### PR TITLE
✨ feat(provider): add OrcaRouter as a new model provider

### DIFF
--- a/locales/en-US/providers.json
+++ b/locales/en-US/providers.json
@@ -50,6 +50,7 @@
   "opencodecodingplan.description": "OpenCode Go is a $10/month subscription providing reliable access to curated open coding models: GLM, Kimi, MiMo, Qwen, MiniMax.",
   "opencodezen.description": "OpenCode Zen provides access to curated models from OpenAI, Anthropic, Moonshot, MiniMax, Zhipu, Qwen, and more via a single API key.",
   "openrouter.description": "OpenRouter provides access to many frontier models from OpenAI, Anthropic, LLaMA, and more, letting users pick the best model and price for their use case.",
+  "orcarouter.description": "OrcaRouter is an adaptive LLM routing gateway that uses a LinUCB contextual bandit over cost, latency, and quality signals to pick the best upstream per request — one API key, 150+ frontier models from OpenAI, Anthropic, Google, DeepSeek, xAI, and more.",
   "perplexity.description": "Perplexity provides advanced chat models, including Llama 3.1 variants, for online and offline use and complex NLP workloads.",
   "ppio.description": "PPIO provides reliable, cost-effective open-model APIs, including DeepSeek, Llama, Qwen, and other leading models.",
   "qiniu.description": "Qiniu provides reliable, cost-effective real-time and batch AI inference services that are easy to use.",

--- a/locales/zh-CN/providers.json
+++ b/locales/zh-CN/providers.json
@@ -50,6 +50,7 @@
   "opencodecodingplan.description": "OpenCode Go 是一项每月 10 美元的订阅服务，提供对精选开源编码模型的稳定访问，包括 GLM、Kimi、MiMo、Qwen、MiniMax。",
   "opencodezen.description": "OpenCode Zen 通过单一 API 密钥即可访问来自 OpenAI、Anthropic、Moonshot、MiniMax、智谱、Qwen 等多个来源的精选模型。",
   "openrouter.description": "OpenRouter 提供对 OpenAI、Anthropic、LLaMA 等前沿模型的访问，用户可根据需求选择最优模型与价格。",
+  "orcarouter.description": "OrcaRouter 是一个自适应 LLM 路由网关，基于 LinUCB 上下文 bandit 在成本、延迟与质量信号之间动态选择最优上游，用一把 API key 即可访问来自 OpenAI、Anthropic、Google、DeepSeek、xAI 等的 150+ 前沿模型。",
   "perplexity.description": "Perplexity 提供先进的对话模型，包括 Llama 3.1 变体，适用于在线与离线使用及复杂 NLP 任务。",
   "ppio.description": "PPIO 提供可靠、性价比高的开源模型 API，支持 DeepSeek、Llama、Qwen 等主流模型。",
   "qiniu.description": "七牛云提供可靠、性价比高的实时与批量 AI 推理服务，使用便捷。",

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -52,6 +52,7 @@ import { default as openai } from './openai';
 import { default as opencodecodingplan } from './opencodeCodingPlan';
 import { default as opencodezen } from './opencodeZen';
 import { default as openrouter } from './openrouter';
+import { default as orcarouter } from './orcarouter';
 import { default as perplexity } from './perplexity';
 import { default as ppio } from './ppio';
 import { default as qiniu } from './qiniu';
@@ -154,6 +155,7 @@ export const LOBE_DEFAULT_MODEL_LIST = buildDefaultModelList({
   opencodecodingplan,
   opencodezen,
   openrouter,
+  orcarouter,
   perplexity,
   ppio,
   qiniu,
@@ -237,6 +239,7 @@ export { default as openai, openaiChatModels } from './openai';
 export { default as opencodecodingplan } from './opencodeCodingPlan';
 export { default as opencodezen } from './opencodeZen';
 export { default as openrouter } from './openrouter';
+export { default as orcarouter } from './orcarouter';
 export { default as perplexity } from './perplexity';
 export { default as ppio } from './ppio';
 export { default as qiniu } from './qiniu';

--- a/packages/model-bank/src/aiModels/orcarouter.ts
+++ b/packages/model-bank/src/aiModels/orcarouter.ts
@@ -1,0 +1,92 @@
+import type { AIChatModelCard } from '../types/aiModel';
+
+// OrcaRouter ships an adaptive routing engine on top of 150+ upstream models.
+// `orcarouter/auto` is the workspace-level virtual router; every other entry is a
+// concrete upstream addressable by id. Full catalog: https://www.orcarouter.ai/models
+const orcarouterChatModels: AIChatModelCard[] = [
+  {
+    abilities: { functionCall: true, vision: true },
+    contextWindowTokens: 128_000,
+    description:
+      'OrcaRouter Auto — adaptive LinUCB router that picks the best upstream per request based on prompt features, cost, latency, and quality signals. Configure routing strategy (cheapest / balanced / quality / adaptive / gated_adaptive) in https://www.orcarouter.ai/console/routing.',
+    displayName: 'OrcaRouter Auto',
+    enabled: true,
+    id: 'orcarouter/auto',
+    maxOutput: 16_384,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 400_000,
+    description: 'OpenAI GPT-5 flagship via OrcaRouter.',
+    displayName: 'GPT-5',
+    enabled: true,
+    id: 'openai/gpt-5',
+    maxOutput: 128_000,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true, vision: true },
+    contextWindowTokens: 200_000,
+    description: 'Anthropic Claude Opus 4.7 flagship reasoning model via OrcaRouter.',
+    displayName: 'Claude Opus 4.7',
+    enabled: true,
+    id: 'anthropic/claude-opus-4.7',
+    maxOutput: 32_000,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, vision: true },
+    contextWindowTokens: 1_000_000,
+    description: 'Google Gemini 3 Flash Preview via OrcaRouter.',
+    displayName: 'Gemini 3 Flash Preview',
+    enabled: true,
+    id: 'google/gemini-3-flash-preview',
+    maxOutput: 65_536,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true },
+    contextWindowTokens: 256_000,
+    description: 'xAI Grok 4.3 flagship via OrcaRouter.',
+    displayName: 'Grok 4.3',
+    enabled: true,
+    id: 'grok/grok-4.3',
+    maxOutput: 32_000,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true, reasoning: true },
+    contextWindowTokens: 128_000,
+    description: 'DeepSeek V4 Pro flagship via OrcaRouter.',
+    displayName: 'DeepSeek V4 Pro',
+    enabled: true,
+    id: 'deepseek/deepseek-v4-pro',
+    maxOutput: 8192,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true },
+    contextWindowTokens: 256_000,
+    description: 'MiniMax M2.7 flagship via OrcaRouter.',
+    displayName: 'MiniMax M2.7',
+    enabled: true,
+    id: 'minimax/minimax-m2.7',
+    maxOutput: 32_000,
+    type: 'chat',
+  },
+  {
+    abilities: { functionCall: true },
+    contextWindowTokens: 128_000,
+    description: 'Alibaba Qwen 3.6 Flash via OrcaRouter.',
+    displayName: 'Qwen 3.6 Flash',
+    enabled: true,
+    id: 'qwen/qwen3.6-flash',
+    maxOutput: 16_384,
+    type: 'chat',
+  },
+];
+
+export const allModels = [...orcarouterChatModels];
+
+export default allModels;

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -50,6 +50,7 @@ export enum ModelProvider {
   OpenCodeCodingPlan = 'opencodecodingplan',
   OpenCodeZen = 'opencodezen',
   OpenRouter = 'openrouter',
+  OrcaRouter = 'orcarouter',
   Perplexity = 'perplexity',
   PPIO = 'ppio',
   Qiniu = 'qiniu',

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -53,6 +53,7 @@ import OpenAIProvider from './openai';
 import OpenCodeCodingPlanProvider from './opencodeCodingPlan';
 import OpenCodeZenProvider from './opencodeZen';
 import OpenRouterProvider from './openrouter';
+import OrcaRouterProvider from './orcarouter';
 import PerplexityProvider from './perplexity';
 import PPIOProvider from './ppio';
 import QiniuProvider from './qiniu';
@@ -157,6 +158,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   AzureAIProvider,
   AiHubMixProvider,
   OpenRouterProvider,
+  OrcaRouterProvider,
   FalProvider,
   OllamaProvider,
   OllamaCloudProvider,
@@ -286,6 +288,7 @@ export { default as OpenAIProviderCard } from './openai';
 export { default as OpenCodeCodingPlanProviderCard } from './opencodeCodingPlan';
 export { default as OpenCodeZenProviderCard } from './opencodeZen';
 export { default as OpenRouterProviderCard } from './openrouter';
+export { default as OrcaRouterProviderCard } from './orcarouter';
 export { default as PerplexityProviderCard } from './perplexity';
 export { default as PPIOProviderCard } from './ppio';
 export { default as QiniuProviderCard } from './qiniu';

--- a/packages/model-bank/src/modelProviders/orcarouter.ts
+++ b/packages/model-bank/src/modelProviders/orcarouter.ts
@@ -1,0 +1,23 @@
+import type { ModelProviderCard } from '@/types/llm';
+
+// ref: https://www.orcarouter.ai/models
+const OrcaRouter: ModelProviderCard = {
+  chatModels: [],
+  checkModel: 'orcarouter/auto',
+  description:
+    'OrcaRouter is an adaptive LLM router that picks the best upstream per request using a LinUCB contextual bandit over cost, latency, and quality signals — one API key, 150+ frontier models from OpenAI, Anthropic, Google, DeepSeek, xAI and more.',
+  id: 'orcarouter',
+  modelList: { showModelFetcher: true },
+  modelsUrl: 'https://www.orcarouter.ai/models',
+  name: 'OrcaRouter',
+  settings: {
+    proxyUrl: {
+      placeholder: 'https://api.orcarouter.ai/v1',
+    },
+    sdkType: 'openai',
+    showModelFetcher: true,
+  },
+  url: 'https://www.orcarouter.ai',
+};
+
+export default OrcaRouter;

--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -34,6 +34,7 @@ export { LobeOllamaAI } from './providers/ollama';
 export { LobeOllamaCloudAI } from './providers/ollamacloud';
 export { LobeOpenAI } from './providers/openai';
 export { LobeOpenRouterAI } from './providers/openrouter';
+export { LobeOrcaRouterAI } from './providers/orcarouter';
 export { LobePerplexityAI } from './providers/perplexity';
 export { LobeQwenAI } from './providers/qwen';
 export { LobeStepfunAI } from './providers/stepfun';

--- a/packages/model-runtime/src/providers/orcarouter/index.test.ts
+++ b/packages/model-runtime/src/providers/orcarouter/index.test.ts
@@ -1,0 +1,208 @@
+// @vitest-environment node
+import { ModelProvider } from 'model-bank';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { testProvider } from '../../providerTestUtils';
+import { LobeOrcaRouterAI, params } from './index';
+
+testProvider({
+  Runtime: LobeOrcaRouterAI,
+  chatDebugEnv: 'DEBUG_ORCAROUTER_CHAT_COMPLETION',
+  chatModel: 'orcarouter/auto',
+  defaultBaseURL: 'https://api.orcarouter.ai/v1',
+  provider: ModelProvider.OrcaRouter,
+  test: {
+    skipAPICall: true,
+  },
+});
+
+describe('LobeOrcaRouterAI - custom features', () => {
+  describe('params object', () => {
+    it('should export params with correct baseURL', () => {
+      expect(params.baseURL).toBe('https://api.orcarouter.ai/v1');
+    });
+
+    it('should have correct provider', () => {
+      expect(params.provider).toBe(ModelProvider.OrcaRouter);
+    });
+
+    it('should inject HTTP-Referer + X-Title attribution headers', () => {
+      const headers = params.constructorOptions?.defaultHeaders as Record<string, string>;
+      expect(headers['HTTP-Referer']).toBe('https://lobehub.com');
+      expect(headers['X-Title']).toBe('LobeHub');
+    });
+  });
+
+  describe('debug configuration', () => {
+    it('should disable debug by default', () => {
+      delete process.env.DEBUG_ORCAROUTER_CHAT_COMPLETION;
+      expect(params.debug.chatCompletion()).toBe(false);
+    });
+
+    it('should enable debug when env is set', () => {
+      process.env.DEBUG_ORCAROUTER_CHAT_COMPLETION = '1';
+      expect(params.debug.chatCompletion()).toBe(true);
+      delete process.env.DEBUG_ORCAROUTER_CHAT_COMPLETION;
+    });
+  });
+
+  describe('handlePayload', () => {
+    it('passes top-level reasoning_effort through for OpenAI gpt-5 family', () => {
+      const result = params.chatCompletion.handlePayload!({
+        messages: [{ content: 'hi', role: 'user' as const }],
+        model: 'openai/gpt-5',
+        reasoning_effort: 'high',
+      } as any) as any;
+      expect(result.reasoning_effort).toBe('high');
+      // gpt-5 is reasoning-only — temperature must be stripped
+      expect(result.temperature).toBeUndefined();
+    });
+
+    it('emits Anthropic native thinking block for claude opus 4.x', () => {
+      const result = params.chatCompletion.handlePayload!({
+        messages: [{ content: 'hi', role: 'user' as const }],
+        model: 'anthropic/claude-opus-4.7',
+        temperature: 0.7,
+        thinking: { budget_tokens: 2000, type: 'enabled' },
+      } as any) as any;
+      expect(result.thinking).toEqual({ budget_tokens: 2000, type: 'enabled' });
+      // claude-opus-4.x rejects temperature/top_p
+      expect(result.temperature).toBeUndefined();
+      expect(result.top_p).toBeUndefined();
+    });
+
+    it('does not strip temperature for non-reasoning models', () => {
+      const result = params.chatCompletion.handlePayload!({
+        messages: [{ content: 'hi', role: 'user' as const }],
+        model: 'openai/gpt-4o',
+        temperature: 0.7,
+      } as any) as any;
+      expect(result.temperature).toBe(0.7);
+      expect(result.reasoning_effort).toBeUndefined();
+    });
+
+    it('strips temperature for deepseek-reasoner', () => {
+      const result = params.chatCompletion.handlePayload!({
+        messages: [{ content: 'hi', role: 'user' as const }],
+        model: 'deepseek/deepseek-reasoner',
+        temperature: 0.5,
+      } as any) as any;
+      expect(result.temperature).toBeUndefined();
+    });
+
+    it('preserves messages and other parameters', () => {
+      const messages = [{ content: 'hi', role: 'user' as const }];
+      const result = params.chatCompletion.handlePayload!({
+        max_tokens: 100,
+        messages,
+        model: 'openai/gpt-4o',
+        top_p: 0.9,
+      } as any) as any;
+      expect(result.messages).toEqual(messages);
+      expect(result.max_tokens).toBe(100);
+      expect(result.top_p).toBe(0.9);
+    });
+  });
+
+  describe('models', () => {
+    const originalFetch = global.fetch;
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('filters non-chat models and computes USD pricing from ratios', async () => {
+      const samplePricing = [
+        {
+          completion_ratio: 4,
+          context_length: 128_000,
+          max_completion_tokens: 16_384,
+          model_name: 'openai/gpt-4o',
+          model_ratio: 1.25,
+          supported_endpoint_types: ['openai'],
+          supported_parameters: ['tools', 'temperature'],
+        },
+        {
+          completion_ratio: 8,
+          context_length: 400_000,
+          model_name: 'openai/gpt-5',
+          model_ratio: 0.625,
+          supported_endpoint_types: ['openai'],
+          supported_parameters: ['tools', 'reasoning_effort'],
+        },
+        {
+          cache_ratio: 0.1,
+          completion_ratio: 5,
+          context_length: 200_000,
+          create_cache_ratio: 1.25,
+          model_name: 'anthropic/claude-opus-4.7',
+          model_ratio: 2.5,
+          supported_endpoint_types: ['openai', 'anthropic'],
+          supported_parameters: ['tools'],
+        },
+        // Should be filtered out:
+        {
+          completion_ratio: 1,
+          model_name: 'openai/dall-e-3',
+          model_ratio: 1,
+          supported_endpoint_types: ['image-generation'],
+        },
+        {
+          completion_ratio: 1,
+          model_name: 'openai/text-embedding-3-small',
+          model_ratio: 0.01,
+          supported_endpoint_types: ['openai'],
+        },
+        {
+          completion_ratio: 1,
+          model_name: 'openai/gpt-5-codex',
+          model_ratio: 0.5,
+          supported_endpoint_types: ['openai'],
+        },
+        {
+          completion_ratio: 1,
+          model_name: 'openai/gpt-5-pro',
+          model_ratio: 5,
+          supported_endpoint_types: ['openai-response'],
+        },
+      ];
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => samplePricing,
+      } as any);
+
+      const list = await params.models!({ client: {} as any });
+      const ids = list.map((m: any) => m.id);
+      expect(ids).toContain('openai/gpt-4o');
+      expect(ids).toContain('openai/gpt-5');
+      expect(ids).toContain('anthropic/claude-opus-4.7');
+      expect(ids).not.toContain('openai/dall-e-3');
+      expect(ids).not.toContain('openai/text-embedding-3-small');
+      expect(ids).not.toContain('openai/gpt-5-codex');
+      expect(ids).not.toContain('openai/gpt-5-pro');
+
+      const gpt4o = list.find((m: any) => m.id === 'openai/gpt-4o') as any;
+      expect(gpt4o).toBeDefined();
+      expect(gpt4o.functionCall).toBe(true);
+
+      const opus = list.find((m: any) => m.id === 'anthropic/claude-opus-4.7') as any;
+      expect(opus).toBeDefined();
+      expect(opus.reasoning).toBe(true);
+    });
+
+    it('returns empty list when pricing fetch fails', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const list = await params.models!({ client: {} as any });
+      expect(list).toEqual([]);
+      warnSpy.mockRestore();
+    });
+
+    it('returns empty list when pricing response is non-ok', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false } as any);
+      const list = await params.models!({ client: {} as any });
+      expect(list).toEqual([]);
+    });
+  });
+});

--- a/packages/model-runtime/src/providers/orcarouter/index.ts
+++ b/packages/model-runtime/src/providers/orcarouter/index.ts
@@ -1,0 +1,139 @@
+import { ModelProvider } from 'model-bank';
+
+import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+import { processMultiProviderModelList } from '../../utils/modelParse';
+import type { OrcaRouterPricingEntry } from './type';
+
+// OrcaRouter quota → USD rate: 1 quota = $0.000002, so per 1M tokens = ratio * 2
+// Source: OrcaRouter common/constants.go `QuotaPerUnit = 500 * 1000.0`
+const QUOTA_USD_PER_1M = 2;
+
+const PRICING_ENDPOINT = 'https://www.orcarouter.ai/api/pricing';
+
+const isReasoningOnlyModel = (id: string) => {
+  // Models that reject `temperature` / `top_p` — anthropic claude opus 4.x,
+  // openai gpt-5 family, deepseek-reasoner.
+  const lower = id.toLowerCase();
+  if (lower.startsWith('anthropic/claude-opus-4')) return true;
+  if (lower.startsWith('openai/gpt-5')) return true;
+  if (lower.includes('deepseek-reasoner')) return true;
+  return false;
+};
+
+const isNonChatModel = (entry: OrcaRouterPricingEntry) => {
+  const name = entry.model_name.toLowerCase();
+  const ep = new Set(entry.supported_endpoint_types ?? []);
+  if (ep.has('image-generation') || ep.has('openai-video')) return true;
+  const outMods = new Set(entry.output_modalities ?? []);
+  if (outMods.has('image')) return true;
+  if (['imagen', 'dall-e', 'gpt-image', 'grok-imagine'].some((k) => name.includes(k))) return true;
+  if (
+    name.includes('embedding') ||
+    name.includes('tts') ||
+    name.endsWith('-speech') ||
+    name.includes('whisper') ||
+    name.includes('transcrib') ||
+    name.includes('rerank')
+  ) {
+    return true;
+  }
+  // Skip codex / gpt-5-pro variants — they live on /v1/completions or /v1/responses
+  if (name.includes('codex')) return true;
+  if (/openai\/gpt-5(\.\d+)?-pro/.test(name)) return true;
+  if (ep.has('openai-response') && !ep.has('openai')) return true;
+  return false;
+};
+
+export const params = {
+  baseURL: 'https://api.orcarouter.ai/v1',
+  chatCompletion: {
+    handlePayload: (payload) => {
+      const { thinking, reasoning_effort, model, ...rest } = payload as any;
+
+      const next: Record<string, any> = { ...rest, model };
+
+      // OrcaRouter passes reasoning fields through to the upstream provider's
+      // native protocol — Anthropic uses `thinking`, everyone else uses
+      // top-level `reasoning_effort`. Avoid the OpenRouter-style nested block.
+      if (model?.toLowerCase().startsWith('anthropic/')) {
+        if (thinking?.type === 'enabled' && thinking?.budget_tokens) {
+          next.thinking = { budget_tokens: thinking.budget_tokens, type: 'enabled' };
+        }
+      } else if (reasoning_effort) {
+        next.reasoning_effort = reasoning_effort;
+      } else if (thinking?.type === 'enabled') {
+        next.reasoning_effort = 'medium';
+      }
+
+      // Reasoning-only models reject `temperature` / `top_p` / `top_k`.
+      if (isReasoningOnlyModel(model ?? '')) {
+        delete next.temperature;
+        delete next.top_p;
+        delete next.top_k;
+      }
+
+      return next as any;
+    },
+  },
+  constructorOptions: {
+    defaultHeaders: {
+      'HTTP-Referer': 'https://lobehub.com',
+      'X-Title': 'LobeHub',
+    },
+  },
+  debug: {
+    chatCompletion: () => process.env.DEBUG_ORCAROUTER_CHAT_COMPLETION === '1',
+  },
+  models: async () => {
+    let pricing: OrcaRouterPricingEntry[] = [];
+    try {
+      const response = await fetch(PRICING_ENDPOINT);
+      if (response.ok) {
+        pricing = (await response.json()) as OrcaRouterPricingEntry[];
+      }
+    } catch (error) {
+      console.warn('Failed to fetch OrcaRouter pricing catalog:', error);
+      return [];
+    }
+
+    const formatted = pricing.filter((m) => !isNonChatModel(m)).map((entry) => {
+      const ratio = entry.model_ratio;
+      const completionRatio = entry.completion_ratio ?? 1;
+      const cacheRatio = entry.cache_ratio;
+      const createCacheRatio = entry.create_cache_ratio;
+      const supportedParams = new Set(entry.supported_parameters ?? []);
+      const inputModalities = entry.input_modalities ?? [];
+
+      const reasoning =
+        supportedParams.has('reasoning') ||
+        supportedParams.has('reasoning_effort') ||
+        /reasoner|opus-4|gpt-5/.test(entry.model_name.toLowerCase());
+
+      return {
+        contextWindowTokens: entry.context_length,
+        displayName: entry.model_name,
+        functionCall: supportedParams.has('tools'),
+        id: entry.model_name,
+        maxOutput: entry.max_completion_tokens,
+        pricing: {
+          cachedInput:
+            cacheRatio !== undefined ? Number((ratio * cacheRatio * QUOTA_USD_PER_1M).toFixed(6)) : undefined,
+          input: Number((ratio * QUOTA_USD_PER_1M).toFixed(6)),
+          output: Number((ratio * completionRatio * QUOTA_USD_PER_1M).toFixed(6)),
+          writeCacheInput:
+            createCacheRatio !== undefined
+              ? Number((ratio * createCacheRatio * QUOTA_USD_PER_1M).toFixed(6))
+              : undefined,
+        },
+        reasoning,
+        vision: inputModalities.includes('image'),
+      };
+    });
+
+    return processMultiProviderModelList(formatted, 'orcarouter');
+  },
+  provider: ModelProvider.OrcaRouter,
+} satisfies OpenAICompatibleFactoryOptions;
+
+export const LobeOrcaRouterAI = createOpenAICompatibleRuntime(params);

--- a/packages/model-runtime/src/providers/orcarouter/type.ts
+++ b/packages/model-runtime/src/providers/orcarouter/type.ts
@@ -1,0 +1,13 @@
+export interface OrcaRouterPricingEntry {
+  cache_ratio?: number;
+  completion_ratio?: number;
+  context_length?: number;
+  create_cache_ratio?: number;
+  input_modalities?: string[] | null;
+  max_completion_tokens?: number;
+  model_name: string;
+  model_ratio: number;
+  output_modalities?: string[] | null;
+  supported_endpoint_types?: string[] | null;
+  supported_parameters?: string[] | null;
+}

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -49,6 +49,7 @@ import { LobeOpenAI } from './providers/openai';
 import { LobeOpenCodeCodingPlanAI } from './providers/opencodeCodingPlan';
 import { LobeOpenCodeZenAI } from './providers/opencodeZen';
 import { LobeOpenRouterAI } from './providers/openrouter';
+import { LobeOrcaRouterAI } from './providers/orcarouter';
 import { LobePerplexityAI } from './providers/perplexity';
 import { LobePPIOAI } from './providers/ppio';
 import { LobeQiniuAI } from './providers/qiniu';
@@ -131,6 +132,7 @@ export const providerRuntimeMap = {
   opencodezen: LobeOpenCodeZenAI,
   openai: LobeOpenAI,
   openrouter: LobeOpenRouterAI,
+  orcarouter: LobeOrcaRouterAI,
   perplexity: LobePerplexityAI,
   ppio: LobePPIOAI,
   qiniu: LobeQiniuAI,

--- a/src/envs/llm.ts
+++ b/src/envs/llm.ts
@@ -232,6 +232,9 @@ export const getLLMConfig = () => {
       ENABLED_ZENMUX: z.boolean(),
       ZENMUX_API_KEY: z.string().optional(),
 
+      ENABLED_ORCAROUTER: z.boolean(),
+      ORCAROUTER_API_KEY: z.string().optional(),
+
       ENABLED_STRAICO: z.boolean(),
       STRAICO_API_KEY: z.string().optional(),
 
@@ -481,6 +484,9 @@ export const getLLMConfig = () => {
 
       ENABLED_ZENMUX: !!process.env.ZENMUX_API_KEY,
       ZENMUX_API_KEY: process.env.ZENMUX_API_KEY,
+
+      ENABLED_ORCAROUTER: !!process.env.ORCAROUTER_API_KEY,
+      ORCAROUTER_API_KEY: process.env.ORCAROUTER_API_KEY,
 
       ENABLED_STRAICO: !!process.env.STRAICO_API_KEY,
       STRAICO_API_KEY: process.env.STRAICO_API_KEY,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A — adds a new OpenAI-compatible model provider.

#### 🔀 Description of Change

Adds **OrcaRouter** (https://www.orcarouter.ai) as a new model provider, alongside existing meta-routers like OpenRouter / CometAPI / ZenMux / AiHubMix.

OrcaRouter is an adaptive LLM routing gateway: one API key fronts 150+ frontier models from OpenAI, Anthropic, Google, DeepSeek, xAI, MiniMax, Qwen and more, and a LinUCB contextual bandit picks the best upstream per request based on cost, latency, and quality signals.

**What this PR adds**

- `packages/model-runtime/src/providers/orcarouter/` — OpenAI-compatible runtime built on `createOpenAICompatibleRuntime`, with:
  - Per-vendor reasoning protocol: Anthropic native `thinking` block for `anthropic/*`, top-level `reasoning_effort` for OpenAI gpt-5 / o-series / Gemini / Grok / Qwen / Kimi reasoning models, no field for `deepseek-reasoner` (model auto-reasons).
  - Strips `temperature` / `top_p` / `top_k` for reasoning-only models (`anthropic/claude-opus-4.x`, `openai/gpt-5.*`, `deepseek-reasoner`) that reject those params upstream.
  - Model fetcher hits the public `/api/pricing` endpoint (no auth) and computes USD/1M from `model_ratio * 2` (the official `QuotaPerUnit` constant), with `cache_ratio` / `create_cache_ratio` mapped to `cachedInput` / `writeCacheInput`. Filters out image-gen / video / embedding / TTS / `*-codex` / `gpt-5-pro` (responses-only) models so the LLM list stays clean.
  - `HTTP-Referer: https://lobehub.com` + `X-Title: LobeHub` attribution headers.
- `packages/model-bank/src/modelProviders/orcarouter.ts` — provider card (`showModelFetcher: true`, default base URL `https://api.orcarouter.ai/v1`, check model `orcarouter/auto`).
- `packages/model-bank/src/aiModels/orcarouter.ts` — 8 built-in flagship cards including `orcarouter/auto` (the workspace-level virtual router) and one flagship per major upstream (gpt-5, claude-opus-4.7, gemini-3-flash-preview, grok-4.3, deepseek-v4-pro, minimax-m2.7, qwen3.6-flash). Users get the full 150+ catalog via the model fetcher.
- Env wiring: `ORCAROUTER_API_KEY` / `ENABLED_ORCAROUTER` in `src/envs/llm.ts`.
- i18n descriptions in `locales/en-US/providers.json` and `locales/zh-CN/providers.json`.
- Registration in `ModelProvider` enum, `DEFAULT_MODEL_PROVIDER_LIST`, `LOBE_DEFAULT_MODEL_LIST`, runtime exports, and `runtimeMap`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

22 unit tests in `packages/model-runtime/src/providers/orcarouter/index.test.ts` covering the standard provider matrix (init, error mapping, debug stream) plus OrcaRouter-specific behavior (reasoning routing per vendor, parameter stripping for reasoning-only models, pricing/USD computation, non-chat-model filtering, fetch failure paths). Run:

```bash
cd packages/model-runtime
bunx vitest run --silent='passed-only' src/providers/orcarouter/index.test.ts
