### PR TITLE
💄 style(mobile): show user nickname in home header instead of product logo

### DIFF
--- a/src/routes/(mobile)/(home)/_layout/SessionHeader.tsx
+++ b/src/routes/(mobile)/(home)/_layout/SessionHeader.tsx
@@ -1,15 +1,16 @@
 'use client';
 
-import { ActionIcon, Flexbox } from '@lobehub/ui';
+import { ActionIcon, Flexbox, Text } from '@lobehub/ui';
 import { ChatHeader } from '@lobehub/ui/mobile';
 import { MessageSquarePlus } from 'lucide-react';
 import { memo } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { ProductLogo } from '@/components/Branding';
 import { MOBILE_HEADER_ICON_SIZE } from '@/const/layoutTokens';
 import UserAvatar from '@/features/User/UserAvatar';
 import { useSessionStore } from '@/store/session';
+import { useUserStore } from '@/store/user';
+import { userProfileSelectors } from '@/store/user/selectors';
 import { mobileHeaderSticky } from '@/styles/mobileHeader';
 
 import { styles } from './SessionHeader/style';
@@ -17,6 +18,10 @@ import { styles } from './SessionHeader/style';
 const Header = memo(() => {
   const [createSession] = useSessionStore((s) => [s.createSession]);
   const navigate = useNavigate();
+  const [nickname, username] = useUserStore((s) => [
+    userProfileSelectors.nickName(s),
+    userProfileSelectors.username(s),
+  ]);
 
   return (
     <ChatHeader
@@ -24,7 +29,9 @@ const Header = memo(() => {
       left={
         <Flexbox horizontal align={'center'} className={styles.leftContainer} gap={8}>
           <UserAvatar size={32} onClick={() => navigate('/me')} />
-          <ProductLogo type={'text'} />
+          <Text ellipsis style={{ flex: 1 }} weight={500}>
+            {nickname || username}
+          </Text>
         </Flexbox>
       }
       right={


### PR DESCRIPTION
## 💻 Changes

In the mobile `SessionHeader`, replace `<ProductLogo type='text' />` next to the user avatar with the user's nickname (falling back to username). Wrap in `<Text ellipsis>` for graceful truncation.

## 🤔 Motivation

Currently, the mobile home header next to the user avatar renders the brand name via `<ProductLogo type='text' />` (`src/routes/(mobile)/(home)/_layout/SessionHeader.tsx:27`). On narrow screens (iPhone mini, etc.) CSS overflow truncates "LobeHub" / "LobeChat" to fewer characters, leaving users with an uninformative fragment — often just "Lobe" or "Lob".

This is redundant with the page `<title>`:

```ts
// src/app/[variants]/metadata.ts:60
title: t('chat.title', { appName: BRANDING_NAME })
```

The page title is already visible in:
- Mobile browser tab/address bar
- iOS Safari pull-to-refresh title overlay
- App switcher card preview
- Share/bookmark default name

So rendering BRANDING_NAME again **inside** the header bar provides little additional value.

## 🔄 Desktop comparison

The desktop counterpart (`src/routes/(main)/home/_layout/Header/components/User.tsx:54-60`) already shows the user's nickname/username next to the avatar:

```tsx
<Text ellipsis style={{ flex: 1 }} weight={500}>
  {nickname || username}
</Text>
```

This PR mirrors that on mobile for **cross-device consistency**.

## ✂️ About truncation

Long names truncate gracefully via `<Text ellipsis>`:

| Username length | Mobile (iPhone standard, ~120px name area) |
|---|---|
| ≤6 CJK chars | full display |
| ≤14 ASCII chars | full display |
| Longer | `Christopher Alex...` (keeps prefix, preserves info) |

This is strictly more informative than truncating "LobeHub" to "Lobe".

## ✅ Scope

- Single file changed: `src/routes/(mobile)/(home)/_layout/SessionHeader.tsx` (+10 / -3)
- No code outside this file is affected
- No new dependencies
- No i18n key additions/removals

## 🧪 Verification

- Desktop home header: unchanged (different component)
- Mobile home header with short Chinese name (e.g. `张伟`): shows "张伟"
- Mobile home header with long ASCII name (e.g. `Christopher Alexander`): shows "Christopher Alex..."
- Page tab/title bar continues to display BRANDING_NAME via existing `metadata.ts`