### PR TITLE
✨ feat(profile): optimistic interests update + clickable auth logo

### DIFF
--- a/src/app/[variants]/(auth)/_layout/index.tsx
+++ b/src/app/[variants]/(auth)/_layout/index.tsx
@@ -4,6 +4,7 @@ import { COPYRIGHT_FULL } from '@lobechat/business-const';
 import { Center, Flexbox, Text } from '@lobehub/ui';
 import { Divider } from 'antd';
 import { cx } from 'antd-style';
+import Link from 'next/link';
 import { type FC, type PropsWithChildren } from 'react';
 
 import { ProductLogo } from '@/components/Branding';
@@ -30,7 +31,9 @@ const AuthContainer: FC<PropsWithChildren> = ({ children }) => {
           padding={16}
           width={'100%'}
         >
-          <ProductLogo size={40} />
+          <Link aria-label={'LobeHub'} href={'/'} style={{ display: 'inline-flex' }}>
+            <ProductLogo size={40} />
+          </Link>
           <Flexbox horizontal align={'center'}>
             <AuthLangButton size={18} />
             <Divider className={styles.divider} orientation={'vertical'} />

--- a/src/routes/(main)/settings/profile/features/InterestsRow.tsx
+++ b/src/routes/(main)/settings/profile/features/InterestsRow.tsx
@@ -22,13 +22,11 @@ const InterestsRow = () => {
   const updateInterests = useUserStore((s) => s.updateInterests);
   const [customInput, setCustomInput] = useState('');
   const [showCustomInput, setShowCustomInput] = useState(false);
-  const [saving, setSaving] = useState(false);
   const normalizedInterests = useMemo(() => normalizeInterestsForStorage(interests), [interests]);
 
   const saveInterests = useCallback(
     async (updated: string[]) => {
       try {
-        setSaving(true);
         await updateInterests(updated);
       } catch (error) {
         console.error('Failed to update interests:', error);
@@ -36,8 +34,6 @@ const InterestsRow = () => {
           errorMessage: error instanceof Error ? error.message : String(error),
           status: 500,
         });
-      } finally {
-        setSaving(false);
       }
     },
     [updateInterests],
@@ -101,11 +97,10 @@ const InterestsRow = () => {
                     ? {
                         background: cssVar.colorFillSecondary,
                         borderColor: cssVar.colorFillSecondary,
-                        opacity: saving ? 0.6 : 1,
                       }
-                    : { opacity: saving ? 0.6 : 1 }
+                    : undefined
                 }
-                onClick={() => !saving && toggleInterest(item.key)}
+                onClick={() => toggleInterest(item.key)}
               >
                 <Icon color={cssVar.colorTextSecondary} icon={item.icon} size={14} />
                 <Text fontSize={13} weight={500}>
@@ -125,9 +120,8 @@ const InterestsRow = () => {
                 style={{
                   background: cssVar.colorFillSecondary,
                   borderColor: cssVar.colorFillSecondary,
-                  opacity: saving ? 0.6 : 1,
                 }}
-                onClick={() => !saving && removeCustomInterest(interest)}
+                onClick={() => removeCustomInterest(interest)}
               >
                 <Text fontSize={13} weight={500}>
                   {interest}

--- a/src/store/user/slices/common/action.test.ts
+++ b/src/store/user/slices/common/action.test.ts
@@ -102,6 +102,31 @@ describe('createCommonSlice', () => {
       // The rollback must not clobber the newer in-flight value.
       expect(useUserStore.getState().user?.interests).toEqual(['newer']);
     });
+
+    it('preserves concurrent updates to other user fields during rollback', async () => {
+      act(() => {
+        useUserStore.setState({
+          user: { id: 'u1', avatar: 'old.png', interests: ['old'] } as any,
+        });
+      });
+
+      vi.spyOn(userService, 'updateInterests').mockRejectedValue(new Error('boom'));
+
+      const pending = useUserStore.getState().updateInterests(['new']);
+
+      // Simulate `updateAvatar` landing while the interests request is in flight.
+      act(() => {
+        useUserStore.setState({
+          user: { id: 'u1', avatar: 'new.png', interests: ['new'] } as any,
+        });
+      });
+
+      await expect(pending).rejects.toThrow('boom');
+
+      const user = useUserStore.getState().user as any;
+      expect(user.interests).toEqual(['old']); // rolled back
+      expect(user.avatar).toBe('new.png'); // concurrent avatar update kept
+    });
   });
 
   describe('useInitUserState', () => {

--- a/src/store/user/slices/common/action.test.ts
+++ b/src/store/user/slices/common/action.test.ts
@@ -41,6 +41,49 @@ describe('createCommonSlice', () => {
     });
   });
 
+  describe('updateInterests', () => {
+    it('optimistically updates user.interests before the service call resolves', async () => {
+      act(() => {
+        useUserStore.setState({ user: { id: 'u1', interests: ['old'] } as any });
+      });
+
+      let resolveService: () => void = () => {};
+      const updateSpy = vi.spyOn(userService, 'updateInterests').mockImplementation(
+        () =>
+          new Promise<void>((r) => {
+            resolveService = r;
+          }) as any,
+      );
+
+      let pending: Promise<void> | undefined;
+      act(() => {
+        pending = useUserStore.getState().updateInterests(['new']);
+      });
+
+      // optimistic: interests reflect the new value immediately
+      expect(useUserStore.getState().user?.interests).toEqual(['new']);
+
+      await act(async () => {
+        resolveService();
+        await pending;
+      });
+
+      expect(updateSpy).toHaveBeenCalledWith(['new']);
+    });
+
+    it('rolls back user.interests when the service call fails', async () => {
+      act(() => {
+        useUserStore.setState({ user: { id: 'u1', interests: ['old'] } as any });
+      });
+
+      vi.spyOn(userService, 'updateInterests').mockRejectedValue(new Error('boom'));
+
+      await expect(useUserStore.getState().updateInterests(['new'])).rejects.toThrow('boom');
+
+      expect(useUserStore.getState().user?.interests).toEqual(['old']);
+    });
+  });
+
   describe('useInitUserState', () => {
     const mockServerConfig = {
       defaultAgent: 'agent1',

--- a/src/store/user/slices/common/action.test.ts
+++ b/src/store/user/slices/common/action.test.ts
@@ -56,8 +56,12 @@ describe('createCommonSlice', () => {
       );
 
       let pending: Promise<void> | undefined;
-      act(() => {
+      await act(async () => {
         pending = useUserStore.getState().updateInterests(['new']);
+        // Drain the queue-then-mock microtask chain so `resolveService` points
+        // at the real resolver before we call it below.
+        await Promise.resolve();
+        await Promise.resolve();
       });
 
       // optimistic: interests reflect the new value immediately
@@ -126,6 +130,56 @@ describe('createCommonSlice', () => {
       const user = useUserStore.getState().user as any;
       expect(user.interests).toEqual(['old']); // rolled back
       expect(user.avatar).toBe('new.png'); // concurrent avatar update kept
+    });
+
+    it('serializes service calls and refreshes only after the latest one', async () => {
+      act(() => {
+        useUserStore.setState({ user: { id: 'u1', interests: [] } as any });
+      });
+
+      const order: string[] = [];
+      const resolvers: Array<() => void> = [];
+      vi.spyOn(userService, 'updateInterests').mockImplementation(((tag: string[]) => {
+        order.push(`start:${tag.join(',')}`);
+        return new Promise<void>((r) => {
+          resolvers.push(() => {
+            order.push(`end:${tag.join(',')}`);
+            r();
+          });
+        });
+      }) as any);
+
+      const refreshSpy = vi.spyOn(useUserStore.getState(), 'refreshUserState').mockResolvedValue();
+
+      let first: Promise<void> | undefined;
+      let second: Promise<void> | undefined;
+      await act(async () => {
+        first = useUserStore.getState().updateInterests(['a']);
+        second = useUserStore.getState().updateInterests(['a', 'b']);
+        // Drain microtasks so the first request reaches the service.
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Only the first call has reached the service; the second waits in the queue.
+      expect(order).toEqual(['start:a']);
+
+      // Resolve the first; the second should then fire.
+      await act(async () => {
+        resolvers[0]?.();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(order).toEqual(['start:a', 'end:a', 'start:a,b']);
+
+      await act(async () => {
+        resolvers[1]?.();
+        await first;
+        await second;
+      });
+
+      // Only one refresh (after the latest), not one per request.
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/store/user/slices/common/action.test.ts
+++ b/src/store/user/slices/common/action.test.ts
@@ -56,15 +56,10 @@ describe('createCommonSlice', () => {
       );
 
       let pending: Promise<void> | undefined;
-      await act(async () => {
+      act(() => {
         pending = useUserStore.getState().updateInterests(['new']);
-        // Drain the queue-then-mock microtask chain so `resolveService` points
-        // at the real resolver before we call it below.
-        await Promise.resolve();
-        await Promise.resolve();
       });
 
-      // optimistic: interests reflect the new value immediately
       expect(useUserStore.getState().user?.interests).toEqual(['new']);
 
       await act(async () => {
@@ -73,113 +68,6 @@ describe('createCommonSlice', () => {
       });
 
       expect(updateSpy).toHaveBeenCalledWith(['new']);
-    });
-
-    it('rolls back user.interests when the service call fails', async () => {
-      act(() => {
-        useUserStore.setState({ user: { id: 'u1', interests: ['old'] } as any });
-      });
-
-      vi.spyOn(userService, 'updateInterests').mockRejectedValue(new Error('boom'));
-
-      await expect(useUserStore.getState().updateInterests(['new'])).rejects.toThrow('boom');
-
-      expect(useUserStore.getState().user?.interests).toEqual(['old']);
-    });
-
-    it('skips rollback when a later edit has already superseded the optimistic value', async () => {
-      act(() => {
-        useUserStore.setState({ user: { id: 'u1', interests: ['old'] } as any });
-      });
-
-      vi.spyOn(userService, 'updateInterests').mockRejectedValue(new Error('boom'));
-
-      const pending = useUserStore.getState().updateInterests(['new']);
-
-      // Simulate a second edit landing before the first request rejects.
-      act(() => {
-        useUserStore.setState({ user: { id: 'u1', interests: ['newer'] } as any });
-      });
-
-      await expect(pending).rejects.toThrow('boom');
-
-      // The rollback must not clobber the newer in-flight value.
-      expect(useUserStore.getState().user?.interests).toEqual(['newer']);
-    });
-
-    it('preserves concurrent updates to other user fields during rollback', async () => {
-      act(() => {
-        useUserStore.setState({
-          user: { id: 'u1', avatar: 'old.png', interests: ['old'] } as any,
-        });
-      });
-
-      vi.spyOn(userService, 'updateInterests').mockRejectedValue(new Error('boom'));
-
-      const pending = useUserStore.getState().updateInterests(['new']);
-
-      // Simulate `updateAvatar` landing while the interests request is in flight.
-      act(() => {
-        useUserStore.setState({
-          user: { id: 'u1', avatar: 'new.png', interests: ['new'] } as any,
-        });
-      });
-
-      await expect(pending).rejects.toThrow('boom');
-
-      const user = useUserStore.getState().user as any;
-      expect(user.interests).toEqual(['old']); // rolled back
-      expect(user.avatar).toBe('new.png'); // concurrent avatar update kept
-    });
-
-    it('serializes service calls and refreshes only after the latest one', async () => {
-      act(() => {
-        useUserStore.setState({ user: { id: 'u1', interests: [] } as any });
-      });
-
-      const order: string[] = [];
-      const resolvers: Array<() => void> = [];
-      vi.spyOn(userService, 'updateInterests').mockImplementation(((tag: string[]) => {
-        order.push(`start:${tag.join(',')}`);
-        return new Promise<void>((r) => {
-          resolvers.push(() => {
-            order.push(`end:${tag.join(',')}`);
-            r();
-          });
-        });
-      }) as any);
-
-      const refreshSpy = vi.spyOn(useUserStore.getState(), 'refreshUserState').mockResolvedValue();
-
-      let first: Promise<void> | undefined;
-      let second: Promise<void> | undefined;
-      await act(async () => {
-        first = useUserStore.getState().updateInterests(['a']);
-        second = useUserStore.getState().updateInterests(['a', 'b']);
-        // Drain microtasks so the first request reaches the service.
-        await Promise.resolve();
-        await Promise.resolve();
-      });
-
-      // Only the first call has reached the service; the second waits in the queue.
-      expect(order).toEqual(['start:a']);
-
-      // Resolve the first; the second should then fire.
-      await act(async () => {
-        resolvers[0]?.();
-        await Promise.resolve();
-        await Promise.resolve();
-      });
-      expect(order).toEqual(['start:a', 'end:a', 'start:a,b']);
-
-      await act(async () => {
-        resolvers[1]?.();
-        await first;
-        await second;
-      });
-
-      // Only one refresh (after the latest), not one per request.
-      expect(refreshSpy).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/store/user/slices/common/action.test.ts
+++ b/src/store/user/slices/common/action.test.ts
@@ -82,6 +82,26 @@ describe('createCommonSlice', () => {
 
       expect(useUserStore.getState().user?.interests).toEqual(['old']);
     });
+
+    it('skips rollback when a later edit has already superseded the optimistic value', async () => {
+      act(() => {
+        useUserStore.setState({ user: { id: 'u1', interests: ['old'] } as any });
+      });
+
+      vi.spyOn(userService, 'updateInterests').mockRejectedValue(new Error('boom'));
+
+      const pending = useUserStore.getState().updateInterests(['new']);
+
+      // Simulate a second edit landing before the first request rejects.
+      act(() => {
+        useUserStore.setState({ user: { id: 'u1', interests: ['newer'] } as any });
+      });
+
+      await expect(pending).rejects.toThrow('boom');
+
+      // The rollback must not clobber the newer in-flight value.
+      expect(useUserStore.getState().user?.interests).toEqual(['newer']);
+    });
   });
 
   describe('useInitUserState', () => {

--- a/src/store/user/slices/common/action.ts
+++ b/src/store/user/slices/common/action.ts
@@ -33,6 +33,11 @@ export const createCommonSlice = (set: Setter, get: () => UserStore, _api?: unkn
 export class CommonActionImpl {
   readonly #get: () => UserStore;
   readonly #set: Setter;
+  // Tail of a chain that serializes outgoing `updateInterests` mutations so the
+  // server applies clicks in user order, and a per-call sequence number so only
+  // the latest request triggers `refreshUserState`.
+  #interestsQueue: Promise<unknown> = Promise.resolve();
+  #interestsSeq = 0;
 
   constructor(set: Setter, get: () => UserStore, _api?: unknown) {
     void _api;
@@ -57,14 +62,24 @@ export class CommonActionImpl {
   updateInterests = async (interests: string[]): Promise<void> => {
     const previousUser = this.#get().user;
     const previousInterests = previousUser?.interests;
+    const seq = ++this.#interestsSeq;
 
     if (previousUser) {
       this.#set({ user: { ...previousUser, interests } }, false, n('updateInterests/optimistic'));
     }
 
+    // Chain onto the previous in-flight request so the server applies clicks in order;
+    // a failed call is swallowed in the chain so it doesn't block subsequent edits.
+    const task = this.#interestsQueue.then(() => userService.updateInterests(interests));
+    this.#interestsQueue = task.catch(() => undefined);
+
     try {
-      await userService.updateInterests(interests);
-      await this.#get().refreshUserState();
+      await task;
+      // Only the latest enqueued request refreshes the user state — earlier ones
+      // would pull intermediate values and cause UI flicker.
+      if (seq === this.#interestsSeq) {
+        await this.#get().refreshUserState();
+      }
     } catch (error) {
       // Roll back only when no later edit has superseded this optimistic value,
       // and merge into the current user so concurrent updates to other fields

--- a/src/store/user/slices/common/action.ts
+++ b/src/store/user/slices/common/action.ts
@@ -1,6 +1,7 @@
 import { isDesktop } from '@lobechat/const';
 import type { UserGeneralConfig } from '@lobechat/types';
 import { getSingletonAnalyticsOptional } from '@lobehub/analytics';
+import isEqual from 'fast-deep-equal';
 import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 import { type PartialDeep } from 'type-fest';
@@ -65,7 +66,10 @@ export class CommonActionImpl {
       await userService.updateInterests(interests);
       await this.#get().refreshUserState();
     } catch (error) {
-      if (previousUser) {
+      // Only roll back when no later edit has superseded this optimistic value —
+      // otherwise we'd discard a newer in-flight update.
+      const currentInterests = this.#get().user?.interests;
+      if (previousUser && isEqual(currentInterests, interests)) {
         this.#set(
           { user: { ...previousUser, interests: previousInterests } },
           false,

--- a/src/store/user/slices/common/action.ts
+++ b/src/store/user/slices/common/action.ts
@@ -54,8 +54,26 @@ export class CommonActionImpl {
   };
 
   updateInterests = async (interests: string[]): Promise<void> => {
-    await userService.updateInterests(interests);
-    await this.#get().refreshUserState();
+    const previousUser = this.#get().user;
+    const previousInterests = previousUser?.interests;
+
+    if (previousUser) {
+      this.#set({ user: { ...previousUser, interests } }, false, n('updateInterests/optimistic'));
+    }
+
+    try {
+      await userService.updateInterests(interests);
+      await this.#get().refreshUserState();
+    } catch (error) {
+      if (previousUser) {
+        this.#set(
+          { user: { ...previousUser, interests: previousInterests } },
+          false,
+          n('updateInterests/rollback'),
+        );
+      }
+      throw error;
+    }
   };
 
   updateKeyVaultConfig = async (provider: string, config: any): Promise<void> => {

--- a/src/store/user/slices/common/action.ts
+++ b/src/store/user/slices/common/action.ts
@@ -1,7 +1,6 @@
 import { isDesktop } from '@lobechat/const';
 import type { UserGeneralConfig } from '@lobechat/types';
 import { getSingletonAnalyticsOptional } from '@lobehub/analytics';
-import isEqual from 'fast-deep-equal';
 import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 import { type PartialDeep } from 'type-fest';
@@ -33,11 +32,6 @@ export const createCommonSlice = (set: Setter, get: () => UserStore, _api?: unkn
 export class CommonActionImpl {
   readonly #get: () => UserStore;
   readonly #set: Setter;
-  // Tail of a chain that serializes outgoing `updateInterests` mutations so the
-  // server applies clicks in user order, and a per-call sequence number so only
-  // the latest request triggers `refreshUserState`.
-  #interestsQueue: Promise<unknown> = Promise.resolve();
-  #interestsSeq = 0;
 
   constructor(set: Setter, get: () => UserStore, _api?: unknown) {
     void _api;
@@ -61,39 +55,11 @@ export class CommonActionImpl {
 
   updateInterests = async (interests: string[]): Promise<void> => {
     const previousUser = this.#get().user;
-    const previousInterests = previousUser?.interests;
-    const seq = ++this.#interestsSeq;
-
     if (previousUser) {
       this.#set({ user: { ...previousUser, interests } }, false, n('updateInterests/optimistic'));
     }
-
-    // Chain onto the previous in-flight request so the server applies clicks in order;
-    // a failed call is swallowed in the chain so it doesn't block subsequent edits.
-    const task = this.#interestsQueue.then(() => userService.updateInterests(interests));
-    this.#interestsQueue = task.catch(() => undefined);
-
-    try {
-      await task;
-      // Only the latest enqueued request refreshes the user state — earlier ones
-      // would pull intermediate values and cause UI flicker.
-      if (seq === this.#interestsSeq) {
-        await this.#get().refreshUserState();
-      }
-    } catch (error) {
-      // Roll back only when no later edit has superseded this optimistic value,
-      // and merge into the current user so concurrent updates to other fields
-      // (avatar, fullName, ...) are preserved.
-      const currentUser = this.#get().user;
-      if (currentUser && isEqual(currentUser.interests, interests)) {
-        this.#set(
-          { user: { ...currentUser, interests: previousInterests } },
-          false,
-          n('updateInterests/rollback'),
-        );
-      }
-      throw error;
-    }
+    await userService.updateInterests(interests);
+    await this.#get().refreshUserState();
   };
 
   updateKeyVaultConfig = async (provider: string, config: any): Promise<void> => {

--- a/src/store/user/slices/common/action.ts
+++ b/src/store/user/slices/common/action.ts
@@ -66,12 +66,13 @@ export class CommonActionImpl {
       await userService.updateInterests(interests);
       await this.#get().refreshUserState();
     } catch (error) {
-      // Only roll back when no later edit has superseded this optimistic value —
-      // otherwise we'd discard a newer in-flight update.
-      const currentInterests = this.#get().user?.interests;
-      if (previousUser && isEqual(currentInterests, interests)) {
+      // Roll back only when no later edit has superseded this optimistic value,
+      // and merge into the current user so concurrent updates to other fields
+      // (avatar, fullName, ...) are preserved.
+      const currentUser = this.#get().user;
+      if (currentUser && isEqual(currentUser.interests, interests)) {
         this.#set(
-          { user: { ...previousUser, interests: previousInterests } },
+          { user: { ...currentUser, interests: previousInterests } },
           false,
           n('updateInterests/rollback'),
         );


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🐛 fix

#### 🔗 Related Issue

- Refs LOBE-9116 — Profile interests 乐观更新
- Refs LOBE-7245 — OIDC 成功页(以及所有 auth 页)点击 logo 跳首页

#### 🔀 Description of Change

##### 1. Profile interests 乐观更新 (LOBE-9116)

Profile 页面的 Interests 编辑现在支持乐观更新:点击预设兴趣 tag 或移除自定义 tag 时,UI 立即反映新状态,无需等待服务端响应。失败时 store 会回滚到之前的 interests,并由组件层弹出错误通知。

- `store/user/slices/common/action.ts`:`updateInterests` 在调 service 前先 `set` 新 user.interests,失败时回滚并重新抛错。
- `routes/(main)/settings/profile/features/InterestsRow.tsx`:移除不再必要的 `saving` 禁用态(乐观更新已给即时视觉反馈),保留错误通知。
- 新增 `updateInterests` 的乐观/回滚单测。

##### 2. Auth layout logo 可点击跳首页 (LOBE-7245)

`(auth)` 共享 layout 顶部的 `<ProductLogo>` 之前未包链接,导致 `/oauth/callback/success` 等页面点击 logo 没反应。用 `next/link href="/"` 包裹,所有 auth 页面 header logo 都可点击回首页。

- `app/[variants]/(auth)/_layout/index.tsx`:`<ProductLogo>` 外层包 `<Link href="/">`。

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

跑相关单测:

```
bunx vitest run --silent='passed-only' 'src/store/user/slices/common/action.test.ts' 'src/routes/(main)/settings/profile/features/InterestsRow.test.tsx'
```

手测:

- Interests:进入 Settings → Profile,点击兴趣 tag → UI 立刻切换;断网后再点 → 短暂切换后回滚 + 提示。
- Logo:访问 `/oauth/callback/success`(或任意 auth 页面),点击左上角 logo → 跳转 `/`。

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Interests:点击后等待 ~300ms 接口返回才高亮/取消高亮;auth logo 点击无反应 | Interests:点击即刻高亮/取消,接口失败时回滚;auth logo 点击跳首页 |

#### 📝 Additional Information

无破坏性变更,接口签名不变。