### PR TITLE
🐛 fix(command-menu): promote inline type filters from setSearch

### DIFF
--- a/src/features/CommandMenu/CommandMenuContext.test.tsx
+++ b/src/features/CommandMenu/CommandMenuContext.test.tsx
@@ -1,0 +1,41 @@
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CommandMenuProvider, useCommandMenuContext } from './CommandMenuContext';
+
+const createWrapper = () => {
+  const onClose = vi.fn();
+
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <CommandMenuProvider pathname="/" onClose={onClose}>
+      {children}
+    </CommandMenuProvider>
+  );
+
+  return Wrapper;
+};
+
+describe('CommandMenuProvider', () => {
+  it('should promote inline type filters into command menu state', () => {
+    const { result } = renderHook(() => useCommandMenuContext(), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.setSearch('type:message search content');
+    });
+
+    expect(result.current.search).toBe('search content');
+    expect(result.current.typeFilter).toBe('message');
+  });
+
+  it('should keep invalid type filters as literal search text', () => {
+    const { result } = renderHook(() => useCommandMenuContext(), { wrapper: createWrapper() });
+
+    act(() => {
+      result.current.setSearch('type:unknown search content');
+    });
+
+    expect(result.current.search).toBe('type:unknown search content');
+    expect(result.current.typeFilter).toBeUndefined();
+  });
+});

--- a/src/features/CommandMenu/CommandMenuContext.tsx
+++ b/src/features/CommandMenu/CommandMenuContext.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { type Dispatch, type ReactNode, type SetStateAction } from 'react';
+import type { Dispatch, ReactNode, SetStateAction } from 'react';
 import { createContext, use, useCallback, useMemo, useState } from 'react';
 
-import { type MenuContext, type PageType, type SelectedAgent } from './types';
+import type { MenuContext, PageType, SelectedAgent } from './types';
 import { detectContext } from './utils/context';
-import { type ValidSearchType } from './utils/queryParser';
+import type { ValidSearchType } from './utils/queryParser';
+import { parseSearchQuery } from './utils/queryParser';
 
 interface CommandMenuContextValue {
   activeAgentId: string | undefined;
@@ -53,7 +54,17 @@ export const CommandMenuProvider = ({ children, onClose, pathname }: CommandMenu
   const viewMode: MenuViewMode = search.trim().length > 0 ? 'search' : 'default';
 
   // Memoize setters to maintain stable references
-  const setSearch = useCallback((value: string) => setSearchState(value), []);
+  const setSearch = useCallback((value: string) => {
+    const parsedQuery = parseSearchQuery(value);
+
+    if (parsedQuery.typeFilter) {
+      setTypeFilterState(parsedQuery.typeFilter);
+      setSearchState(parsedQuery.cleanQuery);
+      return;
+    }
+
+    setSearchState(value);
+  }, []);
   const setTypeFilter = useCallback(
     (value: ValidSearchType | undefined) => setTypeFilterState(value),
     [],


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Closes [LOBE-4236](https://linear.app/lobehub/issue/LOBE-4236) — `type:message` 搜不到内容.

#### 🔀 Description of Change

cmdk's `onValueChange` feeds the raw input into `setSearch`, which previously stored it verbatim. When the user typed `type:message foo`, the literal prefix `type:` ended up in the search string and matched nothing.

`setSearch` now runs `parseSearchQuery` on the incoming value. When a valid `type:` prefix is detected, the parsed filter is hoisted into `typeFilter` and the search state stores only the cleaned query. Unknown prefixes (e.g. `type:unknown ...`) fall through to the literal path so we don't silently swallow user intent.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

New unit tests in `CommandMenuContext.test.tsx`:
- Inline `type:message search content` → `search = 'search content'`, `typeFilter = 'message'`.
- Inline `type:unknown search content` → kept as literal search text, `typeFilter` undefined.

Manual: open command menu, type `type:message hello` — only message results show.

#### 📝 Additional Information

Type-only import tidy on the way in (no behavior change).