### PR TITLE
🐛 fix: resolve desktop visual media urls

### DIFF
--- a/packages/builtin-tool-lobe-agent/package.json
+++ b/packages/builtin-tool-lobe-agent/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@lobechat/const": "workspace:*",
-    "@lobechat/prompts": "workspace:*"
+    "@lobechat/prompts": "workspace:*",
+    "@lobechat/utils": "workspace:*"
   },
   "devDependencies": {
     "@lobechat/types": "workspace:*"

--- a/packages/builtin-tool-lobe-agent/src/client/executor/index.ts
+++ b/packages/builtin-tool-lobe-agent/src/client/executor/index.ts
@@ -35,7 +35,7 @@ import {
   type PlanRuntimeService,
 } from './PlanRuntime';
 import { getTodosFromContext } from './planTodoHelper';
-import { resolveClientVisualMediaUris } from './resolveVisualMediaUris';
+import { resolveClientVisualMediaPayloadItems } from './resolveVisualMediaUris';
 
 const PLAN_DOC_TYPE = 'agent/plan';
 
@@ -290,7 +290,7 @@ class LobeAgentExecutor extends BaseExecutor<typeof LobeAgentApiName> {
       };
     }
 
-    const payloadItems = await resolveClientVisualMediaUris(selectedItems);
+    const payloadItems = await resolveClientVisualMediaPayloadItems({ selectedRefs, selectedUrls });
 
     let content = '';
     let error: { message?: string } | undefined;

--- a/packages/builtin-tool-lobe-agent/src/client/executor/index.ts
+++ b/packages/builtin-tool-lobe-agent/src/client/executor/index.ts
@@ -35,6 +35,7 @@ import {
   type PlanRuntimeService,
 } from './PlanRuntime';
 import { getTodosFromContext } from './planTodoHelper';
+import { resolveClientVisualMediaUris } from './resolveVisualMediaUris';
 
 const PLAN_DOC_TYPE = 'agent/plan';
 
@@ -289,6 +290,8 @@ class LobeAgentExecutor extends BaseExecutor<typeof LobeAgentApiName> {
       };
     }
 
+    const payloadItems = await resolveClientVisualMediaUris(selectedItems);
+
     let content = '';
     let error: { message?: string } | undefined;
     let usage: unknown;
@@ -299,7 +302,7 @@ class LobeAgentExecutor extends BaseExecutor<typeof LobeAgentApiName> {
       max_tokens: 2000,
       messages: [
         {
-          content: buildAnalyzeVisualMediaContent(selectedItems, params.question, {
+          content: buildAnalyzeVisualMediaContent(payloadItems, params.question, {
             includeFallbackInstruction: true,
             includeFileSummary: true,
           }),

--- a/packages/builtin-tool-lobe-agent/src/client/executor/resolveVisualMediaUris.test.ts
+++ b/packages/builtin-tool-lobe-agent/src/client/executor/resolveVisualMediaUris.test.ts
@@ -79,6 +79,39 @@ describe('resolveClientVisualMediaUris', () => {
     expect(imageUrlToBase64).toHaveBeenNthCalledWith(2, 'http://127.0.0.1:3210/uploads/local.mp4');
   });
 
+  it('should reject desktop local URLs when fetched MIME type does not match the item type', async () => {
+    vi.mocked(imageUrlToBase64).mockResolvedValue({
+      base64: 'not-found',
+      mimeType: 'text/plain',
+    });
+
+    const localImage = createVisualItem({
+      name: 'missing.png',
+      uri: 'http://127.0.0.1:3210/uploads/missing.png',
+    });
+
+    await expect(resolveClientVisualMediaUris([localImage])).rejects.toThrow(
+      'Unable to read image attachment "missing.png": expected image/* MIME type, received text/plain.',
+    );
+  });
+
+  it('should reject desktop local video URLs when fetched MIME type is an image', async () => {
+    vi.mocked(imageUrlToBase64).mockResolvedValue({
+      base64: 'poster',
+      mimeType: 'image/png',
+    });
+
+    const localVideo = createVisualItem({
+      name: 'clip.mp4',
+      type: 'video',
+      uri: 'http://127.0.0.1:3210/uploads/clip.mp4',
+    });
+
+    await expect(resolveClientVisualMediaUris([localVideo])).rejects.toThrow(
+      'Unable to read video attachment "clip.mp4": expected video/* MIME type, received image/png.',
+    );
+  });
+
   it('should only convert attachment refs when building visual media payload items', async () => {
     vi.mocked(imageUrlToBase64).mockResolvedValue({
       base64: 'attachment-base64',

--- a/packages/builtin-tool-lobe-agent/src/client/executor/resolveVisualMediaUris.test.ts
+++ b/packages/builtin-tool-lobe-agent/src/client/executor/resolveVisualMediaUris.test.ts
@@ -1,8 +1,11 @@
 import { imageUrlToBase64 } from '@lobechat/utils/imageToBase64';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { VisualFileItem } from '../../visualMedia';
-import { resolveClientVisualMediaUris } from './resolveVisualMediaUris';
+import {
+  resolveClientVisualMediaPayloadItems,
+  resolveClientVisualMediaUris,
+} from './resolveVisualMediaUris';
 
 vi.mock('@lobechat/utils/imageToBase64', () => ({
   imageUrlToBase64: vi.fn(),
@@ -19,6 +22,10 @@ const createVisualItem = (item: Partial<VisualFileItem>): VisualFileItem => ({
 });
 
 describe('resolveClientVisualMediaUris', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('should convert desktop local visual media URLs to data URLs', async () => {
     vi.mocked(imageUrlToBase64)
       .mockResolvedValueOnce({
@@ -70,5 +77,38 @@ describe('resolveClientVisualMediaUris', () => {
     expect(imageUrlToBase64).toHaveBeenCalledTimes(2);
     expect(imageUrlToBase64).toHaveBeenNthCalledWith(1, 'http://127.0.0.1:3210/uploads/local.png');
     expect(imageUrlToBase64).toHaveBeenNthCalledWith(2, 'http://127.0.0.1:3210/uploads/local.mp4');
+  });
+
+  it('should only convert attachment refs when building visual media payload items', async () => {
+    vi.mocked(imageUrlToBase64).mockResolvedValue({
+      base64: 'attachment-base64',
+      mimeType: 'image/png',
+    });
+
+    const localAttachment = createVisualItem({
+      name: 'attachment.png',
+      uri: 'http://127.0.0.1:3210/uploads/attachment.png',
+    });
+    const directLocalUrl = createVisualItem({
+      localRef: 'url_1',
+      name: 'direct.png',
+      ref: 'url_1',
+      uri: 'http://127.0.0.1:3210/private/direct.png',
+    });
+
+    const result = await resolveClientVisualMediaPayloadItems({
+      selectedRefs: [localAttachment],
+      selectedUrls: [directLocalUrl],
+    });
+
+    expect(result).toEqual([
+      {
+        ...localAttachment,
+        uri: 'data:image/png;base64,attachment-base64',
+      },
+      directLocalUrl,
+    ]);
+    expect(imageUrlToBase64).toHaveBeenCalledTimes(1);
+    expect(imageUrlToBase64).toHaveBeenCalledWith('http://127.0.0.1:3210/uploads/attachment.png');
   });
 });

--- a/packages/builtin-tool-lobe-agent/src/client/executor/resolveVisualMediaUris.test.ts
+++ b/packages/builtin-tool-lobe-agent/src/client/executor/resolveVisualMediaUris.test.ts
@@ -1,0 +1,74 @@
+import { imageUrlToBase64 } from '@lobechat/utils/imageToBase64';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { VisualFileItem } from '../../visualMedia';
+import { resolveClientVisualMediaUris } from './resolveVisualMediaUris';
+
+vi.mock('@lobechat/utils/imageToBase64', () => ({
+  imageUrlToBase64: vi.fn(),
+}));
+
+const createVisualItem = (item: Partial<VisualFileItem>): VisualFileItem => ({
+  description: 'test.png',
+  localRef: 'image_1',
+  name: 'test.png',
+  ref: 'msg_1.image_1',
+  type: 'image',
+  uri: 'https://example.com/test.png',
+  ...item,
+});
+
+describe('resolveClientVisualMediaUris', () => {
+  it('should convert desktop local visual media URLs to data URLs', async () => {
+    vi.mocked(imageUrlToBase64)
+      .mockResolvedValueOnce({
+        base64: 'image-base64',
+        mimeType: 'image/png',
+      })
+      .mockResolvedValueOnce({
+        base64: 'video-base64',
+        mimeType: 'video/mp4',
+      });
+
+    const localImage = createVisualItem({
+      name: 'local.png',
+      uri: 'http://127.0.0.1:3210/uploads/local.png',
+    });
+    const localVideo = createVisualItem({
+      name: 'local.mp4',
+      type: 'video',
+      uri: 'http://127.0.0.1:3210/uploads/local.mp4',
+    });
+    const remoteImage = createVisualItem({
+      name: 'remote.png',
+      uri: 'https://example.com/remote.png',
+    });
+    const dataImage = createVisualItem({
+      name: 'inline.png',
+      uri: 'data:image/png;base64,inline-base64',
+    });
+
+    const result = await resolveClientVisualMediaUris([
+      localImage,
+      localVideo,
+      remoteImage,
+      dataImage,
+    ]);
+
+    expect(result).toEqual([
+      {
+        ...localImage,
+        uri: 'data:image/png;base64,image-base64',
+      },
+      {
+        ...localVideo,
+        uri: 'data:video/mp4;base64,video-base64',
+      },
+      remoteImage,
+      dataImage,
+    ]);
+    expect(imageUrlToBase64).toHaveBeenCalledTimes(2);
+    expect(imageUrlToBase64).toHaveBeenNthCalledWith(1, 'http://127.0.0.1:3210/uploads/local.png');
+    expect(imageUrlToBase64).toHaveBeenNthCalledWith(2, 'http://127.0.0.1:3210/uploads/local.mp4');
+  });
+});

--- a/packages/builtin-tool-lobe-agent/src/client/executor/resolveVisualMediaUris.ts
+++ b/packages/builtin-tool-lobe-agent/src/client/executor/resolveVisualMediaUris.ts
@@ -9,6 +9,22 @@ interface ResolveClientVisualMediaPayloadItemsParams {
   selectedUrls: VisualFileItem[];
 }
 
+const VISUAL_MEDIA_MIME_TYPE_PREFIXES = {
+  image: 'image/',
+  video: 'video/',
+} as const satisfies Record<VisualFileItem['type'], string>;
+
+const assertExpectedVisualMediaMimeType = (item: VisualFileItem, mimeType: string) => {
+  const expectedPrefix = VISUAL_MEDIA_MIME_TYPE_PREFIXES[item.type];
+  const normalizedMimeType = mimeType.trim().toLowerCase();
+
+  if (normalizedMimeType.startsWith(expectedPrefix)) return;
+
+  throw new TypeError(
+    `Unable to read ${item.type} attachment "${item.name}": expected ${expectedPrefix}* MIME type, received ${normalizedMimeType || 'unknown'}.`,
+  );
+};
+
 /**
  * Desktop attachments are exposed through a 127.0.0.1 static file server.
  * Convert those URLs in the client before sending a remote visual request;
@@ -24,6 +40,7 @@ export const resolveClientVisualMediaUris = async (
       if (type !== 'url' || !isDesktopLocalStaticServerUrl(item.uri)) return item;
 
       const { base64, mimeType } = await imageUrlToBase64(item.uri);
+      assertExpectedVisualMediaMimeType(item, mimeType);
 
       return {
         ...item,

--- a/packages/builtin-tool-lobe-agent/src/client/executor/resolveVisualMediaUris.ts
+++ b/packages/builtin-tool-lobe-agent/src/client/executor/resolveVisualMediaUris.ts
@@ -1,0 +1,28 @@
+import { imageUrlToBase64 } from '@lobechat/utils/imageToBase64';
+import { parseDataUri } from '@lobechat/utils/uriParser';
+import { isDesktopLocalStaticServerUrl } from '@lobechat/utils/url';
+
+import type { VisualFileItem } from '../../visualMedia';
+
+/**
+ * Desktop attachments are exposed through a 127.0.0.1 static file server.
+ * Convert those URLs in the client before sending a remote visual request;
+ * otherwise the server sees its own localhost and SSRF protection blocks it.
+ */
+export const resolveClientVisualMediaUris = async (
+  items: VisualFileItem[],
+): Promise<VisualFileItem[]> =>
+  Promise.all(
+    items.map(async (item) => {
+      const { type } = parseDataUri(item.uri);
+
+      if (type !== 'url' || !isDesktopLocalStaticServerUrl(item.uri)) return item;
+
+      const { base64, mimeType } = await imageUrlToBase64(item.uri);
+
+      return {
+        ...item,
+        uri: `data:${mimeType};base64,${base64}`,
+      };
+    }),
+  );

--- a/packages/builtin-tool-lobe-agent/src/client/executor/resolveVisualMediaUris.ts
+++ b/packages/builtin-tool-lobe-agent/src/client/executor/resolveVisualMediaUris.ts
@@ -4,6 +4,11 @@ import { isDesktopLocalStaticServerUrl } from '@lobechat/utils/url';
 
 import type { VisualFileItem } from '../../visualMedia';
 
+interface ResolveClientVisualMediaPayloadItemsParams {
+  selectedRefs: VisualFileItem[];
+  selectedUrls: VisualFileItem[];
+}
+
 /**
  * Desktop attachments are exposed through a 127.0.0.1 static file server.
  * Convert those URLs in the client before sending a remote visual request;
@@ -26,3 +31,11 @@ export const resolveClientVisualMediaUris = async (
       };
     }),
   );
+
+export const resolveClientVisualMediaPayloadItems = async ({
+  selectedRefs,
+  selectedUrls,
+}: ResolveClientVisualMediaPayloadItemsParams): Promise<VisualFileItem[]> => [
+  ...(await resolveClientVisualMediaUris(selectedRefs)),
+  ...selectedUrls,
+];

--- a/packages/database/src/models/file.ts
+++ b/packages/database/src/models/file.ts
@@ -95,8 +95,9 @@ export class FileModel {
   updateGlobalFile = async (
     hashId: string,
     data: Partial<Pick<NewGlobalFile, 'metadata' | 'url'>>,
+    trx?: Transaction,
   ) => {
-    return this.db.update(globalFiles).set(data).where(eq(globalFiles.hashId, hashId));
+    return (trx ?? this.db).update(globalFiles).set(data).where(eq(globalFiles.hashId, hashId));
   };
 
   checkHash = async (hash: string) => {

--- a/src/server/routers/lambda/__tests__/file.test.ts
+++ b/src/server/routers/lambda/__tests__/file.test.ts
@@ -29,6 +29,7 @@ function createCallerWithCtx(partialCtx: any = {}) {
     query: vi.fn().mockResolvedValue([]),
     delete: vi.fn().mockResolvedValue(undefined),
     deleteMany: vi.fn().mockResolvedValue([]),
+    updateGlobalFile: vi.fn().mockResolvedValue(undefined),
     clear: vi.fn().mockResolvedValue({} as any),
   };
 
@@ -128,6 +129,7 @@ const mockFileModelDeleteMany = vi.fn();
 const mockFileModelFindById = vi.fn();
 const mockFileModelFindByIds = vi.fn();
 const mockFileModelQuery = vi.fn();
+const mockFileModelUpdateGlobalFile = vi.fn();
 const mockFileModelClear = vi.fn();
 
 vi.mock('@/database/models/file', () => ({
@@ -139,6 +141,7 @@ vi.mock('@/database/models/file', () => ({
     findById: mockFileModelFindById,
     findByIds: mockFileModelFindByIds,
     query: mockFileModelQuery,
+    updateGlobalFile: mockFileModelUpdateGlobalFile,
     clear: mockFileModelClear,
   })),
 }));
@@ -215,6 +218,47 @@ describe('fileRouter', () => {
       ctx.fileModel.checkHash.mockResolvedValue(undefined);
       await expect(caller.checkFileHash({ hash: 'test-hash' })).resolves.toBeUndefined();
     });
+
+    it('should return existing hash when the stored object is still available', async () => {
+      const checkResult = {
+        isExist: true,
+        metadata: { path: 'files/existing.png' },
+        url: 'files/existing.png',
+      };
+      mockFileModelCheckHash.mockResolvedValue(checkResult);
+      mockFileServiceGetFileMetadata.mockResolvedValue({
+        contentLength: 100,
+        contentType: 'image/png',
+      });
+
+      await expect(caller.checkFileHash({ hash: 'test-hash' })).resolves.toEqual(checkResult);
+
+      expect(mockFileServiceGetFileMetadata).toHaveBeenCalledWith('files/existing.png');
+    });
+
+    it('should treat stale hash records as missing when the stored object is unavailable', async () => {
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      mockFileModelCheckHash.mockResolvedValue({
+        isExist: true,
+        metadata: { path: 'generations/images/missing_raw.jpg' },
+        url: 'generations/images/missing_raw.jpg',
+      });
+      mockFileServiceGetFileMetadata.mockRejectedValue(new Error('NoSuchKey'));
+
+      await expect(caller.checkFileHash({ hash: 'test-hash' })).resolves.toEqual({
+        isExist: false,
+      });
+
+      expect(mockFileServiceGetFileMetadata).toHaveBeenCalledWith(
+        'generations/images/missing_raw.jpg',
+      );
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to verify existing file hash storage object:',
+        expect.any(Error),
+      );
+
+      consoleSpy.mockRestore();
+    });
   });
 
   describe('createFile', () => {
@@ -249,6 +293,72 @@ describe('fileRouter', () => {
         id: 'new-file-id',
         url: 'https://lobehub.com/f/new-file-id',
       });
+    });
+
+    it('should refresh global file metadata when an existing hash points to a missing object', async () => {
+      mockFileModelCheckHash.mockResolvedValue({
+        isExist: true,
+        metadata: { path: 'old/path.txt' },
+        url: 'old/path.txt',
+      });
+      mockFileModelCreate.mockResolvedValue({ id: 'new-file-id' });
+      mockFileServiceGetFileMetadata
+        .mockResolvedValueOnce({ contentLength: 100, contentType: 'text/plain' })
+        .mockRejectedValueOnce(new Error('NoSuchKey'));
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await caller.createFile({
+        hash: 'test-hash',
+        fileType: 'text',
+        metadata: { path: 'new/path.txt' },
+        name: 'test.txt',
+        size: 100,
+        url: 'new/path.txt',
+      });
+
+      expect(mockFileModelUpdateGlobalFile).toHaveBeenCalledWith(
+        'test-hash',
+        {
+          metadata: { path: 'new/path.txt' },
+          url: 'new/path.txt',
+        },
+        routerMocks.transactionClient,
+      );
+      expect(mockFileModelCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ fileHash: 'test-hash', url: 'new/path.txt' }),
+        false,
+        routerMocks.transactionClient,
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('should keep the global file pointer when an existing hash object is still available', async () => {
+      mockFileModelCheckHash.mockResolvedValue({
+        isExist: true,
+        metadata: { path: 'old/path.txt' },
+        url: 'old/path.txt',
+      });
+      mockFileModelCreate.mockResolvedValue({ id: 'new-file-id' });
+      mockFileServiceGetFileMetadata.mockResolvedValue({
+        contentLength: 100,
+        contentType: 'text/plain',
+      });
+
+      await caller.createFile({
+        hash: 'test-hash',
+        fileType: 'text',
+        metadata: { path: 'new/path.txt' },
+        name: 'test.txt',
+        size: 100,
+        url: 'new/path.txt',
+      });
+
+      expect(mockFileModelUpdateGlobalFile).not.toHaveBeenCalled();
+      expect(mockFileModelCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ fileHash: 'test-hash', url: 'new/path.txt' }),
+        false,
+        routerMocks.transactionClient,
+      );
     });
 
     it('should run business upload check and file creation in the same transaction', async () => {

--- a/src/server/routers/lambda/file.ts
+++ b/src/server/routers/lambda/file.ts
@@ -102,6 +102,19 @@ const getKnowledgeItemStatusMap = async (
   );
 };
 
+const isStoredObjectAvailable = async (fileService: FileService, url: string): Promise<boolean> => {
+  try {
+    // Hash records can outlive their backing object, for example when generated
+    // assets are cleaned up but the global hash row remains. Treat stale rows as
+    // missing so the client uploads a fresh copy instead of reusing a dead key.
+    await fileService.getFileMetadata(url);
+    return true;
+  } catch (error) {
+    console.error('Failed to verify existing file hash storage object:', error);
+    return false;
+  }
+};
+
 const fileProcedure = authedProcedure.use(serverDatabase).use(async (opts) => {
   const { ctx } = opts;
 
@@ -123,7 +136,12 @@ export const fileRouter = router({
     .use(checkFileStorageUsage)
     .input(z.object({ hash: z.string() }))
     .mutation(async ({ ctx, input }) => {
-      return ctx.fileModel.checkHash(input.hash);
+      const existingFile = await ctx.fileModel.checkHash(input.hash);
+      if (!existingFile?.isExist || !existingFile.url) return existingFile;
+
+      const isStorageAvailable = await isStoredObjectAvailable(ctx.fileService, existingFile.url);
+
+      return isStorageAvailable ? existingFile : { isExist: false };
     }),
 
   createFile: fileProcedure
@@ -135,7 +153,8 @@ export const fileRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      const { isExist } = await ctx.fileModel.checkHash(input.hash!);
+      const existingFile = await ctx.fileModel.checkHash(input.hash!);
+      const { isExist } = existingFile;
 
       // Resolve parentId if it's a slug
       let resolvedParentId = input.parentId;
@@ -176,6 +195,28 @@ export const fileRouter = router({
           url: input.url,
           userId: ctx.userId,
         });
+
+        let shouldRefreshGlobalFile = false;
+        if (isExist && existingFile.url && existingFile.url !== input.url) {
+          shouldRefreshGlobalFile = !(await isStoredObjectAvailable(
+            ctx.fileService,
+            existingFile.url,
+          ));
+        }
+
+        if (shouldRefreshGlobalFile) {
+          // A user may re-upload the same bytes after the old object key was
+          // removed. Keep the global hash pointer on the newly uploaded object so
+          // future dedup checks do not resolve back to the stale key.
+          await ctx.fileModel.updateGlobalFile(
+            input.hash!,
+            {
+              metadata: input.metadata,
+              url: input.url,
+            },
+            trx,
+          );
+        }
 
         return ctx.fileModel.create(
           {

--- a/src/server/routers/lambda/file.ts
+++ b/src/server/routers/lambda/file.ts
@@ -137,9 +137,10 @@ export const fileRouter = router({
     .input(z.object({ hash: z.string() }))
     .mutation(async ({ ctx, input }) => {
       const existingFile = await ctx.fileModel.checkHash(input.hash);
-      if (!existingFile?.isExist || !existingFile.url) return existingFile;
+      const existingHashUrl = existingFile?.isExist ? existingFile.url : undefined;
+      if (!existingHashUrl) return existingFile;
 
-      const isStorageAvailable = await isStoredObjectAvailable(ctx.fileService, existingFile.url);
+      const isStorageAvailable = await isStoredObjectAvailable(ctx.fileService, existingHashUrl);
 
       return isStorageAvailable ? existingFile : { isExist: false };
     }),

--- a/src/server/services/file/__tests__/index.test.ts
+++ b/src/server/services/file/__tests__/index.test.ts
@@ -24,6 +24,7 @@ vi.mock('../impls', () => ({
     deleteFiles: vi.fn(),
     getFileContent: vi.fn(),
     getFileByteArray: vi.fn(),
+    getFileMetadata: vi.fn(),
     createPreSignedUrl: vi.fn(),
     createPreSignedUrlForPreview: vi.fn(),
     uploadContent: vi.fn(),
@@ -381,7 +382,7 @@ describe('FileService', () => {
     });
 
     it('should not insert to global files when hash already exists', async () => {
-      mockFileModel.checkHash.mockResolvedValue({ isExist: true });
+      mockFileModel.checkHash.mockResolvedValue({ isExist: true, url: 'files/test.txt' });
       mockFileModel.create.mockResolvedValue({ id: 'file-id' });
 
       await service.createFileRecord({
@@ -397,6 +398,63 @@ describe('FileService', () => {
           fileHash: 'existing-hash',
         }),
         false, // insertToGlobalFiles = false when hash exists
+      );
+      expect(mockFileModel.updateGlobalFile).not.toHaveBeenCalled();
+    });
+
+    it('should update global file metadata when an existing hash points to a missing object', async () => {
+      mockFileModel.checkHash.mockResolvedValue({ isExist: true, url: 'old/path.txt' });
+      mockFileModel.create.mockResolvedValue({ id: 'file-id' });
+      vi.mocked(service['impl'].getFileMetadata).mockRejectedValue(new Error('NoSuchKey'));
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await service.createFileRecord({
+        fileHash: 'existing-hash',
+        fileType: 'text/plain',
+        metadata: { dirname: 'new', filename: 'test.txt', path: 'new/path.txt' },
+        name: 'test.txt',
+        size: 100,
+        url: 'new/path.txt',
+      });
+
+      expect(mockFileModel.updateGlobalFile).toHaveBeenCalledWith('existing-hash', {
+        metadata: { dirname: 'new', filename: 'test.txt', path: 'new/path.txt' },
+        url: 'new/path.txt',
+      });
+      expect(mockFileModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileHash: 'existing-hash',
+          url: 'new/path.txt',
+        }),
+        false,
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('should keep global file metadata when the existing hash object is still available', async () => {
+      mockFileModel.checkHash.mockResolvedValue({ isExist: true, url: 'old/path.txt' });
+      mockFileModel.create.mockResolvedValue({ id: 'file-id' });
+      vi.mocked(service['impl'].getFileMetadata).mockResolvedValue({
+        contentLength: 100,
+        contentType: 'text/plain',
+      });
+
+      await service.createFileRecord({
+        fileHash: 'existing-hash',
+        fileType: 'text/plain',
+        metadata: { dirname: 'new', filename: 'test.txt', path: 'new/path.txt' },
+        name: 'test.txt',
+        size: 100,
+        url: 'new/path.txt',
+      });
+
+      expect(mockFileModel.updateGlobalFile).not.toHaveBeenCalled();
+      expect(mockFileModel.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileHash: 'existing-hash',
+          url: 'new/path.txt',
+        }),
+        false,
       );
     });
   });

--- a/src/server/services/file/index.ts
+++ b/src/server/services/file/index.ts
@@ -119,6 +119,16 @@ export class FileService {
     return this.impl.uploadBuffer(key, buffer, contentType);
   }
 
+  private async isStoredFileAvailable(url: string): Promise<boolean> {
+    try {
+      await this.getFileMetadata(url);
+      return true;
+    } catch (error) {
+      console.error('Failed to verify existing file hash storage object:', error);
+      return false;
+    }
+  }
+
   /**
    * Create file record (common method)
    * Automatically handles globalFiles deduplication logic
@@ -137,7 +147,22 @@ export class FileService {
     url: string;
   }): Promise<{ fileId: string; url: string }> {
     // Check if hash already exists in globalFiles
-    const { isExist } = await this.fileModel.checkHash(params.fileHash);
+    const existingFile = await this.fileModel.checkHash(params.fileHash);
+    const { isExist } = existingFile;
+
+    let shouldRefreshGlobalFile = false;
+    if (isExist && existingFile.url && existingFile.url !== params.url) {
+      shouldRefreshGlobalFile = !(await this.isStoredFileAvailable(existingFile.url));
+    }
+
+    if (shouldRefreshGlobalFile) {
+      // Keep global hash dedup usable when the same file is uploaded again to a
+      // fresh object key after the previous storage object has been removed.
+      await this.fileModel.updateGlobalFile(params.fileHash, {
+        metadata: params.metadata,
+        url: params.url,
+      });
+    }
 
     // Create database record
     // If hash doesn't exist, also create globalFiles record


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - reported directly.

#### 🔀 Description of Change

- Convert desktop local visual media URLs to data URLs before the Lobe Agent visual analysis fallback sends the request to a remote model.
- Keep remote URLs and existing data URLs unchanged.
- Add regression coverage for desktop local image and video URLs.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/builtin-tool-lobe-agent && bunx vitest run --silent='passed-only'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This prevents server-side SSRF protection from seeing desktop attachment URLs as localhost requests during visual analysis fallback requests.