### PR TITLE
🐛 fix(desktop): prevent App Nap from dropping gateway WebSocket during display sleep

### DIFF
--- a/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
@@ -89,6 +89,10 @@ vi.mock('electron', () => ({
     getPath: vi.fn((name: string) => `/mock/${name}`),
   },
   ipcMain: { handle: ipcMainHandleMock },
+  powerSaveBlocker: {
+    start: vi.fn(() => 1),
+    stop: vi.fn(),
+  },
 }));
 
 vi.mock('@/utils/logger', () => ({

--- a/apps/desktop/src/main/services/gatewayConnectionSrv.ts
+++ b/apps/desktop/src/main/services/gatewayConnectionSrv.ts
@@ -8,7 +8,7 @@ import type {
 } from '@lobechat/device-gateway-client';
 import { GatewayClient } from '@lobechat/device-gateway-client';
 import type { GatewayConnectionStatus } from '@lobechat/electron-client-ipc';
-import { app } from 'electron';
+import { app, powerSaveBlocker } from 'electron';
 
 import { createLogger } from '@/utils/logger';
 
@@ -36,6 +36,7 @@ export default class GatewayConnectionService extends ServiceModule {
   private client: GatewayClient | null = null;
   private status: GatewayConnectionStatus = 'disconnected';
   private deviceId: string | null = null;
+  private powerSaveBlockerId: number | null = null;
 
   private tokenProvider: (() => Promise<string | null>) | null = null;
   private tokenRefresher: (() => Promise<{ error?: string; success: boolean }>) | null = null;
@@ -318,6 +319,26 @@ export default class GatewayConnectionService extends ServiceModule {
     }
   };
 
+  // ─── Power Save Blocker ───
+
+  /**
+   * Start power save blocker to prevent macOS App Nap from suspending the process
+   * while the gateway connection is active. Uses 'prevent-app-suspension' so the
+   * display can still sleep — only the app process is kept alive.
+   */
+  private startPowerSaveBlocker() {
+    if (this.powerSaveBlockerId !== null) return;
+    this.powerSaveBlockerId = powerSaveBlocker.start('prevent-app-suspension');
+    logger.info(`Power save blocker started (id=${this.powerSaveBlockerId})`);
+  }
+
+  private stopPowerSaveBlocker() {
+    if (this.powerSaveBlockerId === null) return;
+    powerSaveBlocker.stop(this.powerSaveBlockerId);
+    logger.info(`Power save blocker stopped (id=${this.powerSaveBlockerId})`);
+    this.powerSaveBlockerId = null;
+  }
+
   // ─── Status Broadcasting ───
 
   private setStatus(status: GatewayConnectionStatus) {
@@ -325,6 +346,15 @@ export default class GatewayConnectionService extends ServiceModule {
 
     logger.info(`Connection status: ${this.status} → ${status}`);
     this.status = status;
+
+    // Keep the app process alive while gateway is connected so macOS App Nap
+    // does not suspend it during display sleep, which would drop the WebSocket.
+    if (status === 'connected') {
+      this.startPowerSaveBlocker();
+    } else if (status === 'disconnected') {
+      this.stopPowerSaveBlocker();
+    }
+
     this.app.browserManager.broadcastToAllWindows('gatewayConnectionStatusChanged', { status });
   }
 

--- a/apps/desktop/src/main/services/gatewayConnectionSrv.ts
+++ b/apps/desktop/src/main/services/gatewayConnectionSrv.ts
@@ -351,7 +351,7 @@ export default class GatewayConnectionService extends ServiceModule {
     // does not suspend it during display sleep, which would drop the WebSocket.
     if (status === 'connected') {
       this.startPowerSaveBlocker();
-    } else if (status === 'disconnected') {
+    } else {
       this.stopPowerSaveBlocker();
     }
 


### PR DESCRIPTION
## Problem

On macOS, when the display sleeps, the OS activates **App Nap** and may suspend the Electron process. This causes the WebSocket connection to the device gateway to drop — and since the process is suspended, the auto-reconnect logic never fires. The result is that the device appears offline until the user manually wakes the machine and the app reconnects.

## Solution

Use Electron's `powerSaveBlocker` API with `prevent-app-suspension` mode, tied to the gateway connection lifecycle:

- **`connected`** → start blocker — keeps the process alive during display sleep
- **`disconnected`** → stop blocker — releases the blocker so normal power saving resumes

This uses `prevent-app-suspension` (not `prevent-display-sleep`), so the screen can still turn off — only the app process suspension is blocked.

## Changes

- `apps/desktop/src/main/services/gatewayConnectionSrv.ts`
  - Import `powerSaveBlocker` from `electron`
  - Add `powerSaveBlockerId` field
  - Add `startPowerSaveBlocker` / `stopPowerSaveBlocker` private methods
  - Call them in `setStatus` when status transitions to/from `connected`