### PR TITLE
refactor(parserPlaceholder): replace any[] with typed PlaceholderMessage

### DIFF
--- a/src/helpers/parserPlaceholder/index.ts
+++ b/src/helpers/parserPlaceholder/index.ts
@@ -209,12 +209,17 @@ export const parsePlaceholderVariables = (text: string, depth = 2): string => {
   return result;
 };
 
+interface PlaceholderMessage {
+  content?: string | unknown[];
+  [key: string]: unknown;
+}
+
 /**
  * Parse message content, replace placeholder variables
  * @param messages Original message array
  * @returns Processed message array
  */
-export const parsePlaceholderVariablesMessages = (messages: any[]): any[] =>
+export const parsePlaceholderVariablesMessages = (messages: PlaceholderMessage[]): PlaceholderMessage[] =>
   messages.map((message) => {
     if (!message?.content) return message;
 


### PR DESCRIPTION
Tighten the public signature of `parsePlaceholderVariablesMessages` by introducing a small `PlaceholderMessage` interface in place of `any[]`.

- Keeps runtime behavior identical (the function still maps over an array and only touches `.content`).
- Improves type-safety at call sites and lets downstream code rely on a stable message shape.

No functional change.