### PR TITLE
🙈 feat(home): hide heterogeneous agents from home picker

### DIFF
--- a/src/routes/(main)/home/features/AgentSelect/AgentList.tsx
+++ b/src/routes/(main)/home/features/AgentSelect/AgentList.tsx
@@ -74,6 +74,9 @@ const AgentList = memo<AgentListProps>(({ activeAgentId, onSelect }) => {
       // Skip chat groups — sendMessage / agent config lookups expect an agent id.
       // Groups go through their own chat-group flow under /group/:gid.
       if (item.type !== 'agent') continue;
+      // Hide heterogeneous agents (Claude Code / Codex …) from the consumer
+      // home picker — they're dev-oriented and clutter the primary list.
+      if (item.heterogeneousType) continue;
       if (seen.has(item.id)) continue;
       seen.add(item.id);
       out.push({


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Heterogeneous agents (Claude Code / Codex / …) are dev-oriented and clutter the consumer home agent picker. Skip any item with a truthy `heterogeneousType` when building `AgentList` so the primary home list only surfaces native agents.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. Have at least one heterogeneous agent (e.g. Claude Code) configured alongside native agents.
2. Open the home agent picker — the heterogeneous agents should no longer appear there.
3. Other surfaces that expose heterogeneous agents (dev/sessions flows) are unaffected.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Heterogeneous agents listed | Only native agents listed |

#### 📝 Additional Information

No data or config change — purely a filter on the home picker render path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)