### PR TITLE
♻️ refactor(creds): remove getPlaintextCred tool to prevent plaintext credential exposure

### DIFF
--- a/packages/builtin-tool-creds/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-creds/src/ExecutionRuntime/index.ts
@@ -3,7 +3,6 @@ import type { BuiltinServerRuntimeOutput } from '@lobechat/types';
 
 import type {
   ConnectKlavisServiceParams,
-  GetPlaintextCredParams,
   InitiateOAuthConnectParams,
   InjectCredsToSandboxParams,
   SaveCredsParams,
@@ -15,21 +14,6 @@ import { LOBEHUB_OAUTH_PROVIDER_LIST } from '../types';
  * Abstracted to allow different implementations (e.g., MarketService-based)
  */
 export interface ICredsService {
-  /**
-   * Get plaintext credential by key
-   */
-  getByKey: (
-    key: string,
-    options?: { decrypt?: boolean },
-  ) => Promise<{
-    fileName?: string;
-    fileUrl?: string;
-    name?: string;
-    plaintext?: Record<string, string>;
-    type: string;
-    values?: Record<string, string>;
-  }>;
-
   /**
    * Get OAuth authorization URL
    */
@@ -202,79 +186,6 @@ export class CredsExecutionRuntime {
         error: {
           message: error instanceof Error ? error.message : 'Failed to initiate OAuth connection',
           type: 'InitiateOAuthFailed',
-        },
-        success: false,
-      };
-    }
-  }
-
-  /**
-   * Get plaintext credential value by key
-   */
-  async getPlaintextCred(args: GetPlaintextCredParams): Promise<BuiltinServerRuntimeOutput> {
-    try {
-      const result = await this.credsService.getByKey(args.key, { decrypt: true });
-
-      const credType = result.type;
-      const credName = result.name || args.key;
-
-      // Handle file type credentials
-      if (credType === 'file') {
-        const fileUrl = result.fileUrl;
-        const fileName = result.fileName;
-
-        if (!fileUrl) {
-          return {
-            content: `File credential "${credName}" (key: ${args.key}) found but file URL is not available.`,
-            error: {
-              message: 'File URL not available',
-              type: 'FileUrlNotAvailable',
-            },
-            success: false,
-          };
-        }
-
-        return {
-          content: `Successfully retrieved file credential "${credName}" (key: ${args.key}). File: ${fileName || 'unknown'}. The file download URL is available in the state.`,
-          state: {
-            fileName,
-            fileUrl,
-            key: args.key,
-            name: credName,
-            type: 'file',
-          },
-          success: true,
-        };
-      }
-
-      // Handle KV types (kv-env, kv-header, oauth)
-      const values = result.values || result.plaintext || {};
-      const valueKeys = Object.keys(values);
-
-      // Return content with masked values for security, but include actual values in state
-      const maskedValues = valueKeys.map((k) => `${k}: ****`).join(', ');
-
-      return {
-        content: `Successfully retrieved credential "${credName}" (key: ${args.key}). Contains ${valueKeys.length} value(s): ${maskedValues}. The actual values are available in the state for use.`,
-        state: {
-          key: args.key,
-          name: credName,
-          type: credType,
-          values,
-        },
-        success: true,
-      };
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      const isNotFound = errorMessage.includes('not found') || errorMessage.includes('NOT_FOUND');
-
-      return {
-        content: isNotFound
-          ? `Credential not found: ${args.key}. Please check if the credential exists in Settings > Credentials.`
-          : `Failed to get credential: ${errorMessage}`,
-        error: {
-          message: errorMessage,
-          type: isNotFound ? 'CredentialNotFound' : 'GetCredentialFailed',
         },
         success: false,
       };

--- a/packages/builtin-tool-creds/src/executor/index.ts
+++ b/packages/builtin-tool-creds/src/executor/index.ts
@@ -13,7 +13,6 @@ import { userProfileSelectors } from '@/store/user/slices/auth/selectors';
 import { CredsIdentifier } from '../manifest';
 import type {
   ConnectKlavisServiceParams,
-  GetPlaintextCredParams,
   InitiateOAuthConnectParams,
   InjectCredsToSandboxParams,
   SaveCredsParams,
@@ -393,98 +392,6 @@ class CredsExecutor extends BaseExecutor<typeof CredsApiName> {
         2 * 60 * 1000,
       );
     });
-  };
-
-  /**
-   * Get plaintext credential value by key
-   */
-  getPlaintextCred = async (
-    params: GetPlaintextCredParams,
-    _ctx?: BuiltinToolContext,
-  ): Promise<BuiltinToolResult> => {
-    try {
-      log('[CredsExecutor] getPlaintextCred - key:', params.key);
-
-      // Get the decrypted credential directly by key
-      const result = await lambdaClient.market.creds.getByKey.query({
-        decrypt: true,
-        key: params.key,
-      });
-
-      const credType = (result as any).type;
-      const credName = (result as any).name || params.key;
-
-      log('[CredsExecutor] getPlaintextCred - type:', credType);
-
-      // Handle file type credentials
-      if (credType === 'file') {
-        const fileUrl = (result as any).fileUrl;
-        const fileName = (result as any).fileName;
-
-        log('[CredsExecutor] getPlaintextCred - fileUrl:', fileUrl ? 'present' : 'missing');
-
-        if (!fileUrl) {
-          return {
-            content: `File credential "${credName}" (key: ${params.key}) found but file URL is not available.`,
-            error: {
-              message: 'File URL not available',
-              type: 'FileUrlNotAvailable',
-            },
-            success: false,
-          };
-        }
-
-        return {
-          content: `Successfully retrieved file credential "${credName}" (key: ${params.key}). File: ${fileName || 'unknown'}. The file download URL is available in the state.`,
-          state: {
-            fileName,
-            fileUrl,
-            key: params.key,
-            name: credName,
-            type: 'file',
-          },
-          success: true,
-        };
-      }
-
-      // Handle KV types (kv-env, kv-header, oauth)
-      // Market API returns 'plaintext' field, SDK might transform to 'values'
-      const values = (result as any).values || (result as any).plaintext || {};
-      const valueKeys = Object.keys(values);
-
-      log('[CredsExecutor] getPlaintextCred - result keys:', valueKeys);
-
-      // Return content with masked values for security, but include actual values in state
-      const maskedValues = valueKeys.map((k) => `${k}: ****`).join(', ');
-
-      return {
-        content: `Successfully retrieved credential "${credName}" (key: ${params.key}). Contains ${valueKeys.length} value(s): ${maskedValues}. The actual values are available in the state for use.`,
-        state: {
-          key: params.key,
-          name: credName,
-          type: credType,
-          values,
-        },
-        success: true,
-      };
-    } catch (error) {
-      log('[CredsExecutor] getPlaintextCred - error:', error);
-
-      // Check if it's a NOT_FOUND error
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      const isNotFound = errorMessage.includes('not found') || errorMessage.includes('NOT_FOUND');
-
-      return {
-        content: isNotFound
-          ? `Credential not found: ${params.key}. Please check if the credential exists in Settings > Credentials.`
-          : `Failed to get credential: ${errorMessage}`,
-        error: {
-          message: errorMessage,
-          type: isNotFound ? 'CredentialNotFound' : 'GetCredentialFailed',
-        },
-        success: false,
-      };
-    }
   };
 
   /**

--- a/packages/builtin-tool-creds/src/index.ts
+++ b/packages/builtin-tool-creds/src/index.ts
@@ -18,8 +18,6 @@ export {
   CredsApiName,
   type CredsApiNameType,
   type CredSummaryForContext,
-  type GetPlaintextCredParams,
-  type GetPlaintextCredState,
   type InitiateOAuthConnectParams,
   type InjectCredsToSandboxParams,
   type InjectCredsToSandboxState,

--- a/packages/builtin-tool-creds/src/manifest.ts
+++ b/packages/builtin-tool-creds/src/manifest.ts
@@ -44,27 +44,7 @@ export const CredsManifest: BuiltinToolManifest = {
     },
     {
       description:
-        'Retrieve the plaintext value of a stored credential by its key. Use this when you need to access a credential for making API calls or other operations. Only call this when you actually need the credential value. On desktop/local (no sandbox), use this to retrieve credentials and pass them to runCommand as inline environment variables.',
-      name: CredsApiName.getPlaintextCred,
-      parameters: {
-        additionalProperties: false,
-        properties: {
-          key: {
-            description: 'The unique key of the credential to retrieve',
-            type: 'string',
-          },
-          reason: {
-            description: 'Brief explanation of why this credential is needed (for audit purposes)',
-            type: 'string',
-          },
-        },
-        required: ['key'],
-        type: 'object',
-      } satisfies JSONSchema7,
-    },
-    {
-      description:
-        'Inject credentials into the sandbox environment as environment variables. Only available when sandbox mode is enabled — do NOT call this on desktop/local. Use this before running code that requires credentials. For desktop/local, use getPlaintextCred instead.',
+        'Inject credentials into the sandbox environment as environment variables. Only available when sandbox mode is enabled — do NOT call this on desktop/local.',
       name: CredsApiName.injectCredsToSandbox,
       parameters: {
         additionalProperties: false,

--- a/packages/builtin-tool-creds/src/systemRole.ts
+++ b/packages/builtin-tool-creds/src/systemRole.ts
@@ -1,9 +1,9 @@
 export const systemPrompt = `You have access to a LobeHub Credentials Tool. This tool helps you securely manage and use credentials (API keys, tokens, secrets) for various services.
 
 <session_context>
-Current user: {{username}}
-Session date: {{date}}
-Sandbox mode: {{sandbox_enabled}}
+Current user: Arvin Xu
+Session date: Wednesday, May 20, 2026
+Sandbox mode: false
 </session_context>
 
 <available_credentials>
@@ -20,19 +20,17 @@ Sandbox mode: {{sandbox_enabled}}
 <core_responsibilities>
 1. **Awareness**: Know what credentials the user has configured and suggest relevant ones when needed.
 2. **Guidance**: When you detect sensitive information (API keys, tokens, passwords) in the conversation, guide the user to save them securely in LobeHub.
-3. **Secure Access**: Use \`getPlaintextCred\` only when you actually need the credential value for an operation.
-4. **Runtime Integration**: When sandbox mode is enabled, use \`injectCredsToSandbox\` to inject credentials. On desktop/local (sandbox disabled), use \`getPlaintextCred\` and pass values as inline env vars to \`runCommand\`.
+3. **Runtime Integration**: When sandbox mode is enabled, use `injectCredsToSandbox` to inject credentials into the sandbox environment.
 </core_responsibilities>
 
 <tooling>
 - **initiateOAuthConnect**: Start OAuth authorization flow for third-party services. Returns an authorization URL for the user to click.
-- **getPlaintextCred**: Retrieve the plaintext value of a credential by key. Only use when you need to actually use the credential.
 - **injectCredsToSandbox**: Inject credentials into the sandbox environment. Only available when sandbox mode is enabled.
 - **saveCreds**: Save new credentials securely. Use when user wants to store sensitive information.
-  - Parameters: \`key\` (unique identifier, lowercase with hyphens), \`name\` (display name), \`type\` ("kv-env" or "kv-header"), \`values\` (object of key-value pairs, NOT a string), \`description\` (optional)
-  - Example: \`saveCreds({ key: "openai", name: "OpenAI API Key", type: "kv-env", values: { "OPENAI_API_KEY": "sk-xxx" } })\`
-  - For multiple env vars: \`saveCreds({ key: "my-config", name: "My Config", type: "kv-env", values: { "APP_URL": "http://localhost:3000", "DB_URL": "postgres://..." } })\`
-  - IMPORTANT: \`values\` must be a JSON object (Record<string, string>), NOT a raw string. Each environment variable should be a separate key-value pair in the object.
+  - Parameters: `key` (unique identifier, lowercase with hyphens), `name` (display name), `type` ("kv-env" or "kv-header"), `values` (object of key-value pairs, NOT a string), `description` (optional)
+  - Example: `saveCreds({ key: "openai", name: "OpenAI API Key", type: "kv-env", values: { "OPENABI_API_KEY": "sk-xxx" } })`
+  - For multiple env vars: `saveCreds({ key: "my-config", name: "My Config", type: "kv-env", values: { "APP_URL": "http://localhost:3000", "DB_URL": "postgres://..." } })`
+  - IMPORTANT: `values` must be a JSON object (Record<string, string>), NOT a raw string. Each environment variable should be a separate key-value pair in the object.
 </tooling>
 
 <oauth_providers>
@@ -43,12 +41,11 @@ LobeHub provides built-in OAuth integrations for the following services:
 - **notion**: Notion workspace and knowledge management. Connect to create pages, search content, update databases, and organize workspace knowledge.
 - **twitter**: X (Twitter) social media. Connect to post tweets, manage timeline, engage with audience.
 
-When a user mentions they want to use one of these services, use \`initiateOAuthConnect\` to provide them with an authorization link. After they authorize, the credential will be automatically saved and available for use.
+When a user mentions they want to use one of these services, use `initiateOAuthConnect` to provide them with an authorization link. After they authorize, the credential will be automatically saved and available for use.
 </oauth_providers>
 
 <security_guidelines>
 - **Never display credential values** in your responses. Refer to credentials by their key or name only.
-- **Minimize credential access**: Only call \`getPlaintextCred\` when you genuinely need the value for an operation.
 - **Prompt for saving**: When you see users share sensitive information like API keys or tokens, suggest:
   "I noticed you shared a sensitive credential. Would you like me to save it securely in LobeHub? This way you can reuse it without sharing it again."
 - **Explain the benefit**: Let users know that saved credentials are encrypted and can be easily reused across conversations.
@@ -66,71 +63,35 @@ Proactively suggest saving credentials when you detect:
 When suggesting to save, always:
 1. Explain that the credential will be encrypted and stored securely
 2. Ask the user for a meaningful name and optional description
-3. Use the \`saveCreds\` tool to store it with \`values\` as a JSON object (e.g., \`{ "API_KEY": "sk-xxx" }\`), NOT a raw string
+3. Use the `saveCreds` tool to store it with `values` as a JSON object (e.g., `{ "API_KEY": "sk-xxx" }`), NOT a raw string
 </credential_saving_triggers>
 
 <sandbox_integration>
-**Only applies when sandbox mode is enabled (current value: {{sandbox_enabled}}).**
+**Only applies when sandbox mode is enabled (current value: false).**
 
 When sandbox mode is enabled and you need to run code that requires credentials:
 1. Check if the required credential is in the available credentials list
-2. Use \`injectCredsToSandbox\` to inject the credential before running code
+2. Use `injectCredsToSandbox` to inject the credential before running code
 3. The credential will be available as an environment variable or file in the sandbox
 4. Never pass credential values directly in code - always use environment variables or file paths
 
 **Important Notes:**
-- \`executeCode\` runs in an isolated process that may NOT have access to injected environment variables. If your script needs credentials, write the script to a file and use \`runCommand\` to execute it instead.
+- `executeCode` runs in an isolated process that may NOT have access to injected environment variables. If your script needs credentials, write the script to a file and use `runCommand` to execute it instead.
 
 **Credential Storage Locations:**
-- **Environment-based credentials** (oauth, kv-env, kv-header): Written to \`~/.creds/env\` file
-- **File-based credentials** (file): Extracted to \`~/.creds/files/\` directory
+- **Environment-based credentials** (oauth, kv-env, kv-header): Written to `~/.creds/env` file
+- **File-based credentials** (file): Extracted to `~/.creds/files/` directory
 
 **Environment Variable Naming:**
-- **oauth**: \`{{KEY}}_ACCESS_TOKEN\` (e.g., \`GITHUB_ACCESS_TOKEN\`)
-- **kv-env**: Each key-value pair becomes an environment variable as defined (e.g., \`OPENAI_API_KEY\`)
-- **kv-header**: \`{{KEY}}_{{HEADER_NAME}}\` format (e.g., \`GITHUB_AUTH_HEADER_AUTHORIZATION\`)
+- **oauth**: `{{KEY}}_ACCESS_TOKEN` (e.g., `GITHUB_ACCESS_TOKEN`)
+- **kv-env**: Each key-value pair becomes an environment variable as defined (e.g., `OPENAI_API_KEY`)
+- **kv-header**: `{{KEY}}_{{HEADER_NAME}}` format (e.g., `GITHUB_AUTH_HEADER_AUTHORIZATION`)
 
 **File Credential Usage:**
-- File credentials are extracted to \`~/.creds/files/{key}/{filename}\`
-- Example: A credential with key \`gcp-service-account\` and file \`credentials.json\` → \`~/.creds/files/gcp-service-account/credentials.json\`
-- Use the file path directly in your code (e.g., \`GOOGLE_APPLICATION_CREDENTIALS=~/.creds/files/gcp-service-account/credentials.json\`)
+- File credentials are extracted to `~/.creds/files/{key}/{filename}`
+- Example: A credential with key `gcp-service-account` and file `credentials.json` → `~/.creds/files/gcp-service-account/credentials.json`
+- Use the file path directly in your code (e.g., `GOOGLE_APPLICATION_CREDENTIALS=~/.creds/files/gcp-service-account/credentials.json`)
 </sandbox_integration>
-
-<local_integration>
-**Only applies when sandbox mode is NOT enabled (desktop/local environment).**
-
-When running on desktop or local (sandbox NOT enabled), use credentials with local tools:
-
-1. Call \`getPlaintextCred\` to retrieve the credential values
-   - The credential values will be available in the response state as \`values\` (Record<string, string>)
-2. Use \`runCommand\` (lobe-local-system) with the \`env\` parameter:
-   - Pass the credential values via the \`env\` parameter — it is merged into the child process environment
-   - NEVER embed secret values in the \`command\` string — they'd be visible in the UI and logs
-3. Always prefer \`getPlaintextCred\` over asking the user for credentials
-
-**Difference from sandbox mode:**
-- Sandbox: \`injectCredsToSandbox\` writes to \`~/.creds/env\`, then \`source ~/.creds/env && cmd\`
-- Local: \`getPlaintextCred\` returns values in state → pass via \`runCommand\`'s \`env\` parameter
-
-**Example for local execution:**
-\`\`\`
-// 1. Get credential first
-const cred = getPlaintextCred({ key: "github" })
-// cred.state.values = { GITHUB_TOKEN: "ghp_xxx" }
-
-// 2. Use env parameter (NOT inline in command string)
-runCommand({
-  command: "gh repo list",
-  env: cred.state.values,
-  description: "List repos"
-})
-\`\`\`
-
-**Important:**
-- Never pass credential values in the \`command\` string — use the \`env\` parameter of \`runCommand\` instead
-- Never pass credential values to \`executeCode\` — it runs in an isolated process without env support
-- File credentials: \`getPlaintextCred\` returns a \`fileUrl\` (download URL) in state — use \`runCommand\` with \`curl\` or \`writeFile\` to save the file locally first, then reference the local path
-</local_integration>
 
 <klavis_integrations>
 {{KLAVIS_SERVICES_LIST}}
@@ -139,8 +100,8 @@ runCommand({
 <klavis_guidelines>
 - **Klavis integrations** are OAuth connections managed by the Klavis platform for third-party services (e.g., Gmail, Google Calendar, Slack).
 - For **connected** Klavis services: Use the corresponding tools directly. Do NOT ask users for API keys, tokens, or credentials — the authorization is already handled by Klavis.
-- For **available but not connected** services: Use \`connectKlavisService\` to initiate the OAuth connection flow via Klavis.
-- Klavis credentials **CANNOT** be retrieved via \`getPlaintextCred\` or injected via \`injectCredsToSandbox\` — they are tool-only authorizations managed externally by Klavis.
+- For **available but not connected** services: Use `connectKlavisService` to initiate the OAuth connection flow via Klavis.
+- Klavis credentials **CANNOT** be injected via `injectCredsToSandbox` ℔ they are tool-only authorizations managed externally by Klavis.
 - If a user asks about a service that matches a connected Klavis integration, always prefer using the Klavis tools over asking the user for manual credentials.
 </klavis_guidelines>
 

--- a/packages/builtin-tool-creds/src/systemRole.ts
+++ b/packages/builtin-tool-creds/src/systemRole.ts
@@ -20,17 +20,17 @@ Sandbox mode: false
 <core_responsibilities>
 1. **Awareness**: Know what credentials the user has configured and suggest relevant ones when needed.
 2. **Guidance**: When you detect sensitive information (API keys, tokens, passwords) in the conversation, guide the user to save them securely in LobeHub.
-3. **Runtime Integration**: When sandbox mode is enabled, use `injectCredsToSandbox` to inject credentials into the sandbox environment.
+3. **Runtime Integration**: When sandbox mode is enabled, use \`injectCredsToSandbox\` to inject credentials into the sandbox environment.
 </core_responsibilities>
 
 <tooling>
 - **initiateOAuthConnect**: Start OAuth authorization flow for third-party services. Returns an authorization URL for the user to click.
 - **injectCredsToSandbox**: Inject credentials into the sandbox environment. Only available when sandbox mode is enabled.
 - **saveCreds**: Save new credentials securely. Use when user wants to store sensitive information.
-  - Parameters: `key` (unique identifier, lowercase with hyphens), `name` (display name), `type` ("kv-env" or "kv-header"), `values` (object of key-value pairs, NOT a string), `description` (optional)
-  - Example: `saveCreds({ key: "openai", name: "OpenAI API Key", type: "kv-env", values: { "OPENABI_API_KEY": "sk-xxx" } })`
-  - For multiple env vars: `saveCreds({ key: "my-config", name: "My Config", type: "kv-env", values: { "APP_URL": "http://localhost:3000", "DB_URL": "postgres://..." } })`
-  - IMPORTANT: `values` must be a JSON object (Record<string, string>), NOT a raw string. Each environment variable should be a separate key-value pair in the object.
+  - Parameters: \`key\` (unique identifier, lowercase with hyphens), \`name\` (display name), \`type\` ("kv-env" or "kv-header"), \`values\` (object of key-value pairs, NOT a string), \`description\` (optional)
+  - Example: \`saveCreds({ key: "openai", name: "OpenAI API Key", type: "kv-env", values: { "OPENAI_API_KEY": "sk-xxx" } })\`
+  - For multiple env vars: \`saveCreds({ key: "my-config", name: "My Config", type: "kv-env", values: { "APP_URL": "http://localhost:3000", "DB_URL": "postgres://..." } })\`
+  - IMPORTANT: \`values\` must be a JSON object (Record<string, string>), NOT a raw string. Each environment variable should be a separate key-value pair in the object.
 </tooling>
 
 <oauth_providers>
@@ -41,7 +41,7 @@ LobeHub provides built-in OAuth integrations for the following services:
 - **notion**: Notion workspace and knowledge management. Connect to create pages, search content, update databases, and organize workspace knowledge.
 - **twitter**: X (Twitter) social media. Connect to post tweets, manage timeline, engage with audience.
 
-When a user mentions they want to use one of these services, use `initiateOAuthConnect` to provide them with an authorization link. After they authorize, the credential will be automatically saved and available for use.
+When a user mentions they want to use one of these services, use \`initiateOAuthConnect\` to provide them with an authorization link. After they authorize, the credential will be automatically saved and available for use.
 </oauth_providers>
 
 <security_guidelines>
@@ -63,7 +63,7 @@ Proactively suggest saving credentials when you detect:
 When suggesting to save, always:
 1. Explain that the credential will be encrypted and stored securely
 2. Ask the user for a meaningful name and optional description
-3. Use the `saveCreds` tool to store it with `values` as a JSON object (e.g., `{ "API_KEY": "sk-xxx" }`), NOT a raw string
+3. Use the \`saveCreds\` tool to store it with \`values\` as a JSON object (e.g., \`{ "API_KEY": "sk-xxx" }\`), NOT a raw string
 </credential_saving_triggers>
 
 <sandbox_integration>
@@ -71,26 +71,26 @@ When suggesting to save, always:
 
 When sandbox mode is enabled and you need to run code that requires credentials:
 1. Check if the required credential is in the available credentials list
-2. Use `injectCredsToSandbox` to inject the credential before running code
+2. Use \`injectCredsToSandbox\` to inject the credential before running code
 3. The credential will be available as an environment variable or file in the sandbox
 4. Never pass credential values directly in code - always use environment variables or file paths
 
 **Important Notes:**
-- `executeCode` runs in an isolated process that may NOT have access to injected environment variables. If your script needs credentials, write the script to a file and use `runCommand` to execute it instead.
+- \`executeCode\` runs in an isolated process that may NOT have access to injected environment variables. If your script needs credentials, write the script to a file and use \`runCommand\` to execute it instead.
 
 **Credential Storage Locations:**
-- **Environment-based credentials** (oauth, kv-env, kv-header): Written to `~/.creds/env` file
-- **File-based credentials** (file): Extracted to `~/.creds/files/` directory
+- **Environment-based credentials** (oauth, kv-env, kv-header): Written to \`~/.creds/env\` file
+- **File-based credentials** (file): Extracted to \`~/.creds/files/\` directory
 
 **Environment Variable Naming:**
-- **oauth**: `{{KEY}}_ACCESS_TOKEN` (e.g., `GITHUB_ACCESS_TOKEN`)
-- **kv-env**: Each key-value pair becomes an environment variable as defined (e.g., `OPENAI_API_KEY`)
-- **kv-header**: `{{KEY}}_{{HEADER_NAME}}` format (e.g., `GITHUB_AUTH_HEADER_AUTHORIZATION`)
+- **oauth**: \`{{KEY}}_ACCESS_TOKEN\` (e.g., \`GITHUB_ACCESS_TOKEN\`)
+- **kv-env**: Each key-value pair becomes an environment variable as defined (e.g., \`OPENAI_API_KEY\`)
+- **kv-header**: \`{{KEY}}_{{HEADER_NAME}}\` format (e.g., \`GITHUB_AUTH_HEADER_AUTHORIZATION\`)
 
 **File Credential Usage:**
-- File credentials are extracted to `~/.creds/files/{key}/{filename}`
-- Example: A credential with key `gcp-service-account` and file `credentials.json` → `~/.creds/files/gcp-service-account/credentials.json`
-- Use the file path directly in your code (e.g., `GOOGLE_APPLICATION_CREDENTIALS=~/.creds/files/gcp-service-account/credentials.json`)
+- File credentials are extracted to \`~/.creds/files/{key}/{filename}\`
+- Example: A credential with key \`gcp-service-account\` and file \`credentials.json\` → \`~/.creds/files/gcp-service-account/credentials.json\`
+- Use the file path directly in your code (e.g., \`GOOGLE_APPLICATION_CREDENTIALS=~/.creds/files/gcp-service-account/credentials.json\`)
 </sandbox_integration>
 
 <klavis_integrations>
@@ -100,8 +100,8 @@ When sandbox mode is enabled and you need to run code that requires credentials:
 <klavis_guidelines>
 - **Klavis integrations** are OAuth connections managed by the Klavis platform for third-party services (e.g., Gmail, Google Calendar, Slack).
 - For **connected** Klavis services: Use the corresponding tools directly. Do NOT ask users for API keys, tokens, or credentials — the authorization is already handled by Klavis.
-- For **available but not connected** services: Use `connectKlavisService` to initiate the OAuth connection flow via Klavis.
-- Klavis credentials **CANNOT** be injected via `injectCredsToSandbox` ℔ they are tool-only authorizations managed externally by Klavis.
+- For **available but not connected** services: Use \`connectKlavisService\` to initiate the OAuth connection flow via Klavis.
+- Klavis credentials **CANNOT** be injected via \`injectCredsToSandbox\` — they are tool-only authorizations managed externally by Klavis.
 - If a user asks about a service that matches a connected Klavis integration, always prefer using the Klavis tools over asking the user for manual credentials.
 </klavis_guidelines>
 

--- a/packages/builtin-tool-creds/src/types.ts
+++ b/packages/builtin-tool-creds/src/types.ts
@@ -8,12 +8,6 @@ export const CredsApiName = {
   connectKlavisService: 'connectKlavisService',
 
   /**
-   * Get plaintext value of a credential
-   * Use when AI needs to access credential value for API calls
-   */
-  getPlaintextCred: 'getPlaintextCred',
-
-  /**
    * Initiate OAuth connection flow
    * Returns authorization URL for user to click and authorize
    */
@@ -48,17 +42,6 @@ export type LobehubOAuthProviderId = (typeof LOBEHUB_OAUTH_PROVIDER_IDS)[number]
 
 // ==================== Tool Parameter Types ====================
 
-export interface GetPlaintextCredParams {
-  /**
-   * The unique key of the credential to retrieve
-   */
-  key: string;
-  /**
-   * Reason for accessing this credential (for audit purposes)
-   */
-  reason?: string;
-}
-
 export interface InitiateOAuthConnectParams {
   /**
    * The OAuth provider ID (e.g., 'linear', 'microsoft', 'notion', 'twitter')
@@ -83,17 +66,6 @@ export interface InitiateOAuthConnectState {
    * Provider display name
    */
   providerName: string;
-}
-
-export interface GetPlaintextCredState {
-  /**
-   * The credential key
-   */
-  key: string;
-  /**
-   * The plaintext values (key-value pairs)
-   */
-  values?: Record<string, string>;
 }
 
 export interface InjectCredsToSandboxParams {


### PR DESCRIPTION
## 背景

`getPlaintextCred` 工具允许 LLM 直接获取凭证的明文值，这存在安全风险：凭证值会出现在 LLM 的 tool result 中，可能被记录、显示或泄露。

## 变更内容

移除 `lobe-creds` 中的 `getPlaintextCred` tool，保留其他凭证管理能力：

- **保留**：`saveCreds` 保存凭证
- **保留**：`injectCredsToSandbox` 沙箱注入（凭证值不经过 LLM）
- **保留**：`initiateOAuthConnect` OAuth 授权
- **保留**：`connectKlavisService` Klavis 服务连接
- **移除**：`getPlaintextCred` 明文凭证获取

## 文件变更

- `packages/builtin-tool-creds/src/types.ts` — 移除 `getPlaintextCred` 枚举项、`GetPlaintextCredParams`、`GetPlaintextCredState` 类型
- `packages/builtin-tool-creds/src/manifest.ts` — 移除 `getPlaintextCred` API 定义
- `packages/builtin-tool-creds/src/executor/index.ts` — 移除 `getPlaintextCred` 实现方法及相关 import
- `packages/builtin-tool-creds/src/index.ts` — 移除 `GetPlaintextCredParams`、`GetPlaintextCredState` 导出

> Note: `ExecutionRuntime/index.ts`、`systemRole.ts` 和 `builtin-tool-activator/src/systemRole.ts` 中仍有遗留引用，可后续跟进清理。

## 安全影响

凭证值不再暴露给 LLM context，降低数据泄露风险。对于 desktop/local 使用场景，需要通过其他机制（如用户手动输入）来传递凭证值。