### PR TITLE
🐛 fix(market-auth): add prompt=consent to OIDC authorization URL to fix missing refresh token

### DIFF
--- a/src/layout/AuthProvider/MarketAuth/oidc.ts
+++ b/src/layout/AuthProvider/MarketAuth/oidc.ts
@@ -111,6 +111,9 @@ export class MarketOIDC {
     authUrl.searchParams.set('state', pkceParams.state);
     authUrl.searchParams.set('code_challenge', pkceParams.codeChallenge);
     authUrl.searchParams.set('code_challenge_method', 'S256');
+    // Required so the OIDC provider always runs the consent step, which prevents
+    // offline_access from being silently dropped when a prior grant exists.
+    authUrl.searchParams.set('prompt', 'consent');
 
     console.info('[MarketOIDC] Authorization URL built:', authUrl.toString());
     return authUrl.toString();


### PR DESCRIPTION
## Summary

- **Root cause**: `MarketOIDC.buildAuthUrl()` in `src/layout/AuthProvider/MarketAuth/oidc.ts` was missing the `prompt=consent` parameter when constructing the authorization URL sent to the market OIDC provider.
- **Effect**: Without `prompt=consent`, the OIDC provider skips the consent screen on repeat logins. The `oidc-provider` v9 library silently strips `offline_access` from granted scopes when the consent step is bypassed, so no `refresh_token` is issued even though the client requests it via `scope=offline_access`.
- **Symptom**: Users are forced to re-authenticate periodically (after access token expiry) because there is no refresh token to extend the session.

## Fix

Add `prompt=consent` to the OIDC authorization URL built in `buildAuthUrl()`. This forces the consent screen every time, ensuring `offline_access` passes through the `check_scope` filter and a `refresh_token` is always issued.

**Note**: The desktop app (`apps/desktop/src/main/controllers/AuthCtr.ts:111`) already includes `prompt=consent` in its own OIDC flow (for remote-server auth). The CLI uses Device Code Flow which is unaffected. Only the web/market auth path (`MarketOIDC`) was missing this parameter.

## Test plan

- [ ] Log in to Market via web popup — confirm `refresh_token` is returned in the token response
- [ ] Log in to Market via desktop (which uses the URL built by `MarketOIDC.buildAuthUrl()`) — confirm `refresh_token` present
- [ ] Verify the consent screen appears on re-login (expected UX trade-off)
- [ ] Verify token auto-refresh works without re-authentication after access token expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)