### PR TITLE
🐛 fix(hetero-finish): use heteroCurrentMsgId for lastAssistantContent

### DIFF
--- a/src/server/services/heterogeneousAgent/index.ts
+++ b/src/server/services/heterogeneousAgent/index.ts
@@ -176,7 +176,16 @@ export class HeterogeneousAgentService {
     try {
       const topic = await this.topicModel.findById(topicId);
       completionWebhook = topic?.metadata?.runningOperation?.completionWebhook;
-      assistantMessageId = topic?.metadata?.runningOperation?.assistantMessageId;
+      // Prefer heteroCurrentMsgId — the persistence handler updates this pointer
+      // on every step boundary, so it refers to the LAST assistant message with
+      // the complete final content.  Fall back to the initial placeholder id
+      // recorded in runningOperation if the pointer is absent or belongs to a
+      // different operation (shouldn't happen, but defensive).
+      const currentMsgRef = topic?.metadata?.heteroCurrentMsgId;
+      assistantMessageId =
+        currentMsgRef?.operationId === operationId
+          ? currentMsgRef.msgId
+          : topic?.metadata?.runningOperation?.assistantMessageId;
       await this.topicModel.updateMetadata(topicId, { runningOperation: null });
     } catch (err) {
       log('heteroFinish: failed to clear runningOperation (non-fatal): %O', err);


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up to #14968.

#### 🔀 Description of Change

`runningOperation.assistantMessageId` is the initial placeholder message created at run start. The persistence handler updates `topic.metadata.heteroCurrentMsgId` on each step boundary to track the latest assistant message.

Reading from the initial placeholder produces only first-step content — IM users received a truncated reply (just the first sentence like "我来查一下...") while the full response was visible on the web platform.

**Fix:** prefer `heteroCurrentMsgId.msgId` (validated against `operationId`) over `runningOperation.assistantMessageId` so `BotCallbackService.handleCompletion` receives the complete final content.

#### 🧪 How to Test

- Configure a bot with a Cloud Claude Code (heterogeneous) agent
- Send a multi-step query via IM (e.g. "查一下 lobehub/lobehub 昨天的 github issues")
- Verify IM receives the full response, not just the first sentence

- [ ] Tested locally
- [ ] No automated tests (requires IM platform + hetero agent setup)