### PR TITLE
✨ chore(agent-tracing): resolve partial op id by _remote/ cache prefix

### DIFF
--- a/packages/agent-tracing/src/cli/inspect.ts
+++ b/packages/agent-tracing/src/cli/inspect.ts
@@ -152,22 +152,26 @@ export function registerInspectCommand(program: Command) {
             }
           }
         } else if (traceId && traceId.startsWith('op_')) {
-          // Partial op id (e.g. `op_<timestamp>`): resolve against the
-          // `_remote/` cache by prefix so users don't have to paste the full
+          // Partial op id (e.g. `op_<timestamp>`): first check the local
+          // FileSnapshotStore (which also covers `_partial/` in-progress
+          // snapshots via substring match), then fall back to a prefix scan
+          // of the `_remote/` cache so users don't have to paste the full
           // `op_<ts>_agt_..._tpc_..._<suffix>` string.
-          const remoteStore = new RemoteSnapshotStore();
-          const matches = await remoteStore.findCachedByPrefix(traceId);
-          if (matches.length === 1) {
-            const fullId = matches[0];
-            snapshot = await remoteStore.getCached(fullId);
-            console.error(`✓ Resolved "${traceId}" → ${fullId}`);
-          } else if (matches.length > 1) {
-            console.error(`Ambiguous id prefix "${traceId}" — multiple cached snapshots match:`);
-            for (const m of matches) console.error(`  ${m}`);
-            console.error('Re-run with the full operation id.');
-            process.exit(1);
-          } else {
-            snapshot = null;
+          const fileStore = new FileSnapshotStore();
+          snapshot = await fileStore.get(traceId);
+          if (!snapshot) {
+            const remoteStore = new RemoteSnapshotStore();
+            const matches = await remoteStore.findCachedByPrefix(traceId);
+            if (matches.length === 1) {
+              const fullId = matches[0];
+              snapshot = await remoteStore.getCached(fullId);
+              console.error(`✓ Resolved "${traceId}" → ${fullId}`);
+            } else if (matches.length > 1) {
+              console.error(`Ambiguous id prefix "${traceId}" — multiple cached snapshots match:`);
+              for (const m of matches) console.error(`  ${m}`);
+              console.error('Re-run with the full operation id.');
+              process.exit(1);
+            }
           }
         } else {
           const store = new FileSnapshotStore();

--- a/packages/agent-tracing/src/cli/inspect.ts
+++ b/packages/agent-tracing/src/cli/inspect.ts
@@ -151,6 +151,24 @@ export function registerInspectCommand(program: Command) {
               snapshot = await remoteStore.fetch(url, traceId);
             }
           }
+        } else if (traceId && traceId.startsWith('op_')) {
+          // Partial op id (e.g. `op_<timestamp>`): resolve against the
+          // `_remote/` cache by prefix so users don't have to paste the full
+          // `op_<ts>_agt_..._tpc_..._<suffix>` string.
+          const remoteStore = new RemoteSnapshotStore();
+          const matches = await remoteStore.findCachedByPrefix(traceId);
+          if (matches.length === 1) {
+            const fullId = matches[0];
+            snapshot = await remoteStore.getCached(fullId);
+            console.error(`✓ Resolved "${traceId}" → ${fullId}`);
+          } else if (matches.length > 1) {
+            console.error(`Ambiguous id prefix "${traceId}" — multiple cached snapshots match:`);
+            for (const m of matches) console.error(`  ${m}`);
+            console.error('Re-run with the full operation id.');
+            process.exit(1);
+          } else {
+            snapshot = null;
+          }
         } else {
           const store = new FileSnapshotStore();
           snapshot = traceId ? await store.get(traceId) : await store.getLatest();

--- a/packages/agent-tracing/src/store/remote-store.ts
+++ b/packages/agent-tracing/src/store/remote-store.ts
@@ -96,6 +96,24 @@ export class RemoteSnapshotStore {
     }
   }
 
+  /**
+   * Find cached snapshots whose operation ID starts with the given prefix.
+   * Lets callers resolve a partial id like `op_<timestamp>` to the full
+   * `op_<timestamp>_agt_..._tpc_..._<suffix>` recorded in `_remote/`.
+   */
+  async findCachedByPrefix(prefix: string): Promise<string[]> {
+    try {
+      const entries = await fs.readdir(this.cacheDir);
+      const suffix = '.json';
+      return entries
+        .filter((f) => f.endsWith(suffix) && f.startsWith(prefix))
+        .map((f) => f.slice(0, -suffix.length))
+        .sort();
+    } catch {
+      return [];
+    }
+  }
+
   async fetch(url: string, operationId: string): Promise<ExecutionSnapshot> {
     // Check cache first
     const cached = await this.getCached(operationId);


### PR DESCRIPTION
## Summary

- `agent-tracing inspect op_<timestamp>` previously failed with `Snapshot not found` because the CLI only accepted the full `op_<ts>_agt_..._tpc_..._<suffix>` id, so users had to copy the entire filename out of `.agent-tracing/_remote/` by hand.
- When the input starts with `op_` but isn't a full operation id, the CLI now scans the local `_remote/` cache and resolves a unique prefix match automatically.
- On multiple matches it lists every candidate and exits, prompting the user to re-run with the full id. Zero matches falls through to the existing `Snapshot not found` error.

## Test plan

- [x] `agent-tracing i op_1776384016594` → resolves to full id and renders the snapshot
- [x] `agent-tracing i op_` (ambiguous) → lists all cached ids and exits
- [x] `agent-tracing i op_9999999999999` (no match) → `Snapshot not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)