### PR TITLE
💄 style: add Gemini 3.5 Flash to LobeHub provider

### DIFF
--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -118,6 +118,7 @@ const googleChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       search: true,
+      structuredOutput: true,
       video: true,
       vision: true,
     },
@@ -132,6 +133,9 @@ const googleChatModels: AIChatModelCard[] = [
       units: [
         { name: 'textInput_cacheRead', rate: 0.15, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'videoInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'audioInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 9, strategy: 'fixed', unit: 'millionTokens' },
         {
           lookup: { prices: { '1h': 1 }, pricingParams: ['ttl'] },

--- a/packages/model-bank/src/aiModels/lobehub/chat/google.ts
+++ b/packages/model-bank/src/aiModels/lobehub/chat/google.ts
@@ -12,6 +12,46 @@ export const googleChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_048_576 + 65_536,
     description:
+      "Gemini's most intelligent model built for speed, combining frontier intelligence with superior search and grounding.",
+    displayName: 'Gemini 3.5 Flash',
+    enabled: true,
+    id: 'gemini-3.5-flash',
+    maxOutput: 65_536,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.15, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'videoInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'audioInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 9, strategy: 'fixed', unit: 'millionTokens' },
+        {
+          lookup: { prices: { '1h': 1 }, pricingParams: ['ttl'] },
+          name: 'textInput_cacheWrite',
+          strategy: 'lookup',
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-05-19',
+    settings: {
+      extendParams: ['thinkingLevel', 'urlContext'],
+      searchImpl: 'params',
+      searchProvider: 'google',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      video: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_048_576 + 65_536,
+    description:
       'Gemini 3.1 Pro Preview improves on Gemini 3 Pro with enhanced reasoning capabilities (ARC-AGI-2 77.1%) and adds medium thinking level support.',
     displayName: 'Gemini 3.1 Pro Preview',
     enabled: true,
@@ -137,7 +177,6 @@ export const googleChatModels: AIChatModelCard[] = [
     description:
       "Gemini 3 Flash Preview is Google's latest best-value model, improving on Gemini 2.5 Flash.",
     displayName: 'Gemini 3 Flash Preview',
-    enabled: true,
     id: 'gemini-3-flash-preview',
     maxOutput: 65_536,
     pricing: {

--- a/packages/model-bank/src/aiModels/vertexai.ts
+++ b/packages/model-bank/src/aiModels/vertexai.ts
@@ -8,6 +8,7 @@ const vertexaiChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       search: true,
+      structuredOutput: true,
       video: true,
       vision: true,
     },
@@ -22,6 +23,9 @@ const vertexaiChatModels: AIChatModelCard[] = [
       units: [
         { name: 'textInput_cacheRead', rate: 0.15, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'videoInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'audioInput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 9, strategy: 'fixed', unit: 'millionTokens' },
         {
           lookup: { prices: { '1h': 1 }, pricingParams: ['ttl'] },


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

Related to #15001

#### 🔀 Description of Change

Completes Gemini 3.5 Flash support and corrects the model card shipped in #15001.

**Add to the LobeHub-hosted provider** (`aiModels/lobehub/chat/google.ts`)

- Add the `gemini-3.5-flash` card so the model is available via the LobeHub Google provider. #15001 only added it to the self-hosted `google.ts` / `vertexai.ts` cards.
- Drop `enabled` from `gemini-3-flash-preview` — it is directly superseded by `gemini-3.5-flash` (Google's migration guide maps `gemini-3-flash-preview` → `gemini-3.5-flash`), and the self-hosted card already has it disabled.

**Fix the `gemini-3.5-flash` card** (`aiModels/google.ts`, `aiModels/vertexai.ts`)

- Add the `structuredOutput` ability — Gemini 3.5 Flash supports structured output (a Gemini 3 family capability), matching the `gemini-3.1-pro-preview` / `gemini-3.1-flash-lite` siblings.
- Add `imageInput` / `videoInput` / `audioInput` pricing units at \$1.5/M. Without them, multimodal input tokens were billed at \$0, because the cost engine splits input by modality and the `textInput` unit only counts text-modality tokens.

Per the official Vertex AI pricing page, Gemini 3.5 Flash prices all input modalities (text / image / video / audio) at a flat \$1.5/M — unlike older Flash models where audio carried a 2x premium.

#### 🧪 How to Test

- [x] No tests needed

Model card data change only. Pricing verified against the [Gemini API pricing page](https://ai.google.dev/gemini-api/docs/pricing) and the [Vertex AI pricing page](https://docs.cloud.google.com/vertex-ai/generative-ai/pricing).

#### 📝 Additional Information

The `thinking_level` default (`medium`) is already wired up via `MODEL_THINKING_LEVEL_DEFAULTS` in #15001.