### PR TITLE
🐛 fix(chat-input): prevent repeated draft restore

### DIFF
--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -3,6 +3,7 @@ import { HotkeyEnum, KeyEnum } from '@lobechat/const/hotkeys';
 import { HETEROGENEOUS_TYPE_LABELS } from '@lobechat/heterogeneous-agents';
 import { chainInputCompletion, escapeXmlAttr } from '@lobechat/prompts';
 import { isCommandPressed, merge } from '@lobechat/utils';
+import type { IEditor } from '@lobehub/editor';
 import { INSERT_MENTION_COMMAND, ReactAutoCompletePlugin, ReactMathPlugin } from '@lobehub/editor';
 import { Editor, FloatMenu, useEditorState } from '@lobehub/editor/react';
 import { combineKeys } from '@lobehub/ui';
@@ -80,6 +81,7 @@ const InputEditor = memo<{
 
   const storeApi = useStoreApi();
   const { restoreDraft, saveDraftDebounced } = useChatInputDraft();
+  const restoredDraftEditorRef = useRef<IEditor | null>(null);
   const state = useEditorState(editor);
   const hotkey = useUserStore(settingsSelectors.getHotkeyById(HotkeyEnum.AddUserMessage));
   const { enableScope, disableScope } = useHotkeysContext();
@@ -329,6 +331,27 @@ const InputEditor = memo<{
       : { plugins };
   }, [enableRichRender, expand, slashMenuRef, autoCompletePlugin]);
 
+  const handleEditorInit = useCallback(
+    (editor: IEditor) => {
+      const saved = storeApi.getState()._savedEditorState;
+      storeApi.setState({ _savedEditorState: undefined, editor });
+      if (saved) {
+        requestAnimationFrame(() => {
+          editor.setDocument('json', saved);
+        });
+        return;
+      }
+
+      if (restoredDraftEditorRef.current === editor) return;
+      restoredDraftEditorRef.current = editor;
+
+      requestAnimationFrame(() => {
+        restoreDraft(editor);
+      });
+    },
+    [restoreDraft, storeApi],
+  );
+
   return (
     <Editor
       autoFocus
@@ -355,6 +378,7 @@ const InputEditor = memo<{
         minHeight: defaultRows > 1 ? defaultRows * 23 : undefined,
       }}
       onCompositionEnd={({ event }) => compositionProps.onCompositionEnd(event)}
+      onInit={handleEditorInit}
       onBlur={() => {
         disableScope(HotkeyEnum.AddUserMessage);
         saveDraftDebounced.flush();
@@ -388,19 +412,6 @@ const InputEditor = memo<{
       }}
       onFocus={() => {
         enableScope(HotkeyEnum.AddUserMessage);
-      }}
-      onInit={(editor) => {
-        const saved = storeApi.getState()._savedEditorState;
-        storeApi.setState({ _savedEditorState: undefined, editor });
-        if (saved) {
-          requestAnimationFrame(() => {
-            editor.setDocument('json', saved);
-          });
-          return;
-        }
-        requestAnimationFrame(() => {
-          restoreDraft(editor);
-        });
       }}
       onPressEnter={({ event: e }) => {
         if (e.shiftKey || isComposingRef.current) return;

--- a/src/features/ChatInput/hooks/useChatInputDraft.test.tsx
+++ b/src/features/ChatInput/hooks/useChatInputDraft.test.tsx
@@ -3,7 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getDraft } from '../draftStorage';
+import { getDraft, saveDraft } from '../draftStorage';
 import { createStore, Provider } from '../store';
 import { useChatInputDraft } from './useChatInputDraft';
 
@@ -39,5 +39,50 @@ describe('useChatInputDraft', () => {
     unmount();
 
     expect(getDraft('main_agent_topic')).toEqual(draftJson);
+  });
+
+  it('restores a draft when the editor is empty', () => {
+    const draftJson = { root: { children: [{ text: 'draft' }] } };
+    const setDocument = vi.fn();
+    const editor = {
+      getDocument: vi.fn(),
+      isEmpty: true,
+      setDocument,
+    } as unknown as IEditor;
+    const store = createStore({ draftKey: 'main_agent_topic', editor });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider createStore={() => store}>{children}</Provider>
+    );
+    saveDraft('main_agent_topic', draftJson);
+
+    const { result } = renderHook(() => useChatInputDraft(), { wrapper });
+
+    act(() => {
+      result.current.restoreDraft(editor);
+    });
+
+    expect(setDocument).toHaveBeenCalledWith('json', draftJson);
+  });
+
+  it('does not overwrite current editor input when restoring a draft', () => {
+    const setDocument = vi.fn();
+    const editor = {
+      getDocument: vi.fn(),
+      isEmpty: false,
+      setDocument,
+    } as unknown as IEditor;
+    const store = createStore({ draftKey: 'main_agent_topic', editor });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider createStore={() => store}>{children}</Provider>
+    );
+    saveDraft('main_agent_topic', { root: { children: [{ text: 'old draft' }] } });
+
+    const { result } = renderHook(() => useChatInputDraft(), { wrapper });
+
+    act(() => {
+      result.current.restoreDraft(editor);
+    });
+
+    expect(setDocument).not.toHaveBeenCalled();
   });
 });

--- a/src/features/ChatInput/hooks/useChatInputDraft.ts
+++ b/src/features/ChatInput/hooks/useChatInputDraft.ts
@@ -34,6 +34,8 @@ export const useChatInputDraft = () => {
       const { draftKey } = storeApi.getState();
       if (!draftKey) return;
 
+      if (!editor.isEmpty) return;
+
       const draft = getDraft(draftKey);
       if (draft) editor.setDocument('json', draft);
     },


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No related issue found.

#### 🔀 Description of Change

Prevents chat input drafts from being restored again after the editor has already initialized and the user has started typing.

- Stabilizes the ChatInput editor `onInit` handler so rerenders do not reschedule draft restoration.
- Tracks the editor instance to restore a persisted draft at most once per editor lifecycle.
- Skips draft restoration when the editor state is no longer empty.
- Adds regression coverage for restoring empty editors and preserving current input.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
NODE_OPTIONS=--no-experimental-webstorage NODE_ENV=test pnpm exec vitest run --silent='passed-only' src/features/ChatInput/hooks/useChatInputDraft.test.tsx src/features/ChatInput/draftStorage.test.ts src/features/ChatInput/StoreUpdater.test.tsx
pnpm exec eslint src/features/ChatInput/InputEditor/index.tsx src/features/ChatInput/hooks/useChatInputDraft.ts src/features/ChatInput/hooks/useChatInputDraft.test.tsx
bun run type-check
```

#### 📸 Screenshots / Videos

N/A. No UI surface change.

#### 📝 Additional Information

This is a downstream business-layer guard. The upstream editor `onInit` behavior can be fixed separately.
