### PR TITLE
🐛 fix: discourage redundant visual tool calls

### DIFF
--- a/packages/builtin-tool-lobe-agent/src/manifest.test.ts
+++ b/packages/builtin-tool-lobe-agent/src/manifest.test.ts
@@ -25,6 +25,16 @@ describe('LobeAgentManifest', () => {
     expect(apiDescription).toContain('answer the user directly with the result');
   });
 
+  it('should instruct agents to prefer native multimodal access before visual analysis', () => {
+    expect(LobeAgentManifest.systemRole).toContain('`analyzeVisualMedia` is only a fallback');
+    expect(LobeAgentManifest.systemRole).toContain(
+      'media is already visible in the current multimodal context',
+    );
+    expect(LobeAgentManifest.systemRole).toContain(
+      'active model lacks the needed image/video capability',
+    );
+  });
+
   it('should keep visual analysis parameters compatible with strict tool schema validators', () => {
     const parameters = LobeAgentManifest.api[0].parameters;
 

--- a/packages/builtin-tool-lobe-agent/src/systemRole.ts
+++ b/packages/builtin-tool-lobe-agent/src/systemRole.ts
@@ -205,6 +205,15 @@ When working with plan/todo tools:
 </plan_and_todos>
 `;
 
+const visualAnalysisSection = `
+<visual_analysis>
+\`analyzeVisualMedia\` is only a fallback when the active model cannot inspect the requested image/video natively.
+If the media is already visible in the current multimodal context, answer directly without this tool.
+Use it only for refs/URLs you cannot inspect directly, or when the active model lacks the needed image/video capability.
+</visual_analysis>
+`;
+
 export const systemPrompt = `Use Lobe Agent capabilities only when the active model needs built-in assistance. Prefer the active model's native capabilities whenever they are sufficient. Follow each tool's description and schema, and use tool results to answer the user directly.
+${visualAnalysisSection}
 ${planTodoSection}
 ${subAgentSection}`;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - no public issue found.

#### 🔀 Description of Change

- Add a concise visual-analysis instruction to the Lobe Agent tool system role.
- Tell agents to use `analyzeVisualMedia` only as a fallback when the active model cannot inspect the requested media natively.
- Add regression coverage so the fallback guidance stays present.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/builtin-tool-lobe-agent && bunx vitest run --silent='passed-only' 'src/manifest.test.ts'
```

#### 📸 Screenshots / Videos

N/A - prompt-only change.

#### 📝 Additional Information

No UI changes.
