### PR TITLE
🐛 fix(onboarding): restore mobile padding on Classic steps

### DIFF
--- a/src/features/Onboarding/Agent/NameSuggestions.tsx
+++ b/src/features/Onboarding/Agent/NameSuggestions.tsx
@@ -92,15 +92,40 @@ const NameSuggestions = memo<NameSuggestionsProps>(({ variant = 'cards' }) => {
   if (variant === 'chips') {
     return (
       <Flexbox gap={6} paddingInline={24}>
-        <Flexbox horizontal align={'center'} gap={4} justify={'space-between'}>
-          <Text fontSize={12} type={'secondary'}>
-            {t('agent.welcome.suggestion.title')}
-          </Text>
+        <Text fontSize={12} type={'secondary'}>
+          {t('agent.welcome.suggestion.title')}
+        </Text>
+        <Flexbox horizontal align={'center'} gap={8}>
+          <Flexbox
+            horizontal
+            className={styles.chipRow}
+            gap={6}
+            style={{ flex: 1, minWidth: 0 }}
+          >
+            {items.map((item) => {
+              const { name, prompt } = resolveNameSuggestion(item, i18n.language);
+              return (
+                <Flexbox
+                  horizontal
+                  align={'center'}
+                  className={styles.chip}
+                  gap={6}
+                  key={item.id}
+                  onClick={() => handleSelect(prompt, item.emoji)}
+                >
+                  <FluentEmoji emoji={item.emoji} size={16} type={'anim'} />
+                  <Text fontSize={13} weight={500}>
+                    {name}
+                  </Text>
+                </Flexbox>
+              );
+            })}
+          </Flexbox>
           <Flexbox
             horizontal
             align={'center'}
             gap={2}
-            style={{ cursor: 'pointer' }}
+            style={{ cursor: 'pointer', flexShrink: 0 }}
             onClick={handleRefresh}
           >
             <ActionIcon icon={RefreshCw} size={'small'} />
@@ -108,26 +133,6 @@ const NameSuggestions = memo<NameSuggestionsProps>(({ variant = 'cards' }) => {
               {t('agent.welcome.suggestion.switch')}
             </Text>
           </Flexbox>
-        </Flexbox>
-        <Flexbox horizontal className={styles.chipRow} gap={6}>
-          {items.map((item) => {
-            const { name, prompt } = resolveNameSuggestion(item, i18n.language);
-            return (
-              <Flexbox
-                horizontal
-                align={'center'}
-                className={styles.chip}
-                gap={6}
-                key={item.id}
-                onClick={() => handleSelect(prompt, item.emoji)}
-              >
-                <FluentEmoji emoji={item.emoji} size={16} type={'anim'} />
-                <Text fontSize={13} weight={500}>
-                  {name}
-                </Text>
-              </Flexbox>
-            );
-          })}
         </Flexbox>
       </Flexbox>
     );

--- a/src/features/Onboarding/Classic/index.tsx
+++ b/src/features/Onboarding/Classic/index.tsx
@@ -7,6 +7,7 @@ import { Navigate, useNavigate } from 'react-router-dom';
 
 import Loading from '@/components/Loading/BrandTextLoading';
 import ModeSwitch from '@/features/Onboarding/components/ModeSwitch';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import OnboardingContainer from '@/routes/onboarding/_layout';
 import AgentPickerStep from '@/routes/onboarding/features/AgentPickerStep';
 import FullNameStep from '@/routes/onboarding/features/FullNameStep';
@@ -18,6 +19,7 @@ import { isDev } from '@/utils/env';
 
 const ClassicOnboardingPage = memo(() => {
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
   const [isUserStateInit, commonStepsCompleted, currentStep, goToNextStep, goToPreviousStep] =
     useUserStore((s) => [
       s.isUserStateInit,
@@ -65,7 +67,11 @@ const ClassicOnboardingPage = memo(() => {
 
   return (
     <OnboardingContainer>
-      <Flexbox gap={24} style={{ maxWidth: contentMaxWidth, width: '100%' }}>
+      <Flexbox
+        gap={24}
+        paddingInline={isMobile ? 16 : 0}
+        style={{ maxWidth: contentMaxWidth, width: '100%' }}
+      >
         {isDev && <ModeSwitch />}
         {renderStep()}
       </Flexbox>


### PR DESCRIPTION
## Summary

- After #15019 dropped the outer 8px padding and inner border on mobile (so the Agent conversation can go full-bleed), Classic step content (e.g. FullName / Interests / ProSettings / AgentPicker) became flush with the viewport edges and looked cramped.
- Add `paddingInline={16}` on the inner `Flexbox` of `ClassicOnboardingPage` for mobile only. Desktop unchanged, Agent flow unchanged.

## Test plan

- [x] Visit `/onboarding/classic` on mobile viewport — each step should have horizontal breathing room.
- [x] Visit `/onboarding/classic` on desktop — layout unchanged (maxWidth still 600 / 780 on Picker step).
- [x] Visit `/onboarding/agent` on mobile — still full-bleed conversation.