### PR TITLE
🐛 fix(onboarding): skip pro settings without Klavis

### DIFF
--- a/src/features/Onboarding/Classic/index.test.tsx
+++ b/src/features/Onboarding/Classic/index.test.tsx
@@ -1,0 +1,231 @@
+import { MAX_ONBOARDING_STEPS } from '@lobechat/types';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ClassicOnboardingPage from './index';
+
+const mocks = vi.hoisted(() => ({
+  commonStepsCompleted: true,
+  currentStep: 1,
+  enableKlavis: true,
+  goToNextStep: vi.fn(),
+  goToPreviousStep: vi.fn(),
+  isUserStateInit: true,
+  serverConfigInit: true,
+  setOnboardingStep: vi.fn(),
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  Flexbox: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/Loading/BrandTextLoading', () => ({
+  default: ({ debugId }: { debugId: string }) => <div>Loading:{debugId}</div>,
+}));
+
+vi.mock('@/features/Onboarding/components/ModeSwitch', () => ({
+  default: () => <div>ModeSwitch</div>,
+}));
+
+vi.mock('@/routes/onboarding/_layout', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/routes/onboarding/features/AgentPickerStep', () => ({
+  default: ({ onBack }: { onBack: () => void }) => (
+    <div>
+      AgentPickerStep
+      <button type="button" onClick={onBack}>
+        agent-back
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/routes/onboarding/features/FullNameStep', () => ({
+  default: ({ onBack, onNext }: { onBack: () => void; onNext: () => void }) => (
+    <div>
+      FullNameStep
+      <button type="button" onClick={onBack}>
+        full-name-back
+      </button>
+      <button type="button" onClick={onNext}>
+        full-name-next
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/routes/onboarding/features/InterestsStep', () => ({
+  default: ({ onBack, onNext }: { onBack: () => void; onNext: () => void }) => (
+    <div>
+      InterestsStep
+      <button type="button" onClick={onBack}>
+        interests-back
+      </button>
+      <button type="button" onClick={onNext}>
+        interests-next
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/routes/onboarding/features/ProSettingsStep', () => ({
+  default: ({ onBack, onNext }: { onBack: () => void; onNext: () => void }) => (
+    <div>
+      ProSettingsStep
+      <button type="button" onClick={onBack}>
+        pro-back
+      </button>
+      <button type="button" onClick={onNext}>
+        pro-next
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/store/serverConfig', () => ({
+  serverConfigSelectors: {
+    enableKlavis: (s: { serverConfig: { enableKlavis?: boolean } }) =>
+      s.serverConfig.enableKlavis || false,
+  },
+  useServerConfigStore: <T,>(
+    selector: (state: { serverConfig: { enableKlavis: boolean }; serverConfigInit: boolean }) => T,
+  ) =>
+    selector({
+      serverConfig: { enableKlavis: mocks.enableKlavis },
+      serverConfigInit: mocks.serverConfigInit,
+    }),
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: <T,>(
+    selector: (state: {
+      commonStepsCompleted: boolean;
+      currentStep: number;
+      goToNextStep: () => void;
+      goToPreviousStep: () => void;
+      isUserStateInit: boolean;
+      setOnboardingStep: (step: number) => void;
+    }) => T,
+  ) =>
+    selector({
+      commonStepsCompleted: mocks.commonStepsCompleted,
+      currentStep: mocks.currentStep,
+      goToNextStep: mocks.goToNextStep,
+      goToPreviousStep: mocks.goToPreviousStep,
+      isUserStateInit: mocks.isUserStateInit,
+      setOnboardingStep: mocks.setOnboardingStep,
+    }),
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  onboardingSelectors: {
+    commonStepsCompleted: (s: { commonStepsCompleted: boolean }) => s.commonStepsCompleted,
+    currentStep: (s: { currentStep: number }) => s.currentStep,
+  },
+}));
+
+const renderClassic = () =>
+  render(
+    <MemoryRouter initialEntries={['/onboarding/classic']}>
+      <ClassicOnboardingPage />
+    </MemoryRouter>,
+  );
+
+beforeEach(() => {
+  mocks.commonStepsCompleted = true;
+  mocks.currentStep = 1;
+  mocks.enableKlavis = true;
+  mocks.goToNextStep.mockReset();
+  mocks.goToPreviousStep.mockReset();
+  mocks.isUserStateInit = true;
+  mocks.serverConfigInit = true;
+  mocks.setOnboardingStep.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ClassicOnboardingPage', () => {
+  it('skips ProSettings when moving forward from interests without Klavis', () => {
+    mocks.currentStep = 2;
+    mocks.enableKlavis = false;
+
+    renderClassic();
+    fireEvent.click(screen.getByText('interests-next'));
+
+    expect(mocks.setOnboardingStep).toHaveBeenCalledWith(MAX_ONBOARDING_STEPS);
+    expect(mocks.goToNextStep).not.toHaveBeenCalled();
+  });
+
+  it('moves back from the agent picker to interests when ProSettings is skipped', () => {
+    mocks.currentStep = MAX_ONBOARDING_STEPS;
+    mocks.enableKlavis = false;
+
+    renderClassic();
+    fireEvent.click(screen.getByText('agent-back'));
+
+    expect(mocks.setOnboardingStep).toHaveBeenCalledWith(2);
+    expect(mocks.goToPreviousStep).not.toHaveBeenCalled();
+  });
+
+  it('waits for server config before deciding whether to skip ProSettings', () => {
+    mocks.currentStep = 2;
+    mocks.enableKlavis = false;
+    mocks.serverConfigInit = false;
+
+    renderClassic();
+    fireEvent.click(screen.getByText('interests-next'));
+
+    expect(mocks.goToNextStep).toHaveBeenCalled();
+    expect(mocks.setOnboardingStep).not.toHaveBeenCalled();
+  });
+
+  it('shows loading at ProSettings until server config initializes', () => {
+    mocks.currentStep = 3;
+    mocks.enableKlavis = false;
+    mocks.serverConfigInit = false;
+
+    renderClassic();
+
+    expect(screen.getByText('Loading:ClassicOnboarding/serverConfig')).toBeInTheDocument();
+    expect(mocks.setOnboardingStep).not.toHaveBeenCalled();
+  });
+
+  it('skips a persisted ProSettings step when Klavis is disabled', async () => {
+    mocks.currentStep = 3;
+    mocks.enableKlavis = false;
+
+    renderClassic();
+
+    await waitFor(() => expect(mocks.setOnboardingStep).toHaveBeenCalledWith(MAX_ONBOARDING_STEPS));
+    expect(screen.queryByText('ProSettingsStep')).not.toBeInTheDocument();
+  });
+
+  it('does not skip while shared prefix steps are incomplete', async () => {
+    mocks.commonStepsCompleted = false;
+    mocks.currentStep = 3;
+    mocks.enableKlavis = false;
+
+    renderClassic();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.setOnboardingStep).not.toHaveBeenCalled();
+  });
+
+  it('keeps ProSettings in the flow when Klavis is enabled', () => {
+    mocks.currentStep = 3;
+    mocks.enableKlavis = true;
+
+    renderClassic();
+    fireEvent.click(screen.getByText('pro-next'));
+
+    expect(screen.getByText('ProSettingsStep')).toBeInTheDocument();
+    expect(mocks.goToNextStep).toHaveBeenCalled();
+    expect(mocks.setOnboardingStep).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/Onboarding/Classic/index.test.tsx
+++ b/src/features/Onboarding/Classic/index.test.tsx
@@ -14,7 +14,6 @@ const mocks = vi.hoisted(() => ({
   goToPreviousStep: vi.fn(),
   isUserStateInit: true,
   serverConfigInit: true,
-  setOnboardingStep: vi.fn(),
 }));
 
 vi.mock('@lobehub/ui', () => ({
@@ -108,7 +107,6 @@ vi.mock('@/store/user', () => ({
       goToNextStep: () => void;
       goToPreviousStep: () => void;
       isUserStateInit: boolean;
-      setOnboardingStep: (step: number) => void;
     }) => T,
   ) =>
     selector({
@@ -117,7 +115,6 @@ vi.mock('@/store/user', () => ({
       goToNextStep: mocks.goToNextStep,
       goToPreviousStep: mocks.goToPreviousStep,
       isUserStateInit: mocks.isUserStateInit,
-      setOnboardingStep: mocks.setOnboardingStep,
     }),
 }));
 
@@ -143,7 +140,6 @@ beforeEach(() => {
   mocks.goToPreviousStep.mockReset();
   mocks.isUserStateInit = true;
   mocks.serverConfigInit = true;
-  mocks.setOnboardingStep.mockReset();
 });
 
 afterEach(() => {
@@ -158,8 +154,7 @@ describe('ClassicOnboardingPage', () => {
     renderClassic();
     fireEvent.click(screen.getByText('interests-next'));
 
-    expect(mocks.setOnboardingStep).toHaveBeenCalledWith(MAX_ONBOARDING_STEPS);
-    expect(mocks.goToNextStep).not.toHaveBeenCalled();
+    expect(mocks.goToNextStep).toHaveBeenCalledTimes(2);
   });
 
   it('moves back from the agent picker to interests when ProSettings is skipped', () => {
@@ -169,8 +164,7 @@ describe('ClassicOnboardingPage', () => {
     renderClassic();
     fireEvent.click(screen.getByText('agent-back'));
 
-    expect(mocks.setOnboardingStep).toHaveBeenCalledWith(2);
-    expect(mocks.goToPreviousStep).not.toHaveBeenCalled();
+    expect(mocks.goToPreviousStep).toHaveBeenCalledTimes(2);
   });
 
   it('waits for server config before deciding whether to skip ProSettings', () => {
@@ -182,7 +176,6 @@ describe('ClassicOnboardingPage', () => {
     fireEvent.click(screen.getByText('interests-next'));
 
     expect(mocks.goToNextStep).toHaveBeenCalled();
-    expect(mocks.setOnboardingStep).not.toHaveBeenCalled();
   });
 
   it('shows loading at ProSettings until server config initializes', () => {
@@ -193,7 +186,7 @@ describe('ClassicOnboardingPage', () => {
     renderClassic();
 
     expect(screen.getByText('Loading:ClassicOnboarding/serverConfig')).toBeInTheDocument();
-    expect(mocks.setOnboardingStep).not.toHaveBeenCalled();
+    expect(mocks.goToNextStep).not.toHaveBeenCalled();
   });
 
   it('skips a persisted ProSettings step when Klavis is disabled', async () => {
@@ -202,7 +195,7 @@ describe('ClassicOnboardingPage', () => {
 
     renderClassic();
 
-    await waitFor(() => expect(mocks.setOnboardingStep).toHaveBeenCalledWith(MAX_ONBOARDING_STEPS));
+    await waitFor(() => expect(mocks.goToNextStep).toHaveBeenCalledTimes(1));
     expect(screen.queryByText('ProSettingsStep')).not.toBeInTheDocument();
   });
 
@@ -214,7 +207,7 @@ describe('ClassicOnboardingPage', () => {
     renderClassic();
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(mocks.setOnboardingStep).not.toHaveBeenCalled();
+    expect(mocks.goToNextStep).not.toHaveBeenCalled();
   });
 
   it('keeps ProSettings in the flow when Klavis is enabled', () => {
@@ -226,6 +219,5 @@ describe('ClassicOnboardingPage', () => {
 
     expect(screen.getByText('ProSettingsStep')).toBeInTheDocument();
     expect(mocks.goToNextStep).toHaveBeenCalled();
-    expect(mocks.setOnboardingStep).not.toHaveBeenCalled();
   });
 });

--- a/src/features/Onboarding/Classic/index.tsx
+++ b/src/features/Onboarding/Classic/index.tsx
@@ -2,7 +2,7 @@
 
 import { MAX_ONBOARDING_STEPS } from '@lobechat/types';
 import { Flexbox } from '@lobehub/ui';
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useEffect } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 
 import Loading from '@/components/Loading/BrandTextLoading';
@@ -13,27 +13,78 @@ import AgentPickerStep from '@/routes/onboarding/features/AgentPickerStep';
 import FullNameStep from '@/routes/onboarding/features/FullNameStep';
 import InterestsStep from '@/routes/onboarding/features/InterestsStep';
 import ProSettingsStep from '@/routes/onboarding/features/ProSettingsStep';
+import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { onboardingSelectors } from '@/store/user/selectors';
 import { isDev } from '@/utils/env';
 
+const INTERESTS_STEP = 2;
+const PRO_SETTINGS_STEP = 3;
+
 const ClassicOnboardingPage = memo(() => {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
-  const [isUserStateInit, commonStepsCompleted, currentStep, goToNextStep, goToPreviousStep] =
-    useUserStore((s) => [
-      s.isUserStateInit,
-      onboardingSelectors.commonStepsCompleted(s),
-      onboardingSelectors.currentStep(s),
-      s.goToNextStep,
-      s.goToPreviousStep,
-    ]);
+  const [
+    isUserStateInit,
+    commonStepsCompleted,
+    currentStep,
+    goToNextStep,
+    goToPreviousStep,
+    setOnboardingStep,
+  ] = useUserStore((s) => [
+    s.isUserStateInit,
+    onboardingSelectors.commonStepsCompleted(s),
+    onboardingSelectors.currentStep(s),
+    s.goToNextStep,
+    s.goToPreviousStep,
+    s.setOnboardingStep,
+  ]);
+  const enableKlavis = useServerConfigStore(serverConfigSelectors.enableKlavis);
+  const serverConfigInit = useServerConfigStore((s) => s.serverConfigInit);
+  const shouldSkipProSettingsStep = serverConfigInit && !enableKlavis;
 
   // FullNameStep is the branch's first step, so its back button leaves the
   // branch and re-enters the shared prefix's ResponseLanguageStep (step 2).
   const backToResponseLanguageStep = useCallback(() => {
     navigate('/onboarding?step=2', { replace: true });
   }, [navigate]);
+
+  useEffect(() => {
+    if (
+      !isUserStateInit ||
+      !commonStepsCompleted ||
+      currentStep !== PRO_SETTINGS_STEP ||
+      !shouldSkipProSettingsStep
+    ) {
+      return;
+    }
+
+    void setOnboardingStep(MAX_ONBOARDING_STEPS);
+  }, [
+    commonStepsCompleted,
+    currentStep,
+    isUserStateInit,
+    setOnboardingStep,
+    shouldSkipProSettingsStep,
+  ]);
+
+  const goToNextStepFromInterests = useCallback(() => {
+    if (shouldSkipProSettingsStep) {
+      void setOnboardingStep(MAX_ONBOARDING_STEPS);
+      return;
+    }
+
+    goToNextStep();
+  }, [goToNextStep, setOnboardingStep, shouldSkipProSettingsStep]);
+
+  const goToPreviousStepFromAgentPicker = useCallback(() => {
+    if (shouldSkipProSettingsStep) {
+      void setOnboardingStep(INTERESTS_STEP);
+      return;
+    }
+
+    goToPreviousStep();
+  }, [goToPreviousStep, setOnboardingStep, shouldSkipProSettingsStep]);
 
   if (!isUserStateInit) {
     return <Loading debugId="ClassicOnboarding" />;
@@ -48,14 +99,17 @@ const ClassicOnboardingPage = memo(() => {
       case 1: {
         return <FullNameStep onBack={backToResponseLanguageStep} onNext={goToNextStep} />;
       }
-      case 2: {
-        return <InterestsStep onBack={goToPreviousStep} onNext={goToNextStep} />;
+      case INTERESTS_STEP: {
+        return <InterestsStep onBack={goToPreviousStep} onNext={goToNextStepFromInterests} />;
       }
-      case 3: {
+      case PRO_SETTINGS_STEP: {
+        if (!serverConfigInit) return <Loading debugId="ClassicOnboarding/serverConfig" />;
+        if (shouldSkipProSettingsStep) return null;
+
         return <ProSettingsStep onBack={goToPreviousStep} onNext={goToNextStep} />;
       }
       case MAX_ONBOARDING_STEPS: {
-        return <AgentPickerStep onBack={goToPreviousStep} />;
+        return <AgentPickerStep onBack={goToPreviousStepFromAgentPicker} />;
       }
       default: {
         return null;

--- a/src/features/Onboarding/Classic/index.tsx
+++ b/src/features/Onboarding/Classic/index.tsx
@@ -30,14 +30,12 @@ const ClassicOnboardingPage = memo(() => {
     currentStep,
     goToNextStep,
     goToPreviousStep,
-    setOnboardingStep,
   ] = useUserStore((s) => [
     s.isUserStateInit,
     onboardingSelectors.commonStepsCompleted(s),
     onboardingSelectors.currentStep(s),
     s.goToNextStep,
     s.goToPreviousStep,
-    s.setOnboardingStep,
   ]);
   const enableKlavis = useServerConfigStore(serverConfigSelectors.enableKlavis);
   const serverConfigInit = useServerConfigStore((s) => s.serverConfigInit);
@@ -59,32 +57,28 @@ const ClassicOnboardingPage = memo(() => {
       return;
     }
 
-    void setOnboardingStep(MAX_ONBOARDING_STEPS);
-  }, [
-    commonStepsCompleted,
-    currentStep,
-    isUserStateInit,
-    setOnboardingStep,
-    shouldSkipProSettingsStep,
-  ]);
+    goToNextStep();
+  }, [commonStepsCompleted, currentStep, goToNextStep, isUserStateInit, shouldSkipProSettingsStep]);
 
   const goToNextStepFromInterests = useCallback(() => {
     if (shouldSkipProSettingsStep) {
-      void setOnboardingStep(MAX_ONBOARDING_STEPS);
+      goToNextStep();
+      goToNextStep();
       return;
     }
 
     goToNextStep();
-  }, [goToNextStep, setOnboardingStep, shouldSkipProSettingsStep]);
+  }, [goToNextStep, shouldSkipProSettingsStep]);
 
   const goToPreviousStepFromAgentPicker = useCallback(() => {
     if (shouldSkipProSettingsStep) {
-      void setOnboardingStep(INTERESTS_STEP);
+      goToPreviousStep();
+      goToPreviousStep();
       return;
     }
 
     goToPreviousStep();
-  }, [goToPreviousStep, setOnboardingStep, shouldSkipProSettingsStep]);
+  }, [goToPreviousStep, shouldSkipProSettingsStep]);
 
   if (!isUserStateInit) {
     return <Loading debugId="ClassicOnboarding" />;

--- a/src/routes/onboarding/features/ProSettingsStep.test.tsx
+++ b/src/routes/onboarding/features/ProSettingsStep.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { MouseEventHandler, ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ProSettingsStep from './ProSettingsStep';
+
+vi.mock('@lobehub/ui', () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+  }: {
+    children: ReactNode;
+    disabled?: boolean;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+  }) => (
+    <button disabled={disabled} type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  Flexbox: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      (
+        {
+          back: 'Back',
+          next: 'Next',
+          'proSettings.connectors.title': 'Connect Your Favorite Tools',
+        } as Record<string, string>
+      )[key] ?? key,
+  }),
+}));
+
+vi.mock('@/routes/onboarding/components/LobeMessage', () => ({
+  default: ({ sentences }: { sentences: string[] }) => <div>{sentences.join(' / ')}</div>,
+}));
+
+vi.mock('../components/KlavisServerList', () => ({
+  default: () => <div>KlavisServerList</div>,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ProSettingsStep', () => {
+  it('uses the connector title as the step title and renders the Klavis server list', () => {
+    render(<ProSettingsStep onBack={vi.fn()} onNext={vi.fn()} />);
+
+    expect(screen.getAllByText('Connect Your Favorite Tools')).toHaveLength(1);
+    expect(screen.getByText('KlavisServerList')).toBeInTheDocument();
+  });
+
+  it('calls the provided navigation handlers', () => {
+    const onBack = vi.fn();
+    const onNext = vi.fn();
+
+    render(<ProSettingsStep onBack={onBack} onNext={onNext} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+
+    cleanup();
+
+    render(<ProSettingsStep onBack={onBack} onNext={onNext} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/routes/onboarding/features/ProSettingsStep.tsx
+++ b/src/routes/onboarding/features/ProSettingsStep.tsx
@@ -1,16 +1,12 @@
 'use client';
 
-import { Button, Flexbox, Text } from '@lobehub/ui';
+import { Button, Flexbox } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { Undo2Icon } from 'lucide-react';
 import { memo, useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import ModelSelect from '@/features/ModelSelect';
 import LobeMessage from '@/routes/onboarding/components/LobeMessage';
-import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
-import { useUserStore } from '@/store/user';
-import { settingsSelectors } from '@/store/user/selectors';
 
 import KlavisServerList from '../components/KlavisServerList';
 
@@ -21,14 +17,6 @@ interface ProSettingsStepProps {
 
 const ProSettingsStep = memo<ProSettingsStepProps>(({ onBack, onNext }) => {
   const { t } = useTranslation('onboarding');
-
-  const enableKlavis = useServerConfigStore(serverConfigSelectors.enableKlavis);
-
-  const updateDefaultModel = useUserStore((s) => s.updateDefaultModel);
-
-  const defaultAgentConfig = useUserStore(
-    (s) => settingsSelectors.currentSettings(s).defaultAgent?.config,
-  );
 
   const [isNavigating, setIsNavigating] = useState(false);
   const isNavigatingRef = useRef(false);
@@ -47,35 +35,11 @@ const ProSettingsStep = memo<ProSettingsStepProps>(({ onBack, onNext }) => {
     onBack();
   }, [onBack]);
 
-  const handleModelChange = useCallback(
-    ({ model, provider }: { model: string; provider: string }) => {
-      updateDefaultModel(model, provider);
-    },
-    [updateDefaultModel],
-  );
-
   return (
     <Flexbox gap={16}>
-      <LobeMessage
-        sentences={[t('proSettings.title'), t('proSettings.title2'), t('proSettings.title3')]}
-      />
-      <Flexbox gap={16}>
-        <Text color={cssVar.colorTextSecondary}>{t('proSettings.model.title')}</Text>
-        <ModelSelect
-          showAbility={false}
-          size="large"
-          style={{ width: '100%' }}
-          value={defaultAgentConfig}
-          onChange={handleModelChange}
-        />
-      </Flexbox>
+      <LobeMessage sentences={[t('proSettings.connectors.title')]} />
 
-      {enableKlavis && (
-        <Flexbox gap={16}>
-          <Text color={cssVar.colorTextSecondary}>{t('proSettings.connectors.title')}</Text>
-          <KlavisServerList />
-        </Flexbox>
-      )}
+      <KlavisServerList />
 
       <Flexbox horizontal align={'center'} justify={'space-between'} style={{ marginTop: 16 }}>
         <Button


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Skip the Classic onboarding Pro Settings step when Klavis is disabled by server config.
- Preserve forward/back navigation around the skipped step, including persisted Pro Settings resumes.
- Simplify Pro Settings to a connector-only step and use the connector title as the main step title.
- Add unit coverage for Klavis-enabled, Klavis-disabled, loading, persisted-step, and back-navigation paths.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Run:

```bash
bunx vitest run --silent='passed-only' 'src/features/Onboarding/Classic/index.test.tsx'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

The branch was rebased onto the latest `origin/canary` before opening this PR.
