### PR TITLE
🐛 fix(desktop): open settings via main window navigation on Windows/Linux

### DIFF
--- a/apps/desktop/src/main/menus/impls/linux.test.ts
+++ b/apps/desktop/src/main/menus/impls/linux.test.ts
@@ -95,6 +95,11 @@ const createMockApp = () => {
       }),
     },
     browserManager: {
+      getMainWindow: vi.fn(() => ({
+        broadcast: vi.fn(),
+        loadUrl: vi.fn(),
+        show: vi.fn(),
+      })),
       showMainWindow: vi.fn(),
       retrieveByIdentifier: vi.fn(() => ({
         show: vi.fn(),
@@ -223,6 +228,9 @@ describe('LinuxMenu', () => {
 
   describe('menu item click handlers', () => {
     it('should handle preferences click', () => {
+      const mainWindow = { broadcast: vi.fn(), loadUrl: vi.fn(), show: vi.fn() };
+      (mockApp.browserManager.getMainWindow as any).mockReturnValue(mainWindow);
+
       linuxMenu.buildAndSetAppMenu();
 
       const template = (Menu.buildFromTemplate as any).mock.calls[0][0];
@@ -231,7 +239,9 @@ describe('LinuxMenu', () => {
 
       expect(preferencesItem).toBeDefined();
       preferencesItem.click();
-      expect(mockApp.browserManager.retrieveByIdentifier).toHaveBeenCalledWith('settings');
+      expect(mockApp.browserManager.getMainWindow).toHaveBeenCalled();
+      expect(mainWindow.show).toHaveBeenCalled();
+      expect(mainWindow.broadcast).toHaveBeenCalledWith('navigate', { path: '/settings' });
     });
 
     it('should handle check for updates click', () => {

--- a/apps/desktop/src/main/menus/impls/linux.ts
+++ b/apps/desktop/src/main/menus/impls/linux.ts
@@ -103,7 +103,11 @@ export class LinuxMenu extends BaseMenuPlatform implements IMenuPlatform {
           },
           { type: 'separator' },
           {
-            click: () => this.app.browserManager.retrieveByIdentifier('settings').show(),
+            click: async () => {
+              const mainWindow = this.app.browserManager.getMainWindow();
+              mainWindow.show();
+              mainWindow.broadcast('navigate', { path: '/settings' });
+            },
             label: t('file.preferences'),
           },
           {
@@ -465,7 +469,11 @@ export class LinuxMenu extends BaseMenuPlatform implements IMenuPlatform {
       },
       { type: 'separator' },
       {
-        click: () => this.app.browserManager.retrieveByIdentifier('settings').show(),
+        click: async () => {
+          const mainWindow = this.app.browserManager.getMainWindow();
+          mainWindow.show();
+          mainWindow.broadcast('navigate', { path: '/settings' });
+        },
         label: t('tray.settings'),
       },
       { type: 'separator' },

--- a/apps/desktop/src/main/menus/impls/windows.test.ts
+++ b/apps/desktop/src/main/menus/impls/windows.test.ts
@@ -205,6 +205,9 @@ describe('WindowsMenu', () => {
 
   describe('menu item click handlers', () => {
     it('should handle preferences click', () => {
+      const mainWindow = { broadcast: vi.fn(), loadUrl: vi.fn(), show: vi.fn() };
+      (mockApp.browserManager.getMainWindow as any).mockReturnValue(mainWindow);
+
       windowsMenu.buildAndSetAppMenu();
 
       const template = (Menu.buildFromTemplate as any).mock.calls[0][0];
@@ -213,7 +216,9 @@ describe('WindowsMenu', () => {
 
       expect(preferencesItem).toBeDefined();
       preferencesItem.click();
-      expect(mockApp.browserManager.retrieveByIdentifier).toHaveBeenCalledWith('settings');
+      expect(mockApp.browserManager.getMainWindow).toHaveBeenCalled();
+      expect(mainWindow.show).toHaveBeenCalled();
+      expect(mainWindow.broadcast).toHaveBeenCalledWith('navigate', { path: '/settings' });
     });
 
     it('should handle check for updates click', () => {

--- a/apps/desktop/src/main/menus/impls/windows.ts
+++ b/apps/desktop/src/main/menus/impls/windows.ts
@@ -102,7 +102,11 @@ export class WindowsMenu extends BaseMenuPlatform implements IMenuPlatform {
           },
           { type: 'separator' },
           {
-            click: () => this.app.browserManager.retrieveByIdentifier('settings').show(),
+            click: async () => {
+              const mainWindow = this.app.browserManager.getMainWindow();
+              mainWindow.show();
+              mainWindow.broadcast('navigate', { path: '/settings' });
+            },
             label: t('file.preferences'),
           },
           this.getUpdateMenuItem(t),
@@ -472,7 +476,11 @@ export class WindowsMenu extends BaseMenuPlatform implements IMenuPlatform {
       },
       { type: 'separator' },
       {
-        click: () => this.app.browserManager.retrieveByIdentifier('settings').show(),
+        click: async () => {
+          const mainWindow = this.app.browserManager.getMainWindow();
+          mainWindow.show();
+          mainWindow.broadcast('navigate', { path: '/settings' });
+        },
         label: t('tray.settings'),
       },
       { type: 'separator' },


### PR DESCRIPTION
## Summary

- On Windows and Linux, both `File → Preferences` and `Tray → Settings` called `retrieveByIdentifier('settings').show()`, but no browser with the `settings` identifier exists in `appBrowsers` (only `app` and `devtools`). Clicking either entry threw `Browser settings not found and is not a static browser` from `BrowserManager.retrieveByIdentifier` (see `apps/desktop/src/main/core/browser/BrowserManager.ts:126`).
- Aligns Windows (`apps/desktop/src/main/menus/impls/windows.ts:105,475`) and Linux (`apps/desktop/src/main/menus/impls/linux.ts:106,468`) with the macOS implementation (`macOS.ts:88-91,692-695`): show the main window and broadcast `navigate` to `/settings`.
- Updates unit tests to assert the new navigation behavior.

## Repro

1. Launch the desktop app on Windows or Linux.
2. Click `File → Preferences` (or `Tray → Settings`).
3. Without this fix: a dialog appears with `A JavaScript error occurred in the main process` / `Browser settings not found and is not a static browser`.

## Test plan

- [x] `bunx vitest run apps/desktop/src/main/menus/impls/windows.test.ts` — 33 passed
- [x] `bunx vitest run apps/desktop/src/main/menus/impls/linux.test.ts` — 40 passed
- [ ] Manual verification on Windows / Linux desktop build (clicking File → Preferences and Tray → Settings opens the in-app `/settings` route)