### PR TITLE
🐛 fix: return bad request for malformed auth JSON

### DIFF
--- a/src/app/(backend)/api/auth/[...all]/route.test.ts
+++ b/src/app/(backend)/api/auth/[...all]/route.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+import type { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GET, POST } from './route';
+
+type RouteHandler = (request: Request) => Promise<Response>;
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn<RouteHandler>(async () => Response.json({ ok: true })),
+  post: vi.fn<RouteHandler>(async () => Response.json({ ok: true })),
+}));
+
+vi.mock('better-auth/next-js', () => ({
+  toNextJsHandler: vi.fn(() => ({
+    GET: mocks.get,
+    POST: mocks.post,
+  })),
+}));
+
+vi.mock('@/auth', () => ({
+  auth: {},
+}));
+
+const createPostRequest = (body: string, contentType = 'application/json') =>
+  new Request('https://localhost/api/auth/sign-in/email', {
+    body,
+    headers: { 'Content-Type': contentType },
+    method: 'POST',
+  }) as NextRequest;
+
+describe('/api/auth/[...all] route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.get.mockResolvedValue(Response.json({ ok: true }));
+    mocks.post.mockResolvedValue(Response.json({ ok: true }));
+  });
+
+  it('returns 400 for malformed JSON auth requests before Better Auth handles them', async () => {
+    const response = await POST(
+      createPostRequest('{"email":"user@example.com","password":"secret",}'),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      code: 'INVALID_JSON',
+      message: 'Malformed JSON request body',
+    });
+    expect(response.status).toBe(400);
+    expect(mocks.post).not.toHaveBeenCalled();
+  });
+
+  it('passes valid JSON auth requests through without consuming the original body', async () => {
+    mocks.post.mockImplementationOnce(async (request: Request) =>
+      Response.json(await request.json()),
+    );
+
+    const response = await POST(
+      createPostRequest(JSON.stringify({ email: 'user@example.com', password: 'secret' })),
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      email: 'user@example.com',
+      password: 'secret',
+    });
+    expect(mocks.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates non-JSON auth requests to Better Auth', async () => {
+    const response = await POST(
+      createPostRequest(
+        'email=user%40example.com&password=secret',
+        'application/x-www-form-urlencoded',
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates GET requests to Better Auth', async () => {
+    const request = new Request('https://localhost/api/auth/get-session') as NextRequest;
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(mocks.get).toHaveBeenCalledWith(request);
+  });
+});

--- a/src/app/(backend)/api/auth/[...all]/route.ts
+++ b/src/app/(backend)/api/auth/[...all]/route.ts
@@ -1,14 +1,36 @@
 import { toNextJsHandler } from 'better-auth/next-js';
-import { type NextRequest } from 'next/server';
+import type { NextRequest } from 'next/server';
 
 import { auth } from '@/auth';
 
+const jsonContentTypeRegex = /^application\/(?:[a-z0-9.+-]*\+)?json/i;
+
 const handler = toNextJsHandler(auth);
 
-export const GET = async (req: NextRequest) => {
-  return handler.GET(req);
+const malformedJsonResponse = () =>
+  Response.json({ code: 'INVALID_JSON', message: 'Malformed JSON request body' }, { status: 400 });
+
+/**
+ * better-call currently treats Request.json() SyntaxError as a server error.
+ * Validate JSON bodies at the route boundary so malformed client payloads stay 400s.
+ */
+const validateJsonBody = async (request: Request) => {
+  const contentType = request.headers.get('content-type') || '';
+  if (!request.body || !jsonContentTypeRegex.test(contentType)) return;
+
+  try {
+    await request.clone().json();
+  } catch (error) {
+    if (error instanceof SyntaxError) return malformedJsonResponse();
+    throw error;
+  }
 };
 
-export const POST = async (req: NextRequest) => {
-  return handler.POST(req);
+export const GET = handler.GET;
+
+export const POST = async (request: NextRequest) => {
+  const invalidJsonResponse = await validateJsonBody(request);
+  if (invalidJsonResponse) return invalidJsonResponse;
+
+  return handler.POST(request);
 };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-9276

#### 🔀 Description of Change

- Validate JSON auth request bodies at the route boundary before delegating to Better Auth.
- Return `400 INVALID_JSON` for malformed JSON instead of letting `better-call` surface it as a server error.
- Preserve the original request body by validating through `request.clone()`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd lobehub
bunx vitest run --silent='passed-only' 'src/app/(backend)/api/auth/[...all]/route.test.ts'\n```\n\nAlso validated from the cloud workspace:\n\n```bash\nbunx eslint 'lobehub/src/app/(backend)/api/auth/[...all]/route.ts' 'lobehub/src/app/(backend)/api/auth/[...all]/route.test.ts' 'src/app/(backend)/api/auth/[...all]/route.ts'\nbun run type-check\ngit diff --check\n```\n\n#### 📸 Screenshots / Videos\n\nN/A\n\n#### 📝 Additional Information\n\nThis is generic auth request boundary handling. The cloud repo re-exports this route and links this submodule PR separately.