### PR TITLE
✨ feat(page-agent): preview initPage streaming arguments

### DIFF
--- a/packages/builtin-tool-page-agent/src/client/Streaming/InitPage/index.tsx
+++ b/packages/builtin-tool-page-agent/src/client/Streaming/InitPage/index.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import type { InitDocumentArgs } from '@lobechat/editor-runtime';
+import type { BuiltinStreamingProps } from '@lobechat/types';
+import { Flexbox, Icon, Text } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+import { FileText, Hash, ListTree } from 'lucide-react';
+import { memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import StreamingMarkdown from '@/components/StreamingMarkdown';
+
+import { AnimatedNumber } from '../../components/AnimatedNumber';
+
+const MAX_PREVIEW_CHARS = 4000;
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  container: css`
+    overflow: hidden;
+
+    width: 100%;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: 8px;
+
+    background: ${cssVar.colorBgContainer};
+  `,
+  header: css`
+    padding-block: 10px;
+    padding-inline: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  icon: css`
+    color: ${cssVar.colorPrimary};
+  `,
+  meta: css`
+    color: ${cssVar.colorTextDescription};
+  `,
+  preview: css`
+    max-height: 360px;
+    overflow: auto;
+    padding-block: 8px;
+    padding-inline: 12px;
+  `,
+  title: css`
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+
+    font-weight: 500;
+    color: ${cssVar.colorText};
+  `,
+}));
+
+const extractTitle = (markdown: string) => {
+  const titleLine = markdown
+    .split(/\r?\n/)
+    .find((line) => line.startsWith('# ') && line.slice(2).trim().length > 0);
+
+  return titleLine?.slice(2).trim();
+};
+
+export const InitPageStreaming = memo<BuiltinStreamingProps<InitDocumentArgs>>(({ args }) => {
+  const { t } = useTranslation('plugin');
+  const markdown = args?.markdown || '';
+
+  const { chars, lines, preview, title } = useMemo(() => {
+    const preview =
+      markdown.length > MAX_PREVIEW_CHARS
+        ? `${markdown.slice(0, MAX_PREVIEW_CHARS)}\n\n...`
+        : markdown;
+
+    return {
+      chars: markdown.length,
+      lines: markdown ? markdown.split('\n').length : 0,
+      preview,
+      title: extractTitle(markdown),
+    };
+  }, [markdown]);
+
+  if (!markdown) return null;
+
+  return (
+    <Flexbox className={styles.container}>
+      <Flexbox horizontal align={'center'} className={styles.header} gap={8}>
+        <FileText className={styles.icon} size={16} />
+        <Flexbox flex={1} gap={2}>
+          <div className={styles.title}>
+            {title || t('builtins.lobe-page-agent.apiName.initPage.creating')}
+          </div>
+          <Flexbox horizontal align={'center'} className={styles.meta} gap={10}>
+            <Text as={'span'} color={cssVar.colorTextDescription} fontSize={12}>
+              <Icon icon={ListTree} size={12} /> <AnimatedNumber value={lines} />
+              {t('builtins.lobe-page-agent.apiName.initPage.lines')}
+            </Text>
+            <Text as={'span'} color={cssVar.colorTextDescription} fontSize={12}>
+              <Icon icon={Hash} size={12} /> <AnimatedNumber value={chars} />
+              {t('builtins.lobe-page-agent.apiName.initPage.chars')}
+            </Text>
+          </Flexbox>
+        </Flexbox>
+      </Flexbox>
+      <div className={styles.preview}>
+        <StreamingMarkdown>{preview}</StreamingMarkdown>
+      </div>
+    </Flexbox>
+  );
+});
+
+InitPageStreaming.displayName = 'PageAgentInitPageStreaming';
+
+export default InitPageStreaming;

--- a/packages/builtin-tool-page-agent/src/client/Streaming/index.ts
+++ b/packages/builtin-tool-page-agent/src/client/Streaming/index.ts
@@ -1,9 +1,14 @@
 import type { BuiltinStreaming } from '@lobechat/types';
 
+import { DocumentApiName } from '../../types';
+import { InitPageStreaming } from './InitPage';
+
 /**
  * Page Agent Streaming Components Registry
  *
  * Streaming components are used to render tool calls while arguments
  * are still being generated, allowing real-time feedback to users.
  */
-export const PageAgentStreamings: Record<string, BuiltinStreaming> = {};
+export const PageAgentStreamings: Record<string, BuiltinStreaming> = {
+  [DocumentApiName.initPage]: InitPageStreaming as BuiltinStreaming,
+};

--- a/packages/builtin-tools/src/streamings.ts
+++ b/packages/builtin-tools/src/streamings.ts
@@ -33,6 +33,7 @@ import {
 } from '@lobechat/builtin-tool-local-system/client';
 import { MemoryManifest, MemoryStreamings } from '@lobechat/builtin-tool-memory/client';
 import { MessageManifest, MessageStreamings } from '@lobechat/builtin-tool-message/client';
+import { PageAgentManifest, PageAgentStreamings } from '@lobechat/builtin-tool-page-agent/client';
 import { type BuiltinStreaming } from '@lobechat/types';
 
 /**
@@ -64,6 +65,7 @@ const BuiltinToolStreamings: Record<string, Record<string, BuiltinStreaming>> = 
   [LocalSystemManifest.identifier]: LocalSystemStreamings as Record<string, BuiltinStreaming>,
   [MemoryManifest.identifier]: MemoryStreamings as Record<string, BuiltinStreaming>,
   [MessageManifest.identifier]: MessageStreamings as Record<string, BuiltinStreaming>,
+  [PageAgentManifest.identifier]: PageAgentStreamings as Record<string, BuiltinStreaming>,
 };
 
 export interface BuiltinStreamingRegistryEntry {

--- a/src/features/DevPanel/RenderGallery/fixtures/lobe-page-agent.test.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/lobe-page-agent.test.ts
@@ -1,0 +1,43 @@
+import { getBuiltinStreaming } from '@lobechat/builtin-tools/streamings';
+import { render, screen } from '@testing-library/react';
+import { createElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { deriveFixtureProps } from '../lifecycleMode';
+import lobePageAgent from './lobe-page-agent';
+
+vi.mock('@/components/StreamingMarkdown', () => ({
+  default: ({ children }: { children?: string }) => children || null,
+}));
+
+describe('lobe-page-agent render gallery fixtures', () => {
+  it('exposes a partial initPage markdown payload for streaming previews', () => {
+    const variant = lobePageAgent.fixtures.initPage.variants[0];
+    const props = deriveFixtureProps(variant, 'streaming');
+
+    expect(props.isArgumentsStreaming).toBe(true);
+    expect(props.pluginState).toBeUndefined();
+    expect(props.args.markdown).toContain('Body segments are still streaming');
+  });
+
+  it('renders the registered initPage streaming preview from the demo payload', async () => {
+    const Streaming = getBuiltinStreaming('lobe-page-agent', 'initPage');
+    const variant = lobePageAgent.fixtures.initPage.variants[0];
+    const props = deriveFixtureProps(variant, 'streaming');
+
+    expect(Streaming).toBeDefined();
+
+    render(
+      createElement(Streaming as any, {
+        apiName: 'initPage',
+        args: props.args,
+        identifier: 'lobe-page-agent',
+        messageId: 'demo-message',
+        toolCallId: 'demo-tool-call',
+      }),
+    );
+
+    expect(await screen.findAllByText('Devtools Render Gallery')).not.toHaveLength(0);
+    expect(screen.getByText(/Body segments are still streaming/)).toBeInTheDocument();
+  });
+});

--- a/src/features/DevPanel/RenderGallery/fixtures/lobe-page-agent.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/lobe-page-agent.ts
@@ -36,6 +36,10 @@ export default defineFixtures({
         markdown:
           '# Devtools Render Gallery\n\nA development-only preview surface for every builtin tool render.\n\n- Inspector previews mirror the chat title bar.\n- Body segments switch between Render, Streaming, Placeholder, and Intervention.\n',
       },
+      partialArgs: {
+        markdown:
+          '# Devtools Render Gallery\n\nA development-only preview surface for every builtin tool render.\n\n- Inspector previews mirror the chat title bar.\n- Body segments are still streaming',
+      },
       pluginState: { nodeCount: 6 },
     }),
     editTitle: single({


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Add a PageAgent `initPage` streaming renderer that previews partial markdown arguments while the tool call is still streaming.
- Register PageAgent streaming renderers in the builtin streaming registry so Conversation tool details can discover them.
- Add a RenderGallery demo fixture and regression test that render the `initPage` streaming preview from partial arguments.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validated with:

```bash
bunx vitest run --silent='passed-only' src/features/DevPanel/RenderGallery/fixtures/lobe-page-agent.test.ts
bun run type-check
git diff --check origin/canary..HEAD
```

Demo scenario:

- Open RenderGallery for `lobe-page-agent / initPage`.
- Switch lifecycle mode to `Streaming`.
- Confirm the streaming body displays the partial markdown preview, inferred title, line count, and character count.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Streaming body had no PageAgent `initPage` preview. | Streaming body renders a live markdown preview from partial arguments. |

#### 📝 Additional Information

The renderer is display-only. It consumes streamed tool arguments and does not invoke PageAgent runtime mutations, editor writes, history, or save queues.
