### PR TITLE
🐛 fix: allow anthropic router timeout option

### DIFF
--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
@@ -58,6 +58,7 @@ interface ProviderIniOptions extends Record<string, any> {
   region?: string;
   sdkType?: string;
   sessionToken?: string;
+  timeout?: number;
 }
 
 /**

--- a/packages/model-runtime/src/providers/deepseek/index.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.test.ts
@@ -123,6 +123,16 @@ describe('LobeDeepSeekAI', () => {
       expect((runtime as any).baseURL).toBe(anthropicBaseURL);
     });
 
+    it('should pass configured timeout to the Anthropic SDK client', () => {
+      const runtime = new LobeDeepSeekAnthropicAI({
+        apiKey: 'test',
+        baseURL: anthropicBaseURL,
+        timeout: 3_600_000,
+      });
+
+      expect((runtime as any).client._options.timeout).toBe(3_600_000);
+    });
+
     it('should let sdkType override legacy baseURL suffix routing', async () => {
       const router = await resolveRouter(anthropicBaseURL, 'openai');
 

--- a/packages/model-runtime/src/providers/moonshot/index.test.ts
+++ b/packages/model-runtime/src/providers/moonshot/index.test.ts
@@ -109,6 +109,16 @@ describe('LobeMoonshotAI', () => {
       expect((runtime as any).baseURL).toBe(anthropicBaseURL);
     });
 
+    it('should pass configured timeout to the Anthropic SDK client', () => {
+      const runtime = new LobeMoonshotAnthropicAI({
+        apiKey: 'test',
+        baseURL: anthropicBaseURL,
+        timeout: 3_600_000,
+      });
+
+      expect((runtime as any).client._options.timeout).toBe(3_600_000);
+    });
+
     it('should let sdkType override legacy baseURL suffix routing', async () => {
       const router = await resolveRouter(anthropicBaseURL, 'openai');
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-8713

#### 🔀 Description of Change

Allow RouterRuntime provider options to carry a client-level `timeout` value. This lets Anthropic-compatible routed channels pass an explicit timeout to the Anthropic SDK when operators choose to support long non-streaming requests.

This PR does not set a provider default timeout and does not change DeepSeek or Moonshot routing behavior.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/providers/deepseek/index.test.ts' 'src/providers/moonshot/index.test.ts'\n```\n\n#### 📸 Screenshots / Videos\n\nN/A\n\n#### 📝 Additional Information\n\nThe `timeout` value must be configured explicitly by the router channel or runtime caller.