### PR TITLE
✨ feat(onboarding): prefetch agent marketplace templates

### DIFF
--- a/packages/builtin-tool-web-onboarding/src/agentMarketplace/client/Intervention/PickAgents/index.tsx
+++ b/packages/builtin-tool-web-onboarding/src/agentMarketplace/client/Intervention/PickAgents/index.tsx
@@ -8,18 +8,16 @@ import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
-import { fetchAgentTemplates, getTemplatesByCategoryPriority } from '../../../data/agent-templates';
 import {
-  type AgentTemplate,
-  type MarketplaceCategory,
-  type ShowAgentMarketplaceArgs,
-} from '../../../types';
+  fetchAgentTemplates,
+  getAgentTemplatesSWRKey,
+  getTemplatesByCategoryPriority,
+} from '../../../data/agent-templates';
+import type { AgentTemplate, MarketplaceCategory, ShowAgentMarketplaceArgs } from '../../../types';
 import { CATEGORY_LABEL_I18N_KEYS } from './constants';
 import PickAgentsSkeleton from './Skeleton';
 import { styles } from './style';
 
-const getTemplatesSWRKey = (locale?: string) =>
-  `builtin-tool-web-onboarding/agent-marketplace/onboarding-templates/${locale ?? 'default'}`;
 const EMPTY_TEMPLATES: AgentTemplate[] = [];
 
 const PickAgentsIntervention = memo<BuiltinInterventionProps<ShowAgentMarketplaceArgs>>(
@@ -37,7 +35,7 @@ const PickAgentsIntervention = memo<BuiltinInterventionProps<ShowAgentMarketplac
       data: allTemplates = EMPTY_TEMPLATES,
       isLoading,
       error,
-    } = useSWR(getTemplatesSWRKey(swrLocale), () => fetchAgentTemplates(), {
+    } = useSWR(getAgentTemplatesSWRKey(swrLocale), () => fetchAgentTemplates(), {
       dedupingInterval: 60_000,
       revalidateOnFocus: false,
       shouldRetryOnError: false,

--- a/packages/builtin-tool-web-onboarding/src/agentMarketplace/data/agent-templates.ts
+++ b/packages/builtin-tool-web-onboarding/src/agentMarketplace/data/agent-templates.ts
@@ -36,6 +36,9 @@ export type AgentTemplateFetcher = (
   options?: FetchAgentTemplatesOptions,
 ) => Promise<AgentTemplate[]>;
 
+export const getAgentTemplatesSWRKey = (locale?: string) =>
+  `builtin-tool-web-onboarding/agent-marketplace/onboarding-templates/${locale ?? 'default'}`;
+
 const defaultFetcher: AgentTemplateFetcher = async () => {
   throw new Error(
     '[AgentMarketplace] Agent templates fetcher is not configured. ' +

--- a/packages/builtin-tool-web-onboarding/src/agentMarketplace/index.ts
+++ b/packages/builtin-tool-web-onboarding/src/agentMarketplace/index.ts
@@ -2,6 +2,7 @@ export {
   type AgentTemplateFetcher,
   fetchAgentTemplates,
   type FetchAgentTemplatesOptions,
+  getAgentTemplatesSWRKey,
   getTemplatesByCategories,
   getTemplatesByCategoryPriority,
   normalizeAgentTemplate,

--- a/src/features/Onboarding/Agent/index.tsx
+++ b/src/features/Onboarding/Agent/index.tsx
@@ -15,6 +15,7 @@ import { useNavigate } from 'react-router-dom';
 import Loading from '@/components/Loading/BrandTextLoading';
 import { ONBOARDING_PRODUCTION_DEFAULT_MODEL } from '@/const/onboarding';
 import ModeSwitch from '@/features/Onboarding/components/ModeSwitch';
+import { useOnboardingAgentTemplates } from '@/hooks/useOnboardingAgentTemplates';
 import { useClientDataSWR, useOnlyFetchOnceSWR } from '@/libs/swr';
 import OnboardingContainer from '@/routes/onboarding/_layout';
 import { fetchOnboardingAgentTemplates } from '@/services/agentMarketplace';
@@ -116,6 +117,8 @@ const AgentOnboardingPage = memo(() => {
 
   const viewingHistoricalTopic =
     !!activeTopicId && !!effectiveTopicId && effectiveTopicId !== activeTopicId;
+
+  useOnboardingAgentTemplates(!onboardingFinished && !viewingHistoricalTopic);
 
   const onboardingChatKey = useMemo(
     () => messageMapKey({ agentId: onboardingAgentId || '', topicId: effectiveTopicId }),

--- a/src/features/Onboarding/Classic/index.test.tsx
+++ b/src/features/Onboarding/Classic/index.test.tsx
@@ -28,6 +28,10 @@ vi.mock('@/features/Onboarding/components/ModeSwitch', () => ({
   default: () => <div>ModeSwitch</div>,
 }));
 
+vi.mock('@/hooks/useOnboardingAgentTemplates', () => ({
+  useOnboardingAgentTemplates: vi.fn(),
+}));
+
 vi.mock('@/routes/onboarding/_layout', () => ({
   default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));

--- a/src/features/Onboarding/Classic/index.tsx
+++ b/src/features/Onboarding/Classic/index.tsx
@@ -8,6 +8,7 @@ import { Navigate, useNavigate } from 'react-router-dom';
 import Loading from '@/components/Loading/BrandTextLoading';
 import ModeSwitch from '@/features/Onboarding/components/ModeSwitch';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { useOnboardingAgentTemplates } from '@/hooks/useOnboardingAgentTemplates';
 import OnboardingContainer from '@/routes/onboarding/_layout';
 import AgentPickerStep from '@/routes/onboarding/features/AgentPickerStep';
 import FullNameStep from '@/routes/onboarding/features/FullNameStep';
@@ -40,6 +41,8 @@ const ClassicOnboardingPage = memo(() => {
   const enableKlavis = useServerConfigStore(serverConfigSelectors.enableKlavis);
   const serverConfigInit = useServerConfigStore((s) => s.serverConfigInit);
   const shouldSkipProSettingsStep = serverConfigInit && !enableKlavis;
+
+  useOnboardingAgentTemplates(isUserStateInit && commonStepsCompleted);
 
   // FullNameStep is the branch's first step, so its back button leaves the
   // branch and re-enters the shared prefix's ResponseLanguageStep (step 2).

--- a/src/features/Onboarding/Common/index.test.tsx
+++ b/src/features/Onboarding/Common/index.test.tsx
@@ -40,6 +40,9 @@ const renderCommon = async ({
   vi.doMock('@/components/Loading/BrandTextLoading', () => ({
     default: ({ debugId }: { debugId: string }) => <div>Loading:{debugId}</div>,
   }));
+  vi.doMock('@/hooks/useOnboardingAgentTemplates', () => ({
+    useOnboardingAgentTemplates: vi.fn(),
+  }));
   vi.doMock('@/routes/onboarding/_layout', () => ({
     default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   }));
@@ -108,6 +111,7 @@ afterEach(() => {
   vi.doUnmock('@lobechat/const');
   vi.doUnmock('@lobehub/ui');
   vi.doUnmock('@/components/Loading/BrandTextLoading');
+  vi.doUnmock('@/hooks/useOnboardingAgentTemplates');
   vi.doUnmock('@/routes/onboarding/_layout');
   vi.doUnmock('@/routes/onboarding/features/TelemetryStep');
   vi.doUnmock('@/routes/onboarding/features/ResponseLanguageStep');

--- a/src/features/Onboarding/Common/index.tsx
+++ b/src/features/Onboarding/Common/index.tsx
@@ -7,6 +7,7 @@ import { memo, useCallback, useEffect, useRef } from 'react';
 import { Navigate, useSearchParams } from 'react-router-dom';
 
 import Loading from '@/components/Loading/BrandTextLoading';
+import { useOnboardingAgentTemplates } from '@/hooks/useOnboardingAgentTemplates';
 import OnboardingContainer from '@/routes/onboarding/_layout';
 import { deriveOnboardingBranchPath } from '@/routes/onboarding/branch';
 import ResponseLanguageStep from '@/routes/onboarding/features/ResponseLanguageStep';
@@ -41,6 +42,8 @@ const CommonOnboardingPage = memo(() => {
   const [searchParams, setSearchParams] = useSearchParams();
   const step: 1 | 2 = searchParams.get('step') === '2' ? 2 : 1;
   const hasStepParam = searchParams.has('step');
+
+  useOnboardingAgentTemplates(isUserStateInit && (!commonStepsCompleted || hasStepParam));
 
   // One-time legacy migration: when the user lands on the shared prefix, if
   // their persisted `currentStep` was authored under the old 5-step schema,

--- a/src/hooks/useOnboardingAgentTemplates.ts
+++ b/src/hooks/useOnboardingAgentTemplates.ts
@@ -1,0 +1,22 @@
+import { getAgentTemplatesSWRKey } from '@lobechat/builtin-tool-web-onboarding/agentMarketplace';
+import { useTranslation } from 'react-i18next';
+import useSWR from 'swr';
+
+import { fetchOnboardingAgentTemplates } from '@/services/agentMarketplace';
+
+const agentTemplatesSWRConfig = {
+  dedupingInterval: 60_000,
+  revalidateOnFocus: false,
+  shouldRetryOnError: false,
+};
+
+export const useOnboardingAgentTemplates = (enabled = true) => {
+  const { i18n } = useTranslation();
+  const swrLocale = i18n.resolvedLanguage || i18n.language;
+
+  return useSWR(
+    enabled ? getAgentTemplatesSWRKey(swrLocale) : null,
+    () => fetchOnboardingAgentTemplates(),
+    agentTemplatesSWRConfig,
+  );
+};

--- a/src/routes/onboarding/features/AgentPickerStep/index.tsx
+++ b/src/routes/onboarding/features/AgentPickerStep/index.tsx
@@ -1,19 +1,18 @@
 'use client';
 
-import {
-  type AgentTemplate,
-  getTemplatesByCategoryPriority,
-  type MarketplaceCategory,
+import type {
+  AgentTemplate,
+  MarketplaceCategory,
 } from '@lobechat/builtin-tool-web-onboarding/agentMarketplace';
+import { getTemplatesByCategoryPriority } from '@lobechat/builtin-tool-web-onboarding/agentMarketplace';
 import { Button, Flexbox, Text } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { Undo2Icon } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import useSWR from 'swr';
 
-import { fetchOnboardingAgentTemplates } from '@/services/agentMarketplace';
+import { useOnboardingAgentTemplates } from '@/hooks/useOnboardingAgentTemplates';
 import { installMarketplaceAgents } from '@/services/installMarketplaceAgents';
 import {
   trackOnboardingMarketplacePicked,
@@ -36,7 +35,7 @@ interface AgentPickerStepProps {
 const EMPTY_TEMPLATES: AgentTemplate[] = [];
 
 const AgentPickerStep = memo<AgentPickerStepProps>(({ onBack }) => {
-  const { t, i18n } = useTranslation('onboarding');
+  const { t } = useTranslation('onboarding');
   const { t: tTool } = useTranslation('tool');
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -47,17 +46,8 @@ const AgentPickerStep = memo<AgentPickerStepProps>(({ onBack }) => {
 
   const categoryHints = useMemo(() => interestsToCategoryHints(interests), [interests]);
   const [requestId] = useState(() => Math.random().toString(36).slice(2));
-  const swrLocale = i18n.resolvedLanguage || i18n.language;
 
-  const {
-    data: allTemplates = EMPTY_TEMPLATES,
-    error,
-    isLoading,
-  } = useSWR(
-    ['onboarding-agent-picker-templates', swrLocale],
-    () => fetchOnboardingAgentTemplates(),
-    { dedupingInterval: 60_000, revalidateOnFocus: false, shouldRetryOnError: false },
-  );
+  const { data: allTemplates = EMPTY_TEMPLATES, error, isLoading } = useOnboardingAgentTemplates();
 
   const orderedTemplates = useMemo(
     () => getTemplatesByCategoryPriority(allTemplates, categoryHints),


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No related issue found.

#### 🔀 Description of Change

- Add a shared onboarding agent templates SWR hook with a shared cache key.
- Reuse the shared key between the classic onboarding picker and the agent marketplace intervention.
- Prefetch onboarding agent templates during common, classic, and agent onboarding stages so the picker can reuse warmed data.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

- `git diff --check`
- `bunx vitest run --silent='passed-only' src/routes/onboarding/features/AgentPickerStep/index.test.tsx src/features/Onboarding/Classic/index.test.tsx src/features/Onboarding/Common/index.test.tsx src/services/agentMarketplace.test.ts`
- `bunx vitest run --silent='passed-only' src/agentMarketplace/data/agent-templates.test.ts` from `packages/builtin-tool-web-onboarding`

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

This change only warms the read-only onboarding agent template request earlier; it does not alter picker selection, install, skip, or onboarding completion behavior.