### PR TITLE
✅ test: guard classic onboarding model removal

### DIFF
--- a/src/routes/onboarding/features/ProSettingsStep.test.tsx
+++ b/src/routes/onboarding/features/ProSettingsStep.test.tsx
@@ -29,9 +29,14 @@ vi.mock('react-i18next', () => ({
           back: 'Back',
           next: 'Next',
           'proSettings.connectors.title': 'Connect Your Favorite Tools',
+          'proSettings.model.title': 'Default Model Used by the Agent',
         } as Record<string, string>
       )[key] ?? key,
   }),
+}));
+
+vi.mock('@/features/ModelSelect', () => ({
+  default: () => <div>ModelSelect</div>,
 }));
 
 vi.mock('@/routes/onboarding/components/LobeMessage', () => ({
@@ -52,6 +57,13 @@ describe('ProSettingsStep', () => {
 
     expect(screen.getAllByText('Connect Your Favorite Tools')).toHaveLength(1);
     expect(screen.getByText('KlavisServerList')).toBeInTheDocument();
+  });
+
+  it('does not allow configuring the default agent model during classic onboarding', () => {
+    render(<ProSettingsStep onBack={vi.fn()} onNext={vi.fn()} />);
+
+    expect(screen.queryByText('Default Model Used by the Agent')).not.toBeInTheDocument();
+    expect(screen.queryByText('ModelSelect')).not.toBeInTheDocument();
   });
 
   it('calls the provided navigation handlers', () => {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-9300

#### 🔀 Description of Change

Adds regression coverage for the classic onboarding advanced step so it cannot reintroduce default model configuration. The current component only renders the connector setup surface; this test explicitly fails if the default model title or `ModelSelect` appears again.

#### 🧪 How to Test

```bash
bunx vitest run --silent='passed-only' 'src/routes/onboarding/features/ProSettingsStep.test.tsx'
```

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

N/A. Test-only guard.

#### 📝 Additional Information

The product code path already no longer renders the model selector on `canary`; this PR locks that behavior with a focused regression test.