### PR TITLE
🐛 fix: hetero agent cloud credential alert flash and width misalignment

### DIFF
--- a/src/business/client/hooks/useHeteroAgentCloudConfig.ts
+++ b/src/business/client/hooks/useHeteroAgentCloudConfig.ts
@@ -28,9 +28,10 @@ export const useHeteroAgentCloudConfig = (): HeteroAgentCloudConfig => {
   const needsCredCheck = !isDesktop && isClaudeCode;
 
   // Only fetch credentials when actually needed
-  const { data: credsData } = lambdaQuery.market.creds.list.useQuery(undefined, {
-    enabled: needsCredCheck,
-  });
+  const { data: credsData, isLoading: isCredsLoading } = lambdaQuery.market.creds.list.useQuery(
+    undefined,
+    { enabled: needsCredCheck },
+  );
 
   // isConfigured is true when:
   // 1. Running on desktop (local execution, no cloud creds needed), or
@@ -39,9 +40,14 @@ export const useHeteroAgentCloudConfig = (): HeteroAgentCloudConfig => {
   // 4. The agent env has a CLAUDE_CODE_CRED_KEY reference set, or
   // 5. The CLAUDE_CODE_OAUTH_TOKEN credential actually exists in the vault
   //    (handles the case where the credential was saved but the env ref wasn't written)
+  // 6. Credentials are still loading — treat as configured to avoid a flash of the
+  //    "not configured" alert that immediately disappears once the query resolves
   const hasCredInVault = (credsData?.data ?? []).some((c) => c.key === CLAUDE_TOKEN_CRED_KEY);
   const isConfigured =
-    !needsCredCheck || !!heterogeneousProvider?.env?.CLAUDE_CODE_CRED_KEY || hasCredInVault;
+    !needsCredCheck ||
+    !!heterogeneousProvider?.env?.CLAUDE_CODE_CRED_KEY ||
+    hasCredInVault ||
+    isCredsLoading;
 
   const goToConfig = () => {
     const agentId = params.aid;

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { useHeteroAgentCloudConfig } from '@/business/client/hooks/useHeteroAgentCloudConfig';
 import { type ActionKeys } from '@/features/ChatInput';
 import { ChatInput } from '@/features/Conversation';
+import WideScreenContainer from '@/features/WideScreenContainer';
 import { useChatStore } from '@/store/chat';
 
 import WorkingDirectoryBar from './WorkingDirectoryBar';
@@ -34,20 +35,22 @@ const HeterogeneousChatInput = memo(() => {
   return (
     <Flexbox>
       {!isConfigured && (
-        <Flexbox paddingBlock={'0 6px'} paddingInline={12}>
-          <Alert
-            type={'warning'}
-            title={t('heteroAgent.cloudNotConfigured.title')}
-            description={
-              <Flexbox horizontal align={'center'} justify={'space-between'} gap={8}>
-                <span>{t('heteroAgent.cloudNotConfigured.desc')}</span>
-                <Button size={'small'} type={'primary'} onClick={goToConfig}>
-                  {t('heteroAgent.cloudNotConfigured.action')}
-                </Button>
-              </Flexbox>
-            }
-          />
-        </Flexbox>
+        <WideScreenContainer>
+          <Flexbox paddingBlock={'0 6px'} paddingInline={12}>
+            <Alert
+              type={'warning'}
+              title={t('heteroAgent.cloudNotConfigured.title')}
+              description={
+                <Flexbox horizontal align={'center'} justify={'space-between'} gap={8}>
+                  <span>{t('heteroAgent.cloudNotConfigured.desc')}</span>
+                  <Button size={'small'} type={'primary'} onClick={goToConfig}>
+                    {t('heteroAgent.cloudNotConfigured.action')}
+                  </Button>
+                </Flexbox>
+              }
+            />
+          </Flexbox>
+        </WideScreenContainer>
       )}
       <ChatInput
         skipScrollMarginWithList


### PR DESCRIPTION
## 问题

在异构 Agent（如 Claude Code）的对话页面，「需要配置云端凭证」Alert 存在两个问题：

1. **闪烁问题**：凭证已配置时，初始渲染仍短暂显示 Alert，等查询完成后立即消失，造成明显的闪烁
2. **宽度问题**：Alert 比下方输入框更宽，两者无法对齐

## 根因

- **闪烁**：`useHeteroAgentCloudConfig` 中，`credsData` 初始为 `undefined`（TRPC 查询未完成），导致 `hasCredInVault = false`，`isConfigured = false`，Alert 瞬间显示；查询完成后再隐藏
- **宽度**：`ChatInput` 内部用 `WideScreenContainer`（含 `paddingInline={16}`）约束内容宽度；Alert 却在外层裸 `Flexbox` 里，缺少这层约束，导致宽度不一致

## 修复

- `useHeteroAgentCloudConfig`：将 `isCredsLoading` 纳入 `isConfigured` 判断 — 查询进行中时视为"已配置"，避免 flash
- `HeterogeneousChatInput`：用 `WideScreenContainer` 包裹 Alert，使其宽度约束与输入框一致

## Test plan

- [ ] 已配置云端凭证时，打开 Claude Code Agent 对话页，Alert 不应出现（无闪烁）
- [ ] 未配置云端凭证时，Alert 正常显示且宽度与输入框对齐
- [ ] 宽屏模式下，Alert 与输入框同步居中缩放

🤖 Generated with [Claude Code](https://claude.com/claude-code)