### PR TITLE
🐛 fix: prevent scrollbar from overlapping ScrollArea content

### DIFF
--- a/package.json
+++ b/package.json
@@ -281,7 +281,7 @@
     "@lobehub/icons": "^5.0.0",
     "@lobehub/market-sdk": "0.33.3",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.14.0",
+    "@lobehub/ui": "^5.14.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@napi-rs/canvas": "^0.1.88",
     "@neondatabase/serverless": "^1.0.2",

--- a/src/components/StreamingMarkdown/index.tsx
+++ b/src/components/StreamingMarkdown/index.tsx
@@ -41,6 +41,7 @@ const StreamingMarkdown = memo<StreamingMarkdownProps>(({ children, maxHeight = 
 
   return (
     <ScrollArea
+      disableContentFit
       scrollFade
       className={styles.scrollRoot}
       contentProps={{

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
@@ -90,6 +90,7 @@ const ContentBlocksScroll = memo<ContentBlocksScrollProps>((props) => {
 
   return (
     <ScrollArea
+      disableContentFit
       scrollFade
       className={styles.scrollRoot}
       contentProps={{
@@ -99,6 +100,12 @@ const ContentBlocksScroll = memo<ContentBlocksScrollProps>((props) => {
           fontSize: 'inherit',
           gap: 0,
           lineHeight: 'inherit',
+          paddingInlineEnd: 12,
+        },
+      }}
+      scrollbarProps={{
+        style: {
+          marginInlineEnd: 2,
         },
       }}
       viewportProps={{

--- a/src/features/Conversation/components/Thinking/index.tsx
+++ b/src/features/Conversation/components/Thinking/index.tsx
@@ -62,6 +62,7 @@ const Thinking = memo<ThinkingProps>((props) => {
         title={<Title duration={duration} showDetail={showDetail} thinking={thinking} />}
       >
         <ScrollArea
+          disableContentFit
           scrollFade
           className={styles.scrollRoot}
           contentProps={{


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The base-ui `ScrollArea` renders the vertical scrollbar as an absolute overlay on top of the viewport. In `ContentBlocksScroll`, the content extended all the way to the right edge of the root, so the scrollbar visually overlapped the content (e.g. text and copy buttons in tool-call blocks were partly hidden behind the bar).

Changes:

- Bump `@lobehub/ui` to `5.14.1` and add `disableContentFit` to the `ScrollArea` usages in `ContentBlocksScroll`, `StreamingMarkdown`, and `Thinking` so the viewport content can shrink instead of being clipped.
- In `ContentBlocksScroll`, add `paddingInlineEnd: 12` on the content so the scrollbar no longer covers it, and tighten `scrollbarProps.marginInlineEnd` to `2` so the bar sits closer to the right edge.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Trigger a long assistant tool-call list (e.g. document creation tool) so the inner workflow/task scroller overflows, then verify the scrollbar floats just inside the right edge without covering text, badges, or copy buttons.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Scrollbar overlaps content on the right edge | Scrollbar hugs the right edge, content reserves space for it |

#### 📝 Additional Information

No breaking changes — purely a visual/layout fix in the assistant content block scroller.