### PR TITLE
✨ feat(chat-input): add installed skills to slash menu with mid-line trigger

### DIFF
--- a/src/features/ChatInput/InputEditor/ActionTag/ActionTag.tsx
+++ b/src/features/ChatInput/InputEditor/ActionTag/ActionTag.tsx
@@ -25,7 +25,7 @@ const ActionTag = memo<ActionTagProps>(({ node, editor, label }) => {
   }, [editor, onClick]);
 
   return (
-    <span ref={spanRef}>
+    <span ref={spanRef} style={{ verticalAlign: -3 }}>
       <ActionMention category={node.actionCategory} label={label} />
     </span>
   );

--- a/src/features/ChatInput/InputEditor/ActionTag/useSlashActionItems.ts
+++ b/src/features/ChatInput/InputEditor/ActionTag/useSlashActionItems.ts
@@ -5,7 +5,7 @@ import { SkillsIcon } from '@lobehub/ui/icons';
 import Fuse from 'fuse.js';
 import { $getSelection, $isRangeSelection } from 'lexical';
 import { ArchiveIcon, MessageSquarePlusIcon } from 'lucide-react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useClientDataSWR } from '@/libs/swr';
@@ -19,6 +19,7 @@ import { useAgentId } from '../../hooks/useAgentId';
 import { useChatInputStore } from '../../store';
 import { INSERT_ACTION_TAG_COMMAND, type InsertActionTagPayload } from './command';
 import { type ActionTagData, BUILTIN_COMMANDS } from './types';
+import { useInstalledSkillsAndTools } from './useInstalledSkillsAndTools';
 
 type SlashItem = NonNullable<SlashOptions['items'] extends (infer U)[] ? U : never>;
 
@@ -59,6 +60,14 @@ export const useSlashActionItems = (): SlashOptions['items'] => {
     { revalidateOnFocus: false, shouldRetryOnError: false },
   );
   const projectSkills = projectSkillsData?.skills;
+
+  // Installed skills shared with the @ mention menu (builtin / lobehub / market / user agent skills).
+  // Tools intentionally stay out of slash — they remain @-mention only.
+  const installedSkillsAndTools = useInstalledSkillsAndTools();
+  const installedSkills = useMemo(
+    () => installedSkillsAndTools.filter((item) => item.category === 'skill'),
+    [installedSkillsAndTools],
+  );
 
   return useCallback(
     async (
@@ -102,32 +111,68 @@ export const useSlashActionItems = (): SlashOptions['items'] => {
         },
       });
 
-      // All action tags are line-start only for now
+      const makeSkillItem = (skill: ActionTagData): SlashMenuOption => ({
+        icon: SkillsIcon,
+        key: `skill-${skill.type}`,
+        label: skill.label,
+        metadata: { category: 'skill', type: skill.type },
+        onSelect: (editor: IEditor) => {
+          const payload: InsertActionTagPayload = {
+            category: 'skill',
+            label: skill.label,
+            type: skill.type,
+          };
+          editor.dispatchCommand(INSERT_ACTION_TAG_COMMAND, payload);
+        },
+      });
+
+      // Trigger position:
+      //   - line-start  → commands + installed skills + project skills
+      //   - mid-line w/ preceding whitespace → installed skills + project skills only (no commands)
+      //   - otherwise (e.g. inside http://, a/b) → menu suppressed
       let isAtLineStart = search === null;
+      let isMidLineAfterWhitespace = false;
       if (!isAtLineStart && editorInstance) {
         const lexicalEditor = editorInstance.getLexicalEditor();
         if (lexicalEditor) {
           lexicalEditor.getEditorState().read(() => {
             const selection = $getSelection();
-            if ($isRangeSelection(selection)) {
-              const node = selection.anchor.getNode();
-              const topElement = node.getTopLevelElement();
-              if (topElement) {
-                const paragraphText = topElement.getTextContent();
-                const triggerAndSearch = '/' + (search?.matchingString || '');
-                isAtLineStart = paragraphText === triggerAndSearch;
-              }
+            if (!$isRangeSelection(selection)) return;
+            const node = selection.anchor.getNode();
+            const topElement = node.getTopLevelElement();
+            if (!topElement) return;
+
+            const paragraphText = topElement.getTextContent();
+            const triggerAndSearch = '/' + (search?.matchingString || '');
+
+            if (paragraphText === triggerAndSearch) {
+              isAtLineStart = true;
+              return;
+            }
+
+            const triggerIndex = paragraphText.lastIndexOf(triggerAndSearch);
+            if (triggerIndex === 0) {
+              isAtLineStart = true;
+            } else if (triggerIndex > 0 && /\s/.test(paragraphText[triggerIndex - 1])) {
+              isMidLineAfterWhitespace = true;
             }
           });
         }
       }
 
-      if (!isAtLineStart) return [];
+      if (!isAtLineStart && !isMidLineAfterWhitespace) return [];
 
-      // Built-in commands (filter newTopic when no active topic)
-      for (const action of BUILTIN_COMMANDS) {
-        if (action.type === 'newTopic' && !activeTopicId) continue;
-        allItems.push(makeCommandItem(action) as SlashItem);
+      // Built-in commands — line-start only
+      if (isAtLineStart) {
+        for (const action of BUILTIN_COMMANDS) {
+          if (action.type === 'newTopic' && !activeTopicId) continue;
+          allItems.push(makeCommandItem(action) as SlashItem);
+        }
+      }
+
+      // Installed skills — shown in both positions
+      for (const skill of installedSkills) {
+        allItems.push(makeSkillItem(skill) as SlashItem);
       }
 
       // Hetero-agent project skills (file-system based, resolved by the CLI agent itself)
@@ -145,6 +190,6 @@ export const useSlashActionItems = (): SlashOptions['items'] => {
 
       return allItems;
     },
-    [t, editorInstance, activeTopicId, projectSkills],
+    [t, editorInstance, activeTopicId, projectSkills, installedSkills],
   );
 };


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Fixes LOBE-7296

#### 🔀 Description of Change

Brings installed skills into the chat input slash (`/`) menu, alongside built-in commands and hetero-agent project skills, and lets `/` trigger mid-line (not just at line start).

**Changes**

- `useSlashActionItems.ts`
  - Surface installed skills (builtin / lobehub / market / user agent) by reusing `useInstalledSkillsAndTools` and filtering `category === 'skill'`. Installed tools intentionally stay `@`-mention only.
  - Skill selection dispatches `INSERT_ACTION_TAG_COMMAND` with `category: 'skill'`, identical to the `@` mention path — same serialization, no behavioral drift.
  - Position detector expanded to three states:
    - **Line-start** → commands + installed skills + project skills
    - **Mid-line w/ preceding whitespace** → installed skills + project skills (no commands)
    - **Otherwise** (e.g. inside `http://`, `a/b`) → menu suppressed
- `ActionTag.tsx`
  - Add `verticalAlign: -3` to the chip wrapper so the tag aligns with the surrounding text baseline.

**Not changed**

- `@` mention Skills / Tools categories are preserved — slash and `@` coexist.
- Installed tools remain `@`-mention only.
- `INSERT_ACTION_TAG_COMMAND` implementation and `ActionTag` node rendering are untouched.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Open the chat input.
2. Type `/` at the start of a line — verify commands (`compact`, `newTopic`), installed skills, and project skills (hetero only) all appear.
3. Type some text, then a space, then `/` — verify only installed skills (+ project skills) show, no commands.
4. Type `http://` or `a/b` — verify the slash menu does not pop.
5. Select an installed skill from the slash menu — verify it inserts the same `ActionTag` chip as choosing it from `@`.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Slash only at line-start; only built-in commands + project skills | Slash works mid-line after whitespace; installed skills available in both positions |

#### 📝 Additional Information

No breaking changes. No migration needed. Performance: installed skills list is memoized from the existing store selector shared with the `@` mention menu.