### PR TITLE
🔨 chore: add DeepSeek payload diagnostics

### DIFF
--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
@@ -222,12 +222,37 @@ describe('createAnthropicCompatibleRuntime', () => {
         message0ContentSerializedLength: 8002,
         message0ContentType: 'string',
         model: 'deepseek-v4-pro',
-        snippetEnd: 7400,
-        snippetStart: 6900,
+        reportedColumn: 7160,
+        reportedLine: 1,
+        request: {
+          maxTokens: 1024,
+          metadataUserId: 'user_target',
+          model: 'deepseek-v4-pro',
+          stream: true,
+        },
+        snippetEnd: 7409,
+        snippetStart: 6909,
         traceId: 'trace-1',
         trigger: 'bot',
         userId: 'user_target',
       });
+      expect(summary.messageSummaries[0]).toMatchObject({
+        containsColumn: true,
+        content: {
+          kind: 'string',
+          serializedLength: 8002,
+          textLength: 8000,
+        },
+        index: 0,
+        role: 'user',
+      });
+      expect(summary.payloadKeys).toEqual([
+        'max_tokens',
+        'messages',
+        'model',
+        'stream',
+        'metadata',
+      ]);
       expect(summary.payloadLength).toBeGreaterThan(7400);
       expect(summary.snippet).toHaveLength(500);
     } finally {

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.test.ts
@@ -19,6 +19,8 @@ vi.mock('@lobechat/const', () => ({
 
 const MockedAnthropic = vi.mocked(Anthropic);
 const originalAnthropicClientTimeout = process.env.ANTHROPIC_CLIENT_TIMEOUT;
+const originalDeepSeekAnthropicPayloadLogUserId =
+  process.env.DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_USER_ID;
 
 afterEach(() => {
   if (originalAnthropicClientTimeout === undefined) {
@@ -26,7 +28,44 @@ afterEach(() => {
   } else {
     process.env.ANTHROPIC_CLIENT_TIMEOUT = originalAnthropicClientTimeout;
   }
+
+  if (originalDeepSeekAnthropicPayloadLogUserId === undefined) {
+    delete process.env.DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_USER_ID;
+  } else {
+    process.env.DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_USER_ID = originalDeepSeekAnthropicPayloadLogUserId;
+  }
 });
+
+const createDeepSeekAnthropicJsonParseRuntime = () => {
+  const apiError = Object.assign(
+    new Error(
+      '400 Failed to parse the request body as JSON: messages[0].content: unexpected end of hex escape at line 1 column 7160',
+    ),
+    { status: 400 },
+  );
+  const messagesCreate = vi.fn().mockRejectedValue(apiError);
+  const createClient = vi.fn(
+    (options) =>
+      ({
+        baseURL: options.baseURL,
+        messages: { create: messagesCreate },
+      }) as unknown as Anthropic,
+  );
+  const Runtime = createAnthropicCompatibleRuntime({
+    baseURL: 'https://api.deepseek.com/anthropic',
+    chatCompletion: {
+      handlePayload: () => ({
+        max_tokens: 1024,
+        messages: [{ content: 'x'.repeat(8000), role: 'user' }],
+        model: 'deepseek-v4-pro',
+      }),
+    },
+    customClient: { createClient },
+    provider: 'deepseek',
+  });
+
+  return new Runtime({ apiKey: 'test-key' });
+};
 
 describe('createDefaultAnthropicClient', () => {
   it('should include User-Agent header with current version', () => {
@@ -156,5 +195,89 @@ describe('createAnthropicCompatibleRuntime', () => {
       }),
     );
     expect(runtime.baseURL).toBe('https://aihubmix.com');
+  });
+
+  it('should log a scoped payload summary for DeepSeek Anthropic JSON parse errors', async () => {
+    process.env.DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_USER_ID = 'user_target';
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const runtime = createDeepSeekAnthropicJsonParseRuntime();
+
+    try {
+      await expect(
+        runtime.chat({ messages: [], model: 'deepseek-v4-pro', provider: 'deepseek' } as any, {
+          metadata: { traceId: 'trace-1', trigger: 'bot' },
+          user: 'user_target',
+        }),
+      ).rejects.toBeDefined();
+
+      const logCall = logSpy.mock.calls.find(
+        ([label]) => label === '[deepseekAnthropicPayloadParseError]',
+      );
+      const summary = JSON.parse(logCall?.[1] as string);
+
+      expect(summary).toMatchObject({
+        column: 7160,
+        errorStatus: 400,
+        message0ContentSerializedLength: 8002,
+        message0ContentType: 'string',
+        model: 'deepseek-v4-pro',
+        snippetEnd: 7400,
+        snippetStart: 6900,
+        traceId: 'trace-1',
+        trigger: 'bot',
+        userId: 'user_target',
+      });
+      expect(summary.payloadLength).toBeGreaterThan(7400);
+      expect(summary.snippet).toHaveLength(500);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('should skip DeepSeek Anthropic payload summary when the target user env is not configured', async () => {
+    delete process.env.DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_USER_ID;
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const runtime = createDeepSeekAnthropicJsonParseRuntime();
+
+    try {
+      await expect(
+        runtime.chat({ messages: [], model: 'deepseek-v4-pro', provider: 'deepseek' } as any, {
+          metadata: { traceId: 'trace-1', trigger: 'bot' },
+          user: 'user_target',
+        }),
+      ).rejects.toBeDefined();
+
+      expect(logSpy).not.toHaveBeenCalledWith(
+        '[deepseekAnthropicPayloadParseError]',
+        expect.any(String),
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it('should skip DeepSeek Anthropic payload summary for other users', async () => {
+    process.env.DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_USER_ID = 'user_target';
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const runtime = createDeepSeekAnthropicJsonParseRuntime();
+
+    try {
+      await expect(
+        runtime.chat({ messages: [], model: 'deepseek-v4-pro', provider: 'deepseek' } as any, {
+          metadata: { traceId: 'trace-1', trigger: 'bot' },
+          user: 'user_other',
+        }),
+      ).rejects.toBeDefined();
+
+      expect(logSpy).not.toHaveBeenCalledWith(
+        '[deepseekAnthropicPayloadParseError]',
+        expect.any(String),
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 });

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -45,11 +45,13 @@ type AnthropicTools = Anthropic.Tool | Anthropic.WebSearchTool20250305;
 
 export const DEFAULT_ANTHROPIC_BASE_URL = 'https://api.anthropic.com';
 const ANTHROPIC_CLIENT_TIMEOUT_ENV = 'ANTHROPIC_CLIENT_TIMEOUT';
-const DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_COLUMN = 7160;
+const DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_DEFAULT_COLUMN = 7160;
+const DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_MESSAGE_LIMIT = 30;
 const DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_MODEL = 'deepseek-v4-pro';
-const DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_SNIPPET_END = 7400;
-const DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_SNIPPET_START = 6900;
+const DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_SNIPPET_RADIUS = 250;
+const DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_TOOL_LIMIT = 30;
 const DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_USER_ID_ENV = 'DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_USER_ID';
+const ERROR_LOCATION_PATTERN = /line\s+(\d+)\s+column\s+(\d+)/i;
 /**
  * Keep Anthropic SDK's timeout explicit so non-streaming structured output
  * calls with large max_tokens do not hit the SDK's long-request guard before
@@ -97,6 +99,15 @@ const getErrorStatus = (error: unknown) => {
   return typeof status === 'number' || typeof status === 'string' ? status : undefined;
 };
 
+const getJSONSerializedLength = (value: unknown) => {
+  try {
+    const serialized = JSON.stringify(value);
+    return typeof serialized === 'string' ? serialized.length : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 const isDeepSeekAnthropicPayloadParseError = (error: unknown) => {
   const message = getErrorMessage(error);
 
@@ -111,6 +122,121 @@ const shouldLogDeepSeekAnthropicPayloadForUser = (requestUserId: string | undefi
 
   return !!targetUserId && requestUserId === targetUserId;
 };
+
+const parseErrorLocation = (error: unknown) => {
+  const match = ERROR_LOCATION_PATTERN.exec(getErrorMessage(error));
+  if (!match) return;
+
+  const line = Number(match[1]);
+  const column = Number(match[2]);
+
+  return Number.isInteger(line) && Number.isInteger(column) ? { column, line } : undefined;
+};
+
+const buildSerializedSnippet = (serializedPayload: string, column: number) => {
+  const columnIndex = Math.max(0, column - 1);
+  const snippetStart = Math.max(0, columnIndex - DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_SNIPPET_RADIUS);
+  const snippetEnd = Math.min(
+    serializedPayload.length,
+    columnIndex + DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_SNIPPET_RADIUS,
+  );
+  const columnChar = serializedPayload.charAt(columnIndex);
+
+  return {
+    columnChar: columnChar || undefined,
+    columnCharCode: columnChar ? columnChar.codePointAt(0) : undefined,
+    snippet: serializedPayload.slice(snippetStart, snippetEnd),
+    snippetEnd,
+    snippetStart,
+  };
+};
+
+const summarizeContentBlock = (block: unknown) => {
+  const record = getErrorRecord(block);
+  const input = record?.input;
+
+  return {
+    id: typeof record?.id === 'string' ? record.id : undefined,
+    inputSerializedLength: input === undefined ? undefined : getJSONSerializedLength(input),
+    name: typeof record?.name === 'string' ? record.name : undefined,
+    textLength: typeof record?.text === 'string' ? record.text.length : undefined,
+    thinkingLength: typeof record?.thinking === 'string' ? record.thinking.length : undefined,
+    type: typeof record?.type === 'string' ? record.type : undefined,
+  };
+};
+
+const summarizeContent = (content: unknown) => ({
+  blocks: Array.isArray(content) ? content.slice(0, 20).map(summarizeContentBlock) : undefined,
+  blocksCount: Array.isArray(content) ? content.length : undefined,
+  kind: getValueKind(content),
+  serializedLength: getJSONSerializedLength(content),
+  textLength: typeof content === 'string' ? content.length : undefined,
+});
+
+const buildSerializedRanges = (items: unknown[], serializedPayload: string) => {
+  let searchStart = 0;
+
+  return items.map((item) => {
+    const serializedItem = JSON.stringify(item);
+    const start = serializedPayload.indexOf(serializedItem, searchStart);
+
+    if (start === -1) {
+      return {
+        serializedEnd: undefined,
+        serializedLength: serializedItem.length,
+        serializedStart: undefined,
+      };
+    }
+
+    const end = start + serializedItem.length;
+    searchStart = end;
+
+    return {
+      serializedEnd: end,
+      serializedLength: serializedItem.length,
+      serializedStart: start,
+    };
+  });
+};
+
+const summarizeMessages = (
+  messages: Anthropic.MessageCreateParams['messages'],
+  serializedPayload: string,
+  column: number,
+) => {
+  const ranges = buildSerializedRanges(messages, serializedPayload);
+  const columnIndex = Math.max(0, column - 1);
+
+  return messages.slice(0, DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_MESSAGE_LIMIT).map((message, index) => {
+    const record = getErrorRecord(message);
+    const content = record?.content;
+    const range = ranges[index];
+
+    return {
+      containsColumn:
+        range.serializedStart !== undefined &&
+        range.serializedEnd !== undefined &&
+        columnIndex >= range.serializedStart &&
+        columnIndex < range.serializedEnd,
+      content: summarizeContent(content),
+      index,
+      role: typeof record?.role === 'string' ? record.role : undefined,
+      serializedEnd: range.serializedEnd,
+      serializedLength: range.serializedLength,
+      serializedStart: range.serializedStart,
+    };
+  });
+};
+
+const summarizeTools = (tools: Anthropic.MessageCreateParams['tools']) =>
+  tools?.slice(0, DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_TOOL_LIMIT).map((tool) => {
+    const record = getErrorRecord(tool);
+    return {
+      name: typeof record?.name === 'string' ? record.name : undefined,
+      serializedLength: getJSONSerializedLength(tool),
+      type: typeof record?.type === 'string' ? record.type : undefined,
+    };
+  });
 
 const logDeepSeekAnthropicPayloadParseError = ({
   baseURL,
@@ -141,9 +267,14 @@ const logDeepSeekAnthropicPayloadParseError = ({
   }
 
   const serializedPayload = JSON.stringify(requestPayload);
+  const reportedLocation = parseErrorLocation(error);
+  const column = reportedLocation?.column ?? DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_DEFAULT_COLUMN;
   const firstMessageContent = requestPayload.messages.at(0)?.content;
   const serializedFirstMessageContent = JSON.stringify(firstMessageContent ?? '');
-  const columnChar = serializedPayload.charAt(DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_COLUMN - 1);
+  const { columnChar, columnCharCode, snippet, snippetStart, snippetEnd } = buildSerializedSnippet(
+    serializedPayload,
+    column,
+  );
 
   // Temporary diagnostic for DeepSeek's Anthropic endpoint JSON parser failure.
   // eslint-disable-next-line no-console
@@ -151,9 +282,9 @@ const logDeepSeekAnthropicPayloadParseError = ({
     '[deepseekAnthropicPayloadParseError]',
     JSON.stringify({
       baseURL: desensitizeUrl(baseURL),
-      column: DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_COLUMN,
+      column,
       columnChar: columnChar || undefined,
-      columnCharCode: columnChar ? columnChar.codePointAt(0) : undefined,
+      columnCharCode,
       errorMessage: getErrorMessage(error),
       errorStatus: getErrorStatus(error),
       message0ContentBlocks: Array.isArray(firstMessageContent)
@@ -161,18 +292,32 @@ const logDeepSeekAnthropicPayloadParseError = ({
         : undefined,
       message0ContentSerializedLength: serializedFirstMessageContent.length,
       message0ContentType: getValueKind(firstMessageContent),
+      messageSummaries: summarizeMessages(requestPayload.messages, serializedPayload, column),
       messagesCount: requestPayload.messages.length,
       model: payload.model,
+      payloadKeys: Object.keys(requestPayload),
       payloadLength: serializedPayload.length,
-      snippet: serializedPayload.slice(
-        DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_SNIPPET_START,
-        DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_SNIPPET_END,
-      ),
-      snippetEnd: DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_SNIPPET_END,
-      snippetStart: DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_SNIPPET_START,
+      reportedColumn: reportedLocation?.column,
+      reportedLine: reportedLocation?.line,
+      request: {
+        maxTokens: requestPayload.max_tokens,
+        metadataUserId: requestPayload.metadata?.user_id,
+        model: requestPayload.model,
+        outputConfig: requestPayload.output_config,
+        stream: requestPayload.stream,
+        temperature: requestPayload.temperature,
+        thinking: requestPayload.thinking,
+        topP: requestPayload.top_p,
+      },
+      snippet,
+      snippetEnd,
+      snippetStart,
+      system: summarizeContent(requestPayload.system),
       systemSerializedLength: JSON.stringify(requestPayload.system ?? '').length,
       thinking: requestPayload.thinking,
+      tools: summarizeTools(requestPayload.tools),
       toolsCount: requestPayload.tools?.length ?? 0,
+      topicId: getMetadataString(metadata, 'topicId'),
       traceId: getMetadataString(metadata, 'traceId'),
       trigger: getMetadataString(metadata, 'trigger'),
       userId: requestUserId,

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -45,6 +45,11 @@ type AnthropicTools = Anthropic.Tool | Anthropic.WebSearchTool20250305;
 
 export const DEFAULT_ANTHROPIC_BASE_URL = 'https://api.anthropic.com';
 const ANTHROPIC_CLIENT_TIMEOUT_ENV = 'ANTHROPIC_CLIENT_TIMEOUT';
+const DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_COLUMN = 7160;
+const DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_MODEL = 'deepseek-v4-pro';
+const DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_SNIPPET_END = 7400;
+const DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_SNIPPET_START = 6900;
+const DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_USER_ID_ENV = 'DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_USER_ID';
 /**
  * Keep Anthropic SDK's timeout explicit so non-streaming structured output
  * calls with large max_tokens do not hit the SDK's long-request guard before
@@ -56,6 +61,124 @@ const ANTHROPIC_SDK_MESSAGES_PATH_PATTERN = /\/v1(?:\/messages)?\/?$/;
 
 const normalizeAnthropicCompatibleBaseURL = (baseURL?: string | null) =>
   baseURL?.replace(ANTHROPIC_SDK_MESSAGES_PATH_PATTERN, '');
+
+const isOfficialDeepSeekAnthropicBaseURL = (baseURL: string) => {
+  try {
+    const url = new URL(baseURL);
+    return url.hostname === 'api.deepseek.com' && url.pathname.replace(/\/$/, '') === '/anthropic';
+  } catch {
+    return baseURL.includes('api.deepseek.com/anthropic');
+  }
+};
+
+const getValueKind = (value: unknown) => {
+  if (Array.isArray(value)) return 'array';
+  if (value === null) return 'null';
+  return typeof value;
+};
+
+const getMetadataString = (metadata: Record<string, unknown> | undefined, key: string) => {
+  const value = metadata?.[key];
+  return typeof value === 'string' ? value : undefined;
+};
+
+const getErrorRecord = (error: unknown) =>
+  typeof error === 'object' && error !== null ? (error as Record<PropertyKey, unknown>) : undefined;
+
+const getErrorMessage = (error: unknown) => {
+  if (error instanceof Error) return error.message;
+
+  const message = getErrorRecord(error)?.message;
+  return typeof message === 'string' ? message : String(error);
+};
+
+const getErrorStatus = (error: unknown) => {
+  const status = getErrorRecord(error)?.status;
+  return typeof status === 'number' || typeof status === 'string' ? status : undefined;
+};
+
+const isDeepSeekAnthropicPayloadParseError = (error: unknown) => {
+  const message = getErrorMessage(error);
+
+  return (
+    message.includes('Failed to parse the request body as JSON') ||
+    message.includes('unexpected end of hex escape')
+  );
+};
+
+const shouldLogDeepSeekAnthropicPayloadForUser = (requestUserId: string | undefined) => {
+  const targetUserId = process.env[DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_USER_ID_ENV]?.trim();
+
+  return !!targetUserId && requestUserId === targetUserId;
+};
+
+const logDeepSeekAnthropicPayloadParseError = ({
+  baseURL,
+  error,
+  metadata,
+  payload,
+  provider,
+  requestPayload,
+  requestUserId,
+}: {
+  baseURL: string;
+  error: unknown;
+  metadata: Record<string, unknown> | undefined;
+  payload: ChatStreamPayload;
+  provider: string;
+  requestPayload: Anthropic.MessageCreateParams;
+  requestUserId: string | undefined;
+}) => {
+  if (
+    provider !== 'deepseek' ||
+    payload.model !== DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_MODEL ||
+    !shouldLogDeepSeekAnthropicPayloadForUser(requestUserId) ||
+    getMetadataString(metadata, 'trigger') !== 'bot' ||
+    !isOfficialDeepSeekAnthropicBaseURL(baseURL) ||
+    !isDeepSeekAnthropicPayloadParseError(error)
+  ) {
+    return;
+  }
+
+  const serializedPayload = JSON.stringify(requestPayload);
+  const firstMessageContent = requestPayload.messages.at(0)?.content;
+  const serializedFirstMessageContent = JSON.stringify(firstMessageContent ?? '');
+  const columnChar = serializedPayload.charAt(DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_COLUMN - 1);
+
+  // Temporary diagnostic for DeepSeek's Anthropic endpoint JSON parser failure.
+  // eslint-disable-next-line no-console
+  console.log(
+    '[deepseekAnthropicPayloadParseError]',
+    JSON.stringify({
+      baseURL: desensitizeUrl(baseURL),
+      column: DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_COLUMN,
+      columnChar: columnChar || undefined,
+      columnCharCode: columnChar ? columnChar.codePointAt(0) : undefined,
+      errorMessage: getErrorMessage(error),
+      errorStatus: getErrorStatus(error),
+      message0ContentBlocks: Array.isArray(firstMessageContent)
+        ? firstMessageContent.length
+        : undefined,
+      message0ContentSerializedLength: serializedFirstMessageContent.length,
+      message0ContentType: getValueKind(firstMessageContent),
+      messagesCount: requestPayload.messages.length,
+      model: payload.model,
+      payloadLength: serializedPayload.length,
+      snippet: serializedPayload.slice(
+        DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_SNIPPET_START,
+        DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_SNIPPET_END,
+      ),
+      snippetEnd: DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_SNIPPET_END,
+      snippetStart: DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_SNIPPET_START,
+      systemSerializedLength: JSON.stringify(requestPayload.system ?? '').length,
+      thinking: requestPayload.thinking,
+      toolsCount: requestPayload.tools?.length ?? 0,
+      traceId: getMetadataString(metadata, 'traceId'),
+      trigger: getMetadataString(metadata, 'trigger'),
+      userId: requestUserId,
+    }),
+  );
+};
 
 const resolveDefaultAnthropicTimeout = () => {
   const timeout = Number(process.env[ANTHROPIC_CLIENT_TIMEOUT_ENV]);
@@ -485,8 +608,7 @@ export const createAnthropicCompatibleRuntime = <T extends Record<string, any> =
         baseURL: finalBaseURL,
         ...constructorOptions,
         ...rest,
-        timeout:
-          rest.timeout ?? constructorOptions?.timeout ?? resolveDefaultAnthropicTimeout(),
+        timeout: rest.timeout ?? constructorOptions?.timeout ?? resolveDefaultAnthropicTimeout(),
       };
 
       if (customClient?.createClient) {
@@ -501,6 +623,14 @@ export const createAnthropicCompatibleRuntime = <T extends Record<string, any> =
     }
 
     async chat(payload: ChatStreamPayload, options?: ChatMethodOptions) {
+      let deepSeekAnthropicPayloadParseErrorContext:
+        | {
+            metadata: Record<string, unknown> | undefined;
+            requestPayload: Anthropic.MessageCreateParams;
+            requestUserId: string | undefined;
+          }
+        | undefined;
+
       try {
         if (!chatCompletion?.handlePayload) {
           throw new Error('Anthropic-compatible runtime requires chatCompletion.handlePayload');
@@ -514,6 +644,15 @@ export const createAnthropicCompatibleRuntime = <T extends Record<string, any> =
         const postPayload = await chatCompletion.handlePayload(payload, this._options);
         const shouldStream = postPayload.stream ?? payload.stream ?? true;
         const finalPayload = { ...postPayload, stream: shouldStream };
+        const requestPayload = {
+          ...finalPayload,
+          metadata: options?.user ? { user_id: options.user } : undefined,
+        };
+        deepSeekAnthropicPayloadParseErrorContext = {
+          metadata: options?.metadata,
+          requestPayload,
+          requestUserId: options?.user,
+        };
 
         if (debugParams?.chatCompletion?.()) {
           // eslint-disable-next-line no-console
@@ -522,16 +661,10 @@ export const createAnthropicCompatibleRuntime = <T extends Record<string, any> =
           console.log(JSON.stringify(finalPayload), '\n');
         }
 
-        const response = await this.client.messages.create(
-          {
-            ...finalPayload,
-            metadata: options?.user ? { user_id: options.user } : undefined,
-          },
-          {
-            headers: options?.requestHeaders,
-            signal: options?.signal,
-          },
-        );
+        const response = await this.client.messages.create(requestPayload, {
+          headers: options?.requestHeaders,
+          signal: options?.signal,
+        });
 
         const pricing = await getModelPricing(payload.model, this.id);
         const pricingOptions = await chatCompletion?.getPricingOptions?.(payload, postPayload);
@@ -655,6 +788,18 @@ export const createAnthropicCompatibleRuntime = <T extends Record<string, any> =
           },
         );
       } catch (error) {
+        if (deepSeekAnthropicPayloadParseErrorContext) {
+          logDeepSeekAnthropicPayloadParseError({
+            baseURL: this.baseURL,
+            error,
+            metadata: deepSeekAnthropicPayloadParseErrorContext.metadata,
+            payload,
+            provider,
+            requestPayload: deepSeekAnthropicPayloadParseErrorContext.requestPayload,
+            requestUserId: deepSeekAnthropicPayloadParseErrorContext.requestUserId,
+          });
+        }
+
         throw this.handleError(error);
       }
     }


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

Related to DeepSeek Anthropic-compatible payload parse diagnostics.

#### 🔀 Description of Change

- Add an env-gated diagnostic log for DeepSeek Anthropic-compatible JSON parse failures.
- Keep the diagnostic disabled unless `DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_USER_ID` is configured.
- Scope the log to the configured user, `deepseek-v4-pro`, bot trigger, and the official DeepSeek Anthropic endpoint.
- Collect enough structured context in one pass to avoid follow-up instrumentation:
  - reported error line/column parsed from the provider message
  - serialized payload length, top-level keys, and dynamic snippet around the reported column
  - request model/max_tokens/stream/sampling/thinking metadata
  - system length and summary
  - tool count and tool name/type/serialized-length summary
  - message count plus per-message role, content kind, content length, block summaries, serialized ranges, and whether the reported column lands in that message
  - trace/topic/trigger/user metadata

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/model-runtime
bunx vitest run --silent='passed-only' 'src/core/anthropicCompatibleFactory/index.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This is disabled by default. Set `DEEPSEEK_ANTHROPIC_PAYLOAD_LOG_USER_ID` to the target user id only during temporary diagnostics. The code does not hardcode user ids or trace ids.