### PR TITLE
🐛 fix: handle deprecated runtime models

### DIFF
--- a/packages/model-runtime/src/providers/baichuan/index.test.ts
+++ b/packages/model-runtime/src/providers/baichuan/index.test.ts
@@ -247,6 +247,16 @@ describe('LobeBaichuanAI - custom features', () => {
       expect(calledPayload.max_tokens).toBe(500);
       expect(calledPayload.top_p).toBe(0.95);
     });
+
+    it('should not send budget_tokens when thinking budget is not provided', () => {
+      const result = params.chatCompletion!.handlePayload!({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'Baichuan-M2',
+        thinking: {},
+      } as any);
+
+      expect(result).not.toHaveProperty('budget_tokens');
+    });
   });
 
   describe('models', () => {

--- a/packages/model-runtime/src/providers/baichuan/index.ts
+++ b/packages/model-runtime/src/providers/baichuan/index.ts
@@ -45,11 +45,9 @@ export const params = {
           frequency_penalty: undefined,
           presence_penalty: undefined,
         }),
-        ...(thinking && {
+        ...(thinking?.budget_tokens !== undefined && {
           budget_tokens:
-            thinking?.budget_tokens === 0
-              ? 0
-              : Math.min(thinking?.budget_tokens, 1024) || undefined,
+            thinking.budget_tokens === 0 ? 0 : Math.min(thinking.budget_tokens, 1024) || undefined,
         }),
       } as any;
     },

--- a/packages/model-runtime/src/providers/wenxin/index.test.ts
+++ b/packages/model-runtime/src/providers/wenxin/index.test.ts
@@ -294,5 +294,17 @@ describe('LobeWenxinAI - Custom Features', () => {
       expect(result.enable_thinking).toBeUndefined();
       expect(result.thinking_budget).toBe(2048);
     });
+
+    it('should not send thinking_budget when thinking budget is not provided', () => {
+      const payload = {
+        messages: [{ role: 'user', content: 'Hello' }],
+        model: 'deepseek-r1-250528',
+        thinking: {},
+      };
+
+      const result = params.chatCompletion!.handlePayload!(payload as any);
+
+      expect(result.thinking_budget).toBeUndefined();
+    });
   });
 });

--- a/packages/model-runtime/src/providers/wenxin/index.ts
+++ b/packages/model-runtime/src/providers/wenxin/index.ts
@@ -28,8 +28,9 @@ export const params = {
         }),
         ...(thinking && {
           enable_thinking: thinking.type ? thinking.type !== 'disabled' : undefined,
-          ...(thinking?.budget_tokens !== 0 && {
-            thinking_budget: Math.min(Math.max(thinking?.budget_tokens, 100), 16_384),
+          ...(thinking.budget_tokens !== undefined &&
+            thinking.budget_tokens !== 0 && {
+              thinking_budget: Math.min(Math.max(thinking.budget_tokens, 100), 16_384),
           }),
         }),
       } as any;

--- a/src/server/services/systemAgent/modelConfig.test.ts
+++ b/src/server/services/systemAgent/modelConfig.test.ts
@@ -1,45 +1,9 @@
-import { loadModels } from '@lobechat/business-model-bank/model-config';
-import { resolveBusinessModelMapping } from '@lobechat/business-model-runtime';
-import { DEFAULT_SYSTEM_AGENT_CONFIG } from '@lobechat/const';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { resolveSystemAgentModelConfig } from './modelConfig';
 
-const availableModels = [
-  {
-    abilities: {},
-    id: 'deepseek-v4-pro',
-    providerId: 'lobehub',
-    type: 'chat',
-  },
-  {
-    abilities: {},
-    id: 'gpt-5.4-mini',
-    providerId: 'lobehub',
-    type: 'chat',
-  },
-] as Awaited<ReturnType<typeof loadModels>>;
-
-vi.mock('@lobechat/business-model-bank/model-config', () => ({
-  loadModels: vi.fn(async () => availableModels),
-}));
-
-vi.mock('@lobechat/business-model-runtime', () => ({
-  resolveBusinessModelMapping: vi.fn(async (_provider: string, model: string) => ({
-    resolvedModelId: model,
-  })),
-}));
-
 describe('resolveSystemAgentModelConfig', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(loadModels).mockResolvedValue(availableModels);
-    vi.mocked(resolveBusinessModelMapping).mockImplementation(async (_provider, model) => ({
-      resolvedModelId: model,
-    }));
-  });
-
-  it('should keep an available LobeHub chat model when no mapping matches', async () => {
+  it('should keep a configured LobeHub chat model', async () => {
     const result = await resolveSystemAgentModelConfig({
       taskConfig: {
         model: 'deepseek-v4-pro',
@@ -49,32 +13,9 @@ describe('resolveSystemAgentModelConfig', () => {
     });
 
     expect(result).toEqual({ model: 'deepseek-v4-pro', provider: 'lobehub' });
-    expect(resolveBusinessModelMapping).toHaveBeenCalledWith('lobehub', 'deepseek-v4-pro');
   });
 
-  it('should resolve model mapping before checking LobeHub model availability', async () => {
-    vi.mocked(resolveBusinessModelMapping).mockResolvedValue({
-      requestedModelId: 'deepseek-v4-pro',
-      resolvedModelId: 'gpt-5.4-mini',
-    });
-
-    const result = await resolveSystemAgentModelConfig({
-      taskConfig: {
-        model: 'deepseek-v4-pro',
-        provider: 'lobehub',
-      },
-      taskKey: 'topic',
-    });
-
-    expect(result).toEqual({ model: 'gpt-5.4-mini', provider: 'lobehub' });
-  });
-
-  it('should use mapped model id when a LobeHub alias resolves to an available chat model', async () => {
-    vi.mocked(resolveBusinessModelMapping).mockResolvedValue({
-      requestedModelId: 'mapped-topic-model',
-      resolvedModelId: 'deepseek-v4-pro',
-    });
-
+  it('should let runtime hooks resolve LobeHub model mapping', async () => {
     const result = await resolveSystemAgentModelConfig({
       taskConfig: {
         model: 'mapped-topic-model',
@@ -83,10 +24,10 @@ describe('resolveSystemAgentModelConfig', () => {
       taskKey: 'topic',
     });
 
-    expect(result).toEqual({ model: 'deepseek-v4-pro', provider: 'lobehub' });
+    expect(result).toEqual({ model: 'mapped-topic-model', provider: 'lobehub' });
   });
 
-  it('should fall back to task defaults for an unavailable LobeHub chat model', async () => {
+  it('should keep deprecated LobeHub model ids for runtime-level rejection', async () => {
     const result = await resolveSystemAgentModelConfig({
       taskConfig: {
         model: 'ag/gemini-3.1-pro-high',
@@ -95,7 +36,7 @@ describe('resolveSystemAgentModelConfig', () => {
       taskKey: 'topic',
     });
 
-    expect(result).toEqual(DEFAULT_SYSTEM_AGENT_CONFIG.topic);
+    expect(result).toEqual({ model: 'ag/gemini-3.1-pro-high', provider: 'lobehub' });
   });
 
   it('should keep non-LobeHub provider model ids untouched', async () => {
@@ -108,6 +49,5 @@ describe('resolveSystemAgentModelConfig', () => {
     });
 
     expect(result).toEqual({ model: 'private-model', provider: 'openai-compatible' });
-    expect(resolveBusinessModelMapping).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/systemAgent/modelConfig.ts
+++ b/src/server/services/systemAgent/modelConfig.ts
@@ -1,26 +1,11 @@
-import { BRANDING_PROVIDER } from '@lobechat/business-const';
-import { loadModels } from '@lobechat/business-model-bank/model-config';
-import { resolveBusinessModelMapping } from '@lobechat/business-model-runtime';
 import { DEFAULT_SYSTEM_AGENT_CONFIG } from '@lobechat/const';
 import type { SystemAgentItem, UserSystemAgentConfigKey } from '@lobechat/types';
-import { isProviderModelAvailable } from 'model-bank';
 
 interface ResolveSystemAgentModelConfigParams {
   override?: Partial<Pick<SystemAgentItem, 'model' | 'provider'>>;
   taskConfig?: Partial<SystemAgentItem>;
   taskKey: UserSystemAgentConfigKey;
 }
-
-const resolveAvailableLobeHubChatModel = async (model: string): Promise<string | undefined> => {
-  try {
-    const { resolvedModelId } = await resolveBusinessModelMapping(BRANDING_PROVIDER, model);
-
-    if (isProviderModelAvailable(await loadModels(), BRANDING_PROVIDER, resolvedModelId, 'chat'))
-      return resolvedModelId;
-  } catch (error) {
-    console.error('resolveSystemAgentModelConfig failed to resolve model availability:', error);
-  }
-};
 
 export const resolveSystemAgentModelConfig = async ({
   override,
@@ -31,11 +16,5 @@ export const resolveSystemAgentModelConfig = async ({
   const model = override?.model || taskConfig?.model || defaults.model;
   const provider = override?.provider || taskConfig?.provider || defaults.provider;
 
-  if (provider !== BRANDING_PROVIDER) return { model, provider };
-
-  const availableModel = await resolveAvailableLobeHubChatModel(model);
-
-  if (availableModel) return { model: availableModel, provider };
-
-  return { model: defaults.model, provider: defaults.provider };
+  return { model, provider };
 };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - production bugfix without a public issue.

#### 🔀 Description of Change

- Stop system-agent model config from silently falling back when a configured model is unavailable; runtime-level handling should surface the deprecated model error.
- Guard Baichuan and Wenxin thinking budget payload shaping when `thinking.budget_tokens` is absent.
- Add regression coverage for omitted thinking budget payloads and deprecated system-agent model ids.

#### 🧪 How to Test

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Diagnostics were checked from the cloud workspace via VSCode MCP. Local test/type-check commands were not run.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Cloud PR will wire runtime hooks to reject deprecated LobeHub chat/generateObject models before RouterRuntime fallback.
