### PR TITLE
♻️ refactor(agent-document): derive category server-side, drop frontend predicates

### DIFF
--- a/packages/database/src/models/agentDocuments/__tests__/deriveFields.test.ts
+++ b/packages/database/src/models/agentDocuments/__tests__/deriveFields.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveAgentDocumentFields } from '../deriveFields';
+
+describe('deriveAgentDocumentFields', () => {
+  it('categorizes managed skill bundles as skills and marks them as folders', () => {
+    expect(
+      deriveAgentDocumentFields({
+        fileType: 'skills/bundle',
+        sourceType: 'agent-signal',
+        templateId: 'agent-skill',
+      }),
+    ).toEqual({
+      category: 'skill',
+      isFolder: true,
+      isSkillBundle: true,
+      isSkillIndex: false,
+    });
+  });
+
+  it('categorizes SKILL.md index documents as skills (but not as folders)', () => {
+    expect(
+      deriveAgentDocumentFields({
+        fileType: 'skills/index',
+        sourceType: 'agent-signal',
+        templateId: 'agent-skill',
+      }),
+    ).toEqual({
+      category: 'skill',
+      isFolder: false,
+      isSkillBundle: false,
+      isSkillIndex: true,
+    });
+  });
+
+  it('treats any skills/* fileType as a managed skill even without the template id', () => {
+    expect(
+      deriveAgentDocumentFields({
+        fileType: 'skills/bundle',
+        sourceType: 'agent',
+        templateId: null,
+      }).category,
+    ).toBe('skill');
+  });
+
+  it('classifies web-sourced articles as web', () => {
+    expect(
+      deriveAgentDocumentFields({
+        fileType: 'article',
+        sourceType: 'web',
+        templateId: null,
+      }),
+    ).toEqual({
+      category: 'web',
+      isFolder: false,
+      isSkillBundle: false,
+      isSkillIndex: false,
+    });
+  });
+
+  it('marks custom folders as folders without changing the category', () => {
+    expect(
+      deriveAgentDocumentFields({
+        fileType: 'custom/folder',
+        sourceType: 'agent',
+        templateId: null,
+      }),
+    ).toEqual({
+      category: 'document',
+      isFolder: true,
+      isSkillBundle: false,
+      isSkillIndex: false,
+    });
+  });
+
+  it('falls back to document for ordinary file-backed agent documents', () => {
+    expect(
+      deriveAgentDocumentFields({
+        fileType: 'agent/document',
+        sourceType: 'file',
+        templateId: null,
+      }),
+    ).toEqual({
+      category: 'document',
+      isFolder: false,
+      isSkillBundle: false,
+      isSkillIndex: false,
+    });
+  });
+
+  it('prefers the skill classification when sourceType is web but the doc is template-managed', () => {
+    // Defensive: even if a managed skill row ever carried sourceType='web',
+    // the template id should still win over the web bucket.
+    expect(
+      deriveAgentDocumentFields({
+        fileType: 'skills/index',
+        sourceType: 'web',
+        templateId: 'agent-skill',
+      }).category,
+    ).toBe('skill');
+  });
+});

--- a/packages/database/src/models/agentDocuments/agentDocument.ts
+++ b/packages/database/src/models/agentDocuments/agentDocument.ts
@@ -3,6 +3,7 @@ import { and, asc, desc, eq, inArray, isNotNull, isNull } from 'drizzle-orm';
 import type { DocumentItem, NewAgentDocument, NewDocument } from '../../schemas';
 import { agentDocuments, documents } from '../../schemas';
 import type { LobeChatDatabase, Transaction } from '../../type';
+import { deriveAgentDocumentFields } from './deriveFields';
 import { buildDocumentFilename } from './filename';
 import {
   composeToolPolicyUpdate,
@@ -875,6 +876,7 @@ export class AgentDocumentModel {
       const item = this.toAgentDocument(settings, doc);
       return {
         ...item,
+        ...deriveAgentDocumentFields(item),
         loadRules: parseLoadRules(item),
       };
     });
@@ -904,6 +906,7 @@ export class AgentDocumentModel {
       const item = this.toAgentDocument(settings, doc);
       return {
         ...item,
+        ...deriveAgentDocumentFields(item),
         loadRules: parseLoadRules(item),
       };
     });
@@ -944,6 +947,7 @@ export class AgentDocumentModel {
       const item = this.toAgentDocument(settings, doc);
       return {
         ...item,
+        ...deriveAgentDocumentFields(item),
         loadRules: parseLoadRules(item),
       };
     });

--- a/packages/database/src/models/agentDocuments/deriveFields.ts
+++ b/packages/database/src/models/agentDocuments/deriveFields.ts
@@ -1,9 +1,10 @@
+import {
+  AGENT_SKILL_TEMPLATE_ID,
+  DOCUMENT_FOLDER_TYPE,
+  SKILL_BUNDLE_FILE_TYPE,
+  SKILL_INDEX_FILE_TYPE,
+} from '../../schemas/file';
 import type { AgentDocument, AgentDocumentCategory, AgentDocumentDerivedFields } from './types';
-
-const FOLDER_FILE_TYPE = 'custom/folder';
-const SKILL_BUNDLE_FILE_TYPE = 'skills/bundle';
-const SKILL_INDEX_FILE_TYPE = 'skills/index';
-const AGENT_SKILL_TEMPLATE_ID = 'agent-skill';
 
 type DeriveInput = Pick<AgentDocument, 'fileType' | 'sourceType' | 'templateId'>;
 
@@ -21,7 +22,7 @@ export const deriveAgentDocumentFields = (doc: DeriveInput): AgentDocumentDerive
   const isSkillIndex = doc.fileType === SKILL_INDEX_FILE_TYPE;
   return {
     category: deriveCategory(doc),
-    isFolder: doc.fileType === FOLDER_FILE_TYPE || isSkillBundle,
+    isFolder: doc.fileType === DOCUMENT_FOLDER_TYPE || isSkillBundle,
     isSkillBundle,
     isSkillIndex,
   };

--- a/packages/database/src/models/agentDocuments/deriveFields.ts
+++ b/packages/database/src/models/agentDocuments/deriveFields.ts
@@ -1,0 +1,28 @@
+import type { AgentDocument, AgentDocumentCategory, AgentDocumentDerivedFields } from './types';
+
+const FOLDER_FILE_TYPE = 'custom/folder';
+const SKILL_BUNDLE_FILE_TYPE = 'skills/bundle';
+const SKILL_INDEX_FILE_TYPE = 'skills/index';
+const AGENT_SKILL_TEMPLATE_ID = 'agent-skill';
+
+type DeriveInput = Pick<AgentDocument, 'fileType' | 'sourceType' | 'templateId'>;
+
+const isManagedSkill = (doc: DeriveInput): boolean =>
+  doc.templateId === AGENT_SKILL_TEMPLATE_ID || doc.fileType?.startsWith('skills/');
+
+const deriveCategory = (doc: DeriveInput): AgentDocumentCategory => {
+  if (isManagedSkill(doc)) return 'skill';
+  if (doc.sourceType === 'web') return 'web';
+  return 'document';
+};
+
+export const deriveAgentDocumentFields = (doc: DeriveInput): AgentDocumentDerivedFields => {
+  const isSkillBundle = doc.fileType === SKILL_BUNDLE_FILE_TYPE;
+  const isSkillIndex = doc.fileType === SKILL_INDEX_FILE_TYPE;
+  return {
+    category: deriveCategory(doc),
+    isFolder: doc.fileType === FOLDER_FILE_TYPE || isSkillBundle,
+    isSkillBundle,
+    isSkillIndex,
+  };
+};

--- a/packages/database/src/models/agentDocuments/index.ts
+++ b/packages/database/src/models/agentDocuments/index.ts
@@ -1,4 +1,5 @@
 export * from './agentDocument';
+export * from './deriveFields';
 export * from './filename';
 export * from './policy';
 export * from './types';

--- a/packages/database/src/models/agentDocuments/types.ts
+++ b/packages/database/src/models/agentDocuments/types.ts
@@ -24,6 +24,27 @@ export type { AgentDocumentPolicy, DocumentLoadRules } from '@lobechat/agent-tem
 
 export type AgentDocumentSourceType = 'file' | 'web' | 'api' | 'topic' | 'agent' | 'agent-signal';
 
+/**
+ * UI-facing tab grouping for an agent document. Derived from `fileType` +
+ * `sourceType` + `templateId` server-side so the client never has to
+ * categorize itself.
+ */
+export type AgentDocumentCategory = 'skill' | 'document' | 'web';
+
+/**
+ * Fields the server computes from the raw row and attaches to every agent
+ * document response. Keeps UI predicates out of the frontend.
+ */
+export interface AgentDocumentDerivedFields {
+  category: AgentDocumentCategory;
+  /** Folder (`custom/folder`) or skill bundle — anything that can contain children. */
+  isFolder: boolean;
+  /** Top-level skill folder (`fileType === 'skills/bundle'`). */
+  isSkillBundle: boolean;
+  /** The `SKILL.md` index document inside a bundle (`fileType === 'skills/index'`). */
+  isSkillIndex: boolean;
+}
+
 export interface AgentDocument {
   accessPublic: number;
   accessSelf: number;
@@ -56,7 +77,7 @@ export interface AgentDocument {
   userId: string;
 }
 
-export interface AgentDocumentWithRules extends AgentDocument {
+export interface AgentDocumentWithRules extends AgentDocument, AgentDocumentDerivedFields {
   loadRules: DocumentLoadRules;
 }
 

--- a/packages/database/src/schemas/file.ts
+++ b/packages/database/src/schemas/file.ts
@@ -24,6 +24,24 @@ import { users } from './user';
 
 export const DOCUMENT_FOLDER_TYPE = 'custom/folder';
 
+/** File type used by the parent document for a managed skill bundle. */
+export const SKILL_BUNDLE_FILE_TYPE = 'skills/bundle';
+
+/** File type used by the SKILL.md index document inside a managed skill bundle. */
+export const SKILL_INDEX_FILE_TYPE = 'skills/index';
+
+/** Source attribution stored on documents created by skill-management tooling. */
+export const SKILL_MANAGEMENT_SOURCE = 'agent-signal:skill-management';
+
+/** Source type stored on documents created by Agent Signal skill-management tooling. */
+export const SKILL_MANAGEMENT_SOURCE_TYPE = 'agent-signal';
+
+/** Canonical filename for a skill index document. */
+export const SKILL_INDEX_FILENAME = 'SKILL.md';
+
+/** Template id applied to agent document bindings that represent managed skills. */
+export const AGENT_SKILL_TEMPLATE_ID = 'agent-skill';
+
 export const globalFiles = pgTable(
   'global_files',
   {

--- a/packages/model-runtime/src/providers/deepseek/index.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/index.test.ts
@@ -272,7 +272,7 @@ describe('LobeDeepSeekAnthropicAI', () => {
       await instance.generateObject({
         ...generateObjectPayload,
         reasoning_effort: 'high',
-        thinking: { type: 'disabled' },
+        thinking: { budget_tokens: 0, type: 'disabled' },
       });
 
       const payload = getLastRequestPayload();

--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.test.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.test.tsx
@@ -6,12 +6,6 @@ import type { ExplorerTreeNode } from '@/features/ExplorerTree';
 
 import DocumentExplorerTree from './DocumentExplorerTree';
 import type { AgentDocumentItem } from './types';
-import {
-  AGENT_SKILL_TEMPLATE_ID,
-  FOLDER_FILE_TYPE,
-  SKILL_BUNDLE_FILE_TYPE,
-  SKILL_INDEX_FILE_TYPE,
-} from './types';
 
 const { navigate, openDocument, useMatchMock } = vi.hoisted(() => ({
   navigate: vi.fn(),
@@ -141,6 +135,7 @@ const createDocument = (overrides: Partial<AgentDocumentItem>): AgentDocumentIte
     accessSelf: 0,
     accessShared: 0,
     agentId: 'agent-1',
+    category: 'document',
     content: '',
     createdAt: new Date('2026-05-09T00:00:00Z'),
     deletedAt: null,
@@ -153,6 +148,9 @@ const createDocument = (overrides: Partial<AgentDocumentItem>): AgentDocumentIte
     filename: 'document.md',
     fileType: 'custom/document',
     id: 'agent-doc-1',
+    isFolder: false,
+    isSkillBundle: false,
+    isSkillIndex: false,
     loadRules: {},
     metadata: null,
     parentId: null,
@@ -187,27 +185,33 @@ describe('DocumentExplorerTree', () => {
   it('renders managed skill bundle as a folder with SKILL.md underneath', () => {
     const data = [
       createDocument({
+        category: 'skill',
         documentId: 'skill-bundle-doc',
-        fileType: SKILL_BUNDLE_FILE_TYPE,
+        fileType: 'skills/bundle',
         filename: 'youtube-comment-retrieval-workflow',
         id: 'skill-bundle-row',
-        templateId: AGENT_SKILL_TEMPLATE_ID,
+        isFolder: true,
+        isSkillBundle: true,
+        templateId: 'agent-skill',
         title: 'YouTube Comment Retrieval Workflow',
       }),
       createDocument({
+        category: 'skill',
         documentId: 'skill-index-doc',
-        fileType: SKILL_INDEX_FILE_TYPE,
+        fileType: 'skills/index',
         filename: 'SKILL.md',
         id: 'skill-index-row',
+        isSkillIndex: true,
         parentId: 'skill-bundle-doc',
-        templateId: AGENT_SKILL_TEMPLATE_ID,
+        templateId: 'agent-skill',
         title: 'Generated workflow title',
       }),
       createDocument({
         documentId: 'folder-doc',
-        fileType: FOLDER_FILE_TYPE,
+        fileType: 'custom/folder',
         filename: 'Notes',
         id: 'folder-row',
+        isFolder: true,
         title: 'Notes',
       }),
     ];
@@ -229,20 +233,25 @@ describe('DocumentExplorerTree', () => {
   it('opens SKILL.md but does not open the empty skill bundle', () => {
     const data = [
       createDocument({
+        category: 'skill',
         documentId: 'skill-bundle-doc',
-        fileType: SKILL_BUNDLE_FILE_TYPE,
+        fileType: 'skills/bundle',
         filename: 'youtube-comment-retrieval-workflow',
         id: 'skill-bundle-row',
-        templateId: AGENT_SKILL_TEMPLATE_ID,
+        isFolder: true,
+        isSkillBundle: true,
+        templateId: 'agent-skill',
         title: 'YouTube Comment Retrieval Workflow',
       }),
       createDocument({
+        category: 'skill',
         documentId: 'skill-index-doc',
-        fileType: SKILL_INDEX_FILE_TYPE,
+        fileType: 'skills/index',
         filename: 'SKILL.md',
         id: 'skill-index-row',
+        isSkillIndex: true,
         parentId: 'skill-bundle-doc',
-        templateId: AGENT_SKILL_TEMPLATE_ID,
+        templateId: 'agent-skill',
         title: 'SKILL.md',
       }),
     ];
@@ -260,11 +269,14 @@ describe('DocumentExplorerTree', () => {
     const mutate = vi.fn().mockResolvedValue(undefined);
     const data = [
       createDocument({
+        category: 'skill',
         documentId: 'skill-bundle-doc',
-        fileType: SKILL_BUNDLE_FILE_TYPE,
+        fileType: 'skills/bundle',
         filename: 'youtube-comment-retrieval-workflow',
         id: 'skill-bundle-row',
-        templateId: AGENT_SKILL_TEMPLATE_ID,
+        isFolder: true,
+        isSkillBundle: true,
+        templateId: 'agent-skill',
         title: 'YouTube Comment Retrieval Workflow',
       }),
     ];

--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
@@ -18,12 +18,7 @@ import { useChatStore } from '@/store/chat';
 import DocumentExplorerToolbar from './DocumentExplorerToolbar';
 import { useDocumentTreeOps } from './hooks/useDocumentTreeOps';
 import type { AgentDocumentItem } from './types';
-import {
-  isFolderItem,
-  isManagedSkillItem,
-  isOrphanSkillBundleItem,
-  isSkillIndexItem,
-} from './types';
+import { isOrphanSkillBundleItem } from './types';
 import { canDropDocument } from './utils/canDrop';
 
 const PAGE_ROUTE_PATTERN = '/agent/:aid/:topicId/page/:docId?';
@@ -74,7 +69,7 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
     topicId: pageMatch?.params.topicId,
   });
 
-  const documents = useMemo(() => data.filter((doc) => doc.sourceType !== 'web'), [data]);
+  const documents = useMemo(() => data.filter((doc) => doc.category !== 'web'), [data]);
 
   // AgentDocument.parentId references the parent's documentId (FK to documents.id),
   // but ExplorerTree's flat layout expects parentId to point at another node's
@@ -98,8 +93,8 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
       documents.map((doc) => ({
         data: doc,
         id: doc.id,
-        isFolder: isFolderItem(doc),
-        name: isSkillIndexItem(doc) ? SKILL_INDEX_FILENAME : doc.title || doc.filename || '',
+        isFolder: doc.isFolder,
+        name: doc.isSkillIndex ? SKILL_INDEX_FILENAME : doc.title || doc.filename || '',
         parentId: resolveParentRowId(doc.parentId),
       })),
     [documents, resolveParentRowId],
@@ -175,14 +170,12 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
   );
 
   const canDrag = useCallback(
-    (node: ExplorerTreeNode<AgentDocumentItem>) =>
-      !!node.data && node.data.sourceType !== 'web' && !isManagedSkillItem(node.data),
+    (node: ExplorerTreeNode<AgentDocumentItem>) => !!node.data && node.data.category === 'document',
     [],
   );
 
   const canRename = useCallback(
-    (node: ExplorerTreeNode<AgentDocumentItem>) =>
-      !!node.data && node.data.sourceType !== 'web' && !isManagedSkillItem(node.data),
+    (node: ExplorerTreeNode<AgentDocumentItem>) => !!node.data && node.data.category === 'document',
     [],
   );
 
@@ -193,7 +186,8 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
 
   const getContextMenuItems = useCallback(
     (node: ExplorerTreeNode<AgentDocumentItem>): MenuProps['items'] => {
-      if (node.data && isManagedSkillItem(node.data) && !isRecoverableSkillBundle(node.data)) {
+      const isSkill = node.data?.category === 'skill';
+      if (isSkill && !isRecoverableSkillBundle(node.data!)) {
         return [];
       }
 
@@ -202,7 +196,7 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
 
       const items: NonNullable<MenuProps['items']> = [];
 
-      if (isFolder && (!node.data || !isManagedSkillItem(node.data))) {
+      if (isFolder && !isSkill) {
         items.push(
           {
             key: 'new-folder',
@@ -218,7 +212,7 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
         );
       }
 
-      if (!node.data || !isManagedSkillItem(node.data)) {
+      if (!isSkill) {
         items.push({
           key: 'rename',
           label: t('workingPanel.resources.tree.rename'),

--- a/src/features/AgentDocumentsExplorer/hooks/useDocumentTreeOps.ts
+++ b/src/features/AgentDocumentsExplorer/hooks/useDocumentTreeOps.ts
@@ -6,13 +6,7 @@ import type { KeyedMutator } from 'swr';
 import { agentDocumentService } from '@/services/agentDocument';
 
 import type { AgentDocumentItem } from '../types';
-import {
-  FOLDER_FILE_TYPE,
-  isManagedSkillItem,
-  isPendingId,
-  isProtectedManagedSkillItem,
-  isSkillBundleItem,
-} from '../types';
+import { isPendingId, isProtectedManagedSkillItem } from '../types';
 import { makePendingDocument } from '../utils/pendingDocument';
 
 interface UseDocumentTreeOpsArgs {
@@ -108,7 +102,7 @@ export const useDocumentTreeOps = ({
       if (parentRowId === null) return ROOT_PATH;
       const parent = byRowId.get(parentRowId);
       if (!parent) return null;
-      if (isManagedSkillItem(parent)) return null;
+      if (parent.category === 'skill') return null;
       return buildItemPath(parent);
     },
     [byRowId, buildItemPath],
@@ -244,7 +238,7 @@ export const useDocumentTreeOps = ({
     async (id: string, newName: string) => {
       const target = dataRef.current.find((doc) => doc.id === id);
       if (!target) return;
-      if (isManagedSkillItem(target)) return;
+      if (target.category === 'skill') return;
 
       const trimmed = newName.trim();
       if (!trimmed) {
@@ -309,7 +303,7 @@ export const useDocumentTreeOps = ({
       }
 
       const targetItem = targetId ? byRowId.get(targetId) : null;
-      if (targetItem && isSkillBundleItem(targetItem)) return;
+      if (targetItem?.isSkillBundle) return;
 
       const targetParentDocId = targetItem ? targetItem.documentId : null;
 
@@ -317,7 +311,7 @@ export const useDocumentTreeOps = ({
       for (const id of sourceIds) {
         const node = sourceNodes.find((n) => n.data?.id === id)?.data;
         if (!node) continue;
-        if (isManagedSkillItem(node)) return;
+        if (node.category === 'skill') return;
         const fromPath = buildItemPath(node);
         if (!fromPath) continue;
         const toPath = joinPath(targetParentPath, node.filename);
@@ -373,7 +367,10 @@ export const useDocumentTreeOps = ({
         okButtonProps: { danger: true, type: 'primary' },
         okText: t('delete', { ns: 'common' }),
         onOk: () => {
-          const isFolder = target.fileType === FOLDER_FILE_TYPE;
+          // Use isFolder rather than the bundle-inclusive isFolder field —
+          // skill bundles are deleted via the bundle row (single doc), not
+          // via path-based recursive removal.
+          const isFolder = target.isFolder && !target.isSkillBundle;
           const folderPath = isFolder ? buildItemPath(target) : null;
           if (isFolder && folderPath === null) {
             message.error(t('workingPanel.resources.tree.parentMissing'));

--- a/src/features/AgentDocumentsExplorer/index.ts
+++ b/src/features/AgentDocumentsExplorer/index.ts
@@ -1,15 +1,3 @@
 export { default as DocumentExplorerTree } from './DocumentExplorerTree';
 export type { AgentDocumentItem } from './types';
-export {
-  AGENT_SKILL_TEMPLATE_ID,
-  FOLDER_FILE_TYPE,
-  hasSkillIndexChild,
-  isFolderItem,
-  isManagedSkillItem,
-  isOrphanSkillBundleItem,
-  isProtectedManagedSkillItem,
-  isSkillBundleItem,
-  isSkillIndexItem,
-  SKILL_BUNDLE_FILE_TYPE,
-  SKILL_INDEX_FILE_TYPE,
-} from './types';
+export { hasSkillIndexChild, isOrphanSkillBundleItem, isProtectedManagedSkillItem } from './types';

--- a/src/features/AgentDocumentsExplorer/types.test.ts
+++ b/src/features/AgentDocumentsExplorer/types.test.ts
@@ -1,19 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { AgentDocumentItem } from './types';
-import {
-  AGENT_SKILL_TEMPLATE_ID,
-  FOLDER_FILE_TYPE,
-  hasSkillIndexChild,
-  isFolderItem,
-  isManagedSkillItem,
-  isOrphanSkillBundleItem,
-  isProtectedManagedSkillItem,
-  isSkillBundleItem,
-  isSkillIndexItem,
-  SKILL_BUNDLE_FILE_TYPE,
-  SKILL_INDEX_FILE_TYPE,
-} from './types';
+import { hasSkillIndexChild, isOrphanSkillBundleItem, isProtectedManagedSkillItem } from './types';
 
 const createDocument = (overrides: Partial<AgentDocumentItem>): AgentDocumentItem =>
   ({
@@ -21,6 +9,7 @@ const createDocument = (overrides: Partial<AgentDocumentItem>): AgentDocumentIte
     accessSelf: 0,
     accessShared: 0,
     agentId: 'agent-1',
+    category: 'document',
     content: '',
     createdAt: new Date('2026-05-09T00:00:00Z'),
     deletedAt: null,
@@ -33,6 +22,9 @@ const createDocument = (overrides: Partial<AgentDocumentItem>): AgentDocumentIte
     filename: 'document.md',
     fileType: 'custom/document',
     id: 'agent-doc-1',
+    isFolder: false,
+    isSkillBundle: false,
+    isSkillIndex: false,
     loadRules: {},
     metadata: null,
     parentId: null,
@@ -50,50 +42,36 @@ const createDocument = (overrides: Partial<AgentDocumentItem>): AgentDocumentIte
     ...overrides,
   }) as AgentDocumentItem;
 
-describe('AgentDocumentsExplorer types', () => {
-  it('treats managed skill bundles as folders', () => {
-    const bundle = createDocument({
-      fileType: SKILL_BUNDLE_FILE_TYPE,
-      templateId: AGENT_SKILL_TEMPLATE_ID,
-    });
-    const index = createDocument({
-      fileType: SKILL_INDEX_FILE_TYPE,
-      templateId: AGENT_SKILL_TEMPLATE_ID,
-    });
-    const folder = createDocument({ fileType: FOLDER_FILE_TYPE });
+const bundle = createDocument({
+  category: 'skill',
+  documentId: 'bundle-doc',
+  isFolder: true,
+  isSkillBundle: true,
+  templateId: 'agent-skill',
+});
 
-    expect(isSkillBundleItem(bundle)).toBe(true);
-    expect(isFolderItem(bundle)).toBe(true);
-    expect(isSkillIndexItem(index)).toBe(true);
-    expect(isFolderItem(index)).toBe(false);
-    expect(isFolderItem(folder)).toBe(true);
-  });
+const index = createDocument({
+  category: 'skill',
+  documentId: 'index-doc',
+  isSkillIndex: true,
+  parentId: 'bundle-doc',
+  templateId: 'agent-skill',
+});
 
-  it('detects managed skill items by template id or file type', () => {
-    expect(isManagedSkillItem(createDocument({ templateId: AGENT_SKILL_TEMPLATE_ID }))).toBe(true);
-    expect(isManagedSkillItem(createDocument({ fileType: SKILL_INDEX_FILE_TYPE }))).toBe(true);
-    expect(isManagedSkillItem(createDocument({ fileType: 'custom/document' }))).toBe(false);
-  });
-
-  it('treats skill bundles without SKILL.md as recoverable orphan bundles', () => {
-    const bundle = createDocument({
-      documentId: 'bundle-doc',
-      fileType: SKILL_BUNDLE_FILE_TYPE,
-      templateId: AGENT_SKILL_TEMPLATE_ID,
-    });
-    const index = createDocument({
-      documentId: 'index-doc',
-      fileType: SKILL_INDEX_FILE_TYPE,
-      parentId: 'bundle-doc',
-      templateId: AGENT_SKILL_TEMPLATE_ID,
-    });
-
+describe('AgentDocumentsExplorer skill relationship helpers', () => {
+  it('detects whether a skill bundle has a SKILL.md child', () => {
     expect(hasSkillIndexChild([bundle, index], bundle)).toBe(true);
-    expect(isOrphanSkillBundleItem(bundle, [bundle, index])).toBe(false);
-    expect(isProtectedManagedSkillItem(bundle, [bundle, index])).toBe(true);
-
     expect(hasSkillIndexChild([bundle], bundle)).toBe(false);
+  });
+
+  it('marks a skill bundle missing SKILL.md as orphan', () => {
+    expect(isOrphanSkillBundleItem(bundle, [bundle, index])).toBe(false);
     expect(isOrphanSkillBundleItem(bundle, [bundle])).toBe(true);
+  });
+
+  it('protects managed skill items from rename/delete unless orphaned', () => {
+    expect(isProtectedManagedSkillItem(bundle, [bundle, index])).toBe(true);
     expect(isProtectedManagedSkillItem(bundle, [bundle])).toBe(false);
+    expect(isProtectedManagedSkillItem(createDocument({}), [])).toBe(false);
   });
 });

--- a/src/features/AgentDocumentsExplorer/types.ts
+++ b/src/features/AgentDocumentsExplorer/types.ts
@@ -8,38 +8,18 @@ export const PENDING_ID_PREFIX = 'pending:';
 
 export const isPendingId = (id: string): boolean => id.startsWith(PENDING_ID_PREFIX);
 
-export const FOLDER_FILE_TYPE = 'custom/folder';
-export const SKILL_BUNDLE_FILE_TYPE = 'skills/bundle';
-export const SKILL_INDEX_FILE_TYPE = 'skills/index';
-export const AGENT_SKILL_TEMPLATE_ID = 'agent-skill';
-
-type AgentDocumentKindFields = Pick<AgentDocumentItem, 'fileType' | 'templateId'>;
-type AgentDocumentSkillBundleFields = Pick<AgentDocumentItem, 'documentId' | 'fileType'>;
-type AgentDocumentSkillChildFields = Pick<AgentDocumentItem, 'fileType' | 'parentId'>;
-
-export const isSkillBundleItem = (doc: Pick<AgentDocumentItem, 'fileType'>): boolean =>
-  doc.fileType === SKILL_BUNDLE_FILE_TYPE;
-
-export const isSkillIndexItem = (doc: Pick<AgentDocumentItem, 'fileType'>): boolean =>
-  doc.fileType === SKILL_INDEX_FILE_TYPE;
-
-export const isManagedSkillItem = (doc: AgentDocumentKindFields): boolean =>
-  doc.templateId === AGENT_SKILL_TEMPLATE_ID || !!doc.fileType?.startsWith('skills/');
+type SkillBundleRef = Pick<AgentDocumentItem, 'documentId' | 'isSkillBundle'>;
+type SkillChildRef = Pick<AgentDocumentItem, 'isSkillIndex' | 'parentId'>;
 
 export const hasSkillIndexChild = (
-  documents: AgentDocumentSkillChildFields[],
+  documents: SkillChildRef[],
   bundle: Pick<AgentDocumentItem, 'documentId'>,
-): boolean => documents.some((doc) => isSkillIndexItem(doc) && doc.parentId === bundle.documentId);
+): boolean => documents.some((doc) => doc.isSkillIndex && doc.parentId === bundle.documentId);
 
-export const isOrphanSkillBundleItem = (
-  doc: AgentDocumentSkillBundleFields,
-  documents: AgentDocumentSkillChildFields[],
-): boolean => isSkillBundleItem(doc) && !hasSkillIndexChild(documents, doc);
+export const isOrphanSkillBundleItem = (doc: SkillBundleRef, documents: SkillChildRef[]): boolean =>
+  doc.isSkillBundle && !hasSkillIndexChild(documents, doc);
 
 export const isProtectedManagedSkillItem = (
-  doc: AgentDocumentKindFields & Pick<AgentDocumentItem, 'documentId'>,
-  documents: AgentDocumentSkillChildFields[],
-): boolean => isManagedSkillItem(doc) && !isOrphanSkillBundleItem(doc, documents);
-
-export const isFolderItem = (doc: AgentDocumentItem): boolean =>
-  doc.fileType === FOLDER_FILE_TYPE || isSkillBundleItem(doc);
+  doc: Pick<AgentDocumentItem, 'category' | 'documentId' | 'isSkillBundle'>,
+  documents: SkillChildRef[],
+): boolean => doc.category === 'skill' && !isOrphanSkillBundleItem(doc, documents);

--- a/src/features/AgentDocumentsExplorer/utils/canDrop.test.ts
+++ b/src/features/AgentDocumentsExplorer/utils/canDrop.test.ts
@@ -3,12 +3,6 @@ import { describe, expect, it } from 'vitest';
 import type { ExplorerTreeCanDropCtx, ExplorerTreeNode } from '@/features/ExplorerTree';
 
 import type { AgentDocumentItem } from '../types';
-import {
-  AGENT_SKILL_TEMPLATE_ID,
-  FOLDER_FILE_TYPE,
-  SKILL_BUNDLE_FILE_TYPE,
-  SKILL_INDEX_FILE_TYPE,
-} from '../types';
 import { canDropDocument } from './canDrop';
 
 const createDocument = (overrides: Partial<AgentDocumentItem>): AgentDocumentItem =>
@@ -17,6 +11,7 @@ const createDocument = (overrides: Partial<AgentDocumentItem>): AgentDocumentIte
     accessSelf: 0,
     accessShared: 0,
     agentId: 'agent-1',
+    category: 'document',
     content: '',
     createdAt: new Date('2026-05-09T00:00:00Z'),
     deletedAt: null,
@@ -29,6 +24,9 @@ const createDocument = (overrides: Partial<AgentDocumentItem>): AgentDocumentIte
     filename: 'document.md',
     fileType: 'custom/document',
     id: 'agent-doc-1',
+    isFolder: false,
+    isSkillBundle: false,
+    isSkillIndex: false,
     loadRules: {},
     metadata: null,
     parentId: null,
@@ -73,7 +71,12 @@ describe('canDropDocument', () => {
     const source = createNode('doc-row', createDocument({ id: 'doc-row' }));
     const target = createNode(
       'folder-row',
-      createDocument({ fileType: FOLDER_FILE_TYPE, id: 'folder-row', title: 'Folder' }),
+      createDocument({
+        fileType: 'custom/folder',
+        id: 'folder-row',
+        isFolder: true,
+        title: 'Folder',
+      }),
       { isFolder: true },
     );
 
@@ -87,10 +90,13 @@ describe('canDropDocument', () => {
     const target = createNode(
       'skill-row',
       createDocument({
+        category: 'skill',
         documentId: 'skill-bundle-doc',
-        fileType: SKILL_BUNDLE_FILE_TYPE,
+        fileType: 'skills/bundle',
         id: 'skill-row',
-        templateId: AGENT_SKILL_TEMPLATE_ID,
+        isFolder: true,
+        isSkillBundle: true,
+        templateId: 'agent-skill',
         title: 'Research Skill',
       }),
       { isFolder: true },
@@ -105,15 +111,22 @@ describe('canDropDocument', () => {
     const source = createNode(
       'skill-index-row',
       createDocument({
-        fileType: SKILL_INDEX_FILE_TYPE,
+        category: 'skill',
+        fileType: 'skills/index',
         id: 'skill-index-row',
-        templateId: AGENT_SKILL_TEMPLATE_ID,
+        isSkillIndex: true,
+        templateId: 'agent-skill',
         title: 'SKILL.md',
       }),
     );
     const target = createNode(
       'folder-row',
-      createDocument({ fileType: FOLDER_FILE_TYPE, id: 'folder-row', title: 'Folder' }),
+      createDocument({
+        fileType: 'custom/folder',
+        id: 'folder-row',
+        isFolder: true,
+        title: 'Folder',
+      }),
       { isFolder: true },
     );
 

--- a/src/features/AgentDocumentsExplorer/utils/canDrop.ts
+++ b/src/features/AgentDocumentsExplorer/utils/canDrop.ts
@@ -1,7 +1,7 @@
 import type { ExplorerTreeCanDropCtx } from '@/features/ExplorerTree';
 
 import type { AgentDocumentItem } from '../types';
-import { isManagedSkillItem, isPendingId, isSkillBundleItem } from '../types';
+import { isPendingId } from '../types';
 
 interface CanDropArgs {
   ctx: ExplorerTreeCanDropCtx<AgentDocumentItem>;
@@ -27,7 +27,7 @@ export const canDropDocument = ({ ctx, parentMap }: CanDropArgs): boolean => {
 
   // Drop target must be a folder or root
   if (targetNode && !targetNode.isFolder) return false;
-  if (targetNode?.data && isSkillBundleItem(targetNode.data)) return false;
+  if (targetNode?.data?.isSkillBundle) return false;
 
   // Pending targets have no server-side row yet — refuse the drop instead of
   // surfacing an error after the fact.
@@ -47,10 +47,9 @@ export const canDropDocument = ({ ctx, parentMap }: CanDropArgs): boolean => {
       if (isAncestor(sourceId, targetId, parentMap)) return false;
     }
 
-    // Web docs cannot move (not part of tree management)
+    // Web docs and managed skills cannot move (not part of tree management).
     const data = node.data;
-    if (data && data.sourceType === 'web') return false;
-    if (data && isManagedSkillItem(data)) return false;
+    if (data && (data.category === 'web' || data.category === 'skill')) return false;
   }
 
   return true;

--- a/src/features/AgentDocumentsExplorer/utils/pendingDocument.ts
+++ b/src/features/AgentDocumentsExplorer/utils/pendingDocument.ts
@@ -1,6 +1,6 @@
 import { nanoid } from 'nanoid';
 
-import { type AgentDocumentItem, FOLDER_FILE_TYPE, PENDING_ID_PREFIX } from '../types';
+import { type AgentDocumentItem, PENDING_ID_PREFIX } from '../types';
 
 interface MakePendingArgs {
   agentId: string;
@@ -22,6 +22,7 @@ export const makePendingDocument = ({
     accessSelf: 1,
     accessShared: 0,
     agentId,
+    category: 'document',
     content: '',
     createdAt: now,
     deletedAt: null,
@@ -32,8 +33,11 @@ export const makePendingDocument = ({
     documentId: id,
     editorData: null,
     filename: title,
-    fileType: isFolder ? FOLDER_FILE_TYPE : 'custom/document',
+    fileType: isFolder ? 'custom/folder' : 'custom/document',
     id,
+    isFolder,
+    isSkillBundle: false,
+    isSkillIndex: false,
     loadRules: {} as AgentDocumentItem['loadRules'],
     metadata: null,
     parentId,

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx
@@ -138,12 +138,16 @@ vi.mock('@/store/chat/selectors', () => ({
 }));
 
 const skillBundleRow = {
+  category: 'skill',
   createdAt: new Date('2026-05-09T00:00:00Z'),
   description: 'Use for YouTube comments',
   documentId: 'skill-bundle-doc',
   fileType: 'skills/bundle',
   filename: 'youtube-comment-retrieval-workflow',
   id: 'skill-bundle-row',
+  isFolder: true,
+  isSkillBundle: true,
+  isSkillIndex: false,
   parentId: null,
   sourceType: 'agent-signal',
   templateId: 'agent-skill',
@@ -152,12 +156,16 @@ const skillBundleRow = {
 };
 
 const skillIndexRow = {
+  category: 'skill',
   createdAt: new Date('2026-05-09T00:00:00Z'),
   description: 'Use for YouTube comments',
   documentId: 'skill-index-doc',
   fileType: 'skills/index',
   filename: 'SKILL.md',
   id: 'skill-index-row',
+  isFolder: false,
+  isSkillBundle: false,
+  isSkillIndex: true,
   parentId: 'skill-bundle-doc',
   sourceType: 'agent-signal',
   templateId: 'agent-skill',
@@ -166,12 +174,16 @@ const skillIndexRow = {
 };
 
 const fileDocRow = {
+  category: 'document',
   createdAt: new Date('2026-04-16T00:00:00Z'),
   description: 'A short brief',
   documentId: 'doc-content-1',
   fileType: 'agent/document',
   filename: 'brief.md',
   id: 'doc-1',
+  isFolder: false,
+  isSkillBundle: false,
+  isSkillIndex: false,
   parentId: null,
   sourceType: 'file',
   templateId: null,
@@ -180,12 +192,16 @@ const fileDocRow = {
 };
 
 const webDocRow = {
+  category: 'web',
   createdAt: new Date('2026-04-16T00:00:00Z'),
   description: 'Crawled page',
   documentId: 'doc-content-2',
   fileType: 'article',
   filename: 'example.com',
   id: 'doc-2',
+  isFolder: false,
+  isSkillBundle: false,
+  isSkillIndex: false,
   parentId: null,
   sourceType: 'web',
   templateId: null,

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx
@@ -13,12 +13,6 @@ import { useMatch, useNavigate } from 'react-router-dom';
 
 import { DocumentExplorerTree } from '@/features/AgentDocumentsExplorer';
 import SkillsList, { type SkillListItem } from '@/features/AgentDocumentsExplorer/SkillsList';
-import {
-  isFolderItem,
-  isManagedSkillItem,
-  isSkillBundleItem,
-  isSkillIndexItem,
-} from '@/features/AgentDocumentsExplorer/types';
 import { useClientDataSWR } from '@/libs/swr';
 import { agentDocumentService, agentDocumentSWRKeys } from '@/services/agentDocument';
 import { useAgentStore } from '@/store/agent';
@@ -229,27 +223,29 @@ const buildSkillBundleViews = (data: AgentDocumentListItem[]): SkillBundleView[]
     childrenByParent.set(doc.parentId, list);
   }
 
-  return data.filter(isSkillBundleItem).map((bundle) => {
-    const files: string[] = [];
-    const pathToDocumentId = new Map<string, string>();
+  return data
+    .filter((doc) => doc.isSkillBundle)
+    .map((bundle) => {
+      const files: string[] = [];
+      const pathToDocumentId = new Map<string, string>();
 
-    const walk = (parentDocId: string, prefix: string) => {
-      const children = childrenByParent.get(parentDocId) ?? [];
-      for (const child of children) {
-        const name = child.filename || child.title || 'untitled';
-        const relPath = prefix ? `${prefix}/${name}` : name;
-        if (isFolderItem(child)) {
-          walk(child.documentId, relPath);
-        } else {
-          files.push(relPath);
-          pathToDocumentId.set(relPath, child.documentId);
+      const walk = (parentDocId: string, prefix: string) => {
+        const children = childrenByParent.get(parentDocId) ?? [];
+        for (const child of children) {
+          const name = child.filename || child.title || 'untitled';
+          const relPath = prefix ? `${prefix}/${name}` : name;
+          if (child.isFolder) {
+            walk(child.documentId, relPath);
+          } else {
+            files.push(relPath);
+            pathToDocumentId.set(relPath, child.documentId);
+          }
         }
-      }
-    };
-    walk(bundle.documentId, '');
+      };
+      walk(bundle.documentId, '');
 
-    return { bundle, files, pathToDocumentId };
-  });
+      return { bundle, files, pathToDocumentId };
+    });
 };
 
 interface AgentDocumentsGroupProps {
@@ -273,12 +269,9 @@ const AgentDocumentsGroup = memo<AgentDocumentsGroupProps>(({ style }) => {
     agentDocumentService.getDocuments({ agentId: agentId! }),
   );
 
-  const webData = useMemo(() => data.filter((doc) => doc.sourceType === 'web'), [data]);
+  const webData = useMemo(() => data.filter((doc) => doc.category === 'web'), [data]);
 
-  const documentsData = useMemo(
-    () => data.filter((doc) => doc.sourceType !== 'web' && !isManagedSkillItem(doc)),
-    [data],
-  );
+  const documentsData = useMemo(() => data.filter((doc) => doc.category === 'document'), [data]);
 
   const skillBundleViews = useMemo(() => buildSkillBundleViews(data), [data]);
 
@@ -340,7 +333,7 @@ const AgentDocumentsGroup = memo<AgentDocumentsGroupProps>(({ style }) => {
           // Open the SKILL.md (skills/index child) when present; fall back to
           // the bundle itself (orphan bundles surface for recovery).
           const view = skillBundleViews.find((v) => v.bundle.documentId === item.id);
-          const indexChild = data.find((doc) => doc.parentId === item.id && isSkillIndexItem(doc));
+          const indexChild = data.find((doc) => doc.parentId === item.id && doc.isSkillIndex);
           openDocumentByRoute(indexChild?.documentId ?? view?.bundle.documentId ?? item.id);
         }}
       />

--- a/src/server/services/agentDocuments/index.ts
+++ b/src/server/services/agentDocuments/index.ts
@@ -17,6 +17,7 @@ import type {
 import {
   AgentDocumentModel,
   buildDocumentFilename,
+  deriveAgentDocumentFields,
   extractMarkdownH1Title,
 } from '@/database/models/agentDocuments';
 import { TopicDocumentModel } from '@/database/models/topicDocument';
@@ -102,7 +103,12 @@ export class AgentDocumentsService {
   private async projectDocuments<T extends AgentDocument | AgentDocumentWithRules>(
     docs: T[],
   ): Promise<T[]> {
-    return Promise.all(docs.map((doc) => this.projectDocumentContent(doc)));
+    return Promise.all(
+      docs.map(async (doc) => {
+        const projected = await this.projectDocumentContent(doc);
+        return { ...projected, ...deriveAgentDocumentFields(projected) };
+      }),
+    );
   }
 
   private async attachLiteXML(doc: AgentDocument): Promise<AgentDocumentWithLiteXML> {

--- a/src/server/services/skillManagement/constants.ts
+++ b/src/server/services/skillManagement/constants.ts
@@ -1,17 +1,11 @@
-/** File type used by the parent document for a managed skill bundle. */
-export const SKILL_BUNDLE_FILE_TYPE = 'skills/bundle';
-
-/** File type used by the SKILL.md index document inside a managed skill bundle. */
-export const SKILL_INDEX_FILE_TYPE = 'skills/index';
-
-/** Source attribution stored on documents created by skill-management tooling. */
-export const SKILL_MANAGEMENT_SOURCE = 'agent-signal:skill-management';
-
-/** Source type stored on documents created by Agent Signal skill-management tooling. */
-export const SKILL_MANAGEMENT_SOURCE_TYPE = 'agent-signal';
-
-/** Canonical filename for a skill index document. */
-export const SKILL_INDEX_FILENAME = 'SKILL.md';
-
-/** Template id applied to agent document bindings that represent managed skills. */
-export const AGENT_SKILL_TEMPLATE_ID = 'agent-skill';
+// Skill-bundle taxonomy constants live with the database schema (the canonical
+// source of truth for fileType / templateId values) and are re-exported here
+// for legacy import paths.
+export {
+  AGENT_SKILL_TEMPLATE_ID,
+  SKILL_BUNDLE_FILE_TYPE,
+  SKILL_INDEX_FILE_TYPE,
+  SKILL_INDEX_FILENAME,
+  SKILL_MANAGEMENT_SOURCE,
+  SKILL_MANAGEMENT_SOURCE_TYPE,
+} from '@lobechat/database/schemas';


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔀 Description of Change

Server-side now owns the Skills / Documents / Web taxonomy. The TRPC `agentDocument.getDocuments` response (and every other endpoint returning `AgentDocumentWithRules`) carries four computed fields derived from `fileType` + `sourceType` + `templateId`:

```ts
category: 'skill' | 'document' | 'web'
isFolder: boolean        // custom/folder + skill bundles
isSkillBundle: boolean   // fileType === 'skills/bundle'
isSkillIndex: boolean    // fileType === 'skills/index'
```

The new `deriveAgentDocumentFields` helper lives in `packages/database/src/models/agentDocuments/deriveFields.ts` and is invoked once inside `AgentDocumentsService.projectDocuments`, so every endpoint that funnels through it inherits the fields automatically. `AgentDocumentModel.findByAgent` / `findByDocumentIds` / `findByTemplate` also apply it so the model layer's typed return matches.

On the frontend, `src/features/AgentDocumentsExplorer/types.ts` loses the categorization predicates (`isSkillBundleItem`, `isSkillIndexItem`, `isManagedSkillItem`, `isFolderItem`) and the duplicated `FOLDER_FILE_TYPE` / `SKILL_*` / `AGENT_SKILL_TEMPLATE_ID` constants. Only the relationship helpers (`hasSkillIndexChild`, `isOrphanSkillBundleItem`, `isProtectedManagedSkillItem`) stay — they inherently need to scan the whole list — and now read the server flags directly. UI callers (`AgentDocumentsGroup`, `DocumentExplorerTree`, `useDocumentTreeOps`, `canDrop`, `pendingDocument`) switch to the new fields.

#### 🧪 How to Test

- [x] Added/updated tests

Tests in this PR:

- New unit test for `deriveAgentDocumentFields` (7 cases — skill bundle / index / web / folder / document / template-id-only / web+template defensive case)
- Existing model + service + skill router integration tests (84 + 21 + 37) all pass with the projection in place
- Frontend `AgentDocumentsExplorer` test fixtures updated to set derived flags directly (no longer relying on deleted predicates)
- `AgentDocumentsGroup.test.tsx` fixtures updated with `category`/`isFolder`/`isSkillBundle`/`isSkillIndex`; all 11 tests pass

`bun run type-check` clean. Local UI verification limited to "no crash" because the running Electron renderer talks to the cloud `lobe-backend://` endpoint, which won't carry the new fields until this lands. The three tabs render in the expected empty state against the pre-deploy backend; once this ships server-side, the existing skill bundle / document / web data will populate.

#### 📝 Additional Information

Follow-up after #15057 (Skills/Documents/Web tab UI). That PR moved the panel layout; this PR cleans up the data plumbing it sits on top of.