### PR TITLE
🐛 fix: preserve current turn with zero history

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -144,6 +144,16 @@ const resolveLLMMaxRetries = (provider: string) =>
   // again here multiplies the same failed routed request across every channel.
   provider === BRANDING_PROVIDER ? 0 : LLM_MAX_RETRIES;
 
+const resolveRuntimeHistoryCount = (historyCount?: number) => {
+  if (historyCount === undefined) return undefined;
+
+  // Agent config stores historical message count, excluding the current turn.
+  // Runtime executors already pass the current user/tool turn in `llmPayload.messages`;
+  // without this +1, `historyCount: 0` truncates the current message too and sends
+  // `messages: []` to providers.
+  return historyCount + 1;
+};
+
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const getLLMRetryDelayMs = (attempt: number) =>
@@ -652,7 +662,7 @@ export const createRuntimeExecutors = (
           enableHistoryCount: agentConfig.chatConfig?.enableHistoryCount ?? undefined,
           evalContext: ctx.evalContext,
           forceFinish: state.forceFinish,
-          historyCount: agentConfig.chatConfig?.historyCount ?? undefined,
+          historyCount: resolveRuntimeHistoryCount(agentConfig.chatConfig?.historyCount),
           initialContext: (state as any).initialContext?.initialContext,
           knowledge: {
             fileContents: agentConfig.files

--- a/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -1072,6 +1072,46 @@ describe('RuntimeExecutors', () => {
         );
       });
 
+      it('should keep current turn when agent historyCount is 0', async () => {
+        const ctxWithConfig: RuntimeExecutorContext = {
+          ...ctx,
+          agentConfig: {
+            chatConfig: { enableHistoryCount: true, historyCount: 0 },
+            plugins: [],
+          },
+        };
+        const executors = createRuntimeExecutors(ctxWithConfig);
+        const state = createMockState();
+
+        const instruction = {
+          payload: {
+            messages: [
+              { content: 'History message', id: 'history-1', role: 'user' },
+              { content: 'History response', id: 'history-2', role: 'assistant' },
+              { content: 'Current message', id: 'current-1', role: 'user' },
+            ],
+            model: 'gpt-4',
+            provider: 'openai',
+          },
+          type: 'call_llm' as const,
+        };
+
+        await executors.call_llm!(instruction, state);
+
+        expect(engineSpy).toHaveBeenCalledWith(expect.objectContaining({ historyCount: 1 }));
+
+        const chatMessages = mockChat.mock.calls[0][0].messages;
+        expect(chatMessages).toContainEqual(
+          expect.objectContaining({ content: 'Current message', role: 'user' }),
+        );
+        expect(chatMessages).not.toContainEqual(
+          expect.objectContaining({ content: 'History message', role: 'user' }),
+        );
+        expect(chatMessages).not.toContainEqual(
+          expect.objectContaining({ content: 'History response', role: 'assistant' }),
+        );
+      });
+
       it('should not call serverMessagesEngine when agentConfig is not set', async () => {
         const executors = createRuntimeExecutors(ctx); // ctx without agentConfig
         const state = createMockState();


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - production trace reported by maintainer (`a62842e020f2ca08026c8909e739678b`).

#### 🔀 Description of Change

Agent runtime now converts the stored history-message limit into the runtime request limit in the same way as the normal chat path.

When an agent is configured with `enableHistoryCount: true` and `historyCount: 0`, the intent is to drop prior history while still sending the current turn. The server-side agent runtime previously passed `0` directly to the context engine, which truncated every message and could send `messages: []` to providers in bot-triggered runs.

This PR keeps the current user/tool turn by passing `historyCount + 1` into `serverMessagesEngine`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts'
```

#### 📸 Screenshots / Videos

N/A - runtime fix.

#### 📝 Additional Information

Searched recent GitHub issues in both `lobehub/lobehub` and `lobehub-biz/lobehub-cloud`; no matching issue was found for this production trace.
