### PR TITLE
🐛 fix: add signup email review spend locale

### DIFF
--- a/locales/zh-CN/spend.json
+++ b/locales/zh-CN/spend.json
@@ -26,6 +26,7 @@
   "table.columns.trigger.enums.onboarding": "引导流程",
   "table.columns.trigger.enums.openapi": "开放API",
   "table.columns.trigger.enums.semantic_search": "知识搜索",
+  "table.columns.trigger.enums.signup_email_llm_review": "注册邮箱审核",
   "table.columns.trigger.enums.topic": "话题总结",
   "table.columns.trigger.enums.video": "视频生成",
   "table.columns.trigger.enums.visual_analysis": "视觉分析",

--- a/src/locales/default/spend.ts
+++ b/src/locales/default/spend.ts
@@ -26,6 +26,7 @@ export default {
   'table.columns.trigger.enums.onboarding': 'Onboarding',
   'table.columns.trigger.enums.openapi': 'OpenAPI',
   'table.columns.trigger.enums.semantic_search': 'Knowledge Search',
+  'table.columns.trigger.enums.signup_email_llm_review': 'Signup Email Review',
   'table.columns.trigger.enums.topic': 'Topic Summary',
   'table.columns.trigger.enums.visual_analysis': 'Visual Analysis',
   'table.columns.trigger.enums.video': 'Video Generation',


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to lobehub-biz/lobehub-cloud#577

#### 🔀 Description of Change

- Add the missing `spend` locale label for `RequestTrigger.SignupEmailLLMReview`.
- Add the zh-CN preview translation for the same trigger.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Not run: full type-check.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

This fixes the Vercel build failure where the strongly typed `t()` call rejected `table.columns.trigger.enums.signup_email_llm_review` as a missing key.