### PR TITLE
🐛 fix(agent-builder): open panel after blank agent creation

### DIFF
--- a/src/routes/(main)/home/_layout/Body/Agent/ModalProvider.test.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/ModalProvider.test.tsx
@@ -1,0 +1,133 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentModalProvider, useAgentModal } from './ModalProvider';
+
+const mocks = vi.hoisted(() => ({
+  createAgent: vi.fn(),
+  navigate: vi.fn(),
+  refreshAgentList: vi.fn(),
+  sendAsAgent: vi.fn(),
+  sendAsGroup: vi.fn(),
+  toggleAgentBuilderPanel: vi.fn(),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock('@/components/ChatGroupWizard', () => ({
+  ChatGroupWizard: () => null,
+}));
+
+vi.mock('@/components/MemberSelectionModal', () => ({
+  MemberSelectionModal: () => null,
+}));
+
+vi.mock('@/features/EditingPopover', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/routes/(main)/home/_layout/hooks/useCreateModal', () => ({
+  CreateAgentModal: ({
+    open,
+    onCreateBlank,
+  }: {
+    onCreateBlank: () => Promise<void> | void;
+    open: boolean;
+  }) =>
+    open ? (
+      <button type="button" onClick={() => void onCreateBlank()}>
+        Create Blank
+      </button>
+    ) : null,
+}));
+
+vi.mock('@/store/agent', () => ({
+  useAgentStore: (
+    selector: (state: { createAgent: typeof mocks.createAgent; inboxAgentId: string }) => unknown,
+  ) =>
+    selector({
+      createAgent: mocks.createAgent,
+      inboxAgentId: 'inbox-agent',
+    }),
+}));
+
+vi.mock('@/store/agent/selectors', () => ({
+  builtinAgentSelectors: {
+    inboxAgentId: (state: { inboxAgentId: string }) => state.inboxAgentId,
+  },
+}));
+
+vi.mock('@/store/global', () => ({
+  useGlobalStore: {
+    getState: () => ({
+      toggleAgentBuilderPanel: mocks.toggleAgentBuilderPanel,
+    }),
+  },
+}));
+
+vi.mock('@/store/home', () => ({
+  useHomeStore: (
+    selector: (state: {
+      refreshAgentList: typeof mocks.refreshAgentList;
+      sendAsAgent: typeof mocks.sendAsAgent;
+      sendAsGroup: typeof mocks.sendAsGroup;
+    }) => unknown,
+  ) =>
+    selector({
+      refreshAgentList: mocks.refreshAgentList,
+      sendAsAgent: mocks.sendAsAgent,
+      sendAsGroup: mocks.sendAsGroup,
+    }),
+}));
+
+vi.mock('./Modals/ConfigGroupModal', () => ({
+  default: () => null,
+}));
+
+vi.mock('./Modals/CreateGroupModal', () => ({
+  default: () => null,
+}));
+
+const OpenCreateAgentModalButton = () => {
+  const { openCreateModal } = useAgentModal();
+
+  return (
+    <button type="button" onClick={() => openCreateModal('agent')}>
+      Open create agent modal
+    </button>
+  );
+};
+
+const renderProvider = () =>
+  render(
+    <AgentModalProvider>
+      <OpenCreateAgentModalButton />
+    </AgentModalProvider>,
+  );
+
+describe('AgentModalProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createAgent.mockResolvedValue({ agentId: 'agent-new' });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('opens the Agent Builder panel after creating a blank agent', async () => {
+    renderProvider();
+
+    fireEvent.click(screen.getByText('Open create agent modal'));
+    fireEvent.click(screen.getByText('Create Blank'));
+
+    await waitFor(() => {
+      expect(mocks.createAgent).toHaveBeenCalledWith({ groupId: undefined });
+      expect(mocks.toggleAgentBuilderPanel).toHaveBeenCalledWith(true);
+      expect(mocks.navigate).toHaveBeenCalledWith('/agent/agent-new/profile');
+      expect(mocks.refreshAgentList).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/routes/(main)/home/_layout/Body/Agent/ModalProvider.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/ModalProvider.tsx
@@ -10,6 +10,7 @@ import EditingPopover from '@/features/EditingPopover';
 import { CreateAgentModal } from '@/routes/(main)/home/_layout/hooks/useCreateModal';
 import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';
+import { useGlobalStore } from '@/store/global';
 import { useHomeStore } from '@/store/home';
 
 import ConfigGroupModal from './Modals/ConfigGroupModal';
@@ -87,6 +88,7 @@ const CreateModalRenderer = memo<CreateModalRendererProps>(({ open, type, groupI
   const handleCreateBlank = useCallback(async () => {
     if (type === 'agent') {
       const result = await storeCreateAgent({ groupId });
+      useGlobalStore.getState().toggleAgentBuilderPanel(true);
       navigate(`/agent/${result.agentId}/profile`);
       await refreshAgentList();
     } else {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #14978

#### 🔀 Description of Change

- Open the Agent Builder panel after creating a blank agent from the create agent modal.
- Add test coverage for the blank agent creation path in the modal provider.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

\`\`\`bash
bunx vitest run --silent='passed-only' 'src/routes/(main)/home/_layout/Body/Agent/ModalProvider.test.tsx'
bunx prettier --check 'src/routes/(main)/home/_layout/Body/Agent/ModalProvider.tsx' 'src/routes/(main)/home/_layout/Body/Agent/ModalProvider.test.tsx'
git diff --check
\`\`\`

#### 📸 Screenshots / Videos

N/A. Behavior-only change.

#### 📝 Additional Information

\`bun run type-check\` was also attempted and failed on existing unrelated repository errors, including missing \`@lobechat/business-model-bank/model-config\`, existing \`ScrollArea\` prop type mismatches, and unrelated implicit \`any\` errors outside this change.