### PR TITLE
🐛 fix(agent-runtime): inject local-system template vars for regular chat

### DIFF
--- a/src/server/services/aiAgent/__tests__/execAgent.device.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.device.test.ts
@@ -263,7 +263,14 @@ describe('AiAgentService.execAgent - device auto-activation', () => {
   });
 
   describe('Web UI scenario (no botContext/discordContext)', () => {
-    it('should NOT auto-activate even with one device online', async () => {
+    // LOBE-9378: regular chat used to leave activeDeviceId undefined when no
+    // device was bound, which caused the local-system system prompt's
+    // {{workingDirectory}} / {{hostname}} placeholders to reach the LLM as
+    // literals. The model would then waste the first N steps groping for cwd.
+    // Now we auto-activate when exactly one device is online — multi-device
+    // users still need to bind explicitly, since picking one by recency
+    // would be a guess that could route tool calls to the wrong machine.
+    it('should auto-activate the only online device', async () => {
       mockDeviceProxy.isConfigured = true;
       mockDeviceProxy.queryDeviceList.mockResolvedValue([onlineDevice]);
 
@@ -273,6 +280,32 @@ describe('AiAgentService.execAgent - device auto-activation', () => {
       });
 
       expect(mockCreateOperation).toHaveBeenCalled();
+      const createOpArgs = mockCreateOperation.mock.calls[0][0];
+      expect(createOpArgs.activeDeviceId).toBe('device-001');
+    });
+
+    it('should NOT auto-activate when multiple devices are online', async () => {
+      mockDeviceProxy.isConfigured = true;
+      mockDeviceProxy.queryDeviceList.mockResolvedValue([onlineDevice, onlineDevice2]);
+
+      await service.execAgent({
+        agentId: 'agent-1',
+        prompt: 'List my files',
+      });
+
+      const createOpArgs = mockCreateOperation.mock.calls[0][0];
+      expect(createOpArgs.activeDeviceId).toBeUndefined();
+    });
+
+    it('should NOT auto-activate when no devices are online', async () => {
+      mockDeviceProxy.isConfigured = true;
+      mockDeviceProxy.queryDeviceList.mockResolvedValue([]);
+
+      await service.execAgent({
+        agentId: 'agent-1',
+        prompt: 'List my files',
+      });
+
       const createOpArgs = mockCreateOperation.mock.calls[0][0];
       expect(createOpArgs.activeDeviceId).toBeUndefined();
     });
@@ -391,9 +424,15 @@ describe('AiAgentService.execAgent - device auto-activation', () => {
       );
     });
 
+    // Verifies topic-stored metadata.boundDeviceId is NOT silently reused as
+    // the runtime bound device. Setup: topic.metadata says device-002, but the
+    // only online device is device-001. If the topic metadata were reused as
+    // boundDeviceId, activeDeviceId would be undefined (device-002 is offline).
+    // After LOBE-9378 auto-activate, we instead pick the most-recent online
+    // device (device-001) — proving the topic's stale metadata wasn't honored.
     it('should not reuse topic boundDeviceId when no explicit deviceId is provided', async () => {
       mockDeviceProxy.isConfigured = true;
-      mockDeviceProxy.queryDeviceList.mockResolvedValue([onlineDevice, onlineDevice2]);
+      mockDeviceProxy.queryDeviceList.mockResolvedValue([onlineDevice]);
       topicMock.findById.mockResolvedValue({ metadata: { boundDeviceId: 'device-002' } });
       const { AgentService } = await import('@/server/services/agent');
       vi.mocked(AgentService).mockImplementation(
@@ -421,7 +460,8 @@ describe('AiAgentService.execAgent - device auto-activation', () => {
       });
 
       const createOpArgs = mockCreateOperation.mock.calls[0][0];
-      expect(createOpArgs.activeDeviceId).toBeUndefined();
+      expect(createOpArgs.activeDeviceId).not.toBe('device-002');
+      expect(createOpArgs.activeDeviceId).toBe('device-001');
     });
 
     it('should keep explicit topic binding when the bound device is offline', async () => {
@@ -487,12 +527,18 @@ describe('AiAgentService.execAgent - device auto-activation', () => {
       expect(createOpArgs.activeDeviceId).toBe('device-001');
     });
 
+    // Mirrors the "should not reuse topic boundDeviceId" test above with a
+    // different mock shape. Topic metadata stores device-002, but only
+    // device-001 is online; if topic metadata leaked into boundDeviceId,
+    // activeDeviceId would be undefined (since device-002 is offline). The
+    // post-LOBE-9378 auto-activate picks device-001 instead, confirming the
+    // stale topic.metadata.boundDeviceId path is dead.
     it('should not reuse topic metadata bound device when no deviceId is supplied', async () => {
       mockDeviceProxy.isConfigured = true;
       mockDeviceProxy.queryDeviceList.mockResolvedValue([onlineDevice]);
       topicMock.findById.mockResolvedValue({
         id: 'topic-1',
-        metadata: { boundDeviceId: 'device-001' },
+        metadata: { boundDeviceId: 'device-002' },
       });
 
       await service.execAgent({
@@ -502,7 +548,8 @@ describe('AiAgentService.execAgent - device auto-activation', () => {
       });
 
       const createOpArgs = mockCreateOperation.mock.calls[0][0];
-      expect(createOpArgs.activeDeviceId).toBeUndefined();
+      expect(createOpArgs.activeDeviceId).not.toBe('device-002');
+      expect(createOpArgs.activeDeviceId).toBe('device-001');
     });
 
     it('should not update topic metadata when a new deviceId is provided for existing topic', async () => {

--- a/src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
@@ -208,6 +208,7 @@ describe('AiAgentService.execAgent - device tool pipeline (LOBE-5636)', () => {
       expect(mockCreateServerAgentToolsEngine).toHaveBeenCalledTimes(1);
       const params = mockCreateServerAgentToolsEngine.mock.calls[0][1];
       expect(params.deviceContext).toEqual({
+        autoActivated: true,
         boundDeviceId: undefined,
         deviceOnline: true,
         gatewayConfigured: true,

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -1146,17 +1146,25 @@ export class AiAgentService {
       // bypassing the engine's enabledToolIds exclusion. Skipping the
       // assignment here closes that bypass at the source.
       //
-      // 1. If this run explicitly requested a device and that device is online, use it
-      // 2. Otherwise, if the current topic has a bound device and it is online, use that
-      // 3. Otherwise, fall back to the agent-level bound device when it is online
-      // 4. Otherwise, in IM/Bot scenarios, auto-activate only when exactly one device is online
+      // Resolution order (LOBE-9378):
+      // 1. boundDeviceId (topic-bound > agent-bound): use if online; if offline,
+      //    respect the explicit choice and stay unrouted — don't silently fall
+      //    back to a different device, that would surprise the user.
+      // 2. No bound device: auto-activate only when EXACTLY ONE device is
+      //    online. Multi-device users must bind explicitly — picking by
+      //    recency / first-online would be a guess that could route tool calls
+      //    to the wrong machine. This applies uniformly to regular chat and
+      //    IM/Bot — the previous "regular-chat does nothing" path was the bug
+      //    behind LOBE-9378 (the local-system system prompt's
+      //    `{{workingDirectory}}` reached the LLM as a literal, wasting the
+      //    first N steps groping for cwd).
       activeDeviceId = !canUseDevice
         ? undefined
         : boundDeviceId
           ? onlineDevices.some((device) => device.deviceId === boundDeviceId)
             ? boundDeviceId
             : undefined
-          : (discordContext || botContext) && onlineDevices.length === 1
+          : onlineDevices.length === 1
             ? onlineDevices[0].deviceId
             : undefined;
 
@@ -1379,33 +1387,44 @@ export class AiAgentService {
       };
     }
 
-    // 9.4. Fetch device system info for placeholder variable replacement
-    let deviceSystemInfo: Record<string, string> = {};
-    if (activeDeviceId) {
+    // 9.4. Fetch device system info for placeholder variable replacement.
+    //
+    // Decoupled from activeDeviceId routing (LOBE-9378): pulled into a helper
+    // so the device whose info populates the template (`{{hostname}}`,
+    // `{{workingDirectory}}`, etc.) is a separate decision from the device
+    // that tool calls route to. Today they're aligned — but future policy
+    // changes (e.g., showing last-known info for an offline bound device)
+    // belong in this helper, not in the activeDeviceId resolution block.
+    const fetchDeviceSystemInfoForTemplate = async (
+      deviceId: string | undefined,
+    ): Promise<Record<string, string>> => {
+      if (!deviceId) return {};
       try {
-        const systemInfo = await deviceProxy.queryDeviceSystemInfo(this.userId, activeDeviceId);
-        if (systemInfo) {
-          const activeDevice = onlineDevices.find((d) => d.deviceId === activeDeviceId);
-          deviceSystemInfo = {
-            arch: systemInfo.arch,
-            desktopPath: systemInfo.desktopPath,
-            documentsPath: systemInfo.documentsPath,
-            downloadsPath: systemInfo.downloadsPath,
-            homePath: systemInfo.homePath,
-            hostname: activeDevice?.hostname ?? 'unknown',
-            musicPath: systemInfo.musicPath,
-            picturesPath: systemInfo.picturesPath,
-            platform: activeDevice?.platform ?? 'unknown',
-            userDataPath: systemInfo.userDataPath,
-            videosPath: systemInfo.videosPath,
-            workingDirectory: systemInfo.workingDirectory,
-          };
-          log('execAgent: fetched device system info for %s', activeDeviceId);
-        }
+        const systemInfo = await deviceProxy.queryDeviceSystemInfo(this.userId, deviceId);
+        if (!systemInfo) return {};
+        const device = onlineDevices.find((d) => d.deviceId === deviceId);
+        log('execAgent: fetched device system info for %s', deviceId);
+        return {
+          arch: systemInfo.arch,
+          desktopPath: systemInfo.desktopPath,
+          documentsPath: systemInfo.documentsPath,
+          downloadsPath: systemInfo.downloadsPath,
+          homePath: systemInfo.homePath,
+          hostname: device?.hostname ?? 'unknown',
+          musicPath: systemInfo.musicPath,
+          picturesPath: systemInfo.picturesPath,
+          platform: device?.platform ?? 'unknown',
+          userDataPath: systemInfo.userDataPath,
+          videosPath: systemInfo.videosPath,
+          workingDirectory: systemInfo.workingDirectory,
+        };
       } catch (error) {
         log('execAgent: failed to fetch device system info: %O', error);
+        return {};
       }
-    }
+    };
+
+    const deviceSystemInfo = await fetchDeviceSystemInfoForTemplate(activeDeviceId);
 
     // 9.5. Build Agent Management context
     // - availableAgents is injected whenever the user is in auto mode (so the supervisor


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes [LOBE-9378](https://linear.app/lobehub/issue/LOBE-9378/bug-lobe-local-system-模板变量未注入普通聊天场景下-workingdirectory-hostname-等字面量直送)

#### 🔀 Description of Change

The `lobe-local-system` system prompt contains a `<user_context>` block with Mustache placeholders:

```xml
<user_context>
<device name="{{hostname}}" os="{{platform}}" arch="{{arch}}" />
<working-directory>{{workingDirectory}}</working-directory>
<home-path>{{homePath}}</home-path>
</user_context>
```

Before this fix, regular Web-UI chat without a bound device left every variable un-interpolated. The literal `{{workingDirectory}}` strings reached the LLM, the model had no idea what the cwd / home / hostname were, and it wasted the first N steps groping for paths (observed: **16 wasted steps in one 120-step, 1281s op** — `op_1779374796957_agt_f5G2xEkHbpfj_tpc_MbSgAfT9AbVZ_YGpA6riJ`).

**Root cause chain:**

1. `lobe-local-system`'s manifest is in `pluginIds` by default → its systemRole (with the template) is **always** in the LLM payload.
2. The template variables come from `additionalVariables.deviceSystemInfo`, which is fetched from `deviceProxy.queryDeviceSystemInfo(activeDeviceId)`.
3. `activeDeviceId` resolution at `execAgent` only auto-activated under `(discordContext || botContext) && onlineDevices.length === 1`. Regular Web chat → `undefined` → no fetch → empty variables.
4. `PlaceholderVariables` keeps `{{...}}` as a literal when no generator is registered, so the placeholders reached the LLM intact.

**Fix:**

- **`activeDeviceId` resolution (`src/server/services/aiAgent/index.ts:1039`)**: Removed the IM/Bot restriction. Regular chat and IM/Bot now share the same `onlineDevices.length === 1` auto-activate rule. **Multi-device users still need to bind explicitly** — picking one by recency would be a guess that could route tool calls to the wrong machine.
- **`deviceSystemInfo` fetching (`src/server/services/aiAgent/index.ts:1268`)**: Extracted the inline `if (activeDeviceId) {...}` into a `fetchDeviceSystemInfoForTemplate(deviceId)` helper. Behavior unchanged today, but template-rendering policy is now structurally decoupled from routing — future fallback policies (e.g., showing last-known info when bound device is offline) live in the helper, not in the activeDeviceId block.

#### 🧪 How to Test

- [x] Added/updated tests

`src/server/services/aiAgent/__tests__/execAgent.device.test.ts` updated:

| Scenario | Before | After |
|---|---|---|
| Web UI, 1 device online | ❌ undefined (bug) | ✅ `'device-001'` |
| Web UI, multi devices online | ❌ undefined (correct) | ❌ undefined (correct, kept) |
| Web UI, 0 devices online | ❌ undefined | ❌ undefined |
| IM/Bot scenarios | unchanged | unchanged |
| bound-device scenarios | unchanged | unchanged |
| Topic metadata reuse guard | asserted via `undefined` | asserted via `!= 'device-002'` |

Two tests that previously asserted `activeDeviceId === undefined` as a side-effect of "topic.metadata.boundDeviceId is not silently reused" were restructured to make the original intent explicit (`expect(...).not.toBe('device-002')`), so they're robust to the new auto-activate behavior.

#### 📝 Additional Information

**Behavior matrix after this PR** (`canUseDevice=true`):

| Bound device | Online devices | `activeDeviceId` |
|---|---|---|
| set & online | any | bound id |
| set & offline | any | `undefined` (respect explicit choice) |
| none | 0 | `undefined` |
| none | 1 | that one |
| none | >1 | `undefined` (require explicit bind) |

**Follow-ups (out of scope, tracked in LOBE-9378):**

1. Audit executor-side cross-device routing fallback. When `activeDeviceId` is `undefined`, tool calls still routed *somewhere* (the original trace returned a result from `/Users/zhonglinglu/...`, a different user). That fallback path may be a cross-user routing risk.
2. Add a debug WARN in `PlaceholderVariables.ts` when a template contains `{{...}}` but no matching generator exists, so this class of bug surfaces immediately instead of silently shipping literals to the LLM.