### PR TITLE
🐛 fix: resolve browser model config import

### DIFF
--- a/packages/model-runtime/src/utils/getModelPricing.ts
+++ b/packages/model-runtime/src/utils/getModelPricing.ts
@@ -1,7 +1,5 @@
 import type { LobeDefaultAiModelListItem, Pricing } from 'model-bank';
 
-const BUSINESS_MODEL_CONFIG_MODULE = '@lobechat/business-model-bank/model-config';
-
 interface BusinessModelConfigModule {
   loadModels: () => Promise<LobeDefaultAiModelListItem[]>;
 }
@@ -17,9 +15,8 @@ export async function getModelPricing(
   model: string,
   provider?: string,
 ): Promise<Pricing | undefined> {
-  const { loadModels } = (await import(
-    /* @vite-ignore */ BUSINESS_MODEL_CONFIG_MODULE
-  )) as BusinessModelConfigModule;
+  const { loadModels } =
+    (await import('@lobechat/business-model-bank/model-config')) as BusinessModelConfigModule;
   const models = await loadModels();
 
   // 1. First try to get pricing from the specified provider

--- a/packages/model-runtime/src/utils/modelConfigImport.test.ts
+++ b/packages/model-runtime/src/utils/modelConfigImport.test.ts
@@ -1,0 +1,22 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const utilsDir = path.dirname(fileURLToPath(import.meta.url));
+
+describe('model config imports', () => {
+  it('keeps runtime model-config imports statically analyzable for browser bundlers', async () => {
+    const sources = await Promise.all(
+      ['getModelPricing.ts', 'getFallbackModelProperty.ts', 'modelParse.ts'].map((file) =>
+        readFile(path.resolve(utilsDir, file), 'utf8'),
+      ),
+    );
+
+    for (const source of sources) {
+      expect(source).not.toContain('@vite-ignore');
+      expect(source).not.toContain('BUSINESS_MODEL_CONFIG_MODULE');
+    }
+  });
+});

--- a/packages/model-runtime/src/utils/modelParse.ts
+++ b/packages/model-runtime/src/utils/modelParse.ts
@@ -201,7 +201,6 @@ export const IMAGE_MODEL_KEYWORDS = [
 export const EMBEDDING_MODEL_KEYWORDS = ['embedding', 'embed', 'bge', 'm3e'] as const;
 
 const AI_MODEL_TYPE_SET = new Set<AiModelType>(AiModelTypeSchema.options);
-const BUSINESS_MODEL_CONFIG_MODULE = '@lobechat/business-model-bank/model-config';
 
 interface BusinessModelConfigModule {
   loadModels: () => Promise<LobeDefaultAiModelListItem[]>;
@@ -464,9 +463,8 @@ const getProviderLocalConfig = async (
   if (!provider) return null;
 
   if (provider === ModelProvider.LobeHub) {
-    const { loadModels } = (await import(
-      /* @vite-ignore */ BUSINESS_MODEL_CONFIG_MODULE
-    )) as BusinessModelConfigModule;
+    const { loadModels } =
+      (await import('@lobechat/business-model-bank/model-config')) as BusinessModelConfigModule;
     const models = await loadModels();
     return models.filter((model) => model.providerId === ModelProvider.LobeHub);
   }


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #15077
Related to #15075

#### 🔀 Description of Change

- Replace the `@vite-ignore` variable dynamic imports for `@lobechat/business-model-bank/model-config` with literal dynamic imports in runtime paths that can execute in the browser.
- Keep the model config loading lazy while allowing Vite/browser bundlers to resolve the package subpath correctly.
- Add a regression test to prevent runtime model config imports from becoming bundler-opaque again.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/utils/modelConfigImport.test.ts' 'src/utils/getModelPricing.test.ts' 'src/utils/getFallbackModelProperty.test.ts' 'src/utils/modelParse.test.ts'
```

Additional check:

```bash
timeout 20s bun -e "import { createServer } from 'vite'; const server = await createServer({ root: process.cwd(), logLevel: 'silent' }); const result = await server.transformRequest('/packages/model-runtime/src/utils/getModelPricing.ts'); console.log(JSON.stringify({ hasRawBusinessSpecifier: result?.code.includes('@lobechat/business-model-bank/model-config') ?? null, hasViteIgnore: result?.code.includes('@vite-ignore') ?? null })); await server.close(); process.exit(0);"
```

Expected result:

```json
{"hasRawBusinessSpecifier":false,"hasViteIgnore":false}
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This PR specifically fixes the browser runtime module resolution regression for model config imports. Issue #15075 is linked as related self-hosting context, but its main build-timeout report may also involve separate deployment performance constraints.
