### PR TITLE
🐛 fix: bound redis command timeout

### DIFF
--- a/src/libs/redis/redis.test.ts
+++ b/src/libs/redis/redis.test.ts
@@ -23,6 +23,8 @@ const buildRedisConfig = (): RedisConfig | null => {
 const loadRedisProvider = async () => (await import('./redis')).IoRedisRedisProvider;
 
 const createMockedProvider = async () => {
+  const instances: Array<{ options: Record<PropertyKey, unknown>; url: string }> = [];
+
   const createPipelineMock = () => {
     const pipeMocks = {
       incr: vi.fn(),
@@ -77,8 +79,10 @@ const createMockedProvider = async () => {
     class FakeRedis {
       constructor(
         public url: string,
-        public options: any,
-      ) {}
+        public options: Record<PropertyKey, unknown>,
+      ) {
+        instances.push({ options, url });
+      }
       connect = mocks.connect;
       ping = mocks.ping;
       quit = mocks.quit;
@@ -114,7 +118,7 @@ const createMockedProvider = async () => {
 
   await provider.initialize();
 
-  return { mocks, provider };
+  return { instances, mocks, provider };
 };
 
 const shouldSkipIntegration = (error: unknown) =>
@@ -163,6 +167,22 @@ describe('integrated', (test) => {
 });
 
 describe('mocked', () => {
+  it('sets bounded ioredis connection and command timeouts', async () => {
+    const { instances, provider } = await createMockedProvider();
+
+    expect(instances).toHaveLength(1);
+    expect(instances[0]).toMatchObject({
+      options: {
+        commandTimeout: 10_000,
+        connectTimeout: 10_000,
+        maxRetriesPerRequest: 2,
+      },
+      url: 'redis://localhost:6379',
+    });
+
+    await provider.disconnect();
+  });
+
   it('normalizes set options into ioredis arguments', async () => {
     const { mocks, provider } = await createMockedProvider();
     await provider.set('key', 'value', { ex: 10, nx: true, get: true });

--- a/src/libs/redis/redis.ts
+++ b/src/libs/redis/redis.ts
@@ -15,6 +15,9 @@ import { buildIORedisSetArgs, normalizeMsetValues } from './utils';
 
 const log = debug('lobe:redis');
 
+const REDIS_CONNECT_TIMEOUT_MS = 10_000;
+const REDIS_COMMAND_TIMEOUT_MS = 10_000;
+
 export class IoRedisRedisProvider implements BaseRedisProvider {
   private client: Redis | null = null;
 
@@ -24,6 +27,8 @@ export class IoRedisRedisProvider implements BaseRedisProvider {
     const IORedis = await import('ioredis');
 
     this.client = new IORedis.default(this.config.url, {
+      commandTimeout: REDIS_COMMAND_TIMEOUT_MS,
+      connectTimeout: REDIS_CONNECT_TIMEOUT_MS,
       db: this.config.database,
       keyPrefix: this.config.prefix ? `${this.config.prefix}:` : undefined,
       lazyConnect: true,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-9381, LOBE-9389, LOBE-9392.

#### 🔀 Description of Change

Add bounded ioredis connection and command timeouts so Redis stalls fail fast instead of holding auth, agent, or tool requests until the Vercel function max duration.

The provider already limits retries per request; this adds a command-level ceiling for cases where the socket is connected but a command never returns.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/libs/redis/redis.test.ts'\n```\n\nVSCode diagnostics checked for the changed files.\n\n#### 📸 Screenshots / Videos\n\nN/A\n\n#### 📝 Additional Information\n\nThis is a defensive fail-fast change for shared Redis access. Redis should normally respond in milliseconds; a 10s command timeout avoids platform-level 120s/300s/800s timeouts while still allowing transient latency headroom.