### PR TITLE
🐛 fix: disable reasoning for Responses structured outputs

### DIFF
--- a/packages/model-runtime/src/const/models.ts
+++ b/packages/model-runtime/src/const/models.ts
@@ -54,6 +54,9 @@ export const responsesAPIModels = new Set([
   'gpt-5.5-pro',
 ]);
 
+export const isGPT5ProResponsesModel = (model: string): boolean =>
+  /(?:^|\/)gpt-5(?:\.\d+)?-pro(?:-|$)/.test(model);
+
 /**
  * Regex patterns for models that support context caching (3.5+)
  */

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -2065,7 +2065,7 @@ describe('LobeOpenAICompatibleFactory', () => {
       );
     });
 
-    it('should normalize GPT-5 Pro Responses generateObject reasoning effort to high', async () => {
+    it('should normalize GPT-5 Pro-family Responses generateObject reasoning effort to high', async () => {
       const mockResponse = {
         output_text: '{"name": "John", "age": 30}',
       };
@@ -2074,7 +2074,7 @@ describe('LobeOpenAICompatibleFactory', () => {
 
       const payload = {
         messages: [{ content: 'Generate a person object', role: 'user' as const }],
-        model: 'gpt-5-pro',
+        model: 'gpt-5.4-pro',
         reasoning_effort: 'medium' as const,
         schema: {
           name: 'person_extractor',
@@ -2089,7 +2089,7 @@ describe('LobeOpenAICompatibleFactory', () => {
 
       expect(instance['client'].responses.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'gpt-5-pro',
+          model: 'gpt-5.4-pro',
           reasoning: { effort: 'high' },
         }),
         expect.anything(),

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -2065,6 +2065,37 @@ describe('LobeOpenAICompatibleFactory', () => {
       );
     });
 
+    it('should normalize GPT-5 Pro Responses generateObject reasoning effort to high', async () => {
+      const mockResponse = {
+        output_text: '{"name": "John", "age": 30}',
+      };
+
+      vi.spyOn(instance['client'].responses, 'create').mockResolvedValue(mockResponse as any);
+
+      const payload = {
+        messages: [{ content: 'Generate a person object', role: 'user' as const }],
+        model: 'gpt-5-pro',
+        reasoning_effort: 'medium' as const,
+        schema: {
+          name: 'person_extractor',
+          schema: {
+            properties: { age: { type: 'number' }, name: { type: 'string' } },
+            type: 'object' as const,
+          },
+        },
+      };
+
+      await instance.generateObject(payload);
+
+      expect(instance['client'].responses.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'gpt-5-pro',
+          reasoning: { effort: 'high' },
+        }),
+        expect.anything(),
+      );
+    });
+
     it('should handle options correctly', async () => {
       const mockResponse = {
         output_text: '{"status": "success"}',

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -2034,6 +2034,37 @@ describe('LobeOpenAICompatibleFactory', () => {
       expect(result).toEqual({ age: 30, name: 'John' });
     });
 
+    it('should map disabled thinking to no reasoning effort for GPT-5.4 Responses generateObject', async () => {
+      const mockResponse = {
+        output_text: '{"name": "John", "age": 30}',
+      };
+
+      vi.spyOn(instance['client'].responses, 'create').mockResolvedValue(mockResponse as any);
+
+      const payload = {
+        messages: [{ content: 'Generate a person object', role: 'user' as const }],
+        model: 'gpt-5.4-mini',
+        schema: {
+          name: 'person_extractor',
+          schema: {
+            properties: { age: { type: 'number' }, name: { type: 'string' } },
+            type: 'object' as const,
+          },
+        },
+        thinking: { budget_tokens: 0, type: 'disabled' as const },
+      };
+
+      await instance.generateObject(payload);
+
+      expect(instance['client'].responses.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'gpt-5.4-mini',
+          reasoning: { effort: 'none' },
+        }),
+        expect.anything(),
+      );
+    });
+
     it('should handle options correctly', async () => {
       const mockResponse = {
         output_text: '{"status": "success"}',

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -110,11 +110,17 @@ const getGenerateObjectReasoningParams = ({
 const supportsResponsesReasoningEffortNone = (model: string): boolean =>
   /(?:^|\/)gpt-5\.[1-9]\d*(?:-(?!pro(?:-|$))|$)/.test(model);
 
+const isGPT5ProResponsesModel = (model: string): boolean => /(?:^|\/)gpt-5-pro(?:-|$)/.test(model);
+
 const getGenerateObjectResponsesReasoningParams = ({
   model,
   reasoning_effort,
   thinking,
 }: GenerateObjectReasoningParams & { model: string }) => {
+  if (isGPT5ProResponsesModel(model)) {
+    return reasoning_effort && reasoning_effort !== 'max' ? { reasoning: { effort: 'high' } } : {};
+  }
+
   if (thinking?.type === 'disabled') {
     return supportsResponsesReasoningEffortNone(model) ? { reasoning: { effort: 'none' } } : {};
   }

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -8,7 +8,7 @@ import type { ClientOptions } from 'openai';
 import OpenAI from 'openai';
 import type { Stream } from 'openai/streaming';
 
-import { responsesAPIModels } from '../../const/models';
+import { isGPT5ProResponsesModel, responsesAPIModels } from '../../const/models';
 import type {
   ChatCompletionErrorPayload,
   ChatCompletionTool,
@@ -109,8 +109,6 @@ const getGenerateObjectReasoningParams = ({
 
 const supportsResponsesReasoningEffortNone = (model: string): boolean =>
   /(?:^|\/)gpt-5\.[1-9]\d*(?:-(?!pro(?:-|$))|$)/.test(model);
-
-const isGPT5ProResponsesModel = (model: string): boolean => /(?:^|\/)gpt-5-pro(?:-|$)/.test(model);
 
 const getGenerateObjectResponsesReasoningParams = ({
   model,

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -107,6 +107,23 @@ const getGenerateObjectReasoningParams = ({
   ...(reasoning_effort && thinking?.type !== 'disabled' ? { reasoning_effort } : {}),
 });
 
+const supportsResponsesReasoningEffortNone = (model: string): boolean =>
+  /(?:^|\/)gpt-5\.[1-9]\d*(?:-(?!pro(?:-|$))|$)/.test(model);
+
+const getGenerateObjectResponsesReasoningParams = ({
+  model,
+  reasoning_effort,
+  thinking,
+}: GenerateObjectReasoningParams & { model: string }) => {
+  if (thinking?.type === 'disabled') {
+    return supportsResponsesReasoningEffortNone(model) ? { reasoning: { effort: 'none' } } : {};
+  }
+
+  return reasoning_effort && reasoning_effort !== 'max'
+    ? { reasoning: { effort: reasoning_effort } }
+    : {};
+};
+
 export type CreateVideoOptions = Omit<ClientOptions, 'apiKey'> & {
   apiKey: string;
   provider: string;
@@ -899,6 +916,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
             {
               input: messages,
               model,
+              ...getGenerateObjectResponsesReasoningParams(payload),
               ...this.resolvePromptCacheKeyParams(model, options?.user),
               text: { format: { strict: true, type: 'json_schema', ...processedSchema } },
               // Responses API replaced `user` with `safety_identifier`; some endpoints reject `user`

--- a/packages/model-runtime/src/providers/openai/index.test.ts
+++ b/packages/model-runtime/src/providers/openai/index.test.ts
@@ -438,6 +438,19 @@ describe('LobeOpenAI', () => {
       expect(createCall.reasoning).toEqual({ effort: 'high', summary: 'auto' });
     });
 
+    it('should set reasoning.effort to high for gpt-5.4-pro models', async () => {
+      const payload = {
+        messages: [{ content: 'Hello', role: 'user' as const }],
+        model: 'gpt-5.4-pro',
+        temperature: 0.7,
+      };
+
+      await instance.chat(payload);
+
+      const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+      expect(createCall.reasoning).toEqual({ effort: 'high', summary: 'auto' });
+    });
+
     it('should convert max_tokens to max_output_tokens for responses API', async () => {
       const payload = {
         max_tokens: 2048,

--- a/packages/model-runtime/src/providers/openai/index.ts
+++ b/packages/model-runtime/src/providers/openai/index.ts
@@ -1,6 +1,6 @@
 import { ModelProvider } from 'model-bank';
 
-import { responsesAPIModels } from '../../const/models';
+import { isGPT5ProResponsesModel, responsesAPIModels } from '../../const/models';
 import { pruneReasoningPayload } from '../../core/contextBuilders/openai';
 import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
@@ -96,7 +96,7 @@ export const params = {
         const reasoning = payload.reasoning
           ? { ...payload.reasoning, summary: 'auto' }
           : { summary: 'auto' };
-        if (model.startsWith('gpt-5-pro')) {
+        if (isGPT5ProResponsesModel(model)) {
           reasoning.effort = 'high';
         }
         return pruneReasoningPayload({


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Map disabled thinking to `reasoning: { effort: 'none' }` for GPT-5.4 structured-output requests that use the OpenAI Responses API.

Keep existing `reasoning_effort` mapping for Responses structured outputs, and avoid sending `none` to GPT-5 pro variants.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
LOBEHUB_MODEL_CONFIG='{"version":1,"models":[{"id":"gpt-5.4-mini","type":"chat","pricing":{"units":[{"name":"textInput","rate":1,"strategy":"fixed","unit":"millionTokens"}]}}],"planCardModels":["gpt-5.4-mini"]}' bunx vitest run --silent='passed-only' 'src/core/openaiCompatibleFactory/index.test.ts' -t 'should map disabled thinking to no reasoning effort for GPT-5.4 Responses generateObject'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No cloud-specific business logic is included in this submodule change.
