### PR TITLE
🐛 fix(model-runtime): preserve image response usage

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/createImage.test.ts
@@ -837,5 +837,41 @@ describe('createOpenAICompatibleImage', () => {
       expect(result.imageUrl).toBe('data:image/png;base64,imageWithoutUsage');
       expect(result.modelUsage).toBeUndefined();
     });
+
+    it('should return image when usage input token details are missing', async () => {
+      const mockImageResponse = {
+        data: [
+          {
+            b64_json: 'imageWithIncompleteUsage',
+          },
+        ],
+        usage: {
+          total_tokens: 1000,
+          input_tokens: 100,
+          output_tokens: 900,
+        },
+      };
+
+      vi.mocked(mockClient.images.generate).mockResolvedValue(mockImageResponse as any);
+
+      const payload: CreateImagePayload = {
+        model: 'gpt-image-1',
+        params: {
+          prompt: 'Generate image with incomplete usage tracking',
+        },
+      };
+
+      const result = await createOpenAICompatibleImage(mockClient, payload, 'openai');
+
+      expect(result.imageUrl).toBe('data:image/png;base64,imageWithIncompleteUsage');
+      expect(result.modelUsage).toMatchObject({
+        inputImageTokens: 0,
+        inputTextTokens: 100,
+        outputImageTokens: 900,
+        totalInputTokens: 100,
+        totalOutputTokens: 900,
+        totalTokens: 1000,
+      });
+    });
   });
 });

--- a/packages/model-runtime/src/core/usageConverters/openai.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/openai.test.ts
@@ -701,4 +701,23 @@ describe('convertOpenAIImageUsage', () => {
       cost: 0.16647, // Based on pricing: 14 * 5/1M + 0 * 10/1M + 4160 * 40/1M = 0.00007 + 0 + 0.1664 = 0.16647
     });
   });
+
+  it('should tolerate image usage without input token details', () => {
+    const usageWithoutDetails = {
+      input_tokens: 100,
+      output_tokens: 900,
+      total_tokens: 1000,
+    } as OpenAI.Images.ImagesResponse.Usage;
+
+    const result = convertOpenAIImageUsage(usageWithoutDetails);
+
+    expect(result).toEqual({
+      inputImageTokens: 0,
+      inputTextTokens: 100,
+      outputImageTokens: 900,
+      totalInputTokens: 100,
+      totalOutputTokens: 900,
+      totalTokens: 1000,
+    });
+  });
 });

--- a/packages/model-runtime/src/core/usageConverters/openai.ts
+++ b/packages/model-runtime/src/core/usageConverters/openai.ts
@@ -208,9 +208,13 @@ export const convertOpenAIImageUsage = (
   usage: OpenAI.Images.ImagesResponse.Usage,
   pricing?: Pricing,
 ): ModelUsage => {
+  const inputTokensDetails = usage.input_tokens_details as
+    | Partial<OpenAI.Images.ImagesResponse.Usage.InputTokensDetails>
+    | undefined;
+
   const data: ModelTokensUsage = {
-    inputImageTokens: usage.input_tokens_details.image_tokens,
-    inputTextTokens: usage.input_tokens_details.text_tokens,
+    inputImageTokens: inputTokensDetails?.image_tokens ?? 0,
+    inputTextTokens: inputTokensDetails?.text_tokens ?? usage.input_tokens,
     outputImageTokens: usage.output_tokens,
     totalInputTokens: usage.input_tokens,
     totalOutputTokens: usage.output_tokens,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

This PR fixes a crash in OpenAI-compatible image generation when the image API response includes `usage` but omits `input_tokens_details`.

Previously, `convertOpenAIImageUsage` directly accessed `usage.input_tokens_details.image_tokens`, which could throw:

Cannot read properties of undefined (reading 'image_tokens')
When this happened after the provider had already generated an image, the async image generation flow failed before the generated asset could be processed and rendered.

The fix makes image usage conversion tolerant of missing token details:

Defaults missing input image tokens to 0
Falls back input text tokens to usage.input_tokens
Preserves total input/output/overall token counts
Keeps generated image responses successful even when usage details are incomplete
🧪 How to Test
 Tested locally
 Added/updated tests
 No tests needed
Tested with:

bash

bunx vitest run --silent='passed-only' packages/model-runtime/src/core/openaiCompatibleFactory/createImage.test.ts
bunx vitest run --silent='passed-only' packages/model-runtime/src/core/usageConverters/openai.test.ts
Added coverage for:

Converting OpenAI image usage when input_tokens_details is missing
Returning the generated image successfully when image usage exists without input token details
📸 Screenshots / Videos
N/A

📝 Additional Information
No UI changes.

This is a defensive runtime compatibility fix for OpenAI-compatible image providers that return partial usage metadata.