### PR TITLE
🐛 fix(context-engine): guard placeholder log preview against undefined content

### DIFF
--- a/packages/context-engine/src/processors/PlaceholderVariables.ts
+++ b/packages/context-engine/src/processors/PlaceholderVariables.ts
@@ -11,6 +11,26 @@ declare module '../types' {
 
 const log = debug('context-engine:processor:PlaceholderVariablesProcessor');
 
+/**
+ * Build a short, log-safe preview of a message's content.
+ *
+ * `JSON.stringify` returns `undefined` (not a string) for `undefined` /
+ * functions / symbols, so naively calling `.slice` on its result crashes —
+ * this is exactly how a tool error result with `content: undefined`
+ * (e.g. budget-exceeded errors) used to take down the whole processor.
+ * Always coerce to a string before slicing.
+ */
+const buildContentPreview = (content: unknown): string => {
+  if (typeof content === 'string') return content.slice(0, 200);
+
+  try {
+    const serialized = JSON.stringify(content);
+    return (serialized ?? String(content)).slice(0, 200);
+  } catch {
+    return String(content).slice(0, 200);
+  }
+};
+
 const PLACEHOLDER_START = '{{';
 const PLACEHOLDER_END = '}}';
 
@@ -320,10 +340,7 @@ export class PlaceholderVariablesProcessor extends BaseProcessor {
     for (let i = 0; i < clonedContext.messages.length; i++) {
       const message = clonedContext.messages[i];
 
-      const contentPreview =
-        typeof message.content === 'string'
-          ? message.content.slice(0, 200)
-          : JSON.stringify(message.content).slice(0, 200);
+      const contentPreview = buildContentPreview(message.content);
 
       log(
         'Processing message %d: role=%s, contentType=%s, contentPreview=%s',

--- a/packages/context-engine/src/processors/__tests__/PlaceholderVariables.toolMessage.test.ts
+++ b/packages/context-engine/src/processors/__tests__/PlaceholderVariables.toolMessage.test.ts
@@ -79,6 +79,37 @@ describe('PlaceholderVariablesProcessor — tool message substitution', () => {
     expect(result.messages[0].content).toBe('agent={{agent_id}}');
   });
 
+  // Regression for LOBE-9408: a tool error result (e.g. budget-exceeded) can
+  // arrive with `content: undefined`. The content-preview logging step used to
+  // call `JSON.stringify(undefined).slice(...)` — which throws because
+  // `JSON.stringify(undefined)` returns `undefined`, not a string — crashing
+  // the whole processor before any message was processed.
+  it('does not crash on a tool message with undefined content', async () => {
+    const processor = new PlaceholderVariablesProcessor({
+      variableGenerators: {
+        agent_id: () => 'agt_xyz',
+      },
+    });
+
+    const ctx = buildContext([
+      { role: 'user', content: 'hi {{agent_id}}' },
+      {
+        role: 'tool',
+        tool_call_id: 'toolu_err',
+        name: 'lobe-agent',
+        content: undefined,
+        error: { errorType: 'InsufficientBudgetForModel' },
+      },
+    ]);
+
+    const result = await processor.process(ctx);
+
+    // The user message after the crashing tool message must still be processed.
+    expect(result.messages[0].content).toBe('hi agt_xyz');
+    // The tool message is preserved untouched.
+    expect(result.messages[1].content).toBeUndefined();
+  });
+
   it('substitutes generator returning empty string to empty (NOT raw)', async () => {
     const processor = new PlaceholderVariablesProcessor({
       variableGenerators: {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-9408

#### 🔀 Description of Change

`PlaceholderVariablesProcessor` crashed the entire request whenever a tool message arrived with `content: undefined` — e.g. a budget-exceeded error result (`InsufficientBudgetForModel`). The crash happened in the per-message logging step:

```ts
const contentPreview =
  typeof message.content === 'string'
    ? message.content.slice(0, 200)
    : JSON.stringify(message.content).slice(0, 200);
```

`JSON.stringify(undefined)` returns `undefined` (not a string), so `.slice(0, 200)` throws `TypeError: Cannot read properties of undefined` and aborts the processor before any placeholder substitution runs.

Extracted a small `buildContentPreview` helper that:

- returns string content directly (sliced),
- falls back to `String(content)` when `JSON.stringify` yields `undefined` (or throws on circular refs),
- always coerces to a string before slicing.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added a regression test in `PlaceholderVariables.toolMessage.test.ts` that feeds a tool message with `content: undefined` (mimicking a budget-exceeded error) and asserts:

1. The processor does not crash.
2. Placeholders in surrounding messages are still substituted.
3. The tool message's `undefined` content is preserved untouched.

All 28 `PlaceholderVariables` tests pass.

#### 📝 Additional Information

No behavior change for tool messages with normal content — the helper is only different on the `undefined` / non-serializable path.