### PR TITLE
✨ feat(onboarding): show agent welcome guidance

### DIFF
--- a/src/features/Onboarding/Agent/Welcome.mobile.tsx
+++ b/src/features/Onboarding/Agent/Welcome.mobile.tsx
@@ -1,4 +1,4 @@
-import { Flexbox } from '@lobehub/ui';
+import { Flexbox, Markdown } from '@lobehub/ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -26,6 +26,9 @@ const WelcomeMobile = memo(() => {
           gap={10}
           sentences={[t('agent.welcome.sentence.1'), t('agent.welcome.sentence.2')]}
         />
+        <Markdown fontSize={13} variant={'chat'}>
+          {t('agent.welcome')}
+        </Markdown>
       </Flexbox>
     </>
   );

--- a/src/features/Onboarding/Agent/Welcome.tsx
+++ b/src/features/Onboarding/Agent/Welcome.tsx
@@ -1,4 +1,5 @@
-import { Flexbox } from '@lobehub/ui';
+import { Flexbox, Markdown } from '@lobehub/ui';
+import { Divider } from 'antd';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -26,6 +27,10 @@ const Welcome = memo(() => {
           gap={16}
           sentences={[t('agent.welcome.sentence.1'), t('agent.welcome.sentence.2')]}
         />
+        <Divider dashed style={{ margin: 0 }} />
+        <Markdown fontSize={16} variant={'chat'}>
+          {t('agent.welcome')}
+        </Markdown>
       </Flexbox>
     </>
   );


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No related issue found.

#### 🔀 Description of Change

- Render the existing onboarding `agent.welcome` copy in the agent welcome screen.
- Add the welcome guidance to both desktop and mobile onboarding variants.
- Add a dashed divider before the guidance copy on desktop to separate it from the animated greeting.

#### 🧪 How to Test

- `pnpm install`
- `bun run type-check`

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

Not captured.

#### 📝 Additional Information

This PR only surfaces an existing locale string; it does not add or change translation keys.