### PR TITLE
💄 style(community): use landing URL for agent share link

### DIFF
--- a/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/index.tsx
+++ b/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/index.tsx
@@ -4,7 +4,7 @@ import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
 import urlJoin from 'url-join';
 
-import { OFFICIAL_URL } from '@/const/url';
+import { AGENTS_OFFICIAL_URL } from '@/const/url';
 
 import ShareButton from '../../../../features/ShareButton';
 import { useDetailContext } from '../../DetailProvider';
@@ -21,7 +21,7 @@ const ActionButton = memo<{ mobile?: boolean }>(({ mobile }) => {
           desc: description,
           hashtags: tags,
           title,
-          url: urlJoin(OFFICIAL_URL, '/community/agent', identifier as string),
+          url: urlJoin(AGENTS_OFFICIAL_URL, identifier as string),
         }}
       />
     </Flexbox>


### PR DESCRIPTION
## Summary

- Change share URL for community agent pages from `app.lobehub.com/community/agent/{id}` to `lobehub.com/agent/{id}`
- Reuses the existing `AGENTS_OFFICIAL_URL` constant (`https://lobehub.com/agent`)

## Test plan

- [ ] Open a community agent page (e.g. `/community/agent/dan`)
- [ ] Click the share button
- [ ] Verify the share link shown is `https://lobehub.com/agent/dan`

🤖 Generated with [Claude Code](https://claude.com/claude-code)