### PR TITLE
🐛 fix(i18n): add provider description fallbacks

### DIFF
--- a/locales/en-US/providers.json
+++ b/locales/en-US/providers.json
@@ -33,6 +33,7 @@
   "jina.description": "Founded in 2020, Jina AI is a leading search AI company. Its search stack includes vector models, rerankers, and small language models to build reliable, high-quality generative and multimodal search apps.",
   "kimicodingplan.description": "Kimi Code from Moonshot AI provides access to Kimi models including K2.5 for coding tasks.",
   "lmstudio.description": "LM Studio is a desktop app for developing and experimenting with LLMs on your computer.",
+  "lobehub.description": "LobeHub Cloud uses official APIs to access AI models and measures usage with Credits tied to model tokens.",
   "longcat.description": "LongCat is a series of generative AI large models independently developed by Meituan. It is designed to enhance internal enterprise productivity and enable innovative applications through an efficient computational architecture and strong multimodal capabilities.",
   "minimax.description": "Founded in 2021, MiniMax builds general-purpose AI with multimodal foundation models, including trillion-parameter MoE text models, speech models, and vision models, along with apps like Hailuo AI.",
   "minimaxcodingplan.description": "MiniMax Token Plan provides access to MiniMax models including M2.7 for coding tasks via a fixed-fee subscription.",

--- a/locales/zh-CN/providers.json
+++ b/locales/zh-CN/providers.json
@@ -33,6 +33,7 @@
   "jina.description": "Jina AI 成立于 2020 年，是领先的搜索 AI 公司，其搜索技术栈包括向量模型、重排序器与小型语言模型，支持构建高质量的生成式与多模态搜索应用。",
   "kimicodingplan.description": "Kimi Code Plan 由 Moonshot AI 提供，通过固定月费订阅方式访问 Kimi 模型（包括 K2.5）用于编程任务。",
   "lmstudio.description": "LM Studio 是一款桌面应用，支持在本地开发与实验大语言模型。",
+  "lobehub.description": "LobeHub Cloud 通过官方 API 接入 AI 模型，并按模型令牌用量消耗积分。",
   "longcat.description": "LongCat 是由美团自主研发的生成式 AI 大模型系列，旨在通过高效的计算架构和强大的多模态能力，提升企业内部工作效率并推动创新应用的发展。",
   "minimax.description": "MiniMax 成立于 2021 年，致力于构建通用 AI，拥有多模态基础模型，包括万亿参数的 MoE 文本模型、语音模型与视觉模型，并推出海螺 AI 等应用。",
   "minimaxcodingplan.description": "MiniMax Token Plan 提供对 MiniMax 模型（包括 M2.7）的访问，适用于编程任务，采用固定月费订阅模式。",

--- a/src/locales/default/providers.ts
+++ b/src/locales/default/providers.ts
@@ -1,8 +1,11 @@
 import { DEFAULT_MODEL_PROVIDER_LIST } from 'model-bank/modelProviders';
+import LobeHubProvider from 'model-bank/modelProviders/lobehub';
 
 const locales: Record<`${string}.description`, string> = {};
 
-DEFAULT_MODEL_PROVIDER_LIST.forEach((provider) => {
+const providers = [LobeHubProvider, ...DEFAULT_MODEL_PROVIDER_LIST];
+
+providers.forEach((provider) => {
   if (!provider.description) return;
   locales[`${provider.id}.description`] = provider.description;
 });

--- a/src/routes/(main)/community/(detail)/model/features/Header.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Header.tsx
@@ -30,7 +30,7 @@ const styles = createStaticStyles(({ css, cssVar }) => {
 });
 
 const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
-  const { identifier, releasedAt, displayName, type, abilities, contextWindowTokens } =
+  const { description, identifier, releasedAt, displayName, type, abilities, contextWindowTokens } =
     useDetailContext();
   const { mobile = isMobile } = useResponsive();
   const { t } = useTranslation('models');
@@ -97,7 +97,7 @@ const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
           color: cssVar.colorTextSecondary,
         }}
       >
-        {t(`${identifier}.description`)}
+        {t(`${identifier}.description`, { defaultValue: description })}
       </div>
     </Flexbox>
   );

--- a/src/routes/(main)/community/(detail)/model/features/Sidebar/Related/Item.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Sidebar/Related/Item.tsx
@@ -26,7 +26,7 @@ const styles = createStaticStyles(({ css, cssVar }) => {
   };
 });
 
-const RelatedItem = memo<DiscoverModelItem>(({ identifier, displayName }) => {
+const RelatedItem = memo<DiscoverModelItem>(({ description, identifier, displayName }) => {
   const { t } = useTranslation('models');
   return (
     <Block horizontal gap={12} key={identifier} padding={12} variant={'outlined'}>
@@ -48,7 +48,7 @@ const RelatedItem = memo<DiscoverModelItem>(({ identifier, displayName }) => {
             rows: 2,
           }}
         >
-          {t(`${identifier}.description`)}
+          {t(`${identifier}.description`, { defaultValue: description })}
         </Text>
       </Flexbox>
     </Block>

--- a/src/routes/(main)/community/(detail)/model/features/Sidebar/RelatedProviders/Item.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Sidebar/RelatedProviders/Item.tsx
@@ -26,7 +26,7 @@ const styles = createStaticStyles(({ css, cssVar }) => {
   };
 });
 
-const RelatedItem = memo<DiscoverModelDetailProviderItem>(({ id, name }) => {
+const RelatedItem = memo<DiscoverModelDetailProviderItem>(({ description, id, name }) => {
   const { t } = useTranslation('providers');
   return (
     <Block horizontal gap={12} key={id} padding={12} variant={'outlined'}>
@@ -48,7 +48,7 @@ const RelatedItem = memo<DiscoverModelDetailProviderItem>(({ id, name }) => {
             rows: 2,
           }}
         >
-          {t(`${id}.description`)}
+          {t(`${id}.description`, { defaultValue: description })}
         </Text>
       </Flexbox>
     </Block>

--- a/src/routes/(main)/community/(detail)/provider/features/Header.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Header.tsx
@@ -12,7 +12,7 @@ import { useDetailContext } from './DetailProvider';
 
 const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
   const { t } = useTranslation('providers');
-  const { identifier, url, modelsUrl, name } = useDetailContext();
+  const { description, identifier, url, modelsUrl, name } = useDetailContext();
   const { mobile = isMobile } = useResponsive();
 
   return (
@@ -73,7 +73,7 @@ const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
           color: cssVar.colorTextSecondary,
         }}
       >
-        {t(`${identifier}.description`)}
+        {t(`${identifier}.description`, { defaultValue: description })}
       </Flexbox>
     </Flexbox>
   );

--- a/src/routes/(main)/community/(detail)/provider/features/Sidebar/ActionButton/index.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Sidebar/ActionButton/index.tsx
@@ -13,7 +13,7 @@ import { useDetailContext } from '../../DetailProvider';
 import ProviderConfig from './ProviderConfig';
 
 const ActionButton = memo(() => {
-  const { models = [], identifier, name } = useDetailContext();
+  const { description, models = [], identifier, name } = useDetailContext();
   const { t } = useTranslation('providers');
   return (
     <Flexbox horizontal align={'center'} gap={8} width={'100%'}>
@@ -21,7 +21,7 @@ const ActionButton = memo(() => {
       <ShareButton
         meta={{
           avatar: <ProviderIcon provider={identifier} size={64} type={'avatar'} />,
-          desc: t(`${identifier}.description`),
+          desc: t(`${identifier}.description`, { defaultValue: description }),
           tags: (
             <Flexbox horizontal align={'center'} gap={4} justify={'center'} wrap={'wrap'}>
               {models

--- a/src/routes/(main)/community/(detail)/provider/features/Sidebar/Related/Item.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Sidebar/Related/Item.tsx
@@ -26,7 +26,7 @@ const styles = createStaticStyles(({ css, cssVar }) => {
   };
 });
 
-const RelatedItem = memo<DiscoverProviderItem>(({ identifier, name }) => {
+const RelatedItem = memo<DiscoverProviderItem>(({ description, identifier, name }) => {
   const { t } = useTranslation('providers');
   return (
     <Block horizontal gap={12} key={identifier} padding={12} variant={'outlined'}>
@@ -48,7 +48,7 @@ const RelatedItem = memo<DiscoverProviderItem>(({ identifier, name }) => {
             rows: 2,
           }}
         >
-          {t(`${identifier}.description`)}
+          {t(`${identifier}.description`, { defaultValue: description })}
         </Text>
       </Flexbox>
     </Block>

--- a/src/routes/(main)/community/(detail)/provider/features/Sidebar/RelatedModels/Item.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Sidebar/RelatedModels/Item.tsx
@@ -26,7 +26,7 @@ const styles = createStaticStyles(({ css, cssVar }) => {
   };
 });
 
-const RelatedItem = memo<DiscoverProviderDetailModelItem>(({ id, displayName }) => {
+const RelatedItem = memo<DiscoverProviderDetailModelItem>(({ description, id, displayName }) => {
   const { t } = useTranslation('models');
   return (
     <Block horizontal gap={12} key={id} padding={12} variant={'outlined'}>
@@ -48,7 +48,7 @@ const RelatedItem = memo<DiscoverProviderDetailModelItem>(({ id, displayName }) 
             rows: 2,
           }}
         >
-          {t(`${id}.description`)}
+          {t(`${id}.description`, { defaultValue: description })}
         </Text>
       </Flexbox>
     </Block>

--- a/src/routes/(main)/community/(list)/model/features/List/Item.tsx
+++ b/src/routes/(main)/community/(list)/model/features/List/Item.tsx
@@ -51,7 +51,16 @@ const styles = createStaticStyles(({ css, cssVar }) => {
 });
 
 const ModelItem = memo<DiscoverModelItem>(
-  ({ identifier, displayName, contextWindowTokens, releasedAt, type, abilities, providers }) => {
+  ({
+    description,
+    identifier,
+    displayName,
+    contextWindowTokens,
+    releasedAt,
+    type,
+    abilities,
+    providers,
+  }) => {
     const { t } = useTranslation(['models', 'discover']);
     const navigate = useNavigate();
     const link = urlJoin('/community/model', identifier);
@@ -129,7 +138,7 @@ const ModelItem = memo<DiscoverModelItem>(
               rows: 3,
             }}
           >
-            {t(`${identifier}.description`)}
+            {t(`${identifier}.description`, { defaultValue: description })}
           </Text>
         </Flexbox>
         <Flexbox

--- a/src/routes/(main)/community/(list)/provider/features/List/Item.tsx
+++ b/src/routes/(main)/community/(list)/provider/features/List/Item.tsx
@@ -105,7 +105,7 @@ const ProviderItem = memo<DiscoverProviderItem>(
                 rows: 3,
               }}
             >
-              {t(`${identifier}.description`, { ns: 'providers' })}
+              {t(`${identifier}.description`, { defaultValue: description, ns: 'providers' })}
             </Text>
           )}
         </Flexbox>

--- a/src/routes/(main)/settings/provider/(list)/ProviderGrid/Card.tsx
+++ b/src/routes/(main)/settings/provider/(list)/ProviderGrid/Card.tsx
@@ -82,7 +82,9 @@ const ProviderCard = memo<ProviderCardProps>(
                   rows: 2,
                 }}
               >
-                {source === 'custom' ? description : t(`${id}.description`)}
+                {source === 'custom'
+                  ? description
+                  : t(`${id}.description`, { defaultValue: description })}
               </Text>
             </Flexbox>
           </div>


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

- Add the missing LobeHub provider description key to the default provider locale source and generated zh-CN/en-US provider locale JSON.
- Add description fallbacks for provider and model description rendering so missing i18n keys display the data-provided description instead of the raw key.
- Apply the same fallback to the settings provider grid card.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validated with:

- `bunx eslint src/locales/default/providers.ts 'src/routes/(main)/community/(list)/provider/features/List/Item.tsx' 'src/routes/(main)/community/(detail)/provider/features/Header.tsx' 'src/routes/(main)/community/(detail)/provider/features/Sidebar/Related/Item.tsx' 'src/routes/(main)/community/(detail)/provider/features/Sidebar/ActionButton/index.tsx' 'src/routes/(main)/community/(detail)/provider/features/Sidebar/RelatedModels/Item.tsx' 'src/routes/(main)/community/(detail)/model/features/Header.tsx' 'src/routes/(main)/community/(detail)/model/features/Sidebar/Related/Item.tsx' 'src/routes/(main)/community/(detail)/model/features/Sidebar/RelatedProviders/Item.tsx' 'src/routes/(main)/community/(list)/model/features/List/Item.tsx' 'src/routes/(main)/settings/provider/(list)/ProviderGrid/Card.tsx'`
- `bun run type-check`
- `git diff --check`

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| LobeHub provider card could show `lobehub.description` when the providers namespace missed the key. | The card uses localized copy or falls back to provider/model description data. |

#### 📝 Additional Information

This only affects i18n display text and fallback rendering. It does not change provider configuration, model lists, enablement, ordering, or server-side discover behavior.