### PR TITLE
🐛 fix(hetero): inject conversation history when cloud sandbox session expires

### DIFF
--- a/apps/cli/src/commands/hetero.ts
+++ b/apps/cli/src/commands/hetero.ts
@@ -320,6 +320,16 @@ const exec = async (options: ExecOptions): Promise<void> => {
     }
 
     const exitedClean = !ingestError && (code === 0 || signal === 'SIGTERM');
+
+    // Detect sandbox session expiry: CC ignored the --resume flag and started a
+    // new session (different sessionId). Conversation history was pre-injected
+    // as context by the server, so CC should have stayed coherent.
+    if (options.resume && handle.sessionId && handle.sessionId !== options.resume) {
+      log.warn(
+        `Sandbox session expired — new session started (requested: ${options.resume}, got: ${handle.sessionId})`,
+      );
+    }
+
     try {
       await sink.finish({
         result: exitedClean ? 'success' : 'error',

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -733,11 +733,48 @@ export class AiAgentService {
         log('execAgent: failed to resolve GitHub token: %O', err);
       }
 
+      // When resuming a prior session, fetch recent conversation messages so CC
+      // retains continuity even if the sandbox was recreated and its session
+      // files are gone. We cap at the most-recent 30 user/assistant turns and
+      // exclude the just-created placeholder and the current user message.
+      let conversationHistory:
+        | Array<{ content: string; role: 'assistant' | 'user' }>
+        | undefined;
+      if (resumeSessionId) {
+        try {
+          const currentTurnIds = new Set<string>(
+            [userMsg?.id, assistantMsg.id].filter((id): id is string => Boolean(id)),
+          );
+          const allMessages = await this.messageModel.query({ pageSize: 200, topicId });
+          const filtered = allMessages.filter(
+            (m) =>
+              (m.role === 'user' || m.role === 'assistant') &&
+              !m.threadId &&
+              !currentTurnIds.has(m.id) &&
+              m.content &&
+              m.content !== LOADING_FLAT,
+          );
+          const historySlice = filtered.slice(-30);
+          if (historySlice.length > 0) {
+            conversationHistory = historySlice.map((m) => ({
+              content: m.content,
+              role: m.role as 'assistant' | 'user',
+            }));
+          }
+        } catch (err) {
+          log(
+            'execAgent: failed to fetch conversation history for resume context (non-fatal): %O',
+            err,
+          );
+        }
+      }
+
       // Build cloud-specific system context (repo list + workspace info + optional agent-level static context).
       const { buildCloudHeteroContext } =
         await import('@/server/services/heterogeneousAgent/cloudHeteroContext');
       const systemContext = buildCloudHeteroContext({
         agentSystemContext: agentConfig.agencyConfig?.heterogeneousProvider?.systemContext,
+        conversationHistory,
         githubToken,
         repos: topicRepos,
       });

--- a/src/server/services/heterogeneousAgent/cloudHeteroContext.ts
+++ b/src/server/services/heterogeneousAgent/cloudHeteroContext.ts
@@ -1,9 +1,27 @@
+/** One message entry from the topic's conversation history, used for resume context. */
+export interface ConversationHistoryEntry {
+  content: string;
+  role: 'assistant' | 'user';
+}
+
+// Max chars to include per message in the history section. Long code dumps are
+// truncated with an ellipsis so the context block stays token-efficient.
+const HISTORY_MAX_CHARS_USER = 1000;
+const HISTORY_MAX_CHARS_ASSISTANT = 2000;
+
+const truncate = (text: string, limit: number): string =>
+  text.length <= limit ? text : `${text.slice(0, limit)}…[truncated]`;
+
 /**
  * Builds the system context injected before every user prompt for cloud Claude Code runs.
  *
  * This context is cloud-sandbox-specific: it describes the workspace layout,
  * lists the GitHub repos that were pre-cloned, and tells CC how to handle
  * repos that may not have been cloned successfully.
+ *
+ * When `conversationHistory` is supplied (resume turns only), a
+ * "Previous Conversation Context" section is prepended so Claude Code retains
+ * continuity even when the sandbox session has expired and CC starts fresh.
  *
  * It is NOT the agent's systemRole (which lives in agentConfig.systemRole and
  * is a user-facing persona definition). This is pure infra context for CC.
@@ -16,16 +34,51 @@ export function buildCloudHeteroContext(params: {
   repos: string[];
   /** Static systemContext from HeterogeneousProviderConfig.systemContext (agent-level). */
   agentSystemContext?: string;
+  /**
+   * Recent conversation messages from the DB (resume turns only).
+   * Injected before the workspace section so CC has conversational continuity
+   * even if the sandbox was recreated and session files are gone.
+   */
+  conversationHistory?: ConversationHistoryEntry[];
   /** GitHub OAuth token injected as GITHUB_TOKEN env var in the sandbox. */
   githubToken?: string;
 }): string {
-  const { repos, agentSystemContext, githubToken } = params;
+  const { repos, agentSystemContext, conversationHistory, githubToken } = params;
 
   const parts: string[] = [];
 
   // --- Agent-level static context (highest priority, goes first) ---
   if (agentSystemContext?.trim()) {
     parts.push(agentSystemContext.trim());
+  }
+
+  // --- Previous conversation history (resume turns only) ---
+  // Injected so CC retains context when the sandbox session has expired and
+  // CC starts a fresh session (new container, no ~/.claude session files).
+  // When the session IS alive CC already has the full history from its own
+  // session state; the block below is a lightweight fallback that CC can
+  // ignore in that case.
+  if (conversationHistory && conversationHistory.length > 0) {
+    const historyLines: string[] = [
+      '## Previous Conversation Context',
+      'This sandbox session may have expired and been recreated since the last turn.',
+      'The following conversation history is provided for continuity.',
+      'If your session state is intact you can ignore this section.',
+      'Note: file system state is **not** preserved across sandbox restarts —',
+      're-clone repositories or recreate any local files as needed.',
+      '',
+      '<previous_conversation>',
+    ];
+
+    for (const msg of conversationHistory) {
+      const label = msg.role === 'user' ? 'User' : 'Assistant';
+      const limit = msg.role === 'user' ? HISTORY_MAX_CHARS_USER : HISTORY_MAX_CHARS_ASSISTANT;
+      historyLines.push(`${label}: ${truncate(msg.content, limit)}`);
+      historyLines.push('');
+    }
+
+    historyLines.push('</previous_conversation>');
+    parts.push(historyLines.join('\n'));
   }
 
   // --- Cloud workspace context ---


### PR DESCRIPTION
## Summary

- When a cloud sandbox is destroyed (~1 hour inactivity), the `heteroSessionId` stored in `topic.metadata` becomes stale
- The next user message passes `--resume <staleId>` to CC CLI, but the session files no longer exist in the fresh container — CC silently starts a new session **with no prior context**
- Fix: when `resumeSessionId` is set (i.e. a continuation turn), fetch the last 30 user/assistant messages from the DB and inject them as a `<previous_conversation>` block in `systemContext`, before the user's prompt
- When the session IS alive CC already has full history and can ignore the block; when the session is dead the block provides continuity

## Changes

**`cloudHeteroContext.ts`**
- New `ConversationHistoryEntry` export type
- New `conversationHistory?` parameter on `buildCloudHeteroContext`
- Renders a `<previous_conversation>` section with per-message truncation (1 KB user / 2 KB assistant) when history is present

**`aiAgent/index.ts`**  
- After resolving `resumeSessionId`, fetches up to 200 recent topic messages (ASC), filters to the last 30 user/assistant turns (excludes thread messages, loading placeholders, current-turn IDs), and passes them to `buildCloudHeteroContext`

**`apps/cli/src/commands/hetero.ts`**
- After stream ends, logs a `[WARN]` when the actual CC session ID differs from the requested resume ID — observable signal that session expiry occurred

## Test plan

- [ ] First turn (no `resumeSessionId`): no history section injected — existing behavior unchanged
- [ ] Resume turn, session alive: history block present in system context but CC ignores it (has real session state)
- [ ] Resume turn, session dead (new sandbox): CC sees history block and stays coherent across sandbox restart
- [ ] CLI `--resume <staleId>` warning fires when IDs differ

🤖 Generated with [Claude Code](https://claude.com/claude-code)