### PR TITLE
🐛 fix: ignore optimistic message parent ids

### DIFF
--- a/packages/database/src/models/__tests__/messages/message.create.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.create.test.ts
@@ -77,6 +77,36 @@ describe('MessageModel Create Tests', () => {
       expect(result[0].content).toBe('new message');
     });
 
+    it('should ignore optimistic temporary parent ids when creating a single message', async () => {
+      const result = await messageModel.create({
+        content: 'message with stale optimistic parent',
+        parentId: 'tmp_staleParent',
+        role: 'assistant',
+        sessionId: '1',
+      });
+
+      expect(result.parentId).toBeNull();
+    });
+
+    it('should ignore optimistic temporary parent ids when creating user and assistant messages', async () => {
+      const result = await messageModel.createUserAndAssistantMessages({
+        assistantMessage: {
+          content: 'assistant reply',
+          role: 'assistant',
+          sessionId: '1',
+        },
+        userMessage: {
+          content: 'follow-up from stale optimistic state',
+          parentId: 'tmp_staleParent',
+          role: 'user',
+          sessionId: '1',
+        },
+      });
+
+      expect(result.userMessage.parentId).toBeNull();
+      expect(result.assistantMessage.parentId).toBe(result.userMessage.id);
+    });
+
     it('should create a message', async () => {
       const sessionId = 'session1';
       await serverDB.insert(sessions).values([{ id: sessionId, userId }]);

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -187,6 +187,8 @@ interface SplitCreateMessageParams {
   relations: CreateMessageRelationParams;
 }
 
+const isOptimisticMessageId = (id?: string | null) => id?.startsWith('tmp_') ?? false;
+
 export class MessageModel {
   private userId: string;
   private db: LobeChatDatabase;
@@ -1592,6 +1594,12 @@ export class MessageModel {
   ) => {
     // Ensure group message does not populate sessionId
     const normalizedMessage = message.groupId ? { ...message, sessionId: null } : message;
+    // Frontend optimistic placeholders are local-only ids. If a stale tmp parent
+    // leaks into persistence, PostgreSQL rejects the insert with
+    // messages_parent_id_messages_id_fk, for example parentId='tmp_i5p71qZm'.
+    const parentId = isOptimisticMessageId(normalizedMessage.parentId)
+      ? undefined
+      : normalizedMessage.parentId;
 
     return {
       ...normalizedMessage,
@@ -1601,6 +1609,7 @@ export class MessageModel {
       createdAt: createdAt ? new Date(createdAt) : undefined,
       id,
       model: fromModel,
+      parentId,
       provider: fromProvider,
       updatedAt: updatedAt ? new Date(updatedAt) : undefined,
       userId: this.userId,

--- a/src/services/aiChat.test.ts
+++ b/src/services/aiChat.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { lambdaClient } from '@/libs/trpc/client';
+
+import { aiChatService } from './aiChat';
+
+vi.mock('@/libs/trpc/client', () => ({
+  lambdaClient: {
+    aiChat: {
+      sendMessageInServer: { mutate: vi.fn() },
+    },
+  },
+}));
+
+describe('AiChatService', () => {
+  describe('sendMessageInServer', () => {
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should omit optimistic temporary parent ids before calling lambdaClient', async () => {
+      vi.mocked(lambdaClient.aiChat.sendMessageInServer.mutate).mockResolvedValue({} as any);
+
+      const abortController = new AbortController();
+
+      await aiChatService.sendMessageInServer(
+        {
+          newAssistantMessage: { provider: 'openai' },
+          newUserMessage: {
+            content: 'test',
+            parentId: 'tmp_staleParent',
+          },
+        },
+        abortController,
+      );
+
+      expect(lambdaClient.aiChat.sendMessageInServer.mutate).toHaveBeenCalledWith(
+        {
+          newAssistantMessage: { provider: 'openai' },
+          newUserMessage: {
+            content: 'test',
+            parentId: undefined,
+          },
+        },
+        {
+          context: { showNotification: false },
+          signal: abortController.signal,
+        },
+      );
+    });
+
+    it('should preserve persisted parent ids', async () => {
+      vi.mocked(lambdaClient.aiChat.sendMessageInServer.mutate).mockResolvedValue({} as any);
+
+      const abortController = new AbortController();
+
+      await aiChatService.sendMessageInServer(
+        {
+          newAssistantMessage: { provider: 'openai' },
+          newUserMessage: {
+            content: 'test',
+            parentId: 'msg_parent',
+          },
+        },
+        abortController,
+      );
+
+      expect(lambdaClient.aiChat.sendMessageInServer.mutate).toHaveBeenCalledWith(
+        {
+          newAssistantMessage: { provider: 'openai' },
+          newUserMessage: {
+            content: 'test',
+            parentId: 'msg_parent',
+          },
+        },
+        {
+          context: { showNotification: false },
+          signal: abortController.signal,
+        },
+      );
+    });
+  });
+});

--- a/src/services/aiChat.ts
+++ b/src/services/aiChat.ts
@@ -3,12 +3,19 @@ import { cleanObject } from '@lobechat/utils';
 
 import { lambdaClient } from '@/libs/trpc/client';
 
+import { omitOptimisticParentId } from './utils/optimisticMessage';
+
 class AiChatService {
   sendMessageInServer = async (
     params: SendMessageServerParams,
     abortController: AbortController,
   ) => {
-    return lambdaClient.aiChat.sendMessageInServer.mutate(cleanObject(params), {
+    const sanitizedParams: SendMessageServerParams = {
+      ...params,
+      newUserMessage: omitOptimisticParentId(params.newUserMessage),
+    };
+
+    return lambdaClient.aiChat.sendMessageInServer.mutate(cleanObject(sanitizedParams), {
       context: { showNotification: false },
       signal: abortController?.signal,
     });

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -18,6 +18,7 @@ import { type HeatmapsProps } from '@lobehub/charts';
 import { lambdaClient } from '@/libs/trpc/client';
 
 import { abortableRequest } from '../utils/abortableRequest';
+import { omitOptimisticParentId } from '../utils/optimisticMessage';
 
 /**
  * Query context for message operations
@@ -33,7 +34,7 @@ export interface MessageQueryContext {
 
 export class MessageService {
   createMessage = async (params: CreateMessageParams): Promise<CreateMessageResult> => {
-    return lambdaClient.message.createMessage.mutate(params as any);
+    return lambdaClient.message.createMessage.mutate(omitOptimisticParentId(params) as any);
   };
 
   getMessages = async (params: MessageQueryContext): Promise<UIChatMessage[]> => {

--- a/src/services/message/server.test.ts
+++ b/src/services/message/server.test.ts
@@ -40,6 +40,27 @@ describe('MessageService', () => {
         agentId: 'agent-123',
       });
     });
+
+    it('should omit optimistic temporary parent ids before calling lambdaClient', async () => {
+      vi.mocked(lambdaClient.message.createMessage.mutate).mockResolvedValue({
+        id: 'msg-1',
+        messages: [],
+      });
+
+      await service.createMessage({
+        content: 'test',
+        parentId: 'tmp_staleParent',
+        role: 'user',
+        agentId: 'agent-123',
+      });
+
+      expect(lambdaClient.message.createMessage.mutate).toHaveBeenCalledWith({
+        content: 'test',
+        parentId: undefined,
+        role: 'user',
+        agentId: 'agent-123',
+      });
+    });
   });
 
   describe('removeMessagesByAssistant', () => {

--- a/src/services/utils/optimisticMessage.ts
+++ b/src/services/utils/optimisticMessage.ts
@@ -1,0 +1,7 @@
+export const isOptimisticMessageId = (id?: string | null) => id?.startsWith('tmp_') ?? false;
+
+export const omitOptimisticParentId = <T extends { parentId?: string | null }>(message: T): T => {
+  if (!isOptimisticMessageId(message.parentId)) return message;
+
+  return { ...message, parentId: undefined };
+};


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-9427
Related to LOBE-9369

#### 🔀 Description of Change

- Omit local `tmp_*` optimistic parent ids at the client service boundary before persistence requests.
- Cover both `aiChat.sendMessageInServer` and direct `message.createMessage` calls.
- Keep the database model guard as a final invariant so local-only optimistic ids cannot violate the `messages.parent_id` foreign key if another path leaks them.
- Preserve real persisted parent ids so genuine foreign key errors remain visible.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bunx vitest run --silent='passed-only' 'src/services/aiChat.test.ts' 'src/services/message/server.test.ts'`\n\n`cd packages/database && bunx vitest run --silent='passed-only' 'src/models/__tests__/messages/message.create.test.ts'`\n\n#### 📸 Screenshots / Videos\n\nN/A, no UI changes.\n\n#### 📝 Additional Information\n\nThe service-level normalization is the primary fix. The DB-level guard is intentionally kept as a narrow last-resort boundary check for local-only ids.