### PR TITLE
🐛 chore(builtin-tool-memory): missing sourceIds in manifest causing memory failure

### DIFF
--- a/packages/builtin-tool-memory/src/manifest.ts
+++ b/packages/builtin-tool-memory/src/manifest.ts
@@ -241,6 +241,11 @@ export const MemoryManifest: BuiltinToolManifest = {
             description: 'Concise overview of this specific memory',
             type: 'string',
           },
+          sourceIds: {
+            description: 'Stable source message ids that support this memory. Use [] when unavailable.',
+            items: { type: 'string' },
+            type: ['array', 'null'],
+          },
           tags: {
             description: 'User defined tags that summarize the context facets',
             items: { type: 'string' },
@@ -391,6 +396,11 @@ export const MemoryManifest: BuiltinToolManifest = {
           summary: {
             description: 'Concise overview of this activity.',
             type: 'string',
+          },
+          sourceIds: {
+            description: 'Stable source message ids that support this memory. Use [] when unavailable.',
+            items: { type: 'string' },
+            type: ['array', 'null'],
           },
           tags: {
             description: 'Model generated tags summarizing key facets of the activity.',
@@ -550,6 +560,11 @@ export const MemoryManifest: BuiltinToolManifest = {
             description: 'Concise overview of this specific memory',
             type: 'string',
           },
+          sourceIds: {
+            description: 'Stable source message ids that support this memory. Use [] when unavailable.',
+            items: { type: 'string' },
+            type: ['array', 'null'],
+          },
           tags: {
             description: 'Model generated tags that summarize the experience facets',
             items: { type: 'string' },
@@ -693,6 +708,12 @@ export const MemoryManifest: BuiltinToolManifest = {
                 type: 'string',
               },
               scoreConfidence: { type: 'number' },
+              sourceIds: {
+                description:
+                  'Stable source message ids that support this memory. Use [] when unavailable.',
+                items: { type: 'string' },
+                type: ['array', 'null'],
+              },
               sourceEvidence: { type: ['string', 'null'] },
               type: {
                 enum: IDENTITY_TYPES,
@@ -747,6 +768,11 @@ export const MemoryManifest: BuiltinToolManifest = {
           summary: {
             description: 'Concise overview of this specific memory',
             type: 'string',
+          },
+          sourceIds: {
+            description: 'Stable source message ids that support this memory. Use [] when unavailable.',
+            items: { type: 'string' },
+            type: ['array', 'null'],
           },
           tags: {
             description: 'Model generated tags that summarize the preference facets',
@@ -928,6 +954,12 @@ export const MemoryManifest: BuiltinToolManifest = {
                     type: ['string', 'null'],
                   },
                   scoreConfidence: { type: ['number', 'null'] },
+                  sourceIds: {
+                    description:
+                      'Stable source message ids that support this memory. Use [] when unavailable.',
+                    items: { type: 'string' },
+                    type: ['array', 'null'],
+                  },
                   sourceEvidence: { type: ['string', 'null'] },
                   type: {
                     description: `Possible values: ${IDENTITY_TYPES.join(' | ')}`,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

Related to memory tool calls that include sourceIds provenance.

#### 🔀 Description of Change

- Add sourceIds to builtin memory tool manifest write/update schemas.
- Align manifest validation with memory extraction schemas so sourceIds are not rejected as additional properties.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Validated with:

```
bun -e '<AJV validation for 6 memory manifest sourceIds cases>'
bunx eslint packages/builtin-tool-memory/src/manifest.ts
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No UI changes.