### PR TITLE
🐛 fix: guard restricted default provider selection

### DIFF
--- a/src/features/ModelSwitchPanel/components/List/MultipleProvidersModelItem.tsx
+++ b/src/features/ModelSwitchPanel/components/List/MultipleProvidersModelItem.tsx
@@ -55,6 +55,10 @@ export const MultipleProvidersModelItem = memo<MultipleProvidersModelItemProps>(
 
     const activeProvider = data.providers.find((p) => menuKey(p.id, data.model.id) === activeKey);
     const isActive = !!activeProvider;
+    const defaultProvider = data.providers[0];
+    const defaultProviderRestricted = Boolean(
+      defaultProvider && isModelRestricted?.(data.model.id, defaultProvider.id),
+    );
 
     const allRestricted =
       isModelRestricted &&
@@ -73,13 +77,17 @@ export const MultipleProvidersModelItem = memo<MultipleProvidersModelItemProps>(
           className={cx(menuSharedStyles.item, isActive && styles.menuItemActive)}
           style={{ paddingBlock: 8, paddingInline: 8 }}
           onClick={() => {
-            if (allRestricted) {
+            if (defaultProviderRestricted) {
               onRestrictedModelClick?.();
               onClose();
               return;
             }
+            if (!defaultProvider) {
+              onClose();
+              return;
+            }
             setSubmenuOpen(false);
-            onModelChange(data.model.id, data.providers[0].id);
+            onModelChange(data.model.id, defaultProvider.id);
             onClose();
           }}
         >
@@ -87,7 +95,7 @@ export const MultipleProvidersModelItem = memo<MultipleProvidersModelItemProps>(
             {...data.model}
             {...data.model.abilities}
             newBadgeLabel={newLabel}
-            proBadgeLabel={allRestricted ? proLabel : undefined}
+            proBadgeLabel={defaultProviderRestricted ? proLabel : undefined}
             showInfoTag={showInfoTag}
           />
         </DropdownMenuSubmenuTrigger>

--- a/src/features/ModelSwitchPanel/components/List/__tests__/MultipleProvidersModelItem.test.tsx
+++ b/src/features/ModelSwitchPanel/components/List/__tests__/MultipleProvidersModelItem.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment happy-dom
  */
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { HTMLAttributes, ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -45,7 +45,18 @@ vi.mock('@lobehub/ui', () => ({
 }));
 
 vi.mock('@/components/ModelSelect', () => ({
-  ModelItemRender: ({ displayName }: { displayName: string }) => <div>{displayName}</div>,
+  ModelItemRender: ({
+    displayName,
+    proBadgeLabel,
+  }: {
+    displayName: string;
+    proBadgeLabel?: string;
+  }) => (
+    <div>
+      {displayName}
+      {proBadgeLabel && <span data-testid="model-pro-badge">{proBadgeLabel}</span>}
+    </div>
+  ),
   ProviderItemRender: ({ name }: { name: string }) => <div>{name}</div>,
 }));
 
@@ -83,5 +94,45 @@ describe('MultipleProvidersModelItem', () => {
 
     expect(screen.getByTestId('model-detail-panel')).toHaveTextContent('lobehub/gpt-5.4');
     expect(screen.getByText('ModelSwitchPanel.useModelFrom')).toBeInTheDocument();
+  });
+
+  it('uses the restricted handler when the default provider is restricted', () => {
+    const onClose = vi.fn();
+    const onModelChange = vi.fn();
+    const onRestrictedModelClick = vi.fn();
+
+    render(
+      <MultipleProvidersModelItem
+        activeKey="anthropic/claude-opus-4-7"
+        newLabel="new"
+        proLabel="pro"
+        showInfoTag={false}
+        data={{
+          displayName: 'Claude Opus 4.7',
+          model: {
+            abilities: {},
+            displayName: 'Claude Opus 4.7',
+            id: 'claude-opus-4-7',
+          } as any,
+          providers: [
+            { id: 'lobehub', name: 'LobeHub' },
+            { id: 'anthropic', name: 'Anthropic' },
+          ],
+        }}
+        isModelRestricted={(modelId, providerId) =>
+          modelId === 'claude-opus-4-7' && providerId === 'lobehub'
+        }
+        onClose={onClose}
+        onModelChange={onModelChange}
+        onRestrictedModelClick={onRestrictedModelClick}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Claude Opus 4.7'));
+
+    expect(onRestrictedModelClick).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onModelChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId('model-pro-badge')).toHaveTextContent('pro');
   });
 });


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Guard multi-provider model top-level selection against the restriction state of the default provider.
- Show the Pro badge on the model row when the default provider is restricted.
- Add coverage for the restricted default-provider click path.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/features/ModelSwitchPanel/components/List/__tests__/MultipleProvidersModelItem.test.tsx'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This keeps provider submenu behavior intact: restricted providers navigate through the restriction handler, while unrestricted providers remain selectable.