### PR TITLE
💄 style(workflow): show check with warning badge for partial-success runs

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx
@@ -387,7 +387,7 @@ describe('WorkflowCollapse', () => {
     expect(icon).toHaveAttribute('data-icon', 'Check');
   });
 
-  it('shows yellow warning when some tools fail after completion', () => {
+  it('shows check with a warning badge when some tools fail after completion', () => {
     mockIsGenerating = false;
     const blocks: AssistantContentBlock[] = [
       {
@@ -415,8 +415,10 @@ describe('WorkflowCollapse', () => {
     ];
 
     render(<WorkflowCollapse assistantMessageId="msg-1" blocks={blocks} />);
-    const icon = screen.getByTestId('icon');
-    expect(icon).toHaveAttribute('data-icon', 'TriangleAlert');
+    const icons = screen.getAllByTestId('icon');
+    const iconNames = icons.map((node) => node.getAttribute('data-icon'));
+    expect(iconNames).toContain('Check');
+    expect(iconNames).toContain('TriangleAlert');
   });
 
   it('shows red x when all tools fail after completion', () => {

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
@@ -331,24 +331,64 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
       threshold: WORKFLOW_EXPANDED_SCROLL_THRESHOLD_PX,
     });
 
-    const getStatusIcon = (): React.ReactNode => {
+    const renderStatusBlock = (): React.ReactNode => {
+      const wrapInBlock = (inner: React.ReactNode) => (
+        <Block
+          horizontal
+          align="center"
+          flex="none"
+          height={24}
+          justify="center"
+          style={{ fontSize: 12 }}
+          variant="outlined"
+          width={24}
+        >
+          {inner}
+        </Block>
+      );
+
       if (streaming) {
-        return pendingInterventionPresent ? (
-          <Icon color={cssVar.colorInfo} icon={HandIcon} />
-        ) : (
-          <NeuralNetworkLoading size={16} />
+        return wrapInBlock(
+          pendingInterventionPresent ? (
+            <Icon color={cssVar.colorInfo} icon={HandIcon} />
+          ) : (
+            <NeuralNetworkLoading size={16} />
+          ),
         );
       }
 
       switch (completionStatus) {
         case 'error': {
-          return <Icon color={cssVar.colorError} icon={X} />;
+          return wrapInBlock(<Icon color={cssVar.colorError} icon={X} />);
         }
         case 'partial': {
-          return <Icon color={cssVar.colorWarning} icon={AlertTriangle} />;
+          // Mix of success + failure: show success as the primary state and
+          // surface a small warning badge at the bottom-right so the overall
+          // turn still reads as "done" rather than "broken".
+          return (
+            <div style={{ flex: 'none', position: 'relative' }}>
+              {wrapInBlock(<Icon color={cssVar.colorSuccess} icon={Check} />)}
+              <div
+                style={{
+                  alignItems: 'center',
+                  background: cssVar.colorBgContainer,
+                  borderRadius: '50%',
+                  bottom: -3,
+                  display: 'flex',
+                  height: 12,
+                  justifyContent: 'center',
+                  position: 'absolute',
+                  right: -3,
+                  width: 12,
+                }}
+              >
+                <Icon color={cssVar.colorWarning} icon={AlertTriangle} size={10} />
+              </div>
+            </div>
+          );
         }
         default: {
-          return <Icon color={cssVar.colorSuccess} icon={Check} />;
+          return wrapInBlock(<Icon color={cssVar.colorSuccess} icon={Check} />);
         }
       }
     };
@@ -391,18 +431,7 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
 
     const title = (
       <Flexbox horizontal align="center" gap={6} style={{ minWidth: 0 }}>
-        <Block
-          horizontal
-          align="center"
-          flex="none"
-          height={24}
-          justify="center"
-          style={{ fontSize: 12 }}
-          variant="outlined"
-          width={24}
-        >
-          {getStatusIcon()}
-        </Block>
+        {renderStatusBlock()}
         {streaming ? (
           <Flexbox
             horizontal

--- a/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.tsx
@@ -373,16 +373,16 @@ const WorkflowCollapse = memo<WorkflowCollapseProps>(
                   alignItems: 'center',
                   background: cssVar.colorBgContainer,
                   borderRadius: '50%',
-                  bottom: -3,
+                  bottom: 0,
                   display: 'flex',
-                  height: 12,
+                  height: 10,
                   justifyContent: 'center',
                   position: 'absolute',
-                  right: -3,
-                  width: 12,
+                  right: 0,
+                  width: 10,
                 }}
               >
-                <Icon color={cssVar.colorWarning} icon={AlertTriangle} size={10} />
+                <Icon color={cssVar.colorWarning} icon={AlertTriangle} size={8} />
               </div>
             </div>
           );


### PR DESCRIPTION
## Summary

- When a workflow turn finishes with both successful and failed tool calls, show a green check as the primary status indicator and pin a small warning triangle to the bottom-right of the 24×24 status block — so the overall turn still reads as "done" rather than flipping the whole indicator to warning.
- All-error and all-success states are unchanged.

## Before / After

Before: partial-success runs showed only a yellow `AlertTriangle` next to "共 N 次调用 · M 次失败", which read as if the whole turn had failed.

After: a green `Check` with a tiny `AlertTriangle` badge at the corner — keeps the success affordance while still surfacing the partial failure.

## Test plan

- [x] `bunx vitest run src/features/Conversation/Messages/AssistantGroup/components/WorkflowCollapse.test.tsx`
- [x] `bun run type-check`
- [ ] Spot-check a Claude Code / heterogeneous-agent run that ends with mixed tool outcomes

🤖 Generated with [Claude Code](https://claude.com/claude-code)