### PR TITLE
🐛 fix: preserve Gemini image diagnostics

### DIFF
--- a/packages/model-runtime/src/providers/google/createImage.test.ts
+++ b/packages/model-runtime/src/providers/google/createImage.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import type { GoogleGenAI } from '@google/genai';
+import { MediaModality } from '@google/genai';
 import * as imageToBase64Module from '@lobechat/utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -10,13 +11,20 @@ const provider = 'google';
 const bizErrorType = 'ProviderBizError';
 const noImageErrorType = 'ProviderNoImageGenerated';
 const invalidErrorType = 'InvalidProviderAPIKey';
+const getModelPricingMock = vi.hoisted(() => vi.fn());
 
 // Mock the console.error to avoid polluting test output
 vi.spyOn(console, 'error').mockImplementation(() => {});
 
+vi.mock('../../utils/getModelPricing', () => ({
+  getModelPricing: getModelPricingMock,
+}));
+
 let mockClient: GoogleGenAI;
 
 beforeEach(() => {
+  getModelPricingMock.mockReset();
+  getModelPricingMock.mockResolvedValue(undefined);
   mockClient = {
     models: {
       generateImages: vi.fn(),
@@ -380,11 +388,77 @@ describe('createGoogleImage', () => {
         ],
         model: 'gemini-2.5-flash-image',
         config: {
-          responseModalities: ['Image'],
+          responseModalities: ['TEXT', 'IMAGE'],
         },
       });
       expect(result).toEqual({
         imageUrl: `data:image/png;base64,${realBase64ImageData}`,
+      });
+    });
+
+    it('should include text output tokens in successful image usage cost', async () => {
+      // Arrange
+      getModelPricingMock.mockResolvedValueOnce({
+        units: [
+          { name: 'imageOutput', rate: 120, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+          { name: 'textOutput', rate: 12, strategy: 'fixed', unit: 'millionTokens' },
+        ],
+      });
+      const realBase64ImageData =
+        'iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==';
+      const mockContentResponse = {
+        candidates: [
+          {
+            content: {
+              parts: [
+                { text: 'Here is the generated image.' },
+                {
+                  inlineData: {
+                    data: realBase64ImageData,
+                    mimeType: 'image/png',
+                  },
+                },
+              ],
+            },
+          },
+        ],
+        usageMetadata: {
+          candidatesTokenCount: 1500,
+          candidatesTokensDetails: [
+            { modality: MediaModality.TEXT, tokenCount: 20 },
+            { modality: MediaModality.IMAGE, tokenCount: 1480 },
+          ],
+          promptTokenCount: 100,
+          promptTokensDetails: [{ modality: MediaModality.TEXT, tokenCount: 100 }],
+          totalTokenCount: 1600,
+        },
+      };
+      vi.spyOn(mockClient.models, 'generateContent').mockResolvedValue(mockContentResponse as any);
+
+      const payload: CreateImagePayload = {
+        model: 'gemini-3-pro-image-preview:image',
+        params: {
+          prompt: 'Create a beautiful sunset landscape',
+        },
+      };
+
+      // Act
+      const result = await createGoogleImage(mockClient, provider, payload);
+
+      // Assert
+      expect(getModelPricingMock).toHaveBeenCalledWith(
+        'gemini-3-pro-image-preview:image',
+        provider,
+      );
+      expect(result.modelUsage).toMatchObject({
+        cost: 0.178_04,
+        inputTextTokens: 100,
+        outputImageTokens: 1480,
+        outputTextTokens: 20,
+        totalInputTokens: 100,
+        totalOutputTokens: 1500,
+        totalTokens: 1600,
       });
     });
 
@@ -431,7 +505,7 @@ describe('createGoogleImage', () => {
         ],
         model: 'gemini-2.5-flash-image',
         config: {
-          responseModalities: ['Image'],
+          responseModalities: ['TEXT', 'IMAGE'],
         },
       });
     });
@@ -482,7 +556,7 @@ describe('createGoogleImage', () => {
         ],
         model: 'gemini-2.5-flash-image',
         config: {
-          responseModalities: ['Image'],
+          responseModalities: ['TEXT', 'IMAGE'],
           imageConfig: {
             imageSize: '4K',
           },
@@ -534,7 +608,7 @@ describe('createGoogleImage', () => {
         ],
         model: 'gemini-2.5-flash-image',
         config: {
-          responseModalities: ['Image'],
+          responseModalities: ['TEXT', 'IMAGE'],
           imageConfig: {
             aspectRatio: '16:9',
             imageSize: '2K',
@@ -586,7 +660,7 @@ describe('createGoogleImage', () => {
         ],
         model: 'gemini-2.5-flash-image',
         config: {
-          responseModalities: ['Image'],
+          responseModalities: ['TEXT', 'IMAGE'],
           imageConfig: {
             aspectRatio: '9:16',
           },
@@ -648,7 +722,7 @@ describe('createGoogleImage', () => {
         ],
         model: 'gemini-2.5-flash-image',
         config: {
-          responseModalities: ['Image'],
+          responseModalities: ['TEXT', 'IMAGE'],
         },
       });
       expect(result).toEqual({
@@ -719,7 +793,7 @@ describe('createGoogleImage', () => {
         ],
         model: 'gemini-2.5-flash-image',
         config: {
-          responseModalities: ['Image'],
+          responseModalities: ['TEXT', 'IMAGE'],
         },
       });
       expect(result).toEqual({
@@ -771,7 +845,7 @@ describe('createGoogleImage', () => {
         ],
         model: 'gemini-2.5-flash-image',
         config: {
-          responseModalities: ['Image'],
+          responseModalities: ['TEXT', 'IMAGE'],
         },
       });
       expect(result).toEqual({
@@ -813,6 +887,106 @@ describe('createGoogleImage', () => {
             provider,
           }),
         );
+      });
+
+      it('should preserve Google no-image diagnostic context without serializing text parts', async () => {
+        // Arrange
+        const mockContentResponse = {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    text: 'I can describe the image, but no image was returned.',
+                  },
+                ],
+              },
+              finishReason: 'NO_IMAGE',
+              finishMessage: 'The model did not produce an image.',
+              safetyRatings: [
+                {
+                  blocked: false,
+                  category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
+                  probability: 'NEGLIGIBLE',
+                },
+              ],
+            },
+          ],
+          modelVersion: 'gemini-3-pro-image-preview',
+          responseId: 'response-1',
+        };
+        vi.spyOn(mockClient.models, 'generateContent').mockResolvedValue(
+          mockContentResponse as any,
+        );
+
+        const payload: CreateImagePayload = {
+          model: 'gemini-3-pro-image-preview:image',
+          params: {
+            prompt: 'Generate an image',
+          },
+        };
+
+        // Act
+        let error: any;
+        try {
+          await createGoogleImage(mockClient, provider, payload);
+        } catch (e) {
+          error = e;
+        }
+
+        // Assert
+        expect(error).toMatchObject({
+          errorType: noImageErrorType,
+          provider,
+        });
+        expect(error.providerResponse).toMatchObject({
+          candidates: [
+            {
+              finishMessage: 'The model did not produce an image.',
+              finishReason: 'NO_IMAGE',
+            },
+          ],
+          responseId: 'response-1',
+        });
+        expect(JSON.stringify(error)).not.toContain('I can describe the image');
+      });
+
+      it('should preserve Google image safety finish reasons without provider policy classification', async () => {
+        // Arrange
+        const mockContentResponse = {
+          candidates: [
+            {
+              content: {},
+              finishReason: 'IMAGE_SAFETY',
+              finishMessage: 'The generated image was blocked.',
+            },
+          ],
+          responseId: 'safety-response',
+        };
+        vi.spyOn(mockClient.models, 'generateContent').mockResolvedValue(
+          mockContentResponse as any,
+        );
+
+        const payload: CreateImagePayload = {
+          model: 'gemini-3-pro-image-preview:image',
+          params: {
+            prompt: 'Generate an image',
+          },
+        };
+
+        // Act & Assert
+        await expect(createGoogleImage(mockClient, provider, payload)).rejects.toMatchObject({
+          errorType: noImageErrorType,
+          provider,
+          providerResponse: {
+            candidates: [
+              {
+                finishReason: 'IMAGE_SAFETY',
+              },
+            ],
+            responseId: 'safety-response',
+          },
+        });
       });
 
       it('should throw error when response is malformed', async () => {

--- a/packages/model-runtime/src/providers/google/createImage.ts
+++ b/packages/model-runtime/src/providers/google/createImage.ts
@@ -1,4 +1,10 @@
-import type { Content, GenerateContentConfig, GoogleGenAI, Part } from '@google/genai';
+import type {
+  Content,
+  GenerateContentConfig,
+  GenerateContentResponse,
+  GoogleGenAI,
+  Part,
+} from '@google/genai';
 import { imageUrlToBase64 } from '@lobechat/utils';
 
 import { convertGoogleAIUsage } from '../../core/usageConverters/google-ai';
@@ -10,6 +16,34 @@ import { parseDataUri } from '../../utils/uriParser';
 
 // Maximum number of images allowed for processing
 const MAX_IMAGE_COUNT = 10;
+
+interface ErrorWithRawProviderResponse extends Error {
+  providerResponse?: GenerateContentResponse;
+}
+
+// Keep raw provider responses available to upstream error handlers without
+// exposing text-only no-image responses through JSON serialization.
+const attachNonSerializableProviderResponse = <T extends object>(
+  target: T,
+  response: GenerateContentResponse,
+): T & { providerResponse?: GenerateContentResponse } => {
+  Object.defineProperty(target, 'providerResponse', {
+    configurable: true,
+    enumerable: false,
+    value: response,
+  });
+
+  return target;
+};
+
+const createGoogleImageNoImageError = (
+  message: string,
+  response: GenerateContentResponse,
+): ErrorWithRawProviderResponse =>
+  attachNonSerializableProviderResponse(
+    new Error(message),
+    response,
+  ) as ErrorWithRawProviderResponse;
 
 /**
  * Process a single image URL and convert it to Google AI Part format
@@ -45,14 +79,15 @@ async function processImageForParts(imageUrl: string): Promise<Part> {
 /**
  * Extract image data from generateContent response
  */
-function extractImageFromResponse(response: any): CreateImageResponse {
+function extractImageFromResponse(response: GenerateContentResponse): CreateImageResponse {
   const candidate = response.candidates?.[0];
+
   if (candidate?.finishReason === 'NO_IMAGE') {
-    throw new Error('No image generated');
+    throw createGoogleImageNoImageError('No image generated', response);
   }
   if (!candidate?.content?.parts) {
     // Handle cases where Google returns 200 but omits image parts (often moderation)
-    throw new Error('No image generated');
+    throw createGoogleImageNoImageError('No image generated', response);
   }
 
   for (const part of candidate.content.parts) {
@@ -63,7 +98,7 @@ function extractImageFromResponse(response: any): CreateImageResponse {
   }
 
   // Fallback when no inlineData is present (commonly moderation or policy blocks)
-  throw new Error('No image data found in response');
+  throw createGoogleImageNoImageError('No image data found in response', response);
 }
 
 /**
@@ -154,7 +189,7 @@ async function generateImageByChatModel(
   }
 
   const config: GenerateContentConfig = {
-    responseModalities: ['Image'],
+    responseModalities: ['TEXT', 'IMAGE'],
     ...(Object.keys(imageConfig).length > 0 ? { imageConfig } : {}),
   };
 
@@ -199,10 +234,17 @@ export async function createGoogleImage(
     }
 
     const { errorType, error: parsedError } = parseGoogleErrorMessage(err.message);
-    throw AgentRuntimeError.createImage({
+    const providerResponse = (err as ErrorWithRawProviderResponse).providerResponse;
+    const agentError = AgentRuntimeError.createImage({
       error: parsedError,
       errorType,
       provider,
     });
+
+    if (providerResponse) {
+      attachNonSerializableProviderResponse(agentError, providerResponse);
+    }
+
+    throw agentError;
   }
 }

--- a/packages/model-runtime/src/providers/google/index.test.ts
+++ b/packages/model-runtime/src/providers/google/index.test.ts
@@ -11,6 +11,11 @@ import { LobeGoogleAI } from './index';
 const provider = 'google';
 const bizErrorType = 'ProviderBizError';
 const invalidErrorType = 'InvalidProviderAPIKey';
+const getModelPricingMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../utils/getModelPricing', () => ({
+  getModelPricing: getModelPricingMock,
+}));
 
 async function* createEmptyAsyncGenerator<T>(): AsyncGenerator<T> {
   yield* [] as unknown as T[];
@@ -22,6 +27,8 @@ vi.spyOn(console, 'error').mockImplementation(() => {});
 let instance: LobeGoogleAI;
 
 beforeEach(() => {
+  getModelPricingMock.mockReset();
+  getModelPricingMock.mockResolvedValue(undefined);
   instance = new LobeGoogleAI({ apiKey: 'test' });
 
   // Use vi.spyOn to mock the chat.completions.create method

--- a/packages/model-runtime/src/providers/google/index.test.ts
+++ b/packages/model-runtime/src/providers/google/index.test.ts
@@ -737,6 +737,7 @@ describe('buildGoogleToolsWithSearch', () => {
     const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
     const config = callArgs[0].config as any;
     expect(config.tools).toBeUndefined();
+    expect(config.toolConfig).toBeUndefined();
   });
 
   it('should drop googleSearch for image response models without search support', async () => {
@@ -771,6 +772,7 @@ describe('buildGoogleToolsWithSearch', () => {
     const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
     const config = callArgs[0].config as any;
     expect(config.tools).toBeUndefined();
+    expect(config.toolConfig).toBeUndefined();
   });
 
   it('should only keep googleSearch for image response models', async () => {
@@ -809,6 +811,7 @@ describe('buildGoogleToolsWithSearch', () => {
     expect(config.tools).toEqual([
       { googleSearch: { searchTypes: { imageSearch: {}, webSearch: {} } } },
     ]);
+    expect(config.toolConfig).toBeUndefined();
   });
 
   it('should combine search tools with function declarations for Gemini 3+ models', async () => {

--- a/packages/model-runtime/src/providers/google/index.test.ts
+++ b/packages/model-runtime/src/providers/google/index.test.ts
@@ -434,7 +434,6 @@ describe('LobeGoogleAI', () => {
       });
 
       it('should handle AbortError without data', async () => {
-        // eslint-disable-next-line require-yield
         const mockStream = (async function* () {
           yield* [] as any;
           throw new Error('aborted');
@@ -697,6 +696,112 @@ describe('buildGoogleToolsWithSearch', () => {
     const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
     const config = callArgs[0].config as any;
     expect(config.tools).toEqual([{ googleSearch: {} }]);
+  });
+
+  it('should drop function declarations for image response models', async () => {
+    const mockStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          text: 'test',
+          candidates: [
+            {
+              content: { parts: [{ text: 'test' }], role: 'model' },
+              finishReason: 'STOP',
+              index: 0,
+            },
+          ],
+          usageMetadata: { promptTokenCount: 1, totalTokenCount: 2 },
+          modelVersion: 'gemini-2.5-flash-image',
+        });
+        controller.close();
+      },
+    });
+    vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(
+      mockStream as any,
+    );
+
+    await instance.chat({
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: 'gemini-2.5-flash-image',
+      temperature: 0,
+      tools: [{ type: 'function', function: { name: 'test_tool', description: 'A test tool' } }],
+    });
+
+    const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
+    const config = callArgs[0].config as any;
+    expect(config.tools).toBeUndefined();
+  });
+
+  it('should drop googleSearch for image response models without search support', async () => {
+    const mockStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          text: 'test',
+          candidates: [
+            {
+              content: { parts: [{ text: 'test' }], role: 'model' },
+              finishReason: 'STOP',
+              index: 0,
+            },
+          ],
+          usageMetadata: { promptTokenCount: 1, totalTokenCount: 2 },
+          modelVersion: 'gemini-2.5-flash-image',
+        });
+        controller.close();
+      },
+    });
+    vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(
+      mockStream as any,
+    );
+
+    await instance.chat({
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: 'gemini-2.5-flash-image',
+      temperature: 0,
+      enabledSearch: true,
+    });
+
+    const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
+    const config = callArgs[0].config as any;
+    expect(config.tools).toBeUndefined();
+  });
+
+  it('should only keep googleSearch for image response models', async () => {
+    const mockStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          text: 'test',
+          candidates: [
+            {
+              content: { parts: [{ text: 'test' }], role: 'model' },
+              finishReason: 'STOP',
+              index: 0,
+            },
+          ],
+          usageMetadata: { promptTokenCount: 1, totalTokenCount: 2 },
+          modelVersion: 'gemini-3.1-flash-image-preview',
+        });
+        controller.close();
+      },
+    });
+    vi.spyOn(instance['client'].models, 'generateContentStream').mockResolvedValue(
+      mockStream as any,
+    );
+
+    await instance.chat({
+      messages: [{ content: 'Hello', role: 'user' }],
+      model: 'gemini-3.1-flash-image-preview',
+      temperature: 0,
+      enabledSearch: true,
+      urlContext: true,
+      tools: [{ type: 'function', function: { name: 'test_tool', description: 'A test tool' } }],
+    });
+
+    const callArgs = (instance['client'].models.generateContentStream as any).mock.calls[0];
+    const config = callArgs[0].config as any;
+    expect(config.tools).toEqual([
+      { googleSearch: { searchTypes: { imageSearch: {}, webSearch: {} } } },
+    ]);
   });
 
   it('should combine search tools with function declarations for Gemini 3+ models', async () => {

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -1,10 +1,10 @@
-import { GoogleGenAI } from '@google/genai';
 import type {
   GenerateContentConfig,
   HttpOptions,
   ThinkingConfig,
   Tool as GoogleFunctionCallTool,
 } from '@google/genai';
+import { GoogleGenAI } from '@google/genai';
 import debug from 'debug';
 
 import { type LobeRuntimeAI } from '../../core/BaseAI';
@@ -46,7 +46,18 @@ const modelsWithModalities = new Set([
   'nano-banana-pro-preview',
 ]);
 
-const modelsWithImageSearch = new Set(['gemini-3.1-flash-image-preview']);
+// These models need the explicit image/web searchTypes payload when googleSearch is enabled.
+// Other search-capable models use the plain `{ googleSearch: {} }` shape.
+const modelsWithImageSearchTypes = new Set(['gemini-3.1-flash-image-preview']);
+
+// Image-response chat models are stricter than text-only chat models because the request
+// also asks Gemini to return images via `responseModalities: ['Text', 'Image']`.
+// For example, gemini-2.5-flash-image rejects googleSearch with:
+// "Search as tool is not enabled for this model", while these models accept googleSearch.
+const imageResponseModelsWithGoogleSearch = new Set([
+  'gemini-3-pro-image-preview',
+  'gemini-3.1-flash-image-preview',
+]);
 
 // Gemini 3+ models support combined tools (search + urlContext + functionDeclarations)
 const isGemini3OrAbove = (model?: string): boolean => {
@@ -513,15 +524,27 @@ export class LobeGoogleAI implements LobeRuntimeAI {
   ): GoogleFunctionCallTool[] | undefined {
     const hasSearch = payload?.enabledSearch;
     const hasUrlContext = payload?.urlContext;
+    const model = payload?.model ?? '';
+    const isImageResponseModel = modelsWithModalities.has(model);
+    const supportsImageResponseGoogleSearch = imageResponseModelsWithGoogleSearch.has(model);
 
-    // Build GoogleSearch tool config with optional image search support
-    const googleSearchTool = hasSearch
-      ? {
-          googleSearch: modelsWithImageSearch.has(payload?.model ?? '')
-            ? { searchTypes: { imageSearch: {}, webSearch: {} } }
-            : {},
-        }
-      : undefined;
+    // Build GoogleSearch tool config with the model-specific search payload shape.
+    const googleSearchTool =
+      hasSearch && (!isImageResponseModel || supportsImageResponseGoogleSearch)
+        ? {
+            googleSearch: modelsWithImageSearchTypes.has(model)
+              ? { searchTypes: { imageSearch: {}, webSearch: {} } }
+              : {},
+          }
+        : undefined;
+
+    if (isImageResponseModel) {
+      // Keep only the prebuilt googleSearch tool for image-response models that support it.
+      // In `responseModalities: ['Text', 'Image']` requests, Vertex AI rejects
+      // function declarations and urlContext with INVALID_ARGUMENT:
+      // "Only google search tool and maps imagery grounding tool is supported for image response."
+      return googleSearchTool ? [googleSearchTool] : undefined;
+    }
 
     // Gemini 3+ models support combined tools (search + urlContext + functionDeclarations)
     if (isGemini3OrAbove(payload?.model)) {

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -201,6 +201,7 @@ export class LobeGoogleAI implements LobeRuntimeAI {
         }
       }
 
+      const tools = this.buildGoogleToolsWithSearch(payload.tools, payload);
       const config: GenerateContentConfig = {
         abortSignal: originalSignal,
         imageConfig:
@@ -245,10 +246,10 @@ export class LobeGoogleAI implements LobeRuntimeAI {
         // https://ai.google.dev/gemini-api/docs/tool-combination
         // Vertex AI does not support includeServerSideToolInvocations
         toolConfig:
-          !this.isVertexAi && this.needsServerSideToolInvocations(payload)
+          !this.isVertexAi && this.needsServerSideToolInvocations(model, tools)
             ? { includeServerSideToolInvocations: true }
             : undefined,
-        tools: this.buildGoogleToolsWithSearch(payload.tools, payload),
+        tools,
         topP: payload.top_p,
       };
 
@@ -509,11 +510,14 @@ export class LobeGoogleAI implements LobeRuntimeAI {
    * in that case.
    * @see https://ai.google.dev/gemini-api/docs/tool-combination
    */
-  private needsServerSideToolInvocations(payload?: ChatStreamPayload): boolean {
-    if (!isGemini3OrAbove(payload?.model)) return false;
+  private needsServerSideToolInvocations(
+    model: string | undefined,
+    tools: GoogleFunctionCallTool[] | undefined,
+  ): boolean {
+    if (!isGemini3OrAbove(model)) return false;
 
-    const hasBuiltIn = payload?.enabledSearch || payload?.urlContext;
-    const hasFunctions = payload?.tools && payload.tools.length > 0;
+    const hasBuiltIn = tools?.some((tool) => 'googleSearch' in tool || 'urlContext' in tool);
+    const hasFunctions = tools?.some((tool) => Boolean(tool.functionDeclarations?.length));
 
     return !!(hasBuiltIn && hasFunctions);
   }

--- a/src/server/routers/async/image.ts
+++ b/src/server/routers/async/image.ts
@@ -151,6 +151,13 @@ const categorizeError = (
     };
   }
 
+  if (providerContentPolicyMessage) {
+    return {
+      errorMessage: providerContentPolicyMessage,
+      errorType: AsyncTaskErrorType.ProviderContentModeration,
+    };
+  }
+
   if (error.errorType === AgentRuntimeErrorType.ProviderNoImageGenerated) {
     return {
       errorMessage: isEditingImage
@@ -166,13 +173,6 @@ const categorizeError = (
       errorMessage:
         error.error?.message || error.message || AgentRuntimeErrorType.InvalidProviderAPIKey,
       errorType: AsyncTaskErrorType.InvalidProviderAPIKey,
-    };
-  }
-
-  if (providerContentPolicyMessage) {
-    return {
-      errorMessage: providerContentPolicyMessage,
-      errorType: AsyncTaskErrorType.ProviderContentModeration,
     };
   }
 

--- a/src/store/image/slices/generationConfig/action.test.ts
+++ b/src/store/image/slices/generationConfig/action.test.ts
@@ -30,6 +30,12 @@ const customModelSchema: ModelParamsSchema = {
   steps: { default: 20, min: 1, max: 50 },
 };
 
+const sizeOnlyModelSchema: ModelParamsSchema = {
+  prompt: { default: '' },
+  imageUrls: { default: [] },
+  size: { default: 'auto', enum: ['auto', '1024x1024'] },
+};
+
 const testImageModels: AIImageModelCard[] = [
   {
     id: 'flux/schnell',
@@ -56,6 +62,13 @@ const testImageModels: AIImageModelCard[] = [
     } as ModelParamsSchema,
     releasedAt: '2024-01-01',
   },
+  {
+    id: 'size-only-model',
+    displayName: 'Size Only Model',
+    type: 'image',
+    parameters: sizeOnlyModelSchema,
+    releasedAt: '2024-01-01',
+  },
 ];
 
 const mockProviders = [
@@ -73,6 +86,11 @@ const mockProviders = [
     id: 'single-image-provider',
     name: 'Single Image Provider',
     children: [testImageModels[2]],
+  },
+  {
+    id: 'size-only-provider',
+    name: 'Size Only Provider',
+    children: [testImageModels[3]],
   },
 ];
 
@@ -357,7 +375,27 @@ describe('GenerationConfigAction', () => {
       });
 
       expect(result.current.parameters?.seed).toBeNull();
-      expect(result.current.parameters?.imageUrl).toBeNull();
+      expect(result.current.parameters?.imageUrl).toBeUndefined();
+    });
+
+    it('should drop settings that are unsupported by the target model schema', () => {
+      const { result } = renderHook(() => useImageStore());
+
+      act(() => {
+        result.current.reuseSettings('size-only-model', 'size-only-provider', {
+          height: 1024,
+          prompt: 'reuse prompt',
+          seed: 123,
+          size: '1024x1024',
+          width: 1024,
+        });
+      });
+
+      expect(result.current.parameters).toEqual({
+        imageUrls: [],
+        prompt: 'reuse prompt',
+        size: '1024x1024',
+      });
     });
 
     it('should update only seed parameter via reuseSeed', () => {

--- a/src/store/image/slices/generationConfig/action.test.ts
+++ b/src/store/image/slices/generationConfig/action.test.ts
@@ -9,6 +9,29 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useImageStore } from '@/store/image';
 
+const localStorageMock = vi.hoisted(() => {
+  let store: Record<string, string> = {};
+  const storage = {
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+  };
+
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: storage,
+  });
+
+  return storage;
+});
+
 const { currentImageSettingsMock } = vi.hoisted(() => ({
   currentImageSettingsMock: vi.fn(() => ({
     defaultImageNum: 4,
@@ -124,6 +147,7 @@ const initialTestState = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorageMock.clear();
   currentImageSettingsMock.mockReturnValue({ defaultImageNum: 4 });
   useImageStore.setState(initialTestState);
 });
@@ -279,7 +303,6 @@ describe('GenerationConfigAction', () => {
     });
 
     it('should convert imageUrl to imageUrls array when switching to multi-image model', () => {
-      const { result } = renderHook(() => useImageStore());
       const singleImageSchema: ModelParamsSchema = {
         prompt: { default: '' },
         imageUrl: { default: '' },

--- a/src/store/image/slices/generationConfig/action.ts
+++ b/src/store/image/slices/generationConfig/action.ts
@@ -82,6 +82,23 @@ function preserveImageInputParams(
   return normalizeImageInputOnSchemaSwitch(previousParameters, nextSchema, result);
 }
 
+function preserveReusableSettings(
+  settings: Partial<RuntimeImageGenParams>,
+  nextDefaultValues: RuntimeImageGenParams,
+  nextSchema: ModelParamsSchema,
+) {
+  const reusableSettings = settings as RuntimeImageGenParams;
+  const supportedParamKeys = Object.keys(nextSchema) as RuntimeImageGenParamsKeys[];
+  const result = preserveSupportedParams(
+    reusableSettings,
+    nextDefaultValues,
+    nextSchema,
+    supportedParamKeys,
+  );
+
+  return normalizeImageInputOnSchemaSwitch(reusableSettings, nextSchema, result);
+}
+
 type Setter = StoreSetter<ImageStore>;
 export const createGenerationConfigSlice = (set: Setter, get: () => ImageStore, _api?: unknown) =>
   new GenerationConfigActionImpl(set, get, _api);
@@ -313,11 +330,13 @@ export class GenerationConfigActionImpl {
     settings: Partial<RuntimeImageGenParams>,
   ): void => {
     const { defaultValues, parametersSchema } = getModelAndDefaults(model, provider);
+    const parameters = preserveReusableSettings(settings, defaultValues, parametersSchema);
+
     this.#set(
       () => ({
         model,
         provider,
-        parameters: { ...defaultValues, ...settings },
+        parameters,
         parametersSchema,
       }),
       false,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

- Preserve raw Gemini image responses on no-image errors as non-enumerable diagnostics so downstream handlers can inspect provider metadata without serializing text-only responses into logs.
- Request both text and image modalities for Gemini image generation and keep the open-source runtime behavior as `ProviderNoImageGenerated` when no image is returned.
- Prioritize provider content-policy messages over generic no-image async task errors when business hooks provide a policy classification.
- Keep existing Gemini image response tool filtering tests independent from cloud-only model pricing config.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/providers/google/createImage.test.ts'
cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/providers/google/index.test.ts'
bunx vitest run --silent='passed-only' 'src/store/image/slices/generationConfig/action.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

The raw provider response is attached as a non-enumerable property, so `JSON.stringify(error)` does not include Gemini text parts.
