### PR TITLE
🐛 fix(docker): make prepare script tolerant when git is unavailable

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "lint:style": "stylelint \"{src,tests}/**/*.{js,jsx,ts,tsx}\" --fix",
     "lint:ts": "eslint src/ tests/ --concurrency=auto",
     "lint:unused": "knip --include files,exports,types,enumMembers,duplicates",
-    "prepare": "git config core.hooksPath .githooks",
+    "prepare": "git rev-parse --git-dir > /dev/null 2>&1 && git config core.hooksPath .githooks || true",
     "prettier": "prettier -c --write \"**/**\"",
     "pull": "git pull",
     "qstash": "pnpx @upstash/qstash-cli@latest dev",


### PR DESCRIPTION
## Summary

- `package.json` 之 `prepare` script 调 `git config core.hooksPath .githooks`，于 Docker build 内既无 `.git` 亦无 `git` binary，致 `pnpm i` 直接退出非零码。
- 以 `git rev-parse --git-dir > /dev/null 2>&1 && git config core.hooksPath .githooks || true` 替换：在 git 工作树内一如往常装钩子；不在则静默 no-op，docker / CI / tarball 安装皆稳。
- 本地开发未受影响（`git rev-parse` 仍成功 → 钩子照常注册）。

## Test plan

- [x] `docker build --target builder .` 现已越过 `pnpm i` 阶段（之前正是在此因 prepare 失败而终止）
- [ ] 本地 `pnpm install` 后确认 `git config --get core.hooksPath` 仍为 `.githooks`
- [ ] CI Docker build 通过