### PR TITLE
🐛 fix: pin baseline-browser-mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
   "overrides": {
     "@types/react": "19.2.13",
     "antd": "6.3.5",
+    "baseline-browser-mapping": "2.10.31",
     "better-auth": "1.4.6",
     "better-call": "1.1.8",
     "drizzle-orm": "^0.45.1",
@@ -556,6 +557,7 @@
       "@react-pdf/image": "3.0.4",
       "@types/react": "19.2.13",
       "antd": "6.3.5",
+      "baseline-browser-mapping": "2.10.31",
       "better-auth": "1.4.6",
       "better-call": "1.1.8",
       "drizzle-orm": "^0.45.1",


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Pin `baseline-browser-mapping` to `2.10.31` in both package override locations.
- Prevent fresh pnpm installs from resolving the newer transitive version that can break the Next.js build chain.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validated `package.json` parses successfully. This is a package resolution change only.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No UI changes.