### PR TITLE
🐛 fix(desktop): route gateway agent runs through lh hetero exec

### DIFF
--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -172,35 +172,24 @@ export default class GatewayConnectionCtr extends ControllerModule {
     request: AgentRunRequestMessage,
   ): Promise<{ reason?: string; status: 'accepted' | 'rejected' }> {
     try {
-      const ctr = this.heterogeneousAgentCtr;
+      const serverUrl = await this.remoteServerConfigCtr.getRemoteServerUrl();
+      if (!serverUrl) {
+        return { reason: 'Remote server URL not configured', status: 'rejected' };
+      }
 
-      // Map agentType to binary name.
-      // claude-code → `claude` CLI; all other platforms use their type name as the binary.
-      const command = request.agentType === 'claude-code' ? 'claude' : request.agentType;
-
-      // Create a session for the hetero agent.
-      const { sessionId } = await ctr.startSession({
+      // Fire-and-forget: lh hetero exec handles spawn -> adapt ->
+      // BatchIngester -> heteroIngest/heteroFinish -> server -> Gateway -> clients.
+      // Same command as spawnHeteroSandbox() on the server side.
+      this.heterogeneousAgentCtr.spawnLhHeteroExec({
         agentType: request.agentType,
-        args: [],
-        command,
         cwd: request.cwd,
-        // Inject LOBEHUB_JWT so the CLI authenticates against heteroIngest.
-        env: { LOBEHUB_JWT: request.jwt },
+        jwt: request.jwt,
+        operationId: request.operationId,
+        prompt: request.prompt,
         resumeSessionId: request.resumeSessionId,
+        serverUrl,
+        topicId: request.topicId,
       });
-
-      // Fire-and-forget: sendPrompt runs the CLI until completion.
-      ctr
-        .sendPrompt({
-          operationId: request.operationId,
-          prompt: request.prompt,
-          sessionId,
-        })
-        .catch((err: Error) => {
-          // Errors are surfaced via heteroFinish on the server side.
-          // Log locally for desktop debugging only.
-          console.error('[GatewayConnectionCtr] agent run failed:', err.message);
-        });
 
       return { status: 'accepted' };
     } catch (err) {

--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -1268,23 +1268,31 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     serverUrl: string;
     topicId: string;
   }): void {
-    const { agentType, cwd, jwt, operationId, prompt, resumeSessionId, serverUrl, topicId } = params;
+    const { agentType, cwd, jwt, operationId, prompt, resumeSessionId, serverUrl, topicId } =
+      params;
     const workDir = cwd ?? process.cwd();
 
     const args = [
-      'lh', 'hetero', 'exec',
-      '--type', agentType,
-      '--operation-id', operationId,
-      '--topic', topicId,
-      '--render', 'none',
-      '--input-json', '-',
-      '--cwd', workDir,
+      'hetero',
+      'exec',
+      '--type',
+      agentType,
+      '--operation-id',
+      operationId,
+      '--topic',
+      topicId,
+      '--render',
+      'none',
+      '--input-json',
+      '-',
+      '--cwd',
+      workDir,
       ...(resumeSessionId ? ['--resume', resumeSessionId] : []),
     ];
 
     const env = {
       ...process.env,
-      ...buildProxyEnv(this.app.storeManager.get("networkProxy")),
+      ...buildProxyEnv(this.app.storeManager.get('networkProxy')),
       LOBEHUB_JWT: jwt,
       LOBEHUB_SERVER: serverUrl,
     };
@@ -1308,5 +1316,4 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
       logger.info('spawnLhHeteroExec: exited — op=%s code=%s signal=%s', operationId, code, signal);
     });
   }
-
 }

--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -1251,4 +1251,62 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     process.on('SIGTERM', onSignal);
     process.on('SIGINT', onSignal);
   }
+
+  /**
+   * Spawn `lh hetero exec` for gateway-driven agent runs.
+   * The `lh` CLI handles everything downstream — no local
+   * AgentStreamPipeline or IPC broadcast needed. Mirrors
+   * `spawnHeteroSandbox()` on the server side.
+   */
+  spawnLhHeteroExec(params: {
+    agentType: string;
+    cwd?: string;
+    jwt: string;
+    operationId: string;
+    prompt: string;
+    resumeSessionId?: string;
+    serverUrl: string;
+    topicId: string;
+  }): void {
+    const { agentType, cwd, jwt, operationId, prompt, resumeSessionId, serverUrl, topicId } = params;
+    const workDir = cwd ?? process.cwd();
+
+    const args = [
+      'lh', 'hetero', 'exec',
+      '--type', agentType,
+      '--operation-id', operationId,
+      '--topic', topicId,
+      '--render', 'none',
+      '--input-json', '-',
+      '--cwd', workDir,
+      ...(resumeSessionId ? ['--resume', resumeSessionId] : []),
+    ];
+
+    const env = {
+      ...process.env,
+      ...buildProxyEnv(this.app.storeManager.get("networkProxy")),
+      LOBEHUB_JWT: jwt,
+      LOBEHUB_SERVER: serverUrl,
+    };
+
+    logger.info('spawnLhHeteroExec: type=%s op=%s topic=%s', agentType, operationId, topicId);
+
+    const child = spawn('lh', args, {
+      cwd: workDir,
+      env,
+      stdio: ['pipe', 'inherit', 'inherit'],
+    });
+
+    child.stdin.write(JSON.stringify(prompt));
+    child.stdin.end();
+
+    child.on('error', (err) => {
+      logger.error('spawnLhHeteroExec: spawn failed — %s', err.message);
+    });
+
+    child.on('exit', (code, signal) => {
+      logger.info('spawnLhHeteroExec: exited — op=%s code=%s signal=%s', operationId, code, signal);
+    });
+  }
+
 }


### PR DESCRIPTION
## Summary

Replace the desktop-side GatewayConnectionCtr.executeAgentRun() flow with a direct lh hetero exec spawn, matching the cloud sandbox path (spawnHeteroSandbox()) exactly.

## Before

Desktop received agent_run_request from Device Gateway → called HeterogeneousAgentCtr.startSession() + sendPrompt() → local AgentStreamPipeline + Electron IPC broadcast. Events never pushed back to server via heteroIngest, breaking the Gateway → Web/Mobile chain.

## After

Desktop receives agent_run_request → calls HeterogeneousAgentCtr.spawnLhHeteroExec() → spawns lh hetero exec. The lh CLI handles everything: spawn → adapt → BatchIngester → heteroIngest/heteroFinish → server → Gateway → clients.

## Changes

| File | Change |
|------|--------|
| HeterogeneousAgentCtr.ts | +57 lines — add spawnLhHeteroExec() method |
| GatewayConnectionCtr.ts | -25/+17 lines — executeAgentRun() delegates to new method |