### PR TITLE
✨ feat(analytics): track onboarding step events

### DIFF
--- a/src/components/Analytics/LobeAnalyticsProviderWrapper.test.tsx
+++ b/src/components/Analytics/LobeAnalyticsProviderWrapper.test.tsx
@@ -1,0 +1,67 @@
+import type { PostHogProviderAnalyticsConfig } from '@lobehub/analytics';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SPAServerConfig } from '@/types/spaServerConfig';
+
+import { LobeAnalyticsProviderWrapper } from './LobeAnalyticsProviderWrapper';
+
+const providerMock = vi.hoisted(() => ({
+  props: undefined as
+    | {
+        children: ReactNode;
+        postHogConfig: PostHogProviderAnalyticsConfig;
+      }
+    | undefined,
+}));
+
+vi.mock('@/components/Analytics/LobeAnalyticsProvider', () => ({
+  LobeAnalyticsProvider: (props: {
+    children: ReactNode;
+    postHogConfig: PostHogProviderAnalyticsConfig;
+  }) => {
+    providerMock.props = props;
+    return props.children;
+  },
+}));
+
+const serverConfig = {
+  analyticsConfig: {
+    posthog: {
+      debug: true,
+      host: 'https://posthog.example.com',
+      key: 'ph-key',
+    },
+  },
+} as SPAServerConfig;
+
+beforeEach(() => {
+  providerMock.props = undefined;
+  window.__SERVER_CONFIG__ = serverConfig;
+});
+
+afterEach(() => {
+  cleanup();
+  window.__SERVER_CONFIG__ = undefined;
+});
+
+describe('LobeAnalyticsProviderWrapper', () => {
+  it('enables PostHog history-change pageview capture for the SPA provider', () => {
+    render(
+      <LobeAnalyticsProviderWrapper>
+        <div>Analytics child</div>
+      </LobeAnalyticsProviderWrapper>,
+    );
+
+    expect(screen.getByText('Analytics child')).toBeInTheDocument();
+    expect(providerMock.props?.postHogConfig).toMatchObject({
+      capture_pageview: 'history_change',
+      debug: true,
+      enabled: true,
+      host: 'https://posthog.example.com',
+      key: 'ph-key',
+      person_profiles: 'always',
+    });
+  });
+});

--- a/src/components/Analytics/LobeAnalyticsProviderWrapper.tsx
+++ b/src/components/Analytics/LobeAnalyticsProviderWrapper.tsx
@@ -26,6 +26,7 @@ export const LobeAnalyticsProviderWrapper = memo<Props>(({ children }) => {
       postHogConfig={{
         debug: analytics?.posthog?.debug ?? false,
         enabled: !!analytics?.posthog?.key,
+        capture_pageview: 'history_change',
         host: analytics?.posthog?.host ?? '',
         key: analytics?.posthog?.key ?? '',
         person_profiles: 'always',

--- a/src/features/Onboarding/Agent/index.tsx
+++ b/src/features/Onboarding/Agent/index.tsx
@@ -21,6 +21,11 @@ import { useOnboardingAgentTemplates } from '@/hooks/useOnboardingAgentTemplates
 import { useClientDataSWR, useOnlyFetchOnceSWR } from '@/libs/swr';
 import OnboardingContainer from '@/routes/onboarding/_layout';
 import { fetchOnboardingAgentTemplates } from '@/services/agentMarketplace';
+import {
+  trackOnboardingCompleted,
+  trackOnboardingStepCompleted,
+  trackOnboardingStepViewed,
+} from '@/services/onboardingMetrics';
 import { topicService } from '@/services/topic';
 import { userService } from '@/services/user';
 import { useAgentStore } from '@/store/agent';
@@ -125,6 +130,25 @@ const AgentOnboardingPage = memo(() => {
 
   useOnboardingAgentTemplates(!onboardingFinished && !viewingHistoricalTopic);
 
+  const conversationViewedRef = useRef(false);
+  useEffect(() => {
+    if (
+      conversationViewedRef.current ||
+      !onboardingAgentId ||
+      onboardingFinished ||
+      viewingHistoricalTopic
+    ) {
+      return;
+    }
+
+    conversationViewedRef.current = true;
+    trackOnboardingStepViewed({
+      flow: 'agent',
+      step: 'conversation',
+      stepIndex: 1,
+    });
+  }, [onboardingAgentId, onboardingFinished, viewingHistoricalTopic]);
+
   const onboardingChatKey = useMemo(
     () => messageMapKey({ agentId: onboardingAgentId || '', topicId: effectiveTopicId }),
     [onboardingAgentId, effectiveTopicId],
@@ -226,6 +250,28 @@ const AgentOnboardingPage = memo(() => {
     return nextContext;
   }, [mutate, mutateHistoryTopics, onboardingAgentId]);
 
+  const trackAgentOnboardingCompletion = useCallback(
+    (topicId: string | undefined) => {
+      trackOnboardingStepCompleted({
+        flow: 'agent',
+        step: 'conversation',
+        stepIndex: 1,
+      });
+      trackOnboardingCompleted({
+        flow: 'agent',
+        hasTopic: !!topicId,
+        targetUrl:
+          inboxAgentId && topicId ? SESSION_CHAT_TOPIC_URL(inboxAgentId, topicId) : undefined,
+      });
+    },
+    [inboxAgentId],
+  );
+
+  const handleAfterWrapUp = useCallback(async () => {
+    const nextContext = await syncOnboardingContext();
+    trackAgentOnboardingCompletion(nextContext.topicId ?? effectiveTopicId);
+  }, [effectiveTopicId, syncOnboardingContext, trackAgentOnboardingCompletion]);
+
   const onboardingTurnSettledHook = useMemo<ConversationHooks>(() => {
     if (onboardingFinished || viewingHistoricalTopic) return {};
 
@@ -241,6 +287,9 @@ const AgentOnboardingPage = memo(() => {
         const newFinishedAt = nextContext?.agentOnboarding?.finishedAt;
 
         const refreshes: Promise<unknown>[] = [];
+        if (newFinishedAt && newFinishedAt !== prevFinishedAt) {
+          trackAgentOnboardingCompletion(effectiveTopicId);
+        }
         if (newFinishedAt !== prevFinishedAt) refreshes.push(refreshUserState());
         if (newPhase !== prevPhase) {
           refreshes.push(refreshBuiltinAgent(BUILTIN_AGENT_SLUGS.webOnboarding));
@@ -257,6 +306,7 @@ const AgentOnboardingPage = memo(() => {
     refreshBuiltinAgent,
     refreshUserState,
     syncOnboardingContext,
+    trackAgentOnboardingCompletion,
   ]);
 
   const conversationHooks = useMemo(() => {
@@ -327,7 +377,7 @@ const AgentOnboardingPage = memo(() => {
               readOnly={viewingHistoricalTopic}
               showFeedback={!viewingHistoricalTopic}
               topicId={effectiveTopicId}
-              onAfterWrapUp={syncOnboardingContext}
+              onAfterWrapUp={handleAfterWrapUp}
             />
           </ErrorBoundary>
         </OnboardingConversationProvider>

--- a/src/features/Onboarding/Classic/index.test.tsx
+++ b/src/features/Onboarding/Classic/index.test.tsx
@@ -6,6 +6,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ClassicOnboardingPage from './index';
 
+const metrics = vi.hoisted(() => ({
+  trackOnboardingStepCompleted: vi.fn(),
+  trackOnboardingStepViewed: vi.fn(),
+}));
+
 const mocks = vi.hoisted(() => ({
   commonStepsCompleted: true,
   currentStep: 1,
@@ -89,6 +94,11 @@ vi.mock('@/routes/onboarding/features/ProSettingsStep', () => ({
   ),
 }));
 
+vi.mock('@/services/onboardingMetrics', () => ({
+  trackOnboardingStepCompleted: metrics.trackOnboardingStepCompleted,
+  trackOnboardingStepViewed: metrics.trackOnboardingStepViewed,
+}));
+
 vi.mock('@/store/serverConfig', () => ({
   serverConfigSelectors: {
     enableKlavis: (s: { serverConfig: { enableKlavis?: boolean } }) =>
@@ -144,6 +154,8 @@ beforeEach(() => {
   mocks.goToPreviousStep.mockReset();
   mocks.isUserStateInit = true;
   mocks.serverConfigInit = true;
+  metrics.trackOnboardingStepCompleted.mockReset();
+  metrics.trackOnboardingStepViewed.mockReset();
 });
 
 afterEach(() => {
@@ -151,6 +163,30 @@ afterEach(() => {
 });
 
 describe('ClassicOnboardingPage', () => {
+  it('tracks the current classic step view', async () => {
+    renderClassic();
+
+    await waitFor(() =>
+      expect(metrics.trackOnboardingStepViewed).toHaveBeenCalledWith({
+        flow: 'classic',
+        step: 'fullname',
+        stepIndex: 1,
+      }),
+    );
+  });
+
+  it('tracks FullName completion before moving forward', () => {
+    renderClassic();
+    fireEvent.click(screen.getByText('full-name-next'));
+
+    expect(metrics.trackOnboardingStepCompleted).toHaveBeenCalledWith({
+      flow: 'classic',
+      step: 'fullname',
+      stepIndex: 1,
+    });
+    expect(mocks.goToNextStep).toHaveBeenCalledTimes(1);
+  });
+
   it('skips ProSettings when moving forward from interests without Klavis', () => {
     mocks.currentStep = 2;
     mocks.enableKlavis = false;
@@ -158,6 +194,12 @@ describe('ClassicOnboardingPage', () => {
     renderClassic();
     fireEvent.click(screen.getByText('interests-next'));
 
+    expect(metrics.trackOnboardingStepCompleted).toHaveBeenCalledWith({
+      flow: 'classic',
+      skippedNextStep: 'prosettings',
+      step: 'interests',
+      stepIndex: 2,
+    });
     expect(mocks.goToNextStep).toHaveBeenCalledTimes(2);
   });
 
@@ -200,6 +242,13 @@ describe('ClassicOnboardingPage', () => {
     renderClassic();
 
     await waitFor(() => expect(mocks.goToNextStep).toHaveBeenCalledTimes(1));
+    expect(metrics.trackOnboardingStepCompleted).toHaveBeenCalledWith({
+      action: 'auto_skip',
+      flow: 'classic',
+      skipped: true,
+      step: 'prosettings',
+      stepIndex: 3,
+    });
     expect(screen.queryByText('ProSettingsStep')).not.toBeInTheDocument();
   });
 
@@ -222,6 +271,11 @@ describe('ClassicOnboardingPage', () => {
     fireEvent.click(screen.getByText('pro-next'));
 
     expect(screen.getByText('ProSettingsStep')).toBeInTheDocument();
+    expect(metrics.trackOnboardingStepCompleted).toHaveBeenCalledWith({
+      flow: 'classic',
+      step: 'prosettings',
+      stepIndex: 3,
+    });
     expect(mocks.goToNextStep).toHaveBeenCalled();
   });
 });

--- a/src/features/Onboarding/Classic/index.tsx
+++ b/src/features/Onboarding/Classic/index.tsx
@@ -2,7 +2,7 @@
 
 import { MAX_ONBOARDING_STEPS } from '@lobechat/types';
 import { Flexbox } from '@lobehub/ui';
-import { memo, useCallback, useEffect } from 'react';
+import { memo, useCallback, useEffect, useRef } from 'react';
 import { Navigate, useNavigate } from 'react-router-dom';
 
 import Loading from '@/components/Loading/BrandTextLoading';
@@ -14,6 +14,10 @@ import AgentPickerStep from '@/routes/onboarding/features/AgentPickerStep';
 import FullNameStep from '@/routes/onboarding/features/FullNameStep';
 import InterestsStep from '@/routes/onboarding/features/InterestsStep';
 import ProSettingsStep from '@/routes/onboarding/features/ProSettingsStep';
+import {
+  trackOnboardingStepCompleted,
+  trackOnboardingStepViewed,
+} from '@/services/onboardingMetrics';
 import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { onboardingSelectors } from '@/store/user/selectors';
@@ -22,25 +26,32 @@ import { isDev } from '@/utils/env';
 const INTERESTS_STEP = 2;
 const PRO_SETTINGS_STEP = 3;
 
+const CLASSIC_STEP_TRACKING = {
+  1: { flow: 'classic', step: 'fullname', stepIndex: 1 },
+  [INTERESTS_STEP]: { flow: 'classic', step: 'interests', stepIndex: 2 },
+  [PRO_SETTINGS_STEP]: { flow: 'classic', step: 'prosettings', stepIndex: 3 },
+  [MAX_ONBOARDING_STEPS]: { flow: 'classic', step: 'agentpicker', stepIndex: 4 },
+} as const;
+
+const getClassicStepTrackingPayload = (step: number) =>
+  CLASSIC_STEP_TRACKING[step as keyof typeof CLASSIC_STEP_TRACKING];
+
 const ClassicOnboardingPage = memo(() => {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
-  const [
-    isUserStateInit,
-    commonStepsCompleted,
-    currentStep,
-    goToNextStep,
-    goToPreviousStep,
-  ] = useUserStore((s) => [
-    s.isUserStateInit,
-    onboardingSelectors.commonStepsCompleted(s),
-    onboardingSelectors.currentStep(s),
-    s.goToNextStep,
-    s.goToPreviousStep,
-  ]);
+  const [isUserStateInit, commonStepsCompleted, currentStep, goToNextStep, goToPreviousStep] =
+    useUserStore((s) => [
+      s.isUserStateInit,
+      onboardingSelectors.commonStepsCompleted(s),
+      onboardingSelectors.currentStep(s),
+      s.goToNextStep,
+      s.goToPreviousStep,
+    ]);
   const enableKlavis = useServerConfigStore(serverConfigSelectors.enableKlavis);
   const serverConfigInit = useServerConfigStore((s) => s.serverConfigInit);
   const shouldSkipProSettingsStep = serverConfigInit && !enableKlavis;
+  const autoSkippedStepKeysRef = useRef<Set<string>>(new Set());
+  const viewedStepKeysRef = useRef<Set<string>>(new Set());
 
   useOnboardingAgentTemplates(isUserStateInit && commonStepsCompleted);
 
@@ -60,10 +71,52 @@ const ClassicOnboardingPage = memo(() => {
       return;
     }
 
+    const payload = CLASSIC_STEP_TRACKING[PRO_SETTINGS_STEP];
+    if (autoSkippedStepKeysRef.current.has(payload.step)) return;
+
+    autoSkippedStepKeysRef.current.add(payload.step);
+    trackOnboardingStepCompleted({
+      ...payload,
+      action: 'auto_skip',
+      skipped: true,
+    });
     goToNextStep();
   }, [commonStepsCompleted, currentStep, goToNextStep, isUserStateInit, shouldSkipProSettingsStep]);
 
+  useEffect(() => {
+    if (!isUserStateInit || !commonStepsCompleted) return;
+    if (currentStep === PRO_SETTINGS_STEP && (!serverConfigInit || shouldSkipProSettingsStep)) {
+      return;
+    }
+
+    const payload = getClassicStepTrackingPayload(currentStep);
+    if (!payload || viewedStepKeysRef.current.has(payload.step)) return;
+
+    viewedStepKeysRef.current.add(payload.step);
+    trackOnboardingStepViewed(payload);
+  }, [
+    commonStepsCompleted,
+    currentStep,
+    isUserStateInit,
+    serverConfigInit,
+    shouldSkipProSettingsStep,
+  ]);
+
+  const goToNextStepFromFullName = useCallback(() => {
+    trackOnboardingStepCompleted(CLASSIC_STEP_TRACKING[1]);
+    goToNextStep();
+  }, [goToNextStep]);
+
   const goToNextStepFromInterests = useCallback(() => {
+    trackOnboardingStepCompleted(
+      shouldSkipProSettingsStep
+        ? {
+            ...CLASSIC_STEP_TRACKING[INTERESTS_STEP],
+            skippedNextStep: 'prosettings',
+          }
+        : CLASSIC_STEP_TRACKING[INTERESTS_STEP],
+    );
+
     if (shouldSkipProSettingsStep) {
       goToNextStep();
       goToNextStep();
@@ -72,6 +125,11 @@ const ClassicOnboardingPage = memo(() => {
 
     goToNextStep();
   }, [goToNextStep, shouldSkipProSettingsStep]);
+
+  const goToNextStepFromProSettings = useCallback(() => {
+    trackOnboardingStepCompleted(CLASSIC_STEP_TRACKING[PRO_SETTINGS_STEP]);
+    goToNextStep();
+  }, [goToNextStep]);
 
   const goToPreviousStepFromAgentPicker = useCallback(() => {
     if (shouldSkipProSettingsStep) {
@@ -94,7 +152,9 @@ const ClassicOnboardingPage = memo(() => {
   const renderStep = () => {
     switch (currentStep) {
       case 1: {
-        return <FullNameStep onBack={backToResponseLanguageStep} onNext={goToNextStep} />;
+        return (
+          <FullNameStep onBack={backToResponseLanguageStep} onNext={goToNextStepFromFullName} />
+        );
       }
       case INTERESTS_STEP: {
         return <InterestsStep onBack={goToPreviousStep} onNext={goToNextStepFromInterests} />;
@@ -103,7 +163,7 @@ const ClassicOnboardingPage = memo(() => {
         if (!serverConfigInit) return <Loading debugId="ClassicOnboarding/serverConfig" />;
         if (shouldSkipProSettingsStep) return null;
 
-        return <ProSettingsStep onBack={goToPreviousStep} onNext={goToNextStep} />;
+        return <ProSettingsStep onBack={goToPreviousStep} onNext={goToNextStepFromProSettings} />;
       }
       case MAX_ONBOARDING_STEPS: {
         return <AgentPickerStep onBack={goToPreviousStepFromAgentPicker} />;

--- a/src/features/Onboarding/Common/index.test.tsx
+++ b/src/features/Onboarding/Common/index.test.tsx
@@ -2,6 +2,11 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const metrics = {
+  trackOnboardingStepCompleted: vi.fn(),
+  trackOnboardingStepViewed: vi.fn(),
+};
+
 interface RenderOptions {
   AGENT_ONBOARDING_ENABLED?: boolean;
   commonStepsCompleted: boolean;
@@ -29,6 +34,8 @@ const renderCommon = async ({
 }: RenderOptions) => {
   cleanup();
   vi.resetModules();
+  metrics.trackOnboardingStepCompleted.mockClear();
+  metrics.trackOnboardingStepViewed.mockClear();
 
   vi.doMock('@lobechat/business-const', () => ({
     AGENT_ONBOARDING_ENABLED,
@@ -47,7 +54,14 @@ const renderCommon = async ({
     default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   }));
   vi.doMock('@/routes/onboarding/features/TelemetryStep', () => ({
-    default: () => <div>TelemetryStep</div>,
+    default: ({ onNext }: { onNext: () => void }) => (
+      <div>
+        TelemetryStep
+        <button type="button" onClick={onNext}>
+          telemetry-next
+        </button>
+      </div>
+    ),
   }));
   vi.doMock('@/routes/onboarding/features/ResponseLanguageStep', () => ({
     default: ({ onBack, onNext }: { onBack: () => void; onNext: () => void }) => (
@@ -73,6 +87,7 @@ const renderCommon = async ({
   vi.doMock('@/store/serverConfig', () => ({
     useServerConfigStore: selectFromServerConfigStore,
   }));
+  vi.doMock('@/services/onboardingMetrics', () => metrics);
 
   const onboarding =
     persistedStep === undefined && finishedAt === undefined
@@ -115,6 +130,7 @@ afterEach(() => {
   vi.doUnmock('@/routes/onboarding/_layout');
   vi.doUnmock('@/routes/onboarding/features/TelemetryStep');
   vi.doUnmock('@/routes/onboarding/features/ResponseLanguageStep');
+  vi.doUnmock('@/services/onboardingMetrics');
   vi.doUnmock('@/store/serverConfig');
   vi.doUnmock('@/store/user');
   vi.doUnmock('@/store/user/selectors');
@@ -124,6 +140,30 @@ describe('CommonOnboardingPage', () => {
   it('renders TelemetryStep (welcome + privacy) when shared prefix is incomplete', async () => {
     await renderCommon({ commonStepsCompleted: false });
     expect(screen.getByText('TelemetryStep')).toBeInTheDocument();
+  });
+
+  it('tracks the Telemetry step view when shared prefix starts', async () => {
+    await renderCommon({ commonStepsCompleted: false });
+    await waitFor(() =>
+      expect(metrics.trackOnboardingStepViewed).toHaveBeenCalledWith({
+        flow: 'common',
+        step: 'telemetry',
+        stepIndex: 1,
+      }),
+    );
+  });
+
+  it('tracks the Telemetry step completion before moving to ResponseLanguage', async () => {
+    await renderCommon({ commonStepsCompleted: false });
+
+    fireEvent.click(screen.getByText('telemetry-next'));
+
+    expect(metrics.trackOnboardingStepCompleted).toHaveBeenCalledWith({
+      flow: 'common',
+      step: 'telemetry',
+      stepIndex: 1,
+    });
+    expect(await screen.findByText('ResponseLanguageStep')).toBeInTheDocument();
   });
 
   it('redirects to /onboarding/agent when shared prefix is complete and agent flag is on', async () => {
@@ -170,6 +210,17 @@ describe('CommonOnboardingPage', () => {
       expect(screen.getByText('ResponseLanguageStep')).toBeInTheDocument();
     });
 
+    it('tracks the ResponseLanguage step view when revisiting ?step=2', async () => {
+      await renderCommon({ commonStepsCompleted: true, initialEntry: '/onboarding?step=2' });
+      await waitFor(() =>
+        expect(metrics.trackOnboardingStepViewed).toHaveBeenCalledWith({
+          flow: 'common',
+          step: 'response_language',
+          stepIndex: 2,
+        }),
+      );
+    });
+
     it('renders TelemetryStep when ?step=1 and prefix is complete', async () => {
       await renderCommon({ commonStepsCompleted: true, initialEntry: '/onboarding?step=1' });
       expect(screen.getByText('TelemetryStep')).toBeInTheDocument();
@@ -188,6 +239,11 @@ describe('CommonOnboardingPage', () => {
         initialEntry: '/onboarding?step=2',
       });
       fireEvent.click(screen.getByText('rl-next'));
+      expect(metrics.trackOnboardingStepCompleted).toHaveBeenCalledWith({
+        flow: 'common',
+        step: 'response_language',
+        stepIndex: 2,
+      });
       expect(await screen.findByText('Classic onboarding')).toBeInTheDocument();
     });
   });

--- a/src/features/Onboarding/Common/index.tsx
+++ b/src/features/Onboarding/Common/index.tsx
@@ -12,6 +12,10 @@ import OnboardingContainer from '@/routes/onboarding/_layout';
 import { deriveOnboardingBranchPath } from '@/routes/onboarding/branch';
 import ResponseLanguageStep from '@/routes/onboarding/features/ResponseLanguageStep';
 import TelemetryStep from '@/routes/onboarding/features/TelemetryStep';
+import {
+  trackOnboardingStepCompleted,
+  trackOnboardingStepViewed,
+} from '@/services/onboardingMetrics';
 import { useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { onboardingSelectors } from '@/store/user/selectors';
@@ -33,6 +37,11 @@ const remapLegacyClassicStep = (raw: number): number => {
   return MAX_ONBOARDING_STEPS - 1;
 };
 
+const COMMON_STEP_TRACKING = {
+  1: { flow: 'common', step: 'telemetry', stepIndex: 1 },
+  2: { flow: 'common', step: 'response_language', stepIndex: 2 },
+} as const;
+
 const CommonOnboardingPage = memo(() => {
   const isUserStateInit = useUserStore((s) => s.isUserStateInit);
   const commonStepsCompleted = useUserStore(onboardingSelectors.commonStepsCompleted);
@@ -42,6 +51,7 @@ const CommonOnboardingPage = memo(() => {
   const [searchParams, setSearchParams] = useSearchParams();
   const step: 1 | 2 = searchParams.get('step') === '2' ? 2 : 1;
   const hasStepParam = searchParams.has('step');
+  const viewedStepKeysRef = useRef<Set<string>>(new Set());
 
   useOnboardingAgentTemplates(isUserStateInit && (!commonStepsCompleted || hasStepParam));
 
@@ -72,7 +82,18 @@ const CommonOnboardingPage = memo(() => {
     void import('@/routes/onboarding/classic');
   }, []);
 
+  useEffect(() => {
+    if (!isUserStateInit || (commonStepsCompleted && !hasStepParam)) return;
+
+    const payload = COMMON_STEP_TRACKING[step];
+    if (viewedStepKeysRef.current.has(payload.step)) return;
+
+    viewedStepKeysRef.current.add(payload.step);
+    trackOnboardingStepViewed(payload);
+  }, [commonStepsCompleted, hasStepParam, isUserStateInit, step]);
+
   const goNextFromTelemetry = useCallback(() => {
+    trackOnboardingStepCompleted(COMMON_STEP_TRACKING[1]);
     setSearchParams({ step: '2' }, { replace: true });
   }, [setSearchParams]);
 
@@ -81,6 +102,7 @@ const CommonOnboardingPage = memo(() => {
   }, [setSearchParams]);
 
   const finishCommon = useCallback(() => {
+    trackOnboardingStepCompleted(COMMON_STEP_TRACKING[2]);
     setSearchParams({}, { replace: true });
   }, [setSearchParams]);
 

--- a/src/layout/AnalyticsRSCProvider.tsx
+++ b/src/layout/AnalyticsRSCProvider.tsx
@@ -22,6 +22,7 @@ const AnalyticsRSCProvider = ({ children }: AnalyticsRSCProviderProps) => {
       postHogConfig={{
         debug: analyticsEnv.DEBUG_POSTHOG_ANALYTICS,
         enabled: analyticsEnv.ENABLED_POSTHOG_ANALYTICS,
+        capture_pageview: 'history_change',
         host: analyticsEnv.POSTHOG_HOST,
         key: analyticsEnv.POSTHOG_KEY ?? '',
         person_profiles: 'always',

--- a/src/routes/onboarding/features/AgentPickerStep/index.test.tsx
+++ b/src/routes/onboarding/features/AgentPickerStep/index.test.tsx
@@ -14,6 +14,12 @@ const installMarketplaceAgents = vi.fn().mockResolvedValue({
   skippedAgentIds: [],
   summaries: [],
 });
+const metrics = vi.hoisted(() => ({
+  trackOnboardingCompleted: vi.fn(),
+  trackOnboardingMarketplacePicked: vi.fn(),
+  trackOnboardingMarketplaceShown: vi.fn(),
+  trackOnboardingStepCompleted: vi.fn(),
+}));
 
 const templates: AgentTemplate[] = [
   {
@@ -66,8 +72,10 @@ vi.mock('@/services/installMarketplaceAgents', () => ({
 }));
 
 vi.mock('@/services/onboardingMetrics', () => ({
-  trackOnboardingMarketplacePicked: vi.fn(),
-  trackOnboardingMarketplaceShown: vi.fn(),
+  trackOnboardingCompleted: metrics.trackOnboardingCompleted,
+  trackOnboardingMarketplacePicked: metrics.trackOnboardingMarketplacePicked,
+  trackOnboardingMarketplaceShown: metrics.trackOnboardingMarketplaceShown,
+  trackOnboardingStepCompleted: metrics.trackOnboardingStepCompleted,
 }));
 
 const userState = { finishOnboarding, user: { interests: [] as string[] } };
@@ -82,6 +90,10 @@ beforeEach(() => {
   navigate.mockClear();
   finishOnboarding.mockClear();
   installMarketplaceAgents.mockClear();
+  metrics.trackOnboardingCompleted.mockClear();
+  metrics.trackOnboardingMarketplacePicked.mockClear();
+  metrics.trackOnboardingMarketplaceShown.mockClear();
+  metrics.trackOnboardingStepCompleted.mockClear();
   swrReturn = { data: templates, error: undefined, isLoading: false };
   searchParams = new URLSearchParams();
 });
@@ -107,6 +119,18 @@ describe('AgentPickerStep', () => {
     await waitFor(() => expect(navigate).toHaveBeenCalledWith('/'));
     expect(installMarketplaceAgents).toHaveBeenCalledWith(['t1']);
     expect(finishOnboarding).toHaveBeenCalledTimes(1);
+    expect(metrics.trackOnboardingStepCompleted).toHaveBeenCalledWith({
+      action: 'continue',
+      entry: 'classic',
+      flow: 'classic',
+      selectedCount: 1,
+      step: 'agentpicker',
+      stepIndex: 4,
+    });
+    expect(metrics.trackOnboardingCompleted).toHaveBeenCalledWith({
+      flow: 'classic',
+      targetUrl: '/',
+    });
   });
 
   it('finishes onboarding without installing on Skip', async () => {
@@ -117,6 +141,18 @@ describe('AgentPickerStep', () => {
     await waitFor(() => expect(navigate).toHaveBeenCalledWith('/'));
     expect(finishOnboarding).toHaveBeenCalledTimes(1);
     expect(installMarketplaceAgents).not.toHaveBeenCalled();
+    expect(metrics.trackOnboardingStepCompleted).toHaveBeenCalledWith({
+      action: 'skip',
+      entry: 'classic',
+      flow: 'classic',
+      selectedCount: 0,
+      step: 'agentpicker',
+      stepIndex: 4,
+    });
+    expect(metrics.trackOnboardingCompleted).toHaveBeenCalledWith({
+      flow: 'classic',
+      targetUrl: '/',
+    });
   });
 
   it('shows a Back button that calls onBack for a normal classic entry', () => {
@@ -132,5 +168,26 @@ describe('AgentPickerStep', () => {
     render(<AgentPickerStep onBack={vi.fn()} />);
 
     expect(screen.queryByRole('button', { name: 'back' })).not.toBeInTheDocument();
+  });
+
+  it('attributes entry=skip completion to the agent flow', async () => {
+    searchParams = new URLSearchParams('entry=skip');
+    render(<AgentPickerStep onBack={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'agentPicker.skip' }));
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/'));
+    expect(metrics.trackOnboardingStepCompleted).toHaveBeenCalledWith({
+      action: 'skip',
+      entry: 'agent_skip',
+      flow: 'agent',
+      selectedCount: 0,
+      step: 'agentpicker',
+      stepIndex: 4,
+    });
+    expect(metrics.trackOnboardingCompleted).toHaveBeenCalledWith({
+      flow: 'agent',
+      targetUrl: '/',
+    });
   });
 });

--- a/src/routes/onboarding/features/AgentPickerStep/index.tsx
+++ b/src/routes/onboarding/features/AgentPickerStep/index.tsx
@@ -15,8 +15,10 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useOnboardingAgentTemplates } from '@/hooks/useOnboardingAgentTemplates';
 import { installMarketplaceAgents } from '@/services/installMarketplaceAgents';
 import {
+  trackOnboardingCompleted,
   trackOnboardingMarketplacePicked,
   trackOnboardingMarketplaceShown,
+  trackOnboardingStepCompleted,
 } from '@/services/onboardingMetrics';
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
@@ -39,7 +41,9 @@ const AgentPickerStep = memo<AgentPickerStepProps>(({ onBack }) => {
   const { t: tTool } = useTranslation('tool');
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-  const showBack = searchParams.get('entry') !== 'skip';
+  const isAgentSkipEntry = searchParams.get('entry') === 'skip';
+  const showBack = !isAgentSkipEntry;
+  const completionFlow = isAgentSkipEntry ? 'agent' : 'classic';
 
   const finishOnboarding = useUserStore((s) => s.finishOnboarding);
   const interests = useUserStore(userProfileSelectors.interests);
@@ -94,16 +98,28 @@ const AgentPickerStep = memo<AgentPickerStepProps>(({ onBack }) => {
     trackOnboardingMarketplaceShown({ categoryHints, requestId });
   }, [categoryHints, requestId]);
 
-  const finish = useCallback(async () => {
-    await finishOnboarding();
-    navigate('/');
-  }, [finishOnboarding, navigate]);
+  const finish = useCallback(
+    async (action: 'continue' | 'skip', selectedCount: number) => {
+      await finishOnboarding();
+      trackOnboardingStepCompleted({
+        action,
+        entry: isAgentSkipEntry ? 'agent_skip' : 'classic',
+        flow: completionFlow,
+        selectedCount,
+        step: 'agentpicker',
+        stepIndex: 4,
+      });
+      trackOnboardingCompleted({ flow: completionFlow, targetUrl: '/' });
+      navigate('/');
+    },
+    [completionFlow, finishOnboarding, isAgentSkipEntry, navigate],
+  );
 
   const handleSkip = useCallback(async () => {
     if (pendingRef.current) return;
     pendingRef.current = true;
     setPending('skip');
-    await finish();
+    await finish('skip', 0);
   }, [finish]);
 
   const handleContinue = useCallback(async () => {
@@ -118,7 +134,7 @@ const AgentPickerStep = memo<AgentPickerStepProps>(({ onBack }) => {
     } catch (installError) {
       console.error('[AgentPickerStep] install failed', installError);
     }
-    await finish();
+    await finish('continue', selectedTemplateIds.length);
   }, [categoryHints, finish, requestId, selected]);
 
   const handleBack = useCallback(() => {

--- a/src/services/onboardingMetrics/index.test.ts
+++ b/src/services/onboardingMetrics/index.test.ts
@@ -4,15 +4,28 @@ import {
   ONBOARDING_METRICS_EVENTS,
   ONBOARDING_METRICS_SPM,
   setOnboardingAnalyticsClient,
+  trackOnboardingCompleted,
   trackOnboardingMarketplacePicked,
   trackOnboardingMarketplaceShown,
+  trackOnboardingStepCompleted,
+  trackOnboardingStepViewed,
 } from './index';
+
+const analyticsMocks = vi.hoisted(() => ({
+  getSingletonAnalyticsOptional: vi.fn(),
+}));
+
+vi.mock('@lobehub/analytics', () => ({
+  getSingletonAnalyticsOptional: analyticsMocks.getSingletonAnalyticsOptional,
+}));
 
 describe('onboardingMetrics', () => {
   const track = vi.fn();
 
   beforeEach(() => {
     track.mockReset();
+    analyticsMocks.getSingletonAnalyticsOptional.mockReset();
+    analyticsMocks.getSingletonAnalyticsOptional.mockReturnValue(null);
     setOnboardingAnalyticsClient({ track });
   });
 
@@ -48,6 +61,88 @@ describe('onboardingMetrics', () => {
         requestId: 'req-b',
         selectedTemplateIds: ['pair-programmer', 'code-reviewer'],
         spm: ONBOARDING_METRICS_SPM.MARKETPLACE_PICKED,
+      },
+    });
+  });
+
+  it('fires onboarding_step_viewed with flow, step and stepIndex', () => {
+    trackOnboardingStepViewed({
+      flow: 'common',
+      step: 'telemetry',
+      stepIndex: 1,
+    });
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith({
+      name: ONBOARDING_METRICS_EVENTS.STEP_VIEWED,
+      properties: {
+        flow: 'common',
+        spm: ONBOARDING_METRICS_SPM.STEP_VIEWED,
+        step: 'telemetry',
+        stepIndex: 1,
+      },
+    });
+  });
+
+  it('fires onboarding_step_completed with extra step context', () => {
+    trackOnboardingStepCompleted({
+      action: 'auto_skip',
+      flow: 'classic',
+      skipped: true,
+      step: 'prosettings',
+      stepIndex: 3,
+    });
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith({
+      name: ONBOARDING_METRICS_EVENTS.STEP_COMPLETED,
+      properties: {
+        action: 'auto_skip',
+        flow: 'classic',
+        skipped: true,
+        spm: ONBOARDING_METRICS_SPM.STEP_COMPLETED,
+        step: 'prosettings',
+        stepIndex: 3,
+      },
+    });
+  });
+
+  it('fires onboarding_completed with the branch flow and targetUrl', () => {
+    trackOnboardingCompleted({
+      flow: 'classic',
+      targetUrl: '/',
+    });
+
+    expect(track).toHaveBeenCalledTimes(1);
+    expect(track).toHaveBeenCalledWith({
+      name: ONBOARDING_METRICS_EVENTS.COMPLETED,
+      properties: {
+        flow: 'classic',
+        spm: ONBOARDING_METRICS_SPM.COMPLETED,
+        targetUrl: '/',
+      },
+    });
+  });
+
+  it('falls back to the global analytics singleton when no explicit client is configured', () => {
+    const singletonTrack = vi.fn();
+    setOnboardingAnalyticsClient(null);
+    analyticsMocks.getSingletonAnalyticsOptional.mockReturnValue({ track: singletonTrack });
+
+    trackOnboardingStepViewed({
+      flow: 'classic',
+      step: 'fullname',
+      stepIndex: 1,
+    });
+
+    expect(singletonTrack).toHaveBeenCalledTimes(1);
+    expect(singletonTrack).toHaveBeenCalledWith({
+      name: ONBOARDING_METRICS_EVENTS.STEP_VIEWED,
+      properties: {
+        flow: 'classic',
+        spm: ONBOARDING_METRICS_SPM.STEP_VIEWED,
+        step: 'fullname',
+        stepIndex: 1,
       },
     });
   });

--- a/src/services/onboardingMetrics/index.ts
+++ b/src/services/onboardingMetrics/index.ts
@@ -1,11 +1,19 @@
+import { getSingletonAnalyticsOptional } from '@lobehub/analytics';
+
 export const ONBOARDING_METRICS_EVENTS = {
+  COMPLETED: 'onboarding_completed',
   MARKETPLACE_PICKED: 'onboarding_marketplace_picked',
   MARKETPLACE_SHOWN: 'onboarding_marketplace_shown',
+  STEP_COMPLETED: 'onboarding_step_completed',
+  STEP_VIEWED: 'onboarding_step_viewed',
 } as const;
 
 export const ONBOARDING_METRICS_SPM = {
+  COMPLETED: 'onboarding.completed',
   MARKETPLACE_PICKED: 'onboarding.marketplace.picked',
   MARKETPLACE_SHOWN: 'onboarding.marketplace.shown',
+  STEP_COMPLETED: 'onboarding.step.completed',
+  STEP_VIEWED: 'onboarding.step.viewed',
 } as const;
 
 interface AnalyticsLike {
@@ -19,12 +27,58 @@ export const setOnboardingAnalyticsClient = (client: AnalyticsLike | null): void
 };
 
 const emit = (name: string, properties: Record<string, unknown>): void => {
-  if (!analyticsClient) return;
+  const client = analyticsClient ?? getSingletonAnalyticsOptional();
+  if (!client) return;
+
   try {
-    analyticsClient.track({ name, properties });
+    client.track({ name, properties });
   } catch (error) {
     console.error('[OnboardingMetrics] track failed', error);
   }
+};
+
+export type OnboardingFlow = 'agent' | 'classic' | 'common';
+
+export type OnboardingStep =
+  | 'agentpicker'
+  | 'conversation'
+  | 'fullname'
+  | 'interests'
+  | 'prosettings'
+  | 'response_language'
+  | 'telemetry';
+
+export interface OnboardingStepPayload extends Record<string, unknown> {
+  flow: OnboardingFlow;
+  skipped?: boolean;
+  step: OnboardingStep;
+  stepIndex?: number;
+}
+
+export interface OnboardingCompletedPayload extends Record<string, unknown> {
+  flow: Exclude<OnboardingFlow, 'common'>;
+  targetUrl?: string;
+}
+
+export const trackOnboardingStepViewed = (payload: OnboardingStepPayload): void => {
+  emit(ONBOARDING_METRICS_EVENTS.STEP_VIEWED, {
+    ...payload,
+    spm: ONBOARDING_METRICS_SPM.STEP_VIEWED,
+  });
+};
+
+export const trackOnboardingStepCompleted = (payload: OnboardingStepPayload): void => {
+  emit(ONBOARDING_METRICS_EVENTS.STEP_COMPLETED, {
+    ...payload,
+    spm: ONBOARDING_METRICS_SPM.STEP_COMPLETED,
+  });
+};
+
+export const trackOnboardingCompleted = (payload: OnboardingCompletedPayload): void => {
+  emit(ONBOARDING_METRICS_EVENTS.COMPLETED, {
+    ...payload,
+    spm: ONBOARDING_METRICS_SPM.COMPLETED,
+  });
 };
 
 export interface MarketplaceShownPayload {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No related issue.

#### 🔀 Description of Change

- Add explicit onboarding analytics events for step views, step completions, and onboarding completion.
- Instrument common, classic, and agent onboarding paths, including skipped ProSettings and AgentPicker completion outcomes.
- Enable PostHog history-change pageview capture in LobeHub analytics provider configs.
- Fall back onboarding metrics to the global analytics singleton when no explicit onboarding client is registered.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

\`\`\`bash
bunx vitest run --silent='passed-only' src/services/onboardingMetrics/index.test.ts src/features/Onboarding/Common/index.test.tsx src/features/Onboarding/Classic/index.test.tsx src/routes/onboarding/features/AgentPickerStep/index.test.tsx
bun run type-check
\`\`\`

#### 📸 Screenshots / Videos

N/A. Analytics-only change.

#### 📝 Additional Information

This enables a reliable onboarding funnel based on \`user_register_completed\` → \`onboarding_step_viewed\` / \`onboarding_step_completed\` by \`flow\` and \`step\` → \`onboarding_completed\`, instead of relying on SPA sub-route pageviews.