### PR TITLE
💄 style: add Qwen3.7 Max locale

### DIFF
--- a/src/locales/default/models.ts
+++ b/src/locales/default/models.ts
@@ -15,6 +15,8 @@ const lobeHubOnlineModelLocales = {
   'grok-4.20-beta-0309-non-reasoning.description': 'A non-reasoning variant for simple use cases',
   'MiniMax-M2.1-Lightning.description':
     'Powerful multilingual programming capabilities with faster and more efficient inference.',
+  'qwen3.7-max.description':
+    "Qwen3.7-Max is Alibaba Cloud's flagship agent-era model for complex coding, reasoning, office automation, and long-horizon autonomous workflows.",
   'seedream-5-0-260128.description':
     'ByteDance-Seedream-5.0-lite by BytePlus features web-retrieval-augmented generation for real-time information, enhanced complex prompt interpretation, and improved reference consistency for professional visual creation.',
   'fal-ai/bytedance/seedream/v4.5.description':


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #13494

#### 🔀 Description of Change

Add the online-only locale description for Qwen3.7 Max so the LobeHub-hosted model can render its model card copy from the default locale map.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Tested with:

```bash
bun run scripts/sync-lobehub-model-locales.ts --check
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

The change only updates public model locale copy and does not expose cloud-specific business logic.