### PR TITLE
✨ feat(chat): consume gateway uiMessages snapshot as SoT at step boundaries

### DIFF
--- a/.agents/skills/local-testing/scripts/agent-gateway/analyze-events.ts
+++ b/.agents/skills/local-testing/scripts/agent-gateway/analyze-events.ts
@@ -1,0 +1,237 @@
+// Analyzer for probe-events dumps. Reads a JSON file produced by `run.ts dump`
+// and prints a layered breakdown:
+//
+//   1. STREAM EVENTS — every non-chunk WS/SSE event in receipt order
+//   2. CHUNKS SUMMARY — collapsed per-step chunk counts (otherwise floods)
+//   3. ACTION CALLS — replaceMessages / refreshMessages / MARK:* with stack
+//   4. CORRELATION — calls ↔ nearest stream event within ±300ms
+//   5. PER-KEY ASSISTANT GROWTH — for each messagesMap key, when the leading
+//      assistant message's cLen / rLen actually moves (this is what reveals
+//      "chunks arrived but the message never grew" regressions)
+//   6. ROLLBACKS — msgN / childN / role drops in the active-topic timeline
+//
+// Usage:
+//   bun run .agents/skills/local-testing/scripts/agent-gateway/analyze-events.ts <dump.json>
+
+import { readFileSync } from 'node:fs';
+
+import type {
+  ProbeActionCall,
+  ProbeDump,
+  ProbeMessageSummary,
+  ProbeStreamEvent,
+  ProbeTimelineSample,
+} from './types';
+
+const file = process.argv[2];
+if (!file) {
+  console.error('usage: bun run analyze-events.ts <dump.json>');
+  process.exit(1);
+}
+
+const raw = readFileSync(file, 'utf8');
+// agent-browser eval --stdin wraps return values in quotes when the value is
+// a string — so the JSON file may be double-encoded depending on how it was
+// captured. Handle both.
+const parsedOnce = JSON.parse(raw) as ProbeDump | string;
+const dump: ProbeDump = typeof parsedOnce === 'string' ? JSON.parse(parsedOnce) : parsedOnce;
+
+const { streamEvents = [], actionCalls = [], timeline = [] } = dump;
+
+const pad = (v: unknown, n: number) => String(v).padStart(n);
+
+// ── META ───────────────────────────────────────────────────────────
+console.log('=== META ===');
+console.log(`  events:    ${streamEvents.length}`);
+console.log(`  calls:     ${actionCalls.length}`);
+console.log(`  timeline:  ${timeline.length}`);
+
+// ── 1. STREAM EVENTS (non-chunk) ───────────────────────────────────
+const nonChunkEvents = streamEvents.filter((e) => e.type !== 'stream_chunk');
+const chunkEvents = streamEvents.filter((e) => e.type === 'stream_chunk');
+
+console.log(
+  `\n=== STREAM EVENTS (${nonChunkEvents.length} non-chunk + ${chunkEvents.length} chunks elided) ===`,
+);
+for (const e of nonChunkEvents) {
+  const dataStr = e.dataKeys?.length ? ` [${e.dataKeys.join(',')}]` : '';
+  const data = e.data as Record<string, unknown> | undefined;
+  const uiHint = data?.uiMessagesPreview
+    ? ` uiPreview=${JSON.stringify(data.uiMessagesPreview)}`
+    : data?.uiMessagesTotal
+      ? ` uiTotal=${data.uiMessagesTotal}`
+      : '';
+  const phaseHint = data?.phase ? ` phase=${data.phase}` : '';
+  const extra = e.serverType ? ` serverType=${e.serverType}` : '';
+  console.log(
+    `  t=${pad(e.t, 7)}  [${(e.transport ?? '?').padEnd(3)}]  step=${pad(e.stepIndex ?? '-', 2)}  ` +
+      `type=${(e.type ?? '').padEnd(22)}  op=${e.opIdTail ?? '-'}${phaseHint}${uiHint}${extra}${dataStr}`,
+  );
+}
+
+// ── 2. CHUNK SUMMARY ───────────────────────────────────────────────
+console.log('\n=== CHUNKS SUMMARY (per step / chunkType) ===');
+const chunkBuckets = new Map<string, { count: number; firstT: number; lastT: number }>();
+for (const c of chunkEvents) {
+  const data = c.data as Record<string, unknown> | undefined;
+  const ct = (data?.chunkType as string | undefined) ?? '?';
+  const key = `step=${c.stepIndex ?? '-'}  chunkType=${ct.padEnd(8)}  op=${c.opIdTail}`;
+  const slot = chunkBuckets.get(key);
+  if (slot) {
+    slot.count += 1;
+    slot.lastT = c.t;
+  } else {
+    chunkBuckets.set(key, { count: 1, firstT: c.t, lastT: c.t });
+  }
+}
+for (const [k, v] of chunkBuckets) {
+  console.log(`  ${k}  count=${pad(v.count, 4)}  t=${pad(v.firstT, 7)}..${pad(v.lastT, 7)}`);
+}
+
+// ── 3. ACTION CALLS ───────────────────────────────────────────────
+console.log('\n=== ACTION CALLS (replace/refresh/MARK) ===');
+for (const c of actionCalls) {
+  if (c.name?.startsWith('MARK:')) {
+    console.log(`  t=${pad(c.t, 7)}  ${c.name}`);
+    continue;
+  }
+  const summary =
+    c.name === 'replaceMessages'
+      ? `count=${c.args?.count} params=${JSON.stringify(c.args?.params)}`
+      : c.name === 'refreshMessages'
+        ? `ctx=${JSON.stringify(c.args?.context)}`
+        : c.error
+          ? `error=${c.error}`
+          : '';
+  console.log(`  t=${pad(c.t, 7)}  ${c.name.padEnd(20)} ${summary}`);
+  if (c.stack) {
+    const frames = c.stack
+      .split(' ← ')
+      .filter((f) => !!f && !f.includes('Object.<anonymous>'))
+      .slice(0, 3);
+    for (const f of frames) console.log(`             ↳ ${f}`);
+  }
+}
+
+// ── 4. CORRELATION ────────────────────────────────────────────────
+function nearestEventForCall(
+  call: ProbeActionCall,
+  windowMs = 300,
+): { event: ProbeStreamEvent; delta: number } | null {
+  let best: ProbeStreamEvent | null = null;
+  let bestDelta = Infinity;
+  for (const e of streamEvents) {
+    const d = Math.abs(e.t - call.t);
+    if (d < bestDelta && d <= windowMs) {
+      bestDelta = d;
+      best = e;
+    }
+  }
+  return best ? { event: best, delta: bestDelta } : null;
+}
+
+console.log('\n=== CORRELATION (replace/refresh ↔ nearest event within ±300ms) ===');
+for (const c of actionCalls) {
+  if (c.name !== 'refreshMessages' && c.name !== 'replaceMessages') continue;
+  const hit = nearestEventForCall(c);
+  if (hit) {
+    const phase = (hit.event.data as Record<string, unknown> | undefined)?.phase;
+    console.log(
+      `  t=${pad(c.t, 7)}  ${c.name.padEnd(16)} ← Δ${pad(hit.delta, 4)}ms ${hit.event.type}` +
+        (phase ? ` phase=${phase}` : ''),
+    );
+  } else {
+    console.log(`  t=${pad(c.t, 7)}  ${c.name.padEnd(16)} ← (no event nearby — external trigger)`);
+  }
+}
+
+// ── 5. PER-KEY ASSISTANT GROWTH ───────────────────────────────────
+// For each messagesMap key, find the trailing assistant message and report
+// the points in time where its cLen / rLen actually changed. If the timeline
+// shows chunks arriving but the assistant cLen never moves, that's the
+// signature of "dispatch queue blocked / messageId mismatch".
+console.log('\n=== PER-KEY ASSISTANT GROWTH ===');
+const keysEverSeen = new Set<string>();
+for (const s of timeline) for (const k of Object.keys(s.byKey ?? {})) keysEverSeen.add(k);
+
+for (const key of keysEverSeen) {
+  console.log(`\n  key=${key}`);
+  let lastSig: string | null = null;
+  for (const s of timeline) {
+    const slot = s.byKey?.[key];
+    if (!slot) continue;
+    const last = slot.msgs.at(-1) as ProbeMessageSummary | undefined;
+    if (!last) continue;
+    const sig = `${last.id}|c${last.cLen}|r${last.rLen}|n${slot.n}`;
+    if (sig === lastSig) continue;
+    lastSig = sig;
+    console.log(
+      `    t=${pad(s.t, 7)}  msgN=${pad(slot.n, 3)}  ` +
+        `lastAssistant=${last.id}  cLen=${pad(last.cLen, 5)}  rLen=${pad(last.rLen, 5)}` +
+        `  runOps=${s.runOps}`,
+    );
+  }
+}
+
+// ── 6. ROLLBACKS (active-topic msgN / childN / role drops) ─────────
+console.log('\n=== ROLLBACKS (active-topic msgN / childN / role drops) ===');
+let prev: ProbeTimelineSample | null = null;
+const rollbacks: Array<{ t: number; topic: string | null; drops: string[] }> = [];
+
+const flatten = (s: ProbeTimelineSample) => {
+  if (!s.activeTopic) return [];
+  return Object.entries(s.byKey ?? {})
+    .filter(([k]) => k.includes(s.activeTopic!))
+    .flatMap(([, v]) => v.msgs);
+};
+
+for (const s of timeline) {
+  if (s.err) {
+    prev = null;
+    continue;
+  }
+  if (!prev || prev.activeTopic !== s.activeTopic) {
+    prev = s;
+    continue;
+  }
+  const prevMsgs = flatten(prev);
+  const curMsgs = flatten(s);
+  const drops: string[] = [];
+
+  if (curMsgs.length < prevMsgs.length) drops.push(`msgN ${prevMsgs.length}→${curMsgs.length}`);
+
+  let prevChild = 0;
+  let curChild = 0;
+  for (const m of prevMsgs) prevChild += m.chN ?? 0;
+  for (const m of curMsgs) curChild += m.chN ?? 0;
+  if (curChild < prevChild) drops.push(`childN ${prevChild}→${curChild}`);
+
+  const prevById = new Map(prevMsgs.map((m) => [m.id, m]));
+  for (const m of curMsgs) {
+    const pr = prevById.get(m.id);
+    if (!pr) continue;
+    if (m.cLen < pr.cLen) drops.push(`cLen[${m.id}] ${pr.cLen}→${m.cLen}`);
+    if (m.rLen < pr.rLen) drops.push(`rLen[${m.id}] ${pr.rLen}→${m.rLen}`);
+  }
+
+  if (drops.length) rollbacks.push({ t: s.t, topic: s.activeTopic, drops });
+  prev = s;
+}
+
+if (rollbacks.length === 0) {
+  console.log('  (none)');
+} else {
+  for (const r of rollbacks) {
+    const nearEvent = streamEvents
+      .filter((e) => Math.abs(e.t - r.t) <= 300)
+      .map((e) => `${e.type}${(e.data as any)?.phase ? ':' + (e.data as any).phase : ''}`);
+    const nearCall = actionCalls
+      .filter((c) => Math.abs(c.t - r.t) <= 300 && !c.name?.startsWith('MARK:'))
+      .map((c) => c.name);
+    console.log(
+      `  t=${pad(r.t, 7)}  topic=${r.topic}  ${r.drops.join(' | ')}` +
+        (nearEvent.length ? `  near-event:[${nearEvent.join(',')}]` : '') +
+        (nearCall.length ? `  near-call:[${nearCall.join(',')}]` : ''),
+    );
+  }
+}

--- a/.agents/skills/local-testing/scripts/agent-gateway/analyze-events.ts
+++ b/.agents/skills/local-testing/scripts/agent-gateway/analyze-events.ts
@@ -95,9 +95,15 @@ for (const c of actionCalls) {
     console.log(`  t=${pad(c.t, 7)}  ${c.name}`);
     continue;
   }
+  const snapshot = (c.args as any)?.snapshot as
+    | Array<{ id: string; role: string; cLen: number; rLen: number }>
+    | undefined;
+  const snapStr = snapshot?.length
+    ? '  snapshot=' + snapshot.map((m) => `${m.id}:${m.role}/c${m.cLen}/r${m.rLen}`).join(' | ')
+    : '';
   const summary =
     c.name === 'replaceMessages'
-      ? `count=${c.args?.count} params=${JSON.stringify(c.args?.params)}`
+      ? `count=${c.args?.count} action=${(c.args?.params as any)?.action ?? '-'}${snapStr}`
       : c.name === 'refreshMessages'
         ? `ctx=${JSON.stringify(c.args?.context)}`
         : c.error

--- a/.agents/skills/local-testing/scripts/agent-gateway/probe-dump.ts
+++ b/.agents/skills/local-testing/scripts/agent-gateway/probe-dump.ts
@@ -18,7 +18,9 @@ if (w.__PROBE_TIMELINE_TIMER) {
   w.__PROBE_TIMELINE_TIMER = null;
 }
 
-const dump: ProbeDump = {
+const mutations = w.__PROBE_MUTATIONS ?? [];
+
+const dump: ProbeDump & { mutations: typeof mutations } = {
   meta: {
     t0: w.__PROBE_T0 ?? 0,
     collectedAt: Date.now(),
@@ -29,6 +31,7 @@ const dump: ProbeDump = {
   streamEvents: w.__PROBE_STREAM_EVENTS ?? [],
   actionCalls: w.__PROBE_ACTION_CALLS ?? [],
   timeline: w.__PROBE_MSG_TIMELINE ?? [],
+  mutations,
 };
 
 w.__PROBE_LAST_DUMP_JSON = JSON.stringify(dump);

--- a/.agents/skills/local-testing/scripts/agent-gateway/probe-dump.ts
+++ b/.agents/skills/local-testing/scripts/agent-gateway/probe-dump.ts
@@ -1,0 +1,34 @@
+// Stops the events-probe timeline timer and stashes the full capture as a
+// JSON string on `window.__PROBE_LAST_DUMP_JSON`. `run.ts` wraps the bundle
+// in an IIFE that returns that global, which `agent-browser eval` prints to
+// stdout — the runner then persists it under `.agent-gateway/`.
+
+import type { ProbeDump } from './types';
+
+declare global {
+  interface Window {
+    __PROBE_LAST_DUMP_JSON?: string;
+  }
+}
+
+const w = window;
+
+if (w.__PROBE_TIMELINE_TIMER) {
+  clearInterval(w.__PROBE_TIMELINE_TIMER);
+  w.__PROBE_TIMELINE_TIMER = null;
+}
+
+const dump: ProbeDump = {
+  meta: {
+    t0: w.__PROBE_T0 ?? 0,
+    collectedAt: Date.now(),
+    sampleCount: (w.__PROBE_MSG_TIMELINE ?? []).length,
+    eventCount: (w.__PROBE_STREAM_EVENTS ?? []).length,
+    callCount: (w.__PROBE_ACTION_CALLS ?? []).length,
+  },
+  streamEvents: w.__PROBE_STREAM_EVENTS ?? [],
+  actionCalls: w.__PROBE_ACTION_CALLS ?? [],
+  timeline: w.__PROBE_MSG_TIMELINE ?? [],
+};
+
+w.__PROBE_LAST_DUMP_JSON = JSON.stringify(dump);

--- a/.agents/skills/local-testing/scripts/agent-gateway/probe-events.ts
+++ b/.agents/skills/local-testing/scripts/agent-gateway/probe-events.ts
@@ -1,0 +1,453 @@
+// LobeHub gateway raw-event-stream probe.
+//
+// Gateway-mode chats subscribe via WebSocket — NOT via the `/api/agent/stream`
+// SSE endpoint (that one belongs to the direct/client durable-agent runtime).
+// `AgentStreamClient` (`packages/agent-gateway-client/src/client.ts`) opens
+// `new WebSocket('wss://.../ws?operationId=...')`, then parses JSON frames in
+// its `onmessage` handler and re-emits `agent_event.event` objects to the
+// chat store.
+//
+// To capture the RAW gateway events before the store touches them, we wrap
+// `window.WebSocket` so that for any socket whose URL contains `operationId=`
+// we intercept the `onmessage` handler / `addEventListener('message')` and
+// log every `agent_event` frame.
+//
+// We *also* keep the `window.fetch` hook for `/api/agent/stream` so this
+// probe still works for direct-mode runs — but gateway-mode events come
+// through the WebSocket path.
+//
+// Buffers (read via `dump`):
+//   __PROBE_STREAM_EVENTS  — raw events parsed off the wire
+//   __PROBE_ACTION_CALLS   — replaceMessages / refreshMessages calls (best-effort)
+//   __PROBE_MSG_TIMELINE   — 200ms snapshots of every messagesMap key
+
+import type {
+  ProbeActionCall,
+  ProbeMessageSummary,
+  ProbeStreamEvent,
+  ProbeTimelineSample,
+} from './types';
+
+// Bundled by esbuild as an IIFE. Top-level code runs once on injection.
+
+const w = window;
+
+// ── Buffers ─────────────────────────────────────────────────────────
+const events: ProbeStreamEvent[] = (w.__PROBE_STREAM_EVENTS ??= []);
+const calls: ProbeActionCall[] = (w.__PROBE_ACTION_CALLS ??= []);
+const timeline: ProbeTimelineSample[] = (w.__PROBE_MSG_TIMELINE ??= []);
+events.length = 0;
+calls.length = 0;
+timeline.length = 0;
+
+const t0 = Date.now();
+w.__PROBE_T0 = t0;
+const now = (): number => Date.now() - t0;
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function summarizeData(data: unknown): Record<string, unknown> | unknown {
+  if (!data || typeof data !== 'object') return data;
+  const src = data as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const k of Object.keys(src)) {
+    const v = src[k];
+    if (v == null) {
+      out[k] = v;
+    } else if (Array.isArray(v)) {
+      out[k] = `Array(${v.length})`;
+      if (k === 'uiMessages') {
+        out.uiMessagesPreview = v.slice(0, 5).map((m: any) => ({
+          id: (m.id ?? '').slice(-8),
+          role: m.role,
+          cLen: (m.content ?? '').length,
+          children: (m.children ?? []).length,
+          tools: (m.tools ?? []).length,
+          reasoning: (m.reasoning?.content ?? '').length,
+        }));
+        out.uiMessagesTotal = v.length;
+      }
+    } else if (typeof v === 'object') {
+      const obj = v as Record<string, unknown>;
+      out[k] =
+        'Object{' +
+        Object.keys(obj)
+          .slice(0, 6)
+          .map((kk) => kk + (typeof obj[kk] === 'string' ? `=${(obj[kk] as string).length}ch` : ''))
+          .join(',') +
+        '}';
+    } else if (typeof v === 'string') {
+      out[k] = v.length > 100 ? v.slice(0, 100) + `…(${v.length})` : v;
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+function summarizeMessages(msgs: any[]): ProbeMessageSummary[] {
+  return (msgs ?? []).slice(0, 80).map((m) => ({
+    id: (m.id ?? '').slice(-8),
+    role: m.role,
+    cLen: (m.content ?? '').length,
+    rLen: (m.reasoning?.content ?? '').length,
+    tools: (m.tools ?? []).length,
+    chN: (m.children ?? []).length,
+  }));
+}
+
+function shortStack(): string {
+  const raw = new Error('probe-stack').stack ?? '';
+  return raw
+    .split('\n')
+    .slice(3)
+    .filter((l) => !l.includes('probe-events') && !l.includes('node_modules'))
+    .map((l) => l.trim().replace(/^at\s+/, ''))
+    .slice(0, 6)
+    .join(' ← ');
+}
+
+function recordAgentEvent(args: {
+  transport: 'ws' | 'sse';
+  opId: string | null;
+  agentEvent: any;
+  eventId?: string | null;
+  rawLen?: number;
+}): void {
+  const { transport, opId, agentEvent, eventId, rawLen } = args;
+  if (!agentEvent || typeof agentEvent !== 'object') return;
+  events.push({
+    t: now(),
+    transport,
+    opIdTail: (opId ?? '').slice(-10),
+    eventId: eventId ?? null,
+    type: agentEvent.type,
+    stepIndex: agentEvent.stepIndex,
+    dataKeys: agentEvent.data ? Object.keys(agentEvent.data) : [],
+    data: summarizeData(agentEvent.data) as Record<string, unknown>,
+    rawLen,
+  });
+}
+
+// ── 1. Patch window.WebSocket for gateway WS events ────────────────
+
+if (!w.__PROBE_ORIG_WEBSOCKET) w.__PROBE_ORIG_WEBSOCKET = w.WebSocket;
+const OrigWS = w.__PROBE_ORIG_WEBSOCKET;
+
+function extractOpIdFromWsUrl(url: string | URL): string | null {
+  const m = String(url ?? '').match(/operationId=([^&]+)/);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+function isGatewayWs(url: string | URL): boolean {
+  return String(url ?? '').includes('operationId=');
+}
+
+function handleWsFrame(rawData: unknown, opId: string | null): void {
+  const rawLen = typeof rawData === 'string' ? rawData.length : -1;
+  let parsed: any;
+  try {
+    parsed = typeof rawData === 'string' ? JSON.parse(rawData) : null;
+  } catch {
+    events.push({
+      t: now(),
+      transport: 'ws',
+      opIdTail: (opId ?? '').slice(-10),
+      type: '_PARSE_ERROR_',
+      raw: typeof rawData === 'string' && rawData.length < 400 ? rawData : '(non-string or large)',
+    });
+    return;
+  }
+  if (!parsed) return;
+
+  if (parsed.type === 'agent_event') {
+    recordAgentEvent({
+      transport: 'ws',
+      opId,
+      agentEvent: parsed.event,
+      eventId: parsed.id,
+      rawLen,
+    });
+  } else {
+    events.push({
+      t: now(),
+      transport: 'ws',
+      opIdTail: (opId ?? '').slice(-10),
+      type: '_SERVER_MSG_',
+      serverType: parsed.type,
+      rawLen,
+    });
+  }
+}
+
+// Wrap the constructor. Instance `constructor` will still reflect OrigWS
+// (we share prototypes), so use the `_WS_OPEN_` sentinel events to confirm
+// the patch is firing.
+function PatchedWebSocket(this: WebSocket, url: string | URL, protocols?: string | string[]) {
+  const ws: WebSocket = protocols == null ? new OrigWS(url) : new OrigWS(url, protocols);
+  const opId = extractOpIdFromWsUrl(url);
+  if (!isGatewayWs(url)) return ws;
+
+  events.push({
+    t: now(),
+    transport: 'ws',
+    opIdTail: (opId ?? '').slice(-10),
+    type: '_WS_OPEN_',
+    url: String(url),
+  });
+
+  // One observer listener that always fires, regardless of how the consumer
+  // (AgentStreamClient uses `ws.onmessage = …`) subscribes.
+  ws.addEventListener('message', (e) => {
+    try {
+      handleWsFrame((e as MessageEvent).data, opId);
+    } catch {
+      /* swallow */
+    }
+  });
+
+  ws.addEventListener('close', () => {
+    events.push({
+      t: now(),
+      transport: 'ws',
+      opIdTail: (opId ?? '').slice(-10),
+      type: '_WS_CLOSE_',
+    });
+  });
+
+  return ws;
+}
+
+// Preserve prototype + static fields so `instanceof WebSocket` and
+// `WebSocket.OPEN` constants still work.
+(PatchedWebSocket as unknown as { prototype: WebSocket }).prototype = OrigWS.prototype;
+for (const k of Object.keys(OrigWS) as Array<keyof typeof OrigWS>) {
+  try {
+    (PatchedWebSocket as any)[k] = (OrigWS as any)[k];
+  } catch {
+    /* readonly */
+  }
+}
+(['CONNECTING', 'OPEN', 'CLOSING', 'CLOSED'] as const).forEach((k) => {
+  (PatchedWebSocket as any)[k] = (OrigWS as any)[k];
+});
+w.WebSocket = PatchedWebSocket as unknown as typeof WebSocket;
+
+// ── 2. Patch window.fetch for `/api/agent/stream` (direct-mode SSE) ─
+
+if (!w.__PROBE_ORIG_FETCH) w.__PROBE_ORIG_FETCH = w.fetch.bind(w);
+const origFetch = w.__PROBE_ORIG_FETCH;
+
+function isAgentStreamUrl(input: RequestInfo | URL): boolean {
+  let url = '';
+  if (typeof input === 'string') url = input;
+  else if (input instanceof URL) url = input.toString();
+  else if (input && typeof (input as Request).url === 'string') url = (input as Request).url;
+  return url.includes('/api/agent/stream');
+}
+
+function extractOpIdFromHttpUrl(input: RequestInfo | URL): string | null {
+  const url = typeof input === 'string' ? input : (input as Request | URL).toString();
+  const m = url.match(/operationId=([^&]+)/);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+function pushFromSSEFrame(rawFrame: string, opId: string | null): void {
+  const lines = rawFrame.split('\n');
+  let dataJson = '';
+  let evtName = 'message';
+  for (const line of lines) {
+    if (line.startsWith('event:')) evtName = line.slice(6).trim();
+    else if (line.startsWith('data:')) dataJson += line.slice(5).trim();
+  }
+  if (!dataJson) return;
+  let parsed: any;
+  try {
+    parsed = JSON.parse(dataJson);
+  } catch {
+    events.push({
+      t: now(),
+      transport: 'sse',
+      opIdTail: (opId ?? '').slice(-10),
+      type: '_PARSE_ERROR_',
+      sseEvent: evtName,
+      raw: dataJson.length > 400 ? dataJson.slice(0, 400) + '…' : dataJson,
+    });
+    return;
+  }
+  recordAgentEvent({
+    transport: 'sse',
+    opId,
+    agentEvent: parsed,
+    eventId: null,
+    rawLen: dataJson.length,
+  });
+}
+
+async function teeAndDrain(response: Response, opId: string | null): Promise<Response> {
+  if (!response.body) return response;
+  const [a, b] = response.body.tee();
+
+  void (async () => {
+    const reader = b.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        let idx: number;
+
+        while ((idx = buf.indexOf('\n\n')) !== -1) {
+          const frame = buf.slice(0, idx);
+          buf = buf.slice(idx + 2);
+          if (frame.trim()) pushFromSSEFrame(frame, opId);
+        }
+      }
+      if (buf.trim()) pushFromSSEFrame(buf, opId);
+    } catch (e: any) {
+      events.push({
+        t: now(),
+        transport: 'sse',
+        opIdTail: (opId ?? '').slice(-10),
+        type: '_TEE_ERROR_',
+        message: String(e?.message ?? e),
+      });
+    }
+  })();
+
+  return new Response(a, {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
+
+w.fetch = async function patchedFetch(input: RequestInfo | URL, init?: RequestInit) {
+  const response = await origFetch(input as any, init);
+  if (!isAgentStreamUrl(input)) return response;
+  const opId = extractOpIdFromHttpUrl(input);
+  const url =
+    typeof input === 'string'
+      ? input.split('?')[0]
+      : (input as Request | URL).toString().split('?')[0];
+  events.push({
+    t: now(),
+    transport: 'sse',
+    opIdTail: (opId ?? '').slice(-10),
+    type: '_CONNECTED_',
+    url,
+    status: response.status,
+  });
+  return teeAndDrain(response, opId);
+} as typeof fetch;
+
+// ── 3. Wrap store actions (best-effort for "who called replace") ────
+
+try {
+  const chat = w.__LOBE_STORES?.chat?.();
+  if (chat && !chat.__probeWrapped) {
+    const origRefresh = chat.refreshMessages;
+    const origReplace = chat.replaceMessages;
+
+    chat.refreshMessages = async function probeRefresh(this: unknown, ...args: any[]) {
+      calls.push({
+        t: now(),
+        name: 'refreshMessages',
+        args: { context: args[0] ?? null },
+        stack: shortStack(),
+      });
+      return origRefresh.apply(this, args);
+    };
+    chat.replaceMessages = function probeReplace(this: unknown, ...args: any[]) {
+      const msgs = (args[0] as unknown[]) ?? [];
+      calls.push({
+        t: now(),
+        name: 'replaceMessages',
+        args: { count: msgs.length, params: args[1] ?? null },
+        stack: shortStack(),
+      });
+      return origReplace.apply(this, args);
+    };
+    chat.__probeWrapped = true;
+  }
+} catch (e: any) {
+  calls.push({ t: now(), name: '_WRAP_ERROR_', error: String(e?.message ?? e) });
+}
+
+// ── 4. Periodic per-key timeline snapshots ─────────────────────────
+
+function captureTimeline(): void {
+  try {
+    const c = w.__LOBE_STORES?.chat?.();
+    if (!c) return;
+    const msgsMap = (c.messagesMap ?? {}) as Record<string, any[]>;
+    const dbMap = (c.dbMessagesMap ?? {}) as Record<string, any[]>;
+    const byKey: ProbeTimelineSample['byKey'] = {};
+    for (const k of Object.keys(msgsMap)) {
+      const display = msgsMap[k] ?? [];
+      const db = dbMap[k] ?? [];
+      if (display.length === 0 && db.length === 0) continue;
+      byKey[k] = {
+        n: display.length,
+        dbN: db.length,
+        msgs: summarizeMessages(display),
+      };
+    }
+    const ops = Object.values((c.operations ?? {}) as Record<string, any>);
+    timeline.push({
+      t: now(),
+      activeTopic: ((c.activeTopicId as string | null) ?? '').slice(-10) || null,
+      keys: Object.keys(byKey),
+      byKey,
+      runOps: ops.filter((o: any) => o.status === 'running').length,
+    });
+  } catch (e: any) {
+    timeline.push({
+      t: now(),
+      activeTopic: null,
+      keys: [],
+      byKey: {},
+      runOps: 0,
+      err: e?.message ?? String(e),
+    });
+  }
+}
+captureTimeline();
+if (w.__PROBE_TIMELINE_TIMER) clearInterval(w.__PROBE_TIMELINE_TIMER);
+w.__PROBE_TIMELINE_TIMER = setInterval(captureTimeline, 200);
+
+// ── 5. Tab-switch helpers ──────────────────────────────────────────
+
+function listTopBarTabs(): HTMLElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLElement>(
+      '[data-insp-path*="TabItem.tsx"][data-contextmenu-trigger]',
+    ),
+  ).filter((t) => t.getBoundingClientRect().top < 30);
+}
+
+w.__listTabs = () =>
+  listTopBarTabs().map((t, i) => ({
+    i,
+    key: t.getAttribute('data-contextmenu-trigger'),
+    active: t.getAttribute('data-active') === 'true',
+    title: (t.innerText ?? '').slice(0, 60),
+  }));
+
+w.__clickTabByKey = (key: string) => {
+  const tab = listTopBarTabs().find((t) => t.getAttribute('data-contextmenu-trigger') === key);
+  if (!tab) return 'not found: ' + key;
+  if (tab.getAttribute('data-active') === 'true') return 'already active: ' + key;
+  tab.click();
+  return 'clicked key=' + key;
+};
+
+w.__PROBE_EVENT = (name: string) => {
+  calls.push({ t: now(), name: 'MARK:' + name });
+};
+
+// `run.ts` wraps the bundle in an IIFE and appends a `return <confirmation>`
+// after the bundle body — agent-browser then prints the confirmation back to
+// the operator. Nothing to do here at the end of the module body.

--- a/.agents/skills/local-testing/scripts/agent-gateway/probe-events.ts
+++ b/.agents/skills/local-testing/scripts/agent-gateway/probe-events.ts
@@ -345,11 +345,28 @@ w.fetch = async function patchedFetch(input: RequestInfo | URL, init?: RequestIn
 
 // ── 3. Wrap store actions (best-effort for "who called replace") ────
 
+// Side-global stash for the original chat-store actions. Re-installs ALWAYS
+// rewrap from the originals so updates to the probe body take effect
+// without a page reload — using only a `__probeWrapped` flag on the chat
+// state object would freeze the first-installed wrapper across re-installs.
+declare global {
+  interface Window {
+    __PROBE_ORIG_REFRESH_MESSAGES?: any;
+    __PROBE_ORIG_REPLACE_MESSAGES?: any;
+  }
+}
+
 try {
   const chat = w.__LOBE_STORES?.chat?.();
-  if (chat && !chat.__probeWrapped) {
-    const origRefresh = chat.refreshMessages;
-    const origReplace = chat.replaceMessages;
+  if (chat) {
+    // First-time install: cache the originals. Re-install: restore from
+    // the cached originals before wrapping again.
+    if (!w.__PROBE_ORIG_REFRESH_MESSAGES) w.__PROBE_ORIG_REFRESH_MESSAGES = chat.refreshMessages;
+    if (!w.__PROBE_ORIG_REPLACE_MESSAGES) w.__PROBE_ORIG_REPLACE_MESSAGES = chat.replaceMessages;
+    const origRefresh = w.__PROBE_ORIG_REFRESH_MESSAGES;
+    const origReplace = w.__PROBE_ORIG_REPLACE_MESSAGES;
+    chat.refreshMessages = origRefresh;
+    chat.replaceMessages = origReplace;
 
     chat.refreshMessages = async function probeRefresh(this: unknown, ...args: any[]) {
       calls.push({
@@ -361,16 +378,25 @@ try {
       return origRefresh.apply(this, args);
     };
     chat.replaceMessages = function probeReplace(this: unknown, ...args: any[]) {
-      const msgs = (args[0] as unknown[]) ?? [];
+      const msgs = (args[0] as any[]) ?? [];
+      // Snapshot last 2 messages' role + cLen + rLen so we can see WHAT
+      // each replaceMessages call writes. "count=2" alone hides whether
+      // the call is restoring streamed content or wiping it to placeholder.
+      const snapshot = msgs.slice(-2).map((m) => ({
+        id: (m.id ?? '').slice(-8),
+        role: m.role,
+        cLen: (m.content ?? '').length,
+        rLen: (m.reasoning?.content ?? '').length,
+        updatedAt: m.updatedAt,
+      }));
       calls.push({
         t: now(),
         name: 'replaceMessages',
-        args: { count: msgs.length, params: args[1] ?? null },
+        args: { count: msgs.length, params: args[1] ?? null, snapshot } as any,
         stack: shortStack(),
       });
       return origReplace.apply(this, args);
     };
-    chat.__probeWrapped = true;
   }
 } catch (e: any) {
   calls.push({ t: now(), name: '_WRAP_ERROR_', error: String(e?.message ?? e) });

--- a/.agents/skills/local-testing/scripts/agent-gateway/probe-events.ts
+++ b/.agents/skills/local-testing/scripts/agent-gateway/probe-events.ts
@@ -33,12 +33,29 @@ import type {
 const w = window;
 
 // ── Buffers ─────────────────────────────────────────────────────────
+
+declare global {
+  interface Window {
+    __PROBE_MUTATIONS?: Array<{
+      t: number;
+      key: string;
+      n: number;
+      last?: { id: string; role: string; cLen: number; rLen: number; updatedAt?: unknown };
+      prevLast?: { id: string; role: string; cLen: number; rLen: number };
+      delta?: string;
+    }>;
+    __PROBE_STORE_UNSUB?: () => void;
+  }
+}
+
 const events: ProbeStreamEvent[] = (w.__PROBE_STREAM_EVENTS ??= []);
 const calls: ProbeActionCall[] = (w.__PROBE_ACTION_CALLS ??= []);
 const timeline: ProbeTimelineSample[] = (w.__PROBE_MSG_TIMELINE ??= []);
+const mutations = (w.__PROBE_MUTATIONS ??= []);
 events.length = 0;
 calls.length = 0;
 timeline.length = 0;
+mutations.length = 0;
 
 const t0 = Date.now();
 w.__PROBE_T0 = t0;
@@ -379,9 +396,6 @@ try {
     };
     chat.replaceMessages = function probeReplace(this: unknown, ...args: any[]) {
       const msgs = (args[0] as any[]) ?? [];
-      // Snapshot last 2 messages' role + cLen + rLen so we can see WHAT
-      // each replaceMessages call writes. "count=2" alone hides whether
-      // the call is restoring streamed content or wiping it to placeholder.
       const snapshot = msgs.slice(-2).map((m) => ({
         id: (m.id ?? '').slice(-8),
         role: m.role,
@@ -395,11 +409,155 @@ try {
         args: { count: msgs.length, params: args[1] ?? null, snapshot } as any,
         stack: shortStack(),
       });
+
+      // Pair the call with a mutation row so the analyzer can build a
+      // single ordered timeline across replaceMessages + dispatchMessage.
+      const stackTop = shortStack().split(' ← ')[0]?.slice(0, 80);
+      const last = msgs.at(-1);
+      const lastSum = last
+        ? {
+            id: (last.id ?? '').slice(-8),
+            role: last.role,
+            cLen: (last.content ?? '').length,
+            rLen: (last.reasoning?.content ?? '').length,
+            updatedAt: last.updatedAt,
+          }
+        : undefined;
+      const params: any = args[1] ?? {};
+      const ctxKey = params.context
+        ? `main_${params.context.agentId ?? '?'}_${
+            params.context.topicId ? 'tpc_' + params.context.topicId : 'new'
+          }`.replace('main_tpc_', 'main_') // crude key inference
+        : '(no-ctx)';
+      mutations.push({
+        t: now(),
+        key: ctxKey,
+        n: msgs.length,
+        last: lastSum,
+        delta: `replaceMessages(action=${params.action ?? '-'})  src=${stackTop ?? '-'}`,
+      });
+
       return origReplace.apply(this, args);
     };
   }
 } catch (e: any) {
   calls.push({ t: now(), name: '_WRAP_ERROR_', error: String(e?.message ?? e) });
+}
+
+// ── 3.5. Mutation log — wrap the TWO ChatStore writers (replaceMessages,
+// internal_dispatchMessage) to record EVERY dbMessagesMap[key] reference
+// change with a one-line "before/after last assistant message" delta. This
+// reveals dispatchMessage-driven collapses that the replaceMessages wrap
+// alone cannot see.
+
+declare global {
+  interface Window {
+    __PROBE_ORIG_DISPATCH_MESSAGE?: any;
+  }
+}
+
+try {
+  const chat = w.__LOBE_STORES?.chat?.();
+  if (chat?.internal_dispatchMessage) {
+    if (!w.__PROBE_ORIG_DISPATCH_MESSAGE)
+      w.__PROBE_ORIG_DISPATCH_MESSAGE = chat.internal_dispatchMessage;
+    const origDispatch = w.__PROBE_ORIG_DISPATCH_MESSAGE;
+    chat.internal_dispatchMessage = origDispatch;
+
+    chat.internal_dispatchMessage = function probeDispatch(this: unknown, payload: any, ctx?: any) {
+      // Snapshot BEFORE — read the would-be target key + last message.
+      const before = (() => {
+        try {
+          const state = w.__LOBE_STORES?.chat?.();
+          if (!state) return null;
+          // Replicate state.internal_getConversationContext logic enough to
+          // resolve a key — but most callers pass operationId on ctx, and
+          // operationId-keyed lookup needs store internals. Easiest: snapshot
+          // ALL keys' last-assistant cLen and compare BEFORE vs AFTER below.
+          const map = state.dbMessagesMap ?? {};
+          const out: Record<string, any> = {};
+          for (const k of Object.keys(map)) {
+            const last = (map[k] ?? []).at(-1);
+            out[k] = last
+              ? {
+                  id: (last.id ?? '').slice(-8),
+                  cLen: (last.content ?? '').length,
+                  rLen: (last.reasoning?.content ?? '').length,
+                  n: map[k].length,
+                }
+              : { n: 0 };
+          }
+          return out;
+        } catch {
+          return null;
+        }
+      })();
+
+      const result = origDispatch.apply(this, [payload, ctx]);
+
+      // Snapshot AFTER — find which key(s) actually changed.
+      try {
+        const state = w.__LOBE_STORES?.chat?.();
+        if (state && before) {
+          const map = state.dbMessagesMap ?? {};
+          for (const k of Object.keys(map)) {
+            const last = (map[k] ?? []).at(-1);
+            const beforeSnap = before[k];
+            const afterSnap = last
+              ? {
+                  id: (last.id ?? '').slice(-8),
+                  cLen: (last.content ?? '').length,
+                  rLen: (last.reasoning?.content ?? '').length,
+                  n: map[k].length,
+                }
+              : { n: 0 };
+            const changed =
+              !beforeSnap ||
+              beforeSnap.n !== afterSnap.n ||
+              beforeSnap.id !== (afterSnap as any).id ||
+              beforeSnap.cLen !== (afterSnap as any).cLen ||
+              beforeSnap.rLen !== (afterSnap as any).rLen;
+            if (!changed) continue;
+            let delta = '';
+            if (beforeSnap?.id !== undefined && beforeSnap.id !== (afterSnap as any).id)
+              delta += `id:${beforeSnap.id}→${(afterSnap as any).id};`;
+            if (
+              beforeSnap?.cLen !== undefined &&
+              (afterSnap as any).cLen !== undefined &&
+              (afterSnap as any).cLen < beforeSnap.cLen
+            )
+              delta += `cLen↓${beforeSnap.cLen}→${(afterSnap as any).cLen};`;
+            if (
+              beforeSnap?.rLen !== undefined &&
+              (afterSnap as any).rLen !== undefined &&
+              (afterSnap as any).rLen < beforeSnap.rLen
+            )
+              delta += `rLen↓${beforeSnap.rLen}→${(afterSnap as any).rLen};`;
+            if (beforeSnap?.n !== undefined && afterSnap.n < beforeSnap.n)
+              delta += `n↓${beforeSnap.n}→${afterSnap.n};`;
+            mutations.push({
+              t: now(),
+              key: k,
+              n: afterSnap.n,
+              last: (afterSnap as any).id ? (afterSnap as any) : undefined,
+              prevLast: beforeSnap?.id ? beforeSnap : undefined,
+              delta: delta || `dispatch:${payload?.type}`,
+            });
+          }
+        }
+      } catch (e: any) {
+        mutations.push({
+          t: now(),
+          key: '_DISPATCH_PROBE_ERROR_',
+          n: -1,
+          delta: String(e?.message ?? e),
+        });
+      }
+      return result;
+    };
+  }
+} catch (e: any) {
+  calls.push({ t: now(), name: '_DISPATCH_WRAP_ERROR_', error: String(e?.message ?? e) });
 }
 
 // ── 4. Periodic per-key timeline snapshots ─────────────────────────

--- a/.agents/skills/local-testing/scripts/agent-gateway/run.ts
+++ b/.agents/skills/local-testing/scripts/agent-gateway/run.ts
@@ -1,0 +1,211 @@
+// CLI for the agent-gateway probe.
+//
+// Bundles the TS probes with esbuild, pipes them into `agent-browser eval`,
+// and persists dumps under `.agent-gateway/` (gitignored) for later use as
+// streaming-replay test fixtures.
+//
+// Commands:
+//   bun run .agents/skills/local-testing/scripts/agent-gateway/run.ts install
+//       Bundle probe-events.ts and inject into the CDP-attached browser.
+//       Re-installing clears all buffers and re-patches WebSocket / fetch.
+//
+//   bun run .agents/skills/local-testing/scripts/agent-gateway/run.ts dump [name]
+//       Stop the timeline timer, fetch the capture as JSON, write it to
+//       `.agent-gateway/<name>-<YYYYMMDD-HHmmss>.json`. `name` defaults to
+//       `dump`. Prints the absolute path written.
+//
+//   bun run .agents/skills/local-testing/scripts/agent-gateway/run.ts analyze [path]
+//       Run analyze-events.ts on the dump. `path` defaults to the most
+//       recently modified file in `.agent-gateway/`.
+//
+// Optional flags:
+//   --cdp <port>     CDP port (default 9222)
+//   --browser <bin>  agent-browser binary (default 'agent-browser')
+
+import { spawn } from 'node:child_process';
+import { mkdirSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+// .agents/skills/local-testing/scripts/agent-gateway/ → 5 levels up
+const PROJECT_ROOT = path.resolve(SCRIPT_DIR, '../../../../..');
+const DUMP_DIR = path.join(PROJECT_ROOT, '.agent-gateway');
+
+interface Flags {
+  browser: string;
+  cdp: string;
+  positional: string[];
+}
+
+function parseFlags(argv: string[]): Flags {
+  const out: Flags = { cdp: '9222', browser: 'agent-browser', positional: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--cdp') out.cdp = argv[++i] ?? out.cdp;
+    else if (a === '--browser') out.browser = argv[++i] ?? out.browser;
+    else out.positional.push(a);
+  }
+  return out;
+}
+
+async function bundle(entry: string): Promise<string> {
+  // Bun.build is built into the Bun runtime — no external dep needed.
+  const r = await Bun.build({
+    entrypoints: [path.join(SCRIPT_DIR, entry)],
+    target: 'browser',
+    format: 'esm',
+    minify: false,
+  });
+  if (!r.success) {
+    const msgs = r.logs.map((l) => `${l.level}: ${l.message}`).path.join('\n');
+    throw new Error(`bundle failed for ${entry}:\n${msgs}`);
+  }
+  return await r.outputs[0].text();
+}
+
+function wrapIife(body: string, returnExpr: string): string {
+  // Wrap as an IIFE that swallows the bundled top-level (top-level `const`
+  // declarations get scoped to the IIFE, so re-injection doesn't conflict)
+  // and returns the configured expression — which `agent-browser eval`
+  // captures and prints to stdout.
+  return `(() => {\n${body}\n;return ${returnExpr};\n})()`;
+}
+
+function runAgentBrowserEval(flags: Flags, script: string): Promise<string> {
+  return new Promise((resolveP, rejectP) => {
+    const child = spawn(flags.browser, ['--cdp', flags.cdp, 'eval', '--stdin'], {
+      stdio: ['pipe', 'pipe', 'inherit'],
+    });
+    let stdout = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
+    });
+    child.on('error', rejectP);
+    child.on('close', (code) => {
+      if (code === 0) resolveP(stdout);
+      else rejectP(new Error(`agent-browser exited ${code}`));
+    });
+    child.stdin.write(script);
+    child.stdin.end();
+  });
+}
+
+// agent-browser prints eval results as JSON (string values are quoted).
+function unquoteAgentBrowserResult(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    try {
+      return JSON.parse(trimmed) as string;
+    } catch {
+      /* fall through */
+    }
+  }
+  return trimmed;
+}
+
+function isoStamp(): string {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mi = String(d.getMinutes()).padStart(2, '0');
+  const ss = String(d.getSeconds()).padStart(2, '0');
+  return `${yyyy}${mm}${dd}-${hh}${mi}${ss}`;
+}
+
+function ensureDumpDir(): void {
+  mkdirSync(DUMP_DIR, { recursive: true });
+}
+
+function latestDump(): string | null {
+  ensureDumpDir();
+  const entries = readdirSync(DUMP_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => ({ f, mtime: statSync(path.join(DUMP_DIR, f)).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime);
+  return entries[0] ? path.join(DUMP_DIR, entries[0].f) : null;
+}
+
+// ── Commands ────────────────────────────────────────────────────────
+
+async function cmdInstall(flags: Flags): Promise<void> {
+  const body = await bundle('probe-events.ts');
+  const installMsg = JSON.stringify(
+    'events probe installed: WebSocket+fetch interception. ' +
+      'WS captures operationId= sockets (gateway), fetch captures /api/agent/stream (direct).',
+  );
+  const script = wrapIife(body, installMsg);
+  const out = await runAgentBrowserEval(flags, script);
+  console.log(unquoteAgentBrowserResult(out));
+}
+
+async function cmdDump(flags: Flags): Promise<void> {
+  const name = flags.positional[1] ?? 'dump';
+  const body = await bundle('probe-dump.ts');
+  const script = wrapIife(body, 'window.__PROBE_LAST_DUMP_JSON');
+  const raw = await runAgentBrowserEval(flags, script);
+  const json = unquoteAgentBrowserResult(raw);
+  ensureDumpDir();
+  const filename = `${name}-${isoStamp()}.json`;
+  const path = path.join(DUMP_DIR, filename);
+  writeFileSync(path, json, 'utf8');
+  // Validate by parsing the meta header so we error early on bad capture
+  try {
+    const parsed = JSON.parse(json) as {
+      meta?: { eventCount?: number; callCount?: number; sampleCount?: number };
+    };
+    const meta = parsed.meta ?? {};
+    console.log(
+      `wrote ${path}  (${json.length} bytes  events=${meta.eventCount ?? '?'}  ` +
+        `calls=${meta.callCount ?? '?'}  samples=${meta.sampleCount ?? '?'})`,
+    );
+  } catch {
+    console.log(`wrote ${path}  (${json.length} bytes — JSON.parse failed; see file)`);
+  }
+}
+
+async function cmdAnalyze(flags: Flags): Promise<void> {
+  const target = flags.positional[1] ?? latestDump();
+  if (!target) {
+    console.error('no dump file found. run `dump` first or pass a path.');
+    process.exit(1);
+  }
+  const child = spawn('bun', ['run', path.join(SCRIPT_DIR, 'analyze-events.ts'), target], {
+    stdio: 'inherit',
+  });
+  await new Promise<void>((resolveP, rejectP) => {
+    child.on('error', rejectP);
+    child.on('close', (code) => (code === 0 ? resolveP() : rejectP(new Error(`exit ${code}`))));
+  });
+}
+
+// ── Entry point ─────────────────────────────────────────────────────
+
+const flags = parseFlags(process.argv.slice(2));
+const cmd = flags.positional[0];
+
+const usage = `usage:
+  bun run run.ts install [--cdp 9222]
+  bun run run.ts dump [name] [--cdp 9222]
+  bun run run.ts analyze [path]
+`;
+
+if (!cmd) {
+  console.error(usage);
+  process.exit(1);
+}
+
+try {
+  if (cmd === 'install') await cmdInstall(flags);
+  else if (cmd === 'dump') await cmdDump(flags);
+  else if (cmd === 'analyze') await cmdAnalyze(flags);
+  else {
+    console.error(`unknown command: ${cmd}\n\n${usage}`);
+    process.exit(1);
+  }
+} catch (e: any) {
+  console.error(e?.stack ?? e);
+  process.exit(1);
+}

--- a/.agents/skills/local-testing/scripts/agent-gateway/run.ts
+++ b/.agents/skills/local-testing/scripts/agent-gateway/run.ts
@@ -58,7 +58,7 @@ async function bundle(entry: string): Promise<string> {
     minify: false,
   });
   if (!r.success) {
-    const msgs = r.logs.map((l) => `${l.level}: ${l.message}`).path.join('\n');
+    const msgs = r.logs.map((l) => `${l.level}: ${l.message}`).join('\n');
     throw new Error(`bundle failed for ${entry}:\n${msgs}`);
   }
   return await r.outputs[0].text();
@@ -149,8 +149,8 @@ async function cmdDump(flags: Flags): Promise<void> {
   const json = unquoteAgentBrowserResult(raw);
   ensureDumpDir();
   const filename = `${name}-${isoStamp()}.json`;
-  const path = path.join(DUMP_DIR, filename);
-  writeFileSync(path, json, 'utf8');
+  const dumpPath = path.join(DUMP_DIR, filename);
+  writeFileSync(dumpPath, json, 'utf8');
   // Validate by parsing the meta header so we error early on bad capture
   try {
     const parsed = JSON.parse(json) as {
@@ -158,11 +158,11 @@ async function cmdDump(flags: Flags): Promise<void> {
     };
     const meta = parsed.meta ?? {};
     console.log(
-      `wrote ${path}  (${json.length} bytes  events=${meta.eventCount ?? '?'}  ` +
+      `wrote ${dumpPath}  (${json.length} bytes  events=${meta.eventCount ?? '?'}  ` +
         `calls=${meta.callCount ?? '?'}  samples=${meta.sampleCount ?? '?'})`,
     );
   } catch {
-    console.log(`wrote ${path}  (${json.length} bytes — JSON.parse failed; see file)`);
+    console.log(`wrote ${dumpPath}  (${json.length} bytes — JSON.parse failed; see file)`);
   }
 }
 

--- a/.agents/skills/local-testing/scripts/agent-gateway/types.ts
+++ b/.agents/skills/local-testing/scripts/agent-gateway/types.ts
@@ -1,0 +1,113 @@
+// Shared types between the in-browser probe and the Node-side analyzer.
+// Kept tiny on purpose — anything the analyzer can re-derive is left off.
+
+export interface ProbeStreamEvent {
+  /** Summarized payload — long strings truncated, arrays printed as Array(N) */
+  data?: Record<string, unknown>;
+  /** Keys present on the event's `data` payload — useful at a glance */
+  dataKeys?: string[];
+  /** ServerMessage.id — gateway WS frames carry an event-id we may resume from */
+  eventId?: string | null;
+  message?: string;
+  /** Last 10 chars of the operationId (full id is excessively long) */
+  opIdTail: string;
+  raw?: string;
+  /** Raw frame byte length, when applicable */
+  rawLen?: number;
+  /** For non-agent_event server frames (auth_success, heartbeat_ack, …) */
+  serverType?: string;
+  sseEvent?: string;
+  status?: number;
+  stepIndex?: number;
+  /** Milliseconds since the probe's t0 (install time). */
+  t: number;
+  /** 'ws' for gateway WebSocket frames, 'sse' for direct /api/agent/stream */
+  transport: 'ws' | 'sse';
+  /** Either the AgentStreamEvent.type, or a probe sentinel like `_WS_OPEN_` */
+  type: string;
+  url?: string;
+}
+
+export interface ProbeActionCall {
+  args?: {
+    count?: number;
+    context?: unknown;
+    params?: unknown;
+  };
+  error?: string;
+  /** `replaceMessages` / `refreshMessages` / `MARK:<label>` / `_WRAP_ERROR_` */
+  name: string;
+  stack?: string;
+  t: number;
+}
+
+export interface ProbeMessageSummary {
+  /** children.length */
+  chN: number;
+  /** content.length */
+  cLen: number;
+  /** Last 8 chars of the message id */
+  id: string;
+  /** reasoning.content.length */
+  rLen: number;
+  role: string;
+  /** tools.length */
+  tools: number;
+}
+
+export interface ProbeTimelineSample {
+  /** Last 10 chars of activeTopicId, or null */
+  activeTopic: string | null;
+  /** Per-key breakdown: display count, db count, message summaries */
+  byKey: Record<
+    string,
+    {
+      n: number;
+      dbN: number;
+      msgs: ProbeMessageSummary[];
+    }
+  >;
+  err?: string;
+  /** All messagesMap keys that have content at this moment */
+  keys: string[];
+  /** Number of operations in 'running' status */
+  runOps: number;
+  t: number;
+}
+
+export interface ProbeDumpMeta {
+  callCount: number;
+  /** Date.now() at dump call */
+  collectedAt: number;
+  eventCount: number;
+  sampleCount: number;
+  /** Date.now() at probe install */
+  t0: number;
+}
+
+export interface ProbeDump {
+  actionCalls: ProbeActionCall[];
+  meta: ProbeDumpMeta;
+  streamEvents: ProbeStreamEvent[];
+  timeline: ProbeTimelineSample[];
+}
+
+/**
+ * Globals the probe attaches to `window`. Keeps `as any` casts at the boundary
+ * instead of sprinkling them through the probe body.
+ */
+declare global {
+  interface Window {
+    __clickTabByKey?: (key: string) => string;
+    __listTabs?: () => Array<{ i: number; key: string | null; active: boolean; title: string }>;
+    __LOBE_STORES?: Record<string, () => any>;
+    __PROBE_ACTION_CALLS?: ProbeActionCall[];
+    __PROBE_EVENT?: (label: string) => void;
+    __PROBE_MSG_TIMELINE?: ProbeTimelineSample[];
+    __PROBE_ORIG_FETCH?: typeof fetch;
+    __PROBE_ORIG_WEBSOCKET?: typeof WebSocket;
+    __PROBE_STREAM_EVENTS?: ProbeStreamEvent[];
+    __PROBE_T0?: number;
+    __PROBE_TIMELINE_TIMER?: ReturnType<typeof setInterval> | null;
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ prd
 # Recordings
 .records/
 
+# Agent-gateway probe captures (local debugging dumps)
+.agent-gateway/
+
 # Temporary files
 .temp/
 temp/

--- a/src/features/Conversation/ChatList/index.tsx
+++ b/src/features/Conversation/ChatList/index.tsx
@@ -7,6 +7,7 @@ import { useFetchAgentDocuments } from '@/hooks/useFetchAgentDocuments';
 import { useFetchTopicMemories } from '@/hooks/useFetchMemoryForTopic';
 import { useFetchNotebookDocuments } from '@/hooks/useFetchNotebookDocuments';
 import { useChatStore } from '@/store/chat';
+import { operationSelectors } from '@/store/chat/selectors';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
@@ -84,8 +85,14 @@ const ChatList = memo<ChatListProps>(
       s.useFetchMessages,
     ]);
     const activeAgentId = useChatStore((s) => s.activeAgentId);
+    // Suppress SWR focus revalidate while the current topic is streaming —
+    // the server-pushed UIChatMessage[] snapshot at step boundaries is the
+    // source of truth during that window. A focus refetch could hit DB
+    // mid-fan-out and clobber the in-memory streamed state with a stale
+    // assistant placeholder.
+    const isStreaming = useChatStore(operationSelectors.isAgentRuntimeRunningByContext(context));
     const { enableAgentSelfIteration } = useServerConfigStore(featureFlagsSelectors);
-    useFetchMessages(context, { skipFetch });
+    useFetchMessages(context, { revalidateOnFocus: !isStreaming, skipFetch });
     const displayMessages = useConversationStore(dataSelectors.displayMessages);
     const displayMessageIds = useConversationStore(dataSelectors.displayMessageIds);
     const latestMessageId = displayMessageIds.at(-1);

--- a/src/features/Conversation/ChatList/index.tsx
+++ b/src/features/Conversation/ChatList/index.tsx
@@ -85,7 +85,7 @@ const ChatList = memo<ChatListProps>(
     ]);
     const activeAgentId = useChatStore((s) => s.activeAgentId);
     const { enableAgentSelfIteration } = useServerConfigStore(featureFlagsSelectors);
-    useFetchMessages(context, skipFetch);
+    useFetchMessages(context, { skipFetch });
     const displayMessages = useConversationStore(dataSelectors.displayMessages);
     const displayMessageIds = useConversationStore(dataSelectors.displayMessageIds);
     const latestMessageId = displayMessageIds.at(-1);

--- a/src/features/Conversation/Messages/GroupTasks/TaskItem/ClientTaskItem.tsx
+++ b/src/features/Conversation/Messages/GroupTasks/TaskItem/ClientTaskItem.tsx
@@ -76,7 +76,7 @@ const ClientTaskItem = memo<ClientTaskItemProps>(({ item }) => {
   );
 
   // Fetch thread messages (skip when executing - messages come from real-time updates)
-  useFetchMessages(threadContext, isProcessing);
+  useFetchMessages(threadContext, { skipFetch: isProcessing });
 
   // Get thread messages from store using selector
   const threadMessages = useChatStore((s) =>

--- a/src/features/Conversation/Messages/GroupTasks/TaskItem/useClientTaskStats.ts
+++ b/src/features/Conversation/Messages/GroupTasks/TaskItem/useClientTaskStats.ts
@@ -59,7 +59,7 @@ export const useClientTaskStats = ({
   );
 
   // Fetch thread messages (skip when disabled or no threadId)
-  useFetchMessages(threadContext, !enabled || !threadId);
+  useFetchMessages(threadContext, { skipFetch: !enabled || !threadId });
 
   // Get thread messages from store using selector
   const threadMessages = useChatStore((s) =>

--- a/src/features/Conversation/Messages/Task/ClientTaskDetail/index.tsx
+++ b/src/features/Conversation/Messages/Task/ClientTaskDetail/index.tsx
@@ -54,7 +54,7 @@ const ClientTaskDetail = memo<ClientTaskDetailProps>(
     );
 
     // Fetch thread messages (skip when executing - messages come from real-time updates)
-    useFetchMessages(threadContext, isExecuting);
+    useFetchMessages(threadContext, { skipFetch: isExecuting });
 
     // Get thread messages from store using selector
     const threadMessages = useChatStore((s) =>

--- a/src/features/Conversation/Messages/Tasks/TaskItem/ClientTaskItem.tsx
+++ b/src/features/Conversation/Messages/Tasks/TaskItem/ClientTaskItem.tsx
@@ -61,7 +61,7 @@ const ClientTaskItem = memo<ClientTaskItemProps>(({ item }) => {
   );
 
   // Fetch thread messages (skip when executing - messages come from real-time updates)
-  useFetchMessages(threadContext, isProcessing);
+  useFetchMessages(threadContext, { skipFetch: isProcessing });
 
   // Get thread messages from store using selector
   const threadMessages = useChatStore((s) =>

--- a/src/features/Conversation/Messages/Tasks/TaskItem/useClientTaskStats.ts
+++ b/src/features/Conversation/Messages/Tasks/TaskItem/useClientTaskStats.ts
@@ -59,7 +59,7 @@ export const useClientTaskStats = ({
   );
 
   // Fetch thread messages (skip when disabled or no threadId)
-  useFetchMessages(threadContext, !enabled || !threadId);
+  useFetchMessages(threadContext, { skipFetch: !enabled || !threadId });
 
   // Get thread messages from store using selector
   const threadMessages = useChatStore((s) =>

--- a/src/features/Conversation/store/slices/data/action.ts
+++ b/src/features/Conversation/store/slices/data/action.ts
@@ -6,6 +6,8 @@ import { type StateCreator } from 'zustand/vanilla';
 
 import { useClientDataSWRWithSync } from '@/libs/swr';
 import { messageService } from '@/services/message';
+import { getChatStoreState } from '@/store/chat';
+import { operationSelectors } from '@/store/chat/selectors';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 
 import { type Store as ConversationStore } from '../../action';
@@ -214,6 +216,22 @@ export const dataSlice: StateCreator<
         onData: (data) => {
           if (!data) return;
           if (!context.topicId) return;
+
+          // Defense-in-depth gate (LOBE-9501): drop any SWR onData while the
+          // topic is streaming. DB fan-out for chunk writes is async and lags
+          // the WS push by anywhere from 100ms to several seconds; an SWR
+          // refetch that lands inside that window returns the assistant row
+          // as the LOADING_FLAT placeholder (cLen=3) and would collapse the
+          // in-memory streamed content. SWR's own cache still receives the
+          // value, so once streaming ends a normal revalidate writes through.
+          //
+          // This is the catch-all backstop sitting BELOW the SoT consumption
+          // in gatewayEventHandler — `mergeFetchedMessagesWithLocalState`'s
+          // updatedAt tie-breaker handles most cases on its own, but the
+          // updatedAt comparison degenerates when server's pushed snapshot
+          // carries a DB updatedAt equal to a later stale fetch's row.
+          if (operationSelectors.isAgentRuntimeRunningByContext(context)(getChatStoreState()))
+            return;
 
           const prevDbMessages = get().dbMessages;
           const mergedMessages = mergeFetchedMessagesWithLocalState(data, prevDbMessages);

--- a/src/features/Conversation/store/slices/data/action.ts
+++ b/src/features/Conversation/store/slices/data/action.ts
@@ -67,14 +67,17 @@ export interface DataAction {
   switchMessageBranch: (messageId: string, branchIndex: number) => Promise<void>;
 
   /**
-   * Fetch messages for this conversation using SWR
+   * Fetch messages for this conversation using SWR.
    *
    * @param context - Conversation context with sessionId and topicId
-   * @param skipFetch - When true, SWR key is null and no fetch occurs
+   * @param options.skipFetch - When true, SWR key is null and no fetch occurs
+   * @param options.revalidateOnFocus - Override SWR's default focus revalidate.
+   *   Pass `false` while a streaming flow owns the in-memory message state so
+   *   a focus refetch doesn't clobber it with a stale DB snapshot.
    */
   useFetchMessages: (
     context: ConversationContext,
-    skipFetch?: boolean,
+    options?: { revalidateOnFocus?: boolean; skipFetch?: boolean },
   ) => SWRResponse<UIChatMessage[]>;
 }
 
@@ -184,7 +187,8 @@ export const dataSlice: StateCreator<
     await state.updateMessageMetadata(message.parentId, { activeBranchIndex: branchIndex });
   },
 
-  useFetchMessages: (context, skipFetch) => {
+  useFetchMessages: (context, options) => {
+    const { skipFetch, revalidateOnFocus } = options ?? {};
     // When skipFetch is true, SWR key is null - no fetch occurs
     // This is used when external messages are provided (e.g., creating new thread)
     // Also skip fetch when topicId is null (new conversation state) - there's no server data,
@@ -206,6 +210,7 @@ export const dataSlice: StateCreator<
 
       () => messageService.getMessages(context),
       {
+        ...(revalidateOnFocus !== undefined && { revalidateOnFocus }),
         onData: (data) => {
           if (!data) return;
           if (!context.topicId) return;

--- a/src/features/ShareModal/ShareDataProvider.tsx
+++ b/src/features/ShareModal/ShareDataProvider.tsx
@@ -64,7 +64,7 @@ const ShareDataProvider = memo<PropsWithChildren<ShareDataProviderProps>>(
     }, [activeAgentId, activeGroupId, activeThreadId, activeTopicId, context]);
 
     const shouldSkipFetch = !resolvedContext.agentId || !resolvedContext.topicId;
-    const { isLoading } = useFetchMessages(resolvedContext, shouldSkipFetch);
+    const { isLoading } = useFetchMessages(resolvedContext, { skipFetch: shouldSkipFetch });
 
     const messageKey = useMemo(() => {
       if (!resolvedContext.agentId) return undefined;

--- a/src/store/chat/slices/aiAgent/actions/__tests__/runAgent.test.ts
+++ b/src/store/chat/slices/aiAgent/actions/__tests__/runAgent.test.ts
@@ -378,6 +378,139 @@ describe('runAgent actions', () => {
           }),
         );
       });
+
+      it('replaces messages from server-pushed uiMessages snapshot (SoT)', async () => {
+        const replaceMessages = vi.fn();
+        act(() => {
+          useChatStore.setState({
+            replaceMessages,
+            operations: {
+              [TEST_IDS.OPERATION_ID]: {
+                abortController: new AbortController(),
+                context: { agentId: 'agent-1', topicId: 'topic-1' },
+                id: TEST_IDS.OPERATION_ID,
+                metadata: { lastEventId: '0', startTime: Date.now(), stepCount: 0 },
+                status: 'running',
+                type: 'groupAgentGenerate',
+              },
+            },
+          });
+        });
+        const { result } = renderHook(() => useChatStore());
+        const context = createStreamingContext({ assistantId: TEST_IDS.ASSISTANT_MESSAGE_ID });
+        const uiMessages = [{ id: 'msg_a', role: 'user' }] as any;
+
+        const event: StreamEvent = {
+          type: 'step_start',
+          timestamp: Date.now(),
+          operationId: TEST_IDS.OPERATION_ID,
+          data: { phase: 'tool_execution', uiMessages },
+        };
+
+        await act(async () => {
+          await result.current.internal_handleAgentStreamEvent(
+            TEST_IDS.OPERATION_ID,
+            event,
+            context,
+          );
+        });
+
+        expect(replaceMessages).toHaveBeenCalledWith(uiMessages, {
+          context: { agentId: 'agent-1', topicId: 'topic-1' },
+        });
+      });
+
+      it('does not call replaceMessages when uiMessages absent on step_start', async () => {
+        const replaceMessages = vi.fn();
+        act(() => {
+          useChatStore.setState({ replaceMessages });
+        });
+        const { result } = renderHook(() => useChatStore());
+        const context = createStreamingContext({ assistantId: TEST_IDS.ASSISTANT_MESSAGE_ID });
+        const event: StreamEvent = {
+          type: 'step_start',
+          timestamp: Date.now(),
+          operationId: TEST_IDS.OPERATION_ID,
+          data: { phase: 'tool_execution' }, // no uiMessages
+        };
+
+        await act(async () => {
+          await result.current.internal_handleAgentStreamEvent(
+            TEST_IDS.OPERATION_ID,
+            event,
+            context,
+          );
+        });
+
+        expect(replaceMessages).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('agent_runtime_end event', () => {
+      it('replaces messages from terminal uiMessages snapshot (final-step SoT)', async () => {
+        const replaceMessages = vi.fn();
+        act(() => {
+          useChatStore.setState({
+            replaceMessages,
+            operations: {
+              [TEST_IDS.OPERATION_ID]: {
+                abortController: new AbortController(),
+                context: { agentId: 'agent-1', topicId: 'topic-1' },
+                id: TEST_IDS.OPERATION_ID,
+                metadata: { lastEventId: '0', startTime: Date.now(), stepCount: 0 },
+                status: 'running',
+                type: 'groupAgentGenerate',
+              },
+            },
+          });
+        });
+        const { result } = renderHook(() => useChatStore());
+        const uiMessages = [{ id: 'msg_final', role: 'assistantGroup' }] as any;
+
+        const event: StreamEvent = {
+          type: 'agent_runtime_end',
+          timestamp: Date.now(),
+          operationId: TEST_IDS.OPERATION_ID,
+          data: { finalState: { status: 'done' }, reason: 'done', uiMessages },
+        };
+
+        await act(async () => {
+          await result.current.internal_handleAgentStreamEvent(
+            TEST_IDS.OPERATION_ID,
+            event,
+            createStreamingContext({ assistantId: TEST_IDS.ASSISTANT_MESSAGE_ID }),
+          );
+        });
+
+        expect(replaceMessages).toHaveBeenCalledWith(uiMessages, {
+          context: { agentId: 'agent-1', topicId: 'topic-1' },
+        });
+      });
+    });
+
+    describe('step_complete event', () => {
+      // The previous DB-refetch on tool_execution was the source of the
+      // assistantGroup-clobber regression (LOBE-9501) — tool results are
+      // now reconciled via the next step_start's uiMessages snapshot.
+      it('does NOT refreshMessages on tool_execution phase', async () => {
+        const { result } = renderHook(() => useChatStore());
+        const event: StreamEvent = {
+          type: 'step_complete',
+          timestamp: Date.now(),
+          operationId: TEST_IDS.OPERATION_ID,
+          data: { executionTime: 10, phase: 'tool_execution', result: { ok: true } },
+        };
+
+        await act(async () => {
+          await result.current.internal_handleAgentStreamEvent(
+            TEST_IDS.OPERATION_ID,
+            event,
+            createStreamingContext({ assistantId: TEST_IDS.ASSISTANT_MESSAGE_ID }),
+          );
+        });
+
+        expect(result.current.refreshMessages).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/src/store/chat/slices/aiAgent/actions/runAgent.ts
+++ b/src/store/chat/slices/aiAgent/actions/runAgent.ts
@@ -118,8 +118,18 @@ export class AgentActionImpl {
 
       case 'agent_runtime_end': {
         // Agent runtime finished - this is the definitive signal that generation is complete
-        const { reason, reasonDetail, finalState } = event.data || {};
+        const { reason, reasonDetail, finalState, uiMessages } = event.data || {};
         log(`Agent runtime ended for ${assistantId}: reason=${reason}, detail=${reasonDetail}`);
+
+        // Server pushes the canonical UIChatMessage[] snapshot for the
+        // topic as the Source of Truth on terminal-state. The last step
+        // has no later step_start to carry a fresh snapshot, so without
+        // this branch the streamed assistantGroup would only be reconciled
+        // with DB once a refetch fires — losing the SoT guarantee.
+        if (Array.isArray(uiMessages)) {
+          log(`Replacing messages from agent_runtime_end uiMessages (${uiMessages.length} msgs)`);
+          this.#get().replaceMessages(uiMessages, { context: operation.context });
+        }
 
         // Update operation metadata with final state
         if (finalState) {
@@ -276,7 +286,19 @@ export class AgentActionImpl {
       }
 
       case 'step_start': {
-        const { phase, toolCall, pendingToolsCalling, requiresApproval } = event.data || {};
+        const { phase, toolCall, pendingToolsCalling, requiresApproval, uiMessages } =
+          event.data || {};
+
+        // Server attaches the canonical UIChatMessage[] snapshot to
+        // step_start so the client uses the pushed payload as Source of
+        // Truth instead of refetching from DB (the DB fan-out from the
+        // previous step's stream chunks is async — a refetch here would
+        // return a stale assistant placeholder that clobbers the
+        // streamed assistantGroup).
+        if (Array.isArray(uiMessages)) {
+          log(`Replacing messages from step_start uiMessages (${uiMessages.length} msgs)`);
+          this.#get().replaceMessages(uiMessages, { context: operation.context });
+        }
 
         if (phase === 'human_approval' && requiresApproval) {
           // Requires human approval
@@ -301,8 +323,10 @@ export class AgentActionImpl {
 
         if (phase === 'tool_execution' && result) {
           log(`Tool execution completed for ${assistantId} in ${executionTime}ms:`, result);
-          // Refresh messages to display tool results
-          await this.#get().refreshMessages();
+          // Tool results are reconciled via the canonical uiMessages
+          // snapshot the server pushes on the next step_start; no need
+          // to refetch from DB here (the refetch was the source of the
+          // assistantGroup-clobber regression that LOBE-9501 fixes).
         } else if (phase === 'execution_complete' && finalState) {
           // Agent execution complete
           log(`Agent execution completed for ${assistantId}:`, finalState);

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -82,7 +82,7 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('stream_start', () => {
-    it('should associate new message with operation', async () => {
+    it('should associate new message with operation and skip the DB refetch (LOBE-9501)', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
@@ -90,7 +90,12 @@ describe('createGatewayEventHandler', () => {
       await flush();
 
       expect(store.associateMessageWithOperation).toHaveBeenCalledWith('msg-step2', 'op-1');
-      expect(store.replaceMessages).toHaveBeenCalled();
+      // Native gateway streams carry the new assistant id directly + a SoT
+      // uiMessages snapshot on the preceding step_start, so stream_start must
+      // NOT trigger a DB refetch (the refetch is what clobbered the streamed
+      // assistantGroup with a stale placeholder).
+      expect(messageService.getMessages).not.toHaveBeenCalled();
+      expect(store.replaceMessages).not.toHaveBeenCalled();
       expect(emitClientAgentSignalSourceEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           payload: expect.objectContaining({
@@ -843,17 +848,14 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('sequential processing', () => {
-    it('should process stream_chunk only after stream_start refresh completes', async () => {
+    it('should dispatch stream_chunk to the new assistant id after stream_start switches it', async () => {
+      // Native gateway streams no longer await a DB fetch on stream_start
+      // (LOBE-9501) — but stream_chunk must still queue behind stream_start
+      // so the chunk targets the NEW assistant id (from stream_start.data),
+      // not the previous one.
       const store = createMockStore();
       const callOrder: string[] = [];
 
-      const { messageService } = await import('@/services/message');
-      (messageService.getMessages as any).mockImplementation(async () => {
-        callOrder.push('refresh_start');
-        await new Promise((r) => setTimeout(r, 10));
-        callOrder.push('refresh_end');
-        return [];
-      });
       store.internal_dispatchMessage.mockImplementation(() => {
         callOrder.push('dispatch');
       });
@@ -867,10 +869,34 @@ describe('createGatewayEventHandler', () => {
       handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'Hello' }));
       await flush();
 
-      const refreshEndIdx = callOrder.indexOf('refresh_end');
+      // associate (from stream_start) precedes dispatch (from stream_chunk)
+      const associateIdx = callOrder.indexOf('associate');
       const dispatchIdx = callOrder.indexOf('dispatch');
-      expect(refreshEndIdx).toBeGreaterThan(-1);
-      expect(dispatchIdx).toBeGreaterThan(refreshEndIdx);
+      expect(associateIdx).toBeGreaterThan(-1);
+      expect(dispatchIdx).toBeGreaterThan(associateIdx);
+
+      // Chunk targets the new id, proving the queue ordering held
+      expect(store.internal_dispatchMessage).toHaveBeenLastCalledWith(
+        expect.objectContaining({ id: 'msg-new', value: { content: 'Hello' } }),
+        { operationId: 'op-1' },
+      );
+      // And no DB refetch was issued for the native stream
+      expect(messageService.getMessages).not.toHaveBeenCalled();
+    });
+
+    it('should still fetch from DB on stream_start when assistantMessage id is absent (hetero CLI)', async () => {
+      // Hetero CLI adapters (Claude Code / Codex) never set
+      // `assistantMessage.id` on stream_start, so the DB read is still
+      // mandatory — it pulls the executor-created placeholder into
+      // `dbMessagesMap` so subsequent chunks have a target.
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(makeEvent('stream_start', {}));
+      await flush();
+
+      expect(messageService.getMessages).toHaveBeenCalled();
+      expect(store.replaceMessages).toHaveBeenCalled();
     });
   });
 
@@ -901,18 +927,22 @@ describe('createGatewayEventHandler', () => {
       // Loading stays active between steps — only tool streaming is cleared
       expect(store.internal_toggleToolCallingStreaming).toHaveBeenCalledWith('msg-1', undefined);
 
-      // Tool execution
+      // Tool execution — tool_end still refreshes from DB to pick up the
+      // server-created tool message row.
       handler(makeEvent('tool_start', { parentMessageId: 'msg-1', toolCalling: tools[0] }));
       handler(makeEvent('tool_end', { isSuccess: true }));
       await flush();
       expect(store.replaceMessages).toHaveBeenCalled();
 
-      // Step 2: Next LLM call with new assistant message
+      // Step 2: Next LLM call with new assistant message — native stream_start
+      // carries the id directly, so it must NOT trigger a DB refetch
+      // (LOBE-9501). Only the association switch happens.
       vi.clearAllMocks();
       handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-2' } }));
       await flush();
-      expect(store.replaceMessages).toHaveBeenCalled();
       expect(store.associateMessageWithOperation).toHaveBeenCalledWith('msg-2', 'op-1');
+      expect(messageService.getMessages).not.toHaveBeenCalled();
+      expect(store.replaceMessages).not.toHaveBeenCalled();
 
       handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'Here are the results.' }));
       await flush();

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -7,7 +7,12 @@ import type {
   ToolExecuteData,
   ToolStartData,
 } from '@lobechat/agent-gateway-client';
-import type { BuiltinToolResult, ChatMessageError, ConversationContext } from '@lobechat/types';
+import type {
+  BuiltinToolResult,
+  ChatMessageError,
+  ConversationContext,
+  UIChatMessage,
+} from '@lobechat/types';
 import { AgentRuntimeErrorType } from '@lobechat/types';
 
 import { messageService } from '@/services/message';
@@ -276,24 +281,35 @@ export const createGatewayEventHandler = (
           accumulatedContent = '';
           accumulatedReasoning = '';
 
-          // Heterogeneous CLI adapters emit `stream_start { newStep: true }`
-          // without a server-side assistant id. Pull the freshly created step
-          // assistant from DB so subsequent live chunks update the RIGHT row
-          // instead of appending onto the previous step's assistant.
-          const messages = await fetchAndReplaceMessages(get, context).catch((error) => {
-            console.error(error);
-            return undefined;
-          });
+          // Skip the DB read ONLY for native gateway streams — those carry
+          // `assistantMessage.id` directly on stream_start AND the preceding
+          // `step_start` already carried the SoT uiMessages snapshot, so
+          // chunks have a valid target in `dbMessagesMap` already. Removing
+          // the await here is what un-blocks the enqueue chain so live
+          // chunks can land mid-stream (LOBE-9501).
+          //
+          // Hetero CLI adapters (Claude Code / Codex) never set
+          // `assistantMessage.id` on stream_start, so the DB read stays
+          // mandatory for them — it (a) pulls the executor-created
+          // placeholder into `dbMessagesMap` so subsequent chunks can
+          // dispatch to it, and (b) resolves the next-step assistant id for
+          // the `newStep` fallback.
+          if (!newAssistantMessageId) {
+            const messages = await fetchAndReplaceMessages(get, context).catch((error) => {
+              console.error(error);
+              return undefined;
+            });
 
-          if (!newAssistantMessageId && data?.newStep) {
-            const resolvedAssistantMessageId = findNextAssistantMessageId(
-              messages as GatewayMessageLike[] | undefined,
-              currentAssistantMessageId,
-            );
+            if (data?.newStep) {
+              const resolvedAssistantMessageId = findNextAssistantMessageId(
+                messages as GatewayMessageLike[] | undefined,
+                currentAssistantMessageId,
+              );
 
-            if (resolvedAssistantMessageId) {
-              currentAssistantMessageId = resolvedAssistantMessageId;
-              get().associateMessageWithOperation(currentAssistantMessageId, operationId);
+              if (resolvedAssistantMessageId) {
+                currentAssistantMessageId = resolvedAssistantMessageId;
+                get().associateMessageWithOperation(currentAssistantMessageId, operationId);
+              }
             }
           }
 
@@ -406,7 +422,17 @@ export const createGatewayEventHandler = (
           pendingToolsCalling?: unknown[];
           phase?: string;
           requiresApproval?: boolean;
+          uiMessages?: UIChatMessage[];
         };
+
+        // Server attaches the canonical UIChatMessage[] snapshot at every
+        // step boundary (agent-runtime #15152). Use it as Source of Truth
+        // instead of issuing a DB refetch — the refetch returns a stale
+        // assistant placeholder while DB fan-out is still in flight, which
+        // clobbers the in-memory streamed assistantGroup (LOBE-9501).
+        if (Array.isArray(data?.uiMessages)) {
+          get().replaceMessages(data.uiMessages, { action: 'gateway/step_start', context });
+        }
 
         if (data?.phase === 'human_approval' && data.requiresApproval && data.pendingToolsCalling) {
           void notifyDesktopHumanApprovalRequired(get, context);
@@ -475,6 +501,8 @@ export const createGatewayEventHandler = (
 
       case 'agent_runtime_end': {
         enqueue(async () => {
+          const data = event.data as { uiMessages?: UIChatMessage[] } | undefined;
+
           void emitClientAgentSignalSourceEvent({
             payload: {
               agentId: context.agentId,
@@ -499,7 +527,18 @@ export const createGatewayEventHandler = (
             get().markUnreadCompleted(completedOp.context.agentId, completedOp.context.topicId);
           }
 
-          await fetchAndReplaceMessages(get, context).catch(console.error);
+          // Terminal step has no later step_start to carry SoT — server
+          // pushes the canonical snapshot directly on this event. Fall back
+          // to a DB refetch only if the snapshot is absent (older server
+          // builds, or push-event delivery edge cases).
+          if (Array.isArray(data?.uiMessages)) {
+            get().replaceMessages(data.uiMessages, {
+              action: 'gateway/agent_runtime_end',
+              context,
+            });
+          } else {
+            await fetchAndReplaceMessages(get, context).catch(console.error);
+          }
         });
         break;
       }

--- a/src/store/chat/slices/message/actions/query.ts
+++ b/src/store/chat/slices/message/actions/query.ts
@@ -106,8 +106,24 @@ export class MessageQueryActionImpl {
 
   useFetchMessages = (
     context: ConversationContext,
-    skipFetch?: boolean,
+    options?: {
+      /**
+       * Skip the fetch entirely (e.g. while another flow owns the data).
+       * Equivalent to passing a null SWR key.
+       */
+      skipFetch?: boolean;
+      /**
+       * Revalidate when the window regains focus. Defaults to SWR's
+       * client-data default (true). Pass `false` to suppress the focus
+       * refetch — used during streaming so the in-memory stream payload
+       * (Source of Truth) isn't clobbered by a stale DB read while DB
+       * fan-out writes are still in flight.
+       */
+      revalidateOnFocus?: boolean;
+    },
   ): SWRResponse<UIChatMessage[]> => {
+    const { skipFetch, revalidateOnFocus } = options ?? {};
+
     // Skip fetch when skipFetch is true or required fields are missing
     const shouldFetch = !skipFetch && !!context.agentId && !!context.topicId;
 
@@ -121,6 +137,7 @@ export class MessageQueryActionImpl {
           // Use replaceMessages to store the fetched messages
           this.#get().replaceMessages(data, { action: 'useFetchMessages', context });
         },
+        ...(revalidateOnFocus !== undefined && { revalidateOnFocus }),
       },
     );
   };


### PR DESCRIPTION
## Summary

Client-side counterpart of #15152 (LOBE-9501 server SoT push).

- `runAgent` now calls `replaceMessages(event.data.uiMessages, { context })` on `step_start` and `agent_runtime_end` whenever the server attaches the canonical `UIChatMessage[]` snapshot — the pushed payload becomes the source of truth.
- Removed the `step_complete` (`phase === 'tool_execution'`) → `refreshMessages()` call; tool results are reconciled via the next step's snapshot instead. The refetch was the direct cause of the `assistantGroup` → `assistant` clobber captured by the agent-gateway probe scripts.
- `useFetchMessages` signature migrated to an options object — `{ skipFetch?, revalidateOnFocus? }` — across both `useChatStore` and `useConversationStore`. All 7 call sites updated.
- `ChatList` disables SWR `revalidateOnFocus` while the active topic is streaming (`operationSelectors.isAgentRuntimeRunningByContext`) and automatically restores it after the run ends. Tab-focus during a run no longer triggers the stale DB read.

## Why

Before #15152, the client refetched messages on every `step_complete` (tool_execution) and on tab-focus. Stream chunks land before the DB fan-out completes, so the refetch returned a stale assistant placeholder that clobbered the in-memory streamed `assistantGroup` (reasoning / tool calls / content). Probe trace:

```
t=95602:  OwEFjLqL  role='assistantGroup'  chCount=1  reasoning=289ch  tools=2
t=95942:  OwEFjLqL  role='assistant'       chCount=0  reasoning=0      tools=0  cLen=3
```

`step_start` fires after the previous step's DB writes are durably awaited, so the snapshot reflects strongly-consistent state — that's the contract that lets the client trust the pushed `uiMessages`.

## Compatibility

- `streamingExecutor.ts` (homogeneous runtime) is untouched — it's a parallel path.
- `agent_runtime_end` / `step_start` cases gracefully no-op when `uiMessages` is absent, so the change is forward-compatible with older server versions or callers that don't have DB context.

## Test plan

- [x] `bun run type-check` (clean)
- [x] `bunx vitest run src/store/chat/slices/aiAgent/ src/store/chat/slices/message/ src/features/Conversation/store/` (363 passed; runAgent: 12 tests including 3 new ones)
- [ ] Manual: run the agent-gateway probe scripts under `.agents/skills/local-testing/scripts/agent-gateway/` — `REGRESSIONS` section should no longer show `childN` / `cT` / `rT` drops on same topic during tab-switch / tool execution

Linear: [LOBE-9501](https://linear.app/lobehub/issue/LOBE-9501)
Server PR: #15152

🤖 Generated with [Claude Code](https://claude.com/claude-code)