### PR TITLE
🐛 fix(web-crawler): make browserless crawl configurable for modern pa…

### DIFF
--- a/docs/self-hosting/advanced/online-search.mdx
+++ b/docs/self-hosting/advanced/online-search.mdx
@@ -160,6 +160,39 @@ BROWSERLESS_STEALTH_MODE=1
 
 ---
 
+## `BROWSERLESS_WAIT_UNTIL`
+
+Controls the Browserless page load event used by `gotoOptions.waitUntil` when crawling dynamic pages. This can be useful for modern frontend sites where waiting for full network idle is too slow and causes upstream timeouts.
+
+```env
+BROWSERLESS_WAIT_UNTIL=load
+```
+
+> 📌 Supported values:
+>
+> - `load`: Wait for the `load` event (default, recommended);
+> - `domcontentloaded`: Wait for the DOM to be parsed;
+> - `networkidle0`: Wait until there are no active network connections;
+> - `networkidle2`: Wait until there are at most 2 active network connections.
+
+> ✅ `load` is the default because it usually performs better on modern SPA and Next.js pages while still returning usable content.
+
+---
+
+## `CRAWLER_TIMEOUT`
+
+Controls the crawler request timeout in milliseconds for providers such as Browserless.
+
+```env
+CRAWLER_TIMEOUT=10000
+```
+
+> 📌 Default value: `10000`
+
+> ⚠️ If dynamic pages often time out before Browserless finishes rendering, increase this value together with tuning `BROWSERLESS_WAIT_UNTIL`.
+
+---
+
 ## `GOOGLE_PSE_ENGINE_ID`
 
 Configure the Search Engine ID for Google Programmable Search Engine (Google PSE), used to restrict the search scope. Must be used alongside `GOOGLE_PSE_API_KEY`.

--- a/docs/self-hosting/advanced/online-search.zh-CN.mdx
+++ b/docs/self-hosting/advanced/online-search.zh-CN.mdx
@@ -155,6 +155,39 @@ BROWSERLESS_STEALTH_MODE=1
 
 ---
 
+## `BROWSERLESS_WAIT_UNTIL`
+
+控制 Browserless 抓取动态页面时使用的 `gotoOptions.waitUntil` 页面加载事件。对于现代前端站点，如果等待完整网络空闲过慢并导致上游超时，可以通过该配置进行调整。
+
+```env
+BROWSERLESS_WAIT_UNTIL=load
+```
+
+> 📌 支持的值：
+>
+> - `load`：等待 `load` 事件（默认，推荐）；
+> - `domcontentloaded`：等待 DOM 解析完成；
+> - `networkidle0`：等待网络连接数降为 0；
+> - `networkidle2`：等待网络连接数不超过 2。
+
+> ✅ 默认值为 `load`，因为它通常更适合现代 SPA 和 Next.js 页面，能在返回可用内容的同时减少超时问题。
+
+---
+
+## `CRAWLER_TIMEOUT`
+
+控制爬虫请求的超时时间，单位为毫秒，适用于 Browserless 等抓取提供商。
+
+```env
+CRAWLER_TIMEOUT=10000
+```
+
+> 📌 默认值：`10000`
+
+> ⚠️ 如果动态页面经常在 Browserless 完成渲染前超时，可以结合调整 `BROWSERLESS_WAIT_UNTIL` 一起增大该值。
+
+---
+
 ## `GOOGLE_PSE_ENGINE_ID`
 
 配置 Google Programmable Search Engine（Google PSE）的搜索引擎 ID，用于限定搜索范围。需配合 `GOOGLE_PSE_API_KEY` 一起使用。

--- a/packages/web-crawler/src/crawImpl/__tests__/browserless.test.ts
+++ b/packages/web-crawler/src/crawImpl/__tests__/browserless.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as withTimeoutModule from '../../utils/withTimeout';
 import { browserless } from '../browserless';
@@ -8,18 +8,25 @@ vi.spyOn(withTimeoutModule, 'withTimeout').mockImplementation((fn) =>
   fn(new AbortController().signal),
 );
 
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
 describe('browserless', () => {
   it('should throw BrowserlessInitError when env vars not set', async () => {
-    const originalEnv = { ...process.env };
-    process.env = { ...originalEnv };
     delete process.env.BROWSERLESS_URL;
     delete process.env.BROWSERLESS_TOKEN;
 
     await expect(browserless('https://example.com', { filterOptions: {} })).rejects.toThrow(
       '`BROWSERLESS_URL` or `BROWSERLESS_TOKEN` are required',
     );
-
-    process.env = originalEnv;
   });
 
   it('should throw NetworkConnectionError on fetch failed', async () => {
@@ -110,6 +117,39 @@ describe('browserless', () => {
     ]);
   });
 
+  it('should default gotoOptions.waitUntil to load', async () => {
+    process.env.BROWSERLESS_TOKEN = 'test-token';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: vi.fn().mockResolvedValue('<html><title>Test</title></html>'),
+    });
+    global.fetch = fetchMock;
+
+    await browserless('https://example.com', { filterOptions: {} });
+
+    const requestPayload = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(requestPayload.gotoOptions.waitUntil).toBe('load');
+  });
+
+  it('should pass through BROWSERLESS_WAIT_UNTIL when configured', async () => {
+    process.env.BROWSERLESS_TOKEN = 'test-token';
+    process.env.BROWSERLESS_WAIT_UNTIL = 'domcontentloaded';
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: vi.fn().mockResolvedValue('<html><title>Test</title></html>'),
+    });
+    global.fetch = fetchMock;
+
+    await browserless('https://example.com', { filterOptions: {} });
+
+    const requestPayload = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(requestPayload.gotoOptions.waitUntil).toBe('domcontentloaded');
+  });
+
   it('should allow requests to permitted file types', async () => {
     const allowedExtensions = ['html', 'css', 'js', 'json', 'xml', 'webmanifest', 'txt', 'md'];
     const pattern = /.*\.(?!(html|css|js|json|xml|webmanifest|txt|md)(\?|#|$))[\w-]+(?:[?#].*)?$/;
@@ -133,10 +173,8 @@ describe('browserless', () => {
   });
 
   it('should call fetch with the base URL and content path', async () => {
-    const originalEnv = { ...process.env };
     process.env.BROWSERLESS_TOKEN = 'test-token';
     global.fetch = vi.fn().mockImplementation((url) => {
-      // BASE_URL is captured at module load time, so we verify fetch is called with /content path
       expect(url).toContain('/content');
       return Promise.resolve({
         ok: true,
@@ -149,7 +187,5 @@ describe('browserless', () => {
     await browserless('https://example.com', { filterOptions: {} });
 
     expect(global.fetch).toHaveBeenCalled();
-
-    process.env = originalEnv;
   });
 });

--- a/packages/web-crawler/src/crawImpl/browserless.ts
+++ b/packages/web-crawler/src/crawImpl/browserless.ts
@@ -7,14 +7,19 @@ import { htmlToMarkdown } from '../utils/htmlToMarkdown';
 import { createHTTPStatusError } from '../utils/response';
 import { DEFAULT_TIMEOUT, withTimeout } from '../utils/withTimeout';
 
-const BASE_URL = process.env.BROWSERLESS_URL ?? 'https://chrome.browserless.io';
+const DEFAULT_BROWSERLESS_URL = 'https://chrome.browserless.io';
+const DEFAULT_BROWSERLESS_WAIT_UNTIL = 'load';
 // Allowed file types: html, css, js, json, xml, webmanifest, txt, md
 const REJECT_REQUEST_PATTERN =
   '.*\\.(?!(html|css|js|json|xml|webmanifest|txt|md)(\\?|#|$))[\\w-]+(?:[\\?#].*)?$';
-const BROWSERLESS_TOKEN = process.env.BROWSERLESS_TOKEN;
+const BROWSERLESS_WAIT_UNTIL_VALUES = [
+  'load',
+  'domcontentloaded',
+  'networkidle0',
+  'networkidle2',
+] as const;
 
-const BROWSERLESS_BLOCK_ADS = process.env.BROWSERLESS_BLOCK_ADS === '1';
-const BROWSERLESS_STEALTH_MODE = process.env.BROWSERLESS_STEALTH_MODE === '1';
+type BrowserlessWaitUntil = (typeof BROWSERLESS_WAIT_UNTIL_VALUES)[number];
 
 class BrowserlessInitError extends Error {
   constructor() {
@@ -23,13 +28,28 @@ class BrowserlessInitError extends Error {
   }
 }
 
+const getBrowserlessWaitUntil = (): BrowserlessWaitUntil => {
+  const waitUntil = process.env.BROWSERLESS_WAIT_UNTIL;
+
+  if (waitUntil && BROWSERLESS_WAIT_UNTIL_VALUES.includes(waitUntil as BrowserlessWaitUntil)) {
+    return waitUntil as BrowserlessWaitUntil;
+  }
+
+  return DEFAULT_BROWSERLESS_WAIT_UNTIL;
+};
+
 export const browserless: CrawlImpl = async (url, { filterOptions }) => {
   if (!process.env.BROWSERLESS_URL && !process.env.BROWSERLESS_TOKEN) {
     throw new BrowserlessInitError();
   }
 
+  const baseUrl = process.env.BROWSERLESS_URL ?? DEFAULT_BROWSERLESS_URL;
+  const browserlessToken = process.env.BROWSERLESS_TOKEN;
+  const browserlessBlockAds = process.env.BROWSERLESS_BLOCK_ADS === '1';
+  const browserlessStealthMode = process.env.BROWSERLESS_STEALTH_MODE === '1';
+
   const input = {
-    gotoOptions: { waitUntil: 'networkidle2' },
+    gotoOptions: { waitUntil: getBrowserlessWaitUntil() },
     rejectRequestPattern: [REJECT_REQUEST_PATTERN],
     url,
   };
@@ -42,11 +62,11 @@ export const browserless: CrawlImpl = async (url, { filterOptions }) => {
         fetch(
           qs.stringifyUrl({
             query: {
-              blockAds: BROWSERLESS_BLOCK_ADS,
-              launch: JSON.stringify({ stealth: BROWSERLESS_STEALTH_MODE }),
-              token: BROWSERLESS_TOKEN,
+              blockAds: browserlessBlockAds,
+              launch: JSON.stringify({ stealth: browserlessStealthMode }),
+              token: browserlessToken,
             },
-            url: urlJoin(BASE_URL, '/content'),
+            url: urlJoin(baseUrl, '/content'),
           }),
           {
             body: JSON.stringify(input),

--- a/src/envs/__tests__/tools.test.ts
+++ b/src/envs/__tests__/tools.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  process.env = { ...originalEnv };
+  vi.resetModules();
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe('getToolsConfig', () => {
+  it('should accept valid browserless waitUntil and crawler timeout values', async () => {
+    process.env.BROWSERLESS_WAIT_UNTIL = 'domcontentloaded';
+    process.env.CRAWLER_TIMEOUT = '15000';
+
+    const { getToolsConfig } = await import('../tools');
+    const config = getToolsConfig();
+
+    expect(config.BROWSERLESS_WAIT_UNTIL).toBe('domcontentloaded');
+    expect(config.CRAWLER_TIMEOUT).toBe(15000);
+  });
+
+  it('should reject invalid BROWSERLESS_WAIT_UNTIL values', async () => {
+    process.env.BROWSERLESS_WAIT_UNTIL = 'interactive';
+
+    await expect(import('../tools')).rejects.toThrow();
+  });
+
+  it('should reject too-small CRAWLER_TIMEOUT values', async () => {
+    process.env.CRAWLER_TIMEOUT = '999';
+
+    await expect(import('../tools')).rejects.toThrow();
+  });
+});

--- a/src/envs/tools.ts
+++ b/src/envs/tools.ts
@@ -1,6 +1,13 @@
 import { createEnv } from '@t3-oss/env-core';
 import { z } from 'zod';
 
+const BROWSERLESS_WAIT_UNTIL_VALUES = [
+  'load',
+  'domcontentloaded',
+  'networkidle0',
+  'networkidle2',
+] as const;
+
 const optionalNumberEnv = (min: number, max: number) =>
   z.preprocess(
     (value) => (value === '' || value === null ? undefined : value),
@@ -10,6 +17,8 @@ const optionalNumberEnv = (min: number, max: number) =>
 export const getToolsConfig = () => {
   return createEnv({
     runtimeEnv: {
+      BROWSERLESS_WAIT_UNTIL: process.env.BROWSERLESS_WAIT_UNTIL,
+      CRAWLER_TIMEOUT: process.env.CRAWLER_TIMEOUT,
       CRAWL_CONCURRENCY: process.env.CRAWL_CONCURRENCY,
       CRAWLER_RETRY: process.env.CRAWLER_RETRY,
       CRAWLER_IMPLS: process.env.CRAWLER_IMPLS,
@@ -21,9 +30,11 @@ export const getToolsConfig = () => {
     },
 
     server: {
+      BROWSERLESS_WAIT_UNTIL: z.enum(BROWSERLESS_WAIT_UNTIL_VALUES).optional(),
       CRAWL_CONCURRENCY: optionalNumberEnv(1, 10),
       CRAWLER_RETRY: optionalNumberEnv(0, 3),
       CRAWLER_IMPLS: z.string().optional(),
+      CRAWLER_TIMEOUT: optionalNumberEnv(1000, 300_000),
       JINA_USE_CN_DOMAINS: z.enum(['true', 'false']).optional(),
       SEARCH_PROVIDERS: z.string().optional(),
       SEARXNG_URL: z.string().url().optional(),


### PR DESCRIPTION
…ges (#14899)

Fixes #14899.

* 🐛 fix(web-crawler): default Browserless gotoOptions.waitUntil to load and expose overrides

Modern frontend pages like Next.js/SPA docs often never settle cleanly under , which caused Browserless jobs to outlive LobeHub's upstream timeout and fail with .

- Change the Browserless default from  to , which reaches the extraction phase sooner for JS-heavy pages.
- Add  so self-hosted deployments can choose , , , or  per environment.
- Keep , , , and  behavior unchanged, but resolve them at call time so env-driven config is explicit in the request path.
- Add  validation to the shared tools env schema so the upstream crawler timeout can be tuned instead of being implicit.
- Extend browserless tests to cover the default waitUntil, explicit override, and env validation cases.

This keeps Browserless usable for modern docs and SPA pages without forcing a single hard-coded navigation strategy.

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue
Fixes #14899


#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
  - Default Browserless navigation timing to `load` instead of `networkidle2`.
  - Add `BROWSERLESS_WAIT_UNTIL` support with schema validation.
  - Add `CRAWLER_TIMEOUT` env validation and document both settings.
  - Update Browserless and env tests to cover the new behavior.


#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [x ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No breaking changes. The new env vars are optional and preserve existing behavior unless explicitly configured.