### PR TITLE
🐛 fix(conversation): only swap model name for remote hetero agents in Usage

### DIFF
--- a/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
@@ -200,11 +200,13 @@ const mockShellCommandCtr = {
 
 const mockHeterogeneousAgentCtr = {
   sendPrompt: vi.fn().mockResolvedValue(undefined),
+  spawnLhHeteroExec: vi.fn(),
   startSession: vi.fn().mockResolvedValue({ sessionId: 'mock-session-id' }),
 } as unknown as HeterogeneousAgentCtr;
 
 const mockRemoteServerConfigCtr = {
   getAccessToken: vi.fn().mockResolvedValue('mock-access-token'),
+  getRemoteServerUrl: vi.fn().mockResolvedValue('https://server.example.com'),
   isRemoteServerConfigured: vi.fn().mockResolvedValue(true),
   refreshAccessToken: vi.fn().mockResolvedValue({ success: true }),
 } as unknown as RemoteServerConfigCtr;
@@ -631,26 +633,23 @@ describe('GatewayConnectionCtr', () => {
     }
 
     beforeEach(() => {
-      vi.mocked(mockHeterogeneousAgentCtr.startSession).mockClear();
-      vi.mocked(mockHeterogeneousAgentCtr.sendPrompt).mockClear();
+      vi.mocked(mockHeterogeneousAgentCtr.spawnLhHeteroExec).mockClear();
     });
 
-    it.each([
-      ['openclaw', 'openclaw'],
-      ['hermes', 'hermes'],
-      ['codex', 'codex'],
-      ['claude-code', 'claude'],
-    ] as const)('uses command "%s" for agentType "%s"', async (agentType, expectedCommand) => {
-      const client = await connectAndOpen();
-      client.simulateAgentRunRequest(agentType);
-      await vi.advanceTimersByTimeAsync(0);
+    it.each(['openclaw', 'hermes', 'codex', 'claude-code'] as const)(
+      'forwards agentType "%s" to spawnLhHeteroExec',
+      async (agentType) => {
+        const client = await connectAndOpen();
+        client.simulateAgentRunRequest(agentType);
+        await vi.advanceTimersByTimeAsync(0);
 
-      expect(mockHeterogeneousAgentCtr.startSession).toHaveBeenCalledWith(
-        expect.objectContaining({ agentType, command: expectedCommand }),
-      );
-    });
+        expect(mockHeterogeneousAgentCtr.spawnLhHeteroExec).toHaveBeenCalledWith(
+          expect.objectContaining({ agentType }),
+        );
+      },
+    );
 
-    it('sends accepted ack and fires sendPrompt', async () => {
+    it('sends accepted ack and spawns lh hetero exec', async () => {
       const client = await connectAndOpen();
       client.simulateAgentRunRequest('openclaw', 'op-xyz');
       await vi.advanceTimersByTimeAsync(0);
@@ -659,15 +658,37 @@ describe('GatewayConnectionCtr', () => {
         operationId: 'op-xyz',
         status: 'accepted',
       });
-      expect(mockHeterogeneousAgentCtr.sendPrompt).toHaveBeenCalledWith(
-        expect.objectContaining({ operationId: 'op-xyz', sessionId: 'mock-session-id' }),
+      expect(mockHeterogeneousAgentCtr.spawnLhHeteroExec).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentType: 'openclaw',
+          jwt: 'mock-jwt',
+          operationId: 'op-xyz',
+          prompt: 'hello',
+          serverUrl: 'https://server.example.com',
+          topicId: 'topic-1',
+        }),
       );
     });
 
-    it('sends rejected ack when startSession throws', async () => {
-      vi.mocked(mockHeterogeneousAgentCtr.startSession).mockRejectedValueOnce(
-        new Error('binary not found'),
-      );
+    it('sends rejected ack when remote server URL is not configured', async () => {
+      vi.mocked(mockRemoteServerConfigCtr.getRemoteServerUrl).mockResolvedValueOnce('');
+
+      const client = await connectAndOpen();
+      client.simulateAgentRunRequest('openclaw', 'op-fail');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(client.sendAgentRunAck).toHaveBeenCalledWith({
+        operationId: 'op-fail',
+        reason: 'Remote server URL not configured',
+        status: 'rejected',
+      });
+      expect(mockHeterogeneousAgentCtr.spawnLhHeteroExec).not.toHaveBeenCalled();
+    });
+
+    it('sends rejected ack when spawnLhHeteroExec throws', async () => {
+      vi.mocked(mockHeterogeneousAgentCtr.spawnLhHeteroExec).mockImplementationOnce(() => {
+        throw new Error('binary not found');
+      });
 
       const client = await connectAndOpen();
       client.simulateAgentRunRequest('openclaw', 'op-fail');

--- a/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
@@ -1,4 +1,7 @@
-import { HETEROGENEOUS_TYPE_LABELS } from '@lobechat/heterogeneous-agents';
+import {
+  HETEROGENEOUS_TYPE_LABELS,
+  isRemoteHeterogeneousType,
+} from '@lobechat/heterogeneous-agents';
 import { type ModelPerformance, type ModelUsage } from '@lobechat/types';
 import { ModelIcon } from '@lobehub/icons';
 import { Center, Flexbox } from '@lobehub/ui';
@@ -33,7 +36,14 @@ const Usage = memo<UsageProps>(({ model, usage, performance, provider }) => {
 
   if (!isDev && onboardingAgentId && conversationAgentId === onboardingAgentId) return null;
 
-  const heteroName = provider ? HETEROGENEOUS_TYPE_LABELS[provider] : undefined;
+  // Only remote platform agents (openclaw, hermes) replace the model name with
+  // the brand label — they don't expose a real model id. Local CLI agents
+  // (claude-code, codex) report their actual model on `turn_metadata` and
+  // should keep showing it.
+  const heteroName =
+    provider && isRemoteHeterogeneousType(provider)
+      ? HETEROGENEOUS_TYPE_LABELS[provider]
+      : undefined;
 
   return (
     <Flexbox


### PR DESCRIPTION
## Summary

- The `Usage` extra (dev-mode model tag below assistant replies) was replacing the real model name with the provider brand label for **every** heterogeneous provider, so Claude Code / Codex turns showed "Claude Code" / "Codex" instead of the actual model id (e.g. `claude-sonnet-4-5`).
- Gate that swap behind `isRemoteHeterogeneousType(provider)` so it only applies to remote platform agents (`openclaw`, `hermes`) — those genuinely don't expose a model id. Local CLI agents already persist `model` from `turn_metadata` and should keep showing it via `ModelIcon` + the model string.

## Background

Introduced in #15065 (`6953f188c1`). The data path (`packages/heterogeneous-agents/src/adapters/claudeCode.ts` → `executeHeterogeneousAgent`) writes the real `model` to DB; only the renderer was suppressing it.

## Test plan

- [ ] Dev mode: send a message in a Claude Code agent → bottom-left tag shows `<ModelIcon> claude-sonnet-4-5` (or whatever CC reports), not "Claude Code".
- [ ] Dev mode: send a message in a Codex agent → shows actual model id, not "Codex".
- [ ] Dev mode: openclaw / hermes agent turns still show "OpenClaw" / "Hermes" (no real model id to surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)