### PR TITLE
chore: clean up LOBE-xx comment (2026-05-24)

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -277,7 +277,11 @@ export interface RuntimeExecutorContext {
    * AgentRuntimeService so the trace recorder can pick CE data up
    * out-of-band, keeping the heavy CE payload (agentDocuments, systemRole, …)
    * out of the `events` array and therefore out of the Redis state pipeline.
-   * See LOBE-9110.
+   *
+   * Context: agent-runtime state blob was hitting Upstash Redis 10MB limit
+   * because contextEngine.input (agentDocuments full inline) accounted for
+   * ~83% of each step. Routing CE through this callback keeps the heavy
+   * payload in trace only, reducing per-step Redis state from ~3.4MB to ~6KB.
    */
   tracingContextEngine?: (input: unknown, output: unknown) => void;
   userId?: string;

--- a/src/server/services/agentRuntime/AgentRuntimeService.ts
+++ b/src/server/services/agentRuntime/AgentRuntimeService.ts
@@ -676,7 +676,10 @@ export class AgentRuntimeService {
       // consumed by traceRecorder.appendStep below. Routing CE this way keeps
       // its heavy payload (agentDocuments, systemRole, …) out of
       // `stepResult.events` and therefore out of the Redis state pipeline.
-      // See LOBE-9110.
+      //
+      // Context: contextEngine.input (agentDocuments) was ~2.7MB/step,
+      // hitting Upstash Redis 10MB limit. Bypassing events keeps the heavy
+      // payload in trace only, reducing per-step Redis state by ~500x.
       let contextEnginePayload: { input: unknown; output: unknown } | undefined;
 
       // Create Agent and Runtime instances

--- a/src/server/services/agentRuntime/OperationTraceRecorder.ts
+++ b/src/server/services/agentRuntime/OperationTraceRecorder.ts
@@ -19,7 +19,11 @@ export interface AppendStepParams {
    * Context engine input/output captured for this step. Delivered via
    * `RuntimeExecutorContext.tracingContextEngine` rather than through the
    * `events` array, so CE payloads (agentDocuments, systemRole, …) stay out
-   * of the Redis state pipeline. See LOBE-9110.
+   * of the Redis state pipeline.
+   *
+   * Context: agent-runtime state blob was hitting Upstash Redis 10MB limit
+   * because ~97% of each step payload was tracing-only fields. Routing CE
+   * via tracingContextEngine keeps it in trace only, keeping Redis state lean.
    */
   contextEngine?: { input?: unknown; output?: unknown };
   currentContext?: { payload?: unknown; phase?: string; stepContext?: unknown };


### PR DESCRIPTION
## 变更说明

自动扫描并清理代码中的 LOBE-XXX 格式注释。

## 清理内容

### 已替换的 LOBE-9110 引用（3 处）

| 文件 | 变更 |
|------|------|
| src/server/modules/AgentRuntime/RuntimeExecutors.ts | See LOBE-9110 → 补充 CE payload 脱离 Redis 的架构上下文 |
| src/server/services/agentRuntime/AgentRuntimeService.ts | See LOBE-9110 → 补充 Upstash 10MB 限制根因说明 |
| src/server/services/agentRuntime/OperationTraceRecorder.ts | See LOBE-9110 → 补充 tracing-only 字段占比说明 |

### 保留不变

- src/routes/(main)/home/features/WelcomeText/index.tsx 中的 /LOBE-\d+/g 正则：功能性代码，用于 AI 生成的欢迎文本中自动链接 LOBE issue 引用

## 变更文件
3 files changed, 14 insertions(+), 3 deletions(-)

自动生成于 2026-05-24