### PR TITLE
🐛 fix(agent): align settings defaults and locale state

### DIFF
--- a/packages/const/src/settings/agent.ts
+++ b/packages/const/src/settings/agent.ts
@@ -34,6 +34,9 @@ export const DEFAULT_AGENT_CHAT_CONFIG: LobeAgentChatConfig = {
   reasoningBudgetToken: 1024,
   searchFCModel: DEFAULT_AGENT_SEARCH_FC_MODEL,
   searchMode: 'auto',
+  selfIteration: {
+    enabled: false,
+  },
 };
 
 export const DEFAULT_AGENT_CONFIG: LobeAgentConfig = {

--- a/src/features/AgentSetting/store/selectors.test.ts
+++ b/src/features/AgentSetting/store/selectors.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_AGENT_CONFIG } from '@/const/settings';
+
+import { type Store } from './action';
+import { selectors } from './selectors';
+
+describe('AgentSetting selectors', () => {
+  describe('currentChatConfig', () => {
+    it('should include disabled self iteration by default', () => {
+      const state = {
+        config: DEFAULT_AGENT_CONFIG,
+      } as Store;
+
+      expect(selectors.currentChatConfig(state).selfIteration).toEqual({ enabled: false });
+    });
+  });
+});

--- a/src/layout/GlobalProvider/AppTheme.tsx
+++ b/src/layout/GlobalProvider/AppTheme.tsx
@@ -18,6 +18,8 @@ import { LOBE_THEME_NEUTRAL_COLOR, LOBE_THEME_PRIMARY_COLOR } from '@/const/them
 import { isDesktop } from '@/const/version';
 import { useIsDark } from '@/hooks/useIsDark';
 import { getUILocaleAndResources } from '@/libs/getUILocaleAndResources';
+import type { UILocaleResources } from '@/libs/getUILocaleAndResources.utils';
+import { resolveUILocale } from '@/libs/getUILocaleAndResources.utils';
 import Image from '@/libs/next/Image';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
@@ -115,20 +117,22 @@ const AppTheme = memo<AppThemeProps>(
       [messageTop],
     );
 
-    const [uiResources, setUIResources] = useState<any>(null);
-    const uiLocale = useMemo(() => {
-      if (language.startsWith('zh')) return 'zh-CN';
-      if (language.startsWith('en')) return 'en-US';
-      return 'en-US';
-    }, [language]);
+    const [uiResources, setUIResources] = useState<UILocaleResources>();
+    const [uiLocale, setUILocale] = useState(() => resolveUILocale(language).uiLocale);
 
     useEffect(() => {
       let mounted = true;
-      getUILocaleAndResources(language).then(({ resources }) => {
-        if (mounted) {
-          setUIResources(resources);
-        }
-      });
+      setUILocale(resolveUILocale(language).uiLocale);
+      getUILocaleAndResources(language)
+        .then(({ locale, resources }) => {
+          if (mounted) {
+            setUILocale(locale);
+            setUIResources(resources);
+          }
+        })
+        .catch((error) => {
+          console.error('Failed to load UI locale resources:', error);
+        });
       return () => {
         mounted = false;
       };

--- a/src/libs/getUILocaleAndResources.desktop.ts
+++ b/src/libs/getUILocaleAndResources.desktop.ts
@@ -1,24 +1,23 @@
 import { en, zhCn } from '@lobehub/ui/es/i18n/resources/index';
 
-import { normalizeLocale } from '@/locales/resources';
-
-type UILocaleResources = Record<string, Record<string, string>>;
+import type { UILocaleResourceInput, UILocaleResources } from './getUILocaleAndResources.utils';
+import {
+  mergeUILocaleResources,
+  normalizeUILocaleResources,
+  resolveUILocale,
+} from './getUILocaleAndResources.utils';
 
 // eager: true — UI locale fully inlined at build time
-const uiLocaleModules = import.meta.glob<{ default: UILocaleResources }>('/locales/*/ui.json', {
+const uiLocaleModules = import.meta.glob<{ default: UILocaleResourceInput }>('/locales/*/ui.json', {
   eager: true,
 });
-
-const getUILocale = (locale: string): string => {
-  if (locale.startsWith('zh')) return 'zh-CN';
-  if (locale.startsWith('en')) return 'en-US';
-  return locale;
-};
 
 const loadBusinessResources = (locale: string): UILocaleResources | null => {
   const key = `/locales/${locale}/ui.json`;
   const mod = uiLocaleModules[key];
-  return mod ? (mod.default as UILocaleResources) : null;
+  const resources = mod?.default as UILocaleResourceInput | null | undefined;
+
+  return resources ? normalizeUILocaleResources(resources) : null;
 };
 
 const loadLobeUIBuiltinResources = (locale: string): UILocaleResources | null => {
@@ -29,15 +28,14 @@ const loadLobeUIBuiltinResources = (locale: string): UILocaleResources | null =>
 export const getUILocaleAndResources = async (
   locale: string | 'auto',
 ): Promise<{ locale: string; resources: UILocaleResources }> => {
-  const effectiveLocale = locale === 'auto' ? 'en-US' : locale;
-  const normalizedLocale = normalizeLocale(effectiveLocale);
-  const uiLocale = getUILocale(normalizedLocale);
+  const { normalizedLocale, uiLocale } = resolveUILocale(locale);
 
   const resources =
-    loadBusinessResources(normalizedLocale) ??
-    loadLobeUIBuiltinResources(normalizedLocale) ??
-    loadBusinessResources('en-US') ??
-    loadLobeUIBuiltinResources('en-US');
+    mergeUILocaleResources(
+      loadLobeUIBuiltinResources(normalizedLocale),
+      loadBusinessResources(normalizedLocale),
+    ) ??
+    mergeUILocaleResources(loadLobeUIBuiltinResources('en-US'), loadBusinessResources('en-US'));
 
   if (!resources)
     throw new Error(

--- a/src/libs/getUILocaleAndResources.test.ts
+++ b/src/libs/getUILocaleAndResources.test.ts
@@ -2,11 +2,40 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { getUILocaleAndResources } from './getUILocaleAndResources';
 
+const translateFromUILocaleResources = (
+  resources: Record<string, Record<string, string>>,
+  key: string,
+) => Object.assign({}, ...Object.values(resources))[key];
+
 describe('getUILocaleAndResources', () => {
   it('should return zh-CN locale and zhCn resources for zh-CN', async () => {
     const result = await getUILocaleAndResources('zh-CN');
     expect(result.locale).toBe('zh-CN');
     expect(result.resources).toBeDefined();
+  });
+
+  it('should normalize business ui.json into a @lobehub/ui consumable resource map', async () => {
+    const result = await getUILocaleAndResources('zh-CN');
+
+    expect(translateFromUILocaleResources(result.resources, 'form.submit')).toBe('提交');
+  });
+
+  it('should merge built-in resources with partial business ui.json resources', async () => {
+    const result = await getUILocaleAndResources('zh-CN');
+
+    expect(translateFromUILocaleResources(result.resources, 'image.copy')).toBe('复制');
+    expect(translateFromUILocaleResources(result.resources, 'hotkey.clear')).toBe('清除绑定');
+    expect(translateFromUILocaleResources(result.resources, 'form.submit')).toBe('提交');
+  });
+
+  it('should merge en built-in fallback resources for non-en/zh partial business ui.json resources', async () => {
+    const result = await getUILocaleAndResources('de-DE');
+
+    expect(result.locale).toBe('de-DE');
+    expect(translateFromUILocaleResources(result.resources, 'image.copy')).toBe('Copy');
+    expect(translateFromUILocaleResources(result.resources, 'hotkey.clear')).toBe('Clear binding');
+    expect(translateFromUILocaleResources(result.resources, 'common.empty')).toBe('(empty)');
+    expect(translateFromUILocaleResources(result.resources, 'form.submit')).toBe('Absenden');
   });
 
   it('should return zh-CN locale and zhCn resources for zh-TW', async () => {
@@ -27,10 +56,18 @@ describe('getUILocaleAndResources', () => {
     expect(result.resources).toBeDefined();
   });
 
-  it('should return en-US locale and en resources for auto', async () => {
-    const result = await getUILocaleAndResources('auto');
-    expect(result.locale).toBe('en-US');
-    expect(result.resources).toBeDefined();
+  it('should resolve auto from the current document language', async () => {
+    const previousLang = document.documentElement.lang;
+    document.documentElement.lang = 'zh-CN';
+
+    try {
+      const result = await getUILocaleAndResources('auto');
+
+      expect(result.locale).toBe('zh-CN');
+      expect(translateFromUILocaleResources(result.resources, 'form.submit')).toBe('提交');
+    } finally {
+      document.documentElement.lang = previousLang;
+    }
   });
 
   it('should return ar locale and custom resources for ar', async () => {

--- a/src/libs/getUILocaleAndResources.ts
+++ b/src/libs/getUILocaleAndResources.ts
@@ -1,17 +1,16 @@
-import { normalizeLocale } from '@/locales/resources';
-
-type UILocaleResources = Record<string, Record<string, string>>;
-
-const getUILocale = (locale: string): string => {
-  if (locale.startsWith('zh')) return 'zh-CN';
-  if (locale.startsWith('en')) return 'en-US';
-  return locale;
-};
+import type { UILocaleResourceInput, UILocaleResources } from './getUILocaleAndResources.utils';
+import {
+  mergeUILocaleResources,
+  normalizeUILocaleResources,
+  resolveUILocale,
+} from './getUILocaleAndResources.utils';
 
 const loadBusinessResources = async (locale: string): Promise<UILocaleResources | null> => {
   try {
     const resourcesModule = await import(`@/../locales/${locale}/ui.json`);
-    return resourcesModule.default as UILocaleResources;
+    const resources = resourcesModule.default as UILocaleResourceInput | null;
+
+    return resources ? normalizeUILocaleResources(resources) : null;
   } catch {
     return null;
   }
@@ -31,19 +30,17 @@ const loadLobeUIBuiltinResources = async (locale: string): Promise<UILocaleResou
 export const getUILocaleAndResources = async (
   locale: string | 'auto',
 ): Promise<{ locale: string; resources: UILocaleResources }> => {
-  const effectiveLocale = locale === 'auto' ? 'en-US' : locale;
-  const normalizedLocale = normalizeLocale(effectiveLocale);
-  const uiLocale = getUILocale(normalizedLocale);
+  const { normalizedLocale, uiLocale } = resolveUILocale(locale);
 
-  // Priority:
-  // 1) business-defined ui.json
-  // 2) @lobehub/ui built-in resources (en/zh)
-  // 3) fallback to default en
   const resources =
-    (await loadBusinessResources(normalizedLocale)) ??
-    (await loadLobeUIBuiltinResources(normalizedLocale)) ??
-    (await loadBusinessResources('en-US')) ??
-    (await loadLobeUIBuiltinResources('en-US'));
+    mergeUILocaleResources(
+      await loadLobeUIBuiltinResources(normalizedLocale),
+      await loadBusinessResources(normalizedLocale),
+    ) ??
+    mergeUILocaleResources(
+      await loadLobeUIBuiltinResources('en-US'),
+      await loadBusinessResources('en-US'),
+    );
 
   if (!resources)
     throw new Error(

--- a/src/libs/getUILocaleAndResources.utils.ts
+++ b/src/libs/getUILocaleAndResources.utils.ts
@@ -1,0 +1,60 @@
+import { DEFAULT_LANG } from '@/const/locale';
+import { normalizeLocale } from '@/locales/resources';
+
+export type UILocaleResourceBundle = Record<string, string>;
+export type UILocaleResources = Record<string, UILocaleResourceBundle>;
+export type UILocaleResourceInput = UILocaleResourceBundle | UILocaleResources;
+
+const getDocumentLocale = () => {
+  if (typeof document === 'undefined') return;
+
+  return document.documentElement.lang || undefined;
+};
+
+const getNavigatorLocale = () => {
+  if (typeof navigator === 'undefined') return;
+
+  return navigator.language || undefined;
+};
+
+const getUILocale = (locale: string): string => {
+  if (locale.startsWith('zh')) return 'zh-CN';
+  if (locale.startsWith('en')) return 'en-US';
+  return locale;
+};
+
+const isFlatUILocaleResources = (
+  resources: UILocaleResourceInput,
+): resources is UILocaleResourceBundle =>
+  Object.values(resources).every((value) => typeof value === 'string');
+
+const flattenUILocaleResources = (resources: UILocaleResourceInput): UILocaleResourceBundle =>
+  isFlatUILocaleResources(resources) ? resources : Object.assign({}, ...Object.values(resources));
+
+export const normalizeUILocaleResources = (
+  resources: UILocaleResourceInput,
+): UILocaleResources => ({
+  app: flattenUILocaleResources(resources),
+});
+
+export const mergeUILocaleResources = (
+  ...resourcesList: (UILocaleResourceInput | null)[]
+): UILocaleResources | null => {
+  const mergedResources = Object.assign(
+    {},
+    ...resourcesList.filter(Boolean).map((resources) => flattenUILocaleResources(resources!)),
+  );
+
+  return Object.keys(mergedResources).length > 0 ? { app: mergedResources } : null;
+};
+
+export const resolveUILocale = (locale: string | 'auto') => {
+  const effectiveLocale =
+    locale === 'auto' ? (getDocumentLocale() ?? getNavigatorLocale() ?? DEFAULT_LANG) : locale;
+  const normalizedLocale = normalizeLocale(effectiveLocale);
+
+  return {
+    normalizedLocale,
+    uiLocale: getUILocale(normalizedLocale),
+  };
+};

--- a/src/libs/getUILocaleAndResources.vite.ts
+++ b/src/libs/getUILocaleAndResources.vite.ts
@@ -1,14 +1,11 @@
-import { normalizeLocale } from '@/locales/resources';
+import type { UILocaleResourceInput, UILocaleResources } from './getUILocaleAndResources.utils';
+import {
+  mergeUILocaleResources,
+  normalizeUILocaleResources,
+  resolveUILocale,
+} from './getUILocaleAndResources.utils';
 
-type UILocaleResources = Record<string, Record<string, string>>;
-
-const uiLocaleLoaders = import.meta.glob<{ default: UILocaleResources }>('/locales/*/ui.json');
-
-const getUILocale = (locale: string): string => {
-  if (locale.startsWith('zh')) return 'zh-CN';
-  if (locale.startsWith('en')) return 'en-US';
-  return locale;
-};
+const uiLocaleLoaders = import.meta.glob<{ default: UILocaleResourceInput }>('/locales/*/ui.json');
 
 const loadBusinessResources = async (locale: string): Promise<UILocaleResources | null> => {
   const key = `/locales/${locale}/ui.json`;
@@ -16,7 +13,9 @@ const loadBusinessResources = async (locale: string): Promise<UILocaleResources 
   if (!loader) return null;
   try {
     const mod = await loader();
-    return mod.default as UILocaleResources;
+    const resources = mod.default as UILocaleResourceInput | null;
+
+    return resources ? normalizeUILocaleResources(resources) : null;
   } catch {
     return null;
   }
@@ -36,15 +35,17 @@ const loadLobeUIBuiltinResources = async (locale: string): Promise<UILocaleResou
 export const getUILocaleAndResources = async (
   locale: string | 'auto',
 ): Promise<{ locale: string; resources: UILocaleResources }> => {
-  const effectiveLocale = locale === 'auto' ? 'en-US' : locale;
-  const normalizedLocale = normalizeLocale(effectiveLocale);
-  const uiLocale = getUILocale(normalizedLocale);
+  const { normalizedLocale, uiLocale } = resolveUILocale(locale);
 
   const resources =
-    (await loadBusinessResources(normalizedLocale)) ??
-    (await loadLobeUIBuiltinResources(normalizedLocale)) ??
-    (await loadBusinessResources('en-US')) ??
-    (await loadLobeUIBuiltinResources('en-US'));
+    mergeUILocaleResources(
+      await loadLobeUIBuiltinResources(normalizedLocale),
+      await loadBusinessResources(normalizedLocale),
+    ) ??
+    mergeUILocaleResources(
+      await loadLobeUIBuiltinResources('en-US'),
+      await loadBusinessResources('en-US'),
+    );
 
   if (!resources)
     throw new Error(

--- a/src/routes/(main)/agent/profile/features/AgentSettings/Content.test.tsx
+++ b/src/routes/(main)/agent/profile/features/AgentSettings/Content.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react';
+import type { PropsWithChildren, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ChatSettingsTabs } from '@/store/global/initialState';
+
+import Content from './Content';
+
+const mocks = vi.hoisted(() => ({
+  agentState: {
+    activeAgentId: 'inbox-agent',
+    config: {},
+    isInbox: true,
+    meta: {},
+    optimisticUpdateAgentConfig: vi.fn(),
+    optimisticUpdateAgentMeta: vi.fn(),
+  },
+  serverState: {
+    featureFlags: {
+      enableAgentSelfIteration: true,
+    },
+  },
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  Avatar: () => <div data-testid="avatar" />,
+  Block: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  Flexbox: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  Icon: () => <span />,
+  Text: ({ children }: PropsWithChildren) => <span>{children}</span>,
+}));
+
+vi.mock('@/components/Menu', () => ({
+  default: ({
+    items = [],
+    onClick,
+    selectedKeys = [],
+  }: {
+    items?: { key?: string; label?: ReactNode }[];
+    onClick?: ({ key }: { key: string }) => void;
+    selectedKeys?: string[];
+  }) => (
+    <div data-selected={selectedKeys.join(',')} data-testid="agent-settings-menu">
+      {items.map((item) => (
+        <button
+          key={item.key}
+          type="button"
+          onClick={() => item.key && onClick?.({ key: item.key })}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@/features/AgentSetting', () => ({
+  AgentSettings: ({ tab }: { tab: ChatSettingsTabs }) => (
+    <div data-tab={tab} data-testid="agent-settings-content" />
+  ),
+}));
+
+vi.mock('@/store/agent', () => {
+  const useAgentStore = (selector: (state: typeof mocks.agentState) => unknown) =>
+    selector(mocks.agentState);
+  useAgentStore.getState = () => mocks.agentState;
+
+  return { useAgentStore };
+});
+
+vi.mock('@/store/agent/selectors', () => ({
+  agentSelectors: {
+    currentAgentConfig: (state: typeof mocks.agentState) => state.config,
+    currentAgentMeta: (state: typeof mocks.agentState) => state.meta,
+  },
+  builtinAgentSelectors: {
+    isInboxAgent: (state: typeof mocks.agentState) => state.isInbox,
+  },
+}));
+
+vi.mock('@/store/serverConfig', () => ({
+  featureFlagsSelectors: (state: typeof mocks.serverState) => state.featureFlags,
+  useServerConfigStore: (selector: (state: typeof mocks.serverState) => unknown) =>
+    selector(mocks.serverState),
+}));
+
+vi.mock('antd-style', () => ({
+  useTheme: () => ({
+    colorBgLayout: '#fff',
+    colorBorderSecondary: '#eee',
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('AgentSettings Content', () => {
+  beforeEach(() => {
+    mocks.agentState.isInbox = true;
+    mocks.serverState.featureFlags.enableAgentSelfIteration = true;
+  });
+
+  it('should select self iteration when inbox hides opening settings', () => {
+    render(<Content />);
+
+    expect(screen.queryByRole('button', { name: 'agentTab.opening' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'agentTab.selfIteration' })).toBeInTheDocument();
+    expect(screen.getByTestId('agent-settings-menu')).toHaveAttribute(
+      'data-selected',
+      ChatSettingsTabs.SelfIteration,
+    );
+    expect(screen.getByTestId('agent-settings-content')).toHaveAttribute(
+      'data-tab',
+      ChatSettingsTabs.SelfIteration,
+    );
+  });
+});

--- a/src/routes/(main)/agent/profile/features/AgentSettings/Content.tsx
+++ b/src/routes/(main)/agent/profile/features/AgentSettings/Content.tsx
@@ -5,7 +5,7 @@ import { type ItemType } from 'antd/es/menu/interface';
 import { useTheme } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { ActivityIcon, MessageSquareHeartIcon } from 'lucide-react';
-import { memo, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { shallow } from 'zustand/shallow';
 
@@ -29,6 +29,21 @@ const Content = memo(() => {
   const { enableAgentSelfIteration } = useServerConfigStore(featureFlagsSelectors);
   const [tab, setTab] = useState(ChatSettingsTabs.Opening);
 
+  const availableTabs = useMemo(
+    () =>
+      [
+        !isInbox ? ChatSettingsTabs.Opening : null,
+        enableAgentSelfIteration ? ChatSettingsTabs.SelfIteration : null,
+      ].filter(Boolean) as ChatSettingsTabs[],
+    [isInbox, enableAgentSelfIteration],
+  );
+
+  const activeTab = availableTabs.includes(tab) ? tab : availableTabs[0];
+
+  useEffect(() => {
+    if (activeTab && activeTab !== tab) setTab(activeTab);
+  }, [activeTab, tab]);
+
   const updateAgentConfig = async (config: any) => {
     if (!agentId) return;
     await useAgentStore.getState().optimisticUpdateAgentConfig(agentId, config);
@@ -41,23 +56,30 @@ const Content = memo(() => {
 
   const menuItems: ItemType[] = useMemo(
     () =>
-      [
-        !isInbox
-          ? {
-              icon: <Icon icon={MessageSquareHeartIcon} />,
-              key: ChatSettingsTabs.Opening,
-              label: t('agentTab.opening'),
+      availableTabs
+        .map((tab) => {
+          switch (tab) {
+            case ChatSettingsTabs.Opening: {
+              return {
+                icon: <Icon icon={MessageSquareHeartIcon} />,
+                key: ChatSettingsTabs.Opening,
+                label: t('agentTab.opening'),
+              };
             }
-          : null,
-        enableAgentSelfIteration
-          ? {
-              icon: <Icon icon={ActivityIcon} />,
-              key: ChatSettingsTabs.SelfIteration,
-              label: t('agentTab.selfIteration'),
+            case ChatSettingsTabs.SelfIteration: {
+              return {
+                icon: <Icon icon={ActivityIcon} />,
+                key: ChatSettingsTabs.SelfIteration,
+                label: t('agentTab.selfIteration'),
+              };
             }
-          : null,
-      ].filter(Boolean) as ItemType[],
-    [t, isInbox, enableAgentSelfIteration],
+            default: {
+              return null;
+            }
+          }
+        })
+        .filter(Boolean) as ItemType[],
+    [availableTabs, t],
   );
 
   const displayTitle = isInbox ? 'Lobe AI' : meta.title || t('defaultSession', { ns: 'common' });
@@ -105,7 +127,7 @@ const Content = memo(() => {
         <Menu
           selectable
           items={menuItems}
-          selectedKeys={[tab]}
+          selectedKeys={activeTab ? [activeTab] : []}
           style={{ width: '100%' }}
           onClick={({ key }) => setTab(key as ChatSettingsTabs)}
         />
@@ -116,15 +138,17 @@ const Content = memo(() => {
         paddingInline={64}
         style={{ overflow: 'scroll', width: '100%' }}
       >
-        <Settings
-          config={config}
-          id={agentId}
-          loading={false}
-          meta={meta}
-          tab={tab}
-          onConfigChange={updateAgentConfig}
-          onMetaChange={updateAgentMeta}
-        />
+        {activeTab && (
+          <Settings
+            config={config}
+            id={agentId}
+            loading={false}
+            meta={meta}
+            tab={activeTab}
+            onConfigChange={updateAgentConfig}
+            onMetaChange={updateAgentMeta}
+          />
+        )}
       </Flexbox>
     </Flexbox>
   );

--- a/src/store/user/slices/settings/selectors/__snapshots__/settings.test.ts.snap
+++ b/src/store/user/slices/settings/selectors/__snapshots__/settings.test.ts.snap
@@ -122,6 +122,9 @@ exports[`settingsSelectors > defaultAgent > should merge DEFAULT_AGENT and s.set
         "provider": "deepseek",
       },
       "searchMode": "auto",
+      "selfIteration": {
+        "enabled": false,
+      },
     },
     "model": "gpt-3.5-turbo",
     "openingQuestions": [],
@@ -166,6 +169,9 @@ exports[`settingsSelectors > defaultAgentConfig > should merge DEFAULT_AGENT_CON
       "provider": "deepseek",
     },
     "searchMode": "auto",
+    "selfIteration": {
+      "enabled": false,
+    },
   },
   "model": "gpt-4",
   "openingQuestions": [],


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

This PR fixes three related agent settings regressions:

- Adds an explicit `selfIteration.enabled: false` default to agent chat config so newly created agents do not appear dirty when the self-iteration form registers its switch field.
- Normalizes `locales/*/ui.json` into the resource shape expected by `@lobehub/ui`, and resolves `auto` UI locale from the current document or browser locale so default UI texts such as Reset/Submit are localized correctly.
- Keeps the agent advanced settings modal tab state aligned with the available menu items, so the inbox agent no longer shows opening settings content after the opening settings menu item is intentionally hidden.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run --silent='passed-only' 'src/routes/(main)/agent/profile/features/AgentSettings/Content.test.tsx' src/features/AgentSetting/store/selectors.test.ts src/libs/getUILocaleAndResources.test.ts
bun run type-check
```

Manual checks in the local SPA debug proxy:

- New agent self-iteration settings no longer show unsaved changes on initial open.
- Reset/Submit footer labels are localized in zh-CN.
- Inbox agent advanced settings opens self-iteration content when opening settings is hidden from the menu.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No migration required.
