### PR TITLE
💄 style(workflow): normalize block spacing

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.test.tsx
@@ -9,7 +9,9 @@ import ContentBlocksScroll from './ContentBlocksScroll';
 import type { RenderableAssistantContentBlock } from './types';
 
 vi.mock('@lobehub/ui', () => ({
-  Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Flexbox: ({ children, gap }: { children?: ReactNode; gap?: number }) => (
+    <div data-gap={gap}>{children}</div>
+  ),
   ScrollArea: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
 }));
 
@@ -61,5 +63,21 @@ describe('ContentBlocksScroll', () => {
       'data-disable-markdown-streaming',
       'true',
     );
+  });
+
+  it('uses a consistent gap between workflow blocks', () => {
+    const { container } = render(
+      <ContentBlocksScroll
+        assistantId="assistant-1"
+        blocks={[
+          { content: 'first workflow block', id: 'block-1' },
+          { content: 'second workflow block', id: 'block-2' },
+        ]}
+        scroll={false}
+        variant="workflow"
+      />,
+    );
+
+    expect(container.querySelector('[data-gap="8"]')).toBeInTheDocument();
   });
 });

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
@@ -68,7 +68,7 @@ const ContentBlocksScroll = memo<ContentBlocksScrollProps>((props) => {
   }, [assistantIdFromProps, blocksFromProps, messagesList]);
 
   const list = (
-    <Flexbox>
+    <Flexbox gap={variant === 'workflow' ? 8 : undefined}>
       {blocks.map((block) => (
         <ContentBlock
           key={block.renderKey ?? block.id}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

- Normalize the spacing between workflow content blocks in the AssistantGroup workflow collapse.
- Keep block-level boundaries visually consistent with the existing reasoning/content/tool spacing.
- Add focused regression coverage for workflow block gaps.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Command:

```bash
bunx vitest run --silent='passed-only' src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.test.tsx
```

Also verified:

```bash
git diff --check -- src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.test.tsx
```

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Reported uneven workflow item spacing | Not captured |

#### 📝 Additional Information

The branch was created from origin/canary. An unrelated untracked docs file remains unstaged locally.