### PR TITLE
🐛 fix(skill): persist SKILL.md editor data from body only

### DIFF
--- a/src/server/services/agentDocumentVfs/mounts/skills/providers/ProviderSkillsAgentDocument.test.ts
+++ b/src/server/services/agentDocumentVfs/mounts/skills/providers/ProviderSkillsAgentDocument.test.ts
@@ -31,6 +31,9 @@ const createAgentDocument = (overrides: Record<string, unknown> = {}) =>
     ...overrides,
   }) as any;
 
+const skillContent = (name = 'writer', body = '# Skill') =>
+  `---\ndescription: Writes documents\nname: ${name}\n---\n${body}`;
+
 describe('Agent skill VFS providers', () => {
   const agentDocumentModel = {
     associate: vi.fn(),
@@ -170,6 +173,57 @@ describe('Agent skill VFS providers', () => {
       expect(result.path).toBe('./lobe/skills/agent/skills/writer/SKILL.md');
     });
 
+    it('creates SKILL.md with full content but body-only editorData when frontmatter is present', async () => {
+      const content = skillContent();
+      agentDocumentModel.findByAgent.mockResolvedValue([]);
+      agentDocumentModel.create
+        .mockResolvedValueOnce({
+          documentId: 'bundle-1',
+          fileType: 'skills/bundle',
+          filename: 'writer',
+          id: 'agent-doc-bundle',
+          metadata: null,
+          parentId: null,
+          templateId: 'agent-skill',
+          title: 'writer',
+        })
+        .mockResolvedValueOnce({
+          content,
+          documentId: 'file-1',
+          fileType: 'skills/index',
+          filename: 'SKILL.md',
+          id: 'agent-doc-file',
+          metadata: null,
+          parentId: 'bundle-1',
+          templateId: 'agent-skill',
+          title: 'SKILL.md',
+        });
+
+      const provider = new ProviderSkillsAgentDocument('agent', {
+        agentDocumentModel,
+        documentService,
+      });
+
+      const result = await provider.create({
+        agentId: 'agent-1',
+        content,
+        skillName: 'writer',
+        targetNamespace: 'agent',
+      });
+
+      expect(agentDocumentModel.create).toHaveBeenNthCalledWith(
+        2,
+        'agent-1',
+        'SKILL.md',
+        content,
+        expect.objectContaining({
+          editorData: { markdown: '# Skill' },
+          fileType: 'skills/index',
+        }),
+      );
+      expect(result.content).toBe(content);
+    });
+
     /**
      * @example
      * A partially-created skill bundle reserves the package name and blocks duplicate creation.
@@ -250,6 +304,46 @@ describe('Agent skill VFS providers', () => {
         editorData: { markdown: 'new content' },
       });
       expect(result.content).toBe('new content');
+    });
+
+    it('updates SKILL.md with full content but body-only editorData when frontmatter is present', async () => {
+      const content = skillContent('skill-a', '# Updated');
+      agentDocumentModel.findByAgent.mockResolvedValue([
+        createAgentDocument({
+          documentId: 'bundle-1',
+          fileType: 'skills/bundle',
+          filename: 'skill-a',
+          id: 'agent-doc-bundle',
+          parentId: null,
+          templateId: 'agent-skill',
+        }),
+        createAgentDocument({
+          content: skillContent('skill-a', '# Old'),
+          documentId: 'file-1',
+          fileType: 'skills/index',
+          filename: 'SKILL.md',
+          id: 'agent-doc-file',
+          parentId: 'bundle-1',
+          templateId: 'agent-skill',
+        }),
+      ]);
+
+      const provider = new ProviderSkillsAgentDocument('agent', {
+        agentDocumentModel,
+        documentService,
+      });
+
+      const result = await provider.update({
+        agentId: 'agent-1',
+        content,
+        path: './lobe/skills/agent/skills/skill-a/SKILL.md',
+      });
+
+      expect(agentDocumentModel.update).toHaveBeenCalledWith('agent-doc-file', {
+        content,
+        editorData: { markdown: '# Updated' },
+      });
+      expect(result.content).toBe(content);
     });
 
     it('soft-deletes the folder subtree for an agent skill', async () => {

--- a/src/server/services/agentDocumentVfs/mounts/skills/providers/ProviderSkillsAgentDocument.test.ts
+++ b/src/server/services/agentDocumentVfs/mounts/skills/providers/ProviderSkillsAgentDocument.test.ts
@@ -224,6 +224,58 @@ describe('Agent skill VFS providers', () => {
       expect(result.content).toBe(content);
     });
 
+    it('creates raw SKILL.md markdown starting with a horizontal rule without treating it as frontmatter', async () => {
+      const content = `---
+# Skill`;
+      agentDocumentModel.findByAgent.mockResolvedValue([]);
+      agentDocumentModel.create
+        .mockResolvedValueOnce({
+          documentId: 'bundle-1',
+          fileType: 'skills/bundle',
+          filename: 'writer',
+          id: 'agent-doc-bundle',
+          metadata: null,
+          parentId: null,
+          templateId: 'agent-skill',
+          title: 'writer',
+        })
+        .mockResolvedValueOnce({
+          content,
+          documentId: 'file-1',
+          fileType: 'skills/index',
+          filename: 'SKILL.md',
+          id: 'agent-doc-file',
+          metadata: null,
+          parentId: 'bundle-1',
+          templateId: 'agent-skill',
+          title: 'SKILL.md',
+        });
+
+      const provider = new ProviderSkillsAgentDocument('agent', {
+        agentDocumentModel,
+        documentService,
+      });
+
+      const result = await provider.create({
+        agentId: 'agent-1',
+        content,
+        skillName: 'writer',
+        targetNamespace: 'agent',
+      });
+
+      expect(agentDocumentModel.create).toHaveBeenNthCalledWith(
+        2,
+        'agent-1',
+        'SKILL.md',
+        content,
+        expect.objectContaining({
+          editorData: { markdown: content },
+          fileType: 'skills/index',
+        }),
+      );
+      expect(result.content).toBe(content);
+    });
+
     /**
      * @example
      * A partially-created skill bundle reserves the package name and blocks duplicate creation.
@@ -342,6 +394,47 @@ describe('Agent skill VFS providers', () => {
       expect(agentDocumentModel.update).toHaveBeenCalledWith('agent-doc-file', {
         content,
         editorData: { markdown: '# Updated' },
+      });
+      expect(result.content).toBe(content);
+    });
+
+    it('updates raw SKILL.md markdown starting with a horizontal rule without treating it as frontmatter', async () => {
+      const content = `---
+# Updated`;
+      agentDocumentModel.findByAgent.mockResolvedValue([
+        createAgentDocument({
+          documentId: 'bundle-1',
+          fileType: 'skills/bundle',
+          filename: 'skill-a',
+          id: 'agent-doc-bundle',
+          parentId: null,
+          templateId: 'agent-skill',
+        }),
+        createAgentDocument({
+          content: '# Old',
+          documentId: 'file-1',
+          fileType: 'skills/index',
+          filename: 'SKILL.md',
+          id: 'agent-doc-file',
+          parentId: 'bundle-1',
+          templateId: 'agent-skill',
+        }),
+      ]);
+
+      const provider = new ProviderSkillsAgentDocument('agent', {
+        agentDocumentModel,
+        documentService,
+      });
+
+      const result = await provider.update({
+        agentId: 'agent-1',
+        content,
+        path: './lobe/skills/agent/skills/skill-a/SKILL.md',
+      });
+
+      expect(agentDocumentModel.update).toHaveBeenCalledWith('agent-doc-file', {
+        content,
+        editorData: { markdown: content },
       });
       expect(result.content).toBe(content);
     });

--- a/src/server/services/agentDocumentVfs/mounts/skills/providers/ProviderSkillsAgentDocument.test.ts
+++ b/src/server/services/agentDocumentVfs/mounts/skills/providers/ProviderSkillsAgentDocument.test.ts
@@ -276,6 +276,60 @@ describe('Agent skill VFS providers', () => {
       expect(result.content).toBe(content);
     });
 
+    it('creates raw SKILL.md markdown with multiple horizontal rules without treating it as frontmatter', async () => {
+      const content = `---
+# Skill
+---
+Body`;
+      agentDocumentModel.findByAgent.mockResolvedValue([]);
+      agentDocumentModel.create
+        .mockResolvedValueOnce({
+          documentId: 'bundle-1',
+          fileType: 'skills/bundle',
+          filename: 'writer',
+          id: 'agent-doc-bundle',
+          metadata: null,
+          parentId: null,
+          templateId: 'agent-skill',
+          title: 'writer',
+        })
+        .mockResolvedValueOnce({
+          content,
+          documentId: 'file-1',
+          fileType: 'skills/index',
+          filename: 'SKILL.md',
+          id: 'agent-doc-file',
+          metadata: null,
+          parentId: 'bundle-1',
+          templateId: 'agent-skill',
+          title: 'SKILL.md',
+        });
+
+      const provider = new ProviderSkillsAgentDocument('agent', {
+        agentDocumentModel,
+        documentService,
+      });
+
+      const result = await provider.create({
+        agentId: 'agent-1',
+        content,
+        skillName: 'writer',
+        targetNamespace: 'agent',
+      });
+
+      expect(agentDocumentModel.create).toHaveBeenNthCalledWith(
+        2,
+        'agent-1',
+        'SKILL.md',
+        content,
+        expect.objectContaining({
+          editorData: { markdown: content },
+          fileType: 'skills/index',
+        }),
+      );
+      expect(result.content).toBe(content);
+    });
+
     /**
      * @example
      * A partially-created skill bundle reserves the package name and blocks duplicate creation.
@@ -401,6 +455,49 @@ describe('Agent skill VFS providers', () => {
     it('updates raw SKILL.md markdown starting with a horizontal rule without treating it as frontmatter', async () => {
       const content = `---
 # Updated`;
+      agentDocumentModel.findByAgent.mockResolvedValue([
+        createAgentDocument({
+          documentId: 'bundle-1',
+          fileType: 'skills/bundle',
+          filename: 'skill-a',
+          id: 'agent-doc-bundle',
+          parentId: null,
+          templateId: 'agent-skill',
+        }),
+        createAgentDocument({
+          content: '# Old',
+          documentId: 'file-1',
+          fileType: 'skills/index',
+          filename: 'SKILL.md',
+          id: 'agent-doc-file',
+          parentId: 'bundle-1',
+          templateId: 'agent-skill',
+        }),
+      ]);
+
+      const provider = new ProviderSkillsAgentDocument('agent', {
+        agentDocumentModel,
+        documentService,
+      });
+
+      const result = await provider.update({
+        agentId: 'agent-1',
+        content,
+        path: './lobe/skills/agent/skills/skill-a/SKILL.md',
+      });
+
+      expect(agentDocumentModel.update).toHaveBeenCalledWith('agent-doc-file', {
+        content,
+        editorData: { markdown: content },
+      });
+      expect(result.content).toBe(content);
+    });
+
+    it('updates raw SKILL.md markdown with multiple horizontal rules without treating it as frontmatter', async () => {
+      const content = `---
+# Updated
+---
+Body`;
       agentDocumentModel.findByAgent.mockResolvedValue([
         createAgentDocument({
           documentId: 'bundle-1',

--- a/src/server/services/agentDocumentVfs/mounts/skills/providers/ProviderSkillsAgentDocument.ts
+++ b/src/server/services/agentDocumentVfs/mounts/skills/providers/ProviderSkillsAgentDocument.ts
@@ -1,5 +1,6 @@
 import { createMarkdownEditorSnapshot } from '@/server/services/agentDocuments/headlessEditor';
 import { AgentDocumentVfsError } from '@/server/services/agentDocumentVfs/errors';
+import { getSkillIndexBodyMarkdown } from '@/server/services/skillManagement/frontmatter';
 
 import type {
   CreateSkillInput,
@@ -36,6 +37,9 @@ const DOCUMENT_SKILL_PROVIDER_CONFIGS = {
     namespace: 'agent',
   },
 } as const satisfies Record<'agent', ProviderSkillsAgentDocumentConfig>;
+
+const getSkillIndexEditorMarkdown = (content: string) =>
+  content.trimStart().startsWith('---') ? getSkillIndexBodyMarkdown(content) : content;
 
 /**
  * Provides writable VFS operations for document-backed skills.
@@ -119,19 +123,21 @@ export class ProviderSkillsAgentDocument implements WritableSkillMountProvider {
       throw new AgentDocumentVfsError('Skill already exists', 'CONFLICT');
     }
 
-    const snapshot = await createMarkdownEditorSnapshot(input.content);
+    const editorSnapshot = await createMarkdownEditorSnapshot(
+      getSkillIndexEditorMarkdown(input.content),
+    );
 
     await createSkillTree({
       agentDocumentModel: this.deps.agentDocumentModel,
       agentId: input.agentId,
-      content: snapshot.content,
-      editorData: snapshot.editorData,
+      content: input.content,
+      editorData: editorSnapshot.editorData,
       namespace: this.config.namespace,
       skillName,
     });
 
     return buildSkillFileNode({
-      content: snapshot.content,
+      content: input.content,
       namespace: this.config.namespace,
       skillName,
     });
@@ -143,9 +149,11 @@ export class ProviderSkillsAgentDocument implements WritableSkillMountProvider {
     const documents = await this.deps.agentDocumentModel.findByAgent(input.agentId);
     const document = assertSkillDocument(getSkillFile(documents, this.config.namespace, skillName));
     const existingContent = await projectDocumentContent(document);
-    const snapshot = await createMarkdownEditorSnapshot(input.content);
+    const editorSnapshot = await createMarkdownEditorSnapshot(
+      getSkillIndexEditorMarkdown(input.content),
+    );
 
-    if (existingContent !== snapshot.content) {
+    if (existingContent !== input.content) {
       await this.deps.documentService.trySaveCurrentDocumentHistory(
         document.documentId,
         'llm_call',
@@ -153,12 +161,12 @@ export class ProviderSkillsAgentDocument implements WritableSkillMountProvider {
     }
 
     await this.deps.agentDocumentModel.update(document.id, {
-      content: snapshot.content,
-      editorData: snapshot.editorData,
+      content: input.content,
+      editorData: editorSnapshot.editorData,
     });
 
     return buildSkillFileNode({
-      content: snapshot.content,
+      content: input.content,
       namespace: this.config.namespace,
       skillName,
     });

--- a/src/server/services/agentDocumentVfs/mounts/skills/providers/ProviderSkillsAgentDocument.ts
+++ b/src/server/services/agentDocumentVfs/mounts/skills/providers/ProviderSkillsAgentDocument.ts
@@ -1,6 +1,6 @@
 import { createMarkdownEditorSnapshot } from '@/server/services/agentDocuments/headlessEditor';
 import { AgentDocumentVfsError } from '@/server/services/agentDocumentVfs/errors';
-import { getSkillIndexBodyMarkdown } from '@/server/services/skillManagement/frontmatter';
+import { tryGetSkillIndexBodyMarkdown } from '@/server/services/skillManagement/frontmatter';
 
 import type {
   CreateSkillInput,
@@ -39,7 +39,7 @@ const DOCUMENT_SKILL_PROVIDER_CONFIGS = {
 } as const satisfies Record<'agent', ProviderSkillsAgentDocumentConfig>;
 
 const getSkillIndexEditorMarkdown = (content: string) =>
-  content.trimStart().startsWith('---') ? getSkillIndexBodyMarkdown(content) : content;
+  tryGetSkillIndexBodyMarkdown(content) ?? content;
 
 /**
  * Provides writable VFS operations for document-backed skills.

--- a/src/server/services/agentDocuments/index.test.ts
+++ b/src/server/services/agentDocuments/index.test.ts
@@ -557,6 +557,44 @@ describe('AgentDocumentsService', () => {
       expect(headlessEditorMocks.applyLiteXMLBatch).not.toHaveBeenCalled();
       expect(result?.content).toBe('xml updated');
     });
+
+    it('should preserve managed skill frontmatter when applying LiteXML operations', async () => {
+      const content = '---\ndescription: Writes docs\nname: writer\n---\n# Old';
+      mockModel.findById
+        .mockResolvedValueOnce({
+          agentId: 'agent-1',
+          content,
+          documentId: 'documents-1',
+          editorData: { root: { children: [{ text: 'old' }] } },
+          fileType: 'skills/index',
+          id: 'agent-doc-1',
+          templateId: 'agent-skill',
+          title: 'SKILL.md',
+        })
+        .mockResolvedValueOnce({
+          agentId: 'agent-1',
+          content: '---\ndescription: Writes docs\nname: writer\n---\nxml updated',
+          documentId: 'documents-1',
+          editorData: { root: { children: [] } },
+          fileType: 'skills/index',
+          id: 'agent-doc-1',
+          templateId: 'agent-skill',
+          title: 'SKILL.md',
+        });
+
+      const service = new AgentDocumentsService(db, userId);
+      const result = await service.modifyDocumentNodesById(
+        'agent-doc-1',
+        [{ action: 'modify', litexml: '<p id="node-1">xml updated</p>' }],
+        'agent-1',
+      );
+
+      expect(mockModel.update).toHaveBeenCalledWith('agent-doc-1', {
+        content: '---\ndescription: Writes docs\nname: writer\n---\nxml updated',
+        editorData: { root: { children: [] } },
+      });
+      expect(result?.content).toBe('---\ndescription: Writes docs\nname: writer\n---\nxml updated');
+    });
   });
 
   describe('renameDocumentById', () => {

--- a/src/server/services/agentDocuments/index.ts
+++ b/src/server/services/agentDocuments/index.ts
@@ -26,6 +26,11 @@ import { TopicDocumentModel } from '@/database/models/topicDocument';
 import { AgentDocumentVfsError } from '../agentDocumentVfs/errors';
 import { isManagedSkillDocument } from '../agentDocumentVfs/mounts/skills/providers/providerSkillsAgentDocumentUtils';
 import { DocumentService } from '../document';
+import { SKILL_INDEX_FILE_TYPE } from '../skillManagement/constants';
+import {
+  replaceSkillIndexBodyMarkdown,
+  tryGetSkillIndexBodyMarkdown,
+} from '../skillManagement/frontmatter';
 import { TOOL_RESULTS_DIR_NAME } from '../toolExecution/constants';
 import {
   type AgentDocumentLiteXMLOperation,
@@ -35,6 +40,11 @@ import {
 } from './headlessEditor';
 
 const MAX_UNIQUE_FILENAME_ATTEMPTS = 1000;
+
+const shouldPreserveSkillIndexFrontmatter = (doc: AgentDocument) =>
+  isManagedSkillDocument(doc) &&
+  doc.fileType === SKILL_INDEX_FILE_TYPE &&
+  tryGetSkillIndexBodyMarkdown(doc.content) !== undefined;
 
 interface UpsertDocumentParams {
   agentId: string;
@@ -653,9 +663,12 @@ export class AgentDocumentsService {
       fallbackContent: doc.content,
       operations,
     });
+    const content = shouldPreserveSkillIndexFrontmatter(doc)
+      ? replaceSkillIndexBodyMarkdown({ bodyMarkdown: snapshot.content, content: doc.content })
+      : snapshot.content;
 
     await this.agentDocumentModel.update(documentId, {
-      content: snapshot.content,
+      content,
       editorData: snapshot.editorData,
     });
 

--- a/src/server/services/skillManagement/SkillManagementDocumentService.test.ts
+++ b/src/server/services/skillManagement/SkillManagementDocumentService.test.ts
@@ -286,6 +286,7 @@ const skillContent = (name: string, description: string, body = '# Skill') =>
   `---\ndescription: ${description}\nname: ${name}\n---\n${body}`;
 
 const skillBody = (body = '# Skill') => body;
+const expectedSkillEditorData = (body = '# Skill') => expectedEditorData(skillBody(body));
 
 describe('SkillManagementDocumentService', () => {
   beforeEach(() => {
@@ -331,7 +332,7 @@ describe('SkillManagementDocumentService', () => {
         content: skillContent('release-writer', 'Writes release notes'),
         filename: SKILL_INDEX_FILENAME,
         params: expect.objectContaining({
-          editorData: expectedEditorData(skillContent('release-writer', 'Writes release notes')),
+          editorData: expectedSkillEditorData(),
           fileType: SKILL_INDEX_FILE_TYPE,
           parentId: 'document-1',
           policyLoad: PolicyLoad.DISABLED,
@@ -380,7 +381,7 @@ describe('SkillManagementDocumentService', () => {
     expect(agentDocumentModel.documents).toHaveLength(2);
     expect(agentDocumentModel.documents.find((doc) => doc.id === source.id)).toEqual(
       expect.objectContaining({
-        editorData: expectedEditorData(skillContent('draft-skill', 'Draft helper', '# Draft')),
+        editorData: expectedSkillEditorData('# Draft'),
         fileType: SKILL_INDEX_FILE_TYPE,
         filename: SKILL_INDEX_FILENAME,
         parentId: detail.bundle.documentId,
@@ -485,9 +486,7 @@ describe('SkillManagementDocumentService', () => {
       expect.objectContaining({
         agentDocumentId: created.index.agentDocumentId,
         params: expect.objectContaining({
-          editorData: expectedEditorData(
-            skillContent('researcher', 'Researches docs better', '# Better'),
-          ),
+          editorData: expectedSkillEditorData('# Better'),
           metadata: {
             skill: { frontmatter: { description: 'Researches docs better', name: 'researcher' } },
           },
@@ -580,7 +579,7 @@ describe('SkillManagementDocumentService', () => {
       expect.objectContaining({
         agentDocumentId: created.index.agentDocumentId,
         params: expect.objectContaining({
-          editorData: expectedEditorData(skillContent('new-skill', 'Old description')),
+          editorData: expectedSkillEditorData(),
         }),
       }),
     );

--- a/src/server/services/skillManagement/SkillManagementDocumentService.ts
+++ b/src/server/services/skillManagement/SkillManagementDocumentService.ts
@@ -15,6 +15,7 @@ import {
   SKILL_MANAGEMENT_SOURCE_TYPE,
 } from './constants';
 import {
+  getSkillIndexBodyMarkdown,
   normalizeSkillIndexContent,
   parseSkillFrontmatter,
   renderSkillIndexContent,
@@ -107,6 +108,11 @@ export class SkillManagementDocumentService {
     this.documentService = deps?.documentService ?? new DocumentService(db, userId);
   }
 
+  private createSkillIndexEditorSnapshot = (
+    content: string,
+  ): Promise<AgentDocumentEditorSnapshot> =>
+    this.createMarkdownEditorSnapshot(getSkillIndexBodyMarkdown(content));
+
   /**
    * Creates a managed skill bundle and its SKILL.md index.
    *
@@ -132,12 +138,10 @@ export class SkillManagementDocumentService {
     const metadata = buildSkillMetadata(frontmatter);
     // NOTICE:
     // Managed skill indexes are Markdown-backed, but document history snapshots are
-    // editor-data-backed. Always keep `content` and `editorData` in sync so the next
-    // automated skill refinement can save a pre-mutation `document_histories` row.
-    // Root cause: older managed-skill writes only persisted Markdown content, which made
-    // `DocumentService.trySaveCurrentDocumentHistory` no-op for `editorData = NULL`.
+    // editor-data-backed. Store the full SKILL.md in `content`, while `editorData` is only the
+    // editable body projection. Frontmatter is document metadata and must not become editor text.
     // Removal condition: only if document history can snapshot Markdown content directly.
-    const indexEditorSnapshot = await this.createMarkdownEditorSnapshot(normalizedContent);
+    const indexEditorSnapshot = await this.createSkillIndexEditorSnapshot(normalizedContent);
     const duplicateBundles = (
       await this.agentDocumentModel.listByParentAndFilename(input.agentId, null, name)
     ).filter((doc) => doc.fileType === SKILL_BUNDLE_FILE_TYPE);
@@ -355,7 +359,7 @@ export class SkillManagementDocumentService {
     // skips managed skills because there is no valid editor state to snapshot.
     // Root cause: `document_histories.editor_data` stores editor snapshots, not Markdown.
     // Removal condition: only if document history can snapshot Markdown content directly.
-    const editorSnapshot = await this.createMarkdownEditorSnapshot(normalizedContent);
+    const editorSnapshot = await this.createSkillIndexEditorSnapshot(normalizedContent);
 
     await this.documentService.trySaveCurrentDocumentHistory(index.documentId, 'llm_call');
     const updatedBundle =
@@ -402,7 +406,7 @@ export class SkillManagementDocumentService {
     });
     const frontmatter = parseSkillFrontmatter(normalizedContent);
     const metadata = buildSkillMetadata(frontmatter);
-    const editorSnapshot = await this.createMarkdownEditorSnapshot(normalizedContent);
+    const editorSnapshot = await this.createSkillIndexEditorSnapshot(normalizedContent);
 
     if (normalizedContent !== index.content) {
       await this.documentService.trySaveCurrentDocumentHistory(index.documentId, 'llm_call');

--- a/src/server/services/skillManagement/frontmatter.test.ts
+++ b/src/server/services/skillManagement/frontmatter.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   normalizeSkillIndexContent,
   parseSkillFrontmatter,
+  tryGetSkillIndexBodyMarkdown,
   validateSkillName,
 } from './frontmatter';
 
@@ -110,5 +111,17 @@ describe('normalizeSkillIndexContent', () => {
         description: '   ',
       }),
     ).toThrow('Skill frontmatter description is required');
+  });
+});
+
+describe('tryGetSkillIndexBodyMarkdown', () => {
+  it('returns body Markdown only when the leading block is valid skill frontmatter', () => {
+    expect(
+      tryGetSkillIndexBodyMarkdown('---\nname: writer\ndescription: Writes docs\n---\n# Body'),
+    ).toBe('# Body');
+  });
+
+  it('does not strip raw Markdown that starts and ends with horizontal rules', () => {
+    expect(tryGetSkillIndexBodyMarkdown('---\n# Title\n---\nBody')).toBeUndefined();
   });
 });

--- a/src/server/services/skillManagement/frontmatter.ts
+++ b/src/server/services/skillManagement/frontmatter.ts
@@ -122,6 +122,16 @@ export const renderSkillIndexContent = (input: RenderSkillIndexContentInput): st
 };
 
 /**
+ * Returns the editable Markdown body from a canonical `SKILL.md` document.
+ *
+ * The raw SKILL.md content owns frontmatter as file metadata, while editorData stores only the
+ * rich-text body projection. Keeping that boundary here prevents YAML metadata from becoming
+ * visible editor content.
+ */
+export const getSkillIndexBodyMarkdown = (content: string): string =>
+  parseMatter(content).body.replace(/^\r?\n/, '');
+
+/**
  * Parses skill index frontmatter.
  *
  * Use when:

--- a/src/server/services/skillManagement/frontmatter.ts
+++ b/src/server/services/skillManagement/frontmatter.ts
@@ -131,6 +131,15 @@ export const renderSkillIndexContent = (input: RenderSkillIndexContentInput): st
 export const getSkillIndexBodyMarkdown = (content: string): string =>
   parseMatter(content).body.replace(/^\r?\n/, '');
 
+export const tryGetSkillIndexBodyMarkdown = (content: string): string | undefined => {
+  const normalizedContent = content.trimStart();
+  const match = normalizedContent.match(FRONTMATTER_BLOCK_PATTERN);
+
+  if (!match) return undefined;
+
+  return normalizedContent.slice(match[0].length).replace(/^\r?\n/, '');
+};
+
 /**
  * Parses skill index frontmatter.
  *

--- a/src/server/services/skillManagement/frontmatter.ts
+++ b/src/server/services/skillManagement/frontmatter.ts
@@ -34,6 +34,16 @@ export interface RenderSkillIndexContentInput {
   name: string;
 }
 
+/**
+ * Input required to replace only the editable body of a canonical managed skill index.
+ */
+export interface ReplaceSkillIndexBodyMarkdownInput {
+  /** Markdown body exported from editorData. */
+  bodyMarkdown: string;
+  /** Raw canonical SKILL.md content whose frontmatter must be preserved. */
+  content: string;
+}
+
 interface ParsedMatterResult {
   body: string;
   data: Record<string, unknown>;
@@ -91,6 +101,22 @@ const parseMatter = (content: string): ParsedMatterResult => {
   return { body: parsed.content, data: parsed.data };
 };
 
+const tryParseSkillMatter = (content: string): ParsedMatterResult | undefined => {
+  const normalizedContent = content.trimStart();
+
+  if (!FRONTMATTER_BLOCK_PATTERN.test(normalizedContent)) return undefined;
+
+  try {
+    const parsed = matter(normalizedContent);
+
+    readRequiredSkillFrontmatterFields(parsed.data);
+
+    return { body: parsed.content, data: parsed.data };
+  } catch {
+    return undefined;
+  }
+};
+
 /**
  * Renders skill index content from structured metadata and body Markdown.
  *
@@ -132,12 +158,23 @@ export const getSkillIndexBodyMarkdown = (content: string): string =>
   parseMatter(content).body.replace(/^\r?\n/, '');
 
 export const tryGetSkillIndexBodyMarkdown = (content: string): string | undefined => {
-  const normalizedContent = content.trimStart();
-  const match = normalizedContent.match(FRONTMATTER_BLOCK_PATTERN);
+  const parsed = tryParseSkillMatter(content);
 
-  if (!match) return undefined;
+  return parsed?.body.replace(/^\r?\n/, '');
+};
 
-  return normalizedContent.slice(match[0].length).replace(/^\r?\n/, '');
+export const replaceSkillIndexBodyMarkdown = (
+  input: ReplaceSkillIndexBodyMarkdownInput,
+): string => {
+  const { data } = parseMatter(input.content);
+  const frontmatter = readRequiredSkillFrontmatterFields(data);
+  const serialized = matter.stringify(input.bodyMarkdown, {
+    ...data,
+    description: frontmatter.description,
+    name: frontmatter.name,
+  });
+
+  return input.bodyMarkdown.endsWith('\n') ? serialized : serialized.replace(/\n$/, '');
 };
 
 /**
@@ -155,15 +192,8 @@ export const tryGetSkillIndexBodyMarkdown = (content: string): string | undefine
  */
 export const parseSkillFrontmatter = (content: string): SkillFrontmatter => {
   const { data } = parseMatter(content);
-  const { description, name } = readSkillFrontmatterFields(data);
 
-  if (!name) throw new Error('Skill frontmatter name is required');
-  if (!description) throw new Error('Skill frontmatter description is required');
-
-  return {
-    description: normalizeFrontmatterScalar(description, 'description'),
-    name: validateSkillName(name),
-  };
+  return readRequiredSkillFrontmatterFields(data);
 };
 
 /**
@@ -202,6 +232,18 @@ const readSkillFrontmatterFields = (data: Record<string, unknown>): Partial<Skil
   const description = typeof data.description === 'string' ? data.description.trim() : undefined;
 
   return { description, name };
+};
+
+const readRequiredSkillFrontmatterFields = (data: Record<string, unknown>): SkillFrontmatter => {
+  const { description, name } = readSkillFrontmatterFields(data);
+
+  if (!name) throw new Error('Skill frontmatter name is required');
+  if (!description) throw new Error('Skill frontmatter description is required');
+
+  return {
+    description: normalizeFrontmatterScalar(description, 'description'),
+    name: validateSkillName(name),
+  };
 };
 
 /**


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

- Keep managed `SKILL.md` `content` as the full Markdown file including YAML frontmatter.
- Generate `editorData` from the editable body projection only, so frontmatter metadata is not rendered again inside the document body.
- Apply the same body-only projection to Skill Management create/replace/rename flows and agent-skill VFS create/update flows.

Root cause: `editorData` was generated from the complete `SKILL.md` file, so YAML frontmatter was converted into rich-text editor nodes while the UI also rendered the same frontmatter as skill metadata.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run --silent='passed-only' src/server/services/skillManagement/SkillManagementDocumentService.test.ts
bunx vitest run --silent='passed-only' src/server/services/agentDocumentVfs/mounts/skills/providers/ProviderSkillsAgentDocument.test.ts
bunx vitest run --silent='passed-only' src/server/services/skillManagement/frontmatter.test.ts
bun run type-check
git diff --check
```

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

This intentionally does not migrate existing persisted `editorData`; it fixes new and subsequent skill writes only.