### PR TITLE
🐛 fix(agent): surface projectSkills regardless of activeDeviceId

### DIFF
--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -2079,22 +2079,36 @@ export class AiAgentService {
         name: skill.name,
       }));
 
-      // Project skills are filesystem SKILL.md discovered on the device. They
-      // are only meaningful when a device is active (readFile resolves against
-      // it). Only `location` (absolute SKILL.md path) flows through — the
-      // skill's directory tree is enumerated lazily at activation time via
-      // `local-system.listFiles` over the device gateway, keeping the op-param
-      // payload small.
+      // Project skills are filesystem SKILL.md discovered on the device. Their
+      // presence in `params.projectSkills` is itself proof that a client just
+      // scanned the working directory, so we surface them in
+      // `<available_skills>` unconditionally — decoupled from `activeDeviceId`
+      // (a routing decision for `LocalSystemManifest` injection that can
+      // legitimately be `undefined` for multi-device-no-bind or
+      // device-just-went-offline cases). Whether SKILL.md can actually be read
+      // at activation time is re-gated at the executor in
+      // `serverRuntimes/skills.ts` — there `deviceFileAccess` is only built
+      // when `activeDeviceId` resolves, and a missing reader naturally fails
+      // the `activateSkill` call rather than silently hiding the option.
+      // Only `location` (absolute SKILL.md path) flows through; the directory
+      // tree is enumerated lazily at activation time via
+      // `local-system.listFiles`, keeping the op-param payload small.
       const projectMetas =
-        activeDeviceId && params.projectSkills?.length
-          ? params.projectSkills.map((s) => ({
-              description: s.description ?? '',
-              identifier: `project:${s.name}`,
-              location: s.path,
-              name: s.name,
-              source: 'project' as const,
-            }))
-          : [];
+        params.projectSkills?.map((s) => ({
+          description: s.description ?? '',
+          identifier: `project:${s.name}`,
+          location: s.path,
+          name: s.name,
+          source: 'project' as const,
+        })) ?? [];
+
+      if (params.projectSkills?.length) {
+        log(
+          'execAgent: projectSkills merged: %d (activeDeviceId=%s)',
+          projectMetas.length,
+          activeDeviceId ?? 'none',
+        );
+      }
 
       // Precedence on name collision: project > db > agent-skills > builtin.
       // Agent-skills carry the `agent-skills:` prefix in their `name`, so they


### PR DESCRIPTION
## Summary

- `execAgent` was silently dropping client-provided `projectSkills` whenever `activeDeviceId` couldn't be resolved at op-create time. The client having scanned `.agents/skills` / `.claude/skills` and sent them is itself proof that a device is reachable — gating availability on a multi-device-routing decision conflated two concerns.
- Drop the `activeDeviceId` precondition so `projectSkills` always populate `<available_skills>`. Activation-time device availability stays gated at `serverRuntimes/skills.ts` (`deviceFileAccess` only built when `activeDeviceId` resolves), so a missing reader fails the `activateSkill` call instead of silently hiding the option.
- Add a one-line merge log so future "I sent skills but the model never sees them" investigations land on the answer.

## Why the previous gate was wrong

`activeDeviceId` (`src/server/services/aiAgent/index.ts:1196-1204`) resolves to `undefined` in several real situations where the requesting client is fully online:

- Multiple devices online + no bound device — auto-bind refuses to guess.
- Bound device offline — explicit choice is respected, no fallback.
- `params.disableTools = true` — entire device-discovery `else` block skipped.
- `DEVICE_GATEWAY_URL` not configured — `gatewayConfigured = false`, `onlineDevices = []`.

In all of these, the client just scanned `.agents/skills` and shipped them up; dropping them at merge time is a silent footgun.

## Test plan

- [x] Existing `src/server/services/aiAgent/__tests__/execAgent.*` suites pass (102/102).
- [ ] Manual: with a topic where `params.projectSkills` is populated and `activeDeviceId` is undefined (e.g. multi-device unbind), confirm `<available_skills>` contains the `project:<name>` entries and the merge log line fires.
- [ ] Manual: `activateSkill('project:<name>')` when no `activeDeviceId` resolves should fail loudly at executor time (not hang or silently skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)