### PR TITLE
🐛 fix(image): explain text-only image responses

### DIFF
--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -20,7 +20,7 @@ export { LobeCometAPIAI } from './providers/cometapi';
 export { LobeComfyUI } from './providers/comfyui';
 export { LobeDeepSeekAI } from './providers/deepseek';
 export { LobeGLMCodingPlanAI } from './providers/glmCodingPlan';
-export { LobeGoogleAI } from './providers/google';
+export { GOOGLE_IMAGE_TEXT_ONLY_RESPONSE_MESSAGE, LobeGoogleAI } from './providers/google';
 export { LobeGroq } from './providers/groq';
 export { LobeKimiCodingPlanAI } from './providers/kimiCodingPlan';
 export { LobeHubAI } from './providers/lobehub';

--- a/packages/model-runtime/src/providers/google/createImage.test.ts
+++ b/packages/model-runtime/src/providers/google/createImage.test.ts
@@ -5,7 +5,7 @@ import * as imageToBase64Module from '@lobechat/utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { CreateImagePayload } from '../../types/image';
-import { createGoogleImage } from './createImage';
+import { createGoogleImage, GOOGLE_IMAGE_TEXT_ONLY_RESPONSE_MESSAGE } from './createImage';
 
 const provider = 'google';
 const bizErrorType = 'ProviderBizError';
@@ -949,6 +949,61 @@ describe('createGoogleImage', () => {
           responseId: 'response-1',
         });
         expect(JSON.stringify(error)).not.toContain('I can describe the image');
+      });
+
+      it('should explain text-only image responses as non-generation prompts', async () => {
+        // Arrange
+        const mockContentResponse = {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    text: 'The uploaded image shows a cartoon portrait.',
+                  },
+                ],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+          modelVersion: 'gemini-3-pro-image-preview',
+          responseId: 'text-only-response',
+        };
+        vi.spyOn(mockClient.models, 'generateContent').mockResolvedValue(
+          mockContentResponse as any,
+        );
+
+        const payload: CreateImagePayload = {
+          model: 'gemini-3-pro-image-preview:image',
+          params: {
+            imageUrl: 'data:image/png;base64,abc123',
+            prompt: 'Explain this image',
+          },
+        };
+
+        // Act
+        let error: any;
+        try {
+          await createGoogleImage(mockClient, provider, payload);
+        } catch (e) {
+          error = e;
+        }
+
+        // Assert
+        expect(error).toMatchObject({
+          error: { message: GOOGLE_IMAGE_TEXT_ONLY_RESPONSE_MESSAGE },
+          errorType: noImageErrorType,
+          provider,
+        });
+        expect(error.providerResponse).toMatchObject({
+          candidates: [
+            {
+              finishReason: 'STOP',
+            },
+          ],
+          responseId: 'text-only-response',
+        });
+        expect(JSON.stringify(error)).not.toContain('cartoon portrait');
       });
 
       it('should preserve Google image safety finish reasons without provider policy classification', async () => {

--- a/packages/model-runtime/src/providers/google/createImage.test.ts
+++ b/packages/model-runtime/src/providers/google/createImage.test.ts
@@ -1006,6 +1006,59 @@ describe('createGoogleImage', () => {
         expect(JSON.stringify(error)).not.toContain('cartoon portrait');
       });
 
+      it('should keep moderation wording for text-only safety refusals', async () => {
+        // Arrange
+        const mockContentResponse = {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    text: "Sorry, I can't generate that image because it may violate safety policies.",
+                  },
+                ],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+          responseId: 'text-refusal-response',
+        };
+        vi.spyOn(mockClient.models, 'generateContent').mockResolvedValue(
+          mockContentResponse as any,
+        );
+
+        const payload: CreateImagePayload = {
+          model: 'gemini-3-pro-image-preview:image',
+          params: {
+            prompt: 'Generate unsafe content',
+          },
+        };
+
+        // Act
+        let error: any;
+        try {
+          await createGoogleImage(mockClient, provider, payload);
+        } catch (e) {
+          error = e;
+        }
+
+        // Assert
+        expect(error).toMatchObject({
+          error: { message: 'No image data found in response' },
+          errorType: noImageErrorType,
+          provider,
+        });
+        expect(error.error.message).not.toBe(GOOGLE_IMAGE_TEXT_ONLY_RESPONSE_MESSAGE);
+        expect(error.providerResponse).toMatchObject({
+          candidates: [
+            {
+              finishReason: 'STOP',
+            },
+          ],
+          responseId: 'text-refusal-response',
+        });
+      });
+
       it('should preserve Google image safety finish reasons without provider policy classification', async () => {
         // Arrange
         const mockContentResponse = {

--- a/packages/model-runtime/src/providers/google/createImage.test.ts
+++ b/packages/model-runtime/src/providers/google/createImage.test.ts
@@ -1006,7 +1006,7 @@ describe('createGoogleImage', () => {
         expect(JSON.stringify(error)).not.toContain('cartoon portrait');
       });
 
-      it('should keep moderation wording for text-only safety refusals', async () => {
+      it('should keep text-only guidance safe for policy refusals', async () => {
         // Arrange
         const mockContentResponse = {
           candidates: [
@@ -1044,11 +1044,11 @@ describe('createGoogleImage', () => {
 
         // Assert
         expect(error).toMatchObject({
-          error: { message: 'No image data found in response' },
+          error: { message: GOOGLE_IMAGE_TEXT_ONLY_RESPONSE_MESSAGE },
           errorType: noImageErrorType,
           provider,
         });
-        expect(error.error.message).not.toBe(GOOGLE_IMAGE_TEXT_ONLY_RESPONSE_MESSAGE);
+        expect(error.error.message).toContain('try a safer prompt');
         expect(error.providerResponse).toMatchObject({
           candidates: [
             {

--- a/packages/model-runtime/src/providers/google/createImage.ts
+++ b/packages/model-runtime/src/providers/google/createImage.ts
@@ -17,6 +17,11 @@ import { parseDataUri } from '../../utils/uriParser';
 // Maximum number of images allowed for processing
 const MAX_IMAGE_COUNT = 10;
 
+export const GOOGLE_IMAGE_TEXT_ONLY_RESPONSE_MESSAGE = [
+  'The model returned text instead of an image.',
+  'Ask it to generate or edit an image instead of describing or analyzing one.',
+].join(' ');
+
 interface ErrorWithRawProviderResponse extends Error {
   providerResponse?: GenerateContentResponse;
 }
@@ -95,6 +100,13 @@ function extractImageFromResponse(response: GenerateContentResponse): CreateImag
       const imageUrl = `data:${part.inlineData.mimeType || 'image/png'};base64,${part.inlineData.data}`;
       return { imageUrl };
     }
+  }
+
+  if (
+    candidate.finishReason === 'STOP' &&
+    candidate.content.parts.some((part) => Boolean(part.text?.trim()))
+  ) {
+    throw createGoogleImageNoImageError(GOOGLE_IMAGE_TEXT_ONLY_RESPONSE_MESSAGE, response);
   }
 
   // Fallback when no inlineData is present (commonly moderation or policy blocks)

--- a/packages/model-runtime/src/providers/google/createImage.ts
+++ b/packages/model-runtime/src/providers/google/createImage.ts
@@ -19,25 +19,8 @@ const MAX_IMAGE_COUNT = 10;
 
 export const GOOGLE_IMAGE_TEXT_ONLY_RESPONSE_MESSAGE = [
   'The model returned text instead of an image.',
-  'Ask it to generate or edit an image instead of describing or analyzing one.',
+  'Ask it to generate or edit an image, or try a safer prompt if the request may have been blocked.',
 ].join(' ');
-
-const GOOGLE_IMAGE_TEXT_REFUSAL_MARKERS = [
-  "can't",
-  'cannot',
-  'harmful',
-  'inappropriate',
-  'not able',
-  'not allowed',
-  'policy',
-  'safety',
-  'sorry',
-  'unable',
-  'unsafe',
-  'violate',
-  'violates',
-  "won't",
-];
 
 interface ErrorWithRawProviderResponse extends Error {
   providerResponse?: GenerateContentResponse;
@@ -72,12 +55,6 @@ const getTextFromParts = (parts: Part[]) =>
     .map((part) => part.text?.trim())
     .filter(Boolean)
     .join('\n');
-
-const isTextOnlyImageRefusal = (parts: Part[]) => {
-  const text = getTextFromParts(parts).toLowerCase();
-
-  return GOOGLE_IMAGE_TEXT_REFUSAL_MARKERS.some((marker) => text.includes(marker));
-};
 
 /**
  * Process a single image URL and convert it to Google AI Part format
@@ -131,11 +108,7 @@ function extractImageFromResponse(response: GenerateContentResponse): CreateImag
     }
   }
 
-  if (
-    candidate.finishReason === 'STOP' &&
-    getTextFromParts(candidate.content.parts) &&
-    !isTextOnlyImageRefusal(candidate.content.parts)
-  ) {
+  if (candidate.finishReason === 'STOP' && getTextFromParts(candidate.content.parts)) {
     throw createGoogleImageNoImageError(GOOGLE_IMAGE_TEXT_ONLY_RESPONSE_MESSAGE, response);
   }
 

--- a/packages/model-runtime/src/providers/google/createImage.ts
+++ b/packages/model-runtime/src/providers/google/createImage.ts
@@ -22,6 +22,23 @@ export const GOOGLE_IMAGE_TEXT_ONLY_RESPONSE_MESSAGE = [
   'Ask it to generate or edit an image instead of describing or analyzing one.',
 ].join(' ');
 
+const GOOGLE_IMAGE_TEXT_REFUSAL_MARKERS = [
+  "can't",
+  'cannot',
+  'harmful',
+  'inappropriate',
+  'not able',
+  'not allowed',
+  'policy',
+  'safety',
+  'sorry',
+  'unable',
+  'unsafe',
+  'violate',
+  'violates',
+  "won't",
+];
+
 interface ErrorWithRawProviderResponse extends Error {
   providerResponse?: GenerateContentResponse;
 }
@@ -49,6 +66,18 @@ const createGoogleImageNoImageError = (
     new Error(message),
     response,
   ) as ErrorWithRawProviderResponse;
+
+const getTextFromParts = (parts: Part[]) =>
+  parts
+    .map((part) => part.text?.trim())
+    .filter(Boolean)
+    .join('\n');
+
+const isTextOnlyImageRefusal = (parts: Part[]) => {
+  const text = getTextFromParts(parts).toLowerCase();
+
+  return GOOGLE_IMAGE_TEXT_REFUSAL_MARKERS.some((marker) => text.includes(marker));
+};
 
 /**
  * Process a single image URL and convert it to Google AI Part format
@@ -104,7 +133,8 @@ function extractImageFromResponse(response: GenerateContentResponse): CreateImag
 
   if (
     candidate.finishReason === 'STOP' &&
-    candidate.content.parts.some((part) => Boolean(part.text?.trim()))
+    getTextFromParts(candidate.content.parts) &&
+    !isTextOnlyImageRefusal(candidate.content.parts)
   ) {
     throw createGoogleImageNoImageError(GOOGLE_IMAGE_TEXT_ONLY_RESPONSE_MESSAGE, response);
   }

--- a/packages/model-runtime/src/providers/google/index.ts
+++ b/packages/model-runtime/src/providers/google/index.ts
@@ -31,6 +31,8 @@ import { createGoogleVideo, pollGoogleVideoOperation } from './createVideo';
 import { createGoogleGenerateObject, createGoogleGenerateObjectWithTools } from './generateObject';
 import { resolveGoogleThinkingConfig } from './thinkingResolver';
 
+export { GOOGLE_IMAGE_TEXT_ONLY_RESPONSE_MESSAGE } from './createImage';
+
 const log = debug('model-runtime:google');
 
 const modelsOffSafetySettings = new Set(['gemini-2.0-flash-exp']);

--- a/packages/model-runtime/src/utils/googleErrorParser.test.ts
+++ b/packages/model-runtime/src/utils/googleErrorParser.test.ts
@@ -210,6 +210,15 @@ describe('googleErrorParser', () => {
       expect(result.error.message).toBe(input);
     });
 
+    it('should classify text-only image response messages as no-image errors', () => {
+      const input =
+        'The model returned text instead of an image. Try an image generation instruction.';
+      const result = parseGoogleErrorMessage(input);
+
+      expect(result.errorType).toBe(AgentRuntimeErrorType.ProviderNoImageGenerated);
+      expect(result.error.message).toBe(input);
+    });
+
     it('should handle status JSON format', () => {
       const input =
         'got status: UNAVAILABLE. {"error":{"code":503,"message":"Service temporarily unavailable","status":"UNAVAILABLE"}}';

--- a/packages/model-runtime/src/utils/googleErrorParser.ts
+++ b/packages/model-runtime/src/utils/googleErrorParser.ts
@@ -108,7 +108,11 @@ export function parseGoogleErrorMessage(message: string): ParsedError {
   }
 
   const lowerMessage = message.toLowerCase();
-  if (lowerMessage.includes('no image generated') || lowerMessage.includes('no image data')) {
+  if (
+    lowerMessage.includes('no image generated') ||
+    lowerMessage.includes('no image data') ||
+    lowerMessage.includes('returned text instead of an image')
+  ) {
     return { error: { message }, errorType: AgentRuntimeErrorType.ProviderNoImageGenerated };
   }
 

--- a/src/server/routers/async/image.ts
+++ b/src/server/routers/async/image.ts
@@ -4,7 +4,10 @@ import {
   buildMappedBusinessModelFields,
   resolveBusinessModelMapping,
 } from '@lobechat/business-model-runtime';
-import { AgentRuntimeErrorType } from '@lobechat/model-runtime';
+import {
+  AgentRuntimeErrorType,
+  GOOGLE_IMAGE_TEXT_ONLY_RESPONSE_MESSAGE,
+} from '@lobechat/model-runtime';
 import {
   AsyncTaskError,
   AsyncTaskErrorType,
@@ -34,6 +37,16 @@ import { getContentPolicyErrorMessage } from './contentPolicyError';
 const log = debug('lobe-image:async');
 
 const IMAGE_URL_PREVIEW_LENGTH = 100;
+const IMAGE_EDITING_NO_IMAGE_MESSAGE = [
+  'The provider did not return an image.',
+  'This may be due to content review.',
+  'Try a safer source image or a milder prompt.',
+].join(' ');
+const IMAGE_GENERATION_NO_IMAGE_MESSAGE = [
+  'The provider did not return an image.',
+  'This may be due to content review.',
+  'Try a milder prompt or another model.',
+].join(' ');
 
 const imageProcedure = asyncAuthedProcedure.use(async (opts) => {
   const { ctx } = opts;
@@ -159,10 +172,22 @@ const categorizeError = (
   }
 
   if (error.errorType === AgentRuntimeErrorType.ProviderNoImageGenerated) {
+    const providerErrorMessage = error.error?.message || error.message;
+
+    if (
+      typeof providerErrorMessage === 'string' &&
+      providerErrorMessage.includes(GOOGLE_IMAGE_TEXT_ONLY_RESPONSE_MESSAGE)
+    ) {
+      return {
+        errorMessage: providerErrorMessage,
+        errorType: AsyncTaskErrorType.ServerError,
+      };
+    }
+
     return {
       errorMessage: isEditingImage
-        ? 'Provider returned no image (maybe content review). Try a safer source image or milder prompt.'
-        : 'Provider returned no image (maybe content review). Try a milder prompt or another model.',
+        ? IMAGE_EDITING_NO_IMAGE_MESSAGE
+        : IMAGE_GENERATION_NO_IMAGE_MESSAGE,
       errorType: AsyncTaskErrorType.ServerError,
     };
   }


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - reported from trace `f0702dc1c6f2bdb88d36477729ad76c4`.

#### 🔀 Description of Change

- Detect Google image responses that return text-only content instead of image data.
- Surface a user-facing message that explains what happened and how to adjust the prompt.
- Keep no-image moderation fallbacks actionable for generation and editing flows.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd lobehub/packages/model-runtime
bunx vitest run --silent='passed-only' 'src/providers/google/createImage.test.ts' 'src/utils/googleErrorParser.test.ts'
```

#### 📸 Screenshots / Videos

N/A - error message behavior only.

#### 📝 Additional Information

Security review: no cloud-specific business logic is added to the open-source submodule.