### PR TITLE
chore: clean up LOBE-XXX code annotations (2026-05-25)

### DIFF
--- a/src/features/Conversation/store/slices/data/action.ts
+++ b/src/features/Conversation/store/slices/data/action.ts
@@ -217,7 +217,7 @@ export const dataSlice: StateCreator<
           if (!data) return;
           if (!context.topicId) return;
 
-          // Defense-in-depth gate (LOBE-9501): drop any SWR onData while the
+          // Defense-in-depth gate: drop any SWR onData while the
           // topic is streaming. DB fan-out for chunk writes is async and lags
           // the WS push by anywhere from 100ms to several seconds; an SWR
           // refetch that lands inside that window returns the assistant row

--- a/src/server/modules/AgentRuntime/AgentRuntimeCoordinator.ts
+++ b/src/server/modules/AgentRuntime/AgentRuntimeCoordinator.ts
@@ -114,12 +114,12 @@ export class AgentRuntimeCoordinator {
    * save. Errors are logged and surfaced to the client as a missing field,
    * which falls back to the legacy refresh path.
    *
-   * LOBE-9523: skip the resolve entirely when the run is moving into
+   * Skip the resolve entirely when the run is moving into
    * `interrupted`. The executor's per-step finalize at line 1078 of
    * RuntimeExecutors only runs on the success path, so a mid-stream cancel
    * leaves the assistant row as the LOADING_FLAT placeholder. Pushing that
    * placeholder as SoT would clobber the client's in-memory streamed
-   * content. The executor's catch-block partial-finalize (LOBE-9523 fix #1)
+   * content. The executor's catch-block partial-finalize
    * writes the real partial content asynchronously, but that update may
    * not be durable by the time we publish — leaving the field undefined
    * lets the client preserve its in-memory state (`gatewayEventHandler.ts`

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -1196,7 +1196,7 @@ export const createRuntimeExecutors = (
             continue;
           }
 
-          // LOBE-9523: cancel/interrupt path — the model-runtime stream was aborted
+          // Cancel/interrupt path — the model-runtime stream was aborted
           // before reaching the post-stream finalize at line 1078, so the DB row is
           // still the LOADING_FLAT placeholder. Persist whatever partial content the
           // `onText` / `onThinking` / `onToolsCalling` callbacks already accumulated

--- a/src/server/modules/AgentRuntime/__tests__/AgentRuntimeCoordinator.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/AgentRuntimeCoordinator.test.ts
@@ -506,12 +506,12 @@ describe('AgentRuntimeCoordinator', () => {
       });
     });
 
-    // LOBE-9523: cancel/interrupt path leaves the streaming assistant row
+    // Cancel/interrupt path leaves the streaming assistant row
     // at the LOADING_FLAT placeholder until the executor's partial-finalize
     // catch writes the accumulated content asynchronously. Publishing a
     // pre-finalize snapshot would clobber the client's in-memory streamed
     // content, so the resolver is skipped entirely for status='interrupted'.
-    it('skips uiMessages on saveAgentState when status=interrupted (LOBE-9523)', async () => {
+    it('skips uiMessages on saveAgentState when status=interrupted', async () => {
       const resolver = vi.fn().mockResolvedValue([{ id: 'placeholder', role: 'assistant' }]);
       const coordinatorWithResolver = new AgentRuntimeCoordinator({
         stateManager: mockStateManager,
@@ -537,7 +537,7 @@ describe('AgentRuntimeCoordinator', () => {
       });
     });
 
-    it('skips uiMessages on saveStepResult when stepResult.newState.status=interrupted (LOBE-9523)', async () => {
+    it('skips uiMessages on saveStepResult when stepResult.newState.status=interrupted', async () => {
       const resolver = vi.fn().mockResolvedValue([{ id: 'placeholder', role: 'assistant' }]);
       const coordinatorWithResolver = new AgentRuntimeCoordinator({
         stateManager: mockStateManager,

--- a/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -1378,14 +1378,14 @@ describe('RuntimeExecutors', () => {
       });
     });
 
-    // LOBE-9523: cancel/interrupt mid-stream — the model-runtime call is
+    // Cancel/interrupt mid-stream — the model-runtime call is
     // aborted before the post-stream finalize at line 1078, so the DB row
     // would normally stay at LOADING_FLAT placeholder. The executor's
     // inner catch must persist whatever partial content the streaming
     // callbacks already accumulated so (a) reload doesn't lose the user's
     // streamed answer and (b) any later uiMessages snapshot reflects real
     // content instead of placeholder.
-    describe('interrupted mid-stream partial finalize (LOBE-9523)', () => {
+    describe('interrupted mid-stream partial finalize', () => {
       it('persists accumulated content + reasoning when stream throws and operation is interrupted', async () => {
         const mockChat = vi.fn().mockImplementation(async (_payload, options) => {
           await options?.callback?.onText?.('Hello, this is a partial ');

--- a/src/server/modules/Mecha/AgentToolsEngine/index.ts
+++ b/src/server/modules/Mecha/AgentToolsEngine/index.ts
@@ -140,7 +140,7 @@ export const createServerAgentToolsEngine = (
   // run on a device registered with the device-gateway. Desktop, CLI, and
   // bot/IM callers all converge on this single path; the previous Phase 6.4
   // `clientRuntime === 'desktop'` short-circuit (Agent Gateway WS dispatch
-  // back to the caller) is removed — see LOBE-9378.
+  // back to the caller) is removed.
   const hasDeviceProxy = !!deviceContext?.gatewayConfigured;
 
   // Platform key is used only to look up the user's per-platform

--- a/src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
@@ -358,7 +358,7 @@ describe('AiAgentService.execAgent - device tool pipeline ()', () => {
     it('keeps executor unset for local-system when DEVICE_GATEWAY is configured', async () => {
       // Desktop, web, and IM callers all share this path: tools route via the
       // Remote Device proxy to the device registered with the gateway, never
-      // back to the caller. (LOBE-9378: the Phase 6.4 clientRuntime=desktop
+      // back to the caller. (The Phase 6.4 clientRuntime=desktop
       // short-circuit that bypassed this gate was removed.)
       const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
       vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(true);

--- a/src/store/chat/slices/aiAgent/actions/__tests__/runAgent.test.ts
+++ b/src/store/chat/slices/aiAgent/actions/__tests__/runAgent.test.ts
@@ -490,7 +490,7 @@ describe('runAgent actions', () => {
 
     describe('step_complete event', () => {
       // The previous DB-refetch on tool_execution was the source of the
-      // assistantGroup-clobber regression (LOBE-9501) — tool results are
+      // assistantGroup-clobber regression — tool results are
       // now reconciled via the next step_start's uiMessages snapshot.
       it('does NOT refreshMessages on tool_execution phase', async () => {
         const { result } = renderHook(() => useChatStore());

--- a/src/store/chat/slices/aiAgent/actions/runAgent.ts
+++ b/src/store/chat/slices/aiAgent/actions/runAgent.ts
@@ -326,7 +326,7 @@ export class AgentActionImpl {
           // Tool results are reconciled via the canonical uiMessages
           // snapshot the server pushes on the next step_start; no need
           // to refetch from DB here (the refetch was the source of the
-          // assistantGroup-clobber regression that LOBE-9501 fixes).
+          // assistantGroup-clobber regression.
         } else if (phase === 'execution_complete' && finalState) {
           // Agent execution complete
           log(`Agent execution completed for ${assistantId}:`, finalState);

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -82,7 +82,7 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('stream_start', () => {
-    it('should associate new message with operation and skip the DB refetch (LOBE-9501)', async () => {
+    it('should associate new message with operation and skip the DB refetch', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
@@ -655,7 +655,7 @@ describe('createGatewayEventHandler', () => {
       );
     });
 
-    // LOBE-9523: MID-stream cancel. The server-side coordinator skips the
+    // MID-stream cancel. The server-side coordinator skips the
     // uiMessages snapshot when state.status='interrupted' to avoid pushing
     // a LOADING_FLAT placeholder. The client must mirror that intent: when
     // `reason='interrupted'` arrives without uiMessages AND we already have
@@ -663,7 +663,7 @@ describe('createGatewayEventHandler', () => {
     // the executor's partial-finalize catch is still racing to write the
     // real content, and a fetch here would return placeholder and clobber
     // in-memory streamed content.
-    it('should NOT refetch from DB when reason=interrupted AND stream had progressed (LOBE-9523)', async () => {
+    it('should NOT refetch from DB when reason=interrupted AND stream had progressed', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
@@ -689,7 +689,7 @@ describe('createGatewayEventHandler', () => {
     // state and they need the DB refetch to be reconciled with the
     // server-side rows. Skipping the fallback would leave the tmp_*
     // ids stuck in the store indefinitely.
-    it('should refetch from DB when reason=interrupted but stream never progressed (LOBE-9523 reviewer fix)', async () => {
+    it('should refetch from DB when reason=interrupted but stream never progressed', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
@@ -921,7 +921,7 @@ describe('createGatewayEventHandler', () => {
   describe('sequential processing', () => {
     it('should dispatch stream_chunk to the new assistant id after stream_start switches it', async () => {
       // Native gateway streams no longer await a DB fetch on stream_start
-      // (LOBE-9501) — but stream_chunk must still queue behind stream_start
+      // — but stream_chunk must still queue behind stream_start
       // so the chunk targets the NEW assistant id (from stream_start.data),
       // not the previous one.
       const store = createMockStore();
@@ -1007,7 +1007,7 @@ describe('createGatewayEventHandler', () => {
 
       // Step 2: Next LLM call with new assistant message — native stream_start
       // carries the id directly, so it must NOT trigger a DB refetch
-      // (LOBE-9501). Only the association switch happens.
+      // Only the association switch happens.
       vi.clearAllMocks();
       handler(makeEvent('stream_start', { assistantMessage: { id: 'msg-2' } }));
       await flush();

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -219,7 +219,7 @@ export const createGatewayEventHandler = (
   let accumulatedContent = '';
   let accumulatedReasoning = '';
 
-  // LOBE-9523: tracks whether any server-confirmed state has actually arrived
+  // Tracks whether any server-confirmed state has actually arrived
   // (server-assigned assistant id, streamed text/reasoning/tools, or a SoT
   // uiMessages snapshot). Used by `agent_runtime_end` to decide between
   // preserving in-memory streamed content (when interrupted MID-stream) vs.
@@ -298,7 +298,7 @@ export const createGatewayEventHandler = (
           // `step_start` already carried the SoT uiMessages snapshot, so
           // chunks have a valid target in `dbMessagesMap` already. Removing
           // the await here is what un-blocks the enqueue chain so live
-          // chunks can land mid-stream (LOBE-9501).
+          // chunks can land mid-stream.
           //
           // Hetero CLI adapters (Claude Code / Codex) never set
           // `assistantMessage.id` on stream_start, so the DB read stays
@@ -444,7 +444,7 @@ export const createGatewayEventHandler = (
         // step boundary (agent-runtime #15152). Use it as Source of Truth
         // instead of issuing a DB refetch — the refetch returns a stale
         // assistant placeholder while DB fan-out is still in flight, which
-        // clobbers the in-memory streamed assistantGroup (LOBE-9501).
+        // clobbers the in-memory streamed assistantGroup.
         if (Array.isArray(data?.uiMessages)) {
           get().replaceMessages(data.uiMessages, { action: 'gateway/step_start', context });
         }
@@ -552,7 +552,7 @@ export const createGatewayEventHandler = (
               context,
             });
           } else if (data?.reason === 'interrupted' && hasStreamedContent) {
-            // LOBE-9523: MID-stream cancel. The server's
+            // MID-stream cancel. The server's
             // `AgentRuntimeCoordinator.resolveUiMessages` omits uiMessages
             // for status='interrupted' precisely so we can preserve the
             // in-memory streamed content here. The executor's partial-


### PR DESCRIPTION
## Summary

Daily automated cleanup of `LOBE-XXX` issue ID annotations from source code. All three referenced issues (LOBE-9501, LOBE-9523, LOBE-9378) are already resolved and closed — the annotations were historical markers no longer needed in the open-source codebase.

## Changes

Removed `LOBE-XXX` tokens from comments and test names across 11 files, preserving all descriptive context:

| Issue | Context | Files |
|-------|---------|-------|
| LOBE-9501 | Gateway pushes UIChatMessage snapshot as SoT at step boundaries to prevent assistantGroup clobber | `action.ts`, `gatewayEventHandler.ts` (3), `runAgent.ts`, + tests |
| LOBE-9523 | Mid-stream cancel fix — skip uiMessages for interrupted status; partial-finalize in executor catch | `AgentRuntimeCoordinator.ts` (2), `RuntimeExecutors.ts`, `gatewayEventHandler.ts` (2), + tests |
| LOBE-9378 | Local-system template variable injection — unified activeDeviceId resolution | `AgentToolsEngine/index.ts`, + test |

## Files changed

```
 src/features/Conversation/store/slices/data/action.ts
 src/server/modules/AgentRuntime/AgentRuntimeCoordinator.ts
 src/server/modules/AgentRuntime/RuntimeExecutors.ts
 src/server/modules/AgentRuntime/__tests__/AgentRuntimeCoordinator.test.ts
 src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
 src/server/modules/Mecha/AgentToolsEngine/index.ts
 src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
 src/store/chat/slices/aiAgent/actions/runAgent.ts
 src/store/chat/slices/aiAgent/actions/__tests__/runAgent.test.ts
 src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
 src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
```

## Verification

- ✅ No remaining `LOBE-XXX` tokens in source files (grep confirmed)
- ✅ All descriptive comments preserved — only issue IDs removed
- ✅ No behavior changes
- ✅ The `/LOBE-\d+/g` regex in `WelcomeText/index.tsx` left untouched (functional code, not an annotation)

---

*Automated by LobeHub daily annotation cleanup workflow*