### PR TITLE
🐛 fix(agent-runtime): strip heavy fields off finalState in stream events

### DIFF
--- a/src/server/modules/AgentRuntime/GatewayStreamNotifier.ts
+++ b/src/server/modules/AgentRuntime/GatewayStreamNotifier.ts
@@ -6,6 +6,7 @@ import {
   getDefaultReasonDetail,
   type StreamChunkData,
   type StreamEvent,
+  stripFinalStateInEventData,
 } from './StreamEventManager';
 import type { IStreamEventManager, PublishAgentRuntimeEndParams } from './types';
 
@@ -147,7 +148,18 @@ export class GatewayStreamNotifier implements IStreamEventManager {
   // ─── Gateway HTTP helpers ───
 
   private pushEvent(operationId: string, event: Record<string, unknown>) {
-    this.httpPost('/api/operations/push-event', { event, operationId }).catch(() => {});
+    // Mirror the Redis publisher's chokepoint — strip
+    // `finalState.messages` + tool-set fields off the gateway WS push
+    // payload too. The gateway forwards events verbatim to clients, and
+    // downstream consumers don't read these fields, so carrying them
+    // would re-introduce the same multi-megabyte serialization that
+    // crashed the xadd path.
+    const sanitizedEvent =
+      event.data === undefined ? event : { ...event, data: stripFinalStateInEventData(event.data) };
+    this.httpPost('/api/operations/push-event', {
+      event: sanitizedEvent,
+      operationId,
+    }).catch(() => {});
   }
 
   /**

--- a/src/server/modules/AgentRuntime/InMemoryStreamEventManager.ts
+++ b/src/server/modules/AgentRuntime/InMemoryStreamEventManager.ts
@@ -1,6 +1,10 @@
 import debug from 'debug';
 
-import { type StreamChunkData, type StreamEvent } from './StreamEventManager';
+import {
+  type StreamChunkData,
+  type StreamEvent,
+  stripFinalStateInEventData,
+} from './StreamEventManager';
 import { type IStreamEventManager, type PublishAgentRuntimeEndParams } from './types';
 
 const log = debug('lobe-server:agent-runtime:in-memory-stream-event-manager');
@@ -41,6 +45,11 @@ export class InMemoryStreamEventManager implements IStreamEventManager {
 
     const eventData: StreamEvent = {
       ...event,
+      // Mirror the Redis-backed manager's chokepoint strip so in-memory
+      // event shape stays identical to the production wire format —
+      // tests run against this manager and would otherwise mask
+      // regressions in the strip behaviour.
+      data: stripFinalStateInEventData(event.data),
       id: eventId,
       operationId,
       timestamp: Date.now(),
@@ -105,6 +114,7 @@ export class InMemoryStreamEventManager implements IStreamEventManager {
     reasonDetail,
     uiMessages,
   }: PublishAgentRuntimeEndParams): Promise<string> {
+    // Strip happens centrally inside `publishStreamEvent`.
     return this.publishStreamEvent(operationId, {
       data: {
         finalState,

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -2778,7 +2778,9 @@ export const createRuntimeExecutors = (
       }
     }
 
-    // Publish execution complete event
+    // Publish execution complete event. `finalState.messages` + tool-set
+    // fields are stripped centrally inside `publishStreamEvent` so this
+    // call site stays unaware.
     await streamManager.publishStreamEvent(operationId, {
       data: {
         finalState: { ...state, status: 'done' },
@@ -3087,7 +3089,8 @@ export const createRuntimeExecutors = (
     newState.lastModified = new Date().toISOString();
     newState.status = 'done';
 
-    // Publish completion event
+    // Publish completion event. finalState stripped centrally inside
+    // `publishStreamEvent`.
     await streamManager.publishStreamEvent(operationId, {
       data: {
         finalState: newState,

--- a/src/server/modules/AgentRuntime/StreamEventManager.ts
+++ b/src/server/modules/AgentRuntime/StreamEventManager.ts
@@ -41,6 +41,61 @@ export const getDefaultReasonDetail = (finalState: any, reason?: string): string
 };
 
 /**
+ * Drop reconstructible / heavy fields from an `AgentState` before
+ * serializing it into a Redis stream event. `messages` is the size
+ * driver — long topics with `compressedGroup` envelopes can push a
+ * single `xadd` past Upstash's 10 MB request limit, manifesting on
+ * the gateway as a misleading watchdog "Operation idle" timeout.
+ *
+ * The dropped fields are all reconstructible:
+ *
+ * - `messages` — canonical copy lives in the DB (UIChatMessage rows)
+ *   and the runtime in-memory state; in-process consumers that need
+ *   it (e.g. `execSubAgentTask.onComplete`) receive the full state
+ *   via the local `HookContext` channel, not via the stream.
+ * - `operationToolSet`, `toolManifestMap`, `toolSourceMap`, `tools`
+ *   — operation-level snapshot; back-compat copies of one struct.
+ *
+ * Mirrors the `done`-event strip in `OperationTraceRecorder.appendStep`;
+ * keep the two lists in sync if either set changes.
+ */
+const stripStateForStream = <T extends Record<string, any>>(
+  state: T | undefined,
+): T | undefined => {
+  if (!state) return state;
+  const {
+    messages: _messages,
+    operationToolSet: _operationToolSet,
+    toolManifestMap: _toolManifestMap,
+    toolSourceMap: _toolSourceMap,
+    tools: _tools,
+    ...rest
+  } = state;
+  return rest as T;
+};
+
+/**
+ * Chokepoint helper applied inside every stream-event publish site.
+ * If the event `data` carries a `finalState`, strip `messages` + the
+ * tool-set group off it (see `stripStateForStream` for the rationale).
+ *
+ * Centralizing the strip here means new callers — including direct
+ * `publishStreamEvent` users (e.g. `RuntimeExecutors`, the per-step
+ * publish in `AgentRuntimeService.executeStep`) — get the size
+ * protection automatically, with no per-site bookkeeping.
+ *
+ * Returns the original reference when no stripping is needed so the
+ * common path stays allocation-free.
+ */
+export const stripFinalStateInEventData = (data: unknown): unknown => {
+  if (!data || typeof data !== 'object') return data;
+  const record = data as Record<string, unknown>;
+  const finalState = record.finalState;
+  if (!finalState || typeof finalState !== 'object') return data;
+  return { ...record, finalState: stripStateForStream(finalState as Record<string, any>) };
+};
+
+/**
  * Server-side stream event shape. Wire-compatible with `AgentStreamEvent` in
  * `@lobechat/agent-gateway-client` (the type union is the single source of
  * truth) — heterogeneous CLI agents that ingest via `aiAgent.heteroIngest`
@@ -103,6 +158,11 @@ export class StreamEventManager {
 
     const eventData: StreamEvent = {
       ...event,
+      // Chokepoint strip — every event passing through here gets its
+      // `data.finalState` trimmed (messages + tool-set fields) before
+      // serialization so a single xadd can't blow past Upstash's 10 MB
+      // request limit on long topics.
+      data: stripFinalStateInEventData(event.data),
       operationId,
       timestamp: Date.now(),
     };
@@ -191,6 +251,10 @@ export class StreamEventManager {
     reasonDetail,
     uiMessages,
   }: PublishAgentRuntimeEndParams): Promise<string> {
+    // `finalState.messages` + tool-set fields are stripped centrally
+    // inside `publishStreamEvent`; callers stay dumb. `reasonDetail`
+    // derivation below uses the un-stripped in-process `finalState`
+    // so the error message remains available.
     return this.publishStreamEvent(operationId, {
       data: {
         finalState,

--- a/src/server/modules/AgentRuntime/__tests__/StreamEventManager.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/StreamEventManager.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { getDefaultReasonDetail, StreamEventManager } from '../StreamEventManager';
+import {
+  getDefaultReasonDetail,
+  StreamEventManager,
+  stripFinalStateInEventData,
+} from '../StreamEventManager';
 
 // Mock Redis client
 const mockRedis = {
@@ -236,6 +240,100 @@ describe('StreamEventManager', () => {
         expect.any(String),
         expect.any(String),
       );
+    });
+
+    // Heavy reconstructible fields (notably `messages` with
+    // compressedGroup envelopes) must be stripped before xadd so a
+    // single event can't blow past Upstash's 10 MB request limit.
+    it('strips messages + tool-set fields from finalState before xadd', async () => {
+      const operationId = 'test-operation-id';
+      const messages = [
+        { content: 'msg', role: 'user' },
+        { content: 'reply', role: 'assistant' },
+      ];
+      const finalState = {
+        cost: { total: 42 },
+        error: { message: 'boom', type: 'BoomError' },
+        messages,
+        operationToolSet: { enabledToolIds: ['x'] },
+        status: 'error',
+        stepCount: 4,
+        toolManifestMap: { x: { name: 'x' } },
+        toolSourceMap: { x: 'plugin' },
+        tools: [{ name: 'x' }],
+        usage: { llm: { tokens: { total: 100 } } },
+      };
+
+      mockRedis.xadd.mockResolvedValue('event-id-strip');
+
+      await streamManager.publishAgentRuntimeEnd({
+        finalState,
+        operationId,
+        reason: 'error',
+        stepIndex: 4,
+      });
+
+      const dataArg = mockRedis.xadd.mock.calls[0]?.find(
+        (a: any) => typeof a === 'string' && a.startsWith('{'),
+      );
+      const parsed = JSON.parse(dataArg);
+
+      // Stripped: heavy / reconstructible fields gone
+      expect(parsed.finalState.messages).toBeUndefined();
+      expect(parsed.finalState.operationToolSet).toBeUndefined();
+      expect(parsed.finalState.toolManifestMap).toBeUndefined();
+      expect(parsed.finalState.toolSourceMap).toBeUndefined();
+      expect(parsed.finalState.tools).toBeUndefined();
+
+      // Preserved: lightweight observability fields downstream consumers use
+      expect(parsed.finalState.status).toBe('error');
+      expect(parsed.finalState.cost).toEqual({ total: 42 });
+      expect(parsed.finalState.error).toEqual({ message: 'boom', type: 'BoomError' });
+      expect(parsed.finalState.stepCount).toBe(4);
+      expect(parsed.finalState.usage).toEqual({ llm: { tokens: { total: 100 } } });
+
+      // reasonDetail derivation runs against the un-stripped in-process
+      // finalState passed as a param, so the error message survives.
+      expect(parsed.reasonDetail).toBe('boom');
+    });
+  });
+
+  describe('stripFinalStateInEventData', () => {
+    it('returns data unchanged when finalState is absent', () => {
+      const data = { phase: 'execution_complete', reason: 'done' };
+      expect(stripFinalStateInEventData(data)).toBe(data);
+    });
+
+    it('returns data unchanged when finalState is falsy', () => {
+      const data = { finalState: null, reason: 'done' };
+      expect(stripFinalStateInEventData(data)).toBe(data);
+    });
+
+    it('strips reconstructible fields off finalState while preserving others', () => {
+      const result = stripFinalStateInEventData({
+        finalState: {
+          cost: { total: 1 },
+          messages: [{ role: 'user' }],
+          operationToolSet: {},
+          status: 'done',
+          toolManifestMap: {},
+          toolSourceMap: {},
+          tools: [],
+        },
+        reason: 'done',
+      });
+
+      expect(result).toEqual({
+        finalState: { cost: { total: 1 }, status: 'done' },
+        reason: 'done',
+      });
+    });
+
+    it('handles non-object data defensively', () => {
+      expect(stripFinalStateInEventData(undefined)).toBeUndefined();
+      expect(stripFinalStateInEventData(null)).toBeNull();
+      expect(stripFinalStateInEventData('chunk')).toBe('chunk');
+      expect(stripFinalStateInEventData(123)).toBe(123);
     });
   });
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes [LOBE-9544](https://linear.app/lobehub/issue/LOBE-9544). Follow-up to [LOBE-9110](https://linear.app/lobehub/issue/LOBE-9110) (`contextEngine.input` + `toolsetBaseline` strip).

#### 🔀 Description of Change

##### Why

Long topics with `compressedGroup` envelopes can serialize a full `AgentState.messages` array that exceeds Upstash Redis's **10 MB single-request limit** on xadd, crashing `agent_runtime_stream:<opId>` writes and surfacing as a misleading watchdog `Operation idle for 600s` false-positive on the gateway side.

A diagnosed case (op_1779674269019) was **20 MB**, of which **15 MB lived in 3 `compressedGroup` envelopes** holding **752 raw original messages**:

```
messagesBaseline 总计 16.3 MB / 124 条
├─ compressedGroup × 3        15.05 MB   ← 占 92%
│   ├─ content (摘要)            ~3 KB
│   └─ compressedMessages[]   ~5 MB     ← 原始 254 / 339 / 159 条全量保留
├─ assistant     × 59          1.05 MB
├─ tool          × 12          0.11 MB
└─ user          × 50          0.09 MB
```

LOBE-9110 already removed `contextEngine.input` + `toolsetBaseline` from the state blob. `messages` is the remaining size driver.

##### Approach: chokepoint, not per-call-site

Every stream-event publish in the runtime — `publishAgentRuntimeEnd`, the per-step `step_complete` in `AgentRuntimeService.executeStep`, and the two terminal `step_complete` sites in `RuntimeExecutors` — flows through `StreamEventManager.publishStreamEvent`. So the strip lives there:

\`\`\`ts
const eventData: StreamEvent = {
  ...event,
  // LOBE-9544: chokepoint strip — every event passing through here
  // gets its \`data.finalState\` trimmed (messages + tool-set fields)
  // before serialization …
  data: stripFinalStateInEventData(event.data),
  operationId,
  timestamp: Date.now(),
};
\`\`\`

Mirrored in `InMemoryStreamEventManager.publishStreamEvent` (test-mode parity) and `GatewayStreamNotifier.pushEvent` (separate HTTP POST WS channel that would otherwise re-introduce the bloat). Call sites stay dumb; future direct `publishStreamEvent` users get protection for free.

##### Fields stripped (mirrors OperationTraceRecorder's done-event strip from LOBE-9110)

- `messages` — canonical copy lives in DB rows / runtime in-memory state. In-process consumers (e.g. `execSubAgentTask.onComplete`) keep receiving the full state via the local `HookContext` channel, not via the stream.
- `operationToolSet`, `toolManifestMap`, `toolSourceMap`, `tools` — operation-level snapshot already covered by LOBE-9110.

`finalState` itself stays in the payload, so existing consumers that read lightweight fields (`status`, `cost`, `usage`, `error`, …) keep working unchanged.

##### Why this is safe to delete

Verified no stream subscriber reads the stripped fields off the wire:

| Consumer | Reads `finalState.messages` etc. from stream? |
|---|---|
| `gatewayEventHandler.ts` `agent_runtime_end` | ❌ — only `reason` + `uiMessages` |
| `gatewayEventHandler.ts` `step_complete` | ❌ — only `phase` |
| `runAgent.ts` `agent_runtime_end` | ❌ — only `finalState.status` (preserved by strip) |
| `runAgent.ts` `step_complete` | ❌ — only `finalState.status` (preserved by strip) |
| `apps/cli/src/utils/agentStream.ts` | ❌ — no `finalState` references |
| `packages/agent-gateway-client/src/client.ts` | ❌ |
| `packages/heterogeneous-agents/` | ❌ |
| `packages/agent-mock/` | ❌ |
| `src/server/services/heterogeneousAgent/` | ❌ |
| `execSubAgentTask.onComplete` | ✅ via `HookContext.finalState` — **in-process channel**, explicitly "not serialized to webhook payloads". Unaffected. |

Agent runtime executors (`call_llm`, `call_tool`, `finish`, …) consume `state.messages` heavily but get it from the in-memory state passed by `runtime.step(state, context)`, sourced from `coordinator.loadAgentState` (Redis SET, separate key `agent_state:<opId>`). They never read from the xadd stream.

##### What this fix does NOT do (out of scope)

- DO-level catch of `max request size exceeded` to publish `op_crashed_redis_overflow` for cleaner gateway error surfacing (LOBE-9544's short-term mitigation section) — separate PR

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

##### New tests

1. `StreamEventManager.publishAgentRuntimeEnd` integration test — a fat `finalState` with `messages` + tool-set fields passed in, asserts heavy fields stripped from the serialized xadd data + lightweight fields preserved + `reasonDetail` derivation still sees the un-stripped error message (in-process param).
2. `stripFinalStateInEventData` unit tests cover the helper contract — no-op when `finalState` is absent / falsy, strips correctly, defensive on non-object input.

##### Why existing tests pass unchanged

The chokepoint is invisible to callers that don't pass heavy state. Existing test fixtures don't carry `messages` in their `finalState` mocks (they're focused on observability-shape assertions), so the strip is a no-op for them. **That's exactly the chokepoint contract.**

##### Results

- StreamEventManager / InMemoryStreamEventManager / GatewayStreamNotifier / RuntimeExecutors / AgentRuntimeService / AgentRuntimeCoordinator / runAgent / gatewayEventHandler: **306 passing ✅**

#### 📝 Additional Information

Diff: **5 files, +193 / -5**. All net additions are the helper (StreamEventManager.ts) + new tests; producer call sites only get comment updates pointing to the chokepoint.

Size-impact estimate: ~20 MB → ~4 MB per terminal event for the heaviest diagnosed op (remainder is mostly `uiMessages`, which is the canonical SoT for the client and stays). Well under Upstash's 10 MB limit.