### PR TITLE
💄 style(llm-generation-tracing): tag task-handoff scenario + prompt version

### DIFF
--- a/packages/const/src/llmGenerationTracing.ts
+++ b/packages/const/src/llmGenerationTracing.ts
@@ -18,6 +18,7 @@ export const TRACING_SCENARIOS = {
   SignalSkillIntent: 'signal_skill_intent',
   SignalSkillManagement: 'signal_skill_management',
   SignupEmailReview: 'signup_email_review',
+  TaskHandoff: 'task_handoff',
   TopicTitle: 'topic_title',
   Unknown: 'unknown',
 } as const;

--- a/packages/prompts/src/chains/taskTopicHandoff.ts
+++ b/packages/prompts/src/chains/taskTopicHandoff.ts
@@ -1,6 +1,15 @@
 import type { ChatStreamPayload } from '@lobechat/types';
 
 /**
+ * Bump when editing the system prompt or schema below. Plumbed through
+ * `tracing.promptVersion` at the call site so per-call tracing groups runs
+ * by prompt iteration.
+ */
+export const TASK_TOPIC_HANDOFF_PROMPT_VERSION = 'v1.0';
+
+export const TASK_TOPIC_HANDOFF_SCHEMA_NAME = 'task_topic_handoff';
+
+/**
  * Generate a handoff summary for a completed task topic.
  * Returns both a title and structured handoff data for the next topic.
  *

--- a/src/features/Conversation/ChatInput/QueueTray.tsx
+++ b/src/features/Conversation/ChatInput/QueueTray.tsx
@@ -105,6 +105,7 @@ const QueuedFilePreview = memo<QueuedFilePreviewProps>(({ file }) => {
         size={PREVIEW_SIZE}
         src={file.url}
         title={file.name}
+        variant={'borderless'}
         styles={{
           image: { height: PREVIEW_SIZE, width: PREVIEW_SIZE },
           wrapper: { height: PREVIEW_SIZE, width: PREVIEW_SIZE },

--- a/src/server/services/taskLifecycle/index.ts
+++ b/src/server/services/taskLifecycle/index.ts
@@ -1,10 +1,14 @@
+import { TRACING_SCENARIOS } from '@lobechat/const';
+import type { TracingOptions } from '@lobechat/llm-generation-tracing';
 import {
   chainGenerateBrief,
   chainJudgeBriefEmit,
   chainTaskTopicHandoff,
   GENERATE_BRIEF_SCHEMA,
   JUDGE_BRIEF_EMIT_SCHEMA,
+  TASK_TOPIC_HANDOFF_PROMPT_VERSION,
   TASK_TOPIC_HANDOFF_SCHEMA,
+  TASK_TOPIC_HANDOFF_SCHEMA_NAME,
 } from '@lobechat/prompts';
 import type {
   BriefArtifacts,
@@ -351,9 +355,16 @@ export class TaskLifecycleService {
         {
           messages: payload.messages as any[],
           model,
-          schema: { name: 'task_topic_handoff', schema: TASK_TOPIC_HANDOFF_SCHEMA },
+          schema: { name: TASK_TOPIC_HANDOFF_SCHEMA_NAME, schema: TASK_TOPIC_HANDOFF_SCHEMA },
         },
-        { metadata: { trigger: 'task-handoff' } },
+        {
+          metadata: { trigger: 'task-handoff' },
+          tracing: {
+            promptVersion: TASK_TOPIC_HANDOFF_PROMPT_VERSION,
+            scenario: TRACING_SCENARIOS.TaskHandoff,
+            schemaName: TASK_TOPIC_HANDOFF_SCHEMA_NAME,
+          } satisfies TracingOptions,
+        },
       );
 
       const handoff = result as {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Stacked on top of #15146.

#### 🔀 Description of Change

Task topic handoff rows were tracing as `scenario=unknown` / `promptVersion=v0` because the `generateObject` call in `taskLifecycle` only set `metadata.trigger = 'task-handoff'`, and that trigger isn't in `TRACING_SCENARIO_REGISTRY` — so the hook fell through to the `UNKNOWN_SCENARIO` sentinel.

Fix mirrors the `followUpAction` pattern:

- Added `TaskHandoff: 'task_handoff'` to `TRACING_SCENARIOS` (the canonical scenario directory).
- Versioned the prompt next to its definition: exported `TASK_TOPIC_HANDOFF_PROMPT_VERSION = 'v1.0'` and `TASK_TOPIC_HANDOFF_SCHEMA_NAME = 'task_topic_handoff'` from `packages/prompts/src/chains/taskTopicHandoff.ts` (per the registry comment: "version lives next to the prompt").
- Pass `tracing: { promptVersion, scenario, schemaName } satisfies TracingOptions` at the call site alongside the existing `metadata.trigger`, and dedup the schema-name string literal.

Also bundles a tiny `💄 style(QueueTray)`: `variant='borderless'` on the queued file preview Image.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Trigger a task that hands off between topics, then check `dc.lobe.li/llm-generation/task_handoff/...` — row's Scenario should now read `task_handoff` and prompt should read `v1.0-<hash>` instead of `unknown` / `v0`.

#### 📸 Screenshots / Videos

N/A — backend metadata only (plus a borderless tweak on QueueTray preview).

#### 📝 Additional Information

No schema migrations. The `scenario` column accepts any text — the new `'task_handoff'` value just starts appearing on new rows. Existing `unknown` rows for task handoff are not back-filled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)