### PR TITLE
✨ refactor(agent-signal): add executeViaExecAgent self-iteration shell

### DIFF
--- a/src/server/services/agentSignal/services/selfIteration/__test__/executeViaExecAgent.test.ts
+++ b/src/server/services/agentSignal/services/selfIteration/__test__/executeViaExecAgent.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment node
+import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
+import { RequestTrigger } from '@lobechat/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AiAgentService } from '@/server/services/aiAgent';
+
+import type { ExecuteSelfIterationContext } from '../execute';
+import { executeViaExecAgent } from '../executeViaExecAgent';
+
+const mockExecAgent = vi.fn();
+
+beforeEach(() => {
+  mockExecAgent.mockReset();
+  vi.spyOn(AiAgentService.prototype, 'execAgent').mockImplementation(mockExecAgent);
+});
+
+const buildContext = (
+  overrides: Partial<ExecuteSelfIterationContext> = {},
+): ExecuteSelfIterationContext => ({
+  agentId: 'agent_1',
+  reviewWindowEnd: '2026-05-25T00:00:00.000Z',
+  reviewWindowStart: '2026-05-24T00:00:00.000Z',
+  userId: 'user_1',
+  ...overrides,
+});
+
+describe('executeViaExecAgent', () => {
+  it('enqueues a self-iteration run via the unified execAgent path', async () => {
+    mockExecAgent.mockResolvedValue({
+      operationId: 'op_run_1',
+      success: true,
+    });
+
+    const result = await executeViaExecAgent({
+      agentId: 'agent_1',
+      context: buildContext(),
+      db: {} as never,
+      maxSteps: 6,
+      sourceId: 'src_1',
+      userId: 'user_1',
+    });
+
+    expect(result).toEqual({ enqueued: true, operationId: 'op_run_1' });
+    expect(mockExecAgent).toHaveBeenCalledTimes(1);
+
+    const call = mockExecAgent.mock.calls[0][0];
+    expect(call.slug).toBe(BUILTIN_AGENT_SLUGS.selfIteration);
+    expect(call.trigger).toBe(RequestTrigger.AgentSignal);
+    expect(call.maxSteps).toBe(6);
+    expect(call.autoStart).toBe(true);
+    expect(call.appContext).toEqual({ scope: 'agent-signal', suppressSignal: true });
+    expect(typeof call.prompt).toBe('string');
+    expect(call.prompt.length).toBeGreaterThan(0);
+  });
+
+  it('defaults mode to "review" when omitted', async () => {
+    mockExecAgent.mockResolvedValue({ operationId: 'op_2', success: true });
+
+    await executeViaExecAgent({
+      agentId: 'agent_2',
+      context: buildContext(),
+      db: {} as never,
+      maxSteps: 4,
+      sourceId: 'src_2',
+      userId: 'user_2',
+    });
+
+    expect(mockExecAgent.mock.calls[0][0].prompt).toContain('review');
+  });
+
+  it('propagates the caller-supplied window over the context defaults', async () => {
+    mockExecAgent.mockResolvedValue({ operationId: 'op_3', success: true });
+
+    await executeViaExecAgent({
+      agentId: 'agent_3',
+      context: buildContext({ reviewWindowStart: 'CTX_START', reviewWindowEnd: 'CTX_END' }),
+      db: {} as never,
+      maxSteps: 4,
+      sourceId: 'src_3',
+      userId: 'user_3',
+      window: {
+        end: 'CALLER_END',
+        localDate: '2026-05-25',
+        start: 'CALLER_START',
+        timezone: 'Asia/Shanghai',
+      },
+    });
+
+    const prompt = mockExecAgent.mock.calls[0][0].prompt;
+    expect(prompt).toContain('Review window: CALLER_START to CALLER_END');
+  });
+
+  it('falls back to context.reviewWindow* when no window is provided', async () => {
+    mockExecAgent.mockResolvedValue({ operationId: 'op_3b', success: true });
+
+    await executeViaExecAgent({
+      agentId: 'agent_3b',
+      context: buildContext({
+        reviewWindowEnd: 'CTX_END_ONLY',
+        reviewWindowStart: 'CTX_START_ONLY',
+      }),
+      db: {} as never,
+      maxSteps: 4,
+      sourceId: 'src_3b',
+      userId: 'user_3b',
+    });
+
+    const prompt = mockExecAgent.mock.calls[0][0].prompt;
+    expect(prompt).toContain('Review window: CTX_START_ONLY to CTX_END_ONLY');
+  });
+
+  it('surfaces enqueue failure without throwing', async () => {
+    mockExecAgent.mockResolvedValue({
+      error: 'queue unavailable',
+      operationId: 'op_failed',
+      success: false,
+    });
+
+    const result = await executeViaExecAgent({
+      agentId: 'agent_4',
+      context: buildContext(),
+      db: {} as never,
+      maxSteps: 4,
+      sourceId: 'src_4',
+      userId: 'user_4',
+    });
+
+    expect(result).toEqual({
+      enqueued: false,
+      error: 'queue unavailable',
+      operationId: 'op_failed',
+    });
+  });
+});

--- a/src/server/services/agentSignal/services/selfIteration/executeViaExecAgent.ts
+++ b/src/server/services/agentSignal/services/selfIteration/executeViaExecAgent.ts
@@ -1,0 +1,93 @@
+import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
+import { createAgentSignalSelfIterationPrompt } from '@lobechat/prompts';
+import { RequestTrigger } from '@lobechat/types';
+
+import type { LobeChatDatabase } from '@/database/type';
+import { AiAgentService } from '@/server/services/aiAgent';
+
+import type { ExecuteSelfIterationContext } from './execute';
+import type { IterationMode } from './types';
+
+/**
+ * Replacement for executeSelfIteration that routes through execAgent (async queue).
+ *
+ * LOBE-9454: Migrates the hand-rolled AgentRuntime loop from execute.ts
+ * (new AgentRuntime + custom call_llm executor + closure accumulators) to
+ * the unified execAgent entry point.
+ *
+ * Key differences vs. the old execute.ts path:
+ * - No side-channel closures — all structured output flows through the tool
+ *   result `kind` field into AgentState and is persisted as a step snapshot.
+ * - Runs asynchronously as queued steps → no Vercel timeout risk.
+ * - Full snapshot visibility → `agent-tracing inspect` works immediately.
+ *
+ * Post-completion bookkeeping (brief writing, receipt projection) is handled
+ * by the `agent.execution.completed` listener policy — see
+ * `completionPolicy.ts` and `finalStateExtractor.ts`.
+ *
+ * The old `executeSelfIteration` in execute.ts is retained during the
+ * migration period and will be deleted by LOBE-9453 (cleanup phase).
+ *
+ * This shell is not yet wired into any caller; the review / reflection /
+ * feedback handlers continue to call `executeSelfIteration` directly until
+ * Phase 3 migrates them one at a time.
+ */
+export interface ExecuteViaExecAgentInput {
+  agentId: string;
+  context: ExecuteSelfIterationContext;
+  db: LobeChatDatabase;
+  maxSteps: number;
+  mode?: IterationMode;
+  sourceId: string;
+  userId: string;
+  window?: { end: string; localDate?: string; start: string; timezone?: string };
+}
+
+export interface ExecuteViaExecAgentResult {
+  /** Whether the run was successfully enqueued. */
+  enqueued: boolean;
+  /** Error message when enqueue failed. */
+  error?: string;
+  /** operationId returned by execAgent — use with agent-tracing inspect. */
+  operationId: string;
+}
+
+export const executeViaExecAgent = async (
+  input: ExecuteViaExecAgentInput,
+): Promise<ExecuteViaExecAgentResult> => {
+  const mode: IterationMode = input.mode ?? 'review';
+
+  const prompt = createAgentSignalSelfIterationPrompt({
+    agentId: input.agentId,
+    context: input.context,
+    mode,
+    sourceId: input.sourceId,
+    userId: input.userId,
+    window: {
+      end: input.window?.end ?? input.context.reviewWindowEnd ?? new Date(0).toISOString(),
+      localDate: input.window?.localDate,
+      start: input.window?.start ?? input.context.reviewWindowStart ?? new Date(0).toISOString(),
+      timezone: input.window?.timezone,
+    },
+  });
+
+  const aiAgentService = new AiAgentService(input.db, input.userId);
+
+  const result = await aiAgentService.execAgent({
+    appContext: {
+      scope: 'agent-signal',
+      suppressSignal: true,
+    },
+    autoStart: true,
+    maxSteps: input.maxSteps,
+    prompt,
+    slug: BUILTIN_AGENT_SLUGS.selfIteration,
+    trigger: RequestTrigger.AgentSignal,
+  });
+
+  return {
+    enqueued: result.success,
+    ...(result.error ? { error: result.error } : {}),
+    operationId: result.operationId,
+  };
+};


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] ✅ test

#### 🔗 Related Issue

Part of LOBE-9434 (parent), LOBE-9454.

Supersedes the Phase 2 piece of #15116 (that PR will be closed; see comment there for context).

#### 🔀 Description of Change

Phase 2 of LOBE-9434: introduces `executeViaExecAgent` as the async-queue
replacement for `executeSelfIteration`. Builds on the Phase 1 plumbing
landed in #15187.

**Not wired into any caller yet** — the review / reflection / feedback
handlers continue to call `executeSelfIteration` directly. Migration of
each caller happens in Phase 3, one at a time, so each cutover is
independently revertable.

**What it does:**

- Builds the self-iteration prompt via the shared
  `createAgentSignalSelfIterationPrompt`
- Routes through `AiAgentService.execAgent` with the `self-iteration`
  builtin slug and `suppressSignal: true` so the run cannot recurse
  into AgentSignal (`shouldSuppressSignal` from Phase 1 enforces this)
- Caller-supplied `window` overrides the context-derived defaults

**What it does NOT do:**

- Does not touch `executeSelfIteration` in `execute.ts`
- Does not change any registered source/signal/action handler
- Does not affect any UI or cron path

#### 🧪 How to Test

- [x] Tested locally — `bun run type-check` clean
- [x] Added 5 unit tests covering happy path, default mode, window
  precedence, context fallback, and enqueue-failure surfacing

```bash
bunx vitest run --silent='passed-only' 'executeViaExecAgent.test.ts'
```

#### 📝 Additional Information

Safe to merge: zero callers reference the new function until Phase 3,
so this is dormant code on the day it lands. Cloud impact: none.

**Next:** Phase 3 F (`userMemory.ts` migration to `execAgent`) — the
high-risk piece — will be a separate dedicated PR so it can be reviewed
and reverted on its own.