### PR TITLE
🐛 fix(llm-generation-tracing): backfill task_brief / task_brief_judge scenario

### DIFF
--- a/packages/const/src/llmGenerationTracing.ts
+++ b/packages/const/src/llmGenerationTracing.ts
@@ -18,6 +18,8 @@ export const TRACING_SCENARIOS = {
   SignalSkillIntent: 'signal_skill_intent',
   SignalSkillManagement: 'signal_skill_management',
   SignupEmailReview: 'signup_email_review',
+  TaskBrief: 'task_brief',
+  TaskBriefJudge: 'task_brief_judge',
   TaskHandoff: 'task_handoff',
   TopicTitle: 'topic_title',
   Unknown: 'unknown',

--- a/packages/prompts/src/chains/generateBrief.ts
+++ b/packages/prompts/src/chains/generateBrief.ts
@@ -1,6 +1,15 @@
 import type { BriefArtifacts, ChatStreamPayload, TaskTopicHandoff } from '@lobechat/types';
 
 /**
+ * Bump when editing the system prompt or schema below. Plumbed through
+ * `tracing.promptVersion` at the call site so per-call tracing groups runs
+ * by prompt iteration.
+ */
+export const GENERATE_BRIEF_PROMPT_VERSION = 'v1.0';
+
+export const GENERATE_BRIEF_SCHEMA_NAME = 'task_topic_brief';
+
+/**
  * Generate the user-facing copy (title + summary) for a brief.
  *
  * This chain is invoked ONLY after the emit decision has been made elsewhere

--- a/packages/prompts/src/chains/judgeBriefEmit.ts
+++ b/packages/prompts/src/chains/judgeBriefEmit.ts
@@ -1,6 +1,15 @@
 import type { BriefArtifacts, ChatStreamPayload, TaskTopicHandoff } from '@lobechat/types';
 
 /**
+ * Bump when editing the system prompt or schema below. Plumbed through
+ * `tracing.promptVersion` at the call site so per-call tracing groups runs
+ * by prompt iteration.
+ */
+export const JUDGE_BRIEF_EMIT_PROMPT_VERSION = 'v1.0';
+
+export const JUDGE_BRIEF_EMIT_SCHEMA_NAME = 'task_topic_brief_judge';
+
+/**
  * Decide whether a completed topic is worth surfacing to the user as a brief.
  *
  * Split from `chainGenerateBrief` so the two stages stay independent: the

--- a/src/server/services/taskLifecycle/index.ts
+++ b/src/server/services/taskLifecycle/index.ts
@@ -4,8 +4,12 @@ import {
   chainGenerateBrief,
   chainJudgeBriefEmit,
   chainTaskTopicHandoff,
+  GENERATE_BRIEF_PROMPT_VERSION,
   GENERATE_BRIEF_SCHEMA,
+  GENERATE_BRIEF_SCHEMA_NAME,
+  JUDGE_BRIEF_EMIT_PROMPT_VERSION,
   JUDGE_BRIEF_EMIT_SCHEMA,
+  JUDGE_BRIEF_EMIT_SCHEMA_NAME,
   TASK_TOPIC_HANDOFF_PROMPT_VERSION,
   TASK_TOPIC_HANDOFF_SCHEMA,
   TASK_TOPIC_HANDOFF_SCHEMA_NAME,
@@ -358,7 +362,7 @@ export class TaskLifecycleService {
           schema: { name: TASK_TOPIC_HANDOFF_SCHEMA_NAME, schema: TASK_TOPIC_HANDOFF_SCHEMA },
         },
         {
-          metadata: { trigger: 'task-handoff' },
+          metadata: { trigger: 'task_handoff' },
           tracing: {
             promptVersion: TASK_TOPIC_HANDOFF_PROMPT_VERSION,
             scenario: TRACING_SCENARIOS.TaskHandoff,
@@ -462,9 +466,16 @@ export class TaskLifecycleService {
           {
             messages: judgePayload.messages as any[],
             model,
-            schema: { name: 'task_topic_brief_judge', schema: JUDGE_BRIEF_EMIT_SCHEMA },
+            schema: { name: JUDGE_BRIEF_EMIT_SCHEMA_NAME, schema: JUDGE_BRIEF_EMIT_SCHEMA },
           },
-          { metadata: { trigger: 'task-brief-judge' } },
+          {
+            metadata: { trigger: 'task_brief_judge' },
+            tracing: {
+              promptVersion: JUDGE_BRIEF_EMIT_PROMPT_VERSION,
+              scenario: TRACING_SCENARIOS.TaskBriefJudge,
+              schemaName: JUDGE_BRIEF_EMIT_SCHEMA_NAME,
+            } satisfies TracingOptions,
+          },
         )) as { emit?: boolean; reason?: string };
 
         decision = {
@@ -515,9 +526,16 @@ export class TaskLifecycleService {
         {
           messages: payload.messages as any[],
           model,
-          schema: { name: 'task_topic_brief', schema: GENERATE_BRIEF_SCHEMA },
+          schema: { name: GENERATE_BRIEF_SCHEMA_NAME, schema: GENERATE_BRIEF_SCHEMA },
         },
-        { metadata: { trigger: 'task-brief' } },
+        {
+          metadata: { trigger: 'task_brief' },
+          tracing: {
+            promptVersion: GENERATE_BRIEF_PROMPT_VERSION,
+            scenario: TRACING_SCENARIOS.TaskBrief,
+            schemaName: GENERATE_BRIEF_SCHEMA_NAME,
+          } satisfies TracingOptions,
+        },
       );
 
       const generated = result as { summary?: string; title?: string };


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

Audit of `llm_generation_tracing` rows with `scenario='unknown'` showed all 893 sat under three triggers used by the task lifecycle, and the brief side wasn't wired through tracing yet:

This PR fixes the upstream so new rows route correctly. A separate one-shot SQL backfill will retro-label the existing 893 unknown rows; this PR is the source-side fix only.

##### Changes

- **`@lobechat/const`**: add `TaskBrief` and `TaskBriefJudge` to `TRACING_SCENARIOS`. `TaskHandoff` was already there.
- **`@lobechat/prompts`**: add `GENERATE_BRIEF_PROMPT_VERSION` / `GENERATE_BRIEF_SCHEMA_NAME` and `JUDGE_BRIEF_EMIT_PROMPT_VERSION` / `JUDGE_BRIEF_EMIT_SCHEMA_NAME` constants next to each chain, matching the existing `TASK_TOPIC_HANDOFF_*` convention.
- **`taskLifecycle`**: switch all three `generateObject` call sites to pass explicit `tracing: { promptVersion, scenario, schemaName } satisfies TracingOptions` instead of relying on a missing default. New rows will now record `scenario='task_brief' | 'task_brief_judge' | 'task_handoff'` with `prompt_version='v1.0'`.
- Normalize `metadata.trigger` from dashed strings (`task-handoff` / `task-brief` / `task-brief-judge`) to underscored ids (`task_handoff` / `task_brief` / `task_brief_judge`) to match the `RequestTrigger` enum convention.

##### Notes

- Registry-side default mapping (`TRACING_SCENARIO_REGISTRY`) intentionally left alone — the canary pattern for task-lifecycle calls is explicit `tracing.scenario` at the call site, not registry fallback.
- No DB migration. Versioning of the brief prompts is bumped to `v1.0` (their first explicit version); the historical `v0` rows in the table stay as-is.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests (existing unit tests on prompt chains + tracing registry still pass)
- [ ] No tests needed

```
cd packages/prompts && bunx vitest run --silent='passed-only' src/chains/__tests__/generateBrief.test.ts src/chains/__tests__/judgeBriefEmit.test.ts
cd packages/llm-generation-tracing && bunx vitest run --silent='passed-only'
```

After deploy, watch for new `llm_generation_tracing` rows where `scenario` is one of `task_brief` / `task_brief_judge` / `task_handoff` with `prompt_version='v1.0'`. No new rows should land in `scenario='unknown'` from these call paths.

#### 📝 Additional Information

The follow-up cleanup SQL (run separately) for the existing unknown rows:

```sql
UPDATE llm_generation_tracing
SET scenario = CASE trigger
  WHEN 'task-handoff'     THEN 'task_handoff'
  WHEN 'task-brief'       THEN 'task_brief'
  WHEN 'task-brief-judge' THEN 'task_brief_judge'
END
WHERE scenario = 'unknown'
  AND trigger IN ('task-handoff','task-brief','task-brief-judge');
```