### PR TITLE
fix(chat-input): disable spellCheck to suppress Safari inline predictive text

### DIFF
--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -334,6 +334,8 @@ const InputEditor = memo<{
       {...richRenderProps}
       mentionOption={mentionOption}
       slashOption={slashOption}
+      // Disable spellCheck to suppress Safari/WebKit inline predictive text (Apple Intelligence)
+      spellCheck={false}
       type={'text'}
       variant={'chat'}
       placeholder={


### PR DESCRIPTION
## Problem

Safari 18+ (macOS Sequoia / Apple Intelligence) shows inline text predictions in the chat input. This is OS-level behavior triggered on all `contenteditable` divs — `autocomplete` attributes have no effect here.

## Fix

Pass `spellCheck={false}` explicitly to `<Editor>` in `InputEditor`.

Setting `spellCheck={false}` on the underlying `contentEditable` div suppresses Safari/WebKit's inline predictive text per [WebKit commit 2d67e9c](https://github.com/WebKit/WebKit/commit/2d67e9cb94d7b6a8fa75ca87c72ca437752e0199).

## Dependency

Requires `@lobehub/editor` to expose the `spellCheck` prop first: https://github.com/lobehub/lobe-editor/pull/161