### PR TITLE
💄 style(explorer-tree): align file icons with folder icons

### DIFF
--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.test.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.test.tsx
@@ -130,7 +130,11 @@ vi.mock('@/features/ExplorerTree', () => {
     );
   };
 
-  return { ExplorerTree, FOLDER_ICON_CSS: '' };
+  return {
+    ExplorerTree,
+    FOLDER_ICON_CSS: '',
+    getExplorerTreeStyleVars: () => ({}),
+  };
 });
 
 const createDocument = (overrides: Partial<AgentDocumentItem>): AgentDocumentItem =>

--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
@@ -12,7 +12,7 @@ import type {
   ExplorerTreeHandle,
   ExplorerTreeNode,
 } from '@/features/ExplorerTree';
-import { ExplorerTree, FOLDER_ICON_CSS } from '@/features/ExplorerTree';
+import { ExplorerTree, FOLDER_ICON_CSS, getExplorerTreeStyleVars } from '@/features/ExplorerTree';
 import { useChatStore } from '@/store/chat';
 
 import DocumentExplorerToolbar from './DocumentExplorerToolbar';
@@ -101,6 +101,10 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
   );
   const defaultExpandedIds = useMemo(
     () => nodes.filter((node) => node.isFolder && node.parentId == null).map((node) => node.id),
+    [nodes],
+  );
+  const treeStyleVars = useMemo(
+    () => getExplorerTreeStyleVars({ reserveChevronSlot: nodes.some((node) => node.isFolder) }),
     [nodes],
   );
 
@@ -244,14 +248,13 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
   );
 
   return (
-    <div className={styles.tree} style={style}>
+    <div className={styles.tree} style={{ ...style, ...treeStyleVars }}>
       <ExplorerTree<AgentDocumentItem>
         iconsColored
         canDrag={canDrag}
         canDrop={canDrop}
         canRename={canRename}
         defaultExpandedIds={defaultExpandedIds}
-        density="compact"
         getContextMenuItems={getContextMenuItems}
         iconSet="complete"
         nodes={nodes}

--- a/src/features/ExplorerTree/folderIconStyle.ts
+++ b/src/features/ExplorerTree/folderIconStyle.ts
@@ -1,8 +1,20 @@
+import type { CSSProperties } from 'react';
+
 const folderClosedSvg = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z'/></svg>`;
 const folderOpenSvg = `<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='m6 14 1.45-2.9A2 2 0 0 1 9.24 10H20a2 2 0 0 1 1.94 2.5l-1.55 6a2 2 0 0 1-1.94 1.5H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h3.9a2 2 0 0 1 1.69.9l.81 1.2a2 2 0 0 0 1.69.9H18a2 2 0 0 1 2 2v2'/></svg>`;
 
-// PierreFileTree only renders a chevron in [data-item-section="icon"] for
-// directories; inject the visible folder glyph into the content cell.
+// Pierre's unsafeCSS is captured at FileTree construction with no public
+// setter, so we can't rebuild this string in response to tree changes. Drive
+// the file-icon offset through a CSS custom property the wrapper sets — custom
+// properties cascade through shadow DOM, so toggling it on the host reflows
+// the offset live (see `getExplorerTreeStyleVars`).
+const FILE_ICON_OFFSET_VAR = '--explorer-file-icon-offset';
+
+// Chevron column width + row gap at default density (16 + 6). We standardised
+// consumers on default density, so this matches `--trees-icon-width` +
+// `--trees-item-row-gap` exactly.
+const RESERVED_FILE_ICON_OFFSET = '22px';
+
 export const FOLDER_ICON_CSS = `
   [data-item-type="folder"] [data-item-section="content"] {
     display: flex;
@@ -23,4 +35,16 @@ export const FOLDER_ICON_CSS = `
     -webkit-mask-image: url("data:image/svg+xml;utf8,${folderOpenSvg}");
     mask-image: url("data:image/svg+xml;utf8,${folderOpenSvg}");
   }
+  [data-item-type="file"] [data-item-section="icon"] {
+    margin-inline-start: var(${FILE_ICON_OFFSET_VAR}, 0px);
+  }
 `;
+
+export const getExplorerTreeStyleVars = ({
+  reserveChevronSlot,
+}: {
+  reserveChevronSlot: boolean;
+}): CSSProperties =>
+  ({
+    [FILE_ICON_OFFSET_VAR]: reserveChevronSlot ? RESERVED_FILE_ICON_OFFSET : '0px',
+  }) as CSSProperties;

--- a/src/features/ExplorerTree/index.tsx
+++ b/src/features/ExplorerTree/index.tsx
@@ -1,4 +1,4 @@
-export { FOLDER_ICON_CSS } from './folderIconStyle';
+export { FOLDER_ICON_CSS, getExplorerTreeStyleVars } from './folderIconStyle';
 export type {
   ExplorerTreeCanDropCtx,
   ExplorerTreeHandle,

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Files/__tests__/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Files/__tests__/index.test.tsx
@@ -47,6 +47,7 @@ vi.mock('@/features/ExplorerTree', () => {
   return {
     ExplorerTree: MockExplorerTree,
     FOLDER_ICON_CSS: '',
+    getExplorerTreeStyleVars: () => ({}),
   };
 });
 

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Files/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Files/index.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
 import type { ExplorerTreeNode } from '@/features/ExplorerTree';
-import { ExplorerTree, FOLDER_ICON_CSS } from '@/features/ExplorerTree';
+import { ExplorerTree, FOLDER_ICON_CSS, getExplorerTreeStyleVars } from '@/features/ExplorerTree';
 import type { ExplorerTreeHandle } from '@/features/ExplorerTree/types';
 import { localFileService } from '@/services/electron/localFileService';
 import { useChatStore } from '@/store/chat';
@@ -115,6 +115,10 @@ const Files = memo<FilesProps>(({ workingDirectory }) => {
   // paint without having to click through every folder.
   const defaultExpandedIds = useMemo(
     () => nodes.filter((node) => node.isFolder && node.parentId == null).map((node) => node.id),
+    [nodes],
+  );
+  const treeStyleVars = useMemo(
+    () => getExplorerTreeStyleVars({ reserveChevronSlot: nodes.some((node) => node.isFolder) }),
     [nodes],
   );
 
@@ -250,11 +254,10 @@ const Files = memo<FilesProps>(({ workingDirectory }) => {
           <Empty description={t('workingPanel.files.empty')} icon={FileIcon} />
         </Center>
       ) : (
-        <div className={styles.tree}>
+        <div className={styles.tree} style={treeStyleVars}>
           <ExplorerTree<ProjectFileIndexEntry>
             iconsColored
             defaultExpandedIds={defaultExpandedIds}
-            density="compact"
             getContextMenuItems={getContextMenuItems}
             gitStatus={gitStatus}
             iconSet="complete"


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Two small adjustments to the PierreFileTree-based explorers (`DocumentExplorerTree`, WorkingSidebar `Files`):

1. **Drop the `compact` density override.** Rows were too tight versus the SkillsList style. Falling back to Pierre's `default` (30px) lands close to SkillsList's 28px and reads much more comfortably.
2. **Reserve a chevron-sized slot on file rows when any folder exists.** Pierre renders the chevron in `[data-item-section="icon"]` for folders and the file glyph in the same slot for files, so file icons sit one column left of folder icons. Mirroring SkillsList's `reserveChevronSlot`, file rows now get `margin-inline-start` equal to the chevron lane when the tree has at least one folder.

Pierre's `unsafeCSS` is captured at FileTree construction with no public setter, so the offset is driven by a CSS custom property (`--explorer-file-icon-offset`) that the wrapper `<div>` sets inline via `getExplorerTreeStyleVars({ reserveChevronSlot })`. Custom properties cascade through the shadow DOM, so deleting the last folder toggles the offset back to `0px` live — no remount, no lost expansion/selection state.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Touched test stubs:
- `src/features/AgentDocumentsExplorer/DocumentExplorerTree.test.tsx`
- `src/routes/(main)/agent/features/Conversation/WorkingSidebar/Files/__tests__/index.test.tsx`

```
bunx vitest run --silent='passed-only' \
  src/features/AgentDocumentsExplorer/DocumentExplorerTree.test.tsx \
  'src/routes/(main)/agent/features/Conversation/WorkingSidebar/Files/__tests__/index.test.tsx'
```

Manual: open the agent Documents panel, create/delete folders, confirm file icons align with folder icons when a folder is present and snap back when the last folder is removed.

#### 📸 Screenshots / Videos

UI change — screenshots welcome from reviewers; not captured locally.

#### 📝 Additional Information

The `22px` reserved offset matches `--trees-icon-width` (16) + `--trees-item-row-gap` (6) at the standard `default` density used by both consumers. If a future consumer overrides density, the offset will drift by 1–3px; at that point it's worth reading Pierre's vars instead of hard-coding.