### PR TITLE
🐛 fix: desktop device hetero task — correct notify URL, auth header, child env

### DIFF
--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -443,6 +443,18 @@ export default class GatewayConnectionCtr extends ControllerModule {
     const { agentId, agentType, cwd, operationId, prompt, taskId, topicId } = args;
     const workDir = cwd || process.cwd();
 
+    const [serverUrl, accessToken] = await Promise.all([
+      this.remoteServerConfigCtr.getRemoteServerUrl(),
+      this.remoteServerConfigCtr.getAccessToken(),
+    ]);
+
+    // Inject auth into child env so `lh notify` can authenticate without CLI config.
+    const childEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      ...(accessToken && { LOBEHUB_JWT: accessToken }),
+      ...(serverUrl && { LOBEHUB_SERVER: serverUrl }),
+    };
+
     if (agentType === 'openclaw') {
       const lhPath = this.resolveLhPath();
       const openclawAgent = process.env['OPENCLAW_AGENT_ID'] ?? 'main';
@@ -478,7 +490,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
           enrichedPrompt,
           '--local',
         ],
-        { cwd: workDir, detached: true, env: { ...process.env }, stdio: 'ignore' },
+        { cwd: workDir, detached: true, env: childEnv, stdio: 'ignore' },
       );
 
       const pid = child.pid;
@@ -528,7 +540,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
       const child = spawn('hermes', hermesArgs, {
         cwd: workDir,
         detached: true,
-        env: { ...process.env },
+        env: childEnv,
         stdio: ['ignore', 'pipe', 'ignore'],
       });
 
@@ -621,11 +633,11 @@ export default class GatewayConnectionCtr extends ControllerModule {
       ]);
       if (!serverUrl || !token) return;
 
-      await fetch(`${serverUrl}/trpc/agentNotify.notify`, {
+      await fetch(`${serverUrl}/trpc/lambda/agentNotify.notify`, {
         body: JSON.stringify({ json: params }),
         headers: {
-          'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json',
+          'Oidc-Auth': token,
         },
         method: 'POST',
       });


### PR DESCRIPTION
## Summary

When the desktop app is bound as a device and dispatches a `runHeteroTask`, openclaw runs but results never reach the UI. The same flow works via `lh connect` (CLI device). Three bugs in `GatewayConnectionCtr.ts` are responsible:

### Bug 1 — Wrong URL in `sendNotify`

```diff
- await fetch(`${serverUrl}/trpc/agentNotify.notify`, ...)
+ await fetch(`${serverUrl}/trpc/lambda/agentNotify.notify`, ...)
```

The lambda tRPC router is mounted at `/trpc/lambda/`. Every done/error signal posted by `sendNotify` hit a 404, silently swallowed by the empty `catch {}` block.

### Bug 2 — Wrong auth header in `sendNotify`

```diff
- 'Authorization': `Bearer ${token}`
+ 'Oidc-Auth': token
```

The lambda tRPC context recognises `Oidc-Auth` (and `X-API-Key`). `Authorization: Bearer` is not handled anywhere, so every request was rejected as UNAUTHORIZED — also silently swallowed.

### Bug 3 — Spawned subprocesses have no auth credentials

Desktop's Electron process starts without a login shell, so:
- `LOBEHUB_JWT` / `LOBEHUB_SERVER` are absent in child env
- `lh notify` falls back to the CLI config file, which may be missing or point at a different server

Fix: resolve the access token and server URL once, then inject them as `LOBEHUB_JWT` + `LOBEHUB_SERVER` into the child environment — matching what `lh connect` gets automatically from terminal env.

### Why CLI works but desktop didn't

| | CLI (`lh connect`) | Desktop device |
|---|---|---|
| `sendNotify` URL | uses `getTrpcClient()` → `/trpc/lambda` | was `/trpc/agentNotify.notify` (missing `/lambda/`) |
| `sendNotify` auth | `Oidc-Auth` header | was `Authorization: Bearer` (unrecognised) |
| Child env | full terminal env with `LOBEHUB_JWT` | bare `process.env` with no credentials |

## Test plan

- [x] All 53 existing unit tests in `GatewayConnectionCtr.test.ts` pass
- [ ] Manual: bind desktop as device, send a message that dispatches `runHeteroTask` to openclaw, confirm results stream back to the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)