### PR TITLE
⬆️ chore(deps): bump @lobehub/ui to 5.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -284,7 +284,7 @@
     "@lobehub/icons": "^5.0.0",
     "@lobehub/market-sdk": "0.33.3",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.14.1",
+    "@lobehub/ui": "^5.15.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@napi-rs/canvas": "^0.1.88",
     "@neondatabase/serverless": "^1.0.2",

--- a/src/features/ChatInput/ActionBar/Knowledge/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Knowledge/useControls.tsx
@@ -26,7 +26,6 @@ const styles = createStaticStyles(({ css }) => ({
 
     width: calc(100% + 8px);
     min-height: 32px;
-    margin-block-end: -4px;
     margin-inline-start: -4px;
     border: 0;
     border-radius: 6px;

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -281,7 +281,6 @@ const styles = createStaticStyles(({ css }) => ({
     align-items: center;
 
     height: 36px;
-    margin-block-start: -4px;
     margin-inline: -8px;
     padding-inline: 4px;
     border-radius: 10px;
@@ -333,9 +332,7 @@ const styles = createStaticStyles(({ css }) => ({
     display: flex;
     gap: 14px;
     align-items: center;
-
     width: 100%;
-    margin-block-end: -4px;
   `,
   statsSettingsButton: css`
     cursor: pointer;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔀 Description of Change

Bump \`@lobehub/ui\` from \`^5.14.1\` to \`^5.15.1\`.

5.15.1 migrates \`ContextMenu\`/\`DropdownMenu\` to base-ui primitives and tightens the menu density. The relevant breaking detail for our code is in the menu popup style: it now self-trims its block padding whenever a header/footer slot is present —

\`\`\`css
&[data-has-header] { padding-block-start: 0; }
&[data-has-footer] { padding-block-end: 0; }
\`\`\`

The Plus action menu (\`src/features/ChatInput/ActionBar/Plus/index.tsx\`) feeds header/footer slot content via \`useToolsControls\` and \`useKnowledgeControls\`. Those contents used \`margin-block-*: -4px\` to bleed into the popup's 4px block padding. With that padding now 0, the negative margins push content outside the popup and the new \`popupWithSlots\` rule \`overflow: hidden\` clips it.

Dropped the now-obsolete compensations:

- \`Tools/useControls.tsx\` — \`searchBox.margin-block-start: -4px\`
- \`Tools/useControls.tsx\` — \`statsFooter.margin-block-end: -4px\`
- \`Knowledge/useControls.tsx\` — \`viewMore.margin-block-end: -4px\`

Inline-axis compensations are kept — popup inline padding is unchanged.

#### 🧪 How to Test

Open the chat input \`+\` menu:
- Hover the **Tools** entry → check the submenu's search bar (header) sits inside the popup with normal spacing, no clipping.
- In the same submenu, scroll to bottom → check the stats footer (pin/auto counts + settings) is fully visible.
- Hover the **Knowledge Base** entry → check the "View more" button (footer) sits flush at the bottom without being cut off.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed