### PR TITLE
🐛 fix(model-runtime): preserve usage cost in custom streams

### DIFF
--- a/packages/model-runtime/src/core/streams/qwen.test.ts
+++ b/packages/model-runtime/src/core/streams/qwen.test.ts
@@ -1,3 +1,4 @@
+import type { Pricing } from 'model-bank';
 import type OpenAI from 'openai';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
@@ -155,6 +156,53 @@ describe('QwenAIStream', () => {
     }
 
     expect(chunks).toEqual([]);
+  });
+
+  it('should enrich usage cost when pricing payload is provided', async () => {
+    const pricing = {
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    } satisfies Pricing;
+    const mockOpenAIStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          choices: [],
+          id: 'usage-cost-id',
+          model: 'qwen-test-model',
+          object: 'chat.completion.chunk',
+          usage: {
+            completion_tokens: 500_000,
+            prompt_tokens: 1_000_000,
+            total_tokens: 1_500_000,
+          },
+        });
+        controller.close();
+      },
+    });
+    const onFinalMock = vi.fn();
+
+    const protocolStream = QwenAIStream(mockOpenAIStream, {
+      callbacks: { onFinal: onFinalMock },
+      payload: { pricing },
+    });
+    const decoder = new TextDecoder();
+    const chunks = [];
+
+    // @ts-ignore
+    for await (const chunk of protocolStream) {
+      chunks.push(decoder.decode(chunk, { stream: true }));
+    }
+
+    expect(chunks.join('')).toContain('"cost":2');
+    expect(onFinalMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        usage: expect.objectContaining({
+          cost: 2,
+        }),
+      }),
+    );
   });
 
   it('should handle chunk with no choices', async () => {

--- a/packages/model-runtime/src/core/streams/qwen.ts
+++ b/packages/model-runtime/src/core/streams/qwen.ts
@@ -8,6 +8,7 @@ import type { Stream } from 'openai/streaming';
 import type { ChatStreamCallbacks } from '../../types';
 import { convertOpenAIUsage } from '../usageConverters';
 import type {
+  ChatPayloadForTransformStream,
   StreamContext,
   StreamProtocolChunk,
   StreamProtocolToolCallChunk,
@@ -24,13 +25,17 @@ import {
 export const transformQwenStream = (
   chunk: OpenAI.ChatCompletionChunk,
   streamContext?: StreamContext,
+  payload?: ChatPayloadForTransformStream,
 ): StreamProtocolChunk | StreamProtocolChunk[] => {
   if (Array.isArray(chunk.choices) && chunk.choices.length === 0 && chunk.usage) {
-    const usage = convertOpenAIUsage({
-      ...chunk.usage,
-      completion_tokens_details: chunk.usage.completion_tokens_details || {},
-      prompt_tokens_details: chunk.usage.prompt_tokens_details || {},
-    });
+    const usage = convertOpenAIUsage(
+      {
+        ...chunk.usage,
+        completion_tokens_details: chunk.usage.completion_tokens_details || {},
+        prompt_tokens_details: chunk.usage.prompt_tokens_details || {},
+      },
+      payload,
+    );
 
     if (streamContext) {
       streamContext.usage = usage;
@@ -149,17 +154,26 @@ export const QwenAIStream = (
 
   {
     callbacks,
+    payload,
     inputStartAt,
     enableStreaming = true,
-  }: { callbacks?: ChatStreamCallbacks; enableStreaming?: boolean; inputStartAt?: number } = {},
+  }: {
+    callbacks?: ChatStreamCallbacks;
+    enableStreaming?: boolean;
+    inputStartAt?: number;
+    payload?: ChatPayloadForTransformStream;
+  } = {},
 ) => {
   const streamContext: StreamContext = { id: '' };
   const readableStream =
     stream instanceof ReadableStream ? stream : convertIterableToStream(stream);
 
+  const transformWithPayload = (chunk: OpenAI.ChatCompletionChunk, streamContext: StreamContext) =>
+    transformQwenStream(chunk, streamContext, payload);
+
   return readableStream
     .pipeThrough(
-      createTokenSpeedCalculator(transformQwenStream, {
+      createTokenSpeedCalculator(transformWithPayload, {
         enableStreaming,
         inputStartAt,
         streamStack: streamContext,

--- a/packages/model-runtime/src/core/streams/spark.test.ts
+++ b/packages/model-runtime/src/core/streams/spark.test.ts
@@ -1,3 +1,4 @@
+import type { Pricing } from 'model-bank';
 import type OpenAI from 'openai';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
@@ -106,7 +107,6 @@ describe('SparkAIStream', () => {
     } as unknown as OpenAI.ChatCompletion;
 
     const stream = transformSparkResponseToStream(mockResponse);
-    const decoder = new TextDecoder();
     const chunks = [];
 
     // @ts-ignore
@@ -268,5 +268,53 @@ describe('SparkAIStream', () => {
     }
 
     expect(chunks).toEqual([]);
+  });
+
+  it('should enrich usage cost when pricing payload is provided', async () => {
+    const pricing = {
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    } satisfies Pricing;
+    const mockStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          choices: [],
+          created: 1734395014,
+          id: 'usage-cost-id',
+          model: 'spark-test-model',
+          object: 'chat.completion.chunk',
+          usage: {
+            completion_tokens: 500_000,
+            prompt_tokens: 1_000_000,
+            total_tokens: 1_500_000,
+          },
+        } as unknown as OpenAI.ChatCompletionChunk);
+        controller.close();
+      },
+    });
+    const onFinalMock = vi.fn();
+
+    const protocolStream = SparkAIStream(mockStream, {
+      callbacks: { onFinal: onFinalMock },
+      payload: { pricing },
+    });
+    const decoder = new TextDecoder();
+    const chunks = [];
+
+    // @ts-ignore
+    for await (const chunk of protocolStream) {
+      chunks.push(decoder.decode(chunk, { stream: true }));
+    }
+
+    expect(chunks.join('')).toContain('"cost":2');
+    expect(onFinalMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        usage: expect.objectContaining({
+          cost: 2,
+        }),
+      }),
+    );
   });
 });

--- a/packages/model-runtime/src/core/streams/spark.ts
+++ b/packages/model-runtime/src/core/streams/spark.ts
@@ -3,7 +3,11 @@ import type { Stream } from 'openai/streaming';
 
 import type { ChatStreamCallbacks } from '../../types';
 import { convertOpenAIUsage } from '../usageConverters';
-import type { StreamProtocolChunk, StreamProtocolToolCallChunk } from './protocol';
+import type {
+  ChatPayloadForTransformStream,
+  StreamProtocolChunk,
+  StreamProtocolToolCallChunk,
+} from './protocol';
 import {
   convertIterableToStream,
   createCallbacksTransformer,
@@ -80,7 +84,14 @@ export function transformSparkResponseToStream(data: OpenAI.ChatCompletion) {
   });
 }
 
-export const transformSparkStream = (chunk: OpenAI.ChatCompletionChunk): StreamProtocolChunk => {
+export const transformSparkStream = (
+  chunk: OpenAI.ChatCompletionChunk,
+  payload?: ChatPayloadForTransformStream,
+): StreamProtocolChunk | StreamProtocolChunk[] => {
+  if (Array.isArray(chunk.choices) && chunk.choices.length === 0 && chunk.usage) {
+    return { data: convertOpenAIUsage(chunk.usage, payload), id: chunk.id, type: 'usage' };
+  }
+
   const item = chunk.choices[0];
 
   if (!item) {
@@ -134,8 +145,8 @@ export const transformSparkStream = (chunk: OpenAI.ChatCompletionChunk): StreamP
     if (chunk.usage) {
       return [
         { data: item.delta.content, id: chunk.id, type: 'text' },
-        { data: convertOpenAIUsage(chunk.usage), id: chunk.id, type: 'usage' },
-      ] as any;
+        { data: convertOpenAIUsage(chunk.usage, payload), id: chunk.id, type: 'usage' },
+      ];
     }
 
     return { data: item.delta.content, id: chunk.id, type: 'text' };
@@ -147,7 +158,7 @@ export const transformSparkStream = (chunk: OpenAI.ChatCompletionChunk): StreamP
 
   // Handle v2 endpoint usage
   if (chunk.usage) {
-    return { data: convertOpenAIUsage(chunk.usage), id: chunk.id, type: 'usage' };
+    return { data: convertOpenAIUsage(chunk.usage, payload), id: chunk.id, type: 'usage' };
   }
 
   return {
@@ -160,13 +171,21 @@ export const transformSparkStream = (chunk: OpenAI.ChatCompletionChunk): StreamP
 export const SparkAIStream = (
   stream: Stream<OpenAI.ChatCompletionChunk> | ReadableStream,
   // TODO: preserve for RFC 097
-  // eslint-disable-next-line unused-imports/no-unused-vars
-  { callbacks, inputStartAt }: { callbacks?: ChatStreamCallbacks; inputStartAt?: number } = {},
+  {
+    callbacks,
+    payload,
+  }: {
+    callbacks?: ChatStreamCallbacks;
+    inputStartAt?: number;
+    payload?: ChatPayloadForTransformStream;
+  } = {},
 ) => {
   const readableStream =
     stream instanceof ReadableStream ? stream : convertIterableToStream(stream);
+  const transformWithPayload = (chunk: OpenAI.ChatCompletionChunk) =>
+    transformSparkStream(chunk, payload);
 
   return readableStream
-    .pipeThrough(createSSEProtocolTransformer(transformSparkStream))
+    .pipeThrough(createSSEProtocolTransformer(transformWithPayload))
     .pipeThrough(createCallbacksTransformer(callbacks));
 };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - reported from local debug logs.

#### 🔀 Description of Change

- Pass pricing payload through Qwen and Spark custom stream usage converters so normalized usage includes computed cost.
- Preserve Qwen/Spark usage cost in stream callbacks used by post-completion billing.
- Add regression coverage for pricing-enriched usage in both custom streams.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/core/streams/qwen.test.ts'
bunx vitest run --silent='passed-only' 'src/core/streams/spark.test.ts'
bunx --bun eslint 'packages/model-runtime/src/core/streams/qwen.ts' 'packages/model-runtime/src/core/streams/qwen.test.ts' 'packages/model-runtime/src/core/streams/spark.ts' 'packages/model-runtime/src/core/streams/spark.test.ts'
```

#### 📸 Screenshots / Videos

N/A - no UI changes.

#### 📝 Additional Information

This fixes custom stream providers that already receive pricing payload from the OpenAI-compatible runtime factory but previously did not pass it into `convertOpenAIUsage`.