### PR TITLE
🐛 fix(chat-input): disable automatic URL highlighting

### DIFF
--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -409,6 +409,7 @@ const InputEditor = memo<{
     const basePlugins = !enableRichRender
       ? CHAT_INPUT_EMBED_PLUGINS
       : createChatInputRichPlugins({
+          linkPlugin: false,
           mathPlugin: Editor.withProps(ReactMathPlugin, {
             renderComp: expand
               ? undefined

--- a/src/features/ChatInput/InputEditor/plugins.ts
+++ b/src/features/ChatInput/InputEditor/plugins.ts
@@ -16,7 +16,7 @@ import { ReactReferTopicPlugin } from './ReferTopic';
 type EditorPlugins = NonNullable<Parameters<typeof Editor>[0]['plugins']>;
 
 interface CreateChatInputRichPluginsOptions {
-  linkPlugin?: EditorPlugins[number];
+  linkPlugin?: EditorPlugins[number] | false;
   mathPlugin?: EditorPlugins[number];
 }
 
@@ -34,7 +34,7 @@ export const createChatInputRichPlugins = ({
   ReactCodePlugin,
   ReactCodemirrorPlugin,
   ReactHRPlugin,
-  linkPlugin,
+  ...(linkPlugin ? [linkPlugin] : []),
   ReactVirtualBlockPlugin,
   mathPlugin,
   ...CHAT_INPUT_EMBED_PLUGINS,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

resolves LOBE-9557

#### 🔀 Description of Change

- Disable the ChatInput rich editor's automatic URL highlighting plugin so plain URLs are not serialized through the auto-link path.
- Allow the shared ChatInput rich plugin helper to omit the link plugin when a caller passes `linkPlugin: false`.
- Preserve existing explicit `ReactLinkPlugin` usage in document editor surfaces.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Validated with:

```bash
bunx eslint src/features/ChatInput/InputEditor/plugins.ts src/features/ChatInput/InputEditor/index.tsx
bunx prettier --check src/features/ChatInput/InputEditor/plugins.ts src/features/ChatInput/InputEditor/index.tsx
git diff --check -- origin/canary..HEAD
```

Full `bun run type-check` was also attempted, but this checkout currently fails on existing workspace-wide type drift outside this PR, including `@lobechat/types` export mismatches and duplicated `@lobehub/ui` / React type instances under `apps/desktop/node_modules`.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

This change intentionally affects the ChatInput editor path only.
