### PR TITLE
🐛 fix(library): add CTA in folder hierarchy empty state

### DIFF
--- a/locales/en-US/file.json
+++ b/locales/en-US/file.json
@@ -53,6 +53,8 @@
   "home.uploadEntries.folder.title": "Upload Folder",
   "home.uploadEntries.library.title": "Create New Library",
   "home.uploadEntries.newPage.title": "New Page",
+  "library.hierarchy.empty.desc": "Add files or create a folder to get started",
+  "library.hierarchy.empty.title": "Nothing here yet",
   "library.list.confirmRemoveLibrary": "You are about to delete this library. The files within it will not be deleted but moved to All Files. This action cannot be undone, so please proceed with caution.",
   "library.list.empty": "Click <1>+</1> to create a new library",
   "library.new": "New Library",

--- a/locales/zh-CN/file.json
+++ b/locales/zh-CN/file.json
@@ -53,6 +53,8 @@
   "home.uploadEntries.folder.title": "上传文件夹",
   "home.uploadEntries.library.title": "新建资源库",
   "home.uploadEntries.newPage.title": "新建文稿",
+  "library.hierarchy.empty.desc": "上传文件或新建文件夹开始整理",
+  "library.hierarchy.empty.title": "这里还没有内容",
   "library.list.confirmRemoveLibrary": "将删除该资源库（其中的文件不会删除，会移入「全部文件」）。删除后不可恢复，建议确认无误再继续",
   "library.list.empty": "点击 <1>+</1> 创建第一个资源库",
   "library.new": "新建资源库",

--- a/src/features/ResourceManager/components/LibraryHierarchy/index.tsx
+++ b/src/features/ResourceManager/components/LibraryHierarchy/index.tsx
@@ -1,7 +1,10 @@
 'use client';
 
-import { Flexbox } from '@lobehub/ui';
+import { Center, Flexbox, Icon, Text } from '@lobehub/ui';
+import { cssVar } from 'antd-style';
+import { FolderPlusIcon } from 'lucide-react';
 import { memo, useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import { VList } from 'virtua';
 
 import { useFolderPath } from '@/routes/(main)/resource/features/hooks/useFolderPath';
@@ -9,6 +12,7 @@ import { useResourceManagerStore } from '@/routes/(main)/resource/features/store
 import type { TreeItem } from '@/store/tree';
 import { useTreeStore } from '@/store/tree';
 
+import AddButton from '../Header/AddButton';
 import { KnowledgeBaseListProvider } from '../KnowledgeBaseListProvider';
 import { HierarchyNode } from './HierarchyNode';
 import TreeSkeleton from './TreeSkeleton';
@@ -21,6 +25,7 @@ interface VisibleNode {
 }
 
 const LibraryHierarchy = memo(() => {
+  const { t } = useTranslation('file');
   const { currentFolderSlug } = useFolderPath();
   const [libraryId, currentViewItemId] = useResourceManagerStore((s) => [
     s.libraryId,
@@ -69,6 +74,24 @@ const LibraryHierarchy = memo(() => {
   }
 
   const selectedKey = currentFolderSlug ?? null;
+  const isRootEmpty = !isLoading && libraryId && visibleNodes.length === 0;
+
+  if (isRootEmpty) {
+    return (
+      <KnowledgeBaseListProvider>
+        <Center gap={16} padding={24} style={{ height: '100%', textAlign: 'center' }}>
+          <Icon color={cssVar.colorTextQuaternary} icon={FolderPlusIcon} size={36} />
+          <Flexbox align={'center'} gap={4}>
+            <Text strong>{t('library.hierarchy.empty.title')}</Text>
+            <Text style={{ fontSize: 12 }} type={'secondary'}>
+              {t('library.hierarchy.empty.desc')}
+            </Text>
+          </Flexbox>
+          <AddButton />
+        </Center>
+      </KnowledgeBaseListProvider>
+    );
+  }
 
   return (
     <KnowledgeBaseListProvider>

--- a/src/locales/default/file.ts
+++ b/src/locales/default/file.ts
@@ -55,6 +55,8 @@ export default {
   'home.uploadEntries.folder.title': 'Upload Folder',
   'home.uploadEntries.library.title': 'Create New Library',
   'home.uploadEntries.newPage.title': 'New Page',
+  'library.hierarchy.empty.desc': 'Add files or create a folder to get started',
+  'library.hierarchy.empty.title': 'Nothing here yet',
   'library.list.confirmRemoveLibrary':
     'You are about to delete this library. The files within it will not be deleted but moved to All Files. This action cannot be undone, so please proceed with caution.',
   'library.list.empty': 'Click <1>+</1> to create a new library',


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-9553

#### 🔀 Description of Change

When a library had no files or folders, the sidebar folder hierarchy rendered a blank panel with no entry point — users landing on a fresh library had nothing to act on in the left pane.

This adds an empty state in `LibraryHierarchy`:

- `FolderPlus` icon + title + secondary hint
- Reuses the existing `<AddButton />` so the CTA exposes the same actions as the explorer header (new page, new folder, upload file/folder, Notion import) without duplicating dropdown logic
- Triggers only on `libraryId && !isLoading && visibleNodes.length === 0`; loading skeleton and populated tree paths are untouched

Files changed:

- `src/features/ResourceManager/components/LibraryHierarchy/index.tsx` — render empty state when the root is empty
- `src/locales/default/file.ts`, `locales/zh-CN/file.json`, `locales/en-US/file.json` — two new i18n keys (`library.hierarchy.empty.title`, `library.hierarchy.empty.desc`)

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Manual check: open an empty library and confirm the sidebar shows the icon, title, hint, and `+ Add` button; clicking the button opens the same dropdown as the explorer header.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Blank left sidebar | Icon + title + hint + `+ Add` dropdown |