### PR TITLE
🐛 fix(sidebar): respect customize sidebar order across the bottom spacer

### DIFF
--- a/locales/en-US/common.json
+++ b/locales/en-US/common.json
@@ -353,6 +353,7 @@
   "messengerBanner.title": "Talk to Lobe AI on your favorite messaging apps",
   "more": "More",
   "navPanel.agent": "Agents",
+  "navPanel.bottomDivider": "Items below anchor to bottom",
   "navPanel.customizeSidebar": "Customize Sidebar",
   "navPanel.displayItems": "Display Items",
   "navPanel.hidden": "Hidden",

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -353,6 +353,7 @@
   "messengerBanner.title": "在你喜爱的聊天应用中，与 Lobe AI 畅聊",
   "more": "更多",
   "navPanel.agent": "助理",
+  "navPanel.bottomDivider": "下方条目锚定到底部",
   "navPanel.customizeSidebar": "自定义侧边栏",
   "navPanel.displayItems": "显示条目",
   "navPanel.hidden": "已隐藏",

--- a/src/locales/default/common.ts
+++ b/src/locales/default/common.ts
@@ -436,6 +436,7 @@ export default {
   'mail.support': 'Email Support',
   'more': 'More',
   'navPanel.agent': 'Agents',
+  'navPanel.bottomDivider': 'Items below anchor to bottom',
   'navPanel.customizeSidebar': 'Customize Sidebar',
   'navPanel.displayItems': 'Display Items',
   'navPanel.resetDefault': 'Reset to Default',

--- a/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
+++ b/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
@@ -24,7 +24,7 @@ import { ActionIcon, Button, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
 import { createModal, type ModalInstance } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { t } from 'i18next';
-import { Eye, EyeOff, GripVertical, PinIcon, RotateCcw } from 'lucide-react';
+import { ArrowDownToLine, Eye, EyeOff, GripVertical, PinIcon, RotateCcw } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
@@ -32,7 +32,7 @@ import { useTranslation } from 'react-i18next';
 import { getRouteById } from '@/config/routes';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
-import { SIDEBAR_ACCORDION_KEYS } from '@/store/global/selectors/systemStatus';
+import { SIDEBAR_ACCORDION_KEYS, SIDEBAR_SPACER_ID } from '@/store/global/selectors/systemStatus';
 
 // ---------------------------------------------------------------------------
 // Types & constants
@@ -61,6 +61,7 @@ const ALL_SIDEBAR_ITEMS: SidebarItemConfig[] = [
 const ITEM_MAP = new Map(ALL_SIDEBAR_ITEMS.map((item) => [item.id, item]));
 
 const isAccordionKey = (id: string) => SIDEBAR_ACCORDION_KEYS.has(id);
+const isSpacer = (id: string) => id === SIDEBAR_SPACER_ID;
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -93,6 +94,11 @@ const styles = createStaticStyles(({ css }) => ({
 
     background: ${cssVar.colorBgElevated};
     box-shadow: ${cssVar.boxShadowSecondary};
+  `,
+  spacerLine: css`
+    flex: 1;
+    block-size: 1px;
+    background: ${cssVar.colorBorderSecondary};
   `,
 }));
 
@@ -162,6 +168,53 @@ const SortableItem = memo<{
 });
 
 // ---------------------------------------------------------------------------
+// SpacerSortableItem — represents the flex spacer slot; draggable like any
+// other item but rendered as a divider with an "Anchor below to bottom" label.
+// ---------------------------------------------------------------------------
+
+const SpacerSortableItem = memo(() => {
+  const { t } = useTranslation('common');
+  const {
+    attributes,
+    isDragging,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({ id: SIDEBAR_SPACER_ID });
+
+  return (
+    <Flexbox
+      horizontal
+      align={'center'}
+      className={isDragging ? cx(styles.item, styles.itemDragging) : styles.item}
+      gap={8}
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Translate.toString(transform),
+        transition,
+      }}
+      {...attributes}
+    >
+      <Flexbox
+        ref={setActivatorNodeRef}
+        style={{ cursor: isDragging ? 'grabbing' : 'grab', flexShrink: 0, touchAction: 'none' }}
+        {...listeners}
+      >
+        <Icon icon={GripVertical} size={14} style={{ color: cssVar.colorTextQuaternary }} />
+      </Flexbox>
+      <Icon icon={ArrowDownToLine} size={14} style={{ color: cssVar.colorTextQuaternary }} />
+      <div className={styles.spacerLine} />
+      <Text style={{ fontSize: 12 }} type={'secondary'}>
+        {t('navPanel.bottomDivider' as any)}
+      </Text>
+      <div className={styles.spacerLine} />
+    </Flexbox>
+  );
+});
+
+// ---------------------------------------------------------------------------
 // AccordionGroup — a non-draggable slot at the outer level that wraps a nested
 // SortableContext for accordion items. Registers with useSortable so other outer
 // items can reorder relative to its position, but has no drag activator of its own.
@@ -198,6 +251,18 @@ const OverlayItem = memo<{ id: string }>(({ id }) => {
         <Icon icon={GripVertical} size={14} style={{ color: cssVar.colorTextQuaternary }} />
         <Text>{t('navPanel.agent' as any)}</Text>
         <Text type={'secondary'}>+ {t('recents' as any)}</Text>
+      </Flexbox>
+    );
+  }
+
+  if (isSpacer(id)) {
+    return (
+      <Flexbox horizontal align={'center'} className={styles.overlay} gap={8}>
+        <Icon icon={GripVertical} size={14} style={{ color: cssVar.colorTextQuaternary }} />
+        <Icon icon={ArrowDownToLine} size={14} style={{ color: cssVar.colorTextQuaternary }} />
+        <Text style={{ fontSize: 12 }} type={'secondary'}>
+          {t('navPanel.bottomDivider' as any)}
+        </Text>
       </Flexbox>
     );
   }
@@ -329,9 +394,12 @@ const CustomizeSidebarContent = memo(() => {
     setItems(storeItems);
   }, [storeItems]);
 
-  const renderItem = (id: string) => (
-    <SortableItem hiddenSections={hiddenSections} id={id} key={id} onToggle={toggleSection} />
-  );
+  const renderItem = (id: string) =>
+    isSpacer(id) ? (
+      <SpacerSortableItem key={id} />
+    ) : (
+      <SortableItem hiddenSections={hiddenSections} id={id} key={id} onToggle={toggleSection} />
+    );
 
   return (
     <DndContext

--- a/src/routes/(main)/home/_layout/Body/index.test.tsx
+++ b/src/routes/(main)/home/_layout/Body/index.test.tsx
@@ -127,15 +127,26 @@ describe('Home sidebar body', () => {
     expect(mocks.updateSystemStatus).toHaveBeenCalledWith({ sidebarExpandedKeys: ['agent'] });
   });
 
-  it('keeps custom top ordering above the bottom spacer', () => {
+  it('renders items strictly in sidebarItems order with the spacer at its stored position', () => {
     mocks.navLayout = {
       bottomMenuItems: [
         { key: 'image', title: 'Image', url: '/image' },
         { key: 'resource', title: 'Resource', url: '/resource' },
       ],
-      topNavItems: [{ key: 'pages', title: 'Pages', url: '/page' }],
+      topNavItems: [
+        { key: 'pages', title: 'Pages', url: '/page' },
+        { key: 'tasks', title: 'Tasks', url: '/tasks' },
+      ],
     };
-    mocks.globalState.status.sidebarItems = ['image', 'pages', 'recents', 'agent', 'resource'];
+    mocks.globalState.status.sidebarItems = [
+      'pages',
+      'recents',
+      'agent',
+      '__spacer__',
+      'image',
+      'tasks',
+      'resource',
+    ];
 
     render(<Body />);
 
@@ -148,6 +159,25 @@ describe('Home sidebar body', () => {
     expect(children[0]).toHaveTextContent('Pages');
     expect(children[1]).toHaveAttribute('data-testid', 'sidebar-accordion');
     expect(children[3]).toHaveTextContent('Image');
-    expect(children[4]).toHaveTextContent('Resource');
+    expect(children[4]).toHaveTextContent('Tasks');
+    expect(children[5]).toHaveTextContent('Resource');
+  });
+
+  it('keeps a top item that was dragged past the spacer in its new position', () => {
+    mocks.navLayout = {
+      bottomMenuItems: [{ key: 'image', title: 'Image', url: '/image' }],
+      topNavItems: [{ key: 'tasks', title: 'Tasks', url: '/tasks' }],
+    };
+    // User dragged `tasks` from the top section to sit after `image`.
+    mocks.globalState.status.sidebarItems = ['recents', 'agent', '__spacer__', 'image', 'tasks'];
+
+    render(<Body />);
+
+    const children = Array.from(screen.getByTestId('sidebar-body').children);
+
+    expect(children[0]).toHaveAttribute('data-testid', 'sidebar-accordion');
+    expect(children[1]).toHaveAttribute('data-sidebar-bottom-spacer');
+    expect(children[2]).toHaveTextContent('Image');
+    expect(children[3]).toHaveTextContent('Tasks');
   });
 });

--- a/src/routes/(main)/home/_layout/Body/index.tsx
+++ b/src/routes/(main)/home/_layout/Body/index.tsx
@@ -15,6 +15,7 @@ import { useNavLayout } from '@/hooks/useNavLayout';
 import Recents from '@/routes/(main)/home/features/Recents';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
+import { SIDEBAR_SPACER_ID } from '@/store/global/selectors/systemStatus';
 import { isModifierClick } from '@/utils/navigation';
 
 import Agent from './Agent';
@@ -100,14 +101,9 @@ const Body = memo(() => {
     return map;
   }, [topNavItems, bottomMenuItems]);
 
-  const bottomNavKeys = useMemo(
-    () => new Set(bottomMenuItems.map((item) => item.key)),
-    [bottomMenuItems],
-  );
-
   // Items that must always be visible regardless of hiddenSections
   const isVisible = useCallback(
-    (k: string) => k === GroupKey.Agent || !hiddenSections.includes(k),
+    (k: string) => k === GroupKey.Agent || k === SIDEBAR_SPACER_ID || !hiddenSections.includes(k),
     [hiddenSections],
   );
 
@@ -160,70 +156,55 @@ const Body = memo(() => {
     [sidebarExpandedKeys, updateSystemStatus],
   );
 
-  // Render the flat list: group consecutive accordion items into an Accordion,
-  // interleave non-accordion keys as nav links.
+  // Render the flat list in `sidebarItems` order: group consecutive accordion
+  // items into an Accordion, interleave non-accordion keys as nav links, and
+  // emit a flex spacer wherever the spacer sentinel appears.
   const content = useMemo(() => {
-    const renderSection = (keys: string[], section: 'bottom' | 'top') => {
-      const elements: ReactElement[] = [];
-      let accGroup: { element: ReactElement; key: string }[] = [];
+    const elements: ReactElement[] = [];
+    let accGroup: { element: ReactElement; key: string }[] = [];
 
-      const flushAccordion = () => {
-        if (accGroup.length > 0) {
-          const accordionKeys = accGroup.map((item) => item.key);
+    const flushAccordion = () => {
+      if (accGroup.length > 0) {
+        const accordionKeys = accGroup.map((item) => item.key);
 
-          elements.push(
-            <Accordion
-              expandedKeys={sidebarExpandedKeys}
-              gap={8}
-              key={`${section}-acc-${elements.length}`}
-              onExpandedChange={(keys) => handleAccordionExpandedChange(accordionKeys, keys)}
-            >
-              {accGroup.map((item) => item.element)}
-            </Accordion>,
-          );
-          accGroup = [];
-        }
-      };
-
-      for (const key of keys) {
-        if (ACCORDION_KEYS.has(key)) {
-          const comp = accordionComponents[key]?.(key);
-          if (comp) accGroup.push({ element: comp, key });
-        } else {
-          flushAccordion();
-          const link = renderNavLink(key);
-          if (link) elements.push(link);
-        }
+        elements.push(
+          <Accordion
+            expandedKeys={sidebarExpandedKeys}
+            gap={8}
+            key={`acc-${elements.length}`}
+            onExpandedChange={(keys) => handleAccordionExpandedChange(accordionKeys, keys)}
+          >
+            {accGroup.map((item) => item.element)}
+          </Accordion>,
+        );
+        accGroup = [];
       }
-      flushAccordion();
-
-      return elements;
     };
 
-    const topKeys = visibleKeys.filter((key) => !bottomNavKeys.has(key));
-    const bottomKeys = visibleKeys.filter((key) => bottomNavKeys.has(key));
-    const topElements = renderSection(topKeys, 'top');
-    const bottomElements = renderSection(bottomKeys, 'bottom');
+    for (const key of visibleKeys) {
+      if (key === SIDEBAR_SPACER_ID) {
+        flushAccordion();
+        elements.push(
+          <div
+            aria-hidden
+            data-sidebar-bottom-spacer
+            key={`spacer-${elements.length}`}
+            style={{ flex: '1 1 0', minHeight: 0 }}
+          />,
+        );
+      } else if (ACCORDION_KEYS.has(key)) {
+        const comp = accordionComponents[key]?.(key);
+        if (comp) accGroup.push({ element: comp, key });
+      } else {
+        flushAccordion();
+        const link = renderNavLink(key);
+        if (link) elements.push(link);
+      }
+    }
+    flushAccordion();
 
-    if (bottomElements.length === 0) return topElements;
-
-    return [
-      ...topElements,
-      <div
-        aria-hidden
-        data-sidebar-bottom-spacer
-        key={'bottom-nav-spacer'}
-        style={{ flex: '1 1 0', minHeight: 0 }}
-      />,
-      ...bottomElements,
-    ];
-  }, [
-    visibleKeys,
-    renderNavLink,
-    sidebarExpandedKeys,
-    handleAccordionExpandedChange,
-    bottomNavKeys,
-  ]);
+    return elements;
+  }, [visibleKeys, renderNavLink, sidebarExpandedKeys, handleAccordionExpandedChange]);
 
   return (
     <Flexbox flex={1} gap={1} paddingInline={4} style={{ minHeight: '100%' }}>

--- a/src/store/global/selectors/systemStatus.test.ts
+++ b/src/store/global/selectors/systemStatus.test.ts
@@ -9,7 +9,12 @@ import {
   INITIAL_STATUS,
   initialState,
 } from '../initialState';
-import { DEFAULT_SIDEBAR_ITEMS, reorderSidebarItems, systemStatusSelectors } from './systemStatus';
+import {
+  DEFAULT_SIDEBAR_ITEMS,
+  reorderSidebarItems,
+  SIDEBAR_SPACER_ID,
+  systemStatusSelectors,
+} from './systemStatus';
 
 // Mock version constants
 vi.mock('@/const/version', () => ({
@@ -128,8 +133,8 @@ describe('systemStatusSelectors', () => {
       expect(systemStatusSelectors.sidebarItems(initialState)).toEqual(DEFAULT_SIDEBAR_ITEMS);
     });
 
-    it('should return stored items when set', () => {
-      const custom = [
+    it('should preserve stored order and inject the spacer before the first bottom item', () => {
+      const stored = [
         'agent',
         'recents',
         'pages',
@@ -140,12 +145,40 @@ describe('systemStatusSelectors', () => {
         'memory',
       ];
       const s: GlobalState = merge(initialState, {
-        status: { sidebarItems: custom },
+        status: { sidebarItems: stored },
       });
-      expect(systemStatusSelectors.sidebarItems(s)).toEqual(custom);
+      expect(systemStatusSelectors.sidebarItems(s)).toEqual([
+        'agent',
+        'recents',
+        'pages',
+        'tasks',
+        SIDEBAR_SPACER_ID,
+        'image',
+        'community',
+        'resource',
+        'memory',
+      ]);
     });
 
-    it('should append missing known keys to the end', () => {
+    it('should respect the stored spacer position', () => {
+      const stored = [
+        'pages',
+        'recents',
+        'agent',
+        SIDEBAR_SPACER_ID,
+        'image',
+        'tasks',
+        'community',
+        'resource',
+        'memory',
+      ];
+      const s: GlobalState = merge(initialState, {
+        status: { sidebarItems: stored },
+      });
+      expect(systemStatusSelectors.sidebarItems(s)).toEqual(stored);
+    });
+
+    it('should append missing known keys to the end and keep the spacer anchored', () => {
       const s: GlobalState = merge(initialState, {
         status: { sidebarItems: ['agent', 'recents'] },
       });
@@ -157,6 +190,11 @@ describe('systemStatusSelectors', () => {
       expect(items).toContain('community');
       expect(items).toContain('resource');
       expect(items).toContain('memory');
+      // spacer sits directly before the first bottom-class item
+      const firstBottomIdx = items.findIndex((k) =>
+        ['image', 'community', 'resource', 'memory'].includes(k),
+      );
+      expect(items[firstBottomIdx - 1]).toBe(SIDEBAR_SPACER_ID);
     });
 
     it('should migrate legacy `sidebarSectionOrder` accordion order into the default layout', () => {
@@ -170,6 +208,7 @@ describe('systemStatusSelectors', () => {
         'pages',
         'agent',
         'recents',
+        SIDEBAR_SPACER_ID,
         'image',
         'community',
         'resource',

--- a/src/store/global/selectors/systemStatus.ts
+++ b/src/store/global/selectors/systemStatus.ts
@@ -50,11 +50,16 @@ const hiddenSidebarSections = (s: GlobalState): string[] =>
 const sidebarExpandedKeys = (s: GlobalState): string[] =>
   s.status.sidebarExpandedKeys ?? DEFAULT_HOME_SIDEBAR_EXPANDED_KEYS;
 
+/** Sentinel id representing the flex spacer slot. Its position in `sidebarItems`
+ * determines where the sidebar pushes items to the bottom. */
+export const SIDEBAR_SPACER_ID = '__spacer__';
+
 export const DEFAULT_SIDEBAR_ITEMS: string[] = [
   'tasks',
   'pages',
   'recents',
   'agent',
+  SIDEBAR_SPACER_ID,
   'image',
   'community',
   'resource',
@@ -64,11 +69,25 @@ export const DEFAULT_SIDEBAR_ITEMS: string[] = [
 /** Items that must stay contiguous in the sidebar list (accordion block). */
 export const SIDEBAR_ACCORDION_KEYS = new Set(['recents', 'agent']);
 
+const DEFAULT_BOTTOM_KEYS = new Set(
+  DEFAULT_SIDEBAR_ITEMS.slice(DEFAULT_SIDEBAR_ITEMS.indexOf(SIDEBAR_SPACER_ID) + 1),
+);
+
+/** Insert the spacer sentinel into `order` if missing — anchored before the first
+ * default "bottom" item (image/community/...), falling back to the end. */
+const ensureSpacer = (order: string[]): string[] => {
+  if (order.includes(SIDEBAR_SPACER_ID)) return order;
+  const insertAt = order.findIndex((k) => DEFAULT_BOTTOM_KEYS.has(k));
+  if (insertAt === -1) return [...order, SIDEBAR_SPACER_ID];
+  return [...order.slice(0, insertAt), SIDEBAR_SPACER_ID, ...order.slice(insertAt)];
+};
+
 /** Append any known keys missing from `order` so new items don't disappear on upgrade. */
 const withAllKnownKeys = (order: string[]): string[] => {
   const present = new Set(order);
-  const missing = DEFAULT_SIDEBAR_ITEMS.filter((k) => !present.has(k));
-  return missing.length === 0 ? order : [...order, ...missing];
+  const missing = DEFAULT_SIDEBAR_ITEMS.filter((k) => k !== SIDEBAR_SPACER_ID && !present.has(k));
+  const withMissing = missing.length === 0 ? order : [...order, ...missing];
+  return ensureSpacer(withMissing);
 };
 
 const accordionIndices = (items: string[]): number[] => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The home sidebar previously split items into hard-coded top/bottom buckets via `useNavLayout().bottomMenuItems` (`image`/`community`/`resource`/`memory`). Anything in that set was always rendered below the flex spacer, regardless of where the user dragged it inside the Customize Sidebar modal. So reordering an item across the spacer — e.g. dragging `tasks` to sit after `image`, or `community` to the very top — had no visible effect in the sidebar even though the modal showed the new order.

This PR fixes it by making the spacer itself a first-class entry (`SIDEBAR_SPACER_ID = '__spacer__'`) in `sidebarItems`:

- `DEFAULT_SIDEBAR_ITEMS` now includes the spacer between `agent` and `image`, preserving the current default look.
- A new `ensureSpacer` helper migrates persisted lists that don't have the sentinel by inserting it before the first "bottom-class" item.
- `CustomizeSidebarModal` renders the spacer as a draggable divider row (grip + `ArrowDownToLine` + label `navPanel.bottomDivider` + lines on both sides), with a matching drag-overlay representation.
- `Body/index.tsx` drops the top/bottom split entirely and renders strictly in `sidebarItems` order, emitting the `flex:1` placeholder wherever the spacer key appears.

Net result: the user fully controls which items anchor to the bottom by dragging the spacer (or items past it). Default visual unchanged.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Selector unit tests cover spacer injection / migration / preservation. Body component tests cover the new rendering rules:
- `renders items strictly in sidebarItems order with the spacer at its stored position`
- `keeps a top item that was dragged past the spacer in its new position`

Manual flow:
1. Open the home sidebar → context-menu on any item → **Customize Sidebar**.
2. Drag e.g. `Tasks` to sit below `Image` (across the divider row).
3. Close the modal — `Tasks` should now appear below the spacer in the sidebar.
4. Drag the divider row itself; items below it follow.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Reordering across the bottom spacer in the modal had no visible effect — `image`/`community`/`resource`/`memory` were always pinned below the spacer. | Sidebar order matches the modal verbatim; the spacer is a draggable row whose position determines what anchors to the bottom. |

#### 📝 Additional Information

Migration is automatic: existing `sidebarItems` without the spacer key get one injected on read (before the first default bottom-class item, or appended if none present).