### PR TITLE
💄 polish(agent-topic-manager): lighter bulk-bar shadow, transparent tool-auth alert, preserve sub-route

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -818,7 +818,7 @@
   "tool.intervention.viewParameters": "View parameters ({{count}})",
   "toolAuth.authorize": "Authorize",
   "toolAuth.authorizing": "Authorizing...",
-  "toolAuth.hint": "Without authorization or configuration, Skills may not work. This can limit the Agent or cause errors.",
+  "toolAuth.hint": "When Skills aren't authorized or configured, the related Skills won't work and the Agent's capabilities may be limited or run into errors.",
   "toolAuth.signIn": "Sign In",
   "toolAuth.title": "Authorize Skills for this Agent",
   "topic.checkOpenNewTopic": "Start a new topic?",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -818,7 +818,7 @@
   "tool.intervention.viewParameters": "查看参数 ({{count}})",
   "toolAuth.authorize": "授权",
   "toolAuth.authorizing": "授权中…",
-  "toolAuth.hint": "未授权或未配置时，相关技能无法使用。这可能导致助理能力受限或报错",
+  "toolAuth.hint": "技能未授权或未配置时，相关技能无法使用，可能导致助理能力受限或报错",
   "toolAuth.signIn": "登录",
   "toolAuth.title": "为助理完成技能授权",
   "topic.checkOpenNewTopic": "要开启新话题吗？",

--- a/packages/builtin-tools/src/inspectors.ts
+++ b/packages/builtin-tools/src/inspectors.ts
@@ -66,6 +66,7 @@ import type { BuiltinInspector } from '@lobechat/types';
 import { CodexInspectors } from './codex';
 import { GithubIdentifier, GithubInspectors } from './github';
 import { LinearIdentifier, LinearInspectors } from './linear';
+import { TwitterIdentifier, TwitterInspectors } from './twitter';
 
 /**
  * Builtin tools inspector registry
@@ -113,6 +114,7 @@ const BuiltinToolInspectors: Record<string, Record<string, BuiltinInspector>> = 
   },
   [GithubIdentifier]: GithubInspectors,
   [LinearIdentifier]: LinearInspectors,
+  [TwitterIdentifier]: TwitterInspectors,
 };
 
 export interface BuiltinInspectorRegistryEntry {

--- a/packages/builtin-tools/src/twitter/index.ts
+++ b/packages/builtin-tools/src/twitter/index.ts
@@ -1,0 +1,20 @@
+import { TwitterInspector } from '@lobechat/shared-tool-ui/inspectors';
+import type { BuiltinInspector } from '@lobechat/types';
+
+// LobeHub X (Twitter) skill: tool calls arrive with `identifier='twitter'`
+// and bare verb_noun apiNames (`get_tweet`, `get_user`, `post_tweet`,
+// `search_tweets`, …). The MCP surface isn't fixed in this repo, so we
+// register the inspector through a Proxy that returns it for any apiName
+// under the twitter identifier — the inspector's verb_noun parser handles
+// labels generically and falls back gracefully on unknown verbs.
+export const TwitterIdentifier = 'twitter';
+
+export const TwitterInspectors: Record<string, BuiltinInspector> = new Proxy(
+  {} as Record<string, BuiltinInspector>,
+  {
+    get: (_target, prop) => {
+      if (typeof prop !== 'string') return undefined;
+      return TwitterInspector;
+    },
+  },
+);

--- a/packages/shared-tool-ui/src/Inspector/Linear/Inspector.tsx
+++ b/packages/shared-tool-ui/src/Inspector/Linear/Inspector.tsx
@@ -28,7 +28,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     flex-shrink: 0;
     padding-block: 2px;
     padding-inline: 10px;
-    color: ${cssVar.colorTextSecondary};
+    color: ${cssVar.colorText};
   `,
   chipDivider: css`
     flex-shrink: 0;
@@ -55,7 +55,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     padding-inline: 10px;
 
     font-family: ${cssVar.fontFamilyCode};
-    color: ${cssVar.colorTextSecondary};
+    color: ${cssVar.colorText};
   `,
   chipValueText: css`
     overflow: hidden;
@@ -81,7 +81,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
     font-family: ${cssVar.fontFamilyCode};
     font-size: 12px;
-    color: ${cssVar.colorTextSecondary};
+    color: ${cssVar.colorText};
 
     background: ${cssVar.colorFillQuaternary};
   `,

--- a/packages/shared-tool-ui/src/Inspector/Linear/Inspector.tsx
+++ b/packages/shared-tool-ui/src/Inspector/Linear/Inspector.tsx
@@ -28,7 +28,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     flex-shrink: 0;
     padding-block: 2px;
     padding-inline: 10px;
-    color: ${cssVar.colorText};
+    color: ${cssVar.colorTextSecondary};
   `,
   chipDivider: css`
     flex-shrink: 0;
@@ -55,7 +55,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     padding-inline: 10px;
 
     font-family: ${cssVar.fontFamilyCode};
-    color: ${cssVar.colorText};
+    color: ${cssVar.colorTextSecondary};
   `,
   chipValueText: css`
     overflow: hidden;
@@ -81,7 +81,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
     font-family: ${cssVar.fontFamilyCode};
     font-size: 12px;
-    color: ${cssVar.colorText};
+    color: ${cssVar.colorTextSecondary};
 
     background: ${cssVar.colorFillQuaternary};
   `,
@@ -96,7 +96,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
     font-size: 13px;
     font-weight: 500;
-    color: ${cssVar.colorText};
+    color: ${cssVar.colorTextSecondary};
   `,
 }));
 

--- a/packages/shared-tool-ui/src/Inspector/Twitter/Inspector.tsx
+++ b/packages/shared-tool-ui/src/Inspector/Twitter/Inspector.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import type { BuiltinInspector, BuiltinInspectorProps } from '@lobechat/types';
+import { createStaticStyles, cx } from 'antd-style';
+import { memo } from 'react';
+
+import { inspectorTextStyles, shinyTextStyles } from '../../styles';
+import { type ParsedTwitterTool, parseTwitterToolName, staticTwitterLabelFor } from './labels';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  chip: css`
+    overflow: hidden;
+    display: inline-flex;
+    flex-shrink: 1;
+    align-items: stretch;
+
+    min-width: 0;
+    margin-inline-start: 6px;
+    border-radius: 999px;
+
+    font-size: 12px;
+    line-height: 18px;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  chipAction: css`
+    flex-shrink: 0;
+    padding-block: 2px;
+    padding-inline: 10px;
+    color: ${cssVar.colorTextSecondary};
+  `,
+  chipDivider: css`
+    flex-shrink: 0;
+    align-self: stretch;
+    width: 1px;
+    background: ${cssVar.colorBorderSecondary};
+  `,
+  chipKey: css`
+    color: ${cssVar.colorTextDescription};
+  `,
+  chipValue: css`
+    overflow: hidden;
+    display: inline-flex;
+    flex-shrink: 1;
+    gap: 4px;
+    align-items: center;
+
+    min-width: 0;
+    padding-block: 2px;
+    padding-inline: 10px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    color: ${cssVar.colorTextSecondary};
+  `,
+  chipValueText: css`
+    overflow: hidden;
+    min-width: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  icon: css`
+    flex-shrink: 0;
+    margin-inline-end: 6px;
+    color: ${cssVar.colorTextDescription};
+  `,
+  productPrefix: css`
+    flex-shrink: 0;
+
+    margin-inline-end: 2px;
+
+    font-size: 13px;
+    font-weight: 500;
+    color: ${cssVar.colorTextSecondary};
+  `,
+}));
+
+const XLogomark = memo<{ size?: number }>(({ size = 14 }) => (
+  <svg
+    aria-hidden="true"
+    className={styles.icon}
+    height={size}
+    viewBox="0 0 1200 1227"
+    width={size}
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M714.163 519.284 1160.89 0h-105.86L667.137 450.887 357.328 0H0l468.492 681.821L0 1226.37h105.866l409.625-476.152 327.181 476.152H1200L714.137 519.284h.026Zm-145 168.544-47.468-67.894L144.011 79.694h162.604l304.797 435.991 47.468 67.894 396.2 566.721H892.476L569.165 687.854Z"
+      fill="currentColor"
+    />
+  </svg>
+));
+XLogomark.displayName = 'XLogomark';
+
+const labelFor = (parsed: ParsedTwitterTool): string => staticTwitterLabelFor(parsed);
+
+const truncate = (value: string, max = 60): string =>
+  value.length > max ? `${value.slice(0, max - 1)}…` : value;
+
+const stringArg = (args: Record<string, unknown> | undefined, key: string): string | undefined => {
+  const value = args?.[key];
+  if (typeof value === 'string' && value.length > 0) return value;
+  if (typeof value === 'number') return String(value);
+  return undefined;
+};
+
+interface Chip {
+  key?: string;
+  value: string;
+}
+
+const PRIMARY_MAX = 60;
+
+// Twitter-specific arg priority — tweet IDs and usernames first, then text-
+// shaped fields (query, text, content) for search/post-style calls.
+const PRIMARY_KEYS_ORDERED = [
+  'tweetId',
+  'tweet_id',
+  'id',
+  'username',
+  'userId',
+  'user_id',
+  'screen_name',
+  'handle',
+  'query',
+  'q',
+  'text',
+  'content',
+  'status',
+  'message',
+  'listId',
+  'list_id',
+  'name',
+];
+
+const pickPrimaryChip = (args: Record<string, unknown> | undefined): Chip | null => {
+  if (!args) return null;
+
+  for (const key of PRIMARY_KEYS_ORDERED) {
+    const value = stringArg(args, key);
+    if (value) return { key, value: truncate(value, PRIMARY_MAX) };
+  }
+
+  for (const [key, value] of Object.entries(args)) {
+    if (typeof value === 'string' && value.length > 0) {
+      return { key, value: truncate(value, PRIMARY_MAX) };
+    }
+  }
+  return null;
+};
+
+const TwitterInspectorImpl = memo<BuiltinInspectorProps<Record<string, unknown>>>(
+  ({ apiName, args, partialArgs, isArgumentsStreaming, isLoading }) => {
+    const effectiveArgs = args ?? partialArgs;
+    const parsed = parseTwitterToolName(apiName);
+    const label = labelFor(parsed);
+    const primary = pickPrimaryChip(effectiveArgs);
+
+    return (
+      <div
+        className={cx(
+          inspectorTextStyles.root,
+          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
+        )}
+      >
+        <XLogomark />
+        <span className={styles.productPrefix}>X (Twitter)</span>
+        <span className={styles.chip}>
+          <span className={styles.chipAction}>{label}</span>
+          {primary && (
+            <>
+              <span className={styles.chipDivider} />
+              <span className={styles.chipValue}>
+                {primary.key && <span className={styles.chipKey}>{primary.key}:</span>}
+                <span className={styles.chipValueText}>{primary.value}</span>
+              </span>
+            </>
+          )}
+        </span>
+      </div>
+    );
+  },
+);
+TwitterInspectorImpl.displayName = 'TwitterInspector';
+
+export const TwitterInspector = TwitterInspectorImpl as unknown as BuiltinInspector;

--- a/packages/shared-tool-ui/src/Inspector/Twitter/Inspector.tsx
+++ b/packages/shared-tool-ui/src/Inspector/Twitter/Inspector.tsx
@@ -27,7 +27,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     flex-shrink: 0;
     padding-block: 2px;
     padding-inline: 10px;
-    color: ${cssVar.colorTextSecondary};
+    color: ${cssVar.colorText};
   `,
   chipDivider: css`
     flex-shrink: 0;
@@ -50,7 +50,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     padding-inline: 10px;
 
     font-family: ${cssVar.fontFamilyCode};
-    color: ${cssVar.colorTextSecondary};
+    color: ${cssVar.colorText};
   `,
   chipValueText: css`
     overflow: hidden;

--- a/packages/shared-tool-ui/src/Inspector/Twitter/index.ts
+++ b/packages/shared-tool-ui/src/Inspector/Twitter/index.ts
@@ -1,0 +1,2 @@
+export { TwitterInspector } from './Inspector';
+export { type ParsedTwitterTool, parseTwitterToolName, staticTwitterLabelFor } from './labels';

--- a/packages/shared-tool-ui/src/Inspector/Twitter/labels.ts
+++ b/packages/shared-tool-ui/src/Inspector/Twitter/labels.ts
@@ -1,0 +1,95 @@
+// Pure label utilities for X (Twitter) tool calls — consumed by both the
+// LobeHub built-in X (Twitter) skill (bare apiName='get_tweet', …) and
+// (potentially) the CC adapter when the same wire names are surfaced via
+// MCP.
+//
+// Kept free of React / antd-style imports so collapsed-summary paths can
+// pull these helpers without dragging the inspector component (and its
+// style modules) into tests transitively.
+
+export interface ParsedTwitterTool {
+  noun: string;
+  verb:
+    | 'get'
+    | 'list'
+    | 'search'
+    | 'post'
+    | 'create'
+    | 'delete'
+    | 'update'
+    | 'like'
+    | 'unlike'
+    | 'retweet'
+    | 'unretweet'
+    | 'reply'
+    | 'quote'
+    | 'follow'
+    | 'unfollow'
+    | 'mute'
+    | 'unmute'
+    | 'block'
+    | 'unblock'
+    | 'bookmark'
+    | 'unbookmark'
+    | 'add'
+    | 'remove'
+    | 'other';
+}
+
+// Multi-word suffixes that a naive split would mangle.
+const NOUN_OVERRIDES: Record<string, string> = {
+  home_timeline: 'home timeline',
+  to_list: 'to list',
+  user_timeline: 'user timeline',
+};
+
+export const parseTwitterToolName = (apiName: string): ParsedTwitterTool => {
+  const underscoreIdx = apiName.indexOf('_');
+  if (underscoreIdx <= 0) return { noun: apiName, verb: 'other' };
+
+  const head = apiName.slice(0, underscoreIdx);
+  const tail = apiName.slice(underscoreIdx + 1);
+  const noun = NOUN_OVERRIDES[tail] ?? tail.replaceAll('_', ' ');
+
+  switch (head) {
+    case 'get':
+    case 'list':
+    case 'search':
+    case 'post':
+    case 'create':
+    case 'delete':
+    case 'update':
+    case 'like':
+    case 'unlike':
+    case 'retweet':
+    case 'unretweet':
+    case 'reply':
+    case 'quote':
+    case 'follow':
+    case 'unfollow':
+    case 'mute':
+    case 'unmute':
+    case 'block':
+    case 'unblock':
+    case 'bookmark':
+    case 'unbookmark':
+    case 'add':
+    case 'remove': {
+      return { noun, verb: head };
+    }
+    default: {
+      return { noun: apiName.replaceAll('_', ' '), verb: 'other' };
+    }
+  }
+};
+
+const capitalize = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+
+// Args-free verb label; the collapsed-summary view has no runtime args.
+export const staticTwitterLabelFor = (parsed: ParsedTwitterTool): string => {
+  const { verb, noun } = parsed;
+  if (verb === 'other') return capitalize(noun);
+  // `retweet` / `unretweet` already imply the noun.
+  if (verb === 'retweet' || verb === 'unretweet') return capitalize(verb);
+  return `${capitalize(verb)} ${noun}`;
+};

--- a/packages/shared-tool-ui/src/Inspector/index.ts
+++ b/packages/shared-tool-ui/src/Inspector/index.ts
@@ -7,4 +7,5 @@ export { createMoveLocalFilesInspector } from './MoveLocalFiles';
 export { createReadLocalFileInspector } from './ReadLocalFile';
 export { createRunCommandInspector, RunCommandInspector } from './RunCommand';
 export { createSearchLocalFilesInspector } from './SearchLocalFiles';
+export { TwitterInspector } from './Twitter';
 export { createWriteLocalFileInspector } from './WriteLocalFile';

--- a/src/features/AgentTopicManager/BulkActionBar.tsx
+++ b/src/features/AgentTopicManager/BulkActionBar.tsx
@@ -21,9 +21,7 @@ const styles = createStaticStyles(({ css }) => ({
     border-radius: 999px;
 
     background: ${cssVar.colorBgElevated};
-    box-shadow:
-      0 4px 12px rgb(0 0 0 / 8%),
-      0 1px 3px rgb(0 0 0 / 6%);
+    box-shadow: ${cssVar.boxShadowSecondary};
   `,
   divider: css`
     width: 1px;

--- a/src/features/AgentTopicManager/BulkActionBar.tsx
+++ b/src/features/AgentTopicManager/BulkActionBar.tsx
@@ -22,8 +22,8 @@ const styles = createStaticStyles(({ css }) => ({
 
     background: ${cssVar.colorBgElevated};
     box-shadow:
-      0 12px 32px rgb(0 0 0 / 24%),
-      0 2px 6px rgb(0 0 0 / 16%);
+      0 4px 12px rgb(0 0 0 / 8%),
+      0 1px 3px rgb(0 0 0 / 6%);
   `,
   divider: css`
     width: 1px;

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -899,7 +899,7 @@ export default {
   'toolAuth.authorize': 'Authorize',
   'toolAuth.authorizing': 'Authorizing...',
   'toolAuth.hint':
-    'Without authorization or configuration, Skills may not work. This can limit the Agent or cause errors.',
+    "When Skills aren't authorized or configured, the related Skills won't work and the Agent's capabilities may be limited or run into errors.",
   'task.title': 'Tasks',
   'toolAuth.signIn': 'Sign In',
   'toolAuth.title': 'Authorize Skills for this Agent',

--- a/src/routes/(main)/agent/features/Conversation/AgentWelcome/ToolAuthAlert.tsx
+++ b/src/routes/(main)/agent/features/Conversation/AgentWelcome/ToolAuthAlert.tsx
@@ -317,7 +317,7 @@ const ToolAuthAlert = memo(() => {
   return (
     <Alert
       showIcon={false}
-      style={{ width: '100%' }}
+      style={{ background: 'transparent', width: '100%' }}
       type="secondary"
       description={
         <>

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/index.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/index.tsx
@@ -1,4 +1,3 @@
-import { SESSION_CHAT_URL } from '@lobechat/const';
 import { HETEROGENEOUS_TYPE_LABELS } from '@lobechat/heterogeneous-agents';
 import { type SidebarAgentItem } from '@lobechat/types';
 import { ActionIcon, Flexbox, Icon, Tag } from '@lobehub/ui';
@@ -7,7 +6,7 @@ import { Loader2, PinIcon } from 'lucide-react';
 import { type CSSProperties, type DragEvent } from 'react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { usePrefetchAgent } from '@/hooks/usePrefetchAgent';
@@ -18,12 +17,9 @@ import { useHomeStore } from '@/store/home';
 
 import { useAgentModal } from '../../ModalProvider';
 import Actions from '../Item/Actions';
+import { usePreservedAgentUrl } from '../usePreservedAgentUrl';
 import Avatar from './Avatar';
 import { useAgentDropdownMenu } from './useDropdownMenu';
-
-// Sub-routes that are agent-scoped views (not tied to a specific topic/task id),
-// safe to carry over when switching between agents from the sidebar switcher.
-const PRESERVED_AGENT_SUB_PATHS = new Set(['topics', 'profile', 'channel']);
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   badge: css`
@@ -119,19 +115,7 @@ const AgentItem = memo<AgentItemProps>(({ item, style, className, onNavigate }) 
     displayTitle
   );
 
-  // Get URL for this agent — when switching from within an agent's sub-view
-  // (e.g. /agent/A/topics), preserve the sub-route on the new agent so users
-  // don't lose their place. Only safe for agent-scoped views; topic/task ids
-  // belong to the previous agent and must not be carried over.
-  const { pathname } = useLocation();
-  const agentUrl = useMemo(() => {
-    const match = pathname.match(/^\/agent\/[^/]+\/([^/]+)\/?$/);
-    const subPath = match?.[1];
-    if (subPath && PRESERVED_AGENT_SUB_PATHS.has(subPath)) {
-      return `/agent/${id}/${subPath}`;
-    }
-    return SESSION_CHAT_URL(id, false);
-  }, [id, pathname]);
+  const agentUrl = usePreservedAgentUrl(id);
 
   // Memoize event handlers
   const handleMouseEnter = useCallback(() => {

--- a/src/routes/(main)/home/_layout/Body/Agent/List/InboxItem.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/InboxItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DEFAULT_INBOX_AVATAR, SESSION_CHAT_URL } from '@lobechat/const';
+import { DEFAULT_INBOX_AVATAR } from '@lobechat/const';
 import { Avatar, Icon } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { Loader2 } from 'lucide-react';
@@ -14,6 +14,8 @@ import { useAgentStore } from '@/store/agent';
 import { agentSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { operationSelectors } from '@/store/chat/selectors';
+
+import { usePreservedAgentUrl } from './usePreservedAgentUrl';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   runningBadge: css`
@@ -57,7 +59,7 @@ const InboxItem = memo<InboxItemProps>(({ className, style }) => {
   const prefetchAgent = usePrefetchAgent();
   const inboxAgentTitle = inboxMeta.title || 'Lobe AI';
   const inboxAgentAvatar = inboxMeta.avatar || DEFAULT_INBOX_AVATAR;
-  const inboxUrl = SESSION_CHAT_URL(inboxAgentId, false);
+  const inboxUrl = usePreservedAgentUrl(inboxAgentId!);
 
   // Prefetch agent layout chunk and data eagerly since Lobe AI is almost always clicked
   prefetchAgent(inboxAgentId!);

--- a/src/routes/(main)/home/_layout/Body/Agent/List/usePreservedAgentUrl.ts
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/usePreservedAgentUrl.ts
@@ -1,0 +1,25 @@
+import { SESSION_CHAT_URL } from '@lobechat/const';
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
+
+// Sub-routes that are agent-scoped views (not tied to a specific topic/task id),
+// safe to carry over when switching between agents from the sidebar switcher.
+const PRESERVED_AGENT_SUB_PATHS = new Set(['topics', 'profile', 'channel']);
+
+/**
+ * When switching from an agent's sub-view (e.g. `/agent/A/topics`) to another
+ * agent, preserve the sub-route on the destination so the user lands on the
+ * same view. Topic / task ids belong to the previous agent and are
+ * intentionally dropped.
+ */
+export const usePreservedAgentUrl = (agentId: string): string => {
+  const { pathname } = useLocation();
+  return useMemo(() => {
+    const match = pathname.match(/^\/agent\/[^/]+\/([^/]+)\/?$/);
+    const subPath = match?.[1];
+    if (subPath && PRESERVED_AGENT_SUB_PATHS.has(subPath)) {
+      return `/agent/${agentId}/${subPath}`;
+    }
+    return SESSION_CHAT_URL(agentId, false);
+  }, [agentId, pathname]);
+};


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

Follow-up polish on top of #15207 (per-agent topic management page).

#### 🔀 Description of Change

Three small UX iterations on the per-agent Topics Manager surface that shipped in #15207:

- **BulkActionBar floating pill** — the previous shadow stack (`0 12px 32px / 24%` + `0 2px 6px / 16%`) was too heavy and visually competed with the list rows underneath. Toned it down to a softer `0 4px 12px / 8%` + `0 1px 3px / 6%`.
- **ToolAuthAlert** (the "Authorize Skills for this Agent" hint on the agent welcome screen) — drops the `Alert` `secondary` tint by passing `style={{ background: 'transparent' }}` so it reads as a calm hint rather than a warning panel. Also reworded the description copy from "Without authorization or configuration, Skills may not work..." to a more direct phrasing that names the symptoms (capabilities limited / errors). Translated zh-CN + en-US inline; other locales will refresh on the next `pnpm i18n`.
- **Sidebar agent switcher** — when you click "Lobe AI" (Inbox) from `/agent/X/topics`, it used to drop you back to the inbox chat URL and lose the `/topics` view. `AgentItem` already had a `PRESERVED_AGENT_SUB_PATHS` rule (`topics` / `profile` / `channel`); extracted it into a small `usePreservedAgentUrl` hook and wired `InboxItem` to the same logic so the inbox entry behaves the same as regular agents.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Open any agent's Topics Manager (`/agent/<id>/topics`) and select a row — the floating bulk action pill should sit on the page without an outsized drop shadow.
2. On an agent welcome screen that has unauthorized Skills (e.g. agents using `lobe-cloud-sandbox` or a Klavis tool), confirm the Skills authorization panel has no background fill and shows the new hint copy.
3. From `/agent/<id>/topics`, open the sidebar agent switcher and click **Lobe AI** — the URL should become `/agent/<inboxId>/topics` (not `/agent/<inboxId>`). Same check via clicking another regular agent should still work as before.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Heavy bulk-bar shadow / filled auth hint / switch loses `/topics` | Soft shadow / transparent hint / sub-route carried over |

#### 📝 Additional Information

No breaking changes. `usePreservedAgentUrl` is a thin wrapper around the existing `AgentItem` logic — same regex, same `PRESERVED_AGENT_SUB_PATHS` set; only the inbox entry gains the behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)