### PR TITLE
✨ feat(service-model): add manual model selection policy

### DIFF
--- a/packages/const/src/settings/index.ts
+++ b/packages/const/src/settings/index.ts
@@ -7,6 +7,7 @@ export * from './knowledge';
 export * from './llm';
 export * from './memory';
 export * from './notification';
+export * from './serviceModelPolicy';
 export * from './systemAgent';
 export * from './tool';
 export * from './tts';

--- a/packages/const/src/settings/serviceModelPolicy.test.ts
+++ b/packages/const/src/settings/serviceModelPolicy.test.ts
@@ -13,8 +13,8 @@ describe('serviceModelPolicy', () => {
     {
       children: [
         { abilities: { reasoning: true }, id: 'gpt-4o-mini' },
-        { abilities: { reasoning: false }, id: 'gpt-5-thinking' },
-        { abilities: { vision: false }, id: 'gpt-image-1' },
+        { abilities: { reasoning: true }, id: 'gpt-5.4-pro' },
+        { abilities: { reasoning: true }, id: 'gpt-5.5-pro' },
         { abilities: { functionCall: true }, id: 'private-fast-json' },
       ],
       id: 'openai',
@@ -28,23 +28,32 @@ describe('serviceModelPolicy', () => {
     },
   ];
 
-  it('returns a policy that allows openai gpt-4o-mini for input completion', () => {
+  it('allows regular input completion models', () => {
     const policy = getServiceModelPolicy('inputCompletion');
 
     expect(
       isServiceModelCandidateAllowed(policy, { model: 'gpt-4o-mini', provider: 'openai' }),
     ).toBe(true);
+    expect(
+      isServiceModelCandidateAllowed(policy, { model: 'private-fast-json', provider: 'custom' }),
+    ).toBe(true);
   });
 
-  it('denies wildcard-matched unsuitable input completion models', () => {
+  it('denies only the configured GPT Pro models for input completion', () => {
     const policy = getServiceModelPolicy('inputCompletion');
 
     expect(
-      isServiceModelCandidateAllowed(policy, { model: 'gpt-5-thinking', provider: 'openai' }),
+      isServiceModelCandidateAllowed(policy, { model: 'gpt-5.4-pro', provider: 'openai' }),
     ).toBe(false);
     expect(
-      isServiceModelCandidateAllowed(policy, { model: 'gpt-image-1', provider: 'openai' }),
+      isServiceModelCandidateAllowed(policy, { model: 'gpt-5.5-pro', provider: 'openai' }),
     ).toBe(false);
+    expect(
+      isServiceModelCandidateAllowed(policy, { model: 'openai/gpt-5.5-pro', provider: 'custom' }),
+    ).toBe(false);
+    expect(isServiceModelCandidateAllowed(policy, { model: 'gpt-5.4', provider: 'openai' })).toBe(
+      true,
+    );
   });
 
   it('lets deny rules override allow rules', () => {
@@ -61,7 +70,7 @@ describe('serviceModelPolicy', () => {
     ).toBe(false);
   });
 
-  it('allows arbitrary models in denylist mode unless they match deny rules', () => {
+  it('allows arbitrary models in unrestricted denylist policies', () => {
     const policy = getServiceModelPolicy('historyCompress');
 
     expect(
@@ -69,25 +78,31 @@ describe('serviceModelPolicy', () => {
     ).toBe(true);
     expect(
       isServiceModelCandidateAllowed(policy, { model: 'my-thinking-model', provider: 'custom' }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
-  it('filters provider groups using manual provider and model rules', () => {
+  it('filters only input completion denied models from provider groups', () => {
     const policy = getServiceModelPolicy('inputCompletion');
 
     expect(filterServiceModelCandidates(policy, providerGroups)).toEqual([
       {
-        children: [{ abilities: { reasoning: true }, id: 'gpt-4o-mini' }],
+        children: [
+          { abilities: { reasoning: true }, id: 'gpt-4o-mini' },
+          { abilities: { functionCall: true }, id: 'private-fast-json' },
+        ],
         id: 'openai',
       },
       {
-        children: [{ abilities: { reasoning: true }, id: 'claude-3-5-haiku-latest' }],
+        children: [
+          { abilities: { reasoning: true }, id: 'claude-3-5-haiku-latest' },
+          { abilities: { reasoning: false }, id: 'claude-opus-4-thinking' },
+        ],
         id: 'anthropic',
       },
     ]);
   });
 
-  it('resolves input completion fallback to openai gpt-4o-mini', () => {
+  it('resolves input completion fallback to the first non-denied model', () => {
     const policy = getServiceModelPolicy('inputCompletion');
 
     expect(resolveServiceModelFallback(policy, providerGroups)).toEqual({
@@ -96,10 +111,8 @@ describe('serviceModelPolicy', () => {
     });
   });
 
-  it('marks optional runtime policies as empty on invalid selection', () => {
-    expect(getServiceModelPolicy('followUpAction')?.invalidSelection).toBe('empty');
+  it('marks input completion as empty on invalid selection', () => {
     expect(getServiceModelPolicy('inputCompletion')?.invalidSelection).toBe('empty');
-    expect(getServiceModelPolicy('promptRewrite')?.invalidSelection).toBe('empty');
   });
 
   it('keeps arbitrary custom models allowed when policy is undefined', () => {

--- a/packages/const/src/settings/serviceModelPolicy.test.ts
+++ b/packages/const/src/settings/serviceModelPolicy.test.ts
@@ -96,6 +96,12 @@ describe('serviceModelPolicy', () => {
     });
   });
 
+  it('marks optional runtime policies as empty on invalid selection', () => {
+    expect(getServiceModelPolicy('followUpAction')?.invalidSelection).toBe('empty');
+    expect(getServiceModelPolicy('inputCompletion')?.invalidSelection).toBe('empty');
+    expect(getServiceModelPolicy('promptRewrite')?.invalidSelection).toBe('empty');
+  });
+
   it('keeps arbitrary custom models allowed when policy is undefined', () => {
     expect(
       isServiceModelCandidateAllowed(undefined, {

--- a/packages/const/src/settings/serviceModelPolicy.test.ts
+++ b/packages/const/src/settings/serviceModelPolicy.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  filterServiceModelCandidates,
+  getServiceModelPolicy,
+  isServiceModelCandidateAllowed,
+  resolveServiceModelFallback,
+  type ServiceModelPolicy,
+} from './serviceModelPolicy';
+
+describe('serviceModelPolicy', () => {
+  const providerGroups = [
+    {
+      children: [
+        { abilities: { reasoning: true }, id: 'gpt-4o-mini' },
+        { abilities: { reasoning: false }, id: 'gpt-5-thinking' },
+        { abilities: { vision: false }, id: 'gpt-image-1' },
+        { abilities: { functionCall: true }, id: 'private-fast-json' },
+      ],
+      id: 'openai',
+    },
+    {
+      children: [
+        { abilities: { reasoning: true }, id: 'claude-3-5-haiku-latest' },
+        { abilities: { reasoning: false }, id: 'claude-opus-4-thinking' },
+      ],
+      id: 'anthropic',
+    },
+  ];
+
+  it('returns a policy that allows openai gpt-4o-mini for input completion', () => {
+    const policy = getServiceModelPolicy('inputCompletion');
+
+    expect(
+      isServiceModelCandidateAllowed(policy, { model: 'gpt-4o-mini', provider: 'openai' }),
+    ).toBe(true);
+  });
+
+  it('denies wildcard-matched unsuitable input completion models', () => {
+    const policy = getServiceModelPolicy('inputCompletion');
+
+    expect(
+      isServiceModelCandidateAllowed(policy, { model: 'gpt-5-thinking', provider: 'openai' }),
+    ).toBe(false);
+    expect(
+      isServiceModelCandidateAllowed(policy, { model: 'gpt-image-1', provider: 'openai' }),
+    ).toBe(false);
+  });
+
+  it('lets deny rules override allow rules', () => {
+    const policy = {
+      allow: [{ model: 'gpt-4o-mini', provider: 'openai' }],
+      deny: [{ model: 'gpt-4o-mini', provider: 'openai' }],
+      invalidSelection: 'fallback',
+      mode: 'allowlist',
+      source: 'chat',
+    } satisfies ServiceModelPolicy;
+
+    expect(
+      isServiceModelCandidateAllowed(policy, { model: 'gpt-4o-mini', provider: 'openai' }),
+    ).toBe(false);
+  });
+
+  it('allows arbitrary models in denylist mode unless they match deny rules', () => {
+    const policy = getServiceModelPolicy('historyCompress');
+
+    expect(
+      isServiceModelCandidateAllowed(policy, { model: 'private-fast-json', provider: 'custom' }),
+    ).toBe(true);
+    expect(
+      isServiceModelCandidateAllowed(policy, { model: 'my-thinking-model', provider: 'custom' }),
+    ).toBe(false);
+  });
+
+  it('filters provider groups using manual provider and model rules', () => {
+    const policy = getServiceModelPolicy('inputCompletion');
+
+    expect(filterServiceModelCandidates(policy, providerGroups)).toEqual([
+      {
+        children: [{ abilities: { reasoning: true }, id: 'gpt-4o-mini' }],
+        id: 'openai',
+      },
+      {
+        children: [{ abilities: { reasoning: true }, id: 'claude-3-5-haiku-latest' }],
+        id: 'anthropic',
+      },
+    ]);
+  });
+
+  it('resolves input completion fallback to openai gpt-4o-mini', () => {
+    const policy = getServiceModelPolicy('inputCompletion');
+
+    expect(resolveServiceModelFallback(policy, providerGroups)).toEqual({
+      model: 'gpt-4o-mini',
+      provider: 'openai',
+    });
+  });
+
+  it('keeps arbitrary custom models allowed when policy is undefined', () => {
+    expect(
+      isServiceModelCandidateAllowed(undefined, {
+        model: 'custom-private-model',
+        provider: 'custom',
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/const/src/settings/serviceModelPolicy.ts
+++ b/packages/const/src/settings/serviceModelPolicy.ts
@@ -1,0 +1,230 @@
+import type { UserServiceModelConfigKey } from '@lobechat/types';
+
+export type ServiceModelSource = 'chat' | 'embedding';
+
+export interface ServiceModelCandidate {
+  model: string;
+  provider: string;
+}
+
+export interface ServiceModelMatcher {
+  model: string;
+  provider: string;
+}
+
+export interface ServiceModelProviderGroup<TModel extends { id: string } = { id: string }> {
+  children: TModel[];
+  id: string;
+  name?: string;
+}
+
+export interface ServiceModelPolicy {
+  allow?: readonly ServiceModelMatcher[];
+  deny?: readonly ServiceModelMatcher[];
+  fallback?: readonly ServiceModelMatcher[];
+  invalidSelection: 'fallback' | 'empty';
+  mode: 'allowlist' | 'denylist';
+  source: ServiceModelSource;
+}
+
+const LOW_LATENCY_JSON_ALLOW = [
+  { model: 'gpt-4o-mini', provider: 'openai' },
+  { model: 'gpt-4.1-mini', provider: 'openai' },
+  { model: 'claude-3-5-haiku*', provider: 'anthropic' },
+  { model: 'gemini-2.0-flash-lite', provider: 'google' },
+  { model: 'gemini-2.5-flash-lite*', provider: 'google' },
+  { model: 'gemini-2.0-flash-lite', provider: 'vertexai' },
+  { model: 'gemini-2.5-flash-lite*', provider: 'vertexai' },
+  { model: 'deepseek-chat', provider: 'deepseek' },
+] as const satisfies readonly ServiceModelMatcher[];
+
+const FAST_TEXT_ALLOW = [
+  ...LOW_LATENCY_JSON_ALLOW,
+  { model: 'gemini-2.0-flash', provider: 'google' },
+  { model: 'gemini-2.0-flash', provider: 'vertexai' },
+] as const satisfies readonly ServiceModelMatcher[];
+
+const TEXT_TASK_DENY = [
+  { model: '*thinking*', provider: '*' },
+  { model: '*reasoning*', provider: '*' },
+  { model: '*image*', provider: '*' },
+  { model: '*vision*', provider: '*' },
+  { model: '*video*', provider: '*' },
+  { model: '*search-preview*', provider: '*' },
+  { model: '*morph*', provider: '*' },
+  { model: '*embedding*', provider: '*' },
+] as const satisfies readonly ServiceModelMatcher[];
+
+const STRUCTURED_TASK_DENY = [
+  ...TEXT_TASK_DENY,
+  { model: '*r1*', provider: '*' },
+  { model: '*o1*', provider: '*' },
+  { model: '*o3*', provider: '*' },
+  { model: '*o4*', provider: '*' },
+] as const satisfies readonly ServiceModelMatcher[];
+
+const policy = ({
+  allow,
+  deny,
+  fallback,
+  invalidSelection = 'fallback',
+  mode,
+  source,
+}: Omit<ServiceModelPolicy, 'fallback' | 'invalidSelection'> &
+  Partial<Pick<ServiceModelPolicy, 'fallback' | 'invalidSelection'>>): ServiceModelPolicy => ({
+  allow,
+  deny,
+  fallback: fallback ?? (allow ? [...allow] : undefined),
+  invalidSelection,
+  mode,
+  source,
+});
+
+export const SERVICE_MODEL_POLICIES = {
+  agentMeta: policy({
+    allow: FAST_TEXT_ALLOW,
+    deny: TEXT_TASK_DENY,
+    mode: 'allowlist',
+    source: 'chat',
+  }),
+  followUpAction: policy({
+    allow: LOW_LATENCY_JSON_ALLOW,
+    deny: STRUCTURED_TASK_DENY,
+    mode: 'allowlist',
+    source: 'chat',
+  }),
+  generationTopic: policy({
+    allow: FAST_TEXT_ALLOW,
+    deny: TEXT_TASK_DENY,
+    mode: 'allowlist',
+    source: 'chat',
+  }),
+  historyCompress: policy({
+    deny: TEXT_TASK_DENY,
+    mode: 'denylist',
+    source: 'chat',
+  }),
+  inputCompletion: policy({
+    allow: LOW_LATENCY_JSON_ALLOW,
+    deny: STRUCTURED_TASK_DENY,
+    mode: 'allowlist',
+    source: 'chat',
+  }),
+  memoryAnalysisAgentConfig: policy({
+    deny: TEXT_TASK_DENY,
+    mode: 'denylist',
+    source: 'chat',
+  }),
+  promptRewrite: policy({
+    allow: FAST_TEXT_ALLOW,
+    deny: TEXT_TASK_DENY,
+    mode: 'allowlist',
+    source: 'chat',
+  }),
+  thread: policy({
+    allow: FAST_TEXT_ALLOW,
+    deny: TEXT_TASK_DENY,
+    mode: 'allowlist',
+    source: 'chat',
+  }),
+  topic: policy({
+    allow: FAST_TEXT_ALLOW,
+    deny: TEXT_TASK_DENY,
+    mode: 'allowlist',
+    source: 'chat',
+  }),
+  translation: policy({
+    deny: TEXT_TASK_DENY,
+    mode: 'denylist',
+    source: 'chat',
+  }),
+  userMemoryEmbedding: policy({
+    mode: 'denylist',
+    source: 'embedding',
+  }),
+  userMemoryPersonaWriter: policy({
+    deny: TEXT_TASK_DENY,
+    mode: 'denylist',
+    source: 'chat',
+  }),
+} as const satisfies Record<UserServiceModelConfigKey, ServiceModelPolicy>;
+
+const wildcardMatch = (pattern: string, value: string) => {
+  const normalizedPattern = pattern.toLowerCase();
+  const normalizedValue = value.toLowerCase();
+
+  if (normalizedPattern === '*') return true;
+  if (!normalizedPattern.includes('*')) return normalizedPattern === normalizedValue;
+
+  const parts = normalizedPattern.split('*');
+  let searchIndex = 0;
+
+  for (const [index, part] of parts.entries()) {
+    if (!part) continue;
+
+    const partIndex = normalizedValue.indexOf(part, searchIndex);
+    if (partIndex === -1) return false;
+    if (index === 0 && partIndex !== 0) return false;
+
+    searchIndex = partIndex + part.length;
+  }
+
+  const lastPart = parts.at(-1);
+  return !lastPart || normalizedValue.endsWith(lastPart);
+};
+
+const matchCandidate = (matcher: ServiceModelMatcher, candidate: ServiceModelCandidate) =>
+  wildcardMatch(matcher.provider, candidate.provider) &&
+  wildcardMatch(matcher.model, candidate.model);
+
+const matchAny = (
+  matchers: readonly ServiceModelMatcher[] | undefined,
+  candidate: ServiceModelCandidate,
+) => matchers?.some((matcher) => matchCandidate(matcher, candidate)) ?? false;
+
+export const getServiceModelPolicy = (key: UserServiceModelConfigKey) =>
+  SERVICE_MODEL_POLICIES[key];
+
+export const isServiceModelCandidateAllowed = (
+  policy: ServiceModelPolicy | undefined,
+  candidate: ServiceModelCandidate,
+) => {
+  if (!policy) return true;
+  if (matchAny(policy.deny, candidate)) return false;
+
+  if (policy.mode === 'allowlist') return matchAny(policy.allow, candidate);
+
+  return true;
+};
+
+export const filterServiceModelCandidates = <TModel extends { id: string }>(
+  policy: ServiceModelPolicy | undefined,
+  providers: ServiceModelProviderGroup<TModel>[],
+) =>
+  providers
+    .map((provider) => ({
+      ...provider,
+      children: provider.children.filter((model) =>
+        isServiceModelCandidateAllowed(policy, { model: model.id, provider: provider.id }),
+      ),
+    }))
+    .filter((provider) => provider.children.length > 0);
+
+export const resolveServiceModelFallback = <TModel extends { id: string }>(
+  policy: ServiceModelPolicy | undefined,
+  providers: ServiceModelProviderGroup<TModel>[],
+): ServiceModelCandidate | undefined => {
+  const candidates = filterServiceModelCandidates(policy, providers).flatMap((provider) =>
+    provider.children.map((model) => ({ model: model.id, provider: provider.id })),
+  );
+
+  if (policy?.fallback) {
+    for (const matcher of policy.fallback) {
+      const fallbackCandidate = candidates.find((candidate) => matchCandidate(matcher, candidate));
+
+      if (fallbackCandidate) return fallbackCandidate;
+    }
+  }
+
+  return candidates[0];
+};

--- a/packages/const/src/settings/serviceModelPolicy.ts
+++ b/packages/const/src/settings/serviceModelPolicy.ts
@@ -90,6 +90,7 @@ export const SERVICE_MODEL_POLICIES = {
   followUpAction: policy({
     allow: LOW_LATENCY_JSON_ALLOW,
     deny: STRUCTURED_TASK_DENY,
+    invalidSelection: 'empty',
     mode: 'allowlist',
     source: 'chat',
   }),
@@ -107,6 +108,7 @@ export const SERVICE_MODEL_POLICIES = {
   inputCompletion: policy({
     allow: LOW_LATENCY_JSON_ALLOW,
     deny: STRUCTURED_TASK_DENY,
+    invalidSelection: 'empty',
     mode: 'allowlist',
     source: 'chat',
   }),
@@ -118,6 +120,7 @@ export const SERVICE_MODEL_POLICIES = {
   promptRewrite: policy({
     allow: FAST_TEXT_ALLOW,
     deny: TEXT_TASK_DENY,
+    invalidSelection: 'empty',
     mode: 'allowlist',
     source: 'chat',
   }),

--- a/packages/const/src/settings/serviceModelPolicy.ts
+++ b/packages/const/src/settings/serviceModelPolicy.ts
@@ -27,40 +27,9 @@ export interface ServiceModelPolicy {
   source: ServiceModelSource;
 }
 
-const LOW_LATENCY_JSON_ALLOW = [
-  { model: 'gpt-4o-mini', provider: 'openai' },
-  { model: 'gpt-4.1-mini', provider: 'openai' },
-  { model: 'claude-3-5-haiku*', provider: 'anthropic' },
-  { model: 'gemini-2.0-flash-lite', provider: 'google' },
-  { model: 'gemini-2.5-flash-lite*', provider: 'google' },
-  { model: 'gemini-2.0-flash-lite', provider: 'vertexai' },
-  { model: 'gemini-2.5-flash-lite*', provider: 'vertexai' },
-  { model: 'deepseek-chat', provider: 'deepseek' },
-] as const satisfies readonly ServiceModelMatcher[];
-
-const FAST_TEXT_ALLOW = [
-  ...LOW_LATENCY_JSON_ALLOW,
-  { model: 'gemini-2.0-flash', provider: 'google' },
-  { model: 'gemini-2.0-flash', provider: 'vertexai' },
-] as const satisfies readonly ServiceModelMatcher[];
-
-const TEXT_TASK_DENY = [
-  { model: '*thinking*', provider: '*' },
-  { model: '*reasoning*', provider: '*' },
-  { model: '*image*', provider: '*' },
-  { model: '*vision*', provider: '*' },
-  { model: '*video*', provider: '*' },
-  { model: '*search-preview*', provider: '*' },
-  { model: '*morph*', provider: '*' },
-  { model: '*embedding*', provider: '*' },
-] as const satisfies readonly ServiceModelMatcher[];
-
-const STRUCTURED_TASK_DENY = [
-  ...TEXT_TASK_DENY,
-  { model: '*r1*', provider: '*' },
-  { model: '*o1*', provider: '*' },
-  { model: '*o3*', provider: '*' },
-  { model: '*o4*', provider: '*' },
+const INPUT_COMPLETION_DENY = [
+  { model: '*gpt-5.4-pro', provider: '*' },
+  { model: '*gpt-5.5-pro', provider: '*' },
 ] as const satisfies readonly ServiceModelMatcher[];
 
 const policy = ({
@@ -81,75 +50,26 @@ const policy = ({
 });
 
 export const SERVICE_MODEL_POLICIES = {
-  agentMeta: policy({
-    allow: FAST_TEXT_ALLOW,
-    deny: TEXT_TASK_DENY,
-    mode: 'allowlist',
-    source: 'chat',
-  }),
-  followUpAction: policy({
-    allow: LOW_LATENCY_JSON_ALLOW,
-    deny: STRUCTURED_TASK_DENY,
-    invalidSelection: 'empty',
-    mode: 'allowlist',
-    source: 'chat',
-  }),
-  generationTopic: policy({
-    allow: FAST_TEXT_ALLOW,
-    deny: TEXT_TASK_DENY,
-    mode: 'allowlist',
-    source: 'chat',
-  }),
-  historyCompress: policy({
-    deny: TEXT_TASK_DENY,
-    mode: 'denylist',
-    source: 'chat',
-  }),
+  agentMeta: policy({ mode: 'denylist', source: 'chat' }),
+  followUpAction: policy({ mode: 'denylist', source: 'chat' }),
+  generationTopic: policy({ mode: 'denylist', source: 'chat' }),
+  historyCompress: policy({ mode: 'denylist', source: 'chat' }),
   inputCompletion: policy({
-    allow: LOW_LATENCY_JSON_ALLOW,
-    deny: STRUCTURED_TASK_DENY,
+    deny: INPUT_COMPLETION_DENY,
     invalidSelection: 'empty',
-    mode: 'allowlist',
-    source: 'chat',
-  }),
-  memoryAnalysisAgentConfig: policy({
-    deny: TEXT_TASK_DENY,
     mode: 'denylist',
     source: 'chat',
   }),
-  promptRewrite: policy({
-    allow: FAST_TEXT_ALLOW,
-    deny: TEXT_TASK_DENY,
-    invalidSelection: 'empty',
-    mode: 'allowlist',
-    source: 'chat',
-  }),
-  thread: policy({
-    allow: FAST_TEXT_ALLOW,
-    deny: TEXT_TASK_DENY,
-    mode: 'allowlist',
-    source: 'chat',
-  }),
-  topic: policy({
-    allow: FAST_TEXT_ALLOW,
-    deny: TEXT_TASK_DENY,
-    mode: 'allowlist',
-    source: 'chat',
-  }),
-  translation: policy({
-    deny: TEXT_TASK_DENY,
-    mode: 'denylist',
-    source: 'chat',
-  }),
+  memoryAnalysisAgentConfig: policy({ mode: 'denylist', source: 'chat' }),
+  promptRewrite: policy({ mode: 'denylist', source: 'chat' }),
+  thread: policy({ mode: 'denylist', source: 'chat' }),
+  topic: policy({ mode: 'denylist', source: 'chat' }),
+  translation: policy({ mode: 'denylist', source: 'chat' }),
   userMemoryEmbedding: policy({
     mode: 'denylist',
     source: 'embedding',
   }),
-  userMemoryPersonaWriter: policy({
-    deny: TEXT_TASK_DENY,
-    mode: 'denylist',
-    source: 'chat',
-  }),
+  userMemoryPersonaWriter: policy({ mode: 'denylist', source: 'chat' }),
 } as const satisfies Record<UserServiceModelConfigKey, ServiceModelPolicy>;
 
 const wildcardMatch = (pattern: string, value: string) => {

--- a/src/features/AgentSetting/store/action.test.ts
+++ b/src/features/AgentSetting/store/action.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createStore } from './index';
+
+const enabledChatModelList = [
+  {
+    children: [{ id: 'gpt-4o-mini' }],
+    id: 'openai',
+    name: 'OpenAI',
+    source: 'builtin',
+  },
+];
+
+vi.mock('@/store/aiInfra', () => ({
+  getAiInfraStoreState: vi.fn(() => ({ enabledChatModelList })),
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: {
+    getState: vi.fn(() => ({})),
+  },
+}));
+
+vi.mock('@/store/user/slices/settings/selectors', () => ({
+  systemAgentSelectors: {
+    agentMeta: vi.fn(() => ({
+      contextLimit: 8192,
+      customPrompt: 'keep this prompt',
+      model: 'gpt-5-thinking',
+      provider: 'openai',
+    })),
+  },
+}));
+
+describe('AgentSetting actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('internal_getSystemAgentForMeta', () => {
+    it('falls back to an allowed agent meta model while preserving non-model config', () => {
+      const store = createStore();
+
+      expect(store.getState().internal_getSystemAgentForMeta()).toEqual({
+        contextLimit: 8192,
+        customPrompt: 'keep this prompt',
+        model: 'gpt-4o-mini',
+        provider: 'openai',
+      });
+    });
+  });
+});

--- a/src/features/AgentSetting/store/action.ts
+++ b/src/features/AgentSetting/store/action.ts
@@ -12,6 +12,7 @@ import { type PartialDeep } from 'type-fest';
 import { type StateCreator } from 'zustand/vanilla';
 
 import { chatService } from '@/services/chat';
+import { resolveClientServiceModelConfig } from '@/services/serviceModelPolicy/client';
 import { globalHelpers } from '@/store/global/helpers';
 import { useUserStore } from '@/store/user';
 import { systemAgentSelectors } from '@/store/user/slices/settings/selectors';
@@ -293,7 +294,10 @@ export const store: StateCreator<Store, [['zustand/devtools', never]]> = (set, g
   }),
 
   internal_getSystemAgentForMeta: () => {
-    return systemAgentSelectors.agentMeta(useUserStore.getState());
+    const agentMetaConfig = systemAgentSelectors.agentMeta(useUserStore.getState());
+    const resolvedAgentMetaConfig = resolveClientServiceModelConfig('agentMeta', agentMetaConfig);
+
+    return merge(agentMetaConfig, resolvedAgentMetaConfig ?? {});
   },
 
   resetAgentConfig: async () => {

--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -22,6 +22,7 @@ import { usePasteFile, useUploadFiles } from '@/components/DragUploadZone';
 import { useEnterToSend } from '@/hooks/useEnterToSend';
 import { useIMECompositionEvent } from '@/hooks/useIMECompositionEvent';
 import { aiChatService } from '@/services/aiChat';
+import { resolveClientServiceModelConfig } from '@/services/serviceModelPolicy/client';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
@@ -227,7 +228,10 @@ const InputEditor = memo<{
       // mid-text causes nested editor updates that freeze the input
       if (afterText.trim()) return null;
 
-      const config = systemAgentSelectors.inputCompletion(useUserStore.getState());
+      const savedConfig = systemAgentSelectors.inputCompletion(useUserStore.getState());
+      const config = resolveClientServiceModelConfig('inputCompletion', savedConfig);
+      if (!config) return null;
+
       const context = getMessagesRef.current?.();
       const { messages, schema } = chainInputCompletion(input, afterText, context);
 

--- a/src/features/Conversation/hooks/useChatFollowUp.test.ts
+++ b/src/features/Conversation/hooks/useChatFollowUp.test.ts
@@ -146,24 +146,6 @@ describe('useChatFollowUp', () => {
       assertEmpty(result.current);
     });
 
-    it('when no allowed follow-up model exists', () => {
-      (useEnabledChatModels as unknown as Mock).mockReturnValue([
-        {
-          children: [{ id: 'gpt-5-thinking' }],
-          id: 'openai',
-          name: 'OpenAI',
-          source: 'builtin',
-        },
-      ] as EnabledProviderWithModels[]);
-
-      const { result } = renderWith({
-        agentChatConfig: VALID_AGENT,
-        conversationKey: CONVERSATION_KEY,
-        topicId: TOPIC_ID,
-      });
-      assertEmpty(result.current);
-    });
-
     it('when conversationKey is missing', () => {
       const { result } = renderWith({
         agentChatConfig: VALID_AGENT,
@@ -253,7 +235,7 @@ describe('useChatFollowUp', () => {
       expect(fetchFor).toHaveBeenCalledTimes(1);
     });
 
-    it('enables after enabled chat models load', async () => {
+    it('updates fallback config after enabled chat models load', async () => {
       (useEnabledChatModels as unknown as Mock).mockReturnValue([
         {
           children: [{ id: 'gpt-5-thinking' }],
@@ -264,13 +246,19 @@ describe('useChatFollowUp', () => {
       ] as EnabledProviderWithModels[]);
 
       const { rerender, result } = renderEnabled({ threadId: 'thread-1' });
-      expect(result.current.onAssistantTurnSettled).toBeUndefined();
+      await result.current.onAssistantTurnSettled?.('m', { reason: 'completed' });
+      expect(fetchFor).toHaveBeenLastCalledWith(CONVERSATION_KEY, {
+        hint: { kind: 'chat' },
+        modelConfig: { model: 'gpt-5-thinking', provider: 'openai' },
+        threadId: 'thread-1',
+        topicId: TOPIC_ID,
+      });
 
       (useEnabledChatModels as unknown as Mock).mockReturnValue(ENABLED_CHAT_MODELS);
       rerender();
 
       await result.current.onAssistantTurnSettled?.('m', { reason: 'completed' });
-      expect(fetchFor).toHaveBeenCalledWith(CONVERSATION_KEY, {
+      expect(fetchFor).toHaveBeenLastCalledWith(CONVERSATION_KEY, {
         hint: { kind: 'chat' },
         modelConfig: { model: VALID_GLOBAL.model, provider: VALID_GLOBAL.provider },
         threadId: 'thread-1',

--- a/src/features/Conversation/hooks/useChatFollowUp.test.ts
+++ b/src/features/Conversation/hooks/useChatFollowUp.test.ts
@@ -2,16 +2,27 @@ import { type LobeAgentChatConfig } from '@lobechat/types';
 import { renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useEnabledChatModels } from '@/hooks/useEnabledChatModels';
 import { useFollowUpActionStore } from '@/store/followUpAction';
 import { useUserStore } from '@/store/user';
+import type { EnabledProviderWithModels } from '@/types/aiProvider';
 
 import { useChatFollowUp } from './useChatFollowUp';
 
 const VALID_GLOBAL = {
   enabled: true,
-  model: 'global-model',
-  provider: 'global-provider',
+  model: 'gpt-4o-mini',
+  provider: 'openai',
 };
+
+const ENABLED_CHAT_MODELS = [
+  {
+    children: [{ id: VALID_GLOBAL.model }],
+    id: VALID_GLOBAL.provider,
+    name: 'OpenAI',
+    source: 'builtin',
+  },
+] as EnabledProviderWithModels[];
 
 const VALID_AGENT: LobeAgentChatConfig = {
   enableFollowUpChips: true,
@@ -26,6 +37,10 @@ vi.mock('@/store/user', () => ({
   useUserStore: vi.fn(),
 }));
 
+vi.mock('@/hooks/useEnabledChatModels', () => ({
+  useEnabledChatModels: vi.fn(),
+}));
+
 describe('useChatFollowUp', () => {
   let fetchFor: ReturnType<typeof vi.fn>;
   let clear: ReturnType<typeof vi.fn>;
@@ -38,6 +53,7 @@ describe('useChatFollowUp', () => {
       fetchFor,
       clear,
     } as any);
+    (useEnabledChatModels as unknown as Mock).mockReturnValue(ENABLED_CHAT_MODELS);
 
     (useUserStore as unknown as Mock).mockImplementation((selector: any) =>
       selector({
@@ -48,6 +64,7 @@ describe('useChatFollowUp', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    (useEnabledChatModels as unknown as Mock).mockReset();
     (useUserStore as unknown as Mock).mockReset();
   });
 
@@ -123,6 +140,24 @@ describe('useChatFollowUp', () => {
     it('when per-agent enableFollowUpChips is false', () => {
       const { result } = renderWith({
         agentChatConfig: { enableFollowUpChips: false } as LobeAgentChatConfig,
+        conversationKey: CONVERSATION_KEY,
+        topicId: TOPIC_ID,
+      });
+      assertEmpty(result.current);
+    });
+
+    it('when no allowed follow-up model exists', () => {
+      (useEnabledChatModels as unknown as Mock).mockReturnValue([
+        {
+          children: [{ id: 'gpt-5-thinking' }],
+          id: 'openai',
+          name: 'OpenAI',
+          source: 'builtin',
+        },
+      ] as EnabledProviderWithModels[]);
+
+      const { result } = renderWith({
+        agentChatConfig: VALID_AGENT,
         conversationKey: CONVERSATION_KEY,
         topicId: TOPIC_ID,
       });
@@ -216,6 +251,31 @@ describe('useChatFollowUp', () => {
       const { result } = renderEnabled();
       await result.current.onAssistantTurnSettled?.('m', { reason: 'continued' });
       expect(fetchFor).toHaveBeenCalledTimes(1);
+    });
+
+    it('enables after enabled chat models load', async () => {
+      (useEnabledChatModels as unknown as Mock).mockReturnValue([
+        {
+          children: [{ id: 'gpt-5-thinking' }],
+          id: 'openai',
+          name: 'OpenAI',
+          source: 'builtin',
+        },
+      ] as EnabledProviderWithModels[]);
+
+      const { rerender, result } = renderEnabled({ threadId: 'thread-1' });
+      expect(result.current.onAssistantTurnSettled).toBeUndefined();
+
+      (useEnabledChatModels as unknown as Mock).mockReturnValue(ENABLED_CHAT_MODELS);
+      rerender();
+
+      await result.current.onAssistantTurnSettled?.('m', { reason: 'completed' });
+      expect(fetchFor).toHaveBeenCalledWith(CONVERSATION_KEY, {
+        hint: { kind: 'chat' },
+        modelConfig: { model: VALID_GLOBAL.model, provider: VALID_GLOBAL.provider },
+        threadId: 'thread-1',
+        topicId: TOPIC_ID,
+      });
     });
 
     it('clear is scoped to the passed conversationKey — different keys do not collide', async () => {

--- a/src/features/Conversation/hooks/useChatFollowUp.ts
+++ b/src/features/Conversation/hooks/useChatFollowUp.ts
@@ -1,6 +1,8 @@
 import { type LobeAgentChatConfig } from '@lobechat/types';
 import { useMemo } from 'react';
 
+import { useEnabledChatModels } from '@/hooks/useEnabledChatModels';
+import { resolveClientServiceModelConfig } from '@/services/serviceModelPolicy/client';
 import { useFollowUpActionStore } from '@/store/followUpAction';
 import { useUserStore } from '@/store/user';
 import { systemAgentSelectors } from '@/store/user/slices/settings/selectors/systemAgent';
@@ -35,21 +37,29 @@ export const useChatFollowUp = ({
   topicId,
 }: UseChatFollowUpParams): ConversationHooks => {
   const globalConfig = useUserStore(systemAgentSelectors.followUpAction);
+  const enabledChatModels = useEnabledChatModels();
+  const resolvedConfig = useMemo(() => {
+    if (!globalConfig.model || !globalConfig.provider) return;
+
+    return resolveClientServiceModelConfig('followUpAction', globalConfig, {
+      chatList: enabledChatModels,
+    });
+  }, [enabledChatModels, globalConfig.model, globalConfig.provider]);
 
   const effective = useMemo(() => {
     const globalEnabled = globalConfig.enabled === true;
-    const hasValidModel = !!globalConfig.model && !!globalConfig.provider;
+    const hasValidModel = !!resolvedConfig?.model && !!resolvedConfig.provider;
     const perAgentEnabled = agentChatConfig?.enableFollowUpChips === true;
     return globalEnabled && hasValidModel && perAgentEnabled;
   }, [
     globalConfig.enabled,
-    globalConfig.model,
-    globalConfig.provider,
+    resolvedConfig?.model,
+    resolvedConfig?.provider,
     agentChatConfig?.enableFollowUpChips,
   ]);
 
   return useMemo<ConversationHooks>(() => {
-    if (!effective || !conversationKey || !topicId) return {};
+    if (!effective || !conversationKey || !topicId || !resolvedConfig) return {};
 
     const clearSlot = () => useFollowUpActionStore.getState().clear(conversationKey);
 
@@ -58,7 +68,7 @@ export const useChatFollowUp = ({
         if (reason === 'stopped') return;
         await useFollowUpActionStore.getState().fetchFor(conversationKey, {
           hint: { kind: 'chat' },
-          modelConfig: { model: globalConfig.model, provider: globalConfig.provider },
+          modelConfig: { model: resolvedConfig.model, provider: resolvedConfig.provider },
           threadId,
           topicId,
         });
@@ -73,5 +83,5 @@ export const useChatFollowUp = ({
         clearSlot();
       },
     };
-  }, [effective, conversationKey, globalConfig.model, globalConfig.provider, threadId, topicId]);
+  }, [effective, conversationKey, resolvedConfig, threadId, topicId]);
 };

--- a/src/features/ModelSelect/index.test.tsx
+++ b/src/features/ModelSelect/index.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EnabledProviderWithModels } from '@/types/aiProvider';
+
+import ModelSelect from './index';
+
+const chatModelList: EnabledProviderWithModels[] = [
+  {
+    children: [
+      {
+        abilities: {},
+        displayName: 'Fast Model',
+        id: 'fast-model',
+      },
+      {
+        abilities: {},
+        displayName: 'Slow Model',
+        id: 'slow-model',
+      },
+    ],
+    id: 'openai',
+    name: 'OpenAI',
+    source: 'builtin',
+  },
+];
+
+const embeddingModelList: EnabledProviderWithModels[] = [
+  {
+    children: [
+      {
+        abilities: {},
+        displayName: 'Text Embedding 3 Small',
+        id: 'text-embedding-3-small',
+      },
+    ],
+    id: 'openai',
+    name: 'OpenAI',
+    source: 'builtin',
+  },
+];
+
+const useEnabledChatModelsMock = vi.fn(() => chatModelList);
+
+vi.mock('@lobehub/ui', () => ({
+  TooltipGroup: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  Select: ({ options }: { options?: { options?: { value: string }[]; value?: string }[] }) => {
+    const values = options?.flatMap((option) =>
+      option.options ? option.options.map((item) => item.value) : [option.value],
+    );
+
+    return <pre data-testid="options">{JSON.stringify(values)}</pre>;
+  },
+}));
+
+vi.mock('@/components/ModelSelect', () => ({
+  ModelItemRender: ({ id }: { id: string }) => <span>{id}</span>,
+  ProviderItemRender: ({ name }: { name: string }) => <span>{name}</span>,
+  TAG_CLASSNAME: 'tag',
+}));
+
+vi.mock('@/hooks/useEnabledChatModels', () => ({
+  useEnabledChatModels: () => useEnabledChatModelsMock(),
+}));
+
+vi.mock('antd-style', () => ({
+  createStaticStyles: () => ({
+    popup: 'popup',
+    select: 'select',
+  }),
+}));
+
+beforeEach(() => {
+  useEnabledChatModelsMock.mockReturnValue(chatModelList);
+});
+
+describe('<ModelSelect />', () => {
+  it('filters models with modelFilter', () => {
+    render(<ModelSelect modelFilter={({ model }) => model.id !== 'slow-model'} />);
+
+    expect(screen.getByTestId('options').textContent).toBe(JSON.stringify(['openai/fast-model']));
+  });
+
+  it('uses explicit modelList instead of the default chat list', () => {
+    render(<ModelSelect modelList={embeddingModelList} />);
+
+    expect(screen.getByTestId('options').textContent).toBe(
+      JSON.stringify(['openai/text-embedding-3-small']),
+    );
+  });
+});

--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -1,7 +1,7 @@
 import { TooltipGroup } from '@lobehub/ui';
 import { Select, type SelectProps } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
-import { type ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { memo, useMemo } from 'react';
 
 import { ModelItemRender, ProviderItemRender, TAG_CLASSNAME } from '@/components/ModelSelect';
@@ -35,9 +35,16 @@ interface ModelOption {
   value: string;
 }
 
+interface ModelFilterParams {
+  model: EnabledProviderWithModels['children'][number];
+  provider: EnabledProviderWithModels;
+}
+
 interface ModelSelectProps extends Pick<SelectProps, 'loading' | 'size' | 'style' | 'variant'> {
   defaultValue?: { model: string; provider?: string };
   initialWidth?: boolean;
+  modelFilter?: (params: ModelFilterParams) => boolean;
+  modelList?: EnabledProviderWithModels[];
   onChange?: (props: { model: string; provider: string }) => void;
   popupWidth?: number;
   requiredAbilities?: (keyof EnabledProviderWithModels['children'][number]['abilities'])[];
@@ -57,8 +64,11 @@ const ModelSelect = memo<ModelSelectProps>(
     variant,
     initialWidth = false,
     popupWidth,
+    modelFilter,
+    modelList,
   }) => {
-    const enabledList = useEnabledChatModels();
+    const defaultEnabledList = useEnabledChatModels();
+    const enabledList = modelList ?? defaultEnabledList;
 
     const options = useMemo<SelectProps['options']>(() => {
       const getChatModels = (provider: EnabledProviderWithModels) => {
@@ -69,7 +79,11 @@ const ModelSelect = memo<ModelSelectProps>(
               )
             : provider.children;
 
-        return models.map((model) => ({
+        const filteredModels = modelFilter
+          ? models.filter((model) => modelFilter({ model, provider }))
+          : models;
+
+        return filteredModels.map((model) => ({
           ...model,
           label: <ModelItemRender {...model} {...model.abilities} showInfoTag={false} />,
           provider: provider.id,
@@ -101,7 +115,7 @@ const ModelSelect = memo<ModelSelectProps>(
           };
         })
         .filter(Boolean) as SelectProps['options'];
-    }, [enabledList, requiredAbilities, showAbility]);
+    }, [enabledList, modelFilter, requiredAbilities, showAbility]);
 
     return (
       <TooltipGroup>

--- a/src/features/PromptTransform/usePromptTransform.ts
+++ b/src/features/PromptTransform/usePromptTransform.ts
@@ -1,7 +1,9 @@
 import { chainRewriteGenerationPrompt, chainTranslate } from '@lobechat/prompts';
+import type { SystemAgentItem } from '@lobechat/types';
 import { useCallback, useState } from 'react';
 
 import { chatService } from '@/services/chat';
+import { resolveClientServiceModelConfig } from '@/services/serviceModelPolicy/client';
 import { useUserStore } from '@/store/user';
 import { systemAgentSelectors } from '@/store/user/selectors';
 import { merge } from '@/utils/merge';
@@ -13,6 +15,7 @@ interface UsePromptTransformParams {
 }
 
 type PromptTransformAction = 'rewrite' | 'translate';
+type PromptTransformModelConfig = Partial<Pick<SystemAgentItem, 'model' | 'provider'>>;
 
 export const usePromptTransform = ({ mode, prompt, onPromptChange }: UsePromptTransformParams) => {
   const [isTransforming, setIsTransforming] = useState(false);
@@ -23,11 +26,14 @@ export const usePromptTransform = ({ mode, prompt, onPromptChange }: UsePromptTr
   const isRewriteActionEnabled = rewriteConfig?.enabled ?? false;
 
   const getConfigByAction = useCallback(
-    (action: PromptTransformAction) => {
+    (action: PromptTransformAction): PromptTransformModelConfig => {
       // Strip config-only fields (enabled, customPrompt); strict upstreams reject unknown OpenAI params.
       const config = action === 'rewrite' ? rewriteConfig : translateConfig;
-      if (!config) return {};
-      return { model: config.model, provider: config.provider };
+      const resolved = resolveClientServiceModelConfig(
+        action === 'rewrite' ? 'promptRewrite' : 'translation',
+        config,
+      );
+      return resolved ?? {};
     },
     [rewriteConfig, translateConfig],
   );
@@ -36,6 +42,9 @@ export const usePromptTransform = ({ mode, prompt, onPromptChange }: UsePromptTr
     async (action: PromptTransformAction) => {
       if (isTransforming || !prompt?.trim()) return;
       if (action === 'rewrite' && !isRewriteActionEnabled) return;
+
+      const selectedConfig = getConfigByAction(action);
+      if (!selectedConfig.model || !selectedConfig.provider) return;
 
       let transformedPrompt = '';
       setTransformAction(action);
@@ -54,7 +63,7 @@ export const usePromptTransform = ({ mode, prompt, onPromptChange }: UsePromptTr
             if (chunk.type === 'text') transformedPrompt += chunk.text;
           },
           params: merge(
-            getConfigByAction(action),
+            selectedConfig,
             action === 'rewrite'
               ? chainRewriteGenerationPrompt({
                   mode,

--- a/src/features/ServiceModel/ModelAssignmentsForm.test.tsx
+++ b/src/features/ServiceModel/ModelAssignmentsForm.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EnabledProviderWithModels } from '@/types/aiProvider';
+
+import ModelAssignmentsForm from './ModelAssignmentsForm';
+
+interface ModelSelectProps {
+  modelFilter?: (params: {
+    model: EnabledProviderWithModels['children'][number];
+    provider: EnabledProviderWithModels;
+  }) => boolean;
+  modelList?: EnabledProviderWithModels[];
+  value?: { model: string; provider?: string };
+}
+
+const mocks = vi.hoisted(() => ({
+  modelSelectProps: [] as ModelSelectProps[],
+}));
+
+const embeddingModelList: EnabledProviderWithModels[] = [
+  {
+    children: [
+      {
+        abilities: {},
+        displayName: 'Text Embedding 3 Small',
+        id: 'text-embedding-3-small',
+      },
+    ],
+    id: 'openai',
+    name: 'OpenAI',
+    source: 'builtin',
+  },
+];
+
+const systemAgentSettings = {
+  agentMeta: { model: 'gpt-4o-mini', provider: 'openai' },
+  followUpAction: { enabled: true, model: 'gpt-4o-mini', provider: 'openai' },
+  generationTopic: { model: 'gpt-4o-mini', provider: 'openai' },
+  historyCompress: { model: 'gpt-4o-mini', provider: 'openai' },
+  inputCompletion: { enabled: true, model: 'gpt-4o-mini', provider: 'openai' },
+  memoryAnalysisAgentConfig: { contextLimit: 1024, model: 'gpt-4o-mini', provider: 'openai' },
+  promptRewrite: { enabled: true, model: 'gpt-4o-mini', provider: 'openai' },
+  topic: { model: 'gpt-4o-mini', provider: 'openai' },
+  translation: { model: 'gpt-4o-mini', provider: 'openai' },
+  userMemoryEmbedding: { contextLimit: 1024, model: 'text-embedding-3-small', provider: 'openai' },
+  userMemoryPersonaWriter: { contextLimit: 1024, model: 'gpt-4o-mini', provider: 'openai' },
+};
+
+const renderFormItems = (items?: { children?: ReactNode }[]): ReactNode =>
+  items?.map((item, index) => {
+    if (Array.isArray(item.children)) {
+      return <div key={index}>{renderFormItems(item.children as { children?: ReactNode }[])}</div>;
+    }
+
+    return <div key={index}>{item.children}</div>;
+  });
+
+vi.mock('@lobehub/ui', () => ({
+  Flexbox: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Form: ({ items }: { items?: { children?: ReactNode }[] }) => (
+    <form>{renderFormItems(items)}</form>
+  ),
+  Icon: () => null,
+  InputNumber: () => null,
+  Skeleton: () => <div data-testid="skeleton" />,
+}));
+
+vi.mock('antd', () => ({
+  Switch: () => null,
+}));
+
+vi.mock('lucide-react', () => ({
+  Loader2Icon: () => null,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/const/layoutTokens', () => ({
+  FORM_STYLE: {},
+}));
+
+vi.mock('@/features/ModelSelect', () => ({
+  default: (props: ModelSelectProps) => {
+    mocks.modelSelectProps.push(props);
+
+    return <div data-testid="model-select" />;
+  },
+}));
+
+vi.mock('@/hooks/useEnabledEmbeddingModels', () => ({
+  useEnabledEmbeddingModels: () => embeddingModelList,
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      isUserStateInit: true,
+      updateDefaultAgent: vi.fn(),
+      updateSystemAgent: vi.fn(),
+    }),
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  settingsSelectors: {
+    currentSystemAgent: () => systemAgentSettings,
+    defaultAgent: () => ({ config: { model: 'default-agent', provider: 'openai' } }),
+  },
+}));
+
+beforeEach(() => {
+  mocks.modelSelectProps.length = 0;
+});
+
+describe('<ModelAssignmentsForm />', () => {
+  it('applies service model policy props without restricting the default assistant selector', () => {
+    render(<ModelAssignmentsForm />);
+
+    expect(screen.getAllByTestId('model-select').length).toBeGreaterThan(0);
+
+    const defaultAgentSelect = mocks.modelSelectProps.find(
+      (props) => props.value?.model === 'default-agent',
+    );
+    expect(defaultAgentSelect?.modelFilter).toBeUndefined();
+    expect(defaultAgentSelect?.modelList).toBeUndefined();
+
+    const inputCompletionSelect = mocks.modelSelectProps.find(
+      (props) => props.value === systemAgentSettings.inputCompletion,
+    );
+    expect(inputCompletionSelect?.modelFilter).toBeTypeOf('function');
+    expect(
+      inputCompletionSelect?.modelFilter?.({
+        model: { abilities: {}, id: 'gpt-5-thinking' },
+        provider: { children: [], id: 'openai', name: 'OpenAI', source: 'builtin' },
+      }),
+    ).toBe(false);
+
+    const userMemoryEmbeddingSelect = mocks.modelSelectProps.find(
+      (props) => props.value === systemAgentSettings.userMemoryEmbedding,
+    );
+    expect(userMemoryEmbeddingSelect?.modelList?.[0]?.children[0]?.id).toBe(
+      'text-embedding-3-small',
+    );
+  });
+});

--- a/src/features/ServiceModel/ModelAssignmentsForm.test.tsx
+++ b/src/features/ServiceModel/ModelAssignmentsForm.test.tsx
@@ -135,10 +135,16 @@ describe('<ModelAssignmentsForm />', () => {
     expect(inputCompletionSelect?.modelFilter).toBeTypeOf('function');
     expect(
       inputCompletionSelect?.modelFilter?.({
-        model: { abilities: {}, id: 'gpt-5-thinking' },
+        model: { abilities: {}, id: 'gpt-5.4-pro' },
         provider: { children: [], id: 'openai', name: 'OpenAI', source: 'builtin' },
       }),
     ).toBe(false);
+    expect(
+      inputCompletionSelect?.modelFilter?.({
+        model: { abilities: {}, id: 'gpt-5.4' },
+        provider: { children: [], id: 'openai', name: 'OpenAI', source: 'builtin' },
+      }),
+    ).toBe(true);
 
     const userMemoryEmbeddingSelect = mocks.modelSelectProps.find(
       (props) => props.value === systemAgentSettings.userMemoryEmbedding,

--- a/src/features/ServiceModel/ModelAssignmentsForm.tsx
+++ b/src/features/ServiceModel/ModelAssignmentsForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { getServiceModelPolicy, isServiceModelCandidateAllowed } from '@lobechat/const';
 import type { FormGroupItemType, FormItemProps } from '@lobehub/ui';
 import { Flexbox, Form, Icon, InputNumber, Skeleton } from '@lobehub/ui';
 import { Switch } from 'antd';
@@ -10,13 +11,16 @@ import { useTranslation } from 'react-i18next';
 
 import { FORM_STYLE } from '@/const/layoutTokens';
 import ModelSelect from '@/features/ModelSelect';
+import { useEnabledEmbeddingModels } from '@/hooks/useEnabledEmbeddingModels';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
+import type { EnabledProviderWithModels } from '@/types/aiProvider';
 import type { SystemAgentItem, UserServiceModelConfigKey } from '@/types/user/settings';
 
 interface SystemAgentModelItem {
   contextLimit?: boolean;
   key: UserServiceModelConfigKey;
+  source?: 'chat' | 'embedding';
 }
 
 type LoadingKey = 'defaultAgent' | UserServiceModelConfigKey;
@@ -38,7 +42,7 @@ const OPTIONAL_FEATURE_ITEMS: SystemAgentModelItem[] = [
 const MEMORY_MODEL_ITEMS: SystemAgentModelItem[] = [
   { contextLimit: true, key: 'memoryAnalysisAgentConfig' },
   { contextLimit: true, key: 'userMemoryPersonaWriter' },
-  { contextLimit: true, key: 'userMemoryEmbedding' },
+  { contextLimit: true, key: 'userMemoryEmbedding', source: 'embedding' },
 ];
 
 const ModelAssignmentsForm = memo(() => {
@@ -52,6 +56,7 @@ const ModelAssignmentsForm = memo(() => {
     s.updateSystemAgent,
     s.isUserStateInit,
   ]);
+  const enabledEmbeddingModels = useEnabledEmbeddingModels();
   const [loadingKey, setLoadingKey] = useState<LoadingKey>();
 
   useEffect(() => {
@@ -87,6 +92,24 @@ const ModelAssignmentsForm = memo(() => {
     }
   };
 
+  const getModelSelectProps = (
+    key: UserServiceModelConfigKey,
+    source?: SystemAgentModelItem['source'],
+  ) => {
+    const policy = getServiceModelPolicy(key);
+
+    return {
+      modelFilter: ({
+        model,
+        provider,
+      }: {
+        model: EnabledProviderWithModels['children'][number];
+        provider: EnabledProviderWithModels;
+      }) => isServiceModelCandidateAllowed(policy, { model: model.id, provider: provider.id }),
+      modelList: source === 'embedding' ? enabledEmbeddingModels : undefined,
+    };
+  };
+
   const defaultAgentItem: FormItemProps = {
     children: (
       <Flexbox align="center" direction="horizontal" gap={12} style={{ width: 'min(100%, 448px)' }}>
@@ -103,7 +126,7 @@ const ModelAssignmentsForm = memo(() => {
     minWidth: undefined,
   };
 
-  const systemModelItems: FormItemProps[] = SYSTEM_AGENT_MODEL_ITEMS.map(({ key }) => {
+  const systemModelItems: FormItemProps[] = SYSTEM_AGENT_MODEL_ITEMS.map(({ key, source }) => {
     const value = systemAgentSettings[key];
 
     return {
@@ -115,6 +138,7 @@ const ModelAssignmentsForm = memo(() => {
           style={{ width: 'min(100%, 448px)' }}
         >
           <ModelSelect
+            {...getModelSelectProps(key, source)}
             showAbility={false}
             style={{ minWidth: 0, width: '100%' }}
             value={value}
@@ -128,40 +152,43 @@ const ModelAssignmentsForm = memo(() => {
     } satisfies FormItemProps;
   });
 
-  const memoryModelItems: FormItemProps[] = MEMORY_MODEL_ITEMS.map(({ contextLimit, key }) => {
-    const value = systemAgentSettings[key];
+  const memoryModelItems: FormItemProps[] = MEMORY_MODEL_ITEMS.map(
+    ({ contextLimit, key, source }) => {
+      const value = systemAgentSettings[key];
 
-    return {
-      children: (
-        <Flexbox direction="vertical" gap={8} style={{ width: 'min(100%, 448px)' }}>
-          <ModelSelect
-            showAbility={false}
-            style={{ minWidth: 0, width: '100%' }}
-            value={value}
-            onChange={(props) => updateSystemAgentModel(key, props)}
-          />
-          {contextLimit && (
-            <InputNumber
-              min={1}
-              placeholder={t('serviceModel.contextLimit.placeholder')}
-              style={{ alignSelf: 'flex-end', width: 180 }}
-              value={value.contextLimit}
-              onChange={(contextLimit) =>
-                updateSystemAgentModel(key, {
-                  contextLimit: typeof contextLimit === 'number' ? contextLimit : undefined,
-                })
-              }
+      return {
+        children: (
+          <Flexbox direction="vertical" gap={8} style={{ width: 'min(100%, 448px)' }}>
+            <ModelSelect
+              {...getModelSelectProps(key, source)}
+              showAbility={false}
+              style={{ minWidth: 0, width: '100%' }}
+              value={value}
+              onChange={(props) => updateSystemAgentModel(key, props)}
             />
-          )}
-        </Flexbox>
-      ),
-      desc: t(`systemAgent.${key}.modelDesc`),
-      label: t(`systemAgent.${key}.title`),
-      minWidth: undefined,
-    } satisfies FormItemProps;
-  });
+            {contextLimit && (
+              <InputNumber
+                min={1}
+                placeholder={t('serviceModel.contextLimit.placeholder')}
+                style={{ alignSelf: 'flex-end', width: 180 }}
+                value={value.contextLimit}
+                onChange={(contextLimit) =>
+                  updateSystemAgentModel(key, {
+                    contextLimit: typeof contextLimit === 'number' ? contextLimit : undefined,
+                  })
+                }
+              />
+            )}
+          </Flexbox>
+        ),
+        desc: t(`systemAgent.${key}.modelDesc`),
+        label: t(`systemAgent.${key}.title`),
+        minWidth: undefined,
+      } satisfies FormItemProps;
+    },
+  );
 
-  const optionalFeatureItems: FormItemProps[] = OPTIONAL_FEATURE_ITEMS.map(({ key }) => {
+  const optionalFeatureItems: FormItemProps[] = OPTIONAL_FEATURE_ITEMS.map(({ key, source }) => {
     const value = systemAgentSettings[key];
     const disabled = value.enabled === false;
 
@@ -174,6 +201,7 @@ const ModelAssignmentsForm = memo(() => {
           style={{ width: 'min(100%, 448px)' }}
         >
           <ModelSelect
+            {...getModelSelectProps(key, source)}
             showAbility={false}
             style={{ minWidth: 0, width: '100%' }}
             value={value}

--- a/src/hooks/useEnabledEmbeddingModels.ts
+++ b/src/hooks/useEnabledEmbeddingModels.ts
@@ -1,0 +1,10 @@
+import isEqual from 'fast-deep-equal';
+
+import { useAiInfraStore } from '@/store/aiInfra';
+import type { EnabledProviderWithModels } from '@/types/aiProvider';
+
+export const useEnabledEmbeddingModels = (): EnabledProviderWithModels[] => {
+  const enabledEmbeddingModelList = useAiInfraStore((s) => s.enabledEmbeddingModelList, isEqual);
+
+  return enabledEmbeddingModelList || [];
+};

--- a/src/server/services/systemAgent/index.ts
+++ b/src/server/services/systemAgent/index.ts
@@ -2,10 +2,14 @@ import { chainSummaryTitle } from '@lobechat/prompts';
 import type { UserSystemAgentConfig, UserSystemAgentConfigKey } from '@lobechat/types';
 import { RequestTrigger } from '@lobechat/types';
 import debug from 'debug';
+import type { EnabledAiModel } from 'model-bank';
 
 import { UserModel } from '@/database/models/user';
+import { AiInfraRepos } from '@/database/repositories/aiInfra';
 import type { LobeChatDatabase } from '@/database/type';
+import { getServerGlobalConfig } from '@/server/globalConfig';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
+import { type ProviderConfig } from '@/types/user/settings';
 
 import { resolveSystemAgentModelConfig } from './modelConfig';
 
@@ -35,6 +39,7 @@ const TOPIC_TITLE_SCHEMA = {
  */
 export class SystemAgentService {
   private readonly db: LobeChatDatabase;
+  private enabledModelsPromise?: Promise<EnabledAiModel[]>;
   private readonly userId: string;
 
   constructor(db: LobeChatDatabase, userId: string) {
@@ -104,7 +109,23 @@ export class SystemAgentService {
     const systemAgent = settings?.systemAgent as Partial<UserSystemAgentConfig> | undefined;
 
     const taskConfig = systemAgent?.[taskKey];
-    return resolveSystemAgentModelConfig({ taskConfig, taskKey });
+    const enabledModels = await this.getEnabledModels();
+
+    return resolveSystemAgentModelConfig({ enabledModels, taskConfig, taskKey });
+  }
+
+  private async getEnabledModels(): Promise<EnabledAiModel[]> {
+    if (this.enabledModelsPromise) return this.enabledModelsPromise;
+
+    const { aiProvider } = await getServerGlobalConfig();
+    const aiInfraRepos = new AiInfraRepos(
+      this.db,
+      this.userId,
+      aiProvider as Record<string, ProviderConfig>,
+    );
+
+    this.enabledModelsPromise = aiInfraRepos.getEnabledModels();
+    return this.enabledModelsPromise;
   }
 
   /**

--- a/src/server/services/systemAgent/modelConfig.test.ts
+++ b/src/server/services/systemAgent/modelConfig.test.ts
@@ -1,6 +1,17 @@
+import type { EnabledAiModel } from 'model-bank';
 import { describe, expect, it } from 'vitest';
 
 import { resolveSystemAgentModelConfig } from './modelConfig';
+
+const enabledChatModels = [
+  {
+    abilities: {},
+    enabled: true,
+    id: 'gpt-4o-mini',
+    providerId: 'openai',
+    type: 'chat',
+  },
+] as EnabledAiModel[];
 
 describe('resolveSystemAgentModelConfig', () => {
   it('should keep a configured LobeHub chat model', async () => {
@@ -49,5 +60,96 @@ describe('resolveSystemAgentModelConfig', () => {
     });
 
     expect(result).toEqual({ model: 'private-model', provider: 'openai-compatible' });
+  });
+
+  it('should fall back when configured topic model is disallowed', async () => {
+    const result = await resolveSystemAgentModelConfig({
+      enabledModels: [
+        {
+          abilities: {},
+          enabled: true,
+          id: 'gpt-5-thinking',
+          providerId: 'openai',
+          type: 'chat',
+        },
+        ...enabledChatModels,
+      ] as EnabledAiModel[],
+      taskConfig: {
+        model: 'gpt-5-thinking',
+        provider: 'openai',
+      },
+      taskKey: 'topic',
+    });
+
+    expect(result).toEqual({ model: 'gpt-4o-mini', provider: 'openai' });
+  });
+
+  it('should fall back when configured topic model is unavailable', async () => {
+    const result = await resolveSystemAgentModelConfig({
+      enabledModels: enabledChatModels,
+      taskConfig: {
+        model: 'claude-3-5-haiku-latest',
+        provider: 'anthropic',
+      },
+      taskKey: 'topic',
+    });
+
+    expect(result).toEqual({ model: 'gpt-4o-mini', provider: 'openai' });
+  });
+
+  it('should skip disabled and non-chat fallback candidates', async () => {
+    const result = await resolveSystemAgentModelConfig({
+      enabledModels: [
+        {
+          abilities: {},
+          enabled: false,
+          id: 'gpt-4o-mini',
+          providerId: 'openai',
+          type: 'chat',
+        },
+        {
+          abilities: {},
+          enabled: true,
+          id: 'gpt-4o-mini',
+          providerId: 'openai',
+          type: 'image',
+        },
+        {
+          abilities: {},
+          enabled: true,
+          id: 'gpt-4.1-mini',
+          providerId: 'openai',
+          type: 'chat',
+        },
+      ] as EnabledAiModel[],
+      taskConfig: {
+        model: 'gpt-5-thinking',
+        provider: 'openai',
+      },
+      taskKey: 'topic',
+    });
+
+    expect(result).toEqual({ model: 'gpt-4.1-mini', provider: 'openai' });
+  });
+
+  it('should keep chosen config when no enabled fallback exists', async () => {
+    const result = await resolveSystemAgentModelConfig({
+      enabledModels: [
+        {
+          abilities: {},
+          enabled: true,
+          id: 'gpt-5-thinking',
+          providerId: 'openai',
+          type: 'chat',
+        },
+      ] as EnabledAiModel[],
+      taskConfig: {
+        model: 'gpt-5-thinking',
+        provider: 'openai',
+      },
+      taskKey: 'topic',
+    });
+
+    expect(result).toEqual({ model: 'gpt-5-thinking', provider: 'openai' });
   });
 });

--- a/src/server/services/systemAgent/modelConfig.test.ts
+++ b/src/server/services/systemAgent/modelConfig.test.ts
@@ -62,23 +62,23 @@ describe('resolveSystemAgentModelConfig', () => {
     expect(result).toEqual({ model: 'private-model', provider: 'openai-compatible' });
   });
 
-  it('should fall back when configured topic model is disallowed', async () => {
+  it('should fall back when configured input completion model is denied', async () => {
     const result = await resolveSystemAgentModelConfig({
       enabledModels: [
         {
           abilities: {},
           enabled: true,
-          id: 'gpt-5-thinking',
+          id: 'gpt-5.4-pro',
           providerId: 'openai',
           type: 'chat',
         },
         ...enabledChatModels,
       ] as EnabledAiModel[],
       taskConfig: {
-        model: 'gpt-5-thinking',
+        model: 'gpt-5.4-pro',
         provider: 'openai',
       },
-      taskKey: 'topic',
+      taskKey: 'inputCompletion',
     });
 
     expect(result).toEqual({ model: 'gpt-4o-mini', provider: 'openai' });

--- a/src/server/services/systemAgent/modelConfig.ts
+++ b/src/server/services/systemAgent/modelConfig.ts
@@ -1,13 +1,42 @@
-import { DEFAULT_SYSTEM_AGENT_CONFIG } from '@lobechat/const';
+import {
+  DEFAULT_SYSTEM_AGENT_CONFIG,
+  getServiceModelPolicy,
+  isServiceModelCandidateAllowed,
+  resolveServiceModelFallback,
+} from '@lobechat/const';
 import type { SystemAgentItem, UserSystemAgentConfigKey } from '@lobechat/types';
+import type { EnabledAiModel } from 'model-bank';
 
 interface ResolveSystemAgentModelConfigParams {
+  enabledModels?: EnabledAiModel[];
   override?: Partial<Pick<SystemAgentItem, 'model' | 'provider'>>;
   taskConfig?: Partial<SystemAgentItem>;
   taskKey: UserSystemAgentConfigKey;
 }
 
+const buildEnabledChatProviderGroups = (enabledModels: EnabledAiModel[] | undefined) => {
+  if (!enabledModels) return;
+
+  const groups = new Map<string, { children: { id: string }[]; id: string }>();
+
+  for (const model of enabledModels) {
+    if (model.enabled === false || model.type !== 'chat') continue;
+
+    const providerId = model.providerId;
+    const group = groups.get(providerId);
+
+    if (group) {
+      group.children.push({ id: model.id });
+    } else {
+      groups.set(providerId, { children: [{ id: model.id }], id: providerId });
+    }
+  }
+
+  return Array.from(groups.values());
+};
+
 export const resolveSystemAgentModelConfig = async ({
+  enabledModels,
   override,
   taskConfig,
   taskKey,
@@ -15,6 +44,33 @@ export const resolveSystemAgentModelConfig = async ({
   const defaults = DEFAULT_SYSTEM_AGENT_CONFIG[taskKey];
   const model = override?.model || taskConfig?.model || defaults.model;
   const provider = override?.provider || taskConfig?.provider || defaults.provider;
+  const candidate = { model, provider };
+  const providerGroups = buildEnabledChatProviderGroups(enabledModels);
 
-  return { model, provider };
+  if (!providerGroups) return candidate;
+
+  const policy = getServiceModelPolicy(taskKey);
+  const isAvailable = providerGroups.some(
+    (providerGroup) =>
+      providerGroup.id === provider &&
+      providerGroup.children.some((providerModel) => providerModel.id === model),
+  );
+
+  if (isAvailable && isServiceModelCandidateAllowed(policy, candidate)) {
+    return candidate;
+  }
+
+  const fallback = resolveServiceModelFallback(policy, providerGroups);
+
+  if (fallback) {
+    console.warn('[SystemAgentModelConfig] resolved fallback model', { fallback, taskKey });
+    return fallback;
+  }
+
+  console.warn('[SystemAgentModelConfig] no allowed fallback model, keeping configured model', {
+    model,
+    provider,
+    taskKey,
+  });
+  return candidate;
 };

--- a/src/server/services/taskReview/index.ts
+++ b/src/server/services/taskReview/index.ts
@@ -2,10 +2,14 @@ import type { EvaluateResult, RubricResult } from '@lobechat/eval-rubric';
 import { evaluate } from '@lobechat/eval-rubric';
 import type { EvalBenchmarkRubric, UserSystemAgentConfig } from '@lobechat/types';
 import debug from 'debug';
+import type { EnabledAiModel } from 'model-bank';
 
 import { UserModel } from '@/database/models/user';
+import { AiInfraRepos } from '@/database/repositories/aiInfra';
 import type { LobeChatDatabase } from '@/database/type';
+import { getServerGlobalConfig } from '@/server/globalConfig';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
+import { type ProviderConfig } from '@/types/user/settings';
 
 import { resolveSystemAgentModelConfig } from '../systemAgent/modelConfig';
 
@@ -35,6 +39,7 @@ export interface ReviewResult {
 
 export class TaskReviewService {
   private db: LobeChatDatabase;
+  private enabledModelsPromise?: Promise<EnabledAiModel[]>;
   private userId: string;
 
   constructor(db: LobeChatDatabase, userId: string) {
@@ -105,8 +110,11 @@ export class TaskReviewService {
   private async resolveModelConfig(
     judge: ReviewJudge,
   ): Promise<{ model: string; provider: string }> {
+    const enabledModels = await this.getEnabledModels();
+
     if (judge.model && judge.provider) {
       return resolveSystemAgentModelConfig({
+        enabledModels,
         override: judge,
         taskKey: 'topic',
       });
@@ -118,9 +126,24 @@ export class TaskReviewService {
     const topicConfig = systemAgent?.topic;
 
     return resolveSystemAgentModelConfig({
+      enabledModels,
       override: judge,
       taskConfig: topicConfig,
       taskKey: 'topic',
     });
+  }
+
+  private async getEnabledModels(): Promise<EnabledAiModel[]> {
+    if (this.enabledModelsPromise) return this.enabledModelsPromise;
+
+    const { aiProvider } = await getServerGlobalConfig();
+    const aiInfraRepos = new AiInfraRepos(
+      this.db,
+      this.userId,
+      aiProvider as Record<string, ProviderConfig>,
+    );
+
+    this.enabledModelsPromise = aiInfraRepos.getEnabledModels();
+    return this.enabledModelsPromise;
   }
 }

--- a/src/services/serviceModelPolicy/client.test.ts
+++ b/src/services/serviceModelPolicy/client.test.ts
@@ -7,7 +7,7 @@ import { resolveClientServiceModelConfig } from './client';
 
 const chatList = [
   {
-    children: [{ id: 'gpt-4o-mini' }, { id: 'gpt-5-thinking' }],
+    children: [{ id: 'gpt-4o-mini' }, { id: 'gpt-5.4-pro' }],
     id: 'openai',
     name: 'OpenAI',
     source: 'builtin',
@@ -38,7 +38,7 @@ describe('resolveClientServiceModelConfig', () => {
 
   it('falls back when the saved input completion model is invalid', () => {
     const config = {
-      model: 'gpt-5-thinking',
+      model: 'gpt-5.4-pro',
       provider: 'openai',
     } satisfies SystemAgentItem;
 
@@ -50,12 +50,12 @@ describe('resolveClientServiceModelConfig', () => {
 
   it('returns undefined for input completion when no allowed model exists', () => {
     const config = {
-      model: 'gpt-5-thinking',
+      model: 'gpt-5.4-pro',
       provider: 'openai',
     } satisfies SystemAgentItem;
     const disallowedChatList = [
       {
-        children: [{ id: 'gpt-5-thinking' }],
+        children: [{ id: 'gpt-5.4-pro' }],
         id: 'openai',
         name: 'OpenAI',
         source: 'builtin',

--- a/src/services/serviceModelPolicy/client.test.ts
+++ b/src/services/serviceModelPolicy/client.test.ts
@@ -1,0 +1,88 @@
+import type { SystemAgentItem } from '@lobechat/types';
+import { describe, expect, it } from 'vitest';
+
+import type { EnabledProviderWithModels } from '@/types/aiProvider';
+
+import { resolveClientServiceModelConfig } from './client';
+
+const chatList = [
+  {
+    children: [{ id: 'gpt-4o-mini' }, { id: 'gpt-5-thinking' }],
+    id: 'openai',
+    name: 'OpenAI',
+    source: 'builtin',
+  },
+] as EnabledProviderWithModels[];
+
+const embeddingList = [
+  {
+    children: [{ id: 'text-embedding-3-small' }],
+    id: 'openai',
+    name: 'OpenAI',
+    source: 'builtin',
+  },
+] as EnabledProviderWithModels[];
+
+describe('resolveClientServiceModelConfig', () => {
+  it('keeps a valid saved input completion model', () => {
+    const config = {
+      model: 'gpt-4o-mini',
+      provider: 'openai',
+    } satisfies SystemAgentItem;
+
+    expect(resolveClientServiceModelConfig('inputCompletion', config, { chatList })).toEqual({
+      model: 'gpt-4o-mini',
+      provider: 'openai',
+    });
+  });
+
+  it('falls back when the saved input completion model is invalid', () => {
+    const config = {
+      model: 'gpt-5-thinking',
+      provider: 'openai',
+    } satisfies SystemAgentItem;
+
+    expect(resolveClientServiceModelConfig('inputCompletion', config, { chatList })).toEqual({
+      model: 'gpt-4o-mini',
+      provider: 'openai',
+    });
+  });
+
+  it('returns undefined for input completion when no allowed model exists', () => {
+    const config = {
+      model: 'gpt-5-thinking',
+      provider: 'openai',
+    } satisfies SystemAgentItem;
+    const disallowedChatList = [
+      {
+        children: [{ id: 'gpt-5-thinking' }],
+        id: 'openai',
+        name: 'OpenAI',
+        source: 'builtin',
+      },
+    ] as EnabledProviderWithModels[];
+
+    expect(
+      resolveClientServiceModelConfig('inputCompletion', config, {
+        chatList: disallowedChatList,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('uses embedding candidates for user memory embedding fallback', () => {
+    const config = {
+      model: 'gpt-5-thinking',
+      provider: 'openai',
+    } satisfies SystemAgentItem;
+
+    expect(
+      resolveClientServiceModelConfig('userMemoryEmbedding', config, {
+        chatList,
+        embeddingList,
+      }),
+    ).toEqual({
+      model: 'text-embedding-3-small',
+      provider: 'openai',
+    });
+  });
+});

--- a/src/services/serviceModelPolicy/client.ts
+++ b/src/services/serviceModelPolicy/client.ts
@@ -1,0 +1,65 @@
+import {
+  getServiceModelPolicy,
+  isServiceModelCandidateAllowed,
+  resolveServiceModelFallback,
+} from '@lobechat/const';
+import type { SystemAgentItem, UserServiceModelConfigKey } from '@lobechat/types';
+
+import { getAiInfraStoreState } from '@/store/aiInfra';
+import type { EnabledProviderWithModels } from '@/types/aiProvider';
+
+interface ResolveClientServiceModelLists {
+  chatList?: EnabledProviderWithModels[];
+  embeddingList?: EnabledProviderWithModels[];
+}
+
+type ResolvedServiceModelConfig = Pick<SystemAgentItem, 'model' | 'provider'>;
+
+export const resolveClientServiceModelConfig = (
+  key: UserServiceModelConfigKey,
+  config: SystemAgentItem | undefined,
+  lists?: ResolveClientServiceModelLists,
+): ResolvedServiceModelConfig | undefined => {
+  if (!config) return;
+
+  const policy = getServiceModelPolicy(key);
+
+  if (!policy) return config;
+
+  const state = getAiInfraStoreState();
+  const candidates =
+    policy.source === 'embedding'
+      ? (lists?.embeddingList ?? state.enabledEmbeddingModelList ?? [])
+      : (lists?.chatList ?? state.enabledChatModelList ?? []);
+
+  const hasSavedCandidate = candidates.some(
+    (provider) =>
+      provider.id === config.provider &&
+      provider.children.some((model) => model.id === config.model),
+  );
+
+  if (hasSavedCandidate && isServiceModelCandidateAllowed(policy, config)) {
+    return {
+      model: config.model,
+      provider: config.provider,
+    };
+  }
+
+  const fallback = resolveServiceModelFallback(policy, candidates);
+
+  if (fallback) {
+    console.warn('[ServiceModelPolicy] resolved fallback model', { fallback, key });
+    return fallback;
+  }
+
+  if (policy.invalidSelection === 'empty') return;
+
+  console.warn('[ServiceModelPolicy] no allowed fallback model, keeping saved config', {
+    config,
+    key,
+  });
+  return {
+    model: config.model,
+    provider: config.provider,
+  };
+};

--- a/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
+++ b/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
@@ -2,8 +2,13 @@ import * as runtimeModule from '@lobechat/model-runtime';
 import type { AIImageModelCard, EnabledAiModel, ModelParamsSchema, Pricing } from 'model-bank';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { EnabledProvider } from '@/types/aiProvider';
+import { AiProviderSourceEnum } from '@/types/aiProvider';
+
 import {
+  buildEmbeddingProviderModelLists,
   getChatModelList,
+  getEmbeddingModelList,
   getImageModelList,
   normalizeChatModel,
   normalizeImageModel,
@@ -210,6 +215,57 @@ describe('aiProvider action helpers', () => {
     it('returns empty array when provider has no image models', async () => {
       const result = await getImageModelList(imageModels, 'unknown');
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('getEmbeddingModelList', () => {
+    it('filters embedding models by provider', async () => {
+      const models = [
+        createChatModel({ id: 'gpt-4o-mini', providerId: 'openai', type: 'chat' }),
+        createChatModel({
+          id: 'text-embedding-3-small',
+          providerId: 'openai',
+          type: 'embedding',
+        }),
+        createChatModel({
+          id: 'text-embedding-3-large',
+          providerId: 'openai',
+          type: 'embedding',
+        }),
+        createChatModel({ id: 'embed-other', providerId: 'cohere', type: 'embedding' }),
+      ];
+
+      const result = await getEmbeddingModelList(models, 'openai');
+
+      expect(result.map((model) => model.id)).toEqual([
+        'text-embedding-3-small',
+        'text-embedding-3-large',
+      ]);
+    });
+
+    it('does not include providers that only have disabled embedding models', async () => {
+      const providers: EnabledProvider[] = [
+        { id: 'openai', name: 'OpenAI', source: AiProviderSourceEnum.Builtin },
+        { id: 'cohere', name: 'Cohere', source: AiProviderSourceEnum.Builtin },
+      ];
+      const builtinModels = [
+        createChatModel({ id: 'gpt-4o-mini', providerId: 'openai', type: 'chat' }),
+        createChatModel({
+          enabled: false,
+          id: 'text-embedding-3-small',
+          providerId: 'openai',
+          type: 'embedding',
+        }),
+        createChatModel({ id: 'embed-other', providerId: 'cohere', type: 'embedding' }),
+      ];
+      const enabledAiModels = builtinModels.filter((model) => model.enabled);
+
+      const result = await buildEmbeddingProviderModelLists(providers, enabledAiModels);
+
+      expect(result.map((provider) => provider.id)).toEqual(['cohere']);
+      expect(result.map((provider) => provider.children.map((model) => model.id))).toEqual([
+        ['embed-other'],
+      ]);
     });
   });
 });

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -173,8 +173,17 @@ export const normalizeVideoModel = async (
   };
 };
 
+export const normalizeEmbeddingModel = async (
+  model: EnabledAiModel,
+): Promise<ProviderModelListItem> => normalizeChatModel(model);
+
 export const getChatModelList = createProviderModelCollector('chat', async (model) =>
   normalizeChatModel(model),
+);
+
+export const getEmbeddingModelList = createProviderModelCollector(
+  'embedding',
+  normalizeEmbeddingModel,
 );
 
 export const getImageModelList = createProviderModelCollector('image', normalizeImageModel);
@@ -214,6 +223,29 @@ const buildChatProviderModelLists = async (
   enabledAiModels: EnabledAiModel[],
 ) => buildProviderModelLists(providers, enabledAiModels, getChatModelList);
 
+export const getEnabledAiProvidersByModelType = (
+  providers: EnabledProvider[],
+  enabledAiModels: EnabledAiModel[],
+  type: EnabledAiModel['type'],
+) => {
+  return providers.filter((provider) =>
+    enabledAiModels.some((model) => model.providerId === provider.id && model.type === type),
+  );
+};
+
+/**
+ * Build embedding provider model lists with proper async handling
+ */
+export const buildEmbeddingProviderModelLists = async (
+  providers: EnabledProvider[],
+  enabledAiModels: EnabledAiModel[],
+) =>
+  buildProviderModelLists(
+    getEnabledAiProvidersByModelType(providers, enabledAiModels, 'embedding'),
+    enabledAiModels,
+    getEmbeddingModelList,
+  );
+
 /**
  * Build video provider model lists with proper async handling
  */
@@ -231,6 +263,8 @@ enum AiProviderSwrKey {
 type AiProviderRuntimeStateWithBuiltinModels = AiProviderRuntimeState & {
   builtinAiModelList: LobeDefaultAiModelListItem[];
   enabledChatModelList?: EnabledProviderWithModels[];
+  enabledEmbeddingAiProviders?: EnabledProvider[];
+  enabledEmbeddingModelList?: EnabledProviderWithModels[];
   enabledImageModelList?: EnabledProviderWithModels[];
   enabledVideoModelList?: EnabledProviderWithModels[];
 };
@@ -479,18 +513,31 @@ export class AiProviderActionImpl {
         if (isLogin) {
           const data = await aiProviderService.getAiProviderRuntimeState();
 
+          const enabledEmbeddingAiProviders = getEnabledAiProvidersByModelType(
+            data.enabledAiProviders,
+            data.enabledAiModels,
+            'embedding',
+          );
+
           // Build model lists with proper async handling
-          const [enabledChatModelList, enabledImageModelList, enabledVideoModelList] =
-            await Promise.all([
-              buildChatProviderModelLists(data.enabledChatAiProviders, data.enabledAiModels),
-              buildImageProviderModelLists(data.enabledImageAiProviders, data.enabledAiModels),
-              buildVideoProviderModelLists(data.enabledVideoAiProviders, data.enabledAiModels),
-            ]);
+          const [
+            enabledChatModelList,
+            enabledEmbeddingModelList,
+            enabledImageModelList,
+            enabledVideoModelList,
+          ] = await Promise.all([
+            buildChatProviderModelLists(data.enabledChatAiProviders, data.enabledAiModels),
+            buildEmbeddingProviderModelLists(data.enabledAiProviders, data.enabledAiModels),
+            buildImageProviderModelLists(data.enabledImageAiProviders, data.enabledAiModels),
+            buildVideoProviderModelLists(data.enabledVideoAiProviders, data.enabledAiModels),
+          ]);
 
           return {
             ...data,
             builtinAiModelList,
             enabledChatModelList,
+            enabledEmbeddingAiProviders,
+            enabledEmbeddingModelList,
             enabledImageModelList,
             enabledVideoModelList,
           };
@@ -524,12 +571,22 @@ export class AiProviderActionImpl {
 
         // Build model lists for non-login state as well
         const enabledAiModels = builtinAiModelList.filter((m) => m.enabled);
-        const [enabledChatModelList, enabledImageModelList, enabledVideoModelList] =
-          await Promise.all([
-            buildChatProviderModelLists(enabledChatAiProviders, enabledAiModels),
-            buildImageProviderModelLists(enabledImageAiProviders, enabledAiModels),
-            buildVideoProviderModelLists(enabledVideoAiProviders, enabledAiModels),
-          ]);
+        const enabledEmbeddingAiProviders = getEnabledAiProvidersByModelType(
+          enabledAiProviders,
+          enabledAiModels,
+          'embedding',
+        );
+        const [
+          enabledChatModelList,
+          enabledEmbeddingModelList,
+          enabledImageModelList,
+          enabledVideoModelList,
+        ] = await Promise.all([
+          buildChatProviderModelLists(enabledChatAiProviders, enabledAiModels),
+          buildEmbeddingProviderModelLists(enabledAiProviders, enabledAiModels),
+          buildImageProviderModelLists(enabledImageAiProviders, enabledAiModels),
+          buildVideoProviderModelLists(enabledVideoAiProviders, enabledAiModels),
+        ]);
 
         return {
           builtinAiModelList,
@@ -537,6 +594,8 @@ export class AiProviderActionImpl {
           enabledAiProviders,
           enabledChatAiProviders,
           enabledChatModelList,
+          enabledEmbeddingAiProviders,
+          enabledEmbeddingModelList,
           enabledImageAiProviders,
           enabledImageModelList,
           enabledVideoAiProviders,
@@ -555,6 +614,7 @@ export class AiProviderActionImpl {
               enabledAiModels: data.enabledAiModels,
               enabledAiProviders: data.enabledAiProviders,
               enabledChatModelList: data.enabledChatModelList || [],
+              enabledEmbeddingModelList: data.enabledEmbeddingModelList || [],
               enabledImageModelList: data.enabledImageModelList || [],
               enabledVideoModelList: data.enabledVideoModelList || [],
               isInitAiProviderRuntimeState: true,

--- a/src/store/aiInfra/slices/aiProvider/initialState.ts
+++ b/src/store/aiInfra/slices/aiProvider/initialState.ts
@@ -24,6 +24,7 @@ export interface AIProviderState {
   enabledAiProviders?: EnabledProvider[];
   // used for select
   enabledChatModelList?: EnabledProviderWithModels[];
+  enabledEmbeddingModelList?: EnabledProviderWithModels[];
   enabledImageModelList?: EnabledProviderWithModels[];
   enabledVideoModelList?: EnabledProviderWithModels[];
   initAiProviderList: boolean;

--- a/src/store/chat/slices/aiChat/actions/memory.test.ts
+++ b/src/store/chat/slices/aiChat/actions/memory.test.ts
@@ -1,0 +1,94 @@
+import { type UIChatMessage } from '@lobechat/types';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { chatService } from '@/services/chat';
+import { topicService } from '@/services/topic';
+import { useChatStore } from '@/store/chat';
+import type { EnabledProviderWithModels } from '@/types/aiProvider';
+
+vi.mock('@/services/chat', () => ({
+  chatService: {
+    fetchPresetTaskResult: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/topic', () => ({
+  topicService: {
+    updateTopic: vi.fn(),
+  },
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: {
+    getState: vi.fn(() => ({})),
+  },
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  systemAgentSelectors: {
+    historyCompress: vi.fn(() => ({
+      contextLimit: 12_000,
+      model: 'gpt-5-thinking',
+      provider: 'openai',
+    })),
+  },
+}));
+
+const aiInfraStoreState = vi.hoisted(() => ({
+  enabledChatModelList: [
+    {
+      children: [{ id: 'gpt-4o-mini' }],
+      id: 'openai',
+      name: 'OpenAI',
+      source: 'builtin',
+    },
+  ] as EnabledProviderWithModels[],
+}));
+
+vi.mock('@/store/aiInfra', () => ({
+  getAiInfraStoreState: () => aiInfraStoreState,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useChatStore.setState({
+    activeAgentId: 'agent-1',
+    activeTopicId: 'topic-1',
+  });
+});
+
+describe('ChatMemoryAction', () => {
+  it('uses resolved history compression model and stores it in topic metadata', async () => {
+    const messages = [
+      { content: 'one', id: 'message-1', role: 'user' },
+      { content: 'two', id: 'message-2', role: 'assistant' },
+    ] as UIChatMessage[];
+    const { result } = renderHook(() => useChatStore());
+
+    vi.spyOn(result.current, 'refreshTopic').mockResolvedValue(undefined);
+    vi.spyOn(result.current, 'refreshMessages').mockResolvedValue(undefined);
+    vi.mocked(chatService.fetchPresetTaskResult).mockImplementation(async ({ onFinish }) => {
+      await onFinish?.('compressed history', { type: 'done' });
+    });
+
+    await act(async () => {
+      await result.current.internal_summaryHistory(messages);
+    });
+
+    expect(chatService.fetchPresetTaskResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({
+          contextLimit: 12_000,
+          model: 'gpt-4o-mini',
+          provider: 'openai',
+          stream: false,
+        }),
+      }),
+    );
+    expect(topicService.updateTopic).toHaveBeenCalledWith('topic-1', {
+      historySummary: 'compressed history',
+      metadata: { model: 'gpt-4o-mini', provider: 'openai' },
+    });
+  });
+});

--- a/src/store/chat/slices/aiChat/actions/memory.ts
+++ b/src/store/chat/slices/aiChat/actions/memory.ts
@@ -3,6 +3,7 @@ import { type UIChatMessage } from '@lobechat/types';
 import { TraceNameMap } from '@lobechat/types';
 
 import { chatService } from '@/services/chat';
+import { resolveClientServiceModelConfig } from '@/services/serviceModelPolicy/client';
 import { topicService } from '@/services/topic';
 import { type ChatStore } from '@/store/chat';
 import { type StoreSetter } from '@/store/types';
@@ -26,14 +27,19 @@ export class ChatMemoryActionImpl {
     const topicId = this.#get().activeTopicId;
     if (messages.length <= 1 || !topicId) return;
 
-    const { model, provider } = systemAgentSelectors.historyCompress(useUserStore.getState());
+    const historyCompressConfig = systemAgentSelectors.historyCompress(useUserStore.getState());
+    const resolvedHistoryCompressConfig = resolveClientServiceModelConfig(
+      'historyCompress',
+      historyCompressConfig,
+    );
+    const taskConfig = { ...historyCompressConfig, ...resolvedHistoryCompressConfig };
 
     let historySummary = '';
     await chatService.fetchPresetTaskResult({
       onFinish: async (text) => {
         historySummary = text;
       },
-      params: { ...chainSummaryHistory(messages), model, provider, stream: false },
+      params: { ...chainSummaryHistory(messages), ...taskConfig, stream: false },
       trace: {
         sessionId: this.#get().activeAgentId,
         topicId: this.#get().activeTopicId,
@@ -43,7 +49,7 @@ export class ChatMemoryActionImpl {
 
     await topicService.updateTopic(topicId, {
       historySummary,
-      metadata: { model, provider },
+      metadata: { model: taskConfig.model, provider: taskConfig.provider },
     });
     await this.#get().refreshTopic();
     await this.#get().refreshMessages();

--- a/src/store/chat/slices/thread/action.test.ts
+++ b/src/store/chat/slices/thread/action.test.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mutate } from '@/libs/swr';
 import { chatService } from '@/services/chat';
 import { threadService } from '@/services/thread';
+import { systemAgentSelectors } from '@/store/user/selectors';
+import type { EnabledProviderWithModels } from '@/types/aiProvider';
 import { type ThreadItem } from '@/types/topic';
 import { ThreadStatus, ThreadType } from '@/types/topic';
 
@@ -77,7 +79,10 @@ vi.mock('@/store/user', () => ({
 
 vi.mock('@/store/user/selectors', () => ({
   systemAgentSelectors: {
-    thread: vi.fn(() => ({})),
+    thread: vi.fn(() => ({
+      model: 'gpt-5-thinking',
+      provider: 'openai',
+    })),
   },
   userGeneralSettingsSelectors: {
     currentResponseLanguage: vi.fn(() => 'en-US'),
@@ -85,6 +90,21 @@ vi.mock('@/store/user/selectors', () => ({
   userProfileSelectors: {
     userAvatar: vi.fn(() => 'avatar-url'),
   },
+}));
+
+const aiInfraStoreState = vi.hoisted(() => ({
+  enabledChatModelList: [
+    {
+      children: [{ id: 'gpt-4o-mini' }],
+      id: 'openai',
+      name: 'OpenAI',
+      source: 'builtin',
+    },
+  ] as EnabledProviderWithModels[],
+}));
+
+vi.mock('@/store/aiInfra', () => ({
+  getAiInfraStoreState: () => aiInfraStoreState,
 }));
 
 beforeEach(() => {
@@ -615,6 +635,12 @@ describe('thread action', () => {
       });
 
       expect(chatService.fetchPresetTaskResult).toHaveBeenCalled();
+      expect(chatService.fetchPresetTaskResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({ model: 'gpt-4o-mini', provider: 'openai' }),
+        }),
+      );
+      expect(systemAgentSelectors.thread).toHaveBeenCalled();
       expect(internalUpdateSpy).toHaveBeenCalledWith('thread-id', {
         title: 'New Generated Title',
       });

--- a/src/store/chat/slices/thread/action.ts
+++ b/src/store/chat/slices/thread/action.ts
@@ -12,6 +12,7 @@ import { type SWRResponse } from 'swr';
 
 import { mutate, useClientDataSWR } from '@/libs/swr';
 import { chatService } from '@/services/chat';
+import { resolveClientServiceModelConfig } from '@/services/serviceModelPolicy/client';
 import { threadService } from '@/services/thread';
 import { threadSelectors } from '@/store/chat/selectors';
 import { type ChatStore } from '@/store/chat/store';
@@ -190,6 +191,8 @@ export class ChatThreadActionImpl {
 
     let output = '';
     const threadConfig = systemAgentSelectors.thread(useUserStore.getState());
+    const resolvedThreadConfig = resolveClientServiceModelConfig('thread', threadConfig);
+    const taskConfig = merge(threadConfig, resolvedThreadConfig ?? {});
 
     await chatService.fetchPresetTaskResult({
       onError: () => {
@@ -211,7 +214,7 @@ export class ChatThreadActionImpl {
         internal_updateThreadTitleInSummary(threadId, output);
       },
       params: merge(
-        threadConfig,
+        taskConfig,
         chainSummaryTitle(
           messages,
           userGeneralSettingsSelectors.currentResponseLanguage(useUserStore.getState()),

--- a/src/store/chat/slices/topic/action.test.ts
+++ b/src/store/chat/slices/topic/action.test.ts
@@ -12,6 +12,8 @@ import { PortalViewType } from '@/store/chat/slices/portal/initialState';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 import { topicMapKey } from '@/store/chat/utils/topicMapKey';
 import { useSessionStore } from '@/store/session';
+import { systemAgentSelectors } from '@/store/user/selectors';
+import type { EnabledProviderWithModels } from '@/types/aiProvider';
 import { type ChatTopic } from '@/types/topic';
 
 import { useChatStore } from '../../store';
@@ -59,6 +61,21 @@ vi.mock('@/components/AntdStaticMethods', () => ({
     error: vi.fn(),
     destroy: vi.fn(),
   },
+}));
+
+const aiInfraStoreState = vi.hoisted(() => ({
+  enabledChatModelList: [
+    {
+      children: [{ id: 'gpt-4o-mini' }],
+      id: 'openai',
+      name: 'OpenAI',
+      source: 'builtin',
+    },
+  ] as EnabledProviderWithModels[],
+}));
+
+vi.mock('@/store/aiInfra', () => ({
+  getAiInfraStoreState: () => aiInfraStoreState,
 }));
 
 vi.mock('i18next', () => ({
@@ -1325,6 +1342,10 @@ describe('topic action', () => {
       const refreshTopicSpy = vi.spyOn(result.current, 'refreshTopic');
 
       // Mock the `chatService.fetchPresetTaskResult` to simulate the AI response
+      vi.spyOn(systemAgentSelectors, 'topic').mockReturnValue({
+        model: 'gpt-5-thinking',
+        provider: 'openai',
+      });
       vi.spyOn(chatService, 'fetchPresetTaskResult').mockImplementation((params) => {
         if (params) {
           params.onFinish?.('Summarized Title', { type: 'done' });
@@ -1339,8 +1360,11 @@ describe('topic action', () => {
       // Verify that the title was updated and the topic was refreshed
       expect(updateTopicTitleInSummarySpy).toHaveBeenCalledWith(topicId, LOADING_FLAT);
       expect(refreshTopicSpy).toHaveBeenCalled();
-
-      // TODO: need to test with fetchPresetTaskResult
+      expect(chatService.fetchPresetTaskResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({ model: 'gpt-4o-mini', provider: 'openai' }),
+        }),
+      );
     });
   });
   describe('createTopic', () => {

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -13,6 +13,7 @@ import { LOADING_FLAT } from '@/const/message';
 import { mutate, useClientDataSWRWithSync } from '@/libs/swr';
 import { chatService } from '@/services/chat';
 import { messageService } from '@/services/message';
+import { resolveClientServiceModelConfig } from '@/services/serviceModelPolicy/client';
 import { topicService } from '@/services/topic';
 import { type ChatStore } from '@/store/chat';
 import { topicMapKey } from '@/store/chat/utils/topicMapKey';
@@ -205,6 +206,8 @@ export class ChatTopicActionImpl {
 
     // Get current agent for topic
     const topicConfig = systemAgentSelectors.topic(useUserStore.getState());
+    const resolvedTopicConfig = resolveClientServiceModelConfig('topic', topicConfig);
+    const taskConfig = merge(topicConfig, resolvedTopicConfig ?? {});
 
     // Automatically summarize the topic title
     await chatService.fetchPresetTaskResult({
@@ -227,7 +230,7 @@ export class ChatTopicActionImpl {
         internal_updateTopicTitleInSummary(topicId, output);
       },
       params: merge(
-        topicConfig,
+        taskConfig,
         chainSummaryTitle(
           messages,
           userGeneralSettingsSelectors.currentResponseLanguage(useUserStore.getState()),

--- a/src/store/chat/slices/translate/action.test.ts
+++ b/src/store/chat/slices/translate/action.test.ts
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { chatService } from '@/services/chat';
 import { messageService } from '@/services/message';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
+import { systemAgentSelectors } from '@/store/user/selectors';
+import type { EnabledProviderWithModels } from '@/types/aiProvider';
 
 import { useChatStore } from '../../store';
 
@@ -31,8 +33,26 @@ vi.mock('@/store/user', () => ({
 
 vi.mock('@/store/user/selectors', () => ({
   systemAgentSelectors: {
-    translation: vi.fn(() => ({})),
+    translation: vi.fn(() => ({
+      model: 'gpt-5-thinking',
+      provider: 'openai',
+    })),
   },
+}));
+
+const aiInfraStoreState = vi.hoisted(() => ({
+  enabledChatModelList: [
+    {
+      children: [{ id: 'gpt-4o-mini' }],
+      id: 'openai',
+      name: 'OpenAI',
+      source: 'builtin',
+    },
+  ] as EnabledProviderWithModels[],
+}));
+
+vi.mock('@/store/aiInfra', () => ({
+  getAiInfraStoreState: () => aiInfraStoreState,
 }));
 
 beforeEach(() => {
@@ -89,6 +109,19 @@ describe('ChatEnhanceAction', () => {
 
       expect(messageService.updateMessageTranslate).toHaveBeenCalled();
       expect(chatService.fetchPresetTaskResult).toHaveBeenCalledTimes(2);
+      expect(chatService.fetchPresetTaskResult).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          params: expect.objectContaining({ model: 'gpt-4o-mini', provider: 'openai' }),
+        }),
+      );
+      expect(chatService.fetchPresetTaskResult).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          params: expect.objectContaining({ model: 'gpt-4o-mini', provider: 'openai' }),
+        }),
+      );
+      expect(systemAgentSelectors.translation).toHaveBeenCalled();
     });
   });
 

--- a/src/store/chat/slices/translate/action.ts
+++ b/src/store/chat/slices/translate/action.ts
@@ -6,6 +6,7 @@ import { merge } from '@lobechat/utils';
 import { supportLocales } from '@/locales/resources';
 import { chatService } from '@/services/chat';
 import { messageService } from '@/services/message';
+import { resolveClientServiceModelConfig } from '@/services/serviceModelPolicy/client';
 import { dbMessageSelectors } from '@/store/chat/selectors';
 import { type ChatStore } from '@/store/chat/store';
 import { type StoreSetter } from '@/store/types';
@@ -49,6 +50,11 @@ export class ChatTranslateActionImpl {
 
     // Get current agent for translation
     const translationSetting = systemAgentSelectors.translation(useUserStore.getState());
+    const resolvedTranslationSetting = resolveClientServiceModelConfig(
+      'translation',
+      translationSetting,
+    );
+    const taskConfig = merge(translationSetting, resolvedTranslationSetting ?? {});
 
     // create translate extra
     await updateMessageTranslate(id, { content: '', from: '', to: targetLang });
@@ -79,7 +85,7 @@ export class ChatTranslateActionImpl {
 
           await updateMessageTranslate(id, { content, from, to: targetLang });
         },
-        params: merge(translationSetting, chainLangDetect(message.content)),
+        params: merge(taskConfig, chainLangDetect(message.content)),
         trace: this.#get().getCurrentTracePayload({ traceName: TraceNameMap.LanguageDetect }),
       });
 
@@ -106,7 +112,7 @@ export class ChatTranslateActionImpl {
             }
           }
         },
-        params: merge(translationSetting, chainTranslate(message.content, targetLang)),
+        params: merge(taskConfig, chainTranslate(message.content, targetLang)),
         trace: this.#get().getCurrentTracePayload({ traceName: TraceNameMap.Translator }),
       });
     } catch (error) {

--- a/src/store/image/slices/generationTopic/action.test.ts
+++ b/src/store/image/slices/generationTopic/action.test.ts
@@ -6,6 +6,8 @@ import { mutate } from '@/libs/swr';
 import { chatService } from '@/services/chat';
 import { generationTopicService } from '@/services/generationTopic';
 import { useImageStore } from '@/store/image';
+import { systemAgentSelectors } from '@/store/user/selectors';
+import type { EnabledProviderWithModels } from '@/types/aiProvider';
 import { type ImageGenerationTopic } from '@/types/generation';
 
 // Mock @/libs/swr mutate
@@ -43,13 +45,28 @@ vi.mock('@/store/user', () => ({
 vi.mock('@/store/user/selectors', () => ({
   systemAgentSelectors: {
     generationTopic: vi.fn().mockReturnValue({
-      model: 'gpt-4',
+      model: 'gpt-5-thinking',
       provider: 'openai',
     }),
   },
   userGeneralSettingsSelectors: {
     currentResponseLanguage: vi.fn(() => 'en-US'),
   },
+}));
+
+const aiInfraStoreState = vi.hoisted(() => ({
+  enabledChatModelList: [
+    {
+      children: [{ id: 'gpt-4o-mini' }],
+      id: 'openai',
+      name: 'OpenAI',
+      source: 'builtin',
+    },
+  ] as EnabledProviderWithModels[],
+}));
+
+vi.mock('@/store/aiInfra', () => ({
+  getAiInfraStoreState: () => aiInfraStoreState,
 }));
 
 beforeEach(() => {
@@ -213,6 +230,10 @@ describe('GenerationTopicAction', () => {
       act(() => {
         useImageStore.setState({ generationTopics: topics });
       });
+      vi.mocked(systemAgentSelectors.generationTopic).mockReturnValue({
+        model: 'gpt-5-thinking',
+        provider: 'openai',
+      });
 
       // Mock successful AI response
       vi.mocked(chatService.fetchPresetTaskResult).mockImplementation((params) => {
@@ -227,6 +248,11 @@ describe('GenerationTopicAction', () => {
       });
 
       expect(chatService.fetchPresetTaskResult).toHaveBeenCalled();
+      expect(chatService.fetchPresetTaskResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({ model: 'gpt-4o-mini', provider: 'openai' }),
+        }),
+      );
       expect(generationTopicService.updateTopic).toHaveBeenCalledWith(topicId, {
         title: generatedTitle,
       });

--- a/src/store/image/slices/generationTopic/action.ts
+++ b/src/store/image/slices/generationTopic/action.ts
@@ -7,6 +7,7 @@ import { mutate, useClientDataSWR } from '@/libs/swr';
 import { type UpdateTopicValue } from '@/server/routers/lambda/generationTopic';
 import { chatService } from '@/services/chat';
 import { generationTopicService } from '@/services/generationTopic';
+import { resolveClientServiceModelConfig } from '@/services/serviceModelPolicy/client';
 import { type StoreSetter } from '@/store/types';
 import { useUserStore } from '@/store/user';
 import { systemAgentSelectors, userGeneralSettingsSelectors } from '@/store/user/selectors';
@@ -100,10 +101,15 @@ export class GenerationTopicActionImpl {
     const generationTopicAgentConfig = systemAgentSelectors.generationTopic(
       useUserStore.getState(),
     );
+    const resolvedGenerationTopicAgentConfig = resolveClientServiceModelConfig(
+      'generationTopic',
+      generationTopicAgentConfig,
+    );
+    const taskConfig = merge(generationTopicAgentConfig, resolvedGenerationTopicAgentConfig ?? {});
     // Auto generate topic title from prompt by AI
     await chatService.fetchPresetTaskResult({
       params: merge(
-        generationTopicAgentConfig,
+        taskConfig,
         chainSummaryGenerationTitle(
           prompts,
           'image',

--- a/src/store/video/slices/generationTopic/action.test.ts
+++ b/src/store/video/slices/generationTopic/action.test.ts
@@ -1,0 +1,96 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { chatService } from '@/services/chat';
+import { generationTopicService } from '@/services/generationTopic';
+import { useVideoStore } from '@/store/video';
+import { type ImageGenerationTopic } from '@/types/generation';
+
+const enabledChatModelList = [
+  {
+    children: [{ id: 'gpt-4o-mini' }],
+    id: 'openai',
+    name: 'OpenAI',
+    source: 'builtin',
+  },
+];
+
+vi.mock('@/store/aiInfra', () => ({
+  getAiInfraStoreState: vi.fn(() => ({ enabledChatModelList })),
+}));
+
+vi.mock('@/services/chat', () => ({
+  chatService: {
+    fetchPresetTaskResult: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/generationTopic', () => ({
+  generationTopicService: {
+    updateTopic: vi.fn(),
+  },
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: {
+    getState: vi.fn(() => ({})),
+  },
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  systemAgentSelectors: {
+    generationTopic: vi.fn(() => ({
+      customPrompt: 'preserve custom prompt',
+      model: 'gpt-5-thinking',
+      provider: 'openai',
+    })),
+  },
+  userGeneralSettingsSelectors: {
+    currentResponseLanguage: vi.fn(() => 'en-US'),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useVideoStore.setState({
+    activeGenerationTopicId: null,
+    generationTopics: [],
+    loadingGenerationTopicIds: [],
+  });
+});
+
+describe('video generation topic actions', () => {
+  describe('summaryGenerationTopicTitle', () => {
+    it('falls back to an allowed model for video generation topic title summaries', async () => {
+      const { result } = renderHook(() => useVideoStore());
+      const topicId = 'video-topic-1';
+
+      act(() => {
+        useVideoStore.setState({
+          generationTopics: [{ id: topicId, title: 'Original Title' }] as ImageGenerationTopic[],
+        });
+      });
+
+      vi.mocked(chatService.fetchPresetTaskResult).mockImplementation(async ({ onFinish }) => {
+        await onFinish?.('Fallback Video Title', { type: 'done' });
+      });
+
+      await act(async () => {
+        await result.current.summaryGenerationTopicTitle(topicId, ['cinematic city skyline']);
+      });
+
+      expect(chatService.fetchPresetTaskResult).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: expect.objectContaining({
+            customPrompt: 'preserve custom prompt',
+            model: 'gpt-4o-mini',
+            provider: 'openai',
+          }),
+        }),
+      );
+      expect(generationTopicService.updateTopic).toHaveBeenCalledWith(topicId, {
+        title: 'Fallback Video Title',
+      });
+    });
+  });
+});

--- a/src/store/video/slices/generationTopic/action.ts
+++ b/src/store/video/slices/generationTopic/action.ts
@@ -7,6 +7,7 @@ import { mutate, useClientDataSWR } from '@/libs/swr';
 import { type UpdateTopicValue } from '@/server/routers/lambda/generationTopic';
 import { chatService } from '@/services/chat';
 import { generationTopicService } from '@/services/generationTopic';
+import { resolveClientServiceModelConfig } from '@/services/serviceModelPolicy/client';
 import { type StoreSetter } from '@/store/types';
 import { useUserStore } from '@/store/user';
 import { systemAgentSelectors, userGeneralSettingsSelectors } from '@/store/user/selectors';
@@ -222,6 +223,11 @@ export class GenerationTopicActionImpl {
     const generationTopicAgentConfig = systemAgentSelectors.generationTopic(
       useUserStore.getState(),
     );
+    const resolvedGenerationTopicAgentConfig = resolveClientServiceModelConfig(
+      'generationTopic',
+      generationTopicAgentConfig,
+    );
+    const taskConfig = merge(generationTopicAgentConfig, resolvedGenerationTopicAgentConfig ?? {});
     await chatService.fetchPresetTaskResult({
       onError: async () => {
         const fallbackTitle = generateFallbackTitle();
@@ -243,7 +249,7 @@ export class GenerationTopicActionImpl {
         }
       },
       params: merge(
-        generationTopicAgentConfig,
+        taskConfig,
         chainSummaryGenerationTitle(
           prompts,
           'video',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Add the service-model policy plumbing while keeping the initial manual rule set intentionally narrow.

- Add a manual service-model policy layer and reusable resolver helpers.
- Support `ModelSelect` custom model lists and filters.
- Filter Service Model assignment candidates through the policy layer.
- Use embedding model options for `userMemoryEmbedding`.
- Apply runtime resolution for client and server system-agent tasks so stale unavailable selections can fall back to enabled models.
- Current confirmed policy rule: input completion excludes `gpt-5.4-pro` and `gpt-5.5-pro` only.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts src/features/ModelSelect/index.test.tsx src/features/ServiceModel/ModelAssignmentsForm.test.tsx src/services/serviceModelPolicy/client.test.ts src/features/Conversation/hooks/useChatFollowUp.test.ts src/store/chat/slices/topic/action.test.ts src/store/chat/slices/thread/action.test.ts src/store/chat/slices/translate/action.test.ts src/store/image/slices/generationTopic/action.test.ts src/store/chat/slices/aiChat/actions/memory.test.ts src/features/AgentSetting/store/action.test.ts src/store/video/slices/generationTopic/action.test.ts src/server/services/systemAgent/modelConfig.test.ts
bunx vitest run --silent='passed-only' --config packages/const/vitest.config.mts packages/const/src/settings/serviceModelPolicy.test.ts
bun run type-check
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

The broader task-specific suitability rules are intentionally not included yet; they should be added only after the exact policy is confirmed.
