### PR TITLE
🐛 fix(prompts): keep input_completion system prompt stable across invocations

### DIFF
--- a/packages/prompts/src/chains/inputCompletion.test.ts
+++ b/packages/prompts/src/chains/inputCompletion.test.ts
@@ -25,15 +25,33 @@ describe('chainInputCompletion', () => {
     expect(schema.schema.properties.completion.type).toBe('string');
   });
 
-  it('appends conversation context to the system prompt when provided', () => {
+  it('adds a separate user message for conversation context when provided', () => {
     const { messages } = chainInputCompletion('write ', '', [
       { content: 'previous response', role: 'assistant' },
       { content: 'previous question', role: 'user' },
     ]);
-    const sys = messages[0].content as string;
-    expect(sys).toContain('Current conversation context');
-    expect(sys).toContain('assistant: previous response');
-    expect(sys).toContain('user: previous question');
+    expect(messages).toHaveLength(3);
+    expect(messages[0].role).toBe('system');
+    expect(messages[1].role).toBe('user');
+    expect(messages[2].role).toBe('user');
+
+    const contextMsg = messages[1].content as string;
+    expect(contextMsg).toContain('Current conversation context');
+    expect(contextMsg).toContain('assistant: previous response');
+    expect(contextMsg).toContain('user: previous question');
+    expect(contextMsg).not.toContain('Before cursor');
+
+    const cursorMsg = messages[2].content as string;
+    expect(cursorMsg).toContain('Before cursor: "write "');
+  });
+
+  it('keeps the system prompt stable regardless of conversation context', () => {
+    const a = chainInputCompletion('hi', '');
+    const b = chainInputCompletion('hi', '', [
+      { content: 'previous response', role: 'assistant' },
+      { content: 'previous question', role: 'user' },
+    ]);
+    expect(a.messages[0].content).toBe(b.messages[0].content);
   });
 
   it('exports a version constant the call site can pin to metadata', () => {

--- a/packages/prompts/src/chains/inputCompletion.ts
+++ b/packages/prompts/src/chains/inputCompletion.ts
@@ -6,7 +6,7 @@ import type { OpenAIChatMessage } from '@lobechat/types';
  * groups runs by prompt iteration. The 6-char prompt hash on the row catches
  * forgotten bumps.
  */
-export const INPUT_COMPLETION_PROMPT_VERSION = 'v1.0';
+export const INPUT_COMPLETION_PROMPT_VERSION = 'v1.1';
 
 /**
  * Symbolic schema name — also recorded on the tracing row's `schemaName`
@@ -83,16 +83,23 @@ export const chainInputCompletion = (
   afterCursor: string,
   context?: OpenAIChatMessage[],
 ): InputCompletionChainResult => {
-  let contextBlock = '';
+  // Context is dynamic per conversation — keep it OUT of the system message so
+  // the system prompt (and thus the tracing `promptHash`) stays stable across
+  // invocations. Otherwise every keystroke in a longer conversation produces a
+  // distinct hash, defeating the per-prompt grouping.
+  const messages: OpenAIChatMessage[] = [{ content: SYSTEM_PROMPT, role: 'system' }];
+
   if (context?.length) {
-    contextBlock = `\n\nCurrent conversation context:\n${context.map((m) => `${m.role}: ${m.content}`).join('\n')}`;
+    messages.push({
+      content: `Current conversation context:\n${context.map((m) => `${m.role}: ${m.content}`).join('\n')}`,
+      role: 'user',
+    });
   }
 
-  return {
-    messages: [
-      { content: `${SYSTEM_PROMPT}${contextBlock}`, role: 'system' },
-      { content: `Before cursor: "${beforeCursor}"\nAfter cursor: "${afterCursor}"`, role: 'user' },
-    ],
-    schema: INPUT_COMPLETION_SCHEMA,
-  };
+  messages.push({
+    content: `Before cursor: "${beforeCursor}"\nAfter cursor: "${afterCursor}"`,
+    role: 'user',
+  });
+
+  return { messages, schema: INPUT_COMPLETION_SCHEMA };
 };

--- a/packages/prompts/src/chains/inputCompletion.ts
+++ b/packages/prompts/src/chains/inputCompletion.ts
@@ -87,19 +87,22 @@ export const chainInputCompletion = (
   // the system prompt (and thus the tracing `promptHash`) stays stable across
   // invocations. Otherwise every keystroke in a longer conversation produces a
   // distinct hash, defeating the per-prompt grouping.
-  const messages: OpenAIChatMessage[] = [{ content: SYSTEM_PROMPT, role: 'system' }];
+  const contextMessage: OpenAIChatMessage | null = context?.length
+    ? {
+        content: `Current conversation context:\n${context.map((m) => `${m.role}: ${m.content}`).join('\n')}`,
+        role: 'user',
+      }
+    : null;
 
-  if (context?.length) {
-    messages.push({
-      content: `Current conversation context:\n${context.map((m) => `${m.role}: ${m.content}`).join('\n')}`,
-      role: 'user',
-    });
-  }
-
-  messages.push({
-    content: `Before cursor: "${beforeCursor}"\nAfter cursor: "${afterCursor}"`,
-    role: 'user',
-  });
-
-  return { messages, schema: INPUT_COMPLETION_SCHEMA };
+  return {
+    messages: [
+      { content: SYSTEM_PROMPT, role: 'system' },
+      ...(contextMessage ? [contextMessage] : []),
+      {
+        content: `Before cursor: "${beforeCursor}"\nAfter cursor: "${afterCursor}"`,
+        role: 'user',
+      },
+    ],
+    schema: INPUT_COMPLETION_SCHEMA,
+  };
 };


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

The tracing `promptHash` for the `input_completion` chain was changing on nearly every invocation — observed 1000+ unique hashes in production tracing, which defeats per-prompt grouping.

**Root cause**: `chainInputCompletion` embedded the rolling conversation window (up to 25 messages, taken from the active topic) directly into the **system** message. The hash is computed over the system prompt + schema, so any change to the included context flipped the hash.

**Fix**: Keep the system prompt purely static (the autocomplete instructions). Move the conversation context into its own dedicated `user` message that precedes the cursor message. The model still sees the same information, but the static instructions are now isolated from the dynamic data, so the `promptHash` is stable across calls.

Also bumps `INPUT_COMPLETION_PROMPT_VERSION` from `v1.0` → `v1.1` so tracing can distinguish the two message layouts going forward.

**New message shape**:
- `system` — autocomplete instructions only (static)
- `user` (optional) — `Current conversation context:\n...` (only when context is non-empty)
- `user` — `Before cursor: "..."\nAfter cursor: "..."`

#### 🧪 How to Test

- [x] Tested locally (`packages/prompts` vitest)
- [x] Added/updated tests

Added a test asserting the system prompt is byte-identical regardless of whether context is passed, and updated the existing context-attachment test to assert against the new separate user message.

```bash
cd packages/prompts && bunx vitest run inputCompletion
```

After deploy, the `prompt_hash` column on tracing rows for `scenario=input_completion` should collapse to one (or two, during rollout) distinct values per `promptVersion`.

#### 📝 Additional Information

No runtime behaviour change other than the message layout — the call site (`src/features/ChatInput/InputEditor/index.tsx`) destructures `{ messages, schema }` from the chain and forwards them verbatim to `generateJSON`, so no caller-side changes are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)