### PR TITLE
🐛 fix: restore userId in gateway dispatch, gate local-system by executionTarget, add device switcher for regular agents

### DIFF
--- a/packages/device-gateway-client/src/http.ts
+++ b/packages/device-gateway-client/src/http.ts
@@ -85,8 +85,7 @@ export class GatewayHttpClient {
     topicId: string;
     userId: string;
   }): Promise<{ success: boolean; error?: string }> {
-    const { userId: _userId, ...body } = params;
-    const res = await this.post('/api/device/agent/run', body);
+    const res = await this.post('/api/device/agent/run', params);
     if (!res.ok) {
       const text = await res.text().catch(() => '');
       return { error: text || `HTTP ${res.status}`, success: false };

--- a/src/features/ChatInput/RuntimeConfig/index.tsx
+++ b/src/features/ChatInput/RuntimeConfig/index.tsx
@@ -19,6 +19,8 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
+import { useUserStore } from '@/store/user';
+import { labPreferSelectors } from '@/store/user/selectors';
 
 import ContextWindow from '../ActionBar/Token';
 import { useAgentId } from '../hooks/useAgentId';
@@ -27,6 +29,7 @@ import { useChatInputStore } from '../store';
 import ApprovalMode from './ApprovalMode';
 import CloudRepoSwitcher from './CloudRepoSwitcher';
 import GitStatus from './GitStatus';
+import HeteroDeviceSwitcher from './HeteroDeviceSwitcher';
 import ModeSelector from './ModeSelector';
 import { useRepoType } from './useRepoType';
 import WorkingDirectory from './WorkingDirectory';
@@ -117,6 +120,10 @@ const RuntimeConfig = memo(() => {
     agentId ? agentByIdSelectors.isAgentHeterogeneousById(agentId)(s) : false,
     agentByIdSelectors.getAgentEnableModeById(agentId)(s),
   ]);
+
+  const enableExecutionDeviceSwitcher = useUserStore(
+    labPreferSelectors.enableExecutionDeviceSwitcher,
+  );
 
   const topicWorkingDirectory = useChatStore(topicSelectors.currentTopicWorkingDirectory);
   const agentWorkingDirectory = useAgentStore((s) =>
@@ -285,6 +292,9 @@ const RuntimeConfig = memo(() => {
       {/* Left: Chat mode switcher + (agent-only) runtime env + working directory */}
       <Flexbox horizontal align={'center'} gap={4}>
         <ModeSelector />
+        {enableAgentMode && !isHeterogeneous && enableExecutionDeviceSwitcher && agentId && (
+          <HeteroDeviceSwitcher agentId={agentId} />
+        )}
         {enableAgentMode && (
           <>
             <Popover

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -1223,7 +1223,11 @@ export class AiAgentService {
       // bypassing the engine's enabledToolIds exclusion. Skipping the
       // assignment here closes that bypass at the source.
       //
-      // Resolution order ():
+      // Resolution order:
+      // 0. executionTarget === 'sandbox': always skip — sandbox and device are
+      //    mutually exclusive. Without this gate a single online device would
+      //    be auto-activated and local-system tool calls would silently route
+      //    to that device instead of being suppressed for the sandbox session.
       // 1. boundDeviceId (topic-bound > agent-bound): use if online; if offline,
       //    respect the explicit choice and stay unrouted — don't silently fall
       //    back to a different device, that would surprise the user.
@@ -1235,15 +1239,17 @@ export class AiAgentService {
       //    behind (the local-system system prompt's
       //    `{{workingDirectory}}` reached the LLM as a literal, wasting the
       //    first N steps groping for cwd).
-      activeDeviceId = !canUseDevice
-        ? undefined
-        : boundDeviceId
-          ? onlineDevices.some((device) => device.deviceId === boundDeviceId)
-            ? boundDeviceId
-            : undefined
-          : onlineDevices.length === 1
-            ? onlineDevices[0].deviceId
-            : undefined;
+      const regularAgentExecutionTarget = agentConfig.agencyConfig?.executionTarget;
+      activeDeviceId =
+        !canUseDevice || regularAgentExecutionTarget === 'sandbox'
+          ? undefined
+          : boundDeviceId
+            ? onlineDevices.some((device) => device.deviceId === boundDeviceId)
+              ? boundDeviceId
+              : undefined
+            : onlineDevices.length === 1
+              ? onlineDevices[0].deviceId
+              : undefined;
 
       const toolsEngine = createServerAgentToolsEngine(toolsContext, {
         additionalManifests: [...lobehubSkillManifests, ...klavisManifests],


### PR DESCRIPTION
## Summary

- **Fix `Missing userId` on desktop device dispatch**: `GatewayHttpClient.dispatchAgentRun` was destructuring `userId` out of params before POSTing to `/api/device/agent/run`, but the gateway router checks `body.userId` to route to the correct Durable Object. Removed the destructuring so `userId` is included in the request body.

- **Gate `activeDeviceId` by `executionTarget`**: When a regular agent has `executionTarget='sandbox'`, `activeDeviceId` was still being resolved (auto-selected from online devices), which caused local-system tools to be injected and routed to the device gateway even in sandbox mode. Added an early-exit guard: if `executionTarget === 'sandbox'`, `activeDeviceId` remains `undefined`.

- **Add device switcher UI for regular agents**: `HeteroDeviceSwitcher` was only rendered inside `WorkingDirectoryBar` (hetero agents only). Added it to `RuntimeConfig` for regular agents, gated by the existing `enableExecutionDeviceSwitcher` lab flag and `!isHeterogeneous`, so users can pick a desktop device for local-system tool execution.

## Test plan

- [ ] Claude Code (hetero agent) with desktop device selected → no more `Missing userId` error
- [ ] Regular agent with `executionTarget=sandbox` → local-system tools are NOT injected (no device routing)
- [ ] Regular agent with a desktop device selected (lab flag on) → `HeteroDeviceSwitcher` visible in RuntimeConfig bar; local-system tools route to selected device via gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)