### PR TITLE
🐛 fix(auth): prompt account selection for Google OAuth

### DIFF
--- a/src/libs/better-auth/sso/providers/google.test.ts
+++ b/src/libs/better-auth/sso/providers/google.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/envs/auth', () => ({
+  authEnv: {
+    AUTH_GOOGLE_ID: 'google-client-id',
+    AUTH_GOOGLE_SECRET: 'google-client-secret',
+  },
+}));
+
+describe('Google SSO provider', () => {
+  it('should prompt account selection during OAuth sign in', async () => {
+    const { default: provider } = await import('./google');
+
+    const env = provider.checkEnvs();
+
+    expect(env).toEqual({
+      AUTH_GOOGLE_ID: 'google-client-id',
+      AUTH_GOOGLE_SECRET: 'google-client-secret',
+    });
+    expect(env && provider.build(env)).toEqual(
+      expect.objectContaining({
+        prompt: 'select_account',
+      }),
+    );
+  });
+});

--- a/src/libs/better-auth/sso/providers/google.ts
+++ b/src/libs/better-auth/sso/providers/google.ts
@@ -13,6 +13,7 @@ const provider: BuiltinProviderDefinition<
     return {
       clientId: env.AUTH_GOOGLE_ID,
       clientSecret: env.AUTH_GOOGLE_SECRET,
+      prompt: 'select_account',
     };
   },
   checkEnvs: () => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Pass `prompt: 'select_account'` to the Google OAuth provider so users are always shown the Google account chooser when signing in, instead of being silently logged in with the last-used Google session.

This matches the typical SSO UX expectation and lets users switch between multiple Google accounts without first having to sign out from Google.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Run `bunx vitest run 'src/libs/better-auth/sso/providers/google.test.ts'`.

Manual: trigger Google sign-in twice in a row — the Google account picker should appear on both attempts.

#### 📸 Screenshots / Videos

N/A — auth flow only.

#### 📝 Additional Information

No breaking changes.