### PR TITLE
🐛 fix(hetero-agent): skip LOADING_FLAT placeholder when restoring accumulatedContent

### DIFF
--- a/src/server/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/src/server/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -1,4 +1,5 @@
 import type { AgentStreamEvent } from '@lobechat/agent-gateway-client';
+import { LOADING_FLAT } from '@lobechat/const';
 import {
   AgentRuntimeErrorType,
   type ChatMessageError,
@@ -546,7 +547,10 @@ export class HeterogeneousPersistenceHandler {
     //     persisted tool messages, and overwrites assistant.tools[] with only the
     //     current batch's tools (losing all previous ones).
     const currentMsg = await this.deps.messageModel.findById(currentAssistantMessageId);
-    const restoredContent = (currentMsg?.content ?? '') as string;
+    // Skip LOADING_FLAT placeholder — it is the initial DB value before any
+    // content arrives and must not be treated as real accumulated text.
+    const rawContent = (currentMsg?.content ?? '') as string;
+    const restoredContent = rawContent === LOADING_FLAT ? '' : rawContent;
     const restoredReasoning = (currentMsg?.reasoning as { content?: string } | null)?.content ?? '';
     const restoredMetadata = ((currentMsg?.metadata as Record<string, any> | null) ?? {}) as Record<
       string,

--- a/src/server/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/src/server/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -284,7 +284,8 @@ export class HeterogeneousPersistenceHandler {
     // already read the message in `loadOrCreateState` — the second read is
     // redundant but harmless and keeps the logic uniform).
     const refreshed = await this.deps.messageModel.findById(state.currentAssistantMessageId);
-    const dbContent = (refreshed?.content ?? '') as string;
+    const rawDbContent = (refreshed?.content ?? '') as string;
+    const dbContent = rawDbContent === LOADING_FLAT ? '' : rawDbContent;
     const dbReasoning = (refreshed?.reasoning as { content?: string } | null)?.content ?? '';
     const dbMetadata = ((refreshed?.metadata as Record<string, any> | null) ?? {}) as Record<
       string,


### PR DESCRIPTION
## Summary

- Cloud/IM Claude Code responses were always prefixed with `...` on the **first turn** of a conversation
- Root cause: `HeterogeneousPersistenceHandler.loadOrCreateState()` reads the pre-created assistant message from DB on cold-start. That message has `content: LOADING_FLAT` (`'...'`) as a placeholder. The handler was treating this placeholder as real accumulated text, so all subsequent Claude Code text chunks were **appended** to `'...'`
- Subsequent turns were unaffected because `handleStepStart` (triggered by `--resume`'s `newStep: true`) always creates a fresh message with `content: ''` and resets `accumulatedContent = ''` before any text arrives
- Desktop local runs were unaffected because they run in-process and never cold-load from DB

## Fix

Guard the DB restoration with a `LOADING_FLAT` check — if the stored content equals the placeholder, treat it as empty:

```typescript
const rawContent = (currentMsg?.content ?? '') as string;
const restoredContent = rawContent === LOADING_FLAT ? '' : rawContent;
```

## Test plan

- [ ] Cloud Claude Code first-turn response no longer starts with `...`
- [ ] Resumed (subsequent turn) responses unaffected
- [ ] Desktop local Claude Code unaffected
- [ ] Type check passes: `bun run type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)