### PR TITLE
🐛 fix(create-platform-agent): wrap long version string in capability status

### DIFF
--- a/src/features/CreatePlatformAgent/index.tsx
+++ b/src/features/CreatePlatformAgent/index.tsx
@@ -283,9 +283,17 @@ const CreatePlatformAgentModal = memo<CreatePlatformAgentModalProps>(
       if (!capabilityResult) return null;
       if (capabilityResult.available) {
         return (
-          <Flexbox horizontal align="center" gap={4}>
-            <Icon color="var(--ant-color-success)" icon={CheckCircle2} size={14} />
-            <Tag color="success" style={{ marginInlineEnd: 0 }}>
+          <Flexbox horizontal align="flex-start" gap={4} style={{ flexWrap: 'wrap' }}>
+            <Icon
+              color="var(--ant-color-success)"
+              icon={CheckCircle2}
+              size={14}
+              style={{ marginTop: 2, flexShrink: 0 }}
+            />
+            <Tag
+              color="success"
+              style={{ marginInlineEnd: 0, whiteSpace: 'normal', wordBreak: 'break-word' }}
+            >
               {capabilityResult.version ?? t('platformAgent.create.available')}
             </Tag>
           </Flexbox>


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

When the capability check returns a long version string (e.g. `Hermes Agent v0.14.0 (2026.5.16) Project: /Users/... Python: 3.11.14 OpenAI SDK: 2.24.0 Up to date`), the `Tag` overflows the modal width on a single line.

Fix: allow the version tag to wrap by setting `whiteSpace: 'normal'` and `wordBreak: 'break-word'` on the `Tag`, and adding `flexWrap: 'wrap'` + `align-items: flex-start` on the wrapping `Flexbox`.

#### 🧪 How to Test

1. Open the "添加平台 Agent" modal
2. Select a device and wait for the capability check to return a long version string
3. Verify the text wraps instead of overflowing

- [x] Tested locally

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Long version string overflows modal on one line | Version string wraps within the modal |