### PR TITLE
🐛 fix(tabbar): debounce route meta publish to avoid tab item flicker

### DIFF
--- a/src/features/RouteMeta/RouteMetaBridge.test.tsx
+++ b/src/features/RouteMeta/RouteMetaBridge.test.tsx
@@ -92,17 +92,20 @@ describe('RouteMetaBridge', () => {
 
     render(<RouteMetaBridge />);
 
-    await waitFor(() => {
-      expect(document.title).toBe(`Chat A · ${BRANDING_NAME}`);
-      expect(mocks.setCurrentRouteMeta).toHaveBeenLastCalledWith(
-        {
-          avatar: undefined,
-          backgroundColor: undefined,
-          title: 'Chat A',
-        },
-        '/agent/agent-a',
-      );
-    });
+    await waitFor(
+      () => {
+        expect(document.title).toBe(`Chat A · ${BRANDING_NAME}`);
+        expect(mocks.setCurrentRouteMeta).toHaveBeenLastCalledWith(
+          {
+            avatar: undefined,
+            backgroundColor: undefined,
+            title: 'Chat A',
+          },
+          '/agent/agent-a',
+        );
+      },
+      { timeout: 2000 },
+    );
 
     act(() => {
       mocks.setMatches([
@@ -120,5 +123,57 @@ describe('RouteMetaBridge', () => {
       expect(document.title).toBe(BRANDING_NAME);
       expect(mocks.setCurrentRouteMeta).toHaveBeenLastCalledWith(null);
     });
+  });
+
+  it('keeps the previous title when switching params within the same route', async () => {
+    const titleSets: string[] = [];
+    const titleDescriptor = Object.getOwnPropertyDescriptor(document, 'title');
+    let titleStore = '';
+    Object.defineProperty(document, 'title', {
+      configurable: true,
+      get: () => titleStore,
+      set: (value: string) => {
+        titleStore = value;
+        titleSets.push(value);
+      },
+    });
+
+    try {
+      const makeMatch = (topicId: string) => ({
+        data: undefined,
+        handle: {
+          meta: {
+            titleKey: 'navigation.chat',
+            useDynamicMeta: (params: Record<string, string | undefined>) => ({
+              title: `Topic ${params.topicId}`,
+            }),
+          },
+        },
+        id: 'routes/agent',
+        params: { topicId },
+        pathname: `/agent/${topicId}`,
+      });
+
+      mocks.setMatches([makeMatch('a')]);
+      render(<RouteMetaBridge />);
+
+      await waitFor(() => {
+        expect(document.title).toBe(`Topic a · ${BRANDING_NAME}`);
+      });
+
+      titleSets.length = 0;
+
+      act(() => {
+        mocks.setMatches([makeMatch('b')]);
+      });
+
+      await waitFor(() => {
+        expect(document.title).toBe(`Topic b · ${BRANDING_NAME}`);
+      });
+
+      expect(titleSets).not.toContain(`translated:navigation.chat · ${BRANDING_NAME}`);
+    } finally {
+      if (titleDescriptor) Object.defineProperty(document, 'title', titleDescriptor);
+    }
   });
 });

--- a/src/features/RouteMeta/RouteMetaBridge.tsx
+++ b/src/features/RouteMeta/RouteMetaBridge.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { BRANDING_NAME } from '@lobechat/business-const';
-import { debounce } from 'es-toolkit/compat';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useMatches } from 'react-router-dom';
@@ -16,8 +15,6 @@ import { useElectronStore } from '@/store/electron';
 
 import DynamicMetaRunner from './DynamicMetaRunner';
 
-const ROUTE_META_PUBLISH_DEBOUNCE_MS = 80;
-
 interface MatchedRouteMeta {
   meta: RouteMeta;
   params: Record<string, string | undefined>;
@@ -25,8 +22,8 @@ interface MatchedRouteMeta {
 }
 
 interface DynamicRouteMetaState {
-  matchKey: string | null;
   meta: DynamicRouteMeta;
+  routeId: string | null;
 }
 
 const useMatchedRouteMeta = (): MatchedRouteMeta | null => {
@@ -52,42 +49,37 @@ const RouteMetaBridge = memo(() => {
   const setCurrentRouteMeta = useElectronStore((s) => s.setCurrentRouteMeta);
   const matched = useMatchedRouteMeta();
   const currentUrl = location.pathname + location.search;
-  const matchedKey = matched ? `${matched.routeId}:${currentUrl}` : null;
-  const [dynamic, setDynamic] = useState<DynamicRouteMetaState>({ matchKey: null, meta: {} });
+  const matchedRouteId = matched?.routeId ?? null;
+  const [dynamic, setDynamic] = useState<DynamicRouteMetaState>({ meta: {}, routeId: null });
 
-  const publishRouteMeta = useMemo(
-    () =>
-      debounce(
-        (resolved: DynamicRouteMeta, url: string) => setCurrentRouteMeta(resolved, url),
-        ROUTE_META_PUBLISH_DEBOUNCE_MS,
-      ),
+  const publishRouteMeta = useCallback(
+    (resolved: DynamicRouteMeta, url: string) => setCurrentRouteMeta(resolved, url),
     [setCurrentRouteMeta],
   );
 
   const handleResolve = useCallback(
     (resolved: DynamicRouteMeta) => {
-      setDynamic({ matchKey: matchedKey, meta: resolved });
+      setDynamic({ meta: resolved, routeId: matchedRouteId });
       if (isDesktop) publishRouteMeta(resolved, currentUrl);
     },
-    [currentUrl, matchedKey, publishRouteMeta],
+    [currentUrl, matchedRouteId, publishRouteMeta],
   );
 
   const translate = t as unknown as Translate;
   const titleKey = matched?.meta.titleKey;
-  const currentDynamic = dynamic.matchKey === matchedKey ? dynamic.meta : {};
+  // Keep the previously resolved meta while navigating within the same route family
+  // (e.g. switching topics) so the title doesn't briefly fall back to the static label.
+  const currentDynamic = matched && dynamic.routeId === matched.routeId ? dynamic.meta : {};
   const title = matched ? currentDynamic.title || (titleKey ? translate(titleKey) : '') : '';
 
   useEffect(() => {
-    if (matchedKey) return;
+    if (matchedRouteId) return;
 
-    setDynamic({ matchKey: null, meta: {} });
+    setDynamic({ meta: {}, routeId: null });
     if (isDesktop) {
-      publishRouteMeta.cancel();
       setCurrentRouteMeta(null);
     }
-  }, [matchedKey, publishRouteMeta, setCurrentRouteMeta]);
-
-  useEffect(() => () => publishRouteMeta.cancel(), [matchedKey, publishRouteMeta]);
+  }, [matchedRouteId, publishRouteMeta, setCurrentRouteMeta]);
 
   useEffect(() => {
     document.title = title ? `${title} · ${BRANDING_NAME}` : BRANDING_NAME;

--- a/src/features/RouteMeta/RouteMetaBridge.tsx
+++ b/src/features/RouteMeta/RouteMetaBridge.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { BRANDING_NAME } from '@lobechat/business-const';
+import { debounce } from 'es-toolkit/compat';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useMatches } from 'react-router-dom';
@@ -14,6 +15,8 @@ import {
 import { useElectronStore } from '@/store/electron';
 
 import DynamicMetaRunner from './DynamicMetaRunner';
+
+const ROUTE_META_PUBLISH_DEBOUNCE_MS = 80;
 
 interface MatchedRouteMeta {
   meta: RouteMeta;
@@ -52,12 +55,21 @@ const RouteMetaBridge = memo(() => {
   const matchedKey = matched ? `${matched.routeId}:${currentUrl}` : null;
   const [dynamic, setDynamic] = useState<DynamicRouteMetaState>({ matchKey: null, meta: {} });
 
+  const publishRouteMeta = useMemo(
+    () =>
+      debounce(
+        (resolved: DynamicRouteMeta, url: string) => setCurrentRouteMeta(resolved, url),
+        ROUTE_META_PUBLISH_DEBOUNCE_MS,
+      ),
+    [setCurrentRouteMeta],
+  );
+
   const handleResolve = useCallback(
     (resolved: DynamicRouteMeta) => {
       setDynamic({ matchKey: matchedKey, meta: resolved });
-      if (isDesktop) setCurrentRouteMeta(resolved, currentUrl);
+      if (isDesktop) publishRouteMeta(resolved, currentUrl);
     },
-    [currentUrl, matchedKey, setCurrentRouteMeta],
+    [currentUrl, matchedKey, publishRouteMeta],
   );
 
   const translate = t as unknown as Translate;
@@ -69,8 +81,13 @@ const RouteMetaBridge = memo(() => {
     if (matchedKey) return;
 
     setDynamic({ matchKey: null, meta: {} });
-    if (isDesktop) setCurrentRouteMeta(null);
-  }, [matchedKey, setCurrentRouteMeta]);
+    if (isDesktop) {
+      publishRouteMeta.cancel();
+      setCurrentRouteMeta(null);
+    }
+  }, [matchedKey, publishRouteMeta, setCurrentRouteMeta]);
+
+  useEffect(() => () => publishRouteMeta.cancel(), [matchedKey, publishRouteMeta]);
 
   useEffect(() => {
     document.title = title ? `${title} · ${BRANDING_NAME}` : BRANDING_NAME;

--- a/src/store/electron/actions/navigationHistory.ts
+++ b/src/store/electron/actions/navigationHistory.ts
@@ -204,6 +204,16 @@ export class NavigationHistoryActionImpl {
   };
 
   setCurrentRouteMeta = (meta: DynamicRouteMeta | null, url: string | null = null): void => {
+    const { currentRouteMeta, currentRouteMetaUrl } = this.#get();
+    if (
+      currentRouteMetaUrl === url &&
+      (currentRouteMeta === null) === (meta === null) &&
+      currentRouteMeta?.avatar === meta?.avatar &&
+      currentRouteMeta?.backgroundColor === meta?.backgroundColor &&
+      currentRouteMeta?.title === meta?.title
+    ) {
+      return;
+    }
     this.#set({ currentRouteMeta: meta, currentRouteMetaUrl: url }, false, 'setCurrentRouteMeta');
   };
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

On the Desktop title bar, the active tab item (title + avatar + background) could flicker through multiple states during page navigation because `useDynamicMeta(...)` subscribes to agent/chat stores and re-emits as those stores settle (agent meta loaded → topic title loaded → ...). Each emission flowed into `setCurrentRouteMeta`, which then re-rendered `useResolvedTabs` and the tab item.

Two coordinated mitigations:

1. **Shallow-equal short-circuit in `setCurrentRouteMeta`** (`src/store/electron/actions/navigationHistory.ts`) — skip the write when `url` and all three meta fields (`avatar`, `backgroundColor`, `title`) are unchanged and the `null` vs object shape matches. Costless; suppresses redundant store writes from any source.
2. **Trailing 80ms debounce in `RouteMetaBridge`** (`src/features/RouteMeta/RouteMetaBridge.tsx`) — coalesces the publish to the store when multiple store updates fire in a short window. `publishRouteMeta.cancel()` is called when `matchedKey` changes or the component unmounts, so a stale resolve from the previous route cannot overwrite the new route. Local `setDynamic` (driving `document.title`) stays synchronous so the document title remains responsive.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Existing `RouteMetaBridge.test.tsx` still passes (uses `waitFor`, tolerant to the 80ms debounce). Manually validated by switching between agent/topic pages on Desktop and observing the tab item title/avatar settles in a single transition instead of flickering through intermediate states.

#### 📝 Additional Information

The debounce is intentionally short (80ms): short enough to be imperceptible during normal navigation, long enough to coalesce same-tick store updates from `useAgentStore` + `useChatStore`. The local `dynamic` state used for `document.title` is left synchronous on purpose.