### PR TITLE
🐛 fix(exec-agent): gate CREDS_LIST/KLAVIS substitution on manifestMap instead of enabledToolIds

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -13,9 +13,16 @@ import {
   UsageCounter,
 } from '@lobechat/agent-runtime';
 import { LobeActivatorIdentifier } from '@lobechat/builtin-tool-activator';
-import { CredsIdentifier, type CredSummary, generateCredsList } from '@lobechat/builtin-tool-creds';
+import {
+  CredsIdentifier,
+  type CredSummary,
+  generateCredsList,
+  generateKlavisServicesList,
+  type KlavisServiceSummary,
+} from '@lobechat/builtin-tool-creds';
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
 import { BRANDING_PROVIDER } from '@lobechat/business-const';
+import { KLAVIS_SERVER_TYPES } from '@lobechat/const';
 import {
   type AgentContextDocument,
   type BotPlatformContext,
@@ -636,8 +643,10 @@ export const createRuntimeExecutors = (
         );
 
         // {{CREDS_LIST}} — used by lobe-creds system role.
-        // Mirrors client-side: lambdaClient.market.creds.list.query()
-        const isCredsEnabled = resolved.enabledToolIds.includes(CredsIdentifier);
+        // Gate on manifestMap presence, NOT enabledToolIds: in execAgent mode lobe-creds is
+        // added to manifestMap (for activator discovery) but never into enabledToolIds, so
+        // checking enabledToolIds would always be false while the system role IS injected.
+        const isCredsEnabled = !!resolved.manifestMap[CredsIdentifier];
         let credsListStr = '';
         if (isCredsEnabled && ctx.userId) {
           try {
@@ -661,6 +670,44 @@ export const createRuntimeExecutors = (
           }
         }
 
+        // {{KLAVIS_SERVICES_LIST}} — used by lobe-creds system role (Klavis integrations section).
+        // Mirrors client-side: klavisStoreSelectors.getServers() filtered by connection status.
+        let klavisServicesListStr = '';
+        if (isCredsEnabled && ctx.serverDB && ctx.userId) {
+          try {
+            const { PluginModel } = await import('@/database/models/plugin');
+            const pluginModel = new PluginModel(ctx.serverDB, ctx.userId);
+            const allPlugins = await pluginModel.query();
+            const validKlavisIds = new Set(KLAVIS_SERVER_TYPES.map((t) => t.identifier));
+            const connectedIds = new Set(
+              allPlugins
+                .filter(
+                  (p) =>
+                    validKlavisIds.has(p.identifier) &&
+                    (p.customParams as any)?.klavis?.isAuthenticated === true,
+                )
+                .map((p) => p.identifier),
+            );
+            const connected: KlavisServiceSummary[] = KLAVIS_SERVER_TYPES.filter((t) =>
+              connectedIds.has(t.identifier),
+            ).map((t) => ({ identifier: t.identifier, name: t.label }));
+            const available: KlavisServiceSummary[] = KLAVIS_SERVER_TYPES.filter(
+              (t) => !connectedIds.has(t.identifier),
+            ).map((t) => ({ identifier: t.identifier, name: t.label }));
+            klavisServicesListStr = generateKlavisServicesList(connected, available);
+            log(
+              'Fetched Klavis services for {{KLAVIS_SERVICES_LIST}}: connected=%d, available=%d',
+              connected.length,
+              available.length,
+            );
+          } catch (error) {
+            log(
+              'Failed to fetch Klavis services for {{KLAVIS_SERVICES_LIST}} substitution: %O',
+              error,
+            );
+          }
+        }
+
         const contextEngineInput = {
           agentDocuments,
           additionalVariables: {
@@ -672,6 +719,7 @@ export const createRuntimeExecutors = (
             // Creds tool variables
             sandbox_enabled: sandboxEnabled,
             ...(isCredsEnabled && { CREDS_LIST: credsListStr }),
+            ...(isCredsEnabled && { KLAVIS_SERVICES_LIST: klavisServicesListStr }),
             // Memory tool variables
             memory_effort: memoryEffort,
           },

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -67,6 +67,7 @@ import {
 import { sanitizeToolCallArguments, serializePartsForStorage } from '@lobechat/utils';
 import debug from 'debug';
 
+import { klavisEnv } from '@/config/klavis';
 import { type MessageModel, MessageModel as MessageModelClass } from '@/database/models/message';
 import { TopicModel } from '@/database/models/topic';
 import { UserModel } from '@/database/models/user';
@@ -673,7 +674,7 @@ export const createRuntimeExecutors = (
         // {{KLAVIS_SERVICES_LIST}} — used by lobe-creds system role (Klavis integrations section).
         // Mirrors client-side: klavisStoreSelectors.getServers() filtered by connection status.
         let klavisServicesListStr = '';
-        if (isCredsEnabled && ctx.serverDB && ctx.userId) {
+        if (isCredsEnabled && ctx.serverDB && ctx.userId && !!klavisEnv.KLAVIS_API_KEY) {
           try {
             const { PluginModel } = await import('@/database/models/plugin');
             const pluginModel = new PluginModel(ctx.serverDB, ctx.userId);


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix https://github.com/lobehub/lobehub/issues/15210 


#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

#### 🔀 Description of Change

In `execAgent` (background QStash-triggered) mode, `lobe-creds` is added to `toolManifestMap` for activator discovery but is **never** added to `enabledToolIds`. This caused the previous check:

```typescript
const isCredsEnabled = resolved.enabledToolIds.includes(CredsIdentifier);
```

to always return `false` while `ToolSystemRoleProvider` was still injecting the lobe-creds system role (which contains `{{CREDS_LIST}}`) because it iterates `resolved.manifestMap`, not `enabledToolIds`.

Result: `{{CREDS_LIST}}` was never substituted in execAgent mode — the agent received the template literal instead of the actual credentials list.

**Fix**: gate on `resolved.manifestMap[CredsIdentifier]` (whether the system role will be injected) instead of `enabledToolIds` (whether the tool is callable). The same fix applies to `{{KLAVIS_SERVICES_LIST}}` which shares the same gate.

```typescript
// Before
const isCredsEnabled = resolved.enabledToolIds.includes(CredsIdentifier);

// After
const isCredsEnabled = !!resolved.manifestMap[CredsIdentifier];
```

#### 🧪 How to Test

Trigger an `execAgent` background task with an agent that has `lobe-creds` enabled. Inspect the LLM call via agent tracing — `{{CREDS_LIST}}` should now be replaced with the user's actual credentials list in the system prompt.