### PR TITLE
🐛 fix(electron-tab): update inactive tab title when topic is auto-named

### DIFF
--- a/src/features/Electron/titlebar/TabBar/TabCacheBridges.test.tsx
+++ b/src/features/Electron/titlebar/TabBar/TabCacheBridges.test.tsx
@@ -1,0 +1,112 @@
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { MessageSquare } from 'lucide-react';
+import { type RouteObject } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { type DynamicRouteMeta, type RouteMeta } from '@/spa/router/routeMeta';
+
+import TabCacheBridges from './TabCacheBridges';
+import { type TabItem } from './types';
+
+const mocks = vi.hoisted(() => {
+  const tabs: { current: { id: string; lastVisited: number; url: string }[] } = { current: [] };
+
+  return {
+    getTabs: () => tabs.current,
+    routes: { current: [] as RouteObject[] },
+    setRoutes: (next: RouteObject[]) => {
+      tabs.current = [];
+      mocks.routes.current = next;
+    },
+    setTabs: (next: { id: string; lastVisited: number; url: string }[]) => {
+      tabs.current = next;
+    },
+    updateTabCache: vi.fn<(id: string, cached: DynamicRouteMeta) => void>(),
+  };
+});
+
+vi.mock('@/spa/router/desktopRouter.config', () => ({
+  get desktopRoutes() {
+    return mocks.routes.current;
+  },
+}));
+
+interface ElectronState {
+  tabs: TabItem[];
+  updateTabCache: typeof mocks.updateTabCache;
+}
+
+vi.mock('@/store/electron', () => ({
+  useElectronStore: (selector: (state: ElectronState) => unknown) =>
+    selector({ tabs: mocks.getTabs(), updateTabCache: mocks.updateTabCache }),
+}));
+
+const dynamicSource: Record<string, DynamicRouteMeta> = {};
+const resolveTopicMeta = (params: Record<string, string | undefined>): DynamicRouteMeta => {
+  const key = params.topicId ?? '';
+  return dynamicSource[key] ?? {};
+};
+
+const agentMeta: RouteMeta = {
+  icon: MessageSquare,
+  titleKey: 'navigation.chat',
+  useDynamicMeta: resolveTopicMeta,
+};
+
+const staticMeta: RouteMeta = {
+  icon: MessageSquare,
+  titleKey: 'navigation.lobehub',
+};
+
+const buildRoutes = (): RouteObject[] => [
+  {
+    children: [
+      { handle: { meta: agentMeta }, path: 'agent/:aid/:topicId' },
+      { handle: { meta: staticMeta }, path: 'settings' },
+    ],
+    path: '/',
+  },
+];
+
+const tab = (url: string): TabItem => ({ id: url, lastVisited: 1, url });
+
+describe('TabCacheBridges', () => {
+  afterEach(() => {
+    cleanup();
+    mocks.updateTabCache.mockReset();
+    mocks.setTabs([]);
+    mocks.routes.current = [];
+    for (const key of Object.keys(dynamicSource)) delete dynamicSource[key];
+  });
+
+  it('pushes dynamic meta into each tab cache, including inactive tabs', async () => {
+    mocks.routes.current = buildRoutes();
+    mocks.setTabs([tab('/agent/a1/topic-A'), tab('/agent/a1/topic-B')]);
+    dynamicSource['topic-A'] = { title: 'Topic A' };
+    dynamicSource['topic-B'] = { title: 'Topic B' };
+
+    render(<TabCacheBridges />);
+
+    await waitFor(() => {
+      expect(mocks.updateTabCache).toHaveBeenCalledWith(
+        '/agent/a1/topic-A',
+        expect.objectContaining({ title: 'Topic A' }),
+      );
+      expect(mocks.updateTabCache).toHaveBeenCalledWith(
+        '/agent/a1/topic-B',
+        expect.objectContaining({ title: 'Topic B' }),
+      );
+    });
+  });
+
+  it('skips tabs whose route has no useDynamicMeta', async () => {
+    mocks.routes.current = buildRoutes();
+    mocks.setTabs([tab('/settings')]);
+
+    render(<TabCacheBridges />);
+
+    await waitFor(() => {
+      expect(mocks.updateTabCache).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/features/Electron/titlebar/TabBar/TabCacheBridges.tsx
+++ b/src/features/Electron/titlebar/TabBar/TabCacheBridges.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { memo, useCallback } from 'react';
+
+import DynamicMetaRunner from '@/features/RouteMeta/DynamicMetaRunner';
+import { desktopRoutes } from '@/spa/router/desktopRouter.config';
+import { type DynamicRouteMeta } from '@/spa/router/routeMeta';
+import { useElectronStore } from '@/store/electron';
+
+import { matchRouteMeta } from './resolveRouteMeta';
+import { type TabItem } from './types';
+
+interface TabCacheBridgeProps {
+  tab: TabItem;
+}
+
+const TabCacheBridge = memo<TabCacheBridgeProps>(({ tab }) => {
+  const updateTabCache = useElectronStore((s) => s.updateTabCache);
+  const matched = matchRouteMeta(desktopRoutes, tab.url);
+  const useDynamicMeta = matched.meta?.useDynamicMeta;
+
+  const handleResolve = useCallback(
+    (resolved: DynamicRouteMeta) => {
+      updateTabCache(tab.id, resolved);
+    },
+    [tab.id, updateTabCache],
+  );
+
+  if (!useDynamicMeta) return null;
+
+  return (
+    <DynamicMetaRunner
+      params={matched.params}
+      useDynamicMeta={useDynamicMeta}
+      onResolve={handleResolve}
+    />
+  );
+});
+
+TabCacheBridge.displayName = 'TabCacheBridge';
+
+const TabCacheBridges = memo(() => {
+  const tabs = useElectronStore((s) => s.tabs);
+
+  return (
+    <>
+      {tabs.map((tab) => (
+        <TabCacheBridge key={tab.id} tab={tab} />
+      ))}
+    </>
+  );
+});
+
+TabCacheBridges.displayName = 'TabCacheBridges';
+
+export default TabCacheBridges;

--- a/src/routes/(main)/_layout/index.tsx
+++ b/src/routes/(main)/_layout/index.tsx
@@ -18,6 +18,7 @@ import AuthRequiredModal from '@/features/Electron/AuthRequiredModal';
 import OverlayCaptureUploader from '@/features/Electron/ScreenCapture/OverlayCaptureUploader';
 import OverlayMessageDispatcher from '@/features/Electron/ScreenCapture/OverlayMessageDispatcher';
 import OverlaySnapshotPublisher from '@/features/Electron/ScreenCapture/OverlaySnapshotPublisher';
+import TabCacheBridges from '@/features/Electron/titlebar/TabBar/TabCacheBridges';
 import TitleBar from '@/features/Electron/titlebar/TitleBar';
 import HotkeyHelperPanel from '@/features/HotkeyHelperPanel';
 import NavPanel from '@/features/NavPanel';
@@ -53,6 +54,7 @@ const Layout: FC = () => {
   return (
     <HotkeysProvider initiallyActiveScopes={[HotkeyScopeEnum.Global]}>
       <RouteMetaBridge />
+      {isDesktop && <TabCacheBridges />}
       <Suspense fallback={null}>
         {isDesktop && <DesktopAutoOidcOnFirstOpen />}
         {isDesktop && <DesktopNavigationBridge />}


### PR DESCRIPTION
## Summary

In the desktop app, opening multiple tabs of the same assistant, the inactive tab's title stays at "Default Topic" even after that conversation is auto-named. Only the active tab's `useDynamicMeta` runs, so background tabs never see the new title.

This PR adds `TabCacheBridges`, mounted once in the main desktop layout, which renders a `DynamicMetaRunner` for **every** tab whose route declares `useDynamicMeta`. Each runner resolves the dynamic meta for its tab and pushes the result into `updateTabCache(tab.id, …)`. The existing guarded merge in `updateTabCache` already de-dupes no-op updates, so the runners are cheap when nothing changes.

Closes LOBE-9492

## Changes

- `src/features/Electron/titlebar/TabBar/TabCacheBridges.tsx` — per-tab dynamic-meta runner; skips tabs whose matched route has no `useDynamicMeta`.
- `src/routes/(main)/_layout/index.tsx` — mount `<TabCacheBridges />` when `isDesktop`.
- `src/features/Electron/titlebar/TabBar/TabCacheBridges.test.tsx` — covers dynamic-meta tabs (including inactive ones) and a static-route tab that should not invoke the cache update.

## Test plan

- [x] `bunx vitest run src/features/Electron/titlebar/TabBar/` — 39 passed (5 files)
- [ ] Manual: open desktop app, create two tabs on the same assistant, send a message in tab A, switch to tab B before tab A finishes — confirm tab A's title updates to the auto-named topic.