### PR TITLE
💄 style(settings): unify select width and migrate to base-ui Select on service-model

### DIFF
--- a/src/features/ServiceModel/ModelAssignmentsForm.tsx
+++ b/src/features/ServiceModel/ModelAssignmentsForm.tsx
@@ -89,7 +89,7 @@ const ModelAssignmentsForm = memo(() => {
 
   const defaultAgentItem: FormItemProps = {
     children: (
-      <Flexbox align="center" direction="horizontal" gap={12} style={{ width: 'min(100%, 448px)' }}>
+      <Flexbox align="center" direction="horizontal" gap={12} style={{ width: 448 }}>
         <ModelSelect
           showAbility={false}
           style={{ minWidth: 0, width: '100%' }}
@@ -100,7 +100,6 @@ const ModelAssignmentsForm = memo(() => {
     ),
     desc: t('defaultAgent.model.desc'),
     label: t('defaultAgent.title'),
-    minWidth: undefined,
   };
 
   const systemModelItems: FormItemProps[] = SYSTEM_AGENT_MODEL_ITEMS.map(({ key }) => {
@@ -112,7 +111,7 @@ const ModelAssignmentsForm = memo(() => {
           align="center"
           direction="horizontal"
           gap={12}
-          style={{ width: 'min(100%, 448px)' }}
+          style={{ width: 448 }}
         >
           <ModelSelect
             showAbility={false}
@@ -124,7 +123,6 @@ const ModelAssignmentsForm = memo(() => {
       ),
       desc: t(`systemAgent.${key}.modelDesc`),
       label: t(`systemAgent.${key}.title`),
-      minWidth: undefined,
     } satisfies FormItemProps;
   });
 
@@ -133,7 +131,7 @@ const ModelAssignmentsForm = memo(() => {
 
     return {
       children: (
-        <Flexbox direction="vertical" gap={8} style={{ width: 'min(100%, 448px)' }}>
+        <Flexbox direction="vertical" gap={8} style={{ width: 448 }}>
           <ModelSelect
             showAbility={false}
             style={{ minWidth: 0, width: '100%' }}
@@ -157,7 +155,6 @@ const ModelAssignmentsForm = memo(() => {
       ),
       desc: t(`systemAgent.${key}.modelDesc`),
       label: t(`systemAgent.${key}.title`),
-      minWidth: undefined,
     } satisfies FormItemProps;
   });
 
@@ -167,26 +164,21 @@ const ModelAssignmentsForm = memo(() => {
 
     return {
       children: (
-        <Flexbox
-          align="center"
-          direction="horizontal"
-          gap={12}
-          style={{ width: 'min(100%, 448px)' }}
-        >
-          <ModelSelect
-            showAbility={false}
-            style={{ minWidth: 0, width: '100%' }}
-            value={value}
-            onChange={(props) => updateSystemAgentModel(key, props)}
-          />
-          <Flexbox align="center" direction="horizontal" gap={8}>
-            <Switch
-              aria-label={t(`systemAgent.${key}.title`)}
-              checked={value.enabled}
-              loading={loadingKey === key}
-              onChange={(enabled) => updateSystemAgentModel(key, { enabled })}
+        <Flexbox align="center" direction="horizontal" gap={12}>
+          <Flexbox style={{ width: 448 }}>
+            <ModelSelect
+              showAbility={false}
+              style={{ minWidth: 0, width: '100%' }}
+              value={value}
+              onChange={(props) => updateSystemAgentModel(key, props)}
             />
           </Flexbox>
+          <Switch
+            aria-label={t(`systemAgent.${key}.title`)}
+            checked={value.enabled}
+            loading={loadingKey === key}
+            onChange={(enabled) => updateSystemAgentModel(key, { enabled })}
+          />
         </Flexbox>
       ),
       desc: t(`systemAgent.${key}.modelDesc`),
@@ -199,7 +191,6 @@ const ModelAssignmentsForm = memo(() => {
           {t(`systemAgent.${key}.title`)}
         </span>
       ),
-      minWidth: undefined,
     } satisfies FormItemProps;
   });
 
@@ -241,6 +232,7 @@ const ModelAssignmentsForm = memo(() => {
       itemsType={'group'}
       variant={'filled'}
       {...FORM_STYLE}
+      itemMinWidth={undefined}
     />
   );
 });

--- a/src/features/ServiceModel/ModelAssignmentsForm.tsx
+++ b/src/features/ServiceModel/ModelAssignmentsForm.tsx
@@ -165,6 +165,12 @@ const ModelAssignmentsForm = memo(() => {
     return {
       children: (
         <Flexbox align="center" direction="horizontal" gap={12}>
+          <Switch
+            aria-label={t(`systemAgent.${key}.title`)}
+            checked={value.enabled}
+            loading={loadingKey === key}
+            onChange={(enabled) => updateSystemAgentModel(key, { enabled })}
+          />
           <Flexbox style={{ width: 448 }}>
             <ModelSelect
               showAbility={false}
@@ -173,12 +179,6 @@ const ModelAssignmentsForm = memo(() => {
               onChange={(props) => updateSystemAgentModel(key, props)}
             />
           </Flexbox>
-          <Switch
-            aria-label={t(`systemAgent.${key}.title`)}
-            checked={value.enabled}
-            loading={loadingKey === key}
-            onChange={(enabled) => updateSystemAgentModel(key, { enabled })}
-          />
         </Flexbox>
       ),
       desc: t(`systemAgent.${key}.modelDesc`),

--- a/src/routes/(main)/settings/tts/features/OpenAI.tsx
+++ b/src/routes/(main)/settings/tts/features/OpenAI.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { type FormGroupItemType } from '@lobehub/ui';
-import { Form, Icon, Select, Skeleton } from '@lobehub/ui';
+import { Form, Icon, Skeleton } from '@lobehub/ui';
+import { Select } from '@lobehub/ui/base-ui';
 import isEqual from 'fast-deep-equal';
 import { Loader2Icon } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -25,12 +26,16 @@ const OpenAI = memo(() => {
   const openai: FormGroupItemType = {
     children: [
       {
-        children: <Select options={opeanaiTTSOptions} />,
+        children: (
+          <Select options={opeanaiTTSOptions} style={{ width: 448 }} />
+        ),
         label: t('settingTTS.openai.ttsModel'),
         name: ['openAI', 'ttsModel'],
       },
       {
-        children: <Select options={opeanaiSTTOptions} />,
+        children: (
+          <Select options={opeanaiSTTOptions} style={{ width: 448 }} />
+        ),
         label: t('settingTTS.openai.sttModel'),
         name: ['openAI', 'sttModel'],
       },
@@ -55,6 +60,7 @@ const OpenAI = memo(() => {
         setLoading(false);
       }}
       {...FORM_STYLE}
+      itemMinWidth={undefined}
     />
   );
 });

--- a/src/routes/(main)/settings/tts/features/STT.tsx
+++ b/src/routes/(main)/settings/tts/features/STT.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { type FormGroupItemType } from '@lobehub/ui';
-import { Form, Icon, Select, Skeleton } from '@lobehub/ui';
+import { Form, Icon, Skeleton } from '@lobehub/ui';
+import { Select } from '@lobehub/ui/base-ui';
 import { Switch } from 'antd';
 import isEqual from 'fast-deep-equal';
 import { Loader2Icon } from 'lucide-react';
@@ -26,7 +27,7 @@ const STT = memo(() => {
   const stt: FormGroupItemType = {
     children: [
       {
-        children: <Select options={sttOptions} />,
+        children: <Select options={sttOptions} style={{ width: 448 }} />,
         desc: t('settingTTS.sttService.desc'),
         label: t('settingTTS.sttService.title'),
         name: 'sttServer',
@@ -36,7 +37,6 @@ const STT = memo(() => {
         desc: t('settingTTS.sttAutoStop.desc'),
         label: t('settingTTS.sttAutoStop.title'),
         layout: 'horizontal',
-        minWidth: undefined,
         name: 'sttAutoStop',
         valuePropName: 'checked',
       },
@@ -61,6 +61,7 @@ const STT = memo(() => {
         setLoading(false);
       }}
       {...FORM_STYLE}
+      itemMinWidth={undefined}
     />
   );
 });

--- a/src/routes/(main)/settings/tts/features/const.tsx
+++ b/src/routes/(main)/settings/tts/features/const.tsx
@@ -1,5 +1,5 @@
 import { OpenAI } from '@lobehub/icons';
-import { type SelectProps } from '@lobehub/ui';
+import { type SelectProps } from '@lobehub/ui/base-ui';
 
 import { LabelRenderer } from '@/components/ModelSelect';
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style
- [x] ♻️ refactor

#### 🔗 Related Issue

Part of LOBE-9637 (migration of antd-derived `Select` to `@lobehub/ui/base-ui`).

#### 🔀 Description of Change

Cleans up the `settings/service-model` page:

1. **Migrate to base-ui Select** — `Select` from `@lobehub/ui` is deprecated (internally still antd `Select`). Replaced with `@lobehub/ui/base-ui` `Select` in:
   - `src/routes/(main)/settings/tts/features/STT.tsx`
   - `src/routes/(main)/settings/tts/features/OpenAI.tsx`
   - `src/routes/(main)/settings/tts/features/const.tsx` (`SelectProps` type import)

2. **Unify select widths on `service-model` page** — all selects now render at a fixed `448px`. Root cause: each form item used `width: 'min(100%, 448px)'` where `100%` resolved against the form item control col, which was `max(34%, 240px)` from `FORM_STYLE`. The result was visually inconsistent widths across rows. Fix:
   - Set `itemMinWidth={undefined}` on the page's three forms so control col falls back to `fit-content`
   - Switch inner `Flexbox` / `Select` width from `'min(100%, 448px)'` to absolute `448`
   - Pull the `Switch` in optional-features rows out of the width-constrained inner Flexbox so the inner `ModelSelect` stays at 448px (Switch sits to its right and may overflow the inner wrap — by design, no need to align with other rows)

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Visit `settings/service-model` and confirm:
- All selects (Default Agent, System Agents, Memory Models, Optional Features, STT, OpenAI) render at the same 448px width
- Switch in Optional Features rows sits to the right of its select
- No layout regression in adjacent `tts` / `image` settings sections

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Mixed widths (~160-360px) per row, optional-feature selects compressed by Switch | All selects 448px, visually consistent |

#### 📝 Additional Information

- LOBE-9637 tracks the remaining 43 files still using antd-derived `Select`