### PR TITLE
🐛 fix(hetero-agent): hide sandbox selector when device switcher is visible and sync runtimeMode

### DIFF
--- a/src/features/ChatInput/RuntimeConfig/HeteroDeviceSwitcher.tsx
+++ b/src/features/ChatInput/RuntimeConfig/HeteroDeviceSwitcher.tsx
@@ -3,7 +3,7 @@
 import { SiApple, SiLinux } from '@icons-pack/react-simple-icons';
 import { isDesktop } from '@lobechat/const';
 import { isRemoteHeterogeneousType } from '@lobechat/heterogeneous-agents';
-import type { HeteroExecutionTarget } from '@lobechat/types';
+import type { HeteroExecutionTarget, RuntimeEnvMode } from '@lobechat/types';
 import { Microsoft } from '@lobehub/icons';
 import { Flexbox, Icon, Popover, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
@@ -227,6 +227,7 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
 
   const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));
   const updateAgentConfig = useAgentStore((s) => s.updateAgentConfig);
+  const updateAgentChatConfigById = useAgentStore((s) => s.updateAgentChatConfigById);
 
   const heteroType = agencyConfig?.heterogeneousProvider?.type;
   const storedTarget = agencyConfig?.executionTarget;
@@ -242,15 +243,27 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
   const handleSelect = useCallback(
     async (target: HeteroExecutionTarget, deviceId?: string) => {
       setOpen(false);
-      await updateAgentConfig({
-        agencyConfig: {
-          ...agencyConfig,
-          executionTarget: target,
-          ...(target === 'device' && deviceId ? { boundDeviceId: deviceId } : {}),
-        },
-      });
+
+      // Keep runtimeMode in sync so the server-side tool gate (runtimeMode === 'cloud'
+      // enables CloudSandbox) reflects the user's chosen execution target.
+      const platform = isDesktop ? 'desktop' : 'web';
+      const runtimeMode: RuntimeEnvMode =
+        target === 'sandbox' ? 'cloud' : target === 'local' ? 'local' : 'none';
+
+      await Promise.all([
+        updateAgentConfig({
+          agencyConfig: {
+            ...agencyConfig,
+            executionTarget: target,
+            ...(target === 'device' && deviceId ? { boundDeviceId: deviceId } : {}),
+          },
+        }),
+        updateAgentChatConfigById(agentId, {
+          runtimeEnv: { runtimeMode: { [platform]: runtimeMode } },
+        }),
+      ]);
     },
-    [agencyConfig, updateAgentConfig],
+    [agentId, agencyConfig, updateAgentConfig, updateAgentChatConfigById],
   );
 
   // Don't render for remote hetero agents — they use RemoteAgentConfigCard in profile.

--- a/src/features/ChatInput/RuntimeConfig/HeteroDeviceSwitcher.tsx
+++ b/src/features/ChatInput/RuntimeConfig/HeteroDeviceSwitcher.tsx
@@ -226,8 +226,7 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
   const [open, setOpen] = useState(false);
 
   const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));
-  const updateAgentConfig = useAgentStore((s) => s.updateAgentConfig);
-  const updateAgentChatConfigById = useAgentStore((s) => s.updateAgentChatConfigById);
+  const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
 
   const heteroType = agencyConfig?.heterogeneousProvider?.type;
   const storedTarget = agencyConfig?.executionTarget;
@@ -246,24 +245,22 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
 
       // Keep runtimeMode in sync so the server-side tool gate (runtimeMode === 'cloud'
       // enables CloudSandbox) reflects the user's chosen execution target.
+      // Use a single updateAgentConfigById to persist both fields atomically — parallel
+      // calls share the same abort signal name and the second would cancel the first.
       const platform = isDesktop ? 'desktop' : 'web';
       const runtimeMode: RuntimeEnvMode =
         target === 'sandbox' ? 'cloud' : target === 'local' ? 'local' : 'none';
 
-      await Promise.all([
-        updateAgentConfig({
-          agencyConfig: {
-            ...agencyConfig,
-            executionTarget: target,
-            ...(target === 'device' && deviceId ? { boundDeviceId: deviceId } : {}),
-          },
-        }),
-        updateAgentChatConfigById(agentId, {
-          runtimeEnv: { runtimeMode: { [platform]: runtimeMode } },
-        }),
-      ]);
+      await updateAgentConfigById(agentId, {
+        agencyConfig: {
+          ...agencyConfig,
+          executionTarget: target,
+          ...(target === 'device' && deviceId ? { boundDeviceId: deviceId } : {}),
+        },
+        chatConfig: { runtimeEnv: { runtimeMode: { [platform]: runtimeMode } } },
+      });
     },
-    [agentId, agencyConfig, updateAgentConfig, updateAgentChatConfigById],
+    [agentId, agencyConfig, updateAgentConfigById],
   );
 
   // Don't render for remote hetero agents — they use RemoteAgentConfigCard in profile.

--- a/src/features/ChatInput/RuntimeConfig/index.tsx
+++ b/src/features/ChatInput/RuntimeConfig/index.tsx
@@ -125,6 +125,11 @@ const RuntimeConfig = memo(() => {
     labPreferSelectors.enableExecutionDeviceSwitcher,
   );
 
+  // When the execution device switcher is visible, it takes over sandbox/runtime routing.
+  // Hide the runtimeMode selector to avoid two conflicting controls for the same decision.
+  const showDeviceSwitcher =
+    enableAgentMode && !isHeterogeneous && enableExecutionDeviceSwitcher && !!agentId;
+
   const topicWorkingDirectory = useChatStore(topicSelectors.currentTopicWorkingDirectory);
   const agentWorkingDirectory = useAgentStore((s) =>
     agentId ? agentByIdSelectors.getAgentWorkingDirectoryById(agentId)(s) : undefined,
@@ -292,27 +297,27 @@ const RuntimeConfig = memo(() => {
       {/* Left: Chat mode switcher + (agent-only) runtime env + working directory */}
       <Flexbox horizontal align={'center'} gap={4}>
         <ModeSelector />
-        {enableAgentMode && !isHeterogeneous && enableExecutionDeviceSwitcher && agentId && (
-          <HeteroDeviceSwitcher agentId={agentId} />
-        )}
+        {showDeviceSwitcher && <HeteroDeviceSwitcher agentId={agentId} />}
         {enableAgentMode && (
           <>
-            <Popover
-              content={modeContent}
-              open={modePopoverOpen}
-              placement="top"
-              styles={{ content: { padding: 4 } }}
-              trigger="click"
-              onOpenChange={setModePopoverOpen}
-            >
-              <div>
-                {modePopoverOpen ? (
-                  modeButton
-                ) : (
-                  <Tooltip title={t('runtimeEnv.selectMode')}>{modeButton}</Tooltip>
-                )}
-              </div>
-            </Popover>
+            {!showDeviceSwitcher && (
+              <Popover
+                content={modeContent}
+                open={modePopoverOpen}
+                placement="top"
+                styles={{ content: { padding: 4 } }}
+                trigger="click"
+                onOpenChange={setModePopoverOpen}
+              >
+                <div>
+                  {modePopoverOpen ? (
+                    modeButton
+                  ) : (
+                    <Tooltip title={t('runtimeEnv.selectMode')}>{modeButton}</Tooltip>
+                  )}
+                </div>
+              </Popover>
+            )}
             {rightContent()}
           </>
         )}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- N/A -->

#### 🔀 Description of Change

Two bugs in the heterogeneous agent toolbar where the execution device switcher and the sandbox `runtimeMode` selector were not mutually exclusive:

**Bug 1 — UI conflict**: When the lab feature `enableExecutionDeviceSwitcher` is on, both `HeteroDeviceSwitcher` and the `runtimeMode` popover ("云端沙箱 ∨") were rendered simultaneously, resulting in two overlapping controls for the same decision.

**Fix**: Extract `showDeviceSwitcher` flag from the existing condition. Wrap the `runtimeMode` Popover with `!showDeviceSwitcher` so it hides whenever the device switcher is visible. `rightContent()` (working directory picker) is intentionally kept outside this guard so it continues to render correctly when `runtimeMode` is synced to `'local'`.

**Bug 2 — Logic desync**: Selecting `local` or a remote `device` in `HeteroDeviceSwitcher` only updated `agencyConfig.executionTarget` but left `runtimeMode` unchanged. If `runtimeMode` was previously `'cloud'`, the server-side gate `[CloudSandboxManifest.identifier]: runtimeMode === 'cloud'` would still enable the cloud sandbox tool — even though the agent was routed to run locally or on a device.

**Fix**: In `handleSelect`, additionally call `updateAgentChatConfigById` to sync `runtimeMode` alongside `executionTarget`:
- `sandbox` → `cloud` (enables CloudSandbox tool)
- `local` → `local` (disables CloudSandbox, keeps local system tools)
- `device` → `none` (disables CloudSandbox; device manages its own tools)

#### 🧪 How to Test

1. Enable lab flag `enableExecutionDeviceSwitcher`
2. Open an agent in Agent mode — verify only the device switcher appears in the toolbar, the "云端沙箱" mode selector is hidden
3. Select **Cloud Sandbox** in the switcher → `runtimeMode` should become `cloud`; sandbox tool is active
4. Select **This Device** (desktop) → `runtimeMode` should become `local`; sandbox tool is inactive
5. Select a **connected device** → `runtimeMode` should become `none`; sandbox tool is inactive

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

`rightContent()` (working directory picker) depends on `runtimeMode === 'local'` and is preserved outside the `!showDeviceSwitcher` guard — it will still appear correctly when the user selects the local execution target.