### PR TITLE
🐛 fix(copy): unescape markdown escapes when copying user messages

### DIFF
--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/copy.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/copy.ts
@@ -8,6 +8,9 @@ import { cleanSpeakerTag } from '@/store/chat/utils/cleanSpeakerTag';
 
 import { defineAction } from '../defineAction';
 
+// mdast-util-to-markdown escapes markdown special chars (e.g. _ → \_) when serializing user input
+const unescapeMarkdown = (str: string) => str.replaceAll(/\\([\\`*_{}[\]()#+\-.!])/g, '$1');
+
 export const copyAction = defineAction({
   key: 'copy',
   useBuild: (ctx) => {
@@ -17,7 +20,7 @@ export const copyAction = defineAction({
     return useMemo(() => {
       const raw =
         ctx.role === 'group' ? (ctx.contentBlock?.content ?? ctx.data.content) : ctx.data.content;
-      const content = ctx.role === 'user' ? cleanSpeakerTag(raw) : raw;
+      const content = ctx.role === 'user' ? unescapeMarkdown(cleanSpeakerTag(raw)) : raw;
 
       return {
         handleClick: async () => {

--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/copy.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/copy.ts
@@ -5,11 +5,9 @@ import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { cleanSpeakerTag } from '@/store/chat/utils/cleanSpeakerTag';
+import { unescapeMarkdown } from '@/store/chat/utils/unescapeMarkdown';
 
 import { defineAction } from '../defineAction';
-
-// mdast-util-to-markdown escapes markdown special chars (e.g. _ → \_) when serializing user input
-const unescapeMarkdown = (str: string) => str.replaceAll(/\\([\\`*_{}[\]()#+\-.!])/g, '$1');
 
 export const copyAction = defineAction({
   key: 'copy',

--- a/src/store/chat/utils/unescapeMarkdown.test.ts
+++ b/src/store/chat/utils/unescapeMarkdown.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { unescapeMarkdown } from './unescapeMarkdown';
+
+describe('unescapeMarkdown', () => {
+  it('unescapes underscores in plain text', () => {
+    expect(unescapeMarkdown('CLAUDE\\_CODE\\_ATTRIBUTION\\_HEADER')).toBe(
+      'CLAUDE_CODE_ATTRIBUTION_HEADER',
+    );
+  });
+
+  it('unescapes other markdown special chars', () => {
+    expect(unescapeMarkdown('\\*bold\\*')).toBe('*bold*');
+    expect(unescapeMarkdown('\\[link\\]')).toBe('[link]');
+    expect(unescapeMarkdown('\\#heading')).toBe('#heading');
+  });
+
+  it('preserves backslashes inside inline code spans', () => {
+    expect(unescapeMarkdown('`FOO\\_BAR`')).toBe('`FOO\\_BAR`');
+  });
+
+  it('preserves backslashes inside fenced code blocks', () => {
+    const input = '```\nFOO\\_BAR\n```';
+    expect(unescapeMarkdown(input)).toBe(input);
+  });
+
+  it('unescapes outside code spans but not inside', () => {
+    expect(unescapeMarkdown('CLAUDE\\_CODE and `FOO\\_BAR`')).toBe('CLAUDE_CODE and `FOO\\_BAR`');
+  });
+
+  it('leaves plain text without escapes unchanged', () => {
+    expect(unescapeMarkdown('hello world')).toBe('hello world');
+  });
+
+  it('preserves actual markdown formatting markers', () => {
+    expect(unescapeMarkdown('**bold** and *italic*')).toBe('**bold** and *italic*');
+  });
+});

--- a/src/store/chat/utils/unescapeMarkdown.ts
+++ b/src/store/chat/utils/unescapeMarkdown.ts
@@ -1,0 +1,6 @@
+// Skip code spans and fenced code blocks — backslashes inside them are literals, not escapes.
+export const unescapeMarkdown = (str: string): string =>
+  str.replaceAll(
+    /(```[\s\S]*?```|`[^`\n]*`)|\\([\\`*_{}[\]()#+\-.!])/g,
+    (_, code, escaped) => code ?? escaped,
+  );


### PR DESCRIPTION
## 问题

用户消息通过 Lexical 编辑器发送时，内容会经过 `@lobehub/editor` → `mdast-util-to-markdown` 序列化为 markdown 字符串存入 `message.content`。该库会将 `_` 等 markdown 特殊字符转义为 `\_`，以防被解析为斜体语法。

UI 渲染时 markdown 渲染器会消费掉转义符，显示正常。但**复制按钮**直接读取 store 里的原始 `content` 字段写入剪贴板，导致粘贴时出现多余的 `\`。

例如用户输入：
```
"CLAUDE_CODE_ATTRIBUTION_HEADER": "0"
```
复制后粘贴得到：
```
"CLAUDE\_CODE\_ATTRIBUTION\_HEADER": "0"
```

手动选择文字复制正常，因为复制的是 DOM 渲染后的文本（转义符已被消费）。

## 修复

在复制用户消息前，用 regex 反转义 markdown 转义字符，还原用户原始输入。

只对 `user` role 的消息做处理，AI 回复内容是模型直接输出的 markdown，`\_` 可能是有意为之，不改动。

## Test plan

- [ ] 发送含下划线的消息（如 `CLAUDE_CODE_ATTRIBUTION_HEADER`），点击复制按钮，粘贴后确认无多余 `\`
- [ ] 手动选择同一消息文字复制，行为与按钮一致
- [ ] 发送含其他 markdown 特殊字符的消息（`*`, `[`, `]` 等），复制后确认无多余 `\`
- [ ] AI 回复含 `\_` 的消息，复制后确认内容不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)