### PR TITLE
✨ feat(onboarding): skip redirect when landing on agent/inbox with message param

### DIFF
--- a/src/layout/GlobalProvider/useUserStateRedirect.ts
+++ b/src/layout/GlobalProvider/useUserStateRedirect.ts
@@ -20,9 +20,14 @@ export const useDesktopUserStateRedirect = () => {
 
 export const useWebUserStateRedirect = () =>
   useCallback((state: UserInitializationState) => {
-    const { pathname } = window.location;
+    const { pathname, search } = window.location;
 
     if (!onboardingSelectors.needsOnboarding(state)) return;
+
+    // Skip onboarding when the user lands on /agent/inbox with a message param
+    // (e.g. "Try in LobeHub" links from Skills Marketplace). Sending the message
+    // is more important than walking through onboarding steps.
+    if (pathname.startsWith('/agent/inbox') && new URLSearchParams(search).has('message')) return;
 
     redirectIfNotOn(pathname, '/onboarding');
   }, []);

--- a/src/layout/GlobalProvider/useUserStateRedirect.ts
+++ b/src/layout/GlobalProvider/useUserStateRedirect.ts
@@ -24,10 +24,11 @@ export const useWebUserStateRedirect = () =>
 
     if (!onboardingSelectors.needsOnboarding(state)) return;
 
-    // Skip onboarding when the user lands on /agent/inbox with a message param
-    // (e.g. "Try in LobeHub" links from Skills Marketplace). Sending the message
-    // is more important than walking through onboarding steps.
-    if (pathname.startsWith('/agent/inbox') && new URLSearchParams(search).has('message')) return;
+    // Skip onboarding when the user lands on any agent page with a message param
+    // (e.g. "Try in LobeHub" links from Skills Marketplace). The /agent/inbox slug
+    // may be rewritten to /agent/{resolvedId} by AgentIdSync before this callback
+    // fires, so matching only /agent/inbox would miss the resolved-slug case.
+    if (pathname.startsWith('/agent/') && new URLSearchParams(search).has('message')) return;
 
     redirectIfNotOn(pathname, '/onboarding');
   }, []);


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

<!-- No Linear issue for this change -->

#### 🔀 Description of Change

Skills Marketplace "Try in LobeHub" links have the format:

```
/agent/inbox?message=<instruction>&skill=<skill-id>&utm_source=...
```

**Problem:** New users arriving via these links were being redirected to `/onboarding` before their message could be delivered, because `useWebUserStateRedirect` detects `needsOnboarding = true` for any new account and immediately navigates away — dropping the `message` param entirely.

**Fix:** In `useWebUserStateRedirect`, return early when the user is on any `/agent/*` path with a `message` search param.

**Why `/agent/*` and not just `/agent/inbox`:** `AgentIdSync` resolves the builtin `inbox` slug to a real agent ID and rewrites the URL to `/agent/{resolvedId}?message=...` via `navigate(..., { replace: true })`. Since `useInitBuiltinAgent` and `useInitUserState` run concurrently, the slug rewrite often completes before the user-state callback fires — so `pathname` is already `/agent/{uuid}` when the guard runs, and matching only `/agent/inbox` would silently miss it.

The `message` query param is the dedicated "send immediately" signal, so widening to `/agent/*` keeps the guard narrow enough.

#### 🧪 How to Test

1. Copy a Skills Marketplace link: `/agent/inbox?message=<any text>`
2. Open in incognito (not logged in) and complete sign-up
3. **Before:** redirected to `/onboarding`, message lost
4. **After:** lands in the agent conversation, message sent automatically

Scenarios covered:

| Scenario | Expected |
|----------|----------|
| Email/password signup, no email verification | ✓ lands on `/agent/inbox?message=...`, message sent |
| Email/password signup, with email verification | ✓ `callbackUrl` preserved through verify-email step |
| OAuth/SSO signup | ✓ `callbackURL` passed to OAuth provider, lands on target |
| AgentIdSync rewrites slug before callback fires | ✓ `/agent/{uuid}?message=...` also matched by new guard |
| Page refresh after message is consumed | ✓ `message` param removed by `MessageFromUrl`, normal onboarding resumes |
| Existing user (onboarding already done) | ✓ `needsOnboarding = false`, guard never reached |

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

No UI changes.

#### 📝 Additional Information

Onboarding state is not affected — `finishedAt` is only written when the user explicitly completes the onboarding flow. Skipping the redirect here just defers onboarding to the user's next session on a non-matching URL. There is no recurring check that would force them back mid-session.