### PR TITLE
🐛 fix(hetero-agent): hide device switcher in regular agent chat input

### DIFF
--- a/src/features/ChatInput/RuntimeConfig/index.tsx
+++ b/src/features/ChatInput/RuntimeConfig/index.tsx
@@ -19,8 +19,6 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
-import { useUserStore } from '@/store/user';
-import { labPreferSelectors } from '@/store/user/selectors';
 
 import ContextWindow from '../ActionBar/Token';
 import { useAgentId } from '../hooks/useAgentId';
@@ -29,7 +27,6 @@ import { useChatInputStore } from '../store';
 import ApprovalMode from './ApprovalMode';
 import CloudRepoSwitcher from './CloudRepoSwitcher';
 import GitStatus from './GitStatus';
-import HeteroDeviceSwitcher from './HeteroDeviceSwitcher';
 import ModeSelector from './ModeSelector';
 import { useRepoType } from './useRepoType';
 import WorkingDirectory from './WorkingDirectory';
@@ -120,15 +117,6 @@ const RuntimeConfig = memo(() => {
     agentId ? agentByIdSelectors.isAgentHeterogeneousById(agentId)(s) : false,
     agentByIdSelectors.getAgentEnableModeById(agentId)(s),
   ]);
-
-  const enableExecutionDeviceSwitcher = useUserStore(
-    labPreferSelectors.enableExecutionDeviceSwitcher,
-  );
-
-  // When the execution device switcher is visible, it takes over sandbox/runtime routing.
-  // Hide the runtimeMode selector to avoid two conflicting controls for the same decision.
-  const showDeviceSwitcher =
-    enableAgentMode && !isHeterogeneous && enableExecutionDeviceSwitcher && !!agentId;
 
   const topicWorkingDirectory = useChatStore(topicSelectors.currentTopicWorkingDirectory);
   const agentWorkingDirectory = useAgentStore((s) =>
@@ -297,27 +285,24 @@ const RuntimeConfig = memo(() => {
       {/* Left: Chat mode switcher + (agent-only) runtime env + working directory */}
       <Flexbox horizontal align={'center'} gap={4}>
         <ModeSelector />
-        {showDeviceSwitcher && <HeteroDeviceSwitcher agentId={agentId} />}
         {enableAgentMode && (
           <>
-            {!showDeviceSwitcher && (
-              <Popover
-                content={modeContent}
-                open={modePopoverOpen}
-                placement="top"
-                styles={{ content: { padding: 4 } }}
-                trigger="click"
-                onOpenChange={setModePopoverOpen}
-              >
-                <div>
-                  {modePopoverOpen ? (
-                    modeButton
-                  ) : (
-                    <Tooltip title={t('runtimeEnv.selectMode')}>{modeButton}</Tooltip>
-                  )}
-                </div>
-              </Popover>
-            )}
+            <Popover
+              content={modeContent}
+              open={modePopoverOpen}
+              placement="top"
+              styles={{ content: { padding: 4 } }}
+              trigger="click"
+              onOpenChange={setModePopoverOpen}
+            >
+              <div>
+                {modePopoverOpen ? (
+                  modeButton
+                ) : (
+                  <Tooltip title={t('runtimeEnv.selectMode')}>{modeButton}</Tooltip>
+                )}
+              </div>
+            </Popover>
             {rightContent()}
           </>
         )}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up to #15232 and #15252.

#### 🔀 Description of Change

The `HeteroDeviceSwitcher` is intended for heterogeneous agents only, and is already rendered inside `HeterogeneousChatInput/WorkingDirectoryBar`. Recently it was also wired into the shared `RuntimeConfig` (used by regular agents) behind the `enableExecutionDeviceSwitcher` lab preference, which caused it to leak into normal agent chat inputs.

This PR removes the switcher (and its `showDeviceSwitcher` gating) from `src/features/ChatInput/RuntimeConfig/index.tsx`, restoring the unconditional runtime-mode `Popover` for regular agents. Heterogeneous agents are unaffected — they continue to render `HeteroDeviceSwitcher` via their own input bar.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Open a regular (non-heterogeneous) agent chat with the execution device switcher lab pref enabled — confirm only the runtime mode selector shows, no device switcher.
2. Open a heterogeneous agent (Claude Code / Codex) — confirm the device switcher still renders in the working directory bar.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Device switcher rendered for regular agents | Device switcher only renders for heterogeneous agents |