### PR TITLE
♻️ refactor(modal): migrate confirm modals to @lobehub/ui/base-ui (Phase 1)

### DIFF
--- a/.agents/skills/react/SKILL.md
+++ b/.agents/skills/react/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react
-description: "LobeHub React component conventions — styling via `antd-style` `createStaticStyles` + `cssVar.*` (zero-runtime preferred over `createStyles` + `token`), `@lobehub/ui` over antd when both exist, routing via `react-router-dom` (not `next/link`). Use when writing or editing any `.tsx` under `src/**`. Triggers on `createStaticStyles`, `createStyles`, `cssVar`, `antd-style`, `Flexbox`, `Center`, `Select`, `Modal`, `Drawer`, `Button`, `Tooltip`, `DropdownMenu`, `Popover`, `Switch`, `ScrollArea`, `Link`, `useNavigate`, `react-router-dom`, `next/link`, `desktopRouter`, `componentMap.desktop`, `.desktop.tsx`, 'new component', 'new page', 'edit layout', 'add styles', 'zustand selector', '@lobehub/ui', 'antd import'."
+description: "LobeHub React component conventions — base-ui (`@lobehub/ui/base-ui`) first for headless primitives (Select, Modal, DropdownMenu, ContextMenu, Popover, ScrollArea, Switch, Toast, FloatingSheet), then `@lobehub/ui` root, antd as last resort; styling via `antd-style` `createStaticStyles` + `cssVar.*` (zero-runtime preferred over `createStyles` + `token`); routing via `react-router-dom` (not `next/link`). Use when writing or editing any `.tsx` under `src/**`. Triggers on `createStaticStyles`, `createStyles`, `cssVar`, `antd-style`, `Flexbox`, `Center`, `Select`, `Modal`, `Drawer`, `Button`, `Tooltip`, `DropdownMenu`, `ContextMenu`, `Popover`, `Switch`, `ScrollArea`, `Toast`, `FloatingSheet`, `Link`, `useNavigate`, `react-router-dom`, `next/link`, `desktopRouter`, `componentMap.desktop`, `.desktop.tsx`, `base-ui`, `@lobehub/ui/base-ui`, 'new component', 'new page', 'edit layout', 'add styles', 'zustand selector', '@lobehub/ui', 'antd import'."
 user-invocable: false
 ---
 
@@ -17,22 +17,41 @@ user-invocable: false
 ## Component Priority
 
 1. **`src/components`** — project-specific reusable components
-2. **`@lobehub/ui/base-ui`** — headless primitives (Select, Modal, DropdownMenu, Popover, Switch, ScrollArea…)
-3. **`@lobehub/ui`** — higher-level components (ActionIcon, Markdown, DragPage…)
-4. **Custom implementation** — last resort; never reach for antd directly
+2. **`@lobehub/ui/base-ui`** — headless primitives. **If the component lives here, use it. Do NOT import the same-named root export.**
+3. **`@lobehub/ui`** — higher-level / antd-wrapping components (only when no base-ui equivalent)
+4. **antd** — only when neither base-ui nor `@lobehub/ui` root provides it
+5. **Custom implementation** — true last resort
 
-If unsure about available components, search existing code or check `node_modules/@lobehub/ui/es/index.mjs`.
+If unsure about available components, search existing code or check `node_modules/@lobehub/ui/es/index.mjs` and `node_modules/@lobehub/ui/es/base-ui/`.
 
-### Common @lobehub/ui Components
+### `@lobehub/ui/base-ui` — always prefer for these
 
-| Category     | Components                                                                      |
-| ------------ | ------------------------------------------------------------------------------- |
-| General      | ActionIcon, ActionIconGroup, Block, Button, Icon                                |
-| Data Display | Avatar, Collapse, Empty, Highlighter, Markdown, Tag, Tooltip                    |
-| Data Entry   | CodeEditor, CopyButton, EditableText, Form, FormModal, Input, SearchBar, Select |
-| Feedback     | Alert, Drawer, Modal                                                            |
-| Layout       | Center, DraggablePanel, Flexbox, Grid, Header, MaskShadow                       |
-| Navigation   | Burger, Dropdown, Menu, SideNav, Tabs                                           |
+| Component                                  | Import                                                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `Select` (+ `SelectProps`, `SelectOption`) | `import { Select } from '@lobehub/ui/base-ui';`                                                         |
+| `Modal` (imperative API)                   | `import { createModal, confirmModal, useModalContext, type ModalInstance } from '@lobehub/ui/base-ui';` |
+| `DropdownMenu`                             | `import { DropdownMenu } from '@lobehub/ui/base-ui';`                                                   |
+| `ContextMenu`                              | `import { ContextMenu } from '@lobehub/ui/base-ui';`                                                    |
+| `Popover`                                  | `import { Popover } from '@lobehub/ui/base-ui';`                                                        |
+| `ScrollArea`                               | `import { ScrollArea } from '@lobehub/ui/base-ui';`                                                     |
+| `Switch`                                   | `import { Switch } from '@lobehub/ui/base-ui';`                                                         |
+| `Toast`                                    | `import { Toast } from '@lobehub/ui/base-ui';`                                                          |
+| `FloatingSheet`                            | `import { FloatingSheet } from '@lobehub/ui/base-ui';`                                                  |
+
+For Modal specifically, see the dedicated **modal** skill — use the imperative `createModal({ content: … })` pattern over the legacy `<Modal open … />` declarative pattern. base-ui has its own `ModalHost` already mounted in `SPAGlobalProvider`.
+
+> Common slip: `import { Select } from '@lobehub/ui'` looks fine but it's the antd-backed Select. Use base-ui Select. Same for `Modal`, `DropdownMenu`, etc.
+
+### `@lobehub/ui` root — use when base-ui has no equivalent
+
+| Category     | Components                                                                            |
+| ------------ | ------------------------------------------------------------------------------------- |
+| General      | ActionIcon, ActionIconGroup, Block, Button, Icon                                      |
+| Data Display | Avatar, Collapse, Empty, Highlighter, Markdown, Tag, Tooltip                          |
+| Data Entry   | CodeEditor, CopyButton, EditableText, Form, Input, InputPassword, SearchBar, TextArea |
+| Feedback     | Alert, Drawer                                                                         |
+| Layout       | Center, DraggablePanel, Flexbox, Grid, Header, MaskShadow                             |
+| Navigation   | Burger, Menu, SideNav, Tabs                                                           |
 
 ## Layout
 
@@ -85,12 +104,15 @@ errorElement: <ErrorBoundary />;
 
 ## Common Mistakes
 
-| Mistake                                                           | Fix                                                               |
-| ----------------------------------------------------------------- | ----------------------------------------------------------------- |
-| Using `next/link` in SPA                                          | Use `react-router-dom` `Link`                                     |
-| Using antd directly                                               | Use `@lobehub/ui/base-ui` first, then `@lobehub/ui`               |
-| `createStyles` for static styles                                  | Use `createStaticStyles` + `cssVar`                               |
-| Editing only `desktopRouter.config.tsx`                           | Must edit both `.tsx` and `.desktop.tsx`                          |
-| Using `margin` for flex spacing                                   | Use `gap` prop on Flexbox                                         |
-| Accessing zustand store without selector                          | Use selectors to access store data (see zustand skill)            |
-| Text or icon-text actions built with `Flexbox`/`Text` + `onClick` | Use `Button type={'text'} size={'small'}` with `icon` when needed |
+| Mistake                                                            | Fix                                                                         |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| Using `next/link` in SPA                                           | Use `react-router-dom` `Link`                                               |
+| Using antd directly                                                | Use `@lobehub/ui/base-ui` first, then `@lobehub/ui`                         |
+| `import { Select } from '@lobehub/ui'`                             | `import { Select } from '@lobehub/ui/base-ui'`                              |
+| `import { Modal } from '@lobehub/ui'` + `<Modal open>` declarative | `createModal` / `confirmModal` from `@lobehub/ui/base-ui` (see modal skill) |
+| `import { DropdownMenu/Popover/Switch } from '@lobehub/ui'`        | Import same name from `@lobehub/ui/base-ui` instead                         |
+| `createStyles` for static styles                                   | Use `createStaticStyles` + `cssVar`                                         |
+| Editing only `desktopRouter.config.tsx`                            | Must edit both `.tsx` and `.desktop.tsx`                                    |
+| Using `margin` for flex spacing                                    | Use `gap` prop on Flexbox                                                   |
+| Accessing zustand store without selector                           | Use selectors to access store data (see zustand skill)                      |
+| Text or icon-text actions built with `Flexbox`/`Text` + `onClick`  | Use `Button type={'text'} size={'small'}` with `icon` when needed           |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ Guidelines for using AI coding agents in this LobeHub repository.
 - Next.js 16 + React 19 + TypeScript
 - SPA inside Next.js with `react-router-dom`
 - `@lobehub/ui`, antd for components; antd-style for CSS-in-JS — **prefer `createStaticStyles` with `cssVar.*`** (zero-runtime); only fall back to `createStyles` + `token` when styles genuinely need runtime computation. See `.cursor/docs/createStaticStyles_migration_guide.md`.
+- **Component priority**: `@lobehub/ui/base-ui` (headless primitives) **first**, then `@lobehub/ui` root, then antd as last resort. When the component exists in base-ui, use it — never reach for the root or antd counterpart. Base-ui covers `Select`, `Modal` / `createModal` / `confirmModal`, `DropdownMenu`, `ContextMenu`, `Popover`, `ScrollArea`, `Switch`, `Toast`, `FloatingSheet`. Prefer `@lobehub/ui/base-ui` for new code and migrate root-package call sites opportunistically.
 - react-i18next for i18n; zustand for state management
 - SWR for data fetching; TRPC for type-safe backend
 - Drizzle ORM with PostgreSQL; Vitest for testing

--- a/e2e/src/steps/agent/conversation-mgmt.steps.ts
+++ b/e2e/src/steps/agent/conversation-mgmt.steps.ts
@@ -427,10 +427,10 @@ When('用户选择删除选项', async function (this: CustomWorld) {
 When('用户确认删除', async function (this: CustomWorld) {
   console.log('   📍 Step: 确认删除...');
 
-  // A confirmation modal should appear
-  const confirmButton = this.page.locator('.ant-modal-confirm-btns button.ant-btn-dangerous');
+  const confirmButton = this.page
+    .getByRole('dialog')
+    .getByRole('button', { name: /^(ok|delete|删除|确认|确定)$/i });
 
-  // Wait for modal to appear
   await expect(confirmButton).toBeVisible({ timeout: 5000 });
   await confirmButton.click();
 

--- a/e2e/src/steps/home/sidebarAgent.steps.ts
+++ b/e2e/src/steps/home/sidebarAgent.steps.ts
@@ -294,7 +294,9 @@ When('用户在菜单中选择删除', async function (this: CustomWorld) {
 When('用户在弹窗中确认删除', async function (this: CustomWorld) {
   console.log('   📍 Step: 确认删除...');
 
-  const confirmButton = this.page.locator('.ant-modal-confirm-btns button.ant-btn-dangerous');
+  const confirmButton = this.page
+    .getByRole('dialog')
+    .getByRole('button', { name: /^(ok|delete|删除|确认|确定)$/i });
   await expect(confirmButton).toBeVisible({ timeout: 5000 });
   await confirmButton.click();
   await this.page.waitForTimeout(500);

--- a/src/components/DotsLoading/index.tsx
+++ b/src/components/DotsLoading/index.tsx
@@ -1,36 +1,32 @@
-import { createStyles, keyframes } from 'antd-style';
+import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { type CSSProperties, memo } from 'react';
 
-const fade = keyframes`
-  0%, 100% {
-    opacity: 0.3;
-  }
-  50% {
-    opacity: 1;
-  }
-`;
-
-interface StyleParams {
-  color?: string;
-  gap: number;
-  size: number;
-}
-
-const useStyles = createStyles(({ css, token }, { size, gap, color }: StyleParams) => ({
+const styles = createStaticStyles(({ css }) => ({
   container: css`
     display: inline-flex;
     flex-direction: row;
-    gap: ${gap}px;
+    gap: var(--dots-loading-gap);
     align-items: center;
   `,
   dot: css`
-    width: ${size}px;
-    height: ${size}px;
+    width: var(--dots-loading-size);
+    height: var(--dots-loading-size);
     border-radius: 50%;
 
-    background-color: ${color || token.colorTextSecondary};
+    background-color: var(--dots-loading-color);
 
-    animation: ${fade} 1.2s ease-in-out infinite;
+    animation: dots-loading-fade 1.2s ease-in-out infinite;
+
+    @keyframes dots-loading-fade {
+      0%,
+      100% {
+        opacity: 0.3;
+      }
+
+      50% {
+        opacity: 1;
+      }
+    }
   `,
 }));
 
@@ -46,12 +42,17 @@ interface DotsLoadingProps extends StyleArgs {
 }
 
 const DotsLoading = memo<DotsLoadingProps>(({ size = 4, gap = 3, color, className, style }) => {
-  const { styles: s, cx } = useStyles({ color, gap, size });
+  const cssVars = {
+    '--dots-loading-color': color || cssVar.colorTextSecondary,
+    '--dots-loading-gap': `${gap}px`,
+    '--dots-loading-size': `${size}px`,
+  } as CSSProperties;
+
   return (
-    <div className={cx(s.container, className)} style={style}>
-      <div className={s.dot} style={{ animationDelay: '0s' }} />
-      <div className={s.dot} style={{ animationDelay: '0.15s' }} />
-      <div className={s.dot} style={{ animationDelay: '0.3s' }} />
+    <div className={cx(styles.container, className)} style={{ ...cssVars, ...style }}>
+      <div className={styles.dot} style={{ animationDelay: '0s' }} />
+      <div className={styles.dot} style={{ animationDelay: '0.15s' }} />
+      <div className={styles.dot} style={{ animationDelay: '0.3s' }} />
     </div>
   );
 });

--- a/src/components/InvalidAPIKey/__tests__/ComfyUIForm.test.tsx
+++ b/src/components/InvalidAPIKey/__tests__/ComfyUIForm.test.tsx
@@ -30,7 +30,6 @@ vi.mock('antd-style', async (importOriginal) => {
         cssVar: {},
       }),
     ),
-    createStyles: vi.fn(() => () => ({ styles: {} })),
     useTheme: () => ({
       colorTextSecondary: '#999',
     }),

--- a/src/features/AgentSetting/AgentDocuments/index.tsx
+++ b/src/features/AgentSetting/AgentDocuments/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { confirmModal } from '@lobehub/ui/base-ui';
 import type { TableColumnsType } from 'antd';
 import { App, Button, Popconfirm, Select, Space, Table, Tag, Typography } from 'antd';
 import { memo, useMemo, useState } from 'react';
@@ -28,7 +29,7 @@ const FILE_PREVIEW_LIMIT = 5;
 
 const AgentDocuments = memo(() => {
   const { t } = useTranslation(['setting', 'common']);
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
   const agentId = useAgentStore((s) => s.activeAgentId);
   const [templateId, setTemplateId] = useState(DEFAULT_TEMPLATE_ID);
   const [isInitializingTemplate, setIsInitializingTemplate] = useState(false);
@@ -160,7 +161,7 @@ const AgentDocuments = memo(() => {
     const previewFilenames = overwrittenFilenames.slice(0, FILE_PREVIEW_LIMIT);
     const remainingCount = overwrittenCount - previewFilenames.length;
 
-    modal.confirm({
+    confirmModal({
       content: (
         <Space direction={'vertical'} size={8}>
           <Typography.Text>

--- a/src/features/AgentSetting/AgentDocuments/index.tsx
+++ b/src/features/AgentSetting/AgentDocuments/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { confirmModal } from '@lobehub/ui/base-ui';
+import { confirmModal, Select } from '@lobehub/ui/base-ui';
 import type { TableColumnsType } from 'antd';
-import { App, Button, Popconfirm, Select, Space, Table, Tag, Typography } from 'antd';
+import { App, Button, Popconfirm, Space, Table, Tag, Typography } from 'antd';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/features/AgentTasks/AgentTaskDetail/CommentCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/CommentCard.tsx
@@ -12,7 +12,7 @@ import {
   Markdown,
   Text,
 } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { MessageCircle, MoreHorizontal, Pencil, Trash } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
@@ -29,7 +29,6 @@ interface CommentCardProps {
 
 const CommentCard = memo<CommentCardProps>(({ activity }) => {
   const { t } = useTranslation('chat');
-  const { modal } = App.useApp();
   const deleteComment = useTaskStore((s) => s.deleteComment);
   const updateComment = useTaskStore((s) => s.updateComment);
 
@@ -64,16 +63,14 @@ const CommentCard = memo<CommentCardProps>(({ activity }) => {
 
   const handleDelete = useCallback(() => {
     if (!commentId) return;
-    modal.confirm({
-      centered: true,
+    confirmModal({
       content: t('taskDetail.comment.deleteConfirm.content'),
       okButtonProps: { danger: true },
       okText: t('taskDetail.comment.deleteConfirm.ok'),
       onOk: () => deleteComment(commentId),
       title: t('taskDetail.comment.deleteConfirm.title'),
-      type: 'error',
     });
-  }, [commentId, deleteComment, modal, t]);
+  }, [commentId, deleteComment, t]);
 
   const menuItems = useMemo<DropdownItem[]>(
     () => [

--- a/src/features/AgentTasks/AgentTaskDetail/TaskArtifacts.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskArtifacts.tsx
@@ -9,7 +9,7 @@ import {
   Tag,
   Text,
 } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { FileTextIcon, MoreHorizontal, Package, Trash } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
@@ -30,7 +30,6 @@ const flattenWorkspace = (nodes: TaskDetailWorkspaceNode[]): TaskDetailWorkspace
 
 const ArtifactCard = memo<{ node: TaskDetailWorkspaceNode }>(({ node }) => {
   const { t } = useTranslation('chat');
-  const { modal } = App.useApp();
   const openDocumentPreview = useDocumentStore((s) => s.openDocumentPreview);
   const unpinDocument = useTaskStore((s) => s.unpinDocument);
   const activeTaskId = useTaskStore(taskDetailSelectors.activeTaskId);
@@ -41,16 +40,14 @@ const ArtifactCard = memo<{ node: TaskDetailWorkspaceNode }>(({ node }) => {
   const handleDelete = useCallback(() => {
     const taskId = node.sourceTaskId ?? activeTaskId;
     if (!taskId) return;
-    modal.confirm({
-      centered: true,
+    confirmModal({
       content: t('taskDetail.artifactMenu.deleteConfirm.content'),
       okButtonProps: { danger: true },
       okText: t('taskDetail.artifactMenu.deleteConfirm.ok'),
       onOk: () => unpinDocument(taskId, node.documentId),
       title: t('taskDetail.artifactMenu.deleteConfirm.title'),
-      type: 'error',
     });
-  }, [activeTaskId, modal, node.documentId, node.sourceTaskId, t, unpinDocument]);
+  }, [activeTaskId, node.documentId, node.sourceTaskId, t, unpinDocument]);
 
   const menuItems = useMemo<DropdownItem[]>(
     () => [

--- a/src/features/AgentTasks/AgentTaskDetail/TaskBriefCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskBriefCard.tsx
@@ -7,7 +7,7 @@ import {
   Icon,
   Text,
 } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { Check, ChevronDownIcon, ChevronUpIcon, MoreHorizontal, Trash } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
@@ -32,15 +32,13 @@ interface TaskBriefCardProps {
 const TaskBriefCard = memo<TaskBriefCardProps>(
   ({ brief, onAfterResolve, onAfterAddComment, onAfterDelete }) => {
     const { t } = useTranslation('home');
-    const { modal } = App.useApp();
     const deleteBrief = useBriefStore((s) => s.deleteBrief);
     const isResolved = Boolean(brief.resolvedAction);
     const [expanded, setExpanded] = useState(false);
     const showFull = !isResolved || expanded;
 
     const handleDelete = useCallback(() => {
-      modal.confirm({
-        centered: true,
+      confirmModal({
         content: t('brief.deleteConfirm.content'),
         okButtonProps: { danger: true },
         okText: t('brief.deleteConfirm.ok'),
@@ -49,9 +47,8 @@ const TaskBriefCard = memo<TaskBriefCardProps>(
           await onAfterDelete?.();
         },
         title: t('brief.deleteConfirm.title'),
-        type: 'error',
       });
-    }, [brief.id, deleteBrief, modal, onAfterDelete, t]);
+    }, [brief.id, deleteBrief, onAfterDelete, t]);
 
     const menuItems = useMemo<DropdownItem[]>(
       () => [

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.tsx
@@ -1,4 +1,5 @@
 import { ActionIcon, copyToClipboard, type DropdownItem, DropdownMenu, Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { CopyIcon, LinkIcon, MoreHorizontal, Trash } from 'lucide-react';
 import { memo, useCallback, useMemo } from 'react';
@@ -13,7 +14,7 @@ import { taskDetailPath } from '../shared/taskDetailPath';
 
 const TaskDetailHeaderActions = memo(() => {
   const { t } = useTranslation(['chat', 'common']);
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
   const navigate = useNavigate();
   const appOrigin = useAppOrigin();
   const taskId = useTaskStore(taskDetailSelectors.activeTaskId);
@@ -22,8 +23,7 @@ const TaskDetailHeaderActions = memo(() => {
 
   const triggerDelete = useCallback(() => {
     if (!taskId) return;
-    modal.confirm({
-      centered: true,
+    confirmModal({
       content: t('taskDetail.deleteConfirm.content'),
       okButtonProps: { danger: true },
       okText: t('taskDetail.deleteConfirm.ok'),
@@ -32,9 +32,8 @@ const TaskDetailHeaderActions = memo(() => {
         navigate('/tasks');
       },
       title: t('taskDetail.deleteConfirm.title'),
-      type: 'error',
     });
-  }, [taskId, modal, t, deleteTask, navigate]);
+  }, [taskId, t, deleteTask, navigate]);
 
   const menuItems = useMemo<DropdownItem[]>(() => {
     if (!taskId) return [];

--- a/src/features/AgentTasks/AgentTaskDetail/TaskSubtasks.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskSubtasks.test.tsx
@@ -81,6 +81,10 @@ vi.mock('antd-style', () => ({
   },
 }));
 
+vi.mock('@lobehub/ui/base-ui', () => ({
+  confirmModal: vi.fn(),
+}));
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));

--- a/src/features/AgentTasks/AgentTaskDetail/TaskSubtasks.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskSubtasks.tsx
@@ -1,5 +1,6 @@
 import type { TaskDetailSubtask } from '@lobechat/types';
 import { ActionIcon, Block, Flexbox, Icon, showContextMenu, Text } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App, ConfigProvider, Tree } from 'antd';
 import type { DataNode } from 'antd/es/tree';
 import { cssVar } from 'antd-style';
@@ -127,7 +128,7 @@ const toTreeData = (tree: TaskTreeNode[]): DataNode[] => {
 
 const TaskSubtasks = memo(() => {
   const { t } = useTranslation('chat');
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
   const navigate = useNavigate();
   const agentId = useTaskStore(taskDetailSelectors.activeTaskAgentId);
   const subtasks = useTaskStore(taskDetailSelectors.activeTaskSubtasks);
@@ -210,9 +211,8 @@ const TaskSubtasks = memo(() => {
       }
 
       const canRun = plan.totalRunnable > 0;
-      modal.confirm({
+      confirmModal({
         cancelText: t('taskDetail.runAll.cancel'),
-        centered: true,
         content: <RunSubtasksPreview plan={plan} />,
         okButtonProps: canRun ? undefined : { disabled: true },
         okText: t('taskDetail.runAll.confirm', { count: plan.totalRunnable }),
@@ -234,7 +234,6 @@ const TaskSubtasks = memo(() => {
           }
         },
         title: t('taskDetail.runAll.title'),
-        width: 520,
       });
     } catch (error) {
       console.error('[TaskSubtasks] Failed to plan subtasks:', error);
@@ -242,7 +241,7 @@ const TaskSubtasks = memo(() => {
     } finally {
       setIsPlanning(false);
     }
-  }, [taskId, isPlanning, message, modal, t, runReadySubtasks]);
+  }, [taskId, isPlanning, message, t, runReadySubtasks]);
 
   if (!taskId) return null;
 

--- a/src/features/AgentTasks/features/useTaskItemContextMenu.tsx
+++ b/src/features/AgentTasks/features/useTaskItemContextMenu.tsx
@@ -7,6 +7,7 @@ import {
   Icon,
   type MenuInfo,
 } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { cssVar } from 'antd-style';
 import {
@@ -55,7 +56,7 @@ export interface TaskContextMenuActions {
 
 export const useTaskContextMenuActions = (): TaskContextMenuActions => {
   const { t } = useTranslation(['chat', 'common']);
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
   const appOrigin = useAppOrigin();
 
   const updateTaskStatus = useTaskStore((s) => s.updateTaskStatus);
@@ -72,8 +73,7 @@ export const useTaskContextMenuActions = (): TaskContextMenuActions => {
 
   return useMemo<TaskContextMenuActions>(() => {
     const triggerDelete = (identifier: string) => {
-      modal.confirm({
-        centered: true,
+      confirmModal({
         content: t('taskDetail.deleteConfirm.content'),
         okButtonProps: { danger: true },
         okText: t('taskDetail.deleteConfirm.ok'),
@@ -81,7 +81,6 @@ export const useTaskContextMenuActions = (): TaskContextMenuActions => {
           await deleteTask(identifier);
         },
         title: t('taskDetail.deleteConfirm.title'),
-        type: 'error',
       });
     };
 
@@ -277,7 +276,6 @@ export const useTaskContextMenuActions = (): TaskContextMenuActions => {
 
     return { buildItems, installKeyboardHandlers };
   }, [
-    modal,
     message,
     t,
     appOrigin,

--- a/src/features/AgentTopicManager/BulkActionBar.tsx
+++ b/src/features/AgentTopicManager/BulkActionBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ActionIcon, Flexbox, Text } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { Archive, Star, Trash2, X } from 'lucide-react';
 import { memo, useCallback } from 'react';
@@ -44,7 +44,6 @@ const styles = createStaticStyles(({ css }) => ({
 
 const BulkActionBar = memo(() => {
   const { t } = useTranslation('topic');
-  const { modal } = App.useApp();
 
   const selectedIds = useTopicsViewStore((s) => s.selectedIds);
   const exitSelectMode = useTopicsViewStore((s) => s.exitSelectMode);
@@ -68,7 +67,7 @@ const BulkActionBar = memo(() => {
   }, [selectedIds, updateTopicStatus, exitSelectMode]);
 
   const handleBatchDelete = useCallback(() => {
-    modal.confirm({
+    confirmModal({
       content: t('management.bulk.deleteConfirm', { count: selectedIds.length }),
       okButtonProps: { danger: true },
       okText: t('management.bulk.delete'),
@@ -82,7 +81,7 @@ const BulkActionBar = memo(() => {
       },
       title: t('management.bulk.deleteTitle'),
     });
-  }, [selectedIds, modal, t, removeTopic, exitSelectMode]);
+  }, [selectedIds, t, removeTopic, exitSelectMode]);
 
   if (selectedIds.length === 0) return null;
 

--- a/src/features/AgentTopicManager/ToolbarActions.tsx
+++ b/src/features/AgentTopicManager/ToolbarActions.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ActionIcon, type DropdownItem, DropdownMenu } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { Archive, MoreHorizontal } from 'lucide-react';
 import { memo, useCallback, useMemo } from 'react';
@@ -13,7 +14,7 @@ const THREE_MONTHS_MS = 90 * 24 * 60 * 60 * 1000;
 
 const ToolbarActions = memo(() => {
   const { t } = useTranslation('topic');
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
 
   // Operate on the management page's own bucket — not the sidebar's — since
   // the management view is the one the user is acting on here.
@@ -34,7 +35,7 @@ const ToolbarActions = memo(() => {
       return;
     }
 
-    modal.confirm({
+    confirmModal({
       content: t('management.actionsMenu.archiveStale.confirm', { count: stale.length }),
       okText: t('management.actionsMenu.archiveStale.confirmOk'),
       onOk: async () => {
@@ -47,7 +48,7 @@ const ToolbarActions = memo(() => {
       },
       title: t('management.actionsMenu.archiveStale.title'),
     });
-  }, [topics, updateTopicStatus, modal, message, t]);
+  }, [topics, updateTopicStatus, message, t]);
 
   const items: DropdownItem[] = useMemo(
     () => [

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/Fallback.tsx
@@ -50,6 +50,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     margin-block-start: -4px;
     padding-block-end: 8px;
     padding-inline: 16px;
+
     font-size: ${cssVar.fontSizeSM};
     line-height: 1.45;
     color: ${cssVar.colorTextSecondary};

--- a/src/features/Conversation/Messages/CompressedGroup/index.tsx
+++ b/src/features/Conversation/Messages/CompressedGroup/index.tsx
@@ -10,7 +10,7 @@ import {
   Tabs,
   type TabsProps,
 } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { ChevronDown, ChevronUp, History, Sparkles, Undo2 } from 'lucide-react';
@@ -68,7 +68,6 @@ export interface CompressedGroupMessageProps {
 
 const CompressedGroupMessage = memo<CompressedGroupMessageProps>(({ id }) => {
   const { t } = useTranslation('chat');
-  const { modal } = App.useApp();
   const [activeTab, setActiveTab] = useState<string>(() => getStoredTab(id));
 
   const handleTabChange = useCallback(
@@ -86,13 +85,12 @@ const CompressedGroupMessage = memo<CompressedGroupMessageProps>(({ id }) => {
   const cancelCompression = useConversationStore((s) => s.cancelCompression);
 
   const handleCancelCompression = useCallback(() => {
-    modal.confirm({
-      centered: true,
+    confirmModal({
       content: t('compression.cancelConfirm'),
       onOk: () => cancelCompression(id),
       title: t('compression.cancel'),
     });
-  }, [id, cancelCompression, modal, t]);
+  }, [id, cancelCompression, t]);
 
   const content = message?.content;
   const rawCompressedMessages = (message as UIChatMessage)?.compressedMessages;

--- a/src/features/CreatePlatformAgent/index.tsx
+++ b/src/features/CreatePlatformAgent/index.tsx
@@ -5,8 +5,9 @@ import {
   type RemoteHeterogeneousAgentType,
 } from '@lobechat/heterogeneous-agents';
 import { Button, Flexbox, Icon } from '@lobehub/ui';
-import { Alert, Input, Modal, Select, Steps, Tag, Typography } from 'antd';
-import { createStyles } from 'antd-style';
+import { Select } from '@lobehub/ui/base-ui';
+import { Alert, Input, Modal, Steps, Tag, Typography } from 'antd';
+import { createStaticStyles, cssVar } from 'antd-style';
 import {
   BotIcon,
   CheckCircle2,
@@ -23,7 +24,7 @@ import { lambdaClient, lambdaQuery } from '@/libs/trpc/client';
 import { useAgentStore } from '@/store/agent';
 import { useHomeStore } from '@/store/home';
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css }) => ({
   avatarPreview: css`
     display: flex;
     align-items: center;
@@ -31,12 +32,12 @@ const useStyles = createStyles(({ css, token }) => ({
 
     width: 48px;
     height: 48px;
-    border-radius: ${token.borderRadiusLG}px;
+    border-radius: ${cssVar.borderRadiusLG};
 
     font-size: 28px;
     line-height: 1;
 
-    background: ${token.colorFillSecondary};
+    background: ${cssVar.colorFillSecondary};
   `,
   deviceItem: css`
     display: flex;
@@ -53,20 +54,20 @@ const useStyles = createStyles(({ css, token }) => ({
 
     padding-block: 12px;
     padding-inline: 16px;
-    border: 1.5px solid ${token.colorBorderSecondary};
-    border-radius: ${token.borderRadiusLG}px;
+    border: 1.5px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusLG};
 
-    background: ${token.colorBgContainer};
+    background: ${cssVar.colorBgContainer};
 
     transition: border-color 0.2s;
 
     &:hover {
-      border-color: ${token.colorPrimary};
+      border-color: ${cssVar.colorPrimary};
     }
 
     &[data-selected='true'] {
-      border-color: ${token.colorPrimary};
-      background: ${token.colorPrimaryBg};
+      border-color: ${cssVar.colorPrimary};
+      background: ${cssVar.colorPrimaryBg};
     }
 
     &[data-disabled='true'] {
@@ -74,18 +75,18 @@ const useStyles = createStyles(({ css, token }) => ({
       opacity: 0.5;
 
       &:hover {
-        border-color: ${token.colorBorderSecondary};
+        border-color: ${cssVar.colorBorderSecondary};
       }
     }
   `,
   platformDesc: css`
     font-size: 13px;
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
   `,
   platformName: css`
     font-size: 15px;
     font-weight: 500;
-    color: ${token.colorText};
+    color: ${cssVar.colorText};
   `,
 }));
 
@@ -104,7 +105,6 @@ interface CreatePlatformAgentModalProps {
 const CreatePlatformAgentModal = memo<CreatePlatformAgentModalProps>(
   ({ open, onClose, groupId }) => {
     const { t } = useTranslation('chat');
-    const { styles } = useStyles();
     const navigate = useNavigate();
     const storeCreateAgent = useAgentStore((s) => s.createAgent);
     const refreshAgentList = useHomeStore((s) => s.refreshAgentList);

--- a/src/features/EditorModal/index.tsx
+++ b/src/features/EditorModal/index.tsx
@@ -1,12 +1,11 @@
 import { useEditor } from '@lobehub/editor/react';
-import { type ModalProps } from '@lobehub/ui';
-import { createRawModal, Modal } from '@lobehub/ui';
+import { Modal, type ModalComponentProps } from '@lobehub/ui/base-ui';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import EditorCanvas from './EditorCanvas';
 
-interface EditorModalProps extends ModalProps {
+interface EditorModalProps extends ModalComponentProps {
   editorData?: unknown;
   onConfirm?: (value: string, editorData?: unknown) => Promise<void>;
   value?: string;
@@ -47,5 +46,3 @@ export const EditorModal = memo<EditorModalProps>(
     );
   },
 );
-
-export const createEditorModal = (props: EditorModalProps) => createRawModal(EditorModal, props);

--- a/src/features/Messenger/AgentSelect.tsx
+++ b/src/features/Messenger/AgentSelect.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Avatar, Flexbox, Select, type SelectProps, Text } from '@lobehub/ui';
+import { Avatar, Flexbox, Text } from '@lobehub/ui';
+import { Select, type SelectProps } from '@lobehub/ui/base-ui';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
@@ -8,21 +9,11 @@ import useSWR from 'swr';
 import { DEFAULT_AVATAR } from '@/const/meta';
 import { messengerService } from '@/services/messenger';
 
-interface AgentSelectProps extends Omit<
-  SelectProps,
-  'options' | 'showSearch' | 'optionFilterProp' | 'value' | 'onChange'
-> {
+interface AgentSelectProps extends Omit<SelectProps<string>, 'options' | 'value' | 'onChange'> {
   onChange?: (agentId: string | undefined) => void;
   value?: string;
 }
 
-/**
- * Shared agent picker used wherever the messenger feature asks the user to
- * pick which agent receives messages. Single source of truth for the option
- * shape (avatar + title, locale-aware fallback) so verify-im and the Settings
- * panel render identically. Fetches `messenger.listAgentsForBinding` (which
- * already pins LobeAI to the top and matches the bot's `/agents` ordering).
- */
 const AgentSelect = memo<AgentSelectProps>(({ value, onChange, ...rest }) => {
   const { t: tCommon } = useTranslation('common');
   const agentsSWR = useSWR('messenger:agentsForBinding', () =>
@@ -36,7 +27,7 @@ const AgentSelect = memo<AgentSelectProps>(({ value, onChange, ...rest }) => {
         const title = agent.title || defaultAgentTitle;
         return {
           label: (
-            <Flexbox horizontal align="center" gap={8}>
+            <Flexbox horizontal align={'center'} gap={8}>
               <Avatar
                 avatar={agent.avatar || DEFAULT_AVATAR}
                 background={agent.backgroundColor ?? undefined}
@@ -45,7 +36,6 @@ const AgentSelect = memo<AgentSelectProps>(({ value, onChange, ...rest }) => {
               <Text ellipsis>{title}</Text>
             </Flexbox>
           ),
-          searchValue: title,
           title,
           value: agent.id,
         };
@@ -55,10 +45,10 @@ const AgentSelect = memo<AgentSelectProps>(({ value, onChange, ...rest }) => {
 
   return (
     <Select
-      optionFilterProp="searchValue"
+      showSearch
       options={options}
-      value={value}
-      onChange={(next) => onChange?.(next as string | undefined)}
+      value={value ?? null}
+      onChange={(next) => onChange?.((next as string | null) ?? undefined)}
       {...rest}
     />
   );

--- a/src/features/Messenger/IntegrationDetail/Discord.tsx
+++ b/src/features/Messenger/IntegrationDetail/Discord.tsx
@@ -2,11 +2,11 @@
 
 import { Button, Icon, Text } from '@lobehub/ui';
 import { LinkIcon, ServerIcon, Trash2Icon, UserIcon } from 'lucide-react';
-import { memo, useState } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { buildDiscordOpenBotUrl } from '../constants';
-import LinkModal from '../LinkModal';
+import { createMessengerLinkModal } from '../LinkModal';
 import {
   ConnectionRow,
   DetailLayout,
@@ -32,7 +32,6 @@ interface DiscordDetailProps {
 // (`messenger.discord.connections.*`) makes that distinction explicit.
 const DiscordDetail = memo<DiscordDetailProps>(({ appId, botUsername, name, onBack }) => {
   const { t } = useTranslation('messenger');
-  const [linkOpen, setLinkOpen] = useState(false);
 
   const data = useMessengerData('discord');
   const { handleSetActive, handleUnlink } = useLinkActions({
@@ -61,90 +60,82 @@ const DiscordDetail = memo<DiscordDetailProps>(({ appId, botUsername, name, onBa
   const hasLinks = links.length > 0;
   const link = links[0];
 
+  const handleOpenLink = () =>
+    createMessengerLinkModal({ appId, botUsername, name, platform: 'discord' });
+
   const headerAction = (
     <Button
       icon={<Icon icon={LinkIcon} />}
       type={hasInstallations ? 'default' : 'primary'}
-      onClick={() => setLinkOpen(true)}
+      onClick={handleOpenLink}
     >
       {hasInstallations ? t('messenger.detail.addServer') : t('messenger.linkCta')}
     </Button>
   );
 
   return (
-    <>
-      <DetailLayout
-        hasConnections={hasInstallations || hasLinks}
-        headerAction={headerAction}
-        name={name}
-        platform="discord"
-        onBack={onBack}
-      >
-        {installations.map((install) => (
+    <DetailLayout
+      hasConnections={hasInstallations || hasLinks}
+      headerAction={headerAction}
+      name={name}
+      platform="discord"
+      onBack={onBack}
+    >
+      {installations.map((install) => (
+        <ConnectionRow
+          icon={<Icon icon={ServerIcon} size="small" />}
+          key={install.id}
+          label={t('messenger.detail.connections.serverLabel')}
+          name={install.tenantName || install.tenantId}
+          status="connected"
+          action={
+            <Button
+              danger
+              icon={<Icon icon={Trash2Icon} />}
+              size="small"
+              onClick={() => handleDisconnectInstallation(install.id)}
+            >
+              {t('messenger.detail.disconnect')}
+            </Button>
+          }
+        />
+      ))}
+      {link ? (
+        <UserAgentConnection
+          link={link}
+          onSetActive={(agentId) => handleSetActive('', agentId)}
+          onUnlink={() => handleUnlink('')}
+        />
+      ) : (
+        hasInstallations &&
+        appId && (
           <ConnectionRow
-            icon={<Icon icon={ServerIcon} size="small" />}
-            key={install.id}
-            label={t('messenger.detail.connections.serverLabel')}
-            name={install.tenantName || install.tenantId}
-            status="connected"
+            icon={<Icon icon={UserIcon} size="small" />}
+            label={t('messenger.detail.connections.userLabel')}
+            name={t('messenger.discord.userPending.name')}
+            status="pending"
             action={
               <Button
-                danger
-                icon={<Icon icon={Trash2Icon} />}
+                href={buildDiscordOpenBotUrl(appId)}
+                icon={<Icon icon={LinkIcon} />}
                 size="small"
-                onClick={() => handleDisconnectInstallation(install.id)}
+                target="_blank"
+                type="primary"
               >
-                {t('messenger.detail.disconnect')}
+                {t('messenger.discord.userPending.cta')}
               </Button>
             }
-          />
-        ))}
-        {link ? (
-          <UserAgentConnection
-            link={link}
-            onSetActive={(agentId) => handleSetActive('', agentId)}
-            onUnlink={() => handleUnlink('')}
-          />
-        ) : (
-          hasInstallations &&
-          appId && (
-            <ConnectionRow
-              icon={<Icon icon={UserIcon} size="small" />}
-              label={t('messenger.detail.connections.userLabel')}
-              name={t('messenger.discord.userPending.name')}
-              status="pending"
-              action={
-                <Button
-                  href={buildDiscordOpenBotUrl(appId)}
-                  icon={<Icon icon={LinkIcon} />}
-                  size="small"
-                  target="_blank"
-                  type="primary"
-                >
-                  {t('messenger.discord.userPending.cta')}
-                </Button>
-              }
-            >
-              <Text style={{ fontSize: 12 }} type="secondary">
-                {t('messenger.discord.userPending.hint')}
-              </Text>
-            </ConnectionRow>
-          )
-        )}
-        {!hasLinks && !hasInstallations && (
-          <div className={styles.emptyRow}>{t('messenger.detail.connections.empty')}</div>
-        )}
-      </DetailLayout>
-
-      <LinkModal
-        appId={appId}
-        botUsername={botUsername}
-        name={name}
-        open={linkOpen}
-        platform="discord"
-        onClose={() => setLinkOpen(false)}
-      />
-    </>
+          >
+            <Text style={{ fontSize: 12 }} type="secondary">
+              {t('messenger.discord.userPending.hint')}
+            </Text>
+          </ConnectionRow>
+        )
+      )}
+      {!hasLinks && !hasInstallations && (
+        <div className={styles.emptyRow}>{t('messenger.detail.connections.empty')}</div>
+      )}
+    </DetailLayout>
   );
 });
 

--- a/src/features/Messenger/IntegrationDetail/Slack.tsx
+++ b/src/features/Messenger/IntegrationDetail/Slack.tsx
@@ -2,10 +2,10 @@
 
 import { Button, Icon } from '@lobehub/ui';
 import { BriefcaseIcon, LinkIcon, Trash2Icon } from 'lucide-react';
-import { memo, useState } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import LinkModal from '../LinkModal';
+import { createMessengerLinkModal } from '../LinkModal';
 import {
   ConnectionRow,
   DetailLayout,
@@ -26,7 +26,6 @@ interface SlackDetailProps {
 
 const SlackDetail = memo<SlackDetailProps>(({ appId, botUsername, name, onBack }) => {
   const { t } = useTranslation('messenger');
-  const [linkOpen, setLinkOpen] = useState(false);
 
   const data = useMessengerData('slack');
   const { handleSetActive, handleUnlink } = useLinkActions({
@@ -57,11 +56,14 @@ const SlackDetail = memo<SlackDetailProps>(({ appId, botUsername, name, onBack }
   const hasInstallations = installations.length > 0;
   const hasLinks = links.length > 0;
 
+  const handleOpenLink = () =>
+    createMessengerLinkModal({ appId, botUsername, name, platform: 'slack' });
+
   const headerAction = (
     <Button
       icon={<Icon icon={LinkIcon} />}
       type={hasInstallations ? 'default' : 'primary'}
-      onClick={() => setLinkOpen(true)}
+      onClick={handleOpenLink}
     >
       {hasInstallations ? t('messenger.detail.addWorkspace') : t('messenger.linkCta')}
     </Button>
@@ -75,60 +77,48 @@ const SlackDetail = memo<SlackDetailProps>(({ appId, botUsername, name, onBack }
     hasInstallations && installations.every((install) => !linkByTenantId.has(install.tenantId));
 
   return (
-    <>
-      <DetailLayout
-        hasConnections={hasInstallations || hasLinks}
-        headerAction={headerAction}
-        name={name}
-        platform="slack"
-        onBack={onBack}
-      >
-        {installations.map((install) => (
-          <ConnectionRow
-            icon={<Icon icon={BriefcaseIcon} size="small" />}
-            key={install.id}
-            label={t('messenger.detail.connections.workspaceLabel')}
-            name={install.tenantName || install.tenantId}
-            status="connected"
-            action={
-              <Button
-                danger
-                icon={<Icon icon={Trash2Icon} />}
-                size="small"
-                onClick={() => handleDisconnectInstallation(install.id)}
-              >
-                {t('messenger.detail.disconnect')}
-              </Button>
-            }
+    <DetailLayout
+      hasConnections={hasInstallations || hasLinks}
+      headerAction={headerAction}
+      name={name}
+      platform="slack"
+      onBack={onBack}
+    >
+      {installations.map((install) => (
+        <ConnectionRow
+          icon={<Icon icon={BriefcaseIcon} size="small" />}
+          key={install.id}
+          label={t('messenger.detail.connections.workspaceLabel')}
+          name={install.tenantName || install.tenantId}
+          status="connected"
+          action={
+            <Button
+              danger
+              icon={<Icon icon={Trash2Icon} />}
+              size="small"
+              onClick={() => handleDisconnectInstallation(install.id)}
+            >
+              {t('messenger.detail.disconnect')}
+            </Button>
+          }
+        />
+      ))}
+      {links.map((link) => {
+        const workspace = tenantNameByTenantId.get(link.tenantId) || link.tenantId;
+        return (
+          <UserAgentConnection
+            extraLabel={workspace}
+            key={link.id}
+            link={link}
+            onSetActive={(agentId) => handleSetActive(link.tenantId, agentId)}
+            onUnlink={() => handleUnlink(link.tenantId)}
           />
-        ))}
-        {links.map((link) => {
-          const workspace = tenantNameByTenantId.get(link.tenantId) || link.tenantId;
-          return (
-            <UserAgentConnection
-              extraLabel={workspace}
-              key={link.id}
-              link={link}
-              onSetActive={(agentId) => handleSetActive(link.tenantId, agentId)}
-              onUnlink={() => handleUnlink(link.tenantId)}
-            />
-          );
-        })}
-        {/* Installs without any user link yet — gentle nudge to /start in Slack. */}
-        {allInstallsUnlinked && !hasLinks && (
-          <div className={styles.emptyRow}>{t('messenger.detail.connections.linkHint')}</div>
-        )}
-      </DetailLayout>
-
-      <LinkModal
-        appId={appId}
-        botUsername={botUsername}
-        name={name}
-        open={linkOpen}
-        platform="slack"
-        onClose={() => setLinkOpen(false)}
-      />
-    </>
+        );
+      })}
+      {allInstallsUnlinked && !hasLinks && (
+        <div className={styles.emptyRow}>{t('messenger.detail.connections.linkHint')}</div>
+      )}
+    </DetailLayout>
   );
 });
 

--- a/src/features/Messenger/IntegrationDetail/Telegram.tsx
+++ b/src/features/Messenger/IntegrationDetail/Telegram.tsx
@@ -2,10 +2,10 @@
 
 import { Button, Icon } from '@lobehub/ui';
 import { LinkIcon, Trash2Icon } from 'lucide-react';
-import { memo, useState } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import LinkModal from '../LinkModal';
+import { createMessengerLinkModal } from '../LinkModal';
 import {
   DetailLayout,
   IntegrationDetailSkeleton,
@@ -27,7 +27,6 @@ interface TelegramDetailProps {
 // header.
 const TelegramDetail = memo<TelegramDetailProps>(({ appId, botUsername, name, onBack }) => {
   const { t } = useTranslation('messenger');
-  const [linkOpen, setLinkOpen] = useState(false);
 
   const data = useMessengerData('telegram');
   const { handleSetActive, handleUnlink } = useLinkActions({
@@ -43,45 +42,37 @@ const TelegramDetail = memo<TelegramDetailProps>(({ appId, botUsername, name, on
   const hasLinks = links.length > 0;
   const link = links[0];
 
+  const handleOpenLink = () =>
+    createMessengerLinkModal({ appId, botUsername, name, platform: 'telegram' });
+
   const headerAction = hasLinks ? (
     <Button danger icon={<Icon icon={Trash2Icon} />} onClick={() => handleUnlink('')}>
       {t('messenger.unlinkCta')}
     </Button>
   ) : (
-    <Button icon={<Icon icon={LinkIcon} />} type="primary" onClick={() => setLinkOpen(true)}>
+    <Button icon={<Icon icon={LinkIcon} />} type="primary" onClick={handleOpenLink}>
       {t('messenger.linkCta')}
     </Button>
   );
 
   return (
-    <>
-      <DetailLayout
-        hasConnections={hasLinks}
-        headerAction={headerAction}
-        name={name}
-        platform="telegram"
-        onBack={onBack}
-      >
-        {link ? (
-          <UserAgentConnection
-            link={link}
-            onSetActive={(agentId) => handleSetActive('', agentId)}
-            onUnlink={() => handleUnlink('')}
-          />
-        ) : (
-          <div className={styles.emptyRow}>{t('messenger.detail.connections.empty')}</div>
-        )}
-      </DetailLayout>
-
-      <LinkModal
-        appId={appId}
-        botUsername={botUsername}
-        name={name}
-        open={linkOpen}
-        platform="telegram"
-        onClose={() => setLinkOpen(false)}
-      />
-    </>
+    <DetailLayout
+      hasConnections={hasLinks}
+      headerAction={headerAction}
+      name={name}
+      platform="telegram"
+      onBack={onBack}
+    >
+      {link ? (
+        <UserAgentConnection
+          link={link}
+          onSetActive={(agentId) => handleSetActive('', agentId)}
+          onUnlink={() => handleUnlink('')}
+        />
+      ) : (
+        <div className={styles.emptyRow}>{t('messenger.detail.connections.empty')}</div>
+      )}
+    </DetailLayout>
   );
 });
 

--- a/src/features/Messenger/IntegrationDetail/shared.tsx
+++ b/src/features/Messenger/IntegrationDetail/shared.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Block, Button, Flexbox, Icon, Skeleton, Tag, Text } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { ArrowLeftIcon, CheckCircle2Icon, Trash2Icon, UserIcon } from 'lucide-react';
@@ -294,7 +295,7 @@ export const useLinkActions = ({
   platform,
 }: UseLinkActionsArgs) => {
   const { t } = useTranslation('messenger');
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
 
   const handleSetActive = async (tenantId: string, agentId: string | null) => {
     try {
@@ -311,7 +312,7 @@ export const useLinkActions = ({
   };
 
   const handleUnlink = (tenantId: string) => {
-    modal.confirm({
+    confirmModal({
       content: t('messenger.unlinkConfirm', { platform: name }),
       okButtonProps: { danger: true },
       onOk: async () => {
@@ -359,10 +360,10 @@ export const useDisconnectInstallation = ({
   linksMutate,
 }: UseDisconnectInstallationArgs) => {
   const { t } = useTranslation('messenger');
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
 
   return (id: string, copy: DisconnectInstallationCopy) => {
-    modal.confirm({
+    confirmModal({
       content: copy.confirm,
       okButtonProps: { danger: true },
       onOk: async () => {

--- a/src/features/Messenger/LinkModal/Content.tsx
+++ b/src/features/Messenger/LinkModal/Content.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { Flexbox } from '@lobehub/ui';
+import { memo } from 'react';
+
+import type { MessengerPlatform } from '../constants';
+import DiscordLinkBody from './Discord';
+import SlackLinkBody from './Slack';
+import TelegramLinkBody from './Telegram';
+
+export interface LinkModalContentProps {
+  appId?: string;
+  botUsername?: string;
+  name: string;
+  platform: MessengerPlatform;
+}
+
+const LinkModalContent = memo<LinkModalContentProps>(({ appId, botUsername, name, platform }) => {
+  const renderBody = () => {
+    switch (platform) {
+      case 'slack': {
+        return <SlackLinkBody />;
+      }
+      case 'discord': {
+        return <DiscordLinkBody appId={appId} name={name} />;
+      }
+      case 'telegram': {
+        return <TelegramLinkBody botUsername={botUsername} name={name} />;
+      }
+    }
+  };
+
+  return (
+    <Flexbox align={'center'} gap={20} style={{ paddingBlockEnd: 16, paddingBlockStart: 24 }}>
+      {renderBody()}
+    </Flexbox>
+  );
+});
+
+LinkModalContent.displayName = 'MessengerLinkModalContent';
+
+export default LinkModalContent;

--- a/src/features/Messenger/LinkModal/index.tsx
+++ b/src/features/Messenger/LinkModal/index.tsx
@@ -1,47 +1,14 @@
 'use client';
 
-import { Flexbox, Modal } from '@lobehub/ui';
-import { memo } from 'react';
+import { createModal, type ModalInstance } from '@lobehub/ui/base-ui';
 
-import type { MessengerPlatform } from '../constants';
-import DiscordLinkBody from './Discord';
-import SlackLinkBody from './Slack';
-import TelegramLinkBody from './Telegram';
+import LinkModalContent, { type LinkModalContentProps } from './Content';
 
-interface LinkModalProps {
-  appId?: string;
-  botUsername?: string;
-  /** Brand-name label (e.g. `"Slack"`) sourced from the registry. */
-  name: string;
-  onClose: () => void;
-  open: boolean;
-  platform: MessengerPlatform;
-}
-
-const LinkModal = memo<LinkModalProps>(({ appId, botUsername, name, onClose, open, platform }) => {
-  const renderBody = () => {
-    switch (platform) {
-      case 'slack': {
-        return <SlackLinkBody />;
-      }
-      case 'discord': {
-        return <DiscordLinkBody appId={appId} name={name} />;
-      }
-      case 'telegram': {
-        return <TelegramLinkBody botUsername={botUsername} name={name} />;
-      }
-    }
-  };
-
-  return (
-    <Modal footer={null} open={open} title={null} width={480} onCancel={onClose}>
-      <Flexbox align="center" gap={20} style={{ paddingBlockEnd: 16, paddingBlockStart: 40 }}>
-        {renderBody()}
-      </Flexbox>
-    </Modal>
-  );
-});
-
-LinkModal.displayName = 'MessengerLinkModal';
-
-export default LinkModal;
+export const createMessengerLinkModal = (props: LinkModalContentProps): ModalInstance =>
+  createModal({
+    content: <LinkModalContent {...props} />,
+    footer: null,
+    maskClosable: true,
+    title: null,
+    width: 'min(90vw, 480px)',
+  });

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ImageAspectRatio2Select.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ImageAspectRatio2Select.tsx
@@ -1,4 +1,4 @@
-import { Select } from 'antd';
+import { Select } from '@lobehub/ui/base-ui';
 import { memo, useMemo } from 'react';
 
 import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ImageAspectRatioSelect.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ImageAspectRatioSelect.tsx
@@ -1,4 +1,4 @@
-import { Select } from 'antd';
+import { Select } from '@lobehub/ui/base-ui';
 import { memo, useMemo } from 'react';
 
 import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';

--- a/src/features/PageEditor/Copilot/AgentSelector/useDropdownMenu.tsx
+++ b/src/features/PageEditor/Copilot/AgentSelector/useDropdownMenu.tsx
@@ -1,6 +1,6 @@
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { Trash2 } from 'lucide-react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -20,13 +20,11 @@ export const useDropdownMenu = ({
   onClose,
 }: UseDropdownMenuProps): MenuProps['items'] => {
   const { t } = useTranslation(['common', 'chat']);
-  const { modal } = App.useApp();
   const removeAgent = useHomeStore((s) => s.removeAgent);
 
   const handleDelete = () => {
-    modal.confirm({
+    confirmModal({
       cancelText: t('cancel'),
-      centered: true,
       okButtonProps: { danger: true },
       okText: t('delete'),
       onOk: async () => {

--- a/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx
+++ b/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx
@@ -1,6 +1,6 @@
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { Trash2 } from 'lucide-react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -20,7 +20,6 @@ export const useDropdownMenu = ({
   topicId,
 }: UseDropdownMenuProps): (() => MenuProps['items']) => {
   const { t } = useTranslation(['common', 'topic']);
-  const { modal } = App.useApp();
   const removeTopic = useChatStore((s) => s.removeTopic);
 
   return useCallback(
@@ -32,9 +31,8 @@ export const useDropdownMenu = ({
           key: 'delete',
           label: t('delete'),
           onClick: () => {
-            modal.confirm({
+            confirmModal({
               cancelText: t('cancel'),
-              centered: true,
               content: t('actions.confirmRemoveTopic', { ns: 'topic' }),
               okButtonProps: { danger: true },
               okText: t('delete'),
@@ -48,6 +46,6 @@ export const useDropdownMenu = ({
           },
         },
       ].filter(Boolean) as MenuProps['items'],
-    [t, modal, removeTopic, topicId, onDelete, onClose],
+    [t, removeTopic, topicId, onDelete, onClose],
   );
 };

--- a/src/features/PageEditor/Header/useMenu.tsx
+++ b/src/features/PageEditor/Header/useMenu.tsx
@@ -21,7 +21,7 @@ import { usePageEditorStore, useStoreApi } from '../store';
  */
 export const useMenu = (): { menuItems: any[] } => {
   const { t } = useTranslation(['file', 'common', 'chat']);
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
   const storeApi = useStoreApi();
   const { lg = true } = useResponsive();
 
@@ -137,7 +137,7 @@ export const useMenu = (): { menuItems: any[] } => {
         label: t('delete', { ns: 'common' }),
         onClick: async () => {
           const state = storeApi.getState();
-          await state.handleDelete(t as any, message, modal, state.onDelete);
+          await state.handleDelete(t as any, message, state.onDelete);
         },
       },
       {
@@ -185,7 +185,6 @@ export const useMenu = (): { menuItems: any[] } => {
     storeApi,
     t,
     message,
-    modal,
     setRightPanelMode,
     wideScreen,
     toggleWideScreen,

--- a/src/features/PageEditor/History/CompareModal/CompareContent.tsx
+++ b/src/features/PageEditor/History/CompareModal/CompareContent.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button, Flexbox, Text } from '@lobehub/ui';
-import { createStyles, cssVar } from 'antd-style';
+import { createStaticStyles, cssVar } from 'antd-style';
 import dayjs from 'dayjs';
 import { RotateCcwIcon } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
@@ -16,10 +16,10 @@ import DocumentHistoryDiff from '../DocumentHistoryDiff';
 import { formatHistoryAbsoluteTime } from '../formatHistoryDate';
 import HistorySidebar from './HistorySidebar';
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css }) => ({
   arrow: css`
     font-size: 12px;
-    color: ${token.colorTextTertiary};
+    color: ${cssVar.colorTextTertiary};
   `,
   badgeNew: css`
     display: inline-flex;
@@ -33,9 +33,9 @@ const useStyles = createStyles(({ css, token }) => ({
     font-size: 11px;
     font-weight: 600;
     line-height: 1.2;
-    color: ${token.colorSuccess};
+    color: ${cssVar.colorSuccess};
 
-    background: ${token.colorSuccessBg};
+    background: ${cssVar.colorSuccessBg};
   `,
   badgeOld: css`
     display: inline-flex;
@@ -48,9 +48,9 @@ const useStyles = createStyles(({ css, token }) => ({
     font-size: 11px;
     font-weight: 600;
     line-height: 1.2;
-    color: ${token.colorError};
+    color: ${cssVar.colorError};
 
-    background: ${token.colorErrorBg};
+    background: ${cssVar.colorErrorBg};
   `,
   cmpbar: css`
     display: flex;
@@ -59,9 +59,9 @@ const useStyles = createStyles(({ css, token }) => ({
 
     padding-block: 10px;
     padding-inline: 16px;
-    border-block-end: 1px solid ${token.colorBorderSecondary};
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
 
-    background: ${token.colorBgLayout};
+    background: ${cssVar.colorBgLayout};
   `,
   diffArea: css`
     overflow: hidden;
@@ -104,7 +104,6 @@ export interface CompareContentProps {
 const CompareContent = memo<CompareContentProps>(
   ({ documentId, initialHistoryId, items, onRestore, saveSourceLabels }) => {
     const { t } = useTranslation('file');
-    const { styles } = useStyles();
 
     const [selectedHistoryId, setSelectedHistoryId] = useState<string>(initialHistoryId);
 

--- a/src/features/PageEditor/History/CompareModal/HistorySidebar.tsx
+++ b/src/features/PageEditor/History/CompareModal/HistorySidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Flexbox, Tag, Text } from '@lobehub/ui';
-import { createStyles, cssVar, cx } from 'antd-style';
+import { createStaticStyles, cssVar, cx } from 'antd-style';
 import dayjs from 'dayjs';
 import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -13,7 +13,7 @@ import type {
 
 import { formatHistoryRowTime } from '../formatHistoryDate';
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css }) => ({
   container: css`
     overflow-y: auto;
     flex-shrink: 0;
@@ -21,9 +21,9 @@ const useStyles = createStyles(({ css, token }) => ({
     width: 232px;
     padding-block: 4px 12px;
     padding-inline: 8px;
-    border-inline-start: 1px solid ${token.colorBorderSecondary};
+    border-inline-start: 1px solid ${cssVar.colorBorderSecondary};
 
-    background: ${token.colorBgContainer};
+    background: ${cssVar.colorBgContainer};
   `,
   dot: css`
     position: absolute;
@@ -32,19 +32,19 @@ const useStyles = createStyles(({ css, token }) => ({
 
     width: 8px;
     height: 8px;
-    border: 1px solid ${token.colorBorder};
+    border: 1px solid ${cssVar.colorBorder};
     border-radius: 999px;
 
-    background: ${token.colorBgContainer};
-    box-shadow: 0 0 0 2px ${token.colorBgContainer};
+    background: ${cssVar.colorBgContainer};
+    box-shadow: 0 0 0 2px ${cssVar.colorBgContainer};
   `,
   dotCurrent: css`
-    border-color: ${token.colorSuccess};
-    background: ${token.colorSuccess};
+    border-color: ${cssVar.colorSuccess};
+    background: ${cssVar.colorSuccess};
   `,
   dotSelected: css`
-    border-color: ${token.colorPrimary};
-    background: ${token.colorPrimary};
+    border-color: ${cssVar.colorPrimary};
+    background: ${cssVar.colorPrimary};
   `,
   group: css`
     position: relative;
@@ -61,7 +61,7 @@ const useStyles = createStyles(({ css, token }) => ({
     font-weight: 500;
     line-height: 1.2;
 
-    background: ${token.colorBgContainer};
+    background: ${cssVar.colorBgContainer};
   `,
   item: css`
     cursor: pointer;
@@ -73,17 +73,17 @@ const useStyles = createStyles(({ css, token }) => ({
     transition: background ${cssVar.motionDurationMid} ${cssVar.motionEaseInOut};
 
     &:hover {
-      background: ${token.colorFillQuaternary};
+      background: ${cssVar.colorFillQuaternary};
     }
   `,
   itemCurrent: css`
     cursor: default;
   `,
   itemSelected: css`
-    background: ${token.colorFillSecondary};
+    background: ${cssVar.colorFillSecondary};
 
     &:hover {
-      background: ${token.colorFillSecondary};
+      background: ${cssVar.colorFillSecondary};
     }
   `,
   meta: css`
@@ -101,7 +101,7 @@ const useStyles = createStyles(({ css, token }) => ({
 
     width: 1px;
 
-    background: ${token.colorFillTertiary};
+    background: ${cssVar.colorFillTertiary};
   `,
   row: css`
     position: relative;
@@ -160,7 +160,6 @@ interface HistorySidebarProps {
 const HistorySidebar = memo<HistorySidebarProps>(
   ({ items, onSelect, saveSourceLabels, selectedHistoryId }) => {
     const { t } = useTranslation('file');
-    const { styles } = useStyles();
 
     const formatLabel = useCallback(
       (savedAt: string) => {

--- a/src/features/PageEditor/store/action.ts
+++ b/src/features/PageEditor/store/action.ts
@@ -1,4 +1,5 @@
 import { EDITOR_DEBOUNCE_TIME, EDITOR_MAX_WAIT, isDesktop } from '@lobechat/const';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import debug from 'debug';
 import { debounce } from 'es-toolkit/compat';
 import { type StateCreator } from 'zustand';
@@ -19,7 +20,6 @@ export interface Action {
   handleDelete: (
     t: (key: string) => string,
     message: any,
-    modal: any,
     onDeleteCallback?: () => void,
   ) => Promise<void>;
   handleTitleSubmit: () => Promise<void>;
@@ -75,12 +75,12 @@ export const store: (initState?: Partial<State>) => StateCreator<Store> =
         }
       },
 
-      handleDelete: async (t, message, modal, onDeleteCallback) => {
+      handleDelete: async (t, message, onDeleteCallback) => {
         const { documentId } = get();
         if (!documentId) return;
 
         return new Promise((resolve, reject) => {
-          modal.confirm({
+          confirmModal({
             cancelText: t('cancel'),
             content: t('pageEditor.deleteConfirm.content'),
             okButtonProps: { danger: true },

--- a/src/features/Pages/PageLayout/Body/List/Item/useDropdownMenu.tsx
+++ b/src/features/Pages/PageLayout/Body/List/Item/useDropdownMenu.tsx
@@ -1,5 +1,6 @@
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { CopyPlus, PanelTop, Pencil, Trash2 } from 'lucide-react';
 import { useCallback } from 'react';
@@ -20,14 +21,14 @@ export const useDropdownMenu = ({
   toggleEditing,
 }: ActionProps): (() => MenuProps['items']) => {
   const { t } = useTranslation(['common', 'file']);
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
   const navigate = useNavigate();
   const addTab = useElectronStore((s) => s.addTab);
   const removePage = usePageStore((s) => s.removePage);
   const duplicatePage = usePageStore((s) => s.duplicatePage);
 
   const handleDelete = () => {
-    modal.confirm({
+    confirmModal({
       cancelText: t('cancel'),
       content: t('pageEditor.deleteConfirm.content', { ns: 'file' }),
       okButtonProps: { danger: true },

--- a/src/features/Portal/Notebook/DocumentItem.tsx
+++ b/src/features/Portal/Notebook/DocumentItem.tsx
@@ -1,6 +1,6 @@
 import { type NotebookDocument } from '@lobechat/types';
 import { ActionIcon, Flexbox, Text } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import { FileTextIcon, Trash2Icon } from 'lucide-react';
 import { type MouseEvent } from 'react';
@@ -38,7 +38,6 @@ interface DocumentItemProps {
 
 const DocumentItem = memo<DocumentItemProps>(({ document, topicId }) => {
   const { t } = useTranslation('portal');
-  const { modal } = App.useApp();
   const [deleting, setDeleting] = useState(false);
 
   const openDocument = useChatStore((s) => s.openDocument);
@@ -51,8 +50,7 @@ const DocumentItem = memo<DocumentItemProps>(({ document, topicId }) => {
   const handleDelete = async (e: MouseEvent) => {
     e.stopPropagation();
 
-    modal.confirm({
-      centered: true,
+    confirmModal({
       okButtonProps: { danger: true },
       onOk: async () => {
         setDeleting(true);

--- a/src/features/ResourceManager/components/Explorer/Header/index.tsx
+++ b/src/features/ResourceManager/components/Explorer/Header/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ActionIcon, Flexbox } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { cssVar } from 'antd-style';
 import { BookMinusIcon, FileBoxIcon, Trash2Icon } from 'lucide-react';
@@ -25,7 +26,7 @@ import SearchInput from './SearchInput';
  */
 const Header = memo(() => {
   const { t } = useTranslation(['components', 'common', 'file', 'knowledgeBase']);
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
 
   // Get state and actions from store
   const [libraryId, category, onActionClick, selectAllState, selectFileIds] =
@@ -52,7 +53,7 @@ const Header = memo(() => {
           icon={BookMinusIcon}
           title={t('FileManager.actions.removeFromLibrary')}
           onClick={() => {
-            modal.confirm({
+            confirmModal({
               okButtonProps: {
                 danger: true,
               },
@@ -80,7 +81,7 @@ const Header = memo(() => {
         icon={Trash2Icon}
         title={t('delete', { ns: 'common' })}
         onClick={() => {
-          modal.confirm({
+          confirmModal({
             okButtonProps: {
               danger: true,
             },

--- a/src/features/ResourceManager/components/Explorer/ItemDropdown/useFileItemDropdown.tsx
+++ b/src/features/ResourceManager/components/Explorer/ItemDropdown/useFileItemDropdown.tsx
@@ -307,6 +307,7 @@ export const useFileItemDropdown = ({
                 ? t('FileManager.actions.confirmDeleteFolder')
                 : t('FileManager.actions.confirmDelete'),
               okButtonProps: { danger: true },
+              title: t('delete', { ns: 'common' }),
               onOk: async () => {
                 // Use optimistic delete - instant UI update, sync in background
                 await deleteResource(id);

--- a/src/features/ResourceManager/components/Explorer/ItemDropdown/useFileItemDropdown.tsx
+++ b/src/features/ResourceManager/components/Explorer/ItemDropdown/useFileItemDropdown.tsx
@@ -1,4 +1,5 @@
 import { copyToClipboard, createRawModal, Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { type ItemType } from 'antd/es/menu/interface';
 import {
@@ -54,7 +55,7 @@ export const useFileItemDropdown = ({
   onRenameStart,
 }: UseFileItemDropdownParams): UseFileItemDropdownReturn => {
   const { t } = useTranslation(['components', 'common', 'knowledgeBase']);
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
   const appOrigin = useAppOrigin();
 
   const { deleteResource, moveResource, refreshFileList } = useFileStore(
@@ -168,7 +169,7 @@ export const useFileItemDropdown = ({
               onClick: async ({ domEvent }) => {
                 domEvent.stopPropagation();
 
-                modal.confirm({
+                confirmModal({
                   okButtonProps: {
                     danger: true,
                   },
@@ -301,7 +302,7 @@ export const useFileItemDropdown = ({
           label: t('delete', { ns: 'common' }),
           onClick: async ({ domEvent }) => {
             domEvent.stopPropagation();
-            modal.confirm({
+            confirmModal({
               content: isFolder
                 ? t('FileManager.actions.confirmDeleteFolder')
                 : t('FileManager.actions.confirmDelete'),
@@ -335,7 +336,6 @@ export const useFileItemDropdown = ({
     libraries,
     libraryId,
     message,
-    modal,
     moveResource,
     onRenameStart,
     refreshFileList,

--- a/src/features/ResourceManager/components/Explorer/ToolBar/BatchActionsDropdown.tsx
+++ b/src/features/ResourceManager/components/Explorer/ToolBar/BatchActionsDropdown.tsx
@@ -1,5 +1,6 @@
 import { type DropdownItem } from '@lobehub/ui';
 import { DropdownMenu, Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import {
   BookMinusIcon,
@@ -33,7 +34,7 @@ interface BatchActionsDropdownProps {
 
 const BatchActionsDropdown = memo<BatchActionsDropdownProps>(({ selectCount, onActionClick }) => {
   const { t } = useTranslation(['components', 'common', 'file', 'knowledgeBase']);
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
 
   const libraryId = useResourceManagerStore((s) => s.libraryId);
   const [resolveSelectedResourceIds, selectAllState] = useResourceManagerStore((s) => [
@@ -54,7 +55,7 @@ const BatchActionsDropdown = memo<BatchActionsDropdownProps>(({ selectCount, onA
         key: 'deleteLibrary',
         label: t('header.actions.deleteLibrary', { ns: 'file' }),
         onClick: async () => {
-          modal.confirm({
+          confirmModal({
             okButtonProps: {
               danger: true,
             },
@@ -100,7 +101,7 @@ const BatchActionsDropdown = memo<BatchActionsDropdownProps>(({ selectCount, onA
         key: 'removeFromKnowledgeBase',
         label: t('FileManager.actions.removeFromLibrary'),
         onClick: () => {
-          modal.confirm({
+          confirmModal({
             okButtonProps: {
               danger: true,
             },
@@ -154,7 +155,7 @@ const BatchActionsDropdown = memo<BatchActionsDropdownProps>(({ selectCount, onA
         key: 'delete',
         label: t('delete', { ns: 'common' }),
         onClick: async () => {
-          modal.confirm({
+          confirmModal({
             okButtonProps: {
               danger: true,
             },
@@ -177,7 +178,6 @@ const BatchActionsDropdown = memo<BatchActionsDropdownProps>(({ selectCount, onA
     addFilesToKnowledgeBase,
     resolveSelectedResourceIds,
     t,
-    modal,
     message,
     knowledgeBases,
   ]);

--- a/src/features/ResourceManager/components/Explorer/ToolBar/MultiSelectActions.tsx
+++ b/src/features/ResourceManager/components/Explorer/ToolBar/MultiSelectActions.tsx
@@ -1,4 +1,5 @@
 import { Button, Checkbox, Flexbox, Icon, Skeleton } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { BookMinusIcon, BookPlusIcon, FileBoxIcon, Trash2Icon } from 'lucide-react';
@@ -34,7 +35,7 @@ const MultiSelectActions = memo<MultiSelectActionsProps>(
     const { t } = useTranslation(['components', 'common']);
 
     const isSelectedFiles = selectCount > 0;
-    const { modal, message } = App.useApp();
+    const { message } = App.useApp();
 
     const libraryId = useResourceManagerStore((s) => s.libraryId);
 
@@ -83,7 +84,7 @@ const MultiSelectActions = memo<MultiSelectActionsProps>(
                   icon={BookMinusIcon}
                   size={'small'}
                   onClick={() => {
-                    modal.confirm({
+                    confirmModal({
                       okButtonProps: {
                         danger: true,
                       },
@@ -142,7 +143,7 @@ const MultiSelectActions = memo<MultiSelectActionsProps>(
               size={'small'}
               variant={'filled'}
               onClick={async () => {
-                modal.confirm({
+                confirmModal({
                   okButtonProps: {
                     danger: true,
                   },

--- a/src/features/ResourceManager/components/Header/hooks/useUploadFolder.ts
+++ b/src/features/ResourceManager/components/Header/hooks/useUploadFolder.ts
@@ -1,3 +1,4 @@
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { type TFunction } from 'i18next';
 import { type ChangeEvent } from 'react';
 import { useCallback } from 'react';
@@ -55,16 +56,13 @@ const useUploadFolder = ({
           const gitignoreContent = await readGitignoreContent(gitignoreFile);
           const gitignoreOriginalCount = files.length;
 
-          const { Modal } = await import('antd');
-
-          Modal.confirm({
+          confirmModal({
             cancelText: t('header.actions.gitignore.cancel'),
             content: t('header.actions.gitignore.content', {
               count: gitignoreOriginalCount,
             }),
             okText: t('header.actions.gitignore.apply'),
             onCancel: () => {
-              // Upload without awaiting - let it run in background
               upload(files);
             },
             onOk: async () => {

--- a/src/features/RightPanel/ToggleRightPanelButton.tsx
+++ b/src/features/RightPanel/ToggleRightPanelButton.tsx
@@ -8,7 +8,7 @@ import { type ReactNode } from 'react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { useUserStore } from '@/store/user';
@@ -55,7 +55,7 @@ const ToggleRightPanelButton = memo<ToggleRightPanelButtonProps>(
         active={showActive ? expand : undefined}
         icon={icon || (expand ? PanelRightClose : PanelRightOpen)}
         id={TOGGLE_BUTTON_ID}
-        size={size || DESKTOP_HEADER_ICON_SIZE}
+        size={size || DESKTOP_HEADER_ICON_SMALL_SIZE}
         title={title || t('toggleRightPanel.title', { ns: 'hotkey' })}
         tooltipProps={{
           hotkey,

--- a/src/features/ShareModal/Modal.tsx
+++ b/src/features/ShareModal/Modal.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { type ConversationContext } from '@lobechat/types';
-import { type ModalInstance } from '@lobehub/ui';
-import { createModal, Flexbox, Segmented, Skeleton } from '@lobehub/ui';
+import { Flexbox, Segmented, Skeleton } from '@lobehub/ui';
+import { createModal, type ModalInstance } from '@lobehub/ui/base-ui';
 import { t } from 'i18next';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -92,21 +92,18 @@ export const openShareModal = ({
   context,
 }: OpenShareModalOptions = {}): ModalInstance =>
   createModal({
-    afterClose,
-    allowFullscreen: true,
-    centered: true,
-    children: (
+    content: (
       <ShareDataProvider context={context}>
         <ShareModalContent />
       </ShareDataProvider>
     ),
-    destroyOnHidden: true,
     footer: null,
-    height: '80vh',
+    maskClosable: true,
+    onOpenChangeComplete: (open) => {
+      if (!open) afterClose?.();
+    },
     styles: {
-      body: {
-        height: '80vh',
-      },
+      content: { height: 'min(80vh, 800px)' },
     },
     title: t('share', { ns: 'common' }),
     width: 'min(90vw, 1024px)',

--- a/src/features/ShareModal/useShareModal.tsx
+++ b/src/features/ShareModal/useShareModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { type ConversationContext } from '@lobechat/types';
-import { type ModalInstance } from '@lobehub/ui';
+import { type ModalInstance } from '@lobehub/ui/base-ui';
 import { useCallback, useEffect, useRef } from 'react';
 
 import { openShareModal as createShareModal } from './Modal';

--- a/src/features/SharePopover/index.tsx
+++ b/src/features/SharePopover/index.tsx
@@ -10,7 +10,7 @@ import {
   Text,
   usePopoverContext,
 } from '@lobehub/ui';
-import { Select } from '@lobehub/ui/base-ui';
+import { confirmModal, Select } from '@lobehub/ui/base-ui';
 import { App, Divider } from 'antd';
 import { ExternalLinkIcon, LinkIcon, LockIcon } from 'lucide-react';
 import { type ReactNode } from 'react';
@@ -36,7 +36,7 @@ interface SharePopoverContentProps {
 
 const SharePopoverContent = memo<SharePopoverContentProps>(({ onOpenModal, topicId }) => {
   const { t } = useTranslation('chat');
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
   const [updating, setUpdating] = useState(false);
   const { close } = usePopoverContext();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -97,9 +97,8 @@ const SharePopoverContent = memo<SharePopoverContentProps>(({ onOpenModal, topic
       ) {
         let doNotShowAgain = false;
 
-        modal.confirm({
+        confirmModal({
           cancelText: t('cancel', { ns: 'common' }),
-          centered: true,
           content: (
             <div>
               <p>{t('shareModal.popover.privacyWarning.content')}</p>
@@ -122,7 +121,6 @@ const SharePopoverContent = memo<SharePopoverContentProps>(({ onOpenModal, topic
             updateVisibility(visibility);
           },
           title: t('shareModal.popover.privacyWarning.title'),
-          type: 'warning',
         });
       } else {
         updateVisibility(visibility);
@@ -131,7 +129,6 @@ const SharePopoverContent = memo<SharePopoverContentProps>(({ onOpenModal, topic
     [
       currentVisibility,
       hideTopicSharePrivacyWarning,
-      modal,
       t,
       updateSystemStatus,
       updateVisibility,

--- a/src/features/SkillStore/SkillList/AgentSkillItem.tsx
+++ b/src/features/SkillStore/SkillList/AgentSkillItem.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { ActionIcon, Block, DropdownMenu, Flexbox, Icon, Modal, Tag } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
-import { App } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { DownloadIcon, MoreVerticalIcon, PackageSearch, Trash2 } from 'lucide-react';
 import { lazy, memo, Suspense, useState } from 'react';
@@ -44,7 +44,6 @@ interface AgentSkillItemProps {
 const AgentSkillItem = memo<AgentSkillItemProps>(({ skill }) => {
   const { t } = useTranslation('plugin');
   const { t: tc } = useTranslation('common');
-  const { modal } = App.useApp();
   const [detailOpen, setDetailOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -65,14 +64,12 @@ const AgentSkillItem = memo<AgentSkillItemProps>(({ skill }) => {
   };
 
   const handleDelete = () => {
-    modal.confirm({
-      centered: true,
+    confirmModal({
       okButtonProps: { danger: true },
       onOk: async () => {
         await deleteAgentSkill(skill.id);
       },
       title: t('store.actions.confirmUninstall'),
-      type: 'error',
     });
   };
 

--- a/src/features/SkillStore/SkillList/Builtin/Item.tsx
+++ b/src/features/SkillStore/SkillList/Builtin/Item.tsx
@@ -9,7 +9,7 @@ import {
   Icon,
   stopPropagation,
 } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { MoreVerticalIcon, Plus, Trash2 } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -30,7 +30,6 @@ interface ItemProps {
 const Item = memo<ItemProps>(({ avatar, description, identifier, onOpenDetail, title }) => {
   const { t } = useTranslation(['setting', 'plugin']);
   const styles = itemStyles;
-  const { modal } = App.useApp();
 
   const [installBuiltinTool, uninstallBuiltinTool, isInstalled] = useToolStore((s) => [
     s.installBuiltinTool,
@@ -43,14 +42,12 @@ const Item = memo<ItemProps>(({ avatar, description, identifier, onOpenDetail, t
   };
 
   const handleUninstall = () => {
-    modal.confirm({
-      centered: true,
+    confirmModal({
       okButtonProps: { danger: true },
       onOk: async () => {
         await uninstallBuiltinTool(identifier);
       },
       title: t('store.actions.confirmUninstall', { ns: 'plugin' }),
-      type: 'error',
     });
   };
 

--- a/src/features/SkillStore/SkillList/Community/Item.tsx
+++ b/src/features/SkillStore/SkillList/Community/Item.tsx
@@ -9,7 +9,8 @@ import {
   Modal,
   stopPropagation,
 } from '@lobehub/ui';
-import { App, Button } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
+import { Button } from 'antd';
 import isEqual from 'fast-deep-equal';
 import { MoreVerticalIcon, Plus, Trash2 } from 'lucide-react';
 import React, { memo, Suspense, useState } from 'react';
@@ -32,7 +33,6 @@ import { itemStyles } from '../style';
 const Item = memo<DiscoverMcpItem>(({ name, description, icon, identifier }) => {
   const styles = itemStyles;
   const { t } = useTranslation('plugin');
-  const { modal } = App.useApp();
   const [detailOpen, setDetailOpen] = useState(false);
 
   const [installed, installing, installMCPPlugin, cancelInstallMCPPlugin, unInstallPlugin, plugin] =
@@ -91,8 +91,7 @@ const Item = memo<DiscoverMcpItem>(({ name, description, icon, identifier }) => 
               key: 'uninstall',
               label: t('store.actions.uninstall'),
               onClick: () => {
-                modal.confirm({
-                  centered: true,
+                confirmModal({
                   okButtonProps: { danger: true },
                   onOk: async () => {
                     if (isPluginEnabledInAgent) {
@@ -101,7 +100,6 @@ const Item = memo<DiscoverMcpItem>(({ name, description, icon, identifier }) => 
                     await unInstallPlugin(identifier);
                   },
                   title: t('store.actions.confirmUninstall'),
-                  type: 'error',
                 });
               },
             },

--- a/src/features/SkillStore/SkillList/Community/MarketSkillItem.tsx
+++ b/src/features/SkillStore/SkillList/Community/MarketSkillItem.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { ActionIcon, Avatar, Block, DropdownMenu, Flexbox, Icon, Modal, Tag } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
-import { App } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { DownloadIcon, Loader2, MoreVerticalIcon, Plus, Trash2 } from 'lucide-react';
 import { lazy, memo, Suspense, useCallback, useState } from 'react';
@@ -42,7 +42,6 @@ const MarketSkillItem = memo<DiscoverSkillItem>(({ name, icon, description, iden
   const [detailOpen, setDetailOpen] = useState(false);
   const [installing, setInstalling] = useState(false);
   const [loading, setLoading] = useState(false);
-  const { modal } = App.useApp();
 
   const installed = useToolStore(agentSkillsSelectors.isAgentSkill(identifier));
   const installedSkill = useToolStore(agentSkillsSelectors.getAgentSkillByIdentifier(identifier));
@@ -66,16 +65,14 @@ const MarketSkillItem = memo<DiscoverSkillItem>(({ name, icon, description, iden
 
   const handleUninstall = useCallback(() => {
     if (!installedSkill) return;
-    modal.confirm({
-      centered: true,
+    confirmModal({
       okButtonProps: { danger: true },
       onOk: async () => {
         await deleteAgentSkill(installedSkill.id);
       },
       title: t('store.actions.confirmUninstall'),
-      type: 'error',
     });
-  }, [installedSkill, deleteAgentSkill, modal, t]);
+  }, [installedSkill, deleteAgentSkill, t]);
 
   const handleDownload = useCallback(async () => {
     if (!installedSkill?.zipFileHash) return;

--- a/src/features/SkillStore/SkillList/Custom/Item.tsx
+++ b/src/features/SkillStore/SkillList/Custom/Item.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ActionIcon, Block, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { MoreVerticalIcon, PackageSearch, Trash2 } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -45,7 +45,6 @@ interface ItemProps {
 
 const Item = memo<ItemProps>(({ identifier, title, description, avatar }) => {
   const { t } = useTranslation('plugin');
-  const { modal } = App.useApp();
   const [configOpen, setConfigOpen] = useState(false);
   const [detailOpen, setDetailOpen] = useState(false);
 
@@ -62,8 +61,7 @@ const Item = memo<ItemProps>(({ identifier, title, description, avatar }) => {
   ]);
 
   const handleDelete = () => {
-    modal.confirm({
-      centered: true,
+    confirmModal({
       okButtonProps: { danger: true },
       onOk: async () => {
         if (isPluginEnabledInAgent) {
@@ -72,7 +70,6 @@ const Item = memo<ItemProps>(({ identifier, title, description, avatar }) => {
         await uninstallPlugin(identifier);
       },
       title: t('store.actions.confirmUninstall'),
-      type: 'error',
     });
   };
 

--- a/src/features/SkillStore/SkillList/LobeHub/Item.tsx
+++ b/src/features/SkillStore/SkillList/LobeHub/Item.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ActionIcon, Block, DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import type { Klavis } from 'klavis';
 import { Loader2, MoreVerticalIcon, Plus, Unplug } from 'lucide-react';
@@ -26,7 +26,6 @@ const Item = memo<ItemProps>(
   ({ description, icon, identifier, label, onOpenDetail, serverName, type }) => {
     const { t } = useTranslation('setting');
     const styles = itemStyles;
-    const { modal } = App.useApp();
 
     const { handleConnect, handleDisconnect, isConnected, isConnecting } = useSkillConnect({
       identifier,
@@ -42,9 +41,8 @@ const Item = memo<ItemProps>(
     });
 
     const confirmDisconnect = () => {
-      modal.confirm({
+      confirmModal({
         cancelText: t('cancel', { ns: 'common' }),
-        centered: true,
         content: t('tools.lobehubSkill.disconnectConfirm.desc', { name: label }),
         okButtonProps: { danger: true },
         okText: t('tools.lobehubSkill.disconnect'),

--- a/src/features/WideScreenContainer/WideScreenButton.tsx
+++ b/src/features/WideScreenContainer/WideScreenButton.tsx
@@ -5,7 +5,7 @@ import { PanelLeftRightDashedIcon, SquareChartGanttIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 
@@ -20,7 +20,7 @@ const WideScreenButton = memo(() => {
   return (
     <ActionIcon
       icon={wideScreen ? SquareChartGanttIcon : PanelLeftRightDashedIcon}
-      size={DESKTOP_HEADER_ICON_SIZE}
+      size={DESKTOP_HEADER_ICON_SMALL_SIZE}
       title={t(wideScreen ? 'toggleWideScreen.off' : 'toggleWideScreen.on')}
       tooltipProps={{
         placement: 'bottom',

--- a/src/layout/AuthProvider/MarketAuth/ProfileSetupModal.tsx
+++ b/src/layout/AuthProvider/MarketAuth/ProfileSetupModal.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { Center, Flexbox, Icon, Input, Text, TextArea, Tooltip } from '@lobehub/ui';
-import { Modal } from '@lobehub/ui/base-ui';
+import { confirmModal, Modal } from '@lobehub/ui/base-ui';
 import { type UploadProps } from 'antd';
-import { App, Form, Modal as AntModal, Upload } from 'antd';
+import { App, Form, Upload } from 'antd';
 import { cssVar } from 'antd-style';
 import { CircleHelp, Globe, ImagePlus, Trash2 } from 'lucide-react';
 import { memo, useCallback, useEffect, useState } from 'react';
@@ -332,7 +332,7 @@ const ProfileSetupModal = memo<ProfileSetupModalProps>(
 
         // If userName changed and it's not first-time setup, show confirmation
         if (!isFirstTimeSetup && oldUserName && values.userName !== oldUserName) {
-          AntModal.confirm({
+          confirmModal({
             cancelText: t('profileSetup.confirmChangeUserId.cancel'),
             content: t('profileSetup.confirmChangeUserId.description', {
               newId: values.userName,

--- a/src/layout/AuthProvider/MarketAuth/ProfileSetupModal.tsx
+++ b/src/layout/AuthProvider/MarketAuth/ProfileSetupModal.tsx
@@ -369,20 +369,22 @@ const ProfileSetupModal = memo<ProfileSetupModalProps>(
         maskClosable={!isFirstTimeSetup}
         okText={isFirstTimeSetup ? t('profileSetup.getStarted') : t('profileSetup.save')}
         open={open}
-        title={false}
         width={640}
+        title={
+          <Flexbox gap={4}>
+            <Text strong fontSize={16} lineHeight={1.4}>
+              {isFirstTimeSetup ? t('profileSetup.titleFirstTime') : t('profileSetup.titleEdit')}
+            </Text>
+            <Text fontSize={13} lineHeight={1.4} type="secondary">
+              {isFirstTimeSetup
+                ? t('profileSetup.descriptionFirstTime')
+                : t('profileSetup.descriptionEdit')}
+            </Text>
+          </Flexbox>
+        }
         onCancel={handleCancel}
         onOk={handleSubmit}
       >
-        <Text strong fontSize={20} style={{ marginTop: 16 }}>
-          {isFirstTimeSetup ? t('profileSetup.titleFirstTime') : t('profileSetup.titleEdit')}
-        </Text>
-        <Text style={{ display: 'block', marginBottom: 24 }} type="secondary">
-          {isFirstTimeSetup
-            ? t('profileSetup.descriptionFirstTime')
-            : t('profileSetup.descriptionEdit')}
-        </Text>
-
         <Form form={form} layout="vertical">
           <Flexbox horizontal gap={24}>
             <Flexbox flex={1}>

--- a/src/routes/(main)/(create)/features/GenerationLayout/Body/List/Item/index.tsx
+++ b/src/routes/(main)/(create)/features/GenerationLayout/Body/List/Item/index.tsx
@@ -2,7 +2,7 @@
 
 import { Icon } from '@lobehub/ui';
 import { type MenuProps } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { Trash } from 'lucide-react';
 import type { CSSProperties } from 'react';
 import { memo, useState } from 'react';
@@ -23,7 +23,6 @@ interface TopicItemProps {
 const TopicItem = memo<TopicItemProps>(({ topic, showMoreInfo, style }) => {
   const { useStore, namespace } = useGenerationTopicContext();
   const { t } = useTranslation(namespace);
-  const { modal } = App.useApp();
   const [isUpdating, setIsUpdating] = useState(false);
   const isLoading = useStore((s) => s.loadingGenerationTopicIds.includes(topic.id));
   const removeGenerationTopic = useStore((s) => s.removeGenerationTopic);
@@ -40,7 +39,7 @@ const TopicItem = memo<TopicItemProps>(({ topic, showMoreInfo, style }) => {
     e.stopPropagation();
     e.preventDefault();
 
-    modal.confirm({
+    confirmModal({
       cancelText: t('cancel', { ns: 'common' }),
       content: t('topic.deleteConfirmDesc'),
       okButtonProps: { danger: true },
@@ -65,7 +64,7 @@ const TopicItem = memo<TopicItemProps>(({ topic, showMoreInfo, style }) => {
       key: 'delete',
       label: t('delete', { ns: 'common' }),
       onClick: () => {
-        modal.confirm({
+        confirmModal({
           cancelText: t('cancel', { ns: 'common' }),
           content: t('topic.deleteConfirmDesc'),
           okButtonProps: { danger: true },

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
@@ -26,13 +26,6 @@ vi.mock('antd-style', () => ({
     neonDot: 'neonDot',
     neonDotWrapper: 'neonDotWrapper',
   }),
-  createStyles: () => () => ({
-    cx: (...classNames: Array<false | string | undefined>) => classNames.filter(Boolean).join(' '),
-    styles: {
-      container: 'container',
-      dot: 'dot',
-    },
-  }),
   cssVar: {
     colorInfo: '#00f',
     colorTextDescription: '#999',

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -1,6 +1,7 @@
 import type { ChatTopicStatus } from '@lobechat/types';
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import {
   CheckCircle2,
@@ -44,7 +45,7 @@ export const useTopicItemDropdownMenu = ({
   title,
 }: TopicItemDropdownMenuProps) => {
   const { t } = useTranslation(['topic', 'common']);
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
   const navigate = useNavigate();
 
   const openTopicInNewWindow = useGlobalStore((s) => s.openTopicInNewWindow);
@@ -205,8 +206,7 @@ export const useTopicItemDropdownMenu = ({
         key: 'delete',
         label: t('delete', { ns: 'common' }),
         onClick: () => {
-          modal.confirm({
-            centered: true,
+          confirmModal({
             okButtonProps: { danger: true },
             onOk: async () => {
               await removeTopic(id);
@@ -234,7 +234,6 @@ export const useTopicItemDropdownMenu = ({
     addTab,
     navigate,
     t,
-    modal,
     message,
     handleOpenShareModal,
   ]);

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
@@ -1,6 +1,6 @@
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { PencilLine, Trash } from 'lucide-react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -17,7 +17,6 @@ export const useThreadItemDropdownMenu = ({
   toggleEditing,
 }: ThreadItemDropdownMenuProps): (() => MenuProps['items']) => {
   const { t } = useTranslation(['thread', 'common']);
-  const { modal } = App.useApp();
 
   const [removeThread] = useChatStore((s) => [s.removeThread]);
 
@@ -40,8 +39,7 @@ export const useThreadItemDropdownMenu = ({
         key: 'delete',
         label: t('delete', { ns: 'common' }),
         onClick: () => {
-          modal.confirm({
-            centered: true,
+          confirmModal({
             okButtonProps: { danger: true },
             onOk: async () => {
               await removeThread(id);
@@ -51,5 +49,5 @@ export const useThreadItemDropdownMenu = ({
         },
       },
     ].filter(Boolean) as MenuProps['items'];
-  }, [id, removeThread, toggleEditing, t, modal]);
+  }, [id, removeThread, toggleEditing, t]);
 };

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/useDropdownMenu.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/useDropdownMenu.tsx
@@ -1,5 +1,6 @@
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App, Upload } from 'antd';
 import { css, cx } from 'antd-style';
 import { Hash, Import, LucideCheck, Trash } from 'lucide-react';
@@ -100,9 +101,8 @@ export const useTopicActionsDropdownMenu = (
         key: 'deleteUnstarred',
         label: t('actions.removeUnstarred'),
         onClick: () => {
-          modal.confirm({
+          confirmModal({
             cancelText: t('cancel', { ns: 'common' }),
-            centered: true,
             okButtonProps: { danger: true },
             okText: t('ok', { ns: 'common' }),
             onOk: removeUnstarredTopic,
@@ -116,9 +116,8 @@ export const useTopicActionsDropdownMenu = (
         key: 'deleteAll',
         label: t('actions.removeAll'),
         onClick: () => {
-          modal.confirm({
+          confirmModal({
             cancelText: t('cancel', { ns: 'common' }),
-            centered: true,
             okButtonProps: { danger: true },
             okText: t('ok', { ns: 'common' }),
             onOk: removeAllTopic,

--- a/src/routes/(main)/agent/channel/detail/index.tsx
+++ b/src/routes/(main)/agent/channel/detail/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App, Form } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
@@ -69,7 +70,7 @@ interface PlatformDetailProps {
 const PlatformDetail = memo<PlatformDetailProps>(
   ({ platformDef, agentId, currentConfig, runtimeStatus }) => {
     const { t } = useTranslation('agent');
-    const { message: msg, modal } = App.useApp();
+    const { message: msg } = App.useApp();
     const [form] = Form.useForm<ChannelFormValues>();
 
     const [
@@ -402,7 +403,7 @@ const PlatformDetail = memo<PlatformDetailProps>(
     const handleDelete = useCallback(async () => {
       if (!currentConfig) return;
 
-      modal.confirm({
+      confirmModal({
         content: t('channel.deleteConfirmDesc'),
         okButtonProps: { danger: true },
         onOk: async () => {
@@ -416,7 +417,7 @@ const PlatformDetail = memo<PlatformDetailProps>(
         },
         title: t('channel.deleteConfirm'),
       });
-    }, [currentConfig, agentId, deleteBotProvider, msg, t, modal, form]);
+    }, [currentConfig, agentId, deleteBotProvider, msg, t, form]);
 
     const handleToggleEnable = useCallback(
       async (enabled: boolean) => {

--- a/src/routes/(main)/agent/channel/list.tsx
+++ b/src/routes/(main)/agent/channel/list.tsx
@@ -2,6 +2,7 @@
 
 import { exportJSONFile } from '@lobechat/utils/client';
 import { Icon, Tag } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App, Dropdown, type MenuProps } from 'antd';
 import { createStaticStyles, cx, useTheme } from 'antd-style';
 import { Book, Download, MoreHorizontal, Trash2, Upload } from 'lucide-react';
@@ -88,7 +89,7 @@ const PlatformList = memo<PlatformListProps>(
   ({ platforms, activeId, agentId, onSelect, providers, runtimeStatuses }) => {
     const { t } = useTranslation('agent');
     const theme = useTheme();
-    const { modal, message } = App.useApp();
+    const { message } = App.useApp();
     const fileInputRef = useRef<HTMLInputElement>(null);
     const deleteAllBotProviders = useAgentStore((s) => s.deleteAllBotProviders);
     const createBotProvider = useAgentStore((s) => s.createBotProvider);
@@ -154,7 +155,7 @@ const PlatformList = memo<PlatformListProps>(
 
     const handleDeleteAll = useCallback(() => {
       if (!providers?.length) return;
-      modal.confirm({
+      confirmModal({
         content: t('channel.deleteAllConfirmDesc'),
         okButtonProps: { danger: true },
         okText: t('channel.deleteAllChannels'),
@@ -167,9 +168,8 @@ const PlatformList = memo<PlatformListProps>(
           }
         },
         title: t('channel.deleteAllConfirm'),
-        type: 'warning',
       });
-    }, [agentId, deleteAllBotProviders, message, modal, providers, t]);
+    }, [agentId, deleteAllBotProviders, message, providers, t]);
 
     const hasProviders = !!providers?.length;
     const menuItems: MenuProps['items'] = [

--- a/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/useMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/useMenu.tsx
@@ -36,7 +36,7 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 
 export const useMenu = (): { menuItems: DropdownItem[] } => {
   const { t } = useTranslation(['chat', 'topic', 'common', 'file']);
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
   const { pathname } = useLocation();
 
   const [wideScreen, toggleWideScreen] = useGlobalStore((s) => [
@@ -260,8 +260,7 @@ export const useMenu = (): { menuItems: DropdownItem[] } => {
           key: 'delete',
           label: t('delete', { ns: 'common' }),
           onClick: () => {
-            modal.confirm({
-              centered: true,
+            confirmModal({
               okButtonProps: { danger: true },
               onOk: async () => {
                 await removeTopic(topicId);
@@ -291,7 +290,6 @@ export const useMenu = (): { menuItems: DropdownItem[] } => {
     toggleWideScreen,
     openCompareModal,
     t,
-    modal,
     message,
   ]);
 

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx
@@ -10,6 +10,10 @@ const messageError = vi.hoisted(() => vi.fn());
 const messageSuccess = vi.hoisted(() => vi.fn());
 const removeDocumentMock = vi.hoisted(() => vi.fn());
 
+vi.mock('@lobehub/ui/base-ui', () => ({
+  confirmModal: modalConfirm,
+}));
+
 vi.mock('@lobehub/ui', () => ({
   Accordion: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   AccordionItem: ({ children, title }: { children?: ReactNode; title?: ReactNode }) => (
@@ -45,7 +49,6 @@ vi.mock('antd', () => ({
   App: {
     useApp: () => ({
       message: { error: messageError, success: messageSuccess },
-      modal: { confirm: modalConfirm },
     }),
   },
 }));

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx
@@ -1,5 +1,6 @@
 import { buildAgentSkillIdentifier } from '@lobechat/const';
 import { ActionIcon, Center, Empty, Flexbox, Text } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
 import { App } from 'antd';
 import { createStaticStyles, cx } from 'antd-style';
@@ -112,7 +113,7 @@ interface DocumentItemProps {
 const DocumentItem = memo<DocumentItemProps>(
   ({ agentId, document, hideDelete = false, mutate }) => {
     const { t } = useTranslation(['chat', 'common']);
-    const { message, modal } = App.useApp();
+    const { message } = App.useApp();
     const [deleting, setDeleting] = useState(false);
     const openDocument = useChatStore((s) => s.openDocument);
     const closeDocument = useChatStore((s) => s.closeDocument);
@@ -138,11 +139,10 @@ const DocumentItem = memo<DocumentItemProps>(
 
     const handleDelete = (e: MouseEvent) => {
       e.stopPropagation();
-      modal.confirm({
+      confirmModal({
         cancelText: t('cancel', { ns: 'common' }),
-        centered: true,
         content: t('workingPanel.resources.deleteConfirm', { ns: 'chat' }),
-        okButtonProps: { danger: true, type: 'primary' },
+        okButtonProps: { danger: true },
         okText: t('delete', { ns: 'common' }),
         onOk: async () => {
           setDeleting(true);

--- a/src/routes/(main)/agent/profile/features/Header/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.test.tsx
@@ -67,6 +67,10 @@ vi.mock('@lobehub/ui/icons', () => ({
   ShapesUploadIcon: () => null,
 }));
 
+vi.mock('@lobehub/ui/base-ui', () => ({
+  confirmModal: vi.fn(),
+}));
+
 vi.mock('antd', () => ({
   App: {
     useApp: () => ({

--- a/src/routes/(main)/agent/profile/features/Header/index.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.tsx
@@ -1,6 +1,6 @@
 import { ActionIcon, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { ShapesUploadIcon } from '@lobehub/ui/icons';
-import { App, Modal } from 'antd';
 import isEqual from 'fast-deep-equal';
 import { BotMessageSquareIcon, MoreHorizontal, Settings2Icon, Trash } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
@@ -29,7 +29,6 @@ import AutoSaveHint from './AutoSaveHint';
 
 const Header = memo(() => {
   const { t } = useTranslation(['setting', 'marketAuth', 'chat']);
-  const { modal } = App.useApp();
   const navigate = useNavigate();
 
   const meta = useAgentStore(agentSelectors.currentAgentMeta, isEqual);
@@ -97,8 +96,7 @@ const Header = memo(() => {
       return;
     }
 
-    Modal.confirm({
-      okButtonProps: { type: 'primary' },
+    confirmModal({
       onOk: async () => {
         if (!isAuthenticated) {
           try {
@@ -128,8 +126,7 @@ const Header = memo(() => {
 
   const handleDelete = useCallback(() => {
     if (!activeAgentId) return;
-    modal.confirm({
-      centered: true,
+    confirmModal({
       okButtonProps: { danger: true },
       onOk: async () => {
         await removeAgent(activeAgentId);
@@ -138,7 +135,7 @@ const Header = memo(() => {
       },
       title: t('confirmRemoveSessionItemAlert', { ns: 'chat' }),
     });
-  }, [activeAgentId, modal, navigate, removeAgent, t]);
+  }, [activeAgentId, navigate, removeAgent, t]);
 
   const menuItems = useMemo(
     () => [

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/CloudHeterogeneousConfig.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/CloudHeterogeneousConfig.tsx
@@ -4,7 +4,7 @@ import { type HeterogeneousProviderConfig, type UserCredSummary } from '@lobecha
 import { Github } from '@lobehub/icons';
 import { Flexbox } from '@lobehub/ui';
 import { Avatar, Button, Input, Select, Spin, Tag, Typography } from 'antd';
-import { createStyles } from 'antd-style';
+import { createStaticStyles, cssVar } from 'antd-style';
 import { CheckCircle2, KeyRound, X } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -15,14 +15,14 @@ import { lambdaClient, lambdaQuery } from '@/libs/trpc/client';
 // Fixed cred key for Claude Code OAuth token — never changes
 const CLAUDE_TOKEN_CRED_KEY = 'CLAUDE_CODE_OAUTH_TOKEN';
 
-const useStyles = createStyles(({ css, token, cssVar }) => ({
+const styles = createStaticStyles(({ css }) => ({
   card: css`
     padding-block: 16px 12px;
     padding-inline: 16px;
-    border: 1px solid ${token.colorBorderSecondary};
-    border-radius: ${token.borderRadiusLG}px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusLG};
 
-    background: ${token.colorBgContainer};
+    background: ${cssVar.colorBgContainer};
   `,
   credOption: css`
     display: flex;
@@ -48,12 +48,12 @@ const useStyles = createStyles(({ css, token, cssVar }) => ({
     min-height: 36px;
     padding-block: 6px;
     padding-inline: 8px;
-    border-radius: ${token.borderRadiusSM}px;
+    border-radius: ${cssVar.borderRadiusSM};
 
     transition: background 0.15s;
 
     &:hover {
-      background: ${token.colorFillTertiary};
+      background: ${cssVar.colorFillTertiary};
 
       .repo-delete-btn {
         opacity: 1;
@@ -61,7 +61,7 @@ const useStyles = createStyles(({ css, token, cssVar }) => ({
     }
   `,
   repoItemActive: css`
-    background: ${token.colorFillSecondary};
+    background: ${cssVar.colorFillSecondary};
   `,
   repoDeleteBtn: css`
     cursor: pointer;
@@ -73,7 +73,7 @@ const useStyles = createStyles(({ css, token, cssVar }) => ({
     border: none;
     border-radius: 4px;
 
-    color: ${token.colorTextTertiary};
+    color: ${cssVar.colorTextTertiary};
 
     opacity: 0;
     background: transparent;
@@ -83,7 +83,7 @@ const useStyles = createStyles(({ css, token, cssVar }) => ({
       color 0.15s;
 
     &:hover {
-      color: ${token.colorError};
+      color: ${cssVar.colorError};
     }
   `,
   repoList: css`
@@ -93,15 +93,15 @@ const useStyles = createStyles(({ css, token, cssVar }) => ({
   `,
   sectionDesc: css`
     font-size: 12px;
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
   `,
   sectionDivider: css`
     margin-block: 12px;
-    border-block-start: 1px solid ${token.colorBorderSecondary};
+    border-block-start: 1px solid ${cssVar.colorBorderSecondary};
   `,
   sectionLabel: css`
     font-size: 12px;
-    color: ${token.colorTextTertiary};
+    color: ${cssVar.colorTextTertiary};
     text-transform: uppercase;
     letter-spacing: 0.04em;
   `,
@@ -121,7 +121,6 @@ interface TokenSectionProps {
 
 const TokenSection = memo<TokenSectionProps>(({ existingCred, onSaved, onEnvChange }) => {
   const { t } = useTranslation('setting');
-  const { styles } = useStyles();
   const [editing, setEditing] = useState(!existingCred);
   const [tokenInput, setTokenInput] = useState('');
   const [saving, setSaving] = useState(false);
@@ -211,7 +210,6 @@ interface RepoListSectionProps {
 
 const RepoListSection = memo<RepoListSectionProps>(({ repos, onReposChange }) => {
   const { t } = useTranslation('setting');
-  const { styles } = useStyles();
   const [input, setInput] = useState('');
 
   const addRepo = () => {
@@ -269,7 +267,6 @@ const RepoListSection = memo<RepoListSectionProps>(({ repos, onReposChange }) =>
 const CloudHeterogeneousConfig = memo<CloudHeterogeneousConfigProps>(
   ({ provider, onEnvChange }) => {
     const { t } = useTranslation('setting');
-    const { styles } = useStyles();
     const navigate = useNavigate();
 
     const currentEnv = provider.env ?? {};

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/HeterogeneousAgentStatusCard.test.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/HeterogeneousAgentStatusCard.test.tsx
@@ -83,13 +83,12 @@ vi.mock('@lobehub/ui', () => ({
 }));
 
 vi.mock('antd-style', () => ({
-  createStyles: () => () => ({
-    styles: {
-      card: 'card',
-      label: 'label',
-      path: 'path',
-    },
+  createStaticStyles: () => ({
+    card: 'card',
+    label: 'label',
+    path: 'path',
   }),
+  cssVar: new Proxy({}, { get: (_, key) => `var(--${String(key)})` }),
 }));
 
 vi.mock('lucide-react', () => ({

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/HeterogeneousAgentStatusCard.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/HeterogeneousAgentStatusCard.tsx
@@ -8,7 +8,7 @@ import {
 } from '@lobechat/heterogeneous-agents/client';
 import type { HeterogeneousProviderConfig } from '@lobechat/types';
 import { ActionIcon, CopyButton, Flexbox, Icon, Input, Tag, Text, Tooltip } from '@lobehub/ui';
-import { createStyles } from 'antd-style';
+import { createStaticStyles, cssVar } from 'antd-style';
 import { Loader2Icon, PencilLine, RefreshCw, XCircle } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -19,14 +19,14 @@ import { toolDetectorService } from '@/services/electron/toolDetector';
 
 const COMMAND_LINE_HEIGHT = 28;
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css }) => ({
   card: css`
     padding-block: 16px 4px;
     padding-inline: 16px;
-    border: 1px solid ${token.colorBorderSecondary};
-    border-radius: ${token.borderRadiusLG}px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusLG};
 
-    background: ${token.colorBgContainer};
+    background: ${cssVar.colorBgContainer};
   `,
   cardHeader: css`
     display: flex;
@@ -57,7 +57,7 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
   metaText: css`
     font-size: 13px;
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
   `,
   pathWrap: css`
     display: flex;
@@ -69,7 +69,7 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
   detailList: css`
     margin-block-start: 4px;
-    border-block-start: 1px solid ${token.colorBorderSecondary};
+    border-block-start: 1px solid ${cssVar.colorBorderSecondary};
   `,
   detailRow: css`
     display: flex;
@@ -80,7 +80,7 @@ const useStyles = createStyles(({ css, token }) => ({
     padding-block: 8px;
 
     & + & {
-      border-block-start: 1px solid ${token.colorBorderSecondary};
+      border-block-start: 1px solid ${cssVar.colorBorderSecondary};
     }
   `,
   detailLabel: css`
@@ -89,7 +89,7 @@ const useStyles = createStyles(({ css, token }) => ({
     width: 96px;
 
     font-size: 12px;
-    color: ${token.colorTextTertiary};
+    color: ${cssVar.colorTextTertiary};
     text-transform: uppercase;
     letter-spacing: 0.04em;
   `,
@@ -111,7 +111,7 @@ const useStyles = createStyles(({ css, token }) => ({
   `,
   commandInput: css`
     width: 100%;
-    font-family: ${token.fontFamilyCode};
+    font-family: ${cssVar.fontFamilyCode};
 
     &,
     &.ant-input,
@@ -127,7 +127,7 @@ const useStyles = createStyles(({ css, token }) => ({
       max-height: ${COMMAND_LINE_HEIGHT}px;
       border-radius: 999px !important;
 
-      font-family: ${token.fontFamilyCode};
+      font-family: ${cssVar.fontFamilyCode};
       font-size: 14px;
       line-height: ${COMMAND_LINE_HEIGHT - 2}px;
     }
@@ -174,10 +174,10 @@ const useStyles = createStyles(({ css, token }) => ({
     height: ${COMMAND_LINE_HEIGHT}px;
     padding-block: 0;
     padding-inline: 12px;
-    border: 1px solid ${token.colorBorderSecondary};
+    border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: 999px;
 
-    background: ${token.colorFillSecondary};
+    background: ${cssVar.colorFillSecondary};
   `,
   commandEditButton: css`
     pointer-events: none;
@@ -187,23 +187,23 @@ const useStyles = createStyles(({ css, token }) => ({
   commandText: css`
     min-width: 0;
 
-    font-family: ${token.fontFamilyCode};
+    font-family: ${cssVar.fontFamilyCode};
     font-size: 14px;
     line-height: 20px;
-    color: ${token.colorText};
+    color: ${cssVar.colorText};
   `,
   accountValue: css`
     font-size: 15px;
-    color: ${token.colorText};
+    color: ${cssVar.colorText};
   `,
   path: css`
-    font-family: ${token.fontFamilyCode};
+    font-family: ${cssVar.fontFamilyCode};
     font-size: 12px;
-    color: ${token.colorTextTertiary};
+    color: ${cssVar.colorTextTertiary};
   `,
   unavailableText: css`
     font-size: 13px;
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
   `,
 }));
 
@@ -215,7 +215,6 @@ interface HeterogeneousAgentStatusCardProps {
 const HeterogeneousAgentStatusCard = memo<HeterogeneousAgentStatusCardProps>(
   ({ provider, onCommandChange }) => {
     const { t } = useTranslation('setting');
-    const { styles } = useStyles();
     const navigate = useNavigate();
     const providerConfig = getHeterogeneousAgentClientConfig(provider.type);
     const defaultCommand = providerConfig?.command || '';

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/RemoteAgentConfigCard.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/RemoteAgentConfigCard.tsx
@@ -6,8 +6,9 @@ import {
 } from '@lobechat/heterogeneous-agents';
 import type { HeterogeneousProviderConfig } from '@lobechat/types';
 import { ActionIcon, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
-import { Button, Modal, Select, Tag } from 'antd';
-import { createStyles } from 'antd-style';
+import { Select } from '@lobehub/ui/base-ui';
+import { Button, Modal, Tag } from 'antd';
+import { createStaticStyles, cssVar } from 'antd-style';
 import { BotIcon, CheckCircle2, MonitorSmartphone, RefreshCw, XCircle } from 'lucide-react';
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -15,14 +16,14 @@ import { useTranslation } from 'react-i18next';
 import { lambdaClient, lambdaQuery } from '@/libs/trpc/client';
 import { useAgentStore } from '@/store/agent';
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css }) => ({
   card: css`
     padding-block: 16px 4px;
     padding-inline: 16px;
-    border: 1px solid ${token.colorBorderSecondary};
-    border-radius: ${token.borderRadiusLG}px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusLG};
 
-    background: ${token.colorBgContainer};
+    background: ${cssVar.colorBgContainer};
   `,
   cardHeader: css`
     display: flex;
@@ -37,7 +38,7 @@ const useStyles = createStyles(({ css, token }) => ({
     font-weight: 500;
   `,
   detailList: css`
-    border-block-start: 1px solid ${token.colorBorderSecondary};
+    border-block-start: 1px solid ${cssVar.colorBorderSecondary};
   `,
   detailRow: css`
     display: flex;
@@ -48,7 +49,7 @@ const useStyles = createStyles(({ css, token }) => ({
     padding-block: 6px;
 
     & + & {
-      border-block-start: 1px solid ${token.colorBorderSecondary};
+      border-block-start: 1px solid ${cssVar.colorBorderSecondary};
     }
   `,
   detailLabel: css`
@@ -57,7 +58,7 @@ const useStyles = createStyles(({ css, token }) => ({
     width: 96px;
 
     font-size: 12px;
-    color: ${token.colorTextTertiary};
+    color: ${cssVar.colorTextTertiary};
     text-transform: uppercase;
     letter-spacing: 0.04em;
   `,
@@ -85,7 +86,6 @@ interface RemoteAgentConfigCardProps {
 const RemoteAgentConfigCard = memo<RemoteAgentConfigCardProps>(
   ({ provider, onBoundDeviceChange }) => {
     const { t } = useTranslation('setting');
-    const { styles } = useStyles();
 
     const agentId = useAgentStore((s) => s.activeAgentId);
     const boundDeviceId = useAgentStore((s) =>

--- a/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/AddAgent.tsx
+++ b/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/AddAgent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { ChevronDownIcon } from 'lucide-react';
@@ -37,7 +38,7 @@ const AddAgent = memo<{ mobile?: boolean }>(({ mobile }) => {
   const [isLoading, setIsLoading] = useState(false);
   const createAgent = useAgentStore((s) => s.createAgent);
   const refreshAgentList = useHomeStore((s) => s.refreshAgentList);
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
   const navigate = useNavigate();
   const { t } = useTranslation('discover');
 
@@ -56,7 +57,7 @@ const AddAgent = memo<{ mobile?: boolean }>(({ mobile }) => {
   };
 
   const showDuplicateConfirmation = (callback: () => void) => {
-    modal.confirm({
+    confirmModal({
       cancelText: t('cancel', { ns: 'common' }),
       content: t('assistants.duplicateAdd.content', { title }),
       okText: t('assistants.duplicateAdd.ok'),

--- a/src/routes/(main)/community/(detail)/features/ShareButton.tsx
+++ b/src/routes/(main)/community/(detail)/features/ShareButton.tsx
@@ -7,11 +7,11 @@ import {
   CopyButton,
   Flexbox,
   Input,
-  Modal,
   Skeleton,
   Tag,
   Text,
 } from '@lobehub/ui';
+import { Modal } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { startCase } from 'es-toolkit/compat';
 import { LinkIcon, Share2Icon } from 'lucide-react';

--- a/src/routes/(main)/community/(detail)/group_agent/features/Sidebar/ActionButton/AddGroupAgent.tsx
+++ b/src/routes/(main)/community/(detail)/group_agent/features/Sidebar/ActionButton/AddGroupAgent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { ChevronDownIcon } from 'lucide-react';
@@ -42,7 +43,7 @@ const AddGroupAgent = memo<{ mobile?: boolean }>(() => {
     memberAgents = [],
   } = useDetailContext();
   const [isLoading, setIsLoading] = useState(false);
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
   const { t } = useTranslation('discover');
   const navigate = useNavigate();
   const loadGroups = useAgentGroupStore((s) => s.loadGroups);
@@ -67,7 +68,7 @@ const AddGroupAgent = memo<{ mobile?: boolean }>(() => {
   };
 
   const showDuplicateConfirmation = (callback: () => void) => {
-    modal.confirm({
+    confirmModal({
       cancelText: t('cancel', { ns: 'common' }),
       content: t('groupAgents.duplicateAdd.content', {
         defaultValue: 'This group agent has already been added. Do you want to add it again?',

--- a/src/routes/(main)/community/(detail)/user/features/StatusFilter.tsx
+++ b/src/routes/(main)/community/(detail)/user/features/StatusFilter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Select } from 'antd';
+import { Select } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/routes/(main)/community/(detail)/user/features/useUserDetail.ts
+++ b/src/routes/(main)/community/(detail)/user/features/useUserDetail.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -17,7 +18,7 @@ interface UseUserDetailOptions {
 
 export const useUserDetail = ({ onMutate }: UseUserDetailOptions = {}) => {
   const { t } = useTranslation('setting');
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
   const { session } = useMarketAuth();
   const enableMarketTrustedClient = useServerConfigStore(
     serverConfigSelectors.enableMarketTrustedClient,
@@ -88,7 +89,7 @@ export const useUserDetail = ({ onMutate }: UseUserDetailOptions = {}) => {
       }
 
       if (action === 'deprecate') {
-        modal.confirm({
+        confirmModal({
           cancelText: t('myAgents.actions.cancel'),
           content: t('myAgents.actions.deprecateConfirmContent'),
           okButtonProps: { danger: true },
@@ -103,7 +104,7 @@ export const useUserDetail = ({ onMutate }: UseUserDetailOptions = {}) => {
 
       await executeStatusChange(identifier, action, type);
     },
-    [enableMarketTrustedClient, session?.accessToken, message, modal, t, onMutate],
+    [enableMarketTrustedClient, session?.accessToken, message, t, onMutate],
   );
 
   return {

--- a/src/routes/(main)/eval/bench/[benchmarkId]/datasets/[datasetId]/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/datasets/[datasetId]/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button, Flexbox } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App, Typography } from 'antd';
 import { ArrowLeft, Database, Pencil, Plus, Trash2 } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
@@ -24,7 +25,7 @@ const DatasetDetail = memo(() => {
   const { t } = useTranslation('eval');
   const { benchmarkId, datasetId } = useParams<{ benchmarkId: string; datasetId: string }>();
   const navigate = useNavigate();
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
 
   const [pagination, setPagination] = useState({ current: 1, pageSize: 10 });
   const [search, setSearch] = useState('');
@@ -78,7 +79,7 @@ const DatasetDetail = memo(() => {
 
   const handleDeleteCase = useCallback(
     (testCase: any) => {
-      modal.confirm({
+      confirmModal({
         content: t('testCase.delete.confirm'),
         okButtonProps: { danger: true },
         okText: t('common.delete'),
@@ -94,11 +95,11 @@ const DatasetDetail = memo(() => {
         title: t('common.delete'),
       });
     },
-    [handleRefresh, message, modal, t],
+    [handleRefresh, message, t],
   );
 
   const handleDelete = useCallback(() => {
-    modal.confirm({
+    confirmModal({
       content: t('dataset.delete.confirm'),
       okButtonProps: { danger: true },
       okText: t('common.delete'),
@@ -113,7 +114,7 @@ const DatasetDetail = memo(() => {
       },
       title: t('common.delete'),
     });
-  }, [benchmarkId, datasetId, message, modal, navigate, t]);
+  }, [benchmarkId, datasetId, message, navigate, t]);
 
   if (!dataset) return null;
 

--- a/src/routes/(main)/eval/bench/[benchmarkId]/features/BenchmarkHeader/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/features/BenchmarkHeader/index.tsx
@@ -3,7 +3,8 @@
 import type { AgentEvalRunListItem } from '@lobechat/types';
 import { formatCost } from '@lobechat/utils';
 import { Button, Flexbox, Icon } from '@lobehub/ui';
-import { App, Badge, Dropdown } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
+import { Badge, Dropdown } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import {
   CircleDollarSign,
@@ -97,7 +98,6 @@ const BenchmarkHeader = memo<BenchmarkHeaderProps>(
     totalCases,
   }) => {
     const { t } = useTranslation('eval');
-    const { modal } = App.useApp();
     const navigate = useNavigate();
     const deleteBenchmark = useEvalStore((s) => s.deleteBenchmark);
     const refreshBenchmarkDetail = useEvalStore((s) => s.refreshBenchmarkDetail);
@@ -109,7 +109,7 @@ const BenchmarkHeader = memo<BenchmarkHeaderProps>(
     };
 
     const handleDelete = () => {
-      modal.confirm({
+      confirmModal({
         content: t('benchmark.actions.delete.confirm'),
         okButtonProps: { danger: true },
         okText: t('benchmark.actions.delete'),

--- a/src/routes/(main)/eval/bench/[benchmarkId]/features/DatasetsTab/DatasetCard.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/features/DatasetsTab/DatasetCard.tsx
@@ -1,4 +1,5 @@
 import { Button, Flexbox, Tag } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App, Card, Dropdown } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { ArrowRight, ChevronRight, Database, Ellipsis, Pencil, Play, Trash2 } from 'lucide-react';
@@ -135,10 +136,10 @@ const DatasetCard = memo<DatasetCardProps>(
     onRun,
   }) => {
     const { t } = useTranslation('eval');
-    const { modal, message } = App.useApp();
+    const { message } = App.useApp();
 
     const handleDelete = useCallback(() => {
-      modal.confirm({
+      confirmModal({
         content: t('dataset.delete.confirm'),
         okButtonProps: { danger: true },
         okText: t('common.delete'),
@@ -153,7 +154,7 @@ const DatasetCard = memo<DatasetCardProps>(
         },
         title: t('common.delete'),
       });
-    }, [dataset.id, message, modal, onRefresh, t]);
+    }, [dataset.id, message, onRefresh, t]);
 
     return (
       <Card className={styles.card}>

--- a/src/routes/(main)/eval/bench/[benchmarkId]/features/DatasetsTab/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/features/DatasetsTab/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button, Flexbox } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App, Card, Skeleton } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { Plus } from 'lucide-react';
@@ -52,7 +53,7 @@ interface DatasetsTabProps {
 const DatasetsTab = memo<DatasetsTabProps>(
   ({ benchmarkId, datasets, loading: datasetsLoading, onImport, onRefresh }) => {
     const { t } = useTranslation('eval');
-    const { modal, message } = App.useApp();
+    const { message } = App.useApp();
     const [expandedDs, setExpandedDs] = useState<string | null>(null);
     const [pagination, setPagination] = useState({ current: 1, pageSize: 5 });
     const [search, setSearch] = useState('');
@@ -115,7 +116,7 @@ const DatasetsTab = memo<DatasetsTabProps>(
 
     const handleDeleteCase = useCallback(
       (testCase: any) => {
-        modal.confirm({
+        confirmModal({
           content: t('testCase.delete.confirm'),
           okButtonProps: { danger: true },
           okText: t('common.delete'),
@@ -132,7 +133,7 @@ const DatasetsTab = memo<DatasetsTabProps>(
           title: t('common.delete'),
         });
       },
-      [expandedDs, message, modal, onRefresh, refreshTestCases, t],
+      [expandedDs, message, onRefresh, refreshTestCases, t],
     );
 
     return (
@@ -218,10 +219,9 @@ const DatasetsTab = memo<DatasetsTabProps>(
           onSuccess={(dataset) => {
             onRefresh();
             // Ask if user wants to import data immediately
-            modal.success({
+            confirmModal({
               cancelText: t('common.later'),
               content: t('dataset.create.importNow'),
-              okCancel: true,
               okText: t('dataset.actions.import'),
               onOk: () => {
                 setImportDatasetId(dataset.id);

--- a/src/routes/(main)/eval/bench/[benchmarkId]/features/RunsTab/RunCard.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/features/RunsTab/RunCard.tsx
@@ -1,5 +1,6 @@
 import type { AgentEvalRunListItem } from '@lobechat/types';
 import { Flexbox, Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App, Card, Dropdown, Progress } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import {
@@ -122,7 +123,7 @@ interface RunCardProps {
 
 const RunCard = memo<RunCardProps>(({ benchmarkId, run, onRefresh, onEdit }) => {
   const { t } = useTranslation('eval');
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
   const deleteRun = useEvalStore((s) => s.deleteRun);
   const startRun = useEvalStore((s) => s.startRun);
   const abortRun = useEvalStore((s) => s.abortRun);
@@ -148,7 +149,7 @@ const RunCard = memo<RunCardProps>(({ benchmarkId, run, onRefresh, onEdit }) => 
   const handleStart = (e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    modal.confirm({
+    confirmModal({
       content: t('run.actions.start.confirm'),
       okText: t('run.actions.start'),
       onOk: async () => {
@@ -166,7 +167,7 @@ const RunCard = memo<RunCardProps>(({ benchmarkId, run, onRefresh, onEdit }) => 
   const handleAbort = (e?: React.MouseEvent) => {
     e?.preventDefault();
     e?.stopPropagation();
-    modal.confirm({
+    confirmModal({
       content: t('run.actions.abort.confirm'),
       okText: t('run.actions.abort'),
       okButtonProps: { danger: true },
@@ -181,7 +182,7 @@ const RunCard = memo<RunCardProps>(({ benchmarkId, run, onRefresh, onEdit }) => 
   const handleDelete = (e?: React.MouseEvent) => {
     e?.preventDefault();
     e?.stopPropagation();
-    modal.confirm({
+    confirmModal({
       content: t('run.actions.delete.confirm'),
       okButtonProps: { danger: true },
       okText: t('run.actions.delete'),

--- a/src/routes/(main)/eval/bench/[benchmarkId]/features/RunsTab/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/features/RunsTab/index.tsx
@@ -2,7 +2,7 @@
 
 import type { AgentEvalRunListItem } from '@lobechat/types';
 import { Button, Flexbox } from '@lobehub/ui';
-import { Select } from 'antd';
+import { Select } from '@lobehub/ui/base-ui';
 import { Plus } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/CaseResultsTable/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/CaseResultsTable/index.tsx
@@ -3,7 +3,8 @@
 import type { EvalThreadResult } from '@lobechat/types';
 import { formatCost, formatShortenNumber } from '@lobechat/utils';
 import { ActionIcon, Flexbox, Icon, Tag } from '@lobehub/ui';
-import { Badge, Input, Select, Table, Tooltip } from 'antd';
+import { Select } from '@lobehub/ui/base-ui';
+import { Badge, Input, Table, Tooltip } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { Footprints, Play, RotateCcw } from 'lucide-react';

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/IdleState/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/IdleState/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button, Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { createStaticStyles, cx } from 'antd-style';
 import { Brain, ChartBar, MessageSquare, Play } from 'lucide-react';
@@ -105,12 +106,12 @@ interface IdleStateProps {
 
 const IdleState = memo<IdleStateProps>(({ run }) => {
   const { t } = useTranslation('eval');
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
   const startRun = useEvalStore((s) => s.startRun);
   const [starting, setStarting] = useState(false);
 
   const handleStart = () => {
-    modal.confirm({
+    confirmModal({
       content: t('run.actions.start.confirm'),
       okText: t('run.actions.start'),
       onOk: async () => {

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/RunHeader/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/RunHeader/index.tsx
@@ -3,6 +3,7 @@
 import { AGENT_PROFILE_URL } from '@lobechat/const';
 import type { AgentEvalRunDetail } from '@lobechat/types';
 import { ActionIcon, Avatar, copyToClipboard, Flexbox, Highlighter, Markdown } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App, Button, Card, Tag, Typography } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import {
@@ -115,7 +116,7 @@ interface RunHeaderProps {
 
 const RunHeader = memo<RunHeaderProps>(({ run, benchmarkId, hideStart }) => {
   const { t } = useTranslation('eval');
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
   const navigate = useNavigate();
   const abortRun = useEvalStore((s) => s.abortRun);
   const deleteRun = useEvalStore((s) => s.deleteRun);
@@ -133,7 +134,7 @@ const RunHeader = memo<RunHeaderProps>(({ run, benchmarkId, hideStart }) => {
   const agentProvider = snapshot?.provider || run.targetAgent?.provider;
 
   const handleAbort = () => {
-    modal.confirm({
+    confirmModal({
       content: t('run.actions.abort.confirm'),
       okButtonProps: { danger: true },
       okText: t('run.actions.abort'),
@@ -143,7 +144,7 @@ const RunHeader = memo<RunHeaderProps>(({ run, benchmarkId, hideStart }) => {
   };
 
   const handleDelete = () => {
-    modal.confirm({
+    confirmModal({
       content: t('run.actions.delete.confirm'),
       okButtonProps: { danger: true },
       okText: t('run.actions.delete'),
@@ -156,7 +157,7 @@ const RunHeader = memo<RunHeaderProps>(({ run, benchmarkId, hideStart }) => {
   };
 
   const handleStart = () => {
-    modal.confirm({
+    confirmModal({
       content: t('run.actions.start.confirm'),
       okText: t('run.actions.start'),
       onOk: async () => {

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { App, Button, Card, Progress, Typography } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
+import { Button, Card, Progress, Typography } from 'antd';
 import { Play, RotateCcw } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -23,7 +24,6 @@ const POLLING_INTERVAL = 3000;
 
 const RunDetail = memo(() => {
   const { t } = useTranslation('eval');
-  const { modal } = App.useApp();
   const { benchmarkId, runId } = useParams<{ benchmarkId: string; runId: string }>();
   const useFetchRunDetail = useEvalStore((s) => s.useFetchRunDetail);
   const useFetchRunResults = useEvalStore((s) => s.useFetchRunResults);
@@ -165,7 +165,7 @@ const RunDetail = memo(() => {
                     loading={retrying}
                     size="small"
                     onClick={() => {
-                      modal.confirm({
+                      confirmModal({
                         content: t('run.actions.retryErrors.confirm'),
                         onOk: async () => {
                           setRetrying(true);

--- a/src/routes/(main)/eval/features/DatasetCreateModal/index.tsx
+++ b/src/routes/(main)/eval/features/DatasetCreateModal/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Center, Flexbox, Icon, Modal, Text } from '@lobehub/ui';
-import { App, Form, Input, Select } from 'antd';
+import { Select } from '@lobehub/ui/base-ui';
+import { App, Form, Input } from 'antd';
 import { cssVar } from 'antd-style';
 import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/routes/(main)/eval/features/DatasetEditModal/index.tsx
+++ b/src/routes/(main)/eval/features/DatasetEditModal/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Center, Flexbox, Icon, Input, Modal, type ModalProps, Text, TextArea } from '@lobehub/ui';
-import { App, Form, Select } from 'antd';
+import { Select } from '@lobehub/ui/base-ui';
+import { App, Form } from 'antd';
 import { cssVar } from 'antd-style';
 import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/routes/(main)/eval/features/DatasetImportModal/MappingStep.tsx
+++ b/src/routes/(main)/eval/features/DatasetImportModal/MappingStep.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { Checkbox, Input, Select, Table } from 'antd';
+import { Select } from '@lobehub/ui/base-ui';
+import { Checkbox, Input, Table } from 'antd';
 import { cssVar } from 'antd-style';
 import { memo, type ReactNode, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/routes/(main)/eval/features/TestCaseCreateModal/index.tsx
+++ b/src/routes/(main)/eval/features/TestCaseCreateModal/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Accordion, AccordionItem, Flexbox, Modal, Text } from '@lobehub/ui';
-import { App, Form, Input, Select } from 'antd';
+import { Select } from '@lobehub/ui/base-ui';
+import { App, Form, Input } from 'antd';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/routes/(main)/eval/features/TestCaseEditModal/index.tsx
+++ b/src/routes/(main)/eval/features/TestCaseEditModal/index.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Accordion, AccordionItem, Flexbox, Modal, Text } from '@lobehub/ui';
-import { App, Form, Input, Select } from 'antd';
+import { Select } from '@lobehub/ui/base-ui';
+import { App, Form, Input } from 'antd';
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -1,6 +1,7 @@
 import type { ChatTopicStatus } from '@lobechat/types';
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import {
   CheckCircle2,
@@ -37,7 +38,7 @@ export const useTopicItemDropdownMenu = ({
   toggleEditing,
 }: TopicItemDropdownMenuProps): (() => MenuProps['items']) => {
   const { t } = useTranslation(['topic', 'common']);
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
   const navigate = useNavigate();
 
   const openGroupTopicInNewWindow = useGlobalStore((s) => s.openGroupTopicInNewWindow);
@@ -162,8 +163,7 @@ export const useTopicItemDropdownMenu = ({
         key: 'delete',
         label: t('delete', { ns: 'common' }),
         onClick: () => {
-          modal.confirm({
-            centered: true,
+          confirmModal({
             okButtonProps: { danger: true },
             onOk: async () => {
               await removeTopic(id);
@@ -188,7 +188,6 @@ export const useTopicItemDropdownMenu = ({
     navigate,
     toggleEditing,
     t,
-    modal,
     message,
   ]);
 };

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
@@ -1,6 +1,6 @@
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { PencilLine, Trash } from 'lucide-react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -17,7 +17,6 @@ export const useThreadItemDropdownMenu = ({
   toggleEditing,
 }: ThreadItemDropdownMenuProps): (() => MenuProps['items']) => {
   const { t } = useTranslation(['thread', 'common']);
-  const { modal } = App.useApp();
 
   const [removeThread] = useChatStore((s) => [s.removeThread]);
 
@@ -40,8 +39,7 @@ export const useThreadItemDropdownMenu = ({
         key: 'delete',
         label: t('delete', { ns: 'common' }),
         onClick: () => {
-          modal.confirm({
-            centered: true,
+          confirmModal({
             okButtonProps: { danger: true },
             onOk: async () => {
               await removeThread(id);
@@ -51,5 +49,5 @@ export const useThreadItemDropdownMenu = ({
         },
       },
     ].filter(Boolean) as MenuProps['items'];
-  }, [id, removeThread, toggleEditing, t, modal]);
+  }, [id, removeThread, toggleEditing, t]);
 };

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/useDropdownMenu.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/useDropdownMenu.tsx
@@ -1,5 +1,6 @@
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App, Upload } from 'antd';
 import { css, cx } from 'antd-style';
 import { Hash, Import, LucideCheck, Trash } from 'lucide-react';
@@ -100,9 +101,8 @@ export const useTopicActionsDropdownMenu = (
         key: 'deleteUnstarred',
         label: t('actions.removeUnstarred'),
         onClick: () => {
-          modal.confirm({
+          confirmModal({
             cancelText: t('cancel', { ns: 'common' }),
-            centered: true,
             okButtonProps: { danger: true },
             okText: t('ok', { ns: 'common' }),
             onOk: removeUnstarredTopic,
@@ -116,9 +116,8 @@ export const useTopicActionsDropdownMenu = (
         key: 'deleteAll',
         label: t('actions.removeAll'),
         onClick: () => {
-          modal.confirm({
+          confirmModal({
             cancelText: t('cancel', { ns: 'common' }),
-            centered: true,
             okButtonProps: { danger: true },
             okText: t('ok', { ns: 'common' }),
             onOk: removeAllTopic,

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentGroupItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentGroupItem/useDropdownMenu.tsx
@@ -1,5 +1,6 @@
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { LucideCopy, Pen, PictureInPicture2Icon, Pin, PinOff, Trash } from 'lucide-react';
 import { useMemo } from 'react';
@@ -29,7 +30,7 @@ export const useGroupDropdownMenu = ({
   title,
 }: UseGroupDropdownMenuParams): (() => MenuProps['items']) => {
   const { t } = useTranslation('chat');
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
 
   const openAgentInNewWindow = useGlobalStore((s) => s.openAgentInNewWindow);
   const [pinAgentGroup, duplicateAgentGroup, removeAgentGroup] = useHomeStore((s) => [
@@ -92,8 +93,7 @@ export const useGroupDropdownMenu = ({
           label: t('delete', { ns: 'common' }),
           onClick: ({ domEvent }: any) => {
             domEvent.stopPropagation();
-            modal.confirm({
-              centered: true,
+            confirmModal({
               okButtonProps: { danger: true },
               onOk: async () => {
                 await removeAgentGroup(id);
@@ -116,7 +116,6 @@ export const useGroupDropdownMenu = ({
       title,
       duplicateAgentGroup,
       openAgentInNewWindow,
-      modal,
       removeAgentGroup,
       message,
     ],

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.tsx
@@ -1,6 +1,7 @@
 import { SessionDefaultGroup } from '@lobechat/types';
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import isEqual from 'fast-deep-equal';
 import {
@@ -42,7 +43,7 @@ export const useAgentDropdownMenu = ({
   title,
 }: UseAgentDropdownMenuParams): (() => MenuProps['items']) => {
   const { t } = useTranslation('chat');
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
 
   const openAgentInNewWindow = useGlobalStore((s) => s.openAgentInNewWindow);
   const sessionCustomGroups = useHomeStore(homeAgentListSelectors.agentGroups, isEqual);
@@ -131,8 +132,7 @@ export const useAgentDropdownMenu = ({
           label: t('delete', { ns: 'common' }),
           onClick: ({ domEvent }: any) => {
             domEvent.stopPropagation();
-            modal.confirm({
-              centered: true,
+            confirmModal({
               okButtonProps: { danger: true },
               onOk: async () => {
                 await removeAgent(id);

--- a/src/routes/(main)/home/_layout/Body/Agent/Modals/ConfigGroupModal/GroupItem.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/Modals/ConfigGroupModal/GroupItem.tsx
@@ -1,4 +1,5 @@
 import { ActionIcon, EditableText, SortableList } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { PencilLine, Trash } from 'lucide-react';
@@ -24,7 +25,7 @@ const styles = createStaticStyles(({ css }) => ({
 
 const GroupItem = memo<SessionGroupItemBase>(({ id, name }) => {
   const { t } = useTranslation('chat');
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
 
   const [editing, setEditing] = useState(false);
   const [updateGroupName, removeGroup] = useHomeStore((s) => [s.updateGroupName, s.removeGroup]);
@@ -40,11 +41,9 @@ const GroupItem = memo<SessionGroupItemBase>(({ id, name }) => {
             icon={Trash}
             size={'small'}
             onClick={() => {
-              modal.confirm({
-                centered: true,
+              confirmModal({
                 okButtonProps: {
                   danger: true,
-                  type: 'primary',
                 },
                 onOk: async () => {
                   await removeGroup(id);

--- a/src/routes/(main)/home/_layout/Body/Project/List/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/_layout/Body/Project/List/useDropdownMenu.tsx
@@ -1,6 +1,6 @@
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { PencilLine, Trash } from 'lucide-react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -18,7 +18,6 @@ export const useProjectItemDropdownMenu = ({
 }: ProjectItemDropdownMenuProps): (() => MenuProps['items']) => {
   const { t } = useTranslation(['home', 'common']);
   const [removeKnowledgeBase] = useKnowledgeBaseStore((s) => [s.removeKnowledgeBase]);
-  const { modal } = App.useApp();
 
   return useCallback(
     () => [
@@ -40,8 +39,7 @@ export const useProjectItemDropdownMenu = ({
         label: t('delete', { ns: 'common' }),
         onClick: () => {
           if (!id) return;
-          modal.confirm({
-            centered: true,
+          confirmModal({
             okButtonProps: { danger: true },
             onOk: async () => {
               await removeKnowledgeBase(id);
@@ -51,6 +49,6 @@ export const useProjectItemDropdownMenu = ({
         },
       },
     ],
-    [t, id, modal, removeKnowledgeBase, toggleEditing],
+    [t, id, removeKnowledgeBase, toggleEditing],
   );
 };

--- a/src/routes/(main)/home/_layout/hooks/useSessionGroupMenuItems.tsx
+++ b/src/routes/(main)/home/_layout/hooks/useSessionGroupMenuItems.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { type ItemType } from 'antd/es/menu/interface';
 import { createStaticStyles } from 'antd-style';
@@ -25,7 +26,7 @@ const styles = createStaticStyles(({ css }) => ({
  */
 export const useSessionGroupMenuItems = () => {
   const { t } = useTranslation('chat');
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
   const groupTemplates = useGroupTemplates();
 
   const [storeCreateAgent] = useAgentStore((s) => [s.createAgent]);
@@ -88,11 +89,7 @@ export const useSessionGroupMenuItems = () => {
         label: t('delete', { ns: 'common' }),
         onClick: (info: any) => {
           info.domEvent?.stopPropagation();
-          modal.confirm({
-            centered: true,
-            classNames: {
-              root: styles.modalRoot,
-            },
+          confirmModal({
             okButtonProps: { danger: true },
             onOk: async () => {
               await removeGroup(groupId);
@@ -102,7 +99,7 @@ export const useSessionGroupMenuItems = () => {
         },
       };
     },
-    [t, modal, removeGroup, styles.modalRoot],
+    [t, removeGroup],
   );
 
   /**

--- a/src/routes/(main)/home/features/Recents/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/features/Recents/useDropdownMenu.tsx
@@ -1,6 +1,6 @@
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { PencilLineIcon, Trash } from 'lucide-react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -16,7 +16,6 @@ export const useRecentItemDropdownMenu = (
   toggleEditing: (visible?: boolean) => void,
 ) => {
   const { t } = useTranslation(['common', 'topic', 'components']);
-  const { modal } = App.useApp();
   const [updateRecentTitle, refreshRecents] = useHomeStore((s) => [
     s.updateRecentTitle,
     s.refreshRecents,
@@ -52,8 +51,7 @@ export const useRecentItemDropdownMenu = (
       topic: t('actions.confirmRemoveTopic', { ns: 'topic' }),
     };
 
-    modal.confirm({
-      centered: true,
+    confirmModal({
       okButtonProps: { danger: true },
       onOk: async () => {
         switch (item.type) {
@@ -75,7 +73,7 @@ export const useRecentItemDropdownMenu = (
       },
       title: confirmMessages[item.type] || t('delete', { ns: 'common' }),
     });
-  }, [item, modal, t, refreshRecents]);
+  }, [item, t, refreshRecents]);
 
   const dropdownMenu = useCallback((): MenuProps['items'] => {
     const canRename = true;

--- a/src/routes/(main)/memory/activities/features/ActivityDropdown.tsx
+++ b/src/routes/(main)/memory/activities/features/ActivityDropdown.tsx
@@ -1,6 +1,6 @@
 import { type ActionIconProps } from '@lobehub/ui';
 import { ActionIcon, DropdownMenu } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { type KeyboardEvent, type MouseEvent } from 'react';
 import { memo } from 'react';
@@ -15,7 +15,6 @@ interface ActivityDropdownProps {
 
 const ActivityDropdown = memo<ActivityDropdownProps>(({ id, size = 'small' }) => {
   const { t } = useTranslation(['memory', 'common']);
-  const { modal } = App.useApp();
 
   const activities = useUserMemoryStore((s) => s.activities);
   const deleteActivity = useUserMemoryStore((s) => s.deleteActivity);
@@ -30,7 +29,7 @@ const ActivityDropdown = memo<ActivityDropdownProps>(({ id, size = 'small' }) =>
         setEditingMemory(id, activity.narrative || activity.notes || '', 'activity');
       }
     } else if (info.key === 'delete') {
-      modal.confirm({
+      confirmModal({
         cancelText: t('cancel', { ns: 'common' }),
         content: t('activity.deleteConfirm'),
         okButtonProps: { danger: true },
@@ -39,7 +38,6 @@ const ActivityDropdown = memo<ActivityDropdownProps>(({ id, size = 'small' }) =>
           await deleteActivity(id);
         },
         title: t('activity.deleteTitle'),
-        type: 'warning',
       });
     }
   };

--- a/src/routes/(main)/memory/contexts/features/ContextDropdown.tsx
+++ b/src/routes/(main)/memory/contexts/features/ContextDropdown.tsx
@@ -6,6 +6,7 @@ import { type KeyboardEvent, type MouseEvent } from 'react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { useUserMemoryStore } from '@/store/userMemory';
 
 interface ContextDropdownProps {
@@ -13,56 +14,58 @@ interface ContextDropdownProps {
   size?: ActionIconProps['size'];
 }
 
-const ContextDropdown = memo<ContextDropdownProps>(({ id, size = 'small' }) => {
-  const { t } = useTranslation(['memory', 'common']);
+const ContextDropdown = memo<ContextDropdownProps>(
+  ({ id, size = DESKTOP_HEADER_ICON_SMALL_SIZE }) => {
+    const { t } = useTranslation(['memory', 'common']);
 
-  const contexts = useUserMemoryStore((s) => s.contexts);
-  const deleteContext = useUserMemoryStore((s) => s.deleteContext);
-  const setEditingMemory = useUserMemoryStore((s) => s.setEditingMemory);
+    const contexts = useUserMemoryStore((s) => s.contexts);
+    const deleteContext = useUserMemoryStore((s) => s.deleteContext);
+    const setEditingMemory = useUserMemoryStore((s) => s.setEditingMemory);
 
-  const handleMenuClick = (info: { domEvent: MouseEvent | KeyboardEvent; key: string }) => {
-    info.domEvent.stopPropagation();
+    const handleMenuClick = (info: { domEvent: MouseEvent | KeyboardEvent; key: string }) => {
+      info.domEvent.stopPropagation();
 
-    if (info.key === 'edit') {
-      const context = contexts.find((c) => c.id === id);
-      if (context) {
-        setEditingMemory(id, context.description || '', 'context');
+      if (info.key === 'edit') {
+        const context = contexts.find((c) => c.id === id);
+        if (context) {
+          setEditingMemory(id, context.description || '', 'context');
+        }
+      } else if (info.key === 'delete') {
+        confirmModal({
+          cancelText: t('cancel', { ns: 'common' }),
+          content: t('context.deleteConfirm'),
+          okButtonProps: { danger: true },
+          okText: t('confirm', { ns: 'common' }),
+          onOk: async () => {
+            await deleteContext(id);
+          },
+          title: t('context.deleteTitle'),
+        });
       }
-    } else if (info.key === 'delete') {
-      confirmModal({
-        cancelText: t('cancel', { ns: 'common' }),
-        content: t('context.deleteConfirm'),
-        okButtonProps: { danger: true },
-        okText: t('confirm', { ns: 'common' }),
-        onOk: async () => {
-          await deleteContext(id);
-        },
-        title: t('context.deleteTitle'),
-      });
-    }
-  };
+    };
 
-  const menuItems = [
-    {
-      icon: <Pencil size={14} />,
-      key: 'edit',
-      label: t('context.actions.edit'),
-      onClick: handleMenuClick,
-    },
-    {
-      danger: true,
-      icon: <Trash2 size={14} />,
-      key: 'delete',
-      label: t('context.actions.delete'),
-      onClick: handleMenuClick,
-    },
-  ];
+    const menuItems = [
+      {
+        icon: <Pencil size={14} />,
+        key: 'edit',
+        label: t('context.actions.edit'),
+        onClick: handleMenuClick,
+      },
+      {
+        danger: true,
+        icon: <Trash2 size={14} />,
+        key: 'delete',
+        label: t('context.actions.delete'),
+        onClick: handleMenuClick,
+      },
+    ];
 
-  return (
-    <DropdownMenu items={menuItems}>
-      <ActionIcon icon={MoreHorizontal} size={size} />
-    </DropdownMenu>
-  );
-});
+    return (
+      <DropdownMenu items={menuItems}>
+        <ActionIcon icon={MoreHorizontal} size={size} />
+      </DropdownMenu>
+    );
+  },
+);
 
 export default ContextDropdown;

--- a/src/routes/(main)/memory/contexts/features/ContextDropdown.tsx
+++ b/src/routes/(main)/memory/contexts/features/ContextDropdown.tsx
@@ -1,6 +1,6 @@
 import { type ActionIconProps } from '@lobehub/ui';
 import { ActionIcon, DropdownMenu } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { type KeyboardEvent, type MouseEvent } from 'react';
 import { memo } from 'react';
@@ -15,7 +15,6 @@ interface ContextDropdownProps {
 
 const ContextDropdown = memo<ContextDropdownProps>(({ id, size = 'small' }) => {
   const { t } = useTranslation(['memory', 'common']);
-  const { modal } = App.useApp();
 
   const contexts = useUserMemoryStore((s) => s.contexts);
   const deleteContext = useUserMemoryStore((s) => s.deleteContext);
@@ -30,7 +29,7 @@ const ContextDropdown = memo<ContextDropdownProps>(({ id, size = 'small' }) => {
         setEditingMemory(id, context.description || '', 'context');
       }
     } else if (info.key === 'delete') {
-      modal.confirm({
+      confirmModal({
         cancelText: t('cancel', { ns: 'common' }),
         content: t('context.deleteConfirm'),
         okButtonProps: { danger: true },
@@ -39,7 +38,6 @@ const ContextDropdown = memo<ContextDropdownProps>(({ id, size = 'small' }) => {
           await deleteContext(id);
         },
         title: t('context.deleteTitle'),
-        type: 'warning',
       });
     }
   };

--- a/src/routes/(main)/memory/experiences/features/ExperienceDropdown.tsx
+++ b/src/routes/(main)/memory/experiences/features/ExperienceDropdown.tsx
@@ -1,6 +1,6 @@
 import { type ActionIconProps } from '@lobehub/ui';
 import { ActionIcon, DropdownMenu } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { type KeyboardEvent, type MouseEvent } from 'react';
 import { memo } from 'react';
@@ -15,7 +15,6 @@ interface ExperienceDropdownProps {
 
 const ExperienceDropdown = memo<ExperienceDropdownProps>(({ id, size = 'small' }) => {
   const { t } = useTranslation(['memory', 'common']);
-  const { modal } = App.useApp();
 
   const experiences = useUserMemoryStore((s) => s.experiences);
   const deleteExperience = useUserMemoryStore((s) => s.deleteExperience);
@@ -30,7 +29,7 @@ const ExperienceDropdown = memo<ExperienceDropdownProps>(({ id, size = 'small' }
         setEditingMemory(id, experience.keyLearning || '', 'experience');
       }
     } else if (info.key === 'delete') {
-      modal.confirm({
+      confirmModal({
         cancelText: t('cancel', { ns: 'common' }),
         content: t('experience.deleteConfirm'),
         okButtonProps: { danger: true },
@@ -39,7 +38,6 @@ const ExperienceDropdown = memo<ExperienceDropdownProps>(({ id, size = 'small' }
           await deleteExperience(id);
         },
         title: t('experience.deleteTitle'),
-        type: 'warning',
       });
     }
   };

--- a/src/routes/(main)/memory/features/ActionBar/PurgeButton.tsx
+++ b/src/routes/(main)/memory/features/ActionBar/PurgeButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ActionIcon, Button, Icon, Tooltip } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { Trash2Icon } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -23,7 +24,7 @@ interface Props {
 }
 
 const PurgeButton = memo<Props>(({ iconOnly }) => {
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
   const { t } = useTranslation(['common', 'memory']);
   const translate = t as (key: string, options?: Record<string, unknown>) => string;
   const purgeAllMemories = useUserMemoryStore((s) => s.purgeAllMemories);
@@ -31,10 +32,10 @@ const PurgeButton = memo<Props>(({ iconOnly }) => {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const handleClick = () => {
-    modal.confirm({
+    confirmModal({
       cancelText: translate('cancel', { ns: 'common' }),
       content: translate('purge.confirm', { ns: 'memory' }),
-      okButtonProps: { danger: true, loading },
+      okButtonProps: { danger: true },
       okText: translate('confirm', { ns: 'common' }),
       onOk: async () => {
         try {
@@ -56,7 +57,6 @@ const PurgeButton = memo<Props>(({ iconOnly }) => {
         }
       },
       title: translate('purge.title', { ns: 'memory' }),
-      type: 'warning',
     });
   };
 

--- a/src/routes/(main)/memory/features/ActionBar/PurgeButton.tsx
+++ b/src/routes/(main)/memory/features/ActionBar/PurgeButton.tsx
@@ -8,7 +8,7 @@ import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSearchParams } from 'react-router-dom';
 
-import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
+import { DESKTOP_HEADER_ICON_SIZE, DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { useUserMemoryStore } from '@/store/userMemory';
 
 export const MEMORY_DETAIL_QUERY_KEYS = [
@@ -67,7 +67,7 @@ const PurgeButton = memo<Props>(({ iconOnly }) => {
           danger
           icon={Trash2Icon}
           loading={loading}
-          size={DESKTOP_HEADER_ICON_SIZE}
+          size={DESKTOP_HEADER_ICON_SMALL_SIZE}
           tooltipProps={{ placement: 'bottom' }}
           onClick={handleClick}
         />

--- a/src/routes/(main)/memory/features/MemoryAnalysis/AnalysisTrigger.tsx
+++ b/src/routes/(main)/memory/features/MemoryAnalysis/AnalysisTrigger.tsx
@@ -6,7 +6,7 @@ import { CalendarClockIcon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { useMemoryAnalysisAsyncTask } from '@/routes/(main)/memory/features/MemoryAnalysis/useTask';
 import { memoryExtractionService } from '@/services/userMemory/extraction';
 
@@ -55,7 +55,7 @@ const AnalysisTrigger = memo<Props>(({ footerNote, range, onRangeChange, iconOnl
         <Tooltip title={t('analysis.action.button')}>
           <ActionIcon
             icon={CalendarClockIcon}
-            size={DESKTOP_HEADER_ICON_SIZE}
+            size={DESKTOP_HEADER_ICON_SMALL_SIZE}
             tooltipProps={{ placement: 'bottom' }}
             onClick={() => setOpen(true)}
           />

--- a/src/routes/(main)/memory/features/ViewModeSwitcher.tsx
+++ b/src/routes/(main)/memory/features/ViewModeSwitcher.tsx
@@ -5,7 +5,7 @@ import { CalendarDaysIcon, LayoutDashboardIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { DESKTOP_HEADER_ICON_SIZE } from '@/const/layoutTokens';
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 
 export type ViewMode = 'timeline' | 'grid';
 
@@ -22,14 +22,14 @@ const ViewModeSwitcher = memo<ViewModeSwitcherProps>(({ value, onChange }) => {
       <ActionIcon
         active={value === 'timeline'}
         icon={CalendarDaysIcon}
-        size={DESKTOP_HEADER_ICON_SIZE}
+        size={DESKTOP_HEADER_ICON_SMALL_SIZE}
         title={t('viewMode.timeline')}
         onClick={() => onChange('timeline')}
       />
       <ActionIcon
         active={value === 'grid'}
         icon={LayoutDashboardIcon}
-        size={DESKTOP_HEADER_ICON_SIZE}
+        size={DESKTOP_HEADER_ICON_SMALL_SIZE}
         title={t('viewMode.masonry')}
         onClick={() => onChange('grid')}
       />

--- a/src/routes/(main)/memory/identities/features/IdentityDropdown.tsx
+++ b/src/routes/(main)/memory/identities/features/IdentityDropdown.tsx
@@ -1,6 +1,6 @@
 import { type ActionIconProps } from '@lobehub/ui';
 import { ActionIcon, DropdownMenu } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { type KeyboardEvent, type MouseEvent } from 'react';
 import { memo } from 'react';
@@ -15,7 +15,6 @@ interface IdentityDropdownProps {
 
 const IdentityDropdown = memo<IdentityDropdownProps>(({ id, size = 'small' }) => {
   const { t } = useTranslation(['memory', 'common']);
-  const { modal } = App.useApp();
 
   const identities = useUserMemoryStore((s) => s.identities);
   const deleteIdentity = useUserMemoryStore((s) => s.deleteIdentity);
@@ -30,7 +29,7 @@ const IdentityDropdown = memo<IdentityDropdownProps>(({ id, size = 'small' }) =>
         setEditingMemory(id, identity.description || '', 'identity');
       }
     } else if (info.key === 'delete') {
-      modal.confirm({
+      confirmModal({
         cancelText: t('cancel', { ns: 'common' }),
         content: t('identity.list.deleteContent'),
         okButtonProps: { danger: true },
@@ -39,7 +38,6 @@ const IdentityDropdown = memo<IdentityDropdownProps>(({ id, size = 'small' }) =>
           await deleteIdentity(id);
         },
         title: t('identity.list.confirmDelete'),
-        type: 'warning',
       });
     }
   };

--- a/src/routes/(main)/memory/preferences/features/PreferenceDropdown.tsx
+++ b/src/routes/(main)/memory/preferences/features/PreferenceDropdown.tsx
@@ -1,6 +1,6 @@
 import { type ActionIconProps } from '@lobehub/ui';
 import { ActionIcon, DropdownMenu } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { type KeyboardEvent, type MouseEvent } from 'react';
 import { memo } from 'react';
@@ -15,7 +15,6 @@ interface PreferenceDropdownProps {
 
 const PreferenceDropdown = memo<PreferenceDropdownProps>(({ id, size = 'small' }) => {
   const { t } = useTranslation(['memory', 'common']);
-  const { modal } = App.useApp();
 
   const preferences = useUserMemoryStore((s) => s.preferences);
   const deletePreference = useUserMemoryStore((s) => s.deletePreference);
@@ -30,7 +29,7 @@ const PreferenceDropdown = memo<PreferenceDropdownProps>(({ id, size = 'small' }
         setEditingMemory(id, preference.conclusionDirectives || '', 'preference');
       }
     } else if (info.key === 'delete') {
-      modal.confirm({
+      confirmModal({
         cancelText: t('cancel', { ns: 'common' }),
         content: t('preference.deleteConfirm'),
         okButtonProps: { danger: true },
@@ -39,7 +38,6 @@ const PreferenceDropdown = memo<PreferenceDropdownProps>(({ id, size = 'small' }
           await deletePreference(id);
         },
         title: t('preference.deleteTitle'),
-        type: 'warning',
       });
     }
   };

--- a/src/routes/(main)/resource/(home)/_layout/Body/LibraryList/Item/useDropdownMenu.tsx
+++ b/src/routes/(main)/resource/(home)/_layout/Body/LibraryList/Item/useDropdownMenu.tsx
@@ -1,6 +1,6 @@
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { FileText, PencilLine, Trash } from 'lucide-react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -17,15 +17,13 @@ interface ActionProps {
 
 export const useDropdownMenu = ({ id, name, description, toggleEditing }: ActionProps): (() => MenuProps['items']) => {
   const { t } = useTranslation(['file', 'common']);
-  const { modal } = App.useApp();
   const removeKnowledgeBase = useKnowledgeBaseStore((s) => s.removeKnowledgeBase);
   const { open } = useCreateNewModal();
 
   const handleDelete = () => {
     if (!id) return;
 
-    modal.confirm({
-      centered: true,
+    confirmModal({
       okButtonProps: { danger: true },
       onOk: async () => {
         await removeKnowledgeBase(id);
@@ -71,6 +69,6 @@ export const useDropdownMenu = ({ id, name, description, toggleEditing }: Action
           onClick: handleDelete,
         },
       ].filter(Boolean) as MenuProps['items'],
-    [t, id, name, description, modal, removeKnowledgeBase, toggleEditing, handleDelete, handleEditDescription, open],
+    [t, id, name, description, removeKnowledgeBase, toggleEditing, handleDelete, handleEditDescription, open],
   );
 };

--- a/src/routes/(main)/settings/apikey/features/ApiKey.tsx
+++ b/src/routes/(main)/settings/apikey/features/ApiKey.tsx
@@ -8,13 +8,13 @@ import { Popconfirm, Switch } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { Trash } from 'lucide-react';
 import { type FC } from 'react';
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { lambdaClient } from '@/libs/trpc/client';
 import { type ApiKeyItem, type CreateApiKeyParams, type UpdateApiKeyParams } from '@/types/apiKey';
 
-import { ApiKeyDisplay, ApiKeyModal, EditableCell } from './index';
+import { ApiKeyDisplay, createApiKeyModal, EditableCell } from './index';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   container: css`
@@ -39,7 +39,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
 const ApiKey: FC = () => {
   const { t } = useTranslation('auth');
-  const [modalOpen, setModalOpen] = useState(false);
 
   const actionRef = useRef<ActionType>(null);
 
@@ -47,7 +46,6 @@ const ApiKey: FC = () => {
     mutationFn: (params: CreateApiKeyParams) => lambdaClient.apiKey.createApiKey.mutate(params),
     onSuccess: () => {
       actionRef.current?.reload();
-      setModalOpen(false);
     },
   });
 
@@ -67,11 +65,11 @@ const ApiKey: FC = () => {
   });
 
   const handleCreate = () => {
-    setModalOpen(true);
-  };
-
-  const handleModalOk = (values: CreateApiKeyParams) => {
-    createMutation.mutate(values);
+    createApiKeyModal({
+      onSubmit: async (values) => {
+        await createMutation.mutateAsync(values);
+      },
+    });
   };
 
   const columns: ProColumns<ApiKeyItem>[] = [
@@ -196,12 +194,6 @@ const ApiKey: FC = () => {
             </Button>,
           ],
         }}
-      />
-      <ApiKeyModal
-        open={modalOpen}
-        submitLoading={createMutation.isPending}
-        onCancel={() => setModalOpen(false)}
-        onOk={handleModalOk}
       />
     </div>
   );

--- a/src/routes/(main)/settings/apikey/features/ApiKeyModal/Content.tsx
+++ b/src/routes/(main)/settings/apikey/features/ApiKeyModal/Content.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { Button, Flexbox, Input } from '@lobehub/ui';
+import { useModalContext } from '@lobehub/ui/base-ui';
+import { Form } from 'antd';
+import { type Dayjs } from 'dayjs';
+import { type FC, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { type CreateApiKeyParams } from '@/types/apiKey';
+
+import ApiKeyDatePicker from '../ApiKeyDatePicker';
+
+type FormValues = Omit<CreateApiKeyParams, 'expiresAt'> & {
+  expiresAt: Dayjs | null;
+};
+
+export interface ApiKeyModalContentProps {
+  onSubmit: (values: CreateApiKeyParams) => Promise<void>;
+}
+
+const ApiKeyModalContent: FC<ApiKeyModalContentProps> = ({ onSubmit }) => {
+  const { t } = useTranslation('auth');
+  const { close } = useModalContext();
+  const [form] = Form.useForm<FormValues>();
+  const [loading, setLoading] = useState(false);
+
+  const handleFinish = async (values: FormValues) => {
+    setLoading(true);
+    try {
+      await onSubmit({
+        ...values,
+        expiresAt: values.expiresAt ? values.expiresAt.toDate() : null,
+      } satisfies CreateApiKeyParams);
+      close();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const itemStyle = { marginBottom: 0 };
+
+  return (
+    <Form colon={false} form={form} layout={'vertical'} onFinish={handleFinish}>
+      <Flexbox gap={16}>
+        <Form.Item
+          label={t('apikey.form.fields.name.label')}
+          name={'name'}
+          rules={[{ required: true }]}
+          style={itemStyle}
+        >
+          <Input placeholder={t('apikey.form.fields.name.placeholder')} />
+        </Form.Item>
+
+        <Form.Item
+          label={t('apikey.form.fields.expiresAt.label')}
+          name={'expiresAt'}
+          style={itemStyle}
+        >
+          <ApiKeyDatePicker style={{ width: '100%' }} />
+        </Form.Item>
+
+        <Button block htmlType={'submit'} loading={loading} type={'primary'}>
+          {t('apikey.form.submit')}
+        </Button>
+      </Flexbox>
+    </Form>
+  );
+};
+
+export default ApiKeyModalContent;

--- a/src/routes/(main)/settings/apikey/features/ApiKeyModal/index.tsx
+++ b/src/routes/(main)/settings/apikey/features/ApiKeyModal/index.tsx
@@ -1,58 +1,18 @@
-import { FormModal, Input } from '@lobehub/ui';
-import { type Dayjs } from 'dayjs';
-import { type FC } from 'react';
-import { useTranslation } from 'react-i18next';
+'use client';
 
-import { type CreateApiKeyParams } from '@/types/apiKey';
+import { createModal, type ModalInstance } from '@lobehub/ui/base-ui';
+import { t } from 'i18next';
 
-import ApiKeyDatePicker from '../ApiKeyDatePicker';
+import ApiKeyModalContent, { type ApiKeyModalContentProps } from './Content';
 
-interface ApiKeyModalProps {
-  onCancel: () => void;
-  onOk: (values: CreateApiKeyParams) => void;
-  open: boolean;
-  submitLoading?: boolean;
-}
-
-type FormValues = Omit<CreateApiKeyParams, 'expiresAt'> & {
-  expiresAt: Dayjs | null;
-};
-
-const ApiKeyModal: FC<ApiKeyModalProps> = ({ open, onCancel, onOk, submitLoading }) => {
-  const { t } = useTranslation('auth');
-
-  return (
-    <FormModal
-      destroyOnHidden
-      height={'90%'}
-      itemMinWidth={'max(30%,240px)'}
-      itemsType={'flat'}
-      open={open}
-      submitLoading={submitLoading}
-      submitText={t('apikey.form.submit')}
-      title={t('apikey.form.title')}
-      items={[
-        {
-          children: <Input placeholder={t('apikey.form.fields.name.placeholder')} />,
-          label: t('apikey.form.fields.name.label'),
-          name: 'name',
-          rules: [{ required: true }],
-        },
-        {
-          children: <ApiKeyDatePicker style={{ width: '100%' }} />,
-          label: t('apikey.form.fields.expiresAt.label'),
-          name: 'expiresAt',
-        },
-      ]}
-      onCancel={onCancel}
-      onFinish={(values: FormValues) => {
-        onOk({
-          ...values,
-          expiresAt: values.expiresAt ? values.expiresAt.toDate() : null,
-        } satisfies CreateApiKeyParams);
-      }}
-    />
-  );
-};
-
-export default ApiKeyModal;
+export const createApiKeyModal = (props: ApiKeyModalContentProps): ModalInstance =>
+  createModal({
+    content: <ApiKeyModalContent {...props} />,
+    footer: null,
+    maskClosable: true,
+    styles: {
+      content: { paddingBlock: 16, paddingInline: 24 },
+    },
+    title: t('apikey.form.title', { ns: 'auth' }),
+    width: 'min(90vw, 560px)',
+  });

--- a/src/routes/(main)/settings/apikey/features/index.ts
+++ b/src/routes/(main)/settings/apikey/features/index.ts
@@ -1,3 +1,3 @@
 export { default as ApiKeyDisplay } from './ApiKeyDisplay';
-export { default as ApiKeyModal } from './ApiKeyModal';
+export { createApiKeyModal } from './ApiKeyModal';
 export { default as EditableCell } from './EditableCell';

--- a/src/routes/(main)/settings/creds/features/CreateCredModal/Content.tsx
+++ b/src/routes/(main)/settings/creds/features/CreateCredModal/Content.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { type CredType } from '@lobechat/types';
+import { useModalContext } from '@lobehub/ui/base-ui';
+import { Steps } from 'antd';
+import { createStaticStyles } from 'antd-style';
+import { type FC, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import CredTypeSelector from './CredTypeSelector';
+import FileCredForm from './FileCredForm';
+import KVCredForm from './KVCredForm';
+import OAuthCredForm from './OAuthCredForm';
+
+const styles = createStaticStyles(({ css }) => ({
+  steps: css`
+    margin-block-end: 24px;
+  `,
+}));
+
+export interface CreateCredModalContentProps {
+  onSuccess?: () => void;
+}
+
+const CreateCredModalContent: FC<CreateCredModalContentProps> = ({ onSuccess }) => {
+  const { t } = useTranslation('setting');
+  const { close } = useModalContext();
+  const [step, setStep] = useState(0);
+  const [credType, setCredType] = useState<CredType | null>(null);
+
+  const handleTypeSelect = (type: CredType) => {
+    setCredType(type);
+    setStep(1);
+  };
+
+  const handleBack = () => {
+    setStep(0);
+    setCredType(null);
+  };
+
+  const handleSuccess = () => {
+    onSuccess?.();
+    close();
+  };
+
+  const renderForm = () => {
+    switch (credType) {
+      case 'kv-env':
+      case 'kv-header': {
+        return <KVCredForm type={credType} onBack={handleBack} onSuccess={handleSuccess} />;
+      }
+      case 'oauth': {
+        return <OAuthCredForm onBack={handleBack} onSuccess={handleSuccess} />;
+      }
+      case 'file': {
+        return <FileCredForm onBack={handleBack} onSuccess={handleSuccess} />;
+      }
+      default: {
+        return null;
+      }
+    }
+  };
+
+  return (
+    <>
+      <Steps
+        className={styles.steps}
+        current={step}
+        size={'small'}
+        items={[
+          { title: t('creds.createModal.selectType') },
+          { title: t('creds.createModal.fillForm') },
+        ]}
+      />
+
+      {step === 0 ? <CredTypeSelector onSelect={handleTypeSelect} /> : renderForm()}
+    </>
+  );
+};
+
+export default CreateCredModalContent;

--- a/src/routes/(main)/settings/creds/features/CreateCredModal/index.tsx
+++ b/src/routes/(main)/settings/creds/features/CreateCredModal/index.tsx
@@ -1,100 +1,18 @@
 'use client';
 
-import { type CredType } from '@lobechat/types';
-import { Modal } from '@lobehub/ui';
-import { Steps } from 'antd';
-import { createStaticStyles } from 'antd-style';
-import { type FC, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { createModal, type ModalInstance } from '@lobehub/ui/base-ui';
+import { t } from 'i18next';
 
-import CredTypeSelector from './CredTypeSelector';
-import FileCredForm from './FileCredForm';
-import KVCredForm from './KVCredForm';
-import OAuthCredForm from './OAuthCredForm';
+import CreateCredModalContent, { type CreateCredModalContentProps } from './Content';
 
-const styles = createStaticStyles(({ css }) => ({
-  content: css`
-    padding-block: 24px;
-  `,
-  steps: css`
-    margin-block-end: 24px;
-  `,
-}));
-
-interface CreateCredModalProps {
-  onCancel: () => void;
-  onSuccess: () => void;
-  open: boolean;
-}
-
-const CreateCredModal: FC<CreateCredModalProps> = ({ open, onCancel, onSuccess }) => {
-  const { t } = useTranslation('setting');
-  const [step, setStep] = useState(0);
-  const [credType, setCredType] = useState<CredType | null>(null);
-
-  const handleTypeSelect = (type: CredType) => {
-    setCredType(type);
-    setStep(1);
-  };
-
-  const handleBack = () => {
-    setStep(0);
-    setCredType(null);
-  };
-
-  const handleClose = () => {
-    setStep(0);
-    setCredType(null);
-    onCancel();
-  };
-
-  const handleSuccess = () => {
-    setStep(0);
-    setCredType(null);
-    onSuccess();
-  };
-
-  const renderForm = () => {
-    switch (credType) {
-      case 'kv-env':
-      case 'kv-header': {
-        return <KVCredForm type={credType} onBack={handleBack} onSuccess={handleSuccess} />;
-      }
-      case 'oauth': {
-        return <OAuthCredForm onBack={handleBack} onSuccess={handleSuccess} />;
-      }
-      case 'file': {
-        return <FileCredForm onBack={handleBack} onSuccess={handleSuccess} />;
-      }
-      default: {
-        return null;
-      }
-    }
-  };
-
-  return (
-    <Modal
-      footer={null}
-      open={open}
-      title={t('creds.createModal.title')}
-      width={600}
-      onCancel={handleClose}
-    >
-      <div className={styles.content}>
-        <Steps
-          className={styles.steps}
-          current={step}
-          size="small"
-          items={[
-            { title: t('creds.createModal.selectType') },
-            { title: t('creds.createModal.fillForm') },
-          ]}
-        />
-
-        {step === 0 ? <CredTypeSelector onSelect={handleTypeSelect} /> : renderForm()}
-      </div>
-    </Modal>
-  );
-};
-
-export default CreateCredModal;
+export const createCreateCredModal = (props?: CreateCredModalContentProps): ModalInstance =>
+  createModal({
+    content: <CreateCredModalContent {...props} />,
+    footer: null,
+    maskClosable: true,
+    styles: {
+      content: { paddingBlock: 16, paddingInline: 24 },
+    },
+    title: t('creds.createModal.title', { ns: 'setting' }),
+    width: 'min(90vw, 640px)',
+  });

--- a/src/routes/(main)/settings/creds/features/CredItem.tsx
+++ b/src/routes/(main)/settings/creds/features/CredItem.tsx
@@ -2,7 +2,8 @@
 
 import { type UserCredSummary } from '@lobechat/types';
 import { Avatar, Button, DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
-import { App, Tag } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
+import { Tag } from 'antd';
 import {
   Eye,
   File,
@@ -41,17 +42,14 @@ const typeColors: Record<string, string> = {
 
 const CredItem: FC<CredItemProps> = memo(({ cred, onEdit, onDelete, onView }) => {
   const { t } = useTranslation('setting');
-  const { modal } = App.useApp();
 
   const handleDelete = () => {
-    modal.confirm({
-      centered: true,
+    confirmModal({
       content: t('creds.actions.deleteConfirm.content'),
       okButtonProps: { danger: true },
       okText: t('creds.actions.deleteConfirm.ok'),
       onOk: () => onDelete(cred.id),
       title: t('creds.actions.deleteConfirm.title'),
-      type: 'error',
     });
   };
 

--- a/src/routes/(main)/settings/creds/features/CredsList.tsx
+++ b/src/routes/(main)/settings/creds/features/CredsList.tsx
@@ -6,15 +6,15 @@ import { useMutation } from '@tanstack/react-query';
 import { Empty, Spin } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { LogIn } from 'lucide-react';
-import { type FC, useState } from 'react';
+import { type FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useMarketAuth } from '@/layout/AuthProvider/MarketAuth';
 import { lambdaClient, lambdaQuery } from '@/libs/trpc/client';
 
 import CredItem from './CredItem';
-import EditCredModal from './EditCredModal';
-import ViewCredModal from './ViewCredModal';
+import { createEditCredModal } from './EditCredModal';
+import { createViewCredModal } from './ViewCredModal';
 
 const styles = createStaticStyles(({ css }) => ({
   container: css`
@@ -39,8 +39,6 @@ const styles = createStaticStyles(({ css }) => ({
 
 const CredsList: FC = () => {
   const { t } = useTranslation('setting');
-  const [editingCred, setEditingCred] = useState<UserCredSummary | null>(null);
-  const [viewingCred, setViewingCred] = useState<UserCredSummary | null>(null);
   const { isAuthenticated, isLoading: isAuthLoading, signIn } = useMarketAuth();
 
   const { data, isLoading, refetch } = lambdaQuery.market.creds.list.useQuery(undefined, {
@@ -56,26 +54,30 @@ const CredsList: FC = () => {
 
   const credentials = data?.data ?? [];
 
-  const handleEditSuccess = () => {
-    setEditingCred(null);
-    refetch();
+  const handleEdit = (cred: UserCredSummary) => {
+    createEditCredModal({
+      cred,
+      onSuccess: () => refetch(),
+    });
   };
 
-  // Show loading while checking auth status
+  const handleView = (cred: UserCredSummary) => {
+    createViewCredModal({ cred });
+  };
+
   if (isAuthLoading) {
     return (
-      <Flexbox align="center" justify="center" style={{ padding: 48 }}>
+      <Flexbox align={'center'} justify={'center'} style={{ padding: 48 }}>
         <Spin />
       </Flexbox>
     );
   }
 
-  // Show sign-in prompt if not authenticated
   if (!isAuthenticated) {
     return (
       <div className={styles.signInPrompt}>
         <Empty description={t('creds.signInRequired')} />
-        <Button icon={LogIn} type="primary" onClick={() => signIn()}>
+        <Button icon={LogIn} type={'primary'} onClick={() => signIn()}>
           {t('creds.signIn')}
         </Button>
       </div>
@@ -85,7 +87,7 @@ const CredsList: FC = () => {
   return (
     <div className={styles.container}>
       {isLoading ? (
-        <Flexbox align="center" justify="center" style={{ padding: 48 }}>
+        <Flexbox align={'center'} justify={'center'} style={{ padding: 48 }}>
           <Spin />
         </Flexbox>
       ) : credentials.length === 0 ? (
@@ -97,20 +99,12 @@ const CredsList: FC = () => {
               cred={cred}
               key={cred.id}
               onDelete={(id) => deleteMutation.mutate(id)}
-              onEdit={setEditingCred}
-              onView={setViewingCred}
+              onEdit={handleEdit}
+              onView={handleView}
             />
           ))}
         </Flexbox>
       )}
-
-      <EditCredModal
-        cred={editingCred}
-        open={!!editingCred}
-        onClose={() => setEditingCred(null)}
-        onSuccess={handleEditSuccess}
-      />
-      <ViewCredModal cred={viewingCred} open={!!viewingCred} onClose={() => setViewingCred(null)} />
     </div>
   );
 };

--- a/src/routes/(main)/settings/creds/features/EditCredModal/Content.tsx
+++ b/src/routes/(main)/settings/creds/features/EditCredModal/Content.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { type UserCredSummary } from '@lobechat/types';
+import { useModalContext } from '@lobehub/ui/base-ui';
+import { type FC } from 'react';
+
+import EditKVForm from './EditKVForm';
+import EditMetaForm from './EditMetaForm';
+
+export interface EditCredModalContentProps {
+  cred: UserCredSummary;
+  onSuccess?: () => void;
+}
+
+const EditCredModalContent: FC<EditCredModalContentProps> = ({ cred, onSuccess }) => {
+  const { close } = useModalContext();
+
+  const isKVType = cred.type === 'kv-env' || cred.type === 'kv-header';
+
+  const handleSuccess = () => {
+    onSuccess?.();
+    close();
+  };
+
+  return isKVType ? (
+    <EditKVForm cred={cred} onCancel={close} onSuccess={handleSuccess} />
+  ) : (
+    <EditMetaForm cred={cred} onCancel={close} onSuccess={handleSuccess} />
+  );
+};
+
+export default EditCredModalContent;

--- a/src/routes/(main)/settings/creds/features/EditCredModal/index.tsx
+++ b/src/routes/(main)/settings/creds/features/EditCredModal/index.tsx
@@ -1,48 +1,18 @@
 'use client';
 
-import { type UserCredSummary } from '@lobechat/types';
-import { Modal } from '@lobehub/ui';
-import { type FC } from 'react';
-import { useTranslation } from 'react-i18next';
+import { createModal, type ModalInstance } from '@lobehub/ui/base-ui';
+import { t } from 'i18next';
 
-import EditKVForm from './EditKVForm';
-import EditMetaForm from './EditMetaForm';
+import EditCredModalContent, { type EditCredModalContentProps } from './Content';
 
-interface EditCredModalProps {
-  cred: UserCredSummary | null;
-  onClose: () => void;
-  onSuccess: () => void;
-  open: boolean;
-}
-
-const EditCredModal: FC<EditCredModalProps> = ({ open, onClose, onSuccess, cred }) => {
-  const { t } = useTranslation('setting');
-
-  if (!cred) return null;
-
-  const isKVType = cred.type === 'kv-env' || cred.type === 'kv-header';
-
-  const handleSuccess = () => {
-    onSuccess();
-    onClose();
-  };
-
-  return (
-    <Modal
-      destroyOnClose
-      footer={null}
-      open={open}
-      title={t('creds.edit.title')}
-      width={520}
-      onCancel={onClose}
-    >
-      {isKVType ? (
-        <EditKVForm cred={cred} onCancel={onClose} onSuccess={handleSuccess} />
-      ) : (
-        <EditMetaForm cred={cred} onCancel={onClose} onSuccess={handleSuccess} />
-      )}
-    </Modal>
-  );
-};
-
-export default EditCredModal;
+export const createEditCredModal = (props: EditCredModalContentProps): ModalInstance =>
+  createModal({
+    content: <EditCredModalContent {...props} />,
+    footer: null,
+    maskClosable: true,
+    styles: {
+      content: { paddingBlock: 16, paddingInline: 24 },
+    },
+    title: t('creds.edit.title', { ns: 'setting' }),
+    width: 'min(90vw, 560px)',
+  });

--- a/src/routes/(main)/settings/creds/features/ViewCredModal/Content.tsx
+++ b/src/routes/(main)/settings/creds/features/ViewCredModal/Content.tsx
@@ -3,7 +3,7 @@
 import { type UserCredSummary } from '@lobechat/types';
 import { CopyButton, Flexbox } from '@lobehub/ui';
 import { useQuery } from '@tanstack/react-query';
-import { Alert, Descriptions, Modal, Skeleton, Typography } from 'antd';
+import { Alert, Descriptions, Skeleton, Typography } from 'antd';
 import { createStaticStyles, cx } from 'antd-style';
 import { Eye, EyeOff } from 'lucide-react';
 import { type FC, useState } from 'react';
@@ -84,7 +84,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-// Mask value like "sk-****xxxx"
 const maskValue = (value: string): string => {
   if (value.length <= 4) return '••••••••';
   return '••••••••' + value.slice(-4);
@@ -113,96 +112,89 @@ const KVRow: FC<KVRowProps> = ({ keyName, value }) => {
         >
           {visible ? value : maskValue(value)}
         </Text>
-        <Flexbox horizontal align="center" gap={4}>
+        <Flexbox horizontal align={'center'} gap={4}>
           <div className={styles.toggleBtn} onClick={() => setVisible(!visible)}>
             {visible ? <EyeOff size={16} /> : <Eye size={16} />}
           </div>
-          <CopyButton content={value} size="small" />
+          <CopyButton content={value} size={'small'} />
         </Flexbox>
       </div>
     </div>
   );
 };
 
-interface ViewCredModalProps {
-  cred: UserCredSummary | null;
-  onClose: () => void;
-  open: boolean;
+export interface ViewCredModalContentProps {
+  cred: UserCredSummary;
 }
 
-const ViewCredModal: FC<ViewCredModalProps> = ({ cred, open, onClose }) => {
+const ViewCredModalContent: FC<ViewCredModalContentProps> = ({ cred }) => {
   const { t } = useTranslation('setting');
 
   const { data, isLoading, error } = useQuery({
-    enabled: open && !!cred,
     queryFn: () =>
       lambdaClient.market.creds.get.query({
         decrypt: true,
-        id: cred!.id,
+        id: cred.id,
       }),
-    queryKey: ['cred-plaintext', cred?.id],
+    queryKey: ['cred-plaintext', cred.id],
   });
 
   const values = (data as any)?.plaintext || {};
   const valueEntries = Object.entries(values);
 
+  if (isLoading) {
+    return <Skeleton active paragraph={{ rows: 3 }} />;
+  }
+
+  if (error) {
+    return (
+      <Alert
+        showIcon
+        description={(error as Error).message}
+        message={t('creds.view.error')}
+        type={'error'}
+      />
+    );
+  }
+
   return (
-    <Modal
-      footer={null}
-      open={open}
-      title={t('creds.view.title', { name: cred?.name })}
-      width={560}
-      onCancel={onClose}
-    >
-      {isLoading ? (
-        <Skeleton active paragraph={{ rows: 3 }} />
-      ) : error ? (
+    <>
+      <Alert
+        showIcon
+        message={t('creds.view.warning')}
+        style={{ marginBottom: 16 }}
+        type={'warning'}
+      />
+      <Descriptions bordered column={1} size={'small'}>
+        <Descriptions.Item label={t('creds.table.name')}>{cred.name}</Descriptions.Item>
+        <Descriptions.Item label={t('creds.table.key')}>
+          <code>{cred.key}</code>
+        </Descriptions.Item>
+        <Descriptions.Item label={t('creds.table.type')}>
+          {cred.type ? t(`creds.types.${cred.type}` as any) : '-'}
+        </Descriptions.Item>
+      </Descriptions>
+
+      {valueEntries.length > 0 && (
+        <div className={styles.valuesSection}>
+          <div className={styles.valuesTitle}>{t('creds.view.values')}</div>
+          {valueEntries.map(([key, value]) => (
+            <KVRow key={key} keyName={key} value={String(value)} />
+          ))}
+        </div>
+      )}
+
+      {valueEntries.length === 0 && cred.type === 'oauth' && (
         <Alert
           showIcon
-          description={(error as Error).message}
-          message={t('creds.view.error')}
-          type="error"
+          description={t('creds.view.oauthNote')}
+          message={t('creds.view.noValues')}
+          style={{ marginTop: 16 }}
+          type={'info'}
         />
-      ) : (
-        <>
-          <Alert
-            showIcon
-            message={t('creds.view.warning')}
-            style={{ marginBottom: 16 }}
-            type="warning"
-          />
-          <Descriptions bordered column={1} size="small">
-            <Descriptions.Item label={t('creds.table.name')}>{cred?.name}</Descriptions.Item>
-            <Descriptions.Item label={t('creds.table.key')}>
-              <code>{cred?.key}</code>
-            </Descriptions.Item>
-            <Descriptions.Item label={t('creds.table.type')}>
-              {cred?.type ? t(`creds.types.${cred.type}` as any) : '-'}
-            </Descriptions.Item>
-          </Descriptions>
-
-          {valueEntries.length > 0 && (
-            <div className={styles.valuesSection}>
-              <div className={styles.valuesTitle}>{t('creds.view.values')}</div>
-              {valueEntries.map(([key, value]) => (
-                <KVRow key={key} keyName={key} value={String(value)} />
-              ))}
-            </div>
-          )}
-
-          {valueEntries.length === 0 && cred?.type === 'oauth' && (
-            <Alert
-              showIcon
-              description={t('creds.view.oauthNote')}
-              message={t('creds.view.noValues')}
-              style={{ marginTop: 16 }}
-              type="info"
-            />
-          )}
-        </>
       )}
-    </Modal>
+    </>
   );
 };
 
-export default ViewCredModal;
+export default ViewCredModalContent;

--- a/src/routes/(main)/settings/creds/features/ViewCredModal/index.tsx
+++ b/src/routes/(main)/settings/creds/features/ViewCredModal/index.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { createModal, type ModalInstance } from '@lobehub/ui/base-ui';
+import { t } from 'i18next';
+
+import ViewCredModalContent, { type ViewCredModalContentProps } from './Content';
+
+export const createViewCredModal = (props: ViewCredModalContentProps): ModalInstance =>
+  createModal({
+    content: <ViewCredModalContent {...props} />,
+    footer: null,
+    maskClosable: true,
+    styles: {
+      content: { paddingBlock: 16, paddingInline: 24 },
+    },
+    title: t('creds.view.title', { name: props.cred.name, ns: 'setting' }),
+    width: 'min(90vw, 600px)',
+  });

--- a/src/routes/(main)/settings/creds/features/index.ts
+++ b/src/routes/(main)/settings/creds/features/index.ts
@@ -1,6 +1,6 @@
-export { default as CreateCredModal } from './CreateCredModal';
+export { createCreateCredModal } from './CreateCredModal';
 export { default as CredDisplay } from './CredDisplay';
 export { default as CredItem } from './CredItem';
 export { default as CredsList } from './CredsList';
-export { default as EditCredModal } from './EditCredModal';
-export { default as ViewCredModal } from './ViewCredModal';
+export { createEditCredModal } from './EditCredModal';
+export { createViewCredModal } from './ViewCredModal';

--- a/src/routes/(main)/settings/creds/index.tsx
+++ b/src/routes/(main)/settings/creds/index.tsx
@@ -7,17 +7,17 @@ import { useTranslation } from 'react-i18next';
 
 import SettingHeader from '@/routes/(main)/settings/features/SettingHeader';
 
-import CreateCredModal from './features/CreateCredModal';
+import { createCreateCredModal } from './features/CreateCredModal';
 import CredsList from './features/CredsList';
 
 const Page = () => {
   const { t } = useTranslation('setting');
-  const [createModalOpen, setCreateModalOpen] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
 
-  const handleCreateSuccess = () => {
-    setCreateModalOpen(false);
-    setRefreshKey((k) => k + 1);
+  const handleCreate = () => {
+    createCreateCredModal({
+      onSuccess: () => setRefreshKey((k) => k + 1),
+    });
   };
 
   return (
@@ -25,17 +25,12 @@ const Page = () => {
       <SettingHeader
         title={t('tab.creds')}
         extra={
-          <Button icon={<Icon icon={Plus} />} size="large" onClick={() => setCreateModalOpen(true)}>
+          <Button icon={<Icon icon={Plus} />} size={'large'} onClick={handleCreate}>
             {t('creds.create')}
           </Button>
         }
       />
       <CredsList key={refreshKey} />
-      <CreateCredModal
-        open={createModalOpen}
-        onCancel={() => setCreateModalOpen(false)}
-        onSuccess={handleCreateSuccess}
-      />
     </>
   );
 };

--- a/src/routes/(main)/settings/profile/features/KlavisAuthorizationList/index.tsx
+++ b/src/routes/(main)/settings/profile/features/KlavisAuthorizationList/index.tsx
@@ -1,9 +1,9 @@
 import { KLAVIS_SERVER_TYPES } from '@lobechat/const';
 import { Avatar, Flexbox, Tag } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { modal } from '@/components/AntdStaticMethods';
 import { useToolStore } from '@/store/tool';
 import { type KlavisServer } from '@/store/tool/slices/klavisStore';
 
@@ -22,7 +22,7 @@ const KlavisAuthItem = memo<KlavisAuthItemProps>(({ server }) => {
 
   // Handle deauthorization
   const handleRevoke = useCallback(() => {
-    modal.confirm({
+    confirmModal({
       content: t('profile.authorizations.revoke.description'),
       okButtonProps: { danger: true },
       onOk: async () => {

--- a/src/routes/(main)/settings/profile/features/SSOProvidersList/index.tsx
+++ b/src/routes/(main)/settings/profile/features/SSOProvidersList/index.tsx
@@ -1,12 +1,13 @@
 import { isDesktop } from '@lobechat/const';
 import { type MenuProps } from '@lobehub/ui';
 import { ActionIcon, DropdownMenu, Flexbox, Text } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { ArrowRight, Plus, Unlink } from 'lucide-react';
 import { type CSSProperties } from 'react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { modal, notification } from '@/components/AntdStaticMethods';
+import { notification } from '@/components/AntdStaticMethods';
 import AuthIcons from '@/components/AuthIcons';
 import { isBuiltinProvider, normalizeProviderId } from '@/libs/better-auth/utils/client';
 import { useServerConfigStore } from '@/store/serverConfig';
@@ -54,7 +55,7 @@ export const SSOProvidersList = memo(() => {
       });
       return;
     }
-    modal.confirm({
+    confirmModal({
       content: t('profile.sso.unlink.description', { provider }),
       okButtonProps: {
         danger: true,

--- a/src/routes/(main)/settings/provider/ProviderMenu/AddNew.tsx
+++ b/src/routes/(main)/settings/provider/ProviderMenu/AddNew.tsx
@@ -2,25 +2,22 @@
 
 import { ActionIcon } from '@lobehub/ui';
 import { PlusIcon } from 'lucide-react';
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import CreateNewProvider from '../features/CreateNewProvider';
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
+
+import { createCreateNewProviderModal } from '../features/CreateNewProvider';
 
 const AddNewProvider = () => {
   const { t } = useTranslation('modelProvider');
-  const [open, setOpen] = useState(false);
 
   return (
-    <>
-      <ActionIcon
-        icon={PlusIcon}
-        size={'small'}
-        title={t('menu.addCustomProvider')}
-        onClick={() => setOpen(true)}
-      />
-      <CreateNewProvider open={open} onClose={() => setOpen(false)} />
-    </>
+    <ActionIcon
+      icon={PlusIcon}
+      size={DESKTOP_HEADER_ICON_SMALL_SIZE}
+      title={t('menu.addCustomProvider')}
+      onClick={() => createCreateNewProviderModal()}
+    />
   );
 };
 

--- a/src/routes/(main)/settings/provider/features/CreateNewProvider/Content.tsx
+++ b/src/routes/(main)/settings/provider/features/CreateNewProvider/Content.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { ProviderIcon } from '@lobehub/icons';
+import { Button, Flexbox, Input, InputPassword, Text, TextArea } from '@lobehub/ui';
+import { Select, useModalContext } from '@lobehub/ui/base-ui';
+import { App, Form } from 'antd';
+import { memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+
+import { useAiInfraStore } from '@/store/aiInfra/store';
+import { type CreateAiProviderParams } from '@/types/aiProvider';
+
+import { KeyVaultsConfigKey, LLMProviderApiTokenKey, LLMProviderBaseUrlKey } from '../../const';
+import { CUSTOM_PROVIDER_SDK_OPTIONS } from '../customProviderSdkOptions';
+import { normalizeProviderSettings } from '../providerSettings';
+
+const SectionTitle = memo<{ children: React.ReactNode }>(({ children }) => (
+  <Text fontSize={13} type={'secondary'} weight={500}>
+    {children}
+  </Text>
+));
+
+const CreateNewProviderContent = memo(() => {
+  const { t } = useTranslation('modelProvider');
+  const [form] = Form.useForm<CreateAiProviderParams>();
+  const [loading, setLoading] = useState(false);
+  const createNewAiProvider = useAiInfraStore((s) => s.createNewAiProvider);
+  const { message } = App.useApp();
+  const navigate = useNavigate();
+  const { close } = useModalContext();
+
+  const onFinish = async (values: CreateAiProviderParams) => {
+    setLoading(true);
+
+    try {
+      const finalValues = {
+        ...values,
+        name: values.name || values.id,
+        settings: normalizeProviderSettings({
+          nextSettings: values.settings,
+        }) as CreateAiProviderParams['settings'],
+      };
+
+      await createNewAiProvider(finalValues);
+      setLoading(false);
+      navigate(`/settings/provider/${values.id}`);
+      message.success(t('createNewAiProvider.createSuccess'));
+      close();
+    } catch (e) {
+      console.error(e);
+      setLoading(false);
+    }
+  };
+
+  const itemStyle = { marginBottom: 0 };
+
+  return (
+    <Form
+      colon={false}
+      form={form}
+      layout={'vertical'}
+      scrollToFirstError={{ behavior: 'instant', block: 'end', focus: true }}
+      onFinish={onFinish}
+    >
+      <Flexbox gap={16}>
+        <SectionTitle>{t('createNewAiProvider.basicTitle')}</SectionTitle>
+
+        <Form.Item
+          extra={t('createNewAiProvider.id.desc')}
+          label={t('createNewAiProvider.id.title')}
+          name={'id'}
+          style={itemStyle}
+          rules={[
+            { message: t('createNewAiProvider.id.required'), required: true },
+            {
+              message: t('createNewAiProvider.id.format'),
+              pattern: /^[\d_a-z-]+$/,
+            },
+            {
+              message: t('createNewAiProvider.id.duplicate'),
+              validator: (_, value: string) => {
+                const list = useAiInfraStore.getState().aiProviderList;
+                if (value && list.some((p) => p.id === value)) {
+                  return Promise.reject();
+                }
+                return Promise.resolve();
+              },
+            },
+          ]}
+        >
+          <Input
+            autoFocus
+            placeholder={t('createNewAiProvider.id.placeholder')}
+            variant={'filled'}
+          />
+        </Form.Item>
+
+        <Form.Item label={t('createNewAiProvider.name.title')} name={'name'} style={itemStyle}>
+          <Input placeholder={t('createNewAiProvider.name.placeholder')} variant={'filled'} />
+        </Form.Item>
+
+        <Form.Item
+          label={t('createNewAiProvider.description.title')}
+          name={'description'}
+          style={itemStyle}
+        >
+          <TextArea
+            placeholder={t('createNewAiProvider.description.placeholder')}
+            style={{ minHeight: 72 }}
+            variant={'filled'}
+          />
+        </Form.Item>
+
+        <Form.Item label={t('createNewAiProvider.logo.title')} name={'logo'} style={itemStyle}>
+          <Input
+            allowClear
+            placeholder={t('createNewAiProvider.logo.placeholder')}
+            variant={'filled'}
+          />
+        </Form.Item>
+
+        <div style={{ marginBlockStart: 8 }}>
+          <SectionTitle>{t('createNewAiProvider.configTitle')}</SectionTitle>
+        </div>
+
+        <Form.Item
+          label={t('createNewAiProvider.sdkType.title')}
+          name={['settings', 'sdkType']}
+          rules={[{ message: t('createNewAiProvider.sdkType.required'), required: true }]}
+          style={itemStyle}
+        >
+          <Select
+            options={CUSTOM_PROVIDER_SDK_OPTIONS}
+            placeholder={t('createNewAiProvider.sdkType.placeholder')}
+            variant={'filled'}
+            optionRender={({ label, value }) => {
+              const iconProvider = value === 'router' ? 'newapi' : (value as string);
+              return (
+                <Flexbox horizontal align={'center'} gap={8}>
+                  <ProviderIcon provider={iconProvider} size={18} />
+                  {label}
+                </Flexbox>
+              );
+            }}
+          />
+        </Form.Item>
+
+        <Form.Item
+          label={t('createNewAiProvider.proxyUrl.title')}
+          name={[KeyVaultsConfigKey, LLMProviderBaseUrlKey]}
+          rules={[{ message: t('createNewAiProvider.proxyUrl.required'), required: true }]}
+          style={itemStyle}
+        >
+          <Input
+            allowClear
+            placeholder={t('createNewAiProvider.proxyUrl.placeholder')}
+            variant={'filled'}
+          />
+        </Form.Item>
+
+        <Form.Item
+          label={t('createNewAiProvider.apiKey.title')}
+          name={[KeyVaultsConfigKey, LLMProviderApiTokenKey]}
+          style={itemStyle}
+        >
+          <InputPassword
+            autoComplete={'new-password'}
+            placeholder={t('createNewAiProvider.apiKey.placeholder')}
+            variant={'filled'}
+          />
+        </Form.Item>
+
+        <Button block htmlType={'submit'} loading={loading} type={'primary'}>
+          {t('createNewAiProvider.confirm')}
+        </Button>
+      </Flexbox>
+    </Form>
+  );
+});
+
+export default CreateNewProviderContent;

--- a/src/routes/(main)/settings/provider/features/CreateNewProvider/index.tsx
+++ b/src/routes/(main)/settings/provider/features/CreateNewProvider/index.tsx
@@ -1,187 +1,25 @@
-import { ProviderIcon } from '@lobehub/icons';
-import { type FormItemProps } from '@lobehub/ui';
-import { Flexbox, FormModal, Icon, Input, InputPassword, Select, TextArea } from '@lobehub/ui';
-import { App } from 'antd';
+'use client';
+
+import { Flexbox, Icon } from '@lobehub/ui';
+import { createModal, type ModalInstance } from '@lobehub/ui/base-ui';
+import { t } from 'i18next';
 import { BrainIcon } from 'lucide-react';
-import { memo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 
-import { useAiInfraStore } from '@/store/aiInfra/store';
-import { type CreateAiProviderParams } from '@/types/aiProvider';
+import CreateNewProviderContent from './Content';
 
-import { KeyVaultsConfigKey, LLMProviderApiTokenKey, LLMProviderBaseUrlKey } from '../../const';
-import { CUSTOM_PROVIDER_SDK_OPTIONS } from '../customProviderSdkOptions';
-import { normalizeProviderSettings } from '../providerSettings';
-
-interface CreateNewProviderProps {
-  onClose?: () => void;
-  open?: boolean;
-}
-
-const CreateNewProvider = memo<CreateNewProviderProps>(({ onClose, open }) => {
-  const { t } = useTranslation('modelProvider');
-  const [loading, setLoading] = useState(false);
-  const createNewAiProvider = useAiInfraStore((s) => s.createNewAiProvider);
-  const { message } = App.useApp();
-  const navigate = useNavigate();
-  const onFinish = async (values: CreateAiProviderParams) => {
-    setLoading(true);
-
-    try {
-      // If name is empty, use id as the name
-      const finalValues = {
-        ...values,
-        name: values.name || values.id,
-        settings: normalizeProviderSettings({
-          nextSettings: values.settings,
-        }) as CreateAiProviderParams['settings'],
-      };
-
-      await createNewAiProvider(finalValues);
-      setLoading(false);
-      navigate(`/settings/provider/${values.id}`);
-      message.success(t('createNewAiProvider.createSuccess'));
-      onClose?.();
-    } catch (e) {
-      console.error(e);
-      setLoading(false);
-    }
-  };
-
-  const basicItems: FormItemProps[] = [
-    {
-      children: (
-        <Input autoFocus placeholder={t('createNewAiProvider.id.placeholder')} variant={'filled'} />
-      ),
-      desc: t('createNewAiProvider.id.desc'),
-      label: t('createNewAiProvider.id.title'),
-      minWidth: 400,
-      name: 'id',
-      rules: [
-        { message: t('createNewAiProvider.id.required'), required: true },
-        {
-          message: t('createNewAiProvider.id.format'),
-          pattern: /^[\d_a-z-]+$/,
-        },
-        {
-          message: t('createNewAiProvider.id.duplicate'),
-          validator: (_, value: string) => {
-            const list = useAiInfraStore.getState().aiProviderList;
-            if (value && list.some((p) => p.id === value)) {
-              return Promise.reject();
-            }
-            return Promise.resolve();
-          },
-        },
-      ],
+export const createCreateNewProviderModal = (): ModalInstance =>
+  createModal({
+    content: <CreateNewProviderContent />,
+    footer: null,
+    maskClosable: true,
+    styles: {
+      content: { paddingBlock: 16, paddingInline: 24 },
     },
-    {
-      children: (
-        <Input placeholder={t('createNewAiProvider.name.placeholder')} variant={'filled'} />
-      ),
-      label: t('createNewAiProvider.name.title'),
-      minWidth: 400,
-      name: 'name',
-    },
-    {
-      children: (
-        <TextArea
-          placeholder={t('createNewAiProvider.description.placeholder')}
-          style={{ minHeight: 80 }}
-          variant={'filled'}
-        />
-      ),
-      label: t('createNewAiProvider.description.title'),
-      minWidth: 400,
-      name: 'description',
-    },
-    {
-      children: (
-        <Input
-          allowClear
-          placeholder={t('createNewAiProvider.logo.placeholder')}
-          variant={'filled'}
-        />
-      ),
-      label: t('createNewAiProvider.logo.title'),
-      minWidth: 400,
-      name: 'logo',
-    },
-  ];
-
-  const configItems: FormItemProps[] = [
-    {
-      children: (
-        <Select
-          options={CUSTOM_PROVIDER_SDK_OPTIONS}
-          placeholder={t('createNewAiProvider.sdkType.placeholder')}
-          variant={'filled'}
-          optionRender={({ label, value }) => {
-            // Map 'router' to 'newapi' for displaying the correct icon
-            const iconProvider = value === 'router' ? 'newapi' : (value as string);
-            return (
-              <Flexbox horizontal align={'center'} gap={8}>
-                <ProviderIcon provider={iconProvider} size={18} />
-                {label}
-              </Flexbox>
-            );
-          }}
-        />
-      ),
-      label: t('createNewAiProvider.sdkType.title'),
-      minWidth: 400,
-      name: ['settings', 'sdkType'],
-      rules: [{ message: t('createNewAiProvider.sdkType.required'), required: true }],
-    },
-    {
-      children: <Input allowClear placeholder={t('createNewAiProvider.proxyUrl.placeholder')} />,
-      label: t('createNewAiProvider.proxyUrl.title'),
-      minWidth: 400,
-      name: [KeyVaultsConfigKey, LLMProviderBaseUrlKey],
-      rules: [{ message: t('createNewAiProvider.proxyUrl.required'), required: true }],
-    },
-    {
-      children: (
-        <InputPassword
-          autoComplete={'new-password'}
-          placeholder={t('createNewAiProvider.apiKey.placeholder')}
-          variant={'filled'}
-        />
-      ),
-      label: t('createNewAiProvider.apiKey.title'),
-      minWidth: 400,
-      name: [KeyVaultsConfigKey, LLMProviderApiTokenKey],
-    },
-  ];
-
-  return (
-    <FormModal
-      destroyOnHidden
-      open={open}
-      scrollToFirstError={{ behavior: 'instant', block: 'end', focus: true }}
-      submitLoading={loading}
-      submitText={t('createNewAiProvider.confirm')}
-      items={[
-        {
-          children: basicItems,
-          title: t('createNewAiProvider.basicTitle'),
-        },
-        {
-          children: configItems,
-          title: t('createNewAiProvider.configTitle'),
-        },
-      ]}
-      title={
-        <Flexbox horizontal gap={8}>
-          <Icon icon={BrainIcon} />
-          {t('createNewAiProvider.title')}
-        </Flexbox>
-      }
-      onCancel={onClose}
-      onFinish={onFinish}
-    />
-  );
-});
-
-export default CreateNewProvider;
+    title: (
+      <Flexbox horizontal align={'center'} gap={8}>
+        <Icon icon={BrainIcon} />
+        {t('createNewAiProvider.title', { ns: 'modelProvider' })}
+      </Flexbox>
+    ),
+    width: 'min(90vw, 640px)',
+  });

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/Form.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/Form.tsx
@@ -1,6 +1,7 @@
 import { Input } from '@lobehub/ui';
+import { Select } from '@lobehub/ui/base-ui';
 import { type FormInstance } from 'antd';
-import { Checkbox, Form, Select } from 'antd';
+import { Checkbox, Form } from 'antd';
 import { type AiModelType } from 'model-bank';
 import { memo, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/routes/(main)/settings/provider/features/ModelList/ModelItem.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/ModelItem.tsx
@@ -1,5 +1,6 @@
 import { ModelIcon } from '@lobehub/icons';
 import { ActionIcon, copyToClipboard, Flexbox, Tag, Text } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App, Switch } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { LucidePencil, TrashIcon } from 'lucide-react';
@@ -154,7 +155,7 @@ const ModelItem = memo<ModelItemProps>(
       ...formatPricing(),
     ].filter(Boolean) as string[];
 
-    const { message, modal } = App.useApp();
+    const { message } = App.useApp();
     const copyModelId = async () => {
       await copyToClipboard(id);
       message.success({ content: t('copySuccess', { ns: 'common' }) });
@@ -203,11 +204,9 @@ const ModelItem = memo<ModelItemProps>(
               size={'small'}
               title={t('providerModels.item.delete.title')}
               onClick={() => {
-                modal.confirm({
-                  centered: true,
+                confirmModal({
                   okButtonProps: {
                     danger: true,
-                    type: 'primary',
                   },
                   onOk: async () => {
                     await removeAiModel(id, activeAiProvider!);

--- a/src/routes/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
@@ -1,4 +1,5 @@
 import { ActionIcon, Button, DropdownMenu, Flexbox, Skeleton, Text } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App, Space } from 'antd';
 import { cssVar } from 'antd-style';
 import { CircleX, EllipsisVertical, LucideRefreshCcwDot, PlusIcon } from 'lucide-react';
@@ -21,7 +22,7 @@ interface ModelFetcherProps {
 const ModelTitle = memo<ModelFetcherProps>(
   ({ provider, showAddNewModel = true, showModelFetcher = true }) => {
     const { t } = useTranslation('modelProvider');
-    const { modal, message } = App.useApp();
+    const { message } = App.useApp();
     const [
       searchKeyword,
       totalModels,
@@ -147,7 +148,7 @@ const ModelTitle = memo<ModelFetcherProps>(
                       key: 'reset',
                       label: t('providerModels.list.resetAll.title'),
                       onClick: async () => {
-                        modal.confirm({
+                        confirmModal({
                           content: t('providerModels.list.resetAll.conform'),
                           onOk: async () => {
                             await clearModelsByProvider(provider);

--- a/src/routes/(main)/settings/provider/features/ProviderConfig/OAuthDeviceFlowAuth/index.tsx
+++ b/src/routes/(main)/settings/provider/features/ProviderConfig/OAuthDeviceFlowAuth/index.tsx
@@ -3,7 +3,8 @@
 import { CheckCircleFilled } from '@ant-design/icons';
 import { ProviderIcon } from '@lobehub/icons';
 import { CopyButton, Flexbox, Icon } from '@lobehub/ui';
-import { App, Avatar, Button, Typography } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
+import { Avatar, Button, Typography } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ExternalLinkIcon, Loader2Icon, LogOutIcon, UnplugIcon } from 'lucide-react';
 import { type ReactNode } from 'react';
@@ -130,7 +131,6 @@ export interface OAuthDeviceFlowAuthProps {
 const OAuthDeviceFlowAuth = memo<OAuthDeviceFlowAuthProps>(
   ({ providerId, name, onAuthChange, title, extra }) => {
     const { t } = useTranslation('modelProvider');
-    const { modal } = App.useApp();
     const [isAuthenticating, setIsAuthenticating] = useState(false);
     const hasAutoClosedRef = useRef(false);
 
@@ -165,8 +165,7 @@ const OAuthDeviceFlowAuth = memo<OAuthDeviceFlowAuthProps>(
     });
 
     const handleDisconnect = useCallback(() => {
-      modal.confirm({
-        centered: true,
+      confirmModal({
         content: t('providerModels.config.oauth.disconnectConfirm'),
         okButtonProps: { danger: true },
         okText: t('providerModels.config.oauth.disconnect'),
@@ -175,7 +174,7 @@ const OAuthDeviceFlowAuth = memo<OAuthDeviceFlowAuthProps>(
         },
         title: t('providerModels.config.oauth.disconnect'),
       });
-    }, [modal, providerId, revokeAuth, t]);
+    }, [providerId, revokeAuth, t]);
 
     const handleStartAuth = useCallback(async () => {
       hasAutoClosedRef.current = false;

--- a/src/routes/(main)/settings/provider/features/ProviderConfig/UpdateProviderInfo/SettingModal.tsx
+++ b/src/routes/(main)/settings/provider/features/ProviderConfig/UpdateProviderInfo/SettingModal.tsx
@@ -1,6 +1,7 @@
 import { ProviderIcon } from '@lobehub/icons';
 import { type FormItemProps } from '@lobehub/ui';
 import { Button, Flexbox, FormModal, Icon, Input, Select, TextArea } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { BrainIcon } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -28,7 +29,7 @@ const CreateNewProvider = memo<CreateNewProviderProps>(({ onClose, open, initial
     s.deleteAiProvider,
   ]);
 
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
   const navigate = useNavigate();
 
   const onFinish = async (values: UpdateAiProviderParams) => {
@@ -140,7 +141,7 @@ const CreateNewProvider = memo<CreateNewProviderProps>(({ onClose, open, initial
             disabled={loading}
             type={'primary'}
             onClick={() => {
-              modal.confirm({
+              confirmModal({
                 okButtonProps: {
                   danger: true,
                 },

--- a/src/routes/(main)/settings/skill/features/Actions.tsx
+++ b/src/routes/(main)/settings/skill/features/Actions.tsx
@@ -1,5 +1,6 @@
 import { Button, DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
-import { App, Space } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
+import { Space } from 'antd';
 import { MoreHorizontalIcon, Trash2 } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -38,7 +39,6 @@ const Actions = memo<ActionsProps>(({ identifier, type, isMCP }) => {
     s.togglePlugin,
     agentSelectors.currentAgentPlugins(s).includes(identifier),
   ]);
-  const { modal } = App.useApp();
   const hasSettings = pluginHelpers.isSettingSchemaNonEmpty(plugin?.settings);
 
   const [showModal, setModal] = useState(false);
@@ -85,8 +85,7 @@ const Actions = memo<ActionsProps>(({ identifier, type, isMCP }) => {
                   key: 'uninstall',
                   label: t('store.actions.uninstall'),
                   onClick: () => {
-                    modal.confirm({
-                      centered: true,
+                    confirmModal({
                       okButtonProps: { danger: true },
                       onOk: async () => {
                         // If plugin is enabled in current agent, disable it first
@@ -96,7 +95,6 @@ const Actions = memo<ActionsProps>(({ identifier, type, isMCP }) => {
                         await unInstallPlugin(identifier);
                       },
                       title: t('store.actions.confirmUninstall'),
-                      type: 'error',
                     });
                   },
                 },

--- a/src/routes/(main)/settings/skill/features/AgentSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/AgentSkillItem.tsx
@@ -11,8 +11,9 @@ import {
   stopPropagation,
   Tag,
 } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
-import { App, Space } from 'antd';
+import { Space } from 'antd';
 import { DownloadIcon, MoreHorizontalIcon, Plus, Trash2 } from 'lucide-react';
 import { lazy, memo, Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -40,7 +41,6 @@ const AgentSkillItem = memo<AgentSkillItemProps>(({ skill }) => {
   const { t } = useTranslation('setting');
   const { t: tc } = useTranslation('common');
   const { t: tp } = useTranslation('plugin');
-  const { modal } = App.useApp();
   const [loading, setLoading] = useState(false);
   const [detailOpen, setDetailOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
@@ -76,8 +76,7 @@ const AgentSkillItem = memo<AgentSkillItemProps>(({ skill }) => {
   };
 
   const handleUninstall = () => {
-    modal.confirm({
-      centered: true,
+    confirmModal({
       okButtonProps: { danger: true },
       onOk: async () => {
         if (isBuiltin) {
@@ -92,7 +91,6 @@ const AgentSkillItem = memo<AgentSkillItemProps>(({ skill }) => {
         }
       },
       title: tp('store.actions.confirmUninstall'),
-      type: 'error',
     });
   };
 

--- a/src/routes/(main)/settings/skill/features/BuiltinSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/BuiltinSkillItem.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Avatar, Button, DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
-import { App } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { MoreHorizontalIcon, Plus, Trash2 } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -21,7 +21,6 @@ interface BuiltinSkillItemProps {
 
 const BuiltinSkillItem = memo<BuiltinSkillItemProps>(({ identifier, title, avatar }) => {
   const { t } = useTranslation(['setting', 'plugin']);
-  const { modal } = App.useApp();
 
   const [installBuiltinTool, uninstallBuiltinTool, isInstalled] = useToolStore((s) => [
     s.installBuiltinTool,
@@ -34,14 +33,12 @@ const BuiltinSkillItem = memo<BuiltinSkillItemProps>(({ identifier, title, avata
   };
 
   const handleUninstall = () => {
-    modal.confirm({
-      centered: true,
+    confirmModal({
       okButtonProps: { danger: true },
       onOk: async () => {
         await uninstallBuiltinTool(identifier);
       },
       title: t('store.actions.confirmUninstall', { ns: 'plugin' }),
-      type: 'error',
     });
   };
 

--- a/src/routes/(main)/settings/skill/features/KlavisSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/KlavisSkillItem.tsx
@@ -2,7 +2,8 @@
 
 import { type KlavisServerType } from '@lobechat/const';
 import { Avatar, Button as LobeButton, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
-import { App, Button } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
+import { Button } from 'antd';
 import { cssVar } from 'antd-style';
 import { Loader2, MoreHorizontalIcon, SquareArrowOutUpRight, Unplug } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
@@ -28,7 +29,6 @@ interface KlavisSkillItemProps {
 
 const KlavisSkillItem = memo<KlavisSkillItemProps>(({ serverType, server }) => {
   const { t } = useTranslation('setting');
-  const { modal } = App.useApp();
   const [isConnecting, setIsConnecting] = useState(false);
   const [isWaitingAuth, setIsWaitingAuth] = useState(false);
 
@@ -164,9 +164,8 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(({ serverType, server }) => {
 
   const handleDisconnect = () => {
     if (!server) return;
-    modal.confirm({
+    confirmModal({
       cancelText: t('cancel', { ns: 'common' }),
-      centered: true,
       content: t('tools.lobehubSkill.disconnectConfirm.desc', { name: serverType.label }),
       okButtonProps: { danger: true },
       okText: t('tools.lobehubSkill.disconnect'),

--- a/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
@@ -2,7 +2,8 @@
 
 import { type LobehubSkillProviderType } from '@lobechat/const';
 import { Avatar, Button as LobeButton, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
-import { App, Button } from 'antd';
+import { confirmModal } from '@lobehub/ui/base-ui';
+import { Button } from 'antd';
 import { cssVar } from 'antd-style';
 import { Loader2, MoreHorizontalIcon, SquareArrowOutUpRight, Unplug } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
@@ -26,7 +27,6 @@ interface LobehubSkillItemProps {
 
 const LobehubSkillItem = memo<LobehubSkillItemProps>(({ provider, server }) => {
   const { t } = useTranslation('setting');
-  const { modal } = App.useApp();
   const [isConnecting, setIsConnecting] = useState(false);
   const [isWaitingAuth, setIsWaitingAuth] = useState(false);
 
@@ -167,9 +167,8 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(({ provider, server }) => {
 
   const handleDisconnect = () => {
     if (!server) return;
-    modal.confirm({
+    confirmModal({
       cancelText: t('cancel', { ns: 'common' }),
-      centered: true,
       content: t('tools.lobehubSkill.disconnectConfirm.desc', { name: provider.label }),
       okButtonProps: { danger: true },
       okText: t('tools.lobehubSkill.disconnect'),

--- a/src/routes/(main)/settings/storage/features/Advanced.tsx
+++ b/src/routes/(main)/settings/storage/features/Advanced.tsx
@@ -3,6 +3,7 @@
 import { BRANDING_NAME } from '@lobechat/business-const';
 import { type FormGroupItemType } from '@lobehub/ui';
 import { Button, Form, Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App, Switch } from 'antd';
 import { HardDriveDownload, HardDriveUpload } from 'lucide-react';
 import { useCallback } from 'react';
@@ -23,7 +24,7 @@ import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 const AdvancedActions = () => {
   const { t } = useTranslation('setting');
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
   const { hideDocs } = useServerConfigStore(featureFlagsSelectors);
   const enableBusinessFeatures = useServerConfigStore(serverConfigSelectors.enableBusinessFeatures);
   const checked = useUserStore(userGeneralSettingsSelectors.telemetry);
@@ -41,8 +42,7 @@ const AdvancedActions = () => {
   const updateGeneralConfig = useUserStore((s) => s.updateGeneralConfig);
 
   const handleClear = useCallback(() => {
-    modal.confirm({
-      centered: true,
+    confirmModal({
       okButtonProps: {
         danger: true,
       },
@@ -64,15 +64,13 @@ const AdvancedActions = () => {
     clearSessions,
     clearTopics,
     message,
-    modal,
     removeAllFiles,
     removeAllPlugins,
     t,
   ]);
 
   const handleReset = useCallback(() => {
-    modal.confirm({
-      centered: true,
+    confirmModal({
       okButtonProps: { danger: true },
       onOk: () => {
         resetSettings();
@@ -80,7 +78,7 @@ const AdvancedActions = () => {
       },
       title: t('danger.reset.confirm'),
     });
-  }, [message, modal, resetSettings, t]);
+  }, [message, resetSettings, t]);
 
   const renderExportButtonFormItem = () => {
     return {

--- a/src/routes/(mobile)/(home)/features/SessionListContent/CollapseGroup/Actions.tsx
+++ b/src/routes/(mobile)/(home)/features/SessionListContent/CollapseGroup/Actions.tsx
@@ -1,5 +1,6 @@
 import { type DropdownMenuProps, type MenuProps } from '@lobehub/ui';
 import { ActionIcon, DropdownMenu, Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { MoreVertical, PencilLine, Plus, Settings2, Trash, UsersRound } from 'lucide-react';
@@ -30,7 +31,7 @@ type MenuItemType = ItemOfType<MenuProps['items']>;
 const Actions = memo<ActionsProps>(
   ({ id, openRenameModal, openConfigModal, onOpenChange, isCustomGroup, isPinned }) => {
     const { t } = useTranslation('chat');
-    const { modal, message } = App.useApp();
+    const { message } = App.useApp();
 
     const isMobile = useIsMobile();
     const [isGroupModalOpen, setIsGroupModalOpen] = useState(false);
@@ -140,11 +141,7 @@ const Actions = memo<ActionsProps>(
           label: t('delete', { ns: 'common' }),
           onClick: ({ domEvent }) => {
             domEvent.stopPropagation();
-            modal.confirm({
-              centered: true,
-              classNames: {
-                root: styles.modalRoot,
-              },
+            confirmModal({
               okButtonProps: { danger: true },
               onOk: async () => {
                 if (!id) return;

--- a/src/routes/(mobile)/(home)/features/SessionListContent/List/Item/Actions.tsx
+++ b/src/routes/(mobile)/(home)/features/SessionListContent/List/Item/Actions.tsx
@@ -1,4 +1,5 @@
 import { ActionIcon, DropdownMenu, Icon } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { type ItemType } from 'antd/es/menu/interface';
 import { createStaticStyles } from 'antd-style';
@@ -63,7 +64,7 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
     s.removeAgentGroup,
   ]);
 
-  const { modal, message } = App.useApp();
+  const { message } = App.useApp();
 
   const isDefault = group === SessionDefaultGroup.Default;
 
@@ -154,11 +155,7 @@ const Actions = memo<ActionProps>(({ group, id, openCreateGroupModal, parentType
             label: t('delete', { ns: 'common' }),
             onClick: ({ domEvent }) => {
               domEvent.stopPropagation();
-              modal.confirm({
-                centered: true,
-                classNames: {
-                  root: styles.modalRoot,
-                },
+              confirmModal({
                 okButtonProps: { danger: true },
                 onOk: async () => {
                   if (parentType === 'group') {

--- a/src/routes/(mobile)/(home)/features/SessionListContent/Modals/ConfigGroupModal/GroupItem.tsx
+++ b/src/routes/(mobile)/(home)/features/SessionListContent/Modals/ConfigGroupModal/GroupItem.tsx
@@ -1,4 +1,5 @@
 import { ActionIcon, EditableText, SortableList } from '@lobehub/ui';
+import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { PencilLine, Trash } from 'lucide-react';
@@ -24,7 +25,7 @@ const styles = createStaticStyles(({ css }) => ({
 
 const GroupItem = memo<SessionGroupItem>(({ id, name }) => {
   const { t } = useTranslation('chat');
-  const { message, modal } = App.useApp();
+  const { message } = App.useApp();
 
   const [editing, setEditing] = useState(false);
   const [updateSessionGroupName, removeSessionGroup] = useSessionStore((s) => [
@@ -43,11 +44,9 @@ const GroupItem = memo<SessionGroupItem>(({ id, name }) => {
             icon={Trash}
             size={'small'}
             onClick={() => {
-              modal.confirm({
-                centered: true,
+              confirmModal({
                 okButtonProps: {
                   danger: true,
-                  type: 'primary',
                 },
                 onOk: async () => {
                   await removeSessionGroup(id);

--- a/src/routes/onboarding/features/AgentPickerStep/style.ts
+++ b/src/routes/onboarding/features/AgentPickerStep/style.ts
@@ -19,7 +19,8 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     gap: 12px;
     align-items: flex-start;
 
-    padding: 12px 14px;
+    padding-block: 12px;
+    padding-inline: 14px;
     border: 1px solid ${cssVar.colorFillSecondary};
     border-radius: ${cssVar.borderRadiusLG};
 
@@ -102,7 +103,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-top: 8px;
+    margin-block-start: 8px;
   `,
   footerActions: css`
     display: flex;
@@ -118,7 +119,8 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   pill: css`
     cursor: pointer;
 
-    padding: 4px 12px;
+    padding-block: 4px;
+    padding-inline: 12px;
     border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: 999px;
 
@@ -144,10 +146,10 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     }
   `,
   pillActive: css`
+    border-color: ${cssVar.colorFillSecondary};
     font-weight: 500;
     color: ${cssVar.colorText};
     background: ${cssVar.colorFillSecondary};
-    border-color: ${cssVar.colorFillSecondary};
 
     &:hover {
       background: ${cssVar.colorFillSecondary};
@@ -169,13 +171,15 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     border-radius: ${cssVar.borderRadius};
 
     background: ${cssVar.colorFillTertiary};
+
     animation: ${pulse} 1.5s ease-in-out infinite;
   `,
   skeletonCard: css`
     display: flex;
     gap: 12px;
 
-    padding: 12px 14px;
+    padding-block: 12px;
+    padding-inline: 14px;
     border: 1px solid ${cssVar.colorFillSecondary};
     border-radius: ${cssVar.borderRadiusLG};
   `,
@@ -189,7 +193,9 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     width: 72px;
     height: 28px;
     border-radius: 999px;
+
     background: ${cssVar.colorFillTertiary};
+
     animation: ${pulse} 1.5s ease-in-out infinite;
   `,
 }));


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Part of LOBE-9645 (Phase 1)

#### 🔀 Description of Change

Phase 1 of the modal migration tracked in LOBE-9645: replace every `App.useApp().modal.confirm` / `Modal.confirm` / `AntModal.confirm` call site with the headless `confirmModal` from `@lobehub/ui/base-ui`.

**Mechanical replacements**

- Import `confirmModal` from `@lobehub/ui/base-ui`
- Drop `modal` from `App.useApp()` destructure (and drop `App` import where it was the only consumer)
- Replace `modal.confirm({ … })` → `confirmModal({ … })`
- Remove `modal` from `useCallback` / `useMemo` dependency arrays

**Antd-only props dropped** (not supported by `ModalConfirmConfig`):

- `centered`, `type: 'warning' | 'error'`, `width`, `classNames.root`
- `okButtonProps.type: 'primary'` (default for confirm OK)
- `okButtonProps.loading` (modal handles loading when `onOk` returns a Promise)

**Notable special cases**

- `src/features/PageEditor/store/action.ts` — `handleDelete` no longer accepts a `modal` argument; the only caller (`PageEditor/Header/useMenu.tsx`) was updated accordingly
- `src/features/ResourceManager/components/Header/hooks/useUploadFolder.ts` — dropped `await import('antd').Modal.confirm` in favour of a static `confirmModal` import
- `src/routes/(main)/eval/bench/[benchmarkId]/features/DatasetsTab/index.tsx` — `modal.success` migrated to `confirmModal` (same UX, single OK + Cancel)
- `src/routes/(main)/settings/profile/features/{SSOProvidersList,KlavisAuthorizationList}` — replaced the static `modal` from `@/components/AntdStaticMethods` with `confirmModal`
- `src/layout/AuthProvider/MarketAuth/ProfileSetupModal.tsx` — replaced `AntModal.confirm` with `confirmModal`; also re-housed the modal title + description into the base-ui Modal header (removed the extra padding the old body-rendered title left at the top)

**Verification**

- ``grep -rn '[^A-Za-z\']modal\.confirm(\|[^A-Za-z\']Modal\.confirm(' src --include='*.tsx' --include='*.ts'`` returns 0 matches in non-locale files.
- `bun run type-check` — no new errors attributable to the changed files; the single residual error in `settings/storage/features/Advanced.tsx` is a pre-existing `FormGroupItemType` issue unrelated to this PR.

#### 🧪 How to Test

- [x] Tested locally (type-check + grep verification)
- [ ] Added/updated tests
- [x] No tests needed

Every confirm dialog touched by this PR is listed below. For each entry: open the page, perform the trigger, and verify the base-ui confirm renders correctly (title / content / OK / Cancel) and the danger styling matches the old antd UX.

> Tip: 80+ dialogs. The dialogs in each subsection share the same shape — sample one per group if time-constrained, focus on the *special cases* called out above.

##### 1. Home (`/`)

| Where | Trigger | Confirm action | File |
|-------|---------|----------------|------|
| Sidebar → Agent item context menu | "Delete" | Remove session (danger) | `src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.tsx` |
| Sidebar → Agent group item context menu | "Delete" | Remove group (danger) | `src/routes/(main)/home/_layout/Body/Agent/List/AgentGroupItem/useDropdownMenu.tsx` |
| Sidebar → Session group menu | "Delete group" | Remove session group (danger) | `src/routes/(main)/home/_layout/hooks/useSessionGroupMenuItems.tsx` |
| Config Group modal → row trash button | (in-modal nested confirm) | Remove a group (danger) | `src/routes/(main)/home/_layout/Body/Agent/Modals/ConfigGroupModal/GroupItem.tsx` |
| Project list item dropdown | "Delete" | Remove knowledge base (danger) | `src/routes/(main)/home/_layout/Body/Project/List/useDropdownMenu.tsx` |
| Recents card dropdown | "Delete" | Delete topic / document (danger) | `src/routes/(main)/home/features/Recents/useDropdownMenu.tsx` |

##### 2. Agent (`/agent/:id`)

| Where | Trigger | Confirm action | File |
|-------|---------|----------------|------|
| Profile page header — publish button | "Publish to community" | Sign-in & publish | `src/routes/(main)/agent/profile/features/Header/index.tsx` |
| Profile page header — delete | "Delete agent" | Remove agent (danger) | same file as above (2nd dialog) |
| Sidebar → Topic root menu | "Clear unstarred" / "Clear all" | Bulk topic removal (danger) | `src/routes/(main)/agent/_layout/Sidebar/Topic/useDropdownMenu.tsx` |
| Sidebar → Topic item menu | "Delete" | Remove single topic (danger) | `src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx` |
| Sidebar → Topic → Thread item menu | "Delete" | Remove thread (danger) | `src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx` |
| Conversation header actions menu | "Restore version" (in history) | Restore document version | `src/routes/(main)/agent/features/Conversation/Header/HeaderActions/useMenu.tsx` |
| Conversation header actions menu | "Delete topic" | Remove current topic (danger) | same file as above (2nd dialog) |
| Working Sidebar → Resources → doc item | "Delete" | Remove agent document (danger) | `src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx` |
| Channels list (under agent) | "Delete all channels" | Bulk delete bot providers (danger) | `src/routes/(main)/agent/channel/list.tsx` |
| Channel detail (under agent) | "Delete this channel" | Delete bot provider (danger) | `src/routes/(main)/agent/channel/detail/index.tsx` |

##### 3. Group (`/group/:id`)

| Where | Trigger | Confirm action | File |
|-------|---------|----------------|------|
| Sidebar → Topic root menu | "Clear unstarred" / "Clear all" | Bulk topic removal (danger) | `src/routes/(main)/group/_layout/Sidebar/Topic/useDropdownMenu.tsx` |
| Sidebar → Topic item menu | "Delete" | Remove single topic (danger) | `src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx` |
| Sidebar → Topic → Thread item menu | "Delete" | Remove thread (danger) | `src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx` |

##### 4. Community (`/community`)

| Where | Trigger | Confirm action | File |
|-------|---------|----------------|------|
| Agent detail sidebar → "Add" (when already added) | "Add anyway" | Re-add agent | `src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/AddAgent.tsx` |
| Group agent detail sidebar → "Add" (when already added) | "Add anyway" | Re-add group agent | `src/routes/(main)/community/(detail)/group_agent/features/Sidebar/ActionButton/AddGroupAgent.tsx` |
| User detail page → "Deprecate" action | (action menu) | Deprecate a contribution (danger) | `src/routes/(main)/community/(detail)/user/features/useUserDetail.ts` |
| Community top-right user avatar → "Edit profile" | "Save" after changing `@userName` | Confirm userName change (nested confirm inside ProfileSetupModal) | `src/layout/AuthProvider/MarketAuth/ProfileSetupModal.tsx` |

##### 5. Eval (`/eval/bench/:benchmarkId/...`)

| Where | Trigger | Confirm action | File |
|-------|---------|----------------|------|
| Benchmark page header | "Delete benchmark" | Delete benchmark (danger) | `src/routes/(main)/eval/bench/[benchmarkId]/features/BenchmarkHeader/index.tsx` |
| Benchmark → Datasets tab → DatasetCard | "Delete" | Delete dataset (danger) | `src/routes/(main)/eval/bench/[benchmarkId]/features/DatasetsTab/DatasetCard.tsx` |
| Benchmark → Datasets tab (test case row) | "Delete test case" | Delete test case (danger) | `src/routes/(main)/eval/bench/[benchmarkId]/features/DatasetsTab/index.tsx` |
| Benchmark → Datasets tab — after creating new dataset | (auto popup) | "Import now?" success/follow-up | same file as above (2nd dialog — replaces `modal.success`) |
| Dataset detail page | "Delete this dataset" | Delete dataset (danger) | `src/routes/(main)/eval/bench/[benchmarkId]/datasets/[datasetId]/index.tsx` |
| Dataset detail page (test case row) | "Delete test case" | Delete test case (danger) | same file as above (2nd dialog) |
| Benchmark → Runs tab → RunCard | "Start" / "Abort" / "Delete" | Start / abort (danger) / delete (danger) run | `src/routes/(main)/eval/bench/[benchmarkId]/features/RunsTab/RunCard.tsx` |
| Run detail header | "Start" / "Abort" / "Delete" | Start / abort (danger) / delete (danger) run | `src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/RunHeader/index.tsx` |
| Run detail → idle state | "Start run" | Start run | `src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/IdleState/index.tsx` |
| Run detail → errors tab | "Retry all errors" | Retry errors | `src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/index.tsx` |

##### 6. Memory (`/memory/...`)

| Where | Trigger | Confirm action | File |
|-------|---------|----------------|------|
| `/memory/activities` row dropdown | "Delete" | Delete activity (danger) | `src/routes/(main)/memory/activities/features/ActivityDropdown.tsx` |
| `/memory/contexts` row dropdown | "Delete" | Delete context (danger) | `src/routes/(main)/memory/contexts/features/ContextDropdown.tsx` |
| `/memory/experiences` row dropdown | "Delete" | Delete experience (danger) | `src/routes/(main)/memory/experiences/features/ExperienceDropdown.tsx` |
| `/memory/identities` row dropdown | "Delete" | Delete identity (danger) | `src/routes/(main)/memory/identities/features/IdentityDropdown.tsx` |
| `/memory/preferences` row dropdown | "Delete" | Delete preference (danger) | `src/routes/(main)/memory/preferences/features/PreferenceDropdown.tsx` |
| `/memory` action bar | "Purge all" button | Purge all memories (danger) | `src/routes/(main)/memory/features/ActionBar/PurgeButton.tsx` |

##### 7. Settings (`/settings/...`)

| Where | Trigger | Confirm action | File |
|-------|---------|----------------|------|
| `/settings/creds` row | "Delete" | Delete credential (danger) | `src/routes/(main)/settings/creds/features/CredItem.tsx` |
| `/settings/profile` → SSO providers | "Unlink" | Unlink SSO account (danger) | `src/routes/(main)/settings/profile/features/SSOProvidersList/index.tsx` |
| `/settings/profile` → Klavis authorizations | "Revoke" | Revoke Klavis server (danger) | `src/routes/(main)/settings/profile/features/KlavisAuthorizationList/index.tsx` |
| `/settings/provider/:id` → Model list row | "Delete" | Remove ai model (danger) | `src/routes/(main)/settings/provider/features/ModelList/ModelItem.tsx` |
| `/settings/provider/:id` → Model list header menu | "Reset all" | Clear all provider models | `src/routes/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx` |
| `/settings/provider/:id` → OAuth device flow auth | "Disconnect" | Revoke OAuth (danger) | `src/routes/(main)/settings/provider/features/ProviderConfig/OAuthDeviceFlowAuth/index.tsx` |
| `/settings/provider/:id` → Update provider info modal | "Delete provider" | Delete custom AI provider (danger) | `src/routes/(main)/settings/provider/features/ProviderConfig/UpdateProviderInfo/SettingModal.tsx` |
| `/settings/skill` → Actions menu | "Uninstall" | Uninstall plugin (danger) | `src/routes/(main)/settings/skill/features/Actions.tsx` |
| `/settings/skill` → Agent skill row | "Uninstall" | Uninstall agent skill (danger) | `src/routes/(main)/settings/skill/features/AgentSkillItem.tsx` |
| `/settings/skill` → Builtin skill row | "Uninstall" | Uninstall builtin tool (danger) | `src/routes/(main)/settings/skill/features/BuiltinSkillItem.tsx` |
| `/settings/skill` → Klavis skill row | "Disconnect" | Remove Klavis server (danger) | `src/routes/(main)/settings/skill/features/KlavisSkillItem.tsx` |
| `/settings/skill` → LobeHub skill row | "Disconnect" | Revoke LobeHub provider (danger) | `src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx` |
| `/settings/storage` → Danger zone | "Clear all data" | Clear sessions / files / messages (danger) | `src/routes/(main)/settings/storage/features/Advanced.tsx` |
| `/settings/storage` → Danger zone | "Reset settings" | Reset settings (danger) | same file as above (2nd dialog) |

##### 8. Skill Store (`/skill-store` and embedded variants)

| Where | Trigger | Confirm action | File |
|-------|---------|----------------|------|
| Agent skill item | "Uninstall" | Delete agent skill (danger) | `src/features/SkillStore/SkillList/AgentSkillItem.tsx` |
| Builtin skill item | "Uninstall" | Uninstall builtin tool (danger) | `src/features/SkillStore/SkillList/Builtin/Item.tsx` |
| Community skill item | "Uninstall" | Toggle off + uninstall plugin (danger) | `src/features/SkillStore/SkillList/Community/Item.tsx` |
| Community → Market skill item | "Uninstall" | Delete agent skill (danger) | `src/features/SkillStore/SkillList/Community/MarketSkillItem.tsx` |
| Custom skill item | "Uninstall" | Toggle off + uninstall plugin (danger) | `src/features/SkillStore/SkillList/Custom/Item.tsx` |
| LobeHub skill item | "Disconnect" | Disconnect LobeHub OAuth provider (danger) | `src/features/SkillStore/SkillList/LobeHub/Item.tsx` |

##### 9. Agent Tasks (Tasks panel)

| Where | Trigger | Confirm action | File |
|-------|---------|----------------|------|
| Tasks list — task context menu | "Delete" | Delete task (danger) | `src/features/AgentTasks/features/useTaskItemContextMenu.tsx` |
| Task detail → header actions | "Delete task" | Delete task + navigate away (danger) | `src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.tsx` |
| Task detail → Brief card menu | "Delete brief" | Delete brief (danger) | `src/features/AgentTasks/AgentTaskDetail/TaskBriefCard.tsx` |
| Task detail → Comment card menu | "Delete comment" | Delete comment (danger) | `src/features/AgentTasks/AgentTaskDetail/CommentCard.tsx` |
| Task detail → Artifact item menu | "Delete artifact" | Unpin document (danger) | `src/features/AgentTasks/AgentTaskDetail/TaskArtifacts.tsx` |
| Task detail → Subtasks toolbar | "Run all" | Show `RunSubtasksPreview` then kick off | `src/features/AgentTasks/AgentTaskDetail/TaskSubtasks.tsx` |

##### 10. Agent Topic Manager (per-agent topic management page)

| Where | Trigger | Confirm action | File |
|-------|---------|----------------|------|
| Bulk action bar | "Delete N topics" | Batch delete (danger) | `src/features/AgentTopicManager/BulkActionBar.tsx` |
| Toolbar actions menu | "Archive stale" | Mark stale topics completed | `src/features/AgentTopicManager/ToolbarActions.tsx` |

##### 11. Page Editor

| Where | Trigger | Confirm action | File |
|-------|---------|----------------|------|
| Page editor header menu | "Delete page" | Delete document (danger) | `src/features/PageEditor/store/action.ts` (caller: `PageEditor/Header/useMenu.tsx`) |
| Copilot → Agent selector dropdown | "Delete agent" | Remove agent (danger) | `src/features/PageEditor/Copilot/AgentSelector/useDropdownMenu.tsx` |
| Copilot → Topic selector dropdown | "Delete topic" | Remove topic (danger) | `src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx` |
| Pages list (page library) → item dropdown | "Delete" | Remove page (danger) | `src/features/Pages/PageLayout/Body/List/Item/useDropdownMenu.tsx` |

##### 12. Resource Manager

| Where | Trigger | Confirm action | File |
|-------|---------|----------------|------|
| Explorer header (single-select) | "Remove from library" / "Delete file" | Remove / delete file (danger) | `src/features/ResourceManager/components/Explorer/Header/index.tsx` |
| Explorer file/folder item dropdown | "Remove from library" / "Delete" | Remove / delete (danger) | `src/features/ResourceManager/components/Explorer/ItemDropdown/useFileItemDropdown.tsx` |
| Explorer toolbar batch dropdown | "Delete library" / "Remove from lib" / "Delete files" | Bulk operations (danger) | `src/features/ResourceManager/components/Explorer/ToolBar/BatchActionsDropdown.tsx` |
| Explorer multi-select actions | "Remove from library" / "Delete" | Bulk (danger) | `src/features/ResourceManager/components/Explorer/ToolBar/MultiSelectActions.tsx` |
| Explorer header — upload folder | (auto when .gitignore detected) | "Apply .gitignore filter?" prompt | `src/features/ResourceManager/components/Header/hooks/useUploadFolder.ts` |
| Library home page — library item dropdown | "Delete library" | Remove knowledge base (danger) | `src/routes/(main)/resource/(home)/_layout/Body/LibraryList/Item/useDropdownMenu.tsx` |

##### 13. Mobile (`/m/...`)

| Where | Trigger | Confirm action | File |
|-------|---------|----------------|------|
| Mobile home → group actions | "Delete group" | Remove session group (danger) | `src/routes/(mobile)/(home)/features/SessionListContent/CollapseGroup/Actions.tsx` |
| Mobile home → session item actions | "Delete" | Remove session / group (danger) | `src/routes/(mobile)/(home)/features/SessionListContent/List/Item/Actions.tsx` |
| Mobile home → Config group modal row | (in-modal nested confirm) | Remove group (danger) | `src/routes/(mobile)/(home)/features/SessionListContent/Modals/ConfigGroupModal/GroupItem.tsx` |

##### 14. Misc (Conversation / Messenger / Portal / Share / AgentSetting)

| Where | Trigger | Confirm action | File |
|-------|---------|----------------|------|
| Chat — "Compressing…" group card | "Cancel" | Cancel compression | `src/features/Conversation/Messages/CompressedGroup/index.tsx` |
| Portal → Notebook document item | "Delete" | Delete document (danger) | `src/features/Portal/Notebook/DocumentItem.tsx` |
| Messenger → integration detail | "Unlink" on tenant row | Unlink tenant (danger) | `src/features/Messenger/IntegrationDetail/shared.tsx` |
| Messenger → integration detail | "Uninstall" on installation row | Uninstall installation (danger) | same file as above (2nd dialog) |
| Agent settings → Documents → Apply template | (auto when overwriting) | Confirm overwrite | `src/features/AgentSetting/AgentDocuments/index.tsx` |
| Any chat message → Share popover | "Generate link" (first time) | Privacy warning + "do not show again" checkbox | `src/features/SharePopover/index.tsx` |

##### 15. Generation Layout (create page)

| Where | Trigger | Confirm action | File |
|-------|---------|----------------|------|
| `/(create)` → topic list item | trash button / "Delete" in menu | Remove generation topic (danger, 2 dialogs in one file) | `src/routes/(main)/(create)/features/GenerationLayout/Body/List/Item/index.tsx` |

#### 📸 Screenshots / Videos

No visual changes intended — same confirm UX, just routed through the base-ui host. One small polish: `ProfileSetupModal` now uses the Modal header for its title + description (previously rendered them inside the body, which left extra padding at the top of the dialog).

#### 📝 Additional Information

- Phase 2 (antd `Modal`/`Drawer` wrapper → `createModal`) and Phase 3 (`@lobehub/ui` root `createModal`/`createRawModal`/`FormModal` → base-ui) are out of scope for this PR; see LOBE-9645 for the rest.
- One behavioural note: a couple of menus inside other modals previously relied on a `classNames: { root: styles.modalRoot }` z-index hack. Base-ui's host stacks modals natively, so the override is no longer needed; if any layering regressions surface in mobile session menus or `useSessionGroupMenuItems`, that's the place to look.
