### PR TITLE
✨ feat: gate agent document floating chat panel

### DIFF
--- a/packages/const/src/user.ts
+++ b/packages/const/src/user.ts
@@ -13,6 +13,7 @@ export const DEFAULT_PREFERENCE: UserPreference = {
     topic: true,
   },
   lab: {
+    enableAgentDocumentFloatingChatPanel: false,
     enableAgentSelfIteration: false,
     enableInputMarkdown: true,
     enablePlatformAgent: false,

--- a/packages/types/src/user/preference.ts
+++ b/packages/types/src/user/preference.ts
@@ -43,6 +43,10 @@ export const UserLabSchema = z.object({
    */
   enableAgentSelfIteration: z.boolean().optional(),
   /**
+   * enable the floating chat panel in agent document preview
+   */
+  enableAgentDocumentFloatingChatPanel: z.boolean().optional(),
+  /**
    * surface the execution-device switcher for heterogeneous agents
    * (lets users pick local / cloud sandbox / a bound device)
    */

--- a/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
+++ b/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
@@ -65,7 +65,6 @@ const SubmenuScrollStyle = createGlobalStyle`
     overflow: hidden auto;
     overscroll-behavior: contain;
 
-    width: 360px;
     max-height: min(50vh, 640px);
     padding-block-end: 4px;
   }

--- a/src/features/Portal/Document/Body.test.tsx
+++ b/src/features/Portal/Document/Body.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DocumentBody from './Body';
+
+vi.mock('antd-style', () => ({
+  createStaticStyles: () => ({
+    content: 'content',
+  }),
+  cssVar: {
+    colorBgContainer: 'var(--color-bg-container)',
+    colorBorderSecondary: 'var(--color-border-secondary)',
+    colorTextSecondary: 'var(--color-text-secondary)',
+    fontFamilyCode: 'monospace',
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  ActionIcon: () => null,
+  Button: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+  Flexbox: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  TextArea: () => <textarea />,
+}));
+
+vi.mock('./EditorCanvas', () => ({
+  default: () => <div data-testid="editor-canvas" />,
+}));
+
+vi.mock('./TodoList', () => ({
+  default: () => <div data-testid="todo-list" />,
+}));
+
+vi.mock('@/features/FloatingChatPanel', () => ({
+  default: () => <div data-testid="floating-chat-panel" />,
+}));
+
+const mockChatState = vi.hoisted(() => ({
+  current: {
+    activeTopicId: 'topic-1',
+    portalStack: [
+      {
+        agentDocumentId: 'agent-document-1',
+        documentId: 'document-1',
+        type: 'document',
+      },
+    ],
+  },
+}));
+
+vi.mock('@/store/chat', () => ({
+  useChatStore: (selector: any) => selector(mockChatState.current),
+}));
+
+const mockAgentState = vi.hoisted(() => ({
+  current: {
+    activeAgentId: 'agent-1',
+  },
+}));
+
+vi.mock('@/store/agent', () => ({
+  useAgentStore: (selector: any) => selector(mockAgentState.current),
+}));
+
+const mockDocumentState = vi.hoisted(() => ({
+  current: {
+    documents: {
+      'document-1': {},
+    },
+    performSave: vi.fn(),
+    updateSkillFrontmatter: vi.fn(),
+  },
+}));
+
+vi.mock('@/store/document', () => ({
+  useDocumentStore: (selector: any) => selector(mockDocumentState.current),
+}));
+
+const mockUserState = vi.hoisted(() => ({
+  current: {
+    preference: {
+      lab: {
+        enableAgentDocumentFloatingChatPanel: false,
+      },
+    },
+  },
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: (selector: any) => selector(mockUserState.current),
+}));
+
+describe('DocumentBody', () => {
+  beforeEach(() => {
+    mockAgentState.current.activeAgentId = 'agent-1';
+    mockUserState.current.preference.lab.enableAgentDocumentFloatingChatPanel = false;
+  });
+
+  it('does not render FloatingChatPanel when the lab feature is disabled', () => {
+    render(<DocumentBody />);
+
+    expect(screen.queryByTestId('floating-chat-panel')).toBeNull();
+  });
+
+  it('renders FloatingChatPanel when the lab feature is enabled', () => {
+    mockUserState.current.preference.lab.enableAgentDocumentFloatingChatPanel = true;
+
+    render(<DocumentBody />);
+
+    expect(screen.getByTestId('floating-chat-panel')).toBeDefined();
+  });
+});

--- a/src/features/Portal/Document/Body.tsx
+++ b/src/features/Portal/Document/Body.tsx
@@ -12,6 +12,8 @@ import { useAgentStore } from '@/store/agent';
 import { useChatStore } from '@/store/chat';
 import { chatPortalSelectors } from '@/store/chat/selectors';
 import { useDocumentStore } from '@/store/document';
+import { useUserStore } from '@/store/user';
+import { labPreferSelectors } from '@/store/user/selectors';
 import {
   getSkillMarkdownMetadataError,
   parseSkillMarkdownFrontmatterFields,
@@ -197,6 +199,9 @@ const DocumentBody = memo(() => {
   const agentDocumentId = useChatStore(chatPortalSelectors.portalAgentDocumentId);
   const activeAgentId = useAgentStore((s) => s.activeAgentId);
   const activeTopicId = useChatStore((s) => s.activeTopicId);
+  const enableFloatingChatPanel = useUserStore(
+    labPreferSelectors.enableAgentDocumentFloatingChatPanel,
+  );
   const [skillFrontmatter, contentFormat] = useDocumentStore((s) =>
     documentId
       ? [s.documents[documentId]?.skillFrontmatter ?? '', s.documents[documentId]?.contentFormat]
@@ -213,7 +218,7 @@ const DocumentBody = memo(() => {
         <EditorCanvas />
       </div>
       <TodoList />
-      {activeAgentId && (
+      {enableFloatingChatPanel && activeAgentId && (
         <FloatingChatPanel
           agentDocumentId={agentDocumentId}
           agentId={activeAgentId}

--- a/src/locales/default/labs.ts
+++ b/src/locales/default/labs.ts
@@ -1,4 +1,7 @@
 export default {
+  'features.agentDocumentFloatingChatPanel.desc':
+    'Show the floating chat panel in agent document preview only when this lab feature is enabled.',
+  'features.agentDocumentFloatingChatPanel.title': 'Agent Document Floating Chat Panel',
   'features.agentSelfIteration.desc':
     'Allow the assistant to reflect, build self-awareness, and continuously iterate through ongoing attempts and interactions.',
   'features.agentSelfIteration.title': 'Agent Self-iteration',

--- a/src/routes/(main)/settings/advanced/index.test.tsx
+++ b/src/routes/(main)/settings/advanced/index.test.tsx
@@ -105,4 +105,16 @@ describe('Advanced settings page', () => {
     expect(screen.getByText('tab.advanced.toolsAndDiagnostics.title')).toBeDefined();
     expect(screen.getByText('tab.advanced.appUpdates.title')).toBeDefined();
   });
+
+  it('renders the agent document floating chat panel lab toggle', () => {
+    useUserStore.setState({
+      isUserStateInit: true,
+      setSettings: vi.fn(),
+      updateLab: vi.fn(),
+    });
+
+    render(<Page />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('features.agentDocumentFloatingChatPanel.title')).toBeDefined();
+  });
 });

--- a/src/routes/(main)/settings/advanced/index.tsx
+++ b/src/routes/(main)/settings/advanced/index.tsx
@@ -37,6 +37,7 @@ const Page = memo(() => {
 
   const [
     isPreferenceInit,
+    enableAgentDocumentFloatingChatPanel,
     enableInputMarkdown,
     enableGatewayMode,
     enablePlatformAgent,
@@ -44,6 +45,7 @@ const Page = memo(() => {
     updateLab,
   ] = useUserStore((s) => [
     preferenceSelectors.isPreferenceInit(s),
+    labPreferSelectors.enableAgentDocumentFloatingChatPanel(s),
     labPreferSelectors.enableInputMarkdown(s),
     labPreferSelectors.enableGatewayMode(s),
     labPreferSelectors.enablePlatformAgent(s),
@@ -104,6 +106,19 @@ const Page = memo(() => {
   };
 
   const labItems: FormItemProps[] = [
+    {
+      children: (
+        <Switch
+          checked={enableAgentDocumentFloatingChatPanel}
+          loading={!isPreferenceInit}
+          onChange={(checked) => updateLab({ enableAgentDocumentFloatingChatPanel: checked })}
+        />
+      ),
+      className: styles.labItem,
+      desc: tLabs('features.agentDocumentFloatingChatPanel.desc'),
+      label: tLabs('features.agentDocumentFloatingChatPanel.title'),
+      minWidth: undefined,
+    },
     {
       children: (
         <Switch

--- a/src/store/user/slices/preference/selectors.test.ts
+++ b/src/store/user/slices/preference/selectors.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { type UserStore } from '@/store/user';
 
 import { initialPreferenceState } from './initialState';
-import { preferenceSelectors } from './selectors';
+import { labPreferSelectors, preferenceSelectors } from './selectors';
 
 describe('preferenceSelectors', () => {
   let store: UserStore;
@@ -64,6 +64,20 @@ describe('preferenceSelectors', () => {
 
       store.isUserStateInit = false;
       expect(preferenceSelectors.isPreferenceInit(store)).toBe(false);
+    });
+  });
+
+  describe('labPreferSelectors', () => {
+    it('returns false for agent document floating chat panel by default', () => {
+      store.preference.lab = undefined;
+
+      expect(labPreferSelectors.enableAgentDocumentFloatingChatPanel(store)).toBe(false);
+    });
+
+    it('returns the configured agent document floating chat panel preference', () => {
+      store.preference.lab = { enableAgentDocumentFloatingChatPanel: true };
+
+      expect(labPreferSelectors.enableAgentDocumentFloatingChatPanel(store)).toBe(true);
     });
   });
 });

--- a/src/store/user/slices/preference/selectors/labPrefer.ts
+++ b/src/store/user/slices/preference/selectors/labPrefer.ts
@@ -3,12 +3,16 @@ import { DEFAULT_PREFERENCE } from '@lobechat/const';
 import { type UserState } from '@/store/user/initialState';
 
 export const labPreferSelectors = {
+  enableAgentDocumentFloatingChatPanel: (s: UserState): boolean =>
+    s.preference.lab?.enableAgentDocumentFloatingChatPanel ??
+    DEFAULT_PREFERENCE.lab?.enableAgentDocumentFloatingChatPanel ??
+    false,
   enableAgentSelfIteration: (s: UserState): boolean =>
     s.preference.lab?.enableAgentSelfIteration ?? false,
   enableExecutionDeviceSwitcher: (s: UserState): boolean =>
     s.preference.lab?.enableExecutionDeviceSwitcher ?? false,
   enableGatewayMode: (s: UserState): boolean => s.preference.lab?.enableGatewayMode ?? false,
   enableInputMarkdown: (s: UserState): boolean =>
-    s.preference.lab?.enableInputMarkdown ?? DEFAULT_PREFERENCE.lab!.enableInputMarkdown!,
+    s.preference.lab?.enableInputMarkdown ?? DEFAULT_PREFERENCE.lab?.enableInputMarkdown ?? true,
   enablePlatformAgent: (s: UserState): boolean => s.preference.lab?.enablePlatformAgent ?? false,
 };


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No related issue found.

#### 🔀 Description of Change

- Adds a Labs preference for showing the FloatingChatPanel in agent document previews.
- Keeps the agent document preview panel disabled by default and renders it only when the Labs toggle is enabled.
- Removes the fixed submenu menu width from `[data-submenu] > [role='menu']` so submenu width is no longer forced.
- Adds regression coverage for the new lab selector, Advanced Settings toggle visibility, and document preview conditional rendering.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run --silent='passed-only' src/features/Portal/Document/Body.test.tsx src/features/FloatingChatPanel/index.test.tsx src/features/FloatingChatPanel/ChatBody.test.tsx src/features/FloatingChatPanel/guard.test.ts src/routes/\(main\)/settings/advanced/index.test.tsx src/store/user/slices/preference/selectors.test.ts src/store/user/slices/preference/action.test.ts
git diff --check origin/canary..HEAD
```

`bun run type-check` was attempted, but the current checkout fails on existing unrelated generated/dependency issues such as missing `.next/dev/types` route modules, `@lobechat/business-model-bank/model-config`, `execa`, `@vitejs/devtools`, and existing ScrollArea prop/type mismatches outside this change.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

`pnpm i18n` was not run; only `src/locales/default/labs.ts` was updated.
