### PR TITLE
🐛 fix: unify TypeScript peer resolution on 6.x

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -44,7 +44,7 @@
     "picocolors": "^1.1.1",
     "superjson": "^2.2.6",
     "tsdown": "^0.21.4",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "ws": "^8.18.1"
   },
   "publishConfig": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -104,7 +104,7 @@
     "stylelint": "^15.11.0",
     "superjson": "^2.2.6",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "undici": "^7.16.0",
     "uuid": "^14.0.0",
     "vite": "8.0.14",

--- a/apps/device-gateway/package.json
+++ b/apps/device-gateway/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.12.19",
     "@cloudflare/workers-types": "^4.20260301.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "vitest": "~3.2.4",
     "wrangler": "^4.70.0"
   }

--- a/package.json
+++ b/package.json
@@ -537,7 +537,7 @@
     "stylelint": "^16.12.0",
     "tsx": "^4.21.0",
     "type-fest": "^5.4.1",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",
     "vite": "8.0.14",
@@ -568,7 +568,8 @@
       "pdfjs-dist": "5.4.530",
       "react": "19.2.5",
       "react-dom": "19.2.5",
-      "stylelint-config-clean-order": "7.0.0"
+      "stylelint-config-clean-order": "7.0.0",
+      "typescript": "6.0.3"
     },
     "patchedDependencies": {
       "@upstash/qstash": "patches/@upstash__qstash.patch"

--- a/packages/builtin-tool-skills/src/client/Inspector/RunSkill/index.tsx
+++ b/packages/builtin-tool-skills/src/client/Inspector/RunSkill/index.tsx
@@ -4,7 +4,6 @@ import { AGENT_SKILLS_IDENTIFIER_PREFIX } from '@lobechat/const';
 import { type BuiltinInspectorProps } from '@lobechat/types';
 import { SkillsIcon } from '@lobehub/ui/icons';
 import { createStaticStyles, cx } from 'antd-style';
-import { type TFunction } from 'i18next';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -12,33 +11,34 @@ import { inspectorTextStyles, shinyTextStyles } from '@/styles';
 
 import type { ActivateSkillParams, ActivateSkillSource, ActivateSkillState } from '../../../types';
 
+type SkillLabelKey =
+  | 'builtins.lobe-skills.apiName.activateAgentSkill'
+  | 'builtins.lobe-skills.apiName.activateProjectSkill'
+  | 'builtins.lobe-skills.apiName.activateSkill';
+
 /**
- * Resolve the inspector label. State-side `source` is the authority once the
+ * Resolve the inspector label key. State-side `source` is the authority once the
  * tool result has streamed in; while args are still streaming we only have the
  * raw `name` to go on, so detect agent skills via the identifier prefix as a
  * best-effort fallback. Project skills can't be inferred from the bare name
  * (no prefix), so they show "Activate Skill" until the result lands.
- *
- * `t` is invoked with literal keys per branch so i18next's typed-key map can
- * still validate the call site.
  */
-const resolveLabel = (
-  t: TFunction<'plugin'>,
+const resolveLabelKey = (
   source: ActivateSkillSource | undefined,
   rawName: string | undefined,
-): string => {
+): SkillLabelKey => {
   const effective: ActivateSkillSource =
     source ?? (rawName?.startsWith(AGENT_SKILLS_IDENTIFIER_PREFIX) ? 'agent' : 'builtin');
 
   switch (effective) {
     case 'agent': {
-      return t('builtins.lobe-skills.apiName.activateAgentSkill');
+      return 'builtins.lobe-skills.apiName.activateAgentSkill';
     }
     case 'project': {
-      return t('builtins.lobe-skills.apiName.activateProjectSkill');
+      return 'builtins.lobe-skills.apiName.activateProjectSkill';
     }
     default: {
-      return t('builtins.lobe-skills.apiName.activateSkill');
+      return 'builtins.lobe-skills.apiName.activateSkill';
     }
   }
 };
@@ -84,7 +84,7 @@ export const RunSkillInspector = memo<
 
   const name = args?.name || partialArgs?.name;
   const displayName = pluginState?.title || pluginState?.name || name;
-  const label = resolveLabel(t, pluginState?.source, name);
+  const label = t(resolveLabelKey(pluginState?.source, name));
 
   if (isArgumentsStreaming) {
     if (!displayName)

--- a/packages/chat-adapter-feishu/package.json
+++ b/packages/chat-adapter-feishu/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "tsup": "^8.3.5",
-    "typescript": "^5.7.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/chat-adapter-imessage/package.json
+++ b/packages/chat-adapter-imessage/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "tsup": "^8.3.5",
-    "typescript": "^5.7.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/chat-adapter-line/package.json
+++ b/packages/chat-adapter-line/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "tsup": "^8.3.5",
-    "typescript": "^5.7.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/chat-adapter-qq/package.json
+++ b/packages/chat-adapter-qq/package.json
@@ -21,6 +21,6 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "tsup": "^8.3.5",
-    "typescript": "^5.7.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/chat-adapter-wechat/package.json
+++ b/packages/chat-adapter-wechat/package.json
@@ -22,6 +22,6 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "tsup": "^8.3.5",
-    "typescript": "^5.7.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/packages/eval-dataset-parser/package.json
+++ b/packages/eval-dataset-parser/package.json
@@ -3,7 +3,14 @@
   "version": "1.0.0",
   "private": true,
   "description": "Parse CSV, XLSX, JSON, and JSONL files into structured dataset records",
-  "keywords": ["dataset", "parser", "csv", "xlsx", "jsonl", "lobehub"],
+  "keywords": [
+    "dataset",
+    "parser",
+    "csv",
+    "xlsx",
+    "jsonl",
+    "lobehub"
+  ],
   "homepage": "https://github.com/lobehub/lobehub/tree/master/packages/eval-dataset-parser",
   "bugs": {
     "url": "https://github.com/lobehub/lobehub/issues/new"
@@ -25,7 +32,7 @@
   },
   "devDependencies": {
     "@types/papaparse": "^5.3.15",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "typescript": ">=5"

--- a/packages/eval-rubric/package.json
+++ b/packages/eval-rubric/package.json
@@ -30,7 +30,7 @@
     "ajv": "^8.17.1"
   },
   "devDependencies": {
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "typescript": ">=5"

--- a/packages/file-loaders/package.json
+++ b/packages/file-loaders/package.json
@@ -25,6 +25,7 @@
     "test:coverage": "vitest --coverage --silent='passed-only'"
   },
   "dependencies": {
+    "@napi-rs/canvas": "^0.1.70",
     "@xmldom/xmldom": "^0.9.8",
     "concat-stream": "^2.0.0",
     "debug": "^4.4.3",
@@ -33,13 +34,12 @@
     "pdfjs-dist": "5.4.530",
     "word-extractor": "^1.0.4",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
-    "yauzl": "^3.2.0",
-    "@napi-rs/canvas": "^0.1.70"
+    "yauzl": "^3.2.0"
   },
   "devDependencies": {
     "@types/concat-stream": "^2.0.3",
     "@types/yauzl": "^2.10.3",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "typescript": ">=5"

--- a/packages/model-bank/package.json
+++ b/packages/model-bank/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "tsdown": "^0.21.4",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "peerDependencies": {
     "zod": "^3.25.76"


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No related issue found.

#### 🔀 Description of Change

- Unify all direct workspace TypeScript dev dependencies on `^6.0.3`.
- Add a pnpm override for `typescript@6.0.3` so transitive dependency and peer resolution use the same TypeScript major.
- Keep the skill inspector from passing `i18next.TFunction` across package peer boundaries by resolving the translation key first and translating locally.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
rm -rf node_modules
pnpm install --registry=https://registry.npmmirror.com
find node_modules/.pnpm -maxdepth 1 -name '*typescript@5*' -print
find node_modules/.pnpm -maxdepth 1 -name 'i18next@25.10.10_typescript@*' -print | sort
pnpm why typescript --depth 1
pnpm type-check
pnpm exec eslint packages/builtin-tool-skills/src/client/Inspector/RunSkill/index.tsx --max-warnings=0
git diff --check
```

Verified results:

- No `typescript@5*` entries under `node_modules/.pnpm`
- `i18next` peer instance: only `i18next@25.10.10_typescript@6.0.3`
- `pnpm why typescript`: `Found 1 version of typescript`
- Type check passed
- Targeted ESLint passed
- Diff check passed

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

The previous duplicate peer graph came from mixed TypeScript 5.x direct workspace dependencies plus transitive packages that already allowed or required TypeScript 6.x.
