### PR TITLE
✨ feat(model-runtime): classify Cloud-only error codes via numericId tier digit

### DIFF
--- a/packages/model-runtime/src/errors/index.ts
+++ b/packages/model-runtime/src/errors/index.ts
@@ -2,14 +2,17 @@ export { ErrorClassifier, type ErrorClassifierType } from './classifier';
 export { isUserSideError, matchErrorPattern, type MatchInput, type MatchResult } from './match';
 export { ERROR_PATTERNS, type ErrorPattern } from './patterns';
 export {
+  type CloudErrorCode,
   ERROR_CODE_SPECS,
   type ErrorCodeSpec,
   formatErrorRef,
   getErrorCodeSpec,
   parseErrorRef,
+  type SpecErrorCode,
 } from './specs';
 export {
   CATEGORY_NUMERIC_PREFIX,
+  CLOUD_TIER_DIGIT,
   type ErrorAttribution,
   type ErrorCategory,
   type ErrorSeverity,

--- a/packages/model-runtime/src/errors/match.test.ts
+++ b/packages/model-runtime/src/errors/match.test.ts
@@ -1,9 +1,9 @@
-import { AgentRuntimeErrorType } from '@lobechat/types';
+import { AgentRuntimeErrorType, ChatErrorType } from '@lobechat/types';
 import { describe, expect, it } from 'vitest';
 
 import { isUserSideError, matchErrorPattern } from './match';
 import { ERROR_CODE_SPECS, formatErrorRef, parseErrorRef } from './specs';
-import { CATEGORY_NUMERIC_PREFIX } from './taxonomy';
+import { CATEGORY_NUMERIC_PREFIX, CLOUD_TIER_DIGIT } from './taxonomy';
 
 describe('matchErrorPattern', () => {
   it('returns undefined for empty input', () => {
@@ -127,6 +127,25 @@ describe('numericId contract', () => {
     const ids = specs.map((s) => s.numericId);
     const sortedIds = [...ids].sort((a, b) => a - b);
     expect(ids).toEqual(sortedIds);
+  });
+
+  it('tier digit is 0 (OSS) or the cloud digit', () => {
+    for (const spec of specs) {
+      const tier = Math.floor(spec.numericId / 100) % 10;
+      expect([0, CLOUD_TIER_DIGIT], `${spec.code} numericId ${spec.numericId}`).toContain(tier);
+    }
+  });
+
+  it('classifies the Cloud-only ChatErrorType codes under the cloud tier', () => {
+    for (const code of [
+      ChatErrorType.FreePlanLimit,
+      ChatErrorType.InsufficientBudgetForModel,
+      ChatErrorType.LobeHubModelDeprecated,
+    ]) {
+      const spec = ERROR_CODE_SPECS[code];
+      expect(spec, code).toBeDefined();
+      expect(Math.floor(spec!.numericId / 100) % 10, code).toBe(CLOUD_TIER_DIGIT);
+    }
   });
 });
 

--- a/packages/model-runtime/src/errors/specs.ts
+++ b/packages/model-runtime/src/errors/specs.ts
@@ -1,12 +1,26 @@
 import type { ILobeAgentRuntimeErrorType } from '@lobechat/types';
-import { AgentRuntimeErrorType } from '@lobechat/types';
+import { AgentRuntimeErrorType, ChatErrorType } from '@lobechat/types';
 
 import type { ErrorAttribution, ErrorCategory, ErrorSeverity } from './taxonomy';
+
+/**
+ * Cloud-only business codes live in `ChatErrorType` (not `AgentRuntimeErrorType`)
+ * because they're emitted solely by the managed LobeHub Cloud gateway. They're
+ * still classified here, distinguished by the `9` tier digit of their
+ * `numericId` (e.g. `E2902`). See `CLOUD_TIER_DIGIT` in `./taxonomy`.
+ */
+export type CloudErrorCode =
+  | typeof ChatErrorType.FreePlanLimit
+  | typeof ChatErrorType.InsufficientBudgetForModel
+  | typeof ChatErrorType.LobeHubModelDeprecated;
+
+/** Every code the spec table can classify. */
+export type SpecErrorCode = CloudErrorCode | ILobeAgentRuntimeErrorType;
 
 export interface ErrorCodeSpec {
   attribution: ErrorAttribution;
   category: ErrorCategory;
-  code: ILobeAgentRuntimeErrorType;
+  code: SpecErrorCode;
   /** Whether this error counts toward operational failure metrics. */
   countAsFailure: boolean;
 
@@ -20,8 +34,8 @@ export interface ErrorCodeSpec {
    *
    * Append-only: once assigned, a (code, numericId) pair must never change so
    * that external docs / support tickets / SDKs can reference it long-term.
-   * The leading digit must match `CATEGORY_NUMERIC_PREFIX[category]`; the
-   * remaining digits are assigned sequentially within the category bucket.
+   * Structure: digit 1 = category (`CATEGORY_NUMERIC_PREFIX`); digit 2 = tier
+   * (`0` OSS / `9` Cloud-only, see `CLOUD_TIER_DIGIT`); digits 3-4 = sequence.
    */
   numericId: number;
 
@@ -31,14 +45,15 @@ export interface ErrorCodeSpec {
   severity: ErrorSeverity;
 }
 
-type SpecMap = Partial<Record<ILobeAgentRuntimeErrorType, ErrorCodeSpec>>;
+type SpecMap = Partial<Record<SpecErrorCode, ErrorCodeSpec>>;
 
 /**
  * Single source of truth for every runtime error code.
  *
  * To add a new code:
- *   1. Add it to `AgentRuntimeErrorType` in `@lobechat/types/agentRuntime.ts`.
- *   2. Add a spec entry here.
+ *   1. Add it to `AgentRuntimeErrorType` in `@lobechat/types/agentRuntime.ts`
+ *      (or `ChatErrorType` + `CloudErrorCode` above for Cloud-only codes).
+ *   2. Add a spec entry here (Cloud-only codes use the `9` tier digit).
  *   3. Add a locale key `response.<code>` in `src/locales/default/error.ts`.
  *   4. (If user-side) add upstream message patterns in `./patterns.ts`.
  */
@@ -144,6 +159,29 @@ export const ERROR_CODE_SPECS: SpecMap = {
     retryable: false,
     countAsFailure: false,
     description: 'Account balance or billing quota exhausted.',
+  },
+  // —— Cloud-only (tier 9) ——
+  [ChatErrorType.FreePlanLimit]: {
+    code: ChatErrorType.FreePlanLimit,
+    numericId: 2901,
+    category: 'quota',
+    severity: 'warning',
+    attribution: 'user',
+    httpStatus: 402,
+    retryable: false,
+    countAsFailure: false,
+    description: 'LobeHub Cloud free-plan usage limit reached.',
+  },
+  [ChatErrorType.InsufficientBudgetForModel]: {
+    code: ChatErrorType.InsufficientBudgetForModel,
+    numericId: 2902,
+    category: 'quota',
+    severity: 'warning',
+    attribution: 'user',
+    httpStatus: 402,
+    retryable: false,
+    countAsFailure: false,
+    description: 'LobeHub Cloud balance is positive but below the model’s estimated cost.',
   },
 
   // ─── 3xxx Capacity ────────────────────────────────────────────────────
@@ -258,6 +296,18 @@ export const ERROR_CODE_SPECS: SpecMap = {
     retryable: false,
     countAsFailure: false,
     description: 'Upstream rejected the request as malformed (bad JSON / schema / parameters).',
+  },
+  // —— Cloud-only (tier 9) ——
+  [ChatErrorType.LobeHubModelDeprecated]: {
+    code: ChatErrorType.LobeHubModelDeprecated,
+    numericId: 4901,
+    category: 'request',
+    severity: 'warning',
+    attribution: 'user',
+    httpStatus: 404,
+    retryable: false,
+    countAsFailure: false,
+    description: 'Requested LobeHub Cloud model has been deprecated / removed.',
   },
 
   // ─── 5xxx Safety ──────────────────────────────────────────────────────
@@ -492,11 +542,11 @@ const CODE_ALIASES: Record<string, ILobeAgentRuntimeErrorType> = {
 
 /** Look up the spec for an error code; falls back to `undefined` when unknown. */
 export const getErrorCodeSpec = (
-  code: ILobeAgentRuntimeErrorType | string | undefined,
+  code: SpecErrorCode | string | undefined,
 ): ErrorCodeSpec | undefined => {
   if (!code) return undefined;
   const canonical = CODE_ALIASES[code] ?? code;
-  return ERROR_CODE_SPECS[canonical as ILobeAgentRuntimeErrorType];
+  return ERROR_CODE_SPECS[canonical as SpecErrorCode];
 };
 
 /**
@@ -507,9 +557,7 @@ export const getErrorCodeSpec = (
  * independent identifier — support tickets, public docs anchors, external SDK
  * error mapping, etc.
  */
-export const formatErrorRef = (
-  code: ILobeAgentRuntimeErrorType | string | undefined,
-): string | undefined => {
+export const formatErrorRef = (code: SpecErrorCode | string | undefined): string | undefined => {
   const spec = getErrorCodeSpec(code);
   if (!spec) return undefined;
   return `E${spec.numericId}`;
@@ -521,7 +569,7 @@ const ERROR_REF_PATTERN = /^E(\d{4})$/;
  * Inverse of `formatErrorRef`: parse `E1001` back into the matching error
  * code. Returns `undefined` if the ref doesn't correspond to a known spec.
  */
-export const parseErrorRef = (ref: string | undefined): ILobeAgentRuntimeErrorType | undefined => {
+export const parseErrorRef = (ref: string | undefined): SpecErrorCode | undefined => {
   if (!ref) return undefined;
   const match = ERROR_REF_PATTERN.exec(ref);
   if (!match) return undefined;

--- a/packages/model-runtime/src/errors/taxonomy.ts
+++ b/packages/model-runtime/src/errors/taxonomy.ts
@@ -34,10 +34,17 @@ export type ErrorAttribution = 'user' | 'provider' | 'harness' | 'system';
 /**
  * Mapping of category → leading digit of the `numericId`.
  *
- * Used to assign and validate stable numeric error references like `E1001`
- * (auth) / `E3001` (capacity) / `E8002` (provider). The first digit is the
- * category bucket; the remaining three digits are assigned sequentially as
- * codes are added.
+ * The 4-digit `numericId` (surfaced as `E1001`, `E2902`, …) is structured:
+ *
+ *   digit 1  — category bucket (this map; 1 = auth … 9 = config)
+ *   digit 2  — **tier**: `0` = open-source / self-host runtime,
+ *              `9` = LobeHub Cloud-only (see `CLOUD_TIER_DIGIT`)
+ *   digits 3-4 — sequence within the (category, tier) bucket
+ *
+ * So `E2001` is the OSS quota code `InsufficientQuota`, while `E2902` is the
+ * Cloud-only quota code `InsufficientBudgetForModel`. The tier digit lets a
+ * dashboard slice "Cloud platform errors" without a separate category, and
+ * keeps the category leading-digit invariant intact.
  *
  * The `numericId` is **append-only**: once published, a (code, id) pair never
  * changes, even if the string `code` is later renamed. This is the contract
@@ -55,3 +62,10 @@ export const CATEGORY_NUMERIC_PREFIX: Record<ErrorCategory, number> = {
   provider: 8,
   config: 9,
 };
+
+/**
+ * The `numericId`'s second digit marks the tier. Cloud-only codes (emitted
+ * solely by the managed LobeHub Cloud gateway, e.g. `InsufficientBudgetForModel`)
+ * use `9`; everything in the open-source runtime uses `0`.
+ */
+export const CLOUD_TIER_DIGIT = 9;

--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -9,6 +9,8 @@ export * from './core/RouterRuntime';
 export * from './core/usageConverters';
 export {
   CATEGORY_NUMERIC_PREFIX,
+  CLOUD_TIER_DIGIT,
+  type CloudErrorCode,
   ERROR_CODE_SPECS,
   ERROR_PATTERNS,
   type ErrorAttribution,
@@ -25,6 +27,7 @@ export {
   type MatchInput,
   type MatchResult,
   parseErrorRef,
+  type SpecErrorCode,
 } from './errors';
 export * from './helpers';
 export { LobeAkashChatAI } from './providers/akashchat';


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] ✅ test

#### 🔗 Related Issue

Follow-up to #15262 / #15273. Three Cloud-only `ChatErrorType` codes were reaching the operation dashboards unclassified because they had no `ERROR_CODE_SPECS` entry.

#### 🔀 Description of Change

`FreePlanLimit`, `InsufficientBudgetForModel`, `LobeHubModelDeprecated` are emitted only by the managed LobeHub Cloud gateway. They live in `ChatErrorType` (not `AgentRuntimeErrorType`) and had no spec, so on Cloud traffic they showed up as `uncategorized` on the error dashboards.

**Why not a new `cloud` category:** the single-digit category prefix (1=auth … 9=config) is exhausted. A 10th category would need prefix 10, which breaks the 4-digit `numericId` scheme, the `E####` parse regex, and the `numericId contract` tests.

**Instead — encode tier in the second digit of `numericId`:** `0` = open-source / self-host runtime, `9` = Cloud-only. Every existing code already has tier digit `0`, so the change is purely additive — the category leading-digit invariant, the 4-digit range, and the `E####` regex all hold unchanged, and no existing numericId moves.

Changes:

- **`taxonomy.ts`** — document the digit layout (`<category><tier><seq>`), export `CLOUD_TIER_DIGIT = 9`.
- **`specs.ts`** — widen the spec key + `code` field to `SpecErrorCode = ILobeAgentRuntimeErrorType | CloudErrorCode`; add the three entries under their semantic categories with tier-9 ids:
  - `FreePlanLimit` → **E2901** (quota)
  - `InsufficientBudgetForModel` → **E2902** (quota)
  - `LobeHubModelDeprecated` → **E4901** (request)
  - all `attribution: user`, `severity: warning`, `countAsFailure: false`; httpStatus 402/402/404. (Previously `getStatus` returned `NaN` for these string codes — now it resolves a sane status; Cloud gateway sets its own status independently so live behavior is unchanged.)
- **`match.test.ts`** — assert every spec's tier digit is `0` or `9`, and the three Cloud codes resolve under the cloud tier.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

\`\`\`bash
bun run type-check                                          # passes
cd packages/model-runtime && bunx vitest run src/errors/    # 49 pass (47 + 2 new tier tests)
\`\`\`

#### 📝 Additional Information

- Locale keys (`response.FreePlanLimit` / `response.InsufficientBudgetForModel` / `response.LobeHubModelDeprecated`) already exist — nothing to add.
- The **agent-gateway mirror** is updated in parallel (it already had `FreePlanLimit`=E2002 / `InsufficientBudgetForModel`=E2003 under quota; those migrate to E2901/E2902 and `LobeHubModelDeprecated`=E4901 is added). Those gateway ids were never published externally, so the append-only contract is not violated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)