### PR TITLE
🐛 fix(chat-input): keep input mounted while intervention panel is shown

### DIFF
--- a/src/features/ChatInput/Desktop/index.tsx
+++ b/src/features/ChatInput/Desktop/index.tsx
@@ -62,6 +62,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 interface DesktopChatInputProps extends ActionToolbarProps {
   actionBarStyle?: React.CSSProperties;
   extentHeaderContent?: ReactNode;
+  hidden?: boolean;
   inputContainerProps?: ChatInputProps;
   /**
    * Swap the action bar and send area for skeleton placeholders while
@@ -94,6 +95,7 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
     borderRadius,
     extraActionItems,
     dropdownPlacement,
+    hidden,
     isConfigLoading = false,
     leftContent,
     placeholder,
@@ -151,6 +153,7 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
         className={cx(styles.container, expand && styles.fullscreen)}
         gap={8}
         paddingBlock={expand ? 0 : showFootnote ? '0 12px' : '0 8px'}
+        style={{ display: hidden ? 'none' : undefined }}
         onDragOver={skillDrop.onDragOver}
         onDrop={skillDrop.onDrop}
       >

--- a/src/features/Conversation/ChatInput/index.tsx
+++ b/src/features/Conversation/ChatInput/index.tsx
@@ -290,47 +290,46 @@ const ChatInput = memo<ChatInputProps>(
       <WideScreenContainer
         style={{ position: 'relative', ...(skipScrollMarginWithList ? { marginTop: -12 } : null) }}
       >
-        {hasPendingInterventions ? (
-          <InterventionBar interventions={pendingInterventions} />
-        ) : (
-          <>
-            {sendMessageErrorMsg && (
-              <Flexbox paddingBlock={'0 6px'} paddingInline={12}>
-                <Alert
-                  closable
-                  title={t('input.errorMsg', { errorMsg: sendMessageErrorMsg })}
-                  type={'secondary'}
-                  onClose={clearSendMessageError}
-                />
-              </Flexbox>
-            )}
-            <Flexbox
-              paddingInline={12}
-              ref={overlayRef}
-              style={{
-                bottom: '100%',
-                left: 12,
-                position: 'absolute',
-                right: 12,
-                zIndex: 10,
-              }}
-            >
-              {!disableQueue && hasQueuedMessages && <QueueTray />}
-              <TodoProgress topAttached={!disableQueue && hasQueuedMessages} />
+        {hasPendingInterventions && <InterventionBar interventions={pendingInterventions} />}
+        {/* Keep the chat input mounted while an intervention panel is showing —
+            unmounting would wipe the Lexical editor's in-memory document. */}
+        <div style={{ display: hasPendingInterventions ? 'none' : 'contents' }}>
+          {sendMessageErrorMsg && (
+            <Flexbox paddingBlock={'0 6px'} paddingInline={12}>
+              <Alert
+                closable
+                title={t('input.errorMsg', { errorMsg: sendMessageErrorMsg })}
+                type={'secondary'}
+                onClose={clearSendMessageError}
+              />
             </Flexbox>
-            <DesktopChatInput
-              actionBarStyle={actionBarStyle}
-              borderRadius={12}
-              extraActionItems={extraActionItems}
-              isConfigLoading={isConfigLoading}
-              leftContent={leftContent}
-              placeholderVariant={placeholderVariant}
-              runtimeConfigSlot={runtimeConfigSlot}
-              sendAreaPrefix={businessSendAreaPrefix}
-              showRuntimeConfig={showRuntimeConfig}
-            />
-          </>
-        )}
+          )}
+          <Flexbox
+            paddingInline={12}
+            ref={overlayRef}
+            style={{
+              bottom: '100%',
+              left: 12,
+              position: 'absolute',
+              right: 12,
+              zIndex: 10,
+            }}
+          >
+            {!disableQueue && hasQueuedMessages && <QueueTray />}
+            <TodoProgress topAttached={!disableQueue && hasQueuedMessages} />
+          </Flexbox>
+          <DesktopChatInput
+            actionBarStyle={actionBarStyle}
+            borderRadius={12}
+            extraActionItems={extraActionItems}
+            isConfigLoading={isConfigLoading}
+            leftContent={leftContent}
+            placeholderVariant={placeholderVariant}
+            runtimeConfigSlot={runtimeConfigSlot}
+            sendAreaPrefix={businessSendAreaPrefix}
+            showRuntimeConfig={showRuntimeConfig}
+          />
+        </div>
       </WideScreenContainer>
     );
 

--- a/src/features/Conversation/ChatInput/index.tsx
+++ b/src/features/Conversation/ChatInput/index.tsx
@@ -322,6 +322,7 @@ const ChatInput = memo<ChatInputProps>(
             actionBarStyle={actionBarStyle}
             borderRadius={12}
             extraActionItems={extraActionItems}
+            hidden={hasPendingInterventions}
             isConfigLoading={isConfigLoading}
             leftContent={leftContent}
             placeholderVariant={placeholderVariant}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

When a tool intervention requires user approval, the conversation swaps `<DesktopChatInput>` for `<InterventionBar>` via a conditional ternary. Unmounting the chat input also unmounts the Lexical editor's React wrapper. On remount (after the user resolves the intervention) `ReactPlainText` re-runs its init effect — `editor.setDocument('text', '')` — which wipes whatever the user had typed into the composer.

The existing draft-save mechanism (`useChatInputDraft`) is meant to restore the unsent text from `localStorage`, but it relies on a debounced save / flush race and visibly flickers; users reported the input simply ending up empty after an intervention.

Fix: wrap the chat-input subtree in a `display: contents | none` container so the editor's React tree stays mounted while the intervention panel is shown. The Lexical editor instance and its in-memory document survive naturally; no extra save/restore round-trip is needed.

Side benefit: the floating overlay (`QueueTray` + `TodoProgress`) is also kept mounted, so the `ResizeObserver` no longer holds a stale reference to a detached DOM node across intervention toggles.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Repro: open a chat, trigger a tool that requires approval (e.g. any builtin tool with intervention enabled), type something in the composer while the intervention panel is visible, then approve/cancel. The typed text should remain after the input returns.

#### 📝 Additional Information

`display: contents` is layout-transparent in modern browsers (Chrome 87+, Firefox, Safari 11.1+) and is already used elsewhere in this repo. When hidden, the wrapper switches to `display: none`, fully removing the input from layout and the accessibility tree — same UX as the previous conditional render.