### PR TITLE
🐛 fix(conversation-flow): prevent infinite recursion in assistant chain

### DIFF
--- a/packages/conversation-flow/src/transformation/MessageCollector.ts
+++ b/packages/conversation-flow/src/transformation/MessageCollector.ts
@@ -88,6 +88,10 @@ export class MessageCollector {
   ): void {
     if (processedIds.has(currentAssistant.id)) return;
 
+    // Mark visited up front so duplicated tool_call_ids (the same tool result
+    // reachable from multiple assistants) can't recurse forever.
+    processedIds.add(currentAssistant.id);
+
     // Add current assistant to chain
     assistantChain.push(currentAssistant);
 

--- a/packages/conversation-flow/src/transformation/MessageCollector.ts
+++ b/packages/conversation-flow/src/transformation/MessageCollector.ts
@@ -119,6 +119,11 @@ export class MessageCollector {
       }
 
       for (const nextMsg of nextMessages) {
+        // Skip an already-collected follower: a duplicated tool_call_id can make
+        // collectToolMessages surface an earlier turn's tool result first, and
+        // returning after that no-op recursion would drop this assistant's real
+        // continuation under a later tool.
+        if (processedIds.has(nextMsg.id)) continue;
         // Only continue if the next assistant has the SAME agentId
         // Different agentId means it's a different agent responding (e.g., via speak tool)
         const isSameAgent = nextMsg.agentId === groupAgentId;

--- a/packages/conversation-flow/src/transformation/__tests__/MessageCollector.test.ts
+++ b/packages/conversation-flow/src/transformation/__tests__/MessageCollector.test.ts
@@ -698,5 +698,26 @@ describe('MessageCollector', () => {
       expect(assistantChain.map((m) => m.id)).toEqual(['ast-A', 'ast-B', 'ast-final']);
       expect(allToolMessages.map((m) => m.id)).toEqual(['tool-1', 'tool-2']);
     });
+
+    it('continues past a duplicate edge to the current turn own tool result', () => {
+      // A → tool(x) → B; B re-declares the SAME tool_call_id x and has its real
+      // continuation C under B's own tool result. collectToolMessages(B) resolves
+      // A's tool result (tool-xa) before B's own (tool-xb), and its child is the
+      // already-visited B. The walk must skip that duplicate edge and continue to
+      // tool-xb → C instead of stopping at B and dropping C.
+      const astA = mkAssistant('ast-A', { parentId: 'user-1', tools: [bashTool('tc-x')] });
+      const toolXA = mkTool('tool-xa', { parentId: 'ast-A', tool_call_id: 'tc-x' });
+      const astB = mkAssistant('ast-B', { parentId: 'tool-xa', tools: [bashTool('tc-x')] });
+      const toolXB = mkTool('tool-xb', { parentId: 'ast-B', tool_call_id: 'tc-x' });
+      const astC = mkAssistant('ast-C', { parentId: 'tool-xb' });
+
+      const allMessages: Message[] = [astA, toolXA, astB, toolXB, astC];
+      const collector = new MessageCollector(new Map(), new Map());
+
+      const assistantChain: Message[] = [];
+      collector.collectAssistantChain(astA, allMessages, assistantChain, [], new Set());
+
+      expect(assistantChain.map((m) => m.id)).toEqual(['ast-A', 'ast-B', 'ast-C']);
+    });
   });
 });

--- a/packages/conversation-flow/src/transformation/__tests__/MessageCollector.test.ts
+++ b/packages/conversation-flow/src/transformation/__tests__/MessageCollector.test.ts
@@ -609,4 +609,94 @@ describe('MessageCollector', () => {
       expect(children.map((c) => c.id)).toEqual(['ast-0', 'ast-4']);
     });
   });
+
+  // ────────────────────────────────────────────────────
+  // collectAssistantChain cycle guard (regression)
+  // ────────────────────────────────────────────────────
+  describe('collectAssistantChain', () => {
+    const mkAssistant = (id: string, opts?: Partial<Message>): Message => ({
+      agentId: 'agent-x',
+      content: '',
+      createdAt: 0,
+      id,
+      role: 'assistant',
+      updatedAt: 0,
+      ...opts,
+    });
+    const mkTool = (id: string, opts?: Partial<Message>): Message => ({
+      content: '',
+      createdAt: 0,
+      id,
+      role: 'tool',
+      updatedAt: 0,
+      ...opts,
+    });
+    const bashTool = (id: string) => ({
+      apiName: 'Bash',
+      arguments: '{}',
+      id,
+      identifier: 'claude-code',
+      type: 'default' as const,
+    });
+
+    it('terminates instead of overflowing the stack when a duplicated tool_call_id creates a cycle', () => {
+      // Regression: two assistant turns declare the SAME tool_call_id, so
+      // collectToolMessages resolves one turn's tool result for the other and
+      // the assistant→tool→assistant walk revisits an already-collected
+      // assistant. Without marking each assistant visited up front this
+      // recurses forever ("Maximum call stack size exceeded").
+      const astA = mkAssistant('ast-A', { parentId: 'user-1', tools: [bashTool('tc-dup')] });
+      const toolA = mkTool('tool-1', { parentId: 'ast-A', tool_call_id: 'tc-dup' });
+      // ast-B is the next turn (child of tool-1) and re-declares the SAME
+      // tc-dup, so collectToolMessages(ast-B) resolves tool-1 again → tool-1's
+      // child is ast-B → self-loop.
+      const astB = mkAssistant('ast-B', { parentId: 'tool-1', tools: [bashTool('tc-dup')] });
+
+      const allMessages: Message[] = [astA, toolA, astB];
+      const collector = new MessageCollector(new Map(), new Map());
+
+      const assistantChain: Message[] = [];
+      const allToolMessages: Message[] = [];
+      const processedIds = new Set<string>();
+
+      expect(() =>
+        collector.collectAssistantChain(
+          astA,
+          allMessages,
+          assistantChain,
+          allToolMessages,
+          processedIds,
+        ),
+      ).not.toThrow();
+
+      // Each assistant collected exactly once despite the cycle.
+      expect(assistantChain.map((m) => m.id)).toEqual(['ast-A', 'ast-B']);
+      expect(processedIds.has('ast-A')).toBe(true);
+      expect(processedIds.has('ast-B')).toBe(true);
+    });
+
+    it('still collects a normal (acyclic) assistant→tool→assistant chain', () => {
+      const astA = mkAssistant('ast-A', { parentId: 'user-1', tools: [bashTool('tc-1')] });
+      const toolA = mkTool('tool-1', { parentId: 'ast-A', tool_call_id: 'tc-1' });
+      const astB = mkAssistant('ast-B', { parentId: 'tool-1', tools: [bashTool('tc-2')] });
+      const toolB = mkTool('tool-2', { parentId: 'ast-B', tool_call_id: 'tc-2' });
+      const astFinal = mkAssistant('ast-final', { parentId: 'tool-2' });
+
+      const allMessages: Message[] = [astA, toolA, astB, toolB, astFinal];
+      const collector = new MessageCollector(new Map(), new Map());
+
+      const assistantChain: Message[] = [];
+      const allToolMessages: Message[] = [];
+      collector.collectAssistantChain(
+        astA,
+        allMessages,
+        assistantChain,
+        allToolMessages,
+        new Set(),
+      );
+
+      expect(assistantChain.map((m) => m.id)).toEqual(['ast-A', 'ast-B', 'ast-final']);
+      expect(allToolMessages.map((m) => m.id)).toEqual(['tool-1', 'tool-2']);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `MessageCollector.collectAssistantChain` checked `processedIds` as its only loop guard but **never populated it** — `processedIds.add(...)` was missing — so the guard was dead.
- When a topic contains duplicated `tool_call_id`s (the same tool result reachable from multiple assistant messages), the `assistant → tool → assistant` walk revisits already-seen assistants and recurses without bound, throwing `RangeError: Maximum call stack size exceeded`. The error boundary then blanks the entire conversation view.
- Fix: mark each assistant visited up front (`processedIds.add(currentAssistant.id)`), matching the `visited`-set pattern the sibling tree-walk helpers already use. The caller (`FlatListBuilder`) already marks chain members processed after the call, so this is consistent and safe.

This is a defensive render-layer fix — the conversation transform should never infinite-loop on any data shape, regardless of how the duplicated ids got persisted.

## Test plan

- [x] Reproduced the crash locally (Electron) on a topic with 17 duplicated `tool_call_id`s — `Maximum call stack size exceeded` in `collectAssistantChain`.
- [x] With the fix, the same topic renders the full conversation; the guard caught the cycle 52× instead of overflowing the stack.
- [ ] CI: lint + type-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)