### PR TITLE
🐛 fix(cc-adapter): emit reasoning chunk before text in batch mode

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -741,11 +741,16 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
       reasoningParts.join(''),
       this.streamedThinkingByMessageId,
     );
-    if (textCompletion) {
-      events.push(this.makeChunkEvent({ chunkType: 'text', content: textCompletion }));
-    }
+    // Emit reasoning before text so the gateway event handler starts the
+    // reasoning operation first — matching Claude's natural output order
+    // (thinking → response). Without this, batch-mode runs (CLI / sandbox
+    // without --include-partial-messages) emit text first, causing the
+    // brain icon to appear below the already-rendered text content.
     if (thinkingCompletion) {
       events.push(this.makeChunkEvent({ chunkType: 'reasoning', reasoning: thinkingCompletion }));
+    }
+    if (textCompletion) {
+      events.push(this.makeChunkEvent({ chunkType: 'text', content: textCompletion }));
     }
     if (messageId) {
       this.clearStreamedBuffers(messageId, {
@@ -838,20 +843,21 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
     // `messagesWithStreamedText` (unlike the main-agent path) because
     // subagent events don't arrive via `stream_event` partial-messages
     // deltas; the full block IS the only emission.
-    if (textParts.length > 0) {
-      events.push(
-        this.makeChunkEvent({
-          chunkType: 'text',
-          content: textParts.join(''),
-          subagent: subagentCtx,
-        }),
-      );
-    }
+    // Reasoning before text — same ordering fix as the main-agent batch path.
     if (reasoningParts.length > 0) {
       events.push(
         this.makeChunkEvent({
           chunkType: 'reasoning',
           reasoning: reasoningParts.join(''),
+          subagent: subagentCtx,
+        }),
+      );
+    }
+    if (textParts.length > 0) {
+      events.push(
+        this.makeChunkEvent({
+          chunkType: 'text',
+          content: textParts.join(''),
           subagent: subagentCtx,
         }),
       );


### PR DESCRIPTION
## Problem

In the batch path (CLI / sandbox **without** `--include-partial-messages`), `ClaudeCodeAdapter.handleAssistant()` extracted thinking and text from the complete assistant block and emitted **text first, reasoning second**. This reversed order caused `gatewayEventHandler` to:

1. Receive `stream_chunk { chunkType: 'text' }` → renders text content
2. Receive `stream_chunk { chunkType: 'reasoning' }` → calls `startReasoningIfNeeded()` → **brain icon appears below the already-rendered text**

The desktop driver uses `--include-partial-messages` (partial deltas arrive in the natural thinking → text order), so it was unaffected. The bug was only visible on CLI / sandbox / cloud runs where CC outputs complete messages.

## Fix

Swap the emission order in both the main-agent and subagent batch paths so reasoning chunks are always emitted **before** text chunks — matching Claude's natural output order (thinking → response):

```
Before: text → reasoning  ← brain icon appears below text ❌
After:  reasoning → text  ← brain icon precedes text, then collapses above it ✓
```

## Test plan

- [x] `packages/heterogeneous-agents` unit tests pass (86/86)
- [ ] Manual: start a `claude-code` agent via CLI/sandbox — verify the thinking indicator appears **above** (before) the response text, not below it
- [ ] Desktop path (`--include-partial-messages`) unaffected — deltas still arrive in correct order naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)