### PR TITLE
🐛 fix(desktop): market OAuth expiry triggers wrong re-login modal

### DIFF
--- a/packages/desktop-bridge/src/index.ts
+++ b/packages/desktop-bridge/src/index.ts
@@ -32,3 +32,12 @@ export const AUTH_REQUIRED_HEADER = 'X-Auth-Required';
  * Used to identify authentication failures in TRPC responses.
  */
 export const TRPC_ERROR_CODE_UNAUTHORIZED = 'UNAUTHORIZED' as const;
+
+/**
+ * Sentinel message placed in TRPCError({ code: 'UNAUTHORIZED' }) when the failure
+ * originates from the Market service's own OAuth token, NOT from the user's LobeHub
+ * session.  responseMeta checks this to suppress the X-Auth-Required header so the
+ * desktop "re-login to LobeHub" modal is NOT shown; the Market OAuth flow handles it
+ * instead via the market-unauthorized event.
+ */
+export const MARKET_AUTH_REQUIRED_MESSAGE = 'MARKET_AUTH_REQUIRED' as const;

--- a/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
+++ b/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
@@ -705,14 +705,12 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
   useEffect(() => {
     const unsubscribe = marketAuthEvents.on('market-unauthorized', async (event) => {
       console.info('[MarketAuth] Received unauthorized event for path:', event.path);
-      // Desktop: do not open community auth / profile modals from background API 401s.
-      // Only attempt a silent token refresh; Lobe cloud re-auth is handled separately (AuthRequiredModal).
       if (isDesktop) {
         const refreshed = await refreshToken();
         if (!refreshed) {
-          console.info(
-            '[MarketAuth] Desktop: market 401 — refresh failed, skipping community sign-in UI',
-          );
+          // Silent refresh failed — the Market OAuth token is genuinely expired.
+          // Show the Market auth modal so the user can re-authorize.
+          await handleUnauthorized();
         }
         return;
       }

--- a/src/libs/trpc/utils/responseMeta.test.ts
+++ b/src/libs/trpc/utils/responseMeta.test.ts
@@ -1,4 +1,8 @@
-import { AUTH_REQUIRED_HEADER, TRPC_ERROR_CODE_UNAUTHORIZED } from '@lobechat/desktop-bridge';
+import {
+  AUTH_REQUIRED_HEADER,
+  MARKET_AUTH_REQUIRED_MESSAGE,
+  TRPC_ERROR_CODE_UNAUTHORIZED,
+} from '@lobechat/desktop-bridge';
 import { TRPCError } from '@trpc/server';
 import { describe, expect, it } from 'vitest';
 
@@ -64,6 +68,19 @@ describe('createResponseMeta', () => {
 
     expect(result.headers).toBeInstanceOf(Headers);
     expect(result.headers?.get(AUTH_REQUIRED_HEADER)).toBe('true');
+  });
+
+  it('should NOT set AUTH_REQUIRED_HEADER for Market OAuth UNAUTHORIZED errors', () => {
+    const error = new TRPCError({
+      code: TRPC_ERROR_CODE_UNAUTHORIZED,
+      message: MARKET_AUTH_REQUIRED_MESSAGE,
+    });
+    const result = createResponseMeta({
+      ctx: undefined,
+      errors: [error],
+    });
+
+    expect(result.headers).toBeUndefined();
   });
 
   it('should handle multiple errors where one is UNAUTHORIZED', () => {

--- a/src/libs/trpc/utils/responseMeta.ts
+++ b/src/libs/trpc/utils/responseMeta.ts
@@ -1,4 +1,8 @@
-import { AUTH_REQUIRED_HEADER, TRPC_ERROR_CODE_UNAUTHORIZED } from '@lobechat/desktop-bridge';
+import {
+  AUTH_REQUIRED_HEADER,
+  MARKET_AUTH_REQUIRED_MESSAGE,
+  TRPC_ERROR_CODE_UNAUTHORIZED,
+} from '@lobechat/desktop-bridge';
 import { type TRPCError } from '@trpc/server';
 
 interface ResponseMetaParams {
@@ -11,11 +15,11 @@ interface ResponseMetaParams {
  *
  * This function handles:
  * 1. Forwarding custom headers from context (ctx.resHeaders)
- * 2. Adding X-Auth-Required header for UNAUTHORIZED errors
+ * 2. Adding X-Auth-Required header for LobeHub session UNAUTHORIZED errors
  *
  * The X-Auth-Required header allows the desktop app (BackendProxyProtocolManager)
- * to distinguish between real authentication failures (e.g., token expired)
- * and other 401 errors (e.g., invalid API keys).
+ * to distinguish between real LobeHub session failures (e.g., token expired)
+ * and other 401 errors (e.g., invalid API keys, Market OAuth expiry).
  */
 export function createResponseMeta({ ctx, errors }: ResponseMetaParams): {
   headers: Headers | undefined;
@@ -26,7 +30,13 @@ export function createResponseMeta({ ctx, errors }: ResponseMetaParams): {
       : undefined;
   const headers = resHeaders ? new Headers(resHeaders) : new Headers();
 
-  const hasUnauthorizedError = errors.some((error) => error.code === TRPC_ERROR_CODE_UNAUTHORIZED);
+  // Only set X-Auth-Required for LobeHub session failures, not for Market OAuth failures.
+  // Market auth errors use MARKET_AUTH_REQUIRED_MESSAGE and are handled by the market-unauthorized
+  // event flow (MarketAuthProvider) rather than the desktop re-login modal.
+  const hasUnauthorizedError = errors.some(
+    (error) =>
+      error.code === TRPC_ERROR_CODE_UNAUTHORIZED && error.message !== MARKET_AUTH_REQUIRED_MESSAGE,
+  );
   if (hasUnauthorizedError) {
     headers.set(AUTH_REQUIRED_HEADER, 'true');
   }

--- a/src/server/routers/tools/market.ts
+++ b/src/server/routers/tools/market.ts
@@ -1,3 +1,4 @@
+import { MARKET_AUTH_REQUIRED_MESSAGE } from '@lobechat/desktop-bridge';
 import { type CodeInterpreterToolName } from '@lobehub/market-sdk';
 import { TRPCError } from '@trpc/server';
 import debug from 'debug';
@@ -229,8 +230,7 @@ const execInSandboxHandler = async ({
       ) {
         throw new TRPCError({
           code: 'UNAUTHORIZED',
-          message:
-            'Market authorization expired. An authorization dialog has been shown to the user. Please wait for the user to complete authorization and then retry the current task.',
+          message: MARKET_AUTH_REQUIRED_MESSAGE,
         });
       }
 
@@ -268,8 +268,7 @@ const execInSandboxHandler = async ({
     ) {
       throw new TRPCError({
         code: 'UNAUTHORIZED',
-        message:
-          'Market authorization expired. An authorization dialog has been shown to the user. Please wait for the user to complete authorization and then retry the current task.',
+        message: MARKET_AUTH_REQUIRED_MESSAGE,
       });
     }
 


### PR DESCRIPTION
## Summary

- **Root cause**: When sandbox tools (Document Writing, Agent Browser) encountered a Market OAuth token expiry, `execInSandbox` threw `TRPCError({ code: 'UNAUTHORIZED' })`. `responseMeta` applies `X-Auth-Required: true` to **all** `UNAUTHORIZED` tRPC errors, causing the Desktop proxy to show the LobeHub cloud re-login modal — wrong dialog for the wrong auth layer.
- Add `MARKET_AUTH_REQUIRED_MESSAGE` sentinel constant in `desktop-bridge` to distinguish Market OAuth failures from LobeHub session failures.
- `market.ts` uses this message when throwing `UNAUTHORIZED` for Market auth errors; `responseMeta` skips `X-Auth-Required` for these errors so the desktop re-login modal is suppressed.
- `MarketAuthProvider` on Desktop now calls `handleUnauthorized()` when silent token refresh fails, correctly opening the Market OAuth flow.

## Test plan

- [ ] Use Document Writing or Agent Browser tool while Market OAuth token is expired → should see Market OAuth dialog, NOT LobeHub re-login modal
- [ ] LobeHub session expiry still correctly shows the LobeHub re-login modal (non-market UNAUTHORIZED errors still set `X-Auth-Required`)
- [ ] `responseMeta.test.ts` passes (8 tests, including new Market auth case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)