### PR TITLE
♻️ refactor(bot): slim iMessage setup schema to user-edited fields

### DIFF
--- a/src/server/services/bot/platforms/imessage/schema.ts
+++ b/src/server/services/bot/platforms/imessage/schema.ts
@@ -4,28 +4,9 @@ import { displayToolCallsField, makeUserIdField, watchKeywordsField } from '../c
 import type { FieldSchema } from '../types';
 
 export const schema: FieldSchema[] = [
-  {
-    key: 'credentials',
-    label: 'channel.credentials',
-    properties: [
-      {
-        key: 'desktopDeviceId',
-        description: 'channel.imessage.desktopDeviceIdHint',
-        label: 'channel.imessage.desktopDeviceId',
-        placeholder: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
-        required: true,
-        type: 'string',
-      },
-      {
-        key: 'webhookSecret',
-        description: 'channel.imessage.webhookSecretHint',
-        label: 'channel.imessage.webhookSecret',
-        required: true,
-        type: 'password',
-      },
-    ],
-    type: 'object',
-  },
+  // `credentials.desktopDeviceId` and `credentials.webhookSecret` are not user
+  // fields: the Desktop client fills the device id from the local gateway and
+  // generates the webhook secret on first save (see imessage/CredentialExtras).
   {
     key: 'applicationId',
     description: 'channel.imessage.applicationIdHint',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔀 Description of Change

Removes `credentials.desktopDeviceId` and `credentials.webhookSecret` from the iMessage platform schema. Neither is user-supplied:

- **desktopDeviceId** — the Desktop client fills it from the local gateway (`getDeviceInfo`).
- **webhookSecret** — a cloud↔desktop shared secret that the Desktop client generates on first save.

After this change the iMessage setup form only asks for the fields a user actually edits (Application ID + the BlueBubbles bridge fields, which live in the Desktop-only `CredentialExtras`).

Safe to land ahead of the Desktop bridge PR: iMessage is still gated as "Coming Soon" in the channel list (`COMING_SOON_PLATFORMS`), so no one can reach this form yet. The Desktop bridge PR (which auto-fills both values and unveils the platform) depends on this.

#### 🔗 Related Issue

Part of the iMessage channel work (LOBE-6554 / LOBE-6384); carved out of the Desktop bridge branch so the server schema lands independently.

#### 🧪 Testing

- [x] `bun run type-check`