### PR TITLE
fix: add recency-ordered fallback to searchHybridExperiences and searchHybridContexts

### DIFF
--- a/packages/database/src/models/userMemory/query.ts
+++ b/packages/database/src/models/userMemory/query.ts
@@ -1655,6 +1655,11 @@ export class UserMemoryQueryModel {
     // for this table in some environments (see getTestDB.ts where pg_search
     // migrations are skipped). Runs a plain recency-ordered query without
     // BM25 conditions; scoreHybridCandidates still applies fuzzy text scoring.
+    //
+    // IMPORTANT: feed fallback items as a lexical list so that
+    // registerRankedList in scoreHybridCandidates populates the candidate map.
+    // Passing lexicalLists: [] would be a no-op — scoreHybridCandidates does
+    // not use items directly, only lexicalLists and semanticLists.
     if (candidates.length === 0 && params.queries.length > 0) {
       const fallbackItems = await this.searchContextsLexical(
         undefined,
@@ -1666,7 +1671,7 @@ export class UserMemoryQueryModel {
         return scoreHybridCandidates({
           baseSignals: await this.loadBaseSignals(fallbackItems),
           items: fallbackItems,
-          lexicalLists: [],
+          lexicalLists: [fallbackItems],
           queries: params.queries,
           queryParams: params.params,
           semanticLists: [],
@@ -1717,6 +1722,11 @@ export class UserMemoryQueryModel {
     // for this table in some environments (see getTestDB.ts where pg_search
     // migrations are skipped). Runs a plain recency-ordered query without
     // BM25 conditions; scoreHybridCandidates still applies fuzzy text scoring.
+    //
+    // IMPORTANT: feed fallback items as a lexical list so that
+    // registerRankedList in scoreHybridCandidates populates the candidate map.
+    // Passing lexicalLists: [] would be a no-op — scoreHybridCandidates does
+    // not use items directly, only lexicalLists and semanticLists.
     if (candidates.length === 0 && params.queries.length > 0) {
       const fallbackItems = await this.searchExperiencesLexical(
         undefined,
@@ -1728,7 +1738,7 @@ export class UserMemoryQueryModel {
         return scoreHybridCandidates({
           baseSignals: await this.loadBaseSignals(fallbackItems),
           items: fallbackItems,
-          lexicalLists: [],
+          lexicalLists: [fallbackItems],
           queries: params.queries,
           queryParams: params.params,
           semanticLists: [],

--- a/packages/database/src/models/userMemory/query.ts
+++ b/packages/database/src/models/userMemory/query.ts
@@ -1641,7 +1641,7 @@ export class UserMemoryQueryModel {
       ).values(),
     ];
 
-    return scoreHybridCandidates({
+    const candidates = scoreHybridCandidates({
       baseSignals: await this.loadBaseSignals(items),
       items,
       lexicalLists,
@@ -1649,6 +1649,32 @@ export class UserMemoryQueryModel {
       queryParams: params.params,
       semanticLists,
     });
+
+    // NOTICE: Fallback when BM25 + vector search both return empty but
+    // data exists (confirmed by taxonomy queries). BM25 indexes may not exist
+    // for this table in some environments (see getTestDB.ts where pg_search
+    // migrations are skipped). Runs a plain recency-ordered query without
+    // BM25 conditions; scoreHybridCandidates still applies fuzzy text scoring.
+    if (candidates.length === 0 && params.queries.length > 0) {
+      const fallbackItems = await this.searchContextsLexical(
+        undefined,
+        limit,
+        params.params,
+      );
+
+      if (fallbackItems.length > 0) {
+        return scoreHybridCandidates({
+          baseSignals: await this.loadBaseSignals(fallbackItems),
+          items: fallbackItems,
+          lexicalLists: [],
+          queries: params.queries,
+          queryParams: params.params,
+          semanticLists: [],
+        });
+      }
+    }
+
+    return candidates;
   }
 
   private async searchHybridExperiences(params: {
@@ -1677,7 +1703,7 @@ export class UserMemoryQueryModel {
       ).values(),
     ];
 
-    return scoreHybridCandidates({
+    const candidates = scoreHybridCandidates({
       baseSignals: await this.loadBaseSignals(items),
       items,
       lexicalLists,
@@ -1685,6 +1711,32 @@ export class UserMemoryQueryModel {
       queryParams: params.params,
       semanticLists,
     });
+
+    // NOTICE: Fallback when BM25 + vector search both return empty but
+    // data exists (confirmed by taxonomy queries). BM25 indexes may not exist
+    // for this table in some environments (see getTestDB.ts where pg_search
+    // migrations are skipped). Runs a plain recency-ordered query without
+    // BM25 conditions; scoreHybridCandidates still applies fuzzy text scoring.
+    if (candidates.length === 0 && params.queries.length > 0) {
+      const fallbackItems = await this.searchExperiencesLexical(
+        undefined,
+        limit,
+        params.params,
+      );
+
+      if (fallbackItems.length > 0) {
+        return scoreHybridCandidates({
+          baseSignals: await this.loadBaseSignals(fallbackItems),
+          items: fallbackItems,
+          lexicalLists: [],
+          queries: params.queries,
+          queryParams: params.params,
+          semanticLists: [],
+        });
+      }
+    }
+
+    return candidates;
   }
 
   private async searchHybridIdentities(params: {


### PR DESCRIPTION
## Summary

When `searchUserMemory` is called with `layers: ["experience"]` or `layers: ["context"]`, it consistently returns zero results even though data is confirmed present by `queryTaxonomyOptions` and the UI.

## Root Cause

The search for Experience and Context layers relies on both:

1. **Vector semantic search** — uses `cosineDistance(situationVector, embedding)` for experiences and `cosineDistance(descriptionVector, embedding)` for contexts
2. **BM25 lexical search** — uses ParadeDB `@@@` with `paradedb.match` on text fields

When either the vector columns are not populated (e.g., `situationVector` is NULL when no situation was saved) or the BM25 index does not exist for these tables (see `packages/database/src/core/getTestDB.ts` where `pg_search` migrations are skipped), both searches can return empty.

Activity, Identity, and Preference layers work because they use different vector columns (`narrativeVector`, `descriptionVector`, `conclusionDirectivesVector`) which may be more consistently populated, and their BM25 indexes may be differently configured.

## Fix

Added a **recency-ordered fallback query** to both `searchHybridExperiences` and `searchHybridContexts`:

* When both primary searches return zero results AND the caller provided queries
* The fallback runs a plain query ordered by `capturedAt DESC` / `createdAt DESC` **without** BM25 condition
* `scoreHybridCandidates` still applies fuzzy text matching against the queries during scoring
* This ensures the search returns data even if BM25 indexes are missing or vector columns are NULL

Fixes lobehub/lobehub#15242