### PR TITLE
🐛 fix: show artifact source while streaming

### DIFF
--- a/src/features/Portal/Artifacts/Body/index.test.tsx
+++ b/src/features/Portal/Artifacts/Body/index.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from '@testing-library/react';
+import type { CSSProperties, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ArtifactDisplayMode } from '@/store/chat/slices/portal/initialState';
+import { ArtifactType } from '@/types/artifact';
+
+import ArtifactsUI from './index';
+
+const mockArtifactState = vi.hoisted(() => ({
+  artifactCodeLanguage: undefined as string | undefined,
+  artifactContent: '',
+  artifactIdentifier: 'snake-game',
+  artifactMessageId: 'message-1',
+  artifactType: 'text/html' as string | undefined,
+  displayMode: 'preview',
+  isArtifactTagClosed: false,
+  isMessageGenerating: true,
+  setState: vi.fn(),
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  Flexbox: ({ children, style }: { children: ReactNode; style?: CSSProperties }) => (
+    <div data-testid={style?.overflow === 'auto' ? 'artifact-scroll-container' : undefined}>
+      {children}
+    </div>
+  ),
+  Highlighter: ({
+    animated,
+    children,
+    language,
+  }: {
+    animated?: boolean;
+    children: ReactNode;
+    language?: string;
+  }) => (
+    <pre
+      data-animated={String(Boolean(animated))}
+      data-language={language}
+      data-testid="artifact-code"
+    >
+      {children}
+    </pre>
+  ),
+}));
+
+vi.mock('@/store/chat', () => ({
+  useChatStore: Object.assign(
+    (selector: (state: Record<PropertyKey, unknown>) => unknown) => {
+      return selector({ portalArtifactDisplayMode: mockArtifactState.displayMode });
+    },
+    {
+      setState: mockArtifactState.setState,
+    },
+  ),
+}));
+
+vi.mock('@/store/chat/selectors', () => ({
+  chatPortalSelectors: {
+    artifactCode: () => () => mockArtifactState.artifactContent,
+    artifactCodeLanguage: () => mockArtifactState.artifactCodeLanguage,
+    artifactIdentifier: () => mockArtifactState.artifactIdentifier,
+    artifactMessageId: () => mockArtifactState.artifactMessageId,
+    artifactType: () => mockArtifactState.artifactType,
+    isArtifactTagClosed: () => () => mockArtifactState.isArtifactTagClosed,
+  },
+  messageStateSelectors: {
+    isMessageGenerating: () => () => mockArtifactState.isMessageGenerating,
+  },
+}));
+
+vi.mock('./Renderer', () => ({
+  default: ({ animated, content }: { animated?: boolean; content: string; type?: string }) => (
+    <div data-animated={String(Boolean(animated))} data-testid="artifact-preview">
+      {content}
+    </div>
+  ),
+}));
+
+describe('ArtifactsUI', () => {
+  beforeEach(() => {
+    mockArtifactState.artifactCodeLanguage = undefined;
+    mockArtifactState.artifactContent = '<!doctype html><html><body><script>';
+    mockArtifactState.artifactIdentifier = 'snake-game';
+    mockArtifactState.artifactMessageId = 'message-1';
+    mockArtifactState.artifactType = 'text/html';
+    mockArtifactState.displayMode = ArtifactDisplayMode.Preview;
+    mockArtifactState.isArtifactTagClosed = false;
+    mockArtifactState.isMessageGenerating = true;
+    mockArtifactState.setState.mockClear();
+  });
+
+  it('shows scrollable source while an HTML artifact is still streaming', () => {
+    render(<ArtifactsUI />);
+
+    expect(screen.getByTestId('artifact-code')).toHaveTextContent('<script>');
+    expect(screen.getByTestId('artifact-code')).toHaveAttribute('data-animated', 'true');
+    expect(screen.getByTestId('artifact-code')).toHaveAttribute('data-language', 'html');
+    expect(screen.getByTestId('artifact-scroll-container')).toBeDefined();
+    expect(screen.queryByTestId('artifact-preview')).toBeNull();
+    expect(mockArtifactState.setState).not.toHaveBeenCalled();
+  });
+
+  it('renders the final preview after the artifact tag closes', () => {
+    mockArtifactState.artifactContent = '<!doctype html><html><body>Done</body></html>';
+    mockArtifactState.isArtifactTagClosed = true;
+
+    render(<ArtifactsUI />);
+
+    expect(screen.getByTestId('artifact-preview')).toHaveTextContent('Done');
+    expect(screen.queryByTestId('artifact-code')).toBeNull();
+  });
+
+  it('keeps explicit code artifacts in source mode after they close', () => {
+    mockArtifactState.artifactContent = 'console.log("done");';
+    mockArtifactState.artifactType = ArtifactType.Code;
+    mockArtifactState.isArtifactTagClosed = true;
+
+    render(<ArtifactsUI />);
+
+    expect(screen.getByTestId('artifact-code')).toHaveTextContent('console.log("done");');
+    expect(screen.queryByTestId('artifact-preview')).toBeNull();
+  });
+});

--- a/src/features/Portal/Artifacts/Body/index.tsx
+++ b/src/features/Portal/Artifacts/Body/index.tsx
@@ -8,8 +8,6 @@ import { ArtifactType } from '@/types/artifact';
 
 import Renderer from './Renderer';
 
-const TEXT_HTML_ARTIFACT_TYPE = 'text/html';
-
 const ArtifactsUI = memo(() => {
   const [
     messageId,
@@ -34,21 +32,12 @@ const ArtifactsUI = memo(() => {
     ];
   });
 
-  const isHtmlArtifact =
-    !artifactType ||
-    artifactType === ArtifactType.Default ||
-    artifactType === TEXT_HTML_ARTIFACT_TYPE;
-
   useEffect(() => {
-    // Prefer live preview while HTML artifacts stream; reset stale code mode from previous artifacts.
-    if (
-      isMessageGenerating &&
-      displayMode === ArtifactDisplayMode.Code &&
-      (isArtifactTagClosed || (isHtmlArtifact && !isArtifactTagClosed))
-    ) {
+    // When generation completes, switch from the live source stream to the final preview.
+    if (isMessageGenerating && displayMode === ArtifactDisplayMode.Code && isArtifactTagClosed) {
       useChatStore.setState({ portalArtifactDisplayMode: ArtifactDisplayMode.Preview });
     }
-  }, [isMessageGenerating, displayMode, isArtifactTagClosed, isHtmlArtifact]);
+  }, [isMessageGenerating, displayMode, isArtifactTagClosed]);
 
   const language = useMemo(() => {
     switch (artifactType) {
@@ -70,11 +59,11 @@ const ArtifactsUI = memo(() => {
     }
   }, [artifactType, artifactCodeLanguage]);
 
-  // Keep incomplete non-HTML artifacts in code mode, but let HTML stream into the preview.
+  // Keep incomplete artifacts in code mode so users can inspect and scroll the generated source.
   const showCode =
     artifactType === ArtifactType.Code ||
-    (!isArtifactTagClosed && !isHtmlArtifact) ||
-    (displayMode === ArtifactDisplayMode.Code && !(isHtmlArtifact && !isArtifactTagClosed));
+    !isArtifactTagClosed ||
+    displayMode === ArtifactDisplayMode.Code;
   const isStreamingCode = isMessageGenerating && showCode && !isArtifactTagClosed;
   const isStreamingArtifact = isMessageGenerating && !isArtifactTagClosed;
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #14777

#### 🔀 Description of Change

Restore the Portal artifact behavior so incomplete artifacts render as scrollable source code while they are still streaming. This keeps generated HTML games and other script-heavy artifacts out of `HtmlPreview` until the artifact tag is closed, avoiding the non-scrollable `Preparing preview...` placeholder during generation.

The final preview path still uses `HtmlPreview` after generation completes.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/features/Portal/Artifacts/Body/index.test.tsx'
```

Manual scenario: ask Artifacts to generate a snake game. While the artifact is streaming, the Portal shows scrollable HTML source. After the artifact closes, the final preview renders normally.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This PR only changes the Portal display decision. It does not change `HtmlPreview` itself.
