### PR TITLE
🔨 chore(conversation): add stream animation toggle for CPU investigation

### DIFF
--- a/src/components/StreamAnimationToggle/index.tsx
+++ b/src/components/StreamAnimationToggle/index.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { createStaticStyles, cx } from 'antd-style';
+import { memo, useEffect, useState } from 'react';
+
+export const STREAM_ANIM_DISABLED_CLASS = 'lobe-no-stream-anim';
+const STORAGE_KEY = 'lobe_stream_anim_disabled';
+
+const readInitial = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+};
+
+const applyClass = (disabled: boolean) => {
+  if (typeof document === 'undefined') return;
+  document.documentElement.classList.toggle(STREAM_ANIM_DISABLED_CLASS, disabled);
+};
+
+if (typeof window !== 'undefined') {
+  applyClass(readInitial());
+}
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  dot: css`
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+  `,
+  dotOff: css`
+    background: ${cssVar.colorTextQuaternary};
+  `,
+  dotOn: css`
+    background: ${cssVar.colorSuccess};
+  `,
+  toggle: css`
+    pointer-events: auto;
+    cursor: pointer;
+    user-select: none;
+
+    position: fixed;
+    z-index: 9999;
+    inset-block-end: 24px;
+    inset-inline-end: 24px;
+
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    padding-block: 6px;
+    padding-inline: 12px;
+    border: 1px solid ${cssVar.colorBorder};
+    border-radius: 999px;
+
+    font-size: 12px;
+    line-height: 1;
+    color: ${cssVar.colorText};
+
+    background: ${cssVar.colorBgElevated};
+    box-shadow: ${cssVar.boxShadowTertiary};
+
+    &:hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
+}));
+
+const StreamAnimationToggle = memo(() => {
+  const [disabled, setDisabled] = useState<boolean>(readInitial);
+
+  useEffect(() => {
+    applyClass(disabled);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, disabled ? '1' : '0');
+    } catch {}
+  }, [disabled]);
+
+  return (
+    <button
+      aria-pressed={!disabled}
+      className={styles.toggle}
+      title="切换 streaming 动画 (用于 CPU 占用对比)"
+      type="button"
+      onClick={() => setDisabled((v) => !v)}
+    >
+      <span className={cx(styles.dot, disabled ? styles.dotOff : styles.dotOn)} />
+      <span>动画 {disabled ? '关' : '开'}</span>
+    </button>
+  );
+});
+
+StreamAnimationToggle.displayName = 'StreamAnimationToggle';
+
+export default StreamAnimationToggle;

--- a/src/features/Conversation/ChatList/index.tsx
+++ b/src/features/Conversation/ChatList/index.tsx
@@ -3,6 +3,7 @@
 import { type ReactNode } from 'react';
 import { memo, useCallback } from 'react';
 
+import StreamAnimationToggle from '@/components/StreamAnimationToggle';
 import { useFetchAgentDocuments } from '@/hooks/useFetchAgentDocuments';
 import { useFetchTopicMemories } from '@/hooks/useFetchMemoryForTopic';
 import { useFetchNotebookDocuments } from '@/hooks/useFetchNotebookDocuments';
@@ -171,6 +172,7 @@ const ChatList = memo<ChatListProps>(
           headerSlot={headerSlot}
           itemContent={itemContent ?? defaultItemContent}
         />
+        <StreamAnimationToggle />
       </MessageActionProvider>
     );
   },

--- a/src/styles/global.ts
+++ b/src/styles/global.ts
@@ -74,4 +74,10 @@ export default ({ token }: { prefixCls: string; token: Theme }) => css`
   ) {
     opacity: 1;
   }
+
+  html.lobe-no-stream-anim *,
+  html.lobe-no-stream-anim *::before,
+  html.lobe-no-stream-anim *::after {
+    animation-play-state: paused !important;
+  }
 `;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔗 Related Issue

N/A — internal performance investigation tooling.

#### 🔀 Description of Change

Adds a debug toggle that **pauses all keyframe animations** on the page via `animation-play-state: paused`, used to A/B compare CPU usage during message streaming.

Reports came in that `src/features/Conversation/` streams cause noticeable CPU spikes, while an isolated markdown streaming demo does not. Suspicion: it's the accumulation of CSS keyframe animations rather than the markdown/diffing path. During a typical streaming turn the page can have **10–30+ `shinyText` shimmer (background-position + background-clip: text)** + **multiple `NeuralNetworkLoading` instances (14 animated SVG nodes each)** + dots / spinners running concurrently. `background-clip: text` + animated gradient cannot be GPU-composited in Chrome, so each frame is paid on the main thread.

This PR ships a toggle so testers can flip animations on/off and compare CPU directly. **No animation source is removed.**

**How it works**

- Global CSS rule in `src/styles/global.ts`:
  \`\`\`css
  html.lobe-no-stream-anim *,
  html.lobe-no-stream-anim *::before,
  html.lobe-no-stream-anim *::after {
    animation-play-state: paused !important;
  }
  \`\`\`
- New `src/components/StreamAnimationToggle/`: floating bottom-right pill button, persists state in `localStorage` (`lobe_stream_anim_disabled`), applies the class at module load to avoid a flash on reload.
- Mounted once in `src/features/Conversation/ChatList/index.tsx` inside `MessageActionProvider`.

`animation-play-state: paused` (rather than `animation: none`) keeps the last computed frame, so toggling does not cause layout jumps — cleanest possible A/B comparison.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Open any conversation.
2. Trigger a streaming response (ideally one with tool calls / thinking / subtasks to maximize animation count).
3. Click the bottom-right toggle to flip animations on/off.
4. In Chrome DevTools → Performance, record with toggle ON vs OFF and compare main-thread / paint costs.

State persists across reloads via `localStorage`.

#### 📝 Additional Information

- Affects keyframe animations only — CSS `transition` (hover effects etc.) is unaffected, UI remains interactive.
- Intended for testers / perf investigation. If we confirm `shinyText` is the dominant cost, a follow-up PR can migrate it to a GPU-composable implementation (mask + `transform: translateX`) instead of relying on this toggle.