### PR TITLE
🐛 fix: preserve empty agent prompt export

### DIFF
--- a/src/routes/(main)/agent/profile/features/Header/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.test.tsx
@@ -72,6 +72,8 @@ const renderMenuItems = (items: MockDropdownItem[]) =>
       </div>
     ));
 
+const getLatestExportedBlob = () => vi.mocked(URL.createObjectURL).mock.calls.at(-1)?.[0] as Blob;
+
 vi.mock('@lobehub/ui', () => ({
   ActionIcon: () => <button aria-label="more" type="button" />,
   DropdownMenu: ({
@@ -260,7 +262,7 @@ describe('Agent profile Header', () => {
 
     await waitFor(() => expect(URL.createObjectURL).toHaveBeenCalled());
 
-    const exportedBlob = vi.mocked(URL.createObjectURL).mock.calls[0][0] as Blob;
+    const exportedBlob = getLatestExportedBlob();
     await expect(exportedBlob.text()).resolves.toContain('# Test Agent');
     await expect(exportedBlob.text()).resolves.toContain('You are helpful.');
     expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
@@ -278,7 +280,7 @@ describe('Agent profile Header', () => {
 
     await waitFor(() => expect(URL.createObjectURL).toHaveBeenCalled());
 
-    const exportedBlob = vi.mocked(URL.createObjectURL).mock.calls[0][0] as Blob;
+    const exportedBlob = getLatestExportedBlob();
     const exportedMarkdown = await exportedBlob.text();
 
     expect(exportedMarkdown).toContain('# Test Agent');

--- a/src/routes/(main)/agent/profile/features/Header/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.test.tsx
@@ -40,6 +40,9 @@ const mocks = vi.hoisted(() => ({
     publish: vi.fn(),
   },
   navigate: vi.fn(),
+  profileState: {
+    editor: undefined as { getDocument: (format: string) => string | undefined } | undefined,
+  },
   versionReviewStatus: {
     isUnderReview: false,
   },
@@ -192,8 +195,8 @@ vi.mock('@/store/home', () => ({
 }));
 
 vi.mock('../store', () => ({
-  useProfileStore: (selector: (state: { editor: undefined }) => unknown) =>
-    selector({ editor: undefined }),
+  useProfileStore: (selector: (state: typeof mocks.profileState) => unknown) =>
+    selector(mocks.profileState),
 }));
 
 vi.mock('./AgentForkTag', () => ({
@@ -232,6 +235,7 @@ describe('Agent profile Header', () => {
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
     mocks.agentState.canCurrentAgentPublishToCommunity = true;
     mocks.agentState.isCurrentAgentHeterogeneous = false;
+    mocks.profileState.editor = undefined;
   });
 
   it('should show the community publish action for normal agents', () => {
@@ -261,6 +265,25 @@ describe('Agent profile Header', () => {
     await expect(exportedBlob.text()).resolves.toContain('You are helpful.');
     expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:agent-profile');
+  });
+
+  it('should preserve an empty prompt from the mounted editor when exporting markdown', async () => {
+    mocks.profileState.editor = {
+      getDocument: vi.fn().mockReturnValue(''),
+    };
+
+    render(<Header />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'pageEditor.menu.export.markdown' }));
+
+    await waitFor(() => expect(URL.createObjectURL).toHaveBeenCalled());
+
+    const exportedBlob = vi.mocked(URL.createObjectURL).mock.calls[0][0] as Blob;
+    const exportedMarkdown = await exportedBlob.text();
+
+    expect(exportedMarkdown).toContain('# Test Agent');
+    expect(exportedMarkdown).not.toContain('You are helpful.');
+    expect(exportedMarkdown).not.toContain('settingAgent.prompt.title');
   });
 
   it('should hide the community publish action for heterogeneous and platform agents', () => {

--- a/src/routes/(main)/agent/profile/features/Header/index.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.tsx
@@ -199,13 +199,13 @@ const Header = memo(() => {
 
   const handleExportMarkdown = useCallback(async () => {
     try {
-      const editorMarkdown = editor?.getDocument('markdown') as string | undefined;
+      const editorMarkdown = editor?.getDocument('markdown') as string | null | undefined;
       const profileMarkdown = buildAgentProfileMarkdown({
         description: meta?.description,
         model: config.model,
         plugins: config.plugins,
         provider: config.provider,
-        systemRole: editorMarkdown || systemRole,
+        systemRole: editorMarkdown ?? systemRole,
         t,
         tags: meta?.tags,
         title: meta?.title,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up to lobehub-biz/lobehub-cloud#640 review feedback.

#### 🔀 Description of Change

- Preserve an empty prompt returned by the mounted agent prompt editor when exporting an agent profile as Markdown.
- Use a nullish fallback so only an absent editor document falls back to the saved agent store prompt.
- Add a regression test covering cleared prompt export.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/routes/(main)/agent/profile/features/Header/index.test.tsx'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Addresses a regression introduced with the agent profile Markdown export feature.