### PR TITLE
⬆️ chore: update @lobehub/ui to v5.15.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -285,7 +285,7 @@
     "@lobehub/icons": "^5.0.0",
     "@lobehub/market-sdk": "0.33.3",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.15.1",
+    "@lobehub/ui": "^5.15.5",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@napi-rs/canvas": "^0.1.88",
     "@neondatabase/serverless": "^1.0.2",

--- a/src/routes/(main)/community/(detail)/user/features/UserAgentList.tsx
+++ b/src/routes/(main)/community/(detail)/user/features/UserAgentList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Flexbox, Grid, Tag, Text } from '@lobehub/ui';
-import { Input, Pagination } from 'antd';
+import { Flexbox, Grid, SearchBar, Tag, Text } from '@lobehub/ui';
+import { Pagination } from 'antd';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -89,10 +89,10 @@ const UserAgentList = memo<UserAgentListProps>(({ rows = 4, pageSize = 8 }) => {
         </Flexbox>
         {isOwner && (
           <Flexbox horizontal align={'center'} gap={8}>
-            <Input.Search
+            <SearchBar
               allowClear
               placeholder={t('user.searchPlaceholder')}
-              style={{ width: 200 }}
+              styles={{ input: { height: 31, width: 320 } }}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />

--- a/src/routes/(main)/community/(detail)/user/features/UserGroupList.tsx
+++ b/src/routes/(main)/community/(detail)/user/features/UserGroupList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { Flexbox, Grid, Tag, Text } from '@lobehub/ui';
-import { Input, Pagination } from 'antd';
+import { Flexbox, Grid, SearchBar, Tag, Text } from '@lobehub/ui';
+import { Pagination } from 'antd';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -82,10 +82,10 @@ const UserGroupList = memo<UserGroupListProps>(({ rows = 4, pageSize = 8 }) => {
         </Flexbox>
         {isOwner && (
           <Flexbox horizontal align={'center'} gap={8}>
-            <Input.Search
+            <SearchBar
               allowClear
               placeholder={t('user.searchPlaceholder')}
-              style={{ width: 200 }}
+              styles={{ input: { height: 31, width: 320 } }}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore
- [x] 💄 style

#### 🔀 Description of Change

- Bump `@lobehub/ui` from the `pkg.pr.new/@lobehub/ui@544` preview build to the released **v5.15.5**.
- Replace the antd `Input.Search` in the community user lists (`UserAgentList`, `UserGroupList`) with `@lobehub/ui` `SearchBar`. The previous `Input.Search` button addon overflowed and could not be height-matched to the adjacent status `Select`. `SearchBar` uses a prefix icon, and its width/height are set via `styles.input` (avoiding the wrapper `max-width: 100%` circular sizing) so the field is 320×31 and aligns with the status select.

#### 🧪 How to Test

- [x] Tested locally

Open a community user profile as the owner and check the "published agents" / "published groups" toolbars — the search field and the status select should be the same height and the search box should be wider.

#### 📝 Additional Information

Lockfiles (`bun.lock` / `pnpm-lock.yaml`) are gitignored in this repo, so only `package.json` and the two component files change.