### PR TITLE
🐛 fix(desktop): upload .blockmap files to S3 for differential updates

### DIFF
--- a/.github/actions/desktop-publish-s3/action.yml
+++ b/.github/actions/desktop-publish-s3/action.yml
@@ -75,7 +75,7 @@ runs:
 
         # 1. 上传安装包到版本目录
         echo "📦 Uploading release files to s3://$S3_BUCKET/$CHANNEL/$VERSION/"
-        for file in release/*.dmg release/*.zip release/*.exe release/*.AppImage release/*.deb release/*.rpm release/*.snap release/*.tar.gz; do
+        for file in release/*.dmg release/*.zip release/*.exe release/*.AppImage release/*.deb release/*.rpm release/*.snap release/*.tar.gz release/*.blockmap; do
           if [ -f "$file" ]; then
             filename=$(basename "$file")
             echo "   ↗️ $filename"


### PR DESCRIPTION
## Summary

- The S3 publish action (`desktop-publish-s3`) was missing `*.blockmap` from its upload glob, so `.blockmap` files were never uploaded to the CDN
- This caused `electron-updater` to **always** fall back to full downloads on every update, since fetching the new blockmap returned HTTP 404

**Evidence from production logs** (`~/Library/Logs/LobeHub/main.log`):
```
[error] Cannot download differentially, fallback to full download:
  Error: Cannot download "https://cdn-desktop-releases.lobehub.com/canary/2.2.1-canary.66/LobeHub-2.2.1-canary.66-arm64-mac.zip.blockmap", status 404
```

**CDN verification:**
- `.zip` → 206 (exists)
- `.zip.blockmap` → 404 (missing)

## Fix

Add `release/*.blockmap` to the upload glob in `.github/actions/desktop-publish-s3/action.yml`.

## Test plan

- [ ] After next canary release, verify `.blockmap` files are present on CDN (`curl -I https://cdn-desktop-releases.lobehub.com/canary/<version>/<name>.blockmap`)
- [ ] Check `main.log` for `Download block maps` succeeding instead of 404 fallback
- [ ] Confirm differential download size is smaller than full package size