### PR TITLE
🐛 fix: respect vision base64 in client request mode

### DIFF
--- a/packages/types/src/serverConfig.ts
+++ b/packages/types/src/serverConfig.ts
@@ -80,6 +80,8 @@ export interface GlobalServerConfig {
   telemetry: {
     langfuse?: boolean;
   };
+  useVisionImageBase64?: boolean;
+  useVisionVideoBase64?: boolean;
   visualUnderstanding?: VisualUnderstandingConfig;
 }
 

--- a/src/server/globalConfig/index.ts
+++ b/src/server/globalConfig/index.ts
@@ -126,6 +126,8 @@ export const getServerGlobalConfig = async () => {
     telemetry: {
       langfuse: langfuseEnv.ENABLE_LANGFUSE,
     },
+    useVisionImageBase64: process.env.LLM_VISION_IMAGE_USE_BASE64 === '1',
+    useVisionVideoBase64: process.env.LLM_VISION_VIDEO_USE_BASE64 === '1',
   };
 
   return config;

--- a/src/services/chat/chat.test.ts
+++ b/src/services/chat/chat.test.ts
@@ -14,6 +14,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useChatStore } from '@/store/chat';
+import { createServerConfigStore } from '@/store/serverConfig/store';
 import { useToolStore } from '@/store/tool';
 import { settingsSelectors } from '@/store/user/selectors';
 
@@ -147,6 +148,14 @@ beforeEach(async () => {
   useAgentStore.setState({ activeAgentId: undefined, agentDocumentsMap: {} } as any);
   useAiInfraStore.setState({ enabledAiModels: [] });
   useChatStore.setState({ activeAgentId: undefined } as any);
+  createServerConfigStore().setState({
+    serverConfig: {
+      aiProvider: {},
+      telemetry: {},
+      useVisionImageBase64: false,
+      useVisionVideoBase64: false,
+    },
+  });
 });
 
 // mock auth
@@ -1778,6 +1787,55 @@ describe('ChatService', () => {
           deploymentName: 'prod-gpt-54',
           messages: [],
           model: 'gpt-5.4',
+        }),
+      );
+    });
+
+    it('should force server request when vision base64 is enabled for remote image URLs', async () => {
+      useAiInfraStore.setState({
+        aiProviderRuntimeConfig: {
+          openai: {
+            fetchOnClient: true,
+            keyVaults: {
+              apiKey: 'sk-test',
+              baseURL: 'https://api.example.com/v1',
+            },
+            settings: {},
+          },
+        },
+      } as any);
+      createServerConfigStore().setState({
+        serverConfig: {
+          aiProvider: {},
+          telemetry: {},
+          useVisionImageBase64: true,
+        },
+      });
+
+      await chatService.getChatCompletion({
+        messages: [
+          {
+            content: [
+              { text: 'describe this image', type: 'text' },
+              {
+                image_url: { url: 'https://s3.example.com/files/image.png' },
+                type: 'image_url',
+              },
+            ],
+            role: 'user',
+          },
+        ],
+        model: 'gpt-4o',
+        provider: 'openai',
+      });
+
+      expect(mockFetchSSE).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          fetcher: undefined,
+          requestContext: expect.objectContaining({
+            fetchOnClient: false,
+          }),
         }),
       );
     });

--- a/src/services/chat/helper.ts
+++ b/src/services/chat/helper.ts
@@ -2,6 +2,12 @@ import { ModelProvider } from 'model-bank';
 
 import { getAiInfraStoreState } from '@/store/aiInfra';
 import { aiProviderSelectors } from '@/store/aiInfra/selectors';
+import { getServerConfigStoreState, serverConfigSelectors } from '@/store/serverConfig';
+import type {
+  ChatStreamPayload,
+  OpenAIChatMessage,
+  UserMessageContentPart,
+} from '@/types/openai/chat';
 
 const getModelAbilities = (model: string, provider: string) => {
   const state = getAiInfraStoreState();
@@ -42,6 +48,50 @@ export const findDeploymentName = (model: string, provider: string) => {
 
 export const isEnableFetchOnClient = (provider: string) => {
   return aiProviderSelectors.isProviderFetchOnClient(provider)(getAiInfraStoreState());
+};
+
+const getImageUrl = (part: UserMessageContentPart) => {
+  if (part.type !== 'image_url') return undefined;
+
+  return part.image_url.url;
+};
+
+const getVideoUrl = (part: UserMessageContentPart) => {
+  if (part.type !== 'video_url') return undefined;
+
+  return part.video_url?.url;
+};
+
+const isRemoteUrl = (url: string | undefined) => !!url && !url.startsWith('data:');
+
+const hasRemoteVisionMedia = (
+  messages: OpenAIChatMessage[] | undefined,
+  options: { image?: boolean; video?: boolean },
+) =>
+  messages?.some((message) => {
+    if (!Array.isArray(message.content)) return false;
+
+    return message.content.some((part) => {
+      if (options.image && isRemoteUrl(getImageUrl(part))) return true;
+      if (options.video && isRemoteUrl(getVideoUrl(part))) return true;
+
+      return false;
+    });
+  }) || false;
+
+export const shouldUseServerSideVisionBase64 = (payload: Partial<ChatStreamPayload>) => {
+  const serverConfig = getServerConfigStoreState();
+  if (!serverConfig) return false;
+
+  const useImageBase64 = serverConfigSelectors.useVisionImageBase64(serverConfig);
+  const useVideoBase64 = serverConfigSelectors.useVisionVideoBase64(serverConfig);
+
+  if (!useImageBase64 && !useVideoBase64) return false;
+
+  return hasRemoteVisionMedia(payload.messages, {
+    image: useImageBase64,
+    video: useVideoBase64,
+  });
 };
 
 export const resolveRuntimeProvider = (provider: string) => {

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -49,7 +49,12 @@ import { createTraceHeader } from '@/utils/trace';
 
 import { createHeaderWithAuth } from '../_auth';
 import { API_ENDPOINTS } from '../_url';
-import { findDeploymentName, isEnableFetchOnClient, resolveRuntimeProvider } from './helper';
+import {
+  findDeploymentName,
+  isEnableFetchOnClient,
+  resolveRuntimeProvider,
+  shouldUseServerSideVisionBase64,
+} from './helper';
 import { type ResolvedAgentConfig } from './mecha';
 import {
   contextEngineering,
@@ -59,7 +64,6 @@ import {
 } from './mecha';
 import { type FetchOptions } from './types';
 
-const defaultProvider = ModelProvider.OpenAI;
 const providersWithDeploymentName = new Set<string>([
   ModelProvider.Azure,
   ModelProvider.AzureAI,
@@ -418,7 +422,8 @@ class ChatService {
     /**
      * Use browser agent runtime
      */
-    const enableFetchOnClient = isEnableFetchOnClient(provider);
+    const enableFetchOnClient =
+      isEnableFetchOnClient(provider) && !shouldUseServerSideVisionBase64(payload);
 
     let fetcher: typeof fetch | undefined = undefined;
 

--- a/src/store/serverConfig/selectors.ts
+++ b/src/store/serverConfig/selectors.ts
@@ -18,5 +18,7 @@ export const serverConfigSelectors = {
   enabledTelemetryChat: (s: ServerConfigStore) => s.serverConfig.telemetry.langfuse || false,
   isMobile: (s: ServerConfigStore) => s.isMobile || false,
   oAuthSSOProviders: (s: ServerConfigStore) => s.serverConfig.oAuthSSOProviders,
+  useVisionImageBase64: (s: ServerConfigStore) => s.serverConfig.useVisionImageBase64 || false,
+  useVisionVideoBase64: (s: ServerConfigStore) => s.serverConfig.useVisionVideoBase64 || false,
   visualUnderstanding: (s: ServerConfigStore) => s.serverConfig.visualUnderstanding,
 };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #15155

#### 🔀 Description of Change

When `LLM_VISION_IMAGE_USE_BASE64=1` or `LLM_VISION_VIDEO_USE_BASE64=1` is enabled, requests that include remote vision media must go through the server runtime so the existing URL-to-base64 conversion can run.

This PR exposes the server-side vision base64 flags through server config and disables client request mode only for requests that contain remote image/video URLs requiring base64 conversion.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run --silent='passed-only' 'src/services/chat/chat.test.ts'
bunx vitest run --silent='passed-only' 'src/store/serverConfig/selectors.test.ts'
bunx eslint packages/types/src/serverConfig.ts src/server/globalConfig/index.ts src/store/serverConfig/selectors.ts src/services/chat/helper.ts src/services/chat/index.ts src/services/chat/chat.test.ts
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This preserves normal client request mode for text-only requests and for already-inline `data:` media URLs.
