### PR TITLE
fix(comfyui): support INTERNAL_APP_URL in LobeComfyUI.createImage() for reverse-proxy deployments

### DIFF
--- a/packages/model-runtime/src/providers/comfyui/index.ts
+++ b/packages/model-runtime/src/providers/comfyui/index.ts
@@ -76,6 +76,7 @@ export class LobeComfyUI implements LobeRuntimeAI, AuthenticatedImageRuntime {
       const isInVercel = process.env.VERCEL === '1';
       const vercelUrl = `https://${process.env.VERCEL_URL}`;
       const appUrl =
+        process.env.INTERNAL_APP_URL ||
         process.env.APP_URL ||
         (isInVercel ? vercelUrl : `http://localhost:${process.env.PORT || 3010}`);
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes #15328

#### 🔀 Description of Change

`LobeComfyUI.createImage()` currently uses `process.env.APP_URL` to construct the internal loopback URL for `POST /webapi/create-image/comfyui`. When LobeHub is deployed behind a reverse-proxy that protects all routes (e.g. Traefik + oauth2-proxy), the request is intercepted by the proxy before reaching Next.js — the `Authorization: Bearer ${KEY_VAULTS_SECRET}` bypass check in the route handler never runs, and the request fails with an HTML redirect response wrapped as `InvalidProviderAPIKey`.

**One-line fix** in `packages/model-runtime/src/providers/comfyui/index.ts`:

```diff
 const appUrl =
+  process.env.INTERNAL_APP_URL ||
   process.env.APP_URL ||
   (isInVercel ? vercelUrl : `http://localhost:${process.env.PORT || 3010}`);
```

`INTERNAL_APP_URL` is already defined in `src/envs/app.ts` with the explicit comment _"INTERNAL_APP_URL is used for server-to-server calls to bypass CDN/proxy"_ and is already used in 3 other call sites:
- `src/server/routers/async/caller.ts`
- `src/server/workflows/agentSignal/index.ts`
- `src/server/workflows-hono/memory-user-memory/workflows/hourly.ts`

Deployments without `INTERNAL_APP_URL` set are completely unaffected (falls through to `APP_URL` as before).

#### 🧪 How to Test

Set `INTERNAL_APP_URL=http://localhost:3210` and `APP_URL=https://your-public-domain.com` in a deployment behind an oauth2-proxy. ComfyUI image generation should succeed; previously it would fail with `InvalidProviderAPIKey` containing an HTML redirect body.

- [ ] Tested locally
- [x] No tests needed (env-var fallback chain, no logic change for existing deployments)