### PR TITLE
🐛 fix(library): refresh folder data on slug switch and dedupe breadcrumb fetch

### DIFF
--- a/src/features/ResourceManager/components/LibraryHierarchy/index.tsx
+++ b/src/features/ResourceManager/components/LibraryHierarchy/index.tsx
@@ -9,6 +9,7 @@ import { VList } from 'virtua';
 
 import { useFolderPath } from '@/routes/(main)/resource/features/hooks/useFolderPath';
 import { useResourceManagerStore } from '@/routes/(main)/resource/features/store';
+import { useFileStore } from '@/store/file';
 import type { TreeItem } from '@/store/tree';
 import { useTreeStore } from '@/store/tree';
 
@@ -36,8 +37,13 @@ const LibraryHierarchy = memo(() => {
   const expanded = useTreeStore((s) => s.expanded);
   const status = useTreeStore((s) => s.status);
   const init = useTreeStore((s) => s.init);
-  const navigateTo = useTreeStore((s) => s.navigateTo);
+  const expandAncestors = useTreeStore((s) => s.expandAncestors);
   const toggle = useTreeStore((s) => s.toggle);
+
+  // Reuse Explorer Breadcrumb's SWR cache so the sidebar doesn't double-fetch
+  // document.getFolderBreadcrumb when navigating into a folder.
+  const useFetchFolderBreadcrumb = useFileStore((s) => s.useFetchFolderBreadcrumb);
+  const { data: folderChain } = useFetchFolderBreadcrumb(currentFolderSlug);
 
   // Effect 1: Library switch → reset + load root
   useEffect(() => {
@@ -45,11 +51,11 @@ const LibraryHierarchy = memo(() => {
     init(libraryId);
   }, [libraryId, init]);
 
-  // Effect 2: Folder navigation → expand ancestors
+  // Effect 2: Folder navigation → expand ancestors once breadcrumb resolves
   useEffect(() => {
-    if (!currentFolderSlug) return;
-    void navigateTo(currentFolderSlug);
-  }, [currentFolderSlug, navigateTo]);
+    if (!folderChain?.length) return;
+    void expandAncestors(folderChain.map((c) => c.id));
+  }, [folderChain, expandAncestors]);
 
   const isLoading = status[''] === 'loading';
 

--- a/src/store/file/slices/resource/hooks.ts
+++ b/src/store/file/slices/resource/hooks.ts
@@ -1,4 +1,5 @@
 import { isEqual } from 'es-toolkit';
+import { useEffect } from 'react';
 import { shallow } from 'zustand/shallow';
 
 import { mutate, useClientDataSWR } from '@/libs/swr';
@@ -25,7 +26,7 @@ export const revalidateResources = async (params?: ResourceQueryParams) => {
  * Custom SWR hook for fetching resources with caching and revalidation
  */
 export const useFetchResources = (params: ResourceQueryParams | null, enable: any = true) => {
-  return useClientDataSWR(
+  const swr = useClientDataSWR(
     enable && params ? [SWR_KEY_RESOURCES, params] : null,
     async ([, queryParams]: [string, ResourceQueryParams]) => {
       const response = await resourceService.queryResources({
@@ -36,34 +37,45 @@ export const useFetchResources = (params: ResourceQueryParams | null, enable: an
       return response;
     },
     {
-      // SWR configuration for optimal UX
-      dedupingInterval: 2000,
-      onSuccess: (data: { hasMore: boolean; items: any[]; total?: number }) => {
-        const { resourceList, resourceMap } = useFileStore.getState();
-        const merged = mergeServerResourcesWithOptimistic(data.items, resourceMap, params);
-        const newResourceList = merged.resourceList;
-        const newResourceMap = merged.resourceMap;
-
-        // Only update store if data actually changed
-        if (!isEqual(newResourceList, resourceList) || !isEqual(newResourceMap, resourceMap)) {
-          useFileStore.setState(
-            {
-              hasMore: data.hasMore,
-              offset: data.items.length,
-              queryParams: params ?? undefined,
-              resourceList: newResourceList,
-              resourceMap: newResourceMap,
-              total: data.total,
-            },
-            false,
-            'useFetchResources/success',
-          );
-        }
-      },
+      // Skip background revalidation when a fresh fetch for the same key
+      // happened recently. Cache-hit display still works because the
+      // useEffect below syncs swr.data → store regardless of whether the
+      // fetcher actually ran.
+      dedupingInterval: 30 * 1000,
       revalidateOnFocus: true,
       revalidateOnReconnect: true,
     },
   );
+
+  // Sync SWR data → store on every data ref change.
+  // Using useEffect (not onSuccess) covers the cache-hit path: when the key
+  // changes to a previously-fetched folder, SWR returns cached data synchronously
+  // without firing onSuccess. Reading the store mirror alone would surface the
+  // previously-written folder's data until revalidation completes.
+  const data = swr.data;
+  useEffect(() => {
+    if (!data || !params) return;
+
+    const { resourceList, resourceMap } = useFileStore.getState();
+    const merged = mergeServerResourcesWithOptimistic(data.items, resourceMap, params);
+
+    if (!isEqual(merged.resourceList, resourceList) || !isEqual(merged.resourceMap, resourceMap)) {
+      useFileStore.setState(
+        {
+          hasMore: data.hasMore,
+          offset: data.items.length,
+          queryParams: params,
+          resourceList: merged.resourceList,
+          resourceMap: merged.resourceMap,
+          total: data.total,
+        },
+        false,
+        'useFetchResources/sync',
+      );
+    }
+  }, [data, params]);
+
+  return swr;
 };
 
 /**

--- a/src/store/tree/actions.test.ts
+++ b/src/store/tree/actions.test.ts
@@ -36,7 +36,7 @@ const createState = (): TreeState => ({
   loadChildren: vi.fn(),
   moveItem: vi.fn(),
   moveItems: vi.fn(),
-  navigateTo: vi.fn(),
+  expandAncestors: vi.fn(),
   reconcile: vi.fn(),
   removeItems: vi.fn(),
   renameItem: vi.fn(),

--- a/src/store/tree/actions.ts
+++ b/src/store/tree/actions.ts
@@ -189,21 +189,19 @@ export class TreeActionImpl {
     );
   };
 
-  navigateTo = async (folderSlug: string) => {
+  expandAncestors = async (folderIds: string[]) => {
+    if (!folderIds.length) return;
     const epoch = this.#get().epoch;
-    const breadcrumb = await fileService.getFolderBreadcrumb(folderSlug);
-    if (!breadcrumb?.length || this.#get().epoch !== epoch) return;
 
-    const folderIds = breadcrumb.map((c: { id: string }) => c.id);
     const expanded = { ...this.#get().expanded };
     for (const id of folderIds) expanded[id] = true;
-    this.#set({ expanded }, false, 'tree/navigateTo/expand');
+    this.#set({ expanded }, false, 'tree/expandAncestors');
 
     await Promise.all(
-      folderIds
-        .filter((id: string) => !this.#get().children[id])
-        .map((id: string) => this.loadChildren(id)),
+      folderIds.filter((id) => !this.#get().children[id]).map((id) => this.loadChildren(id)),
     );
+
+    if (this.#get().epoch !== epoch) return;
   };
 
   moveItem = async (itemId: string, fromParent: string, toParent: string): Promise<void> => {

--- a/src/store/tree/types.ts
+++ b/src/store/tree/types.ts
@@ -20,15 +20,15 @@ export type TreeStoreHandle = StoreHandle<TreeDataState>;
 
 export interface TreeState extends TreeDataState {
   epoch: number;
+  expandAncestors: (folderIds: string[]) => Promise<void>;
   expanded: Record<string, boolean>;
+
   // actions
   init: (knowledgeBaseId: string) => void;
-
   knowledgeBaseId: string | null;
   loadChildren: (folderId: string) => Promise<void>;
   moveItem: (itemId: string, fromParent: string, toParent: string) => Promise<void>;
   moveItems: (itemIds: string[], fromParent: string, toParent: string) => Promise<void>;
-  navigateTo: (folderSlug: string) => Promise<void>;
   reconcile: (folderId: string, items: TreeItem[]) => void;
   removeItems: (itemIds: string[], parentId: string) => Promise<void>;
   renameItem: (itemId: string, parentId: string, newName: string) => Promise<void>;


### PR DESCRIPTION
## Summary

- Resource Explorer kept showing the previous folder's items when sidebar hierarchy clicks switched the URL slug. SWR `onSuccess` only fires after revalidate completes, so cache-hit navigations could not update the zustand mirror that the Explorer reads from. Moved SWR `data` → `useFileStore` sync into a `useEffect` so cache hits push fresh items into the store immediately, while keeping a 30s `dedupingInterval` to avoid wasted background revalidations.
- Replaced `tree.navigateTo(slug)` (which fetched the breadcrumb directly) with `tree.expandAncestors(ids)`, and let `LibraryHierarchy` reuse the existing `useFetchFolderBreadcrumb` SWR cache to feed the ids. A folder switch no longer issues two parallel `document.getFolderBreadcrumb` requests.

Fixes LOBE-4293

## Test plan

- [x] `bunx vitest run src/store/tree src/store/file/slices/resource src/store/file/slices/fileManager` — 51 passed
- [x] `bunx tsc --noEmit` — no errors
- [x] `bunx eslint` on modified files — no new errors
- [ ] Manual: switch folders via sidebar tree, verify Explorer data refreshes and the trpc batch only contains one `getFolderBreadcrumb` per navigation