### PR TITLE
chore: remove LOBE-XXX auto-link pattern from WelcomeText

### DIFF
--- a/src/routes/(main)/home/features/WelcomeText/index.tsx
+++ b/src/routes/(main)/home/features/WelcomeText/index.tsx
@@ -61,10 +61,6 @@ interface AutoLinkPattern {
 // becomes clickable.
 const AUTO_LINK_PATTERNS: AutoLinkPattern[] = [
   {
-    build: (match) => `https://linear.app/lobehub/issue/${match}`,
-    regex: /LOBE-\d+/g,
-  },
-  {
     build: (match) => `https://github.com/lobehub/lobehub/issues/${match.slice(1)}`,
     regex: /#\d+/g,
   },


### PR DESCRIPTION
## Summary

Removes the `LOBE-\d+` regex from `AUTO_LINK_PATTERNS` in the WelcomeText component.

## Context

- The `/LOBE-\d+/g` regex auto-linked bare LOBE issue references (e.g., LOBE-123) in the daily brief welcome text to Linear issues.
- Since LobeHub is an open-source project, LOBE internal references should not appear in public code.
- Only the GitHub issue auto-link pattern (`#\d+`) is retained.

## Changes

| File | Change |
|------|--------|
| `src/routes/(main)/home/features/WelcomeText/index.tsx` | Removed `LOBE-\d+` entry from `AUTO_LINK_PATTERNS` |