### PR TITLE
feat(cli): add `lh topic view` command

### DIFF
--- a/apps/cli/src/commands/topic.test.ts
+++ b/apps/cli/src/commands/topic.test.ts
@@ -12,6 +12,7 @@ const { mockTrpcClient } = vi.hoisted(() => ({
     topic: {
       batchDelete: { mutate: vi.fn() },
       createTopic: { mutate: vi.fn() },
+      getTopicContext: { query: vi.fn() },
       getTopics: { query: vi.fn() },
       recentTopics: { query: vi.fn() },
       removeTopic: { mutate: vi.fn() },
@@ -49,6 +50,11 @@ describe('topic command', () => {
         (fn as ReturnType<typeof vi.fn>).mockReset();
       }
     }
+    // Default stub for getTopicContext
+    mockTrpcClient.topic.getTopicContext.query.mockResolvedValue({
+      content: '# Topic: Test Topic\n\n## Recent Messages\n',
+      success: true,
+    });
   });
 
   afterEach(() => {
@@ -214,9 +220,6 @@ describe('topic command', () => {
 
   describe('view', () => {
     it('should display topic metadata and messages', async () => {
-      mockTrpcClient.topic.getTopics.query.mockResolvedValue([
-        { id: 't1', favorite: true, title: 'My Topic', updatedAt: new Date().toISOString() },
-      ]);
       mockTrpcClient.message.getMessages.query.mockResolvedValue([
         { content: 'Hello world', id: 'm1', role: 'user' },
         { content: 'Hi there', id: 'm2', role: 'assistant' },
@@ -225,18 +228,26 @@ describe('topic command', () => {
       const program = createProgram();
       await program.parseAsync(['node', 'test', 'topic', 'view', 't1']);
 
-      expect(mockTrpcClient.topic.getTopics.query).toHaveBeenCalled();
+      expect(mockTrpcClient.topic.getTopicContext.query).toHaveBeenCalledWith(
+        expect.objectContaining({ topicId: 't1' }),
+      );
       expect(mockTrpcClient.message.getMessages.query).toHaveBeenCalledWith(
         expect.objectContaining({ topicId: 't1' }),
       );
-      // Should print header + messages
       expect(consoleSpy).toHaveBeenCalled();
     });
 
+    it('should skip message query entirely when --no-messages flag is set', async () => {
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', 'topic', 'view', 't1', '--no-messages']);
+
+      // getTopicContext is still called (for metadata)
+      expect(mockTrpcClient.topic.getTopicContext.query).toHaveBeenCalled();
+      // but getMessages must NOT be called
+      expect(mockTrpcClient.message.getMessages.query).not.toHaveBeenCalled();
+    });
+
     it('should output json when --json flag is set', async () => {
-      mockTrpcClient.topic.getTopics.query.mockResolvedValue([
-        { id: 't1', title: 'My Topic' },
-      ]);
       mockTrpcClient.message.getMessages.query.mockResolvedValue([
         { content: 'Hello', id: 'm1', role: 'user' },
       ]);
@@ -248,22 +259,22 @@ describe('topic command', () => {
       const parsed = JSON.parse(calls);
       expect(parsed.topic.id).toBe('t1');
       expect(parsed.messages).toHaveLength(1);
+      expect(parsed.messages[0]).toHaveProperty('role', 'user');
+      expect(parsed.messages[0]).toHaveProperty('content', 'Hello');
     });
 
-    it('should skip messages when --no-messages flag is set', async () => {
-      mockTrpcClient.topic.getTopics.query.mockResolvedValue([
-        { id: 't1', title: 'My Topic', updatedAt: new Date().toISOString() },
-      ]);
-      mockTrpcClient.message.getMessages.query.mockResolvedValue([]);
-
+    it('should output json with empty messages for --no-messages --json', async () => {
       const program = createProgram();
-      await program.parseAsync(['node', 'test', 'topic', 'view', 't1', '--no-messages']);
+      await program.parseAsync(['node', 'test', 'topic', 'view', 't1', '--no-messages', '--json']);
 
       expect(mockTrpcClient.message.getMessages.query).not.toHaveBeenCalled();
+      const calls = consoleSpy.mock.calls.flat().join('');
+      const parsed = JSON.parse(calls);
+      expect(parsed.topic.id).toBe('t1');
+      expect(parsed.messages).toHaveLength(0);
     });
 
-    it('should respect --limit for messages', async () => {
-      mockTrpcClient.topic.getTopics.query.mockResolvedValue([]);
+    it('should respect -L for message page size', async () => {
       mockTrpcClient.message.getMessages.query.mockResolvedValue([]);
 
       const program = createProgram();
@@ -272,6 +283,64 @@ describe('topic command', () => {
       expect(mockTrpcClient.message.getMessages.query).toHaveBeenCalledWith(
         expect.objectContaining({ pageSize: 10, topicId: 't1' }),
       );
+    });
+
+    it('should slice messages with --from and --to', async () => {
+      mockTrpcClient.message.getMessages.query.mockResolvedValue([
+        { content: 'msg1', id: 'm1', role: 'user' },
+        { content: 'msg2', id: 'm2', role: 'assistant' },
+        { content: 'msg3', id: 'm3', role: 'user' },
+      ]);
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', 'topic', 'view', 't1', '--from', '2', '--to', '3']);
+
+      // Should print only m2 and m3 (index 1 and 2)
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('msg2');
+      expect(output).toContain('msg3');
+      expect(output).not.toContain('msg1');
+    });
+
+    it('should render tool calls inline', async () => {
+      mockTrpcClient.message.getMessages.query.mockResolvedValue([
+        {
+          content: "I'll search for that.",
+          id: 'm1',
+          role: 'assistant',
+          tools: [
+            {
+              function: { arguments: '{"query":"lobehub"}', name: 'web_search' },
+              id: 'call_1',
+              type: 'function',
+            },
+          ],
+        },
+        { content: 'search results...', id: 'm2', role: 'tool' },
+      ]);
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', 'topic', 'view', 't1']);
+
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('web_search');
+      expect(output).toContain('lobehub');
+    });
+
+    it('should render threaded messages with indentation', async () => {
+      mockTrpcClient.message.getMessages.query.mockResolvedValue([
+        { content: 'Parent message', id: 'm1', parentId: null, role: 'user' },
+        { content: 'Thread reply', id: 'm2', parentId: 'm1', role: 'assistant' },
+      ]);
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', 'topic', 'view', 't1']);
+
+      const output = consoleSpy.mock.calls.flat().join('\n');
+      expect(output).toContain('Parent message');
+      expect(output).toContain('Thread reply');
+      // thread reply should appear after parent (basic ordering check)
+      expect(output.indexOf('Thread reply')).toBeGreaterThan(output.indexOf('Parent message'));
     });
   });
 });

--- a/apps/cli/src/commands/topic.test.ts
+++ b/apps/cli/src/commands/topic.test.ts
@@ -6,6 +6,9 @@ import { registerTopicCommand } from './topic';
 
 const { mockTrpcClient } = vi.hoisted(() => ({
   mockTrpcClient: {
+    message: {
+      getMessages: { query: vi.fn() },
+    },
     topic: {
       batchDelete: { mutate: vi.fn() },
       createTopic: { mutate: vi.fn() },
@@ -37,6 +40,11 @@ describe('topic command', () => {
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     mockGetTrpcClient.mockResolvedValue(mockTrpcClient);
     for (const method of Object.values(mockTrpcClient.topic)) {
+      for (const fn of Object.values(method)) {
+        (fn as ReturnType<typeof vi.fn>).mockReset();
+      }
+    }
+    for (const method of Object.values(mockTrpcClient.message)) {
       for (const fn of Object.values(method)) {
         (fn as ReturnType<typeof vi.fn>).mockReset();
       }
@@ -201,6 +209,69 @@ describe('topic command', () => {
       await program.parseAsync(['node', 'test', 'topic', 'recent']);
 
       expect(mockTrpcClient.topic.recentTopics.query).toHaveBeenCalledWith({ limit: 10 });
+    });
+  });
+
+  describe('view', () => {
+    it('should display topic metadata and messages', async () => {
+      mockTrpcClient.topic.getTopics.query.mockResolvedValue([
+        { id: 't1', favorite: true, title: 'My Topic', updatedAt: new Date().toISOString() },
+      ]);
+      mockTrpcClient.message.getMessages.query.mockResolvedValue([
+        { content: 'Hello world', id: 'm1', role: 'user' },
+        { content: 'Hi there', id: 'm2', role: 'assistant' },
+      ]);
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', 'topic', 'view', 't1']);
+
+      expect(mockTrpcClient.topic.getTopics.query).toHaveBeenCalled();
+      expect(mockTrpcClient.message.getMessages.query).toHaveBeenCalledWith(
+        expect.objectContaining({ topicId: 't1' }),
+      );
+      // Should print header + messages
+      expect(consoleSpy).toHaveBeenCalled();
+    });
+
+    it('should output json when --json flag is set', async () => {
+      mockTrpcClient.topic.getTopics.query.mockResolvedValue([
+        { id: 't1', title: 'My Topic' },
+      ]);
+      mockTrpcClient.message.getMessages.query.mockResolvedValue([
+        { content: 'Hello', id: 'm1', role: 'user' },
+      ]);
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', 'topic', 'view', 't1', '--json']);
+
+      const calls = consoleSpy.mock.calls.flat().join('');
+      const parsed = JSON.parse(calls);
+      expect(parsed.topic.id).toBe('t1');
+      expect(parsed.messages).toHaveLength(1);
+    });
+
+    it('should skip messages when --no-messages flag is set', async () => {
+      mockTrpcClient.topic.getTopics.query.mockResolvedValue([
+        { id: 't1', title: 'My Topic', updatedAt: new Date().toISOString() },
+      ]);
+      mockTrpcClient.message.getMessages.query.mockResolvedValue([]);
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', 'topic', 'view', 't1', '--no-messages']);
+
+      expect(mockTrpcClient.message.getMessages.query).not.toHaveBeenCalled();
+    });
+
+    it('should respect --limit for messages', async () => {
+      mockTrpcClient.topic.getTopics.query.mockResolvedValue([]);
+      mockTrpcClient.message.getMessages.query.mockResolvedValue([]);
+
+      const program = createProgram();
+      await program.parseAsync(['node', 'test', 'topic', 'view', 't1', '-L', '10']);
+
+      expect(mockTrpcClient.message.getMessages.query).toHaveBeenCalledWith(
+        expect.objectContaining({ pageSize: 10, topicId: 't1' }),
+      );
     });
   });
 });

--- a/apps/cli/src/commands/topic.test.ts
+++ b/apps/cli/src/commands/topic.test.ts
@@ -12,7 +12,7 @@ const { mockTrpcClient } = vi.hoisted(() => ({
     topic: {
       batchDelete: { mutate: vi.fn() },
       createTopic: { mutate: vi.fn() },
-      getTopicContext: { query: vi.fn() },
+      getTopicDetail: { query: vi.fn() },
       getTopics: { query: vi.fn() },
       recentTopics: { query: vi.fn() },
       removeTopic: { mutate: vi.fn() },
@@ -50,10 +50,12 @@ describe('topic command', () => {
         (fn as ReturnType<typeof vi.fn>).mockReset();
       }
     }
-    // Default stub for getTopicContext
-    mockTrpcClient.topic.getTopicContext.query.mockResolvedValue({
-      content: '# Topic: Test Topic\n\n## Recent Messages\n',
-      success: true,
+    // Default stub for getTopicDetail
+    mockTrpcClient.topic.getTopicDetail.query.mockResolvedValue({
+      favorite: false,
+      id: 't1',
+      title: 'Test Topic',
+      updatedAt: new Date().toISOString(),
     });
   });
 
@@ -228,8 +230,8 @@ describe('topic command', () => {
       const program = createProgram();
       await program.parseAsync(['node', 'test', 'topic', 'view', 't1']);
 
-      expect(mockTrpcClient.topic.getTopicContext.query).toHaveBeenCalledWith(
-        expect.objectContaining({ topicId: 't1' }),
+      expect(mockTrpcClient.topic.getTopicDetail.query).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 't1' }),
       );
       expect(mockTrpcClient.message.getMessages.query).toHaveBeenCalledWith(
         expect.objectContaining({ topicId: 't1' }),
@@ -241,8 +243,8 @@ describe('topic command', () => {
       const program = createProgram();
       await program.parseAsync(['node', 'test', 'topic', 'view', 't1', '--no-messages']);
 
-      // getTopicContext is still called (for metadata)
-      expect(mockTrpcClient.topic.getTopicContext.query).toHaveBeenCalled();
+      // getTopicDetail is still called (for metadata)
+      expect(mockTrpcClient.topic.getTopicDetail.query).toHaveBeenCalled();
       // but getMessages must NOT be called
       expect(mockTrpcClient.message.getMessages.query).not.toHaveBeenCalled();
     });

--- a/apps/cli/src/commands/topic.ts
+++ b/apps/cli/src/commands/topic.ts
@@ -338,64 +338,160 @@ export function registerTopicCommand(program: Command) {
   topic
     .command('view <id>')
     .description('View topic details and its messages')
-    .option('-L, --limit <n>', 'Max messages to show', '50')
+    .option('-L, --limit <n>', 'Max messages to fetch per page', '50')
+    .option('--from <n>', 'Show messages starting from this index (1-based)', '1')
+    .option('--to <n>', 'Show messages up to this index (inclusive)')
     .option('--no-messages', 'Skip messages, show topic metadata only')
     .option('--json', 'Output JSON')
     .action(
       async (
         id: string,
-        options: { json?: boolean; limit?: string; messages?: boolean },
+        options: {
+          from?: string;
+          json?: boolean;
+          limit?: string;
+          messages?: boolean;
+          to?: string;
+        },
       ) => {
         const client = await getTrpcClient();
 
-        // Fetch topic metadata via getTopics filtered by id, then find the match.
-        // (No getTopic-by-id endpoint exists yet; we search the list and match.)
-        const topicsResult = await client.topic.getTopics.query({} as any);
-        const allTopics = Array.isArray(topicsResult)
-          ? topicsResult
-          : ((topicsResult as any).items ?? []);
-        const topicMeta = allTopics.find((t: any) => t.id === id) as any | undefined;
+        // ── 1. Fetch topic metadata via getTopicContext (single query, has permission check) ──
+        const ctxResult = await client.topic.getTopicContext.query({ topicId: id } as any);
 
-        // Fetch messages for this topic
+        // ── 2. Fetch messages only when needed ──
+        if (options.messages === false) {
+          // --no-messages: skip message query entirely
+          if (options.json) {
+            console.log(JSON.stringify({ messages: [], topic: { id } }, null, 2));
+            return;
+          }
+          console.log('');
+          console.log(`${pc.bold('Topic:')}   ${pc.cyan(id)}`);
+          console.log('');
+          return;
+        }
+
         const msgLimit = Number.parseInt(options.limit || '50', 10);
         const msgResult = await client.message.getMessages.query({
           pageSize: msgLimit,
           topicId: id,
         } as any);
-        const messages = Array.isArray(msgResult) ? msgResult : ((msgResult as any).items ?? []);
+        const allMessages: any[] = Array.isArray(msgResult)
+          ? msgResult
+          : ((msgResult as any).items ?? []);
+
+        // Apply --from / --to slicing (1-based)
+        const fromIdx = Math.max(1, Number.parseInt(options.from || '1', 10)) - 1;
+        const toIdx = options.to ? Number.parseInt(options.to, 10) : allMessages.length;
+        const messages = allMessages.slice(fromIdx, toIdx);
 
         if (options.json) {
-          console.log(JSON.stringify({ messages, topic: topicMeta ?? { id } }, null, 2));
+          console.log(
+            JSON.stringify(
+              {
+                messages: messages.map((m: any) => ({
+                  content: m.content ?? null,
+                  createdAt: m.createdAt ?? null,
+                  id: m.id,
+                  parentId: m.parentId ?? null,
+                  role: m.role,
+                  threadId: m.threadId ?? null,
+                  tools: m.tools ?? null,
+                })),
+                topic: { id },
+              },
+              null,
+              2,
+            ),
+          );
           return;
         }
 
-        // ── Header ──
+        // ── Header (extract title from getTopicContext result) ──
+        const ctxContent = (ctxResult as any)?.content ?? '';
+        const titleMatch = ctxContent.match(/^#\s+Topic:\s+(.+)/m);
+        const title = titleMatch ? titleMatch[1].trim() : id;
+
         console.log('');
-        console.log(
-          `${pc.bold('Topic:')}   ${pc.cyan(topicMeta?.title ?? id)}  ${pc.dim(`(${id})`)}`,
-        );
-        if (topicMeta?.favorite) console.log(`${pc.bold('Favorite:')} ★`);
-        if (topicMeta?.updatedAt)
-          console.log(`${pc.bold('Updated:')}  ${timeAgo(topicMeta.updatedAt)}`);
+        console.log(`${pc.bold('Topic:')}   ${pc.cyan(title)}  ${pc.dim(`(${id})`)}`);
         console.log('');
 
         // ── Messages ──
-        if (options.messages === false) return;
-
         if (messages.length === 0) {
           console.log(pc.dim('  (no messages)'));
           return;
         }
 
-        for (const m of messages as any[]) {
-          const role = m.role === 'user' ? pc.green('user      ') : pc.blue('assistant ');
-          const preview = truncate(m.content || '', 120);
-          console.log(`  ${role}  ${preview}`);
+        // Build parentId → children map for thread display
+        const childrenOf = new Map<string | null, any[]>();
+        for (const m of messages) {
+          const key = m.parentId ?? null;
+          if (!childrenOf.has(key)) childrenOf.set(key, []);
+          childrenOf.get(key)!.push(m);
         }
 
-        if (messages.length === msgLimit) {
+        const printMessage = (m: any, depth: number) => {
+          const indent = '  '.repeat(depth + 1);
+          const roleLabel =
+            m.role === 'user'
+              ? pc.green('user     ')
+              : m.role === 'tool'
+                ? pc.yellow('tool     ')
+                : pc.blue('assistant');
+          const threadMark = depth > 0 ? pc.dim('↳ ') : '';
+
+          // Full content (no truncation)
+          const content = (m.content || '').trim();
+          if (content) {
+            console.log(`${indent}${threadMark}${roleLabel}  ${content}`);
+          }
+
+          // Tool calls (assistant requesting tools)
+          if (m.tools && Array.isArray(m.tools) && m.tools.length > 0) {
+            for (const tool of m.tools) {
+              const toolName = tool.function?.name ?? tool.id ?? 'unknown';
+              const toolArgs = tool.function?.arguments
+                ? (() => {
+                    try {
+                      return JSON.stringify(JSON.parse(tool.function.arguments), null, 2)
+                        .split('\n')
+                        .map((l: string) => `${indent}    ${l}`)
+                        .join('\n');
+                    } catch {
+                      return `${indent}    ${tool.function.arguments}`;
+                    }
+                  })()
+                : '';
+              console.log(`${indent}  ${pc.yellow('⚙')} ${pc.bold(toolName)}`);
+              if (toolArgs) console.log(toolArgs);
+            }
+          }
+
+          // Render thread children recursively
+          const children = childrenOf.get(m.id) ?? [];
+          for (const child of children) {
+            printMessage(child, depth + 1);
+          }
+        };
+
+        // Print only top-level messages (parentId === null/undefined, or parentId not in current page)
+        const msgIds = new Set(messages.map((m: any) => m.id));
+        const topLevel = messages.filter(
+          (m: any) => !m.parentId || !msgIds.has(m.parentId),
+        );
+
+        for (const m of topLevel) {
+          printMessage(m, 0);
+        }
+
+        if (allMessages.length > msgLimit) {
           console.log('');
-          console.log(pc.dim(`  … showing first ${msgLimit} messages. Use -L to show more.`));
+          console.log(
+            pc.dim(
+              `  … total ${allMessages.length} messages, showing ${fromIdx + 1}–${Math.min(toIdx, allMessages.length)}. Use -L / --from / --to to paginate.`,
+            ),
+          );
         }
       },
     );

--- a/apps/cli/src/commands/topic.ts
+++ b/apps/cli/src/commands/topic.ts
@@ -356,18 +356,20 @@ export function registerTopicCommand(program: Command) {
       ) => {
         const client = await getTrpcClient();
 
-        // ── 1. Fetch topic metadata via getTopicContext (single query, has permission check) ──
-        const ctxResult = await client.topic.getTopicContext.query({ topicId: id } as any);
+        // ── 1. Fetch topic detail (single query by id) ──
+        const topicDetail = await client.topic.getTopicDetail.query({ id } as any);
 
         // ── 2. Fetch messages only when needed ──
         if (options.messages === false) {
           // --no-messages: skip message query entirely
           if (options.json) {
-            console.log(JSON.stringify({ messages: [], topic: { id } }, null, 2));
+            console.log(JSON.stringify({ messages: [], topic: topicDetail ?? { id } }, null, 2));
             return;
           }
           console.log('');
-          console.log(`${pc.bold('Topic:')}   ${pc.cyan(id)}`);
+          console.log(
+            `${pc.bold('Topic:')}   ${pc.cyan((topicDetail as any)?.title ?? id)}  ${pc.dim(`(${id})`)}`,
+          );
           console.log('');
           return;
         }
@@ -408,13 +410,14 @@ export function registerTopicCommand(program: Command) {
           return;
         }
 
-        // ── Header (extract title from getTopicContext result) ──
-        const ctxContent = (ctxResult as any)?.content ?? '';
-        const titleMatch = ctxContent.match(/^#\s+Topic:\s+(.+)/m);
-        const title = titleMatch ? titleMatch[1].trim() : id;
-
+        // ── Header ──
+        const t = topicDetail as any;
         console.log('');
-        console.log(`${pc.bold('Topic:')}   ${pc.cyan(title)}  ${pc.dim(`(${id})`)}`);
+        console.log(`${pc.bold('Topic:')}   ${pc.cyan(t?.title ?? id)}  ${pc.dim(`(${id})`)}`);
+        if (t?.favorite) console.log(`${pc.bold('Favorite:')} ★`);
+        if (t?.updatedAt) console.log(`${pc.bold('Updated:')}  ${timeAgo(t.updatedAt)}`);
+        if (t?.status) console.log(`${pc.bold('Status:')}   ${t.status}`);
+        if (t?.model) console.log(`${pc.bold('Model:')}    ${t.model}${t.provider ? ` (${t.provider})` : ''}`);
         console.log('');
 
         // ── Messages ──

--- a/apps/cli/src/commands/topic.ts
+++ b/apps/cli/src/commands/topic.ts
@@ -332,4 +332,71 @@ export function registerTopicCommand(program: Command) {
 
       printTable(rows, ['ID', 'TITLE', 'UPDATED']);
     });
+
+  // ── view ──────────────────────────────────────────────
+
+  topic
+    .command('view <id>')
+    .description('View topic details and its messages')
+    .option('-L, --limit <n>', 'Max messages to show', '50')
+    .option('--no-messages', 'Skip messages, show topic metadata only')
+    .option('--json', 'Output JSON')
+    .action(
+      async (
+        id: string,
+        options: { json?: boolean; limit?: string; messages?: boolean },
+      ) => {
+        const client = await getTrpcClient();
+
+        // Fetch topic metadata via getTopics filtered by id, then find the match.
+        // (No getTopic-by-id endpoint exists yet; we search the list and match.)
+        const topicsResult = await client.topic.getTopics.query({} as any);
+        const allTopics = Array.isArray(topicsResult)
+          ? topicsResult
+          : ((topicsResult as any).items ?? []);
+        const topicMeta = allTopics.find((t: any) => t.id === id) as any | undefined;
+
+        // Fetch messages for this topic
+        const msgLimit = Number.parseInt(options.limit || '50', 10);
+        const msgResult = await client.message.getMessages.query({
+          pageSize: msgLimit,
+          topicId: id,
+        } as any);
+        const messages = Array.isArray(msgResult) ? msgResult : ((msgResult as any).items ?? []);
+
+        if (options.json) {
+          console.log(JSON.stringify({ messages, topic: topicMeta ?? { id } }, null, 2));
+          return;
+        }
+
+        // ── Header ──
+        console.log('');
+        console.log(
+          `${pc.bold('Topic:')}   ${pc.cyan(topicMeta?.title ?? id)}  ${pc.dim(`(${id})`)}`,
+        );
+        if (topicMeta?.favorite) console.log(`${pc.bold('Favorite:')} ★`);
+        if (topicMeta?.updatedAt)
+          console.log(`${pc.bold('Updated:')}  ${timeAgo(topicMeta.updatedAt)}`);
+        console.log('');
+
+        // ── Messages ──
+        if (options.messages === false) return;
+
+        if (messages.length === 0) {
+          console.log(pc.dim('  (no messages)'));
+          return;
+        }
+
+        for (const m of messages as any[]) {
+          const role = m.role === 'user' ? pc.green('user      ') : pc.blue('assistant ');
+          const preview = truncate(m.content || '', 120);
+          console.log(`  ${role}  ${preview}`);
+        }
+
+        if (messages.length === msgLimit) {
+          console.log('');
+          console.log(pc.dim(`  … showing first ${msgLimit} messages. Use -L to show more.`));
+        }
+      },
+    );
 }

--- a/src/server/routers/lambda/topic.ts
+++ b/src/server/routers/lambda/topic.ts
@@ -39,6 +39,14 @@ const topicProcedure = authedProcedure.use(serverDatabase).use(async (opts) => {
 });
 
 export const topicRouter = router({
+  getTopicDetail: topicProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ input, ctx }) => {
+      const topic = await ctx.topicModel.findById(input.id);
+      if (!topic) return null;
+      return topic;
+    }),
+
   getTopicContext: topicProcedure
     .input(z.object({ topicId: z.string() }))
     .query(async ({ input, ctx }) => {


### PR DESCRIPTION
## Summary

Add `lh topic view <id>` command to `lh topic` — shows topic metadata and its messages in one shot.

### Motivation

Currently `lh topic` only manages topic metadata (list / search / create / edit). There's no way to inspect a topic's content directly; users have to cross-reference `lh message list --topic-id <id>`. `lh topic view` is the natural, intuitive entry point.

### Changes

**`apps/cli/src/commands/topic.ts`**
- Add `view <id>` subcommand
  - Fetches topic metadata via `client.topic.getTopics` and finds the matching entry by id
  - Fetches messages via `client.message.getMessages` with `topicId` filter
  - Renders a human-readable header (title, favorite ★, last updated) followed by a message list (role + content preview)
  - `--json` flag outputs `{ topic, messages }` as JSON for scripting
  - `--no-messages` flag shows metadata only (skips the message fetch)
  - `-L / --limit` (default 50) caps the number of messages shown

**`apps/cli/src/commands/topic.test.ts`**
- Extend `mockTrpcClient` to include `message.getMessages`
- Add `describe('view')` block with 4 test cases:
  - displays metadata + messages
  - outputs JSON when `--json` is passed
  - skips message fetch when `--no-messages` is passed
  - respects `-L` for message page size

### Usage

```bash
# Human-readable view
lh topic view tpc_abc123

# JSON output (for piping)
lh topic view tpc_abc123 --json

# Metadata only, no messages
lh topic view tpc_abc123 --no-messages

# Show more messages
lh topic view tpc_abc123 -L 100
```

### Notes

- No new API endpoint needed — reuses `getTopics` + `getMessages` (both already exist)
- The topic metadata lookup does a full list + client-side find. A future `getTopic(id)` endpoint would make this cleaner, but that's a separate concern.
