### PR TITLE
✨ feat(device): add recent directory management with drag-to-reorder

### DIFF
--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -272,6 +272,7 @@
   "devices.actions.remove": "Remove",
   "devices.channel.connected": "Connected {{time}}",
   "devices.currentBadge": "This device",
+  "devices.detail.addDir": "Add directory",
   "devices.detail.connections": "Connections",
   "devices.detail.noRecent": "No recent directories",
   "devices.detail.recentDirs": "Recent directories",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -272,6 +272,7 @@
   "devices.actions.remove": "移除",
   "devices.channel.connected": "已连接 {{time}}",
   "devices.currentBadge": "当前设备",
+  "devices.detail.addDir": "添加目录",
   "devices.detail.connections": "连接通道",
   "devices.detail.noRecent": "暂无最近目录",
   "devices.detail.recentDirs": "最近目录",

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -329,6 +329,7 @@ export default {
   'devices.actions.remove': 'Remove',
   'devices.channel.connected': 'Connected {{time}}',
   'devices.currentBadge': 'This device',
+  'devices.detail.addDir': 'Add directory',
   'devices.detail.connections': 'Connections',
   'devices.detail.noRecent': 'No recent directories',
   'devices.detail.recentDirs': 'Recent directories',

--- a/src/routes/(main)/settings/devices/features/DeviceDetailPanel.tsx
+++ b/src/routes/(main)/settings/devices/features/DeviceDetailPanel.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { isDesktop } from '@lobechat/const';
-import { ActionIcon, Button, Flexbox, Icon, Input, Tag, Text } from '@lobehub/ui';
+import { ActionIcon, Button, Flexbox, Icon, Input, SortableList, Tag, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import dayjs from 'dayjs';
-import { FolderOpenIcon, XIcon } from 'lucide-react';
+import { FolderOpenIcon, FolderPlusIcon, XIcon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -35,29 +35,19 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   path: css`
     overflow: hidden;
+    flex: 1;
+
+    min-width: 0;
 
     font-family: ${cssVar.fontFamilyCode};
     font-size: 12px;
+    color: ${cssVar.colorTextSecondary};
     text-overflow: ellipsis;
     white-space: nowrap;
   `,
-  recentRow: css`
+  recentItem: css`
     padding-block: 6px;
     padding-inline: 8px;
-    border-radius: ${cssVar.borderRadius};
-
-    &:hover {
-      background: ${cssVar.colorFillTertiary};
-    }
-  `,
-  removeBtn: css`
-    cursor: pointer;
-    flex: none;
-    color: ${cssVar.colorTextQuaternary};
-
-    &:hover {
-      color: ${cssVar.colorText};
-    }
   `,
 }));
 
@@ -85,17 +75,28 @@ const DeviceDetailPanel = memo<DeviceDetailPanelProps>(({ device, isCurrent, onC
   // row per connection; an empty array means offline.
   const channels = device.channels ?? [];
 
-  const isDirty = name !== (device.friendlyName ?? '') || cwd !== (device.defaultCwd ?? '');
+  // Every edit persists immediately — there is no Save button. Name and the
+  // default cwd commit on blur; recent-dir add / remove / reorder commit on the
+  // spot.
+  const commitName = () => {
+    const next = name.trim() || null;
+    if (next === (device.friendlyName ?? null)) return;
+    update.mutate({ deviceId: device.deviceId, friendlyName: next });
+  };
 
-  const handleSave = async () => {
-    const trimmed = cwd.trim();
-    await update.mutateAsync({
+  const commitCwd = (value: string) => {
+    const trimmed = value.trim();
+    update.mutate({
       defaultCwd: trimmed || null,
       deviceId: device.deviceId,
-      friendlyName: name.trim() || null,
       // Setting a default cwd also seeds the recent list.
       recentCwds: trimmed ? nextRecentCwds(trimmed, device.recentCwds) : device.recentCwds,
     });
+  };
+
+  const handleCwdBlur = () => {
+    if (cwd.trim() === (device.defaultCwd ?? '')) return;
+    commitCwd(cwd);
   };
 
   const handleBrowse = async () => {
@@ -103,13 +104,35 @@ const DeviceDetailPanel = memo<DeviceDetailPanelProps>(({ device, isCurrent, onC
       defaultPath: cwd.trim() || undefined,
       title: t('devices.edit.defaultCwd'),
     });
-    if (result?.path) setCwd(result.path);
+    if (result?.path) {
+      setCwd(result.path);
+      commitCwd(result.path);
+    }
+  };
+
+  const handleAddRecent = async () => {
+    const result = await electronSystemService.selectFolder({
+      title: t('devices.detail.addDir'),
+    });
+    if (result?.path) {
+      update.mutate({
+        deviceId: device.deviceId,
+        recentCwds: nextRecentCwds(result.path, device.recentCwds),
+      });
+    }
   };
 
   const handleRemoveRecent = (path: string) => {
     update.mutate({
       deviceId: device.deviceId,
       recentCwds: device.recentCwds.filter((p) => p !== path),
+    });
+  };
+
+  const handleReorderRecent = (items: { id: string }[]) => {
+    update.mutate({
+      deviceId: device.deviceId,
+      recentCwds: items.map((item) => item.id),
     });
   };
 
@@ -161,7 +184,9 @@ const DeviceDetailPanel = memo<DeviceDetailPanelProps>(({ device, isCurrent, onC
         <Input
           placeholder={t('devices.edit.friendlyNamePlaceholder')}
           value={name}
+          onBlur={commitName}
           onChange={(e) => setName(e.target.value)}
+          onPressEnter={commitName}
         />
       </Flexbox>
 
@@ -172,7 +197,9 @@ const DeviceDetailPanel = memo<DeviceDetailPanelProps>(({ device, isCurrent, onC
           <Input
             placeholder={t('devices.edit.defaultCwdPlaceholder')}
             value={cwd}
+            onBlur={handleCwdBlur}
             onChange={(e) => setCwd(e.target.value)}
+            onPressEnter={handleCwdBlur}
           />
           {canBrowse && (
             <Button icon={<Icon icon={FolderOpenIcon} />} onClick={handleBrowse}>
@@ -190,34 +217,35 @@ const DeviceDetailPanel = memo<DeviceDetailPanelProps>(({ device, isCurrent, onC
             {t('devices.detail.noRecent')}
           </Text>
         ) : (
-          device.recentCwds.map((path) => (
-            <Flexbox horizontal align={'center'} className={styles.recentRow} gap={8} key={path}>
-              <Text
-                className={styles.path}
-                style={{ color: cssVar.colorTextSecondary, cursor: 'pointer', flex: 1 }}
-                onClick={() => setCwd(path)}
-              >
-                {path}
-              </Text>
-              <Icon
-                className={styles.removeBtn}
-                icon={XIcon}
-                size={14}
-                onClick={() => handleRemoveRecent(path)}
-              />
-            </Flexbox>
-          ))
+          <SortableList
+            items={device.recentCwds.map((path) => ({ id: path }))}
+            renderItem={(item: { id: string }) => (
+              <SortableList.Item className={styles.recentItem} id={item.id} variant={'filled'}>
+                <SortableList.DragHandle />
+                <Text className={styles.path} title={item.id}>
+                  {item.id}
+                </Text>
+                <ActionIcon
+                  icon={XIcon}
+                  size={'small'}
+                  onClick={() => handleRemoveRecent(item.id)}
+                />
+              </SortableList.Item>
+            )}
+            onChange={handleReorderRecent}
+          />
+        )}
+        {canBrowse && (
+          <Button
+            block
+            icon={<Icon icon={FolderPlusIcon} />}
+            variant={'filled'}
+            onClick={handleAddRecent}
+          >
+            {t('devices.detail.addDir')}
+          </Button>
         )}
       </Flexbox>
-
-      {/* ─── Save ─── */}
-      {isDirty && (
-        <Flexbox horizontal justify={'flex-end'}>
-          <Button loading={update.isPending} type={'primary'} onClick={handleSave}>
-            {t('devices.edit.save')}
-          </Button>
-        </Flexbox>
-      )}
     </Flexbox>
   );
 });


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

Reworks the device detail panel's recent-directories handling:

- **Add directory button** — a full-width (`block`) `filled` button opens the native folder picker and prepends the chosen path to the device's recent directories.
- **Drag-to-reorder** — the recent directories list now uses `@lobehub/ui` `SortableList` with a drag handle; reordering persists immediately.
- **No Save button** — every device edit now persists on the spot:
  - Name and Default working directory commit on blur / Enter (only when the value actually changed).
  - Recent-dir add / remove / reorder commit immediately via the `updateDevice` mutation.
- Recent directories are now display-only entries (no click-to-edit) — only add, remove, and reorder are supported.

#### 🧪 How to Test

- [x] Tested locally

1. Open Settings → My Devices and select the current device.
2. Edit the name / default working directory, then click elsewhere — change saves without a Save button.
3. Click **Add directory**, pick a folder — it appears at the top of Recent directories.
4. Drag a recent directory to reorder — new order persists.
5. Remove a recent directory via the × — list updates immediately.

#### 📝 Additional Information

The default-cwd seeding behavior (`nextRecentCwds` promoting the selected directory to the front) coexists with manual drag ordering: newly added / selected directories surface first, after which the user can freely reorder.