### PR TITLE
🐛 fix(creds): replace hardcoded session_context values with template variables

### DIFF
--- a/packages/builtin-tool-creds/src/systemRole.ts
+++ b/packages/builtin-tool-creds/src/systemRole.ts
@@ -1,9 +1,9 @@
 export const systemPrompt = `You have access to a LobeHub Credentials Tool. This tool helps you securely manage and use credentials (API keys, tokens, secrets) for various services.
 
 <session_context>
-Current user: Arvin Xu
-Session date: Wednesday, May 20, 2026
-Sandbox mode: false
+Current user: {{username}}
+Session date: {{session_date}}
+Sandbox mode: {{sandbox_enabled}}
 </session_context>
 
 <available_credentials>
@@ -67,7 +67,7 @@ When suggesting to save, always:
 </credential_saving_triggers>
 
 <sandbox_integration>
-**Only applies when sandbox mode is enabled (current value: false).**
+**Only applies when sandbox mode is enabled (current value: {{sandbox_enabled}}).**
 
 When sandbox mode is enabled and you need to run code that requires credentials:
 1. Check if the required credential is in the available credentials list

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -14,7 +14,6 @@ import {
 } from '@lobechat/agent-runtime';
 import { LobeActivatorIdentifier } from '@lobechat/builtin-tool-activator';
 import {
-  CredsIdentifier,
   type CredSummary,
   generateCredsList,
   generateKlavisServicesList,
@@ -639,18 +638,25 @@ export const createRuntimeExecutors = (
         // {{sandbox_enabled}} — mirrors client-side check for lobe-cloud-sandbox.
         const sandboxEnabled = String(resolved.enabledToolIds.includes('lobe-cloud-sandbox'));
 
+        // {{session_date}} — current date formatted for user's timezone.
+        const sessionDate = new Intl.DateTimeFormat('en-US', {
+          day: 'numeric',
+          month: 'long',
+          timeZone: ctx.userTimezone || 'UTC',
+          weekday: 'long',
+          year: 'numeric',
+        }).format(new Date());
+
         // {{memory_effort}} — read from agentConfig chatConfig; no extra query needed.
         const memoryEffort = String(
           (state.metadata?.agentConfig as any)?.chatConfig?.memory?.effort ?? '',
         );
 
         // {{CREDS_LIST}} — used by lobe-creds system role.
-        // Gate on manifestMap presence, NOT enabledToolIds: in execAgent mode lobe-creds is
-        // added to manifestMap (for activator discovery) but never into enabledToolIds, so
-        // checking enabledToolIds would always be false while the system role IS injected.
-        const isCredsEnabled = !!resolved.manifestMap[CredsIdentifier];
+        // Always fetched when userId is available so substitution works regardless of which
+        // execution path (execAgent / client-side activator) injected the system role.
         let credsListStr = '';
-        if (isCredsEnabled && ctx.userId) {
+        if (ctx.userId) {
           try {
             const { MarketService } = await import('@/server/services/market');
             const marketService = new MarketService({ userInfo: { userId: ctx.userId } });
@@ -675,7 +681,7 @@ export const createRuntimeExecutors = (
         // {{KLAVIS_SERVICES_LIST}} — used by lobe-creds system role (Klavis integrations section).
         // Mirrors client-side: klavisStoreSelectors.getServers() filtered by connection status.
         let klavisServicesListStr = '';
-        if (isCredsEnabled && ctx.serverDB && ctx.userId && !!klavisEnv.KLAVIS_API_KEY) {
+        if (ctx.serverDB && ctx.userId && !!klavisEnv.KLAVIS_API_KEY) {
           try {
             const { PluginModel } = await import('@/database/models/plugin');
             const pluginModel = new PluginModel(ctx.serverDB, ctx.userId);
@@ -718,10 +724,11 @@ export const createRuntimeExecutors = (
             // User identity variables
             username: serverUsername,
             language: serverLanguage,
+            session_date: sessionDate,
             // Creds tool variables
             sandbox_enabled: sandboxEnabled,
-            ...(isCredsEnabled && { CREDS_LIST: credsListStr }),
-            ...(isCredsEnabled && { KLAVIS_SERVICES_LIST: klavisServicesListStr }),
+            CREDS_LIST: credsListStr,
+            KLAVIS_SERVICES_LIST: klavisServicesListStr,
             // Memory tool variables
             memory_effort: memoryEffort,
           },

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -653,10 +653,13 @@ export const createRuntimeExecutors = (
         );
 
         // {{CREDS_LIST}} — used by lobe-creds system role.
-        // Always fetched when userId is available so substitution works regardless of which
-        // execution path (execAgent / client-side activator) injected the system role.
+        // Check both enabledToolIds (normal client path) and manifestMap (execAgent path where
+        // lobe-creds is added to manifestMap for activator discovery but not enabledToolIds).
+        const isCredsEnabled =
+          resolved.enabledToolIds.includes(CredsIdentifier) ||
+          !!resolved.manifestMap[CredsIdentifier];
         let credsListStr = '';
-        if (ctx.userId) {
+        if (isCredsEnabled && ctx.userId) {
           try {
             const { MarketService } = await import('@/server/services/market');
             const marketService = new MarketService({ userInfo: { userId: ctx.userId } });
@@ -681,7 +684,7 @@ export const createRuntimeExecutors = (
         // {{KLAVIS_SERVICES_LIST}} — used by lobe-creds system role (Klavis integrations section).
         // Mirrors client-side: klavisStoreSelectors.getServers() filtered by connection status.
         let klavisServicesListStr = '';
-        if (ctx.serverDB && ctx.userId && !!klavisEnv.KLAVIS_API_KEY) {
+        if (isCredsEnabled && ctx.serverDB && ctx.userId && !!klavisEnv.KLAVIS_API_KEY) {
           try {
             const { PluginModel } = await import('@/database/models/plugin');
             const pluginModel = new PluginModel(ctx.serverDB, ctx.userId);
@@ -727,8 +730,8 @@ export const createRuntimeExecutors = (
             session_date: sessionDate,
             // Creds tool variables
             sandbox_enabled: sandboxEnabled,
-            CREDS_LIST: credsListStr,
-            KLAVIS_SERVICES_LIST: klavisServicesListStr,
+            ...(isCredsEnabled && { CREDS_LIST: credsListStr }),
+            ...(isCredsEnabled && { KLAVIS_SERVICES_LIST: klavisServicesListStr }),
             // Memory tool variables
             memory_effort: memoryEffort,
           },

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -653,13 +653,10 @@ export const createRuntimeExecutors = (
         );
 
         // {{CREDS_LIST}} — used by lobe-creds system role.
-        // Check both enabledToolIds (normal client path) and manifestMap (execAgent path where
-        // lobe-creds is added to manifestMap for activator discovery but not enabledToolIds).
-        const isCredsEnabled =
-          resolved.enabledToolIds.includes(CredsIdentifier) ||
-          !!resolved.manifestMap[CredsIdentifier];
+        // Always fetched when userId is available so substitution works regardless of which
+        // execution path (execAgent / client-side activator) injected the system role.
         let credsListStr = '';
-        if (isCredsEnabled && ctx.userId) {
+        if (ctx.userId) {
           try {
             const { MarketService } = await import('@/server/services/market');
             const marketService = new MarketService({ userInfo: { userId: ctx.userId } });
@@ -684,7 +681,7 @@ export const createRuntimeExecutors = (
         // {{KLAVIS_SERVICES_LIST}} — used by lobe-creds system role (Klavis integrations section).
         // Mirrors client-side: klavisStoreSelectors.getServers() filtered by connection status.
         let klavisServicesListStr = '';
-        if (isCredsEnabled && ctx.serverDB && ctx.userId && !!klavisEnv.KLAVIS_API_KEY) {
+        if (ctx.serverDB && ctx.userId && !!klavisEnv.KLAVIS_API_KEY) {
           try {
             const { PluginModel } = await import('@/database/models/plugin');
             const pluginModel = new PluginModel(ctx.serverDB, ctx.userId);
@@ -730,8 +727,8 @@ export const createRuntimeExecutors = (
             session_date: sessionDate,
             // Creds tool variables
             sandbox_enabled: sandboxEnabled,
-            ...(isCredsEnabled && { CREDS_LIST: credsListStr }),
-            ...(isCredsEnabled && { KLAVIS_SERVICES_LIST: klavisServicesListStr }),
+            CREDS_LIST: credsListStr,
+            KLAVIS_SERVICES_LIST: klavisServicesListStr,
             // Memory tool variables
             memory_effort: memoryEffort,
           },

--- a/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -62,6 +62,13 @@ vi.mock('model-bank', () => ({
   LOBE_DEFAULT_MODEL_LIST: mockBuiltinModels,
 }));
 
+// klavisEnv uses @t3-oss/env-nextjs which throws in jsdom (treats it as client context)
+vi.mock('@/config/klavis', () => ({
+  getKlavisConfig: vi.fn(),
+  getServerKlavisApiKey: vi.fn().mockReturnValue(undefined),
+  klavisEnv: { KLAVIS_API_KEY: undefined },
+}));
+
 describe('RuntimeExecutors', () => {
   let mockMessageModel: any;
   let mockStreamManager: any;

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -719,6 +719,15 @@ export const contextEngineering = async ({
       CREDS_LIST: () => (credsList ? generateCredsList(credsList) : ''),
       // NOTICE: required by builtin-tool-creds/src/systemRole.ts (Klavis integrations)
       KLAVIS_SERVICES_LIST: () => klavisServicesList,
+      // NOTICE: required by builtin-tool-creds/src/systemRole.ts (session_context)
+      session_date: () =>
+        new Intl.DateTimeFormat('en-US', {
+          day: 'numeric',
+          month: 'long',
+          weekday: 'long',
+          year: 'numeric',
+        }).format(new Date()),
+      sandbox_enabled: () => String(tools?.includes('lobe-cloud-sandbox') ?? false),
       // NOTICE(@nekomeowww): required by builtin-tool-memory/src/systemRole.ts
       memory_effort: () => (userMemoryConfig ? (memoryContext?.effort ?? '') : ''),
       // Current agent + topic identity — referenced by the LobeHub builtin


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- N/A -->

#### 🔀 Description of Change

The `lobe-creds` system role (`packages/builtin-tool-creds/src/systemRole.ts`) had three hardcoded values in `<session_context>` that should have been template variables:

- `Current user: Arvin Xu` → `{{username}}`
- `Session date: Wednesday, May 20, 2026` → `{{session_date}}`
- `Sandbox mode: false` (two occurrences) → `{{sandbox_enabled}}`

Additionally, `{{CREDS_LIST}}` was not being substituted in some execution paths because it was gated on `isCredsEnabled = !!resolved.manifestMap[CredsIdentifier]`, which is false when lobe-creds is activated outside of execAgent mode.

**Changes:**

- Replace all hardcoded `<session_context>` values in `systemRole.ts` with proper template variables
- Add `{{session_date}}` injection via `Intl.DateTimeFormat` using the user's timezone in `RuntimeExecutors.ts`
- Remove the `isCredsEnabled` gate — `CREDS_LIST` and `KLAVIS_SERVICES_LIST` are now always fetched and injected when `userId` is available, ensuring substitution works regardless of execution path
- `session_date` added to `additionalVariables`

#### 🧪 How to Test

- Enable lobe-creds tool and start a conversation — `<session_context>` should show the actual username, today's date, and correct sandbox mode
- Verify `<available_credentials>` shows real credentials list instead of `{{CREDS_LIST}}`

- [ ] Tested locally
- [ ] No tests needed