### PR TITLE
✨ feat(device): switch device cwd handling to structured workingDirs

### DIFF
--- a/packages/database/src/models/__tests__/device.test.ts
+++ b/packages/database/src/models/__tests__/device.test.ts
@@ -78,7 +78,7 @@ describe('DeviceModel', () => {
       await deviceModel.update('dev-1', {
         defaultCwd: '/Users/me/work',
         friendlyName: 'My Work Mac',
-        recentCwds: ['/Users/me/work', '/Users/me/tmp'],
+        workingDirs: [{ path: '/Users/me/work' }, { path: '/Users/me/tmp', repoType: 'github' }],
       });
 
       // Re-register (e.g. user logs in again / reconnects)
@@ -93,7 +93,7 @@ describe('DeviceModel', () => {
       expect(row).toMatchObject({
         defaultCwd: '/Users/me/work',
         friendlyName: 'My Work Mac',
-        recentCwds: ['/Users/me/work', '/Users/me/tmp'],
+        workingDirs: [{ path: '/Users/me/work' }, { path: '/Users/me/tmp', repoType: 'github' }],
       });
     });
   });

--- a/packages/database/src/models/device.ts
+++ b/packages/database/src/models/device.ts
@@ -1,6 +1,6 @@
 import { and, desc, eq } from 'drizzle-orm';
 
-import type { DeviceItem } from '../schemas';
+import type { DeviceItem, WorkingDirEntry } from '../schemas';
 import { devices } from '../schemas';
 import type { LobeChatDatabase } from '../type';
 
@@ -15,7 +15,7 @@ export interface RegisterDeviceParams {
 export interface UpdateDeviceParams {
   defaultCwd?: string | null;
   friendlyName?: string | null;
-  recentCwds?: string[];
+  workingDirs?: WorkingDirEntry[];
 }
 
 export class DeviceModel {
@@ -30,7 +30,7 @@ export class DeviceModel {
   /**
    * Auto-register from desktop/CLI. Upserts on the (userId, deviceId) unique
    * index. On conflict only the machine-reported fields + lastSeenAt are
-   * refreshed — friendlyName / defaultCwd / recentCwds are user-owned and
+   * refreshed — friendlyName / defaultCwd / workingDirs are user-owned and
    * must survive re-registration.
    */
   register = async (params: RegisterDeviceParams) => {

--- a/src/features/ChatInput/RuntimeConfig/DeviceWorkingDirectory.tsx
+++ b/src/features/ChatInput/RuntimeConfig/DeviceWorkingDirectory.tsx
@@ -13,6 +13,8 @@ import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 
+import type { WorkingDirEntry } from './deviceCwd';
+import { renderDirIcon } from './dirIcon';
 import { useUpdateDeviceCwd } from './useUpdateDeviceCwd';
 
 const styles = createStaticStyles(({ css }) => ({
@@ -91,9 +93,9 @@ interface DeviceWorkingDirectoryProps {
  * Working-directory picker for runs dispatched to a remote device
  * (`executionTarget='device'`). Unlike the desktop picker, the device's
  * filesystem isn't browsable from here, so the cwd comes from the device's
- * `recentCwds` (persisted via the registry) plus a manual path field. A pick is
+ * `workingDirs` (persisted via the registry) plus a manual path field. A pick is
  * pinned to the active topic (override) and persisted back to the device
- * (`defaultCwd` + `recentCwds`) so it seeds future topics and the recent list.
+ * (`defaultCwd` + `workingDirs`) so it seeds future topics and the recent list.
  */
 const DeviceWorkingDirectory = memo<DeviceWorkingDirectoryProps>(({ agentId }) => {
   const { t } = useTranslation(['plugin', 'chat']);
@@ -110,7 +112,7 @@ const DeviceWorkingDirectory = memo<DeviceWorkingDirectoryProps>(({ agentId }) =
     () => devices?.find((d) => d.deviceId === boundDeviceId),
     [devices, boundDeviceId],
   );
-  const recentCwds = device?.recentCwds ?? [];
+  const workingDirs = device?.workingDirs ?? [];
 
   const topicWorkingDirectory = useChatStore(topicSelectors.currentTopicWorkingDirectory);
   // Mirror the server's resolution (topic override > device.defaultCwd).
@@ -124,15 +126,15 @@ const DeviceWorkingDirectory = memo<DeviceWorkingDirectoryProps>(({ agentId }) =
   const updateDeviceCwd = useUpdateDeviceCwd();
 
   const commitDir = useCallback(
-    async (path: string) => {
-      const newPath = path.trim();
+    async (entry: WorkingDirEntry) => {
+      const newPath = entry.path.trim();
       if (!newPath || !boundDeviceId) return;
 
       const commit = async () => {
         // Pin this topic to the chosen cwd (override wins server-side), and
-        // persist to the device so defaultCwd + recentCwds stay in sync.
+        // persist to the device so defaultCwd + workingDirs stay in sync.
         if (activeTopicId) await updateTopicMetadata(activeTopicId, { workingDirectory: newPath });
-        await updateDeviceCwd(boundDeviceId, newPath, recentCwds);
+        await updateDeviceCwd(boundDeviceId, { ...entry, path: newPath }, workingDirs);
         setInput('');
         setOpen(false);
       };
@@ -158,7 +160,7 @@ const DeviceWorkingDirectory = memo<DeviceWorkingDirectoryProps>(({ agentId }) =
       activeTopicId,
       activeTopic,
       boundDeviceId,
-      recentCwds,
+      workingDirs,
       t,
       updateDeviceCwd,
       updateTopicMetadata,
@@ -169,7 +171,7 @@ const DeviceWorkingDirectory = memo<DeviceWorkingDirectoryProps>(({ agentId }) =
     <Flexbox gap={4} style={{ minWidth: 280 }}>
       <div className={styles.sectionTitle}>{t('localSystem.workingDirectory.recent')}</div>
       <div className={styles.scrollContainer}>
-        {recentCwds.length === 0 ? (
+        {workingDirs.length === 0 ? (
           <Flexbox
             align={'center'}
             justify={'center'}
@@ -178,25 +180,21 @@ const DeviceWorkingDirectory = memo<DeviceWorkingDirectoryProps>(({ agentId }) =
             {t('localSystem.workingDirectory.noRecent')}
           </Flexbox>
         ) : (
-          recentCwds.map((path) => {
-            const isActive = path === effectiveDir;
+          workingDirs.map((entry) => {
+            const isActive = entry.path === effectiveDir;
             return (
               <Flexbox
                 horizontal
                 align={'center'}
                 className={cx(styles.dirItem, isActive && styles.dirItemActive)}
                 gap={8}
-                key={path}
-                onClick={() => void commitDir(path)}
+                key={entry.path}
+                onClick={() => void commitDir(entry)}
               >
-                <Icon
-                  icon={FolderIcon}
-                  size={16}
-                  style={{ color: cssVar.colorTextTertiary, flex: 'none' }}
-                />
+                {renderDirIcon(entry.repoType)}
                 <Flexbox flex={1} style={{ minWidth: 0 }}>
-                  <div className={styles.dirName}>{getDirName(path)}</div>
-                  <div className={styles.dirPath}>{path}</div>
+                  <div className={styles.dirName}>{getDirName(entry.path)}</div>
+                  <div className={styles.dirPath}>{entry.path}</div>
                 </Flexbox>
                 {isActive ? (
                   <Icon
@@ -214,7 +212,7 @@ const DeviceWorkingDirectory = memo<DeviceWorkingDirectoryProps>(({ agentId }) =
         placeholder={t('localSystem.workingDirectory.placeholder')}
         value={input}
         onChange={(e) => setInput(e.target.value)}
-        onPressEnter={() => void commitDir(input)}
+        onPressEnter={() => void commitDir({ path: input })}
       />
     </Flexbox>
   );

--- a/src/features/ChatInput/RuntimeConfig/WorkingDirectory.tsx
+++ b/src/features/ChatInput/RuntimeConfig/WorkingDirectory.tsx
@@ -1,10 +1,9 @@
 import { isDesktop } from '@lobechat/const';
-import { Github } from '@lobehub/icons';
 import { Flexbox, Icon } from '@lobehub/ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
-import { CheckIcon, FolderIcon, FolderOpenIcon, GitBranchIcon, XIcon } from 'lucide-react';
-import { memo, type ReactNode, useCallback, useMemo, useState } from 'react';
+import { CheckIcon, FolderOpenIcon, XIcon } from 'lucide-react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { lambdaQuery } from '@/libs/trpc/client';
@@ -15,6 +14,7 @@ import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 import { useElectronStore } from '@/store/electron';
 
+import { renderDirIcon } from './dirIcon';
 import { addRecentDir, getRecentDirs, type RecentDirEntry, removeRecentDir } from './recentDirs';
 import { useRepoType } from './useRepoType';
 import { useUpdateDeviceCwd } from './useUpdateDeviceCwd';
@@ -119,14 +119,6 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-const renderDirIcon = (repoType?: 'git' | 'github'): ReactNode => {
-  const iconStyle = { color: cssVar.colorTextTertiary, flex: 'none' as const };
-  if (repoType === 'github') return <Github size={16} style={iconStyle} />;
-  return (
-    <Icon icon={repoType === 'git' ? GitBranchIcon : FolderIcon} size={16} style={iconStyle} />
-  );
-};
-
 // Backfills `repoType` for entries cached before detection supported submodule /
 // worktree layouts — `useRepoType` probes and updates the recents cache.
 const RecentDirIcon = memo<{ entry: RecentDirEntry }>(({ entry }) => {
@@ -158,8 +150,8 @@ const WorkingDirectoryContent = memo<WorkingDirectoryContentProps>(({ agentId, o
   const updateTopicMetadata = useChatStore((s) => s.updateTopicMetadata);
 
   // Local runs execute on this very machine, so also record the chosen dir in
-  // its device-registry `recentCwds` — keeps the settings detail view + future
-  // device-mode picker in sync. recentCwds only; the device default is untouched.
+  // its device-registry `workingDirs` — keeps the settings detail view + future
+  // device-mode picker in sync. workingDirs only; the device default is untouched.
   const useFetchDeviceInfo = useElectronStore((s) => s.useFetchGatewayDeviceInfo);
   const gatewayDeviceInfo = useElectronStore((s) => s.gatewayDeviceInfo);
   useFetchDeviceInfo();
@@ -167,8 +159,8 @@ const WorkingDirectoryContent = memo<WorkingDirectoryContentProps>(({ agentId, o
   const { data: allDevices } = lambdaQuery.device.listDevices.useQuery(undefined, {
     staleTime: 30_000,
   });
-  const deviceRecentCwds =
-    allDevices?.find((d) => d.deviceId === currentDeviceId)?.recentCwds ?? [];
+  const deviceWorkingDirs =
+    allDevices?.find((d) => d.deviceId === currentDeviceId)?.workingDirs ?? [];
   const updateDeviceCwd = useUpdateDeviceCwd();
 
   const [recentDirs, setRecentDirs] = useState(getRecentDirs);
@@ -195,9 +187,10 @@ const WorkingDirectoryContent = memo<WorkingDirectoryContentProps>(({ agentId, o
           await updateAgentRuntimeEnvConfig(agentId, { workingDirectory: newPath });
         }
         setRecentDirs(addRecentDir(entry));
-        // Record on this machine's device registry (recentCwds only).
+        // Record on this machine's device registry (workingDirs only) — the
+        // whole entry, so the detected repoType is preserved cross-device.
         if (currentDeviceId) {
-          void updateDeviceCwd(currentDeviceId, newPath, deviceRecentCwds, { setDefault: false });
+          void updateDeviceCwd(currentDeviceId, entry, deviceWorkingDirs, { setDefault: false });
         }
         onClose?.();
       };
@@ -227,7 +220,7 @@ const WorkingDirectoryContent = memo<WorkingDirectoryContentProps>(({ agentId, o
       activeTopic,
       agentId,
       currentDeviceId,
-      deviceRecentCwds,
+      deviceWorkingDirs,
       t,
       updateAgentRuntimeEnvConfig,
       updateDeviceCwd,

--- a/src/features/ChatInput/RuntimeConfig/deviceCwd.test.ts
+++ b/src/features/ChatInput/RuntimeConfig/deviceCwd.test.ts
@@ -1,32 +1,50 @@
 import { describe, expect, it } from 'vitest';
 
-import { nextRecentCwds, RECENT_CWDS_MAX } from './deviceCwd';
+import { nextWorkingDirs, WORKING_DIRS_MAX, type WorkingDirEntry } from './deviceCwd';
 
-describe('nextRecentCwds', () => {
-  it('prepends a new path as most-recent', () => {
-    expect(nextRecentCwds('/b', ['/a'])).toEqual(['/b', '/a']);
+const entry = (path: string, repoType?: 'git' | 'github'): WorkingDirEntry => ({ path, repoType });
+
+describe('nextWorkingDirs', () => {
+  it('prepends a new entry as most-recent', () => {
+    expect(nextWorkingDirs(entry('/b'), [entry('/a')])).toEqual([entry('/b'), entry('/a')]);
   });
 
   it('moves an existing path to the front without duplicating it', () => {
-    expect(nextRecentCwds('/a', ['/a', '/b', '/c'])).toEqual(['/a', '/b', '/c']);
-    expect(nextRecentCwds('/c', ['/a', '/b', '/c'])).toEqual(['/c', '/a', '/b']);
+    expect(nextWorkingDirs(entry('/a'), [entry('/a'), entry('/b'), entry('/c')])).toEqual([
+      entry('/a'),
+      entry('/b'),
+      entry('/c'),
+    ]);
+    expect(nextWorkingDirs(entry('/c'), [entry('/a'), entry('/b'), entry('/c')])).toEqual([
+      entry('/c'),
+      entry('/a'),
+      entry('/b'),
+    ]);
+  });
+
+  it('preserves and updates metadata such as repoType', () => {
+    expect(nextWorkingDirs(entry('/a', 'github'), [])).toEqual([entry('/a', 'github')]);
+    // Re-picking with a freshly-detected type overwrites the stale entry.
+    expect(nextWorkingDirs(entry('/a', 'github'), [entry('/a', 'git')])).toEqual([
+      entry('/a', 'github'),
+    ]);
   });
 
   it('caps the list length', () => {
-    const current = Array.from({ length: RECENT_CWDS_MAX }, (_, i) => `/p${i}`);
-    const result = nextRecentCwds('/new', current);
-    expect(result).toHaveLength(RECENT_CWDS_MAX);
-    expect(result[0]).toBe('/new');
-    expect(result).not.toContain(`/p${RECENT_CWDS_MAX - 1}`); // oldest dropped
+    const current = Array.from({ length: WORKING_DIRS_MAX }, (_, i) => entry(`/p${i}`));
+    const result = nextWorkingDirs(entry('/new'), current);
+    expect(result).toHaveLength(WORKING_DIRS_MAX);
+    expect(result[0]).toEqual(entry('/new'));
+    expect(result.some((d) => d.path === `/p${WORKING_DIRS_MAX - 1}`)).toBe(false); // oldest dropped
   });
 
-  it('trims the input and ignores a blank path', () => {
-    expect(nextRecentCwds('  /a  ', ['/b'])).toEqual(['/a', '/b']);
-    expect(nextRecentCwds('   ', ['/b'])).toEqual(['/b']);
-    expect(nextRecentCwds('', ['/b'])).toEqual(['/b']);
+  it('trims the path and ignores a blank one', () => {
+    expect(nextWorkingDirs(entry('  /a  '), [entry('/b')])).toEqual([entry('/a'), entry('/b')]);
+    expect(nextWorkingDirs(entry('   '), [entry('/b')])).toEqual([entry('/b')]);
+    expect(nextWorkingDirs(entry(''), [entry('/b')])).toEqual([entry('/b')]);
   });
 
   it('defaults to an empty current list', () => {
-    expect(nextRecentCwds('/a')).toEqual(['/a']);
+    expect(nextWorkingDirs(entry('/a'))).toEqual([entry('/a')]);
   });
 });

--- a/src/features/ChatInput/RuntimeConfig/deviceCwd.ts
+++ b/src/features/ChatInput/RuntimeConfig/deviceCwd.ts
@@ -1,21 +1,31 @@
-/** Max number of recent working directories persisted per device. Matches the
- * `recentCwds` cap enforced by the `device.updateDevice` tRPC input. */
-export const RECENT_CWDS_MAX = 20;
+/** Max number of working directories persisted per device. Matches the
+ * `workingDirs` cap enforced by the `device.updateDevice` tRPC input. */
+export const WORKING_DIRS_MAX = 20;
 
 /**
- * Compute the next `recentCwds` list after the user picks `cwd`: move it to the
- * front (most-recent-first), drop any earlier duplicate, and cap the length.
- * Blank paths are ignored (returns the list unchanged).
+ * A working directory recorded on a device. Structured so metadata such as the
+ * detected repo type survives across machines — a remote client viewing this
+ * device can't re-probe its filesystem. Mirrors the DB `WorkingDirEntry`.
+ */
+export interface WorkingDirEntry {
+  path: string;
+  repoType?: 'git' | 'github';
+}
+
+/**
+ * Compute the next `workingDirs` list after the user picks `entry`: move it to
+ * the front (most-recent-first), drop any earlier entry with the same path, and
+ * cap the length. Blank paths are ignored (returns the list unchanged).
  *
- * The server stores `recentCwds` verbatim — there is no server-side dedupe or
+ * The server stores `workingDirs` verbatim — there is no server-side dedupe or
  * cap — so the client owns this logic.
  */
-export const nextRecentCwds = (
-  cwd: string,
-  current: readonly string[] = [],
-  max: number = RECENT_CWDS_MAX,
-): string[] => {
-  const trimmed = cwd.trim();
-  if (!trimmed) return [...current];
-  return [trimmed, ...current.filter((p) => p !== trimmed)].slice(0, max);
+export const nextWorkingDirs = (
+  entry: WorkingDirEntry,
+  current: readonly WorkingDirEntry[] = [],
+  max: number = WORKING_DIRS_MAX,
+): WorkingDirEntry[] => {
+  const path = entry.path.trim();
+  if (!path) return [...current];
+  return [{ ...entry, path }, ...current.filter((d) => d.path !== path)].slice(0, max);
 };

--- a/src/features/ChatInput/RuntimeConfig/dirIcon.tsx
+++ b/src/features/ChatInput/RuntimeConfig/dirIcon.tsx
@@ -1,0 +1,16 @@
+import { Github } from '@lobehub/icons';
+import { Icon } from '@lobehub/ui';
+import { cssVar } from 'antd-style';
+import { FolderIcon, GitBranchIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+/** Render the directory icon for a detected repo type: GitHub mark, git branch,
+ * or a plain folder when the type is unknown. Shared by every cwd picker so a
+ * `github` dir looks the same in the local, device, and settings views. */
+export const renderDirIcon = (repoType?: 'git' | 'github'): ReactNode => {
+  const iconStyle = { color: cssVar.colorTextTertiary, flex: 'none' as const };
+  if (repoType === 'github') return <Github size={16} style={iconStyle} />;
+  return (
+    <Icon icon={repoType === 'git' ? GitBranchIcon : FolderIcon} size={16} style={iconStyle} />
+  );
+};

--- a/src/features/ChatInput/RuntimeConfig/useUpdateDeviceCwd.ts
+++ b/src/features/ChatInput/RuntimeConfig/useUpdateDeviceCwd.ts
@@ -2,11 +2,11 @@ import { useCallback } from 'react';
 
 import { lambdaQuery } from '@/libs/trpc/client';
 
-import { nextRecentCwds } from './deviceCwd';
+import { nextWorkingDirs, type WorkingDirEntry } from './deviceCwd';
 
 /**
  * Persist a working-directory choice to a device's registry record
- * (`defaultCwd` + `recentCwds`) with an **optimistic** update of the
+ * (`defaultCwd` + `workingDirs`) with an **optimistic** update of the
  * `listDevices` cache, so the picker reflects the pick instantly and the
  * server's `device.defaultCwd` (read by the hetero device-dispatch branch)
  * stays in sync. Rolls back on error.
@@ -15,7 +15,7 @@ export const useUpdateDeviceCwd = () => {
   const utils = lambdaQuery.useUtils();
 
   const mutation = lambdaQuery.device.updateDevice.useMutation({
-    onMutate: async ({ defaultCwd, deviceId, recentCwds }) => {
+    onMutate: async ({ defaultCwd, deviceId, workingDirs }) => {
       // Optimistic write: cancel in-flight refetches so they don't clobber it,
       // then patch the touched device in place. onSettled re-fetches the truth
       // afterwards (on both success and error), so a failed write self-corrects
@@ -31,7 +31,7 @@ export const useUpdateDeviceCwd = () => {
             ? {
                 ...device,
                 defaultCwd: defaultCwd ?? device.defaultCwd,
-                recentCwds: recentCwds ?? device.recentCwds,
+                workingDirs: workingDirs ?? device.workingDirs,
               }
             : device,
         ) as typeof old;
@@ -43,19 +43,19 @@ export const useUpdateDeviceCwd = () => {
   return useCallback(
     (
       deviceId: string,
-      cwd: string,
-      currentRecentCwds: readonly string[] = [],
-      // Local-mode runs only want to record the dir in the recent list, not
-      // repoint the device's default working directory.
+      entry: WorkingDirEntry,
+      currentWorkingDirs: readonly WorkingDirEntry[] = [],
+      // Local-mode runs only want to record the dir in the working-dirs list,
+      // not repoint the device's default working directory.
       options: { setDefault?: boolean } = {},
     ) => {
-      const trimmed = cwd.trim();
+      const trimmed = entry.path.trim();
       if (!trimmed) return;
       const setDefault = options.setDefault ?? true;
       return mutation.mutateAsync({
         ...(setDefault ? { defaultCwd: trimmed } : {}),
         deviceId,
-        recentCwds: nextRecentCwds(trimmed, currentRecentCwds),
+        workingDirs: nextWorkingDirs(entry, currentWorkingDirs),
       });
     },
     [mutation],

--- a/src/routes/(main)/settings/devices/features/DeviceDetailPanel.tsx
+++ b/src/routes/(main)/settings/devices/features/DeviceDetailPanel.tsx
@@ -8,7 +8,8 @@ import { FolderOpenIcon, FolderPlusIcon, XIcon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { nextRecentCwds } from '@/features/ChatInput/RuntimeConfig/deviceCwd';
+import { nextWorkingDirs } from '@/features/ChatInput/RuntimeConfig/deviceCwd';
+import { renderDirIcon } from '@/features/ChatInput/RuntimeConfig/dirIcon';
 import { lambdaQuery } from '@/libs/trpc/client';
 import { electronSystemService } from '@/services/electron/system';
 
@@ -84,13 +85,15 @@ const DeviceDetailPanel = memo<DeviceDetailPanelProps>(({ device, isCurrent, onC
     update.mutate({ deviceId: device.deviceId, friendlyName: next });
   };
 
-  const commitCwd = (value: string) => {
+  const commitCwd = (value: string, repoType?: 'git' | 'github') => {
     const trimmed = value.trim();
     update.mutate({
       defaultCwd: trimmed || null,
       deviceId: device.deviceId,
-      // Setting a default cwd also seeds the recent list.
-      recentCwds: trimmed ? nextRecentCwds(trimmed, device.recentCwds) : device.recentCwds,
+      // Setting a default cwd also seeds the working-dirs list.
+      workingDirs: trimmed
+        ? nextWorkingDirs({ path: trimmed, repoType }, device.workingDirs)
+        : device.workingDirs,
     });
   };
 
@@ -106,7 +109,7 @@ const DeviceDetailPanel = memo<DeviceDetailPanelProps>(({ device, isCurrent, onC
     });
     if (result?.path) {
       setCwd(result.path);
-      commitCwd(result.path);
+      commitCwd(result.path, result.repoType);
     }
   };
 
@@ -117,7 +120,10 @@ const DeviceDetailPanel = memo<DeviceDetailPanelProps>(({ device, isCurrent, onC
     if (result?.path) {
       update.mutate({
         deviceId: device.deviceId,
-        recentCwds: nextRecentCwds(result.path, device.recentCwds),
+        workingDirs: nextWorkingDirs(
+          { path: result.path, repoType: result.repoType },
+          device.workingDirs,
+        ),
       });
     }
   };
@@ -125,14 +131,17 @@ const DeviceDetailPanel = memo<DeviceDetailPanelProps>(({ device, isCurrent, onC
   const handleRemoveRecent = (path: string) => {
     update.mutate({
       deviceId: device.deviceId,
-      recentCwds: device.recentCwds.filter((p) => p !== path),
+      workingDirs: device.workingDirs.filter((d) => d.path !== path),
     });
   };
 
   const handleReorderRecent = (items: { id: string }[]) => {
+    // SortableList items are keyed by path; map ids back to their entries so the
+    // detected repoType survives a reorder.
+    const byPath = new Map(device.workingDirs.map((d) => [d.path, d]));
     update.mutate({
       deviceId: device.deviceId,
-      recentCwds: items.map((item) => item.id),
+      workingDirs: items.map((item) => byPath.get(item.id) ?? { path: item.id }),
     });
   };
 
@@ -212,16 +221,17 @@ const DeviceDetailPanel = memo<DeviceDetailPanelProps>(({ device, isCurrent, onC
       {/* ─── Recent directories ─── */}
       <Flexbox gap={6}>
         <span className={styles.label}>{t('devices.detail.recentDirs')}</span>
-        {device.recentCwds.length === 0 ? (
+        {device.workingDirs.length === 0 ? (
           <Text style={{ fontSize: 12 }} type={'secondary'}>
             {t('devices.detail.noRecent')}
           </Text>
         ) : (
           <SortableList
-            items={device.recentCwds.map((path) => ({ id: path }))}
-            renderItem={(item: { id: string }) => (
+            items={device.workingDirs.map((d) => ({ id: d.path, repoType: d.repoType }))}
+            renderItem={(item: { id: string; repoType?: 'git' | 'github' }) => (
               <SortableList.Item className={styles.recentItem} id={item.id} variant={'filled'}>
                 <SortableList.DragHandle />
+                {renderDirIcon(item.repoType)}
                 <Text className={styles.path} title={item.id}>
                   {item.id}
                 </Text>

--- a/src/routes/(main)/settings/devices/features/DeviceItem.tsx
+++ b/src/routes/(main)/settings/devices/features/DeviceItem.tsx
@@ -8,6 +8,7 @@ import { FolderIcon, MoreVerticalIcon, Trash2Icon, TriangleAlertIcon } from 'luc
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import type { WorkingDirEntry } from '@/features/ChatInput/RuntimeConfig/deviceCwd';
 import { lambdaQuery } from '@/libs/trpc/client';
 
 import { getDeviceIcon } from './getDeviceIcon';
@@ -29,8 +30,8 @@ export interface DeviceListItem {
   lastSeen: string;
   online: boolean;
   platform: string | null;
-  recentCwds: string[];
   registered: boolean;
+  workingDirs: WorkingDirEntry[];
 }
 
 const styles = createStaticStyles(({ css }) => ({

--- a/src/server/routers/lambda/device.ts
+++ b/src/server/routers/lambda/device.ts
@@ -1,3 +1,4 @@
+import type { WorkingDirEntry } from '@lobechat/database/schemas';
 import { REMOTE_HETEROGENEOUS_AGENT_CONFIGS } from '@lobechat/heterogeneous-agents';
 import { z } from 'zod';
 
@@ -173,8 +174,8 @@ export const deviceRouter = router({
         lastSeen: d.lastSeenAt.toISOString(),
         online: channels.length > 0,
         platform: d.platform ?? live?.platform ?? null,
-        recentCwds: d.recentCwds,
         registered: true,
+        workingDirs: d.workingDirs ?? [],
       };
     });
 
@@ -191,8 +192,8 @@ export const deviceRouter = router({
         lastSeen: channels[0]?.connectedAt ?? new Date().toISOString(),
         online: true,
         platform: channels[0]?.platform ?? null,
-        recentCwds: [] as string[],
         registered: false,
+        workingDirs: [] as WorkingDirEntry[],
       }));
 
     return [...fromDb, ...ghosts];
@@ -234,7 +235,10 @@ export const deviceRouter = router({
         defaultCwd: z.string().nullable().optional(),
         deviceId: z.string(),
         friendlyName: z.string().max(100).nullable().optional(),
-        recentCwds: z.array(z.string()).max(20).optional(),
+        workingDirs: z
+          .array(z.object({ path: z.string(), repoType: z.enum(['git', 'github']).optional() }))
+          .max(20)
+          .optional(),
       }),
     )
     .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

The DB layer (`working_dirs` column + `WorkingDirEntry`) is already on `canary` (landed via the workspace-id migration batch). This PR is the consumer layer.

#### 🔀 Description of Change

Switch device cwd handling from the flat `recentCwds: string[]` to `workingDirs: WorkingDirEntry[]` (`{ path, repoType?: 'git' | 'github' }`), backed by the `working_dirs` column already on `canary`.

- **model / tRPC** (`updateDevice` input, `listDevices` output): use `workingDirs` (input capped at 20, validated `{ path, repoType? }`)
- **tRPC `listDevices`**: coalesces the nullable `working_dirs` read to `[]` so the API contract stays an always-array
- **client `deviceCwd`**: `nextRecentCwds` → `nextWorkingDirs` over `WorkingDirEntry`
- **UI**: `DeviceWorkingDirectory`, `WorkingDirectory`, `DeviceDetailPanel`, `DeviceItem` render the detected repo type via the new shared `renderDirIcon`

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```
cd packages/database && bunx vitest run src/models/__tests__/device.test.ts   # 7 passed
bunx vitest run src/features/ChatInput/RuntimeConfig/deviceCwd.test.ts         # 6 passed
```

#### 📝 Additional Information

- `recent_cwds` remains on the table as a `@deprecated` legacy column; this PR stops reading/writing it. A later cleanup can drop the column.