### PR TITLE
🐛 fix(gateway): prevent duplicate streaming from stale reconnects

### DIFF
--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -385,7 +385,7 @@ describe('GatewayActionImpl', () => {
   describe('executeGatewayAgent', () => {
     function createExecuteTestAction() {
       const mockClient = createMockClient();
-      const state: Record<string, any> = { gatewayConnections: {} };
+      const state: Record<string, any> = { gatewayConnections: {}, topicDataMap: {} };
       const set = vi.fn((updater: any) => {
         if (typeof updater === 'function') {
           Object.assign(state, updater(state));
@@ -396,12 +396,13 @@ describe('GatewayActionImpl', () => {
 
       const get = vi.fn(() => ({
         ...state,
-        startOperation: vi.fn(() => ({ operationId: 'gw-op-1' })),
         associateMessageWithOperation: vi.fn(),
         connectToGateway: vi.fn(),
+        internal_dispatchTopic: vi.fn(),
         internal_updateTopicLoading: vi.fn(),
         onOperationCancel: vi.fn(),
         replaceMessages: vi.fn(),
+        startOperation: vi.fn(() => ({ operationId: 'gw-op-1' })),
         switchTopic: vi.fn(),
       })) as any;
 
@@ -688,7 +689,7 @@ describe('GatewayActionImpl', () => {
       const startOperation = vi.fn(() => ({ operationId: 'gw-op-local' }));
 
       const mockClient = createMockClient();
-      const state: Record<string, any> = { gatewayConnections: {} };
+      const state: Record<string, any> = { gatewayConnections: {}, topicDataMap: {} };
       const set = vi.fn((updater: any) => {
         if (typeof updater === 'function') Object.assign(state, updater(state));
         else Object.assign(state, updater);
@@ -697,6 +698,7 @@ describe('GatewayActionImpl', () => {
         ...state,
         associateMessageWithOperation: vi.fn(),
         connectToGateway: vi.fn(),
+        internal_dispatchTopic: vi.fn(),
         internal_updateTopicLoading: vi.fn(),
         onOperationCancel,
         replaceMessages: vi.fn(),

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -566,6 +566,13 @@ export class GatewayActionImpl {
     // Get a fresh JWT token (original expired after 5 min)
     const { token } = await aiAgentService.refreshGatewayToken(topicId);
 
+    // Re-check after the async token refresh: a newer executeGatewayAgent call may have
+    // taken over for this topic while we were waiting. If so, bail to avoid a duplicate stream.
+    // (disconnectFromGateway on the stale op is a no-op here because we haven't connected yet.)
+    const topicOpIdAfterRefresh = topicSelectors.getTopicById(topicId)(this.#get())?.metadata
+      ?.runningOperation?.operationId;
+    if (topicOpIdAfterRefresh && topicOpIdAfterRefresh !== operationId) return;
+
     const agentId = this.#get().activeAgentId;
     const context = {
       agentId,

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -452,6 +452,31 @@ export class GatewayActionImpl {
     // the caller's op (e.g. `sendMessage`) to the child without a gap.
     if (parentOperationId) this.#get().completeOperation(parentOperationId);
 
+    // Optimistically update the local store's runningOperation for this topic so
+    // useGatewayReconnect doesn't fire for a stale previous operation while the new
+    // gateway connection is being established. Also disconnect any live reconnect
+    // connection that was already established for the old operation.
+    if (result.topicId) {
+      const existingTopic = topicSelectors.getTopicById(result.topicId)(this.#get());
+      const staleOpId = existingTopic?.metadata?.runningOperation?.operationId;
+      if (staleOpId && staleOpId !== result.operationId) {
+        this.#get().internal_dispatchTopic({
+          id: result.topicId,
+          type: 'updateTopic',
+          value: {
+            metadata: {
+              ...existingTopic?.metadata,
+              runningOperation: {
+                assistantMessageId: result.assistantMessageId,
+                operationId: result.operationId,
+              },
+            },
+          },
+        });
+        this.disconnectFromGateway(staleOpId);
+      }
+    }
+
     // When the local operation is cancelled (e.g. user clicks stop), forward
     // the interrupt directly to the server via the existing tRPC endpoint.
     // Closure captures `result.operationId` (the server-side id) so we don't
@@ -529,6 +554,14 @@ export class GatewayActionImpl {
     // overwriting the fresh non-resume connect with resumeOnConnect:true.
     const existingStatus = this.#get().gatewayConnections[operationId]?.status;
     if (existingStatus && existingStatus !== 'disconnected') return;
+
+    // Skip reconnect if the topic already has a newer running operation. This
+    // happens when executeGatewayAgent was called (creating a new op) while this
+    // stale reconnect was still queued — connecting to the old op would produce
+    // duplicate streaming events alongside the new connection.
+    const topicCurrentOpId = topicSelectors.getTopicById(topicId)(this.#get())?.metadata
+      ?.runningOperation?.operationId;
+    if (topicCurrentOpId && topicCurrentOpId !== operationId) return;
 
     // Get a fresh JWT token (original expired after 5 min)
     const { token } = await aiAgentService.refreshGatewayToken(topicId);


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- N/A -->

#### 🔀 Description of Change

When a new agent execution starts for a topic that still has a stale `runningOperation` in its metadata (e.g. the browser was closed mid-stream and the topic was never cleared), `useGatewayReconnect` would attempt to reconnect to the old operation **concurrently** with the new one, producing duplicate streaming events.

Two fixes:

1. **Optimistic store update** — immediately after `executeGatewayAgent` creates the new operation, update the topic's `runningOperation` to the new op ID and call `disconnectFromGateway` for the stale op, so any live reconnect connection is torn down before the new WS opens.

2. **Reconnect guard** — in `connectToGateway` (via the reconnect path), skip the connection if the topic already has a *newer* `runningOperation` ID than the one we're about to reconnect. This handles the race where the reconnect fires after `executeGatewayAgent` has already updated the store.

#### 🧪 How to Test

1. Start an agent run, close the browser mid-stream (so `runningOperation` is persisted in topic metadata).
2. Re-open the conversation and immediately send a new message.
3. Previously: two concurrent streaming connections → duplicated assistant tokens.
4. After fix: only the new connection fires; the stale reconnect is skipped.

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

No breaking changes. The `internal_dispatchTopic` call is an existing pattern used elsewhere in the gateway actions.