### PR TITLE
🐛 fix(agent-builder): explicitly sync editing agent ID to chatStore

### DIFF
--- a/src/features/AgentBuilder/AgentBuilderProvider.tsx
+++ b/src/features/AgentBuilder/AgentBuilderProvider.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react';
-import { memo, useMemo } from 'react';
+import { memo, useEffect, useMemo } from 'react';
 
 import { ConversationProvider } from '@/features/Conversation';
 import { useOperationState } from '@/hooks/useOperationState';
@@ -10,6 +10,12 @@ import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 interface AgentBuilderProviderProps {
   agentId: string;
   children: ReactNode;
+  /**
+   * The ID of the agent currently being edited in the profile page.
+   * This is synced to chatStore.activeAgentId so the chat service can read it
+   * when building the agentBuilderContext for injection into the LLM prompt.
+   */
+  editingAgentId?: string;
 }
 
 /**
@@ -17,45 +23,60 @@ interface AgentBuilderProviderProps {
  * Provides context for the Agent Builder chat panel
  * Uses 'agent_builder' scope to isolate messages from main conversation
  */
-const AgentBuilderProvider = memo<AgentBuilderProviderProps>(({ agentId, children }) => {
-  const activeTopicId = useChatStore((s) => s.activeTopicId);
+const AgentBuilderProvider = memo<AgentBuilderProviderProps>(
+  ({ agentId, editingAgentId, children }) => {
+    const activeTopicId = useChatStore((s) => s.activeTopicId);
 
-  // Build conversation context for agent builder
-  // Using agent_builder scope for message management
-  const context = useMemo<MessageMapKeyInput>(
-    () => ({
-      agentId,
-      scope: 'agent_builder',
-      topicId: activeTopicId,
-    }),
-    [agentId, activeTopicId],
-  );
+    // Keep chatStore.activeAgentId in sync with the agent being edited.
+    // The chat service reads getChatStoreState().activeAgentId to build agentBuilderContext,
+    // so this must reflect the profile page agent, not the Agent Builder builtin agent.
+    useEffect(() => {
+      if (!editingAgentId) return;
+      if (useChatStore.getState().activeAgentId === editingAgentId) return;
+      useChatStore.setState(
+        { activeAgentId: editingAgentId },
+        false,
+        'AgentBuilderProvider/syncEditingAgentId',
+      );
+    }, [editingAgentId]);
 
-  // Get messages from ChatStore based on context
-  const chatKey = useMemo(
-    () => (context ? messageMapKey(context) : null),
-    [context?.agentId, context?.topicId],
-  );
+    // Build conversation context for agent builder
+    // Using agent_builder scope for message management
+    const context = useMemo<MessageMapKeyInput>(
+      () => ({
+        agentId,
+        scope: 'agent_builder',
+        topicId: activeTopicId,
+      }),
+      [agentId, activeTopicId],
+    );
 
-  const replaceMessages = useChatStore((s) => s.replaceMessages);
-  const messages = useChatStore((s) => (chatKey ? s.dbMessagesMap[chatKey] : undefined));
+    // Get messages from ChatStore based on context
+    const chatKey = useMemo(
+      () => (context ? messageMapKey(context) : null),
+      [context?.agentId, context?.topicId],
+    );
 
-  // Get operation state for reactive updates
-  const operationState = useOperationState(context);
+    const replaceMessages = useChatStore((s) => s.replaceMessages);
+    const messages = useChatStore((s) => (chatKey ? s.dbMessagesMap[chatKey] : undefined));
 
-  return (
-    <ConversationProvider
-      context={context}
-      hasInitMessages={!!messages}
-      messages={messages}
-      operationState={operationState}
-      onMessagesChange={(msgs, ctx) => {
-        replaceMessages(msgs, { context: ctx });
-      }}
-    >
-      {children}
-    </ConversationProvider>
-  );
-});
+    // Get operation state for reactive updates
+    const operationState = useOperationState(context);
+
+    return (
+      <ConversationProvider
+        context={context}
+        hasInitMessages={!!messages}
+        messages={messages}
+        operationState={operationState}
+        onMessagesChange={(msgs, ctx) => {
+          replaceMessages(msgs, { context: ctx });
+        }}
+      >
+        {children}
+      </ConversationProvider>
+    );
+  },
+);
 
 export default AgentBuilderProvider;

--- a/src/features/AgentBuilder/index.tsx
+++ b/src/features/AgentBuilder/index.tsx
@@ -39,7 +39,7 @@ const AgentBuilder = memo(() => {
       }}
     >
       {agentId && agentBuilderId ? (
-        <AgentBuilderProvider agentId={agentBuilderId}>
+        <AgentBuilderProvider agentId={agentBuilderId} editingAgentId={agentId}>
           <AgentBuilderConversation agentId={agentBuilderId} />
         </AgentBuilderProvider>
       ) : (


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No issue tracked -->

#### 🔀 Description of Change

**Problem**

Agent Builder fails to read the correct agent's configuration from the profile page. It either reports itself ("Agent Builder") or a stale/wrong agent's config instead of the agent currently being edited.

**Root Cause**

`chatService.createAssistantMessage` calls `getChatStoreState().activeAgentId` to determine which agent is being edited, in order to build the `agentBuilderContext` injected into the LLM prompt as `<current_agent_context>`.

This relies on `AgentIdSync` (mounted in `routes/(main)/agent/_layout`) syncing the URL param `/:aid` into `chatStore.activeAgentId`. However, this is a fragile implicit dependency that can be broken by:

- SWR cache hits causing `useFetchAgentConfig`'s `onData` callback to fire before React effects settle
- React effect scheduling order — `AgentIdSync`'s `useChatStoreUpdater` effect fires in parent-last order, meaning child component effects (including the Agent Builder panel) may run before `chatStore.activeAgentId` is updated
- Any other concurrent write racing against `chatStore.activeAgentId`

As a result, `agentBuilderContext` gets built from the wrong agent ID, and the LLM describes the wrong agent's parameters in its response.

**Fix**

- `AgentBuilderProvider` now accepts an `editingAgentId` prop
- A `useEffect` writes `editingAgentId` to `chatStore.activeAgentId` whenever it changes, making the data flow explicit and resilient
- `AgentBuilder/index.tsx` passes `agentStore.activeAgentId` (the profile-page agent) as `editingAgentId`

This ensures `chatStore.activeAgentId` always reflects the agent being edited whenever the Agent Builder panel is mounted, regardless of `AgentIdSync` timing.

#### 🧪 How to Test

- [x] Tested locally

1. Open any agent's Profile page (`/agent/:aid/profile`)
2. Open the Agent Builder right panel
3. Ask "What are the current parameters of this agent?"
4. **Before fix**: LLM responds with "Agent Builder"'s own config or a stale agent's config
5. **After fix**: LLM correctly responds with the profile-page agent's name, model, system prompt, and plugins

Also verify:
- Switching between different agents' profile pages — Agent Builder always reflects the current agent
- `updateConfig` / `updatePrompt` tool calls still update the correct agent

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Agent Builder reports wrong agent name (e.g. "Agent Builder" or stale "sjdnjdqw") | Agent Builder correctly reads and displays the currently edited agent's config |

#### 📝 Additional Information

Only `AgentBuilderProvider` (for individual agents, `agent_builder` scope) is changed. The group agent builder (`group_agent_builder` scope) uses a separate provider and context path and is not affected.