### PR TITLE
♻️ refactor(agent-runtime): persist canonical nested usage/performance on assistant messages

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -1031,6 +1031,7 @@ export const createRuntimeExecutors = (
             const imageList: any[] = [];
             let grounding: any = null;
             let currentStepUsage: any = undefined;
+            let currentStepSpeed: any = undefined;
             let currentStepFinishReason: string | undefined = undefined;
             let streamError: any = undefined;
             const contentParts: ContentPart[] = [];
@@ -1072,6 +1073,10 @@ export const createRuntimeExecutors = (
                     // Capture usage (may or may not include cost)
                     if (data.usage) {
                       currentStepUsage = data.usage;
+                    }
+                    // Capture performance metrics (tps / ttft / duration / latency)
+                    if (data.speed) {
+                      currentStepSpeed = data.speed;
                     }
                     // Capture provider's terminal finishReason so soft interrupts
                     // (e.g. Gemini RECITATION / MAX_TOKENS with empty content)
@@ -1306,7 +1311,14 @@ export const createRuntimeExecutors = (
                 // Build metadata object
                 const metadata: Record<string, any> = {};
                 if (currentStepUsage && typeof currentStepUsage === 'object') {
+                  // Flat fields are kept for backward-compatible readers; `usage`
+                  // is the canonical nested shape new readers should consume.
                   Object.assign(metadata, currentStepUsage);
+                  metadata.usage = currentStepUsage;
+                }
+                if (currentStepSpeed && typeof currentStepSpeed === 'object') {
+                  Object.assign(metadata, currentStepSpeed);
+                  metadata.performance = currentStepSpeed;
                 }
                 if (hasContentImages) {
                   metadata.isMultimodal = true;
@@ -1484,6 +1496,11 @@ export const createRuntimeExecutors = (
                   const interruptedMetadata: Record<string, any> = { interruptedMidStream: true };
                   if (currentStepUsage && typeof currentStepUsage === 'object') {
                     Object.assign(interruptedMetadata, currentStepUsage);
+                    interruptedMetadata.usage = currentStepUsage;
+                  }
+                  if (currentStepSpeed && typeof currentStepSpeed === 'object') {
+                    Object.assign(interruptedMetadata, currentStepSpeed);
+                    interruptedMetadata.performance = currentStepSpeed;
                   }
                   await ctx.messageModel.update(assistantMessageItem.id, {
                     content,

--- a/src/server/services/usage/index.ts
+++ b/src/server/services/usage/index.ts
@@ -45,18 +45,24 @@ export class UsageRecordService {
       .orderBy(desc(messages.createdAt));
     return spends.map((spend) => {
       const metadata = spend.metadata as MessageMetadata;
+      // Prefer the canonical nested `usage` / `performance` shapes, falling back
+      // to the deprecated flat fields for messages written before the migration.
+      const usage = metadata?.usage;
+      const performance = metadata?.performance;
+      const totalInputTokens = usage?.totalInputTokens ?? metadata?.totalInputTokens ?? 0;
+      const totalOutputTokens = usage?.totalOutputTokens ?? metadata?.totalOutputTokens ?? 0;
       return {
         createdAt: spend.createdAt,
         id: spend.id,
         metadata: spend.metadata,
         model: spend.model,
         provider: spend.provider,
-        spend: metadata?.cost || 0,
-        totalInputTokens: metadata?.totalInputTokens || 0,
-        totalOutputTokens: metadata?.totalOutputTokens || 0,
-        totalTokens: (metadata?.totalInputTokens || 0) + (metadata?.totalOutputTokens || 0),
-        tps: metadata?.tps || 0,
-        ttft: metadata?.ttft || 0,
+        spend: usage?.cost ?? metadata?.cost ?? 0,
+        totalInputTokens,
+        totalOutputTokens,
+        totalTokens: totalInputTokens + totalOutputTokens,
+        tps: performance?.tps ?? metadata?.tps ?? 0,
+        ttft: performance?.ttft ?? metadata?.ttft ?? 0,
         type: 'chat',
         updatedAt: spend.createdAt,
         userId: spend.userId,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

Today the three message-write paths disagree on the shape of token/perf metadata persisted to `messages.metadata`:

- **client store** (`createAgentExecutors.ts`) — writes flat fields **and** canonical nested `metadata.usage` / `metadata.performance` ✅
- **heterogeneous agent** (`HeterogeneousPersistenceHandler`) — writes nested `metadata.usage` ✅
- **standard agent chat** (`RuntimeExecutors`) — only **flattened** token usage onto metadata, and **never** persisted performance ❌

This PR converges the standard server path to the same shape as the others:

- capture `data.speed` (`ModelPerformance`) from the model-runtime `onCompletion` callback (it was already provided on `OnFinishData`, just not consumed) and persist it as `metadata.performance`
- write nested `metadata.usage` alongside the existing flat fields (flat kept for backward-compatible readers) — applied to both the normal finalize and the interrupted/cancel finalize
- `usage` service now reads `metadata.usage` / `metadata.performance` first, falling back to the deprecated flat fields, so both pre- and post-migration messages read correctly

This is the write-path prerequisite (Step 0) for an upcoming historical backfill that normalizes flat → nested `metadata.usage` and then aggregates per-topic usage. Without it, the standard chat path would keep emitting flat-only metadata and re-introduce drift after the backfill.

No DB schema change. Flat fields are intentionally left in place; stripping them is a separate later step once all readers consume the nested shape.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Run a standard (non-hetero) agent chat turn and inspect the assistant message row: `metadata.usage` (tokens + cost) and `metadata.performance` (tps/ttft/duration/latency) should both be populated, in addition to the legacy flat fields. `type-check` passes (no new errors in the two changed files).

#### 📝 Additional Information

Mirrors the client store shape exactly; client requires no change.