### PR TITLE
💄 style(sidebar): bind the bottom spacer to the accordion block

### DIFF
--- a/plugins/vite/sharedRendererConfig.ts
+++ b/plugins/vite/sharedRendererConfig.ts
@@ -234,6 +234,13 @@ export const sharedOptimizeDeps = {
     '@ant-design/icons',
     '@lobehub/ui',
     '@lobehub/ui > @emotion/react',
+    // Dedupe motion the same way as @emotion/react: force @lobehub/ui's internal
+    // `motion/react` (LazyMotion context) and `motion/react-m` (m component) into the
+    // shared prebundle, so they share a single React context with the app-level
+    // <LazyMotion> in SPAGlobalProvider. Otherwise useMotionComponent throws
+    // "wrap your app with <ConfigProvider>/<MotionProvider>".
+    '@lobehub/ui > motion/react',
+    '@lobehub/ui > motion/react-m',
     'antd-style',
     'zustand',
     'zustand/middleware',
@@ -262,6 +269,7 @@ export const sharedOptimizeDeps = {
 
     'ahooks',
     'motion/react',
+    'motion/react-m',
   ],
 };
 

--- a/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
+++ b/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
@@ -32,7 +32,11 @@ import { useTranslation } from 'react-i18next';
 import { getRouteById } from '@/config/routes';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
-import { SIDEBAR_ACCORDION_KEYS, SIDEBAR_SPACER_ID } from '@/store/global/selectors/systemStatus';
+import {
+  anchorSpacerToAccordion,
+  SIDEBAR_ACCORDION_KEYS,
+  SIDEBAR_SPACER_ID,
+} from '@/store/global/selectors/systemStatus';
 
 // ---------------------------------------------------------------------------
 // Types & constants
@@ -168,42 +172,16 @@ const SortableItem = memo<{
 });
 
 // ---------------------------------------------------------------------------
-// SpacerSortableItem — represents the flex spacer slot; draggable like any
-// other item but rendered as a divider with an "Anchor below to bottom" label.
+// SpacerRow — static divider rendered inside the accordion group, anchored right
+// after `agent`. The spacer is bound to the accordion block, so it is not draggable
+// on its own and carries no grip handle.
 // ---------------------------------------------------------------------------
 
-const SpacerSortableItem = memo(() => {
+const SpacerRow = memo(() => {
   const { t } = useTranslation('common');
-  const {
-    attributes,
-    isDragging,
-    listeners,
-    setActivatorNodeRef,
-    setNodeRef,
-    transform,
-    transition,
-  } = useSortable({ id: SIDEBAR_SPACER_ID });
 
   return (
-    <Flexbox
-      horizontal
-      align={'center'}
-      className={isDragging ? cx(styles.item, styles.itemDragging) : styles.item}
-      gap={8}
-      ref={setNodeRef}
-      style={{
-        transform: CSS.Translate.toString(transform),
-        transition,
-      }}
-      {...attributes}
-    >
-      <Flexbox
-        ref={setActivatorNodeRef}
-        style={{ cursor: isDragging ? 'grabbing' : 'grab', flexShrink: 0, touchAction: 'none' }}
-        {...listeners}
-      >
-        <Icon icon={GripVertical} size={14} style={{ color: cssVar.colorTextQuaternary }} />
-      </Flexbox>
+    <Flexbox horizontal align={'center'} className={styles.item} gap={8}>
       <Icon icon={ArrowDownToLine} size={14} style={{ color: cssVar.colorTextQuaternary }} />
       <div className={styles.spacerLine} />
       <Text style={{ fontSize: 12 }} type={'secondary'}>
@@ -255,18 +233,6 @@ const OverlayItem = memo<{ id: string }>(({ id }) => {
     );
   }
 
-  if (isSpacer(id)) {
-    return (
-      <Flexbox horizontal align={'center'} className={styles.overlay} gap={8}>
-        <Icon icon={GripVertical} size={14} style={{ color: cssVar.colorTextQuaternary }} />
-        <Icon icon={ArrowDownToLine} size={14} style={{ color: cssVar.colorTextQuaternary }} />
-        <Text style={{ fontSize: 12 }} type={'secondary'}>
-          {t('navPanel.bottomDivider' as any)}
-        </Text>
-      </Flexbox>
-    );
-  }
-
   const item = ITEM_MAP.get(id);
   if (!item) return null;
   const route = item.routeId ? getRouteById(item.routeId) : undefined;
@@ -310,6 +276,7 @@ const CustomizeSidebarContent = memo(() => {
     const inner: string[] = [];
     let insertedGroup = false;
     for (const id of items) {
+      if (isSpacer(id)) continue; // spacer is rendered statically inside the accordion group
       if (isAccordionKey(id)) {
         inner.push(id);
         if (!insertedGroup) {
@@ -383,8 +350,10 @@ const CustomizeSidebarContent = memo(() => {
         next = flattenItems(arrayMove(outerItems, oldIdx, newIdx), innerItems);
       }
 
-      setItems(next);
-      updateSystemStatus({ sidebarItems: next });
+      // Re-anchor the spacer (absent from outer/inner) to the accordion block.
+      const normalized = anchorSpacerToAccordion(next);
+      setItems(normalized);
+      updateSystemStatus({ sidebarItems: normalized });
     },
     [innerItems, outerItems, updateSystemStatus],
   );
@@ -394,12 +363,9 @@ const CustomizeSidebarContent = memo(() => {
     setItems(storeItems);
   }, [storeItems]);
 
-  const renderItem = (id: string) =>
-    isSpacer(id) ? (
-      <SpacerSortableItem key={id} />
-    ) : (
-      <SortableItem hiddenSections={hiddenSections} id={id} key={id} onToggle={toggleSection} />
-    );
+  const renderItem = (id: string) => (
+    <SortableItem hiddenSections={hiddenSections} id={id} key={id} onToggle={toggleSection} />
+  );
 
   return (
     <DndContext
@@ -417,6 +383,7 @@ const CustomizeSidebarContent = memo(() => {
                 <SortableContext items={innerItems} strategy={verticalListSortingStrategy}>
                   {innerItems.map(renderItem)}
                 </SortableContext>
+                <SpacerRow />
               </AccordionGroup>
             ) : (
               renderItem(id)

--- a/src/store/global/selectors/systemStatus.test.ts
+++ b/src/store/global/selectors/systemStatus.test.ts
@@ -10,6 +10,7 @@ import {
   initialState,
 } from '../initialState';
 import {
+  anchorSpacerToAccordion,
   DEFAULT_SIDEBAR_ITEMS,
   reorderSidebarItems,
   SIDEBAR_SPACER_ID,
@@ -133,7 +134,7 @@ describe('systemStatusSelectors', () => {
       expect(systemStatusSelectors.sidebarItems(initialState)).toEqual(DEFAULT_SIDEBAR_ITEMS);
     });
 
-    it('should preserve stored order and inject the spacer before the first bottom item', () => {
+    it('should preserve stored order and anchor the spacer right after the accordion block', () => {
       const stored = [
         'agent',
         'recents',
@@ -150,9 +151,9 @@ describe('systemStatusSelectors', () => {
       expect(systemStatusSelectors.sidebarItems(s)).toEqual([
         'agent',
         'recents',
+        SIDEBAR_SPACER_ID,
         'pages',
         'tasks',
-        SIDEBAR_SPACER_ID,
         'image',
         'community',
         'resource',
@@ -178,7 +179,7 @@ describe('systemStatusSelectors', () => {
       expect(systemStatusSelectors.sidebarItems(s)).toEqual(stored);
     });
 
-    it('should append missing known keys to the end and keep the spacer anchored', () => {
+    it('should append missing known keys and keep the spacer after the accordion block', () => {
       const s: GlobalState = merge(initialState, {
         status: { sidebarItems: ['agent', 'recents'] },
       });
@@ -190,11 +191,8 @@ describe('systemStatusSelectors', () => {
       expect(items).toContain('community');
       expect(items).toContain('resource');
       expect(items).toContain('memory');
-      // spacer sits directly before the first bottom-class item
-      const firstBottomIdx = items.findIndex((k) =>
-        ['image', 'community', 'resource', 'memory'].includes(k),
-      );
-      expect(items[firstBottomIdx - 1]).toBe(SIDEBAR_SPACER_ID);
+      // spacer sits directly after the accordion block's last member (`recents`)
+      expect(items[2]).toBe(SIDEBAR_SPACER_ID);
     });
 
     it('should migrate legacy `sidebarSectionOrder` accordion order into the default layout', () => {
@@ -339,6 +337,101 @@ describe('systemStatusSelectors', () => {
 
     it('should be a no-op when from === to', () => {
       expect(reorderSidebarItems(DEFAULT, 2, 2)).toBe(DEFAULT);
+    });
+  });
+
+  describe('reorderSidebarItems with the spacer bound to the accordion block', () => {
+    // ['tasks', 'pages', 'recents', 'agent', '__spacer__', 'image', 'community', 'resource', 'memory']
+    const FULL = DEFAULT_SIDEBAR_ITEMS;
+
+    it('moves the spacer together when `agent` is dragged down past the block', () => {
+      // agent (idx 3) moveDown → idx 4 (the spacer slot). The compound block
+      // [recents, agent, spacer] slides past `image`.
+      expect(reorderSidebarItems(FULL, 3, 4)).toEqual([
+        'tasks',
+        'pages',
+        'image',
+        'recents',
+        'agent',
+        SIDEBAR_SPACER_ID,
+        'community',
+        'resource',
+        'memory',
+      ]);
+    });
+
+    it('moves the spacer together when `recents` is dragged up past the block', () => {
+      // recents (idx 2) moveUp → idx 1. Compound block slides above `pages`.
+      expect(reorderSidebarItems(FULL, 2, 1)).toEqual([
+        'tasks',
+        'recents',
+        'agent',
+        SIDEBAR_SPACER_ID,
+        'pages',
+        'image',
+        'community',
+        'resource',
+        'memory',
+      ]);
+    });
+
+    it('keeps the spacer at the block tail when swapping recents/agent within the block', () => {
+      // agent (idx 3) moveUp → idx 2 (swap with recents). Spacer stays at the tail.
+      expect(reorderSidebarItems(FULL, 3, 2)).toEqual([
+        'tasks',
+        'pages',
+        'agent',
+        'recents',
+        SIDEBAR_SPACER_ID,
+        'image',
+        'community',
+        'resource',
+        'memory',
+      ]);
+    });
+
+    it('never lets another item split the block from its spacer', () => {
+      // community (idx 6) dragged up to idx 3 — it must snap above the block,
+      // not land between `agent` and the spacer.
+      const next = reorderSidebarItems(FULL, 6, 3);
+      const agentIdx = next.indexOf('agent');
+      expect(next[agentIdx + 1]).toBe(SIDEBAR_SPACER_ID);
+      expect(next.indexOf('community')).toBeLessThan(next.indexOf('recents'));
+    });
+
+    it('is a no-op when trying to reorder the spacer itself', () => {
+      const spacerIdx = FULL.indexOf(SIDEBAR_SPACER_ID);
+      expect(reorderSidebarItems(FULL, spacerIdx, 0)).toBe(FULL);
+    });
+  });
+
+  describe('anchorSpacerToAccordion', () => {
+    it('moves the spacer to right after the accordion block', () => {
+      expect(
+        anchorSpacerToAccordion(['tasks', SIDEBAR_SPACER_ID, 'recents', 'agent', 'image']),
+      ).toEqual(['tasks', 'recents', 'agent', SIDEBAR_SPACER_ID, 'image']);
+    });
+
+    it('inserts a spacer after the block when none is present', () => {
+      expect(anchorSpacerToAccordion(['tasks', 'recents', 'agent', 'image'])).toEqual([
+        'tasks',
+        'recents',
+        'agent',
+        SIDEBAR_SPACER_ID,
+        'image',
+      ]);
+    });
+
+    it('collapses duplicate spacers into a single one after the block', () => {
+      expect(
+        anchorSpacerToAccordion([
+          SIDEBAR_SPACER_ID,
+          'recents',
+          'agent',
+          SIDEBAR_SPACER_ID,
+          'image',
+        ]),
+      ).toEqual(['recents', 'agent', SIDEBAR_SPACER_ID, 'image']);
     });
   });
 });

--- a/src/store/global/selectors/systemStatus.ts
+++ b/src/store/global/selectors/systemStatus.ts
@@ -69,17 +69,22 @@ export const DEFAULT_SIDEBAR_ITEMS: string[] = [
 /** Items that must stay contiguous in the sidebar list (accordion block). */
 export const SIDEBAR_ACCORDION_KEYS = new Set(['recents', 'agent']);
 
-const DEFAULT_BOTTOM_KEYS = new Set(
-  DEFAULT_SIDEBAR_ITEMS.slice(DEFAULT_SIDEBAR_ITEMS.indexOf(SIDEBAR_SPACER_ID) + 1),
-);
+const accordionIndices = (items: string[]): number[] => {
+  const out: number[] = [];
+  for (let i = 0; i < items.length; i++) {
+    if (SIDEBAR_ACCORDION_KEYS.has(items[i])) out.push(i);
+  }
+  return out;
+};
 
-/** Insert the spacer sentinel into `order` if missing — anchored before the first
- * default "bottom" item (image/community/...), falling back to the end. */
-const ensureSpacer = (order: string[]): string[] => {
-  if (order.includes(SIDEBAR_SPACER_ID)) return order;
-  const insertAt = order.findIndex((k) => DEFAULT_BOTTOM_KEYS.has(k));
-  if (insertAt === -1) return [...order, SIDEBAR_SPACER_ID];
-  return [...order.slice(0, insertAt), SIDEBAR_SPACER_ID, ...order.slice(insertAt)];
+/** Anchor a single spacer immediately after the accordion block's last member, binding
+ * it to `recents`/`agent` as one compound block. Drops any duplicate spacers; falls back
+ * to the list end when no accordion member is present. */
+export const anchorSpacerToAccordion = (order: string[]): string[] => {
+  const withoutSpacer = order.filter((k) => k !== SIDEBAR_SPACER_ID);
+  const acc = accordionIndices(withoutSpacer);
+  const insertAt = acc.length > 0 ? acc.at(-1)! + 1 : withoutSpacer.length;
+  return [...withoutSpacer.slice(0, insertAt), SIDEBAR_SPACER_ID, ...withoutSpacer.slice(insertAt)];
 };
 
 /** Append any known keys missing from `order` so new items don't disappear on upgrade. */
@@ -87,15 +92,7 @@ const withAllKnownKeys = (order: string[]): string[] => {
   const present = new Set(order);
   const missing = DEFAULT_SIDEBAR_ITEMS.filter((k) => k !== SIDEBAR_SPACER_ID && !present.has(k));
   const withMissing = missing.length === 0 ? order : [...order, ...missing];
-  return ensureSpacer(withMissing);
-};
-
-const accordionIndices = (items: string[]): number[] => {
-  const out: number[] = [];
-  for (let i = 0; i < items.length; i++) {
-    if (SIDEBAR_ACCORDION_KEYS.has(items[i])) out.push(i);
-  }
-  return out;
+  return anchorSpacerToAccordion(withMissing);
 };
 
 /**
@@ -107,6 +104,24 @@ const accordionIndices = (items: string[]): number[] => {
 export const reorderSidebarItems = (items: string[], from: number, to: number): string[] => {
   if (from === to || from < 0 || to < 0 || from >= items.length || to >= items.length) {
     return items;
+  }
+
+  // The spacer is bound to the accordion block and never reorders on its own.
+  if (items[from] === SIDEBAR_SPACER_ID) return items;
+
+  // When a spacer is present, reorder in a spacer-free coordinate space and re-anchor
+  // the spacer to the accordion block afterwards. This keeps `[recents, agent, spacer]`
+  // moving as one compound block and stops other items from splitting it.
+  const spacerIdx = items.indexOf(SIDEBAR_SPACER_ID);
+  if (spacerIdx !== -1) {
+    const compact = items.filter((k) => k !== SIDEBAR_SPACER_ID);
+    const cFrom = from > spacerIdx ? from - 1 : from;
+    let cTo: number;
+    if (to > spacerIdx) cTo = to - 1;
+    else if (to < spacerIdx) cTo = to;
+    // Target is the spacer slot itself → move across it in the drag direction.
+    else cTo = from < to ? to : Math.max(0, to - 1);
+    return anchorSpacerToAccordion(reorderSidebarItems(compact, cFrom, cTo));
   }
 
   const key = items[from];


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] 💄 style

#### 🔗 Related Issue

Follow-up to #15222 (respect customize sidebar order across the bottom spacer).

#### 🔀 Description of Change

The customize-sidebar bottom spacer used to be a standalone **draggable** slot. Any item could be dropped *before* it, so users could split the spacer away from the accordion group and end up with a broken-looking layout. This PR binds the spacer to the accordion block instead, plus a supporting Vite fix so the accordion's `motion` animation works inside the modal.

**`systemStatus` selector**
- Replace `ensureSpacer` with `anchorSpacerToAccordion`, which drops duplicate spacers and re-pins a single spacer immediately **after the accordion block's last member**.
- `reorderSidebarItems` now reorders in a spacer-free coordinate space and re-anchors afterwards, so `[recents, agent, spacer]` always moves as one compound block and no other item can split it. Dragging the spacer itself is a no-op.

**`CustomizeSidebarModal`**
- Render the spacer as a static `SpacerRow` *inside* the `AccordionGroup` (no grip handle, not sortable) instead of the old draggable `SpacerSortableItem` / overlay branch.

**`plugins/vite/sharedRendererConfig`**
- Dedupe `@lobehub/ui`'s internal `motion/react` (LazyMotion context) and `motion/react-m` into the shared prebundle — the same treatment `@emotion/react` already gets. Without this, `@lobehub/ui` components use a different `motion` React context than the app-level `<LazyMotion>` in `SPAGlobalProvider`, and `useMotionComponent` throws *"wrap your app with `<ConfigProvider>/<MotionProvider>`"*.

#### 🧪 How to Test

Open the home sidebar → **Customize** modal and drag items around the accordion block:
- the spacer always stays directly after the accordion group;
- dragging `agent`/`recents` moves the whole `[recents, agent, spacer]` block together;
- no item can be dropped between the accordion and its spacer;
- the spacer divider itself can't be picked up.

- [x] Tested locally
- [x] Added/updated tests (`systemStatus.test.ts`, 31 passing)
- [ ] No tests needed

#### 📝 Additional Information

The Vite `motion` dedupe is required for the `AccordionGroup`'s enter/exit animation to run inside the modal; it's bundled here because that's the surface that exposed the missing dedupe.