### PR TITLE
✨ feat(chat-input): show execution-device switcher for all agents

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -217,6 +217,7 @@
   "heteroAgent.executionTarget.online": "Online",
   "heteroAgent.executionTarget.sandbox": "Cloud sandbox",
   "heteroAgent.executionTarget.sandboxDesc": "Run in an ephemeral cloud sandbox",
+  "heteroAgent.executionTarget.downloadDesktop": "Get Desktop App",
   "heteroAgent.executionTarget.title": "Execution Device",
   "heteroAgent.executionTarget.unknownDevice": "Unknown device",
   "heteroAgent.fullAccess.label": "Full access",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -217,6 +217,7 @@
   "heteroAgent.executionTarget.online": "在线",
   "heteroAgent.executionTarget.sandbox": "云端沙箱",
   "heteroAgent.executionTarget.sandboxDesc": "在临时云端沙箱中运行",
+  "heteroAgent.executionTarget.downloadDesktop": "下载桌面端",
   "heteroAgent.executionTarget.title": "执行设备",
   "heteroAgent.executionTarget.unknownDevice": "未知设备",
   "heteroAgent.fullAccess.label": "完全访问权限",

--- a/src/features/ChatInput/RuntimeConfig/HeteroDeviceSwitcher.tsx
+++ b/src/features/ChatInput/RuntimeConfig/HeteroDeviceSwitcher.tsx
@@ -11,6 +11,7 @@ import {
   CheckIcon,
   ChevronDownIcon,
   CloudIcon,
+  ExternalLinkIcon,
   InfoIcon,
   LaptopIcon,
   MonitorIcon,
@@ -160,6 +161,21 @@ const styles = createStaticStyles(({ css }) => ({
       color: ${cssVar.colorTextSecondary};
     }
   `,
+  headerLink: css`
+    display: flex;
+    gap: 3px;
+    align-items: center;
+
+    font-size: 11px;
+    color: ${cssVar.colorTextQuaternary};
+    text-decoration: none;
+
+    transition: color 0.2s;
+
+    &:hover {
+      color: ${cssVar.colorPrimary};
+    }
+  `,
   headerTitle: css`
     font-size: 12px;
     font-weight: 500;
@@ -293,11 +309,22 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
     <Flexbox gap={2} style={{ maxWidth: 320, minWidth: 280 }}>
       <div className={styles.header}>
         <span className={styles.headerTitle}>{t('heteroAgent.executionTarget.title')}</span>
-        <Tooltip title={t('heteroAgent.executionTarget.infoTooltip')}>
-          <span className={styles.headerInfo}>
-            <Icon icon={InfoIcon} size={12} />
-          </span>
-        </Tooltip>
+        <Flexbox horizontal align={'center'} gap={6}>
+          <a
+            className={styles.headerLink}
+            href="https://lobehub.com/downloads"
+            rel="noreferrer"
+            target="_blank"
+          >
+            <Icon icon={ExternalLinkIcon} size={11} />
+            <span>{t('heteroAgent.executionTarget.downloadDesktop')}</span>
+          </a>
+          <Tooltip title={t('heteroAgent.executionTarget.infoTooltip')}>
+            <span className={styles.headerInfo}>
+              <Icon icon={InfoIcon} size={12} />
+            </span>
+          </Tooltip>
+        </Flexbox>
       </div>
       {isDesktop ? (
         <OptionRow

--- a/src/features/ChatInput/RuntimeConfig/index.tsx
+++ b/src/features/ChatInput/RuntimeConfig/index.tsx
@@ -19,6 +19,8 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
+import { useUserStore } from '@/store/user';
+import { labPreferSelectors } from '@/store/user/selectors';
 
 import ContextWindow from '../ActionBar/Token';
 import { useAgentId } from '../hooks/useAgentId';
@@ -27,6 +29,7 @@ import { useChatInputStore } from '../store';
 import ApprovalMode from './ApprovalMode';
 import CloudRepoSwitcher from './CloudRepoSwitcher';
 import GitStatus from './GitStatus';
+import HeteroDeviceSwitcher from './HeteroDeviceSwitcher';
 import ModeSelector from './ModeSelector';
 import { useRepoType } from './useRepoType';
 import WorkingDirectory from './WorkingDirectory';
@@ -117,6 +120,10 @@ const RuntimeConfig = memo(() => {
     agentId ? agentByIdSelectors.isAgentHeterogeneousById(agentId)(s) : false,
     agentByIdSelectors.getAgentEnableModeById(agentId)(s),
   ]);
+
+  const enableExecutionDeviceSwitcher = useUserStore(
+    labPreferSelectors.enableExecutionDeviceSwitcher,
+  );
 
   const topicWorkingDirectory = useChatStore(topicSelectors.currentTopicWorkingDirectory);
   const agentWorkingDirectory = useAgentStore((s) =>
@@ -285,24 +292,29 @@ const RuntimeConfig = memo(() => {
       {/* Left: Chat mode switcher + (agent-only) runtime env + working directory */}
       <Flexbox horizontal align={'center'} gap={4}>
         <ModeSelector />
+        {enableAgentMode && enableExecutionDeviceSwitcher && agentId && (
+          <HeteroDeviceSwitcher agentId={agentId} />
+        )}
         {enableAgentMode && (
           <>
-            <Popover
-              content={modeContent}
-              open={modePopoverOpen}
-              placement="top"
-              styles={{ content: { padding: 4 } }}
-              trigger="click"
-              onOpenChange={setModePopoverOpen}
-            >
-              <div>
-                {modePopoverOpen ? (
-                  modeButton
-                ) : (
-                  <Tooltip title={t('runtimeEnv.selectMode')}>{modeButton}</Tooltip>
-                )}
-              </div>
-            </Popover>
+            {!enableExecutionDeviceSwitcher && (
+              <Popover
+                content={modeContent}
+                open={modePopoverOpen}
+                placement="top"
+                styles={{ content: { padding: 4 } }}
+                trigger="click"
+                onOpenChange={setModePopoverOpen}
+              >
+                <div>
+                  {modePopoverOpen ? (
+                    modeButton
+                  ) : (
+                    <Tooltip title={t('runtimeEnv.selectMode')}>{modeButton}</Tooltip>
+                  )}
+                </div>
+              </Popover>
+            )}
             {rightContent()}
           </>
         )}

--- a/src/locales/default/chat.ts
+++ b/src/locales/default/chat.ts
@@ -186,6 +186,7 @@ export default {
   'heteroAgent.executionTarget.online': 'Online',
   'heteroAgent.executionTarget.sandbox': 'Cloud sandbox',
   'heteroAgent.executionTarget.sandboxDesc': 'Run in an ephemeral cloud sandbox',
+  'heteroAgent.executionTarget.downloadDesktop': 'Get Desktop App',
   'heteroAgent.executionTarget.title': 'Execution Device',
   'heteroAgent.executionTarget.unknownDevice': 'Unknown device',
   'hideForYou':


### PR DESCRIPTION
## 📋 Summary

- Remove the `!isHeterogeneous` guard from `HeteroDeviceSwitcher` rendering in `RuntimeConfig`, so the execution-device selector is now available for **all agents** (not just non-heterogeneous ones) when the Lab toggle is enabled
- Make the sandbox / runtime-env mode selector **mutually exclusive** with the device switcher: the mode popover is hidden when `enableExecutionDeviceSwitcher` is `true`, since the device switcher covers the same functionality (cloud sandbox + local + remote device)
- Add a **"下载桌面端 / Get Desktop App"** quick link in the execution-device popover header (right side, next to the info tooltip), linking to https://lobehub.com/downloads — makes it easy to discover the desktop app when no remote devices are connected

## 🔄 Behavior

| `enableExecutionDeviceSwitcher` | What shows in the toolbar |
|---|---|
| `false` (default) | Sandbox mode selector (cloud / local / none) — unchanged |
| `true` (Lab opt-in) | Device switcher for **every** agent type; sandbox mode selector hidden |

The `rightContent()` slot (working directory picker, CloudRepoSwitcher) is unaffected and always renders when appropriate.

## 🗂 Files changed

- `src/features/ChatInput/RuntimeConfig/HeteroDeviceSwitcher.tsx` — download link + `headerLink` style + `ExternalLinkIcon`
- `src/features/ChatInput/RuntimeConfig/index.tsx` — removed `!isHeterogeneous`, added `!enableExecutionDeviceSwitcher` guard on mode popover
- `src/locales/default/chat.ts` + `locales/zh-CN/chat.json` + `locales/en-US/chat.json` — new key `heteroAgent.executionTarget.downloadDesktop`

## ✅ Test plan

- [ ] With Lab toggle **off**: sandbox mode selector still renders for all agents
- [ ] With Lab toggle **on**: device switcher shows for a regular agent (non-heterogeneous); sandbox mode popover is hidden
- [ ] With Lab toggle **on**: device switcher shows for a heterogeneous agent in normal chat input
- [ ] Execution-device popover header shows "下载桌面端" / "Get Desktop App" link on the right, clicking opens https://lobehub.com/downloads in a new tab
- [ ] Working directory picker and CloudRepoSwitcher still render correctly regardless of the toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)