### PR TITLE
🐛 fix(topic): strip markdown tokens from fallback titles

### DIFF
--- a/src/server/routers/lambda/thread.ts
+++ b/src/server/routers/lambda/thread.ts
@@ -8,6 +8,7 @@ import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { type ThreadItem } from '@/types/topic/thread';
 import { createThreadSchema } from '@/types/topic/thread';
+import { markdownToTxt } from '@/utils/markdownToTxt';
 
 /**
  * `ThreadModel.create` uses `onConflictDoNothing()` and returns undefined when
@@ -73,7 +74,7 @@ export const threadRouter = router({
           metadata: input.metadata,
           parentThreadId: input.parentThreadId,
           sourceMessageId: input.sourceMessageId,
-          title: input.message.content.slice(0, 80),
+          title: markdownToTxt(input.message.content).slice(0, 80),
           topicId: input.topicId,
           type: input.type,
         }),

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -82,6 +82,7 @@ import type { ConversationHistoryEntry } from '@/server/services/heterogeneousAg
 import { KlavisService } from '@/server/services/klavis';
 import { MarketService } from '@/server/services/market';
 import { deviceProxy } from '@/server/services/toolExecution/deviceProxy';
+import { markdownToTxt } from '@/utils/markdownToTxt';
 
 import { resolveDeviceAccessPolicy } from './deviceAccessPolicy';
 import { buildAllowedBuiltinTools, isDeviceToolIdentifier } from './deviceToolRegistry';
@@ -628,11 +629,14 @@ export class AiAgentService {
             }
           : undefined;
 
+      const fallbackTitleSource = markdownToTxt(prompt);
       const newTopic = await this.topicModel.create({
         agentId: resolvedAgentId,
         metadata,
         title:
-          title !== undefined ? title : prompt.slice(0, 50) + (prompt.length > 50 ? '...' : ''),
+          title !== undefined
+            ? title
+            : fallbackTitleSource.slice(0, 50) + (fallbackTitleSource.length > 50 ? '...' : ''),
         trigger,
       });
       topicId = newTopic.id;
@@ -2358,8 +2362,10 @@ export class AiAgentService {
     // - newTopic is explicitly provided, OR
     // - no topicId is provided (default behavior for group chat)
     if (newTopic || !inputTopicId) {
+      const fallbackTitleSource = markdownToTxt(message);
       const topicTitle =
-        newTopic?.title || message.slice(0, 50) + (message.length > 50 ? '...' : '');
+        newTopic?.title ||
+        fallbackTitleSource.slice(0, 50) + (fallbackTitleSource.length > 50 ? '...' : '');
       const topicItem = await this.topicModel.create({
         agentId,
         groupId,

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -58,6 +58,7 @@ import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { type StoreSetter } from '@/store/types';
 import { useUserMemoryStore } from '@/store/userMemory';
+import { markdownToTxt } from '@/utils/markdownToTxt';
 
 import { dbMessageSelectors, displayMessageSelectors, topicSelectors } from '../../../selectors';
 import { messageMapKey } from '../../../utils/messageMapKey';
@@ -516,7 +517,7 @@ export class ConversationLifecycleActionImpl {
             newTopic: !operationContext.topicId
               ? {
                   metadata: workingDirectory ? { workingDirectory } : undefined,
-                  title: message.slice(0, 80) || t('defaultTitle', { ns: 'topic' }),
+                  title: markdownToTxt(message).slice(0, 80) || t('defaultTitle', { ns: 'topic' }),
                   topicMessageIds: messages.map((m) => m.id),
                 }
               : undefined,
@@ -920,7 +921,7 @@ export class ConversationLifecycleActionImpl {
       }
 
       const firstUserText = messages.find((m) => m.role === 'user')?.content?.trim() ?? '';
-      const title = firstUserText.slice(0, 80) || 'New Topic';
+      const title = markdownToTxt(firstUserText).slice(0, 80) || 'New Topic';
       await this.#get().internal_updateTopic(topicId, { title });
       // summaryTopicTitle would normally clear loading via onLoadingChange; do it manually.
       this.#get().internal_updateTopicLoading(topicId, false);

--- a/src/store/home/slices/homeInput/action.ts
+++ b/src/store/home/slices/homeInput/action.ts
@@ -10,6 +10,7 @@ import { useGlobalStore } from '@/store/global';
 import { useGroupProfileStore } from '@/store/groupProfile';
 import { type HomeStore } from '@/store/home/store';
 import { type StoreSetter } from '@/store/types';
+import { markdownToTxt } from '@/utils/markdownToTxt';
 import { getStableNavigate } from '@/utils/stableNavigate';
 import { setNamespace } from '@/utils/storeDebug';
 
@@ -83,7 +84,7 @@ export class HomeInputActionImpl {
           model,
           provider,
           systemRole: message,
-          title: message?.slice(0, 50) || 'New Agent',
+          title: markdownToTxt(message ?? '').slice(0, 50) || 'New Agent',
         },
         groupId,
       });
@@ -153,7 +154,7 @@ export class HomeInputActionImpl {
           systemPrompt: message,
         },
         groupId,
-        title: message?.slice(0, 50) || 'New Group',
+        title: markdownToTxt(message ?? '').slice(0, 50) || 'New Group',
       });
 
       // 3. Load groups and refresh
@@ -225,7 +226,7 @@ export class HomeInputActionImpl {
       const newDoc = await documentService.createDocument({
         editorData: '{}',
         fileType: 'custom/document',
-        title: message?.slice(0, 50) || 'Untitled',
+        title: markdownToTxt(message ?? '').slice(0, 50) || 'Untitled',
       });
 
       // 3. Navigate to Page


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

When a topic / thread / agent / group / document is first created, the visible title falls back to a slice of the user's raw input until the system agent produces a summarized title. Because that input is markdown, syntax characters (`#`, `**`, ` ``` `, links, etc.) leak into the displayed fallback title.

Run the source string through the existing `markdownToTxt` helper (powered by `remove-markdown`) before slicing, so the fallback is plain text.

Sites updated:

- `src/server/services/aiAgent/index.ts` — `execAgent` and `execGroupAgent` topic creation
- `src/store/chat/slices/aiChat/actions/conversationLifecycle.ts` — hetero agent new-topic title and the dev fast-path
- `src/server/routers/lambda/thread.ts` — thread title
- `src/store/home/slices/homeInput/action.ts` — `sendAsAgent` / `sendAsGroup` / `sendAsWrite` titles

No new dependency — `remove-markdown` is already a project dep and `markdownToTxt` is already used on both server and client.

#### 🧪 How to Test

- Start a new topic with a message that contains markdown syntax, e.g. `# Hello **world**` or a fenced code block. Before LLM summarization completes, the sidebar topic title should show plain text (`Hello world`) rather than the raw markdown tokens.
- Same flow for: hetero agent / dev `NEXT_PUBLIC_DEV_DISABLE_AUTO_TOPIC=1` path, thread creation, and the home-screen `sendAs*` flows.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

N/A — internal text sanitization only.

#### 📝 Additional Information

No breaking changes. Existing behavior is preserved when input contains no markdown.