### PR TITLE
💄 style(sidebar): group spacer with recents and agents

### DIFF
--- a/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
+++ b/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
@@ -168,8 +168,8 @@ const SortableItem = memo<{
 });
 
 // ---------------------------------------------------------------------------
-// SpacerSortableItem — represents the flex spacer slot; draggable like any
-// other item but rendered as a divider with an "Anchor below to bottom" label.
+// SpacerSortableItem — represents the flex spacer slot when it is not bound to
+// the accordion group; draggable like any other item.
 // ---------------------------------------------------------------------------
 
 const SpacerSortableItem = memo(() => {
@@ -204,6 +204,21 @@ const SpacerSortableItem = memo(() => {
       >
         <Icon icon={GripVertical} size={14} style={{ color: cssVar.colorTextQuaternary }} />
       </Flexbox>
+      <Icon icon={ArrowDownToLine} size={14} style={{ color: cssVar.colorTextQuaternary }} />
+      <div className={styles.spacerLine} />
+      <Text style={{ fontSize: 12 }} type={'secondary'}>
+        {t('navPanel.bottomDivider' as any)}
+      </Text>
+      <div className={styles.spacerLine} />
+    </Flexbox>
+  );
+});
+
+const BoundSpacerItem = memo(() => {
+  const { t } = useTranslation('common');
+
+  return (
+    <Flexbox horizontal align={'center'} className={styles.item} gap={8}>
       <Icon icon={ArrowDownToLine} size={14} style={{ color: cssVar.colorTextQuaternary }} />
       <div className={styles.spacerLine} />
       <Text style={{ fontSize: 12 }} type={'secondary'}>
@@ -285,8 +300,12 @@ const OverlayItem = memo<{ id: string }>(({ id }) => {
 // ---------------------------------------------------------------------------
 
 /** Flatten outer list (with ACCORDION_GROUP_ID placeholder) + inner accordion items → full list. */
-const flattenItems = (outer: string[], inner: string[]): string[] =>
-  outer.flatMap((id) => (id === ACCORDION_GROUP_ID ? inner : [id]));
+const flattenItems = (outer: string[], inner: string[], bindSpacerToAccordion: boolean): string[] =>
+  outer.flatMap((id) =>
+    id === ACCORDION_GROUP_ID
+      ? [...inner, ...(bindSpacerToAccordion ? [SIDEBAR_SPACER_ID] : [])]
+      : [id],
+  );
 
 const CustomizeSidebarContent = memo(() => {
   const [storeItems, hiddenSections, updateSystemStatus] = useGlobalStore((s) => [
@@ -305,10 +324,13 @@ const CustomizeSidebarContent = memo(() => {
   }, [storeItems]);
 
   // Derive outer (with group placeholder) and inner (accordion items)
-  const { innerItems, outerItems } = useMemo(() => {
+  const { bindSpacerToAccordion, innerItems, outerItems } = useMemo(() => {
+    const hasAccordion = items.some(isAccordionKey);
+    const shouldBindSpacer = hasAccordion && items.includes(SIDEBAR_SPACER_ID);
     const outer: string[] = [];
     const inner: string[] = [];
     let insertedGroup = false;
+
     for (const id of items) {
       if (isAccordionKey(id)) {
         inner.push(id);
@@ -316,11 +338,14 @@ const CustomizeSidebarContent = memo(() => {
           outer.push(ACCORDION_GROUP_ID);
           insertedGroup = true;
         }
+      } else if (isSpacer(id) && shouldBindSpacer) {
+        continue;
       } else {
         outer.push(id);
       }
     }
-    return { innerItems: inner, outerItems: outer };
+
+    return { bindSpacerToAccordion: shouldBindSpacer, innerItems: inner, outerItems: outer };
   }, [items]);
 
   const sensors = useSensors(
@@ -374,19 +399,27 @@ const CustomizeSidebarContent = memo(() => {
         const oldIdx = innerItems.indexOf(activeKey);
         const newIdx = innerItems.indexOf(overKey);
         if (oldIdx === -1 || newIdx === -1) return;
-        next = flattenItems(outerItems, arrayMove(innerItems, oldIdx, newIdx));
+        next = flattenItems(
+          outerItems,
+          arrayMove(innerItems, oldIdx, newIdx),
+          bindSpacerToAccordion,
+        );
       } else {
         // Outer reorder (pages/community/... or the whole accordion group)
         const oldIdx = outerItems.indexOf(activeKey);
         const newIdx = outerItems.indexOf(overKey);
         if (oldIdx === -1 || newIdx === -1) return;
-        next = flattenItems(arrayMove(outerItems, oldIdx, newIdx), innerItems);
+        next = flattenItems(
+          arrayMove(outerItems, oldIdx, newIdx),
+          innerItems,
+          bindSpacerToAccordion,
+        );
       }
 
       setItems(next);
       updateSystemStatus({ sidebarItems: next });
     },
-    [innerItems, outerItems, updateSystemStatus],
+    [bindSpacerToAccordion, innerItems, outerItems, updateSystemStatus],
   );
 
   const handleDragCancel = useCallback(() => {
@@ -417,6 +450,7 @@ const CustomizeSidebarContent = memo(() => {
                 <SortableContext items={innerItems} strategy={verticalListSortingStrategy}>
                   {innerItems.map(renderItem)}
                 </SortableContext>
+                {bindSpacerToAccordion && <BoundSpacerItem />}
               </AccordionGroup>
             ) : (
               renderItem(id)


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Groups the sidebar bottom spacer with the recents and agents accordion block in `CustomizeSidebarModal`.
- Keeps the persisted sidebar order flat by writing `recents` / `agent` followed by `__spacer__` when the accordion group is reordered.
- Preserves the previous independent spacer behavior when no accordion group is present.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Commands run:

- `bunx vitest run --silent='passed-only' 'src/routes/(main)/home/_layout/Body/index.test.tsx'` — passed, 4 tests.
- `bunx eslint 'src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx'` — passed.
- `git diff --check origin/canary..HEAD` — passed.
- `bun run type-check` — failed on existing `src/server/services/push/*` errors around missing `expo-server-sdk` types and downstream inferred types; no error references this PR file.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

The branch was created from the current `origin/canary` tip and contains one commit:

- `085b2e8410 💄 style(sidebar): group spacer with recents and agents`