### PR TITLE
✅ test(hetero-agent): use canonical usage fields in persistence fixtures

### DIFF
--- a/src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.eventBranches.test.ts
+++ b/src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.eventBranches.test.ts
@@ -198,7 +198,7 @@ describe('HeterogeneousPersistenceHandler — event branch coverage', () => {
   describe('step_complete', () => {
     it('phase=turn_metadata with usage writes assistant.metadata.usage and caches model/provider', async () => {
       const h = createHarness();
-      const usage = { inputTokens: 100, outputTokens: 50 };
+      const usage = { totalInputTokens: 100, totalOutputTokens: 50, totalTokens: 150 };
 
       await ingest(h, [
         buildEvent('step_complete', 0, {

--- a/src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.fixture.test.ts
+++ b/src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.fixture.test.ts
@@ -120,7 +120,11 @@ const buildSyntheticStream = (): AgentStreamEvent[] => {
       model: 'claude-opus-4-7',
       phase: 'turn_metadata',
       provider: 'claude-code',
-      usage: { inputTokens: 100 + step, outputTokens: 50 + step },
+      usage: {
+        totalInputTokens: 100 + step,
+        totalOutputTokens: 50 + step,
+        totalTokens: 150 + 2 * step,
+      },
     });
 
     stepIndex += 1;

--- a/src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts
+++ b/src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts
@@ -437,7 +437,7 @@ describe('HeterogeneousPersistenceHandler', () => {
 
       const evt = buildEvent('step_complete', 0, {
         phase: 'turn_metadata',
-        usage: { inputTokens: 1 },
+        usage: { totalInputTokens: 1, totalOutputTokens: 0, totalTokens: 1 },
       });
 
       // First attempt: handler throws.
@@ -451,7 +451,9 @@ describe('HeterogeneousPersistenceHandler', () => {
       await h.handler.ingest({ events: [evt], operationId: 'op-1', topicId: 'topic-1' });
 
       const asst = h.messages.get('asst-1')!;
-      expect(asst.metadata).toEqual({ usage: { inputTokens: 1 } });
+      expect(asst.metadata).toEqual({
+        usage: { totalInputTokens: 1, totalOutputTokens: 0, totalTokens: 1 },
+      });
     });
   });
 
@@ -704,7 +706,7 @@ describe('HeterogeneousPersistenceHandler', () => {
             model: 'claude-sonnet-4-6',
             phase: 'turn_metadata',
             provider: 'claude-code',
-            usage: { inputTokens: 10, outputTokens: 5 },
+            usage: { totalInputTokens: 10, totalOutputTokens: 5, totalTokens: 15 },
           }),
         ],
         operationId: 'op-1',
@@ -715,7 +717,7 @@ describe('HeterogeneousPersistenceHandler', () => {
       // carry model/provider so a replica picking up the next step boundary
       // can read them back from DB even if it never drained this event.
       expect(h.messageModel.update).toHaveBeenCalledWith('asst-init', {
-        metadata: { usage: { inputTokens: 10, outputTokens: 5 } },
+        metadata: { usage: { totalInputTokens: 10, totalOutputTokens: 5, totalTokens: 15 } },
         model: 'claude-sonnet-4-6',
         provider: 'claude-code',
       });


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✅ test

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

The `HeterogeneousPersistenceHandler` tests seeded `metadata.usage` as `{ inputTokens, outputTokens }` — a shape the het adapters **never** emit. Both `claudeCode.ts` and `codex.ts` build the canonical `UsageData` (`totalInputTokens` / `totalOutputTokens` / `totalTokens` + cache fields) via `toUsageData()`, and `handleTurnMetadata` persists that unchanged. So production Claude Code / Codex messages already carry canonical fields, and the topic usage/cost rollup sums them correctly.

The unrealistic alias fixtures made it look like the rollup would store `total_* = 0` for Claude Code / Codex topics (and pick the wrong dominant model). This is purely a **test-fixture fidelity** issue — production was already correct. This PR aligns the fixtures with real adapter output so the tests reflect reality and don't mislead future reviewers.

No production code changed.

Updated fixtures in:
- `HeterogeneousPersistenceHandler.test.ts`
- `HeterogeneousPersistenceHandler.eventBranches.test.ts`
- `HeterogeneousPersistenceHandler.fixture.test.ts`

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

\`\`\`
bunx vitest run 'src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts' \
  'src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.eventBranches.test.ts' \
  'src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.fixture.test.ts'
# → 61 passed
\`\`\`

#### 📝 Additional Information

No runtime/behavior change; touches test fixtures only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)