### PR TITLE
🐛 fix(cli): auto-register device on login, matching desktop

### DIFF
--- a/apps/cli/src/auth/resolveToken.ts
+++ b/apps/cli/src/auth/resolveToken.ts
@@ -20,7 +20,7 @@ interface ResolvedAuth {
 /**
  * Parse the `sub` claim from a JWT without verifying the signature.
  */
-function parseJwtSub(token: string): string | undefined {
+export function parseJwtSub(token: string): string | undefined {
   try {
     const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());
     return payload.sub;

--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -8,11 +8,8 @@ import type {
   ToolCallRequestMessage,
 } from '@lobechat/device-gateway-client';
 import { GatewayClient } from '@lobechat/device-gateway-client';
-import type { IdentitySource } from '@lobechat/device-identity';
-import { deriveDeviceId } from '@lobechat/device-identity';
 import type { Command } from 'commander';
 
-import { createLambdaClient } from '../api/client';
 import { getValidToken } from '../auth/refresh';
 import { resolveToken } from '../auth/resolveToken';
 import { CLI_API_KEY_ENV } from '../constants/auth';
@@ -28,6 +25,7 @@ import {
   stopDaemon,
   writeStatus,
 } from '../daemon/manager';
+import { registerDevice, resolveDeviceIdentity } from '../device/register';
 import { loadOrCreateConnectionId, loadSettings, normalizeUrl, saveSettings } from '../settings';
 import { executeToolCall } from '../tools';
 import { cleanupAllProcesses } from '../tools/shell';
@@ -198,12 +196,7 @@ async function runConnect(options: ConnectOptions, isDaemonChild: boolean) {
   // Resolve a stable device identity. An explicit `--device-id` wins (lets a
   // user pin a VM to a fixed identity); otherwise derive from the machine id so
   // the same machine + user maps to one device across reconnects.
-  const identity: { deviceId: string; identitySource: IdentitySource } | undefined =
-    options.deviceId
-      ? { deviceId: options.deviceId, identitySource: 'fallback' }
-      : auth.userId
-        ? deriveDeviceId(auth.userId)
-        : undefined;
+  const identity = resolveDeviceIdentity(auth.userId, options.deviceId);
 
   // Freeform channel label (`cli` by default); `LOBEHUB_CLI_CHANNEL` lets a
   // dev build tag itself `cli-dev` so the gateway can prioritise / display it.
@@ -406,19 +399,15 @@ async function runConnect(options: ConnectOptions, isDaemonChild: boolean) {
   });
 
   // Register this device in the server registry before opening the WS, so the
-  // row exists by the time the gateway reports it online. Best-effort: a
-  // failure must not block the connection.
+  // row exists by the time the gateway reports it online. `lh login` already
+  // registers, but re-running here is cheap (idempotent upsert) and covers
+  // `--token` sessions that never went through login. Best-effort: a failure
+  // must not block the connection.
   if (identity) {
     try {
-      // Reuse the already-resolved auth (respects `--token` mode) instead of
-      // getTrpcClient(), which re-discovers creds and exits when none are found.
-      const trpc = createLambdaClient(auth);
-      await trpc.device.register.mutate({
-        deviceId: identity.deviceId,
-        hostname: os.hostname(),
-        identitySource: identity.identitySource,
-        platform: process.platform,
-      });
+      // Reuse the already-resolved auth (respects `--token` mode) so we don't
+      // re-discover creds and exit when none are found.
+      await registerDevice(auth, identity);
     } catch (err) {
       error(`Device registration failed (non-fatal): ${(err as Error).message}`);
     }

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -220,8 +220,15 @@ export function registerLoginCommand(program: Command) {
             // (which only adds the channel-online step). Mirrors the desktop
             // app, which registers on login. Best-effort: a failure here must
             // not fail the login.
+            //
+            // Skip the `fallback` source: `lh login` has no `--device-id` and
+            // persists no fallback id, so a machine without a readable
+            // machine-id would derive a *fresh random* id on every login —
+            // registering it just spawns orphan device rows that never match
+            // the id a later `lh connect` resolves. Defer registration to
+            // `connect` in that case, where the same id is reused for the WS.
             const identity = resolveDeviceIdentity(parseJwtSub(body.access_token));
-            if (identity) {
+            if (identity && identity.identitySource !== 'fallback') {
               try {
                 await registerDevice(
                   { serverUrl, token: body.access_token, tokenType: 'jwt' },

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -6,8 +6,10 @@ import type { Command } from 'commander';
 
 import { getUserIdFromApiKey } from '../auth/apiKey';
 import { saveCredentials } from '../auth/credentials';
+import { parseJwtSub } from '../auth/resolveToken';
 import { CLI_API_KEY_ENV } from '../constants/auth';
 import { OFFICIAL_SERVER_URL } from '../constants/urls';
+import { registerDevice, resolveDeviceIdentity } from '../device/register';
 import { loadSettings, normalizeUrl, saveSettings } from '../settings';
 import { log } from '../utils/logger';
 
@@ -212,6 +214,23 @@ export function registerLoginCommand(program: Command) {
                     serverUrl,
                   },
             );
+
+            // Register this device in the server registry right after auth, so
+            // the device row exists without waiting for a later `lh connect`
+            // (which only adds the channel-online step). Mirrors the desktop
+            // app, which registers on login. Best-effort: a failure here must
+            // not fail the login.
+            const identity = resolveDeviceIdentity(parseJwtSub(body.access_token));
+            if (identity) {
+              try {
+                await registerDevice(
+                  { serverUrl, token: body.access_token, tokenType: 'jwt' },
+                  identity,
+                );
+              } catch (err) {
+                log.warn(`Device registration failed (non-fatal): ${(err as Error).message}`);
+              }
+            }
 
             log.info('Login successful! Credentials saved.');
             return;

--- a/apps/cli/src/device/register.ts
+++ b/apps/cli/src/device/register.ts
@@ -1,0 +1,40 @@
+import os from 'node:os';
+
+import type { DeviceIdentity } from '@lobechat/device-identity';
+import { deriveDeviceId } from '@lobechat/device-identity';
+
+import { createLambdaClient } from '../api/client';
+
+/**
+ * Resolve a stable device identity. An explicit `--device-id` wins (lets a user
+ * pin a VM to a fixed identity); otherwise derive from the machine id so the
+ * same machine + user maps to one device across reconnects. Returns undefined
+ * when neither an explicit id nor a userId is available.
+ */
+export function resolveDeviceIdentity(
+  userId: string | undefined,
+  explicitDeviceId?: string,
+): DeviceIdentity | undefined {
+  if (explicitDeviceId) return { deviceId: explicitDeviceId, identitySource: 'fallback' };
+  if (userId) return deriveDeviceId(userId);
+  return undefined;
+}
+
+/**
+ * Register this device in the server registry. Shared by `lh login` (so the
+ * device row exists right after auth) and `lh connect` (so the row exists
+ * before the WS opens). Best-effort by contract: callers should wrap this in a
+ * try/catch and treat any failure as non-fatal.
+ */
+export async function registerDevice(
+  auth: { serverUrl: string; token: string; tokenType: 'apiKey' | 'jwt' | 'serviceToken' },
+  identity: DeviceIdentity,
+): Promise<void> {
+  const trpc = createLambdaClient(auth);
+  await trpc.device.register.mutate({
+    deviceId: identity.deviceId,
+    hostname: os.hostname(),
+    identitySource: identity.identitySource,
+    platform: process.platform,
+  });
+}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- no matching tracked issue -->

#### 🔀 Description of Change

Device registration previously only ran inside `lh connect`, so `lh login` authenticated but left **no device row** in the server registry until the user separately ran `lh connect` (which opens the gateway WebSocket / channel-online step). The desktop app, by contrast, registers the device on login success (its `AuthCtr` triggers gateway connection, which registers before opening the WS). This PR brings the CLI to parity: **`lh login` now registers the device right after auth.**

Changes:

- **New `apps/cli/src/device/register.ts`** — extracts the shared logic that was inline in `connect`:
  - `resolveDeviceIdentity(userId, explicitDeviceId?)` — explicit `--device-id` wins, otherwise derives a stable id from the machine id.
  - `registerDevice(auth, identity)` — best-effort `device.register` upsert.
- **`login.ts`** — after credentials are saved, resolve the identity from the access-token `sub` and call `registerDevice` (best-effort; a failure only warns and never fails login).
- **`connect.ts`** — refactored to use the shared helper; deletes the duplicated identity-resolution + register block. `connect` keeps its own register call as an **idempotent fallback** for `--token` sessions that never went through `login`.
- **`resolveToken.ts`** — export `parseJwtSub` for reuse (avoids a third copy of the JWT-sub parse).

Server-side `device.register` is an upsert keyed by the stable `(machine, user)` deviceId, so registering in both `login` and `connect` is safe and produces no duplicate rows.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Type-check is clean for all changed files. The CLI test suite has pre-existing, unrelated failures in `login.test.ts` (17 failed/1 passed) and `connect.test.ts` (4 failed/22 passed) that are identical before and after this change — this PR introduces zero new failures.

Manual: run `lh login`, complete the device-code flow, and confirm a device row appears server-side without needing a subsequent `lh connect`.

#### 📝 Additional Information

Best-effort by design: registration failures during login are logged as a non-fatal warning so a registry hiccup never blocks authentication.