### PR TITLE
🐛 fix: default provider setup in business mode

### DIFF
--- a/src/server/globalConfig/genServerAiProviderConfig.ts
+++ b/src/server/globalConfig/genServerAiProviderConfig.ts
@@ -6,7 +6,7 @@ import { loadModels } from '@/business/client/model-bank/loadModels';
 import { getLLMConfig } from '@/envs/llm';
 import { extractEnabledModels, transformToAiModelList } from '@/utils/server/parseModels';
 
-interface ProviderSpecificConfig {
+export interface ProviderSpecificConfig {
   enabled?: boolean;
   enabledKey?: string;
   fetchOnClient?: boolean;

--- a/src/server/globalConfig/getServerGlobalConfig.test.ts
+++ b/src/server/globalConfig/getServerGlobalConfig.test.ts
@@ -1,0 +1,140 @@
+import { ModelProvider } from 'model-bank';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+interface CapturedProviderConfig {
+  enabled?: boolean;
+  enabledKey?: string;
+  fetchOnClient?: boolean;
+  modelListKey?: string;
+  withDeploymentName?: boolean;
+}
+
+const mocks = vi.hoisted(() => ({
+  genServerAiProvidersConfig: vi.fn(async () => ({})),
+}));
+
+const mockGlobalConfigDependencies = (enableBusinessFeatures: boolean) => {
+  vi.doMock('@lobechat/business-const', () => ({
+    ENABLE_BUSINESS_FEATURES: enableBusinessFeatures,
+  }));
+
+  vi.doMock('@/config/klavis', () => ({
+    klavisEnv: {},
+  }));
+
+  vi.doMock('@/const/version', () => ({
+    isDesktop: false,
+  }));
+
+  vi.doMock('@/envs/app', () => ({
+    appEnv: {},
+    getAppConfig: vi.fn(() => ({
+      DEFAULT_AGENT_CONFIG: '',
+    })),
+  }));
+
+  vi.doMock('@/envs/auth', () => ({
+    authEnv: {
+      AUTH_DISABLE_EMAIL_PASSWORD: false,
+      AUTH_EMAIL_VERIFICATION: false,
+      AUTH_ENABLE_MAGIC_LINK: false,
+      AUTH_SSO_PROVIDERS: '',
+    },
+  }));
+
+  vi.doMock('@/envs/file', () => ({
+    fileEnv: {},
+  }));
+
+  vi.doMock('@/envs/image', () => ({
+    imageEnv: {
+      AI_IMAGE_DEFAULT_IMAGE_NUM: undefined,
+    },
+  }));
+
+  vi.doMock('@/envs/knowledge', () => ({
+    knowledgeEnv: {
+      DEFAULT_FILES_CONFIG: undefined,
+    },
+  }));
+
+  vi.doMock('@/envs/langfuse', () => ({
+    langfuseEnv: {
+      ENABLE_LANGFUSE: false,
+    },
+  }));
+
+  vi.doMock('@/envs/tools', () => ({
+    toolsEnv: {},
+  }));
+
+  vi.doMock('@/libs/better-auth/utils/server', () => ({
+    parseSSOProviders: vi.fn(() => []),
+  }));
+
+  vi.doMock('@/server/globalConfig/parseSystemAgent', () => ({
+    parseSystemAgent: vi.fn(() => undefined),
+  }));
+
+  vi.doMock('@/utils/object', () => ({
+    cleanObject: vi.fn((object) => object),
+  }));
+
+  vi.doMock('./genServerAiProviderConfig', () => ({
+    genServerAiProvidersConfig: mocks.genServerAiProvidersConfig,
+  }));
+
+  vi.doMock('./parseDefaultAgent', () => ({
+    parseAgentConfig: vi.fn(() => ({})),
+  }));
+
+  vi.doMock('./parseFilesConfig', () => ({
+    parseFilesConfig: vi.fn(() => ({})),
+  }));
+
+  vi.doMock('./parseMemoryExtractionConfig', () => ({
+    getPublicMemoryExtractionConfig: vi.fn(() => ({})),
+  }));
+};
+
+const loadCapturedProviderConfig = async (enableBusinessFeatures: boolean) => {
+  vi.resetModules();
+  mocks.genServerAiProvidersConfig.mockClear();
+  mockGlobalConfigDependencies(enableBusinessFeatures);
+
+  const { getServerGlobalConfig } = await import('./index');
+  await getServerGlobalConfig();
+
+  return mocks.genServerAiProvidersConfig.mock.calls[0][0] as Record<
+    string,
+    CapturedProviderConfig
+  >;
+};
+
+describe('getServerGlobalConfig', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should only enable LobeHub by default in business feature mode', async () => {
+    const providerConfig = await loadCapturedProviderConfig(true);
+
+    expect(providerConfig[ModelProvider.LobeHub].enabled).toBe(true);
+    expect(providerConfig[ModelProvider.DeepSeek].enabled).toBe(false);
+    expect(providerConfig[ModelProvider.Ollama].fetchOnClient).toBe(true);
+
+    for (const provider of Object.values(ModelProvider)) {
+      if (provider === ModelProvider.LobeHub) continue;
+
+      expect(providerConfig[provider].enabled).toBe(false);
+    }
+  });
+
+  it('should keep upstream defaults outside business feature mode', async () => {
+    const providerConfig = await loadCapturedProviderConfig(false);
+
+    expect(providerConfig[ModelProvider.LobeHub]).toBeUndefined();
+    expect(providerConfig[ModelProvider.OpenAI]).toBeUndefined();
+    expect(providerConfig[ModelProvider.DeepSeek].enabled).toBe(true);
+  });
+});

--- a/src/server/globalConfig/getServerGlobalConfig.test.ts
+++ b/src/server/globalConfig/getServerGlobalConfig.test.ts
@@ -10,7 +10,9 @@ interface CapturedProviderConfig {
 }
 
 const mocks = vi.hoisted(() => ({
-  genServerAiProvidersConfig: vi.fn(async () => ({})),
+  genServerAiProvidersConfig: vi.fn(
+    async (_specificConfig: Record<string, CapturedProviderConfig>) => ({}),
+  ),
 }));
 
 const mockGlobalConfigDependencies = (enableBusinessFeatures: boolean) => {

--- a/src/server/globalConfig/index.ts
+++ b/src/server/globalConfig/index.ts
@@ -1,4 +1,5 @@
 import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
+import { ModelProvider } from 'model-bank';
 
 import { klavisEnv } from '@/config/klavis';
 import { isDesktop } from '@/const/version';
@@ -14,7 +15,10 @@ import { parseSystemAgent } from '@/server/globalConfig/parseSystemAgent';
 import { type GlobalServerConfig } from '@/types/serverConfig';
 import { cleanObject } from '@/utils/object';
 
-import { genServerAiProvidersConfig } from './genServerAiProviderConfig';
+import {
+  genServerAiProvidersConfig,
+  type ProviderSpecificConfig,
+} from './genServerAiProviderConfig';
 import { parseAgentConfig } from './parseDefaultAgent';
 import { parseFilesConfig } from './parseFilesConfig';
 import { getPublicMemoryExtractionConfig } from './parseMemoryExtractionConfig';
@@ -30,63 +34,70 @@ const getBetterAuthSSOProviders = () => {
 export const getServerGlobalConfig = async () => {
   const { DEFAULT_AGENT_CONFIG } = getAppConfig();
 
+  const aiProviderSpecificConfig: Record<string, ProviderSpecificConfig> = {
+    azure: {
+      enabledKey: 'ENABLED_AZURE_OPENAI',
+      withDeploymentName: true,
+    },
+    azureai: {
+      withDeploymentName: true,
+    },
+    bedrock: {
+      enabledKey: 'ENABLED_AWS_BEDROCK',
+      modelListKey: 'AWS_BEDROCK_MODEL_LIST',
+    },
+    deepseek: {
+      enabled: true,
+    },
+    giteeai: {
+      enabledKey: 'ENABLED_GITEE_AI',
+      modelListKey: 'GITEE_AI_MODEL_LIST',
+    },
+    kimicodingplan: {
+      withDeploymentName: true,
+    },
+    lmstudio: {
+      fetchOnClient: isDesktop ? false : undefined,
+    },
+    ollama: {
+      enabled: isDesktop ? true : undefined,
+      fetchOnClient: isDesktop ? false : !process.env.OLLAMA_PROXY_URL,
+    },
+    ollamacloud: {
+      enabledKey: 'ENABLED_OLLAMA_CLOUD',
+    },
+    qwen: {
+      withDeploymentName: true,
+    },
+    spark: {
+      withDeploymentName: true,
+    },
+    tencentcloud: {
+      enabledKey: 'ENABLED_TENCENT_CLOUD',
+      modelListKey: 'TENCENT_CLOUD_MODEL_LIST',
+    },
+    volcengine: {
+      withDeploymentName: true,
+    },
+    volcenginecodingplan: {
+      withDeploymentName: true,
+    },
+  };
+
+  // In business feature mode, keep the built-in provider as the only default-enabled
+  // provider while preserving provider-specific metadata such as fetch/model-list keys.
+  // Non-business builds keep the upstream defaults.
+  if (ENABLE_BUSINESS_FEATURES) {
+    for (const provider of Object.values(ModelProvider)) {
+      aiProviderSpecificConfig[provider] = {
+        ...aiProviderSpecificConfig[provider],
+        enabled: provider === ModelProvider.LobeHub,
+      };
+    }
+  }
+
   const config: GlobalServerConfig = {
-    aiProvider: await genServerAiProvidersConfig({
-      ...(ENABLE_BUSINESS_FEATURES
-        ? {
-            lobehub: {
-              enabled: true,
-            },
-          }
-        : {}),
-      azure: {
-        enabledKey: 'ENABLED_AZURE_OPENAI',
-        withDeploymentName: true,
-      },
-      azureai: {
-        withDeploymentName: true,
-      },
-      bedrock: {
-        enabledKey: 'ENABLED_AWS_BEDROCK',
-        modelListKey: 'AWS_BEDROCK_MODEL_LIST',
-      },
-      deepseek: {
-        enabled: true,
-      },
-      giteeai: {
-        enabledKey: 'ENABLED_GITEE_AI',
-        modelListKey: 'GITEE_AI_MODEL_LIST',
-      },
-      kimicodingplan: {
-        withDeploymentName: true,
-      },
-      lmstudio: {
-        fetchOnClient: isDesktop ? false : undefined,
-      },
-      ollama: {
-        enabled: isDesktop ? true : undefined,
-        fetchOnClient: isDesktop ? false : !process.env.OLLAMA_PROXY_URL,
-      },
-      ollamacloud: {
-        enabledKey: 'ENABLED_OLLAMA_CLOUD',
-      },
-      qwen: {
-        withDeploymentName: true,
-      },
-      spark: {
-        withDeploymentName: true,
-      },
-      tencentcloud: {
-        enabledKey: 'ENABLED_TENCENT_CLOUD',
-        modelListKey: 'TENCENT_CLOUD_MODEL_LIST',
-      },
-      volcengine: {
-        withDeploymentName: true,
-      },
-      volcenginecodingplan: {
-        withDeploymentName: true,
-      },
-    }),
+    aiProvider: await genServerAiProvidersConfig(aiProviderSpecificConfig),
     defaultAgent: {
       config: parseAgentConfig(DEFAULT_AGENT_CONFIG),
     },


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Default only the LobeHub provider to enabled when business features are enabled.
- Preserve provider-specific metadata such as deployment-name and model-list options when applying the default enabled state.
- Add regression coverage for business-feature provider defaults and upstream defaults outside business-feature mode.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/server/globalConfig/index.test.ts' 'src/server/globalConfig/getServerGlobalConfig.test.ts' 'src/server/globalConfig/genServerAiProviderConfig.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This changes server-side provider defaults only. User-saved provider settings continue to be merged by the existing AI provider repository logic.
