### PR TITLE
✨ feat: support MiniMax M3 Anthropic video runtime

### DIFF
--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
@@ -1073,6 +1073,38 @@ describe('createRouterRuntime', () => {
       expect(mockCreateVideo).toHaveBeenCalledWith(payload);
       expect(onRouteAttempt).toHaveBeenCalledWith(expect.objectContaining({ metadata }));
     });
+
+    it('should delegate video polling to the matched runtime', async () => {
+      const mockHandlePollVideoStatus = vi.fn().mockResolvedValue({
+        status: 'success',
+        videoUrl: 'https://example.com/video.mp4',
+      });
+
+      class MockRuntime implements LobeRuntimeAI {
+        handlePollVideoStatus = mockHandlePollVideoStatus;
+      }
+
+      const Runtime = createRouterRuntime({
+        id: 'test-runtime',
+        routers: [
+          {
+            apiType: 'openai',
+            options: {},
+            runtime: MockRuntime as any,
+          },
+        ],
+      });
+
+      const runtime = new Runtime();
+
+      const result = await runtime.handlePollVideoStatus('job-1');
+
+      expect(result).toEqual({
+        status: 'success',
+        videoUrl: 'https://example.com/video.mp4',
+      });
+      expect(mockHandlePollVideoStatus).toHaveBeenCalledWith('job-1');
+    });
   });
 
   describe('generateObject method', () => {

--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
@@ -695,6 +695,22 @@ export const createRouterRuntime = ({
       );
     }
 
+    async handlePollVideoStatus(inferenceId: string) {
+      const resolvedRouters = await this.resolveRouters();
+      const matchedRouter = this._options.baseURL
+        ? (resolvedRouters.find((router) => router.baseURLPattern?.test(this._options.baseURL!)) ??
+          resolvedRouters.at(-1)!)
+        : resolvedRouters.at(-1)!;
+      const routerOptions = this.normalizeRouterOptions(matchedRouter);
+      const { runtime } = await this.createRuntimeFromOption(matchedRouter, routerOptions[0]);
+
+      if (!runtime.handlePollVideoStatus) {
+        throw new Error('Video polling is not supported by the matched runtime');
+      }
+
+      return runtime.handlePollVideoStatus(inferenceId);
+    }
+
     async handleCreateVideoWebhook(payload: HandleCreateVideoWebhookPayload) {
       const model = (payload.body as any)?.model;
       const resolvedRouters = await this.resolveRouters(model);

--- a/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
@@ -242,12 +242,6 @@ describe('anthropicHelpers', () => {
     });
 
     it('should pass MiniMax file references as Anthropic-compatible video URL sources', async () => {
-      vi.mocked(parseDataUri).mockReturnValueOnce({
-        mimeType: null,
-        base64: null,
-        type: 'url',
-      });
-
       const content = {
         type: 'video_url',
         video_url: { url: 'mm_file://file_123' },
@@ -255,6 +249,7 @@ describe('anthropicHelpers', () => {
 
       const result = await buildAnthropicBlock(content);
 
+      expect(parseDataUri).not.toHaveBeenCalled();
       expect(result).toEqual({
         source: {
           type: 'url',

--- a/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.test.ts
@@ -142,7 +142,7 @@ describe('anthropicHelpers', () => {
       vi.mocked(parseDataUri).mockReturnValueOnce({
         mimeType: null,
         base64: null,
-        // @ts-ignore
+        // @ts-expect-error test invalid parser branch
         type: 'invalid',
       });
 
@@ -191,6 +191,94 @@ describe('anthropicHelpers', () => {
       const result = await buildAnthropicBlock(content);
       expect(imageUrlToBase64).toHaveBeenCalledWith(content.image_url.url);
       expect(result).toBeUndefined();
+    });
+
+    it('should transform a video data URL into an Anthropic-compatible video block', async () => {
+      vi.mocked(parseDataUri).mockReturnValueOnce({
+        mimeType: 'video/mp4',
+        base64: 'videoBase64String',
+        type: 'base64',
+      });
+
+      const content = {
+        type: 'video_url',
+        video_url: { url: 'data:video/mp4;base64,videoBase64String' },
+      } as const;
+
+      const result = await buildAnthropicBlock(content);
+
+      expect(parseDataUri).toHaveBeenCalledWith(content.video_url.url);
+      expect(result).toEqual({
+        source: {
+          data: 'videoBase64String',
+          media_type: 'video/mp4',
+          type: 'base64',
+        },
+        type: 'video',
+      });
+    });
+
+    it('should transform a video URL into an Anthropic-compatible URL source block', async () => {
+      vi.mocked(parseDataUri).mockReturnValueOnce({
+        mimeType: null,
+        base64: null,
+        type: 'url',
+      });
+
+      const content = {
+        type: 'video_url',
+        video_url: { url: 'https://example.com/video.mp4' },
+      } as const;
+
+      const result = await buildAnthropicBlock(content);
+
+      expect(result).toEqual({
+        source: {
+          type: 'url',
+          url: 'https://example.com/video.mp4',
+        },
+        type: 'video',
+      });
+    });
+
+    it('should pass MiniMax file references as Anthropic-compatible video URL sources', async () => {
+      vi.mocked(parseDataUri).mockReturnValueOnce({
+        mimeType: null,
+        base64: null,
+        type: 'url',
+      });
+
+      const content = {
+        type: 'video_url',
+        video_url: { url: 'mm_file://file_123' },
+      } as const;
+
+      const result = await buildAnthropicBlock(content);
+
+      expect(result).toEqual({
+        source: {
+          type: 'url',
+          url: 'mm_file://file_123',
+        },
+        type: 'video',
+      });
+    });
+
+    it('should throw an error for invalid video URLs', async () => {
+      vi.mocked(parseDataUri).mockReturnValueOnce({
+        mimeType: null,
+        base64: null,
+        type: null,
+      });
+
+      const content = {
+        type: 'video_url',
+        video_url: { url: 'invalid-video-url' },
+      } as const;
+
+      await expect(buildAnthropicBlock(content)).rejects.toThrow(
+        'Invalid video URL: invalid-video-url',
+      );
     });
   });
 

--- a/packages/model-runtime/src/core/contextBuilders/anthropic.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.ts
@@ -13,8 +13,25 @@ const ANTHROPIC_SUPPORTED_IMAGE_TYPES = new Set([
   'image/webp',
 ]);
 
+interface AnthropicVideoBlockParam {
+  source:
+    | {
+        data: string;
+        media_type: string;
+        type: 'base64';
+      }
+    | {
+        type: 'url';
+        url: string;
+      };
+  type: 'video';
+}
+
 const isImageTypeSupported = (mimeType: string | null | undefined): mimeType is string =>
   !!mimeType && ANTHROPIC_SUPPORTED_IMAGE_TYPES.has(mimeType.toLowerCase());
+
+const isVideoTypeSupported = (mimeType: string | null | undefined): mimeType is string =>
+  !!mimeType && mimeType.toLowerCase().startsWith('video/');
 
 /**
  * Check if a text value contains visible (non-whitespace) characters.
@@ -24,7 +41,9 @@ const hasVisibleText = (text: string | null | undefined): text is string => !!te
 
 export const buildAnthropicBlock = async (
   content: UserMessageContentPart,
-): Promise<Anthropic.ContentBlock | Anthropic.ImageBlockParam | undefined> => {
+): Promise<
+  Anthropic.ContentBlock | Anthropic.ImageBlockParam | AnthropicVideoBlockParam | undefined
+> => {
   switch (content.type) {
     case 'thinking': {
       // just pass-through the content
@@ -71,6 +90,37 @@ export const buildAnthropicBlock = async (
       }
 
       throw new Error(`Invalid image URL: ${content.image_url.url}`);
+    }
+
+    case 'video_url': {
+      // MiniMax M3's Anthropic-compatible API accepts video content blocks, while
+      // the upstream Anthropic SDK types do not expose a video block param yet.
+      const { mimeType, base64, type } = parseDataUri(content.video_url.url);
+
+      if (type === 'base64') {
+        if (!isVideoTypeSupported(mimeType)) return undefined;
+
+        return {
+          source: {
+            data: base64 as string,
+            media_type: mimeType,
+            type: 'base64',
+          },
+          type: 'video',
+        };
+      }
+
+      if (type === 'url') {
+        return {
+          source: {
+            type: 'url',
+            url: content.video_url.url,
+          },
+          type: 'video',
+        };
+      }
+
+      throw new Error(`Invalid video URL: ${content.video_url.url}`);
     }
   }
 };

--- a/packages/model-runtime/src/core/contextBuilders/anthropic.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.ts
@@ -95,6 +95,16 @@ export const buildAnthropicBlock = async (
     case 'video_url': {
       // MiniMax M3's Anthropic-compatible API accepts video content blocks, while
       // the upstream Anthropic SDK types do not expose a video block param yet.
+      if (content.video_url.url.startsWith('mm_file://')) {
+        return {
+          source: {
+            type: 'url',
+            url: content.video_url.url,
+          },
+          type: 'video',
+        };
+      }
+
       const { mimeType, base64, type } = parseDataUri(content.video_url.url);
 
       if (type === 'base64') {

--- a/packages/model-runtime/src/providers/minimax/index.test.ts
+++ b/packages/model-runtime/src/providers/minimax/index.test.ts
@@ -1,18 +1,43 @@
 // @vitest-environment node
 import { ModelProvider } from 'model-bank';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { testProvider } from '../../providerTestUtils';
 import { ContextExceededPreFlightError } from '../../utils/resolveSafeMaxTokens';
-import { LobeMinimaxAI, params } from './index';
+import {
+  anthropicParams,
+  LobeMinimaxAI,
+  LobeMinimaxAnthropicAI,
+  LobeMinimaxOpenAI,
+  openAIParams,
+} from './index';
+
+const loadModelsMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue([
+    {
+      id: 'abab6.5s-chat',
+      providerId: 'minimax',
+    },
+    {
+      id: 'MiniMax-M3',
+      maxOutput: 524_288,
+      providerId: 'minimax',
+    },
+  ]),
+);
+
+vi.mock('@lobechat/business-model-bank/model-config', () => ({
+  loadModels: loadModelsMock,
+}));
 
 const provider = ModelProvider.Minimax;
-const defaultBaseURL = 'https://api.minimaxi.com/v1';
+const defaultOpenAIBaseURL = 'https://api.minimaxi.com/v1';
+const anthropicBaseURL = 'https://api.minimax.io/anthropic';
 
 testProvider({
-  Runtime: LobeMinimaxAI,
+  Runtime: LobeMinimaxOpenAI,
   provider,
-  defaultBaseURL,
+  defaultBaseURL: defaultOpenAIBaseURL,
   chatDebugEnv: 'DEBUG_MINIMAX_CHAT_COMPLETION',
   chatModel: 'abab6.5s-chat',
   test: {
@@ -20,7 +45,114 @@ testProvider({
   },
 });
 
-const handlePayload = params.chatCompletion.handlePayload;
+const handlePayload = openAIParams.chatCompletion!.handlePayload!;
+const handleAnthropicPayload = anthropicParams.chatCompletion!.handlePayload!;
+
+describe('LobeMinimaxAI', () => {
+  const createRuntime = ({
+    baseURL,
+    sdkType,
+  }: {
+    baseURL?: string;
+    sdkType?: string;
+  } = {}) =>
+    new LobeMinimaxAI({
+      apiKey: 'test',
+      ...(baseURL ? { baseURL } : {}),
+      ...(sdkType ? { sdkType } : {}),
+    });
+
+  const resolveRouter = async (baseURL?: string, sdkType?: string) => {
+    const runtime = createRuntime({ baseURL, sdkType });
+
+    return (runtime as any).resolveMatchedRouter('MiniMax-M3');
+  };
+
+  const resolveFirstRouterOption = async (baseURL: string, sdkType: string) => {
+    const runtime = createRuntime({ baseURL, sdkType });
+    const router = await (runtime as any).resolveMatchedRouter('MiniMax-M3');
+    const routerOptions = (runtime as any).normalizeRouterOptions(router);
+
+    return {
+      option: routerOptions[0],
+      router,
+    };
+  };
+
+  describe('RouterRuntime baseURL routing', () => {
+    it('should route to OpenAI format by default', async () => {
+      const router = await resolveRouter();
+
+      expect(router.apiType).toBe('openai');
+      expect(router.id).toBe('openai-compatible');
+      expect(router.runtime).toBe(LobeMinimaxOpenAI);
+    });
+
+    it('should route to OpenAI format when baseURL ends with /v1', async () => {
+      const router = await resolveRouter(defaultOpenAIBaseURL);
+
+      expect(router.apiType).toBe('openai');
+      expect(router.id).toBe('openai-compatible');
+      expect(router.runtime).toBe(LobeMinimaxOpenAI);
+    });
+
+    it('should route to Anthropic format when baseURL ends with /anthropic', async () => {
+      const router = await resolveRouter(anthropicBaseURL);
+
+      expect(router.apiType).toBe('anthropic');
+      expect(router.id).toBe('anthropic-compatible');
+      expect(router.runtime).toBe(LobeMinimaxAnthropicAI);
+    });
+
+    it('should route to Anthropic format when sdkType is anthropic', async () => {
+      const router = await resolveRouter(
+        'https://api.minimax.io/anthropic/v1/messages',
+        'anthropic',
+      );
+
+      expect(router.apiType).toBe('anthropic');
+      expect(router.id).toBe('anthropic-compatible');
+      expect(router.runtime).toBe(LobeMinimaxAnthropicAI);
+    });
+
+    it('should normalize /v1/messages before creating an Anthropic SDK runtime', async () => {
+      const { option } = await resolveFirstRouterOption(
+        'https://api.minimax.io/anthropic/v1/messages',
+        'anthropic',
+      );
+      const runtime = new LobeMinimaxAnthropicAI({ apiKey: 'test', baseURL: option.baseURL });
+
+      expect(option.baseURL).toBe(anthropicBaseURL);
+      expect(runtime).toBeInstanceOf(LobeMinimaxAnthropicAI);
+      expect((runtime as any).baseURL).toBe(anthropicBaseURL);
+    });
+
+    it('should let sdkType override legacy baseURL suffix routing', async () => {
+      const router = await resolveRouter(anthropicBaseURL, 'openai');
+
+      expect(router.apiType).toBe('openai');
+      expect(router.id).toBe('openai-compatible');
+      expect(router.runtime).toBe(LobeMinimaxOpenAI);
+    });
+
+    it('should reject unsupported sdkType values', async () => {
+      await expect(resolveRouter(defaultOpenAIBaseURL, 'invalid')).rejects.toThrow(
+        'Unsupported MiniMax sdkType: invalid',
+      );
+    });
+  });
+});
+
+describe('LobeMinimaxAnthropicAI', () => {
+  describe('init', () => {
+    it('should correctly initialize with an API key', () => {
+      const runtime = new LobeMinimaxAnthropicAI({ apiKey: 'test_api_key' });
+
+      expect(runtime).toBeInstanceOf(LobeMinimaxAnthropicAI);
+      expect((runtime as any).baseURL).toEqual(anthropicBaseURL);
+    });
+  });
+});
 
 describe('LobeMinimaxAI - handlePayload', () => {
   it('respects an explicitly provided max_tokens', () => {
@@ -138,5 +270,49 @@ describe('LobeMinimaxAI - handlePayload', () => {
     expect(result.temperature).toBeUndefined();
     // Reasoning split is always enabled.
     expect(result.reasoning_split).toBe(true);
+  });
+});
+
+describe('LobeMinimaxAnthropicAI - handlePayload', () => {
+  it('normalizes MiniMax sampling params consistently with the OpenAI runtime', async () => {
+    const result = await handleAnthropicPayload(
+      {
+        max_tokens: 4096,
+        messages: [{ content: 'hi', role: 'user' }],
+        model: 'MiniMax-M3',
+        temperature: 1.6,
+        top_p: 0.9,
+      } as any,
+      {} as any,
+    );
+
+    expect(result.temperature).toBe(0.8);
+    expect(result.top_p).toBe(0.9);
+  });
+
+  it('converts assistant reasoning history to Anthropic thinking blocks', async () => {
+    const result = await handleAnthropicPayload(
+      {
+        max_tokens: 4096,
+        messages: [
+          {
+            content: 'answer',
+            reasoning: { content: 'thinking history' },
+            role: 'assistant',
+          },
+          { content: 'next', role: 'user' },
+        ],
+        model: 'MiniMax-M3',
+      } as any,
+      {} as any,
+    );
+
+    expect(result.messages[0]).toEqual({
+      content: [
+        { thinking: 'thinking history', type: 'thinking' },
+        { text: 'answer', type: 'text' },
+      ],
+      role: 'assistant',
+    });
   });
 });

--- a/packages/model-runtime/src/providers/minimax/index.ts
+++ b/packages/model-runtime/src/providers/minimax/index.ts
@@ -1,82 +1,183 @@
+import type Anthropic from '@anthropic-ai/sdk';
 import { minimax as minimaxChatModels, ModelProvider } from 'model-bank';
 
+import {
+  buildDefaultAnthropicPayload,
+  createAnthropicCompatibleParams,
+  createAnthropicCompatibleRuntime,
+} from '../../core/anthropicCompatibleFactory';
+import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
 import { resolveParameters } from '../../core/parameterResolver';
+import type { CreateRouterRuntimeOptions } from '../../core/RouterRuntime';
+import { createRouterRuntime } from '../../core/RouterRuntime';
+import type { ChatStreamPayload } from '../../types';
+import { getModelPropertyWithFallback } from '../../utils/getFallbackModelProperty';
 import { resolveSafeMaxTokens } from '../../utils/resolveSafeMaxTokens';
 import { createMiniMaxImage } from './createImage';
 import { createMiniMaxVideo } from './createVideo';
 
-export const params = {
-  baseURL: 'https://api.minimaxi.com/v1',
-  chatCompletion: {
-    handlePayload: (payload: any) => {
-      const { enabledSearch, max_tokens, messages, temperature, top_p, ...params } = payload;
+const DEFAULT_MINIMAX_BASE_URL = 'https://api.minimaxi.com/v1';
+const DEFAULT_MINIMAX_ANTHROPIC_BASE_URL = 'https://api.minimax.io/anthropic';
+const MINIMAX_ANTHROPIC_BASE_URL_PATTERN = /\/anthropic\/?$/;
+const MINIMAX_ANTHROPIC_MESSAGES_PATH_PATTERN = /\/v1\/messages\/?$/;
 
-      // Interleaved thinking
-      const processedMessages = messages.map((message: any) => {
-        if (message.role === 'assistant' && message.reasoning) {
-          // Only process historical reasoning content without a signature
-          if (!message.reasoning.signature && message.reasoning.content) {
-            const { reasoning, ...messageWithoutReasoning } = message;
-            return {
-              ...messageWithoutReasoning,
-              reasoning_details: [
-                {
-                  format: 'MiniMax-response-v1',
-                  id: 'reasoning-text-0',
-                  index: 0,
-                  text: reasoning.content,
-                  type: 'reasoning.text',
-                },
-              ],
-            };
-          }
+type MiniMaxSDKType = 'anthropic' | 'openai';
 
-          // If there is a signature or no content, remove the reasoning field
-          // eslint-disable-next-line unused-imports/no-unused-vars
-          const { reasoning, ...messageWithoutReasoning } = message;
-          return messageWithoutReasoning;
-        }
-        return message;
-      });
+const isEmptyContent = (content: unknown) =>
+  content === '' || content === null || content === undefined;
 
-      // MiniMax API enforces `input_tokens + max_tokens <= context_window`,
-      // so we must derive max_tokens dynamically from the actual input size
-      // when the caller did not specify one. Estimate against the sanitized
-      // messages (with stripped reasoning) — that's what we actually send.
-      const safeMaxTokens = resolveSafeMaxTokens(
-        { ...payload, messages: processedMessages },
-        minimaxChatModels,
-      );
+const hasReasoningContent = (reasoning: any) => typeof reasoning?.content === 'string';
 
-      // Resolve parameters with constraints
-      const resolvedParams = resolveParameters(
-        {
-          max_tokens: safeMaxTokens,
-          temperature,
-          top_p,
-        },
-        {
-          normalizeTemperature: true,
-          topPRange: { max: 1, min: 0.01 },
-        },
-      );
+const normalizeMiniMaxAnthropicBaseURL = (baseURL?: string | null) =>
+  baseURL?.replace(MINIMAX_ANTHROPIC_MESSAGES_PATH_PATTERN, '');
 
-      // Minimax doesn't support temperature <= 0
-      const finalTemperature =
-        resolvedParams.temperature !== undefined && resolvedParams.temperature <= 0
-          ? undefined
-          : resolvedParams.temperature;
+const resolveMiniMaxSDKType = (sdkType: unknown): MiniMaxSDKType | undefined => {
+  if (sdkType === undefined || sdkType === null || sdkType === '') return undefined;
+  if (sdkType === 'anthropic' || sdkType === 'openai') return sdkType;
 
-      return {
-        ...params,
-        max_tokens: resolvedParams.max_tokens,
-        messages: processedMessages,
-        reasoning_split: true,
-        temperature: finalTemperature,
-        top_p: resolvedParams.top_p,
-      } as any;
+  throw new Error(`Unsupported MiniMax sdkType: ${String(sdkType)}`);
+};
+
+const buildThinkingBlock = (reasoning: any) =>
+  hasReasoningContent(reasoning)
+    ? { thinking: reasoning.content, type: 'thinking' as const }
+    : undefined;
+
+const toContentArray = (content: any) =>
+  Array.isArray(content)
+    ? content
+    : [{ text: isEmptyContent(content) ? ' ' : content, type: 'text' as const }];
+
+const normalizeMessagesForAnthropic = (messages: ChatStreamPayload['messages']) =>
+  messages.map((message: any) => {
+    if (message.role !== 'assistant') return message;
+
+    const { reasoning, ...rest } = message;
+    const thinkingBlock = buildThinkingBlock(reasoning);
+
+    if (!thinkingBlock) return rest;
+
+    return {
+      ...rest,
+      content: [thinkingBlock, ...toContentArray(message.content)],
+    };
+  });
+
+export const buildMiniMaxAnthropicPayload = async (
+  payload: ChatStreamPayload,
+): Promise<Anthropic.MessageCreateParams> => {
+  const resolvedMaxTokens =
+    payload.max_tokens ??
+    (await getModelPropertyWithFallback<number | undefined>(
+      payload.model,
+      'maxOutput',
+      ModelProvider.Minimax,
+    )) ??
+    64_000;
+
+  const basePayload = await buildDefaultAnthropicPayload({
+    ...payload,
+    enabledSearch: false,
+    max_tokens: resolvedMaxTokens,
+    messages: normalizeMessagesForAnthropic(payload.messages),
+  });
+  const { temperature, top_p, ...restPayload } = basePayload;
+  const resolvedParams = resolveParameters(
+    {
+      temperature: payload.temperature,
+      top_p: payload.top_p,
     },
+    {
+      normalizeTemperature: true,
+      topPRange: { max: 1, min: 0.01 },
+    },
+  );
+  const finalTemperature =
+    resolvedParams.temperature !== undefined && resolvedParams.temperature <= 0
+      ? undefined
+      : resolvedParams.temperature;
+
+  return {
+    ...restPayload,
+    ...(finalTemperature !== undefined ? { temperature: finalTemperature } : {}),
+    ...(resolvedParams.top_p !== undefined ? { top_p: resolvedParams.top_p } : {}),
+  };
+};
+
+export const buildMiniMaxOpenAIPayload = (payload: ChatStreamPayload) => {
+  const { enabledSearch, max_tokens, messages, temperature, top_p, ...params } = payload;
+
+  // Interleaved thinking
+  const processedMessages = messages.map((message: any) => {
+    if (message.role === 'assistant' && message.reasoning) {
+      // Only process historical reasoning content without a signature
+      if (!message.reasoning.signature && message.reasoning.content) {
+        const { reasoning, ...messageWithoutReasoning } = message;
+        return {
+          ...messageWithoutReasoning,
+          reasoning_details: [
+            {
+              format: 'MiniMax-response-v1',
+              id: 'reasoning-text-0',
+              index: 0,
+              text: reasoning.content,
+              type: 'reasoning.text',
+            },
+          ],
+        };
+      }
+
+      // If there is a signature or no content, remove the reasoning field
+      // eslint-disable-next-line unused-imports/no-unused-vars
+      const { reasoning, ...messageWithoutReasoning } = message;
+      return messageWithoutReasoning;
+    }
+    return message;
+  });
+
+  // MiniMax API enforces `input_tokens + max_tokens <= context_window`,
+  // so we must derive max_tokens dynamically from the actual input size
+  // when the caller did not specify one. Estimate against the sanitized
+  // messages (with stripped reasoning) — that's what we actually send.
+  const safeMaxTokens = resolveSafeMaxTokens(
+    { ...payload, messages: processedMessages },
+    minimaxChatModels,
+  );
+
+  // Resolve parameters with constraints
+  const resolvedParams = resolveParameters(
+    {
+      max_tokens: safeMaxTokens,
+      temperature,
+      top_p,
+    },
+    {
+      normalizeTemperature: true,
+      topPRange: { max: 1, min: 0.01 },
+    },
+  );
+
+  // Minimax doesn't support temperature <= 0
+  const finalTemperature =
+    resolvedParams.temperature !== undefined && resolvedParams.temperature <= 0
+      ? undefined
+      : resolvedParams.temperature;
+
+  return {
+    ...params,
+    max_tokens: resolvedParams.max_tokens,
+    messages: processedMessages,
+    reasoning_split: true,
+    temperature: finalTemperature,
+    top_p: resolvedParams.top_p,
+  } as any;
+};
+
+export const openAIParams = {
+  baseURL: DEFAULT_MINIMAX_BASE_URL,
+  chatCompletion: {
+    handlePayload: buildMiniMaxOpenAIPayload,
   },
   createImage: createMiniMaxImage,
   createVideo: createMiniMaxVideo,
@@ -91,6 +192,70 @@ export const params = {
     });
   },
   provider: ModelProvider.Minimax,
+} satisfies OpenAICompatibleFactoryOptions;
+
+export const LobeMinimaxOpenAI = createOpenAICompatibleRuntime(openAIParams);
+
+export const anthropicParams = createAnthropicCompatibleParams({
+  baseURL: DEFAULT_MINIMAX_ANTHROPIC_BASE_URL,
+  chatCompletion: {
+    handlePayload: buildMiniMaxAnthropicPayload,
+  },
+  customClient: {},
+  debug: {
+    chatCompletion: () => process.env.DEBUG_MINIMAX_CHAT_COMPLETION === '1',
+  },
+  provider: ModelProvider.Minimax,
+});
+
+export const LobeMinimaxAnthropicAI = createAnthropicCompatibleRuntime(anthropicParams);
+
+const createAnthropicRouter = ({
+  baseURL,
+  baseURLPattern,
+}: {
+  baseURL?: string;
+  baseURLPattern?: RegExp;
+} = {}) => ({
+  apiType: 'anthropic' as const,
+  ...(baseURLPattern ? { baseURLPattern } : {}),
+  id: 'anthropic-compatible',
+  options: {
+    ...(baseURL ? { baseURL } : {}),
+    remark: 'anthropic-compatible',
+  },
+  runtime: LobeMinimaxAnthropicAI,
+});
+
+const createOpenAIRouter = () => ({
+  apiType: 'openai' as const,
+  id: 'openai-compatible',
+  options: { remark: 'openai-compatible' },
+  runtime: LobeMinimaxOpenAI,
+});
+
+export const params: CreateRouterRuntimeOptions = {
+  id: ModelProvider.Minimax,
+  routers: (options) => {
+    const sdkType = resolveMiniMaxSDKType(options.sdkType);
+
+    if (sdkType === 'anthropic') {
+      return [
+        createAnthropicRouter({
+          baseURL: normalizeMiniMaxAnthropicBaseURL(options.baseURL),
+        }),
+      ];
+    }
+
+    if (sdkType === 'openai') {
+      return [createOpenAIRouter()];
+    }
+
+    return [
+      createAnthropicRouter({ baseURLPattern: MINIMAX_ANTHROPIC_BASE_URL_PATTERN }),
+      createOpenAIRouter(),
+    ];
+  },
 };
 
-export const LobeMinimaxAI = createOpenAICompatibleRuntime(params);
+export const LobeMinimaxAI = createRouterRuntime(params);

--- a/src/locales/default/models.ts
+++ b/src/locales/default/models.ts
@@ -13,6 +13,8 @@ const lobeHubOnlineModelLocales = {
   'grok-4.20-beta-0309-reasoning.description':
     'Intelligent, blazing-fast model that reasons before responding',
   'grok-4.20-beta-0309-non-reasoning.description': 'A non-reasoning variant for simple use cases',
+  'MiniMax-M3.description':
+    'Frontier multimodal coding and agentic model with a 1M context window, native image/video understanding, and controllable thinking.',
   'MiniMax-M2.1-Lightning.description':
     'Powerful multilingual programming capabilities with faster and more efficient inference.',
   'seedream-5-0-260128.description':


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - no related issue found.

#### 🔀 Description of Change

- Add an Anthropic-compatible MiniMax runtime path while keeping the existing OpenAI-compatible runtime for legacy MiniMax models.
- Route MiniMax requests by `sdkType` or Anthropic base URL so `MiniMax-M3` can use the Anthropic messages API.
- Add Anthropic video content block support for `video_url`, including base64, URL, and `mm_file://` sources.
- Delegate RouterRuntime video polling to the matched runtime for nested router compatibility.
- Add the online-only MiniMax M3 default model description.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/providers/minimax/index.test.ts' 'src/core/contextBuilders/anthropic.test.ts' 'src/core/RouterRuntime/createRuntime.test.ts'
```

Also verified:

```bash
git diff --check
bun run scripts/sync-lobehub-model-locales.ts --check
```

#### 📸 Screenshots / Videos

N/A - runtime-only change.

#### 📝 Additional Information

MiniMax M3 video input is exposed through MiniMax's Anthropic-compatible API. The OpenAI-compatible MiniMax runtime remains the default fallback for existing MiniMax routes.