### PR TITLE
🐛 fix(agent-manager): guard createAgent against LLM double-encoded array fields

### DIFF
--- a/packages/agent-manager-runtime/src/AgentManagerRuntime.ts
+++ b/packages/agent-manager-runtime/src/AgentManagerRuntime.ts
@@ -78,17 +78,30 @@ export class AgentManagerRuntime {
    */
   async createAgent(params: CreateAgentParams): Promise<BuiltinToolResult> {
     try {
+      // Guard against LLM double-encoding: if array fields are JSON strings, parse them.
+      // Use `as any` to bypass TS narrowing — at runtime LLMs can send strings for typed array params.
+      const parseArrayParam = (v: any): string[] | undefined => {
+        if (typeof v === 'string') {
+          try {
+            return JSON.parse(v);
+          } catch {
+            return undefined;
+          }
+        }
+        return v;
+      };
+
       const config = {
         avatar: params.avatar,
         backgroundColor: params.backgroundColor,
         description: params.description,
         model: params.model,
         openingMessage: params.openingMessage,
-        openingQuestions: params.openingQuestions,
-        plugins: params.plugins,
+        openingQuestions: parseArrayParam(params.openingQuestions),
+        plugins: parseArrayParam(params.plugins),
         provider: params.provider,
         systemRole: params.systemRole,
-        tags: params.tags,
+        tags: parseArrayParam(params.tags),
         title: params.title,
       };
 

--- a/src/server/services/toolExecution/serverRuntimes/agentManagement.ts
+++ b/src/server/services/toolExecution/serverRuntimes/agentManagement.ts
@@ -61,17 +61,29 @@ export const agentManagementRuntime: ServerRuntimeRegistration = {
 
       createAgent: async (params: CreateAgentParams): Promise<ToolExecutionResult> => {
         try {
+          // Guard against LLM double-encoding: if array fields are JSON strings, parse them.
+          const parseArrayParam = (v: any): string[] | undefined => {
+            if (typeof v === 'string') {
+              try {
+                return JSON.parse(v);
+              } catch {
+                return undefined;
+              }
+            }
+            return v;
+          };
+
           const agent = await agentModel.create({
             avatar: params.avatar,
             backgroundColor: params.backgroundColor,
             description: params.description,
             model: params.model,
             openingMessage: params.openingMessage,
-            openingQuestions: params.openingQuestions,
-            plugins: params.plugins,
+            openingQuestions: parseArrayParam(params.openingQuestions),
+            plugins: parseArrayParam(params.plugins),
             provider: params.provider,
             systemRole: params.systemRole,
-            tags: params.tags,
+            tags: parseArrayParam(params.tags),
             title: params.title,
           });
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- N/A - discovered via ETL failure analysis on agents.plugins data -->

#### 🔀 Description of Change

`AgentManagerRuntime.createAgent` was storing `plugins` (and other array fields) directly into the database without guarding against LLM double-encoding. When an LLM passes `plugins` as a JSON string (e.g. `'["lobe-cloud-sandbox"]'`) instead of a proper array, the value gets stored in jsonb as a doubly-serialized string, causing downstream failures like `ERROR: cannot get array length of a scalar`.

Root cause: `updateAgentConfig` already had this guard (added at line 130+), but `createAgent` did not.

**Fix:** Add the same `parseArrayParam` helper to `createAgent` for all three array-typed fields: `plugins`, `openingQuestions`, and `tags`.

```ts
// Before
plugins: params.plugins,

// After
plugins: parseArrayParam(params.plugins),  // safely parses '["x"]' → ["x"]
```

#### 🧪 How to Test

- [x] Tested locally

Reproduce: call `createAgent` from lobe-agent-management builtin tool and have the LLM pass `plugins` as a JSON string. Before this fix the DB row stores a string; after the fix it stores a proper array.

#### 📝 Additional Information

The dirty data in production was written by the `lobe-agent-management` builtin tool on 2026-03-13, 2026-04-30, and 2026-05-27. The ETL started failing from 2026-05-28 because it hit rows with `virtual=f` for the first time. This fix prevents new dirty rows from being written.