### PR TITLE
🐛 fix: block disabling official provider

### DIFF
--- a/packages/business/const/src/index.ts
+++ b/packages/business/const/src/index.ts
@@ -1,3 +1,5 @@
+import { BRANDING_PROVIDER } from './branding';
+
 export * from './bedrock-model-mapping';
 export * from './branding';
 export * from './llm';
@@ -8,3 +10,8 @@ const isDev = process.env.NODE_ENV === 'development';
 export const ENABLE_BUSINESS_FEATURES = false;
 
 export const AGENT_ONBOARDING_ENABLED = isDev;
+
+export const OFFICIAL_PROVIDER_DISABLE_ERROR = 'The official provider cannot be disabled.';
+
+export const isOfficialProvider = (id: string) =>
+  ENABLE_BUSINESS_FEATURES && id === BRANDING_PROVIDER;

--- a/packages/openapi/src/services/provider.service.test.ts
+++ b/packages/openapi/src/services/provider.service.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+import type * as BusinessConst from '@lobechat/business-const';
+import { OFFICIAL_PROVIDER_DISABLE_ERROR } from '@lobechat/business-const';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { LobeChatDatabase } from '@/database/type';
+
+import { ProviderService } from './provider.service';
+
+vi.mock('@lobechat/business-const', async () => {
+  const actual = await vi.importActual<typeof BusinessConst>('@lobechat/business-const');
+
+  return {
+    ...actual,
+    BRANDING_PROVIDER: 'lobehub',
+    ENABLE_BUSINESS_FEATURES: true,
+    isOfficialProvider: (id: string) => id === 'lobehub',
+  };
+});
+
+describe('ProviderService', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const createService = () => new ProviderService({} as LobeChatDatabase, 'test-user-id');
+
+  describe('official provider guard', () => {
+    it('should reject creating the official provider as disabled', async () => {
+      const service = createService();
+
+      await expect(
+        service.createProvider({
+          enabled: false,
+          id: 'lobehub',
+        }),
+      ).rejects.toMatchObject({
+        message: OFFICIAL_PROVIDER_DISABLE_ERROR,
+        name: 'BusinessError',
+      });
+    });
+
+    it('should reject updating the official provider as disabled', async () => {
+      const service = createService();
+
+      await expect(
+        service.updateProvider({
+          enabled: false,
+          id: 'lobehub',
+        }),
+      ).rejects.toMatchObject({
+        message: OFFICIAL_PROVIDER_DISABLE_ERROR,
+        name: 'BusinessError',
+      });
+    });
+  });
+});

--- a/packages/openapi/src/services/provider.service.test.ts
+++ b/packages/openapi/src/services/provider.service.test.ts
@@ -7,6 +7,35 @@ import type { LobeChatDatabase } from '@/database/type';
 
 import { ProviderService } from './provider.service';
 
+vi.mock('@/const/rbac', () => ({
+  ALL_SCOPE: 'all',
+}));
+
+vi.mock('@/database/models/rbac', () => ({
+  RbacModel: class {},
+}));
+
+vi.mock('@/database/schemas', () => ({
+  agents: {},
+  aiModels: {},
+  aiProviders: {},
+  files: {},
+  knowledgeBases: {},
+  messages: {},
+  sessions: {},
+  topics: {},
+}));
+
+vi.mock('@/server/modules/KeyVaultsEncrypt', () => ({
+  KeyVaultsGateKeeper: {
+    initWithEnvKey: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils/rbac', () => ({
+  getScopePermissions: vi.fn(() => []),
+}));
+
 vi.mock('@lobechat/business-const', async () => {
   const actual = await vi.importActual<typeof BusinessConst>('@lobechat/business-const');
 

--- a/packages/openapi/src/services/provider.service.ts
+++ b/packages/openapi/src/services/provider.service.ts
@@ -1,3 +1,4 @@
+import { isOfficialProvider, OFFICIAL_PROVIDER_DISABLE_ERROR } from '@lobechat/business-const';
 import { and, asc, count, desc, eq, ilike, or } from 'drizzle-orm';
 
 import type { AiProviderSelectItem } from '@/database/schemas';
@@ -191,6 +192,10 @@ export class ProviderService extends BaseService {
     });
 
     try {
+      if (isOfficialProvider(request.id) && request.enabled === false) {
+        throw this.createBusinessError(OFFICIAL_PROVIDER_DISABLE_ERROR);
+      }
+
       const permissionResult = await this.resolveOperationPermission('AI_PROVIDER_CREATE');
 
       if (!permissionResult.isPermitted) {
@@ -244,6 +249,10 @@ export class ProviderService extends BaseService {
     });
 
     try {
+      if (isOfficialProvider(request.id) && request.enabled === false) {
+        throw this.createBusinessError(OFFICIAL_PROVIDER_DISABLE_ERROR);
+      }
+
       const permissionResult = await this.resolveOperationPermission('AI_PROVIDER_UPDATE', {
         targetProviderId: request.id,
       });

--- a/packages/openapi/vitest.config.mts
+++ b/packages/openapi/vitest.config.mts
@@ -1,10 +1,13 @@
-import path from 'node:path';
+import { resolve } from 'node:path';
 
 import { defineConfig } from 'vitest/config';
-import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-  plugins: [tsconfigPaths({ projects: [path.resolve(__dirname, '../../tsconfig.json')] })],
+  resolve: {
+    alias: {
+      '@/': resolve(__dirname, '../../src') + '/',
+    },
+  },
   test: {
     environment: 'node',
   },

--- a/packages/openapi/vitest.config.mts
+++ b/packages/openapi/vitest.config.mts
@@ -1,13 +1,10 @@
-import { resolve } from 'node:path';
+import path from 'node:path';
 
 import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-  resolve: {
-    alias: {
-      '@/': resolve(__dirname, '../../src') + '/',
-    },
-  },
+  plugins: [tsconfigPaths({ projects: [path.resolve(__dirname, '../../tsconfig.json')] })],
   test: {
     environment: 'node',
   },

--- a/src/server/routers/lambda/__tests__/aiProvider.test.ts
+++ b/src/server/routers/lambda/__tests__/aiProvider.test.ts
@@ -1,4 +1,6 @@
 // @vitest-environment node
+import type * as BusinessConst from '@lobechat/business-const';
+import { OFFICIAL_PROVIDER_DISABLE_ERROR } from '@lobechat/business-const';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AiProviderModel } from '@/database/models/aiProvider';
@@ -14,6 +16,16 @@ vi.mock('@/server/modules/KeyVaultsEncrypt');
 vi.mock('@/database/repositories/aiInfra');
 vi.mock('@/database/models/aiProvider');
 vi.mock('@/database/models/user');
+vi.mock('@lobechat/business-const', async () => {
+  const actual = await vi.importActual<typeof BusinessConst>('@lobechat/business-const');
+
+  return {
+    ...actual,
+    BRANDING_PROVIDER: 'lobehub',
+    ENABLE_BUSINESS_FEATURES: true,
+    isOfficialProvider: (id: string) => id === 'lobehub',
+  };
+});
 
 describe('aiProviderRouter', () => {
   const mockUserId = 'test-user-id';
@@ -148,6 +160,25 @@ describe('aiProviderRouter', () => {
       });
 
       expect(mockToggle).toHaveBeenCalledWith(mockProviderId, true);
+    });
+
+    it('should reject disabling the official provider', async () => {
+      const mockToggle = vi.fn();
+      vi.mocked(AiProviderModel).prototype.toggleProviderEnabled = mockToggle;
+
+      const caller = aiProviderRouter.createCaller(createMockContext());
+
+      await expect(
+        caller.toggleProviderEnabled({
+          enabled: false,
+          id: 'lobehub',
+        }),
+      ).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: OFFICIAL_PROVIDER_DISABLE_ERROR,
+      });
+
+      expect(mockToggle).not.toHaveBeenCalled();
     });
   });
 

--- a/src/server/routers/lambda/aiProvider.ts
+++ b/src/server/routers/lambda/aiProvider.ts
@@ -1,3 +1,4 @@
+import { isOfficialProvider, OFFICIAL_PROVIDER_DISABLE_ERROR } from '@lobechat/business-const';
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
@@ -134,6 +135,13 @@ export const aiProviderRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
+      if (isOfficialProvider(input.id) && input.enabled === false) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: OFFICIAL_PROVIDER_DISABLE_ERROR,
+        });
+      }
+
       return ctx.aiProviderModel.toggleProviderEnabled(input.id, input.enabled);
     }),
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - no related issue found.

#### 🔀 Description of Change

- Add a shared official-provider guard in business constants.
- Reject attempts to create or update the official provider as disabled through the OpenAPI provider service.
- Reject attempts to disable the official provider through the tRPC provider toggle endpoint.
- Update OpenAPI Vitest path resolution to use the package's root tsconfig paths.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands:

```bash
bunx vitest run --silent='passed-only' 'src/server/routers/lambda/__tests__/aiProvider.test.ts'
cd packages/openapi && bunx vitest run --silent='passed-only' 'src/services/provider.service.test.ts'
```

#### 📝 Additional Information

This prevents the official provider row from being persisted with `enabled: false` by server-side API calls.
