### PR TITLE
🔨 chore: pin Vitest 3.2.4

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -111,7 +111,7 @@
     "undici": "^7.16.0",
     "uuid": "^14.0.0",
     "vite": "8.0.14",
-    "vitest": "^3.2.4",
+    "vitest": "3.2.4",
     "zod": "^3.25.76"
   },
   "optionalDependencies": {
@@ -126,7 +126,8 @@
     ],
     "overrides": {
       "react": "19.2.4",
-      "react-dom": "19.2.4"
+      "react-dom": "19.2.4",
+      "vitest": "3.2.4"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -495,7 +495,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260425.1",
     "@vitejs/devtools": "0.2.0",
     "@vitejs/plugin-react": "^6.0.2",
-    "@vitest/coverage-v8": "^3.2.4",
+    "@vitest/coverage-v8": "3.2.4",
     "ajv": "^8.17.1",
     "ajv-keywords": "^5.1.0",
     "code-inspector-plugin": "1.3.3",
@@ -544,7 +544,7 @@
     "vite": "8.0.14",
     "vite-plugin-pwa": "^1.2.0",
     "vite-tsconfig-paths": "^6.1.1",
-    "vitest": "^3.2.4"
+    "vitest": "3.2.4"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
   "publishConfig": {
@@ -559,6 +559,7 @@
     "overrides": {
       "@react-pdf/image": "3.0.4",
       "@types/react": "19.2.13",
+      "@vitest/coverage-v8": "3.2.4",
       "antd": "6.3.5",
       "baseline-browser-mapping": "2.10.31",
       "better-auth": "1.4.6",
@@ -570,7 +571,8 @@
       "react": "19.2.5",
       "react-dom": "19.2.5",
       "stylelint-config-clean-order": "7.0.0",
-      "typescript": "6.0.3"
+      "typescript": "6.0.3",
+      "vitest": "3.2.4"
     },
     "patchedDependencies": {
       "@upstash/qstash": "patches/@upstash__qstash.patch"


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

N/A - no related issue found.

#### 🔀 Description of Change

- Pin `vitest` and `@vitest/coverage-v8` to `3.2.4` for deterministic installs.
- Add matching `pnpm.overrides` so workspace packages that declare broad Vitest ranges do not resolve to `3.2.5`.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Command:

```bash
NPM_CONFIG_LOCKFILE=true pnpm install --lockfile-only --no-frozen-lockfile
```

Verified the generated lockfile resolves `vitest`, `vite-node`, and `@vitest/coverage-v8` to `3.2.4` and does not resolve `3.2.5`.

#### 📝 Additional Information

This avoids the current npm registry drift where `vitest@3.2.5` depends on `vite-node@3.2.5`, but `vite-node@3.2.5` is not available from the registry.
