### PR TITLE
✨ feat: support configurable model routing and starters

### DIFF
--- a/packages/business/const/src/bedrock-model-mapping.ts
+++ b/packages/business/const/src/bedrock-model-mapping.ts
@@ -1,4 +1,0 @@
-
-export const cloudModelIdMapping: Record<string, string> = {
-  // 'claude-sonnet-4-5-20250929': 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
-};

--- a/packages/business/const/src/index.ts
+++ b/packages/business/const/src/index.ts
@@ -1,6 +1,5 @@
 import { BRANDING_PROVIDER } from './branding';
 
-export * from './bedrock-model-mapping';
 export * from './branding';
 export * from './llm';
 export * from './url';

--- a/packages/model-runtime/src/providers/bedrock/index.test.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.test.ts
@@ -787,6 +787,40 @@ describe('LobeBedrockAI', () => {
             modelId: 'claude-opus-4-1',
           });
         });
+
+        it('should resolve Claude model IDs from channel modelIdMapping', async () => {
+          // Arrange
+          const mappedInstance = new LobeBedrockAI({
+            region: 'us-east-1',
+            accessKeyId: 'test-access-key-id',
+            accessKeySecret: 'test-access-key-secret',
+            modelIdMapping: {
+              'claude-opus-4-8': 'us.anthropic.claude-opus-4-8',
+            },
+          });
+          const mockStream = new ReadableStream({
+            start(controller) {
+              controller.enqueue('Hello, world!');
+              controller.close();
+            },
+          });
+          const mockResponse = Promise.resolve(mockStream);
+          vi.spyOn(mappedInstance['client'], 'send').mockResolvedValue(mockResponse as any);
+
+          // Act
+          await mappedInstance.chat({
+            messages: [{ content: 'Hello', role: 'user' }],
+            model: 'claude-opus-4-8',
+            temperature: 0.7,
+          });
+
+          // Assert
+          expect(InvokeModelWithResponseStreamCommand).toHaveBeenCalledWith(
+            expect.objectContaining({
+              modelId: 'us.anthropic.claude-opus-4-8',
+            }),
+          );
+        });
       });
 
       it('should handle errors and throw AgentRuntimeError', async () => {
@@ -1108,6 +1142,51 @@ describe('LobeBedrockAI', () => {
           totalTokens: 150,
         }),
       );
+    });
+
+    it('should resolve generateObject model IDs from channel modelIdMapping', async () => {
+      const mappedInstance = new LobeBedrockAI({
+        region: 'us-east-1',
+        accessKeyId: 'test-access-key-id',
+        accessKeySecret: 'test-access-key-secret',
+        modelIdMapping: {
+          'claude-opus-4-8': 'us.anthropic.claude-opus-4-8',
+        },
+      });
+      const mockResponse = {
+        body: new TextEncoder().encode(
+          JSON.stringify({
+            content: [
+              {
+                input: { title: 'Mapped' },
+                name: 'mapped_schema',
+                type: 'tool_use',
+              },
+            ],
+          }),
+        ),
+      };
+      vi.spyOn(mappedInstance['client'], 'send').mockResolvedValue(mockResponse as any);
+
+      await mappedInstance.generateObject({
+        messages: [{ content: 'Create a title.', role: 'user' }],
+        model: 'claude-opus-4-8',
+        schema: {
+          name: 'mapped_schema',
+          schema: {
+            additionalProperties: false,
+            properties: {
+              title: { type: 'string' },
+            },
+            required: ['title'],
+            type: 'object',
+          },
+          strict: true,
+        },
+      });
+
+      const commandInput = (InvokeModelCommand as unknown as Mock).mock.calls.at(-1)?.[0];
+      expect(commandInput.modelId).toBe('us.anthropic.claude-opus-4-8');
     });
 
     it('should return tool calls when tools are provided', async () => {

--- a/packages/model-runtime/src/providers/bedrock/index.ts
+++ b/packages/model-runtime/src/providers/bedrock/index.ts
@@ -4,7 +4,6 @@ import {
   InvokeModelCommand,
   InvokeModelWithResponseStreamCommand,
 } from '@aws-sdk/client-bedrock-runtime';
-import { cloudModelIdMapping } from '@lobechat/business-const';
 import { ModelProvider } from 'model-bank';
 
 import { shouldDropUnsupportedClaudeAssistantPrefill } from '../../const/models';
@@ -77,6 +76,7 @@ export interface LobeBedrockAIParams {
   accessKeyId?: string;
   accessKeySecret?: string;
   id?: string;
+  modelIdMapping?: Record<string, string>;
   region?: string;
   sessionToken?: string;
 }
@@ -84,16 +84,18 @@ export interface LobeBedrockAIParams {
 export class LobeBedrockAI implements LobeRuntimeAI {
   private client: BedrockRuntimeClient;
   private id: string;
+  private modelIdMapping: Record<string, string>;
 
   region: string;
 
   constructor(options: LobeBedrockAIParams = {}) {
-    const { id, region, accessKeyId, accessKeySecret, sessionToken } = options;
+    const { id, modelIdMapping = {}, region, accessKeyId, accessKeySecret, sessionToken } = options;
 
     if (!(accessKeyId && accessKeySecret))
       throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidBedrockCredentials);
     this.region = region ?? 'us-east-1';
     this.id = id ?? ModelProvider.Bedrock;
+    this.modelIdMapping = modelIdMapping;
     this.client = new BedrockRuntimeClient({
       credentials: {
         accessKeyId,
@@ -108,6 +110,10 @@ export class LobeBedrockAI implements LobeRuntimeAI {
     if (payload.model.startsWith('meta')) return this.invokeLlamaModel(payload, options);
 
     return this.invokeClaudeModel(payload, options);
+  }
+
+  private resolveModelId(model: string): string {
+    return this.modelIdMapping[model] ?? model;
   }
   /**
    * Supports the Amazon Titan Text models series.
@@ -166,7 +172,7 @@ export class LobeBedrockAI implements LobeRuntimeAI {
         ...bedrockRequestParams,
       }),
       contentType: 'application/json',
-      modelId: cloudModelIdMapping[payload.model] || payload.model,
+      modelId: this.resolveModelId(payload.model),
     });
 
     try {
@@ -332,7 +338,7 @@ export class LobeBedrockAI implements LobeRuntimeAI {
       accept: 'application/json',
       body: JSON.stringify(anthropicPayload),
       contentType: 'application/json',
-      modelId: cloudModelIdMapping[model] || model,
+      modelId: this.resolveModelId(model),
     });
 
     try {

--- a/src/business/client/hooks/useHomeNewModels.ts
+++ b/src/business/client/hooks/useHomeNewModels.ts
@@ -1,0 +1,11 @@
+export type HomeNewModelType = 'chat' | 'image' | 'video';
+
+export interface HomeNewModelItem {
+  iconModel?: string;
+  model: string;
+  title: string;
+  type: HomeNewModelType;
+}
+
+export const useHomeNewModels = (fallbackItems: HomeNewModelItem[]): HomeNewModelItem[] =>
+  fallbackItems;

--- a/src/routes/(main)/home/features/InputArea/StarterList.tsx
+++ b/src/routes/(main)/home/features/InputArea/StarterList.tsx
@@ -1,28 +1,19 @@
-import { Claude, Jimeng, OpenAI } from '@lobehub/icons';
-import { type ButtonProps } from '@lobehub/ui';
-import { Button, Center, Tag, Tooltip } from '@lobehub/ui';
+import { ModelIcon } from '@lobehub/icons';
+import { Button, Center, Tag } from '@lobehub/ui';
 import { App } from 'antd';
 import { createStaticStyles, cx } from 'antd-style';
-import { memo, useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import type { HomeNewModelItem } from '@/business/client/hooks/useHomeNewModels';
+import { useHomeNewModels } from '@/business/client/hooks/useHomeNewModels';
 import { useStableNavigate } from '@/hooks/useStableNavigate';
 import { agentService } from '@/services/agent';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 
 import { useResolvedHomeAgentId } from '../AgentSelect/useResolvedHomeAgentId';
-import {
-  NEW_CHAT_MODEL,
-  NEW_CHAT_MODEL_NAME,
-  NEW_CHAT_PROVIDER,
-  NEW_IMAGE_MODEL,
-  NEW_IMAGE_MODEL_NAME,
-  NEW_VIDEO_MODEL,
-  NEW_VIDEO_MODEL_NAME,
-} from './starterModels';
-
-type StarterKey = 'chat' | 'image' | 'video';
+import { DEFAULT_HOME_NEW_MODELS, NEW_CHAT_PROVIDER } from './starterModels';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   button: css`
@@ -36,19 +27,16 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
       background: ${cssVar.colorBgElevated} !important;
     }
   `,
+  container: css`
+    flex-wrap: wrap;
+  `,
   newTag: css`
     padding-inline: 10px !important;
     border-radius: 999px !important;
   `,
 }));
 
-interface StarterItem {
-  disabled?: boolean;
-  icon?: ButtonProps['icon'];
-  key: StarterKey;
-  /** Fixed product name — not translated, see starterModels.ts */
-  title: string;
-}
+const getStarterItemKey = (item: HomeNewModelItem) => `${item.type}:${item.model}`;
 
 const StarterList = memo(() => {
   const { t } = useTranslation('home');
@@ -56,42 +44,24 @@ const StarterList = memo(() => {
   const { message } = App.useApp();
   const { agentId: activeAgentId } = useResolvedHomeAgentId();
   const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
-  const [switchingKey, setSwitchingKey] = useState<StarterKey | null>(null);
-
-  const items: StarterItem[] = useMemo(
-    () => [
-      {
-        icon: Claude.Avatar,
-        key: 'chat',
-        title: NEW_CHAT_MODEL_NAME,
-      },
-      {
-        icon: OpenAI.Avatar,
-        key: 'image',
-        title: NEW_IMAGE_MODEL_NAME,
-      },
-      {
-        icon: Jimeng.Avatar,
-        key: 'video',
-        title: NEW_VIDEO_MODEL_NAME,
-      },
-    ],
-    [],
-  );
+  const [switchingKey, setSwitchingKey] = useState<string | null>(null);
+  const items = useHomeNewModels(DEFAULT_HOME_NEW_MODELS);
 
   const handleClick = useCallback(
-    async (key: StarterKey) => {
-      if (key === 'video') {
-        navigate(`/video?model=${NEW_VIDEO_MODEL}`);
+    async (item: HomeNewModelItem) => {
+      const key = getStarterItemKey(item);
+
+      if (item.type === 'video') {
+        navigate(`/video?model=${item.model}`);
         return;
       }
 
-      if (key === 'image') {
-        navigate(`/image?model=${NEW_IMAGE_MODEL}`);
+      if (item.type === 'image') {
+        navigate(`/image?model=${item.model}`);
         return;
       }
 
-      if (key === 'chat') {
+      if (item.type === 'chat') {
         if (!activeAgentId || switchingKey) return;
         setSwitchingKey(key);
         try {
@@ -107,16 +77,16 @@ const StarterList = memo(() => {
           const currentModel = agentByIdSelectors.getAgentModelById(activeAgentId)(agentState);
           const currentProvider =
             agentByIdSelectors.getAgentModelProviderById(activeAgentId)(agentState);
-          if (currentModel === NEW_CHAT_MODEL && currentProvider === NEW_CHAT_PROVIDER) {
-            message.info(t('starter.modelInUse', { name: NEW_CHAT_MODEL_NAME }));
+          if (currentModel === item.model && currentProvider === NEW_CHAT_PROVIDER) {
+            message.info(t('starter.modelInUse', { name: item.title }));
             return;
           }
 
           await updateAgentConfigById(activeAgentId, {
-            model: NEW_CHAT_MODEL,
+            model: item.model,
             provider: NEW_CHAT_PROVIDER,
           });
-          message.success(t('starter.modelSwitched', { name: NEW_CHAT_MODEL_NAME }));
+          message.success(t('starter.modelSwitched', { name: item.title }));
         } finally {
           setSwitchingKey(null);
         }
@@ -127,39 +97,28 @@ const StarterList = memo(() => {
   );
 
   return (
-    <Center horizontal gap={8}>
+    <Center horizontal className={styles.container} gap={8}>
       <Tag className={styles.newTag} size={'small'}>
         {t('starter.newLabel')}
       </Tag>
       {items.map((item) => {
-        const isLoading = switchingKey === item.key;
-        const button = (
+        const key = getStarterItemKey(item);
+        const isLoading = switchingKey === key;
+
+        return (
           <Button
             className={cx(styles.button)}
-            disabled={item.disabled || (!!switchingKey && !isLoading)}
-            icon={item.icon}
-            key={item.key}
+            disabled={!!switchingKey && !isLoading}
+            icon={<ModelIcon model={item.iconModel ?? item.model} size={18} />}
+            key={key}
             loading={isLoading}
             shape={'round'}
             variant={'outlined'}
-            iconProps={{
-              size: 18,
-            }}
-            onClick={() => handleClick(item.key)}
+            onClick={() => handleClick(item)}
           >
             {item.title}
           </Button>
         );
-
-        if (item.disabled) {
-          return (
-            <Tooltip key={item.key} title={t('starter.developing')}>
-              {button}
-            </Tooltip>
-          );
-        }
-
-        return button;
       })}
     </Center>
   );

--- a/src/routes/(main)/home/features/InputArea/starterModels.test.ts
+++ b/src/routes/(main)/home/features/InputArea/starterModels.test.ts
@@ -1,11 +1,31 @@
 import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import { describe, expect, it } from 'vitest';
 
-import { NEW_CHAT_MODEL, NEW_CHAT_PROVIDER } from './starterModels';
+import { DEFAULT_HOME_NEW_MODELS, NEW_CHAT_MODEL, NEW_CHAT_PROVIDER } from './starterModels';
 
 describe('starter models', () => {
   it('uses the Anthropic provider in OSS and the LobeHub provider in business builds', () => {
     expect(NEW_CHAT_MODEL).toBe('claude-opus-4-8');
     expect(NEW_CHAT_PROVIDER).toBe(ENABLE_BUSINESS_FEATURES ? 'lobehub' : 'anthropic');
+  });
+
+  it('keeps the fallback home new model entries in the current product order', () => {
+    expect(DEFAULT_HOME_NEW_MODELS).toEqual([
+      {
+        model: 'claude-opus-4-8',
+        title: 'Claude Opus 4.8',
+        type: 'chat',
+      },
+      {
+        model: 'gpt-image-2',
+        title: 'GPT Image 2',
+        type: 'image',
+      },
+      {
+        model: 'dreamina-seedance-2-0-260128',
+        title: 'Seedance 2.0',
+        type: 'video',
+      },
+    ]);
   });
 });

--- a/src/routes/(main)/home/features/InputArea/starterModels.ts
+++ b/src/routes/(main)/home/features/InputArea/starterModels.ts
@@ -1,5 +1,7 @@
 import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 
+import type { HomeNewModelItem } from '@/business/client/hooks/useHomeNewModels';
+
 // Chat — first starter slot
 export const NEW_CHAT_MODEL = 'claude-opus-4-8';
 export const NEW_CHAT_PROVIDER = ENABLE_BUSINESS_FEATURES ? 'lobehub' : 'anthropic';
@@ -12,3 +14,21 @@ export const NEW_IMAGE_MODEL_NAME = 'GPT Image 2';
 // Video
 export const NEW_VIDEO_MODEL = 'dreamina-seedance-2-0-260128';
 export const NEW_VIDEO_MODEL_NAME = 'Seedance 2.0';
+
+export const DEFAULT_HOME_NEW_MODELS = [
+  {
+    model: NEW_CHAT_MODEL,
+    title: NEW_CHAT_MODEL_NAME,
+    type: 'chat',
+  },
+  {
+    model: NEW_IMAGE_MODEL,
+    title: NEW_IMAGE_MODEL_NAME,
+    type: 'image',
+  },
+  {
+    model: NEW_VIDEO_MODEL,
+    title: NEW_VIDEO_MODEL_NAME,
+    type: 'video',
+  },
+] satisfies HomeNewModelItem[];


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-9780

#### 🔀 Description of Change

- Add a generic `useHomeNewModels` business hook contract and wire the home starter list to configurable model entries.
- Move Bedrock model ID resolution to provider options via `modelIdMapping`.
- Remove the old business-const Bedrock mapping export.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'packages/model-runtime/src/providers/bedrock/index.test.ts' 'src/routes/(main)/home/features/InputArea/starterModels.test.ts'
cd packages/model-runtime && bunx vitest run --silent='passed-only' 'src/providers/bedrock/index.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Cloud counterpart PR will provide the online configuration loader and router option mapping.