### PR TITLE
🐛 fix: stabilize home starter loading

### DIFF
--- a/src/business/client/hooks/useHomeNewModels.ts
+++ b/src/business/client/hooks/useHomeNewModels.ts
@@ -3,6 +3,7 @@ export type HomeNewModelType = 'chat' | 'image' | 'video';
 export interface HomeNewModelItem {
   iconModel?: string;
   model: string;
+  provider?: string;
   title: string;
   type: HomeNewModelType;
 }

--- a/src/business/client/hooks/useHomeNewModels.ts
+++ b/src/business/client/hooks/useHomeNewModels.ts
@@ -7,5 +7,12 @@ export interface HomeNewModelItem {
   type: HomeNewModelType;
 }
 
-export const useHomeNewModels = (fallbackItems: HomeNewModelItem[]): HomeNewModelItem[] =>
-  fallbackItems;
+export interface HomeNewModelsState {
+  isLoading: boolean;
+  items: HomeNewModelItem[];
+}
+
+export const useHomeNewModels = (fallbackItems: HomeNewModelItem[]): HomeNewModelsState => ({
+  isLoading: false,
+  items: fallbackItems,
+});

--- a/src/routes/(main)/home/features/InputArea/StarterList.tsx
+++ b/src/routes/(main)/home/features/InputArea/StarterList.tsx
@@ -1,5 +1,5 @@
 import { ModelIcon } from '@lobehub/icons';
-import { Button, Center, Tag } from '@lobehub/ui';
+import { Button, Center, Skeleton, Tag } from '@lobehub/ui';
 import { App } from 'antd';
 import { createStaticStyles, cx } from 'antd-style';
 import { memo, useCallback, useState } from 'react';
@@ -37,6 +37,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 }));
 
 const getStarterItemKey = (item: HomeNewModelItem) => `${item.type}:${item.model}`;
+const skeletonWidths = [112, 150, 126, 138];
 
 const StarterList = memo(() => {
   const { t } = useTranslation('home');
@@ -45,7 +46,7 @@ const StarterList = memo(() => {
   const { agentId: activeAgentId } = useResolvedHomeAgentId();
   const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
   const [switchingKey, setSwitchingKey] = useState<string | null>(null);
-  const items = useHomeNewModels(DEFAULT_HOME_NEW_MODELS);
+  const { isLoading, items } = useHomeNewModels(DEFAULT_HOME_NEW_MODELS);
 
   const handleClick = useCallback(
     async (item: HomeNewModelItem) => {
@@ -101,25 +102,37 @@ const StarterList = memo(() => {
       <Tag className={styles.newTag} size={'small'}>
         {t('starter.newLabel')}
       </Tag>
-      {items.map((item) => {
-        const key = getStarterItemKey(item);
-        const isLoading = switchingKey === key;
+      {isLoading
+        ? DEFAULT_HOME_NEW_MODELS.map((item, index) => (
+            <Skeleton.Button
+              active
+              key={getStarterItemKey(item)}
+              style={{
+                borderRadius: 999,
+                height: 40,
+                width: skeletonWidths[index] ?? 126,
+              }}
+            />
+          ))
+        : items.map((item) => {
+            const key = getStarterItemKey(item);
+            const isSwitching = switchingKey === key;
 
-        return (
-          <Button
-            className={cx(styles.button)}
-            disabled={!!switchingKey && !isLoading}
-            icon={<ModelIcon model={item.iconModel ?? item.model} size={18} />}
-            key={key}
-            loading={isLoading}
-            shape={'round'}
-            variant={'outlined'}
-            onClick={() => handleClick(item)}
-          >
-            {item.title}
-          </Button>
-        );
-      })}
+            return (
+              <Button
+                className={cx(styles.button)}
+                disabled={!!switchingKey && !isSwitching}
+                icon={<ModelIcon model={item.iconModel ?? item.model} size={18} />}
+                key={key}
+                loading={isSwitching}
+                shape={'round'}
+                variant={'outlined'}
+                onClick={() => handleClick(item)}
+              >
+                {item.title}
+              </Button>
+            );
+          })}
     </Center>
   );
 });

--- a/src/routes/(main)/home/features/InputArea/StarterList.tsx
+++ b/src/routes/(main)/home/features/InputArea/StarterList.tsx
@@ -37,6 +37,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 }));
 
 const getStarterItemKey = (item: HomeNewModelItem) => `${item.type}:${item.model}`;
+const getStarterItemProvider = (item: HomeNewModelItem) => item.provider ?? NEW_CHAT_PROVIDER;
 const skeletonWidths = [112, 150, 126, 138];
 
 const StarterList = memo(() => {
@@ -65,6 +66,7 @@ const StarterList = memo(() => {
       if (item.type === 'chat') {
         if (!activeAgentId || switchingKey) return;
         setSwitchingKey(key);
+        const provider = getStarterItemProvider(item);
         try {
           // Hydrate the agent's config before mutating so the optimistic update
           // doesn't drop pre-existing fields the home input never loaded.
@@ -78,14 +80,14 @@ const StarterList = memo(() => {
           const currentModel = agentByIdSelectors.getAgentModelById(activeAgentId)(agentState);
           const currentProvider =
             agentByIdSelectors.getAgentModelProviderById(activeAgentId)(agentState);
-          if (currentModel === item.model && currentProvider === NEW_CHAT_PROVIDER) {
+          if (currentModel === item.model && currentProvider === provider) {
             message.info(t('starter.modelInUse', { name: item.title }));
             return;
           }
 
           await updateAgentConfigById(activeAgentId, {
             model: item.model,
-            provider: NEW_CHAT_PROVIDER,
+            provider,
           });
           message.success(t('starter.modelSwitched', { name: item.title }));
         } finally {

--- a/src/routes/(main)/home/features/InputArea/starterModels.test.ts
+++ b/src/routes/(main)/home/features/InputArea/starterModels.test.ts
@@ -1,23 +1,31 @@
 import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import { describe, expect, it } from 'vitest';
 
-import { DEFAULT_HOME_NEW_MODELS, NEW_CHAT_MODEL, NEW_CHAT_PROVIDER } from './starterModels';
+import {
+  DEFAULT_HOME_NEW_MODELS,
+  NEW_CHAT_MODEL,
+  NEW_CHAT_PROVIDER,
+  NEW_MINIMAX_PROVIDER,
+} from './starterModels';
 
 describe('starter models', () => {
   it('uses the Anthropic provider in OSS and the LobeHub provider in business builds', () => {
     expect(NEW_CHAT_MODEL).toBe('claude-opus-4-8');
     expect(NEW_CHAT_PROVIDER).toBe(ENABLE_BUSINESS_FEATURES ? 'lobehub' : 'anthropic');
+    expect(NEW_MINIMAX_PROVIDER).toBe(ENABLE_BUSINESS_FEATURES ? 'lobehub' : 'minimax');
   });
 
   it('keeps the fallback home new model entries in the current product order', () => {
     expect(DEFAULT_HOME_NEW_MODELS).toEqual([
       {
         model: 'MiniMax-M3',
+        provider: NEW_MINIMAX_PROVIDER,
         title: 'MiniMax M3',
         type: 'chat',
       },
       {
         model: 'claude-opus-4-8',
+        provider: NEW_CHAT_PROVIDER,
         title: 'Claude Opus 4.8',
         type: 'chat',
       },

--- a/src/routes/(main)/home/features/InputArea/starterModels.test.ts
+++ b/src/routes/(main)/home/features/InputArea/starterModels.test.ts
@@ -16,13 +16,7 @@ describe('starter models', () => {
   });
 
   it('keeps the fallback home new model entries in the current product order', () => {
-    expect(DEFAULT_HOME_NEW_MODELS).toEqual([
-      {
-        model: 'MiniMax-M3',
-        provider: NEW_MINIMAX_PROVIDER,
-        title: 'MiniMax M3',
-        type: 'chat',
-      },
+    const sharedItems = [
       {
         model: 'claude-opus-4-8',
         provider: NEW_CHAT_PROVIDER,
@@ -39,6 +33,20 @@ describe('starter models', () => {
         title: 'Seedance 2.0',
         type: 'video',
       },
-    ]);
+    ];
+
+    expect(DEFAULT_HOME_NEW_MODELS).toEqual(
+      ENABLE_BUSINESS_FEATURES
+        ? [
+            {
+              model: 'MiniMax-M3',
+              provider: NEW_MINIMAX_PROVIDER,
+              title: 'MiniMax M3',
+              type: 'chat',
+            },
+            ...sharedItems,
+          ]
+        : sharedItems,
+    );
   });
 });

--- a/src/routes/(main)/home/features/InputArea/starterModels.test.ts
+++ b/src/routes/(main)/home/features/InputArea/starterModels.test.ts
@@ -12,6 +12,11 @@ describe('starter models', () => {
   it('keeps the fallback home new model entries in the current product order', () => {
     expect(DEFAULT_HOME_NEW_MODELS).toEqual([
       {
+        model: 'MiniMax-M3',
+        title: 'MiniMax M3',
+        type: 'chat',
+      },
+      {
         model: 'claude-opus-4-8',
         title: 'Claude Opus 4.8',
         type: 'chat',

--- a/src/routes/(main)/home/features/InputArea/starterModels.ts
+++ b/src/routes/(main)/home/features/InputArea/starterModels.ts
@@ -4,6 +4,7 @@ import type { HomeNewModelItem } from '@/business/client/hooks/useHomeNewModels'
 
 // Chat
 export const NEW_MINIMAX_MODEL = 'MiniMax-M3';
+export const NEW_MINIMAX_PROVIDER = ENABLE_BUSINESS_FEATURES ? 'lobehub' : 'minimax';
 export const NEW_MINIMAX_MODEL_NAME = 'MiniMax M3';
 export const NEW_CHAT_MODEL = 'claude-opus-4-8';
 export const NEW_CHAT_PROVIDER = ENABLE_BUSINESS_FEATURES ? 'lobehub' : 'anthropic';
@@ -20,11 +21,13 @@ export const NEW_VIDEO_MODEL_NAME = 'Seedance 2.0';
 export const DEFAULT_HOME_NEW_MODELS = [
   {
     model: NEW_MINIMAX_MODEL,
+    provider: NEW_MINIMAX_PROVIDER,
     title: NEW_MINIMAX_MODEL_NAME,
     type: 'chat',
   },
   {
     model: NEW_CHAT_MODEL,
+    provider: NEW_CHAT_PROVIDER,
     title: NEW_CHAT_MODEL_NAME,
     type: 'chat',
   },

--- a/src/routes/(main)/home/features/InputArea/starterModels.ts
+++ b/src/routes/(main)/home/features/InputArea/starterModels.ts
@@ -2,7 +2,9 @@ import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 
 import type { HomeNewModelItem } from '@/business/client/hooks/useHomeNewModels';
 
-// Chat — first starter slot
+// Chat
+export const NEW_MINIMAX_MODEL = 'MiniMax-M3';
+export const NEW_MINIMAX_MODEL_NAME = 'MiniMax M3';
 export const NEW_CHAT_MODEL = 'claude-opus-4-8';
 export const NEW_CHAT_PROVIDER = ENABLE_BUSINESS_FEATURES ? 'lobehub' : 'anthropic';
 export const NEW_CHAT_MODEL_NAME = 'Claude Opus 4.8';
@@ -16,6 +18,11 @@ export const NEW_VIDEO_MODEL = 'dreamina-seedance-2-0-260128';
 export const NEW_VIDEO_MODEL_NAME = 'Seedance 2.0';
 
 export const DEFAULT_HOME_NEW_MODELS = [
+  {
+    model: NEW_MINIMAX_MODEL,
+    title: NEW_MINIMAX_MODEL_NAME,
+    type: 'chat',
+  },
   {
     model: NEW_CHAT_MODEL,
     title: NEW_CHAT_MODEL_NAME,

--- a/src/routes/(main)/home/features/InputArea/starterModels.ts
+++ b/src/routes/(main)/home/features/InputArea/starterModels.ts
@@ -18,7 +18,7 @@ export const NEW_IMAGE_MODEL_NAME = 'GPT Image 2';
 export const NEW_VIDEO_MODEL = 'dreamina-seedance-2-0-260128';
 export const NEW_VIDEO_MODEL_NAME = 'Seedance 2.0';
 
-export const DEFAULT_HOME_NEW_MODELS = [
+const BUSINESS_HOME_NEW_MODELS = [
   {
     model: NEW_MINIMAX_MODEL,
     provider: NEW_MINIMAX_PROVIDER,
@@ -42,3 +42,26 @@ export const DEFAULT_HOME_NEW_MODELS = [
     type: 'video',
   },
 ] satisfies HomeNewModelItem[];
+
+const OSS_HOME_NEW_MODELS = [
+  {
+    model: NEW_CHAT_MODEL,
+    provider: NEW_CHAT_PROVIDER,
+    title: NEW_CHAT_MODEL_NAME,
+    type: 'chat',
+  },
+  {
+    model: NEW_IMAGE_MODEL,
+    title: NEW_IMAGE_MODEL_NAME,
+    type: 'image',
+  },
+  {
+    model: NEW_VIDEO_MODEL,
+    title: NEW_VIDEO_MODEL_NAME,
+    type: 'video',
+  },
+] satisfies HomeNewModelItem[];
+
+export const DEFAULT_HOME_NEW_MODELS = ENABLE_BUSINESS_FEATURES
+  ? BUSINESS_HOME_NEW_MODELS
+  : OSS_HOME_NEW_MODELS;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-9780

#### 🔀 Description of Change

- Keep the business home starter/new-model fallback at four entries, with MiniMax M3 before Claude Opus 4.8.
- Keep the OSS fallback limited to starter models that are available in OSS builds.
- Let the business home-new-model hook expose a loading state alongside resolved items.
- Render stable skeleton pills while remote starter configuration is loading.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
cd lobehub && bunx vitest run --silent='passed-only' 'src/routes/(main)/home/features/InputArea/starterModels.test.ts'
bunx vitest run --silent='passed-only' 'src/business/client/hooks/useHomeNewModels.test.ts'
bun run type-check
```

#### 📸 Screenshots / Videos

Not captured.

#### 📝 Additional Information

The open-source business hook remains a generic fallback implementation and does not include cloud-specific behavior.