### PR TITLE
fix: prefer INTERNAL_APP_URL for ComfyUI server calls

### DIFF
--- a/packages/model-runtime/src/providers/comfyui/__tests__/index.test.ts
+++ b/packages/model-runtime/src/providers/comfyui/__tests__/index.test.ts
@@ -199,7 +199,9 @@ describe('LobeComfyUI Runtime', () => {
       });
 
       // Set APP_URL environment variable
+      const originalInternalAppUrl = process.env.INTERNAL_APP_URL;
       const originalAppUrl = process.env.APP_URL;
+      delete process.env.INTERNAL_APP_URL;
       process.env.APP_URL = 'http://localhost:3010';
 
       const result = await runtime.createImage(mockPayload);
@@ -231,6 +233,48 @@ describe('LobeComfyUI Runtime', () => {
       expect(result).toEqual(mockResponse);
 
       // Restore environment
+      if (originalInternalAppUrl === undefined) {
+        delete process.env.INTERNAL_APP_URL;
+      } else {
+        process.env.INTERNAL_APP_URL = originalInternalAppUrl;
+      }
+      if (originalAppUrl === undefined) {
+        delete process.env.APP_URL;
+      } else {
+        process.env.APP_URL = originalAppUrl;
+      }
+    });
+
+    it('should prefer INTERNAL_APP_URL over APP_URL for server-to-server calls', async () => {
+      const mockPayload: CreateImagePayload = {
+        model: 'flux1-dev.safetensors',
+        params: {
+          prompt: 'test prompt',
+        },
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ imageUrl: 'test.png' }),
+      });
+
+      const originalInternalAppUrl = process.env.INTERNAL_APP_URL;
+      const originalAppUrl = process.env.APP_URL;
+      process.env.INTERNAL_APP_URL = 'http://internal-service:3210';
+      process.env.APP_URL = 'https://public.example.com';
+
+      await runtime.createImage(mockPayload);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://internal-service:3210/webapi/create-image/comfyui',
+        expect.any(Object),
+      );
+
+      if (originalInternalAppUrl === undefined) {
+        delete process.env.INTERNAL_APP_URL;
+      } else {
+        process.env.INTERNAL_APP_URL = originalInternalAppUrl;
+      }
       if (originalAppUrl === undefined) {
         delete process.env.APP_URL;
       } else {
@@ -253,8 +297,10 @@ describe('LobeComfyUI Runtime', () => {
       });
 
       // Ensure APP_URL is not set
+      const originalInternalAppUrl = process.env.INTERNAL_APP_URL;
       const originalAppUrl = process.env.APP_URL;
       const originalPort = process.env.PORT;
+      delete process.env.INTERNAL_APP_URL;
       delete process.env.APP_URL;
       process.env.PORT = '3000';
 
@@ -267,6 +313,9 @@ describe('LobeComfyUI Runtime', () => {
       );
 
       // Restore environment
+      if (originalInternalAppUrl !== undefined) {
+        process.env.INTERNAL_APP_URL = originalInternalAppUrl;
+      }
       if (originalAppUrl !== undefined) {
         process.env.APP_URL = originalAppUrl;
       }
@@ -292,8 +341,10 @@ describe('LobeComfyUI Runtime', () => {
       });
 
       // Ensure both APP_URL and PORT are not set
+      const originalInternalAppUrl = process.env.INTERNAL_APP_URL;
       const originalAppUrl = process.env.APP_URL;
       const originalPort = process.env.PORT;
+      delete process.env.INTERNAL_APP_URL;
       delete process.env.APP_URL;
       delete process.env.PORT;
 
@@ -306,6 +357,9 @@ describe('LobeComfyUI Runtime', () => {
       );
 
       // Restore environment
+      if (originalInternalAppUrl !== undefined) {
+        process.env.INTERNAL_APP_URL = originalInternalAppUrl;
+      }
       if (originalAppUrl !== undefined) {
         process.env.APP_URL = originalAppUrl;
       }

--- a/packages/model-runtime/src/providers/comfyui/index.ts
+++ b/packages/model-runtime/src/providers/comfyui/index.ts
@@ -76,6 +76,7 @@ export class LobeComfyUI implements LobeRuntimeAI, AuthenticatedImageRuntime {
       const isInVercel = process.env.VERCEL === '1';
       const vercelUrl = `https://${process.env.VERCEL_URL}`;
       const appUrl =
+        process.env.INTERNAL_APP_URL ||
         process.env.APP_URL ||
         (isInVercel ? vercelUrl : `http://localhost:${process.env.PORT || 3010}`);
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #15328

#### 🔀 Description of Change

This PR makes `LobeComfyUI.createImage()` prefer `INTERNAL_APP_URL` when calling the internal `/webapi/create-image/comfyui` endpoint.

This keeps the existing fallback order intact for deployments that do not configure `INTERNAL_APP_URL`:

1. `INTERNAL_APP_URL`
2. `APP_URL`
3. Vercel URL
4. local `PORT` fallback

This helps self-hosted reverse-proxy deployments route server-to-server ComfyUI calls through an internal URL instead of the public URL protected by auth/CDN/proxy layers.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
pnpm exec vitest run --silent='passed-only' src/providers/comfyui/__tests__/index.test.ts