### PR TITLE
🐛 fix: add restore subscription copy

### DIFF
--- a/locales/zh-CN/subscription.json
+++ b/locales/zh-CN/subscription.json
@@ -301,6 +301,8 @@
   "plans.plan.starter.title": "基础版",
   "plans.plan.ultimate.desc": "适合需要复杂 AI 对话的重度用户",
   "plans.plan.ultimate.title": "专业版",
+  "plans.restoreSubscription": "恢复订阅",
+  "plans.restoreSubscriptionSuccess": "订阅已恢复",
   "plans.storage.title": "数据存储",
   "plans.subscribe": "订阅",
   "plans.support.hobby": "社区论坛",

--- a/src/locales/default/subscription.ts
+++ b/src/locales/default/subscription.ts
@@ -285,6 +285,8 @@ export default {
   'plans.downgradeWillCancel': 'This action will cancel your scheduled plan downgrade',
   'plans.cancelDowngrade': 'Cancel Scheduled Downgrade',
   'plans.cancelDowngradeSuccess': 'Scheduled downgrade has been cancelled',
+  'plans.restoreSubscription': 'Restore Subscription',
+  'plans.restoreSubscriptionSuccess': 'Subscription has been restored',
   'plans.pendingDowngrade': 'Pending Downgrade',
   'plans.embeddingStorage.embeddings': 'entries',
   'plans.embeddingStorage.title': 'Vector Storage',


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-9809

#### 🔀 Description of Change

Adds the default and zh-CN subscription copy used by the cloud restore-subscription flow.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Copy-only locale update.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Cloud implementation PR will reference this submodule PR.