### PR TITLE
🐛 fix: clarify local command session handling

### DIFF
--- a/packages/builtin-tool-local-system/src/manifest.ts
+++ b/packages/builtin-tool-local-system/src/manifest.ts
@@ -265,7 +265,7 @@ export const LocalSystemManifest: BuiltinToolManifest = {
     {
       defaultTimeoutMs: 30_000,
       description:
-        'Start a terminal session to execute a shell command and return console output collected during the wait window. If the command exits during that window, the result includes `exit_code`; if it is still running, the result includes `shell_id` for later output retrieval or termination.',
+        'Start a terminal session to execute a shell command and return console output collected during the wait window (up to 30 seconds by default). If the command exits during that window, the result includes `exit_code`; if it is still running, the result includes `shell_id` for later output retrieval or termination.',
       humanIntervention: 'required',
       name: LocalSystemApiName.runCommand,
       parameters: {
@@ -298,7 +298,7 @@ export const LocalSystemManifest: BuiltinToolManifest = {
     {
       defaultTimeoutMs: 30_000,
       description:
-        'Retrieve output from a running or completed background shell command. Returns only new output since the last check.',
+        'Retrieve output from a running or completed background shell command. Waits for one output window (up to 30 seconds by default) and returns only new output since the last check.',
       name: LocalSystemApiName.getCommandOutput,
       parameters: {
         properties: {

--- a/packages/builtin-tool-local-system/src/systemRole.desktop.ts
+++ b/packages/builtin-tool-local-system/src/systemRole.desktop.ts
@@ -86,7 +86,7 @@ You have access to a set of tools to interact with the user's local file system:
     - 'command': The shell command to execute.
     - 'description' (Optional but recommended): A clear, concise description of what the command does (5-10 words, in active voice). **IMPORTANT: Always use the same language as the user's input.** If the user speaks Chinese, write the description in Chinese; if English, use English, etc.
     - 'run_in_background' (Optional): Set to true to return immediately after starting the terminal session. The result includes a 'shell_id' for later observation or termination.
-    The command runs in cmd.exe on Windows or /bin/sh on macOS/Linux.
+    The command runs in cmd.exe on Windows or /bin/sh on macOS/Linux. The returned output reflects the tool's wait window, not necessarily the full command lifetime.
     - Result semantics:
       - 'success' indicates whether the tool call itself succeeded.
       - 'shell_id' identifies the terminal session for later observation/termination.
@@ -94,8 +94,12 @@ You have access to a set of tools to interact with the user's local file system:
 - For retrieving output from terminal sessions: Use 'getCommandOutput'. Provide:
     - 'shell_id': The ID returned from runCommand.
     - 'filter' (Optional): A regex pattern to filter output lines.
-    Returns only new output since the last check.
+    Returns only new output since the last check. Each call observes another wait window, so repeated checks consume real time.
 - For killing running terminal sessions: Use 'killCommand' with 'shell_id'.
+    Treat terminal sessions as ongoing resources: when elapsed wait time and observed progress no longer match the command's expected lifecycle, reassess whether the session should continue running.
+- For remote device execution feedback: 'Device tool call failed (HTTP ...)' describes the remote-device/gateway layer, not necessarily the local operation.
+    - HTTP 403 or 503 can be transient during reconnects, restarts, or stale session replacement; retry can be reasonable.
+    - HTTP 504 means the device did not respond within the wait window; the command may already have started, so retry only when the operation is safe to repeat.
 - For searching content in files: Use 'grepContent'. Provide:
     - 'pattern': The regex pattern to search for.
     - 'scope' (Optional): Directory to search in. Defaults to the working directory if omitted.

--- a/packages/builtin-tool-local-system/src/systemRole.ts
+++ b/packages/builtin-tool-local-system/src/systemRole.ts
@@ -75,7 +75,7 @@ You have access to a set of tools to interact with the user's local file system:
     - 'command': The shell command to execute.
     - 'description' (Optional but recommended): A clear, concise description of what the command does (5-10 words, in active voice). **IMPORTANT: Always use the same language as the user's input.** If the user speaks Chinese, write the description in Chinese; if English, use English, etc.
     - 'run_in_background' (Optional): Set to true to return immediately after starting the terminal session. The result includes a 'shell_id' for later observation or termination.
-    The command runs in cmd.exe on Windows or /bin/sh on macOS/Linux.
+    The command runs in cmd.exe on Windows or /bin/sh on macOS/Linux. The returned output reflects the tool's wait window, not necessarily the full command lifetime.
     - Result semantics:
       - 'success' indicates whether the tool call itself succeeded.
       - 'shell_id' identifies the terminal session for later observation/termination.
@@ -83,8 +83,12 @@ You have access to a set of tools to interact with the user's local file system:
 - For retrieving output from terminal sessions: Use 'getCommandOutput'. Provide:
     - 'shell_id': The ID returned from runCommand.
     - 'filter' (Optional): A regex pattern to filter output lines.
-    Returns only new output since the last check.
+    Returns only new output since the last check. Each call observes another wait window, so repeated checks consume real time.
 - For killing running terminal sessions: Use 'killCommand' with 'shell_id'.
+    Treat terminal sessions as ongoing resources: when elapsed wait time and observed progress no longer match the command's expected lifecycle, reassess whether the session should continue running.
+- For remote device execution feedback: 'Device tool call failed (HTTP ...)' describes the remote-device/gateway layer, not necessarily the local operation.
+    - HTTP 403 or 503 can be transient during reconnects, restarts, or stale session replacement; retry can be reasonable.
+    - HTTP 504 means the device did not respond within the wait window; the command may already have started, so retry only when the operation is safe to repeat.
 - For searching content in files: Use 'grepContent'. Provide:
     - 'pattern': The regex pattern to search for.
     - 'scope' (Optional): Directory to search in. Defaults to the working directory if omitted.


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

本次调整补充了 Local System 工具背后的实际执行语义，帮助 Agent 更准确地判断工具结果。

-  runCommand / getCommandOutput 并不是一次性同步返回完整命令结果，而是在默认最多 30 秒的等待窗口内观察终端输出。命令可能仍在运行，因此 Agent 需要感知真实时间消耗，并主动管理 terminal session 生命周期。

 - 同时补充 remote device 场景下的错误语义：Device tool call failed (HTTP ...) 通常是设备连接或 gateway 层反馈，不一定代表本地命令失败。403/503 可能是重连、重启或 stale session 导致的瞬时错误；504 则表示等待窗
  口内未收到响应，命令可能已经开始执行，重试时需要考虑副作用。

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
