### PR TITLE
🐛 fix: canonicalize app domain before auth

### DIFF
--- a/src/libs/next/proxy/define-config.test.ts
+++ b/src/libs/next/proxy/define-config.test.ts
@@ -77,6 +77,30 @@ describe('defineConfig middleware', () => {
     expect(authMock.getSession).not.toHaveBeenCalled();
   });
 
+  it('does not canonicalize the dev proxy bypass route', async () => {
+    const { middleware } = defineConfig();
+
+    const response = await middleware(
+      createRequest('https://other.example.com/_dangerous_local_dev_proxy/path?debug-host=local'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('location')).toBeNull();
+    expect(authMock.getSession).not.toHaveBeenCalled();
+  });
+
+  it('does not canonicalize backend endpoints from other hosts', async () => {
+    const { middleware } = defineConfig();
+
+    const response = await middleware(
+      createRequest('https://other.example.com/api/auth/get-session'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('location')).toBeNull();
+    expect(authMock.getSession).not.toHaveBeenCalled();
+  });
+
   it('allows canonical-host protected requests when the user is signed in', async () => {
     authMock.getSession.mockResolvedValue({ user: { id: 'user_1' } });
     const { middleware } = defineConfig();

--- a/src/libs/next/proxy/define-config.test.ts
+++ b/src/libs/next/proxy/define-config.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment node
+import type { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { defineConfig } from './define-config';
+
+const appEnvMock = vi.hoisted(() => ({
+  APP_URL: 'https://base.example.com',
+  MIDDLEWARE_REWRITE_THROUGH_LOCAL: false,
+}));
+
+const authMock = vi.hoisted(() => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock('@/auth', () => ({
+  auth: {
+    api: {
+      getSession: authMock.getSession,
+    },
+  },
+}));
+
+vi.mock('@/envs/app', () => ({
+  appEnv: appEnvMock,
+}));
+
+vi.mock('@/envs/auth', () => ({
+  authEnv: {
+    ENABLE_OIDC: true,
+  },
+}));
+
+vi.mock('@/utils/locale', () => ({
+  parseBrowserLanguage: vi.fn(() => 'en-US'),
+}));
+
+vi.mock('@/utils/server/routeVariants', () => ({
+  RouteVariants: {
+    serializeVariants: vi.fn(() => 'desktop'),
+  },
+}));
+
+const createRequest = (url: string): NextRequest => {
+  const nextUrl = new URL(url);
+
+  return {
+    cookies: {
+      get: vi.fn(() => undefined),
+    },
+    headers: new Headers({
+      host: nextUrl.host,
+    }),
+    method: 'GET',
+    nextUrl,
+    url,
+  } as unknown as NextRequest;
+};
+
+describe('defineConfig middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    appEnvMock.APP_URL = 'https://base.example.com';
+    appEnvMock.MIDDLEWARE_REWRITE_THROUGH_LOCAL = false;
+    authMock.getSession.mockResolvedValue(null);
+  });
+
+  it('redirects requests from other hosts to the canonical app URL before auth', async () => {
+    const { middleware } = defineConfig();
+
+    const response = await middleware(
+      createRequest('https://other.example.com/settings?tab=profile'),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('https://base.example.com/settings?tab=profile');
+    expect(authMock.getSession).not.toHaveBeenCalled();
+  });
+
+  it('allows canonical-host protected requests when the user is signed in', async () => {
+    authMock.getSession.mockResolvedValue({ user: { id: 'user_1' } });
+    const { middleware } = defineConfig();
+
+    const response = await middleware(
+      createRequest('https://base.example.com/settings?tab=profile'),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('location')).toBeNull();
+    expect(authMock.getSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('redirects canonical-host protected requests to sign-in when the user is signed out', async () => {
+    const { middleware } = defineConfig();
+
+    const response = await middleware(
+      createRequest('https://base.example.com/settings?tab=profile'),
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe(
+      'https://base.example.com/signin?callbackUrl=https%3A%2F%2Fbase.example.com%2Fsettings%3Ftab%3Dprofile',
+    );
+    expect(authMock.getSession).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/libs/next/proxy/define-config.test.ts
+++ b/src/libs/next/proxy/define-config.test.ts
@@ -41,7 +41,7 @@ vi.mock('@/utils/server/routeVariants', () => ({
   },
 }));
 
-const createRequest = (url: string): NextRequest => {
+const createRequest = (url: string, method = 'GET'): NextRequest => {
   const nextUrl = new URL(url);
 
   return {
@@ -51,7 +51,7 @@ const createRequest = (url: string): NextRequest => {
     headers: new Headers({
       host: nextUrl.host,
     }),
-    method: 'GET',
+    method,
     nextUrl,
     url,
   } as unknown as NextRequest;
@@ -99,6 +99,18 @@ describe('defineConfig middleware', () => {
     expect(response.status).toBe(200);
     expect(response.headers.get('location')).toBeNull();
     expect(authMock.getSession).not.toHaveBeenCalled();
+  });
+
+  it('does not canonicalize non-GET protected requests from other hosts', async () => {
+    const { middleware } = defineConfig();
+
+    const response = await middleware(createRequest('https://other.example.com/settings', 'POST'));
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe(
+      'https://base.example.com/signin?callbackUrl=https%3A%2F%2Fbase.example.com%2Fsettings',
+    );
+    expect(authMock.getSession).toHaveBeenCalledTimes(1);
   });
 
   it('allows canonical-host protected requests when the user is signed in', async () => {

--- a/src/libs/next/proxy/define-config.ts
+++ b/src/libs/next/proxy/define-config.ts
@@ -22,6 +22,24 @@ const logBetterAuth = debug('middleware:better-auth');
 // Dev-only debug proxy route should bypass all middleware rewrites.
 const dangerousLocalDevProxyRoute = '/_dangerous_local_dev_proxy';
 
+const getCanonicalAppRedirect = (request: NextRequest) => {
+  if (!appEnv.APP_URL) return;
+
+  try {
+    const appUrl = new URL(appEnv.APP_URL);
+    const requestUrl = new URL(request.url);
+
+    if (requestUrl.origin === appUrl.origin) return;
+
+    requestUrl.protocol = appUrl.protocol;
+    requestUrl.host = appUrl.host;
+
+    return NextResponse.redirect(requestUrl, 307);
+  } catch {
+    return;
+  }
+};
+
 export function defineConfig() {
   const backendApiEndpoints = ['/api', '/trpc', '/webapi', '/oidc'];
 
@@ -203,6 +221,9 @@ export function defineConfig() {
 
   const betterAuthMiddleware = async (req: NextRequest) => {
     logBetterAuth('BetterAuth middleware processing request: %s %s', req.method, req.url);
+
+    const canonicalRedirect = getCanonicalAppRedirect(req);
+    if (canonicalRedirect) return canonicalRedirect;
 
     const response = defaultMiddleware(req);
 

--- a/src/libs/next/proxy/define-config.ts
+++ b/src/libs/next/proxy/define-config.ts
@@ -185,6 +185,8 @@ export function defineConfig() {
   };
 
   const isPublicRoute = createRouteMatcher([
+    dangerousLocalDevProxyRoute,
+    `${dangerousLocalDevProxyRoute}(.*)`,
     // backend api
     '/api/v1(.*)', // OpenAPI routes should use OpenAPI auth (API Key/OIDC), not BetterAuth session
     '/api/auth(.*)',
@@ -222,15 +224,17 @@ export function defineConfig() {
   const betterAuthMiddleware = async (req: NextRequest) => {
     logBetterAuth('BetterAuth middleware processing request: %s %s', req.method, req.url);
 
-    const canonicalRedirect = getCanonicalAppRedirect(req);
-    if (canonicalRedirect) return canonicalRedirect;
-
     const response = defaultMiddleware(req);
 
     // when enable auth protection, only public route is not protected, others are all protected
     const isProtected = !isPublicRoute(req);
 
     logBetterAuth('Route protection status: %s, %s', req.url, isProtected ? 'protected' : 'public');
+
+    if (isProtected) {
+      const canonicalRedirect = getCanonicalAppRedirect(req);
+      if (canonicalRedirect) return canonicalRedirect;
+    }
 
     // Skip session lookup for public routes to reduce latency
     if (!isProtected) return response;

--- a/src/libs/next/proxy/define-config.ts
+++ b/src/libs/next/proxy/define-config.ts
@@ -21,6 +21,7 @@ const logBetterAuth = debug('middleware:better-auth');
 
 // Dev-only debug proxy route should bypass all middleware rewrites.
 const dangerousLocalDevProxyRoute = '/_dangerous_local_dev_proxy';
+const canonicalRedirectMethods = new Set(['GET', 'HEAD']);
 
 const getCanonicalAppRedirect = (request: NextRequest) => {
   if (!appEnv.APP_URL) return;
@@ -231,7 +232,7 @@ export function defineConfig() {
 
     logBetterAuth('Route protection status: %s, %s', req.url, isProtected ? 'protected' : 'public');
 
-    if (isProtected) {
+    if (isProtected && canonicalRedirectMethods.has(req.method)) {
       const canonicalRedirect = getCanonicalAppRedirect(req);
       if (canonicalRedirect) return canonicalRedirect;
     }


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

No linked issue.

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

Canonicalize requests from non-`APP_URL` origins before running the Better Auth session guard.

For self-hosted deployments, a non-canonical domain can still point to the app, but it does not carry the base-domain session cookie. Previously, protected routes on that domain could be treated as signed out and redirect directly to `/signin`, even when the user was already signed in on the configured base domain.

This change redirects those requests to the canonical `APP_URL` origin first while preserving the original path and query string. After that, the existing auth guard handles the known state normally:

- signed-in users continue into the requested page
- signed-out users are redirected to sign-in

From a state-transition perspective, this is a canonicalization step: unknown or non-canonical origin states are first reduced to the canonical base-domain state, then the existing auth transition function is reused. This keeps the auth decision in the only origin where the session cookie has semantic value, instead of adding separate auth branches for an origin that cannot observe the correct login state.

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
pnpm exec vitest run --silent='passed-only' src/libs/next/proxy/define-config.test.ts
pnpm exec eslint src/libs/next/proxy/define-config.ts src/libs/next/proxy/define-
config.test.ts
```

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

Not applicable. Middleware-only change.

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

The canonical redirect uses status `307` and runs before `auth.api.getSession`, so session checks happen only after the request has been moved back to the deployment's canonical origin.

The redirect is idempotent for canonical requests: once a request is already on `APP_URL`, the canonicalization step is a no-op. This avoids redirect loops while making the state flow simpler and more sufficient: `other domain -> base domain -> existing auth guard`.