### PR TITLE
🐛 fix(chat-input): close skill dropdown before navigating to settings

### DIFF
--- a/src/features/ChatInput/ActionBar/Plus/index.tsx
+++ b/src/features/ChatInput/ActionBar/Plus/index.tsx
@@ -288,6 +288,7 @@ const PlusAction = memo(() => {
     footer: knowledgeFooter,
     items: knowledgeItems,
   } = useKnowledgeControls({ openAttachKnowledgeModal: handleOpenKnowledge });
+  const closeDropdown = useCallback(() => setDropdownOpen(false), []);
   const {
     autoCount: skillAutoCount,
     editPluginDrawer: skillEditPluginDrawer,
@@ -295,7 +296,7 @@ const PlusAction = memo(() => {
     marketHeader: skillMarketHeader,
     marketItems: skillItems,
     pinnedCount: skillPinnedCount,
-  } = useToolsControls();
+  } = useToolsControls({ closeDropdown });
 
   const isModelBuiltinSearchInternal = useAiInfraStore(
     aiModelSelectors.isModelBuiltinSearchInternal(model, provider),

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -332,7 +332,10 @@ const styles = createStaticStyles(({ css }) => ({
     display: flex;
     gap: 14px;
     align-items: center;
-    width: 100%;
+
+    margin-block-end: -4px;
+    margin-inline: -8px;
+    padding-inline: 8px;
   `,
   statsSettingsButton: css`
     cursor: pointer;
@@ -373,7 +376,7 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-export const useControls = () => {
+export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = {}) => {
   const { t } = useTranslation('setting');
   const agentId = useAgentId();
   const navigate = useNavigate();
@@ -1283,6 +1286,7 @@ export const useControls = () => {
             type="button"
             onClick={(event) => {
               event.stopPropagation();
+              closeDropdown?.();
               navigate('/settings/skill');
             }}
           >

--- a/src/features/ModelSwitchPanel/components/Footer.tsx
+++ b/src/features/ModelSwitchPanel/components/Footer.tsx
@@ -25,8 +25,8 @@ export const Footer: FC<FooterProps> = ({ onClose }) => {
         paddingInline={12}
         variant={'borderless'}
         onClick={() => {
-          navigate('/settings/provider/all');
           onClose();
+          navigate('/settings/provider/all');
         }}
       >
         <Flexbox horizontal align={'center'} gap={8} style={{ flex: 1 }}>

--- a/src/features/ModelSwitchPanel/components/List/GenerationListItemRenderer.tsx
+++ b/src/features/ModelSwitchPanel/components/List/GenerationListItemRenderer.tsx
@@ -54,8 +54,8 @@ const GenerationListItemRenderer = memo<GenerationListItemRendererProps>(
             gap={8}
             style={{ color: cssVar.colorTextTertiary }}
             onClick={() => {
-              navigate('/settings/provider/all');
               onClose();
+              navigate('/settings/provider/all');
             }}
           >
             {t('ModelSwitchPanel.emptyProvider')}

--- a/src/features/ModelSwitchPanel/components/List/ListItemRenderer.tsx
+++ b/src/features/ModelSwitchPanel/components/List/ListItemRenderer.tsx
@@ -72,7 +72,10 @@ export const ListItemRenderer = memo<ListItemRendererProps>(
             key="no-provider"
             style={{ color: cssVar.colorTextTertiary }}
             variant={'borderless'}
-            onClick={() => navigate('/settings/provider/all')}
+            onClick={() => {
+              onClose();
+              navigate('/settings/provider/all');
+            }}
           >
             {t('ModelSwitchPanel.emptyProvider')}
             <Icon icon={LucideArrowRight} />
@@ -125,7 +128,10 @@ export const ListItemRenderer = memo<ListItemRendererProps>(
             gap={8}
             key={`empty-${item.provider.id}`}
             style={{ color: cssVar.colorTextTertiary }}
-            onClick={() => navigate(`/settings/provider/${item.provider.id}`)}
+            onClick={() => {
+              onClose();
+              navigate(`/settings/provider/${item.provider.id}`);
+            }}
           >
             {t('ModelSwitchPanel.emptyModel')}
             <Icon icon={LucideArrowRight} />


### PR DESCRIPTION
## Summary

- The skill market dropdown's settings button calls `navigate('/settings/skill')` but never closes the controlled dropdown. After the chat-input trigger unmounts, the menu lingers on screen — reported as LOBE-9852.
- Restore the negative margins on the stats footer (regressed in #15214 when bumping `@lobehub/ui` to 5.15.1) so the row aligns with the dropdown's outer padding instead of leaving a visible gap.
- Sweep the surrounding ModelSwitchPanel for the same shape: `ListItemRenderer` `no-provider` / `empty-model` rows used to navigate **without** calling `onClose` at all; `Footer` and `GenerationListItemRenderer` closed **after** navigate. All four now close first, then navigate.

## Test plan

- [ ] On the homepage (not inside an agent chat), open the **Plus → Skills** dropdown, click the settings gear in the footer → settings page opens and the dropdown closes.
- [ ] Open the **ModelSwitchPanel** with no provider configured, click the "empty provider" row → settings opens, panel closes.
- [ ] Same panel: click the bottom "Manage providers" footer → settings opens, panel closes.
- [ ] Generation panel "no provider" row: same.
- [ ] Verify the stats footer (skill counts + settings button) sits flush against the dropdown's inner edges — no inset gap on left/right/bottom.

Closes LOBE-9852