### PR TITLE
🐛 fix(chat-input): restore editor focus after file picker closes

### DIFF
--- a/src/features/ChatInput/ActionBar/Plus/index.tsx
+++ b/src/features/ChatInput/ActionBar/Plus/index.tsx
@@ -277,6 +277,7 @@ const PlusAction = memo(() => {
 
   const isMemoryEnabled = useMemoryEnabled(agentId);
   const [showTypoBar, setShowTypoBar] = useChatInputStore((s) => [s.showTypoBar, s.setShowTypoBar]);
+  const editor = useChatInputStore((s) => s.editor);
   const { canUploadImage, canUploadVideo } = useVisualMediaUploadAbility(model, provider);
   const enableFC = useModelSupportToolUse(model, provider);
   const handleOpenKnowledge = useCallback(() => {
@@ -414,6 +415,7 @@ const PlusAction = memo(() => {
                 return false;
               }
               setDropdownOpen(false);
+              editor?.focus();
               await upload([file]);
               return false;
             }}
@@ -565,6 +567,7 @@ const PlusAction = memo(() => {
     activeSearchOption,
     canUploadImage,
     canUploadVideo,
+    editor,
     enableFC,
     enableKnowledgeBase,
     handleOpenTools,

--- a/src/features/ChatInput/ActionBar/Upload/index.tsx
+++ b/src/features/ChatInput/ActionBar/Upload/index.tsx
@@ -22,6 +22,7 @@ import { useUserStore } from '@/store/user';
 import { preferenceSelectors } from '@/store/user/selectors';
 
 import { useAgentId } from '../../hooks/useAgentId';
+import { useChatInputStore } from '../../store';
 import Action from '../components/Action';
 import { type ActionDropdownMenuItems } from '../components/ActionDropdown';
 import CheckboxItem from '../components/CheckboxWithLoading';
@@ -43,6 +44,7 @@ const FileUpload = memo(() => {
   );
 
   const upload = useFileStore((s) => s.uploadChatFiles);
+  const editor = useChatInputStore((s) => s.editor);
 
   const agentId = useAgentId();
   const model = useAgentStore((s) => agentByIdSelectors.getAgentModelById(agentId)(s));
@@ -83,6 +85,7 @@ const FileUpload = memo(() => {
           showUploadList={false}
           beforeUpload={async (file) => {
             setDropdownOpen(false);
+            editor?.focus();
             await upload([file]);
 
             return false;
@@ -123,6 +126,7 @@ const FileUpload = memo(() => {
             }
 
             setDropdownOpen(false);
+            editor?.focus();
             await upload([file]);
 
             return false;
@@ -160,6 +164,7 @@ const FileUpload = memo(() => {
             }
 
             setDropdownOpen(false);
+            editor?.focus();
             await upload([file]);
 
             return false;

--- a/src/features/EditorCanvas/editorAttachments.ts
+++ b/src/features/EditorCanvas/editorAttachments.ts
@@ -46,6 +46,9 @@ export const insertFilesIntoEditor = (editor: IEditor | undefined, files: File[]
       lexicalEditor.dispatchCommand(INSERT_FILE_COMMAND, { file });
     }
   }
+  // File picker / Upload dropdown steals focus; restore it so the cursor
+  // remains visible and the user can keep typing.
+  editor.focus?.();
 };
 
 export const pickAndInsertAttachments = (editor: IEditor | undefined, accept?: string): void => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-9862

#### 🔀 Description of Change

Picking files through the chat-input `Upload` dropdowns (paperclip / plus menus) and through the AgentTasks attachment helpers left focus on `document.body` once the OS file picker closed. The editor cursor disappeared and it was unclear whether typing could continue — surfaced by Rene Wang in Discord #dev.

Refocus the editor as soon as the picker yields:

- `ChatInput/ActionBar/Upload`: subscribe to `editor` from the chat-input store and call `editor?.focus()` inside the three `beforeUpload` handlers (image / file / folder).
- `ChatInput/ActionBar/Plus`: same one-liner for the unified file-or-image upload entry, plus `editor` added to the items `useMemo` deps.
- `EditorCanvas/editorAttachments`: refocus inside `insertFilesIntoEditor` so every AgentTasks composer (`CommentInput`, `CommentCard`, `FeedbackInput`, `CreateTaskContent`, `CreateTaskInlineEntry`, `TaskInstruction`) recovers the cursor through the shared helper, including the native `pickAndInsertAttachments` flow.

Other antd `Upload` call sites (avatar / profile / cred / DataImporter / SkillStore / ResourceManager / Topic JSON import / PageExplorerPlaceholder) are not editor contexts and need no change.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Manual:
1. Open a chat, click the paperclip → Image / File / Folder upload — after selecting from the OS dialog, the editor cursor blinks again and typing continues.
2. Repeat with the `+` menu → File or image upload.
3. In an AgentTask detail, drop a file via the comment composer's attachment button — cursor remains in the editor.

#### 📸 Screenshots / Videos

N/A — behavior change only (focus restoration).

#### 📝 Additional Information

No breaking changes; no migration needed.