### PR TITLE
chore: remove LOBE-XXX annotations from code comments

### DIFF
--- a/apps/cli/e2e/agent-signal.e2e.test.ts
+++ b/apps/cli/e2e/agent-signal.e2e.test.ts
@@ -13,7 +13,7 @@ import {
  * E2E tests for `lh agent-signal trigger`.
  *
  * The "golden fixture" block runs fully offline — it is the structural
- * regression baseline that the execAgent migration (LOBE-9434 #5/#7) asserts
+ * regression baseline that the execAgent migration asserts
  * against. The "live trigger" block requires a running server + authenticated
  * CLI and is gated behind AGENT_SIGNAL_AGENT_ID (or AGENT_ID).
  *

--- a/apps/cli/e2e/fixtures/agent-signal/assertGoldenFinalState.ts
+++ b/apps/cli/e2e/fixtures/agent-signal/assertGoldenFinalState.ts
@@ -1,7 +1,7 @@
 /**
  * Standalone structural assertions for self-iteration finalState snapshots.
  *
- * Dependency-free on purpose: the execAgent migration PRs (LOBE-9434 #5/#7)
+ * Dependency-free on purpose: the execAgent migration PRs
  * import this from server tests AND the CLI e2e suite, so it must not pull in
  * vitest or any server-only module. Mirrors the `kind` discrimination used by
  * `src/server/services/agentSignal/services/selfIteration/finalStateExtractor.ts`.

--- a/packages/builtin-tool-agent-signal/src/shared/ExecutionRuntime.ts
+++ b/packages/builtin-tool-agent-signal/src/shared/ExecutionRuntime.ts
@@ -2,7 +2,7 @@ import type { BuiltinServerRuntimeOutput } from '@lobechat/types';
 
 import { AGENT_SIGNAL_TOOL_RESULT_KIND, type AgentSignalToolApiName } from './apiNames';
 
-/** Tool result discriminator (LOBE-9434 #5). */
+/** Tool result discriminator. */
 export type ToolResultKind = 'artifact' | 'mutation' | 'read';
 
 /**

--- a/packages/builtin-tool-agent-signal/src/shared/apiNames.ts
+++ b/packages/builtin-tool-agent-signal/src/shared/apiNames.ts
@@ -45,7 +45,7 @@ export type AgentSignalToolApiName =
   | (typeof AGENT_SIGNAL_REFLECTION_TOOL_API_NAMES)[number];
 
 /**
- * Result discriminator per tool (LOBE-9434 #5). The shared ExecutionRuntime
+ * Result discriminator per tool. The shared ExecutionRuntime
  * stamps this onto every tool result so `extractFromFinalState` can partition
  * read / artifact / mutation outcomes from a persisted snapshot.
  */

--- a/packages/types/src/agentRuntime.ts
+++ b/packages/types/src/agentRuntime.ts
@@ -120,7 +120,9 @@ export const AgentRuntimeErrorType = {
    * effectively gives up. Retryable: re-issuing the same request usually
    * yields a real response. Without this code the harness silently finalized
    * to `done` and persisted a blank assistant message (empty bubble). See
-   * LOBE-9834.
+   * This addresses the "empty completion" failure mode: after a stalled
+   * tool loop the model may give up and emit a blank turn with ~0 output
+   * tokens, no text, and no tool calls.
    */
   ModelEmptyCompletion: 'ModelEmptyCompletion',
   /**

--- a/src/server/modules/AgentRuntime/ModelEmptyError.ts
+++ b/src/server/modules/AgentRuntime/ModelEmptyError.ts
@@ -3,7 +3,7 @@ import { AgentRuntimeErrorType } from '@lobechat/types';
 /**
  * Thrown by the `call_llm` executor when the model returns an empty completion
  * — no text content, no reasoning, no tool calls, no images, and ~0 output
- * tokens. This is the LOBE-9834 failure mode: after a stalled tool loop the
+ * tokens. This is the "empty completion" failure mode: after a stalled tool loop the
  * model effectively gives up and emits a blank turn, which the harness used to
  * silently finalize to `done` while persisting an empty assistant message
  * (empty bubble, `status=done, error=null`).

--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -119,7 +119,7 @@ const LLM_RETRY_BASE_DELAY_MS = 1000;
 const LLM_RETRY_MAX_DELAY_MS = 30_000;
 
 /**
- * Retry budget for empty completions (LOBE-9834), applied independently of
+ * Retry budget for empty completions, applied independently of
  * `resolveLLMMaxRetries`. The branded provider gets 0 general retries because
  * its own fallback chain already re-routes failed requests — but an
  * HTTP-200-but-empty turn never triggered that chain, so it must still be
@@ -130,13 +130,13 @@ const EMPTY_COMPLETION_MAX_RETRIES = 2;
 
 /**
  * Output-token count at or below this — combined with no content, reasoning,
- * tool calls, or images — marks a turn as an empty completion (LOBE-9834).
+ * tool calls, or images — marks a turn as an empty completion.
  * The observed failure case reported `out=1 token`.
  */
 const EMPTY_COMPLETION_MAX_OUTPUT_TOKENS = 1;
 
 /**
- * Detect the "empty completion" failure mode (LOBE-9834): the model returns a
+ * Detect the "empty completion" failure mode: the model returns a
  * turn with no text, no reasoning, no tool calls, no images, and ~0 output
  * tokens — typically after a stalled tool loop where it effectively gives up.
  * Callers throw `ModelEmptyError` on a hit so the LLM retry loop re-attempts
@@ -248,7 +248,7 @@ const resolveLLMMaxRetries = (provider: string) =>
  * error-type override, so it can only be resolved once the error exists (in the
  * catch) — unlike {@link resolveLLMMaxRetries}, which runs before the request.
  *
- * Empty completions (LOBE-9834) bypass the per-provider policy: the branded
+ * Empty completions bypass the per-provider policy: the branded
  * provider's 0-retry rule exists to avoid re-routing its own already-failed
  * requests, but an HTTP-200-but-empty turn never hit that fallback chain, so it
  * must still be re-issued. Folding this into `resolveLLMMaxRetries` would wrongly
@@ -1203,7 +1203,7 @@ export const createRuntimeExecutors = (
               await flushReasoningBuffer();
               clearAttemptBuffers();
 
-              // Empty-completion guard (LOBE-9834): if the model produced
+              // Empty-completion guard: if the model produced
               // nothing actionable — no content, reasoning, tool calls, images,
               // or output tokens — throw so the retry loop below re-attempts the
               // turn instead of finalizing to `done` with a blank assistant

--- a/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -32,7 +32,7 @@ const mockBuiltinModels = vi.hoisted(() => [
 vi.mock('@/server/modules/ModelRuntime', () => ({
   initModelRuntimeFromDB: vi.fn().mockResolvedValue({
     // Emit a minimal non-empty completion so the call_llm empty-completion
-    // guard (LOBE-9834) doesn't treat the default mock as a "gave up" turn and
+    // guard doesn't treat the default mock as a "gave up" turn and
     // throw ModelEmptyError. Tests that exercise real output override this.
     chat: vi.fn().mockImplementation(async (_payload: any, options: any) => {
       await options?.callback?.onText?.('done');
@@ -399,9 +399,9 @@ describe('RuntimeExecutors', () => {
       );
     });
 
-    it('retries empty completions on the branded provider then throws ModelEmptyError (LOBE-9834)', async () => {
+    it('retries empty completions on the branded provider then throws ModelEmptyError', async () => {
       // A "gave up" turn: no onText / onThinking / onToolsCalling and ~0 output
-      // tokens — mirrors the LOBE-9834 repro (provider=lobehub, `out=1 token`).
+      // tokens — mirrors the empty completion repro (provider=lobehub, `out=1 token`).
       // The branded provider has 0 general retries, but empty completions get a
       // dedicated budget so the request is still re-issued before failing.
       vi.useFakeTimers();

--- a/src/server/modules/AgentRuntime/__tests__/llmErrorClassification.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/llmErrorClassification.test.ts
@@ -87,7 +87,7 @@ describe('classifyLLMError', () => {
       expect(classifyLLMError({ errorType, message }).kind).toBe('retry');
     });
 
-    it('classifies a thrown ModelEmptyError instance as retry (LOBE-9834)', () => {
+    it('classifies a thrown ModelEmptyError instance as retry', () => {
       expect(classifyLLMError(new ModelEmptyError()).kind).toBe('retry');
     });
   });

--- a/src/server/modules/AgentRuntime/formatErrorForState.test.ts
+++ b/src/server/modules/AgentRuntime/formatErrorForState.test.ts
@@ -54,7 +54,7 @@ describe('formatErrorForState', () => {
       });
     });
 
-    it('enriches a thrown ModelEmptyError into a readable retryable terminal error (LOBE-9834)', () => {
+    it('enriches a thrown ModelEmptyError into a readable retryable terminal error', () => {
       const result = formatErrorForState(new ModelEmptyError());
 
       // The `errorType` field must win over the generic Error → InternalServerError

--- a/src/store/task/selectors/detailSelectors.ts
+++ b/src/store/task/selectors/detailSelectors.ts
@@ -28,7 +28,7 @@ const activeTaskDescription = (s: TaskStoreState) => activeTaskDetail(s)?.descri
 
 const activeTaskAgentId = (s: TaskStoreState) => activeTaskDetail(s)?.agentId;
 
-// TODO [LOBE-6634]: Once the backend getTaskDetail returns model/provider, read from detail.model / detail.provider instead
+// TODO: Once the frontend store switches to reading from detail.model / detail.provider returned by the backend getTaskDetail procedure
 const activeTaskModel = (s: TaskStoreState) =>
   activeTaskDetail(s)?.config?.model as string | undefined;
 

--- a/src/store/task/slices/detail/action.ts
+++ b/src/store/task/slices/detail/action.ts
@@ -19,7 +19,7 @@ type DeletedTask = NonNullable<Awaited<ReturnType<typeof taskService.delete>>['d
 // - model/provider goes through configSlice.updateTaskModelConfig
 // - checkpoint goes through configSlice.updateCheckpoint
 // - review goes through configSlice.updateReview
-// - heartbeat config will get a dedicated action once the upstream infra in LOBE-6587 is complete
+// - heartbeat config will get a dedicated action once the upstream task scheduler infra is complete
 export interface TaskUpdatePayload {
   assigneeAgentId?: string | null;
   description?: string;


### PR DESCRIPTION
## Summary

Daily cleanup of `LOBE-XXX` internal annotations from source code comments. As an open-source project, internal Linear issue markers should not remain in the codebase.

## Changes

### LOBE-9834 - empty completion failure mode (10 references)

Replaced inline references with descriptive context about the "empty completion" failure mode: after a stalled tool loop, the model may give up and emit a blank turn with ~0 output tokens, no text, and no tool calls.

| File | Change |
|---|---|
| `src/server/modules/AgentRuntime/ModelEmptyError.ts` | Reword comment |
| `src/server/modules/AgentRuntime/RuntimeExecutors.ts` | Remove 4 references |
| `src/server/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts` | Remove 3 references |
| `src/server/modules/AgentRuntime/__tests__/llmErrorClassification.test.ts` | Remove test name suffix |
| `src/server/modules/AgentRuntime/formatErrorForState.test.ts` | Remove test name suffix |
| `packages/types/src/agentRuntime.ts` | Replace with inline description |

### LOBE-6587 - task scheduler infra (1 reference)

| File | Change |
|---|---|
| `src/store/task/slices/detail/action.ts` | Replace with "task scheduler infra" |

### LOBE-6634 - getTaskDetail model/provider (1 reference)

| File | Change |
|---|---|
| `src/store/task/selectors/detailSelectors.ts` | Reword TODO comment |

### LOBE-9434 #5/#7 - execAgent migration (4 references)

| File | Change |
|---|---|
| `packages/builtin-tool-agent-signal/src/shared/apiNames.ts` | Remove issue marker |
| `packages/builtin-tool-agent-signal/src/shared/ExecutionRuntime.ts` | Remove issue marker |
| `apps/cli/e2e/agent-signal.e2e.test.ts` | Remove issue marker |
| `apps/cli/e2e/fixtures/agent-signal/assertGoldenFinalState.ts` | Remove issue marker |

## Files changed

12 files changed, 20 insertions(+), 18 deletions(-)
