### PR TITLE
♻️ refactor(modal): convert create custom model modal to base-ui imperative API

### DIFF
--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/Content.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/Content.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { type FormInstance } from 'antd';
+import { memo } from 'react';
+
+import ModelConfigForm from './Form';
+
+interface CreateNewModelContentProps {
+  onFormReady: (instance: FormInstance) => void;
+  showDeployName?: boolean;
+}
+
+const CreateNewModelContent = memo<CreateNewModelContentProps>(
+  ({ showDeployName, onFormReady }) => (
+    <ModelConfigForm showDeployName={showDeployName} onFormInstanceReady={onFormReady} />
+  ),
+);
+
+export default CreateNewModelContent;

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -1,8 +1,8 @@
-import { Flexbox } from '@lobehub/ui';
-import { Popover, Select, Space, Switch, Tag, theme, Typography } from 'antd';
+import { Flexbox, Popover } from '@lobehub/ui';
+import { Select } from '@lobehub/ui/base-ui';
+import { Space, Switch, Tag, theme, Typography } from 'antd';
 import { type ExtendParamsType } from 'model-bank';
-import { type ReactNode } from 'react';
-import { memo, useMemo } from 'react';
+import { memo, type ReactNode, type SyntheticEvent, useMemo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import CodexMaxReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/CodexMaxReasoningEffortSlider';
@@ -316,39 +316,55 @@ const PreviewContent = ({
     ? { minWidth: previewWidth, width: previewWidth }
     : { minWidth: 240 };
 
+  const stop = (e: SyntheticEvent) => e.stopPropagation();
+
   return (
-    <Flexbox gap={12} style={containerStyle}>
-      <Typography.Text style={{ whiteSpace: 'normal' }} type={'secondary'}>
-        {hint}
-      </Typography.Text>
-      <Flexbox gap={12}>
-        <Flexbox
-          gap={8}
-          style={{
-            background: token.colorBgElevated,
-            border: `1px solid ${token.colorBorderSecondary}`,
-            borderRadius: 10,
-            padding: 12,
-            width: previewWidth,
-          }}
-        >
-          <Flexbox horizontal align={'center'} gap={8}>
-            <Typography.Text strong>{label}</Typography.Text>
-            {parameterTag ? <Tag color={'cyan'}>{parameterTag}</Tag> : null}
+    <div
+      onClick={stop}
+      onClickCapture={stop}
+      onKeyDown={stop}
+      onMouseDown={stop}
+      onMouseDownCapture={stop}
+      onMouseUp={stop}
+      onMouseUpCapture={stop}
+      onPointerDown={stop}
+      onPointerDownCapture={stop}
+      onPointerUp={stop}
+      onPointerUpCapture={stop}
+    >
+      <Flexbox gap={12} style={containerStyle}>
+        <Typography.Text style={{ whiteSpace: 'normal' }} type={'secondary'}>
+          {hint}
+        </Typography.Text>
+        <Flexbox gap={12}>
+          <Flexbox
+            gap={8}
+            style={{
+              background: token.colorBgElevated,
+              border: `1px solid ${token.colorBorderSecondary}`,
+              borderRadius: 10,
+              padding: 12,
+              width: previewWidth,
+            }}
+          >
+            <Flexbox horizontal align={'center'} gap={8}>
+              <Typography.Text strong>{label}</Typography.Text>
+              {parameterTag ? <Tag color={'cyan'}>{parameterTag}</Tag> : null}
+            </Flexbox>
+            {desc ? (
+              <Typography.Text style={{ fontSize: 12, whiteSpace: 'normal' }} type={'secondary'}>
+                {desc}
+              </Typography.Text>
+            ) : null}
+            {preview ? (
+              <div style={{ pointerEvents: 'none', width: '100%' }}>{preview}</div>
+            ) : (
+              <Typography.Text type={'secondary'}>{previewFallback}</Typography.Text>
+            )}
           </Flexbox>
-          {desc ? (
-            <Typography.Text style={{ fontSize: 12, whiteSpace: 'normal' }} type={'secondary'}>
-              {desc}
-            </Typography.Text>
-          ) : null}
-          {preview ? (
-            <div style={{ pointerEvents: 'none', width: '100%' }}>{preview}</div>
-          ) : (
-            <Typography.Text type={'secondary'}>{previewFallback}</Typography.Text>
-          )}
         </Flexbox>
       </Flexbox>
-    </Flexbox>
+    </div>
   );
 };
 

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -357,7 +357,9 @@ const PreviewContent = ({
               </Typography.Text>
             ) : null}
             {preview ? (
-              <div style={{ pointerEvents: 'none', width: '100%' }}>{preview}</div>
+              <div aria-hidden style={{ opacity: 0.72, pointerEvents: 'none', width: '100%' }}>
+                {preview}
+              </div>
             ) : (
               <Typography.Text type={'secondary'}>{previewFallback}</Typography.Text>
             )}
@@ -372,7 +374,7 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
   const { t } = useTranslation('modelProvider');
   const { t: tChat } = useTranslation('chat');
 
-  // Preview controls use controlled mode with default values (no store access)
+  // Preview controls are read-only examples; the form only stores supported parameter keys.
   const previewControls = useMemo<Partial<Record<ExtendParamsType, ReactNode>>>(
     () => ({
       codexMaxReasoningEffort: <CodexMaxReasoningEffortSlider value="medium" />,

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/Footer.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/Footer.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { Button } from '@lobehub/ui';
+import { ModalFooter, useModalContext } from '@lobehub/ui/base-ui';
+import { type FormInstance } from 'antd';
+import { memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useAiInfraStore } from '@/store/aiInfra';
+
+interface CreateNewModelFooterProps {
+  formRef: { current?: FormInstance };
+}
+
+const CreateNewModelFooter = memo<CreateNewModelFooterProps>(({ formRef }) => {
+  const { t } = useTranslation('common');
+  const { close } = useModalContext();
+  const [loading, setLoading] = useState(false);
+  const [editingProvider, createNewAiModel] = useAiInfraStore((s) => [
+    s.activeAiProvider!,
+    s.createNewAiModel,
+  ]);
+
+  return (
+    <ModalFooter>
+      <Button onClick={close}>{t('cancel')}</Button>
+      <Button
+        loading={loading}
+        type="primary"
+        onClick={async () => {
+          const form = formRef.current;
+          if (!editingProvider || !form) return;
+
+          setLoading(true);
+
+          try {
+            await form.validateFields();
+            const data = form.getFieldsValue();
+            await createNewAiModel({ ...data, providerId: editingProvider });
+            setLoading(false);
+            close();
+          } catch {
+            setLoading(false);
+          }
+        }}
+      >
+        {t('ok')}
+      </Button>
+    </ModalFooter>
+  );
+});
+
+export default CreateNewModelFooter;

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/index.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/index.tsx
@@ -1,80 +1,33 @@
-import { Button, Modal } from '@lobehub/ui';
+'use client';
+
+import { createModal, type ModalInstance } from '@lobehub/ui/base-ui';
 import { type FormInstance } from 'antd';
-import { memo, use, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { t } from 'i18next';
 
-import { useAiInfraStore } from '@/store/aiInfra';
+import CreateNewModelContent from './Content';
+import CreateNewModelFooter from './Footer';
 
-import { ProviderSettingsContext } from '../ProviderSettingsContext';
-import ModelConfigForm from './Form';
-
-interface ModelConfigModalProps {
-  open: boolean;
-  setOpen: (open: boolean) => void;
+interface CreateNewModelModalOptions {
+  showDeployName?: boolean;
 }
 
-const ModelConfigModal = memo<ModelConfigModalProps>(({ open, setOpen }) => {
-  const { t } = useTranslation(['modelProvider', 'common']);
-  const [formInstance, setFormInstance] = useState<FormInstance>();
-  const [loading, setLoading] = useState(false);
-  const [editingProvider, createNewAiModel] = useAiInfraStore((s) => [
-    s.activeAiProvider!,
-    s.createNewAiModel,
-  ]);
+export const createCreateNewModelModal = (
+  options: CreateNewModelModalOptions = {},
+): ModalInstance => {
+  const formRef: { current?: FormInstance } = {};
 
-  const closeModal = () => {
-    setOpen(false);
-  };
-
-  const { showDeployName } = use(ProviderSettingsContext);
-
-  return (
-    <Modal
-      destroyOnHidden
-      maskClosable
-      open={open}
-      title={t('providerModels.createNew.title')}
-      zIndex={1251} // Select is 1150
-      footer={[
-        <Button key="cancel" onClick={closeModal}>
-          {t('cancel', { ns: 'common' })}
-        </Button>,
-
-        <Button
-          key="ok"
-          loading={loading}
-          style={{ marginInlineStart: '16px' }}
-          type="primary"
-          onClick={async () => {
-            if (!editingProvider || !formInstance) return;
-            const data = formInstance.getFieldsValue();
-
-            setLoading(true);
-
-            try {
-              await formInstance.validateFields();
-              await createNewAiModel({ ...data, providerId: editingProvider });
-              setLoading(false);
-              closeModal();
-            } catch {
-              setLoading(false);
-            }
-          }}
-        >
-          {t('ok', { ns: 'common' })}
-        </Button>,
-      ]}
-      styles={{
-        body: {
-          display: 'flex',
-          flexDirection: 'column',
-          maxHeight: 'calc(100vh - 150px)',
-        },
-      }}
-      onCancel={closeModal}
-    >
-      <ModelConfigForm showDeployName={showDeployName} onFormInstanceReady={setFormInstance} />
-    </Modal>
-  );
-});
-export default ModelConfigModal;
+  return createModal({
+    content: (
+      <CreateNewModelContent
+        showDeployName={options.showDeployName}
+        onFormReady={(instance) => {
+          formRef.current = instance;
+        }}
+      />
+    ),
+    footer: <CreateNewModelFooter formRef={formRef} />,
+    maskClosable: true,
+    title: t('providerModels.createNew.title', { ns: 'modelProvider' }),
+    width: 'min(90vw, 640px)',
+  });
+};

--- a/src/routes/(main)/settings/provider/features/ModelList/EmptyModels.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/EmptyModels.tsx
@@ -1,12 +1,13 @@
 import { Button, Center, Flexbox, Icon } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { BrainIcon, LucideRefreshCcwDot, PlusIcon } from 'lucide-react';
-import { memo, useState } from 'react';
+import { memo, use, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useAiInfraStore } from '@/store/aiInfra';
 
-import CreateNewModelModal from './CreateNewModelModal';
+import { createCreateNewModelModal } from './CreateNewModelModal';
+import { ProviderSettingsContext } from './ProviderSettingsContext';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   circle: css`
@@ -50,7 +51,7 @@ const EmptyState = memo<{ provider: string }>(({ provider }) => {
   const [fetchRemoteModelList] = useAiInfraStore((s) => [s.fetchRemoteModelList]);
 
   const [fetchRemoteModelsLoading, setFetchRemoteModelsLoading] = useState(false);
-  const [showModal, setShowModal] = useState(false);
+  const { showDeployName } = use(ProviderSettingsContext);
 
   return (
     <Center className={styles.container} gap={24} paddingBlock={40}>
@@ -66,12 +67,11 @@ const EmptyState = memo<{ provider: string }>(({ provider }) => {
         <Button
           icon={PlusIcon}
           onClick={() => {
-            setShowModal(true);
+            createCreateNewModelModal({ showDeployName });
           }}
         >
           {t('providerModels.list.addNew')}
         </Button>
-        <CreateNewModelModal open={showModal} setOpen={setShowModal} />
         <Button
           icon={<Icon icon={LucideRefreshCcwDot} />}
           loading={fetchRemoteModelsLoading}

--- a/src/routes/(main)/settings/provider/features/ModelList/ModelConfigModal/Content.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/ModelConfigModal/Content.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { type FormInstance } from 'antd';
+import isEqual from 'fast-deep-equal';
+import { memo } from 'react';
+
+import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
+
+import ModelConfigForm from '../CreateNewModelModal/Form';
+
+interface ModelConfigContentProps {
+  id: string;
+  onFormReady: (instance: FormInstance) => void;
+  showDeployName?: boolean;
+}
+
+const ModelConfigContent = memo<ModelConfigContentProps>(({ id, showDeployName, onFormReady }) => {
+  const model = useAiInfraStore(aiModelSelectors.getAiModelById(id), isEqual);
+
+  return (
+    <ModelConfigForm
+      idEditable={false}
+      initialValues={model}
+      showDeployName={showDeployName}
+      type={model?.type}
+      onFormInstanceReady={onFormReady}
+    />
+  );
+});
+
+export default ModelConfigContent;

--- a/src/routes/(main)/settings/provider/features/ModelList/ModelConfigModal/Footer.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/ModelConfigModal/Footer.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Button } from '@lobehub/ui';
+import { ModalFooter, useModalContext } from '@lobehub/ui/base-ui';
+import { type FormInstance } from 'antd';
+import { memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useAiInfraStore } from '@/store/aiInfra';
+
+interface ModelConfigFooterProps {
+  formRef: { current?: FormInstance };
+  id: string;
+}
+
+const ModelConfigFooter = memo<ModelConfigFooterProps>(({ formRef, id }) => {
+  const { t } = useTranslation('common');
+  const { close } = useModalContext();
+  const [loading, setLoading] = useState(false);
+  const [editingProvider, updateAiModelsConfig] = useAiInfraStore((s) => [
+    s.activeAiProvider!,
+    s.updateAiModelsConfig,
+  ]);
+
+  return (
+    <ModalFooter>
+      <Button onClick={close}>{t('cancel')}</Button>
+      <Button
+        loading={loading}
+        type="primary"
+        onClick={async () => {
+          const form = formRef.current;
+          if (!editingProvider || !id || !form) return;
+          const data = form.getFieldsValue();
+
+          setLoading(true);
+          await updateAiModelsConfig(id, editingProvider, data);
+          setLoading(false);
+
+          close();
+        }}
+      >
+        {t('ok')}
+      </Button>
+    </ModalFooter>
+  );
+});
+
+export default ModelConfigFooter;

--- a/src/routes/(main)/settings/provider/features/ModelList/ModelConfigModal/index.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/ModelConfigModal/index.tsx
@@ -1,82 +1,33 @@
-import { Button, Modal } from '@lobehub/ui';
+'use client';
+
+import { createModal, type ModalInstance } from '@lobehub/ui/base-ui';
 import { type FormInstance } from 'antd';
-import isEqual from 'fast-deep-equal';
-import { memo, use, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { t } from 'i18next';
 
-import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
+import ModelConfigContent from './Content';
+import ModelConfigFooter from './Footer';
 
-import ModelConfigForm from '../CreateNewModelModal/Form';
-import { ProviderSettingsContext } from '../ProviderSettingsContext';
-
-interface ModelConfigModalProps {
+interface ModelConfigModalOptions {
   id: string;
-  open: boolean;
-  setOpen: (open: boolean) => void;
+  showDeployName?: boolean;
 }
 
-const ModelConfigModal = memo<ModelConfigModalProps>(({ id, open, setOpen }) => {
-  const { t } = useTranslation(['common', 'setting']);
-  const [formInstance, setFormInstance] = useState<FormInstance>();
-  const [loading, setLoading] = useState(false);
-  const [editingProvider, updateAiModelsConfig] = useAiInfraStore((s) => [
-    s.activeAiProvider!,
-    s.updateAiModelsConfig,
-  ]);
-  const model = useAiInfraStore(aiModelSelectors.getAiModelById(id), isEqual);
+export const createModelConfigModal = (options: ModelConfigModalOptions): ModalInstance => {
+  const formRef: { current?: FormInstance } = {};
 
-  const closeModal = () => {
-    setOpen(false);
-  };
-  const { showDeployName } = use(ProviderSettingsContext);
-
-  return (
-    <Modal
-      destroyOnHidden
-      maskClosable
-      open={open}
-      title={t('llm.customModelCards.modelConfig.modalTitle', { ns: 'setting' })}
-      zIndex={1251} // Select is 1150
-      footer={[
-        <Button key="cancel" onClick={closeModal}>
-          {t('cancel')}
-        </Button>,
-        <Button
-          key="ok"
-          loading={loading}
-          style={{ marginInlineStart: '16px' }}
-          type="primary"
-          onClick={async () => {
-            if (!editingProvider || !id || !formInstance) return;
-            const data = formInstance.getFieldsValue();
-
-            setLoading(true);
-            await updateAiModelsConfig(id, editingProvider, data);
-            setLoading(false);
-
-            closeModal();
-          }}
-        >
-          {t('ok')}
-        </Button>,
-      ]}
-      styles={{
-        body: {
-          display: 'flex',
-          flexDirection: 'column',
-          maxHeight: 'calc(100vh - 150px)',
-        },
-      }}
-      onCancel={closeModal}
-    >
-      <ModelConfigForm
-        idEditable={false}
-        initialValues={model}
-        showDeployName={showDeployName}
-        type={model?.type}
-        onFormInstanceReady={setFormInstance}
+  return createModal({
+    content: (
+      <ModelConfigContent
+        id={options.id}
+        showDeployName={options.showDeployName}
+        onFormReady={(instance) => {
+          formRef.current = instance;
+        }}
       />
-    </Modal>
-  );
-});
-export default ModelConfigModal;
+    ),
+    footer: <ModelConfigFooter formRef={formRef} id={options.id} />,
+    maskClosable: true,
+    title: t('llm.customModelCards.modelConfig.modalTitle', { ns: 'setting' }),
+    width: 'min(90vw, 640px)',
+  });
+};

--- a/src/routes/(main)/settings/provider/features/ModelList/ModelItem.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/ModelItem.tsx
@@ -20,7 +20,7 @@ import {
   getTextOutputUnitRate,
 } from '@/utils/pricing';
 
-import ModelConfigModal from './ModelConfigModal';
+import { createModelConfigModal } from './ModelConfigModal';
 import { ProviderSettingsContext } from './ProviderSettingsContext';
 
 const styles = createStaticStyles(({ css, cx }) => {
@@ -80,7 +80,7 @@ const ModelItem = memo<ModelItemProps>(
     type,
   }) => {
     const { t } = useTranslation(['modelProvider', 'components', 'models', 'common']);
-    const { modelEditable } = use(ProviderSettingsContext);
+    const { modelEditable, showDeployName } = use(ProviderSettingsContext);
 
     const [activeAiProvider, isModelLoading, toggleModelEnabled, removeAiModel] = useAiInfraStore(
       (s) => [
@@ -92,7 +92,6 @@ const ModelItem = memo<ModelItemProps>(
     );
 
     const [checked, setChecked] = useState(enabled);
-    const [showConfig, setShowConfig] = useState(false);
 
     const formatPricing = (): string[] => {
       if (!pricing) return [];
@@ -195,7 +194,7 @@ const ModelItem = memo<ModelItemProps>(
             title={t('providerModels.item.config')}
             onClick={(e) => {
               e.stopPropagation();
-              setShowConfig(true);
+              createModelConfigModal({ id, showDeployName });
             }}
           />
           {source !== AiModelSourceEnum.Builtin && (
@@ -304,12 +303,7 @@ const ModelItem = memo<ModelItemProps>(
       </Flexbox>
     );
 
-    return (
-      <>
-        {dom}
-        {showConfig && <ModelConfigModal id={id} open={showConfig} setOpen={setShowConfig} />}
-      </>
-    );
+    return dom;
   },
 );
 

--- a/src/routes/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
@@ -3,14 +3,15 @@ import { confirmModal } from '@lobehub/ui/base-ui';
 import { App, Space } from 'antd';
 import { cssVar } from 'antd-style';
 import { CircleX, EllipsisVertical, LucideRefreshCcwDot, PlusIcon } from 'lucide-react';
-import { memo, useEffect, useState } from 'react';
+import { memo, use, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useAiInfraStore } from '@/store/aiInfra';
 import { aiModelSelectors } from '@/store/aiInfra/selectors';
 
-import CreateNewModelModal from '../CreateNewModelModal';
+import { createCreateNewModelModal } from '../CreateNewModelModal';
+import { ProviderSettingsContext } from '../ProviderSettingsContext';
 import Search from './Search';
 
 interface ModelFetcherProps {
@@ -47,7 +48,7 @@ const ModelTitle = memo<ModelFetcherProps>(
 
     const [fetchRemoteModelsLoading, setFetchRemoteModelsLoading] = useState(false);
     const [clearRemoteModelsLoading, setClearRemoteModelsLoading] = useState(false);
-    const [showModal, setShowModal] = useState(false);
+    const { showDeployName } = use(ProviderSettingsContext);
 
     const mobile = useIsMobile();
 
@@ -131,16 +132,13 @@ const ModelTitle = memo<ModelFetcherProps>(
                   </Button>
                 )}
                 {showAddNewModel && (
-                  <>
-                    <Button
-                      icon={PlusIcon}
-                      size={'small'}
-                      onClick={() => {
-                        setShowModal(true);
-                      }}
-                    />
-                    <CreateNewModelModal open={showModal} setOpen={setShowModal} />
-                  </>
+                  <Button
+                    icon={PlusIcon}
+                    size={'small'}
+                    onClick={() => {
+                      createCreateNewModelModal({ showDeployName });
+                    }}
+                  />
                 )}
                 <DropdownMenu
                   items={[


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Converts the \"Create custom AI model\" modal (\`CreateNewModelModal\`) under \`src/routes/(main)/settings/provider/features/ModelList/\` from declarative \`open\`-state + antd \`<Modal />\` (legacy \`@lobehub/ui\` root) to the **imperative** \`createModal\` API from \`@lobehub/ui/base-ui\`, in line with the \`refactor/modal-imperative-api\` initiative.

- \`CreateNewModelModal/index.tsx\`: exports a \`createCreateNewModelModal({ showDeployName })\` function that returns a \`ModalInstance\`. Uses the base-ui \`footer\` slot (fixed footer, not part of the scrollable content) and bridges the antd \`FormInstance\` between content & footer via a local \`formRef\`.
- New \`Content.tsx\`: renders the model config form only.
- New \`Footer.tsx\`: renders Cancel/OK buttons inside \`<ModalFooter>\`, wires \`useModalContext().close\` and the \`createNewAiModel\` store action.
- \`EmptyModels.tsx\` and \`ModelTitle/index.tsx\`: removed local \`showModal\` state + JSX mount; now call \`createCreateNewModelModal({ showDeployName })\` directly, reading \`showDeployName\` from \`ProviderSettingsContext\`.
- \`ExtendParamsSelect.tsx\`: switched the \`Select\` to base-ui (\`@lobehub/ui/base-ui\`). Replaced the antd \`Popover\` with the base-ui \`Popover\` (re-exported as \`{ Popover }\` from \`@lobehub/ui\`) so it shares the same floating-ui \`FloatingTree\` as the Select dropdown — this prevents the nested popup's pointerdown from being treated as an outside-press that would close the Select. Added \`stopPropagation\` on the preview content to keep clicks inside the popover from bubbling up to \`Select.Item\` and toggling the option.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Steps:

1. Go to \`Settings → AI Provider → <any provider> → Models\`.
2. Click the **+** button (or the \"Add new model\" button in the empty state) — the create modal opens via the base-ui imperative API.
3. Fill in the form, hover an option in **Extend Params** to see the preview popover (popover stays open; clicking its interior does not select the option). Confirm clicking option label still selects it.
4. Submit — the new model is created and the modal closes.
5. Cancel button and click-outside also close the modal.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| antd Modal with declarative open state | base-ui imperative modal with fixed footer |

#### 📝 Additional Information

- The base-ui \`Popover\` is the same component as \`@lobehub/ui/base-ui\`'s — it is re-exported only from the root \`@lobehub/ui\` package (base-ui index does not surface the top-level \`Popover\` wrapper, only its atoms). The import path \`import { Popover } from '@lobehub/ui'\` is therefore intentional.
- No behavior change for the model config edit modal (\`ModelConfigModal\`) — still on the legacy API; can be migrated in a follow-up.