### PR TITLE
🐛 fix(agent-runtime): classify topic/agent/session FK violations as ConversationParentMissing

### DIFF
--- a/src/server/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/src/server/modules/AgentRuntime/RuntimeExecutors.ts
@@ -96,7 +96,7 @@ import { formatErrorEventData } from './formatErrorEventData';
 import { classifyLLMError, type LLMErrorKind } from './llmErrorClassification';
 import {
   createConversationParentMissingError,
-  isParentMessageMissingError,
+  isMidOperationReferenceMissingError,
   isPersistFatal,
   markPersistFatal,
 } from './messagePersistErrors';
@@ -2189,7 +2189,7 @@ export const createRuntimeExecutors = (
           // Normalize BEFORE publishing so clients (which treat `error` stream
           // events as terminal and surface `event.data.error` directly) see the
           // typed business error, not the raw SQL / driver text.
-          const fatal = isParentMessageMissingError(error)
+          const fatal = isMidOperationReferenceMissingError(error)
             ? createConversationParentMissingError(payload.parentMessageId, error)
             : error instanceof Error
               ? error
@@ -2696,7 +2696,7 @@ export const createRuntimeExecutors = (
               // events as terminal and surface `event.data.error` directly, so
               // a raw SQL error here would leak driver text to the user before
               // the ConversationParentMissing throw is consumed. See .
-              const fatal = isParentMessageMissingError(error)
+              const fatal = isMidOperationReferenceMissingError(error)
                 ? createConversationParentMissingError(parentMessageId, error)
                 : error instanceof Error
                   ? error
@@ -3440,7 +3440,7 @@ export const createRuntimeExecutors = (
         );
         // Normalize BEFORE publishing so clients surface the typed business
         // error instead of the raw driver text (see review).
-        const fatal = isParentMessageMissingError(error)
+        const fatal = isMidOperationReferenceMissingError(error)
           ? createConversationParentMissingError(parentMessageId, error)
           : error instanceof Error
             ? error

--- a/src/server/modules/AgentRuntime/__tests__/messagePersistErrors.test.ts
+++ b/src/server/modules/AgentRuntime/__tests__/messagePersistErrors.test.ts
@@ -2,42 +2,61 @@ import { describe, expect, it } from 'vitest';
 
 import {
   createConversationParentMissingError,
-  isParentMessageMissingError,
+  isMidOperationReferenceMissingError,
   isPersistFatal,
   markPersistFatal,
 } from '../messagePersistErrors';
 
-describe('isParentMessageMissingError', () => {
+describe('isMidOperationReferenceMissingError', () => {
   it('matches the drizzle + postgres-js error shape (FK via .cause)', () => {
     const error: any = new Error('Failed query: insert into messages ...');
     error.cause = { code: '23503', constraint: 'messages_parent_id_messages_id_fk' };
-    expect(isParentMessageMissingError(error)).toBe(true);
+    expect(isMidOperationReferenceMissingError(error)).toBe(true);
   });
 
   it('matches top-level code/constraint_name variants', () => {
     const error: any = new Error('x');
     error.code = '23503';
     error.constraint_name = 'messages_parent_id_messages_id_fk';
-    expect(isParentMessageMissingError(error)).toBe(true);
+    expect(isMidOperationReferenceMissingError(error)).toBe(true);
   });
 
-  it('does not match other FK violations (different constraint)', () => {
+  it.each([
+    'messages_parent_id_messages_id_fk',
+    'messages_quota_id_messages_id_fk',
+    'messages_topic_id_topics_id_fk',
+    'messages_agent_id_agents_id_fk',
+    'messages_session_id_sessions_id_fk',
+    'messages_thread_id_threads_id_fk',
+  ])('matches every mid-operation-deletable reference FK: %s', (constraint) => {
     const error: any = new Error('x');
-    error.cause = { code: '23503', constraint: 'messages_topic_id_topics_id_fk' };
-    expect(isParentMessageMissingError(error)).toBe(false);
+    error.cause = { code: '23503', constraint };
+    expect(isMidOperationReferenceMissingError(error)).toBe(true);
+  });
+
+  it('does not match FK violations on out-of-scope constraints', () => {
+    // user-account deletion / non-messages tables stay real failures
+    const userFk: any = new Error('x');
+    userFk.cause = { code: '23503', constraint: 'messages_user_id_users_id_fk' };
+    expect(isMidOperationReferenceMissingError(userFk)).toBe(false);
+
+    const otherTable: any = new Error('x');
+    otherTable.cause = { code: '23503', constraint: 'files_user_id_users_id_fk' };
+    expect(isMidOperationReferenceMissingError(otherTable)).toBe(false);
   });
 
   it('does not match non-FK pg errors', () => {
     const error: any = new Error('x');
     error.cause = { code: '23505', constraint: 'messages_parent_id_messages_id_fk' };
-    expect(isParentMessageMissingError(error)).toBe(false);
+    expect(isMidOperationReferenceMissingError(error)).toBe(false);
   });
 
-  it('handles null / non-object safely', () => {
-    expect(isParentMessageMissingError(null)).toBe(false);
-    expect(isParentMessageMissingError(undefined)).toBe(false);
-    expect(isParentMessageMissingError('string-error')).toBe(false);
-    expect(isParentMessageMissingError(42)).toBe(false);
+  it('handles null / non-object / missing-constraint safely', () => {
+    expect(isMidOperationReferenceMissingError(null)).toBe(false);
+    expect(isMidOperationReferenceMissingError(undefined)).toBe(false);
+    expect(isMidOperationReferenceMissingError('string-error')).toBe(false);
+    expect(isMidOperationReferenceMissingError(42)).toBe(false);
+    expect(isMidOperationReferenceMissingError({ code: '23503' })).toBe(false);
   });
 });
 

--- a/src/server/modules/AgentRuntime/messagePersistErrors.ts
+++ b/src/server/modules/AgentRuntime/messagePersistErrors.ts
@@ -8,11 +8,25 @@ import { AgentRuntimeErrorType } from '@lobechat/types';
 const PG_FOREIGN_KEY_VIOLATION = '23503';
 
 /**
- * Constraint name drizzle generates for the `messages.parent_id` self-FK.
- * Hard-coded because we only use it as a signature — no need to reflect over
- * the schema at runtime.
+ * Constraint names drizzle generates for the `messages` foreign keys that point
+ * at rows a user can delete *while an operation is still running* — the parent /
+ * quota message, the topic, the agent, the session, the thread. When any of
+ * these rows is removed mid-flight, the assistant/tool-message INSERT fails with
+ * a 23503 foreign_key_violation. That's a lost race against the user, not a
+ * runtime bug.
+ *
+ * Hard-coded because we only use them as signatures — no need to reflect over
+ * the schema at runtime. An entry for a constraint that doesn't exist is a
+ * harmless no-op.
  */
-const MESSAGES_PARENT_FK_CONSTRAINT = 'messages_parent_id_messages_id_fk';
+const MID_OPERATION_DELETABLE_FK_CONSTRAINTS = new Set([
+  'messages_parent_id_messages_id_fk', // parent message deleted
+  'messages_quota_id_messages_id_fk', // quota (root) message deleted
+  'messages_topic_id_topics_id_fk', // topic deleted
+  'messages_agent_id_agents_id_fk', // agent deleted
+  'messages_session_id_sessions_id_fk', // session deleted
+  'messages_thread_id_threads_id_fk', // thread deleted
+]);
 
 /**
  * Internal property the runtime uses to mark a thrown error as coming from
@@ -23,15 +37,21 @@ const MESSAGES_PARENT_FK_CONSTRAINT = 'messages_parent_id_messages_id_fk';
 export const PERSIST_FATAL_MARKER = 'persistFatal';
 
 /**
- * Detect whether an error returned by `messageModel.create` is a `parent_id`
- * FK violation — meaning the parent message no longer exists. Most commonly
- * caused by the parent being deleted concurrently with agent execution
- * (see ).
+ * Detect whether an error returned by `messageModel.create` is a foreign-key
+ * violation on one of the mid-operation-deletable `messages` references — the
+ * parent / quota message, topic, agent, session or thread no longer exists,
+ * almost always because the user deleted that context concurrently with agent
+ * execution.
+ *
+ * Previously this only matched the `parent_id` self-FK, so topic / agent / etc.
+ * deletions slipped through as raw `Failed query: insert into "messages"` 500s
+ * (DatabasePersistError noise on the dashboard) instead of the typed user-side
+ * error.
  *
  * `drizzle` + `postgres-js` wrap the raw PG error as `.cause`, so the check
  * looks at both the top level and the cause.
  */
-export const isParentMessageMissingError = (error: unknown): boolean => {
+export const isMidOperationReferenceMissingError = (error: unknown): boolean => {
   if (!error || typeof error !== 'object') return false;
   const err = error as any;
   const code = err?.code ?? err?.cause?.code;
@@ -40,7 +60,11 @@ export const isParentMessageMissingError = (error: unknown): boolean => {
     err?.constraint ??
     err?.cause?.constraint_name ??
     err?.cause?.constraint;
-  return code === PG_FOREIGN_KEY_VIOLATION && constraint === MESSAGES_PARENT_FK_CONSTRAINT;
+  return (
+    code === PG_FOREIGN_KEY_VIOLATION &&
+    typeof constraint === 'string' &&
+    MID_OPERATION_DELETABLE_FK_CONSTRAINTS.has(constraint)
+  );
 };
 
 /**


### PR DESCRIPTION
## 💻 变更类型 | Change Type

- [x] 🐛 fix

## 🔀 背景 | Background

DC 错误看板上长期排在前列的 `Failed query: insert into "messages" …` 500（DatabasePersistError）这一类，根因定位为 **FK 违反未被完整归类**。

当用户在 agent operation **执行过程中删除 topic（或 agent / session / thread）** 时，收尾持久化 assistant / tool 消息的 `INSERT` 会因对应 `messages` 外键命中 Postgres `23503 foreign_key_violation` 而整事务回滚。

但 `messagePersistErrors.ts` 的 guard 只识别 `messages_parent_id_messages_id_fk`（父消息自引用 FK）——也就是只覆盖"用户删了**父消息**"这一种。用户删"**整个 topic**"时命中的是 `messages_topic_id_topics_id_fk`，guard 漏掉 → 原始 SQL 错误直接冒泡，前端看到 driver 文本，看板上堆成 DatabasePersistError 噪音。

这也解释了为什么同一批用户会同时刷出 `ConversationParentMissing`（parent_id 被捕获）和 `Failed query: insert messages`（topic_id 没被捕获）。

## 🔨 改动 | Changes

- `isParentMessageMissingError` → **`isMidOperationReferenceMissingError`**：把单一约束放宽为一组**运行中可被用户删除的 `messages` 引用 FK**（parent / quota message、topic、agent、session、thread）。命中即归一化为已有的、用户侧的 `ConversationParentMissing`（与 parent 情形一致）。
- 越界 FK（如 `messages_user_id_users_id_fk`、其它表）仍保持为真实失败，不吞。
- 同步更新 3 处调用点（`RuntimeExecutors.ts`）与单测。

## ✅ 测试 | Testing

`messagePersistErrors.test.ts` 覆盖：六类引用 FK 均命中、`.cause` 解包、`constraint`/`constraint_name` 别名、越界约束与非-FK 错误不命中、null/非对象安全。`15 passed`。

> 配合：agent-gateway 侧已把 `ConversationParentMissing` 加入 user-side 不再记录；本 PR 合并部署后，这类 topic 删除导致的 `Failed query insert messages` 噪音应随之消失。