### PR TITLE
🐛 fix: serialize Langfuse model parameters

### DIFF
--- a/src/server/modules/ModelRuntime/trace.test.ts
+++ b/src/server/modules/ModelRuntime/trace.test.ts
@@ -1,0 +1,80 @@
+// @vitest-environment node
+import type { ChatStreamPayload } from '@lobechat/model-runtime';
+import { TraceNameMap } from '@lobechat/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createTraceOptions } from './trace';
+
+const traceMocks = vi.hoisted(() => {
+  const generation = vi.fn(() => ({ id: 'generation-id', update: vi.fn() }));
+  const createTrace = vi.fn(() => ({ generation, id: 'trace-id', update: vi.fn() }));
+
+  return { createTrace, generation };
+});
+
+vi.mock('@/libs/traces', () => ({
+  TraceClient: vi.fn(() => ({
+    createTrace: traceMocks.createTrace,
+    shutdownAsync: vi.fn(),
+  })),
+}));
+
+describe('createTraceOptions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should only pass Langfuse-compatible values as generation modelParameters', () => {
+    const payload = {
+      messages: [{ content: 'hello', role: 'user' }],
+      model: 'GLM-5',
+      reasoning: { effort: 'medium', summary: 'auto' },
+      response_format: { type: 'json_object' },
+      stream: true,
+      temperature: 0.7,
+      thinking: { budget_tokens: 1024, type: 'enabled' },
+      tool_choice: 'auto',
+    } as ChatStreamPayload;
+
+    createTraceOptions(payload, {
+      provider: 'newapi',
+      trace: { enabled: true, traceName: TraceNameMap.Conversation },
+    });
+
+    expect(traceMocks.generation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelParameters: {
+          reasoning: JSON.stringify({ effort: 'medium', summary: 'auto' }),
+          response_format: JSON.stringify({ type: 'json_object' }),
+          stream: true,
+          temperature: 0.7,
+          thinking: JSON.stringify({ budget_tokens: 1024, type: 'enabled' }),
+          tool_choice: 'auto',
+        },
+      }),
+    );
+  });
+
+  it('should preserve array parameters and omit nullish parameters', () => {
+    const payload = {
+      messages: [{ content: 'hello', role: 'user' }],
+      mockChunks: ['hello', { type: 'text' }],
+      model: 'test-model',
+      n: null,
+      provider: undefined,
+    } as unknown as ChatStreamPayload;
+
+    createTraceOptions(payload, {
+      provider: 'mock',
+      trace: { enabled: true, traceName: TraceNameMap.Conversation },
+    });
+
+    expect(traceMocks.generation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        modelParameters: {
+          mockChunks: ['hello', JSON.stringify({ type: 'text' })],
+        },
+      }),
+    );
+  });
+});

--- a/src/server/modules/ModelRuntime/trace.ts
+++ b/src/server/modules/ModelRuntime/trace.ts
@@ -2,6 +2,7 @@ import { INBOX_SESSION_ID, LOBE_CHAT_OBSERVATION_ID, LOBE_CHAT_TRACE_ID } from '
 import { type ChatStreamCallbacks, type ChatStreamPayload } from '@lobechat/model-runtime';
 import { type TracePayload } from '@lobechat/types';
 import { TraceTagMap } from '@lobechat/types';
+import type { CreateLangfuseGenerationBody } from 'langfuse-core';
 import { after } from 'next/server';
 
 import { TraceClient } from '@/libs/traces';
@@ -12,11 +13,59 @@ export interface AgentChatOptions {
   trace?: TracePayload;
 }
 
+type TraceModelParameters = NonNullable<CreateLangfuseGenerationBody['modelParameters']>;
+type TraceModelParameterValue = TraceModelParameters[string];
+
+// Langfuse modelParameters only accepts primitives and string arrays.
+// Keep structured runtime params observable by serializing them instead of dropping them.
+const serializeTraceModelParameter = (value: unknown): TraceModelParameterValue | undefined => {
+  if (value === undefined || value === null) return;
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => {
+      const serializedItem = serializeTraceModelParameter(item);
+
+      // Langfuse arrays are typed as string arrays, so nested values need a stable string form.
+      if (Array.isArray(serializedItem)) return JSON.stringify(serializedItem);
+
+      return String(serializedItem);
+    });
+  }
+
+  if (typeof value === 'bigint') return value.toString();
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+const sanitizeTraceModelParameters = (parameters: Record<string, unknown>) => {
+  const sanitizedParameters: Record<string, TraceModelParameterValue> = {};
+
+  for (const [key, value] of Object.entries(parameters)) {
+    const serializedValue = serializeTraceModelParameter(value);
+
+    if (serializedValue !== undefined) {
+      sanitizedParameters[key] = serializedValue;
+    }
+  }
+
+  return sanitizedParameters;
+};
+
 export const createTraceOptions = (
   payload: ChatStreamPayload,
   { trace: tracePayload, provider }: AgentChatOptions,
 ) => {
   const { messages, model, tools, ...parameters } = payload;
+  const modelParameters = sanitizeTraceModelParameters(parameters);
+
   // create a trace to monitor the completion
   const traceClient = new TraceClient();
   const messageLength = messages.length;
@@ -38,7 +87,7 @@ export const createTraceOptions = (
     input: messages,
     metadata: { messageLength, model, provider },
     model,
-    modelParameters: parameters as any,
+    modelParameters,
     name: `Chat Completion (${provider})`,
     startTime: new Date(),
   });


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #15405

#### 🔀 Description of Change

Langfuse rejects ingestion events when `generation.modelParameters` contains
structured object values such as `thinking`, `reasoning`, or
`response_format`.

This change sanitizes trace model parameters before sending them to Langfuse:

- keeps primitive values unchanged
- serializes structured object values to JSON strings
- normalizes array values to string arrays
- omits nullish values

This preserves observability while matching the Langfuse SDK/API schema.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run --silent='passed-only' src/server/modules/ModelRuntime/trace.test.ts src/libs/traces/index.test.ts
bunx eslint src/server/modules/ModelRuntime/trace.ts src/server/modules/ModelRuntime/trace.test.ts
```

Notes:

- The focused Vitest suite passed: 6 tests.
- ESLint exits successfully. It still reports one pre-existing warning in
  `trace.ts` on the unchanged `sessionId` ternary.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Langfuse ingestion can return `207` with `body.modelParameters.thinking` schema errors. | Structured model parameters are serialized before ingestion. |

#### 📝 Additional Information

`bun run type-check` was also attempted, but current `canary` has unrelated
pre-existing type-check failures in generated `.next` route declarations and
`packages/heterogeneous-agents/src/askUser/AskUserMcpServer.ts`.
