### PR TITLE
✅ test(model-runtime): classify ollamacloud "context window exceeds limit" as ExceededContextWindow

### DIFF
--- a/packages/model-runtime/src/errors/match.test.ts
+++ b/packages/model-runtime/src/errors/match.test.ts
@@ -17,6 +17,19 @@ describe('matchErrorPattern', () => {
     );
   });
 
+  it('classifies ollamacloud "context window exceeds limit" as ExceededContextWindow, not ProviderBizError (LOBE-9913)', () => {
+    // ollamacloud surfaces context-window overflow as a generic 400 that the
+    // upstream labels ProviderBizError. The ECW message pattern sits before the
+    // 400 / ProviderBizError catch-alls, so the message wins regardless.
+    expect(
+      matchErrorPattern({
+        errorType: AgentRuntimeErrorType.ProviderBizError,
+        message: '400 "invalid params, context window exceeds limit (ref: 0x123)"',
+        provider: 'ollamacloud',
+      })?.code,
+    ).toBe(AgentRuntimeErrorType.ExceededContextWindow);
+  });
+
   it('disambiguates 429-class rate limit from balance-class quota', () => {
     expect(matchErrorPattern({ message: 'rate_limit_exceeded' })?.code).toBe(
       AgentRuntimeErrorType.RateLimitExceeded,

--- a/packages/model-runtime/src/errors/patterns.ts
+++ b/packages/model-runtime/src/errors/patterns.ts
@@ -74,7 +74,6 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   {
     code: AgentRuntimeErrorType.ExceededContextWindow,
     match: sub('context window exceeds', { caseInsensitive: true }),
-    note: 'ollamacloud reports ECW as a 400 ProviderBizError "context window exceeds limit" (LOBE-9913)',
   },
   {
     code: AgentRuntimeErrorType.ExceededContextWindow,

--- a/packages/model-runtime/src/errors/patterns.ts
+++ b/packages/model-runtime/src/errors/patterns.ts
@@ -74,6 +74,7 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   {
     code: AgentRuntimeErrorType.ExceededContextWindow,
     match: sub('context window exceeds', { caseInsensitive: true }),
+    note: 'ollamacloud reports ECW as a 400 ProviderBizError "context window exceeds limit" (LOBE-9913)',
   },
   {
     code: AgentRuntimeErrorType.ExceededContextWindow,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✅ test

#### 🔗 Related Issue

Fixes LOBE-9913

#### 🔀 Description of Change

ollamacloud surfaces context-window overflow as a generic `400 "invalid params, context window exceeds limit (ref: ...)"` that the upstream classifies as `ProviderBizError` — same nature as `ExceededContextWindow`, just a different provider error code/type.

Investigation: the message **already** classifies as `ExceededContextWindow` today, because the generic `context window exceeds` pattern (added in #15262) sits ahead of the `400` / `ProviderBizError` catch-alls in `ERROR_PATTERNS`, and first-match-wins. The residuals seen in the dashboard are historical data written **before** that pattern existed (errors are classified at write-time), so they aren't reclassified retroactively; new occurrences are already correct.

This PR adds a regression test to lock the behavior in — no behavior change:

- `match.test.ts`: assert the exact ollamacloud message (with `errorType: ProviderBizError`, `provider: ollamacloud`) resolves to `ExceededContextWindow`, so a future reorder/removal of the pattern can't silently regress it.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

`bunx vitest run packages/model-runtime/src/errors/match.test.ts` — 31 passed.

#### 📝 Additional Information

If DC wants the 3 historical residuals folded into the unified ECW count, that's a data-side backfill — no further code change needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)