### PR TITLE
chore: remove LOBE-XXX markers from code comments (2026-06-03)

### DIFF
--- a/apps/cli/e2e/fixtures/agent-signal/nightly-review.golden.json
+++ b/apps/cli/e2e/fixtures/agent-signal/nightly-review.golden.json
@@ -1,5 +1,5 @@
 {
-  "description": "Desensitized golden snapshot of one nightly-review self-iteration run. Used as a structural regression baseline by the execAgent migration (LOBE-9434). Assert structure, never byte-for-byte: the LLM output is non-deterministic.",
+  "description": "Desensitized golden snapshot of one nightly-review self-iteration run. Used as a structural regression baseline by the execAgent migration which converges all agent execution paths (chat, self-iteration, memoryWriter, skillManagement) onto a single execAgent entry point. Assert structure, never byte-for-byte: the LLM output is non-deterministic.",
   "finalState": {
     "messages": [
       {

--- a/packages/model-runtime/src/errors/match.test.ts
+++ b/packages/model-runtime/src/errors/match.test.ts
@@ -17,7 +17,7 @@ describe('matchErrorPattern', () => {
     );
   });
 
-  it('classifies ollamacloud "context window exceeds limit" as ExceededContextWindow, not ProviderBizError (LOBE-9913)', () => {
+  it('classifies ollamacloud "context window exceeds limit" as ExceededContextWindow, not ProviderBizError', () => {
     // ollamacloud surfaces context-window overflow as a generic 400 that the
     // upstream labels ProviderBizError. The ECW message pattern sits before the
     // 400 / ProviderBizError catch-alls, so the message wins regardless.


### PR DESCRIPTION
## Summary

Automated daily scan and cleanup of `LOBE-XXX` format markers from source code comments.

## Changes

| File | Change |
|------|--------|
| `packages/model-runtime/src/errors/match.test.ts` | Removed `(LOBE-9913)` from test description; the inline comment already explains the ollamacloud error classification context |
| `apps/cli/e2e/fixtures/agent-signal/nightly-review.golden.json` | Replaced `(LOBE-9434)` marker with the actual context: execAgent migration converges all agent execution paths (chat, self-iteration, memoryWriter, skillManagement) onto a single entry point |

## Verification

- No remaining `LOBE-\d+` markers in `.ts`, `.tsx`, `.js`, `.jsx`, `.json` source files
- Affected file count: 2
- Only comment/text changes — zero functional impact