### PR TITLE
💄 style(service-model): polish form layout & migrate Switch to base-ui

### DIFF
--- a/src/features/ServiceModel/ModelAssignmentsForm.tsx
+++ b/src/features/ServiceModel/ModelAssignmentsForm.tsx
@@ -2,7 +2,8 @@
 
 import type { FormGroupItemType, FormItemProps } from '@lobehub/ui';
 import { Flexbox, Form, Icon, InputNumber, Skeleton } from '@lobehub/ui';
-import { Switch } from 'antd';
+import { Switch } from '@lobehub/ui/base-ui';
+import { ConfigProvider } from 'antd';
 import isEqual from 'fast-deep-equal';
 import { Loader2Icon } from 'lucide-react';
 import { memo, useEffect, useState } from 'react';
@@ -107,12 +108,7 @@ const ModelAssignmentsForm = memo(() => {
 
     return {
       children: (
-        <Flexbox
-          align="center"
-          direction="horizontal"
-          gap={12}
-          style={{ width: 448 }}
-        >
+        <Flexbox align="center" direction="horizontal" gap={12} style={{ width: 448 }}>
           <ModelSelect
             showAbility={false}
             style={{ minWidth: 0, width: '100%' }}
@@ -139,17 +135,19 @@ const ModelAssignmentsForm = memo(() => {
             onChange={(props) => updateSystemAgentModel(key, props)}
           />
           {contextLimit && (
-            <InputNumber
-              min={1}
-              placeholder={t('serviceModel.contextLimit.placeholder')}
-              style={{ alignSelf: 'flex-end', width: 180 }}
-              value={value.contextLimit}
-              onChange={(contextLimit) =>
-                updateSystemAgentModel(key, {
-                  contextLimit: typeof contextLimit === 'number' ? contextLimit : undefined,
-                })
-              }
-            />
+            <ConfigProvider theme={{ token: { controlHeight: 32 } }}>
+              <InputNumber
+                min={1}
+                placeholder={t('serviceModel.contextLimit.placeholder')}
+                style={{ alignSelf: 'flex-end', width: 180 }}
+                value={value.contextLimit}
+                onChange={(contextLimit) =>
+                  updateSystemAgentModel(key, {
+                    contextLimit: typeof contextLimit === 'number' ? contextLimit : undefined,
+                  })
+                }
+              />
+            </ConfigProvider>
           )}
         </Flexbox>
       ),
@@ -164,21 +162,20 @@ const ModelAssignmentsForm = memo(() => {
 
     return {
       children: (
-        <Flexbox align="center" direction="horizontal" gap={12}>
+        <Flexbox direction="vertical" gap={8} style={{ width: 448 }}>
           <Switch
-            aria-label={t(`systemAgent.${key}.title`)}
             checked={value.enabled}
             loading={loadingKey === key}
+            style={{ alignSelf: 'flex-end' }}
+            title={t(`systemAgent.${key}.title`)}
             onChange={(enabled) => updateSystemAgentModel(key, { enabled })}
           />
-          <Flexbox style={{ width: 448 }}>
-            <ModelSelect
-              showAbility={false}
-              style={{ minWidth: 0, width: '100%' }}
-              value={value}
-              onChange={(props) => updateSystemAgentModel(key, props)}
-            />
-          </Flexbox>
+          <ModelSelect
+            showAbility={false}
+            style={{ minWidth: 0, width: '100%' }}
+            value={value}
+            onChange={(props) => updateSystemAgentModel(key, props)}
+          />
         </Flexbox>
       ),
       desc: t(`systemAgent.${key}.modelDesc`),


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style
- [x] ♻️ refactor

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Tidy up the **Service Model** settings form (`ModelAssignmentsForm`):

- **Memory models — input/select height alignment**
  The per-row context-limit `InputNumber` rendered at 36px (antd `controlHeight` is bumped by `@lobehub/ui`), while the `ModelSelect` trigger from `@lobehub/ui/base-ui` is 32px. Wrapped the `InputNumber` in a local `ConfigProvider` with `controlHeight: 32` so it matches the select trigger. Scope is limited to that single input — no other antd component is affected.

- **Optional features — vertical layout, right-aligned switch**
  Each optional feature row previously placed the toggle and model select side by side. Restructured into a two-row layout: row 1 holds the `Switch` (aligned to the right edge of the 448px column), row 2 holds the `ModelSelect`. Gives the model select the same width as the other groups.

- **Switch migration to base-ui**
  Replaced the antd `Switch` on optional feature rows with `@lobehub/ui/base-ui` `Switch`, in line with the ongoing base-ui migration. `aria-label` is replaced with `title` since base-ui `Switch` does not forward arbitrary aria props; the FormItem already supplies the visible label.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Open **Settings → Service Model**:
1. Memory models section — verify the context-limit `InputNumber` and the model select trigger render at the same height (32px).
2. Optional features section — verify each row stacks the switch on top of the model select; the switch sits flush to the right edge.
3. Toggle each switch and confirm enabled/loading states still behave (loading spinner, disabled label opacity).

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Switch + select on one row; memory input slightly taller than select | Switch on top (right-aligned), select on bottom; memory input height matches select |

#### 📝 Additional Information

No behavioral or API change; pure layout & component-source refactor.