### PR TITLE
🐛 fix(agent-doc): default new files to .md and preserve IME composition

### DIFF
--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
@@ -12,6 +12,7 @@ import type {
   ExplorerTreeNode,
 } from '@/features/ExplorerTree';
 import { ExplorerTree, FOLDER_ICON_CSS, getExplorerTreeStyleVars } from '@/features/ExplorerTree';
+import { useIMECompositionEvent } from '@/hooks/useIMECompositionEvent';
 import { useChatStore } from '@/store/chat';
 
 import DocumentExplorerToolbar from './DocumentExplorerToolbar';
@@ -21,6 +22,23 @@ import { isOrphanSkillBundleItem } from './types';
 import { canDropDocument } from './utils/canDrop';
 
 const SKILL_INDEX_FILENAME = 'SKILL.md';
+const FILE_TREE_HOST_TAG = 'file-tree-container';
+const RENAME_INPUT_SELECTOR = 'input[data-item-rename-input]';
+
+// pierre/trees auto-selects the full value when the rename input mounts. For
+// files with extensions (e.g. `Untitled document.md`), narrow the selection to
+// the stem so the user can type a new name without overwriting the suffix.
+const selectStemOfActiveRenameInput = (root: HTMLElement | null) => {
+  if (!root) return;
+  const host = root.querySelector(FILE_TREE_HOST_TAG);
+  const input = host?.shadowRoot?.querySelector<HTMLInputElement>(RENAME_INPUT_SELECTOR);
+  if (!input) return;
+  const value = input.value;
+  const dotIndex = value.lastIndexOf('.');
+  // Skip dotfiles and extension-less names — leave pierre's full-selection.
+  if (dotIndex <= 0) return;
+  input.setSelectionRange(0, dotIndex);
+};
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   tree: css`
@@ -53,6 +71,13 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
   const { t } = useTranslation(['chat', 'common']);
   const openDocument = useChatStore((s) => s.openDocument);
   const treeRef = useRef<ExplorerTreeHandle | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  // pierre/trees' inline rename input commits on every Enter keydown without
+  // checking IME state, so a Chinese-pinyin candidate confirmed via Enter would
+  // truncate to half a word. Track composition at the outer container so we can
+  // suppress Enter while composing — composition events bubble out of the
+  // shadow DOM (composed=true), so binding here is sufficient.
+  const { compositionProps, isComposingRef } = useIMECompositionEvent();
 
   const startInlineRename = useCallback((id: string) => {
     treeRef.current?.startRenaming(id);
@@ -113,7 +138,12 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
   const focusNewRowForRename = useCallback((pendingId: string) => {
     // Defer past the current task so React commits the inserted row and the
     // tree adapter rebuilds its id→path map before we trigger rename.
-    setTimeout(() => treeRef.current?.startRenaming(pendingId), 0);
+    setTimeout(() => {
+      treeRef.current?.startRenaming(pendingId);
+      // After pierre's input.select() runs in its own layout effect, narrow
+      // selection to the stem so the `.md` extension stays intact.
+      requestAnimationFrame(() => selectStemOfActiveRenameInput(containerRef.current));
+    }, 0);
   }, []);
 
   const handleCreateFolder = useCallback(
@@ -233,7 +263,19 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
   );
 
   return (
-    <div className={styles.tree} style={{ ...style, ...treeStyleVars }}>
+    <div
+      className={styles.tree}
+      ref={containerRef}
+      style={{ ...style, ...treeStyleVars }}
+      onCompositionEnd={compositionProps.onCompositionEnd}
+      onCompositionStart={compositionProps.onCompositionStart}
+      onKeyDownCapture={(event) => {
+        if (event.key !== 'Enter') return;
+        if (!isComposingRef.current && !event.nativeEvent.isComposing) return;
+        event.stopPropagation();
+        event.nativeEvent.stopImmediatePropagation();
+      }}
+    >
       <ExplorerTree<AgentDocumentItem>
         iconsColored
         canDrag={canDrag}

--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
@@ -1,8 +1,8 @@
 import type { MenuProps } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { Trash2Icon } from 'lucide-react';
-import type { CSSProperties } from 'react';
-import { memo, useCallback, useMemo, useRef } from 'react';
+import type { CompositionEvent as ReactCompositionEvent, CSSProperties } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { KeyedMutator } from 'swr';
 
@@ -78,6 +78,65 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
   // suppress Enter while composing — composition events bubble out of the
   // shadow DOM (composed=true), so binding here is sufficient.
   const { compositionProps, isComposingRef } = useIMECompositionEvent();
+  // `isComposingRef` flips back to false synchronously on compositionend, but
+  // some IMEs emit the final Enter keydown right after compositionend in the
+  // same task — `imeSessionRef` extends the guard until the next microtask so
+  // we don't miss those edge cases.
+  const imeSessionRef = useRef(false);
+  const imeClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleCompositionStart = useCallback(
+    (event: ReactCompositionEvent<HTMLDivElement>) => {
+      if (imeClearTimerRef.current) clearTimeout(imeClearTimerRef.current);
+      imeSessionRef.current = true;
+      compositionProps.onCompositionStart(event.nativeEvent);
+    },
+    [compositionProps],
+  );
+
+  const handleCompositionEnd = useCallback(
+    (event: ReactCompositionEvent<HTMLDivElement>) => {
+      compositionProps.onCompositionEnd(event.nativeEvent);
+      imeClearTimerRef.current = setTimeout(() => {
+        imeSessionRef.current = false;
+      }, 0);
+    },
+    [compositionProps],
+  );
+
+  // Native capture listener — beats React's synthetic-event ordering edge
+  // cases and lets us inspect `composedPath()` to confirm the keydown started
+  // inside pierre's shadow-DOM rename input before we swallow it.
+  useEffect(() => {
+    const root = containerRef.current;
+    if (!root) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Enter') return;
+      const composing =
+        imeSessionRef.current ||
+        isComposingRef.current ||
+        event.isComposing ||
+        // Some IMEs report keyCode 229 instead of setting `isComposing`.
+        event.keyCode === 229;
+      if (!composing) return;
+      const inRenameInput = event
+        .composedPath()
+        .some(
+          (target): target is HTMLInputElement =>
+            target instanceof HTMLInputElement && target.matches(RENAME_INPUT_SELECTOR),
+        );
+      if (!inRenameInput) return;
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+    };
+
+    root.addEventListener('keydown', handleKeyDown, true);
+    return () => {
+      root.removeEventListener('keydown', handleKeyDown, true);
+      if (imeClearTimerRef.current) clearTimeout(imeClearTimerRef.current);
+    };
+  }, [isComposingRef]);
 
   const startInlineRename = useCallback((id: string) => {
     treeRef.current?.startRenaming(id);
@@ -267,14 +326,8 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
       className={styles.tree}
       ref={containerRef}
       style={{ ...style, ...treeStyleVars }}
-      onCompositionEnd={compositionProps.onCompositionEnd}
-      onCompositionStart={compositionProps.onCompositionStart}
-      onKeyDownCapture={(event) => {
-        if (event.key !== 'Enter') return;
-        if (!isComposingRef.current && !event.nativeEvent.isComposing) return;
-        event.stopPropagation();
-        event.nativeEvent.stopImmediatePropagation();
-      }}
+      onCompositionEnd={handleCompositionEnd}
+      onCompositionStart={handleCompositionStart}
     >
       <ExplorerTree<AgentDocumentItem>
         iconsColored

--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
@@ -74,6 +74,9 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
 
   const startInlineRename = useCallback((id: string) => {
     treeRef.current?.startRenaming(id);
+    // Match the new-file flow: leave the extension out of the selection so
+    // the user can retype only the stem.
+    requestAnimationFrame(() => selectStemOfActiveRenameInput(containerRef.current));
   }, []);
 
   const ops = useDocumentTreeOps({ agentId, data, mutate });

--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
@@ -1,8 +1,8 @@
 import type { MenuProps } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { Trash2Icon } from 'lucide-react';
-import type { CompositionEvent as ReactCompositionEvent, CSSProperties } from 'react';
-import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import type { CSSProperties } from 'react';
+import { memo, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { KeyedMutator } from 'swr';
 
@@ -12,7 +12,6 @@ import type {
   ExplorerTreeNode,
 } from '@/features/ExplorerTree';
 import { ExplorerTree, FOLDER_ICON_CSS, getExplorerTreeStyleVars } from '@/features/ExplorerTree';
-import { useIMECompositionEvent } from '@/hooks/useIMECompositionEvent';
 import { useChatStore } from '@/store/chat';
 
 import DocumentExplorerToolbar from './DocumentExplorerToolbar';
@@ -72,71 +71,6 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
   const openDocument = useChatStore((s) => s.openDocument);
   const treeRef = useRef<ExplorerTreeHandle | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
-  // pierre/trees' inline rename input commits on every Enter keydown without
-  // checking IME state, so a Chinese-pinyin candidate confirmed via Enter would
-  // truncate to half a word. Track composition at the outer container so we can
-  // suppress Enter while composing — composition events bubble out of the
-  // shadow DOM (composed=true), so binding here is sufficient.
-  const { compositionProps, isComposingRef } = useIMECompositionEvent();
-  // `isComposingRef` flips back to false synchronously on compositionend, but
-  // some IMEs emit the final Enter keydown right after compositionend in the
-  // same task — `imeSessionRef` extends the guard until the next microtask so
-  // we don't miss those edge cases.
-  const imeSessionRef = useRef(false);
-  const imeClearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const handleCompositionStart = useCallback(
-    (event: ReactCompositionEvent<HTMLDivElement>) => {
-      if (imeClearTimerRef.current) clearTimeout(imeClearTimerRef.current);
-      imeSessionRef.current = true;
-      compositionProps.onCompositionStart(event.nativeEvent);
-    },
-    [compositionProps],
-  );
-
-  const handleCompositionEnd = useCallback(
-    (event: ReactCompositionEvent<HTMLDivElement>) => {
-      compositionProps.onCompositionEnd(event.nativeEvent);
-      imeClearTimerRef.current = setTimeout(() => {
-        imeSessionRef.current = false;
-      }, 0);
-    },
-    [compositionProps],
-  );
-
-  // Native capture listener — beats React's synthetic-event ordering edge
-  // cases and lets us inspect `composedPath()` to confirm the keydown started
-  // inside pierre's shadow-DOM rename input before we swallow it.
-  useEffect(() => {
-    const root = containerRef.current;
-    if (!root) return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Enter') return;
-      const composing =
-        imeSessionRef.current ||
-        isComposingRef.current ||
-        event.isComposing ||
-        // Some IMEs report keyCode 229 instead of setting `isComposing`.
-        event.keyCode === 229;
-      if (!composing) return;
-      const inRenameInput = event
-        .composedPath()
-        .some(
-          (target): target is HTMLInputElement =>
-            target instanceof HTMLInputElement && target.matches(RENAME_INPUT_SELECTOR),
-        );
-      if (!inRenameInput) return;
-      event.stopPropagation();
-      event.stopImmediatePropagation();
-    };
-
-    root.addEventListener('keydown', handleKeyDown, true);
-    return () => {
-      root.removeEventListener('keydown', handleKeyDown, true);
-      if (imeClearTimerRef.current) clearTimeout(imeClearTimerRef.current);
-    };
-  }, [isComposingRef]);
 
   const startInlineRename = useCallback((id: string) => {
     treeRef.current?.startRenaming(id);
@@ -322,13 +256,7 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, style }) => {
   );
 
   return (
-    <div
-      className={styles.tree}
-      ref={containerRef}
-      style={{ ...style, ...treeStyleVars }}
-      onCompositionEnd={handleCompositionEnd}
-      onCompositionStart={handleCompositionStart}
-    >
+    <div className={styles.tree} ref={containerRef} style={{ ...style, ...treeStyleVars }}>
       <ExplorerTree<AgentDocumentItem>
         iconsColored
         canDrag={canDrag}

--- a/src/features/AgentDocumentsExplorer/hooks/useDocumentTreeOps.ts
+++ b/src/features/AgentDocumentsExplorer/hooks/useDocumentTreeOps.ts
@@ -18,6 +18,7 @@ interface UseDocumentTreeOpsArgs {
 }
 
 const ROOT_PATH = './';
+const DEFAULT_DOCUMENT_EXTENSION = '.md';
 
 const joinPath = (parentPath: string, segment: string) =>
   parentPath === ROOT_PATH ? `${ROOT_PATH}${segment}` : `${parentPath}/${segment}`;
@@ -112,17 +113,20 @@ export const useDocumentTreeOps = ({
   // Picks a unique filename within the given parent. Used for client-side
   // dedup of "Untitled" rows because the path-based VFS mkdir is idempotent
   // (same name re-uses the existing folder), and writeByPath in always-new
-  // mode rejects collisions outright.
+  // mode rejects collisions outright. When an extension is provided, the
+  // numeric suffix is inserted before the extension so the file keeps its
+  // type (e.g. `Untitled document 2.md`).
   const pickUniqueFilename = useCallback(
-    (parentDocumentId: string | null, baseName: string): string => {
+    (parentDocumentId: string | null, baseStem: string, extension = ''): string => {
       const siblings = dataRef.current.filter((doc) => (doc.parentId ?? null) === parentDocumentId);
       const taken = new Set(siblings.map((doc) => doc.filename));
-      if (!taken.has(baseName)) return baseName;
+      const first = `${baseStem}${extension}`;
+      if (!taken.has(first)) return first;
       for (let i = 2; i < 1000; i += 1) {
-        const candidate = `${baseName} ${i}`;
+        const candidate = `${baseStem} ${i}${extension}`;
         if (!taken.has(candidate)) return candidate;
       }
-      return `${baseName} ${Date.now()}`;
+      return `${baseStem} ${Date.now()}${extension}`;
     },
     [],
   );
@@ -183,9 +187,13 @@ export const useDocumentTreeOps = ({
         return;
       }
 
-      const baseName = t('workingPanel.resources.tree.untitledDocument');
+      const baseStem = t('workingPanel.resources.tree.untitledDocument');
       const parentDocumentId = parentId ? (byRowId.get(parentId)?.documentId ?? null) : null;
-      const pendingFilename = pickUniqueFilename(parentDocumentId, baseName);
+      const pendingFilename = pickUniqueFilename(
+        parentDocumentId,
+        baseStem,
+        DEFAULT_DOCUMENT_EXTENSION,
+      );
 
       const pending = makePendingDocument({
         agentId,
@@ -200,11 +208,13 @@ export const useDocumentTreeOps = ({
         try {
           const result =
             parentPath === ROOT_PATH
-              ? // Server's createDocument auto-deduplicates filenames at the root.
+              ? // Pass the client-picked filename (with extension) as the title so
+                // the server keeps the `.md` suffix; server dedup remains a safety
+                // net for racing clients.
                 await agentDocumentService.createDocument({
                   agentId,
                   content: '',
-                  title: baseName,
+                  title: pendingFilename,
                 })
               : await agentDocumentService.writeByPath({
                   agentId,

--- a/src/server/services/agentDocuments/index.test.ts
+++ b/src/server/services/agentDocuments/index.test.ts
@@ -151,6 +151,37 @@ describe('AgentDocumentsService', () => {
       expect(result).toEqual({ id: 'new-doc', filename: 'note-2' });
     });
 
+    it('should append collision suffix before the filename extension', async () => {
+      mockModel.findByFilename
+        .mockResolvedValueOnce({ id: 'existing-doc' })
+        .mockResolvedValueOnce(undefined);
+      mockModel.create.mockResolvedValue({ id: 'new-doc', filename: 'Untitled document-2.md' });
+
+      const service = new AgentDocumentsService(db, userId);
+      const result = await service.createDocument('agent-1', 'Untitled document.md', 'content');
+
+      expect(mockModel.findByFilename).toHaveBeenNthCalledWith(
+        1,
+        'agent-1',
+        'Untitled document.md',
+      );
+      expect(mockModel.findByFilename).toHaveBeenNthCalledWith(
+        2,
+        'agent-1',
+        'Untitled document-2.md',
+      );
+      expect(mockModel.create).toHaveBeenCalledWith(
+        'agent-1',
+        'Untitled document-2.md',
+        'content',
+        {
+          editorData: { root: { children: [] } },
+          title: 'Untitled document.md',
+        },
+      );
+      expect(result).toEqual({ id: 'new-doc', filename: 'Untitled document-2.md' });
+    });
+
     it('should throw after too many filename collisions', async () => {
       mockModel.findByFilename.mockResolvedValue({ id: 'existing-doc' });
 

--- a/src/server/services/agentDocuments/index.ts
+++ b/src/server/services/agentDocuments/index.ts
@@ -36,6 +36,14 @@ import {
 
 const MAX_UNIQUE_FILENAME_ATTEMPTS = 1000;
 
+const appendFilenameSuffix = (filename: string, suffix: number): string => {
+  const dotIndex = filename.lastIndexOf('.');
+
+  if (dotIndex <= 0) return `${filename}-${suffix}`;
+
+  return `${filename.slice(0, dotIndex)}-${suffix}${filename.slice(dotIndex)}`;
+};
+
 interface UpsertDocumentParams {
   agentId: string;
   content: string;
@@ -189,7 +197,7 @@ export class AgentDocumentsService {
         );
       }
 
-      filename = `${baseFilename}-${suffix}`;
+      filename = appendFilenameSuffix(baseFilename, suffix);
       suffix += 1;
     }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No tracked issue. -->

#### 🔀 Description of Change

Two small UX fixes for the agent document explorer's inline file creation:

1. **Default `.md` extension on new documents.** `useDocumentTreeOps.createDocument` now appends `.md` to the picked filename (e.g. `Untitled document.md`, with the numeric dedup suffix inserted before the extension as `Untitled document 2.md`). At the tree root the client-picked filename is forwarded as the title to `agentDocumentService.createDocument` so the server keeps the `.md` suffix end-to-end.
2. **Pre-select the stem, not the extension.** After `startRenaming`, we reach into the `file-tree-container` shadow DOM and call `setSelectionRange(0, lastDotIndex)` on `input[data-item-rename-input]` so the user can type a new name without overwriting `.md`. Dotfiles and extension-less names fall through to pierre/trees' default full-selection.

#### ⚠️ Known Limitation — IME composition (not addressed in this PR)

`@pierre/trees`' inline rename input lives in a shadow root and its `handleTreeKeyDown` commits the rename on every `Enter` keydown **without checking `event.isComposing` / `keyCode === 229`** (`node_modules/@pierre/trees/dist/render/FileTreeView.js:1110-1118`). When a Chinese-pinyin / Japanese / Korean candidate is confirmed via Enter, the rename commits the half-formed input instead of the intended character.

We explored intercepting from outside the shadow boundary (React `onKeyDownCapture` and a native `addEventListener('keydown', …, true)` on the host with `composedPath()` scoping). It works for the common path but fails on edge cases where the IME emits `Enter` keydown with `isComposing: false` right after `compositionend` in the same task — there is no reliable purely-external fix. The IME guard has been **reverted** in this PR; the proper fix needs to land in `@pierre/trees`.

Upstream issue filed: pierrecomputer/pierre#773 — we'll follow up here once it's released.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Steps:

1. Open an agent's working panel → documents explorer.
2. Click the "new document" toolbar action — the optimistic row should read `Untitled document.md` with only `Untitled document` selected in the rename input.
3. Press Enter without typing — file is saved as `Untitled document.md`.
4. Repeat in the same folder — second file should be `Untitled document 2.md`.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| New file had no extension; rename selected the whole name. | New file is `Untitled document.md` with stem-only selection. |

#### 📝 Additional Information

No schema changes, no migrations, no API surface changes. The shadow-DOM `querySelector` is scoped to the explorer container's `file-tree-container` host, so it can't reach unrelated pierre trees on the page.