### PR TITLE
🐛 fix(const): point CHANGELOG_URL to /changelog

### DIFF
--- a/packages/const/src/url.ts
+++ b/packages/const/src/url.ts
@@ -74,7 +74,7 @@ export const mailTo = (email: string) => `mailto:${email}`;
 export const AES_GCM_URL = 'https://datatracker.ietf.org/doc/html/draft-ietf-avt-srtp-aes-gcm-01';
 export const BASE_PROVIDER_DOC_URL = 'https://lobehub.com/docs/usage/providers';
 export const SITEMAP_BASE_URL = isDev ? '/sitemap.xml/' : 'sitemap';
-export const CHANGELOG_URL = urlJoin(OFFICIAL_SITE, 'changelog/versions');
+export const CHANGELOG_URL = urlJoin(OFFICIAL_SITE, 'changelog');
 
 export const DOWNLOAD_URL = {
   android: 'https://play.google.com/store/apps/details?id=com.lobehub.app',


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

`CHANGELOG_URL` previously resolved to `https://lobehub.com/changelog/versions`. This points it at `https://lobehub.com/changelog` instead.

This constant is used as the "open changelog" external link in two places:

- `src/components/ChangelogModal/index.tsx` — the changelog modal title link
- `src/routes/(main)/settings/about/features/Version.tsx` — Settings → About → Version

Note: changelog *content* is still fetched from GitHub raw (`src/server/services/changelog`), unaffected by this change — `CHANGELOG_URL` only controls the click-through target.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Open the changelog modal / Settings → About → Version and confirm the link now points to `https://lobehub.com/changelog`.