### PR TITLE
⚡️ perf(device): preset local device on first LLM request for 本机 target

### DIFF
--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -38,9 +38,8 @@ vi.mock('@/store/user', () => ({
 // device resolution, no electron IPC).
 const mockEnv = vi.hoisted(() => ({ isDesktop: false }));
 const mockGateway = vi.hoisted(() => ({ getDeviceInfo: vi.fn() }));
-const mockAgency = vi.hoisted(() => ({
-  value: undefined as { executionTarget?: string } | undefined,
-}));
+// Effective runtime mode === 'local' (what isLocalSystemEnabledById returns).
+const mockRuntime = vi.hoisted(() => ({ isLocal: false }));
 
 vi.mock('@/const/version', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/const/version')>();
@@ -59,8 +58,8 @@ vi.mock('@/services/electron/gatewayConnection', () => ({
 vi.mock('@/store/agent', () => ({ getAgentStoreState: () => ({}) }));
 
 vi.mock('@/store/agent/selectors', () => ({
-  agentByIdSelectors: { getAgencyConfigById: () => () => mockAgency.value },
   agentSelectors: { currentAgentWorkingDirectory: () => undefined },
+  chatConfigByIdSelectors: { isLocalSystemEnabledById: () => () => mockRuntime.isLocal },
 }));
 
 // ─── Mock Client Factory ───
@@ -780,10 +779,11 @@ describe('GatewayActionImpl', () => {
       });
     });
 
-    // When the desktop runs against 本机 (executionTarget 'local'), the client
-    // must forward this machine's own gateway deviceId so the server can preset
-    // activeDeviceId and inject lobe-local-system into the first LLM payload —
-    // skipping the activateDevice round-trip.
+    // When the desktop runs against 本机 (effective runtime mode 'local'), the
+    // client must forward this machine's own gateway deviceId so the server can
+    // preset activeDeviceId and inject lobe-local-system into the first LLM
+    // payload — skipping the activateDevice round-trip. It must NOT do so for a
+    // cloud/none run, otherwise that run would be wrongly routed to the device.
     describe('local device activation (本机)', () => {
       const successResult = {
         agentId: 'agent-1',
@@ -802,7 +802,7 @@ describe('GatewayActionImpl', () => {
 
       afterEach(() => {
         mockEnv.isDesktop = false;
-        mockAgency.value = undefined;
+        mockRuntime.isLocal = false;
         mockGateway.getDeviceInfo.mockReset();
       });
 
@@ -815,9 +815,9 @@ describe('GatewayActionImpl', () => {
         });
       };
 
-      it('forwards this desktop deviceId when execution target is local', async () => {
+      it('forwards this desktop deviceId when local execution is selected', async () => {
         mockEnv.isDesktop = true;
-        mockAgency.value = { executionTarget: 'local' };
+        mockRuntime.isLocal = true;
         mockGateway.getDeviceInfo.mockResolvedValue({ deviceId: 'device-local-1' });
 
         await send();
@@ -828,22 +828,12 @@ describe('GatewayActionImpl', () => {
         );
       });
 
-      it('treats an unset target on desktop as local (matches the UI fallback)', async () => {
+      // Regression guard: the legacy ModeSelector writes only runtimeMode, so an
+      // explicit cloud/none run leaves executionTarget unset. Gating on the
+      // effective runtime mode (not the unset target) keeps it off the device.
+      it('does not resolve a deviceId when a non-local runtime mode is selected', async () => {
         mockEnv.isDesktop = true;
-        mockAgency.value = undefined;
-        mockGateway.getDeviceInfo.mockResolvedValue({ deviceId: 'device-local-1' });
-
-        await send();
-
-        expect(aiAgentService.execAgentTask).toHaveBeenCalledWith(
-          expect.objectContaining({ deviceId: 'device-local-1' }),
-          expect.anything(),
-        );
-      });
-
-      it('does not resolve a deviceId for the sandbox target', async () => {
-        mockEnv.isDesktop = true;
-        mockAgency.value = { executionTarget: 'sandbox' };
+        mockRuntime.isLocal = false;
 
         await send();
 
@@ -854,24 +844,9 @@ describe('GatewayActionImpl', () => {
         );
       });
 
-      it('does not resolve a deviceId for an explicit remote device target', async () => {
-        // 'device' is handled server-side via agentConfig.agencyConfig.boundDeviceId,
-        // so the client must not also send a deviceId here.
-        mockEnv.isDesktop = true;
-        mockAgency.value = { executionTarget: 'device' };
-
-        await send();
-
-        expect(mockGateway.getDeviceInfo).not.toHaveBeenCalled();
-        expect(aiAgentService.execAgentTask).toHaveBeenCalledWith(
-          expect.objectContaining({ deviceId: undefined }),
-          expect.anything(),
-        );
-      });
-
-      it('never resolves a deviceId off desktop, even for a local target', async () => {
+      it('never resolves a deviceId off desktop, even when local mode is set', async () => {
         mockEnv.isDesktop = false;
-        mockAgency.value = { executionTarget: 'local' };
+        mockRuntime.isLocal = true;
 
         await send();
 

--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -2,6 +2,7 @@ import type { AgentStreamEvent } from '@lobechat/agent-gateway-client';
 import { RequestTrigger } from '@lobechat/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import type * as ConstVersion from '@/const/version';
 import { aiAgentService } from '@/services/aiAgent';
 
 import type { GatewayConnection } from '../gateway';
@@ -42,7 +43,7 @@ const mockGateway = vi.hoisted(() => ({ getDeviceInfo: vi.fn() }));
 const mockRuntime = vi.hoisted(() => ({ isLocal: false }));
 
 vi.mock('@/const/version', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@/const/version')>();
+  const actual = await importOriginal<typeof ConstVersion>();
   return {
     ...actual,
     get isDesktop() {

--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -33,6 +33,36 @@ vi.mock('@/store/user', () => ({
   },
 }));
 
+// ─── Local-device activation (本机) test seams ───
+// Controlled per-test; default off so the rest of the suite runs as web (no
+// device resolution, no electron IPC).
+const mockEnv = vi.hoisted(() => ({ isDesktop: false }));
+const mockGateway = vi.hoisted(() => ({ getDeviceInfo: vi.fn() }));
+const mockAgency = vi.hoisted(() => ({
+  value: undefined as { executionTarget?: string } | undefined,
+}));
+
+vi.mock('@/const/version', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/const/version')>();
+  return {
+    ...actual,
+    get isDesktop() {
+      return mockEnv.isDesktop;
+    },
+  };
+});
+
+vi.mock('@/services/electron/gatewayConnection', () => ({
+  gatewayConnectionService: { getDeviceInfo: mockGateway.getDeviceInfo },
+}));
+
+vi.mock('@/store/agent', () => ({ getAgentStoreState: () => ({}) }));
+
+vi.mock('@/store/agent/selectors', () => ({
+  agentByIdSelectors: { getAgencyConfigById: () => () => mockAgency.value },
+  agentSelectors: { currentAgentWorkingDirectory: () => undefined },
+}));
+
 // ─── Mock Client Factory ───
 
 function createMockClient(): GatewayConnection['client'] & {
@@ -747,6 +777,109 @@ describe('GatewayActionImpl', () => {
       expect(interruptTaskSpy).toHaveBeenCalledWith({
         operationId: 'server-op-xyz',
         topicId: 'topic-1',
+      });
+    });
+
+    // When the desktop runs against 本机 (executionTarget 'local'), the client
+    // must forward this machine's own gateway deviceId so the server can preset
+    // activeDeviceId and inject lobe-local-system into the first LLM payload —
+    // skipping the activateDevice round-trip.
+    describe('local device activation (本机)', () => {
+      const successResult = {
+        agentId: 'agent-1',
+        assistantMessageId: 'ast-1',
+        autoStarted: true,
+        createdAt: new Date().toISOString(),
+        message: 'ok',
+        operationId: 'server-op-1',
+        status: 'created' as const,
+        success: true,
+        timestamp: new Date().toISOString(),
+        token: 'test-token',
+        topicId: 'topic-1',
+        userMessageId: 'usr-1',
+      };
+
+      afterEach(() => {
+        mockEnv.isDesktop = false;
+        mockAgency.value = undefined;
+        mockGateway.getDeviceInfo.mockReset();
+      });
+
+      const send = async () => {
+        const { action } = createExecuteTestAction();
+        vi.mocked(aiAgentService.execAgentTask).mockResolvedValue(successResult);
+        await action.executeGatewayAgent({
+          context: { agentId: 'agent-1', scope: 'main', threadId: null, topicId: 'topic-1' },
+          message: 'list files in cwd',
+        });
+      };
+
+      it('forwards this desktop deviceId when execution target is local', async () => {
+        mockEnv.isDesktop = true;
+        mockAgency.value = { executionTarget: 'local' };
+        mockGateway.getDeviceInfo.mockResolvedValue({ deviceId: 'device-local-1' });
+
+        await send();
+
+        expect(aiAgentService.execAgentTask).toHaveBeenCalledWith(
+          expect.objectContaining({ deviceId: 'device-local-1' }),
+          expect.anything(),
+        );
+      });
+
+      it('treats an unset target on desktop as local (matches the UI fallback)', async () => {
+        mockEnv.isDesktop = true;
+        mockAgency.value = undefined;
+        mockGateway.getDeviceInfo.mockResolvedValue({ deviceId: 'device-local-1' });
+
+        await send();
+
+        expect(aiAgentService.execAgentTask).toHaveBeenCalledWith(
+          expect.objectContaining({ deviceId: 'device-local-1' }),
+          expect.anything(),
+        );
+      });
+
+      it('does not resolve a deviceId for the sandbox target', async () => {
+        mockEnv.isDesktop = true;
+        mockAgency.value = { executionTarget: 'sandbox' };
+
+        await send();
+
+        expect(mockGateway.getDeviceInfo).not.toHaveBeenCalled();
+        expect(aiAgentService.execAgentTask).toHaveBeenCalledWith(
+          expect.objectContaining({ deviceId: undefined }),
+          expect.anything(),
+        );
+      });
+
+      it('does not resolve a deviceId for an explicit remote device target', async () => {
+        // 'device' is handled server-side via agentConfig.agencyConfig.boundDeviceId,
+        // so the client must not also send a deviceId here.
+        mockEnv.isDesktop = true;
+        mockAgency.value = { executionTarget: 'device' };
+
+        await send();
+
+        expect(mockGateway.getDeviceInfo).not.toHaveBeenCalled();
+        expect(aiAgentService.execAgentTask).toHaveBeenCalledWith(
+          expect.objectContaining({ deviceId: undefined }),
+          expect.anything(),
+        );
+      });
+
+      it('never resolves a deviceId off desktop, even for a local target', async () => {
+        mockEnv.isDesktop = false;
+        mockAgency.value = { executionTarget: 'local' };
+
+        await send();
+
+        expect(mockGateway.getDeviceInfo).not.toHaveBeenCalled();
+        expect(aiAgentService.execAgentTask).toHaveBeenCalledWith(
+          expect.objectContaining({ deviceId: undefined }),
+          expect.anything(),
+        );
       });
     });
   });

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -8,11 +8,12 @@ import type { ConversationContext, ExecAgentResult, MessageMetadata } from '@lob
 
 import { isDesktop } from '@/const/version';
 import { aiAgentService, type ResumeApprovalParam } from '@/services/aiAgent';
+import { gatewayConnectionService } from '@/services/electron/gatewayConnection';
 import { localFileService } from '@/services/electron/localFileService';
 import { messageService } from '@/services/message';
 import { topicService } from '@/services/topic';
 import { getAgentStoreState } from '@/store/agent';
-import { agentSelectors } from '@/store/agent/selectors';
+import { agentByIdSelectors, agentSelectors } from '@/store/agent/selectors';
 import { consumePendingTopicRepos, getPendingTopicRepos } from '@/store/chat/pendingTopicRepos';
 import { topicSelectors } from '@/store/chat/selectors';
 import type { ChatStore } from '@/store/chat/store';
@@ -48,6 +49,37 @@ const resolveProjectSkills = async (
       name: skill.name,
       path: skill.path,
     }));
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * When the agent runs against the local machine ("本机" / `executionTarget:
+ * 'local'`), resolve this desktop's own gateway deviceId so it can be passed as
+ * the run's `deviceId`. The server then presets `activeDeviceId` and injects
+ * `lobe-local-system` into the very first LLM payload — skipping the extra
+ * `activateDevice` round-trip the model is otherwise forced to make whenever
+ * more than one device is online (with a single device the server's heuristic
+ * already covered it).
+ *
+ * Desktop-only and best-effort: any failure falls back to the server-side
+ * device-resolution heuristics. We don't pre-check online status here — an
+ * offline id simply fails the server's `onlineDevices` guard and stays unrouted.
+ */
+const resolveLocalDeviceId = async (agentId?: string): Promise<string | undefined> => {
+  if (!isDesktop || !agentId) return undefined;
+
+  // Mirror HeteroDeviceSwitcher's effective-target fallback: on desktop an
+  // unset target means the local machine.
+  const executionTarget =
+    agentByIdSelectors.getAgencyConfigById(agentId)(getAgentStoreState())?.executionTarget ??
+    'local';
+  if (executionTarget !== 'local') return undefined;
+
+  try {
+    const info = await gatewayConnectionService.getDeviceInfo();
+    return info?.deviceId;
   } catch {
     return undefined;
   }
@@ -353,7 +385,10 @@ export class GatewayActionImpl {
       ? this.#get().getOperationAbortSignal(parentOperationId)
       : undefined;
 
-    const projectSkills = await resolveProjectSkills(this.#get);
+    const [projectSkills, localDeviceId] = await Promise.all([
+      resolveProjectSkills(this.#get),
+      resolveLocalDeviceId(context.agentId),
+    ]);
 
     const result = await aiAgentService.execAgentTask(
       {
@@ -369,6 +404,7 @@ export class GatewayActionImpl {
           threadId: context.threadId,
           topicId: context.topicId,
         },
+        deviceId: localDeviceId,
         fileIds,
         parentMessageId,
         projectSkills,

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -13,7 +13,7 @@ import { localFileService } from '@/services/electron/localFileService';
 import { messageService } from '@/services/message';
 import { topicService } from '@/services/topic';
 import { getAgentStoreState } from '@/store/agent';
-import { agentByIdSelectors, agentSelectors } from '@/store/agent/selectors';
+import { agentSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { consumePendingTopicRepos, getPendingTopicRepos } from '@/store/chat/pendingTopicRepos';
 import { topicSelectors } from '@/store/chat/selectors';
 import type { ChatStore } from '@/store/chat/store';
@@ -55,13 +55,20 @@ const resolveProjectSkills = async (
 };
 
 /**
- * When the agent runs against the local machine ("本机" / `executionTarget:
- * 'local'`), resolve this desktop's own gateway deviceId so it can be passed as
- * the run's `deviceId`. The server then presets `activeDeviceId` and injects
- * `lobe-local-system` into the very first LLM payload — skipping the extra
- * `activateDevice` round-trip the model is otherwise forced to make whenever
- * more than one device is online (with a single device the server's heuristic
- * already covered it).
+ * When the agent runs against the local machine ("本机"), resolve this desktop's
+ * own gateway deviceId so it can be passed as the run's `deviceId`. The server
+ * then presets `activeDeviceId` and injects `lobe-local-system` into the very
+ * first LLM payload — skipping the extra `activateDevice` round-trip the model
+ * is otherwise forced to make whenever more than one device is online (with a
+ * single device the server's heuristic already covered it).
+ *
+ * Gated on the effective runtime mode (`isLocalSystemEnabledById`), NOT on
+ * `agencyConfig.executionTarget`: the latter is only written by the newer
+ * HeteroDeviceSwitcher, whereas the legacy ModeSelector writes just
+ * `runtimeMode`. Resolving a device whenever the target is unset would override
+ * an explicit `cloud` / `none` choice and wrongly route a cloud run to the
+ * local machine. `runtimeMode` is the single source of truth both selectors
+ * agree on (and what the server gates CloudSandbox on).
  *
  * Desktop-only and best-effort: any failure falls back to the server-side
  * device-resolution heuristics. We don't pre-check online status here — an
@@ -70,12 +77,8 @@ const resolveProjectSkills = async (
 const resolveLocalDeviceId = async (agentId?: string): Promise<string | undefined> => {
   if (!isDesktop || !agentId) return undefined;
 
-  // Mirror HeteroDeviceSwitcher's effective-target fallback: on desktop an
-  // unset target means the local machine.
-  const executionTarget =
-    agentByIdSelectors.getAgencyConfigById(agentId)(getAgentStoreState())?.executionTarget ??
-    'local';
-  if (executionTarget !== 'local') return undefined;
+  const isLocal = chatConfigByIdSelectors.isLocalSystemEnabledById(agentId)(getAgentStoreState());
+  if (!isLocal) return undefined;
 
   try {
     const info = await gatewayConnectionService.getDeviceInfo();


### PR DESCRIPTION
#### 💻 Change Type

- [x] ⚡️ perf

#### 🔀 Description of Change

When the desktop client runs an agent against **本机** (`executionTarget: 'local'`), the runtime now resolves this desktop's own gateway `deviceId` **client-side** and passes it as the run's `deviceId`.

**Why:** The whole `activeDeviceId → buildStepToolDelta → lobe-local-system` machinery already exists, but the `local` target was modeled as a *mode* (executionTarget + runtimeMode) rather than a concrete device. The client never told the server *which* device "本机" was, and the server's `activeDeviceId` resolver only understood `boundDeviceId` (the `device` target) plus a "exactly one online device" fallback heuristic. So with **multiple devices online**, picking 本机 left `activeDeviceId` undefined → the model was forced to call `listOnlineDevices` + `activateDevice` before `lobe-local-system` became available (an extra LLM round-trip, plus the `{{workingDirectory}}` literal leaking into the first steps).

By passing the local `deviceId`, the server presets `activeDeviceId` and injects `lobe-local-system` into the **first** LLM payload — the `activateDevice` round-trip is skipped.

**Scope:** purely client-side — reuses the existing server `deviceId` param, no server changes.

- New `resolveLocalDeviceId(agentId)` helper in `aiChat/actions/gateway.ts` (mirrors `resolveProjectSkills`): desktop-only, gated on `executionTarget === 'local'`, reads the local id via `gatewayConnectionService.getDeviceInfo()`, best-effort (any failure falls back to the server's existing heuristic).
- Wired into the `execAgentTask` call, run in parallel with `resolveProjectSkills`.

**Edge cases (safe):**
- `sandbox` / `device` targets → helper returns `undefined`, behavior unchanged.
- Device offline → server's `onlineDevices` guard fails the id → stays unrouted, no misrouting.
- Topic persistence → server writes the id into `topic.metadata.boundDeviceId`, but that field is never read back for activation (guarded by the existing `should not reuse topic boundDeviceId` test); each turn re-resolves from the current machine, so switching machine / moving to web self-corrects.

#### 🧪 How to Test

On desktop with **2+ devices online**, select 本机 and send a message that needs the filesystem/shell (e.g. "list files in cwd"). The agent should call a `lobe-local-system` tool on its **first** step, with no preceding `activateDevice` tool call.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

Type-check is clean for the changed file (remaining `tsgo` errors are pre-existing unbuilt-workspace-package issues, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
