### PR TITLE
🐛 fix(ui): restructure confirmModal title and content across deletion flows

### DIFF
--- a/src/features/PageEditor/Copilot/AgentSelector/useDropdownMenu.tsx
+++ b/src/features/PageEditor/Copilot/AgentSelector/useDropdownMenu.tsx
@@ -25,13 +25,14 @@ export const useDropdownMenu = ({
   const handleDelete = () => {
     confirmModal({
       cancelText: t('cancel'),
+      content: t('confirmRemoveSessionItemAlert', { ns: 'chat' }),
       okButtonProps: { danger: true },
       okText: t('delete'),
       onOk: async () => {
         await removeAgent(agentId);
         onClose();
       },
-      title: t('confirmRemoveSessionItemAlert', { ns: 'chat' }),
+      title: t('delete'),
     });
   };
 

--- a/src/features/ResourceManager/components/Explorer/Header/index.tsx
+++ b/src/features/ResourceManager/components/Explorer/Header/index.tsx
@@ -54,16 +54,19 @@ const Header = memo(() => {
           title={t('FileManager.actions.removeFromLibrary')}
           onClick={() => {
             confirmModal({
+              cancelText: t('cancel', { ns: 'common' }),
+              content: t('FileManager.actions.confirmRemoveFromLibrary', {
+                count: selectCount,
+              }),
               okButtonProps: {
                 danger: true,
               },
+              okText: t('FileManager.actions.removeFromLibrary'),
               onOk: async () => {
                 await onActionClick('removeFromKnowledgeBase');
                 message.success(t('FileManager.actions.removeFromLibrarySuccess'));
               },
-              title: t('FileManager.actions.confirmRemoveFromLibrary', {
-                count: selectCount,
-              }),
+              title: t('FileManager.actions.removeFromLibrary'),
             });
           }}
         />
@@ -82,19 +85,22 @@ const Header = memo(() => {
         title={t('delete', { ns: 'common' })}
         onClick={() => {
           confirmModal({
-            okButtonProps: {
-              danger: true,
-            },
-            onOk: async () => {
-              await onActionClick('delete');
-              message.success(t('FileManager.actions.deleteSuccess'));
-            },
-            title: t(
+            cancelText: t('cancel', { ns: 'common' }),
+            content: t(
               selectAllState === 'all'
                 ? 'FileManager.actions.confirmDeleteAllFiles'
                 : 'FileManager.actions.confirmDeleteMultiFiles',
               { count: selectCount },
             ),
+            okButtonProps: {
+              danger: true,
+            },
+            okText: t('delete', { ns: 'common' }),
+            onOk: async () => {
+              await onActionClick('delete');
+              message.success(t('FileManager.actions.deleteSuccess'));
+            },
+            title: t('delete', { ns: 'common' }),
           });
         }}
       />

--- a/src/features/ResourceManager/components/Explorer/ItemDropdown/useFileItemDropdown.tsx
+++ b/src/features/ResourceManager/components/Explorer/ItemDropdown/useFileItemDropdown.tsx
@@ -170,17 +170,20 @@ export const useFileItemDropdown = ({
                 domEvent.stopPropagation();
 
                 confirmModal({
+                  cancelText: t('cancel', { ns: 'common' }),
+                  content: t('FileManager.actions.confirmRemoveFromLibrary', {
+                    count: 1,
+                  }),
                   okButtonProps: {
                     danger: true,
                   },
+                  okText: t('FileManager.actions.removeFromLibrary'),
                   onOk: async () => {
                     await removeFilesFromKnowledgeBase(libraryId, [id]);
 
                     message.success(t('FileManager.actions.removeFromLibrarySuccess'));
                   },
-                  title: t('FileManager.actions.confirmRemoveFromLibrary', {
-                    count: 1,
-                  }),
+                  title: t('FileManager.actions.removeFromLibrary'),
                 });
               },
             },

--- a/src/features/ResourceManager/components/Explorer/ToolBar/BatchActionsDropdown.tsx
+++ b/src/features/ResourceManager/components/Explorer/ToolBar/BatchActionsDropdown.tsx
@@ -56,13 +56,16 @@ const BatchActionsDropdown = memo<BatchActionsDropdownProps>(({ selectCount, onA
         label: t('header.actions.deleteLibrary', { ns: 'file' }),
         onClick: async () => {
           confirmModal({
+            cancelText: t('cancel', { ns: 'common' }),
+            content: t('library.list.confirmRemoveLibrary', { ns: 'file' }),
             okButtonProps: {
               danger: true,
             },
+            okText: t('delete', { ns: 'common' }),
             onOk: async () => {
               await onActionClick('deleteLibrary');
             },
-            title: t('library.list.confirmRemoveLibrary', { ns: 'file' }),
+            title: t('header.actions.deleteLibrary', { ns: 'file' }),
           });
         },
       });
@@ -102,16 +105,19 @@ const BatchActionsDropdown = memo<BatchActionsDropdownProps>(({ selectCount, onA
         label: t('FileManager.actions.removeFromLibrary'),
         onClick: () => {
           confirmModal({
+            cancelText: t('cancel', { ns: 'common' }),
+            content: t('FileManager.actions.confirmRemoveFromLibrary', {
+              count: selectCount,
+            }),
             okButtonProps: {
               danger: true,
             },
+            okText: t('FileManager.actions.removeFromLibrary'),
             onOk: async () => {
               await onActionClick('removeFromKnowledgeBase');
               message.success(t('FileManager.actions.removeFromLibrarySuccess'));
             },
-            title: t('FileManager.actions.confirmRemoveFromLibrary', {
-              count: selectCount,
-            }),
+            title: t('FileManager.actions.removeFromLibrary'),
           });
         },
       });
@@ -156,14 +162,17 @@ const BatchActionsDropdown = memo<BatchActionsDropdownProps>(({ selectCount, onA
         label: t('delete', { ns: 'common' }),
         onClick: async () => {
           confirmModal({
+            cancelText: t('cancel', { ns: 'common' }),
+            content: t('FileManager.actions.confirmDeleteMultiFiles', { count: selectCount }),
             okButtonProps: {
               danger: true,
             },
+            okText: t('delete', { ns: 'common' }),
             onOk: async () => {
               await onActionClick('delete');
               message.success(t('FileManager.actions.deleteSuccess'));
             },
-            title: t('FileManager.actions.confirmDeleteMultiFiles', { count: selectCount }),
+            title: t('delete', { ns: 'common' }),
           });
         },
       },

--- a/src/features/ResourceManager/components/Explorer/ToolBar/MultiSelectActions.tsx
+++ b/src/features/ResourceManager/components/Explorer/ToolBar/MultiSelectActions.tsx
@@ -85,16 +85,19 @@ const MultiSelectActions = memo<MultiSelectActionsProps>(
                   size={'small'}
                   onClick={() => {
                     confirmModal({
+                      cancelText: t('cancel', { ns: 'common' }),
+                      content: t('FileManager.actions.confirmRemoveFromLibrary', {
+                        count: selectCount,
+                      }),
                       okButtonProps: {
                         danger: true,
                       },
+                      okText: t('FileManager.actions.removeFromLibrary'),
                       onOk: async () => {
                         await onActionClick('removeFromKnowledgeBase');
                         message.success(t('FileManager.actions.removeFromLibrarySuccess'));
                       },
-                      title: t('FileManager.actions.confirmRemoveFromLibrary', {
-                        count: selectCount,
-                      }),
+                      title: t('FileManager.actions.removeFromLibrary'),
                     });
                   }}
                 >
@@ -144,14 +147,17 @@ const MultiSelectActions = memo<MultiSelectActionsProps>(
               variant={'filled'}
               onClick={async () => {
                 confirmModal({
+                  cancelText: t('cancel', { ns: 'common' }),
+                  content: t('FileManager.actions.confirmDeleteMultiFiles', { count: selectCount }),
                   okButtonProps: {
                     danger: true,
                   },
+                  okText: t('delete', { ns: 'common' }),
                   onOk: async () => {
                     await onActionClick('delete');
                     message.success(t('FileManager.actions.deleteSuccess'));
                   },
-                  title: t('FileManager.actions.confirmDeleteMultiFiles', { count: selectCount }),
+                  title: t('delete', { ns: 'common' }),
                 });
               }}
             >

--- a/src/features/SkillStore/SkillList/AgentSkillItem.tsx
+++ b/src/features/SkillStore/SkillList/AgentSkillItem.tsx
@@ -65,11 +65,14 @@ const AgentSkillItem = memo<AgentSkillItemProps>(({ skill }) => {
 
   const handleDelete = () => {
     confirmModal({
+      cancelText: tc('cancel'),
+      content: t('store.actions.confirmUninstall'),
       okButtonProps: { danger: true },
+      okText: t('store.actions.uninstall'),
       onOk: async () => {
         await deleteAgentSkill(skill.id);
       },
-      title: t('store.actions.confirmUninstall'),
+      title: t('store.actions.uninstall'),
     });
   };
 

--- a/src/features/SkillStore/SkillList/Builtin/Item.tsx
+++ b/src/features/SkillStore/SkillList/Builtin/Item.tsx
@@ -28,7 +28,7 @@ interface ItemProps {
 }
 
 const Item = memo<ItemProps>(({ avatar, description, identifier, onOpenDetail, title }) => {
-  const { t } = useTranslation(['setting', 'plugin']);
+  const { t } = useTranslation(['setting', 'plugin', 'common']);
   const styles = itemStyles;
 
   const [installBuiltinTool, uninstallBuiltinTool, isInstalled] = useToolStore((s) => [
@@ -43,11 +43,14 @@ const Item = memo<ItemProps>(({ avatar, description, identifier, onOpenDetail, t
 
   const handleUninstall = () => {
     confirmModal({
+      cancelText: t('cancel', { ns: 'common' }),
+      content: t('store.actions.confirmUninstall', { ns: 'plugin' }),
       okButtonProps: { danger: true },
+      okText: t('store.actions.uninstall', { ns: 'plugin' }),
       onOk: async () => {
         await uninstallBuiltinTool(identifier);
       },
-      title: t('store.actions.confirmUninstall', { ns: 'plugin' }),
+      title: t('store.actions.uninstall', { ns: 'plugin' }),
     });
   };
 

--- a/src/features/SkillStore/SkillList/Community/MarketSkillItem.tsx
+++ b/src/features/SkillStore/SkillList/Community/MarketSkillItem.tsx
@@ -66,13 +66,16 @@ const MarketSkillItem = memo<DiscoverSkillItem>(({ name, icon, description, iden
   const handleUninstall = useCallback(() => {
     if (!installedSkill) return;
     confirmModal({
+      cancelText: tc('cancel'),
+      content: t('store.actions.confirmUninstall'),
       okButtonProps: { danger: true },
+      okText: t('store.actions.uninstall'),
       onOk: async () => {
         await deleteAgentSkill(installedSkill.id);
       },
-      title: t('store.actions.confirmUninstall'),
+      title: t('store.actions.uninstall'),
     });
-  }, [installedSkill, deleteAgentSkill, t]);
+  }, [installedSkill, deleteAgentSkill, t, tc]);
 
   const handleDownload = useCallback(async () => {
     if (!installedSkill?.zipFileHash) return;

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -207,11 +207,14 @@ export const useTopicItemDropdownMenu = ({
         label: t('delete', { ns: 'common' }),
         onClick: () => {
           confirmModal({
+            cancelText: t('cancel', { ns: 'common' }),
+            content: t('actions.confirmRemoveTopic'),
             okButtonProps: { danger: true },
+            okText: t('delete', { ns: 'common' }),
             onOk: async () => {
               await removeTopic(id);
             },
-            title: t('actions.confirmRemoveTopic'),
+            title: t('delete', { ns: 'common' }),
           });
         },
       },

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
@@ -40,11 +40,14 @@ export const useThreadItemDropdownMenu = ({
         label: t('delete', { ns: 'common' }),
         onClick: () => {
           confirmModal({
+            cancelText: t('cancel', { ns: 'common' }),
+            content: t('actions.confirmRemoveThread'),
             okButtonProps: { danger: true },
+            okText: t('delete', { ns: 'common' }),
             onOk: async () => {
               await removeThread(id);
             },
-            title: t('actions.confirmRemoveThread'),
+            title: t('delete', { ns: 'common' }),
           });
         },
       },

--- a/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/useMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/useMenu.tsx
@@ -261,11 +261,14 @@ export const useMenu = (): { menuItems: DropdownItem[] } => {
           label: t('delete', { ns: 'common' }),
           onClick: () => {
             confirmModal({
+              cancelText: t('cancel', { ns: 'common' }),
+              content: t('actions.confirmRemoveTopic', { ns: 'topic' }),
               okButtonProps: { danger: true },
+              okText: t('delete', { ns: 'common' }),
               onOk: async () => {
                 await removeTopic(topicId);
               },
-              title: t('actions.confirmRemoveTopic', { ns: 'topic' }),
+              title: t('delete', { ns: 'common' }),
             });
           },
         },

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -164,11 +164,14 @@ export const useTopicItemDropdownMenu = ({
         label: t('delete', { ns: 'common' }),
         onClick: () => {
           confirmModal({
+            cancelText: t('cancel', { ns: 'common' }),
+            content: t('actions.confirmRemoveTopic'),
             okButtonProps: { danger: true },
+            okText: t('delete', { ns: 'common' }),
             onOk: async () => {
               await removeTopic(id);
             },
-            title: t('actions.confirmRemoveTopic'),
+            title: t('delete', { ns: 'common' }),
           });
         },
       },

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/useDropdownMenu.tsx
@@ -40,11 +40,14 @@ export const useThreadItemDropdownMenu = ({
         label: t('delete', { ns: 'common' }),
         onClick: () => {
           confirmModal({
+            cancelText: t('cancel', { ns: 'common' }),
+            content: t('actions.confirmRemoveThread'),
             okButtonProps: { danger: true },
+            okText: t('delete', { ns: 'common' }),
             onOk: async () => {
               await removeThread(id);
             },
-            title: t('actions.confirmRemoveThread'),
+            title: t('delete', { ns: 'common' }),
           });
         },
       },

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentGroupItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentGroupItem/useDropdownMenu.tsx
@@ -29,7 +29,7 @@ export const useGroupDropdownMenu = ({
   pinned,
   title,
 }: UseGroupDropdownMenuParams): (() => MenuProps['items']) => {
-  const { t } = useTranslation('chat');
+  const { t } = useTranslation(['chat', 'common']);
   const { message } = App.useApp();
 
   const openAgentInNewWindow = useGlobalStore((s) => s.openAgentInNewWindow);
@@ -94,12 +94,15 @@ export const useGroupDropdownMenu = ({
           onClick: ({ domEvent }: any) => {
             domEvent.stopPropagation();
             confirmModal({
+              cancelText: t('cancel', { ns: 'common' }),
+              content: t('confirmRemoveChatGroupItemAlert'),
               okButtonProps: { danger: true },
+              okText: t('delete', { ns: 'common' }),
               onOk: async () => {
                 await removeAgentGroup(id);
                 message.success(t('confirmRemoveGroupSuccess'));
               },
-              title: t('confirmRemoveChatGroupItemAlert'),
+              title: t('delete', { ns: 'common' }),
             });
           },
         },

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.tsx
@@ -42,7 +42,7 @@ export const useAgentDropdownMenu = ({
   pinned,
   title,
 }: UseAgentDropdownMenuParams): (() => MenuProps['items']) => {
-  const { t } = useTranslation('chat');
+  const { t } = useTranslation(['chat', 'common']);
   const { message } = App.useApp();
 
   const openAgentInNewWindow = useGlobalStore((s) => s.openAgentInNewWindow);
@@ -133,12 +133,15 @@ export const useAgentDropdownMenu = ({
           onClick: ({ domEvent }: any) => {
             domEvent.stopPropagation();
             confirmModal({
+              cancelText: t('cancel', { ns: 'common' }),
+              content: t('confirmRemoveSessionItemAlert'),
               okButtonProps: { danger: true },
+              okText: t('delete', { ns: 'common' }),
               onOk: async () => {
                 await removeAgent(id);
                 message.success(t('confirmRemoveSessionSuccess'));
               },
-              title: t('confirmRemoveSessionItemAlert'),
+              title: t('delete', { ns: 'common' }),
             });
           },
         },

--- a/src/routes/(main)/home/_layout/Body/Agent/Modals/ConfigGroupModal/GroupItem.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/Modals/ConfigGroupModal/GroupItem.tsx
@@ -24,7 +24,7 @@ const styles = createStaticStyles(({ css }) => ({
 }));
 
 const GroupItem = memo<SessionGroupItemBase>(({ id, name }) => {
-  const { t } = useTranslation('chat');
+  const { t } = useTranslation(['chat', 'common']);
   const { message } = App.useApp();
 
   const [editing, setEditing] = useState(false);
@@ -42,13 +42,16 @@ const GroupItem = memo<SessionGroupItemBase>(({ id, name }) => {
             size={'small'}
             onClick={() => {
               confirmModal({
+                cancelText: t('cancel', { ns: 'common' }),
+                content: t('sessionGroup.confirmRemoveGroupAlert'),
                 okButtonProps: {
                   danger: true,
                 },
+                okText: t('delete', { ns: 'common' }),
                 onOk: async () => {
                   await removeGroup(id);
                 },
-                title: t('sessionGroup.confirmRemoveGroupAlert'),
+                title: t('delete', { ns: 'common' }),
               });
             }}
           />

--- a/src/routes/(main)/home/_layout/Body/Project/List/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/_layout/Body/Project/List/useDropdownMenu.tsx
@@ -40,11 +40,14 @@ export const useProjectItemDropdownMenu = ({
         onClick: () => {
           if (!id) return;
           confirmModal({
+            cancelText: t('cancel', { ns: 'common' }),
+            content: t('project.deleteConfirm'),
             okButtonProps: { danger: true },
+            okText: t('delete', { ns: 'common' }),
             onOk: async () => {
               await removeKnowledgeBase(id);
             },
-            title: t('project.deleteConfirm'),
+            title: t('delete', { ns: 'common' }),
           });
         },
       },

--- a/src/routes/(main)/home/_layout/hooks/useSessionGroupMenuItems.tsx
+++ b/src/routes/(main)/home/_layout/hooks/useSessionGroupMenuItems.tsx
@@ -25,7 +25,7 @@ const styles = createStaticStyles(({ css }) => ({
  * Used in List/Group/Actions.tsx
  */
 export const useSessionGroupMenuItems = () => {
-  const { t } = useTranslation('chat');
+  const { t } = useTranslation(['chat', 'common']);
   const { message } = App.useApp();
   const groupTemplates = useGroupTemplates();
 
@@ -90,11 +90,14 @@ export const useSessionGroupMenuItems = () => {
         onClick: (info: any) => {
           info.domEvent?.stopPropagation();
           confirmModal({
+            cancelText: t('cancel', { ns: 'common' }),
+            content: t('sessionGroup.confirmRemoveGroupAlert'),
             okButtonProps: { danger: true },
+            okText: t('delete', { ns: 'common' }),
             onOk: async () => {
               await removeGroup(groupId);
             },
-            title: t('sessionGroup.confirmRemoveGroupAlert'),
+            title: t('delete', { ns: 'common' }),
           });
         },
       };

--- a/src/routes/(main)/home/features/Recents/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/features/Recents/useDropdownMenu.tsx
@@ -52,7 +52,10 @@ export const useRecentItemDropdownMenu = (
     };
 
     confirmModal({
+      cancelText: t('cancel', { ns: 'common' }),
+      content: confirmMessages[item.type],
       okButtonProps: { danger: true },
+      okText: t('delete', { ns: 'common' }),
       onOk: async () => {
         switch (item.type) {
           case 'topic': {
@@ -71,7 +74,7 @@ export const useRecentItemDropdownMenu = (
         }
         await refreshRecents();
       },
-      title: confirmMessages[item.type] || t('delete', { ns: 'common' }),
+      title: t('delete', { ns: 'common' }),
     });
   }, [item, t, refreshRecents]);
 

--- a/src/routes/(main)/resource/(home)/_layout/Body/LibraryList/Item/useDropdownMenu.tsx
+++ b/src/routes/(main)/resource/(home)/_layout/Body/LibraryList/Item/useDropdownMenu.tsx
@@ -15,7 +15,12 @@ interface ActionProps {
   toggleEditing: (visible?: boolean) => void;
 }
 
-export const useDropdownMenu = ({ id, name, description, toggleEditing }: ActionProps): (() => MenuProps['items']) => {
+export const useDropdownMenu = ({
+  id,
+  name,
+  description,
+  toggleEditing,
+}: ActionProps): (() => MenuProps['items']) => {
   const { t } = useTranslation(['file', 'common']);
   const removeKnowledgeBase = useKnowledgeBaseStore((s) => s.removeKnowledgeBase);
   const { open } = useCreateNewModal();
@@ -24,11 +29,14 @@ export const useDropdownMenu = ({ id, name, description, toggleEditing }: Action
     if (!id) return;
 
     confirmModal({
+      cancelText: t('cancel', { ns: 'common' }),
+      content: t('library.list.confirmRemoveLibrary'),
       okButtonProps: { danger: true },
+      okText: t('delete', { ns: 'common' }),
       onOk: async () => {
         await removeKnowledgeBase(id);
       },
-      title: t('library.list.confirmRemoveLibrary'),
+      title: t('header.actions.deleteLibrary'),
     });
   };
 
@@ -69,6 +77,16 @@ export const useDropdownMenu = ({ id, name, description, toggleEditing }: Action
           onClick: handleDelete,
         },
       ].filter(Boolean) as MenuProps['items'],
-    [t, id, name, description, removeKnowledgeBase, toggleEditing, handleDelete, handleEditDescription, open],
+    [
+      t,
+      id,
+      name,
+      description,
+      removeKnowledgeBase,
+      toggleEditing,
+      handleDelete,
+      handleEditDescription,
+      open,
+    ],
   );
 };

--- a/src/routes/(main)/settings/provider/features/ModelList/ModelItem.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/ModelItem.tsx
@@ -204,16 +204,19 @@ const ModelItem = memo<ModelItemProps>(
               title={t('providerModels.item.delete.title')}
               onClick={() => {
                 confirmModal({
+                  cancelText: t('cancel', { ns: 'common' }),
+                  content: t('providerModels.item.delete.confirm', {
+                    displayName: displayName || id,
+                  }),
                   okButtonProps: {
                     danger: true,
                   },
+                  okText: t('delete', { ns: 'common' }),
                   onOk: async () => {
                     await removeAiModel(id, activeAiProvider!);
                     message.success(t('providerModels.item.delete.success'));
                   },
-                  title: t('providerModels.item.delete.confirm', {
-                    displayName: displayName || id,
-                  }),
+                  title: t('providerModels.item.delete.title'),
                 });
               }}
             />

--- a/src/routes/(main)/settings/skill/features/BuiltinSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/BuiltinSkillItem.tsx
@@ -20,7 +20,7 @@ interface BuiltinSkillItemProps {
 }
 
 const BuiltinSkillItem = memo<BuiltinSkillItemProps>(({ identifier, title, avatar }) => {
-  const { t } = useTranslation(['setting', 'plugin']);
+  const { t } = useTranslation(['setting', 'plugin', 'common']);
 
   const [installBuiltinTool, uninstallBuiltinTool, isInstalled] = useToolStore((s) => [
     s.installBuiltinTool,
@@ -34,11 +34,14 @@ const BuiltinSkillItem = memo<BuiltinSkillItemProps>(({ identifier, title, avata
 
   const handleUninstall = () => {
     confirmModal({
+      cancelText: t('cancel', { ns: 'common' }),
+      content: t('store.actions.confirmUninstall', { ns: 'plugin' }),
       okButtonProps: { danger: true },
+      okText: t('store.actions.uninstall', { ns: 'plugin' }),
       onOk: async () => {
         await uninstallBuiltinTool(identifier);
       },
-      title: t('store.actions.confirmUninstall', { ns: 'plugin' }),
+      title: t('store.actions.uninstall', { ns: 'plugin' }),
     });
   };
 

--- a/src/routes/(main)/settings/storage/features/Advanced.tsx
+++ b/src/routes/(main)/settings/storage/features/Advanced.tsx
@@ -23,7 +23,7 @@ import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/selectors';
 
 const AdvancedActions = () => {
-  const { t } = useTranslation('setting');
+  const { t } = useTranslation(['setting', 'common']);
   const { message } = App.useApp();
   const { hideDocs } = useServerConfigStore(featureFlagsSelectors);
   const enableBusinessFeatures = useServerConfigStore(serverConfigSelectors.enableBusinessFeatures);
@@ -43,9 +43,12 @@ const AdvancedActions = () => {
 
   const handleClear = useCallback(() => {
     confirmModal({
+      cancelText: t('cancel', { ns: 'common' }),
+      content: t('danger.clear.confirm'),
       okButtonProps: {
         danger: true,
       },
+      okText: t('danger.clear.action'),
       onOk: async () => {
         await clearSessions();
         await removeAllPlugins();
@@ -56,7 +59,7 @@ const AdvancedActions = () => {
 
         message.success(t('danger.clear.success'));
       },
-      title: t('danger.clear.confirm'),
+      title: t('danger.clear.title'),
     });
   }, [
     clearAllMessages,
@@ -71,12 +74,15 @@ const AdvancedActions = () => {
 
   const handleReset = useCallback(() => {
     confirmModal({
+      cancelText: t('cancel', { ns: 'common' }),
+      content: t('danger.reset.confirm'),
       okButtonProps: { danger: true },
+      okText: t('danger.reset.action'),
       onOk: () => {
         resetSettings();
         message.success(t('danger.reset.success'));
       },
-      title: t('danger.reset.confirm'),
+      title: t('danger.reset.title'),
     });
   }, [message, resetSettings, t]);
 

--- a/src/routes/(mobile)/(home)/features/SessionListContent/CollapseGroup/Actions.tsx
+++ b/src/routes/(mobile)/(home)/features/SessionListContent/CollapseGroup/Actions.tsx
@@ -30,7 +30,7 @@ type MenuItemType = ItemOfType<MenuProps['items']>;
 
 const Actions = memo<ActionsProps>(
   ({ id, openRenameModal, openConfigModal, onOpenChange, isCustomGroup, isPinned }) => {
-    const { t } = useTranslation('chat');
+    const { t } = useTranslation(['chat', 'common']);
     const { message } = App.useApp();
 
     const isMobile = useIsMobile();
@@ -142,12 +142,15 @@ const Actions = memo<ActionsProps>(
           onClick: ({ domEvent }) => {
             domEvent.stopPropagation();
             confirmModal({
+              cancelText: t('cancel', { ns: 'common' }),
+              content: t('sessionGroup.confirmRemoveGroupAlert'),
               okButtonProps: { danger: true },
+              okText: t('delete', { ns: 'common' }),
               onOk: async () => {
                 if (!id) return;
                 await removeSessionGroup(id);
               },
-              title: t('sessionGroup.confirmRemoveGroupAlert'),
+              title: t('delete', { ns: 'common' }),
             });
           },
         },

--- a/src/routes/(mobile)/(home)/features/SessionListContent/Modals/ConfigGroupModal/GroupItem.tsx
+++ b/src/routes/(mobile)/(home)/features/SessionListContent/Modals/ConfigGroupModal/GroupItem.tsx
@@ -24,7 +24,7 @@ const styles = createStaticStyles(({ css }) => ({
 }));
 
 const GroupItem = memo<SessionGroupItem>(({ id, name }) => {
-  const { t } = useTranslation('chat');
+  const { t } = useTranslation(['chat', 'common']);
   const { message } = App.useApp();
 
   const [editing, setEditing] = useState(false);
@@ -45,13 +45,16 @@ const GroupItem = memo<SessionGroupItem>(({ id, name }) => {
             size={'small'}
             onClick={() => {
               confirmModal({
+                cancelText: t('cancel', { ns: 'common' }),
+                content: t('sessionGroup.confirmRemoveGroupAlert'),
                 okButtonProps: {
                   danger: true,
                 },
+                okText: t('delete', { ns: 'common' }),
                 onOk: async () => {
                   await removeSessionGroup(id);
                 },
-                title: t('sessionGroup.confirmRemoveGroupAlert'),
+                title: t('delete', { ns: 'common' }),
               });
             }}
           />


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

`confirmModal` from `@lobehub/ui/base-ui` expects `{ title, content, okText, cancelText, okButtonProps, onOk }`. Across the app, 25 deletion/uninstall flows were passing the long warning sentence (e.g. `"You are about to delete this topic. This action cannot be undone."`) as `title` while leaving `content` empty, producing an oversized title and no body in the modal.

This PR normalises every affected site to:

- `title`: short verb/noun (e.g. `"Delete"`, `"Uninstall"`, `"Wipe Data"`, `"Reset All Settings"`, `"Delete Model"`, `"Remove from Library"`)
- `content`: the long warning sentence
- `okText` / `cancelText`: i18n labels matching the action (`common:delete`, `common:cancel`, `store.actions.uninstall`, etc.)
- `okButtonProps.danger: true` preserved

Sites grouped by domain:

- **File / Library (8)** — `ResourceManager` Header / ItemDropdown / BatchActionsDropdown / MultiSelectActions, `resource/(home)` library item
- **SkillStore (4)** — `SkillStore/AgentSkillItem` / `Builtin/Item` / `Community/MarketSkillItem`, `settings/skill/BuiltinSkillItem`
- **Session / Group (7)** — `PageEditor/AgentSelector`, `home` AgentItem / AgentGroupItem / ConfigGroupModal / `useSessionGroupMenuItems`, mobile `CollapseGroup/Actions` / `ConfigGroupModal`
- **Topic / Thread (6)** — `agent` + `group` Sidebar Topic List / ThreadList items, `agent` Conversation Header actions, `home/features/Recents`, `PageEditor/Copilot/TopicSelector`
- **Misc (4)** — `home/Project` delete, `settings/provider/ModelList/ModelItem`, `settings/storage/Advanced` (clear + reset)

A few files added `'common'` to their `useTranslation([...])` namespaces to access `cancel`/`delete` keys.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Trigger any deletion flow (topic, thread, agent, group, library, file, model, skill, storage wipe) and verify the confirm dialog now shows a short title with the warning as body text, and the OK/Cancel buttons carry localized labels.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Long sentence as title, empty body | Short verb title, sentence in body |

#### 📝 Additional Information

No behaviour changes — purely a structural fix to the confirm-modal payload. No locale keys added or renamed.