### PR TITLE
🐛 fix(github): render runCommand tool result card

### DIFF
--- a/packages/builtin-tools/src/github/index.ts
+++ b/packages/builtin-tools/src/github/index.ts
@@ -6,13 +6,18 @@ import GithubRunCommandRender from './RunCommandRender';
 export const GithubIdentifier = 'github';
 
 export const GithubApiName = {
-  runCommand: 'run_command',
+  runCommand: 'runCommand',
 } as const;
 
+// The tool call emits the camelCase `runCommand` apiName, while older payloads
+// used the snake_case `run_command`. Register both so the render/inspector match
+// regardless of the casing.
 export const GithubInspectors: Record<string, BuiltinInspector> = {
-  [GithubApiName.runCommand]: GithubRunCommandInspector as BuiltinInspector,
+  runCommand: GithubRunCommandInspector as BuiltinInspector,
+  run_command: GithubRunCommandInspector as BuiltinInspector,
 };
 
 export const GithubRenders: Record<string, BuiltinRender> = {
-  [GithubApiName.runCommand]: GithubRunCommandRender as BuiltinRender,
+  runCommand: GithubRunCommandRender as BuiltinRender,
+  run_command: GithubRunCommandRender as BuiltinRender,
 };


### PR DESCRIPTION
### 💻 Change Type

- [x] 🐛 fix

### 🔀 Description of Change

The GitHub builtin tool's render and inspector were registered under the snake_case `run_command` key in `packages/builtin-tools/src/github/index.ts`. However, the actual tool call emits the camelCase `runCommand` apiName, so `getBuiltinRender('github', 'runCommand')` missed the lookup and fell back to the generic collapsed pill (see screenshot below) instead of the dedicated command/output/stderr card.

This registers both casings (`runCommand` + `run_command`) for the render and inspector maps so the custom UI renders regardless of payload casing. Re-applies the previously reverted `6770d8f3` cleanly.

**Before:** `GitHub > runCommand (command: pr view 15439 …)` shown as a raw generic pill.
**After:** rendered with `GithubRunCommandRender` — command, output, and stderr card.

### 📝 Additional Information

How to test: trigger the GitHub builtin tool's `runCommand` action and confirm the result renders as the structured card rather than the generic collapsed pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)