### PR TITLE
:lipstick: style(modal): use base-ui Button in custom modal footers

### DIFF
--- a/src/features/Electron/AuthRequiredModal/index.tsx
+++ b/src/features/Electron/AuthRequiredModal/index.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
-import { Button, Flexbox, Icon } from '@lobehub/ui';
+import { Flexbox, Icon } from '@lobehub/ui';
 import {
+  Button,
   createModal,
   type ImperativeModalProps,
   ModalFooter,

--- a/src/features/RecommendTaskTemplates/TaskTemplateDetailModal.tsx
+++ b/src/features/RecommendTaskTemplates/TaskTemplateDetailModal.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import type { TaskTemplate } from '@lobechat/const';
-import { ActionIcon, Button, Flexbox, Icon, Markdown, Text } from '@lobehub/ui';
-import { createModal, type ModalInstance, useModalContext } from '@lobehub/ui/base-ui';
+import { ActionIcon, Flexbox, Icon, Markdown, Text } from '@lobehub/ui';
+import { Button, createModal, type ModalInstance, useModalContext } from '@lobehub/ui/base-ui';
 import { Divider } from 'antd';
 import { cssVar } from 'antd-style';
 import { Clock, X } from 'lucide-react';


### PR DESCRIPTION
## Summary

Use `Button` from `@lobehub/ui/base-ui` in custom modal footers / actions so they share the same padding (14) / font-size (13) / height (32) as the base-ui Modal's built-in `OkBtn` / `CancelBtn`. Without this change, action buttons sat 1px shy and one font-size step heavier than the modal's own footer button.

## Changes

- `src/features/Electron/AuthRequiredModal/index.tsx` — footer's two buttons (Later / Sign In) now use `base-ui` `Button`.
- `src/features/RecommendTaskTemplates/TaskTemplateDetailModal.tsx` — primary action button in modal content uses `base-ui` `Button`.

No behaviour change — `disabled`, `loading`, `icon`, `shape='round'`, `type='primary'`, `onClick` all supported identically.

## Test plan

- [ ] Trigger the Electron auth required modal — verify the footer's two buttons line up with the modal's typography.
- [ ] Open a task template detail modal — verify the primary action button feels consistent with other base-ui buttons.
- [ ] Hover / tap each — micro-lift + scale spring should engage.