### PR TITLE
⚡️ perf(database): add optional statement_timeout to server DB connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -376,6 +376,11 @@ OPENAI_API_KEY=sk-xxxxxxxxx
 # Postgres database URL
 # DATABASE_URL=postgres://username:password@host:port/database
 
+# Optional: server-side timeout (in milliseconds) for a single SQL statement.
+# When set, Postgres aborts any statement/idle transaction exceeding it, so a stuck
+# query can't block indefinitely. Leave unset to keep Postgres' default of no timeout.
+# DATABASE_STATEMENT_TIMEOUT=300000
+
 # use `openssl rand -base64 32` to generate a key for the encryption of the database
 # we use this key to encrypt the user api key and proxy url
 # KEY_VAULTS_SECRET=xxxxx/xxxxxxxxxxxxxx=

--- a/packages/database/src/core/web-server.ts
+++ b/packages/database/src/core/web-server.ts
@@ -28,8 +28,19 @@ If you don't have it, please run \`openssl rand -base64 32\` to create one.
     throw new Error(`You are try to use database, but "DATABASE_URL" is not set correctly`);
   }
 
+  // When DATABASE_STATEMENT_TIMEOUT is set, Postgres aborts any statement (and any
+  // transaction left idle) exceeding it on the server side, so a stuck query can't
+  // block indefinitely. Omit the keys entirely when unset to keep Postgres' defaults.
+  const statementTimeout = serverDBEnv.DATABASE_STATEMENT_TIMEOUT;
+  const timeoutConfig = statementTimeout
+    ? {
+        idle_in_transaction_session_timeout: statementTimeout,
+        statement_timeout: statementTimeout,
+      }
+    : {};
+
   if (serverDBEnv.DATABASE_DRIVER === 'node') {
-    const client = new NodePool({ connectionString });
+    const client = new NodePool({ connectionString, ...timeoutConfig });
     // pg.Pool emits 'error' on idle clients when the backend connection drops.
     // Without a listener Node escalates it to uncaughtException and exits the process.
     // See: https://node-postgres.com/apis/pool#error
@@ -48,7 +59,7 @@ If you don't have it, please run \`openssl rand -base64 32\` to create one.
     neonConfig.webSocketConstructor = ws;
   }
 
-  const client = new NeonPool({ connectionString });
+  const client = new NeonPool({ connectionString, ...timeoutConfig });
   // NeonPool runs over WebSocket; transient drops surface as 'error' on the pool.
   // Without a listener Node escalates it to uncaughtException — on Vercel this killed
   // the entire Lambda 1800+ times in 5 minutes (see ).

--- a/src/config/db.ts
+++ b/src/config/db.ts
@@ -5,6 +5,7 @@ export const getServerDBConfig = () => {
   return createEnv({
     runtimeEnv: {
       DATABASE_DRIVER: process.env.DATABASE_DRIVER || 'neon',
+      DATABASE_STATEMENT_TIMEOUT: process.env.DATABASE_STATEMENT_TIMEOUT,
       DATABASE_TEST_URL: process.env.DATABASE_TEST_URL,
       DATABASE_URL: process.env.DATABASE_URL,
 
@@ -14,6 +15,11 @@ export const getServerDBConfig = () => {
     },
     server: {
       DATABASE_DRIVER: z.enum(['neon', 'node']),
+      // Server-side timeout (in milliseconds) for a single SQL statement.
+      // When set, Postgres aborts any statement running longer than this,
+      // preventing a stuck query (e.g. lock contention) from blocking indefinitely.
+      // Leave unset to keep Postgres' default of no timeout.
+      DATABASE_STATEMENT_TIMEOUT: z.coerce.number().optional(),
       DATABASE_TEST_URL: z.string().optional(),
       DATABASE_URL: z.string().optional(),
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ⚡️ perf

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Long-running queries (an `insert` observed stuck for **700s** under lock contention) could block indefinitely, because Postgres' `statement_timeout` defaults to `0` (no limit) and neither the `node` (`pg`) nor the `neon` (`@neondatabase/serverless`) pool configured any timeout.

This adds an optional `DATABASE_STATEMENT_TIMEOUT` env (in **milliseconds**, **no default** — unset keeps the previous behavior), applied to **both** `NodePool` and `NeonPool`:

- `statement_timeout` — Postgres aborts any single statement exceeding the limit on the **server side**, actually freeing the backend (not just a client-side reject).
- `idle_in_transaction_session_timeout` — kills a transaction left idle past the limit, so a stuck transaction can't keep holding row locks.

Both drivers natively support these keys in their pool config (verified against their type defs / `pg` client implementation). When the env is unset, the timeout keys are omitted entirely, preserving Postgres defaults.

`.env.example` documents the new variable (suggested `300000` = 300s).

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Set `DATABASE_STATEMENT_TIMEOUT=5000`, run a query that exceeds 5s (e.g. `SELECT pg_sleep(10)`), and confirm Postgres aborts it with `canceling statement due to statement timeout`. With the env unset, behavior is unchanged.

#### 📝 Additional Information

`statement_timeout` is server-side termination (the robust knob for "kill blocking queries"); a client-side `query_timeout` was intentionally **not** added, since it only rejects the JS promise while the statement can keep running on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)