### PR TITLE
♻️ refactor(message): prefer dedicated usage column over metadata.usage

### DIFF
--- a/packages/context-engine/src/tokenAccounting/__tests__/index.test.ts
+++ b/packages/context-engine/src/tokenAccounting/__tests__/index.test.ts
@@ -87,6 +87,22 @@ describe('countContextTokens', () => {
       expect(r.messages[0].bySource.content).toBe(5000);
     });
 
+    it('prefers top-level usage.totalOutputTokens over metadata.usage', () => {
+      const r = countContextTokens({
+        messages: [
+          mkMsg({
+            role: 'assistant',
+            content: 'short text',
+            // dedicated field must win over the legacy metadata.usage
+            usage: { totalOutputTokens: 7000 } as any,
+            metadata: { usage: { totalOutputTokens: 5000 } as any } as any,
+          }),
+        ],
+      });
+      expect(r.bySource.content).toBe(7000);
+      expect(r.messages[0].bySource.content).toBe(7000);
+    });
+
     it('falls back to estimating content when usage is missing or zero', () => {
       const r = countContextTokens({
         messages: [

--- a/packages/context-engine/src/tokenAccounting/index.ts
+++ b/packages/context-engine/src/tokenAccounting/index.ts
@@ -105,9 +105,12 @@ export const countContextTokens = ({
     const bySource: Partial<Record<TokenSourceType, number>> = {};
 
     // Assistant fast-path: recorded usage covers content + tool_calls + reasoning
-    // produced by THIS turn's generation. Use it directly when available.
+    // produced by THIS turn's generation. Use it directly when available. Prefer
+    // the dedicated `usage` field, falling back to legacy `metadata.usage`.
     const recordedOutputTokens =
-      msg.role === 'assistant' ? msg.metadata?.usage?.totalOutputTokens : undefined;
+      msg.role === 'assistant'
+        ? (msg.usage?.totalOutputTokens ?? msg.metadata?.usage?.totalOutputTokens)
+        : undefined;
 
     if (recordedOutputTokens && recordedOutputTokens > 0) {
       bumpSource(bySource, 'content', recordedOutputTokens);

--- a/packages/database/src/models/__tests__/messages/message.create.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.create.test.ts
@@ -94,6 +94,33 @@ describe('MessageModel Create Tests', () => {
       expect(result.userId).toBe(userId);
     });
 
+    it('promotes metadata.usage into the dedicated usage column on create', async () => {
+      const usage = { cost: 0.004, totalInputTokens: 70, totalOutputTokens: 30, totalTokens: 100 };
+      const result = await messageModel.create({
+        content: 'answer',
+        metadata: { usage } as any,
+        role: 'assistant',
+        sessionId: '1',
+      });
+
+      expect(result.usage).toEqual(usage);
+      // metadata.usage stays written for backward-compatible reads
+      expect((result.metadata as any).usage).toEqual(usage);
+    });
+
+    it('prefers a top-level usage over metadata.usage on create', async () => {
+      const topLevel = { cost: 0.01, totalTokens: 200 };
+      const result = await messageModel.create({
+        content: 'answer',
+        metadata: { usage: { cost: 0.004, totalTokens: 100 } } as any,
+        role: 'assistant',
+        sessionId: '1',
+        usage: topLevel as any,
+      });
+
+      expect(result.usage).toEqual(topLevel);
+    });
+
     it('should generate message ID automatically', async () => {
       // Call createMessage method
       await messageModel.create({

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -96,6 +96,35 @@ describe('MessageModel Query Tests', () => {
       expect(result[1].id).toBe('2');
     });
 
+    it('reads usage from the dedicated column and falls back to metadata.usage', async () => {
+      await serverDB.insert(messages).values([
+        // dedicated column must win over the legacy metadata.usage
+        {
+          id: 'usage-col',
+          userId,
+          role: 'assistant',
+          content: 'a',
+          createdAt: new Date('2023-01-01'),
+          usage: { totalTokens: 100 } as any,
+          metadata: { usage: { totalTokens: 999 } },
+        },
+        // legacy row: only metadata.usage → falls back
+        {
+          id: 'usage-meta',
+          userId,
+          role: 'assistant',
+          content: 'b',
+          createdAt: new Date('2023-01-02'),
+          metadata: { usage: { totalTokens: 50 } },
+        },
+      ]);
+
+      const result = await messageModel.query();
+
+      expect(result.find((m) => m.id === 'usage-col')?.usage).toEqual({ totalTokens: 100 });
+      expect(result.find((m) => m.id === 'usage-meta')?.usage).toEqual({ totalTokens: 50 });
+    });
+
     it('should return empty messages if not match the user ID', async () => {
       // Create test data
       await serverDB.insert(messages).values([

--- a/packages/database/src/models/__tests__/messages/message.stats.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.stats.test.ts
@@ -589,6 +589,41 @@ describe('MessageModel Statistics Tests', () => {
       vi.useRealTimers();
     });
 
+    it('prefers the usage column and falls back to metadata.usage', async () => {
+      vi.useFakeTimers();
+      const fixedDate = new Date('2023-04-07T13:00:00Z');
+      vi.setSystemTime(fixedDate);
+
+      const today = dayjs(fixedDate);
+      const dayKey = today.subtract(2, 'day').format('YYYY-MM-DD');
+
+      await serverDB.insert(messages).values([
+        // dedicated column wins over metadata.usage → contributes 100, not 9999
+        {
+          id: 'h1',
+          userId,
+          role: 'assistant',
+          usage: { totalTokens: 100 } as any,
+          metadata: { usage: { totalTokens: 9999 } },
+          createdAt: today.subtract(2, 'day').toDate(),
+        },
+        // legacy row: only metadata.usage → falls back, contributes 50
+        {
+          id: 'h2',
+          userId,
+          role: 'assistant',
+          metadata: { usage: { totalTokens: 50 } },
+          createdAt: today.subtract(2, 'day').toDate(),
+        },
+      ]);
+
+      const result = await messageModel.getTokenHeatmaps();
+      const day = result.find((item) => item.date === dayKey);
+      expect(day?.count).toBe(150);
+
+      vi.useRealTimers();
+    });
+
     it('should return all-zero data when there are no messages', async () => {
       const result = await messageModel.getTokenHeatmaps();
 

--- a/packages/database/src/models/__tests__/messages/message.update.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.update.test.ts
@@ -1497,4 +1497,50 @@ describe('MessageModel Update Tests', () => {
       expect(topic.totalCost).toBeCloseTo(0.01, 6);
     });
   });
+
+  describe('usage column promotion', () => {
+    it('promotes metadata.usage into the dedicated usage column', async () => {
+      await serverDB.insert(messages).values({
+        id: 'promote-msg',
+        role: 'assistant',
+        userId,
+      });
+
+      const usage = { cost: 0.004, totalInputTokens: 70, totalOutputTokens: 30, totalTokens: 100 };
+      await messageModel.update('promote-msg', { metadata: { usage } as any });
+
+      const [row] = await serverDB.select().from(messages).where(eq(messages.id, 'promote-msg'));
+      expect(row.usage).toEqual(usage);
+      // metadata.usage stays written for backward-compatible reads
+      expect((row.metadata as any).usage).toEqual(usage);
+    });
+
+    it('prefers a top-level usage over metadata.usage', async () => {
+      await serverDB.insert(messages).values({
+        id: 'prefer-msg',
+        role: 'assistant',
+        userId,
+      });
+
+      const topLevel = { cost: 0.01, totalTokens: 200 };
+      await messageModel.update('prefer-msg', {
+        metadata: { usage: { cost: 0.004, totalTokens: 100 } } as any,
+        usage: topLevel as any,
+      });
+
+      const [row] = await serverDB.select().from(messages).where(eq(messages.id, 'prefer-msg'));
+      expect(row.usage).toEqual(topLevel);
+    });
+
+    it('updateMetadata syncs usage into the usage column', async () => {
+      await serverDB.insert(messages).values({ id: 'meta-msg', role: 'assistant', userId });
+
+      const usage = { cost: 0.002, totalTokens: 60 };
+      await messageModel.updateMetadata('meta-msg', { usage });
+
+      const [row] = await serverDB.select().from(messages).where(eq(messages.id, 'meta-msg'));
+      expect(row.usage).toEqual(usage);
+      expect((row.metadata as any).usage).toEqual(usage);
+    });
+  });
 });

--- a/packages/database/src/models/__tests__/messages/message.update.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.update.test.ts
@@ -1530,6 +1530,27 @@ describe('MessageModel Update Tests', () => {
 
       const [row] = await serverDB.select().from(messages).where(eq(messages.id, 'prefer-msg'));
       expect(row.usage).toEqual(topLevel);
+      // metadata.usage is kept consistent with the column
+      expect((row.metadata as any).usage).toEqual(topLevel);
+    });
+
+    it('dual-writes metadata.usage when usage arrives as a top-level param only', async () => {
+      await serverDB.insert(messages).values({
+        id: 'top-only-msg',
+        metadata: { tps: 1 }, // pre-existing non-usage metadata must be preserved
+        role: 'assistant',
+        userId,
+      });
+
+      const usage = { cost: 0.006, totalTokens: 150 };
+      // no metadata payload — only the top-level usage
+      await messageModel.update('top-only-msg', { usage: usage as any });
+
+      const [row] = await serverDB.select().from(messages).where(eq(messages.id, 'top-only-msg'));
+      expect(row.usage).toEqual(usage);
+      // legacy readers / rollback paths still see metadata.usage
+      expect((row.metadata as any).usage).toEqual(usage);
+      expect((row.metadata as any).tps).toBe(1);
     });
 
     it('updateMetadata syncs usage into the usage column', async () => {

--- a/packages/database/src/models/__tests__/topics/topicUsage.test.ts
+++ b/packages/database/src/models/__tests__/topics/topicUsage.test.ts
@@ -196,6 +196,47 @@ describe('recomputeTopicUsage', () => {
     expect(claude.usage.totalTokens).toBe(300);
   });
 
+  it('prefers the dedicated usage column over metadata.usage', async () => {
+    await serverDB.insert(messages).values({
+      id: 'col-msg',
+      metadata: {
+        usage: { cost: 9.9, totalInputTokens: 999, totalOutputTokens: 999, totalTokens: 9999 },
+      },
+      model: 'gpt-4o',
+      provider: 'openai',
+      role: 'assistant',
+      topicId,
+      usage: { cost: 0.01, totalInputTokens: 10, totalOutputTokens: 5, totalTokens: 15 } as any,
+      userId,
+    });
+
+    await recompute();
+    const topic = await getTopic();
+
+    expect(topic.totalTokens).toBe(15);
+    expect(topic.totalCost).toBeCloseTo(0.01, 6);
+  });
+
+  it('counts rows that only carry the usage column (no metadata.usage)', async () => {
+    await serverDB.insert(messages).values({
+      id: 'col-only',
+      metadata: { tps: 1 }, // realistic non-usage metadata
+      model: 'gpt-4o',
+      provider: 'openai',
+      role: 'assistant',
+      topicId,
+      usage: { cost: 0.02, totalInputTokens: 30, totalOutputTokens: 20, totalTokens: 50 } as any,
+      userId,
+    });
+
+    await recompute();
+    const topic = await getTopic();
+
+    expect(topic.totalTokens).toBe(50);
+    expect(topic.totalCost).toBeCloseTo(0.02, 6);
+    expect((topic.usage as any).llm.apiCalls).toBe(1);
+  });
+
   it('only counts role=assistant messages with metadata.usage', async () => {
     // counted
     await insertAssistantMessage({

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -1976,6 +1976,14 @@ export class MessageModel {
     // (Gateway / hetero-agent executors) keep populating the column without
     // changes. `metadata.usage` is still written for backward-compatible reads.
     const usageToWrite = usage ?? (metadata as { usage?: ModelUsage } | undefined)?.usage;
+    // Keep `metadata.usage` dual-written even when usage arrives as a top-level
+    // param (with no metadata payload) — legacy readers / rollback paths still
+    // consume it during the transition. Folding the resolved usage into the
+    // patch also keeps it consistent with the column when both are sent.
+    const metadataPatch =
+      metadata || usageToWrite
+        ? { ...metadata, ...(usageToWrite && { usage: usageToWrite }) }
+        : undefined;
     try {
       await runTimedStage(
         timing,
@@ -1999,9 +2007,10 @@ export class MessageModel {
               );
             }
 
-            // 2. Handle metadata merge if provided
+            // 2. Handle metadata merge if there's a metadata payload or a
+            // top-level usage to fold back into `metadata.usage`.
             let mergedMetadata: Record<string, any> | undefined;
-            if (metadata) {
+            if (metadataPatch) {
               const [existingMessage] = await runTimedStage(
                 timing,
                 'db.message.update.metadata.select',
@@ -2011,7 +2020,7 @@ export class MessageModel {
                     .from(messages)
                     .where(and(eq(messages.id, id), eq(messages.userId, this.userId))),
               );
-              mergedMetadata = merge(existingMessage?.metadata || {}, metadata);
+              mergedMetadata = merge(existingMessage?.metadata || {}, metadataPatch);
             }
 
             const [updated] = await runTimedStage(
@@ -2027,7 +2036,7 @@ export class MessageModel {
                   })
                   .where(and(eq(messages.id, id), eq(messages.userId, this.userId)))
                   .returning({ topicId: messages.topicId }),
-              { hasMetadata: !!metadata, valueKeys: Object.keys(message) },
+              { hasMetadata: !!metadataPatch, valueKeys: Object.keys(message) },
             );
 
             // Touch topic's updatedAt when updating a message
@@ -2055,7 +2064,7 @@ export class MessageModel {
           }),
         {
           hasImageList: !!imageList?.length,
-          hasMetadata: !!metadata,
+          hasMetadata: !!metadataPatch,
           valueKeys: Object.keys(message),
         },
       );

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -12,6 +12,7 @@ import type {
   IThreadType,
   MessagePluginItem,
   ModelRankItem,
+  ModelUsage,
   NewMessageQueryParams,
   QueryMessageParams,
   TaskDetail,
@@ -367,6 +368,7 @@ export class MessageModel {
             reasoning: messages.reasoning,
             search: messages.search,
             metadata: messages.metadata,
+            usage: messages.usage,
             error: messages.error,
 
             model: messages.model,
@@ -530,6 +532,9 @@ export class MessageModel {
               ragRawQuery: messageQuery?.userQuery,
               // Add taskDetail for task messages
               taskDetail: item.role === 'task' ? threadMap.get(item.id as string) : undefined,
+              // Prefer the dedicated `usage` column, falling back to legacy
+              // `metadata.usage` for rows written before the migration.
+              usage: item.usage ?? (item.metadata as { usage?: ModelUsage } | null)?.usage,
               videoList: videoList
                 .filter((relation) => relation.messageId === item.id)
 
@@ -840,6 +845,7 @@ export class MessageModel {
         reasoning: messages.reasoning,
         search: messages.search,
         metadata: messages.metadata,
+        usage: messages.usage,
         error: messages.error,
 
         model: messages.model,
@@ -1068,6 +1074,9 @@ export class MessageModel {
           ragRawQuery: messageQuery?.userQuery,
           // Add taskDetail for task messages
           taskDetail: item.role === 'task' ? threadMap.get(item.id as string) : undefined,
+          // Prefer the dedicated `usage` column, falling back to legacy
+          // `metadata.usage` for rows written before the migration.
+          usage: item.usage ?? (item.metadata as { usage?: ModelUsage } | null)?.usage,
           videoList: videoList
             .filter((relation) => relation.messageId === item.id)
             .map<ChatVideoItem>(({ id, url, name }) => ({ alt: name!, id, url })),
@@ -1558,13 +1567,13 @@ export class MessageModel {
   /**
    * Daily token-usage heatmap for the last year.
    *
-   * Sums `metadata.usage.totalTokens` of assistant messages bucketed by the day
-   * each message was created — so tokens land on the day they were actually
-   * consumed (a long-running topic spreads across days instead of piling onto
-   * its creation date). `metadata.usage` is the source of truth for usage, so we
-   * aggregate it directly in SQL rather than pulling rows into JS. `level` is
-   * scaled relative to the busiest day so the heatmap stays readable regardless
-   * of absolute token volume.
+   * Sums `usage.totalTokens` of assistant messages bucketed by the day each
+   * message was created — so tokens land on the day they were actually consumed
+   * (a long-running topic spreads across days instead of piling onto its
+   * creation date). Reads prefer the dedicated `usage` column and fall back to
+   * legacy `metadata.usage`, aggregating directly in SQL rather than pulling
+   * rows into JS. `level` is scaled relative to the busiest day so the heatmap
+   * stays readable regardless of absolute token volume.
    */
   getTokenHeatmaps = async (): Promise<HeatmapsProps['data']> => {
     const startDate = today().subtract(1, 'year').startOf('day');
@@ -1574,7 +1583,7 @@ export class MessageModel {
       .select({
         date: sql`DATE(${messages.createdAt})`.as('heatmaps_date'),
         tokens:
-          sql<number>`COALESCE(SUM((${messages.metadata}->'usage'->>'totalTokens')::numeric), 0)`.mapWith(
+          sql<number>`COALESCE(SUM((COALESCE(${messages.usage}, ${messages.metadata}->'usage')->>'totalTokens')::numeric), 0)`.mapWith(
             Number,
           ),
       })
@@ -1701,6 +1710,11 @@ export class MessageModel {
       model: fromModel,
       provider: fromProvider,
       updatedAt: updatedAt ? new Date(updatedAt) : undefined,
+      // Promote token usage into the dedicated `usage` column, preferring a
+      // top-level `usage` over the legacy `metadata.usage`.
+      usage:
+        normalizedMessage.usage ??
+        (normalizedMessage.metadata as { usage?: ModelUsage } | undefined)?.usage,
       userId: this.userId,
     };
   };
@@ -1954,9 +1968,14 @@ export class MessageModel {
 
   update = async (
     id: string,
-    { imageList, metadata, ...message }: Partial<UpdateMessageParams>,
+    { imageList, metadata, usage, ...message }: Partial<UpdateMessageParams>,
     timing?: ModelTimingContext,
   ): Promise<{ success: boolean }> => {
+    // Promote token usage into the dedicated `usage` column. Prefer a top-level
+    // `usage` payload, falling back to `metadata.usage` so existing writers
+    // (Gateway / hetero-agent executors) keep populating the column without
+    // changes. `metadata.usage` is still written for backward-compatible reads.
+    const usageToWrite = usage ?? (metadata as { usage?: ModelUsage } | undefined)?.usage;
     try {
       await runTimedStage(
         timing,
@@ -2001,7 +2020,11 @@ export class MessageModel {
               () =>
                 trx
                   .update(messages)
-                  .set({ ...message, ...(mergedMetadata && { metadata: mergedMetadata }) })
+                  .set({
+                    ...message,
+                    ...(mergedMetadata && { metadata: mergedMetadata }),
+                    ...(usageToWrite && { usage: usageToWrite }),
+                  })
                   .where(and(eq(messages.id, id), eq(messages.userId, this.userId)))
                   .returning({ topicId: messages.topicId }),
               { hasMetadata: !!metadata, valueKeys: Object.keys(message) },
@@ -2020,7 +2043,7 @@ export class MessageModel {
               // step), recompute the topic's denormalized usage rollup from its
               // messages. Gated on the *incoming* payload so streaming
               // content-only updates don't trigger needless recomputes.
-              if ((metadata as { usage?: unknown } | undefined)?.usage) {
+              if (usageToWrite) {
                 await runTimedStage(
                   timing,
                   'db.message.update.topic.recomputeUsage',
@@ -2051,9 +2074,14 @@ export class MessageModel {
 
     if (!item) return;
 
+    const mergedMetadata = merge(item.metadata || {}, metadata);
+    // Keep the dedicated `usage` column in sync when the merged metadata carries
+    // token usage, preferring it over the existing column value.
+    const usageToWrite = (metadata as { usage?: ModelUsage } | undefined)?.usage;
+
     return this.db
       .update(messages)
-      .set({ metadata: merge(item.metadata || {}, metadata) })
+      .set({ metadata: mergedMetadata, ...(usageToWrite && { usage: usageToWrite }) })
       .where(and(eq(messages.userId, this.userId), eq(messages.id, id)));
   };
 

--- a/packages/database/src/models/topicUsage.ts
+++ b/packages/database/src/models/topicUsage.ts
@@ -39,8 +39,9 @@ const num = (v: unknown): number => (v == null ? 0 : Number(v));
  * Recompute a topic's denormalized usage/cost rollup from its assistant messages.
  *
  * Pure derived projection: SUM over the topic's `role='assistant'` messages
- * (thread messages count too — they also carry `topic_id`), reading the
- * canonical `metadata.usage`. The stored shape mirrors `agent_operations`:
+ * (thread messages count too — they also carry `topic_id`), preferring the
+ * dedicated `usage` column and falling back to legacy `metadata.usage`. The
+ * stored shape mirrors `agent_operations`:
  *   - scalar columns : total_input_tokens / total_output_tokens / total_tokens / total_cost
  *   - `usage` jsonb  : flat aggregate { llm: { apiCalls, processingTimeMs, tokens }, tools, humanInteraction }
  *   - `cost`  jsonb  : { total, currency, llm: { total, currency, byModel[] }, tools } — or NULL when no model reported cost
@@ -60,8 +61,10 @@ export const recomputeTopicUsage = async (
   userId: string,
   topicId: string,
 ): Promise<void> => {
+  // Reads prefer the dedicated `usage` column, falling back to legacy
+  // `metadata->'usage'` for rows written before the migration.
   const fieldSelects = USAGE_FIELDS.map(
-    (f) => `sum((metadata->'usage'->>'${f}')::numeric) AS "${f}"`,
+    (f) => `sum((COALESCE(usage, metadata->'usage')->>'${f}')::numeric) AS "${f}"`,
   ).join(',\n      ');
 
   const { rows } = await trx.execute(sql`
@@ -69,14 +72,14 @@ export const recomputeTopicUsage = async (
       provider,
       model,
       count(*)::int AS "msgCount",
-      sum((metadata->'usage'->>'cost')::numeric) AS "cost",
+      sum((COALESCE(usage, metadata->'usage')->>'cost')::numeric) AS "cost",
       sum((metadata->'performance'->>'duration')::numeric) AS "durationMs",
       ${sql.raw(fieldSelects)}
     FROM messages
     WHERE topic_id = ${topicId}
       AND user_id = ${userId}
       AND role = 'assistant'
-      AND metadata ? 'usage'
+      AND (usage IS NOT NULL OR metadata ? 'usage')
     GROUP BY provider, model
   `);
 

--- a/packages/types/src/message/common/metadata.ts
+++ b/packages/types/src/message/common/metadata.ts
@@ -185,6 +185,8 @@ export const MessageMetadataSchema = ModelUsageSchema.merge(ModelPerformanceSche
   subAgentId: z.string().optional(),
   toolExecutionTimeMs: z.number().optional(),
   trigger: z.nativeEnum(RequestTrigger).optional(),
+  // @deprecated token usage moved to the top-level `usage` column. Still listed
+  // so zod doesn't strip `metadata.usage` from legacy writes during migration.
   usage: ModelUsageSchema.optional(),
 });
 
@@ -217,11 +219,12 @@ export interface ModelPerformance {
 export interface MessageMetadata {
   // ───────────────────────────────────────────────────────────────
   // Token usage + performance fields — DEPRECATED flat shape.
-  // New code must write to `metadata.usage` / `metadata.performance` (nested)
-  // instead. Kept here so legacy reads still type-check during migration;
-  // writers should stop populating them.
+  // Token usage now lives in the dedicated top-level `usage` column
+  // (`UIChatMessage.usage`); performance still lives in `metadata.performance`.
+  // These flat fields (and the nested `metadata.usage` below) are kept so legacy
+  // reads still type-check during migration; writers should stop populating them.
   // ───────────────────────────────────────────────────────────────
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   acceptedPredictionTokens?: number;
   activeBranchIndex?: number;
   activeColumn?: boolean;
@@ -231,36 +234,36 @@ export interface MessageMetadata {
    */
   collapsed?: boolean;
   compare?: boolean;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   cost?: number;
   /** @deprecated use `metadata.performance` instead */
   duration?: number;
   finishType?: string;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   inputAudioTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   inputCachedAudioTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   inputCachedImageTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   inputCachedTextTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   inputCachedTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   inputCachedVideoTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   inputCacheMissTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   inputCitationTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   inputImageTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   inputTextTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   inputToolTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   inputVideoTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   inputWriteCacheTokens?: number;
   /**
    * Tool inspect expanded state
@@ -289,13 +292,13 @@ export interface MessageMetadata {
    * Local-system tool snapshots materialized when the user sent @file mentions.
    */
   localSystemToolSnapshots?: LocalSystemToolSnapshot[];
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   outputAudioTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   outputImageTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   outputReasoningTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   outputTextTokens?: number;
   /**
    * Page selections attached to user message
@@ -311,7 +314,7 @@ export interface MessageMetadata {
    * Emoji reactions on this message
    */
   reactions?: EmojiReaction[];
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   rejectedPredictionTokens?: number;
   /**
    * Message scope - indicates the context in which this message was created
@@ -351,11 +354,11 @@ export interface MessageMetadata {
    * Tool execution time for tool messages (ms)
    */
   toolExecutionTimeMs?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   totalInputTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   totalOutputTokens?: number;
-  /** @deprecated use `metadata.usage` instead */
+  /** @deprecated use the top-level message `usage` field instead */
   totalTokens?: number;
   /** @deprecated use `metadata.performance` instead */
   tps?: number;
@@ -365,6 +368,11 @@ export interface MessageMetadata {
   trigger?: RequestTrigger;
   /** @deprecated use `metadata.performance` instead */
   ttft?: number;
+  /**
+   * @deprecated Token usage has been promoted to the dedicated top-level `usage`
+   * column / `UIChatMessage.usage` field. Reads fall back here for legacy rows,
+   * but new writers should target the top-level `usage` instead.
+   */
   usage?: ModelUsage;
 }
 

--- a/packages/types/src/message/db/item.ts
+++ b/packages/types/src/message/db/item.ts
@@ -1,5 +1,5 @@
 import type { GroundingSearch } from '../../search';
-import type { MessageMetadata, ModelReasoning, ToolIntervention } from '../common';
+import type { MessageMetadata, ModelReasoning, ModelUsage, ToolIntervention } from '../common';
 
 export interface DBMessageItem {
   agentId: string | null;
@@ -30,6 +30,11 @@ export interface DBMessageItem {
 
   traceId: string | null;
   updatedAt: Date;
+  /**
+   * Token usage + cost, promoted out of `metadata.usage` into a dedicated
+   * column. Reads prefer this, falling back to `metadata.usage` for legacy rows.
+   */
+  usage?: ModelUsage | null;
   userId: string;
 }
 

--- a/packages/types/src/message/db/params.ts
+++ b/packages/types/src/message/db/params.ts
@@ -9,6 +9,7 @@ import type {
   MessageMetadata,
   MessageToolCall,
   ModelReasoning,
+  ModelUsage,
 } from '../common';
 import {
   ChatImageItemSchema,
@@ -17,6 +18,7 @@ import {
   MessageMetadataSchema,
   MessageToolCallSchema,
   ModelReasoningSchema,
+  ModelUsageSchema,
 } from '../common';
 import type { UIChatMessage } from '../ui';
 
@@ -104,6 +106,12 @@ export interface UpdateMessageParams {
   toolCalls?: MessageToolCall[];
   tools?: ChatToolPayload[] | null;
   traceId?: string;
+  /**
+   * Token usage + cost, promoted out of `metadata.usage` into the dedicated
+   * `usage` column. Writers may pass it top-level; the model also falls back to
+   * `metadata.usage` so existing callers keep populating the column.
+   */
+  usage?: ModelUsage;
 }
 
 export interface NewMessageQueryParams {
@@ -131,5 +139,6 @@ export const UpdateMessageParamsSchema = z
     toolCalls: z.array(MessageToolCallSchema).optional(),
     tools: z.array(ChatToolPayloadSchema).nullable().optional(),
     traceId: z.string().optional(),
+    usage: ModelUsageSchema.optional(),
   })
   .passthrough();

--- a/src/server/services/usage/index.test.ts
+++ b/src/server/services/usage/index.test.ts
@@ -98,6 +98,35 @@ describe('UsageRecordService', () => {
       expect(result[0].spend).toBe(0.03);
     });
 
+    it('prefers the top-level usage column over metadata.usage', async () => {
+      const mockMessages = [
+        {
+          id: 'msg-1',
+          userId,
+          role: 'assistant',
+          provider: 'openai',
+          model: 'gpt-4',
+          createdAt: new Date(),
+          // dedicated column must win over the legacy metadata.usage
+          usage: { cost: 0.05, totalInputTokens: 100, totalOutputTokens: 50 },
+          metadata: {
+            usage: { cost: 9.9, totalInputTokens: 999, totalOutputTokens: 999 },
+          } as MessageMetadata,
+        },
+      ];
+
+      setupQueryChainMock(mockMessages);
+
+      const result = await service.findByMonth();
+
+      expect(result[0]).toMatchObject({
+        spend: 0.05,
+        totalInputTokens: 100,
+        totalOutputTokens: 50,
+        totalTokens: 150,
+      });
+    });
+
     it('should handle messages with missing metadata fields', async () => {
       const mockMessages = [
         {

--- a/src/server/services/usage/index.ts
+++ b/src/server/services/usage/index.ts
@@ -32,6 +32,7 @@ export class UsageRecordService {
         provider: messages.provider,
         role: messages.role,
         updatedAt: messages.createdAt,
+        usage: messages.usage,
         userId: messages.userId,
       })
       .from(messages)
@@ -45,9 +46,10 @@ export class UsageRecordService {
       .orderBy(desc(messages.createdAt));
     return spends.map((spend) => {
       const metadata = spend.metadata as MessageMetadata;
-      // Prefer the canonical nested `usage` / `performance` shapes, falling back
-      // to the deprecated flat fields for messages written before the migration.
-      const usage = metadata?.usage;
+      // Prefer the dedicated `usage` column, then the canonical nested
+      // `metadata.usage` / `metadata.performance` shapes, falling back to the
+      // deprecated flat fields for messages written before the migration.
+      const usage = spend.usage ?? metadata?.usage;
       const performance = metadata?.performance;
       const totalInputTokens = usage?.totalInputTokens ?? metadata?.totalInputTokens ?? 0;
       const totalOutputTokens = usage?.totalOutputTokens ?? metadata?.totalOutputTokens ?? 0;


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor
- [x] ✅ test

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Token usage was previously promoted out of `metadata.usage` into a dedicated `messages.usage` jsonb column — but nothing populated that column, and every read still went through `metadata.usage`. This PR wires up the dual-write / preferred-read so the column becomes the source of truth while staying backward-compatible.

**Write side** — centralized in the DB model so all executor callers (Gateway, hetero-agent, client) are covered without touching them:
- `update()` / `updateMetadata()` / `buildMessageInsertValue()` promote token usage into the `usage` column, preferring a top-level `usage` payload and falling back to `metadata.usage`.
- `metadata.usage` stays **dual-written** during the transition for backward-compatible reads.
- The topic-usage rollup recompute now gates on the resolved usage value.

**Read side** — prefer the `usage` column, fall back to `metadata.usage` for legacy rows:
- `queryByIds` / `queryWithWhere` select the column and expose it as `UIChatMessage.usage`.
- `getTokenHeatmaps` and `recomputeTopicUsage` use `COALESCE(usage, metadata->'usage')` in SQL.
- `UsageRecordService.findByDateRange` and context-engine `tokenAccounting` prefer the top-level usage.

**Types**:
- Add top-level `usage` to `UpdateMessageParams` and `DBMessageItem`.
- Mark `metadata.usage` and the legacy flat token fields (`totalTokens`, `cost`, `inputXxxTokens`, …) as `@deprecated`, pointing to the top-level `usage` field. Performance fields are untouched.

Note: `metadata.usage` is intentionally still written and still listed in the zod schema, so it's not yet removable — a follow-up can do the full cut-over (stop writing `metadata.usage`, drop the read fallbacks, backfill legacy rows).

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added/extended tests asserting the column wins over `metadata.usage` (and legacy rows fall back) across: message create / query / update / stats(heatmap), topic usage rollup, usage record service, and token accounting. Full repo `type-check` passes; all touched suites green.

#### 📸 Screenshots / Videos

No UI changes.

#### 📝 Additional Information

Backward-compatible and additive — no migration required (the `usage` column already exists on trunk). Dual-write means rollback-safe.