### PR TITLE
♻️ refactor(tool-runtime): anchor param schema on local-file-shell/manifest A shape

### DIFF
--- a/apps/cli/src/tools/localSystemRuntime.ts
+++ b/apps/cli/src/tools/localSystemRuntime.ts
@@ -49,8 +49,8 @@ const unsupported = (method: string) => (): Promise<never> =>
 /**
  * Adapter wiring the CLI's `@lobechat/local-file-shell` functions (file ops) and
  * shell wrappers (with the shared `ShellProcessManager`) into the shape the
- * runtime expects. The runtime denormalizes its camelCase params back to the
- * snake_case IPC shapes these functions consume — see `LocalSystemExecutionRuntime`.
+ * runtime expects. The runtime forwards its canonical A-shape params straight to
+ * these functions with zero conversion — see `LocalSystemExecutionRuntime`.
  */
 const localSystemService: ILocalSystemService = {
   editLocalFile,
@@ -112,24 +112,16 @@ export async function runLocalSystemTool(
 ): Promise<LocalSystemToolOutput | null> {
   const normalized = LEGACY_API_ALIASES[apiName] ?? apiName;
 
+  // The runtime now consumes the canonical A shape (same as the wire/manifest
+  // and `@lobechat/local-file-shell`), so every case forwards `args` straight
+  // through — only scope resolution (search/grep) is applied first.
   switch (normalized) {
     case 'listFiles': {
-      const p = args as ListFilesParams;
-      return runtime.listFiles({
-        directoryPath: p.path,
-        limit: p.limit,
-        sortBy: p.sortBy,
-        sortOrder: p.sortOrder,
-      } as never);
+      return runtime.listFiles(args as ListFilesParams);
     }
 
     case 'readFile': {
-      const p = args as ReadFileParams;
-      return runtime.readFile({
-        endLine: p.loc?.[1],
-        path: p.path,
-        startLine: p.loc?.[0],
-      });
+      return runtime.readFile(args as ReadFileParams);
     }
 
     case 'writeFile': {
@@ -137,13 +129,7 @@ export async function runLocalSystemTool(
     }
 
     case 'editFile': {
-      const p = args as EditFileParams;
-      return runtime.editFile({
-        all: p.replace_all,
-        path: p.file_path,
-        replace: p.new_string,
-        search: p.old_string,
-      });
+      return runtime.editFile(args as EditFileParams);
     }
 
     case 'searchFiles': {
@@ -160,34 +146,21 @@ export async function runLocalSystemTool(
     }
 
     case 'globFiles': {
-      const p = args as GlobFilesParams;
-      // Honor both `scope` (current manifest) and the `cwd` legacy alias.
-      return runtime.globFiles({ directory: p.scope ?? p.cwd, pattern: p.pattern });
+      return runtime.globFiles(args as GlobFilesParams);
     }
 
     case 'runCommand': {
-      // ComputerRuntime's RunCommandState reads `args.background`; the manifest
-      // exposes `run_in_background`. Without this normalize the state would
-      // always show foreground even for background commands.
-      const p = args as RunCommandParams;
-      return runtime.runCommand({ ...p, background: p.run_in_background } as never);
+      return runtime.runCommand(args as RunCommandParams);
     }
 
     case 'getCommandOutput': {
-      // Forward `timeout` (gateway per-call budget, injected into args by
-      // executeToolCall) so polling a running command honors it instead of the
-      // service's default wait. The runtime carries it through to getOutput.
-      const p = args as GetCommandOutputParams;
-      return runtime.getCommandOutput({
-        commandId: p.shell_id,
-        filter: p.filter,
-        timeout: p.timeout,
-      } as never);
+      // `timeout` (gateway per-call budget, injected into args by
+      // executeToolCall) flows through unchanged so polling honors it.
+      return runtime.getCommandOutput(args as GetCommandOutputParams);
     }
 
     case 'killCommand': {
-      const p = args as KillCommandParams;
-      return runtime.killCommand({ commandId: p.shell_id });
+      return runtime.killCommand(args as KillCommandParams);
     }
 
     default: {

--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -331,30 +331,19 @@ export default class GatewayConnectionCtr extends ControllerModule {
     const runtime = this.getLocalSystemRuntime();
     const normalized = LEGACY_API_ALIASES[apiName] ?? apiName;
 
-    // Each case narrows `args` to its IPC param type — the manifest guarantees
-    // the gateway sends params matching the apiName. The `as never` casts on
-    // runtime calls are legitimate widenings: the runtime's typed signatures
-    // (e.g. `ListFilesParams`) are narrower than what the IPC layer accepts
-    // (`limit`, `run_in_background`, etc.), and the same casts exist in the
-    // renderer-side `LocalSystemExecutor`.
+    // The runtime now consumes the canonical A shape (identical to the IPC param
+    // types and `@lobechat/local-file-shell`), so each case forwards `args`
+    // straight through — only scope resolution (search/grep) runs first. The
+    // `as never` casts absorb residual nominal differences between the IPC param
+    // types and the runtime's own copies; the renderer-side `LocalSystemExecutor`
+    // does the same.
     switch (normalized) {
       case 'listFiles': {
-        const p = args as ListLocalFileParams;
-        return runtime.listFiles({
-          directoryPath: p.path,
-          limit: p.limit,
-          sortBy: p.sortBy,
-          sortOrder: p.sortOrder,
-        } as never);
+        return runtime.listFiles(args as ListLocalFileParams as never);
       }
 
       case 'readFile': {
-        const p = args as LocalReadFileParams;
-        return runtime.readFile({
-          endLine: p.loc?.[1],
-          path: p.path,
-          startLine: p.loc?.[0],
-        });
+        return runtime.readFile(args as LocalReadFileParams as never);
       }
 
       case 'readFiles': {
@@ -366,17 +355,11 @@ export default class GatewayConnectionCtr extends ControllerModule {
         return runtime.searchFiles({
           ...resolved,
           directory: resolved.directory || '',
-        });
+        } as never);
       }
 
       case 'moveFiles': {
-        const p = args as MoveLocalFilesParams;
-        return runtime.moveFiles({
-          operations: p.items?.map((item) => ({
-            destination: item.newPath,
-            source: item.oldPath,
-          })),
-        });
+        return runtime.moveFiles(args as MoveLocalFilesParams as never);
       }
 
       case 'writeFile': {
@@ -384,39 +367,19 @@ export default class GatewayConnectionCtr extends ControllerModule {
       }
 
       case 'editFile': {
-        const p = args as EditLocalFileParams;
-        return runtime.editFile({
-          all: p.replace_all,
-          path: p.file_path,
-          replace: p.new_string,
-          search: p.old_string,
-        });
+        return runtime.editFile(args as EditLocalFileParams as never);
       }
 
       case 'runCommand': {
-        // ComputerRuntime's RunCommandState reads `args.background`; the manifest
-        // exposes `run_in_background`. Without this normalize the state would
-        // always show foreground even for background commands.
-        const p = args as RunCommandParams;
-        return runtime.runCommand({
-          ...p,
-          background: p.run_in_background,
-        } as never);
+        return runtime.runCommand(args as RunCommandParams as never);
       }
 
       case 'getCommandOutput': {
-        const p = args as GetCommandOutputParams;
-        return runtime.getCommandOutput({
-          commandId: p.shell_id,
-          filter: p.filter,
-        } as never);
+        return runtime.getCommandOutput(args as GetCommandOutputParams as never);
       }
 
       case 'killCommand': {
-        const p = args as KillCommandParams;
-        return runtime.killCommand({
-          commandId: p.shell_id,
-        });
+        return runtime.killCommand(args as KillCommandParams as never);
       }
 
       case 'grepContent': {
@@ -425,11 +388,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
       }
 
       case 'globFiles': {
-        const p = args as GlobFilesParams;
-        return runtime.globFiles({
-          directory: p.scope,
-          pattern: p.pattern,
-        });
+        return runtime.globFiles(args as GlobFilesParams as never);
       }
 
       case 'renameLocalFile': {
@@ -459,9 +418,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
       }
 
       case 'getAgentProfile': {
-        const result = await this.getAgentProfile(
-          args as { agentId?: string; platform: string },
-        );
+        const result = await this.getAgentProfile(args as { agentId?: string; platform: string });
         return { content: JSON.stringify(result), state: result, success: true };
       }
 

--- a/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
@@ -527,10 +527,10 @@ describe('GatewayConnectionCtr', () => {
     ] as const)('should route %s to %s', async (apiName, methodName, controller) => {
       const client = await connectAndOpen();
 
-      // Each tool's args are domain-shaped (path, file_path, items, etc.).
-      // The runtime denormalizes them before calling the controller, so this
-      // test only asserts that the *right* controller method runs — see the
-      // envelope-shape test below for end-to-end content/state coverage.
+      // Each tool's args are domain-shaped (path, file_path, items, etc.) and
+      // now forwarded straight through to the controller (no camel↔snake
+      // denormalization), so this test only asserts that the *right* controller
+      // method runs — see the envelope-shape test below for content/state.
       client.simulateToolCallRequest(apiName, { test: 'arg' });
       await vi.advanceTimersByTimeAsync(0);
 

--- a/packages/builtin-tool-cloud-sandbox/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-cloud-sandbox/src/ExecutionRuntime/index.ts
@@ -1,3 +1,4 @@
+import { formatExecuteCodeResult } from '@lobechat/prompts/fileSystem';
 import { ComputerRuntime } from '@lobechat/tool-runtime';
 import type { BuiltinServerRuntimeOutput } from '@lobechat/types';
 
@@ -9,6 +10,175 @@ import type {
   ISandboxService,
   SandboxCallToolResult,
 } from '../types';
+
+/**
+ * The shared `ComputerRuntime` base now speaks the canonical **A** shape
+ * (snake_case + `loc` tuple), aligned with the local-system tool args. The cloud
+ * sandbox keeps its own legacy **B** manifest/UI (backward compatible) and the
+ * remote sandbox SDK also speaks B — so this runtime is the single boundary that
+ * bridges the two: it normalizes **B→A on entry** (so the A-base builds correct
+ * `content`/`state`) and converts **A→B at `callService`** for the remote SDK.
+ * All conversion stays on the (lower-frequency) cloud path (LOBE-9954); neither
+ * the cloud tool contract nor the local path pays for it.
+ *
+ * The bridge lives here (not in the client executor) because the server runtime
+ * also calls these runtime methods directly.
+ */
+
+/** Normalize the cloud sandbox's legacy **B** params into the canonical **A** shape. */
+const normalizeFromSandbox = (toolName: string, params: Record<string, any>): any => {
+  switch (toolName) {
+    case 'listLocalFiles': {
+      return {
+        limit: params.limit,
+        path: params.directoryPath,
+        sortBy: params.sortBy,
+        sortOrder: params.sortOrder,
+      };
+    }
+
+    case 'readLocalFile': {
+      const loc: [number, number] | undefined =
+        params.startLine !== undefined || params.endLine !== undefined
+          ? [params.startLine ?? 0, params.endLine ?? params.startLine ?? 0]
+          : undefined;
+      return { loc, path: params.path };
+    }
+
+    case 'editLocalFile': {
+      return {
+        file_path: params.path,
+        new_string: params.replace,
+        old_string: params.search,
+        replace_all: params.all,
+      };
+    }
+
+    case 'searchLocalFiles': {
+      return {
+        fileTypes: params.fileType ? [params.fileType] : undefined,
+        keywords: params.keyword,
+        modifiedAfter: params.modifiedAfter,
+        modifiedBefore: params.modifiedBefore,
+        scope: params.directory,
+      };
+    }
+
+    case 'moveLocalFiles': {
+      return {
+        items: params.operations?.map((op: { destination: string; source: string }) => ({
+          newPath: op.destination,
+          oldPath: op.source,
+        })),
+      };
+    }
+
+    case 'runCommand': {
+      return {
+        command: params.command,
+        description: params.description,
+        run_in_background: params.background,
+        timeout: params.timeout,
+      };
+    }
+
+    case 'getCommandOutput': {
+      return { shell_id: params.commandId };
+    }
+
+    case 'killCommand': {
+      return { shell_id: params.commandId };
+    }
+
+    case 'grepContent': {
+      return { glob: params.filePattern, pattern: params.pattern, scope: params.directory };
+    }
+
+    case 'globLocalFiles': {
+      return { pattern: params.pattern, scope: params.directory };
+    }
+
+    default: {
+      return params;
+    }
+  }
+};
+
+/** Convert the canonical **A** params back to the legacy **B** shape the remote sandbox SDK expects. */
+const denormalizeForSandbox = (toolName: string, params: Record<string, any>): any => {
+  switch (toolName) {
+    case 'listLocalFiles': {
+      return {
+        directoryPath: params.path,
+        limit: params.limit,
+        sortBy: params.sortBy,
+        sortOrder: params.sortOrder,
+      };
+    }
+
+    case 'readLocalFile': {
+      return { endLine: params.loc?.[1], path: params.path, startLine: params.loc?.[0] };
+    }
+
+    case 'editLocalFile': {
+      return {
+        all: params.replace_all,
+        path: params.file_path,
+        replace: params.new_string,
+        search: params.old_string,
+      };
+    }
+
+    case 'searchLocalFiles': {
+      return {
+        directory: params.scope,
+        fileType: params.fileTypes?.[0],
+        keyword: params.keywords,
+        modifiedAfter: params.modifiedAfter,
+        modifiedBefore: params.modifiedBefore,
+      };
+    }
+
+    case 'moveLocalFiles': {
+      return {
+        operations: params.items?.map((item: { newPath: string; oldPath: string }) => ({
+          destination: item.newPath,
+          source: item.oldPath,
+        })),
+      };
+    }
+
+    case 'runCommand': {
+      return {
+        background: params.run_in_background,
+        command: params.command,
+        description: params.description,
+        timeout: params.timeout,
+      };
+    }
+
+    case 'getCommandOutput': {
+      return { commandId: params.shell_id };
+    }
+
+    case 'killCommand': {
+      return { commandId: params.shell_id };
+    }
+
+    case 'grepContent': {
+      return { directory: params.scope, filePattern: params.glob, pattern: params.pattern };
+    }
+
+    case 'globLocalFiles': {
+      return { directory: params.scope, pattern: params.pattern };
+    }
+
+    default: {
+      // Cloud-specific tools (executeCode) already pass remote-shaped params.
+      return params;
+    }
+  }
+};
 
 /**
  * Cloud Sandbox Execution Runtime
@@ -28,11 +198,57 @@ export class CloudSandboxExecutionRuntime extends ComputerRuntime {
     this.sandboxService = sandboxService;
   }
 
+  // ─── B→A entry bridge ───
+  // The manifest/executor still send the legacy B shape; map it to the A shape
+  // the base methods consume so they build correct content/state.
+
+  async listFiles(args: any): Promise<BuiltinServerRuntimeOutput> {
+    return super.listFiles(normalizeFromSandbox('listLocalFiles', args));
+  }
+
+  async readFile(args: any): Promise<BuiltinServerRuntimeOutput> {
+    return super.readFile(normalizeFromSandbox('readLocalFile', args));
+  }
+
+  async editFile(args: any): Promise<BuiltinServerRuntimeOutput> {
+    return super.editFile(normalizeFromSandbox('editLocalFile', args));
+  }
+
+  async searchFiles(args: any): Promise<BuiltinServerRuntimeOutput> {
+    return super.searchFiles(normalizeFromSandbox('searchLocalFiles', args));
+  }
+
+  async moveFiles(args: any): Promise<BuiltinServerRuntimeOutput> {
+    return super.moveFiles(normalizeFromSandbox('moveLocalFiles', args));
+  }
+
+  async runCommand(args: any): Promise<BuiltinServerRuntimeOutput> {
+    return super.runCommand(normalizeFromSandbox('runCommand', args));
+  }
+
+  async getCommandOutput(args: any): Promise<BuiltinServerRuntimeOutput> {
+    return super.getCommandOutput(normalizeFromSandbox('getCommandOutput', args));
+  }
+
+  async killCommand(args: any): Promise<BuiltinServerRuntimeOutput> {
+    return super.killCommand(normalizeFromSandbox('killCommand', args));
+  }
+
+  async grepContent(args: any): Promise<BuiltinServerRuntimeOutput> {
+    return super.grepContent(normalizeFromSandbox('grepContent', args));
+  }
+
+  async globFiles(args: any): Promise<BuiltinServerRuntimeOutput> {
+    return super.globFiles(normalizeFromSandbox('globLocalFiles', args));
+  }
+
+  // ─── A→B exit bridge ───
+
   protected async callService(
     toolName: string,
     params: Record<string, any>,
   ): Promise<SandboxCallToolResult> {
-    return this.sandboxService.callTool(toolName, params);
+    return this.sandboxService.callTool(toolName, denormalizeForSandbox(toolName, params));
   }
 
   // ==================== Cloud-Specific: Code Execution ====================
@@ -54,16 +270,19 @@ export class CloudSandboxExecutionRuntime extends ComputerRuntime {
         success: result.success || false,
       };
 
-      if (!result.success) {
-        return {
-          content: result.error?.message || JSON.stringify(result.error),
-          state,
-          success: true,
-        };
-      }
+      const content = formatExecuteCodeResult({
+        error:
+          result.result?.error ??
+          (result.success ? undefined : result.error?.message || JSON.stringify(result.error)),
+        exitCode: result.result?.exitCode,
+        language,
+        output: result.result?.output,
+        stderr: result.result?.stderr,
+        success: result.success || false,
+      });
 
       return {
-        content: JSON.stringify(result.result),
+        content,
         state,
         success: true,
       };
@@ -96,11 +315,9 @@ export class CloudSandboxExecutionRuntime extends ComputerRuntime {
 
       if (!result.success) {
         return {
-          content: JSON.stringify({
-            error: result.error?.message || 'Failed to export file from sandbox',
-            filename,
-            success: false,
-          }),
+          content: `File export failed for ${filename}: ${
+            result.error?.message || 'Failed to export file from sandbox'
+          }`,
           state,
           success: true,
         };

--- a/packages/builtin-tool-local-system/src/__tests__/grepContentForwarding.test.ts
+++ b/packages/builtin-tool-local-system/src/__tests__/grepContentForwarding.test.ts
@@ -131,9 +131,11 @@ describe('localSystemExecutor.listFiles — limit forwarding', () => {
 
     await localSystemExecutor.listFiles({ limit: 50, path: '/tmp', sortBy: 'name' });
 
+    // The runtime now consumes the canonical A shape, so the executor forwards
+    // `path` straight through (no `directoryPath` rename).
     expect(spy.mock.calls[0][0]).toMatchObject({
-      directoryPath: '/tmp',
       limit: 50,
+      path: '/tmp',
       sortBy: 'name',
     });
 
@@ -154,9 +156,10 @@ describe('localSystemExecutor.getCommandOutput — filter forwarding', () => {
 
     await localSystemExecutor.getCommandOutput({ filter: 'ERROR', shell_id: 'sh-1' });
 
+    // Passthrough: `shell_id` reaches the runtime unchanged (no `commandId` rename).
     expect(spy.mock.calls[0][0]).toMatchObject({
-      commandId: 'sh-1',
       filter: 'ERROR',
+      shell_id: 'sh-1',
     });
 
     spy.mockRestore();
@@ -190,8 +193,8 @@ describe('localSystemExecutor.getCommandOutput — filter forwarding', () => {
   });
 });
 
-describe('localSystemExecutor.runCommand — background field normalization', () => {
-  it('mirrors `run_in_background` to `background` so RunCommandState.isBackground is correct', async () => {
+describe('localSystemExecutor.runCommand — background field passthrough', () => {
+  it('forwards `run_in_background` unchanged (the runtime reads it for RunCommandState.isBackground)', async () => {
     const runtime = (localSystemExecutor as any).runtime as {
       runCommand: (args: any) => Promise<unknown>;
     };
@@ -208,12 +211,13 @@ describe('localSystemExecutor.runCommand — background field normalization', ()
     });
 
     const forwarded = spy.mock.calls[0][0] as Record<string, unknown>;
-    // Both fields present: `background` for ComputerRuntime state, `run_in_background` for IPC.
+    // Passthrough: `run_in_background` reaches the runtime, which reads it
+    // directly — no mirrored `background` field is synthesized anymore.
     expect(forwarded).toMatchObject({
-      background: true,
       command: 'sleep 60',
       run_in_background: true,
     });
+    expect(forwarded).not.toHaveProperty('background');
 
     spy.mockRestore();
   });

--- a/packages/builtin-tool-local-system/src/client/executor/index.ts
+++ b/packages/builtin-tool-local-system/src/client/executor/index.ts
@@ -86,12 +86,7 @@ class LocalSystemExecutor extends BaseExecutor<typeof LocalSystemApiEnum> {
 
   listFiles = async (params: ListLocalFileParams): Promise<BuiltinToolResult> => {
     try {
-      const result = await this.runtime.listFiles({
-        directoryPath: params.path,
-        limit: params.limit,
-        sortBy: params.sortBy,
-        sortOrder: params.sortOrder,
-      } as any);
+      const result = await this.runtime.listFiles(params as any);
       return this.toResult(result);
     } catch (error) {
       return this.errorResult(error);
@@ -100,11 +95,7 @@ class LocalSystemExecutor extends BaseExecutor<typeof LocalSystemApiEnum> {
 
   readFile = async (params: LocalReadFileParams): Promise<BuiltinToolResult> => {
     try {
-      const result = await this.runtime.readFile({
-        endLine: params.loc?.[1],
-        path: params.path,
-        startLine: params.loc?.[0],
-      });
+      const result = await this.runtime.readFile(params as any);
       return this.toResult(result);
     } catch (error) {
       return this.errorResult(error);
@@ -135,12 +126,7 @@ class LocalSystemExecutor extends BaseExecutor<typeof LocalSystemApiEnum> {
 
   moveFiles = async (params: MoveLocalFilesParams): Promise<BuiltinToolResult> => {
     try {
-      const result = await this.runtime.moveFiles({
-        operations: params.items.map((item) => ({
-          destination: item.newPath,
-          source: item.oldPath,
-        })),
-      });
+      const result = await this.runtime.moveFiles(params as any);
       return this.toResult(result);
     } catch (error) {
       return this.errorResult(error);
@@ -158,12 +144,7 @@ class LocalSystemExecutor extends BaseExecutor<typeof LocalSystemApiEnum> {
 
   editFile = async (params: EditLocalFileParams): Promise<BuiltinToolResult> => {
     try {
-      const result = await this.runtime.editFile({
-        all: params.replace_all,
-        path: params.file_path,
-        replace: params.new_string,
-        search: params.old_string,
-      });
+      const result = await this.runtime.editFile(params as any);
       return this.toResult(result);
     } catch (error) {
       return this.errorResult(error);
@@ -174,14 +155,7 @@ class LocalSystemExecutor extends BaseExecutor<typeof LocalSystemApiEnum> {
 
   runCommand = async (params: RunCommandParams): Promise<BuiltinToolResult> => {
     try {
-      // The manifest exposes `run_in_background`, but ComputerRuntime's RunCommandState
-      // reads `args.background` for the `isBackground` field — without this normalize
-      // the UI/state would always say foreground even for background commands.
-      // The IPC handler reads `run_in_background` itself, so we keep that field too.
-      const result = await this.runtime.runCommand({
-        ...params,
-        background: params.run_in_background,
-      } as any);
+      const result = await this.runtime.runCommand(params as any);
       return this.toResult(result);
     } catch (error) {
       return this.errorResult(error);
@@ -190,10 +164,7 @@ class LocalSystemExecutor extends BaseExecutor<typeof LocalSystemApiEnum> {
 
   getCommandOutput = async (params: GetCommandOutputParams): Promise<BuiltinToolResult> => {
     try {
-      const result = await this.runtime.getCommandOutput({
-        commandId: params.shell_id,
-        filter: params.filter,
-      } as any);
+      const result = await this.runtime.getCommandOutput(params as any);
       return this.toResult(result);
     } catch (error) {
       return this.errorResult(error);
@@ -202,9 +173,7 @@ class LocalSystemExecutor extends BaseExecutor<typeof LocalSystemApiEnum> {
 
   killCommand = async (params: KillCommandParams): Promise<BuiltinToolResult> => {
     try {
-      const result = await this.runtime.killCommand({
-        commandId: params.shell_id,
-      });
+      const result = await this.runtime.killCommand(params as any);
       return this.toResult(result);
     } catch (error) {
       return this.errorResult(error);
@@ -230,10 +199,7 @@ class LocalSystemExecutor extends BaseExecutor<typeof LocalSystemApiEnum> {
 
   globFiles = async (params: GlobFilesParams): Promise<BuiltinToolResult> => {
     try {
-      const result = await this.runtime.globFiles({
-        directory: params.scope,
-        pattern: params.pattern,
-      });
+      const result = await this.runtime.globFiles(params as any);
       return this.toResult(result);
     } catch (error) {
       return this.errorResult(error);

--- a/packages/prompts/src/prompts/fileSystem/formatExecuteCodeResult.test.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatExecuteCodeResult.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatExecuteCodeResult } from './formatExecuteCodeResult';
+
+describe('formatExecuteCodeResult', () => {
+  it('formats a successful run with output', () => {
+    const result = formatExecuteCodeResult({
+      language: 'python',
+      output: 'hello\nworld',
+      success: true,
+    });
+    expect(result).toMatchInlineSnapshot(`
+      "python executed successfully.
+
+      Output:
+      hello
+      world"
+    `);
+  });
+
+  it('formats success without a language label', () => {
+    const result = formatExecuteCodeResult({ output: '42', success: true });
+    expect(result).toMatchInlineSnapshot(`
+      "Code executed successfully.
+
+      Output:
+      42"
+    `);
+  });
+
+  it('treats a non-zero exit code as failure even when the envelope succeeded', () => {
+    const result = formatExecuteCodeResult({
+      exitCode: 1,
+      language: 'javascript',
+      stderr: 'ReferenceError: x is not defined',
+      success: true,
+    });
+    expect(result).toMatchInlineSnapshot(`
+      "javascript execution failed with exit code 1
+
+      Stderr:
+      ReferenceError: x is not defined"
+    `);
+  });
+
+  it('includes the error message on failure', () => {
+    const result = formatExecuteCodeResult({
+      error: 'sandbox timed out',
+      language: 'python',
+      success: false,
+    });
+    expect(result).toMatchInlineSnapshot(`"python execution failed: sandbox timed out"`);
+  });
+});

--- a/packages/prompts/src/prompts/fileSystem/formatExecuteCodeResult.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatExecuteCodeResult.ts
@@ -1,0 +1,41 @@
+export interface FormatExecuteCodeResultParams {
+  error?: string;
+  exitCode?: number;
+  language?: string;
+  output?: string;
+  stderr?: string;
+  success: boolean;
+}
+
+/**
+ * Format a cloud-sandbox code-execution result into prompt text. Keeps the
+ * model-facing payload human-readable instead of a raw `JSON.stringify` of the
+ * service result.
+ */
+export const formatExecuteCodeResult = ({
+  success,
+  language,
+  output,
+  stderr,
+  error,
+  exitCode,
+}: FormatExecuteCodeResultParams): string => {
+  const parts: string[] = [];
+
+  const hasNonZeroExit = exitCode !== undefined && exitCode !== 0;
+  const failed = !success || hasNonZeroExit;
+
+  if (failed) {
+    let header = language ? `${language} execution failed` : 'Code execution failed';
+    if (hasNonZeroExit) header += ` with exit code ${exitCode}`;
+    if (error) header += `: ${error}`;
+    parts.push(header);
+  } else {
+    parts.push(language ? `${language} executed successfully.` : 'Code executed successfully.');
+  }
+
+  if (output) parts.push(`Output:\n${output}`);
+  if (stderr) parts.push(`Stderr:\n${stderr}`);
+
+  return parts.join('\n\n');
+};

--- a/packages/prompts/src/prompts/fileSystem/index.ts
+++ b/packages/prompts/src/prompts/fileSystem/index.ts
@@ -1,6 +1,7 @@
 export * from './formatCommandOutput';
 export * from './formatCommandResult';
 export * from './formatEditResult';
+export * from './formatExecuteCodeResult';
 export * from './formatFileContent';
 export * from './formatFileList';
 export * from './formatFileSearchResults';

--- a/packages/tool-runtime/src/ComputerRuntime.ts
+++ b/packages/tool-runtime/src/ComputerRuntime.ts
@@ -76,7 +76,7 @@ export abstract class ComputerRuntime {
       const state: ListFilesState = { files, totalCount };
 
       const content = formatFileList({
-        directory: args.directoryPath,
+        directory: args.path,
         files: files.map((f: { isDirectory: boolean; name: string }) => ({
           isDirectory: f.isDirectory,
           name: f.name,
@@ -99,9 +99,9 @@ export abstract class ComputerRuntime {
       if (!result.success) {
         return this.errorOutput(result, {
           content: '',
-          endLine: args.endLine,
+          endLine: args.loc?.[1],
           path: args.path,
-          startLine: args.startLine,
+          startLine: args.loc?.[0],
         });
       }
 
@@ -111,24 +111,19 @@ export abstract class ComputerRuntime {
       const state: ReadFileState = {
         charCount: r.charCount ?? fileContent.length,
         content: fileContent,
-        endLine: args.endLine,
+        endLine: args.loc?.[1],
         fileType: r.fileType,
         filename: r.filename,
         loc: r.loc,
         path: args.path,
-        startLine: args.startLine,
+        startLine: args.loc?.[0],
         totalCharCount: r.totalCharCount,
         totalLines: r.totalLineCount ?? r.totalLines,
       };
 
-      const lineRange: [number, number] | undefined =
-        args.startLine !== undefined && args.endLine !== undefined
-          ? [args.startLine, args.endLine]
-          : undefined;
-
       const content = formatFileContent({
         content: fileContent,
-        lineRange,
+        lineRange: args.loc,
         path: args.path,
       });
 
@@ -165,19 +160,19 @@ export abstract class ComputerRuntime {
       const result = await this.callService('editLocalFile', args);
 
       if (!result.success) {
-        return this.errorOutput(result, { path: args.path, replacements: 0 });
+        return this.errorOutput(result, { path: args.file_path, replacements: 0 });
       }
 
       const state: EditFileState = {
         diffText: result.result?.diffText,
         linesAdded: result.result?.linesAdded,
         linesDeleted: result.result?.linesDeleted,
-        path: args.path,
+        path: args.file_path,
         replacements: result.result?.replacements || 0,
       };
 
       const content = formatEditResult({
-        filePath: args.path,
+        filePath: args.file_path,
         linesAdded: state.linesAdded,
         linesDeleted: state.linesDeleted,
         replacements: state.replacements,
@@ -222,7 +217,7 @@ export abstract class ComputerRuntime {
         return this.errorOutput(result, {
           results: [],
           successCount: 0,
-          totalCount: args.operations.length,
+          totalCount: args.items.length,
         });
       }
 
@@ -235,7 +230,7 @@ export abstract class ComputerRuntime {
       const state: MoveFilesState = {
         results,
         successCount,
-        totalCount: args.operations.length,
+        totalCount: args.items.length,
       };
 
       const content = formatMoveResults(results);
@@ -256,13 +251,13 @@ export abstract class ComputerRuntime {
           content: formatRenameResult({
             error: errorMsg,
             newName: args.newName,
-            oldPath: args.oldPath,
+            oldPath: args.path,
             success: false,
           }),
           state: {
             error: errorMsg,
             newPath: '',
-            oldPath: args.oldPath,
+            oldPath: args.path,
             success: false,
           } satisfies RenameFileState,
           success: true,
@@ -272,14 +267,14 @@ export abstract class ComputerRuntime {
       const state: RenameFileState = {
         error: result.result?.error,
         newPath: result.result?.newPath || '',
-        oldPath: args.oldPath,
+        oldPath: args.path,
         success: true,
       };
 
       const content = formatRenameResult({
         error: result.result?.error,
         newName: args.newName,
-        oldPath: args.oldPath,
+        oldPath: args.path,
         success: true,
       });
 
@@ -299,7 +294,7 @@ export abstract class ComputerRuntime {
         return this.errorOutput(result, {
           error: result.error?.message,
           exitCode: result.result?.exitCode ?? result.result?.exit_code,
-          isBackground: args.background || false,
+          isBackground: args.run_in_background || false,
           stderr: result.result?.stderr,
           stdout: result.result?.stdout,
           success: false,
@@ -312,7 +307,7 @@ export abstract class ComputerRuntime {
         commandId: r.commandId || r.shell_id,
         error: r.error,
         exitCode: r.exitCode ?? r.exit_code,
-        isBackground: args.background || false,
+        isBackground: args.run_in_background || false,
         output: r.output,
         stderr: r.stderr,
         stdout: r.stdout,
@@ -373,21 +368,21 @@ export abstract class ComputerRuntime {
 
       if (!result.success) {
         return this.errorOutput(result, {
-          commandId: args.commandId,
+          commandId: args.shell_id,
           error: result.error?.message,
           success: false,
         });
       }
 
       const state: KillCommandState = {
-        commandId: args.commandId,
+        commandId: args.shell_id,
         error: result.result?.error,
         success: result.success,
       };
 
       const content = formatKillResult({
         error: result.result?.error,
-        shellId: args.commandId,
+        shellId: args.shell_id,
         success: result.success,
       });
 

--- a/packages/tool-runtime/src/LocalSystemExecutionRuntime.ts
+++ b/packages/tool-runtime/src/LocalSystemExecutionRuntime.ts
@@ -46,8 +46,12 @@ const SERVICE_METHOD_MAP: Record<string, keyof ILocalSystemService> = {
  * Local System Execution Runtime
  *
  * Extends ComputerRuntime for standard computer operations via Electron IPC.
- * Normalizes snake_case IPC results (exit_code, shell_id, total_matches)
- * into the camelCase format expected by ComputerRuntime.
+ *
+ * Params are the canonical **A** shape (snake_case + `loc` tuple), identical to
+ * what `@lobechat/local-file-shell` consumes — so `callService` forwards them
+ * straight through with zero conversion (LOBE-9954). It only normalizes the
+ * snake_case *results* (exit_code, shell_id, total_matches) back into the
+ * camelCase fields ComputerRuntime's formatters/state expect.
  */
 export class LocalSystemExecutionRuntime extends ComputerRuntime {
   private service: ILocalSystemService;
@@ -66,81 +70,12 @@ export class LocalSystemExecutionRuntime extends ComputerRuntime {
       return { error: { message: `Unknown tool: ${toolName}` }, result: null, success: false };
     }
 
-    // Map ComputerRuntime params back to IPC-expected shapes
-    const ipcParams = this.denormalizeParams(toolName, params);
-
+    // Params are already in the A shape the underlying functions consume —
+    // forward them unchanged (no camel↔snake denormalization).
     const method = this.service[methodName] as (params: any) => Promise<any>;
-    const result = await method(ipcParams);
+    const result = await method(params);
 
     return this.normalizeResult(toolName, result);
-  }
-
-  /**
-   * Map ComputerRuntime normalized params back to IPC field names.
-   */
-  private denormalizeParams(toolName: string, params: Record<string, any>): any {
-    switch (toolName) {
-      case 'editLocalFile': {
-        return {
-          file_path: params.path,
-          new_string: params.replace,
-          old_string: params.search,
-          replace_all: params.all,
-        };
-      }
-
-      case 'listLocalFiles': {
-        return {
-          limit: params.limit,
-          path: params.directoryPath,
-          sortBy: params.sortBy,
-          sortOrder: params.sortOrder,
-        };
-      }
-
-      case 'moveLocalFiles': {
-        return {
-          items: params.operations?.map((op: any) => ({
-            newPath: op.destination,
-            oldPath: op.source,
-          })),
-        };
-      }
-
-      case 'renameLocalFile': {
-        return {
-          newName: params.newName,
-          path: params.oldPath,
-        };
-      }
-
-      case 'getCommandOutput': {
-        return { filter: params.filter, shell_id: params.commandId, timeout: params.timeout };
-      }
-
-      case 'killCommand': {
-        return { shell_id: params.commandId };
-      }
-
-      case 'readLocalFile': {
-        const loc: [number, number] | undefined =
-          params.startLine !== undefined || params.endLine !== undefined
-            ? [params.startLine ?? 0, params.endLine ?? 200]
-            : undefined;
-        return { fullContent: params.fullContent, loc, path: params.path };
-      }
-
-      case 'globLocalFiles': {
-        return {
-          pattern: params.pattern,
-          scope: params.directory,
-        };
-      }
-
-      default: {
-        return params;
-      }
-    }
   }
 
   /**

--- a/packages/tool-runtime/src/types.ts
+++ b/packages/tool-runtime/src/types.ts
@@ -9,17 +9,26 @@ export interface ServiceResult {
 }
 
 // ==================== Params ====================
+//
+// Canonical param shape (**A**): snake_case + `loc` tuple, anchored on the
+// wire/manifest + `@lobechat/local-file-shell` contract. The high-frequency
+// local path forwards these straight through to the underlying functions with
+// zero camel↔snake conversion; the cloud sandbox runtime adapts A→B at its own
+// `callService` boundary (the remote SDK still speaks B). See LOBE-9954.
 
 export interface ListFilesParams {
-  directoryPath: string;
+  limit?: number;
+  path: string;
   sortBy?: string;
   sortOrder?: string;
 }
 
 export interface ReadFileParams {
-  endLine?: number;
+  /** Return the entire file, ignoring `loc`. */
+  fullContent?: boolean;
+  /** Line range to read as a tuple [startLine, endLine]. */
+  loc?: [number, number];
   path: string;
-  startLine?: number;
 }
 
 export interface WriteFileParams {
@@ -29,10 +38,10 @@ export interface WriteFileParams {
 }
 
 export interface EditFileParams {
-  all?: boolean;
-  path: string;
-  replace: string;
-  search: string;
+  file_path: string;
+  new_string: string;
+  old_string: string;
+  replace_all?: boolean;
 }
 
 export interface SearchFilesParams {
@@ -40,14 +49,13 @@ export interface SearchFilesParams {
   createdAfter?: string;
   createdBefore?: string;
   detailed?: boolean;
-  directory: string;
+  /** @deprecated Legacy alias for `scope`. */
+  directory?: string;
   exclude?: string[];
   /** @deprecated Prefer `fileTypes` (plural). Retained for cloud sandbox back-compat. */
   fileType?: string;
   fileTypes?: string[];
-  /** @deprecated Prefer `keywords` (plural). Retained for cloud sandbox back-compat. */
-  keyword?: string;
-  keywords?: string;
+  keywords: string;
   limit?: number;
   liveUpdate?: boolean;
   modifiedAfter?: string;
@@ -58,30 +66,36 @@ export interface SearchFilesParams {
 }
 
 export interface MoveFilesParams {
-  operations: Array<{
-    destination: string;
-    source: string;
+  items: Array<{
+    newPath: string;
+    oldPath: string;
   }>;
 }
 
 export interface RenameFileParams {
   newName: string;
-  oldPath: string;
+  path: string;
 }
 
 export interface GlobFilesParams {
-  directory?: string;
+  /** Legacy alias for `scope`. */
+  cwd?: string;
   pattern: string;
+  /** Working directory scope. Relative patterns are resolved against it. */
+  scope?: string;
 }
 
 export interface RunCommandParams {
-  background?: boolean;
   command: string;
+  description?: string;
+  env?: Record<string, string>;
+  run_in_background?: boolean;
   timeout?: number;
 }
 
 export interface GetCommandOutputParams {
-  commandId: string;
+  filter?: string;
+  shell_id: string;
   /**
    * Max time to wait for this observation before returning (does not kill the
    * process). Forwarded to the service so callers polling a running command can
@@ -91,14 +105,24 @@ export interface GetCommandOutputParams {
 }
 
 export interface KillCommandParams {
-  commandId: string;
+  shell_id: string;
 }
 
 export interface GrepContentParams {
-  directory: string;
-  filePattern?: string;
-  pattern: string;
-  recursive?: boolean;
+  '-A'?: number;
+  '-B'?: number;
+  '-C'?: number;
+  '-i'?: boolean;
+  '-n'?: boolean;
+  /** @deprecated Legacy alias for `glob`. */
+  'filePattern'?: string;
+  'glob'?: string;
+  'head_limit'?: number;
+  'multiline'?: boolean;
+  'output_mode'?: 'content' | 'count' | 'files_with_matches';
+  'pattern': string;
+  'scope'?: string;
+  'type'?: string;
 }
 
 // ==================== State ====================

--- a/src/server/services/toolExecution/serverRuntimes/__tests__/cloudSandboxRuntime.test.ts
+++ b/src/server/services/toolExecution/serverRuntimes/__tests__/cloudSandboxRuntime.test.ts
@@ -1,0 +1,123 @@
+import { CloudSandboxExecutionRuntime } from '@lobechat/builtin-tool-cloud-sandbox';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The shared ComputerRuntime base now speaks the canonical **A** shape, but the
+ * cloud sandbox keeps its legacy **B** manifest and the remote SDK also speaks B.
+ * CloudSandboxExecutionRuntime bridges the two: it normalizes B→A on entry (so
+ * the A-base builds correct content/state) and converts A→B at `callService` for
+ * the remote. End to end the legacy B contract must round-trip unchanged — these
+ * tests lock that (LOBE-9954).
+ */
+const makeRuntime = () => {
+  const callTool = vi.fn().mockResolvedValue({ result: {}, success: true });
+  const exportAndUploadFile = vi.fn();
+  const runtime = new CloudSandboxExecutionRuntime({ callTool, exportAndUploadFile } as any);
+  return { callTool, runtime };
+};
+
+describe('CloudSandboxExecutionRuntime — legacy B params round-trip to the remote SDK', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('listFiles: directoryPath preserved', async () => {
+    const { callTool, runtime } = makeRuntime();
+    await runtime.listFiles({ directoryPath: '/tmp', sortBy: 'name' } as any);
+    expect(callTool).toHaveBeenCalledWith(
+      'listLocalFiles',
+      expect.objectContaining({ directoryPath: '/tmp', sortBy: 'name' }),
+    );
+  });
+
+  it('readFile: startLine/endLine preserved', async () => {
+    const { callTool, runtime } = makeRuntime();
+    await runtime.readFile({ endLine: 20, path: '/a.ts', startLine: 10 } as any);
+    expect(callTool).toHaveBeenCalledWith(
+      'readLocalFile',
+      expect.objectContaining({ endLine: 20, path: '/a.ts', startLine: 10 }),
+    );
+  });
+
+  it('editFile: path/search/replace/all preserved', async () => {
+    const { callTool, runtime } = makeRuntime();
+    await runtime.editFile({ all: true, path: '/a.ts', replace: 'b', search: 'a' } as any);
+    expect(callTool).toHaveBeenCalledWith('editLocalFile', {
+      all: true,
+      path: '/a.ts',
+      replace: 'b',
+      search: 'a',
+    });
+  });
+
+  it('searchFiles: directory/keyword/fileType preserved', async () => {
+    const { callTool, runtime } = makeRuntime();
+    await runtime.searchFiles({ directory: '/src', fileType: 'ts', keyword: 'foo' } as any);
+    expect(callTool).toHaveBeenCalledWith(
+      'searchLocalFiles',
+      expect.objectContaining({ directory: '/src', fileType: 'ts', keyword: 'foo' }),
+    );
+  });
+
+  it('moveFiles: operations[{source,destination}] preserved', async () => {
+    const { callTool, runtime } = makeRuntime();
+    await runtime.moveFiles({ operations: [{ destination: '/b', source: '/a' }] } as any);
+    expect(callTool).toHaveBeenCalledWith('moveLocalFiles', {
+      operations: [{ destination: '/b', source: '/a' }],
+    });
+  });
+
+  it('runCommand: background preserved', async () => {
+    const { callTool, runtime } = makeRuntime();
+    await runtime.runCommand({ background: true, command: 'ls' } as any);
+    expect(callTool).toHaveBeenCalledWith(
+      'runCommand',
+      expect.objectContaining({ background: true, command: 'ls' }),
+    );
+  });
+
+  it('getCommandOutput / killCommand: commandId preserved', async () => {
+    const { callTool, runtime } = makeRuntime();
+    await runtime.getCommandOutput({ commandId: 'sh-1' } as any);
+    expect(callTool).toHaveBeenCalledWith('getCommandOutput', { commandId: 'sh-1' });
+    await runtime.killCommand({ commandId: 'sh-1' } as any);
+    expect(callTool).toHaveBeenCalledWith('killCommand', { commandId: 'sh-1' });
+  });
+
+  it('grepContent: directory/filePattern preserved', async () => {
+    const { callTool, runtime } = makeRuntime();
+    await runtime.grepContent({ directory: '/src', filePattern: '*.ts', pattern: 'x' } as any);
+    expect(callTool).toHaveBeenCalledWith('grepContent', {
+      directory: '/src',
+      filePattern: '*.ts',
+      pattern: 'x',
+    });
+  });
+
+  it('globFiles: directory preserved', async () => {
+    const { callTool, runtime } = makeRuntime();
+    await runtime.globFiles({ directory: '/src', pattern: '**/*.ts' } as any);
+    expect(callTool).toHaveBeenCalledWith('globLocalFiles', {
+      directory: '/src',
+      pattern: '**/*.ts',
+    });
+  });
+});
+
+describe('CloudSandboxExecutionRuntime.executeCode — formatter instead of raw JSON', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('routes the result through the formatter (not JSON.stringify)', async () => {
+    const callTool = vi
+      .fn()
+      .mockResolvedValue({ result: { exitCode: 0, output: 'hello' }, success: true });
+    const runtime = new CloudSandboxExecutionRuntime({
+      callTool,
+      exportAndUploadFile: vi.fn(),
+    } as any);
+
+    const out = await runtime.executeCode({ code: 'print(1)', language: 'python' });
+
+    expect(out.content).toContain('python executed successfully.');
+    expect(out.content).toContain('hello');
+    expect(out.content).not.toContain('{"');
+  });
+});


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔗 Related Issue

Fixes LOBE-9954

#### 🔀 Description of Change

`@lobechat/tool-runtime`'s `ComputerRuntime` base class used a camelCase, expanded param shape (**B**: `directoryPath`, `startLine`/`endLine`, `replace`/`search`, `commandId`, `background`) as its canonical public API. But the wire/manifest (the LLM tool contract) and `@lobechat/local-file-shell` use the **A** shape (snake_case + `loc` tuple: `path`, `loc`, `file_path`, `old_string`, `run_in_background`, `shell_id`).

This made the **high-frequency local (desktop + CLI) path** pay a wasteful **A→B→A roundtrip**. This PR anchors the runtime's canonical shape on **A** (aligned with local-system), so local is zero-transform; the **cloud sandbox keeps its existing B contract** and absorbs the conversion internally.

**Local path (zero-roundtrip):**
- `tool-runtime`: `*Params` rewritten B→A; `ComputerRuntime` bodies consume A; **`LocalSystemExecutionRuntime.denormalizeParams` deleted**, `callService` is pure passthrough. `*State` output kept **byte-identical**.
- The 3 local map sites collapsed to passthrough: CLI `runLocalSystemTool`, desktop `executeToolCall`, renderer `LocalSystemExecutor`.
- Fixes the `readFile` roundtrip semantic loss (`fullContent` was dropped, `loc` forced to `[0, 200]`).

**Cloud path (B contract unchanged; conversion contained in the sandbox):**
- The cloud sandbox's **manifest + types/params + UI stay B** — no model-facing tool-contract change, no UI change, fully backward compatible.
- `CloudSandboxExecutionRuntime` is the single bridge: it normalizes **B→A on entry** (so the shared A-base builds correct `content`/`state`) and converts **A→B at `callService`** for the remote sandbox SDK (which still speaks B). The bridge lives in the runtime — not the client executor — because the **server** runtime (`serverRuntimes/cloudSandbox.ts`) calls these methods directly.
- Fixes `executeCode`/`exportFile` bare `JSON.stringify` into prompt `content`: `executeCode` now uses a new `formatExecuteCodeResult` formatter; `exportFile` failure uses a plain string.

Net result: the runtime layer is uniformly A (local-system aligned), the high-frequency local path does zero camel↔snake conversion, and the cloud sandbox is fully backward compatible — the conversion cost stays entirely on the lower-frequency cloud path.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- Whole-repo `type-check` is clean (no errors in touched files).
- Green suites: `builtin-tool-local-system` (executor + grep forwarding), CLI tools, server `serverRuntimes` (incl. `cloudSandboxRuntime.test.ts` locking the B→A→B round-trip), `prompts/fileSystem` (incl. new `formatExecuteCodeResult.test.ts`).
- ⚠️ `apps/desktop` `GatewayConnectionCtr.test.ts` couldn't run in my local sandbox (pre-existing `@lobechat/device-identity` workspace-resolution failure, unrelated) — type-check validated the file; please confirm in CI.

#### 📝 Additional Information

`*State` shapes are intentionally frozen (only param *inputs* change), so `content` + `state` stay identical on the local path after deleting `denormalizeParams`. The cloud sandbox's LLM tool contract and UI are unchanged — the B↔A bridge is purely internal to `CloudSandboxExecutionRuntime`.