### PR TITLE
fix(chat): unescape markdown-only underscores before send

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lobehub/lobehub",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "LobeHub - an open-source,comprehensive AI Agent framework that supports speech synthesis, multimodal, and extensible Function Call plugin system. Supports one-click free deployment of your private ChatGPT/LLM web application.",
   "keywords": [
     "framework",

--- a/src/features/Conversation/ChatInput/index.tsx
+++ b/src/features/Conversation/ChatInput/index.tsx
@@ -250,7 +250,7 @@ const ChatInput = memo<ChatInputProps>(
         if (disableQueue && isInputLoading) return;
 
         // Get content before clearing
-        const message = getMarkdownContent();
+        const message = unescapeMarkdown(getMarkdownContent());
         if (!message.trim() && currentFileList.length === 0 && currentContextList.length === 0)
           return;
 

--- a/src/features/Conversation/ChatInput/unescapeSendMarkdown.test.ts
+++ b/src/features/Conversation/ChatInput/unescapeSendMarkdown.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { unescapeMarkdown } from '@/store/chat/utils/unescapeMarkdown';
+
+describe('chat input send markdown normalization', () => {
+  it('unescapes markdown-only escapes before sending plain text', () => {
+    expect(unescapeMarkdown('D:\\godot\\_mcp')).toBe('D:\\godot_mcp');
+    expect(unescapeMarkdown('A\\_i = k')).toBe('A_i = k');
+  });
+
+  it('keeps escapes inside inline code and fenced code blocks', () => {
+    expect(unescapeMarkdown('`D:\\godot\\_mcp`')).toBe('`D:\\godot\\_mcp`');
+    expect(unescapeMarkdown('```\nD:\\godot\\_mcp\n```')).toBe('```\nD:\\godot\\_mcp\n```');
+  });
+});


### PR DESCRIPTION
## Summary

- normalize chat-input markdown before send by reusing the existing `unescapeMarkdown` helper
- preserve literal backslashes inside inline code and fenced code blocks
- add a focused regression test for underscore-escaped Windows-style paths and plain-text formulas

## Testing

- `pnpm exec vitest run src/features/Conversation/ChatInput/unescapeSendMarkdown.test.ts src/store/chat/utils/unescapeMarkdown.test.ts`
- `git diff --check`

Fixes #14933
