### PR TITLE
✨ feat(connector): Connectors system — API-level tool permissions with plugin fallback

### DIFF
--- a/packages/database/src/models/connector.ts
+++ b/packages/database/src/models/connector.ts
@@ -100,7 +100,7 @@ export class ConnectorModel {
     gateKeeper?: GateKeeper,
   ): Promise<void> => {
     const credentials =
-      patch.credentials !== undefined
+      patch.credentials !== undefined && patch.credentials !== null
         ? await encryptCredentials(patch.credentials, gateKeeper)
         : undefined;
 

--- a/packages/database/src/models/connector.ts
+++ b/packages/database/src/models/connector.ts
@@ -1,0 +1,148 @@
+import { and, eq, inArray } from 'drizzle-orm';
+
+import type {
+  ConnectorCredentials,
+  ConnectorStatus,
+  NewUserConnector,
+  UserConnectorItem,
+} from '../schemas';
+import { userConnectors } from '../schemas';
+import type { LobeChatDatabase } from '../type';
+
+interface GateKeeper {
+  decrypt: (ciphertext: string) => Promise<{ plaintext: string }>;
+  encrypt: (plaintext: string) => Promise<string>;
+}
+
+export interface DecryptedConnector extends Omit<UserConnectorItem, 'credentials'> {
+  credentials: ConnectorCredentials | null;
+}
+
+type CreateConnectorParams = Omit<NewUserConnector, 'userId' | 'id' | 'createdAt' | 'updatedAt'>;
+
+type UpdateConnectorParams = Partial<
+  Omit<NewUserConnector, 'userId' | 'id' | 'createdAt' | 'updatedAt'>
+>;
+
+export class ConnectorModel {
+  private userId: string;
+  private db: LobeChatDatabase;
+
+  constructor(db: LobeChatDatabase, userId: string) {
+    this.db = db;
+    this.userId = userId;
+  }
+
+  create = async (
+    params: CreateConnectorParams,
+    gateKeeper?: GateKeeper,
+  ): Promise<UserConnectorItem> => {
+    const credentials = params.credentials
+      ? await encryptCredentials(params.credentials, gateKeeper)
+      : null;
+
+    const [result] = await this.db
+      .insert(userConnectors)
+      .values({ ...params, credentials, userId: this.userId })
+      .returning();
+
+    return result;
+  };
+
+  delete = async (id: string): Promise<void> => {
+    await this.db
+      .delete(userConnectors)
+      .where(and(eq(userConnectors.id, id), eq(userConnectors.userId, this.userId)));
+  };
+
+  query = async (gateKeeper?: GateKeeper): Promise<DecryptedConnector[]> => {
+    const rows = await this.db
+      .select()
+      .from(userConnectors)
+      .where(eq(userConnectors.userId, this.userId));
+
+    return Promise.all(rows.map((r) => decryptRow(r, gateKeeper)));
+  };
+
+  queryByIdentifiers = async (
+    identifiers: string[],
+    gateKeeper?: GateKeeper,
+  ): Promise<DecryptedConnector[]> => {
+    if (identifiers.length === 0) return [];
+
+    const rows = await this.db
+      .select()
+      .from(userConnectors)
+      .where(
+        and(
+          eq(userConnectors.userId, this.userId),
+          inArray(userConnectors.identifier, identifiers),
+        ),
+      );
+
+    return Promise.all(rows.map((r) => decryptRow(r, gateKeeper)));
+  };
+
+  findById = async (id: string, gateKeeper?: GateKeeper): Promise<DecryptedConnector | null> => {
+    const [row] = await this.db
+      .select()
+      .from(userConnectors)
+      .where(and(eq(userConnectors.id, id), eq(userConnectors.userId, this.userId)))
+      .limit(1);
+
+    if (!row) return null;
+    return decryptRow(row, gateKeeper);
+  };
+
+  update = async (
+    id: string,
+    patch: UpdateConnectorParams,
+    gateKeeper?: GateKeeper,
+  ): Promise<void> => {
+    const credentials =
+      patch.credentials !== undefined
+        ? await encryptCredentials(patch.credentials, gateKeeper)
+        : undefined;
+
+    const set = {
+      ...patch,
+      ...(credentials !== undefined ? { credentials } : {}),
+      updatedAt: new Date(),
+    };
+
+    await this.db
+      .update(userConnectors)
+      .set(set)
+      .where(and(eq(userConnectors.id, id), eq(userConnectors.userId, this.userId)));
+  };
+
+  updateStatus = async (id: string, status: ConnectorStatus): Promise<void> => {
+    await this.db
+      .update(userConnectors)
+      .set({ status, updatedAt: new Date() })
+      .where(and(eq(userConnectors.id, id), eq(userConnectors.userId, this.userId)));
+  };
+}
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+async function encryptCredentials(credentials: string, gateKeeper?: GateKeeper): Promise<string> {
+  if (!gateKeeper) return credentials;
+  return gateKeeper.encrypt(credentials);
+}
+
+async function decryptRow(
+  row: UserConnectorItem,
+  gateKeeper?: GateKeeper,
+): Promise<DecryptedConnector> {
+  if (!row.credentials) return { ...row, credentials: null };
+
+  try {
+    const plain = gateKeeper
+      ? (await gateKeeper.decrypt(row.credentials)).plaintext
+      : row.credentials;
+    return { ...row, credentials: JSON.parse(plain) as ConnectorCredentials };
+  } catch {
+    return { ...row, credentials: null };
+  }
+}

--- a/packages/database/src/models/connectorTool.ts
+++ b/packages/database/src/models/connectorTool.ts
@@ -11,6 +11,8 @@ import type { LobeChatDatabase } from '../type';
 
 export interface SyncToolInput {
   crudType: ToolCRUDType;
+  /** Default permission for newly-inserted rows. Existing rows keep their setting. */
+  defaultPermission?: ConnectorToolPermission;
   description?: string;
   displayName?: string;
   inputSchema?: Record<string, unknown>;
@@ -46,7 +48,7 @@ export class ConnectorToolModel {
       inputSchema: t.inputSchema ?? null,
       isWorkArtifact: false,
       outputSchema: t.outputSchema ?? null,
-      permission: Permission.auto,
+      permission: t.defaultPermission ?? Permission.auto,
       renderConfig: t.renderConfig ?? null,
       toolName: t.toolName,
       userConnectorId,

--- a/packages/database/src/models/connectorTool.ts
+++ b/packages/database/src/models/connectorTool.ts
@@ -87,7 +87,12 @@ export class ConnectorToolModel {
     return this.db
       .select()
       .from(userConnectorTools)
-      .where(eq(userConnectorTools.userConnectorId, userConnectorId));
+      .where(
+        and(
+          eq(userConnectorTools.userConnectorId, userConnectorId),
+          eq(userConnectorTools.userId, this.userId),
+        ),
+      );
   };
 
   /**
@@ -107,5 +112,38 @@ export class ConnectorToolModel {
           ne(userConnectorTools.permission, Permission.disabled),
         ),
       );
+  };
+
+  /**
+   * Query all tools for the given connector UUIDs, including disabled ones.
+   * Used for manifest building where disabled tools must be visible (blocking description).
+   */
+  queryAllByConnectorIds = async (connectorIds: string[]): Promise<UserConnectorToolItem[]> => {
+    if (connectorIds.length === 0) return [];
+
+    return this.db
+      .select()
+      .from(userConnectorTools)
+      .where(
+        and(
+          eq(userConnectorTools.userId, this.userId),
+          inArray(userConnectorTools.userConnectorId, connectorIds),
+        ),
+      );
+  };
+
+  /**
+   * Look up a single tool by its toolName for this user.
+   * Used for direct permission checks (e.g. Klavis gate).
+   */
+  findByToolName = async (toolName: string): Promise<UserConnectorToolItem | undefined> => {
+    const results = await this.db
+      .select()
+      .from(userConnectorTools)
+      .where(
+        and(eq(userConnectorTools.userId, this.userId), eq(userConnectorTools.toolName, toolName)),
+      )
+      .limit(1);
+    return results[0];
   };
 }

--- a/packages/database/src/models/connectorTool.ts
+++ b/packages/database/src/models/connectorTool.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, ne } from 'drizzle-orm';
+import { and, eq, inArray, ne, sql } from 'drizzle-orm';
 
 import type {
   ConnectorToolPermission,
@@ -62,12 +62,14 @@ export class ConnectorToolModel {
         // unique index: (userConnectorId, toolName)
         target: [userConnectorTools.userConnectorId, userConnectorTools.toolName],
         set: {
-          crudType: userConnectorTools.crudType,
-          description: userConnectorTools.description,
-          displayName: userConnectorTools.displayName,
-          inputSchema: userConnectorTools.inputSchema,
-          outputSchema: userConnectorTools.outputSchema,
-          renderConfig: userConnectorTools.renderConfig,
+          // Use sql`excluded.*` to reference the incoming row's values, not the existing row.
+          // Using table.column in set would generate a no-op self-reference in some Drizzle versions.
+          crudType: sql`excluded.crud_type`,
+          description: sql`excluded.description`,
+          displayName: sql`excluded.display_name`,
+          inputSchema: sql`excluded.input_schema`,
+          outputSchema: sql`excluded.output_schema`,
+          renderConfig: sql`excluded.render_config`,
           updatedAt: new Date(),
           // permission / isWorkArtifact / workArtifactConfig / limitConfig NOT updated
         },

--- a/packages/database/src/models/connectorTool.ts
+++ b/packages/database/src/models/connectorTool.ts
@@ -1,0 +1,107 @@
+import { and, eq, inArray, ne } from 'drizzle-orm';
+
+import type {
+  ConnectorToolPermission,
+  NewUserConnectorTool,
+  ToolCRUDType,
+  UserConnectorToolItem,
+} from '../schemas';
+import { ConnectorToolPermission as Permission, userConnectorTools } from '../schemas';
+import type { LobeChatDatabase } from '../type';
+
+export interface SyncToolInput {
+  crudType: ToolCRUDType;
+  description?: string;
+  displayName?: string;
+  inputSchema?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  renderConfig?: Record<string, unknown>;
+  toolName: string;
+}
+
+export class ConnectorToolModel {
+  private userId: string;
+  private db: LobeChatDatabase;
+
+  constructor(db: LobeChatDatabase, userId: string) {
+    this.db = db;
+    this.userId = userId;
+  }
+
+  /**
+   * Batch-upsert tools from a manifest sync.
+   *
+   * Manifest-derived fields are always overwritten (toolName, displayName,
+   * description, inputSchema, outputSchema, crudType, renderConfig).
+   * User-controlled fields (permission, isWorkArtifact, workArtifactConfig,
+   * limitConfig) are preserved on conflict.
+   */
+  upsertMany = async (userConnectorId: string, tools: SyncToolInput[]): Promise<void> => {
+    if (tools.length === 0) return;
+
+    const values: NewUserConnectorTool[] = tools.map((t) => ({
+      crudType: t.crudType,
+      description: t.description ?? null,
+      displayName: t.displayName ?? null,
+      inputSchema: t.inputSchema ?? null,
+      isWorkArtifact: false,
+      outputSchema: t.outputSchema ?? null,
+      permission: Permission.auto,
+      renderConfig: t.renderConfig ?? null,
+      toolName: t.toolName,
+      userConnectorId,
+      userId: this.userId,
+    }));
+
+    await this.db
+      .insert(userConnectorTools)
+      .values(values)
+      .onConflictDoUpdate({
+        // unique index: (userConnectorId, toolName)
+        target: [userConnectorTools.userConnectorId, userConnectorTools.toolName],
+        set: {
+          crudType: userConnectorTools.crudType,
+          description: userConnectorTools.description,
+          displayName: userConnectorTools.displayName,
+          inputSchema: userConnectorTools.inputSchema,
+          outputSchema: userConnectorTools.outputSchema,
+          renderConfig: userConnectorTools.renderConfig,
+          updatedAt: new Date(),
+          // permission / isWorkArtifact / workArtifactConfig / limitConfig NOT updated
+        },
+      });
+  };
+
+  updatePermission = async (toolId: string, permission: ConnectorToolPermission): Promise<void> => {
+    await this.db
+      .update(userConnectorTools)
+      .set({ permission, updatedAt: new Date() })
+      .where(and(eq(userConnectorTools.id, toolId), eq(userConnectorTools.userId, this.userId)));
+  };
+
+  queryByConnector = async (userConnectorId: string): Promise<UserConnectorToolItem[]> => {
+    return this.db
+      .select()
+      .from(userConnectorTools)
+      .where(eq(userConnectorTools.userConnectorId, userConnectorId));
+  };
+
+  /**
+   * Hot-path query for agent session tool resolution.
+   * Returns only non-disabled tools for the given connector UUIDs.
+   */
+  queryByConnectorIds = async (connectorIds: string[]): Promise<UserConnectorToolItem[]> => {
+    if (connectorIds.length === 0) return [];
+
+    return this.db
+      .select()
+      .from(userConnectorTools)
+      .where(
+        and(
+          eq(userConnectorTools.userId, this.userId),
+          inArray(userConnectorTools.userConnectorId, connectorIds),
+          ne(userConnectorTools.permission, Permission.disabled),
+        ),
+      );
+  };
+}

--- a/packages/database/src/schemas/connector.ts
+++ b/packages/database/src/schemas/connector.ts
@@ -241,7 +241,7 @@ export const userConnectorTools = pgTable(
      * Three-state permission:
      * - 'auto'            — allow AI to call without confirmation
      * - 'needs_approval'  — require human approval before execution
-     * - 'disabled'        — not injected; AI cannot see or call this tool
+     * - 'disabled'        — injected with blocking description; AI knows it is disabled and cannot call it
      */
     permission: text('permission').notNull(),
 

--- a/src/features/AgentSetting/AgentCategory/useCategory.tsx
+++ b/src/features/AgentSetting/AgentCategory/useCategory.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@lobehub/ui';
 import { type MenuItemType } from 'antd/es/menu/interface';
-import { Activity, Bot, Handshake, Mic2 } from 'lucide-react';
+import { Activity, Bot, Handshake, LinkIcon, Mic2 } from 'lucide-react';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -42,6 +42,11 @@ export const useCategory = ({ mobile }: UseCategoryOptions = {}) => {
           icon: <Icon icon={Mic2} size={iconSize} />,
           key: ChatSettingsTabs.TTS,
           label: t('agentTab.tts'),
+        },
+        {
+          icon: <Icon icon={LinkIcon} size={iconSize} />,
+          key: ChatSettingsTabs.Connector,
+          label: t('agentTab.connector', 'Connectors'),
         },
       ].filter(Boolean) as MenuProps['items'],
     [t, isInbox, iconSize, enableAgentSelfIteration],

--- a/src/features/AgentSetting/AgentConnectors/index.tsx
+++ b/src/features/AgentSetting/AgentConnectors/index.tsx
@@ -1,0 +1,75 @@
+import { Switch } from 'antd';
+import { LinkIcon } from 'lucide-react';
+import { memo, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useToolStore } from '@/store/tool';
+import { connectorSelectors } from '@/store/tool/slices/connector';
+
+import { useStore } from '../store';
+
+const AgentConnectors = memo(() => {
+  const { t } = useTranslation('setting');
+
+  const [userEnabledPlugins, toggleAgentPlugin] = useStore((s) => [
+    s.config.plugins ?? [],
+    s.toggleAgentPlugin,
+  ]);
+
+  const connectors = useToolStore(connectorSelectors.connectorList);
+  const fetchConnectors = useToolStore((s) => s.fetchConnectors);
+  const isInit = useToolStore((s) => s.isConnectorsInit);
+
+  useEffect(() => {
+    if (!isInit) fetchConnectors();
+  }, [isInit, fetchConnectors]);
+
+  if (connectors.length === 0) {
+    return (
+      <div
+        style={{ color: 'var(--lobe-colors-neutral-500)', padding: '24px 0', textAlign: 'center' }}
+      >
+        {t('agentConnectors.empty', 'No connectors connected yet. Go to Connectors to add one.')}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {connectors.map((connector) => {
+        const isEnabled = userEnabledPlugins.includes(connector.identifier);
+        const enabledCount = connector.tools.filter((t) => t.permission !== 'disabled').length;
+
+        return (
+          <div
+            key={connector.id}
+            style={{
+              alignItems: 'center',
+              borderRadius: 8,
+              display: 'flex',
+              gap: 10,
+              padding: '10px 12px',
+            }}
+          >
+            <LinkIcon size={16} style={{ flexShrink: 0 }} />
+            <div style={{ flex: 1 }}>
+              <div style={{ fontWeight: 500 }}>{connector.name}</div>
+              <div style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 12 }}>
+                {t('agentConnectors.toolCount', '{{count}} tools', { count: enabledCount })}
+              </div>
+            </div>
+            <Switch
+              checked={isEnabled}
+              size="small"
+              onChange={() => toggleAgentPlugin(connector.identifier)}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+});
+
+AgentConnectors.displayName = 'AgentConnectors';
+
+export default AgentConnectors;

--- a/src/features/AgentSetting/AgentSettingsContent.tsx
+++ b/src/features/AgentSetting/AgentSettingsContent.tsx
@@ -6,6 +6,7 @@ import { agentSelectors } from '@/store/agent/selectors';
 import { ChatSettingsTabs } from '@/store/global/initialState';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 
+import AgentConnectors from './AgentConnectors';
 import AgentOpening from './AgentOpening';
 import AgentSelfIteration from './AgentSelfIteration';
 
@@ -24,6 +25,7 @@ const AgentSettingsContent = memo<AgentSettingsContentProps>(({ tab, loadingSkel
     <>
       {tab === ChatSettingsTabs.Opening && <AgentOpening />}
       {enableAgentSelfIteration && tab === ChatSettingsTabs.SelfIteration && <AgentSelfIteration />}
+      {tab === ChatSettingsTabs.Connector && <AgentConnectors />}
     </>
   );
 });

--- a/src/features/Connectors/AddConnectorModal/index.tsx
+++ b/src/features/Connectors/AddConnectorModal/index.tsx
@@ -1,0 +1,72 @@
+import { Modal } from '@lobehub/ui/base-ui';
+import { Input } from 'antd';
+import { memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ConnectorSourceType } from '@/database/schemas';
+import { useToolStore } from '@/store/tool';
+
+interface AddConnectorModalProps {
+  onClose: () => void;
+  open: boolean;
+}
+
+const AddConnectorModal = memo<AddConnectorModalProps>(({ open, onClose }) => {
+  const { t } = useTranslation('tool');
+  const createConnector = useToolStore((s) => s.createConnector);
+  const creating = useToolStore((s) => s.connectorCreating);
+
+  const [name, setName] = useState('');
+  const [url, setUrl] = useState('');
+
+  const handleAdd = async () => {
+    if (!name.trim() || !url.trim()) return;
+    await createConnector({
+      identifier: name.toLowerCase().replaceAll(/\s+/g, '-'),
+      mcpConnectionType: 'http',
+      mcpServerUrl: url.trim(),
+      name: name.trim(),
+      sourceType: ConnectorSourceType.custom,
+    });
+    setName('');
+    setUrl('');
+    onClose();
+  };
+
+  return (
+    <Modal
+      cancelText={t('connector.add.cancel', 'Cancel')}
+      okButtonProps={{ disabled: !name.trim() || !url.trim(), loading: creating }}
+      okText={t('connector.add.confirm', 'Add')}
+      open={open}
+      title={t('connector.add.title', 'Add custom connector')}
+      onCancel={onClose}
+      onOk={handleAdd}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <div>
+          <div style={{ fontSize: 12, marginBottom: 4 }}>{t('connector.add.name', 'Name')}</div>
+          <Input
+            placeholder={t('connector.add.namePlaceholder', 'My connector')}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </div>
+        <div>
+          <div style={{ fontSize: 12, marginBottom: 4 }}>
+            {t('connector.add.url', 'Remote MCP server URL')}
+          </div>
+          <Input
+            placeholder="https://mcp.example.com"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+});
+
+AddConnectorModal.displayName = 'AddConnectorModal';
+
+export default AddConnectorModal;

--- a/src/features/Connectors/AddConnectorModal/index.tsx
+++ b/src/features/Connectors/AddConnectorModal/index.tsx
@@ -1,5 +1,6 @@
 import { Modal } from '@lobehub/ui/base-ui';
 import { Input } from 'antd';
+import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -18,6 +19,8 @@ const AddConnectorModal = memo<AddConnectorModalProps>(({ open, onClose }) => {
 
   const [name, setName] = useState('');
   const [url, setUrl] = useState('');
+  const [clientId, setClientId] = useState('');
+  const [showAdvanced, setShowAdvanced] = useState(false);
 
   const handleAdd = async () => {
     if (!name.trim() || !url.trim()) return;
@@ -26,10 +29,23 @@ const AddConnectorModal = memo<AddConnectorModalProps>(({ open, onClose }) => {
       mcpConnectionType: 'http',
       mcpServerUrl: url.trim(),
       name: name.trim(),
+      oidcConfig: clientId.trim()
+        ? { clientId: clientId.trim(), scheme: 'pre_registration' }
+        : undefined,
       sourceType: ConnectorSourceType.custom,
     });
     setName('');
     setUrl('');
+    setClientId('');
+    setShowAdvanced(false);
+    onClose();
+  };
+
+  const handleCancel = () => {
+    setName('');
+    setUrl('');
+    setClientId('');
+    setShowAdvanced(false);
     onClose();
   };
 
@@ -40,7 +56,7 @@ const AddConnectorModal = memo<AddConnectorModalProps>(({ open, onClose }) => {
       okText={t('connector.add.confirm', 'Add')}
       open={open}
       title={t('connector.add.title', 'Add custom connector')}
-      onCancel={onClose}
+      onCancel={handleCancel}
       onOk={handleAdd}
     >
       <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
@@ -61,6 +77,38 @@ const AddConnectorModal = memo<AddConnectorModalProps>(({ open, onClose }) => {
             value={url}
             onChange={(e) => setUrl(e.target.value)}
           />
+        </div>
+
+        {/* Advanced settings */}
+        <div>
+          <div
+            style={{
+              alignItems: 'center',
+              cursor: 'pointer',
+              display: 'flex',
+              fontSize: 13,
+              fontWeight: 500,
+              gap: 4,
+              userSelect: 'none',
+            }}
+            onClick={() => setShowAdvanced((v) => !v)}
+          >
+            {showAdvanced ? <ChevronDownIcon size={14} /> : <ChevronRightIcon size={14} />}
+            {t('connector.add.advanced', 'Advanced settings')}
+          </div>
+
+          {showAdvanced && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 8 }}>
+              <Input
+                placeholder={t('connector.add.clientId', 'OAuth Client ID (optional)')}
+                value={clientId}
+                onChange={(e) => setClientId(e.target.value)}
+              />
+              <Input.Password
+                placeholder={t('connector.add.clientSecret', 'OAuth Client Secret (optional)')}
+              />
+            </div>
+          )}
         </div>
       </div>
     </Modal>

--- a/src/features/Connectors/AddConnectorModal/index.tsx
+++ b/src/features/Connectors/AddConnectorModal/index.tsx
@@ -52,7 +52,8 @@ const AddConnectorModal = memo<AddConnectorModalProps>(({ open, onClose }) => {
   return (
     <Modal
       cancelText={t('connector.add.cancel', 'Cancel')}
-      okButtonProps={{ disabled: !name.trim() || !url.trim(), loading: creating }}
+      confirmLoading={creating}
+      okButtonProps={{ disabled: !name.trim() || !url.trim() }}
       okText={t('connector.add.confirm', 'Add')}
       open={open}
       title={t('connector.add.title', 'Add custom connector')}

--- a/src/features/Connectors/ConnectorDetail/ToolPermissionGroup.tsx
+++ b/src/features/Connectors/ConnectorDetail/ToolPermissionGroup.tsx
@@ -1,0 +1,97 @@
+import { DropdownMenu } from '@lobehub/ui/base-ui';
+import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
+import { memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { ConnectorToolPermission } from '@/database/schemas';
+import type { ConnectorTool } from '@/store/tool/slices/connector';
+
+import ToolPermissionRow from './ToolPermissionRow';
+
+interface ToolPermissionGroupProps {
+  label: string;
+  onBatchPermission: (toolIds: string[], permission: ConnectorToolPermission) => void;
+  onPermissionChange: (toolId: string, permission: ConnectorToolPermission) => void;
+  tools: ConnectorTool[];
+}
+
+const ToolPermissionGroup = memo<ToolPermissionGroupProps>(
+  ({ label, tools, onPermissionChange, onBatchPermission }) => {
+    const { t } = useTranslation('tool');
+    const [expanded, setExpanded] = useState(true);
+
+    if (tools.length === 0) return null;
+
+    const toolIds = tools.map((t) => t.id);
+
+    const batchItems = [
+      {
+        key: 'auto',
+        label: t('connector.permission.autoAll', 'Auto all'),
+        onClick: () => onBatchPermission(toolIds, ConnectorToolPermission.auto),
+      },
+      {
+        key: 'approval',
+        label: t('connector.permission.approvalAll', 'Needs approval all'),
+        onClick: () => onBatchPermission(toolIds, ConnectorToolPermission.needs_approval),
+      },
+      {
+        key: 'disable',
+        label: t('connector.permission.disableAll', 'Disable all'),
+        onClick: () => onBatchPermission(toolIds, ConnectorToolPermission.disabled),
+      },
+    ];
+
+    return (
+      <div>
+        <div
+          style={{
+            alignItems: 'center',
+            display: 'flex',
+            gap: 8,
+            padding: '8px 0',
+          }}
+        >
+          <div
+            style={{ alignItems: 'center', cursor: 'pointer', display: 'flex', flex: 1, gap: 6 }}
+            onClick={() => setExpanded((e) => !e)}
+          >
+            {expanded ? <ChevronDownIcon size={14} /> : <ChevronRightIcon size={14} />}
+            <span style={{ fontWeight: 500 }}>{label}</span>
+            <span style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 12 }}>
+              {tools.length}
+            </span>
+          </div>
+
+          <DropdownMenu items={batchItems}>
+            <span
+              style={{
+                color: 'var(--lobe-colors-neutral-500)',
+                cursor: 'pointer',
+                fontSize: 12,
+              }}
+            >
+              {t('connector.permission.custom', 'Custom')} ▾
+            </span>
+          </DropdownMenu>
+        </div>
+
+        {expanded && (
+          <div>
+            {tools.map((tool) => (
+              <ToolPermissionRow
+                key={tool.id}
+                tool={tool}
+                onPermissionChange={onPermissionChange}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+ToolPermissionGroup.displayName = 'ToolPermissionGroup';
+
+export default ToolPermissionGroup;

--- a/src/features/Connectors/ConnectorDetail/ToolPermissionGroup.tsx
+++ b/src/features/Connectors/ConnectorDetail/ToolPermissionGroup.tsx
@@ -1,5 +1,7 @@
 import { DropdownMenu } from '@lobehub/ui/base-ui';
-import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
+import { Button } from 'antd';
+import { createStaticStyles } from 'antd-style';
+import { ChevronDownIcon, ChevronRightIcon, MoreHorizontalIcon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -7,6 +9,48 @@ import { ConnectorToolPermission } from '@/database/schemas';
 import type { ConnectorTool } from '@/store/tool/slices/connector';
 
 import ToolPermissionRow from './ToolPermissionRow';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  badge: css`
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    padding-block: 1px;
+    padding-inline: 6px;
+    border-radius: 4px;
+
+    font-size: 12px;
+    color: ${cssVar.colorTextSecondary};
+
+    background: ${cssVar.colorFillSecondary};
+  `,
+  groupHeader: css`
+    cursor: pointer;
+    user-select: none;
+
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    padding-block: 10px;
+    padding-inline: 0;
+
+    &:hover span {
+      color: ${cssVar.colorText};
+    }
+  `,
+  groupLabel: css`
+    display: flex;
+    flex: 1;
+    gap: 6px;
+    align-items: center;
+
+    font-size: 13px;
+    font-weight: 500;
+    color: ${cssVar.colorText};
+  `,
+}));
 
 interface ToolPermissionGroupProps {
   label: string;
@@ -22,7 +66,7 @@ const ToolPermissionGroup = memo<ToolPermissionGroupProps>(
 
     if (tools.length === 0) return null;
 
-    const toolIds = tools.map((t) => t.id);
+    const toolIds = tools.map((tool) => tool.id);
 
     const batchItems = [
       {
@@ -44,35 +88,23 @@ const ToolPermissionGroup = memo<ToolPermissionGroupProps>(
 
     return (
       <div>
-        <div
-          style={{
-            alignItems: 'center',
-            display: 'flex',
-            gap: 8,
-            padding: '8px 0',
-          }}
-        >
-          <div
-            style={{ alignItems: 'center', cursor: 'pointer', display: 'flex', flex: 1, gap: 6 }}
-            onClick={() => setExpanded((e) => !e)}
-          >
+        <div className={styles.groupHeader} onClick={() => setExpanded((e) => !e)}>
+          <div className={styles.groupLabel}>
             {expanded ? <ChevronDownIcon size={14} /> : <ChevronRightIcon size={14} />}
-            <span style={{ fontWeight: 500 }}>{label}</span>
-            <span style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 12 }}>
-              {tools.length}
-            </span>
+            {label}
+            <span className={styles.badge}>{tools.length}</span>
           </div>
 
           <DropdownMenu items={batchItems}>
-            <span
-              style={{
-                color: 'var(--lobe-colors-neutral-500)',
-                cursor: 'pointer',
-                fontSize: 12,
-              }}
+            <Button
+              size="small"
+              style={{ fontSize: 12, height: 26 }}
+              onClick={(e) => e.stopPropagation()}
             >
-              {t('connector.permission.custom', 'Custom')} ▾
-            </span>
+              <MoreHorizontalIcon size={12} />
+              {t('connector.permission.custom', 'Custom')}
+              <ChevronDownIcon size={12} />
+            </Button>
           </DropdownMenu>
         </div>
 

--- a/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
+++ b/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
@@ -1,5 +1,5 @@
 import { createStaticStyles } from 'antd-style';
-import { BanIcon, CheckCircleIcon, HandIcon } from 'lucide-react';
+import { BanIcon, CheckIcon, HandIcon } from 'lucide-react';
 import { memo } from 'react';
 
 import { ConnectorToolPermission } from '@/database/schemas';
@@ -17,33 +17,34 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     height: 28px;
     border-radius: 6px;
 
-    color: ${cssVar.colorTextTertiary};
+    color: ${cssVar.colorTextQuaternary};
 
-    transition: all 0.15s;
+    transition:
+      color 0.15s,
+      background 0.15s;
 
     &:hover {
-      background: ${cssVar.colorFillTertiary};
+      color: ${cssVar.colorText};
+      background: ${cssVar.colorFillSecondary};
     }
   `,
   btnActive: css`
-    color: ${cssVar.colorPrimary};
-    background: ${cssVar.colorPrimaryBg};
-
-    &:hover {
-      background: ${cssVar.colorPrimaryBg};
-    }
+    color: ${cssVar.colorText};
   `,
   row: css`
     display: flex;
-    gap: 8px;
     align-items: center;
 
-    padding-block: 6px;
-    padding-inline: 0;
+    padding-block: 10px;
+    padding-inline: 12px;
     border-block-end: 1px solid ${cssVar.colorBorderSecondary};
 
     &:last-child {
       border-block-end: none;
+    }
+
+    &:hover {
+      background: ${cssVar.colorFillQuaternary};
     }
   `,
 }));
@@ -59,28 +60,30 @@ const ToolPermissionRow = memo<ToolPermissionRowProps>(({ tool, onPermissionChan
 
   return (
     <div className={styles.row}>
-      <span style={{ flex: 1, fontSize: 13 }}>{tool.toolName}</span>
+      <span style={{ flex: 1, fontFamily: 'var(--font-mono, monospace)', fontSize: 13 }}>
+        {tool.toolName}
+      </span>
       <div style={{ display: 'flex', gap: 2 }}>
         <div
           className={btnClass(ConnectorToolPermission.auto)}
           title="Auto — AI calls directly"
           onClick={() => onPermissionChange(tool.id, ConnectorToolPermission.auto)}
         >
-          <CheckCircleIcon size={14} />
+          <CheckIcon size={15} />
         </div>
         <div
           className={btnClass(ConnectorToolPermission.needs_approval)}
           title="Needs approval"
           onClick={() => onPermissionChange(tool.id, ConnectorToolPermission.needs_approval)}
         >
-          <HandIcon size={14} />
+          <HandIcon size={15} />
         </div>
         <div
           className={btnClass(ConnectorToolPermission.disabled)}
           title="Disabled — hidden from AI"
           onClick={() => onPermissionChange(tool.id, ConnectorToolPermission.disabled)}
         >
-          <BanIcon size={14} />
+          <BanIcon size={15} />
         </div>
       </div>
     </div>

--- a/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
+++ b/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
@@ -29,7 +29,13 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     }
   `,
   btnActive: css`
-    color: ${cssVar.colorText};
+    color: ${cssVar.colorPrimary};
+    background: ${cssVar.colorPrimaryBg};
+
+    &:hover {
+      color: ${cssVar.colorPrimary};
+      background: ${cssVar.colorPrimaryBgHover};
+    }
   `,
   row: css`
     display: flex;

--- a/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
+++ b/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
@@ -1,0 +1,100 @@
+import { createStaticStyles, cssVar } from 'antd-style';
+import { BanIcon, CheckCircleIcon, HandIcon } from 'lucide-react';
+import { memo } from 'react';
+
+import { ConnectorToolPermission } from '@/database/schemas';
+import type { ConnectorTool } from '@/store/tool/slices/connector';
+
+const useStyles = createStaticStyles(({ css }) => ({
+  btn: css`
+    cursor: pointer;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+
+    color: ${cssVar('colorTextTertiary')};
+
+    transition: all 0.15s;
+
+    &:hover {
+      background: ${cssVar('colorFillTertiary')};
+    }
+  `,
+  btnActive: css`
+    color: ${cssVar('colorPrimary')};
+    background: ${cssVar('colorPrimaryBg')};
+
+    &:hover {
+      background: ${cssVar('colorPrimaryBg')};
+    }
+  `,
+  row: css`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    padding-block: 6px;
+    padding-inline: 0;
+    border-block-end: 1px solid ${cssVar('colorBorderSecondary')};
+
+    &:last-child {
+      border-block-end: none;
+    }
+  `,
+}));
+
+interface ToolPermissionRowProps {
+  onPermissionChange: (toolId: string, permission: ConnectorToolPermission) => void;
+  tool: ConnectorTool;
+}
+
+const ToolPermissionRow = memo<ToolPermissionRowProps>(({ tool, onPermissionChange }) => {
+  const { styles, cx } = useStyles();
+
+  return (
+    <div className={styles.row}>
+      <span style={{ flex: 1, fontSize: 13 }}>{tool.toolName}</span>
+      <div style={{ display: 'flex', gap: 2 }}>
+        <div
+          className={cx(
+            styles.btn,
+            tool.permission === ConnectorToolPermission.auto && styles.btnActive,
+          )}
+          title="Auto — AI calls directly"
+          onClick={() => onPermissionChange(tool.id, ConnectorToolPermission.auto)}
+        >
+          <CheckCircleIcon size={14} />
+        </div>
+        <div
+          className={cx(
+            styles.btn,
+            tool.permission === ConnectorToolPermission.needs_approval && styles.btnActive,
+          )}
+          title="Needs approval"
+          onClick={() => onPermissionChange(tool.id, ConnectorToolPermission.needs_approval)}
+        >
+          <HandIcon size={14} />
+        </div>
+        <div
+          className={cx(
+            styles.btn,
+            tool.permission === ConnectorToolPermission.disabled && styles.btnActive,
+          )}
+          title="Disabled — hidden from AI"
+          onClick={() => onPermissionChange(tool.id, ConnectorToolPermission.disabled)}
+        >
+          <BanIcon size={14} />
+        </div>
+      </div>
+    </div>
+  );
+});
+
+ToolPermissionRow.displayName = 'ToolPermissionRow';
+
+export default ToolPermissionRow;

--- a/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
+++ b/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
@@ -1,11 +1,11 @@
-import { createStaticStyles, cssVar } from 'antd-style';
+import { createStaticStyles } from 'antd-style';
 import { BanIcon, CheckCircleIcon, HandIcon } from 'lucide-react';
 import { memo } from 'react';
 
 import { ConnectorToolPermission } from '@/database/schemas';
 import type { ConnectorTool } from '@/store/tool/slices/connector';
 
-const useStyles = createStaticStyles(({ css }) => ({
+const useStyles = createStaticStyles(({ css, cssVar }) => ({
   btn: css`
     cursor: pointer;
 
@@ -17,20 +17,20 @@ const useStyles = createStaticStyles(({ css }) => ({
     height: 28px;
     border-radius: 6px;
 
-    color: ${cssVar('colorTextTertiary')};
+    color: ${cssVar.colorTextTertiary};
 
     transition: all 0.15s;
 
     &:hover {
-      background: ${cssVar('colorFillTertiary')};
+      background: ${cssVar.colorFillTertiary};
     }
   `,
   btnActive: css`
-    color: ${cssVar('colorPrimary')};
-    background: ${cssVar('colorPrimaryBg')};
+    color: ${cssVar.colorPrimary};
+    background: ${cssVar.colorPrimaryBg};
 
     &:hover {
-      background: ${cssVar('colorPrimaryBg')};
+      background: ${cssVar.colorPrimaryBg};
     }
   `,
   row: css`
@@ -40,7 +40,7 @@ const useStyles = createStaticStyles(({ css }) => ({
 
     padding-block: 6px;
     padding-inline: 0;
-    border-block-end: 1px solid ${cssVar('colorBorderSecondary')};
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
 
     &:last-child {
       border-block-end: none;
@@ -61,31 +61,31 @@ const ToolPermissionRow = memo<ToolPermissionRowProps>(({ tool, onPermissionChan
       <span style={{ flex: 1, fontSize: 13 }}>{tool.toolName}</span>
       <div style={{ display: 'flex', gap: 2 }}>
         <div
+          title="Auto — AI calls directly"
           className={cx(
             styles.btn,
             tool.permission === ConnectorToolPermission.auto && styles.btnActive,
           )}
-          title="Auto — AI calls directly"
           onClick={() => onPermissionChange(tool.id, ConnectorToolPermission.auto)}
         >
           <CheckCircleIcon size={14} />
         </div>
         <div
+          title="Needs approval"
           className={cx(
             styles.btn,
             tool.permission === ConnectorToolPermission.needs_approval && styles.btnActive,
           )}
-          title="Needs approval"
           onClick={() => onPermissionChange(tool.id, ConnectorToolPermission.needs_approval)}
         >
           <HandIcon size={14} />
         </div>
         <div
+          title="Disabled — hidden from AI"
           className={cx(
             styles.btn,
             tool.permission === ConnectorToolPermission.disabled && styles.btnActive,
           )}
-          title="Disabled — hidden from AI"
           onClick={() => onPermissionChange(tool.id, ConnectorToolPermission.disabled)}
         >
           <BanIcon size={14} />

--- a/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
+++ b/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { BanIcon, CheckIcon, HandIcon } from 'lucide-react';
 import { memo } from 'react';
@@ -37,11 +38,26 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
       background: ${cssVar.colorPrimaryBgHover};
     }
   `,
+  description: css`
+    overflow: hidden;
+
+    font-size: 11px;
+    line-height: 1.4;
+    color: ${cssVar.colorTextTertiary};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  nameCell: css`
+    overflow: hidden;
+    flex: 1;
+    min-width: 0;
+  `,
   row: css`
     display: flex;
+    gap: 8px;
     align-items: center;
 
-    padding-block: 10px;
+    padding-block: 8px;
     padding-inline: 12px;
     border-block-end: 1px solid ${cssVar.colorBorderSecondary};
 
@@ -52,6 +68,15 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     &:hover {
       background: ${cssVar.colorFillQuaternary};
     }
+  `,
+  toolName: css`
+    overflow: hidden;
+
+    font-family: var(--font-mono, monospace);
+    font-size: 13px;
+    color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
   `,
 }));
 
@@ -66,10 +91,15 @@ const ToolPermissionRow = memo<ToolPermissionRowProps>(({ tool, onPermissionChan
 
   return (
     <div className={styles.row}>
-      <span style={{ flex: 1, fontFamily: 'var(--font-mono, monospace)', fontSize: 13 }}>
-        {tool.toolName}
-      </span>
-      <div style={{ display: 'flex', gap: 2 }}>
+      <div className={styles.nameCell}>
+        <div className={styles.toolName}>{tool.toolName}</div>
+        {tool.description && (
+          <Tooltip mouseEnterDelay={0.5} title={tool.description}>
+            <div className={styles.description}>{tool.description}</div>
+          </Tooltip>
+        )}
+      </div>
+      <div style={{ display: 'flex', gap: 2, flexShrink: 0 }}>
         <div
           className={btnClass(ConnectorToolPermission.auto)}
           title="Auto — AI calls directly"

--- a/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
+++ b/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
@@ -5,7 +5,7 @@ import { memo } from 'react';
 import { ConnectorToolPermission } from '@/database/schemas';
 import type { ConnectorTool } from '@/store/tool/slices/connector';
 
-const useStyles = createStaticStyles(({ css, cssVar }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   btn: css`
     cursor: pointer;
 
@@ -54,38 +54,30 @@ interface ToolPermissionRowProps {
 }
 
 const ToolPermissionRow = memo<ToolPermissionRowProps>(({ tool, onPermissionChange }) => {
-  const { styles, cx } = useStyles();
+  const btnClass = (permission: ConnectorToolPermission) =>
+    tool.permission === permission ? `${styles.btn} ${styles.btnActive}` : styles.btn;
 
   return (
     <div className={styles.row}>
       <span style={{ flex: 1, fontSize: 13 }}>{tool.toolName}</span>
       <div style={{ display: 'flex', gap: 2 }}>
         <div
+          className={btnClass(ConnectorToolPermission.auto)}
           title="Auto — AI calls directly"
-          className={cx(
-            styles.btn,
-            tool.permission === ConnectorToolPermission.auto && styles.btnActive,
-          )}
           onClick={() => onPermissionChange(tool.id, ConnectorToolPermission.auto)}
         >
           <CheckCircleIcon size={14} />
         </div>
         <div
+          className={btnClass(ConnectorToolPermission.needs_approval)}
           title="Needs approval"
-          className={cx(
-            styles.btn,
-            tool.permission === ConnectorToolPermission.needs_approval && styles.btnActive,
-          )}
           onClick={() => onPermissionChange(tool.id, ConnectorToolPermission.needs_approval)}
         >
           <HandIcon size={14} />
         </div>
         <div
+          className={btnClass(ConnectorToolPermission.disabled)}
           title="Disabled — hidden from AI"
-          className={cx(
-            styles.btn,
-            tool.permission === ConnectorToolPermission.disabled && styles.btnActive,
-          )}
           onClick={() => onPermissionChange(tool.id, ConnectorToolPermission.disabled)}
         >
           <BanIcon size={14} />

--- a/src/features/Connectors/ConnectorDetail/index.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.tsx
@@ -26,6 +26,7 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
   const syncConnectorTools = useToolStore((s) => s.syncConnectorTools);
   const syncBuiltinTool = useToolStore((s) => s.syncBuiltinTool);
   const syncPluginTools = useToolStore((s) => s.syncPluginTools);
+  const resetConnectorPermissions = useToolStore((s) => s.resetConnectorPermissions);
   const disconnectConnector = useToolStore((s) => s.disconnectConnector);
   const updateToolPermission = useToolStore((s) => s.updateToolPermission);
 
@@ -44,12 +45,11 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
 
   if (!connector) return null;
 
+  // Sync button label: re-sync tool list from manifest (does NOT reset permissions)
   const syncLabel =
-    connector?.sourceType === ConnectorSourceType.builtin
-      ? t('connector.reset', 'Reset')
-      : connector?.sourceType === ConnectorSourceType.marketplace
-        ? t('connector.refresh', 'Refresh')
-        : t('connector.sync', 'Sync');
+    connector?.sourceType === ConnectorSourceType.custom
+      ? t('connector.sync', 'Sync')
+      : t('connector.refresh', 'Refresh');
 
   const hasTools =
     readTools.length > 0 ||
@@ -75,6 +75,11 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
       >
         <div style={{ fontSize: 16, fontWeight: 600 }}>{connector.name}</div>
         <div style={{ display: 'flex', gap: 8 }}>
+          {/* Reset permissions: restore all tools to auto (fully open) */}
+          <Button size="small" onClick={() => resetConnectorPermissions(connectorId)}>
+            {t('connector.resetPermissions', 'Reset permissions')}
+          </Button>
+          {/* Sync/Refresh: re-sync tool list from manifest */}
           <Button
             icon={<RefreshCwIcon size={14} />}
             loading={syncing}

--- a/src/features/Connectors/ConnectorDetail/index.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.tsx
@@ -69,14 +69,7 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
           marginBottom: 16,
         }}
       >
-        <div>
-          <div style={{ fontSize: 16, fontWeight: 600 }}>{connector.name}</div>
-          {connector.metadata?.description && (
-            <div style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 13, marginTop: 2 }}>
-              {connector.metadata.description as string}
-            </div>
-          )}
-        </div>
+        <div style={{ fontSize: 16, fontWeight: 600 }}>{connector.name}</div>
         <div style={{ display: 'flex', gap: 8 }}>
           <Button
             icon={<RefreshCwIcon size={14} />}
@@ -94,13 +87,19 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
         </div>
       </div>
 
-      {/* Tool permissions section */}
-      <div style={{ marginBottom: 16 }}>
-        <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>Tool permissions</div>
-        <div style={{ color: 'var(--ant-color-text-tertiary)', fontSize: 13 }}>
-          Choose when AI is allowed to use these tools.
+      {/* Description */}
+      {connector.metadata?.description && (
+        <div
+          style={{
+            color: 'var(--ant-color-text-secondary)',
+            fontSize: 13,
+            lineHeight: 1.6,
+            marginBottom: 16,
+          }}
+        >
+          {connector.metadata.description as string}
         </div>
-      </div>
+      )}
 
       {hasTools ? (
         <div style={{ flex: 1, overflowY: 'auto' }}>

--- a/src/features/Connectors/ConnectorDetail/index.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.tsx
@@ -1,9 +1,10 @@
 import { Button } from 'antd';
 import { RefreshCwIcon } from 'lucide-react';
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { ConnectorToolPermission } from '@/database/schemas';
+import { ConnectorSourceType } from '@/database/schemas';
 import { useToolStore } from '@/store/tool';
 import { connectorSelectors } from '@/store/tool/slices/connector';
 
@@ -23,10 +24,34 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
   const syncing = useToolStore(connectorSelectors.isSyncing(connectorId));
 
   const syncConnectorTools = useToolStore((s) => s.syncConnectorTools);
+  const syncBuiltinTool = useToolStore((s) => s.syncBuiltinTool);
+  const syncPluginTools = useToolStore((s) => s.syncPluginTools);
   const disconnectConnector = useToolStore((s) => s.disconnectConnector);
   const updateToolPermission = useToolStore((s) => s.updateToolPermission);
 
+  const isMcpConnector = connector?.sourceType === ConnectorSourceType.custom;
+
+  const handleSync = useCallback(async () => {
+    if (!connector) return;
+    if (connector.sourceType === ConnectorSourceType.builtin) {
+      await syncBuiltinTool(connector.identifier);
+    } else if (connector.sourceType === ConnectorSourceType.marketplace) {
+      await syncPluginTools(connector.identifier);
+    } else {
+      await syncConnectorTools(connectorId);
+    }
+  }, [connector, connectorId, syncBuiltinTool, syncPluginTools, syncConnectorTools]);
+
   if (!connector) return null;
+
+  const syncLabel =
+    connector?.sourceType === ConnectorSourceType.builtin
+      ? t('connector.reset', 'Reset')
+      : connector?.sourceType === ConnectorSourceType.marketplace
+        ? t('connector.refresh', 'Refresh')
+        : t('connector.sync', 'Sync');
+
+  const hasTools = readTools.length > 0 || writeTools.length > 0;
 
   const handleBatchPermission = async (toolIds: string[], permission: ConnectorToolPermission) => {
     await Promise.all(toolIds.map((id) => updateToolPermission(id, permission)));
@@ -50,38 +75,47 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
             icon={<RefreshCwIcon size={14} />}
             loading={syncing}
             size="small"
-            onClick={() => syncConnectorTools(connectorId)}
+            onClick={handleSync}
           >
-            {t('connector.sync', 'Sync')}
+            {syncLabel}
           </Button>
-          <Button danger size="small" onClick={() => disconnectConnector(connectorId)}>
-            {t('connector.disconnect', 'Disconnect')}
-          </Button>
+          {isMcpConnector && (
+            <Button danger size="small" onClick={() => disconnectConnector(connectorId)}>
+              {t('connector.disconnect', 'Disconnect')}
+            </Button>
+          )}
         </div>
       </div>
 
       {/* Tool permissions */}
-      <div style={{ fontWeight: 500, marginBottom: 4 }}>
-        {t('connector.toolPermissions', 'Tool permissions')}
-      </div>
-      <div style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 12, marginBottom: 12 }}>
-        {t('connector.toolPermissionsDesc', 'Choose when AI is allowed to use these tools.')}
-      </div>
-
-      <div style={{ flex: 1, overflowY: 'auto' }}>
-        <ToolPermissionGroup
-          label={t('connector.readOnlyTools', 'Read-only tools')}
-          tools={readTools}
-          onBatchPermission={handleBatchPermission}
-          onPermissionChange={updateToolPermission}
-        />
-        <ToolPermissionGroup
-          label={t('connector.writeTools', 'Write/delete tools')}
-          tools={writeTools}
-          onBatchPermission={handleBatchPermission}
-          onPermissionChange={updateToolPermission}
-        />
-      </div>
+      {hasTools ? (
+        <>
+          <div style={{ fontWeight: 500, marginBottom: 4 }}>
+            {t('connector.toolPermissions', 'Tool permissions')}
+          </div>
+          <div style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 12, marginBottom: 12 }}>
+            {t('connector.toolPermissionsDesc', 'Choose when AI is allowed to use these tools.')}
+          </div>
+          <div style={{ flex: 1, overflowY: 'auto' }}>
+            <ToolPermissionGroup
+              label={t('connector.readOnlyTools', 'Read-only tools')}
+              tools={readTools}
+              onBatchPermission={handleBatchPermission}
+              onPermissionChange={updateToolPermission}
+            />
+            <ToolPermissionGroup
+              label={t('connector.writeTools', 'Write/delete tools')}
+              tools={writeTools}
+              onBatchPermission={handleBatchPermission}
+              onPermissionChange={updateToolPermission}
+            />
+          </div>
+        </>
+      ) : (
+        <div style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 14 }}>
+          {t('connector.noTools', 'No tool permissions to configure for this skill.')}
+        </div>
+      )}
     </div>
   );
 });

--- a/src/features/Connectors/ConnectorDetail/index.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.tsx
@@ -69,7 +69,14 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
           marginBottom: 16,
         }}
       >
-        <span style={{ fontSize: 16, fontWeight: 600 }}>{connector.name}</span>
+        <div>
+          <div style={{ fontSize: 16, fontWeight: 600 }}>{connector.name}</div>
+          {connector.metadata?.description && (
+            <div style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 13, marginTop: 2 }}>
+              {connector.metadata.description as string}
+            </div>
+          )}
+        </div>
         <div style={{ display: 'flex', gap: 8 }}>
           <Button
             icon={<RefreshCwIcon size={14} />}

--- a/src/features/Connectors/ConnectorDetail/index.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.tsx
@@ -97,7 +97,7 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
       </div>
 
       {/* Description */}
-      {connector.metadata?.description && (
+      {typeof connector.metadata?.description === 'string' && connector.metadata.description && (
         <div
           style={{
             color: 'var(--ant-color-text-secondary)',
@@ -106,7 +106,7 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
             marginBottom: 16,
           }}
         >
-          {String(connector.metadata.description)}
+          {connector.metadata.description}
         </div>
       )}
 

--- a/src/features/Connectors/ConnectorDetail/index.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.tsx
@@ -94,7 +94,14 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
         </div>
       </div>
 
-      {/* Tool permission editor */}
+      {/* Tool permissions section */}
+      <div style={{ marginBottom: 16 }}>
+        <div style={{ fontSize: 14, fontWeight: 600, marginBottom: 4 }}>Tool permissions</div>
+        <div style={{ color: 'var(--ant-color-text-tertiary)', fontSize: 13 }}>
+          Choose when AI is allowed to use these tools.
+        </div>
+      </div>
+
       {hasTools ? (
         <div style={{ flex: 1, overflowY: 'auto' }}>
           <ToolPermissionGroup

--- a/src/features/Connectors/ConnectorDetail/index.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.tsx
@@ -18,7 +18,7 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
   const { t } = useTranslation('tool');
 
   const connector = useToolStore(connectorSelectors.connectorById(connectorId));
-  const { readTools, writeTools } = useToolStore(
+  const { readTools, createTools, updateTools, deleteTools } = useToolStore(
     connectorSelectors.connectorToolsGrouped(connectorId),
   );
   const syncing = useToolStore(connectorSelectors.isSyncing(connectorId));
@@ -51,7 +51,11 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
         ? t('connector.refresh', 'Refresh')
         : t('connector.sync', 'Sync');
 
-  const hasTools = readTools.length > 0 || writeTools.length > 0;
+  const hasTools =
+    readTools.length > 0 ||
+    createTools.length > 0 ||
+    updateTools.length > 0 ||
+    deleteTools.length > 0;
 
   const handleBatchPermission = async (toolIds: string[], permission: ConnectorToolPermission) => {
     await Promise.all(toolIds.map((id) => updateToolPermission(id, permission)));
@@ -110,8 +114,20 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
             onPermissionChange={updateToolPermission}
           />
           <ToolPermissionGroup
-            label={t('connector.writeTools', 'Write/delete tools')}
-            tools={writeTools}
+            label={t('connector.createTools', 'Create tools')}
+            tools={createTools}
+            onBatchPermission={handleBatchPermission}
+            onPermissionChange={updateToolPermission}
+          />
+          <ToolPermissionGroup
+            label={t('connector.updateTools', 'Update tools')}
+            tools={updateTools}
+            onBatchPermission={handleBatchPermission}
+            onPermissionChange={updateToolPermission}
+          />
+          <ToolPermissionGroup
+            label={t('connector.deleteTools', 'Delete tools')}
+            tools={deleteTools}
             onBatchPermission={handleBatchPermission}
             onPermissionChange={updateToolPermission}
           />

--- a/src/features/Connectors/ConnectorDetail/index.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.tsx
@@ -1,0 +1,91 @@
+import { Button } from 'antd';
+import { RefreshCwIcon } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { ConnectorToolPermission } from '@/database/schemas';
+import { useToolStore } from '@/store/tool';
+import { connectorSelectors } from '@/store/tool/slices/connector';
+
+import ToolPermissionGroup from './ToolPermissionGroup';
+
+interface ConnectorDetailProps {
+  connectorId: string;
+}
+
+const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
+  const { t } = useTranslation('tool');
+
+  const connector = useToolStore(connectorSelectors.connectorById(connectorId));
+  const { readTools, writeTools } = useToolStore(
+    connectorSelectors.connectorToolsGrouped(connectorId),
+  );
+  const syncing = useToolStore(connectorSelectors.isSyncing(connectorId));
+
+  const syncConnectorTools = useToolStore((s) => s.syncConnectorTools);
+  const disconnectConnector = useToolStore((s) => s.disconnectConnector);
+  const updateToolPermission = useToolStore((s) => s.updateToolPermission);
+
+  if (!connector) return null;
+
+  const handleBatchPermission = async (toolIds: string[], permission: ConnectorToolPermission) => {
+    await Promise.all(toolIds.map((id) => updateToolPermission(id, permission)));
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', padding: 16 }}>
+      {/* Header */}
+      <div
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          gap: 8,
+          justifyContent: 'space-between',
+          marginBottom: 16,
+        }}
+      >
+        <span style={{ fontSize: 16, fontWeight: 600 }}>{connector.name}</span>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <Button
+            icon={<RefreshCwIcon size={14} />}
+            loading={syncing}
+            size="small"
+            onClick={() => syncConnectorTools(connectorId)}
+          >
+            {t('connector.sync', 'Sync')}
+          </Button>
+          <Button danger size="small" onClick={() => disconnectConnector(connectorId)}>
+            {t('connector.disconnect', 'Disconnect')}
+          </Button>
+        </div>
+      </div>
+
+      {/* Tool permissions */}
+      <div style={{ fontWeight: 500, marginBottom: 4 }}>
+        {t('connector.toolPermissions', 'Tool permissions')}
+      </div>
+      <div style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 12, marginBottom: 12 }}>
+        {t('connector.toolPermissionsDesc', 'Choose when AI is allowed to use these tools.')}
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        <ToolPermissionGroup
+          label={t('connector.readOnlyTools', 'Read-only tools')}
+          tools={readTools}
+          onBatchPermission={handleBatchPermission}
+          onPermissionChange={updateToolPermission}
+        />
+        <ToolPermissionGroup
+          label={t('connector.writeTools', 'Write/delete tools')}
+          tools={writeTools}
+          onBatchPermission={handleBatchPermission}
+          onPermissionChange={updateToolPermission}
+        />
+      </div>
+    </div>
+  );
+});
+
+ConnectorDetail.displayName = 'ConnectorDetail';
+
+export default ConnectorDetail;

--- a/src/features/Connectors/ConnectorDetail/index.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.tsx
@@ -87,33 +87,25 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
         </div>
       </div>
 
-      {/* Tool permissions */}
+      {/* Tool permission editor */}
       {hasTools ? (
-        <>
-          <div style={{ fontWeight: 500, marginBottom: 4 }}>
-            {t('connector.toolPermissions', 'Tool permissions')}
-          </div>
-          <div style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 12, marginBottom: 12 }}>
-            {t('connector.toolPermissionsDesc', 'Choose when AI is allowed to use these tools.')}
-          </div>
-          <div style={{ flex: 1, overflowY: 'auto' }}>
-            <ToolPermissionGroup
-              label={t('connector.readOnlyTools', 'Read-only tools')}
-              tools={readTools}
-              onBatchPermission={handleBatchPermission}
-              onPermissionChange={updateToolPermission}
-            />
-            <ToolPermissionGroup
-              label={t('connector.writeTools', 'Write/delete tools')}
-              tools={writeTools}
-              onBatchPermission={handleBatchPermission}
-              onPermissionChange={updateToolPermission}
-            />
-          </div>
-        </>
+        <div style={{ flex: 1, overflowY: 'auto' }}>
+          <ToolPermissionGroup
+            label={t('connector.readOnlyTools', 'Read-only tools')}
+            tools={readTools}
+            onBatchPermission={handleBatchPermission}
+            onPermissionChange={updateToolPermission}
+          />
+          <ToolPermissionGroup
+            label={t('connector.writeTools', 'Write/delete tools')}
+            tools={writeTools}
+            onBatchPermission={handleBatchPermission}
+            onPermissionChange={updateToolPermission}
+          />
+        </div>
       ) : (
         <div style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 14 }}>
-          {t('connector.noTools', 'No tool permissions to configure for this skill.')}
+          {t('connector.noTools', 'No tool permissions to configure.')}
         </div>
       )}
     </div>

--- a/src/features/Connectors/ConnectorDetail/index.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.tsx
@@ -106,7 +106,7 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId }) => {
             marginBottom: 16,
           }}
         >
-          {connector.metadata.description as string}
+          {String(connector.metadata.description)}
         </div>
       )}
 

--- a/src/features/Connectors/ConnectorList/ConnectorItem.tsx
+++ b/src/features/Connectors/ConnectorList/ConnectorItem.tsx
@@ -1,0 +1,49 @@
+import { createStaticStyles, cssVar } from 'antd-style';
+import { LinkIcon } from 'lucide-react';
+import { memo } from 'react';
+
+import type { ConnectorWithTools } from '@/store/tool/slices/connector';
+
+const useStyles = createStaticStyles(({ css }) => ({
+  active: css`
+    background: ${cssVar('colorFillSecondary')};
+  `,
+  item: css`
+    cursor: pointer;
+
+    display: flex;
+    gap: 8px;
+    align-items: center;
+
+    margin-block: 0;
+    margin-inline: 4px;
+    padding-block: 6px;
+    padding-inline: 12px;
+    border-radius: 6px;
+
+    &:hover {
+      background: ${cssVar('colorFillTertiary')};
+    }
+  `,
+}));
+
+interface ConnectorItemProps {
+  active?: boolean;
+  connector: ConnectorWithTools;
+  onClick: () => void;
+}
+
+const ConnectorItem = memo<ConnectorItemProps>(({ connector, active, onClick }) => {
+  const { styles, cx } = useStyles();
+
+  return (
+    <div className={cx(styles.item, active && styles.active)} onClick={onClick}>
+      <LinkIcon size={14} />
+      <span style={{ flex: 1, fontSize: 14 }}>{connector.name}</span>
+    </div>
+  );
+});
+
+ConnectorItem.displayName = 'ConnectorItem';
+
+export default ConnectorItem;

--- a/src/features/Connectors/ConnectorList/ConnectorItem.tsx
+++ b/src/features/Connectors/ConnectorList/ConnectorItem.tsx
@@ -1,12 +1,12 @@
-import { createStaticStyles, cssVar } from 'antd-style';
+import { createStaticStyles } from 'antd-style';
 import { LinkIcon } from 'lucide-react';
 import { memo } from 'react';
 
 import type { ConnectorWithTools } from '@/store/tool/slices/connector';
 
-const useStyles = createStaticStyles(({ css }) => ({
+const useStyles = createStaticStyles(({ css, cssVar }) => ({
   active: css`
-    background: ${cssVar('colorFillSecondary')};
+    background: ${cssVar.colorFillSecondary};
   `,
   item: css`
     cursor: pointer;
@@ -22,7 +22,7 @@ const useStyles = createStaticStyles(({ css }) => ({
     border-radius: 6px;
 
     &:hover {
-      background: ${cssVar('colorFillTertiary')};
+      background: ${cssVar.colorFillTertiary};
     }
   `,
 }));

--- a/src/features/Connectors/ConnectorList/ConnectorItem.tsx
+++ b/src/features/Connectors/ConnectorList/ConnectorItem.tsx
@@ -4,7 +4,7 @@ import { memo } from 'react';
 
 import type { ConnectorWithTools } from '@/store/tool/slices/connector';
 
-const useStyles = createStaticStyles(({ css, cssVar }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   active: css`
     background: ${cssVar.colorFillSecondary};
   `,
@@ -34,10 +34,10 @@ interface ConnectorItemProps {
 }
 
 const ConnectorItem = memo<ConnectorItemProps>(({ connector, active, onClick }) => {
-  const { styles, cx } = useStyles();
+  const itemClass = active ? `${styles.item} ${styles.active}` : styles.item;
 
   return (
-    <div className={cx(styles.item, active && styles.active)} onClick={onClick}>
+    <div className={itemClass} onClick={onClick}>
       <LinkIcon size={14} />
       <span style={{ flex: 1, fontSize: 14 }}>{connector.name}</span>
     </div>

--- a/src/features/Connectors/ConnectorList/index.tsx
+++ b/src/features/Connectors/ConnectorList/index.tsx
@@ -1,0 +1,81 @@
+import { ActionIcon } from '@lobehub/ui';
+import { PlusIcon } from 'lucide-react';
+import { memo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useToolStore } from '@/store/tool';
+import { connectorSelectors } from '@/store/tool/slices/connector';
+
+import AddConnectorModal from '../AddConnectorModal';
+import ConnectorItem from './ConnectorItem';
+
+interface ConnectorListProps {
+  onSelect: (id: string) => void;
+  selectedId?: string;
+}
+
+const ConnectorList = memo<ConnectorListProps>(({ onSelect, selectedId }) => {
+  const { t } = useTranslation('tool');
+  const [showAdd, setShowAdd] = useState(false);
+
+  const connected = useToolStore(connectorSelectors.connectedConnectors);
+  const notConnected = useToolStore(connectorSelectors.notConnectedConnectors);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4, padding: '8px 0' }}>
+      <div
+        style={{
+          alignItems: 'center',
+          display: 'flex',
+          justifyContent: 'space-between',
+          padding: '0 12px 4px',
+        }}
+      >
+        <span style={{ fontWeight: 600 }}>{t('connector.title', 'Connectors')}</span>
+        <ActionIcon icon={PlusIcon} size="small" onClick={() => setShowAdd(true)} />
+      </div>
+
+      {connected.length > 0 && (
+        <div>
+          <div
+            style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 12, padding: '4px 12px' }}
+          >
+            {t('connector.connected', 'Connected')}
+          </div>
+          {connected.map((c) => (
+            <ConnectorItem
+              active={c.id === selectedId}
+              connector={c}
+              key={c.id}
+              onClick={() => onSelect(c.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {notConnected.length > 0 && (
+        <div>
+          <div
+            style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 12, padding: '4px 12px' }}
+          >
+            {t('connector.notConnected', 'Not connected')}
+          </div>
+          {notConnected.map((c) => (
+            <ConnectorItem
+              active={c.id === selectedId}
+              connector={c}
+              key={c.id}
+              onClick={() => onSelect(c.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      <AddConnectorModal open={showAdd} onClose={() => setShowAdd(false)} />
+    </div>
+  );
+});
+
+ConnectorList.displayName = 'ConnectorList';
+
+export default ConnectorList;

--- a/src/features/Connectors/Connectors.tsx
+++ b/src/features/Connectors/Connectors.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+
+import { useToolStore } from '@/store/tool';
+
+import ConnectorDetail from './ConnectorDetail';
+import ConnectorList from './ConnectorList';
+
+const Connectors = () => {
+  const [selectedId, setSelectedId] = useState<string | undefined>();
+  const fetchConnectors = useToolStore((s) => s.fetchConnectors);
+  const isInit = useToolStore((s) => s.isConnectorsInit);
+  const connectors = useToolStore((s) => s.connectors);
+
+  useEffect(() => {
+    fetchConnectors();
+  }, [fetchConnectors]);
+
+  // Auto-select first connector
+  useEffect(() => {
+    if (!selectedId && connectors.length > 0) {
+      setSelectedId(connectors[0].id);
+    }
+  }, [connectors, selectedId]);
+
+  if (!isInit) return null;
+
+  return (
+    <div style={{ display: 'flex', height: '100%' }}>
+      <div
+        style={{
+          borderRight: '1px solid var(--lobe-colors-border)',
+          minWidth: 220,
+          overflowY: 'auto',
+          width: 220,
+        }}
+      >
+        <ConnectorList selectedId={selectedId} onSelect={setSelectedId} />
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {selectedId && <ConnectorDetail connectorId={selectedId} />}
+      </div>
+    </div>
+  );
+};
+
+export default Connectors;

--- a/src/features/Connectors/index.ts
+++ b/src/features/Connectors/index.ts
@@ -1,0 +1,3 @@
+export { default as ConnectorDetail } from './ConnectorDetail';
+export { default as ConnectorList } from './ConnectorList';
+export { default as Connectors } from './Connectors';

--- a/src/features/Connectors/index.ts
+++ b/src/features/Connectors/index.ts
@@ -1,3 +1,4 @@
+export { default as AddConnectorModal } from './AddConnectorModal';
 export { default as ConnectorDetail } from './ConnectorDetail';
 export { default as ConnectorList } from './ConnectorList';
 export { default as Connectors } from './Connectors';

--- a/src/libs/mcp/buildConnectorManifests.ts
+++ b/src/libs/mcp/buildConnectorManifests.ts
@@ -1,11 +1,11 @@
-import type { LobeToolManifest } from '@lobechat/types';
+import type { ToolManifest } from '@lobechat/types';
 
 import type { DecryptedConnector } from '@/database/models/connector';
 import type { UserConnectorToolItem } from '@/database/schemas';
 import { ConnectorToolPermission } from '@/database/schemas';
 
 /**
- * Convert connector DB rows into LobeToolManifest entries suitable for
+ * Convert connector DB rows into ToolManifest entries suitable for
  * injection into the server AgentToolsEngine as additionalManifests.
  *
  * Permission mapping:
@@ -16,7 +16,7 @@ import { ConnectorToolPermission } from '@/database/schemas';
 export function buildConnectorManifests(
   connectors: DecryptedConnector[],
   tools: UserConnectorToolItem[],
-): LobeToolManifest[] {
+): ToolManifest[] {
   const toolsByConnector = new Map<string, UserConnectorToolItem[]>();
   for (const tool of tools) {
     const list = toolsByConnector.get(tool.userConnectorId) ?? [];
@@ -24,7 +24,7 @@ export function buildConnectorManifests(
     toolsByConnector.set(tool.userConnectorId, list);
   }
 
-  const manifests: LobeToolManifest[] = [];
+  const manifests: ToolManifest[] = [];
 
   for (const connector of connectors) {
     if (!connector.isEnabled) continue;

--- a/src/libs/mcp/buildConnectorManifests.ts
+++ b/src/libs/mcp/buildConnectorManifests.ts
@@ -1,0 +1,102 @@
+import type { LobeToolManifest } from '@lobechat/types';
+
+import type { DecryptedConnector } from '@/database/models/connector';
+import type { UserConnectorToolItem } from '@/database/schemas';
+import { ConnectorToolPermission } from '@/database/schemas';
+
+/**
+ * Convert connector DB rows into LobeToolManifest entries suitable for
+ * injection into the server AgentToolsEngine as additionalManifests.
+ *
+ * Permission mapping:
+ * - 'auto'           → humanIntervention: undefined (AI calls freely)
+ * - 'needs_approval' → humanIntervention: 'required' (human must confirm)
+ * - 'disabled'       → tool excluded from manifest (AI cannot see it)
+ */
+export function buildConnectorManifests(
+  connectors: DecryptedConnector[],
+  tools: UserConnectorToolItem[],
+): LobeToolManifest[] {
+  const toolsByConnector = new Map<string, UserConnectorToolItem[]>();
+  for (const tool of tools) {
+    const list = toolsByConnector.get(tool.userConnectorId) ?? [];
+    list.push(tool);
+    toolsByConnector.set(tool.userConnectorId, list);
+  }
+
+  const manifests: LobeToolManifest[] = [];
+
+  for (const connector of connectors) {
+    if (!connector.isEnabled) continue;
+
+    const connectorTools = toolsByConnector.get(connector.id) ?? [];
+    const visibleTools = connectorTools.filter(
+      (t) => t.permission !== ConnectorToolPermission.disabled,
+    );
+
+    if (visibleTools.length === 0) continue;
+
+    const api = visibleTools.map((t) => ({
+      description: t.description ?? '',
+      humanIntervention:
+        t.permission === ConnectorToolPermission.needs_approval ? ('required' as const) : undefined,
+      name: t.toolName,
+      parameters: (t.inputSchema ?? { properties: {}, type: 'object' }) as Record<string, unknown>,
+    }));
+
+    const mcpParams = buildMcpParams(connector);
+
+    manifests.push({
+      api,
+      identifier: connector.identifier,
+      // @ts-ignore — mcpParams is a runtime-only field not in the public type
+      mcpParams,
+      meta: {
+        avatar: 'MCP_AVATAR',
+        description: `${connector.name} connector with ${api.length} tools`,
+        title: connector.name,
+      },
+      type: 'mcp' as any,
+    });
+  }
+
+  return manifests;
+}
+
+function buildMcpParams(connector: DecryptedConnector) {
+  const auth = buildAuthFromCredentials(connector);
+
+  if (connector.mcpConnectionType === 'stdio') {
+    return {
+      args: connector.mcpStdioConfig?.args ?? [],
+      command: connector.mcpStdioConfig?.command ?? '',
+      env: connector.mcpStdioConfig?.env,
+      name: connector.identifier,
+      type: 'stdio' as const,
+    };
+  }
+
+  return {
+    auth,
+    name: connector.identifier,
+    type: 'http' as const,
+    url: connector.mcpServerUrl ?? '',
+  };
+}
+
+function buildAuthFromCredentials(connector: DecryptedConnector) {
+  const creds = connector.credentials;
+  if (!creds) return undefined;
+
+  switch (creds.type) {
+    case 'oauth2': {
+      return { accessToken: creds.accessToken, type: 'oauth2' as const };
+    }
+    case 'bearer': {
+      return { token: creds.token, type: 'bearer' as const };
+    }
+    default: {
+      return undefined;
+    }
+  }
+}

--- a/src/libs/mcp/buildConnectorManifests.ts
+++ b/src/libs/mcp/buildConnectorManifests.ts
@@ -30,19 +30,40 @@ export function buildConnectorManifests(
     if (!connector.isEnabled) continue;
 
     const connectorTools = toolsByConnector.get(connector.id) ?? [];
-    const visibleTools = connectorTools.filter(
-      (t) => t.permission !== ConnectorToolPermission.disabled,
-    );
 
-    if (visibleTools.length === 0) continue;
+    // Include ALL tools in the manifest so the AI is aware of their existence.
+    // Disabled tools get a blocking description so the AI knows not to call them.
+    // At execution time, the callTool endpoint will double-check and hard-block disabled tools.
+    if (connectorTools.length === 0) continue;
 
-    const api = visibleTools.map((t) => ({
-      description: t.description ?? '',
-      humanIntervention:
-        t.permission === ConnectorToolPermission.needs_approval ? ('required' as const) : undefined,
-      name: t.toolName,
-      parameters: (t.inputSchema ?? { properties: {}, type: 'object' }) as Record<string, unknown>,
-    }));
+    const api = connectorTools.map((t) => {
+      if (t.permission === ConnectorToolPermission.disabled) {
+        return {
+          description:
+            `[TOOL DISABLED] The user has disabled this tool and it cannot be executed. ` +
+            `Do NOT call this tool. If the user asks to perform this action, inform them ` +
+            `that they have manually disabled "${t.toolName}" and can re-enable it in Settings > Connectors.`,
+          humanIntervention: 'required' as const,
+          name: t.toolName,
+          parameters: (t.inputSchema ?? { properties: {}, type: 'object' }) as Record<
+            string,
+            unknown
+          >,
+        };
+      }
+      return {
+        description: t.description ?? '',
+        humanIntervention:
+          t.permission === ConnectorToolPermission.needs_approval
+            ? ('required' as const)
+            : undefined,
+        name: t.toolName,
+        parameters: (t.inputSchema ?? { properties: {}, type: 'object' }) as Record<
+          string,
+          unknown
+        >,
+      };
+    });
 
     const mcpParams = buildMcpParams(connector);
 

--- a/src/libs/mcp/buildConnectorManifests.ts
+++ b/src/libs/mcp/buildConnectorManifests.ts
@@ -11,7 +11,7 @@ import { ConnectorToolPermission } from '@/database/schemas';
  * Permission mapping:
  * - 'auto'           → humanIntervention: undefined (AI calls freely)
  * - 'needs_approval' → humanIntervention: 'required' (human must confirm)
- * - 'disabled'       → tool excluded from manifest (AI cannot see it)
+ * - 'disabled'       → tool included with blocking description; AI knows it exists but is told it cannot be called
  */
 export function buildConnectorManifests(
   connectors: DecryptedConnector[],

--- a/src/libs/mcp/connectorPermissionCheck.ts
+++ b/src/libs/mcp/connectorPermissionCheck.ts
@@ -1,0 +1,88 @@
+import type { LobeChatDatabase } from '@lobechat/database';
+
+import { ConnectorModel } from '@/database/models/connector';
+import { ConnectorToolModel } from '@/database/models/connectorTool';
+import { ConnectorToolPermission } from '@/database/schemas';
+
+/**
+ * Look up the user's permission setting for a specific connector tool.
+ *
+ * @param db        - Server DB instance
+ * @param userId    - Authenticated user ID
+ * @param identifier - Connector identifier (e.g. 'gmail', 'vercel')
+ * @param toolName  - Tool API name (e.g. 'gmail_search_emails', 'deploy')
+ *
+ * Returns the stored permission, or null if no connector/tool entry exists.
+ */
+export async function getConnectorToolPermission(
+  db: LobeChatDatabase,
+  userId: string,
+  identifier: string,
+  toolName: string,
+): Promise<ConnectorToolPermission | null> {
+  try {
+    const connectorModel = new ConnectorModel(db, userId);
+    const [connector] = await connectorModel.queryByIdentifiers([identifier]);
+    if (!connector) return null;
+
+    const toolModel = new ConnectorToolModel(db, userId);
+    const tools = await toolModel.queryByConnector(connector.id);
+    return tools.find((t) => t.toolName === toolName)?.permission ?? null;
+  } catch {
+    return null; // never block execution due to DB error
+  }
+}
+
+/** Standardised blocked-tool response returned to the AI. */
+export function buildBlockedToolResponse(toolName: string): {
+  content: string;
+  state: { content: [{ text: string; type: 'text' }]; isError: boolean };
+  success: boolean;
+} {
+  const message =
+    `The tool "${toolName}" has been disabled by the user and cannot be executed. ` +
+    `Please inform the user that this tool is currently disabled and can be re-enabled in Settings > Connectors.`;
+  return {
+    content: message,
+    state: { content: [{ text: message, type: 'text' }], isError: false },
+    success: true,
+  };
+}
+
+/**
+ * Patch a LobeToolManifest's api[] with connector tool permissions.
+ *
+ * - needs_approval → humanIntervention: 'required'  (handled by intervention system)
+ * - disabled       → blocking description + humanIntervention: 'required'
+ *   (AI sees the tool is disabled; executor-level check also prevents execution)
+ */
+export function patchManifestWithPermissions(
+  manifest: {
+    api: Array<{
+      description?: string;
+      humanIntervention?: unknown;
+      name: string;
+      [k: string]: unknown;
+    }>;
+  },
+  toolPermissions: Map<string, ConnectorToolPermission>,
+): typeof manifest {
+  const patchedApi = manifest.api.map((api) => {
+    const permission = toolPermissions.get(api.name);
+    if (permission === ConnectorToolPermission.disabled) {
+      return {
+        ...api,
+        description:
+          `[TOOL DISABLED] The user has disabled this tool and it cannot be executed. ` +
+          `Do NOT call this tool. If the user asks to perform this action, inform them ` +
+          `that they have manually disabled "${api.name}" and can re-enable it in Settings > Connectors.`,
+        humanIntervention: 'required' as const,
+      };
+    }
+    if (permission === ConnectorToolPermission.needs_approval) {
+      return { ...api, humanIntervention: 'required' as const };
+    }
+    return api;
+  });
+  return { ...manifest, api: patchedApi };
+}

--- a/src/libs/mcp/connectorPermissionCheck.ts
+++ b/src/libs/mcp/connectorPermissionCheck.ts
@@ -27,7 +27,9 @@ export async function getConnectorToolPermission(
 
     const toolModel = new ConnectorToolModel(db, userId);
     const tools = await toolModel.queryByConnector(connector.id);
-    return tools.find((t) => t.toolName === toolName)?.permission ?? null;
+    return (
+      (tools.find((t) => t.toolName === toolName)?.permission as ConnectorToolPermission) ?? null
+    );
   } catch {
     return null; // never block execution due to DB error
   }

--- a/src/libs/mcp/index.ts
+++ b/src/libs/mcp/index.ts
@@ -1,2 +1,3 @@
 export * from './client';
 export * from './types';
+export * from './utils';

--- a/src/libs/mcp/utils.ts
+++ b/src/libs/mcp/utils.ts
@@ -1,20 +1,23 @@
 import type { ToolCRUDType } from '@/database/schemas';
 
-const DELETE_PATTERN = /\b(?:delete|remove|destroy|drop|unlink|uninstall|clear|purge)\b/;
-const UPDATE_PATTERN = /\b(?:update|edit|modify|patch|set|change|rename|move)\b/;
-const READ_PATTERN =
-  /\b(?:get|list|read|fetch|search|find|check|describe|show|view|extract|query|count)\b/;
+// Prefix-based matching (anchored at ^) handles camelCase names like getReactions, listPins.
+// \b word-boundary fails on camelCase because adjacent word-chars share no boundary.
+const DELETE_PREFIX = /^(?:delete|remove|destroy|drop|unlink|uninstall|clear|purge)/;
+const UPDATE_PREFIX = /^(?:update|edit|modify|patch|set|change|rename|move)/;
+const READ_PREFIX =
+  /^(?:get|list|read|fetch|search|find|check|describe|show|view|extract|query|count)/;
 
 /**
  * Infer the CRUD operation type from an MCP tool name.
  *
- * Priority: delete > update > read > write (conservative default).
- * The 'write' fallback covers create/add/save/send/upload/post/publish etc.
+ * Uses prefix matching so camelCase names like getReactions, listPins, searchMessages
+ * are correctly classified as 'read'. Priority: delete > update > read > write.
+ * The 'write' fallback covers create/add/save/send/upload/post/connect etc.
  */
 export function inferCrudType(toolName: string): ToolCRUDType {
   const n = toolName.toLowerCase();
-  if (DELETE_PATTERN.test(n)) return 'delete';
-  if (UPDATE_PATTERN.test(n)) return 'update';
-  if (READ_PATTERN.test(n)) return 'read';
+  if (DELETE_PREFIX.test(n)) return 'delete';
+  if (UPDATE_PREFIX.test(n)) return 'update';
+  if (READ_PREFIX.test(n)) return 'read';
   return 'write';
 }

--- a/src/libs/mcp/utils.ts
+++ b/src/libs/mcp/utils.ts
@@ -1,0 +1,20 @@
+import type { ToolCRUDType } from '@/database/schemas';
+
+const DELETE_PATTERN = /\b(?:delete|remove|destroy|drop|unlink|uninstall|clear|purge)\b/;
+const UPDATE_PATTERN = /\b(?:update|edit|modify|patch|set|change|rename|move)\b/;
+const READ_PATTERN =
+  /\b(?:get|list|read|fetch|search|find|check|describe|show|view|extract|query|count)\b/;
+
+/**
+ * Infer the CRUD operation type from an MCP tool name.
+ *
+ * Priority: delete > update > read > write (conservative default).
+ * The 'write' fallback covers create/add/save/send/upload/post/publish etc.
+ */
+export function inferCrudType(toolName: string): ToolCRUDType {
+  const n = toolName.toLowerCase();
+  if (DELETE_PATTERN.test(n)) return 'delete';
+  if (UPDATE_PATTERN.test(n)) return 'update';
+  if (READ_PATTERN.test(n)) return 'read';
+  return 'write';
+}

--- a/src/routes/(main)/settings/connector/index.tsx
+++ b/src/routes/(main)/settings/connector/index.tsx
@@ -1,9 +1,0 @@
-'use client';
-
-import { Connectors } from '@/features/Connectors';
-
-const ConnectorSettingsPage = () => <Connectors />;
-
-ConnectorSettingsPage.displayName = 'ConnectorSettings';
-
-export default ConnectorSettingsPage;

--- a/src/routes/(main)/settings/connector/index.tsx
+++ b/src/routes/(main)/settings/connector/index.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { Connectors } from '@/features/Connectors';
+
+const ConnectorSettingsPage = () => <Connectors />;
+
+ConnectorSettingsPage.displayName = 'ConnectorSettings';
+
+export default ConnectorSettingsPage;

--- a/src/routes/(main)/settings/features/SettingsContent.tsx
+++ b/src/routes/(main)/settings/features/SettingsContent.tsx
@@ -67,7 +67,10 @@ const SettingsContent = ({ mobile, activeTab }: SettingsContentProps) => {
   return (
     <>
       {Object.keys(componentMap).map((tabKey) => {
-        const isFullWidth = tabKey === SettingsTabs.Provider || tabKey === SettingsTabs.Connector;
+        const isFullWidth =
+          tabKey === SettingsTabs.Provider ||
+          tabKey === SettingsTabs.Connector ||
+          tabKey === SettingsTabs.Skill;
         if (activeTab !== tabKey) return null;
         const content = renderComponent(tabKey);
         if (isFullWidth) return <Fragment key={tabKey}>{content}</Fragment>;

--- a/src/routes/(main)/settings/features/SettingsContent.tsx
+++ b/src/routes/(main)/settings/features/SettingsContent.tsx
@@ -67,10 +67,7 @@ const SettingsContent = ({ mobile, activeTab }: SettingsContentProps) => {
   return (
     <>
       {Object.keys(componentMap).map((tabKey) => {
-        const isFullWidth =
-          tabKey === SettingsTabs.Provider ||
-          tabKey === SettingsTabs.Connector ||
-          tabKey === SettingsTabs.Skill;
+        const isFullWidth = tabKey === SettingsTabs.Provider || tabKey === SettingsTabs.Skill;
         if (activeTab !== tabKey) return null;
         const content = renderComponent(tabKey);
         if (isFullWidth) return <Fragment key={tabKey}>{content}</Fragment>;

--- a/src/routes/(main)/settings/features/SettingsContent.tsx
+++ b/src/routes/(main)/settings/features/SettingsContent.tsx
@@ -67,10 +67,10 @@ const SettingsContent = ({ mobile, activeTab }: SettingsContentProps) => {
   return (
     <>
       {Object.keys(componentMap).map((tabKey) => {
-        const isProvider = tabKey === SettingsTabs.Provider;
+        const isFullWidth = tabKey === SettingsTabs.Provider || tabKey === SettingsTabs.Connector;
         if (activeTab !== tabKey) return null;
         const content = renderComponent(tabKey);
-        if (isProvider) return <Fragment key={tabKey}>{content}</Fragment>;
+        if (isFullWidth) return <Fragment key={tabKey}>{content}</Fragment>;
         return (
           <Fragment key={tabKey}>
             <NavHeader />

--- a/src/routes/(main)/settings/features/componentMap.ts
+++ b/src/routes/(main)/settings/features/componentMap.ts
@@ -71,6 +71,9 @@ export const componentMap = {
   [SettingsTabs.Skill]: dynamic(() => import('../skill'), {
     loading: loading('Settings > Skill'),
   }),
+  [SettingsTabs.Connector]: dynamic(() => import('../connector'), {
+    loading: loading('Settings > Connector'),
+  }),
 
   [SettingsTabs.Plans]: dynamic(() => import('@/business/client/BusinessSettingPages/Plans'), {
     loading: loading('Settings > Plans'),

--- a/src/routes/(main)/settings/features/componentMap.ts
+++ b/src/routes/(main)/settings/features/componentMap.ts
@@ -71,9 +71,6 @@ export const componentMap = {
   [SettingsTabs.Skill]: dynamic(() => import('../skill'), {
     loading: loading('Settings > Skill'),
   }),
-  [SettingsTabs.Connector]: dynamic(() => import('../connector'), {
-    loading: loading('Settings > Connector'),
-  }),
 
   [SettingsTabs.Plans]: dynamic(() => import('@/business/client/BusinessSettingPages/Plans'), {
     loading: loading('Settings > Plans'),

--- a/src/routes/(main)/settings/hooks/useCategory.tsx
+++ b/src/routes/(main)/settings/hooks/useCategory.tsx
@@ -16,7 +16,6 @@ import {
   KeyboardIcon,
   KeyIcon,
   KeyRound,
-  LinkIcon,
   Map,
   MessageCircleIcon,
   MonitorSmartphoneIcon,
@@ -161,11 +160,6 @@ export const useCategory = () => {
         icon: SkillsIcon,
         key: SettingsTabs.Skill,
         label: t('tab.skill'),
-      },
-      {
-        icon: LinkIcon,
-        key: SettingsTabs.Connector,
-        label: t('tab.connector', 'Connectors'),
       },
       {
         icon: BrainCircuit,

--- a/src/routes/(main)/settings/hooks/useCategory.tsx
+++ b/src/routes/(main)/settings/hooks/useCategory.tsx
@@ -16,6 +16,7 @@ import {
   KeyboardIcon,
   KeyIcon,
   KeyRound,
+  LinkIcon,
   Map,
   MessageCircleIcon,
   MonitorSmartphoneIcon,
@@ -160,6 +161,11 @@ export const useCategory = () => {
         icon: SkillsIcon,
         key: SettingsTabs.Skill,
         label: t('tab.skill'),
+      },
+      {
+        icon: LinkIcon,
+        key: SettingsTabs.Connector,
+        label: t('tab.connector', 'Connectors'),
       },
       {
         icon: BrainCircuit,

--- a/src/routes/(main)/settings/skill/features/AgentSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/AgentSkillItem.tsx
@@ -215,7 +215,7 @@ const AgentSkillItem = memo<AgentSkillItemProps>(({ skill, isSelected, onSelect 
             onClick={onSelect ? undefined : handleOpenDetail}
           >
             <div className={`${styles.icon} ${showDisconnected ? styles.disconnectedIcon : ''}`}>
-              {avatar ? <Avatar avatar={avatar} size={22} /> : <Icon icon={SkillsIcon} size={18} />}
+              {avatar ? <Avatar avatar={avatar} size={16} /> : <Icon icon={SkillsIcon} size={16} />}
             </div>
             <span className={`${styles.title} ${showDisconnected ? styles.disconnectedTitle : ''}`}>
               {title}

--- a/src/routes/(main)/settings/skill/features/AgentSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/AgentSkillItem.tsx
@@ -9,7 +9,6 @@ import { DownloadIcon, MoreHorizontalIcon, Plus, Trash2 } from 'lucide-react';
 import { lazy, memo, Suspense, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import SkillSourceTag from '@/components/SkillSourceTag';
 import { createBuiltinAgentSkillDetailModal } from '@/features/SkillStore/SkillDetail';
 import { agentSkillService } from '@/services/skill';
 import { useToolStore } from '@/store/tool';
@@ -223,9 +222,7 @@ const AgentSkillItem = memo<AgentSkillItemProps>(({ skill, isSelected, onSelect 
           </Flexbox>
           {showDisconnected && renderStatus()}
         </Flexbox>
-        {onSelect ? (
-          <SkillSourceTag source={skill.source} />
-        ) : (
+        {!onSelect && (
           <Flexbox horizontal align="center" gap={8} onClick={stopPropagation}>
             {isBuiltin && isBuiltinInstalled && renderStatus()}
             {renderActions()}

--- a/src/routes/(main)/settings/skill/features/AgentSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/AgentSkillItem.tsx
@@ -1,16 +1,7 @@
 'use client';
 
 import { type BuiltinSkill, type SkillListItem } from '@lobechat/types';
-import {
-  Avatar,
-  Button,
-  DropdownMenu,
-  Flexbox,
-  Icon,
-  Modal,
-  stopPropagation,
-  Tag,
-} from '@lobehub/ui';
+import { Avatar, Button, DropdownMenu, Flexbox, Icon, Modal, stopPropagation } from '@lobehub/ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
 import { Space } from 'antd';
@@ -210,38 +201,32 @@ const AgentSkillItem = memo<AgentSkillItemProps>(({ skill, isSelected, onSelect 
         gap={16}
         justify="space-between"
         style={{
-          ...(isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : {}),
+          ...(isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 6 } : {}),
           ...(onSelect ? { cursor: 'pointer' } : {}),
         }}
         onClick={onSelect}
       >
-        <Flexbox horizontal align="center" gap={16} style={{ flex: 1, overflow: 'hidden' }}>
+        <Flexbox horizontal align="center" gap={8} style={{ flex: 1, overflow: 'hidden' }}>
           <Flexbox
             horizontal
             align="center"
-            gap={16}
+            gap={8}
             style={{ cursor: onSelect ? undefined : 'pointer' }}
             onClick={onSelect ? undefined : handleOpenDetail}
           >
             <div className={`${styles.icon} ${showDisconnected ? styles.disconnectedIcon : ''}`}>
-              {avatar ? <Avatar avatar={avatar} size={32} /> : <Icon icon={SkillsIcon} size={28} />}
+              {avatar ? <Avatar avatar={avatar} size={22} /> : <Icon icon={SkillsIcon} size={18} />}
             </div>
-            <Flexbox gap={4} style={{ overflow: 'hidden' }}>
-              <Flexbox horizontal align="center" gap={8}>
-                <span
-                  className={`${styles.title} ${showDisconnected ? styles.disconnectedTitle : ''}`}
-                >
-                  {title}
-                </span>
-                {!isBuiltin && <Tag icon={<Icon icon={SkillsIcon} />} size={'small'} />}
-                <SkillSourceTag source={skill.source} />
-              </Flexbox>
-              {showDisconnected && renderStatus()}
-            </Flexbox>
+            <span className={`${styles.title} ${showDisconnected ? styles.disconnectedTitle : ''}`}>
+              {title}
+            </span>
           </Flexbox>
+          {showDisconnected && renderStatus()}
         </Flexbox>
-        {!onSelect && (
-          <Flexbox horizontal align="center" gap={12} onClick={stopPropagation}>
+        {onSelect ? (
+          <SkillSourceTag source={skill.source} />
+        ) : (
+          <Flexbox horizontal align="center" gap={8} onClick={stopPropagation}>
             {isBuiltin && isBuiltinInstalled && renderStatus()}
             {renderActions()}
           </Flexbox>

--- a/src/routes/(main)/settings/skill/features/AgentSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/AgentSkillItem.tsx
@@ -34,10 +34,12 @@ const isBuiltinSkill = (skill: BuiltinSkill | SkillListItem): skill is BuiltinSk
   !('id' in skill);
 
 interface AgentSkillItemProps {
+  isSelected?: boolean;
+  onSelect?: () => void;
   skill: BuiltinSkill | SkillListItem;
 }
 
-const AgentSkillItem = memo<AgentSkillItemProps>(({ skill }) => {
+const AgentSkillItem = memo<AgentSkillItemProps>(({ skill, isSelected, onSelect }) => {
   const { t } = useTranslation('setting');
   const { t: tc } = useTranslation('common');
   const { t: tp } = useTranslation('plugin');
@@ -207,14 +209,19 @@ const AgentSkillItem = memo<AgentSkillItemProps>(({ skill }) => {
         className={styles.container}
         gap={16}
         justify="space-between"
+        style={{
+          ...(isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : {}),
+          ...(onSelect ? { cursor: 'pointer' } : {}),
+        }}
+        onClick={onSelect}
       >
         <Flexbox horizontal align="center" gap={16} style={{ flex: 1, overflow: 'hidden' }}>
           <Flexbox
             horizontal
             align="center"
             gap={16}
-            style={{ cursor: 'pointer' }}
-            onClick={handleOpenDetail}
+            style={{ cursor: onSelect ? undefined : 'pointer' }}
+            onClick={onSelect ? undefined : handleOpenDetail}
           >
             <div className={`${styles.icon} ${showDisconnected ? styles.disconnectedIcon : ''}`}>
               {avatar ? <Avatar avatar={avatar} size={32} /> : <Icon icon={SkillsIcon} size={28} />}
@@ -233,12 +240,14 @@ const AgentSkillItem = memo<AgentSkillItemProps>(({ skill }) => {
             </Flexbox>
           </Flexbox>
         </Flexbox>
-        <Flexbox horizontal align="center" gap={12} onClick={stopPropagation}>
-          {isBuiltin && isBuiltinInstalled && renderStatus()}
-          {renderActions()}
-        </Flexbox>
+        {!onSelect && (
+          <Flexbox horizontal align="center" gap={12} onClick={stopPropagation}>
+            {isBuiltin && isBuiltinInstalled && renderStatus()}
+            {renderActions()}
+          </Flexbox>
+        )}
       </Flexbox>
-      {renderDetailModal()}
+      {!onSelect && renderDetailModal()}
     </>
   );
 });

--- a/src/routes/(main)/settings/skill/features/BuiltinSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/BuiltinSkillItem.tsx
@@ -112,7 +112,7 @@ const BuiltinSkillItem = memo<BuiltinSkillItemProps>(
             onClick={onSelect ? undefined : () => createBuiltinSkillDetailModal({ identifier })}
           >
             <div className={`${styles.icon} ${!isInstalled ? styles.disconnectedIcon : ''}`}>
-              <Avatar avatar={avatar} size={22} />
+              <Avatar avatar={avatar} size={16} />
             </div>
             <span className={`${styles.title} ${!isInstalled ? styles.disconnectedTitle : ''}`}>
               {title}

--- a/src/routes/(main)/settings/skill/features/BuiltinSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/BuiltinSkillItem.tsx
@@ -6,7 +6,6 @@ import { MoreHorizontalIcon, Plus, Trash2 } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import SkillSourceTag from '@/components/SkillSourceTag';
 import { createBuiltinSkillDetailModal } from '@/features/SkillStore/SkillDetail';
 import { useToolStore } from '@/store/tool';
 import { builtinToolSelectors } from '@/store/tool/selectors';
@@ -120,9 +119,7 @@ const BuiltinSkillItem = memo<BuiltinSkillItemProps>(
           </Flexbox>
           {!isInstalled && renderStatus()}
         </Flexbox>
-        {onSelect ? (
-          <SkillSourceTag source="builtin" />
-        ) : (
+        {!onSelect && (
           <Flexbox horizontal align="center" gap={8} onClick={stopPropagation}>
             {isInstalled && renderStatus()}
             {renderActions()}

--- a/src/routes/(main)/settings/skill/features/BuiltinSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/BuiltinSkillItem.tsx
@@ -16,112 +16,121 @@ import { styles } from './style';
 interface BuiltinSkillItemProps {
   avatar?: string;
   identifier: string;
+  isSelected?: boolean;
+  onSelect?: () => void;
   title: string;
 }
 
-const BuiltinSkillItem = memo<BuiltinSkillItemProps>(({ identifier, title, avatar }) => {
-  const { t } = useTranslation(['setting', 'plugin', 'common']);
+const BuiltinSkillItem = memo<BuiltinSkillItemProps>(
+  ({ identifier, title, avatar, isSelected, onSelect }) => {
+    const { t } = useTranslation(['setting', 'plugin', 'common']);
 
-  const [installBuiltinTool, uninstallBuiltinTool, isInstalled] = useToolStore((s) => [
-    s.installBuiltinTool,
-    s.uninstallBuiltinTool,
-    builtinToolSelectors.isBuiltinToolInstalled(identifier)(s),
-  ]);
+    const [installBuiltinTool, uninstallBuiltinTool, isInstalled] = useToolStore((s) => [
+      s.installBuiltinTool,
+      s.uninstallBuiltinTool,
+      builtinToolSelectors.isBuiltinToolInstalled(identifier)(s),
+    ]);
 
-  const handleInstall = async () => {
-    await installBuiltinTool(identifier);
-  };
+    const handleInstall = async () => {
+      await installBuiltinTool(identifier);
+    };
 
-  const handleUninstall = () => {
-    confirmModal({
-      cancelText: t('cancel', { ns: 'common' }),
-      content: t('store.actions.confirmUninstall', { ns: 'plugin' }),
-      okButtonProps: { danger: true },
-      okText: t('store.actions.uninstall', { ns: 'plugin' }),
-      onOk: async () => {
-        await uninstallBuiltinTool(identifier);
-      },
-      title: t('store.actions.uninstall', { ns: 'plugin' }),
-    });
-  };
+    const handleUninstall = () => {
+      confirmModal({
+        cancelText: t('cancel', { ns: 'common' }),
+        content: t('store.actions.confirmUninstall', { ns: 'plugin' }),
+        okButtonProps: { danger: true },
+        okText: t('store.actions.uninstall', { ns: 'plugin' }),
+        onOk: async () => {
+          await uninstallBuiltinTool(identifier);
+        },
+        title: t('store.actions.uninstall', { ns: 'plugin' }),
+      });
+    };
 
-  const renderStatus = () => {
-    if (isInstalled) {
+    const renderStatus = () => {
+      if (isInstalled) {
+        return (
+          <span className={styles.connected}>
+            {t('tools.builtins.installed', { ns: 'setting' })}
+          </span>
+        );
+      }
       return (
-        <span className={styles.connected}>{t('tools.builtins.installed', { ns: 'setting' })}</span>
+        <span className={styles.disconnected}>
+          {t('tools.builtins.uninstalled', { ns: 'setting' })}
+        </span>
       );
-    }
-    return (
-      <span className={styles.disconnected}>
-        {t('tools.builtins.uninstalled', { ns: 'setting' })}
-      </span>
-    );
-  };
+    };
 
-  const renderActions = () => {
-    if (isInstalled) {
+    const renderActions = () => {
+      if (isInstalled) {
+        return (
+          <DropdownMenu
+            placement="bottomRight"
+            items={[
+              {
+                danger: true,
+                icon: <Icon icon={Trash2} />,
+                key: 'uninstall',
+                label: t('store.actions.uninstall', { ns: 'plugin' }),
+                onClick: handleUninstall,
+              },
+            ]}
+          >
+            <Button icon={MoreHorizontalIcon} />
+          </DropdownMenu>
+        );
+      }
+
       return (
-        <DropdownMenu
-          placement="bottomRight"
-          items={[
-            {
-              danger: true,
-              icon: <Icon icon={Trash2} />,
-              key: 'uninstall',
-              label: t('store.actions.uninstall', { ns: 'plugin' }),
-              onClick: handleUninstall,
-            },
-          ]}
-        >
-          <Button icon={MoreHorizontalIcon} />
-        </DropdownMenu>
+        <Button icon={Plus} onClick={handleInstall}>
+          {t('store.actions.install', { ns: 'plugin' })}
+        </Button>
       );
-    }
+    };
 
     return (
-      <Button icon={Plus} onClick={handleInstall}>
-        {t('store.actions.install', { ns: 'plugin' })}
-      </Button>
-    );
-  };
-
-  return (
-    <Flexbox
-      horizontal
-      align="center"
-      className={styles.container}
-      gap={16}
-      justify="space-between"
-    >
-      <Flexbox horizontal align="center" gap={16} style={{ flex: 1, overflow: 'hidden' }}>
-        <Flexbox
-          horizontal
-          align="center"
-          gap={16}
-          style={{ cursor: 'pointer' }}
-          onClick={() => createBuiltinSkillDetailModal({ identifier })}
-        >
-          <div className={`${styles.icon} ${!isInstalled ? styles.disconnectedIcon : ''}`}>
-            <Avatar avatar={avatar} size={32} />
-          </div>
-          <Flexbox gap={4} style={{ overflow: 'hidden' }}>
-            <Flexbox horizontal align="center" gap={8}>
-              <span className={`${styles.title} ${!isInstalled ? styles.disconnectedTitle : ''}`}>
-                {title}
-              </span>
-              <SkillSourceTag source="builtin" />
+      <Flexbox
+        horizontal
+        align="center"
+        className={styles.container}
+        gap={16}
+        justify="space-between"
+        style={
+          isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : undefined
+        }
+      >
+        <Flexbox horizontal align="center" gap={16} style={{ flex: 1, overflow: 'hidden' }}>
+          <Flexbox
+            horizontal
+            align="center"
+            gap={16}
+            style={{ cursor: 'pointer' }}
+            onClick={onSelect ?? (() => createBuiltinSkillDetailModal({ identifier }))}
+          >
+            <div className={`${styles.icon} ${!isInstalled ? styles.disconnectedIcon : ''}`}>
+              <Avatar avatar={avatar} size={32} />
+            </div>
+            <Flexbox gap={4} style={{ overflow: 'hidden' }}>
+              <Flexbox horizontal align="center" gap={8}>
+                <span className={`${styles.title} ${!isInstalled ? styles.disconnectedTitle : ''}`}>
+                  {title}
+                </span>
+                <SkillSourceTag source="builtin" />
+              </Flexbox>
+              {!isInstalled && renderStatus()}
             </Flexbox>
-            {!isInstalled && renderStatus()}
           </Flexbox>
         </Flexbox>
+        <Flexbox horizontal align="center" gap={12} onClick={stopPropagation}>
+          {isInstalled && renderStatus()}
+          {renderActions()}
+        </Flexbox>
       </Flexbox>
-      <Flexbox horizontal align="center" gap={12} onClick={stopPropagation}>
-        {isInstalled && renderStatus()}
-        {renderActions()}
-      </Flexbox>
-    </Flexbox>
-  );
-});
+    );
+  },
+);
 
 BuiltinSkillItem.displayName = 'BuiltinSkillItem';
 

--- a/src/routes/(main)/settings/skill/features/BuiltinSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/BuiltinSkillItem.tsx
@@ -97,17 +97,19 @@ const BuiltinSkillItem = memo<BuiltinSkillItemProps>(
         className={styles.container}
         gap={16}
         justify="space-between"
-        style={
-          isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : undefined
-        }
+        style={{
+          ...(isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : {}),
+          ...(onSelect ? { cursor: 'pointer' } : {}),
+        }}
+        onClick={onSelect}
       >
         <Flexbox horizontal align="center" gap={16} style={{ flex: 1, overflow: 'hidden' }}>
           <Flexbox
             horizontal
             align="center"
             gap={16}
-            style={{ cursor: 'pointer' }}
-            onClick={onSelect ?? (() => createBuiltinSkillDetailModal({ identifier }))}
+            style={{ cursor: onSelect ? undefined : 'pointer' }}
+            onClick={onSelect ? undefined : () => createBuiltinSkillDetailModal({ identifier })}
           >
             <div className={`${styles.icon} ${!isInstalled ? styles.disconnectedIcon : ''}`}>
               <Avatar avatar={avatar} size={32} />
@@ -123,10 +125,12 @@ const BuiltinSkillItem = memo<BuiltinSkillItemProps>(
             </Flexbox>
           </Flexbox>
         </Flexbox>
-        <Flexbox horizontal align="center" gap={12} onClick={stopPropagation}>
-          {isInstalled && renderStatus()}
-          {renderActions()}
-        </Flexbox>
+        {!onSelect && (
+          <Flexbox horizontal align="center" gap={12} onClick={stopPropagation}>
+            {isInstalled && renderStatus()}
+            {renderActions()}
+          </Flexbox>
+        )}
       </Flexbox>
     );
   },

--- a/src/routes/(main)/settings/skill/features/BuiltinSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/BuiltinSkillItem.tsx
@@ -95,38 +95,35 @@ const BuiltinSkillItem = memo<BuiltinSkillItemProps>(
         horizontal
         align="center"
         className={styles.container}
-        gap={16}
+        gap={8}
         justify="space-between"
         style={{
-          ...(isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : {}),
+          ...(isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 6 } : {}),
           ...(onSelect ? { cursor: 'pointer' } : {}),
         }}
         onClick={onSelect}
       >
-        <Flexbox horizontal align="center" gap={16} style={{ flex: 1, overflow: 'hidden' }}>
+        <Flexbox horizontal align="center" gap={8} style={{ flex: 1, overflow: 'hidden' }}>
           <Flexbox
             horizontal
             align="center"
-            gap={16}
+            gap={8}
             style={{ cursor: onSelect ? undefined : 'pointer' }}
             onClick={onSelect ? undefined : () => createBuiltinSkillDetailModal({ identifier })}
           >
             <div className={`${styles.icon} ${!isInstalled ? styles.disconnectedIcon : ''}`}>
-              <Avatar avatar={avatar} size={32} />
+              <Avatar avatar={avatar} size={22} />
             </div>
-            <Flexbox gap={4} style={{ overflow: 'hidden' }}>
-              <Flexbox horizontal align="center" gap={8}>
-                <span className={`${styles.title} ${!isInstalled ? styles.disconnectedTitle : ''}`}>
-                  {title}
-                </span>
-                <SkillSourceTag source="builtin" />
-              </Flexbox>
-              {!isInstalled && renderStatus()}
-            </Flexbox>
+            <span className={`${styles.title} ${!isInstalled ? styles.disconnectedTitle : ''}`}>
+              {title}
+            </span>
           </Flexbox>
+          {!isInstalled && renderStatus()}
         </Flexbox>
-        {!onSelect && (
-          <Flexbox horizontal align="center" gap={12} onClick={stopPropagation}>
+        {onSelect ? (
+          <SkillSourceTag source="builtin" />
+        ) : (
+          <Flexbox horizontal align="center" gap={8} onClick={stopPropagation}>
             {isInstalled && renderStatus()}
             {renderActions()}
           </Flexbox>

--- a/src/routes/(main)/settings/skill/features/KlavisSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/KlavisSkillItem.tsx
@@ -23,295 +23,308 @@ const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 15_000;
 
 interface KlavisSkillItemProps {
+  isSelected?: boolean;
+  onSelect?: () => void;
   server?: KlavisServer;
   serverType: KlavisServerType;
 }
 
-const KlavisSkillItem = memo<KlavisSkillItemProps>(({ serverType, server }) => {
-  const { t } = useTranslation('setting');
-  const [isConnecting, setIsConnecting] = useState(false);
-  const [isWaitingAuth, setIsWaitingAuth] = useState(false);
+const KlavisSkillItem = memo<KlavisSkillItemProps>(
+  ({ serverType, server, isSelected, onSelect }) => {
+    const { t } = useTranslation('setting');
+    const [isConnecting, setIsConnecting] = useState(false);
+    const [isWaitingAuth, setIsWaitingAuth] = useState(false);
 
-  const oauthWindowRef = useRef<Window | null>(null);
-  const windowCheckIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const oauthWindowRef = useRef<Window | null>(null);
+    const windowCheckIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const userId = useUserStore(userProfileSelectors.userId);
-  const createKlavisServer = useToolStore((s) => s.createKlavisServer);
-  const refreshKlavisServerTools = useToolStore((s) => s.refreshKlavisServerTools);
-  const removeKlavisServer = useToolStore((s) => s.removeKlavisServer);
+    const userId = useUserStore(userProfileSelectors.userId);
+    const createKlavisServer = useToolStore((s) => s.createKlavisServer);
+    const refreshKlavisServerTools = useToolStore((s) => s.refreshKlavisServerTools);
+    const removeKlavisServer = useToolStore((s) => s.removeKlavisServer);
 
-  const cleanup = useCallback(() => {
-    if (windowCheckIntervalRef.current) {
-      clearInterval(windowCheckIntervalRef.current);
-      windowCheckIntervalRef.current = null;
-    }
-    if (pollIntervalRef.current) {
-      clearInterval(pollIntervalRef.current);
-      pollIntervalRef.current = null;
-    }
-    if (pollTimeoutRef.current) {
-      clearTimeout(pollTimeoutRef.current);
-      pollTimeoutRef.current = null;
-    }
-    oauthWindowRef.current = null;
-    setIsWaitingAuth(false);
-  }, []);
+    const cleanup = useCallback(() => {
+      if (windowCheckIntervalRef.current) {
+        clearInterval(windowCheckIntervalRef.current);
+        windowCheckIntervalRef.current = null;
+      }
+      if (pollIntervalRef.current) {
+        clearInterval(pollIntervalRef.current);
+        pollIntervalRef.current = null;
+      }
+      if (pollTimeoutRef.current) {
+        clearTimeout(pollTimeoutRef.current);
+        pollTimeoutRef.current = null;
+      }
+      oauthWindowRef.current = null;
+      setIsWaitingAuth(false);
+    }, []);
 
-  useEffect(() => {
-    return () => {
-      cleanup();
-    };
-  }, [cleanup]);
+    useEffect(() => {
+      return () => {
+        cleanup();
+      };
+    }, [cleanup]);
 
-  useEffect(() => {
-    if (server?.status === KlavisServerStatus.CONNECTED && isWaitingAuth) {
-      cleanup();
-    }
-  }, [server?.status, isWaitingAuth, cleanup]);
+    useEffect(() => {
+      if (server?.status === KlavisServerStatus.CONNECTED && isWaitingAuth) {
+        cleanup();
+      }
+    }, [server?.status, isWaitingAuth, cleanup]);
 
-  const startFallbackPolling = useCallback(
-    (serverName: string) => {
-      if (pollIntervalRef.current) return;
+    const startFallbackPolling = useCallback(
+      (serverName: string) => {
+        if (pollIntervalRef.current) return;
 
-      pollIntervalRef.current = setInterval(async () => {
-        try {
-          await refreshKlavisServerTools(serverName);
-        } catch (error) {
-          console.info('[Klavis] Polling check (expected during auth):', error);
-        }
-      }, POLL_INTERVAL_MS);
+        pollIntervalRef.current = setInterval(async () => {
+          try {
+            await refreshKlavisServerTools(serverName);
+          } catch (error) {
+            console.info('[Klavis] Polling check (expected during auth):', error);
+          }
+        }, POLL_INTERVAL_MS);
 
-      pollTimeoutRef.current = setTimeout(() => {
-        if (pollIntervalRef.current) {
-          clearInterval(pollIntervalRef.current);
-          pollIntervalRef.current = null;
-        }
-        setIsWaitingAuth(false);
-      }, POLL_TIMEOUT_MS);
-    },
-    [refreshKlavisServerTools],
-  );
+        pollTimeoutRef.current = setTimeout(() => {
+          if (pollIntervalRef.current) {
+            clearInterval(pollIntervalRef.current);
+            pollIntervalRef.current = null;
+          }
+          setIsWaitingAuth(false);
+        }, POLL_TIMEOUT_MS);
+      },
+      [refreshKlavisServerTools],
+    );
 
-  const startWindowMonitor = useCallback(
-    (oauthWindow: Window, serverName: string) => {
-      windowCheckIntervalRef.current = setInterval(async () => {
-        try {
-          if (oauthWindow.closed) {
+    const startWindowMonitor = useCallback(
+      (oauthWindow: Window, serverName: string) => {
+        windowCheckIntervalRef.current = setInterval(async () => {
+          try {
+            if (oauthWindow.closed) {
+              if (windowCheckIntervalRef.current) {
+                clearInterval(windowCheckIntervalRef.current);
+                windowCheckIntervalRef.current = null;
+              }
+              oauthWindowRef.current = null;
+              // Start polling after window closes
+              startFallbackPolling(serverName);
+            }
+          } catch {
+            console.info('[Klavis] COOP blocked window.closed access, falling back to polling');
             if (windowCheckIntervalRef.current) {
               clearInterval(windowCheckIntervalRef.current);
               windowCheckIntervalRef.current = null;
             }
-            oauthWindowRef.current = null;
-            // Start polling after window closes
             startFallbackPolling(serverName);
           }
-        } catch {
-          console.info('[Klavis] COOP blocked window.closed access, falling back to polling');
-          if (windowCheckIntervalRef.current) {
-            clearInterval(windowCheckIntervalRef.current);
-            windowCheckIntervalRef.current = null;
-          }
+        }, 500);
+      },
+      [refreshKlavisServerTools, startFallbackPolling],
+    );
+
+    const openOAuthWindow = useCallback(
+      (oauthUrl: string, serverName: string) => {
+        cleanup();
+        setIsWaitingAuth(true);
+
+        const oauthWindow = window.open(oauthUrl, '_blank', 'width=600,height=700');
+        if (oauthWindow) {
+          oauthWindowRef.current = oauthWindow;
+          startWindowMonitor(oauthWindow, serverName);
+        } else {
           startFallbackPolling(serverName);
         }
-      }, 500);
-    },
-    [refreshKlavisServerTools, startFallbackPolling],
-  );
-
-  const openOAuthWindow = useCallback(
-    (oauthUrl: string, serverName: string) => {
-      cleanup();
-      setIsWaitingAuth(true);
-
-      const oauthWindow = window.open(oauthUrl, '_blank', 'width=600,height=700');
-      if (oauthWindow) {
-        oauthWindowRef.current = oauthWindow;
-        startWindowMonitor(oauthWindow, serverName);
-      } else {
-        startFallbackPolling(serverName);
-      }
-    },
-    [cleanup, startWindowMonitor, startFallbackPolling],
-  );
-
-  const handleConnect = async () => {
-    if (!userId) return;
-    if (server) return;
-
-    setIsConnecting(true);
-    try {
-      const newServer = await createKlavisServer({
-        identifier: serverType.identifier,
-        serverName: serverType.serverName,
-        userId,
-      });
-
-      if (newServer) {
-        if (newServer.isAuthenticated) {
-          await refreshKlavisServerTools(newServer.identifier);
-        } else if (newServer.oauthUrl) {
-          openOAuthWindow(newServer.oauthUrl, newServer.identifier);
-        }
-      }
-    } catch (error) {
-      console.error('[Klavis] Failed to connect server:', error);
-    } finally {
-      setIsConnecting(false);
-    }
-  };
-
-  const handleDisconnect = () => {
-    if (!server) return;
-    confirmModal({
-      cancelText: t('cancel', { ns: 'common' }),
-      content: t('tools.lobehubSkill.disconnectConfirm.desc', { name: serverType.label }),
-      okButtonProps: { danger: true },
-      okText: t('tools.lobehubSkill.disconnect'),
-      onOk: async () => {
-        await removeKlavisServer(server.identifier);
       },
-      title: t('tools.lobehubSkill.disconnectConfirm.title', { name: serverType.label }),
-    });
-  };
+      [cleanup, startWindowMonitor, startFallbackPolling],
+    );
 
-  const renderIcon = () => {
-    const { icon, label } = serverType;
-    if (typeof icon === 'string') {
-      return <Avatar alt={label} avatar={icon} size={32} />;
-    }
-    return <Icon fill={cssVar.colorText} icon={icon} size={32} />;
-  };
+    const handleConnect = async () => {
+      if (!userId) return;
+      if (server) return;
 
-  const renderStatus = () => {
-    if (!server) {
-      return (
-        <span className={styles.disconnected}>
-          {t('tools.klavis.disconnected', { defaultValue: 'Disconnected' })}
-        </span>
-      );
-    }
+      setIsConnecting(true);
+      try {
+        const newServer = await createKlavisServer({
+          identifier: serverType.identifier,
+          serverName: serverType.serverName,
+          userId,
+        });
 
-    switch (server.status) {
-      case KlavisServerStatus.CONNECTED: {
-        return <span className={styles.connected}>{t('tools.klavis.connected')}</span>;
+        if (newServer) {
+          if (newServer.isAuthenticated) {
+            await refreshKlavisServerTools(newServer.identifier);
+          } else if (newServer.oauthUrl) {
+            openOAuthWindow(newServer.oauthUrl, newServer.identifier);
+          }
+        }
+      } catch (error) {
+        console.error('[Klavis] Failed to connect server:', error);
+      } finally {
+        setIsConnecting(false);
       }
-      case KlavisServerStatus.PENDING_AUTH: {
-        return <span className={styles.pending}>{t('tools.klavis.authRequired')}</span>;
+    };
+
+    const handleDisconnect = () => {
+      if (!server) return;
+      confirmModal({
+        cancelText: t('cancel', { ns: 'common' }),
+        content: t('tools.lobehubSkill.disconnectConfirm.desc', { name: serverType.label }),
+        okButtonProps: { danger: true },
+        okText: t('tools.lobehubSkill.disconnect'),
+        onOk: async () => {
+          await removeKlavisServer(server.identifier);
+        },
+        title: t('tools.lobehubSkill.disconnectConfirm.title', { name: serverType.label }),
+      });
+    };
+
+    const renderIcon = () => {
+      const { icon, label } = serverType;
+      if (typeof icon === 'string') {
+        return <Avatar alt={label} avatar={icon} size={32} />;
       }
-      case KlavisServerStatus.ERROR: {
-        return <span className={styles.error}>{t('tools.klavis.error')}</span>;
-      }
-      default: {
+      return <Icon fill={cssVar.colorText} icon={icon} size={32} />;
+    };
+
+    const renderStatus = () => {
+      if (!server) {
         return (
           <span className={styles.disconnected}>
             {t('tools.klavis.disconnected', { defaultValue: 'Disconnected' })}
           </span>
         );
       }
-    }
-  };
 
-  const renderAction = () => {
-    if (isConnecting || isWaitingAuth) {
-      return (
-        <Button disabled icon={<Icon spin icon={Loader2} />} type="default">
-          {t('tools.klavis.connect', { defaultValue: 'Connect' })}
-        </Button>
-      );
-    }
+      switch (server.status) {
+        case KlavisServerStatus.CONNECTED: {
+          return <span className={styles.connected}>{t('tools.klavis.connected')}</span>;
+        }
+        case KlavisServerStatus.PENDING_AUTH: {
+          return <span className={styles.pending}>{t('tools.klavis.authRequired')}</span>;
+        }
+        case KlavisServerStatus.ERROR: {
+          return <span className={styles.error}>{t('tools.klavis.error')}</span>;
+        }
+        default: {
+          return (
+            <span className={styles.disconnected}>
+              {t('tools.klavis.disconnected', { defaultValue: 'Disconnected' })}
+            </span>
+          );
+        }
+      }
+    };
 
-    if (!server) {
-      return (
-        <Button icon={<Icon icon={SquareArrowOutUpRight} />} type="default" onClick={handleConnect}>
-          {t('tools.klavis.connect', { defaultValue: 'Connect' })}
-        </Button>
-      );
-    }
+    const renderAction = () => {
+      if (isConnecting || isWaitingAuth) {
+        return (
+          <Button disabled icon={<Icon spin icon={Loader2} />} type="default">
+            {t('tools.klavis.connect', { defaultValue: 'Connect' })}
+          </Button>
+        );
+      }
 
-    if (server.status === KlavisServerStatus.PENDING_AUTH) {
-      return (
-        <Button
-          icon={<Icon icon={SquareArrowOutUpRight} />}
-          type="default"
-          onClick={() => {
-            if (server.oauthUrl) {
-              openOAuthWindow(server.oauthUrl, server.identifier);
+      if (!server) {
+        return (
+          <Button
+            icon={<Icon icon={SquareArrowOutUpRight} />}
+            type="default"
+            onClick={handleConnect}
+          >
+            {t('tools.klavis.connect', { defaultValue: 'Connect' })}
+          </Button>
+        );
+      }
+
+      if (server.status === KlavisServerStatus.PENDING_AUTH) {
+        return (
+          <Button
+            icon={<Icon icon={SquareArrowOutUpRight} />}
+            type="default"
+            onClick={() => {
+              if (server.oauthUrl) {
+                openOAuthWindow(server.oauthUrl, server.identifier);
+              }
+            }}
+          >
+            {t('tools.klavis.pendingAuth', { defaultValue: 'Authorize' })}
+          </Button>
+        );
+      }
+
+      if (server.status === KlavisServerStatus.CONNECTED) {
+        return (
+          <DropdownMenu
+            placement="bottomRight"
+            items={[
+              {
+                danger: true,
+                icon: <Icon icon={Unplug} />,
+                key: 'disconnect',
+                label: t('tools.klavis.disconnect', { defaultValue: 'Disconnect' }),
+                onClick: handleDisconnect,
+              },
+            ]}
+          >
+            <LobeButton icon={MoreHorizontalIcon} />
+          </DropdownMenu>
+        );
+      }
+
+      return null;
+    };
+
+    const isConnected = server?.status === KlavisServerStatus.CONNECTED;
+
+    return (
+      <Flexbox
+        horizontal
+        align="center"
+        className={styles.container}
+        gap={16}
+        justify="space-between"
+        style={
+          isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : undefined
+        }
+      >
+        <Flexbox horizontal align="center" gap={16} style={{ flex: 1, overflow: 'hidden' }}>
+          <Flexbox
+            horizontal
+            align="center"
+            gap={16}
+            style={{ cursor: 'pointer' }}
+            onClick={
+              onSelect ??
+              (() =>
+                createKlavisSkillDetailModal({
+                  identifier: serverType.identifier,
+                  serverName: serverType.serverName,
+                }))
             }
-          }}
-        >
-          {t('tools.klavis.pendingAuth', { defaultValue: 'Authorize' })}
-        </Button>
-      );
-    }
-
-    if (server.status === KlavisServerStatus.CONNECTED) {
-      return (
-        <DropdownMenu
-          placement="bottomRight"
-          items={[
-            {
-              danger: true,
-              icon: <Icon icon={Unplug} />,
-              key: 'disconnect',
-              label: t('tools.klavis.disconnect', { defaultValue: 'Disconnect' }),
-              onClick: handleDisconnect,
-            },
-          ]}
-        >
-          <LobeButton icon={MoreHorizontalIcon} />
-        </DropdownMenu>
-      );
-    }
-
-    return null;
-  };
-
-  const isConnected = server?.status === KlavisServerStatus.CONNECTED;
-
-  return (
-    <Flexbox
-      horizontal
-      align="center"
-      className={styles.container}
-      gap={16}
-      justify="space-between"
-    >
-      <Flexbox horizontal align="center" gap={16} style={{ flex: 1, overflow: 'hidden' }}>
-        <Flexbox
-          horizontal
-          align="center"
-          gap={16}
-          style={{ cursor: 'pointer' }}
-          onClick={() =>
-            createKlavisSkillDetailModal({
-              identifier: serverType.identifier,
-              serverName: serverType.serverName,
-            })
-          }
-        >
-          <div className={`${styles.icon} ${!isConnected ? styles.disconnectedIcon : ''}`}>
-            {renderIcon()}
-          </div>
-          <Flexbox gap={4} style={{ overflow: 'hidden' }}>
-            <Flexbox horizontal align="center" gap={8}>
-              <span className={`${styles.title} ${!isConnected ? styles.disconnectedTitle : ''}`}>
-                {serverType.label}
-              </span>
-              <SkillSourceTag source="builtin" />
+          >
+            <div className={`${styles.icon} ${!isConnected ? styles.disconnectedIcon : ''}`}>
+              {renderIcon()}
+            </div>
+            <Flexbox gap={4} style={{ overflow: 'hidden' }}>
+              <Flexbox horizontal align="center" gap={8}>
+                <span className={`${styles.title} ${!isConnected ? styles.disconnectedTitle : ''}`}>
+                  {serverType.label}
+                </span>
+                <SkillSourceTag source="builtin" />
+              </Flexbox>
+              {!isConnected && renderStatus()}
             </Flexbox>
-            {!isConnected && renderStatus()}
           </Flexbox>
         </Flexbox>
+        <Flexbox horizontal align="center" gap={12}>
+          {isConnected && renderStatus()}
+          {renderAction()}
+        </Flexbox>
       </Flexbox>
-      <Flexbox horizontal align="center" gap={12}>
-        {isConnected && renderStatus()}
-        {renderAction()}
-      </Flexbox>
-    </Flexbox>
-  );
-});
+    );
+  },
+);
 
 KlavisSkillItem.displayName = 'KlavisSkillItem';
 

--- a/src/routes/(main)/settings/skill/features/KlavisSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/KlavisSkillItem.tsx
@@ -9,7 +9,6 @@ import { Loader2, MoreHorizontalIcon, SquareArrowOutUpRight, Unplug } from 'luci
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import SkillSourceTag from '@/components/SkillSourceTag';
 import { createKlavisSkillDetailModal } from '@/features/SkillStore/SkillDetail';
 import { useToolStore } from '@/store/tool';
 import { type KlavisServer } from '@/store/tool/slices/klavisStore';
@@ -315,9 +314,7 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(
           </Flexbox>
           {!isConnected && renderStatus()}
         </Flexbox>
-        {onSelect ? (
-          <SkillSourceTag source="builtin" />
-        ) : (
+        {!onSelect && (
           <Flexbox horizontal align="center" gap={8}>
             {isConnected && renderStatus()}
             {renderAction()}

--- a/src/routes/(main)/settings/skill/features/KlavisSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/KlavisSkillItem.tsx
@@ -284,23 +284,26 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(
         className={styles.container}
         gap={16}
         justify="space-between"
-        style={
-          isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : undefined
-        }
+        style={{
+          ...(isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : {}),
+          ...(onSelect ? { cursor: 'pointer' } : {}),
+        }}
+        onClick={onSelect}
       >
         <Flexbox horizontal align="center" gap={16} style={{ flex: 1, overflow: 'hidden' }}>
           <Flexbox
             horizontal
             align="center"
             gap={16}
-            style={{ cursor: 'pointer' }}
+            style={{ cursor: onSelect ? undefined : 'pointer' }}
             onClick={
-              onSelect ??
-              (() =>
-                createKlavisSkillDetailModal({
-                  identifier: serverType.identifier,
-                  serverName: serverType.serverName,
-                }))
+              onSelect
+                ? undefined
+                : () =>
+                    createKlavisSkillDetailModal({
+                      identifier: serverType.identifier,
+                      serverName: serverType.serverName,
+                    })
             }
           >
             <div className={`${styles.icon} ${!isConnected ? styles.disconnectedIcon : ''}`}>
@@ -317,10 +320,12 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(
             </Flexbox>
           </Flexbox>
         </Flexbox>
-        <Flexbox horizontal align="center" gap={12}>
-          {isConnected && renderStatus()}
-          {renderAction()}
-        </Flexbox>
+        {!onSelect && (
+          <Flexbox horizontal align="center" gap={12}>
+            {isConnected && renderStatus()}
+            {renderAction()}
+          </Flexbox>
+        )}
       </Flexbox>
     );
   },

--- a/src/routes/(main)/settings/skill/features/KlavisSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/KlavisSkillItem.tsx
@@ -182,9 +182,9 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(
     const renderIcon = () => {
       const { icon, label } = serverType;
       if (typeof icon === 'string') {
-        return <Avatar alt={label} avatar={icon} size={22} />;
+        return <Avatar alt={label} avatar={icon} size={16} />;
       }
-      return <Icon fill={cssVar.colorText} icon={icon} size={22} />;
+      return <Icon fill={cssVar.colorText} icon={icon} size={16} />;
     };
 
     const renderStatus = () => {

--- a/src/routes/(main)/settings/skill/features/KlavisSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/KlavisSkillItem.tsx
@@ -182,9 +182,9 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(
     const renderIcon = () => {
       const { icon, label } = serverType;
       if (typeof icon === 'string') {
-        return <Avatar alt={label} avatar={icon} size={32} />;
+        return <Avatar alt={label} avatar={icon} size={22} />;
       }
-      return <Icon fill={cssVar.colorText} icon={icon} size={32} />;
+      return <Icon fill={cssVar.colorText} icon={icon} size={22} />;
     };
 
     const renderStatus = () => {
@@ -282,19 +282,19 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(
         horizontal
         align="center"
         className={styles.container}
-        gap={16}
+        gap={8}
         justify="space-between"
         style={{
-          ...(isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : {}),
+          ...(isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 6 } : {}),
           ...(onSelect ? { cursor: 'pointer' } : {}),
         }}
         onClick={onSelect}
       >
-        <Flexbox horizontal align="center" gap={16} style={{ flex: 1, overflow: 'hidden' }}>
+        <Flexbox horizontal align="center" gap={8} style={{ flex: 1, overflow: 'hidden' }}>
           <Flexbox
             horizontal
             align="center"
-            gap={16}
+            gap={8}
             style={{ cursor: onSelect ? undefined : 'pointer' }}
             onClick={
               onSelect
@@ -309,19 +309,16 @@ const KlavisSkillItem = memo<KlavisSkillItemProps>(
             <div className={`${styles.icon} ${!isConnected ? styles.disconnectedIcon : ''}`}>
               {renderIcon()}
             </div>
-            <Flexbox gap={4} style={{ overflow: 'hidden' }}>
-              <Flexbox horizontal align="center" gap={8}>
-                <span className={`${styles.title} ${!isConnected ? styles.disconnectedTitle : ''}`}>
-                  {serverType.label}
-                </span>
-                <SkillSourceTag source="builtin" />
-              </Flexbox>
-              {!isConnected && renderStatus()}
-            </Flexbox>
+            <span className={`${styles.title} ${!isConnected ? styles.disconnectedTitle : ''}`}>
+              {serverType.label}
+            </span>
           </Flexbox>
+          {!isConnected && renderStatus()}
         </Flexbox>
-        {!onSelect && (
-          <Flexbox horizontal align="center" gap={12}>
+        {onSelect ? (
+          <SkillSourceTag source="builtin" />
+        ) : (
+          <Flexbox horizontal align="center" gap={8}>
             {isConnected && renderStatus()}
             {renderAction()}
           </Flexbox>

--- a/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
@@ -9,7 +9,6 @@ import { Loader2, MoreHorizontalIcon, SquareArrowOutUpRight, Unplug } from 'luci
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import SkillSourceTag from '@/components/SkillSourceTag';
 import { createLobehubSkillDetailModal } from '@/features/SkillStore/SkillDetail';
 import { useToolStore } from '@/store/tool';
 import { type LobehubSkillServer } from '@/store/tool/slices/lobehubSkillStore/types';
@@ -296,9 +295,7 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(
           </Flexbox>
           {!isConnected && renderStatus()}
         </Flexbox>
-        {onSelect ? (
-          <SkillSourceTag source="builtin" />
-        ) : (
+        {!onSelect && (
           <Flexbox horizontal align="center" gap={8}>
             {isConnected && renderStatus()}
             {renderAction()}

--- a/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
@@ -269,17 +269,23 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(
         className={styles.container}
         gap={16}
         justify="space-between"
-        style={
-          isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : undefined
-        }
+        style={{
+          ...(isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : {}),
+          ...(onSelect ? { cursor: 'pointer' } : {}),
+        }}
+        onClick={onSelect}
       >
         <Flexbox horizontal align="center" gap={16} style={{ flex: 1, overflow: 'hidden' }}>
           <Flexbox
             horizontal
             align="center"
             gap={16}
-            style={{ cursor: 'pointer' }}
-            onClick={onSelect ?? (() => createLobehubSkillDetailModal({ identifier: provider.id }))}
+            style={{ cursor: onSelect ? undefined : 'pointer' }}
+            onClick={
+              onSelect
+                ? undefined
+                : () => createLobehubSkillDetailModal({ identifier: provider.id })
+            }
           >
             <div className={`${styles.icon} ${!isConnected ? styles.disconnectedIcon : ''}`}>
               {renderIcon()}
@@ -295,10 +301,12 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(
             </Flexbox>
           </Flexbox>
         </Flexbox>
-        <Flexbox horizontal align="center" gap={12}>
-          {isConnected && renderStatus()}
-          {renderAction()}
-        </Flexbox>
+        {!onSelect && (
+          <Flexbox horizontal align="center" gap={12}>
+            {isConnected && renderStatus()}
+            {renderAction()}
+          </Flexbox>
+        )}
       </Flexbox>
     );
   },

--- a/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
@@ -187,9 +187,9 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(
     const renderIcon = () => {
       const { icon, label } = provider;
       if (typeof icon === 'string') {
-        return <Avatar alt={label} avatar={icon} size={22} />;
+        return <Avatar alt={label} avatar={icon} size={16} />;
       }
-      return <Icon fill={cssVar.colorText} icon={icon} size={22} />;
+      return <Icon fill={cssVar.colorText} icon={icon} size={16} />;
     };
 
     const renderStatus = () => {

--- a/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
@@ -21,279 +21,288 @@ const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 15_000;
 
 interface LobehubSkillItemProps {
+  isSelected?: boolean;
+  onSelect?: () => void;
   provider: LobehubSkillProviderType;
   server?: LobehubSkillServer;
 }
 
-const LobehubSkillItem = memo<LobehubSkillItemProps>(({ provider, server }) => {
-  const { t } = useTranslation('setting');
-  const [isConnecting, setIsConnecting] = useState(false);
-  const [isWaitingAuth, setIsWaitingAuth] = useState(false);
+const LobehubSkillItem = memo<LobehubSkillItemProps>(
+  ({ provider, server, isSelected, onSelect }) => {
+    const { t } = useTranslation('setting');
+    const [isConnecting, setIsConnecting] = useState(false);
+    const [isWaitingAuth, setIsWaitingAuth] = useState(false);
 
-  const oauthWindowRef = useRef<Window | null>(null);
-  const windowCheckIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const oauthWindowRef = useRef<Window | null>(null);
+    const windowCheckIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const checkStatus = useToolStore((s) => s.checkLobehubSkillStatus);
-  const revokeConnect = useToolStore((s) => s.revokeLobehubSkill);
-  const getAuthorizeUrl = useToolStore((s) => s.getLobehubSkillAuthorizeUrl);
+    const checkStatus = useToolStore((s) => s.checkLobehubSkillStatus);
+    const revokeConnect = useToolStore((s) => s.revokeLobehubSkill);
+    const getAuthorizeUrl = useToolStore((s) => s.getLobehubSkillAuthorizeUrl);
 
-  const cleanup = useCallback(() => {
-    if (windowCheckIntervalRef.current) {
-      clearInterval(windowCheckIntervalRef.current);
-      windowCheckIntervalRef.current = null;
-    }
-    if (pollIntervalRef.current) {
-      clearInterval(pollIntervalRef.current);
-      pollIntervalRef.current = null;
-    }
-    if (pollTimeoutRef.current) {
-      clearTimeout(pollTimeoutRef.current);
-      pollTimeoutRef.current = null;
-    }
-    oauthWindowRef.current = null;
-    setIsWaitingAuth(false);
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      cleanup();
-    };
-  }, [cleanup]);
-
-  useEffect(() => {
-    if (server?.status === LobehubSkillStatus.CONNECTED && isWaitingAuth) {
-      cleanup();
-    }
-  }, [server?.status, isWaitingAuth, cleanup]);
-
-  const startFallbackPolling = useCallback(() => {
-    if (pollIntervalRef.current) return;
-
-    pollIntervalRef.current = setInterval(async () => {
-      try {
-        await checkStatus(provider.id);
-      } catch (error) {
-        console.error('[LobehubSkill] Failed to check status:', error);
+    const cleanup = useCallback(() => {
+      if (windowCheckIntervalRef.current) {
+        clearInterval(windowCheckIntervalRef.current);
+        windowCheckIntervalRef.current = null;
       }
-    }, POLL_INTERVAL_MS);
-
-    pollTimeoutRef.current = setTimeout(() => {
       if (pollIntervalRef.current) {
         clearInterval(pollIntervalRef.current);
         pollIntervalRef.current = null;
       }
+      if (pollTimeoutRef.current) {
+        clearTimeout(pollTimeoutRef.current);
+        pollTimeoutRef.current = null;
+      }
+      oauthWindowRef.current = null;
       setIsWaitingAuth(false);
-    }, POLL_TIMEOUT_MS);
-  }, [checkStatus, provider.id]);
+    }, []);
 
-  const startWindowMonitor = useCallback(
-    (oauthWindow: Window) => {
-      windowCheckIntervalRef.current = setInterval(async () => {
+    useEffect(() => {
+      return () => {
+        cleanup();
+      };
+    }, [cleanup]);
+
+    useEffect(() => {
+      if (server?.status === LobehubSkillStatus.CONNECTED && isWaitingAuth) {
+        cleanup();
+      }
+    }, [server?.status, isWaitingAuth, cleanup]);
+
+    const startFallbackPolling = useCallback(() => {
+      if (pollIntervalRef.current) return;
+
+      pollIntervalRef.current = setInterval(async () => {
         try {
-          if (oauthWindow.closed) {
+          await checkStatus(provider.id);
+        } catch (error) {
+          console.error('[LobehubSkill] Failed to check status:', error);
+        }
+      }, POLL_INTERVAL_MS);
+
+      pollTimeoutRef.current = setTimeout(() => {
+        if (pollIntervalRef.current) {
+          clearInterval(pollIntervalRef.current);
+          pollIntervalRef.current = null;
+        }
+        setIsWaitingAuth(false);
+      }, POLL_TIMEOUT_MS);
+    }, [checkStatus, provider.id]);
+
+    const startWindowMonitor = useCallback(
+      (oauthWindow: Window) => {
+        windowCheckIntervalRef.current = setInterval(async () => {
+          try {
+            if (oauthWindow.closed) {
+              if (windowCheckIntervalRef.current) {
+                clearInterval(windowCheckIntervalRef.current);
+                windowCheckIntervalRef.current = null;
+              }
+              oauthWindowRef.current = null;
+              await checkStatus(provider.id);
+              setIsWaitingAuth(false);
+            }
+          } catch {
+            console.info(
+              '[LobehubSkill] COOP blocked window.closed access, falling back to polling',
+            );
             if (windowCheckIntervalRef.current) {
               clearInterval(windowCheckIntervalRef.current);
               windowCheckIntervalRef.current = null;
             }
-            oauthWindowRef.current = null;
-            await checkStatus(provider.id);
-            setIsWaitingAuth(false);
+            startFallbackPolling();
           }
-        } catch {
-          console.info('[LobehubSkill] COOP blocked window.closed access, falling back to polling');
-          if (windowCheckIntervalRef.current) {
-            clearInterval(windowCheckIntervalRef.current);
-            windowCheckIntervalRef.current = null;
-          }
+        }, 500);
+      },
+      [checkStatus, provider.id, startFallbackPolling],
+    );
+
+    const openOAuthWindow = useCallback(
+      (authorizeUrl: string) => {
+        cleanup();
+        setIsWaitingAuth(true);
+
+        const oauthWindow = window.open(authorizeUrl, '_blank', 'width=600,height=700');
+        if (oauthWindow) {
+          oauthWindowRef.current = oauthWindow;
+          startWindowMonitor(oauthWindow);
+        } else {
           startFallbackPolling();
         }
-      }, 500);
-    },
-    [checkStatus, provider.id, startFallbackPolling],
-  );
+      },
+      [cleanup, startWindowMonitor, startFallbackPolling],
+    );
 
-  const openOAuthWindow = useCallback(
-    (authorizeUrl: string) => {
-      cleanup();
-      setIsWaitingAuth(true);
+    useEffect(() => {
+      const handleMessage = async (event: MessageEvent) => {
+        if (event.origin !== window.location.origin) return;
 
-      const oauthWindow = window.open(authorizeUrl, '_blank', 'width=600,height=700');
-      if (oauthWindow) {
-        oauthWindowRef.current = oauthWindow;
-        startWindowMonitor(oauthWindow);
-      } else {
-        startFallbackPolling();
-      }
-    },
-    [cleanup, startWindowMonitor, startFallbackPolling],
-  );
+        if (
+          event.data?.type === 'LOBEHUB_SKILL_AUTH_SUCCESS' &&
+          event.data?.provider === provider.id
+        ) {
+          cleanup();
+          await checkStatus(provider.id);
+        }
+      };
 
-  useEffect(() => {
-    const handleMessage = async (event: MessageEvent) => {
-      if (event.origin !== window.location.origin) return;
+      window.addEventListener('message', handleMessage);
+      return () => window.removeEventListener('message', handleMessage);
+    }, [provider.id, cleanup, checkStatus]);
 
-      if (
-        event.data?.type === 'LOBEHUB_SKILL_AUTH_SUCCESS' &&
-        event.data?.provider === provider.id
-      ) {
-        cleanup();
-        await checkStatus(provider.id);
+    const handleConnect = async () => {
+      if (server?.isConnected) return;
+
+      setIsConnecting(true);
+      try {
+        // Skip redirectUri on desktop (app:// protocol) since the system browser can't navigate to it
+        const redirectUri = window.location.protocol.startsWith('http')
+          ? `${window.location.origin}/oauth/callback/success?provider=${encodeURIComponent(provider.id)}`
+          : undefined;
+        const { authorizeUrl } = await getAuthorizeUrl(provider.id, { redirectUri });
+        openOAuthWindow(authorizeUrl);
+      } catch (error) {
+        console.error('[LobehubSkill] Failed to get authorize URL:', error);
+      } finally {
+        setIsConnecting(false);
       }
     };
 
-    window.addEventListener('message', handleMessage);
-    return () => window.removeEventListener('message', handleMessage);
-  }, [provider.id, cleanup, checkStatus]);
+    const handleDisconnect = () => {
+      if (!server) return;
+      confirmModal({
+        cancelText: t('cancel', { ns: 'common' }),
+        content: t('tools.lobehubSkill.disconnectConfirm.desc', { name: provider.label }),
+        okButtonProps: { danger: true },
+        okText: t('tools.lobehubSkill.disconnect'),
+        onOk: async () => {
+          await revokeConnect(server.identifier);
+        },
+        title: t('tools.lobehubSkill.disconnectConfirm.title', { name: provider.label }),
+      });
+    };
 
-  const handleConnect = async () => {
-    if (server?.isConnected) return;
-
-    setIsConnecting(true);
-    try {
-      // Skip redirectUri on desktop (app:// protocol) since the system browser can't navigate to it
-      const redirectUri = window.location.protocol.startsWith('http')
-        ? `${window.location.origin}/oauth/callback/success?provider=${encodeURIComponent(provider.id)}`
-        : undefined;
-      const { authorizeUrl } = await getAuthorizeUrl(provider.id, { redirectUri });
-      openOAuthWindow(authorizeUrl);
-    } catch (error) {
-      console.error('[LobehubSkill] Failed to get authorize URL:', error);
-    } finally {
-      setIsConnecting(false);
-    }
-  };
-
-  const handleDisconnect = () => {
-    if (!server) return;
-    confirmModal({
-      cancelText: t('cancel', { ns: 'common' }),
-      content: t('tools.lobehubSkill.disconnectConfirm.desc', { name: provider.label }),
-      okButtonProps: { danger: true },
-      okText: t('tools.lobehubSkill.disconnect'),
-      onOk: async () => {
-        await revokeConnect(server.identifier);
-      },
-      title: t('tools.lobehubSkill.disconnectConfirm.title', { name: provider.label }),
-    });
-  };
-
-  const renderIcon = () => {
-    const { icon, label } = provider;
-    if (typeof icon === 'string') {
-      return <Avatar alt={label} avatar={icon} size={32} />;
-    }
-    return <Icon fill={cssVar.colorText} icon={icon} size={32} />;
-  };
-
-  const renderStatus = () => {
-    if (!server) {
-      return (
-        <span className={styles.disconnected}>
-          {t('tools.lobehubSkill.disconnected', { defaultValue: 'Disconnected' })}
-        </span>
-      );
-    }
-
-    switch (server.status) {
-      case LobehubSkillStatus.CONNECTED: {
-        return (
-          <span className={styles.connected}>
-            {t('tools.lobehubSkill.connected', { defaultValue: 'Connected' })}
-          </span>
-        );
+    const renderIcon = () => {
+      const { icon, label } = provider;
+      if (typeof icon === 'string') {
+        return <Avatar alt={label} avatar={icon} size={32} />;
       }
-      case LobehubSkillStatus.ERROR: {
-        return <span className={styles.error}>{t('tools.lobehubSkill.error')}</span>;
-      }
-      default: {
+      return <Icon fill={cssVar.colorText} icon={icon} size={32} />;
+    };
+
+    const renderStatus = () => {
+      if (!server) {
         return (
           <span className={styles.disconnected}>
             {t('tools.lobehubSkill.disconnected', { defaultValue: 'Disconnected' })}
           </span>
         );
       }
-    }
-  };
 
-  const renderAction = () => {
-    if (isConnecting || isWaitingAuth) {
-      return (
-        <Button disabled icon={<Icon spin icon={Loader2} />} type="default">
-          {t('tools.lobehubSkill.connect')}
-        </Button>
-      );
-    }
+      switch (server.status) {
+        case LobehubSkillStatus.CONNECTED: {
+          return (
+            <span className={styles.connected}>
+              {t('tools.lobehubSkill.connected', { defaultValue: 'Connected' })}
+            </span>
+          );
+        }
+        case LobehubSkillStatus.ERROR: {
+          return <span className={styles.error}>{t('tools.lobehubSkill.error')}</span>;
+        }
+        default: {
+          return (
+            <span className={styles.disconnected}>
+              {t('tools.lobehubSkill.disconnected', { defaultValue: 'Disconnected' })}
+            </span>
+          );
+        }
+      }
+    };
 
-    if (!server || server.status !== LobehubSkillStatus.CONNECTED) {
+    const renderAction = () => {
+      if (isConnecting || isWaitingAuth) {
+        return (
+          <Button disabled icon={<Icon spin icon={Loader2} />} type="default">
+            {t('tools.lobehubSkill.connect')}
+          </Button>
+        );
+      }
+
+      if (!server || server.status !== LobehubSkillStatus.CONNECTED) {
+        return (
+          <Button
+            icon={<Icon icon={SquareArrowOutUpRight} />}
+            type="default"
+            onClick={handleConnect}
+          >
+            {t('tools.lobehubSkill.connect')}
+          </Button>
+        );
+      }
+
       return (
-        <Button icon={<Icon icon={SquareArrowOutUpRight} />} type="default" onClick={handleConnect}>
-          {t('tools.lobehubSkill.connect')}
-        </Button>
+        <DropdownMenu
+          placement="bottomRight"
+          items={[
+            {
+              icon: <Icon icon={Unplug} />,
+              key: 'disconnect',
+              label: t('tools.lobehubSkill.disconnect', { defaultValue: 'Disconnect' }),
+              onClick: handleDisconnect,
+            },
+          ]}
+        >
+          <LobeButton icon={MoreHorizontalIcon} />
+        </DropdownMenu>
       );
-    }
+    };
+
+    const isConnected = server?.status === LobehubSkillStatus.CONNECTED;
 
     return (
-      <DropdownMenu
-        placement="bottomRight"
-        items={[
-          {
-            icon: <Icon icon={Unplug} />,
-            key: 'disconnect',
-            label: t('tools.lobehubSkill.disconnect', { defaultValue: 'Disconnect' }),
-            onClick: handleDisconnect,
-          },
-        ]}
+      <Flexbox
+        horizontal
+        align="center"
+        className={styles.container}
+        gap={16}
+        justify="space-between"
+        style={
+          isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : undefined
+        }
       >
-        <LobeButton icon={MoreHorizontalIcon} />
-      </DropdownMenu>
-    );
-  };
-
-  const isConnected = server?.status === LobehubSkillStatus.CONNECTED;
-
-  return (
-    <Flexbox
-      horizontal
-      align="center"
-      className={styles.container}
-      gap={16}
-      justify="space-between"
-    >
-      <Flexbox horizontal align="center" gap={16} style={{ flex: 1, overflow: 'hidden' }}>
-        <Flexbox
-          horizontal
-          align="center"
-          gap={16}
-          style={{ cursor: 'pointer' }}
-          onClick={() =>
-            createLobehubSkillDetailModal({
-              identifier: provider.id,
-            })
-          }
-        >
-          <div className={`${styles.icon} ${!isConnected ? styles.disconnectedIcon : ''}`}>
-            {renderIcon()}
-          </div>
-          <Flexbox gap={4} style={{ overflow: 'hidden' }}>
-            <Flexbox horizontal align="center" gap={8}>
-              <span className={`${styles.title} ${!isConnected ? styles.disconnectedTitle : ''}`}>
-                {provider.label}
-              </span>
-              <SkillSourceTag source="builtin" />
+        <Flexbox horizontal align="center" gap={16} style={{ flex: 1, overflow: 'hidden' }}>
+          <Flexbox
+            horizontal
+            align="center"
+            gap={16}
+            style={{ cursor: 'pointer' }}
+            onClick={onSelect ?? (() => createLobehubSkillDetailModal({ identifier: provider.id }))}
+          >
+            <div className={`${styles.icon} ${!isConnected ? styles.disconnectedIcon : ''}`}>
+              {renderIcon()}
+            </div>
+            <Flexbox gap={4} style={{ overflow: 'hidden' }}>
+              <Flexbox horizontal align="center" gap={8}>
+                <span className={`${styles.title} ${!isConnected ? styles.disconnectedTitle : ''}`}>
+                  {provider.label}
+                </span>
+                <SkillSourceTag source="builtin" />
+              </Flexbox>
+              {!isConnected && renderStatus()}
             </Flexbox>
-            {!isConnected && renderStatus()}
           </Flexbox>
         </Flexbox>
+        <Flexbox horizontal align="center" gap={12}>
+          {isConnected && renderStatus()}
+          {renderAction()}
+        </Flexbox>
       </Flexbox>
-      <Flexbox horizontal align="center" gap={12}>
-        {isConnected && renderStatus()}
-        {renderAction()}
-      </Flexbox>
-    </Flexbox>
-  );
-});
+    );
+  },
+);
 
 LobehubSkillItem.displayName = 'LobehubSkillItem';
 

--- a/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
@@ -187,9 +187,9 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(
     const renderIcon = () => {
       const { icon, label } = provider;
       if (typeof icon === 'string') {
-        return <Avatar alt={label} avatar={icon} size={32} />;
+        return <Avatar alt={label} avatar={icon} size={22} />;
       }
-      return <Icon fill={cssVar.colorText} icon={icon} size={32} />;
+      return <Icon fill={cssVar.colorText} icon={icon} size={22} />;
     };
 
     const renderStatus = () => {
@@ -267,19 +267,19 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(
         horizontal
         align="center"
         className={styles.container}
-        gap={16}
+        gap={8}
         justify="space-between"
         style={{
-          ...(isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : {}),
+          ...(isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 6 } : {}),
           ...(onSelect ? { cursor: 'pointer' } : {}),
         }}
         onClick={onSelect}
       >
-        <Flexbox horizontal align="center" gap={16} style={{ flex: 1, overflow: 'hidden' }}>
+        <Flexbox horizontal align="center" gap={8} style={{ flex: 1, overflow: 'hidden' }}>
           <Flexbox
             horizontal
             align="center"
-            gap={16}
+            gap={8}
             style={{ cursor: onSelect ? undefined : 'pointer' }}
             onClick={
               onSelect
@@ -290,19 +290,16 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(
             <div className={`${styles.icon} ${!isConnected ? styles.disconnectedIcon : ''}`}>
               {renderIcon()}
             </div>
-            <Flexbox gap={4} style={{ overflow: 'hidden' }}>
-              <Flexbox horizontal align="center" gap={8}>
-                <span className={`${styles.title} ${!isConnected ? styles.disconnectedTitle : ''}`}>
-                  {provider.label}
-                </span>
-                <SkillSourceTag source="builtin" />
-              </Flexbox>
-              {!isConnected && renderStatus()}
-            </Flexbox>
+            <span className={`${styles.title} ${!isConnected ? styles.disconnectedTitle : ''}`}>
+              {provider.label}
+            </span>
           </Flexbox>
+          {!isConnected && renderStatus()}
         </Flexbox>
-        {!onSelect && (
-          <Flexbox horizontal align="center" gap={12}>
+        {onSelect ? (
+          <SkillSourceTag source="builtin" />
+        ) : (
+          <Flexbox horizontal align="center" gap={8}>
             {isConnected && renderStatus()}
             {renderAction()}
           </Flexbox>

--- a/src/routes/(main)/settings/skill/features/McpSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/McpSkillItem.tsx
@@ -22,13 +22,15 @@ interface McpSkillItemProps {
   author?: string;
   avatar?: string;
   identifier: string;
+  isSelected?: boolean;
+  onSelect?: () => void;
   runtimeType?: string;
   title: string;
   type: LobeToolType;
 }
 
 const McpSkillItem = memo<McpSkillItemProps>(
-  ({ identifier, title, avatar, type, runtimeType, author }) => {
+  ({ identifier, title, avatar, type, runtimeType, author, isSelected, onSelect }) => {
     const { t } = useTranslation('plugin');
     const isMCP = runtimeType === 'mcp';
     const isCustomPlugin = type === 'customPlugin';
@@ -45,6 +47,9 @@ const McpSkillItem = memo<McpSkillItemProps>(
           className={styles.container}
           gap={16}
           justify="space-between"
+          style={
+            isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : undefined
+          }
         >
           <Flexbox horizontal align="center" gap={12} style={{ flex: 1, overflow: 'hidden' }}>
             <div className={styles.icon}>
@@ -55,7 +60,7 @@ const McpSkillItem = memo<McpSkillItemProps>(
               )}
             </div>
             <Flexbox horizontal align="center" gap={8} style={{ overflow: 'hidden' }}>
-              <span className={styles.title} onClick={() => setDetailOpen(true)}>
+              <span className={styles.title} onClick={onSelect ?? (() => setDetailOpen(true))}>
                 {title}
               </span>
               {isCustomPlugin ? (

--- a/src/routes/(main)/settings/skill/features/McpSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/McpSkillItem.tsx
@@ -45,38 +45,41 @@ const McpSkillItem = memo<McpSkillItemProps>(
           horizontal
           align="center"
           className={styles.container}
-          gap={16}
+          gap={8}
           justify="space-between"
           style={{
-            ...(isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : {}),
+            ...(isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 6 } : {}),
             ...(onSelect ? { cursor: 'pointer' } : {}),
           }}
           onClick={onSelect}
         >
-          <Flexbox horizontal align="center" gap={12} style={{ flex: 1, overflow: 'hidden' }}>
+          <Flexbox horizontal align="center" gap={8} style={{ flex: 1, overflow: 'hidden' }}>
             <div className={styles.icon}>
               {avatar && avatar !== 'MCP_AVATAR' ? (
-                <Avatar avatar={avatar} shape={'square'} size={32} />
+                <Avatar avatar={avatar} shape={'square'} size={22} />
               ) : (
-                <Icon icon={McpIcon} size={28} />
+                <Icon icon={McpIcon} size={18} />
               )}
             </div>
-            <Flexbox horizontal align="center" gap={8} style={{ overflow: 'hidden' }}>
-              <span
-                className={styles.title}
-                onClick={onSelect ? undefined : () => setDetailOpen(true)}
-              >
-                {title}
-              </span>
+            <span
+              className={styles.title}
+              onClick={onSelect ? undefined : () => setDetailOpen(true)}
+            >
+              {title}
+            </span>
+          </Flexbox>
+          {onSelect ? (
+            <SkillSourceTag source={isCustomPlugin ? 'user' : 'market'} />
+          ) : (
+            <Flexbox horizontal align="center" gap={4}>
               {isCustomPlugin ? (
                 <MCPTag showText={false} />
               ) : (
                 <PluginTag author={author} isMCP={isMCP} type={type} />
               )}
-              <SkillSourceTag source={isCustomPlugin ? 'user' : 'market'} />
+              <Actions identifier={identifier} isMCP={isMCP} type={type} />
             </Flexbox>
-          </Flexbox>
-          {!onSelect && <Actions identifier={identifier} isMCP={isMCP} type={type} />}
+          )}
         </Flexbox>
         {isCommunityMCP && (
           <Modal

--- a/src/routes/(main)/settings/skill/features/McpSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/McpSkillItem.tsx
@@ -47,9 +47,11 @@ const McpSkillItem = memo<McpSkillItemProps>(
           className={styles.container}
           gap={16}
           justify="space-between"
-          style={
-            isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : undefined
-          }
+          style={{
+            ...(isSelected ? { background: 'var(--ant-color-primary-bg)', borderRadius: 8 } : {}),
+            ...(onSelect ? { cursor: 'pointer' } : {}),
+          }}
+          onClick={onSelect}
         >
           <Flexbox horizontal align="center" gap={12} style={{ flex: 1, overflow: 'hidden' }}>
             <div className={styles.icon}>
@@ -60,7 +62,10 @@ const McpSkillItem = memo<McpSkillItemProps>(
               )}
             </div>
             <Flexbox horizontal align="center" gap={8} style={{ overflow: 'hidden' }}>
-              <span className={styles.title} onClick={onSelect ?? (() => setDetailOpen(true))}>
+              <span
+                className={styles.title}
+                onClick={onSelect ? undefined : () => setDetailOpen(true)}
+              >
                 {title}
               </span>
               {isCustomPlugin ? (
@@ -71,7 +76,7 @@ const McpSkillItem = memo<McpSkillItemProps>(
               <SkillSourceTag source={isCustomPlugin ? 'user' : 'market'} />
             </Flexbox>
           </Flexbox>
-          <Actions identifier={identifier} isMCP={isMCP} type={type} />
+          {!onSelect && <Actions identifier={identifier} isMCP={isMCP} type={type} />}
         </Flexbox>
         {isCommunityMCP && (
           <Modal

--- a/src/routes/(main)/settings/skill/features/McpSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/McpSkillItem.tsx
@@ -56,9 +56,9 @@ const McpSkillItem = memo<McpSkillItemProps>(
           <Flexbox horizontal align="center" gap={8} style={{ flex: 1, overflow: 'hidden' }}>
             <div className={styles.icon}>
               {avatar && avatar !== 'MCP_AVATAR' ? (
-                <Avatar avatar={avatar} shape={'square'} size={22} />
+                <Avatar avatar={avatar} shape={'square'} size={16} />
               ) : (
-                <Icon icon={McpIcon} size={18} />
+                <Icon icon={McpIcon} size={16} />
               )}
             </div>
             <span

--- a/src/routes/(main)/settings/skill/features/McpSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/McpSkillItem.tsx
@@ -7,7 +7,6 @@ import { useTranslation } from 'react-i18next';
 
 import MCPTag from '@/components/Plugins/MCPTag';
 import PluginTag from '@/components/Plugins/PluginTag';
-import SkillSourceTag from '@/components/SkillSourceTag';
 import McpDetail from '@/features/MCP/MCPDetail';
 import McpDetailLoading from '@/features/MCP/MCPDetail/Loading';
 import PluginDetailModal from '@/features/PluginDetailModal';
@@ -68,9 +67,7 @@ const McpSkillItem = memo<McpSkillItemProps>(
               {title}
             </span>
           </Flexbox>
-          {onSelect ? (
-            <SkillSourceTag source={isCustomPlugin ? 'user' : 'market'} />
-          ) : (
+          {!onSelect && (
             <Flexbox horizontal align="center" gap={4}>
               {isCustomPlugin ? (
                 <MCPTag showText={false} />

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
@@ -7,6 +7,7 @@ import { lazy, memo, Suspense, useEffect, useState } from 'react';
 
 import { ConnectorDetail } from '@/features/Connectors';
 import { useToolStore } from '@/store/tool';
+import { lobehubSkillStoreSelectors } from '@/store/tool/selectors';
 import { connectorSelectors } from '@/store/tool/slices/connector';
 
 const AgentSkillDetail = lazy(() => import('@/features/AgentSkillDetail'));
@@ -15,6 +16,7 @@ export type ToolDetailType =
   | 'agent-skill'
   | 'builtin'
   | 'builtin-skill'
+  | 'lobehub-connector'
   | 'mcp-connector'
   | 'plugin';
 
@@ -64,8 +66,12 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
 
   const syncBuiltinTool = useToolStore((s) => s.syncBuiltinTool);
   const syncPluginTools = useToolStore((s) => s.syncPluginTools);
+  const syncToolsFromClient = useToolStore((s) => s.syncToolsFromClient);
   const fetchConnectors = useToolStore((s) => s.fetchConnectors);
   const connector = useToolStore(connectorSelectors.connectorByIdentifier(identifier));
+
+  // For lobehub-connector: get the server's tool list from the store
+  const lobehubServer = useToolStore(lobehubSkillStoreSelectors.getServerByIdentifier(identifier));
 
   // For builtin-skill: look up from store
   const builtinSkill = useToolStore(
@@ -73,7 +79,11 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
     isEqual,
   );
 
-  const isConnectorType = type === 'builtin' || type === 'plugin' || type === 'mcp-connector';
+  const isConnectorType =
+    type === 'builtin' ||
+    type === 'plugin' ||
+    type === 'mcp-connector' ||
+    type === 'lobehub-connector';
 
   useEffect(() => {
     if (!isConnectorType) return;
@@ -84,6 +94,23 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
       try {
         if (type === 'builtin') {
           await syncBuiltinTool(identifier);
+        } else if (type === 'lobehub-connector') {
+          // Use tools from the lobehub skill server (already fetched via OAuth flow)
+          const tools = (lobehubServer?.tools ?? []).map((t) => ({
+            description: t.description,
+            inputSchema: t.inputSchema as Record<string, unknown>,
+            toolName: t.name,
+          }));
+          if (tools.length === 0) {
+            setNoManifest(true);
+          } else {
+            await syncToolsFromClient({
+              identifier,
+              name: lobehubServer?.name || identifier,
+              sourceType: 'marketplace',
+              tools,
+            });
+          }
         } else if (type === 'plugin') {
           await syncPluginTools(identifier);
         } else {

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
@@ -1,29 +1,21 @@
 'use client';
 
 import { Skeleton } from '@lobehub/ui';
-import { memo, useEffect, useState } from 'react';
+import { lazy, memo, Suspense, useEffect, useState } from 'react';
 
 import { ConnectorDetail } from '@/features/Connectors';
 import { useToolStore } from '@/store/tool';
 import { connectorSelectors } from '@/store/tool/slices/connector';
 
-export type ToolDetailType = 'builtin' | 'mcp-connector' | 'plugin';
+const AgentSkillDetail = lazy(() => import('@/features/AgentSkillDetail'));
+
+export type ToolDetailType = 'agent-skill' | 'builtin' | 'mcp-connector' | 'plugin';
 
 interface SkillDetailProps {
   identifier: string;
   type: ToolDetailType;
 }
 
-/**
- * Right panel for the Settings > Skill master-detail layout.
- *
- * On mount, ensures a user_connectors entry exists for the selected tool
- * (auto-syncing from the manifest for builtins and plugins), then renders
- * the shared ConnectorDetail permission editor.
- *
- * If the tool has no API manifest (e.g. agent skills), shows a graceful
- * "no tool permissions" message instead of an error.
- */
 const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
   const [syncing, setSyncing] = useState(false);
   const [noManifest, setNoManifest] = useState(false);
@@ -33,7 +25,11 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
   const fetchConnectors = useToolStore((s) => s.fetchConnectors);
   const connector = useToolStore(connectorSelectors.connectorByIdentifier(identifier));
 
+  const isAgentSkill = type === 'agent-skill';
+
   useEffect(() => {
+    if (isAgentSkill) return; // agent skills don't need connector sync
+
     setNoManifest(false);
     const ensureConnector = async () => {
       setSyncing(true);
@@ -46,7 +42,6 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
           await fetchConnectors();
         }
       } catch {
-        // Tool not found in any manifest — this is a skill without API tools
         setNoManifest(true);
       } finally {
         setSyncing(false);
@@ -55,7 +50,24 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
 
     ensureConnector();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [identifier, type]);
+  }, [identifier, type, isAgentSkill]);
+
+  // Agent skill: render detail inline instead of connector permissions
+  if (isAgentSkill) {
+    return (
+      <div style={{ flex: 1, overflow: 'auto' }}>
+        <Suspense
+          fallback={
+            <div style={{ padding: 24 }}>
+              <Skeleton active paragraph={{ rows: 6 }} title={false} />
+            </div>
+          }
+        >
+          <AgentSkillDetail skillId={identifier} />
+        </Suspense>
+      </div>
+    );
+  }
 
   if (syncing) {
     return (

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
@@ -64,7 +64,7 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
   if (error) {
     return (
       <div style={{ color: 'var(--ant-color-text-tertiary)', fontSize: 14, padding: 24 }}>
-        {error}
+        This skill does not expose configurable tool permissions.
       </div>
     );
   }

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { Skeleton } from '@lobehub/ui';
+import { Avatar, Skeleton } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import isEqual from 'fast-deep-equal';
 import { lazy, memo, Suspense, useEffect, useState } from 'react';
 
 import { ConnectorDetail } from '@/features/Connectors';
@@ -9,13 +11,53 @@ import { connectorSelectors } from '@/store/tool/slices/connector';
 
 const AgentSkillDetail = lazy(() => import('@/features/AgentSkillDetail'));
 
-export type ToolDetailType = 'agent-skill' | 'builtin' | 'mcp-connector' | 'plugin';
+export type ToolDetailType =
+  | 'agent-skill'
+  | 'builtin'
+  | 'builtin-skill'
+  | 'mcp-connector'
+  | 'plugin';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  description: css`
+    margin-block-start: 8px;
+    font-size: 13px;
+    line-height: 1.6;
+    color: ${cssVar.colorTextSecondary};
+  `,
+  header: css`
+    display: flex;
+    gap: 12px;
+    align-items: flex-start;
+
+    padding-block: 20px 16px;
+    padding-inline: 24px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  name: css`
+    font-size: 16px;
+    font-weight: 600;
+    color: ${cssVar.colorText};
+  `,
+  noPermissions: css`
+    padding: 24px;
+    font-size: 14px;
+    color: ${cssVar.colorTextTertiary};
+  `,
+}));
 
 interface SkillDetailProps {
   identifier: string;
   type: ToolDetailType;
 }
 
+/**
+ * Right panel for the Settings > Skill master-detail layout.
+ *
+ * - 'agent-skill': renders AgentSkillDetail inline (user/market agent skills with UUID id)
+ * - 'builtin-skill': renders BuiltinSkill description panel (Artifacts, Task, etc.)
+ * - 'builtin'/'plugin'/'mcp-connector': syncs connector entry, renders permission editor
+ */
 const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
   const [syncing, setSyncing] = useState(false);
   const [noManifest, setNoManifest] = useState(false);
@@ -25,10 +67,16 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
   const fetchConnectors = useToolStore((s) => s.fetchConnectors);
   const connector = useToolStore(connectorSelectors.connectorByIdentifier(identifier));
 
-  const isAgentSkill = type === 'agent-skill';
+  // For builtin-skill: look up from store
+  const builtinSkill = useToolStore(
+    (s) => s.builtinSkills?.find((sk) => sk.identifier === identifier),
+    isEqual,
+  );
+
+  const isConnectorType = type === 'builtin' || type === 'plugin' || type === 'mcp-connector';
 
   useEffect(() => {
-    if (isAgentSkill) return; // agent skills don't need connector sync
+    if (!isConnectorType) return;
 
     setNoManifest(false);
     const ensureConnector = async () => {
@@ -50,10 +98,11 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
 
     ensureConnector();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [identifier, type, isAgentSkill]);
+  }, [identifier, type, isConnectorType]);
 
-  // Agent skill: render detail inline instead of connector permissions
-  if (isAgentSkill) {
+  // ── Render by type ──────────────────────────────────────────────────────────
+
+  if (type === 'agent-skill') {
     return (
       <div style={{ flex: 1, overflow: 'auto' }}>
         <Suspense
@@ -69,6 +118,26 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
     );
   }
 
+  if (type === 'builtin-skill') {
+    return (
+      <div style={{ flex: 1, overflow: 'auto' }}>
+        <div className={styles.header}>
+          {builtinSkill?.avatar && <Avatar avatar={builtinSkill.avatar} size={40} />}
+          <div>
+            <div className={styles.name}>{builtinSkill?.name || identifier}</div>
+            {builtinSkill?.description && (
+              <div className={styles.description}>{builtinSkill.description}</div>
+            )}
+          </div>
+        </div>
+        <div className={styles.noPermissions}>
+          This is a prompt-based skill. It does not expose individual tool permissions.
+        </div>
+      </div>
+    );
+  }
+
+  // Connector types: builtin tool / plugin / mcp-connector
   if (syncing) {
     return (
       <div style={{ padding: 24 }}>
@@ -79,11 +148,9 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
 
   if (noManifest || !connector) {
     return (
-      <div style={{ padding: 24 }}>
+      <div className={styles.noPermissions}>
         <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 8 }}>{identifier}</div>
-        <div style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 14 }}>
-          This skill does not expose configurable tool permissions.
-        </div>
+        This skill does not expose configurable tool permissions.
       </div>
     );
   }

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
@@ -23,6 +23,7 @@ interface SkillDetailProps {
  */
 const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
   const [syncing, setSyncing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const syncBuiltinTool = useToolStore((s) => s.syncBuiltinTool);
   const syncPluginTools = useToolStore((s) => s.syncPluginTools);
@@ -30,6 +31,7 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
   const connector = useToolStore(connectorSelectors.connectorByIdentifier(identifier));
 
   useEffect(() => {
+    setError(null);
     const ensureConnector = async () => {
       setSyncing(true);
       try {
@@ -38,20 +40,36 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
         } else if (type === 'plugin') {
           await syncPluginTools(identifier);
         } else {
-          // mcp-connector already has an entry — just refresh
           await fetchConnectors();
         }
+      } catch (err: any) {
+        setError(err?.message ?? 'Failed to load tool details');
       } finally {
         setSyncing(false);
       }
     };
 
     ensureConnector();
-    // Re-run when identifier or type changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [identifier, type]);
 
-  if (syncing || !connector) {
+  if (syncing) {
+    return (
+      <div style={{ padding: 24 }}>
+        <Skeleton active paragraph={{ rows: 6 }} title={false} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={{ color: 'var(--ant-color-text-tertiary)', fontSize: 14, padding: 24 }}>
+        {error}
+      </div>
+    );
+  }
+
+  if (!connector) {
     return (
       <div style={{ padding: 24 }}>
         <Skeleton active paragraph={{ rows: 6 }} title={false} />

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { Skeleton } from '@lobehub/ui';
+import { memo, useEffect, useState } from 'react';
+
+import { ConnectorDetail } from '@/features/Connectors';
+import { useToolStore } from '@/store/tool';
+import { connectorSelectors } from '@/store/tool/slices/connector';
+
+export type ToolDetailType = 'builtin' | 'mcp-connector' | 'plugin';
+
+interface SkillDetailProps {
+  identifier: string;
+  type: ToolDetailType;
+}
+
+/**
+ * Right panel for the Settings > Skill master-detail layout.
+ *
+ * On mount, ensures a user_connectors entry exists for the selected tool
+ * (auto-syncing from the manifest for builtins and plugins), then renders
+ * the shared ConnectorDetail permission editor.
+ */
+const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
+  const [syncing, setSyncing] = useState(false);
+
+  const syncBuiltinTool = useToolStore((s) => s.syncBuiltinTool);
+  const syncPluginTools = useToolStore((s) => s.syncPluginTools);
+  const fetchConnectors = useToolStore((s) => s.fetchConnectors);
+  const connector = useToolStore(connectorSelectors.connectorByIdentifier(identifier));
+
+  useEffect(() => {
+    const ensureConnector = async () => {
+      setSyncing(true);
+      try {
+        if (type === 'builtin') {
+          await syncBuiltinTool(identifier);
+        } else if (type === 'plugin') {
+          await syncPluginTools(identifier);
+        } else {
+          // mcp-connector already has an entry — just refresh
+          await fetchConnectors();
+        }
+      } finally {
+        setSyncing(false);
+      }
+    };
+
+    ensureConnector();
+    // Re-run when identifier or type changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [identifier, type]);
+
+  if (syncing || !connector) {
+    return (
+      <div style={{ padding: 24 }}>
+        <Skeleton active paragraph={{ rows: 6 }} title={false} />
+      </div>
+    );
+  }
+
+  return <ConnectorDetail connectorId={connector.id} />;
+});
+
+SkillDetail.displayName = 'SkillDetail';
+
+export default SkillDetail;

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
@@ -20,10 +20,13 @@ interface SkillDetailProps {
  * On mount, ensures a user_connectors entry exists for the selected tool
  * (auto-syncing from the manifest for builtins and plugins), then renders
  * the shared ConnectorDetail permission editor.
+ *
+ * If the tool has no API manifest (e.g. agent skills), shows a graceful
+ * "no tool permissions" message instead of an error.
  */
 const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
   const [syncing, setSyncing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [noManifest, setNoManifest] = useState(false);
 
   const syncBuiltinTool = useToolStore((s) => s.syncBuiltinTool);
   const syncPluginTools = useToolStore((s) => s.syncPluginTools);
@@ -31,7 +34,7 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
   const connector = useToolStore(connectorSelectors.connectorByIdentifier(identifier));
 
   useEffect(() => {
-    setError(null);
+    setNoManifest(false);
     const ensureConnector = async () => {
       setSyncing(true);
       try {
@@ -42,8 +45,9 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
         } else {
           await fetchConnectors();
         }
-      } catch (err: any) {
-        setError(err?.message ?? 'Failed to load tool details');
+      } catch {
+        // Tool not found in any manifest — this is a skill without API tools
+        setNoManifest(true);
       } finally {
         setSyncing(false);
       }
@@ -61,18 +65,13 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
     );
   }
 
-  if (error) {
-    return (
-      <div style={{ color: 'var(--ant-color-text-tertiary)', fontSize: 14, padding: 24 }}>
-        This skill does not expose configurable tool permissions.
-      </div>
-    );
-  }
-
-  if (!connector) {
+  if (noManifest || !connector) {
     return (
       <div style={{ padding: 24 }}>
-        <Skeleton active paragraph={{ rows: 6 }} title={false} />
+        <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 8 }}>{identifier}</div>
+        <div style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 14 }}>
+          This skill does not expose configurable tool permissions.
+        </div>
       </div>
     );
   }

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Avatar, Skeleton } from '@lobehub/ui';
+import { Avatar, Markdown, Skeleton } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { lazy, memo, Suspense, useEffect, useState } from 'react';
@@ -130,9 +130,11 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type }) => {
             )}
           </div>
         </div>
-        <div className={styles.noPermissions}>
-          This is a prompt-based skill. It does not expose individual tool permissions.
-        </div>
+        {builtinSkill?.content && (
+          <div style={{ padding: '16px 24px' }}>
+            <Markdown variant="chat">{builtinSkill.content}</Markdown>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -80,390 +80,403 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
+export type SkillViewMode = 'connector' | 'skill';
+
 interface SkillListProps {
   onSelect?: (identifier: string, type: ToolDetailType) => void;
   selectedIdentifier?: string;
+  viewMode?: SkillViewMode;
 }
 
-const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
-  const { t } = useTranslation('setting');
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+const SkillList = memo<SkillListProps>(
+  ({ onSelect, selectedIdentifier, viewMode = 'connector' }) => {
+    const { t } = useTranslation('setting');
+    const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
 
-  const isLobehubSkillEnabled = useServerConfigStore(serverConfigSelectors.enableLobehubSkill);
-  const isKlavisEnabled = useServerConfigStore(serverConfigSelectors.enableKlavis);
-  const allLobehubSkillServers = useToolStore(lobehubSkillStoreSelectors.getServers, isEqual);
-  const allKlavisServers = useToolStore(klavisStoreSelectors.getServers, isEqual);
-  const installedPluginList = useToolStore(pluginSelectors.installedPluginMetaList, isEqual);
-  const marketAgentSkills = useToolStore(agentSkillsSelectors.getMarketAgentSkills, isEqual);
-  const userAgentSkills = useToolStore(agentSkillsSelectors.getUserAgentSkills, isEqual);
-  const builtinSkills = useToolStore((s) => s.builtinSkills, isEqual);
-  const allBuiltinTools = useToolStore((s) => s.builtinTools, isEqual);
-  const uninstalledBuiltinTools = useToolStore(
-    builtinToolSelectors.uninstalledBuiltinTools,
-    isEqual,
-  );
+    const isLobehubSkillEnabled = useServerConfigStore(serverConfigSelectors.enableLobehubSkill);
+    const isKlavisEnabled = useServerConfigStore(serverConfigSelectors.enableKlavis);
+    const allLobehubSkillServers = useToolStore(lobehubSkillStoreSelectors.getServers, isEqual);
+    const allKlavisServers = useToolStore(klavisStoreSelectors.getServers, isEqual);
+    const installedPluginList = useToolStore(pluginSelectors.installedPluginMetaList, isEqual);
+    const marketAgentSkills = useToolStore(agentSkillsSelectors.getMarketAgentSkills, isEqual);
+    const userAgentSkills = useToolStore(agentSkillsSelectors.getUserAgentSkills, isEqual);
+    const builtinSkills = useToolStore((s) => s.builtinSkills, isEqual);
+    const allBuiltinTools = useToolStore((s) => s.builtinTools, isEqual);
+    const uninstalledBuiltinTools = useToolStore(
+      builtinToolSelectors.uninstalledBuiltinTools,
+      isEqual,
+    );
 
-  const [
-    useFetchLobehubSkillConnections,
-    useFetchUserKlavisServers,
-    useFetchAgentSkills,
-    useFetchUninstalledBuiltinTools,
-  ] = useToolStore((s) => [
-    s.useFetchLobehubSkillConnections,
-    s.useFetchUserKlavisServers,
-    s.useFetchAgentSkills,
-    s.useFetchUninstalledBuiltinTools,
-  ]);
+    const [
+      useFetchLobehubSkillConnections,
+      useFetchUserKlavisServers,
+      useFetchAgentSkills,
+      useFetchUninstalledBuiltinTools,
+    ] = useToolStore((s) => [
+      s.useFetchLobehubSkillConnections,
+      s.useFetchUserKlavisServers,
+      s.useFetchAgentSkills,
+      s.useFetchUninstalledBuiltinTools,
+    ]);
 
-  useFetchInstalledPlugins();
-  useFetchLobehubSkillConnections(isLobehubSkillEnabled);
-  useFetchUserKlavisServers(isKlavisEnabled);
-  useFetchAgentSkills(true);
-  useFetchUninstalledBuiltinTools(true);
+    useFetchInstalledPlugins();
+    useFetchLobehubSkillConnections(isLobehubSkillEnabled);
+    useFetchUserKlavisServers(isKlavisEnabled);
+    useFetchAgentSkills(true);
+    useFetchUninstalledBuiltinTools(true);
 
-  const getLobehubSkillServerByProvider = (providerId: string) => {
-    return allLobehubSkillServers.find((server) => server.identifier === providerId);
-  };
+    const getLobehubSkillServerByProvider = (providerId: string) => {
+      return allLobehubSkillServers.find((server) => server.identifier === providerId);
+    };
 
-  const getKlavisServerByIdentifier = (identifier: string) => {
-    return allKlavisServers.find((server) => server.identifier === identifier);
-  };
+    const getKlavisServerByIdentifier = (identifier: string) => {
+      return allKlavisServers.find((server) => server.identifier === identifier);
+    };
 
-  const getBuiltinToolByIdentifier = (identifier: string) => {
-    return allBuiltinTools.find((tool) => tool.identifier === identifier);
-  };
+    const getBuiltinToolByIdentifier = (identifier: string) => {
+      return allBuiltinTools.find((tool) => tool.identifier === identifier);
+    };
 
-  const isBuiltinToolInstalled = (identifier: string) => {
-    return !uninstalledBuiltinTools.includes(identifier);
-  };
+    const isBuiltinToolInstalled = (identifier: string) => {
+      return !uninstalledBuiltinTools.includes(identifier);
+    };
 
-  // Separate skills into three categories:
-  // 1. Integrations (Builtin, LobeHub and Klavis skills)
-  // 2. Community MCP Tools (type === 'plugin')
-  // 3. Custom MCP Tools (type === 'customPlugin')
-  const { integrations, communityMCPs, customMCPs } = useMemo(() => {
-    type IntegrationItem =
-      | { builtinAgentSkill: BuiltinSkill; type: 'builtinAgent' }
-      | { builtinTool: LobeBuiltinTool; type: 'builtin' }
-      | { provider: LobehubSkillProviderType; type: 'lobehub' }
-      | { serverType: KlavisServerType; type: 'klavis' };
+    // Separate skills into three categories:
+    // 1. Integrations (Builtin, LobeHub and Klavis skills)
+    // 2. Community MCP Tools (type === 'plugin')
+    // 3. Custom MCP Tools (type === 'customPlugin')
+    const { integrations, communityMCPs, customMCPs } = useMemo(() => {
+      type IntegrationItem =
+        | { builtinAgentSkill: BuiltinSkill; type: 'builtinAgent' }
+        | { builtinTool: LobeBuiltinTool; type: 'builtin' }
+        | { provider: LobehubSkillProviderType; type: 'lobehub' }
+        | { serverType: KlavisServerType; type: 'klavis' };
 
-    let integrationItems: IntegrationItem[] = [];
+      let integrationItems: IntegrationItem[] = [];
 
-    // Add builtin agent skills first so they appear early in the list
-    for (const skill of builtinSkills) {
-      integrationItems.push({ builtinAgentSkill: skill, type: 'builtinAgent' });
-    }
-
-    const addedBuiltinIds = new Set<string>();
-    const addedLobehubIds = new Set<string>();
-    const addedKlavisIds = new Set<string>();
-
-    // If RECOMMENDED_SKILLS is configured, use it to build the list
-    if (RECOMMENDED_SKILLS.length > 0) {
-      for (const skill of RECOMMENDED_SKILLS) {
-        if (skill.type === RecommendedSkillType.Builtin) {
-          const builtinTool = getBuiltinToolByIdentifier(skill.id);
-          if (builtinTool && !builtinTool.hidden) {
-            integrationItems.push({ builtinTool, type: 'builtin' });
-            addedBuiltinIds.add(skill.id);
-          }
-        } else if (skill.type === RecommendedSkillType.Lobehub && isLobehubSkillEnabled) {
-          const provider = getLobehubSkillProviderById(skill.id);
-          if (provider) {
-            integrationItems.push({ provider, type: 'lobehub' });
-            addedLobehubIds.add(skill.id);
-          }
-        } else if (skill.type === RecommendedSkillType.Klavis && isKlavisEnabled) {
-          const serverType = getKlavisServerByServerIdentifier(skill.id);
-          if (serverType) {
-            integrationItems.push({ serverType, type: 'klavis' });
-            addedKlavisIds.add(skill.id);
-          }
-        }
+      // Add builtin agent skills first so they appear early in the list
+      for (const skill of builtinSkills) {
+        integrationItems.push({ builtinAgentSkill: skill, type: 'builtinAgent' });
       }
 
-      // Also add installed builtin tools that are not in RECOMMENDED_SKILLS
-      for (const tool of allBuiltinTools) {
-        if (
-          !tool.hidden &&
-          isBuiltinToolInstalled(tool.identifier) &&
-          !addedBuiltinIds.has(tool.identifier)
-        ) {
-          integrationItems.push({ builtinTool: tool, type: 'builtin' });
-        }
-      }
+      const addedBuiltinIds = new Set<string>();
+      const addedLobehubIds = new Set<string>();
+      const addedKlavisIds = new Set<string>();
 
-      // Also add connected Lobehub skills that are not in RECOMMENDED_SKILLS
-      if (isLobehubSkillEnabled) {
-        for (const server of allLobehubSkillServers) {
-          if (
-            server.status === LobehubSkillStatus.CONNECTED &&
-            !addedLobehubIds.has(server.identifier)
-          ) {
-            const provider = getLobehubSkillProviderById(server.identifier);
+      // If RECOMMENDED_SKILLS is configured, use it to build the list
+      if (RECOMMENDED_SKILLS.length > 0) {
+        for (const skill of RECOMMENDED_SKILLS) {
+          if (skill.type === RecommendedSkillType.Builtin) {
+            const builtinTool = getBuiltinToolByIdentifier(skill.id);
+            if (builtinTool && !builtinTool.hidden) {
+              integrationItems.push({ builtinTool, type: 'builtin' });
+              addedBuiltinIds.add(skill.id);
+            }
+          } else if (skill.type === RecommendedSkillType.Lobehub && isLobehubSkillEnabled) {
+            const provider = getLobehubSkillProviderById(skill.id);
             if (provider) {
               integrationItems.push({ provider, type: 'lobehub' });
+              addedLobehubIds.add(skill.id);
             }
-          }
-        }
-      }
-
-      // Also add connected Klavis skills that are not in RECOMMENDED_SKILLS
-      if (isKlavisEnabled) {
-        for (const server of allKlavisServers) {
-          if (
-            server.status === KlavisServerStatus.CONNECTED &&
-            !addedKlavisIds.has(server.identifier)
-          ) {
-            const serverType = getKlavisServerByServerIdentifier(server.identifier);
+          } else if (skill.type === RecommendedSkillType.Klavis && isKlavisEnabled) {
+            const serverType = getKlavisServerByServerIdentifier(skill.id);
             if (serverType) {
               integrationItems.push({ serverType, type: 'klavis' });
+              addedKlavisIds.add(skill.id);
             }
           }
         }
-      }
-    } else {
-      // Default behavior: add all non-hidden builtin tools
-      for (const tool of allBuiltinTools) {
-        if (!tool.hidden) {
-          integrationItems.push({ builtinTool: tool, type: 'builtin' });
-        }
-      }
 
-      // Add lobehub skills
-      if (isLobehubSkillEnabled) {
-        for (const provider of LOBEHUB_SKILL_PROVIDERS) {
-          integrationItems.push({ provider, type: 'lobehub' });
+        // Also add installed builtin tools that are not in RECOMMENDED_SKILLS
+        for (const tool of allBuiltinTools) {
+          if (
+            !tool.hidden &&
+            isBuiltinToolInstalled(tool.identifier) &&
+            !addedBuiltinIds.has(tool.identifier)
+          ) {
+            integrationItems.push({ builtinTool: tool, type: 'builtin' });
+          }
         }
-      }
 
-      // Add klavis skills
-      if (isKlavisEnabled) {
-        for (const serverType of KLAVIS_SERVER_TYPES) {
-          integrationItems.push({ serverType, type: 'klavis' });
+        // Also add connected Lobehub skills that are not in RECOMMENDED_SKILLS
+        if (isLobehubSkillEnabled) {
+          for (const server of allLobehubSkillServers) {
+            if (
+              server.status === LobehubSkillStatus.CONNECTED &&
+              !addedLobehubIds.has(server.identifier)
+            ) {
+              const provider = getLobehubSkillProviderById(server.identifier);
+              if (provider) {
+                integrationItems.push({ provider, type: 'lobehub' });
+              }
+            }
+          }
         }
-      }
 
-      // Filter integrations: show all builtin and lobehub skills, but only connected klavis
-      integrationItems = integrationItems.filter((item) => {
-        if (item.type === 'builtinAgent' || item.type === 'builtin' || item.type === 'lobehub') {
-          return true;
+        // Also add connected Klavis skills that are not in RECOMMENDED_SKILLS
+        if (isKlavisEnabled) {
+          for (const server of allKlavisServers) {
+            if (
+              server.status === KlavisServerStatus.CONNECTED &&
+              !addedKlavisIds.has(server.identifier)
+            ) {
+              const serverType = getKlavisServerByServerIdentifier(server.identifier);
+              if (serverType) {
+                integrationItems.push({ serverType, type: 'klavis' });
+              }
+            }
+          }
         }
-        return (
-          getKlavisServerByIdentifier(item.serverType.identifier)?.status ===
-          KlavisServerStatus.CONNECTED
-        );
-      });
-    }
+      } else {
+        // Default behavior: add all non-hidden builtin tools
+        for (const tool of allBuiltinTools) {
+          if (!tool.hidden) {
+            integrationItems.push({ builtinTool: tool, type: 'builtin' });
+          }
+        }
 
-    // Sort integrations: installed/connected ones first
-    const getIsConnected = (item: IntegrationItem) => {
-      switch (item.type) {
-        case 'builtinAgent': {
-          return isBuiltinToolInstalled(item.builtinAgentSkill.identifier);
+        // Add lobehub skills
+        if (isLobehubSkillEnabled) {
+          for (const provider of LOBEHUB_SKILL_PROVIDERS) {
+            integrationItems.push({ provider, type: 'lobehub' });
+          }
         }
-        case 'builtin': {
-          return isBuiltinToolInstalled(item.builtinTool.identifier);
+
+        // Add klavis skills
+        if (isKlavisEnabled) {
+          for (const serverType of KLAVIS_SERVER_TYPES) {
+            integrationItems.push({ serverType, type: 'klavis' });
+          }
         }
-        case 'lobehub': {
-          return (
-            getLobehubSkillServerByProvider(item.provider.id)?.status ===
-            LobehubSkillStatus.CONNECTED
-          );
-        }
-        case 'klavis': {
+
+        // Filter integrations: show all builtin and lobehub skills, but only connected klavis
+        integrationItems = integrationItems.filter((item) => {
+          if (item.type === 'builtinAgent' || item.type === 'builtin' || item.type === 'lobehub') {
+            return true;
+          }
           return (
             getKlavisServerByIdentifier(item.serverType.identifier)?.status ===
             KlavisServerStatus.CONNECTED
           );
-        }
+        });
       }
-    };
-    const sortedIntegrations = integrationItems.sort((a, b) => {
-      const isConnectedA = getIsConnected(a);
-      const isConnectedB = getIsConnected(b);
 
-      if (isConnectedA && !isConnectedB) return -1;
-      if (!isConnectedA && isConnectedB) return 1;
-      return 0;
-    });
-
-    // Separate installed plugins into community and custom
-    const communityPlugins = installedPluginList.filter((plugin) => plugin.type === 'plugin');
-    const customPlugins = installedPluginList.filter((plugin) => plugin.type === 'customPlugin');
-
-    return {
-      communityMCPs: communityPlugins,
-      customMCPs: customPlugins,
-      integrations: sortedIntegrations,
-    };
-  }, [
-    installedPluginList,
-    isLobehubSkillEnabled,
-    isKlavisEnabled,
-    allLobehubSkillServers,
-    allKlavisServers,
-    allBuiltinTools,
-    uninstalledBuiltinTools,
-    builtinSkills,
-  ]);
-
-  const hasAnySkills =
-    builtinSkills.length > 0 ||
-    integrations.length > 0 ||
-    marketAgentSkills.length > 0 ||
-    userAgentSkills.length > 0 ||
-    communityMCPs.length > 0 ||
-    customMCPs.length > 0;
-
-  if (!hasAnySkills) {
-    return (
-      <Center className={styles.container} paddingBlock={48}>
-        <Empty description={t('tab.skillDesc')} icon={SkillsIcon} title={t('tab.skillEmpty')} />
-        <AddSkillButton />
-      </Center>
-    );
-  }
-
-  const renderMarketAgentSkills = () =>
-    marketAgentSkills.map((skill) => (
-      <AgentSkillItem
-        isSelected={selectedIdentifier === skill.id}
-        key={skill.id}
-        skill={skill}
-        onSelect={onSelect ? () => onSelect(skill.id, 'agent-skill') : undefined}
-      />
-    ));
-
-  const renderUserAgentSkills = () =>
-    userAgentSkills.map((skill) => (
-      <AgentSkillItem
-        isSelected={selectedIdentifier === skill.id}
-        key={skill.id}
-        skill={skill}
-        onSelect={onSelect ? () => onSelect(skill.id, 'agent-skill') : undefined}
-      />
-    ));
-
-  const renderCommunityMCPs = () =>
-    communityMCPs.map((plugin) => (
-      <McpSkillItem
-        author={plugin.author}
-        avatar={plugin.avatar}
-        identifier={plugin.identifier}
-        isSelected={selectedIdentifier === plugin.identifier}
-        key={plugin.identifier}
-        runtimeType={plugin.runtimeType}
-        title={plugin.title || plugin.identifier}
-        type={plugin.type as LobeToolType}
-        onSelect={onSelect ? () => onSelect(plugin.identifier, 'plugin') : undefined}
-      />
-    ));
-
-  const renderCustomMCPs = () =>
-    customMCPs.map((plugin) => (
-      <McpSkillItem
-        author={plugin.author}
-        avatar={plugin.avatar}
-        identifier={plugin.identifier}
-        isSelected={selectedIdentifier === plugin.identifier}
-        key={plugin.identifier}
-        runtimeType={plugin.runtimeType}
-        title={plugin.title || plugin.identifier}
-        type={plugin.type as LobeToolType}
-        onSelect={onSelect ? () => onSelect(plugin.identifier, 'mcp-connector') : undefined}
-      />
-    ));
-
-  // Split integrations into builtin tools vs builtin skills
-  const builtinToolItems = integrations.filter((i) => i.type === 'builtin');
-  const builtinSkillItems = integrations.filter((i) => i.type === 'builtinAgent');
-  const communitySkillItems = integrations.filter(
-    (i) => i.type === 'lobehub' || i.type === 'klavis',
-  );
-
-  const toggleSection = (key: string) => {
-    setCollapsed((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  };
-
-  const renderSection = (key: string, label: string, children: React.ReactNode) => {
-    const isCollapsed = collapsed.has(key);
-    return (
-      <>
-        <div className={styles.sectionHeader} onClick={() => toggleSection(key)}>
-          {isCollapsed ? <ChevronRightIcon size={10} /> : <ChevronDownIcon size={10} />}
-          {label}
-        </div>
-        {!isCollapsed && children}
-      </>
-    );
-  };
-
-  const hasBuiltinTools = builtinToolItems.length > 0;
-  const hasBuiltinSkills = builtinSkillItems.length > 0;
-  const hasCommunitySkills = communitySkillItems.length > 0 || marketAgentSkills.length > 0;
-  const hasCommunityTools = communityMCPs.length > 0;
-  const hasCustom = userAgentSkills.length > 0 || customMCPs.length > 0;
-
-  return (
-    <div className={styles.container}>
-      {hasBuiltinTools &&
-        renderSection(
-          'builtinTools',
-          t('skillGroup.builtinTools', 'LobeHub 内置 Tools'),
-          builtinToolItems.map((item) => {
-            if (item.type !== 'builtin') return null;
-            const localizedTitle = t(`tools.builtins.${item.builtinTool.identifier}.title`, {
-              defaultValue: item.builtinTool.manifest.meta?.title || item.builtinTool.identifier,
-            });
+      // Sort integrations: installed/connected ones first
+      const getIsConnected = (item: IntegrationItem) => {
+        switch (item.type) {
+          case 'builtinAgent': {
+            return isBuiltinToolInstalled(item.builtinAgentSkill.identifier);
+          }
+          case 'builtin': {
+            return isBuiltinToolInstalled(item.builtinTool.identifier);
+          }
+          case 'lobehub': {
             return (
-              <BuiltinSkillItem
-                avatar={item.builtinTool.manifest.meta?.avatar}
-                identifier={item.builtinTool.identifier}
-                isSelected={selectedIdentifier === item.builtinTool.identifier}
-                key={item.builtinTool.identifier}
-                title={localizedTitle}
-                onSelect={
-                  onSelect ? () => onSelect(item.builtinTool.identifier, 'builtin') : undefined
-                }
-              />
+              getLobehubSkillServerByProvider(item.provider.id)?.status ===
+              LobehubSkillStatus.CONNECTED
             );
-          }),
-        )}
-
-      {hasBuiltinSkills &&
-        renderSection(
-          'builtinSkills',
-          t('skillGroup.builtinSkills', '内置 Skill'),
-          builtinSkillItems.map((item) => {
-            if (item.type !== 'builtinAgent') return null;
+          }
+          case 'klavis': {
             return (
-              <AgentSkillItem
-                isSelected={selectedIdentifier === item.builtinAgentSkill.identifier}
-                key={item.builtinAgentSkill.identifier}
-                skill={item.builtinAgentSkill}
-                onSelect={
-                  onSelect
-                    ? () => onSelect(item.builtinAgentSkill.identifier, 'builtin-skill')
-                    : undefined
-                }
-              />
+              getKlavisServerByIdentifier(item.serverType.identifier)?.status ===
+              KlavisServerStatus.CONNECTED
             );
-          }),
-        )}
+          }
+        }
+      };
+      const sortedIntegrations = integrationItems.sort((a, b) => {
+        const isConnectedA = getIsConnected(a);
+        const isConnectedB = getIsConnected(b);
 
-      {hasCommunitySkills &&
-        renderSection(
-          'communitySkills',
-          t('skillGroup.communitySkills', '社区 Skill'),
-          <>
-            {communitySkillItems.map((item) => {
+        if (isConnectedA && !isConnectedB) return -1;
+        if (!isConnectedA && isConnectedB) return 1;
+        return 0;
+      });
+
+      // Separate installed plugins into community and custom
+      const communityPlugins = installedPluginList.filter((plugin) => plugin.type === 'plugin');
+      const customPlugins = installedPluginList.filter((plugin) => plugin.type === 'customPlugin');
+
+      return {
+        communityMCPs: communityPlugins,
+        customMCPs: customPlugins,
+        integrations: sortedIntegrations,
+      };
+    }, [
+      installedPluginList,
+      isLobehubSkillEnabled,
+      isKlavisEnabled,
+      allLobehubSkillServers,
+      allKlavisServers,
+      allBuiltinTools,
+      uninstalledBuiltinTools,
+      builtinSkills,
+    ]);
+
+    const hasAnySkills =
+      builtinSkills.length > 0 ||
+      integrations.length > 0 ||
+      marketAgentSkills.length > 0 ||
+      userAgentSkills.length > 0 ||
+      communityMCPs.length > 0 ||
+      customMCPs.length > 0;
+
+    if (!hasAnySkills) {
+      return (
+        <Center className={styles.container} paddingBlock={48}>
+          <Empty description={t('tab.skillDesc')} icon={SkillsIcon} title={t('tab.skillEmpty')} />
+          <AddSkillButton />
+        </Center>
+      );
+    }
+
+    const renderMarketAgentSkills = () =>
+      marketAgentSkills.map((skill) => (
+        <AgentSkillItem
+          isSelected={selectedIdentifier === skill.id}
+          key={skill.id}
+          skill={skill}
+          onSelect={onSelect ? () => onSelect(skill.id, 'agent-skill') : undefined}
+        />
+      ));
+
+    const renderUserAgentSkills = () =>
+      userAgentSkills.map((skill) => (
+        <AgentSkillItem
+          isSelected={selectedIdentifier === skill.id}
+          key={skill.id}
+          skill={skill}
+          onSelect={onSelect ? () => onSelect(skill.id, 'agent-skill') : undefined}
+        />
+      ));
+
+    const renderCommunityMCPs = () =>
+      communityMCPs.map((plugin) => (
+        <McpSkillItem
+          author={plugin.author}
+          avatar={plugin.avatar}
+          identifier={plugin.identifier}
+          isSelected={selectedIdentifier === plugin.identifier}
+          key={plugin.identifier}
+          runtimeType={plugin.runtimeType}
+          title={plugin.title || plugin.identifier}
+          type={plugin.type as LobeToolType}
+          onSelect={onSelect ? () => onSelect(plugin.identifier, 'plugin') : undefined}
+        />
+      ));
+
+    const renderCustomMCPs = () =>
+      customMCPs.map((plugin) => (
+        <McpSkillItem
+          author={plugin.author}
+          avatar={plugin.avatar}
+          identifier={plugin.identifier}
+          isSelected={selectedIdentifier === plugin.identifier}
+          key={plugin.identifier}
+          runtimeType={plugin.runtimeType}
+          title={plugin.title || plugin.identifier}
+          type={plugin.type as LobeToolType}
+          onSelect={onSelect ? () => onSelect(plugin.identifier, 'mcp-connector') : undefined}
+        />
+      ));
+
+    // Split integrations into builtin tools vs builtin skills
+    const builtinToolItems = integrations.filter((i) => i.type === 'builtin');
+    const builtinSkillItems = integrations.filter((i) => i.type === 'builtinAgent');
+    const communitySkillItems = integrations.filter(
+      (i) => i.type === 'lobehub' || i.type === 'klavis',
+    );
+
+    const toggleSection = (key: string) => {
+      setCollapsed((prev) => {
+        const next = new Set(prev);
+        if (next.has(key)) next.delete(key);
+        else next.add(key);
+        return next;
+      });
+    };
+
+    const renderSection = (key: string, label: string, children: React.ReactNode) => {
+      const isCollapsed = collapsed.has(key);
+      return (
+        <>
+          <div className={styles.sectionHeader} onClick={() => toggleSection(key)}>
+            {isCollapsed ? <ChevronRightIcon size={10} /> : <ChevronDownIcon size={10} />}
+            {label}
+          </div>
+          {!isCollapsed && children}
+        </>
+      );
+    };
+
+    const isConnectorView = viewMode === 'connector';
+
+    // Connectors tab: tools/MCP items (provide API-level permissions)
+    // Skills tab: prompt/agent-based skills (show description/content)
+    const hasBuiltinTools = builtinToolItems.length > 0 && isConnectorView;
+    const hasBuiltinSkills = builtinSkillItems.length > 0 && !isConnectorView;
+    const hasCommunitySkills =
+      !isConnectorView && (communitySkillItems.length > 0 || marketAgentSkills.length > 0);
+    const hasCommunityTools = communityMCPs.length > 0 && isConnectorView;
+    // In connector view: custom MCPs. In skill view: user agent skills
+    const hasCustomConnectors = customMCPs.length > 0 && isConnectorView;
+    const hasCustomSkills = userAgentSkills.length > 0 && !isConnectorView;
+    // Lobehub/Klavis OAuth skills go in Connectors tab (they provide tools)
+    const hasCommunityConnectors = communitySkillItems.length > 0 && isConnectorView;
+
+    return (
+      <div className={styles.container}>
+        {hasBuiltinTools &&
+          renderSection(
+            'builtinTools',
+            t('skillGroup.builtinTools', 'LobeHub 内置 Tools'),
+            builtinToolItems.map((item) => {
+              if (item.type !== 'builtin') return null;
+              const localizedTitle = t(`tools.builtins.${item.builtinTool.identifier}.title`, {
+                defaultValue: item.builtinTool.manifest.meta?.title || item.builtinTool.identifier,
+              });
+              return (
+                <BuiltinSkillItem
+                  avatar={item.builtinTool.manifest.meta?.avatar}
+                  identifier={item.builtinTool.identifier}
+                  isSelected={selectedIdentifier === item.builtinTool.identifier}
+                  key={item.builtinTool.identifier}
+                  title={localizedTitle}
+                  onSelect={
+                    onSelect ? () => onSelect(item.builtinTool.identifier, 'builtin') : undefined
+                  }
+                />
+              );
+            }),
+          )}
+
+        {hasBuiltinSkills &&
+          renderSection(
+            'builtinSkills',
+            t('skillGroup.builtinSkills', '内置 Skill'),
+            builtinSkillItems.map((item) => {
+              if (item.type !== 'builtinAgent') return null;
+              return (
+                <AgentSkillItem
+                  isSelected={selectedIdentifier === item.builtinAgentSkill.identifier}
+                  key={item.builtinAgentSkill.identifier}
+                  skill={item.builtinAgentSkill}
+                  onSelect={
+                    onSelect
+                      ? () => onSelect(item.builtinAgentSkill.identifier, 'builtin-skill')
+                      : undefined
+                  }
+                />
+              );
+            }),
+          )}
+
+        {/* Connector view: Lobehub/Klavis OAuth connectors */}
+        {hasCommunityConnectors &&
+          renderSection(
+            'communityConnectors',
+            t('skillGroup.communityConnectors', 'OAuth Connectors'),
+            communitySkillItems.map((item) => {
               if (item.type === 'lobehub') {
                 return (
                   <LobehubSkillItem
@@ -486,34 +499,71 @@ const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
                   }
                 />
               );
-            })}
-            {renderMarketAgentSkills()}
-          </>,
-        )}
+            }),
+          )}
 
-      {hasCommunityTools &&
-        renderSection(
-          'communityTools',
-          t('skillGroup.communityTools', '社区 Tools'),
-          renderCommunityMCPs(),
-        )}
+        {/* Skill view: community skills */}
+        {hasCommunitySkills &&
+          renderSection(
+            'communitySkills',
+            t('skillGroup.communitySkills', '社区 Skill'),
+            <>
+              {communitySkillItems.map((item) => {
+                if (item.type === 'lobehub') {
+                  return (
+                    <LobehubSkillItem
+                      isSelected={selectedIdentifier === item.provider.id}
+                      key={item.provider.id}
+                      provider={item.provider}
+                      server={getLobehubSkillServerByProvider(item.provider.id)}
+                      onSelect={onSelect ? () => onSelect(item.provider.id, 'plugin') : undefined}
+                    />
+                  );
+                }
+                return (
+                  <KlavisSkillItem
+                    isSelected={selectedIdentifier === item.serverType.identifier}
+                    key={item.serverType.identifier}
+                    server={getKlavisServerByIdentifier(item.serverType.identifier)}
+                    serverType={item.serverType}
+                    onSelect={
+                      onSelect ? () => onSelect(item.serverType.identifier, 'plugin') : undefined
+                    }
+                  />
+                );
+              })}
+              {renderMarketAgentSkills()}
+            </>,
+          )}
 
-      {hasCustom &&
-        renderSection(
-          'custom',
-          t('skillGroup.custom', '自定义'),
-          <>
-            {renderCustomMCPs()}
-            {renderUserAgentSkills()}
-          </>,
-        )}
+        {hasCommunityTools &&
+          renderSection(
+            'communityTools',
+            t('skillGroup.communityTools', '社区 Tools'),
+            renderCommunityMCPs(),
+          )}
 
-      <div style={{ marginTop: 8 }}>
-        <AddSkillButton />
+        {hasCustomConnectors &&
+          renderSection(
+            'customConnectors',
+            t('skillGroup.customConnectors', '自定义 Connectors'),
+            renderCustomMCPs(),
+          )}
+
+        {hasCustomSkills &&
+          renderSection(
+            'customSkills',
+            t('skillGroup.customSkills', '自定义 Skills'),
+            renderUserAgentSkills(),
+          )}
+
+        <div style={{ marginTop: 8 }}>
+          <AddSkillButton />
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  },
+);
 
 SkillList.displayName = 'SkillList';
 

--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -15,8 +15,9 @@ import { Center, Empty } from '@lobehub/ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
+import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
 import type React from 'react';
-import { memo, useMemo } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AddSkillButton from '@/features/SkillStore/SkillList/AddSkillButton';
@@ -57,7 +58,14 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     text-align: center;
   `,
   sectionHeader: css`
-    padding-block: 8px 4px;
+    cursor: pointer;
+    user-select: none;
+
+    display: flex;
+    gap: 4px;
+    align-items: center;
+
+    padding-block: 8px 2px;
     padding-inline: 0;
 
     font-size: 11px;
@@ -65,6 +73,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorTextTertiary};
     text-transform: uppercase;
     letter-spacing: 0.5px;
+
+    &:hover {
+      color: ${cssVar.colorText};
+    }
   `,
 }));
 
@@ -75,6 +87,7 @@ interface SkillListProps {
 
 const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
   const { t } = useTranslation('setting');
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
 
   const isLobehubSkillEnabled = useServerConfigStore(serverConfigSelectors.enableLobehubSkill);
   const isKlavisEnabled = useServerConfigStore(serverConfigSelectors.enableKlavis);
@@ -370,12 +383,27 @@ const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
     (i) => i.type === 'lobehub' || i.type === 'klavis',
   );
 
-  const renderSection = (label: string, children: React.ReactNode) => (
-    <>
-      <div className={styles.sectionHeader}>{label}</div>
-      {children}
-    </>
-  );
+  const toggleSection = (key: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const renderSection = (key: string, label: string, children: React.ReactNode) => {
+    const isCollapsed = collapsed.has(key);
+    return (
+      <>
+        <div className={styles.sectionHeader} onClick={() => toggleSection(key)}>
+          {isCollapsed ? <ChevronRightIcon size={10} /> : <ChevronDownIcon size={10} />}
+          {label}
+        </div>
+        {!isCollapsed && children}
+      </>
+    );
+  };
 
   const hasBuiltinTools = builtinToolItems.length > 0;
   const hasBuiltinSkills = builtinSkillItems.length > 0;
@@ -387,6 +415,7 @@ const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
     <div className={styles.container}>
       {hasBuiltinTools &&
         renderSection(
+          'builtinTools',
           t('skillGroup.builtinTools', 'LobeHub 内置 Tools'),
           builtinToolItems.map((item) => {
             if (item.type !== 'builtin') return null;
@@ -410,6 +439,7 @@ const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
 
       {hasBuiltinSkills &&
         renderSection(
+          'builtinSkills',
           t('skillGroup.builtinSkills', '内置 Skill'),
           builtinSkillItems.map((item) => {
             if (item.type !== 'builtinAgent') return null;
@@ -430,6 +460,7 @@ const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
 
       {hasCommunitySkills &&
         renderSection(
+          'communitySkills',
           t('skillGroup.communitySkills', '社区 Skill'),
           <>
             {communitySkillItems.map((item) => {
@@ -461,10 +492,15 @@ const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
         )}
 
       {hasCommunityTools &&
-        renderSection(t('skillGroup.communityTools', '社区 Tools'), renderCommunityMCPs())}
+        renderSection(
+          'communityTools',
+          t('skillGroup.communityTools', '社区 Tools'),
+          renderCommunityMCPs(),
+        )}
 
       {hasCustom &&
         renderSection(
+          'custom',
           t('skillGroup.custom', '自定义'),
           <>
             {renderCustomMCPs()}

--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -484,7 +484,9 @@ const SkillList = memo<SkillListProps>(
                     key={item.provider.id}
                     provider={item.provider}
                     server={getLobehubSkillServerByProvider(item.provider.id)}
-                    onSelect={onSelect ? () => onSelect(item.provider.id, 'plugin') : undefined}
+                    onSelect={
+                      onSelect ? () => onSelect(item.provider.id, 'lobehub-connector') : undefined
+                    }
                   />
                 );
               }
@@ -516,7 +518,9 @@ const SkillList = memo<SkillListProps>(
                       key={item.provider.id}
                       provider={item.provider}
                       server={getLobehubSkillServerByProvider(item.provider.id)}
-                      onSelect={onSelect ? () => onSelect(item.provider.id, 'plugin') : undefined}
+                      onSelect={
+                        onSelect ? () => onSelect(item.provider.id, 'lobehub-connector') : undefined
+                      }
                     />
                   );
                 }

--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -39,6 +39,7 @@ import BuiltinSkillItem from './BuiltinSkillItem';
 import KlavisSkillItem from './KlavisSkillItem';
 import LobehubSkillItem from './LobehubSkillItem';
 import McpSkillItem from './McpSkillItem';
+import type { ToolDetailType } from './SkillDetail';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   container: css`
@@ -57,7 +58,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-const SkillList = memo(() => {
+interface SkillListProps {
+  onSelect?: (identifier: string, type: ToolDetailType) => void;
+  selectedIdentifier?: string;
+}
+
+const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
   const { t } = useTranslation('setting');
 
   const isLobehubSkillEnabled = useServerConfigStore(serverConfigSelectors.enableLobehubSkill);
@@ -312,8 +318,10 @@ const SkillList = memo(() => {
           <BuiltinSkillItem
             avatar={item.builtinTool.manifest.meta?.avatar}
             identifier={item.builtinTool.identifier}
+            isSelected={selectedIdentifier === item.builtinTool.identifier}
             key={item.builtinTool.identifier}
             title={localizedTitle}
+            onSelect={onSelect ? () => onSelect(item.builtinTool.identifier, 'builtin') : undefined}
           />
         );
       }
@@ -347,10 +355,12 @@ const SkillList = memo(() => {
         author={plugin.author}
         avatar={plugin.avatar}
         identifier={plugin.identifier}
+        isSelected={selectedIdentifier === plugin.identifier}
         key={plugin.identifier}
         runtimeType={plugin.runtimeType}
         title={plugin.title || plugin.identifier}
         type={plugin.type as LobeToolType}
+        onSelect={onSelect ? () => onSelect(plugin.identifier, 'plugin') : undefined}
       />
     ));
 
@@ -360,10 +370,12 @@ const SkillList = memo(() => {
         author={plugin.author}
         avatar={plugin.avatar}
         identifier={plugin.identifier}
+        isSelected={selectedIdentifier === plugin.identifier}
         key={plugin.identifier}
         runtimeType={plugin.runtimeType}
         title={plugin.title || plugin.identifier}
         type={plugin.type as LobeToolType}
+        onSelect={onSelect ? () => onSelect(plugin.identifier, 'mcp-connector') : undefined}
       />
     ));
 

--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -360,7 +360,7 @@ const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
         isSelected={selectedIdentifier === skill.id}
         key={skill.id}
         skill={skill}
-        onSelect={onSelect ? () => onSelect(skill.id, 'plugin') : undefined}
+        onSelect={onSelect ? () => onSelect(skill.id, 'agent-skill') : undefined}
       />
     ));
 
@@ -370,7 +370,7 @@ const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
         isSelected={selectedIdentifier === skill.id}
         key={skill.id}
         skill={skill}
-        onSelect={onSelect ? () => onSelect(skill.id, 'plugin') : undefined}
+        onSelect={onSelect ? () => onSelect(skill.id, 'agent-skill') : undefined}
       />
     ));
 

--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -312,7 +312,9 @@ const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
             key={item.builtinAgentSkill.identifier}
             skill={item.builtinAgentSkill}
             onSelect={
-              onSelect ? () => onSelect(item.builtinAgentSkill.identifier, 'builtin') : undefined
+              onSelect
+                ? () => onSelect(item.builtinAgentSkill.identifier, 'builtin-skill')
+                : undefined
             }
           />
         );

--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -328,17 +328,21 @@ const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
       if (item.type === 'lobehub') {
         return (
           <LobehubSkillItem
+            isSelected={selectedIdentifier === item.provider.id}
             key={item.provider.id}
             provider={item.provider}
             server={getLobehubSkillServerByProvider(item.provider.id)}
+            onSelect={onSelect ? () => onSelect(item.provider.id, 'plugin') : undefined}
           />
         );
       }
       return (
         <KlavisSkillItem
+          isSelected={selectedIdentifier === item.serverType.identifier}
           key={item.serverType.identifier}
           server={getKlavisServerByIdentifier(item.serverType.identifier)}
           serverType={item.serverType}
+          onSelect={onSelect ? () => onSelect(item.serverType.identifier, 'plugin') : undefined}
         />
       );
     });

--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -13,9 +13,9 @@ import {
 import { type BuiltinSkill, type LobeBuiltinTool } from '@lobechat/types';
 import { Center, Empty } from '@lobehub/ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
-import { Divider } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
+import type React from 'react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -45,7 +45,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   container: css`
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 2px;
   `,
   description: css`
     margin-block-end: 8px;
@@ -55,6 +55,16 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     padding: 24px;
     color: ${cssVar.colorTextTertiary};
     text-align: center;
+  `,
+  sectionHeader: css`
+    padding-block: 8px 4px;
+    padding-inline: 0;
+
+    font-size: 11px;
+    font-weight: 500;
+    color: ${cssVar.colorTextTertiary};
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
   `,
 }));
 
@@ -303,59 +313,6 @@ const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
     );
   }
 
-  const renderIntegrations = () =>
-    integrations.map((item) => {
-      if (item.type === 'builtinAgent') {
-        return (
-          <AgentSkillItem
-            isSelected={selectedIdentifier === item.builtinAgentSkill.identifier}
-            key={item.builtinAgentSkill.identifier}
-            skill={item.builtinAgentSkill}
-            onSelect={
-              onSelect
-                ? () => onSelect(item.builtinAgentSkill.identifier, 'builtin-skill')
-                : undefined
-            }
-          />
-        );
-      }
-      if (item.type === 'builtin') {
-        const localizedTitle = t(`tools.builtins.${item.builtinTool.identifier}.title`, {
-          defaultValue: item.builtinTool.manifest.meta?.title || item.builtinTool.identifier,
-        });
-        return (
-          <BuiltinSkillItem
-            avatar={item.builtinTool.manifest.meta?.avatar}
-            identifier={item.builtinTool.identifier}
-            isSelected={selectedIdentifier === item.builtinTool.identifier}
-            key={item.builtinTool.identifier}
-            title={localizedTitle}
-            onSelect={onSelect ? () => onSelect(item.builtinTool.identifier, 'builtin') : undefined}
-          />
-        );
-      }
-      if (item.type === 'lobehub') {
-        return (
-          <LobehubSkillItem
-            isSelected={selectedIdentifier === item.provider.id}
-            key={item.provider.id}
-            provider={item.provider}
-            server={getLobehubSkillServerByProvider(item.provider.id)}
-            onSelect={onSelect ? () => onSelect(item.provider.id, 'plugin') : undefined}
-          />
-        );
-      }
-      return (
-        <KlavisSkillItem
-          isSelected={selectedIdentifier === item.serverType.identifier}
-          key={item.serverType.identifier}
-          server={getKlavisServerByIdentifier(item.serverType.identifier)}
-          serverType={item.serverType}
-          onSelect={onSelect ? () => onSelect(item.serverType.identifier, 'plugin') : undefined}
-        />
-      );
-    });
-
   const renderMarketAgentSkills = () =>
     marketAgentSkills.map((skill) => (
       <AgentSkillItem
@@ -406,21 +363,115 @@ const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
       />
     ));
 
-  const hasIntegrationsSection = integrations.length > 0;
-  const hasCommunitySection = communityMCPs.length > 0 || marketAgentSkills.length > 0;
-  const hasCustomSection = userAgentSkills.length > 0 || customMCPs.length > 0;
+  // Split integrations into builtin tools vs builtin skills
+  const builtinToolItems = integrations.filter((i) => i.type === 'builtin');
+  const builtinSkillItems = integrations.filter((i) => i.type === 'builtinAgent');
+  const communitySkillItems = integrations.filter(
+    (i) => i.type === 'lobehub' || i.type === 'klavis',
+  );
+
+  const renderSection = (label: string, children: React.ReactNode) => (
+    <>
+      <div className={styles.sectionHeader}>{label}</div>
+      {children}
+    </>
+  );
+
+  const hasBuiltinTools = builtinToolItems.length > 0;
+  const hasBuiltinSkills = builtinSkillItems.length > 0;
+  const hasCommunitySkills = communitySkillItems.length > 0 || marketAgentSkills.length > 0;
+  const hasCommunityTools = communityMCPs.length > 0;
+  const hasCustom = userAgentSkills.length > 0 || customMCPs.length > 0;
 
   return (
     <div className={styles.container}>
-      {integrations.length > 0 && renderIntegrations()}
-      {hasIntegrationsSection && hasCommunitySection && <Divider style={{ margin: 0 }} />}
-      {marketAgentSkills.length > 0 && renderMarketAgentSkills()}
-      {communityMCPs.length > 0 && renderCommunityMCPs()}
-      {(hasIntegrationsSection || hasCommunitySection) && hasCustomSection && (
-        <Divider style={{ margin: 0 }} />
-      )}
-      {userAgentSkills.length > 0 && renderUserAgentSkills()}
-      {customMCPs.length > 0 && renderCustomMCPs()}
+      {hasBuiltinTools &&
+        renderSection(
+          t('skillGroup.builtinTools', 'LobeHub 内置 Tools'),
+          builtinToolItems.map((item) => {
+            if (item.type !== 'builtin') return null;
+            const localizedTitle = t(`tools.builtins.${item.builtinTool.identifier}.title`, {
+              defaultValue: item.builtinTool.manifest.meta?.title || item.builtinTool.identifier,
+            });
+            return (
+              <BuiltinSkillItem
+                avatar={item.builtinTool.manifest.meta?.avatar}
+                identifier={item.builtinTool.identifier}
+                isSelected={selectedIdentifier === item.builtinTool.identifier}
+                key={item.builtinTool.identifier}
+                title={localizedTitle}
+                onSelect={
+                  onSelect ? () => onSelect(item.builtinTool.identifier, 'builtin') : undefined
+                }
+              />
+            );
+          }),
+        )}
+
+      {hasBuiltinSkills &&
+        renderSection(
+          t('skillGroup.builtinSkills', '内置 Skill'),
+          builtinSkillItems.map((item) => {
+            if (item.type !== 'builtinAgent') return null;
+            return (
+              <AgentSkillItem
+                isSelected={selectedIdentifier === item.builtinAgentSkill.identifier}
+                key={item.builtinAgentSkill.identifier}
+                skill={item.builtinAgentSkill}
+                onSelect={
+                  onSelect
+                    ? () => onSelect(item.builtinAgentSkill.identifier, 'builtin-skill')
+                    : undefined
+                }
+              />
+            );
+          }),
+        )}
+
+      {hasCommunitySkills &&
+        renderSection(
+          t('skillGroup.communitySkills', '社区 Skill'),
+          <>
+            {communitySkillItems.map((item) => {
+              if (item.type === 'lobehub') {
+                return (
+                  <LobehubSkillItem
+                    isSelected={selectedIdentifier === item.provider.id}
+                    key={item.provider.id}
+                    provider={item.provider}
+                    server={getLobehubSkillServerByProvider(item.provider.id)}
+                    onSelect={onSelect ? () => onSelect(item.provider.id, 'plugin') : undefined}
+                  />
+                );
+              }
+              return (
+                <KlavisSkillItem
+                  isSelected={selectedIdentifier === item.serverType.identifier}
+                  key={item.serverType.identifier}
+                  server={getKlavisServerByIdentifier(item.serverType.identifier)}
+                  serverType={item.serverType}
+                  onSelect={
+                    onSelect ? () => onSelect(item.serverType.identifier, 'plugin') : undefined
+                  }
+                />
+              );
+            })}
+            {renderMarketAgentSkills()}
+          </>,
+        )}
+
+      {hasCommunityTools &&
+        renderSection(t('skillGroup.communityTools', '社区 Tools'), renderCommunityMCPs())}
+
+      {hasCustom &&
+        renderSection(
+          t('skillGroup.custom', '自定义'),
+          <>
+            {renderCustomMCPs()}
+            {renderUserAgentSkills()}
+          </>,
+        )}
+
       <div style={{ marginTop: 8 }}>
         <AddSkillButton />
       </div>

--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -71,8 +71,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     font-size: 11px;
     font-weight: 500;
     color: ${cssVar.colorTextTertiary};
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
 
     &:hover {
       color: ${cssVar.colorText};

--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -307,7 +307,14 @@ const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
     integrations.map((item) => {
       if (item.type === 'builtinAgent') {
         return (
-          <AgentSkillItem key={item.builtinAgentSkill.identifier} skill={item.builtinAgentSkill} />
+          <AgentSkillItem
+            isSelected={selectedIdentifier === item.builtinAgentSkill.identifier}
+            key={item.builtinAgentSkill.identifier}
+            skill={item.builtinAgentSkill}
+            onSelect={
+              onSelect ? () => onSelect(item.builtinAgentSkill.identifier, 'builtin') : undefined
+            }
+          />
         );
       }
       if (item.type === 'builtin') {
@@ -348,10 +355,24 @@ const SkillList = memo<SkillListProps>(({ onSelect, selectedIdentifier }) => {
     });
 
   const renderMarketAgentSkills = () =>
-    marketAgentSkills.map((skill) => <AgentSkillItem key={skill.id} skill={skill} />);
+    marketAgentSkills.map((skill) => (
+      <AgentSkillItem
+        isSelected={selectedIdentifier === skill.id}
+        key={skill.id}
+        skill={skill}
+        onSelect={onSelect ? () => onSelect(skill.id, 'plugin') : undefined}
+      />
+    ));
 
   const renderUserAgentSkills = () =>
-    userAgentSkills.map((skill) => <AgentSkillItem key={skill.id} skill={skill} />);
+    userAgentSkills.map((skill) => (
+      <AgentSkillItem
+        isSelected={selectedIdentifier === skill.id}
+        key={skill.id}
+        skill={skill}
+        onSelect={onSelect ? () => onSelect(skill.id, 'plugin') : undefined}
+      />
+    ));
 
   const renderCommunityMCPs = () =>
     communityMCPs.map((plugin) => (

--- a/src/routes/(main)/settings/skill/features/style.ts
+++ b/src/routes/(main)/settings/skill/features/style.ts
@@ -2,46 +2,46 @@ import { createStaticStyles } from 'antd-style';
 
 export const styles = createStaticStyles(({ css, cssVar }) => ({
   connected: css`
-    font-size: 14px;
+    font-size: 12px;
     color: ${cssVar.colorSuccess};
   `,
   container: css`
-    padding-block: 6px;
+    padding-block: 3px;
     padding-inline: 0;
   `,
   disconnected: css`
-    font-size: 14px;
+    font-size: 12px;
     color: ${cssVar.colorTextTertiary};
   `,
   disconnectedIcon: css`
-    opacity: 0.5;
+    opacity: 0.4;
   `,
   disconnectedTitle: css`
     opacity: 0.5;
   `,
   error: css`
-    font-size: 14px;
+    font-size: 12px;
     color: ${cssVar.colorError};
   `,
+  /* No background — just the avatar/icon itself, matching reference design */
   icon: css`
+    overflow: hidden;
     display: flex;
     flex-shrink: 0;
     align-items: center;
     justify-content: center;
 
-    width: 36px;
-    height: 36px;
-    border-radius: 8px;
-
-    background: ${cssVar.colorFillTertiary};
+    width: 24px;
+    height: 24px;
+    border-radius: 6px;
   `,
   pending: css`
-    font-size: 14px;
+    font-size: 12px;
     color: ${cssVar.colorWarning};
   `,
   title: css`
     cursor: pointer;
-    font-size: 15px;
+    font-size: 13px;
     font-weight: 500;
     color: ${cssVar.colorText};
 

--- a/src/routes/(main)/settings/skill/features/style.ts
+++ b/src/routes/(main)/settings/skill/features/style.ts
@@ -6,8 +6,8 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorSuccess};
   `,
   container: css`
-    padding-block: 3px;
-    padding-inline: 0;
+    padding-block: 6px;
+    padding-inline: 4px;
   `,
   disconnected: css`
     font-size: 12px;
@@ -23,7 +23,6 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     font-size: 12px;
     color: ${cssVar.colorError};
   `,
-  /* No background — just the avatar/icon itself, matching reference design */
   icon: css`
     overflow: hidden;
     display: flex;
@@ -31,9 +30,9 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     align-items: center;
     justify-content: center;
 
-    width: 24px;
-    height: 24px;
-    border-radius: 6px;
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
   `,
   pending: css`
     font-size: 12px;
@@ -41,8 +40,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   title: css`
     cursor: pointer;
-    font-size: 13px;
-    font-weight: 500;
+    font-size: 14px;
     color: ${cssVar.colorText};
 
     &:hover {

--- a/src/routes/(main)/settings/skill/features/style.ts
+++ b/src/routes/(main)/settings/skill/features/style.ts
@@ -6,7 +6,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorSuccess};
   `,
   container: css`
-    padding-block: 12px;
+    padding-block: 6px;
     padding-inline: 0;
   `,
   disconnected: css`
@@ -29,9 +29,9 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     align-items: center;
     justify-content: center;
 
-    width: 48px;
-    height: 48px;
-    border-radius: 12px;
+    width: 36px;
+    height: 36px;
+    border-radius: 8px;
 
     background: ${cssVar.colorFillTertiary};
   `,

--- a/src/routes/(main)/settings/skill/index.tsx
+++ b/src/routes/(main)/settings/skill/index.tsx
@@ -3,11 +3,10 @@
 import { Button, Icon } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
-import { PlusIcon, Store } from 'lucide-react';
+import { Store } from 'lucide-react';
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { AddConnectorModal } from '@/features/Connectors';
 import NavHeader from '@/features/NavHeader';
 import { createSkillStoreModal } from '@/features/SkillStore';
 import { useToolStore } from '@/store/tool';
@@ -83,7 +82,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 const Page = memo(() => {
   const { t } = useTranslation('setting');
   const [selected, setSelected] = useState<SelectedTool | null>(null);
-  const [showAddConnector, setShowAddConnector] = useState(false);
   const [viewMode, setViewMode] = useState<SkillViewMode>('connector');
 
   // Data sources for auto-select
@@ -148,13 +146,6 @@ const Page = memo(() => {
             </div>
 
             <div style={{ display: 'flex', gap: 6 }}>
-              {viewMode === 'connector' && (
-                <Button
-                  icon={<Icon icon={PlusIcon} />}
-                  size="small"
-                  onClick={() => setShowAddConnector(true)}
-                />
-              )}
               <Button icon={<Icon icon={Store} />} size="small" onClick={handleOpenStore} />
             </div>
           </div>
@@ -175,8 +166,6 @@ const Page = memo(() => {
           </div>
         )}
       </div>
-
-      <AddConnectorModal open={showAddConnector} onClose={() => setShowAddConnector(false)} />
     </>
   );
 });

--- a/src/routes/(main)/settings/skill/index.tsx
+++ b/src/routes/(main)/settings/skill/index.tsx
@@ -14,7 +14,7 @@ import { useToolStore } from '@/store/tool';
 import { builtinToolSelectors } from '@/store/tool/selectors';
 
 import SkillDetail, { type ToolDetailType } from './features/SkillDetail';
-import SkillList from './features/SkillList';
+import SkillList, { type SkillViewMode } from './features/SkillList';
 
 export interface SelectedTool {
   identifier: string;
@@ -28,6 +28,9 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   left: css`
     overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+
     width: 300px;
     min-width: 260px;
     border-inline-end: 1px solid ${cssVar.colorBorderSecondary};
@@ -38,7 +41,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     align-items: center;
     justify-content: space-between;
 
-    padding-block: 12px;
+    padding-block: 10px;
     padding-inline: 16px;
     border-block-end: 1px solid ${cssVar.colorBorderSecondary};
   `,
@@ -48,38 +51,70 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     flex: 1;
     height: 100%;
   `,
+  tab: css`
+    cursor: pointer;
+
+    padding-block: 4px;
+    padding-inline: 10px;
+    border-radius: 6px;
+
+    font-size: 13px;
+    font-weight: 500;
+    color: ${cssVar.colorTextSecondary};
+
+    transition: all 0.15s;
+
+    &:hover {
+      color: ${cssVar.colorText};
+      background: ${cssVar.colorFillSecondary};
+    }
+  `,
+  tabActive: css`
+    color: ${cssVar.colorText};
+    background: ${cssVar.colorFillSecondary};
+  `,
+  tabs: css`
+    display: flex;
+    gap: 2px;
+    align-items: center;
+  `,
 }));
 
 const Page = memo(() => {
   const { t } = useTranslation('setting');
   const [selected, setSelected] = useState<SelectedTool | null>(null);
   const [showAddConnector, setShowAddConnector] = useState(false);
+  const [viewMode, setViewMode] = useState<SkillViewMode>('connector');
 
   // Data sources for auto-select
   const builtinTools = useToolStore((s) => s.builtinTools, isEqual);
   const builtinSkills = useToolStore((s) => s.builtinSkills, isEqual);
   const installedBuiltinIds = useToolStore(
-    (s) => builtinToolSelectors.installedAllMetaList(s).map((t) => t.identifier),
+    (s) => builtinToolSelectors.installedAllMetaList(s).map((tool) => tool.identifier),
     isEqual,
   );
 
-  // Auto-select the first visible item on load
+  // Auto-select first item when view changes or on load
+  useEffect(() => {
+    setSelected(null);
+  }, [viewMode]);
+
   useEffect(() => {
     if (selected) return;
-    // 1. First installed builtin tool
-    const firstTool = builtinTools.find(
-      (t) => !t.hidden && installedBuiltinIds.includes(t.identifier),
-    );
-    if (firstTool) {
-      setSelected({ identifier: firstTool.identifier, type: 'builtin' });
-      return;
+    if (viewMode === 'connector') {
+      const firstTool = builtinTools.find(
+        (tool) => !tool.hidden && installedBuiltinIds.includes(tool.identifier),
+      );
+      if (firstTool) {
+        setSelected({ identifier: firstTool.identifier, type: 'builtin' });
+      }
+    } else {
+      const firstSkill = builtinSkills[0];
+      if (firstSkill) {
+        setSelected({ identifier: firstSkill.identifier, type: 'builtin-skill' });
+      }
     }
-    // 2. First builtin skill
-    const firstSkill = builtinSkills[0];
-    if (firstSkill) {
-      setSelected({ identifier: firstSkill.identifier, type: 'builtin-skill' });
-    }
-  }, [builtinTools, builtinSkills, installedBuiltinIds, selected]);
+  }, [builtinTools, builtinSkills, installedBuiltinIds, selected, viewMode]);
 
   const handleOpenStore = useCallback(() => {
     createSkillStoreModal();
@@ -93,25 +128,43 @@ const Page = memo(() => {
     <>
       <NavHeader />
       <div className={styles.root}>
-        {/* Left: unified skill list */}
+        {/* Left panel */}
         <div className={styles.left}>
           <div className={styles.leftHeader}>
-            <span style={{ fontWeight: 600 }}>{t('tab.skill')}</span>
+            {/* Connector / Skill tab switcher */}
+            <div className={styles.tabs}>
+              <span
+                className={`${styles.tab} ${viewMode === 'connector' ? styles.tabActive : ''}`}
+                onClick={() => setViewMode('connector')}
+              >
+                {t('skillView.connectors', 'Connectors')}
+              </span>
+              <span
+                className={`${styles.tab} ${viewMode === 'skill' ? styles.tabActive : ''}`}
+                onClick={() => setViewMode('skill')}
+              >
+                {t('skillView.skills', 'Skills')}
+              </span>
+            </div>
+
             <div style={{ display: 'flex', gap: 6 }}>
-              {/* + opens "Add custom MCP connector" modal */}
-              <Button
-                icon={<Icon icon={PlusIcon} />}
-                size="small"
-                onClick={() => setShowAddConnector(true)}
-              />
-              {/* Skill store for built-in / community skills */}
-              <Button icon={<Icon icon={Store} />} size="small" onClick={handleOpenStore}>
-                {t('skillStore.button')}
-              </Button>
+              {viewMode === 'connector' && (
+                <Button
+                  icon={<Icon icon={PlusIcon} />}
+                  size="small"
+                  onClick={() => setShowAddConnector(true)}
+                />
+              )}
+              <Button icon={<Icon icon={Store} />} size="small" onClick={handleOpenStore} />
             </div>
           </div>
-          <div style={{ padding: '4px 8px' }}>
-            <SkillList selectedIdentifier={selected?.identifier} onSelect={handleSelect} />
+
+          <div style={{ flex: 1, overflowY: 'auto', padding: '4px 8px' }}>
+            <SkillList
+              selectedIdentifier={selected?.identifier}
+              viewMode={viewMode}
+              onSelect={handleSelect}
+            />
           </div>
         </div>
 

--- a/src/routes/(main)/settings/skill/index.tsx
+++ b/src/routes/(main)/settings/skill/index.tsx
@@ -17,7 +17,7 @@ export interface SelectedTool {
   type: ToolDetailType;
 }
 
-const useStyles = createStaticStyles(({ css, cssVar }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   detail: css`
     overflow-y: auto;
     flex: 1;
@@ -57,7 +57,6 @@ const useStyles = createStaticStyles(({ css, cssVar }) => ({
 
 const Page = memo(() => {
   const { t } = useTranslation('setting');
-  const { styles } = useStyles();
   const [selected, setSelected] = useState<SelectedTool | null>(null);
 
   const handleOpenStore = useCallback(() => {

--- a/src/routes/(main)/settings/skill/index.tsx
+++ b/src/routes/(main)/settings/skill/index.tsx
@@ -1,37 +1,108 @@
 'use client';
 
 import { Button, Icon } from '@lobehub/ui';
-import { Store } from 'lucide-react';
-import { useCallback } from 'react';
+import { createStaticStyles } from 'antd-style';
+import { PlusIcon, Store } from 'lucide-react';
+import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import NavHeader from '@/features/NavHeader';
 import { createSkillStoreModal } from '@/features/SkillStore';
-import SettingHeader from '@/routes/(main)/settings/features/SettingHeader';
 
+import SkillDetail, { type ToolDetailType } from './features/SkillDetail';
 import SkillList from './features/SkillList';
 
-const Page = () => {
+export interface SelectedTool {
+  identifier: string;
+  type: ToolDetailType;
+}
+
+const useStyles = createStaticStyles(({ css, cssVar }) => ({
+  detail: css`
+    overflow-y: auto;
+    flex: 1;
+  `,
+  empty: css`
+    display: flex;
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+
+    font-size: 14px;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  left: css`
+    overflow-y: auto;
+    width: 300px;
+    min-width: 260px;
+    border-inline-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  leftHeader: css`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    justify-content: space-between;
+
+    padding-block: 12px;
+    padding-inline: 16px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+  `,
+  root: css`
+    overflow: hidden;
+    display: flex;
+    flex: 1;
+    height: 100%;
+  `,
+}));
+
+const Page = memo(() => {
   const { t } = useTranslation('setting');
+  const { styles } = useStyles();
+  const [selected, setSelected] = useState<SelectedTool | null>(null);
 
   const handleOpenStore = useCallback(() => {
     createSkillStoreModal();
   }, []);
 
+  const handleSelect = (identifier: string, type: ToolDetailType) => {
+    setSelected({ identifier, type });
+  };
+
   return (
     <>
-      <SettingHeader
-        title={t('tab.skill')}
-        extra={
-          <Button icon={<Icon icon={Store} />} size="large" onClick={handleOpenStore}>
-            {t('skillStore.button')}
-          </Button>
-        }
-      />
-      <SkillList />
+      <NavHeader />
+      <div className={styles.root}>
+        {/* Left: unified skill list */}
+        <div className={styles.left}>
+          <div className={styles.leftHeader}>
+            <span style={{ fontWeight: 600 }}>{t('tab.skill')}</span>
+            <div style={{ display: 'flex', gap: 6 }}>
+              <Button icon={<Icon icon={PlusIcon} />} size="small" onClick={handleOpenStore} />
+              <Button icon={<Icon icon={Store} />} size="small" onClick={handleOpenStore}>
+                {t('skillStore.button')}
+              </Button>
+            </div>
+          </div>
+          <div style={{ padding: '4px 8px' }}>
+            <SkillList selectedIdentifier={selected?.identifier} onSelect={handleSelect} />
+          </div>
+        </div>
+
+        {/* Right: tool detail + permissions */}
+        {selected ? (
+          <div className={styles.detail}>
+            <SkillDetail identifier={selected.identifier} type={selected.type} />
+          </div>
+        ) : (
+          <div className={styles.empty}>
+            {t('skillDetail.selectHint', 'Select a skill to configure its tool permissions')}
+          </div>
+        )}
+      </div>
     </>
   );
-};
+});
 
-Page.displayName = 'SkillsSetting';
+Page.displayName = 'SkillSettings';
 
 export default Page;

--- a/src/routes/(main)/settings/skill/index.tsx
+++ b/src/routes/(main)/settings/skill/index.tsx
@@ -2,12 +2,16 @@
 
 import { Button, Icon } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
+import isEqual from 'fast-deep-equal';
 import { PlusIcon, Store } from 'lucide-react';
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { AddConnectorModal } from '@/features/Connectors';
 import NavHeader from '@/features/NavHeader';
 import { createSkillStoreModal } from '@/features/SkillStore';
+import { useToolStore } from '@/store/tool';
+import { builtinToolSelectors } from '@/store/tool/selectors';
 
 import SkillDetail, { type ToolDetailType } from './features/SkillDetail';
 import SkillList from './features/SkillList';
@@ -21,15 +25,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   detail: css`
     overflow-y: auto;
     flex: 1;
-  `,
-  empty: css`
-    display: flex;
-    flex: 1;
-    align-items: center;
-    justify-content: center;
-
-    font-size: 14px;
-    color: ${cssVar.colorTextTertiary};
   `,
   left: css`
     overflow-y: auto;
@@ -58,6 +53,33 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 const Page = memo(() => {
   const { t } = useTranslation('setting');
   const [selected, setSelected] = useState<SelectedTool | null>(null);
+  const [showAddConnector, setShowAddConnector] = useState(false);
+
+  // Data sources for auto-select
+  const builtinTools = useToolStore((s) => s.builtinTools, isEqual);
+  const builtinSkills = useToolStore((s) => s.builtinSkills, isEqual);
+  const installedBuiltinIds = useToolStore(
+    (s) => builtinToolSelectors.installedAllMetaList(s).map((t) => t.identifier),
+    isEqual,
+  );
+
+  // Auto-select the first visible item on load
+  useEffect(() => {
+    if (selected) return;
+    // 1. First installed builtin tool
+    const firstTool = builtinTools.find(
+      (t) => !t.hidden && installedBuiltinIds.includes(t.identifier),
+    );
+    if (firstTool) {
+      setSelected({ identifier: firstTool.identifier, type: 'builtin' });
+      return;
+    }
+    // 2. First builtin skill
+    const firstSkill = builtinSkills[0];
+    if (firstSkill) {
+      setSelected({ identifier: firstSkill.identifier, type: 'builtin-skill' });
+    }
+  }, [builtinTools, builtinSkills, installedBuiltinIds, selected]);
 
   const handleOpenStore = useCallback(() => {
     createSkillStoreModal();
@@ -76,7 +98,13 @@ const Page = memo(() => {
           <div className={styles.leftHeader}>
             <span style={{ fontWeight: 600 }}>{t('tab.skill')}</span>
             <div style={{ display: 'flex', gap: 6 }}>
-              <Button icon={<Icon icon={PlusIcon} />} size="small" onClick={handleOpenStore} />
+              {/* + opens "Add custom MCP connector" modal */}
+              <Button
+                icon={<Icon icon={PlusIcon} />}
+                size="small"
+                onClick={() => setShowAddConnector(true)}
+              />
+              {/* Skill store for built-in / community skills */}
               <Button icon={<Icon icon={Store} />} size="small" onClick={handleOpenStore}>
                 {t('skillStore.button')}
               </Button>
@@ -88,16 +116,14 @@ const Page = memo(() => {
         </div>
 
         {/* Right: tool detail + permissions */}
-        {selected ? (
+        {selected && (
           <div className={styles.detail}>
             <SkillDetail identifier={selected.identifier} type={selected.type} />
           </div>
-        ) : (
-          <div className={styles.empty}>
-            {t('skillDetail.selectHint', 'Select a skill to configure its tool permissions')}
-          </div>
         )}
       </div>
+
+      <AddConnectorModal open={showAddConnector} onClose={() => setShowAddConnector(false)} />
     </>
   );
 });

--- a/src/server/routers/lambda/connector.ts
+++ b/src/server/routers/lambda/connector.ts
@@ -177,6 +177,21 @@ export const connectorRouter = router({
       return { toolCount: syncInputs.length };
     }),
 
+  /**
+   * Reset all tool permissions for a connector back to 'auto' (fully open).
+   */
+  resetPermissions: connectorProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ input, ctx }) => {
+      const tools = await ctx.connectorToolModel.queryByConnector(input.id);
+      await Promise.all(
+        tools.map((t) =>
+          ctx.connectorToolModel.updatePermission(t.id, ConnectorToolPermission.auto),
+        ),
+      );
+      return { toolCount: tools.length };
+    }),
+
   updateToolPermission: connectorProcedure
     .input(
       z.object({

--- a/src/server/routers/lambda/connector.ts
+++ b/src/server/routers/lambda/connector.ts
@@ -1,0 +1,219 @@
+import { TRPCError } from '@trpc/server';
+import { z } from 'zod';
+
+import { ConnectorModel } from '@/database/models/connector';
+import { ConnectorToolModel } from '@/database/models/connectorTool';
+import type { ConnectorCredentials } from '@/database/schemas';
+import {
+  ConnectorMcpConnectionType,
+  ConnectorSourceType,
+  ConnectorStatus,
+  ConnectorToolPermission,
+} from '@/database/schemas';
+import type { AuthConfig } from '@/libs/mcp';
+import { inferCrudType } from '@/libs/mcp/utils';
+import { authedProcedure, router } from '@/libs/trpc/lambda';
+import { serverDatabase } from '@/libs/trpc/lambda/middleware';
+import { mcpService } from '@/server/services/mcp';
+
+const connectorProcedure = authedProcedure.use(serverDatabase).use(async (opts) => {
+  const { ctx } = opts;
+  return opts.next({
+    ctx: {
+      connectorModel: new ConnectorModel(ctx.serverDB, ctx.userId),
+      connectorToolModel: new ConnectorToolModel(ctx.serverDB, ctx.userId),
+    },
+  });
+});
+
+const createConnectorSchema = z.object({
+  identifier: z.string().min(1).max(255),
+  isEnabled: z.boolean().optional().default(true),
+  mcpConnectionType: z
+    .enum([
+      ConnectorMcpConnectionType.http,
+      ConnectorMcpConnectionType.stdio,
+      ConnectorMcpConnectionType.cloud,
+    ])
+    .optional(),
+  mcpServerUrl: z.string().url().optional(),
+  mcpStdioConfig: z
+    .object({
+      args: z.array(z.string()).optional(),
+      command: z.string(),
+      env: z.record(z.string()).optional(),
+    })
+    .optional(),
+  metadata: z.record(z.unknown()).optional(),
+  name: z.string().min(1).max(255),
+  oidcConfig: z.record(z.unknown()).optional(),
+  sourceType: z.enum([
+    ConnectorSourceType.builtin,
+    ConnectorSourceType.custom,
+    ConnectorSourceType.marketplace,
+  ]),
+});
+
+export const connectorRouter = router({
+  // ── Queries ──────────────────────────────────────────────────────────────
+
+  list: connectorProcedure.query(async ({ ctx }) => {
+    const connectors = await ctx.connectorModel.query();
+
+    const toolsByConnector = await Promise.all(
+      connectors.map(async (c) => {
+        const tools = await ctx.connectorToolModel.queryByConnector(c.id);
+        return { ...c, tools };
+      }),
+    );
+
+    return toolsByConnector;
+  }),
+
+  // ── Mutations ─────────────────────────────────────────────────────────────
+
+  create: connectorProcedure.input(createConnectorSchema).mutation(async ({ input, ctx }) => {
+    return ctx.connectorModel.create({
+      ...input,
+      mcpConnectionType: input.mcpConnectionType ?? null,
+      mcpServerUrl: input.mcpServerUrl ?? null,
+      mcpStdioConfig: input.mcpStdioConfig ?? null,
+      metadata: input.metadata ?? null,
+      oidcConfig: (input.oidcConfig as any) ?? null,
+      status: ConnectorStatus.disconnected,
+    });
+  }),
+
+  update: connectorProcedure
+    .input(
+      z.object({
+        id: z.string().uuid(),
+        patch: createConnectorSchema.partial().omit({ identifier: true, sourceType: true }),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      await ctx.connectorModel.update(input.id, input.patch as any);
+    }),
+
+  delete: connectorProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ input, ctx }) => {
+      await ctx.connectorModel.delete(input.id);
+    }),
+
+  /**
+   * Fetch the tool list from the remote MCP server and sync it into
+   * `user_connector_tools`. Manifest-derived fields are overwritten;
+   * user permission settings are preserved.
+   */
+  syncTools: connectorProcedure
+    .input(z.object({ id: z.string().uuid() }))
+    .mutation(async ({ input, ctx }) => {
+      const connector = await ctx.connectorModel.findById(input.id);
+
+      if (!connector) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Connector not found' });
+      }
+
+      if (
+        !connector.mcpServerUrl &&
+        connector.mcpConnectionType !== ConnectorMcpConnectionType.stdio
+      ) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Connector has no MCP server URL configured',
+        });
+      }
+
+      // Build MCPClientParams from stored connector config
+      let mcpParams: Parameters<typeof mcpService.listRawTools>[0];
+
+      if (connector.mcpConnectionType === ConnectorMcpConnectionType.stdio) {
+        if (!connector.mcpStdioConfig) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing stdio config' });
+        }
+        mcpParams = {
+          args: connector.mcpStdioConfig.args ?? [],
+          command: connector.mcpStdioConfig.command,
+          env: connector.mcpStdioConfig.env,
+          name: connector.name,
+          type: 'stdio',
+        };
+      } else {
+        // http or cloud — both use URL-based connection
+        const auth = buildAuthFromCredentials(connector.credentials);
+        mcpParams = {
+          auth,
+          name: connector.name,
+          type: 'http',
+          url: connector.mcpServerUrl!,
+        };
+      }
+
+      let rawTools: Awaited<ReturnType<typeof mcpService.listRawTools>>;
+      try {
+        rawTools = await mcpService.listRawTools(mcpParams);
+      } catch (err: any) {
+        await ctx.connectorModel.updateStatus(input.id, ConnectorStatus.error);
+        throw new TRPCError({
+          cause: err,
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Failed to fetch tools from MCP server: ${err?.message ?? 'unknown error'}`,
+        });
+      }
+
+      const syncInputs = rawTools.map((t) => ({
+        crudType: inferCrudType(t.name),
+        description: t.description,
+        inputSchema: t.inputSchema as Record<string, unknown>,
+        toolName: t.name,
+      }));
+
+      await ctx.connectorToolModel.upsertMany(input.id, syncInputs);
+      await ctx.connectorModel.updateStatus(input.id, ConnectorStatus.connected);
+
+      return { toolCount: syncInputs.length };
+    }),
+
+  updateToolPermission: connectorProcedure
+    .input(
+      z.object({
+        permission: z.enum([
+          ConnectorToolPermission.auto,
+          ConnectorToolPermission.needs_approval,
+          ConnectorToolPermission.disabled,
+        ]),
+        toolId: z.string().uuid(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      await ctx.connectorToolModel.updatePermission(input.toolId, input.permission);
+    }),
+});
+
+// ── Private helpers ───────────────────────────────────────────────────────────
+
+function buildAuthFromCredentials(
+  credentials: ConnectorCredentials | null,
+): AuthConfig | undefined {
+  if (!credentials) return undefined;
+
+  switch (credentials.type) {
+    case 'oauth2': {
+      return {
+        accessToken: credentials.accessToken,
+        clientId: undefined,
+        clientSecret: credentials.clientSecret,
+        refreshToken: credentials.refreshToken,
+        tokenExpiresAt: credentials.expiresAt,
+        type: 'oauth2',
+      };
+    }
+    case 'bearer': {
+      return { token: credentials.token, type: 'bearer' };
+    }
+    default: {
+      return undefined;
+    }
+  }
+}

--- a/src/server/routers/lambda/connector.ts
+++ b/src/server/routers/lambda/connector.ts
@@ -193,6 +193,48 @@ export const connectorRouter = router({
     }),
 
   /**
+   * Sync tools from a client-provided list (for Lobehub OAuth skills, Klavis, etc.
+   * that already have their tool list available on the client side).
+   * Idempotent — safe to call whenever the detail panel opens.
+   */
+  syncToolsFromClient: connectorProcedure
+    .input(
+      z.object({
+        identifier: z.string().min(1),
+        name: z.string().min(1),
+        sourceType: z.enum([
+          ConnectorSourceType.builtin,
+          ConnectorSourceType.custom,
+          ConnectorSourceType.marketplace,
+        ]),
+        tools: z.array(
+          z.object({
+            description: z.string().optional(),
+            inputSchema: z.record(z.unknown()).optional(),
+            toolName: z.string(),
+          }),
+        ),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const connectorId = await upsertConnectorEntry(ctx.connectorModel, {
+        identifier: input.identifier,
+        name: input.name,
+        sourceType: input.sourceType,
+      });
+
+      const syncInputs = input.tools.map((t) => ({
+        crudType: inferCrudType(t.toolName),
+        description: t.description,
+        inputSchema: t.inputSchema,
+        toolName: t.toolName,
+      }));
+
+      await ctx.connectorToolModel.upsertMany(connectorId, syncInputs);
+      return { connectorId, toolCount: syncInputs.length };
+    }),
+
+  /**
    * Bootstrap a connector entry for a builtin tool (lobe-creds, lobe-local-system, etc.)
    * by reading its manifest from @lobechat/builtin-tools.
    * Idempotent — safe to call on every open of the detail panel.

--- a/src/server/routers/lambda/connector.ts
+++ b/src/server/routers/lambda/connector.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 
 import { ConnectorModel } from '@/database/models/connector';
 import { ConnectorToolModel } from '@/database/models/connectorTool';
+import { PluginModel } from '@/database/models/plugin';
 import type { ConnectorCredentials } from '@/database/schemas';
 import {
   ConnectorMcpConnectionType,
@@ -22,6 +23,7 @@ const connectorProcedure = authedProcedure.use(serverDatabase).use(async (opts) 
     ctx: {
       connectorModel: new ConnectorModel(ctx.serverDB, ctx.userId),
       connectorToolModel: new ConnectorToolModel(ctx.serverDB, ctx.userId),
+      pluginModel: new PluginModel(ctx.serverDB, ctx.userId),
     },
   });
 });
@@ -189,9 +191,107 @@ export const connectorRouter = router({
     .mutation(async ({ input, ctx }) => {
       await ctx.connectorToolModel.updatePermission(input.toolId, input.permission);
     }),
+
+  /**
+   * Bootstrap a connector entry for a builtin tool (lobe-creds, lobe-local-system, etc.)
+   * by reading its manifest from @lobechat/builtin-tools.
+   * Idempotent — safe to call on every open of the detail panel.
+   */
+  syncBuiltinTool: connectorProcedure
+    .input(z.object({ identifier: z.string().min(1) }))
+    .mutation(async ({ input, ctx }) => {
+      const { builtinTools } = await import('@lobechat/builtin-tools');
+      const tool = builtinTools.find((t) => t.identifier === input.identifier);
+
+      if (!tool) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: `Builtin tool '${input.identifier}' not found`,
+        });
+      }
+
+      const connectorId = await upsertConnectorEntry(ctx.connectorModel, {
+        identifier: input.identifier,
+        name: tool.manifest.meta?.title || input.identifier,
+        sourceType: ConnectorSourceType.builtin,
+      });
+
+      const syncInputs = tool.manifest.api.map((api) => ({
+        crudType: inferCrudType(api.name),
+        defaultPermission: resolveDefaultPermission(api.humanIntervention),
+        description: api.description,
+        inputSchema: api.parameters as Record<string, unknown>,
+        toolName: api.name,
+      }));
+
+      await ctx.connectorToolModel.upsertMany(connectorId, syncInputs);
+      return { connectorId, toolCount: syncInputs.length };
+    }),
+
+  /**
+   * Bootstrap a connector entry for an installed marketplace plugin.
+   * Reads tool list from user_installed_plugins.manifest.api.
+   * Idempotent — safe to call on every open of the detail panel.
+   */
+  syncPluginTools: connectorProcedure
+    .input(z.object({ identifier: z.string().min(1) }))
+    .mutation(async ({ input, ctx }) => {
+      const plugin = await ctx.pluginModel.findById(input.identifier);
+
+      if (!plugin || !plugin.manifest) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: `Plugin '${input.identifier}' not found or has no manifest`,
+        });
+      }
+
+      const connectorId = await upsertConnectorEntry(ctx.connectorModel, {
+        identifier: input.identifier,
+        name: plugin.manifest.meta?.title || input.identifier,
+        sourceType: ConnectorSourceType.marketplace,
+      });
+
+      const apiList = plugin.manifest.api ?? [];
+      const syncInputs = apiList.map((api: any) => ({
+        crudType: inferCrudType(api.name),
+        defaultPermission: resolveDefaultPermission(api.humanIntervention),
+        description: api.description,
+        inputSchema: api.parameters as Record<string, unknown>,
+        toolName: api.name,
+      }));
+
+      await ctx.connectorToolModel.upsertMany(connectorId, syncInputs);
+      return { connectorId, toolCount: syncInputs.length };
+    }),
 });
 
 // ── Private helpers ───────────────────────────────────────────────────────────
+
+/** Create connector entry if not exists, return connectorId */
+async function upsertConnectorEntry(
+  connectorModel: ConnectorModel,
+  params: { identifier: string; name: string; sourceType: string },
+): Promise<string> {
+  const existing = await connectorModel.queryByIdentifiers([params.identifier]);
+  if (existing.length > 0) return existing[0].id;
+
+  const created = await connectorModel.create({
+    identifier: params.identifier,
+    isEnabled: true,
+    name: params.name,
+    sourceType: params.sourceType as any,
+    status: ConnectorStatus.connected,
+  });
+  return created.id;
+}
+
+/** Map builtin manifest humanIntervention → default ConnectorToolPermission */
+function resolveDefaultPermission(humanIntervention: unknown): ConnectorToolPermission {
+  if (humanIntervention === 'required' || humanIntervention === 'always') {
+    return ConnectorToolPermission.needs_approval;
+  }
+  return ConnectorToolPermission.auto;
+}
 
 function buildAuthFromCredentials(
   credentials: ConnectorCredentials | null,

--- a/src/server/routers/lambda/connector.ts
+++ b/src/server/routers/lambda/connector.ts
@@ -211,6 +211,8 @@ export const connectorRouter = router({
       }
 
       const connectorId = await upsertConnectorEntry(ctx.connectorModel, {
+        avatar: tool.manifest.meta?.avatar,
+        description: tool.manifest.meta?.description,
         identifier: input.identifier,
         name: tool.manifest.meta?.title || input.identifier,
         sourceType: ConnectorSourceType.builtin,
@@ -246,6 +248,8 @@ export const connectorRouter = router({
       }
 
       const connectorId = await upsertConnectorEntry(ctx.connectorModel, {
+        avatar: plugin.manifest.meta?.avatar,
+        description: plugin.manifest.meta?.description,
         identifier: input.identifier,
         name: plugin.manifest.meta?.title || input.identifier,
         sourceType: ConnectorSourceType.marketplace,
@@ -267,17 +271,32 @@ export const connectorRouter = router({
 
 // ── Private helpers ───────────────────────────────────────────────────────────
 
-/** Create connector entry if not exists, return connectorId */
+/** Create connector entry if not exists (or update metadata), return connectorId */
 async function upsertConnectorEntry(
   connectorModel: ConnectorModel,
-  params: { identifier: string; name: string; sourceType: string },
+  params: {
+    avatar?: string;
+    description?: string;
+    identifier: string;
+    name: string;
+    sourceType: string;
+  },
 ): Promise<string> {
+  const metadata: Record<string, unknown> = {};
+  if (params.description) metadata.description = params.description;
+  if (params.avatar) metadata.avatar = params.avatar;
+
   const existing = await connectorModel.queryByIdentifiers([params.identifier]);
-  if (existing.length > 0) return existing[0].id;
+  if (existing.length > 0) {
+    // Update metadata with latest description/avatar from manifest
+    await connectorModel.update(existing[0].id, { metadata });
+    return existing[0].id;
+  }
 
   const created = await connectorModel.create({
     identifier: params.identifier,
     isEnabled: true,
+    metadata,
     name: params.name,
     sourceType: params.sourceType as any,
     status: ConnectorStatus.connected,

--- a/src/server/routers/lambda/index.ts
+++ b/src/server/routers/lambda/index.ts
@@ -31,6 +31,7 @@ import { changelogRouter } from './changelog';
 import { chunkRouter } from './chunk';
 import { comfyuiRouter } from './comfyui';
 import { configRouter } from './config';
+import { connectorRouter } from './connector';
 import { deviceRouter } from './device';
 import { documentRouter } from './document';
 import { exporterRouter } from './exporter';
@@ -92,6 +93,7 @@ export const lambdaRouter = router({
   chunk: chunkRouter,
   comfyui: comfyuiRouter,
   config: configRouter,
+  connector: connectorRouter,
   device: deviceRouter,
   document: documentRouter,
   exporter: exporterRouter,

--- a/src/server/routers/tools/klavis.ts
+++ b/src/server/routers/tools/klavis.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 
-import { ConnectorModel } from '@/database/models/connector';
 import { ConnectorToolModel } from '@/database/models/connectorTool';
 import { ConnectorToolPermission } from '@/database/schemas';
 import { getKlavisClient } from '@/libs/klavis';
@@ -37,27 +36,21 @@ export const klavisRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       // ── Connector tool permission gate ────────────────────────────────────
-      // Extract connector identifier from tool name prefix (e.g. "gmail_search_emails" → "gmail")
-      // and check if this tool has been disabled by the user.
-      const identifierPrefix = input.toolName.split('_')[0];
-      if (identifierPrefix && ctx.userId && ctx.serverDB) {
-        const connectorModel = new ConnectorModel(ctx.serverDB, ctx.userId);
-        const [connector] = await connectorModel.queryByIdentifiers([identifierPrefix]);
-        if (connector) {
-          const connectorToolModel = new ConnectorToolModel(ctx.serverDB, ctx.userId);
-          const tools = await connectorToolModel.queryByConnector(connector.id);
-          const tool = tools.find((t) => t.toolName === input.toolName);
-          if (tool?.permission === ConnectorToolPermission.disabled) {
-            const message =
-              `The tool "${input.toolName}" has been disabled by the user and cannot be executed. ` +
-              `Please inform the user that this tool is currently disabled. ` +
-              `They can re-enable it in Settings > Connectors.`;
-            return {
-              content: message,
-              state: { content: [{ text: message, type: 'text' }], isError: false },
-              success: true,
-            };
-          }
+      // Look up the tool directly by toolName so hyphenated identifiers like
+      // "google-calendar" are handled correctly (splitting on "_" would truncate them).
+      if (ctx.userId && ctx.serverDB) {
+        const connectorToolModel = new ConnectorToolModel(ctx.serverDB, ctx.userId);
+        const connectorTool = await connectorToolModel.findByToolName(input.toolName);
+        if (connectorTool?.permission === ConnectorToolPermission.disabled) {
+          const message =
+            `The tool "${input.toolName}" has been disabled by the user and cannot be executed. ` +
+            `Please inform the user that this tool is currently disabled. ` +
+            `They can re-enable it in Settings > Connectors.`;
+          return {
+            content: message,
+            state: { content: [{ text: message, type: 'text' }], isError: false },
+            success: true,
+          };
         }
       }
       // ── End permission gate ───────────────────────────────────────────────

--- a/src/server/routers/tools/klavis.ts
+++ b/src/server/routers/tools/klavis.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { ConnectorModel } from '@/database/models/connector';
 import { ConnectorToolModel } from '@/database/models/connectorTool';
 import { ConnectorToolPermission } from '@/database/schemas';
 import { getKlavisClient } from '@/libs/klavis';
@@ -29,6 +30,8 @@ export const klavisRouter = router({
   callTool: klavisProcedure
     .input(
       z.object({
+        /** Klavis server identifier (e.g. 'gmail', 'google-calendar') for precise permission lookup */
+        identifier: z.string().optional(),
         serverUrl: z.string(),
         toolArgs: z.record(z.unknown()).optional(),
         toolName: z.string(),
@@ -36,11 +39,26 @@ export const klavisRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       // ── Connector tool permission gate ────────────────────────────────────
-      // Look up the tool directly by toolName so hyphenated identifiers like
-      // "google-calendar" are handled correctly (splitting on "_" would truncate them).
+      // Use identifier + toolName when available for a precise lookup (avoids
+      // same-name collisions across connectors). Falls back to toolName-only
+      // if identifier is absent (legacy callers).
       if (ctx.userId && ctx.serverDB) {
         const connectorToolModel = new ConnectorToolModel(ctx.serverDB, ctx.userId);
-        const connectorTool = await connectorToolModel.findByToolName(input.toolName);
+        let connectorTool:
+          | Awaited<ReturnType<typeof connectorToolModel.findByToolName>>
+          | undefined;
+
+        if (input.identifier) {
+          const connectorModel = new ConnectorModel(ctx.serverDB, ctx.userId);
+          const [connector] = await connectorModel.queryByIdentifiers([input.identifier]);
+          if (connector) {
+            const tools = await connectorToolModel.queryByConnector(connector.id);
+            connectorTool = tools.find((t) => t.toolName === input.toolName);
+          }
+        } else {
+          connectorTool = await connectorToolModel.findByToolName(input.toolName);
+        }
+
         if (connectorTool?.permission === ConnectorToolPermission.disabled) {
           const message =
             `The tool "${input.toolName}" has been disabled by the user and cannot be executed. ` +

--- a/src/server/routers/tools/klavis.ts
+++ b/src/server/routers/tools/klavis.ts
@@ -1,13 +1,17 @@
 import { z } from 'zod';
 
+import { ConnectorModel } from '@/database/models/connector';
+import { ConnectorToolModel } from '@/database/models/connectorTool';
+import { ConnectorToolPermission } from '@/database/schemas';
 import { getKlavisClient } from '@/libs/klavis';
 import { authedProcedure, publicProcedure, router } from '@/libs/trpc/lambda';
+import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { MCPService } from '@/server/services/mcp';
 
 /**
  * Klavis procedure with client initialized in context
  */
-const klavisProcedure = authedProcedure.use(async (opts) => {
+const klavisProcedure = authedProcedure.use(serverDatabase).use(async (opts) => {
   const klavisClient = getKlavisClient();
 
   return opts.next({
@@ -32,6 +36,32 @@ export const klavisRouter = router({
       }),
     )
     .mutation(async ({ ctx, input }) => {
+      // ── Connector tool permission gate ────────────────────────────────────
+      // Extract connector identifier from tool name prefix (e.g. "gmail_search_emails" → "gmail")
+      // and check if this tool has been disabled by the user.
+      const identifierPrefix = input.toolName.split('_')[0];
+      if (identifierPrefix && ctx.userId && ctx.serverDB) {
+        const connectorModel = new ConnectorModel(ctx.serverDB, ctx.userId);
+        const [connector] = await connectorModel.queryByIdentifiers([identifierPrefix]);
+        if (connector) {
+          const connectorToolModel = new ConnectorToolModel(ctx.serverDB, ctx.userId);
+          const tools = await connectorToolModel.queryByConnector(connector.id);
+          const tool = tools.find((t) => t.toolName === input.toolName);
+          if (tool?.permission === ConnectorToolPermission.disabled) {
+            const message =
+              `The tool "${input.toolName}" has been disabled by the user and cannot be executed. ` +
+              `Please inform the user that this tool is currently disabled. ` +
+              `They can re-enable it in Settings > Connectors.`;
+            return {
+              content: message,
+              state: { content: [{ text: message, type: 'text' }], isError: false },
+              success: true,
+            };
+          }
+        }
+      }
+      // ── End permission gate ───────────────────────────────────────────────
+
       const response = await ctx.klavisClient.mcpServer.callTools({
         serverUrl: input.serverUrl,
         toolArgs: input.toolArgs,

--- a/src/server/routers/tools/mcp.ts
+++ b/src/server/routers/tools/mcp.ts
@@ -6,6 +6,9 @@ import {
 import { TRPCError } from '@trpc/server';
 import { z } from 'zod';
 
+import { ConnectorModel } from '@/database/models/connector';
+import { ConnectorToolModel } from '@/database/models/connectorTool';
+import { ConnectorToolPermission } from '@/database/schemas';
 import { type ToolCallContent } from '@/libs/mcp';
 import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase, telemetry } from '@/libs/trpc/lambda/middleware';
@@ -133,6 +136,44 @@ export const mcpRouter = router({
     .mutation(async ({ input, ctx }) => {
       // Stdio check can be done here or rely on the service/client layer
       checkStdioEnvironment(input.params);
+
+      // ── Connector tool permission gate ────────────────────────────────────
+      // If the connector identifier matches a user_connectors entry, check whether
+      // this specific tool has been disabled by the user. Disabled tools are still
+      // present in the AI manifest (so the AI knows they exist) but are hard-blocked
+      // here at execution time so the MCP server is never actually called.
+      const connectorId = input.params.name;
+      if (connectorId && ctx.userId) {
+        const connectorModel = new ConnectorModel(ctx.serverDB, ctx.userId);
+        const [connector] = await connectorModel.queryByIdentifiers([connectorId]);
+        if (connector) {
+          const connectorToolModel = new ConnectorToolModel(ctx.serverDB, ctx.userId);
+          const tools = await connectorToolModel.queryByConnector(connector.id);
+          const tool = tools.find((t) => t.toolName === input.toolName);
+          if (tool?.permission === ConnectorToolPermission.disabled) {
+            return {
+              content:
+                `The tool "${input.toolName}" has been disabled by the user and cannot be executed. ` +
+                `Please inform the user that this tool is currently disabled. ` +
+                `They can re-enable it in Settings > Connectors.`,
+              state: {
+                content: [
+                  {
+                    text:
+                      `The tool "${input.toolName}" has been disabled by the user and cannot be executed. ` +
+                      `Please inform the user that this tool is currently disabled. ` +
+                      `They can re-enable it in Settings > Connectors.`,
+                    type: 'text',
+                  },
+                ],
+                isError: false,
+              },
+              success: true,
+            };
+          }
+        }
+      }
+      // ── End permission gate ───────────────────────────────────────────────
 
       const startTime = Date.now();
       let success = true;

--- a/src/server/services/aiAgent/__tests__/execAgent.builtinRuntime.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.builtinRuntime.test.ts
@@ -89,6 +89,20 @@ vi.mock('@/database/models/plugin', () => ({
   })),
 }));
 
+vi.mock('@/database/models/connector', () => ({
+  ConnectorModel: vi.fn().mockImplementation(() => ({
+    queryByIdentifiers: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+vi.mock('@/database/models/connectorTool', () => ({
+  ConnectorToolModel: vi.fn().mockImplementation(() => ({
+    queryByConnector: vi.fn().mockResolvedValue([]),
+    queryByConnectorIds: vi.fn().mockResolvedValue([]),
+    queryAllByConnectorIds: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
 vi.mock('@/database/models/topic', () => ({
   TopicModel: vi.fn().mockImplementation(() => ({
     create: vi.fn().mockResolvedValue({ id: 'topic-1' }),
@@ -220,7 +234,10 @@ describe('AiAgentService.execAgent - builtin agent runtime config', () => {
       slug: 'self-reflection',
       systemRole: '',
     });
-    mockGetBuiltinAgent.mockResolvedValueOnce({ id: 'agent-self-reflection', slug: 'self-reflection' });
+    mockGetBuiltinAgent.mockResolvedValueOnce({
+      id: 'agent-self-reflection',
+      slug: 'self-reflection',
+    });
 
     await service.execAgent({ prompt: 'reflect', slug: 'self-reflection' });
 

--- a/src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
@@ -58,6 +58,20 @@ vi.mock('@/database/models/plugin', () => ({
   })),
 }));
 
+vi.mock('@/database/models/connector', () => ({
+  ConnectorModel: vi.fn().mockImplementation(() => ({
+    queryByIdentifiers: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+vi.mock('@/database/models/connectorTool', () => ({
+  ConnectorToolModel: vi.fn().mockImplementation(() => ({
+    queryByConnector: vi.fn().mockResolvedValue([]),
+    queryByConnectorIds: vi.fn().mockResolvedValue([]),
+    queryAllByConnectorIds: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
 vi.mock('@/database/models/topic', () => ({
   TopicModel: vi.fn().mockImplementation(() => ({
     create: vi.fn().mockResolvedValue({ id: 'topic-1' }),

--- a/src/server/services/aiAgent/__tests__/execAgent.disableTools.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.disableTools.test.ts
@@ -57,6 +57,19 @@ vi.mock('@/database/models/plugin', () => ({
   })),
 }));
 
+vi.mock('@/database/models/connector', () => ({
+  ConnectorModel: vi.fn().mockImplementation(() => ({
+    queryByIdentifiers: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+vi.mock('@/database/models/connectorTool', () => ({
+  ConnectorToolModel: vi.fn().mockImplementation(() => ({
+    queryByConnector: vi.fn().mockResolvedValue([]),
+    queryByConnectorIds: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
 vi.mock('@/database/models/topic', () => ({
   TopicModel: vi.fn().mockImplementation(() => ({
     create: vi.fn().mockResolvedValue({ id: 'topic-1' }),

--- a/src/server/services/aiAgent/__tests__/execAgent.disableTools.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.disableTools.test.ts
@@ -67,6 +67,7 @@ vi.mock('@/database/models/connectorTool', () => ({
   ConnectorToolModel: vi.fn().mockImplementation(() => ({
     queryByConnector: vi.fn().mockResolvedValue([]),
     queryByConnectorIds: vi.fn().mockResolvedValue([]),
+    queryAllByConnectorIds: vi.fn().mockResolvedValue([]),
   })),
 }));
 

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -1189,11 +1189,12 @@ export class AiAgentService {
         (p) => !connectorIdentifierSet.has(p.identifier),
       );
 
-      // Fetch tools for enabled real-MCP connectors (non-disabled only, via queryByConnectorIds)
-      const enabledConnectorsMcp = connectorsMcp.filter((c) => c.isEnabled);
+      // Fetch ALL tools for all real-MCP connectors (including disabled tools) so that
+      // buildConnectorManifests can show blocking descriptions for disabled tools.
+      // The runtime hot-path still uses queryByConnectorIds (non-disabled only) elsewhere.
       const connectorTools =
-        enabledConnectorsMcp.length > 0
-          ? await this.connectorToolModel.queryByConnectorIds(enabledConnectorsMcp.map((c) => c.id))
+        connectorsMcp.length > 0
+          ? await this.connectorToolModel.queryAllByConnectorIds(connectorsMcp.map((c) => c.id))
           : [];
 
       const connectorManifests = buildConnectorManifests(connectorsMcp, connectorTools);

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -1174,21 +1174,29 @@ export class AiAgentService {
       // 5a-1. Resolve connectors — connector identifier takes priority over plugin
       const connectors =
         agentPlugins.length > 0 ? await this.connectorModel.queryByIdentifiers(agentPlugins) : [];
-      const connectorIdentifierSet = new Set(connectors.map((c) => c.identifier));
 
-      // Filter out plugin entries that are now handled by connectors
+      // Only connectors WITH a real MCP endpoint (mcpServerUrl or stdio) can replace plugins in the
+      // manifest. Connectors WITHOUT an endpoint (e.g. Lobehub/Klavis OAuth skills synced via
+      // syncToolsFromClient) must continue using their original plugin executor path — otherwise
+      // after humanIntervention approval the runtime tries to call mcpServerUrl='' and returns empty.
+      const connectorsMcp = connectors.filter(
+        (c) => c.mcpServerUrl || c.mcpConnectionType === 'stdio',
+      );
+      const connectorIdentifierSet = new Set(connectorsMcp.map((c) => c.identifier));
+
+      // Filter out plugin entries that are now handled by real MCP connectors
       const pluginsWithoutConnectors = installedPlugins.filter(
         (p) => !connectorIdentifierSet.has(p.identifier),
       );
 
-      // Fetch tools for enabled connectors (non-disabled only, via queryByConnectorIds)
-      const enabledConnectors = connectors.filter((c) => c.isEnabled);
+      // Fetch tools for enabled real-MCP connectors (non-disabled only, via queryByConnectorIds)
+      const enabledConnectorsMcp = connectorsMcp.filter((c) => c.isEnabled);
       const connectorTools =
-        enabledConnectors.length > 0
-          ? await this.connectorToolModel.queryByConnectorIds(enabledConnectors.map((c) => c.id))
+        enabledConnectorsMcp.length > 0
+          ? await this.connectorToolModel.queryByConnectorIds(enabledConnectorsMcp.map((c) => c.id))
           : [];
 
-      const connectorManifests = buildConnectorManifests(connectors, connectorTools);
+      const connectorManifests = buildConnectorManifests(connectorsMcp, connectorTools);
       log('execAgent: got %d connector manifests', connectorManifests.length);
 
       // 5b. Get model abilities from model-bank for function calling support check
@@ -1449,7 +1457,7 @@ export class AiAgentService {
             toolExecutorMap[plugin.identifier] = 'client';
           }
         }
-        for (const connector of connectors) {
+        for (const connector of connectorsMcp) {
           if (connector.mcpConnectionType === 'stdio' && manifestMap.has(connector.identifier)) {
             toolExecutorMap[connector.identifier] = 'client';
           }

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -1221,6 +1221,54 @@ export class AiAgentService {
       }
       log('execAgent: got %d klavis manifests', klavisManifests.length);
 
+      // 5d-1. Patch Lobehub/Klavis manifests with connector tool permissions.
+      // This enables needs_approval (→ humanIntervention: 'required') and disabled
+      // (→ blocking description) for skills that are managed via the connector system.
+      // The humanIntervention system already handles headless auto-rejection for qstash.
+      if (lobehubSkillManifests.length > 0 || klavisManifests.length > 0) {
+        try {
+          const { patchManifestWithPermissions } =
+            await import('@/libs/mcp/connectorPermissionCheck');
+          const { ConnectorToolModel } = await import('@/database/models/connectorTool');
+          const allIdentifiers = [
+            ...lobehubSkillManifests.map((m) => m.identifier),
+            ...klavisManifests.map((m) => m.identifier),
+          ];
+          const connectorEntries =
+            allIdentifiers.length > 0
+              ? await this.connectorModel.queryByIdentifiers(allIdentifiers)
+              : [];
+
+          if (connectorEntries.length > 0) {
+            const toolModel = new ConnectorToolModel(this.db, this.userId);
+            const connectorToolsMap = new Map<string, Map<string, string>>();
+            await Promise.all(
+              connectorEntries.map(async (c) => {
+                const tools = await toolModel.queryByConnector(c.id);
+                const perms = new Map(tools.map((t) => [t.toolName, t.permission]));
+                connectorToolsMap.set(c.identifier, perms);
+              }),
+            );
+
+            lobehubSkillManifests = lobehubSkillManifests.map((m) => {
+              const perms = connectorToolsMap.get(m.identifier);
+              return perms && perms.size > 0
+                ? (patchManifestWithPermissions(m as any, perms as any) as any)
+                : m;
+            });
+
+            klavisManifests = klavisManifests.map((m) => {
+              const perms = connectorToolsMap.get(m.identifier);
+              return perms && perms.size > 0
+                ? (patchManifestWithPermissions(m as any, perms as any) as any)
+                : m;
+            });
+          }
+        } catch (err) {
+          log('execAgent: failed to patch manifests with connector permissions: %O', err);
+        }
+      }
+
       await throwIfExecutionAborted('tool discovery');
 
       // 5e. Create tools using Server AgentToolsEngine

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -46,6 +46,8 @@ import { AgentModel } from '@/database/models/agent';
 import { AgentOperationModel } from '@/database/models/agentOperation';
 import { AgentSkillModel } from '@/database/models/agentSkill';
 import { AiModelModel } from '@/database/models/aiModel';
+import { ConnectorModel } from '@/database/models/connector';
+import { ConnectorToolModel } from '@/database/models/connectorTool';
 import { DeviceModel } from '@/database/models/device';
 import { FileModel } from '@/database/models/file';
 import { MessageModel } from '@/database/models/message';
@@ -57,6 +59,7 @@ import { UserModel } from '@/database/models/user';
 import { UserPersonaModel } from '@/database/models/userMemory/persona';
 import { toolsEnv } from '@/envs/tools';
 import { shouldEnableBuiltinSkill } from '@/helpers/skillFilters';
+import { buildConnectorManifests } from '@/libs/mcp/buildConnectorManifests';
 import { signOperationJwt, signUserJWT } from '@/libs/trpc/utils/internalJwt';
 import type { EvalContext, ServerAgentToolsContext } from '@/server/modules/Mecha';
 import { createServerAgentToolsEngine } from '@/server/modules/Mecha';
@@ -246,6 +249,8 @@ export class AiAgentService {
   private readonly agentModel: AgentModel;
   private readonly agentService: AgentService;
   private readonly messageModel: MessageModel;
+  private readonly connectorModel: ConnectorModel;
+  private readonly connectorToolModel: ConnectorToolModel;
   private readonly pluginModel: PluginModel;
   private readonly taskModel: TaskModel;
   private readonly threadModel: ThreadModel;
@@ -265,6 +270,8 @@ export class AiAgentService {
     this.agentModel = new AgentModel(db, userId);
     this.agentService = new AgentService(db, userId);
     this.messageModel = new MessageModel(db, userId);
+    this.connectorModel = new ConnectorModel(db, userId);
+    this.connectorToolModel = new ConnectorToolModel(db, userId);
     this.pluginModel = new PluginModel(db, userId);
     this.taskModel = new TaskModel(db, userId);
     this.threadModel = new ThreadModel(db, userId);
@@ -1164,6 +1171,26 @@ export class AiAgentService {
       const installedPlugins = await this.pluginModel.query();
       log('execAgent: got %d installed plugins', installedPlugins.length);
 
+      // 5a-1. Resolve connectors — connector identifier takes priority over plugin
+      const connectors =
+        agentPlugins.length > 0 ? await this.connectorModel.queryByIdentifiers(agentPlugins) : [];
+      const connectorIdentifierSet = new Set(connectors.map((c) => c.identifier));
+
+      // Filter out plugin entries that are now handled by connectors
+      const pluginsWithoutConnectors = installedPlugins.filter(
+        (p) => !connectorIdentifierSet.has(p.identifier),
+      );
+
+      // Fetch tools for enabled connectors (non-disabled only, via queryByConnectorIds)
+      const enabledConnectors = connectors.filter((c) => c.isEnabled);
+      const connectorTools =
+        enabledConnectors.length > 0
+          ? await this.connectorToolModel.queryByConnectorIds(enabledConnectors.map((c) => c.id))
+          : [];
+
+      const connectorManifests = buildConnectorManifests(connectors, connectorTools);
+      log('execAgent: got %d connector manifests', connectorManifests.length);
+
       // 5b. Get model abilities from model-bank for function calling support check
       const isModelSupportToolUse = (m: string, p: string) => {
         const info = builtinModels.find((item) => item.id === m && item.providerId === p);
@@ -1217,7 +1244,7 @@ export class AiAgentService {
       const deviceOnline = onlineDevices.length > 0;
 
       const toolsContext: ServerAgentToolsContext = {
-        installedPlugins,
+        installedPlugins: pluginsWithoutConnectors,
         isModelSupportToolUse,
       };
 
@@ -1297,7 +1324,7 @@ export class AiAgentService {
               : undefined;
 
       const toolsEngine = createServerAgentToolsEngine(toolsContext, {
-        additionalManifests: [...lobehubSkillManifests, ...klavisManifests],
+        additionalManifests: [...lobehubSkillManifests, ...klavisManifests, ...connectorManifests],
         agentConfig: {
           chatConfig: agentConfig.chatConfig ?? undefined,
           plugins: agentPlugins,
@@ -1329,6 +1356,8 @@ export class AiAgentService {
           // Include LobeHub Skills and Klavis tools so they are passed to generateToolsDetailed
           ...lobehubSkillManifests.map((m) => m.identifier),
           ...klavisManifests.map((m) => m.identifier),
+          // Connector manifests are also injected as additionalManifests
+          ...connectorManifests.map((m) => m.identifier),
         ]),
       ];
       log('execAgent: agent configured plugins: %O', pluginIds);
@@ -1418,6 +1447,11 @@ export class AiAgentService {
         for (const plugin of installedPlugins) {
           if (plugin.customParams?.mcp?.type === 'stdio' && manifestMap.has(plugin.identifier)) {
             toolExecutorMap[plugin.identifier] = 'client';
+          }
+        }
+        for (const connector of connectors) {
+          if (connector.mcpConnectionType === 'stdio' && manifestMap.has(connector.identifier)) {
+            toolExecutorMap[connector.identifier] = 'client';
           }
         }
       }

--- a/src/server/services/toolExecution/index.ts
+++ b/src/server/services/toolExecution/index.ts
@@ -2,7 +2,12 @@ import { type ChatToolPayload } from '@lobechat/types';
 import { safeParseJSON } from '@lobechat/utils';
 import debug from 'debug';
 
+import { ConnectorToolPermission } from '@/database/schemas';
 import { type CloudMCPParams, type StdioMCPParams, type ToolCallContent } from '@/libs/mcp';
+import {
+  buildBlockedToolResponse,
+  getConnectorToolPermission,
+} from '@/libs/mcp/connectorPermissionCheck';
 import { contentBlocksToString } from '@/server/services/mcp/contentProcessor';
 import {
   DEFAULT_TOOL_RESULT_MAX_LENGTH,
@@ -74,6 +79,27 @@ export class ToolExecutionService {
     const { identifier, apiName, type } = payload;
 
     log('Executing tool: %s:%s (type: %s)', identifier, apiName, type);
+
+    // ── Connector tool permission gate (covers ALL paths + qstash) ────────
+    // Check before any execution so that disabled tools are blocked universally:
+    // Lobehub market skills, Klavis, MCP connectors, and execAgent/qstash alike.
+    // needs_approval is handled via humanIntervention in the manifest; we only
+    // hard-block 'disabled' here (and needs_approval in headless/qstash context
+    // since the manifest's humanIntervention auto-rejects them there already).
+    if (context.serverDB && context.userId && identifier && apiName) {
+      const permission = await getConnectorToolPermission(
+        context.serverDB,
+        context.userId,
+        identifier,
+        apiName,
+      );
+      if (permission === ConnectorToolPermission.disabled) {
+        log('Tool %s:%s is disabled by user — blocking execution', identifier, apiName);
+        const blocked = buildBlockedToolResponse(apiName);
+        return { ...blocked, executionTime: 0 };
+      }
+    }
+    // ── End permission gate ───────────────────────────────────────────────
 
     const startTime = Date.now();
     try {

--- a/src/store/chat/slices/plugin/actions/exector.ts
+++ b/src/store/chat/slices/plugin/actions/exector.ts
@@ -47,8 +47,9 @@ export const klavisExecutor: RemoteToolExecutor = async (p, _context) => {
   // Parse arguments
   const args = safeParseJSON(p.arguments) || {};
 
-  // Call Klavis tool via store action
+  // Call Klavis tool via store action — pass identifier for precise permission gate lookup
   const result = await useToolStore.getState().callKlavisTool({
+    identifier,
     serverUrl: server.serverUrl,
     toolArgs: args,
     toolName: p.apiName,

--- a/src/store/chat/slices/plugin/actions/pluginTypes.ts
+++ b/src/store/chat/slices/plugin/actions/pluginTypes.ts
@@ -12,6 +12,7 @@ import { archiveToolResultViaServer } from '@/services/toolResultArchive';
 import { AI_RUNTIME_OPERATION_TYPES } from '@/store/chat/slices/operation';
 import { type ChatStore } from '@/store/chat/store';
 import { useToolStore } from '@/store/tool';
+import { klavisStoreSelectors, lobehubSkillStoreSelectors } from '@/store/tool/selectors';
 import { hasExecutor } from '@/store/tool/slices/builtin/executors';
 import { type StoreSetter } from '@/store/types';
 import { safeParseJSON } from '@/utils/safeParseJSON';
@@ -45,14 +46,33 @@ export class PluginTypesActionImpl {
     payload: ChatToolPayload,
     stepContext?: RuntimeStepContext,
   ): Promise<any> => {
-    // Check if this is a Klavis tool by source field
-    if (payload.source === 'klavis') {
-      return await this.#get().invokeKlavisTypePlugin(id, payload);
+    // When the tool call comes from a DB-stored message (e.g. after humanIntervention approval),
+    // the `source` field is not persisted and arrives as undefined. Fall back to a live store
+    // lookup so Klavis / LobeHub Skill tools still route correctly.
+    let effectiveSource = payload.source;
+    if (!effectiveSource) {
+      const toolStoreState = useToolStore.getState();
+      const klavisTools = klavisStoreSelectors.klavisAsLobeTools(toolStoreState);
+      if (klavisTools.some((t) => t.identifier === payload.identifier)) {
+        effectiveSource = 'klavis';
+      } else {
+        const lobehubSkillTools =
+          lobehubSkillStoreSelectors.lobehubSkillAsLobeTools(toolStoreState);
+        if (lobehubSkillTools.some((t) => t.identifier === payload.identifier)) {
+          effectiveSource = 'lobehubSkill';
+        }
+      }
     }
 
-    // Check if this is a LobeHub Skill tool by source field
-    if (payload.source === 'lobehubSkill') {
-      return await this.#get().invokeLobehubSkillTypePlugin(id, payload);
+    if (effectiveSource === 'klavis') {
+      return await this.#get().invokeKlavisTypePlugin(id, { ...payload, source: effectiveSource });
+    }
+
+    if (effectiveSource === 'lobehubSkill') {
+      return await this.#get().invokeLobehubSkillTypePlugin(id, {
+        ...payload,
+        source: effectiveSource,
+      });
     }
 
     const params = safeParseJSON(payload.arguments);

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -22,6 +22,7 @@ export enum SidebarTabKey {
 }
 
 export enum ChatSettingsTabs {
+  Connector = 'connector',
   Opening = 'opening',
   Plugin = 'plugin',
   Prompt = 'prompt',

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -50,7 +50,6 @@ export enum SettingsTabs {
   ChatAppearance = 'chat-appearance',
   /** @deprecated Use Appearance instead */
   Common = 'common',
-  Connector = 'connector',
   Credits = 'credits',
   Creds = 'creds',
   Devices = 'devices',

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -50,6 +50,7 @@ export enum SettingsTabs {
   ChatAppearance = 'chat-appearance',
   /** @deprecated Use Appearance instead */
   Common = 'common',
+  Connector = 'connector',
   Credits = 'credits',
   Creds = 'creds',
   Devices = 'devices',

--- a/src/store/tool/initialState.ts
+++ b/src/store/tool/initialState.ts
@@ -4,6 +4,7 @@ import {
 } from './slices/agentDocumentSkills/initialState';
 import { type AgentSkillsState, initialAgentSkillsState } from './slices/agentSkills/initialState';
 import { type BuiltinToolState, initialBuiltinToolState } from './slices/builtin/initialState';
+import { type ConnectorState, initialConnectorState } from './slices/connector/initialState';
 import {
   type CustomPluginState,
   initialCustomPluginState,
@@ -16,7 +17,8 @@ import {
 import { initialMCPStoreState, type MCPStoreState } from './slices/mcpStore/initialState';
 import { initialPluginState, type PluginState } from './slices/plugin/initialState';
 
-export type ToolStoreState = PluginState &
+export type ToolStoreState = ConnectorState &
+  PluginState &
   CustomPluginState &
   BuiltinToolState &
   MCPStoreState &
@@ -26,6 +28,7 @@ export type ToolStoreState = PluginState &
   AgentDocumentSkillsState;
 
 export const initialState: ToolStoreState = {
+  ...initialConnectorState,
   ...initialPluginState,
   ...initialCustomPluginState,
   ...initialBuiltinToolState,

--- a/src/store/tool/slices/connector/action.ts
+++ b/src/store/tool/slices/connector/action.ts
@@ -1,0 +1,93 @@
+import type { ConnectorToolPermission } from '@/database/schemas';
+import { lambdaClient } from '@/libs/trpc/client';
+import type { StoreSetter } from '@/store/types';
+
+import type { ToolStore } from '../../store';
+
+type Setter = StoreSetter<ToolStore>;
+
+export const createConnectorSlice = (set: Setter, get: () => ToolStore, _api?: unknown) =>
+  new ConnectorActionImpl(set, get, _api);
+
+export class ConnectorActionImpl {
+  readonly #set: Setter;
+
+  constructor(set: Setter, _get: () => ToolStore, _api?: unknown) {
+    void _api;
+    this.#set = set;
+  }
+
+  fetchConnectors = async (): Promise<void> => {
+    const data = await lambdaClient.connector.list.query();
+    this.#set({ connectors: data as any, isConnectorsInit: true }, false, 'fetchConnectors');
+  };
+
+  createConnector = async (
+    params: Parameters<typeof lambdaClient.connector.create.mutate>[0],
+  ): Promise<void> => {
+    this.#set({ connectorCreating: true }, false, 'createConnector/start');
+    try {
+      await lambdaClient.connector.create.mutate(params);
+      await this.fetchConnectors();
+    } finally {
+      this.#set({ connectorCreating: false }, false, 'createConnector/end');
+    }
+  };
+
+  deleteConnector = async (id: string): Promise<void> => {
+    await lambdaClient.connector.delete.mutate({ id });
+    await this.fetchConnectors();
+  };
+
+  syncConnectorTools = async (id: string): Promise<void> => {
+    this.#set(
+      (s) => ({ connectorSyncing: { ...s.connectorSyncing, [id]: true } }),
+      false,
+      'syncConnectorTools/start',
+    );
+    try {
+      await lambdaClient.connector.syncTools.mutate({ id });
+      await this.fetchConnectors();
+    } finally {
+      this.#set(
+        (s) => ({ connectorSyncing: { ...s.connectorSyncing, [id]: false } }),
+        false,
+        'syncConnectorTools/end',
+      );
+    }
+  };
+
+  disconnectConnector = async (id: string): Promise<void> => {
+    await lambdaClient.connector.update.mutate({
+      id,
+      patch: { isEnabled: false },
+    });
+    await this.fetchConnectors();
+  };
+
+  updateToolPermission = async (
+    toolId: string,
+    permission: ConnectorToolPermission,
+  ): Promise<void> => {
+    // Optimistic update
+    this.#set(
+      (s) => ({
+        connectors: s.connectors.map((c) => ({
+          ...c,
+          tools: c.tools.map((t) => (t.id === toolId ? { ...t, permission } : t)),
+        })),
+      }),
+      false,
+      'updateToolPermission/optimistic',
+    );
+
+    try {
+      await lambdaClient.connector.updateToolPermission.mutate({ permission, toolId });
+    } catch {
+      // Roll back on error
+      await this.fetchConnectors();
+    }
+  };
+}
+
+export type ConnectorAction = ReturnType<typeof createConnectorSlice>;

--- a/src/store/tool/slices/connector/action.ts
+++ b/src/store/tool/slices/connector/action.ts
@@ -136,4 +136,4 @@ export class ConnectorActionImpl {
   };
 }
 
-export type ConnectorAction = ReturnType<typeof createConnectorSlice>;
+export type ConnectorAction = Pick<ConnectorActionImpl, keyof ConnectorActionImpl>;

--- a/src/store/tool/slices/connector/action.ts
+++ b/src/store/tool/slices/connector/action.ts
@@ -65,6 +65,28 @@ export class ConnectorActionImpl {
     await this.fetchConnectors();
   };
 
+  /**
+   * Bootstrap connector entry for a builtin tool (reads manifest server-side).
+   * Idempotent — safe to call whenever the detail panel opens.
+   * Returns the connectorId.
+   */
+  syncBuiltinTool = async (identifier: string): Promise<string> => {
+    const result = await lambdaClient.connector.syncBuiltinTool.mutate({ identifier });
+    await this.fetchConnectors();
+    return result.connectorId;
+  };
+
+  /**
+   * Bootstrap connector entry for an installed marketplace plugin.
+   * Idempotent — safe to call whenever the detail panel opens.
+   * Returns the connectorId.
+   */
+  syncPluginTools = async (identifier: string): Promise<string> => {
+    const result = await lambdaClient.connector.syncPluginTools.mutate({ identifier });
+    await this.fetchConnectors();
+    return result.connectorId;
+  };
+
   updateToolPermission = async (
     toolId: string,
     permission: ConnectorToolPermission,

--- a/src/store/tool/slices/connector/action.ts
+++ b/src/store/tool/slices/connector/action.ts
@@ -66,6 +66,22 @@ export class ConnectorActionImpl {
   };
 
   /**
+   * Sync tools from a client-provided list (for Lobehub OAuth skills / Klavis
+   * that already have their tool list available on the client side).
+   * Idempotent — safe to call whenever the detail panel opens.
+   */
+  syncToolsFromClient = async (params: {
+    identifier: string;
+    name: string;
+    sourceType: 'builtin' | 'custom' | 'marketplace';
+    tools: Array<{ description?: string; inputSchema?: Record<string, unknown>; toolName: string }>;
+  }): Promise<string> => {
+    const result = await lambdaClient.connector.syncToolsFromClient.mutate(params);
+    await this.fetchConnectors();
+    return result.connectorId;
+  };
+
+  /**
    * Bootstrap connector entry for a builtin tool (reads manifest server-side).
    * Idempotent — safe to call whenever the detail panel opens.
    * Returns the connectorId.

--- a/src/store/tool/slices/connector/action.ts
+++ b/src/store/tool/slices/connector/action.ts
@@ -66,6 +66,14 @@ export class ConnectorActionImpl {
   };
 
   /**
+   * Reset all tool permissions for a connector back to 'auto' (fully open).
+   */
+  resetConnectorPermissions = async (id: string): Promise<void> => {
+    await lambdaClient.connector.resetPermissions.mutate({ id });
+    await this.fetchConnectors();
+  };
+
+  /**
    * Sync tools from a client-provided list (for Lobehub OAuth skills / Klavis
    * that already have their tool list available on the client side).
    * Idempotent — safe to call whenever the detail panel opens.

--- a/src/store/tool/slices/connector/index.ts
+++ b/src/store/tool/slices/connector/index.ts
@@ -1,0 +1,4 @@
+export * from './action';
+export * from './initialState';
+export * from './selectors';
+export * from './types';

--- a/src/store/tool/slices/connector/initialState.ts
+++ b/src/store/tool/slices/connector/initialState.ts
@@ -1,0 +1,15 @@
+import type { ConnectorWithTools } from './types';
+
+export interface ConnectorState {
+  connectorCreating: boolean;
+  connectors: ConnectorWithTools[];
+  connectorSyncing: Record<string, boolean>;
+  isConnectorsInit: boolean;
+}
+
+export const initialConnectorState: ConnectorState = {
+  connectorCreating: false,
+  connectors: [],
+  connectorSyncing: {},
+  isConnectorsInit: false,
+};

--- a/src/store/tool/slices/connector/selectors.ts
+++ b/src/store/tool/slices/connector/selectors.ts
@@ -1,5 +1,3 @@
-import { ConnectorToolPermission } from '@/database/schemas';
-
 import type { ToolStore } from '../../store';
 import type { ConnectorTool, ConnectorWithTools } from './types';
 
@@ -35,13 +33,11 @@ const connectorToolsGrouped =
     const connector = s.connectors.find((c) => c.id === connectorId);
     if (!connector) return { readTools: [], writeTools: [] };
 
-    const visibleTools = connector.tools.filter(
-      (t) => t.permission !== ConnectorToolPermission.disabled,
-    );
-
+    // Show ALL tools in the settings UI (including disabled ones so users can re-enable them).
+    // Disabled tools are filtered out at runtime in buildConnectorManifests / queryByConnectorIds.
     return {
-      readTools: visibleTools.filter((t) => t.crudType === 'read'),
-      writeTools: visibleTools.filter((t) => t.crudType !== 'read'),
+      readTools: connector.tools.filter((t) => t.crudType === 'read'),
+      writeTools: connector.tools.filter((t) => t.crudType !== 'read'),
     };
   };
 

--- a/src/store/tool/slices/connector/selectors.ts
+++ b/src/store/tool/slices/connector/selectors.ts
@@ -1,0 +1,56 @@
+import { ConnectorToolPermission } from '@/database/schemas';
+
+import type { ToolStore } from '../../store';
+import type { ConnectorTool, ConnectorWithTools } from './types';
+
+const connectorList = (s: ToolStore): ConnectorWithTools[] => s.connectors;
+
+const connectorById =
+  (id: string) =>
+  (s: ToolStore): ConnectorWithTools | undefined =>
+    s.connectors.find((c) => c.id === id);
+
+const enabledConnectors = (s: ToolStore): ConnectorWithTools[] =>
+  s.connectors.filter((c) => c.isEnabled);
+
+const connectedConnectors = (s: ToolStore): ConnectorWithTools[] =>
+  s.connectors.filter((c) => c.status === 'connected');
+
+const notConnectedConnectors = (s: ToolStore): ConnectorWithTools[] =>
+  s.connectors.filter((c) => c.status !== 'connected');
+
+interface GroupedTools {
+  readTools: ConnectorTool[];
+  writeTools: ConnectorTool[];
+}
+
+const connectorToolsGrouped =
+  (connectorId: string) =>
+  (s: ToolStore): GroupedTools => {
+    const connector = s.connectors.find((c) => c.id === connectorId);
+    if (!connector) return { readTools: [], writeTools: [] };
+
+    const visibleTools = connector.tools.filter(
+      (t) => t.permission !== ConnectorToolPermission.disabled,
+    );
+
+    return {
+      readTools: visibleTools.filter((t) => t.crudType === 'read'),
+      writeTools: visibleTools.filter((t) => t.crudType !== 'read'),
+    };
+  };
+
+const isSyncing =
+  (connectorId: string) =>
+  (s: ToolStore): boolean =>
+    s.connectorSyncing[connectorId] ?? false;
+
+export const connectorSelectors = {
+  connectedConnectors,
+  connectorById,
+  connectorList,
+  connectorToolsGrouped,
+  enabledConnectors,
+  isSyncing,
+  notConnectedConnectors,
+};

--- a/src/store/tool/slices/connector/selectors.ts
+++ b/src/store/tool/slices/connector/selectors.ts
@@ -10,6 +10,11 @@ const connectorById =
   (s: ToolStore): ConnectorWithTools | undefined =>
     s.connectors.find((c) => c.id === id);
 
+const connectorByIdentifier =
+  (identifier: string) =>
+  (s: ToolStore): ConnectorWithTools | undefined =>
+    s.connectors.find((c) => c.identifier === identifier);
+
 const enabledConnectors = (s: ToolStore): ConnectorWithTools[] =>
   s.connectors.filter((c) => c.isEnabled);
 
@@ -48,9 +53,23 @@ const isSyncing =
 export const connectorSelectors = {
   connectedConnectors,
   connectorById,
+  connectorByIdentifier,
   connectorList,
   connectorToolsGrouped,
+  connectorToolsGroupedByIdentifier:
+    (identifier: string) =>
+    (s: ToolStore): { readTools: ConnectorTool[]; writeTools: ConnectorTool[] } => {
+      const connector = connectorByIdentifier(identifier)(s);
+      if (!connector) return { readTools: [], writeTools: [] };
+      return connectorToolsGrouped(connector.id)(s);
+    },
   enabledConnectors,
   isSyncing,
+  isSyncingByIdentifier:
+    (identifier: string) =>
+    (s: ToolStore): boolean => {
+      const connector = connectorByIdentifier(identifier)(s);
+      return connector ? (s.connectorSyncing[connector.id] ?? false) : false;
+    },
   notConnectedConnectors,
 };

--- a/src/store/tool/slices/connector/selectors.ts
+++ b/src/store/tool/slices/connector/selectors.ts
@@ -23,21 +23,25 @@ const notConnectedConnectors = (s: ToolStore): ConnectorWithTools[] =>
   s.connectors.filter((c) => c.status !== 'connected');
 
 interface GroupedTools {
+  createTools: ConnectorTool[];
+  deleteTools: ConnectorTool[];
   readTools: ConnectorTool[];
-  writeTools: ConnectorTool[];
+  updateTools: ConnectorTool[];
 }
 
 const connectorToolsGrouped =
   (connectorId: string) =>
   (s: ToolStore): GroupedTools => {
     const connector = s.connectors.find((c) => c.id === connectorId);
-    if (!connector) return { readTools: [], writeTools: [] };
+    if (!connector) return { createTools: [], deleteTools: [], readTools: [], updateTools: [] };
 
     // Show ALL tools in the settings UI (including disabled ones so users can re-enable them).
     // Disabled tools are filtered out at runtime in buildConnectorManifests / queryByConnectorIds.
     return {
+      createTools: connector.tools.filter((t) => t.crudType === 'write'),
+      deleteTools: connector.tools.filter((t) => t.crudType === 'delete'),
       readTools: connector.tools.filter((t) => t.crudType === 'read'),
-      writeTools: connector.tools.filter((t) => t.crudType !== 'read'),
+      updateTools: connector.tools.filter((t) => t.crudType === 'update'),
     };
   };
 
@@ -54,9 +58,9 @@ export const connectorSelectors = {
   connectorToolsGrouped,
   connectorToolsGroupedByIdentifier:
     (identifier: string) =>
-    (s: ToolStore): { readTools: ConnectorTool[]; writeTools: ConnectorTool[] } => {
+    (s: ToolStore): GroupedTools => {
       const connector = connectorByIdentifier(identifier)(s);
-      if (!connector) return { readTools: [], writeTools: [] };
+      if (!connector) return { createTools: [], deleteTools: [], readTools: [], updateTools: [] };
       return connectorToolsGrouped(connector.id)(s);
     },
   enabledConnectors,

--- a/src/store/tool/slices/connector/types.ts
+++ b/src/store/tool/slices/connector/types.ts
@@ -1,0 +1,26 @@
+import type { ConnectorToolPermission } from '@/database/schemas';
+
+export interface ConnectorTool {
+  crudType: string;
+  description: string | null;
+  displayName: string | null;
+  id: string;
+  inputSchema: Record<string, unknown> | null;
+  permission: ConnectorToolPermission;
+  toolName: string;
+  userConnectorId: string;
+}
+
+export interface ConnectorWithTools {
+  credentials: unknown;
+  id: string;
+  identifier: string;
+  isEnabled: boolean;
+  mcpConnectionType: string | null;
+  mcpServerUrl: string | null;
+  metadata: Record<string, unknown> | null;
+  name: string;
+  sourceType: string;
+  status: string;
+  tools: ConnectorTool[];
+}

--- a/src/store/tool/slices/klavisStore/action.ts
+++ b/src/store/tool/slices/klavisStore/action.ts
@@ -42,7 +42,7 @@ export class KlavisStoreActionImpl {
   }
 
   callKlavisTool = async (params: CallKlavisToolParams): Promise<CallKlavisToolResult> => {
-    const { serverUrl, toolName, toolArgs } = params;
+    const { serverUrl, toolName, toolArgs, identifier } = params;
 
     const toolId = `${serverUrl}:${toolName}`;
 
@@ -57,6 +57,7 @@ export class KlavisStoreActionImpl {
     try {
       // Call tRPC server interface to execute tool (use toolsClient for longer timeout)
       const response = await toolsClient.klavis.callTool.mutate({
+        identifier,
         serverUrl,
         toolArgs,
         toolName,

--- a/src/store/tool/slices/klavisStore/types.ts
+++ b/src/store/tool/slices/klavisStore/types.ts
@@ -79,6 +79,8 @@ export interface CreateKlavisServerParams {
  * Parameters for calling Klavis tool
  */
 export interface CallKlavisToolParams {
+  /** Klavis server identifier (e.g. 'gmail', 'google-calendar') — used for precise permission lookup */
+  identifier?: string;
   /** Strata Server URL */
   serverUrl: string;
   /** Tool arguments */

--- a/src/store/tool/store.ts
+++ b/src/store/tool/store.ts
@@ -13,6 +13,7 @@ import {
 } from './slices/agentDocumentSkills';
 import { type AgentSkillsAction, createAgentSkillsSlice } from './slices/agentSkills';
 import { type BuiltinToolAction, createBuiltinToolSlice } from './slices/builtin';
+import { type ConnectorAction, createConnectorSlice } from './slices/connector';
 import { createCustomPluginSlice, type CustomPluginAction } from './slices/customPlugin';
 import { createKlavisStoreSlice, type KlavisStoreAction } from './slices/klavisStore';
 import {
@@ -25,6 +26,7 @@ import { createPluginSlice, type PluginAction } from './slices/plugin';
 //  ===============  Aggregate createStoreFn ============ //
 
 export type ToolStore = ToolStoreState &
+  ConnectorAction &
   CustomPluginAction &
   PluginAction &
   BuiltinToolAction &
@@ -35,7 +37,8 @@ export type ToolStore = ToolStoreState &
   AgentDocumentSkillsAction &
   ResetableStore;
 
-type ToolStoreAction = CustomPluginAction &
+type ToolStoreAction = ConnectorAction &
+  CustomPluginAction &
   PluginAction &
   BuiltinToolAction &
   PluginMCPStoreAction &
@@ -54,6 +57,7 @@ const createStore: StateCreator<ToolStore, [['zustand/devtools', never]]> = (
 ) => ({
   ...initialState,
   ...flattenActions<ToolStoreAction>([
+    createConnectorSlice(...parameters),
     createPluginSlice(...parameters),
     createCustomPluginSlice(...parameters),
     createBuiltinToolSlice(...parameters),


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🐛 fix

#### 🔗 Related Issue

Related to LOBE-9983 (parent) — LOBE-9984 through LOBE-9989

#### 🔀 Description of Change

Implements the Connectors system as a unified tool permission management layer, extending it to cover ALL tool types (MCP, Klavis, Lobehub market skills, builtin tools).

---

### Core Architecture

**DB Layer (user_connectors + user_connector_tools)**
- `ConnectorModel`: create/delete/query/queryByIdentifiers/findById/update/updateStatus
- `ConnectorToolModel`: upsertMany with `defaultPermission`, updatePermission, queryByConnector/ByConnectorIds
- `inferCrudType()`: prefix-based camelCase matching (getReactions → 'read', not 'write')

**tRPC Router (connector.*)**
- CRUD: list/create/update/delete
- `syncTools`: fetch from remote MCP server
- `syncBuiltinTool` / `syncPluginTools` / `syncToolsFromClient`: bootstrap connector entries from various manifest sources
- `updateToolPermission`, `resetPermissions`

**Runtime (aiAgent.ts)**
- Connector-first resolution: `queryByIdentifiers(agentPlugins)` → connector wins over plugin
- Only connectors with real MCP endpoint (`mcpServerUrl` or `stdio`) replace plugins in manifest; Lobehub/Klavis OAuth skills keep their native executor path
- `buildConnectorManifests`: injects tools with `humanIntervention: 'required'` for `needs_approval`, and blocking description for `disabled`
- Lobehub/Klavis manifests patched with permissions from DB before being passed to the engine

---

### Permission Enforcement (3-layer)

| Layer | Where | What |
|-------|-------|------|
| Manifest | `buildConnectorManifests` + `aiAgent` manifest patch | `needs_approval` → `humanIntervention: 'required'`; `disabled` → blocking description |
| Executor gate | `ToolExecutionService.executeTool()` — covers ALL paths + qstash | Hard-blocks `disabled` tools before any executor runs |
| Specific gates | `klavis.callTool`, `mcp.callTool` | Additional per-router checks |

**Execution paths covered:**
- ✅ Lobehub market skills (Vercel, GitHub, Linear...)
- ✅ Klavis tools (Gmail, Google Calendar...)
- ✅ MCP connectors (custom HTTP/stdio)
- ✅ Builtin tools
- ✅ qstash / execAgent (async, headless — humanIntervention auto-rejects needs_approval)

---

### /settings/skill Refactor

**Master-detail layout** (left: skill list, right: permission editor)
- **Connectors tab**: builtin tools + OAuth connectors + community/custom MCP
- **Skills tab**: builtin agent skills + community/user agent skills
- Left panel: collapsible sections, compact items (20px icon, 14px font)
- Section headers: lowercase, no caps
- Tool groups: Read-only / Create / Update / Delete (4-way split by crudType)
- SkillDetail: 5 types — `builtin`, `builtin-skill`, `plugin`, `agent-skill`, `lobehub-connector`
- `AgentSkillDetail` inline for agent skills (no modal)

---

#### 🧪 How to Test

- [ ] Open `/settings/skill` → Connectors tab → click any builtin tool → right panel shows tool permissions
- [ ] Set a tool to `disabled` → start chat → tool is blocked with "disabled by user" message
- [ ] Set a tool to `needs_approval` → start chat → approval dialog appears; after Allow the tool executes
- [ ] Set Klavis Gmail tool to `disabled` → ask AI to check email → blocked with message
- [ ] Click `Reset permissions` → all tools reset to `auto`
- [ ] Skills tab → click Artifacts/Task → shows markdown content; click user skill → shows AgentSkillDetail inline

#### 📝 Notes for reviewer

1. `oidcConfig` uses `as any` — OIDCConfig zod schema alignment is follow-up
2. OAuth2 access token embedded in manifest — server-side proxy for credential isolation is follow-up
3. Custom HTTP MCP connector OAuth flow (DCR/Pre-registration) intentionally deferred — `+` button hidden
4. i18n fallback strings in UI — locale keys need adding to `src/locales/default/` before merge
5. `buildConnectorManifests` now includes `disabled` tools in manifest (with blocking description) — AI knows they exist but can inform user they're disabled