### PR TITLE
🔨 chore(database): re-tighten getBuiltinAgent onConflict after 0109

### DIFF
--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -673,13 +673,9 @@ export class AgentModel {
     // `onConflictDoNothing`, the loser hits the `agents_slug_user_id_unique`
     // constraint; with it, the loser's `.returning()` is empty and we re-read
     // the row that won.
-    // Bare `onConflictDoNothing()` (no target) does NOT pin an arbiter index,
-    // so it works whether `agents_slug_user_id_unique` is the legacy full
-    // unique or the migration-0109 partial (WHERE workspace_id IS NULL) — this
-    // is the transition-safe form while 0109 rolls out. For this row only
-    // (slug, user_id) can collide (client_id / workspace_id are NULL, id is
-    // freshly generated). Tighten back to { target, where: isNull(workspaceId) }
-    // once 0109 has flipped the index in every environment.
+    // `agents_slug_user_id_unique` is a partial index (WHERE workspace_id IS
+    // NULL) since migration 0109, so the conflict arbiter must carry the same
+    // predicate; builtin agents are always workspace-less (workspace_id NULL).
     const result = await this.db
       .insert(agents)
       .values({
@@ -689,7 +685,10 @@ export class AgentModel {
         userId: this.userId,
         virtual: true,
       })
-      .onConflictDoNothing()
+      .onConflictDoNothing({
+        target: [agents.slug, agents.userId],
+        where: isNull(agents.workspaceId),
+      })
       .returning();
 
     if (result[0]) return result[0];


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔗 Related Issue

Follow-up to #15472 / LOBE-9962 (workspace_id migration phase 4).

#### 🔀 Description of Change

Migration 0109 turned `agents_slug_user_id_unique` into a partial index (`WHERE workspace_id IS NULL`). During the rollout, #15472 temporarily used a bare `onConflictDoNothing()` (no arbiter) in `getBuiltinAgent` so the upsert worked regardless of whether the index was the legacy full unique or the new partial — avoiding a deploy-ordering footgun.

Now that 0109 has flipped the index in every environment (verified: `agents_slug_user_id_unique` is `valid`, `unique`, predicate `workspace_id IS NULL`), this restores the precise arbiter:

```ts
.onConflictDoNothing({ target: [agents.slug, agents.userId], where: isNull(agents.workspaceId) })
```

so genuine/unexpected unique violations surface instead of being silently swallowed. Builtin agents are always workspace-less, so the predicate always holds.

#### 🧪 How to Test

- [x] Tested locally — `agent.test.ts` 114/114 pass against the partial index.
- [ ] Added/updated tests
- [x] No tests needed