### PR TITLE
♻️ refactor: expose email harmony options slot

### DIFF
--- a/src/business/server/better-auth.ts
+++ b/src/business/server/better-auth.ts
@@ -1,4 +1,7 @@
-// eslint-disable-next-line unused-imports/no-unused-vars
-export async function businessEmailValidator(email: string): Promise<boolean> {
-  return true;
-}
+import type { emailHarmony } from 'better-auth-harmony';
+
+export type BusinessEmailHarmonyOptions = NonNullable<Parameters<typeof emailHarmony>[0]>;
+
+export const businessEmailHarmonyOptions = {
+  allowNormalizedSignin: false,
+} satisfies BusinessEmailHarmonyOptions;

--- a/src/libs/better-auth/define-config.test.ts
+++ b/src/libs/better-auth/define-config.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   betterAuth: vi.fn((options) => options),
+  businessEmailHarmonyOptions: { allowNormalizedSignin: false },
+  emailHarmony: vi.fn((options) => ({ id: 'email-harmony', options })),
 }));
 
 vi.mock('@better-auth/expo', () => ({
@@ -10,10 +12,6 @@ vi.mock('@better-auth/expo', () => ({
 
 vi.mock('@better-auth/passkey', () => ({
   passkey: vi.fn(() => ({ id: 'passkey' })),
-}));
-
-vi.mock('@lobechat/business-const', () => ({
-  ENABLE_BUSINESS_FEATURES: false,
 }));
 
 vi.mock('@lobechat/database', () => ({
@@ -50,11 +48,7 @@ vi.mock('better-auth/plugins', () => ({
 }));
 
 vi.mock('better-auth-harmony', () => ({
-  emailHarmony: vi.fn(() => ({ id: 'email-harmony' })),
-}));
-
-vi.mock('better-auth-harmony/email', () => ({
-  validateEmail: vi.fn(),
+  emailHarmony: mocks.emailHarmony,
 }));
 
 vi.mock('undici', () => ({
@@ -63,7 +57,7 @@ vi.mock('undici', () => ({
 }));
 
 vi.mock('@/business/server/better-auth', () => ({
-  businessEmailValidator: vi.fn(),
+  businessEmailHarmonyOptions: mocks.businessEmailHarmonyOptions,
 }));
 
 vi.mock('@/envs/app', () => ({
@@ -131,5 +125,13 @@ describe('defineConfig', () => {
         }),
       }),
     );
+  });
+
+  it('should delegate emailHarmony options to the business slot', async () => {
+    const { defineConfig } = await import('./define-config');
+
+    defineConfig({ plugins: [] });
+
+    expect(mocks.emailHarmony).toHaveBeenCalledWith(mocks.businessEmailHarmonyOptions);
   });
 });

--- a/src/libs/better-auth/define-config.ts
+++ b/src/libs/better-auth/define-config.ts
@@ -1,6 +1,5 @@
 import { expo } from '@better-auth/expo';
 import { passkey } from '@better-auth/passkey';
-import { ENABLE_BUSINESS_FEATURES } from '@lobechat/business-const';
 import { createNanoId, idGenerator, serverDB } from '@lobechat/database';
 import * as schema from '@lobechat/database/schemas';
 import bcrypt from 'bcryptjs';
@@ -11,10 +10,9 @@ import { betterAuth } from 'better-auth/minimal';
 import { admin, emailOTP, genericOAuth, magicLink } from 'better-auth/plugins';
 import { type BetterAuthPlugin } from 'better-auth/types';
 import { emailHarmony } from 'better-auth-harmony';
-import { validateEmail } from 'better-auth-harmony/email';
 import { ProxyAgent, setGlobalDispatcher } from 'undici';
 
-import { businessEmailValidator } from '@/business/server/better-auth';
+import { businessEmailHarmonyOptions } from '@/business/server/better-auth';
 import { appEnv } from '@/envs/app';
 import { authEnv } from '@/envs/auth';
 import {
@@ -83,10 +81,6 @@ const enableMagicLink = authEnv.AUTH_ENABLE_MAGIC_LINK;
 const enabledSSOProviders = parseSSOProviders(authEnv.AUTH_SSO_PROVIDERS);
 
 const { socialProviders, genericOAuthProviders } = initBetterAuthSSOProviders();
-
-async function customEmailValidator(email: string): Promise<boolean> {
-  return ENABLE_BUSINESS_FEATURES ? businessEmailValidator(email) : validateEmail(email);
-}
 
 interface CustomBetterAuthOptions {
   plugins: BetterAuthPlugin[];
@@ -264,7 +258,7 @@ export function defineConfig(customOptions: CustomBetterAuthOptions) {
       ...customOptions.plugins,
       emailWhitelist(),
       expo(),
-      emailHarmony({ allowNormalizedSignin: false, validator: customEmailValidator }),
+      emailHarmony(businessEmailHarmonyOptions),
       admin(),
       // Email OTP plugin for mobile verification
       emailOTP({


### PR DESCRIPTION

#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Move the email harmony plugin options behind the existing extension point.
- Keep the shared default configuration minimal while allowing downstream builds to provide their own option shape.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' src/libs/better-auth/define-config.test.ts
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

N/A
