### PR TITLE
🐛 fix: handle runtime request errors

### DIFF
--- a/src/app/(backend)/oidc/[...oidc]/route.test.ts
+++ b/src/app/(backend)/oidc/[...oidc]/route.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @vitest-environment node
+ */
+import type { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createNodeRequest: vi.fn(),
+  createNodeResponse: vi.fn(),
+  middleware: vi.fn(),
+  providerCallback: vi.fn(),
+}));
+
+vi.mock('debug', () => ({
+  default: () => vi.fn(),
+}));
+
+vi.mock('@/envs/auth', () => ({
+  authEnv: {
+    ENABLE_OIDC: true,
+  },
+}));
+
+vi.mock('@/libs/oidc-provider/http-adapter', () => ({
+  createNodeRequest: mocks.createNodeRequest,
+  createNodeResponse: mocks.createNodeResponse,
+}));
+
+vi.mock('@/server/services/oidc/oidcProvider', () => ({
+  getOIDCProvider: vi.fn(async () => ({
+    callback: mocks.providerCallback,
+  })),
+}));
+
+describe('OIDC route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.providerCallback.mockReturnValue(mocks.middleware);
+    mocks.createNodeResponse.mockReturnValue({
+      nodeResponse: {},
+      responseBody: '',
+      responseHeaders: {},
+      responseStatus: 200,
+    });
+  });
+
+  it('returns a 500 response when creating the Node request fails', async () => {
+    mocks.createNodeRequest.mockRejectedValueOnce(new Error('body stream aborted'));
+
+    const { POST } = await import('./route');
+    const request = new Request('https://example.com/oidc/token', {
+      body: 'grant_type=refresh_token',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      method: 'POST',
+    }) as unknown as NextRequest;
+
+    const response = await Promise.race([
+      POST(request),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('OIDC route timed out')), 50),
+      ),
+    ]);
+
+    expect(response.status).toBe(500);
+    await expect(response.text()).resolves.toContain('body stream aborted');
+    expect(mocks.middleware).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(backend)/oidc/[...oidc]/route.ts
+++ b/src/app/(backend)/oidc/[...oidc]/route.ts
@@ -61,7 +61,7 @@ const handler = async (req: NextRequest) => {
           }
         });
         log('Middleware call initiated, waiting for its callback OR nodeResponse.end()...');
-      });
+      }, reject);
     });
 
     log('Promise surrounding middleware call resolved.');

--- a/src/libs/oidc-provider/http-adapter.test.ts
+++ b/src/libs/oidc-provider/http-adapter.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment node
+ */
+import type { Readable } from 'node:stream';
+
+import type { NextRequest } from 'next/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('debug', () => ({
+  default: () => vi.fn(),
+}));
+
+vi.mock('@/envs/app', () => ({
+  appEnv: {
+    APP_URL: 'https://example.com',
+  },
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}));
+
+const readStream = async (stream: Readable) => {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+
+  return Buffer.concat(chunks).toString();
+};
+
+describe('OIDC HTTP adapter', () => {
+  describe('createNodeRequest', () => {
+    it('passes POST bodies through as a readable Node stream without pre-parsing', async () => {
+      const body = 'grant_type=authorization_code&code=test-code';
+      const request = new Request('https://example.com/oidc/token?client_id=test', {
+        body,
+        headers: {
+          'content-length': String(Buffer.byteLength(body)),
+          'content-type': 'application/x-www-form-urlencoded',
+          'x-forwarded-for': '203.0.113.10',
+        },
+        method: 'POST',
+      }) as unknown as NextRequest;
+
+      const { createNodeRequest } = await import('./http-adapter');
+      const nodeRequest = await createNodeRequest(request);
+
+      expect(nodeRequest).toMatchObject({
+        method: 'POST',
+        url: '/oidc/token?client_id=test',
+      });
+      expect(nodeRequest.socket.remoteAddress).toBe('203.0.113.10');
+      expect(nodeRequest.readable).toBe(true);
+      expect('body' in nodeRequest).toBe(false);
+      await expect(readStream(nodeRequest as unknown as Readable)).resolves.toBe(body);
+    });
+
+    it('does not consume an explicitly empty request body', async () => {
+      const arrayBuffer = vi.fn();
+      const request = {
+        arrayBuffer,
+        body: new ReadableStream(),
+        headers: new Headers({ 'content-length': '0' }),
+        method: 'POST',
+        url: 'https://example.com/oidc/token',
+      } as unknown as NextRequest;
+
+      const { createNodeRequest } = await import('./http-adapter');
+      const nodeRequest = await createNodeRequest(request);
+
+      expect(arrayBuffer).not.toHaveBeenCalled();
+      expect(nodeRequest.readable).toBe(true);
+      await expect(readStream(nodeRequest as unknown as Readable)).resolves.toBe('');
+    });
+  });
+});

--- a/src/libs/oidc-provider/http-adapter.test.ts
+++ b/src/libs/oidc-provider/http-adapter.test.ts
@@ -57,6 +57,47 @@ describe('OIDC HTTP adapter', () => {
       await expect(readStream(nodeRequest as unknown as Readable)).resolves.toBe(body);
     });
 
+    it('keeps token endpoint form parameters parseable by oidc-provider', async () => {
+      const body = new URLSearchParams({
+        client_id: 'lobehub-desktop',
+        code: 'test-code',
+        code_verifier: 'test-verifier',
+        grant_type: 'authorization_code',
+        redirect_uri: 'https://example.com/oidc/callback/desktop',
+      }).toString();
+      const request = new Request('https://example.com/oidc/token', {
+        body,
+        headers: {
+          'content-length': String(Buffer.byteLength(body)),
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+        method: 'POST',
+      }) as unknown as NextRequest;
+
+      const { createNodeRequest } = await import('./http-adapter');
+      const { urlencoded } = (await import('oidc-provider/lib/shared/selective_body.js')) as {
+        urlencoded: (ctx: any, next: () => Promise<void>) => Promise<void>;
+      };
+      const nodeRequest = await createNodeRequest(request);
+      const ctx = {
+        charset: 'utf-8',
+        is: (contentType: string) => contentType === 'application/x-www-form-urlencoded',
+        oidc: {},
+        req: nodeRequest,
+        request: { length: Buffer.byteLength(body) },
+      };
+
+      await urlencoded(ctx, async () => {});
+
+      expect(ctx.oidc.body).toMatchObject({
+        client_id: 'lobehub-desktop',
+        code: 'test-code',
+        code_verifier: 'test-verifier',
+        grant_type: 'authorization_code',
+        redirect_uri: 'https://example.com/oidc/callback/desktop',
+      });
+    });
+
     it('does not consume an explicitly empty request body', async () => {
       const arrayBuffer = vi.fn();
       const request = {

--- a/src/libs/oidc-provider/http-adapter.ts
+++ b/src/libs/oidc-provider/http-adapter.ts
@@ -1,4 +1,5 @@
 import { type IncomingMessage, type ServerResponse } from 'node:http';
+import { Readable } from 'node:stream';
 
 import debug from 'debug';
 import { cookies } from 'next/headers';
@@ -8,6 +9,8 @@ import urlJoin from 'url-join';
 import { appEnv } from '@/envs/app';
 
 const log = debug('lobe-oidc:http-adapter');
+
+const methodsWithBody = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
 /**
  * Convert Next.js request headers to standard Node.js HTTP header format
@@ -39,71 +42,28 @@ export const createNodeRequest = async (req: NextRequest): Promise<IncomingMessa
   log('Creating Node.js request from Next.js request');
   log('Original path: %s, Provider path: %s', url.pathname, providerPath);
 
-  // Attempt to parse and attach body for relevant methods
-  let parsedBody: any = undefined;
-  const methodsWithBody = ['POST', 'PUT', 'PATCH', 'DELETE'];
-  if (methodsWithBody.includes(req.method)) {
-    const contentType = req.headers.get('content-type')?.split(';')[0]; // Get content type without charset etc.
-    log(`Attempting to parse body for ${req.method} with Content-Type: ${contentType}`);
-    try {
-      // Check if body exists and has size before attempting to parse
-      if (req.body && req.headers.get('content-length') !== '0') {
-        if (contentType === 'application/x-www-form-urlencoded') {
-          const formData = await req.formData();
-          parsedBody = {};
-          formData.forEach((value, key) => {
-            // If a key appears multiple times, keep the last one (standard form behavior)
-            // Or convert to array if oidc-provider expects it:
-            // if (parsedBody[key]) {
-            //   if (!Array.isArray(parsedBody[key])) parsedBody[key] = [parsedBody[key]];
-            //   parsedBody[key].push(value);
-            // } else {
-            //   parsedBody[key] = value;
-            // }
-            parsedBody[key] = value;
-          });
-          log('Parsed form data body: %O', parsedBody);
-        } else if (contentType === 'application/json') {
-          parsedBody = await req.json();
-          log('Parsed JSON body: %O', parsedBody);
-        } else {
-          log(`Body parsing skipped for Content-Type: ${contentType}. Trying text() as fallback.`);
-          // Fallback: try reading as text if content type is unknown but body exists
-          parsedBody = await req.text();
-          log('Parsed body as text fallback.');
-        }
-      } else {
-        log('Request has no body or content-length is 0, skipping parsing.');
-      }
-    } catch (error) {
-      log('Error parsing request body: %O', error);
-      // Keep parsedBody as undefined, let oidc-provider handle the potential issue
-    }
-  }
-  const nodeRequest = {
+  const bodyStream =
+    methodsWithBody.has(req.method) && req.body && req.headers.get('content-length') !== '0'
+      ? Readable.from([Buffer.from(await req.arrayBuffer())])
+      : Readable.from([]);
+
+  /**
+   * oidc-provider expects a readable Node request and parses supported body types itself.
+   * Passing a pre-parsed `body` triggers its upstream parser warning and bypasses raw-body.
+   */
+  const nodeRequest = Object.assign(bodyStream, {
     // Basic properties
     headers: convertHeadersToNodeHeaders(req.headers),
 
     method: req.method,
-    // Simulate readable stream behavior (oidc-provider might not rely on this if body is pre-parsed)
-    on: (event: string, handler: (...args: any[]) => any) => {
-      if (event === 'end') {
-        // Simulate end immediately as body is already processed or will be attached
-        handler();
-      }
-    },
     // Add extra properties expected by the Node.js server
     socket: {
       remoteAddress: req.headers.get('x-forwarded-for') || '127.0.0.1',
     },
     url: providerPath + url.search,
-    ...(parsedBody !== undefined && { body: parsedBody }), // Attach body if it exists
-  };
+  });
 
   log('Node.js request created with method %s and path %s', nodeRequest.method, nodeRequest.url);
-  if (nodeRequest.body) {
-    log('Attached parsed body to Node.js request.');
-  }
   // Cast back to IncomingMessage for the function's return signature
   return nodeRequest as unknown as IncomingMessage;
 };

--- a/src/libs/trpc/utils/responseMeta.test.ts
+++ b/src/libs/trpc/utils/responseMeta.test.ts
@@ -8,6 +8,8 @@ import { describe, expect, it } from 'vitest';
 
 import { createResponseMeta } from './responseMeta';
 
+type TRPCErrorWithHttpStatus = TRPCError & { httpStatus?: number };
+
 describe('createResponseMeta', () => {
   it('should return undefined headers when no errors and no resHeaders', () => {
     const result = createResponseMeta({ ctx: undefined, errors: [] });
@@ -81,6 +83,37 @@ describe('createResponseMeta', () => {
     });
 
     expect(result.headers).toBeUndefined();
+  });
+
+  it('should NOT set AUTH_REQUIRED_HEADER for runtime provider auth errors', () => {
+    const error = new TRPCError({
+      code: TRPC_ERROR_CODE_UNAUTHORIZED,
+      message: 'InvalidProviderAPIKey',
+    }) as TRPCErrorWithHttpStatus;
+    error.httpStatus = 401;
+
+    const result = createResponseMeta({
+      ctx: undefined,
+      errors: [error],
+    });
+
+    expect(result.status).toBe(401);
+    expect(result.headers?.get(AUTH_REQUIRED_HEADER)).toBeNull();
+  });
+
+  it('should preserve runtime custom HTTP status', () => {
+    const error = new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'ProviderBizError',
+    }) as TRPCErrorWithHttpStatus;
+    error.httpStatus = 471;
+
+    const result = createResponseMeta({
+      ctx: undefined,
+      errors: [error],
+    });
+
+    expect(result.status).toBe(471);
   });
 
   it('should handle multiple errors where one is UNAUTHORIZED', () => {

--- a/src/libs/trpc/utils/responseMeta.test.ts
+++ b/src/libs/trpc/utils/responseMeta.test.ts
@@ -8,8 +8,6 @@ import { describe, expect, it } from 'vitest';
 
 import { createResponseMeta } from './responseMeta';
 
-type TRPCErrorWithHttpStatus = TRPCError & { httpStatus?: number };
-
 describe('createResponseMeta', () => {
   it('should return undefined headers when no errors and no resHeaders', () => {
     const result = createResponseMeta({ ctx: undefined, errors: [] });
@@ -87,33 +85,17 @@ describe('createResponseMeta', () => {
 
   it('should NOT set AUTH_REQUIRED_HEADER for runtime provider auth errors', () => {
     const error = new TRPCError({
+      cause: { errorType: 'InvalidProviderAPIKey' },
       code: TRPC_ERROR_CODE_UNAUTHORIZED,
       message: 'InvalidProviderAPIKey',
-    }) as TRPCErrorWithHttpStatus;
-    error.httpStatus = 401;
+    });
 
     const result = createResponseMeta({
       ctx: undefined,
       errors: [error],
     });
 
-    expect(result.status).toBe(401);
-    expect(result.headers?.get(AUTH_REQUIRED_HEADER)).toBeNull();
-  });
-
-  it('should preserve runtime custom HTTP status', () => {
-    const error = new TRPCError({
-      code: 'BAD_REQUEST',
-      message: 'ProviderBizError',
-    }) as TRPCErrorWithHttpStatus;
-    error.httpStatus = 471;
-
-    const result = createResponseMeta({
-      ctx: undefined,
-      errors: [error],
-    });
-
-    expect(result.status).toBe(471);
+    expect(result.headers).toBeUndefined();
   });
 
   it('should handle multiple errors where one is UNAUTHORIZED', () => {

--- a/src/libs/trpc/utils/responseMeta.ts
+++ b/src/libs/trpc/utils/responseMeta.ts
@@ -10,6 +10,15 @@ interface ResponseMetaParams {
   errors: TRPCError[];
 }
 
+type TRPCErrorWithHttpStatus = TRPCError & { httpStatus?: number };
+
+const getRuntimeHttpStatus = (error: TRPCError): number | undefined => {
+  const status = (error as TRPCErrorWithHttpStatus).httpStatus;
+  if (typeof status !== 'number' || !Number.isInteger(status)) return;
+  if (status < 400 || status > 599) return;
+  return status;
+};
+
 /**
  * Create response metadata for TRPC handlers.
  *
@@ -23,6 +32,7 @@ interface ResponseMetaParams {
  */
 export function createResponseMeta({ ctx, errors }: ResponseMetaParams): {
   headers: Headers | undefined;
+  status?: number;
 } {
   const resHeaders =
     ctx && typeof ctx === 'object' && 'resHeaders' in ctx
@@ -35,15 +45,19 @@ export function createResponseMeta({ ctx, errors }: ResponseMetaParams): {
   // event flow (MarketAuthProvider) rather than the desktop re-login modal.
   const hasUnauthorizedError = errors.some(
     (error) =>
-      error.code === TRPC_ERROR_CODE_UNAUTHORIZED && error.message !== MARKET_AUTH_REQUIRED_MESSAGE,
+      error.code === TRPC_ERROR_CODE_UNAUTHORIZED &&
+      error.message !== MARKET_AUTH_REQUIRED_MESSAGE &&
+      !getRuntimeHttpStatus(error),
   );
   if (hasUnauthorizedError) {
     headers.set(AUTH_REQUIRED_HEADER, 'true');
   }
 
+  const runtimeHttpStatus = errors.map(getRuntimeHttpStatus).find((status) => status !== undefined);
+
   // Only return headers if there's content or auth error
-  if (hasUnauthorizedError || resHeaders) {
-    return { headers };
+  if (hasUnauthorizedError || resHeaders || runtimeHttpStatus) {
+    return { headers, status: runtimeHttpStatus };
   }
 
   return { headers: undefined };

--- a/src/libs/trpc/utils/responseMeta.ts
+++ b/src/libs/trpc/utils/responseMeta.ts
@@ -10,13 +10,11 @@ interface ResponseMetaParams {
   errors: TRPCError[];
 }
 
-type TRPCErrorWithHttpStatus = TRPCError & { httpStatus?: number };
+const isRuntimeError = (error: TRPCError) => {
+  const cause = error.cause;
+  if (!cause || typeof cause !== 'object') return false;
 
-const getRuntimeHttpStatus = (error: TRPCError): number | undefined => {
-  const status = (error as TRPCErrorWithHttpStatus).httpStatus;
-  if (typeof status !== 'number' || !Number.isInteger(status)) return;
-  if (status < 400 || status > 599) return;
-  return status;
+  return typeof (cause as { errorType?: unknown }).errorType === 'string';
 };
 
 /**
@@ -32,7 +30,6 @@ const getRuntimeHttpStatus = (error: TRPCError): number | undefined => {
  */
 export function createResponseMeta({ ctx, errors }: ResponseMetaParams): {
   headers: Headers | undefined;
-  status?: number;
 } {
   const resHeaders =
     ctx && typeof ctx === 'object' && 'resHeaders' in ctx
@@ -47,17 +44,15 @@ export function createResponseMeta({ ctx, errors }: ResponseMetaParams): {
     (error) =>
       error.code === TRPC_ERROR_CODE_UNAUTHORIZED &&
       error.message !== MARKET_AUTH_REQUIRED_MESSAGE &&
-      !getRuntimeHttpStatus(error),
+      !isRuntimeError(error),
   );
   if (hasUnauthorizedError) {
     headers.set(AUTH_REQUIRED_HEADER, 'true');
   }
 
-  const runtimeHttpStatus = errors.map(getRuntimeHttpStatus).find((status) => status !== undefined);
-
   // Only return headers if there's content or auth error
-  if (hasUnauthorizedError || resHeaders || runtimeHttpStatus) {
-    return { headers, status: runtimeHttpStatus };
+  if (hasUnauthorizedError || resHeaders) {
+    return { headers };
   }
 
   return { headers: undefined };

--- a/src/server/routers/lambda/__tests__/aiChat.test.ts
+++ b/src/server/routers/lambda/__tests__/aiChat.test.ts
@@ -999,7 +999,6 @@ describe('aiChatRouter', () => {
         expect(error).toMatchObject({
           cause: runtimeError,
           code: 'UNAUTHORIZED',
-          httpStatus: 401,
           message: AgentRuntimeErrorType.InvalidProviderAPIKey,
         });
       }
@@ -1028,7 +1027,6 @@ describe('aiChatRouter', () => {
         expect(error).toMatchObject({
           cause: runtimeError,
           code: 'TOO_MANY_REQUESTS',
-          httpStatus: 429,
           message: AgentRuntimeErrorType.RateLimitExceeded,
         });
       }

--- a/src/server/routers/lambda/__tests__/aiChat.test.ts
+++ b/src/server/routers/lambda/__tests__/aiChat.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import type { CreateMessageParams } from '@lobechat/types';
-import { ThreadType } from '@lobechat/types';
+import { AgentRuntimeErrorType, ThreadType } from '@lobechat/types';
+import { TRPCError } from '@trpc/server';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AgentModel } from '@/database/models/agent';
@@ -973,6 +974,64 @@ describe('aiChatRouter', () => {
       );
       expect(result.data).toEqual(mockResult);
       expect(result.tracingId).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    it('maps provider auth runtime errors to UNAUTHORIZED instead of leaking as internal errors', async () => {
+      const { initModelRuntimeFromDB } = await import('@/server/modules/ModelRuntime');
+      const runtimeError = {
+        error: undefined,
+        errorType: AgentRuntimeErrorType.InvalidProviderAPIKey,
+      };
+
+      vi.mocked(initModelRuntimeFromDB).mockRejectedValueOnce(runtimeError);
+
+      const caller = aiChatRouter.createCaller({ ...mockCtx, serverDB: {} } as any);
+
+      try {
+        await caller.outputJSON({
+          messages: [{ content: 'test', role: 'user' }],
+          model: 'gpt-4o',
+          provider: 'openai',
+        });
+        throw new Error('Expected outputJSON to throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(TRPCError);
+        expect(error).toMatchObject({
+          cause: runtimeError,
+          code: 'UNAUTHORIZED',
+          httpStatus: 401,
+          message: AgentRuntimeErrorType.InvalidProviderAPIKey,
+        });
+      }
+    });
+
+    it('maps known runtime errors with their configured transport status', async () => {
+      const { initModelRuntimeFromDB } = await import('@/server/modules/ModelRuntime');
+      const runtimeError = {
+        error: { message: 'rate limited' },
+        errorType: AgentRuntimeErrorType.RateLimitExceeded,
+      };
+
+      vi.mocked(initModelRuntimeFromDB).mockRejectedValueOnce(runtimeError);
+
+      const caller = aiChatRouter.createCaller({ ...mockCtx, serverDB: {} } as any);
+
+      try {
+        await caller.outputJSON({
+          messages: [{ content: 'test', role: 'user' }],
+          model: 'gpt-4o',
+          provider: 'openai',
+        });
+        throw new Error('Expected outputJSON to throw');
+      } catch (error) {
+        expect(error).toBeInstanceOf(TRPCError);
+        expect(error).toMatchObject({
+          cause: runtimeError,
+          code: 'TOO_MANY_REQUESTS',
+          httpStatus: 429,
+          message: AgentRuntimeErrorType.RateLimitExceeded,
+        });
+      }
     });
 
     it('should handle tools parameter when provided', async () => {

--- a/src/server/routers/lambda/aiChat.ts
+++ b/src/server/routers/lambda/aiChat.ts
@@ -31,7 +31,8 @@ type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 type TRPCStatusCode = Parameters<typeof getStatusKeyFromCode>[0];
 
 const getRuntimeErrorType = (error: unknown): string | undefined => {
-  if (!error || typeof error !== 'object') return;
+  if (!error) return;
+  if (typeof error !== 'object') return;
 
   const errorType = (error as { errorType?: unknown }).errorType;
   return typeof errorType === 'string' ? errorType : undefined;
@@ -39,7 +40,8 @@ const getRuntimeErrorType = (error: unknown): string | undefined => {
 
 const getTRPCErrorCodeFromStatus = (status: number): TRPCErrorCode => {
   const code = getStatusKeyFromCode(status as TRPCStatusCode) as TRPCErrorCode;
-  if (code !== 'INTERNAL_SERVER_ERROR' || status === 500) return code;
+  if (status === 500) return code;
+  if (code !== 'INTERNAL_SERVER_ERROR') return code;
 
   if (status >= 500) return 'INTERNAL_SERVER_ERROR';
   if (status >= 400) return 'BAD_REQUEST';
@@ -50,7 +52,8 @@ const getTRPCErrorCodeFromStatus = (status: number): TRPCErrorCode => {
 const createRuntimeTRPCError = (error: unknown): TRPCError | undefined => {
   const errorType = getRuntimeErrorType(error);
   const spec = getErrorCodeSpec(errorType);
-  if (!errorType || !spec) return;
+  if (!errorType) return;
+  if (!spec) return;
 
   return new TRPCError({
     cause: error,

--- a/src/server/routers/lambda/aiChat.ts
+++ b/src/server/routers/lambda/aiChat.ts
@@ -28,7 +28,6 @@ const { createPrefixedTimingContext, logTiming, runTimedStage } = createTimingHe
 );
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
-type TRPCErrorWithHttpStatus = TRPCError & { httpStatus?: number };
 type TRPCStatusCode = Parameters<typeof getStatusKeyFromCode>[0];
 
 const getRuntimeErrorType = (error: unknown): string | undefined => {
@@ -42,24 +41,22 @@ const getTRPCErrorCodeFromStatus = (status: number): TRPCErrorCode => {
   const code = getStatusKeyFromCode(status as TRPCStatusCode) as TRPCErrorCode;
   if (code !== 'INTERNAL_SERVER_ERROR' || status === 500) return code;
 
+  if (status >= 500) return 'INTERNAL_SERVER_ERROR';
   if (status >= 400) return 'BAD_REQUEST';
 
   return 'INTERNAL_SERVER_ERROR';
 };
 
-const createRuntimeTRPCError = (error: unknown): TRPCErrorWithHttpStatus | undefined => {
+const createRuntimeTRPCError = (error: unknown): TRPCError | undefined => {
   const errorType = getRuntimeErrorType(error);
   const spec = getErrorCodeSpec(errorType);
   if (!errorType || !spec) return;
 
-  const trpcError = new TRPCError({
+  return new TRPCError({
     cause: error,
     code: getTRPCErrorCodeFromStatus(spec.httpStatus),
     message: errorType,
-  }) as TRPCErrorWithHttpStatus;
-  trpcError.httpStatus = spec.httpStatus;
-
-  return trpcError;
+  });
 };
 
 const aiChatProcedure = authedProcedure.use(serverDatabase).use(async (opts) => {

--- a/src/server/routers/lambda/aiChat.ts
+++ b/src/server/routers/lambda/aiChat.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from 'node:crypto';
 
+import { getErrorCodeSpec } from '@lobechat/model-runtime';
 import type { CreateMessageParams, SendMessageServerResponse } from '@lobechat/types';
 import { AiSendMessageServerSchema, RequestTrigger, StructureOutputSchema } from '@lobechat/types';
 import { createTimingHelpers, createTimingRequestId } from '@lobechat/utils';
+import { TRPCError } from '@trpc/server';
 import debug from 'debug';
 import { z } from 'zod';
 
@@ -23,6 +25,101 @@ const log = debug('lobe-lambda-router:ai-chat');
 const { createPrefixedTimingContext, logTiming, runTimedStage } = createTimingHelpers(
   'lobe-server:chat:lobehub:timing',
 );
+
+type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
+type TRPCErrorWithHttpStatus = TRPCError & { httpStatus?: number };
+
+const getRuntimeErrorType = (error: unknown): string | undefined => {
+  if (!error || typeof error !== 'object') return;
+
+  const errorType = (error as { errorType?: unknown }).errorType;
+  return typeof errorType === 'string' ? errorType : undefined;
+};
+
+const getTRPCErrorCodeFromStatus = (status: number): TRPCErrorCode => {
+  switch (status) {
+    case 400: {
+      return 'BAD_REQUEST';
+    }
+    case 401: {
+      return 'UNAUTHORIZED';
+    }
+    case 402: {
+      return 'PAYMENT_REQUIRED';
+    }
+    case 403: {
+      return 'FORBIDDEN';
+    }
+    case 404: {
+      return 'NOT_FOUND';
+    }
+    case 405: {
+      return 'METHOD_NOT_SUPPORTED';
+    }
+    case 408: {
+      return 'TIMEOUT';
+    }
+    case 409: {
+      return 'CONFLICT';
+    }
+    case 412: {
+      return 'PRECONDITION_FAILED';
+    }
+    case 413: {
+      return 'PAYLOAD_TOO_LARGE';
+    }
+    case 415: {
+      return 'UNSUPPORTED_MEDIA_TYPE';
+    }
+    case 422: {
+      return 'UNPROCESSABLE_CONTENT';
+    }
+    case 428: {
+      return 'PRECONDITION_REQUIRED';
+    }
+    case 429: {
+      return 'TOO_MANY_REQUESTS';
+    }
+    case 499: {
+      return 'CLIENT_CLOSED_REQUEST';
+    }
+    case 500: {
+      return 'INTERNAL_SERVER_ERROR';
+    }
+    case 501: {
+      return 'NOT_IMPLEMENTED';
+    }
+    case 502: {
+      return 'BAD_GATEWAY';
+    }
+    case 503: {
+      return 'SERVICE_UNAVAILABLE';
+    }
+    case 504: {
+      return 'GATEWAY_TIMEOUT';
+    }
+  }
+
+  if (status >= 500) return 'INTERNAL_SERVER_ERROR';
+  if (status >= 400) return 'BAD_REQUEST';
+
+  return 'INTERNAL_SERVER_ERROR';
+};
+
+const createRuntimeTRPCError = (error: unknown): TRPCErrorWithHttpStatus | undefined => {
+  const errorType = getRuntimeErrorType(error);
+  const spec = getErrorCodeSpec(errorType);
+  if (!errorType || !spec) return;
+
+  const trpcError = new TRPCError({
+    cause: error,
+    code: getTRPCErrorCodeFromStatus(spec.httpStatus),
+    message: errorType,
+  }) as TRPCErrorWithHttpStatus;
+  trpcError.httpStatus = spec.httpStatus;
+
+  return trpcError;
+};
 
 const aiChatProcedure = authedProcedure.use(serverDatabase).use(async (opts) => {
   const { ctx } = opts;
@@ -57,19 +154,27 @@ export const aiChatRouter = router({
     // routing) and the tracing registry have a fallback when the caller
     // forgets to set one. `tracing` carries the structured tracing config
     // (scenario / promptVersion / schemaName / inputHint / ...).
-    const data = await ctx.aiGenerationService.generateObject(
-      {
-        messages: input.messages,
-        model: input.model,
-        provider: input.provider,
-        schema: input.schema,
-        tools: input.tools,
-      },
-      {
-        metadata: { trigger: RequestTrigger.Chat, ...input.metadata },
-        tracing: { ...input.tracing, tracingId },
-      },
-    );
+    let data: unknown;
+    try {
+      data = await ctx.aiGenerationService.generateObject(
+        {
+          messages: input.messages,
+          model: input.model,
+          provider: input.provider,
+          schema: input.schema,
+          tools: input.tools,
+        },
+        {
+          metadata: { trigger: RequestTrigger.Chat, ...input.metadata },
+          tracing: { ...input.tracing, tracingId },
+        },
+      );
+    } catch (error) {
+      const runtimeTRPCError = createRuntimeTRPCError(error);
+      if (runtimeTRPCError) throw runtimeTRPCError;
+
+      throw error;
+    }
 
     log('generateObject completed, result: %O', data);
     return { data, tracingId };

--- a/src/server/routers/lambda/aiChat.ts
+++ b/src/server/routers/lambda/aiChat.ts
@@ -5,6 +5,7 @@ import type { CreateMessageParams, SendMessageServerResponse } from '@lobechat/t
 import { AiSendMessageServerSchema, RequestTrigger, StructureOutputSchema } from '@lobechat/types';
 import { createTimingHelpers, createTimingRequestId } from '@lobechat/utils';
 import { TRPCError } from '@trpc/server';
+import { getStatusKeyFromCode } from '@trpc/server/unstable-core-do-not-import';
 import debug from 'debug';
 import { z } from 'zod';
 
@@ -28,6 +29,7 @@ const { createPrefixedTimingContext, logTiming, runTimedStage } = createTimingHe
 
 type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 type TRPCErrorWithHttpStatus = TRPCError & { httpStatus?: number };
+type TRPCStatusCode = Parameters<typeof getStatusKeyFromCode>[0];
 
 const getRuntimeErrorType = (error: unknown): string | undefined => {
   if (!error || typeof error !== 'object') return;
@@ -37,70 +39,9 @@ const getRuntimeErrorType = (error: unknown): string | undefined => {
 };
 
 const getTRPCErrorCodeFromStatus = (status: number): TRPCErrorCode => {
-  switch (status) {
-    case 400: {
-      return 'BAD_REQUEST';
-    }
-    case 401: {
-      return 'UNAUTHORIZED';
-    }
-    case 402: {
-      return 'PAYMENT_REQUIRED';
-    }
-    case 403: {
-      return 'FORBIDDEN';
-    }
-    case 404: {
-      return 'NOT_FOUND';
-    }
-    case 405: {
-      return 'METHOD_NOT_SUPPORTED';
-    }
-    case 408: {
-      return 'TIMEOUT';
-    }
-    case 409: {
-      return 'CONFLICT';
-    }
-    case 412: {
-      return 'PRECONDITION_FAILED';
-    }
-    case 413: {
-      return 'PAYLOAD_TOO_LARGE';
-    }
-    case 415: {
-      return 'UNSUPPORTED_MEDIA_TYPE';
-    }
-    case 422: {
-      return 'UNPROCESSABLE_CONTENT';
-    }
-    case 428: {
-      return 'PRECONDITION_REQUIRED';
-    }
-    case 429: {
-      return 'TOO_MANY_REQUESTS';
-    }
-    case 499: {
-      return 'CLIENT_CLOSED_REQUEST';
-    }
-    case 500: {
-      return 'INTERNAL_SERVER_ERROR';
-    }
-    case 501: {
-      return 'NOT_IMPLEMENTED';
-    }
-    case 502: {
-      return 'BAD_GATEWAY';
-    }
-    case 503: {
-      return 'SERVICE_UNAVAILABLE';
-    }
-    case 504: {
-      return 'GATEWAY_TIMEOUT';
-    }
-  }
+  const code = getStatusKeyFromCode(status as TRPCStatusCode) as TRPCErrorCode;
+  if (code !== 'INTERNAL_SERVER_ERROR' || status === 500) return code;
 
-  if (status >= 500) return 'INTERNAL_SERVER_ERROR';
   if (status >= 400) return 'BAD_REQUEST';
 
   return 'INTERNAL_SERVER_ERROR';

--- a/src/server/routers/lambda/aiChat.ts
+++ b/src/server/routers/lambda/aiChat.ts
@@ -31,8 +31,7 @@ type TRPCErrorCode = ConstructorParameters<typeof TRPCError>[0]['code'];
 type TRPCStatusCode = Parameters<typeof getStatusKeyFromCode>[0];
 
 const getRuntimeErrorType = (error: unknown): string | undefined => {
-  if (!error) return;
-  if (typeof error !== 'object') return;
+  if (!error || typeof error !== 'object') return;
 
   const errorType = (error as { errorType?: unknown }).errorType;
   return typeof errorType === 'string' ? errorType : undefined;
@@ -40,8 +39,7 @@ const getRuntimeErrorType = (error: unknown): string | undefined => {
 
 const getTRPCErrorCodeFromStatus = (status: number): TRPCErrorCode => {
   const code = getStatusKeyFromCode(status as TRPCStatusCode) as TRPCErrorCode;
-  if (status === 500) return code;
-  if (code !== 'INTERNAL_SERVER_ERROR') return code;
+  if (code !== 'INTERNAL_SERVER_ERROR' || status === 500) return code;
 
   if (status >= 500) return 'INTERNAL_SERVER_ERROR';
   if (status >= 400) return 'BAD_REQUEST';
@@ -52,8 +50,7 @@ const getTRPCErrorCodeFromStatus = (status: number): TRPCErrorCode => {
 const createRuntimeTRPCError = (error: unknown): TRPCError | undefined => {
   const errorType = getRuntimeErrorType(error);
   const spec = getErrorCodeSpec(errorType);
-  if (!errorType) return;
-  if (!spec) return;
+  if (!errorType || !spec) return;
 
   return new TRPCError({
     cause: error,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Convert known model-runtime errors thrown by `aiChat.outputJSON` into native `TRPCError` instances so expected provider/config/quota/request failures no longer surface as generic 500 errors.
- Reuse the shared runtime error spec and tRPC's existing status-code mapping instead of maintaining a custom mapping in the router.
- Avoid treating runtime provider auth failures such as `InvalidProviderAPIKey` as LobeHub session-expired errors in `responseMeta`.
- Pass OIDC request bodies through as a readable Node stream instead of attaching a pre-parsed body object.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' src/libs/oidc-provider/http-adapter.test.ts src/libs/trpc/utils/responseMeta.test.ts src/server/routers/lambda/__tests__/aiChat.test.ts
vscode-cli get-diagnostics --workspace /Users/tj/code/lobehub-cloud
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

The HTTP response status is still produced by tRPC from `TRPCError.code`; this PR only normalizes model-runtime errors before they reach tRPC's default `INTERNAL_SERVER_ERROR` wrapper.

The OIDC adapter test now also feeds a `/oidc/token` form body through `oidc-provider`'s own `urlencoded` parser to verify `grant_type`, `code`, `client_id`, `redirect_uri`, and `code_verifier` remain parseable from the Node readable stream.
