### PR TITLE
🐛 fix(agent-signal): attribute self-iteration run trace to reviewed agent & isolate memory runs

### DIFF
--- a/src/server/services/agentSignal/policies/analyzeIntent/actions/__tests__/userMemory.test.ts
+++ b/src/server/services/agentSignal/policies/analyzeIntent/actions/__tests__/userMemory.test.ts
@@ -74,6 +74,42 @@ describe('defineUserMemoryActionHandler', () => {
     expect(context.runtimeState.touchGuardState).toHaveBeenCalledTimes(1);
   });
 
+  it('anchors the memory-agent thread on the user message id when no assistant boundary exists', async () => {
+    // Non-clientRuntimeComplete source: sourceId has no `:completion:` segment,
+    // so assistantMessageId is absent. The run must still anchor a child thread
+    // under the triggering user message instead of leaking into the main topic.
+    memoryActionRunner.mockResolvedValue({ status: 'applied' });
+
+    const handler = defineUserMemoryActionHandler({
+      db: {} as never,
+      memoryActionRunner,
+      userId: 'user_1',
+    });
+
+    await handler.handle(
+      {
+        actionId: 'act_memory_fallback_anchor',
+        actionType: 'action.user-memory.handle',
+        chain: { chainId: 'chain_1', rootSourceId: 'source_1' },
+        payload: {
+          agentId: 'agent_1',
+          idempotencyKey: 'source_1:memory:msg_user_1',
+          message: 'Remember that I prefer concise answers.',
+          messageId: 'msg_user_1',
+          topicId: 'topic_1',
+        },
+        signal: { signalId: 'sig_1', signalType: 'signal.feedback.domain.memory' },
+        source: { sourceId: 'source_1', sourceType: 'agent.user.message' },
+        timestamp: 1,
+      },
+      context,
+    );
+
+    expect(memoryActionRunner).toHaveBeenCalledWith(
+      expect.objectContaining({ sourceMessageId: 'msg_user_1', topicId: 'topic_1' }),
+    );
+  });
+
   it('returns the applied memory target from the memory agent runner', async () => {
     memoryActionRunner.mockResolvedValue({
       detail: 'Arvin Xu 希望助手在输出时每个段落/模块都写得更长、更展开。',

--- a/src/server/services/agentSignal/policies/analyzeIntent/actions/userMemory.ts
+++ b/src/server/services/agentSignal/policies/analyzeIntent/actions/userMemory.ts
@@ -392,14 +392,21 @@ export const handleUserMemoryAction = async (
         typeof action.payload.sourceHints === 'object' && action.payload.sourceHints
           ? action.payload.sourceHints
           : undefined,
-      // The assistant message that completed the turn — used to anchor the
-      // memory-agent child thread under that message instead of the main topic.
-      // Populated by planUserMemory via extractAssistantMessageIdFromSourceId;
-      // absent for non-clientRuntimeComplete sources where no assistant boundary exists.
+      // The message to anchor the memory-agent child thread under, so its
+      // messages stay isolated from the main topic instead of being flattened
+      // into it. Prefer the assistant message that completed the turn (set by
+      // planUserMemory via extractAssistantMessageIdFromSourceId — only present
+      // for clientRuntimeComplete sources whose id is
+      // `${assistantMessageId}:completion:${parentMessageId}`). Other sources
+      // carry no assistant boundary, so fall back to the triggering user
+      // message id; without this fallback no thread is created and the run
+      // leaks into the active conversation.
       sourceMessageId:
         typeof action.payload.assistantMessageId === 'string'
           ? action.payload.assistantMessageId
-          : undefined,
+          : typeof action.payload.messageId === 'string'
+            ? action.payload.messageId
+            : undefined,
       topicId: typeof action.payload.topicId === 'string' ? action.payload.topicId : undefined,
     };
     // Stamp the run so the completion path can project the memory receipt (the

--- a/src/server/services/aiAgent/__tests__/execAgent.threadId.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.threadId.test.ts
@@ -293,4 +293,45 @@ describe('AiAgentService.execAgent - threadId handling', () => {
       // This is handled by the createOperation call
     }, 10_000);
   });
+
+  describe('Agent Signal marker attribution', () => {
+    it('persists trace messages under the reviewed user agent carried on the marker', async () => {
+      // Background self-iteration runs execute under a builtin slug, so the
+      // resolved agent ('agent-1') is the builtin agent — but their persisted
+      // messages must attribute to the reviewed user agent on `marker.agentId`,
+      // matching the operation row + receipts (not the builtin slug).
+      await service.execAgent({
+        agentId: 'agent-1',
+        appContext: {
+          agentSignal: { agentId: 'user-agent-9', kind: 'skill', sourceId: 'src-1' },
+          topicId: 'topic-1',
+        },
+        prompt: 'Skill feedback evidence',
+      });
+
+      const userMessageCall = mockMessageCreate.mock.calls.find((call) => call[0].role === 'user');
+      const assistantMessageCall = mockMessageCreate.mock.calls.find(
+        (call) => call[0].role === 'assistant',
+      );
+
+      expect(userMessageCall![0].agentId).toBe('user-agent-9');
+      expect(assistantMessageCall![0].agentId).toBe('user-agent-9');
+    }, 10_000);
+
+    it('falls back to the executing agent id for ordinary runs without a marker', async () => {
+      await service.execAgent({
+        agentId: 'agent-1',
+        appContext: { topicId: 'topic-1' },
+        prompt: 'Test prompt',
+      });
+
+      const userMessageCall = mockMessageCreate.mock.calls.find((call) => call[0].role === 'user');
+      const assistantMessageCall = mockMessageCreate.mock.calls.find(
+        (call) => call[0].role === 'assistant',
+      );
+
+      expect(userMessageCall![0].agentId).toBe('agent-1');
+      expect(assistantMessageCall![0].agentId).toBe('agent-1');
+    }, 10_000);
+  });
 });

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -403,6 +403,15 @@ export class AiAgentService {
     // Use actual agent ID from config for subsequent operations
     const resolvedAgentId = agentConfig.id;
 
+    // Persistence-attribution agent id. Background Agent Signal runs (memory /
+    // skill / self-reflection) execute under a builtin slug, so `resolvedAgentId`
+    // is the builtin agent — but the run's persisted messages, like its operation
+    // row (createOperation appContext.agentId) and receipts, must attribute to the
+    // reviewed *user* agent carried on `marker.agentId`. Ordinary runs (no marker)
+    // fall back to the executing agent. Tools / systemRole / skills / agent
+    // documents stay keyed on `resolvedAgentId`.
+    const persistAgentId = appContext?.agentSignal?.agentId ?? resolvedAgentId;
+
     // Apply per-call model/provider overrides (e.g. from task.config)
     if (modelOverride) agentConfig.model = modelOverride;
     if (providerOverride) agentConfig.provider = providerOverride;
@@ -1852,7 +1861,7 @@ export class AiAgentService {
     const userMessageRecord = effectiveResume
       ? undefined
       : await this.messageModel.create({
-          agentId: resolvedAgentId,
+          agentId: persistAgentId,
           content: prompt,
           files: fileIds,
           metadata: requestTriggerMetadata,
@@ -1898,7 +1907,7 @@ export class AiAgentService {
     // 14. Create assistant message placeholder in database
     // Include threadId if provided (for SubAgent task execution in isolated Thread)
     const assistantMessageRecord = await this.messageModel.create({
-      agentId: resolvedAgentId,
+      agentId: persistAgentId,
       content: LOADING_FLAT,
       model,
       parentId: parentMessageId ?? userMessageRecord?.id,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No matching GitHub/Linear issue found. -->

#### 🔀 Description of Change

Background Agent Signal runs (memory / skill / self-reflection) execute under a **builtin agent slug**, with the reviewed **user agent** carried on `marker.agentId`. The design attributes the whole run back to the user agent — but two gaps caused the trace to surface in the wrong place.

**1. The run's message rows were attributed to the builtin agent.**
`execAgent` persisted the user + assistant message rows under `resolvedAgentId` (the builtin slug's agent), while the operation row (`createOperation` `appContext.agentId`), the isolated thread, and the receipts all attribute to `marker.agentId`. So the execution trace "hung" under the builtin reflection/skill agent instead of the current user agent. Now the message rows use `appContext.agentSignal.agentId ?? resolvedAgentId` — matching the operation row. Config/tools/systemRole/skills/agent-documents stay keyed on `resolvedAgentId`. As a side benefit, this realigns the history re-read in `AgentRuntimeService` (`queryMessages({ agentId: metadata.agentId })`) with how the messages are stored.

**2. The memory run leaked into the active conversation.**
The memory action only created its isolated thread when an `assistantMessageId` could be extracted from a hydrated `clientRuntimeComplete` source id (`${assistantMessageId}:completion:${parentMessageId}`). Any other source left it `undefined`, so `if (topicId && sourceMessageId)` was false, no thread was created, and the memory-agent messages flattened into the main topic. Now it falls back to the triggering user `messageId` (which `planUserMemory` already propagates but was unused), so a child thread is always created — anchored on the assistant message when available, otherwise the user message.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `execAgent.threadId.test.ts` — new `Agent Signal marker attribution` describe: a marker-carrying run persists its messages under `marker.agentId`; an ordinary run (no marker) falls back to the executing agent id.
- `userMemory.test.ts` — new case: a non-`clientRuntimeComplete` source (no assistant boundary) anchors the memory-agent thread on the triggering user `messageId` instead of leaking into the topic.
- Full agent-signal self-iteration suite + execAgent memory/threadId suites pass (214 tests). `type-check` clean for the touched files (pre-existing antd-version noise unrelated).

#### 📝 Additional Information

Server-only change, single layer — no schema or client contract changes.