### PR TITLE
♻️ refactor(editor-canvas): import extractMediaFromEditorState from headless entry

### DIFF
--- a/src/features/EditorCanvas/editorAttachments.ts
+++ b/src/features/EditorCanvas/editorAttachments.ts
@@ -1,9 +1,6 @@
 import type { IEditor } from '@lobehub/editor';
-import {
-  extractMediaFromEditorState,
-  INSERT_FILE_COMMAND,
-  INSERT_IMAGE_COMMAND,
-} from '@lobehub/editor';
+import { INSERT_FILE_COMMAND, INSERT_IMAGE_COMMAND } from '@lobehub/editor';
+import { extractMediaFromEditorState } from '@lobehub/editor/headless';
 import type { SerializedEditorState } from 'lexical';
 
 import { getFileIdForUrl } from './attachmentRegistry';


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Splits `@lobehub/editor` imports in `editorAttachments.ts` so the pure `extractMediaFromEditorState` helper is loaded from the `/headless` subpath, while UI-bound commands (`INSERT_FILE_COMMAND`, `INSERT_IMAGE_COMMAND`) keep coming from the root entry.

This mirrors the headless/UI split already used elsewhere in the codebase (e.g. `src/server/services/agentDocuments/headlessEditor.ts`) and avoids dragging editor UI code into modules that only need the pure extractor.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Pure import-path refactor — behavior unchanged. Verified type-check on touched file.

#### 📸 Screenshots / Videos

N/A — no UI change.

#### 📝 Additional Information

No breaking changes, no migration needed.