### PR TITLE
🐛 fix: timeout Market connection listing

### DIFF
--- a/src/server/routers/tools/_helpers/marketConnections.test.ts
+++ b/src/server/routers/tools/_helpers/marketConnections.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  isMarketConnectionsTimeoutError,
+  listMarketConnectionsWithTimeout,
+  MARKET_CONNECTIONS_REQUEST_TIMEOUT_MS,
+} from './marketConnections';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('marketConnections helpers', () => {
+  it('passes an abort signal to the Market SDK listConnections request', async () => {
+    const controller = new AbortController();
+    const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal);
+    const listConnections = vi.fn().mockResolvedValue({ connections: [] });
+
+    await expect(listMarketConnectionsWithTimeout({ listConnections })).resolves.toEqual({
+      connections: [],
+    });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(MARKET_CONNECTIONS_REQUEST_TIMEOUT_MS);
+    expect(listConnections).toHaveBeenCalledWith({ signal: controller.signal });
+  });
+
+  it('detects AbortSignal timeout errors', () => {
+    expect(isMarketConnectionsTimeoutError(new DOMException('Timed out', 'TimeoutError'))).toBe(
+      true,
+    );
+    expect(isMarketConnectionsTimeoutError(new DOMException('Aborted', 'AbortError'))).toBe(true);
+    expect(isMarketConnectionsTimeoutError(new Error('market failed'))).toBe(false);
+  });
+});

--- a/src/server/routers/tools/_helpers/marketConnections.ts
+++ b/src/server/routers/tools/_helpers/marketConnections.ts
@@ -1,0 +1,17 @@
+import type { ListConnectionsResponse, MarketSDK } from '@lobehub/market-sdk';
+
+export const MARKET_CONNECTIONS_REQUEST_TIMEOUT_MS = 10_000;
+
+type MarketConnectClient = Pick<MarketSDK['connect'], 'listConnections'>;
+
+export const isMarketConnectionsTimeoutError = (error: unknown): boolean =>
+  error instanceof Error && (error.name === 'TimeoutError' || error.name === 'AbortError');
+
+export const listMarketConnectionsWithTimeout = async (
+  marketConnect: MarketConnectClient,
+  timeoutMs = MARKET_CONNECTIONS_REQUEST_TIMEOUT_MS,
+): Promise<ListConnectionsResponse> => {
+  return marketConnect.listConnections({
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+};

--- a/src/server/routers/tools/market.ts
+++ b/src/server/routers/tools/market.ts
@@ -22,6 +22,11 @@ import {
 } from '@/server/services/mcp/contentProcessor';
 
 import { scheduleToolCallReport } from './_helpers';
+import {
+  isMarketConnectionsTimeoutError,
+  listMarketConnectionsWithTimeout,
+  MARKET_CONNECTIONS_REQUEST_TIMEOUT_MS,
+} from './_helpers/marketConnections';
 
 const log = debug('lobe-server:tools:market');
 
@@ -530,7 +535,7 @@ export const marketRouter = router({
     log('connectListConnections');
 
     try {
-      const response = await ctx.marketSDK.connect.listConnections();
+      const response = await listMarketConnectionsWithTimeout(ctx.marketSDK.connect);
       // Debug logging
       log('connectListConnections raw response: %O', response);
       log('connectListConnections connections: %O', response.connections);
@@ -539,7 +544,16 @@ export const marketRouter = router({
       };
     } catch (error) {
       log('connectListConnections error: %O', error);
+      if (isMarketConnectionsTimeoutError(error)) {
+        throw new TRPCError({
+          cause: error,
+          code: 'TIMEOUT',
+          message: `Market connections request timed out after ${MARKET_CONNECTIONS_REQUEST_TIMEOUT_MS / 1000}s`,
+        });
+      }
+
       throw new TRPCError({
+        cause: error,
         code: 'INTERNAL_SERVER_ERROR',
         message: `Failed to list connections: ${(error as Error).message}`,
       });

--- a/src/store/tool/slices/lobehubSkillStore/action.ts
+++ b/src/store/tool/slices/lobehubSkillStore/action.ts
@@ -316,6 +316,7 @@ export class LobehubSkillStoreActionImpl {
           }
         },
         revalidateOnFocus: false,
+        shouldRetryOnError: false,
       },
     );
   };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-10029

#### 🔀 Description of Change

- Add a 10s AbortSignal timeout to the Market connection listing request.
- Map Market connection timeout failures to tRPC TIMEOUT instead of letting the request wait for the platform limit.
- Disable SWR error retries for the LobeHub Skill connections fetcher.
- Add focused regression coverage for the timeout helper.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' src/server/routers/tools/_helpers/marketConnections.test.ts src/store/tool/slices/lobehubSkillStore/action.test.ts
bunx prettier --check src/server/routers/tools/_helpers/marketConnections.ts src/server/routers/tools/_helpers/marketConnections.test.ts src/server/routers/tools/market.ts src/store/tool/slices/lobehubSkillStore/action.ts
git diff --check
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This is a defensive client-side timeout for the generic Market tools integration. It does not include cloud-specific business logic.
