### PR TITLE
🐛 fix: type errors in oidc http-adapter test breaking CI lint

### DIFF
--- a/src/libs/oidc-provider/http-adapter.test.ts
+++ b/src/libs/oidc-provider/http-adapter.test.ts
@@ -4,6 +4,7 @@
 import type { Readable } from 'node:stream';
 
 import type { NextRequest } from 'next/server';
+import type { SelectiveBodyContext } from 'oidc-provider/lib/shared/selective_body.js';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('debug', () => ({
@@ -75,11 +76,9 @@ describe('OIDC HTTP adapter', () => {
       }) as unknown as NextRequest;
 
       const { createNodeRequest } = await import('./http-adapter');
-      const { urlencoded } = (await import('oidc-provider/lib/shared/selective_body.js')) as {
-        urlencoded: (ctx: any, next: () => Promise<void>) => Promise<void>;
-      };
+      const { urlencoded } = await import('oidc-provider/lib/shared/selective_body.js');
       const nodeRequest = await createNodeRequest(request);
-      const ctx = {
+      const ctx: SelectiveBodyContext = {
         charset: 'utf-8',
         is: (contentType: string) => contentType === 'application/x-www-form-urlencoded',
         oidc: {},

--- a/src/libs/oidc-provider/selective-body.d.ts
+++ b/src/libs/oidc-provider/selective-body.d.ts
@@ -1,0 +1,36 @@
+/**
+ * Minimal declaration for the untyped `oidc-provider` internal module used in
+ * `http-adapter.test.ts` — `@types/oidc-provider` does not cover deep imports.
+ *
+ * Source: https://github.com/panva/node-oidc-provider/blob/main/lib/shared/selective_body.js
+ */
+declare module 'oidc-provider/lib/shared/selective_body.js' {
+  import type { IncomingMessage } from 'node:http';
+
+  export interface SelectiveBodyContext {
+    charset?: string;
+    get?: (header: string) => string;
+    is: (contentType: string) => string | boolean | null;
+    method?: string;
+    oidc: { body?: unknown };
+    path?: string;
+    req: IncomingMessage;
+    request: { body?: unknown; length?: number };
+  }
+
+  export type SelectiveBodyMiddleware = (
+    ctx: SelectiveBodyContext,
+    next: () => Promise<void>,
+  ) => Promise<void>;
+
+  export const json: SelectiveBodyMiddleware;
+  export const urlencoded: SelectiveBodyMiddleware;
+
+  const selectiveBody: (
+    cty: string,
+    ctx: SelectiveBodyContext,
+    next: () => Promise<void>,
+  ) => Promise<void>;
+
+  export default selectiveBody;
+}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Introduced by #15478 (merged with a red `Test Database` check).

#### 🔀 Description of Change

`src/libs/oidc-provider/http-adapter.test.ts` (added in #15478) fails type-check with two errors, which breaks the `Lint` step of the **Test Database** job for **every PR** since the merge (PR CI runs against the merge result with `canary`):

```
http-adapter.test.ts(78,44): error TS7016: Could not find a declaration file for
  module 'oidc-provider/lib/shared/selective_body.js'
http-adapter.test.ts(92,23): error TS2339: Property 'body' does not exist on type '{}'
```

Note: `canary` itself still looks green because push runs skip test jobs via the duplicate-run check.

Fix:

- Add `src/libs/oidc-provider/selective-body.d.ts` declaring the untyped `oidc-provider` deep import (`@types/oidc-provider` doesn't cover internal `lib/` paths), modeled on the actual middleware contract in [`selective_body.js`](https://github.com/panva/node-oidc-provider/blob/main/lib/shared/selective_body.js).
- Type the mock `ctx` with the exported `SelectiveBodyContext` and drop the now-redundant inline `as` cast (which didn't suppress TS7016 anyway).

No runtime behavior change — type-only fix.

#### 🧪 How to Test

- `bunx tsgo --noEmit` → exit 0 (2 errors before this fix)
- `bunx vitest run src/libs/oidc-provider/http-adapter.test.ts` → 3 passed
- `bunx eslint` on both files → 0 errors

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

The remaining red on recent PRs' **Test Web App** is a separate issue: the E2E scenario `agent-scroll.feature:19` (用户消息应固定在聊天列表顶部, expected ≤150px got 643px) fails in ~75% of runs since 2026-06-04 — needs its own investigation (possible real regression in the pin-to-top behavior).