### PR TITLE
🐛 fix(conversation): hide Usage extra for local hetero agents until model arrives

### DIFF
--- a/src/features/Conversation/Messages/Assistant/Extra/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/Extra/index.tsx
@@ -1,5 +1,5 @@
 import { LOADING_FLAT } from '@lobechat/const';
-import { HETEROGENEOUS_TYPE_LABELS } from '@lobechat/heterogeneous-agents';
+import { isRemoteHeterogeneousType } from '@lobechat/heterogeneous-agents';
 import { type ModelPerformance, type ModelUsage } from '@lobechat/types';
 import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
@@ -31,10 +31,16 @@ export const AssistantMessageExtra = memo<AssistantMessageExtraProps>(
     const isLogin = useUserStore(authSelectors.isLogin);
     const isDevMode = useUserStore((s) => userGeneralSettingsSelectors.config(s).isDevMode);
 
+    // Local CLI hetero agents (claude-code, codex) only report `model` after
+    // turn_metadata lands mid-stream, so gating on `!!model` alone would skip
+    // showing Usage at all. Remote hetero (openclaw, hermes) never expose a
+    // real model id and rely on the brand label fallback in Usage — only those
+    // should bypass the model check, otherwise local agents render a lone
+    // empty-model ModelIcon while streaming.
     const showUsage =
       isDevMode &&
       content !== LOADING_FLAT &&
-      (!!model || !!(provider && HETEROGENEOUS_TYPE_LABELS[provider]));
+      (!!model || (!!provider && isRemoteHeterogeneousType(provider)));
     const showTts = isLogin && !!extra?.tts;
     const showTranslate = isLogin && !!extra?.translate;
 


### PR DESCRIPTION
## Summary

- Empty `<ModelIcon model='' />` placeholder shows up under streaming Claude Code / Codex assistant messages in dev mode — the brand icon with no text beside it.
- Root cause: `AssistantMessageExtra` gates `showUsage` on `HETEROGENEOUS_TYPE_LABELS[provider]` (matches **local + remote** hetero), but the `Usage` component only treats **remote** hetero (`openclaw`, `hermes`) as `heteroName`-eligible via `isRemoteHeterogeneousType`. So `provider='claude-code'` + `model=''` passes the gate, falls into the `ModelIcon` branch, and renders the lone empty placeholder.
- Fix: align the gate with `Usage`'s branching — only bypass the `!!model` check for **remote** hetero, since local CLI agents always populate `model` from `turn_metadata` mid-stream and the `AssistantGroup` variant already uses `isDevMode && model && ...`.

## Test plan

- [ ] In dev mode, send a message to a local Claude Code / Codex agent and confirm no stray empty-model icon appears under the assistant message during streaming.
- [ ] Verify the Usage extra still appears once `turn_metadata` lands (model name + token count visible).
- [ ] Verify remote hetero (openclaw / hermes) still shows the brand label immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)