### PR TITLE
🐛 fix(agent-signal): nest memory isolation thread under originating threadId

### DIFF
--- a/apps/server/src/services/agentSignal/policies/analyzeIntent/actions/__tests__/userMemory.test.ts
+++ b/apps/server/src/services/agentSignal/policies/analyzeIntent/actions/__tests__/userMemory.test.ts
@@ -110,6 +110,49 @@ describe('defineUserMemoryActionHandler', () => {
     );
   });
 
+  it('forwards the originating threadId to the runner so the isolation thread can nest', async () => {
+    // When the source carries an active threadId (originating conversation was
+    // already inside a thread), the action payload must propagate it so the
+    // memory-agent isolation thread nests under it via parentThreadId instead
+    // of being created at topic root and detached from the active thread.
+    memoryActionRunner.mockResolvedValue({ status: 'applied' });
+
+    const handler = defineUserMemoryActionHandler({
+      db: {} as never,
+      memoryActionRunner,
+      userId: 'user_1',
+    });
+
+    await handler.handle(
+      {
+        actionId: 'act_memory_thread_nest',
+        actionType: 'action.user-memory.handle',
+        chain: { chainId: 'chain_1', rootSourceId: 'source_1' },
+        payload: {
+          agentId: 'agent_1',
+          assistantMessageId: 'msg_assistant_1',
+          idempotencyKey: 'source_1:memory:msg_user_1',
+          message: 'Remember that I prefer concise answers.',
+          messageId: 'msg_user_1',
+          threadId: 'thread_42',
+          topicId: 'topic_1',
+        },
+        signal: { signalId: 'sig_1', signalType: 'signal.feedback.domain.memory' },
+        source: { sourceId: 'source_1', sourceType: 'agent.user.message' },
+        timestamp: 1,
+      },
+      context,
+    );
+
+    expect(memoryActionRunner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceMessageId: 'msg_assistant_1',
+        threadId: 'thread_42',
+        topicId: 'topic_1',
+      }),
+    );
+  });
+
   it('returns the applied memory target from the memory agent runner', async () => {
     memoryActionRunner.mockResolvedValue({
       detail: 'Arvin Xu 希望助手在输出时每个段落/模块都写得更长、更展开。',

--- a/apps/server/src/services/agentSignal/policies/analyzeIntent/actions/userMemory.ts
+++ b/apps/server/src/services/agentSignal/policies/analyzeIntent/actions/userMemory.ts
@@ -71,6 +71,7 @@ export interface UserMemoryActionHandlerOptions {
     serializedContext?: string;
     sourceHints?: AgentSignalFeedbackSourceHints;
     sourceMessageId?: string;
+    threadId?: string;
     topicId?: string;
   }) => Promise<MemoryAgentActionResult>;
   pluginModel?: Pick<PluginModel, 'query'>;
@@ -155,6 +156,13 @@ export const runMemoryActionAgent = async (
      * from the main topic conversation.
      */
     sourceMessageId?: string;
+    /**
+     * Active thread id of the originating conversation. When set, the
+     * memory-agent isolation thread is created with `parentThreadId` so the
+     * sub-thread is properly nested under the active thread instead of being
+     * detached at topic root.
+     */
+    threadId?: string;
     topicId?: string;
   },
   options: UserMemoryActionHandlerOptions,
@@ -239,7 +247,10 @@ export const runMemoryActionAgent = async (
 
   // Create a child thread under the triggering assistant message so that
   // memory-agent messages are isolated from the main topic conversation
-  // instead of being flattened into it.
+  // instead of being flattened into it. When the originating conversation
+  // was itself running inside a thread, nest the isolation thread under it
+  // via `parentThreadId` so sub-thread work stays scoped to that thread
+  // instead of landing as a sibling at topic root.
   let threadId: string | undefined;
   if (input.topicId && input.sourceMessageId) {
     try {
@@ -247,6 +258,7 @@ export const runMemoryActionAgent = async (
       const thread = await threadModel.create({
         agentId: input.agentId,
         metadata: { operationId },
+        ...(input.threadId ? { parentThreadId: input.threadId } : {}),
         sourceMessageId: input.sourceMessageId,
         title: 'Agent Signal Memory',
         topicId: input.topicId,
@@ -413,6 +425,10 @@ export const handleUserMemoryAction = async (
           : typeof action.payload.messageId === 'string'
             ? action.payload.messageId
             : undefined,
+      // Propagated from the hydrated source payload via planUserMemory so the
+      // isolation thread can nest under the active thread instead of landing
+      // detached at topic root.
+      threadId: typeof action.payload.threadId === 'string' ? action.payload.threadId : undefined,
       topicId: typeof action.payload.topicId === 'string' ? action.payload.topicId : undefined,
     };
     // Stamp the run so the completion path can project the memory receipt (the

--- a/apps/server/src/services/agentSignal/policies/types.ts
+++ b/apps/server/src/services/agentSignal/policies/types.ts
@@ -330,6 +330,12 @@ export interface AgentSignalPolicyActionPayloadMap {
   };
   [AGENT_SIGNAL_POLICY_ACTION_TYPES.userMemoryHandle]: {
     agentId?: string;
+    /**
+     * Assistant message id that completed the triggering turn, when the source
+     * carries an assistant boundary (e.g. hydrated `clientRuntimeComplete`).
+     * Used as the anchor `sourceMessageId` for the memory-agent isolation thread.
+     */
+    assistantMessageId?: string;
     conflictPolicy?: AgentSignalFeedbackDomainConflictPolicy;
     evidence?: AgentSignalFeedbackEvidence[];
     feedbackHint?: Exclude<AgentSignalFeedbackSatisfactionResult, 'neutral'>;
@@ -339,6 +345,13 @@ export interface AgentSignalPolicyActionPayloadMap {
     reason?: string;
     serializedContext?: string;
     sourceHints?: AgentSignalFeedbackSourceHints;
+    /**
+     * Active thread id of the originating conversation. When set, the
+     * memory-agent isolation thread nests under it via `parentThreadId` so
+     * sub-thread work stays scoped to the originating thread instead of
+     * landing at topic root.
+     */
+    threadId?: string;
     topicId?: string;
   };
 }

--- a/apps/server/src/services/agentSignal/processors/__tests__/actions.test.ts
+++ b/apps/server/src/services/agentSignal/processors/__tests__/actions.test.ts
@@ -24,6 +24,7 @@ const createMemorySignal = (
     signalId: string;
     sourceSerializedContext: unknown;
     sourceId: string;
+    sourceThreadId: string;
   }> = {},
 ) => {
   const base = {
@@ -33,10 +34,12 @@ const createMemorySignal = (
       rootSourceId: input.sourceId ?? 'source_1',
     },
     source: {
-      payload:
-        'sourceSerializedContext' in input
+      payload: {
+        ...('sourceSerializedContext' in input
           ? { serializedContext: input.sourceSerializedContext }
-          : { serializedContext: sourceSerializedContext },
+          : { serializedContext: sourceSerializedContext }),
+        ...(input.sourceThreadId ? { threadId: input.sourceThreadId } : {}),
+      },
       sourceId: input.sourceId ?? 'source_1',
       sourceType: 'agent.user.message',
     },
@@ -257,6 +260,33 @@ describe('action planning processors', () => {
     const action = planUserMemory(signal);
 
     expect(action.payload.serializedContext).toBeUndefined();
+  });
+
+  /**
+   * @example
+   * planUserMemory(memorySignal) propagates the source's active threadId so the
+   * downstream memory-agent isolation thread can nest under it via
+   * parentThreadId instead of landing at topic root.
+   */
+  it('propagates threadId from the hydrated source payload', () => {
+    const signal = createMemorySignal({ sourceThreadId: 'thread_42' });
+
+    const action = planUserMemory(signal);
+
+    expect(action.payload.threadId).toBe('thread_42');
+  });
+
+  /**
+   * @example
+   * planUserMemory(memorySignal) omits threadId when the source carries none —
+   * the originating conversation lives at topic root.
+   */
+  it('omits threadId when the source payload has no threadId', () => {
+    const signal = createMemorySignal();
+
+    const action = planUserMemory(signal);
+
+    expect(action.payload.threadId).toBeUndefined();
   });
 
   /**

--- a/apps/server/src/services/agentSignal/processors/actions.ts
+++ b/apps/server/src/services/agentSignal/processors/actions.ts
@@ -8,6 +8,7 @@ import { AGENT_SIGNAL_POLICY_ACTION_TYPES } from '../policies/types';
 
 interface SerializedContextPayload {
   serializedContext?: unknown;
+  threadId?: unknown;
 }
 
 interface SourcePayloadCarrier {
@@ -55,6 +56,19 @@ const getSerializedContext = (signal: SignalFeedbackDomainMemory | SignalFeedbac
 };
 
 /**
+ * Reads `threadId` from the hydrated source payload.
+ *
+ * Only some source types carry an active thread context (e.g. the hydrated
+ * `agentUserMessage` source written by `clientRuntimeComplete` hydration).
+ * Returns undefined for sources without a thread payload — the caller treats
+ * absence as "originating conversation lives at the topic root".
+ */
+const getThreadIdFromSource = (signal: SignalFeedbackDomainMemory | SignalFeedbackDomainSkill) => {
+  const source = signal.source as SignalFeedbackDomainMemory['source'] & SourcePayloadCarrier;
+  return typeof source.payload?.threadId === 'string' ? source.payload.threadId : undefined;
+};
+
+/**
  * Plans a user-memory action from one memory feedback-domain signal.
  *
  * Use when:
@@ -96,6 +110,11 @@ export const planUserMemory = (signal: SignalFeedbackDomainMemory): ActionUserMe
       reason: payload.reason,
       serializedContext: getSerializedContext(signal),
       sourceHints: payload.sourceHints,
+      // Carry the originating thread id (when the source was hydrated from an
+      // in-thread conversation) so the downstream memory-agent isolation
+      // thread can nest via `parentThreadId` instead of being created at
+      // topic root and silently detached from the active thread.
+      threadId: getThreadIdFromSource(signal),
       topicId: payload.topicId,
     },
     signal: {


### PR DESCRIPTION
## Summary

`clientRuntimeComplete` hydration captures the originating conversation's `threadId` onto `source.payload.threadId`, but `planUserMemory` dropped it when materializing the user-memory action. `handleUserMemoryAction`'s runner input and `runMemoryActionAgent`'s thread-creation block had no `threadId` either, so the memory-agent isolation thread was always built at topic root — silently detached from the active thread when the originating conversation was itself inside a thread.

The complementary leak (no thread created at all when `assistantMessageId` was absent) was fixed in #15479. This PR closes the second half: when a thread *can* be created, it's now properly nested under the active thread.

### Changes

- Add `assistantMessageId` and `threadId` to the `userMemoryHandle` action payload type so the schema reflects what the code already writes/reads.
- Read `signal.source.payload.threadId` in `planUserMemory` via the same `SourcePayloadCarrier` pattern that already reads `serializedContext`.
- Forward `threadId` through `handleUserMemoryAction`'s runner input and `runMemoryActionAgent`'s input signature.
- When `input.threadId` is set, create the isolation thread with `parentThreadId: input.threadId` so the sub-thread nests under the active thread instead of becoming a topic-root sibling.

## Test plan

- [x] `bun run type-check` clean
- [x] `bunx vitest run src/server/services/agentSignal/processors/__tests__/actions.test.ts` — new test asserts `planUserMemory` propagates `threadId` from the hydrated source payload, plus an omission test
- [x] `bunx vitest run src/server/services/agentSignal/policies/analyzeIntent/actions/__tests__/userMemory.test.ts` — new test asserts the handler forwards `threadId` to the runner alongside `sourceMessageId` and `topicId`
- [ ] Manual: trigger a memory action from inside a thread (e.g. start a sub-thread, send a turn that produces memory feedback) and verify the resulting `Agent Signal Memory` thread row carries `parent_thread_id` pointing at the active thread instead of being detached at topic root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)