### PR TITLE
🐛 fix(database): scope ai-infra upsert conflict targets to workspace (precursor for 0110)

### DIFF
--- a/packages/database/src/models/aiModel.ts
+++ b/packages/database/src/models/aiModel.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, isNull, sql } from 'drizzle-orm';
 import type {
   AiModelSortMap,
   AiProviderModelListItem,
@@ -131,6 +131,7 @@ export class AiModelModel {
       .onConflictDoUpdate({
         set: value,
         target: [aiModels.id, aiModels.providerId, aiModels.userId],
+        targetWhere: isNull(aiModels.workspaceId),
       });
   };
 
@@ -157,6 +158,7 @@ export class AiModelModel {
       .onConflictDoUpdate({
         set: updateValues,
         target: [aiModels.id, aiModels.providerId, aiModels.userId],
+        targetWhere: isNull(aiModels.workspaceId),
       });
   };
 
@@ -179,6 +181,7 @@ export class AiModelModel {
       .values(records)
       .onConflictDoNothing({
         target: [aiModels.id, aiModels.userId, aiModels.providerId],
+        where: isNull(aiModels.workspaceId),
       })
       .returning();
   };
@@ -227,6 +230,7 @@ export class AiModelModel {
           updatedAt: sql`excluded.updated_at`,
         },
         target: [aiModels.id, aiModels.userId, aiModels.providerId],
+        targetWhere: isNull(aiModels.workspaceId),
       });
   };
 
@@ -282,6 +286,7 @@ export class AiModelModel {
           .onConflictDoUpdate({
             set: updateValues,
             target: [aiModels.id, aiModels.userId, aiModels.providerId],
+            targetWhere: isNull(aiModels.workspaceId),
           });
       });
 

--- a/packages/database/src/models/aiProvider.ts
+++ b/packages/database/src/models/aiProvider.ts
@@ -5,7 +5,7 @@ import type {
   CreateAiProviderParams,
   UpdateAiProviderConfigParams,
 } from '@lobechat/types';
-import { and, asc, desc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq, isNull } from 'drizzle-orm';
 import { isEmpty } from 'es-toolkit/compat';
 import { ModelProvider } from 'model-bank';
 import { DEFAULT_MODEL_PROVIDER_LIST } from 'model-bank/modelProviders';
@@ -152,6 +152,7 @@ export class AiProviderModel {
       .onConflictDoUpdate({
         set: commonFields,
         target: [aiProviders.id, aiProviders.userId],
+        targetWhere: isNull(aiProviders.workspaceId),
       });
   };
 
@@ -168,6 +169,7 @@ export class AiProviderModel {
       .onConflictDoUpdate({
         set: { enabled },
         target: [aiProviders.id, aiProviders.userId],
+        targetWhere: isNull(aiProviders.workspaceId),
       });
   };
 
@@ -187,6 +189,7 @@ export class AiProviderModel {
           .onConflictDoUpdate({
             set: { sort, updatedAt: new Date() },
             target: [aiProviders.id, aiProviders.userId],
+            targetWhere: isNull(aiProviders.workspaceId),
           });
       });
 


### PR DESCRIPTION
## Why

Code-first precursor for the **Phase 5 / 0110** ai_infra migration ([LOBE-10056](https://linear.app/lobehub/issue/LOBE-10056)), which replaces the composite PKs on `ai_models` / `ai_providers` with a surrogate `_id` PK + **workspace-scoped partial unique indexes** (`WHERE workspace_id IS NULL` / `IS NOT NULL`).

After that migration, a bare `ON CONFLICT (id, user_id)` can no longer infer the (now partial) unique index and fails with `no unique or exclusion constraint matching the ON CONFLICT specification`.

This PR adds the matching index predicate to every personal-scope upsert in `aiProvider.ts` / `aiModel.ts`:
- `onConflictDoUpdate` → `targetWhere: isNull(workspaceId)`
- `onConflictDoNothing` → `where: isNull(workspaceId)`

## Why ship this FIRST (separate from the migration)

The predicate is **forward-compatible with both schemas**: with an index predicate supplied, Postgres can still infer the *current* full `(id, user_id)` unique index (`Any indexes that satisfy the predicate ... can be inferred`), and it will infer the future partial index too.

So the safe ordering is **code-first**: this must be live in production **before** the `0110` schema change runs. The migration itself stays in #15488 and is executed via the manual safe script in LOBE-10056 (online, CONCURRENTLY) — never migration-first.

## Scope

- Only `packages/database/src/models/aiProvider.ts` + `aiModel.ts` (+`isNull` import). **No migration / schema changes.**
- Behaviour is unchanged on today's schema; this purely makes the upserts robust to the upcoming partial indexes.

Related: LOBE-10056 · migration PR #15488

🤖 Generated with [Claude Code](https://claude.com/claude-code)