### PR TITLE
🐛 fix(skill): stop OAuth connectors duplicating into the Skills tab

### DIFF
--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -413,8 +413,9 @@ const SkillList = memo<SkillListProps>(
     // Skills tab: prompt/agent-based skills (show description/content)
     const hasBuiltinTools = builtinToolItems.length > 0 && isConnectorView;
     const hasBuiltinSkills = builtinSkillItems.length > 0 && !isConnectorView;
-    const hasCommunitySkills =
-      !isConnectorView && (communitySkillItems.length > 0 || marketAgentSkills.length > 0);
+    // Skills tab only shows agent-based community skills; Lobehub/Klavis OAuth
+    // connectors live exclusively in the Connectors view (hasCommunityConnectors).
+    const hasCommunitySkills = !isConnectorView && marketAgentSkills.length > 0;
     const hasCommunityTools = communityMCPs.length > 0 && isConnectorView;
     // In connector view: custom MCPs. In skill view: user agent skills
     const hasCustomConnectors = customMCPs.length > 0 && isConnectorView;
@@ -502,40 +503,12 @@ const SkillList = memo<SkillListProps>(
             }),
           )}
 
-        {/* Skill view: community skills */}
+        {/* Skill view: community agent skills only (OAuth connectors are in the Connectors view) */}
         {hasCommunitySkills &&
           renderSection(
             'communitySkills',
             t('skillGroup.communitySkills', '社区 Skill'),
-            <>
-              {communitySkillItems.map((item) => {
-                if (item.type === 'lobehub') {
-                  return (
-                    <LobehubSkillItem
-                      isSelected={selectedIdentifier === item.provider.id}
-                      key={item.provider.id}
-                      provider={item.provider}
-                      server={getLobehubSkillServerByProvider(item.provider.id)}
-                      onSelect={
-                        onSelect ? () => onSelect(item.provider.id, 'lobehub-connector') : undefined
-                      }
-                    />
-                  );
-                }
-                return (
-                  <KlavisSkillItem
-                    isSelected={selectedIdentifier === item.serverType.identifier}
-                    key={item.serverType.identifier}
-                    server={getKlavisServerByIdentifier(item.serverType.identifier)}
-                    serverType={item.serverType}
-                    onSelect={
-                      onSelect ? () => onSelect(item.serverType.identifier, 'plugin') : undefined
-                    }
-                  />
-                );
-              })}
-              {renderMarketAgentSkills()}
-            </>,
+            renderMarketAgentSkills(),
           )}
 
         {hasCommunityTools &&


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

The unified `/settings/skill` manager renders the **Connectors** and **Skills** sub-tabs from a single `SkillList` driven by `viewMode`. Lobehub/Klavis OAuth connectors (`type: 'lobehub' | 'klavis'` — Gmail, Notion, Google Drive, Google Calendar, GitHub, Linear, etc.) are meant to live **only** in the Connectors view's "OAuth Connectors" group.

However, the Skills view's "Community Skill" (`社区 Skill`) section still mapped `communitySkillItems` alongside the market agent skills, so every OAuth connector appeared in **both** tabs.

This PR makes the Skills view render only `marketAgentSkills` (xlsx, pdf, docx, skill-creator, …). OAuth connectors stay exclusively under the Connectors view.

Two changes in `src/routes/(main)/settings/skill/features/SkillList.tsx`:
- `hasCommunitySkills` no longer keys off `communitySkillItems.length`, only `marketAgentSkills.length`.
- The `communitySkills` section renders just `renderMarketAgentSkills()`; the lobehub/klavis branch is removed.

#### 🧪 How to Test

- [x] Tested locally

Open `/settings/skill`:
- **Connectors** tab → OAuth connectors appear under "OAuth Connectors" (unchanged).
- **Skills** tab → "社区 Skill" now lists only agent skills; Gmail/Notion/Google Drive no longer duplicated here.

#### 📝 Additional Information

Regression from #15463 (Connectors system). The code already documented the intent (`// Lobehub/Klavis OAuth skills go in Connectors tab`), but the skill-view render path was left in place.