### PR TITLE
♻️ refactor(server): rename deviceProxy → deviceGateway

### DIFF
--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -308,7 +308,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
    * renderer uses, so remote tool calls produce identical
    * `{ content, state, success }` envelopes — `content` is the LLM-facing
    * prompt text, `state` is the structured payload, both flow downstream
-   * intact (the gateway / DeviceProxy / RuntimeExecutors paths preserve them
+   * intact (the gateway / DeviceGateway / RuntimeExecutors paths preserve them
    * and write `state` to the tool message's `pluginState`).
    */
   private getLocalSystemRuntime(): LocalSystemExecutionRuntime {

--- a/apps/desktop/src/main/services/gatewayConnectionSrv.ts
+++ b/apps/desktop/src/main/services/gatewayConnectionSrv.ts
@@ -465,7 +465,7 @@ export default class GatewayConnectionService extends ServiceModule {
       // Forward the typed envelope unchanged. Critically, do NOT stringify the
       // whole result into `content` — that would bury the structured payload
       // inside a JSON blob and lose `state`. The wire protocol carries each
-      // field separately so downstream (`DeviceProxy` → `RuntimeExecutors`)
+      // field separately so downstream (`DeviceGateway` → `RuntimeExecutors`)
       // can persist `state` to `pluginState`. Optional fields are only set
       // when present so payloads stay minimal.
       const wireResult: ToolCallResponseMessage['result'] = {

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
@@ -380,7 +380,7 @@ export class SkillsExecutionRuntime {
         // Don't enumerate the directory here — let the model do it on demand
         // via `local-system.listFiles`. Just point at the skill's directory so
         // it knows where to look. Keeps the op-param payload small and avoids
-        // a second deviceProxy round-trip at activation time.
+        // a second deviceGateway round-trip at activation time.
         const skillDir = getDirname(projectSkill.location);
         if (skillDir) {
           content += '\n\n' + buildProjectDirectoryHint(name, skillDir);

--- a/src/server/routers/lambda/device.ts
+++ b/src/server/routers/lambda/device.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { DeviceModel } from '@/database/models/device';
 import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
-import { deviceProxy } from '@/server/services/toolExecution/deviceProxy';
+import { deviceGateway } from '@/server/services/toolExecution/deviceGateway';
 
 // Derive the zod enum from the canonical config so new platforms are
 // automatically covered without touching this file.
@@ -49,7 +49,7 @@ export const deviceRouter = router({
       }),
     )
     .query(async ({ ctx, input }) => {
-      const result = await deviceProxy.executeToolCall(
+      const result = await deviceGateway.executeToolCall(
         { deviceId: input.deviceId, userId: ctx.userId },
         {
           apiName: 'checkPlatformCapability',
@@ -87,7 +87,7 @@ export const deviceRouter = router({
       }),
     )
     .query(async ({ ctx, input }) => {
-      const result = await deviceProxy.executeToolCall(
+      const result = await deviceGateway.executeToolCall(
         { deviceId: input.deviceId, userId: ctx.userId },
         {
           apiName: 'getAgentProfile',
@@ -113,7 +113,7 @@ export const deviceRouter = router({
   getDeviceSystemInfo: deviceProcedure
     .input(z.object({ deviceId: z.string() }))
     .query(async ({ ctx, input }) => {
-      return deviceProxy.queryDeviceSystemInfo(ctx.userId, input.deviceId);
+      return deviceGateway.queryDeviceSystemInfo(ctx.userId, input.deviceId);
     }),
 
   /**
@@ -131,7 +131,7 @@ export const deviceRouter = router({
   listDevices: deviceProcedure.query(async ({ ctx }) => {
     const [registered, onlineList] = await Promise.all([
       ctx.deviceModel.query(),
-      deviceProxy.queryDeviceList(ctx.userId),
+      deviceGateway.queryDeviceList(ctx.userId),
     ]);
 
     // The gateway already groups by device, exposing live sessions as nested
@@ -225,7 +225,7 @@ export const deviceRouter = router({
     }),
 
   status: deviceProcedure.query(async ({ ctx }) => {
-    return deviceProxy.queryDeviceStatus(ctx.userId);
+    return deviceGateway.queryDeviceStatus(ctx.userId);
   }),
 
   /** User-editable fields only — never the machine-reported identity columns. */

--- a/src/server/services/aiAgent/__tests__/execAgent.builtinRuntime.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.builtinRuntime.test.ts
@@ -162,8 +162,8 @@ vi.mock('@/server/modules/Mecha', () => ({
   serverMessagesEngine: vi.fn().mockResolvedValue([{ content: 'test', role: 'user' }]),
 }));
 
-vi.mock('@/server/services/toolExecution/deviceProxy', () => ({
-  deviceProxy: {
+vi.mock('@/server/services/toolExecution/deviceGateway', () => ({
+  deviceGateway: {
     isConfigured: false,
     queryDeviceList: vi.fn().mockResolvedValue([]),
   },

--- a/src/server/services/aiAgent/__tests__/execAgent.device.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.device.test.ts
@@ -118,8 +118,8 @@ vi.mock('@/server/modules/Mecha', () => ({
   serverMessagesEngine: vi.fn().mockResolvedValue([{ content: 'test', role: 'user' }]),
 }));
 
-vi.mock('@/server/services/toolExecution/deviceProxy', () => ({
-  deviceProxy: mockDeviceProxy,
+vi.mock('@/server/services/toolExecution/deviceGateway', () => ({
+  deviceGateway: mockDeviceProxy,
 }));
 
 vi.mock('model-bank', async (importOriginal) => {

--- a/src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
@@ -126,8 +126,8 @@ vi.mock('@/server/modules/Mecha', () => {
   };
 });
 
-vi.mock('@/server/services/toolExecution/deviceProxy', () => ({
-  deviceProxy: {
+vi.mock('@/server/services/toolExecution/deviceGateway', () => ({
+  deviceGateway: {
     get isConfigured() {
       // Will be overridden per-test via vi.spyOn or re-mock
       return false;
@@ -208,9 +208,9 @@ describe('AiAgentService.execAgent - device tool pipeline ()', () => {
 
   describe('deviceContext forwarded to createServerAgentToolsEngine', () => {
     it('should pass deviceContext when gateway is configured', async () => {
-      // Override deviceProxy.isConfigured
-      const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
-      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(true);
+      // Override deviceGateway.isConfigured
+      const { deviceGateway } = await import('@/server/services/toolExecution/deviceGateway');
+      vi.spyOn(deviceGateway, 'isConfigured', 'get').mockReturnValue(true);
       mockQueryDeviceList.mockResolvedValue([
         { deviceId: 'dev-1', deviceName: 'My PC', platform: 'win32' },
       ]);
@@ -230,8 +230,8 @@ describe('AiAgentService.execAgent - device tool pipeline ()', () => {
     });
 
     it('should not pass deviceContext when gateway is not configured', async () => {
-      const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
-      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(false);
+      const { deviceGateway } = await import('@/server/services/toolExecution/deviceGateway');
+      vi.spyOn(deviceGateway, 'isConfigured', 'get').mockReturnValue(false);
 
       mockGetAgentConfig.mockResolvedValue(createBaseAgentConfig());
 
@@ -245,8 +245,8 @@ describe('AiAgentService.execAgent - device tool pipeline ()', () => {
 
   describe('RemoteDevice systemRole override', () => {
     it('should override RemoteDevice systemRole with dynamic prompt when enabled by ToolsEngine', async () => {
-      const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
-      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(true);
+      const { deviceGateway } = await import('@/server/services/toolExecution/deviceGateway');
+      vi.spyOn(deviceGateway, 'isConfigured', 'get').mockReturnValue(true);
       mockQueryDeviceList.mockResolvedValue([
         { deviceId: 'dev-1', deviceName: 'My PC', platform: 'win32' },
       ]);
@@ -279,8 +279,8 @@ describe('AiAgentService.execAgent - device tool pipeline ()', () => {
     });
 
     it('should NOT have RemoteDevice in manifestMap when gateway is not configured', async () => {
-      const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
-      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(false);
+      const { deviceGateway } = await import('@/server/services/toolExecution/deviceGateway');
+      vi.spyOn(deviceGateway, 'isConfigured', 'get').mockReturnValue(false);
 
       // ToolsEngine returns empty manifestMap (RemoteDevice disabled by enableChecker)
       mockGetEnabledPluginManifests.mockReturnValue(new Map());
@@ -301,8 +301,8 @@ describe('AiAgentService.execAgent - device tool pipeline ()', () => {
 
   describe('toolExecutorMap gating on gatewayConfigured (regression for #13769)', () => {
     it('should mark local-system as client when gateway is NOT configured (standalone Electron)', async () => {
-      const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
-      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(false);
+      const { deviceGateway } = await import('@/server/services/toolExecution/deviceGateway');
+      vi.spyOn(deviceGateway, 'isConfigured', 'get').mockReturnValue(false);
 
       mockGetEnabledPluginManifests.mockReturnValue(
         new Map([[LocalSystemManifest.identifier, LocalSystemManifest]]),
@@ -316,8 +316,8 @@ describe('AiAgentService.execAgent - device tool pipeline ()', () => {
     });
 
     it('should NOT mark local-system as client when gateway IS configured (cloud)', async () => {
-      const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
-      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(true);
+      const { deviceGateway } = await import('@/server/services/toolExecution/deviceGateway');
+      vi.spyOn(deviceGateway, 'isConfigured', 'get').mockReturnValue(true);
       mockQueryDeviceList.mockResolvedValue([
         { deviceId: 'dev-1', deviceName: 'My PC', platform: 'win32' },
       ]);
@@ -348,17 +348,17 @@ describe('AiAgentService.execAgent - device tool pipeline ()', () => {
       mockGetEnabledPluginManifests.mockReturnValue(new Map([['my-stdio-mcp', stdioManifest]]));
       mockGetAgentConfig.mockResolvedValue(createBaseAgentConfig({ plugins: ['my-stdio-mcp'] }));
 
-      const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
+      const { deviceGateway } = await import('@/server/services/toolExecution/deviceGateway');
 
       // Gateway NOT configured → should mark as client
-      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(false);
+      vi.spyOn(deviceGateway, 'isConfigured', 'get').mockReturnValue(false);
       await service.execAgent({ agentId: 'agent-1', prompt: 'Hello' });
       let executorMap = mockCreateOperation.mock.calls[0][0].toolSet.executorMap;
       expect(executorMap['my-stdio-mcp']).toBe('client');
 
       // Gateway configured → should NOT mark as client
       mockCreateOperation.mockClear();
-      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(true);
+      vi.spyOn(deviceGateway, 'isConfigured', 'get').mockReturnValue(true);
       mockQueryDeviceList.mockResolvedValue([
         { deviceId: 'dev-1', deviceName: 'PC', platform: 'win32' },
       ]);
@@ -374,8 +374,8 @@ describe('AiAgentService.execAgent - device tool pipeline ()', () => {
       // Remote Device proxy to the device registered with the gateway, never
       // back to the caller. (The Phase 6.4 clientRuntime=desktop
       // short-circuit that bypassed this gate was removed.)
-      const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
-      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(true);
+      const { deviceGateway } = await import('@/server/services/toolExecution/deviceGateway');
+      vi.spyOn(deviceGateway, 'isConfigured', 'get').mockReturnValue(true);
       mockQueryDeviceList.mockResolvedValue([
         { deviceId: 'dev-1', deviceName: 'Remote VM', platform: 'linux' },
       ]);
@@ -402,8 +402,8 @@ describe('AiAgentService.execAgent - device tool pipeline ()', () => {
         meta: { title: 'Stdio' },
       };
 
-      const { deviceProxy } = await import('@/server/services/toolExecution/deviceProxy');
-      vi.spyOn(deviceProxy, 'isConfigured', 'get').mockReturnValue(true);
+      const { deviceGateway } = await import('@/server/services/toolExecution/deviceGateway');
+      vi.spyOn(deviceGateway, 'isConfigured', 'get').mockReturnValue(true);
       mockQueryDeviceList.mockResolvedValue([
         { deviceId: 'dev-1', deviceName: 'Remote VM', platform: 'linux' },
       ]);

--- a/src/server/services/aiAgent/__tests__/execAgent.disableTools.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.disableTools.test.ts
@@ -114,8 +114,8 @@ vi.mock('@/server/modules/Mecha', () => ({
   serverMessagesEngine: vi.fn().mockResolvedValue([{ content: 'test', role: 'user' }]),
 }));
 
-vi.mock('@/server/services/toolExecution/deviceProxy', () => ({
-  deviceProxy: {
+vi.mock('@/server/services/toolExecution/deviceGateway', () => ({
+  deviceGateway: {
     isConfigured: false,
     queryDeviceList: vi.fn().mockResolvedValue([]),
   },

--- a/src/server/services/aiAgent/__tests__/execAgent.files.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.files.test.ts
@@ -137,8 +137,8 @@ vi.mock('@/server/modules/Mecha', () => ({
   serverMessagesEngine: vi.fn().mockResolvedValue([{ content: 'test', role: 'user' }]),
 }));
 
-vi.mock('@/server/services/toolExecution/deviceProxy', () => ({
-  deviceProxy: {
+vi.mock('@/server/services/toolExecution/deviceGateway', () => ({
+  deviceGateway: {
     isConfigured: false,
     queryDeviceList: vi.fn().mockResolvedValue([]),
   },

--- a/src/server/services/aiAgent/__tests__/execAgent.headlessDefault.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.headlessDefault.test.ts
@@ -88,8 +88,8 @@ vi.mock('@/server/modules/Mecha', () => ({
   serverMessagesEngine: vi.fn().mockResolvedValue([{ content: 'test', role: 'user' }]),
 }));
 
-vi.mock('@/server/services/toolExecution/deviceProxy', () => ({
-  deviceProxy: {
+vi.mock('@/server/services/toolExecution/deviceGateway', () => ({
+  deviceGateway: {
     isConfigured: false,
     queryDeviceList: vi.fn().mockResolvedValue([]),
   },

--- a/src/server/services/aiAgent/__tests__/execAgent.modelOverride.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.modelOverride.test.ts
@@ -88,8 +88,8 @@ vi.mock('@/server/modules/Mecha', () => ({
   serverMessagesEngine: vi.fn().mockResolvedValue([{ content: 'test', role: 'user' }]),
 }));
 
-vi.mock('@/server/services/toolExecution/deviceProxy', () => ({
-  deviceProxy: {
+vi.mock('@/server/services/toolExecution/deviceGateway', () => ({
+  deviceGateway: {
     isConfigured: false,
     queryDeviceList: vi.fn().mockResolvedValue([]),
   },

--- a/src/server/services/aiAgent/__tests__/execAgent.resume.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.resume.test.ts
@@ -110,8 +110,8 @@ vi.mock('@/server/modules/Mecha', () => ({
   }),
 }));
 
-vi.mock('@/server/services/toolExecution/deviceProxy', () => ({
-  deviceProxy: {
+vi.mock('@/server/services/toolExecution/deviceGateway', () => ({
+  deviceGateway: {
     isConfigured: false,
     queryDeviceList: vi.fn().mockResolvedValue([]),
   },

--- a/src/server/services/aiAgent/__tests__/execAgent.resumeApproval.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.resumeApproval.test.ts
@@ -118,8 +118,8 @@ vi.mock('@/server/modules/Mecha', () => ({
   }),
 }));
 
-vi.mock('@/server/services/toolExecution/deviceProxy', () => ({
-  deviceProxy: { isConfigured: false, queryDeviceList: vi.fn().mockResolvedValue([]) },
+vi.mock('@/server/services/toolExecution/deviceGateway', () => ({
+  deviceGateway: { isConfigured: false, queryDeviceList: vi.fn().mockResolvedValue([]) },
 }));
 
 vi.mock('@/server/modules/ModelRuntime', () => ({

--- a/src/server/services/aiAgent/__tests__/execAgent.threadId.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.threadId.test.ts
@@ -123,9 +123,9 @@ vi.mock('@/server/modules/Mecha', () => ({
   serverMessagesEngine: vi.fn().mockResolvedValue([{ content: 'test', role: 'user' }]),
 }));
 
-// Mock deviceProxy
-vi.mock('@/server/services/toolExecution/deviceProxy', () => ({
-  deviceProxy: {
+// Mock deviceGateway
+vi.mock('@/server/services/toolExecution/deviceGateway', () => ({
+  deviceGateway: {
     isConfigured: false,
     queryDeviceList: vi.fn().mockResolvedValue([]),
   },

--- a/src/server/services/aiAgent/__tests__/execAgent.topicHistory.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.topicHistory.test.ts
@@ -110,8 +110,8 @@ vi.mock('@/server/services/file', () => ({
   })),
 }));
 
-vi.mock('@/server/services/toolExecution/deviceProxy', () => ({
-  deviceProxy: {
+vi.mock('@/server/services/toolExecution/deviceGateway', () => ({
+  deviceGateway: {
     isConfigured: false,
     queryDeviceList: vi.fn().mockResolvedValue([]),
   },

--- a/src/server/services/aiAgent/deviceToolAudit.ts
+++ b/src/server/services/aiAgent/deviceToolAudit.ts
@@ -44,7 +44,7 @@ export interface LogDeviceToolAuditParams {
  * Reason for being a logger (not a DB table): the goal here is post-incident
  * forensics ("who triggered this read_file?"), not real-time risk control.
  * The debug namespace keeps it cheap, fire-and-forget, and consistent with
- * the existing `lobe-server:device-proxy` line at the actual proxy dispatch.
+ * the existing `lobe-server:device-gateway` line at the actual proxy dispatch.
  *
  * Sensitive payloads (file contents, shell stdout, tool args) are NEVER
  * recorded here — only identity + decision metadata.

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -86,7 +86,7 @@ import { HeterogeneousAgentService } from '@/server/services/heterogeneousAgent'
 import type { ConversationHistoryEntry } from '@/server/services/heterogeneousAgent/cloudHeteroContext';
 import { KlavisService } from '@/server/services/klavis';
 import { MarketService } from '@/server/services/market';
-import { deviceProxy } from '@/server/services/toolExecution/deviceProxy';
+import { deviceGateway } from '@/server/services/toolExecution/deviceGateway';
 import { markdownToTxt } from '@/utils/markdownToTxt';
 
 import { resolveDeviceAccessPolicy } from './deviceAccessPolicy';
@@ -885,7 +885,7 @@ export class AiAgentService {
 
         // lh connect only handles tool_call_request (not agent_run_request),
         // so we use executeToolCall with the runHeteroTask tool instead of dispatchAgentRun.
-        const result = await deviceProxy.executeToolCall(
+        const result = await deviceGateway.executeToolCall(
           { deviceId: remoteDeviceId, userId: this.userId },
           {
             apiName: 'runHeteroTask',
@@ -980,7 +980,7 @@ export class AiAgentService {
           // Resolve the working directory for the run: a topic-level override
           // wins, else the device's user-configured defaultCwd. The device row
           // lives in the DB (the gateway only knows live connections), so read
-          // it directly rather than via deviceProxy.
+          // it directly rather than via deviceGateway.
           const boundDevice = await new DeviceModel(this.db, this.userId).findByDeviceId(
             dispatchDeviceId,
           );
@@ -1005,7 +1005,7 @@ export class AiAgentService {
             cwd: deviceCwd,
           });
 
-          const result = await deviceProxy.dispatchAgentRun({
+          const result = await deviceGateway.dispatchAgentRun({
             ...heteroParams,
             cwd: deviceCwd,
             deviceId: dispatchDeviceId,
@@ -1296,12 +1296,12 @@ export class AiAgentService {
       log('execAgent: isBotConversation=%s', isBotConversation);
 
       // Build device context for ToolsEngine enableChecker
-      const gatewayConfigured = deviceProxy.isConfigured;
+      const gatewayConfigured = deviceGateway.isConfigured;
       const agentBoundDeviceId = agentConfig.agencyConfig?.boundDeviceId;
       const boundDeviceId = topicBoundDeviceId || agentBoundDeviceId;
       if (gatewayConfigured) {
         try {
-          onlineDevices = await deviceProxy.queryDeviceList(this.userId);
+          onlineDevices = await deviceGateway.queryDeviceList(this.userId);
           log('execAgent: found %d online device(s)', onlineDevices.length);
         } catch (error) {
           log('execAgent: failed to query device list: %O', error);
@@ -1614,7 +1614,7 @@ export class AiAgentService {
     ): Promise<Record<string, string>> => {
       if (!deviceId) return {};
       try {
-        const systemInfo = await deviceProxy.queryDeviceSystemInfo(this.userId, deviceId);
+        const systemInfo = await deviceGateway.queryDeviceSystemInfo(this.userId, deviceId);
         if (!systemInfo) return {};
         const device = onlineDevices.find((d) => d.deviceId === deviceId);
         log('execAgent: fetched device system info for %s', deviceId);
@@ -2950,7 +2950,7 @@ export class AiAgentService {
           runningOp.deviceId,
           taskId,
         );
-        await deviceProxy
+        await deviceGateway
           .executeToolCall(
             { deviceId: runningOp.deviceId, userId: this.userId },
             {

--- a/src/server/services/bot/platforms/imessage/client.test.ts
+++ b/src/server/services/bot/platforms/imessage/client.test.ts
@@ -4,8 +4,8 @@ import { ImessageClientFactory } from './client';
 
 const mockExecuteMessageApi = vi.hoisted(() => vi.fn());
 
-vi.mock('@/server/services/toolExecution/deviceProxy', () => ({
-  deviceProxy: {
+vi.mock('@/server/services/toolExecution/deviceGateway', () => ({
+  deviceGateway: {
     executeMessageApi: mockExecuteMessageApi,
   },
 }));

--- a/src/server/services/bot/platforms/imessage/desktopBridge.ts
+++ b/src/server/services/bot/platforms/imessage/desktopBridge.ts
@@ -7,7 +7,7 @@ import type {
   BlueBubblesSendOptions,
 } from '@lobechat/chat-adapter-imessage';
 
-import { deviceProxy } from '@/server/services/toolExecution/deviceProxy';
+import { deviceGateway } from '@/server/services/toolExecution/deviceGateway';
 
 const IMESSAGE_MESSAGE_API_TIMEOUT_MS = 60_000;
 
@@ -95,7 +95,7 @@ export class ImessageDesktopBridgeApi {
   };
 
   private async call<T>(apiName: string, payload: Record<string, unknown>): Promise<T> {
-    const result = await deviceProxy.executeMessageApi(
+    const result = await deviceGateway.executeMessageApi(
       { deviceId: this.deviceId, userId: this.userId },
       {
         apiName,

--- a/src/server/services/toolExecution/__tests__/deviceGateway.test.ts
+++ b/src/server/services/toolExecution/__tests__/deviceGateway.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // Import after mocks are set up
-import { DeviceProxy } from '../deviceProxy';
+import { DeviceGateway } from '../deviceGateway';
 
 const mockEnv = vi.hoisted(() => ({
   DEVICE_GATEWAY_SERVICE_TOKEN: undefined as string | undefined,
@@ -27,7 +27,7 @@ vi.mock('@lobechat/device-gateway-client', () => ({
   GatewayHttpClient: MockGatewayHttpClient,
 }));
 
-describe('DeviceProxy', () => {
+describe('DeviceGateway', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockEnv.DEVICE_GATEWAY_URL = undefined;
@@ -36,20 +36,20 @@ describe('DeviceProxy', () => {
 
   describe('isConfigured', () => {
     it('should return false when DEVICE_GATEWAY_URL is not set', () => {
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       expect(proxy.isConfigured).toBe(false);
     });
 
     it('should return true when DEVICE_GATEWAY_URL is set', () => {
       mockEnv.DEVICE_GATEWAY_URL = 'https://gateway.example.com';
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       expect(proxy.isConfigured).toBe(true);
     });
   });
 
   describe('queryDeviceStatus', () => {
     it('should return offline status when not configured', async () => {
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.queryDeviceStatus('user-1');
       expect(result).toEqual({ deviceCount: 0, online: false });
     });
@@ -60,7 +60,7 @@ describe('DeviceProxy', () => {
       const expected = { deviceCount: 2, online: true };
       mockClient.queryDeviceStatus.mockResolvedValue(expected);
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.queryDeviceStatus('user-1');
 
       expect(result).toEqual(expected);
@@ -72,7 +72,7 @@ describe('DeviceProxy', () => {
       mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';
       mockClient.queryDeviceStatus.mockRejectedValue(new Error('network error'));
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.queryDeviceStatus('user-1');
 
       expect(result).toEqual({ deviceCount: 0, online: false });
@@ -81,7 +81,7 @@ describe('DeviceProxy', () => {
 
   describe('queryDeviceList', () => {
     it('should return empty array when not configured', async () => {
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.queryDeviceList('user-1');
       expect(result).toEqual([]);
     });
@@ -111,7 +111,7 @@ describe('DeviceProxy', () => {
         },
       ]);
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.queryDeviceList('user-1');
 
       expect(result).toEqual([
@@ -146,7 +146,7 @@ describe('DeviceProxy', () => {
         { connectedAt, deviceId: 'dev-1', hostname: 'my-laptop', platform: 'darwin' },
       ]);
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.queryDeviceList('user-1');
 
       expect(result).toEqual([
@@ -166,7 +166,7 @@ describe('DeviceProxy', () => {
       mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';
       mockClient.queryDeviceList.mockRejectedValue(new Error('fail'));
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.queryDeviceList('user-1');
 
       expect(result).toEqual([]);
@@ -175,7 +175,7 @@ describe('DeviceProxy', () => {
 
   describe('queryDeviceSystemInfo', () => {
     it('should return undefined when not configured', async () => {
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.queryDeviceSystemInfo('user-1', 'dev-1');
       expect(result).toBeUndefined();
     });
@@ -186,7 +186,7 @@ describe('DeviceProxy', () => {
       const systemInfo = { cpuModel: 'Apple M1', os: 'macOS', totalMemory: 16384 };
       mockClient.getDeviceSystemInfo.mockResolvedValue({ success: true, systemInfo });
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.queryDeviceSystemInfo('user-1', 'dev-1');
 
       expect(result).toEqual(systemInfo);
@@ -198,7 +198,7 @@ describe('DeviceProxy', () => {
       mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';
       mockClient.getDeviceSystemInfo.mockResolvedValue({ success: false });
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.queryDeviceSystemInfo('user-1', 'dev-1');
 
       expect(result).toBeUndefined();
@@ -209,7 +209,7 @@ describe('DeviceProxy', () => {
       mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';
       mockClient.getDeviceSystemInfo.mockRejectedValue(new Error('timeout'));
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.queryDeviceSystemInfo('user-1', 'dev-1');
 
       expect(result).toBeUndefined();
@@ -221,7 +221,7 @@ describe('DeviceProxy', () => {
     const toolCall = { apiName: 'listFiles', arguments: '{}', identifier: 'file-manager' };
 
     it('should return error when not configured', async () => {
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.executeToolCall(params, toolCall);
 
       expect(result).toEqual({
@@ -237,7 +237,7 @@ describe('DeviceProxy', () => {
       const expected = { content: 'file list', success: true };
       mockClient.executeToolCall.mockResolvedValue(expected);
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.executeToolCall(params, toolCall);
 
       expect(result).toEqual(expected);
@@ -252,7 +252,7 @@ describe('DeviceProxy', () => {
       mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';
       mockClient.executeToolCall.mockResolvedValue({ content: 'ok', success: true });
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       await proxy.executeToolCall(params, toolCall, 60_000);
 
       expect(mockClient.executeToolCall).toHaveBeenCalledWith(
@@ -266,7 +266,7 @@ describe('DeviceProxy', () => {
       mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';
       mockClient.executeToolCall.mockRejectedValue(new Error('connection refused'));
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.executeToolCall(params, toolCall);
 
       expect(result).toEqual({
@@ -281,7 +281,7 @@ describe('DeviceProxy', () => {
       mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';
       mockClient.executeToolCall.mockRejectedValue('string error');
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.executeToolCall(params, toolCall);
 
       expect(result).toEqual({
@@ -309,7 +309,7 @@ describe('DeviceProxy', () => {
     };
 
     it('should return error when not configured', async () => {
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.executeMcpCall(mcpCall);
 
       expect(result).toEqual({
@@ -325,7 +325,7 @@ describe('DeviceProxy', () => {
       const expected = { content: 'stock data', state: { rows: 3 }, success: true };
       mockClient.executeMcpCall.mockResolvedValue(expected);
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.executeMcpCall(mcpCall);
 
       expect(result).toEqual(expected);
@@ -337,7 +337,7 @@ describe('DeviceProxy', () => {
       mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';
       mockClient.executeMcpCall.mockResolvedValue({ content: 'ok', success: true });
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       await proxy.executeMcpCall(mcpCall, 60_000);
 
       expect(mockClient.executeMcpCall).toHaveBeenCalledWith({ ...mcpCall, timeout: 60_000 });
@@ -348,7 +348,7 @@ describe('DeviceProxy', () => {
       mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';
       mockClient.executeMcpCall.mockRejectedValue(new Error('connection refused'));
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.executeMcpCall(mcpCall);
 
       expect(result).toEqual({
@@ -364,7 +364,7 @@ describe('DeviceProxy', () => {
     const api = { apiName: 'sendText', payload: { chatGuid: 'chat-1' }, platform: 'imessage' };
 
     it('should return error when not configured', async () => {
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.executeMessageApi(params, api);
 
       expect(result).toEqual({
@@ -380,7 +380,7 @@ describe('DeviceProxy', () => {
       const expected = { content: '{"ok":true}', success: true };
       mockClient.executeMessageApi.mockResolvedValue(expected);
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.executeMessageApi(params, api);
 
       expect(result).toEqual(expected);
@@ -395,7 +395,7 @@ describe('DeviceProxy', () => {
       mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';
       mockClient.executeMessageApi.mockResolvedValue({ content: 'ok', success: true });
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       await proxy.executeMessageApi(params, api, 60_000);
 
       expect(mockClient.executeMessageApi).toHaveBeenCalledWith(
@@ -409,7 +409,7 @@ describe('DeviceProxy', () => {
       mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';
       mockClient.executeMessageApi.mockRejectedValue(new Error('connection refused'));
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.executeMessageApi(params, api);
 
       expect(result).toEqual({
@@ -423,7 +423,7 @@ describe('DeviceProxy', () => {
   describe('getClient (lazy initialization)', () => {
     it('should return null when URL is missing', async () => {
       mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.queryDeviceStatus('user-1');
 
       expect(result).toEqual({ deviceCount: 0, online: false });
@@ -432,7 +432,7 @@ describe('DeviceProxy', () => {
 
     it('should return null when token is missing', async () => {
       mockEnv.DEVICE_GATEWAY_URL = 'https://gateway.example.com';
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       const result = await proxy.queryDeviceStatus('user-1');
 
       expect(result).toEqual({ deviceCount: 0, online: false });
@@ -444,7 +444,7 @@ describe('DeviceProxy', () => {
       mockEnv.DEVICE_GATEWAY_SERVICE_TOKEN = 'token';
       mockClient.queryDeviceStatus.mockResolvedValue({ deviceCount: 1, online: true });
 
-      const proxy = new DeviceProxy();
+      const proxy = new DeviceGateway();
       await proxy.queryDeviceStatus('user-1');
       await proxy.queryDeviceStatus('user-2');
 

--- a/src/server/services/toolExecution/deviceGateway.ts
+++ b/src/server/services/toolExecution/deviceGateway.ts
@@ -12,11 +12,11 @@ import debug from 'debug';
 
 import { gatewayEnv } from '@/envs/gateway';
 
-const log = debug('lobe-server:device-proxy');
+const log = debug('lobe-server:device-gateway');
 
 export type { DeviceAttachment, DeviceStatusResult, DeviceSystemInfo };
 
-export class DeviceProxy {
+export class DeviceGateway {
   private client: GatewayHttpClient | null = null;
 
   get isConfigured(): boolean {
@@ -224,4 +224,4 @@ export class DeviceProxy {
   }
 }
 
-export const deviceProxy = new DeviceProxy();
+export const deviceGateway = new DeviceGateway();

--- a/src/server/services/toolExecution/index.ts
+++ b/src/server/services/toolExecution/index.ts
@@ -17,7 +17,7 @@ import {
 import { DiscoverService } from '../discover';
 import { type MCPService } from '../mcp';
 import { type BuiltinToolsExecutor } from './builtin';
-import { deviceProxy } from './deviceProxy';
+import { deviceGateway } from './deviceGateway';
 import { classifyToolError } from './errorClassification';
 import {
   type ToolExecutionContext,
@@ -225,7 +225,7 @@ export class ToolExecutionService {
       // in-process MCP service below, where spawning is on the user's machine.
       if (
         mcpParams.type === 'stdio' &&
-        deviceProxy.isConfigured &&
+        deviceGateway.isConfigured &&
         context.activeDeviceId &&
         context.userId
       ) {
@@ -279,7 +279,7 @@ export class ToolExecutionService {
       context.activeDeviceId,
     );
 
-    const result = await deviceProxy.executeMcpCall(
+    const result = await deviceGateway.executeMcpCall(
       {
         apiName,
         arguments: args,

--- a/src/server/services/toolExecution/serverRuntimes/__tests__/localSystem.test.ts
+++ b/src/server/services/toolExecution/serverRuntimes/__tests__/localSystem.test.ts
@@ -3,10 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { type ToolExecutionContext } from '../../types';
 
-// Mock deviceProxy
+// Mock deviceGateway
 const mockExecuteToolCall = vi.fn();
-vi.mock('../../deviceProxy', () => ({
-  deviceProxy: {
+vi.mock('../../deviceGateway', () => ({
+  deviceGateway: {
     executeToolCall: (...args: any[]) => mockExecuteToolCall(...args),
   },
 }));
@@ -61,7 +61,7 @@ describe('localSystemRuntime', () => {
       }
     });
 
-    it('should call deviceProxy.executeToolCall with correct arguments when a proxy function is invoked', async () => {
+    it('should call deviceGateway.executeToolCall with correct arguments when a proxy function is invoked', async () => {
       const context: ToolExecutionContext = {
         activeDeviceId: 'device-1',
         toolManifestMap: {},

--- a/src/server/services/toolExecution/serverRuntimes/__tests__/remoteDevice.test.ts
+++ b/src/server/services/toolExecution/serverRuntimes/__tests__/remoteDevice.test.ts
@@ -6,10 +6,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { type ToolExecutionContext } from '../../types';
 
-// Mock deviceProxy
+// Mock deviceGateway
 const mockQueryDeviceList = vi.fn();
-vi.mock('../../deviceProxy', () => ({
-  deviceProxy: {
+vi.mock('../../deviceGateway', () => ({
+  deviceGateway: {
     queryDeviceList: (...args: any[]) => mockQueryDeviceList(...args),
   },
 }));
@@ -44,7 +44,7 @@ describe('remoteDeviceRuntime', () => {
       expect(runtime).toBeInstanceOf(RemoteDeviceExecutionRuntime);
     });
 
-    it('should pass queryDeviceList that calls deviceProxy with the userId', async () => {
+    it('should pass queryDeviceList that calls deviceGateway with the userId', async () => {
       const context: ToolExecutionContext = {
         toolManifestMap: {},
         userId: 'user-1',

--- a/src/server/services/toolExecution/serverRuntimes/localSystem.ts
+++ b/src/server/services/toolExecution/serverRuntimes/localSystem.ts
@@ -1,6 +1,6 @@
 import { LocalSystemIdentifier, LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
 
-import { deviceProxy } from '../deviceProxy';
+import { deviceGateway } from '../deviceGateway';
 import { type ServerRuntimeRegistration } from './types';
 
 export const localSystemRuntime: ServerRuntimeRegistration = {
@@ -16,7 +16,7 @@ export const localSystemRuntime: ServerRuntimeRegistration = {
 
     for (const api of LocalSystemManifest.api) {
       proxy[api.name] = async (args: any) => {
-        return deviceProxy.executeToolCall(
+        return deviceGateway.executeToolCall(
           { deviceId: context.activeDeviceId!, userId: context.userId! },
           {
             apiName: api.name,

--- a/src/server/services/toolExecution/serverRuntimes/remoteDevice.ts
+++ b/src/server/services/toolExecution/serverRuntimes/remoteDevice.ts
@@ -3,7 +3,7 @@ import {
   RemoteDeviceIdentifier,
 } from '@lobechat/builtin-tool-remote-device';
 
-import { deviceProxy } from '../deviceProxy';
+import { deviceGateway } from '../deviceGateway';
 import { type ServerRuntimeRegistration } from './types';
 
 export const remoteDeviceRuntime: ServerRuntimeRegistration = {
@@ -15,7 +15,7 @@ export const remoteDeviceRuntime: ServerRuntimeRegistration = {
     const userId = context.userId;
 
     return new RemoteDeviceExecutionRuntime({
-      queryDeviceList: () => deviceProxy.queryDeviceList(userId),
+      queryDeviceList: () => deviceGateway.queryDeviceList(userId),
     });
   },
   identifier: RemoteDeviceIdentifier,

--- a/src/server/services/toolExecution/serverRuntimes/skills.ts
+++ b/src/server/services/toolExecution/serverRuntimes/skills.ts
@@ -1,6 +1,6 @@
 import { builtinSkills } from '@lobechat/builtin-skills';
 import { LocalSystemApiName, LocalSystemIdentifier } from '@lobechat/builtin-tool-local-system';
-// Note: only `readFile` is wired through deviceProxy. Directory enumeration is
+// Note: only `readFile` is wired through deviceGateway. Directory enumeration is
 // left to the model via `local-system.listFiles` so we don't double-fetch.
 import { type CommandResult, SkillsIdentifier } from '@lobechat/builtin-tool-skills';
 import {
@@ -25,7 +25,7 @@ import { MarketService } from '@/server/services/market';
 import { SkillResourceService } from '@/server/services/skill/resource';
 import { preprocessLhCommand } from '@/server/services/toolExecution/preprocessLhCommand';
 
-import { deviceProxy } from '../deviceProxy';
+import { deviceGateway } from '../deviceGateway';
 import { type ServerRuntimeRegistration } from './types';
 
 const log = debug('lobe-server:skills-runtime');
@@ -379,7 +379,7 @@ export const skillsRuntime: ServerRuntimeRegistration = {
 
     // Project skills live on the device filesystem. Read them through the
     // device gateway by reusing the local-system tools — no special
-    // file-read primitive, just the existing capabilities over deviceProxy.
+    // file-read primitive, just the existing capabilities over deviceGateway.
     //   - `readFile`  loads SKILL.md and validated reference files.
     //   - `globFiles` enumerates the skill directory so `readReference` can
     //     reject paths the model guessed (e.g. `.env`) instead of trusting
@@ -391,7 +391,7 @@ export const skillsRuntime: ServerRuntimeRegistration = {
       const userId = context.userId;
       deviceFileAccess = {
         listFiles: async (dir: string) => {
-          const result = await deviceProxy.executeToolCall(
+          const result = await deviceGateway.executeToolCall(
             { deviceId: activeDeviceId, userId },
             {
               apiName: LocalSystemApiName.globFiles,
@@ -420,7 +420,7 @@ export const skillsRuntime: ServerRuntimeRegistration = {
             .map((f) => (f.startsWith(dir) ? f.slice(dir.length).replace(/^[/\\]+/, '') : f));
         },
         readFile: async (filePath: string) => {
-          const result = await deviceProxy.executeToolCall(
+          const result = await deviceGateway.executeToolCall(
             { deviceId: activeDeviceId, userId },
             {
               apiName: LocalSystemApiName.readFile,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔀 Description of Change

**Pure mechanical rename** of the server-side device-relay module/class/singleton `deviceProxy` → `deviceGateway` (file `deviceProxy.ts` → `deviceGateway.ts` included), to match the underlying `GatewayHttpClient` / device-gateway naming. **No behavior change.**

Split out of the workspace-init feature PR (#15512) so that PR's diff is reviewable without ~27 files of rename churn. The feature PR is stacked on this branch.

Word-boundary rename only — compound identifiers (`hasDeviceProxy` flag, `mockDeviceProxy` test locals) are intentionally left untouched.

#### 🧪 How to Test

- [x] Tested locally

`bun run type-check` green; affected server suites pass (no behavior change — same tests, renamed symbols).