### PR TITLE
💄 style(tool-ui): render ANSI escape codes in RunCommand output

### DIFF
--- a/packages/shared-tool-ui/package.json
+++ b/packages/shared-tool-ui/package.json
@@ -11,7 +11,8 @@
     "./styles": "./src/styles.ts"
   },
   "dependencies": {
-    "@lobechat/tool-runtime": "workspace:*"
+    "@lobechat/tool-runtime": "workspace:*",
+    "anser": "^2.3.5"
   },
   "devDependencies": {
     "@lobechat/types": "workspace:*"

--- a/packages/shared-tool-ui/src/Render/RunCommand/AnsiOutput.tsx
+++ b/packages/shared-tool-ui/src/Render/RunCommand/AnsiOutput.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import Anser from 'anser';
+import { createStaticStyles, cssVar } from 'antd-style';
+import { memo, useMemo } from 'react';
+
+const styles = createStaticStyles(({ css }) => ({
+  pre: css`
+    overflow: auto;
+
+    max-height: 200px;
+    margin: 0;
+    padding: 8px;
+    border-radius: 6px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    line-height: 1.6;
+    color: ${cssVar.colorText};
+    word-break: break-word;
+    white-space: pre-wrap;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+}));
+
+interface AnsiOutputProps {
+  text: string;
+}
+
+const AnsiOutput = memo<AnsiOutputProps>(({ text }) => {
+  const segments = useMemo(
+    () =>
+      Anser.ansiToJson(text, {
+        json: true,
+        remove_empty: true,
+        use_classes: false,
+      }),
+    [text],
+  );
+
+  return (
+    <pre className={styles.pre}>
+      {segments.map((seg, i) => {
+        const decorations = seg.decorations ?? [];
+        const isDim = decorations.includes('dim');
+        const isBold = decorations.includes('bold');
+        const isItalic = decorations.includes('italic');
+        const isUnderline = decorations.includes('underline');
+        const isStrike = decorations.includes('strikethrough');
+
+        return (
+          <span
+            key={i}
+            style={{
+              background: seg.bg ? `rgb(${seg.bg})` : undefined,
+              color: seg.fg ? `rgb(${seg.fg})` : undefined,
+              fontStyle: isItalic ? 'italic' : undefined,
+              fontWeight: isBold ? 600 : undefined,
+              opacity: isDim ? 0.6 : undefined,
+              textDecoration:
+                [isUnderline && 'underline', isStrike && 'line-through']
+                  .filter(Boolean)
+                  .join(' ') || undefined,
+            }}
+          >
+            {seg.content}
+          </span>
+        );
+      })}
+    </pre>
+  );
+});
+
+AnsiOutput.displayName = 'AnsiOutput';
+
+export default AnsiOutput;

--- a/packages/shared-tool-ui/src/Render/RunCommand/index.tsx
+++ b/packages/shared-tool-ui/src/Render/RunCommand/index.tsx
@@ -6,6 +6,8 @@ import { Block, Flexbox, Highlighter } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 
+import AnsiOutput from './AnsiOutput';
+
 const styles = createStaticStyles(({ css }) => ({
   container: css`
     overflow: hidden;
@@ -36,22 +38,8 @@ const RunCommand = memo<BuiltinRenderProps<RunCommandArgs, RunCommandState>>(
           >
             {args?.command || ''}
           </Highlighter>
-          {output && (
-            <Highlighter
-              wrap
-              language={'text'}
-              showLanguage={false}
-              style={{ maxHeight: 200, overflow: 'auto', paddingInline: 8 }}
-              variant={'filled'}
-            >
-              {output}
-            </Highlighter>
-          )}
-          {pluginState?.stderr && (
-            <Highlighter wrap language={'text'} showLanguage={false} variant={'filled'}>
-              {pluginState.stderr}
-            </Highlighter>
-          )}
+          {output && <AnsiOutput text={output} />}
+          {pluginState?.stderr && <AnsiOutput text={pluginState.stderr} />}
         </Block>
       </Flexbox>
     );


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

Shell tools (e.g. `agent-tracing inspect`, `ls --color`, anything that uses chalk) emit ANSI SGR escape sequences in their stdout. The `RunCommand` render currently passes that raw text into `<Highlighter language={'text'}>`, so the user sees literal `[2m`, `[32m`, `[22m` noise instead of the colored / dimmed output the terminal would show.

This PR adds a small `AnsiOutput` component that:

- parses the text with [`anser`](https://github.com/IonicaBizau/anser) (~10KB, zero deps, no `dangerouslySetInnerHTML`)
- emits styled `<span>`s honoring foreground/background color, `dim`, `bold`, `italic`, `underline`, `strikethrough`
- preserves the existing visual container (`colorFillTertiary` background, `fontFamilyCode`, `maxHeight: 200` + scroll, `pre-wrap` wrapping)

Plain (no-ANSI) output renders as a single segment — no visual regression.

The `args.command` line keeps using `<Highlighter language={'sh'}>` since shell syntax highlighting is still desirable there.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Run any agent step that invokes a shell command producing ANSI output, e.g.:

```sh
agent-tracing inspect op_xxx 2>&1 | tail -15
```

Confirm the tree-drawing characters appear dimmed and `tool_calls` arrows / success ticks pick up their original colors instead of showing `[2m` / `[32m` literals.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Raw `[2m...[22m` escape sequences shown as text | Dim / colored output matching terminal rendering |

#### 📝 Additional Information

- New dep: `anser@2.3.5` added to `packages/shared-tool-ui` (private package, not shipped as standalone).
- No API / contract changes; consumers of `@lobechat/shared-tool-ui/renders` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)