### PR TITLE
✨ feat(llm-tracing): collect implicit feedback for follow-up chips and task briefs

### DIFF
--- a/apps/server/src/services/brief/index.test.ts
+++ b/apps/server/src/services/brief/index.test.ts
@@ -27,6 +27,13 @@ vi.mock('@/server/services/taskRunner', () => ({
   TaskRunnerService: vi.fn().mockImplementation(() => ({ cascadeOnCompletion })),
 }));
 
+// `recordBriefFeedback` dynamically imports the tracing service — stub it so we
+// can assert the action→signal mapping without a DB.
+const { recordFeedback } = vi.hoisted(() => ({ recordFeedback: vi.fn() }));
+vi.mock('@/server/services/llmGenerationTracing', () => ({
+  getLLMGenerationTracingService: () => ({ recordFeedback }),
+}));
+
 describe('BriefService', () => {
   const db = {} as LobeChatDatabase;
   const userId = 'user-1';
@@ -510,6 +517,87 @@ describe('BriefService', () => {
       await service.resolve('b7', { action: 'approve' });
 
       expect(mockTaskModel.updateStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resolve → implicit feedback', () => {
+    const briefWithTracing = (extra: Record<string, unknown>) => ({
+      id: 'b1',
+      metadata: { tracingId: 'trace-1' },
+      taskId: 'task-1',
+      type: 'decision',
+      ...extra,
+    });
+
+    it('reports a positive signal when a brief is approved', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue(briefWithTracing({ type: 'insight' }));
+
+      await service.resolve('b1', { action: 'approve' });
+
+      expect(recordFeedback).toHaveBeenCalledWith('user-1', 'trace-1', {
+        data: { briefType: 'insight', hasComment: false },
+        signal: 'positive',
+        source: 'brief_approved',
+      });
+    });
+
+    it('reports a negative signal carrying the comment flag for feedback actions', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue(briefWithTracing({}));
+
+      await service.resolve('b1', { action: 'feedback', comment: 'tighten it' });
+
+      expect(recordFeedback).toHaveBeenCalledWith('user-1', 'trace-1', {
+        data: { briefType: 'decision', hasComment: true },
+        signal: 'negative',
+        source: 'brief_feedback',
+      });
+    });
+
+    it('reports a negative signal for ignore', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue(briefWithTracing({}));
+
+      await service.resolve('b1', { action: 'ignore' });
+
+      expect(recordFeedback).toHaveBeenCalledWith(
+        'user-1',
+        'trace-1',
+        expect.objectContaining({ signal: 'negative', source: 'brief_ignored' }),
+      );
+    });
+
+    it('falls back to a neutral signal for ambiguous actions', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue(briefWithTracing({}));
+
+      await service.resolve('b1', { action: 'acknowledge' });
+
+      expect(recordFeedback).toHaveBeenCalledWith(
+        'user-1',
+        'trace-1',
+        expect.objectContaining({ signal: 'neutral', source: 'brief_acknowledge' }),
+      );
+    });
+
+    it('does not report feedback for briefs without a tracingId', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue({ id: 'b9', taskId: null, type: 'insight' });
+
+      await service.resolve('b9', { action: 'approve' });
+
+      expect(recordFeedback).not.toHaveBeenCalled();
+    });
+
+    it('never lets a tracing failure break brief resolution', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue(briefWithTracing({}));
+      recordFeedback.mockRejectedValueOnce(new Error('db down'));
+
+      const brief = await service.resolve('b1', { action: 'ignore' });
+
+      expect(brief).not.toBeNull();
     });
   });
 });

--- a/apps/server/src/services/brief/index.test.ts
+++ b/apps/server/src/services/brief/index.test.ts
@@ -27,6 +27,13 @@ vi.mock('@/server/services/taskRunner', () => ({
   TaskRunnerService: vi.fn().mockImplementation(() => ({ cascadeOnCompletion })),
 }));
 
+// `recordBriefFeedback` dynamically imports the tracing service — stub it so we
+// can assert the action→signal mapping without a DB.
+const { recordFeedback } = vi.hoisted(() => ({ recordFeedback: vi.fn() }));
+vi.mock('@/server/services/llmGenerationTracing', () => ({
+  getLLMGenerationTracingService: () => ({ recordFeedback }),
+}));
+
 describe('BriefService', () => {
   const db = {} as LobeChatDatabase;
   const userId = 'user-1';
@@ -548,6 +555,87 @@ describe('BriefService', () => {
       await service.resolve('b7', { action: 'approve' });
 
       expect(mockTaskModel.updateStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resolve → implicit feedback', () => {
+    const briefWithTracing = (extra: Record<string, unknown>) => ({
+      id: 'b1',
+      metadata: { tracingId: 'trace-1' },
+      taskId: 'task-1',
+      type: 'decision',
+      ...extra,
+    });
+
+    it('reports a positive signal when a brief is approved', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue(briefWithTracing({ type: 'insight' }));
+
+      await service.resolve('b1', { action: 'approve' });
+
+      expect(recordFeedback).toHaveBeenCalledWith('user-1', 'trace-1', {
+        data: { briefType: 'insight', hasComment: false },
+        signal: 'positive',
+        source: 'brief_approved',
+      });
+    });
+
+    it('reports a negative signal carrying the comment flag for feedback actions', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue(briefWithTracing({}));
+
+      await service.resolve('b1', { action: 'feedback', comment: 'tighten it' });
+
+      expect(recordFeedback).toHaveBeenCalledWith('user-1', 'trace-1', {
+        data: { briefType: 'decision', hasComment: true },
+        signal: 'negative',
+        source: 'brief_feedback',
+      });
+    });
+
+    it('reports a negative signal for ignore', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue(briefWithTracing({}));
+
+      await service.resolve('b1', { action: 'ignore' });
+
+      expect(recordFeedback).toHaveBeenCalledWith(
+        'user-1',
+        'trace-1',
+        expect.objectContaining({ signal: 'negative', source: 'brief_ignored' }),
+      );
+    });
+
+    it('falls back to a neutral signal for ambiguous actions', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue(briefWithTracing({}));
+
+      await service.resolve('b1', { action: 'acknowledge' });
+
+      expect(recordFeedback).toHaveBeenCalledWith(
+        'user-1',
+        'trace-1',
+        expect.objectContaining({ signal: 'neutral', source: 'brief_acknowledge' }),
+      );
+    });
+
+    it('does not report feedback for briefs without a tracingId', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue({ id: 'b9', taskId: null, type: 'insight' });
+
+      await service.resolve('b9', { action: 'approve' });
+
+      expect(recordFeedback).not.toHaveBeenCalled();
+    });
+
+    it('never lets a tracing failure break brief resolution', async () => {
+      const service = new BriefService(db, userId);
+      mockBriefModel.resolve.mockResolvedValue(briefWithTracing({}));
+      recordFeedback.mockRejectedValueOnce(new Error('db down'));
+
+      const brief = await service.resolve('b1', { action: 'ignore' });
+
+      expect(brief).not.toBeNull();
     });
   });
 });

--- a/apps/server/src/services/brief/index.test.ts
+++ b/apps/server/src/services/brief/index.test.ts
@@ -573,11 +573,16 @@ describe('BriefService', () => {
 
       await service.resolve('b1', { action: 'approve' });
 
-      expect(recordFeedback).toHaveBeenCalledWith('user-1', 'trace-1', {
-        data: { briefType: 'insight', hasComment: false },
-        signal: 'positive',
-        source: 'brief_approved',
-      });
+      expect(recordFeedback).toHaveBeenCalledWith(
+        'user-1',
+        'trace-1',
+        {
+          data: { briefType: 'insight', hasComment: false },
+          signal: 'positive',
+          source: 'brief_approved',
+        },
+        undefined,
+      );
     });
 
     it('reports a negative signal carrying the comment flag for feedback actions', async () => {
@@ -586,11 +591,16 @@ describe('BriefService', () => {
 
       await service.resolve('b1', { action: 'feedback', comment: 'tighten it' });
 
-      expect(recordFeedback).toHaveBeenCalledWith('user-1', 'trace-1', {
-        data: { briefType: 'decision', hasComment: true },
-        signal: 'negative',
-        source: 'brief_feedback',
-      });
+      expect(recordFeedback).toHaveBeenCalledWith(
+        'user-1',
+        'trace-1',
+        {
+          data: { briefType: 'decision', hasComment: true },
+          signal: 'negative',
+          source: 'brief_feedback',
+        },
+        undefined,
+      );
     });
 
     it('reports a negative signal for ignore', async () => {
@@ -603,6 +613,7 @@ describe('BriefService', () => {
         'user-1',
         'trace-1',
         expect.objectContaining({ signal: 'negative', source: 'brief_ignored' }),
+        undefined,
       );
     });
 
@@ -616,6 +627,21 @@ describe('BriefService', () => {
         'user-1',
         'trace-1',
         expect.objectContaining({ signal: 'neutral', source: 'brief_acknowledge' }),
+        undefined,
+      );
+    });
+
+    it('records feedback in the brief workspace scope', async () => {
+      const service = new BriefService(db, userId, 'workspace-1');
+      mockBriefModel.resolve.mockResolvedValue(briefWithTracing({}));
+
+      await service.resolve('b1', { action: 'approve' });
+
+      expect(recordFeedback).toHaveBeenCalledWith(
+        'user-1',
+        'trace-1',
+        expect.objectContaining({ signal: 'positive', source: 'brief_approved' }),
+        'workspace-1',
       );
     });
 

--- a/apps/server/src/services/brief/index.ts
+++ b/apps/server/src/services/brief/index.ts
@@ -251,6 +251,64 @@ export class BriefService {
       }
     }
 
+    // Implicit feedback for the LLM that synthesized this brief. Only briefs
+    // carrying a `tracingId` (task-synthesized ones) participate — others (e.g.
+    // signal briefs) simply have nothing to score.
+    await this.recordBriefFeedback(brief, options);
+
     return brief;
+  }
+
+  /**
+   * Translate the user's resolve action into a feedback signal against the
+   * brief's source generation. Fire-and-forget at the service boundary — a
+   * tracing write must never break brief resolution, so failures are swallowed.
+   */
+  private async recordBriefFeedback(
+    brief: BriefItem,
+    options?: BriefResolveOptions,
+  ): Promise<void> {
+    const tracingId = brief.metadata?.tracingId;
+    if (!tracingId) return;
+
+    const action = options?.action;
+    const { signal, source } = ((): {
+      signal: 'positive' | 'negative' | 'neutral';
+      source: string;
+    } => {
+      switch (action) {
+        case 'approve': {
+          return { signal: 'positive', source: 'brief_approved' };
+        }
+        case 'feedback': {
+          return { signal: 'negative', source: 'brief_feedback' };
+        }
+        case 'ignore': {
+          return { signal: 'negative', source: 'brief_ignored' };
+        }
+        // acknowledge / retry / dismiss / unknown — neither a clear accept nor
+        // reject of the brief's content.
+        default: {
+          return { signal: 'neutral', source: `brief_${action ?? 'resolved'}` };
+        }
+      }
+    })();
+
+    try {
+      // Lazy-load to keep the tracing service out of BriefService's static
+      // import graph, mirroring the TaskRunner lazy-import above.
+      const { getLLMGenerationTracingService } =
+        await import('@/server/services/llmGenerationTracing');
+      await getLLMGenerationTracingService().recordFeedback(this.userId, tracingId, {
+        data: {
+          briefType: brief.type,
+          hasComment: !!options?.comment,
+        },
+        signal,
+        source,
+      });
+    } catch (error) {
+      console.warn('[brief:resolve] recordFeedback failed', error);
+    }
   }
 }

--- a/apps/server/src/services/brief/index.ts
+++ b/apps/server/src/services/brief/index.ts
@@ -299,14 +299,19 @@ export class BriefService {
       // import graph, mirroring the TaskRunner lazy-import above.
       const { getLLMGenerationTracingService } =
         await import('@/server/services/llmGenerationTracing');
-      await getLLMGenerationTracingService().recordFeedback(this.userId, tracingId, {
-        data: {
-          briefType: brief.type,
-          hasComment: !!options?.comment,
+      await getLLMGenerationTracingService().recordFeedback(
+        this.userId,
+        tracingId,
+        {
+          data: {
+            briefType: brief.type,
+            hasComment: !!options?.comment,
+          },
+          signal,
+          source,
         },
-        signal,
-        source,
-      });
+        this.workspaceId,
+      );
     } catch (error) {
       console.warn('[brief:resolve] recordFeedback failed', error);
     }

--- a/apps/server/src/services/brief/index.ts
+++ b/apps/server/src/services/brief/index.ts
@@ -215,6 +215,62 @@ export class BriefService {
       }
     }
 
+    // Implicit feedback for the LLM that synthesized this brief. Only briefs
+    // carrying a `tracingId` (task-synthesized ones) participate — others (e.g.
+    // signal briefs) simply have nothing to score.
+    await this.recordBriefFeedback(brief, options);
+
     return brief;
+  }
+
+  /**
+   * Translate the user's resolve action into a feedback signal against the
+   * brief's source generation. Fire-and-forget at the service boundary — a
+   * tracing write must never break brief resolution, so failures are swallowed.
+   */
+  private async recordBriefFeedback(brief: BriefItem, options?: BriefResolveOptions): Promise<void> {
+    const tracingId = brief.metadata?.tracingId;
+    if (!tracingId) return;
+
+    const action = options?.action;
+    const { signal, source } = ((): {
+      signal: 'positive' | 'negative' | 'neutral';
+      source: string;
+    } => {
+      switch (action) {
+        case 'approve': {
+          return { signal: 'positive', source: 'brief_approved' };
+        }
+        case 'feedback': {
+          return { signal: 'negative', source: 'brief_feedback' };
+        }
+        case 'ignore': {
+          return { signal: 'negative', source: 'brief_ignored' };
+        }
+        // acknowledge / retry / dismiss / unknown — neither a clear accept nor
+        // reject of the brief's content.
+        default: {
+          return { signal: 'neutral', source: `brief_${action ?? 'resolved'}` };
+        }
+      }
+    })();
+
+    try {
+      // Lazy-load to keep the tracing service out of BriefService's static
+      // import graph, mirroring the TaskRunner lazy-import above.
+      const { getLLMGenerationTracingService } = await import(
+        '@/server/services/llmGenerationTracing'
+      );
+      await getLLMGenerationTracingService().recordFeedback(this.userId, tracingId, {
+        data: {
+          briefType: brief.type,
+          hasComment: !!options?.comment,
+        },
+        signal,
+        source,
+      });
+    } catch (error) {
+      console.warn('[brief:resolve] recordFeedback failed', error);
+    }
   }
 }

--- a/apps/server/src/services/followUpAction/index.test.ts
+++ b/apps/server/src/services/followUpAction/index.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as ModelRuntimeModule from '@/server/modules/ModelRuntime';
+import * as TracingServiceModule from '@/server/services/llmGenerationTracing';
 
 import { FollowUpActionService } from './index';
 
@@ -218,6 +219,35 @@ describe('FollowUpActionService.extract', () => {
       MODEL_CONFIG.provider,
       'workspace-1',
     );
+  });
+
+  const mockTracingEnabled = (enabled: boolean) =>
+    vi
+      .spyOn(TracingServiceModule, 'getLLMGenerationTracingService')
+      .mockReturnValue({ isEnabled: () => enabled } as any);
+
+  it('returns a tracingId when the tracing store is enabled', async () => {
+    mockTracingEnabled(true);
+    queryFindFirstSpy.mockResolvedValue({ id: FOUND_MSG, content: 'q?' });
+    runtimeMock.generateObject.mockResolvedValue({ chips: [{ label: 'ok', message: 'ok' }] });
+
+    const result = await svc.extract({ modelConfig: MODEL_CONFIG, topicId: TEST_TOPIC });
+
+    expect(typeof result.tracingId).toBe('string');
+    // The id handed to the client must be the same one passed to the tracing hook.
+    expect(runtimeMock.generateObject.mock.calls[0][1].tracing.tracingId).toBe(result.tracingId);
+  });
+
+  it('omits the tracingId when the tracing store is disabled (no row would exist)', async () => {
+    mockTracingEnabled(false);
+    queryFindFirstSpy.mockResolvedValue({ id: FOUND_MSG, content: 'q?' });
+    runtimeMock.generateObject.mockResolvedValue({ chips: [{ label: 'ok', message: 'ok' }] });
+
+    const result = await svc.extract({ modelConfig: MODEL_CONFIG, topicId: TEST_TOPIC });
+
+    expect(result.chips).toHaveLength(1);
+    expect(result.tracingId).toBeUndefined();
+    expect(runtimeMock.generateObject.mock.calls[0][1].tracing.tracingId).toBeUndefined();
   });
 
   it('appends onboarding addendum to system prompt when hint is onboarding', async () => {

--- a/apps/server/src/services/followUpAction/index.test.ts
+++ b/apps/server/src/services/followUpAction/index.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as ModelRuntimeModule from '@/server/modules/ModelRuntime';
+import * as TracingServiceModule from '@/server/services/llmGenerationTracing';
 
 import { FollowUpActionService } from './index';
 
@@ -220,6 +221,35 @@ describe('FollowUpActionService.extract', () => {
       MODEL_CONFIG.provider,
       'workspace-1',
     );
+  });
+
+  const mockTracingEnabled = (enabled: boolean) =>
+    vi
+      .spyOn(TracingServiceModule, 'getLLMGenerationTracingService')
+      .mockReturnValue({ isEnabled: () => enabled } as any);
+
+  it('returns a tracingId when the tracing store is enabled', async () => {
+    mockTracingEnabled(true);
+    queryFindFirstSpy.mockResolvedValue({ id: FOUND_MSG, content: 'q?' });
+    runtimeMock.generateObject.mockResolvedValue({ chips: [{ label: 'ok', message: 'ok' }] });
+
+    const result = await svc.extract({ modelConfig: MODEL_CONFIG, topicId: TEST_TOPIC });
+
+    expect(typeof result.tracingId).toBe('string');
+    // The id handed to the client must be the same one passed to the tracing hook.
+    expect(runtimeMock.generateObject.mock.calls[0][1].tracing.tracingId).toBe(result.tracingId);
+  });
+
+  it('omits the tracingId when the tracing store is disabled (no row would exist)', async () => {
+    mockTracingEnabled(false);
+    queryFindFirstSpy.mockResolvedValue({ id: FOUND_MSG, content: 'q?' });
+    runtimeMock.generateObject.mockResolvedValue({ chips: [{ label: 'ok', message: 'ok' }] });
+
+    const result = await svc.extract({ modelConfig: MODEL_CONFIG, topicId: TEST_TOPIC });
+
+    expect(result.chips).toHaveLength(1);
+    expect(result.tracingId).toBeUndefined();
+    expect(runtimeMock.generateObject.mock.calls[0][1].tracing.tracingId).toBeUndefined();
   });
 
   it('appends onboarding addendum to system prompt when hint is onboarding', async () => {

--- a/apps/server/src/services/followUpAction/index.ts
+++ b/apps/server/src/services/followUpAction/index.ts
@@ -7,6 +7,7 @@ import debug from 'debug';
 
 import type { LobeChatDatabase } from '@/database/type';
 import { AiGenerationService } from '@/server/services/aiGeneration';
+import { getLLMGenerationTracingService } from '@/server/services/llmGenerationTracing';
 
 import { buildSuggestionPrompt, FOLLOW_UP_PROMPT_VERSION } from './prompts';
 import { RawResponseSchema, SUGGESTION_RESPONSE_JSON_SCHEMA } from './schema';
@@ -64,7 +65,12 @@ export class FollowUpActionService {
     // Pre-allocate the tracing row id so it can be returned to the client
     // synchronously — the client holds it for the chip's lifetime to report a
     // click (positive) / dismissal (negative) back via `recordFeedback`.
-    const tracingId = randomUUID();
+    //
+    // Gate on the tracing store actually being configured: when it isn't (e.g.
+    // prod without ENABLE_LLM_GENERATION_TRACING_S3), the tracing hook is a
+    // no-op and never inserts a row, so handing the client an id would make
+    // every feedback call resolve to NOT_FOUND.
+    const tracingId = getLLMGenerationTracingService().isEnabled() ? randomUUID() : undefined;
     let raw: unknown;
     try {
       raw = await ai.generateObject(
@@ -108,9 +114,9 @@ export class FollowUpActionService {
       )
       .slice(0, 4);
 
-    // Only surface the tracingId when chips actually rendered — an empty result
-    // gives the user nothing to act on, so there's no feedback to collect.
-    return chips.length > 0
+    // Only surface the tracingId when chips actually rendered (nothing to act
+    // on otherwise) AND tracing is enabled (a row exists to attach feedback to).
+    return chips.length > 0 && tracingId
       ? { chips, messageId: row.id, tracingId }
       : { chips, messageId: row.id };
   }

--- a/apps/server/src/services/followUpAction/index.ts
+++ b/apps/server/src/services/followUpAction/index.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { TRACING_SCENARIOS } from '@lobechat/const';
 import type { TracingOptions } from '@lobechat/llm-generation-tracing';
 import type { FollowUpChip, FollowUpExtractInput, FollowUpExtractResult } from '@lobechat/types';
@@ -59,6 +61,10 @@ export class FollowUpActionService {
     const { model, provider } = modelConfig;
 
     const ai = new AiGenerationService(this.db, this.userId, this.workspaceId);
+    // Pre-allocate the tracing row id so it can be returned to the client
+    // synchronously — the client holds it for the chip's lifetime to report a
+    // click (positive) / dismissal (negative) back via `recordFeedback`.
+    const tracingId = randomUUID();
     let raw: unknown;
     try {
       raw = await ai.generateObject(
@@ -77,6 +83,7 @@ export class FollowUpActionService {
             scenario: TRACING_SCENARIOS.FollowUp,
             schemaName: 'FollowUpSuggestionResponse',
             topicId,
+            tracingId,
           } satisfies TracingOptions,
         },
       );
@@ -101,6 +108,10 @@ export class FollowUpActionService {
       )
       .slice(0, 4);
 
-    return { chips, messageId: row.id };
+    // Only surface the tracingId when chips actually rendered — an empty result
+    // gives the user nothing to act on, so there's no feedback to collect.
+    return chips.length > 0
+      ? { chips, messageId: row.id, tracingId }
+      : { chips, messageId: row.id };
   }
 }

--- a/apps/server/src/services/followUpAction/index.ts
+++ b/apps/server/src/services/followUpAction/index.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { TRACING_SCENARIOS } from '@lobechat/const';
 import type { TracingOptions } from '@lobechat/llm-generation-tracing';
 import {
@@ -63,6 +65,10 @@ export class FollowUpActionService {
     const { model, provider } = modelConfig;
 
     const ai = new AiGenerationService(this.db, this.userId, this.workspaceId);
+    // Pre-allocate the tracing row id so it can be returned to the client
+    // synchronously — the client holds it for the chip's lifetime to report a
+    // click (positive) / dismissal (negative) back via `recordFeedback`.
+    const tracingId = randomUUID();
     let raw: unknown;
     try {
       raw = await ai.generateObject(
@@ -78,6 +84,7 @@ export class FollowUpActionService {
             scenario: TRACING_SCENARIOS.FollowUp,
             schemaName: FOLLOW_UP_JSON_SCHEMA.name,
             topicId,
+            tracingId,
           } satisfies TracingOptions,
         },
       );
@@ -102,6 +109,10 @@ export class FollowUpActionService {
       )
       .slice(0, 4);
 
-    return { chips, messageId: row.id };
+    // Only surface the tracingId when chips actually rendered — an empty result
+    // gives the user nothing to act on, so there's no feedback to collect.
+    return chips.length > 0
+      ? { chips, messageId: row.id, tracingId }
+      : { chips, messageId: row.id };
   }
 }

--- a/apps/server/src/services/followUpAction/index.ts
+++ b/apps/server/src/services/followUpAction/index.ts
@@ -12,6 +12,7 @@ import debug from 'debug';
 
 import type { LobeChatDatabase } from '@/database/type';
 import { AiGenerationService } from '@/server/services/aiGeneration';
+import { getLLMGenerationTracingService } from '@/server/services/llmGenerationTracing';
 
 import { RawResponseSchema } from './schema';
 
@@ -68,7 +69,12 @@ export class FollowUpActionService {
     // Pre-allocate the tracing row id so it can be returned to the client
     // synchronously — the client holds it for the chip's lifetime to report a
     // click (positive) / dismissal (negative) back via `recordFeedback`.
-    const tracingId = randomUUID();
+    //
+    // Gate on the tracing store actually being configured: when it isn't (e.g.
+    // prod without ENABLE_LLM_GENERATION_TRACING_S3), the tracing hook is a
+    // no-op and never inserts a row, so handing the client an id would make
+    // every feedback call resolve to NOT_FOUND.
+    const tracingId = getLLMGenerationTracingService().isEnabled() ? randomUUID() : undefined;
     let raw: unknown;
     try {
       raw = await ai.generateObject(
@@ -109,9 +115,9 @@ export class FollowUpActionService {
       )
       .slice(0, 4);
 
-    // Only surface the tracingId when chips actually rendered — an empty result
-    // gives the user nothing to act on, so there's no feedback to collect.
-    return chips.length > 0
+    // Only surface the tracingId when chips actually rendered (nothing to act
+    // on otherwise) AND tracing is enabled (a row exists to attach feedback to).
+    return chips.length > 0 && tracingId
       ? { chips, messageId: row.id, tracingId }
       : { chips, messageId: row.id };
   }

--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -43,6 +43,7 @@ import { VerifyRunModel } from '@/database/models/verifyRun';
 import type { LobeChatDatabase } from '@/database/type';
 import { translation } from '@/libs/i18n/serverTranslation';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
+import { getLLMGenerationTracingService } from '@/server/services/llmGenerationTracing';
 import { SystemAgentService } from '@/server/services/systemAgent';
 import { TaskResultBridgeService } from '@/server/services/taskResultBridge';
 import { createTaskSchedulerModule } from '@/server/services/taskScheduler';
@@ -978,7 +979,13 @@ export class TaskLifecycleService {
       // Pre-allocate the tracing row id so it can be stamped onto the brief —
       // the user's later resolve action (approve / feedback / ignore) is then
       // reported back as implicit feedback against this exact generation.
-      const briefTracingId = randomUUID();
+      //
+      // Gate on tracing being enabled: with no store configured the hook never
+      // writes a row, so stamping an id would make every resolve's feedback
+      // call resolve to NOT_FOUND.
+      const briefTracingId = getLLMGenerationTracingService().isEnabled()
+        ? randomUUID()
+        : undefined;
       const result = await modelRuntime.generateObject(
         {
           messages: payload.messages as any[],
@@ -1015,7 +1022,7 @@ export class TaskLifecycleService {
         actions,
         agentId: currentTask.assigneeAgentId || undefined,
         artifacts,
-        metadata: { tracingId: briefTracingId },
+        metadata: briefTracingId ? { tracingId: briefTracingId } : undefined,
         priority,
         summary: generated.summary,
         taskId,

--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -975,6 +975,10 @@ export class TaskLifecycleService {
         provider,
         this.workspaceId,
       );
+      // Pre-allocate the tracing row id so it can be stamped onto the brief —
+      // the user's later resolve action (approve / feedback / ignore) is then
+      // reported back as implicit feedback against this exact generation.
+      const briefTracingId = randomUUID();
       const result = await modelRuntime.generateObject(
         {
           messages: payload.messages as any[],
@@ -987,6 +991,8 @@ export class TaskLifecycleService {
             promptVersion: GENERATE_BRIEF_PROMPT_VERSION,
             scenario: TRACING_SCENARIOS.TaskBrief,
             schemaName: GENERATE_BRIEF_SCHEMA_NAME,
+            topicId,
+            tracingId: briefTracingId,
           } satisfies TracingOptions,
         },
       );
@@ -1009,6 +1015,7 @@ export class TaskLifecycleService {
         actions,
         agentId: currentTask.assigneeAgentId || undefined,
         artifacts,
+        metadata: { tracingId: briefTracingId },
         priority,
         summary: generated.summary,
         taskId,

--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { TRACING_SCENARIOS } from '@lobechat/const';
 import type { TracingOptions } from '@lobechat/llm-generation-tracing';
 import {
@@ -735,6 +737,10 @@ export class TaskLifecycleService {
         provider,
         this.workspaceId,
       );
+      // Pre-allocate the tracing row id so it can be stamped onto the brief —
+      // the user's later resolve action (approve / feedback / ignore) is then
+      // reported back as implicit feedback against this exact generation.
+      const briefTracingId = randomUUID();
       const result = await modelRuntime.generateObject(
         {
           messages: payload.messages as any[],
@@ -747,6 +753,8 @@ export class TaskLifecycleService {
             promptVersion: GENERATE_BRIEF_PROMPT_VERSION,
             scenario: TRACING_SCENARIOS.TaskBrief,
             schemaName: GENERATE_BRIEF_SCHEMA_NAME,
+            topicId,
+            tracingId: briefTracingId,
           } satisfies TracingOptions,
         },
       );
@@ -769,6 +777,7 @@ export class TaskLifecycleService {
         actions,
         agentId: currentTask.assigneeAgentId || undefined,
         artifacts,
+        metadata: { tracingId: briefTracingId },
         priority,
         summary: generated.summary,
         taskId,

--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -35,6 +35,7 @@ import { TopicModel } from '@/database/models/topic';
 import { VerifyRunModel } from '@/database/models/verifyRun';
 import type { LobeChatDatabase } from '@/database/type';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
+import { getLLMGenerationTracingService } from '@/server/services/llmGenerationTracing';
 import { SystemAgentService } from '@/server/services/systemAgent';
 import { TaskResultBridgeService } from '@/server/services/taskResultBridge';
 import { createTaskSchedulerModule } from '@/server/services/taskScheduler';
@@ -740,7 +741,13 @@ export class TaskLifecycleService {
       // Pre-allocate the tracing row id so it can be stamped onto the brief —
       // the user's later resolve action (approve / feedback / ignore) is then
       // reported back as implicit feedback against this exact generation.
-      const briefTracingId = randomUUID();
+      //
+      // Gate on tracing being enabled: with no store configured the hook never
+      // writes a row, so stamping an id would make every resolve's feedback
+      // call resolve to NOT_FOUND.
+      const briefTracingId = getLLMGenerationTracingService().isEnabled()
+        ? randomUUID()
+        : undefined;
       const result = await modelRuntime.generateObject(
         {
           messages: payload.messages as any[],
@@ -777,7 +784,7 @@ export class TaskLifecycleService {
         actions,
         agentId: currentTask.assigneeAgentId || undefined,
         artifacts,
-        metadata: { tracingId: briefTracingId },
+        metadata: briefTracingId ? { tracingId: briefTracingId } : undefined,
         priority,
         summary: generated.summary,
         taskId,

--- a/packages/types/src/brief/index.ts
+++ b/packages/types/src/brief/index.ts
@@ -64,4 +64,10 @@ export interface BriefMetadata {
   [key: string]: unknown;
   /** Agent Signal extension metadata. */
   agentSignal?: BriefAgentSignalMetadata;
+  /**
+   * `llm_generation_tracing` row id of the generation that produced this brief's
+   * title/summary. Set for LLM-synthesized briefs so the user's resolve action
+   * (approve / feedback / ignore) can be reported back as implicit feedback.
+   */
+  tracingId?: string;
 }

--- a/packages/types/src/brief/index.ts
+++ b/packages/types/src/brief/index.ts
@@ -71,4 +71,10 @@ export interface BriefMetadata {
   [key: string]: unknown;
   /** Agent Signal extension metadata. */
   agentSignal?: BriefAgentSignalMetadata;
+  /**
+   * `llm_generation_tracing` row id of the generation that produced this brief's
+   * title/summary. Set for LLM-synthesized briefs so the user's resolve action
+   * (approve / feedback / ignore) can be reported back as implicit feedback.
+   */
+  tracingId?: string;
 }

--- a/packages/types/src/followUpAction.ts
+++ b/packages/types/src/followUpAction.ts
@@ -27,6 +27,13 @@ export interface FollowUpExtractResult {
   chips: FollowUpChip[];
   /** Resolved server-side id of the assistant message the chips were extracted from. Empty string if no eligible message was found. */
   messageId: string;
+  /**
+   * `llm_generation_tracing` row id for this chip generation. Present only when
+   * chips were actually generated. The client holds it for the chip's lifetime
+   * so a click (positive) or dismissal (negative) can be reported back via
+   * `llmGenerationTracing.recordFeedback`.
+   */
+  tracingId?: string;
 }
 
 export const FollowUpHintSchema = z.union([

--- a/src/features/Conversation/FollowUp/FollowUpChips.tsx
+++ b/src/features/Conversation/FollowUp/FollowUpChips.tsx
@@ -25,6 +25,7 @@ const FollowUpChips = memo<FollowUpChipsProps>(({ conversationKey, messageId }) 
     [childIdsKey, conversationKey, messageId],
   );
   const chips = useFollowUpActionStore(selector);
+  const recordChipClick = useFollowUpActionStore((s) => s.recordChipClick);
   const updateInputMessage = useConversationStore((s) => s.updateInputMessage);
   const editor = useConversationStore((s) => s.editor);
   const isGenerating = useConversationStore(
@@ -32,14 +33,15 @@ const FollowUpChips = memo<FollowUpChipsProps>(({ conversationKey, messageId }) 
   );
 
   const handleClick = useCallback(
-    (chip: FollowUpChip) => {
+    (chip: FollowUpChip, chipIndex: number) => {
+      recordChipClick(conversationKey, chipIndex);
       updateInputMessage('');
       editor?.setDocument('text', '');
       updateInputMessage(chip.message);
       editor?.setDocument('text', chip.message);
       editor?.focus();
     },
-    [updateInputMessage, editor],
+    [recordChipClick, conversationKey, updateInputMessage, editor],
   );
 
   if (chips.length === 0 || isGenerating) return null;
@@ -53,7 +55,7 @@ const FollowUpChips = memo<FollowUpChipsProps>(({ conversationKey, messageId }) 
           key={`${messageId}-${i}`}
           style={{ animationDelay: `${i * 60}ms` }}
           type="button"
-          onClick={() => handleClick(chip)}
+          onClick={() => handleClick(chip, i)}
         >
           <Reply className={`${styles.chipIcon} followup-icon`} size={14} />
           <span>{chip.label}</span>

--- a/src/features/Conversation/FollowUp/FollowUpChips.tsx
+++ b/src/features/Conversation/FollowUp/FollowUpChips.tsx
@@ -25,15 +25,17 @@ const FollowUpChips = memo<FollowUpChipsProps>(({ conversationKey, messageId }) 
   );
   const chips = useFollowUpActionStore(selector);
   const fillInputMessage = useConversationStore((s) => s.fillInputMessage);
+  const recordChipClick = useFollowUpActionStore((s) => s.recordChipClick);
   const isGenerating = useConversationStore(
     messageStateSelectors.isAssistantGroupItemGenerating(messageId),
   );
 
   const handleClick = useCallback(
-    (chip: FollowUpChip) => {
+    (chip: FollowUpChip, chipIndex: number) => {
+      recordChipClick(conversationKey, chipIndex);
       fillInputMessage(chip.message);
     },
-    [fillInputMessage],
+    [recordChipClick, conversationKey, fillInputMessage],
   );
 
   if (chips.length === 0 || isGenerating) return null;
@@ -47,7 +49,7 @@ const FollowUpChips = memo<FollowUpChipsProps>(({ conversationKey, messageId }) 
           key={`${messageId}-${i}`}
           style={{ animationDelay: `${i * 60}ms` }}
           type="button"
-          onClick={() => handleClick(chip)}
+          onClick={() => handleClick(chip, i)}
         >
           <Reply className={`${styles.chipIcon} followup-icon`} size={14} />
           <span>{chip.label}</span>

--- a/src/store/followUpAction/action.ts
+++ b/src/store/followUpAction/action.ts
@@ -1,5 +1,6 @@
 import type { FollowUpChip, FollowUpHint, FollowUpModelConfig } from '@lobechat/types';
 
+import { aiChatService } from '@/services/aiChat';
 import { followUpActionService } from '@/services/followUpAction';
 import { type StoreSetter } from '@/store/types';
 
@@ -72,6 +73,10 @@ export class FollowUpActionImpl {
     const existing = this.#get().slots[conversationKey];
     if (existing?.status === 'loading') return;
 
+    // A ready-but-unacted chip set being replaced by a new turn is a dismissal.
+    // (Normally `onBeforeSendMessage` clears first, so this is a belt-and-braces
+    // guard for paths that fetch without an explicit clear.)
+    this.#maybeRecordDismissal(existing);
     existing?.abortController?.abort();
 
     const controller = new AbortController();
@@ -116,6 +121,7 @@ export class FollowUpActionImpl {
         chips: result.chips,
         messageId: result.messageId,
         status: 'ready',
+        tracingId: result.tracingId,
       },
       'fetchFor:ready',
     );
@@ -124,6 +130,7 @@ export class FollowUpActionImpl {
   abort = (conversationKey: string): void => {
     const slot = this.#get().slots[conversationKey];
     if (!slot) return;
+    this.#maybeRecordDismissal(slot);
     slot.abortController?.abort();
     writeSlot(this.#set, conversationKey, { ...IDLE_SLOT }, 'abort');
   };
@@ -131,6 +138,7 @@ export class FollowUpActionImpl {
   clear = (conversationKey: string): void => {
     const slot = this.#get().slots[conversationKey];
     if (!slot) return;
+    this.#maybeRecordDismissal(slot);
     slot.abortController?.abort();
     removeSlot(this.#set, conversationKey, 'clear');
   };
@@ -138,6 +146,47 @@ export class FollowUpActionImpl {
   consume = (conversationKey: string, chip: FollowUpChip): void => {
     void chip;
     this.clear(conversationKey);
+  };
+
+  /**
+   * Report that the user clicked a chip — a positive feedback signal for the
+   * generated suggestion set. Marks the slot so the subsequent clear-on-send
+   * doesn't additionally fire a dismissal for the same chips.
+   */
+  recordChipClick = (conversationKey: string, chipIndex: number): void => {
+    const slot = this.#get().slots[conversationKey];
+    if (!slot || slot.status !== 'ready' || !slot.tracingId || slot.feedbackDone) return;
+
+    void aiChatService
+      .recordTracingFeedback({
+        data: { chipIndex, totalChips: slot.chips.length },
+        signal: 'positive',
+        source: 'followup_clicked',
+        tracingId: slot.tracingId,
+      })
+      .catch((err) => console.warn('[FollowUp] recordFeedback (clicked) failed', err));
+
+    writeSlot(this.#set, conversationKey, { ...slot, feedbackDone: true }, 'recordChipClick');
+  };
+
+  /**
+   * Fire a `negative` dismissal for a chip set the user saw but never clicked —
+   * the suggestions weren't compelling. Together with `followup_clicked` this
+   * makes chip click-through-rate computable per prompt version. No-op unless
+   * the slot was actually shown (`ready`), carries a tracingId, and hasn't
+   * already produced a click signal.
+   */
+  #maybeRecordDismissal = (slot: FollowUpActionSlot | undefined): void => {
+    if (!slot || slot.status !== 'ready' || !slot.tracingId || slot.feedbackDone) return;
+
+    void aiChatService
+      .recordTracingFeedback({
+        data: { totalChips: slot.chips.length },
+        signal: 'negative',
+        source: 'followup_dismissed',
+        tracingId: slot.tracingId,
+      })
+      .catch((err) => console.warn('[FollowUp] recordFeedback (dismissed) failed', err));
   };
 }
 

--- a/src/store/followUpAction/index.test.ts
+++ b/src/store/followUpAction/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { aiChatService } from '@/services/aiChat';
 import { followUpActionService } from '@/services/followUpAction';
 
 import { followUpActionSelectors } from './selectors';
@@ -213,6 +214,86 @@ describe('useFollowUpActionStore', () => {
     useFollowUpActionStore.getState().reset();
     expect(signals.every((s) => s.aborted)).toBe(true);
     expect(useFollowUpActionStore.getState().slots).toEqual({});
+  });
+});
+
+describe('follow-up implicit feedback', () => {
+  const TRACING_ID = 'tracing-1';
+  const readySlot = (extra?: Record<string, unknown>) => ({
+    chips: [{ label: 'x', message: 'hello' }],
+    messageId: MSG,
+    status: 'ready' as const,
+    tracingId: TRACING_ID,
+    ...extra,
+  });
+
+  beforeEach(() => {
+    useFollowUpActionStore.getState().reset?.();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetchFor stores the tracingId returned by the service', async () => {
+    vi.spyOn(followUpActionService, 'extract').mockResolvedValue({
+      chips: [{ label: 'a', message: 'a' }],
+      messageId: MSG,
+      tracingId: TRACING_ID,
+    });
+    await useFollowUpActionStore.getState().fetchFor(KEY_A, FETCH_PARAMS_A);
+    expect(slotA().tracingId).toBe(TRACING_ID);
+  });
+
+  it('recordChipClick reports a positive signal and marks the slot done', () => {
+    const spy = vi.spyOn(aiChatService, 'recordTracingFeedback').mockResolvedValue({ ok: true });
+    useFollowUpActionStore.setState({ slots: { [KEY_A]: readySlot() } });
+
+    useFollowUpActionStore.getState().recordChipClick(KEY_A, 2);
+
+    expect(spy).toHaveBeenCalledWith({
+      data: { chipIndex: 2, totalChips: 1 },
+      signal: 'positive',
+      source: 'followup_clicked',
+      tracingId: TRACING_ID,
+    });
+    expect(slotA().feedbackDone).toBe(true);
+  });
+
+  it('clear reports a dismissal for a shown-but-unacted chip set', () => {
+    const spy = vi.spyOn(aiChatService, 'recordTracingFeedback').mockResolvedValue({ ok: true });
+    useFollowUpActionStore.setState({ slots: { [KEY_A]: readySlot() } });
+
+    useFollowUpActionStore.getState().clear(KEY_A);
+
+    expect(spy).toHaveBeenCalledWith({
+      data: { totalChips: 1 },
+      signal: 'negative',
+      source: 'followup_dismissed',
+      tracingId: TRACING_ID,
+    });
+  });
+
+  it('a click followed by clear does not double-report (no dismissal after click)', () => {
+    const spy = vi.spyOn(aiChatService, 'recordTracingFeedback').mockResolvedValue({ ok: true });
+    useFollowUpActionStore.setState({ slots: { [KEY_A]: readySlot() } });
+
+    useFollowUpActionStore.getState().recordChipClick(KEY_A, 0);
+    useFollowUpActionStore.getState().clear(KEY_A);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ signal: 'positive' }));
+  });
+
+  it('does not report feedback when the slot carries no tracingId', () => {
+    const spy = vi.spyOn(aiChatService, 'recordTracingFeedback').mockResolvedValue({ ok: true });
+    useFollowUpActionStore.setState({
+      slots: { [KEY_A]: { chips: [{ label: 'x', message: 'h' }], messageId: MSG, status: 'ready' } },
+    });
+
+    useFollowUpActionStore.getState().recordChipClick(KEY_A, 0);
+    useFollowUpActionStore.getState().clear(KEY_A);
+
+    expect(spy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/store/followUpAction/index.test.ts
+++ b/src/store/followUpAction/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { aiChatService } from '@/services/aiChat';
 import { followUpActionService } from '@/services/followUpAction';
 
 import { followUpActionSelectors } from './selectors';
@@ -213,6 +214,88 @@ describe('useFollowUpActionStore', () => {
     useFollowUpActionStore.getState().reset();
     expect(signals.every((s) => s.aborted)).toBe(true);
     expect(useFollowUpActionStore.getState().slots).toEqual({});
+  });
+});
+
+describe('follow-up implicit feedback', () => {
+  const TRACING_ID = 'tracing-1';
+  const readySlot = (extra?: Record<string, unknown>) => ({
+    chips: [{ label: 'x', message: 'hello' }],
+    messageId: MSG,
+    status: 'ready' as const,
+    tracingId: TRACING_ID,
+    ...extra,
+  });
+
+  beforeEach(() => {
+    useFollowUpActionStore.getState().reset?.();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetchFor stores the tracingId returned by the service', async () => {
+    vi.spyOn(followUpActionService, 'extract').mockResolvedValue({
+      chips: [{ label: 'a', message: 'a' }],
+      messageId: MSG,
+      tracingId: TRACING_ID,
+    });
+    await useFollowUpActionStore.getState().fetchFor(KEY_A, FETCH_PARAMS_A);
+    expect(slotA().tracingId).toBe(TRACING_ID);
+  });
+
+  it('recordChipClick reports a positive signal and marks the slot done', () => {
+    const spy = vi.spyOn(aiChatService, 'recordTracingFeedback').mockResolvedValue({ ok: true });
+    useFollowUpActionStore.setState({ slots: { [KEY_A]: readySlot() } });
+
+    useFollowUpActionStore.getState().recordChipClick(KEY_A, 2);
+
+    expect(spy).toHaveBeenCalledWith({
+      data: { chipIndex: 2, totalChips: 1 },
+      signal: 'positive',
+      source: 'followup_clicked',
+      tracingId: TRACING_ID,
+    });
+    expect(slotA().feedbackDone).toBe(true);
+  });
+
+  it('clear reports a dismissal for a shown-but-unacted chip set', () => {
+    const spy = vi.spyOn(aiChatService, 'recordTracingFeedback').mockResolvedValue({ ok: true });
+    useFollowUpActionStore.setState({ slots: { [KEY_A]: readySlot() } });
+
+    useFollowUpActionStore.getState().clear(KEY_A);
+
+    expect(spy).toHaveBeenCalledWith({
+      data: { totalChips: 1 },
+      signal: 'negative',
+      source: 'followup_dismissed',
+      tracingId: TRACING_ID,
+    });
+  });
+
+  it('a click followed by clear does not double-report (no dismissal after click)', () => {
+    const spy = vi.spyOn(aiChatService, 'recordTracingFeedback').mockResolvedValue({ ok: true });
+    useFollowUpActionStore.setState({ slots: { [KEY_A]: readySlot() } });
+
+    useFollowUpActionStore.getState().recordChipClick(KEY_A, 0);
+    useFollowUpActionStore.getState().clear(KEY_A);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ signal: 'positive' }));
+  });
+
+  it('does not report feedback when the slot carries no tracingId', () => {
+    const spy = vi.spyOn(aiChatService, 'recordTracingFeedback').mockResolvedValue({ ok: true });
+    useFollowUpActionStore.setState({
+      slots: {
+        [KEY_A]: { chips: [{ label: 'x', message: 'h' }], messageId: MSG, status: 'ready' },
+      },
+    });
+
+    useFollowUpActionStore.getState().recordChipClick(KEY_A, 0);
+    useFollowUpActionStore.getState().clear(KEY_A);
+
+    expect(spy).not.toHaveBeenCalled();
   });
 });
 

--- a/src/store/followUpAction/initialState.ts
+++ b/src/store/followUpAction/initialState.ts
@@ -6,8 +6,12 @@ export type FollowUpActionStatus = 'idle' | 'loading' | 'ready';
 export interface FollowUpActionSlot {
   abortController?: AbortController;
   chips: FollowUpChip[];
+  /** Guards against double-reporting feedback (a click followed by the clear-on-send). */
+  feedbackDone?: boolean;
   messageId?: string;
   status: FollowUpActionStatus;
+  /** `llm_generation_tracing` row id this chip set was generated under, if any. */
+  tracingId?: string;
 }
 
 export interface FollowUpActionState {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Builds on the existing `llm_generation_tracing` write path (DB feedback columns, `recordFeedback` service/router, and `aiChatService.recordTracingFeedback` — all already on `canary`) by wiring the **first two production collectors** of implicit feedback. No new contract; this only calls the shipped one from new places.

**`follow_up` (client, session-scoped):**
- The server pre-allocates the tracing row id and returns it on `FollowUpExtractResult` (only when chips actually render); the store holds it on the per-conversation slot.
- A chip click → `positive` / `followup_clicked`.
- A chip set that was shown but never clicked, cleared on the next send/regenerate/continue → `negative` / `followup_dismissed`.
- Together these make chip **click-through-rate computable per prompt version**. A `feedbackDone` flag guards against a click and the follow-up clear both reporting.

**`task_brief` (server, deferred):**
- The synthesized brief stamps its tracing id onto `brief.metadata.tracingId` (no migration — reuses the existing jsonb column).
- `BriefService.resolve` translates the user's action into a signal: `approve → positive/brief_approved`, `feedback → negative/brief_feedback`, `ignore → negative/brief_ignored`, anything else → `neutral`. It runs fire-and-forget and swallows errors so a tracing write can never break brief resolution. Briefs without a tracing id (e.g. signal briefs) are skipped.

Known minor behavior (matches the existing `input_completion` collector): the tracing row is written via `after()`, so an extremely fast action can race ahead of the row and get a silent `not_found` on the feedback call.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

New/updated unit tests:
- `src/store/followUpAction/index.test.ts` — tracingId stored on slot; click reports positive; dismissal reports negative; click-then-clear doesn't double-report; no-tracingId is a no-op.
- `src/server/services/brief/index.test.ts` — action→signal mapping (approve/feedback/ignore/neutral), no-tracingId skip, and a tracing failure not breaking `resolve`.

Manual: enable follow-up chips, click vs. ignore a suggestion, and resolve a task brief; confirm a row in `llm_generation_tracing` gets `feedback_signal` / `feedback_source` set.

#### 📝 Additional Information

Next step in the rollout (separate PR): a read-side aggregation query/CLI over `(scenario, prompt_version)` so the collected signals become usable for prompt iteration.