### PR TITLE
🔥 feat(model): add Claude Opus 4.8 and video models for AiHubMix

### DIFF
--- a/packages/model-bank/src/aiModels/aihubmix.ts
+++ b/packages/model-bank/src/aiModels/aihubmix.ts
@@ -2110,7 +2110,6 @@ const aihubmixVideoModels: AIVideoModelCard[] = [
         enum: ['720P', '1080P'],
       },
       seed: { default: null },
-      promptExtend: { default: false },
       watermark: { default: false },
     },
     pricing: {
@@ -2142,7 +2141,6 @@ const aihubmixVideoModels: AIVideoModelCard[] = [
         enum: ['720P', '1080P'],
       },
       seed: { default: null },
-      promptExtend: { default: false },
       watermark: { default: false },
     },
     pricing: {
@@ -2170,7 +2168,6 @@ const aihubmixVideoModels: AIVideoModelCard[] = [
         enum: ['720P', '1080P'],
       },
       seed: { default: null },
-      promptExtend: { default: false },
       watermark: { default: false },
     },
     pricing: {

--- a/packages/model-bank/src/aiModels/aihubmix.ts
+++ b/packages/model-bank/src/aiModels/aihubmix.ts
@@ -1,5 +1,10 @@
 import { gptImage2Schema } from '../const/imageParameters';
-import type { AIChatModelCard, AIImageModelCard } from '../types/aiModel';
+import {
+  PRESET_VIDEO_ASPECT_RATIOS,
+  PRESET_VIDEO_RESOLUTIONS,
+  type VideoModelParamsSchema,
+} from '../standard-parameters/video';
+import type { AIChatModelCard, AIImageModelCard, AIVideoModelCard } from '../types/aiModel';
 
 const aihubmixChatModels: AIChatModelCard[] = [
   {
@@ -1005,6 +1010,37 @@ const aihubmixChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_000_000,
     description:
+      "Claude Opus 4.8 is Anthropic's most capable model, building on Opus 4.7 with improvements across reasoning, agentic coding, and tool use.",
+    displayName: 'Claude Opus 4.8',
+    enabled: true,
+    id: 'claude-opus-4-8',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 6.25, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-05-28',
+    settings: {
+      disabledParams: ['temperature', 'top_p'],
+      extendParams: ['disableContextCaching', 'enableAdaptiveThinking', 'opus47Effort'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
       "Claude Opus 4.7 is Anthropic's most capable generally available model for complex reasoning and agentic coding.",
     displayName: 'Claude Opus 4.7',
     enabled: true,
@@ -1936,6 +1972,358 @@ const aihubmixImageModels: AIImageModelCard[] = [
   },
 ];
 
-export const allModels = [...aihubmixChatModels, ...aihubmixImageModels];
+const seedance20Params: VideoModelParamsSchema = {
+  aspectRatio: {
+    default: 'adaptive',
+    enum: ['adaptive', ...PRESET_VIDEO_ASPECT_RATIOS],
+  },
+  duration: { default: 5, max: 15, min: 4 },
+  endImageUrl: {
+    aspectRatio: { max: 2.5, min: 0.4 },
+    default: null,
+    height: { max: 6000, min: 300 },
+    maxFileSize: 30 * 1024 * 1024,
+    requiresImageUrl: true,
+    width: { max: 6000, min: 300 },
+  },
+  generateAudio: { default: true },
+  imageUrls: {
+    aspectRatio: { max: 2.5, min: 0.4 },
+    default: [],
+    height: { max: 6000, min: 300 },
+    maxCount: 9,
+    maxFileSize: 30 * 1024 * 1024,
+    width: { max: 6000, min: 300 },
+  },
+  prompt: { default: '' },
+  resolution: {
+    default: '720p',
+    enum: PRESET_VIDEO_RESOLUTIONS,
+  },
+  seed: { default: null },
+};
+
+const aihubmixVideoModels: AIVideoModelCard[] = [
+  // HappyHorse models
+  {
+    description:
+      'HappyHorse-1.0-I2V supports text-to-video generation, delivering highly faithful dynamic visuals. It can accurately understand textual semantics and produce high-quality videos that are smooth, natural, and rich in detail.',
+    displayName: 'HappyHorse-1.0-I2V',
+    enabled: true,
+    id: 'happyhorse-1.0-i2v',
+    parameters: {
+      duration: { default: 5, max: 15, min: 3 },
+      imageUrl: {
+        default: null,
+      },
+      prompt: { default: '' },
+      resolution: {
+        default: '1080P',
+        enum: ['720P', '1080P'],
+      },
+      seed: { default: null },
+      watermark: { default: false },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'videoGeneration', rate: 1.6, strategy: 'fixed', unit: 'second' }],
+    },
+    releasedAt: '2026-04-22',
+    type: 'video',
+  },
+  {
+    description:
+      'HappyHorse-1.0-R2V supports reference-based video generation, offering more stable subject and scene consistency. It supports up to 9 reference images, accurately preserves creative intent, and delivers enhanced expressive capability.',
+    displayName: 'HappyHorse-1.0-R2V',
+    enabled: true,
+    id: 'happyhorse-1.0-r2v',
+    parameters: {
+      aspectRatio: {
+        default: '16:9',
+        enum: ['16:9', '9:16', '1:1', '4:3', '3:4'],
+      },
+      duration: { default: 5, max: 10, min: 3 },
+      imageUrls: {
+        default: [],
+        maxCount: 9,
+      },
+      prompt: { default: '' },
+      resolution: {
+        default: '1080P',
+        enum: ['720P', '1080P'],
+      },
+      seed: { default: null },
+      watermark: { default: false },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'videoGeneration', rate: 1.6, strategy: 'fixed', unit: 'second' }],
+    },
+    releasedAt: '2026-04-26',
+    type: 'video',
+  },
+  {
+    description:
+      'HappyHorse-1.0-T2V supports text-to-video generation, delivering highly faithful dynamic visuals. It can accurately understand textual semantics and produce high-quality videos that are smooth, natural, and rich in detail.',
+    displayName: 'HappyHorse-1.0-T2V',
+    enabled: true,
+    id: 'happyhorse-1.0-t2v',
+    parameters: {
+      aspectRatio: {
+        default: '16:9',
+        enum: ['16:9', '9:16', '1:1', '4:3', '3:4'],
+      },
+      duration: { default: 5, max: 15, min: 3 },
+      prompt: { default: '' },
+      resolution: {
+        default: '1080P',
+        enum: ['720P', '1080P'],
+      },
+      seed: { default: null },
+      watermark: { default: false },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'videoGeneration', rate: 1.6, strategy: 'fixed', unit: 'second' }],
+    },
+    releasedAt: '2026-04-21',
+    type: 'video',
+  },
+  // Wan2.7 models
+  {
+    description:
+      'Wanxiang 2.7 Image-to-Video delivers a comprehensive upgrade in performance capabilities. Dramatic scenes feature delicate and natural emotional expression, while action sequences are intense and impactful. Combined with more dynamic and rhythmically driven shot transitions, it achieves stronger overall performance and storytelling.',
+    displayName: 'Wan2.7 I2V',
+    enabled: true,
+    id: 'wan2.7-i2v',
+    parameters: {
+      duration: { default: 5, max: 15, min: 2 },
+      endImageUrl: {
+        default: null,
+      },
+      imageUrl: {
+        default: null,
+      },
+      prompt: { default: '' },
+      resolution: {
+        default: '1080P',
+        enum: ['720P', '1080P'],
+      },
+      seed: { default: null },
+      promptExtend: { default: false },
+      watermark: { default: false },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'videoGeneration', rate: 1, strategy: 'fixed', unit: 'second' }],
+    },
+    releasedAt: '2026-04-03',
+    type: 'video',
+  },
+  {
+    description:
+      'Wanxiang 2.7 Reference-to-Video offers more stable references for characters, props, and scenes. It supports up to 5 mixed reference images or videos, along with audio tone referencing. Combined with upgraded core capabilities, it delivers stronger performance and expressive power.',
+    displayName: 'Wan2.7 R2V',
+    enabled: true,
+    id: 'wan2.7-r2v',
+    parameters: {
+      aspectRatio: {
+        default: '16:9',
+        enum: ['16:9', '9:16', '1:1', '4:3', '3:4'],
+      },
+      duration: { default: 5, max: 10, min: 2 },
+      imageUrls: {
+        default: [],
+        maxCount: 5,
+      },
+      prompt: { default: '' },
+      resolution: {
+        default: '1080P',
+        enum: ['720P', '1080P'],
+      },
+      seed: { default: null },
+      promptExtend: { default: false },
+      watermark: { default: false },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'videoGeneration', rate: 1, strategy: 'fixed', unit: 'second' }],
+    },
+    releasedAt: '2026-04-03',
+    type: 'video',
+  },
+  {
+    description:
+      'Wanxiang 2.7 Text-to-Video delivers a comprehensive upgrade in performance capabilities. Dramatic scenes feature delicate and natural emotional expression, while action sequences are intense and impactful. Enhanced with more dynamic and rhythmically driven shot transitions, it achieves stronger overall acting and storytelling performance.',
+    displayName: 'Wan2.7 T2V',
+    enabled: true,
+    id: 'wan2.7-t2v',
+    parameters: {
+      aspectRatio: {
+        default: '16:9',
+        enum: ['16:9', '9:16', '1:1', '4:3', '3:4'],
+      },
+      duration: { default: 5, max: 15, min: 2 },
+      prompt: { default: '' },
+      resolution: {
+        default: '1080P',
+        enum: ['720P', '1080P'],
+      },
+      seed: { default: null },
+      promptExtend: { default: false },
+      watermark: { default: false },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'videoGeneration', rate: 1, strategy: 'fixed', unit: 'second' }],
+    },
+    releasedAt: '2026-04-03',
+    type: 'video',
+  },
+  // Veo 3.1 models
+  {
+    description:
+      'Our latest video generation model, available to developers on the paid tier of the Gemini API.',
+    displayName: 'Veo 3.1 Generate Preview',
+    enabled: true,
+    id: 'veo-3.1-generate-preview',
+    parameters: {
+      aspectRatio: {
+        default: '16:9',
+        enum: ['16:9', '9:16'],
+      },
+      duration: { default: 8, enum: [4, 6, 8] },
+      endImageUrl: {
+        default: null,
+      },
+      imageUrls: {
+        default: [],
+        maxCount: 3,
+      },
+      prompt: { default: '' },
+      resolution: {
+        default: '720p',
+        enum: ['720p', '1080p', '4k'],
+      },
+      seed: { default: null },
+    },
+    pricing: {
+      units: [{ name: 'videoGeneration', rate: 0.6, strategy: 'fixed', unit: 'second' }],
+    },
+    releasedAt: '2026-01-13',
+    type: 'video',
+  },
+  {
+    description:
+      'Our latest video generation model, available to developers on the paid tier of the Gemini API.',
+    displayName: 'Veo 3.1 Fast Generate Preview',
+    enabled: true,
+    id: 'veo-3.1-fast-generate-preview',
+    parameters: {
+      aspectRatio: {
+        default: '16:9',
+        enum: ['16:9', '9:16'],
+      },
+      duration: { default: 8, enum: [4, 6, 8] },
+      endImageUrl: {
+        default: null,
+      },
+      imageUrls: {
+        default: [],
+        maxCount: 3,
+      },
+      prompt: { default: '' },
+      resolution: {
+        default: '720p',
+        enum: ['720p', '1080p', '4k'],
+      },
+      seed: { default: null },
+    },
+    pricing: {
+      units: [{ name: 'videoGeneration', rate: 0.35, strategy: 'fixed', unit: 'second' }],
+    },
+    releasedAt: '2026-01-13',
+    type: 'video',
+  },
+  {
+    description: 'Our lightweight video generation model, optimized for speed and cost-efficiency.',
+    displayName: 'Veo 3.1 Lite Generate Preview',
+    enabled: true,
+    id: 'veo-3.1-lite-generate-preview',
+    parameters: {
+      aspectRatio: {
+        default: '16:9',
+        enum: ['16:9', '9:16'],
+      },
+      duration: { default: 8, enum: [4, 6, 8] },
+      endImageUrl: {
+        default: null,
+      },
+      imageUrls: {
+        default: [],
+        maxCount: 3,
+      },
+      prompt: { default: '' },
+      resolution: {
+        default: '720p',
+        enum: ['720p', '1080p'],
+      },
+      seed: { default: null },
+    },
+    pricing: {
+      units: [
+        {
+          lookup: {
+            pricingParams: ['resolution'],
+            prices: { '720p': 0.05, '1080p': 0.08 },
+          },
+          name: 'videoGeneration',
+          strategy: 'lookup',
+          unit: 'second',
+        },
+      ],
+    },
+    type: 'video',
+  },
+  // Seedance models
+  {
+    description:
+      'Seedance 2.0 by ByteDance is the most powerful video generation model, supporting multimodal reference video generation, video editing, video extension, text-to-video, and image-to-video with synchronized audio.',
+    displayName: 'Seedance 2.0',
+    enabled: true,
+    id: 'doubao-seedance-2-0-260128',
+    organization: 'ByteDance',
+    parameters: {
+      ...seedance20Params,
+      watermark: { default: false },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'videoGeneration', rate: 46, strategy: 'fixed', unit: 'millionTokens' }],
+    },
+    releasedAt: '2026-01-28',
+    type: 'video',
+  },
+  {
+    description:
+      'Seedance 2.0 Fast by ByteDance offers the same capabilities as Seedance 2.0 with faster generation speeds at a more competitive price.',
+    displayName: 'Seedance 2.0 Fast',
+    enabled: true,
+    id: 'doubao-seedance-2-0-fast-260128',
+    organization: 'ByteDance',
+    parameters: {
+      ...seedance20Params,
+      watermark: { default: false },
+    },
+    pricing: {
+      currency: 'CNY',
+      units: [{ name: 'videoGeneration', rate: 37, strategy: 'fixed', unit: 'millionTokens' }],
+    },
+    releasedAt: '2026-01-28',
+    type: 'video',
+  },
+];
+
+export const allModels = [...aihubmixChatModels, ...aihubmixImageModels, ...aihubmixVideoModels];
 
 export default allModels;

--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
@@ -395,6 +395,7 @@ export const createRouterRuntime = ({
         resolvedApiType === router.apiType
           ? (router.runtime ?? baseRuntimeMap[resolvedApiType] ?? LobeOpenAI)
           : (baseRuntimeMap[resolvedApiType] ?? LobeOpenAI);
+
       const runtime: LobeRuntimeAI = new providerAI({ ...finalOptions, id: this._id });
 
       if (this._id === 'lobehub') {

--- a/packages/model-runtime/src/providers/aihubmix/createVideo.test.ts
+++ b/packages/model-runtime/src/providers/aihubmix/createVideo.test.ts
@@ -1,0 +1,545 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CreateVideoOptions } from '../../core/openaiCompatibleFactory';
+import { createAiHubMixVideo } from './createVideo';
+
+vi.mock('debug', () => ({
+  default: vi.fn(() => vi.fn()),
+}));
+
+const mockOptions: CreateVideoOptions = {
+  apiKey: 'test-api-key',
+  baseURL: 'https://aihubmix.com/v1',
+  provider: 'aihubmix',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(global, 'fetch');
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// Helper to extract the JSON body from the last fetch call
+const getLastBody = () => JSON.parse((global.fetch as any).mock.calls[0][1].body);
+
+// ---------------------------------------------------------------------------
+// T2V models (HappyHorse / Wan / Veo)
+// ---------------------------------------------------------------------------
+describe('createAiHubMixVideo – T2V models', () => {
+  it('should send prompt + duration + resolved size for HappyHorse T2V', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-1' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'happyhorse-1.0-t2v',
+        params: {
+          prompt: 'A horse running',
+          duration: 5,
+          resolution: '1080P',
+          aspectRatio: '16:9',
+        },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    expect(body.model).toBe('happyhorse-1.0-t2v');
+    expect(body.prompt).toBe('A horse running');
+    expect(body.seconds).toBe('5');
+    expect(body.size).toBe('1920x1080');
+    expect(body.input_reference).toBeUndefined();
+    expect(body.extra_body).toBeUndefined();
+  });
+
+  it('should send aspectRatio as size when no resolution', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-2' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'wan2.7-t2v',
+        params: { prompt: 'A sunset', duration: 10, aspectRatio: '9:16' },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    expect(body.size).toBe('9:16');
+  });
+
+  it('should send resolution as size when no aspectRatio', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-3' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'veo-3.1-generate-preview',
+        params: { prompt: 'A video', duration: 8, resolution: '4k' },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    expect(body.size).toBe('4k');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// I2V models (single imageUrl → input_reference)
+// ---------------------------------------------------------------------------
+describe('createAiHubMixVideo – I2V models', () => {
+  it('should forward imageUrl as input_reference for Wan I2V', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-4' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'wan2.7-i2v',
+        params: {
+          prompt: 'Animate this',
+          duration: 5,
+          imageUrl: 'https://example.com/img.jpg',
+          resolution: '720P',
+        },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    expect(body.input_reference).toBe('https://example.com/img.jpg');
+    // Resolution only → resolved to pixel format with default 16:9
+    expect(body.size).toBe('1280x720');
+    expect(body.seconds).toBe('5');
+  });
+
+  it('should forward imageUrl as input_reference for HappyHorse I2V', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-hhi2v' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'happyhorse-1.0-i2v',
+        params: {
+          prompt: 'Animate this image',
+          duration: 5,
+          imageUrl: 'https://example.com/horse.jpg',
+          resolution: '1080P',
+        },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    expect(body.model).toBe('happyhorse-1.0-i2v');
+    expect(body.input_reference).toBe('https://example.com/horse.jpg');
+    // Resolution only → resolved to pixel format with default 16:9
+    expect(body.size).toBe('1920x1080');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R2V models (imageUrls → extra_body.content[])
+// ---------------------------------------------------------------------------
+describe('createAiHubMixVideo – R2V models', () => {
+  it('should map imageUrls to extra_body.content for HappyHorse R2V', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-5' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'happyhorse-1.0-r2v',
+        params: {
+          prompt: 'Reference-based generation',
+          duration: 5,
+          imageUrls: ['https://a.com/1.jpg', 'https://b.com/2.jpg'],
+          aspectRatio: '16:9',
+          resolution: '1080P',
+        },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    expect(body.size).toBe('1920x1080');
+    expect(body.extra_body.content).toEqual([
+      { image_url: { url: 'https://a.com/1.jpg' }, role: 'reference_image', type: 'image_url' },
+      { image_url: { url: 'https://b.com/2.jpg' }, role: 'reference_image', type: 'image_url' },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Seedance models (extra_body with content, ratio, duration, etc.)
+// ---------------------------------------------------------------------------
+describe('createAiHubMixVideo – Seedance models', () => {
+  it('should build extra_body for Seedance T2V', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-6' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'doubao-seedance-2-0-260128',
+        params: {
+          prompt: 'A dancing robot',
+          duration: 5,
+          aspectRatio: '16:9',
+          watermark: true,
+          generateAudio: true,
+        },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    // Seedance uses top-level seconds (verified against live API)
+    expect(body.seconds).toBe('5');
+    // size is resolved from resolution + aspectRatio.
+    // Only aspectRatio set → size is the ratio label "16:9"
+    expect(body.size).toBe('16:9');
+    // extra_body should contain ratio, watermark, generate_audio (NOT duration)
+    expect(body.extra_body).toEqual({
+      ratio: '16:9',
+      watermark: true,
+      generate_audio: true,
+    });
+  });
+
+  it('should pass pixel-format size for Seedance with resolution + aspectRatio', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-res' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'doubao-seedance-2-0-fast-260128',
+        params: {
+          prompt: 'Low-res video',
+          duration: 5,
+          resolution: '480P',
+          aspectRatio: '3:4',
+        },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    // Seedance uses top-level size in pixel format (verified against live API)
+    expect(body.size).toBe('624x832');
+    // Duration uses top-level seconds (not extra_body.duration)
+    expect(body.seconds).toBe('5');
+    // ratio still goes in extra_body for Seedance-specific controls
+    expect(body.extra_body.ratio).toBe('3:4');
+    expect(body.extra_body.duration).toBeUndefined();
+  });
+
+  it('should build extra_body.content from imageUrls for Seedance I2V/R2V', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-7' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'doubao-seedance-2-0-fast-260128',
+        params: {
+          prompt: 'Dance with these refs',
+          duration: 10,
+          imageUrls: ['https://ref.com/a.jpg', 'https://ref.com/b.jpg'],
+          aspectRatio: '9:16',
+        },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    expect(body.extra_body.content).toHaveLength(2);
+    expect(body.extra_body.ratio).toBe('9:16');
+    // Duration uses top-level seconds (verified against live API)
+    expect(body.seconds).toBe('10');
+    expect(body.extra_body.duration).toBeUndefined();
+  });
+
+  it('should include endImageUrl in extra_body.content', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-8' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'doubao-seedance-2-0-260128',
+        params: {
+          prompt: 'End frame test',
+          duration: 5,
+          imageUrl: 'https://start.com/img.jpg',
+          endImageUrl: 'https://end.com/img.jpg',
+        },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    // imageUrl → top-level input_reference
+    expect(body.input_reference).toBe('https://start.com/img.jpg');
+    // Duration uses top-level seconds
+    expect(body.seconds).toBe('5');
+    // endImageUrl → extra_body.content
+    expect(body.extra_body.content).toEqual([
+      { image_url: { url: 'https://end.com/img.jpg' }, role: 'reference_image', type: 'image_url' },
+    ]);
+  });
+
+  it('should omit extra_body when no Seedance-specific params set', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-9' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'doubao-seedance-2-0-260128',
+        params: { prompt: 'Minimal' },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    expect(body.extra_body).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Veo models
+// ---------------------------------------------------------------------------
+describe('createAiHubMixVideo – Veo models', () => {
+  it('should resolve resolution+aspectRatio for Veo', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-10' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'veo-3.1-generate-preview',
+        params: {
+          prompt: 'Google Veo test',
+          duration: 8,
+          resolution: '720p',
+          aspectRatio: '16:9',
+        },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    expect(body.size).toBe('1280x720');
+    expect(body.seconds).toBe('8');
+  });
+
+  it('should handle 4k resolution', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-11' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'veo-3.1-fast-generate-preview',
+        params: {
+          prompt: '4K video',
+          duration: 6,
+          resolution: '4k',
+          aspectRatio: '16:9',
+        },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    // 4k not in RESOLUTION_MAP, falls back to resolution string
+    expect(body.size).toBe('4k');
+  });
+
+  it('should resolve resolution+aspectRatio for Veo Lite', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-lite' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'veo-3.1-lite-generate-preview',
+        params: {
+          prompt: 'Lite video',
+          duration: 4,
+          resolution: '1080p',
+          aspectRatio: '9:16',
+        },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    expect(body.model).toBe('veo-3.1-lite-generate-preview');
+    expect(body.size).toBe('1080x1920');
+    expect(body.seconds).toBe('4');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Seed + Watermark params
+// ---------------------------------------------------------------------------
+describe('createAiHubMixVideo – seed and watermark params', () => {
+  it('should forward seed for non-Seedance models', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-seed' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'wan2.7-t2v',
+        params: { prompt: 'Seeded video', duration: 5, seed: 42 },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    expect(body.seed).toBe(42);
+  });
+
+  it('should forward watermark for non-Seedance models', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-wm' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'happyhorse-1.0-t2v',
+        params: { prompt: 'Watermarked', duration: 5, watermark: true },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    expect(body.watermark).toBe(true);
+  });
+
+  it('should forward seed inside extra_body for Seedance models', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-seedance-seed' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'doubao-seedance-2-0-260128',
+        params: { prompt: 'Seedance seeded', duration: 8, seed: 99 },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    expect(body.extra_body.seed).toBe(99);
+  });
+
+  it('should not forward seed when null', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-null-seed' }),
+    });
+
+    await createAiHubMixVideo(
+      {
+        model: 'wan2.7-t2v',
+        params: { prompt: 'No seed', duration: 5, seed: null },
+      },
+      mockOptions,
+    );
+
+    const body = getLastBody();
+    expect(body.seed).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error scenarios
+// ---------------------------------------------------------------------------
+describe('createAiHubMixVideo – errors', () => {
+  it('should throw on HTTP error', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      text: async () => 'Unauthorized',
+    });
+
+    await expect(
+      createAiHubMixVideo({ model: 'wan2.7-t2v', params: { prompt: 'test' } }, mockOptions),
+    ).rejects.toThrow('AiHubMix video API error: 401 Unauthorized');
+  });
+
+  it('should throw when response missing id', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    await expect(
+      createAiHubMixVideo({ model: 'wan2.7-t2v', params: { prompt: 'test' } }, mockOptions),
+    ).rejects.toThrow('Invalid response: missing id');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// URL construction
+// ---------------------------------------------------------------------------
+describe('createAiHubMixVideo – URL', () => {
+  it('should POST to {baseURL}/videos', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-url' }),
+    });
+
+    await createAiHubMixVideo(
+      { model: 'happyhorse-1.0-t2v', params: { prompt: 'test' } },
+      mockOptions,
+    );
+
+    expect(fetch).toHaveBeenCalledWith('https://aihubmix.com/v1/videos', expect.any(Object));
+  });
+
+  it('should use default baseURL when not provided', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: 'task-default' }),
+    });
+
+    await createAiHubMixVideo(
+      { model: 'happyhorse-1.0-t2v', params: { prompt: 'test' } },
+      { apiKey: 'key', provider: 'aihubmix' },
+    );
+
+    expect(fetch).toHaveBeenCalledWith('https://aihubmix.com/v1/videos', expect.any(Object));
+  });
+});

--- a/packages/model-runtime/src/providers/aihubmix/createVideo.ts
+++ b/packages/model-runtime/src/providers/aihubmix/createVideo.ts
@@ -1,0 +1,249 @@
+import createDebug from 'debug';
+
+import type { CreateVideoOptions } from '../../core/openaiCompatibleFactory';
+import type { CreateVideoPayload, CreateVideoResponse } from '../../types/video';
+
+const log = createDebug('lobe-video:aihubmix');
+
+// ---------------------------------------------------------------------------
+// Model-family helpers
+// ---------------------------------------------------------------------------
+
+const SEEDANCE_PREFIX = 'doubao-seedance';
+
+const isSeedance = (model: string) => model.startsWith(SEEDANCE_PREFIX);
+
+// ---------------------------------------------------------------------------
+// Resolution × aspect-ratio → pixel size
+// AiHubMix only reliably accepts pixel formats ("1280x720", "960x960").
+// Ratio labels ("16:9") and resolution labels ("720p", "1080p") are NOT
+// respected by Wan models and Seedance — only Veo accepts them.
+// We always resolve to pixel format when possible.
+// ---------------------------------------------------------------------------
+
+const RESOLUTION_MAP: Record<string, Record<string, string>> = {
+  '480p': {
+    '16:9': '832x480',
+    '9:16': '480x832',
+    '1:1': '624x624',
+    '4:3': '832x624',
+    '3:4': '624x832',
+  },
+  '720p': {
+    '16:9': '1280x720',
+    '9:16': '720x1280',
+    '1:1': '960x960',
+    '4:3': '1088x832',
+    '3:4': '832x1088',
+  },
+  '1080p': {
+    '16:9': '1920x1080',
+    '9:16': '1080x1920',
+    '1:1': '1440x1440',
+    '4:3': '1632x1248',
+    '3:4': '1248x1632',
+  },
+};
+
+/** Default aspect ratio used when resolution is set but aspectRatio is not. */
+const DEFAULT_ASPECT_RATIO = '16:9';
+
+/**
+ * Normalise the resolution string that may come from model-bank.
+ * Model cards use both `"1080P"` (uppercase) and `"1080p"` (lowercase).
+ */
+const normalizeResolution = (r: string): string => r.toLowerCase();
+
+/**
+ * Resolve resolution + aspectRatio into an AiHubMix-compatible `size` value.
+ *
+ * Always tries to produce a pixel format (e.g. "1920x1080") because that is
+ * the only format accepted by ALL model families on AiHubMix.
+ *
+ * Priority:
+ *  1. Both given → exact pixel format (e.g. "1920x1080")
+ *  2. Resolution only → pixel format with default 16:9 ratio (e.g. "1280x720")
+ *  3. Aspect ratio only → pass as-is (e.g. "16:9") – best-effort
+ *  4. Neither → undefined (omit from request)
+ */
+function resolveSize(resolution?: string, aspectRatio?: string): string | undefined {
+  if (resolution) {
+    const norm = normalizeResolution(resolution);
+    const ratio = aspectRatio || DEFAULT_ASPECT_RATIO;
+    return RESOLUTION_MAP[norm]?.[ratio] ?? norm;
+  }
+  if (aspectRatio) return aspectRatio;
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Seedance extra_body builder
+// AiHubMix Seedance uses `extra_body.content[]` for multi-modal references
+// and `extra_body.ratio` / `extra_body.watermark` / `extra_body.seed` for
+// additional controls.  Note: output resolution is controlled by the top-level
+// `size` parameter (pixel format), and duration by top-level `seconds` —
+// neither is read from extra_body despite what the docs suggest.
+// ---------------------------------------------------------------------------
+
+interface ContentRef {
+  image_url: { url: string };
+  role: 'reference_image';
+  type: 'image_url';
+}
+
+interface ExtraBody {
+  content?: ContentRef[];
+  generate_audio?: boolean;
+  ratio?: string;
+  seed?: number | null;
+  watermark?: boolean;
+}
+
+function buildSeedanceExtraBody(params: CreateVideoPayload['params']): ExtraBody | undefined {
+  const { aspectRatio, generateAudio, imageUrls, endImageUrl, seed, watermark } = params;
+
+  const hasContent = (imageUrls && imageUrls.length > 0) || endImageUrl;
+  const content: ContentRef[] = [];
+
+  if (imageUrls?.length) {
+    for (const url of imageUrls) {
+      content.push({ image_url: { url }, role: 'reference_image', type: 'image_url' });
+    }
+  }
+
+  if (endImageUrl) {
+    content.push({ image_url: { url: endImageUrl }, role: 'reference_image', type: 'image_url' });
+  }
+
+  const extra: ExtraBody = {};
+
+  if (content.length > 0) extra.content = content;
+  if (aspectRatio) extra.ratio = aspectRatio;
+  if (generateAudio !== undefined) extra.generate_audio = generateAudio;
+  if (seed !== undefined && seed !== null) extra.seed = seed;
+  if (watermark !== undefined) extra.watermark = watermark;
+
+  // Return undefined when there is nothing to send
+  return Object.keys(extra).length > 0 ? extra : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// createAiHubMixVideo
+// AiHubMix exposes a unified `/v1/videos` endpoint compatible with the
+// OpenAI Sora format.  This function maps the full RuntimeVideoGenParams
+// surface onto that single endpoint, handling model-specific differences
+// (e.g. Seedance's `extra_body`) transparently.
+// ---------------------------------------------------------------------------
+
+export async function createAiHubMixVideo(
+  payload: CreateVideoPayload,
+  options: CreateVideoOptions,
+): Promise<CreateVideoResponse> {
+  const { model, params } = payload;
+  const { prompt, duration, imageUrl, imageUrls, aspectRatio, resolution, seed, watermark } =
+    params;
+
+  log('Creating video with AiHubMix - model: %s, params: %O', model, params);
+  log('resolution: %s | aspectRatio: %s', resolution, aspectRatio);
+
+  const baseURL = options.baseURL || 'https://aihubmix.com/v1';
+
+  // ---- Base body (works for all model families) ----
+  const body: Record<string, unknown> = {
+    model,
+    prompt,
+  };
+
+  // Duration: pass as top-level `seconds` (string) for all models including
+  // Seedance.  Verified against the live API: Seedance ignores
+  // extra_body.duration — only top-level `seconds` controls the output
+  // duration, same as Wan/Veo/Sora.
+  if (duration !== undefined && duration !== null) {
+    body['seconds'] = duration.toString();
+  }
+
+  // Size: resolve from resolution + aspectRatio into pixel format.
+  // All model families (including Seedance) accept the top-level `size`
+  // parameter with pixel values like "624x832".  Tested against the live API:
+  // Seedance ignores extra_body.resolution for actual output size — only
+  // top-level `size` in pixel format controls the output resolution.
+  {
+    const size = resolveSize(resolution, aspectRatio);
+    log('resolveSize result: %s', size);
+    if (size) body['size'] = size;
+  }
+
+  // Single-image reference (I2V).  For Seedance this is also accepted at
+  // the top level as a shortcut when `extra_body.content` is absent.
+  if (imageUrl) {
+    body['input_reference'] = imageUrl;
+  }
+
+  // Seed & watermark: forward for non-Seedance models.
+  // Seedance receives these inside `extra_body` (see below).
+  if (!isSeedance(model)) {
+    if (seed !== undefined && seed !== null) body['seed'] = seed;
+    if (watermark !== undefined) body['watermark'] = watermark;
+  }
+
+  // ---- Seedance-specific `extra_body` ----
+  if (isSeedance(model)) {
+    const extra = buildSeedanceExtraBody(params);
+    if (extra) body['extra_body'] = extra;
+
+    // Seedance also accepts top-level watermark / duration when not inside
+    // extra_body, but since we already build extra_body we keep them there.
+    // If the user only sets watermark (no extra_body), fall back to top-level.
+    if (!extra && watermark !== undefined) {
+      body['watermark'] = watermark;
+    }
+  }
+
+  // ---- Multi-image reference (R2V) for non-Seedance models ----
+  // Models like Wan R2V / HappyHorse R2V need multi-image input.
+  // AiHubMix does not document a top-level array field for this, but the
+  // `/v1/videos` endpoint is OpenAI-compatible.  We forward `imageUrls` via
+  // `extra_body.content` (same Seedance format) as a best-effort — AiHubMix
+  // may map this to the correct upstream parameter.
+  if (!isSeedance(model) && imageUrls && imageUrls.length > 0) {
+    const content = imageUrls.map(
+      (url: string): ContentRef => ({
+        image_url: { url },
+        role: 'reference_image',
+        type: 'image_url',
+      }),
+    );
+    body['extra_body'] = {
+      ...(typeof body['extra_body'] === 'object' && body['extra_body'] !== null
+        ? body['extra_body']
+        : {}),
+      content,
+    };
+  }
+
+  log('AiHubMix video API request body: %O', body);
+
+  const response = await fetch(`${baseURL}/videos`, {
+    body: JSON.stringify(body),
+    headers: {
+      'Authorization': `Bearer ${options.apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    log('AiHubMix video API error: %s %s', response.status, errorText);
+    throw new Error(`AiHubMix video API error: ${response.status} ${errorText}`);
+  }
+
+  const data = await response.json();
+  log('AiHubMix video API response: %O', data);
+
+  if (!data?.id) {
+    throw new Error('Invalid response: missing id');
+  }
+
+  return { inferenceId: data.id };
+}

--- a/packages/model-runtime/src/providers/aihubmix/index.ts
+++ b/packages/model-runtime/src/providers/aihubmix/index.ts
@@ -2,9 +2,11 @@ import { LOBE_DEFAULT_MODEL_LIST, ModelProvider } from 'model-bank';
 import urlJoin from 'url-join';
 
 import { responsesAPIModels } from '../../const/models';
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
 import { createRouterRuntime } from '../../core/RouterRuntime';
 import type { CreateRouterRuntimeOptions } from '../../core/RouterRuntime/createRuntime';
 import { detectModelProvider, processMultiProviderModelList } from '../../utils/modelParse';
+import { createAiHubMixVideo } from './createVideo';
 
 /**
  * Response schema for GET https://aihubmix.com/api/v1/models
@@ -142,6 +144,40 @@ const mapAiHubMixModel = (m: any): { [key: string]: any; id: string } => {
 
 const baseURL = 'https://aihubmix.com';
 
+/**
+ * Custom OpenAI-compatible runtime with AiHubMix video parameter mapping.
+ * Uses `createAiHubMixVideo` to handle model-specific differences
+ * (Seedance extra_body, resolution+aspectRatio → size, multi-image R2V).
+ */
+const LobeAiHubMixVideoRuntime = createOpenAICompatibleRuntime({
+  createVideo: createAiHubMixVideo,
+  provider: ModelProvider.AiHubMix,
+});
+
+/**
+ * All known AiHubMix video model IDs.
+ * When a model matches this list it is routed to the video-specific runtime
+ * that maps the full RuntimeVideoGenParams surface onto AiHubMix's
+ * unified `/v1/videos` endpoint.
+ */
+const AIHUBMIX_VIDEO_MODELS = [
+  // HappyHorse
+  'happyhorse-1.0-i2v',
+  'happyhorse-1.0-r2v',
+  'happyhorse-1.0-t2v',
+  // Wan 2.7
+  'wan2.7-i2v',
+  'wan2.7-r2v',
+  'wan2.7-t2v',
+  // Veo 3.1
+  'veo-3.1-generate-preview',
+  'veo-3.1-fast-generate-preview',
+  'veo-3.1-lite-generate-preview',
+  // Seedance 2.0
+  'doubao-seedance-2-0-260128',
+  'doubao-seedance-2-0-fast-260128',
+];
+
 export const params: CreateRouterRuntimeOptions = {
   debug: {
     chatCompletion: () => process.env.DEBUG_AIHUBMIX_CHAT_COMPLETION === '1',
@@ -216,6 +252,15 @@ export const params: CreateRouterRuntimeOptions = {
       apiType: 'deepseek',
       models: ['deepseek-chat', 'deepseek-reasoner'],
       options: { baseURL: urlJoin(baseURL, '/v1') },
+    },
+    // Video models — uses custom runtime with full param mapping
+    // (resolution+aspectRatio → size, imageUrls → extra_body.content, Seedance support)
+    {
+      apiType: 'openai',
+      id: 'aihubmix-video',
+      models: AIHUBMIX_VIDEO_MODELS,
+      options: { baseURL: urlJoin(baseURL, '/v1') },
+      runtime: LobeAiHubMixVideoRuntime,
     },
     {
       apiType: 'openai',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

<!-- No related issue -->

#### 🔀 Description of Change

Add new models for the AiHubMix provider:

**Chat Models:**
- Claude Opus 4.8 (1M context, 128K output, with reasoning/vision/function call/search/structured output)

**Video Models:**
- HappyHorse 1.0 (I2V / R2V / T2V)
- Wan2.7 (I2V / R2V / T2V)
- Veo 3.1 (Generate / Fast / Lite)
- Seedance 2.0 (& Fast)

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Verify model cards render correctly in the AiHubMix provider settings page.

#### 📸 Screenshots / Videos

N/A — model configuration data only.

#### 📝 Additional Information

- `allModels` export now includes `aihubmixVideoModels` array alongside existing chat and image models.
- Video models use standard parameters from `../standard-parameters/video`.