### PR TITLE
🐛 fix(desktop): skip browser beforeunload guard so auto-update can quit

### DIFF
--- a/src/store/chat/utils/index.ts
+++ b/src/store/chat/utils/index.ts
@@ -1,7 +1,13 @@
+import { isDesktop } from '@lobechat/const';
 import i18n from 'i18next';
 import { produce } from 'immer';
 
 export const preventLeavingFn = (e: BeforeUnloadEvent) => {
+  // On desktop the main process manages window close / app quit (keepAlive + isQuiting),
+  // so the browser "are you sure you want to leave" guard is unnecessary here — and it can
+  // block window.close() during auto-update, leaving the app unable to quit & install.
+  if (isDesktop) return;
+
   // set returnValue to trigger alert modal
   // Note: No matter what value is set, the browser will display the standard text
   e.returnValue = i18n.t('beforeUnload.confirmLeave', { ns: 'chat' });


### PR DESCRIPTION
### 💡 Description of Change

On desktop, clicking "install update" sometimes fails to quit & relaunch the app.

**Root cause:** while a chat message is generating, the renderer registers a browser `beforeunload` guard (`preventLeavingFn`) — the web "are you sure you want to leave?" prompt. In Electron this fires `will-prevent-unload`, which by default **cancels `window.close()`**, so `autoUpdater.quitAndInstall()` can't tear the window down and the app stays open.

On desktop this guard is unnecessary: window close / app quit is already managed by the main process via `keepAlive` + `isQuiting`. So we short-circuit `preventLeavingFn` on desktop.

The fix lives in `preventLeavingFn` itself (one place) rather than the add/remove listener call sites, so every caller is covered and the listener becomes a no-op on desktop.

### 🔗 Related

Reported internally: auto-update doesn't quit/relaunch on desktop while a generation is in progress.

### ✅ Change Type

- [x] 🐛 `fix`: A bug fix

### 🧪 How to Test

1. On the desktop build, start a chat generation (so the `beforeunload` guard is registered).
2. Trigger an available update → click install.
3. App should quit and relaunch to install the update (previously it could hang with the window open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)