### PR TITLE
🐛 fix(desktop): pin electron-builder to 26.14.0 to fix broken macOS update signing

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -78,7 +78,7 @@
     "cross-env": "^10.1.0",
     "diff": "^8.0.4",
     "electron": "41.3.0",
-    "electron-builder": "^26.8.1",
+    "electron-builder": "26.14.0",
     "electron-devtools-installer": "4.0.0",
     "electron-is": "^3.0.0",
     "electron-store": "^8.2.0",


### PR DESCRIPTION
### 💡 Description of Change

Desktop auto-update silently fails on macOS: clicking "install update" does nothing and the app never quits/relaunches.

**Root cause — a broken build artifact, empirically confirmed.** The `canary.12` macOS zip, once Squirrel.Mac extracts it during update, fails code-signature validation:

```
Code signature ... did not pass validation: bundle format is ambiguous (could be app or framework)
```

This is `errSecCSBadBundleFormat` — the extracted `.app` is structurally malformed, so macOS rejects the swap and the install aborts before the app quits.

**Why it started ~2 days ago.** `electron-builder` was floating on `^26.8.1` and the repo commits no lockfile, so each CI build resolves a fresh version. The `canary.12` build (2026-06-07) picked up **26.15.0**, which switched the macOS **zip** packaging to 7zip (part of the app-builder-bin Go→TS migration, #9829). 7zip does not preserve the symlink farm of `.framework` bundles, so after extraction `Electron Framework.framework` has an ambiguous layout.

### 🔬 Local reproduction (same code, same Electron 41.3.0, only electron-builder version swapped)

| | electron-builder **26.15.0** | electron-builder **26.14.0** |
|---|---|---|
| `--dir` bundle (assembly) | valid | valid |
| zip packer | **7zip** (downloads `7zip-darwin-arm64`) | `ditto` |
| **zip size** | **350 MB** | **154 MB** |
| extract → `codesign --deep --sign -` | ❌ `bundle format is ambiguous … Electron Framework.framework` | ✅ exit 0 |
| extract → `codesign --verify --deep --strict` | ❌ fails | ✅ exit 0 |

The `--dir` bundle is fine for both; only the **zip round-trip** (the path auto-update uses) breaks under 26.15.0. The 2.3× zip bloat corroborates symlinks being dereferenced instead of preserved.

`26.15.1` (latest) does **not** fix it — its only mac-touching PR (#9838) is pure lint/refactor; the zip change is untouched. So "pull latest" is not a fix.

### ✅ Fix

Pin `electron-builder` to exact `26.14.0` — the last release before the 7zip mac-zip regression, confirmed above to produce a valid, re-extractable bundle. The exact pin cascades to `app-builder-lib` / `dmg-builder` / `builder-util` (electron-builder pins those exactly), so the toolchain stops floating across CI installs.

### ✅ Change Type

- [x] 🐛 `fix`: A bug fix

### 🧪 How to Test

1. Cut a macOS build with this pin.
2. Extract the produced `*-mac.zip` and run `codesign --verify --deep --strict <LobeHub.app>` → exit 0 (26.15.0 yields "bundle format is ambiguous").
3. Auto-update end-to-end → app quits and relaunches to install.

### ⚠️ Follow-ups (not in this PR)

- Root cause is "no lockfile + caret range floats". Consider committing a lockfile for the desktop build and/or a release-gate `codesign --verify --deep --strict` on the extracted zip so a broken bundle can never ship silently again.
- File an upstream electron-builder issue for the 26.15.0 macOS zip (7zip) symlink regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)