### PR TITLE
💄 style(conversation): show running indicator after a settled inline tool while generating

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -115,6 +115,10 @@ vi.mock('./GroupItem', () => ({
   ),
 }));
 
+vi.mock('@/features/Conversation/Messages/components/ContentLoading', () => ({
+  default: ({ id }: { id: string }) => <div data-id={id} data-testid="tail-running" />,
+}));
+
 const blk = (p: Partial<AssistantContentBlock> & { id: string }): AssistantContentBlock =>
   ({ content: '', ...p }) as AssistantContentBlock;
 
@@ -349,6 +353,63 @@ describe('Group', () => {
         toolCount: 1,
       },
     ]);
+  });
+
+  it('shows a running indicator below a settled single inline tool while still generating', () => {
+    mockIsGenerating = true;
+    render(
+      <Group
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: '',
+            id: 'block-1',
+            tools: [{ apiName: 'bash', id: 'tool-1', result: { content: 'done' } } as any],
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('tail-running')).toHaveAttribute('data-id', 'assistant-1');
+  });
+
+  it('hides the running indicator while the inline tool is still executing', () => {
+    mockIsGenerating = true;
+    render(
+      <Group
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: '',
+            id: 'block-1',
+            tools: [{ apiName: 'bash', id: 'tool-1' } as any],
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.queryByTestId('tail-running')).not.toBeInTheDocument();
+  });
+
+  it('hides the running indicator once generation has finished', () => {
+    mockIsGenerating = false;
+    render(
+      <Group
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: '',
+            id: 'block-1',
+            tools: [{ apiName: 'bash', id: 'tool-1', result: { content: 'done' } } as any],
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.queryByTestId('tail-running')).not.toBeInTheDocument();
   });
 
   it('only animates the last block in a multi-block group', () => {

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -4,6 +4,7 @@ import isEqual from 'fast-deep-equal';
 import { memo, useMemo } from 'react';
 
 import { LOADING_FLAT } from '@/const/message';
+import ContentLoading from '@/features/Conversation/Messages/components/ContentLoading';
 import { type AssistantContentBlock } from '@/types/index';
 
 import { messageStateSelectors, useConversationStore } from '../../../store';
@@ -436,6 +437,20 @@ const Group = memo<GroupChildrenProps>(
 
     const workflowChromeComplete = !isGenerating || postToolTailPromoted;
 
+    // When the turn ends on an inline single-tool segment whose tool already
+    // settled but the run is still generating (waiting on the next step), the
+    // inline path renders no working chrome — unlike WorkflowCollapse, which has
+    // its own streaming header. Without this the user sees a blank gap below the
+    // finished tool. Render the same "running" indicator used at turn start to
+    // fill it. Multi-tool segments keep their own chrome; a tool still executing
+    // is covered by its own loading placeholder (areWorkflowToolsComplete=false).
+    const lastSegment = segments.at(-1);
+    const showTailRunningIndicator =
+      isGenerating &&
+      lastSegment?.kind === 'workflow' &&
+      shouldInlineWorkflowSegment(lastSegment.blocks) &&
+      areWorkflowToolsComplete(lastSegment.blocks.flatMap((block) => block.tools ?? []));
+
     if (isCollapsed) {
       return (
         content && (
@@ -499,6 +514,7 @@ const Group = memo<GroupChildrenProps>(
               />
             );
           })}
+          {showTailRunningIndicator && <ContentLoading id={id} />}
         </Flexbox>
       </MessageAggregationContext>
     );


### PR DESCRIPTION
## 💡 背景

异构 agent(Claude Code / Codex)的一个 turn 里,工具调用有两条渲染路径:

- **多工具** → `WorkflowCollapse`,它的 header 在 streaming 阶段(含工具完成后的间隙)已经显示 `NeuralNetworkLoading` + "Working..." + 计时;
- **单工具** → `shouldInlineWorkflowSegment` 走 inline `GroupItem`,**裸渲染、没有任何 working chrome**。

于是当一个 turn 以「单工具调用」收尾、工具已成功返回、但运行时仍在等下一步(loading 中、还没有下一条文本)时,工具卡片下方是一片空白,读起来像"卡住了"。

![scenario](https://github.com/user-attachments/assets/placeholder)

## 🔧 改动

在 `Group.tsx` 的 segments 末尾补一个运行中指示器,触发条件:

- `isGenerating`(turn 仍在跑)
- 最后一段是 **inline 单工具** segment
- 该工具已结束(`areWorkflowToolsComplete` 为 true)

满足时复用 turn 起始那个 `ContentLoading`(即 "Claude Code is running… (Ns)"),把空白填上。

### 为什么不会重复

- **多工具**段走 `WorkflowCollapse`,有自己的 streaming header,本次条件 `shouldInlineWorkflowSegment` 排除了它;
- **工具执行中**时 `areWorkflowToolsComplete` 为 false,该阶段由 Tool 自身的 loading placeholder 兜底;
- **存在后续文本/答案块**时,最后一段是 `answer`(或空块自带 `ContentLoading`),本次条件 `kind === 'workflow'` 不命中。

三种情况互斥,不会出现双指示器。

## ✅ 测试

`Group.test.tsx` 新增 3 个用例:生成中 + 工具已完成 → 显示;生成中 + 工具执行中 → 不显示;已完成 → 不显示。共 9 个用例全过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
