### PR TITLE
🎨 refactor(local-system): preserve ANSI escape codes in command output

### DIFF
--- a/packages/local-file-shell/src/shell/__tests__/utils.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/utils.test.ts
@@ -1,35 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getShellConfig, MAX_OUTPUT_LENGTH, stripAnsi, truncateOutput } from '../utils';
-
-describe('stripAnsi', () => {
-  it('should strip ANSI color codes', () => {
-    expect(stripAnsi('\x1B[31mred\x1B[0m')).toBe('red');
-  });
-
-  it('should strip complex ANSI sequences', () => {
-    expect(stripAnsi('\x1B[38;5;250m███████╗\x1B[0m')).toBe('███████╗');
-  });
-
-  it('should strip bold/bright codes', () => {
-    expect(stripAnsi('\x1B[1;32mSuccess\x1B[0m')).toBe('Success');
-  });
-
-  it('should handle string without ANSI codes', () => {
-    expect(stripAnsi('plain text')).toBe('plain text');
-  });
-
-  it('should handle empty string', () => {
-    expect(stripAnsi('')).toBe('');
-  });
-
-  it('should strip multiple ANSI sequences', () => {
-    const input = '\x1B[33mwarning:\x1B[0m something \x1B[31mhappened\x1B[0m';
-    expect(input).toContain('\x1B[');
-    expect(stripAnsi(input)).toBe('warning: something happened');
-    expect(stripAnsi(input)).not.toContain('\x1B[');
-  });
-});
+import { getShellConfig, MAX_OUTPUT_LENGTH, truncateOutput } from '../utils';
 
 describe('truncateOutput', () => {
   it('should return string as-is when within limit', () => {
@@ -45,10 +16,11 @@ describe('truncateOutput', () => {
     expect(result).toContain('more characters');
   });
 
-  it('should strip ANSI before checking length', () => {
+  it('should preserve ANSI escape codes so the client can render colors', () => {
     const colored = '\x1B[31m' + 'x'.repeat(50) + '\x1B[0m';
     const result = truncateOutput(colored, 100);
-    expect(result).toBe('x'.repeat(50));
+    expect(result).toBe(colored);
+    expect(result).toContain('\x1B[');
   });
 
   it('should use MAX_OUTPUT_LENGTH as default', () => {

--- a/packages/local-file-shell/src/shell/__tests__/utils.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/utils.test.ts
@@ -23,6 +23,37 @@ describe('truncateOutput', () => {
     expect(result).toContain('\x1B[');
   });
 
+  it('should reset an open SGR state before the truncation notice', () => {
+    // A long colored line whose closing \x1B[0m falls beyond the cut boundary.
+    const colored = '\x1B[31m' + 'x'.repeat(200) + '\x1B[0m';
+    const result = truncateOutput(colored, 100);
+
+    expect(result).toContain('truncated');
+    // The reset must sit right before the notice so the color cannot bleed into it.
+    expect(result).toContain('\x1B[0m\n... [truncated');
+    // Everything after the reset (the notice) carries no further escape codes.
+    const notice = result.slice(result.indexOf('\x1B[0m\n'));
+    expect(notice.slice('\x1B[0m'.length)).not.toContain('\x1B[');
+  });
+
+  it('should drop a partial escape sequence left dangling at the cut boundary', () => {
+    // maxLength lands in the middle of the second color sequence (\x1B[32 has no final byte yet).
+    const input = '\x1B[31mred' + '\x1B[32mgreen';
+    const cutInsideEscape = ('\x1B[31mred' + '\x1B[32').length;
+    const result = truncateOutput(input, cutInsideEscape);
+
+    // The incomplete \x1B[32 must be removed, not carried into the output.
+    expect(result).not.toContain('\x1B[32');
+    expect(result.startsWith('\x1B[31mred')).toBe(true);
+    expect(result).toContain('\x1B[0m\n... [truncated');
+  });
+
+  it('should not inject an ANSI reset into plain (non-colored) output', () => {
+    const result = truncateOutput('x'.repeat(200), 100);
+    expect(result).not.toContain('\x1B');
+    expect(result).toBe('x'.repeat(100) + '\n... [truncated, 100 more characters]');
+  });
+
   it('should use MAX_OUTPUT_LENGTH as default', () => {
     const long = 'x'.repeat(MAX_OUTPUT_LENGTH + 1000);
     const result = truncateOutput(long);

--- a/packages/local-file-shell/src/shell/index.ts
+++ b/packages/local-file-shell/src/shell/index.ts
@@ -2,4 +2,4 @@ export type { ShellProcess } from './process-manager';
 export { ShellProcessManager } from './process-manager';
 export type { RunCommandOptions } from './runner';
 export { runCommand } from './runner';
-export { getShellConfig, MAX_OUTPUT_LENGTH, stripAnsi, truncateOutput } from './utils';
+export { getShellConfig, MAX_OUTPUT_LENGTH, truncateOutput } from './utils';

--- a/packages/local-file-shell/src/shell/utils.ts
+++ b/packages/local-file-shell/src/shell/utils.ts
@@ -1,21 +1,14 @@
 /** Maximum output length to prevent context explosion */
 export const MAX_OUTPUT_LENGTH = 80_000;
 
-/** Strip ANSI escape codes from terminal output */
-// eslint-disable-next-line no-control-regex, regexp/no-obscure-range
-const ANSI_REGEX = /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
-
-export const stripAnsi = (str: string): string => str.replaceAll(ANSI_REGEX, '');
-
-/** Truncate string to max length with indicator */
+/**
+ * Truncate string to max length with indicator.
+ * ANSI escape codes are preserved so the client can render colored output.
+ */
 export const truncateOutput = (str: string, maxLength: number = MAX_OUTPUT_LENGTH): string => {
-  const cleaned = stripAnsi(str);
-  if (cleaned.length <= maxLength) return cleaned;
+  if (str.length <= maxLength) return str;
   return (
-    cleaned.slice(0, maxLength) +
-    '\n... [truncated, ' +
-    (cleaned.length - maxLength) +
-    ' more characters]'
+    str.slice(0, maxLength) + '\n... [truncated, ' + (str.length - maxLength) + ' more characters]'
   );
 };
 

--- a/packages/local-file-shell/src/shell/utils.ts
+++ b/packages/local-file-shell/src/shell/utils.ts
@@ -1,15 +1,38 @@
 /** Maximum output length to prevent context explosion */
 export const MAX_OUTPUT_LENGTH = 80_000;
 
+/** ANSI SGR reset, closes any open color/style state */
+const ANSI_RESET = '\u001B[0m';
+
+/** Matches a complete ANSI escape sequence anchored at the start of the string */
+// eslint-disable-next-line no-control-regex, regexp/no-obscure-range
+const ANSI_ESCAPE_AT_START = /^\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/;
+
 /**
  * Truncate string to max length with indicator.
- * ANSI escape codes are preserved so the client can render colored output.
+ *
+ * ANSI escape codes are preserved so the client can render colored output, but a
+ * naive slice can (a) cut across an escape sequence and (b) stop while a color or
+ * style is still open. Either would bleed styling into the truncation notice and
+ * anything the client renders afterwards. So we drop a dangling partial sequence
+ * at the cut boundary and append a reset before the notice.
  */
 export const truncateOutput = (str: string, maxLength: number = MAX_OUTPUT_LENGTH): string => {
   if (str.length <= maxLength) return str;
-  return (
-    str.slice(0, maxLength) + '\n... [truncated, ' + (str.length - maxLength) + ' more characters]'
-  );
+
+  let slice = str.slice(0, maxLength);
+
+  // Drop a partial escape sequence left dangling at the cut boundary, otherwise
+  // it would consume the leading characters of the truncation notice.
+  const lastEsc = slice.lastIndexOf('\u001B');
+  if (lastEsc !== -1 && !ANSI_ESCAPE_AT_START.test(slice.slice(lastEsc))) {
+    slice = slice.slice(0, lastEsc);
+  }
+
+  // Reset any still-open SGR state so it cannot leak into the notice.
+  const reset = slice.includes('\u001B') ? ANSI_RESET : '';
+
+  return slice + reset + '\n... [truncated, ' + (str.length - maxLength) + ' more characters]';
 };
 
 /** Get cross-platform shell configuration */


### PR DESCRIPTION
### 💻 Change Type

- [x] 💄 style / refactor

### 🔀 Description of Change

The chat client now renders ANSI escape sequences, so stripping color codes from `lobe-local-system` command output is no longer necessary — it was actively discarding the colored terminal output users could otherwise see.

- Removed the `ANSI_REGEX` / `stripAnsi()` helper from `packages/local-file-shell/src/shell/utils.ts`.
- `truncateOutput()` now truncates the raw string directly, preserving escape codes (length check runs against the same raw string that gets returned).
- Dropped `stripAnsi` from the package barrel export.
- Updated tests: removed the `stripAnsi` suite; the former "strip ANSI before checking length" case now asserts colored input round-trips unchanged.

The two other `stripAnsi` implementations in the repo (`src/libs/debug-file-logger.ts` for the debug log file, `apps/cli/src/utils/format.ts` for CLI rendering) are intentionally left alone — neither touches the tool-result payload.

### 📝 How to Test

- [x] Unit tests: `bunx vitest run packages/local-file-shell/src/shell/__tests__/utils.test.ts`
- Run a colored command (e.g. `ls --color=always`, `npm` output) via the local-system tool and confirm ANSI colors now render in the chat client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)