### PR TITLE
🐛 fix(market-auth): skip auth flow when LobeChat session is missing

### DIFF
--- a/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
+++ b/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
@@ -392,6 +392,9 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
    * Sign-in method (shows confirmation dialog first)
    */
   const signIn = useCallback(async (): Promise<number | null> => {
+    if (!useUserStore.getState().isSignedIn) {
+      throw new Error('LobeChat session required');
+    }
     return new Promise<number | null>((resolve, reject) => {
       setPendingSignInResolve(() => resolve);
       setPendingSignInReject(() => reject);

--- a/src/libs/trpc/client/lambda.ts
+++ b/src/libs/trpc/client/lambda.ts
@@ -44,6 +44,10 @@ const errorHandlingLink: TRPCLink<LambdaRouter> = () => {
                 if (isMarketApi) {
                   // Market API 401: emit event for MarketAuthProvider to handle
                   // Don't trigger LobeChat logout for market auth issues
+                  const { getUserStoreState } = await import('@/store/user/store');
+                  // Without a LobeChat session a market.* 401 is not a Market auth
+                  // issue — let it bubble instead of triggering the auth modal
+                  if (!getUserStoreState().isSignedIn) break;
                   const now = Date.now();
                   if (now - lastMarket401Time > MIN_401_INTERVAL) {
                     lastMarket401Time = now;

--- a/src/libs/trpc/client/tools.ts
+++ b/src/libs/trpc/client/tools.ts
@@ -30,16 +30,22 @@ const errorHandlingLink: TRPCLink<ToolsRouter> = () => {
           // UNAUTHORIZED tRPC code maps to HTTP 401
           const is401 = status === 401 || code === 'UNAUTHORIZED';
           if (is401 && op.path.startsWith('market.')) {
-            const now = Date.now();
-            if (now - lastMarket401Time > MIN_401_INTERVAL) {
-              lastMarket401Time = now;
-              console.info('[toolsClient] Emitting market-unauthorized event for path:', op.path);
-              // Emit event for MarketAuthProvider to handle
-              const { marketAuthEvents } = await import('@/layout/AuthProvider/MarketAuth/events');
-              marketAuthEvents.emit('market-unauthorized', {
-                path: op.path,
-                timestamp: now,
-              });
+            const { getUserStoreState } = await import('@/store/user/store');
+            // Without a LobeChat session a market.* 401 is not a Market auth
+            // issue — let it bubble instead of triggering the auth modal
+            if (getUserStoreState().isSignedIn) {
+              const now = Date.now();
+              if (now - lastMarket401Time > MIN_401_INTERVAL) {
+                lastMarket401Time = now;
+                console.info('[toolsClient] Emitting market-unauthorized event for path:', op.path);
+                // Emit event for MarketAuthProvider to handle
+                const { marketAuthEvents } =
+                  await import('@/layout/AuthProvider/MarketAuth/events');
+                marketAuthEvents.emit('market-unauthorized', {
+                  path: op.path,
+                  timestamp: now,
+                });
+              }
             }
           }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The **Create Community Profile** modal (`MarketAuthConfirmModal`) was popping up for users who weren't signed in to LobeChat at all. It happened through two paths:

1. **Auto-triggered via `market-unauthorized` event.** In trusted-client (cloud) mode, `isAuthenticated` is computed as `enableMarketTrustedClient || status === 'authenticated'` — always `true` once the server flag is set, regardless of LobeChat session. Components therefore freely call `market.*` tRPC procedures; backend rejects with 401 because there's no LobeChat session to mint a trusted-client token; the lambda/tools tRPC error link sees `op.path.startsWith('market.')` and emits `market-unauthorized`; `MarketAuthProvider` reacts by calling `signIn()`, which opens the modal.
2. **User explicitly clicking a button** wired to `signIn()` (Follow / Publish / etc.) without first being signed in to LobeChat.

This PR guards both paths on `useUserStore.isSignedIn`:

- `MarketAuthProvider.signIn()` throws synchronously when no LobeChat session exists, so the confirm modal never opens.
- The `market.*` 401 branches in `src/libs/trpc/client/lambda.ts` and `src/libs/trpc/client/tools.ts` `break` out before emitting `market-unauthorized`, letting the error bubble naturally.

Routing the user back to LobeChat sign-in is **not** MarketAuth's responsibility — upstream callers / UI handle that. `isAuthenticated` is intentionally left untouched so its semantic ("market authorized") stays clean.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. Open the app in an incognito/clean state so LobeChat user is signed out (`useUserStore.getState().isSignedIn === false`).
2. Visit community-related routes that fire `market.*` queries (e.g. community list, user detail page).
3. Confirm the **Create Community Profile** modal does **not** appear.
4. Sign in to LobeChat, then click a Market action (Follow, Publish, etc.) and confirm the modal still appears as designed.

#### 📝 Additional Information

Behavior unchanged for signed-in users. No public API or schema changes.