### PR TITLE
🐛 fix: fall back to model config when model parameters is an empty object

### DIFF
--- a/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
+++ b/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
@@ -144,6 +144,36 @@ describe('aiProvider action helpers', () => {
       expect(fallbackSpy).toHaveBeenCalledWith('stable-diffusion', 'pricing', 'stability');
       expect(fallbackSpy).toHaveBeenCalledWith('stable-diffusion', 'description', 'stability');
     });
+
+    it('falls back to model config when parameters is an empty object', async () => {
+      // Regression for #15493: the `parameters` DB column defaults to `{}`, which
+      // must be treated as missing so required fields (e.g. `prompt`) are restored
+      // from the bundled model config instead of failing schema validation.
+      const fallbackSpy = vi
+        .mocked(runtimeModule.getModelPropertyWithFallback)
+        .mockImplementation(async (_id, key) => {
+          if (key === 'parameters')
+            return {
+              prompt: { default: '' },
+              size: { default: '1024x1024', enum: ['512x512', '1024x1024'] },
+            } satisfies ModelParamsSchema;
+          return undefined;
+        });
+
+      const model = createImageModel({
+        id: 'cogview-4',
+        parameters: {} as ModelParamsSchema,
+        providerId: 'zhipu',
+      });
+
+      const result = await normalizeImageModel(model);
+
+      expect(result.parameters).toEqual({
+        prompt: { default: '' },
+        size: { default: '1024x1024', enum: ['512x512', '1024x1024'] },
+      });
+      expect(fallbackSpy).toHaveBeenCalledWith('cogview-4', 'parameters', 'zhipu');
+    });
   });
 
   describe('getChatModelList', () => {

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -61,6 +61,26 @@ const getModelProperty = async <T>(
   return getModelPropertyWithFallback<T | undefined>(model.id, propertyName, model.providerId);
 };
 
+const hasParameters = (
+  parameters?: ModelParamsSchema,
+): parameters is ModelParamsSchema => !!parameters && Object.keys(parameters).length > 0;
+
+const resolveModelParameters = async (
+  model: EnabledAiModel,
+): Promise<ModelParamsSchema | undefined> => {
+  // The `parameters` DB column defaults to `{}`, and enabling a model never
+  // populates it. An empty object is truthy, so a naive truthy check would skip
+  // the fallback and leave required fields (e.g. `prompt`) missing, which later
+  // fails schema validation. Treat an empty object as "no inline parameters".
+  if (hasParameters(model.parameters)) return model.parameters;
+
+  return getModelPropertyWithFallback<ModelParamsSchema | undefined>(
+    model.id,
+    'parameters',
+    model.providerId,
+  );
+};
+
 const dedupeById = (models: ProviderModelListItem[]) => uniqBy(models, 'id');
 
 const createProviderModelCollector = (
@@ -99,26 +119,12 @@ export const normalizeChatModel = async (model: EnabledAiModel): Promise<Provide
 export const normalizeImageModel = async (
   model: EnabledAiModel,
 ): Promise<ProviderModelListItem> => {
-  const fallbackParametersPromise = model.parameters
-    ? Promise.resolve<ModelParamsSchema | undefined>(model.parameters)
-    : getModelPropertyWithFallback<ModelParamsSchema | undefined>(
-        model.id,
-        'parameters',
-        model.providerId,
-      );
-
-  const fallbackPricingPromise = getModelProperty<Pricing>(model, 'pricing');
-  const fallbackDescriptionPromise = getModelProperty<string>(model, 'description');
-
-  const [fallbackParameters, fallbackPricing, fallbackDescription] = await Promise.all([
-    fallbackParametersPromise,
-    fallbackPricingPromise,
-    fallbackDescriptionPromise,
+  const [parameters, pricing, description] = await Promise.all([
+    resolveModelParameters(model),
+    getModelProperty<Pricing>(model, 'pricing'),
+    getModelProperty<string>(model, 'description'),
   ]);
 
-  const parameters = model.parameters ?? fallbackParameters;
-  const pricing = fallbackPricing;
-  const description = fallbackDescription;
   const { price, approximatePrice } = resolveImageSinglePrice(pricing);
 
   return {
@@ -138,26 +144,12 @@ export const normalizeImageModel = async (
 export const normalizeVideoModel = async (
   model: EnabledAiModel,
 ): Promise<ProviderModelListItem> => {
-  const fallbackParametersPromise = model.parameters
-    ? Promise.resolve<ModelParamsSchema | undefined>(model.parameters)
-    : getModelPropertyWithFallback<ModelParamsSchema | undefined>(
-        model.id,
-        'parameters',
-        model.providerId,
-      );
-
-  const fallbackPricingPromise = getModelProperty<Pricing>(model, 'pricing');
-  const fallbackDescriptionPromise = getModelProperty<string>(model, 'description');
-
-  const [fallbackParameters, fallbackPricing, fallbackDescription] = await Promise.all([
-    fallbackParametersPromise,
-    fallbackPricingPromise,
-    fallbackDescriptionPromise,
+  const [parameters, pricing, description] = await Promise.all([
+    resolveModelParameters(model),
+    getModelProperty<Pricing>(model, 'pricing'),
+    getModelProperty<string>(model, 'description'),
   ]);
 
-  const parameters = model.parameters ?? fallbackParameters;
-  const pricing = fallbackPricing;
-  const description = fallbackDescription;
   const { approximatePrice } = resolveVideoSinglePrice(pricing);
 
   return {


### PR DESCRIPTION
## Problem

Closes #15493.

Selecting a ZhipuAI image model (GLM-IMAGE, CogView-4, CogView-3-Flash) in the image-generation workspace throws a `ZodError`:

```json
{ "name": "ZodError", "message": "[{\"code\":\"invalid_type\",\"expected\":\"object\",\"received\":\"undefined\",\"path\":[\"prompt\"],\"message\":\"Required\"}]" }
```

The `parameters` column in `packages/database/src/schemas/aiInfra.ts` defaults to `{}`, and enabling a model (`toggleModelEnabled` / `batchToggleAiModels`) never populates it — so a stored model carries an empty `parameters` object.

In `normalizeImageModel` / `normalizeVideoModel`, the fallback was selected with a truthy check:

```ts
const fallbackParametersPromise = model.parameters
  ? Promise.resolve(model.parameters)   // {} is truthy → empty object is kept
  : getModelPropertyWithFallback(...);  // fallback never runs
```

Because `{}` is truthy, the fallback to the bundled model config was skipped, and `const parameters = model.parameters ?? fallbackParameters` (nullish, so `{}` survives too) left the parameters empty. The empty object then fails `ModelParamsMetaSchema.parse()` since `prompt` is required.

## Solution

Extract a shared `resolveModelParameters` helper that treats an empty object as "no inline parameters" and falls back to the model config in that case. Both `normalizeImageModel` and `normalizeVideoModel` had the same duplicated logic and the same bug, so both now use the helper. No behavior change for models that already have inline parameters.

## Testing

- Added a regression test in `action.test.ts`: a model with `parameters: {}` now resolves parameters from `getModelPropertyWithFallback`. Verified it fails on the previous code and passes with the fix.
- `bunx vitest run src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts` — 10 passed
- `bun run type-check` — passes