### PR TITLE
🧹 chore: clean LOBE marker comments from aiInfra schema (2026-06-08)

### DIFF
--- a/packages/database/src/schemas/aiInfra.ts
+++ b/packages/database/src/schemas/aiInfra.ts
@@ -23,9 +23,12 @@ export const aiProviders = pgTable(
     name: text('name'),
 
     /**
-     * Surrogate key for the online workspace-scoped rebuild (LOBE-10056). Added
-     * nullable + DEFAULT so it's a catalog-only change (no table rewrite); a
-     * later manual step backfills history and adds NOT NULL.
+     * Surrogate primary key for the ai_providers workspace-scoped unique
+     * constraints migration. The original composite PK (id, user_id) was
+     * incompatible with workspace-scoped duplicates because workspace_id can
+     * be NULL for personal rows. Added nullable + DEFAULT to avoid a full
+     * table rewrite; a later manual step backfills history and adds NOT NULL
+     * before the unique index + PK swap.
      */
     _id: uuid('_id').defaultRandom(),
 
@@ -71,9 +74,12 @@ export const aiModels = pgTable(
     id: varchar('id', { length: 150 }).notNull(),
 
     /**
-     * Surrogate key for the online workspace-scoped rebuild (LOBE-10056). Added
-     * nullable + DEFAULT so it's a catalog-only change (no table rewrite); a
-     * later manual step backfills history and adds NOT NULL.
+     * Surrogate primary key for the ai_models workspace-scoped unique
+     * constraints migration. The original composite PK (id, provider_id,
+     * user_id) was incompatible with workspace-scoped duplicates because
+     * workspace_id can be NULL for personal rows. Added nullable + DEFAULT
+     * to avoid a full table rewrite (~4M rows); a later manual step
+     * backfills history and adds NOT NULL before the unique index + PK swap.
      */
     _id: uuid('_id').defaultRandom(),
 


### PR DESCRIPTION
## Summary

Daily scan found 2 `LOBE-10056` marker comments in `packages/database/src/schemas/aiInfra.ts`. Replaced with inline context explaining the workspace-scoped surrogate PK migration rationale.

## Changes

### `packages/database/src/schemas/aiInfra.ts`

- **`aiProviders._id`**: Replaced `(LOBE-10056)` reference with description of why surrogate PK was needed (composite PK incompatible with `workspace_id` NULL for personal rows).
- **`aiModels._id`**: Same cleanup, noting the \~4M row scale constraint.

## Context

Both columns were added as part of Phase 5 Migration 0110 ([LOBE-10056](https://linear.app/lobehub/issue/LOBE-10056)) — ai_infra workspace-scoped unique constraints migration. The comments now carry the rationale directly instead of an opaque Linear reference.

## Verification

- `git grep 'LOBE-[0-9]'` returns zero matches in source files
- Lint-staged passes (eslint + prettier)

---
Generated on 2026-06-08