### PR TITLE
✨ feat(connector): wire custom MCP OAuth — Pre-registration & DCR (LOBE-9983)

### DIFF
--- a/packages/context-engine/src/providers/AgentManagementContextInjector.ts
+++ b/packages/context-engine/src/providers/AgentManagementContextInjector.ts
@@ -66,8 +66,11 @@ export interface AvailablePluginInfo {
   identifier: string;
   /** Plugin display name */
   name: string;
-  /** Plugin type: 'builtin' for built-in tools, 'klavis' for Klavis servers, 'lobehub-skill' for LobehubSkill providers */
-  type: 'builtin' | 'klavis' | 'lobehub-skill';
+  /**
+   * Plugin type: 'builtin' for built-in tools, 'klavis' for Klavis servers,
+   * 'lobehub-skill' for LobehubSkill providers, 'connector' for custom MCP connectors
+   */
+  type: 'builtin' | 'klavis' | 'lobehub-skill' | 'connector';
 }
 
 /**
@@ -165,6 +168,7 @@ const defaultFormatContext = (context: AgentManagementContext): string => {
     const builtinPlugins = context.availablePlugins.filter((p) => p.type === 'builtin');
     const klavisPlugins = context.availablePlugins.filter((p) => p.type === 'klavis');
     const lobehubSkillPlugins = context.availablePlugins.filter((p) => p.type === 'lobehub-skill');
+    const connectorPlugins = context.availablePlugins.filter((p) => p.type === 'connector');
 
     const pluginsSections: string[] = [];
 
@@ -198,6 +202,16 @@ const defaultFormatContext = (context: AgentManagementContext): string => {
       pluginsSections.push(
         `  <lobehub_skill_plugins>\n${lobehubSkillItems}\n  </lobehub_skill_plugins>`,
       );
+    }
+
+    if (connectorPlugins.length > 0) {
+      const connectorItems = connectorPlugins
+        .map((p) => {
+          const desc = p.description ? ` - ${escapeXml(p.description)}` : '';
+          return `    <plugin id="${p.identifier}">${escapeXml(p.name)}${desc}</plugin>`;
+        })
+        .join('\n');
+      pluginsSections.push(`  <connector_plugins>\n${connectorItems}\n  </connector_plugins>`);
     }
 
     if (pluginsSections.length > 0) {

--- a/packages/database/src/models/connector.ts
+++ b/packages/database/src/models/connector.ts
@@ -27,15 +27,17 @@ type UpdateConnectorParams = Partial<
 export class ConnectorModel {
   private userId: string;
   private db: LobeChatDatabase;
+  private gateKeeper?: GateKeeper;
 
-  constructor(db: LobeChatDatabase, userId: string) {
+  constructor(db: LobeChatDatabase, userId: string, gateKeeper?: GateKeeper) {
     this.db = db;
     this.userId = userId;
+    this.gateKeeper = gateKeeper;
   }
 
   create = async (
     params: CreateConnectorParams,
-    gateKeeper?: GateKeeper,
+    gateKeeper: GateKeeper | undefined = this.gateKeeper,
   ): Promise<UserConnectorItem> => {
     const credentials = params.credentials
       ? await encryptCredentials(params.credentials, gateKeeper)
@@ -55,7 +57,9 @@ export class ConnectorModel {
       .where(and(eq(userConnectors.id, id), eq(userConnectors.userId, this.userId)));
   };
 
-  query = async (gateKeeper?: GateKeeper): Promise<DecryptedConnector[]> => {
+  query = async (
+    gateKeeper: GateKeeper | undefined = this.gateKeeper,
+  ): Promise<DecryptedConnector[]> => {
     const rows = await this.db
       .select()
       .from(userConnectors)
@@ -66,7 +70,7 @@ export class ConnectorModel {
 
   queryByIdentifiers = async (
     identifiers: string[],
-    gateKeeper?: GateKeeper,
+    gateKeeper: GateKeeper | undefined = this.gateKeeper,
   ): Promise<DecryptedConnector[]> => {
     if (identifiers.length === 0) return [];
 
@@ -83,7 +87,10 @@ export class ConnectorModel {
     return Promise.all(rows.map((r) => decryptRow(r, gateKeeper)));
   };
 
-  findById = async (id: string, gateKeeper?: GateKeeper): Promise<DecryptedConnector | null> => {
+  findById = async (
+    id: string,
+    gateKeeper: GateKeeper | undefined = this.gateKeeper,
+  ): Promise<DecryptedConnector | null> => {
     const [row] = await this.db
       .select()
       .from(userConnectors)
@@ -97,7 +104,7 @@ export class ConnectorModel {
   update = async (
     id: string,
     patch: UpdateConnectorParams,
-    gateKeeper?: GateKeeper,
+    gateKeeper: GateKeeper | undefined = this.gateKeeper,
   ): Promise<void> => {
     const credentials =
       patch.credentials !== undefined && patch.credentials !== null

--- a/packages/database/src/schemas/connector.ts
+++ b/packages/database/src/schemas/connector.ts
@@ -30,6 +30,15 @@ export interface OIDCConfig {
    */
   clientId?: string;
 
+  /**
+   * Client secret for confidential clients.
+   * - pre_registration: filled in by the user
+   * - dcr: written back after dynamic registration succeeds
+   * Stored in plaintext (non-token credential); access/refresh tokens live
+   * encrypted in `credentials` instead.
+   */
+  clientSecret?: string;
+
   /** OIDC discovery issuer URL — preferred over manual endpoint overrides */
   issuer?: string;
   redirectUri?: string;

--- a/src/app/(backend)/oauth/connector/callback/route.ts
+++ b/src/app/(backend)/oauth/connector/callback/route.ts
@@ -23,13 +23,26 @@ const targetOrigin = (): string => {
   }
 };
 
+/**
+ * Serialize a value for safe embedding inside an inline `<script>`. Plain
+ * JSON.stringify does NOT escape `</script>` or the U+2028/U+2029 line
+ * separators, so an attacker-controlled OAuth error string could break out of
+ * the script context and execute on the app origin. Escaping `<`, `>`, `&` and
+ * the JS line separators to their `\uXXXX` form closes that hole.
+ */
+const jsonForScript = (value: unknown): string =>
+  JSON.stringify(value).replaceAll(
+    /[<>&\u2028\u2029]/g,
+    (c) => '\\u' + c.codePointAt(0)!.toString(16).padStart(4, '0'),
+  );
+
 /** Auto-closing popup page that reports the result back to the opener window. */
 const renderResultPage = (result: {
   connectorId?: string;
   error?: string;
   success: boolean;
 }): NextResponse => {
-  const payload = JSON.stringify({ type: 'lobe-connector-oauth', ...result });
+  const payload = jsonForScript({ type: 'lobe-connector-oauth', ...result });
   const html = `<!doctype html>
 <html>
   <head><meta charset="utf-8" /><title>Connector authorization</title></head>
@@ -39,7 +52,7 @@ const renderResultPage = (result: {
       (function () {
         try {
           if (window.opener) {
-            window.opener.postMessage(${payload}, ${JSON.stringify(targetOrigin())});
+            window.opener.postMessage(${payload}, ${jsonForScript(targetOrigin())});
           }
         } catch (e) {}
         setTimeout(function () { window.close(); }, 300);

--- a/src/app/(backend)/oauth/connector/callback/route.ts
+++ b/src/app/(backend)/oauth/connector/callback/route.ts
@@ -1,0 +1,120 @@
+import { discoverAuthorizationServerMetadata } from '@modelcontextprotocol/sdk/client/auth.js';
+import debug from 'debug';
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { ConnectorModel } from '@/database/models/connector';
+import { ConnectorStatus } from '@/database/schemas';
+import { serverDB } from '@/database/server';
+import { appEnv } from '@/envs/app';
+import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
+import { exchangeConnectorCode } from '@/server/services/connector/oauth';
+import { consumeConnectorOAuthState } from '@/server/services/connector/stateStore';
+import { tokensToCredentials } from '@/server/services/connector/tokens';
+
+const log = debug('lobe-server:connector:oauth-callback');
+
+/** Origin allowed to receive the postMessage result (the app itself). */
+const targetOrigin = (): string => {
+  try {
+    return appEnv.APP_URL ? new URL(appEnv.APP_URL).origin : '*';
+  } catch {
+    return '*';
+  }
+};
+
+/** Auto-closing popup page that reports the result back to the opener window. */
+const renderResultPage = (result: {
+  connectorId?: string;
+  error?: string;
+  success: boolean;
+}): NextResponse => {
+  const payload = JSON.stringify({ type: 'lobe-connector-oauth', ...result });
+  const html = `<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>Connector authorization</title></head>
+  <body style="font-family: system-ui, sans-serif; padding: 24px; text-align: center;">
+    <p>${result.success ? 'Authorization complete. You can close this window.' : 'Authorization failed.'}</p>
+    <script>
+      (function () {
+        try {
+          if (window.opener) {
+            window.opener.postMessage(${payload}, ${JSON.stringify(targetOrigin())});
+          }
+        } catch (e) {}
+        setTimeout(function () { window.close(); }, 300);
+      })();
+    </script>
+  </body>
+</html>`;
+  return new NextResponse(html, {
+    headers: { 'content-type': 'text/html; charset=utf-8' },
+  });
+};
+
+export const GET = async (req: NextRequest) => {
+  const searchParams = req.nextUrl.searchParams;
+  const code = searchParams.get('code');
+  const state = searchParams.get('state');
+  const oauthError = searchParams.get('error');
+
+  if (oauthError) {
+    log('authorization server returned error: %s', oauthError);
+    return renderResultPage({ error: oauthError, success: false });
+  }
+
+  if (!code || !state) {
+    return renderResultPage({ error: 'missing_code_or_state', success: false });
+  }
+
+  try {
+    const payload = await consumeConnectorOAuthState(state);
+    if (!payload) {
+      return renderResultPage({ error: 'invalid_or_expired_state', success: false });
+    }
+
+    const gateKeeper = await KeyVaultsGateKeeper.initWithEnvKey();
+    const connectorModel = new ConnectorModel(serverDB, payload.lobeUserId, gateKeeper);
+
+    const connector = await connectorModel.findById(payload.connectorId);
+    if (!connector) {
+      return renderResultPage({ error: 'connector_not_found', success: false });
+    }
+
+    const oidc = connector.oidcConfig;
+    if (!oidc?.clientId) {
+      return renderResultPage({ error: 'connector_missing_client', success: false });
+    }
+
+    const metadata = await discoverAuthorizationServerMetadata(payload.authorizationServerUrl);
+    if (!metadata) {
+      return renderResultPage({ error: 'metadata_discovery_failed', success: false });
+    }
+
+    const tokens = await exchangeConnectorCode({
+      authorizationCode: code,
+      authorizationServerUrl: payload.authorizationServerUrl,
+      clientInformation: { client_id: oidc.clientId, client_secret: oidc.clientSecret },
+      codeVerifier: payload.codeVerifier,
+      metadata,
+      redirectUri: oidc.redirectUri!,
+      resource: connector.mcpServerUrl ?? undefined,
+    });
+
+    const { credentials, tokenExpiresAt } = tokensToCredentials(tokens, {
+      clientSecret: oidc.clientSecret,
+    });
+
+    await connectorModel.update(payload.connectorId, {
+      credentials: JSON.stringify(credentials),
+      status: ConnectorStatus.connected,
+      tokenExpiresAt,
+    });
+
+    log('connector %s authorized for user %s', payload.connectorId, payload.lobeUserId);
+    return renderResultPage({ connectorId: payload.connectorId, success: true });
+  } catch (err) {
+    log('connector OAuth callback error: %O', err);
+    const message = err instanceof Error ? err.message : 'internal_error';
+    return renderResultPage({ error: message, success: false });
+  }
+};

--- a/src/app/(backend)/oauth/connector/callback/route.ts
+++ b/src/app/(backend)/oauth/connector/callback/route.ts
@@ -3,12 +3,13 @@ import debug from 'debug';
 import { type NextRequest, NextResponse } from 'next/server';
 
 import { ConnectorModel } from '@/database/models/connector';
-import { ConnectorStatus } from '@/database/schemas';
+import { ConnectorToolModel } from '@/database/models/connectorTool';
 import { serverDB } from '@/database/server';
 import { appEnv } from '@/envs/app';
 import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
 import { exchangeConnectorCode } from '@/server/services/connector/oauth';
 import { consumeConnectorOAuthState } from '@/server/services/connector/stateStore';
+import { syncConnectorToolsById } from '@/server/services/connector/sync';
 import { tokensToCredentials } from '@/server/services/connector/tokens';
 
 const log = debug('lobe-server:connector:oauth-callback');
@@ -106,11 +107,25 @@ export const GET = async (req: NextRequest) => {
 
     await connectorModel.update(payload.connectorId, {
       credentials: JSON.stringify(credentials),
-      status: ConnectorStatus.connected,
       tokenExpiresAt,
     });
 
-    log('connector %s authorized for user %s', payload.connectorId, payload.lobeUserId);
+    // Sync the tool list server-side so the connector is immediately usable —
+    // no dependency on the popup/postMessage round-trip. This also sets the
+    // connector status (connected on success, error on failure).
+    const connectorToolModel = new ConnectorToolModel(serverDB, payload.lobeUserId);
+    try {
+      const { toolCount } = await syncConnectorToolsById(payload.connectorId, {
+        connectorModel,
+        connectorToolModel,
+      });
+      log('connector %s authorized + synced %d tools', payload.connectorId, toolCount);
+    } catch (err) {
+      // Auth succeeded but the tool list could not be fetched; the user can
+      // retry via the Sync button. Still report success to close the popup.
+      log('post-OAuth tool sync failed for connector=%s: %O', payload.connectorId, err);
+    }
+
     return renderResultPage({ connectorId: payload.connectorId, success: true });
   } catch (err) {
     log('connector OAuth callback error: %O', err);

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -26,7 +26,7 @@ import {
   Zap,
 } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
@@ -45,6 +45,7 @@ import {
   lobehubSkillStoreSelectors,
   pluginSelectors,
 } from '@/store/tool/selectors';
+import { connectorSelectors } from '@/store/tool/slices/connector';
 import { KlavisServerStatus } from '@/store/tool/slices/klavisStore';
 import { LobehubSkillStatus } from '@/store/tool/slices/lobehubSkillStore/types';
 
@@ -671,6 +672,14 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
   const marketAgentSkills = useToolStore(agentSkillsSelectors.getMarketAgentSkills, isEqual);
   const userAgentSkills = useToolStore(agentSkillsSelectors.getUserAgentSkills, isEqual);
 
+  // Custom connectors (user-added OAuth MCP servers) from the connector store
+  const customConnectors = useToolStore(connectorSelectors.customConnectors, isEqual);
+  const isConnectorsInit = useToolStore((s) => s.isConnectorsInit);
+  const fetchConnectors = useToolStore((s) => s.fetchConnectors);
+  useEffect(() => {
+    if (!isConnectorsInit) fetchConnectors();
+  }, [isConnectorsInit, fetchConnectors]);
+
   const [
     useFetchUserKlavisServers,
     useFetchLobehubSkillConnections,
@@ -1054,6 +1063,36 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
     [userAgentSkills, t, createManagedSkillItem, deleteAgentSkill],
   );
 
+  // Custom connector list items (user-added OAuth MCP servers).
+  // Toggling adds the connector identifier to agents.plugins[] — the same field
+  // the runtime resolves connectors from, so they become callable immediately.
+  const customConnectorItems = useMemo(
+    () =>
+      customConnectors.map((connector) => {
+        const title = connector.name || connector.identifier;
+        const icon = <Icon icon={McpIcon} size={SKILL_ICON_SIZE} />;
+        const popoverContent = (
+          <ToolItemDetailPopover
+            description={connector.mcpServerUrl ?? ''}
+            icon={<Icon icon={McpIcon} size={36} />}
+            identifier={connector.identifier}
+            sourceLabel={t('skillStore.tabs.custom')}
+            title={title}
+          />
+        );
+
+        return createManagedSkillItem({
+          badge: <Icon icon={McpIcon} size={12} />,
+          icon,
+          id: connector.identifier,
+          popoverContent,
+          searchText: `${title} ${connector.identifier}`,
+          title,
+        });
+      }),
+    [customConnectors, t, createManagedSkillItem],
+  );
+
   // Skills list items (including LobeHub Skill and Klavis)
   // Connected items listed first, deduplicated by key (LobeHub takes priority)
   const skillItems = useMemo(() => {
@@ -1164,10 +1203,11 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
     ...communityPlugins.map(mapPluginToItem),
   ];
 
-  // Build Custom group children (User Agent Skills + custom plugins)
+  // Build Custom group children (User Agent Skills + custom plugins + custom connectors)
   const customGroupChildren: ItemType[] = [
     ...userAgentSkillItems,
     ...customPlugins.map(mapPluginToItem),
+    ...customConnectorItems,
   ];
 
   const normalizedSearchKeyword = searchKeyword.trim().toLowerCase();

--- a/src/features/Connectors/AddConnectorModal/index.tsx
+++ b/src/features/Connectors/AddConnectorModal/index.tsx
@@ -1,5 +1,5 @@
 import { Modal } from '@lobehub/ui/base-ui';
-import { Input } from 'antd';
+import { App, Input } from 'antd';
 import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -12,47 +12,127 @@ interface AddConnectorModalProps {
   open: boolean;
 }
 
+/** Open the authorize URL in a popup and resolve once it reports back. */
+const runOAuthPopup = (authorizationUrl: string, connectorId: string): Promise<boolean> =>
+  new Promise((resolve) => {
+    const popup = window.open(authorizationUrl, 'lobe-connector-oauth', 'width=600,height=720');
+
+    const cleanup = () => {
+      window.removeEventListener('message', onMessage);
+      clearInterval(timer);
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) return;
+      const data = event.data;
+      if (!data || data.type !== 'lobe-connector-oauth') return;
+      if (data.connectorId && data.connectorId !== connectorId) return;
+      cleanup();
+      resolve(Boolean(data.success));
+    };
+
+    window.addEventListener('message', onMessage);
+
+    // Resolve (as failure) if the user closes the popup without authorizing.
+    const timer = setInterval(() => {
+      if (popup?.closed) {
+        cleanup();
+        resolve(false);
+      }
+    }, 800);
+  });
+
 const AddConnectorModal = memo<AddConnectorModalProps>(({ open, onClose }) => {
   const { t } = useTranslation('tool');
+  const { message } = App.useApp();
   const createConnector = useToolStore((s) => s.createConnector);
-  const creating = useToolStore((s) => s.connectorCreating);
+  const startConnectorOAuth = useToolStore((s) => s.startConnectorOAuth);
+  const syncConnectorTools = useToolStore((s) => s.syncConnectorTools);
 
   const [name, setName] = useState('');
   const [url, setUrl] = useState('');
   const [clientId, setClientId] = useState('');
+  const [clientSecret, setClientSecret] = useState('');
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const redirectUri =
+    typeof window === 'undefined' ? '' : `${window.location.origin}/oauth/connector/callback`;
+
+  const reset = () => {
+    setName('');
+    setUrl('');
+    setClientId('');
+    setClientSecret('');
+    setShowAdvanced(false);
+    setSubmitting(false);
+  };
 
   const handleAdd = async () => {
     if (!name.trim() || !url.trim()) return;
-    await createConnector({
-      identifier: name.toLowerCase().replaceAll(/\s+/g, '-'),
-      mcpConnectionType: 'http',
-      mcpServerUrl: url.trim(),
-      name: name.trim(),
-      oidcConfig: clientId.trim()
-        ? { clientId: clientId.trim(), scheme: 'pre_registration' }
-        : undefined,
-      sourceType: ConnectorSourceType.custom,
-    });
-    setName('');
-    setUrl('');
-    setClientId('');
-    setShowAdvanced(false);
-    onClose();
+    setSubmitting(true);
+
+    try {
+      const trimmedClientId = clientId.trim();
+      // client_id present → pre-registration; absent → dynamic client registration (DCR).
+      const scheme = trimmedClientId ? 'pre_registration' : 'dcr';
+
+      const connectorId = await createConnector({
+        identifier: name.toLowerCase().replaceAll(/\s+/g, '-'),
+        mcpConnectionType: 'http',
+        mcpServerUrl: url.trim(),
+        name: name.trim(),
+        oidcConfig: {
+          clientId: trimmedClientId || undefined,
+          clientSecret: clientSecret.trim() || undefined,
+          scheme,
+        },
+        sourceType: ConnectorSourceType.custom,
+      });
+
+      // Kick off the OAuth flow. If the server turns out not to require OAuth
+      // (no authorization server discovered), fall back to a plain tool sync.
+      try {
+        const authorizationUrl = await startConnectorOAuth(connectorId);
+        const ok = await runOAuthPopup(authorizationUrl, connectorId);
+        if (ok) {
+          await syncConnectorTools(connectorId);
+          message.success(t('connector.add.success', 'Connector connected'));
+        } else {
+          message.warning(t('connector.add.cancelled', 'Authorization was not completed'));
+        }
+      } catch {
+        // Not an OAuth server (or DCR unsupported without a client id) — try a
+        // direct sync so non-auth MCP servers still connect.
+        try {
+          await syncConnectorTools(connectorId);
+          message.success(t('connector.add.success', 'Connector connected'));
+        } catch {
+          message.error(
+            t(
+              'connector.add.authFailed',
+              'Could not connect. This server may require an OAuth Client ID in Advanced settings.',
+            ),
+          );
+        }
+      }
+
+      reset();
+      onClose();
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const handleCancel = () => {
-    setName('');
-    setUrl('');
-    setClientId('');
-    setShowAdvanced(false);
+    reset();
     onClose();
   };
 
   return (
     <Modal
       cancelText={t('connector.add.cancel', 'Cancel')}
-      confirmLoading={creating}
+      confirmLoading={submitting}
       okButtonProps={{ disabled: !name.trim() || !url.trim() }}
       okText={t('connector.add.confirm', 'Add')}
       open={open}
@@ -107,7 +187,14 @@ const AddConnectorModal = memo<AddConnectorModalProps>(({ open, onClose }) => {
               />
               <Input.Password
                 placeholder={t('connector.add.clientSecret', 'OAuth Client Secret (optional)')}
+                value={clientSecret}
+                onChange={(e) => setClientSecret(e.target.value)}
               />
+              <div style={{ color: 'var(--lobe-colors-neutral-500)', fontSize: 12 }}>
+                {t('connector.add.redirectHint', 'Redirect URI to register with your OAuth app:')}
+                <br />
+                <code style={{ wordBreak: 'break-all' }}>{redirectUri}</code>
+              </div>
             </div>
           )}
         </div>

--- a/src/features/Connectors/AddConnectorModal/index.tsx
+++ b/src/features/Connectors/AddConnectorModal/index.tsx
@@ -15,17 +15,17 @@ interface AddConnectorModalProps {
 type OAuthPopupResult = 'success' | 'closed';
 
 /**
- * Open the authorize URL in a popup and resolve once it reports back.
+ * Wait for an already-opened popup to report the OAuth result.
  *
- * The callback page posts a message before attempting `window.close()`, so the
- * 'success' signal is reliable even when the browser refuses to close a popup
- * that navigated cross-origin. The popup-closed path is a fallback for when the
- * user dismisses the window without finishing.
+ * The popup MUST be opened synchronously from the user's click (browsers block
+ * `window.open` once an async boundary is crossed), then navigated to the
+ * authorize URL. The callback page posts a message before attempting
+ * `window.close()`, so the 'success' signal is reliable even when the browser
+ * refuses to close a popup that navigated cross-origin. The popup-closed path is
+ * a fallback for when the user dismisses the window without finishing.
  */
-const runOAuthPopup = (authorizationUrl: string, connectorId: string): Promise<OAuthPopupResult> =>
+const waitForOAuthPopup = (popup: Window, connectorId: string): Promise<OAuthPopupResult> =>
   new Promise((resolve) => {
-    const popup = window.open(authorizationUrl, 'lobe-connector-oauth', 'width=600,height=720');
-
     const cleanup = () => {
       window.removeEventListener('message', onMessage);
       clearInterval(timer);
@@ -43,7 +43,7 @@ const runOAuthPopup = (authorizationUrl: string, connectorId: string): Promise<O
     window.addEventListener('message', onMessage);
 
     const timer = setInterval(() => {
-      if (popup?.closed) {
+      if (popup.closed) {
         cleanup();
         resolve('closed');
       }
@@ -79,6 +79,18 @@ const AddConnectorModal = memo<AddConnectorModalProps>(({ open, onClose }) => {
 
   const handleAdd = async () => {
     if (!name.trim() || !url.trim()) return;
+
+    // Open the popup synchronously within the click handler, otherwise the
+    // browser blocks it once we cross the first `await` below. It's navigated to
+    // the real authorize URL after the connector + OAuth-start mutations resolve.
+    const popup = window.open('about:blank', 'lobe-connector-oauth', 'width=600,height=720');
+    if (!popup) {
+      message.error(
+        t('connector.add.popupBlocked', 'Please allow popups for this site and try again.'),
+      );
+      return;
+    }
+
     setSubmitting(true);
 
     try {
@@ -105,7 +117,8 @@ const AddConnectorModal = memo<AddConnectorModalProps>(({ open, onClose }) => {
       // discovered), fall back to a plain tool sync for public MCP servers.
       try {
         const authorizationUrl = await startConnectorOAuth(connectorId);
-        const result = await runOAuthPopup(authorizationUrl, connectorId);
+        popup.location.href = authorizationUrl;
+        const result = await waitForOAuthPopup(popup, connectorId);
         // Reflect the server-side state regardless of how the popup ended
         // (window.close is often blocked for cross-origin-navigated popups).
         await fetchConnectors();
@@ -113,6 +126,7 @@ const AddConnectorModal = memo<AddConnectorModalProps>(({ open, onClose }) => {
           message.success(t('connector.add.success', 'Connector connected'));
         }
       } catch {
+        popup.close();
         try {
           await syncConnectorTools(connectorId);
           message.success(t('connector.add.success', 'Connector connected'));

--- a/src/features/Connectors/AddConnectorModal/index.tsx
+++ b/src/features/Connectors/AddConnectorModal/index.tsx
@@ -12,8 +12,17 @@ interface AddConnectorModalProps {
   open: boolean;
 }
 
-/** Open the authorize URL in a popup and resolve once it reports back. */
-const runOAuthPopup = (authorizationUrl: string, connectorId: string): Promise<boolean> =>
+type OAuthPopupResult = 'success' | 'closed';
+
+/**
+ * Open the authorize URL in a popup and resolve once it reports back.
+ *
+ * The callback page posts a message before attempting `window.close()`, so the
+ * 'success' signal is reliable even when the browser refuses to close a popup
+ * that navigated cross-origin. The popup-closed path is a fallback for when the
+ * user dismisses the window without finishing.
+ */
+const runOAuthPopup = (authorizationUrl: string, connectorId: string): Promise<OAuthPopupResult> =>
   new Promise((resolve) => {
     const popup = window.open(authorizationUrl, 'lobe-connector-oauth', 'width=600,height=720');
 
@@ -28,16 +37,15 @@ const runOAuthPopup = (authorizationUrl: string, connectorId: string): Promise<b
       if (!data || data.type !== 'lobe-connector-oauth') return;
       if (data.connectorId && data.connectorId !== connectorId) return;
       cleanup();
-      resolve(Boolean(data.success));
+      resolve(data.success ? 'success' : 'closed');
     };
 
     window.addEventListener('message', onMessage);
 
-    // Resolve (as failure) if the user closes the popup without authorizing.
     const timer = setInterval(() => {
       if (popup?.closed) {
         cleanup();
-        resolve(false);
+        resolve('closed');
       }
     }, 800);
   });
@@ -48,6 +56,7 @@ const AddConnectorModal = memo<AddConnectorModalProps>(({ open, onClose }) => {
   const createConnector = useToolStore((s) => s.createConnector);
   const startConnectorOAuth = useToolStore((s) => s.startConnectorOAuth);
   const syncConnectorTools = useToolStore((s) => s.syncConnectorTools);
+  const fetchConnectors = useToolStore((s) => s.fetchConnectors);
 
   const [name, setName] = useState('');
   const [url, setUrl] = useState('');
@@ -90,20 +99,20 @@ const AddConnectorModal = memo<AddConnectorModalProps>(({ open, onClose }) => {
         sourceType: ConnectorSourceType.custom,
       });
 
-      // Kick off the OAuth flow. If the server turns out not to require OAuth
-      // (no authorization server discovered), fall back to a plain tool sync.
+      // Kick off the OAuth flow. The callback exchanges the code and syncs the
+      // tool list server-side, so we only need to refresh once it reports back.
+      // If the server turns out not to require OAuth (no authorization server
+      // discovered), fall back to a plain tool sync for public MCP servers.
       try {
         const authorizationUrl = await startConnectorOAuth(connectorId);
-        const ok = await runOAuthPopup(authorizationUrl, connectorId);
-        if (ok) {
-          await syncConnectorTools(connectorId);
+        const result = await runOAuthPopup(authorizationUrl, connectorId);
+        // Reflect the server-side state regardless of how the popup ended
+        // (window.close is often blocked for cross-origin-navigated popups).
+        await fetchConnectors();
+        if (result === 'success') {
           message.success(t('connector.add.success', 'Connector connected'));
-        } else {
-          message.warning(t('connector.add.cancelled', 'Authorization was not completed'));
         }
       } catch {
-        // Not an OAuth server (or DCR unsupported without a client id) — try a
-        // direct sync so non-auth MCP servers still connect.
         try {
           await syncConnectorTools(connectorId);
           message.success(t('connector.add.success', 'Connector connected'));

--- a/src/helpers/toolEngineering/buildClientConnectorManifests.ts
+++ b/src/helpers/toolEngineering/buildClientConnectorManifests.ts
@@ -1,0 +1,66 @@
+import { type ToolManifest } from '@lobechat/types';
+
+import { ConnectorToolPermission } from '@/database/schemas';
+import type { ConnectorWithTools } from '@/store/tool/slices/connector/types';
+
+/**
+ * Convert connector store rows into ToolManifest entries for the classic
+ * (client-orchestrated) chat path, mirroring the server-side
+ * `buildConnectorManifests`. The manifest carries no `mcpParams`/auth — the
+ * client has no token; connector tool calls are executed server-side via
+ * `connector.callTool`, which decrypts the stored credentials.
+ *
+ * Permission mapping:
+ * - 'auto'           → humanIntervention undefined (AI calls freely)
+ * - 'needs_approval' → humanIntervention 'required'
+ * - 'disabled'       → tool included with a blocking description
+ */
+export const buildClientConnectorManifests = (connectors: ConnectorWithTools[]): ToolManifest[] => {
+  const manifests: ToolManifest[] = [];
+
+  for (const connector of connectors) {
+    if (!connector.isEnabled) continue;
+    const tools = connector.tools ?? [];
+    if (tools.length === 0) continue;
+
+    const api = tools.map((t) => {
+      const parameters = (t.inputSchema ?? { properties: {}, type: 'object' }) as Record<
+        string,
+        unknown
+      >;
+      if (t.permission === ConnectorToolPermission.disabled) {
+        return {
+          description:
+            `[TOOL DISABLED] The user has disabled this tool and it cannot be executed. ` +
+            `Do NOT call this tool. If the user asks to perform this action, inform them ` +
+            `that they have manually disabled "${t.toolName}" and can re-enable it in Settings > Connectors.`,
+          humanIntervention: 'required' as const,
+          name: t.toolName,
+          parameters,
+        };
+      }
+      return {
+        description: t.description ?? '',
+        humanIntervention:
+          t.permission === ConnectorToolPermission.needs_approval
+            ? ('required' as const)
+            : undefined,
+        name: t.toolName,
+        parameters,
+      };
+    });
+
+    manifests.push({
+      api,
+      identifier: connector.identifier,
+      meta: {
+        avatar: 'MCP_AVATAR',
+        description: `${connector.name} connector with ${api.length} tools`,
+        title: connector.name,
+      },
+      type: 'mcp' as any,
+    });
+  }
+
+  return manifests;
+};

--- a/src/helpers/toolEngineering/index.ts
+++ b/src/helpers/toolEngineering/index.ts
@@ -20,11 +20,13 @@ import {
   lobehubSkillStoreSelectors,
   pluginSelectors,
 } from '@/store/tool/selectors';
+import { connectorSelectors } from '@/store/tool/slices/connector';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
 
 import { getSearchConfig } from '../getSearchConfig';
 import { isCanUseFC } from '../isCanUseFC';
+import { buildClientConnectorManifests } from './buildClientConnectorManifests';
 
 /**
  * Tools engine configuration options
@@ -83,8 +85,18 @@ export const createToolsEngine = (config: ToolsEngineConfig = {}): ToolsEngine =
 
   const toolStoreState = getToolStoreState();
 
-  // Get all available plugin manifests
-  const pluginManifests = pluginSelectors.installedPluginManifestList(toolStoreState);
+  // Get custom connector manifests (user-added MCP servers). Connectors take
+  // priority over plugins: any plugin sharing a connector identifier is dropped
+  // so the connector (server-side execution with its stored token) wins.
+  const connectorManifests = buildClientConnectorManifests(
+    connectorSelectors.customConnectors(toolStoreState),
+  );
+  const connectorIdentifiers = new Set(connectorManifests.map((m) => m.identifier));
+
+  // Get all available plugin manifests (excluding ones now covered by a connector)
+  const pluginManifests = pluginSelectors
+    .installedPluginManifestList(toolStoreState)
+    .filter((m) => !connectorIdentifiers.has(m.identifier));
 
   // Get all builtin tool manifests
   const builtinManifests = toolStoreState.builtinTools.map((tool) => tool.manifest as ToolManifest);
@@ -106,6 +118,7 @@ export const createToolsEngine = (config: ToolsEngineConfig = {}): ToolsEngine =
     ...dropInvalidManifests(builtinManifests, 'builtinTools'),
     ...dropInvalidManifests(klavisManifests, 'klavis'),
     ...dropInvalidManifests(lobehubSkillManifests, 'lobehubSkills'),
+    ...dropInvalidManifests(connectorManifests, 'connectors'),
     ...dropInvalidManifests(additionalManifests, 'additionalManifests'),
   ];
 

--- a/src/layout/GlobalProvider/DeferredStoreInitialization.tsx
+++ b/src/layout/GlobalProvider/DeferredStoreInitialization.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 
 import { useAiInfraStore } from '@/store/aiInfra';
 import { useElectronStore } from '@/store/electron';
 import { electronSyncSelectors } from '@/store/electron/selectors';
+import { useToolStore } from '@/store/tool';
 import { useUserMemoryStore } from '@/store/userMemory';
 
 interface DeferredStoreInitializationProps {
@@ -18,6 +19,13 @@ const DeferredStoreInitialization = memo<DeferredStoreInitializationProps>(({ is
 
   useInitAiProviderKeyVaults(isLogin, isSyncActive);
   useFetchPersona(isLogin);
+
+  // Load custom connectors so the classic chat path can expose their tools.
+  const fetchConnectors = useToolStore((s) => s.fetchConnectors);
+  const isConnectorsInit = useToolStore((s) => s.isConnectorsInit);
+  useEffect(() => {
+    if (isLogin && !isConnectorsInit) fetchConnectors();
+  }, [isLogin, isConnectorsInit, fetchConnectors]);
 
   return null;
 });

--- a/src/libs/next/proxy/define-config.ts
+++ b/src/libs/next/proxy/define-config.ts
@@ -23,7 +23,10 @@ const logBetterAuth = debug('middleware:better-auth');
 const dangerousLocalDevProxyRoute = '/_dangerous_local_dev_proxy';
 
 export function defineConfig() {
-  const backendApiEndpoints = ['/api', '/trpc', '/webapi', '/oidc'];
+  // `/oauth/connector` is a backend route handler (custom connector OAuth callback);
+  // the rest of `/oauth/*` (e.g. /oauth/callback/success) are SPA pages, so scope
+  // the passthrough to the connector subtree only.
+  const backendApiEndpoints = ['/api', '/trpc', '/webapi', '/oidc', '/oauth/connector'];
 
   const defaultMiddleware = (request: NextRequest) => {
     const url = new URL(request.url);
@@ -188,6 +191,9 @@ export function defineConfig() {
     // oauth
     // Make only the consent view public (GET page), not other oauth paths
     '/oauth/consent/(.*)',
+    // Custom connector OAuth callback — hit via a cross-site redirect from the
+    // provider, carries its own code+state, so it must not be session-gated.
+    '/oauth/connector/callback',
     '/oidc/handoff',
     '/oidc/device/auth',
     '/oidc/token',

--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -17,7 +17,7 @@ import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react';
 import type React from 'react';
-import { memo, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AddSkillButton from '@/features/SkillStore/SkillList/AddSkillButton';
@@ -31,6 +31,7 @@ import {
   lobehubSkillStoreSelectors,
   pluginSelectors,
 } from '@/store/tool/selectors';
+import { connectorSelectors } from '@/store/tool/slices/connector';
 import { KlavisServerStatus } from '@/store/tool/slices/klavisStore';
 import { LobehubSkillStatus } from '@/store/tool/slices/lobehubSkillStore/types';
 import { type LobeToolType } from '@/types/tool/tool';
@@ -99,6 +100,9 @@ const SkillList = memo<SkillListProps>(
     const marketAgentSkills = useToolStore(agentSkillsSelectors.getMarketAgentSkills, isEqual);
     const userAgentSkills = useToolStore(agentSkillsSelectors.getUserAgentSkills, isEqual);
     const builtinSkills = useToolStore((s) => s.builtinSkills, isEqual);
+    const customConnectors = useToolStore(connectorSelectors.customConnectors, isEqual);
+    const isConnectorsInit = useToolStore((s) => s.isConnectorsInit);
+    const fetchConnectors = useToolStore((s) => s.fetchConnectors);
     const allBuiltinTools = useToolStore((s) => s.builtinTools, isEqual);
     const uninstalledBuiltinTools = useToolStore(
       builtinToolSelectors.uninstalledBuiltinTools,
@@ -122,6 +126,12 @@ const SkillList = memo<SkillListProps>(
     useFetchUserKlavisServers(isKlavisEnabled);
     useFetchAgentSkills(true);
     useFetchUninstalledBuiltinTools(true);
+
+    // Load custom connectors (new connector store) so user-added OAuth MCP
+    // connectors appear in the Connectors tab list.
+    useEffect(() => {
+      if (!isConnectorsInit) fetchConnectors();
+    }, [isConnectorsInit, fetchConnectors]);
 
     const getLobehubSkillServerByProvider = (providerId: string) => {
       return allLobehubSkillServers.find((server) => server.identifier === providerId);
@@ -378,6 +388,20 @@ const SkillList = memo<SkillListProps>(
         />
       ));
 
+    // Custom connectors from the connector store (user-added OAuth MCP servers)
+    const renderCustomConnectors = () =>
+      customConnectors.map((c) => (
+        <McpSkillItem
+          identifier={c.identifier}
+          isSelected={selectedIdentifier === c.identifier}
+          key={c.id}
+          runtimeType="mcp"
+          title={c.name || c.identifier}
+          type={'customPlugin' as LobeToolType}
+          onSelect={onSelect ? () => onSelect(c.identifier, 'mcp-connector') : undefined}
+        />
+      ));
+
     // Split integrations into builtin tools vs builtin skills
     const builtinToolItems = integrations.filter((i) => i.type === 'builtin');
     const builtinSkillItems = integrations.filter((i) => i.type === 'builtinAgent');
@@ -416,8 +440,10 @@ const SkillList = memo<SkillListProps>(
     const hasCommunitySkills =
       !isConnectorView && (communitySkillItems.length > 0 || marketAgentSkills.length > 0);
     const hasCommunityTools = communityMCPs.length > 0 && isConnectorView;
-    // In connector view: custom MCPs. In skill view: user agent skills
-    const hasCustomConnectors = customMCPs.length > 0 && isConnectorView;
+    // In connector view: custom MCPs (old plugins) + custom connectors (new store).
+    // In skill view: user agent skills
+    const hasCustomConnectors =
+      isConnectorView && (customMCPs.length > 0 || customConnectors.length > 0);
     const hasCustomSkills = userAgentSkills.length > 0 && !isConnectorView;
     // Lobehub/Klavis OAuth skills go in Connectors tab (they provide tools)
     const hasCommunityConnectors = communitySkillItems.length > 0 && isConnectorView;
@@ -549,7 +575,10 @@ const SkillList = memo<SkillListProps>(
           renderSection(
             'customConnectors',
             t('skillGroup.customConnectors', '自定义 Connectors'),
-            renderCustomMCPs(),
+            <>
+              {renderCustomConnectors()}
+              {renderCustomMCPs()}
+            </>,
           )}
 
         {hasCustomSkills &&

--- a/src/routes/(main)/settings/skill/index.tsx
+++ b/src/routes/(main)/settings/skill/index.tsx
@@ -3,10 +3,11 @@
 import { Button, Icon } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
-import { Store } from 'lucide-react';
+import { Plus, Store } from 'lucide-react';
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { AddConnectorModal } from '@/features/Connectors';
 import NavHeader from '@/features/NavHeader';
 import { createSkillStoreModal } from '@/features/SkillStore';
 import { useToolStore } from '@/store/tool';
@@ -83,6 +84,7 @@ const Page = memo(() => {
   const { t } = useTranslation('setting');
   const [selected, setSelected] = useState<SelectedTool | null>(null);
   const [viewMode, setViewMode] = useState<SkillViewMode>('connector');
+  const [showAddConnector, setShowAddConnector] = useState(false);
 
   // Data sources for auto-select
   const builtinTools = useToolStore((s) => s.builtinTools, isEqual);
@@ -146,6 +148,17 @@ const Page = memo(() => {
             </div>
 
             <div style={{ display: 'flex', gap: 6 }}>
+              {viewMode === 'connector' && (
+                <Button
+                  icon={<Icon icon={Plus} />}
+                  size="small"
+                  title={t('connector.add.title', {
+                    defaultValue: 'Add custom connector',
+                    ns: 'tool',
+                  })}
+                  onClick={() => setShowAddConnector(true)}
+                />
+              )}
               <Button icon={<Icon icon={Store} />} size="small" onClick={handleOpenStore} />
             </div>
           </div>
@@ -166,6 +179,7 @@ const Page = memo(() => {
           </div>
         )}
       </div>
+      <AddConnectorModal open={showAddConnector} onClose={() => setShowAddConnector(false)} />
     </>
   );
 });

--- a/src/server/routers/lambda/connector.ts
+++ b/src/server/routers/lambda/connector.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import { ConnectorModel } from '@/database/models/connector';
 import { ConnectorToolModel } from '@/database/models/connectorTool';
 import { PluginModel } from '@/database/models/plugin';
-import type { ConnectorCredentials } from '@/database/schemas';
+import type { ConnectorCredentials, OIDCConfig } from '@/database/schemas';
 import {
   ConnectorMcpConnectionType,
   ConnectorSourceType,
@@ -15,17 +15,44 @@ import type { AuthConfig } from '@/libs/mcp';
 import { inferCrudType } from '@/libs/mcp/utils';
 import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
+import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
+import {
+  buildAuthorizationUrl,
+  discoverConnectorOAuth,
+  getConnectorRedirectUri,
+  registerDynamicClient,
+} from '@/server/services/connector/oauth';
+import {
+  generateConnectorOAuthState,
+  saveConnectorOAuthState,
+} from '@/server/services/connector/stateStore';
+import { ensureFreshConnectorToken } from '@/server/services/connector/tokens';
 import { mcpService } from '@/server/services/mcp';
 
 const connectorProcedure = authedProcedure.use(serverDatabase).use(async (opts) => {
   const { ctx } = opts;
+  // Credentials (OAuth tokens) are encrypted at rest — give the model a gatekeeper.
+  const gateKeeper = await KeyVaultsGateKeeper.initWithEnvKey();
   return opts.next({
     ctx: {
-      connectorModel: new ConnectorModel(ctx.serverDB, ctx.userId),
+      connectorModel: new ConnectorModel(ctx.serverDB, ctx.userId, gateKeeper),
       connectorToolModel: new ConnectorToolModel(ctx.serverDB, ctx.userId),
       pluginModel: new PluginModel(ctx.serverDB, ctx.userId),
     },
   });
+});
+
+const oidcConfigSchema = z.object({
+  authorizationEndpoint: z.string().optional(),
+  clientId: z.string().optional(),
+  clientSecret: z.string().optional(),
+  issuer: z.string().optional(),
+  redirectUri: z.string().optional(),
+  registrationEndpoint: z.string().optional(),
+  scheme: z.enum(['pre_registration', 'dcr', 'client_id_metadata_document']),
+  scopes: z.array(z.string()).optional(),
+  tokenEndpoint: z.string().optional(),
+  usePKCE: z.boolean().optional(),
 });
 
 const createConnectorSchema = z.object({
@@ -48,7 +75,7 @@ const createConnectorSchema = z.object({
     .optional(),
   metadata: z.record(z.unknown()).optional(),
   name: z.string().min(1).max(255),
-  oidcConfig: z.record(z.unknown()).optional(),
+  oidcConfig: oidcConfigSchema.optional(),
   sourceType: z.enum([
     ConnectorSourceType.builtin,
     ConnectorSourceType.custom,
@@ -65,7 +92,10 @@ export const connectorRouter = router({
     const toolsByConnector = await Promise.all(
       connectors.map(async (c) => {
         const tools = await ctx.connectorToolModel.queryByConnector(c.id);
-        return { ...c, tools };
+        // Never ship decrypted OAuth tokens or the client secret to the browser.
+        const { credentials: _credentials, oidcConfig, ...rest } = c;
+        const safeOidcConfig = oidcConfig ? { ...oidcConfig, clientSecret: undefined } : oidcConfig;
+        return { ...rest, oidcConfig: safeOidcConfig, tools };
       }),
     );
 
@@ -81,10 +111,96 @@ export const connectorRouter = router({
       mcpServerUrl: input.mcpServerUrl ?? null,
       mcpStdioConfig: input.mcpStdioConfig ?? null,
       metadata: input.metadata ?? null,
-      oidcConfig: (input.oidcConfig as any) ?? null,
+      oidcConfig: input.oidcConfig ?? null,
       status: ConnectorStatus.disconnected,
     });
   }),
+
+  /**
+   * Begin the OAuth authorization-code flow for a custom MCP connector.
+   *
+   * Discovers the authorization server (RFC 9728 → RFC 8414), resolves the
+   * client (pre-registration when a client_id was provided, otherwise RFC 7591
+   * dynamic registration), persists the resolved OIDC config, and returns the
+   * authorize URL for the client to open. The PKCE verifier is stashed in Redis
+   * keyed by `state`; the callback route completes the exchange.
+   */
+  startOAuth: connectorProcedure
+    .input(z.object({ id: z.string().uuid(), returnTo: z.string().optional() }))
+    .mutation(async ({ input, ctx }) => {
+      const connector = await ctx.connectorModel.findById(input.id);
+      if (!connector) throw new TRPCError({ code: 'NOT_FOUND', message: 'Connector not found' });
+      if (!connector.mcpServerUrl) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Connector has no MCP server URL' });
+      }
+
+      const existing: OIDCConfig = connector.oidcConfig ?? { scheme: 'dcr' };
+      const redirectUri = getConnectorRedirectUri();
+
+      // 1. Discover the authorization server backing the MCP resource.
+      const { authorizationServerUrl, metadata } = await discoverConnectorOAuth(
+        connector.mcpServerUrl,
+      );
+
+      // 2. Resolve the OAuth client: pre-registration vs. DCR.
+      let clientId = existing.clientId;
+      let clientSecret = existing.clientSecret;
+      const scheme: OIDCConfig['scheme'] = clientId ? 'pre_registration' : 'dcr';
+
+      if (!clientId) {
+        if (!metadata.registration_endpoint) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message:
+              'This server does not support dynamic registration. Provide an OAuth Client ID in Advanced settings.',
+          });
+        }
+        const reg = await registerDynamicClient({
+          authorizationServerUrl,
+          metadata,
+          redirectUri,
+          scopes: existing.scopes,
+        });
+        clientId = reg.client_id;
+        clientSecret = reg.client_secret ?? undefined;
+      }
+
+      // 3. Persist the resolved config so the callback + refresh can reuse it.
+      const resolvedOidc: OIDCConfig = {
+        ...existing,
+        authorizationEndpoint: metadata.authorization_endpoint,
+        clientId,
+        clientSecret,
+        issuer: authorizationServerUrl,
+        redirectUri,
+        registrationEndpoint: metadata.registration_endpoint,
+        scheme,
+        tokenEndpoint: metadata.token_endpoint,
+      };
+      await ctx.connectorModel.update(input.id, { oidcConfig: resolvedOidc });
+
+      // 4. Build the authorize URL (with PKCE) and stash the verifier under `state`.
+      const state = generateConnectorOAuthState();
+      const { authorizationUrl, codeVerifier } = await buildAuthorizationUrl({
+        authorizationServerUrl,
+        clientInformation: { client_id: clientId, client_secret: clientSecret },
+        metadata,
+        redirectUri,
+        resource: connector.mcpServerUrl,
+        scopes: existing.scopes,
+        state,
+      });
+
+      await saveConnectorOAuthState(state, {
+        authorizationServerUrl,
+        codeVerifier,
+        connectorId: input.id,
+        lobeUserId: ctx.userId,
+        returnTo: input.returnTo,
+      });
+
+      return { authorizationUrl };
+    }),
 
   update: connectorProcedure
     .input(
@@ -111,11 +227,14 @@ export const connectorRouter = router({
   syncTools: connectorProcedure
     .input(z.object({ id: z.string().uuid() }))
     .mutation(async ({ input, ctx }) => {
-      const connector = await ctx.connectorModel.findById(input.id);
+      let connector = await ctx.connectorModel.findById(input.id);
 
       if (!connector) {
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Connector not found' });
       }
+
+      // Refresh the OAuth access token if it has expired before connecting.
+      connector = await ensureFreshConnectorToken(connector, ctx.connectorModel);
 
       if (
         !connector.mcpServerUrl &&

--- a/src/server/routers/lambda/connector.ts
+++ b/src/server/routers/lambda/connector.ts
@@ -142,6 +142,12 @@ export const connectorRouter = router({
         connector.mcpServerUrl,
       );
 
+      // Default to the scopes advertised by the server when the user did not
+      // specify any — many MCP authorization servers reject (or issue a useless
+      // token for) a scope-less request.
+      const scopes =
+        existing.scopes && existing.scopes.length > 0 ? existing.scopes : metadata.scopes_supported;
+
       // 2. Resolve the OAuth client: pre-registration vs. DCR.
       let clientId = existing.clientId;
       let clientSecret = existing.clientSecret;
@@ -159,7 +165,7 @@ export const connectorRouter = router({
           authorizationServerUrl,
           metadata,
           redirectUri,
-          scopes: existing.scopes,
+          scopes,
         });
         clientId = reg.client_id;
         clientSecret = reg.client_secret ?? undefined;
@@ -175,6 +181,7 @@ export const connectorRouter = router({
         redirectUri,
         registrationEndpoint: metadata.registration_endpoint,
         scheme,
+        scopes,
         tokenEndpoint: metadata.token_endpoint,
       };
       await ctx.connectorModel.update(input.id, { oidcConfig: resolvedOidc });
@@ -187,7 +194,7 @@ export const connectorRouter = router({
         metadata,
         redirectUri,
         resource: connector.mcpServerUrl,
-        scopes: existing.scopes,
+        scopes,
         state,
       });
 

--- a/src/server/routers/lambda/connector.ts
+++ b/src/server/routers/lambda/connector.ts
@@ -4,14 +4,13 @@ import { z } from 'zod';
 import { ConnectorModel } from '@/database/models/connector';
 import { ConnectorToolModel } from '@/database/models/connectorTool';
 import { PluginModel } from '@/database/models/plugin';
-import type { ConnectorCredentials, OIDCConfig } from '@/database/schemas';
+import type { OIDCConfig } from '@/database/schemas';
 import {
   ConnectorMcpConnectionType,
   ConnectorSourceType,
   ConnectorStatus,
   ConnectorToolPermission,
 } from '@/database/schemas';
-import type { AuthConfig } from '@/libs/mcp';
 import { inferCrudType } from '@/libs/mcp/utils';
 import { authedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
@@ -26,6 +25,7 @@ import {
   generateConnectorOAuthState,
   saveConnectorOAuthState,
 } from '@/server/services/connector/stateStore';
+import { buildConnectorMcpParams, syncConnectorToolsById } from '@/server/services/connector/sync';
 import { ensureFreshConnectorToken } from '@/server/services/connector/tokens';
 import { mcpService } from '@/server/services/mcp';
 
@@ -234,73 +234,61 @@ export const connectorRouter = router({
   syncTools: connectorProcedure
     .input(z.object({ id: z.string().uuid() }))
     .mutation(async ({ input, ctx }) => {
-      let connector = await ctx.connectorModel.findById(input.id);
-
-      if (!connector) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'Connector not found' });
-      }
-
-      // Refresh the OAuth access token if it has expired before connecting.
-      connector = await ensureFreshConnectorToken(connector, ctx.connectorModel);
-
-      if (
-        !connector.mcpServerUrl &&
-        connector.mcpConnectionType !== ConnectorMcpConnectionType.stdio
-      ) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'Connector has no MCP server URL configured',
-        });
-      }
-
-      // Build MCPClientParams from stored connector config
-      let mcpParams: Parameters<typeof mcpService.listRawTools>[0];
-
-      if (connector.mcpConnectionType === ConnectorMcpConnectionType.stdio) {
-        if (!connector.mcpStdioConfig) {
-          throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing stdio config' });
-        }
-        mcpParams = {
-          args: connector.mcpStdioConfig.args ?? [],
-          command: connector.mcpStdioConfig.command,
-          env: connector.mcpStdioConfig.env,
-          name: connector.name,
-          type: 'stdio',
-        };
-      } else {
-        // http or cloud — both use URL-based connection
-        const auth = buildAuthFromCredentials(connector.credentials);
-        mcpParams = {
-          auth,
-          name: connector.name,
-          type: 'http',
-          url: connector.mcpServerUrl!,
-        };
-      }
-
-      let rawTools: Awaited<ReturnType<typeof mcpService.listRawTools>>;
       try {
-        rawTools = await mcpService.listRawTools(mcpParams);
+        return await syncConnectorToolsById(input.id, ctx);
       } catch (err: any) {
-        await ctx.connectorModel.updateStatus(input.id, ConnectorStatus.error);
         throw new TRPCError({
           cause: err,
           code: 'INTERNAL_SERVER_ERROR',
           message: `Failed to fetch tools from MCP server: ${err?.message ?? 'unknown error'}`,
         });
       }
+    }),
 
-      const syncInputs = rawTools.map((t) => ({
-        crudType: inferCrudType(t.name),
-        description: t.description,
-        inputSchema: t.inputSchema as Record<string, unknown>,
-        toolName: t.name,
-      }));
+  /**
+   * Execute a single connector tool by identifier (classic chat path). Resolves
+   * the connector, hard-blocks disabled tools, refreshes the OAuth token if
+   * needed, and calls the remote MCP server with the decrypted credentials.
+   */
+  callTool: connectorProcedure
+    .input(
+      z.object({
+        args: z.string().optional(),
+        identifier: z.string().min(1),
+        toolName: z.string().min(1),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const [connector] = await ctx.connectorModel.queryByIdentifiers([input.identifier]);
+      if (!connector) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'Connector not found' });
+      }
 
-      await ctx.connectorToolModel.upsertMany(input.id, syncInputs);
-      await ctx.connectorModel.updateStatus(input.id, ConnectorStatus.connected);
+      // Hard-block disabled tools server-side (defense beyond the manifest hint).
+      const tools = await ctx.connectorToolModel.queryByConnector(connector.id);
+      const tool = tools.find((t) => t.toolName === input.toolName);
+      if (tool?.permission === ConnectorToolPermission.disabled) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: `Tool '${input.toolName}' is disabled for this connector`,
+        });
+      }
 
-      return { toolCount: syncInputs.length };
+      const fresh = await ensureFreshConnectorToken(connector, ctx.connectorModel);
+
+      try {
+        return await mcpService.callTool({
+          argsStr: input.args ?? '{}',
+          clientParams: buildConnectorMcpParams(fresh),
+          toolName: input.toolName,
+        });
+      } catch (err: any) {
+        throw new TRPCError({
+          cause: err,
+          code: 'INTERNAL_SERVER_ERROR',
+          message: `Connector tool call failed: ${err?.message ?? 'unknown error'}`,
+        });
+      }
     }),
 
   /**
@@ -493,29 +481,4 @@ function resolveDefaultPermission(humanIntervention: unknown): ConnectorToolPerm
     return ConnectorToolPermission.needs_approval;
   }
   return ConnectorToolPermission.auto;
-}
-
-function buildAuthFromCredentials(
-  credentials: ConnectorCredentials | null,
-): AuthConfig | undefined {
-  if (!credentials) return undefined;
-
-  switch (credentials.type) {
-    case 'oauth2': {
-      return {
-        accessToken: credentials.accessToken,
-        clientId: undefined,
-        clientSecret: credentials.clientSecret,
-        refreshToken: credentials.refreshToken,
-        tokenExpiresAt: credentials.expiresAt,
-        type: 'oauth2',
-      };
-    }
-    case 'bearer': {
-      return { token: credentials.token, type: 'bearer' };
-    }
-    default: {
-      return undefined;
-    }
-  }
 }

--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -61,6 +61,7 @@ import { toolsEnv } from '@/envs/tools';
 import { shouldEnableBuiltinSkill } from '@/helpers/skillFilters';
 import { buildConnectorManifests } from '@/libs/mcp/buildConnectorManifests';
 import { signOperationJwt, signUserJWT } from '@/libs/trpc/utils/internalJwt';
+import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
 import type { EvalContext, ServerAgentToolsContext } from '@/server/modules/Mecha';
 import { createServerAgentToolsEngine } from '@/server/modules/Mecha';
 import type { ServerUserMemoryConfig } from '@/server/modules/Mecha/ContextEngineering/types';
@@ -1132,6 +1133,7 @@ export class AiAgentService {
     // These are needed outside the tools block (for agent management context, skill engine, etc.)
     let lobehubSkillManifests: LobeToolManifest[] = [];
     let klavisManifests: LobeToolManifest[] = [];
+    let connectorManifests: ReturnType<typeof buildConnectorManifests> = [];
     let agentPlugins: string[] = [...(agentConfig?.plugins ?? []), ...(additionalPluginIds || [])];
 
     // Model metadata is needed both for tool support checks and agent-management context.
@@ -1180,9 +1182,19 @@ export class AiAgentService {
       const installedPlugins = await this.pluginModel.query();
       log('execAgent: got %d installed plugins', installedPlugins.length);
 
-      // 5a-1. Resolve connectors — connector identifier takes priority over plugin
+      // 5a-1. Resolve connectors — connector identifier takes priority over plugin.
+      // Credentials (OAuth tokens) are encrypted at rest, so decrypt them with a
+      // gatekeeper; otherwise buildConnectorManifests gets no auth and tool calls 401.
+      let connectorGateKeeper: KeyVaultsGateKeeper | undefined;
+      try {
+        connectorGateKeeper = await KeyVaultsGateKeeper.initWithEnvKey();
+      } catch (err) {
+        log('execAgent: failed to init gatekeeper for connector credentials: %O', err);
+      }
       const connectors =
-        agentPlugins.length > 0 ? await this.connectorModel.queryByIdentifiers(agentPlugins) : [];
+        agentPlugins.length > 0
+          ? await this.connectorModel.queryByIdentifiers(agentPlugins, connectorGateKeeper)
+          : [];
 
       // Only connectors WITH a real MCP endpoint (mcpServerUrl or stdio) can replace plugins in the
       // manifest. Connectors WITHOUT an endpoint (e.g. Lobehub/Klavis OAuth skills synced via
@@ -1206,7 +1218,7 @@ export class AiAgentService {
           ? await this.connectorToolModel.queryAllByConnectorIds(connectorsMcp.map((c) => c.id))
           : [];
 
-      const connectorManifests = buildConnectorManifests(connectorsMcp, connectorTools);
+      connectorManifests = buildConnectorManifests(connectorsMcp, connectorTools);
       log('execAgent: got %d connector manifests', connectorManifests.length);
 
       // 5b. Get model abilities from model-bank for function calling support check
@@ -1758,6 +1770,13 @@ export class AiAgentService {
           identifier: manifest.identifier,
           name: manifest.meta?.title || manifest.identifier,
           type: 'klavis' as const,
+        })),
+        // Custom connectors (user-added MCP servers)
+        ...connectorManifests.map((manifest) => ({
+          description: manifest.meta?.description,
+          identifier: manifest.identifier,
+          name: manifest.meta?.title || manifest.identifier,
+          type: 'connector' as const,
         })),
       ];
 

--- a/src/server/services/connector/oauth.ts
+++ b/src/server/services/connector/oauth.ts
@@ -1,0 +1,172 @@
+import {
+  discoverAuthorizationServerMetadata,
+  discoverOAuthProtectedResourceMetadata,
+  exchangeAuthorization,
+  extractResourceMetadataUrl,
+  refreshAuthorization,
+  registerClient,
+  startAuthorization,
+} from '@modelcontextprotocol/sdk/client/auth.js';
+import type {
+  AuthorizationServerMetadata,
+  OAuthClientInformationFull,
+  OAuthClientInformationMixed,
+  OAuthTokens,
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import debug from 'debug';
+
+import { appEnv } from '@/envs/app';
+
+const log = debug('lobe-server:connector:oauth');
+
+export const CONNECTOR_OAUTH_CALLBACK_PATH = '/oauth/connector/callback';
+
+/**
+ * Fixed redirect URI for all custom-connector OAuth flows. Pre-registration
+ * users must register this exact URI with their OAuth app; DCR sends it as a
+ * redirect_uri at registration time.
+ */
+export const getConnectorRedirectUri = (): string => {
+  const base = appEnv.APP_URL;
+  if (!base) {
+    throw new Error('APP_URL is not configured; cannot build connector OAuth redirect URI');
+  }
+  return new URL(CONNECTOR_OAUTH_CALLBACK_PATH, base).toString();
+};
+
+export interface DiscoveredOAuth {
+  authorizationServerUrl: string;
+  metadata: AuthorizationServerMetadata;
+}
+
+/**
+ * Discover the OAuth authorization server backing a remote MCP resource.
+ *
+ * Standard MCP auth path:
+ *   1. Probe the MCP URL → expect 401 carrying `WWW-Authenticate` with the
+ *      protected-resource-metadata URL (RFC 9728).
+ *   2. Fetch the protected resource metadata → pick its authorization server.
+ *   3. Fetch the authorization server metadata (RFC 8414) for the endpoints.
+ *
+ * Falls back to the MCP server origin as the authorization server when the
+ * resource does not advertise PRM (some servers co-locate the AS).
+ */
+export const discoverConnectorOAuth = async (mcpServerUrl: string): Promise<DiscoveredOAuth> => {
+  let resourceMetadataUrl: URL | undefined;
+  try {
+    const res = await fetch(mcpServerUrl, {
+      headers: { accept: 'application/json, text/event-stream' },
+      method: 'GET',
+    });
+    if (res.status === 401) resourceMetadataUrl = extractResourceMetadataUrl(res);
+  } catch (err) {
+    log('probe request failed, falling back to well-known discovery: %O', err);
+  }
+
+  let authorizationServerUrl: string | undefined;
+  try {
+    const prm = await discoverOAuthProtectedResourceMetadata(mcpServerUrl, { resourceMetadataUrl });
+    authorizationServerUrl = prm?.authorization_servers?.[0]?.toString();
+  } catch (err) {
+    log('protected-resource-metadata discovery failed: %O', err);
+  }
+
+  // Fallback: assume the authorization server lives at the MCP server origin.
+  if (!authorizationServerUrl) authorizationServerUrl = new URL(mcpServerUrl).origin;
+
+  const metadata = await discoverAuthorizationServerMetadata(authorizationServerUrl);
+  if (!metadata) {
+    throw new Error(`Failed to discover OAuth metadata for ${authorizationServerUrl}`);
+  }
+
+  return { authorizationServerUrl, metadata };
+};
+
+/**
+ * RFC 7591 Dynamic Client Registration — used when the user did not provide a
+ * client_id. Returns the issued client_id (+ optional client_secret).
+ */
+export const registerDynamicClient = async (params: {
+  authorizationServerUrl: string;
+  clientName?: string;
+  metadata: AuthorizationServerMetadata;
+  redirectUri: string;
+  scopes?: string[];
+}): Promise<OAuthClientInformationFull> => {
+  return registerClient(params.authorizationServerUrl, {
+    clientMetadata: {
+      client_name: params.clientName ?? 'LobeHub',
+      grant_types: ['authorization_code', 'refresh_token'],
+      redirect_uris: [params.redirectUri],
+      response_types: ['code'],
+      scope: params.scopes?.join(' '),
+      token_endpoint_auth_method: 'client_secret_post',
+    },
+    metadata: params.metadata,
+    scope: params.scopes?.join(' '),
+  });
+};
+
+/**
+ * Build the authorization-code redirect URL (with PKCE). Returns the URL to
+ * open in the popup plus the `codeVerifier` that must be stashed (server-side,
+ * single-use) until the callback exchanges the code.
+ */
+export const buildAuthorizationUrl = async (params: {
+  authorizationServerUrl: string;
+  clientInformation: OAuthClientInformationMixed;
+  metadata: AuthorizationServerMetadata;
+  redirectUri: string;
+  resource?: string;
+  scopes?: string[];
+  state: string;
+}): Promise<{ authorizationUrl: string; codeVerifier: string }> => {
+  const { authorizationUrl, codeVerifier } = await startAuthorization(
+    params.authorizationServerUrl,
+    {
+      clientInformation: params.clientInformation,
+      metadata: params.metadata,
+      redirectUrl: params.redirectUri,
+      resource: params.resource ? new URL(params.resource) : undefined,
+      scope: params.scopes?.join(' '),
+      state: params.state,
+    },
+  );
+  return { authorizationUrl: authorizationUrl.toString(), codeVerifier };
+};
+
+/** Exchange the authorization code for tokens (callback step). */
+export const exchangeConnectorCode = async (params: {
+  authorizationCode: string;
+  authorizationServerUrl: string;
+  clientInformation: OAuthClientInformationMixed;
+  codeVerifier: string;
+  metadata: AuthorizationServerMetadata;
+  redirectUri: string;
+  resource?: string;
+}): Promise<OAuthTokens> => {
+  return exchangeAuthorization(params.authorizationServerUrl, {
+    authorizationCode: params.authorizationCode,
+    clientInformation: params.clientInformation,
+    codeVerifier: params.codeVerifier,
+    metadata: params.metadata,
+    redirectUri: params.redirectUri,
+    resource: params.resource ? new URL(params.resource) : undefined,
+  });
+};
+
+/** Refresh an expired access token using the stored refresh token. */
+export const refreshConnectorToken = async (params: {
+  authorizationServerUrl: string;
+  clientInformation: OAuthClientInformationMixed;
+  metadata: AuthorizationServerMetadata;
+  refreshToken: string;
+  resource?: string;
+}): Promise<OAuthTokens> => {
+  return refreshAuthorization(params.authorizationServerUrl, {
+    clientInformation: params.clientInformation,
+    metadata: params.metadata,
+    refreshToken: params.refreshToken,
+    resource: params.resource ? new URL(params.resource) : undefined,
+  });
+};

--- a/src/server/services/connector/stateStore.ts
+++ b/src/server/services/connector/stateStore.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from 'node:crypto';
+
+import debug from 'debug';
+
+import { getAgentRuntimeRedisClient } from '@/server/modules/AgentRuntime/redis';
+
+const log = debug('lobe-server:connector:oauth-state');
+
+const STATE_TTL_SECONDS = 600; // 10 minutes — interactive but quick
+
+const KEY_PREFIX = 'connector:oauth-state:';
+
+const stateKey = (state: string): string => `${KEY_PREFIX}${state}`;
+
+export interface ConnectorOAuthStatePayload {
+  /** Authorization server resolved at start; reused at exchange to avoid drift. */
+  authorizationServerUrl: string;
+  /** PKCE verifier — must round-trip to the token exchange. */
+  codeVerifier: string;
+  /** The connector being connected. */
+  connectorId: string;
+  /** LobeHub user who initiated the connect. */
+  lobeUserId: string;
+  /** Where to send the user after the callback finishes (relative path). */
+  returnTo?: string;
+  /** Issuance timestamp (ms epoch) for diagnostics. */
+  ts: number;
+}
+
+/** Generate an opaque, single-use state value to embed in the authorize URL. */
+export const generateConnectorOAuthState = (): string => randomUUID().replaceAll('-', '');
+
+/**
+ * Persist the connect-flow payload under an explicit `state` value. The state
+ * is chosen first (so it can be embedded in the authorize URL), then the PKCE
+ * verifier returned by `startAuthorization` is stored alongside it. Same
+ * Redis-backed single-use pattern as the messenger Slack OAuth state store
+ * (TTL expiry, delete-on-consume, no replay).
+ */
+export const saveConnectorOAuthState = async (
+  state: string,
+  payload: Omit<ConnectorOAuthStatePayload, 'ts'>,
+): Promise<void> => {
+  const redis = getAgentRuntimeRedisClient();
+  if (!redis) throw new Error('Redis is required for connector OAuth state storage');
+
+  const value: ConnectorOAuthStatePayload = { ...payload, ts: Date.now() };
+
+  await redis.set(stateKey(state), JSON.stringify(value), 'EX', STATE_TTL_SECONDS);
+  log(
+    'saved connector OAuth state for user=%s connector=%s',
+    payload.lobeUserId,
+    payload.connectorId,
+  );
+};
+
+/**
+ * Atomically read + delete the state. Replay is impossible after the first
+ * consume. Returns null if invalid / expired / already consumed.
+ */
+export const consumeConnectorOAuthState = async (
+  state: string,
+): Promise<ConnectorOAuthStatePayload | null> => {
+  const redis = getAgentRuntimeRedisClient();
+  if (!redis) return null;
+
+  const raw = await redis.get(stateKey(state));
+  if (!raw) return null;
+
+  await redis.del(stateKey(state));
+
+  try {
+    return JSON.parse(raw) as ConnectorOAuthStatePayload;
+  } catch {
+    return null;
+  }
+};

--- a/src/server/services/connector/sync.ts
+++ b/src/server/services/connector/sync.ts
@@ -1,0 +1,108 @@
+import type { ConnectorModel, DecryptedConnector } from '@/database/models/connector';
+import type { ConnectorToolModel } from '@/database/models/connectorTool';
+import type { ConnectorCredentials } from '@/database/schemas';
+import { ConnectorMcpConnectionType, ConnectorStatus } from '@/database/schemas';
+import type { AuthConfig } from '@/libs/mcp';
+import { inferCrudType } from '@/libs/mcp/utils';
+import { mcpService } from '@/server/services/mcp';
+
+import { ensureFreshConnectorToken } from './tokens';
+
+export interface ConnectorToolSyncContext {
+  connectorModel: ConnectorModel;
+  connectorToolModel: ConnectorToolModel;
+}
+
+/** Build the MCP client connection params (with auth) from a connector row. */
+export const buildConnectorMcpParams = (
+  connector: DecryptedConnector,
+): Parameters<typeof mcpService.listRawTools>[0] => {
+  if (connector.mcpConnectionType === ConnectorMcpConnectionType.stdio) {
+    if (!connector.mcpStdioConfig) throw new Error('Missing stdio config');
+    return {
+      args: connector.mcpStdioConfig.args ?? [],
+      command: connector.mcpStdioConfig.command,
+      env: connector.mcpStdioConfig.env,
+      name: connector.name,
+      type: 'stdio',
+    };
+  }
+  if (!connector.mcpServerUrl) throw new Error('Connector has no MCP server URL configured');
+  return {
+    auth: buildAuthFromCredentials(connector.credentials),
+    name: connector.name,
+    type: 'http',
+    url: connector.mcpServerUrl,
+  };
+};
+
+/** Map stored credentials into the MCP client's auth config. */
+export const buildAuthFromCredentials = (
+  credentials: ConnectorCredentials | null,
+): AuthConfig | undefined => {
+  if (!credentials) return undefined;
+
+  switch (credentials.type) {
+    case 'oauth2': {
+      return {
+        accessToken: credentials.accessToken,
+        clientId: undefined,
+        clientSecret: credentials.clientSecret,
+        refreshToken: credentials.refreshToken,
+        tokenExpiresAt: credentials.expiresAt,
+        type: 'oauth2',
+      };
+    }
+    case 'bearer': {
+      return { token: credentials.token, type: 'bearer' };
+    }
+    default: {
+      return undefined;
+    }
+  }
+};
+
+/**
+ * Connect to a connector's MCP server, fetch its tool list, and sync it into
+ * `user_connector_tools`. Refreshes the OAuth token first when needed, and
+ * updates the connector status (`connected` on success, `error` on failure).
+ *
+ * Shared by the `syncTools` tRPC mutation and the OAuth callback so a connector
+ * has its tools immediately after authorization — no client round-trip needed.
+ */
+export const syncConnectorToolsById = async (
+  connectorId: string,
+  ctx: ConnectorToolSyncContext,
+): Promise<{ toolCount: number }> => {
+  let connector = await ctx.connectorModel.findById(connectorId);
+  if (!connector) throw new Error('Connector not found');
+
+  if (!connector.mcpServerUrl && connector.mcpConnectionType !== ConnectorMcpConnectionType.stdio) {
+    throw new Error('Connector has no MCP server URL configured');
+  }
+
+  // Refresh the OAuth access token if it has expired before connecting.
+  connector = await ensureFreshConnectorToken(connector, ctx.connectorModel);
+
+  const mcpParams = buildConnectorMcpParams(connector);
+
+  let rawTools: Awaited<ReturnType<typeof mcpService.listRawTools>>;
+  try {
+    rawTools = await mcpService.listRawTools(mcpParams);
+  } catch (err) {
+    await ctx.connectorModel.updateStatus(connectorId, ConnectorStatus.error);
+    throw err;
+  }
+
+  const syncInputs = rawTools.map((t) => ({
+    crudType: inferCrudType(t.name),
+    description: t.description,
+    inputSchema: t.inputSchema as Record<string, unknown>,
+    toolName: t.name,
+  }));
+
+  await ctx.connectorToolModel.upsertMany(connectorId, syncInputs);
+  await ctx.connectorModel.updateStatus(connectorId, ConnectorStatus.connected);
+
+  return { toolCount: syncInputs.length };
+};

--- a/src/server/services/connector/tokens.ts
+++ b/src/server/services/connector/tokens.ts
@@ -1,0 +1,79 @@
+import { discoverAuthorizationServerMetadata } from '@modelcontextprotocol/sdk/client/auth.js';
+import type { OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth.js';
+import debug from 'debug';
+
+import type { ConnectorModel, DecryptedConnector } from '@/database/models/connector';
+import type { ConnectorCredentials } from '@/database/schemas';
+
+import { refreshConnectorToken } from './oauth';
+
+const log = debug('lobe-server:connector:tokens');
+
+/** Refresh slightly before actual expiry to avoid races on the boundary. */
+const EXPIRY_SKEW_MS = 60_000;
+
+/** Map an OAuth token response into the persisted credential + expiry shape. */
+export const tokensToCredentials = (
+  tokens: OAuthTokens,
+  opts: { clientSecret?: string; fallbackRefreshToken?: string } = {},
+): { credentials: ConnectorCredentials; tokenExpiresAt: Date | null } => {
+  const expiresAt = tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : undefined;
+  return {
+    credentials: {
+      accessToken: tokens.access_token,
+      clientSecret: opts.clientSecret,
+      expiresAt,
+      // Refresh tokens may rotate; keep the previous one when the AS omits it.
+      refreshToken: tokens.refresh_token ?? opts.fallbackRefreshToken,
+      scope: tokens.scope,
+      type: 'oauth2',
+    },
+    tokenExpiresAt: expiresAt ? new Date(expiresAt) : null,
+  };
+};
+
+/**
+ * Lazily refresh a connector's OAuth access token when it is expired (or about
+ * to expire). Persists the rotated credentials and returns the connector with
+ * fresh credentials in memory. No-op for non-oauth2 connectors or when the
+ * token is still valid / not refreshable.
+ */
+export const ensureFreshConnectorToken = async (
+  connector: DecryptedConnector,
+  connectorModel: ConnectorModel,
+): Promise<DecryptedConnector> => {
+  const creds = connector.credentials;
+  const oidc = connector.oidcConfig;
+
+  if (!creds || creds.type !== 'oauth2' || !creds.refreshToken) return connector;
+  if (creds.expiresAt && creds.expiresAt - EXPIRY_SKEW_MS > Date.now()) return connector;
+  if (!oidc?.issuer || !oidc.clientId) return connector;
+
+  try {
+    const metadata = await discoverAuthorizationServerMetadata(oidc.issuer);
+    if (!metadata) return connector;
+
+    const tokens = await refreshConnectorToken({
+      authorizationServerUrl: oidc.issuer,
+      clientInformation: { client_id: oidc.clientId, client_secret: oidc.clientSecret },
+      metadata,
+      refreshToken: creds.refreshToken,
+      resource: connector.mcpServerUrl ?? undefined,
+    });
+
+    const { credentials, tokenExpiresAt } = tokensToCredentials(tokens, {
+      clientSecret: oidc.clientSecret,
+      fallbackRefreshToken: creds.refreshToken,
+    });
+
+    await connectorModel.update(connector.id, {
+      credentials: JSON.stringify(credentials),
+      tokenExpiresAt,
+    });
+
+    return { ...connector, credentials };
+  } catch (err) {
+    log('token refresh failed for connector=%s: %O', connector.id, err);
+    return connector;
+  }
+};

--- a/src/services/mcp.ts
+++ b/src/services/mcp.ts
@@ -43,6 +43,22 @@ class MCPService {
     const s = getToolStoreState();
     const { identifier, arguments: args, apiName } = payload;
 
+    // Connector-first: custom connectors execute server-side with their stored
+    // (encrypted) OAuth token, so route them before the plugin path. The client
+    // has no credentials, hence the dedicated `connector.callTool` endpoint.
+    // Only connectors with a real MCP endpoint are routed here — Lobehub/Klavis
+    // skills synced into the connector store have no mcpServerUrl and keep their
+    // original executor path.
+    const { connectorSelectors } = await import('@/store/tool/slices/connector');
+    const connector = connectorSelectors.connectorByIdentifier(identifier)(s);
+    if (connector && (connector.mcpServerUrl || connector.mcpConnectionType === 'stdio')) {
+      const { lambdaClient } = await import('@/libs/trpc/client');
+      return (await lambdaClient.connector.callTool.mutate(
+        { args, identifier, toolName: apiName },
+        { signal },
+      )) as MCPToolCallResult;
+    }
+
     const installPlugin = pluginSelectors.getInstalledPluginById(identifier)(s);
     const customPlugin = pluginSelectors.getCustomPluginById(identifier)(s);
 

--- a/src/store/tool/slices/connector/action.ts
+++ b/src/store/tool/slices/connector/action.ts
@@ -24,14 +24,25 @@ export class ConnectorActionImpl {
 
   createConnector = async (
     params: Parameters<typeof lambdaClient.connector.create.mutate>[0],
-  ): Promise<void> => {
+  ): Promise<string> => {
     this.#set({ connectorCreating: true }, false, 'createConnector/start');
     try {
-      await lambdaClient.connector.create.mutate(params);
+      const created = await lambdaClient.connector.create.mutate(params);
       await this.fetchConnectors();
+      return created.id;
     } finally {
       this.#set({ connectorCreating: false }, false, 'createConnector/end');
     }
+  };
+
+  /**
+   * Begin the OAuth authorization-code flow for a custom connector and return
+   * the authorize URL for the caller to open in a popup. Resolves the client
+   * via pre-registration or DCR on the server.
+   */
+  startConnectorOAuth = async (id: string): Promise<string> => {
+    const { authorizationUrl } = await lambdaClient.connector.startOAuth.mutate({ id });
+    return authorizationUrl;
   };
 
   deleteConnector = async (id: string): Promise<void> => {

--- a/src/store/tool/slices/connector/selectors.ts
+++ b/src/store/tool/slices/connector/selectors.ts
@@ -19,6 +19,10 @@ const enabledConnectors = (s: ToolStore): ConnectorWithTools[] =>
 const connectedConnectors = (s: ToolStore): ConnectorWithTools[] =>
   s.connectors.filter((c) => c.status === 'connected');
 
+/** User-added custom connectors (sourceType 'custom'), e.g. OAuth MCP servers. */
+const customConnectors = (s: ToolStore): ConnectorWithTools[] =>
+  s.connectors.filter((c) => c.sourceType === 'custom');
+
 const notConnectedConnectors = (s: ToolStore): ConnectorWithTools[] =>
   s.connectors.filter((c) => c.status !== 'connected');
 
@@ -56,6 +60,7 @@ export const connectorSelectors = {
   connectorByIdentifier,
   connectorList,
   connectorToolsGrouped,
+  customConnectors,
   connectorToolsGroupedByIdentifier:
     (identifier: string) =>
     (s: ToolStore): GroupedTools => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Related to LOBE-9983 (Connectors system). Builds on the `oidcConfig` design from LOBE-9736.

#### 🔀 Description of Change

The Connectors system (#15463) shipped the DB schema, models, and tool-permission UI, and `oidcConfig` was designed in LOBE-9736 to support three OIDC schemes — but **the OAuth authorization flow was never wired up**. `syncTools` only worked when a token already existed, and the Add-connector modal never set the DCR scheme or captured the client secret. This PR connects **Pre-registration** and **DCR (RFC 7591)** end-to-end so a user can add a custom OAuth MCP server from `/settings/skill`.

**One pipeline, branching only on where `client_id` comes from:**

1. **Add modal** — `client_id` present → Pre-registration; absent → DCR.
2. **`connector.startOAuth`** — probe the MCP URL → RFC 9728 protected-resource metadata → RFC 8414 authorization-server metadata; dynamically register the client (RFC 7591) when there's no `client_id`; persist the resolved `oidcConfig`; build a PKCE authorize URL and stash the verifier in Redis keyed by `state`.
3. **`/oauth/connector/callback`** — consume the single-use state → exchange the code → store **encrypted** tokens (`KeyVaultsGateKeeper`) + `tokenExpiresAt` + `status=connected` → `postMessage` the opener to close the popup.
4. **`syncTools`** — lazily refreshes the access token before connecting.

Built entirely on the `@modelcontextprotocol/sdk` OAuth helpers (`discover*` / `registerClient` / `startAuthorization` / `exchangeAuthorization` / `refreshAuthorization`) — no hand-rolled protocol code. The third scheme (`client_id_metadata_document`) is intentionally out of scope; the type slot remains.

**Security**

- Wired `KeyVaultsGateKeeper` into `ConnectorModel` so OAuth tokens are encrypted at rest (the router previously passed no gatekeeper → plaintext).
- Stripped decrypted `credentials` and `oidcConfig.clientSecret` from the `list` response so tokens/secrets never reach the browser.

**UI**

- `+` button in the `/settings/skill` Connectors tab opens the Add modal.
- `SkillList` now surfaces custom connectors from the connector store.
- Modal wires the client-secret field, infers the scheme, and shows the redirect URI to register.

#### 🧪 How to Test

- [x] Tested locally (type-check passes; no new errors)

1. `/settings/skill` → Connectors tab → `+` → enter Name + Remote MCP server URL.
2. Leave Client ID empty → server must support DCR; or fill Client ID (+ Secret) → Pre-registration. Register the shown redirect URI (`<APP_URL>/oauth/connector/callback`) with your OAuth app.
3. Authorize in the popup → it closes → the connector connects and its tools sync.

#### 📝 Additional Information

- `clientSecret` is stored in plaintext `oidcConfig` by design (non-token credential); access/refresh **tokens** are encrypted in `credentials`.
- No DB migration needed — `clientSecret` is a new optional field inside the existing `oidc_config` jsonb column.
- Requires `APP_URL`, `KEY_VAULTS_SECRET`, and Redis (already standard for this deployment).