### PR TITLE
🐛 fix(desktop): stop showing "Authorization Successful" for an expired session

### DIFF
--- a/apps/desktop/src/main/controllers/RemoteServerConfigCtr.ts
+++ b/apps/desktop/src/main/controllers/RemoteServerConfigCtr.ts
@@ -137,6 +137,24 @@ export default class RemoteServerConfigCtr extends ControllerModule {
   }
 
   /**
+   * Mark the remote session as requiring re-authorization (triggered by a backend
+   * 401 + X-Auth-Required). Flips the persisted `active` flag off so the UI and any
+   * `active`-gated state stop trusting a dead session. No-op when already inactive,
+   * so a burst of 401s doesn't fan out redundant config-updated broadcasts.
+   *
+   * Tokens are intentionally preserved (we only drop `active`): the re-auth flow
+   * reuses the configured endpoint/storageMode, and we don't want to wipe a
+   * still-valid refresh token on a transient auth hiccup.
+   */
+  async markAuthorizationRequired() {
+    const config = await this.getRemoteServerConfig();
+    if (!config.active) return;
+
+    logger.info('Marking remote server inactive: backend reported authorization required (401)');
+    await this.setRemoteServerConfig({ active: false });
+  }
+
+  /**
    * Clear remote server configuration
    */
   @IpcMethod()

--- a/apps/desktop/src/main/controllers/__tests__/RemoteServerConfigCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/RemoteServerConfigCtr.test.ts
@@ -116,6 +116,27 @@ describe('RemoteServerConfigCtr', () => {
     });
   });
 
+  describe('markAuthorizationRequired', () => {
+    it('flips active to false when the session was active', async () => {
+      mockStoreManager.get.mockReturnValue({ active: true, storageMode: 'cloud' });
+
+      await controller.markAuthorizationRequired();
+
+      expect(mockStoreManager.set).toHaveBeenCalledWith('dataSyncConfig', {
+        active: false,
+        storageMode: 'cloud',
+      });
+    });
+
+    it('is a no-op when already inactive (avoids redundant broadcasts)', async () => {
+      mockStoreManager.get.mockReturnValue({ active: false, storageMode: 'cloud' });
+
+      await controller.markAuthorizationRequired();
+
+      expect(mockStoreManager.set).not.toHaveBeenCalled();
+    });
+  });
+
   describe('clearRemoteServerConfig', () => {
     it('should clear configuration and tokens', async () => {
       const result = await controller.clearRemoteServerConfig();

--- a/apps/desktop/src/main/core/browser/Browser.ts
+++ b/apps/desktop/src/main/core/browser/Browser.ts
@@ -579,6 +579,9 @@ export default class Browser {
         const remoteServerUrl = await remoteServerConfigCtr.getRemoteServerUrl(config);
         return remoteServerUrl || null;
       },
+      // A 401 + X-Auth-Required means the persisted session is dead — flip `active` off so
+      // the UI stops reporting "Authorization Successful" for an expired/anonymous session.
+      onAuthorizationRequired: () => remoteServerConfigCtr.markAuthorizationRequired(),
       source: this.identifier,
     });
   }

--- a/apps/desktop/src/main/core/infrastructure/BackendProxyProtocolManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/BackendProxyProtocolManager.ts
@@ -11,6 +11,12 @@ import type { RendererRequestInterceptor } from './RendererProtocolManager';
 
 interface BackendProxyContext {
   getAccessToken: () => Promise<string | undefined | null>;
+  /**
+   * Invoked (debounced, once per 401 burst) when the backend reports that the
+   * session must re-authenticate. Lets the owner flip persisted auth state so it
+   * stops trusting a dead session.
+   */
+  onAuthorizationRequired?: () => void | Promise<void>;
   rewriteUrl: (rawUrl: string) => Promise<string | null>;
   source?: string;
 }
@@ -18,6 +24,7 @@ interface BackendProxyContext {
 interface BackendProxyRemoteBaseOptions {
   getAccessToken: () => Promise<string | undefined | null>;
   getRemoteBaseUrl: () => Promise<string | undefined | null>;
+  onAuthorizationRequired?: () => void | Promise<void>;
   source?: string;
 }
 
@@ -34,9 +41,10 @@ export class BackendProxyProtocolManager {
   private authRequiredDebounceTimer: NodeJS.Timeout | null = null;
   private static readonly AUTH_REQUIRED_DEBOUNCE_MS = 1000;
 
-  private notifyAuthorizationRequired() {
+  private notifyAuthorizationRequired(onFire?: () => void | Promise<void>) {
     // Trailing-edge debounce: coalesce rapid 401 bursts and fire AFTER the burst settles.
-    // This ensures the IPC event is sent after the renderer has had time to mount listeners.
+    // This ensures the IPC event is sent after the renderer has had time to mount listeners,
+    // and that the persisted-state flip (onFire) runs at most once per burst.
     if (this.authRequiredDebounceTimer) {
       clearTimeout(this.authRequiredDebounceTimer);
     }
@@ -50,6 +58,12 @@ export class BackendProxyProtocolManager {
           win.webContents.send('authorizationRequired');
         }
       }
+
+      // Flip persisted auth state (e.g. dataSyncConfig.active=false) so the UI and any
+      // active-gated logic stop trusting a dead session. Errors here must not break the proxy.
+      void Promise.resolve()
+        .then(() => onFire?.())
+        .catch((error) => this.logger.error('onAuthorizationRequired handler failed', error));
     }, BackendProxyProtocolManager.AUTH_REQUIRED_DEBOUNCE_MS);
   }
 
@@ -92,6 +106,7 @@ export class BackendProxyProtocolManager {
 
     this.register(session, {
       getAccessToken: options.getAccessToken,
+      onAuthorizationRequired: options.onAuthorizationRequired,
       rewriteUrl,
       source: options.source,
     });
@@ -196,7 +211,7 @@ export class BackendProxyProtocolManager {
     // Other failures keep 401 without this header (e.g., invalid API keys) and must not notify here.
     const authRequired = upstreamResponse.headers.get(AUTH_REQUIRED_HEADER) === 'true';
     if (authRequired) {
-      this.notifyAuthorizationRequired();
+      this.notifyAuthorizationRequired(context.onAuthorizationRequired);
     }
 
     return new Response(upstreamResponse.body, {

--- a/apps/desktop/src/main/core/infrastructure/__tests__/BackendProxyProtocolManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/BackendProxyProtocolManager.test.ts
@@ -261,6 +261,44 @@ describe('BackendProxyProtocolManager', () => {
     expect(send).toHaveBeenCalledWith('authorizationRequired');
   });
 
+  it('invokes onAuthorizationRequired once per 401 burst (debounced) so persisted auth state is flipped', async () => {
+    vi.useFakeTimers();
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
+      { isDestroyed: () => false, webContents: { send: vi.fn() } },
+    ] as any);
+
+    const manager = new BackendProxyProtocolManager();
+    const session = {} as any;
+    const onAuthorizationRequired = vi.fn(async () => {});
+
+    const headers = new Headers({ [AUTH_REQUIRED_HEADER]: 'true' });
+    const fetchMock = vi.fn<FetchMock>(
+      async () => new Response('{}', { headers, status: 401, statusText: 'Unauthorized' }),
+    );
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    manager.registerWithRemoteBaseUrl(session, {
+      getAccessToken: async () => 'expired-token',
+      getRemoteBaseUrl: async () => 'https://remote.example.com',
+      onAuthorizationRequired,
+    });
+
+    const fire = () =>
+      manager.proxy(
+        { headers: new Headers(), method: 'GET', url: 'app://renderer/trpc/hello' } as any,
+        session,
+      );
+
+    // A burst of 401s must collapse into a single handler invocation.
+    await fire();
+    await fire();
+    await fire();
+
+    expect(onAuthorizationRequired).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onAuthorizationRequired).toHaveBeenCalledTimes(1);
+  });
+
   describe('createAppRequestInterceptor', () => {
     it('returns null for non-backend paths', async () => {
       const manager = new BackendProxyProtocolManager();

--- a/src/features/Electron/connection/Connection.tsx
+++ b/src/features/Electron/connection/Connection.tsx
@@ -1,11 +1,12 @@
 import { Center, Flexbox } from '@lobehub/ui';
 import { Drawer } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
-import { Suspense, useCallback } from 'react';
+import { Suspense, useCallback, useEffect } from 'react';
 
 import { BrandTextLoading } from '@/components/Loading';
 import LoginStep from '@/routes/(desktop)/desktop-onboarding/features/LoginStep';
 import { useElectronStore } from '@/store/electron';
+import { useUserStore } from '@/store/user';
 import { isMacOS } from '@/utils/platform';
 
 import RemoteStatus from './RemoteStatus';
@@ -29,6 +30,16 @@ const Connection = () => {
     s.isConnectionDrawerOpen,
     s.setConnectionDrawerOpen,
   ]);
+  const refreshUserState = useUserStore((s) => s.refreshUserState);
+
+  // Re-probe the session whenever the drawer opens. `getUserState` is fetched once at
+  // startup, so a session that expired afterwards would otherwise leave a stale
+  // signed-in state and make the panel claim "Authorization Successful". Revalidating
+  // refreshes that state (and surfaces a dead session via the backend's 401 → re-auth flow).
+  useEffect(() => {
+    if (!isOpen) return;
+    refreshUserState().catch(() => {});
+  }, [isOpen, refreshUserState]);
 
   const handleClose = useCallback(() => {
     setConnectionDrawerOpen(false);

--- a/src/routes/(desktop)/desktop-onboarding/features/LoginStep.test.tsx
+++ b/src/routes/(desktop)/desktop-onboarding/features/LoginStep.test.tsx
@@ -13,6 +13,10 @@ const mockElectronState = vi.hoisted(() => ({
   useDataSyncConfig: vi.fn(() => ({})),
 }));
 
+const mockUserState = vi.hoisted(() => ({
+  isSignedIn: true,
+}));
+
 vi.mock('@lobechat/electron-client-ipc', () => ({
   useWatchBroadcast: vi.fn(),
 }));
@@ -125,6 +129,16 @@ vi.mock('@/store/electron', () => ({
     selector(mockElectronState),
 }));
 
+vi.mock('@/store/user', () => ({
+  useUserStore: <T,>(selector: (state: typeof mockUserState) => T) => selector(mockUserState),
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  authSelectors: {
+    isLogin: (s: typeof mockUserState) => s.isSignedIn,
+  },
+}));
+
 vi.mock('@/utils/electron/autoOidc', () => ({
   setDesktopAutoOidcFirstOpenHandled: vi.fn(),
 }));
@@ -149,6 +163,7 @@ beforeEach(() => {
   mockElectronState.refreshServerConfig.mockClear();
   mockElectronState.remoteServerSyncError = undefined;
   mockElectronState.useDataSyncConfig.mockClear();
+  mockUserState.isSignedIn = true;
 });
 
 afterEach(() => {
@@ -170,5 +185,16 @@ describe('Desktop onboarding LoginStep', () => {
     expect(screen.queryByText('Authorization Successful')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Sign in Cloud' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Use self-hosted server' })).toBeInTheDocument();
+  });
+
+  it('does not claim success when config is active but the session is signed out', async () => {
+    // Regression: an expired/anonymous session leaves dataSyncConfig.active = true.
+    // The panel must not show "Authorization Successful" — it should offer re-login.
+    mockUserState.isSignedIn = false;
+
+    await renderLoginStep();
+
+    expect(screen.queryByText('Authorization Successful')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign in Cloud' })).toBeInTheDocument();
   });
 });

--- a/src/routes/(desktop)/desktop-onboarding/features/LoginStep.tsx
+++ b/src/routes/(desktop)/desktop-onboarding/features/LoginStep.tsx
@@ -17,6 +17,8 @@ import { useIMECompositionEvent } from '@/hooks/useIMECompositionEvent';
 import { remoteServerService } from '@/services/electron/remoteServer';
 import { electronSystemService } from '@/services/electron/system';
 import { useElectronStore } from '@/store/electron';
+import { useUserStore } from '@/store/user';
+import { authSelectors } from '@/store/user/selectors';
 import { setDesktopAutoOidcFirstOpenHandled } from '@/utils/electron/autoOidc';
 
 import LobeMessage from '../components/LobeMessage';
@@ -93,6 +95,12 @@ const LoginStep = memo<LoginStepProps>(({ onBack, onNext }) => {
 
   useDataSyncConfig();
 
+  // The persisted `dataSyncConfig.active` flag only records that a remote was once
+  // connected — it is NOT cleared when the session silently expires. Gate "authorized"
+  // on the real signed-in state (getUserState succeeded) so a dead/anonymous session
+  // never renders as "Authorization Successful".
+  const isSignedIn = useUserStore(authSelectors.isLogin);
+
   useEffect(() => {
     if (!isDesktop) return;
 
@@ -109,8 +117,10 @@ const LoginStep = memo<LoginStepProps>(({ onBack, onNext }) => {
     };
   }, []);
 
-  const isCloudAuthed = !!dataSyncConfig?.active && dataSyncConfig.storageMode === 'cloud';
-  const isSelfHostAuthed = !!dataSyncConfig?.active && dataSyncConfig.storageMode === 'selfHost';
+  const isCloudAuthed =
+    !!dataSyncConfig?.active && dataSyncConfig.storageMode === 'cloud' && isSignedIn;
+  const isSelfHostAuthed =
+    !!dataSyncConfig?.active && dataSyncConfig.storageMode === 'selfHost' && isSignedIn;
   const authorizedLoginMethod: LoginMethod | null = isCloudAuthed
     ? 'cloud'
     : isSelfHostAuthed


### PR DESCRIPTION
## What & Why

On desktop, opening the cross-device-sync login panel (the onboarding `LoginStep`, **also reused by the Home connection drawer**) could show **「授权成功 / Authorization Successful」** with an **anonymous** user even though the session had actually expired — and no re-authorization window popped up.

Root cause: the success state was derived purely from the persisted `dataSyncConfig.active` flag, which is **never cleared when a session silently expires**. So `active: true` + dead/anonymous session → false "success", with no detection.

<img width="400" alt="false success + anonymous user" src="https://github.com/user-attachments/assets/placeholder" />

## Changes

1. **Gate success on the real signed-in state** — `LoginStep` now requires `authSelectors.isLogin` (true only after `getUserState()` succeeds), not just `active`. A dead/anonymous session no longer renders as success.
2. **Re-probe on open** — the `Connection` drawer calls `refreshUserState()` when it opens, so a session that expired *after* startup is re-validated instead of showing stale state.
3. **Make 401 authoritative** — a backend `401 + X-Auth-Required` now flips `dataSyncConfig.active` off via the new `RemoteServerConfigCtr.markAuthorizationRequired()`, wired through a new `onAuthorizationRequired` callback on `BackendProxyProtocolManager` (folded into the existing 1s debounce → fires once per 401 burst). Tokens are preserved; no-op when already inactive.

### Notes / trade-offs
- `getRemoteServerUrl` does **not** gate on `active` (cloud always returns the official server), so flipping `active` off does not break proxy routing.
- Flipping `active: false` disables `AuthCtr`'s background auto-refresh recovery for that session (`isRemoteServerConfigured` → false), which is consistent with the existing "401 → re-login" intent.
- **Out of scope (deliberately deferred):** the `isTokenExpiringSoon` / `initializeAutoRefresh` blind spot where a missing `tokenExpiresAt` is treated as "valid" and never validated.

## Tests
- `LoginStep.test.tsx` — new regression: `active: true` + signed-out → no "Authorization Successful".
- `BackendProxyProtocolManager.test.ts` — `onAuthorizationRequired` fires once per debounced 401 burst.
- `RemoteServerConfigCtr.test.ts` — `markAuthorizationRequired` flips when active, no-op when inactive.

All passing; type-check clean for touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)