### PR TITLE
✨ feat(auth): preserve utm_source through the OIDC sign-in/sign-up flow

### DIFF
--- a/src/app/[variants]/(auth)/signin/useSignIn.ts
+++ b/src/app/[variants]/(auth)/signin/useSignIn.ts
@@ -140,9 +140,12 @@ export const useSignIn = () => {
           return;
         }
         const callbackUrl = searchParams.get('callbackUrl') || '/';
-        router.push(
-          `/signup?email=${encodeURIComponent(targetEmail)}&callbackUrl=${encodeURIComponent(callbackUrl)}`,
-        );
+        const signupParams = new URLSearchParams();
+        signupParams.set('email', targetEmail);
+        signupParams.set('callbackUrl', callbackUrl);
+        const utmSource = searchParams.get('utm_source');
+        if (utmSource) signupParams.set('utm_source', utmSource);
+        router.push(`/signup?${signupParams.toString()}`);
         return;
       }
 
@@ -257,6 +260,8 @@ export const useSignIn = () => {
     const params = new URLSearchParams();
     if (currentEmail) params.set('email', currentEmail);
     params.set('callbackUrl', callbackUrl);
+    const utmSource = searchParams.get('utm_source');
+    if (utmSource) params.set('utm_source', utmSource);
     void trackLoginOrSignupClicked({ spm: 'signin.go_to_signup.click' }).finally(() => {
       router.push(`/signup?${params.toString()}`);
     });

--- a/src/libs/next/proxy/define-config.ts
+++ b/src/libs/next/proxy/define-config.ts
@@ -239,6 +239,13 @@ export function defineConfig() {
           signInUrl.searchParams.set('hl', hl);
           logBetterAuth('Preserving locale to sign-in: hl=%s', hl);
         }
+        // Preserve marketing attribution (e.g. sign-ups originating from Market)
+        // so it survives the auth detour and reaches the sign-up page.
+        const utmSource = req.nextUrl.searchParams.get('utm_source');
+        if (utmSource) {
+          signInUrl.searchParams.set('utm_source', utmSource);
+          logBetterAuth('Preserving utm_source to sign-in: %s', utmSource);
+        }
         return Response.redirect(signInUrl);
       }
       logBetterAuth('Request a free route but not login, allow visit without auth header');


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

When LobeHub Market kicks off the OIDC flow against LobeHub, the request to `/oidc/auth` now carries a `utm_source` so sign-ups originating from Market can be attributed.

`/oidc/auth` is a **protected** route, so the auth middleware redirects unauthenticated users to `/signin` (and from there to `/signup`). Previously `utm_source` only survived buried inside the `callbackUrl` param and never surfaced as a usable param on the sign-up page.

This PR carries `utm_source` as a first-class query param through the auth detour, mirroring exactly how the existing `hl` (locale) param is already preserved:

- **Middleware** (`src/libs/next/proxy/define-config.ts`): lifts `utm_source` from the incoming request onto the `/signin` URL, right next to the existing `hl` handling.
- **Sign-in** (`src/app/[variants]/(auth)/signin/useSignIn.ts`): forwards `utm_source` to `/signup` in both navigation paths (`handleCheckUser` for unknown emails, and `handleGoToSignup` for the explicit "create account" action).

Scope is intentionally minimal — this only **propagates** the param through the redirects. No analytics wiring and no persistence/DB changes are included.

#### 🧪 How to Test

Visit a protected OIDC entry with the param while logged out, e.g.:

```
https://app.lobehub.com/oidc/auth?...&utm_source=lobehub-market
```

The middleware redirects to `/signin?...&utm_source=lobehub-market`, and proceeding to registration lands on `/signup?...&utm_source=lobehub-market`.

- [x] Tested locally
- [x] Added/updated tests (existing `useSignIn.test.ts` passes; signup redirect assertion still holds)
- [ ] No tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)