### PR TITLE
💄 style(chat-input): use compact stats footer for skill tools popover

### DIFF
--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -1018,6 +1018,7 @@
   "tools.activation.pinned": "Pinned",
   "tools.activation.pinned.desc": "Always On",
   "tools.add": "Add Skill",
+  "tools.addSkillOrConnector": "Add Skills / Connector",
   "tools.builtins.configure": "Configure",
   "tools.builtins.find-skills.description": "Helps users discover and install agent skills when they ask \"how do I do X\", \"find a skill for X\", or want to extend capabilities",
   "tools.builtins.find-skills.title": "Find Skills",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -1019,6 +1019,7 @@
   "tools.activation.pinned": "固定启用",
   "tools.activation.pinned.desc": "始终注入",
   "tools.add": "集成技能",
+  "tools.addSkillOrConnector": "添加技能 / 连接器",
   "tools.builtins.configure": "配置",
   "tools.builtins.find-skills.description": "当用户询问“我该如何做 X”、“帮我找一个能做 X 的技能”或希望扩展能力时，帮助用户发现并安装助手技能",
   "tools.builtins.find-skills.title": "查找技能",

--- a/src/features/ChatInput/ActionBar/Tools/PopoverContent.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/PopoverContent.tsx
@@ -1,18 +1,23 @@
 import { type ItemType } from '@lobehub/ui';
 import { Flexbox, Icon, SearchBar, stopPropagation, usePopoverContext } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
-import { ChevronRight, ExternalLink, Settings, Store } from 'lucide-react';
+import { Pin, Settings, Store, Zap } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
 import { ScrollSignalProvider } from './ScrollSignalContext';
 import SkillActivateMode from './SkillActivateMode';
-import ToolsList, { toolsListStyles } from './ToolsList';
+import ToolsList from './ToolsList';
 
 const styles = createStaticStyles(({ css }) => ({
   footer: css`
-    padding: 4px;
+    display: flex;
+    gap: 14px;
+    align-items: center;
+
+    padding-block: 6px;
+    padding-inline: 12px;
     border-block-start: 1px solid ${cssVar.colorFill};
   `,
   header: css`
@@ -20,8 +25,67 @@ const styles = createStaticStyles(({ css }) => ({
     padding-inline: 8px;
     border-block-end: 1px solid ${cssVar.colorFill};
   `,
-  trailingIcon: css`
-    opacity: 0.5;
+  iconButton: css`
+    cursor: pointer;
+
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+
+    width: 28px;
+    height: 28px;
+    border: 0;
+    border-radius: 6px;
+
+    color: ${cssVar.colorTextTertiary};
+
+    background: transparent;
+
+    transition:
+      color 0.2s,
+      background 0.2s;
+
+    &:hover {
+      color: ${cssVar.colorTextSecondary};
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
+  statsItem: css`
+    display: inline-flex;
+    gap: 5px;
+    align-items: center;
+
+    font-size: 12px;
+    line-height: 18px;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  storeButton: css`
+    cursor: pointer;
+
+    display: inline-flex;
+    flex: none;
+    gap: 4px;
+    align-items: center;
+
+    height: 28px;
+    padding-inline: 8px;
+    border: 0;
+    border-radius: 6px;
+
+    font-size: 13px;
+    color: ${cssVar.colorTextSecondary};
+
+    background: transparent;
+
+    transition:
+      color 0.2s,
+      background 0.2s;
+
+    &:hover {
+      color: ${cssVar.colorText};
+      background: ${cssVar.colorFillTertiary};
+    }
   `,
 }));
 
@@ -51,80 +115,86 @@ const filterItems = (items: ItemType[], keyword: string): ItemType[] => {
 };
 
 interface PopoverContentProps {
+  autoCount: number;
   items: ItemType[];
   onOpenStore: () => void;
+  pinnedCount: number;
 }
 
-const PopoverContent = memo<PopoverContentProps>(({ items, onOpenStore }) => {
-  const { t } = useTranslation('setting');
-  const navigate = useNavigate();
-  const [searchKeyword, setSearchKeyword] = useState('');
+const PopoverContent = memo<PopoverContentProps>(
+  ({ autoCount, items, onOpenStore, pinnedCount }) => {
+    const { t } = useTranslation('setting');
+    const navigate = useNavigate();
+    const [searchKeyword, setSearchKeyword] = useState('');
 
-  const { close: closePopover } = usePopoverContext();
+    const { close: closePopover } = usePopoverContext();
 
-  const filteredItems = useMemo(
-    () => (searchKeyword ? filterItems(items, searchKeyword) : items),
-    [items, searchKeyword],
-  );
+    const filteredItems = useMemo(
+      () => (searchKeyword ? filterItems(items, searchKeyword) : items),
+      [items, searchKeyword],
+    );
 
-  return (
-    <Flexbox gap={0}>
-      <Flexbox horizontal align="center" className={styles.header} gap={4}>
-        <SearchBar
-          allowClear
-          placeholder={t('tools.search')}
-          size="small"
-          style={{ flex: 1 }}
-          value={searchKeyword}
-          variant="borderless"
-          onChange={(e) => setSearchKeyword(e.target.value)}
-          onKeyDown={stopPropagation}
-        />
-        <SkillActivateMode />
+    return (
+      <Flexbox gap={0}>
+        <Flexbox horizontal align="center" className={styles.header} gap={4}>
+          <SearchBar
+            allowClear
+            placeholder={t('tools.search')}
+            size="small"
+            style={{ flex: 1 }}
+            value={searchKeyword}
+            variant="borderless"
+            onChange={(e) => setSearchKeyword(e.target.value)}
+            onKeyDown={stopPropagation}
+          />
+          <SkillActivateMode />
+        </Flexbox>
+        <ScrollSignalProvider
+          style={{
+            height: 480,
+            overflowY: 'auto',
+          }}
+        >
+          <ToolsList items={filteredItems} />
+        </ScrollSignalProvider>
+        <div className={styles.footer}>
+          <span className={styles.statsItem}>
+            <Icon icon={Pin} size={12} />
+            {pinnedCount}
+          </span>
+          <span className={styles.statsItem}>
+            <Icon icon={Zap} size={12} />
+            {autoCount}
+          </span>
+          <Flexbox horizontal align="center" gap={2} style={{ marginInlineStart: 'auto' }}>
+            <button
+              className={styles.storeButton}
+              type="button"
+              onClick={() => {
+                closePopover();
+                onOpenStore();
+              }}
+            >
+              <Icon icon={Store} size={14} />
+              {t('tools.addSkillOrConnector')}
+            </button>
+            <button
+              aria-label={t('tools.plugins.management')}
+              className={styles.iconButton}
+              type="button"
+              onClick={() => {
+                closePopover();
+                navigate('/settings/skill');
+              }}
+            >
+              <Icon icon={Settings} size={14} />
+            </button>
+          </Flexbox>
+        </div>
       </Flexbox>
-      <ScrollSignalProvider
-        style={{
-          height: 480,
-          overflowY: 'auto',
-        }}
-      >
-        <ToolsList items={filteredItems} />
-      </ScrollSignalProvider>
-      <div className={styles.footer}>
-        <div
-          className={toolsListStyles.item}
-          role="button"
-          tabIndex={0}
-          onClick={() => {
-            closePopover();
-            onOpenStore();
-          }}
-        >
-          <div className={toolsListStyles.itemIcon}>
-            <Icon icon={Store} size={20} />
-          </div>
-          <div className={toolsListStyles.itemContent}>{t('skillStore.title')}</div>
-          <Icon className={styles.trailingIcon} icon={ChevronRight} size={16} />
-        </div>
-        <div
-          className={toolsListStyles.item}
-          role="button"
-          tabIndex={0}
-          onClick={() => {
-            closePopover();
-            navigate('/settings/skill');
-          }}
-        >
-          <div className={toolsListStyles.itemIcon}>
-            <Icon icon={Settings} size={20} />
-          </div>
-          <div className={toolsListStyles.itemContent}>{t('tools.plugins.management')}</div>
-          <Icon className={styles.trailingIcon} icon={ExternalLink} size={16} />
-        </div>
-      </div>
-    </Flexbox>
-  );
-});
+    );
+  },
+);
 
 PopoverContent.displayName = 'PopoverContent';
 

--- a/src/features/ChatInput/ActionBar/Tools/index.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/index.tsx
@@ -14,7 +14,7 @@ import { useControls } from './useControls';
 
 const Tools = memo(() => {
   const { t } = useTranslation('setting');
-  const { marketItems, editPluginDrawer } = useControls();
+  const { marketItems, editPluginDrawer, pinnedCount, autoCount } = useControls();
 
   const agentId = useAgentId();
   const model = useAgentStore((s) => agentByIdSelectors.getAgentModelById(agentId)(s));
@@ -36,7 +36,14 @@ const Tools = memo(() => {
         showTooltip={false}
         title={t('tools.title')}
         popover={{
-          content: <PopoverContent items={marketItems} onOpenStore={handleOpenStore} />,
+          content: (
+            <PopoverContent
+              autoCount={autoCount}
+              items={marketItems}
+              pinnedCount={pinnedCount}
+              onOpenStore={handleOpenStore}
+            />
+          ),
           maxWidth: 320,
           minWidth: 320,
           styles: {

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -317,6 +317,12 @@ const styles = createStaticStyles(({ css }) => ({
     width: 100%;
     min-width: 0;
   `,
+  toolTrailing: css`
+    display: inline-flex;
+    flex: none;
+    gap: 8px;
+    align-items: center;
+  `,
   typeTag: css`
     display: inline-flex;
     flex: none;
@@ -614,9 +620,11 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
           {icon}
           <span className={cx(styles.toolLabelText)}>{label}</span>
           {extraTag}
-          {badge && <span className={cx(styles.typeTag)}>{badge}</span>}
         </span>
-        {action}
+        <span className={cx(styles.toolTrailing)}>
+          {badge && <span className={cx(styles.typeTag)}>{badge}</span>}
+          {action}
+        </span>
       </span>
     ),
     [openSkillPolicyMenu],
@@ -1000,15 +1008,17 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
                 {icon}
                 <span className={cx(styles.toolLabelText)}>{title}</span>
                 {officialTag}
+              </span>
+              <span className={cx(styles.toolTrailing)}>
                 <span className={cx(styles.typeTag)}>
                   <Icon icon={Wrench} size={12} />
                 </span>
+                <Tooltip placement={'top'} title={t('tools.activation.fixed.hint')}>
+                  <span className={cx(styles.fixedIndicator)}>
+                    <Icon icon={Pin} size={15} />
+                  </span>
+                </Tooltip>
               </span>
-              <Tooltip placement={'top'} title={t('tools.activation.fixed.hint')}>
-                <span className={cx(styles.fixedIndicator)}>
-                  <Icon icon={Pin} size={15} />
-                </span>
-              </Tooltip>
             </span>
           ),
           popoverContent,

--- a/src/locales/default/setting.ts
+++ b/src/locales/default/setting.ts
@@ -1170,6 +1170,7 @@ When I am ___, I need ___
   'tab.uploadZip.desc': 'Upload a local .zip or .skill file',
   'tab.usage': 'Usage',
   'tools.add': 'Add Skill',
+  'tools.addSkillOrConnector': 'Add Skills / Connector',
   'tools.builtins.groupName': 'Built-ins',
   'tools.builtins.install': 'Install',
   'tools.builtins.installed': 'Installed',

--- a/src/server/services/aiAgent/__tests__/execAgent.connectorOverlap.test.ts
+++ b/src/server/services/aiAgent/__tests__/execAgent.connectorOverlap.test.ts
@@ -116,6 +116,10 @@ vi.mock('@/server/services/toolExecution/deviceProxy', () => ({
   deviceProxy: { isConfigured: false, queryDeviceList: vi.fn().mockResolvedValue([]) },
 }));
 
+vi.mock('@/server/services/deviceGateway', () => ({
+  deviceGateway: { isConfigured: false, queryDeviceList: vi.fn().mockResolvedValue([]) },
+}));
+
 vi.mock('@/server/modules/ModelRuntime', () => ({ initModelRuntimeFromDB: vi.fn() }));
 
 vi.mock('model-bank', async (importOriginal) => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Reworks the footer and item layout of the chat-input **Skills/Tools** popover (`ChatInput/ActionBar/Tools`).

- **Compact stats footer.** Replaces the two full-width footer rows (Skill Store / Skill Management) with a compact stats footer:
  - left: 📌 pinned count and ⚡ auto count
  - right: an **"Add Skills / Connector"** store button (icon + text label, instead of an icon-only entry) and a settings icon button that opens skill management.
- **Right-aligned type tags.** Each item's type tag (MCP / Skills / builtin wrench) is now pushed flush to the right next to the row action, instead of trailing immediately after the item name. Applied to both managed skill rows (`renderToolLabel`) and app-fixed tool rows.

New i18n key `tools.addSkillOrConnector` (en-US + zh-CN shipped).

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Open the chat input, click the Skills/Tools (Blocks) button, and verify the popover footer shows the pinned/auto counts plus the "Add Skills / Connector" store button and settings icon, and that item type tags are right-aligned.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Two-row footer (Store / Management); type tag after the item name | Compact stats footer with labeled store button; right-aligned type tags |

#### 📝 Additional Information

Purely a presentation change to the existing skill tools popover; no behavior or data changes.