### PR TITLE
🐛 fix: show gateway running operation status

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
@@ -64,7 +64,7 @@ const TopicChatDrawerBody = memo<TopicChatDrawerBodyProps>(({ agentId, topicId }
   const runningOperation = useTaskStore(
     (s) => taskActivitySelectors.activeDrawerTopicActivity(s)?.runningOperation,
   );
-  useGatewayReconnect(topicId, runningOperation);
+  useGatewayReconnect(topicId, runningOperation, { agentId });
 
   const itemContent = useCallback(
     (index: number, id: string) => (

--- a/src/features/Conversation/Messages/Task/TaskDetailPanel/StatusContent.tsx
+++ b/src/features/Conversation/Messages/Task/TaskDetailPanel/StatusContent.tsx
@@ -8,6 +8,7 @@ import { ThreadStatus } from '@/types/index';
 
 import {
   ErrorState,
+  hasActiveRuntimeOperationForMessage,
   InitializingState,
   isProcessingStatus,
   TaskMessages,
@@ -30,13 +31,8 @@ const StatusContent = memo<StatusContentProps>(({ taskDetail, messageId }) => {
     s.operations,
   ]);
 
-  // Check if exec_async_task is already polling for this message
-  const hasActiveOperationPolling = Object.values(operations).some(
-    (op) =>
-      op.status === 'running' &&
-      op.type === 'execAgentRuntime' &&
-      op.context?.messageId === messageId,
-  );
+  // Check if a live runtime operation is already responsible for this message.
+  const hasActiveOperationPolling = hasActiveRuntimeOperationForMessage(operations, messageId);
 
   // Enable polling when task has threadId and no active operation is polling
   // For completed tasks, this will fetch messages once (no refreshInterval needed)

--- a/src/features/Conversation/Messages/Tasks/shared/ProcessingState.tsx
+++ b/src/features/Conversation/Messages/Tasks/shared/ProcessingState.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
 import { useChatStore } from '@/store/chat';
 
+import { hasActiveRuntimeOperationForMessage } from './activeOperation';
 import { MAX_PROGRESS, PROGRESS_INCREMENT, PROGRESS_INTERVAL } from './constants';
 import { formatElapsedTime, formatToolName } from './utils';
 
@@ -111,13 +112,8 @@ const ProcessingState = memo<ProcessingStateProps>(
       s.operations,
     ]);
 
-    // Check if exec_async_task is already polling for this message
-    const hasActiveOperationPolling = Object.values(operations).some(
-      (op) =>
-        op.status === 'running' &&
-        op.type === 'execAgentRuntime' &&
-        op.context?.messageId === messageId,
-    );
+    // Check if a live runtime operation is already responsible for this message.
+    const hasActiveOperationPolling = hasActiveRuntimeOperationForMessage(operations, messageId);
 
     // Enable polling only when no active operation is already polling
     // This handles the case when user refreshes page and exec_async_task is no longer running

--- a/src/features/Conversation/Messages/Tasks/shared/activeOperation.test.ts
+++ b/src/features/Conversation/Messages/Tasks/shared/activeOperation.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ChatOperationState } from '@/store/chat/slices/operation/initialState';
+
+import { hasActiveRuntimeOperationForMessage } from './activeOperation';
+
+type OperationRecord = ChatOperationState['operations'];
+
+const createOperation = (
+  type: OperationRecord[string]['type'],
+  status: OperationRecord[string]['status'],
+  messageId = 'msg-1',
+): OperationRecord[string] => ({
+  abortController: new AbortController(),
+  context: { messageId },
+  id: `${type}-${status}`,
+  metadata: { startTime: 1 },
+  status,
+  type,
+});
+
+describe('hasActiveRuntimeOperationForMessage', () => {
+  it('treats running server runtime operations as active', () => {
+    const operations: OperationRecord = {
+      'op-server': createOperation('execServerAgentRuntime', 'running'),
+    };
+
+    expect(hasActiveRuntimeOperationForMessage(operations, 'msg-1')).toBe(true);
+  });
+
+  it('ignores completed runtime operations and unrelated messages', () => {
+    const operations: OperationRecord = {
+      'op-completed': createOperation('execAgentRuntime', 'completed'),
+      'op-other-message': createOperation('execHeterogeneousAgent', 'running', 'msg-2'),
+      'op-tool': createOperation('toolCalling', 'running'),
+    };
+
+    expect(hasActiveRuntimeOperationForMessage(operations, 'msg-1')).toBe(false);
+  });
+});

--- a/src/features/Conversation/Messages/Tasks/shared/activeOperation.ts
+++ b/src/features/Conversation/Messages/Tasks/shared/activeOperation.ts
@@ -1,0 +1,13 @@
+import type { ChatOperationState } from '@/store/chat/slices/operation/initialState';
+import { AI_RUNTIME_OPERATION_TYPES } from '@/store/chat/slices/operation/types';
+
+export const hasActiveRuntimeOperationForMessage = (
+  operations: ChatOperationState['operations'],
+  messageId: string,
+): boolean =>
+  Object.values(operations).some(
+    (op) =>
+      op.status === 'running' &&
+      AI_RUNTIME_OPERATION_TYPES.includes(op.type) &&
+      op.context?.messageId === messageId,
+  );

--- a/src/features/Conversation/Messages/Tasks/shared/index.ts
+++ b/src/features/Conversation/Messages/Tasks/shared/index.ts
@@ -1,3 +1,4 @@
+export * from './activeOperation';
 export type { CompletedStateVariant } from './CompletedState';
 export { default as CompletedState, MetricItem } from './CompletedState';
 export * from './constants';

--- a/src/features/Conversation/Messages/Tasks/shared/useTaskPolling.ts
+++ b/src/features/Conversation/Messages/Tasks/shared/useTaskPolling.ts
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 
 import { useChatStore } from '@/store/chat';
 
+import { hasActiveRuntimeOperationForMessage } from './activeOperation';
 import { isProcessingStatus } from './utils';
 
 interface UseTaskPollingParams {
@@ -22,13 +23,8 @@ export const useTaskPolling = ({ messageId, threadId, status }: UseTaskPollingPa
     s.operations,
   ]);
 
-  // Check if exec_async_task is already polling for this message
-  const hasActiveOperationPolling = Object.values(operations).some(
-    (op) =>
-      op.status === 'running' &&
-      op.type === 'execAgentRuntime' &&
-      op.context?.messageId === messageId,
-  );
+  // Check if a live runtime operation is already responsible for this message.
+  const hasActiveOperationPolling = hasActiveRuntimeOperationForMessage(operations, messageId);
 
   // Enable polling when:
   // 1. Has threadId

--- a/src/hooks/useGatewayReconnect.ts
+++ b/src/hooks/useGatewayReconnect.ts
@@ -10,6 +10,11 @@ interface RunningOperation {
   threadId?: string | null;
 }
 
+interface GatewayReconnectContext {
+  agentId?: string;
+  groupId?: string | null;
+}
+
 /**
  * Auto-reconnect to a running Gateway operation on the given topic.
  *
@@ -27,6 +32,7 @@ interface RunningOperation {
 export const useGatewayReconnect = (
   topicId: string | null | undefined,
   runningOperation: RunningOperation | null | undefined,
+  context?: GatewayReconnectContext,
 ) => {
   const agentGatewayUrl = useServerConfigStore((s) => s.serverConfig.agentGatewayUrl);
 
@@ -38,7 +44,9 @@ export const useGatewayReconnect = (
       if (!runningOperation || !topicId) return;
 
       await useChatStore.getState().reconnectToGatewayOperation({
+        agentId: context?.agentId,
         assistantMessageId: runningOperation.assistantMessageId,
+        groupId: context?.groupId,
         operationId: runningOperation.operationId,
         scope: runningOperation.scope,
         threadId: runningOperation.threadId,

--- a/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
@@ -71,7 +71,10 @@ const Conversation = memo(() => {
       ? topicSelectors.getTopicById(context.topicId)(s)?.metadata?.runningOperation
       : undefined,
   );
-  useGatewayReconnect(context.topicId, runningOperation);
+  useGatewayReconnect(context.topicId, runningOperation, {
+    agentId: context.agentId,
+    groupId: context.groupId,
+  });
 
   const agentChatConfig = useAgentStore(agentChatConfigSelectors.currentChatConfig);
   const chatFollowUpHooks = useChatFollowUp({

--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type * as ConstVersion from '@/const/version';
 import { aiAgentService } from '@/services/aiAgent';
+import { topicService } from '@/services/topic';
 
 import type { GatewayConnection } from '../gateway';
 import { GatewayActionImpl } from '../gateway';
@@ -118,6 +119,7 @@ function createTestAction() {
 describe('GatewayActionImpl', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    delete (globalThis as any).window;
   });
 
   describe('connectToGateway', () => {
@@ -409,6 +411,98 @@ describe('GatewayActionImpl', () => {
     it('should return undefined for unknown operationId', () => {
       const { action } = createTestAction();
       expect(action.getGatewayConnectionStatus('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('reconnectToGatewayOperation', () => {
+    it('marks the topic running while reconnecting an existing server operation', async () => {
+      const associateMessageWithOperation = vi.fn();
+      const completeOperation = vi.fn();
+      const connectToGateway = vi.fn();
+      const internal_updateTopicLoading = vi.fn();
+      const onOperationCancel = vi.fn();
+      const startOperation = vi.fn(() => ({ operationId: 'gw-op-local' }));
+      const updateTopicStatus = vi.fn();
+
+      const state: Record<string, any> = {
+        activeAgentId: 'agent-1',
+        activeGroupId: null,
+        gatewayConnections: {},
+        topicDataMap: {},
+      };
+      const set = vi.fn((updater: any) => {
+        if (typeof updater === 'function') Object.assign(state, updater(state));
+        else Object.assign(state, updater);
+      });
+      const get = vi.fn(() => ({
+        ...state,
+        associateMessageWithOperation,
+        completeOperation,
+        connectToGateway,
+        internal_updateTopicLoading,
+        onOperationCancel,
+        startOperation,
+        updateTopicStatus,
+      })) as any;
+
+      (globalThis as any).window = {
+        global_serverConfigStore: {
+          getState: () => ({ serverConfig: { agentGatewayUrl: 'https://gateway.test.com' } }),
+        },
+      };
+
+      vi.mocked(aiAgentService.refreshGatewayToken).mockResolvedValue({ token: 'fresh-token' });
+      vi.mocked(topicService.updateTopicMetadata).mockResolvedValue(undefined);
+
+      const action = new GatewayActionImpl(set as any, get, undefined);
+
+      await action.reconnectToGatewayOperation({
+        agentId: 'agent-from-context',
+        assistantMessageId: 'ast-1',
+        groupId: 'group-1',
+        operationId: 'server-op-1',
+        topicId: 'topic-1',
+      });
+
+      expect(startOperation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: expect.objectContaining({
+            agentId: 'agent-from-context',
+            groupId: 'group-1',
+            topicId: 'topic-1',
+          }),
+          metadata: { serverOperationId: 'server-op-1' },
+          type: 'execServerAgentRuntime',
+        }),
+      );
+      expect(associateMessageWithOperation).toHaveBeenCalledWith('ast-1', 'gw-op-local');
+      expect(internal_updateTopicLoading).toHaveBeenCalledWith('topic-1', true);
+      expect(updateTopicStatus).toHaveBeenCalledWith({
+        agentId: 'agent-from-context',
+        groupId: 'group-1',
+        status: 'running',
+        topicId: 'topic-1',
+      });
+      expect(connectToGateway).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operationId: 'server-op-1',
+          resumeOnConnect: true,
+          token: 'fresh-token',
+          topicId: 'topic-1',
+        }),
+      );
+
+      const [{ onSessionComplete }] = connectToGateway.mock.calls[0];
+      onSessionComplete();
+
+      expect(completeOperation).toHaveBeenCalledWith('gw-op-local');
+      expect(internal_updateTopicLoading).toHaveBeenLastCalledWith('topic-1', false);
+      expect(updateTopicStatus).toHaveBeenLastCalledWith({
+        agentId: 'agent-from-context',
+        groupId: 'group-1',
+        status: 'active',
+        topicId: 'topic-1',
+      });
     });
   });
 

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -551,13 +551,23 @@ export class GatewayActionImpl {
    * and establishes a new WebSocket connection with event replay.
    */
   reconnectToGatewayOperation = async (params: {
+    agentId?: string;
     assistantMessageId: string;
+    groupId?: string | null;
     operationId: string;
     scope?: string;
     threadId?: string | null;
     topicId: string;
   }): Promise<void> => {
-    const { assistantMessageId, operationId, topicId, scope, threadId } = params;
+    const {
+      agentId: reconnectAgentId,
+      assistantMessageId,
+      groupId,
+      operationId,
+      scope,
+      threadId,
+      topicId,
+    } = params;
 
     const agentGatewayUrl =
       window.global_serverConfigStore?.getState()?.serverConfig?.agentGatewayUrl;
@@ -592,9 +602,10 @@ export class GatewayActionImpl {
       ?.runningOperation?.operationId;
     if (topicOpIdAfterRefresh && topicOpIdAfterRefresh !== operationId) return;
 
-    const agentId = this.#get().activeAgentId;
+    const agentId = reconnectAgentId ?? this.#get().activeAgentId;
     const context = {
       agentId,
+      groupId: groupId ?? undefined,
       scope: (scope ?? 'main') as ConversationContext['scope'],
       threadId: threadId ?? null,
       topicId,
@@ -609,6 +620,13 @@ export class GatewayActionImpl {
     });
 
     this.#get().associateMessageWithOperation(assistantMessageId, gatewayOpId);
+    this.#get().internal_updateTopicLoading(topicId, true);
+    void this.#get().updateTopicStatus?.({
+      agentId: context.agentId,
+      groupId: context.groupId,
+      status: 'running',
+      topicId,
+    });
 
     // Forward local-op cancellation to the server-side agent loop via tRPC.
     // See note in executeGatewayAgent for details.
@@ -635,6 +653,7 @@ export class GatewayActionImpl {
         this.#get().internal_updateTopicLoading(topicId, false);
         void this.#get().updateTopicStatus?.({
           agentId: context.agentId,
+          groupId: context.groupId,
           status: 'active',
           topicId,
         });


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Mark reconnected gateway operations as topic loading/running so existing backend runs have visible frontend status.
- Preserve agent/group context when reconnecting to a running gateway operation.
- Reuse AI runtime operation types for task polling guards so server runtime ops are treated as active.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run --silent='passed-only' src/features/Conversation/Messages/Tasks/shared/activeOperation.test.ts
bunx vitest run --silent='passed-only' src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
bunx vitest run --silent='passed-only' src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx
```

`bun run type-check` was also attempted, but current canary/local deps fail before this change on unresolved new workspace packages / base-ui Button export / antd-style CacheManager version mismatch.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This PR only changes generic open-source gateway/task UI state plumbing; no cloud-specific business logic is exposed.
