### PR TITLE
:sparkles: feat(page-editor): enable block plugin with shared inline padding

### DIFF
--- a/src/features/PageEditor/EditorCanvas/index.tsx
+++ b/src/features/PageEditor/EditorCanvas/index.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { type CSSProperties } from 'react';
+import { ReactBlockPlugin } from '@lobehub/editor';
+import { Editor } from '@lobehub/editor/react';
+import { type CSSProperties, useMemo } from 'react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -24,10 +26,16 @@ const EditorCanvas = memo<EditorCanvasProps>(({ placeholder, style }) => {
   const slashItems = useSlashItems();
   const askCopilotItem = useAskCopilotItem(editor);
 
+  const extraPlugins = useMemo(
+    () => [Editor.withProps(ReactBlockPlugin, { anchorPadding: 0 })],
+    [],
+  );
+
   return (
     <SharedEditorCanvas
       documentId={documentId}
       editor={editor}
+      extraPlugins={extraPlugins}
       placeholder={placeholder || t('pageEditor.editorPlaceholder')}
       slashItems={slashItems}
       style={style}

--- a/src/features/PageEditor/PageEditor.tsx
+++ b/src/features/PageEditor/PageEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { EditorProvider } from '@lobehub/editor/react';
+import { DEFAULT_BLOCK_ANCHOR_PADDING, EditorProvider } from '@lobehub/editor/react';
 import { Flexbox } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import type { FC, ReactNode } from 'react';
@@ -43,6 +43,7 @@ const styles = StyleSheet.create({
   },
   editorContent: {
     overflowY: 'auto',
+    paddingInline: DEFAULT_BLOCK_ANCHOR_PADDING,
     position: 'relative',
   },
 });

--- a/src/features/PageEditor/PageEditor.tsx
+++ b/src/features/PageEditor/PageEditor.tsx
@@ -42,7 +42,6 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   editorContent: {
-    overflowY: 'auto',
     paddingInline: DEFAULT_BLOCK_ANCHOR_PADDING,
     position: 'relative',
   },


### PR DESCRIPTION
## Summary

- Mount `ReactBlockPlugin` on the PageEditor via `extraPlugins`, with `anchorPadding={0}` so the editor root no longer reserves its default 54 px gutters.
- Move that 54 px to the parent `Flexbox` (the wrapper around `TitleSection` + `EditorCanvas`) using `DEFAULT_BLOCK_ANCHOR_PADDING` imported from `@lobehub/editor/react`. Title and editor body now share the same indent, while the gutter that hosts the floating block menu and drag handle is preserved.
- Scoped to PageEditor — ChatInput and other shared callers remain untouched.

## Dependency

Requires `@lobehub/editor` with `BlockPluginOptions.anchorPadding` and the exported `DEFAULT_BLOCK_ANCHOR_PADDING` constant (lobehub/lobe-editor#169). Bump the editor dep once that ships before merging.

## Test plan

- [ ] PageEditor renders without the 54 px blank strips on either side of the content
- [ ] Hover a block — drag handle / `+` button appear in the gutter to the left of the content
- [ ] `TitleSection` aligns flush with editor content (same left edge)
- [ ] ChatInput unaffected