### PR TITLE
✨ feat(heterogeneous-agents): default Codex exec to bypass approvals/sandbox

### DIFF
--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -440,8 +440,14 @@ describe('HeterogeneousAgentCtr', () => {
       expect(command).toBe('codex');
       expect(cliArgs).not.toContain(prompt);
       expect(cliArgs).toEqual(
-        expect.arrayContaining(['exec', '--json', '--skip-git-repo-check', '--full-auto']),
+        expect.arrayContaining([
+          'exec',
+          '--json',
+          '--skip-git-repo-check',
+          '--dangerously-bypass-approvals-and-sandbox',
+        ]),
       );
+      expect(cliArgs).not.toContain('--full-auto');
       expect(cliArgs).not.toContain('-');
       expect(writes).toEqual([prompt]);
     });

--- a/apps/desktop/src/main/modules/heterogeneousAgent/drivers/codex.ts
+++ b/apps/desktop/src/main/modules/heterogeneousAgent/drivers/codex.ts
@@ -1,12 +1,10 @@
-import type { HeterogeneousAgentBuildPlanParams, HeterogeneousAgentDriver } from '../types';
+import {
+  CODEX_DEFAULT_EXECUTION_ARGS,
+  CODEX_EXECUTION_MODE_FLAGS,
+  CODEX_REQUIRED_ARGS,
+} from '@lobechat/heterogeneous-agents/spawn';
 
-const CODEX_REQUIRED_ARGS = ['--json', '--skip-git-repo-check'] as const;
-const CODEX_AUTO_EXECUTION_FLAGS = [
-  '--full-auto',
-  '--dangerously-bypass-approvals-and-sandbox',
-  '--sandbox',
-  '-s',
-] as const;
+import type { HeterogeneousAgentBuildPlanParams, HeterogeneousAgentDriver } from '../types';
 
 const hasAnyFlag = (args: string[], flags: readonly string[]) =>
   args.some((arg) => flags.includes(arg as (typeof flags)[number]));
@@ -18,9 +16,11 @@ const buildCodexOptionArgs = async ({
 }: Pick<HeterogeneousAgentBuildPlanParams, 'args' | 'helpers' | 'imageList'>) => {
   const imagePaths = await helpers.resolveCliImagePaths(imageList);
   const imageArgs = imagePaths.flatMap((filePath) => ['--image', filePath]);
-  const autoExecutionArgs = hasAnyFlag(args, CODEX_AUTO_EXECUTION_FLAGS) ? [] : ['--full-auto'];
+  const executionModeArgs = hasAnyFlag(args, CODEX_EXECUTION_MODE_FLAGS)
+    ? []
+    : [...CODEX_DEFAULT_EXECUTION_ARGS];
 
-  return [...CODEX_REQUIRED_ARGS, ...autoExecutionArgs, ...args, ...imageArgs];
+  return [...CODEX_REQUIRED_ARGS, ...executionModeArgs, ...args, ...imageArgs];
 };
 
 export const codexDriver: HeterogeneousAgentDriver = {

--- a/packages/heterogeneous-agents/src/adapters/codex.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/codex.test.ts
@@ -176,6 +176,94 @@ describe('CodexAdapter', () => {
     });
   });
 
+  it('keeps consecutive agent_message items in the same Codex step', () => {
+    const adapter = new CodexAdapter();
+
+    adapter.adapt({ type: 'turn.started' });
+    adapter.adapt({
+      item: {
+        id: 'item_0',
+        text: 'First status update.',
+        type: 'agent_message',
+      },
+      type: 'item.completed',
+    });
+
+    const secondMessage = adapter.adapt({
+      item: {
+        id: 'item_1',
+        text: 'Second status update.',
+        type: 'agent_message',
+      },
+      type: 'item.completed',
+    });
+
+    expect(secondMessage).toHaveLength(1);
+    expect(secondMessage[0]).toMatchObject({
+      data: { chunkType: 'text', content: '\n\nSecond status update.' },
+      stepIndex: 0,
+      type: 'stream_chunk',
+    });
+  });
+
+  it('does not start a new step for an old pending tool completion', () => {
+    const adapter = new CodexAdapter();
+
+    adapter.adapt({ type: 'turn.started' });
+    adapter.adapt({
+      item: {
+        id: 'item_0',
+        text: 'Starting a long search.',
+        type: 'agent_message',
+      },
+      type: 'item.completed',
+    });
+    adapter.adapt({
+      item: {
+        command: '/bin/zsh -lc find .',
+        id: 'item_1',
+        status: 'in_progress',
+        type: 'command_execution',
+      },
+      type: 'item.started',
+    });
+    adapter.adapt({
+      item: {
+        id: 'item_2',
+        text: 'Continuing with narrower checks.',
+        type: 'agent_message',
+      },
+      type: 'item.completed',
+    });
+    adapter.adapt({
+      item: {
+        aggregated_output: '',
+        command: '/bin/zsh -lc find .',
+        exit_code: 0,
+        id: 'item_1',
+        status: 'completed',
+        type: 'command_execution',
+      },
+      type: 'item.completed',
+    });
+
+    const nextMessage = adapter.adapt({
+      item: {
+        id: 'item_3',
+        text: 'The broad search is done; continuing.',
+        type: 'agent_message',
+      },
+      type: 'item.completed',
+    });
+
+    expect(nextMessage).toHaveLength(1);
+    expect(nextMessage[0]).toMatchObject({
+      data: { chunkType: 'text', content: '\n\nThe broad search is done; continuing.' },
+      stepIndex: 1,
+      type: 'stream_chunk',
+    });
+  });
+
   it('maps command execution items into tool lifecycle events', () => {
     const adapter = new CodexAdapter();
 
@@ -469,7 +557,7 @@ describe('CodexAdapter', () => {
     });
   });
 
-  it('keeps a real collab_tool_call stream fixture readable and flushes unfinished attempts', async () => {
+  it('keeps a real collab_tool_call stream fixture readable and drains unfinished attempts', async () => {
     const adapter = new CodexAdapter();
     const rawEvents = await loadFixture('collab_tool_call.spawn_wait.jsonl');
 
@@ -496,7 +584,58 @@ describe('CodexAdapter', () => {
         }),
       ]),
     );
-    expect(flushed).toEqual([
+    expect(adapted).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: {
+            isSuccess: false,
+            toolCallId: 'item_1',
+          },
+          type: 'tool_end',
+        }),
+      ]),
+    );
+    expect(flushed).toEqual([]);
+  });
+
+  it('emits stream_end + agent_runtime_end on successful turn completion', () => {
+    const adapter = new CodexAdapter();
+
+    adapter.adapt({ type: 'turn.started' });
+    const events = adapter.adapt({
+      type: 'turn.completed',
+      usage: {
+        input_tokens: 10,
+        output_tokens: 3,
+      },
+    });
+
+    expect(events.map((event) => event.type)).toEqual([
+      'step_complete',
+      'stream_end',
+      'agent_runtime_end',
+    ]);
+  });
+
+  it('drains unfinished Codex tools before successful turn completion', () => {
+    const adapter = new CodexAdapter();
+
+    adapter.adapt({ type: 'turn.started' });
+    adapter.adapt({
+      item: {
+        command: '/bin/zsh -lc sleep',
+        id: 'item_1',
+        status: 'in_progress',
+        type: 'command_execution',
+      },
+      type: 'item.started',
+    });
+
+    const events = adapter.adapt({
+      type: 'turn.completed',
+    });
+
+    expect(events).toEqual([
       expect.objectContaining({
         data: {
           isSuccess: false,
@@ -504,7 +643,14 @@ describe('CodexAdapter', () => {
         },
         type: 'tool_end',
       }),
+      expect.objectContaining({
+        type: 'stream_end',
+      }),
+      expect.objectContaining({
+        type: 'agent_runtime_end',
+      }),
     ]);
+    expect(adapter.flush()).toEqual([]);
   });
 
   it('emits cumulative tools_calling within the same Codex step', () => {

--- a/packages/heterogeneous-agents/src/adapters/codex.ts
+++ b/packages/heterogeneous-agents/src/adapters/codex.ts
@@ -386,12 +386,15 @@ export class CodexAdapter implements AgentEventAdapter {
   private currentModel?: string;
   sessionId?: string;
 
-  private hasStepActivity = false;
+  private hasTextInCurrentStep = false;
+  private hasToolActivitySinceAgentMessage = false;
   private pendingToolCalls = new Set<string>();
+  private pendingToolCallStepIndex = new Map<string, number>();
   private stepToolCalls: ToolCallPayload[] = [];
   private stepToolCallIds = new Set<string>();
   private started = false;
   private stepIndex = 0;
+  private terminalEndEmitted = false;
   private terminalErrorEmitted = false;
 
   adapt(raw: any): HeterogeneousAgentEvent[] {
@@ -429,36 +432,38 @@ export class CodexAdapter implements AgentEventAdapter {
   }
 
   flush(): HeterogeneousAgentEvent[] {
-    const events = [...this.pendingToolCalls].map((toolCallId) =>
-      this.makeEvent('tool_end', {
-        isSuccess: false,
-        toolCallId,
-      }),
-    );
-
-    this.pendingToolCalls.clear();
-    return events;
+    return this.drainPendingToolEndEvents();
   }
 
   private handleTurnCompleted(raw: any): HeterogeneousAgentEvent[] {
+    if (this.terminalEndEmitted || this.terminalErrorEmitted) return [];
+
+    this.terminalEndEmitted = true;
     const model = getEventModel(raw) || this.currentModel;
     if (model) this.currentModel = model;
 
     const usage = toUsageData(raw.usage);
-    if (!usage && !model) return [];
+    const events = this.drainPendingToolEndEvents();
 
-    const data: StepCompleteData = {
-      ...(model ? { model } : {}),
-      phase: 'turn_metadata',
-      provider: CODEX_IDENTIFIER,
-      ...(usage ? { usage } : {}),
-    };
+    if (usage || model) {
+      const data: StepCompleteData = {
+        ...(model ? { model } : {}),
+        phase: 'turn_metadata',
+        provider: CODEX_IDENTIFIER,
+        ...(usage ? { usage } : {}),
+      };
 
-    return [this.makeEvent('step_complete', data)];
+      events.push(this.makeEvent('step_complete', data));
+    }
+
+    if (this.started) events.push(this.makeEvent('stream_end', {}));
+    events.push(this.makeEvent('agent_runtime_end', {}));
+
+    return events;
   }
 
   private handleTerminalError(raw: any): HeterogeneousAgentEvent[] {
-    if (this.terminalErrorEmitted) return [];
+    if (this.terminalErrorEmitted || this.terminalEndEmitted) return [];
 
     this.terminalErrorEmitted = true;
     const data: HeterogeneousTerminalErrorData = {
@@ -485,7 +490,8 @@ export class CodexAdapter implements AgentEventAdapter {
 
   private handleTurnStarted(): HeterogeneousAgentEvent[] {
     this.currentAgentMessageItemId = undefined;
-    this.hasStepActivity = false;
+    this.hasTextInCurrentStep = false;
+    this.hasToolActivitySinceAgentMessage = false;
     this.resetStepToolCalls();
 
     if (!this.started) {
@@ -503,10 +509,11 @@ export class CodexAdapter implements AgentEventAdapter {
   private handleItemStarted(item: any): HeterogeneousAgentEvent[] {
     if (!item?.id || !item?.type || item.type === 'agent_message') return [];
 
-    this.hasStepActivity = true;
+    this.hasToolActivitySinceAgentMessage = true;
 
     const tool = toToolPayload(item);
     this.pendingToolCalls.add(tool.id);
+    this.pendingToolCallStepIndex.set(tool.id, this.stepIndex);
 
     return this.emitToolChunk(tool);
   }
@@ -519,21 +526,30 @@ export class CodexAdapter implements AgentEventAdapter {
 
       const events: HeterogeneousAgentEvent[] = [];
       const shouldStartNewStep =
-        this.hasStepActivity && !!item.id && item.id !== this.currentAgentMessageItemId;
+        this.hasToolActivitySinceAgentMessage &&
+        !!item.id &&
+        item.id !== this.currentAgentMessageItemId;
 
       if (shouldStartNewStep) {
         this.stepIndex += 1;
         this.resetStepToolCalls();
+        this.hasTextInCurrentStep = false;
         events.push(this.makeEvent('stream_end', {}));
         events.push(this.makeEvent('stream_start', { newStep: true, provider: CODEX_IDENTIFIER }));
       }
 
+      const content =
+        this.hasTextInCurrentStep && item.id !== this.currentAgentMessageItemId
+          ? `\n\n${item.text}`
+          : item.text;
+
       this.currentAgentMessageItemId = item.id;
-      this.hasStepActivity = true;
+      this.hasTextInCurrentStep = true;
+      this.hasToolActivitySinceAgentMessage = false;
       events.push(
         this.makeEvent('stream_chunk', {
           chunkType: 'text',
-          content: item.text,
+          content,
         }),
       );
 
@@ -543,14 +559,19 @@ export class CodexAdapter implements AgentEventAdapter {
     if (!item.id) return [];
 
     const events: HeterogeneousAgentEvent[] = [];
+    const pendingStepIndex = this.pendingToolCallStepIndex.get(item.id);
+    const belongsToCurrentStep =
+      pendingStepIndex === undefined || pendingStepIndex === this.stepIndex;
 
     if (!this.pendingToolCalls.has(item.id)) {
       const tool = toToolPayload(item);
+      this.pendingToolCallStepIndex.set(tool.id, this.stepIndex);
       events.push(...this.emitToolChunk(tool));
     }
 
     this.pendingToolCalls.delete(item.id);
-    this.hasStepActivity = true;
+    this.pendingToolCallStepIndex.delete(item.id);
+    if (belongsToCurrentStep) this.hasToolActivitySinceAgentMessage = true;
     events.push(this.makeEvent('tool_result', getToolResultData(item as CodexToolItem)));
     events.push(
       this.makeEvent('tool_end', {
@@ -559,6 +580,19 @@ export class CodexAdapter implements AgentEventAdapter {
       }),
     );
 
+    return events;
+  }
+
+  private drainPendingToolEndEvents(): HeterogeneousAgentEvent[] {
+    const events = [...this.pendingToolCalls].map((toolCallId) =>
+      this.makeEvent('tool_end', {
+        isSuccess: false,
+        toolCallId,
+      }),
+    );
+
+    this.pendingToolCalls.clear();
+    this.pendingToolCallStepIndex.clear();
     return events;
   }
 

--- a/packages/heterogeneous-agents/src/spawn/index.ts
+++ b/packages/heterogeneous-agents/src/spawn/index.ts
@@ -32,6 +32,10 @@ export {
 export { JsonlStreamProcessor } from './jsonlProcessor';
 export {
   CLAUDE_CODE_BASE_ARGS,
+  CODEX_BYPASS_APPROVALS_AND_SANDBOX_ARG,
+  CODEX_DEFAULT_EXECUTION_ARGS,
+  CODEX_EXECUTION_MODE_FLAGS,
+  CODEX_REQUIRED_ARGS,
   spawnAgent,
   type SpawnAgentHandle,
   type SpawnAgentOptions,

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
@@ -179,7 +179,7 @@ describe('spawnAgent', () => {
     expect(args[resumeIdx + 1]).toBe('cc-prev-123');
   });
 
-  it('builds codex args with `exec` + json + skip-git-repo-check + full-auto', async () => {
+  it('builds codex args with `exec` + json + skip-git-repo-check + bypass approvals/sandbox', async () => {
     nextFakeProc = createFakeProc().proc;
     const { spawnAgent } = await import('./spawnAgent');
     await spawnAgent({ agentType: 'codex', operationId: 'op-1', prompt: 'hello' });
@@ -189,7 +189,23 @@ describe('spawnAgent', () => {
     expect(args[0]).toBe('exec');
     expect(args).toContain('--json');
     expect(args).toContain('--skip-git-repo-check');
+    expect(args).toContain('--dangerously-bypass-approvals-and-sandbox');
+    expect(args).not.toContain('--full-auto');
+  });
+
+  it('does not add the default codex execution mode when extraArgs already choose one', async () => {
+    nextFakeProc = createFakeProc().proc;
+    const { spawnAgent } = await import('./spawnAgent');
+    await spawnAgent({
+      agentType: 'codex',
+      extraArgs: ['--full-auto'],
+      operationId: 'op-1',
+      prompt: 'hello',
+    });
+
+    const { args } = spawnCalls[0];
     expect(args).toContain('--full-auto');
+    expect(args).not.toContain('--dangerously-bypass-approvals-and-sandbox');
   });
 
   it('spawns the Windows executable resolved by the shared CLI spawn plan', async () => {

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
@@ -129,7 +129,18 @@ const CLAUDE_CODE_PERMISSION_ARGS = (): string[] =>
       ]
     : ['--permission-mode', 'bypassPermissions'];
 
-const CODEX_REQUIRED_ARGS = ['--json', '--skip-git-repo-check', '--full-auto'] as const;
+export const CODEX_REQUIRED_ARGS = ['--json', '--skip-git-repo-check'] as const;
+export const CODEX_BYPASS_APPROVALS_AND_SANDBOX_ARG = '--dangerously-bypass-approvals-and-sandbox';
+export const CODEX_DEFAULT_EXECUTION_ARGS = [CODEX_BYPASS_APPROVALS_AND_SANDBOX_ARG] as const;
+export const CODEX_EXECUTION_MODE_FLAGS = [
+  '--full-auto',
+  CODEX_BYPASS_APPROVALS_AND_SANDBOX_ARG,
+  '--sandbox',
+  '-s',
+] as const;
+
+const hasAnyFlag = (args: string[], flags: readonly string[]) =>
+  args.some((arg) => flags.includes(arg as (typeof flags)[number]));
 
 interface BuildSpawnArgsParams {
   agentType: string;
@@ -157,10 +168,16 @@ const buildClaudeCodeArgs = ({
   ...extraArgs,
 ];
 
-const buildCodexArgs = ({ extraArgs, inputArgs, resumeSessionId }: BuildSpawnArgsParams) =>
-  resumeSessionId
-    ? ['exec', 'resume', ...CODEX_REQUIRED_ARGS, ...inputArgs, ...extraArgs, resumeSessionId, '-']
-    : ['exec', ...CODEX_REQUIRED_ARGS, ...inputArgs, ...extraArgs];
+const buildCodexArgs = ({ extraArgs, inputArgs, resumeSessionId }: BuildSpawnArgsParams) => {
+  const executionModeArgs = hasAnyFlag(extraArgs, CODEX_EXECUTION_MODE_FLAGS)
+    ? []
+    : [...CODEX_DEFAULT_EXECUTION_ARGS];
+  const optionArgs = [...CODEX_REQUIRED_ARGS, ...executionModeArgs, ...inputArgs, ...extraArgs];
+
+  return resumeSessionId
+    ? ['exec', 'resume', ...optionArgs, resumeSessionId, '-']
+    : ['exec', ...optionArgs];
+};
 
 const buildSpawnArgs = (params: BuildSpawnArgsParams): string[] => {
   switch (params.agentType) {

--- a/packages/local-file-shell/src/fileSearch/__tests__/unix.test.ts
+++ b/packages/local-file-shell/src/fileSearch/__tests__/unix.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { ToolDetector } from '../../toolDetector';
 import { LinuxSearchServiceImpl } from '../impl/linux';
 
 vi.mock('node:os', () => ({
@@ -65,5 +66,23 @@ describe('UnixFileSearch glob fallback root', () => {
 
     const [, options] = fgMock.mock.calls[0] as [string, { cwd: string }];
     expect(options.cwd).toBe('/Users/test-home/Downloads');
+  });
+
+  it('uses fast-glob instead of find for globstar-compatible matching', async () => {
+    const toolDetector: ToolDetector = {
+      getBestTool: vi.fn().mockResolvedValue('find'),
+    };
+    const impl = new LinuxSearchServiceImpl(toolDetector);
+
+    await impl.glob({ pattern: '**/*skill*', scope: '/repo/packages' });
+
+    expect(fgMock).toHaveBeenCalledTimes(1);
+    expect(execaMock).not.toHaveBeenCalledWith('find', expect.anything(), expect.anything());
+
+    const [pattern, options] = fgMock.mock.calls[0] as [string, { cwd: string; ignore: string[] }];
+    expect(pattern).toBe('**/*skill*');
+    expect(options.cwd).toBe('/repo/packages');
+    expect(options.ignore).toContain('**/node_modules/**');
+    expect(options.ignore).toContain('**/.git/**');
   });
 });

--- a/packages/local-file-shell/src/fileSearch/impl/unix.ts
+++ b/packages/local-file-shell/src/fileSearch/impl/unix.ts
@@ -244,13 +244,14 @@ export abstract class UnixFileSearch extends BaseFileSearch {
 
   /**
    * Perform glob pattern matching
-   * Uses fd > find > fast-glob fallback strategy
+   * Uses fd when available; falls back to fast-glob to preserve globstar semantics.
    */
   async glob(params: GlobFilesParams): Promise<GlobFilesResult> {
     const tool = await this.determineBestUnixTool();
-    logger.info(`Using glob tool: ${tool}`);
+    const globTool = tool === 'find' ? 'fast-glob' : tool;
+    logger.info(`Using glob tool: ${globTool}`);
 
-    return this.globWithUnixTool(tool, params);
+    return this.globWithUnixTool(globTool, params);
   }
 
   protected async globWithUnixTool(
@@ -262,7 +263,7 @@ export abstract class UnixFileSearch extends BaseFileSearch {
         return this.globWithFd(params);
       }
       case 'find': {
-        return this.globWithFind(params);
+        return this.globWithFastGlob(params);
       }
       default: {
         return this.globWithFastGlob(params);
@@ -296,8 +297,8 @@ export abstract class UnixFileSearch extends BaseFileSearch {
       });
 
       if (exitCode !== 0 && !stdout.trim()) {
-        logger.warn(`${logPrefix} fd glob failed with code ${exitCode}, falling back to find`);
-        return this.globWithFind(params);
+        logger.warn(`${logPrefix} fd glob failed with code ${exitCode}, falling back to fast-glob`);
+        return this.globWithFastGlob(params);
       }
 
       const files = stdout
@@ -318,8 +319,8 @@ export abstract class UnixFileSearch extends BaseFileSearch {
       };
     } catch (error) {
       logger.error(`${logPrefix} fd glob failed:`, error);
-      logger.warn(`${logPrefix} Falling back to find`);
-      return this.globWithFind(params);
+      logger.warn(`${logPrefix} Falling back to fast-glob`);
+      return this.globWithFastGlob(params);
     }
   }
 

--- a/packages/shared-tool-ui/src/Inspector/RunCommand/index.tsx
+++ b/packages/shared-tool-ui/src/Inspector/RunCommand/index.tsx
@@ -8,6 +8,7 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { inspectorTextStyles, shinyTextStyles } from '../../styles';
+import { getRunCommandDisplayCommand } from '../../utils/runCommand';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   chip: css`
@@ -64,7 +65,8 @@ export const RunCommandInspector = memo<RunCommandInspectorProps>(
   ({ args, partialArgs, isArgumentsStreaming, pluginState, isLoading, translationKey }) => {
     const { t } = useTranslation('plugin');
 
-    const description = args?.description || partialArgs?.description || args?.command || '';
+    const command = getRunCommandDisplayCommand(args?.command || partialArgs?.command);
+    const description = args?.description || partialArgs?.description || command;
 
     if (isArgumentsStreaming) {
       if (!description)

--- a/packages/shared-tool-ui/src/Render/RunCommand/index.tsx
+++ b/packages/shared-tool-ui/src/Render/RunCommand/index.tsx
@@ -6,6 +6,7 @@ import { Block, Flexbox, Highlighter } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
 
+import { getRunCommandDisplayCommand } from '../../utils/runCommand';
 import AnsiOutput from './AnsiOutput';
 
 const styles = createStaticStyles(({ css }) => ({
@@ -25,6 +26,7 @@ interface RunCommandArgs {
 const RunCommand = memo<BuiltinRenderProps<RunCommandArgs, RunCommandState>>(
   ({ args, content, pluginState }) => {
     const output = pluginState?.output || pluginState?.stdout || content;
+    const command = getRunCommandDisplayCommand(args?.command);
 
     return (
       <Flexbox className={styles.container} gap={8}>
@@ -36,7 +38,7 @@ const RunCommand = memo<BuiltinRenderProps<RunCommandArgs, RunCommandState>>(
             style={{ maxHeight: 200, overflow: 'auto', paddingInline: 8 }}
             variant={'borderless'}
           >
-            {args?.command || ''}
+            {command}
           </Highlighter>
           {output && <AnsiOutput text={output} />}
           {pluginState?.stderr && <AnsiOutput text={pluginState.stderr} />}

--- a/packages/shared-tool-ui/src/utils/runCommand.test.ts
+++ b/packages/shared-tool-ui/src/utils/runCommand.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { getRunCommandDisplayCommand } from './runCommand';
+
+describe('getRunCommandDisplayCommand', () => {
+  it('keeps plain commands unchanged', () => {
+    expect(getRunCommandDisplayCommand('git status --short')).toBe('git status --short');
+  });
+
+  it('unwraps zsh login shell commands', () => {
+    expect(getRunCommandDisplayCommand("/bin/zsh -lc 'git diff --stat'")).toBe('git diff --stat');
+  });
+
+  it('unwraps double-quoted bash commands', () => {
+    expect(getRunCommandDisplayCommand('/bin/bash -lc "git commit -m \\"fix\\""')).toBe(
+      'git commit -m "fix"',
+    );
+  });
+
+  it('unwraps env shell commands', () => {
+    expect(getRunCommandDisplayCommand("/usr/bin/env zsh -lc 'bun run type-check'")).toBe(
+      'bun run type-check',
+    );
+  });
+
+  it('supports sh -c wrappers', () => {
+    expect(getRunCommandDisplayCommand("sh -c 'printf ok'")).toBe('printf ok');
+  });
+});

--- a/packages/shared-tool-ui/src/utils/runCommand.ts
+++ b/packages/shared-tool-ui/src/utils/runCommand.ts
@@ -1,0 +1,29 @@
+const SHELL_WRAPPER_PATTERN =
+  /^(?:\/usr\/bin\/env\s+)?(?:\/\S+\/)?(?:bash|sh|zsh)\s+(?:-lc|-c|-l\s+-c)\s+(\S[\s\S]*)$/;
+
+const stripOuterShellQuotes = (value: string) => {
+  const trimmed = value.trim();
+  if (trimmed.length < 2) return trimmed;
+
+  const quote = trimmed[0];
+  if ((quote !== '"' && quote !== "'") || trimmed.at(-1) !== quote) return trimmed;
+
+  const body = trimmed.slice(1, -1);
+  if (quote === "'") return body.replaceAll("'\\''", "'");
+
+  return body
+    .replaceAll('\\"', '"')
+    .replaceAll('\\`', '`')
+    .replaceAll('\\$', '$')
+    .replaceAll('\\\\', '\\');
+};
+
+export const getRunCommandDisplayCommand = (command?: string) => {
+  const trimmed = command?.trim() || '';
+  if (!trimmed) return '';
+
+  const match = trimmed.match(SHELL_WRAPPER_PATTERN);
+  if (!match) return trimmed;
+
+  return stripOuterShellQuotes(match[1]) || trimmed;
+};

--- a/packages/shared-tool-ui/vitest.config.mts
+++ b/packages/shared-tool-ui/vitest.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/src/features/DevPanel/RenderGallery/fixtures/codex.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/codex.ts
@@ -24,7 +24,7 @@ export default defineFixtures({
   ],
   fixtures: {
     command_execution: single({
-      args: { command: 'bun run type-check' },
+      args: { command: "/bin/zsh -lc 'bun run type-check'" },
       content: 'Checked 1247 files in 2.3s\nNo type errors found.',
       pluginState: {
         exitCode: 0,


### PR DESCRIPTION
## 💡 Background

The Codex `exec` heterogeneous-agent driver previously defaulted to `--full-auto`, which still keeps the approval/sandbox prompts in some flows. For the desktop heterogeneous-agent runtime we want Codex to run fully non-interactively.

## 🔨 Changes

- **Default execution mode** — switch Codex `exec` default from `--full-auto` to `--dangerously-bypass-approvals-and-sandbox`. An explicit execution-mode flag in `extraArgs` (`--full-auto`, `--sandbox`, `-s`, or the bypass flag itself) still takes precedence.
- **Shared constants** — export `CODEX_REQUIRED_ARGS`, `CODEX_DEFAULT_EXECUTION_ARGS`, `CODEX_EXECUTION_MODE_FLAGS`, and `CODEX_BYPASS_APPROVALS_AND_SANDBOX_ARG` from `@lobechat/heterogeneous-agents/spawn` so the desktop driver and `spawnAgent` stay in sync instead of each hard-coding the flag list.
- **Codex adapter step tracking fixes**:
  - Consecutive `agent_message` items stay in the same step (separated by `\n\n`) instead of each starting a new step.
  - A stale/old pending tool completion no longer forces a new step.
  - `turn.completed` drains unfinished tool calls and emits `step_complete` → `stream_end` → `agent_runtime_end`, guarded so terminal end/error fire only once.

## 🧪 Tests

- `packages/heterogeneous-agents`: codex adapter + spawnAgent (35 passed)
- `apps/desktop`: HeterogeneousAgentCtr (35 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)