### PR TITLE
♻️ chore: replace LOBE-XXX markers with inline migration context

### DIFF
--- a/packages/database/migrations/0110_add_verify_tables_and_ai_infra_id.sql
+++ b/packages/database/migrations/0110_add_verify_tables_and_ai_infra_id.sql
@@ -167,9 +167,11 @@ CREATE INDEX IF NOT EXISTS "verify_rubrics_user_id_idx" ON "verify_rubrics" USIN
 --> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "verify_rubrics_workspace_id_idx" ON "verify_rubrics" USING btree ("workspace_id");
 --> statement-breakpoint
--- LOBE-10072: nullable surrogate `_id` for the online workspace-scoped rebuild
--- (LOBE-10056). Two-step (ADD nullable, then SET DEFAULT) so it stays catalog-only
--- — a combined volatile-DEFAULT ADD COLUMN would rewrite the whole table under lock.
+-- Phase 5 ai_infra workspace-scoped migration: add nullable surrogate `_id` columns
+-- for ai_providers and ai_models. Two-step approach (ADD nullable first, then SET DEFAULT)
+-- keeps the operation catalog-only. A combined ADD COLUMN ... DEFAULT gen_random_uuid()
+-- NOT NULL would trigger a full table rewrite under ACCESS EXCLUSIVE lock (ai_models has
+-- ~4M rows), which would block all chat reads that depend on model resolution.
 ALTER TABLE "ai_providers" ADD COLUMN IF NOT EXISTS "_id" uuid;
 --> statement-breakpoint
 ALTER TABLE "ai_providers" ALTER COLUMN "_id" SET DEFAULT gen_random_uuid();


### PR DESCRIPTION
## Summary

Daily scan found 2 remaining `LOBE-XXX` markers in `packages/database/migrations/0110_add_verify_tables_and_ai_infra_id.sql`. Replaced them with descriptive inline context derived from the Linear issue.

## Changes

| File | Change |
|------|--------|
| `packages/database/migrations/0110_add_verify_tables_and_ai_infra_id.sql` | Replaced `LOBE-10072` and `LOBE-10056` markers with Phase 5 ai_infra migration rationale (two-step nullable `_id` approach to avoid full table rewrite on `ai_models` ~4M rows) |

## Verification

- [x] No remaining `LOBE-\d+` markers in `.sql`, `.ts`, `.tsx`, `.js`, `.jsx` files
- [x] Comment semantics preserved and enriched with Linear context