### PR TITLE
🐛 fix(agent): make working-directory Clear actually clear legacy / default-sourced cwd

### DIFF
--- a/packages/builtin-tool-claude-code/src/client/Inspector/Agent.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/Agent.tsx
@@ -178,7 +178,11 @@ export const AgentInspector = memo<BuiltinInspectorProps<AgentArgs>>(
             )}
             {metrics.totalTokens > 0 && (
               <span>
-                <AnimatedNumber formatter={formatTokens} value={metrics.totalTokens} />
+                <AnimatedNumber
+                  duration={2000}
+                  formatter={formatTokens}
+                  value={metrics.totalTokens}
+                />
               </span>
             )}
           </span>

--- a/src/features/ChatInput/RuntimeConfig/WorkingDirectoryPicker.tsx
+++ b/src/features/ChatInput/RuntimeConfig/WorkingDirectoryPicker.tsx
@@ -266,6 +266,18 @@ const WorkingDirectoryPicker = memo<WorkingDirectoryPickerProps>(({ agentId }) =
     topicWorkingDirectory,
   });
 
+  // Clear only makes sense when an agent-level override exists. The device-wide
+  // `deviceDefaultCwd` isn't clearable from here (it's a device setting), so
+  // gating on it would render a dead button when the cwd comes from the default.
+  const agentChoice = targetDeviceId
+    ? agencyConfig?.workingDirByDevice?.[targetDeviceId]
+    : undefined;
+  const hasClearableSelection = !!(
+    topicWorkingDirectory ||
+    agentChoice ||
+    legacyAgentWorkingDirectory
+  );
+
   const { clear, commit } = useCommitWorkingDirectory(agentId);
   const removeDeviceWorkingDir = useDeviceStore((s) => s.removeDeviceWorkingDir);
 
@@ -283,7 +295,7 @@ const WorkingDirectoryPicker = memo<WorkingDirectoryPickerProps>(({ agentId }) =
     <Flexbox gap={4} style={{ minWidth: 280 }}>
       <Flexbox horizontal align={'center'} distribution={'space-between'}>
         <div className={styles.sectionTitle}>{t('workingDirectory.recent')}</div>
-        {selectedDir && (
+        {hasClearableSelection && (
           <div className={styles.clearText} onClick={() => void clear().then(() => setOpen(false))}>
             {t('workingDirectory.clear')}
           </div>

--- a/src/features/ChatInput/RuntimeConfig/useCommitWorkingDirectory.ts
+++ b/src/features/ChatInput/RuntimeConfig/useCommitWorkingDirectory.ts
@@ -27,6 +27,10 @@ export const useCommitWorkingDirectory = (agentId: string) => {
 
   const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));
   const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
+  const updateAgentRuntimeEnvConfigById = useAgentStore((s) => s.updateAgentRuntimeEnvConfigById);
+  const legacyAgentWorkingDirectory = useAgentStore(
+    (s) => s.localAgentWorkingDirectoryMap[agentId],
+  );
 
   const activeTopicId = useChatStore((s) => s.activeTopicId);
   const activeTopic = useChatStore((s) =>
@@ -44,14 +48,23 @@ export const useCommitWorkingDirectory = (agentId: string) => {
       // agent's per-device choice so a new topic inherits it.
       if (activeTopicId) {
         await updateTopicMetadata(activeTopicId, { workingDirectory: newPath });
-      } else if (targetDeviceId) {
-        const prev = agencyConfig?.workingDirByDevice ?? {};
-        const nextMap = { ...prev };
-        if (newPath) nextMap[targetDeviceId] = newPath;
-        else delete nextMap[targetDeviceId];
-        await updateAgentConfigById(agentId, {
-          agencyConfig: { ...agencyConfig, workingDirByDevice: nextMap },
-        });
+      } else {
+        if (targetDeviceId) {
+          const prev = agencyConfig?.workingDirByDevice ?? {};
+          const nextMap = { ...prev };
+          if (newPath) nextMap[targetDeviceId] = newPath;
+          else delete nextMap[targetDeviceId];
+          await updateAgentConfigById(agentId, {
+            agencyConfig: { ...agencyConfig, workingDirByDevice: nextMap },
+          });
+        }
+        // Clearing the agent default must also drop the legacy per-agent value —
+        // otherwise it keeps re-supplying a stale cwd from a lower precedence
+        // level and Clear looks dead. (Only clears the localStorage map; no
+        // network round-trip since `workingDirectory` is stripped before send.)
+        if (!newPath && legacyAgentWorkingDirectory) {
+          await updateAgentRuntimeEnvConfigById(agentId, { workingDirectory: undefined });
+        }
       }
       // Record on the target device's recent list (not the device-wide default —
       // a per-agent pick shouldn't repoint other agents on the same device).
@@ -64,7 +77,9 @@ export const useCommitWorkingDirectory = (agentId: string) => {
       agencyConfig,
       activeTopicId,
       targetDeviceId,
+      legacyAgentWorkingDirectory,
       updateAgentConfigById,
+      updateAgentRuntimeEnvConfigById,
       updateTopicMetadata,
       updateDeviceCwd,
     ],


### PR DESCRIPTION
## Problem

The **Clear** button in the working-directory picker does nothing in some cases — clicking it has no visible effect.

## Root cause

`clear()` → `writeCwd(undefined)` only removes the two highest-precedence sources:

- the topic-level override (`topic.metadata.workingDirectory`)
- the agent's per-device choice (`agencyConfig.workingDirByDevice`)

But the button's visibility is gated on `selectedDir`, whose resolution **also** includes two *lower*-precedence sources:

- `legacyAgentWorkingDirectory` — a pre-migration pick still living in localStorage (the most common hit for existing desktop users)
- `deviceDefaultCwd` — the device-wide default (configured in device settings)

When the current cwd comes from either of those, `clear()` deletes an already-empty higher level → nothing changes, so the button looks broken.

## Fix

- **`useCommitWorkingDirectory`**: when clearing at the agent-default scope, also drop the legacy per-agent value (localStorage map only; `workingDirectory` is stripped before the request, so there's no network round-trip).
- **`WorkingDirectoryPicker`**: gate the Clear button on `hasClearableSelection` (topic / agent choice / legacy) instead of `selectedDir`. This way the button no longer renders as a dead control when the cwd comes solely from the device default — which isn't clearable from the agent picker (it's a device setting).

## Impact

- Type check: changed files ✅ no new errors (the pre-existing tts / onboarding / agentSignal errors are unrelated).
- These two files have no existing unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)