### PR TITLE
🐛 fix(heterogeneous-agents): show real CLI model on remote-spawned Claude Code

### DIFF
--- a/src/server/services/aiAgent/index.ts
+++ b/src/server/services/aiAgent/index.ts
@@ -807,14 +807,21 @@ export class AiAgentService {
           });
 
       // Create an assistant message placeholder (shows spinner in the UI).
-      // For remote hetero agents (openclaw/hermes), override provider with the hetero type
-      // so the frontend can identify the platform and display the correct name in the model tag.
+      // Use the hetero type as the provider so the frontend can identify the
+      // platform and render the correct name in the model tag — for ALL hetero
+      // agents, not just remote ones. The agent's configured chat model/provider
+      // (e.g. deepseek) is meaningless for a CLI run: the real model is reported
+      // by the CLI via `stream_start` / `turn_metadata` and backfilled by
+      // `HeterogeneousPersistenceHandler`. Seeding the placeholder with the agent
+      // model leaked it into the model tag (and got re-applied at terminal) on
+      // the device / sandbox path; mirror the client (`conversationLifecycle`),
+      // which sets only the provider and leaves the model empty until the CLI
+      // reports it.
       const assistantMsg = await this.messageModel.create({
         agentId: resolvedAgentId,
         content: LOADING_FLAT,
-        model,
         parentId: parentMessageId ?? userMsg?.id,
-        provider: isRemoteHetero ? heteroType : provider,
+        provider: heteroType,
         role: 'assistant',
         threadId: appContext?.threadId ?? undefined,
         topicId,

--- a/src/server/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/src/server/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -675,6 +675,8 @@ export class HeterogeneousPersistenceHandler {
       case 'stream_start': {
         if (event.data?.newStep) {
           await this.handleStepStart(state);
+        } else {
+          await this.handleStreamInit(state, event);
         }
         return;
       }
@@ -700,6 +702,33 @@ export class HeterogeneousPersistenceHandler {
   }
 
   // ─── Per-event handlers ──────────────────────────────────────────────────
+
+  /**
+   * The adapter's FIRST `stream_start` (CC's system/init, `newStep` unset)
+   * carries the CLI's authoritative model/provider (e.g. claude-sonnet-x /
+   * 'claude-code'). Capture it into step state and backfill the placeholder
+   * assistant so the model tag shows the real CLI model from the very first
+   * turn — even before (or entirely without) any usage-bearing `turn_metadata`.
+   *
+   * The placeholder is created with only `provider: heteroType` and no model
+   * (see `aiAgent.execAgent`), so without this the first turn would render an
+   * empty model until `turn_metadata` lands, and a usage-less run would never
+   * resolve a real model at all.
+   */
+  private async handleStreamInit(state: OperationState, event: AgentStreamEvent) {
+    const { model, provider } = event.data ?? {};
+    const update: Record<string, any> = {};
+    if (model) {
+      state.lastModel = model;
+      update.model = model;
+    }
+    if (provider) {
+      state.lastProvider = provider;
+      update.provider = provider;
+    }
+    if (Object.keys(update).length === 0) return;
+    await this.deps.messageModel.update(state.currentAssistantMessageId, update);
+  }
 
   private async handleTurnMetadata(state: OperationState, event: AgentStreamEvent) {
     const { model, provider, usage } = event.data ?? {};

--- a/src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.eventBranches.test.ts
+++ b/src/server/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.eventBranches.test.ts
@@ -265,18 +265,34 @@ describe('HeterogeneousPersistenceHandler — event branch coverage', () => {
   // ─── stream_start ─────────────────────────────────────────────────────────
 
   describe('stream_start', () => {
-    it('without newStep is a no-op (orchestrator already seeded the assistant id)', async () => {
+    it('without newStep (CLI init) backfills the placeholder with the CLI model/provider', async () => {
       const h = createHarness();
-      const beforeUpdates = h.messageModel.update.mock.calls.length;
       const beforeCreates = h.messageModel.create.mock.calls.length;
 
       await ingest(h, [
         buildEvent('stream_start', 0, {
-          assistantMessage: { id: 'asst-from-event' },
-          model: 'foo',
-          provider: 'bar',
+          model: 'claude-sonnet-4-5',
+          provider: 'claude-code',
         }),
       ]);
+
+      // The init event carries the CLI's authoritative model/provider — it must
+      // backfill the placeholder (which was created with only `provider`, no
+      // model) so the model tag shows the real CLI model from the first turn,
+      // even without any usage-bearing turn_metadata.
+      const asst = h.messages.get(h.assistantMessageId);
+      expect(asst?.model).toBe('claude-sonnet-4-5');
+      expect(asst?.provider).toBe('claude-code');
+      // No new assistant row is created — only the placeholder is patched.
+      expect(h.messageModel.create.mock.calls.length).toBe(beforeCreates);
+    });
+
+    it('without newStep and no model/provider is a no-op', async () => {
+      const h = createHarness();
+      const beforeUpdates = h.messageModel.update.mock.calls.length;
+      const beforeCreates = h.messageModel.create.mock.calls.length;
+
+      await ingest(h, [buildEvent('stream_start', 0, {})]);
 
       expect(h.messageModel.update.mock.calls.length).toBe(beforeUpdates);
       expect(h.messageModel.create.mock.calls.length).toBe(beforeCreates);


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Remote/device-spawned Claude Code (and Codex) runs persist through the **server-side** `HeterogeneousPersistenceHandler` because the executing device is not the viewing client — unlike local desktop runs, which use the client-side `heterogeneousAgentExecutor`.

The assistant placeholder was created with the agent's configured chat **model/provider** (e.g. `deepseek-v4-pro`). For `claude-code`/`codex` (which are not `isRemoteHeterogeneousType`) the provider stayed the agent's provider and the model stayed the agent's model. That bogus model:

1. leaked straight into the model tag in the UI (showed `deepseek-v4-pro` with the wrong provider icon), and
2. got re-seeded into `state.lastModel` on cold replicas (`if (!state.lastModel && refreshed?.model) …`) and re-applied at terminal — so it stuck.

The client path never hit this because it sets only `provider: heteroType`, leaves the model empty, and never seeds `lastModel` from the placeholder.

**Fix:**

- Create the hetero placeholder with `provider: heteroType` for **all** hetero agents (not just remote openclaw/hermes) and **no** model — mirroring the client. The real model is reported by the CLI and backfilled.
- Capture the CLI's authoritative model/provider from the first `stream_start` (CC's `system/init`, which always carries `model` + `provider: 'claude-code'`) and backfill the placeholder, so the real model lands from the first turn even on a short run with no usage-bearing `turn_metadata`.

This also aligns with the existing UI intent: `Usage`/`Extra` only render the model tag for local hetero once a real `model` is present.

#### 🧪 How to Test

- [x] Added/updated tests

Updated `HeterogeneousPersistenceHandler.eventBranches.test.ts`: the first `stream_start` (CLI init) now backfills the placeholder with the real model/provider; a no-model/provider init remains a no-op. Full handler suite (82 tests) passes; type-check has no new errors in touched files.

To verify manually: spawn a Claude Code agent on a remote device, send a short prompt (e.g. "你好") — the model tag should show the real Claude model (and CC provider), not the agent's configured chat model.

#### 📝 Additional Information

Server-only change (server service + persistence handler + test). Local client path was already correct and is intentionally left untouched.