### PR TITLE
🐛 fix(heterogeneous-agents): emit per-turn usage for batch-mode Claude Code

### DIFF
--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -41,6 +41,33 @@ import { createLogger } from '@/utils/logger';
 import { ControllerModule, IpcMethod } from './index';
 
 const logger = createLogger('controllers:HeterogeneousAgentCtr');
+
+// Anthropic auth env vars that must NOT be inherited from the desktop process
+// when spawning a local CLI agent. A developer with `ANTHROPIC_API_KEY` (or an
+// auth token / base url) exported in their shell would otherwise have it
+// forwarded to `claude`, which then switches from its own subscription login to
+// that key — an expired / wrong key surfaces as a baffling "Invalid API key"
+// and the run exits non-zero. Agents that genuinely want an API key still set
+// it through `session.env`, which is spread AFTER the inherited env below and
+// therefore wins.
+const STRIPPED_INHERITED_ENV_KEYS = [
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_BASE_URL',
+] as const;
+
+/**
+ * Inherited `process.env` with the Anthropic auth vars removed. Keep this pure
+ * and exported so the "never leak host Anthropic creds into the CLI" invariant
+ * can be unit-tested directly.
+ */
+export const buildInheritedSpawnEnv = (
+  sourceEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv => {
+  const env = { ...sourceEnv };
+  for (const key of STRIPPED_INHERITED_ENV_KEYS) delete env[key];
+  return env;
+};
 const CODEX_RESUME_THREAD_NOT_FOUND_PATTERNS = [
   /no conversation found/i,
   /thread .*not found/i,
@@ -920,7 +947,10 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     const spawnOptions = {
       cwd,
       detached: process.platform !== 'win32',
-      env: { ...process.env, ...proxyEnv, ...session.env },
+      // Strip host Anthropic creds from the inherited env so a developer's
+      // shell `ANTHROPIC_API_KEY` can't hijack the CLI's own auth. `session.env`
+      // is spread last, so an agent that explicitly configures a key still wins.
+      env: { ...buildInheritedSpawnEnv(), ...proxyEnv, ...session.env },
       stdio: [useStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'] as ['pipe' | 'ignore', 'pipe', 'pipe'],
     };
 

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -313,6 +313,53 @@ describe('HeterogeneousAgentCtr', () => {
       ]);
     });
 
+    it('does not leak host Anthropic auth env into the spawned CLI', async () => {
+      // A developer with these exported in their shell would otherwise have them
+      // forwarded to `claude`, overriding its subscription login and surfacing
+      // as a baffling "Invalid API key" / non-zero exit. Regression guard for
+      // that env-leak.
+      const original = {
+        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+        ANTHROPIC_AUTH_TOKEN: process.env.ANTHROPIC_AUTH_TOKEN,
+        ANTHROPIC_BASE_URL: process.env.ANTHROPIC_BASE_URL,
+      };
+      process.env.ANTHROPIC_API_KEY = 'sk-host-should-not-leak';
+      process.env.ANTHROPIC_AUTH_TOKEN = 'host-token-should-not-leak';
+      process.env.ANTHROPIC_BASE_URL = 'https://host.example/should-not-leak';
+
+      try {
+        const { options } = await runSendPrompt('hello');
+
+        expect(options.env).not.toHaveProperty('ANTHROPIC_API_KEY');
+        expect(options.env).not.toHaveProperty('ANTHROPIC_AUTH_TOKEN');
+        expect(options.env).not.toHaveProperty('ANTHROPIC_BASE_URL');
+        // Unrelated inherited vars must still pass through.
+        expect(options.env.PATH).toBe(process.env.PATH);
+      } finally {
+        for (const [key, value] of Object.entries(original)) {
+          if (value === undefined) delete process.env[key];
+          else process.env[key] = value;
+        }
+      }
+    });
+
+    it('lets an agent-configured Anthropic key in session.env override the stripped host env', async () => {
+      const originalKey = process.env.ANTHROPIC_API_KEY;
+      process.env.ANTHROPIC_API_KEY = 'sk-host-should-not-leak';
+
+      try {
+        const { options } = await runSendPrompt('hello', {
+          env: { ANTHROPIC_API_KEY: 'sk-agent-explicit' },
+        });
+
+        // Explicit per-agent config wins; the host value is never seen.
+        expect(options.env.ANTHROPIC_API_KEY).toBe('sk-agent-explicit');
+      } finally {
+        if (originalKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+        else process.env.ANTHROPIC_API_KEY = originalKey;
+      }
+    });
+
     it('captures the Claude Code session id from stream-json init events', async () => {
       const { ctr, sessionId } = await runSendPrompt('hello', {}, [
         `${JSON.stringify({ session_id: 'sess_cc_123', subtype: 'init', type: 'system' })}\n`,

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.e2e.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.e2e.test.ts
@@ -182,16 +182,22 @@ describe('ClaudeCodeAdapter E2E', () => {
     // 2 boundaries: msg_01 → msg_02, msg_02 → msg_03
     expect(newStepStarts.length).toBe(2);
 
-    // 5. turn_metadata is now emitted on `stream_event: message_delta`, not on
-    // `assistant` events (CC echoes a stale message_start usage on every
-    // content block). This simplified fixture has no stream_event records, so
-    // no turn_metadata fires here — a dedicated test in claudeCode.test.ts
-    // covers the message_delta flow. We still assert the result_usage summary
-    // lands at session end.
+    // 5. This fixture has no `stream_event` records — i.e. BATCH mode, like the
+    // `lh hetero exec` device / sandbox path. There is no `message_delta` to
+    // own per-turn usage, so the adapter emits turn_metadata from each
+    // `assistant` event that carries `message.usage` (authoritative in batch
+    // mode, not a stale echo). The fixture has 5 such assistant events.
+    // In partial mode this path is suppressed — see claudeCode.test.ts.
     const metaEvents = allEvents.filter(
       (e) => e.type === 'step_complete' && e.data?.phase === 'turn_metadata',
     );
-    expect(metaEvents.length).toBe(0);
+    expect(metaEvents.length).toBe(5);
+    // All carry the canonical model + provider.
+    expect(metaEvents.every((e) => e.data.model === 'claude-sonnet-4-6')).toBe(true);
+    expect(metaEvents.every((e) => e.data.provider === 'claude-code')).toBe(true);
+    // Final turn's authoritative usage (msg_03: input 1000 + output 30).
+    expect(metaEvents.at(-1)!.data.usage.totalTokens).toBe(1030);
+
     const resultUsage = allEvents.filter(
       (e) => e.type === 'step_complete' && e.data?.phase === 'result_usage',
     );

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -1291,14 +1291,20 @@ describe('ClaudeCodeAdapter', () => {
   });
 
   describe('usage and model extraction', () => {
-    // Under `--include-partial-messages`, CC emits a stale
+    // Under `--include-partial-messages` (partial mode), CC emits a stale
     // `message_start.usage` snapshot (e.g. `output_tokens: 8`) that it echoes
     // verbatim on every content-block `assistant` event. The authoritative
-    // per-turn total only arrives later as `message_delta`. So turn_metadata
-    // emission is wired to `message_delta`, not `assistant`.
-    it('does NOT emit turn_metadata on assistant events (usage there is stale)', () => {
+    // per-turn total only arrives later as `message_delta`. So in partial mode
+    // turn_metadata emission is wired to `message_delta`, not `assistant`.
+    // Seeing a `stream_event` is what tells the adapter it is in partial mode.
+    it('does NOT emit turn_metadata on assistant events in partial mode (usage there is stale)', () => {
       const adapter = new ClaudeCodeAdapter();
       adapter.adapt({ subtype: 'init', type: 'system' });
+      // A stream_event marks partial mode — message_delta will own usage.
+      adapter.adapt({
+        event: { message: { id: 'msg_1', model: 'claude-sonnet-4-6' }, type: 'message_start' },
+        type: 'stream_event',
+      });
 
       const events = adapter.adapt({
         message: {
@@ -1313,6 +1319,42 @@ describe('ClaudeCodeAdapter', () => {
       expect(
         events.find((e) => e.type === 'step_complete' && e.data?.phase === 'turn_metadata'),
       ).toBeUndefined();
+    });
+
+    // BATCH mode (no `--include-partial-messages`, e.g. the `lh hetero exec`
+    // CLI used by device + sandbox runs): no `message_delta` arrives, and the
+    // `assistant` event's usage is authoritative — not a stale echo. The
+    // adapter must emit turn_metadata here so token counts land, carrying the
+    // clean `assistant` model id (NOT the `[1m]` beta-tagged `system init` one).
+    it('emits turn_metadata on assistant events in batch mode (no stream_event)', () => {
+      const adapter = new ClaudeCodeAdapter();
+      // `system init` reports the beta-tagged id; the assistant event is clean.
+      adapter.adapt({ model: 'claude-opus-4-8[1m]', subtype: 'init', type: 'system' });
+
+      const events = adapter.adapt({
+        message: {
+          id: 'msg_1',
+          content: [{ text: 'hello', type: 'text' }],
+          model: 'claude-opus-4-8',
+          usage: { input_tokens: 100, output_tokens: 50 },
+        },
+        type: 'assistant',
+      });
+
+      const meta = events.find(
+        (e) => e.type === 'step_complete' && e.data?.phase === 'turn_metadata',
+      );
+      expect(meta).toBeDefined();
+      expect(meta!.data.model).toBe('claude-opus-4-8');
+      expect(meta!.data.provider).toBe('claude-code');
+      expect(meta!.data.usage).toEqual({
+        inputCacheMissTokens: 100,
+        inputCachedTokens: undefined,
+        inputWriteCacheTokens: undefined,
+        totalInputTokens: 100,
+        totalOutputTokens: 50,
+        totalTokens: 150,
+      });
     });
 
     it('emits turn_metadata on message_delta with authoritative usage', () => {

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -455,6 +455,14 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
   private pendingToolCalls = new Set<string>();
   private started = false;
   private stepIndex = 0;
+  /**
+   * True once any `stream_event` wrapper is seen — i.e. CC was spawned with
+   * `--include-partial-messages` (desktop driver). The `lh hetero exec` CLI
+   * used by device + sandbox runs spawns in BATCH mode (no partial flag), so
+   * this stays false and `handleAssistant` owns per-turn usage instead of
+   * `message_delta`.
+   */
+  private sawStreamEvent = false;
   /** Track current message.id to detect step boundaries */
   private currentMessageId: string | undefined;
   /** message.id of the stream_event delta flow currently in flight */
@@ -816,6 +824,29 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
       });
     }
     events.push(...this.emitToolChunk(newToolCalls, messageId));
+
+    // BATCH mode (no `--include-partial-messages`, e.g. the `lh hetero exec`
+    // CLI used by device + sandbox runs): there is no `message_delta` to carry
+    // per-turn usage, and the `assistant` event's usage is NOT a stale
+    // message_start echo — it's the real per-message total. Emit it as
+    // turn_metadata so usage (token counts) AND the canonical model id (the
+    // `assistant` event reports a clean `claude-opus-4-8`, unlike `system init`
+    // which appends a `[1m]` beta marker) land on the assistant message. In
+    // partial mode (`sawStreamEvent`) `message_delta` owns this — skip here to
+    // avoid double-counting the stale snapshot.
+    if (!this.sawStreamEvent) {
+      const usage = toUsageData(raw.message?.usage);
+      if (usage) {
+        events.push(
+          this.makeEvent('step_complete', {
+            model: raw.message?.model,
+            phase: 'turn_metadata',
+            provider: 'claude-code',
+            usage,
+          }),
+        );
+      }
+    }
 
     return events;
   }
@@ -1285,6 +1316,12 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
   private handleStreamEvent(raw: any): HeterogeneousAgentEvent[] {
     const event = raw?.event;
     if (!event) return [];
+
+    // Seeing any stream_event proves CC is running with
+    // `--include-partial-messages` — `message_delta` owns authoritative usage,
+    // so `handleAssistant` must NOT also emit it (the assistant block echoes a
+    // stale message_start usage snapshot in this mode).
+    this.sawStreamEvent = true;
 
     switch (event.type) {
       case 'message_start': {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

Follow-up to the CC remote-spawn model/provider fix. Two symptoms on remotely-spawned (device / sandbox) Claude Code runs:

1. **No token total in the model tag.**
2. **Model showed `claude-opus-4-8[1m]`** instead of the canonical `claude-opus-4-8`.

**Root cause:** device + sandbox runs spawn CC through the `lh hetero exec` CLI, which defaults to **batch mode** (`includePartialMessages: false`, no `--include-partial-messages`) — unlike the desktop driver, which always streams partial messages. In batch mode:

- CC emits no `stream_event` / `message_delta`, so the partial-mode `turn_metadata` (which carries authoritative per-turn usage) never fires.
- `handleAssistant` *deliberately* skips usage on `assistant` events, assuming the stale `message_start` echo that only exists in partial mode.
- The grand-total `result_usage` is intentionally ignored (avoids double-counting).

Net result for batch runs: **no usage persisted at all** → no token count. And the only model source was `system init`, whose `model` field carries CC's `[1m]` 1M-context beta marker (`assistant`/`message_delta` events report the clean `claude-opus-4-8`).

**Fix:** the adapter now tracks whether any `stream_event` was seen (= partial mode). When none has (batch mode), it emits per-turn usage from the `assistant` event as `turn_metadata` — the assistant usage is authoritative there, not a stale echo. This:

- persists usage → the token total renders, and
- carries the clean `claude-opus-4-8` model id, which supersedes the `[1m]` init-captured value (and matches what `ModelIcon` / pricing lookups expect).

Partial mode (desktop / local) is unchanged — `message_delta` still owns usage, and the `assistant`-event path stays skipped via the `sawStreamEvent` guard, so no double-counting.

#### 🧪 How to Test

- [x] Added/updated tests

Updated `claudeCode.test.ts`: the existing "no turn_metadata on assistant" case now primes partial mode with a `stream_event` first; a new case asserts batch mode (no `stream_event`) emits `turn_metadata` with the clean model + authoritative usage. Full adapter suite (91 tests) passes; type-check clean on touched files.

Manual: run a Claude Code agent on a remote device, send a short prompt — the model tag should show `claude-opus-4-8` with the token count, not `claude-opus-4-8[1m]` with no tokens.

#### 📝 Additional Information

Shared-package change (`@lobechat/heterogeneous-agents`); affects all batch-mode CC runs (device, sandbox, CLI). No server or UI changes needed — the existing `turn_metadata` persistence path handles it.