### PR TITLE
🐛 fix(skill): consolidate add-skill button into header dropdown

### DIFF
--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -20,7 +20,6 @@ import type React from 'react';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import AddSkillButton from '@/features/SkillStore/SkillList/AddSkillButton';
 import { useFetchInstalledPlugins } from '@/hooks/useFetchInstalledPlugins';
 import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useToolStore } from '@/store/tool';
@@ -333,7 +332,6 @@ const SkillList = memo<SkillListProps>(
       return (
         <Center className={styles.container} paddingBlock={48}>
           <Empty description={t('tab.skillDesc')} icon={SkillsIcon} title={t('tab.skillEmpty')} />
-          <AddSkillButton />
         </Center>
       );
     }
@@ -561,9 +559,6 @@ const SkillList = memo<SkillListProps>(
             renderUserAgentSkills(),
           )}
 
-        <div style={{ marginTop: 8 }}>
-          <AddSkillButton />
-        </div>
       </div>
     );
   },

--- a/src/routes/(main)/settings/skill/index.tsx
+++ b/src/routes/(main)/settings/skill/index.tsx
@@ -1,13 +1,17 @@
 'use client';
 
-import { Button, Icon } from '@lobehub/ui';
+import { Button, DropdownMenu, Flexbox, Icon, Text } from '@lobehub/ui';
+import { GithubIcon } from '@lobehub/ui/icons';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
-import { Plus, Store } from 'lucide-react';
+import { ChevronDown, FileArchive, Grid2x2Plus, Link, Store } from 'lucide-react';
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { AddConnectorModal } from '@/features/Connectors';
+import ImportFromGithubModal from '@/features/SkillStore/SkillList/ImportFromGithubModal';
+import ImportFromUrlModal from '@/features/SkillStore/SkillList/ImportFromUrlModal';
+import UploadSkillModal from '@/features/SkillStore/SkillList/UploadSkillModal';
 import NavHeader from '@/features/NavHeader';
 import { createSkillStoreModal } from '@/features/SkillStore';
 import { useToolStore } from '@/store/tool';
@@ -85,6 +89,9 @@ const Page = memo(() => {
   const [selected, setSelected] = useState<SelectedTool | null>(null);
   const [viewMode, setViewMode] = useState<SkillViewMode>('connector');
   const [showAddConnector, setShowAddConnector] = useState(false);
+  const [showUrlModal, setUrlModal] = useState(false);
+  const [showGithubModal, setGithubModal] = useState(false);
+  const [showUploadModal, setUploadModal] = useState(false);
 
   // Data sources for auto-select
   const builtinTools = useToolStore((s) => s.builtinTools, isEqual);
@@ -93,7 +100,6 @@ const Page = memo(() => {
     (s) => builtinToolSelectors.installedAllMetaList(s).map((tool) => tool.identifier),
     isEqual,
   );
-
   // Auto-select first item when view changes or on load
   useEffect(() => {
     setSelected(null);
@@ -147,18 +153,40 @@ const Page = memo(() => {
               </span>
             </div>
 
-            <div style={{ display: 'flex', gap: 6 }}>
-              {viewMode === 'connector' && (
-                <Button
-                  icon={<Icon icon={Plus} />}
-                  size="small"
-                  title={t('connector.add.title', {
-                    defaultValue: 'Add custom connector',
-                    ns: 'tool',
-                  })}
-                  onClick={() => setShowAddConnector(true)}
-                />
-              )}
+            <div style={{ display: 'flex', gap: 6 }} onClick={(e) => e.stopPropagation()}>
+              <DropdownMenu
+                nativeButton={false}
+                placement="bottomRight"
+                items={[
+                  {
+                    icon: <Icon icon={Link} />,
+                    key: 'importUrl',
+                    label: <Flexbox gap={2}><span>{t('tab.importFromUrl')}</span><Text style={{ fontSize: 12 }} type="secondary">{t('tab.importFromUrl.desc')}</Text></Flexbox>,
+                    onClick: () => setUrlModal(true),
+                  },
+                  {
+                    icon: <Icon icon={GithubIcon} />,
+                    key: 'importGithub',
+                    label: <Flexbox gap={2}><span>{t('tab.importFromGithub')}</span><Text style={{ fontSize: 12 }} type="secondary">{t('tab.importFromGithub.desc')}</Text></Flexbox>,
+                    onClick: () => setGithubModal(true),
+                  },
+                  {
+                    icon: <Icon icon={FileArchive} />,
+                    key: 'uploadZip',
+                    label: <Flexbox gap={2}><span>{t('tab.uploadZip')}</span><Text style={{ fontSize: 12 }} type="secondary">{t('tab.uploadZip.desc')}</Text></Flexbox>,
+                    onClick: () => setUploadModal(true),
+                  },
+                  { type: 'divider' as const },
+                  {
+                    icon: <Icon icon={Grid2x2Plus} />,
+                    key: 'addConnector',
+                    label: <Flexbox gap={2}><span>{t('connector.add.title', { defaultValue: 'Add Custom Connector', ns: 'tool' })}</span></Flexbox>,
+                    onClick: () => setShowAddConnector(true),
+                  },
+                ]}
+              >
+                <Button icon={Grid2x2Plus} size="small" />
+              </DropdownMenu>
               <Button icon={<Icon icon={Store} />} size="small" onClick={handleOpenStore} />
             </div>
           </div>
@@ -179,6 +207,9 @@ const Page = memo(() => {
           </div>
         )}
       </div>
+      <ImportFromUrlModal open={showUrlModal} onOpenChange={setUrlModal} />
+      <ImportFromGithubModal open={showGithubModal} onOpenChange={setGithubModal} />
+      <UploadSkillModal open={showUploadModal} onOpenChange={setUploadModal} />
       <AddConnectorModal open={showAddConnector} onClose={() => setShowAddConnector(false)} />
     </>
   );

--- a/src/routes/(main)/settings/skill/index.tsx
+++ b/src/routes/(main)/settings/skill/index.tsx
@@ -4,16 +4,16 @@ import { Button, DropdownMenu, Flexbox, Icon, Text } from '@lobehub/ui';
 import { GithubIcon } from '@lobehub/ui/icons';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
-import { ChevronDown, FileArchive, Grid2x2Plus, Link, Store } from 'lucide-react';
+import { FileArchive, Grid2x2Plus, Link, Store } from 'lucide-react';
 import { memo, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { AddConnectorModal } from '@/features/Connectors';
+import NavHeader from '@/features/NavHeader';
+import { createSkillStoreModal } from '@/features/SkillStore';
 import ImportFromGithubModal from '@/features/SkillStore/SkillList/ImportFromGithubModal';
 import ImportFromUrlModal from '@/features/SkillStore/SkillList/ImportFromUrlModal';
 import UploadSkillModal from '@/features/SkillStore/SkillList/UploadSkillModal';
-import NavHeader from '@/features/NavHeader';
-import { createSkillStoreModal } from '@/features/SkillStore';
 import { useToolStore } from '@/store/tool';
 import { builtinToolSelectors } from '@/store/tool/selectors';
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [ ] ✨ feat
- [ ] ♻️ refactor
- [ ] 💄 style

#### 🔀 Description of Change

Move the standalone `AddSkillButton` from the SkillList sidebar into the header `+` dropdown, providing a unified entry point for all add-skill actions.

**Changes:**
- Removed `AddSkillButton` from `SkillList.tsx` (was rendered in empty state and at list bottom)
- Replaced the header `+` button with a `DropdownMenu` containing all import/add actions
- Menu items: Import from URL → Import from GitHub → Upload Zip → divider → Add Custom Connector
- Replaced legacy "Add Custom MCP Skill" with the new "Add Custom Connector" flow
- Dropdown now works in both Connector and Skill view modes

#### 🔗 Related Files
- `src/routes/(main)/settings/skill/index.tsx`
- `src/routes/(main)/settings/skill/features/SkillList.tsx`

#### 🧪 How to Test

- [ ] No tests needed (UI consolidation)

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Standalone AddSkillButton at bottom of sidebar + separate header + button | Unified dropdown in header covering all add actions |