### PR TITLE
feat(cli): add binary release workflow and curl install script

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,0 +1,75 @@
+name: Release CLI
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag name for the release (e.g. v0.1.0)'
+        required: true
+        default: 'v0.0.0'
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    # skip pre-release tags (containing '-') on auto-trigger; always run on workflow_dispatch
+    if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: lobe-linux-x64
+          - os: macos-latest
+            target: lobe-macos-arm64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build binary
+        run: |
+          mkdir -p dist
+          bun build ./apps/cli/src/index.ts --compile --minify --outfile ./dist/${{ matrix.target }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: ./dist/${{ matrix.target }}
+
+  release:
+    name: Upload to Release
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./dist
+
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+          files: |
+            ./dist/lobe-linux-x64/lobe-linux-x64
+            ./dist/lobe-macos-arm64/lobe-macos-arm64
+            ./apps/cli/install.sh

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
-    # skip pre-release tags (containing '-') on auto-trigger; always run on workflow_dispatch
+    # 跳过预发布 tag（含 "-"）；workflow_dispatch 始终执行
     if: ${{ github.event_name == 'workflow_dispatch' || !contains(github.ref_name, '-') }}
     strategy:
       fail-fast: false
@@ -26,8 +26,16 @@ jobs:
         include:
           - os: ubuntu-latest
             target: lobe-linux-x64
+            bun_target: bun-linux-x64
+          - os: ubuntu-latest
+            target: lobe-linux-arm64
+            bun_target: bun-linux-arm64
+          - os: macos-latest
+            target: lobe-macos-x64
+            bun_target: bun-darwin-x64
           - os: macos-latest
             target: lobe-macos-arm64
+            bun_target: bun-darwin-arm64
 
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +52,11 @@ jobs:
       - name: Build binary
         run: |
           mkdir -p dist
-          bun build ./apps/cli/src/index.ts --compile --minify --outfile ./dist/${{ matrix.target }}
+          bun build ./apps/cli/src/index.ts \
+            --compile \
+            --minify \
+            --target ${{ matrix.bun_target }} \
+            --outfile ./dist/${{ matrix.target }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -71,5 +83,7 @@ jobs:
           tag_name: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
           files: |
             ./dist/lobe-linux-x64/lobe-linux-x64
+            ./dist/lobe-linux-arm64/lobe-linux-arm64
+            ./dist/lobe-macos-x64/lobe-macos-x64
             ./dist/lobe-macos-arm64/lobe-macos-arm64
             ./apps/cli/install.sh

--- a/apps/cli/install.sh
+++ b/apps/cli/install.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+set -e
+
+REPO="lobehub/lobe-chat"
+BIN_NAME="lh"
+
+# Detect OS
+case "$(uname -s)" in
+  Linux)  OS="linux" ;;
+  Darwin) OS="macos" ;;
+  *)
+    printf 'Error: Unsupported OS: %s\n' "$(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+# Detect architecture
+case "$(uname -m)" in
+  x86_64)        ARCH="x64" ;;
+  aarch64|arm64) ARCH="arm64" ;;
+  *)
+    printf 'Error: Unsupported architecture: %s\n' "$(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+BINARY="lobe-${OS}-${ARCH}"
+URL="https://github.com/${REPO}/releases/latest/download/${BINARY}"
+
+printf 'Detected: %s/%s\n' "$OS" "$ARCH"
+printf 'Downloading %s...\n' "$BINARY"
+
+TMP="$(mktemp)"
+trap 'rm -f "$TMP"' EXIT
+
+if command -v curl >/dev/null 2>&1; then
+  curl -fsSL "$URL" -o "$TMP"
+elif command -v wget >/dev/null 2>&1; then
+  wget -qO "$TMP" "$URL"
+else
+  printf 'Error: curl or wget is required\n' >&2
+  exit 1
+fi
+
+chmod +x "$TMP"
+
+# Choose install directory: prefer /usr/local/bin, fall back to ~/.local/bin
+USE_SUDO=0
+if [ -w "/usr/local/bin" ]; then
+  INSTALL_DIR="/usr/local/bin"
+elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+  INSTALL_DIR="/usr/local/bin"
+  USE_SUDO=1
+else
+  INSTALL_DIR="${HOME}/.local/bin"
+  mkdir -p "$INSTALL_DIR"
+  printf 'Note: No sudo access. Installing to %s\n' "$INSTALL_DIR"
+  printf 'Add the following to your shell profile if needed:\n'
+  printf '  export PATH="%s:$PATH"\n' "$INSTALL_DIR"
+fi
+
+# Install binary and create symlinks
+if [ "$USE_SUDO" = "1" ]; then
+  sudo cp "$TMP" "${INSTALL_DIR}/${BIN_NAME}"
+  sudo chmod +x "${INSTALL_DIR}/${BIN_NAME}"
+  sudo ln -sf "${INSTALL_DIR}/${BIN_NAME}" "${INSTALL_DIR}/lobe"
+  sudo ln -sf "${INSTALL_DIR}/${BIN_NAME}" "${INSTALL_DIR}/lobehub"
+else
+  cp "$TMP" "${INSTALL_DIR}/${BIN_NAME}"
+  chmod +x "${INSTALL_DIR}/${BIN_NAME}"
+  ln -sf "${INSTALL_DIR}/${BIN_NAME}" "${INSTALL_DIR}/lobe"
+  ln -sf "${INSTALL_DIR}/${BIN_NAME}" "${INSTALL_DIR}/lobehub"
+fi
+
+printf '\nInstalled successfully!\n'
+printf '  Binary:   %s/%s\n' "$INSTALL_DIR" "$BIN_NAME"
+printf '  Symlinks: lobe, lobehub -> lh\n\n'
+"${INSTALL_DIR}/${BIN_NAME}" --version

--- a/apps/cli/install.sh
+++ b/apps/cli/install.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 set -e
 
-REPO="lobehub/lobe-chat"
+# 从本仓库的 Release 下载预编译二进制
+REPO="lobehub/lobehub"
 BIN_NAME="lh"
 
-# Detect OS
+# 检测操作系统
 case "$(uname -s)" in
   Linux)  OS="linux" ;;
   Darwin) OS="macos" ;;
@@ -14,7 +15,7 @@ case "$(uname -s)" in
     ;;
 esac
 
-# Detect architecture
+# 检测 CPU 架构
 case "$(uname -m)" in
   x86_64)        ARCH="x64" ;;
   aarch64|arm64) ARCH="arm64" ;;
@@ -44,7 +45,7 @@ fi
 
 chmod +x "$TMP"
 
-# Choose install directory: prefer /usr/local/bin, fall back to ~/.local/bin
+# 选择安装目录：优先 /usr/local/bin，否则退回 ~/.local/bin
 USE_SUDO=0
 if [ -w "/usr/local/bin" ]; then
   INSTALL_DIR="/usr/local/bin"
@@ -59,7 +60,7 @@ else
   printf '  export PATH="%s:$PATH"\n' "$INSTALL_DIR"
 fi
 
-# Install binary and create symlinks
+# 安装二进制并创建 lobe / lobehub 别名
 if [ "$USE_SUDO" = "1" ]; then
   sudo cp "$TMP" "${INSTALL_DIR}/${BIN_NAME}"
   sudo chmod +x "${INSTALL_DIR}/${BIN_NAME}"


### PR DESCRIPTION
## Summary

Adds two files to support distributing the CLI as a pre-compiled binary that users can install via .

### 
- Triggers on  (skips pre-release tags containing ) and 
- Matrix build on **ubuntu-latest** →  and **macos-latest** →  using bun build v1.3.11 (af24e281)
error: Missing entrypoints. What would you like to bundle?

Usage:
  $ bun build <entrypoint> [...<entrypoints>] [...flags]  

To see full documentation:
  $ bun build --help
-  so one platform failure won't cancel the other
- Uploads all artifacts +  to the GitHub Release via 

### 
- POSIX  compatible (Alpine, macOS, standard Linux)
- Auto-detects OS (/) and arch (/)
- Installs to , falls back to  if no sudo access
- Creates  and  symlinks pointing to 
- Supports both  and 

## Install command (after next release tag)

```sh
curl -fsSL https://github.com/lobehub/lobehub/releases/latest/download/install.sh | sh
```

## Notes
- No changes to any existing files — only 2 new files added
- POSIX sh syntax validated ()
-  ERR_PNPM_NO_PKG_MANIFEST  No package.json found in /workspace from repo root resolves all  deps before bun compiles