### PR TITLE
🐛 fix(hetero): stop cross-message text duplication in server-ingest mode

### DIFF
--- a/apps/cli/src/commands/hetero.test.ts
+++ b/apps/cli/src/commands/hetero.test.ts
@@ -645,4 +645,75 @@ describe('hetero exec command', () => {
       'finish',
     ]);
   });
+
+  it('resets the per-message text accumulator at message boundaries (no cross-message duplication)', async () => {
+    // LOBE-10157 Bug 3: the `replace` snapshot accumulator must not span
+    // message boundaries. Two assistant messages separated by a
+    // stream_end/stream_start boundary must each snapshot only their OWN
+    // text — otherwise the second message re-emits the first's text verbatim.
+    const textSnapshots: string[] = [];
+    mockHeteroIngestMutate.mockImplementation(async ({ events }: any) => {
+      for (const e of events) {
+        if (e.type === 'stream_chunk' && e.data?.chunkType === 'text') {
+          textSnapshots.push(e.data.content);
+        }
+      }
+      return { ack: true };
+    });
+
+    mockSpawnAgent.mockReturnValue(
+      createFakeHandle({
+        events: [
+          {
+            data: { chunkType: 'text', content: 'first message' },
+            operationId: 'op-server',
+            stepIndex: 0,
+            timestamp: 1,
+            type: 'stream_chunk',
+          },
+          { data: {}, operationId: 'op-server', stepIndex: 0, timestamp: 2, type: 'stream_end' },
+          {
+            data: { newStep: true, provider: 'claude-code' },
+            operationId: 'op-server',
+            stepIndex: 1,
+            timestamp: 3,
+            type: 'stream_start',
+          },
+          {
+            data: { chunkType: 'text', content: 'second message' },
+            operationId: 'op-server',
+            stepIndex: 1,
+            timestamp: 4,
+            type: 'stream_chunk',
+          },
+          {
+            data: { reason: 'success' },
+            operationId: 'op-server',
+            stepIndex: 1,
+            timestamp: 5,
+            type: 'agent_runtime_end',
+          },
+        ],
+        exitCode: 0,
+      }),
+    );
+
+    await runCmd([
+      'hetero',
+      'exec',
+      '--type',
+      'claude-code',
+      '--prompt',
+      'hi',
+      '--topic',
+      'topic-1',
+      '--operation-id',
+      'op-server',
+      '--render',
+      'none',
+    ]);
+
+    // Second snapshot carries ONLY the second message — not "first messagesecond message".
+    expect(textSnapshots).toEqual(['first message', 'second message']);
+  });
 });

--- a/apps/cli/src/commands/hetero.ts
+++ b/apps/cli/src/commands/hetero.ts
@@ -233,6 +233,17 @@ class SerialServerIngester {
     }
 
     this.queuePendingTextSnapshot();
+    // `accumulatedText` is a PER-MESSAGE accumulator: it coalesces the text
+    // deltas of the current assistant message into one `replace` snapshot.
+    // A new message boundary (`stream_start` / `stream_end`, emitted by the
+    // adapter's `openMainMessage`) must reset it — otherwise it spans the
+    // whole run and every later message's snapshot re-emits all prior
+    // messages' text verbatim, which the server then persists into the new
+    // DB message (LOBE-10157 Bug 3: cross-message text duplication). Reset
+    // AFTER flushing the just-ended message's pending snapshot above.
+    if (event.type === 'stream_start' || event.type === 'stream_end') {
+      this.accumulatedText = '';
+    }
     this.enqueue(async () => {
       await this.sink.ingest([event]);
     });


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Part of LOBE-10157 (Bug 3 of 3). Bug 1 (no `agent_operations` / trace snapshot) and Bug 2 (empty tool result) are tracked separately in the same issue.

#### 🔀 Description of Change

Remote-device Claude Code and cloud-sandbox CC both run through `lh hetero exec` (`spawnLhHeteroExec` for devices, `spawnHeteroSandbox` on the server) and share the producer-side `SerialServerIngester`.

**Bug:** `SerialServerIngester.accumulatedText` is a *per-message* text accumulator that coalesces a message's text deltas into one `snapshotMode: 'replace'` snapshot. But it was never reset across assistant-message boundaries, so it spanned the whole run. Each new message's snapshot therefore re-emitted **all prior messages' text verbatim**, and the server persisted that into the new DB message — producing the cross-message text duplication seen in topic `tpc_IkEBRHI18qdY` (a later assistant message containing an earlier one's full text + its own).

**Fix:** reset `accumulatedText` on `stream_start` / `stream_end` boundary events (emitted by the adapter's `openMainMessage`), *after* flushing the just-ended message's pending snapshot. Each message now snapshots only its own text. One fix covers both the device and sandbox paths.

Verified against raw `claude` stream-json: the upstream CC output is clean (each assistant message carries only its own text), confirming the duplication is introduced in lobehub's ingest pipeline, not by Claude Code.

#### 🧪 How to Test

- [x] Added/updated tests

Added a regression test in `hetero.test.ts`: two assistant messages separated by a `stream_end`/`stream_start` boundary must each snapshot only their own text (`['first message', 'second message']`, not `['first message', 'first messagesecond message']`). Confirmed the test fails without the fix and passes with it. Full `hetero.test.ts` suite (20 tests) green.

#### 📝 Additional Information

Scope note: this is the highest-confidence, reproducible part of LOBE-10157. The remaining two bugs need separate work — Bug 1 is a server-side operation/trace gap in the heterogeneous ingest path; Bug 2 (empty tool result) was shown **not** to be an adapter extraction bug and needs the actual failing run's raw stream to root-cause.