### PR TITLE
🐛 fix: activator tool discovery for cloud-sandbox and local-system

### DIFF
--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1631,6 +1631,14 @@ export class AiAgentService {
         agentConfig.chatConfig?.runtimeEnv?.runtimeMode?.[gatewayConfigured ? 'desktop' : 'web'],
         gatewayConfigured,
       );
+      // When sandbox is not the active runtime, remove lobe-cloud-sandbox from the
+      // manifest map. The initial seed via getEnabledPluginManifests (which includes
+      // defaultToolIds) may have already placed it there, and the allowedBuiltinTools
+      // loop below only guards the discoverable-builtin append path. Deleting here
+      // covers both sources in a single point.
+      if (agentRuntimeMode !== 'cloud') {
+        delete toolManifestMap[CloudSandboxManifest.identifier];
+      }
       for (const tool of allowedBuiltinTools) {
         // lobe-cloud-sandbox is only activator-discoverable when runtimeMode resolves
         // to 'cloud'. Handles both executionTarget='sandbox' (new) and the legacy

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1652,13 +1652,14 @@ export class AiAgentService {
 
       // lobe-local-system has `discoverable: isDesktop` in builtinTools, which
       // evaluates to false on the Node.js server side, so it never enters the
-      // loop above. Explicitly inject it when a device gateway is configured:
-      // in that scenario the agent IS reachable via the gateway and the
-      // activator must be able to find its manifest.
+      // loop above. Explicitly inject it only when the device gateway is
+      // configured AND the runtime mode is 'local' — skip for sandbox/none
+      // targets to avoid leaking local-system into non-local sessions.
       if (
         canUseDevice &&
         !disableLocalSystem &&
         gatewayConfigured &&
+        agentRuntimeMode === 'local' &&
         !toolManifestMap[LocalSystemManifest.identifier]
       ) {
         toolManifestMap[LocalSystemManifest.identifier] = LocalSystemManifest as LobeToolManifest;

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1,6 +1,7 @@
 import type { AgentRuntimeContext, AgentState } from '@lobechat/agent-runtime';
 import { BUILTIN_AGENT_SLUGS, getAgentRuntimeConfig } from '@lobechat/builtin-agents';
 import { builtinSkills } from '@lobechat/builtin-skills';
+import { CloudSandboxManifest } from '@lobechat/builtin-tool-cloud-sandbox';
 import { LobeAgentManifest } from '@lobechat/builtin-tool-lobe-agent';
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
 import { MessageToolIdentifier } from '@lobechat/builtin-tool-message';
@@ -60,6 +61,7 @@ import { TopicModel } from '@/database/models/topic';
 import { UserModel } from '@/database/models/user';
 import { UserPersonaModel } from '@/database/models/userMemory/persona';
 import { toolsEnv } from '@/envs/tools';
+import { resolveRuntimeMode } from '@/helpers/executionTarget';
 import { shouldEnableBuiltinSkill } from '@/helpers/skillFilters';
 import { buildConnectorManifests } from '@/libs/mcp/buildConnectorManifests';
 import { signOperationJwt, signUserJWT } from '@/libs/trpc/utils/internalJwt';
@@ -1621,10 +1623,37 @@ export class AiAgentService {
         canUseDevice,
         disableLocalSystem,
       });
+      // Resolve effective runtimeMode once, mirroring AgentToolsEngine's derivation:
+      // executionTarget wins; falls back to per-platform chatConfig.runtimeEnv.runtimeMode
+      // for legacy agents that predate the unified executionTarget field.
+      const agentRuntimeMode = resolveRuntimeMode(
+        agentConfig.agencyConfig,
+        agentConfig.chatConfig?.runtimeEnv?.runtimeMode?.[gatewayConfigured ? 'desktop' : 'web'],
+        gatewayConfigured,
+      );
       for (const tool of allowedBuiltinTools) {
+        // lobe-cloud-sandbox is only activator-discoverable when runtimeMode resolves
+        // to 'cloud'. Handles both executionTarget='sandbox' (new) and the legacy
+        // chatConfig.runtimeEnv.runtimeMode='cloud' path via resolveRuntimeMode.
+        if (tool.identifier === CloudSandboxManifest.identifier && agentRuntimeMode !== 'cloud')
+          continue;
         if (tool.discoverable !== false && !toolManifestMap[tool.identifier]) {
           toolManifestMap[tool.identifier] = tool.manifest as LobeToolManifest;
         }
+      }
+
+      // lobe-local-system has `discoverable: isDesktop` in builtinTools, which
+      // evaluates to false on the Node.js server side, so it never enters the
+      // loop above. Explicitly inject it when a device gateway is configured:
+      // in that scenario the agent IS reachable via the gateway and the
+      // activator must be able to find its manifest.
+      if (
+        canUseDevice &&
+        !disableLocalSystem &&
+        gatewayConfigured &&
+        !toolManifestMap[LocalSystemManifest.identifier]
+      ) {
+        toolManifestMap[LocalSystemManifest.identifier] = LocalSystemManifest as LobeToolManifest;
       }
 
       // Include lobehub skill and klavis manifests for activator discovery


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- None -->

#### 🔀 Description of Change

修复 activator 中 tool manifest discovery 的两个问题：

**P0 — \`lobe-local-system\` 在 device gateway 场景下缺失**

\`LocalSystemManifest\` 的 \`discoverable\` 属性为 \`isDesktop\`，在 Node.js 服务端永远为 \`false\`，因此永远不会进入 discovery loop。当 device gateway 已配置时，agent 可通过 gateway 触达，activator 需要能发现该 manifest。

修复：当 \`canUseDevice && !disableLocalSystem && gatewayConfigured\` 时，显式注入 \`LocalSystemManifest\` 到 \`toolManifestMap\`。

**P1 — \`lobe-cloud-sandbox\` 在沙箱关闭时仍出现在 availableTools 中**

当 sandbox 未启用（\`executionTarget !== "sandbox"\`），\`lobe-cloud-sandbox\` 仍出现在 availableTools 中，导致 activator 可动态激活沙箱。

修复：使用 \`resolveRuntimeMode\`（统一解析 \`executionTarget\` 和 legacy \`runtimeEnv.runtimeMode\`），当 \`agentRuntimeMode !== 'cloud'\` 时跳过 \`CloudSandboxManifest\`。

引入 \`resolveRuntimeMode\`（来自 \`@/helpers/executionTarget\`），引入 \`CloudSandboxManifest\`、\`LocalSystemManifest\`（来自 builtin-tools）。29 行改动，单文件 \`src/server/services/aiAgent/index.ts\`。

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

**测试场景**：

1. **Device gateway 场景**：配置 device gateway，开启 agent chat，验证系统提示词 \`<available_tools>\` 中是否出现 \`lobe-local-system\`
2. **Sandbox 关闭场景**：\`executionTarget\` 设为 \`local\` 或 \`device\`，验证 \`<available_tools>\` 中不再出现 \`lobe-cloud-sandbox\`
3. **Sandbox 开启场景**：\`executionTarget\` 设为 \`sandbox\`，验证 \`<available_tools>\` 中正常出现 \`lobe-cloud-sandbox\`
4. 回归：无 device gateway 的 web 端行为不变

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A（非 UI 变更） | N/A |

#### 📝 Additional Information

- 由 Claude Code 分析 operation trace 定位根因并修复
- 修复在 manifest map 构建阶段生效，所有下游消费者（activator discovery、\`availableTools\` 等）自动一致