### PR TITLE
♻️ refactor(auth): remove email harmony plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -328,7 +328,6 @@
     "async-retry": "^1.3.3",
     "bcryptjs": "^3.0.3",
     "better-auth": "1.4.6",
-    "better-auth-harmony": "^1.2.5",
     "better-call": "1.1.8",
     "brotli-wasm": "^3.0.1",
     "buffer.js": "npm:buffer@^6.0.3",

--- a/packages/business-server/src/better-auth.ts
+++ b/packages/business-server/src/better-auth.ts
@@ -1,7 +1,0 @@
-import type { emailHarmony } from 'better-auth-harmony';
-
-export type BusinessEmailHarmonyOptions = NonNullable<Parameters<typeof emailHarmony>[0]>;
-
-export const businessEmailHarmonyOptions = {
-  allowNormalizedSignin: false,
-} satisfies BusinessEmailHarmonyOptions;

--- a/src/libs/better-auth/define-config.test.ts
+++ b/src/libs/better-auth/define-config.test.ts
@@ -2,8 +2,6 @@ import { describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   betterAuth: vi.fn((options) => options),
-  businessEmailHarmonyOptions: { allowNormalizedSignin: false },
-  emailHarmony: vi.fn((options) => ({ id: 'email-harmony', options })),
 }));
 
 vi.mock('@better-auth/expo', () => ({
@@ -47,17 +45,9 @@ vi.mock('better-auth/plugins', () => ({
   magicLink: vi.fn(() => ({ id: 'magic-link' })),
 }));
 
-vi.mock('better-auth-harmony', () => ({
-  emailHarmony: mocks.emailHarmony,
-}));
-
 vi.mock('undici', () => ({
   ProxyAgent: vi.fn(),
   setGlobalDispatcher: vi.fn(),
-}));
-
-vi.mock('@/business/server/better-auth', () => ({
-  businessEmailHarmonyOptions: mocks.businessEmailHarmonyOptions,
 }));
 
 vi.mock('@/envs/app', () => ({
@@ -125,13 +115,5 @@ describe('defineConfig', () => {
         }),
       }),
     );
-  });
-
-  it('should delegate emailHarmony options to the business slot', async () => {
-    const { defineConfig } = await import('./define-config');
-
-    defineConfig({ plugins: [] });
-
-    expect(mocks.emailHarmony).toHaveBeenCalledWith(mocks.businessEmailHarmonyOptions);
   });
 });

--- a/src/libs/better-auth/define-config.ts
+++ b/src/libs/better-auth/define-config.ts
@@ -9,10 +9,8 @@ import { type BetterAuthOptions } from 'better-auth/minimal';
 import { betterAuth } from 'better-auth/minimal';
 import { admin, emailOTP, genericOAuth, magicLink } from 'better-auth/plugins';
 import { type BetterAuthPlugin } from 'better-auth/types';
-import { emailHarmony } from 'better-auth-harmony';
 import { ProxyAgent, setGlobalDispatcher } from 'undici';
 
-import { businessEmailHarmonyOptions } from '@/business/server/better-auth';
 import { appEnv } from '@/envs/app';
 import { authEnv } from '@/envs/auth';
 import {
@@ -258,7 +256,6 @@ export function defineConfig(customOptions: CustomBetterAuthOptions) {
       ...customOptions.plugins,
       emailWhitelist(),
       expo(),
-      emailHarmony(businessEmailHarmonyOptions),
       admin(),
       // Email OTP plugin for mobile verification
       emailOTP({

--- a/src/libs/next/config/define-config.ts
+++ b/src/libs/next/config/define-config.ts
@@ -363,7 +363,7 @@ export function defineConfig(config: CustomNextConfig) {
       'oidc-provider',
     ],
 
-    transpilePackages: ['mermaid', 'better-auth-harmony'],
+    transpilePackages: ['mermaid'],
     turbopack: {
       rules: {
         ...(isTest


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-10154

#### 🔀 Description of Change

- Remove the email harmony plugin from the shared Better Auth configuration.
- Drop the related dependency, business option stub, and Next.js transpile entry.
- Update the Better Auth config test to match the remaining plugin setup.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' src/libs/better-auth/define-config.test.ts
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No UI changes.
