### PR TITLE
✨ feat: add user-scoped LobeHub model availability

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/video.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/video.test.ts
@@ -67,8 +67,13 @@ vi.mock('@lobechat/business-model-runtime', async (importOriginal) => ({
     mockResolveBusinessModelMapping(...args),
 }));
 vi.mock('@lobechat/business-model-bank/model-config', () => ({
-  isLobeHubModelAvailable: (...args: [string, string, { userEmail?: string | null }?]) =>
-    mockIsLobeHubModelAvailable(...args),
+  isLobeHubModelAvailable: (
+    ...args: [
+      string,
+      string,
+      { getUserEmail?: () => Promise<string | null | undefined>; userEmail?: string | null }?,
+    ]
+  ) => mockIsLobeHubModelAvailable(...args),
 }));
 vi.mock('@/business/server/video-generation/getVideoFreeQuota', () => ({
   getVideoFreeQuota: vi.fn().mockResolvedValue({ remaining: 10 }),
@@ -196,8 +201,12 @@ describe('videoRouter', () => {
       expect(mockIsLobeHubModelAvailable).toHaveBeenCalledWith(
         'dreamina-seedance-2-0-260128',
         'video',
-        { userEmail: 'user@example.com' },
+        { getUserEmail: expect.any(Function) },
       );
+      const availabilityOptions = mockIsLobeHubModelAvailable.mock.calls.at(-1)?.[2];
+      expect(mockFindUserById).not.toHaveBeenCalled();
+      await expect(availabilityOptions!.getUserEmail!()).resolves.toBe('user@example.com');
+      expect(mockFindUserById).toHaveBeenCalledWith(mockServerDB, mockCtx.userId);
       expect(mockCreateVideo).toHaveBeenCalledWith(
         expect.objectContaining({ model: 'dreamina-seedance-2-0-260128' }),
         expect.any(Object),

--- a/apps/server/src/routers/lambda/__tests__/video.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/video.test.ts
@@ -9,7 +9,8 @@ import { AsyncTaskStatus } from '@/types/asyncTask';
 const {
   mockAfter,
   mockCreateVideo,
-  mockLoadModels,
+  mockFindUserById,
+  mockIsLobeHubModelAvailable,
   mockProcessBackgroundVideoPolling,
   mockResolveBusinessModelMapping,
   mockServerDB,
@@ -19,13 +20,15 @@ const {
   const mockServerDB = { transaction: mockTransaction };
   const mockCreateVideo = vi.fn();
   const mockAfter = vi.fn((cb: () => void) => cb());
-  const mockLoadModels = vi.fn();
+  const mockFindUserById = vi.fn();
+  const mockIsLobeHubModelAvailable = vi.fn();
   const mockProcessBackgroundVideoPolling = vi.fn().mockResolvedValue(undefined);
   const mockResolveBusinessModelMapping = vi.fn();
   return {
     mockAfter,
     mockCreateVideo,
-    mockLoadModels,
+    mockFindUserById,
+    mockIsLobeHubModelAvailable,
     mockProcessBackgroundVideoPolling,
     mockResolveBusinessModelMapping,
     mockServerDB,
@@ -37,6 +40,11 @@ const {
 
 vi.mock('@/database/models/asyncTask');
 vi.mock('@/server/services/file');
+vi.mock('@/database/models/user', () => ({
+  UserModel: {
+    findById: mockFindUserById,
+  },
+}));
 
 vi.mock('@/database/core/db-adaptor', () => ({
   getServerDB: vi.fn().mockResolvedValue(mockServerDB),
@@ -59,7 +67,8 @@ vi.mock('@lobechat/business-model-runtime', async (importOriginal) => ({
     mockResolveBusinessModelMapping(...args),
 }));
 vi.mock('@lobechat/business-model-bank/model-config', () => ({
-  loadModels: mockLoadModels,
+  isLobeHubModelAvailable: (...args: [string, string, { userEmail?: string | null }?]) =>
+    mockIsLobeHubModelAvailable(...args),
 }));
 vi.mock('@/business/server/video-generation/getVideoFreeQuota', () => ({
   getVideoFreeQuota: vi.fn().mockResolvedValue({ remaining: 10 }),
@@ -146,15 +155,8 @@ describe('videoRouter', () => {
         resolvedModelId: model,
       }),
     );
-    mockLoadModels.mockResolvedValue([
-      {
-        abilities: {},
-        enabled: true,
-        id: 'dreamina-seedance-2-0-260128',
-        providerId: 'lobehub',
-        type: 'video',
-      },
-    ]);
+    mockFindUserById.mockResolvedValue({ email: 'user@example.com' });
+    mockIsLobeHubModelAvailable.mockResolvedValue(true);
   });
 
   describe('createVideo - async strategy routing', () => {
@@ -191,10 +193,36 @@ describe('videoRouter', () => {
 
       expect(result.success).toBe(true);
       expect(mockResolveBusinessModelMapping).toHaveBeenCalledWith('lobehub', 'onboarding-video');
+      expect(mockIsLobeHubModelAvailable).toHaveBeenCalledWith(
+        'dreamina-seedance-2-0-260128',
+        'video',
+        { userEmail: 'user@example.com' },
+      );
       expect(mockCreateVideo).toHaveBeenCalledWith(
         expect.objectContaining({ model: 'dreamina-seedance-2-0-260128' }),
         expect.any(Object),
       );
+    });
+
+    it('should reject unavailable lobehub video models before creating async tasks', async () => {
+      setupMocks();
+      mockIsLobeHubModelAvailable.mockResolvedValue(false);
+
+      const caller = videoRouter.createCaller(mockCtx);
+
+      await expect(
+        caller.createVideo({
+          ...defaultInput,
+          model: 'restricted-video-model',
+          provider: 'lobehub',
+        }),
+      ).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: 'LobeHubModelDeprecated',
+      });
+
+      expect(mockTransaction).not.toHaveBeenCalled();
+      expect(mockCreateVideo).not.toHaveBeenCalled();
     });
 
     it('should use polling path when response contains only inferenceId', async () => {

--- a/apps/server/src/routers/lambda/image/index.test.ts
+++ b/apps/server/src/routers/lambda/image/index.test.ts
@@ -74,8 +74,13 @@ vi.mock('@lobechat/business-model-runtime', async (importOriginal) => ({
 }));
 
 vi.mock('@lobechat/business-model-bank/model-config', () => ({
-  isLobeHubModelAvailable: (...args: [string, string, { userEmail?: string | null }?]) =>
-    mockIsLobeHubModelAvailable(...args),
+  isLobeHubModelAvailable: (
+    ...args: [
+      string,
+      string,
+      { getUserEmail?: () => Promise<string | null | undefined>; userEmail?: string | null }?,
+    ]
+  ) => mockIsLobeHubModelAvailable(...args),
 }));
 
 // Mock async caller
@@ -228,8 +233,12 @@ describe('imageRouter', () => {
       expect(result.success).toBe(true);
       expect(mockResolveBusinessModelMapping).toHaveBeenCalledWith('lobehub', 'onboarding-image');
       expect(mockIsLobeHubModelAvailable).toHaveBeenCalledWith('gpt-image-1', 'image', {
-        userEmail: 'user@example.com',
+        getUserEmail: expect.any(Function),
       });
+      const availabilityOptions = mockIsLobeHubModelAvailable.mock.calls.at(-1)?.[2];
+      expect(mockFindUserById).not.toHaveBeenCalled();
+      await expect(availabilityOptions!.getUserEmail!()).resolves.toBe('user@example.com');
+      expect(mockFindUserById).toHaveBeenCalledWith(mockServerDB, mockUserId);
       expect(mockCreateAsyncCaller).toHaveBeenCalledWith({ userId: mockUserId });
     });
 

--- a/apps/server/src/routers/lambda/image/index.test.ts
+++ b/apps/server/src/routers/lambda/image/index.test.ts
@@ -12,8 +12,9 @@ const {
   mockAsyncTaskModelUpdate,
   mockChargeBeforeGenerate,
   mockCreateAsyncCaller,
+  mockFindUserById,
   mockInsertValues,
-  mockLoadModels,
+  mockIsLobeHubModelAvailable,
   mockResolveBusinessModelMapping,
 } = vi.hoisted(() => ({
   mockServerDB: {
@@ -24,8 +25,9 @@ const {
   mockAsyncTaskModelUpdate: vi.fn(),
   mockChargeBeforeGenerate: vi.fn(),
   mockCreateAsyncCaller: vi.fn(),
+  mockFindUserById: vi.fn(),
   mockInsertValues: [] as unknown[],
-  mockLoadModels: vi.fn(),
+  mockIsLobeHubModelAvailable: vi.fn(),
   mockResolveBusinessModelMapping: vi.fn(),
 }));
 
@@ -54,6 +56,12 @@ vi.mock('@/database/models/asyncTask', () => ({
   })),
 }));
 
+vi.mock('@/database/models/user', () => ({
+  UserModel: {
+    findById: mockFindUserById,
+  },
+}));
+
 // Mock chargeBeforeGenerate
 vi.mock('@/business/server/image-generation/chargeBeforeGenerate', () => ({
   chargeBeforeGenerate: (params: any) => mockChargeBeforeGenerate(params),
@@ -66,7 +74,8 @@ vi.mock('@lobechat/business-model-runtime', async (importOriginal) => ({
 }));
 
 vi.mock('@lobechat/business-model-bank/model-config', () => ({
-  loadModels: mockLoadModels,
+  isLobeHubModelAvailable: (...args: [string, string, { userEmail?: string | null }?]) =>
+    mockIsLobeHubModelAvailable(...args),
 }));
 
 // Mock async caller
@@ -127,15 +136,8 @@ describe('imageRouter', () => {
     mockChargeBeforeGenerate.mockResolvedValue(undefined);
     mockGetKeyFromFullUrl.mockResolvedValue(null);
     mockGetFullFileUrl.mockResolvedValue(null);
-    mockLoadModels.mockResolvedValue([
-      {
-        abilities: {},
-        enabled: true,
-        id: 'gpt-image-1',
-        providerId: 'lobehub',
-        type: 'image',
-      },
-    ]);
+    mockFindUserById.mockResolvedValue({ email: 'user@example.com' });
+    mockIsLobeHubModelAvailable.mockResolvedValue(true);
 
     // Setup default transaction mock
     const mockBatch = {
@@ -225,7 +227,30 @@ describe('imageRouter', () => {
 
       expect(result.success).toBe(true);
       expect(mockResolveBusinessModelMapping).toHaveBeenCalledWith('lobehub', 'onboarding-image');
+      expect(mockIsLobeHubModelAvailable).toHaveBeenCalledWith('gpt-image-1', 'image', {
+        userEmail: 'user@example.com',
+      });
       expect(mockCreateAsyncCaller).toHaveBeenCalledWith({ userId: mockUserId });
+    });
+
+    it('should reject unavailable lobehub image models before creating async tasks', async () => {
+      mockIsLobeHubModelAvailable.mockResolvedValue(false);
+
+      const ctx = createMockCtx();
+      const input = createDefaultInput({
+        model: 'restricted-image-model',
+        provider: 'lobehub',
+      });
+
+      const caller = imageRouter.createCaller(ctx);
+
+      await expect(caller.createImage(input)).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: 'LobeHubModelDeprecated',
+      });
+
+      expect(mockServerDB.transaction).not.toHaveBeenCalled();
+      expect(mockCreateAsyncCaller).not.toHaveBeenCalled();
     });
 
     it('should convert imageUrls to S3 keys for database storage', async () => {

--- a/apps/server/src/routers/lambda/image/index.ts
+++ b/apps/server/src/routers/lambda/image/index.ts
@@ -1,17 +1,17 @@
 import { BRANDING_PROVIDER } from '@lobechat/business-const';
-import { loadModels } from '@lobechat/business-model-bank/model-config';
+import { isLobeHubModelAvailable } from '@lobechat/business-model-bank/model-config';
 import { resolveBusinessModelMapping } from '@lobechat/business-model-runtime';
 import { ChatErrorType } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import debug from 'debug';
 import { and, eq } from 'drizzle-orm';
-import { isProviderModelAvailable } from 'model-bank';
 import { z } from 'zod';
 
 import { chargeBeforeGenerate } from '@/business/server/image-generation/chargeBeforeGenerate';
 import { withScopedPermission } from '@/business/server/trpc-middlewares/rbacPermission';
 import { wsCompatProcedure } from '@/business/server/trpc-middlewares/workspaceAuth';
 import { AsyncTaskModel } from '@/database/models/asyncTask';
+import { UserModel } from '@/database/models/user';
 import { type NewGeneration, type NewGenerationBatch } from '@/database/schemas';
 import { asyncTasks, generationBatches, generations } from '@/database/schemas';
 import { router } from '@/libs/trpc/lambda';
@@ -80,7 +80,9 @@ export const imageRouter = router({
       // can't serve the requested id.
       if (
         provider === BRANDING_PROVIDER &&
-        !isProviderModelAvailable(await loadModels(), BRANDING_PROVIDER, resolvedModelId, 'image')
+        !(await isLobeHubModelAvailable(resolvedModelId, 'image', {
+          userEmail: (await UserModel.findById(serverDB, userId))?.email,
+        }))
       ) {
         throw new TRPCError({
           cause: { data: { modelType: 'image', requestedModel: model } },

--- a/apps/server/src/routers/lambda/image/index.ts
+++ b/apps/server/src/routers/lambda/image/index.ts
@@ -81,7 +81,7 @@ export const imageRouter = router({
       if (
         provider === BRANDING_PROVIDER &&
         !(await isLobeHubModelAvailable(resolvedModelId, 'image', {
-          userEmail: (await UserModel.findById(serverDB, userId))?.email,
+          getUserEmail: async () => (await UserModel.findById(serverDB, userId))?.email,
         }))
       ) {
         throw new TRPCError({

--- a/apps/server/src/routers/lambda/video/index.ts
+++ b/apps/server/src/routers/lambda/video/index.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from 'node:crypto';
 
 import { BRANDING_PROVIDER } from '@lobechat/business-const';
-import { loadModels } from '@lobechat/business-model-bank/model-config';
+import { isLobeHubModelAvailable } from '@lobechat/business-model-bank/model-config';
 import {
   buildMappedBusinessModelFields,
   resolveBusinessModelMapping,
@@ -10,7 +10,6 @@ import { ChatErrorType, RequestTrigger } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import debug from 'debug';
 import { and, eq } from 'drizzle-orm';
-import { isProviderModelAvailable } from 'model-bank';
 import { after } from 'next/server';
 import { z } from 'zod';
 
@@ -21,6 +20,7 @@ import { chargeAfterGenerate } from '@/business/server/video-generation/chargeAf
 import { chargeBeforeGenerate } from '@/business/server/video-generation/chargeBeforeGenerate';
 import { getVideoFreeQuota } from '@/business/server/video-generation/getVideoFreeQuota';
 import { AsyncTaskModel } from '@/database/models/asyncTask';
+import { UserModel } from '@/database/models/user';
 import {
   asyncTasks,
   generationBatches,
@@ -90,7 +90,9 @@ export const videoRouter = router({
       // model is no longer in the model bank.
       if (
         provider === BRANDING_PROVIDER &&
-        !isProviderModelAvailable(await loadModels(), BRANDING_PROVIDER, resolvedModelId, 'video')
+        !(await isLobeHubModelAvailable(resolvedModelId, 'video', {
+          userEmail: (await UserModel.findById(serverDB, userId))?.email,
+        }))
       ) {
         throw new TRPCError({
           cause: { data: { modelType: 'video', requestedModel: model } },

--- a/apps/server/src/routers/lambda/video/index.ts
+++ b/apps/server/src/routers/lambda/video/index.ts
@@ -91,7 +91,7 @@ export const videoRouter = router({
       if (
         provider === BRANDING_PROVIDER &&
         !(await isLobeHubModelAvailable(resolvedModelId, 'video', {
-          userEmail: (await UserModel.findById(serverDB, userId))?.email,
+          getUserEmail: async () => (await UserModel.findById(serverDB, userId))?.email,
         }))
       ) {
         throw new TRPCError({

--- a/packages/business/model-bank/src/model-config.ts
+++ b/packages/business/model-bank/src/model-config.ts
@@ -1,4 +1,4 @@
-import type { AiFullModelCard } from 'model-bank';
+import type { AiFullModelCard, AiModelType } from 'model-bank';
 import { loadModels as loadModelBankModels, ModelProvider } from 'model-bank';
 
 interface LobeHubModelConfig {
@@ -29,3 +29,9 @@ const loadLobeHubModels = async (): Promise<AiFullModelCard[]> =>
 
 export const loadLobeHubPlanCardModels = async (): Promise<string[]> =>
   (await loadLobeHubModelConfig()).planCardModels;
+
+export const isLobeHubModelAvailable = async (
+  _id: string,
+  _expectedType: AiModelType,
+  _options?: { userEmail?: string | null },
+): Promise<boolean> => false;

--- a/packages/business/model-bank/src/model-config.ts
+++ b/packages/business/model-bank/src/model-config.ts
@@ -1,5 +1,9 @@
 import type { AiFullModelCard, AiModelType } from 'model-bank';
-import { loadModels as loadModelBankModels, ModelProvider } from 'model-bank';
+import {
+  isProviderModelAvailable,
+  loadModels as loadModelBankModels,
+  ModelProvider,
+} from 'model-bank';
 
 interface LobeHubModelConfig {
   models: AiFullModelCard[];
@@ -31,10 +35,11 @@ export const loadLobeHubPlanCardModels = async (): Promise<string[]> =>
   (await loadLobeHubModelConfig()).planCardModels;
 
 export const isLobeHubModelAvailable = async (
-  _id: string,
-  _expectedType: AiModelType,
+  id: string,
+  expectedType: AiModelType,
   _options?: {
     getUserEmail?: () => Promise<string | null | undefined>;
     userEmail?: string | null;
   },
-): Promise<boolean> => false;
+): Promise<boolean> =>
+  isProviderModelAvailable(await loadModels(), ModelProvider.LobeHub, id, expectedType);

--- a/packages/business/model-bank/src/model-config.ts
+++ b/packages/business/model-bank/src/model-config.ts
@@ -33,5 +33,8 @@ export const loadLobeHubPlanCardModels = async (): Promise<string[]> =>
 export const isLobeHubModelAvailable = async (
   _id: string,
   _expectedType: AiModelType,
-  _options?: { userEmail?: string | null },
+  _options?: {
+    getUserEmail?: () => Promise<string | null | undefined>;
+    userEmail?: string | null;
+  },
 ): Promise<boolean> => false;

--- a/packages/business/model-bank/src/model-config.ts
+++ b/packages/business/model-bank/src/model-config.ts
@@ -1,9 +1,5 @@
 import type { AiFullModelCard, AiModelType } from 'model-bank';
-import {
-  isProviderModelAvailable,
-  loadModels as loadModelBankModels,
-  ModelProvider,
-} from 'model-bank';
+import { loadModels as loadModelBankModels, ModelProvider } from 'model-bank';
 
 interface LobeHubModelConfig {
   models: AiFullModelCard[];
@@ -34,12 +30,11 @@ const loadLobeHubModels = async (): Promise<AiFullModelCard[]> =>
 export const loadLobeHubPlanCardModels = async (): Promise<string[]> =>
   (await loadLobeHubModelConfig()).planCardModels;
 
-export const isLobeHubModelAvailable = async (
-  id: string,
-  expectedType: AiModelType,
+export const isLobeHubModelAvailable = (
+  _id: string,
+  _expectedType: AiModelType,
   _options?: {
     getUserEmail?: () => Promise<string | null | undefined>;
     userEmail?: string | null;
   },
-): Promise<boolean> =>
-  isProviderModelAvailable(await loadModels(), ModelProvider.LobeHub, id, expectedType);
+): boolean => false;

--- a/src/business/model-config.test.ts
+++ b/src/business/model-config.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockIsProviderModelAvailable = vi.fn();
+const mockLoadModelBankModels = vi.fn();
+
+vi.mock('model-bank', () => ({
+  isProviderModelAvailable: mockIsProviderModelAvailable,
+  loadModels: mockLoadModelBankModels,
+  ModelProvider: { LobeHub: 'lobehub' },
+}));
+
+const { isLobeHubModelAvailable } = await import('@lobechat/business-model-bank/model-config');
+
+describe('business model config', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should preserve default model-bank availability checks for LobeHub models', async () => {
+    const loadedModels = [
+      {
+        enabled: true,
+        id: 'image-model',
+        providerId: 'lobehub',
+        type: 'image',
+      },
+    ];
+    mockLoadModelBankModels.mockResolvedValue(loadedModels);
+    mockIsProviderModelAvailable.mockReturnValue(true);
+
+    await expect(isLobeHubModelAvailable('image-model', 'image')).resolves.toBe(true);
+
+    expect(mockIsProviderModelAvailable).toHaveBeenCalledWith(
+      loadedModels,
+      'lobehub',
+      'image-model',
+      'image',
+    );
+  });
+});

--- a/src/business/model-config.test.ts
+++ b/src/business/model-config.test.ts
@@ -16,25 +16,13 @@ describe('business model config', () => {
     vi.clearAllMocks();
   });
 
-  it('should preserve default model-bank availability checks for LobeHub models', async () => {
-    const loadedModels = [
-      {
-        enabled: true,
-        id: 'image-model',
-        providerId: 'lobehub',
-        type: 'image',
-      },
-    ];
-    mockLoadModelBankModels.mockResolvedValue(loadedModels);
-    mockIsProviderModelAvailable.mockReturnValue(true);
+  it('should disable LobeHub model availability by default', () => {
+    const getUserEmail = vi.fn();
 
-    await expect(isLobeHubModelAvailable('image-model', 'image')).resolves.toBe(true);
+    expect(isLobeHubModelAvailable('image-model', 'image', { getUserEmail })).toBe(false);
 
-    expect(mockIsProviderModelAvailable).toHaveBeenCalledWith(
-      loadedModels,
-      'lobehub',
-      'image-model',
-      'image',
-    );
+    expect(mockLoadModelBankModels).not.toHaveBeenCalled();
+    expect(mockIsProviderModelAvailable).not.toHaveBeenCalled();
+    expect(getUserEmail).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-10103

#### 🔀 Description of Change

Adds a user-scoped availability hook for LobeHub provider models and routes image/video LobeHub model checks through it. This keeps the open-source package contract generic while allowing downstream implementations to apply additional model access rules.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' apps/server/src/routers/lambda/image/index.test.ts apps/server/src/routers/lambda/__tests__/video.test.ts
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No UI changes.
