### PR TITLE
🐛 fix(hetero): forward user images on regenerate so vision input isn't dropped

### DIFF
--- a/packages/builtin-tool-local-system/src/client/Intervention/OutOfScopeWarning.tsx
+++ b/packages/builtin-tool-local-system/src/client/Intervention/OutOfScopeWarning.tsx
@@ -6,6 +6,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
+import { useElectronStore } from '@/store/electron';
 
 import { isPathWithinScope } from '../../utils/path';
 
@@ -23,7 +24,10 @@ const OutOfScopeWarning = memo<OutOfScopeWarningProps>(({ paths }) => {
   const { t } = useTranslation('tool');
 
   const topicWorkingDir = useChatStore(topicSelectors.currentTopicWorkingDirectory);
-  const agentWorkingDir = useAgentStore(agentSelectors.currentAgentWorkingDirectory);
+  const currentDeviceId = useElectronStore((s) => s.gatewayDeviceInfo?.deviceId);
+  const agentWorkingDir = useAgentStore(
+    agentSelectors.currentAgentWorkingDirectory(currentDeviceId),
+  );
   const workingDirectory = topicWorkingDir || agentWorkingDir;
 
   // Find paths that are outside the working directory

--- a/src/features/ChatInput/InputEditor/useLocalFileMention.desktop.ts
+++ b/src/features/ChatInput/InputEditor/useLocalFileMention.desktop.ts
@@ -6,6 +6,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
+import { useElectronStore } from '@/store/electron';
 
 import { useAgentId } from '../hooks/useAgentId';
 import {
@@ -30,8 +31,9 @@ export const useLocalFileMention = (): UseLocalFileMentionResult => {
   const isLocalSystemEnabled = useAgentStore(
     chatConfigByIdSelectors.isLocalSystemEnabledById(agentId),
   );
+  const currentDeviceId = useElectronStore((s) => s.gatewayDeviceInfo?.deviceId);
   const agentWorkingDirectory = useAgentStore((s) =>
-    agentByIdSelectors.getAgentWorkingDirectoryById(agentId)(s),
+    agentByIdSelectors.getAgentWorkingDirectoryById(agentId, currentDeviceId)(s),
   );
   const topicWorkingDirectory = useChatStore(topicSelectors.currentTopicWorkingDirectory);
   const workingDirectory = topicWorkingDirectory || agentWorkingDirectory;

--- a/src/features/Conversation/store/slices/generation/action.ts
+++ b/src/features/Conversation/store/slices/generation/action.ts
@@ -1,6 +1,10 @@
 import { AgentManagementIdentifier } from '@lobechat/builtin-tool-agent-management';
 import { LOADING_FLAT } from '@lobechat/const';
-import type { ConversationContext, HeterogeneousProviderConfig } from '@lobechat/types';
+import type {
+  ChatImageItem,
+  ConversationContext,
+  HeterogeneousProviderConfig,
+} from '@lobechat/types';
 import { t } from 'i18next';
 import { type StateCreator } from 'zustand';
 
@@ -71,12 +75,15 @@ const runHeterogeneousFromExistingMessage = async (
   params: {
     context: ConversationContext;
     heterogeneousProvider: HeterogeneousProviderConfig;
+    /** Image attachments from the original user message — forwarded to the CLI for vision support */
+    imageList?: ChatImageItem[];
     parentMessageId: string;
     parentOperationId: string;
     prompt: string;
   },
 ): Promise<string> => {
-  const { context, heterogeneousProvider, parentMessageId, parentOperationId, prompt } = params;
+  const { context, heterogeneousProvider, imageList, parentMessageId, parentOperationId, prompt } =
+    params;
   const agentId = context.agentId;
   if (!agentId) throw new Error('agentId is required for heterogeneous agent');
 
@@ -132,6 +139,7 @@ const runHeterogeneousFromExistingMessage = async (
       assistantMessageId: assistantMsg.id,
       context,
       heterogeneousProvider,
+      imageList: imageList?.length ? imageList : undefined,
       message: prompt,
       operationId: heteroOpId,
       resumeSessionId,
@@ -526,6 +534,11 @@ export const generationSlice: StateCreator<
         await runHeterogeneousFromExistingMessage(chatStore, {
           context,
           heterogeneousProvider,
+          // Forward the original user message's images so regenerate re-runs
+          // the CLI with the same vision input as the first attempt. Without
+          // this, regenerate silently drops attachments (the send path reads
+          // imageList off the persisted user message; this path must too).
+          imageList: item.imageList,
           parentMessageId: messageId,
           parentOperationId: operationId,
           prompt: item.content,

--- a/src/features/Conversation/store/slices/generation/action.ts
+++ b/src/features/Conversation/store/slices/generation/action.ts
@@ -24,6 +24,7 @@ import {
   mergeAgentRuntimeInitialContexts,
   resolveActiveTopicDocumentInitialContext,
 } from '@/store/chat/utils/activeTopicDocumentContext';
+import { getElectronStoreState } from '@/store/electron';
 
 import { type Store as ConversationStore } from '../../action';
 
@@ -85,8 +86,11 @@ const runHeterogeneousFromExistingMessage = async (
   const topic = context.topicId
     ? topicSelectors.getTopicById(context.topicId)(chatStore)
     : undefined;
-  const agentWorkingDirectory =
-    agentByIdSelectors.getAgentWorkingDirectoryById(agentId)(getAgentStoreState());
+  const currentDeviceId = getElectronStoreState().gatewayDeviceInfo?.deviceId;
+  const agentWorkingDirectory = agentByIdSelectors.getAgentWorkingDirectoryById(
+    agentId,
+    currentDeviceId,
+  )(getAgentStoreState());
   const workingDirectory = topic?.metadata?.workingDirectory || agentWorkingDirectory;
 
   // Drops the saved sessionId when its bound cwd disagrees with the current

--- a/src/features/Conversation/store/slices/generation/regenerateHeteroImages.test.ts
+++ b/src/features/Conversation/store/slices/generation/regenerateHeteroImages.test.ts
@@ -1,0 +1,143 @@
+import { act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type ConversationContext } from '../../../types';
+import { createStore } from '../../index';
+
+// ── Mock the hetero runtime seam ──
+// regenerate (hetero) re-creates an assistant row, then delegates to
+// `executeHeterogeneousAgent`. We spy on that boundary and assert the original
+// user message's `imageList` is forwarded — the regression this guards against
+// is regenerate silently dropping image attachments (the send path forwards
+// them; this path must too).
+const mockExecuteHeterogeneousAgent = vi.fn();
+vi.mock('@/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor', () => ({
+  executeHeterogeneousAgent: (...args: any[]) => mockExecuteHeterogeneousAgent(...args),
+}));
+
+vi.mock('@/store/chat/slices/aiChat/actions/agentDispatcher', () => ({
+  selectRuntimeType: () => 'hetero',
+}));
+
+vi.mock('@/store/chat/slices/aiChat/actions/heteroResume', () => ({
+  resolveHeteroResume: () => ({ cwdChanged: false, resumeSessionId: 'sess-1' }),
+}));
+
+vi.mock('@/store/chat/utils/activeTopicDocumentContext', () => ({
+  mergeAgentRuntimeInitialContexts: () => undefined,
+  resolveActiveTopicDocumentInitialContext: async () => undefined,
+}));
+
+vi.mock('@/store/chat/slices/operation/selectors', () => ({
+  operationSelectors: { isMessageProcessing: () => () => false },
+}));
+
+vi.mock('@/services/message', () => ({
+  messageService: { createMessage: vi.fn(async () => ({ id: 'assistant-new' })) },
+}));
+
+vi.mock('@/store/agent', () => ({ getAgentStoreState: () => ({}) }));
+
+vi.mock('@/store/agent/selectors', () => ({
+  agentByIdSelectors: { getAgentWorkingDirectoryById: () => () => '/work/dir' },
+  agentSelectors: {
+    getAgentConfigById: () => () => ({
+      agencyConfig: {
+        executionTarget: 'local',
+        heterogeneousProvider: { type: 'claude-code' },
+      },
+    }),
+  },
+}));
+
+vi.mock('@/store/chat/selectors', () => ({
+  topicSelectors: { getTopicById: () => () => undefined },
+}));
+
+vi.mock('@/store/electron', () => ({
+  getElectronStoreState: () => ({ gatewayDeviceInfo: { deviceId: 'device-1' } }),
+}));
+
+vi.mock('@/components/AntdStaticMethods', () => ({
+  message: { info: vi.fn() },
+}));
+
+const noop = vi.fn();
+vi.mock('@/store/chat', () => ({
+  useChatStore: {
+    getState: vi.fn(() => ({
+      operations: {},
+      operationsByMessage: {},
+
+      associateMessageWithOperation: noop,
+      completeOperation: noop,
+      failOperation: noop,
+      internal_updateTopicLoading: noop,
+      isGatewayModeEnabled: () => false,
+      refreshMessages: vi.fn(async () => {}),
+      startOperation: vi.fn(() => ({ operationId: 'hetero-op-id' })),
+      switchMessageBranch: vi.fn(async () => {}),
+    })),
+    setState: vi.fn(),
+  },
+}));
+
+describe('regenerateUserMessage (hetero) — image forwarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forwards the original user message imageList to executeHeterogeneousAgent', async () => {
+    const context: ConversationContext = {
+      agentId: 'agent-1',
+      topicId: 'topic-1',
+      threadId: null,
+    };
+
+    const imageList = [{ alt: 'shot.png', id: 'img-1', url: 'https://x/img-1.png' }];
+
+    const store = createStore({ context });
+    act(() => {
+      store.setState({
+        displayMessages: [{ content: 'describe this', id: 'msg-1', imageList, role: 'user' }],
+        dbMessages: [{ content: 'describe this', id: 'msg-1', role: 'user' }],
+      } as any);
+    });
+
+    await act(async () => {
+      await store.getState().regenerateUserMessage('msg-1');
+    });
+
+    expect(mockExecuteHeterogeneousAgent).toHaveBeenCalledTimes(1);
+    const [, params] = mockExecuteHeterogeneousAgent.mock.calls[0];
+    expect(params).toMatchObject({
+      assistantMessageId: 'assistant-new',
+      imageList,
+      message: 'describe this',
+    });
+  });
+
+  it('passes undefined imageList when the original message had no images', async () => {
+    const context: ConversationContext = {
+      agentId: 'agent-1',
+      topicId: 'topic-1',
+      threadId: null,
+    };
+
+    const store = createStore({ context });
+    act(() => {
+      store.setState({
+        displayMessages: [{ content: 'hello', id: 'msg-1', role: 'user' }],
+        dbMessages: [{ content: 'hello', id: 'msg-1', role: 'user' }],
+      } as any);
+    });
+
+    await act(async () => {
+      await store.getState().regenerateUserMessage('msg-1');
+    });
+
+    expect(mockExecuteHeterogeneousAgent).toHaveBeenCalledTimes(1);
+    const [, params] = mockExecuteHeterogeneousAgent.mock.calls[0];
+    expect(params.imageList).toBeUndefined();
+  });
+});

--- a/src/helpers/parserPlaceholder/index.test.ts
+++ b/src/helpers/parserPlaceholder/index.test.ts
@@ -36,7 +36,7 @@ vi.mock('@/store/agent/selectors', () => ({
   agentSelectors: {
     currentAgentModel: () => 'gpt-4',
     currentAgentModelProvider: () => 'openai',
-    currentAgentWorkingDirectory: () => undefined,
+    currentAgentWorkingDirectory: () => () => undefined,
   },
 }));
 

--- a/src/helpers/parserPlaceholder/index.ts
+++ b/src/helpers/parserPlaceholder/index.ts
@@ -5,6 +5,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
+import { getElectronStoreState } from '@/store/electron';
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
 
@@ -161,7 +162,10 @@ export const VARIABLE_GENERATORS = {
     const topicWorkingDir = topicSelectors.currentTopicWorkingDirectory(useChatStore.getState());
     if (topicWorkingDir) return topicWorkingDir;
 
-    const agentWorkingDir = agentSelectors.currentAgentWorkingDirectory(useAgentStore.getState());
+    const currentDeviceId = getElectronStoreState().gatewayDeviceInfo?.deviceId;
+    const agentWorkingDir = agentSelectors.currentAgentWorkingDirectory(currentDeviceId)(
+      useAgentStore.getState(),
+    );
     return agentWorkingDir ?? '(not specified, use user Home directory as default)';
   },
 } as Record<string, () => string>;

--- a/src/routes/(main)/agent/features/Conversation/Header/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/index.tsx
@@ -10,6 +10,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
+import { useElectronStore } from '@/store/electron';
 
 import HeaderActions from './HeaderActions';
 import ParamsPanelToggle from './ParamsPanelToggle';
@@ -42,8 +43,11 @@ const headerStyles = createStaticStyles(({ css }) => ({
 const Header = memo(() => {
   const agentId = useChatStore((s) => s.activeAgentId);
   const topicWorkingDirectory = useChatStore(topicSelectors.currentTopicWorkingDirectory);
+  const currentDeviceId = useElectronStore((s) => s.gatewayDeviceInfo?.deviceId);
   const agentWorkingDirectory = useAgentStore((s) =>
-    agentId ? agentByIdSelectors.getAgentWorkingDirectoryById(agentId)(s) : undefined,
+    agentId
+      ? agentByIdSelectors.getAgentWorkingDirectoryById(agentId, currentDeviceId)(s)
+      : undefined,
   );
   const isLocalSystemEnabled = useAgentStore((s) =>
     agentId ? chatConfigByIdSelectors.isLocalSystemEnabledById(agentId)(s) : false,

--- a/src/store/agent/selectors/agentByIdSelectors.test.ts
+++ b/src/store/agent/selectors/agentByIdSelectors.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { globalAgentContextManager } from '@/helpers/GlobalAgentContextManager';
 import { type AgentStoreState } from '@/store/agent/initialState';
 import { initialAgentSliceState } from '@/store/agent/slices/agent/initialState';
 import { initialBuiltinAgentSliceState } from '@/store/agent/slices/builtin/initialState';
 
 import { agentByIdSelectors } from './agentByIdSelectors';
+
+// getAgentWorkingDirectoryById is desktop-only; force the desktop branch on.
+vi.mock('@lobechat/const', async (importOriginal) => ({
+  ...(await importOriginal()),
+  isDesktop: true,
+}));
 
 const createState = (overrides: Partial<AgentStoreState> = {}): AgentStoreState => ({
   ...initialAgentSliceState,
@@ -54,6 +61,66 @@ describe('agentByIdSelectors', () => {
         provider: undefined,
         systemRole: undefined,
       });
+    });
+  });
+
+  describe('getAgentWorkingDirectoryById', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    const stateWith = (config: Record<string, any>, localMap: Record<string, string> = {}) =>
+      createState({
+        agentMap: { 'agent-1': config },
+        localAgentWorkingDirectoryMap: localMap,
+      });
+
+    it('reads the per-device choice for the current (local) device', () => {
+      vi.spyOn(globalAgentContextManager, 'getContext').mockReturnValue({ homePath: '/home/me' });
+      const state = stateWith({
+        agencyConfig: { workingDirByDevice: { 'device-A': '/repos/agent-gateway' } },
+      });
+
+      expect(agentByIdSelectors.getAgentWorkingDirectoryById('agent-1', 'device-A')(state)).toBe(
+        '/repos/agent-gateway',
+      );
+    });
+
+    it('reads the bound device choice when the agent targets a device', () => {
+      vi.spyOn(globalAgentContextManager, 'getContext').mockReturnValue({ homePath: '/home/me' });
+      const state = stateWith({
+        agencyConfig: {
+          boundDeviceId: 'device-B',
+          executionTarget: 'device',
+          workingDirByDevice: { 'device-A': '/repos/local', 'device-B': '/repos/remote' },
+        },
+      });
+
+      // currentDeviceId is the local machine, but executionTarget=device → device-B wins
+      expect(agentByIdSelectors.getAgentWorkingDirectoryById('agent-1', 'device-A')(state)).toBe(
+        '/repos/remote',
+      );
+    });
+
+    it('falls back to the legacy per-agent value when no device choice exists', () => {
+      vi.spyOn(globalAgentContextManager, 'getContext').mockReturnValue({ homePath: '/home/me' });
+      const state = stateWith({ agencyConfig: {} }, { 'agent-1': '/repos/legacy' });
+
+      expect(agentByIdSelectors.getAgentWorkingDirectoryById('agent-1', 'device-A')(state)).toBe(
+        '/repos/legacy',
+      );
+    });
+
+    it('falls back to desktop/home path when nothing is set', () => {
+      vi.spyOn(globalAgentContextManager, 'getContext').mockReturnValue({
+        desktopPath: '/home/me/Desktop',
+        homePath: '/home/me',
+      });
+      const state = stateWith({ agencyConfig: {} });
+
+      expect(agentByIdSelectors.getAgentWorkingDirectoryById('agent-1', 'device-A')(state)).toBe(
+        '/home/me/Desktop',
+      );
     });
   });
 });

--- a/src/store/agent/selectors/agentByIdSelectors.ts
+++ b/src/store/agent/selectors/agentByIdSelectors.ts
@@ -8,6 +8,7 @@ import {
   type RuntimeEnvConfig,
 } from '@lobechat/types';
 
+import { resolveTargetDeviceId } from '@/helpers/agentWorkingDirectory';
 import { globalAgentContextManager } from '@/helpers/GlobalAgentContextManager';
 
 import { type AgentStoreState } from '../initialState';
@@ -85,15 +86,35 @@ const getAgentRuntimeEnvConfigById =
     agentSelectors.getAgentConfigById(agentId)(s)?.chatConfig?.runtimeEnv;
 
 /**
- * Get working directory by agentId
+ * Get the agent-level working directory by agentId.
+ *
+ * Precedence (the agent-owned slice only — topic overrides and device defaults
+ * are layered on by callers):
+ *
+ *   agent's per-device choice (`agencyConfig.workingDirByDevice[targetDeviceId]`)
+ *     > legacy per-agent localStorage value (pre-migration fallback)
+ *     > desktop path > home path
+ *
+ * `currentDeviceId` is passed in (not read cross-store) so hook callers stay
+ * reactive to device changes. The target device is resolved from it via
+ * `resolveTargetDeviceId`, so a device-bound agent reads its bound device's
+ * choice rather than the local machine's.
  */
 const getAgentWorkingDirectoryById =
-  (agentId: string) =>
+  (agentId: string, currentDeviceId?: string) =>
   (s: AgentStoreState): string | undefined => {
     if (!isDesktop) return;
 
     const ctx = globalAgentContextManager.getContext();
-    return s.localAgentWorkingDirectoryMap[agentId] ?? ctx.desktopPath ?? ctx.homePath;
+    const agencyConfig = agentSelectors.getAgentConfigById(agentId)(s)?.agencyConfig;
+    const targetDeviceId = resolveTargetDeviceId(agencyConfig, currentDeviceId);
+    const agentChoice = targetDeviceId
+      ? agencyConfig?.workingDirByDevice?.[targetDeviceId]
+      : undefined;
+
+    return (
+      agentChoice ?? s.localAgentWorkingDirectoryMap[agentId] ?? ctx.desktopPath ?? ctx.homePath
+    );
   };
 
 /**

--- a/src/store/agent/selectors/selectors.ts
+++ b/src/store/agent/selectors/selectors.ts
@@ -20,6 +20,7 @@ import { KnowledgeType } from '@lobechat/types';
 import { VoiceList } from '@lobehub/tts';
 
 import { DEFAULT_OPENING_QUESTIONS } from '@/features/AgentSetting/store/selectors';
+import { resolveTargetDeviceId } from '@/helpers/agentWorkingDirectory';
 import { globalAgentContextManager } from '@/helpers/GlobalAgentContextManager';
 import { filterToolIds } from '@/helpers/toolFilters';
 
@@ -260,20 +261,34 @@ const currentAgentRuntimeEnvConfig = (s: AgentStoreState): RuntimeEnvConfig | un
   currentAgentConfig(s)?.chatConfig?.runtimeEnv;
 
 /**
- * Get current agent's working directory
+ * Get the active agent's agent-level working directory.
+ *
+ * Precedence mirrors `getAgentWorkingDirectoryById` (the agent-owned slice only;
+ * topic overrides are layered on by callers):
+ *
+ *   agent's per-device choice (`agencyConfig.workingDirByDevice[targetDeviceId]`)
+ *     > legacy per-agent localStorage value > home path
+ *
+ * `currentDeviceId` is passed in (not read cross-store) so the target device is
+ * resolved correctly for device-bound agents and hook callers stay reactive.
  */
-const currentAgentWorkingDirectory = (s: AgentStoreState): string | undefined =>
-  (() => {
+const currentAgentWorkingDirectory =
+  (currentDeviceId?: string) =>
+  (s: AgentStoreState): string | undefined => {
     if (!isDesktop) return;
 
+    const homePath = globalAgentContextManager.getContext().homePath;
     const activeAgentId = s.activeAgentId;
-    if (!activeAgentId) return globalAgentContextManager.getContext().homePath;
+    if (!activeAgentId) return homePath;
 
-    return (
-      s.localAgentWorkingDirectoryMap[activeAgentId] ??
-      globalAgentContextManager.getContext().homePath
-    );
-  })();
+    const agencyConfig = currentAgentConfig(s)?.agencyConfig;
+    const targetDeviceId = resolveTargetDeviceId(agencyConfig, currentDeviceId);
+    const agentChoice = targetDeviceId
+      ? agencyConfig?.workingDirByDevice?.[targetDeviceId]
+      : undefined;
+
+    return agentChoice ?? s.localAgentWorkingDirectoryMap[activeAgentId] ?? homePath;
+  };
 
 const isCurrentAgentExternal = (s: AgentStoreState): boolean => !currentAgentData(s)?.virtual;
 

--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -59,7 +59,7 @@ vi.mock('@/services/electron/gatewayConnection', () => ({
 vi.mock('@/store/agent', () => ({ getAgentStoreState: () => ({}) }));
 
 vi.mock('@/store/agent/selectors', () => ({
-  agentSelectors: { currentAgentWorkingDirectory: () => undefined },
+  agentSelectors: { currentAgentWorkingDirectory: () => () => undefined },
   chatConfigByIdSelectors: { isLocalSystemEnabledById: () => () => mockRuntime.isLocal },
 }));
 

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -54,6 +54,7 @@ import {
   getCompressionCandidateMessageIds,
   hasRunningCompressionOperation,
 } from '@/store/chat/utils/compression';
+import { getElectronStoreState } from '@/store/electron';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { type StoreSetter } from '@/store/types';
@@ -524,8 +525,11 @@ export class ConversationLifecycleActionImpl {
       const existingTopic = operationContext.topicId
         ? topicSelectors.getTopicById(operationContext.topicId)(this.#get())
         : undefined;
-      const agentWorkingDirectory =
-        agentByIdSelectors.getAgentWorkingDirectoryById(agentId)(getAgentStoreState());
+      const currentDeviceId = getElectronStoreState().gatewayDeviceInfo?.deviceId;
+      const agentWorkingDirectory = agentByIdSelectors.getAgentWorkingDirectoryById(
+        agentId,
+        currentDeviceId,
+      )(getAgentStoreState());
       const workingDirectory = existingTopic?.metadata?.workingDirectory || agentWorkingDirectory;
 
       // Persist messages to DB first (same as client mode)

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -42,6 +42,7 @@ import {
   notifyDesktopHumanApprovalRequired,
   resolveNotificationNavigatePath,
 } from '@/store/chat/utils/desktopNotification';
+import { getElectronStoreState } from '@/store/electron';
 import { getServerConfigStoreState, serverConfigSelectors } from '@/store/serverConfig';
 import { getTaskStoreState } from '@/store/task';
 import { pageAgentRuntime } from '@/store/tool/slices/builtin/executors/lobe-page-agent';
@@ -331,7 +332,9 @@ export class StreamingExecutorActionImpl {
     };
 
     const topicWorkingDirectory = topicSelectors.currentTopicWorkingDirectory(this.#get());
-    const agentWorkingDirectory = agentSelectors.currentAgentWorkingDirectory(getAgentStoreState());
+    const currentDeviceId = getElectronStoreState().gatewayDeviceInfo?.deviceId;
+    const agentWorkingDirectory =
+      agentSelectors.currentAgentWorkingDirectory(currentDeviceId)(getAgentStoreState());
     const workingDirectory = topicWorkingDirectory ?? agentWorkingDirectory;
 
     // Create initial state or use provided state


### PR DESCRIPTION
### 💡 Description of Change

The heterogeneous (Claude Code / Codex) **regenerate / resend** path
(`runHeterogeneousFromExistingMessage`) only forwarded the text prompt to
`executeHeterogeneousAgent` — it never carried the original user message's
`imageList`.

The normal **send** path already reads `imageList` off the persisted user
message and passes it through to the CLI (`conversationLifecycle.ts`). The
regenerate path was asymmetric, so re-running an image turn lost the
attachment:

- When the session **couldn't be resumed** (e.g. cwd changed →
  `resolveHeteroResume` drops the sessionId), the image was gone entirely.
- When resume succeeded the prior image still lived in the CLI's session
  context, which is why this only reproduced *sometimes*.

#### Fix (3 edits, one file)

- `runHeterogeneousFromExistingMessage` now accepts an optional `imageList`
  and forwards it to `executeHeterogeneousAgent` (same shape as the send path).
- `regenerateUserMessage`'s hetero branch passes the original message's
  `item.imageList`.

### 🔗 Related

Part of the heterogeneous-agent vision support.

> **Stacked PR** — based on `fix/agent-working-dir-by-device` (#15591) because
> both edit the same `runHeterogeneousFromExistingMessage` function and #15591
> isn't on `canary` yet. **Retarget this PR's base to `canary` once #15591
> merges** (GitHub usually auto-retargets).

### ✅ How to Test

1. In a desktop hetero (Claude Code) agent, send a message **with an image
   attachment**, get a response.
2. Click **regenerate** on that turn.
3. The CLI should receive the same image again (vision input preserved),
   instead of re-running on text only.

Automated: `bunx vitest run src/features/Conversation/store/slices/generation/regenerateHeteroImages.test.ts`
— asserts `executeHeterogeneousAgent` receives the original `imageList`, and
`undefined` when the message had no images. Verified the image-forwarding case
**fails without the fix** and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)