### PR TITLE
🐛 fix(desktop): preserve Error cause across IPC so renderer sees real failure reason

### DIFF
--- a/apps/desktop/src/common/ipcError.test.ts
+++ b/apps/desktop/src/common/ipcError.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { fromIpcErrorEnvelope, isIpcErrorEnvelope, toIpcErrorEnvelope } from './ipcError';
+
+describe('ipcError envelope', () => {
+  it('round-trips an Error and preserves its cause + code', () => {
+    const cause = Object.assign(new Error('getaddrinfo ENOTFOUND example.com'), {
+      code: 'ENOTFOUND',
+    });
+    const error = new TypeError('fetch failed', { cause });
+
+    const envelope = toIpcErrorEnvelope(error);
+    expect(isIpcErrorEnvelope(envelope)).toBe(true);
+
+    const revived = fromIpcErrorEnvelope(envelope);
+    expect(revived).toBeInstanceOf(Error);
+    expect(revived.name).toBe('TypeError');
+    expect(revived.message).toBe('fetch failed');
+
+    const revivedCause = revived.cause as Error & { code?: unknown };
+    expect(revivedCause).toBeInstanceOf(Error);
+    expect(revivedCause.message).toBe('getaddrinfo ENOTFOUND example.com');
+    expect(revivedCause.code).toBe('ENOTFOUND');
+  });
+
+  it('is clone-safe: the envelope survives structuredClone (the IPC boundary)', () => {
+    const error = new Error('boom', { cause: new Error('root') });
+    const envelope = toIpcErrorEnvelope(error);
+
+    const cloned = structuredClone(envelope);
+    const revived = fromIpcErrorEnvelope(cloned);
+
+    expect(revived.message).toBe('boom');
+    expect((revived.cause as Error).message).toBe('root');
+  });
+
+  it('handles non-Error thrown values', () => {
+    const revived = fromIpcErrorEnvelope(toIpcErrorEnvelope('plain string failure'));
+    expect(revived.message).toBe('plain string failure');
+  });
+
+  it('caps a deep / cyclic cause chain instead of recursing forever', () => {
+    const a = new Error('a');
+    const b = new Error('b', { cause: a });
+    (a as { cause?: unknown }).cause = b; // cycle
+
+    // Should not throw (stack overflow) — depth is bounded.
+    expect(() => toIpcErrorEnvelope(b)).not.toThrow();
+  });
+
+  it('isIpcErrorEnvelope rejects plain values and look-alikes', () => {
+    expect(isIpcErrorEnvelope(null)).toBe(false);
+    expect(isIpcErrorEnvelope(undefined)).toBe(false);
+    expect(isIpcErrorEnvelope('error')).toBe(false);
+    expect(isIpcErrorEnvelope({ data: 'ok' })).toBe(false);
+    expect(isIpcErrorEnvelope({ __lobeIpcError__: false })).toBe(false);
+  });
+});

--- a/apps/desktop/src/common/ipcError.ts
+++ b/apps/desktop/src/common/ipcError.ts
@@ -1,0 +1,86 @@
+/**
+ * IPC error envelope.
+ *
+ * Electron's `ipcRenderer.invoke` rebuilds a thrown handler error from a
+ * *string* on the renderer side (roughly `new Error("Error invoking remote
+ * method '<channel>': " + String(mainError))`), so the original error object —
+ * including a non-enumerable `cause` — never crosses the boundary. The real
+ * failure reason (e.g. undici's `ENOTFOUND` / `ECONNREFUSED` hidden under a
+ * generic `TypeError: fetch failed`) is therefore lost.
+ *
+ * To preserve it, the main process *returns* a clone-safe envelope (a plain
+ * object) instead of throwing, and the preload `invoke` wrapper rebuilds a real
+ * `Error` (with `cause`) from the envelope before re-throwing — keeping the
+ * existing "promise rejects on failure" contract for every caller.
+ */
+
+const IPC_ERROR_MARKER = '__lobeIpcError__';
+
+/** Bound recursion on a deliberately malicious / cyclic `cause` chain. */
+const MAX_CAUSE_DEPTH = 5;
+
+export interface SerializedIpcError {
+  cause?: SerializedIpcError | string;
+  /** Node/undici machine-readable reason (`ENOTFOUND`, `ECONNREFUSED`, …). */
+  code?: unknown;
+  message: string;
+  name: string;
+  stack?: string;
+}
+
+export interface IpcErrorEnvelope {
+  error: SerializedIpcError;
+  [IPC_ERROR_MARKER]: true;
+}
+
+const serializeError = (value: unknown, depth: number): SerializedIpcError => {
+  if (value instanceof Error) {
+    const serialized: SerializedIpcError = { message: value.message, name: value.name };
+
+    if (typeof value.stack === 'string') serialized.stack = value.stack;
+
+    const { code } = value as { code?: unknown };
+    if (code !== undefined) serialized.code = code;
+
+    if (value.cause !== undefined && value.cause !== null && depth < MAX_CAUSE_DEPTH) {
+      serialized.cause =
+        value.cause instanceof Error ? serializeError(value.cause, depth + 1) : String(value.cause);
+    }
+
+    return serialized;
+  }
+
+  return { message: typeof value === 'string' ? value : String(value), name: 'Error' };
+};
+
+/** Build a clone-safe envelope from a thrown value (main process). */
+export const toIpcErrorEnvelope = (value: unknown): IpcErrorEnvelope => ({
+  [IPC_ERROR_MARKER]: true,
+  error: serializeError(value, 0),
+});
+
+/** Detect an envelope produced by {@link toIpcErrorEnvelope} (preload). */
+export const isIpcErrorEnvelope = (value: unknown): value is IpcErrorEnvelope =>
+  typeof value === 'object' &&
+  value !== null &&
+  (value as Record<string, unknown>)[IPC_ERROR_MARKER] === true;
+
+const reviveError = (serialized: SerializedIpcError): Error => {
+  const cause =
+    serialized.cause === undefined
+      ? undefined
+      : typeof serialized.cause === 'string'
+        ? serialized.cause
+        : reviveError(serialized.cause);
+
+  const error = new Error(serialized.message, cause === undefined ? undefined : { cause });
+  error.name = serialized.name;
+  if (serialized.stack !== undefined) error.stack = serialized.stack;
+  if (serialized.code !== undefined) (error as { code?: unknown }).code = serialized.code;
+
+  return error;
+};
+
+/** Rebuild a real `Error` (with `cause`) from an envelope (preload). */
+export const fromIpcErrorEnvelope = (envelope: IpcErrorEnvelope): Error =>
+  reviveError(envelope.error);

--- a/apps/desktop/src/main/utils/ipc/base.ts
+++ b/apps/desktop/src/main/utils/ipc/base.ts
@@ -13,6 +13,39 @@ export interface IpcContext {
 const methodMetadata = new WeakMap<any, Map<string, string>>();
 const ipcContextStorage = new AsyncLocalStorage<IpcContext>();
 
+/**
+ * Electron's IPC error serialization carries an Error's `message` / `stack` /
+ * `name` plus its *enumerable* own properties. A standard `cause` (set via
+ * `new Error(msg, { cause })`) is non-enumerable, so the real failure reason —
+ * e.g. undici wrapping `ENOTFOUND` / `ECONNREFUSED` under a generic
+ * `TypeError: fetch failed` — is dropped on the way to the renderer.
+ *
+ * Re-expose `cause` as an enumerable, plain (clone-safe) field so callers
+ * receive it alongside `message`. A nested Error is flattened to
+ * `{ name, message, code }` because it would otherwise lose its own
+ * non-enumerable props through the same serialization.
+ */
+const exposeErrorCause = (error: unknown): unknown => {
+  if (!(error instanceof Error) || error.cause === undefined || error.cause === null) {
+    return error;
+  }
+
+  const { cause } = error;
+  const serializableCause =
+    cause instanceof Error
+      ? { code: (cause as { code?: unknown }).code, message: cause.message, name: cause.name }
+      : cause;
+
+  Object.defineProperty(error, 'cause', {
+    configurable: true,
+    enumerable: true,
+    value: serializableCause,
+    writable: true,
+  });
+
+  return error;
+};
+
 // Decorator for IPC methods
 export function IpcMethod() {
   return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
@@ -63,7 +96,7 @@ export class IpcHandler {
           return await handler(...typedArgs);
         } catch (error) {
           console.error(`Error in IPC method ${channel}:`, error);
-          throw error;
+          throw exposeErrorCause(error);
         }
       });
     });

--- a/apps/desktop/src/main/utils/ipc/base.ts
+++ b/apps/desktop/src/main/utils/ipc/base.ts
@@ -3,6 +3,8 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import type { IpcMainInvokeEvent, WebContents } from 'electron';
 import { ipcMain } from 'electron';
 
+import { toIpcErrorEnvelope } from '~common/ipcError';
+
 // Base context for IPC methods
 export interface IpcContext {
   event: IpcMainInvokeEvent;
@@ -12,39 +14,6 @@ export interface IpcContext {
 // Metadata storage for decorated methods
 const methodMetadata = new WeakMap<any, Map<string, string>>();
 const ipcContextStorage = new AsyncLocalStorage<IpcContext>();
-
-/**
- * Electron's IPC error serialization carries an Error's `message` / `stack` /
- * `name` plus its *enumerable* own properties. A standard `cause` (set via
- * `new Error(msg, { cause })`) is non-enumerable, so the real failure reason —
- * e.g. undici wrapping `ENOTFOUND` / `ECONNREFUSED` under a generic
- * `TypeError: fetch failed` — is dropped on the way to the renderer.
- *
- * Re-expose `cause` as an enumerable, plain (clone-safe) field so callers
- * receive it alongside `message`. A nested Error is flattened to
- * `{ name, message, code }` because it would otherwise lose its own
- * non-enumerable props through the same serialization.
- */
-const exposeErrorCause = (error: unknown): unknown => {
-  if (!(error instanceof Error) || error.cause === undefined || error.cause === null) {
-    return error;
-  }
-
-  const { cause } = error;
-  const serializableCause =
-    cause instanceof Error
-      ? { code: (cause as { code?: unknown }).code, message: cause.message, name: cause.name }
-      : cause;
-
-  Object.defineProperty(error, 'cause', {
-    configurable: true,
-    enumerable: true,
-    value: serializableCause,
-    writable: true,
-  });
-
-  return error;
-};
 
 // Decorator for IPC methods
 export function IpcMethod() {
@@ -96,7 +65,11 @@ export class IpcHandler {
           return await handler(...typedArgs);
         } catch (error) {
           console.error(`Error in IPC method ${channel}:`, error);
-          throw exposeErrorCause(error);
+          // Return a clone-safe envelope rather than throwing: Electron rebuilds
+          // a thrown handler error from its string form, dropping `cause` and
+          // other structured fields. The preload `invoke` wrapper rebuilds a
+          // real Error from the envelope and re-throws it. See `~common/ipcError`.
+          return toIpcErrorEnvelope(error);
         }
       });
     });

--- a/apps/desktop/src/preload/invoke.test.ts
+++ b/apps/desktop/src/preload/invoke.test.ts
@@ -62,6 +62,30 @@ describe('invoke', () => {
     expect(mockIpcRendererInvoke).toHaveBeenCalledWith('system.getAppVersion');
   });
 
+  it('should rebuild and throw a real Error (with cause) from a main-process error envelope', async () => {
+    mockIpcRendererInvoke.mockResolvedValue({
+      __lobeIpcError__: true,
+      error: {
+        cause: { code: 'ENOTFOUND', message: 'getaddrinfo ENOTFOUND example.com', name: 'Error' },
+        message: 'fetch failed',
+        name: 'TypeError',
+      },
+    });
+
+    await expect(invoke('heterogeneousAgent.sendPrompt')).rejects.toMatchObject({
+      cause: { code: 'ENOTFOUND', message: 'getaddrinfo ENOTFOUND example.com' },
+      message: 'fetch failed',
+      name: 'TypeError',
+    });
+  });
+
+  it('should not treat a plain object result as an error envelope', async () => {
+    const result = { __lobeIpcError__: false, data: 'ok' };
+    mockIpcRendererInvoke.mockResolvedValue(result);
+
+    await expect(invoke('someEvent')).resolves.toEqual(result);
+  });
+
   it('should handle ipcRenderer returning undefined', async () => {
     mockIpcRendererInvoke.mockResolvedValue(undefined);
 

--- a/apps/desktop/src/preload/invoke.ts
+++ b/apps/desktop/src/preload/invoke.ts
@@ -1,8 +1,24 @@
 import { ipcRenderer } from 'electron';
 
+import { fromIpcErrorEnvelope, isIpcErrorEnvelope } from '~common/ipcError';
+
 type IpcInvoke = <T = unknown>(event: string, ...data: unknown[]) => Promise<T>;
 
 /**
- * Client-side method to invoke electron main process
+ * Client-side method to invoke electron main process.
+ *
+ * The main-process handler returns an error envelope instead of throwing (see
+ * `~common/ipcError`), so structured failure detail — notably `cause` — isn't
+ * flattened away by Electron's thrown-error serialization. Rebuild the real
+ * Error here and re-throw it, preserving the "promise rejects on failure"
+ * contract every caller already relies on.
  */
-export const invoke: IpcInvoke = async (event, ...data) => ipcRenderer.invoke(event, ...data);
+export const invoke: IpcInvoke = async (event, ...data) => {
+  const result = await ipcRenderer.invoke(event, ...data);
+
+  if (isIpcErrorEnvelope(result)) {
+    throw fromIpcErrorEnvelope(result);
+  }
+
+  return result as never;
+};

--- a/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
@@ -166,9 +166,19 @@ const toHeterogeneousAgentMessageError = (error: unknown, agentType?: string): C
         : 'Agent execution failed';
 
   // Surface the underlying `cause` (e.g. undici's `ENOTFOUND` / `ECONNREFUSED`
-  // hidden under a generic `TypeError: fetch failed`). The main process
-  // re-exposes it as an enumerable field so it survives IPC serialization.
-  const cause = error instanceof Error ? error.cause : undefined;
+  // hidden under a generic `TypeError: fetch failed`). The desktop IPC layer
+  // ferries `cause` across via an error envelope (see `~common/ipcError`).
+  // Flatten any Error cause to a plain object — `ChatMessageError.body` is
+  // persisted as DB JSONB, where a raw Error would serialize to `{}`.
+  const rawCause = error instanceof Error ? error.cause : undefined;
+  const cause =
+    rawCause instanceof Error
+      ? {
+          code: (rawCause as { code?: unknown }).code,
+          message: rawCause.message,
+          name: rawCause.name,
+        }
+      : rawCause;
 
   return {
     body: cause === undefined || cause === null ? { message } : { cause, message },

--- a/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
@@ -165,8 +165,13 @@ const toHeterogeneousAgentMessageError = (error: unknown, agentType?: string): C
         ? error
         : 'Agent execution failed';
 
+  // Surface the underlying `cause` (e.g. undici's `ENOTFOUND` / `ECONNREFUSED`
+  // hidden under a generic `TypeError: fetch failed`). The main process
+  // re-exposes it as an enumerable field so it survives IPC serialization.
+  const cause = error instanceof Error ? error.cause : undefined;
+
   return {
-    body: { message },
+    body: cause === undefined || cause === null ? { message } : { cause, message },
     message,
     type: AgentRuntimeErrorType.AgentRuntimeError,
   };


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

When a main-process IPC handler fails (e.g. undici wrapping `ENOTFOUND` / `ECONNREFUSED` under a generic `TypeError: fetch failed`), the renderer only ever saw the opaque top-level message and lost the actionable `cause`.

**Why the obvious fix doesn't work:** Electron's `ipcRenderer.invoke` rebuilds a thrown handler error from its *string* form (`Error invoking remote method '<channel>': <String(error)>`) — it constructs a brand-new `Error`, so the original error object and any `cause` (enumerable or not) never cross the boundary.

**Fix — an explicit serializable error envelope:**

- **`apps/desktop/src/common/ipcError.ts`** (shared by main + preload via `~common`): `toIpcErrorEnvelope` builds a clone-safe plain object that recursively captures `name` / `message` / `stack` / `code` / `cause` (depth-bounded against cyclic chains); `isIpcErrorEnvelope` + `fromIpcErrorEnvelope` rebuild a real `Error` (with `cause`).
- **IPC base handler** (`utils/ipc/base.ts`): **returns** the envelope instead of throwing.
- **preload `invoke`** (`preload/invoke.ts`): detects the envelope and re-throws a rebuilt `Error` — preserving the "promise rejects on failure" contract every caller relies on.
- **Heterogeneous agent executor**: flattens the Error `cause` to a plain object for the DB-persisted `ChatMessageError.body`.

Applies to **every** IPC method, not just the heterogeneous-agent path.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

New unit tests cover the envelope round-trip (incl. `structuredClone` across the boundary, cyclic-cause cap) and the preload unwrap. `bun run type-check` shows no new errors in touched files.

End-to-end: trigger any main-process remote method that fails with an undici `TypeError: fetch failed` (e.g. a heterogeneous-agent prompt with an image when the image host is unreachable). The renderer error now carries `cause` (e.g. `{ name: 'Error', message: 'getaddrinfo ENOTFOUND …', code: 'ENOTFOUND' }`).

#### 📝 Additional Information

Groundwork for diagnosing the "heterogeneous agent image send → `fetch failed`" report — exposes the real `cause.code` so we can pick the correct downstream fix. The image-download fix itself is intentionally **not** in this PR.

> Addresses review feedback: the initial enumerable-`cause` approach couldn't survive Electron's thrown-error serialization; replaced with a return-based serializable envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)