### PR TITLE
🔨 chore(deps): pin @lobehub/editor to stable ^4.17.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -287,7 +287,7 @@
     "@lobehub/analytics": "^1.6.2",
     "@lobehub/charts": "^5.0.0",
     "@lobehub/desktop-ipc-typings": "workspace:*",
-    "@lobehub/editor": "https://pkg.pr.new/@lobehub/editor@90f7402",
+    "@lobehub/editor": "^4.17.1",
     "@lobehub/icons": "^5.0.0",
     "@lobehub/market-sdk": "0.34.0",
     "@lobehub/tts": "^5.1.2",


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Switch `@lobehub/editor` from the `pkg.pr.new/@lobehub/editor@90f7402` preview snapshot back to the published `^4.17.1` release now that the corresponding fixes have landed upstream. Keeps the dependency on the public registry so installs remain reproducible without the temporary preview build.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Run `pnpm install` and confirm the resolved `@lobehub/editor` matches the published 4.17.x release; smoke-test the page editor (load, edit, save) to confirm parity with the preview snapshot.

#### 📝 Additional Information

Dependency-only change; no source code touched.