### PR TITLE
🐛 fix(desktop): trace Session Expired cause and resume onboarding at Login

### DIFF
--- a/apps/desktop/src/main/controllers/AuthCtr.ts
+++ b/apps/desktop/src/main/controllers/AuthCtr.ts
@@ -321,7 +321,9 @@ export default class AuthCtr extends ControllerModule {
             this.stopAutoRefresh();
             await this.remoteServerConfigCtr.clearTokens();
             await this.remoteServerConfigCtr.setRemoteServerConfig({ active: false });
-            this.broadcastAuthorizationRequired();
+            this.broadcastAuthorizationRequired(
+              `auto-refresh:non_retryable ${result.error ?? ''}`.trim(),
+            );
           } else {
             // For other errors (after retries exhausted), log but don't clear tokens immediately
             // The next refresh cycle will retry
@@ -432,7 +434,7 @@ export default class AuthCtr extends ControllerModule {
           this.stopAutoRefresh();
           await this.remoteServerConfigCtr.clearTokens();
           await this.remoteServerConfigCtr.setRemoteServerConfig({ active: false });
-          this.broadcastAuthorizationRequired();
+          this.broadcastAuthorizationRequired(`refresh:non_retryable ${result.error ?? ''}`.trim());
         } else {
           // For transient errors, don't clear tokens - allow manual retry
           logger.warn('Refresh failed but error may be transient, tokens preserved for retry');
@@ -450,7 +452,7 @@ export default class AuthCtr extends ControllerModule {
         this.stopAutoRefresh();
         await this.remoteServerConfigCtr.clearTokens();
         await this.remoteServerConfigCtr.setRemoteServerConfig({ active: false });
-        this.broadcastAuthorizationRequired();
+        this.broadcastAuthorizationRequired(`refresh:exception ${errorMessage}`);
       }
 
       return { error: errorMessage, success: false };
@@ -618,15 +620,17 @@ export default class AuthCtr extends ControllerModule {
   }
 
   /**
-   * Broadcast authorization required event
+   * Broadcast authorization required event.
+   * `reason` is a short tag (e.g. `refresh:invalid_grant`, `startup:non_retryable`)
+   * recorded so the renderer can log why the Session Expired modal appeared.
    */
-  private broadcastAuthorizationRequired() {
-    logger.debug('Broadcasting authorizationRequired event to all windows');
+  private broadcastAuthorizationRequired(reason: string) {
+    logger.info(`Broadcasting authorizationRequired event (reason=${reason})`);
     const allWindows = BrowserWindow.getAllWindows();
 
     for (const win of allWindows) {
       if (!win.isDestroyed()) {
-        win.webContents.send('authorizationRequired');
+        win.webContents.send('authorizationRequired', { reason });
       }
     }
   }
@@ -751,7 +755,9 @@ export default class AuthCtr extends ControllerModule {
         logger.warn('Non-retryable error during proactive refresh, clearing tokens');
         await this.remoteServerConfigCtr.clearTokens();
         await this.remoteServerConfigCtr.setRemoteServerConfig({ active: false });
-        this.broadcastAuthorizationRequired();
+        this.broadcastAuthorizationRequired(
+          `startup:non_retryable ${refreshResult.error ?? ''}`.trim(),
+        );
       } else {
         // For transient errors, still start auto-refresh timer to retry later
         logger.warn('Transient error during proactive refresh, will retry via auto-refresh');

--- a/apps/desktop/src/main/controllers/__tests__/AuthCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/AuthCtr.test.ts
@@ -797,7 +797,12 @@ describe('AuthCtr', () => {
         expect(mockRemoteServerConfigCtr.setRemoteServerConfig).toHaveBeenCalledWith({
           active: false,
         });
-        expect(mockWindow.webContents.send).toHaveBeenCalledWith('authorizationRequired');
+        expect(mockWindow.webContents.send).toHaveBeenCalledWith(
+          'authorizationRequired',
+          expect.objectContaining({
+            reason: expect.stringContaining('startup:non_retryable'),
+          }),
+        );
       });
 
       it('should preserve tokens on transient error', async () => {

--- a/apps/desktop/src/main/core/infrastructure/BackendProxyProtocolManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/BackendProxyProtocolManager.ts
@@ -32,22 +32,30 @@ export class BackendProxyProtocolManager {
   private readonly logger = createLogger('core:BackendProxyProtocolManager');
 
   private authRequiredDebounceTimer: NodeJS.Timeout | null = null;
+  private pendingAuthRequiredReason: string | null = null;
   private static readonly AUTH_REQUIRED_DEBOUNCE_MS = 1000;
 
-  private notifyAuthorizationRequired() {
+  private notifyAuthorizationRequired(reason: string) {
     // Trailing-edge debounce: coalesce rapid 401 bursts and fire AFTER the burst settles.
     // This ensures the IPC event is sent after the renderer has had time to mount listeners.
+    // The most recent reason wins — within a burst they almost always describe the same cause.
+    this.pendingAuthRequiredReason = reason;
+
     if (this.authRequiredDebounceTimer) {
       clearTimeout(this.authRequiredDebounceTimer);
     }
 
     this.authRequiredDebounceTimer = setTimeout(() => {
       this.authRequiredDebounceTimer = null;
+      const finalReason = this.pendingAuthRequiredReason ?? reason;
+      this.pendingAuthRequiredReason = null;
+
+      this.logger.info(`Broadcasting authorizationRequired (reason=${finalReason})`);
 
       const allWindows = BrowserWindow.getAllWindows();
       for (const win of allWindows) {
         if (!win.isDestroyed()) {
-          win.webContents.send('authorizationRequired');
+          win.webContents.send('authorizationRequired', { reason: finalReason });
         }
       }
     }, BackendProxyProtocolManager.AUTH_REQUIRED_DEBOUNCE_MS);
@@ -196,7 +204,32 @@ export class BackendProxyProtocolManager {
     // Other failures keep 401 without this header (e.g., invalid API keys) and must not notify here.
     const authRequired = upstreamResponse.headers.get(AUTH_REQUIRED_HEADER) === 'true';
     if (authRequired) {
-      this.notifyAuthorizationRequired();
+      const pathTag = (() => {
+        try {
+          return new URL(rewrittenUrl).pathname;
+        } catch {
+          return rewrittenUrl;
+        }
+      })();
+      const sourceTag = context.source ? `${context.source}:` : '';
+      const wwwAuth = upstreamResponse.headers.get('www-authenticate') ?? '';
+      // Clone before forwarding the body downstream — the original stream stays
+      // intact for the renderer. Body snippet is truncated to keep logs small
+      // and to avoid leaking large payloads if the server ever returns one.
+      let bodySnippet: string;
+      try {
+        bodySnippet = (await upstreamResponse.clone().text()).slice(0, 300).replaceAll(/\s+/g, ' ');
+      } catch (error) {
+        bodySnippet = `<body-read-failed:${error instanceof Error ? error.message : 'unknown'}>`;
+      }
+      const parts = [
+        `proxy:${sourceTag}status=${upstreamResponse.status}`,
+        `${request.method} ${pathTag}`,
+        `hadToken=${Boolean(token)}`,
+      ];
+      if (wwwAuth) parts.push(`wwwAuth=${wwwAuth}`);
+      if (bodySnippet) parts.push(`body=${bodySnippet}`);
+      this.notifyAuthorizationRequired(parts.join(' '));
     }
 
     return new Response(upstreamResponse.body, {

--- a/apps/desktop/src/main/core/infrastructure/__tests__/BackendProxyProtocolManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/BackendProxyProtocolManager.test.ts
@@ -258,7 +258,63 @@ describe('BackendProxyProtocolManager', () => {
 
     expect(send).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1000);
-    expect(send).toHaveBeenCalledWith('authorizationRequired');
+    expect(send).toHaveBeenCalledWith(
+      'authorizationRequired',
+      expect.objectContaining({
+        reason: expect.stringContaining('status=207'),
+      }),
+    );
+  });
+
+  it('captures www-authenticate, body snippet and hadToken in reason on 401', async () => {
+    vi.useFakeTimers();
+    const send = vi.fn();
+    vi.mocked(BrowserWindow.getAllWindows).mockReturnValue([
+      { isDestroyed: () => false, webContents: { send } },
+    ] as any);
+
+    const manager = new BackendProxyProtocolManager();
+    const session = {} as any;
+
+    const upstreamBody = JSON.stringify({
+      error: { json: { data: { code: 'UNAUTHORIZED' }, message: 'token expired at 2026-06-09' } },
+    });
+    const headers = new Headers({
+      [AUTH_REQUIRED_HEADER]: 'true',
+      'Content-Type': 'application/json',
+      'www-authenticate': 'Bearer error="invalid_token", error_description="expired"',
+    });
+    const fetchMock = vi.fn<FetchMock>(
+      async () => new Response(upstreamBody, { headers, status: 401, statusText: 'Unauthorized' }),
+    );
+    vi.stubGlobal('fetch', fetchMock as any);
+
+    manager.registerWithRemoteBaseUrl(session, {
+      getAccessToken: async () => 'fake-token',
+      getRemoteBaseUrl: async () => 'https://remote.example.com',
+    });
+
+    const response = await manager.proxy(
+      {
+        headers: new Headers(),
+        method: 'POST',
+        url: 'app://renderer/trpc/lambda/me',
+      } as any,
+      session,
+    );
+
+    // Original body is still readable by the downstream caller — clone() must not consume it.
+    expect(await response!.text()).toBe(upstreamBody);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(send).toHaveBeenCalledTimes(1);
+    const [, payload] = send.mock.calls[0];
+    expect(payload.reason).toContain('status=401');
+    expect(payload.reason).toContain('POST /trpc/lambda/me');
+    expect(payload.reason).toContain('hadToken=true');
+    expect(payload.reason).toContain('wwwAuth=Bearer error="invalid_token"');
+    expect(payload.reason).toContain('UNAUTHORIZED');
+    expect(payload.reason).toContain('token expired');
   });
 
   describe('createAppRequestInterceptor', () => {

--- a/packages/electron-client-ipc/src/events/remoteServer.ts
+++ b/packages/electron-client-ipc/src/events/remoteServer.ts
@@ -30,7 +30,13 @@ export interface RemoteServerBroadcastEvents {
   authorizationFailed: (params: { error: string }) => void;
   /** Broadcast authorization progress for UI updates */
   authorizationProgress: (params: AuthorizationProgress) => void;
-  authorizationRequired: (params: void) => void;
+  /**
+   * Broadcast when the main process needs the user to re-authenticate.
+   * `reason` is a short, log-friendly tag describing why (e.g. `refresh:invalid_grant`,
+   * `proxy:status=401`, `startup:non_retryable`). Useful for diagnosing why the
+   * Session Expired modal showed up in field reports.
+   */
+  authorizationRequired: (params: { reason: string }) => void;
   authorizationSuccessful: (params: void) => void;
   remoteServerConfigUpdated: (params: void) => void;
   tokenRefreshed: (params: void) => void;

--- a/src/features/Electron/AuthRequiredModal/index.tsx
+++ b/src/features/Electron/AuthRequiredModal/index.tsx
@@ -9,12 +9,14 @@ import {
   ModalFooter,
   type ModalInstance,
 } from '@lobehub/ui/base-ui';
-import { t as i18nt } from 'i18next';
+import debug from 'debug';
 import { AlertCircle, LogIn } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useElectronStore } from '@/store/electron';
+
+const log = debug('lobe-client:auth-required-modal');
 
 interface AuthRequiredModalContentProps {
   onActionReady: (api: { signIn: () => Promise<void> }) => void;
@@ -94,6 +96,7 @@ const AuthRequiredFooter = memo<FooterProps>(({ isSigningIn, onLater, onSignIn }
 AuthRequiredFooter.displayName = 'AuthRequiredFooter';
 
 export const useAuthRequiredModal = () => {
+  const { t } = useTranslation('auth');
   const instanceRef = useRef<ModalInstance | null>(null);
 
   const open = useCallback(() => {
@@ -140,11 +143,11 @@ export const useAuthRequiredModal = () => {
       title: (
         <Flexbox horizontal align="center" gap={8}>
           <Icon icon={AlertCircle} />
-          {i18nt('authModal.title', { ns: 'auth' })}
+          {t('authModal.title')}
         </Flexbox>
       ),
     });
-  }, []);
+  }, [t]);
 
   return { open };
 };
@@ -152,14 +155,25 @@ export const useAuthRequiredModal = () => {
 const AuthRequiredModal = memo(() => {
   const { open } = useAuthRequiredModal();
 
-  useWatchBroadcast('authorizationRequired', () => {
+  useWatchBroadcast('authorizationRequired', (payload) => {
+    const reason = payload?.reason ?? 'unknown';
     const state = useElectronStore.getState();
-    if (state.isConnectionDrawerOpen) return;
+    if (state.isConnectionDrawerOpen) {
+      log('authorizationRequired ignored (connection drawer open). reason=%s', reason);
+      return;
+    }
     // Wait until remote sync config has loaded once (avoid a flash before SWR resolves).
     // Do not gate on `dataSyncConfig.active`: after sign-out `active` is false but 401 + X-Auth-Required
     // still means the user must re-authenticate; gating on active would suppress the modal forever.
-    if (!state.isInitRemoteServerConfig) return;
+    if (!state.isInitRemoteServerConfig) {
+      log(
+        'authorizationRequired ignored (remote server config not initialized). reason=%s',
+        reason,
+      );
+      return;
+    }
 
+    log('authorizationRequired: opening modal. reason=%s', reason);
     open();
   });
 

--- a/src/routes/(desktop)/desktop-onboarding/index.tsx
+++ b/src/routes/(desktop)/desktop-onboarding/index.tsx
@@ -13,10 +13,13 @@ import DataModeStep from './features/DataModeStep';
 import LoginStep from './features/LoginStep';
 import PermissionsStep from './features/PermissionsStep';
 import WelcomeStep from './features/WelcomeStep';
+import { resolveInitialScreen } from './resolveInitialScreen';
 import {
   clearDesktopOnboardingScreen,
+  getDesktopOnboardingEverCompleted,
   getDesktopOnboardingScreen,
   setDesktopOnboardingCompleted,
+  setDesktopOnboardingEverCompleted,
   setDesktopOnboardingScreen,
 } from './storage';
 import { DesktopOnboardingScreen, isDesktopOnboardingScreen } from './types';
@@ -40,11 +43,13 @@ const DesktopOnboardingPage = memo(() => {
       ];
 
   const resolveScreenForPlatform = useCallback(
-    (screen: DesktopOnboardingScreen) => {
-      if (!isMac && screen === DesktopOnboardingScreen.Permissions)
-        return DesktopOnboardingScreen.DataMode;
-      return screen;
-    },
+    (screen: DesktopOnboardingScreen) =>
+      resolveInitialScreen({
+        everCompleted: false,
+        isMac,
+        requested: screen,
+        saved: null,
+      }),
     [isMac],
   );
 
@@ -62,10 +67,12 @@ const DesktopOnboardingPage = memo(() => {
   useEffect(() => {
     if (isLoading) return;
 
-    const saved = getDesktopOnboardingScreen();
-    const requested = getRequestedScreenFromUrl();
-
-    const initial = resolveScreenForPlatform(requested ?? saved ?? DesktopOnboardingScreen.Welcome);
+    const initial = resolveInitialScreen({
+      everCompleted: getDesktopOnboardingEverCompleted(),
+      isMac,
+      requested: getRequestedScreenFromUrl(),
+      saved: getDesktopOnboardingScreen(),
+    });
 
     setCurrentScreen(initial);
 
@@ -74,13 +81,7 @@ const DesktopOnboardingPage = memo(() => {
     if (currentUrlScreen !== initial) {
       setSearchParams({ screen: initial });
     }
-  }, [
-    getRequestedScreenFromUrl,
-    isLoading,
-    resolveScreenForPlatform,
-    searchParams,
-    setSearchParams,
-  ]);
+  }, [getRequestedScreenFromUrl, isLoading, isMac, searchParams, setSearchParams]);
 
   // Persist current screen to localStorage.
   useEffect(() => {
@@ -147,6 +148,7 @@ const DesktopOnboardingPage = memo(() => {
       if (!next) {
         // Complete onboarding - mark as completed and clear persisted screen state
         setDesktopOnboardingCompleted();
+        setDesktopOnboardingEverCompleted();
         clearDesktopOnboardingScreen();
 
         // Restore window minimum size before hard reload (cleanup won't run due to hard navigation)

--- a/src/routes/(desktop)/desktop-onboarding/resolveInitialScreen.test.ts
+++ b/src/routes/(desktop)/desktop-onboarding/resolveInitialScreen.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveInitialScreen } from './resolveInitialScreen';
+import { DesktopOnboardingScreen } from './types';
+
+describe('resolveInitialScreen', () => {
+  it('returns Welcome for first-time users with no saved/requested screen', () => {
+    expect(
+      resolveInitialScreen({
+        everCompleted: false,
+        isMac: true,
+        requested: null,
+        saved: null,
+      }),
+    ).toBe(DesktopOnboardingScreen.Welcome);
+  });
+
+  it('returns Login when the user has previously completed onboarding (returning user)', () => {
+    expect(
+      resolveInitialScreen({
+        everCompleted: true,
+        isMac: true,
+        requested: null,
+        saved: null,
+      }),
+    ).toBe(DesktopOnboardingScreen.Login);
+  });
+
+  it('prefers the saved (in-progress) screen over the ever-completed fallback', () => {
+    // Edge case: an in-progress user who somehow has ever-completed=true (e.g.
+    // re-entered after first completion). The mid-flow position still wins.
+    expect(
+      resolveInitialScreen({
+        everCompleted: true,
+        isMac: true,
+        requested: null,
+        saved: DesktopOnboardingScreen.DataMode,
+      }),
+    ).toBe(DesktopOnboardingScreen.DataMode);
+  });
+
+  it('honours an explicit ?screen= URL parameter over everything else', () => {
+    expect(
+      resolveInitialScreen({
+        everCompleted: true,
+        isMac: true,
+        requested: DesktopOnboardingScreen.Welcome,
+        saved: DesktopOnboardingScreen.DataMode,
+      }),
+    ).toBe(DesktopOnboardingScreen.Welcome);
+  });
+
+  it('rewrites Permissions to DataMode on non-macOS', () => {
+    expect(
+      resolveInitialScreen({
+        everCompleted: false,
+        isMac: false,
+        requested: DesktopOnboardingScreen.Permissions,
+        saved: null,
+      }),
+    ).toBe(DesktopOnboardingScreen.DataMode);
+  });
+});

--- a/src/routes/(desktop)/desktop-onboarding/resolveInitialScreen.ts
+++ b/src/routes/(desktop)/desktop-onboarding/resolveInitialScreen.ts
@@ -1,0 +1,41 @@
+import { DesktopOnboardingScreen } from './types';
+
+interface ResolveInitialScreenInput {
+  /** Has the user previously completed onboarding on this install? */
+  everCompleted: boolean;
+  /** Running on macOS — drives the Permissions screen fallback. */
+  isMac: boolean;
+  /** Explicit `?screen=` query parameter, when present and valid. */
+  requested: DesktopOnboardingScreen | null;
+  /** Whatever screen the component last persisted, or `null` if cleared/missing. */
+  saved: DesktopOnboardingScreen | null;
+}
+
+/**
+ * Pick which onboarding screen the user should land on when entering
+ * `/desktop-onboarding`. Priority:
+ *
+ * 1. `requested` from the URL — explicit deep-link wins.
+ * 2. `saved` — a mid-flow user resumes where they left off.
+ * 3. `Login` if the user has *ever* completed onboarding (returning user after
+ *    sign-out / token expiry — Welcome / Permissions / DataMode are first-run
+ *    screens and would force the whole flow again).
+ * 4. `Welcome` for first-time users.
+ *
+ * On non-macOS, `Permissions` is rewritten to `DataMode` since the macOS-only
+ * screen has no useful content.
+ */
+export const resolveInitialScreen = ({
+  everCompleted,
+  isMac,
+  requested,
+  saved,
+}: ResolveInitialScreenInput): DesktopOnboardingScreen => {
+  const fallback = everCompleted ? DesktopOnboardingScreen.Login : DesktopOnboardingScreen.Welcome;
+  const chosen = requested ?? saved ?? fallback;
+
+  if (!isMac && chosen === DesktopOnboardingScreen.Permissions) {
+    return DesktopOnboardingScreen.DataMode;
+  }
+  return chosen;
+};

--- a/src/routes/(desktop)/desktop-onboarding/storage.test.ts
+++ b/src/routes/(desktop)/desktop-onboarding/storage.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DESKTOP_ONBOARDING_EVER_COMPLETED_KEY,
+  getDesktopOnboardingEverCompleted,
+  setDesktopOnboardingEverCompleted,
+} from './storage';
+
+describe('desktop-onboarding storage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  describe('ever-completed flag', () => {
+    it('returns false by default', () => {
+      expect(getDesktopOnboardingEverCompleted()).toBe(false);
+    });
+
+    it('persists set-and-read across calls', () => {
+      expect(setDesktopOnboardingEverCompleted()).toBe(true);
+      expect(getDesktopOnboardingEverCompleted()).toBe(true);
+      expect(window.localStorage.getItem(DESKTOP_ONBOARDING_EVER_COMPLETED_KEY)).toBe('1');
+    });
+
+    it('returns false when localStorage holds an unrelated value', () => {
+      window.localStorage.setItem(DESKTOP_ONBOARDING_EVER_COMPLETED_KEY, '0');
+      expect(getDesktopOnboardingEverCompleted()).toBe(false);
+    });
+  });
+});

--- a/src/routes/(desktop)/desktop-onboarding/storage.ts
+++ b/src/routes/(desktop)/desktop-onboarding/storage.ts
@@ -2,6 +2,7 @@ import { type DesktopOnboardingScreen } from './types';
 import { isDesktopOnboardingScreen } from './types';
 
 export const DESKTOP_ONBOARDING_COMPLETED_KEY = 'lobechat:desktop:onboarding:completed:v1';
+export const DESKTOP_ONBOARDING_EVER_COMPLETED_KEY = 'lobechat:desktop:onboarding:everCompleted:v1';
 export const DESKTOP_ONBOARDING_SCREEN_KEY = 'lobechat:desktop:onboarding:screen:v1';
 
 /**
@@ -26,6 +27,37 @@ export const setDesktopOnboardingCompleted = () => {
 
   try {
     window.sessionStorage.setItem(DESKTOP_ONBOARDING_COMPLETED_KEY, '1');
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Whether the user has *ever* completed desktop onboarding on this install.
+ * Backed by localStorage so it survives quit/relaunch — used to skip first-run
+ * screens (Welcome / Permissions / DataMode) when a returning user is sent
+ * back to /desktop-onboarding (e.g. token refresh failed, sign-out).
+ */
+export const getDesktopOnboardingEverCompleted = () => {
+  if (typeof window === 'undefined') return false;
+
+  try {
+    return window.localStorage.getItem(DESKTOP_ONBOARDING_EVER_COMPLETED_KEY) === '1';
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Mark desktop onboarding as completed permanently. Should be called once on
+ * first-time completion and is never cleared.
+ */
+export const setDesktopOnboardingEverCompleted = () => {
+  if (typeof window === 'undefined') return false;
+
+  try {
+    window.localStorage.setItem(DESKTOP_ONBOARDING_EVER_COMPLETED_KEY, '1');
     return true;
   } catch {
     return false;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No public GitHub issue tracked for this; surfaced via internal triage. -->

#### 🔀 Description of Change

Two related improvements to the desktop re-auth flow.

**1. Trace the cause of the Session Expired modal.**

Today the `authorizationRequired` IPC event is fired with no payload, so it is impossible to tell from logs why the desktop "Session Expired" modal appeared. This PR carries a `reason` tag on the event and writes it to `electron-log` in production. Reasons are produced at every emission site:

- `proxy:<source>:status=… <METHOD> <path> hadToken=… wwwAuth=… body=…` — when an upstream `X-Auth-Required` header arrives. The body snippet is read via `Response.clone().text()` so the downstream stream is not consumed; it is truncated to 300 chars with whitespace collapsed.
- `auto-refresh:non_retryable <err>` — non-retryable failure inside the auto-refresh timer.
- `refresh:non_retryable <err>` — non-retryable failure from `refreshAccessToken`.
- `refresh:exception <err>` — caught exception in the same path.
- `startup:non_retryable <err>` — proactive refresh on startup failed non-retryably.

Renderer-side, `AuthRequiredModal` logs the reason through the `debug` package (`lobe-client:auth-required-modal`).

**2. Fix returning users landing on the Welcome screen of desktop onboarding.**

Reproducer: log in once → token refresh fails non-retryably (`active` flips to `false`, tokens cleared) → dismiss the Session Expired modal → quit → relaunch. `BrowserManager` sees `isRemoteServerConfigured() === false` and routes to `/desktop-onboarding`. The page reads `getDesktopOnboardingScreen()` (in-progress screen, cleared at first completion) and falls back to `Welcome`, forcing the full flow again — even though the user only needs to sign in.

The page now consults a persistent `everCompleted` flag in `localStorage` (set once when the flow finishes) and resumes at the `Login` screen for anyone who has previously completed onboarding. First-time users still land on `Welcome`. The screen-resolution logic is extracted into a pure `resolveInitialScreen` helper.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Unit tests:

- `BackendProxyProtocolManager.test.ts` — asserts the new payload, `hadToken`, `wwwAuth`, body snippet on 401 + `X-Auth-Required`; verifies `clone()` does not consume the downstream stream.
- `AuthCtr.test.ts` — verifies the IPC payload includes the `startup:non_retryable` reason.
- `resolveInitialScreen.test.ts` — first-time vs returning, in-progress saved screen wins, URL `?screen=` wins, non-mac Permissions rewrite.
- `storage.test.ts` — `everCompleted` default/set/get round-trip.

Manual:

1. Sign in to cloud, invalidate the refresh token (e.g. server-side revoke), dismiss the Session Expired modal, quit, relaunch → land on `/desktop-onboarding?screen=login` (not `?screen=welcome`).
2. Tail `~/Library/Logs/<AppName>/main.log`; trigger a stale-token request → see `Broadcasting authorizationRequired (reason=proxy:...)` with the upstream body snippet.

#### 📝 Additional Information

No DB / migration / API surface changes. The `authorizationRequired` IPC event payload changes from `void` to `{ reason: string }`; only the desktop renderer consumes it and is updated in the same PR.