### PR TITLE
📝 docs(agents): replace device-gateway with server in apps tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ lobehub/
 ├── apps/
 │   ├── desktop/            # Electron desktop app
 │   ├── cli/                # LobeHub CLI
-│   └── device-gateway/     # Device gateway service
+│   └── server/             # Server service
 ├── packages/               # Shared packages (@lobechat/*)
 │   ├── database/           # Database schemas, models, repositories
 │   ├── agent-runtime/      # Agent runtime


### PR DESCRIPTION
#### 💻 Change Type

- [x] 📝 docs

#### 🔗 Related Issue

<!-- No related issue -->

#### 🔀 Description of Change

The `apps/` directory tree in `AGENTS.md` listed a `device-gateway/` service that no longer exists in the repository. The actual subprojects under `apps/` are `desktop/`, `cli/`, and `server/`.

This updates the doc to replace the stale `device-gateway/` entry with the real `server/` service, keeping the structure map in sync with the codebase.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Docs-only change — verify the `apps/` tree in `AGENTS.md` matches `ls apps/` (`cli`, `desktop`, `server`).

#### 📝 Additional Information

Pure documentation edit, single line in `AGENTS.md`. No code or behavior impact.