### PR TITLE
chore: add home free credit badge business slot

### DIFF
--- a/locales/en-US/home.json
+++ b/locales/en-US/home.json
@@ -38,6 +38,7 @@
   "brief.title": "Brief",
   "brief.viewAllTasks": "View all tasks",
   "brief.viewRun": "View run",
+  "freeCreditBadge.label": "Exclusive {{amount}} free credits for {{model}}",
   "project.create": "New project",
   "project.deleteConfirm": "This project will be deleted and can't be recovered. Confirm to continue.",
   "recommendations.heteroAgent.cta": "Add Agent",

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -38,6 +38,7 @@
   "brief.title": "简报",
   "brief.viewAllTasks": "查看全部任务",
   "brief.viewRun": "查看运行轨迹",
+  "freeCreditBadge.label": "{{model}} 免费 {{amount}} 积分专属额度",
   "project.create": "新建项目",
   "project.deleteConfirm": "此项目将被删除且无法恢复。确认继续操作。",
   "recommendations.heteroAgent.cta": "添加助手",

--- a/packages/locales/src/default/home.ts
+++ b/packages/locales/src/default/home.ts
@@ -40,6 +40,7 @@ export default {
   'brief.title': 'Brief',
   'brief.viewAllTasks': 'View all tasks',
   'brief.viewRun': 'View run',
+  'freeCreditBadge.label': 'Exclusive {{amount}} free credits for {{model}}',
   'project.create': 'New project',
   'project.deleteConfirm':
     "This project will be deleted and can't be recovered. Confirm to continue.",

--- a/src/business/client/features/HomeFreeCreditBadge.tsx
+++ b/src/business/client/features/HomeFreeCreditBadge.tsx
@@ -1,0 +1,3 @@
+export default function HomeFreeCreditBadge() {
+  return null;
+}

--- a/src/routes/(main)/home/features/index.tsx
+++ b/src/routes/(main)/home/features/index.tsx
@@ -3,6 +3,7 @@
 import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
 
+import HomeFreeCreditBadge from '@/business/client/features/HomeFreeCreditBadge';
 import DailyBrief from '@/features/DailyBrief';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/slices/auth/selectors';
@@ -16,6 +17,7 @@ const Home = memo(() => {
 
   return (
     <Flexbox gap={40}>
+      <HomeFreeCreditBadge />
       <Flexbox gap={24}>
         <Flexbox gap={8}>
           <AgentSelect />


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Add a `HomeFreeCreditBadge` business slot on the home page, following the existing `VideoFreeQuotaInfo` pattern:

- New stub `src/business/client/features/HomeFreeCreditBadge.tsx` that renders `null` in the open-source build.
- Mount it at the top of the home content (`src/routes/(main)/home/features/index.tsx`), above the agent select block. Since the stub renders `null`, OSS layout is unchanged (no extra flex gap).
- Add the `freeCreditBadge.label` locale key (`packages/locales/src/default/home.ts`) with interpolated `{{model}}` / `{{amount}}` placeholders, plus hand-written en-US and zh-CN mirrors.

#### 🧪 How to Test

- OSS build: home page renders exactly as before (stub returns `null`).
- Business build: the slot implementation renders a centered pill badge above the home hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)