### PR TITLE
🐛 fix: type fable starter config

### DIFF
--- a/src/routes/(main)/home/features/InputArea/StarterList.tsx
+++ b/src/routes/(main)/home/features/InputArea/StarterList.tsx
@@ -5,7 +5,10 @@ import { createStaticStyles, cx } from 'antd-style';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useBusinessModelModeConfig } from '@/business/client/hooks/useBusinessAgentMode';
+import {
+  type BusinessModelModeConfig,
+  useBusinessModelModeConfig,
+} from '@/business/client/hooks/useBusinessAgentMode';
 import type { HomeNewModelItem } from '@/business/client/hooks/useHomeNewModels';
 import { useHomeNewModels } from '@/business/client/hooks/useHomeNewModels';
 import { useStableNavigate } from '@/hooks/useStableNavigate';
@@ -82,7 +85,7 @@ const StarterList = memo(() => {
           const currentModel = agentByIdSelectors.getAgentModelById(activeAgentId)(agentState);
           const currentProvider =
             agentByIdSelectors.getAgentModelProviderById(activeAgentId)(agentState);
-          const nextConfig = applyBusinessModelModeConfig({
+          const nextConfig: BusinessModelModeConfig = applyBusinessModelModeConfig({
             model: item.model,
             provider,
           });


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-10179

#### 🔀 Description of Change

Explicitly type the home starter model config after applying the business model mode override so `chatConfig` is available to TypeScript.

This fixes the Vercel build failure on cloud main:

```text
StarterList.tsx(90,24): error TS2339: Property 'chatConfig' does not exist on type '{ model: string; provider: string; }'.
```

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

```bash
NODE_OPTIONS=--max-old-space-size=8192 bun run type-check:vercel
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Type-only fix. Runtime behavior is unchanged.
