### PR TITLE
chore: clean [LOBE-XXX] code annotations (2026-06-10)

### DIFF
--- a/apps/cli/src/commands/hetero.test.ts
+++ b/apps/cli/src/commands/hetero.test.ts
@@ -650,7 +650,7 @@ describe('hetero exec command', () => {
   });
 
   it('resets the per-message text accumulator at message boundaries (no cross-message duplication)', async () => {
-    // LOBE-10157 Bug 3: the `replace` snapshot accumulator must not span
+    // The `replace` snapshot accumulator must not span
     // message boundaries. Two assistant messages separated by a
     // stream_end/stream_start boundary must each snapshot only their OWN
     // text — otherwise the second message re-emits the first's text verbatim.

--- a/apps/cli/src/commands/hetero.ts
+++ b/apps/cli/src/commands/hetero.ts
@@ -261,7 +261,7 @@ class SerialServerIngester {
     // adapter's `openMainMessage`) must reset it — otherwise it spans the
     // whole run and every later message's snapshot re-emits all prior
     // messages' text verbatim, which the server then persists into the new
-    // DB message (LOBE-10157 Bug 3: cross-message text duplication). Reset
+    // DB message: cross-message text duplication. Reset
     // AFTER flushing the just-ended message's pending snapshot above.
     if (event.type === 'stream_start' || event.type === 'stream_end') {
       this.accumulatedText = '';

--- a/apps/server/src/modules/ModelRuntime/index.ts
+++ b/apps/server/src/modules/ModelRuntime/index.ts
@@ -408,7 +408,7 @@ export const initModelRuntimeFromDB = async (
 ): Promise<ModelRuntime> => {
   // 1. Get user's provider configuration from database
   // NOTE: workspace-scoped ai_infra is deferred until the ai_infra surrogate-`_id`
-  // PK migration (LOBE-10056) lands; AiProviderModel stays personal-scoped for now.
+  // PK migration lands; AiProviderModel stays personal-scoped for now.
   const aiProviderModel = new AiProviderModel(db, userId);
 
   // Use getAiProviderById with KeyVaultsGateKeeper.getUserKeyVaults as decryptor

--- a/packages/database/src/models/rbac.ts
+++ b/packages/database/src/models/rbac.ts
@@ -251,7 +251,7 @@ export class RbacModel {
 
   /**
    * List all roles defined inside a workspace (both built-in and custom).
-   * Used by the upcoming custom-role admin UI (LOBE-9193) and any client that
+   * Used by the custom-role admin UI and any client that
    * wants to show available roles for a workspace.
    */
   listWorkspaceRoles = async (workspaceId: string): Promise<RoleItem[]> => {

--- a/scripts/codemodWorkspaceNav.ts
+++ b/scripts/codemodWorkspaceNav.ts
@@ -6,7 +6,7 @@
  *   <Link to="/{shared}">                          → <WorkspaceLink to="/{shared}">
  *
  * Idempotent. Re-run after rebasing the lobehub submodule onto upstream canary
- * to re-apply Step B's workspace-aware navigation patches (LOBE-9024).
+ * to re-apply Step B workspace-aware navigation patches.
  *
  * Strategy:
  *   - Scope: lobehub/src/{features,routes,hooks} excluding tests, the router

--- a/src/features/Conversation/Markdown/plugins/Link/parse.test.ts
+++ b/src/features/Conversation/Markdown/plugins/Link/parse.test.ts
@@ -32,9 +32,9 @@ describe('parseLobeLink', () => {
   });
 
   it('parses linear issue', () => {
-    expect(parseLobeLink('https://linear.app/lobehub/issue/LOBE-10141/codex-pptx-preview')).toEqual(
+    expect(parseLobeLink('https://linear.app/lobehub/issue/TST-10001/codex-pptx-preview')).toEqual(
       {
-        canonicalLabel: 'LOBE-10141',
+        canonicalLabel: 'TST-10001',
         kind: 'linear',
       },
     );

--- a/src/features/Conversation/Markdown/plugins/Link/parse.ts
+++ b/src/features/Conversation/Markdown/plugins/Link/parse.ts
@@ -5,7 +5,7 @@ export type LobeLinkKind = 'github' | 'linear' | 'email' | 'generic';
 export interface ParsedLobeLink {
   /**
    * Canonical label used when the link has no author-provided text, e.g.
-   * `lobehub/lobehub#15554` / `LOBE-10141` / `@lobehub/ui` / the full URL.
+   * `lobehub/lobehub#15554` / `TST-10001` / `@lobehub/ui` / the full URL.
    */
   canonicalLabel: string;
   /** Host for generic links, used to fetch a favicon. */
@@ -84,7 +84,7 @@ export const parseLobeLink = (href?: string): ParsedLobeLink | null => {
   }
 
   if (host === 'linear.app') {
-    // workspace/issue/LOBE-123/slug
+    // workspace/issue/MY-123/slug
     const issueIndex = segments.indexOf('issue');
     const id = issueIndex >= 0 ? segments[issueIndex + 1] : undefined;
     if (id) return { canonicalLabel: id.toUpperCase(), kind: 'linear' };


### PR DESCRIPTION
## Changes

Daily automated scan and cleanup of `LOBE-XXX` formatted annotations in source code.

### Files changed (7)

| File | Change |
|------|--------|
| `apps/cli/src/commands/hetero.ts` | Remove LOBE-10157 marker, keep cross-message dedup context |
| `apps/cli/src/commands/hetero.test.ts` | Remove LOBE-10157 marker in test comment |
| `apps/server/src/modules/ModelRuntime/index.ts` | Remove LOBE-10056, keep PK migration note |
| `packages/database/src/models/rbac.ts` | Remove LOBE-9193 from JSDoc, keep API context |
| `scripts/codemodWorkspaceNav.ts` | Remove LOBE-9024 from description |
| `src/features/Conversation/Markdown/plugins/Link/parse.ts` | Replace LOBE-10141/LOBE-123 with generic IDs |
| `src/features/Conversation/Markdown/plugins/Link/parse.test.ts` | Replace LOBE-10141 test values with generic IDs |

Generated automatically on 2026-06-10 02:07:54 UTC.