### PR TITLE
✨ feat: land new signups directly on onboarding

### DIFF
--- a/src/app/[variants]/(auth)/signin/useSignIn.test.ts
+++ b/src/app/[variants]/(auth)/signin/useSignIn.test.ts
@@ -306,7 +306,7 @@ describe('useSignIn', () => {
       });
 
       expect(mockSignInSocial).toHaveBeenCalledWith(
-        expect.objectContaining({ provider: 'google' }),
+        expect.objectContaining({ newUserCallbackURL: '/onboarding', provider: 'google' }),
       );
       expect(mockMessageError).not.toHaveBeenCalled();
     });
@@ -321,7 +321,7 @@ describe('useSignIn', () => {
       });
 
       expect(mockSignInOauth2).toHaveBeenCalledWith(
-        expect.objectContaining({ providerId: 'custom-oidc' }),
+        expect.objectContaining({ newUserCallbackURL: '/onboarding', providerId: 'custom-oidc' }),
       );
     });
 

--- a/src/app/[variants]/(auth)/signin/useSignIn.ts
+++ b/src/app/[variants]/(auth)/signin/useSignIn.ts
@@ -11,6 +11,7 @@ import { message } from '@/components/AntdStaticMethods';
 import { trackLoginOrSignupClicked } from '@/features/User/UserLoginOrSignup/trackLoginOrSignupClicked';
 import { requestPasswordReset, signIn } from '@/libs/better-auth/auth-client';
 import { isBuiltinProvider, normalizeProviderId } from '@/libs/better-auth/utils/client';
+import { buildOnboardingRedirectUrl } from '@/utils/onboardingRedirect';
 
 import { useAuthServerConfigStore } from '../_layout/AuthServerConfigProvider';
 import { EMAIL_REGEX, USERNAME_REGEX } from './SignInEmailStep';
@@ -70,7 +71,12 @@ export const useSignIn = () => {
       if (!emailValue) return;
 
       const callbackUrl = searchParams.get('callbackUrl') || '/';
-      const { error } = await signIn.magicLink({ callbackURL: callbackUrl, email: emailValue });
+      const { error } = await signIn.magicLink({
+        callbackURL: callbackUrl,
+        email: emailValue,
+        // First-time magic-link users are signups — land them on onboarding first
+        newUserCallbackURL: buildOnboardingRedirectUrl(callbackUrl),
+      });
       if (error) {
         message.error(error.message || t('betterAuth.signin.magicLinkError'));
         return;
@@ -223,17 +229,21 @@ export const useSignIn = () => {
       }
 
       const callbackUrl = searchParams.get('callbackUrl') || '/';
+      // First-time OAuth users are signups — land them on onboarding first
+      const newUserCallbackURL = buildOnboardingRedirectUrl(callbackUrl);
       const additionalData = await getAdditionalData();
       const signInWithAdditionalData = async () =>
         isBuiltinProvider(normalizedProvider)
           ? await signIn.social({
               additionalData,
               callbackURL: callbackUrl,
+              newUserCallbackURL,
               provider: normalizedProvider,
             })
           : await signIn.oauth2({
               additionalData,
               callbackURL: callbackUrl,
+              newUserCallbackURL,
               providerId: normalizedProvider,
             });
 

--- a/src/app/[variants]/(auth)/signup/[[...signup]]/useSignUp.test.ts
+++ b/src/app/[variants]/(auth)/signup/[[...signup]]/useSignUp.test.ts
@@ -97,7 +97,7 @@ describe('useSignUp', () => {
       );
     });
 
-    it('should redirect to callbackUrl on success', async () => {
+    it('should redirect to onboarding on success', async () => {
       mockSignUpEmail.mockResolvedValue({ error: null });
 
       const { result } = renderHook(() => useSignUp());
@@ -106,10 +106,10 @@ describe('useSignUp', () => {
         await result.current.onSubmit(validValues);
       });
 
-      expect(mockPush).toHaveBeenCalledWith('/');
+      expect(mockPush).toHaveBeenCalledWith('/onboarding');
     });
 
-    it('should use callbackUrl from search params', async () => {
+    it('should thread callbackUrl from search params through onboarding', async () => {
       mockSearchParamsGet.mockImplementation((key: string) =>
         key === 'callbackUrl' ? '/dashboard' : null,
       );
@@ -122,9 +122,9 @@ describe('useSignUp', () => {
       });
 
       expect(mockSignUpEmail).toHaveBeenCalledWith(
-        expect.objectContaining({ callbackURL: '/dashboard' }),
+        expect.objectContaining({ callbackURL: '/onboarding?callbackUrl=%2Fdashboard' }),
       );
-      expect(mockPush).toHaveBeenCalledWith('/dashboard');
+      expect(mockPush).toHaveBeenCalledWith('/onboarding?callbackUrl=%2Fdashboard');
     });
 
     it('should redirect to verify-email when email verification is enabled', async () => {
@@ -223,7 +223,7 @@ describe('useSignUp', () => {
         }),
       );
       expect(mockMessageError).not.toHaveBeenCalled();
-      expect(mockPush).toHaveBeenCalledWith('/');
+      expect(mockPush).toHaveBeenCalledWith('/onboarding');
     });
 
     it('should stop sign up when captcha modal is cancelled', async () => {

--- a/src/app/[variants]/(auth)/signup/[[...signup]]/useSignUp.ts
+++ b/src/app/[variants]/(auth)/signup/[[...signup]]/useSignUp.ts
@@ -9,6 +9,7 @@ import { useBusinessSignup } from '@/business/client/hooks/useBusinessSignup';
 import { message } from '@/components/AntdStaticMethods';
 import { trackLoginOrSignupClicked } from '@/features/User/UserLoginOrSignup/trackLoginOrSignupClicked';
 import { signUp } from '@/libs/better-auth/auth-client';
+import { buildOnboardingRedirectUrl } from '@/utils/onboardingRedirect';
 
 import { useAuthServerConfigStore } from '../../_layout/AuthServerConfigProvider';
 import type { AuthFetchOptions } from '../../utils/authFetchOptions';
@@ -49,12 +50,15 @@ export const useSignUp = () => {
       }
 
       const callbackUrl = searchParams.get('callbackUrl') || '/';
+      // New users always go through onboarding first; the original target is
+      // threaded via the `callbackUrl` query param and restored on finish.
+      const redirectUrl = buildOnboardingRedirectUrl(callbackUrl);
       const username = values.email.split('@')[0];
       const fetchOptions = await getFetchOptions();
 
       const submit = async (nextFetchOptions?: AuthFetchOptions) =>
         signUp.email({
-          callbackURL: callbackUrl,
+          callbackURL: redirectUrl,
           email: values.email,
           fetchOptions: nextFetchOptions,
           name: username,
@@ -96,10 +100,10 @@ export const useSignUp = () => {
 
       if (enableEmailVerification) {
         router.push(
-          `/verify-email?email=${encodeURIComponent(values.email)}&callbackUrl=${encodeURIComponent(callbackUrl)}`,
+          `/verify-email?email=${encodeURIComponent(values.email)}&callbackUrl=${encodeURIComponent(redirectUrl)}`,
         );
       } else {
-        router.push(callbackUrl);
+        router.push(redirectUrl);
       }
     } catch {
       message.error(t('betterAuth.signup.error'));

--- a/src/features/Onboarding/Agent/CompletionPanel.tsx
+++ b/src/features/Onboarding/Agent/CompletionPanel.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { useAgentMeta } from '@/features/Conversation/hooks/useAgentMeta';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import LobeMessage from '@/routes/onboarding/components/LobeMessage';
+import { consumeOnboardingCallbackUrl } from '@/utils/onboardingRedirect';
 
 import FeedbackPanel from './FeedbackPanel';
 import MessengerIntegrations from './MessengerIntegrations';
@@ -57,7 +58,9 @@ const CompletionPanel = memo<CompletionPanelProps>(
               style={{ marginTop: 8 }}
               type={'primary'}
               onClick={() => {
-                if (finishTargetUrl) window.location.assign(finishTargetUrl);
+                // The original signup target takes priority over continuing the onboarding topic
+                const target = consumeOnboardingCallbackUrl() || finishTargetUrl;
+                if (target) window.location.assign(target);
               }}
             >
               {t('agent.enterApp')}

--- a/src/features/Onboarding/Agent/index.tsx
+++ b/src/features/Onboarding/Agent/index.tsx
@@ -34,6 +34,7 @@ import { useChatStore } from '@/store/chat';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 import { useUserStore } from '@/store/user';
 import { isDev } from '@/utils/env';
+import { peekOnboardingCallbackUrl } from '@/utils/onboardingRedirect';
 
 import AnalyticsBridge from './AnalyticsBridge';
 import { resolveAgentOnboardingContext } from './context';
@@ -261,7 +262,9 @@ const AgentOnboardingPage = memo(() => {
         flow: 'agent',
         hasTopic: !!topicId,
         targetUrl:
-          inboxAgentId && topicId ? SESSION_CHAT_TOPIC_URL(inboxAgentId, topicId) : undefined,
+          // A threaded signup target (if any) wins over the onboarding topic on finish
+          peekOnboardingCallbackUrl() ??
+          (inboxAgentId && topicId ? SESSION_CHAT_TOPIC_URL(inboxAgentId, topicId) : undefined),
       });
     },
     [inboxAgentId],

--- a/src/features/Onboarding/Common/index.test.tsx
+++ b/src/features/Onboarding/Common/index.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const metrics = {
@@ -19,6 +19,20 @@ interface RenderOptions {
   serverConfigInit?: boolean;
   setOnboardingStep?: ReturnType<typeof vi.fn>;
 }
+
+const BranchPage = ({ label, testId }: { label: string; testId: string }) => {
+  const location = useLocation();
+
+  return (
+    <div>
+      <span>{label}</span>
+      <span data-testid={testId}>
+        {location.pathname}
+        {location.search}
+      </span>
+    </div>
+  );
+};
 
 const renderCommon = async ({
   AGENT_ONBOARDING_ENABLED = true,
@@ -113,8 +127,14 @@ const renderCommon = async ({
     <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
         <Route element={<CommonOnboardingPage />} path="/onboarding" />
-        <Route element={<div>Agent onboarding</div>} path="/onboarding/agent" />
-        <Route element={<div>Classic onboarding</div>} path="/onboarding/classic" />
+        <Route
+          element={<BranchPage label="Agent onboarding" testId="agent-branch-location" />}
+          path="/onboarding/agent"
+        />
+        <Route
+          element={<BranchPage label="Classic onboarding" testId="classic-branch-location" />}
+          path="/onboarding/classic"
+        />
       </Routes>
     </MemoryRouter>,
   );
@@ -169,6 +189,18 @@ describe('CommonOnboardingPage', () => {
   it('redirects to /onboarding/agent when shared prefix is complete and agent flag is on', async () => {
     await renderCommon({ commonStepsCompleted: true, enableAgentOnboarding: true });
     expect(screen.getByText('Agent onboarding')).toBeInTheDocument();
+  });
+
+  it('threads callbackUrl when redirecting to the agent branch', async () => {
+    await renderCommon({
+      commonStepsCompleted: true,
+      enableAgentOnboarding: true,
+      initialEntry: '/onboarding?callbackUrl=%2Fsettings%3Ftab%3Dprofile',
+    });
+
+    expect(screen.getByTestId('agent-branch-location')).toHaveTextContent(
+      '/onboarding/agent?callbackUrl=%2Fsettings%3Ftab%3Dprofile',
+    );
   });
 
   it('redirects to /onboarding/classic when shared prefix is complete and agent flag is off', async () => {

--- a/src/features/Onboarding/Common/index.tsx
+++ b/src/features/Onboarding/Common/index.tsx
@@ -19,7 +19,7 @@ import {
 import { useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { onboardingSelectors } from '@/store/user/selectors';
-import { clearStaleOnboardingCallbackUrl } from '@/utils/onboardingRedirect';
+import { clearStaleOnboardingCallbackUrl, isSafeRedirectPath } from '@/utils/onboardingRedirect';
 
 /**
  * Remap a `currentStep` persisted under the old 5-step classic flow
@@ -42,6 +42,15 @@ const COMMON_STEP_TRACKING = {
   1: { flow: 'common', step: 'telemetry', stepIndex: 1 },
   2: { flow: 'common', step: 'response_language', stepIndex: 2 },
 } as const;
+
+const appendCallbackUrl = (path: string, searchParams: URLSearchParams): string => {
+  const callbackUrl = searchParams.get('callbackUrl');
+  if (!callbackUrl || !isSafeRedirectPath(callbackUrl)) return path;
+
+  const params = new URLSearchParams();
+  params.set('callbackUrl', callbackUrl);
+  return `${path}?${params.toString()}`;
+};
 
 const CommonOnboardingPage = memo(() => {
   const isUserStateInit = useUserStore((s) => s.isUserStateInit);
@@ -130,7 +139,7 @@ const CommonOnboardingPage = memo(() => {
       enableAgentOnboarding: !!enableAgentOnboarding,
       isDesktop,
     });
-    return <Navigate replace to={branchPath} />;
+    return <Navigate replace to={appendCallbackUrl(branchPath, searchParams)} />;
   }
 
   return (

--- a/src/features/Onboarding/Common/index.tsx
+++ b/src/features/Onboarding/Common/index.tsx
@@ -19,6 +19,7 @@ import {
 import { useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { onboardingSelectors } from '@/store/user/selectors';
+import { clearStaleOnboardingCallbackUrl } from '@/utils/onboardingRedirect';
 
 /**
  * Remap a `currentStep` persisted under the old 5-step classic flow
@@ -75,6 +76,15 @@ const CommonOnboardingPage = memo(() => {
     }
     remappedRef.current = true;
   }, [isUserStateInit]);
+
+  // This component only mounts on top-level entries to `/onboarding` (fresh
+  // signup landings and `?step` re-entries from the branch's back button), so
+  // mount is the one safe point to drop a stale callback stashed by a
+  // previously abandoned attempt — later search changes are internal step
+  // navigations that must keep the stash.
+  useEffect(() => {
+    clearStaleOnboardingCallbackUrl(window.location.pathname, window.location.search);
+  }, []);
 
   useEffect(() => {
     if (__TEST__) return;

--- a/src/layout/GlobalProvider/useUserStateRedirect.ts
+++ b/src/layout/GlobalProvider/useUserStateRedirect.ts
@@ -26,12 +26,6 @@ export const useWebUserStateRedirect = () =>
 
     if (!onboardingSelectors.needsOnboarding(state)) return;
 
-    // Skip onboarding when the user lands on any agent page with a message param
-    // (e.g. "Try in LobeHub" links from Skills Marketplace). The /agent/inbox slug
-    // may be rewritten to /agent/{resolvedId} by AgentIdSync before this callback
-    // fires, so matching only /agent/inbox would miss the resolved-slug case.
-    if (pathname.startsWith('/agent/') && new URLSearchParams(search).has('message')) return;
-
     redirectToOnboarding(pathname, search);
   }, []);
 

--- a/src/layout/GlobalProvider/useUserStateRedirect.ts
+++ b/src/layout/GlobalProvider/useUserStateRedirect.ts
@@ -5,10 +5,12 @@ import { useCallback } from 'react';
 import { isDesktop } from '@/const/version';
 import { onboardingSelectors } from '@/store/user/selectors';
 import { type UserInitializationState } from '@/types/user';
+import { buildOnboardingRedirectUrl } from '@/utils/onboardingRedirect';
 
-const redirectIfNotOn = (currentPath: string, path: string) => {
-  if (!currentPath.startsWith(path)) {
-    window.location.href = path;
+const redirectToOnboarding = (currentPath: string, search: string) => {
+  if (!currentPath.startsWith('/onboarding')) {
+    // Thread the page the user was on so onboarding finish points return there
+    window.location.href = buildOnboardingRedirectUrl(currentPath + search);
   }
 };
 
@@ -30,7 +32,7 @@ export const useWebUserStateRedirect = () =>
     // fires, so matching only /agent/inbox would miss the resolved-slug case.
     if (pathname.startsWith('/agent/') && new URLSearchParams(search).has('message')) return;
 
-    redirectIfNotOn(pathname, '/onboarding');
+    redirectToOnboarding(pathname, search);
   }, []);
 
 export const useUserStateRedirect = () => {

--- a/src/routes/onboarding/_layout/index.tsx
+++ b/src/routes/onboarding/_layout/index.tsx
@@ -6,7 +6,7 @@ import { MAX_ONBOARDING_STEPS } from '@lobechat/types';
 import { Center, Flexbox, Text } from '@lobehub/ui';
 import { Divider } from 'antd';
 import { cx, useTheme } from 'antd-style';
-import { type FC, type MouseEvent, type PropsWithChildren, useCallback } from 'react';
+import { type FC, type MouseEvent, type PropsWithChildren, useCallback, useEffect } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -17,6 +17,7 @@ import { useIsDark } from '@/hooks/useIsDark';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
+import { stashOnboardingCallbackUrl } from '@/utils/onboardingRedirect';
 
 import { styles } from './style';
 
@@ -25,8 +26,15 @@ const OnBoardingContainer: FC<PropsWithChildren> = ({ children }) => {
   const isMobile = useIsMobile();
   const theme = useTheme();
   const { t } = useTranslation('onboarding');
-  const { pathname } = useLocation();
+  const { pathname, search } = useLocation();
   const navigate = useNavigate();
+
+  // Signup flows land here with a threaded `callbackUrl`; stash it so finish
+  // points can restore the original target after onboarding completes.
+  useEffect(() => {
+    stashOnboardingCallbackUrl(search);
+  }, [search]);
+
   const setOnboardingStep = useUserStore((s) => s.setOnboardingStep);
   const enableAgentOnboarding = useServerConfigStore((s) => s.featureFlags.enableAgentOnboarding);
   const serverConfigInit = useServerConfigStore((s) => s.serverConfigInit);

--- a/src/routes/onboarding/features/AgentPickerStep/index.test.tsx
+++ b/src/routes/onboarding/features/AgentPickerStep/index.test.tsx
@@ -5,6 +5,8 @@ import {
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { peekOnboardingCallbackUrl, stashOnboardingCallbackUrl } from '@/utils/onboardingRedirect';
+
 import AgentPickerStep from './index';
 
 const navigate = vi.fn();
@@ -96,6 +98,7 @@ beforeEach(() => {
   metrics.trackOnboardingStepCompleted.mockClear();
   swrReturn = { data: templates, error: undefined, isLoading: false };
   searchParams = new URLSearchParams();
+  sessionStorage.clear();
 });
 
 afterEach(() => {
@@ -153,6 +156,20 @@ describe('AgentPickerStep', () => {
       flow: 'classic',
       targetUrl: '/',
     });
+  });
+
+  it('navigates to the stashed signup callbackUrl on finish and clears it', async () => {
+    stashOnboardingCallbackUrl('?callbackUrl=%2Fagent%2Fabc%3Fmessage%3Dhi');
+    render(<AgentPickerStep onBack={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'agentPicker.skip' }));
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/agent/abc?message=hi'));
+    expect(metrics.trackOnboardingCompleted).toHaveBeenCalledWith({
+      flow: 'classic',
+      targetUrl: '/agent/abc?message=hi',
+    });
+    expect(peekOnboardingCallbackUrl()).toBeUndefined();
   });
 
   it('shows a Back button that calls onBack for a normal classic entry', () => {

--- a/src/routes/onboarding/features/AgentPickerStep/index.tsx
+++ b/src/routes/onboarding/features/AgentPickerStep/index.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/services/onboardingMetrics';
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
+import { consumeOnboardingCallbackUrl } from '@/utils/onboardingRedirect';
 
 import LobeMessage from '../../components/LobeMessage';
 import { interestsToCategoryHints } from '../../interestCategoryMap';
@@ -109,8 +110,10 @@ const AgentPickerStep = memo<AgentPickerStepProps>(({ onBack }) => {
         step: 'agentpicker',
         stepIndex: 4,
       });
-      trackOnboardingCompleted({ flow: completionFlow, targetUrl: '/' });
-      navigate('/');
+      // Restore the original signup target (threaded through onboarding), if any
+      const targetUrl = consumeOnboardingCallbackUrl() || '/';
+      trackOnboardingCompleted({ flow: completionFlow, targetUrl });
+      navigate(targetUrl);
     },
     [completionFlow, finishOnboarding, isAgentSkipEntry, navigate],
   );

--- a/src/routes/onboarding/features/ModeSelectionStep.tsx
+++ b/src/routes/onboarding/features/ModeSelectionStep.tsx
@@ -11,6 +11,7 @@ import { useIsDark } from '@/hooks/useIsDark';
 import LobeMessage from '@/routes/onboarding/components/LobeMessage';
 import { useUserStore } from '@/store/user';
 import { isDev } from '@/utils/env';
+import { consumeOnboardingCallbackUrl } from '@/utils/onboardingRedirect';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   base: css`
@@ -99,7 +100,7 @@ const ModeSelectionStep = memo<ModeSelectionStepProps>(({ onBack, onNext }) => {
     finishOnboarding();
 
     if (!isDev) {
-      navigate('/');
+      navigate(consumeOnboardingCallbackUrl() || '/');
     }
   };
 

--- a/src/utils/onboardingRedirect.test.ts
+++ b/src/utils/onboardingRedirect.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
   buildOnboardingRedirectUrl,
+  clearStaleOnboardingCallbackUrl,
   consumeOnboardingCallbackUrl,
   isSafeRedirectPath,
   peekOnboardingCallbackUrl,
@@ -92,6 +93,46 @@ describe('stash/peek/consumeOnboardingCallbackUrl', () => {
   it('should not clobber an existing stash with internal navigations', () => {
     stashOnboardingCallbackUrl('?callbackUrl=%2Fdiscover');
     stashOnboardingCallbackUrl('?entry=skip');
+
+    expect(peekOnboardingCallbackUrl()).toBe('/discover');
+  });
+});
+
+describe('clearStaleOnboardingCallbackUrl', () => {
+  beforeEach(() => {
+    stashOnboardingCallbackUrl('?callbackUrl=%2Fdiscover');
+  });
+
+  it('should clear a stale stash on a fresh top-level entry without callbackUrl', () => {
+    clearStaleOnboardingCallbackUrl('/onboarding', '');
+
+    expect(peekOnboardingCallbackUrl()).toBeUndefined();
+  });
+
+  it('should clear when the supplied callbackUrl is unsafe', () => {
+    clearStaleOnboardingCallbackUrl(
+      '/onboarding',
+      `?callbackUrl=${encodeURIComponent('https://evil.com')}`,
+    );
+
+    expect(peekOnboardingCallbackUrl()).toBeUndefined();
+  });
+
+  it('should keep the stash when a valid callbackUrl is present', () => {
+    clearStaleOnboardingCallbackUrl('/onboarding', '?callbackUrl=%2Fsettings');
+
+    expect(peekOnboardingCallbackUrl()).toBe('/discover');
+  });
+
+  it('should keep the stash on shared-prefix re-entries carrying a step param', () => {
+    clearStaleOnboardingCallbackUrl('/onboarding', '?step=1');
+
+    expect(peekOnboardingCallbackUrl()).toBe('/discover');
+  });
+
+  it('should keep the stash on branch paths', () => {
+    clearStaleOnboardingCallbackUrl('/onboarding/agent', '');
+    clearStaleOnboardingCallbackUrl('/onboarding/classic', '?entry=skip');
 
     expect(peekOnboardingCallbackUrl()).toBe('/discover');
   });

--- a/src/utils/onboardingRedirect.test.ts
+++ b/src/utils/onboardingRedirect.test.ts
@@ -23,6 +23,12 @@ describe('isSafeRedirectPath', () => {
     expect(isSafeRedirectPath('//evil.com')).toBe(false);
     expect(isSafeRedirectPath('javascript:alert(1)')).toBe(false);
   });
+
+  it('should reject backslash paths that browsers normalize to protocol-relative URLs', () => {
+    expect(isSafeRedirectPath('/\\evil.com')).toBe(false);
+    expect(isSafeRedirectPath('/\\/evil.com')).toBe(false);
+    expect(isSafeRedirectPath('/foo\\bar')).toBe(false);
+  });
 });
 
 describe('buildOnboardingRedirectUrl', () => {
@@ -46,6 +52,16 @@ describe('buildOnboardingRedirectUrl', () => {
   it('should drop unsafe external targets', () => {
     expect(buildOnboardingRedirectUrl('https://evil.com')).toBe('/onboarding');
     expect(buildOnboardingRedirectUrl('//evil.com')).toBe('/onboarding');
+    expect(buildOnboardingRedirectUrl('/\\evil.com')).toBe('/onboarding');
+  });
+
+  it('should normalize same-origin absolute URLs to relative paths', () => {
+    const origin = window.location.origin;
+    expect(buildOnboardingRedirectUrl(`${origin}/settings?tab=profile`)).toBe(
+      '/onboarding?callbackUrl=%2Fsettings%3Ftab%3Dprofile',
+    );
+    expect(buildOnboardingRedirectUrl(`${origin}/`)).toBe('/onboarding');
+    expect(buildOnboardingRedirectUrl(`${origin}/onboarding/agent`)).toBe('/onboarding/agent');
   });
 });
 

--- a/src/utils/onboardingRedirect.test.ts
+++ b/src/utils/onboardingRedirect.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  buildOnboardingRedirectUrl,
+  consumeOnboardingCallbackUrl,
+  isSafeRedirectPath,
+  peekOnboardingCallbackUrl,
+  stashOnboardingCallbackUrl,
+} from './onboardingRedirect';
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe('isSafeRedirectPath', () => {
+  it('should accept same-site relative paths', () => {
+    expect(isSafeRedirectPath('/')).toBe(true);
+    expect(isSafeRedirectPath('/agent/abc?message=hi')).toBe(true);
+  });
+
+  it('should reject absolute and protocol-relative URLs', () => {
+    expect(isSafeRedirectPath('https://evil.com')).toBe(false);
+    expect(isSafeRedirectPath('//evil.com')).toBe(false);
+    expect(isSafeRedirectPath('javascript:alert(1)')).toBe(false);
+  });
+});
+
+describe('buildOnboardingRedirectUrl', () => {
+  it('should return plain onboarding path for default or missing callbackUrl', () => {
+    expect(buildOnboardingRedirectUrl()).toBe('/onboarding');
+    expect(buildOnboardingRedirectUrl(null)).toBe('/onboarding');
+    expect(buildOnboardingRedirectUrl('/')).toBe('/onboarding');
+  });
+
+  it('should thread an explicit target through the callbackUrl query param', () => {
+    expect(buildOnboardingRedirectUrl('/agent/abc?message=hi')).toBe(
+      '/onboarding?callbackUrl=%2Fagent%2Fabc%3Fmessage%3Dhi',
+    );
+  });
+
+  it('should not nest when the target is already an onboarding path', () => {
+    expect(buildOnboardingRedirectUrl('/onboarding')).toBe('/onboarding');
+    expect(buildOnboardingRedirectUrl('/onboarding/agent')).toBe('/onboarding/agent');
+  });
+
+  it('should drop unsafe external targets', () => {
+    expect(buildOnboardingRedirectUrl('https://evil.com')).toBe('/onboarding');
+    expect(buildOnboardingRedirectUrl('//evil.com')).toBe('/onboarding');
+  });
+});
+
+describe('stash/peek/consumeOnboardingCallbackUrl', () => {
+  it('should stash the callbackUrl from a location search string', () => {
+    stashOnboardingCallbackUrl('?callbackUrl=%2Fagent%2Fabc%3Fmessage%3Dhi');
+
+    expect(peekOnboardingCallbackUrl()).toBe('/agent/abc?message=hi');
+  });
+
+  it('should keep the stashed value across peeks and clear it on consume', () => {
+    stashOnboardingCallbackUrl('?callbackUrl=%2Fdiscover');
+
+    expect(peekOnboardingCallbackUrl()).toBe('/discover');
+    expect(consumeOnboardingCallbackUrl()).toBe('/discover');
+    expect(peekOnboardingCallbackUrl()).toBeUndefined();
+    expect(consumeOnboardingCallbackUrl()).toBeUndefined();
+  });
+
+  it('should not stash when callbackUrl is missing or unsafe', () => {
+    stashOnboardingCallbackUrl('?step=2');
+    expect(peekOnboardingCallbackUrl()).toBeUndefined();
+
+    stashOnboardingCallbackUrl(`?callbackUrl=${encodeURIComponent('https://evil.com')}`);
+    expect(peekOnboardingCallbackUrl()).toBeUndefined();
+  });
+
+  it('should not clobber an existing stash with internal navigations', () => {
+    stashOnboardingCallbackUrl('?callbackUrl=%2Fdiscover');
+    stashOnboardingCallbackUrl('?entry=skip');
+
+    expect(peekOnboardingCallbackUrl()).toBe('/discover');
+  });
+});

--- a/src/utils/onboardingRedirect.ts
+++ b/src/utils/onboardingRedirect.ts
@@ -4,9 +4,28 @@ const CALLBACK_STORAGE_KEY = 'onboarding-callback-url';
 /**
  * Only same-site relative paths are allowed as post-onboarding redirect
  * targets, to prevent open redirects (e.g. `https://evil.com`, `//evil.com`).
+ * Backslashes are rejected because browsers normalize `\` to `/` in
+ * navigations, so `/\evil.com` would escape as a protocol-relative URL.
  */
 export const isSafeRedirectPath = (url: string): boolean =>
-  url.startsWith('/') && !url.startsWith('//');
+  url.startsWith('/') && !url.startsWith('//') && !url.includes('\\');
+
+/**
+ * Auth detours can produce same-origin absolute callback URLs (e.g. the
+ * protected-route proxy builds `APP_URL + pathname + search`) — normalize
+ * them to relative paths instead of dropping them as unsafe.
+ */
+const toRelativePath = (url: string): string => {
+  if (!/^https?:\/\//.test(url)) return url;
+  try {
+    const parsed = new URL(url);
+    if (typeof window !== 'undefined' && parsed.origin === window.location.origin)
+      return parsed.pathname + parsed.search + parsed.hash;
+  } catch {
+    // fall through — non-parsable URLs are rejected by isSafeRedirectPath
+  }
+  return url;
+};
 
 /**
  * Build the first-hop URL for a freshly signed-up user. New users always land
@@ -14,10 +33,10 @@ export const isSafeRedirectPath = (url: string): boolean =>
  * `callbackUrl` query param and restored when onboarding finishes.
  */
 export const buildOnboardingRedirectUrl = (callbackUrl?: string | null): string => {
-  if (!callbackUrl || callbackUrl === '/' || !isSafeRedirectPath(callbackUrl))
-    return ONBOARDING_PATH;
-  if (callbackUrl.startsWith(ONBOARDING_PATH)) return callbackUrl;
-  return `${ONBOARDING_PATH}?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+  const target = callbackUrl && toRelativePath(callbackUrl);
+  if (!target || target === '/' || !isSafeRedirectPath(target)) return ONBOARDING_PATH;
+  if (target.startsWith(ONBOARDING_PATH)) return target;
+  return `${ONBOARDING_PATH}?callbackUrl=${encodeURIComponent(target)}`;
 };
 
 /**

--- a/src/utils/onboardingRedirect.ts
+++ b/src/utils/onboardingRedirect.ts
@@ -54,6 +54,26 @@ export const stashOnboardingCallbackUrl = (search: string): void => {
   }
 };
 
+/**
+ * Drop a stale stashed callback left by a previously abandoned onboarding
+ * attempt in this tab. Only a fresh top-level entry (`/onboarding` without a
+ * valid `callbackUrl`) may clear: internal navigations either stay on branch
+ * paths (`/onboarding/agent`, `/onboarding/classic`) or re-enter the shared
+ * prefix with an explicit `?step` param, and must keep the stash intact.
+ */
+export const clearStaleOnboardingCallbackUrl = (pathname: string, search: string): void => {
+  if (pathname !== ONBOARDING_PATH) return;
+  const params = new URLSearchParams(search);
+  if (params.has('step')) return;
+  const callbackUrl = params.get('callbackUrl');
+  if (callbackUrl && isSafeRedirectPath(callbackUrl)) return;
+  try {
+    sessionStorage.removeItem(CALLBACK_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+};
+
 export const peekOnboardingCallbackUrl = (): string | undefined => {
   try {
     const url = sessionStorage.getItem(CALLBACK_STORAGE_KEY);

--- a/src/utils/onboardingRedirect.ts
+++ b/src/utils/onboardingRedirect.ts
@@ -1,0 +1,56 @@
+const ONBOARDING_PATH = '/onboarding';
+const CALLBACK_STORAGE_KEY = 'onboarding-callback-url';
+
+/**
+ * Only same-site relative paths are allowed as post-onboarding redirect
+ * targets, to prevent open redirects (e.g. `https://evil.com`, `//evil.com`).
+ */
+export const isSafeRedirectPath = (url: string): boolean =>
+  url.startsWith('/') && !url.startsWith('//');
+
+/**
+ * Build the first-hop URL for a freshly signed-up user. New users always land
+ * on onboarding first; the original target (if any) is threaded through the
+ * `callbackUrl` query param and restored when onboarding finishes.
+ */
+export const buildOnboardingRedirectUrl = (callbackUrl?: string | null): string => {
+  if (!callbackUrl || callbackUrl === '/' || !isSafeRedirectPath(callbackUrl))
+    return ONBOARDING_PATH;
+  if (callbackUrl.startsWith(ONBOARDING_PATH)) return callbackUrl;
+  return `${ONBOARDING_PATH}?callbackUrl=${encodeURIComponent(callbackUrl)}`;
+};
+
+/**
+ * Persist the threaded callbackUrl when landing on onboarding. sessionStorage
+ * (rather than query threading) survives the internal multi-route hops of the
+ * onboarding flow and mid-flow page refreshes.
+ */
+export const stashOnboardingCallbackUrl = (search: string): void => {
+  try {
+    const callbackUrl = new URLSearchParams(search).get('callbackUrl');
+    if (callbackUrl && isSafeRedirectPath(callbackUrl))
+      sessionStorage.setItem(CALLBACK_STORAGE_KEY, callbackUrl);
+  } catch {
+    // sessionStorage unavailable (e.g. privacy mode) — finish points fall back to defaults
+  }
+};
+
+export const peekOnboardingCallbackUrl = (): string | undefined => {
+  try {
+    const url = sessionStorage.getItem(CALLBACK_STORAGE_KEY);
+    return url && isSafeRedirectPath(url) ? url : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/** Read and clear the stashed callbackUrl — call once when onboarding finishes. */
+export const consumeOnboardingCallbackUrl = (): string | undefined => {
+  const url = peekOnboardingCallbackUrl();
+  try {
+    sessionStorage.removeItem(CALLBACK_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+  return url;
+};


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

None

#### 🔀 Description of Change

New users previously bounced through the home page after signup: the page rendered, the async user-state fetch resolved, and only then did the client hard-redirect to `/onboarding`, causing a visible flash.

Now every signup entry lands on `/onboarding` directly:

- **Email signup** (`useSignUp`): `signUp.email` callbackURL, the verify-email param, and the success `router.push` all go through the new `buildOnboardingRedirectUrl` helper — covers both email-verification on/off paths.
- **First-time social OAuth / generic OAuth / magic link** (`useSignIn`): pass better-auth's native `newUserCallbackURL`, so only newly created accounts land on onboarding; existing users are unaffected.
- **Fallback needs-onboarding redirect** (`useUserStateRedirect`): now threads the page the user was on, so finishing onboarding returns them there instead of always landing on home. The previous skip for agent pages with a `message` param (#15256) is removed — these users now go through onboarding like everyone else, and the threaded callbackUrl keeps the `message` intact so it is delivered right after onboarding completes.

An explicit signup target (e.g. marketplace "Try in LobeHub" links) is threaded through the `callbackUrl` query param, stashed in sessionStorage at onboarding entry (survives internal route hops and mid-flow refreshes), and consumed at every onboarding finish point:

- classic agent picker (`AgentPickerStep`)
- lite mode selection (`ModeSelectionStep`)
- agent flow completion panel (`CompletionPanel`, original target wins over the onboarding topic)

Only same-site relative paths are accepted as redirect targets (open-redirect guard). `trackOnboardingCompleted` now reports the real target URL.

#### 🧪 How to Test

1. Sign up with a fresh email (verification off) → lands on `/onboarding` directly, no home flash.
2. Sign up with email verification on → clicking the email link lands on `/onboarding`.
3. First-time Google/GitHub login → lands on `/onboarding`; existing account login behavior unchanged.
4. Visit `/signup?callbackUrl=%2Fagent%2Fxxx%3Fmessage%3Dhi`, sign up and finish onboarding (any branch) → returns to `/agent/xxx?message=hi`.
5. Existing not-onboarded user opens `/settings` → redirected to onboarding, finishing returns to `/settings`.
6. Existing not-onboarded user opens `/agent/inbox?message=hi` → redirected to onboarding, finishing returns to `/agent/inbox?message=hi` and the message auto-sends.

- [x] Tested locally
- [x] Added/updated tests

#### 📝 Additional Information

No new routes, no schema changes. Desktop builds are unaffected (no stashed target → all finish points behave as before).
