### PR TITLE
🐛 fix(cli): skill list/search commands returning empty results

### DIFF
--- a/apps/cli/src/commands/skill.test.ts
+++ b/apps/cli/src/commands/skill.test.ts
@@ -64,15 +64,18 @@ describe('skill command', () => {
 
   describe('list', () => {
     it('should display skills in table format', async () => {
-      mockTrpcClient.agentSkills.list.query.mockResolvedValue([
-        {
-          description: 'A skill',
-          id: 's1',
-          identifier: 'test-skill',
-          name: 'Test Skill',
-          source: 'user',
-        },
-      ]);
+      mockTrpcClient.agentSkills.list.query.mockResolvedValue({
+        data: [
+          {
+            description: 'A skill',
+            id: 's1',
+            identifier: 'test-skill',
+            name: 'Test Skill',
+            source: 'user',
+          },
+        ],
+        total: 1,
+      });
 
       const program = createProgram();
       await program.parseAsync(['node', 'test', 'skill', 'list']);
@@ -83,7 +86,7 @@ describe('skill command', () => {
 
     it('should output JSON when --json flag is used', async () => {
       const items = [{ id: 's1', name: 'Test' }];
-      mockTrpcClient.agentSkills.list.query.mockResolvedValue(items);
+      mockTrpcClient.agentSkills.list.query.mockResolvedValue({ data: items, total: items.length });
 
       const program = createProgram();
       await program.parseAsync(['node', 'test', 'skill', 'list', '--json']);
@@ -92,7 +95,7 @@ describe('skill command', () => {
     });
 
     it('should filter by source', async () => {
-      mockTrpcClient.agentSkills.list.query.mockResolvedValue([]);
+      mockTrpcClient.agentSkills.list.query.mockResolvedValue({ data: [], total: 0 });
 
       const program = createProgram();
       await program.parseAsync(['node', 'test', 'skill', 'list', '--source', 'builtin']);
@@ -111,7 +114,7 @@ describe('skill command', () => {
     });
 
     it('should show message when no skills found', async () => {
-      mockTrpcClient.agentSkills.list.query.mockResolvedValue([]);
+      mockTrpcClient.agentSkills.list.query.mockResolvedValue({ data: [], total: 0 });
 
       const program = createProgram();
       await program.parseAsync(['node', 'test', 'skill', 'list']);
@@ -211,9 +214,10 @@ describe('skill command', () => {
 
   describe('search', () => {
     it('should search skills', async () => {
-      mockTrpcClient.agentSkills.search.query.mockResolvedValue([
-        { description: 'A skill', id: 's1', name: 'Found Skill' },
-      ]);
+      mockTrpcClient.agentSkills.search.query.mockResolvedValue({
+        data: [{ description: 'A skill', id: 's1', name: 'Found Skill' }],
+        total: 1,
+      });
 
       const program = createProgram();
       await program.parseAsync(['node', 'test', 'skill', 'search', 'test']);
@@ -223,7 +227,7 @@ describe('skill command', () => {
     });
 
     it('should show message when no results', async () => {
-      mockTrpcClient.agentSkills.search.query.mockResolvedValue([]);
+      mockTrpcClient.agentSkills.search.query.mockResolvedValue({ data: [], total: 0 });
 
       const program = createProgram();
       await program.parseAsync(['node', 'test', 'skill', 'search', 'nothing']);

--- a/apps/cli/src/commands/skill.ts
+++ b/apps/cli/src/commands/skill.ts
@@ -47,7 +47,7 @@ export function registerSkillCommand(program: Command) {
       if (options.source) input.source = options.source as 'builtin' | 'market' | 'user';
 
       const result = await client.agentSkills.list.query(input);
-      const items = Array.isArray(result) ? result : [];
+      const items = result?.data ?? [];
 
       if (options.json !== undefined) {
         const fields = typeof options.json === 'string' ? options.json : undefined;
@@ -206,7 +206,7 @@ export function registerSkillCommand(program: Command) {
     .action(async (query: string, options: { json?: string | boolean }) => {
       const client = await getTrpcClient();
       const result = await client.agentSkills.search.query({ query });
-      const items = Array.isArray(result) ? result : [];
+      const items = result?.data ?? [];
 
       if (options.json !== undefined) {
         const fields = typeof options.json === 'string' ? options.json : undefined;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

`tRPC` `agentSkills.list` and `agentSkills.search` endpoints return `{ data: SkillListItem[], total: number }`, but the CLI was checking `Array.isArray(result)` which is always `false` for an object, causing both commands to silently show "No skills found." for every source.

**Root cause:** `const items = Array.isArray(result) ? result : []`
**Fix:** `const items = result?.data ?? []`

Changes:
- `apps/cli/src/commands/skill.ts` — use `result?.data ?? []` in both `list` and `search` action handlers
- `apps/cli/src/commands/skill.test.ts` — update all `list`/`search` mock return values from `[...]` to `{ data: [...], total: n }` to match actual tRPC shape

#### 🧪 How to Test

```bash
lh skill list
lh skill list --source builtin
lh skill search <query>
```

All should now return actual results instead of "No skills found."

- [x] Added/updated tests

#### 📝 Additional Information

Only the CLI layer is modified — no tRPC router changes.