### PR TITLE
💄 style(desktop): tighten tab close button right padding

### DIFF
--- a/src/features/Electron/titlebar/TabBar/styles.ts
+++ b/src/features/Electron/titlebar/TabBar/styles.ts
@@ -56,7 +56,7 @@ export const useStyles = createStaticStyles(({ css, cssVar }) => ({
 
     width: 180px;
     padding-block: 2px;
-    padding-inline: 10px 4px;
+    padding-inline: 10px 2px;
     border-radius: ${cssVar.borderRadiusSM};
 
     font-size: 12px;


### PR DESCRIPTION
#### 💄 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 Description of Change

Reduce the right padding of desktop title-bar tabs from `4px` to `2px` (`padding-inline: 10px 2px`).

The close button is a `size="small"` `ActionIcon` with its own inner padding, so the gap between the ✕ icon and the tab's right edge looked visibly wider than the nominal 4px. Tightening the container padding by 2px balances the spacing.

#### 📝 Additional Information

Visual-only tweak in `src/features/Electron/titlebar/TabBar/styles.ts`; no behavior change.