### PR TITLE
💄 style(desktop): keep tab bar new-tab button visible on every route

### DIFF
--- a/src/features/Electron/titlebar/TabBar/index.tsx
+++ b/src/features/Electron/titlebar/TabBar/index.tsx
@@ -22,6 +22,12 @@ import TabItem from './TabItem';
 const TAB_WIDTH = 180;
 const TAB_GAP = 0;
 
+// Fallback when the active route doesn't define createNewTab: open the home page,
+// so the "+" button stays available on every page.
+const DEFAULT_NEW_TAB_ACTION: NewTabAction = {
+  onCreate: async () => ({ url: '/' }),
+};
+
 const TabBar = () => {
   const styles = useStyles;
   const navigate = useNavigate();
@@ -117,13 +123,13 @@ const TabBar = () => {
     }
   }, [activeTabId, tabs]);
 
-  const newTabAction: NewTabAction | null = useMemo(() => {
-    if (!activeTabId) return null;
+  const newTabAction: NewTabAction = useMemo(() => {
+    if (!activeTabId) return DEFAULT_NEW_TAB_ACTION;
     const activeTab = tabs.find((tab) => tab.tab.id === activeTabId);
-    if (!activeTab) return null;
+    if (!activeTab) return DEFAULT_NEW_TAB_ACTION;
 
     const matched = matchRouteMeta(desktopRoutes, activeTab.tab.url);
-    return matched.meta?.createNewTab?.(matched.params) ?? null;
+    return matched.meta?.createNewTab?.(matched.params) ?? DEFAULT_NEW_TAB_ACTION;
   }, [activeTabId, tabs]);
 
   useWatchBroadcast('closeCurrentTabOrWindow', () => {
@@ -135,7 +141,6 @@ const TabBar = () => {
   });
 
   const handleNewTab = useCallback(async () => {
-    if (!newTabAction) return;
     let result;
     try {
       result = await newTabAction.onCreate();
@@ -177,15 +182,13 @@ const TabBar = () => {
           onCloseRight={handleCloseRight}
         />
       ))}
-      {newTabAction && (
-        <ActionIcon
-          className={cx(electronStylish.nodrag, styles.newTabButton)}
-          icon={Plus}
-          size="small"
-          title={t('tab.newTab')}
-          onClick={handleNewTab}
-        />
-      )}
+      <ActionIcon
+        className={cx(electronStylish.nodrag, styles.newTabButton)}
+        icon={Plus}
+        size="small"
+        title={t('tab.newTab')}
+        onClick={handleNewTab}
+      />
     </ScrollArea>
   );
 };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Previously the "+" (new tab) button in the desktop tab bar only rendered when the **active tab's route** defined `createNewTab` in its route meta — currently only `agent`, `group`, and `page` (editor) routes do. Switching to any other page (settings, home, etc.) made the button disappear, which felt like it "doesn't show by default".

This PR adds a fallback `NewTabAction` that opens the home page (`/`) when the active route doesn't provide `createNewTab`, so the "+" button is now always visible whenever the tab bar is rendered:

- Added `DEFAULT_NEW_TAB_ACTION` (`onCreate` returns `{ url: '/' }`; the root route already carries a `routeMeta` with the Home icon/title, so the new tab resolves its title correctly).
- `newTabAction` is narrowed from `NewTabAction | null` to `NewTabAction` — all `null` branches now return the fallback.
- Removed the conditional rendering of the `ActionIcon` and the null guard in `handleNewTab`. As a side effect, the `createNewTab` broadcast (Cmd+T) now also works on every page.

Notes:
- If a home tab already exists, clicking "+" activates it instead of opening a duplicate — this is existing `addTab` dedupe behavior (tab id = normalized URL).
- The `tabs.length === 0` early return is untouched: the zero-tab "no tab mode" still hides the whole bar.

#### 🧪 How to Test

1. Open the desktop app with at least one tab.
2. Navigate to a page without `createNewTab` route meta (e.g. settings or home) — the "+" button stays visible.
3. Click "+" — a new Home tab opens and activates.
4. On an agent/group/page tab, "+" keeps its original route-specific behavior (new topic / new page).

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| "+" hidden on routes without `createNewTab` meta | "+" always visible; falls back to opening Home |

#### 📝 Additional Information

No breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)