### PR TITLE
💄 style(chat-input): fix control bar height jump when TokenTag appears

### DIFF
--- a/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
+++ b/src/features/ChatInput/ActionBar/Token/TokenTag.tsx
@@ -192,7 +192,7 @@ const Token = memo(() => {
         mode={'used'}
         value={totalToken}
         size={{
-          blockSize: 32,
+          blockSize: 28,
           size: 18,
         }}
         text={{

--- a/src/features/ChatInput/ControlBar/index.tsx
+++ b/src/features/ChatInput/ControlBar/index.tsx
@@ -14,6 +14,7 @@ import WorkspaceControls from './WorkspaceControls';
 
 const styles = createStaticStyles(({ css }) => ({
   bar: css`
+    height: 28px;
     padding-block: 0;
     padding-inline: 4px;
   `,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The chat input control bar had no fixed height, so its height was determined by the tallest child. The `TokenTag` (an `ActionIcon` with `blockSize: 32`) mounts conditionally — it returns `null` until token usage exceeds 50% of the context window (token counting is async, so it always appears after first paint). When it mounted, the bar grew from 28px (the `ModeSelector` trigger height) to 32px, causing a 4px layout shift. The loading skeleton (22px) caused a similar jump on load.

Fixes:

- Give the control bar a fixed `height: 28px` so neither `TokenTag` mounting nor skeleton → content transition shifts layout.
- Shrink `TokenTag`'s `blockSize` from 32 to 28 to match the other controls in the row.

#### 🧪 How to Test

Open a chat with enough history (or enable dev mode) so the context window indicator appears, and verify the control bar height no longer jumps when the token tag shows up or when the bar finishes loading.

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

None.