### PR TITLE
💄 style: use Geist as the default UI font with CJK fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "@emotion/react": "^11.14.0",
     "@fal-ai/client": "^1.8.4",
     "@floating-ui/react": "^0.27.19",
+    "@fontsource-variable/geist": "^5.2.9",
     "@formkit/auto-animate": "^0.9.0",
     "@google/genai": "~1.50.1",
     "@henrygd/queue": "^1.2.0",

--- a/packages/const/src/theme.ts
+++ b/packages/const/src/theme.ts
@@ -1,3 +1,13 @@
 export const LOBE_THEME_PRIMARY_COLOR = 'LOBE_THEME_PRIMARY_COLOR';
 
 export const LOBE_THEME_NEUTRAL_COLOR = 'LOBE_THEME_NEUTRAL_COLOR';
+
+const FONT_EN = `"HarmonyOS Sans","Segoe UI","SF Pro Display",-apple-system,BlinkMacSystemFont,Roboto,Oxygen,Ubuntu,Cantarell,"Open Sans","Helvetica Neue",sans-serif`;
+const FONT_CN = `"HarmonyOS Sans SC","PingFang SC","Hiragino Sans GB","Microsoft Yahei UI","Microsoft Yahei","Source Han Sans CN",sans-serif`;
+const FONT_EMOJI = `"Segoe UI Emoji","Segoe UI Symbol","Apple Color Emoji","Twemoji Mozilla","Noto Color Emoji","Android Emoji"`;
+
+/**
+ * Geist only ships Latin glyphs, so CJK characters fall through to the
+ * fallback chain, which mirrors the default `fontFamily` token of @lobehub/ui.
+ */
+export const UI_FONT_FAMILY = [`"Geist Variable"`, FONT_EN, FONT_CN, FONT_EMOJI].join(',');

--- a/src/app/[variants]/(auth)/_layout/AuthThemeLite.tsx
+++ b/src/app/[variants]/(auth)/_layout/AuthThemeLite.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import 'antd/dist/reset.css';
+import '@fontsource-variable/geist/index.css';
 
 import { ConfigProvider, ThemeProvider } from '@lobehub/ui';
 import { App } from 'antd';
@@ -10,6 +11,7 @@ import { type PropsWithChildren } from 'react';
 import { memo } from 'react';
 
 import AntdStaticMethods from '@/components/AntdStaticMethods';
+import { UI_FONT_FAMILY } from '@/const/theme';
 import { useIsDark } from '@/hooks/useIsDark';
 import Image from '@/libs/next/Image';
 
@@ -30,6 +32,9 @@ const AuthThemeLite = memo<AuthThemeLiteProps>(({ children, globalCDN }) => {
       style={{ height: '100%' }}
       theme={{
         cssVar: { key: 'lobe-vars' },
+        token: {
+          fontFamily: UI_FONT_FAMILY,
+        },
       }}
     >
       <App style={{ height: '100%' }}>

--- a/src/layout/GlobalProvider/AppTheme.tsx
+++ b/src/layout/GlobalProvider/AppTheme.tsx
@@ -1,20 +1,21 @@
 'use client';
 
 import 'antd/dist/reset.css';
+import '@fontsource-variable/geist/index.css';
 
 import { TITLE_BAR_HEIGHT } from '@lobechat/desktop-bridge';
 import { type NeutralColors, type PrimaryColors } from '@lobehub/ui';
 import { ConfigProvider, FontLoader, ThemeProvider } from '@lobehub/ui';
 import { message as antdMessage } from 'antd';
 import { AppConfigContext } from 'antd/es/app/context';
-import { createStaticStyles, cx, useTheme } from 'antd-style';
+import { createStaticStyles, cx } from 'antd-style';
 import * as m from 'motion/react-m';
 import { type ReactNode } from 'react';
 import { memo, useEffect, useMemo, useState } from 'react';
 
 import AntdStaticMethods from '@/components/AntdStaticMethods';
 import Link from '@/components/Link';
-import { LOBE_THEME_NEUTRAL_COLOR, LOBE_THEME_PRIMARY_COLOR } from '@/const/theme';
+import { LOBE_THEME_NEUTRAL_COLOR, LOBE_THEME_PRIMARY_COLOR, UI_FONT_FAMILY } from '@/const/theme';
 import { isDesktop } from '@/const/version';
 import { useIsDark } from '@/hooks/useIsDark';
 import { getUILocaleAndResources } from '@/libs/getUILocaleAndResources';
@@ -103,7 +104,6 @@ const AppTheme = memo<AppThemeProps>(
     customFontFamily,
   }) => {
     const language = useGlobalStore(systemStatusSelectors.language);
-    const antdTheme = useTheme();
     const isDark = useIsDark();
 
     const [primaryColor, neutralColor, animationMode] = useUserStore((s) => [
@@ -168,8 +168,8 @@ const AppTheme = memo<AppThemeProps>(
             cssVar: { key: 'lobe-vars' },
             token: {
               fontFamily: customFontFamily
-                ? `${customFontFamily},${antdTheme.fontFamily}`
-                : undefined,
+                ? `${customFontFamily},${UI_FONT_FAMILY}`
+                : UI_FONT_FAMILY,
               motion: animationMode !== 'disabled',
               motionUnit: animationMode === 'agile' ? 0.05 : 0.1,
             },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -295,6 +295,10 @@ export default defineConfig({
   server: {
     cors: true,
     host: true,
+    // Absolute dev asset URLs: CSS-referenced assets (e.g. self-hosted font files) must
+    // resolve to the Vite origin even when the SPA HTML is served from the Next.js dev
+    // server or the online debug proxy, where root-relative URLs hit the wrong origin.
+    origin: 'http://localhost:9876',
     port: 9876,
     proxy: {
       '/api': `http://localhost:${process.env.PORT || 3010}`,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Font change experiment: make **Geist** the UI font for the app.

- Adds `@fontsource-variable/geist` (self-hosted variable font, OFL-licensed, bundled by Vite/Next — no extra CDN origin, subsets load on demand via `unicode-range`; Latin subset is ~35 KB woff2).
- Adds a shared `UI_FONT_FAMILY` constant in `@/const/theme`: `"Geist Variable"` first, followed by the previous default stack. Geist only ships Latin glyphs, so **CJK characters keep falling through to the current fonts** (HarmonyOS Sans SC, PingFang SC, Microsoft Yahei, …), and emoji fonts stay at the end. The fallback chain mirrors the default `fontFamily` token of `@lobehub/ui`.
- Applies the stack at both theme roots:
  - `AppTheme` — all SPA surfaces (web / mobile / desktop / popup) and layouts that reuse it
  - `AuthThemeLite` — SSR auth pages
- `customFontFamily` (self-host `CUSTOM_FONT_FAMILY`) still wins: it is prepended ahead of the new stack. As a side effect this also fixes its previous fallback, which used the plain antd default stack (no CJK fonts) instead of the product stack.
- `fontFamilyCode` (code font) is unchanged.

#### 🧪 How to Test

- Open any chat page: Latin text should render in Geist (inspect computed `font-family`, first entry `"Geist Variable"`).
- Switch to zh-CN and verify CJK text still renders with the existing CJK fonts (PingFang SC on macOS, Microsoft Yahei on Windows).
- Check the network panel: only the needed Geist subsets (typically `latin`) are fetched.
- Auth pages (`/signin`) should render in Geist as well.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |