### PR TITLE
🐛 fix(model-runtime): guard Cloudflare models() against null result envelope

### DIFF
--- a/packages/model-runtime/src/providers/cloudflare/index.test.ts
+++ b/packages/model-runtime/src/providers/cloudflare/index.test.ts
@@ -559,9 +559,9 @@ describe('LobeCloudflareAI', () => {
       expect(result).toHaveLength(2);
     });
 
-    it('should throw ProviderBizError when Cloudflare returns a null result envelope', async () => {
-      // Arrange: Cloudflare's V4 envelope on auth/account errors carries `result: null`
-      // and the detail in `errors`. Without a guard, `result.map()` throws a 500 TypeError.
+    it('should return an empty list when Cloudflare returns a null result envelope', async () => {
+      // Arrange: Cloudflare's V4 envelope carries `result: null` on auth / account
+      // errors. Without the fallback, `result.map()` throws a 500 TypeError.
       const apiKey = 'test_api_key';
       const instance = new LobeCloudflareAI({ apiKey, baseURLOrAccountID: accountID });
 
@@ -578,13 +578,7 @@ describe('LobeCloudflareAI', () => {
       );
 
       // Act & Assert
-      await expect(instance.models()).rejects.toEqual({
-        endpoint: expect.not.stringContaining(accountID),
-        error: expect.objectContaining({ result: null, success: false }),
-        errorType: bizErrorType,
-        message: 'Authentication error',
-        provider,
-      });
+      await expect(instance.models()).resolves.toEqual([]);
     });
   });
 });

--- a/packages/model-runtime/src/providers/cloudflare/index.test.ts
+++ b/packages/model-runtime/src/providers/cloudflare/index.test.ts
@@ -558,5 +558,33 @@ describe('LobeCloudflareAI', () => {
 
       expect(result).toHaveLength(2);
     });
+
+    it('should throw ProviderBizError when Cloudflare returns a null result envelope', async () => {
+      // Arrange: Cloudflare's V4 envelope on auth/account errors carries `result: null`
+      // and the detail in `errors`. Without a guard, `result.map()` throws a 500 TypeError.
+      const apiKey = 'test_api_key';
+      const instance = new LobeCloudflareAI({ apiKey, baseURLOrAccountID: accountID });
+
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            errors: [{ code: 10000, message: 'Authentication error' }],
+            messages: [],
+            result: null,
+            success: false,
+          }),
+          { status: 400 },
+        ),
+      );
+
+      // Act & Assert
+      await expect(instance.models()).rejects.toEqual({
+        endpoint: expect.not.stringContaining(accountID),
+        error: expect.objectContaining({ result: null, success: false }),
+        errorType: bizErrorType,
+        message: 'Authentication error',
+        provider,
+      });
+    });
   });
 });

--- a/packages/model-runtime/src/providers/cloudflare/index.ts
+++ b/packages/model-runtime/src/providers/cloudflare/index.ts
@@ -162,25 +162,13 @@ export class LobeCloudflareAI implements LobeRuntimeAI {
     });
     const json = await response.json();
 
-    // Cloudflare wraps every response in a V4 envelope; on auth / account errors
-    // `result` is null and the failure detail lives in `errors`. Guard before
-    // mapping so a misconfigured key surfaces a proper provider error instead of
-    // a 500 `Cannot read properties of null (reading 'map')`.
+    // Cloudflare's V4 envelope returns `result: null` (not an array) on auth /
+    // account errors, so fall back to an empty list to avoid a 500
+    // `Cannot read properties of null (reading 'map')`. The model-list fetch is
+    // best-effort and the client swallows failures, so a misconfigured key just
+    // yields "no models" rather than a surfaced error.
     // https://developers.cloudflare.com/fundamentals/api/reference/responses/
-    const modelList: CloudflareModelCard[] | null | undefined = json?.result;
-
-    if (!Array.isArray(modelList)) {
-      throw AgentRuntimeError.chat({
-        endpoint: desensitizeCloudflareUrl(url),
-        error: json ?? { status: response.status },
-        errorType: AgentRuntimeErrorType.ProviderBizError,
-        message:
-          extractProviderErrorMessage(json?.errors?.[0]) ||
-          extractProviderErrorMessage(json) ||
-          `Cloudflare API returned ${response.status} ${response.statusText}`,
-        provider: ModelProvider.Cloudflare,
-      });
-    }
+    const modelList: CloudflareModelCard[] = json?.result ?? [];
 
     return modelList
       .map((model) => {

--- a/packages/model-runtime/src/providers/cloudflare/index.ts
+++ b/packages/model-runtime/src/providers/cloudflare/index.ts
@@ -162,7 +162,25 @@ export class LobeCloudflareAI implements LobeRuntimeAI {
     });
     const json = await response.json();
 
-    const modelList: CloudflareModelCard[] = json.result;
+    // Cloudflare wraps every response in a V4 envelope; on auth / account errors
+    // `result` is null and the failure detail lives in `errors`. Guard before
+    // mapping so a misconfigured key surfaces a proper provider error instead of
+    // a 500 `Cannot read properties of null (reading 'map')`.
+    // https://developers.cloudflare.com/fundamentals/api/reference/responses/
+    const modelList: CloudflareModelCard[] | null | undefined = json?.result;
+
+    if (!Array.isArray(modelList)) {
+      throw AgentRuntimeError.chat({
+        endpoint: desensitizeCloudflareUrl(url),
+        error: json ?? { status: response.status },
+        errorType: AgentRuntimeErrorType.ProviderBizError,
+        message:
+          extractProviderErrorMessage(json?.errors?.[0]) ||
+          extractProviderErrorMessage(json) ||
+          `Cloudflare API returned ${response.status} ${response.statusText}`,
+        provider: ModelProvider.Cloudflare,
+      });
+    }
 
     return modelList
       .map((model) => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- Surfaced by runtime error monitoring. -->

#### 🔀 Description of Change

`LobeCloudflareAI.models()` parsed the Cloudflare V4 response and called `json.result.map(...)` directly. Cloudflare wraps every API response in a V4 envelope, and on auth / account errors (invalid API token, wrong account ID, insufficient permissions) it returns `{ success: false, errors: [...], result: null }`. With `result` being `null`, `.map()` threw `TypeError: Cannot read properties of null (reading 'map')`, surfacing as a 500 from `Object.models`.

The model-list fetch is best-effort and the client (`ModelsService.getModels`) swallows failures (`if (!res.ok) return`), so there is nothing to surface to the user beyond an empty list. This falls back to an empty array when `result` is not present, mirroring the existing `(data.models || []).map()` guard in the GitHub Copilot provider. A misconfigured Cloudflare key now yields "no models" instead of a 500.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added a regression test in `cloudflare/index.test.ts` feeding a `result: null` envelope. It reproduces the exact `TypeError: Cannot read properties of null (reading 'map')` before the fix and asserts an empty list after. All 21 tests pass.