### PR TITLE
🔨 chore(codecov): update coverage grouping

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Packages
     env:
-      PACKAGES: '@lobechat/file-loaders @lobechat/prompts @lobechat/model-runtime @lobechat/web-crawler @lobechat/electron-server-ipc @lobechat/utils @lobechat/python-interpreter @lobechat/context-engine @lobechat/agent-runtime @lobechat/conversation-flow @lobechat/ssrf-safe-fetch @lobechat/memory-user-memory @lobechat/types @lobechat/trpc @lobechat/app-config @lobechat/locales @lobechat/env @lobechat/builtin-tool-lobe-agent model-bank @lobechat/agent-gateway-client @lobechat/agent-manager-runtime @lobechat/device-gateway-client @lobechat/device-identity @lobechat/eval-dataset-parser @lobechat/eval-rubric @lobechat/fetch-sse @lobechat/heterogeneous-agents'
+      PACKAGES: '@lobechat/file-loaders @lobechat/prompts @lobechat/model-runtime @lobechat/web-crawler @lobechat/electron-server-ipc @lobechat/utils @lobechat/context-engine @lobechat/agent-runtime @lobechat/conversation-flow @lobechat/ssrf-safe-fetch @lobechat/memory-user-memory @lobechat/types @lobechat/trpc @lobechat/app-config @lobechat/locales @lobechat/env @lobechat/builtin-tool-lobe-agent model-bank @lobechat/agent-gateway-client @lobechat/agent-manager-runtime @lobechat/device-gateway-client @lobechat/device-identity @lobechat/eval-dataset-parser @lobechat/eval-rubric @lobechat/fetch-sse @lobechat/heterogeneous-agents'
 
     steps:
       - name: Checkout
@@ -90,11 +90,23 @@ jobs:
           for package in $PACKAGES; do
             dir="${package#@lobechat/}"
             if [ -f "./packages/$dir/coverage/lcov.info" ]; then
-              echo "Uploading coverage for $dir..."
+              flag="packages/$dir"
+
+              case "$dir" in
+                builtin-tool-*)
+                  flag="builtin-tools"
+                  ;;
+                locales|env|device-gateway-client)
+                  echo "Skipping Codecov upload for $dir."
+                  continue
+                  ;;
+              esac
+
+              echo "Uploading coverage for $dir as $flag..."
               ./codecov upload-coverage \
                 $COMMON_ARGS \
                 --file ./packages/$dir/coverage/lcov.info \
-                --flag packages/$dir \
+                --flag "$flag" \
                 --disable-search
             fi
           done
@@ -105,8 +117,8 @@ jobs:
     if: needs.check-duplicate-run.outputs.should_skip != 'true'
     strategy:
       matrix:
-        shard: [1, 2, 3]
-    name: Test App (shard ${{ matrix.shard }}/3)
+        shard: [1, 2]
+    name: Test App (shard ${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -126,7 +138,7 @@ jobs:
         run: pnpm install
 
       - name: Run tests
-        run: bunx vitest --coverage --silent='passed-only' --reporter=default --reporter=blob --shard=${{ matrix.shard }}/3
+        run: bunx vitest --coverage --silent='passed-only' --reporter=default --reporter=blob --shard=${{ matrix.shard }}/2 --exclude '**/apps/server/**'
 
       - name: Upload blob report
         if: ${{ !cancelled() }}
@@ -218,6 +230,40 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./apps/desktop/coverage/lcov.info
           flags: desktop
+
+  test-server:
+    needs: check-duplicate-run
+    if: needs.check-duplicate-run.outputs.should_skip != 'true'
+    name: Test Server
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        env:
+          REF_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          REPOSITORY: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
+        run: |
+          git init .
+          git remote add origin "https://github.com/${REPOSITORY}.git"
+          git fetch --no-tags --depth=1 origin "${REF_SHA}"
+          git checkout --force FETCH_HEAD
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+
+      - name: Install deps
+        run: pnpm install
+
+      - name: Test Server Coverage
+        run: bunx vitest --coverage --silent='passed-only' --reporter=default --coverage.reportsDirectory=./apps/server/coverage --dir apps/server
+
+      - name: Upload Server coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./apps/server/coverage/lcov.info
+          flags: server
 
   test-databsae:
     needs: check-duplicate-run

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,20 @@
 component_management:
   individual_components:
+    # Top-level packages
+    - component_id: server
+      name: 'Server'
+      paths:
+        - apps/server/**
+    - component_id: database
+      name: 'Database'
+      paths:
+        - packages/database/**
+    - component_id: builtin_tools
+      name: 'Builtin Tools'
+      paths:
+        - packages/builtin-tool-*/**
+        - packages/builtin-tools/**
+
     # App architecture layers
     - component_id: app_store
       name: 'Store'
@@ -9,10 +24,6 @@ component_management:
       name: 'Services'
       paths:
         - src/services/**
-    - component_id: app_server
-      name: 'Server'
-      paths:
-        - src/server/**
     - component_id: app_libs
       name: 'Libs'
       paths:
@@ -26,14 +37,27 @@ coverage:
   status:
     project:
       default: off
+      server:
+        flags:
+          - server
       database:
         flags:
           - database
+      builtin-tools:
+        flags:
+          - builtin-tools
       app:
         flags:
           - app
       threshold: '0.5%'
     patch: off
+
+ignore:
+  - src/app/**/*.tsx
+  - packages/python-interpreter/**
+  - packages/locales/**
+  - packages/env/**
+  - packages/device-gateway-client/**
 
 comment:
   layout: 'header, diff, flags, components' # show component info in the PR comment


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Promote `apps/server`, `packages/database`, and built-in tools to top-level Codecov components, and remove the legacy `src/server` component from Codecov tracking.
- Add a dedicated server coverage upload with the `server` flag and exclude `apps/server` from the app coverage shards.
- Collapse `packages/builtin-tool-*` coverage uploads into a single `builtin-tools` flag.
- Remove `@lobechat/python-interpreter` from the package coverage job and hide low-signal package coverage for `locales`, `env`, and `device-gateway-client`.
- Ignore `src/app/**/*.tsx` in Codecov because these files are primarily component/page shells.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

```bash
ruby -e 'require "yaml"; YAML.load_file("codecov.yml"); YAML.load_file(".github/workflows/test.yml")'
bunx prettier --check codecov.yml .github/workflows/test.yml
git diff --check origin/canary..HEAD -- codecov.yml .github/workflows/test.yml
bunx vitest --coverage --silent='passed-only' --reporter=default --coverage.reportsDirectory=./apps/server/coverage --dir apps/server apps/server/src/utils/url.test.ts
```

The targeted server Vitest run passed with 4 tests. The full server suite was not run locally.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

N/A
