### PR TITLE
🔨 chore(ci): bump outdated action versions to latest

### DIFF
--- a/.github/workflows/issue-auto-comments.yml
+++ b/.github/workflows/issue-auto-comments.yml
@@ -30,7 +30,7 @@ jobs:
             This issue is closed, If you have any questions, you can comment and reply.
       - name: Checkout repository
         if: github.event_name == 'pull_request_target' && github.event.pull_request.merged == true
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check if PR author is maintainer
         if: github.event.pull_request.merged == true

--- a/.github/workflows/release-desktop-canary.yml
+++ b/.github/workflows/release-desktop-canary.yml
@@ -409,7 +409,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Delete old canary GitHub releases
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const { data: releases } = await github.rest.repos.listReleases({


### PR DESCRIPTION
## Description

Fix CI action version drift. Two workflows were using outdated action versions while all other workflows had already been upgraded.

## Changes

- **`.github/workflows/issue-auto-comments.yml`** — `actions/checkout@v4` → `@v6` (last remaining @v4; all 48 other uses are @v6)
- **`.github/workflows/release-desktop-canary.yml`** — `actions/github-script@v7` → `@v8` (last remaining @v7; all 4 other uses are @v8)

## Verification

- ✅ YAML syntax valid for both files
- ✅ Only workflow files changed (no source code impact)
- ✅ Hardcoded `node-version: 24.11.1` in other workflows were checked and are already consistent with `setup-env` action defaults