### PR TITLE
🐛 fix(agent-runtime): preserve server sub-agent parent chain

### DIFF
--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -353,9 +353,23 @@ const buildServerSubAgentRunner = (
         started: true,
         subOperationId: result?.operationId,
         threadId: result?.threadId ?? '',
+        toolMessageId: placeholder.id,
       };
     },
   };
+};
+
+const getDeferredToolMessageId = (result: ToolExecutionResultResponse): string | undefined => {
+  const toolMessageId = result.state?.toolMessageId;
+  return typeof toolMessageId === 'string' ? toolMessageId : undefined;
+};
+
+const withDeferredToolResultMessageId = (
+  tool: ChatToolPayload,
+  result: ToolExecutionResultResponse,
+): ChatToolPayload => {
+  const resultMessageId = getDeferredToolMessageId(result);
+  return resultMessageId ? { ...tool, result_msg_id: resultMessageId } : tool;
 };
 
 const shouldRetryLLM = (kind: LLMErrorKind, attempt: number, maxRetries: number) =>
@@ -1708,6 +1722,7 @@ export const createRuntimeExecutors = (
               newState.messages.push({
                 content,
                 id: assistantMessageItem.id,
+                parentId,
                 reasoning: persistedReasoning,
                 role: 'assistant',
                 tool_calls: stateToolCalls,
@@ -2467,7 +2482,9 @@ export const createRuntimeExecutors = (
             interruptedAt: new Date().toISOString(),
             reason: 'async_tool',
           };
-          newState.pendingToolsCalling = [chatToolPayload];
+          newState.pendingToolsCalling = [
+            withDeferredToolResultMessageId(chatToolPayload, execution.result),
+          ];
           return {
             events: [
               {
@@ -2769,9 +2786,11 @@ export const createRuntimeExecutors = (
    */
   call_tools_batch: async (instruction, state) => {
     const { payload } = instruction as Extract<AgentInstruction, { type: 'call_tools_batch' }>;
-    const { parentMessageId, toolsCalling } = payload;
+    const { parentMessageId } = payload;
+    const toolsCalling = payload.toolsCalling as ChatToolPayload[];
     const { operationId, stepIndex, streamManager, toolExecutionService } = ctx;
     const events: AgentEvent[] = [];
+    const toolCallOrder = new Map(toolsCalling.map((tool, index) => [tool.id, index] as const));
 
     const operationLogId = `${operationId}:${stepIndex}`;
     log(
@@ -3022,7 +3041,9 @@ export const createRuntimeExecutors = (
             // the batch parks for it after all server tools settle.
             if (execution.result.deferred) {
               log(`[${operationLogId}] Tool ${toolName} deferred; will park after batch`);
-              deferredTools.push(chatToolPayload);
+              deferredTools.push(
+                withDeferredToolResultMessageId(chatToolPayload, execution.result),
+              );
               batchExecuteToolSpan.setAttributes(
                 buildExecuteToolResultAttributes({ attempts: execution.attempts, success: true }),
               );
@@ -3287,7 +3308,9 @@ export const createRuntimeExecutors = (
     // Park if any tools still owe an out-of-band result: client tools (run on
     // the client) and/or deferred async tools (e.g. sub-agents). The operation
     // resumes once every pending tool's result is delivered.
-    const pendingTools = [...deferredTools, ...clientTools];
+    const pendingTools = [...deferredTools, ...clientTools].sort(
+      (a, b) => (toolCallOrder.get(a.id) ?? 0) - (toolCallOrder.get(b.id) ?? 0),
+    );
     if (pendingTools.length > 0) {
       // Prefer the async-tool reason when any deferred tool is present; the
       // individual pending payloads still carry their own identity for the

--- a/apps/server/src/routers/lambda/__tests__/integration/aiAgent/serverSubAgent.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/aiAgent/serverSubAgent.integration.test.ts
@@ -11,8 +11,8 @@
  *      sub-agent's answer and resumes the parent.
  *   5. The parent op runs one more LLM step and reaches `done`.
  */
-import { type LobeChatDatabase } from '@lobechat/database';
-import { agentOperations, agents, messages } from '@lobechat/database/schemas';
+import type { LobeChatDatabase } from '@lobechat/database';
+import { agentOperations, agents, messagePlugins, messages } from '@lobechat/database/schemas';
 import { getTestDB } from '@lobechat/database/test-utils';
 import { eq } from 'drizzle-orm';
 import OpenAI from 'openai';
@@ -45,6 +45,7 @@ let testAgentId: string;
 
 const SUB_AGENT_ANSWER = 'The sub-agent researched the topic and found the answer is 42.';
 const PARENT_FINAL = 'Based on the sub-agent result, the final answer is 42.';
+const BATCH_PARENT_FINAL = 'All three sub-agent results are ready.';
 
 const createTestContext = () => ({ jwtPayload: { userId }, userId });
 
@@ -109,6 +110,81 @@ const createCallSubAgentResponse = () => {
             type: 'message',
           },
           fnCall,
+        ],
+        status: 'completed',
+        usage: { input_tokens: 30, output_tokens: 20, total_tokens: 50 },
+      },
+      type: 'response.completed',
+    },
+  ];
+
+  return createMockResponsesStream(chunks);
+};
+
+/** Mock parent first step: three parallel `callSubAgent` tool calls. */
+const createBatchCallSubAgentResponse = () => {
+  const responseId = `resp_parent_batch_${Date.now()}`;
+  const msgItemId = `msg_parent_batch_${Date.now()}`;
+  const calls = [1, 2, 3].map((index) => ({
+    arguments: JSON.stringify({
+      description: `Research part ${index}`,
+      instruction: `Find answer part ${index}.`,
+    }),
+    call_id: `call_subagent_${index}`,
+    name: 'lobe-agent____callSubAgent',
+    type: 'function_call',
+  }));
+
+  const chunks = [
+    {
+      response: {
+        created_at: Math.floor(Date.now() / 1000),
+        id: responseId,
+        model: 'gpt-5-pro',
+        object: 'response',
+        output: [],
+        status: 'in_progress',
+      },
+      type: 'response.created',
+    },
+    {
+      item: {
+        content: [],
+        id: msgItemId,
+        role: 'assistant',
+        status: 'in_progress',
+        type: 'message',
+      },
+      output_index: 0,
+      type: 'response.output_item.added',
+    },
+    {
+      content_index: 0,
+      delta: 'I will delegate these three parts.',
+      item_id: msgItemId,
+      output_index: 0,
+      type: 'response.output_text.delta',
+    },
+    ...calls.map((item, index) => ({
+      item,
+      output_index: index + 1,
+      type: 'response.output_item.added',
+    })),
+    {
+      response: {
+        created_at: Math.floor(Date.now() / 1000),
+        id: responseId,
+        model: 'gpt-5-pro',
+        object: 'response',
+        output: [
+          {
+            content: [{ text: 'I will delegate these three parts.', type: 'output_text' }],
+            id: msgItemId,
+            role: 'assistant',
+            status: 'completed',
+            type: 'message',
+          },
+          ...calls,
         ],
         status: 'completed',
         usage: { input_tokens: 30, output_tokens: 20, total_tokens: 50 },
@@ -244,5 +320,77 @@ describe('Server callSubAgent suspend/resume', () => {
       (m) => m.role === 'tool' && m.content === SUB_AGENT_ANSWER,
     );
     expect(subAgentToolMessage).toBeDefined();
+  });
+
+  it('keeps the resumed parent assistant chained to the last sub-agent tool result', async () => {
+    // 1: parent emits three callSubAgent tool calls
+    // 2-4: three sub-ops answer
+    // 5: parent resumes with the final answer
+    let callCount = 0;
+    mockResponsesCreate.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve(createBatchCallSubAgentResponse() as any);
+      if (callCount <= 4) {
+        return Promise.resolve(createFinalTextResponse(`Sub-agent answer ${callCount - 1}`) as any);
+      }
+      return Promise.resolve(createFinalTextResponse(BATCH_PARENT_FINAL) as any);
+    });
+
+    const caller = aiAgentRouter.createCaller(createTestContext());
+
+    const createResult = await caller.execAgent({
+      agentId: testAgentId,
+      prompt: 'Please research three parts in parallel and summarize.',
+    });
+    expect(createResult.success).toBe(true);
+
+    const finalState = await waitForOperationComplete(
+      inMemoryAgentStateManager,
+      createResult.operationId,
+      { maxWaitTime: 20_000 },
+    );
+
+    expect(finalState.status).toBe('done');
+    expect(mockResponsesCreate).toHaveBeenCalledTimes(5);
+
+    const allMessages = await serverDB.select().from(messages).where(eq(messages.userId, userId));
+    const allPlugins = await serverDB
+      .select()
+      .from(messagePlugins)
+      .where(eq(messagePlugins.userId, userId));
+
+    const parentMessages = allMessages.filter(
+      (m) => m.agentId === testAgentId && !m.threadId && m.topicId === createResult.topicId,
+    );
+
+    const delegatingAssistant = parentMessages.find(
+      (m) => m.role === 'assistant' && Array.isArray(m.tools) && m.tools.length === 3,
+    );
+    expect(delegatingAssistant).toBeDefined();
+
+    const declaredTools = delegatingAssistant!.tools as Array<{ id: string }>;
+    const lastDeclaredToolId = declaredTools.at(-1)?.id;
+    expect(lastDeclaredToolId).toBe('call_subagent_3');
+
+    const pluginByToolCallId = new Map(
+      allPlugins.map((plugin) => [plugin.toolCallId, plugin.id] as const),
+    );
+    const toolMessageIds = declaredTools.map((tool) => pluginByToolCallId.get(tool.id));
+    expect(toolMessageIds.every(Boolean)).toBe(true);
+
+    const expectedLastToolMessageId = pluginByToolCallId.get(lastDeclaredToolId!);
+    expect(expectedLastToolMessageId).toBeDefined();
+
+    const finalAssistant = parentMessages.find(
+      (m) => m.role === 'assistant' && m.content === BATCH_PARENT_FINAL,
+    );
+    expect(finalAssistant).toBeDefined();
+    expect(toolMessageIds).toContain(finalAssistant!.parentId);
+
+    const finalStateAssistant = [...(finalState.messages ?? [])]
+      .reverse()
+      .find((m) => m.role === 'assistant' && m.content === BATCH_PARENT_FINAL);
+    expect(finalStateAssistant).toBeDefined();
+    expect(finalStateAssistant!.parentId).toBe(expectedLastToolMessageId);
   });
 });

--- a/apps/server/src/services/toolExecution/serverRuntimes/lobeAgent.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/lobeAgent.ts
@@ -151,7 +151,7 @@ class LobeAgentExecutionRuntime {
       return buildError('instruction is required.', 'INVALID_ARGUMENTS');
     }
 
-    const { started, threadId, subOperationId } = await ctx.subAgent.run({
+    const { started, threadId, subOperationId, toolMessageId } = await ctx.subAgent.run({
       description,
       instruction,
       timeout,
@@ -169,7 +169,7 @@ class LobeAgentExecutionRuntime {
       // No tool_result yet — the bridge fills this in when the sub-op completes.
       content: '',
       deferred: true,
-      state: { status: 'pending', subOperationId, threadId },
+      state: { status: 'pending', subOperationId, threadId, toolMessageId },
       success: true,
     };
   };

--- a/apps/server/src/services/toolExecution/types.ts
+++ b/apps/server/src/services/toolExecution/types.ts
@@ -38,6 +38,8 @@ export interface ServerSubAgentRunResult {
   subOperationId?: string;
   /** The isolation thread holding the sub-agent's full message trace. */
   threadId: string;
+  /** Parent conversation tool message placeholder that receives the sub-agent result. */
+  toolMessageId?: string;
 }
 
 /**


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

This fixes the parent message chain for server-side `callSubAgent` resume flows.

- Return the parent conversation placeholder tool message id from the server sub-agent runner.
- Carry that id through the deferred tool result as `result_msg_id` so async-tool resume can use a deterministic parent anchor.
- Preserve the original tool-call order for mixed/batched pending tools, instead of relying on concurrent completion order.
- Include `parentId` when appending the resumed assistant message into `AgentState.messages`, so the server final state matches the persisted DB chain.
- Add a regression integration test for three parallel `callSubAgent` calls and the resumed parent assistant chain.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run --silent='passed-only' apps/server/src/routers/lambda/__tests__/integration/aiAgent/serverSubAgent.integration.test.ts
bunx vitest run --silent='passed-only' apps/server/src/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
git diff --check
```

Also ran:

```bash
bun run type-check
```

It currently fails on existing repository-wide type issues unrelated to this change, including `@lobehub/market-sdk` export drift, missing `@lobechat/types` exports, and duplicated Form/React dependency types. The touched runtime/test files no longer report type errors.

#### 📸 Screenshots / Videos

N/A. Backend/runtime fix only.

#### 📝 Additional Information

The regression first failed with `finalStateAssistant.parentId` missing after a server sub-agent resume. It now passes and asserts both persisted message sanity and the final runtime state parent chain.
