### PR TITLE
🐛 fix: add sendDirectMessage to MessageDispatcherService

### DIFF
--- a/apps/server/src/services/toolExecution/serverRuntimes/message/MessageDispatcherService.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/message/MessageDispatcherService.ts
@@ -30,6 +30,8 @@ import type {
   ReplyToThreadState,
   SearchMessagesParams,
   SearchMessagesState,
+  SendDirectMessageParams,
+  SendDirectMessageState,
   SendMessageParams,
   SendMessageState,
   UnpinMessageParams,
@@ -150,5 +152,13 @@ export class MessageDispatcherService implements MessageRuntimeService {
 
   createPoll = async (params: CreatePollParams): Promise<CreatePollState> => {
     return (await this.getService(params.platform)).createPoll(params);
+  };
+
+  // ==================== Direct Messaging ====================
+
+  sendDirectMessage = async (
+    params: SendDirectMessageParams,
+  ): Promise<SendDirectMessageState> => {
+    return (await this.getService(params.platform)).sendDirectMessage!(params);
   };
 }


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->
<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of change

Add `sendDirectMessage` method to `MessageDispatcherService` in the task execution service layer. This delegates direct message sending to platform-specific runtime services, enabling direct messaging support in task execution workflows.

- Adds `SendDirectMessageParams` and `SendDirectMessageState` type imports
- Implements `sendDirectMessage` method following the existing delegation pattern used by other methods (e.g., `createPoll`)

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Verify the method correctly delegates to the platform-specific service implementation.

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

#### 📝 Additional Information

This is part of the `fix-directMessage-in-tasks` branch work to enable direct messaging capabilities in task execution.

The fix has been implemented by Qwen-3.6. Tested on self hosted instance