### PR TITLE
🐛 fix: keep model guard in provider grouping

### DIFF
--- a/src/features/ModelSwitchPanel/components/List/ListItemRenderer.tsx
+++ b/src/features/ModelSwitchPanel/components/List/ListItemRenderer.tsx
@@ -147,39 +147,6 @@ export const ListItemRenderer = memo<ListItemRendererProps>(
         const isActive = key === activeKey;
         const restricted = isModelRestricted?.(item.model.id, item.provider.id);
 
-        if (isDevMode) {
-          return (
-            <Flexbox style={{ marginBlock: 1, marginInline: 4 }}>
-              <DropdownMenuSubmenuRoot open={detailOpen} onOpenChange={setDetailOpen}>
-                <DropdownMenuSubmenuTrigger
-                  className={cx(menuSharedStyles.item, isActive && styles.menuItemActive)}
-                  style={{ paddingBlock: 8, paddingInline: 8 }}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    setDetailOpen(false);
-                    onClose();
-                    onModelChange(item.model.id, item.provider.id);
-                  }}
-                >
-                  <ModelItemRender
-                    {...item.model}
-                    {...item.model.abilities}
-                    showInfoTag
-                    newBadgeLabel={newLabel}
-                  />
-                </DropdownMenuSubmenuTrigger>
-                <DropdownMenuPortal>
-                  <DropdownMenuPositioner anchor={null} placement="right" sideOffset={12}>
-                    <DropdownMenuPopup className={styles.detailPopup}>
-                      <ModelDetailPanel model={item.model.id} provider={item.provider.id} />
-                    </DropdownMenuPopup>
-                  </DropdownMenuPositioner>
-                </DropdownMenuPortal>
-              </DropdownMenuSubmenuRoot>
-            </Flexbox>
-          );
-        }
-
         return (
           <Flexbox style={{ marginBlock: 1, marginInline: 4 }}>
             <DropdownMenuSubmenuRoot open={detailOpen} onOpenChange={setDetailOpen}>
@@ -203,6 +170,7 @@ export const ListItemRenderer = memo<ListItemRendererProps>(
                   {...item.model.abilities}
                   newBadgeLabel={newLabel}
                   proBadgeLabel={restricted ? proLabel : undefined}
+                  showInfoTag={isDevMode}
                 />
               </DropdownMenuSubmenuTrigger>
               <DropdownMenuPortal>


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

This PR keeps provider-grouped model rows on the same guarded selection path as the default model row rendering.

Previously, Dev Mode used a separate early return for provider-grouped rows. That path skipped the restricted-model guard and badge props. The row now reuses the common render branch while still showing Dev Mode info tags.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Automated/local checks:

```bash
vscode-cli get-diagnostics --not-recommend-file-paths lobehub/src/features/ModelSwitchPanel/components/List/ListItemRenderer.tsx
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No breaking changes.
