### PR TITLE
🐛 fix(editor-canvas): re-check editor init state before subscribing

### DIFF
--- a/src/features/EditorCanvas/DiffAllToolbar.tsx
+++ b/src/features/EditorCanvas/DiffAllToolbar.tsx
@@ -42,6 +42,14 @@ const useIsEditorInit = (editor?: IEditor) => {
   useEffect(() => {
     if (!editor) return;
 
+    // The editor may have initialized between render and this effect
+    // (the Editor canvas mounts earlier and emits 'initialized' synchronously),
+    // so re-check before subscribing to avoid missing the event forever.
+    if (editor.getLexicalEditor()) {
+      setEditInit(true);
+      return;
+    }
+
     const onInit = () => {
       setEditInit(true);
     };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

`useIsEditorInit` in `DiffAllToolbar` subscribes to the editor's `initialized` event inside a `useEffect`. The Editor canvas mounts earlier and may emit `initialized` synchronously between render and effect execution, so the subscription could miss the event forever and the toolbar would never render.

This adds a re-check of `editor.getLexicalEditor()` at the start of the effect: if the editor is already initialized by the time the effect runs, set the state directly instead of waiting for an event that already fired.

#### 🧪 How to Test

Open a file with pending diffs in the editor canvas and verify the Diff All toolbar appears reliably, including when the editor initializes before the toolbar mounts (e.g. fast reopen of an already-loaded document).

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

Pure race-condition fix, no behavior change when the event still arrives after subscription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)