### PR TITLE
🐛 fix(agent-runtime): always persist assistant reasoning to DB

### DIFF
--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -660,7 +660,7 @@ export const createRuntimeExecutors = (
 
     try {
       type ContentPart = { text: string; type: 'text' } | { image: string; type: 'image' };
-      let shouldPersistAssistantReasoning = false;
+      let shouldReplayAssistantReasoning = false;
       let preserveThinkingForPayload: boolean | undefined;
 
       // Process messages through serverMessagesEngine to inject system role, knowledge, etc.
@@ -699,8 +699,7 @@ export const createRuntimeExecutors = (
           modelSupportsPreserveThinkingFromCard ||
           (!modelCard && providerSupportsPreserveThinkingFallback);
 
-        shouldPersistAssistantReasoning =
-          preserveThinkingRequested && modelSupportsPreserveThinking;
+        shouldReplayAssistantReasoning = preserveThinkingRequested && modelSupportsPreserveThinking;
         preserveThinkingForPayload =
           modelSupportsPreserveThinking && typeof preserveThinkingConfigured === 'boolean'
             ? preserveThinkingConfigured
@@ -1639,9 +1638,10 @@ export const createRuntimeExecutors = (
                 };
               }
 
-              const persistedReasoning = shouldPersistAssistantReasoning
-                ? finalReasoning
-                : undefined;
+              // preserveThinking only gates whether reasoning is replayed into the
+              // next LLM payload (state.messages); the DB copy powers UI display
+              // after refresh and must always be saved.
+              const replayedReasoning = shouldReplayAssistantReasoning ? finalReasoning : undefined;
 
               try {
                 // Build metadata object
@@ -1675,7 +1675,7 @@ export const createRuntimeExecutors = (
                   content: finalContent,
                   imageList: imageList.length > 0 ? imageList : undefined,
                   metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
-                  reasoning: persistedReasoning,
+                  reasoning: finalReasoning,
                   search: grounding,
                   tools: persistedTools,
                 });
@@ -1708,7 +1708,7 @@ export const createRuntimeExecutors = (
               newState.messages.push({
                 content,
                 id: assistantMessageItem.id,
-                reasoning: persistedReasoning,
+                reasoning: replayedReasoning,
                 role: 'assistant',
                 tool_calls: stateToolCalls,
               });

--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -408,8 +408,11 @@ describe('RuntimeExecutors', () => {
       );
     });
 
-    describe('reasoning persistence gate', () => {
-      it('should persist assistant reasoning with tool calls when preserveThinking is enabled on a supported model', async () => {
+    // preserveThinking gates whether reasoning is replayed into the next LLM
+    // payload (state.messages). The DB copy powers UI display after refresh and
+    // is always persisted regardless of the gate.
+    describe('reasoning replay gate', () => {
+      it('should replay assistant reasoning with tool calls when preserveThinking is enabled on a supported model', async () => {
         const toolCallPayload = [
           {
             function: { arguments: '{}', name: 'search' },
@@ -474,7 +477,7 @@ describe('RuntimeExecutors', () => {
         );
       });
 
-      it('should not persist assistant reasoning when preserveThinking is not enabled', async () => {
+      it('should persist reasoning to DB but not replay it when preserveThinking is not enabled', async () => {
         const mockChat = vi.fn().mockImplementation(async (_payload, options) => {
           await options?.callback?.onThinking?.('hidden reasoning');
           await options?.callback?.onText?.('answer');
@@ -498,9 +501,14 @@ describe('RuntimeExecutors', () => {
         const assistant = result.newState.messages.at(-1) as any;
 
         expect(assistant.reasoning).toBeUndefined();
+        // DB persistence must NOT be gated — UI shows reasoning after refresh
+        expect(mockMessageModel.update).toHaveBeenCalledWith(
+          'msg-123',
+          expect.objectContaining({ reasoning: { content: 'hidden reasoning' } }),
+        );
       });
 
-      it('should persist assistant reasoning when preserveThinking is enabled on a supported model', async () => {
+      it('should replay assistant reasoning when preserveThinking is enabled on a supported model', async () => {
         const mockChat = vi.fn().mockImplementation(async (_payload, options) => {
           await options?.callback?.onThinking?.('preserved reasoning');
           await options?.callback?.onText?.('answer');
@@ -546,7 +554,7 @@ describe('RuntimeExecutors', () => {
         );
       });
 
-      it('should persist reasoning for unknown custom deployments on supported providers', async () => {
+      it('should replay reasoning for unknown custom deployments on supported providers', async () => {
         const mockChat = vi.fn().mockImplementation(async (_payload, options) => {
           await options?.callback?.onThinking?.('custom deployment reasoning');
           await options?.callback?.onText?.('answer');
@@ -592,9 +600,9 @@ describe('RuntimeExecutors', () => {
         );
       });
 
-      it('should not persist reasoning when model does not declare preserveThinking capability', async () => {
+      it('should persist reasoning to DB but not replay it when model does not declare preserveThinking capability', async () => {
         const mockChat = vi.fn().mockImplementation(async (_payload, options) => {
-          await options?.callback?.onThinking?.('reasoning that should not be saved');
+          await options?.callback?.onThinking?.('reasoning on an unsupported model');
           await options?.callback?.onText?.('answer');
           return new Response('done');
         });
@@ -633,6 +641,13 @@ describe('RuntimeExecutors', () => {
         expect(mockChat).toHaveBeenCalledWith(
           expect.not.objectContaining({ preserveThinking: expect.any(Boolean) }),
           expect.anything(),
+        );
+        // DB persistence must NOT be gated — UI shows reasoning after refresh
+        expect(mockMessageModel.update).toHaveBeenCalledWith(
+          'msg-123',
+          expect.objectContaining({
+            reasoning: { content: 'reasoning on an unsupported model' },
+          }),
         );
       });
     });
@@ -771,9 +786,9 @@ describe('RuntimeExecutors', () => {
         });
         vi.mocked(initModelRuntimeFromDB).mockResolvedValueOnce({ chat: mockChat } as any);
 
-        // Reasoning only lands in the finalized message when preserveThinking is
-        // enabled on a supported model; otherwise it is intentionally dropped.
-        // Enable it here so this still guards reasoning_part capture (not drop).
+        // Reasoning is only replayed into state.messages when preserveThinking is
+        // enabled on a supported model. Enable it here so this asserts
+        // reasoning_part capture via the state replay path.
         const ctxWithThinking: RuntimeExecutorContext = {
           ...ctx,
           agentConfig: { chatConfig: { preserveThinking: true }, plugins: [], systemRole: 'test' },

--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -918,7 +918,7 @@
   "workflow.toolDisplayName.calculate": "Calculated",
   "workflow.toolDisplayName.callAgent": "Called an agent",
   "workflow.toolDisplayName.callMcpTool": "Called MCP tool",
-  "workflow.toolDisplayName.callSubAgent": "Call SubAgent",
+  "workflow.toolDisplayName.callSubAgent": "Called a sub-agent",
   "workflow.toolDisplayName.clearTodos": "Cleared todos",
   "workflow.toolDisplayName.copyDocument": "Copied a document",
   "workflow.toolDisplayName.crawlMultiPages": "Crawled pages",

--- a/locales/en-US/plugin.json
+++ b/locales/en-US/plugin.json
@@ -100,7 +100,7 @@
   "builtins.lobe-agent.apiName.analyzeVisualMedia": "Analyze visual media",
   "builtins.lobe-agent.apiName.analyzeVisualMedia.mediaCount": "{{count}} media",
   "builtins.lobe-agent.apiName.analyzeVisualMedia.result": "Analyze visual media: <question>{{question}}</question>",
-  "builtins.lobe-agent.apiName.callSubAgent": "Call SubAgent",
+  "builtins.lobe-agent.apiName.callSubAgent": "Call sub-agent",
   "builtins.lobe-agent.apiName.clearTodos": "Clear todos",
   "builtins.lobe-agent.apiName.clearTodos.modeAll": "all",
   "builtins.lobe-agent.apiName.clearTodos.modeCompleted": "completed",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -918,7 +918,7 @@
   "workflow.toolDisplayName.calculate": "完成了计算",
   "workflow.toolDisplayName.callAgent": "调用了助理",
   "workflow.toolDisplayName.callMcpTool": "调用了 MCP 工具",
-  "workflow.toolDisplayName.callSubAgent": "Call SubAgent",
+  "workflow.toolDisplayName.callSubAgent": "调用了子助理",
   "workflow.toolDisplayName.clearTodos": "清空了待办",
   "workflow.toolDisplayName.copyDocument": "复制了文档",
   "workflow.toolDisplayName.crawlMultiPages": "抓取了多个页面",

--- a/locales/zh-CN/plugin.json
+++ b/locales/zh-CN/plugin.json
@@ -100,7 +100,7 @@
   "builtins.lobe-agent.apiName.analyzeVisualMedia": "分析视觉媒体",
   "builtins.lobe-agent.apiName.analyzeVisualMedia.mediaCount": "{{count}} 个媒体",
   "builtins.lobe-agent.apiName.analyzeVisualMedia.result": "分析视觉媒体：<question>{{question}}</question>",
-  "builtins.lobe-agent.apiName.callSubAgent": "Call SubAgent",
+  "builtins.lobe-agent.apiName.callSubAgent": "调用子助理",
   "builtins.lobe-agent.apiName.clearTodos": "清除待办",
   "builtins.lobe-agent.apiName.clearTodos.modeAll": "全部",
   "builtins.lobe-agent.apiName.clearTodos.modeCompleted": "已完成",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -1006,7 +1006,7 @@ export default {
   'workflow.toolDisplayName.calculate': 'Calculated',
   'workflow.toolDisplayName.callAgent': 'Called an agent',
   'workflow.toolDisplayName.callMcpTool': 'Called MCP tool',
-  'workflow.toolDisplayName.callSubAgent': 'Call SubAgent',
+  'workflow.toolDisplayName.callSubAgent': 'Called a sub-agent',
   'workflow.toolDisplayName.clearTodos': 'Cleared todos',
   'workflow.toolDisplayName.copyDocument': 'Copied a document',
   'workflow.toolDisplayName.crawlMultiPages': 'Crawled pages',

--- a/packages/locales/src/default/plugin.ts
+++ b/packages/locales/src/default/plugin.ts
@@ -55,7 +55,7 @@ export default {
   'builtins.lobe-agent.apiName.analyzeVisualMedia.mediaCount': '{{count}} media',
   'builtins.lobe-agent.apiName.analyzeVisualMedia.result':
     'Analyze visual media: <question>{{question}}</question>',
-  'builtins.lobe-agent.apiName.callSubAgent': 'Call SubAgent',
+  'builtins.lobe-agent.apiName.callSubAgent': 'Call sub-agent',
   'builtins.lobe-agent.subAgent.stats.tokens': '{{count}} tokens',
   'builtins.lobe-agent.subAgent.stats.tools': '{{count}} tools',
   'builtins.lobe-agent.title': 'Lobe Agent',


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Regression introduced by #13494.

#### 🔀 Description of Change

#13494 added a `preserveThinking` feature for Qwen3.7 Max, but it also gated the **DB persistence** of assistant reasoning behind the same condition (`chatConfig.preserveThinking === true` **and** model `extendParams` includes `preserveThinking` / qwen-zhipu provider fallback).

That gate conflates two distinct concerns:

1. **Payload replay** — whether reasoning is fed back into the next LLM call (`state.messages`). This *should* be gated by model capability, since most providers reject or ignore replayed thinking.
2. **DB persistence** — whether reasoning is saved to the `messages` table for UI display. This should *not* be gated.

Since the merge, every server-side agent run on a non-qwen/zhipu reasoning model silently lost its thinking content: reasoning streamed live via `stream_end`, but after a page refresh it was gone (`messages.reasoning` was `null`). The interrupted-stream persistence path was never gated, making the happy path inconsistent with it as well.

This PR:

- Restores **unconditional** `reasoning: finalReasoning` in the `messageModel.update` call.
- Keeps the `preserveThinking` gate only for the `state.messages` push (payload replay), renaming `shouldPersistAssistantReasoning` → `shouldReplayAssistantReasoning` to match its actual semantics.
- Updates the test suite: the existing replay-gate assertions are preserved, and new assertions verify the DB update always receives reasoning even when the gate is off.

#### 🧪 How to Test

Run a server-side agent with any non-qwen/zhipu thinking model (e.g. `lobehub/deepseek-v4-pro`), let it produce reasoning, then refresh the page — the thinking block should still render (previously it disappeared).

```bash
bunx vitest run 'apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts'
```

All 116 tests pass.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

Behavior matrix after this fix:

| Scenario | DB `reasoning` | Replayed into next payload |
| -------- | -------------- | -------------------------- |
| preserveThinking on + supported model | saved | yes |
| preserveThinking off / unsupported model | saved | no (unchanged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)