### PR TITLE
🐛 fix(agent-runtime): persist assistant reasoning to DB

### DIFF
--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -660,7 +660,7 @@ export const createRuntimeExecutors = (
 
     try {
       type ContentPart = { text: string; type: 'text' } | { image: string; type: 'image' };
-      let shouldPersistAssistantReasoning = false;
+      let shouldReplayAssistantReasoning = false;
       let preserveThinkingForPayload: boolean | undefined;
 
       // Process messages through serverMessagesEngine to inject system role, knowledge, etc.
@@ -699,8 +699,7 @@ export const createRuntimeExecutors = (
           modelSupportsPreserveThinkingFromCard ||
           (!modelCard && providerSupportsPreserveThinkingFallback);
 
-        shouldPersistAssistantReasoning =
-          preserveThinkingRequested && modelSupportsPreserveThinking;
+        shouldReplayAssistantReasoning = preserveThinkingRequested && modelSupportsPreserveThinking;
         preserveThinkingForPayload =
           modelSupportsPreserveThinking && typeof preserveThinkingConfigured === 'boolean'
             ? preserveThinkingConfigured
@@ -1639,9 +1638,10 @@ export const createRuntimeExecutors = (
                 };
               }
 
-              const persistedReasoning = shouldPersistAssistantReasoning
-                ? finalReasoning
-                : undefined;
+              // preserveThinking only gates whether reasoning is replayed into the
+              // next LLM payload (state.messages); the DB copy powers UI display
+              // after refresh and must always be saved.
+              const replayedReasoning = shouldReplayAssistantReasoning ? finalReasoning : undefined;
 
               try {
                 // Build metadata object
@@ -1675,7 +1675,7 @@ export const createRuntimeExecutors = (
                   content: finalContent,
                   imageList: imageList.length > 0 ? imageList : undefined,
                   metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
-                  reasoning: persistedReasoning,
+                  reasoning: finalReasoning,
                   search: grounding,
                   tools: persistedTools,
                 });
@@ -1708,7 +1708,7 @@ export const createRuntimeExecutors = (
               newState.messages.push({
                 content,
                 id: assistantMessageItem.id,
-                reasoning: persistedReasoning,
+                reasoning: replayedReasoning,
                 role: 'assistant',
                 tool_calls: stateToolCalls,
               });

--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -202,15 +202,46 @@ const isEmptyModelCompletion = (params: {
   return true;
 };
 
+type ReasoningReplayMessage = UIChatMessage & {
+  children?: ReasoningReplayMessage[];
+  members?: ReasoningReplayMessage[];
+  reasoning?: unknown;
+};
+
 const stripAssistantReasoningForReplay = (messages: UIChatMessage[]): UIChatMessage[] => {
+  const stripMessage = (message: ReasoningReplayMessage): ReasoningReplayMessage => {
+    let changed = false;
+
+    const children = message.children?.map((child) => {
+      const strippedChild = stripMessage(child);
+      if (strippedChild !== child) changed = true;
+      return strippedChild;
+    });
+
+    const members = message.members?.map((member) => {
+      const strippedMember = stripMessage(member);
+      if (strippedMember !== member) changed = true;
+      return strippedMember;
+    });
+
+    if ('reasoning' in message) changed = true;
+    if (!changed) return message;
+
+    const { reasoning: _reasoning, ...messageWithoutReasoning } = message;
+
+    return {
+      ...messageWithoutReasoning,
+      ...(children ? { children } : {}),
+      ...(members ? { members } : {}),
+    } as ReasoningReplayMessage;
+  };
+
   let changed = false;
 
   const strippedMessages = messages.map((message) => {
-    if (message.role !== 'assistant' || !('reasoning' in message)) return message;
-
-    changed = true;
-    const { reasoning: _reasoning, ...messageWithoutReasoning } = message;
-    return messageWithoutReasoning as UIChatMessage;
+    const strippedMessage = stripMessage(message as ReasoningReplayMessage);
+    if (strippedMessage !== message) changed = true;
+    return strippedMessage as UIChatMessage;
   });
 
   return changed ? strippedMessages : messages;

--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -202,14 +202,14 @@ const isEmptyModelCompletion = (params: {
   return true;
 };
 
-type ReasoningReplayMessage = UIChatMessage & {
-  children?: ReasoningReplayMessage[];
-  members?: ReasoningReplayMessage[];
+type ReasoningReplayNode = {
+  children?: ReasoningReplayNode[];
+  members?: ReasoningReplayNode[];
   reasoning?: unknown;
 };
 
 const stripAssistantReasoningForReplay = (messages: UIChatMessage[]): UIChatMessage[] => {
-  const stripMessage = (message: ReasoningReplayMessage): ReasoningReplayMessage => {
+  const stripMessage = <T extends ReasoningReplayNode>(message: T): T => {
     let changed = false;
 
     const children = message.children?.map((child) => {
@@ -233,15 +233,15 @@ const stripAssistantReasoningForReplay = (messages: UIChatMessage[]): UIChatMess
       ...messageWithoutReasoning,
       ...(children ? { children } : {}),
       ...(members ? { members } : {}),
-    } as ReasoningReplayMessage;
+    } as T;
   };
 
   let changed = false;
 
   const strippedMessages = messages.map((message) => {
-    const strippedMessage = stripMessage(message as ReasoningReplayMessage);
+    const strippedMessage = stripMessage(message);
     if (strippedMessage !== message) changed = true;
-    return strippedMessage as UIChatMessage;
+    return strippedMessage;
   });
 
   return changed ? strippedMessages : messages;

--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -202,6 +202,20 @@ const isEmptyModelCompletion = (params: {
   return true;
 };
 
+const stripAssistantReasoningForReplay = (messages: UIChatMessage[]): UIChatMessage[] => {
+  let changed = false;
+
+  const strippedMessages = messages.map((message) => {
+    if (message.role !== 'assistant' || !('reasoning' in message)) return message;
+
+    changed = true;
+    const { reasoning: _reasoning, ...messageWithoutReasoning } = message;
+    return messageWithoutReasoning as UIChatMessage;
+  });
+
+  return changed ? strippedMessages : messages;
+};
+
 const GEN_AI_FUNCTION_TOOL_TYPE: ToolType = 'function';
 
 type ToolFailureKind = 'replan' | 'retry' | 'stop';
@@ -704,13 +718,16 @@ export const createRuntimeExecutors = (
           modelSupportsPreserveThinking && typeof preserveThinkingConfigured === 'boolean'
             ? preserveThinkingConfigured
             : undefined;
+        const messagesForContext = shouldReplayAssistantReasoning
+          ? (llmPayload.messages as UIChatMessage[])
+          : stripAssistantReasoningForReplay(llmPayload.messages as UIChatMessage[]);
 
         // Extract <refer_topic> tags from messages and fetch summaries.
         // Skip if messages already contain injected topic_reference_context
         // (e.g., from client-side contextEngineering preprocessing) to avoid double injection.
         let topicReferences;
         const alreadyHasTopicRefs = (
-          llmPayload.messages as Array<{ content: string | unknown }>
+          messagesForContext as Array<{ content: string | unknown }>
         ).some(
           (m) => typeof m.content === 'string' && m.content.includes('topic_reference_context'),
         );
@@ -719,7 +736,7 @@ export const createRuntimeExecutors = (
           const topicModel = new TopicModel(ctx.serverDB, ctx.userId, ctx.workspaceId);
           const messageModel = new MessageModelClass(ctx.serverDB, ctx.userId, ctx.workspaceId);
           topicReferences = await resolveTopicReferences(
-            llmPayload.messages as Array<{ content: string | unknown }>,
+            messagesForContext as Array<{ content: string | unknown }>,
             async (topicId) => topicModel.findById(topicId),
             async (topicId) => {
               const topic = await topicModel.findById(topicId);
@@ -761,7 +778,7 @@ export const createRuntimeExecutors = (
           agentConfig?.slug === 'web-onboarding' ||
           resolved.enabledToolIds.includes('lobe-web-onboarding');
         const alreadyHasOnboardingContext = (
-          llmPayload.messages as Array<{ content: string | unknown }>
+          messagesForContext as Array<{ content: string | unknown }>
         ).some((message) => {
           if (typeof message.content !== 'string') return false;
 
@@ -1042,7 +1059,7 @@ export const createRuntimeExecutors = (
                 name: kb.name ?? '',
               })),
           },
-          messages: llmPayload.messages as UIChatMessage[],
+          messages: messagesForContext,
           model,
           provider,
           systemRole: agentConfig.systemRole ?? undefined,
@@ -1070,14 +1087,14 @@ export const createRuntimeExecutors = (
           CONTEXT_ENGINEERING_SPAN_NAME,
           {
             attributes: buildContextEngineeringAttributes({
-              hasImages: (llmPayload.messages as Array<{ content?: unknown }>).some(
+              hasImages: (messagesForContext as Array<{ content?: unknown }>).some(
                 (m) =>
                   Array.isArray(m.content) &&
                   (m.content as Array<{ type?: string }>).some((p) => p?.type === 'image_url'),
               ),
               historyCompressed:
-                Array.isArray(llmPayload.messages) &&
-                llmPayload.messages.some((m: { role?: string }) => m?.role === 'compressedGroup'),
+                Array.isArray(messagesForContext) &&
+                messagesForContext.some((m: { role?: string }) => m?.role === 'compressedGroup'),
               knowledgeCount:
                 (contextEngineInput.knowledge?.knowledgeBases?.length ?? 0) +
                 (contextEngineInput.knowledge?.fileContents?.length ?? 0),
@@ -1085,7 +1102,7 @@ export const createRuntimeExecutors = (
                 (contextEngineInput.knowledge?.knowledgeBases?.length ?? 0) > 0 ||
                 (contextEngineInput.knowledge?.fileContents?.length ?? 0) > 0,
               memoryInjected: Boolean(contextEngineInput.userMemory?.memories),
-              messageCount: llmPayload.messages.length,
+              messageCount: messagesForContext.length,
               operationId,
               stepIndex,
               systemRoleLength: contextEngineInput.systemRole?.length,

--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -408,8 +408,11 @@ describe('RuntimeExecutors', () => {
       );
     });
 
-    describe('reasoning persistence gate', () => {
-      it('should persist assistant reasoning with tool calls when preserveThinking is enabled on a supported model', async () => {
+    // preserveThinking gates whether reasoning is replayed into the next LLM
+    // payload (state.messages). The DB copy powers UI display after refresh and
+    // is always persisted regardless of the gate.
+    describe('reasoning replay gate', () => {
+      it('should replay assistant reasoning with tool calls when preserveThinking is enabled on a supported model', async () => {
         const toolCallPayload = [
           {
             function: { arguments: '{}', name: 'search' },
@@ -474,7 +477,7 @@ describe('RuntimeExecutors', () => {
         );
       });
 
-      it('should not persist assistant reasoning when preserveThinking is not enabled', async () => {
+      it('should persist reasoning to DB but not replay it when preserveThinking is not enabled', async () => {
         const mockChat = vi.fn().mockImplementation(async (_payload, options) => {
           await options?.callback?.onThinking?.('hidden reasoning');
           await options?.callback?.onText?.('answer');
@@ -498,9 +501,14 @@ describe('RuntimeExecutors', () => {
         const assistant = result.newState.messages.at(-1) as any;
 
         expect(assistant.reasoning).toBeUndefined();
+        // DB persistence must NOT be gated — UI shows reasoning after refresh
+        expect(mockMessageModel.update).toHaveBeenCalledWith(
+          'msg-123',
+          expect.objectContaining({ reasoning: { content: 'hidden reasoning' } }),
+        );
       });
 
-      it('should persist assistant reasoning when preserveThinking is enabled on a supported model', async () => {
+      it('should replay assistant reasoning when preserveThinking is enabled on a supported model', async () => {
         const mockChat = vi.fn().mockImplementation(async (_payload, options) => {
           await options?.callback?.onThinking?.('preserved reasoning');
           await options?.callback?.onText?.('answer');
@@ -546,7 +554,7 @@ describe('RuntimeExecutors', () => {
         );
       });
 
-      it('should persist reasoning for unknown custom deployments on supported providers', async () => {
+      it('should replay reasoning for unknown custom deployments on supported providers', async () => {
         const mockChat = vi.fn().mockImplementation(async (_payload, options) => {
           await options?.callback?.onThinking?.('custom deployment reasoning');
           await options?.callback?.onText?.('answer');
@@ -592,9 +600,9 @@ describe('RuntimeExecutors', () => {
         );
       });
 
-      it('should not persist reasoning when model does not declare preserveThinking capability', async () => {
+      it('should persist reasoning to DB but not replay it when model does not declare preserveThinking capability', async () => {
         const mockChat = vi.fn().mockImplementation(async (_payload, options) => {
-          await options?.callback?.onThinking?.('reasoning that should not be saved');
+          await options?.callback?.onThinking?.('reasoning on an unsupported model');
           await options?.callback?.onText?.('answer');
           return new Response('done');
         });
@@ -633,6 +641,13 @@ describe('RuntimeExecutors', () => {
         expect(mockChat).toHaveBeenCalledWith(
           expect.not.objectContaining({ preserveThinking: expect.any(Boolean) }),
           expect.anything(),
+        );
+        // DB persistence must NOT be gated — UI shows reasoning after refresh
+        expect(mockMessageModel.update).toHaveBeenCalledWith(
+          'msg-123',
+          expect.objectContaining({
+            reasoning: { content: 'reasoning on an unsupported model' },
+          }),
         );
       });
     });
@@ -771,9 +786,9 @@ describe('RuntimeExecutors', () => {
         });
         vi.mocked(initModelRuntimeFromDB).mockResolvedValueOnce({ chat: mockChat } as any);
 
-        // Reasoning only lands in the finalized message when preserveThinking is
-        // enabled on a supported model; otherwise it is intentionally dropped.
-        // Enable it here so this still guards reasoning_part capture (not drop).
+        // Reasoning is only replayed into state.messages when preserveThinking is
+        // enabled on a supported model. Enable it here so this asserts
+        // reasoning_part capture via the state replay path.
         const ctxWithThinking: RuntimeExecutorContext = {
           ...ctx,
           agentConfig: { chatConfig: { preserveThinking: true }, plugins: [], systemRole: 'test' },

--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -1654,6 +1654,80 @@ describe('RuntimeExecutors', () => {
         );
       });
 
+      it('should strip stored reasoning from grouped assistant messages before context processing when replay gate is off', async () => {
+        const ctxWithConfig: RuntimeExecutorContext = {
+          ...ctx,
+          agentConfig: {
+            plugins: [],
+            systemRole: 'test',
+          },
+        };
+        const executors = createRuntimeExecutors(ctxWithConfig);
+        const state = createMockState();
+        const messages = [
+          {
+            children: [
+              {
+                content: 'Grouped answer',
+                id: 'group-child-1',
+                reasoning: { content: 'grouped child reasoning should stay display-only' },
+                role: 'assistant',
+              },
+            ],
+            content: '',
+            id: 'group-1',
+            role: 'assistantGroup',
+          },
+          {
+            content: '',
+            id: 'council-1',
+            members: [
+              {
+                content: 'Council member answer',
+                id: 'member-1',
+                reasoning: { content: 'member reasoning should stay display-only' },
+                role: 'assistant',
+              },
+              {
+                children: [
+                  {
+                    content: 'Nested council answer',
+                    id: 'member-child-1',
+                    reasoning: { content: 'nested member reasoning should stay display-only' },
+                    role: 'assistant',
+                  },
+                ],
+                content: '',
+                id: 'member-group-1',
+                role: 'assistantGroup',
+              },
+            ],
+            role: 'agentCouncil',
+          },
+          { content: 'Continue', role: 'user' },
+        ];
+
+        await executors.call_llm!(
+          {
+            payload: {
+              messages,
+              model: 'gpt-4',
+              provider: 'openai',
+            },
+            type: 'call_llm' as const,
+          },
+          state,
+        );
+
+        const engineInput = engineSpy.mock.calls[0][0];
+        expect(engineInput.messages[0].children[0]).not.toHaveProperty('reasoning');
+        expect(engineInput.messages[1].members[0]).not.toHaveProperty('reasoning');
+        expect(engineInput.messages[1].members[1].children[0]).not.toHaveProperty('reasoning');
+        expect(messages[0].children[0]).toHaveProperty('reasoning');
+        expect(messages[1].members[0]).toHaveProperty('reasoning');
+        expect(messages[1].members[1].children[0]).toHaveProperty('reasoning');
+      });
+
       it('should keep stored assistant reasoning before context processing when replay gate is enabled', async () => {
         const ctxWithConfig: RuntimeExecutorContext = {
           ...ctx,

--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -1611,6 +1611,95 @@ describe('RuntimeExecutors', () => {
         );
       });
 
+      it('should strip stored assistant reasoning before context processing when replay gate is off', async () => {
+        const ctxWithConfig: RuntimeExecutorContext = {
+          ...ctx,
+          agentConfig: {
+            plugins: [],
+            systemRole: 'test',
+          },
+        };
+        const executors = createRuntimeExecutors(ctxWithConfig);
+        const state = createMockState();
+        const messages = [
+          {
+            content: 'Previous answer',
+            reasoning: { content: 'stored reasoning should stay display-only' },
+            role: 'assistant',
+          },
+          { content: 'Continue', role: 'user' },
+        ];
+
+        await executors.call_llm!(
+          {
+            payload: {
+              messages,
+              model: 'gpt-4',
+              provider: 'openai',
+            },
+            type: 'call_llm' as const,
+          },
+          state,
+        );
+
+        const engineInput = engineSpy.mock.calls[0][0];
+        expect(engineInput.messages[0]).toEqual({
+          content: 'Previous answer',
+          role: 'assistant',
+        });
+        expect(messages[0]).toEqual(
+          expect.objectContaining({
+            reasoning: { content: 'stored reasoning should stay display-only' },
+          }),
+        );
+      });
+
+      it('should keep stored assistant reasoning before context processing when replay gate is enabled', async () => {
+        const ctxWithConfig: RuntimeExecutorContext = {
+          ...ctx,
+          agentConfig: {
+            chatConfig: { preserveThinking: true },
+            plugins: [],
+            systemRole: 'test',
+          },
+        };
+        const executors = createRuntimeExecutors(ctxWithConfig);
+        const state = createMockState({
+          modelRuntimeConfig: {
+            model: 'qwen3.6-plus',
+            provider: 'qwen',
+          },
+        });
+
+        await executors.call_llm!(
+          {
+            payload: {
+              messages: [
+                {
+                  content: 'Previous answer',
+                  reasoning: { content: 'reasoning to replay' },
+                  role: 'assistant',
+                },
+                { content: 'Continue', role: 'user' },
+              ],
+              model: 'qwen3.6-plus',
+              provider: 'qwen',
+            },
+            type: 'call_llm' as const,
+          },
+          state,
+        );
+
+        const engineInput = engineSpy.mock.calls[0][0];
+        expect(engineInput.messages[0]).toEqual(
+          expect.objectContaining({
+            content: 'Previous answer',
+            reasoning: { content: 'reasoning to replay' },
+            role: 'assistant',
+          }),
+        );
+      });
+
       it('should not call serverMessagesEngine when agentConfig is not set', async () => {
         const executors = createRuntimeExecutors(ctx); // ctx without agentConfig
         const state = createMockState();

--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -1664,16 +1664,27 @@ describe('RuntimeExecutors', () => {
         };
         const executors = createRuntimeExecutors(ctxWithConfig);
         const state = createMockState();
+        const groupedChild = {
+          content: 'Grouped answer',
+          id: 'group-child-1',
+          reasoning: { content: 'grouped child reasoning should stay display-only' },
+          role: 'assistant',
+        };
+        const councilMember = {
+          content: 'Council member answer',
+          id: 'member-1',
+          reasoning: { content: 'member reasoning should stay display-only' },
+          role: 'assistant',
+        };
+        const nestedCouncilChild = {
+          content: 'Nested council answer',
+          id: 'member-child-1',
+          reasoning: { content: 'nested member reasoning should stay display-only' },
+          role: 'assistant',
+        };
         const messages = [
           {
-            children: [
-              {
-                content: 'Grouped answer',
-                id: 'group-child-1',
-                reasoning: { content: 'grouped child reasoning should stay display-only' },
-                role: 'assistant',
-              },
-            ],
+            children: [groupedChild],
             content: '',
             id: 'group-1',
             role: 'assistantGroup',
@@ -1682,21 +1693,9 @@ describe('RuntimeExecutors', () => {
             content: '',
             id: 'council-1',
             members: [
+              councilMember,
               {
-                content: 'Council member answer',
-                id: 'member-1',
-                reasoning: { content: 'member reasoning should stay display-only' },
-                role: 'assistant',
-              },
-              {
-                children: [
-                  {
-                    content: 'Nested council answer',
-                    id: 'member-child-1',
-                    reasoning: { content: 'nested member reasoning should stay display-only' },
-                    role: 'assistant',
-                  },
-                ],
+                children: [nestedCouncilChild],
                 content: '',
                 id: 'member-group-1',
                 role: 'assistantGroup',
@@ -1723,9 +1722,9 @@ describe('RuntimeExecutors', () => {
         expect(engineInput.messages[0].children[0]).not.toHaveProperty('reasoning');
         expect(engineInput.messages[1].members[0]).not.toHaveProperty('reasoning');
         expect(engineInput.messages[1].members[1].children[0]).not.toHaveProperty('reasoning');
-        expect(messages[0].children[0]).toHaveProperty('reasoning');
-        expect(messages[1].members[0]).toHaveProperty('reasoning');
-        expect(messages[1].members[1].children[0]).toHaveProperty('reasoning');
+        expect(groupedChild).toHaveProperty('reasoning');
+        expect(councilMember).toHaveProperty('reasoning');
+        expect(nestedCouncilChild).toHaveProperty('reasoning');
       });
 
       it('should keep stored assistant reasoning before context processing when replay gate is enabled', async () => {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - regression introduced by #13494.

#### 🔀 Description of Change

#13494 added preserveThinking support, but the server-side agent runtime used the same gate for two different behaviors: replaying reasoning into the next LLM payload and persisting reasoning to the message record.

Payload replay still needs the model capability gate, because unsupported providers may reject replayed thinking. DB persistence should not be gated, because it powers the visible thinking block after refresh.

This PR keeps preserveThinking as the replay gate and restores unconditional reasoning persistence in messageModel.update.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
```

Result: 116 tests passed.

#### 📝 Additional Information

This branch is based on the latest canary and only contains the runtime fix. See also #15687, whose branch currently includes unrelated canary drift.