### PR TITLE
🐛 fix(model-runtime): align tool-calling fallback tests & surface missing tool call as error

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -3242,6 +3242,7 @@ describe('LobeOpenAICompatibleFactory', () => {
         vi.spyOn(instanceWithToolCalling['client'].chat.completions, 'create').mockResolvedValue(
           mockResponse as any,
         );
+        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
         const payload = {
           messages: [{ content: 'Generate data', role: 'user' as const }],
@@ -3254,7 +3255,13 @@ describe('LobeOpenAICompatibleFactory', () => {
 
         const result = await instanceWithToolCalling.generateObject(payload);
 
+        expect(consoleSpy).toHaveBeenCalledWith(
+          'no tool call found in structured output response:',
+          mockResponse.choices[0].message,
+        );
         expect(result).toBeUndefined();
+
+        consoleSpy.mockRestore();
       });
 
       it('should return undefined when tool call arguments parsing fails', async () => {

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -3173,9 +3173,9 @@ describe('LobeOpenAICompatibleFactory', () => {
           { headers: undefined, signal: undefined },
         );
 
-        expect(result).toEqual([
-          { arguments: { age: 28, name: 'Alice' }, name: 'person_extractor' },
-        ]);
+        // The fallback returns the parsed schema object, same shape as the
+        // json_schema path
+        expect(result).toEqual({ age: 28, name: 'Alice' });
       });
 
       it('should not forward internal thinking to generic OpenAI-compatible generateObject requests', async () => {
@@ -3242,7 +3242,6 @@ describe('LobeOpenAICompatibleFactory', () => {
         vi.spyOn(instanceWithToolCalling['client'].chat.completions, 'create').mockResolvedValue(
           mockResponse as any,
         );
-        const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
         const payload = {
           messages: [{ content: 'Generate data', role: 'user' as const }],
@@ -3255,10 +3254,7 @@ describe('LobeOpenAICompatibleFactory', () => {
 
         const result = await instanceWithToolCalling.generateObject(payload);
 
-        expect(consoleSpy).toHaveBeenCalledWith('parse tool call arguments error:', undefined);
         expect(result).toBeUndefined();
-
-        consoleSpy.mockRestore();
       });
 
       it('should return undefined when tool call arguments parsing fails', async () => {
@@ -3298,7 +3294,7 @@ describe('LobeOpenAICompatibleFactory', () => {
 
         expect(consoleSpy).toHaveBeenCalledWith(
           'parse tool call arguments error:',
-          mockResponse.choices[0].message.tool_calls,
+          mockResponse.choices[0].message.tool_calls[0],
         );
         expect(result).toBeUndefined();
 
@@ -3350,7 +3346,7 @@ describe('LobeOpenAICompatibleFactory', () => {
           { headers: options.headers, signal: options.signal },
         );
 
-        expect(result).toEqual([{ arguments: { data: 'test' }, name: 'data_extractor' }]);
+        expect(result).toEqual({ data: 'test' });
       });
     });
   });

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -898,7 +898,9 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         toolCalls?.find((item) => item.function?.name === tool.function.name) ?? toolCalls?.[0];
 
       if (!toolCall?.function) {
-        log('no tool call found in structured output response');
+        // tool_choice forces this function, so a missing tool call means the
+        // provider misbehaved — surface it instead of silently returning undefined
+        console.error('no tool call found in structured output response:', res.choices[0]?.message);
         return undefined;
       }
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up to #15680, which left `canary` CI red.

#### 🔀 Description of Change

Two commits:

**1. Align stale tests with #15680's new fallback behavior.** #15680 intentionally changed `generateObject`'s tool-calling fallback (extracted into `generateObjectViaToolCalling`): it now returns the **parsed schema object** — the same shape as the json_schema path — instead of an array of `{ name, arguments }` tool calls, and the parse-failure path logs the single matched tool call instead of the whole `tool_calls` array. The new `generateObject.test.ts` and provider suites were updated accordingly, but the pre-existing `tool calling fallback` block in `openaiCompatibleFactory/index.test.ts` was not, so 4 of its tests still asserted the old behavior and fail on `canary`. This PR updates those assertions. The block is kept (rather than deleted as a duplicate of `generateObject.test.ts`) because it covers scenarios the new file does not, e.g. internal-thinking params stripping.

**2. Surface the missing-tool-call case as `console.error`.** `tool_choice` forces the structured-output function, so a response without a tool call means the provider misbehaved. #15680 routed this branch to a debug-namespace log that is invisible in production, leaving callers with an unexplained `undefined`. Before #15680 this path *did* `console.error`, but only as an accidental artifact (`toolCalls!.map` throwing into the catch with a misleading "parse tool call arguments error: undefined"). Now it logs explicitly with the response message as context, matching the parse-failure branch.

#### 🧪 How to Test

```bash
cd packages/model-runtime
bunx vitest run 'src/core/openaiCompatibleFactory/index.test.ts'          # 90 passed
bunx vitest run 'src/core/openaiCompatibleFactory/generateObject.test.ts' # 5 passed
bunx vitest run 'src/providers/deepseek' 'src/providers/aihubmix' \
  'src/providers/newapi' 'src/providers/opencodeZen' \
  'src/providers/opencodeCodingPlan'                                      # 172 passed, 1 skipped
```

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

Only runtime behavior change: the no-tool-call branch of `generateObjectViaToolCalling` now logs `console.error` instead of a debug-only log. Return values are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)