### PR TITLE
🐛 fix(share): always serve desktop bundle for share routes

### DIFF
--- a/src/libs/next/proxy/define-config.ts
+++ b/src/libs/next/proxy/define-config.ts
@@ -66,9 +66,13 @@ export function defineConfig() {
       locale,
     });
 
+    // Share pages are responsive on their own; always serve the desktop bundle
+    // so mobile UA does not land on mobile-specific routes.
+    const isSharePath = url.pathname === '/share' || url.pathname.startsWith('/share/');
+
     // 2. Create normalized preference values
     const route = RouteVariants.serializeVariants({
-      isMobile: device.type === 'mobile',
+      isMobile: !isSharePath && device.type === 'mobile',
       locale,
     });
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Share pages (`/share/t/:id`, `/share/page/:id`) are responsive on their own, but the proxy middleware serialized route variants from the device UA, so a mobile UA landed on the mobile-specific bundle/routes for share links.

This change forces `isMobile: false` when serializing variants for `/share` and `/share/*` paths, so share links always get the desktop bundle regardless of UA. The share routes registered in `mobileRouter.config.tsx` are kept for in-bundle client-side navigation.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Open a `/share/page/:id` link with a mobile UA (e.g. Chrome DevTools device emulation, full reload) and confirm the desktop share rendering is served instead of the mobile-specific route.

#### 📝 Additional Information

Cloud needs to sync canary to pick this up.