### PR TITLE
🔨 chore: reduce test log noise

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -36,7 +36,7 @@
     "package:win": "npm run build:main && electron-builder --win --config electron-builder.mjs  --publish never",
     "start": "electron-vite preview",
     "stylelint": "stylelint \"src/**/*.{js,jsx,ts,tsx}\" --fix",
-    "test": "vitest --run",
+    "test": "vitest --run --silent='passed-only'",
     "type-check": "tsgo --noEmit -p tsconfig.json",
     "typecheck": "tsgo --noEmit -p tsconfig.json",
     "update-server": "sh scripts/update-test/run-test.sh"

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "test:e2e": "pnpm --filter @lobechat/e2e-tests test",
     "test:e2e:smoke": "pnpm --filter @lobechat/e2e-tests test:smoke",
     "test:update": "vitest -u",
-    "test-app": "vitest run",
+    "test-app": "vitest run --silent='passed-only'",
     "test-app:coverage": "vitest --coverage --silent='passed-only'",
     "tunnel:cloudflare": "cloudflared tunnel --url http://localhost:3010 --protocol http2",
     "tunnel:ngrok": "ngrok http http://localhost:3010",

--- a/packages/agent-gateway-client/package.json
+++ b/packages/agent-gateway-client/package.json
@@ -10,7 +10,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "test": "bunx vitest run --silent='passed-only'",
-    "test:coverage": "bunx vitest run --coverage"
+    "test:coverage": "bunx vitest run --coverage --silent='passed-only'"
   },
   "devDependencies": {
     "vitest": "^3.2.6"

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -11,7 +11,7 @@
     "test": "npm run test:client-db && npm run test:server-db",
     "test:client-db": "vitest run --silent='passed-only'",
     "test:coverage": "vitest --coverage --silent='passed-only' --config vitest.config.server.mts",
-    "test:server-db": "vitest run --config vitest.config.server.mts"
+    "test:server-db": "vitest run --config vitest.config.server.mts --silent='passed-only'"
   },
   "dependencies": {
     "@lobechat/agent-templates": "workspace:*",

--- a/packages/device-gateway-client/package.json
+++ b/packages/device-gateway-client/package.json
@@ -8,7 +8,7 @@
   "main": "./src/index.ts",
   "scripts": {
     "test": "bunx vitest run --silent='passed-only'",
-    "test:coverage": "bunx vitest run --coverage"
+    "test:coverage": "bunx vitest run --coverage --silent='passed-only'"
   },
   "dependencies": {
     "ws": "^8.18.1"

--- a/packages/device-identity/package.json
+++ b/packages/device-identity/package.json
@@ -8,7 +8,7 @@
   "main": "./src/index.ts",
   "scripts": {
     "test": "bunx vitest run --silent='passed-only'",
-    "test:coverage": "bunx vitest run --coverage"
+    "test:coverage": "bunx vitest run --coverage --silent='passed-only'"
   },
   "dependencies": {
     "node-machine-id": "^1.1.12"


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-9953

Related cloud PR: https://github.com/lobehub-biz/lobehub-cloud/pull/743

#### 🔀 Description of Change

Reduce non-actionable Vitest log noise in CI-facing test scripts while preserving logs from failing tests.

- Add `--silent=passed-only` to the root app test script used by release checks.
- Add `--silent=passed-only` to the database server test script used by the database test command.
- Add `--silent=passed-only` to the desktop Vitest script used by the desktop CI job.
- Add `--silent=passed-only` to package coverage scripts used by the `Test Packages` workflow for agent gateway, device gateway, and device identity tests.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

- `jq -e . package.json apps/desktop/package.json packages/database/package.json >/dev/null`
- `jq -e . packages/agent-gateway-client/package.json packages/device-gateway-client/package.json packages/device-identity/package.json >/dev/null`
- Verified all Vitest `test:coverage` scripts referenced by `.github/workflows/test.yml` `PACKAGES` include `silent`.
- `rtk git diff --check`
- `vscode-cli get-diagnostics` from the cloud workspace root

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This changes Vitest output behavior only. Passed-test console output is suppressed; failing-test output remains visible.