### PR TITLE
🐛 fix(agent): block recursive server sub-agents

### DIFF
--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -371,6 +371,7 @@ const buildServerSubAgentRunner = (
         agentId: targetAgentId ?? agentId,
         groupId: state.metadata?.groupId ?? undefined,
         instruction,
+        isSubAgent: true,
         parentMessageId: placeholder.id,
         parentOperationId: ctx.operationId,
         resumeParentOnComplete: true,

--- a/apps/server/src/services/aiAgent/__tests__/execGroupSubAgentTask.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execGroupSubAgentTask.test.ts
@@ -21,6 +21,12 @@ vi.mock('@/database/models/thread', () => ({
   ThreadModel: vi.fn().mockImplementation(() => mockThreadModel),
 }));
 
+vi.mock('@/database/models/agentOperation', () => ({
+  AgentOperationModel: vi.fn().mockImplementation(() => ({
+    findById: vi.fn().mockResolvedValue({ trigger: 'cli' }),
+  })),
+}));
+
 // Mock other models
 vi.mock('@/database/models/agent', () => ({
   AgentModel: vi.fn().mockImplementation(() => ({
@@ -221,6 +227,45 @@ describe('AiAgentService.execSubAgent', () => {
           approvalMode: 'headless',
         },
       });
+    });
+
+    it('should mark deferred lobe-agent sub-agent children as sub-agents', async () => {
+      const execAgentSpy = vi.spyOn(service, 'execAgent').mockResolvedValue({
+        agentId: 'agent-1',
+        assistantMessageId: 'assistant-msg-1',
+        autoStarted: true,
+        createdAt: new Date().toISOString(),
+        message: 'Agent operation created successfully',
+        messageId: 'queue-msg-1',
+        operationId: 'op-123',
+        status: 'created',
+        success: true,
+        timestamp: new Date().toISOString(),
+        topicId: 'topic-1',
+        userMessageId: 'user-msg-1',
+      });
+
+      await service.execSubAgent({
+        agentId: 'agent-1',
+        instruction: 'Nested research task',
+        isSubAgent: true,
+        parentMessageId: 'tool-msg-1',
+        parentOperationId: 'parent-op-1',
+        resumeParentOnComplete: true,
+        topicId: 'topic-1',
+      });
+
+      expect(execAgentSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appContext: expect.objectContaining({
+            isSubAgent: true,
+            threadId: 'thread-123',
+            topicId: 'topic-1',
+          }),
+          parentOperationId: 'parent-op-1',
+          trigger: 'cli',
+        }),
+      );
     });
 
     it('should store operationId and startedAt in Thread metadata', async () => {

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -2878,6 +2878,7 @@ export class AiAgentService {
       parentMessageId,
       agentId,
       instruction,
+      isSubAgent,
       title,
       parentOperationId,
       resumeParentOnComplete,
@@ -2957,12 +2958,19 @@ export class AiAgentService {
       }
     }
 
+    const appContext: NonNullable<InternalExecAgentParams['appContext']> = {
+      groupId,
+      threadId: thread.id,
+      topicId,
+    };
+    if (isSubAgent) appContext.isSubAgent = true;
+
     // 4. Delegate to execAgent with threadId in appContext and hooks
     // The instruction will be created as user message in the Thread
     // Use headless mode to skip human approval in async task execution
     const result = await this.execAgent({
       agentId,
-      appContext: { groupId, threadId: thread.id, topicId },
+      appContext,
       autoStart: true,
       hooks,
       parentOperationId,

--- a/packages/types/src/agentExecution/index.ts
+++ b/packages/types/src/agentExecution/index.ts
@@ -266,6 +266,8 @@ export interface ExecSubAgentParams {
   groupId?: string;
   /** Task instruction/prompt for the SubAgent */
   instruction: string;
+  /** Whether the child run is a lobe-agent virtual sub-agent and must not spawn more sub-agents */
+  isSubAgent?: boolean;
   /** The parent message ID (Supervisor's tool call message or task message) */
   parentMessageId: string;
   /** Parent operation ID for dispatching callAgent hooks */


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-10316

#### 🔀 Description of Change

This patch closes the server-side recursion gap in `lobe-agent.callSubAgent`.

Server `callSubAgent` spawns a deferred child operation through `execSubAgent`. That child now carries `isSubAgent: true` into its `execAgent` app context, so the child runtime strips the `lobe-agent` tool and the server tool runtime can reject nested `callSubAgent` execution.

The regular group/call-agent task path remains unchanged because it only receives the flag when the lobe-agent deferred runner explicitly passes it.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run --silent='passed-only' 'apps/server/src/services/aiAgent/__tests__/execGroupSubAgentTask.test.ts'
bunx vitest run --silent='passed-only' 'apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts'
bunx vitest run --silent='passed-only' 'apps/server/src/routers/lambda/__tests__/integration/aiAgent/serverSubAgent.integration.test.ts'
git diff --check
```

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

A follow-up refactor should split the overloaded `execSubAgent` naming/contract so virtual lobe-agent sub-agents and group/call-agent isolated tasks use separate service entry points.
