### PR TITLE
🐛 fix(codex): reuse Linear inspector for MCP calls

### DIFF
--- a/packages/builtin-tools/src/codex/McpToolInspector.tsx
+++ b/packages/builtin-tools/src/codex/McpToolInspector.tsx
@@ -20,7 +20,7 @@ import {
   getMcpToolName,
 } from './mcpToolUtils';
 
-const LINEAR_TOOL_NAME_SET = new Set<string>(LINEAR_TOOL_NAMES);
+const LINEAR_TOOL_NAME_SET = new Set<string>([...LINEAR_TOOL_NAMES, 'fetch', 'search']);
 const SharedLinearInspector = LinearInspector as ComponentType<
   BuiltinInspectorProps<Record<string, unknown>>
 >;
@@ -33,17 +33,19 @@ const McpToolInspector = memo<BuiltinInspectorProps<CodexMcpToolArgs, CodexMcpTo
     });
     const server = getMcpServer(args, pluginState) || getMcpServer(partialArgs);
     const tool = getMcpToolName(args, pluginState) || getMcpToolName(partialArgs);
-    const linearApiName = getCodexLinearMcpApiName(tool);
+    const input = getMcpInputRecord(args, pluginState);
+    const partialInput = getMcpInputRecord(partialArgs);
+    const linearApiName = getCodexLinearMcpApiName(tool, input || partialInput);
 
     if (LINEAR_TOOL_NAME_SET.has(linearApiName)) {
       return (
         <SharedLinearInspector
           apiName={linearApiName}
-          args={getMcpInputRecord(args, pluginState) || {}}
+          args={input || {}}
           identifier={'codex'}
           isArgumentsStreaming={isArgumentsStreaming}
           isLoading={isLoading}
-          partialArgs={getMcpInputRecord(partialArgs) || {}}
+          partialArgs={partialInput || {}}
           pluginState={pluginState}
         />
       );

--- a/packages/builtin-tools/src/codex/McpToolInspector.tsx
+++ b/packages/builtin-tools/src/codex/McpToolInspector.tsx
@@ -35,7 +35,11 @@ const McpToolInspector = memo<BuiltinInspectorProps<CodexMcpToolArgs, CodexMcpTo
     const tool = getMcpToolName(args, pluginState) || getMcpToolName(partialArgs);
     const input = getMcpInputRecord(args, pluginState);
     const partialInput = getMcpInputRecord(partialArgs);
-    const linearApiName = getCodexLinearMcpApiName(tool, input || partialInput);
+    const linearApiName = getCodexLinearMcpApiName({
+      input: input || partialInput,
+      server,
+      toolName: tool,
+    });
 
     if (LINEAR_TOOL_NAME_SET.has(linearApiName)) {
       return (

--- a/packages/builtin-tools/src/codex/mcpToolUtils.test.ts
+++ b/packages/builtin-tools/src/codex/mcpToolUtils.test.ts
@@ -4,33 +4,89 @@ import { getCodexLinearMcpApiName, getMcpInputRecord } from './mcpToolUtils';
 
 describe('getCodexLinearMcpApiName', () => {
   it('maps Codex Apps fetch calls to entity-specific Linear APIs', () => {
-    expect(getCodexLinearMcpApiName('linear_fetch', { id: 'issue:LOBE-10205' })).toBe(
-      'get_issue',
-    );
-    expect(getCodexLinearMcpApiName('linear_fetch', { id: 'project:Desktop' })).toBe(
-      'get_project',
-    );
-    expect(getCodexLinearMcpApiName('linear_fetch', { id: 'initiative:AI' })).toBe(
-      'get_initiative',
-    );
-    expect(getCodexLinearMcpApiName('linear_fetch', { id: 'document:agent-runtime' })).toBe(
-      'get_document',
-    );
+    expect(
+      getCodexLinearMcpApiName({ input: { id: 'issue:LOBE-10205' }, toolName: 'linear_fetch' }),
+    ).toBe('get_issue');
+    expect(
+      getCodexLinearMcpApiName({ input: { id: 'project:Desktop' }, toolName: 'linear_fetch' }),
+    ).toBe('get_project');
+    expect(
+      getCodexLinearMcpApiName({ input: { id: 'initiative:AI' }, toolName: 'linear_fetch' }),
+    ).toBe('get_initiative');
+    expect(
+      getCodexLinearMcpApiName({
+        input: { id: 'document:agent-runtime' },
+        toolName: 'linear_fetch',
+      }),
+    ).toBe('get_document');
   });
 
   it('keeps generic Codex Apps Linear search and unknown fetch names renderable', () => {
-    expect(getCodexLinearMcpApiName('linear_search', { query: 'agent runtime' })).toBe('search');
-    expect(getCodexLinearMcpApiName('linear_fetch', { id: 'unknown:123' })).toBe('fetch');
+    expect(
+      getCodexLinearMcpApiName({
+        input: { query: 'agent runtime' },
+        toolName: 'linear_search',
+      }),
+    ).toBe('search');
+    expect(
+      getCodexLinearMcpApiName({ input: { id: 'unknown:123' }, toolName: 'linear_fetch' }),
+    ).toBe('fetch');
   });
 
   it('normalizes MCP-prefixed and underscored Linear tool names', () => {
-    expect(getCodexLinearMcpApiName('_get_issue')).toBe('get_issue');
-    expect(getCodexLinearMcpApiName('linear__get_issue')).toBe('get_issue');
-    expect(getCodexLinearMcpApiName('server_linear_get_issue')).toBe('get_issue');
+    expect(getCodexLinearMcpApiName({ toolName: '_get_issue' })).toBe('get_issue');
+    expect(getCodexLinearMcpApiName({ toolName: 'linear__get_issue' })).toBe('get_issue');
+    expect(getCodexLinearMcpApiName({ toolName: 'server_linear_get_issue' })).toBe('get_issue');
   });
 
   it('treats bare issue identifiers as issue fetch calls', () => {
-    expect(getCodexLinearMcpApiName('linear_fetch', { id: 'LOBE-10205' })).toBe('get_issue');
+    expect(
+      getCodexLinearMcpApiName({ input: { id: 'LOBE-10205' }, toolName: 'linear_fetch' }),
+    ).toBe('get_issue');
+  });
+
+  it('does not treat generic fetch or search from other MCP servers as Linear', () => {
+    expect(
+      getCodexLinearMcpApiName({
+        input: { query: 'agent runtime' },
+        server: 'node_repl',
+        toolName: 'search',
+      }),
+    ).toBe('');
+    expect(
+      getCodexLinearMcpApiName({
+        input: { id: 'LOBE-10205' },
+        server: 'github',
+        toolName: 'fetch',
+      }),
+    ).toBe('');
+  });
+
+  it('allows bare fetch only when the input has a Linear entity prefix', () => {
+    expect(
+      getCodexLinearMcpApiName({
+        input: { id: 'issue:LOBE-10205' },
+        server: 'node_repl',
+        toolName: 'fetch',
+      }),
+    ).toBe('get_issue');
+  });
+
+  it('allows generic fetch or search from a Linear server', () => {
+    expect(
+      getCodexLinearMcpApiName({
+        input: { query: 'agent runtime' },
+        server: 'mcp__codex_apps__linear',
+        toolName: 'search',
+      }),
+    ).toBe('search');
+    expect(
+      getCodexLinearMcpApiName({
+        input: { id: 'unknown:123' },
+        server: 'mcp__codex_apps__linear',
+        toolName: 'fetch',
+      }),
+    ).toBe('fetch');
   });
 });
 

--- a/packages/builtin-tools/src/codex/mcpToolUtils.test.ts
+++ b/packages/builtin-tools/src/codex/mcpToolUtils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { getCodexLinearMcpApiName, getMcpInputRecord } from './mcpToolUtils';
+
+describe('getCodexLinearMcpApiName', () => {
+  it('maps Codex Apps fetch calls to entity-specific Linear APIs', () => {
+    expect(getCodexLinearMcpApiName('linear_fetch', { id: 'issue:LOBE-10205' })).toBe(
+      'get_issue',
+    );
+    expect(getCodexLinearMcpApiName('linear_fetch', { id: 'project:Desktop' })).toBe(
+      'get_project',
+    );
+    expect(getCodexLinearMcpApiName('linear_fetch', { id: 'initiative:AI' })).toBe(
+      'get_initiative',
+    );
+    expect(getCodexLinearMcpApiName('linear_fetch', { id: 'document:agent-runtime' })).toBe(
+      'get_document',
+    );
+  });
+
+  it('keeps generic Codex Apps Linear search and unknown fetch names renderable', () => {
+    expect(getCodexLinearMcpApiName('linear_search', { query: 'agent runtime' })).toBe('search');
+    expect(getCodexLinearMcpApiName('linear_fetch', { id: 'unknown:123' })).toBe('fetch');
+  });
+
+  it('normalizes MCP-prefixed and underscored Linear tool names', () => {
+    expect(getCodexLinearMcpApiName('_get_issue')).toBe('get_issue');
+    expect(getCodexLinearMcpApiName('linear__get_issue')).toBe('get_issue');
+    expect(getCodexLinearMcpApiName('server_linear_get_issue')).toBe('get_issue');
+  });
+
+  it('treats bare issue identifiers as issue fetch calls', () => {
+    expect(getCodexLinearMcpApiName('linear_fetch', { id: 'LOBE-10205' })).toBe('get_issue');
+  });
+});
+
+describe('getMcpInputRecord', () => {
+  it('parses JSON string MCP arguments', () => {
+    expect(getMcpInputRecord({ arguments: '{"id":"issue:LOBE-10205"}' })).toEqual({
+      id: 'issue:LOBE-10205',
+    });
+  });
+});

--- a/packages/builtin-tools/src/codex/mcpToolUtils.ts
+++ b/packages/builtin-tools/src/codex/mcpToolUtils.ts
@@ -24,6 +24,13 @@ export interface FormattedMcpValue {
 
 const LINEAR_CODEX_PREFIX = 'linear_';
 const LINEAR_CODEX_SERVER_PREFIX = 'server_';
+const CODEX_LINEAR_GENERIC_TOOL_NAMES = new Set(['fetch', 'search']);
+const CODEX_LINEAR_FETCH_API_BY_ENTITY: Record<string, string> = {
+  document: 'get_document',
+  initiative: 'get_initiative',
+  issue: 'get_issue',
+  project: 'get_project',
+};
 const SERVER_KEYS = ['server', 'serverName', 'server_name', 'connector', 'connector_id'];
 const TOOL_KEYS = ['tool', 'toolName', 'tool_name', 'name'];
 const INPUT_KEYS = ['arguments', 'args', 'input', 'params', 'parameters'];
@@ -83,16 +90,53 @@ export const getMcpInputRecord = (
   }
 };
 
-export const getCodexLinearMcpApiName = (toolName: string) => {
+const normalizeCodexLinearToolName = (toolName: string) => {
   if (!toolName) return '';
 
   let apiName = toolName.trim();
-  if (apiName.startsWith(LINEAR_CODEX_PREFIX)) {
-    apiName = apiName.slice(LINEAR_CODEX_PREFIX.length);
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+
+    if (apiName.startsWith(LINEAR_CODEX_PREFIX)) {
+      apiName = apiName.slice(LINEAR_CODEX_PREFIX.length);
+      changed = true;
+    }
+
+    if (apiName.startsWith(LINEAR_CODEX_SERVER_PREFIX)) {
+      apiName = apiName.slice(LINEAR_CODEX_SERVER_PREFIX.length);
+      changed = true;
+    }
+
+    while (apiName.startsWith('_')) {
+      apiName = apiName.slice(1);
+      changed = true;
+    }
   }
-  if (apiName.startsWith(LINEAR_CODEX_SERVER_PREFIX)) {
-    apiName = apiName.slice(LINEAR_CODEX_SERVER_PREFIX.length);
-  }
+
+  return apiName;
+};
+
+const getCodexLinearFetchApiName = (input?: Record<string, unknown>) => {
+  const id = normalizeString(input?.id);
+  const entityPrefix = id.includes(':') ? id.slice(0, id.indexOf(':')).toLowerCase() : '';
+  const prefixedApiName = CODEX_LINEAR_FETCH_API_BY_ENTITY[entityPrefix];
+  if (prefixedApiName) return prefixedApiName;
+
+  if (/^[A-Z][A-Z0-9]+-\d+$/u.test(id)) return 'get_issue';
+
+  return 'fetch';
+};
+
+export const getCodexLinearMcpApiName = (
+  toolName: string,
+  input?: Record<string, unknown>,
+) => {
+  const apiName = normalizeCodexLinearToolName(toolName);
+
+  if (apiName === 'fetch') return getCodexLinearFetchApiName(input);
+  if (CODEX_LINEAR_GENERIC_TOOL_NAMES.has(apiName)) return apiName;
 
   return apiName;
 };

--- a/packages/builtin-tools/src/codex/mcpToolUtils.ts
+++ b/packages/builtin-tools/src/codex/mcpToolUtils.ts
@@ -24,7 +24,6 @@ export interface FormattedMcpValue {
 
 const LINEAR_CODEX_PREFIX = 'linear_';
 const LINEAR_CODEX_SERVER_PREFIX = 'server_';
-const CODEX_LINEAR_GENERIC_TOOL_NAMES = new Set(['fetch', 'search']);
 const CODEX_LINEAR_FETCH_API_BY_ENTITY: Record<string, string> = {
   document: 'get_document',
   initiative: 'get_initiative',
@@ -91,9 +90,10 @@ export const getMcpInputRecord = (
 };
 
 const normalizeCodexLinearToolName = (toolName: string) => {
-  if (!toolName) return '';
+  if (!toolName) return { apiName: '', hasLinearPrefix: false };
 
   let apiName = toolName.trim();
+  let hasLinearPrefix = false;
 
   let changed = true;
   while (changed) {
@@ -101,6 +101,7 @@ const normalizeCodexLinearToolName = (toolName: string) => {
 
     if (apiName.startsWith(LINEAR_CODEX_PREFIX)) {
       apiName = apiName.slice(LINEAR_CODEX_PREFIX.length);
+      hasLinearPrefix = true;
       changed = true;
     }
 
@@ -115,28 +116,44 @@ const normalizeCodexLinearToolName = (toolName: string) => {
     }
   }
 
-  return apiName;
+  return { apiName, hasLinearPrefix };
 };
 
-const getCodexLinearFetchApiName = (input?: Record<string, unknown>) => {
+const isLinearServerName = (server?: string) =>
+  normalizeString(server)
+    .split(/[^a-z0-9]+/iu)
+    .some((part) => part.toLowerCase() === 'linear');
+
+const getCodexLinearFetchApiName = (
+  input: Record<string, unknown> | undefined,
+  isLinearContext: boolean,
+) => {
   const id = normalizeString(input?.id);
   const entityPrefix = id.includes(':') ? id.slice(0, id.indexOf(':')).toLowerCase() : '';
   const prefixedApiName = CODEX_LINEAR_FETCH_API_BY_ENTITY[entityPrefix];
   if (prefixedApiName) return prefixedApiName;
+
+  if (!isLinearContext) return '';
 
   if (/^[A-Z][A-Z0-9]+-\d+$/u.test(id)) return 'get_issue';
 
   return 'fetch';
 };
 
-export const getCodexLinearMcpApiName = (
-  toolName: string,
-  input?: Record<string, unknown>,
-) => {
-  const apiName = normalizeCodexLinearToolName(toolName);
+export const getCodexLinearMcpApiName = ({
+  input,
+  server,
+  toolName,
+}: {
+  input?: Record<string, unknown>;
+  server?: string;
+  toolName: string;
+}) => {
+  const { apiName, hasLinearPrefix } = normalizeCodexLinearToolName(toolName);
+  const isLinearContext = hasLinearPrefix || isLinearServerName(server);
 
-  if (apiName === 'fetch') return getCodexLinearFetchApiName(input);
-  if (CODEX_LINEAR_GENERIC_TOOL_NAMES.has(apiName)) return apiName;
+  if (apiName === 'fetch') return getCodexLinearFetchApiName(input, isLinearContext);
+  if (apiName === 'search') return isLinearContext ? apiName : '';
 
   return apiName;
 };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - no matching GitHub issue found. Observed with Codex Apps Linear fetch calls such as `linear_fetch` for `issue:LOBE-10205`.

#### 🔀 Description of Change

- Reuse the shared Linear inspector for Codex MCP tool calls from Codex Apps Linear.
- Normalize Codex Apps tool names such as `linear_fetch` and `linear_search` before matching them against Linear inspector APIs.
- Map entity-prefixed fetch IDs (`issue:`, `project:`, `initiative:`, `document:`) to the corresponding Linear `get_*` inspector labels.
- Add focused tests for Codex Linear MCP name normalization and JSON argument parsing.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/builtin-tools
bunx vitest run --silent='passed-only' src/codex/commandExecutionUtils.test.ts src/codex/collabToolUtils.test.ts src/codex/mcpToolUtils.test.ts
```

#### 📸 Screenshots / Videos

N/A - inspector-only label behavior covered by focused normalization tests.

#### 📝 Additional Information

`bun run type-check` from the cloud repo currently fails on existing repo-wide dependency resolution issues (Drizzle/Next/Zustand duplicate package instances and missing optional modules), with no errors pointing to these changed files.