### PR TITLE
✨ feat(topic): add selector topic actions

### DIFF
--- a/src/features/PageEditor/Copilot/Toolbar.tsx
+++ b/src/features/PageEditor/Copilot/Toolbar.tsx
@@ -75,7 +75,10 @@ const CopilotToolbar = memo(() => {
                   {(topics || []).map((topic) => (
                     <TopicItem
                       active={topic.id === activeTopicId}
+                      agentId={agentId}
+                      fav={topic.favorite}
                       key={topic.id}
+                      status={topic.status}
                       topicId={topic.id}
                       topicTitle={topic.title}
                       onClose={() => setTopicPopoverOpen(false)}

--- a/src/features/PageEditor/Copilot/TopicSelector/TopicItem.tsx
+++ b/src/features/PageEditor/Copilot/TopicSelector/TopicItem.tsx
@@ -1,3 +1,4 @@
+import type { ChatTopicStatus } from '@lobechat/types';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -8,20 +9,26 @@ import { useDropdownMenu } from './useDropdownMenu';
 
 interface TopicItemProps {
   active: boolean;
+  agentId?: string;
+  fav?: boolean;
   onClose: () => void;
   onDelete?: (topicId: string) => void;
   onTopicChange: (topicId: string) => void;
+  status?: ChatTopicStatus | null;
   topicId: string;
   topicTitle: string;
 }
 
 const TopicItem = memo<TopicItemProps>(
-  ({ active, onClose, onDelete, onTopicChange, topicId, topicTitle }) => {
+  ({ active, agentId, fav, onClose, onDelete, onTopicChange, status, topicId, topicTitle }) => {
     const { t } = useTranslation('topic');
 
     const dropdownMenu = useDropdownMenu({
+      agentId,
+      fav,
       onClose,
       onDelete,
+      status,
       topicId,
       topicTitle,
     });

--- a/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.test.tsx
+++ b/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useDropdownMenu } from './useDropdownMenu';
+
+const confirmModalMock = vi.hoisted(() => vi.fn());
+const removeTopicMock = vi.hoisted(() => vi.fn());
+const permissionMock = vi.hoisted(() => ({
+  create_content: true,
+  edit_own_content: true,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  Icon: () => null,
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  confirmModal: confirmModalMock,
+}));
+
+vi.mock('antd', () => ({
+  App: {
+    useApp: () => ({
+      message: {
+        success: vi.fn(),
+      },
+    }),
+  },
+}));
+
+vi.mock('@/components/RenameModal', () => ({
+  openRenameModal: vi.fn(),
+}));
+
+vi.mock('@/const/url', () => ({
+  SESSION_CHAT_TOPIC_URL: (agentId: string, topicId: string) => `/agent/${agentId}/${topicId}`,
+}));
+
+vi.mock('@/const/version', () => ({
+  isDesktop: true,
+}));
+
+vi.mock('@/features/ShareModal', () => ({
+  openShareModal: vi.fn(),
+}));
+
+vi.mock('@/features/Workspace/useWorkspaceAwareNavigate', () => ({
+  useWorkspaceAwareNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/hooks/useAppOrigin', () => ({
+  useAppOrigin: () => 'https://example.com',
+}));
+
+vi.mock('@/hooks/usePermission', () => ({
+  usePermission: (action: 'create_content' | 'edit_own_content') => ({
+    allowed: permissionMock[action],
+    reason: '',
+  }),
+}));
+
+vi.mock('@/store/chat', () => ({
+  useChatStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      autoRenameTopicTitle: vi.fn(),
+      duplicateTopic: vi.fn(),
+      favoriteTopic: vi.fn(),
+      markTopicCompleted: vi.fn(),
+      removeTopic: removeTopicMock,
+      unmarkTopicCompleted: vi.fn(),
+      updateTopicTitle: vi.fn(),
+    }),
+}));
+
+vi.mock('@/store/electron', () => ({
+  useElectronStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ addTab: vi.fn() }),
+}));
+
+vi.mock('@/store/global', () => ({
+  useGlobalStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ openTopicInNewWindow: vi.fn() }),
+}));
+
+interface TestMenuItem {
+  disabled?: boolean;
+  key?: PropertyKey;
+  onClick?: () => void;
+}
+
+const getMenuItem = (
+  items: NonNullable<ReturnType<ReturnType<typeof useDropdownMenu>>>,
+  key: string,
+): TestMenuItem | undefined =>
+  items.find((item) => item && 'key' in item && item.key === key) as TestMenuItem | undefined;
+
+describe('PageEditor Copilot TopicSelector useDropdownMenu', () => {
+  beforeEach(() => {
+    confirmModalMock.mockReset();
+    removeTopicMock.mockReset();
+    permissionMock.create_content = true;
+    permissionMock.edit_own_content = true;
+  });
+
+  it('renders the full topic action set in the selector menu', () => {
+    const { result } = renderHook(() =>
+      useDropdownMenu({
+        agentId: 'agent-1',
+        fav: false,
+        onClose: vi.fn(),
+        status: 'active',
+        topicId: 'topic-1',
+        topicTitle: 'Topic 1',
+      }),
+    );
+
+    const keys = result.current()?.flatMap((item) => (item && 'key' in item ? [item.key] : []));
+
+    expect(keys).toEqual([
+      'markCompleted',
+      'favorite',
+      'autoRename',
+      'rename',
+      'openInNewTab',
+      'openInNewWindow',
+      'copySessionId',
+      'copyLink',
+      'duplicate',
+      'share',
+      'delete',
+    ]);
+  });
+
+  it('disables write actions for viewers but keeps copy actions available', () => {
+    permissionMock.create_content = false;
+    permissionMock.edit_own_content = false;
+
+    const { result } = renderHook(() =>
+      useDropdownMenu({
+        agentId: 'agent-1',
+        onClose: vi.fn(),
+        topicId: 'topic-1',
+        topicTitle: 'Topic 1',
+      }),
+    );
+    const items = result.current();
+
+    for (const key of [
+      'markCompleted',
+      'favorite',
+      'autoRename',
+      'rename',
+      'duplicate',
+      'share',
+      'delete',
+    ]) {
+      expect(getMenuItem(items, key)).toMatchObject({ disabled: true });
+    }
+
+    expect(getMenuItem(items, 'copySessionId')).not.toMatchObject({ disabled: true });
+    expect(getMenuItem(items, 'copyLink')).not.toMatchObject({ disabled: true });
+  });
+
+  it('removes the topic and closes the selector from the delete confirmation', async () => {
+    const onClose = vi.fn();
+    const onDelete = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDropdownMenu({
+        agentId: 'agent-1',
+        onClose,
+        onDelete,
+        topicId: 'topic-1',
+        topicTitle: 'Topic 1',
+      }),
+    );
+
+    getMenuItem(result.current(), 'delete')?.onClick?.();
+    const config = confirmModalMock.mock.calls[0][0];
+    await config.onOk();
+
+    expect(removeTopicMock).toHaveBeenCalledWith('topic-1');
+    expect(onDelete).toHaveBeenCalledWith('topic-1');
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx
+++ b/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx
@@ -1,33 +1,229 @@
-import { type MenuProps } from '@lobehub/ui';
+import type { ChatTopicStatus } from '@lobechat/types';
+import type { MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
-import { Trash2 } from 'lucide-react';
+import { App } from 'antd';
+import {
+  CheckCircle2,
+  Circle,
+  ExternalLink,
+  Hash,
+  Link2,
+  LucideCopy,
+  PanelTop,
+  PencilLine,
+  Share2,
+  Star,
+  Trash,
+  Wand2,
+} from 'lucide-react';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { openRenameModal } from '@/components/RenameModal';
+import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
+import { isDesktop } from '@/const/version';
+import { openShareModal } from '@/features/ShareModal';
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
+import { useAppOrigin } from '@/hooks/useAppOrigin';
+import { usePermission } from '@/hooks/usePermission';
 import { useChatStore } from '@/store/chat';
+import { useElectronStore } from '@/store/electron';
+import { useGlobalStore } from '@/store/global';
 
 interface UseDropdownMenuProps {
+  agentId?: string;
+  fav?: boolean;
   onClose: () => void;
   onDelete?: (topicId: string) => void;
+  status?: ChatTopicStatus | null;
   topicId: string;
   topicTitle: string;
 }
 
 export const useDropdownMenu = ({
+  agentId,
+  fav,
   onClose,
   onDelete,
+  status,
   topicId,
+  topicTitle,
 }: UseDropdownMenuProps): (() => MenuProps['items']) => {
   const { t } = useTranslation(['common', 'topic']);
-  const removeTopic = useChatStore((s) => s.removeTopic);
+  const { message } = App.useApp();
+  const appOrigin = useAppOrigin();
+  const navigate = useWorkspaceAwareNavigate();
+  const { allowed: canCreateTopic } = usePermission('create_content');
+  const { allowed: canEditTopic } = usePermission('edit_own_content');
+
+  const addTab = useElectronStore((s) => s.addTab);
+  const openTopicInNewWindow = useGlobalStore((s) => s.openTopicInNewWindow);
+
+  const [
+    autoRenameTopicTitle,
+    duplicateTopic,
+    favoriteTopic,
+    markTopicCompleted,
+    removeTopic,
+    unmarkTopicCompleted,
+    updateTopicTitle,
+  ] = useChatStore((s) => [
+    s.autoRenameTopicTitle,
+    s.duplicateTopic,
+    s.favoriteTopic,
+    s.markTopicCompleted,
+    s.removeTopic,
+    s.unmarkTopicCompleted,
+    s.updateTopicTitle,
+  ]);
+
+  const isCompleted = status === 'completed';
+  const handleOpenShareModal = useCallback(() => {
+    openShareModal({ context: { threadId: null, topicId } });
+  }, [topicId]);
 
   return useCallback(
     () =>
       [
         {
+          disabled: !canEditTopic,
+          icon: <Icon icon={isCompleted ? Circle : CheckCircle2} />,
+          key: 'markCompleted',
+          label: isCompleted
+            ? t('actions.unmarkCompleted', { ns: 'topic' })
+            : t('actions.markCompleted', { ns: 'topic' }),
+          onClick: () => {
+            if (isCompleted) {
+              unmarkTopicCompleted(topicId);
+            } else {
+              markTopicCompleted(topicId);
+            }
+          },
+        },
+        {
+          type: 'divider' as const,
+        },
+        {
+          disabled: !canEditTopic,
+          icon: <Icon icon={Star} />,
+          key: 'favorite',
+          label: fav
+            ? t('actions.unfavorite', { ns: 'topic' })
+            : t('actions.favorite', { ns: 'topic' }),
+          onClick: () => {
+            favoriteTopic(topicId, !fav);
+          },
+        },
+        {
+          type: 'divider' as const,
+        },
+        {
+          disabled: !canEditTopic,
+          icon: <Icon icon={Wand2} />,
+          key: 'autoRename',
+          label: t('actions.autoRename', { ns: 'topic' }),
+          onClick: () => {
+            autoRenameTopicTitle(topicId);
+          },
+        },
+        {
+          disabled: !canEditTopic,
+          icon: <Icon icon={PencilLine} />,
+          key: 'rename',
+          label: t('rename'),
+          onClick: () => {
+            openRenameModal({
+              defaultValue: topicTitle,
+              description: t('renameModal.description', { ns: 'topic' }),
+              onSave: async (newTitle) => {
+                await updateTopicTitle(topicId, newTitle);
+              },
+              title: t('renameModal.title', { ns: 'topic' }),
+            });
+          },
+        },
+        {
+          type: 'divider' as const,
+        },
+        ...(isDesktop
+          ? [
+              {
+                disabled: !agentId,
+                icon: <Icon icon={PanelTop} />,
+                key: 'openInNewTab',
+                label: t('actions.openInNewTab', { ns: 'topic' }),
+                onClick: () => {
+                  if (!agentId) return;
+                  const url = SESSION_CHAT_TOPIC_URL(agentId, topicId);
+                  addTab(url);
+                  navigate(url);
+                  onClose();
+                },
+              },
+              {
+                disabled: !agentId,
+                icon: <Icon icon={ExternalLink} />,
+                key: 'openInNewWindow',
+                label: t('actions.openInNewWindow', { ns: 'topic' }),
+                onClick: () => {
+                  if (!agentId) return;
+                  openTopicInNewWindow(agentId, topicId);
+                  onClose();
+                },
+              },
+              {
+                type: 'divider' as const,
+              },
+            ]
+          : []),
+        {
+          icon: <Icon icon={Hash} />,
+          key: 'copySessionId',
+          label: t('actions.copySessionId', { ns: 'topic' }),
+          onClick: () => {
+            void navigator.clipboard.writeText(topicId);
+            message.success(t('actions.copySessionIdSuccess', { ns: 'topic' }));
+          },
+        },
+        {
+          disabled: !agentId,
+          icon: <Icon icon={Link2} />,
+          key: 'copyLink',
+          label: t('actions.copyLink', { ns: 'topic' }),
+          onClick: () => {
+            if (!agentId) return;
+            const url = `${appOrigin}${SESSION_CHAT_TOPIC_URL(agentId, topicId)}`;
+            void navigator.clipboard.writeText(url);
+            message.success(t('actions.copyLinkSuccess', { ns: 'topic' }));
+          },
+        },
+        {
+          disabled: !canCreateTopic,
+          icon: <Icon icon={LucideCopy} />,
+          key: 'duplicate',
+          label: t('actions.duplicate', { ns: 'topic' }),
+          onClick: () => {
+            duplicateTopic(topicId);
+          },
+        },
+        {
+          type: 'divider' as const,
+        },
+        {
+          disabled: !canEditTopic,
+          icon: <Icon icon={Share2} />,
+          key: 'share',
+          label: t('share'),
+          onClick: handleOpenShareModal,
+        },
+        {
+          type: 'divider' as const,
+        },
+        {
           danger: true,
-          icon: <Icon icon={Trash2} />,
+          disabled: !canEditTopic,
+          icon: <Icon icon={Trash} />,
           key: 'delete',
           label: t('delete'),
           onClick: () => {
@@ -46,6 +242,30 @@ export const useDropdownMenu = ({
           },
         },
       ].filter(Boolean) as MenuProps['items'],
-    [t, removeTopic, topicId, onDelete, onClose],
+    [
+      addTab,
+      agentId,
+      appOrigin,
+      autoRenameTopicTitle,
+      canCreateTopic,
+      canEditTopic,
+      duplicateTopic,
+      favoriteTopic,
+      fav,
+      handleOpenShareModal,
+      isCompleted,
+      markTopicCompleted,
+      message,
+      navigate,
+      onClose,
+      onDelete,
+      openTopicInNewWindow,
+      removeTopic,
+      t,
+      topicId,
+      topicTitle,
+      unmarkTopicCompleted,
+      updateTopicTitle,
+    ],
   );
 };


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

Adds the full topic action menu to the Page Editor Copilot topic selector dropdown.

- Adds mark completed, favorite, auto rename, rename, open in new tab/window, copy ID/link, duplicate, share, and delete actions.
- Passes topic metadata from the Copilot toolbar into selector items so action labels and state match each topic.
- Keeps the delete confirmation flow closing the selector and notifying callers after removal.
- Adds hook-level tests for menu composition, permission gating, and delete confirmation behavior.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx eslint 'src/features/PageEditor/Copilot/Toolbar.tsx' 'src/features/PageEditor/Copilot/TopicSelector/TopicItem.tsx' 'src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx' 'src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.test.tsx' --fix
bunx vitest run --silent='passed-only' 'src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.test.tsx'
git diff --check
```

`bun run type-check` was also run. It currently fails on pre-existing unrelated errors outside this change, including missing exports from `@lobechat/types` and duplicate dependency type mismatches. A filtered check for `PageEditor/Copilot`, `TopicSelector`, and `Copilot/Toolbar` produced no errors.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Topic selector menu only exposed delete. | Topic selector menu exposes the same topic management actions as the main topic menu. |

#### 📝 Additional Information

This PR is intentionally based on `canary` with a single clean commit so it does not include the existing `feat(agent): show topic sidebar status indicators` branch changes.
