### PR TITLE
📝 fix: clarify local system shell result wording

### DIFF
--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -262,19 +262,23 @@ async function runConnect(options: ConnectOptions, isDaemonChild: boolean) {
 
   // Handle tool call requests
   client.on('tool_call_request', async (request: ToolCallRequestMessage) => {
-    const { requestId, timeout, toolCall } = request;
+    const { operationId, requestId, timeout, toolCall } = request;
     if (isDaemonChild) {
-      appendLog(`[TOOL] ${toolCall.apiName} (${requestId})`);
+      appendLog(
+        `[TOOL] ${toolCall.apiName}${operationId ? ` op=${operationId}` : ''} (${requestId})`,
+      );
     } else {
-      log.toolCall(toolCall.apiName, requestId, toolCall.arguments);
+      log.toolCall(toolCall.apiName, requestId, toolCall.arguments, operationId);
     }
 
     const result = await executeToolCall(toolCall.apiName, toolCall.arguments, timeout);
 
     if (isDaemonChild) {
-      appendLog(`[RESULT] ${result.success ? 'OK' : 'FAIL'} (${requestId})`);
+      appendLog(
+        `[RESULT] ${result.success ? 'OK' : 'FAIL'}${operationId ? ` op=${operationId}` : ''} (${requestId})`,
+      );
     } else {
-      log.toolResult(requestId, result.success, result.content);
+      log.toolResult(requestId, result.success, result.content, operationId);
     }
 
     client.sendToolCallResponse({

--- a/apps/cli/src/utils/logger.ts
+++ b/apps/cli/src/utils/logger.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import pc from 'picocolors';
 
 let verbose = false;
@@ -41,18 +40,20 @@ export const log = {
     console.log(`${timestamp()} ${pc.bold('[STATUS]')} ${color(status)}`);
   },
 
-  toolCall: (apiName: string, requestId: string, args?: string) => {
+  toolCall: (apiName: string, requestId: string, args?: string, operationId?: string) => {
     console.log(
-      `${timestamp()} ${pc.magenta('[TOOL]')} ${pc.bold(apiName)} ${pc.dim(`(${requestId})`)}`,
+      `${timestamp()} ${pc.magenta('[TOOL]')} ${pc.bold(apiName)}${operationId ? ` ${pc.dim(`op=${operationId}`)}` : ''} ${pc.dim(`(${requestId})`)}`,
     );
     if (args && verbose) {
       console.log(`  ${pc.dim(args)}`);
     }
   },
 
-  toolResult: (requestId: string, success: boolean, content?: string) => {
+  toolResult: (requestId: string, success: boolean, content?: string, operationId?: string) => {
     const icon = success ? pc.green('OK') : pc.red('FAIL');
-    console.log(`${timestamp()} ${pc.magenta('[RESULT]')} ${icon} ${pc.dim(`(${requestId})`)}`);
+    console.log(
+      `${timestamp()} ${pc.magenta('[RESULT]')} ${icon}${operationId ? ` ${pc.dim(`op=${operationId}`)}` : ''} ${pc.dim(`(${requestId})`)}`,
+    );
     if (content && verbose) {
       const preview = content.length > 200 ? content.slice(0, 200) + '...' : content;
       console.log(`  ${pc.dim(preview)}`);

--- a/apps/server/src/services/deviceGateway/index.ts
+++ b/apps/server/src/services/deviceGateway/index.ts
@@ -669,7 +669,7 @@ export class DeviceGateway {
   }
 
   async executeToolCall(
-    params: { deviceId: string; userId: string },
+    params: { deviceId: string; operationId?: string; userId: string },
     toolCall: { apiName: string; arguments: string; identifier: string },
     timeout = 30_000,
   ): Promise<DeviceToolCallResult> {
@@ -683,7 +683,8 @@ export class DeviceGateway {
     }
 
     log(
-      'executeToolCall: userId=%s, deviceId=%s, tool=%s/%s',
+      'executeToolCall: operationId=%s, userId=%s, deviceId=%s, tool=%s/%s',
+      params.operationId ?? 'N/A',
       params.userId,
       params.deviceId,
       toolCall.identifier,
@@ -692,7 +693,12 @@ export class DeviceGateway {
 
     try {
       return await client.executeToolCall(
-        { deviceId: params.deviceId, timeout, userId: params.userId },
+        {
+          deviceId: params.deviceId,
+          operationId: params.operationId,
+          timeout,
+          userId: params.userId,
+        },
         toolCall,
       );
     } catch (error) {

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/localSystem.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/localSystem.test.ts
@@ -64,6 +64,7 @@ describe('localSystemRuntime', () => {
     it('should call deviceGateway.executeToolCall with correct arguments when a proxy function is invoked', async () => {
       const context: ToolExecutionContext = {
         activeDeviceId: 'device-1',
+        operationId: 'op-1',
         toolManifestMap: {},
         userId: 'user-1',
       };
@@ -78,7 +79,7 @@ describe('localSystemRuntime', () => {
       const result = await proxy[apiName](args);
 
       expect(mockExecuteToolCall).toHaveBeenCalledWith(
-        { deviceId: 'device-1', userId: 'user-1' },
+        { deviceId: 'device-1', operationId: 'op-1', userId: 'user-1' },
         {
           apiName,
           arguments: JSON.stringify(args),

--- a/apps/server/src/services/toolExecution/serverRuntimes/localSystem.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/localSystem.ts
@@ -18,7 +18,11 @@ export const localSystemRuntime: ServerRuntimeRegistration = {
     for (const api of LocalSystemManifest.api) {
       proxy[api.name] = async (args: any) => {
         return deviceGateway.executeToolCall(
-          { deviceId: context.activeDeviceId!, userId: context.userId! },
+          {
+            deviceId: context.activeDeviceId!,
+            operationId: context.operationId,
+            userId: context.userId!,
+          },
           {
             apiName: api.name,
             arguments: JSON.stringify(args),

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -1,5 +1,7 @@
 import { builtinSkills } from '@lobechat/builtin-skills';
 import { LocalSystemApiName, LocalSystemIdentifier } from '@lobechat/builtin-tool-local-system';
+// Project skill files are wired through deviceGateway using local-system tools:
+// `readFile` loads content, and `globFiles` enumerates resources for validation.
 import {
   type CommandResult,
   type ExecScriptActivatedSkill,

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -1,7 +1,7 @@
 import { builtinSkills } from '@lobechat/builtin-skills';
 import { LocalSystemApiName, LocalSystemIdentifier } from '@lobechat/builtin-tool-local-system';
-// Project skill files are wired through deviceGateway using local-system tools:
-// `readFile` loads content, and `globFiles` enumerates resources for validation.
+// Note: only `readFile` is wired through deviceGateway. Directory enumeration is
+// left to the model via `local-system.globFiles` so we don't double-fetch.
 import {
   type CommandResult,
   type ExecScriptActivatedSkill,

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -1,7 +1,5 @@
 import { builtinSkills } from '@lobechat/builtin-skills';
 import { LocalSystemApiName, LocalSystemIdentifier } from '@lobechat/builtin-tool-local-system';
-// Note: only `readFile` is wired through deviceGateway. Directory enumeration is
-// left to the model via `local-system.listFiles` so we don't double-fetch.
 import {
   type CommandResult,
   type ExecScriptActivatedSkill,

--- a/packages/builtin-tool-local-system/src/manifest.ts
+++ b/packages/builtin-tool-local-system/src/manifest.ts
@@ -9,46 +9,6 @@ export const LocalSystemManifest: BuiltinToolManifest = {
     {
       defaultTimeoutMs: 30_000,
       description:
-        'List files and folders in a specified directory. Input should be a path. Output is a JSON array of file/folder names.',
-      humanIntervention: {
-        dynamic: {
-          default: 'never',
-          policy: 'required',
-          type: 'pathScopeAudit',
-        },
-      },
-      name: LocalSystemApiName.listFiles,
-      parameters: {
-        properties: {
-          limit: {
-            default: 100,
-            description: 'Maximum number of items to return (default: 100)',
-            type: 'number',
-          },
-          path: {
-            description: 'The directory path to list',
-            type: 'string',
-          },
-          sortBy: {
-            default: 'modifiedTime',
-            description: 'Field to sort by (default: modifiedTime)',
-            enum: ['name', 'modifiedTime', 'createdTime', 'size'],
-            type: 'string',
-          },
-          sortOrder: {
-            default: 'desc',
-            description: 'Sort order (default: desc)',
-            enum: ['asc', 'desc'],
-            type: 'string',
-          },
-        },
-        required: ['path'],
-        type: 'object',
-      },
-    },
-    {
-      defaultTimeoutMs: 30_000,
-      description:
         'Read the content of a text or document file (txt/md/json/source code/pdf/docx/etc.). Binary files (.bin/.exe/.zip/.b64/encoded blobs) are rejected with a structured error — use runCommand with file/hexdump/strings to inspect those instead. Output is capped at 500K chars total and 8K chars per line; for larger files, use a narrower line range or grepContent.',
       humanIntervention: {
         dynamic: {

--- a/packages/builtin-tool-local-system/src/manifest.ts
+++ b/packages/builtin-tool-local-system/src/manifest.ts
@@ -225,7 +225,7 @@ export const LocalSystemManifest: BuiltinToolManifest = {
     {
       defaultTimeoutMs: 30_000,
       description:
-        'Start a terminal session to execute a shell command and return console output collected during the wait window (up to 30 seconds by default). If the command is still running after the wait window, the result includes `shell_id` for later observation or termination. If the command exits with a non-zero status, the result includes `exit_code`.',
+        'Start a terminal session to execute a shell command and return console output collected during the wait window (up to 30 seconds by default). If the command is still running after the wait window, the result includes `shell_id` for later observation or termination.',
       humanIntervention: 'required',
       name: LocalSystemApiName.runCommand,
       parameters: {
@@ -258,7 +258,7 @@ export const LocalSystemManifest: BuiltinToolManifest = {
     {
       defaultTimeoutMs: 30_000,
       description:
-        'Retrieve new output from a background shell command. Waits for one output window (up to 30 seconds by default) and returns only output produced since the last check.',
+        'Retrieve output from a running or completed background shell command. Waits for one output window (up to 30 seconds by default) and returns only new output since the last check.',
       name: LocalSystemApiName.getCommandOutput,
       parameters: {
         properties: {
@@ -268,7 +268,7 @@ export const LocalSystemManifest: BuiltinToolManifest = {
             type: 'string',
           },
           shell_id: {
-            description: 'The terminal session handle to retrieve output from',
+            description: 'The ID of the background shell to retrieve output from',
             type: 'string',
           },
         },

--- a/packages/builtin-tool-local-system/src/manifest.ts
+++ b/packages/builtin-tool-local-system/src/manifest.ts
@@ -225,7 +225,7 @@ export const LocalSystemManifest: BuiltinToolManifest = {
     {
       defaultTimeoutMs: 30_000,
       description:
-        'Start a terminal session to execute a shell command and return console output collected during the wait window (up to 30 seconds by default). If the command exits during that window, the result includes `exit_code`; if it is still running, the result includes `shell_id` for later output retrieval or termination.',
+        'Start a terminal session to execute a shell command and return console output collected during the wait window (up to 30 seconds by default). `shell_id` is the session handle for later observation or termination. `exit_code` is present only after the command exits; if absent, the command is still running.',
       humanIntervention: 'required',
       name: LocalSystemApiName.runCommand,
       parameters: {
@@ -247,7 +247,7 @@ export const LocalSystemManifest: BuiltinToolManifest = {
           },
           run_in_background: {
             description:
-              'Set to true to return immediately after starting the terminal session. The result will include a `shell_id` for later observation or termination.',
+              'Set to true to return immediately after starting the terminal session. The result includes a `shell_id` session handle for later observation or termination.',
             type: 'boolean',
           },
         },
@@ -258,7 +258,7 @@ export const LocalSystemManifest: BuiltinToolManifest = {
     {
       defaultTimeoutMs: 30_000,
       description:
-        'Retrieve output from a running or completed background shell command. Waits for one output window (up to 30 seconds by default) and returns only new output since the last check.',
+        'Retrieve new output from an existing terminal session. Waits for one output window (up to 30 seconds by default) and returns only output produced since the last check.',
       name: LocalSystemApiName.getCommandOutput,
       parameters: {
         properties: {
@@ -268,7 +268,7 @@ export const LocalSystemManifest: BuiltinToolManifest = {
             type: 'string',
           },
           shell_id: {
-            description: 'The ID of the background shell to retrieve output from',
+            description: 'The terminal session handle to retrieve output from',
             type: 'string',
           },
         },
@@ -278,12 +278,12 @@ export const LocalSystemManifest: BuiltinToolManifest = {
     },
     {
       defaultTimeoutMs: 10_000,
-      description: 'Kill a running background shell command by its ID.',
+      description: 'Kill a running terminal session by its handle.',
       name: LocalSystemApiName.killCommand,
       parameters: {
         properties: {
           shell_id: {
-            description: 'The ID of the background shell to kill',
+            description: 'The terminal session handle to kill',
             type: 'string',
           },
         },

--- a/packages/builtin-tool-local-system/src/manifest.ts
+++ b/packages/builtin-tool-local-system/src/manifest.ts
@@ -225,7 +225,7 @@ export const LocalSystemManifest: BuiltinToolManifest = {
     {
       defaultTimeoutMs: 30_000,
       description:
-        'Start a terminal session to execute a shell command and return console output collected during the wait window (up to 30 seconds by default). `shell_id` is the session handle for later observation or termination. `exit_code` is present only after the command exits; if absent, the command is still running.',
+        'Start a terminal session to execute a shell command and return console output collected during the wait window (up to 30 seconds by default). If the command is still running after the wait window, the result includes `shell_id` for later observation or termination. If the command exits with a non-zero status, the result includes `exit_code`.',
       humanIntervention: 'required',
       name: LocalSystemApiName.runCommand,
       parameters: {
@@ -247,7 +247,7 @@ export const LocalSystemManifest: BuiltinToolManifest = {
           },
           run_in_background: {
             description:
-              'Set to true to return immediately after starting the terminal session. The result includes a `shell_id` session handle for later observation or termination.',
+              'Set to true to return immediately after starting the terminal session. The result will include a `shell_id` for later observation or termination.',
             type: 'boolean',
           },
         },
@@ -258,7 +258,7 @@ export const LocalSystemManifest: BuiltinToolManifest = {
     {
       defaultTimeoutMs: 30_000,
       description:
-        'Retrieve new output from an existing terminal session. Waits for one output window (up to 30 seconds by default) and returns only output produced since the last check.',
+        'Retrieve new output from a background shell command. Waits for one output window (up to 30 seconds by default) and returns only output produced since the last check.',
       name: LocalSystemApiName.getCommandOutput,
       parameters: {
         properties: {
@@ -278,12 +278,12 @@ export const LocalSystemManifest: BuiltinToolManifest = {
     },
     {
       defaultTimeoutMs: 10_000,
-      description: 'Kill a running terminal session by its handle.',
+      description: 'Kill a running background shell command by its ID.',
       name: LocalSystemApiName.killCommand,
       parameters: {
         properties: {
           shell_id: {
-            description: 'The terminal session handle to kill',
+            description: 'The ID of the background shell to kill',
             type: 'string',
           },
         },

--- a/packages/builtin-tool-local-system/src/systemRole.desktop.ts
+++ b/packages/builtin-tool-local-system/src/systemRole.desktop.ts
@@ -77,14 +77,14 @@ You have access to a set of tools to interact with the user's local file system:
 - For executing shell commands: Use 'runCommand'. Provide the following parameters:
     - 'command': The shell command to execute.
     - 'description' (Optional but recommended): A clear, concise description of what the command does (5-10 words, in active voice). **IMPORTANT: Always use the same language as the user's input.** If the user speaks Chinese, write the description in Chinese; if English, use English, etc.
-    - 'run_in_background' (Optional): Set to true to return immediately after starting the terminal session. The result includes a 'shell_id' for later observation or termination.
+    - 'run_in_background' (Optional): Set to true to return immediately after starting the terminal session. The result includes a 'shell_id' session handle for later observation or termination.
     The command runs in cmd.exe on Windows or /bin/sh on macOS/Linux. The returned output reflects the tool's wait window, not necessarily the full command lifetime.
     - Result semantics:
       - 'success' indicates whether the tool call itself succeeded.
-      - 'shell_id' identifies the terminal session for later observation/termination.
-      - 'exit_code' is only present after the command has exited. If it is absent, the command is still running.
+      - 'shell_id' is the terminal session handle for later observation/termination.
+      - 'exit_code' is present only after the command has exited. If it is absent, the command is still running.
 - For retrieving output from terminal sessions: Use 'getCommandOutput'. Provide:
-    - 'shell_id': The ID returned from runCommand.
+    - 'shell_id': The session handle returned from runCommand.
     - 'filter' (Optional): A regex pattern to filter output lines.
     Returns only new output since the last check. Each call observes another wait window, so repeated checks consume real time.
 - For killing running terminal sessions: Use 'killCommand' with 'shell_id'.

--- a/packages/builtin-tool-local-system/src/systemRole.desktop.ts
+++ b/packages/builtin-tool-local-system/src/systemRole.desktop.ts
@@ -90,7 +90,7 @@ You have access to a set of tools to interact with the user's local file system:
     Treat terminal sessions as ongoing resources: when elapsed wait time and observed progress no longer match the command's expected lifecycle, reassess whether the session should continue running.
 - For remote device execution feedback: 'Device tool call failed (HTTP ...)' describes the remote-device/gateway layer, not necessarily the local operation.
     - HTTP 403 likely means an edge security policy blocked the request; replan with an equivalent approach or another tool such as runCommand.
-    - HTTP 503 is usually transient; retry when the operation is safe to repeat.
+    - HTTP 503 is usually transient during reconnects or stale session replacement. For the same intended operation, retry up to 8 times only when the operation is safe to repeat; if it still fails, stop retrying that operation and replan.
     - HTTP 504 means the device did not respond within the wait window; the command may already have started, so retry only when the operation is safe to repeat.
 - For searching content in files: Use 'grepContent'. Provide:
     - 'pattern': The regex pattern to search for.

--- a/packages/builtin-tool-local-system/src/systemRole.desktop.ts
+++ b/packages/builtin-tool-local-system/src/systemRole.desktop.ts
@@ -77,14 +77,13 @@ You have access to a set of tools to interact with the user's local file system:
 - For executing shell commands: Use 'runCommand'. Provide the following parameters:
     - 'command': The shell command to execute.
     - 'description' (Optional but recommended): A clear, concise description of what the command does (5-10 words, in active voice). **IMPORTANT: Always use the same language as the user's input.** If the user speaks Chinese, write the description in Chinese; if English, use English, etc.
-    - 'run_in_background' (Optional): Set to true to return immediately after starting the terminal session. The result includes a 'shell_id' session handle for later observation or termination.
+    - 'run_in_background' (Optional): Set to true to return immediately after starting the terminal session. The result includes a 'shell_id' for later observation or termination.
     The command runs in cmd.exe on Windows or /bin/sh on macOS/Linux. The returned output reflects the tool's wait window, not necessarily the full command lifetime.
     - Result semantics:
       - 'success' indicates whether the tool call itself succeeded.
-      - 'shell_id' is the terminal session handle for later observation/termination.
-      - 'exit_code' is present only after the command has exited. If it is absent, the command is still running.
+      - 'shell_id' identifies the terminal session for later observation/termination.
 - For retrieving output from terminal sessions: Use 'getCommandOutput'. Provide:
-    - 'shell_id': The session handle returned from runCommand.
+    - 'shell_id': The ID returned from runCommand.
     - 'filter' (Optional): A regex pattern to filter output lines.
     Returns only new output since the last check. Each call observes another wait window, so repeated checks consume real time.
 - For killing running terminal sessions: Use 'killCommand' with 'shell_id'.

--- a/packages/builtin-tool-local-system/src/systemRole.desktop.ts
+++ b/packages/builtin-tool-local-system/src/systemRole.desktop.ts
@@ -1,4 +1,4 @@
-export const systemPrompt = `You have a Local System tool with capabilities to interact with the user's local system. You can list directories, read file contents, search for files, move, and rename files/directories.
+export const systemPrompt = `You have a Local System tool with capabilities to interact with the user's local system. You can read file contents, search for files, move and rename files/directories, and run shell commands.
 
 <user_context>
 **Current Working Directory:** {{workingDirectory}}
@@ -21,27 +21,26 @@ Use these paths when the user refers to these common locations by name (e.g., "m
 You have access to a set of tools to interact with the user's local file system:
 
 **File Operations:**
-1.  **listFiles**: Lists files and directories in a specified path. Returns metadata including file size and modification time. Results are sorted by modification time (newest first) by default and limited to 100 items.
-2.  **readFile**: Reads the content of a specified file, optionally within a line range. You can read file types such as Word, Excel, PowerPoint, PDF, and plain text files.
-3.  **writeFile**: Write content to a specific file, only support plain text file like \`.text\` or \`.md\`
-4.  **editFile**: Performs exact string replacements in files. Must read the file first before editing.
-5.  **moveFiles**: Moves multiple files or directories. Also handles renames — pass the original directory with the new filename in \`newPath\`.
+1.  **readFile**: Reads the content of a specified file, optionally within a line range. You can read file types such as Word, Excel, PowerPoint, PDF, and plain text files.
+2.  **writeFile**: Write content to a specific file, only support plain text file like \`.text\` or \`.md\`
+3.  **editFile**: Performs exact string replacements in files. Must read the file first before editing.
+4.  **moveFiles**: Moves multiple files or directories. Also handles renames — pass the original directory with the new filename in \`newPath\`.
 
 **Shell Commands:**
-6.  **runCommand**: Start a terminal session to execute shell commands and return console output collected during the wait window. When providing a description, always use the same language as the user's input.
-7.  **getCommandOutput**: Retrieve output from an existing terminal session. Returns only new output since last check.
-8.  **killCommand**: Terminate a running terminal session by its ID.
+5.  **runCommand**: Start a terminal session to execute shell commands and return console output collected during the wait window. When providing a description, always use the same language as the user's input.
+6.  **getCommandOutput**: Retrieve output from an existing terminal session. Returns only new output since last check.
+7.  **killCommand**: Terminate a running terminal session by its ID.
 
 **Search & Find:**
-9.  **searchFiles**: Searches for files based on keywords and other criteria using native search. Use this tool to find files if the user is unsure about the exact path.
-10. **grepContent**: Search for content within files using regex patterns. Supports various output modes, filtering, and context lines.
-11. **globFiles**: Find files matching glob patterns (e.g., "**/*.js", "*.{ts,tsx}").
+8.  **searchFiles**: Searches for files based on keywords and other criteria using native search. Use this tool to find files if the user is unsure about the exact path.
+9.  **grepContent**: Search for content within files using regex patterns. Supports various output modes, filtering, and context lines.
+10. **globFiles**: Find files matching glob patterns (e.g., "**/*.js", "*.{ts,tsx}").
 </core_capabilities>
 
 <workflow>
 1. Understand the user's request regarding local operations (files, commands, searches).
 2. Select the appropriate tool:
-   - File operations: listFiles, readFile, writeFile, editFile, moveFiles
+   - File operations: readFile, writeFile, editFile, moveFiles
    - Shell commands: runCommand, getCommandOutput, killCommand
    - Search/Find: searchFiles, grepContent, globFiles
 3. Execute the operation. **If the user mentions a common location (like Desktop, Documents, Downloads, etc.) without providing a full path, use the corresponding path from the <user_context> section.**
@@ -49,13 +48,6 @@ You have access to a set of tools to interact with the user's local file system:
 </workflow>
 
 <tool_usage_guidelines>
-- For listing directory contents: Use 'listFiles'. Provide the following parameters:
-    - 'path': The directory path to list.
-    - 'sortBy' (Optional): Field to sort results by. Options: 'name', 'modifiedTime', 'createdTime', 'size'. Defaults to 'modifiedTime'.
-    - 'sortOrder' (Optional): Sort order. Options: 'asc', 'desc'. Defaults to 'desc' (newest/largest first).
-    - 'limit' (Optional): Maximum number of items to return. Defaults to 100.
-    - The response includes file/folder names with metadata (size in bytes, modification time) for each item.
-    - System files (e.g., '.DS_Store', 'Thumbs.db', '$RECYCLE.BIN') are automatically filtered out.
 - For reading a file: Use 'readFile'. Provide the following parameters:
     - 'path': The exact file path.
     - 'loc' (Optional): A two-element array [startLine, endLine] to specify a line range to read (e.g., '[301, 400]' reads lines 301 to 400).

--- a/packages/builtin-tool-local-system/src/systemRole.ts
+++ b/packages/builtin-tool-local-system/src/systemRole.ts
@@ -66,14 +66,13 @@ You have access to a set of tools to interact with the user's local file system:
 - For executing shell commands: Use 'runCommand'. Provide the following parameters:
     - 'command': The shell command to execute.
     - 'description' (Optional but recommended): A clear, concise description of what the command does (5-10 words, in active voice). **IMPORTANT: Always use the same language as the user's input.** If the user speaks Chinese, write the description in Chinese; if English, use English, etc.
-    - 'run_in_background' (Optional): Set to true to return immediately after starting the terminal session. The result includes a 'shell_id' session handle for later observation or termination.
+    - 'run_in_background' (Optional): Set to true to return immediately after starting the terminal session. The result includes a 'shell_id' for later observation or termination.
     The command runs in cmd.exe on Windows or /bin/sh on macOS/Linux. The returned output reflects the tool's wait window, not necessarily the full command lifetime.
     - Result semantics:
       - 'success' indicates whether the tool call itself succeeded.
-      - 'shell_id' is the terminal session handle for later observation/termination.
-      - 'exit_code' is present only after the command has exited. If it is absent, the command is still running.
+      - 'shell_id' identifies the terminal session for later observation/termination.
 - For retrieving output from terminal sessions: Use 'getCommandOutput'. Provide:
-    - 'shell_id': The session handle returned from runCommand.
+    - 'shell_id': The ID returned from runCommand.
     - 'filter' (Optional): A regex pattern to filter output lines.
     Returns only new output since the last check. Each call observes another wait window, so repeated checks consume real time.
 - For killing running terminal sessions: Use 'killCommand' with 'shell_id'.

--- a/packages/builtin-tool-local-system/src/systemRole.ts
+++ b/packages/builtin-tool-local-system/src/systemRole.ts
@@ -79,7 +79,7 @@ You have access to a set of tools to interact with the user's local file system:
     Treat terminal sessions as ongoing resources: when elapsed wait time and observed progress no longer match the command's expected lifecycle, reassess whether the session should continue running.
 - For remote device execution feedback: 'Device tool call failed (HTTP ...)' describes the remote-device/gateway layer, not necessarily the local operation.
     - HTTP 403 likely means an edge security policy blocked the request; replan with an equivalent approach or another tool such as runCommand.
-    - HTTP 503 is usually transient; retry when the operation is safe to repeat.
+    - HTTP 503 is usually transient during reconnects or stale session replacement. For the same intended operation, retry up to 8 times only when the operation is safe to repeat; if it still fails, stop retrying that operation and replan.
     - HTTP 504 means the device did not respond within the wait window; the command may already have started, so retry only when the operation is safe to repeat.
 - For searching content in files: Use 'grepContent'. Provide:
     - 'pattern': The regex pattern to search for.

--- a/packages/builtin-tool-local-system/src/systemRole.ts
+++ b/packages/builtin-tool-local-system/src/systemRole.ts
@@ -1,4 +1,4 @@
-export const systemPrompt = `You have a Local System tool with capabilities to interact with the user's local system. You can list directories, read file contents, search for files, move, and rename files/directories.
+export const systemPrompt = `You have a Local System tool with capabilities to interact with the user's local system. You can read file contents, search for files, move and rename files/directories, and run shell commands.
 
 <user_context>
 <device name="{{hostname}}" os="{{platform}}" arch="{{arch}}" />
@@ -10,27 +10,26 @@ export const systemPrompt = `You have a Local System tool with capabilities to i
 You have access to a set of tools to interact with the user's local file system:
 
 **File Operations:**
-1.  **listFiles**: Lists files and directories in a specified path. Returns metadata including file size and modification time. Results are sorted by modification time (newest first) by default and limited to 100 items.
-2.  **readFile**: Reads the content of a specified file, optionally within a line range. You can read file types such as Word, Excel, PowerPoint, PDF, and plain text files.
-3.  **writeFile**: Write content to a specific file, only support plain text file like \`.text\` or \`.md\`
-4.  **editFile**: Performs exact string replacements in files. Must read the file first before editing.
-5.  **moveFiles**: Moves multiple files or directories. Also handles renames — pass the original directory with the new filename in \`newPath\`.
+1.  **readFile**: Reads the content of a specified file, optionally within a line range. You can read file types such as Word, Excel, PowerPoint, PDF, and plain text files.
+2.  **writeFile**: Write content to a specific file, only support plain text file like \`.text\` or \`.md\`
+3.  **editFile**: Performs exact string replacements in files. Must read the file first before editing.
+4.  **moveFiles**: Moves multiple files or directories. Also handles renames — pass the original directory with the new filename in \`newPath\`.
 
 **Shell Commands:**
-6.  **runCommand**: Start a terminal session to execute shell commands and return console output collected during the wait window. When providing a description, always use the same language as the user's input.
-7.  **getCommandOutput**: Retrieve output from an existing terminal session. Returns only new output since last check.
-8.  **killCommand**: Terminate a running terminal session by its ID.
+5.  **runCommand**: Start a terminal session to execute shell commands and return console output collected during the wait window. When providing a description, always use the same language as the user's input.
+6.  **getCommandOutput**: Retrieve output from an existing terminal session. Returns only new output since last check.
+7.  **killCommand**: Terminate a running terminal session by its ID.
 
 **Search & Find:**
-9.  **searchFiles**: Searches for files based on keywords and other criteria using native search. Use this tool to find files if the user is unsure about the exact path.
-10. **grepContent**: Search for content within files using regex patterns. Supports various output modes, filtering, and context lines.
-11. **globFiles**: Find files matching glob patterns (e.g., "**/*.js", "*.{ts,tsx}").
+8.  **searchFiles**: Searches for files based on keywords and other criteria using native search. Use this tool to find files if the user is unsure about the exact path.
+9.  **grepContent**: Search for content within files using regex patterns. Supports various output modes, filtering, and context lines.
+10. **globFiles**: Find files matching glob patterns (e.g., "**/*.js", "*.{ts,tsx}").
 </core_capabilities>
 
 <workflow>
 1. Understand the user's request regarding local operations (files, commands, searches).
 2. Select the appropriate tool:
-   - File operations: listFiles, readFile, writeFile, editFile, moveFiles
+   - File operations: readFile, writeFile, editFile, moveFiles
    - Shell commands: runCommand, getCommandOutput, killCommand
    - Search/Find: searchFiles, grepContent, globFiles
 3. Execute the operation. **If the user mentions a common location (like Desktop, Documents, Downloads, etc.) without providing a full path, use the corresponding path from the <user_context> section.**
@@ -38,13 +37,6 @@ You have access to a set of tools to interact with the user's local file system:
 </workflow>
 
 <tool_usage_guidelines>
-- For listing directory contents: Use 'listFiles'. Provide the following parameters:
-    - 'path': The directory path to list.
-    - 'sortBy' (Optional): Field to sort results by. Options: 'name', 'modifiedTime', 'createdTime', 'size'. Defaults to 'modifiedTime'.
-    - 'sortOrder' (Optional): Sort order. Options: 'asc', 'desc'. Defaults to 'desc' (newest/largest first).
-    - 'limit' (Optional): Maximum number of items to return. Defaults to 100.
-    - The response includes file/folder names with metadata (size in bytes, modification time) for each item.
-    - System files (e.g., '.DS_Store', 'Thumbs.db', '$RECYCLE.BIN') are automatically filtered out.
 - For reading a file: Use 'readFile'. Provide the following parameters:
     - 'path': The exact file path.
     - 'loc' (Optional): A two-element array [startLine, endLine] to specify a line range to read (e.g., '[301, 400]' reads lines 301 to 400).

--- a/packages/builtin-tool-local-system/src/systemRole.ts
+++ b/packages/builtin-tool-local-system/src/systemRole.ts
@@ -66,14 +66,14 @@ You have access to a set of tools to interact with the user's local file system:
 - For executing shell commands: Use 'runCommand'. Provide the following parameters:
     - 'command': The shell command to execute.
     - 'description' (Optional but recommended): A clear, concise description of what the command does (5-10 words, in active voice). **IMPORTANT: Always use the same language as the user's input.** If the user speaks Chinese, write the description in Chinese; if English, use English, etc.
-    - 'run_in_background' (Optional): Set to true to return immediately after starting the terminal session. The result includes a 'shell_id' for later observation or termination.
+    - 'run_in_background' (Optional): Set to true to return immediately after starting the terminal session. The result includes a 'shell_id' session handle for later observation or termination.
     The command runs in cmd.exe on Windows or /bin/sh on macOS/Linux. The returned output reflects the tool's wait window, not necessarily the full command lifetime.
     - Result semantics:
       - 'success' indicates whether the tool call itself succeeded.
-      - 'shell_id' identifies the terminal session for later observation/termination.
-      - 'exit_code' is only present after the command has exited. If it is absent, the command is still running.
+      - 'shell_id' is the terminal session handle for later observation/termination.
+      - 'exit_code' is present only after the command has exited. If it is absent, the command is still running.
 - For retrieving output from terminal sessions: Use 'getCommandOutput'. Provide:
-    - 'shell_id': The ID returned from runCommand.
+    - 'shell_id': The session handle returned from runCommand.
     - 'filter' (Optional): A regex pattern to filter output lines.
     Returns only new output since the last check. Each call observes another wait window, so repeated checks consume real time.
 - For killing running terminal sessions: Use 'killCommand' with 'shell_id'.

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts
@@ -204,9 +204,9 @@ describe('SkillsExecutionRuntime', () => {
       expect(result.success).toBe(true);
       expect(result.content).toContain('Run the deploy steps.');
       // The hint points at the skill's directory and instructs the model to
-      // call `local-system.listFiles` itself rather than pre-enumerating here.
+      // call `local-system.globFiles` itself rather than pre-enumerating here.
       expect(result.content).toContain('/repo/.agents/skills/deploy');
-      expect(result.content).toContain('listFiles');
+      expect(result.content).toContain('globFiles');
       expect(result.state).toMatchObject({ name: 'deploy', source: 'project' });
     });
 

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
@@ -124,13 +124,13 @@ const hasHiddenSegment = (rel: string): boolean =>
 /**
  * Hint appended to activated project-skill content so the model knows how to
  * discover the rest of the skill's directory. We deliberately don't enumerate
- * the tree here — the model has `local-system.listFiles` available and can
+ * the tree here — the model has `local-system.globFiles` available and can
  * call it on demand, which keeps the op-param payload small.
  */
 const buildProjectDirectoryHint = (skillName: string, skillDir: string): string =>
   `## Skill resources
 
-This project skill lives in \`${skillDir}\`. Use \`local-system.listFiles\` on that path to discover reference files, then \`readReference\` with skillName="${skillName}" + the relative path to load any of them.`;
+This project skill lives in \`${skillDir}\`. Use \`local-system.globFiles\` with scope="${skillDir}" and pattern="**/*" to discover reference files, then \`readReference\` with skillName="${skillName}" + the relative path to load any of them.`;
 
 export class SkillsExecutionRuntime {
   private builtinSkills: BuiltinSkill[];
@@ -378,7 +378,7 @@ export class SkillsExecutionRuntime {
         let content = await this.deviceFileAccess.readFile(projectSkill.location);
 
         // Don't enumerate the directory here — let the model do it on demand
-        // via `local-system.listFiles`. Just point at the skill's directory so
+        // via `local-system.globFiles`. Just point at the skill's directory so
         // it knows where to look. Keeps the op-param payload small and avoids
         // a second deviceGateway round-trip at activation time.
         const skillDir = getDirname(projectSkill.location);

--- a/packages/device-gateway-client/src/http.test.ts
+++ b/packages/device-gateway-client/src/http.test.ts
@@ -274,6 +274,22 @@ describe('GatewayHttpClient', () => {
       expect(body.toolCall.type).toBe('tool');
     });
 
+    it('should pass optional operationId', async () => {
+      mockFetch({
+        json: vi.fn().mockResolvedValue({ content: 'ok', success: true }),
+        ok: true,
+      });
+
+      await client.executeToolCall(
+        { operationId: 'op-1', userId: 'user-1' },
+        { apiName: 'readFile', arguments: '{}', identifier: 'test' },
+      );
+
+      const init = vi.mocked(fetch).mock.calls[0][1];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.operationId).toBe('op-1');
+    });
+
     it('should use default gateway timeout plus HTTP caller padding when timeout is absent', async () => {
       mockFetch({
         json: vi.fn().mockResolvedValue({ content: 'ok', success: true }),

--- a/packages/device-gateway-client/src/http.ts
+++ b/packages/device-gateway-client/src/http.ts
@@ -66,7 +66,7 @@ export class GatewayHttpClient {
   }
 
   async executeToolCall(
-    params: { deviceId?: string; timeout?: number; userId: string },
+    params: { deviceId?: string; operationId?: string; timeout?: number; userId: string },
     toolCall: { apiName: string; arguments: string; identifier: string },
   ): Promise<DeviceToolCallResult> {
     return this.postToolCall(params, { ...toolCall, type: 'tool' });
@@ -95,7 +95,7 @@ export class GatewayHttpClient {
   }
 
   private async postToolCall(
-    params: { deviceId?: string; timeout?: number; userId: string },
+    params: { deviceId?: string; operationId?: string; timeout?: number; userId: string },
     toolCall: {
       apiName: string;
       arguments: string;
@@ -112,6 +112,7 @@ export class GatewayHttpClient {
       '/api/device/tool-call',
       {
         deviceId: params.deviceId,
+        operationId: params.operationId,
         timeout: params.timeout,
         toolCall,
         userId: params.userId,

--- a/packages/local-file-shell/src/shell/__tests__/process-manager.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/process-manager.test.ts
@@ -190,6 +190,41 @@ describe('ShellProcessManager', () => {
       expect(result.exit_code).toBe(0);
     });
 
+    it('should report elapsed duration while the process is still running', async () => {
+      vi.useFakeTimers();
+      try {
+        const process = createMockProcess();
+        manager.register('test-1', createShellProcess(process));
+
+        await vi.advanceTimersByTimeAsync(42_000);
+
+        const result = await manager.getOutput({ shell_id: 'test-1', timeout: 0 });
+        expect(result.exit_code).toBeUndefined();
+        expect(result.duration_ms).toBe(42_000);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should keep the final duration after the process exits', async () => {
+      vi.useFakeTimers();
+      try {
+        const process = createMockProcess();
+        manager.register('test-1', createShellProcess(process));
+
+        await vi.advanceTimersByTimeAsync(2500);
+        (process as { exitCode: number | null }).exitCode = 0;
+        process.emit('exit', 0);
+        await vi.advanceTimersByTimeAsync(7500);
+
+        const result = await manager.getOutput({ shell_id: 'test-1', timeout: 0 });
+        expect(result.exit_code).toBe(0);
+        expect(result.duration_ms).toBe(2500);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('should retain completed output after the process exits', async () => {
       const process = createMockProcess();
       manager.register('test-1', {

--- a/packages/local-file-shell/src/shell/process-manager.ts
+++ b/packages/local-file-shell/src/shell/process-manager.ts
@@ -7,10 +7,12 @@ const DEFAULT_OBSERVATION_TIMEOUT_MS = 30_000;
 const MAX_OBSERVATION_TIMEOUT_MS = 120_000;
 
 export interface ShellProcess {
+  endedAt?: number;
   exitCode: number | null;
   lastReadStderr: number;
   lastReadStdout: number;
   process: ChildProcess;
+  startedAt?: number;
   stderr: string[];
   stdout: string[];
 }
@@ -25,6 +27,17 @@ export class ShellProcessManager {
   }
 
   register(shellId: string, shellProcess: ShellProcess): void {
+    shellProcess.startedAt ??= Date.now();
+    if (shellProcess.exitCode !== null || shellProcess.process.exitCode !== null) {
+      shellProcess.endedAt ??= Date.now();
+    }
+
+    const markEnded = () => {
+      shellProcess.endedAt ??= Date.now();
+    };
+
+    shellProcess.process.once('exit', markEnded);
+    shellProcess.process.once('error', markEnded);
     this.processes.set(shellId, shellProcess);
   }
 
@@ -81,6 +94,9 @@ export class ShellProcessManager {
     }
 
     exitCode = childProcess.exitCode ?? shellProcess.exitCode;
+    if (exitCode !== null) {
+      shellProcess.endedAt ??= Date.now();
+    }
 
     const newStdout = stdout.slice(lastReadStdout).join('');
     const newStderr = stderr.slice(lastReadStderr).join('');
@@ -98,8 +114,11 @@ export class ShellProcessManager {
 
     shellProcess.lastReadStdout = stdout.length;
     shellProcess.lastReadStderr = stderr.length;
+    const startedAt = shellProcess.startedAt ?? Date.now();
+    const durationMs = Math.max(0, (shellProcess.endedAt ?? Date.now()) - startedAt);
 
     return {
+      duration_ms: durationMs,
       exit_code: exitCode ?? undefined,
       output: truncateOutput(output),
       stderr: truncateOutput(newStderr),

--- a/packages/local-file-shell/src/types.ts
+++ b/packages/local-file-shell/src/types.ts
@@ -14,12 +14,6 @@ export interface RunCommandParams {
 }
 
 export interface RunCommandResult {
-  /**
-   * Time in milliseconds from command start to this observation.
-   * For running commands, this is elapsed time at observation time.
-   * For completed commands, this is the final duration.
-   */
-  duration_ms?: number;
   error?: string;
   /**
    * Present only after the command has exited.

--- a/packages/local-file-shell/src/types.ts
+++ b/packages/local-file-shell/src/types.ts
@@ -14,6 +14,12 @@ export interface RunCommandParams {
 }
 
 export interface RunCommandResult {
+  /**
+   * Time in milliseconds from command start to this observation.
+   * For running commands, this is elapsed time at observation time.
+   * For completed commands, this is the final duration.
+   */
+  duration_ms?: number;
   error?: string;
   /**
    * Present only after the command has exited.
@@ -47,6 +53,12 @@ export interface GetCommandOutputParams {
 }
 
 export interface GetCommandOutputResult {
+  /**
+   * Time in milliseconds from command start to this observation.
+   * For running commands, this is elapsed time at observation time.
+   * For completed commands, this is the final duration.
+   */
+  duration_ms?: number;
   error?: string;
   /**
    * Present only after the command has exited.

--- a/packages/prompts/src/prompts/fileSystem/formatCommandOutput.test.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandOutput.test.ts
@@ -18,8 +18,21 @@ describe('formatCommandOutput', () => {
     expect(result).toMatchInlineSnapshot(`"Output retrieved."`);
   });
 
+  it('should format duration in seconds when present', () => {
+    const result = formatCommandOutput({
+      durationMs: 45_400,
+      success: true,
+    });
+    expect(result).toMatchInlineSnapshot(`
+      "Output retrieved.
+
+      Duration: 45s"
+    `);
+  });
+
   it('should format completed output with non-zero exit code', () => {
     const result = formatCommandOutput({
+      durationMs: 123_000,
       exitCode: 17,
       output: 'Process output here',
       success: true,
@@ -28,6 +41,8 @@ describe('formatCommandOutput', () => {
       "Output retrieved.
 
       Exit code: 17
+
+      Duration: 123s
 
       Output:
       Process output here"

--- a/packages/prompts/src/prompts/fileSystem/formatCommandOutput.test.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandOutput.test.ts
@@ -10,19 +10,15 @@ describe('formatCommandOutput', () => {
     expect(result).toMatchInlineSnapshot(`"Output retrieved."`);
   });
 
-  it('should include exit code when present', () => {
+  it('should suppress zero exit code when present', () => {
     const result = formatCommandOutput({
       exitCode: 0,
       success: true,
     });
-    expect(result).toMatchInlineSnapshot(`
-      "Output retrieved.
-
-      Exit code: 0"
-    `);
+    expect(result).toMatchInlineSnapshot(`"Output retrieved."`);
   });
 
-  it('should format successful output with content', () => {
+  it('should format completed output with non-zero exit code', () => {
     const result = formatCommandOutput({
       exitCode: 17,
       output: 'Process output here',

--- a/packages/prompts/src/prompts/fileSystem/formatCommandOutput.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandOutput.ts
@@ -14,7 +14,7 @@ export const formatCommandOutput = ({
   const message = success ? 'Output retrieved.' : `Failed: ${error}`;
 
   const parts: string[] = [message];
-  if (exitCode !== undefined) parts.push(`Exit code: ${exitCode}`);
+  if (exitCode !== undefined && exitCode !== 0) parts.push(`Exit code: ${exitCode}`);
   if (output) parts.push(`Output:\n${output}`);
   if (error && success) parts.push(`Error: ${error}`);
 

--- a/packages/prompts/src/prompts/fileSystem/formatCommandOutput.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandOutput.ts
@@ -1,11 +1,18 @@
 export interface FormatCommandOutputParams {
+  durationMs?: number;
   error?: string;
   exitCode?: number;
   output?: string;
   success: boolean;
 }
 
+const formatDuration = (durationMs: number): string => {
+  const seconds = Math.max(0, Math.round(durationMs / 1000));
+  return `${seconds}s`;
+};
+
 export const formatCommandOutput = ({
+  durationMs,
   success,
   exitCode,
   output,
@@ -15,6 +22,9 @@ export const formatCommandOutput = ({
 
   const parts: string[] = [message];
   if (exitCode !== undefined && exitCode !== 0) parts.push(`Exit code: ${exitCode}`);
+  if (durationMs !== undefined && Number.isFinite(durationMs)) {
+    parts.push(`Duration: ${formatDuration(durationMs)}`);
+  }
   if (output) parts.push(`Output:\n${output}`);
   if (error && success) parts.push(`Error: ${error}`);
 

--- a/packages/prompts/src/prompts/fileSystem/formatCommandResult.test.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandResult.test.ts
@@ -8,14 +8,15 @@ describe('formatCommandResult', () => {
     expect(result).toMatchInlineSnapshot(`"Command completed successfully."`);
   });
 
-  it('should format successful background command', () => {
+  it('should format still-running command', () => {
     const result = formatCommandResult({
       shellId: 'shell-123',
       success: true,
     });
-    expect(result).toMatchInlineSnapshot(
-      `"Command started in background with shell_id: shell-123"`,
-    );
+    expect(result).toMatchInlineSnapshot(`
+      "Command is still running after the wait window.
+      shell_id: shell-123"
+    `);
   });
 
   it('should format successful command with stdout', () => {
@@ -47,6 +48,15 @@ describe('formatCommandResult', () => {
   it('should suppress the Exit code line when exitCode is 0', () => {
     const result = formatCommandResult({
       exitCode: 0,
+      success: true,
+    });
+    expect(result).toMatchInlineSnapshot(`"Command completed successfully."`);
+  });
+
+  it('should treat shell id with exitCode 0 as completed', () => {
+    const result = formatCommandResult({
+      exitCode: 0,
+      shellId: 'shell-123',
       success: true,
     });
     expect(result).toMatchInlineSnapshot(`"Command completed successfully."`);

--- a/packages/prompts/src/prompts/fileSystem/formatCommandResult.test.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandResult.test.ts
@@ -4,7 +4,7 @@ import { formatCommandResult } from './formatCommandResult';
 
 describe('formatCommandResult', () => {
   it('should format successful command without output', () => {
-    const result = formatCommandResult({ success: true });
+    const result = formatCommandResult({ exitCode: 0, success: true });
     expect(result).toMatchInlineSnapshot(`"Command completed successfully."`);
   });
 
@@ -21,6 +21,7 @@ describe('formatCommandResult', () => {
 
   it('should format successful command with stdout', () => {
     const result = formatCommandResult({
+      exitCode: 0,
       stdout: 'Hello World',
       success: true,
     });
@@ -34,6 +35,7 @@ describe('formatCommandResult', () => {
 
   it('should format successful command with stderr', () => {
     const result = formatCommandResult({
+      exitCode: 0,
       stderr: 'Warning: deprecated',
       success: true,
     });

--- a/packages/prompts/src/prompts/fileSystem/formatCommandResult.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandResult.ts
@@ -28,10 +28,8 @@ export const formatCommandResult = ({
     if (hasNonZeroExit) header += ` with exit code ${exitCode}`;
     if (error) header += `: ${error}`;
     parts.push(header);
-  } else if (shellId && exitCode === undefined) {
-    parts.push(
-      ['Command is still running after the wait window.', `shell_id: ${shellId}`].join('\n'),
-    );
+  } else if (exitCode === undefined) {
+    parts.push(`Command is still running after the wait window.\nshell_id: ${shellId}`);
   } else {
     parts.push('Command completed successfully.');
   }

--- a/packages/prompts/src/prompts/fileSystem/formatCommandResult.ts
+++ b/packages/prompts/src/prompts/fileSystem/formatCommandResult.ts
@@ -28,8 +28,10 @@ export const formatCommandResult = ({
     if (hasNonZeroExit) header += ` with exit code ${exitCode}`;
     if (error) header += `: ${error}`;
     parts.push(header);
-  } else if (shellId) {
-    parts.push(`Command started in background with shell_id: ${shellId}`);
+  } else if (shellId && exitCode === undefined) {
+    parts.push(
+      ['Command is still running after the wait window.', `shell_id: ${shellId}`].join('\n'),
+    );
   } else {
     parts.push('Command completed successfully.');
   }

--- a/packages/tool-runtime/src/ComputerRuntime.ts
+++ b/packages/tool-runtime/src/ComputerRuntime.ts
@@ -350,6 +350,7 @@ export abstract class ComputerRuntime {
       const outputSuccess = typeof r.success === 'boolean' ? r.success : result.success;
 
       const state: GetCommandOutputState = {
+        durationMs: r.durationMs ?? r.duration_ms,
         error: r.error,
         exitCode: r.exitCode ?? r.exit_code,
         newOutput: r.newOutput || r.output,
@@ -358,6 +359,7 @@ export abstract class ComputerRuntime {
       };
 
       const content = formatCommandOutput({
+        durationMs: r.durationMs ?? r.duration_ms,
         error: r.error,
         exitCode: r.exitCode ?? r.exit_code,
         output: r.newOutput || r.output,

--- a/packages/tool-runtime/src/LocalSystemExecutionRuntime.ts
+++ b/packages/tool-runtime/src/LocalSystemExecutionRuntime.ts
@@ -186,6 +186,7 @@ export class LocalSystemExecutionRuntime extends ComputerRuntime {
       case 'getCommandOutput': {
         return {
           result: {
+            durationMs: raw.duration_ms,
             exitCode: raw.exit_code,
             error: raw.error,
             newOutput: raw.output,

--- a/packages/tool-runtime/src/types.ts
+++ b/packages/tool-runtime/src/types.ts
@@ -193,6 +193,7 @@ export interface RunCommandState {
 }
 
 export interface GetCommandOutputState {
+  durationMs?: number;
   error?: string;
   exitCode?: number;
   newOutput?: string;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

- local-system-tool
  - 在工具调用上暂时移除使用率较低的 listing 的 prompt
    - `packages/builtin-tool-skills/src/ExecutionRuntime/index.ts` 将 skill 的默认提示改为用 `globFiles` 
    - `packages/builtin-tool-local-system/src/manifest.ts` 在 minifest 中取消 listFiles 的 api 接口，以及在 prompt 中移除提示。 当前为了兼容前端，并未移除对应前端组件。
  - 更正 `shell_id` 和 `exit_code` 语义
    - `shell_id` 返回代表命令还在执行
    - `exit_code` 只在非 0 的时候提醒

- runCommand
  - 在 30s 内返回
```
Command completed successfully.

Output:
total 22272
-rw-r--r--  1 cy948 cy948     7368 May 17 15:10 .zshrc
```

  - 在 30s 内未返回
```
Command is still running after the wait window.
shell_id: sh-4

Output:
2026-06-13T15:32:42 random=5
2026-06-13T15:32:47 random=1
2026-06-13T15:32:52 random=5
2026-06-13T15:32:57 random=2
2026-06-13T15:33:02 random=3
```

- getCommandOutput
```
Output retrieved.

Duration: 89s

Output:
2026-06-13T15:33:52 random=5
2026-06-13T15:33:57 random=1
2026-06-13T15:34:02 random=3
2026-06-13T15:34:06 random=5
final_value=5
```

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
