### PR TITLE
🐛 fix(chat): stop ContentLoading from leaking raw operation i18n keys

### DIFF
--- a/src/features/Conversation/ChatInput/OpStatusTray.tsx
+++ b/src/features/Conversation/ChatInput/OpStatusTray.tsx
@@ -9,10 +9,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useChatStore } from '@/store/chat';
 import { operationSelectors } from '@/store/chat/selectors';
-import {
-  AI_RUNTIME_OPERATION_TYPES,
-  type OperationType,
-} from '@/store/chat/slices/operation/types';
+import { AI_RUNTIME_OPERATION_TYPES } from '@/store/chat/slices/operation/types';
 import { shinyTextStyles } from '@/styles';
 import {
   calculateOperationUsageMetrics,
@@ -22,13 +19,15 @@ import {
 } from '@/utils/operationUsageMetrics';
 
 import { contextSelectors, dataSelectors, useConversationStore } from '../store';
+import { type ActivityKey, resolveOperationActivity } from '../utils/operationActivity';
 import { parseStatusPhrases, pickStableStatusPhrase } from './OpStatusTray/logic';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   container: css`
+    container-type: inline-size;
+
     padding-block: 8px;
     padding-inline: 14px;
-    container-type: inline-size;
     border: 1px solid ${cssVar.colorFillSecondary};
     border-block-end: none;
     border-start-start-radius: 12px;
@@ -52,6 +51,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     display: inline-flex;
     gap: 4px;
     align-items: center;
+
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
   `,
@@ -81,8 +81,8 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     font-size: 12px;
   `,
   metricPopoverValue: css`
-    color: ${cssVar.colorTextSecondary};
     font-variant-numeric: tabular-nums;
+    color: ${cssVar.colorTextSecondary};
   `,
   metricValue: css`
     overflow: hidden;
@@ -90,10 +90,9 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     text-overflow: ellipsis;
   `,
   compactMetric: css`
+    cursor: default;
     display: none;
     flex: none;
-
-    cursor: default;
 
     @container (max-width: 360px) {
       display: inline-flex;
@@ -106,7 +105,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   statusText: css`
     overflow: hidden;
-
     font-weight: 500;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -203,34 +201,6 @@ const normalizeStepCount = (stepCount: unknown) => {
   return Math.max(0, Math.floor(stepCount));
 };
 
-type ActivityKey = 'compressing' | 'generating' | 'reasoning' | 'searching' | 'toolCalling';
-
-/**
- * Map a running sub-operation type to the streaming phase shown on the left.
- * Container ops (AI_RUNTIME) and bookkeeping ops return undefined.
- */
-const resolveActivity = (type: OperationType): ActivityKey | undefined => {
-  if (type === 'reasoning') return 'reasoning';
-  if (
-    type === 'toolCalling' ||
-    type === 'executeToolCall' ||
-    type === 'createToolMessage' ||
-    type === 'pluginApi' ||
-    type.startsWith('builtinTool')
-  )
-    return 'toolCalling';
-  if (type === 'rag' || type === 'searchWorkflow') return 'searching';
-  if (type === 'contextCompression' || type === 'generateSummary') return 'compressing';
-  if (
-    type === 'callLLM' ||
-    type === 'groupAgentStream' ||
-    type === 'createAssistantMessage' ||
-    type === 'supervisorDecision'
-  )
-    return 'generating';
-  return undefined;
-};
-
 interface OpStatusTrayProps {
   /**
    * Square the top corners when another panel sits flush above this one.
@@ -264,7 +234,7 @@ const OpStatusTray = memo<OpStatusTrayProps>(({ topAttached }) => {
     for (const op of ops) {
       if (op.status !== 'running' || op.metadata.isAborting) continue;
 
-      const mapped = resolveActivity(op.type);
+      const mapped = resolveOperationActivity(op.type);
       if (mapped && op.metadata.startTime > latestActivityStart) {
         latestActivityStart = op.metadata.startTime;
         activity = mapped;

--- a/src/features/Conversation/Messages/components/ContentLoading.tsx
+++ b/src/features/Conversation/Messages/components/ContentLoading.tsx
@@ -10,9 +10,21 @@ import { operationSelectors } from '@/store/chat/selectors';
 import { type OperationType } from '@/store/chat/slices/operation/types';
 import { elapsedTimeStyles, shinyTextStyles } from '@/styles/loading';
 
+import { resolveOperationActivity } from '../../utils/operationActivity';
+
 const ELAPSED_TIME_THRESHOLD = 2100; // Show elapsed time after 2 seconds
 
 const NO_NEED_SHOW_DOT_OP_TYPES = new Set<OperationType>(['reasoning']);
+
+// Container/runtime ops carry their own user-facing `operation.*` copy.
+// Everything else is an internal/bookkeeping op without a dedicated key, so it
+// routes through the shared activity mapping instead of leaking the raw key.
+const DEDICATED_OPERATION_LABELS = new Set<OperationType>([
+  'execAgentRuntime',
+  'execClientSubAgent',
+  'execServerAgentRuntime',
+  'sendMessage',
+]);
 
 interface ContentLoadingProps {
   id: string;
@@ -49,14 +61,27 @@ const ContentLoading = memo<ContentLoadingProps>(({ id }) => {
   // so the user can tell which external agent is working.
   const getOperationLabel = () => {
     if (!operationType) return undefined;
-    if (operationType !== 'execHeterogeneousAgent') {
+
+    if (operationType === 'execHeterogeneousAgent') {
+      const heterogeneousType = runningOp?.metadata?.heterogeneousType as string | undefined;
+      const name = heterogeneousType
+        ? (HETEROGENEOUS_TYPE_LABELS[heterogeneousType] ?? heterogeneousType)
+        : t('operation.heterogeneousAgentFallback');
+      return t('operation.execHeterogeneousAgent', { name });
+    }
+
+    if (DEDICATED_OPERATION_LABELS.has(operationType)) {
       return t(`operation.${operationType}` as any) as string;
     }
-    const heterogeneousType = runningOp?.metadata?.heterogeneousType as string | undefined;
-    const name = heterogeneousType
-      ? (HETEROGENEOUS_TYPE_LABELS[heterogeneousType] ?? heterogeneousType)
-      : t('operation.heterogeneousAgentFallback');
-    return t('operation.execHeterogeneousAgent', { name });
+
+    // Internal/bookkeeping ops (toolCalling, callLLM, executeToolCall, ...) have
+    // no `operation.*` copy. Reuse the localized op-status-tray phase label so we
+    // never fall back to the raw i18n key. Unmappable container ops return
+    // undefined and render the generic dot loader below.
+    const activity = resolveOperationActivity(operationType);
+    if (activity) return t(`opStatusTray.status.${activity}`);
+
+    return undefined;
   };
   const operationLabel = getOperationLabel();
 

--- a/src/features/Conversation/utils/operationActivity.test.ts
+++ b/src/features/Conversation/utils/operationActivity.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { type OperationType } from '@/store/chat/slices/operation/types';
+
+import { resolveOperationActivity } from './operationActivity';
+
+describe('resolveOperationActivity', () => {
+  it('maps tool-related ops (including bookkeeping ones) to toolCalling', () => {
+    const toolOps: OperationType[] = [
+      'toolCalling',
+      'executeToolCall',
+      'createToolMessage',
+      'pluginApi',
+      'builtinToolSearch',
+      'builtinToolInterpreter',
+      'builtinToolPageAgent',
+    ];
+    for (const type of toolOps) {
+      expect(resolveOperationActivity(type)).toBe('toolCalling');
+    }
+  });
+
+  it('maps retrieval ops to searching', () => {
+    expect(resolveOperationActivity('rag')).toBe('searching');
+    expect(resolveOperationActivity('searchWorkflow')).toBe('searching');
+  });
+
+  it('maps compression ops to compressing', () => {
+    expect(resolveOperationActivity('contextCompression')).toBe('compressing');
+    expect(resolveOperationActivity('generateSummary')).toBe('compressing');
+  });
+
+  it('maps generation ops to generating', () => {
+    const genOps: OperationType[] = [
+      'callLLM',
+      'groupAgentStream',
+      'createAssistantMessage',
+      'supervisorDecision',
+    ];
+    for (const type of genOps) {
+      expect(resolveOperationActivity(type)).toBe('generating');
+    }
+  });
+
+  it('maps reasoning to reasoning', () => {
+    expect(resolveOperationActivity('reasoning')).toBe('reasoning');
+  });
+
+  it('returns undefined for container/runtime and other unmapped ops', () => {
+    const unmapped: OperationType[] = [
+      'execAgentRuntime',
+      'execHeterogeneousAgent',
+      'execServerAgentRuntime',
+      'sendMessage',
+      'translate',
+    ];
+    for (const type of unmapped) {
+      expect(resolveOperationActivity(type)).toBeUndefined();
+    }
+  });
+});

--- a/src/features/Conversation/utils/operationActivity.ts
+++ b/src/features/Conversation/utils/operationActivity.ts
@@ -1,0 +1,40 @@
+import { type OperationType } from '@/store/chat/slices/operation/types';
+
+/**
+ * User-facing streaming phase. Each key has a matching `opStatusTray.status.*`
+ * locale entry, so a phase can always be rendered without leaking a raw key.
+ */
+export type ActivityKey = 'compressing' | 'generating' | 'reasoning' | 'searching' | 'toolCalling';
+
+/**
+ * Map a running (sub-)operation type to the user-facing streaming phase.
+ *
+ * Many `OperationType`s are internal/bookkeeping ops (`createToolMessage`,
+ * `executeToolCall`, `pluginApi`, `builtinTool*`, `callLLM`, ...) that have no
+ * dedicated user copy. Both `OpStatusTray` and `ContentLoading` route them
+ * through this helper so they reuse the localized phase labels instead of
+ * exposing the raw `operation.*` i18n key.
+ *
+ * Container ops (AI_RUNTIME) and other bookkeeping ops return undefined.
+ */
+export const resolveOperationActivity = (type: OperationType): ActivityKey | undefined => {
+  if (type === 'reasoning') return 'reasoning';
+  if (
+    type === 'toolCalling' ||
+    type === 'executeToolCall' ||
+    type === 'createToolMessage' ||
+    type === 'pluginApi' ||
+    type.startsWith('builtinTool')
+  )
+    return 'toolCalling';
+  if (type === 'rag' || type === 'searchWorkflow') return 'searching';
+  if (type === 'contextCompression' || type === 'generateSummary') return 'compressing';
+  if (
+    type === 'callLLM' ||
+    type === 'groupAgentStream' ||
+    type === 'createAssistantMessage' ||
+    type === 'supervisorDecision'
+  )
+    return 'generating';
+  return undefined;
+};


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-10325

#### 🔀 Description of Change

`ContentLoading` rendered the message-level loading copy by calling `t('operation.<operationType>')` directly. Many `OperationType`s are internal/bookkeeping ops (`createToolMessage`, `executeToolCall`, `pluginApi`, `builtinTool*`, `callLLM`, `searchWorkflow`, ...) that have **no** `operation.*` locale key, so `react-i18next` fell back to the raw key and leaked it into the UI (e.g. `operation.toolCalling...`).

`OpStatusTray` already normalized these internal ops into user-facing phases (`toolCalling` / `searching` / `generating` / `compressing` / `reasoning`), but `ContentLoading` didn't reuse that mapping.

This PR:

- Extracts `OpStatusTray`'s operation→activity mapping into a shared `resolveOperationActivity` helper (`src/features/Conversation/utils/operationActivity.ts`) and reuses it in both components.
- In `ContentLoading`: container/runtime ops keep their dedicated `operation.*` copy, internal/bookkeeping ops now render the localized `opStatusTray.status.*` phase label, and any unmappable op falls back to the generic dot loader instead of a raw key.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added `operationActivity.test.ts` covering the operation→activity mapping (tool/search/compression/generation/reasoning + undefined for container ops). Trigger a tool call (e.g. web search) and confirm the message-level loading shows "Calling tools..." instead of `operation.toolCalling...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)