### PR TITLE
🐛 fix(fetch-sse): support streaming toggle and disable animation when stream is false

### DIFF
--- a/packages/fetch-sse/src/__tests__/fetchSSE.test.ts
+++ b/packages/fetch-sse/src/__tests__/fetchSSE.test.ts
@@ -185,6 +185,38 @@ describe('fetchSSE', () => {
     });
   });
 
+  it('should skip animation and buffering when stream is false in request body', async () => {
+    const mockOnMessageHandle = vi.fn();
+    const mockOnFinish = vi.fn();
+
+    (fetchEventSource as any).mockImplementationOnce(
+      async (url: string, options: FetchEventSourceInit) => {
+        options.onopen!({ clone: () => ({ ok: true, headers: new Headers() }) } as any);
+        options.onmessage!({ event: 'text', data: JSON.stringify('He') } as any);
+        options.onmessage!({ event: 'text', data: JSON.stringify('llo') } as any);
+        options.onmessage!({ event: 'text', data: JSON.stringify(' World') } as any);
+      },
+    );
+
+    await fetchSSE('/', {
+      body: JSON.stringify({ stream: false }),
+      onMessageHandle: mockOnMessageHandle,
+      onFinish: mockOnFinish,
+      responseAnimation: 'smooth',
+    });
+
+    expect(mockOnMessageHandle).toHaveBeenNthCalledWith(1, { text: 'He', type: 'text' });
+    expect(mockOnMessageHandle).toHaveBeenNthCalledWith(2, { text: 'llo', type: 'text' });
+    expect(mockOnMessageHandle).toHaveBeenNthCalledWith(3, { text: ' World', type: 'text' });
+
+    expect(mockOnFinish).toHaveBeenCalledWith('Hello World', {
+      observationId: null,
+      toolCalls: undefined,
+      traceId: null,
+      type: 'done',
+    });
+  });
+
   describe('reasoning', () => {
     it('should handle reasoning event without smoothing', async () => {
       const mockOnMessageHandle = vi.fn();

--- a/packages/fetch-sse/src/fetchSSE.ts
+++ b/packages/fetch-sse/src/fetchSSE.ts
@@ -254,11 +254,21 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
   let response!: Response;
   const fetchStartTime = Date.now();
 
+  let isStreaming = true;
+  if (options.body && typeof options.body === 'string') {
+    try {
+      const parsedBody = JSON.parse(options.body);
+      if (parsedBody && parsedBody.stream === false) {
+        isStreaming = false;
+      }
+    } catch {}
+  }
+
   const { text, speed: smoothingSpeed } = standardizeAnimationStyle(
     options.responseAnimation ?? {},
   );
-  const shouldSkipTextProcessing = text === 'none';
-  const textSmoothing = text === 'smooth';
+  const shouldSkipTextProcessing = text === 'none' || !isStreaming;
+  const textSmoothing = text === 'smooth' && isStreaming;
 
   // Add text buffer and timer related variables
   let textBuffer = '';
@@ -451,7 +461,10 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
         }
 
         case 'reasoning': {
-          if (textSmoothing) {
+          if (shouldSkipTextProcessing) {
+            thinking += data;
+            options.onMessageHandle?.({ text: data, type: 'reasoning' });
+          } else if (textSmoothing) {
             thinkingController.pushToQueue(data);
 
             if (!thinkingController.isAnimationActive) thinkingController.startAnimation();


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- No specific issue linked -->

#### 🔀 Description of Change

When `stream: false` is set in the request body, the SSE fetch handler now:

1. **Detects the non-streaming flag** by parsing the JSON request body and checking for `stream === false`.
2. **Skips text smoothing/animation** — text and reasoning chunks are delivered immediately to `onMessageHandle` without buffering or animation delays.
3. **Skips reasoning buffering** — reasoning events are also delivered immediately instead of being queued through the animation controller.

This ensures that non-streaming responses are displayed instantly without the artificial typing animation, which is the expected UX when streaming is explicitly disabled.

**Files changed:**
- `packages/fetch-sse/src/fetchSSE.ts` — Added stream detection and conditional animation bypass
- `packages/fetch-sse/src/__tests__/fetchSSE.test.ts` — Added test case verifying animation is skipped when `stream: false`

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Run the fetch-sse tests:
`ash
pnpm --filter @lobechat/fetch-sse test
`

#### 📝 Additional Information

No breaking changes. The behavior is fully backwards-compatible — existing streaming requests are unaffected.