### PR TITLE
🐛 fix(web-crawler): use document.write for proper HTML document parsing

### DIFF
--- a/packages/web-crawler/src/utils/__snapshots__/htmlToMarkdown.test.ts.snap
+++ b/packages/web-crawler/src/utils/__snapshots__/htmlToMarkdown.test.ts.snap
@@ -111,6 +111,8 @@ Examples of prohibited activities include but are not limited to:
 
  By accessing or using the LobeHub Services, You acknowledge that You have read, understood, and agreed to be bound by this agreement. If You have any questions regarding this agreement, please contact us at[support@lobehub.com](mailto:support@lobehub.com).",
   "description": "Lasted Updated at",
+  "dir": "ltr",
+  "lang": "zh",
   "length": 18284,
   "title": "Terms of Service · LobeHub",
 }
@@ -252,6 +254,7 @@ copyright © 2016 - 2025 qiumiwu.com All Rights Reserved
 
 扫描二维码，下载球迷屋App，获得更好的使用体验",
   "description": "球迷屋为您提供2024-2025赛季英超积分排行榜，包含所有英超球队的全部赛季的排行榜数据，包含了英超球队的排名、场次、胜平负、进球、失球、积分等等详细积分数据，让大家迅速了解英超积分排行榜的数据。",
+  "lang": "zh-CN",
   "length": 201,
   "title": "英超排行榜|英超积分榜2024-2025赛季 - 球迷屋",
 }

--- a/packages/web-crawler/src/utils/htmlToMarkdown.ts
+++ b/packages/web-crawler/src/utils/htmlToMarkdown.ts
@@ -38,7 +38,7 @@ export const htmlToMarkdown = (
 
   try {
     const document = window.document;
-    document.body.innerHTML = html;
+    document.write(html);
 
     let parsedContent: ReturnType<Readability<string>['parse']> = null;
     try {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #15180

#### 🔀 Description of Change

Large HTML pages parsed via happy-dom and `@mozilla/readability` were failing because they were nested inside `document.body.innerHTML`, producing malformed DOM trees where `<html>` and `<head>` tags were parsed as body content. This prevented Readability from extracting metadata (`lang`, `dir`, `title`, `description`, etc.) and article content.

**Fix:** Replace `document.body.innerHTML = html` with `document.write(html)` on the happy-dom document. This properly parses complete HTML document hierarchies, retaining meta tags, `html` attributes like `lang` and `dir`, and other document-level information.

**Files changed:**
- `packages/web-crawler/src/utils/htmlToMarkdown.ts` — One-line change from `document.body.innerHTML = html` to `document.write(html)`
- `packages/web-crawler/src/utils/__snapshots__/htmlToMarkdown.test.ts.snap` — Updated snapshots reflecting the improved metadata extraction (`lang` and `dir` now correctly extracted)

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Run the web-crawler tests:
`ash
pnpm --filter @lobechat/web-crawler test
`

All 159 tests pass. Type-check (`pnpm run type-check`) passes with 0 errors.

#### 📝 Additional Information

No breaking changes. The output is strictly improved — previously missing metadata fields (`lang`, `dir`) are now correctly extracted from the HTML document. Existing content extraction is unaffected.