### PR TITLE
🐛 fix(portal): close empty local file preview

### DIFF
--- a/src/features/Portal/LocalFile/Body.test.tsx
+++ b/src/features/Portal/LocalFile/Body.test.tsx
@@ -1,0 +1,198 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createLocalFileScopeKey, createLocalFileTabId } from '@/store/chat/slices/portal/helpers';
+import { topicMapKey } from '@/store/chat/utils/topicMapKey';
+
+import Body from './Body';
+
+vi.mock('antd-style', () => ({
+  createStaticStyles: () => ({
+    card: 'card',
+    key: 'key',
+    row: 'row',
+    value: 'value',
+  }),
+  cssVar: {
+    colorBgContainer: 'var(--color-bg-container)',
+    colorBorderSecondary: 'var(--color-border-secondary)',
+    colorTextSecondary: 'var(--color-text-secondary)',
+    fontFamilyCode: 'monospace',
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  ActionIcon: () => null,
+  Center: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Empty: ({ description }: { description?: ReactNode }) => <div>{description}</div>,
+  Flexbox: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Icon: () => null,
+  Markdown: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Segmented: () => null,
+  Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock('@/components/CodeEditorPane', () => ({
+  default: () => <textarea data-testid="code-editor" />,
+}));
+
+vi.mock('@/components/HtmlPreview', () => ({
+  InlineHtmlPreview: () => <iframe title="html-preview" />,
+  isHtmlFile: () => false,
+}));
+
+vi.mock('@/components/Loading/CircleLoading', () => ({
+  default: () => <div data-testid="loading" />,
+}));
+
+const mockUseClientDataSWR = vi.hoisted(() => vi.fn());
+
+vi.mock('@/libs/swr', () => ({
+  useClientDataSWR: mockUseClientDataSWR,
+}));
+
+vi.mock('@/services/projectFile', () => ({
+  projectFileService: {
+    getLocalFilePreview: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils/skillMarkdown', () => ({
+  parseSkillMarkdownFrontmatter: (content: string) => ({ body: content }),
+  parseSkillMarkdownFrontmatterFields: () => ({}),
+  parseSkillMarkdownMetadata: () => [],
+}));
+
+vi.mock('./MarkdownImage', () => ({
+  default: () => null,
+}));
+
+const mockClearPortalStack = vi.hoisted(() => vi.fn());
+const mockChatState = vi.hoisted(() => ({
+  current: {} as Record<PropertyKey, unknown>,
+}));
+
+vi.mock('@/store/chat', () => ({
+  useChatStore: (selector: (state: Record<PropertyKey, unknown>) => unknown) =>
+    selector(mockChatState.current),
+}));
+
+vi.mock('@/store/chat/selectors', () => {
+  const getCurrentWorkingDirectory = (state: Record<PropertyKey, unknown>) => {
+    const activeAgentId = state.activeAgentId as string | undefined;
+    const activeTopicId = state.activeTopicId as string | undefined;
+    const topicDataMap = state.topicDataMap as
+      | Record<string, { items?: Array<{ id: string; metadata?: { workingDirectory?: string } }> }>
+      | undefined;
+
+    return topicDataMap?.[`agent_${activeAgentId}`]?.items?.find(
+      (topic) => topic.id === activeTopicId,
+    )?.metadata?.workingDirectory;
+  };
+
+  const openLocalFiles = (state: Record<PropertyKey, unknown>) => {
+    const files =
+      (state.openLocalFiles as
+        | Array<{ filePath: string; id?: string; workingDirectory: string }>
+        | undefined) ?? [];
+    const workingDirectory = getCurrentWorkingDirectory(state);
+
+    return workingDirectory
+      ? files.filter((file) => file.workingDirectory === workingDirectory)
+      : files;
+  };
+
+  return {
+    chatPortalSelectors: {
+      currentLocalFile: (state: Record<PropertyKey, unknown>) => {
+        const files = openLocalFiles(state);
+        const activeLocalFileId = state.activeLocalFileId as string | undefined;
+        const activeLocalFilePath = state.activeLocalFilePath as string | undefined;
+
+        return (
+          files.find((file) => file.id === activeLocalFileId) ??
+          files.find((file) => file.filePath === activeLocalFilePath) ??
+          files[0]
+        );
+      },
+      openLocalFiles,
+    },
+  };
+});
+
+const projectAFileId = createLocalFileTabId({
+  filePath: '/project-a/a.ts',
+  workingDirectory: '/project-a',
+});
+
+const createChatState = (activeTopicId: 'topic-a' | 'topic-b') => ({
+  activeAgentId: 'agent-1',
+  activeLocalFileId: projectAFileId,
+  activeLocalFileIdsByScope: {
+    [createLocalFileScopeKey('/project-a')]: projectAFileId,
+  },
+  activeLocalFilePath: '/project-a/a.ts',
+  activeTopicId,
+  clearPortalStack: mockClearPortalStack,
+  openLocalFiles: [
+    {
+      filePath: '/project-a/a.ts',
+      id: projectAFileId,
+      workingDirectory: '/project-a',
+    },
+  ],
+  topicDataMap: {
+    [topicMapKey({ agentId: 'agent-1' })]: {
+      currentPage: 1,
+      hasMore: false,
+      items: [
+        {
+          id: 'topic-a',
+          metadata: { workingDirectory: '/project-a' },
+        },
+        {
+          id: 'topic-b',
+          metadata: { workingDirectory: '/project-b' },
+        },
+      ],
+      pageSize: 20,
+      total: 2,
+    },
+  },
+});
+
+describe('LocalFile Body', () => {
+  beforeEach(() => {
+    mockClearPortalStack.mockClear();
+    mockUseClientDataSWR.mockReturnValue({
+      isLoading: true,
+      mutate: vi.fn(),
+    });
+  });
+
+  it('closes the LocalFile portal when the current project has no visible local-file tabs', async () => {
+    mockChatState.current = createChatState('topic-b');
+
+    render(<Body />);
+
+    await waitFor(() => {
+      expect(mockClearPortalStack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('keeps the LocalFile portal open when the current project has an active local-file tab', () => {
+    mockChatState.current = createChatState('topic-a');
+
+    render(<Body />);
+
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
+    expect(mockClearPortalStack).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/Portal/LocalFile/Body.tsx
+++ b/src/features/Portal/LocalFile/Body.tsx
@@ -399,6 +399,13 @@ const Body = memo(() => {
   const openLocalFiles = useChatStore(chatPortalSelectors.openLocalFiles);
   const activeFile = useChatStore(chatPortalSelectors.currentLocalFile);
   const activeTopicId = useChatStore((s) => s.activeTopicId);
+  const clearPortalStack = useChatStore((s) => s.clearPortalStack);
+
+  useEffect(() => {
+    if (openLocalFiles.length > 0 && activeFile) return;
+
+    clearPortalStack();
+  }, [activeFile, clearPortalStack, openLocalFiles.length]);
 
   if (openLocalFiles.length === 0) return null;
   if (!activeFile) return null;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Close the LocalFile portal automatically when the current project scope has no visible local-file tab or active file. This prevents the right preview panel from staying open as an empty view after switching to another project.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run --silent='passed-only' src/features/Portal/LocalFile/Body.test.tsx src/store/chat/slices/portal/action.test.ts src/store/chat/slices/portal/selectors.test.ts\n```\n\n#### 📸 Screenshots / Videos\n\nN/A\n\n#### 📝 Additional Information\n\nThis uses the same `clearPortalStack` path as the LocalFile header close button.