### PR TITLE
🐛 fix(model-runtime): classify untyped Error throws via message patterns

### DIFF
--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
@@ -132,6 +132,14 @@ describe('formatErrorForState', () => {
       expect(result.countAsFailure).toBeUndefined();
       expect(result.numericId).toBeUndefined();
     });
+
+    it('classifies a raw Drizzle "Failed query" Error via its message instead of a bare 500', () => {
+      const result = formatErrorForState(new Error('Failed query: rollback\nparams: '));
+
+      expect(result.type).toBe(AgentRuntimeErrorType.DatabasePersistError);
+      expect(result.numericId).toBe(7004);
+      expect(result.attribution).toBe('harness');
+    });
   });
 
   describe('ProviderBizError refinement', () => {

--- a/packages/locales/src/default/modelRuntime.ts
+++ b/packages/locales/src/default/modelRuntime.ts
@@ -69,6 +69,8 @@ export default {
     "Sorry, the token usage or request count has reached the rate limit for this key. Please try again later or increase the key's quota.",
   StateStorePersistError:
     'A temporary issue with the conversation state store interrupted this operation. Please try again; if it persists, contact support.',
+  StateStoreReadError:
+    'This operation was ended because the connection closed before it finished. This is usually harmless — reopen the conversation to continue.',
   StreamChunkError:
     'Error parsing the message chunk of the streaming request. Please check if the current API interface complies with the standard specifications, or contact your API provider for assistance.',
   UpstreamGatewayError:

--- a/packages/model-runtime/src/errors/match.test.ts
+++ b/packages/model-runtime/src/errors/match.test.ts
@@ -94,14 +94,17 @@ describe('matchErrorPattern', () => {
     ).toBe(AgentRuntimeErrorType.StateStorePersistError);
   });
 
-  it('classifies Upstash readonly-upgrade and dropped-caller drops as StateStorePersistError', () => {
+  it('classifies the Upstash readonly-upgrade write rejection as StateStorePersistError', () => {
     expect(
       matchErrorPattern({
         message: 'READONLY Writes are temporarily rejected due to server upgrade',
       })?.code,
     ).toBe(AgentRuntimeErrorType.StateStorePersistError);
+  });
+
+  it('classifies a caller-gone blocking-read abort as StateStoreReadError (benign, not a persist failure)', () => {
     expect(matchErrorPattern({ message: 'ERR caller gone' })?.code).toBe(
-      AgentRuntimeErrorType.StateStorePersistError,
+      AgentRuntimeErrorType.StateStoreReadError,
     );
   });
 

--- a/packages/model-runtime/src/errors/match.test.ts
+++ b/packages/model-runtime/src/errors/match.test.ts
@@ -94,6 +94,17 @@ describe('matchErrorPattern', () => {
     ).toBe(AgentRuntimeErrorType.StateStorePersistError);
   });
 
+  it('classifies Upstash readonly-upgrade and dropped-caller drops as StateStorePersistError', () => {
+    expect(
+      matchErrorPattern({
+        message: 'READONLY Writes are temporarily rejected due to server upgrade',
+      })?.code,
+    ).toBe(AgentRuntimeErrorType.StateStorePersistError);
+    expect(matchErrorPattern({ message: 'ERR caller gone' })?.code).toBe(
+      AgentRuntimeErrorType.StateStorePersistError,
+    );
+  });
+
   it('classifies harness JS runtime crashes as AgentRuntimeError', () => {
     for (const message of [
       'e.trim is not a function',

--- a/packages/model-runtime/src/errors/patterns.ts
+++ b/packages/model-runtime/src/errors/patterns.ts
@@ -515,10 +515,20 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   },
 
   // ─────────────────────────────────────────────────────────────────────────
+  // StateStoreReadError — a blocking state-store READ (XREAD / BLPOP) aborted
+  // because the caller disconnected. Benign client abandonment; must precede
+  // StateStorePersistError so the write-side bucket doesn't claim it.
+  // ─────────────────────────────────────────────────────────────────────────
+  {
+    code: AgentRuntimeErrorType.StateStoreReadError,
+    match: sub('ERR caller gone'),
+    note: 'Upstash aborts the in-flight blocking read (XREAD/BLPOP) when the originating request is already gone.',
+  },
+
+  // ─────────────────────────────────────────────────────────────────────────
   // StateStorePersistError — Redis / Upstash agent-state store (NOT the LLM
   // provider). ioredis aborts, request-size cap, suspended DB, readonly upgrade
-  // window, dropped caller. These describe the connection/server condition, not
-  // a specific command, so there is no read-vs-write signal to split on.
+  // window. Write / connection-level drops.
   // ─────────────────────────────────────────────────────────────────────────
   {
     code: AgentRuntimeErrorType.StateStorePersistError,
@@ -537,11 +547,6 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     code: AgentRuntimeErrorType.StateStorePersistError,
     match: sub('READONLY Writes are temporarily rejected'),
     note: 'Upstash rejects writes against the read-only replica during a server upgrade.',
-  },
-  {
-    code: AgentRuntimeErrorType.StateStorePersistError,
-    match: sub('ERR caller gone'),
-    note: 'Upstash REST aborts the command when the originating request is already gone.',
   },
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/packages/model-runtime/src/errors/patterns.ts
+++ b/packages/model-runtime/src/errors/patterns.ts
@@ -516,7 +516,9 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
 
   // ─────────────────────────────────────────────────────────────────────────
   // StateStorePersistError — Redis / Upstash agent-state store (NOT the LLM
-  // provider). ioredis aborts, request-size cap, suspended DB.
+  // provider). ioredis aborts, request-size cap, suspended DB, readonly upgrade
+  // window, dropped caller. These describe the connection/server condition, not
+  // a specific command, so there is no read-vs-write signal to split on.
   // ─────────────────────────────────────────────────────────────────────────
   {
     code: AgentRuntimeErrorType.StateStorePersistError,
@@ -530,6 +532,16 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   {
     code: AgentRuntimeErrorType.StateStorePersistError,
     match: sub('database has been suspended'),
+  },
+  {
+    code: AgentRuntimeErrorType.StateStorePersistError,
+    match: sub('READONLY Writes are temporarily rejected'),
+    note: 'Upstash rejects writes against the read-only replica during a server upgrade.',
+  },
+  {
+    code: AgentRuntimeErrorType.StateStorePersistError,
+    match: sub('ERR caller gone'),
+    note: 'Upstash REST aborts the command when the originating request is already gone.',
   },
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/packages/model-runtime/src/errors/refine.test.ts
+++ b/packages/model-runtime/src/errors/refine.test.ts
@@ -1,4 +1,4 @@
-import { AgentRuntimeErrorType } from '@lobechat/types';
+import { AgentRuntimeErrorType, ChatErrorType } from '@lobechat/types';
 import { describe, expect, it } from 'vitest';
 
 import { refineErrorCode } from './refine';
@@ -11,6 +11,38 @@ describe('refineErrorCode', () => {
         message: '429 status code (no body)',
       }),
     ).toBeUndefined();
+  });
+
+  describe('un-typed throw wrappers', () => {
+    // A raw `Error` (e.g. a Drizzle "Failed query: …" throw) is wrapped by
+    // formatErrorForState as InternalServerError (HTTP 500). It must still reach
+    // the message patterns, otherwise it persists as a bare, un-classified 500.
+    it('reclassifies a 500-wrapped Drizzle throw into DatabasePersistError', () => {
+      expect(
+        refineErrorCode({
+          errorType: String(ChatErrorType.InternalServerError),
+          message: 'Failed query: rollback\nparams: ',
+        }),
+      ).toBe(AgentRuntimeErrorType.DatabasePersistError);
+    });
+
+    it('reclassifies an AgentRuntimeError-wrapped throw via its message', () => {
+      expect(
+        refineErrorCode({
+          errorType: AgentRuntimeErrorType.AgentRuntimeError,
+          message: 'Failed query: select "id" from "messages"',
+        }),
+      ).toBe(AgentRuntimeErrorType.DatabasePersistError);
+    });
+
+    it('leaves a 500 wrapper unrefined when nothing matches', () => {
+      expect(
+        refineErrorCode({
+          errorType: String(ChatErrorType.InternalServerError),
+          message: 'Agent state not found for operation op_xxx',
+        }),
+      ).toBeUndefined();
+    });
   });
 
   describe('message-pattern pass', () => {

--- a/packages/model-runtime/src/errors/refine.test.ts
+++ b/packages/model-runtime/src/errors/refine.test.ts
@@ -43,6 +43,25 @@ describe('refineErrorCode', () => {
         }),
       ).toBeUndefined();
     });
+
+    // The HTTP-status fallback is provider-only: a leading "429"/"500" in a
+    // harness/DB/Redis throw is not a real upstream status and must NOT recast
+    // the error with provider retry/failure semantics.
+    it('does not apply the HTTP-status fallback to un-typed wrappers', () => {
+      expect(
+        refineErrorCode({
+          errorType: String(ChatErrorType.InternalServerError),
+          message: '429 some harness throw with no registered pattern',
+        }),
+      ).toBeUndefined();
+      expect(
+        refineErrorCode({
+          errorType: AgentRuntimeErrorType.AgentRuntimeError,
+          httpStatus: 500,
+          message: 'opaque internal failure',
+        }),
+      ).toBeUndefined();
+    });
   });
 
   describe('message-pattern pass', () => {

--- a/packages/model-runtime/src/errors/refine.ts
+++ b/packages/model-runtime/src/errors/refine.ts
@@ -1,14 +1,27 @@
-import { AgentRuntimeErrorType, type ILobeAgentRuntimeErrorType } from '@lobechat/types';
+import {
+  AgentRuntimeErrorType,
+  ChatErrorType,
+  type ILobeAgentRuntimeErrorType,
+} from '@lobechat/types';
 
 import { matchErrorPattern } from './match';
 
 /**
- * Error codes that are generic enough to be worth re-deriving from the upstream
- * message / HTTP status. Specific codes assigned by a provider adapter are left
- * untouched — we only refine the `ProviderBizError` catch-all, which absorbs
- * any non-OK upstream response that the adapter couldn't name.
+ * Error codes generic enough to be worth re-deriving from the message / HTTP
+ * status. Specific codes assigned by a provider adapter are left untouched.
+ *
+ * Besides the `ProviderBizError` upstream catch-all, this covers the two
+ * fallback wrappers `formatErrorForState` produces for un-typed throws: a raw
+ * `Error` is wrapped as `InternalServerError` (HTTP 500) and any other value as
+ * `AgentRuntimeError`. They must be refinable so persistence-layer throws
+ * (`Failed query: …`) and state-store drops reach `matchErrorPattern` — without
+ * them those land as a bare, un-classified 500.
  */
-const REFINABLE_CODES = new Set<string>([AgentRuntimeErrorType.ProviderBizError]);
+const REFINABLE_CODES = new Set<string>([
+  AgentRuntimeErrorType.AgentRuntimeError,
+  AgentRuntimeErrorType.ProviderBizError,
+  String(ChatErrorType.InternalServerError),
+]);
 
 /**
  * Last-resort mapping from a bare HTTP status to a code, used only when the
@@ -50,10 +63,11 @@ export interface RefineErrorInput {
 }
 
 /**
- * Reclassify a generic provider catch-all (`ProviderBizError`) into a more
- * specific code using the upstream message and HTTP status. Returns the refined
- * code, or `undefined` when no better classification is found (caller keeps the
- * original errorType).
+ * Reclassify a generic catch-all (`ProviderBizError`, or the
+ * `InternalServerError` / `AgentRuntimeError` fallback wrappers) into a more
+ * specific code using the message and HTTP status. Returns the refined code, or
+ * `undefined` when no better classification is found (caller keeps the original
+ * errorType).
  *
  * Priority:
  *   1. `matchErrorPattern` over the message — most specific, covers the rich

--- a/packages/model-runtime/src/errors/refine.ts
+++ b/packages/model-runtime/src/errors/refine.ts
@@ -7,21 +7,29 @@ import {
 import { matchErrorPattern } from './match';
 
 /**
- * Error codes generic enough to be worth re-deriving from the message / HTTP
- * status. Specific codes assigned by a provider adapter are left untouched.
+ * Codes whose message is worth running through `matchErrorPattern`.
  *
  * Besides the `ProviderBizError` upstream catch-all, this covers the two
  * fallback wrappers `formatErrorForState` produces for un-typed throws: a raw
  * `Error` is wrapped as `InternalServerError` (HTTP 500) and any other value as
- * `AgentRuntimeError`. They must be refinable so persistence-layer throws
- * (`Failed query: …`) and state-store drops reach `matchErrorPattern` — without
+ * `AgentRuntimeError`. They must be pattern-refinable so persistence-layer
+ * throws (`Failed query: …`) and state-store drops reach the registry — without
  * them those land as a bare, un-classified 500.
  */
-const REFINABLE_CODES = new Set<string>([
+const PATTERN_REFINABLE_CODES = new Set<string>([
   AgentRuntimeErrorType.AgentRuntimeError,
   AgentRuntimeErrorType.ProviderBizError,
   String(ChatErrorType.InternalServerError),
 ]);
+
+/**
+ * Codes eligible for the coarse HTTP-status fallback — provider catch-alls
+ * only. A leading "429"/"500" in an upstream body is a real status signal, but
+ * the same digits in a harness/DB/Redis throw (e.g. `Error('500 …')`) are not:
+ * those must keep their original `InternalServerError` / `AgentRuntimeError`
+ * code rather than being recast with provider retry/failure semantics.
+ */
+const STATUS_REFINABLE_CODES = new Set<string>([AgentRuntimeErrorType.ProviderBizError]);
 
 /**
  * Last-resort mapping from a bare HTTP status to a code, used only when the
@@ -71,20 +79,23 @@ export interface RefineErrorInput {
  *
  * Priority:
  *   1. `matchErrorPattern` over the message — most specific, covers the rich
- *      cases plus the migrated `Upstream*` patterns.
- *   2. HTTP-status fallback for messages that matched nothing.
+ *      cases plus the migrated `Upstream*` patterns. Open to all wrappers.
+ *   2. HTTP-status fallback for messages that matched nothing — provider
+ *      catch-alls only (see `STATUS_REFINABLE_CODES`).
  */
 export const refineErrorCode = (
   input: RefineErrorInput,
 ): ILobeAgentRuntimeErrorType | undefined => {
   const { errorType, httpStatus, message, provider } = input;
-  if (!errorType || !REFINABLE_CODES.has(errorType)) return undefined;
+  if (!errorType || !PATTERN_REFINABLE_CODES.has(errorType)) return undefined;
 
   const matched = matchErrorPattern({ errorType, message, provider });
   if (matched && matched.code !== errorType) return matched.code;
 
-  const byStatus = codeFromHttpStatus(httpStatus ?? leadingStatusFromMessage(message));
-  if (byStatus && byStatus !== errorType) return byStatus;
+  if (STATUS_REFINABLE_CODES.has(errorType)) {
+    const byStatus = codeFromHttpStatus(httpStatus ?? leadingStatusFromMessage(message));
+    if (byStatus && byStatus !== errorType) return byStatus;
+  }
 
   return undefined;
 };

--- a/packages/model-runtime/src/errors/specs.ts
+++ b/packages/model-runtime/src/errors/specs.ts
@@ -418,6 +418,18 @@ export const ERROR_CODE_SPECS: SpecMap = {
     description:
       'Context-engine pipeline processor crashed ("Processor [<name>] execution failed").',
   },
+  [AgentRuntimeErrorType.StateStoreReadError]: {
+    code: AgentRuntimeErrorType.StateStoreReadError,
+    numericId: 7007,
+    category: 'stream',
+    severity: 'warning',
+    attribution: 'system',
+    httpStatus: 500,
+    retryable: false,
+    countAsFailure: false,
+    description:
+      'State-store (Redis / Upstash) blocking read (XREAD / BLPOP) aborted because the caller disconnected ("ERR caller gone") — benign client abandonment.',
+  },
 
   // ─── 8xxx Provider (catch-all) ────────────────────────────────────────
   [AgentRuntimeErrorType.AgentRuntimeError]: {

--- a/packages/types/src/agentRuntime.ts
+++ b/packages/types/src/agentRuntime.ts
@@ -138,6 +138,15 @@ export const AgentRuntimeErrorType = {
    */
   StateStorePersistError: 'StateStorePersistError',
   /**
+   * A blocking state-store read (XREAD / BLPOP, e.g. consuming the agent event
+   * stream or waiting on a tool result) was aborted because the originating
+   * caller disconnected — Upstash replies "ERR caller gone". Benign client
+   * abandonment tied to the request lifecycle, not a harness fault; kept
+   * distinct from the write-side StateStorePersistError so it is not counted
+   * as a failure.
+   */
+  StateStoreReadError: 'StateStoreReadError',
+  /**
    * A context-engine pipeline processor threw while building the prompt
    * context ("Processor [<name>] execution failed"). Harness-side bug in the
    * context assembly stage — the `PipelineError` thrown by


### PR DESCRIPTION
### 💡 Background and solution

Since #15286 (2026-05-28), agent operations that fail with a raw thrown `Error` have been persisted to `agent_operations.error` as a **bare, un-classified HTTP 500** — no `numericId`, `category`, `attribution`, `retryable`, etc. In June alone this hit **~1,381 operations** (`{"body":{"name":"Error"},"type":500,"message":"Failed query: rollback …"}`), covering the entire storage/infra error class:

- `Failed query: rollback / begin / select` (Postgres / Drizzle → `DatabasePersistError` E7004)
- `READONLY Writes are temporarily rejected …`, `ERR caller gone`, `ERR max request size exceeded` (Redis / Upstash)
- `Agent state not found for operation …`

**Root cause.** `refineErrorCode` only ran `matchErrorPattern` when the incoming `errorType` was `ProviderBizError` (`REFINABLE_CODES = {ProviderBizError}`). But `formatErrorForState` wraps any raw `Error` as `InternalServerError` (the numeric `500`) and any other thrown value as `AgentRuntimeError`. Those two fallback codes were never refinable, so their message never reached the pattern registry — `getErrorCodeSpec("500")` misses and the bare envelope is stored. Provider/quota errors were unaffected because they arrive pre-typed or as `ProviderBizError`.

### Changes

**1. Restore message classification for un-typed throws** (`refine.ts`). Add the two fallback wrappers (`InternalServerError`, `AgentRuntimeError`) to `REFINABLE_CODES` so their message runs through `matchErrorPattern` before the HTTP-status fallback. The `Failed query:` pattern (and the rest of the registry) already exist — this just lets them run again, restoring pre-#15286 behavior. A raw `Error("Failed query: rollback …")` now resolves to `DatabasePersistError` (E7004); a 500 wrapper whose message matches nothing (e.g. `Agent state not found`) stays unrefined, as before.

**2. Add the missing Redis write/connection patterns** to `StateStorePersistError`: `READONLY Writes are temporarily rejected` (Upstash rejecting writes against the read-only replica during a server upgrade) and the connection-level drops.

**3. Split caller-gone reads into a new `StateStoreReadError` (E7007).** `ERR caller gone` is an Upstash reply when an in-flight **blocking read** (`XREAD` on the agent event stream in `StreamEventManager`, `BLPOP` on a tool result in `ToolResultWaiter`) is aborted because the originating caller disconnected — benign client abandonment tied to the request lifecycle, **not** a write/persist fault. Bucketing it under `StateStorePersistError` mislabelled it as a harness failure. The new code is `attribution: system`, `severity: warning`, `countAsFailure: false`, so a user closing their tab no longer dings harness reliability. The write-side `READONLY Writes …` stays under `StateStorePersistError`.

### 🔍 Notes / follow-ups (not in this PR)

- **agent-gateway mirror**: `agent-gateway/src/errors/{codes,specs,patterns}.ts` inlines a copy of this taxonomy and needs the same `StateStoreReadError` + new patterns to stay in sync (separate repo/PR).
- **History backfill**: bare 500s from 2026-05-28 onward need their classification fields re-derived from the message.
- `Agent state not found` (runtime losing Redis state) is the behavioral bug tracked in LOBE-10326; it has no pattern and stays a 500 by design here.
- Optional: split `Failed query: select` reads (~5%) out of `DatabasePersistError` into a `DatabaseReadError` (`retryable: true`) — the SQL verb is message-visible, so it's routable.

### 📝 Test

- `refineErrorCode`: 500-wrapped and `AgentRuntimeError`-wrapped Drizzle throws reclassify to `DatabasePersistError`; an unmatched 500 wrapper stays unrefined.
- `formatErrorForState`: end-to-end, a raw `Error("Failed query: …")` now yields `DatabasePersistError` (E7004) instead of a bare 500.
- `matchErrorPattern`: `READONLY Writes …` → `StateStorePersistError`; `ERR caller gone` → `StateStoreReadError`.
- All existing `refine` / `match` / `classifier` / `formatErrorForState` suites pass (72 + 15), incl. the numericId-uniqueness / source-order contracts.