### PR TITLE
💄 style: compact device guard alert

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx
@@ -92,13 +92,14 @@ const HeterogeneousChatInput = memo(() => {
     }
 
     return (
-      <Flexbox paddingBlock={'0 6px'} paddingInline={12}>
-        <Alert
-          title={title}
-          type={'warning'}
-          description={
-            <Flexbox horizontal align={'center'} gap={8} justify={'space-between'}>
-              <span>{desc}</span>
+      <WideScreenContainer>
+        <Flexbox align={'center'} paddingBlock={'0 8px'} paddingInline={12}>
+          <Alert
+            description={desc}
+            style={{ maxWidth: 880, width: '100%' }}
+            title={title}
+            type={'warning'}
+            action={
               <Flexbox horizontal gap={6}>
                 <Button size={'small'} onClick={refresh}>
                   {t('platformAgent.deviceGuard.refresh')}
@@ -107,44 +108,50 @@ const HeterogeneousChatInput = memo(() => {
                   {t('platformAgent.deviceGuard.configure')}
                 </Button>
               </Flexbox>
-            </Flexbox>
-          }
-        />
-      </Flexbox>
+            }
+          />
+        </Flexbox>
+      </WideScreenContainer>
+    );
+  };
+
+  const renderCloudConfigGuard = () => {
+    if (isDeviceExecution || isConfigured) return null;
+
+    return (
+      <WideScreenContainer>
+        <Flexbox align={'center'} paddingBlock={'0 8px'} paddingInline={12}>
+          <Alert
+            description={t('heteroAgent.cloudNotConfigured.desc')}
+            style={{ maxWidth: 880, width: '100%' }}
+            title={t('heteroAgent.cloudNotConfigured.title')}
+            type={'warning'}
+            action={
+              <Button size={'small'} type={'primary'} onClick={goToConfig}>
+                {t('heteroAgent.cloudNotConfigured.action')}
+              </Button>
+            }
+          />
+        </Flexbox>
+      </WideScreenContainer>
     );
   };
 
   // Device execution doesn't use the cloud sandbox, so it doesn't need cloud
   // credentials — only the sandbox path gates on `isConfigured`.
   const inputDisabled = (!isConfigured && !isDeviceExecution) || deviceBlocked;
+  const hasGuard = deviceBlocked || (!isConfigured && !isDeviceExecution);
 
   return (
     <Flexbox>
-      {!isDeviceExecution && !isConfigured && (
-        <WideScreenContainer>
-          <Flexbox paddingBlock={'0 6px'} paddingInline={12}>
-            <Alert
-              title={t('heteroAgent.cloudNotConfigured.title')}
-              type={'warning'}
-              description={
-                <Flexbox horizontal align={'center'} gap={8} justify={'space-between'}>
-                  <span>{t('heteroAgent.cloudNotConfigured.desc')}</span>
-                  <Button size={'small'} type={'primary'} onClick={goToConfig}>
-                    {t('heteroAgent.cloudNotConfigured.action')}
-                  </Button>
-                </Flexbox>
-              }
-            />
-          </Flexbox>
-        </WideScreenContainer>
-      )}
+      {renderCloudConfigGuard()}
       {renderDeviceGuard()}
       <ChatInput
-        skipScrollMarginWithList
         controlBarSlot={<HeteroControlBar />}
         leftActions={leftActions}
         rightActions={rightActions}
         sendButtonProps={{ disabled: inputDisabled, shape: 'round' }}
+        skipScrollMarginWithList={!hasGuard}
         onEditorReady={(instance) => {
           // Sync to global ChatStore for compatibility with other features
           useChatStore.setState({ mainInputEditor: instance });


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Compact the heterogeneous agent device/cloud guard alerts so they no longer stretch across the full chat input area on wide screens.

- Wrap the device guard alert with the same wide-screen container used by the chat input.
- Center guard alerts and cap their visual width while keeping them responsive on smaller viewports.
- Move guard buttons into the Alert action slot and preserve input spacing when a guard is visible.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Validated with:

- `pnpm exec prettier --write 'src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx'`
- `pnpm exec eslint 'src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx' --fix`
- `git diff --check -- 'src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx'`

#### 📸 Screenshots / Videos

State-dependent UI change; no after screenshot captured in local dev.

#### 📝 Additional Information

This is a presentational change only. It does not alter device guard logic, cloud credential checks, or send behavior.
