### PR TITLE
🐛 fix(model-runtime): classify "Agent state not found" as StateStoreReadError

### DIFF
--- a/packages/locales/src/default/modelRuntime.ts
+++ b/packages/locales/src/default/modelRuntime.ts
@@ -70,7 +70,7 @@ export default {
   StateStorePersistError:
     'A temporary issue with the conversation state store interrupted this operation. Please try again; if it persists, contact support.',
   StateStoreReadError:
-    'This operation was ended because the connection closed before it finished. This is usually harmless — reopen the conversation to continue.',
+    'This operation could not be resumed because its session state was unavailable. Please reopen the conversation to continue; if it persists, contact support.',
   StreamChunkError:
     'Error parsing the message chunk of the streaming request. Please check if the current API interface complies with the standard specifications, or contact your API provider for assistance.',
   UpstreamGatewayError:

--- a/packages/model-runtime/src/errors/match.test.ts
+++ b/packages/model-runtime/src/errors/match.test.ts
@@ -102,10 +102,18 @@ describe('matchErrorPattern', () => {
     ).toBe(AgentRuntimeErrorType.StateStorePersistError);
   });
 
-  it('classifies a caller-gone blocking-read abort as StateStoreReadError (benign, not a persist failure)', () => {
+  it('classifies a caller-gone blocking-read abort as StateStoreReadError', () => {
     expect(matchErrorPattern({ message: 'ERR caller gone' })?.code).toBe(
       AgentRuntimeErrorType.StateStoreReadError,
     );
+  });
+
+  it('classifies a missing-agent-state read as StateStoreReadError', () => {
+    expect(
+      matchErrorPattern({
+        message: 'Agent state not found for operation op_1781276404066_agt_x_tpc_y_z',
+      })?.code,
+    ).toBe(AgentRuntimeErrorType.StateStoreReadError);
   });
 
   it('classifies harness JS runtime crashes as AgentRuntimeError', () => {

--- a/packages/model-runtime/src/errors/patterns.ts
+++ b/packages/model-runtime/src/errors/patterns.ts
@@ -515,14 +515,20 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   },
 
   // ─────────────────────────────────────────────────────────────────────────
-  // StateStoreReadError — a blocking state-store READ (XREAD / BLPOP) aborted
-  // because the caller disconnected. Benign client abandonment; must precede
-  // StateStorePersistError so the write-side bucket doesn't claim it.
+  // StateStoreReadError — a state-store READ failed: either a blocking read
+  // (XREAD / BLPOP) aborted because the caller disconnected, or the operation's
+  // agent state could not be loaded. Must precede StateStorePersistError so the
+  // write-side bucket doesn't claim it.
   // ─────────────────────────────────────────────────────────────────────────
   {
     code: AgentRuntimeErrorType.StateStoreReadError,
     match: sub('ERR caller gone'),
     note: 'Upstash aborts the in-flight blocking read (XREAD/BLPOP) when the originating request is already gone.',
+  },
+  {
+    code: AgentRuntimeErrorType.StateStoreReadError,
+    match: sub('Agent state not found for operation'),
+    note: 'coordinator.loadAgentState() returned null — the operation state was evicted/cleaned up before this read.',
   },
 
   // ─────────────────────────────────────────────────────────────────────────

--- a/packages/model-runtime/src/errors/refine.test.ts
+++ b/packages/model-runtime/src/errors/refine.test.ts
@@ -39,7 +39,7 @@ describe('refineErrorCode', () => {
       expect(
         refineErrorCode({
           errorType: String(ChatErrorType.InternalServerError),
-          message: 'Agent state not found for operation op_xxx',
+          message: 'some opaque internal failure with no registered pattern',
         }),
       ).toBeUndefined();
     });

--- a/packages/model-runtime/src/errors/specs.ts
+++ b/packages/model-runtime/src/errors/specs.ts
@@ -422,13 +422,13 @@ export const ERROR_CODE_SPECS: SpecMap = {
     code: AgentRuntimeErrorType.StateStoreReadError,
     numericId: 7007,
     category: 'stream',
-    severity: 'warning',
+    severity: 'error',
     attribution: 'system',
     httpStatus: 500,
     retryable: false,
-    countAsFailure: false,
+    countAsFailure: true,
     description:
-      'State-store (Redis / Upstash) blocking read (XREAD / BLPOP) aborted because the caller disconnected ("ERR caller gone") — benign client abandonment.',
+      'State-store (Redis / Upstash) read failed: a blocking read (XREAD / BLPOP) aborted because the caller disconnected ("ERR caller gone"), or the operation\'s agent state could not be loaded ("Agent state not found for operation …"). System-side — counts as a failure.',
   },
 
   // ─── 8xxx Provider (catch-all) ────────────────────────────────────────

--- a/packages/types/src/agentRuntime.ts
+++ b/packages/types/src/agentRuntime.ts
@@ -138,12 +138,12 @@ export const AgentRuntimeErrorType = {
    */
   StateStorePersistError: 'StateStorePersistError',
   /**
-   * A blocking state-store read (XREAD / BLPOP, e.g. consuming the agent event
-   * stream or waiting on a tool result) was aborted because the originating
-   * caller disconnected — Upstash replies "ERR caller gone". Benign client
-   * abandonment tied to the request lifecycle, not a harness fault; kept
-   * distinct from the write-side StateStorePersistError so it is not counted
-   * as a failure.
+   * A state-store (Redis / Upstash) READ failed: either a blocking read
+   * (XREAD / BLPOP, consuming the agent event stream or waiting on a tool
+   * result) was aborted because the caller disconnected ("ERR caller gone"), or
+   * the operation's agent state could not be loaded ("Agent state not found for
+   * operation …"). System-side read failure, kept distinct from the write-side
+   * StateStorePersistError; counts as a failure.
    */
   StateStoreReadError: 'StateStoreReadError',
   /**


### PR DESCRIPTION
### 💡 Background and solution

`AgentRuntimeService` throws `new Error("Agent state not found for operation <id>")` at three sites when `coordinator.loadAgentState(operationId)` returns null (the operation's agent state was already evicted / cleaned up from Redis). It's a raw `Error`, so — even after the refine fix (#15767) lets it reach the pattern registry — it has no matching pattern and lands as a **bare 500**. In June this was the single largest bare-500 family (~750 ops).

It is a state-store **READ** failure (a `loadAgentState` read that returned nothing), so this routes it to `StateStoreReadError` alongside the caller-gone abort.

**`countAsFailure` change.** Losing an operation's state mid-flight is a genuine **system fault**, not benign client abandonment — so `StateStoreReadError` is promoted to `countAsFailure: true` / `severity: error` (`attribution: system`). The previously-classified `ERR caller gone` now counts as a failure too; accepted trade-off — both are system-side state-store read failures worth tracking rather than hiding.

### Changes

- `agentRuntime.ts`: broaden `StateStoreReadError` doc to cover both caller-gone and missing-state reads.
- `specs.ts`: `StateStoreReadError` → `severity: error`, `countAsFailure: true`; description updated.
- `patterns.ts`: add `Agent state not found for operation` → `StateStoreReadError` (in the read block, ahead of the write-side `StateStorePersistError`).
- `modelRuntime.ts`: generalize the user-facing message (no longer "harmless").

### 🔍 Notes

- The underlying behavioral bug — the runtime losing Redis state and rejecting in-flight ops — is tracked in LOBE-10326. This PR only fixes the *classification* (stop emitting a bare 500; count it correctly).
- agent-gateway inlines a mirror of this taxonomy (`src/errors/{codes,specs,patterns}.ts`) and needs the same `Agent state not found` pattern + the `StateStoreReadError` spec change to stay in sync (separate repo/PR).

### 📝 Test

- `matchErrorPattern`: `Agent state not found for operation …` → `StateStoreReadError`.
- All `match` / `refine` / `classifier` suites pass (74), incl. numericId contracts; types package type-checks clean.