### PR TITLE
🐛 fix: allow deepseek visibility control via ENABLED_DEEPSEEK environment variable

### DIFF
--- a/apps/server/src/globalConfig/getServerGlobalConfig.test.ts
+++ b/apps/server/src/globalConfig/getServerGlobalConfig.test.ts
@@ -137,6 +137,8 @@ describe('getServerGlobalConfig', () => {
 
     expect(providerConfig[ModelProvider.LobeHub]).toBeUndefined();
     expect(providerConfig[ModelProvider.OpenAI]).toBeUndefined();
-    expect(providerConfig[ModelProvider.DeepSeek].enabled).toBe(true);
+    expect(providerConfig[ModelProvider.DeepSeek]).toEqual({
+      enabledKey: 'ENABLED_DEEPSEEK',
+    });
   });
 });

--- a/apps/server/src/globalConfig/index.ts
+++ b/apps/server/src/globalConfig/index.ts
@@ -47,7 +47,7 @@ export const getServerGlobalConfig = async () => {
       modelListKey: 'AWS_BEDROCK_MODEL_LIST',
     },
     deepseek: {
-      enabled: true,
+      enabledKey: 'ENABLED_DEEPSEEK',
     },
     giteeai: {
       enabledKey: 'ENABLED_GITEE_AI',

--- a/packages/env/src/llm.ts
+++ b/packages/env/src/llm.ts
@@ -273,7 +273,7 @@ export const getLLMConfig = () => {
       ENABLED_ZHIPU: !!process.env.ZHIPU_API_KEY,
       ZHIPU_API_KEY: process.env.ZHIPU_API_KEY,
 
-      ENABLED_DEEPSEEK: !!process.env.DEEPSEEK_API_KEY,
+      ENABLED_DEEPSEEK: process.env.ENABLED_DEEPSEEK !== '0',
       DEEPSEEK_API_KEY: process.env.DEEPSEEK_API_KEY,
 
       ENABLED_GOOGLE: process.env.ENABLED_GOOGLE !== '0',


### PR DESCRIPTION
Resolves #15721 by mapping the DeepSeek provider's visibility to the ENABLED_DEEPSEEK environment variable, enabling administrators to explicitly disable it using ENABLED_DEEPSEEK=0.