### PR TITLE
🐛 fix: support auto inference and capability override for custom embedding models

### DIFF
--- a/src/utils/server/parseModels.test.ts
+++ b/src/utils/server/parseModels.test.ts
@@ -324,6 +324,24 @@ describe('parseModelString', () => {
         type: 'chat',
       });
     });
+
+    it('should infer type as embedding if model ID contains embed or embedding', async () => {
+      const result = await parseModelString('test-provider', 'bge-large-zh-v1.5,nomic-embed-text');
+      expect(result.add).toMatchObject([
+        { id: 'bge-large-zh-v1.5', abilities: {}, type: 'embedding' },
+        { id: 'nomic-embed-text', abilities: {}, type: 'embedding' },
+      ]);
+    });
+
+    it('should set type as embedding if explicitly declared as capability', async () => {
+      const result = await parseModelString('test-provider', 'my-custom-model<1024:embedding>');
+      expect(result.add[0]).toMatchObject({
+        id: 'my-custom-model',
+        contextWindowTokens: 1024,
+        abilities: {},
+        type: 'embedding',
+      });
+    });
   });
 
   describe('FAL image models', () => {

--- a/src/utils/server/parseModels.ts
+++ b/src/utils/server/parseModels.ts
@@ -50,11 +50,24 @@ export const parseModelString = async (
     }
 
     // Use new type lookup function, prioritizing same provider first, then fallback to other providers
-    const modelType: AiModelType = await getModelPropertyWithFallback<AiModelType>(
+    let modelType: AiModelType = await getModelPropertyWithFallback<AiModelType>(
       id,
       'type',
       providerId,
     );
+
+    if (modelType === 'chat') {
+      const lowerId = id.toLowerCase();
+      if (
+        lowerId.includes('embed') ||
+        lowerId.includes('embedding') ||
+        lowerId.includes('bge') ||
+        lowerId.includes('minilm') ||
+        lowerId.startsWith('gte-')
+      ) {
+        modelType = 'embedding';
+      }
+    }
 
     const model: AiFullModelCard = {
       abilities: {},
@@ -75,6 +88,10 @@ export const parseModelString = async (
         switch (capability) {
           case 'reasoning': {
             model.abilities!.reasoning = true;
+            break;
+          }
+          case 'embedding': {
+            model.type = 'embedding';
             break;
           }
           case 'vision': {


### PR DESCRIPTION
Resolves #15720 by automatically inferring type as 'embedding' if the custom model ID contains 'embed', 'embedding', 'bge', 'minilm', or starts with 'gte-'. Additionally adds support for the explicit 'embedding' capability override in custom model strings.