### PR TITLE
🐛 fix: handle spawn error cleanly for hermes and openclaw platform agents

### DIFF
--- a/apps/cli/src/tools/heteroTask.ts
+++ b/apps/cli/src/tools/heteroTask.ts
@@ -255,6 +255,17 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
     }
     child.unref();
 
+    child.on('error', (err) => {
+      log.error(`Failed to start openclaw process: ${err.message}`);
+      removeTask(taskId);
+      void sendAutoNotify(
+        topicId,
+        taskId,
+        `Failed to run OpenClaw Platform Agent: ${err.message}. Please make sure 'openclaw' is installed and available in the PATH.`,
+        agentId,
+      ).finally(() => sendDoneSignal(topicId, agentId));
+    });
+
     saveTask({
       agentId,
       agentType,
@@ -347,6 +358,17 @@ export async function runHeteroTask(params: RunHeteroTaskParams): Promise<string
     const pid = child.pid;
     if (pid === undefined) throw new Error('Failed to get PID for hermes process');
     child.unref();
+
+    child.on('error', (err) => {
+      log.error(`Failed to start hermes process: ${err.message}`);
+      removeTask(taskId);
+      void sendAutoNotify(
+        topicId,
+        taskId,
+        `Failed to run Hermes Platform Agent: ${err.message}. Please make sure 'hermes' is installed and available in the PATH.`,
+        agentId,
+      ).finally(() => sendDoneSignal(topicId, agentId));
+    });
 
     saveTask({
       agentId,

--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -764,6 +764,19 @@ export default class GatewayConnectionCtr extends ControllerModule {
       if (pid === undefined) throw new Error('Failed to get PID for openclaw process');
       child.unref();
 
+      child.on('error', (err) => {
+        console.error(`Failed to start openclaw process: ${err.message}`);
+        this.platformTasks.delete(taskId);
+        void this.sendNotify({
+          agentId,
+          content: `Failed to run OpenClaw Platform Agent: ${err.message}. Please make sure 'openclaw' is installed and available in the PATH.`,
+          role: 'assistant',
+          topicId,
+        }).finally(() =>
+          this.sendNotify({ agentId, content: '', done: true, role: 'assistant', topicId }),
+        );
+      });
+
       this.platformTasks.set(taskId, {
         agentId,
         agentType,
@@ -859,6 +872,19 @@ export default class GatewayConnectionCtr extends ControllerModule {
       const pid = child.pid;
       if (pid === undefined) throw new Error('Failed to get PID for hermes process');
       child.unref();
+
+      child.on('error', (err) => {
+        console.error(`Failed to start hermes process: ${err.message}`);
+        this.platformTasks.delete(taskId);
+        void this.sendNotify({
+          agentId,
+          content: `Failed to run Hermes Platform Agent: ${err.message}. Please make sure 'hermes' is installed and available in the PATH.`,
+          role: 'assistant',
+          topicId,
+        }).finally(() =>
+          this.sendNotify({ agentId, content: '', done: true, role: 'assistant', topicId }),
+        );
+      });
 
       this.platformTasks.set(taskId, {
         agentId,


### PR DESCRIPTION
Resolves #15718 by adding 'error' event handlers to the spawned 'hermes' and 'openclaw' processes in both the CLI and desktop packages. This prevents unhandled exceptions when the platform executables are missing (ENOENT) and notifies the client with an actionable error message.