### PR TITLE
📝 docs: replace Claude-specific references with generic agent wording in skills

### DIFF
--- a/.agents/skills/version-release/references/changelog-example/db-migration.md
+++ b/.agents/skills/version-release/references/changelog-example/db-migration.md
@@ -49,4 +49,4 @@ Migration owner: @{pr-author}
 
 The migration owner is responsible for rollout follow-up and incident handling for this schema change.
 
-> **Note for Claude**: Replace `{pr-author}` with the actual PR author. Retrieve via `gh pr view <number> --json author --jq '.author.login'` or from commit metadata. Do not hardcode a username.
+> \[!NOTE]: Replace `{pr-author}` with the actual PR author. Retrieve via `gh pr view <number> --json author --jq '.author.login'` or from commit metadata. Do not hardcode a username.

--- a/.agents/skills/version-release/references/changelog-example/hotfix.md
+++ b/.agents/skills/version-release/references/changelog-example/hotfix.md
@@ -18,4 +18,4 @@
 
 @{pr-author}
 
-> **Note for Claude**: Replace `{pr-author}` with the actual PR author. Retrieve via `gh pr view <number> --json author --jq '.author.login'`. Do not hardcode a username.
+> \[!NOTE]: Replace `{pr-author}` with the actual PR author. Retrieve via `gh pr view <number> --json author --jq '.author.login'`. Do not hardcode a username.

--- a/.agents/skills/version-release/references/patch-release-scenarios.md
+++ b/.agents/skills/version-release/references/patch-release-scenarios.md
@@ -86,7 +86,7 @@ New AI model or provider support, typically contributed via community PRs.
 - These PR title prefixes (`feat` / `style`) are in the auto-tag trigger list
 - No special branch naming or manual release steps required — merging the PR triggers auto patch +1
 
-### When Claude is involved
+### When an agent is involved
 
 If asked to add model support, just create a normal feature PR. The title prefix will trigger the release automatically.
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 📝 docs

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Replace Claude-specific references with generic "agent" wording in skill files so they apply to all AI coding agents (Claude, Codex, etc.):

- `changelog-example/db-migration.md`: "Note for Claude" → "Note"
- `changelog-example/hotfix.md`: "Note for Claude" → "Note"
- `patch-release-scenarios.md`: "When Claude is involved" → "When an agent is involved"

#### 🧪 How to Test

- [x] No tests needed