### PR TITLE
✨ feat: support drag-to-reorder for desktop tabs

### DIFF
--- a/src/features/Electron/titlebar/TabBar/TabItem.tsx
+++ b/src/features/Electron/titlebar/TabBar/TabItem.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import {
   ActionIcon,
   Avatar,
@@ -52,6 +54,10 @@ const TabItem = memo<TabItemProps>(
     const isUnread = useTabUnread(tab);
     const showUnreadDot = !isRunning && isUnread;
 
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+      id,
+    });
+
     const handleClick = useCallback(() => {
       if (!isActive) {
         onActivate(id, tab.url);
@@ -102,10 +108,23 @@ const TabItem = memo<TabItemProps>(
         <Flexbox
           horizontal
           align="center"
-          className={cx(electronStylish.nodrag, styles.tab, isActive && styles.tabActive)}
           data-active={isActive ? 'true' : undefined}
           gap={6}
+          ref={setNodeRef}
+          className={cx(
+            electronStylish.nodrag,
+            styles.tab,
+            isActive && styles.tabActive,
+            isDragging && styles.tabDragging,
+          )}
+          style={{
+            transform: CSS.Translate.toString(transform),
+            transition,
+            zIndex: isDragging ? 1 : undefined,
+          }}
           onClick={handleClick}
+          {...attributes}
+          {...listeners}
         >
           {meta.avatar ? (
             <span className={styles.avatarWrapper}>

--- a/src/features/Electron/titlebar/TabBar/index.tsx
+++ b/src/features/Electron/titlebar/TabBar/index.tsx
@@ -49,6 +49,7 @@ const TabBar = () => {
   const { t } = useTranslation('electron');
   const { allowed: canCreate, reason } = usePermission('create_content');
   const viewportRef = useRef<HTMLDivElement>(null);
+  const scrolledActiveTabIdRef = useRef<string | null>(null);
   const { tabs, activeTabId } = useResolvedTabs();
   const activateTab = useElectronStore((s) => s.activateTab);
   const addTab = useElectronStore((s) => s.addTab);
@@ -150,6 +151,13 @@ const TabBar = () => {
 
     const activeIndex = tabs.findIndex((tab) => tab.tab.id === activeTabId);
     if (activeIndex < 0) return;
+
+    // Only scroll into view when the active tab itself changes. Reordering
+    // background tabs keeps the same active tab, so skip it — otherwise every
+    // drop would yank the viewport back to the active tab and lose the user's
+    // scroll position.
+    if (scrolledActiveTabIdRef.current === activeTabId) return;
+    scrolledActiveTabIdRef.current = activeTabId;
 
     const tabLeft = activeIndex * (TAB_WIDTH + TAB_GAP);
     const tabRight = tabLeft + TAB_WIDTH;

--- a/src/features/Electron/titlebar/TabBar/index.tsx
+++ b/src/features/Electron/titlebar/TabBar/index.tsx
@@ -1,5 +1,16 @@
 'use client';
 
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  type Modifier,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import { horizontalListSortingStrategy, SortableContext } from '@dnd-kit/sortable';
 import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
 import { ActionIcon, ScrollArea } from '@lobehub/ui';
 import { cx } from 'antd-style';
@@ -23,6 +34,9 @@ import TabItem from './TabItem';
 const TAB_WIDTH = 180;
 const TAB_GAP = 0;
 
+// Tabs only reorder along the horizontal axis, so lock the drag transform to X.
+const restrictToHorizontalAxis: Modifier = ({ transform }) => ({ ...transform, y: 0 });
+
 // Fallback when the active route doesn't define createNewTab: open the home page,
 // so the "+" button stays available on every page.
 const DEFAULT_NEW_TAB_ACTION: NewTabAction = {
@@ -42,6 +56,29 @@ const TabBar = () => {
   const closeOtherTabs = useElectronStore((s) => s.closeOtherTabs);
   const closeLeftTabs = useElectronStore((s) => s.closeLeftTabs);
   const closeRightTabs = useElectronStore((s) => s.closeRightTabs);
+  const reorderTabs = useElectronStore((s) => s.reorderTabs);
+
+  const sensors = useSensors(
+    // Require a small drag distance so a plain click still activates the tab.
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor),
+  );
+
+  const tabIds = useMemo(() => tabs.map((tab) => tab.tab.id), [tabs]);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const fromIndex = tabIds.indexOf(active.id as string);
+      const toIndex = tabIds.indexOf(over.id as string);
+      if (fromIndex < 0 || toIndex < 0) return;
+
+      reorderTabs(fromIndex, toIndex);
+    },
+    [tabIds, reorderTabs],
+  );
 
   const handleActivate = useCallback(
     (id: string, url: string) => {
@@ -173,20 +210,29 @@ const TabBar = () => {
         style: { alignItems: 'center', flexDirection: 'row', gap: TAB_GAP },
       }}
     >
-      {tabs.map((tab, index) => (
-        <TabItem
-          index={index}
-          isActive={tab.tab.id === activeTabId}
-          item={tab}
-          key={tab.tab.id}
-          totalCount={tabs.length}
-          onActivate={handleActivate}
-          onClose={handleClose}
-          onCloseLeft={handleCloseLeft}
-          onCloseOthers={handleCloseOthers}
-          onCloseRight={handleCloseRight}
-        />
-      ))}
+      <DndContext
+        collisionDetection={closestCenter}
+        modifiers={[restrictToHorizontalAxis]}
+        sensors={sensors}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
+          {tabs.map((tab, index) => (
+            <TabItem
+              index={index}
+              isActive={tab.tab.id === activeTabId}
+              item={tab}
+              key={tab.tab.id}
+              totalCount={tabs.length}
+              onActivate={handleActivate}
+              onClose={handleClose}
+              onCloseLeft={handleCloseLeft}
+              onCloseOthers={handleCloseOthers}
+              onCloseRight={handleCloseRight}
+            />
+          ))}
+        </SortableContext>
+      </DndContext>
       {(newTabAction || !canCreate) && (
         <ActionIcon
           className={cx(electronStylish.nodrag, styles.newTabButton)}

--- a/src/features/Electron/titlebar/TabBar/styles.ts
+++ b/src/features/Electron/titlebar/TabBar/styles.ts
@@ -92,6 +92,17 @@ export const useStyles = createStaticStyles(({ css, cssVar }) => ({
       opacity: 0;
     }
   `,
+  tabDragging: css`
+    cursor: grabbing;
+    z-index: 1;
+    background-color: ${cssVar.colorBgElevated};
+    box-shadow: ${cssVar.boxShadowSecondary};
+
+    &::before,
+    & + &::before {
+      opacity: 0;
+    }
+  `,
   tabActive: css`
     background-color: ${cssVar.colorBgElevated};
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

The desktop titlebar tabs were a fixed-order list. This PR makes them draggable horizontally so users can reorder them like Chrome tabs.

Implementation:
- Wrap the tab list in a `@dnd-kit` `DndContext` + `SortableContext` with `horizontalListSortingStrategy` (`src/features/Electron/titlebar/TabBar/index.tsx`).
- Each `TabItem` registers via `useSortable`; the whole tab acts as the drag handle, and the drag transform is locked to the X axis via a small inline modifier so tabs stay within the bar.
- On drag end, the existing `reorderTabs(fromIndex, toIndex)` store action is invoked — order is persisted to localStorage through the action's existing `#persist()`, so reordering survives reloads.
- A `PointerSensor` activation distance of 4px ensures a plain click still activates the tab and the close button / context menu keep working.
- Added a `tabDragging` style (elevated background + shadow, dividers hidden) for visual feedback while dragging.

No new dependencies — `@dnd-kit/core`, `@dnd-kit/sortable`, and `@dnd-kit/utilities` are already in the repo (used by the Kanban board and sidebar customization).

#### 🧪 How to Test

In the desktop app, open multiple tabs and drag a tab left/right by its body to reorder. A plain click still switches tabs; the close (X) button and right-click context menu still work; the new order persists across reloads.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Tabs fixed in insertion order | Tabs reorder by horizontal drag (Chrome-style) |