### PR TITLE
🐛 fix: resolve agent council parent_id postgres constraint failure

### DIFF
--- a/src/store/chat/slices/message/selectors/displayMessage.test.ts
+++ b/src/store/chat/slices/message/selectors/displayMessage.test.ts
@@ -907,5 +907,69 @@ describe('displayMessageSelectors', () => {
       const result = displayMessageSelectors.findLastMessageId('mg_123456')(state as ChatStore);
       expect(result).toBe('msg-999');
     });
+
+    it('should return parentMessageId for agentCouncil when members are empty', () => {
+      const agentCouncilMessage = {
+        id: 'agentCouncil-parent-123',
+        role: 'agentCouncil',
+        members: [],
+        extra: {
+          parentMessageId: 'parent-msg-id',
+        },
+      } as unknown as UIChatMessage;
+
+      const state: Partial<ChatStore> = {
+        activeAgentId: 'test-id',
+        messagesMap: {
+          [messageMapKey({ agentId: 'test-id' })]: [agentCouncilMessage],
+        },
+      };
+
+      const result = displayMessageSelectors.findLastMessageId('agentCouncil-parent-123')(
+        state as ChatStore,
+      );
+      expect(result).toBe('parent-msg-id');
+    });
+
+    it('should recursively find the last message ID from members for agentCouncil', () => {
+      const agentCouncilMessage = {
+        id: 'agentCouncil-parent-123',
+        role: 'agentCouncil',
+        members: [
+          {
+            id: 'member-1',
+            role: 'assistant',
+            content: 'Agent 1 response',
+          },
+          {
+            id: 'member-2',
+            role: 'assistant',
+            content: 'Agent 2 response with tools',
+            tools: [
+              {
+                id: 'tool-call-1',
+                identifier: 'tool-id',
+                apiName: 'tool-name',
+                arguments: '{}',
+                type: 'default',
+                result_msg_id: 'tool-result-id',
+              },
+            ],
+          },
+        ],
+      } as unknown as UIChatMessage;
+
+      const state: Partial<ChatStore> = {
+        activeAgentId: 'test-id',
+        messagesMap: {
+          [messageMapKey({ agentId: 'test-id' })]: [agentCouncilMessage],
+        },
+      };
+
+      const result = displayMessageSelectors.findLastMessageId('agentCouncil-parent-123')(
+        state as ChatStore,
+      );
+      expect(result).toBe('tool-result-id');
+    });
   });
 });

--- a/src/store/chat/slices/message/selectors/displayMessage.ts
+++ b/src/store/chat/slices/message/selectors/displayMessage.ts
@@ -262,6 +262,18 @@ const findLastMessageIdRecursive = (node: UIChatMessage | undefined): string | u
     return (node as any).lastMessageId;
   }
 
+  // Priority 3.5: For agentCouncil, recursively find the last message ID of the last member
+  if (node.role === 'agentCouncil' && (node as any).members) {
+    const members = (node as any).members;
+    if (members.length > 0) {
+      const lastMember = members.at(-1);
+      return findLastMessageIdRecursive(lastMember);
+    }
+    if ((node as any).extra?.parentMessageId) {
+      return (node as any).extra.parentMessageId;
+    }
+  }
+
   // Priority 4: Return self ID
   return node.id;
 };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Closes #15531

#### 🔀 Description of Change

In parallel Agent Council turns or when users reply to a message generated by an agent council, the virtual `agentCouncil` message has a composite concatenated ID (e.g. `agentCouncil-parentMessageId-memberIds`). When submitting subsequent messages or executing sequential rounds, this virtual ID is passed downstream as `parent_id` (via the last message selector). Since this virtual ID does not exist in the real database, the PostgreSQL server throws a `foreign_key_violation` constraint error.

This PR modifies the `findLastMessageIdRecursive` selector to handle `node.role === 'agentCouncil'` nodes by recursively finding the message ID of the last member in the `members` array (the last real message generated in the council) or falling back to `extra.parentMessageId` if there are no members.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Running:
`pnpm exec vitest run src/store/chat/slices/message/selectors/displayMessage.test.ts`
