### PR TITLE
🐛 fix: rate limit native dialogs in HTML preview to prevent infinite loops

### DIFF
--- a/src/components/HtmlPreview/InlinePreview.tsx
+++ b/src/components/HtmlPreview/InlinePreview.tsx
@@ -3,6 +3,7 @@ import type { CSSProperties } from 'react';
 import { memo, useMemo } from 'react';
 
 import { applyHtmlPreviewBaseUrl } from './applyBaseUrl';
+import { injectDialogInterceptor } from './dialogInterceptor';
 
 const hideHtmlPreviewActions = () => null;
 
@@ -38,7 +39,7 @@ const InlineHtmlPreview = memo<InlineHtmlPreviewProps>(
           iframe: { height: '100%' },
         }}
       >
-        {previewContent}
+        {injectDialogInterceptor(previewContent)}
       </HtmlPreview>
     );
   },

--- a/src/components/HtmlPreview/PreviewDrawer.tsx
+++ b/src/components/HtmlPreview/PreviewDrawer.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import { isDesktop } from '@/const/version';
 
 import { extractHtmlTitle } from './htmlTagScanner';
+import { injectDialogInterceptor } from './dialogInterceptor';
 
 const styles = createStaticStyles(({ css }) => ({
   container: css`
@@ -100,7 +101,7 @@ const HtmlPreviewDrawer = memo<HtmlPreviewDrawerProps>(({ content, open, onClose
             title={t('HtmlPreview.iframeTitle')}
             variant={'borderless'}
           >
-            {content}
+            {injectDialogInterceptor(content)}
           </HtmlPreview>
         </Block>
       ) : (

--- a/src/components/HtmlPreview/dialogInterceptor.test.ts
+++ b/src/components/HtmlPreview/dialogInterceptor.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { injectDialogInterceptor } from './dialogInterceptor';
+
+describe('injectDialogInterceptor', () => {
+  it('should return empty/falsy inputs unmodified', () => {
+    expect(injectDialogInterceptor('')).toBe('');
+  });
+
+  it('should inject right after <head> tag if present', () => {
+    const html = '<html><head><title>Test</title></head><body><h1>Hello</h1></body></html>';
+    const result = injectDialogInterceptor(html);
+    expect(result.includes('<html><head>\n<script>')).toBe(true);
+    expect(result.includes('window.alert = function')).toBe(true);
+    expect(result.endsWith('</head><body><h1>Hello</h1></body></html>')).toBe(true);
+  });
+
+  it('should inject right after <html> tag if <head> is missing but <html> is present', () => {
+    const html = '<html><body><h1>Hello</h1></body></html>';
+    const result = injectDialogInterceptor(html);
+    expect(result.includes('<html>\n<script>')).toBe(true);
+    expect(result.includes('window.alert = function')).toBe(true);
+    expect(result.endsWith('<body><h1>Hello</h1></body></html>')).toBe(true);
+  });
+
+  it('should prepend script if neither <head> nor <html> tags are present', () => {
+    const html = '<div>Hello World</div>';
+    const result = injectDialogInterceptor(html);
+    expect(result.startsWith('\n<script>')).toBe(true);
+    expect(result.includes('window.alert = function')).toBe(true);
+    expect(result.endsWith('<div>Hello World</div>')).toBe(true);
+  });
+});

--- a/src/components/HtmlPreview/dialogInterceptor.ts
+++ b/src/components/HtmlPreview/dialogInterceptor.ts
@@ -1,0 +1,65 @@
+const INTERCEPT_SCRIPT = `
+<script>
+  (function() {
+    let alertCount = 0;
+    let confirmCount = 0;
+    let promptCount = 0;
+    
+    setInterval(() => {
+      alertCount = 0;
+      confirmCount = 0;
+      promptCount = 0;
+    }, 5000);
+
+    const LIMIT = 3;
+
+    const originalAlert = window.alert;
+    window.alert = function(msg) {
+      alertCount++;
+      if (alertCount > LIMIT) {
+        console.warn('alert() rate limited by LobeHub to prevent infinite loop.');
+        return;
+      }
+      return originalAlert(msg);
+    };
+
+    const originalConfirm = window.confirm;
+    window.confirm = function(msg) {
+      confirmCount++;
+      if (confirmCount > LIMIT) {
+        console.warn('confirm() rate limited by LobeHub to prevent infinite loop.');
+        return false;
+      }
+      return originalConfirm(msg);
+    };
+
+    const originalPrompt = window.prompt;
+    window.prompt = function(msg, defaultVal) {
+      promptCount++;
+      if (promptCount > LIMIT) {
+        console.warn('prompt() rate limited by LobeHub to prevent infinite loop.');
+        return null;
+      }
+      return originalPrompt(msg, defaultVal);
+    };
+  })();
+</script>
+`;
+
+export const injectDialogInterceptor = (html: string): string => {
+  if (!html) return html;
+
+  const headMatch = html.match(/<head>/i);
+  if (headMatch && headMatch.index !== undefined) {
+    const insertIndex = headMatch.index + headMatch[0].length;
+    return html.slice(0, insertIndex) + INTERCEPT_SCRIPT + html.slice(insertIndex);
+  }
+
+  const htmlMatch = html.match(/<html>/i);
+  if (htmlMatch && htmlMatch.index !== undefined) {
+    const insertIndex = htmlMatch.index + htmlMatch[0].length;
+    return html.slice(0, insertIndex) + INTERCEPT_SCRIPT + html.slice(insertIndex);
+  }
+
+  return INTERCEPT_SCRIPT + html;
+};

--- a/src/components/HtmlPreview/index.ts
+++ b/src/components/HtmlPreview/index.ts
@@ -1,3 +1,4 @@
 export { isHtmlFile } from './fileType';
+export { injectDialogInterceptor } from './dialogInterceptor';
 export { default as InlineHtmlPreview } from './InlinePreview';
 export { default as HtmlPreviewDrawer } from './PreviewDrawer';


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Closes #15491

#### 🔀 Description of Change

When previewing AI-generated HTML code, there is no rate limiting or circuit breaker on native browser dialog triggers like `alert()`, `confirm()`, and `prompt()`. This can lead to an infinite dialog loop that locks the user out of the interface entirely (forcing a tab/process kill).

This PR intercepts and rate-limits `alert()`, `confirm()`, and `prompt()` in all rendered HTML preview contexts (both inline and drawer-based). It injects a tiny script into the previewed HTML document that dynamically overrides these functions and caps them to a maximum of 3 invocations within a rolling 5-second window. Suppressed calls log a warning to the console instead of blocking execution.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Running:
`pnpm exec vitest run src/components/HtmlPreview/dialogInterceptor.test.ts`
