### PR TITLE
✨ feat(server): add batchMoveTopics TRPC mutation

### DIFF
--- a/apps/server/src/routers/lambda/topic.ts
+++ b/apps/server/src/routers/lambda/topic.ts
@@ -162,6 +162,18 @@ export const topicRouter = router({
       return ctx.topicModel.batchDeleteBySessionId(resolved.sessionId);
     }),
 
+  batchMoveTopics: topicProcedure
+    .use(withScopedPermission('topic:update'))
+    .input(
+      z.object({
+        targetAgentId: z.string(),
+        topicIds: z.array(z.string()),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      return ctx.topicModel.batchMoveToAgent(input.topicIds, input.targetAgentId);
+    }),
+
   cloneTopic: topicProcedure
     .use(withScopedPermission('topic:create'))
     .input(z.object({ id: z.string(), newTitle: z.string().optional() }))

--- a/src/services/topic/index.ts
+++ b/src/services/topic/index.ts
@@ -32,6 +32,10 @@ export class TopicService {
     return lambdaClient.topic.cloneTopic.mutate({ id, newTitle });
   };
 
+  batchMoveTopics = (topicIds: string[], targetAgentId: string) => {
+    return lambdaClient.topic.batchMoveTopics.mutate({ targetAgentId, topicIds });
+  };
+
   importTopic = (params: {
     agentId: string;
     data: string;


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Part of LOBE-10330 (server layer)

#### 🔀 Description of Change

Second (server) layer of batch-moving topics between agents. **Stacked on top of #15792** (database layer).

- Adds a `topic.batchMoveTopics` lambda TRPC mutation — `topic:update` scoped permission, input `{ topicIds, targetAgentId }` — that delegates to `TopicModel.batchMoveToAgent`.
- Adds the matching `topicService.batchMoveTopics` client wrapper.

Depends on `TopicModel.batchMoveToAgent` from the database PR; this branch is based on `lobe-10330-db-batch-move-topics`, so the diff here is server-only. **After #15792 merges to `canary`, this PR's base should retarget to `canary`** (GitHub usually auto-retargets — please confirm before merge).

The UI layer (multi-select "move to assistant" action) lands in a later PR that consumes `topicService.batchMoveTopics`. LOBE-10330 stays open until that UI PR merges.

#### 🧪 How to Test

- [x] No tests needed

Server contract change only; behavior is exercised by the database-layer tests and the upcoming UI PR. Verified the cross-layer symbol resolves on the stacked branch (`ctx.topicModel.batchMoveToAgent` is present from the base).

#### 📝 Additional Information

Middle layer of a stacked split (DB → Server → UI). Must merge after #15792.