### PR TITLE
🐛 fix: support inline HTML tags in markdown code blocks to prevent Mermaid rendering failures

### DIFF
--- a/src/components/mdx/CodeBlock.test.tsx
+++ b/src/components/mdx/CodeBlock.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import CodeBlock from './CodeBlock';
+
+vi.mock('@lobehub/ui', () => ({
+  Mermaid: ({ children, variant }: any) => (
+    <div data-testid="mermaid" data-variant={variant}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('@lobehub/ui/mdx', () => ({
+  Pre: ({ children, language }: any) => (
+    <pre data-testid="pre" data-lang={language}>
+      {children}
+    </pre>
+  ),
+  PreSingleLine: ({ children, language }: any) => (
+    <span data-testid="pre-single" data-lang={language}>
+      {children}
+    </span>
+  ),
+}));
+
+describe('CodeBlock', () => {
+  it('should render PreSingleLine for single line short code', () => {
+    const raw = {
+      props: {
+        children: 'hello',
+        className: 'language-js',
+      },
+    };
+
+    render(<CodeBlock>{raw}</CodeBlock>);
+
+    const el = screen.getByTestId('pre-single');
+    expect(el).toBeDefined();
+    expect(el.textContent).toBe('hello');
+    expect(el.getAttribute('data-lang')).toBe('js');
+  });
+
+  it('should render Mermaid component for language-mermaid', () => {
+    const raw = {
+      props: {
+        children: 'flowchart TD\n  A --> B\n  C --> D\n  E --> F\n  G --> H',
+        className: 'language-mermaid',
+      },
+    };
+
+    render(<CodeBlock>{raw}</CodeBlock>);
+
+    const el = screen.getByTestId('mermaid');
+    expect(el).toBeDefined();
+    expect(el.textContent).toBe('flowchart TD\n  A --> B\n  C --> D\n  E --> F\n  G --> H');
+  });
+
+  it('should render Pre component for standard multi-line code', () => {
+    const raw = {
+      props: {
+        children: 'const x = 1;\nconst y = 2;\nconst z = 3;\nconst w = 4;',
+        className: 'language-js',
+      },
+    };
+
+    render(<CodeBlock>{raw}</CodeBlock>);
+
+    const el = screen.getByTestId('pre');
+    expect(el).toBeDefined();
+    expect(el.textContent).toBe('const x = 1;\nconst y = 2;\nconst z = 3;\nconst w = 4;');
+    expect(el.getAttribute('data-lang')).toBe('js');
+  });
+
+  it('should extract text recursively and convert br tag elements to <br> string', () => {
+    // Mimic the children array with mixed text and <br> elements parsed by rehype-raw
+    const brNode = { type: 'br', props: {} };
+    const raw = {
+      props: {
+        children: ['flowchart LR\n  A["text', brNode, 'line2"] --> B["some long connection description"]'],
+        className: 'language-mermaid',
+      },
+    };
+
+    render(<CodeBlock>{raw}</CodeBlock>);
+
+    const el = screen.getByTestId('mermaid');
+    expect(el).toBeDefined();
+    expect(el.textContent).toBe('flowchart LR\n  A["text<br>line2"] --> B["some long connection description"]');
+  });
+});

--- a/src/components/mdx/CodeBlock.tsx
+++ b/src/components/mdx/CodeBlock.tsx
@@ -10,6 +10,19 @@ const countLines = (str: string): number => {
   return matches ? matches.length : 1;
 };
 
+const extractText = (node: any): string => {
+  if (!node) return '';
+  if (typeof node === 'string') return node;
+  if (typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(extractText).join('');
+
+  if (node.props) {
+    if (node.type === 'br') return '<br>';
+    if (node.props.children) return extractText(node.props.children);
+  }
+  return '';
+};
+
 const useCode = (raw: any) => {
   if (!raw) return;
 
@@ -17,7 +30,7 @@ const useCode = (raw: any) => {
 
   if (!children) return;
 
-  const content = (Array.isArray(children) ? (children[0] as string) : children).trim();
+  const content = extractText(children).trim();
 
   const lang = className?.replace('language-', '') || 'txt';
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Closes #15631

#### 🔀 Description of Change

When the markdown code block contains HTML tags like `<br>`, the processor parses them into React elements. The previous code extraction logic in `CodeBlock.tsx` only took the first child (`children[0]`), causing the parser to discard everything after the first `<br>` tag. This resulted in broken Mermaid syntax and other code block rendering failures.

This PR introduces recursive text extraction in `CodeBlock` component via `extractText` function to process all children nodes (including text, numbers, arrays, and React elements) and map React `<br>` elements back to `"<br>"` strings. This ensures valid multi-line Mermaid labels and standard code block content are preserved and rendered correctly.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Running:
`pnpm exec vitest run src/components/mdx/CodeBlock.test.tsx`
