### PR TITLE
🐛 fix(server): persist subagent turn id so cold replicas don't fragment a turn

### DIFF
--- a/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -626,7 +626,13 @@ export class HeterogeneousPersistenceHandler {
   private buildSubagentSnapshot(
     parentToolCallId: string,
     threadId: string,
-    messages: Array<{ id: string; parentId?: string | null; role: string; tool_call_id?: string }>,
+    messages: Array<{
+      id: string;
+      metadata?: Record<string, any> | null;
+      parentId?: string | null;
+      role: string;
+      tool_call_id?: string;
+    }>,
   ): SubagentRunSnapshot | undefined {
     const assistants = messages.filter((m) => m.role === 'assistant');
     const currentAssistant = assistants.at(-1);
@@ -635,9 +641,16 @@ export class HeterogeneousPersistenceHandler {
     const toolRows = messages.filter((m) => m.role === 'tool' && m.tool_call_id);
     const childTools = toolRows.filter((m) => m.parentId === currentAssistant.id);
     const lastChainParentId = childTools.at(-1)?.id ?? currentAssistant.id;
+    // Recover the in-flight turn's CC message.id so a continuation event is
+    // recognized as the SAME turn (no spurious boundary → no fragmentation).
+    const currentSubagentMessageId =
+      typeof currentAssistant.metadata?.subagentMessageId === 'string'
+        ? currentAssistant.metadata.subagentMessageId
+        : undefined;
 
     return {
       currentAssistantId: currentAssistant.id,
+      currentSubagentMessageId,
       lastChainParentId,
       lifetimeToolCallIds: toolRows.map((m) => m.tool_call_id!),
       parentToolCallId,
@@ -962,11 +975,18 @@ export class HeterogeneousPersistenceHandler {
           {
             agentId: intent.agentId ?? undefined,
             content: intent.content,
+            // Persist the turn's CC message.id so a cold replica can recover
+            // `currentSubagentMessageId` (via buildSubagentSnapshot) and avoid
+            // a spurious turn boundary that fragments one CC turn into multiple
+            // in-thread assistant rows + empty shells.
+            ...(intent.subagentMessageId
+              ? { metadata: { subagentMessageId: intent.subagentMessageId } }
+              : {}),
             parentId: intent.parentId,
             role: intent.role,
             threadId: intent.threadId,
             topicId: intent.topicId ?? state.topicId,
-          },
+          } as any,
           intent.messageId,
         );
         return;

--- a/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.subagentRehydration.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.subagentRehydration.test.ts
@@ -101,7 +101,13 @@ const createHarness = (params: {
     update: vi.fn(async (id: string, patch: Partial<FakeMessage>) => {
       const existing = messages.get(id);
       if (!existing) return { success: false };
-      messages.set(id, { ...existing, ...patch });
+      // Mirror the real MessageModel.update: metadata is DEEP-MERGED, not
+      // replaced — so e.g. a usage write doesn't clobber subagentMessageId.
+      const next = { ...existing, ...patch };
+      if (patch.metadata && existing.metadata) {
+        next.metadata = { ...existing.metadata, ...patch.metadata };
+      }
+      messages.set(id, next);
       return { success: true };
     }),
     updateToolMessage: vi.fn(async (id: string, patch: any) => {
@@ -370,5 +376,70 @@ describe('HeterogeneousPersistenceHandler — subagent run survives a cold repli
     // The unrelated thread is untouched: still Processing, never updated.
     expect(h.threads.get('thd-stale')!.status).toBe('processing');
     expect(h.threadModel.update).not.toHaveBeenCalledWith('thd-stale', expect.anything());
+  });
+
+  // The in-thread analog of the cold-replica bug: one CC subagent turn continued
+  // on a fresh replica must NOT fork into a second in-thread assistant. The turn's
+  // CC message.id is persisted on the assistant's metadata and recovered into
+  // `currentSubagentMessageId`, so a continuation is recognized as the SAME turn.
+  it('does NOT fragment one CC subagent turn across a cold replica (no split / empty shell)', async () => {
+    const h = createHarness({
+      assistantMessageId: 'asst-1',
+      operationId: 'op-1',
+      topicId: 'topic-1',
+    });
+    const PARENT = 'tc-spawn-1';
+
+    // Batch 1: turn sub-1's first tool → lazy-create thread + user + in-thread
+    // assistant (stamped subagentMessageId=sub-1) + tool t1.
+    await h.handler.ingest({
+      assistantMessageId: 'asst-1',
+      events: [
+        buildEvent('stream_chunk', 0, {
+          chunkType: 'tools_calling',
+          subagent: {
+            parentToolCallId: PARENT,
+            spawnMetadata: { prompt: 'go', subagentType: 'Explore' },
+            subagentMessageId: 'sub-1',
+          },
+          toolsCalling: [innerTool('t1')],
+        }),
+      ],
+      operationId: 'op-1',
+      topicId: 'topic-1',
+    });
+
+    const threadId = [...h.threads.keys()][0];
+    const assistantsOf = () =>
+      [...h.messages.values()].filter((m) => m.role === 'assistant' && m.threadId === threadId);
+    expect(assistantsOf()).toHaveLength(1);
+    // The turn id was persisted so a cold replica can recover it.
+    expect(assistantsOf()[0].metadata?.subagentMessageId).toBe('sub-1');
+
+    __resetOperationStatesForTesting(); // cold replica
+
+    // Batch 2 (fresh replica): SAME turn sub-1 continues (cumulative [t1, t2]).
+    await h.handler.ingest({
+      assistantMessageId: 'asst-1',
+      events: [
+        buildEvent('stream_chunk', 1, {
+          chunkType: 'tools_calling',
+          subagent: { parentToolCallId: PARENT, subagentMessageId: 'sub-1' },
+          toolsCalling: [innerTool('t1'), innerTool('t2')],
+        }),
+      ],
+      operationId: 'op-1',
+      topicId: 'topic-1',
+    });
+
+    // Still exactly ONE in-thread assistant — no fork, no empty shell.
+    const assistants = assistantsOf();
+    expect(assistants).toHaveLength(1);
+    // Both tool rows hang off that same assistant (t1 not duplicated).
+    const toolRows = [...h.messages.values()].filter(
+      (m) => m.role === 'tool' && (m.tool_call_id === 't1' || m.tool_call_id === 't2'),
+    );
+    expect(toolRows).toHaveLength(2);
+    expect(new Set(toolRows.map((m) => m.parentId))).toEqual(new Set([assistants[0].id]));
   });
 });

--- a/packages/heterogeneous-agents/src/subagentCoordinator/reducer.ts
+++ b/packages/heterogeneous-agents/src/subagentCoordinator/reducer.ts
@@ -130,6 +130,7 @@ const ensureRun = (
         messageId: firstAssistantId,
         parentId: userMsgId,
         role: 'assistant',
+        subagentMessageId: subCtx.subagentMessageId,
         threadId,
         topicId: ctx.topicId,
       },
@@ -170,6 +171,7 @@ const ensureRun = (
       messageId: nextAssistantId,
       parentId: run.lastChainParentId,
       role: 'assistant',
+      subagentMessageId: subCtx.subagentMessageId,
       threadId: run.threadId,
       topicId: ctx.topicId,
     });

--- a/packages/heterogeneous-agents/src/subagentCoordinator/types.ts
+++ b/packages/heterogeneous-agents/src/subagentCoordinator/types.ts
@@ -93,16 +93,21 @@ export const createSubagentRunsState = (): SubagentRunsState => ({
  * server rebuilds main-agent state from DB on cold start; this lets it rebuild
  * the subagent runs the same way.
  *
- * Only the fields needed to keep the run attached to its EXISTING thread are
- * required. `currentSubagentMessageId` is intentionally NOT recoverable from DB
- * (CC's per-turn `message.id` is not persisted) — leaving it empty makes the
- * first post-rehydration subagent event read as a turn boundary, cutting a fresh
- * in-thread assistant chained off `lastChainParentId`. That is correct and safe:
- * it reuses the thread (no duplicate) and never appends to a half-written turn.
+ * Only the fields needed to keep the run attached to its EXISTING thread and to
+ * its IN-FLIGHT turn are required. `currentSubagentMessageId` is recovered from
+ * the latest in-thread assistant's persisted `metadata.subagentMessageId`: a
+ * cold replica must know the in-flight turn's CC `message.id`, otherwise the
+ * next event (`'' !== realId`) reads as a spurious turn boundary and splits one
+ * CC turn across multiple assistant rows (text on one, tools on another) plus
+ * empty shells. When the latest assistant predates this field (or is the
+ * terminal result row), it's omitted and falls back to `''` — same single-extra-
+ * turn behavior as before, no duplicate thread.
  */
 export interface SubagentRunSnapshot {
   /** Latest in-thread assistant id (where a continuation turn would otherwise append). */
   currentAssistantId: string;
+  /** CC `message.id` of the in-flight turn, from the latest assistant's `metadata.subagentMessageId`. */
+  currentSubagentMessageId?: string;
   /** Chain anchor for the next turn's assistant — last tool row of the thread, else the assistant. */
   lastChainParentId?: string;
   /** Every inner tool_call_id already persisted in the thread (delayed tool_results resolve via this). */
@@ -127,7 +132,7 @@ export const rehydrateSubagentRunsState = (snapshots: SubagentRunSnapshot[]): Su
       accContent: '',
       accReasoning: '',
       currentAssistantId: s.currentAssistantId,
-      currentSubagentMessageId: '',
+      currentSubagentMessageId: s.currentSubagentMessageId ?? '',
       lastChainParentId: s.lastChainParentId ?? s.currentAssistantId,
       lifetimeToolCallIds: new Set(s.lifetimeToolCallIds ?? []),
       threadId: s.threadId,
@@ -200,6 +205,16 @@ export interface CreateMessageIntent {
   messageId: string;
   parentId: string;
   role: 'user' | 'assistant';
+  /**
+   * CC's per-turn `message.id` for an `assistant` turn row. Persisted (server:
+   * onto `metadata.subagentMessageId`) so a cold serverless replica can recover
+   * {@link SubagentRun.currentSubagentMessageId} via {@link SubagentRunSnapshot}
+   * and recognize a CONTINUING turn instead of forcing a spurious turn boundary
+   * — which would split one CC turn across multiple in-thread assistant rows
+   * (text on one, tools on another) and leave empty shells. Absent on the user
+   * seed and the terminal result assistant.
+   */
+  subagentMessageId?: string;
   threadId: string;
   topicId: string | null;
 }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up to #15788 (subagent thread rehydration on cold replica).

#### 🔀 Description of Change

**Symptom (server / cloud only):** opening a remote-CC subagent thread shows the run shredded — one logical turn split into a text bubble + a separate tools bubble, **empty-shell** assistant bubbles (avatar + model name, no content/tools, sometimes with token usage), and many assistant rows mis-anchored as siblings under the same old tool. Pointers aren't corrupted; the rows are simply written wrong.

**Root cause:** on a cold serverless replica the subagent run is rebuilt from DB, but the run's *turn identity* — CC's per-turn `message.id` (`currentSubagentMessageId`) — was the one field with no DB home, so `rehydrateSubagentRunsState` hard-set it to `''`. The subagent reducer detects in-thread turn boundaries by comparing that id (`subagentMessageId !== currentSubagentMessageId`), so the first event of every cold batch satisfied `'' !== realId` → a **spurious turn boundary** → a brand-new in-thread assistant. A turn continued across a batch boundary therefore fragmented (text on the old row, tools on a freshly-forked one), and boundary-created rows that received only `turn_metadata` (or nothing) before the next cold batch became empty shells.

This is the in-thread analog of #15788: that fixed the **thread-duplication** half of cold-replica recovery (one thread now); this fixes the **turn-boundary** half (one assistant per CC turn). Desktop never hits either — it keeps one long-lived run-state closure.

**Fix:** give the turn id a DB home.
- `CreateMessageIntent.subagentMessageId` carries the turn's CC `message.id`; the reducer stamps it on each in-thread assistant row (lazy-create + turn boundary).
- The server interpreter writes it to `metadata.subagentMessageId` on createMessage. `MessageModel.update` deep-merges metadata, so later usage/content writes don't clobber it.
- `buildSubagentSnapshot` recovers it from the latest assistant's metadata → `SubagentRunSnapshot.currentSubagentMessageId` → `rehydrateSubagentRunsState` uses it instead of `''`.

A continuation is then recognized as the SAME turn → no spurious boundary → no fragmentation, no empty shells, correct parent chain.

#### 🧪 How to Test

New regression in `HeterogeneousPersistenceHandler.subagentRehydration.test.ts`: ingest a subagent turn's first tool, drop operation state (cold replica), ingest the SAME turn's next tool batch → assert exactly **one** in-thread assistant with both tools hanging off it. Verified to fail without the recovery (forks into 2 assistants).

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

95 `apps/server/.../heterogeneousAgent` tests + 30 coordinator tests pass; touched files type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)