### PR TITLE
🐛 fix(chat): normalize reconnect startTime to epoch ms

### DIFF
--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -940,8 +940,11 @@ describe('GatewayActionImpl', () => {
         topicId: 'topic-1',
       });
 
-      const metadata = startOperation.mock.calls[0][0].metadata;
-      expect(metadata).not.toHaveProperty('startTime');
+      expect(startOperation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.not.objectContaining({ startTime: expect.anything() }),
+        }),
+      );
     });
   });
 });

--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -858,4 +858,90 @@ describe('GatewayActionImpl', () => {
       });
     });
   });
+
+  describe('reconnectToGatewayOperation', () => {
+    function createReconnectTestAction(assistantMessage: any) {
+      const startOperation = vi.fn(() => ({ operationId: 'gw-op-reconnect' }));
+      const mockClient = createMockClient();
+      const state: Record<string, any> = {
+        activeAgentId: 'agent-1',
+        gatewayConnections: {},
+        messagesMap: { 'agent-1_topic-1': assistantMessage ? [assistantMessage] : [] },
+        // getTopicById reads here; an empty map yields no running op so the
+        // reconnect guards fall through to startOperation.
+        topicDataMap: {},
+      };
+      const set = vi.fn((updater: any) => {
+        if (typeof updater === 'function') Object.assign(state, updater(state));
+        else Object.assign(state, updater);
+      });
+      const get = vi.fn(() => ({
+        ...state,
+        associateMessageWithOperation: vi.fn(),
+        connectToGateway: vi.fn(),
+        internal_updateTopicLoading: vi.fn(),
+        onOperationCancel: vi.fn(),
+        startOperation,
+      })) as any;
+
+      (globalThis as any).window = {
+        global_serverConfigStore: {
+          getState: () => ({ serverConfig: { agentGatewayUrl: 'https://gateway.test.com' } }),
+        },
+      };
+
+      vi.mocked(aiAgentService.refreshGatewayToken).mockResolvedValue({
+        token: 'fresh-token',
+      } as any);
+
+      const action = new GatewayActionImpl(set as any, get, undefined);
+      action.createClient = vi.fn(() => mockClient);
+
+      return { action, startOperation };
+    }
+
+    afterEach(() => {
+      delete (globalThis as any).window;
+    });
+
+    // After a DB rehydrate (e.g. quit + relaunch), `createdAt` can arrive as an
+    // ISO string instead of epoch ms. Anchoring startTime to it raw makes
+    // `Date.now() - startTime` evaluate to NaN, which the elapsed-time label
+    // renders as "NaN:NaN". The reconnect path must normalize it to a number.
+    it('normalizes an ISO-string createdAt into an epoch-ms startTime', async () => {
+      const createdAtMs = 1_700_000_000_000;
+      const { action, startOperation } = createReconnectTestAction({
+        createdAt: new Date(createdAtMs).toISOString(),
+        id: 'ast-1',
+      });
+
+      await action.reconnectToGatewayOperation({
+        assistantMessageId: 'ast-1',
+        operationId: 'server-op-1',
+        topicId: 'topic-1',
+      });
+
+      expect(startOperation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({ startTime: createdAtMs }),
+        }),
+      );
+    });
+
+    it('omits startTime when createdAt is not a parseable date', async () => {
+      const { action, startOperation } = createReconnectTestAction({
+        createdAt: 'not-a-date',
+        id: 'ast-1',
+      });
+
+      await action.reconnectToGatewayOperation({
+        assistantMessageId: 'ast-1',
+        operationId: 'server-op-1',
+        topicId: 'topic-1',
+      });
+
+      const metadata = startOperation.mock.calls[0][0].metadata;
+      expect(metadata).not.toHaveProperty('startTime');
+    });
+  });
 });

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -604,13 +604,22 @@ export class GatewayActionImpl {
       .flat()
       .find((m) => m.id === assistantMessageId);
 
+    // `createdAt` is typed as a number but, after a DB rehydrate, it can arrive
+    // as a Date / ISO string (the message service casts rows `as unknown` without
+    // converting). Normalize to epoch ms here so the elapsed-time math stays a
+    // number — passing a string/Invalid Date straight through makes
+    // `Date.now() - startTime` resolve to NaN and renders as "NaN:NaN".
+    const startTime = assistantMessage?.createdAt
+      ? new Date(assistantMessage.createdAt).getTime()
+      : undefined;
+
     // Create a local operation for UI loading state, stashing the server op id
     // so intervention flows can find it after reconnect as well.
     const { operationId: gatewayOpId } = this.#get().startOperation({
       context,
       metadata: {
         serverOperationId: operationId,
-        ...(assistantMessage?.createdAt ? { startTime: assistantMessage.createdAt } : {}),
+        ...(Number.isFinite(startTime) ? { startTime } : {}),
       },
       type: 'execServerAgentRuntime',
     });


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No tracked issue; reported in-app. -->

#### 🔀 Description of Change

After quitting and relaunching the app, a running topic's elapsed-time label in the sidebar showed `NaN:NaN` instead of a `mm:ss` timer.

Root cause: on cold start the local operation state isn't persisted, so a still-running topic is restored via the gateway reconnect path (`reconnectToGatewayOperation`). That path anchors the operation's `startTime` to the assistant message's `createdAt`. `createdAt` is typed as `number`, but the message service returns DB rows via `as unknown as UIChatMessage[]` without converting `Date` → epoch ms, so at runtime it can be a `Date` / ISO string. Passing it through verbatim made the elapsed-time math `Date.now() - startTime` resolve to `NaN`, and `formatElapsedClockTime(NaN)` renders `"NaN:NaN"`. (A fresh run is unaffected because it uses `startOperation`'s `Date.now()` default.)

Fix: normalize `createdAt` to epoch ms (`new Date(createdAt).getTime()`) and only set `startTime` when the result is finite; otherwise fall back to `startOperation`'s `Date.now()` default.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added two unit tests for `reconnectToGatewayOperation`:
- an ISO-string `createdAt` is normalized into an epoch-ms `startTime`;
- an unparseable `createdAt` omits `startTime` (falls back to the default).

Repro: start a long-running agent task, quit the app while it's running, relaunch — the sidebar timer for that topic should now show a valid `mm:ss` instead of `NaN:NaN`.

#### 📝 Additional Information

Source-level normalization fix. A defensive `Number.isFinite` guard at the elapsed-time render site and the `Math.min` poisoning in `getAgentRuntimeStartTimeByContext` are separate hardening opportunities, intentionally left out of this minimal fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)