### PR TITLE
✨ feat(chat): show token usage cache rate

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -332,6 +332,7 @@
   "messages.modelCard.pricing.outputTokens": "Output {{amount}} credits · ${{amount}}/M",
   "messages.modelCard.pricing.writeCacheInputTokens": "Cache write {{amount}} credits · ${{amount}}/M",
   "messages.tokenDetails.average": "Average unit price",
+  "messages.tokenDetails.cacheRate": "Cache rate",
   "messages.tokenDetails.input": "Input",
   "messages.tokenDetails.inputAudio": "Audio Input",
   "messages.tokenDetails.inputCached": "Cached Input",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -332,6 +332,7 @@
   "messages.modelCard.pricing.outputTokens": "输出 {{amount}} 积分 · ${{amount}}/M",
   "messages.modelCard.pricing.writeCacheInputTokens": "缓存写入 {{amount}} 积分 · ${{amount}}/M",
   "messages.tokenDetails.average": "平均单价",
+  "messages.tokenDetails.cacheRate": "缓存率",
   "messages.tokenDetails.input": "输入",
   "messages.tokenDetails.inputAudio": "音频输入",
   "messages.tokenDetails.inputCached": "输入缓存",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -290,6 +290,7 @@ export default {
   'messages.modelCard.pricing.writeCacheInputTokens':
     'Cache write {{amount}} credits · ${{amount}}/M',
   'messages.tokenDetails.average': 'Average unit price',
+  'messages.tokenDetails.cacheRate': 'Cache rate',
   'messages.tokenDetails.input': 'Input',
   'messages.tokenDetails.inputAudio': 'Audio Input',
   'messages.tokenDetails.inputCached': 'Cached Input',

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx
@@ -129,6 +129,10 @@ const TokenDetail = memo<TokenDetailProps>(({ usage, performance, model, provide
       : detailTokens.totalTokens!.token;
 
   const detailTotal = formatUsageValue(totalCount);
+  const cacheRate =
+    typeof detailTokens.inputCacheRate === 'number'
+      ? `${formatNumber(detailTokens.inputCacheRate * 100, 1)}%`
+      : undefined;
 
   const averagePricing = formatNumber(
     detailTokens.totalTokens!.credit / detailTokens.totalTokens!.token,
@@ -182,6 +186,14 @@ const TokenDetail = memo<TokenDetailProps>(({ usage, performance, model, provide
             <Flexbox>
               <TokenProgress showIcon data={totalDetail} />
               <Divider style={{ marginBlock: 8 }} />
+              {cacheRate && (
+                <Flexbox horizontal align={'center'} gap={4} justify={'space-between'}>
+                  <div style={{ color: cssVar.colorTextSecondary }}>
+                    {t('messages.tokenDetails.cacheRate')}
+                  </div>
+                  <div style={{ fontWeight: 500 }}>{cacheRate}</div>
+                </Flexbox>
+              )}
               <Flexbox horizontal align={'center'} gap={4} justify={'space-between'}>
                 <div style={{ color: cssVar.colorTextSecondary }}>
                   {t('messages.tokenDetails.total')}

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/tokens.ts
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/tokens.ts
@@ -27,19 +27,25 @@ export const getDetailsToken = (usage: ModelUsage, modelCard?: LobeDefaultAiMode
     typeof usage.outputTextTokens === 'number'
       ? usage.outputTextTokens
       : Math.max(
-        0,
-        totalOutputTokens -
-        outputReasoningTokens -
-        (usage.outputAudioTokens || 0) -
-        outputImageTokens,
-      );
+          0,
+          totalOutputTokens -
+            outputReasoningTokens -
+            (usage.outputAudioTokens || 0) -
+            outputImageTokens,
+        );
 
   const inputWriteCacheTokens = usage.inputWriteCacheTokens || 0;
   const inputCacheTokens = usage.inputCachedTokens || (usage as any).cachedTokens || 0;
 
-  const inputCacheMissTokens = usage?.inputCacheMissTokens
-    ? usage?.inputCacheMissTokens
-    : totalInputTokens - (inputCacheTokens || 0) - inputToolTokens;
+  const inputCacheMissTokens =
+    typeof usage?.inputCacheMissTokens === 'number'
+      ? usage.inputCacheMissTokens
+      : totalInputTokens - (inputCacheTokens || 0) - inputToolTokens;
+  const cacheRateInputTokens = inputCacheMissTokens + inputCacheTokens + inputWriteCacheTokens;
+  const cacheRate =
+    cacheRateInputTokens > 0 && (inputCacheTokens > 0 || inputWriteCacheTokens > 0)
+      ? inputCacheTokens / cacheRateInputTokens
+      : undefined;
 
   // Pricing
   const formatPrice = getPrice(modelCard?.pricing || { units: [] });
@@ -76,9 +82,9 @@ export const getDetailsToken = (usage: ModelUsage, modelCard?: LobeDefaultAiMode
   return {
     inputAudio: !!usage.inputAudioTokens
       ? {
-        credit: calcCredit(usage.inputAudioTokens, getAudioInputUnitRate(modelCard?.pricing)),
-        token: usage.inputAudioTokens,
-      }
+          credit: calcCredit(usage.inputAudioTokens, getAudioInputUnitRate(modelCard?.pricing)),
+          token: usage.inputAudioTokens,
+        }
       : undefined,
     inputCacheMiss: !!inputCacheMissTokens
       ? { credit: inputCacheMissCredit, token: inputCacheMissTokens }
@@ -89,50 +95,51 @@ export const getDetailsToken = (usage: ModelUsage, modelCard?: LobeDefaultAiMode
     inputCachedWrite: !!inputWriteCacheTokens
       ? { credit: inputWriteCachedCredit, token: inputWriteCacheTokens }
       : undefined,
+    inputCacheRate: cacheRate,
     inputCitation: !!usage.inputCitationTokens
       ? {
-        credit: calcCredit(usage.inputCitationTokens, formatPrice.input),
-        token: usage.inputCitationTokens,
-      }
+          credit: calcCredit(usage.inputCitationTokens, formatPrice.input),
+          token: usage.inputCitationTokens,
+        }
       : undefined,
     inputText: !!inputTextTokens
       ? {
-        credit: calcCredit(inputTextTokens, formatPrice.input),
-        token: inputTextTokens,
-      }
+          credit: calcCredit(inputTextTokens, formatPrice.input),
+          token: inputTextTokens,
+        }
       : undefined,
     inputTool: !!inputToolTokens
       ? {
-        credit: inputToolCredit,
-        token: inputToolTokens,
-      }
+          credit: inputToolCredit,
+          token: inputToolTokens,
+        }
       : undefined,
 
     outputAudio: !!usage.outputAudioTokens
       ? {
-        credit: calcCredit(usage.outputAudioTokens, getAudioOutputUnitRate(modelCard?.pricing)),
-        id: 'outputAudio',
-        token: usage.outputAudioTokens,
-      }
+          credit: calcCredit(usage.outputAudioTokens, getAudioOutputUnitRate(modelCard?.pricing)),
+          id: 'outputAudio',
+          token: usage.outputAudioTokens,
+        }
       : undefined,
     outputImage: !!outputImageTokens
       ? {
-        credit: calcCredit(outputImageTokens, formatPrice.output),
-        id: 'outputImage',
-        token: outputImageTokens,
-      }
+          credit: calcCredit(outputImageTokens, formatPrice.output),
+          id: 'outputImage',
+          token: outputImageTokens,
+        }
       : undefined,
     outputReasoning: !!outputReasoningTokens
       ? {
-        credit: calcCredit(outputReasoningTokens, formatPrice.output),
-        token: outputReasoningTokens,
-      }
+          credit: calcCredit(outputReasoningTokens, formatPrice.output),
+          token: outputReasoningTokens,
+        }
       : undefined,
     outputText: !!outputTextTokens
       ? {
-        credit: calcCredit(outputTextTokens, formatPrice.output),
-        token: outputTextTokens,
-      }
+          credit: calcCredit(outputTextTokens, formatPrice.output),
+          token: outputTextTokens,
+        }
       : undefined,
 
     totalInput: !!totalInputTokens


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Calculate the token usage input cache rate from cached, uncached, and cache-write input token counters.
- Show the cache rate in the token usage detail popover when cache usage data is available.
- Add default, en-US, and zh-CN i18n labels for the new cache rate row.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Checked with:

- `pnpm exec prettier --check locales/en-US/chat.json locales/zh-CN/chat.json packages/locales/src/default/chat.ts src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/tokens.ts`
- `pnpm exec eslint src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/tokens.ts`
- `git diff --check origin/canary..HEAD`

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Full `bun run type-check` was attempted in an isolated worktree, but the temporary dependency setup reused a sibling checkout's `node_modules`, which produced cross-checkout duplicate type paths unrelated to this change. It was not counted as a valid verification signal.
