### PR TITLE
🐛 fix(chat): drop subagent-tagged events from the main gateway stream handler

### DIFF
--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -246,6 +246,44 @@ describe('createGatewayEventHandler', () => {
 
       expect(store.internal_dispatchMessage).not.toHaveBeenCalled();
     });
+
+    it('should DROP subagent-tagged tool chunks so they do not leak into the main bubble', async () => {
+      // Regression: on a live gateway / remote-CC stream, a subagent (Agent/Task)
+      // inner tool chunk is tagged with `data.subagent`. It belongs to an
+      // isolation Thread, not the main assistant. If dispatched here it appends
+      // to the MAIN assistant's tools[] until the terminal DB refetch corrects it
+      // ("流式时漏出来、结束后正常"). It must be dropped before any dispatch.
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(
+        makeEvent('stream_chunk', {
+          chunkType: 'tools_calling',
+          subagent: { parentToolCallId: 'toolu_agent', subagentMessageId: 'sub-1' },
+          toolsCalling: [{ id: 'inner-1' }],
+        }),
+      );
+      await flush();
+
+      // Not dispatched onto the main assistant, and no tool-calling spinner.
+      expect(store.internal_dispatchMessage).not.toHaveBeenCalled();
+      expect(store.internal_toggleToolCallingStreaming).not.toHaveBeenCalled();
+    });
+
+    it('should still dispatch a NON-subagent tool chunk (drop is scoped to subagent)', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(
+        makeEvent('stream_chunk', { chunkType: 'tools_calling', toolsCalling: [{ id: 'm-1' }] }),
+      );
+      await flush();
+
+      expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
+        { id: 'msg-initial', type: 'updateMessage', value: { tools: [{ id: 'm-1' }] } },
+        { operationId: 'op-1' },
+      );
+    });
   });
 
   describe('reasoning operation lifecycle', () => {

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -267,6 +267,13 @@ export const createGatewayEventHandler = (
   return (event: AgentStreamEvent) => {
     if (terminalState) return;
 
+    // Subagent (`Agent`/`Task`) inner-tool events are tagged `data.subagent` and
+    // belong to an isolation Thread. This handler is main-agent-only, so
+    // dispatching them leaks the subagent's tools into the parent bubble
+    // mid-stream until the terminal fetch corrects it. The local executor drops
+    // them before forwarding; the gateway path doesn't. (DB is unaffected.)
+    if ((event.data as { subagent?: unknown } | undefined)?.subagent) return;
+
     if (event.type === 'agent_runtime_end' || event.type === 'error') {
       terminalState = event.type === 'error' ? 'error' : 'completed';
     }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Live-streaming sibling of the subagent thread fixes (#15788 / #15808), which addressed server **persistence** (end-state). This fixes the **client live render**.

#### 🔀 Description of Change

**Symptom:** during a live remote-CC stream, a subagent's inner tools (e.g. the `Bash` calls of an `Agent: Explore`) **leak into the parent bubble** — the main "N 次技能调用" group shows tools that actually belong inside the Agent. The final state is correct; only the streaming view is wrong ("流式时漏出来、结束后正常").

**Root cause:** the gateway path (`gateway.ts` → `connectToGateway({ onEvent })`) feeds **raw** `AgentStreamEvent`s straight into `createGatewayEventHandler`, which is **main-agent-only**. Subagent events carry `data.subagent` (the isolation-Thread tag), but nothing filtered them, so a subagent `tools_calling` chunk dispatched `updateMessage { tools }` onto the MAIN assistant. It snapped back only when the terminal `fetchAndReplaceMessages` pulled correct DB state (subagent rows live under the Thread). The local desktop executor (`heterogeneousAgentExecutor`) already drops `data.subagent` events before forwarding; the gateway path didn't.

**Fix:** drop `data.subagent`-tagged events at the top of `createGatewayEventHandler` — one place covering every gateway caller, and a no-op for the local executor (which already pre-drops). DB persistence is untouched (the server writes subagent rows under the Thread regardless), so they still render — correctly under their Thread — after the terminal fetch.

Note: this stops the leak; live *in-Thread* streaming of remote subagents (rendering their tools into the Thread bucket as they arrive, like the local executor does) is a separate follow-up — remote subagent content currently appears on the terminal fetch.

#### 🧪 How to Test

Two new cases in `gatewayEventHandler.test.ts`: a `tools_calling` chunk tagged with `data.subagent` is **not** dispatched to the main assistant (verified red without the drop), and a non-subagent chunk still dispatches.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`gatewayEventHandler.test.ts` 48 pass; touched file type-checks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)