### PR TITLE
🐛 fix(conversation): stop tool workflow collapse showing 'in progress' once content renders below it

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -38,6 +38,7 @@ vi.mock('./CollapsedMessage', () => ({
 vi.mock('./WorkflowCollapse', () => ({
   default: ({
     blocks,
+    workflowChromeComplete,
   }: {
     blocks: Array<{
       content: string;
@@ -48,8 +49,10 @@ vi.mock('./WorkflowCollapse', () => ({
       hasToolsOverride?: boolean;
       tools?: unknown[];
     }>;
+    workflowChromeComplete?: boolean;
   }) => (
     <div
+      data-chrome-complete={String(!!workflowChromeComplete)}
       data-testid="workflow-segment"
       data-blocks={JSON.stringify(
         blocks.map(
@@ -145,7 +148,7 @@ describe('Group', () => {
     // renders as ONE inline unit (content above its tool inside ContentBlock),
     // never split into a tool-first / text-after layout.
     const longContent =
-      '后宫番 + 实际项目中的状态管理问题，这个组合挺有意思的！\n\n对于实际项目中的状态管理，你目前遇到的具体问题是什么？比如：\n- 不知道什么时候该用 useState，什么时候该用 Context\n- 组件间状态传递变得混乱\n- 性能问题（不必要的重渲染）';
+      'State management in real projects is an interesting topic!\n\nWhat specific problem are you running into right now? For example:\n- Not sure when to use useState vs Context\n- State passing between components gets messy\n- Performance issues from unnecessary re-renders';
 
     render(
       <Group
@@ -431,5 +434,78 @@ describe('Group', () => {
       { disableMarkdownStreaming: true, id: 'block-2' },
       { disableMarkdownStreaming: false, id: 'block-3' },
     ]);
+  });
+
+  it('marks the workflow chrome complete once content renders below a settled fold while generating', () => {
+    // An errored multi-tool block splits into a folded workflow (the tools) plus
+    // a trailing answer segment (the error text). While still generating, the
+    // collapse must not keep showing its streaming "working" header now that the
+    // model has moved past it and content renders below.
+    mockIsGenerating = true;
+
+    const { container } = render(
+      <Group
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: 'Something failed while running the commands.',
+            error: { message: 'boom' } as any,
+            id: 'block-1',
+            tools: [
+              { apiName: 'command_execution', id: 'tool-1', result: { content: 'ok' } } as any,
+              { apiName: 'command_execution', id: 'tool-2', result: { content: 'ok' } } as any,
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    const sequence = Array.from(container.querySelectorAll('[data-testid]')).map((node) =>
+      node.getAttribute('data-testid'),
+    );
+
+    expect(sequence).toEqual(['workflow-segment', 'answer-segment']);
+    expect(screen.getByTestId('workflow-segment').getAttribute('data-chrome-complete')).toBe(
+      'true',
+    );
+  });
+
+  it('keeps the fold streaming when it still holds a pending intervention, even with content below', () => {
+    // Same shape as above, but one tool awaits user confirmation. The completion
+    // shortcut must be suppressed so the "awaiting confirmation" chrome survives —
+    // areWorkflowToolsComplete ignores pending tools, so we cannot rely on it.
+    mockIsGenerating = true;
+
+    const { container } = render(
+      <Group
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: 'Partial output before the failure.',
+            error: { message: 'boom' } as any,
+            id: 'block-1',
+            tools: [
+              { apiName: 'command_execution', id: 'tool-1', result: { content: 'ok' } } as any,
+              {
+                apiName: 'command_execution',
+                id: 'tool-2',
+                intervention: { status: 'pending' },
+              } as any,
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    const sequence = Array.from(container.querySelectorAll('[data-testid]')).map((node) =>
+      node.getAttribute('data-testid'),
+    );
+
+    expect(sequence).toEqual(['workflow-segment', 'answer-segment']);
+    expect(screen.getByTestId('workflow-segment').getAttribute('data-chrome-complete')).toBe(
+      'false',
+    );
   });
 });

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -331,6 +331,29 @@ const shouldInlineWorkflowSegment = (blocks: RenderableAssistantContentBlock[]):
   return toolCount === 1;
 };
 
+/**
+ * A workflow segment is only the "active" step while it is the last thing in the
+ * group. Once any later segment has real content below it (e.g. an errored
+ * tool block whose error text renders as a trailing answer segment), the tools
+ * are settled and the collapse should read as done rather than keep showing its
+ * streaming "working" header. Empty trailing blocks (an answer not streamed yet)
+ * don't count. `postToolTailPromoted` already covers the promoted-final-answer
+ * path at the group level; this catches the remaining segment-ordering cases.
+ */
+const hasRenderedContentAfter = (segments: GroupRenderSegment[], index: number): boolean =>
+  segments
+    .slice(index + 1)
+    .some((seg) => (seg.kind === 'workflow' ? seg.blocks.length > 0 : !isEmptyBlock(seg.block)));
+
+/**
+ * A pending intervention still needs the user's confirmation, so the collapse
+ * must keep its streaming "awaiting confirmation" chrome even when a later
+ * segment has already rendered below it. `areWorkflowToolsComplete` ignores
+ * pending tools, so the completion shortcut must not be applied here.
+ */
+const hasPendingIntervention = (blocks: RenderableAssistantContentBlock[]): boolean =>
+  blocks.some((block) => block.tools?.some((tool) => tool.intervention?.status === 'pending'));
+
 const Group = memo<GroupChildrenProps>(
   ({
     blocks,
@@ -410,10 +433,14 @@ const Group = memo<GroupChildrenProps>(
                   defaultWorkflowExpandLevel={defaultWorkflowExpandLevel}
                   disableEditing={disableEditing}
                   key={segment.blocks[0]?.renderKey ?? `${id}.workflow.${index}`}
-                  workflowChromeComplete={workflowChromeComplete}
                   blocks={segment.blocks.map((block) =>
                     withMarkdownStreamingState(block, lastBlockId),
                   )}
+                  workflowChromeComplete={
+                    workflowChromeComplete ||
+                    (hasRenderedContentAfter(segments, index) &&
+                      !hasPendingIntervention(segment.blocks))
+                  }
                 />
               );
             }


### PR DESCRIPTION
### 💻 Change Type

- [x] 🐛 fix

### 🔀 Description of Change

#### Problem

While an assistant group is still generating, a folded tool-workflow collapse can have a real answer segment rendered **below** it, yet the collapse keeps showing its streaming "working / in-progress" header (spinner + `N tool calls`). Since the model has clearly moved past the tools, this is poor UX.

The group-level `workflowChromeComplete` is `!isGenerating || postToolTailPromoted`, where `postToolTailPromoted` only covers the **promoted-final-answer** path (`getPostToolAnswerSplitIndex`). Other segment-ordering cases that put content after the workflow aren't accounted for — most notably an **errored tool block**, which `partitionBlocks` splits into a folded workflow (the tools) plus a trailing answer segment (the error text). In that case the fold stays stuck in "working".

> Note: the original mixed-block reproduction (a block holding the last tool **and** the final prose, relocated below the fold) was independently removed by #15810, which now renders that prose as a preamble **above** the fold. This PR covers the remaining segment-ordering cases (chiefly the error-tail) and is defensive against future ones.

#### Fix

Derive completeness from segment ordering: a workflow segment that has any rendered content after it is no longer the active step. Add `hasRenderedContentAfter(segments, index)` (ignoring not-yet-streamed empty trailing blocks) and OR it into the per-segment `workflowChromeComplete`.

Guard the shortcut with `hasPendingIntervention`: `areWorkflowToolsComplete` ignores pending-intervention tools and the "Awaiting your confirmation" UI only shows while streaming, so a segment still awaiting user confirmation must keep its streaming chrome even with content below it.

### 📝 Additional Information

Two regression cases added to `Group.test.tsx` (errored multi-tool block, generating):

- content renders below a settled fold → chrome marked complete (fails if the shortcut is reverted, verified)
- one tool has `intervention.status === 'pending'` → chrome stays streaming (fails if the pending-intervention gate is removed, verified)

Also replaced an ambiguous Chinese test fixture string with an English equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)