### PR TITLE
✨ feat(desktop): tray double-click opens main window

### DIFF
--- a/apps/desktop/src/main/core/ui/Tray.ts
+++ b/apps/desktop/src/main/core/ui/Tray.ts
@@ -16,6 +16,12 @@ import type { App } from '../App';
 // Create logger
 const logger = createLogger('core:Tray');
 
+// Debounce window for distinguishing a single-click from the leading edge of
+// a double-click. Electron delivers two `click` events before `double-click`,
+// so we defer the single-click action until this window passes — the
+// `double-click` handler clears it if it arrives in time.
+const CLICK_DEBOUNCE_MS = 250;
+
 export interface TrayOptions {
   /**
    * Tray icon path (relative to resource directory)
@@ -53,6 +59,12 @@ export class Tray {
    * happen automatically if we called `_tray.setContextMenu(menu)`).
    */
   private _contextMenu?: ElectronMenu;
+
+  /**
+   * Pending single-click timer. Cleared by the double-click handler so a
+   * double-click never accidentally fires startSession before showMainWindow.
+   */
+  private _clickTimer?: NodeJS.Timeout;
 
   /**
    * Identifier
@@ -118,10 +130,25 @@ export class Tray {
       // Set default context menu
       this.setContextMenu();
 
-      // Left-click: open Quick Composer.
+      // Left-click: deferred so a follow-up `double-click` can pre-empt it.
       this._tray.on('click', () => {
         logger.debug(`[${this.identifier}] Tray clicked`);
-        this.onClick();
+        if (this._clickTimer) clearTimeout(this._clickTimer);
+        this._clickTimer = setTimeout(() => {
+          this._clickTimer = undefined;
+          this.onClick();
+        }, CLICK_DEBOUNCE_MS);
+      });
+
+      // Double-click (macOS / Windows): cancel the pending single-click and
+      // surface the main window instead.
+      this._tray.on('double-click', () => {
+        logger.debug(`[${this.identifier}] Tray double-clicked`);
+        if (this._clickTimer) {
+          clearTimeout(this._clickTimer);
+          this._clickTimer = undefined;
+        }
+        this.onDoubleClick();
       });
 
       // Right-click: pop the stored context menu manually so left-click stays
@@ -186,6 +213,18 @@ export class Tray {
       void this.app.screenCaptureManager.startSession();
     } catch (error) {
       logger.error(`[${this.identifier}] Failed to start capture session:`, error);
+    }
+  }
+
+  /**
+   * Handle tray double-click event — surfaces the main window.
+   */
+  onDoubleClick() {
+    logger.debug(`[${this.identifier}] Tray double-click → showMainWindow`);
+    try {
+      this.app.browserManager.showMainWindow();
+    } catch (error) {
+      logger.error(`[${this.identifier}] Failed to show main window:`, error);
     }
   }
 
@@ -259,6 +298,10 @@ export class Tray {
    */
   destroy() {
     logger.debug(`Destroying tray instance: ${this.identifier}`);
+    if (this._clickTimer) {
+      clearTimeout(this._clickTimer);
+      this._clickTimer = undefined;
+    }
     if (this._tray) {
       this._tray.destroy();
       this._tray = undefined;

--- a/apps/desktop/src/main/core/ui/__tests__/Tray.test.ts
+++ b/apps/desktop/src/main/core/ui/__tests__/Tray.test.ts
@@ -189,7 +189,7 @@ describe('Tray', () => {
       expect(mockElectronTray.setContextMenu).not.toHaveBeenCalled();
     });
 
-    it('should register both click and right-click listeners', () => {
+    it('should register click, double-click and right-click listeners', () => {
       tray = new Tray(
         {
           iconPath: 'tray.png',
@@ -200,6 +200,7 @@ describe('Tray', () => {
 
       const events = mockElectronTray.on.mock.calls.map((c: any[]) => c[0]);
       expect(events).toContain('click');
+      expect(events).toContain('double-click');
       expect(events).toContain('right-click');
     });
 
@@ -343,6 +344,96 @@ describe('Tray', () => {
       });
 
       expect(() => tray.onClick()).not.toThrow();
+    });
+  });
+
+  describe('onDoubleClick', () => {
+    beforeEach(() => {
+      tray = new Tray(
+        {
+          iconPath: 'tray.png',
+          identifier: 'test-tray',
+        },
+        mockApp,
+      );
+    });
+
+    it('should show the main window', () => {
+      tray.onDoubleClick();
+
+      expect(mockApp.browserManager.showMainWindow).toHaveBeenCalled();
+    });
+
+    it('should not start the capture session', () => {
+      tray.onDoubleClick();
+
+      expect(mockApp.screenCaptureManager.startSession).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when showMainWindow throws', () => {
+      vi.mocked(mockApp.browserManager.showMainWindow).mockImplementationOnce(() => {
+        throw new Error('window failed');
+      });
+
+      expect(() => tray.onDoubleClick()).not.toThrow();
+    });
+  });
+
+  describe('click vs double-click handling', () => {
+    let clickHandler: (() => void) | undefined;
+    let doubleClickHandler: (() => void) | undefined;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      tray = new Tray(
+        {
+          iconPath: 'tray.png',
+          identifier: 'test-tray',
+        },
+        mockApp,
+      );
+
+      clickHandler = mockElectronTray.on.mock.calls.find((c: any[]) => c[0] === 'click')?.[1];
+      doubleClickHandler = mockElectronTray.on.mock.calls.find(
+        (c: any[]) => c[0] === 'double-click',
+      )?.[1];
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should debounce single click before calling startSession', () => {
+      expect(clickHandler).toBeDefined();
+
+      clickHandler?.();
+      expect(mockApp.screenCaptureManager.startSession).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(250);
+      expect(mockApp.screenCaptureManager.startSession).toHaveBeenCalledTimes(1);
+    });
+
+    it('should cancel the pending single click when double-click fires', () => {
+      expect(clickHandler).toBeDefined();
+      expect(doubleClickHandler).toBeDefined();
+
+      clickHandler?.();
+      clickHandler?.();
+      doubleClickHandler?.();
+
+      vi.advanceTimersByTime(1000);
+
+      expect(mockApp.screenCaptureManager.startSession).not.toHaveBeenCalled();
+      expect(mockApp.browserManager.showMainWindow).toHaveBeenCalledTimes(1);
+    });
+
+    it('should only fire startSession once per single-click burst', () => {
+      clickHandler?.();
+      clickHandler?.();
+
+      vi.advanceTimersByTime(250);
+
+      expect(mockApp.screenCaptureManager.startSession).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Adds a double-click handler to the desktop tray icon that surfaces the main window via `browserManager.showMainWindow()`. Single-click behavior (start a Quick Composer capture session) is preserved.

Because Electron delivers two `click` events before `double-click`, the single-click action is now deferred by a 250ms debounce. If a `double-click` lands inside that window, the pending single-click is cancelled and the main window opens instead.

Platform behavior:

| Platform | Single click | Double click |
| --- | --- | --- |
| macOS | `startSession` after 250ms | `showMainWindow` |
| Windows | `startSession` after 250ms | `showMainWindow` |
| Linux | Unchanged — AppIndicator does not emit click events; only the right-click menu is reachable | Same |

Files touched:

- `apps/desktop/src/main/core/ui/Tray.ts` — debounce single-click, add `double-click` handler and `onDoubleClick()` method, clear pending timer on `destroy()`
- `apps/desktop/src/main/core/ui/__tests__/Tray.test.ts` — new tests for the double-click handler, debounce behavior, and pending-click cancellation

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Unit: `cd apps/desktop && bunx vitest run src/main/core/ui/__tests__/Tray.test.ts` — 35 tests pass.

Manual (macOS / Windows):

1. Launch the desktop app, ensure the tray icon is visible.
2. Single-click the tray icon → after a brief delay, the Quick Composer capture overlay starts.
3. Double-click the tray icon → the main window is shown / focused; capture does **not** start.
4. Right-click the tray icon → the context menu still appears.

#### 📸 Screenshots / Videos

N/A — tray behavior only.

#### 📝 Additional Information

The 250ms debounce is a tradeoff between perceived responsiveness on single click and the system's double-click threshold (macOS default ~500ms). Slow double-clicks may still be misread as two single-clicks; if that turns out to be a problem in practice we can dial it up.