### PR TITLE
🐛 fix(chat): derive operation token usage from messages, not a parallel accumulation

### DIFF
--- a/src/features/Conversation/ChatInput/OpStatusTray.tsx
+++ b/src/features/Conversation/ChatInput/OpStatusTray.tsx
@@ -12,12 +12,7 @@ import { useChatStore } from '@/store/chat';
 import { operationSelectors } from '@/store/chat/selectors';
 import { AI_RUNTIME_OPERATION_TYPES } from '@/store/chat/slices/operation/types';
 import { shinyTextStyles } from '@/styles';
-import {
-  calculateOperationUsageMetrics,
-  hasOperationUsageMetrics,
-  mergeOperationUsageMetrics,
-  type OperationUsageMetrics,
-} from '@/utils/operationUsageMetrics';
+import { calculateOperationUsageMetrics } from '@/utils/operationUsageMetrics';
 
 import { contextSelectors, dataSelectors, useConversationStore } from '../store';
 import { type ActivityKey, resolveOperationActivity } from '../utils/operationActivity';
@@ -238,7 +233,6 @@ const OpStatusTray = memo<OpStatusTrayProps>(({ topAttached }) => {
     let latestActivityStart = -1;
     let statusSeed: string | undefined;
     let stepCount = 0;
-    let usageMetrics: OperationUsageMetrics | undefined;
     const runtimeOperationIds: string[] = [];
 
     for (const op of ops) {
@@ -256,9 +250,6 @@ const OpStatusTray = memo<OpStatusTrayProps>(({ topAttached }) => {
 
       runtimeOperationIds.push(op.id);
       stepCount = Math.max(stepCount, normalizeStepCount(op.metadata.stepCount));
-      if (hasOperationUsageMetrics(op.metadata.usageMetrics)) {
-        usageMetrics = mergeOperationUsageMetrics(usageMetrics, op.metadata.usageMetrics);
-      }
 
       if (earliestStart === undefined || op.metadata.startTime < earliestStart) {
         earliestStart = op.metadata.startTime;
@@ -271,7 +262,6 @@ const OpStatusTray = memo<OpStatusTrayProps>(({ topAttached }) => {
       startTime: earliestStart,
       statusSeed,
       steps: stepCount,
-      usageMetrics,
     };
   });
   const operationsByMessage = useChatStore((s) => s.operationsByMessage);
@@ -289,17 +279,16 @@ const OpStatusTray = memo<OpStatusTrayProps>(({ topAttached }) => {
     [operationState.operationIdsKey],
   );
 
-  // Fallback for older / reloaded operation state: derive usage from messages
-  // produced by this operation when live operation metadata is unavailable.
-  const fallbackMetrics = useMemo(() => {
+  // Single source of truth: derive the operation total from the same per-message
+  // usage shown on each bubble, so the tray always equals their sum. (Updates as
+  // messages refresh — no separate live accumulation that can drift.)
+  const usageMetrics = useMemo(() => {
     return calculateOperationUsageMetrics(dbMessages, operationIds, operationsByMessage);
   }, [dbMessages, operationIds, operationsByMessage]);
 
   if (!operationState.startTime) return null;
 
-  const { totalCost, totalTokens } = hasOperationUsageMetrics(operationState.usageMetrics)
-    ? operationState.usageMetrics
-    : fallbackMetrics;
+  const { totalCost, totalTokens } = usageMetrics;
   const elapsed = now - operationState.startTime;
   const costLabel = t('chat:opStatusTray.cost');
   const stepLabel = t('chat:opStatusTray.steps');

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -39,7 +39,7 @@ function createMockStore() {
     operations: {
       'op-1': {
         context: { agentId: 'agent-1', scope: 'session', topicId: 'topic-1' },
-        metadata: { startTime: 0, usageMetrics: { totalTokens: 100 } },
+        metadata: { startTime: 0 },
       },
     } as Record<string, any>,
     replaceMessages: vi.fn(),
@@ -661,29 +661,6 @@ describe('createGatewayEventHandler', () => {
       handler(makeEvent('step_complete', { phase: 'human_approval' }));
       await flush();
 
-      expect(store.replaceMessages).not.toHaveBeenCalled();
-    });
-
-    it('should accumulate turn metadata usage onto the operation', async () => {
-      const store = createMockStore();
-      const handler = createHandler(store);
-
-      handler(
-        makeEvent('step_complete', {
-          phase: 'turn_metadata',
-          usage: { cost: 0.2, totalInputTokens: 40, totalOutputTokens: 10, totalTokens: 50 },
-        }),
-      );
-      await flush();
-
-      expect(store.updateOperationMetadata).toHaveBeenCalledWith('op-1', {
-        usageMetrics: {
-          totalCost: 0.2,
-          totalInputTokens: 40,
-          totalOutputTokens: 10,
-          totalTokens: 150,
-        },
-      });
       expect(store.replaceMessages).not.toHaveBeenCalled();
     });
   });

--- a/src/store/chat/slices/aiChat/actions/__tests__/heterogeneousAgentExecutor.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/heterogeneousAgentExecutor.test.ts
@@ -720,7 +720,7 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
     it('should persist per-step usage to each step assistant message, not accumulated', async () => {
       // Realistic CC partial-messages flow: message_start primes the turn,
       // assistant events echo a stale usage, message_delta carries the final.
-      const { store } = await runWithEvents([
+      await runWithEvents([
         ccInit(),
         ccMessageStart('msg_01'),
         ccAssistant('msg_01', [{ text: 'a', type: 'text' }]),
@@ -769,13 +769,6 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
       // No cache tokens for this turn — these fields should be absent
       expect(u2.inputCachedTokens).toBeUndefined();
       expect(u2.inputWriteCacheTokens).toBeUndefined();
-
-      expect(store.operations['op-1'].metadata.usageMetrics).toEqual({
-        totalCost: 0,
-        totalInputTokens: 650,
-        totalOutputTokens: 130,
-        totalTokens: 780,
-      });
     });
 
     it('should ignore stale usage on assistant events (from message_start echo)', async () => {

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -19,7 +19,6 @@ import { messageService } from '@/services/message';
 import { emitClientAgentSignalSourceEvent } from '@/store/chat/slices/aiChat/actions/agentSignalBridge';
 import type { ChatStore } from '@/store/chat/store';
 import { notifyDesktopHumanApprovalRequired } from '@/store/chat/utils/desktopNotification';
-import { addUsageToOperationMetrics, type OperationUsageLike } from '@/utils/operationUsageMetrics';
 
 // Lazy-loaded to break the import cycle:
 //   gateway.ts → gatewayEventHandler.ts → executors/index.ts (which pulls in
@@ -55,10 +54,6 @@ interface ToolPayloadIdentity {
   params: unknown;
   toolCallId?: string;
 }
-
-type StepCompleteDataWithUsage = StepCompleteData & {
-  usage?: OperationUsageLike | null;
-};
 
 /**
  * Extract `{ identifier, apiName, params, toolCallId }` from a stream event's
@@ -512,14 +507,7 @@ export const createGatewayEventHandler = (
       }
 
       case 'step_complete': {
-        const data = event.data as StepCompleteDataWithUsage | undefined;
-
-        if (data?.phase === 'turn_metadata' && data.usage) {
-          const operation = get().operations[operationId];
-          get().updateOperationMetadata(operationId, {
-            usageMetrics: addUsageToOperationMetrics(operation?.metadata?.usageMetrics, data.usage),
-          });
-        }
+        const data = event.data as StepCompleteData | undefined;
 
         // Refresh on execution_complete to ensure final step state is consistent
         if (data?.phase === 'execution_complete') {

--- a/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
@@ -38,7 +38,6 @@ import { threadService } from '@/services/thread';
 import { type ChatStore, useChatStore } from '@/store/chat/store';
 import { resolveNotificationNavigatePath } from '@/store/chat/utils/desktopNotification';
 import { markdownToTxt } from '@/utils/markdownToTxt';
-import { addUsageToOperationMetrics } from '@/utils/operationUsageMetrics';
 
 import { messageMapKey } from '../../../utils/messageMapKey';
 import { mergeQueuedMessages } from '../../operation/types';
@@ -1197,19 +1196,11 @@ export const executeHeterogeneousAgent = async (
       // ─── step_complete with turn_metadata: per-step usage + model/provider ───
       // The reducer writes usage/model/provider onto the current step's
       // assistant (main) or the subagent's in-thread assistant (delegated).
-      // `result_usage` (grand total) is ignored by the reducer. Main usage also
-      // feeds the operation's usage-metrics tray — a renderer-only side effect
-      // the reducer doesn't model, so it stays here. Not forwarded (bookkeeping).
+      // `result_usage` (grand total) is ignored by the reducer. The operation
+      // usage tray derives its total from these per-message usages directly
+      // (OpStatusTray → calculateOperationUsageMetrics), so there is no separate
+      // accumulation here. Not forwarded (bookkeeping).
       if (event.type === 'step_complete' && event.data?.phase === 'turn_metadata') {
-        if (!event.data.subagent && event.data.usage) {
-          const operation = get().operations[operationId];
-          get().updateOperationMetadata(operationId, {
-            usageMetrics: addUsageToOperationMetrics(
-              operation?.metadata?.usageMetrics,
-              event.data.usage,
-            ),
-          });
-        }
         persistQueue = persistQueue.then(() => reduceAndApplyMain(event));
         return;
       }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

The operation status tray (bottom-right of the chat input) showed a cumulative token count far higher than the sum of the per-message token badges — e.g. ~8M in the tray vs ~2.2M summing the bubbles — most visibly in long Claude Code (heterogeneous agent) runs.

#### 🔀 Description of Change

There were **two independent token computations for one operation**:

1. **The tray** kept its own running total by summing every `turn_metadata` event's usage via `addUsageToOperationMetrics` (`OpStatusTray` read `operation.metadata.usageMetrics`).
2. **Each message** got its usage written via the `recordUsage` intent.

They diverge by construction:

- `recordUsage` **overwrites** an assistant message's usage — when several agentic turns map to one message, only the last turn survives.
- The tray **added** every turn, and each turn's `totalTokens` includes `cache_read_input_tokens`. In an agentic loop the whole context is re-read (cache-read) every turn, so the same context got counted once per turn → massive inflation.

**Fix:** make the per-message usage the single source of truth.

- `OpStatusTray` now **always** derives the total from `calculateOperationUsageMetrics(messages)` (previously only a fallback when live metadata was absent).
- Removed the parallel `addUsageToOperationMetrics` accumulation from both the heterogeneous-agent executor and the gateway event handler (plus the now-dead `StepCompleteDataWithUsage` type / imports).

The tray now equals the sum of the per-message badges and updates as messages refresh.

**Trade-off:** the tray total now advances when messages refresh (`fetchAndReplaceMessages`) rather than on every streamed turn event — a small lag mid-generation, in exchange for a single, consistent number.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Updated `heterogeneousAgentExecutor.test.ts` and `gatewayEventHandler.test.ts`: dropped the obsolete "accumulate onto the operation" assertions; the per-message usage assertions (the data now relied upon) all stay green.
- Run: `bunx vitest run src/store/chat/slices/aiChat/actions/__tests__/heterogeneousAgentExecutor.test.ts src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts src/utils/operationUsageMetrics.test.ts` → 110 passed.
- Manual: run a multi-turn Claude Code session and confirm the tray token count matches the sum of the per-message badges.

#### 📝 Additional Information

Net `+13 / -75` — removes a duplicate code path. The change is generic, so long homogeneous chats (multi-turn + caching) are fixed too, not just heterogeneous agents.