### PR TITLE
🐛 fix: infer custom embedding model types

### DIFF
--- a/packages/model-runtime/src/utils/getFallbackModelProperty.test.ts
+++ b/packages/model-runtime/src/utils/getFallbackModelProperty.test.ts
@@ -181,6 +181,16 @@ describe('getModelPropertyWithFallback', () => {
       expect(result).toBe('chat');
     });
 
+    it('should infer embedding type for unknown embedding-like model IDs', async () => {
+      const result = await getModelPropertyWithFallback('bge-m3', 'type', 'newapi');
+      expect(result).toBe('embedding');
+    });
+
+    it('should infer embedding type case-insensitively for custom model IDs', async () => {
+      const result = await getModelPropertyWithFallback('TEXT-EMBEDDING-3-SMALL', 'type');
+      expect(result).toBe('embedding');
+    });
+
     it('should return undefined for non-type properties when model not found', async () => {
       const result = await getModelPropertyWithFallback('non-existent-model', 'displayName');
       expect(result).toBeUndefined();

--- a/packages/model-runtime/src/utils/getFallbackModelProperty.ts
+++ b/packages/model-runtime/src/utils/getFallbackModelProperty.ts
@@ -1,8 +1,20 @@
-import type { AiFullModelCard, LobeDefaultAiModelListItem } from 'model-bank';
+import type { AiFullModelCard, AiModelType, LobeDefaultAiModelListItem } from 'model-bank';
+
+import { EMBEDDING_MODEL_KEYWORDS } from './modelTypeKeywords';
 
 interface BusinessModelConfigModule {
   loadModels: () => Promise<LobeDefaultAiModelListItem[]>;
 }
+
+const getDefaultModelType = (modelId: string): AiModelType => {
+  const lowerModelId = modelId.toLowerCase();
+
+  if (EMBEDDING_MODEL_KEYWORDS.some((keyword) => lowerModelId.includes(keyword))) {
+    return 'embedding';
+  }
+
+  return 'chat';
+};
 
 /**
  * Get the model property value, first from the specified provider, and then from other providers as a fallback.
@@ -37,5 +49,5 @@ export const getModelPropertyWithFallback = async <T>(
   }
 
   // Step 3: Return a default value
-  return (propertyName === 'type' ? 'chat' : undefined) as T;
+  return (propertyName === 'type' ? getDefaultModelType(modelId) : undefined) as T;
 };

--- a/packages/model-runtime/src/utils/modelParse.ts
+++ b/packages/model-runtime/src/utils/modelParse.ts
@@ -10,6 +10,8 @@ import type {
 import { AiModelTypeSchema, ModelProvider } from 'model-bank';
 
 import type { ModelProviderKey } from '../types';
+import { EMBEDDING_MODEL_KEYWORDS } from './modelTypeKeywords';
+export { EMBEDDING_MODEL_KEYWORDS } from './modelTypeKeywords';
 
 export interface ModelProcessorConfig {
   excludeKeywords?: readonly string[]; // Do not add tags to models that match
@@ -209,9 +211,6 @@ export const IMAGE_MODEL_KEYWORDS = [
   '^V_2',
   '^V_1',
 ] as const;
-
-// Embedding model keyword configuration
-export const EMBEDDING_MODEL_KEYWORDS = ['embedding', 'embed', 'bge', 'm3e'] as const;
 
 const AI_MODEL_TYPE_SET = new Set<AiModelType>(AiModelTypeSchema.options);
 

--- a/packages/model-runtime/src/utils/modelTypeKeywords.ts
+++ b/packages/model-runtime/src/utils/modelTypeKeywords.ts
@@ -1,0 +1,1 @@
+export const EMBEDDING_MODEL_KEYWORDS = ['embedding', 'embed', 'bge', 'm3e'] as const;

--- a/src/utils/server/parseModels.test.ts
+++ b/src/utils/server/parseModels.test.ts
@@ -35,6 +35,24 @@ describe('parseModelString', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('infers embedding type for custom embedding model ids', async () => {
+    const result = await parseModelString('newapi', '+bge-m3=bge-m3,+text-embedding-custom');
+
+    expect(result.add).toEqual([
+      {
+        abilities: {},
+        displayName: 'bge-m3',
+        id: 'bge-m3',
+        type: 'embedding',
+      },
+      {
+        abilities: {},
+        id: 'text-embedding-custom',
+        type: 'embedding',
+      },
+    ]);
+  });
+
   it('empty string model', async () => {
     const result = await parseModelString(
       'test-provider',


### PR DESCRIPTION
#### Change Type

- [x] fix
- [x] test

#### Related Issue

Fixes #15720
Related to #15520, #15367, #15127

#### Description of Change

This PR keeps the server/env model-list parsing path aligned with the dynamic model-list parser for custom embedding models.

Previously, when a custom model configured through env strings such as NEWAPI_MODEL_LIST=+bge-m3=bge-m3 was not found in the builtin model bank, getModelPropertyWithFallback(..., 'type') always returned chat. That made embedding-like custom model IDs such as ge-m3 appear as chat models.

The change:

- shares the embedding model keyword list used by modelParse
- uses that keyword list when the fallback model type is requested for an unknown model
- preserves the existing chat default for non-embedding custom model IDs
- adds regression coverage for both getModelPropertyWithFallback and parseModelString

#### How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

`ash
corepack pnpm exec vitest run --silent='passed-only' src/utils/server/parseModels.test.ts
corepack pnpm exec vitest run --silent='passed-only' --dir packages/model-runtime src/utils/getFallbackModelProperty.test.ts
corepack pnpm exec prettier --check packages/model-runtime/src/utils/getFallbackModelProperty.ts packages/model-runtime/src/utils/getFallbackModelProperty.test.ts packages/model-runtime/src/utils/modelParse.ts packages/model-runtime/src/utils/modelTypeKeywords.ts src/utils/server/parseModels.test.ts
git diff --check
`

#### Screenshots / Videos

No UI changes.

#### Additional Information

While installing local dependencies on Windows, pnpm install ended with the repository prepare script failing because 	rue is not available in the Windows shell. The install had already populated 
ode_modules, and the targeted tests above were run successfully afterward.