### PR TITLE
📝 docs(skills): add ux design-values & execution-checklist skill

### DIFF
--- a/.agents/skills/react/SKILL.md
+++ b/.agents/skills/react/SKILL.md
@@ -55,17 +55,9 @@ For Modal specifically, see the dedicated **modal** skill — use the imperative
 
 ## Loading indicators
 
-**Do NOT use antd `Spin` / `<Spin />`** — it doesn't match the product's loading
-visual. Use the project loaders in `src/components` instead:
-
-| Need                           | Component                                                                     |
-| ------------------------------ | ----------------------------------------------------------------------------- |
-| Default loading (spinner spot) | `NeuralNetworkLoading` from `@/components/NeuralNetworkLoading` (`size` prop) |
-| Inline dots                    | `DotsLoading` / `BubblesLoading` from `@/components`                          |
-| Branded full-page              | `Loading` from `@/components/Loading/BrandTextLoading`                        |
-
-When in doubt, reach for `NeuralNetworkLoading` — it is the default in-flight
-indicator (e.g. modal "in progress" states).
+**Do NOT use antd `Spin` / `<Spin />`.** Use a project loader
+(`NeuralNetworkLoading`, `DotsLoading`, …) — see the **ux** skill ("Loading
+visuals") for the component table and when to use each.
 
 ## State
 
@@ -122,16 +114,16 @@ errorElement: <ErrorBoundary />;
 
 ## Common Mistakes
 
-| Mistake                                                            | Fix                                                                                          |
-| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| Using `next/link` in SPA                                           | Use `react-router-dom` `Link`                                                                |
-| Using antd directly                                                | Use `@lobehub/ui/base-ui` first, then `@lobehub/ui`                                          |
-| antd `Spin` / `<Spin />` for loading                               | Use `NeuralNetworkLoading` from `@/components/NeuralNetworkLoading` (see Loading indicators) |
-| `import { Select } from '@lobehub/ui'`                             | `import { Select } from '@lobehub/ui/base-ui'`                                               |
-| `import { Modal } from '@lobehub/ui'` + `<Modal open>` declarative | `createModal` / `confirmModal` from `@lobehub/ui/base-ui` (see modal skill)                  |
-| `import { DropdownMenu/Popover/Switch } from '@lobehub/ui'`        | Import same name from `@lobehub/ui/base-ui` instead                                          |
-| `createStyles` for static styles                                   | Use `createStaticStyles` + `cssVar`                                                          |
-| Editing only `desktopRouter.config.tsx`                            | Must edit both `.tsx` and `.desktop.tsx`                                                     |
-| Using `margin` for flex spacing                                    | Use `gap` prop on Flexbox                                                                    |
-| Accessing zustand store without selector                           | Use selectors to access store data (see zustand skill)                                       |
-| Text or icon-text actions built with `Flexbox`/`Text` + `onClick`  | Use `Button type={'text'} size={'small'}` with `icon` when needed                            |
+| Mistake                                                            | Fix                                                                         |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| Using `next/link` in SPA                                           | Use `react-router-dom` `Link`                                               |
+| Using antd directly                                                | Use `@lobehub/ui/base-ui` first, then `@lobehub/ui`                         |
+| antd `Spin` / `<Spin />` for loading                               | Use `NeuralNetworkLoading` / project loaders (see the **ux** skill)         |
+| `import { Select } from '@lobehub/ui'`                             | `import { Select } from '@lobehub/ui/base-ui'`                              |
+| `import { Modal } from '@lobehub/ui'` + `<Modal open>` declarative | `createModal` / `confirmModal` from `@lobehub/ui/base-ui` (see modal skill) |
+| `import { DropdownMenu/Popover/Switch } from '@lobehub/ui'`        | Import same name from `@lobehub/ui/base-ui` instead                         |
+| `createStyles` for static styles                                   | Use `createStaticStyles` + `cssVar`                                         |
+| Editing only `desktopRouter.config.tsx`                            | Must edit both `.tsx` and `.desktop.tsx`                                    |
+| Using `margin` for flex spacing                                    | Use `gap` prop on Flexbox                                                   |
+| Accessing zustand store without selector                           | Use selectors to access store data (see zustand skill)                      |
+| Text or icon-text actions built with `Flexbox`/`Text` + `onClick`  | Use `Button type={'text'} size={'small'}` with `icon` when needed           |

--- a/.agents/skills/ux/SKILL.md
+++ b/.agents/skills/ux/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: ux
+description: 'LobeHub product design values (自然 Natural / 意义感 Meaningful / 确定性 Certainty / 生长性 Growth) and per-aspect UX execution checklists. Use when designing or reviewing any user-facing flow — empty/loading/error states, confirmations, async feedback, button hierarchy, action parity, lists at scale, pickers, discoverability, and loading visuals.'
+user-invocable: false
+---
+
+# UX — Design Values & Execution Checklists
+
+How LobeHub products should feel, and concrete rules to get there. Use this when
+**building or reviewing** any user-facing flow. For component/styling choices see
+**react**, for wording see **microcopy**, for imperative modal wiring see **modal**.
+
+## Design values (设计价值观)
+
+LobeHub follows four product design values — **自然 Natural・意义感 Meaningful・
+确定性 Certainty・生长性 Growth**. Read them before designing:
+**[references/design-values.md](references/design-values.md)** (definitions +
+conflict priority).
+
+> The checklists below are the execution layer. Each item is tagged with the
+> value(s) it serves; for what those values mean, see the file above.
+
+## 1. Flow & momentum (操作链路)・自然・意义感
+
+Every action chain must **push the user forward**, never dead-end or block the flow.
+
+- [ ] **Forward momentum** — after any operation, lead the user to the next step,
+      don't just stop. _(意义感)_
+- [ ] **Success state = primary "go to result", secondary "dismiss"** — the strong
+      button is the forward action (take me to the result); "Done" is the weak/
+      secondary button. ✅ After moving topics: primary = "Go to «target»", secondary
+      \= "Done". _(意义感・自然)_
+- [ ] **Bulk ⇄ single-item parity** — an action on a multi-select toolbar must also
+      be reachable on a single item (its context menu), and vice versa. _(确定性)_
+- [ ] **Confirm → in-progress → done, in one surface** — bulk/irreversible/async
+      ops use a modal state machine: a confirm step stating exactly what happens →
+      an in-progress view with **dismissal locked** → a done (or error) view in the
+      same modal. Never fire-and-forget with only a toast; never leave a dead
+      spinner. _(确定性・意义感)_
+
+## 2. States: empty /loading/error (状态设计)・意义感・确定性
+
+Every data surface has **four** states — design all of them, not just "has data".
+
+- [ ] **Empty state is a purpose-built page, not a blank screen.** It explains what
+      this is, why it's empty, and gives a clear next action (CTA + value props).
+      ✅ Devices: an empty "Connect your first device" page with primary/secondary
+      connect paths and "what you can do once connected" cards — ❌ not a bare title
+      over skeleton rows or a blank body. _(意义感)_
+- [ ] **Distinguish the empty variants** — "no data yet" (onboarding CTA) vs
+      "no match for filters" (clear-filters affordance) are different screens. _(确定性)_
+- [ ] **Loading state** designed (skeleton / NeuralNetworkLoading), not a flash of
+      blank or layout shift. _(自然)_
+- [ ] **Error state** designed — surface the reason and a retry/back path. _(意义感)_
+
+## 3. Buttons & focus (按钮与焦点)・确定性
+
+- [ ] **One primary button per surface.** The single primary CTA tells the user the
+      core action; everything else is secondary/tertiary. Never a pile of primary
+      buttons competing for attention. _(确定性)_
+
+## 4. Lists at scale (列表与规模)・确定性・自然
+
+A list/data page must be designed for its **whole range of sizes**, not just the
+demo data.
+
+- [ ] **Walk the scale: 1 / 2 / 5 / 20 / 100 / 1k–10k rows.** Pick the right
+      mechanism per range — plain render → load-more / pagination → virtual scroll;
+      add batch-select / bulk actions once counts get large. _(确定性)_
+- [ ] **Co-design empty / loading / error with the data state** (see §2). A list
+      isn't done until all four render well. _(自然)_
+
+## 5. Option visibility (选项可见性)・确定性・意义感
+
+- [ ] **Pickers list every valid target.** Watch for options dropped by backend
+      list queries (pagination, `virtual` flags, scope filters) and add them back.
+      ✅ The default "LobeAI" (inbox) agent is `virtual` and excluded from the
+      sidebar list, so the move picker re-adds it. An empty picker must mean
+      "genuinely none", never "we filtered out the only option". _(意义感)_
+
+## 6. Loading visuals (Loading 视觉)・自然
+
+**Never use antd `Spin`** — it doesn't match the product's loading visual. Use a
+project loader:
+
+| Need                        | Component                                                                     |
+| --------------------------- | ----------------------------------------------------------------------------- |
+| Default loading (in-flight) | `NeuralNetworkLoading` from `@/components/NeuralNetworkLoading` (`size` prop) |
+| Inline dots                 | `DotsLoading` / `BubblesLoading` from `@/components`                          |
+| Branded full-page           | `Loading` from `@/components/Loading/BrandTextLoading`                        |
+| List / card placeholder     | a skeleton (e.g. `SkeletonList`)                                              |
+
+When in doubt, reach for `NeuralNetworkLoading` — it's the default in-flight
+indicator (e.g. modal "in progress" states).
+
+## 7. Discoverability & growth (可发现性与生长)・生长性
+
+The product should grow with the user — deeper power shows up as needs deepen.
+
+- [ ] **Progressive disclosure** — keep the novice path clean; reveal advanced
+      capabilities as the user gets there, don't dump everything at once. _(生长性・自然)_
+- [ ] **Surface related actions at the moment of need** — make the next capability
+      discoverable in context (e.g. after the first item exists, offer what to do
+      with it), not buried in a far-off menu. _(生长性・意义感)_
+
+## 8. Entity lifecycle completeness (实体生命周期完整性)・意义感・确定性
+
+The recurring trap: a feature ships only the **display** of a list, but edit /
+delete / management are never built — so the user can add something and then be
+stuck with it. For every entity a user can see, design its **full lifecycle**:
+create / read / update / delete, plus state transitions (enable/disable,
+connect/disconnect, install/uninstall). A read-only list the user can't manage
+breaks the flow.
+
+**The allowed operation set depends on the entity's source / ownership** — decide
+it explicitly _before_ building. Worked example, the tools/connectors list:
+
+| Entity class                        | Add     | Edit      | Remove             |
+| ----------------------------------- | ------- | --------- | ------------------ |
+| Official / built-in (skills, tools) | —       | —         | ✗ not removable    |
+| Community (installed MCP)           | install | configure | uninstall / remove |
+| User-custom (custom connector)      | create  | edit      | delete             |
+
+- [ ] **No display-only features.** For every listed entity, enumerate CRUD +
+      lifecycle ops and build the ones that apply. _(意义感)_
+- [ ] **Operation set per source/ownership class** — built-in may be read-only;
+      anything the user _installed_ must be removable; anything the user _created_
+      must be editable **and** deletable. _(确定性)_
+- [ ] **Each item exposes its allowed ops** (hover action / context menu / detail
+      page), and there's a clear entry point to add/create where applicable. _(自然)_
+- [ ] **An intentionally-absent op is a documented decision, not an oversight**
+      (e.g. official tools can't be deleted — by design). _(确定性)_
+
+## Quick review checklist
+
+- [ ] Action leads the user forward; success offers a primary "go to result".
+- [ ] Bulk action has a single-item entry (and vice versa).
+- [ ] Async/bulk/irreversible action: confirm → in-progress (locked) → done/error.
+- [ ] Empty / loading / error states are all designed; empty is a real page with a CTA.
+- [ ] Exactly one primary button per surface.
+- [ ] List designed across 1 → 10k rows (virtual scroll / pagination / batch as needed).
+- [ ] Pickers show all valid targets (default/inbox included); empty = truly none.
+- [ ] No antd `Spin`; use `NeuralNetworkLoading` / project loaders.
+- [ ] Advanced capability is progressively disclosed / discoverable at the moment of need.
+- [ ] Listed entities have their full lifecycle (not display-only); ops match source (built-in / installed / custom).
+
+## Related skills
+
+- **modal** — imperative `createModal` state-machine wiring for confirm/progress/done.
+- **microcopy** — wording for confirm / done / empty / error states.
+- **react** — component priority, `Button` usage, styling.

--- a/.agents/skills/ux/references/design-values.md
+++ b/.agents/skills/ux/references/design-values.md
@@ -1,0 +1,51 @@
+# LobeHub Design Values (设计价值观)
+
+The philosophy behind every LobeHub interface. Read this before designing or
+reviewing a flow; the per-aspect execution rules live in the parent
+[SKILL.md](../SKILL.md) and each checklist item is tagged with the value(s) it serves.
+
+Adapted from Ant Design's design values
+(<https://ant.design/docs/spec/values-cn>, <https://zhuanlan.zhihu.com/p/44809866>).
+LobeHub adopts all four.
+
+## 自然 (Natural)
+
+Minimise cognitive load. Digital products keep getting more complex while human
+attention stays scarce — so the interface should feel as effortless as the
+physical world. The next step should be obvious without thinking; the product
+proactively carries the user forward (sensible defaults, AI-assisted decisions,
+smooth transitions) rather than making them stop and figure things out.
+
+## 意义感 (Meaningful)
+
+Every screen is rooted in the user's real goal, not an isolated feature. Make the
+objective clear, give immediate feedback on the result of each action, and always
+point at the next meaningful step. Calibrate difficulty — neither a patronising
+over-simplification nor an overwhelming wall — so the user keeps a sense of
+progress and accomplishment.
+
+## 确定性 (Certainty)
+
+Low-entropy, predictable interactions. Reuse the same patterns, components, and
+wording so behaviour is never surprising. Keep a single clear focus per surface,
+and design **every** state (empty / loading / error / success) so nothing is left
+undefined. Restraint over cleverness: fewer, consistent rules beat many bespoke
+ones.
+
+## 生长性 (Growth)
+
+The product grows together with the user. As needs deepen and roles evolve,
+surface advanced capabilities progressively and make related features
+discoverable at the moment they become relevant — without crowding the novice
+path. Bridge product value to the user's changing scenarios and aim for
+human–machine symbiosis (人机共生): the user and the agent co-evolve, each making
+the other more capable over time.
+
+## Priority when values conflict
+
+For moment-to-moment interaction decisions: **意义感 ≳ 自然 > 确定性** — never
+sacrifice the user's goal or forward momentum just to keep things uniform.
+
+**生长性 (Growth)** is a longer-horizon lens: weigh it when shaping how a feature
+is discovered and how it scales with the user, not when resolving a single-screen
+layout trade-off.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,3 +136,5 @@ bun run type-check
 ### Code Review
 
 Before reviewing a PR / diff / branch change, read the **review-checklist** skill (`.agents/skills/review-checklist/SKILL.md`) — it lists the recurring mistakes specific to this codebase.
+
+When designing or reviewing user-facing flows (empty/loading/error states, confirmations, async feedback, button hierarchy, lists at scale, pickers), follow the **ux** skill (`.agents/skills/ux/SKILL.md`) — LobeHub's design values (自然 / 意义感 / 确定性) plus per-aspect execution checklists.


### PR DESCRIPTION
#### 💻 Change Type

- [x] 📝 docs

#### 🔗 Related Issue

N/A — distills UX conventions surfaced while reviewing the move-topics feature.

#### 🔀 Description of Change

Adds a new **`ux`** agent skill capturing LobeHub's product design philosophy and how to execute on it.

- **Design values** in a dedicated reference file (`.agents/skills/ux/references/design-values.md`): **自然 Natural · 意义感 Meaningful · 确定性 Certainty · 生长性 Growth** (adapted from Ant Design's design values), with definitions and a conflict-priority note. Kept out of the skill index per separation of philosophy vs. execution.
- **Execution checklists** in `SKILL.md`, one section per aspect, each item tagged with the value(s) it serves:
  - Flow & momentum — push the user forward; success state = primary "go to result".
  - States — empty / loading / error all designed; empty is a purpose-built page with a CTA, not a blank/skeleton screen.
  - Buttons & focus — exactly one primary button per surface.
  - Lists at scale — design for 1 → 10k rows (virtual scroll / pagination / batch).
  - Option visibility — pickers list all valid targets (e.g. the virtual inbox agent).
  - Loading visuals — no antd `Spin`; use `NeuralNetworkLoading` / project loaders (component table moved here from the `react` skill).
  - Discoverability & growth — progressive disclosure; surface the next capability in context.
- `react` skill now points to `ux` for loading components (table de-duplicated).
- `AGENTS.md` references the `ux` skill for designing/reviewing user-facing flows.

Docs-only; no code or behavior changes.

#### 🧪 How to Test

- [x] No tests needed

Markdown-only; passes the repo's remark/prettier pre-commit formatting.