### PR TITLE
✨ feat(electron): open a new Home tab from the tab bar "+" button

### DIFF
--- a/src/features/Electron/titlebar/TabBar/index.tsx
+++ b/src/features/Electron/titlebar/TabBar/index.tsx
@@ -21,27 +21,21 @@ import { useTranslation } from 'react-i18next';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { usePermission } from '@/hooks/usePermission';
 import { electronSystemService } from '@/services/electron/system';
-import { desktopRoutes } from '@/spa/router/desktopRouter.config';
-import { type NewTabAction } from '@/spa/router/routeMeta';
 import { useElectronStore } from '@/store/electron';
 import { electronStylish } from '@/styles/electron';
 
 import { useResolvedTabs } from './hooks/useResolvedTabs';
-import { matchRouteMeta } from './resolveRouteMeta';
 import { useStyles } from './styles';
 import TabItem from './TabItem';
 
 const TAB_WIDTH = 180;
 const TAB_GAP = 0;
 
+// The "+" button always opens a fresh Home tab, regardless of the active page.
+const NEW_TAB_URL = '/';
+
 // Tabs only reorder along the horizontal axis, so lock the drag transform to X.
 const restrictToHorizontalAxis: Modifier = ({ transform }) => ({ ...transform, y: 0 });
-
-// Fallback when the active route doesn't define createNewTab: open the home page,
-// so the "+" button stays available on every page.
-const DEFAULT_NEW_TAB_ACTION: NewTabAction = {
-  onCreate: async () => ({ url: '/' }),
-};
 
 const TabBar = () => {
   const styles = useStyles;
@@ -170,16 +164,6 @@ const TabBar = () => {
     }
   }, [activeTabId, tabs]);
 
-  const newTabAction: NewTabAction | null = useMemo(() => {
-    if (!canCreate) return null;
-    if (!activeTabId) return DEFAULT_NEW_TAB_ACTION;
-    const activeTab = tabs.find((tab) => tab.tab.id === activeTabId);
-    if (!activeTab) return DEFAULT_NEW_TAB_ACTION;
-
-    const matched = matchRouteMeta(desktopRoutes, activeTab.tab.url);
-    return matched.meta?.createNewTab?.(matched.params) ?? DEFAULT_NEW_TAB_ACTION;
-  }, [activeTabId, tabs, canCreate]);
-
   useWatchBroadcast('closeCurrentTabOrWindow', () => {
     if (tabs.length > 1 && activeTabId) {
       handleClose(activeTabId);
@@ -188,24 +172,17 @@ const TabBar = () => {
     }
   });
 
-  const handleNewTab = useCallback(async () => {
+  const handleNewTab = useCallback(() => {
     if (!canCreate) return;
-    if (!newTabAction) return;
-    let result;
-    try {
-      result = await newTabAction.onCreate();
-    } catch (error) {
-      console.error('[TabBar] failed to create new tab:', error);
-      return;
-    }
-    if (!result) return;
 
-    addTab(result.url, result.cached, true);
-    startTransition(() => navigate(result.url));
-  }, [canCreate, newTabAction, addTab, navigate]);
+    // Always open a fresh Home tab. If a Home tab already exists, addTab just
+    // activates it instead of stacking duplicates.
+    addTab(NEW_TAB_URL, undefined, true);
+    startTransition(() => navigate(NEW_TAB_URL));
+  }, [canCreate, addTab, navigate]);
 
   useWatchBroadcast('createNewTab', () => {
-    void handleNewTab();
+    handleNewTab();
   });
 
   if (tabs.length === 0) return null;
@@ -241,16 +218,14 @@ const TabBar = () => {
           ))}
         </SortableContext>
       </DndContext>
-      {(newTabAction || !canCreate) && (
-        <ActionIcon
-          className={cx(electronStylish.nodrag, styles.newTabButton)}
-          disabled={!canCreate}
-          icon={Plus}
-          size="small"
-          title={canCreate ? t('tab.newTab') : reason}
-          onClick={canCreate ? handleNewTab : undefined}
-        />
-      )}
+      <ActionIcon
+        className={cx(electronStylish.nodrag, styles.newTabButton)}
+        disabled={!canCreate}
+        icon={Plus}
+        size="small"
+        title={canCreate ? t('tab.newTab') : reason}
+        onClick={canCreate ? handleNewTab : undefined}
+      />
     </ScrollArea>
   );
 };

--- a/src/features/Pages/routeMeta.ts
+++ b/src/features/Pages/routeMeta.ts
@@ -1,58 +1,11 @@
-import { CUSTOM_DOCUMENT_FILE_TYPE } from '@lobechat/const';
-import { t } from 'i18next';
 import { FilePenIcon } from 'lucide-react';
 
 import { type DynamicRouteMeta, routeMeta } from '@/spa/router/routeMeta';
 import { usePageStore } from '@/store/page';
 import { listSelectors } from '@/store/page/slices/list/selectors';
-import { DocumentSourceType, type LobeDocument } from '@/types/document';
 import { getIdFromIdentifier } from '@/utils/identifier';
 
-const EDITOR_PAGE_FILE_TYPE = CUSTOM_DOCUMENT_FILE_TYPE;
-
 export const pageRouteMeta = routeMeta({
-  createNewTab: () => ({
-    onCreate: async () => {
-      const untitled = t('pageList.untitled', { ns: 'file' });
-      const pageStore = usePageStore.getState();
-
-      const newPage = await pageStore.createPage({ content: '', title: untitled });
-
-      const now = new Date();
-      const document: LobeDocument = {
-        content: newPage.content || '',
-        createdAt: newPage.createdAt ? new Date(newPage.createdAt) : now,
-        editorData:
-          typeof newPage.editorData === 'string'
-            ? (() => {
-                try {
-                  return JSON.parse(newPage.editorData);
-                } catch {
-                  return null;
-                }
-              })()
-            : newPage.editorData || null,
-        fileType: newPage.fileType || EDITOR_PAGE_FILE_TYPE,
-        filename: newPage.title || untitled,
-        id: newPage.id,
-        metadata: newPage.metadata || {},
-        source: 'document',
-        sourceType: DocumentSourceType.EDITOR,
-        title: newPage.title || untitled,
-        totalCharCount: (newPage.content || '').length,
-        totalLineCount: 0,
-        updatedAt: newPage.updatedAt ? new Date(newPage.updatedAt) : now,
-      };
-
-      pageStore.internal_dispatchDocuments({ document, type: 'addDocument' });
-      usePageStore.setState({ selectedPageId: newPage.id }, false, 'TabBar/newPage');
-
-      return {
-        cached: { title: document.title || untitled },
-        url: `/page/${newPage.id}`,
-      };
-    },
-  }),
   icon: FilePenIcon,
   titleKey: 'navigation.page',
   useDynamicMeta: (params): DynamicRouteMeta => {

--- a/src/routes/(main)/agent/features/routeMeta.ts
+++ b/src/routes/(main)/agent/features/routeMeta.ts
@@ -1,7 +1,5 @@
-import { t } from 'i18next';
 import { MessageSquare } from 'lucide-react';
 
-import { lambdaClient } from '@/libs/trpc/client';
 import { type DynamicRouteMeta, routeMeta } from '@/spa/router/routeMeta';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
@@ -18,35 +16,6 @@ const useTopicTitle = (topicId: string | undefined): string | undefined =>
   });
 
 export const agentRouteMeta = routeMeta({
-  createNewTab: (params) => {
-    const agentId = params.aid;
-    if (!agentId) return null;
-
-    return {
-      onCreate: async () => {
-        const meta = agentSelectors.getAgentMetaById(agentId)(useAgentStore.getState());
-        if (!meta || Object.keys(meta).length === 0) return null;
-
-        const defaultTitle = t('defaultTitle', { ns: 'topic' });
-        const topicId = await lambdaClient.topic.createTopic.mutate({
-          agentId,
-          messages: [],
-          title: defaultTitle,
-        });
-
-        await useChatStore.getState().refreshTopic();
-
-        return {
-          cached: {
-            avatar: meta.avatar,
-            backgroundColor: meta.backgroundColor,
-            title: defaultTitle,
-          },
-          url: `/agent/${agentId}/${topicId}`,
-        };
-      },
-    };
-  },
   icon: MessageSquare,
   titleKey: 'navigation.chat',
   useDynamicMeta: (params): DynamicRouteMeta => {

--- a/src/routes/(main)/group/features/routeMeta.ts
+++ b/src/routes/(main)/group/features/routeMeta.ts
@@ -1,8 +1,6 @@
-import { t } from 'i18next';
 import { Users } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
 
-import { lambdaClient } from '@/libs/trpc/client';
 import { type DynamicRouteMeta, routeMeta } from '@/spa/router/routeMeta';
 import { useChatStore } from '@/store/chat';
 import { useSessionStore } from '@/store/session';
@@ -19,31 +17,6 @@ const useTopicTitle = (topicId: string | null): string | undefined =>
   });
 
 export const groupRouteMeta = routeMeta({
-  createNewTab: (params) => {
-    const groupId = params.gid;
-    if (!groupId) return null;
-
-    return {
-      onCreate: async () => {
-        const group = sessionGroupSelectors.getGroupById(groupId)(useSessionStore.getState());
-        if (!group) return null;
-
-        const defaultTitle = t('defaultTitle', { ns: 'topic' });
-        const topicId = await lambdaClient.topic.createTopic.mutate({
-          groupId,
-          messages: [],
-          title: defaultTitle,
-        });
-
-        await useChatStore.getState().refreshTopic();
-
-        return {
-          cached: { title: defaultTitle },
-          url: `/group/${groupId}?topic=${topicId}`,
-        };
-      },
-    };
-  },
   icon: Users,
   titleKey: 'navigation.groupChat',
   useDynamicMeta: (params): DynamicRouteMeta => {

--- a/src/spa/router/routeMeta.ts
+++ b/src/spa/router/routeMeta.ts
@@ -11,17 +11,7 @@ export interface DynamicRouteMeta {
   title?: string;
 }
 
-export interface NewTabActionResult {
-  cached?: DynamicRouteMeta;
-  url: string;
-}
-
-export interface NewTabAction {
-  onCreate: () => Promise<NewTabActionResult | null>;
-}
-
 export interface RouteMeta extends StaticRouteMeta {
-  createNewTab?: (params: Record<string, string | undefined>) => NewTabAction | null;
   useDynamicMeta?: (params: Record<string, string | undefined>) => DynamicRouteMeta;
 }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

The desktop tab bar's **"+" button** previously ran the active route's `createNewTab` handler, so its behavior depended on which page you were on:

- on an **agent** tab → created a new topic for that same agent (a new "agent tab")
- on a **group** tab → created a new group topic
- on a **Pages** tab → created a new blank page

This made "+" unpredictable. Now it **always opens a new Home tab**, regardless of the active page — matching the browser-like mental model of "new tab = home".

Notes:
- `addTab` dedupes by URL, so if a Home tab already exists, "+" focuses it instead of stacking duplicate Home tabs.
- The keyboard/IPC `createNewTab` broadcast flows through the same handler, so a "new tab" shortcut opens Home too.
- Removed the now-dead `createNewTab` route-meta machinery (the `NewTabAction`/`NewTabActionResult` types, the `RouteMeta.createNewTab` field, and each route's definition + imports only it used). The `useDynamicMeta` tab title/icon logic and `matchRouteMeta`/`resolveRouteMeta` are untouched.

#### 🧪 How to Test

- [x] Tested locally
- [x] No tests needed

From an agent / group / page tab, click the "+" in the tab bar → a Home tab opens (or the existing Home tab is focused) instead of a new topic/page.

#### 📝 Additional Information

Net `-140` lines (mostly dead-code removal). Type-check passes for all touched files.