### PR TITLE
🐛 fix(page-editor): isolate page copilot context from global agent/document state

### DIFF
--- a/src/features/PageEditor/PageAgentProvider.test.tsx
+++ b/src/features/PageEditor/PageAgentProvider.test.tsx
@@ -9,6 +9,7 @@ import { PageAgentProvider } from './PageAgentProvider';
 
 interface AgentState {
   activeAgentId?: string;
+  heterogeneousAgentIds?: string[];
   pageAgentId: string;
   setActiveAgentId: (agentId: string) => void;
   useInitBuiltinAgent: (slug: string) => void;
@@ -50,6 +51,10 @@ vi.mock('@/store/agent', () => ({
 }));
 
 vi.mock('@/store/agent/selectors', () => ({
+  agentByIdSelectors: {
+    isAgentHeterogeneousById: (agentId: string) => (state: AgentState) =>
+      !!state.heterogeneousAgentIds?.includes(agentId),
+  },
   builtinAgentSelectors: {
     pageAgentId: (state: AgentState) => state.pageAgentId,
   },
@@ -156,5 +161,39 @@ describe('PageAgentProvider', () => {
     await waitFor(() => {
       expect(chatState.switchTopic).toHaveBeenCalledTimes(2);
     });
+  });
+
+  it('falls back to the page agent when the active agent is heterogeneous', async () => {
+    agentState.activeAgentId = 'claude-code';
+    agentState.heterogeneousAgentIds = ['claude-code'];
+
+    render(
+      <PageAgentProvider>
+        <div>child</div>
+      </PageAgentProvider>,
+    );
+
+    await waitFor(() => {
+      expect(conversationProviderSpy).toHaveBeenCalled();
+    });
+
+    const { context } = conversationProviderSpy.mock.calls.at(-1)![0];
+    expect(context.agentId).toBe('page-agent');
+  });
+
+  it('injects the open document id into the conversation context', async () => {
+    render(
+      <PageAgentProvider pageId="doc-1">
+        <div>child</div>
+      </PageAgentProvider>,
+    );
+
+    await waitFor(() => {
+      expect(conversationProviderSpy).toHaveBeenCalled();
+    });
+
+    const { context } = conversationProviderSpy.mock.calls.at(-1)![0];
+    expect(context.documentId).toBe('doc-1');
+    expect(context.scope).toBe('page');
   });
 });

--- a/src/features/PageEditor/PageAgentProvider.test.tsx
+++ b/src/features/PageEditor/PageAgentProvider.test.tsx
@@ -70,8 +70,12 @@ vi.mock('@/store/chat', () => ({
 }));
 
 vi.mock('@/store/chat/utils/messageMapKey', () => ({
-  messageMapKey: (context: { agentId?: string; scope?: string; topicId?: string | null }) =>
-    `${context.scope}_${context.agentId}_${context.topicId ?? 'new'}`,
+  messageMapKey: (context: {
+    agentId?: string;
+    documentId?: string | null;
+    scope?: string;
+    topicId?: string | null;
+  }) => `${context.scope}_${context.agentId}_${context.topicId ?? context.documentId ?? 'new'}`,
 }));
 
 beforeEach(() => {

--- a/src/features/PageEditor/PageAgentProvider.tsx
+++ b/src/features/PageEditor/PageAgentProvider.tsx
@@ -4,32 +4,48 @@ import type { ReactNode } from 'react';
 import { memo, useEffect, useMemo, useRef } from 'react';
 
 import Loading from '@/components/Loading/BrandTextLoading';
+import type { ConversationContext } from '@/features/Conversation';
 import { ConversationProvider } from '@/features/Conversation';
 import { useOperationState } from '@/hooks/useOperationState';
 import { useAgentStore } from '@/store/agent';
-import { builtinAgentSelectors } from '@/store/agent/selectors';
+import { agentByIdSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
-import type { MessageMapKeyInput } from '@/store/chat/utils/messageMapKey';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 
 interface PageAgentProviderProps {
   children: ReactNode;
+  /**
+   * The id of the document currently open in the editor. Injected into the
+   * conversation context as `documentId` so page-scoped tool calls are bound to
+   * this exact document instead of relying on the process-wide
+   * `pageAgentRuntime` singleton, which can only represent one open document and
+   * gets cleared/overwritten when switching tabs.
+   */
+  pageId?: string;
 }
 
-export const PageAgentProvider = memo<PageAgentProviderProps>(({ children }) => {
+export const PageAgentProvider = memo<PageAgentProviderProps>(({ children, pageId }) => {
   const useInitBuiltinAgent = useAgentStore((s) => s.useInitBuiltinAgent);
   const pageAgentId = useAgentStore(builtinAgentSelectors.pageAgentId);
   const activeTopicId = useChatStore((s) => s.activeTopicId);
   const activeAgentId = useAgentStore((s) => s.activeAgentId);
+  const isActiveAgentHeterogeneous = useAgentStore((s) =>
+    activeAgentId ? agentByIdSelectors.isAgentHeterogeneousById(activeAgentId)(s) : false,
+  );
   const setActiveAgentId = useAgentStore((s) => s.setActiveAgentId);
   const syncedAgentIdRef = useRef<string | undefined>(undefined);
 
   useInitBuiltinAgent(BUILTIN_AGENT_SLUGS.pageAgent);
 
   // Build conversation context for page agent.
-  // Ignore chat-group ids in page scope and fall back to page agent.
+  // Fall back to the page agent when the global active agent cannot drive a page
+  // copilot: empty, a chat-group id, or a heterogeneous agent (e.g. Claude Code
+  // / Codex). Heterogeneous agents run on external runtimes and must not leak
+  // into the page-scoped conversation when navigating from their tab.
   const selectedAgentId =
-    !activeAgentId || isChatGroupSessionId(activeAgentId) ? pageAgentId : activeAgentId;
+    !activeAgentId || isChatGroupSessionId(activeAgentId) || isActiveAgentHeterogeneous
+      ? pageAgentId
+      : activeAgentId;
 
   useEffect(() => {
     if (!selectedAgentId) return;
@@ -58,13 +74,17 @@ export const PageAgentProvider = memo<PageAgentProviderProps>(({ children }) => 
     }
   }, [selectedAgentId, setActiveAgentId]);
 
-  const context = useMemo<MessageMapKeyInput>(
+  const context = useMemo<ConversationContext>(
     () => ({
       agentId: selectedAgentId,
+      // Bind the conversation to the open document directly so page-scoped tool
+      // calls don't depend on the `pageAgentRuntime` singleton, which can't
+      // represent multiple tabs/documents and is cleared on tab switch.
+      documentId: pageId,
       scope: 'page',
       topicId: activeTopicId, // No topic initially, can be extended later
     }),
-    [selectedAgentId, activeTopicId],
+    [selectedAgentId, activeTopicId, pageId],
   );
 
   // Get messages from ChatStore based on context

--- a/src/features/PageEditor/PageEditor.tsx
+++ b/src/features/PageEditor/PageEditor.tsx
@@ -339,7 +339,7 @@ export const PageEditor: FC<PageEditorProps> = ({
   const deletePage = usePageStore((s) => s.deletePage);
 
   return (
-    <PageAgentProvider>
+    <PageAgentProvider pageId={pageId}>
       <EditorProvider>
         <PageEditorProvider
           emoji={emoji}

--- a/src/store/chat/utils/messageMapKey.test.ts
+++ b/src/store/chat/utils/messageMapKey.test.ts
@@ -79,6 +79,34 @@ describe('messageMapKey', () => {
     });
   });
 
+  describe('Page mode', () => {
+    it('should bind a page conversation to the open document id', () => {
+      const result = messageMapKey({ scope: 'page', agentId: 'agt_page', documentId: 'doc_aaa' });
+      expect(result).toBe('page_agt_page_doc_aaa');
+    });
+
+    it('should isolate different documents sharing the same page agent', () => {
+      const a = messageMapKey({ scope: 'page', agentId: 'agt_page', documentId: 'doc_aaa' });
+      const b = messageMapKey({ scope: 'page', agentId: 'agt_page', documentId: 'doc_bbb' });
+      expect(a).not.toBe(b);
+    });
+
+    it('should fall back to the new bucket when no document is open', () => {
+      const result = messageMapKey({ scope: 'page', agentId: 'agt_page' });
+      expect(result).toBe('page_agt_page_new');
+    });
+
+    it('should include topicId alongside documentId when a page topic exists', () => {
+      const result = messageMapKey({
+        scope: 'page',
+        agentId: 'agt_page',
+        documentId: 'doc_aaa',
+        topicId: 'tpc_yyy',
+      });
+      expect(result).toBe('page_agt_page_tpc_yyy_doc_aaa');
+    });
+  });
+
   describe('Group mode with groupId (auto-detected)', () => {
     it('should auto-detect group scope when groupId is present', () => {
       const result = messageMapKey({

--- a/src/store/chat/utils/messageMapKey.ts
+++ b/src/store/chat/utils/messageMapKey.ts
@@ -9,6 +9,13 @@ export interface MessageMapKeyInput {
    * Agent ID (maps to scopeId in main/thread scope)
    */
   agentId: string;
+  /**
+   * Document ID (page scope only). The page agent is a single builtin agent
+   * shared by every open document, so the documentId is what isolates one
+   * document's conversation/operation bucket from another's. Maps to subTopicId
+   * in page scope; ignored for every other scope.
+   */
+  documentId?: string;
   groupId?: string;
   /**
    * Whether this is a new/creating state (for optimistic updates)
@@ -41,7 +48,22 @@ export interface MessageMapKeyInput {
  * Handles mapping from agentId/threadId to scopeId/subTopicId format
  */
 const toMessageMapContext = (input: MessageMapKeyInput): MessageMapContext => {
-  const { agentId, topicId, threadId, isNew, groupId, subAgentId, scope } = input;
+  const { agentId, topicId, threadId, isNew, groupId, subAgentId, scope, documentId } = input;
+
+  // Page scope: the page agent is a single shared builtin agent, so the open
+  // documentId is the only thing that distinguishes one document's conversation
+  // from another's. Carry it as subTopicId so the generated key isolates each
+  // document; without it, document A and B collapse into the same `page_<agent>`
+  // bucket and leak history / queue behind each other's operations.
+  if (scope === 'page' && documentId) {
+    return {
+      isNew,
+      scope: 'page',
+      scopeId: agentId,
+      subTopicId: documentId,
+      topicId,
+    };
+  }
 
   // If threadId is present and scope is explicitly 'thread', use thread scope
   // Thread scope takes priority when explicitly requested, even with groupId
@@ -102,9 +124,11 @@ const generateKey = (context: MessageMapContext): string => {
 
   const base = `${scope}_${scopeId}`;
 
-  // Has subTopicId (existing thread or existing agent topic in group)
+  // Has subTopicId (existing thread, agent topic in group, or page documentId).
+  // Page scope is usually topicless, so guard against emitting a literal `null`
+  // segment when topicId is absent.
   if (subTopicId) {
-    return `${base}_${topicId}_${subTopicId}`;
+    return topicId ? `${base}_${topicId}_${subTopicId}` : `${base}_${subTopicId}`;
   }
 
   // New thread/sub-topic with parent topicId
@@ -143,6 +167,8 @@ const generateKey = (context: MessageMapContext): string => {
  * - Group agent existing topic: `group_agent_grp_xxx_tpc_yyy_tpc_zzz`
  * - Task new topic: `task_agt_xxx_new`
  * - Task existing topic: `task_agt_xxx_tpc_yyy`
+ * - Page document (topicless): `page_agt_xxx_doc_zzz`
+ * - Page without an open document: `page_agt_xxx_new`
  *
  * Auto-detection rules (when scope is not explicitly set):
  * - If threadId exists: scope = 'thread', subTopicId = threadId


### PR DESCRIPTION
## 🐛 What

修复 Page 编辑器右侧 copilot 的两个**独立但同源**的 bug —— 根因都是 page 会话上下文依赖了**进程级单例 / 全局 state**,而它们无法表达「多 tab / 多文档」。

### ① 多 tab 下 documentId 丢失

`PageAgentProvider` 构造的 conversation context 不带 `documentId`,完全依赖进程级单例 `pageAgentRuntime` 在发送时兜底:

```ts
const activePageDocumentId =
  context.scope === 'page' && !context.documentId
    ? pageAgentRuntime.getCurrentDocId()   // ← 多 tab 切换后拿到 undefined
    : undefined;
```

而单例只能代表「一个打开的文档」。多 tab 场景下 editor 的挂载/卸载生命周期在切页时会把单例清成 `undefined`(或指向已切走的文档),导致服务端报 `PageAgent server runtime received a tool call without documentId`,LLM 表现为「你有两个文档,不确定你在编辑哪一个」。

**修复**:把 editor 已有的 `pageId` 直接注入到 `context.documentId`,发送时的 `!context.documentId` 守卫就会用确定值,从根上摆脱单例的时序竞争。

### ② activeAgentId 污染(heterogeneous agent 泄漏)

`selectedAgentId` 只排除了「空」和「chat-group」,**没有排除 heterogeneous agent(Claude Code / Codex)**。所以从 ClaudeCode/Codex tab 进 page → 全局 `activeAgentId` 是外部 runtime agent → page 右侧直接用了它来驱动。

**修复**:计算 `selectedAgentId` 时,若 `activeAgentId` 是 heterogeneous(复用现成 selector `isAgentHeterogeneousById`)也回退到 `pageAgentId`。

## 🧪 Test

- `PageAgentProvider.test.tsx`:新增「heterogeneous agent 回退到 page agent」「注入 documentId 到 context」两条用例
- 回归:`PageAgentProvider` / `PageEditor` / `ConversationProvider` / `conversationLifecycle` / `agentByIdSelectors` 全绿
- `type-check`:本次改动文件无新增类型错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)
