### PR TITLE
🐛 fix(chat): warn when agent mode is on but the model lacks tool calling

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -246,6 +246,7 @@
   "inbox.title": "Lobe AI",
   "input.addAi": "Add an AI message",
   "input.addUser": "Add a user message",
+  "input.agentModeUnsupportedModel": "The current model doesn’t support agentic tool calling. Switch to a model with agent capability for the best experience.",
   "input.costEstimate.creditsPerMillionTokens": "{{credits}} credits/M tokens",
   "input.costEstimate.hint": "Estimated cost: ~{{credits}} credits",
   "input.costEstimate.inputLabel": "Input",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -246,6 +246,7 @@
   "inbox.title": "Lobe AI",
   "input.addAi": "添加一条助理消息",
   "input.addUser": "添加一条用户消息",
+  "input.agentModeUnsupportedModel": "当前模型不支持 Agentic 工具调用，建议切换为具备 Agent 能力的模型以获得最佳体验。",
   "input.costEstimate.creditsPerMillionTokens": "{{credits}} 积分/百万标记",
   "input.costEstimate.hint": "预计费用：约{{credits}}积分",
   "input.costEstimate.inputLabel": "输入",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -208,6 +208,8 @@ export default {
   'inbox.title': 'Lobe AI',
   'input.addAi': 'Add an AI message',
   'input.addUser': 'Add a user message',
+  'input.agentModeUnsupportedModel':
+    'The current model doesn’t support agentic tool calling. Switch to a model with agent capability for the best experience.',
   'input.costEstimate.creditsPerMillionTokens': '{{credits}} credits/M tokens',
   'input.costEstimate.hint': 'Estimated cost: ~{{credits}} credits',
   'input.costEstimate.inputLabel': 'Input',

--- a/src/features/ChatInput/Desktop/AgentModeNotice.tsx
+++ b/src/features/ChatInput/Desktop/AgentModeNotice.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { Alert } from '@lobehub/ui';
+import { createStaticStyles, cx } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';
+import { useAgentStore } from '@/store/agent';
+import { agentByIdSelectors } from '@/store/agent/selectors';
+import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
+
+const styles = createStaticStyles(({ css }) => ({
+  alert: css`
+    .ant-alert-message {
+      font-size: 12px;
+      line-height: 18px !important;
+    }
+
+    .ant-alert-icon {
+      height: 18px !important;
+    }
+  `,
+}));
+
+/**
+ * Warns the user when Agent mode is enabled but the currently selected model
+ * does not support function/tool calling — agentic runs need tool calling to
+ * work, so we suggest switching to a model with agent capability.
+ */
+const AgentModeNotice = memo(() => {
+  const { t } = useTranslation('chat');
+  const agentId = useAgentId();
+
+  const [enableAgentMode, model, provider] = useAgentStore((s) => [
+    agentByIdSelectors.getAgentEnableModeById(agentId)(s),
+    agentByIdSelectors.getAgentModelById(agentId)(s),
+    agentByIdSelectors.getAgentModelProviderById(agentId)(s),
+  ]);
+
+  const supportToolUse = useAiInfraStore(aiModelSelectors.isModelSupportToolUse(model, provider));
+
+  if (!enableAgentMode || supportToolUse) return null;
+
+  return (
+    <Alert
+      classNames={{ alert: cx(styles.alert) }}
+      style={{ fontSize: 12 }}
+      title={t('input.agentModeUnsupportedModel')}
+      type={'warning'}
+      variant={'borderless'}
+    />
+  );
+});
+
+AgentModeNotice.displayName = 'AgentModeNotice';
+
+export default AgentModeNotice;

--- a/src/features/ChatInput/Desktop/index.tsx
+++ b/src/features/ChatInput/Desktop/index.tsx
@@ -25,6 +25,7 @@ import { useSkillDrop } from '../InputEditor/ActionTag/useSkillDrop';
 import { type PlaceholderVariant } from '../InputEditor/Placeholder';
 import SendArea from '../SendArea';
 import TypoBar from '../TypoBar';
+import AgentModeNotice from './AgentModeNotice';
 import ContextContainer from './ContextContainer';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
@@ -157,6 +158,7 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
         onDragOver={skillDrop.onDragOver}
         onDrop={skillDrop.onDrop}
       >
+        {!isConfigLoading && <AgentModeNotice />}
         <ChatInput
           data-testid="chat-input"
           defaultHeight={chatInputHeight || 32}


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

close #15804

#### 🔀 Description of Change

When **Agent mode** is enabled on an assistant but the currently selected model does **not** support function/tool calling, agentic runs can't work as expected. This PR adds a lightweight warning (`AgentModeNotice`) above the desktop chat input, suggesting the user switch to a model with agent capability.

- New component `src/features/ChatInput/Desktop/AgentModeNotice.tsx`, rendered inside `DesktopChatInput` (gated on `!isConfigLoading`).
- Condition: `enableAgentMode && !isModelSupportToolUse(model, provider)` → show warning; otherwise renders `null`.
- i18n key `chat:input.agentModeUnsupportedModel` shipped for `en-US` and `zh-CN`.

#### 🧪 How to Test

Verified end-to-end in the Electron desktop app via agent-browser (CDP):

1. Enable Agent mode + select a model without tool calling (e.g. Nano Banana 2 / `gemini-3.1-flash-image-preview`) → warning shows above the input.
2. Keep Agent mode on + switch to a tool-supporting model (e.g. Claude Opus 4.8) → warning disappears reactively.

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

| Warning shown (non-tool model) | Warning cleared (tool model) |
| ------ | ----- |
| Yellow alert: "The current model doesn't support agentic tool calling. Switch to a model with agent capability for the best experience." | Clean input, no alert |

#### 📝 Additional Information

Relates to feedback in #15804 where agent behavior degraded — this proactively surfaces the case where the selected model can't do tool calling.