### PR TITLE
🐛 fix(device): pass CLI command to remote agent runs

### DIFF
--- a/apps/cli/src/commands/connect.test.ts
+++ b/apps/cli/src/commands/connect.test.ts
@@ -21,6 +21,15 @@ vi.mock('../settings', () => ({
   saveSettings: vi.fn(),
 }));
 
+vi.mock('../device/register', () => ({
+  registerDevice: vi.fn().mockResolvedValue(undefined),
+  resolveDeviceIdentity: vi.fn((userId?: string, explicitDeviceId?: string) =>
+    userId || explicitDeviceId
+      ? { deviceId: explicitDeviceId ?? 'mock-device-id', identitySource: 'machine-id' }
+      : undefined,
+  ),
+}));
+
 vi.mock('../utils/logger', () => ({
   log: {
     debug: vi.fn(),
@@ -226,7 +235,7 @@ describe('connect command', () => {
       type: 'tool_call_request',
     });
 
-    expect(executeToolCall).toHaveBeenCalledWith('readLocalFile', '{"path":"/test"}');
+    expect(executeToolCall).toHaveBeenCalledWith('readLocalFile', '{"path":"/test"}', undefined);
     expect(lastSentToolResponse).toEqual({
       requestId: 'req-1',
       result: { content: 'tool result', error: undefined, success: true },
@@ -261,15 +270,14 @@ describe('connect command', () => {
   });
 
   it('should retry auth_failed with token refresh when new token available', async () => {
+    const program = createProgram();
+    await program.parseAsync(['node', 'test', 'connect']);
     vi.mocked(resolveToken).mockResolvedValueOnce({
       serverUrl: 'https://app.lobehub.com',
       token: 'refreshed-token',
       tokenType: 'jwt',
       userId: 'test-user',
     });
-
-    const program = createProgram();
-    await program.parseAsync(['node', 'test', 'connect']);
 
     const mockClient = vi.mocked(GatewayClient).mock.results[0].value;
 
@@ -280,7 +288,9 @@ describe('connect command', () => {
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
-  it('should handle auth_expired', async () => {
+  it('should refresh and reconnect on auth_expired', async () => {
+    const program = createProgram();
+    await program.parseAsync(['node', 'test', 'connect']);
     vi.mocked(resolveToken).mockResolvedValueOnce({
       serverUrl: 'https://app.lobehub.com',
       token: 'new-tok',
@@ -288,14 +298,14 @@ describe('connect command', () => {
       userId: 'user',
     });
 
-    const program = createProgram();
-    await program.parseAsync(['node', 'test', 'connect']);
+    const mockClient = vi.mocked(GatewayClient).mock.results[0].value;
 
     await clientEventHandlers['auth_expired']?.();
 
-    expect(log.error).toHaveBeenCalledWith(expect.stringContaining('expired'));
-    expect(cleanupAllProcesses).toHaveBeenCalled();
-    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(log.info).toHaveBeenCalledWith(expect.stringContaining('Token refreshed'));
+    expect(mockClient.updateToken).toHaveBeenCalledWith('new-tok');
+    expect(mockClient.reconnect).toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 
   it('should ignore auth_expired for api key auth', async () => {

--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -337,6 +337,7 @@ async function runConnect(options: ConnectOptions, isDaemonChild: boolean) {
       const ack = await spawnHeteroAgentRun(
         {
           agentType: request.agentType,
+          command: request.command,
           cwd: request.cwd,
           imageList: request.imageList,
           jwt: request.jwt,

--- a/apps/cli/src/device/agentRun.test.ts
+++ b/apps/cli/src/device/agentRun.test.ts
@@ -103,6 +103,16 @@ describe('spawnHeteroAgentRun', () => {
     expect(args).toContain('sess-9');
   });
 
+  it('passes an explicit CLI command through to `lh hetero exec`', () => {
+    const child = makeFakeChild();
+    spawnMock.mockReturnValue(child);
+
+    void spawnHeteroAgentRun({ ...baseParams, command: '/opt/bin/codex' });
+
+    const [, args] = spawnMock.mock.calls[0];
+    expect(args).toEqual(expect.arrayContaining(['--command', '/opt/bin/codex']));
+  });
+
   it('sends a content-block array to stdin when systemContext is provided', async () => {
     const child = makeFakeChild();
     spawnMock.mockReturnValue(child);

--- a/apps/cli/src/device/agentRun.ts
+++ b/apps/cli/src/device/agentRun.ts
@@ -7,6 +7,7 @@ import {
 
 export interface SpawnHeteroAgentRunParams {
   agentType: string;
+  command?: string;
   cwd?: string;
   /** Image attachments (signed URLs) appended as image content blocks. */
   imageList?: HeteroExecImageRef[];
@@ -52,6 +53,7 @@ export function spawnHeteroAgentRun(
 ): Promise<AgentRunAckResult> {
   const {
     agentType,
+    command,
     cwd,
     imageList,
     jwt,
@@ -72,6 +74,7 @@ export function spawnHeteroAgentRun(
     'exec',
     '--type',
     agentType,
+    ...(command ? ['--command', command] : []),
     '--operation-id',
     operationId,
     '--topic',

--- a/apps/cli/vitest.config.mts
+++ b/apps/cli/vitest.config.mts
@@ -10,6 +10,14 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../../packages/device-gateway-client/src/index.ts'),
       },
       {
+        find: '@lobechat/device-identity',
+        replacement: path.resolve(__dirname, '../../packages/device-identity/src/index.ts'),
+      },
+      {
+        find: '@lobechat/device-control',
+        replacement: path.resolve(__dirname, '../../packages/device-control/src/index.ts'),
+      },
+      {
         find: '@lobechat/local-file-shell',
         replacement: path.resolve(__dirname, '../../packages/local-file-shell/src/index.ts'),
       },

--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -286,11 +286,12 @@ export default class GatewayConnectionCtr extends ControllerModule {
         return { reason: 'Remote server URL not configured', status: 'rejected' };
       }
 
-      // Fire-and-forget: lh hetero exec handles spawn -> adapt ->
+      // Hand off to `lh hetero exec`; the spawned CLI then owns adapt ->
       // BatchIngester -> heteroIngest/heteroFinish -> server -> Gateway -> clients.
       // Same command as spawnHeteroSandbox() on the server side.
-      this.heterogeneousAgentCtr.spawnLhHeteroExec({
+      await this.heterogeneousAgentCtr.spawnLhHeteroExec({
         agentType: request.agentType,
+        command: request.command,
         cwd: request.cwd,
         imageList: request.imageList,
         jwt: request.jwt,

--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -36,6 +36,7 @@ import {
 import { app as electronApp, BrowserWindow } from 'electron';
 
 import { HETERO_AGENT_FILES_DIR, HETERO_AGENT_TRACING_DIR } from '@/const/heteroAgent';
+import type { ToolStatus } from '@/core/infrastructure/ToolDetectorManager';
 import { getHeterogeneousAgentDriver } from '@/modules/heterogeneousAgent';
 import type {
   HeterogeneousAgentBuildPlan,
@@ -219,6 +220,11 @@ interface CliTraceSession {
   writeQueue: Promise<void>;
 }
 
+interface ResolvedDeviceHeteroCommand {
+  command: string;
+  resolvedPathEnv?: string;
+}
+
 /**
  * External Agent Controller — manages external agent CLI processes via Electron IPC.
  *
@@ -257,6 +263,58 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     if (resolvedCommand) return resolvedCommand;
 
     return session.agentType === 'codex' ? 'codex' : 'claude';
+  }
+
+  private getDefaultCommandForAgentType(agentType: string): string | undefined {
+    if (agentType === 'codex') return 'codex';
+    if (agentType === 'claude-code') return 'claude';
+  }
+
+  private isBareCommand(command: string): boolean {
+    return !command.includes('/') && !command.includes('\\');
+  }
+
+  private async resolveDeviceHeteroCommand(
+    agentType: string,
+    command?: string,
+  ): Promise<ResolvedDeviceHeteroCommand | undefined> {
+    const requestedCommand = command?.trim() || this.getDefaultCommandForAgentType(agentType);
+    if (!requestedCommand) return;
+
+    if (agentType !== 'claude-code' && agentType !== 'codex') {
+      return { command: requestedCommand };
+    }
+
+    const defaultCommand = this.getDefaultCommandForAgentType(agentType);
+    let status: ToolStatus | undefined;
+    try {
+      status =
+        requestedCommand === defaultCommand && defaultCommand
+          ? await this.app.toolDetectorManager?.detect?.(defaultCommand, true)
+          : await detectHeterogeneousCliCommand(
+              agentType === 'claude-code' ? 'claude-code' : 'codex',
+              requestedCommand,
+            );
+
+      if (status?.available && status.path && this.isBareCommand(requestedCommand)) {
+        return { command: status.path, resolvedPathEnv: status.resolvedPathEnv };
+      }
+    } catch (err) {
+      logger.warn(
+        'resolveDeviceHeteroCommand: failed to resolve %s command "%s": %s',
+        agentType,
+        requestedCommand,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+
+    if (status && !status.available) {
+      throw new Error(
+        `${agentType} CLI command "${requestedCommand}" was not found on this device`,
+      );
+    }
+
+    return { command: requestedCommand };
   }
 
   private buildCodexCliMissingError(session: AgentSession): HeterogeneousAgentSessionError {
@@ -1469,8 +1527,9 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
    * AgentStreamPipeline or IPC broadcast needed. Mirrors
    * `spawnHeteroSandbox()` on the server side.
    */
-  spawnLhHeteroExec(params: {
+  async spawnLhHeteroExec(params: {
     agentType: string;
+    command?: string;
     cwd?: string;
     /** Image attachments (signed URLs) appended as image content blocks. */
     imageList?: HeteroExecImageRef[];
@@ -1481,9 +1540,10 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     serverUrl: string;
     systemContext?: string;
     topicId: string;
-  }): void {
+  }): Promise<void> {
     const {
       agentType,
+      command,
       cwd,
       imageList,
       jwt,
@@ -1495,6 +1555,7 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
       topicId,
     } = params;
     const workDir = cwd ?? process.cwd();
+    const resolvedCommand = await this.resolveDeviceHeteroCommand(agentType, command);
 
     // When CLI tracing is enabled (dev builds, or the Help-menu toggle in
     // packaged builds), have `lh hetero exec` persist the agent process's RAW
@@ -1509,6 +1570,7 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
       'exec',
       '--type',
       agentType,
+      ...(resolvedCommand?.command ? ['--command', resolvedCommand.command] : []),
       '--operation-id',
       operationId,
       '--topic',
@@ -1526,6 +1588,7 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     const env = {
       ...process.env,
       ...buildProxyEnv(this.app.storeManager.get('networkProxy')),
+      ...(resolvedCommand?.resolvedPathEnv ? { PATH: resolvedCommand.resolvedPathEnv } : {}),
       LOBEHUB_JWT: jwt,
       LOBEHUB_SERVER: serverUrl,
     };

--- a/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
@@ -199,6 +199,10 @@ vi.mock('@lobechat/device-gateway-client', () => ({
   GatewayClient: MockGatewayClient,
 }));
 
+vi.mock('@lobechat/device-identity', () => ({
+  deriveDeviceId: vi.fn(() => 'mock-device-id'),
+}));
+
 vi.mock('@/services/imessageBridgeSrv', () => ({
   default: class ImessageBridgeService {},
 }));
@@ -845,9 +849,10 @@ describe('GatewayConnectionCtr', () => {
       },
     );
 
-    it('forwards cwd and systemContext from the request to spawnLhHeteroExec', async () => {
+    it('forwards cwd, command, and systemContext from the request to spawnLhHeteroExec', async () => {
       const client = await connectAndOpen();
       client.simulateAgentRunRequest('claude-code', 'op-ctx', 'hi', 'mock-jwt', {
+        command: '/custom/bin/claude',
         cwd: '/Users/alice/repo',
         systemContext: 'WORKSPACE CONTEXT',
       });
@@ -855,6 +860,7 @@ describe('GatewayConnectionCtr', () => {
 
       expect(mockHeterogeneousAgentCtr.spawnLhHeteroExec).toHaveBeenCalledWith(
         expect.objectContaining({
+          command: '/custom/bin/claude',
           cwd: '/Users/alice/repo',
           systemContext: 'WORKSPACE CONTEXT',
         }),

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -127,6 +127,71 @@ describe('HeterogeneousAgentCtr', () => {
     await rm(appStoragePath, { force: true, recursive: true });
   });
 
+  describe('spawnLhHeteroExec', () => {
+    beforeEach(() => {
+      spawnCalls.length = 0;
+      execFileMock.mockReset();
+      nextFakeProc = null;
+    });
+
+    it('passes the detector-resolved Codex command to remote-device lh hetero exec', async () => {
+      const resolvedPath = '/Applications/Codex.app/Contents/Resources/codex';
+      const searchPath = '/Users/h/.local/share/mise/shims:/usr/bin:/bin';
+      const detect = vi
+        .fn()
+        .mockResolvedValue({ available: true, path: resolvedPath, resolvedPathEnv: searchPath });
+      const { proc, writes } = createFakeProc();
+      nextFakeProc = proc;
+
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+        toolDetectorManager: { detect },
+      } as any);
+
+      await ctr.spawnLhHeteroExec({
+        agentType: 'codex',
+        command: 'codex',
+        jwt: 'jwt-1',
+        operationId: 'op-1',
+        prompt: 'hello codex',
+        serverUrl: 'https://server.example.com',
+        topicId: 'topic-1',
+      });
+
+      expect(detect).toHaveBeenCalledWith('codex', true);
+      expect(spawnCalls[0].command).toBe('lh');
+      expect(spawnCalls[0].args).toEqual(
+        expect.arrayContaining(['--type', 'codex', '--command', resolvedPath]),
+      );
+      expect(spawnCalls[0].options.env.PATH).toBe(searchPath);
+      expect(writes).toEqual([JSON.stringify('hello codex')]);
+    });
+
+    it('rejects before spawning lh when the Codex command is unavailable on the device', async () => {
+      const detect = vi.fn().mockResolvedValue({ available: false });
+      const ctr = new HeterogeneousAgentCtr({
+        appStoragePath,
+        storeManager: { get: vi.fn() },
+        toolDetectorManager: { detect },
+      } as any);
+
+      await expect(
+        ctr.spawnLhHeteroExec({
+          agentType: 'codex',
+          command: 'codex',
+          jwt: 'jwt-1',
+          operationId: 'op-1',
+          prompt: 'hello codex',
+          serverUrl: 'https://server.example.com',
+          topicId: 'topic-1',
+        }),
+      ).rejects.toThrow('codex CLI command "codex" was not found on this device');
+
+      expect(spawnCalls).toHaveLength(0);
+    });
+  });
+
   describe('image cache (delegates to shared `normalizeImage`)', () => {
     // Image fetch + cache moved to `@lobechat/heterogeneous-agents/spawn`'s
     // `normalizeImage`. The desktop controller passes its own cacheDir so the

--- a/apps/desktop/vitest.config.mts
+++ b/apps/desktop/vitest.config.mts
@@ -6,6 +6,7 @@ export default defineConfig({
     alias: {
       '@': resolve(__dirname, './src/main'),
       '~common': resolve(__dirname, './src/common'),
+      '@lobechat/device-control': resolve(__dirname, '../../packages/device-control/src'),
       '@lobechat/local-file-shell': resolve(__dirname, '../../packages/local-file-shell/src'),
     },
     coverage: {

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1280,6 +1280,7 @@ export class AiAgentService {
 
           const result = await deviceGateway.dispatchAgentRun({
             ...heteroParams,
+            command: agentConfig.agencyConfig?.heterogeneousProvider?.command,
             cwd: deviceCwd,
             deviceId: dispatchDeviceId,
             systemContext: deviceSystemContext,

--- a/apps/server/src/services/deviceGateway/index.ts
+++ b/apps/server/src/services/deviceGateway/index.ts
@@ -713,6 +713,7 @@ export class DeviceGateway {
 
   async dispatchAgentRun(params: {
     agentType: HeterogeneousAgentType;
+    command?: string;
     cwd?: string;
     deviceId?: string;
     /** Image attachments forwarded to the device as fetchable (signed) URLs. */

--- a/packages/device-gateway-client/src/http.ts
+++ b/packages/device-gateway-client/src/http.ts
@@ -182,6 +182,7 @@ export class GatewayHttpClient {
 
   async dispatchAgentRun(params: {
     agentType: string;
+    command?: string;
     cwd?: string;
     deviceId?: string;
     /** Image attachments forwarded into the `agent_run_request` message. */

--- a/packages/device-gateway-client/src/types.ts
+++ b/packages/device-gateway-client/src/types.ts
@@ -195,6 +195,11 @@ export interface RpcResponseMessage {
 /** Server → Client: request the desktop to spawn `lh hetero exec`. */
 export interface AgentRunRequestMessage {
   agentType: string;
+  /**
+   * Optional CLI command/path to use for this agent. Device clients may resolve
+   * bare commands to an executable path before invoking `lh hetero exec`.
+   */
+  command?: string;
   cwd?: string;
   /**
    * Image attachments from the user message, as URLs the device can fetch


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Pass the configured heterogeneous CLI command from server-side device dispatch through the gateway request payload.
- Forward the command into CLI and desktop `lh hetero exec` spawns so remote-device Codex/Claude runs use the intended executable.
- Resolve bare Codex/Claude commands on desktop with the local tool detector and preserve the detected `PATH` for the spawned process.
- Add/update focused tests and Vitest aliases for the shared device-control/device-identity workspace packages.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Passed:

```bash
cd lobehub/apps/cli && bunx vitest run --config vitest.config.mts --silent='passed-only' src/commands/connect.test.ts src/device/agentRun.test.ts
cd lobehub/apps/desktop && bunx vitest run --config vitest.config.mts --silent='passed-only' src/main/controllers/__tests__/GatewayConnectionCtr.test.ts src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
```

Known unrelated failure:

```bash
cd lobehub && bun run type-check
```

Fails in existing cloud business override files outside this change, e.g. `../packages/business/model-runtime/src/router-runtime-options.ts` missing `ChannelStats` fields and cloud service modules.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No UI changes.
