### PR TITLE
🐛 fix: render mention name from serialized attribute instead of falling back to unknown

### DIFF
--- a/src/features/Conversation/Markdown/plugins/Mention/Render.tsx
+++ b/src/features/Conversation/Markdown/plugins/Mention/Render.tsx
@@ -44,7 +44,7 @@ interface MentionProps {
   name: string;
 }
 const Render = memo<MarkdownElementProps<MentionProps>>(({ children, node }) => {
-  const { id: mentionId } = node?.properties || {};
+  const { id: mentionId, name } = node?.properties || {};
   const { t } = useTranslation('chat');
 
   const currentGroupMembers = useSessionStore(sessionSelectors.currentGroupAgents, isEqual);
@@ -67,7 +67,7 @@ const Render = memo<MarkdownElementProps<MentionProps>>(({ children, node }) => 
     return (
       <span className={styles.mention}>
         {'@'}
-        {children || 'unknown'}
+        {name || children || 'unknown'}
       </span>
     );
   }
@@ -95,7 +95,7 @@ const Render = memo<MarkdownElementProps<MentionProps>>(({ children, node }) => 
     >
       <span className={styles.mention}>
         {'@'}
-        {member.title || children}
+        {member.title || name || children}
       </span>
     </Popover>
   );


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 🐛 fix

### 🔀 变更说明 | Description of Change

When a sent message containing an `@mention` is rendered in the conversation, it displayed `@unknown` instead of the mentioned name.

**Root cause:** The mention is serialized to markdown with both `name` and `id` attributes (`<mention name="CC 2号机" id="xxx" />`), and the remark plugin parses both into `node.properties`. But `Mention/Render.tsx` only read `id` and resolved the display name solely by looking the id up in `currentGroupMembers`. When the lookup fails (e.g. a non-group / single-agent session, where `currentGroupAgents` returns `[]`, or the agent was removed), it fell back to `children`, which is always empty for a self-closing tag — so it rendered the literal `'unknown'`.

The input box never had this issue because the editor renders its own live mention node using the selected `label` directly, with no id lookup. The two render paths were inconsistent.

**Fix:** Read the serialized `name` from `node.properties` and use it as the display value / fallback. The `currentGroupMembers` lookup is now only used to enrich the Popover (avatar + description), not as the sole source of the display name.

### 📝 补充信息 | Additional Information

N/A