### PR TITLE
📝 docs: add capability-gated feature checklist to ux skill

### DIFF
--- a/.agents/skills/ux/SKILL.md
+++ b/.agents/skills/ux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ux
-description: 'LobeHub product design values (自然 Natural / 意义感 Meaningful / 确定性 Certainty / 生长性 Growth) and per-aspect UX execution checklists. Load this skill whenever the work touches user-interface features or implementation — designing or building any user-facing flow — to get better UX results.'
+description: 'LobeHub product design values / principles / checklists. Load this skill whenever the work touches user-interface features or implementation — designing or building any user-facing flow — to get better UX results.'
 user-invocable: false
 ---
 

--- a/.agents/skills/ux/SKILL.md
+++ b/.agents/skills/ux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ux
-description: 'LobeHub product design values (自然 Natural / 意义感 Meaningful / 确定性 Certainty / 生长性 Growth) and per-aspect UX execution checklists. Use when designing or reviewing any user-facing flow — empty/loading/error states, confirmations, async feedback, button hierarchy, action parity, lists at scale, pickers, discoverability, loading visuals, and capability-gated config reminders (warn when the selected model can not deliver an agentic/tool-calling feature).'
+description: 'LobeHub product design values (自然 Natural / 意义感 Meaningful / 确定性 Certainty / 生长性 Growth) and per-aspect UX execution checklists. Load this skill whenever the work touches user-interface features or implementation — designing or building any user-facing flow — to get better UX results.'
 user-invocable: false
 ---
 

--- a/.agents/skills/ux/SKILL.md
+++ b/.agents/skills/ux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ux
-description: 'LobeHub product design values (自然 Natural / 意义感 Meaningful / 确定性 Certainty / 生长性 Growth) and per-aspect UX execution checklists. Use when designing or reviewing any user-facing flow — empty/loading/error states, confirmations, async feedback, button hierarchy, action parity, lists at scale, pickers, discoverability, and loading visuals.'
+description: 'LobeHub product design values (自然 Natural / 意义感 Meaningful / 确定性 Certainty / 生长性 Growth) and per-aspect UX execution checklists. Use when designing or reviewing any user-facing flow — empty/loading/error states, confirmations, async feedback, button hierarchy, action parity, lists at scale, pickers, discoverability, loading visuals, and capability-gated config reminders (warn when the selected model can not deliver an agentic/tool-calling feature).'
 user-invocable: false
 ---
 
@@ -131,6 +131,30 @@ it explicitly _before_ building. Worked example, the tools/connectors list:
 - [ ] **An intentionally-absent op is a documented decision, not an oversight**
       (e.g. official tools can't be deleted — by design). _(确定性)_
 
+## 9. Capability-gated features・Certainty・Meaningful
+
+A feature can be fully built and still produce a broken result when the selected
+model — or its still-loading config — **can't deliver the capability the feature
+depends on** (for example, an agentic run on a model without tool calling). This
+is usually the user's configuration choice, not a defect; but if the product stays
+silent the user reads it as the product being broken. When a feature's success
+depends on a capability the current config may lack, the product owes a
+**proactive, non-blocking reminder** — a guardrail, not a gate.
+
+- [ ] **Surface the mismatch, don't fail silently.** When a feature needs a model
+      capability (tool calling, vision, reasoning, long context) the current model
+      lacks, show a soft inline warning at the point of action — never a hard block
+      or a modal that stops the user. _(Meaningful)_
+- [ ] **Stay reactive.** The reminder clears the moment the user switches to a
+      capable model — derive it from live state, not a one-shot check. _(Natural)_
+- [ ] **Don't warn while config is loading.** A capability that hasn't resolved yet
+      looks "unsupported"; warning then is a false alarm — exactly the glitch users
+      mistake for a product bug. Warn only on a _resolved_ unsupported state. _(Certainty)_
+- [ ] **Scope to the mode that needs it.** Show only when the capability-dependent
+      mode is on; one reminder per root cause, never a pile of overlapping notices. _(Natural・Certainty)_
+- [ ] **State the problem and the remedy.** The copy says what's wrong _and_ what
+      the user should do about it. _(Meaningful)_
+
 ## Quick review checklist
 
 - [ ] Action leads the user forward; success offers a primary "go to result".
@@ -143,6 +167,7 @@ it explicitly _before_ building. Worked example, the tools/connectors list:
 - [ ] No antd `Spin`; use `NeuralNetworkLoading` / project loaders.
 - [ ] Advanced capability is progressively disclosed / discoverable at the moment of need.
 - [ ] Listed entities have their full lifecycle (not display-only); ops match source (built-in / installed / custom).
+- [ ] Capability-gated feature warns (soft, reactive, load-gated) when the model can't deliver it; copy gives the remedy.
 
 ## Related skills
 


### PR DESCRIPTION
## 💡 Motivation

LobeHub exposes a huge model surface. A feature can be fully built and still produce a broken result when the selected model — or its still-loading config — can't deliver the capability the feature depends on (e.g. an agentic run on a model without tool calling). This is usually the user's configuration choice rather than a defect, but if the product stays silent the user reads it as the product being broken (see #15804).

This adds a design-method checklist to the `ux` skill so we consistently fulfil the **reminder obligation**: a proactive, non-blocking hint — a guardrail, not a gate.

## 📝 Changes

- New section **9. Capability-gated features** in `.agents/skills/ux/SKILL.md`, tagged with the existing design values (Certainty / Meaningful / Natural):
  - Surface the mismatch instead of failing silently (soft inline warning, never a hard block/modal)
  - Stay reactive — clears the moment the user picks a capable model
  - Don't warn while config is still loading (avoid false alarms on unresolved capability)
  - Scope to the mode that needs it; one reminder per root cause
  - Copy states the problem **and** the remedy
- Matching line in the Quick review checklist and an updated skill `description` for discoverability.

Design guidance only — no implementation details. Pairs with the UX surfaced in #15828.

## ✅ Checklist

- [x] Docs/skill-only change, no code paths touched
- [x] English-only wording in the new content