### PR TITLE
✨ feat(chat): add gateway mode hover card

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -164,6 +164,8 @@
   "extendParams.urlContext.title": "Extract Webpage Link Content",
   "followUpPlaceholder": "Follow up.",
   "followUpPlaceholderHeterogeneous": "Follow up.",
+  "gatewayMode.beta": "Beta",
+  "gatewayMode.desc": "Run agents in the cloud through Gateway. Tasks keep running even if you close this page.",
   "gatewayMode.title": "Gateway Mode",
   "group.desc": "Move a task forward with multiple Agents in one shared space.",
   "group.memberTooltip": "There are {{count}} members in the group",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -164,6 +164,8 @@
   "extendParams.urlContext.title": "提取网页链接内容",
   "followUpPlaceholder": "继续跟进。",
   "followUpPlaceholderHeterogeneous": "继续跟进。",
+  "gatewayMode.beta": "Beta",
+  "gatewayMode.desc": "让 Agent 通过 Gateway 在云端执行。即使关闭网页，任务也会继续运行。",
   "gatewayMode.title": "Gateway 模式",
   "group.desc": "在同一对话空间，让多个助理一起推进任务",
   "group.memberTooltip": "群组内有 {{count}} 名成员",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -486,6 +486,9 @@ export default {
   'memory.on.desc': 'Allow AI to actively search and manage your memories during conversation.',
   'memory.on.title': 'Enable Memory Tool',
   'memory.title': 'Memory',
+  'gatewayMode.beta': 'Beta',
+  'gatewayMode.desc':
+    'Run agents in the cloud through Gateway. Tasks keep running even if you close this page.',
   'gatewayMode.title': 'Gateway Mode',
   'search.grounding.imageSearchQueries': 'Image Search Keywords',
   'search.grounding.imageTitle': 'Found {{count}} images',

--- a/src/features/ChatInput/ActionBar/Plus/index.tsx
+++ b/src/features/ChatInput/ActionBar/Plus/index.tsx
@@ -82,29 +82,6 @@ const activeLabel = css`
   }
 `;
 
-const optionLabel = css`
-  display: flex;
-  gap: 12px;
-  align-items: center;
-  justify-content: space-between;
-
-  width: 100%;
-  min-width: 220px;
-
-  .title {
-    line-height: 1.25;
-  }
-
-  .desc {
-    margin-block-start: 3px;
-
-    font-size: 12px;
-    line-height: 1.35;
-    color: ${cssVar.colorTextDescription};
-    white-space: normal;
-  }
-`;
-
 const searchOptionRow = css`
   display: flex;
   gap: 10px;
@@ -164,6 +141,58 @@ const countChip = css`
   color: ${cssVar.colorTextSecondary};
 
   background: ${cssVar.colorFillSecondary};
+`;
+
+const gatewayModeLabel = css`
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  min-width: 0;
+
+  .title {
+    overflow: hidden;
+    min-width: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`;
+
+const betaTag = css`
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+
+  height: 18px;
+  padding-block: 0;
+  padding-inline: 6px;
+  border: 1px solid color-mix(in srgb, ${cssVar.colorInfo} 35%, transparent);
+  border-radius: 6px;
+
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 16px;
+  color: ${cssVar.colorInfo};
+
+  background: ${cssVar.colorInfoBg};
+`;
+
+const gatewayModeInfoCard = css`
+  width: 260px;
+  padding: 12px;
+
+  .title {
+    font-size: 14px;
+    font-weight: 600;
+    line-height: 1.35;
+  }
+
+  .desc {
+    margin-block-start: 6px;
+    font-size: 12px;
+    line-height: 1.5;
+    color: ${cssVar.colorTextSecondary};
+  }
 `;
 
 const activeIcon = (icon: IconProps['icon'], active?: boolean): IconProps['icon'] =>
@@ -378,16 +407,6 @@ const PlusAction = memo(() => {
         label
       );
 
-    const renderOption = (title: string, description: string, active: boolean) => (
-      <div className={cx(optionLabel)}>
-        <div>
-          <div className="title">{title}</div>
-          {description && <div className="desc">{description}</div>}
-        </div>
-        {active && <Icon icon={CheckIcon} size={14} />}
-      </div>
-    );
-
     const renderSearchOption = (
       icon: ReactNode,
       title: string,
@@ -413,6 +432,20 @@ const PlusAction = memo(() => {
       ) : (
         label
       );
+
+    const renderGatewayModeLabel = () => (
+      <span className={cx(gatewayModeLabel)}>
+        <span className="title">{t('gatewayMode.title')}</span>
+        <span className={cx(betaTag)}>{t('gatewayMode.beta')}</span>
+      </span>
+    );
+
+    const gatewayModeInfo = (
+      <div className={cx(gatewayModeInfoCard)}>
+        <div className="title">{t('gatewayMode.title')}</div>
+        <div className="desc">{t('gatewayMode.desc')}</div>
+      </div>
+    );
 
     const skillMenuItems = stripPopoverContent(skillItems as ActionDropdownMenuItems);
 
@@ -559,9 +592,11 @@ const PlusAction = memo(() => {
         ? [
             {
               checked: isGatewayModeEnabled,
-              icon: activeIcon(Cloud, isGatewayModeEnabled),
+              icon: Cloud,
               key: 'gateway-mode',
-              label: t('gatewayMode.title'),
+              label: (
+                <PopoverLabel label={renderGatewayModeLabel()} popoverContent={gatewayModeInfo} />
+              ),
               onCheckedChange: handleToggleGatewayMode,
               type: 'switch',
             } as ActionDropdownMenuItems[number],
@@ -619,7 +654,6 @@ const PlusAction = memo(() => {
     enableFC,
     enableGatewayMode,
     enableKnowledgeBase,
-    defaultDisableGatewayMode,
     handleSelectSearch,
     handleToggleGatewayMode,
     handleToggleMemory,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No related issue found.

#### 🔀 Description of Change

- Add a Beta badge to the Gateway Mode menu label.
- Add a hover popover explaining that Gateway runs agents in the cloud and keeps tasks running after the page closes.
- Add matching `chat` locale strings for the default, en-US, and zh-CN locales.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Checked with:

```bash
pnpm exec eslint src/features/ChatInput/ActionBar/Plus/index.tsx
pnpm exec prettier --check packages/locales/src/default/chat.ts locales/en-US/chat.json locales/zh-CN/chat.json src/features/ChatInput/ActionBar/Plus/index.tsx
node -e "const fs=require('fs'); for (const f of ['locales/en-US/chat.json','locales/zh-CN/chat.json']) JSON.parse(fs.readFileSync(f,'utf8')); console.log('locale json ok')"
```

#### 📸 Screenshots / Videos

Not captured.

#### 📝 Additional Information

None.