### PR TITLE
🐛 fix: route single @agent mention through gateway in gateway mode

### DIFF
--- a/src/store/chat/slices/aiChat/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/conversationLifecycle.test.ts
@@ -1391,6 +1391,115 @@ describe('ConversationLifecycle actions', () => {
         );
       });
 
+      it('should route a single leading @agent through the gateway when gateway mode is enabled', async () => {
+        const { result } = renderHook(() => useChatStore());
+        const targetAgentId = 'agent-direct-target';
+        const toolMessageId = 'tool-call-agent-result';
+        const message = '@Agent B hello';
+
+        const userMessage = createMockMessage({
+          id: TEST_IDS.USER_MESSAGE_ID,
+          role: 'user',
+          content: message,
+        });
+        let assistantMessage = createMockMessage({
+          id: TEST_IDS.ASSISTANT_MESSAGE_ID,
+          role: 'assistant',
+          content: '',
+          tools: [],
+        });
+
+        // sendMessageInServer must still run: directMention deliberately uses the
+        // client message-persistence path even under gateway mode (the supervisor
+        // is a pure router and never executes an LLM turn on the gateway).
+        const sendMessageInServerSpy = vi
+          .spyOn(aiChatService, 'sendMessageInServer')
+          .mockResolvedValue({
+            messages: [userMessage, assistantMessage],
+            topics: [],
+            assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+            userMessageId: TEST_IDS.USER_MESSAGE_ID,
+          } as any);
+
+        (messageService.updateMessage as any).mockImplementation(
+          async (_id: string, value: any) => {
+            assistantMessage = { ...assistantMessage, ...value };
+            return { messages: [userMessage, assistantMessage], success: true };
+          },
+        );
+        (messageService.createMessage as any).mockImplementation(async (params: any) => {
+          const toolMessage = createMockMessage({ ...params, id: toolMessageId, role: 'tool' });
+          return { id: toolMessageId, messages: [userMessage, assistantMessage, toolMessage] };
+        });
+
+        const executeGatewayAgentSpy = vi.fn().mockResolvedValue({
+          assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+          operationId: 'op-gw-sub',
+          userMessageId: TEST_IDS.USER_MESSAGE_ID,
+        });
+
+        act(() => {
+          useChatStore.setState({
+            executeGatewayAgent: executeGatewayAgentSpy,
+            isGatewayModeEnabled: () => true,
+          });
+        });
+
+        await act(async () => {
+          await result.current.sendMessage({
+            message,
+            editorData: {
+              root: {
+                children: [
+                  {
+                    children: [
+                      {
+                        label: 'Agent B',
+                        metadata: { id: targetAgentId, type: 'agent' },
+                        type: 'mention',
+                      },
+                      { text: ' hello', type: 'text' },
+                    ],
+                    type: 'paragraph',
+                  },
+                ],
+                type: 'root',
+              },
+            } as any,
+            context: createTestContext(),
+          });
+        });
+
+        // Messages were persisted client-side (we did NOT take the supervisor
+        // gateway early-return, which skips sendMessageInServer entirely).
+        expect(sendMessageInServerSpy).toHaveBeenCalled();
+        // The callAgent tool call was still emitted on the supervisor message.
+        expect(messageService.updateMessage).toHaveBeenCalledWith(
+          TEST_IDS.ASSISTANT_MESSAGE_ID,
+          expect.objectContaining({
+            tools: [
+              expect.objectContaining({
+                apiName: 'callAgent',
+                identifier: 'lobe-agent-management',
+              }),
+            ],
+          }),
+          expect.objectContaining({ agentId: TEST_IDS.SESSION_ID }),
+        );
+        // The TARGET agent runs on the gateway, not the client.
+        expect(result.current.executeClientAgent).not.toHaveBeenCalled();
+        expect(executeGatewayAgentSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            context: expect.objectContaining({
+              agentId: targetAgentId,
+              scope: 'sub_agent',
+              subAgentId: targetAgentId,
+            }),
+            message,
+          }),
+        );
+      });
+
       it('should keep supervisor delegation for multiple @agent mentions', async () => {
         const { result } = renderHook(() => useChatStore());
 

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -716,7 +716,15 @@ export class ConversationLifecycleActionImpl {
     }
 
     // ── Gateway mode: skip sendMessageInServer, let execAgentTask handle everything ──
-    if (runtimeType === 'gateway') {
+    // A single-agent @mention (`directMentionRoute`) is the exception: the current
+    // agent acts as a pure deterministic router and never runs an LLM turn itself, so
+    // there is nothing to execute on the gateway. We let it fall through to the client
+    // message-persistence path below, where `#executeDirectMentionRoute` emits the
+    // callAgent tool call and dispatches the *target* agent via
+    // `dispatchNonHeteroSubAgent` — which re-selects the runtime and runs the target on
+    // the gateway when gateway mode is enabled. Routing the supervisor through the
+    // gateway here would drop the mention entirely (execAgentTask carries no mention data).
+    if (runtimeType === 'gateway' && !directMentionRoute) {
       try {
         // Pass `sendMessage` as `parentOperationId` so executeGatewayAgent
         // completes it the instant phase-1 init finishes (after the child


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 🐛 fix

### 🔀 变更说明 | Description of Change

In **gateway mode**, `@`-mentioning a single agent in a non-group chat silently did nothing — the mentioned agent was never invoked.

**Root cause:** A single leading `@agent` mention (`directMentionRoute`) makes the current agent act as a **pure deterministic router** — it never runs an LLM turn itself; it just emits a `callAgent` tool call and dispatches the target. But the routing logic that consumes `directMentionRoute` lives at the *end* of the client-mode branch in `sendMessage`. The gateway path early-returns much earlier and runs the supervisor on the server via `execAgentTask`, whose payload carries no mention data — so the mention was dropped entirely and the target agent never ran.

**Fix:** Guard the gateway early-return with `!directMentionRoute`. A directMention request now falls through to the client message-persistence path, where `#executeDirectMentionRoute` emits the `callAgent` tool call and dispatches the **target** agent via `dispatchNonHeteroSubAgent` — which re-selects the runtime and runs the target *on the gateway* when gateway mode is enabled (`isGatewayModeEnabled`).

Key points:
- The supervisor turn is a deterministic router, so running it through the gateway was never necessary — bypassing it loses nothing.
- The target agent still executes on the gateway, reusing the existing gateway branch in `dispatchNonHeteroSubAgent`.
- **No server-side changes** — `ExecAgentSchema` / `execAgent` / context-engine are untouched.

**Scope:** This covers the single-mention `directMentionRoute` case (the common one). Multi-mention supervisor delegation (`hasMentionedAgents`), where the supervisor LLM must actually decide, still runs server-side in gateway mode and would need separate mention plumbing — out of scope here.

### ✅ 测试 | Testing

Added a regression test in `conversationLifecycle.test.ts`: with gateway mode enabled, a single leading `@agent` now persists messages client-side, emits the `callAgent` tool call, and dispatches the target via `executeGatewayAgent` (never `executeClientAgent`). Verified the test fails without the guard. All 33 tests in the file pass.