### PR TITLE
 🔨 chore(agent-runtime): enable S3 tracing by default in production

### DIFF
--- a/apps/server/src/services/agentRuntime/AbandonOperationService.ts
+++ b/apps/server/src/services/agentRuntime/AbandonOperationService.ts
@@ -10,6 +10,7 @@ import type { LobeChatDatabase } from '@/database/type';
 import { AgentRuntimeCoordinator } from '@/server/modules/AgentRuntime/AgentRuntimeCoordinator';
 
 import { OperationTraceRecorder } from './OperationTraceRecorder';
+import { createDefaultSnapshotStore } from './snapshotStore';
 
 const log = debug('lobe-server:abandon-operation');
 
@@ -126,26 +127,4 @@ export class AbandonOperationService {
     log('[%s] abandoned op finalized (reason=%s): %O', operationId, reason, result);
     return result;
   }
-}
-
-function createDefaultSnapshotStore(): ISnapshotStore | null {
-  if (process.env.ENABLE_AGENT_S3_TRACING === '1') {
-    try {
-      const { S3SnapshotStore } = require('@/server/modules/AgentTracing');
-      return new S3SnapshotStore();
-    } catch {
-      /* S3SnapshotStore not available */
-    }
-  }
-
-  if (process.env.NODE_ENV === 'development') {
-    try {
-      const { FileSnapshotStore } = require('@lobechat/agent-tracing');
-      return new FileSnapshotStore();
-    } catch {
-      /* agent-tracing not available */
-    }
-  }
-
-  return null;
 }

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -61,6 +61,7 @@ import { CompletionLifecycle } from './CompletionLifecycle';
 import { hookDispatcher } from './hooks';
 import { HumanInterventionHandler } from './HumanInterventionHandler';
 import { OperationTraceRecorder } from './OperationTraceRecorder';
+import { createDefaultSnapshotStore } from './snapshotStore';
 import { buildStepPresentation, formatTokenCount } from './stepPresentation';
 import {
   type AgentExecutionParams,
@@ -256,7 +257,7 @@ export class AgentRuntimeService {
     this.queueService =
       options?.queueService === null ? null : (options?.queueService ?? new QueueService());
     this.traceRecorder = new OperationTraceRecorder(
-      options?.snapshotStore ?? this.createDefaultSnapshotStore(),
+      options?.snapshotStore ?? createDefaultSnapshotStore(),
     );
     this.agentFactory = options?.agentFactory;
     this.delegate = options?.delegate ?? {};
@@ -1972,34 +1973,6 @@ export class AgentRuntimeService {
     });
 
     return { agent, runtime };
-  }
-
-  /**
-   * Create default snapshot store based on environment.
-   * - ENABLE_AGENT_S3_TRACING=1 → S3SnapshotStore
-   * - NODE_ENV=development → FileSnapshotStore
-   * - Otherwise → null (no tracing)
-   */
-  private createDefaultSnapshotStore(): ISnapshotStore | null {
-    if (process.env.ENABLE_AGENT_S3_TRACING === '1') {
-      try {
-        const { S3SnapshotStore } = require('@/server/modules/AgentTracing');
-        return new S3SnapshotStore();
-      } catch {
-        // S3SnapshotStore not available
-      }
-    }
-
-    if (process.env.NODE_ENV === 'development') {
-      try {
-        const { FileSnapshotStore } = require('@lobechat/agent-tracing');
-        return new FileSnapshotStore();
-      } catch {
-        // agent-tracing not available
-      }
-    }
-
-    return null;
   }
 
   /**

--- a/apps/server/src/services/agentRuntime/__tests__/snapshotStore.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/snapshotStore.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createDefaultSnapshotStore, shouldUseAgentS3Tracing } from '../snapshotStore';
+
+const s3SnapshotStoreMock = vi.fn(() => ({ kind: 's3' }));
+const fileSnapshotStoreMock = vi.fn(() => ({ kind: 'file' }));
+
+const setEnv = (nodeEnv: string, agentS3Tracing?: string) => {
+  vi.stubEnv('NODE_ENV', nodeEnv);
+  vi.stubEnv('ENABLE_AGENT_S3_TRACING', agentS3Tracing);
+};
+
+const loadModule = vi.fn((moduleName: string) => {
+  if (moduleName === '@/server/modules/AgentTracing') {
+    return { S3SnapshotStore: s3SnapshotStoreMock };
+  }
+
+  if (moduleName === '@lobechat/agent-tracing') {
+    return { FileSnapshotStore: fileSnapshotStoreMock };
+  }
+
+  throw new Error(`Unexpected module: ${moduleName}`);
+});
+
+describe('agent runtime snapshot store defaults', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  it('enables S3 tracing by default in production when env is unset', () => {
+    setEnv('production');
+
+    expect(shouldUseAgentS3Tracing()).toBe(true);
+    expect(createDefaultSnapshotStore(loadModule)).toEqual({ kind: 's3' });
+    expect(loadModule).toHaveBeenCalledWith('@/server/modules/AgentTracing');
+    expect(s3SnapshotStoreMock).toHaveBeenCalledTimes(1);
+    expect(fileSnapshotStoreMock).not.toHaveBeenCalled();
+  });
+
+  it('uses the local file snapshot store in development when env is unset', () => {
+    setEnv('development');
+
+    expect(shouldUseAgentS3Tracing()).toBe(false);
+    expect(createDefaultSnapshotStore(loadModule)).toEqual({ kind: 'file' });
+    expect(loadModule).toHaveBeenCalledWith('@lobechat/agent-tracing');
+    expect(s3SnapshotStoreMock).not.toHaveBeenCalled();
+    expect(fileSnapshotStoreMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets ENABLE_AGENT_S3_TRACING=1 force S3 tracing outside production', () => {
+    setEnv('development', '1');
+
+    expect(shouldUseAgentS3Tracing()).toBe(true);
+    expect(createDefaultSnapshotStore(loadModule)).toEqual({ kind: 's3' });
+    expect(loadModule).toHaveBeenCalledWith('@/server/modules/AgentTracing');
+    expect(s3SnapshotStoreMock).toHaveBeenCalledTimes(1);
+    expect(fileSnapshotStoreMock).not.toHaveBeenCalled();
+  });
+
+  it('lets an explicit ENABLE_AGENT_S3_TRACING value disable the production default', () => {
+    setEnv('production', '0');
+
+    expect(shouldUseAgentS3Tracing()).toBe(false);
+    expect(createDefaultSnapshotStore(loadModule)).toBeNull();
+    expect(loadModule).not.toHaveBeenCalled();
+    expect(s3SnapshotStoreMock).not.toHaveBeenCalled();
+    expect(fileSnapshotStoreMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/services/agentRuntime/snapshotStore.ts
+++ b/apps/server/src/services/agentRuntime/snapshotStore.ts
@@ -1,0 +1,59 @@
+import type { ISnapshotStore } from '@lobechat/agent-tracing';
+
+const ENABLE_AGENT_S3_TRACING_VALUE = '1';
+
+type SnapshotStoreConstructor = new () => ISnapshotStore;
+type SnapshotStoreModuleLoader = (moduleName: string) => unknown;
+
+interface FileSnapshotStoreModule {
+  FileSnapshotStore: SnapshotStoreConstructor;
+}
+
+interface S3SnapshotStoreModule {
+  S3SnapshotStore: SnapshotStoreConstructor;
+}
+
+const nodeRequire: SnapshotStoreModuleLoader = (moduleName) => require(moduleName);
+
+export const shouldUseAgentS3Tracing = () => {
+  const explicitValue = process.env.ENABLE_AGENT_S3_TRACING;
+
+  if (explicitValue !== undefined) return explicitValue === ENABLE_AGENT_S3_TRACING_VALUE;
+
+  return process.env.NODE_ENV === 'production';
+};
+
+/**
+ * Create default snapshot store based on environment.
+ * - ENABLE_AGENT_S3_TRACING=1 -> S3SnapshotStore
+ * - NODE_ENV=production with ENABLE_AGENT_S3_TRACING unset -> S3SnapshotStore
+ * - NODE_ENV=development -> FileSnapshotStore
+ * - Otherwise -> null (no tracing)
+ */
+export const createDefaultSnapshotStore = (
+  loadModule: SnapshotStoreModuleLoader = nodeRequire,
+): ISnapshotStore | null => {
+  if (shouldUseAgentS3Tracing()) {
+    try {
+      const { S3SnapshotStore } = loadModule(
+        '@/server/modules/AgentTracing',
+      ) as S3SnapshotStoreModule;
+      return new S3SnapshotStore();
+    } catch {
+      // S3SnapshotStore not available
+    }
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    try {
+      const { FileSnapshotStore } = loadModule(
+        '@lobechat/agent-tracing',
+      ) as FileSnapshotStoreModule;
+      return new FileSnapshotStore();
+    } catch {
+      // agent-tracing not available
+    }
+  }
+
+  return null;
+};


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Centralize the default agent runtime snapshot store selection in a shared helper.
- Enable `S3SnapshotStore` by default when `NODE_ENV=production` and `ENABLE_AGENT_S3_TRACING` is unset.
- Preserve explicit env overrides: `ENABLE_AGENT_S3_TRACING=1` forces S3 outside production, while an explicit non-`1` value disables the production default.
- Keep the existing local development fallback to `FileSnapshotStore`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' apps/server/src/services/agentRuntime/__tests__/snapshotStore.test.ts apps/server/src/services/agentRuntime/__tests__/AbandonOperationService.test.ts apps/server/src/services/agentRuntime/AgentRuntimeService.test.ts
git diff --check
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

`bun run type-check` currently fails on unrelated repository-wide type errors, including existing `agentSignal` implicit-any errors, missing `@lobechat/types` exports in package code, and duplicate UI/React dependency type incompatibilities. No touched `agentRuntime` files were reported after the env-stub fix.
