### PR TITLE
🔒 fix(deps): pin remark-cjk-friendly to 2.0.1 to dodge broken 2.1.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -580,6 +580,7 @@
       "pdfjs-dist": "5.4.530",
       "react": "19.2.5",
       "react-dom": "19.2.5",
+      "remark-cjk-friendly": "2.0.1",
       "stylelint-config-clean-order": "7.0.0",
       "typescript": "6.0.3",
       "vitest": "3.2.6"


### PR DESCRIPTION
### 💡 Description of Change

`remark-cjk-friendly@2.1.0` (published 2026-06-14, pulled in transitively via `@lobehub/ui`) declares a dependency on **`mdast-util-to-markdown-cjk-friendly@1.0.0`**, which was never published to the npm registry. Every fresh `pnpm i` that resolves to `2.1.0` now hard-fails:

```
ERR_PNPM_FETCH_404  GET .../mdast-util-to-markdown-cjk-friendly: Not Found - 404
  at remark-cjk-friendly@2.1.0
  (installing deps of @lobehub/ui@5.15.15)
```

This pins `remark-cjk-friendly` to the last good release (`2.0.1`) via `pnpm.overrides` to unblock CI.

This is a **temporary** workaround — remove the override once upstream republishes the missing package or yanks `2.1.0`. Tracked upstream at tats-u/markdown-cjk-friendly#46.

### 🔗 Related

Upstream broken release: https://github.com/tats-u/markdown-cjk-friendly/issues/46

### ✅ How to Test

- `pnpm i` resolves without the `mdast-util-to-markdown-cjk-friendly` 404 ✓ (verified locally, install completes; resolves to `remark-cjk-friendly@2.0.1`)
- CI green on this branch

### 🔄 Change Type

🔒 fix(deps): dependency / build fix