### PR TITLE
🐛 fix(home): hide agent-mode notice while config is loading

### DIFF
--- a/src/routes/(main)/home/features/InputArea/index.tsx
+++ b/src/routes/(main)/home/features/InputArea/index.tsx
@@ -159,6 +159,7 @@ const InputArea = () => {
             <DesktopChatInput
               dropdownPlacement="bottomLeft"
               inputContainerProps={inputContainerProps}
+              isConfigLoading={isAgentConfigLoading}
               placeholder={dailyHint}
               showControlBar={false}
             />


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- N/A -->

#### 🔀 Description of Change

The home `InputArea` already computed `isAgentConfigLoading` (used to disable the send button), but never forwarded it to `<DesktopChatInput>`. Since `AgentModeNotice` is only gated by `!isConfigLoading` inside `ChatInput/Desktop/index.tsx`, the "current model doesn't support Agentic tool calling" warning flashed during hydration — before model info had loaded, `supportToolUse` defaults to `false` so the banner showed, then disappeared once config finished loading.

This forwards `isConfigLoading={isAgentConfigLoading}` to `DesktopChatInput`, matching every other call site (Conversation, AgentColumn). The notice now only appears after config has loaded.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

On the home page with a fresh/cold load, the agent-mode unsupported-model warning no longer flashes during the loading state; it appears (when applicable) only after config has hydrated.

#### 📝 Additional Information

One-line fix; follows the existing `isConfigLoading` skeleton/notice gating convention.