### PR TITLE
feat: add fastCRW search/crawl provider

### DIFF
--- a/apps/cli/src/commands/search.ts
+++ b/apps/cli/src/commands/search.ts
@@ -84,7 +84,7 @@ export function registerSearchCommand(program: Command) {
     .option('--json [fields]', 'Output JSON, optionally specify fields (comma-separated)')
     .option(
       '-i, --impl <impls>',
-      'Crawler implementations for web URLs (comma-separated: browserless, exa, firecrawl, jina, naive, search1api, tavily)',
+      'Crawler implementations for web URLs (comma-separated: browserless, crw, exa, firecrawl, jina, naive, search1api, tavily)',
     )
     .action(
       async (
@@ -220,7 +220,7 @@ async function crawlView(url: string, options: { impl?: string; json?: string | 
   const toolsClient = await getToolsTrpcClient();
 
   const input: {
-    impls?: ('browserless' | 'exa' | 'firecrawl' | 'jina' | 'naive' | 'search1api' | 'tavily')[];
+    impls?: ('browserless' | 'crw' | 'exa' | 'firecrawl' | 'jina' | 'naive' | 'search1api' | 'tavily')[];
     urls: string[];
   } = { urls: [url] };
 

--- a/apps/server/src/routers/tools/search.test.ts
+++ b/apps/server/src/routers/tools/search.test.ts
@@ -47,6 +47,7 @@ describe('searchRouter', () => {
 
       const allImpls = [
         'browserless',
+        'crw',
         'exa',
         'firecrawl',
         'jina',

--- a/apps/server/src/routers/tools/search.ts
+++ b/apps/server/src/routers/tools/search.ts
@@ -10,7 +10,7 @@ export const searchRouter = router({
     .input(
       z.object({
         impls: z
-          .enum(['browserless', 'exa', 'firecrawl', 'jina', 'naive', 'search1api', 'tavily'])
+          .enum(['browserless', 'crw', 'exa', 'firecrawl', 'jina', 'naive', 'search1api', 'tavily'])
           .array()
           .optional(),
         urls: z.string().array(),

--- a/apps/server/src/services/search/impls/crw/index.ts
+++ b/apps/server/src/services/search/impls/crw/index.ts
@@ -101,52 +101,30 @@ export class CrwImpl implements SearchServiceImpl {
 
       log('Parsed fastCRW response: %o', crwResponse);
 
-      // Response returns data as object with web/images/news arrays
-      const webResults = crwResponse.data.web || [];
-      const imageResults = crwResponse.data.images || [];
-      const newsResults = crwResponse.data.news || [];
+      // fastCRW returns a flat `data` array of hits (Firecrawl-compatible shape).
+      const searchResults = crwResponse.data || [];
 
-      // Map web results
-      const mappedWebResults = webResults.map(
-        (result): UniformSearchResult => ({
-          category: 'general',
-          content: result.description || result.markdown || '',
+      const allResults = searchResults.map((result): UniformSearchResult => {
+        const isImage = result.category === 'images';
+        const isNews = result.category === 'news';
+
+        const category = isImage ? 'images' : isNews ? 'news' : 'general';
+        const content = isImage
+          ? result.title || ''
+          : result.description || result.snippet || result.markdown || '';
+        // Image hits use `imageUrl` as the primary link; others use `url`.
+        const url = isImage ? result.imageUrl || result.url : result.url;
+
+        return {
+          category,
+          content,
           engines: ['crw'],
-          parsedUrl: result.url ? new URL(result.url).hostname : '',
-          score: 1,
+          parsedUrl: url ? new URL(url).hostname : '',
+          score: result.score ?? 1,
           title: result.title || '',
-          url: result.url,
-        }),
-      );
-
-      // Map news results
-      const mappedNewsResults = newsResults.map(
-        (result): UniformSearchResult => ({
-          category: 'news',
-          content: result.snippet || result.markdown || '',
-          engines: ['crw'],
-          parsedUrl: result.url ? new URL(result.url).hostname : '',
-          score: 1,
-          title: result.title || '',
-          url: result.url,
-        }),
-      );
-
-      // Map image results
-      const mappedImageResults = imageResults.map(
-        (result): UniformSearchResult => ({
-          category: 'images',
-          content: result.title || '',
-          engines: ['crw'],
-          parsedUrl: result.url ? new URL(result.url).hostname : '',
-          score: 1,
-          title: result.title || '',
-          url: result.imageUrl, // Use imageUrl for images
-        }),
-      );
-
-      // Combine all results
-      const allResults = [...mappedWebResults, ...mappedNewsResults, ...mappedImageResults];
+          url,
+        };
+      });
 
       log('Mapped %d results to SearchResult format', allResults.length);
 

--- a/apps/server/src/services/search/impls/crw/index.ts
+++ b/apps/server/src/services/search/impls/crw/index.ts
@@ -1,0 +1,172 @@
+import {
+  type SearchParams,
+  type UniformSearchResponse,
+  type UniformSearchResult,
+} from '@lobechat/types';
+import { TRPCError } from '@trpc/server';
+import debug from 'debug';
+import urlJoin from 'url-join';
+
+import { type SearchServiceImpl } from '../type';
+import { type CrwResponse, type CrwSearchParameters } from './type';
+
+const log = debug('lobe-search:Crw');
+
+const timeRangeMapping = {
+  day: 'qdr:d',
+  month: 'qdr:m',
+  week: 'qdr:w',
+  year: 'qdr:y',
+};
+
+/**
+ * fastCRW implementation of the search service.
+ * fastCRW is a Firecrawl-compatible web data engine (single binary; self-host or cloud).
+ * This mirrors the Firecrawl impl, defaulting to the managed cloud base URL.
+ */
+export class CrwImpl implements SearchServiceImpl {
+  private get apiKey(): string | undefined {
+    return process.env.CRW_API_KEY;
+  }
+
+  private get baseUrl(): string {
+    // Default to the managed cloud; allow overriding the base URL for self-host.
+    return process.env.CRW_URL || 'https://fastcrw.com/api';
+  }
+
+  async query(query: string, params: SearchParams = {}): Promise<UniformSearchResponse> {
+    log('Starting fastCRW query with query: "%s", params: %o', query, params);
+    const endpoint = urlJoin(this.baseUrl, '/v1/search');
+
+    const defaultQueryParams: CrwSearchParameters = {
+      limit: 20,
+      query,
+      /*
+      scrapeOptions: {
+        formats: ["markdown"]
+      },
+      */
+      sources: [{ type: 'web' }, { type: 'news' }],
+    };
+
+    const body: CrwSearchParameters = {
+      ...defaultQueryParams,
+      tbs:
+        params?.searchTimeRange && params.searchTimeRange !== 'anytime'
+          ? (timeRangeMapping[params.searchTimeRange as keyof typeof timeRangeMapping] ?? undefined)
+          : undefined,
+    };
+
+    log('Constructed request body: %o', body);
+
+    let response: Response;
+    const startAt = Date.now();
+    let costTime: number;
+    try {
+      log('Sending request to endpoint: %s', endpoint);
+      response = await fetch(endpoint, {
+        body: JSON.stringify(body),
+        headers: {
+          'Authorization': this.apiKey ? `Bearer ${this.apiKey}` : '',
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      });
+      log('Received response with status: %d', response.status);
+      costTime = Date.now() - startAt;
+    } catch (error) {
+      log.extend('error')('fastCRW fetch error: %o', error);
+      throw new TRPCError({
+        cause: error,
+        code: 'SERVICE_UNAVAILABLE',
+        message: 'Failed to connect to fastCRW.',
+      });
+    }
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      log.extend('error')(
+        `fastCRW request failed with status ${response.status}: %s`,
+        errorBody.length > 200 ? `${errorBody.slice(0, 200)}...` : errorBody,
+      );
+      throw new TRPCError({
+        cause: errorBody,
+        code: 'SERVICE_UNAVAILABLE',
+        message: `fastCRW request failed: ${response.statusText}`,
+      });
+    }
+
+    try {
+      const crwResponse = (await response.json()) as CrwResponse;
+
+      log('Parsed fastCRW response: %o', crwResponse);
+
+      // Response returns data as object with web/images/news arrays
+      const webResults = crwResponse.data.web || [];
+      const imageResults = crwResponse.data.images || [];
+      const newsResults = crwResponse.data.news || [];
+
+      // Map web results
+      const mappedWebResults = webResults.map(
+        (result): UniformSearchResult => ({
+          category: 'general',
+          content: result.description || result.markdown || '',
+          engines: ['crw'],
+          parsedUrl: result.url ? new URL(result.url).hostname : '',
+          score: 1,
+          title: result.title || '',
+          url: result.url,
+        }),
+      );
+
+      // Map news results
+      const mappedNewsResults = newsResults.map(
+        (result): UniformSearchResult => ({
+          category: 'news',
+          content: result.snippet || result.markdown || '',
+          engines: ['crw'],
+          parsedUrl: result.url ? new URL(result.url).hostname : '',
+          score: 1,
+          title: result.title || '',
+          url: result.url,
+        }),
+      );
+
+      // Map image results
+      const mappedImageResults = imageResults.map(
+        (result): UniformSearchResult => ({
+          category: 'images',
+          content: result.title || '',
+          engines: ['crw'],
+          parsedUrl: result.url ? new URL(result.url).hostname : '',
+          score: 1,
+          title: result.title || '',
+          url: result.imageUrl, // Use imageUrl for images
+        }),
+      );
+
+      // Combine all results
+      const allResults = [...mappedWebResults, ...mappedNewsResults, ...mappedImageResults];
+
+      log('Mapped %d results to SearchResult format', allResults.length);
+
+      if (crwResponse.warning) {
+        log.extend('warn')('fastCRW warning: %s', crwResponse.warning);
+      }
+
+      return {
+        costTime,
+        query,
+        resultNumbers: allResults.length,
+        results: allResults,
+      };
+    } catch (error) {
+      log.extend('error')('Error parsing fastCRW response: %o', error);
+      throw new TRPCError({
+        cause: error,
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to parse fastCRW response.',
+      });
+    }
+  }
+}

--- a/apps/server/src/services/search/impls/crw/type.ts
+++ b/apps/server/src/services/search/impls/crw/type.ts
@@ -1,0 +1,87 @@
+// fastCRW is a Firecrawl-compatible web scraper; these types mirror the Firecrawl
+// search impl shapes (cloud base https://fastcrw.com/api).
+interface CrwScrapeOptions {
+  blockAds?: boolean;
+  formats?: string[];
+  maxAge?: number;
+  onlyMainContent?: boolean;
+  removeBase64Images?: boolean;
+}
+
+type CrwSource =
+  | { location?: string; tbs?: string; type: 'web' }
+  | { type: 'images' }
+  | { type: 'news' };
+
+type CrwCategory = { type: 'github' } | { type: 'research' } | { type: 'pdf' };
+
+export interface CrwSearchParameters {
+  categories?: CrwCategory[];
+  country?: string;
+  ignoreInvalidURLs?: boolean;
+  limit?: number;
+  location?: string;
+  query: string;
+  scrapeOptions?: CrwScrapeOptions;
+  sources?: CrwSource[];
+  tbs?: string;
+  timeout?: number;
+}
+
+interface CrwMetadata {
+  description?: string;
+  error?: string | null;
+  sourceURL?: string;
+  statusCode?: number;
+  title?: string;
+}
+
+// Web search result
+interface CrwWebResult {
+  description: string;
+  html?: string | null;
+  links?: string[];
+  markdown?: string | null;
+  metadata?: CrwMetadata;
+  rawHtml?: string | null;
+  screenshot?: string | null;
+  title: string;
+  url: string;
+}
+
+// Image search result
+interface CrwImageResult {
+  imageHeight: number;
+  imageUrl: string;
+  imageWidth: number;
+  position: number;
+  title: string;
+  url: string;
+}
+
+// News search result
+interface CrwNewsResult {
+  date: string;
+  html?: string | null;
+  imageUrl?: string;
+  links?: string[];
+  markdown?: string | null;
+  metadata?: CrwMetadata;
+  position: number;
+  rawHtml?: string | null;
+  screenshot?: string | null;
+  snippet: string;
+  title: string;
+  url: string;
+}
+
+// Response structure
+export interface CrwResponse {
+  data: {
+    images?: CrwImageResult[];
+    news?: CrwNewsResult[];
+    web?: CrwWebResult[];
+  };
+  success: boolean;
+  warning?: string | null;
+}

--- a/apps/server/src/services/search/impls/crw/type.ts
+++ b/apps/server/src/services/search/impls/crw/type.ts
@@ -36,52 +36,26 @@ interface CrwMetadata {
   title?: string;
 }
 
-// Web search result
-interface CrwWebResult {
-  description: string;
-  html?: string | null;
-  links?: string[];
-  markdown?: string | null;
-  metadata?: CrwMetadata;
-  rawHtml?: string | null;
-  screenshot?: string | null;
-  title: string;
-  url: string;
-}
-
-// Image search result
-interface CrwImageResult {
-  imageHeight: number;
-  imageUrl: string;
-  imageWidth: number;
-  position: number;
-  title: string;
-  url: string;
-}
-
-// News search result
-interface CrwNewsResult {
-  date: string;
+// fastCRW returns search hits as a flat array (Firecrawl-compatible shape:
+// `{ success, data: [...] }`). Each hit carries the fields below; `category`
+// distinguishes web/news/image results.
+interface CrwSearchResult {
+  category?: string;
+  description?: string;
   html?: string | null;
   imageUrl?: string;
-  links?: string[];
   markdown?: string | null;
   metadata?: CrwMetadata;
-  position: number;
-  rawHtml?: string | null;
-  screenshot?: string | null;
-  snippet: string;
-  title: string;
+  position?: number;
+  score?: number;
+  snippet?: string;
+  title?: string;
   url: string;
 }
 
 // Response structure
 export interface CrwResponse {
-  data: {
-    images?: CrwImageResult[];
-    news?: CrwNewsResult[];
-    web?: CrwWebResult[];
-  };
+  data: CrwSearchResult[];
   success: boolean;
   warning?: string | null;
 }

--- a/apps/server/src/services/search/impls/index.ts
+++ b/apps/server/src/services/search/impls/index.ts
@@ -1,6 +1,7 @@
 import { AnspireImpl } from './anspire';
 import { BochaImpl } from './bocha';
 import { BraveImpl } from './brave';
+import { CrwImpl } from './crw';
 import { ExaImpl } from './exa';
 import { FirecrawlImpl } from './firecrawl';
 import { GoogleImpl } from './google';
@@ -18,6 +19,7 @@ export enum SearchImplType {
   Anspire = 'anspire',
   Bocha = 'bocha',
   Brave = 'brave',
+  Crw = 'crw',
   Exa = 'exa',
   Firecrawl = 'firecrawl',
   Google = 'google',
@@ -45,6 +47,10 @@ export const createSearchServiceImpl = (
 
     case SearchImplType.Brave: {
       return new BraveImpl();
+    }
+
+    case SearchImplType.Crw: {
+      return new CrwImpl();
     }
 
     case SearchImplType.Exa: {

--- a/packages/web-crawler/src/crawImpl/__tests__/crw.test.ts
+++ b/packages/web-crawler/src/crawImpl/__tests__/crw.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createMockResponse } from '../../test-utils';
+import { NetworkConnectionError, PageNotFoundError, TimeoutError } from '../../utils/errorType';
+import { crw } from '../crw';
+
+// Mock dependencies
+vi.mock('../../utils/withTimeout', () => ({
+  DEFAULT_TIMEOUT: 30000,
+  withTimeout: vi.fn(),
+}));
+
+describe('crw crawler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.CRW_API_KEY;
+    delete process.env.CRW_URL;
+  });
+
+  it('should successfully crawl content with API key', async () => {
+    process.env.CRW_API_KEY = 'test-api-key';
+
+    const mockResponse = createMockResponse({
+      success: true,
+      data: {
+        markdown: 'This is a test markdown content with enough length to pass validation. '.repeat(
+          3,
+        ),
+        metadata: {
+          title: 'Test Article',
+          description: 'Test description',
+          sourceURL: 'https://example.com',
+          statusCode: 200,
+          language: 'en',
+          keywords: 'test',
+          robots: 'index',
+        },
+      },
+    });
+
+    const { withTimeout } = await import('../../utils/withTimeout');
+    vi.mocked(withTimeout).mockResolvedValue(mockResponse as any);
+
+    const result = await crw('https://example.com', { filterOptions: {} });
+
+    expect(result).toEqual({
+      content: 'This is a test markdown content with enough length to pass validation. '.repeat(3),
+      contentType: 'text',
+      description: 'Test description',
+      length: 'This is a test markdown content with enough length to pass validation. '.repeat(3)
+        .length,
+      siteName: 'example.com',
+      title: 'Test Article',
+      url: 'https://example.com',
+    });
+
+    expect(withTimeout).toHaveBeenCalledWith(expect.any(Function), 30000);
+  });
+
+  it('should handle missing API key', async () => {
+    const mockResponse = createMockResponse({
+      success: true,
+      data: {
+        markdown: 'Test content with sufficient length. '.repeat(5),
+        metadata: {
+          title: 'Test',
+          description: 'Test',
+          sourceURL: 'https://example.com',
+          statusCode: 200,
+          language: 'en',
+          keywords: 'test',
+          robots: 'index',
+        },
+      },
+    });
+
+    const { withTimeout } = await import('../../utils/withTimeout');
+    vi.mocked(withTimeout).mockResolvedValue(mockResponse as any);
+
+    await crw('https://example.com', { filterOptions: {} });
+
+    expect(withTimeout).toHaveBeenCalledWith(expect.any(Function), 30000);
+  });
+
+  it('should return undefined for short content', async () => {
+    process.env.CRW_API_KEY = 'test-api-key';
+
+    const mockResponse = createMockResponse({
+      success: true,
+      data: {
+        markdown: 'Short', // Content too short
+        metadata: {
+          title: 'Test',
+          description: 'Test',
+          sourceURL: 'https://example.com',
+          statusCode: 200,
+          language: 'en',
+          keywords: 'test',
+          robots: 'index',
+        },
+      },
+    });
+
+    const { withTimeout } = await import('../../utils/withTimeout');
+    vi.mocked(withTimeout).mockResolvedValue(mockResponse as any);
+
+    const result = await crw('https://example.com', { filterOptions: {} });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when markdown is missing', async () => {
+    process.env.CRW_API_KEY = 'test-api-key';
+
+    const mockResponse = createMockResponse({
+      success: true,
+      data: {
+        // markdown is missing
+        metadata: {
+          title: 'Test',
+          description: 'Test',
+          sourceURL: 'https://example.com',
+          statusCode: 200,
+          language: 'en',
+          keywords: 'test',
+          robots: 'index',
+        },
+      },
+    });
+
+    const { withTimeout } = await import('../../utils/withTimeout');
+    vi.mocked(withTimeout).mockResolvedValue(mockResponse as any);
+
+    const result = await crw('https://example.com', { filterOptions: {} });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should throw PageNotFoundError for 404 status', async () => {
+    process.env.CRW_API_KEY = 'test-api-key';
+
+    const mockResponse = createMockResponse('Not Found', {
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    });
+
+    const { withTimeout } = await import('../../utils/withTimeout');
+    vi.mocked(withTimeout).mockResolvedValue(mockResponse as any);
+
+    await expect(crw('https://example.com', { filterOptions: {} })).rejects.toThrow(
+      PageNotFoundError,
+    );
+  });
+
+  it('should throw error for other HTTP errors', async () => {
+    process.env.CRW_API_KEY = 'test-api-key';
+
+    const mockResponse = createMockResponse('', {
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    });
+
+    const { withTimeout } = await import('../../utils/withTimeout');
+    vi.mocked(withTimeout).mockResolvedValue(mockResponse as any);
+
+    await expect(crw('https://example.com', { filterOptions: {} })).rejects.toThrow(
+      'fastCRW request failed with status 500: Internal Server Error',
+    );
+  });
+
+  it('should throw NetworkConnectionError for fetch failures', async () => {
+    process.env.CRW_API_KEY = 'test-api-key';
+
+    const { withTimeout } = await import('../../utils/withTimeout');
+    vi.mocked(withTimeout).mockRejectedValue(new TypeError('fetch failed'));
+
+    await expect(crw('https://example.com', { filterOptions: {} })).rejects.toThrow(
+      NetworkConnectionError,
+    );
+  });
+
+  it('should throw TimeoutError when request times out', async () => {
+    process.env.CRW_API_KEY = 'test-api-key';
+
+    const timeoutError = new TimeoutError('Request timeout');
+
+    const { withTimeout } = await import('../../utils/withTimeout');
+    vi.mocked(withTimeout).mockRejectedValue(timeoutError);
+
+    await expect(crw('https://example.com', { filterOptions: {} })).rejects.toThrow(TimeoutError);
+  });
+
+  it('should rethrow unknown errors', async () => {
+    process.env.CRW_API_KEY = 'test-api-key';
+
+    const unknownError = new Error('Unknown error');
+
+    const { withTimeout } = await import('../../utils/withTimeout');
+    vi.mocked(withTimeout).mockRejectedValue(unknownError);
+
+    await expect(crw('https://example.com', { filterOptions: {} })).rejects.toThrow('Unknown error');
+  });
+
+  it('should throw ResponseBodyParseError when JSON parsing fails', async () => {
+    process.env.CRW_API_KEY = 'test-api-key';
+
+    const mockResponse = createMockResponse('not json', { ok: true });
+    mockResponse.json = vi.fn().mockRejectedValue(new Error('Invalid JSON'));
+    mockResponse.clone.mockReturnValue({
+      ...mockResponse,
+      json: vi.fn().mockRejectedValue(new Error('Invalid JSON')),
+      text: vi.fn().mockResolvedValue('not json'),
+    });
+
+    const { withTimeout } = await import('../../utils/withTimeout');
+    vi.mocked(withTimeout).mockResolvedValue(mockResponse as any);
+
+    await expect(crw('https://example.com', { filterOptions: {} })).rejects.toThrow(
+      'fastCRW returned non-JSON response: not json',
+    );
+  });
+
+  it('should handle metadata with all optional fields', async () => {
+    process.env.CRW_API_KEY = 'test-api-key';
+
+    const mockResponse = createMockResponse({
+      success: true,
+      data: {
+        markdown: 'Complete test content with all metadata fields provided. '.repeat(3),
+        metadata: {
+          title: 'Complete Test Article',
+          description: 'Complete test description',
+          keywords: 'test,complete,article',
+          language: 'en',
+          ogDescription: 'OG description',
+          ogImage: 'https://example.com/image.jpg',
+          ogLocaleAlternate: ['en-US', 'fr-FR'],
+          ogSiteName: 'Example Site',
+          ogTitle: 'OG Title',
+          ogUrl: 'https://example.com/og',
+          robots: 'index,follow',
+          statusCode: 200,
+          sourceURL: 'https://example.com',
+        },
+      },
+    });
+
+    const { withTimeout } = await import('../../utils/withTimeout');
+    vi.mocked(withTimeout).mockResolvedValue(mockResponse as any);
+
+    const result = await crw('https://example.com', { filterOptions: {} });
+
+    expect(result).toEqual({
+      content: 'Complete test content with all metadata fields provided. '.repeat(3),
+      contentType: 'text',
+      description: 'Complete test description',
+      length: 'Complete test content with all metadata fields provided. '.repeat(3).length,
+      siteName: 'example.com',
+      title: 'Complete Test Article',
+      url: 'https://example.com',
+    });
+  });
+});

--- a/packages/web-crawler/src/crawImpl/crw.ts
+++ b/packages/web-crawler/src/crawImpl/crw.ts
@@ -1,0 +1,106 @@
+import type { CrawlImpl, CrawlSuccessResult } from '../type';
+import { PageNotFoundError, toFetchError } from '../utils/errorType';
+import { createHTTPStatusError, parseJSONResponse } from '../utils/response';
+import { DEFAULT_TIMEOUT, withTimeout } from '../utils/withTimeout';
+
+// fastCRW is a Firecrawl-compatible web scraper (single binary; self-host or cloud).
+// This impl mirrors the Firecrawl crawler, swapping the base URL and env vars.
+
+interface CrwMetadata {
+  description?: string;
+  error?: string;
+  keywords?: string;
+  language?: string;
+  ogDescription?: string;
+  ogImage?: string;
+  ogLocaleAlternate?: string[];
+  ogSiteName?: string;
+  ogTitle?: string;
+  ogUrl?: string;
+  robots?: string;
+  sourceURL: string;
+  statusCode: number;
+  title?: string;
+}
+
+interface CrwResults {
+  html?: string;
+  links?: string[];
+  markdown?: string;
+  metadata: CrwMetadata;
+  rawHtml?: string;
+  screenshot?: string;
+  summary?: string;
+  warning?: string;
+}
+
+interface CrwResponse {
+  data: CrwResults;
+  success: boolean;
+}
+
+export const crw: CrawlImpl = async (url) => {
+  // Get API key from environment variable
+  const apiKey = process.env.CRW_API_KEY;
+  // Default to the managed cloud; allow overriding the base URL for self-host.
+  const baseUrl = process.env.CRW_URL || 'https://fastcrw.com/api';
+
+  let res: Response;
+
+  try {
+    res = await withTimeout(
+      (signal) =>
+        fetch(`${baseUrl}/v1/scrape`, {
+          body: JSON.stringify({
+            formats: ['markdown'], // ["markdown", "html"]
+            url,
+          }),
+          headers: {
+            'Authorization': !apiKey ? '' : `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+          },
+          method: 'POST',
+          signal,
+        }),
+      DEFAULT_TIMEOUT,
+    );
+  } catch (e) {
+    throw toFetchError(e);
+  }
+
+  if (!res.ok) {
+    if (res.status === 404) {
+      throw new PageNotFoundError(res.statusText);
+    }
+
+    throw await createHTTPStatusError(res, 'fastCRW');
+  }
+
+  const data = await parseJSONResponse<CrwResponse>(res, 'fastCRW');
+  if (!data.data) {
+    throw new Error('fastCRW response missing data field');
+  }
+
+  if (data.data.warning) {
+    console.warn('[fastCRW] Warning:', data.data.warning);
+  }
+
+  if (data.data.metadata.error) {
+    console.error('[fastCRW] Metadata error:', data.data.metadata.error);
+  }
+
+  // Check if content is empty or too short
+  if (!data.data.markdown || data.data.markdown.length < 100) {
+    return;
+  }
+
+  return {
+    content: data.data.markdown,
+    contentType: 'text',
+    description: data.data.metadata.description || '',
+    length: data.data.markdown.length,
+    siteName: new URL(url).hostname,
+    title: data.data.metadata.title || '',
+    url,
+  } satisfies CrawlSuccessResult;
+};

--- a/packages/web-crawler/src/crawImpl/index.ts
+++ b/packages/web-crawler/src/crawImpl/index.ts
@@ -1,4 +1,5 @@
 import { browserless } from './browserless';
+import { crw } from './crw';
 import { exa } from './exa';
 import { firecrawl } from './firecrawl';
 import { jina } from './jina';
@@ -8,6 +9,7 @@ import { tavily } from './tavily';
 
 export const crawlImpls = {
   browserless,
+  crw,
   exa,
   firecrawl,
   jina,


### PR DESCRIPTION
## What
Adds **fastCRW** as a web scrape/search provider, alongside the existing Firecrawl integration — additive only, Firecrawl untouched.

## Why

**[fastCRW](https://fastcrw.com) is a fully open-source, self-hostable web engine** (single ~8 MB Rust binary, AGPL) that outperforms Firecrawl on both quality and speed:

- **Runs 100% locally — anti-bot and JS rendering included in the open core.** Firecrawl's OSS self-host gates its stealth/anti-bot engine (`fire-engine`) behind a cloud-only flag, so it silently falls back to plain fetch or Playwright on Cloudflare- and JS-heavy pages. fastCRW ships JS-challenge handling, UA rotation, SPA rendering, BYO-proxy + rotation, and an HTTP→headless→proxy fallback ladder in the open core — one binary, no cloud dependency.

- **Faster and higher-recall on Firecrawl's own benchmark dataset.** Truth-recall 63.74 % vs 56.04 %; median latency p50 ~1.9 s vs ~2.3 s. ~6 MB RAM at idle.

- **Search is built on top of SearXNG, not instead of it.** SearXNG is the metasearch aggregator underneath; fastCRW adds a quality layer on top: query expansion (multi-variant rewrite), content-aware reranking (re-scoring by fetched content instead of SearXNG's content-blind ordering), and category routing (research queries fan out to arXiv / Semantic Scholar / Google Scholar, code queries to GitHub). You get SearXNG's breadth plus a measurable accuracy layer — all open-source (AGPL) and self-hostable with configurable engines.

Key via `CRW_API_KEY` (free tier at https://fastcrw.com/dashboard); self-host base URL supported. I maintain the integration and can provide free credits to evaluate.

Because fastCRW exposes a Firecrawl-compatible API, the integration is a small additive diff that mirrors the existing Firecrawl wiring exactly.
