### PR TITLE
chore: remove LOBE-XXX markers from characterization test comments (2026-06-15)

### DIFF
--- a/src/store/chat/slices/aiChat/actions/__tests__/streamingExecutor.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/streamingExecutor.test.ts
@@ -2413,7 +2413,7 @@ describe('StreamingExecutor actions', () => {
     });
   });
 
-  // Characterization net for the upcoming unified run-lifecycle refactor (LOBE-10377).
+  // Characterization net for the upcoming unified run-lifecycle refactor — cross-transport regression baseline across client, gateway, and hetero runtimes.
   // These lock the CURRENT client completion behavior across terminal branches so the
   // refactor can't silently drift queue-drain gating, unread marking, afterCompletion
   // timing, or the normalized client.runtime.complete signal status.
@@ -2568,7 +2568,7 @@ describe('StreamingExecutor actions', () => {
     });
 
     // Parked states (run ≠ operation). These lock the CURRENT per-state handling that
-    // the unified run-lifecycle + normalized parked signal (LOBE-10382) will rewrite.
+    // the unified run-lifecycle + normalized parked signal — cross-transport parked / resumed / terminal signal normalization will rewrite.
     const pinStep = (operationId: string, status: AgentState['status']) => {
       vi.spyOn(agentRuntime.AgentRuntime.prototype, 'step').mockResolvedValue({
         events: [],
@@ -2597,7 +2597,7 @@ describe('StreamingExecutor actions', () => {
       pinStep(operationId, 'waiting_for_async_tool');
       await runExecutor(result, operationId);
 
-      // CURRENT BEHAVIOR (suspected gap, locked for LOBE-10382): the completion switch
+      // CURRENT BEHAVIOR (suspected gap, locked as baseline for cross-transport parked/resumed/terminal signal normalization): the completion switch
       // has no `waiting_for_async_tool` case, so the op is never completed (stays
       // 'running') and the queue is not drained.
       expect(result.current.operations[operationId].status).toBe('running');


### PR DESCRIPTION
## Summary

Daily automated cleanup of `LOBE-XXX` markers in the codebase. This PR replaces Linear ticket references in test comments with descriptive context.

## Changes

**1 file changed** — `src/store/chat/slices/aiChat/actions/__tests__/streamingExecutor.test.ts`

| Line | Before | After |
|------|--------|-------|
| 2416 | `(LOBE-10377)` | cross-transport regression baseline description |
| 2571 | `(LOBE-10382)` | parked/resumed/terminal signal normalization context |
| 2600 | `locked for LOBE-10382` | locked as baseline with normalization description |

## Context

- **LOBE-10377**: [Done] Characterization tests for unified run-lifecycle refactor — regression safety net locking current client completion behavior
- **LOBE-10382**: [Backlog] Cross-transport normalization of parked/resumed/terminal signals across client, gateway, and hetero runtimes

All test semantics preserved — comments now explain intent directly without Linear ticket references.

---
Auto-generated on 2026-06-15