### PR TITLE
♻️ refactor(swr): converge remaining store-layer SWR keys (discover/tool/global/userMemory)

### DIFF
--- a/src/libs/swr/keys.ts
+++ b/src/libs/swr/keys.ts
@@ -206,9 +206,114 @@ export const discoverKeys = {
     userId,
     params,
   ]),
+  groupAgentCategories: def('discover:groupAgentCategories', (locale: string, params: unknown) => [
+    'discover:groupAgentCategories',
+    locale,
+    params,
+  ]),
+  groupAgentDetail: def(
+    'discover:groupAgentDetail',
+    (locale: string, identifier: string, version?: string) => [
+      'discover:groupAgentDetail',
+      locale,
+      identifier,
+      version,
+    ],
+  ),
+  groupAgentIdentifiers: def('discover:groupAgentIdentifiers', () => [
+    'discover:groupAgentIdentifiers',
+  ]),
+  groupAgentList: def('discover:groupAgentList', (locale: string, params: unknown) => [
+    'discover:groupAgentList',
+    locale,
+    params,
+  ]),
+  mcpCategories: def('discover:mcpCategories', (locale: string, params: unknown) => [
+    'discover:mcpCategories',
+    locale,
+    params,
+  ]),
+  mcpDetail: def('discover:mcpDetail', (locale: string, identifier: string, version?: string) => [
+    'discover:mcpDetail',
+    locale,
+    identifier,
+    version,
+  ]),
+  mcpList: def('discover:mcpList', (locale: string, params: unknown) => [
+    'discover:mcpList',
+    locale,
+    params,
+  ]),
+  modelCategories: def('discover:modelCategories', (params: unknown) => [
+    'discover:modelCategories',
+    params,
+  ]),
+  modelDetail: def('discover:modelDetail', (locale: string, identifier: string) => [
+    'discover:modelDetail',
+    locale,
+    identifier,
+  ]),
   modelIdentifiers: def('discover:modelIdentifiers', () => ['discover:modelIdentifiers']),
+  modelList: def('discover:modelList', (locale: string, params: unknown) => [
+    'discover:modelList',
+    locale,
+    params,
+  ]),
+  pluginCategories: def('discover:pluginCategories', (locale: string, params: unknown) => [
+    'discover:pluginCategories',
+    locale,
+    params,
+  ]),
+  pluginDetail: def(
+    'discover:pluginDetail',
+    (locale: string, identifier: string, withManifest?: boolean) => [
+      'discover:pluginDetail',
+      locale,
+      identifier,
+      withManifest,
+    ],
+  ),
   pluginIdentifiers: def('discover:pluginIdentifiers', () => ['discover:pluginIdentifiers']),
+  pluginList: def('discover:pluginList', (locale: string, params: unknown) => [
+    'discover:pluginList',
+    locale,
+    params,
+  ]),
+  providerDetail: def('discover:providerDetail', (locale: string, identifier: string) => [
+    'discover:providerDetail',
+    locale,
+    identifier,
+  ]),
   providerIdentifiers: def('discover:providerIdentifiers', () => ['discover:providerIdentifiers']),
+  providerList: def('discover:providerList', (locale: string, params: unknown) => [
+    'discover:providerList',
+    locale,
+    params,
+  ]),
+  skillCategories: def('discover:skillCategories', (locale: string, params: unknown) => [
+    'discover:skillCategories',
+    locale,
+    params,
+  ]),
+  skillDetail: def(
+    'discover:skillDetail',
+    (locale: string, identifier: string, version?: string) => [
+      'discover:skillDetail',
+      locale,
+      identifier,
+      version,
+    ],
+  ),
+  skillList: def('discover:skillList', (locale: string, params: unknown) => [
+    'discover:skillList',
+    locale,
+    params,
+  ]),
+  userProfile: def('discover:userProfile', (locale: string, username: string) => [
+    'discover:userProfile',
+    locale,
+    username,
+  ]),
 };
 
 // ---- agent eval ---------------------------------------------------------
@@ -276,13 +381,73 @@ export const deviceKeys = {
 
 // ---- user memory --------------------------------------------------------
 export const userMemoryKeys = {
+  activities: def('userMemory:activities', (params: unknown) => ['userMemory:activities', params]),
+  contexts: def('userMemory:contexts', (params: unknown) => ['userMemory:contexts', params]),
+  experiences: def('userMemory:experiences', (params: unknown) => [
+    'userMemory:experiences',
+    params,
+  ]),
+  /** Injection identities (distinct from the paginated `identityList`). */
   identities: def('userMemory:identities', () => ['userMemory:identities']),
+  /** Paginated identity list for the memory home views. */
+  identityList: def('userMemory:identityList', (params: unknown) => [
+    'userMemory:identityList',
+    params,
+  ]),
+  memoryDetail: def('userMemory:memoryDetail', (layer: string, id: string) => [
+    'userMemory:memoryDetail',
+    layer,
+    id,
+  ]),
   persona: def('userMemory:persona', () => ['userMemory:persona']),
+  preferences: def('userMemory:preferences', (params: unknown) => [
+    'userMemory:preferences',
+    params,
+  ]),
+  retrieve: def('userMemory:retrieve', (cacheKey: string | undefined) => [
+    'userMemory:retrieve',
+    cacheKey,
+  ]),
   tags: def('userMemory:tags', () => ['userMemory:tags']),
   topicMemories: def('userMemory:topicMemories', (topicId: string) => [
     'userMemory:topicMemories',
     topicId,
   ]),
+};
+
+// ---- tool (skills / plugins / builtin / mcp / klavis stores) -------------
+export const toolKeys = {
+  agentSkillDetail: def('tool:agentSkillDetail', (id: string) => ['tool:agentSkillDetail', id]),
+  agentSkills: def('tool:agentSkills', () => ['tool:agentSkills']),
+  installedPlugins: def('tool:installedPlugins', () => ['tool:installedPlugins']),
+  klavisServerTools: def('tool:klavisServerTools', (serverName: string) => [
+    'tool:klavisServerTools',
+    serverName,
+  ]),
+  klavisServers: def('tool:klavisServers', () => ['tool:klavisServers']),
+  lobehubSkillConnections: def('tool:lobehubSkillConnections', () => [
+    'tool:lobehubSkillConnections',
+  ]),
+  lobehubSkillTools: def('tool:lobehubSkillTools', (provider: string) => [
+    'tool:lobehubSkillTools',
+    provider,
+  ]),
+  mcpPluginList: def('tool:mcpPluginList', (locale: string, params: unknown) => [
+    'tool:mcpPluginList',
+    locale,
+    params,
+  ]),
+  uninstalledBuiltins: def('tool:uninstalledBuiltins', (workspaceId: string | null | undefined) => [
+    'tool:uninstalledBuiltins',
+    workspaceId,
+  ]),
+};
+
+// ---- global -------------------------------------------------------------
+export const globalKeys = {
+  latestVersion: def('global:latestVersion', () => ['global:latestVersion']),
+  serverVersion: def('global:serverVersion', () => ['global:serverVersion']),
+  systemStatus: def('global:systemStatus', () => ['global:systemStatus']),
 };
 
 // ---- agent knowledge (kept off the `agent:` idb tier on purpose) --------
@@ -336,6 +501,7 @@ export const swrKeys = {
   document: documentSWRKeys,
   eval: evalKeys,
   file: fileKeys,
+  global: globalKeys,
   group: groupKeys,
   image: imageKeys,
   knowledgeBase: knowledgeBaseKeys,
@@ -347,6 +513,7 @@ export const swrKeys = {
   session: sessionKeys,
   task: taskKeys,
   thread: threadKeys,
+  tool: toolKeys,
   topic: topicKeys,
   userMemory: userMemoryKeys,
   video: videoKeys,

--- a/src/store/discover/slices/groupAgent/action.ts
+++ b/src/store/discover/slices/groupAgent/action.ts
@@ -2,6 +2,7 @@ import { type CategoryItem, type CategoryListQuery } from '@lobehub/market-sdk';
 import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 
+import { discoverKeys } from '@/libs/swr/keys';
 import { discoverService } from '@/services/discover';
 import { type DiscoverStore } from '@/store/discover';
 import { globalHelpers } from '@/store/global/helpers';
@@ -27,7 +28,7 @@ export class GroupAgentActionImpl {
   useGroupAgentCategories = (params: CategoryListQuery = {}): SWRResponse<CategoryItem[]> => {
     const locale = globalHelpers.getCurrentLanguage();
     return useSWR(
-      ['group-agent-categories', locale, ...Object.values(params)].filter(Boolean).join('-'),
+      discoverKeys.groupAgentCategories(locale, params),
       async () => discoverService.getGroupAgentCategories(params),
       {
         revalidateOnFocus: false,
@@ -41,7 +42,7 @@ export class GroupAgentActionImpl {
   }): SWRResponse<DiscoverGroupAgentDetail | undefined> => {
     const locale = globalHelpers.getCurrentLanguage();
     return useSWR(
-      ['group-agent-details', locale, params.identifier, params.version].filter(Boolean).join('-'),
+      discoverKeys.groupAgentDetail(locale, params.identifier, params.version),
       async () => discoverService.getGroupAgentDetail(params),
       {
         revalidateOnFocus: false,
@@ -51,7 +52,7 @@ export class GroupAgentActionImpl {
 
   useGroupAgentIdentifiers = (): SWRResponse<IdentifiersResponse> => {
     return useSWR(
-      'group-agent-identifiers',
+      discoverKeys.groupAgentIdentifiers(),
       async () => discoverService.getGroupAgentIdentifiers(),
       {
         revalidateOnFocus: false,
@@ -62,7 +63,7 @@ export class GroupAgentActionImpl {
   useGroupAgentList = (params: GroupAgentQueryParams = {}): SWRResponse<GroupAgentListResponse> => {
     const locale = globalHelpers.getCurrentLanguage();
     return useSWR(
-      ['group-agent-list', locale, ...Object.values(params)].filter(Boolean).join('-'),
+      discoverKeys.groupAgentList(locale, params),
       async () =>
         discoverService.getGroupAgentList({
           ...params,

--- a/src/store/discover/slices/mcp/action.ts
+++ b/src/store/discover/slices/mcp/action.ts
@@ -2,6 +2,7 @@ import { type CategoryItem, type CategoryListQuery } from '@lobehub/market-sdk';
 import { type SWRResponse } from 'swr';
 
 import { useClientDataSWR } from '@/libs/swr';
+import { discoverKeys } from '@/libs/swr/keys';
 import { discoverService } from '@/services/discover';
 import { type DiscoverStore } from '@/store/discover';
 import { globalHelpers } from '@/store/global/helpers';
@@ -33,28 +34,26 @@ export class MCPActionImpl {
     const locale = globalHelpers.getCurrentLanguage();
 
     return useClientDataSWR(
-      !identifier ? null : ['mcp-detail', locale, identifier, version].filter(Boolean).join('-'),
+      !identifier ? null : discoverKeys.mcpDetail(locale, identifier, version),
       async () => discoverService.getMcpDetail({ identifier: identifier!, version }),
     );
   };
 
   useFetchMcpList = (params: McpQueryParams): SWRResponse<McpListResponse> => {
     const locale = globalHelpers.getCurrentLanguage();
-    return useClientDataSWR(
-      ['mcp-list', locale, ...Object.values(params)].filter(Boolean).join('-'),
-      async () =>
-        discoverService.getMcpList({
-          ...params,
-          page: params.page ? Number(params.page) : 1,
-          pageSize: params.pageSize ? Number(params.pageSize) : 21,
-        }),
+    return useClientDataSWR(discoverKeys.mcpList(locale, params), async () =>
+      discoverService.getMcpList({
+        ...params,
+        page: params.page ? Number(params.page) : 1,
+        pageSize: params.pageSize ? Number(params.pageSize) : 21,
+      }),
     );
   };
 
   useMcpCategories = (params: CategoryListQuery): SWRResponse<CategoryItem[]> => {
     const locale = globalHelpers.getCurrentLanguage();
     return useClientDataSWR(
-      ['mcp-categories', locale, ...Object.values(params)].join('-'),
+      discoverKeys.mcpCategories(locale, params),
       async () => discoverService.getMcpCategories(params),
       {
         revalidateOnFocus: false,

--- a/src/store/discover/slices/model/action.ts
+++ b/src/store/discover/slices/model/action.ts
@@ -27,7 +27,7 @@ export class ModelActionImpl {
 
   useModelCategories = (params: CategoryListQuery): SWRResponse<CategoryItem[]> => {
     return useSWR(
-      ['model-categories', ...Object.values(params)].filter(Boolean).join('-'),
+      discoverKeys.modelCategories(params),
       async () => discoverService.getModelCategories(params),
       {
         revalidateOnFocus: false,
@@ -40,7 +40,7 @@ export class ModelActionImpl {
   }): SWRResponse<DiscoverModelDetail | undefined> => {
     const locale = globalHelpers.getCurrentLanguage();
     return useSWR(
-      ['model-details', locale, params.identifier].filter(Boolean).join('-'),
+      discoverKeys.modelDetail(locale, params.identifier),
       async () => discoverService.getModelDetail(params),
       {
         revalidateOnFocus: false,
@@ -61,7 +61,7 @@ export class ModelActionImpl {
   useModelList = (params: ModelQueryParams = {}): SWRResponse<ModelListResponse> => {
     const locale = globalHelpers.getCurrentLanguage();
     return useSWR(
-      ['model-list', locale, ...Object.values(params)].filter(Boolean).join('-'),
+      discoverKeys.modelList(locale, params),
       async () =>
         discoverService.getModelList({
           ...params,

--- a/src/store/discover/slices/plugin/action.ts
+++ b/src/store/discover/slices/plugin/action.ts
@@ -28,7 +28,7 @@ export class PluginActionImpl {
   usePluginCategories = (params: CategoryListQuery): SWRResponse<CategoryItem[]> => {
     const locale = globalHelpers.getCurrentLanguage();
     return useSWR(
-      ['plugin-categories', locale, ...Object.values(params)].filter(Boolean).join('-'),
+      discoverKeys.pluginCategories(locale, params),
       async () => discoverService.getPluginCategories(params),
       {
         revalidateOnFocus: false,
@@ -45,9 +45,7 @@ export class PluginActionImpl {
   }): SWRResponse<DiscoverPluginDetail | undefined> => {
     const locale = globalHelpers.getCurrentLanguage();
     return useSWR(
-      !identifier
-        ? null
-        : ['plugin-details', locale, identifier, withManifest].filter(Boolean).join('-'),
+      !identifier ? null : discoverKeys.pluginDetail(locale, identifier, withManifest),
       async () => discoverService.getPluginDetail({ identifier: identifier!, withManifest }),
       {
         revalidateOnFocus: false,
@@ -68,7 +66,7 @@ export class PluginActionImpl {
   usePluginList = (params: PluginQueryParams = {}): SWRResponse<PluginListResponse> => {
     const locale = globalHelpers.getCurrentLanguage();
     return useSWR(
-      ['plugin-list', locale, ...Object.values(params)].filter(Boolean).join('-'),
+      discoverKeys.pluginList(locale, params),
       async () =>
         discoverService.getPluginList({
           ...params,

--- a/src/store/discover/slices/provider/action.ts
+++ b/src/store/discover/slices/provider/action.ts
@@ -30,7 +30,7 @@ export class ProviderActionImpl {
   }): SWRResponse<DiscoverProviderDetail | undefined> => {
     const locale = globalHelpers.getCurrentLanguage();
     return useSWR(
-      ['provider-details', locale, params.identifier].filter(Boolean).join('-'),
+      discoverKeys.providerDetail(locale, params.identifier),
       async () => discoverService.getProviderDetail(params),
       {
         revalidateOnFocus: false,
@@ -51,7 +51,7 @@ export class ProviderActionImpl {
   useProviderList = (params: ProviderQueryParams = {}): SWRResponse<ProviderListResponse> => {
     const locale = globalHelpers.getCurrentLanguage();
     return useSWR(
-      ['provider-list', locale, ...Object.values(params)].filter(Boolean).join('-'),
+      discoverKeys.providerList(locale, params),
       async () =>
         discoverService.getProviderList({
           ...params,

--- a/src/store/discover/slices/skill/action.ts
+++ b/src/store/discover/slices/skill/action.ts
@@ -2,6 +2,7 @@ import { type CategoryListQuery } from '@lobehub/market-sdk';
 import { type SWRResponse } from 'swr';
 
 import { useClientDataSWR } from '@/libs/swr';
+import { discoverKeys } from '@/libs/swr/keys';
 import { discoverService } from '@/services/discover';
 import { type DiscoverStore } from '@/store/discover';
 import { globalHelpers } from '@/store/global/helpers';
@@ -35,28 +36,26 @@ export class SkillActionImpl {
     const locale = globalHelpers.getCurrentLanguage();
 
     return useClientDataSWR(
-      !identifier ? null : ['skill-detail', locale, identifier, version].filter(Boolean).join('-'),
+      !identifier ? null : discoverKeys.skillDetail(locale, identifier, version),
       async () => discoverService.getSkillDetail({ identifier: identifier!, version }),
     );
   };
 
   useFetchSkillList = (params: SkillQueryParams): SWRResponse<SkillListResponse> => {
     const locale = globalHelpers.getCurrentLanguage();
-    return useClientDataSWR(
-      ['skill-list', locale, ...Object.values(params)].filter(Boolean).join('-'),
-      async () =>
-        discoverService.getSkillList({
-          ...params,
-          page: params.page ? Number(params.page) : 1,
-          pageSize: params.pageSize ? Number(params.pageSize) : 21,
-        }),
+    return useClientDataSWR(discoverKeys.skillList(locale, params), async () =>
+      discoverService.getSkillList({
+        ...params,
+        page: params.page ? Number(params.page) : 1,
+        pageSize: params.pageSize ? Number(params.pageSize) : 21,
+      }),
     );
   };
 
   useSkillCategories = (params: CategoryListQuery = {}): SWRResponse<SkillCategoryItem[]> => {
     const locale = globalHelpers.getCurrentLanguage();
     return useClientDataSWR(
-      ['skill-categories', locale, ...Object.values(params)].join('-'),
+      discoverKeys.skillCategories(locale, params),
       async () => discoverService.getSkillCategories(params),
       {
         revalidateOnFocus: false,

--- a/src/store/discover/slices/user/action.ts
+++ b/src/store/discover/slices/user/action.ts
@@ -1,6 +1,7 @@
 import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 
+import { discoverKeys } from '@/libs/swr/keys';
 import { discoverService } from '@/services/discover';
 import { type DiscoverStore } from '@/store/discover';
 import { globalHelpers } from '@/store/global/helpers';
@@ -21,7 +22,7 @@ export class UserActionImpl {
   useUserProfile = (params: { username: string }): SWRResponse<DiscoverUserProfile | undefined> => {
     const locale = globalHelpers.getCurrentLanguage();
     return useSWR(
-      params.username ? ['user-profile', locale, params.username].join('-') : null,
+      params.username ? discoverKeys.userProfile(locale, params.username) : null,
       async () => discoverService.getUserInfo({ username: params.username }),
       {
         revalidateOnFocus: false,

--- a/src/store/global/actions/general.ts
+++ b/src/store/global/actions/general.ts
@@ -5,6 +5,7 @@ import type { SWRResponse } from 'swr';
 import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
 import { CURRENT_VERSION, isDesktop } from '@/const/version';
 import { useOnlyFetchOnceSWR } from '@/libs/swr';
+import { globalKeys } from '@/libs/swr/keys';
 import { globalService } from '@/services/global';
 import { getElectronStoreState } from '@/store/electron';
 import { electronSyncSelectors } from '@/store/electron/selectors';
@@ -187,7 +188,7 @@ export class GlobalGeneralActionImpl {
 
   useCheckLatestVersion = (enabledCheck: boolean = true): SWRResponse<string> => {
     return useOnlyFetchOnceSWR(
-      enabledCheck ? 'checkLatestVersion' : null,
+      enabledCheck ? globalKeys.latestVersion() : null,
       async () => globalService.getLatestVersion(),
       {
         focusThrottleInterval: 1000 * 60 * 30,
@@ -215,7 +216,7 @@ export class GlobalGeneralActionImpl {
       isDesktop &&
         // only check server version for self-hosted remote server
         electronSyncSelectors.storageMode(getElectronStoreState()) !== 'cloud'
-        ? 'checkServerVersion'
+        ? globalKeys.serverVersion()
         : null,
       async () => globalService.getServerVersion(),
       {
@@ -262,7 +263,7 @@ export class GlobalGeneralActionImpl {
 
   useInitSystemStatus = (): SWRResponse => {
     return useOnlyFetchOnceSWR<SystemStatus>(
-      'initSystemStatus',
+      globalKeys.systemStatus(),
       () => this.#get().statusStorage.getFromLocalStorage(),
       {
         onSuccess: (status) => {

--- a/src/store/tool/slices/agentSkills/action.ts
+++ b/src/store/tool/slices/agentSkills/action.ts
@@ -13,6 +13,7 @@ import { produce } from 'immer';
 import useSWR, { mutate, type SWRResponse } from 'swr';
 
 import { useClientDataSWR } from '@/libs/swr';
+import { toolKeys } from '@/libs/swr/keys';
 import { agentSkillService } from '@/services/skill';
 import { type StoreSetter } from '@/store/types';
 import { setNamespace } from '@/utils/storeDebug';
@@ -59,7 +60,7 @@ export class AgentSkillsActionImpl {
       n('deleteAgentSkill'),
     );
 
-    await mutate(['fetchAgentSkillDetail', id].join('-'), undefined, { revalidate: false });
+    await mutate(toolKeys.agentSkillDetail(id), undefined, { revalidate: false });
 
     await this.#get().refreshAgentSkills();
   };
@@ -123,7 +124,7 @@ export class AgentSkillsActionImpl {
       );
     }
 
-    await mutate(['fetchAgentSkillDetail', params.id].join('-'), undefined, { revalidate: false });
+    await mutate(toolKeys.agentSkillDetail(params.id), undefined, { revalidate: false });
 
     await this.#get().refreshAgentSkills();
     return result;
@@ -131,7 +132,7 @@ export class AgentSkillsActionImpl {
 
   useFetchAgentSkillDetail = (skillId?: string): SWRResponse<AgentSkillDetailData> =>
     useClientDataSWR<AgentSkillDetailData>(
-      skillId ? ['fetchAgentSkillDetail', skillId].join('-') : null,
+      skillId ? toolKeys.agentSkillDetail(skillId) : null,
       async () => {
         const [detail, resourceTree] = await Promise.all([
           agentSkillService.getById(skillId!),
@@ -155,7 +156,7 @@ export class AgentSkillsActionImpl {
 
   useFetchAgentSkills = (enabled: boolean): SWRResponse<SkillListItem[]> =>
     useSWR<SkillListItem[]>(
-      enabled ? 'fetchAgentSkills' : null,
+      enabled ? toolKeys.agentSkills() : null,
       async () => {
         const { data } = await agentSkillService.list();
         return data;

--- a/src/store/tool/slices/builtin/action.ts
+++ b/src/store/tool/slices/builtin/action.ts
@@ -8,6 +8,7 @@ import {
   useActiveWorkspaceId,
 } from '@/business/client/hooks/useActiveWorkspaceId';
 import { mutate } from '@/libs/swr';
+import { toolKeys } from '@/libs/swr/keys';
 import { userService } from '@/services/user';
 import { type StoreSetter } from '@/store/types';
 import { setNamespace } from '@/utils/storeDebug';
@@ -18,8 +19,6 @@ import { type BuiltinToolContext, type BuiltinToolResult } from './types';
 
 const n = setNamespace('builtinTool');
 const log = debug('lobe-store:builtin-tool');
-
-const UNINSTALLED_BUILTIN_TOOLS = 'loadUninstalledBuiltinTools';
 
 /**
  * Minimal view of `settings.tool` covering just the builtin-tool install slots.
@@ -214,7 +213,7 @@ export class BuiltinToolActionImpl {
    * Refresh uninstalled builtin tools from server (active scope)
    */
   refreshUninstalledBuiltinTools = async (): Promise<void> => {
-    await mutate([UNINSTALLED_BUILTIN_TOOLS, getActiveWorkspaceId()]);
+    await mutate(toolKeys.uninstalledBuiltins(getActiveWorkspaceId()));
   };
 
   /**
@@ -228,7 +227,7 @@ export class BuiltinToolActionImpl {
     const workspaceId = useActiveWorkspaceId();
 
     return useSWR<string[]>(
-      enabled ? [UNINSTALLED_BUILTIN_TOOLS, workspaceId] : null,
+      enabled ? toolKeys.uninstalledBuiltins(workspaceId) : null,
       async () => {
         const userState = await userService.getUserState();
         return resolveUninstalledBuiltinTools(userState?.settings?.tool, workspaceId);

--- a/src/store/tool/slices/klavisStore/action.ts
+++ b/src/store/tool/slices/klavisStore/action.ts
@@ -3,6 +3,7 @@ import { produce } from 'immer';
 import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 
+import { toolKeys } from '@/libs/swr/keys';
 import { lambdaClient, toolsClient } from '@/libs/trpc/client';
 import { type StoreSetter } from '@/store/types';
 import { setNamespace } from '@/utils/storeDebug';
@@ -319,7 +320,7 @@ export class KlavisStoreActionImpl {
 
   useFetchServerTools = (serverName: string | undefined): SWRResponse<KlavisTool[]> => {
     return useSWR<KlavisTool[]>(
-      serverName ? `klavis-server-tools-${serverName}` : null,
+      serverName ? toolKeys.klavisServerTools(serverName) : null,
       async () => {
         const response = await toolsClient.klavis.getTools.query({ serverName: serverName! });
         return (response.tools || []).map((tool: any) => ({
@@ -337,7 +338,7 @@ export class KlavisStoreActionImpl {
 
   useFetchUserKlavisServers = (enabled: boolean): SWRResponse<KlavisServer[]> => {
     return useSWR<KlavisServer[]>(
-      enabled ? 'fetchUserKlavisServers' : null,
+      enabled ? toolKeys.klavisServers() : null,
       async () => {
         const klavisPlugins = await lambdaClient.klavis.getKlavisPlugins.query();
 

--- a/src/store/tool/slices/lobehubSkillStore/action.ts
+++ b/src/store/tool/slices/lobehubSkillStore/action.ts
@@ -3,6 +3,7 @@ import { produce } from 'immer';
 import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 
+import { toolKeys } from '@/libs/swr/keys';
 import { toolsClient } from '@/libs/trpc/client';
 import { type StoreSetter } from '@/store/types';
 import { setNamespace } from '@/utils/storeDebug';
@@ -271,7 +272,7 @@ export class LobehubSkillStoreActionImpl {
 
   useFetchLobehubSkillConnections = (enabled: boolean): SWRResponse<LobehubSkillServer[]> => {
     return useSWR<LobehubSkillServer[]>(
-      enabled ? 'fetchLobehubSkillConnections' : null,
+      enabled ? toolKeys.lobehubSkillConnections() : null,
       async () => {
         const response = await toolsClient.market.connectListConnections.query();
 
@@ -323,7 +324,7 @@ export class LobehubSkillStoreActionImpl {
 
   useFetchProviderTools = (provider: string | undefined): SWRResponse<LobehubSkillTool[]> => {
     return useSWR<LobehubSkillTool[]>(
-      provider ? `lobehub-skill-tools-${provider}` : null,
+      provider ? toolKeys.lobehubSkillTools(provider) : null,
       async () => {
         const response = await toolsClient.market.connectListTools.query({ provider: provider! });
         return (response.tools || []).map((tool: any) => ({

--- a/src/store/tool/slices/mcpStore/action.ts
+++ b/src/store/tool/slices/mcpStore/action.ts
@@ -11,6 +11,7 @@ import useSWR from 'swr';
 
 import { type MCPErrorData } from '@/libs/mcp/types';
 import { parseStdioErrorMessage } from '@/libs/mcp/types';
+import { toolKeys } from '@/libs/swr/keys';
 import { discoverService } from '@/services/discover';
 import { mcpService } from '@/services/mcp';
 import { pluginService } from '@/services/plugin';
@@ -864,21 +865,15 @@ export class PluginMCPStoreActionImpl {
     const requestParams = isDesktop
       ? params
       : { ...params, connectionType: McpConnectionType.http };
-    const swrKeyParts = [
-      'useFetchMCPPluginList',
-      locale,
-      requestParams.page,
-      requestParams.pageSize,
-      requestParams.q,
-      requestParams.connectionType,
-    ];
-    const swrKey = swrKeyParts
-      .filter((part) => part !== undefined && part !== null && part !== '')
-      .join('-');
     const page = requestParams.page ?? 1;
 
     return useSWR<PluginListResponse>(
-      swrKey,
+      toolKeys.mcpPluginList(locale, {
+        connectionType: requestParams.connectionType,
+        page: requestParams.page,
+        pageSize: requestParams.pageSize,
+        q: requestParams.q,
+      }),
       () => discoverService.getMCPPluginList(requestParams),
       {
         onSuccess: (data) => {

--- a/src/store/tool/slices/plugin/action.ts
+++ b/src/store/tool/slices/plugin/action.ts
@@ -4,6 +4,7 @@ import { type SWRResponse } from 'swr';
 
 import { MESSAGE_CANCEL_FLAT } from '@/const/message';
 import { useClientDataSWR } from '@/libs/swr';
+import { toolKeys } from '@/libs/swr/keys';
 import { pluginService } from '@/services/plugin';
 import { type StoreSetter } from '@/store/types';
 import { merge } from '@/utils/merge';
@@ -88,7 +89,7 @@ export class PluginActionImpl {
 
   useFetchInstalledPlugins = (enable: boolean): SWRResponse => {
     return useClientDataSWR(
-      enable ? 'useFetchInstalledPlugins' : null,
+      enable ? toolKeys.installedPlugins() : null,
       () => pluginService.getInstalledPlugins(),
       {
         onSuccess: (data: LobeTool[]) => {

--- a/src/store/userMemory/slices/activity/action.ts
+++ b/src/store/userMemory/slices/activity/action.ts
@@ -4,6 +4,7 @@ import { produce } from 'immer';
 import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 
+import { userMemoryKeys } from '@/libs/swr/keys';
 import { memoryCRUDService, userMemoryService } from '@/services/userMemory';
 import { type StoreSetter } from '@/store/types';
 import { setNamespace } from '@/utils/storeDebug';
@@ -71,22 +72,10 @@ export class ActivityActionImpl {
   };
 
   useFetchActivities = (params: ActivityQueryParams): SWRResponse<ActivityListResult> => {
-    const swrKeyParts = [
-      'useFetchActivities',
-      params.page,
-      params.pageSize,
-      params.q,
-      params.sort,
-      params.status?.join(',') ?? '',
-      params.types?.join(',') ?? '',
-    ];
-    const swrKey = swrKeyParts
-      .filter((part) => part !== undefined && part !== null && part !== '')
-      .join('-');
     const page = params.page ?? 1;
 
     return useSWR(
-      swrKey,
+      userMemoryKeys.activities(params),
       async () => {
         return userMemoryService.queryActivities({
           page: params.page,

--- a/src/store/userMemory/slices/base/action.ts
+++ b/src/store/userMemory/slices/base/action.ts
@@ -21,7 +21,6 @@ import { experienceInitialState } from '../experience/initialState';
 import { identityInitialState } from '../identity/initialState';
 import { preferenceInitialState } from '../preference/initialState';
 
-const SWR_FETCH_USER_MEMORY = 'SWR_FETCH_USER_MEMORY';
 const n = setNamespace('userMemory');
 
 type MemoryContext = Parameters<typeof createMemorySearchParams>[0];
@@ -83,25 +82,31 @@ export class BaseActionImpl {
     );
 
     await Promise.all([
-      mutate((key) => typeof key === 'string' && key.startsWith('memoryDetail-'), undefined, {
+      mutate(
+        (key) => Array.isArray(key) && key[0] === userMemoryKeys.memoryDetail.root,
+        undefined,
+        { revalidate: true },
+      ),
+      mutate((key) => Array.isArray(key) && key[0] === userMemoryKeys.activities.root, undefined, {
         revalidate: true,
       }),
-      mutate((key) => typeof key === 'string' && key.startsWith('useFetchActivities'), undefined, {
+      mutate((key) => Array.isArray(key) && key[0] === userMemoryKeys.contexts.root, undefined, {
         revalidate: true,
       }),
-      mutate((key) => typeof key === 'string' && key.startsWith('useFetchContexts'), undefined, {
+      mutate((key) => Array.isArray(key) && key[0] === userMemoryKeys.experiences.root, undefined, {
         revalidate: true,
       }),
-      mutate((key) => typeof key === 'string' && key.startsWith('useFetchExperiences'), undefined, {
+      mutate(
+        (key) => Array.isArray(key) && key[0] === userMemoryKeys.identityList.root,
+        undefined,
+        {
+          revalidate: true,
+        },
+      ),
+      mutate((key) => Array.isArray(key) && key[0] === userMemoryKeys.preferences.root, undefined, {
         revalidate: true,
       }),
-      mutate((key) => typeof key === 'string' && key.startsWith('useFetchIdentities'), undefined, {
-        revalidate: true,
-      }),
-      mutate((key) => typeof key === 'string' && key.startsWith('useFetchPreferences'), undefined, {
-        revalidate: true,
-      }),
-      mutate((key) => Array.isArray(key) && key[0] === SWR_FETCH_USER_MEMORY, undefined, {
+      mutate((key) => Array.isArray(key) && key[0] === userMemoryKeys.retrieve.root, undefined, {
         revalidate: true,
       }),
       mutate(userMemoryKeys.persona(), null, { revalidate: false }),
@@ -119,7 +124,7 @@ export class BaseActionImpl {
   refreshUserMemory = async (params: RetrieveMemoryParams): Promise<void> => {
     const key = userMemoryCacheKey(params);
 
-    await mutate([SWR_FETCH_USER_MEMORY, key]);
+    await mutate(userMemoryKeys.retrieve(key));
   };
 
   setActiveMemoryContext = (context?: MemoryContext): void => {
@@ -198,7 +203,7 @@ export class BaseActionImpl {
   };
 
   useFetchMemoryDetail = (id: string | null, layer: LayersEnum): SWRResponse<any> => {
-    const swrKey = id ? `memoryDetail-${layer}-${id}` : null;
+    const swrKey = id ? userMemoryKeys.memoryDetail(layer, id) : null;
 
     return useSWR(
       swrKey,
@@ -284,7 +289,7 @@ export class BaseActionImpl {
     const key = resolvedParams ? userMemoryCacheKey(resolvedParams) : undefined;
 
     return useClientDataSWR<RetrieveMemoryResult>(
-      enable && resolvedParams ? [SWR_FETCH_USER_MEMORY, key] : null,
+      enable && resolvedParams ? userMemoryKeys.retrieve(key) : null,
       () => userMemoryService.retrieveMemory(resolvedParams!),
       {
         onSuccess: (result) => {

--- a/src/store/userMemory/slices/context/action.ts
+++ b/src/store/userMemory/slices/context/action.ts
@@ -4,6 +4,7 @@ import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 
 import { type DisplayContextMemory } from '@/database/repositories/userMemory';
+import { userMemoryKeys } from '@/libs/swr/keys';
 import { memoryCRUDService, userMemoryService } from '@/services/userMemory';
 import { type StoreSetter } from '@/store/types';
 import { LayersEnum } from '@/types/userMemory';
@@ -68,14 +69,10 @@ export class ContextActionImpl {
   };
 
   useFetchContexts = (params: ContextQueryParams): SWRResponse<any> => {
-    const swrKeyParts = ['useFetchContexts', params.page, params.pageSize, params.q, params.sort];
-    const swrKey = swrKeyParts
-      .filter((part) => part !== undefined && part !== null && part !== '')
-      .join('-');
     const page = params.page ?? 1;
 
     return useSWR(
-      swrKey,
+      userMemoryKeys.contexts(params),
       async () => {
         const result = await userMemoryService.queryMemories({
           layer: LayersEnum.Context,

--- a/src/store/userMemory/slices/experience/action.ts
+++ b/src/store/userMemory/slices/experience/action.ts
@@ -4,6 +4,7 @@ import { produce } from 'immer';
 import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 
+import { userMemoryKeys } from '@/libs/swr/keys';
 import { memoryCRUDService, userMemoryService } from '@/services/userMemory';
 import { type StoreSetter } from '@/store/types';
 import { setNamespace } from '@/utils/storeDebug';
@@ -70,20 +71,10 @@ export class ExperienceActionImpl {
   };
 
   useFetchExperiences = (params: ExperienceQueryParams): SWRResponse<ExperienceListResult> => {
-    const swrKeyParts = [
-      'useFetchExperiences',
-      params.page,
-      params.pageSize,
-      params.q,
-      params.sort,
-    ];
-    const swrKey = swrKeyParts
-      .filter((part) => part !== undefined && part !== null && part !== '')
-      .join('-');
     const page = params.page ?? 1;
 
     return useSWR(
-      swrKey,
+      userMemoryKeys.experiences(params),
       async () => {
         // Use the new dedicated queryExperiences API
         return userMemoryService.queryExperiences({

--- a/src/store/userMemory/slices/identity/action.ts
+++ b/src/store/userMemory/slices/identity/action.ts
@@ -9,6 +9,7 @@ import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 
 import { type AddIdentityEntryResult } from '@/database/models/userMemory';
+import { userMemoryKeys } from '@/libs/swr/keys';
 import { memoryCRUDService, userMemoryService } from '@/services/userMemory';
 import { type StoreSetter } from '@/store/types';
 import { setNamespace } from '@/utils/storeDebug';
@@ -105,22 +106,10 @@ export class IdentityActionImpl {
   };
 
   useFetchIdentities = (params: IdentityQueryParams): SWRResponse<IdentityListResult> => {
-    const swrKeyParts = [
-      'useFetchIdentities',
-      params.page,
-      params.pageSize,
-      params.q,
-      params.relationships?.join(','),
-      params.sort,
-      params.types?.join(','),
-    ];
-    const swrKey = swrKeyParts
-      .filter((part) => part !== undefined && part !== null && part !== '')
-      .join('-');
     const page = params.page ?? 1;
 
     return useSWR(
-      swrKey,
+      userMemoryKeys.identityList(params),
       async () => {
         // Use the new dedicated queryIdentities API
         return userMemoryService.queryIdentities({

--- a/src/store/userMemory/slices/preference/action.ts
+++ b/src/store/userMemory/slices/preference/action.ts
@@ -4,6 +4,7 @@ import { type SWRResponse } from 'swr';
 import useSWR from 'swr';
 
 import { type DisplayPreferenceMemory } from '@/database/repositories/userMemory';
+import { userMemoryKeys } from '@/libs/swr/keys';
 import { memoryCRUDService, userMemoryService } from '@/services/userMemory';
 import { type StoreSetter } from '@/store/types';
 import { LayersEnum } from '@/types/userMemory';
@@ -71,20 +72,10 @@ export class PreferenceActionImpl {
   };
 
   useFetchPreferences = (params: PreferenceQueryParams): SWRResponse<any> => {
-    const swrKeyParts = [
-      'useFetchPreferences',
-      params.page,
-      params.pageSize,
-      params.q,
-      params.sort,
-    ];
-    const swrKey = swrKeyParts
-      .filter((part) => part !== undefined && part !== null && part !== '')
-      .join('-');
     const page = params.page ?? 1;
 
     return useSWR(
-      swrKey,
+      userMemoryKeys.preferences(params),
       async () => {
         const result = await userMemoryService.queryMemories({
           layer: LayersEnum.Preference,


### PR DESCRIPTION
## 💡 Background

Completes the **store-layer** SWR key convergence into the central registry (`src/libs/swr/keys.ts`). Batch3 (#15850) only partially covered `discover`; an exhaustive re-sweep found ~39 remaining store-layer ad-hoc keys, which this PR migrates. **UI-layer keys are a separate follow-up PR.**

## 🔨 Changes

- **discover** — `model` / `plugin` / `provider` / `skill` / `mcp` / `groupAgent` list+detail+categories, and `user` profile. The `['x', …].join('-')` string keys become registry array factories.
- **tool** (previously-undiscovered cluster) — `agentSkills`, `installedPlugins`, `builtin` uninstalled-tools, `lobehubSkillStore`, `mcpStore` plugin list, `klavisStore`. The dynamic `plugins`-array key (`checkPluginsIsInstalled`) is intentionally left as-is — it's data-derived, not a named key.
- **global** — latest/server version, system status.
- **userMemory** — `retrieve` / `memoryDetail` / `activities` / `contexts` / `experiences` / `identityList` / `preferences`. **Notable:** `purgeAllMemories` invalidation was rewritten from `startsWith('useFetch…')` string matchers to array `key[0] === *.root` matchers, in lockstep with the migrated fetch keys.

## ✅ Guarantees

- **No tiering/caching change.** New prefixes (`discover:`/`tool:`/`global:`/`userMemory:`) are kept out of `CACHE_TIERS`, so everything stays memory-only exactly as before.
- **Behavior preserved** — key identity, mutate match sets, and personal-vs-workspace semantics unchanged.

## 🧪 Test

- `bun run type-check` clean on all touched files.
- `bunx vitest run src/store/{discover,tool,global,userMemory}` → **399 passed, 1 failed**. The single failure (`mcpStore › should not append connectionType in desktop environment`) is a **pre-existing flaky timeout** — verified it fails identically on clean `canary` with all changes stashed.

## ⏭️ Follow-up

UI-layer keys (~54: stats, messenger, verify, inbox/notifications, share, etc.) + the cross-layer `cronTopicsWithJobInfo` will land in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)