### PR TITLE
🐛 fix(assistant): fold short mixed tool blocks together

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -209,17 +209,17 @@ describe('Group', () => {
     ]);
   });
 
-  it('keeps a mixed block full preamble visible above a folded multi-tool workflow', () => {
-    // The whole preamble (every sentence) stays in a visible answer segment; the
-    // workflow fold holds only the tools. Otherwise the prose past the first
-    // sentence would be hidden inside the collapsed-by-default workflow body.
+  it('keeps answer-like mixed prose visible above a folded multi-tool workflow', () => {
+    const answerLikePreamble =
+      'I found the likely rendering issue and need to verify the grouped workflow behavior.\n\n- The assistant prose should remain above the fold when it explains the result.\n- The tools still belong in the collapsed workflow.\n- Short progress lines should not split the workflow.';
+
     const { container } = render(
       <Group
         id="assistant-1"
         messageIndex={0}
         blocks={[
           blk({
-            content: '我先帮你查一下。接下来我会继续整理结果。',
+            content: answerLikePreamble,
             id: 'block-1',
             tools: [{ apiName: 'search', id: 'tool-1' } as any],
           }),
@@ -238,8 +238,8 @@ describe('Group', () => {
 
     expect(sequence).toEqual(['answer-segment', 'workflow-segment']);
     expect(parseAnswerSegment()).toEqual({
-      content: '我先帮你查一下。接下来我会继续整理结果。',
-      contentOverride: '我先帮你查一下。接下来我会继续整理结果。',
+      content: answerLikePreamble,
+      contentOverride: answerLikePreamble,
       disableMarkdownStreaming: true,
       domId: 'block-1__answer',
       hasError: false,
@@ -260,6 +260,50 @@ describe('Group', () => {
       },
       {
         content: '',
+        disableMarkdownStreaming: false,
+        domId: undefined,
+        hasError: false,
+        toolCount: 1,
+      },
+    ]);
+  });
+
+  it('folds consecutive short mixed single-tool blocks into one workflow segment', () => {
+    const { container } = render(
+      <Group
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: 'Let me inspect the package scripts.',
+            id: 'block-1',
+            tools: [{ apiName: 'command_execution', id: 'tool-1' } as any],
+          }),
+          blk({
+            content: 'Now let me read the source file.',
+            id: 'block-2',
+            tools: [{ apiName: 'readFile', id: 'tool-2' } as any],
+          }),
+        ]}
+      />,
+    );
+
+    const sequence = Array.from(container.querySelectorAll('[data-testid]')).map((node) =>
+      node.getAttribute('data-testid'),
+    );
+
+    expect(sequence).toEqual(['workflow-segment']);
+    expect(screen.queryByTestId('answer-segment')).not.toBeInTheDocument();
+    expect(parseWorkflowSegment()).toEqual([
+      {
+        content: 'Let me inspect the package scripts.',
+        disableMarkdownStreaming: true,
+        domId: undefined,
+        hasError: false,
+        toolCount: 1,
+      },
+      {
+        content: 'Now let me read the source file.',
         disableMarkdownStreaming: false,
         domId: undefined,
         hasError: false,

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -5,11 +5,16 @@ import { memo, useMemo } from 'react';
 
 import { LOADING_FLAT } from '@/const/message';
 import ContentLoading from '@/features/Conversation/Messages/components/ContentLoading';
-import { type AssistantContentBlock } from '@/types/index';
+import type { AssistantContentBlock } from '@/types/index';
 
 import { messageStateSelectors, useConversationStore } from '../../../store';
 import { MessageAggregationContext } from '../../Contexts/MessageAggregationContext';
-import { areWorkflowToolsComplete, getPostToolAnswerSplitIndex } from '../toolDisplayNames';
+import { POST_TOOL_FINAL_ANSWER_SCORE_THRESHOLD } from '../constants';
+import {
+  areWorkflowToolsComplete,
+  getPostToolAnswerSplitIndex,
+  scoreBlockContentAsAnswerLike,
+} from '../toolDisplayNames';
 import { CollapsedMessage } from './CollapsedMessage';
 import GroupItem from './GroupItem';
 import type { RenderableAssistantContentBlock } from './types';
@@ -137,6 +142,12 @@ const appendWorkflowBlock = (
   segments.push({ blocks: [block], kind: 'workflow' });
 };
 
+const shouldPromoteMixedBlockContent = (block: AssistantContentBlock): boolean => {
+  if (!hasTools(block) || !hasSubstantiveContent(block)) return false;
+
+  return scoreBlockContentAsAnswerLike(block) >= POST_TOOL_FINAL_ANSWER_SCORE_THRESHOLD;
+};
+
 const appendWorkflowRangeBlock = (
   segments: GroupRenderSegment[],
   block: AssistantContentBlock,
@@ -167,18 +178,11 @@ const appendWorkflowRangeBlock = (
     return;
   }
 
-  // A block that carries both tool calls and prose keeps its NATURAL order
-  // (content above the tool). Within one assistant message the model's text
-  // always precedes its tool_use — tool_use ends the turn, so any post-tool
-  // prose lands in a separate, tool-less block. A mixed block's content is
-  // therefore always a preamble, never a post-tool summary.
-  //
-  // In a single-tool turn the block renders inline as-is (content above its
-  // tool). In a multi-tool turn the tools collapse into a WorkflowCollapse that
-  // defaults to folded once complete, so we lift the full preamble into its own
-  // visible answer segment first and leave only the tool(s) in the fold —
-  // otherwise the explanation would be hidden inside the collapsed body.
-  if (collapsesIntoWorkflow && hasTools(block) && hasSubstantiveContent(block)) {
+  // Mixed blocks keep their natural order: assistant prose precedes tool_use.
+  // Short step/status prose belongs with the workflow so adjacent tools can
+  // still fold together; answer-like prose is lifted above the fold so it does
+  // not disappear inside a collapsed WorkflowCollapse.
+  if (collapsesIntoWorkflow && shouldPromoteMixedBlockContent(block)) {
     appendAnswerBlock(
       segments,
       createAnswerRenderBlock(block, {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None found.

#### 🔀 Description of Change

- Only promote mixed tool/prose blocks above a folded workflow when the prose is answer-like.
- Keep short status-style mixed blocks inside the workflow so consecutive tool calls collapse together.
- Update AssistantGroup rendering tests for answer-like mixed prose and short mixed workflow blocks.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
```

#### 📸 Screenshots / Videos

N/A. Rendering behavior is covered by component tests.

#### 📝 Additional Information

No breaking changes.