### PR TITLE
♻️ refactor(swr): converge UI-layer SWR keys into swrKeys registry

### DIFF
--- a/src/components/ChangelogModal/ChangelogContent.tsx
+++ b/src/components/ChangelogModal/ChangelogContent.tsx
@@ -8,6 +8,7 @@ import urlJoin from 'url-join';
 
 import { CustomMDX } from '@/components/mdx';
 import { OFFICIAL_SITE } from '@/const/url';
+import { changelogKeys } from '@/libs/swr/keys';
 import { lambdaClient } from '@/libs/trpc/client';
 import { type Locales } from '@/locales/resources';
 import { type ChangelogIndexItem } from '@/types/changelog';
@@ -24,7 +25,7 @@ interface PostItemProps extends ChangelogIndexItem {
 }
 
 const PostItem = ({ id, versionRange, locale, showDivider = true }: PostItemProps) => {
-  const { data } = useSWR([`changelog-post-${id}`, locale], async () => {
+  const { data } = useSWR(changelogKeys.post(id, locale), async () => {
     return await lambdaClient.changelog.getPostById.query({ id, locale });
   });
 

--- a/src/components/ChangelogModal/ChangelogModalContent.tsx
+++ b/src/components/ChangelogModal/ChangelogModalContent.tsx
@@ -5,6 +5,7 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
+import { changelogKeys } from '@/libs/swr/keys';
 import { lambdaClient } from '@/libs/trpc/client';
 
 import ChangelogContent from './ChangelogContent';
@@ -13,7 +14,7 @@ const SCROLL_HEIGHT = 'min(80vh, 760px)';
 
 const ChangelogModalContent = memo(() => {
   const { t } = useTranslation('common');
-  const { data, isLoading } = useSWR('changelog-modal-index', () =>
+  const { data, isLoading } = useSWR(changelogKeys.modalIndex(), () =>
     lambdaClient.changelog.getIndex.query(),
   );
 

--- a/src/features/AgentHome/RecentTopics.tsx
+++ b/src/features/AgentHome/RecentTopics.tsx
@@ -10,6 +10,7 @@ import useSWR from 'swr';
 
 import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
+import { agentHomeKeys } from '@/libs/swr/keys';
 import { topicService } from '@/services/topic';
 
 import SectionHeader from './SectionHeader';
@@ -18,7 +19,7 @@ const AgentRecentTopics = memo(() => {
   const { t } = useTranslation('chat');
   const { aid } = useParams<{ aid: string }>();
 
-  const { data: result, isLoading } = useSWR(aid ? ['agentHome.topics', aid] : null, () =>
+  const { data: result, isLoading } = useSWR(aid ? agentHomeKeys.topics(aid) : null, () =>
     topicService.getTopics({ agentId: aid!, current: 0, pageSize: 10 }),
   );
 

--- a/src/features/AgentProfileCard/AgentProfilePopup.tsx
+++ b/src/features/AgentProfileCard/AgentProfilePopup.tsx
@@ -12,6 +12,7 @@ import useSWR from 'swr';
 
 import ModelSelect from '@/features/ModelSelect';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
+import { agentProfileKeys } from '@/libs/swr/keys';
 import { agentService } from '@/services/agent';
 import { useAgentGroupStore } from '@/store/agentGroup';
 
@@ -78,7 +79,7 @@ const AgentProfilePopup = memo<AgentProfilePopupProps>(
     const updateMemberAgentConfig = useAgentGroupStore((s) => s.updateMemberAgentConfig);
 
     const { data: fetched, isLoading } = useSWR(
-      open ? ['agentProfile', agentId] : null,
+      open ? agentProfileKeys.detail(agentId) : null,
       () => agentService.getAgentConfigById(agentId) as Promise<FetchedAgent | null>,
       { revalidateOnFocus: false },
     );

--- a/src/features/Auth/OAuthConsent/useInteractionDetails.ts
+++ b/src/features/Auth/OAuthConsent/useInteractionDetails.ts
@@ -1,5 +1,6 @@
 import useSWR from 'swr';
 
+import { authKeys } from '@/libs/swr/keys';
 import type { OidcInteractionDetailsResponse, OidcInteractionErrorResponse } from '@/types/oidc';
 
 export class InteractionDetailsError extends Error {
@@ -31,7 +32,7 @@ export const fetchInteractionDetails = async (
 
 export const useInteractionDetails = (uid?: string) =>
   useSWR(
-    uid ? ['oidc-interaction', uid] : null,
+    uid ? authKeys.oidcInteraction(uid) : null,
     ([, id]: [string, string]) => fetchInteractionDetails(id),
     {
       revalidateOnFocus: false,

--- a/src/features/ChatInput/ActionBar/SaveTopic/index.tsx
+++ b/src/features/ChatInput/ActionBar/SaveTopic/index.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { usePermission } from '@/hooks/usePermission';
 import { useActionSWR } from '@/libs/swr';
+import { topicActionKeys } from '@/libs/swr/keys';
 import { useChatStore } from '@/store/chat';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
@@ -23,7 +24,10 @@ const SaveTopic = memo(() => {
 
   const mobile = useIsMobile();
 
-  const { mutate, isValidating } = useActionSWR('openNewTopicOrSaveTopic', openNewTopicOrSaveTopic);
+  const { mutate, isValidating } = useActionSWR(
+    topicActionKeys.openNewOrSave(),
+    openNewTopicOrSaveTopic,
+  );
 
   const [confirmOpened, setConfirmOpened] = useState(false);
 

--- a/src/features/ChatInput/ControlBar/BranchSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/BranchSwitcher.tsx
@@ -32,6 +32,7 @@ import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
 import { message } from '@/components/AntdStaticMethods';
+import { deviceKeys } from '@/libs/swr/keys';
 import { gitService } from '@/services/git';
 import { useFetchGitWorkingTreeStatus } from '@/store/device';
 
@@ -243,7 +244,7 @@ const BranchSwitcher = memo<BranchSwitcherProps>(
       error: branchesError,
       mutate: mutateBranches,
     } = useSWR(
-      open ? ['git-branches', deviceId ?? 'local', path] : null,
+      open ? deviceKeys.gitBranches(deviceId ?? 'local', path) : null,
       () => gitService.listGitBranches({ deviceId, path }),
       { revalidateOnFocus: false, shouldRetryOnError: false },
     );

--- a/src/features/ChatInput/ControlBar/useRepoType.ts
+++ b/src/features/ChatInput/ControlBar/useRepoType.ts
@@ -2,6 +2,7 @@ import { isDesktop } from '@lobechat/const';
 import { useEffect, useMemo } from 'react';
 import useSWR from 'swr';
 
+import { deviceKeys } from '@/libs/swr/keys';
 import { electronGitService } from '@/services/electron/git';
 import { deviceSelectors, useDeviceStore } from '@/store/device';
 import { useElectronStore } from '@/store/electron';
@@ -45,7 +46,7 @@ export const useRepoType = (path?: string, deviceId?: string): RepoType => {
   const shouldProbe = isDesktop && isLocalTarget && !!path && !cached;
 
   const { data: probed } = useSWR(
-    shouldProbe ? ['detect-repo-type', path] : null,
+    shouldProbe ? deviceKeys.repoType(path!) : null,
     () => electronGitService.detectRepoType(path!),
     {
       dedupingInterval: 60 * 1000,

--- a/src/features/Conversation/ChatList/hooks/useAgentSignalReceipts.ts
+++ b/src/features/Conversation/ChatList/hooks/useAgentSignalReceipts.ts
@@ -2,6 +2,7 @@ import type { UIChatMessage } from '@lobechat/types';
 import { useMemo, useRef } from 'react';
 import useSWR from 'swr';
 
+import { agentSignalKeys } from '@/libs/swr/keys';
 import { agentSignalService } from '@/services/agentSignal';
 
 /** Poll cadence for the active conversation's Agent Signal receipt surface. */
@@ -49,7 +50,7 @@ export const useAgentSignalReceipts = (input: {
   }
 
   const { data, isLoading } = useSWR(
-    shouldFetch ? ['agentSignalReceipts', input.agentId, input.topicId] : null,
+    shouldFetch ? agentSignalKeys.receipts(input.agentId!, input.topicId!) : null,
     async () => {
       const result = await agentSignalService.listReceipts({
         agentId: input.agentId!,

--- a/src/features/MCPPluginDetail/Agents.tsx
+++ b/src/features/MCPPluginDetail/Agents.tsx
@@ -11,6 +11,7 @@ import AgentItem from '@/features/SkillStore/SkillDetail/AgentItem';
 import { agentListStyles as styles } from '@/features/SkillStore/SkillDetail/style';
 import VirtuosoLoading from '@/features/SkillStore/SkillList/VirtuosoLoading';
 import { useClientDataSWR } from '@/libs/swr';
+import { discoverKeys } from '@/libs/swr/keys';
 import { discoverService } from '@/services/discover';
 import { type DiscoverAssistantItem } from '@/types/discover';
 
@@ -35,7 +36,7 @@ const Agents = memo<AgentsProps>(({ inModal }) => {
 
   // SWR fetch data (lazy loading - only requests when component mounts)
   const { data, isLoading, error } = useClientDataSWR(
-    identifier ? ['mcp-agents', identifier, currentPage] : null,
+    identifier ? discoverKeys.mcpAgents(identifier, currentPage) : null,
     () =>
       discoverService.getAgentsByPlugin({
         page: currentPage,

--- a/src/features/MCPPluginDetail/Header.tsx
+++ b/src/features/MCPPluginDetail/Header.tsx
@@ -34,6 +34,7 @@ import Scores from '@/features/MCP/Scores';
 import { getLanguageColor, getRecommendedDeployment } from '@/features/MCP/utils';
 import { useCategory } from '@/hooks/useMCPCategory';
 import { useMarketAuth } from '@/layout/AuthProvider/MarketAuth';
+import { favoriteKeys } from '@/libs/swr/keys';
 import { socialService } from '@/services/social';
 
 import InstallationIcon from '../../components/MCPDepsIcon';
@@ -90,7 +91,7 @@ const Header = memo<{ inModal?: boolean; mobile?: boolean }>(({ mobile: isMobile
 
   // Fetch favorite status
   const { data: favoriteStatus, mutate: mutateFavorite } = useSWR(
-    identifier && isAuthenticated ? ['favorite-status', 'plugin', identifier] : null,
+    identifier && isAuthenticated ? favoriteKeys.status('plugin', identifier) : null,
     () => socialService.checkFavoriteStatus('plugin', identifier!),
     { revalidateOnFocus: false },
   );

--- a/src/features/Messenger/AgentSelect.tsx
+++ b/src/features/Messenger/AgentSelect.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
 import { DEFAULT_AVATAR } from '@/const/meta';
+import { messengerKeys } from '@/libs/swr/keys';
 import { messengerService } from '@/services/messenger';
 
 interface AgentSelectProps extends Omit<SelectProps<string>, 'options' | 'value' | 'onChange'> {
@@ -28,7 +29,7 @@ const AgentSelect = memo<AgentSelectProps>(
     // Cascading fetch: agents are scoped to the selected `workspaceId` (or
     // personal when null). The scope is part of the SWR key so switching scope
     // refetches the right list.
-    const agentsSWR = useSWR(['messenger:agentsForBinding', workspaceId ?? null], () =>
+    const agentsSWR = useSWR(messengerKeys.agentsForBinding(workspaceId), () =>
       messengerService.listAgentsForBinding(workspaceId),
     );
 

--- a/src/features/Messenger/IntegrationDetail/shared.test.tsx
+++ b/src/features/Messenger/IntegrationDetail/shared.test.tsx
@@ -2,6 +2,8 @@ import { render, screen, within } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { messengerKeys } from '@/libs/swr/keys';
+
 import { UserAgentConnection } from './shared';
 
 const userState = {
@@ -80,9 +82,9 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('swr', () => ({
-  default: (key: string) => ({
+  default: (key: unknown) => ({
     data:
-      key === 'messenger:bindingScopes'
+      Array.isArray(key) && key[0] === messengerKeys.bindingScopes.root
         ? [{ avatar: 'workspace-avatar', id: 'workspace-1', name: 'love' }]
         : undefined,
     isLoading: false,

--- a/src/features/Messenger/IntegrationDetail/shared.tsx
+++ b/src/features/Messenger/IntegrationDetail/shared.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
 import { usePermission } from '@/hooks/usePermission';
+import { messengerKeys } from '@/libs/swr/keys';
 import { messengerService } from '@/services/messenger';
 import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
@@ -255,7 +256,7 @@ export const UserAgentConnection = memo<UserAgentConnectionProps>(
     // filters the agent list below. The active scope is persisted server-side
     // only when an agent is chosen (it derives the workspace from the agent).
     // `PERSONAL_SCOPE` is the sentinel for personal (null).
-    const scopesSWR = useSWR(enableWorkspaceScopes ? 'messenger:bindingScopes' : null, () =>
+    const scopesSWR = useSWR(enableWorkspaceScopes ? messengerKeys.bindingScopes() : null, () =>
       messengerService.listBindingScopes(),
     );
     const [scope, setScope] = useState<string>(
@@ -383,8 +384,8 @@ export const UserAgentConnection = memo<UserAgentConnectionProps>(
 UserAgentConnection.displayName = 'MessengerUserAgentConnection';
 
 export const useMessengerData = (platform: MessengerPlatform) => {
-  const linksSWR = useSWR('messenger:listMyLinks', () => messengerService.listMyLinks());
-  const installationsSWR = useSWR('messenger:listMyInstallations', () =>
+  const linksSWR = useSWR(messengerKeys.listMyLinks(), () => messengerService.listMyLinks());
+  const installationsSWR = useSWR(messengerKeys.listMyInstallations(), () =>
     messengerService.listMyInstallations(),
   );
 

--- a/src/features/Messenger/Verify/Body/shared.tsx
+++ b/src/features/Messenger/Verify/Body/shared.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
 import { ProductLogo } from '@/components/Branding';
+import { messengerKeys } from '@/libs/swr/keys';
 import { messengerService } from '@/services/messenger';
 import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
@@ -171,7 +172,7 @@ export const ConfirmCard = memo<ConfirmCardProps>(
     // First-level scope selector — personal plus every workspace the user
     // belongs to. Picking a scope just filters the agent list below; the
     // backend derives the binding's workspace from the chosen agent on confirm.
-    const scopesSWR = useSWR(enableWorkspaceScopes ? 'messenger:bindingScopes' : null, () =>
+    const scopesSWR = useSWR(enableWorkspaceScopes ? messengerKeys.bindingScopes() : null, () =>
       messengerService.listBindingScopes(),
     );
     const [scope, setScope] = useState<string>(PERSONAL_SCOPE);
@@ -188,7 +189,7 @@ export const ConfirmCard = memo<ConfirmCardProps>(
 
     // Scope-aware agent list. The SWR key matches AgentSelect's so the fetch is
     // shared (single request per scope) and stays in sync as the scope changes.
-    const agentsSWR = useSWR(['messenger:agentsForBinding', scopeWorkspaceId], () =>
+    const agentsSWR = useSWR(messengerKeys.agentsForBinding(scopeWorkspaceId), () =>
       messengerService.listAgentsForBinding(scopeWorkspaceId),
     );
 

--- a/src/features/Messenger/Verify/index.tsx
+++ b/src/features/Messenger/Verify/index.tsx
@@ -8,6 +8,7 @@ import useSWR from 'swr';
 
 import Loading from '@/components/Loading/BrandTextLoading';
 import { useSession } from '@/libs/better-auth/auth-client';
+import { messengerKeys } from '@/libs/swr/keys';
 import { messengerService } from '@/services/messenger';
 
 import { type MessengerPlatform } from '../constants';
@@ -30,11 +31,11 @@ const MessengerVerifyPage = memo(() => {
   const isSignedIn = !!session?.user;
 
   // Used in the success state to deep-link the user back to the bot.
-  const platformsSWR = useSWR('messenger:availablePlatforms', () =>
+  const platformsSWR = useSWR(messengerKeys.availablePlatforms(), () =>
     messengerService.availablePlatforms(),
   );
 
-  const tokenSWR = useSWR(randomId && isSignedIn ? ['messenger:peek', randomId] : null, async () =>
+  const tokenSWR = useSWR(randomId && isSignedIn ? messengerKeys.peek(randomId) : null, async () =>
     messengerService.peekLinkToken(randomId),
   );
 
@@ -58,7 +59,7 @@ const MessengerVerifyPage = memo(() => {
   const tokenScopeKey =
     tokenStatus === 'active' || tokenStatus === 'consumed' ? (scopedTenantId ?? '') : '__any__';
   const existingLinkSWR = useSWR(
-    isSignedIn && tokenResolved && platform ? ['messenger:myLink', platform, tokenScopeKey] : null,
+    isSignedIn && tokenResolved && platform ? messengerKeys.myLink(platform, tokenScopeKey) : null,
     async () =>
       messengerService.getMyLink(
         platform!,

--- a/src/features/Messenger/index.tsx
+++ b/src/features/Messenger/index.tsx
@@ -9,6 +9,7 @@ import { useParams } from 'react-router-dom';
 import useSWR from 'swr';
 
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
+import { messengerKeys } from '@/libs/swr/keys';
 import { messengerService } from '@/services/messenger';
 
 import { type MessengerPlatform, PlatformAvatar } from './constants';
@@ -55,7 +56,7 @@ const MessengerSettings = memo(() => {
   // next-step guidance.
   const [blocked, setBlocked] = useState<BlockedInstall | null>(null);
 
-  const platformsSWR = useSWR('messenger:availablePlatforms', () =>
+  const platformsSWR = useSWR(messengerKeys.availablePlatforms(), () =>
     messengerService.availablePlatforms(),
   );
 

--- a/src/features/OllamaModelDownloader/index.tsx
+++ b/src/features/OllamaModelDownloader/index.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 
 import FormAction from '@/components/FormAction';
 import { useActionSWR } from '@/libs/swr';
+import { ollamaKeys } from '@/libs/swr/keys';
 import { type ModelProgressInfo } from '@/services/models';
 import { modelsService } from '@/services/models';
 import { formatSize } from '@/utils/format';
@@ -43,7 +44,7 @@ const OllamaModelDownloader = memo<OllamaModelDownloaderProps>(
       isValidating: isDownloading,
       error,
     } = useActionSWR(
-      ['ollama.downloadModel', modelToPull],
+      ollamaKeys.downloadModel(modelToPull),
       async () => {
         await modelsService.downloadModel(
           { model: modelToPull, provider: 'ollama' },

--- a/src/features/Onboarding/Agent/MessengerIntegrations.tsx
+++ b/src/features/Onboarding/Agent/MessengerIntegrations.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
 import { buildTelegramDeepLink, PlatformAvatar } from '@/features/Messenger/constants';
+import { messengerKeys } from '@/libs/swr/keys';
 import { messengerService } from '@/services/messenger';
 
 const SLACK_INSTALL_HREF = '/api/agent/messenger/slack/install';
@@ -66,7 +67,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 const MessengerIntegrations = memo(() => {
   const { t } = useTranslation('onboarding');
 
-  const { data, isLoading } = useSWR('messenger:availablePlatforms', () =>
+  const { data, isLoading } = useSWR(messengerKeys.availablePlatforms(), () =>
     messengerService.availablePlatforms(),
   );
 

--- a/src/features/Onboarding/Agent/index.tsx
+++ b/src/features/Onboarding/Agent/index.tsx
@@ -19,6 +19,7 @@ import ModeSwitch from '@/features/Onboarding/components/ModeSwitch';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useOnboardingAgentTemplates } from '@/hooks/useOnboardingAgentTemplates';
 import { useClientDataSWR, useOnlyFetchOnceSWR } from '@/libs/swr';
+import { onboardingKeys } from '@/libs/swr/keys';
 import OnboardingContainer from '@/routes/onboarding/_layout';
 import { fetchOnboardingAgentTemplates } from '@/services/agentMarketplace';
 import {
@@ -86,7 +87,7 @@ const AgentOnboardingPage = memo(() => {
   }, []);
 
   const { data: historyData, mutate: mutateHistoryTopics } = useClientDataSWR(
-    isDev && onboardingAgentId ? ['agent-onboarding-history-topics', onboardingAgentId] : null,
+    isDev && onboardingAgentId ? onboardingKeys.agentHistoryTopics(onboardingAgentId) : null,
     () =>
       topicService.getTopics({
         agentId: onboardingAgentId,
@@ -95,7 +96,7 @@ const AgentOnboardingPage = memo(() => {
   );
 
   const { data, error, isLoading, mutate } = useOnlyFetchOnceSWR(
-    'agent-onboarding-bootstrap',
+    onboardingKeys.agentBootstrap(),
     () => userService.getOnboardingBootstrapState(),
     {
       onSuccess: async () => {

--- a/src/features/Portal/Document/Body.tsx
+++ b/src/features/Portal/Document/Body.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import CodeEditorPane from '@/components/CodeEditorPane';
 import FloatingChatPanel from '@/features/FloatingChatPanel';
 import { useClientDataSWR } from '@/libs/swr';
+import { portalKeys } from '@/libs/swr/keys';
 import { documentService } from '@/services/document';
 import { useAgentStore } from '@/store/agent';
 import { useChatStore } from '@/store/chat';
@@ -324,7 +325,7 @@ const DocumentBody = memo(() => {
   const isSkillMarkdown = contentFormat === 'skillMarkdown';
 
   const { data: documentMeta, mutate: mutateDocumentMeta } = useClientDataSWR(
-    documentId ? ['portal-document-header', documentId] : null,
+    documentId ? portalKeys.documentHeader(documentId) : null,
     () => documentService.getDocumentById(documentId!),
   );
   const renderMode = documentMeta

--- a/src/features/Portal/Document/Header.tsx
+++ b/src/features/Portal/Document/Header.tsx
@@ -4,6 +4,7 @@ import { Flexbox, Skeleton, Text } from '@lobehub/ui';
 import { cx } from 'antd-style';
 
 import { useClientDataSWR } from '@/libs/swr';
+import { portalKeys } from '@/libs/swr/keys';
 import { documentService } from '@/services/document';
 import { useChatStore } from '@/store/chat';
 import { chatPortalSelectors } from '@/store/chat/selectors';
@@ -16,7 +17,7 @@ const Header = () => {
   const documentId = useChatStore(chatPortalSelectors.portalDocumentId);
 
   const { data: document, isLoading } = useClientDataSWR(
-    documentId ? ['portal-document-header', documentId] : null,
+    documentId ? portalKeys.documentHeader(documentId) : null,
     () => documentService.getDocumentById(documentId!),
   );
 

--- a/src/features/SharePopover/index.tsx
+++ b/src/features/SharePopover/index.tsx
@@ -29,6 +29,7 @@ import useSWR from 'swr';
 import { useAppOrigin } from '@/hooks/useAppOrigin';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { usePermission } from '@/hooks/usePermission';
+import { shareKeys } from '@/libs/swr/keys';
 import { topicService } from '@/services/topic';
 import { useChatStore } from '@/store/chat';
 import { useGlobalStore } from '@/store/global';
@@ -71,7 +72,7 @@ const SharePopoverContent = memo<SharePopoverContentProps>(({ onOpenModal, topic
     isLoading,
     mutate,
   } = useSWR(
-    activeTopicId && canShare ? ['topic-share-info', activeTopicId] : null,
+    activeTopicId && canShare ? shareKeys.topicInfo(activeTopicId) : null,
     () => topicService.getShareInfo(activeTopicId!),
     { revalidateOnFocus: false },
   );

--- a/src/features/SkillStore/SkillDetail/Agents.tsx
+++ b/src/features/SkillStore/SkillDetail/Agents.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { VirtuosoGrid } from 'react-virtuoso';
 
 import { useClientDataSWR } from '@/libs/swr';
+import { discoverKeys } from '@/libs/swr/keys';
 import { discoverService } from '@/services/discover';
 import { type DiscoverAssistantItem } from '@/types/discover';
 
@@ -31,7 +32,7 @@ const Agents = memo(() => {
 
   // SWR fetch data (lazy loading - only requests when component mounts)
   const { data, isLoading, error } = useClientDataSWR(
-    identifier ? ['skill-agents', identifier, currentPage] : null,
+    identifier ? discoverKeys.skillAgents(identifier, currentPage) : null,
     () =>
       discoverService.getAgentsByPlugin({
         page: currentPage,

--- a/src/features/SkillStore/SkillList/MarketSkills/index.tsx
+++ b/src/features/SkillStore/SkillList/MarketSkills/index.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { VirtuosoGrid } from 'react-virtuoso';
 
 import { useClientDataSWR } from '@/libs/swr';
+import { discoverKeys } from '@/libs/swr/keys';
 import { discoverService } from '@/services/discover';
 import { globalHelpers } from '@/store/global/helpers';
 import { useToolStore } from '@/store/tool';
@@ -38,7 +39,7 @@ const MarketSkillList = memo<MarketSkillListProps>(({ keywords }) => {
 
   const locale = globalHelpers.getCurrentLanguage();
   const { data, isLoading, error } = useClientDataSWR(
-    ['skill-store-market-skills', locale, keywords || '', page].filter(Boolean).join('-'),
+    discoverKeys.skillStoreMarketSkills(locale, keywords || '', page),
     () =>
       discoverService.getSkillList({
         page,

--- a/src/features/User/DataStatistics.tsx
+++ b/src/features/User/DataStatistics.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
 import { useClientDataSWR } from '@/libs/swr';
+import { statsKeys } from '@/libs/swr/keys';
 import { messageService } from '@/services/message';
 import { sessionService } from '@/services/session';
 import { topicService } from '@/services/topic';
@@ -46,16 +47,17 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 const DataStatistics = memo<Omit<FlexboxProps, 'children'>>(({ style, ...rest }) => {
   const mobile = useServerConfigStore((s) => s.isMobile);
   // sessions
-  const { data: sessions, isLoading: sessionsLoading } = useClientDataSWR('count-sessions', () =>
-    sessionService.countSessions(),
+  const { data: sessions, isLoading: sessionsLoading } = useClientDataSWR(
+    statsKeys.countSessions(),
+    () => sessionService.countSessions(),
   );
   // topics
-  const { data: topics, isLoading: topicsLoading } = useClientDataSWR('count-topics', () =>
+  const { data: topics, isLoading: topicsLoading } = useClientDataSWR(statsKeys.countTopics(), () =>
     topicService.countTopics(),
   );
   // messages
   const { data: { messages, messagesToday } = {}, isLoading: messagesLoading } = useClientDataSWR(
-    'count-messages',
+    statsKeys.countMessages(),
     async () => ({
       messages: await messageService.countMessages(),
       messagesToday: await messageService.countMessages({

--- a/src/features/Verify/hooks.ts
+++ b/src/features/Verify/hooks.ts
@@ -1,39 +1,34 @@
 import { useClientDataSWR } from '@/libs/swr';
+import { verifyKeys } from '@/libs/swr/keys';
 import { documentService } from '@/services/document';
 import { verifyService } from '@/services/verify';
 
-export const VERIFY_STATE_KEY = 'verify-state';
-export const VERIFY_RESULTS_KEY = 'verify-results';
-export const VERIFY_TRACING_KEY = 'verify-tracing';
-export const VERIFY_INSTRUCTION_KEY = 'verify-instruction';
-export const VERIFY_RUBRIC_KEY = 'verify-rubric';
-
 /** Plan + rollup status for one Agent Run. Pass null operationId to skip. */
 export const useVerifyState = (operationId: string | null) =>
-  useClientDataSWR(operationId ? [VERIFY_STATE_KEY, operationId] : null, () =>
+  useClientDataSWR(operationId ? verifyKeys.state(operationId) : null, () =>
     verifyService.getVerifyState(operationId!),
   );
 
 /** Per-item check results for one Agent Run. Pass null operationId to skip. */
 export const useVerifyResults = (operationId: string | null) =>
-  useClientDataSWR(operationId ? [VERIFY_RESULTS_KEY, operationId] : null, () =>
+  useClientDataSWR(operationId ? verifyKeys.results(operationId) : null, () =>
     verifyService.listResults(operationId!),
   );
 
 /** Model / token / latency for an LLM verifier judgment. Pass null to skip. */
 export const useVerifierTracing = (tracingId: string | null | undefined) =>
-  useClientDataSWR(tracingId ? [VERIFY_TRACING_KEY, tracingId] : null, () =>
+  useClientDataSWR(tracingId ? verifyKeys.tracing(tracingId) : null, () =>
     verifyService.getVerifierTracing(tracingId!),
   );
 
 /** The criterion's original judging rule, stored in its instruction document. */
 export const useVerifyInstruction = (documentId: string | null | undefined) =>
-  useClientDataSWR(documentId ? [VERIFY_INSTRUCTION_KEY, documentId] : null, () =>
+  useClientDataSWR(documentId ? verifyKeys.instruction(documentId) : null, () =>
     documentService.getDocumentById(documentId!),
   );
 
 /** A rubric and its run-policy config (e.g. maxRepairRounds). Pass null to skip. */
 export const useRubric = (rubricId: string | null | undefined) =>
-  useClientDataSWR(rubricId ? [VERIFY_RUBRIC_KEY, rubricId] : null, () =>
+  useClientDataSWR(rubricId ? verifyKeys.rubric(rubricId) : null, () =>
     verifyService.getRubric(rubricId!),
   );

--- a/src/hooks/useHotkeys/chatScope.ts
+++ b/src/hooks/useHotkeys/chatScope.ts
@@ -4,6 +4,7 @@ import { useHotkeysContext } from 'react-hotkeys-hook';
 
 import { useOpenChatSettings } from '@/hooks/useInterceptingRoutes';
 import { useActionSWR } from '@/libs/swr';
+import { topicActionKeys } from '@/libs/swr/keys';
 import { useChatStore } from '@/store/chat';
 import { useGlobalStore } from '@/store/global';
 
@@ -11,7 +12,7 @@ import { useHotkeyById } from './useHotkeyById';
 
 export const useSaveTopicHotkey = () => {
   const openNewTopicOrSaveTopic = useChatStore((s) => s.openNewTopicOrSaveTopic);
-  const { mutate } = useActionSWR('openNewTopicOrSaveTopic', openNewTopicOrSaveTopic);
+  const { mutate } = useActionSWR(topicActionKeys.openNewOrSave(), openNewTopicOrSaveTopic);
   return useHotkeyById(HotkeyEnum.SaveTopic, () => mutate(), { enableOnContentEditable: true });
 };
 

--- a/src/libs/swr/keys.ts
+++ b/src/libs/swr/keys.ts
@@ -80,10 +80,18 @@ export const agentKeys = {
 export const groupKeys = {
   detail: def('group:detail', (groupId: string) => ['group:detail', groupId]),
   list: def('group:list', (isLogin: boolean) => ['group:list', isLogin]),
+  /** Agent picker for the "add member" modal. */
+  queryAgents: def('group:queryAgents', () => ['group:queryAgents']),
+  /** Agent picker for the "create group" modal. */
+  queryAgentsForCreate: def('group:queryAgentsForCreate', () => ['group:queryAgentsForCreate']),
 };
 
 // ---- session ------------------------------------------------------------
 export const sessionKeys = {
+  createSession: def('session:createSession', (groupId: string | undefined) => [
+    'session:createSession',
+    groupId,
+  ]),
   list: def('session:list', (isLogin: boolean | undefined) => ['session:list', isLogin]),
   search: def('session:search', (keyword?: string) => ['session:search', keyword]),
 };
@@ -314,6 +322,26 @@ export const discoverKeys = {
     locale,
     username,
   ]),
+  // -- marketplace detail "related agents" lists (UI) --
+  mcpAgents: def('discover:mcpAgents', (identifier: string, page: number) => [
+    'discover:mcpAgents',
+    identifier,
+    page,
+  ]),
+  skillAgents: def('discover:skillAgents', (identifier: string, page: number) => [
+    'discover:skillAgents',
+    identifier,
+    page,
+  ]),
+  skillStoreMarketSkills: def(
+    'discover:skillStoreMarketSkills',
+    (locale: string, keywords: string, page: number) => [
+      'discover:skillStoreMarketSkills',
+      locale,
+      keywords,
+      page,
+    ],
+  ),
 };
 
 // ---- agent eval ---------------------------------------------------------
@@ -365,6 +393,11 @@ export const deviceKeys = {
     deviceId,
     path,
   ]),
+  gitBranches: def('device:gitBranches', (deviceId: string, path: string) => [
+    'device:gitBranches',
+    deviceId,
+    path,
+  ]),
   gitInfo: def('device:gitInfo', (deviceId: string, path: string, isGithub: boolean) => [
     'device:gitInfo',
     deviceId,
@@ -377,6 +410,7 @@ export const deviceKeys = {
     path,
   ]),
   listDevices: def('device:listDevices', () => ['device:listDevices']),
+  repoType: def('device:repoType', (path: string) => ['device:repoType', path]),
 };
 
 // ---- user memory --------------------------------------------------------
@@ -475,6 +509,157 @@ export const chatToolKeys = {
   interpreterFile: def('chat:interpreterFile', (id: string) => ['chat:interpreterFile', id]),
 };
 
+// =========================================================================
+// UI-layer keys (features / routes / components). Same rule as above: every
+// prefix below is deliberately kept OUT of `CACHE_TIERS` (memory-only). Names
+// avoid colliding with cached prefixes — e.g. share/topicInfo is `share:` not
+// `topic:`, portal header is `portal:` not `document:`.
+// =========================================================================
+
+// ---- stats (settings/stats + user header counts) ------------------------
+export const statsKeys = {
+  countMessages: def('stats:countMessages', () => ['stats:countMessages']),
+  countSessions: def('stats:countSessions', () => ['stats:countSessions']),
+  countTopics: def('stats:countTopics', () => ['stats:countTopics']),
+  heatmaps: def('stats:heatmaps', (type: string) => ['stats:heatmaps', type]),
+  maxTaskDuration: def('stats:maxTaskDuration', () => ['stats:maxTaskDuration']),
+  messages: def('stats:messages', () => ['stats:messages']),
+  rankAgents: def('stats:rankAgents', () => ['stats:rankAgents']),
+  rankModels: def('stats:rankModels', () => ['stats:rankModels']),
+  rankTopics: def('stats:rankTopics', () => ['stats:rankTopics']),
+  sessions: def('stats:sessions', () => ['stats:sessions']),
+  topics: def('stats:topics', () => ['stats:topics']),
+  usageLogs: def('stats:usageLogs', () => ['stats:usageLogs']),
+  usageStat: def('stats:usageStat', () => ['stats:usageStat']),
+  welcome: def('stats:welcome', () => ['stats:welcome']),
+};
+
+// ---- messenger / platform integration -----------------------------------
+export const messengerKeys = {
+  agentsForBinding: def('messenger:agentsForBinding', (workspaceId: string | null | undefined) => [
+    'messenger:agentsForBinding',
+    workspaceId ?? null,
+  ]),
+  availablePlatforms: def('messenger:availablePlatforms', () => ['messenger:availablePlatforms']),
+  bindingScopes: def('messenger:bindingScopes', () => ['messenger:bindingScopes']),
+  listMyInstallations: def('messenger:listMyInstallations', () => [
+    'messenger:listMyInstallations',
+  ]),
+  listMyLinks: def('messenger:listMyLinks', () => ['messenger:listMyLinks']),
+  myLink: def('messenger:myLink', (platform: string, tokenScopeKey: string | undefined) => [
+    'messenger:myLink',
+    platform,
+    tokenScopeKey,
+  ]),
+  peek: def('messenger:peek', (randomId: string) => ['messenger:peek', randomId]),
+};
+
+// ---- verify (deliverable judging) ---------------------------------------
+export const verifyKeys = {
+  instruction: def('verify:instruction', (documentId: string) => [
+    'verify:instruction',
+    documentId,
+  ]),
+  results: def('verify:results', (operationId: string) => ['verify:results', operationId]),
+  rubric: def('verify:rubric', (rubricId: string) => ['verify:rubric', rubricId]),
+  state: def('verify:state', (operationId: string) => ['verify:state', operationId]),
+  tracing: def('verify:tracing', (tracingId: string) => ['verify:tracing', tracingId]),
+};
+
+// ---- inbox / notifications ----------------------------------------------
+export const inboxKeys = {
+  notifications: def(
+    'inbox:notifications',
+    (cursor: string | undefined, unreadOnly: boolean | undefined) => [
+      'inbox:notifications',
+      cursor,
+      unreadOnly,
+    ],
+  ),
+  unreadCount: def('inbox:unreadCount', () => ['inbox:unreadCount']),
+};
+
+// ---- share (shared topic / page) ----------------------------------------
+export const shareKeys = {
+  pageDocument: def('share:pageDocument', (documentId: string) => [
+    'share:pageDocument',
+    documentId,
+  ]),
+  topic: def('share:topic', (id: string) => ['share:topic', id]),
+  topicInfo: def('share:topicInfo', (topicId: string) => ['share:topicInfo', topicId]),
+};
+
+// ---- fork source (community detail) -------------------------------------
+export const forkKeys = {
+  groupSource: def('fork:groupSource', (identifier: string) => ['fork:groupSource', identifier]),
+  source: def('fork:source', (identifier: string) => ['fork:source', identifier]),
+};
+
+// ---- portal -------------------------------------------------------------
+export const portalKeys = {
+  documentHeader: def('portal:documentHeader', (documentId: string) => [
+    'portal:documentHeader',
+    documentId,
+  ]),
+};
+
+// ---- favorite status (marketplace detail headers) -----------------------
+export const favoriteKeys = {
+  status: def('favorite:status', (targetType: string, identifier: string) => [
+    'favorite:status',
+    targetType,
+    identifier,
+  ]),
+};
+
+// ---- changelog ----------------------------------------------------------
+export const changelogKeys = {
+  modalIndex: def('changelog:modalIndex', () => ['changelog:modalIndex']),
+  post: def('changelog:post', (id: string, locale: string) => ['changelog:post', id, locale]),
+};
+
+// ---- agent onboarding ---------------------------------------------------
+export const onboardingKeys = {
+  agentBootstrap: def('onboarding:agentBootstrap', () => ['onboarding:agentBootstrap']),
+  agentHistoryTopics: def('onboarding:agentHistoryTopics', (agentId: string) => [
+    'onboarding:agentHistoryTopics',
+    agentId,
+  ]),
+};
+
+// ---- agent home / profile / signal (kept off the `agent:` idb tier) -----
+export const agentHomeKeys = {
+  topics: def('agentHome:topics', (agentId: string) => ['agentHome:topics', agentId]),
+};
+export const agentProfileKeys = {
+  detail: def('agentProfile:detail', (agentId: string) => ['agentProfile:detail', agentId]),
+};
+export const agentSignalKeys = {
+  receipts: def('agentSignal:receipts', (agentId: string, topicId: string) => [
+    'agentSignal:receipts',
+    agentId,
+    topicId,
+  ]),
+};
+
+// ---- misc UI singletons -------------------------------------------------
+export const ollamaKeys = {
+  downloadModel: def('ollama:downloadModel', (model: string) => ['ollama:downloadModel', model]),
+};
+export const authKeys = {
+  oidcInteraction: def('auth:oidcInteraction', (uid: string) => ['auth:oidcInteraction', uid]),
+};
+export const cronKeys = {
+  topicsWithJobInfo: def('cron:topicsWithJobInfo', (agentId: string | undefined) => [
+    'cron:topicsWithJobInfo',
+    agentId,
+  ]),
+};
+/** Imperative "save / create topic" action (useActionSWR), shared across call sites. */
+export const topicActionKeys = {
+  openNewOrSave: def('topicAction:openNewOrSave', () => ['topicAction:openNewOrSave']),
+};
+
 /**
  * Build a `mutate` matcher that selects every key in a `domain:` namespace.
  *
@@ -492,29 +677,46 @@ export const swrKeys = {
   agent: { ...agentKeys, ...agentConfigKeys },
   agentBot: agentBotKeys,
   agentDocument: agentDocumentSWRKeys,
+  agentHome: agentHomeKeys,
   agentKnowledge: agentKnowledgeKeys,
+  agentProfile: agentProfileKeys,
+  agentSignal: agentSignalKeys,
   aiModel: aiModelKeys,
+  auth: authKeys,
   brief: briefKeys,
+  changelog: changelogKeys,
   chatTool: chatToolKeys,
+  cron: cronKeys,
   device: deviceKeys,
   discover: discoverKeys,
   document: documentSWRKeys,
   eval: evalKeys,
+  favorite: favoriteKeys,
   file: fileKeys,
+  fork: forkKeys,
   global: globalKeys,
   group: groupKeys,
   image: imageKeys,
+  inbox: inboxKeys,
   knowledgeBase: knowledgeBaseKeys,
   message: messageKeys,
+  messenger: messengerKeys,
   notebook: notebookSWRKeys,
+  ollama: ollamaKeys,
+  onboarding: onboardingKeys,
+  portal: portalKeys,
   ragEval: ragEvalKeys,
   recent: recentKeys,
   serverConfig: serverConfigKeys,
   session: sessionKeys,
+  share: shareKeys,
+  stats: statsKeys,
   task: taskKeys,
   thread: threadKeys,
   tool: toolKeys,
   topic: topicKeys,
+  topicAction: topicActionKeys,
   userMemory: userMemoryKeys,
+  verify: verifyKeys,
   video: videoKeys,
 };

--- a/src/routes/(main)/agent/_layout/Sidebar/Header/Nav.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Header/Nav.tsx
@@ -18,6 +18,7 @@ import { usePermission } from '@/hooks/usePermission';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { usePathname } from '@/libs/router/navigation';
 import { useActionSWR } from '@/libs/swr';
+import { topicActionKeys } from '@/libs/swr/keys';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
@@ -49,7 +50,7 @@ const Nav = memo(() => {
   const switchTopic = useChatStore((s) => s.switchTopic);
   const [openNewTopicOrSaveTopic] = useChatStore((s) => [s.openNewTopicOrSaveTopic]);
 
-  const { mutate } = useActionSWR('openNewTopicOrSaveTopic', openNewTopicOrSaveTopic);
+  const { mutate } = useActionSWR(topicActionKeys.openNewOrSave(), openNewTopicOrSaveTopic);
   const handleNewTopic = () => {
     if (!canCreateTopic) return;
     // Always navigate to the bare agent chat URL — drops any sub-route

--- a/src/routes/(main)/community/(detail)/agent/features/AgentForkTag.tsx
+++ b/src/routes/(main)/community/(detail)/agent/features/AgentForkTag.tsx
@@ -8,6 +8,7 @@ import useSWR from 'swr';
 import urlJoin from 'url-join';
 
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
+import { forkKeys } from '@/libs/swr/keys';
 import { marketApiService } from '@/services/marketApi';
 
 import { useDetailContext } from './DetailProvider';
@@ -23,7 +24,7 @@ const AgentForkTag = memo(() => {
 
   // Fetch fork source info
   const { data: forkSource } = useSWR(
-    identifier && forkedFromAgentId ? ['fork-source', identifier] : null,
+    identifier && forkedFromAgentId ? forkKeys.source(identifier) : null,
     () => marketApiService.getAgentForkSource(identifier!),
     { revalidateOnFocus: false },
   );

--- a/src/routes/(main)/community/(detail)/agent/features/Header.tsx
+++ b/src/routes/(main)/community/(detail)/agent/features/Header.tsx
@@ -30,6 +30,7 @@ import useSWR from 'swr';
 import PublishedTime from '@/components/PublishedTime';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 import { useMarketAuth } from '@/layout/AuthProvider/MarketAuth';
+import { favoriteKeys } from '@/libs/swr/keys';
 import { socialService } from '@/services/social';
 import { formatIntergerNumber } from '@/utils/format';
 
@@ -73,7 +74,7 @@ const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
 
   // Fetch favorite status
   const { data: favoriteStatus, mutate: mutateFavorite } = useSWR(
-    identifier && isAuthenticated ? ['favorite-status', 'agent', identifier] : null,
+    identifier && isAuthenticated ? favoriteKeys.status('agent', identifier) : null,
     () => socialService.checkFavoriteStatus('agent', identifier!),
     { revalidateOnFocus: false },
   );

--- a/src/routes/(main)/community/(detail)/group_agent/features/GroupAgentForkTag.tsx
+++ b/src/routes/(main)/community/(detail)/group_agent/features/GroupAgentForkTag.tsx
@@ -8,6 +8,7 @@ import useSWR from 'swr';
 import urlJoin from 'url-join';
 
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
+import { forkKeys } from '@/libs/swr/keys';
 import { marketApiService } from '@/services/marketApi';
 
 import { useDetailContext } from './DetailProvider';
@@ -23,7 +24,7 @@ const GroupAgentForkTag = memo(() => {
 
   // Fetch fork source info
   const { data: forkSource } = useSWR(
-    identifier && forkedFromGroupId ? ['group-fork-source', identifier] : null,
+    identifier && forkedFromGroupId ? forkKeys.groupSource(identifier) : null,
     () => marketApiService.getAgentGroupForkSource(identifier!),
     { revalidateOnFocus: false },
   );

--- a/src/routes/(main)/community/(detail)/group_agent/features/Header.tsx
+++ b/src/routes/(main)/community/(detail)/group_agent/features/Header.tsx
@@ -22,6 +22,7 @@ import useSWR from 'swr';
 import PublishedTime from '@/components/PublishedTime';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 import { useMarketAuth } from '@/layout/AuthProvider/MarketAuth';
+import { favoriteKeys } from '@/libs/swr/keys';
 import { socialService } from '@/services/social';
 
 import { resolveCommunityProfileLink } from '../../utils/profileLink';
@@ -67,7 +68,7 @@ const Header = memo<{ mobile?: boolean }>(({ mobile: isMobile }) => {
   // TODO: Use 'group_agent' type when social service supports it
   // Fetch favorite status
   const { data: favoriteStatus, mutate: mutateFavorite } = useSWR(
-    identifier && isAuthenticated ? ['favorite-status', 'agent', identifier] : null,
+    identifier && isAuthenticated ? favoriteKeys.status('agent', identifier) : null,
     () => socialService.checkFavoriteStatus('agent-group', identifier!),
     { revalidateOnFocus: false },
   );

--- a/src/routes/(main)/group/_layout/Sidebar/AddGroupMemberModal/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/AddGroupMemberModal/index.tsx
@@ -7,6 +7,7 @@ import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
+import { groupKeys } from '@/libs/swr/keys';
 import { agentService } from '@/services/agent';
 
 import { type AgentItemData } from './AgentItem';
@@ -48,7 +49,7 @@ const AddGroupMemberModal = memo<AddGroupMemberModalProps>(
 
     // Fetch agents from the new API (non-virtual agents only)
     const { data: allAgents = [], isLoading: isLoadingAgents } = useSWR(
-      open ? 'queryAgents' : null,
+      open ? groupKeys.queryAgents() : null,
       () => agentService.queryAgents(),
     );
 

--- a/src/routes/(main)/home/_layout/CreateGroupModal/index.tsx
+++ b/src/routes/(main)/home/_layout/CreateGroupModal/index.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';
 
 import { usePermission } from '@/hooks/usePermission';
+import { groupKeys } from '@/libs/swr/keys';
 import { agentService } from '@/services/agent';
 import { useGlobalStore } from '@/store/global';
 import { useHomeStore } from '@/store/home';
@@ -56,7 +57,7 @@ const CreateGroupModal = memo<CreateGroupModalProps>(({ id, onCancel, open }) =>
 
   // Fetch all agents
   const { data: allAgents = [], isLoading: isLoadingAgents } = useSWR<AgentItemData[]>(
-    open ? 'queryAgentsForCreateGroup' : null,
+    open ? groupKeys.queryAgentsForCreate() : null,
     () => agentService.queryAgents(),
   );
 

--- a/src/routes/(main)/home/_layout/Header/components/InboxDrawer/Content.tsx
+++ b/src/routes/(main)/home/_layout/Header/components/InboxDrawer/Content.tsx
@@ -9,9 +9,9 @@ import useSWRInfinite from 'swr/infinite';
 import { VList, type VListHandle } from 'virtua';
 
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
+import { inboxKeys } from '@/libs/swr/keys';
 import { notificationService } from '@/services/notification';
 
-import { FETCH_KEY } from './constants';
 import NotificationItem from './NotificationItem';
 
 const PAGE_SIZE = 20;
@@ -32,10 +32,10 @@ const Content = memo<ContentProps>(({ open, unreadOnly, onMarkAsRead, onArchive 
       if (!open) return null;
       if (previousPageData && previousPageData.length < PAGE_SIZE) return null;
 
-      if (pageIndex === 0) return [FETCH_KEY, undefined, unreadOnly] as const;
+      if (pageIndex === 0) return inboxKeys.notifications(undefined, unreadOnly);
 
       const lastItem = previousPageData?.at(-1);
-      return [FETCH_KEY, lastItem?.id, unreadOnly] as const;
+      return inboxKeys.notifications(lastItem?.id, unreadOnly);
     },
     [open, unreadOnly],
   );
@@ -49,7 +49,7 @@ const Content = memo<ContentProps>(({ open, unreadOnly, onMarkAsRead, onArchive 
     return notificationService.list({
       cursor: cursor as string | undefined,
       limit: PAGE_SIZE,
-      unreadOnly: filterUnread,
+      unreadOnly: filterUnread as boolean | undefined,
     });
   });
 

--- a/src/routes/(main)/home/_layout/Header/components/InboxDrawer/constants.ts
+++ b/src/routes/(main)/home/_layout/Header/components/InboxDrawer/constants.ts
@@ -1,2 +1,0 @@
-export const UNREAD_COUNT_KEY = 'inbox-unread-count';
-export const FETCH_KEY = 'inbox-notifications';

--- a/src/routes/(main)/home/_layout/Header/components/InboxDrawer/index.tsx
+++ b/src/routes/(main)/home/_layout/Header/components/InboxDrawer/index.tsx
@@ -10,9 +10,8 @@ import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import SideBarDrawer from '@/features/NavPanel/SideBarDrawer';
 import dynamic from '@/libs/next/dynamic';
 import { mutate } from '@/libs/swr';
+import { inboxKeys } from '@/libs/swr/keys';
 import { notificationService } from '@/services/notification';
-
-import { FETCH_KEY, UNREAD_COUNT_KEY } from './constants';
 
 const Content = dynamic(() => import('./Content'), {
   loading: () => (
@@ -33,8 +32,8 @@ const InboxDrawer = memo<InboxDrawerProps>(({ open, onClose }) => {
   const [unreadOnly, setUnreadOnly] = useState(false);
 
   const refreshList = useCallback(() => {
-    mutate((key: unknown) => Array.isArray(key) && key[0] === FETCH_KEY);
-    mutate(UNREAD_COUNT_KEY);
+    mutate((key: unknown) => Array.isArray(key) && key[0] === inboxKeys.notifications.root);
+    mutate(inboxKeys.unreadCount());
   }, []);
 
   const handleMarkAsRead = useCallback(

--- a/src/routes/(main)/home/_layout/Header/components/useInboxUnreadCount.test.ts
+++ b/src/routes/(main)/home/_layout/Header/components/useInboxUnreadCount.test.ts
@@ -1,7 +1,8 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { UNREAD_COUNT_KEY } from './InboxDrawer/constants';
+import { inboxKeys } from '@/libs/swr/keys';
+
 import { INBOX_UNREAD_COUNT_REFRESH_INTERVAL, useInboxUnreadCount } from './useInboxUnreadCount';
 
 const mocks = vi.hoisted(() => ({
@@ -66,9 +67,13 @@ describe('useInboxUnreadCount', () => {
     const { result } = renderHook(() => useInboxUnreadCount());
 
     expect(result.current.enabled).toBe(true);
-    expect(mocks.useClientDataSWR).toHaveBeenCalledWith(UNREAD_COUNT_KEY, expect.any(Function), {
-      refreshInterval: INBOX_UNREAD_COUNT_REFRESH_INTERVAL,
-    });
+    expect(mocks.useClientDataSWR).toHaveBeenCalledWith(
+      inboxKeys.unreadCount(),
+      expect.any(Function),
+      {
+        refreshInterval: INBOX_UNREAD_COUNT_REFRESH_INTERVAL,
+      },
+    );
   });
 
   it('keeps unread count polling on the same 10 second cadence', () => {

--- a/src/routes/(main)/home/_layout/Header/components/useInboxUnreadCount.ts
+++ b/src/routes/(main)/home/_layout/Header/components/useInboxUnreadCount.ts
@@ -1,10 +1,9 @@
 import { useClientDataSWR } from '@/libs/swr';
+import { inboxKeys } from '@/libs/swr/keys';
 import { notificationService } from '@/services/notification';
 import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/selectors';
-
-import { UNREAD_COUNT_KEY } from './InboxDrawer/constants';
 
 export const INBOX_UNREAD_COUNT_REFRESH_INTERVAL = 10_000;
 
@@ -14,7 +13,7 @@ export const useInboxUnreadCount = () => {
   const enabled = enableBusinessFeatures && isLogin === true;
 
   const { data: unreadCount = 0 } = useClientDataSWR<number>(
-    enabled ? UNREAD_COUNT_KEY : null,
+    enabled ? inboxKeys.unreadCount() : null,
     () => notificationService.getUnreadCount(),
     { refreshInterval: INBOX_UNREAD_COUNT_REFRESH_INTERVAL },
   );

--- a/src/routes/(main)/settings/stats/features/overview/TotalAssistants.tsx
+++ b/src/routes/(main)/settings/stats/features/overview/TotalAssistants.tsx
@@ -5,6 +5,7 @@ import Statistic from '@/components/Statistic';
 import StatisticCard from '@/components/StatisticCard';
 import TitleWithPercentage from '@/components/StatisticCard/TitleWithPercentage';
 import { useClientDataSWR } from '@/libs/swr';
+import { statsKeys } from '@/libs/swr/keys';
 import { sessionService } from '@/services/session';
 import { formatIntergerNumber } from '@/utils/format';
 import { lastMonth } from '@/utils/time';
@@ -13,7 +14,7 @@ import TotalCard from './ShareButton/TotalCard';
 
 const TotalMessages = memo<{ inShare?: boolean; mobile?: boolean }>(({ inShare }) => {
   const { t } = useTranslation('auth');
-  const { data, isLoading } = useClientDataSWR('stats-sessions', async () => ({
+  const { data, isLoading } = useClientDataSWR(statsKeys.sessions(), async () => ({
     count: await sessionService.countSessions(),
     prevCount: await sessionService.countSessions({ endDate: lastMonth().format('YYYY-MM-DD') }),
   }));

--- a/src/routes/(main)/settings/stats/features/overview/TotalMessages.tsx
+++ b/src/routes/(main)/settings/stats/features/overview/TotalMessages.tsx
@@ -5,6 +5,7 @@ import Statistic from '@/components/Statistic';
 import StatisticCard from '@/components/StatisticCard';
 import TitleWithPercentage from '@/components/StatisticCard/TitleWithPercentage';
 import { useClientDataSWR } from '@/libs/swr';
+import { statsKeys } from '@/libs/swr/keys';
 import { messageService } from '@/services/message';
 import { formatIntergerNumber } from '@/utils/format';
 import { lastMonth } from '@/utils/time';
@@ -13,7 +14,7 @@ import TotalCard from './ShareButton/TotalCard';
 
 const TotalMessages = memo<{ inShare?: boolean; mobile?: boolean }>(({ inShare }) => {
   const { t } = useTranslation('auth');
-  const { data, isLoading } = useClientDataSWR('stats-messages', async () => ({
+  const { data, isLoading } = useClientDataSWR(statsKeys.messages(), async () => ({
     count: await messageService.countMessages(),
     prevCount: await messageService.countMessages({ endDate: lastMonth().format('YYYY-MM-DD') }),
   }));

--- a/src/routes/(main)/settings/stats/features/overview/TotalTokens.tsx
+++ b/src/routes/(main)/settings/stats/features/overview/TotalTokens.tsx
@@ -6,6 +6,7 @@ import Statistic from '@/components/Statistic';
 import StatisticCard from '@/components/StatisticCard';
 import TitleWithPercentage from '@/components/StatisticCard/TitleWithPercentage';
 import { useClientDataSWR } from '@/libs/swr';
+import { statsKeys } from '@/libs/swr/keys';
 import { messageService } from '@/services/message';
 import { formatShortenNumber } from '@/utils/format';
 import { lastMonth } from '@/utils/time';
@@ -22,9 +23,8 @@ import TotalCard from './ShareButton/TotalCard';
 const TotalTokens = memo<{ inShare?: boolean }>(({ inShare }) => {
   const { t } = useTranslation('auth');
 
-  const { data, isLoading } = useClientDataSWR(
-    ['stats-heatmaps', HeatmapType.Tokens].join('-'),
-    () => messageService.getTokenHeatmaps(),
+  const { data, isLoading } = useClientDataSWR(statsKeys.heatmaps(HeatmapType.Tokens), () =>
+    messageService.getTokenHeatmaps(),
   );
 
   const { count, prevCount } = useMemo(() => {

--- a/src/routes/(main)/settings/stats/features/overview/TotalTopics.tsx
+++ b/src/routes/(main)/settings/stats/features/overview/TotalTopics.tsx
@@ -5,6 +5,7 @@ import Statistic from '@/components/Statistic';
 import StatisticCard from '@/components/StatisticCard';
 import TitleWithPercentage from '@/components/StatisticCard/TitleWithPercentage';
 import { useClientDataSWR } from '@/libs/swr';
+import { statsKeys } from '@/libs/swr/keys';
 import { topicService } from '@/services/topic';
 import { formatIntergerNumber } from '@/utils/format';
 import { lastMonth } from '@/utils/time';
@@ -13,7 +14,7 @@ import TotalCard from './ShareButton/TotalCard';
 
 const TotalMessages = memo<{ inShare?: boolean; mobile?: boolean }>(({ inShare }) => {
   const { t } = useTranslation('auth');
-  const { data, isLoading } = useClientDataSWR('stats-topics', async () => ({
+  const { data, isLoading } = useClientDataSWR(statsKeys.topics(), async () => ({
     count: await topicService.countTopics(),
     prevCount: await topicService.countTopics({ endDate: lastMonth().format('YYYY-MM-DD') }),
   }));

--- a/src/routes/(main)/settings/stats/features/overview/Welcome.tsx
+++ b/src/routes/(main)/settings/stats/features/overview/Welcome.tsx
@@ -5,6 +5,7 @@ import { memo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { useClientDataSWR } from '@/libs/swr';
+import { statsKeys } from '@/libs/swr/keys';
 import { userService } from '@/services/user';
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
@@ -26,7 +27,7 @@ const Welcome = memo<{ mobile?: boolean }>(({ mobile }) => {
     userProfileSelectors.username(s),
   ]);
 
-  const { data, isLoading } = useClientDataSWR('welcome', async () =>
+  const { data, isLoading } = useClientDataSWR(statsKeys.welcome(), async () =>
     userService.getUserRegistrationDuration(),
   );
 

--- a/src/routes/(main)/settings/stats/features/rankings/AssistantsRank.tsx
+++ b/src/routes/(main)/settings/stats/features/rankings/AssistantsRank.tsx
@@ -10,6 +10,7 @@ import { SESSION_CHAT_URL } from '@/const/url';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import Link from '@/libs/router/Link';
 import { useClientDataSWR } from '@/libs/swr';
+import { statsKeys } from '@/libs/swr/keys';
 import { agentService } from '@/services/agent';
 import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';
@@ -22,7 +23,7 @@ export const AssistantsRank = memo<{ mobile?: boolean }>(({ mobile }) => {
   const { t } = useTranslation(['auth', 'chat']);
   const navigate = useWorkspaceAwareNavigate();
   const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
-  const { data, isLoading } = useClientDataSWR('rank-agents', async () =>
+  const { data, isLoading } = useClientDataSWR(statsKeys.rankAgents(), async () =>
     agentService.rankAgents(),
   );
 

--- a/src/routes/(main)/settings/stats/features/rankings/ModelsRank.tsx
+++ b/src/routes/(main)/settings/stats/features/rankings/ModelsRank.tsx
@@ -7,6 +7,7 @@ import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useClientDataSWR } from '@/libs/swr';
+import { statsKeys } from '@/libs/swr/keys';
 import { messageService } from '@/services/message';
 
 import StatsFormGroup from '../components/StatsFormGroup';
@@ -14,7 +15,7 @@ import StatsFormGroup from '../components/StatsFormGroup';
 export const TopicsRank = memo(() => {
   const [open, setOpen] = useState(false);
   const { t } = useTranslation('auth');
-  const { data, isLoading } = useClientDataSWR('rank-models', async () =>
+  const { data, isLoading } = useClientDataSWR(statsKeys.rankModels(), async () =>
     messageService.rankModels(),
   );
 

--- a/src/routes/(main)/settings/stats/features/rankings/TopicsRank.tsx
+++ b/src/routes/(main)/settings/stats/features/rankings/TopicsRank.tsx
@@ -10,6 +10,7 @@ import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import Link from '@/libs/router/Link';
 import { useClientDataSWR } from '@/libs/swr';
+import { statsKeys } from '@/libs/swr/keys';
 import { topicService } from '@/services/topic';
 import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';
@@ -22,7 +23,7 @@ export const TopicsRank = memo<{ mobile?: boolean }>(({ mobile }) => {
   const { t } = useTranslation('auth');
   const navigate = useWorkspaceAwareNavigate();
   const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
-  const { data, isLoading } = useClientDataSWR('rank-topics', async () =>
+  const { data, isLoading } = useClientDataSWR(statsKeys.rankTopics(), async () =>
     topicService.rankTopics(),
   );
 

--- a/src/routes/(main)/settings/stats/features/usage/UsageTable.tsx
+++ b/src/routes/(main)/settings/stats/features/usage/UsageTable.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from 'react-i18next';
 import InlineTable from '@/components/InlineTable';
 import { parseAsInteger, useQueryParam } from '@/hooks/useQueryParam';
 import { useClientDataSWR } from '@/libs/swr';
+import { statsKeys } from '@/libs/swr/keys';
 import { usageService } from '@/services/usage';
 import { formatDate, formatNumber } from '@/utils/format';
 
@@ -16,7 +17,7 @@ import { type UsageChartProps } from '../../types';
 const UsageTable = memo<UsageChartProps>(({ dateStrings }) => {
   const { t } = useTranslation('auth');
 
-  const { data, isLoading, mutate } = useClientDataSWR('usage-logs', async () =>
+  const { data, isLoading, mutate } = useClientDataSWR(statsKeys.usageLogs(), async () =>
     usageService.findByMonth(dateStrings),
   );
 

--- a/src/routes/(main)/settings/stats/features/visualization/AiHeatmaps.tsx
+++ b/src/routes/(main)/settings/stats/features/visualization/AiHeatmaps.tsx
@@ -7,6 +7,7 @@ import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useClientDataSWR } from '@/libs/swr';
+import { statsKeys } from '@/libs/swr/keys';
 import { messageService } from '@/services/message';
 import { formatIntergerNumber, formatShortenNumber } from '@/utils/format';
 
@@ -23,7 +24,7 @@ const AiHeatmaps = memo<
   );
   const isTokens = type === HeatmapType.Tokens;
 
-  const { data, isLoading } = useClientDataSWR(['stats-heatmaps', type].join('-'), async () =>
+  const { data, isLoading } = useClientDataSWR(statsKeys.heatmaps(type), async () =>
     isTokens ? messageService.getTokenHeatmaps() : messageService.getHeatmaps(),
   );
 

--- a/src/routes/(main)/settings/stats/features/visualization/HeatmapStats.tsx
+++ b/src/routes/(main)/settings/stats/features/visualization/HeatmapStats.tsx
@@ -5,6 +5,7 @@ import { Fragment, memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useClientDataSWR } from '@/libs/swr';
+import { statsKeys } from '@/libs/swr/keys';
 import { messageService } from '@/services/message';
 import { topicService } from '@/services/topic';
 import { formatShortenNumber } from '@/utils/format';
@@ -35,13 +36,12 @@ const formatDuration = (seconds?: number) => {
 const HeatmapStats = memo(() => {
   const { t } = useTranslation('auth');
 
-  const { data, isLoading } = useClientDataSWR(
-    ['stats-heatmaps', HeatmapType.Tokens].join('-'),
-    () => messageService.getTokenHeatmaps(),
+  const { data, isLoading } = useClientDataSWR(statsKeys.heatmaps(HeatmapType.Tokens), () =>
+    messageService.getTokenHeatmaps(),
   );
   const loading = isLoading || !data;
 
-  const { data: maxTaskDuration } = useClientDataSWR('stats-max-task-duration', () =>
+  const { data: maxTaskDuration } = useClientDataSWR(statsKeys.maxTaskDuration(), () =>
     topicService.getMaxTaskDuration(),
   );
 

--- a/src/routes/(main)/settings/stats/index.tsx
+++ b/src/routes/(main)/settings/stats/index.tsx
@@ -10,6 +10,7 @@ import { memo, type ReactNode, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useClientDataSWR } from '@/libs/swr';
+import { statsKeys } from '@/libs/swr/keys';
 import SettingHeader from '@/routes/(main)/settings/features/SettingHeader';
 import { usageService } from '@/services/usage';
 
@@ -54,7 +55,7 @@ const StatsSetting = memo<StatsSettingProps>(
     const [dateRange, setDateRange] = useState<dayjs.Dayjs>(dayjs(new Date()));
     const [dateStrings, setDateStrings] = useState<string>();
 
-    const { data, isLoading, mutate } = useClientDataSWR('usage-stat', async () =>
+    const { data, isLoading, mutate } = useClientDataSWR(statsKeys.usageStat(), async () =>
       usageService.findAndGroupByDay(dateStrings),
     );
 

--- a/src/routes/(mobile)/(home)/features/SessionListContent/List/AddButton.tsx
+++ b/src/routes/(mobile)/(home)/features/SessionListContent/List/AddButton.tsx
@@ -4,6 +4,7 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useActionSWR } from '@/libs/swr';
+import { sessionKeys } from '@/libs/swr/keys';
 import { useServerConfigStore } from '@/store/serverConfig';
 import { useSessionStore } from '@/store/session';
 
@@ -11,7 +12,7 @@ const AddButton = memo<{ groupId?: string }>(({ groupId }) => {
   const { t } = useTranslation('chat');
   const createSession = useSessionStore((s) => s.createSession);
   const mobile = useServerConfigStore((s) => s.isMobile);
-  const { mutate, isValidating } = useActionSWR(['session.createSession', groupId], () => {
+  const { mutate, isValidating } = useActionSWR(sessionKeys.createSession(groupId), () => {
     return createSession({ group: groupId });
   });
 

--- a/src/routes/share/page/[id]/index.tsx
+++ b/src/routes/share/page/[id]/index.tsx
@@ -8,6 +8,7 @@ import useSWR from 'swr';
 import PublishedShell from '@/business/client/features/PageShare/PublishedShell';
 import ReadOnlyPageViewer from '@/business/client/features/PageShare/ReadOnlyPageViewer';
 import Loading from '@/components/Loading/BrandTextLoading';
+import { shareKeys } from '@/libs/swr/keys';
 import { lambdaClient } from '@/libs/trpc/client';
 import { getIdFromIdentifier } from '@/utils/identifier';
 
@@ -16,7 +17,7 @@ const SharePagePage = memo(() => {
   const documentId = getIdFromIdentifier(id ?? '', 'docs');
 
   const { data, error, isLoading } = useSWR(
-    documentId ? ['pageShare.getSharedDocument', documentId] : null,
+    documentId ? shareKeys.pageDocument(documentId) : null,
     () => lambdaClient.pageShare.getSharedDocument.query({ documentId }),
     { revalidateOnFocus: false },
   );

--- a/src/routes/share/t/[id]/_layout/Title.tsx
+++ b/src/routes/share/t/[id]/_layout/Title.tsx
@@ -6,6 +6,7 @@ import { memo, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import useSWR from 'swr';
 
+import { shareKeys } from '@/libs/swr/keys';
 import { lambdaClient } from '@/libs/trpc/client';
 import { useAgentStore } from '@/store/agent';
 import { useAgentGroupStore } from '@/store/agentGroup';
@@ -15,7 +16,7 @@ const Title = memo(() => {
   const dispatchAgentMap = useAgentStore((s) => s.internal_dispatchAgentMap);
 
   const { data } = useSWR(
-    id ? ['shared-topic', id] : null,
+    id ? shareKeys.topic(id) : null,
     () => lambdaClient.share.getSharedTopic.query({ shareId: id! }),
     { revalidateOnFocus: false },
   );

--- a/src/routes/share/t/[id]/index.tsx
+++ b/src/routes/share/t/[id]/index.tsx
@@ -11,6 +11,7 @@ import useSWR from 'swr';
 import NotFound from '@/components/404';
 import Loading from '@/components/Loading/BrandTextLoading';
 import { trackLoginOrSignupClicked } from '@/features/User/UserLoginOrSignup/trackLoginOrSignupClicked';
+import { shareKeys } from '@/libs/swr/keys';
 import { lambdaClient } from '@/libs/trpc/client';
 
 import ActionBar from './features/ActionBar';
@@ -35,7 +36,7 @@ const ShareTopicPage = memo(() => {
   const { id } = useParams<{ id: string }>();
 
   const { data, error, isLoading } = useSWR(
-    id ? ['shared-topic', id] : null,
+    id ? shareKeys.topic(id) : null,
     () => lambdaClient.share.getSharedTopic.query({ shareId: id! }),
     { revalidateOnFocus: false },
   );

--- a/src/routes/share/t/[id]/routeMeta.ts
+++ b/src/routes/share/t/[id]/routeMeta.ts
@@ -1,6 +1,7 @@
 import { MessageSquare } from 'lucide-react';
 import useSWR from 'swr';
 
+import { shareKeys } from '@/libs/swr/keys';
 import { lambdaClient } from '@/libs/trpc/client';
 import { routeMeta } from '@/spa/router/routeMeta';
 
@@ -10,7 +11,7 @@ export const shareTopicRouteMeta = routeMeta({
   useDynamicMeta: (params) => {
     const shareId = params.id;
     const { data } = useSWR(
-      shareId ? ['shared-topic', shareId] : null,
+      shareId ? shareKeys.topic(shareId) : null,
       () => lambdaClient.share.getSharedTopic.query({ shareId: shareId! }),
       { revalidateOnFocus: false },
     );

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -11,7 +11,7 @@ import useSWR from 'swr';
 import { message } from '@/components/AntdStaticMethods';
 import { LOADING_FLAT } from '@/const/message';
 import { mutate, useClientDataSWRWithSync } from '@/libs/swr';
-import { topicKeys } from '@/libs/swr/keys';
+import { cronKeys, topicKeys } from '@/libs/swr/keys';
 import { chatService } from '@/services/chat';
 import { messageService } from '@/services/message';
 import { topicService } from '@/services/topic';
@@ -265,7 +265,7 @@ export class ChatTopicActionImpl {
     if (!activeAgentId) return;
 
     await mutate(
-      ['cronTopicsWithJobInfo', activeAgentId],
+      cronKeys.topicsWithJobInfo(activeAgentId),
       (groups?: CronTopicsGroupWithJobInfo[]) => {
         if (!Array.isArray(groups)) return groups;
 


### PR DESCRIPTION
## 💡 Background

Final step of the SWR key convergence series (#15844 → #15848 → #15850 → #15853). With the store layer fully migrated, this PR converges the remaining **UI-layer** ad-hoc SWR keys (features / routes / components) into the central registry (`src/libs/swr/keys.ts`).

After this, the only ad-hoc SWR keys left are inside `packages/*` (e.g. `readLocalFile`, agent-templates) — those can't import `@/libs/swr/keys`, so they're intentionally out of scope.

## 🔨 Changes (~58 files)

New registry domains: `stats`, `messenger`, `verify`, `inbox`, `share`, `fork`, `portal`, `favorite`, `changelog`, `onboarding`, `agentHome`, `agentProfile`, `agentSignal`, `ollama`, `auth`, `cron`, `topicAction`. Plus extensions to existing domains: `discover` (mcpAgents / skillAgents / skillStoreMarketSkills), `device` (gitBranches / repoType), `session` (createSession), `group` (queryAgents / queryAgentsForCreate).

Areas migrated: settings/stats + user header counts, Messenger, Verify, inbox/notifications, share (topic + page), community fork tags, marketplace-detail favorite-status + related-agents, Portal document header, agent profile/home/signal, changelog modal, agent onboarding, ollama download, OIDC consent, ChatInput git/repo + save-topic action, mobile create-session, group/create-group agent pickers.

## ✅ Guarantees

- **Shared keys dedupe correctly.** Keys used across multiple files (`availablePlatforms`, `agentsForBinding`, `bindingScopes`, `shared-topic`×3, `favorite-status`×3, `openNewTopicOrSaveTopic`×3, `portal-document-header`×2, inbox notifications/unread) all route through one factory at every site.
- **No tiering/caching change.** Every new prefix is kept out of `CACHE_TIERS`; names deliberately avoid the cached prefixes (`share:`/`portal:`/`agentHome:`/`agentProfile:` rather than `topic:`/`document:`/`agent:`). Behavior preserved (key identity, mutate match sets, `useSWRInfinite` getKey shape).
- Also folds in the lone cross-layer `cronTopicsWithJobInfo` store mutate.

## 🧪 Test

- `bun run type-check` clean across all touched files (remaining repo type errors are pre-existing `@lobehub/ui` Form-type / hotkey-config issues in untouched files).
- Affected tests pass: Messenger, useAgentSignalReceipts, OAuthConsent, Portal/Document, useInboxUnreadCount, Nav, chat/topic → **77 passed**.

## 📦 Out of scope

`packages/*` client keys (`readLocalFile`, `getAgentTemplatesSWRKey`) — can't reach the `src/` registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)