### PR TITLE
fix: remove ParamsPanelToggle (control icon) from chat header

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/Header/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/index.tsx
@@ -13,7 +13,6 @@ import { topicSelectors } from '@/store/chat/selectors';
 import { useElectronStore } from '@/store/electron';
 
 import HeaderActions from './HeaderActions';
-import ParamsPanelToggle from './ParamsPanelToggle';
 import ShareButton from './ShareButton';
 import Tags from './Tags';
 import WorkingPanelToggle from './WorkingPanelToggle';
@@ -81,7 +80,6 @@ const Header = memo(() => {
               <OpenInAppButton workingDirectory={effectiveWorkingDirectory} />
             )}
             <ShareButton />
-            <ParamsPanelToggle />
             <WorkingPanelToggle />
           </Flexbox>
         }


### PR DESCRIPTION
## What

Remove the `ParamsPanelToggle` (control icon) from the top-right of the chat header.

## Why

The control params are now accessible via the `+` advanced params entry in `ChatInput`, making the dedicated header icon redundant.

## Changes

- `src/routes/(main)/agent/features/Conversation/Header/index.tsx`: removed `<ParamsPanelToggle />` and its import