### PR TITLE
💄 style(thread-list): cap nested thread list height with scroll overflow

### DIFF
--- a/.agents/skills/ux/SKILL.md
+++ b/.agents/skills/ux/SKILL.md
@@ -10,35 +10,32 @@ How LobeHub products should feel, and concrete rules to get there. Use this when
 **building or reviewing** any user-facing flow. For component/styling choices see
 **react**, for wording see **microcopy**, for imperative modal wiring see **modal**.
 
-## Design values (设计价值观)
+## Design values
 
-LobeHub follows four product design values — **自然 Natural・意义感 Meaningful・
-确定性 Certainty・生长性 Growth**. Read them before designing:
+LobeHub follows four product design values — **Natural・Meaningful・Certainty・
+Growth**. Read them before designing:
 **[references/design-values.md](references/design-values.md)** (definitions +
 conflict priority).
 
 > The checklists below are the execution layer. Each item is tagged with the
 > value(s) it serves; for what those values mean, see the file above.
 
-## 1. Flow & momentum (操作链路)・自然・意义感
+## How this is organized
 
-Every action chain must **push the user forward**, never dead-end or block the flow.
+The checklists are grouped by **interaction type** — the kind of thing the user
+is doing. Jump to the module that matches the surface you're building (reading a
+list, editing content, running an action, …); each module collects the rules
+specific to that interaction. The same surface often spans several modules (an
+editable list is Read + Edit + Act) — walk each that applies.
 
-- [ ] **Forward momentum** — after any operation, lead the user to the next step,
-      don't just stop. _(意义感)_
-- [ ] **Success state = primary "go to result", secondary "dismiss"** — the strong
-      button is the forward action (take me to the result); "Done" is the weak/
-      secondary button. ✅ After moving topics: primary = "Go to «target»", secondary
-      \= "Done". _(意义感・自然)_
-- [ ] **Bulk ⇄ single-item parity** — an action on a multi-select toolbar must also
-      be reachable on a single item (its context menu), and vice versa. _(确定性)_
-- [ ] **Confirm → in-progress → done, in one surface** — bulk/irreversible/async
-      ops use a modal state machine: a confirm step stating exactly what happens →
-      an in-progress view with **dismissal locked** → a done (or error) view in the
-      same modal. Never fire-and-forget with only a toast; never leave a dead
-      spinner. _(确定性・意义感)_
+---
 
-## 2. States: empty /loading/error (状态设计)・意义感・确定性
+## 1. Read — viewing data & lists
+
+Any surface that **displays** records, lists, or detail. Covers the states a data
+view can be in, behavior at scale, and keeping the user's place visible.
+
+### 1.1 Data states: empty / loading / error・Meaningful・Certainty
 
 Every data surface has **four** states — design all of them, not just "has data".
 
@@ -46,64 +43,118 @@ Every data surface has **four** states — design all of them, not just "has dat
       this is, why it's empty, and gives a clear next action (CTA + value props).
       ✅ Devices: an empty "Connect your first device" page with primary/secondary
       connect paths and "what you can do once connected" cards — ❌ not a bare title
-      over skeleton rows or a blank body. _(意义感)_
+      over skeleton rows or a blank body. _(Meaningful)_
 - [ ] **Distinguish the empty variants** — "no data yet" (onboarding CTA) vs
-      "no match for filters" (clear-filters affordance) are different screens. _(确定性)_
+      "no match for filters" (clear-filters affordance) are different screens. _(Certainty)_
 - [ ] **Loading state** designed (skeleton / NeuralNetworkLoading), not a flash of
-      blank or layout shift. _(自然)_
-- [ ] **Error state** designed — surface the reason and a retry/back path. _(意义感)_
+      blank or layout shift. _(Natural)_
+- [ ] **Error state** designed — surface the reason and a retry/back path. _(Meaningful)_
 
-## 3. Buttons & focus (按钮与焦点)・确定性
-
-- [ ] **One primary button per surface.** The single primary CTA tells the user the
-      core action; everything else is secondary/tertiary. Never a pile of primary
-      buttons competing for attention. _(确定性)_
-
-## 4. Lists at scale (列表与规模)・确定性・自然
+### 1.2 Lists at scale・Certainty・Natural
 
 A list/data page must be designed for its **whole range of sizes**, not just the
 demo data.
 
 - [ ] **Walk the scale: 1 / 2 / 5 / 20 / 100 / 1k–10k rows.** Pick the right
       mechanism per range — plain render → load-more / pagination → virtual scroll;
-      add batch-select / bulk actions once counts get large. _(确定性)_
-- [ ] **Co-design empty / loading / error with the data state** (see §2). A list
-      isn't done until all four render well. _(自然)_
+      add batch-select / bulk actions once counts get large. _(Certainty)_
+- [ ] **Co-design empty / loading / error with the data state** (see §1.1). A list
+      isn't done until all four render well. _(Natural)_
 
-## 5. Option visibility (选项可见性)・确定性・意义感
+### 1.3 Selection visibility in scrolled lists・Certainty・Natural
+
+A capped / scrollable / virtualized list mounts at `scrollTop = 0`. If the
+active item sits below the fold, the user lands on a valid selection that is
+**off-screen** — and reads it as "nothing is selected" or a broken page. Any
+list that can open with a pre-selected item must **scroll that item into view**.
+This is an easy case to miss: it only shows up once the list is long enough and
+the selection is restored rather than freshly clicked.
+
+- [ ] **Scroll the active item into view on mount / restore.** When the selection
+      is restored from a URL query, deep link, or persisted state (not a fresh
+      click), bring it into view — the container starts at the top otherwise. ✅
+      The nested thread list is capped to \~9 rows; a thread restored from
+      `?thread=` below the fold is scrolled into view on mount. _(Certainty)_
+- [ ] **Hardest when the selection has no other anchor.** If the parent/container
+      row isn't highlighted while a child is active (no breadcrumb, no header
+      echo), an off-screen active row means **zero** visible feedback — design
+      for exactly this case. _(Meaningful)_
+- [ ] **Use `block: 'nearest'` (or equivalent).** Only scroll when the row is
+      actually off-screen; an already-visible selection must not jump. _(Natural)_
+- [ ] **Re-run once async rows mount.** The active id is usually known before the
+      list finishes loading; key the scroll off a list-ready signal (e.g. row
+      count), not only off the id, so a restored selection still lands when the
+      data arrives. _(Certainty)_
+- [ ] **Mirror it across duplicated list variants** so the behavior can't regress
+      in just one (e.g. parallel agent / group lists). _(Certainty)_
+
+### 1.4 Option visibility in pickers・Certainty・Meaningful
 
 - [ ] **Pickers list every valid target.** Watch for options dropped by backend
       list queries (pagination, `virtual` flags, scope filters) and add them back.
       ✅ The default "LobeAI" (inbox) agent is `virtual` and excluded from the
       sidebar list, so the move picker re-adds it. An empty picker must mean
-      "genuinely none", never "we filtered out the only option". _(意义感)_
+      "genuinely none", never "we filtered out the only option". _(Meaningful)_
 
-## 6. Loading visuals (Loading 视觉)・自然
+---
 
-**Never use antd `Spin`** — it doesn't match the product's loading visual. Use a
-project loader:
+## 2. Edit — entering & changing content
 
-| Need                        | Component                                                                     |
-| --------------------------- | ----------------------------------------------------------------------------- |
-| Default loading (in-flight) | `NeuralNetworkLoading` from `@/components/NeuralNetworkLoading` (`size` prop) |
-| Inline dots                 | `DotsLoading` / `BubblesLoading` from `@/components`                          |
-| Branded full-page           | `Loading` from `@/components/Loading/BrandTextLoading`                        |
-| List / card placeholder     | a skeleton (e.g. `SkeletonList`)                                              |
+Any surface where the user **types or edits**. Input is expensive effort; the
+overriding rule is **never lose it**.
 
-When in doubt, reach for `NeuralNetworkLoading` — it's the default in-flight
-indicator (e.g. modal "in progress" states).
+### 2.1 Protect in-progress edits・Certainty・Meaningful
 
-## 7. Discoverability & growth (可发现性与生长)・生长性
+Typed / edited content is real user effort; losing it is one of the most
+infuriating outcomes a product can produce. Whenever an editor holds unsaved
+input, assume the exit can be **accidental** — a misclick, a refresh, a crash, a
+navigation, a failed save — and build a safety net: back the draft up locally and
+recover it.
 
-The product should grow with the user — deeper power shows up as needs deepen.
+- [ ] **Back up the draft locally as the user types.** Persist to
+      localStorage / IndexedDB / store so a refresh, crash, accidental close, or
+      navigation doesn't vaporize the content. _(Certainty)_
+- [ ] **Restore on return.** Coming back to the same editing context auto-restores
+      (or offers to restore) the unsaved draft, rather than showing a blank field. _(Meaningful)_
+- [ ] **Guard destructive exits.** Closing / navigating / switching items away
+      from a dirty editor warns or auto-saves — never silently discards. _(Certainty)_
+- [ ] **Survive a failed save.** If the save errors, keep the user's content in
+      the field / draft and let them retry; never clear the input on failure. _(Meaningful)_
+- [ ] **Scope the draft to its target** (per topic / message / item id) so drafts
+      don't bleed across entities or resurrect on the wrong item. _(Certainty)_
 
-- [ ] **Progressive disclosure** — keep the novice path clean; reveal advanced
-      capabilities as the user gets there, don't dump everything at once. _(生长性・自然)_
-- [ ] **Surface related actions at the moment of need** — make the next capability
-      discoverable in context (e.g. after the first item exists, offer what to do
-      with it), not buried in a far-off menu. _(生长性・意义感)_
+---
 
-## 8. Entity lifecycle completeness (实体生命周期完整性)・意义感・确定性
+## 3. Act — operations, flows & buttons
+
+Any surface where the user **performs an action** — a single op, a bulk op, or a
+multi-step flow. Covers momentum, focus, and full entity lifecycle.
+
+### 3.1 Flow & momentum・Natural・Meaningful
+
+Every action chain must **push the user forward**, never dead-end or block the flow.
+
+- [ ] **Forward momentum** — after any operation, lead the user to the next step,
+      don't just stop. _(Meaningful)_
+- [ ] **Success state = primary "go to result", secondary "dismiss"** — the strong
+      button is the forward action (take me to the result); "Done" is the weak/
+      secondary button. ✅ After moving topics: primary = "Go to «target»", secondary
+      \= "Done". _(Meaningful・Natural)_
+- [ ] **Bulk ⇄ single-item parity** — an action on a multi-select toolbar must also
+      be reachable on a single item (its context menu), and vice versa. _(Certainty)_
+- [ ] **Confirm → in-progress → done, in one surface** — bulk/irreversible/async
+      ops use a modal state machine: a confirm step stating exactly what happens →
+      an in-progress view with **dismissal locked** → a done (or error) view in the
+      same modal. Never fire-and-forget with only a toast; never leave a dead
+      spinner. _(Certainty・Meaningful)_
+
+### 3.2 One primary button per surface・Certainty
+
+- [ ] **One primary button per surface.** The single primary CTA tells the user the
+      core action; everything else is secondary/tertiary. Never a pile of primary
+      buttons competing for attention. _(Certainty)_
+
+### 3.3 Entity lifecycle completeness・Meaningful・Certainty
 
 The recurring trap: a feature ships only the **display** of a list, but edit /
 delete / management are never built — so the user can add something and then be
@@ -122,16 +173,38 @@ it explicitly _before_ building. Worked example, the tools/connectors list:
 | User-custom (custom connector)      | create  | edit      | delete             |
 
 - [ ] **No display-only features.** For every listed entity, enumerate CRUD +
-      lifecycle ops and build the ones that apply. _(意义感)_
+      lifecycle ops and build the ones that apply. _(Meaningful)_
 - [ ] **Operation set per source/ownership class** — built-in may be read-only;
       anything the user _installed_ must be removable; anything the user _created_
-      must be editable **and** deletable. _(确定性)_
+      must be editable **and** deletable. _(Certainty)_
 - [ ] **Each item exposes its allowed ops** (hover action / context menu / detail
-      page), and there's a clear entry point to add/create where applicable. _(自然)_
+      page), and there's a clear entry point to add/create where applicable. _(Natural)_
 - [ ] **An intentionally-absent op is a documented decision, not an oversight**
-      (e.g. official tools can't be deleted — by design). _(确定性)_
+      (e.g. official tools can't be deleted — by design). _(Certainty)_
 
-## 9. Capability-gated features・Certainty・Meaningful
+---
+
+## 4. Feedback — loading & system response
+
+How the product **answers back** while and after the user acts — loading visuals
+and proactive guardrails.
+
+### 4.1 Loading visuals・Natural
+
+**Never use antd `Spin`** — it doesn't match the product's loading visual. Use a
+project loader:
+
+| Need                        | Component                                                                     |
+| --------------------------- | ----------------------------------------------------------------------------- |
+| Default loading (in-flight) | `NeuralNetworkLoading` from `@/components/NeuralNetworkLoading` (`size` prop) |
+| Inline dots                 | `DotsLoading` / `BubblesLoading` from `@/components`                          |
+| Branded full-page           | `Loading` from `@/components/Loading/BrandTextLoading`                        |
+| List / card placeholder     | a skeleton (e.g. `SkeletonList`)                                              |
+
+When in doubt, reach for `NeuralNetworkLoading` — it's the default in-flight
+indicator (e.g. modal "in progress" states).
+
+### 4.2 Capability-gated features・Certainty・Meaningful
 
 A feature can be fully built and still produce a broken result when the selected
 model — or its still-loading config — **can't deliver the capability the feature
@@ -155,19 +228,53 @@ depends on a capability the current config may lack, the product owes a
 - [ ] **State the problem and the remedy.** The copy says what's wrong _and_ what
       the user should do about it. _(Meaningful)_
 
+---
+
+## 5. Grow — discoverability & progressive disclosure
+
+How the product **deepens** as the user's needs deepen.
+
+### 5.1 Progressive disclosure・Growth
+
+The product should grow with the user — deeper power shows up as needs deepen.
+
+- [ ] **Progressive disclosure** — keep the novice path clean; reveal advanced
+      capabilities as the user gets there, don't dump everything at once. _(Growth・Natural)_
+- [ ] **Surface related actions at the moment of need** — make the next capability
+      discoverable in context (e.g. after the first item exists, offer what to do
+      with it), not buried in a far-off menu. _(Growth・Meaningful)_
+
+---
+
 ## Quick review checklist
+
+**Read — viewing data & lists**
+
+- [ ] Empty / loading / error states are all designed; empty is a real page with a CTA.
+- [ ] List designed across 1 → 10k rows (virtual scroll / pagination / batch as needed).
+- [ ] Capped/scrollable/virtualized list scrolls the restored active item into view on mount (`block: 'nearest'`, re-run after async rows mount).
+- [ ] Pickers show all valid targets (default/inbox included); empty = truly none.
+
+**Edit — entering & changing content**
+
+- [ ] Editors back up in-progress input locally and recover it after refresh/crash/failed-save; destructive exits warn, never silently discard.
+
+**Act — operations, flows & buttons**
 
 - [ ] Action leads the user forward; success offers a primary "go to result".
 - [ ] Bulk action has a single-item entry (and vice versa).
 - [ ] Async/bulk/irreversible action: confirm → in-progress (locked) → done/error.
-- [ ] Empty / loading / error states are all designed; empty is a real page with a CTA.
 - [ ] Exactly one primary button per surface.
-- [ ] List designed across 1 → 10k rows (virtual scroll / pagination / batch as needed).
-- [ ] Pickers show all valid targets (default/inbox included); empty = truly none.
-- [ ] No antd `Spin`; use `NeuralNetworkLoading` / project loaders.
-- [ ] Advanced capability is progressively disclosed / discoverable at the moment of need.
 - [ ] Listed entities have their full lifecycle (not display-only); ops match source (built-in / installed / custom).
+
+**Feedback — loading & system response**
+
+- [ ] No antd `Spin`; use `NeuralNetworkLoading` / project loaders.
 - [ ] Capability-gated feature warns (soft, reactive, load-gated) when the model can't deliver it; copy gives the remedy.
+
+**Grow — discoverability & progressive disclosure**
+
+- [ ] Advanced capability is progressively disclosed / discoverable at the moment of need.
 
 ## Related skills
 

--- a/src/hooks/useScrollActiveThreadIntoView.test.tsx
+++ b/src/hooks/useScrollActiveThreadIntoView.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useScrollActiveThreadIntoView } from './useScrollActiveThreadIntoView';
+
+interface HarnessProps {
+  activeId?: string | null;
+  ids: string[];
+}
+
+const Harness = ({ activeId, ids }: HarnessProps) => {
+  const ref = useScrollActiveThreadIntoView(activeId, ids.length);
+  return (
+    <div ref={ref}>
+      {ids.map((id) => (
+        <div data-thread-id={id} key={id}>
+          row-{id}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const makeIds = (count: number) => Array.from({ length: count }, (_, i) => `t${i}`);
+
+// Capture every scrollIntoView call together with the element it was called on,
+// regardless of whether the DOM env provides a native implementation.
+const calls: { el: Element; options: unknown }[] = [];
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+beforeEach(() => {
+  calls.length = 0;
+  Element.prototype.scrollIntoView = vi.fn(function (this: Element, options: unknown) {
+    calls.push({ el: this, options });
+  });
+});
+
+afterEach(() => {
+  Element.prototype.scrollIntoView = originalScrollIntoView;
+});
+
+describe('useScrollActiveThreadIntoView', () => {
+  it('scrolls the active row into view when it sits below the visible rows', () => {
+    const ids = makeIds(16);
+    const { container } = render(<Harness activeId={'t12'} ids={ids} />);
+
+    const activeRow = container.querySelector('[data-thread-id="t12"]');
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].el).toBe(activeRow);
+    // `block: 'nearest'` keeps an already-visible row put.
+    expect(calls[0].options).toEqual({ block: 'nearest' });
+  });
+
+  it('does nothing when there is no active thread', () => {
+    render(<Harness activeId={undefined} ids={makeIds(16)} />);
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it('does nothing when the active thread is not in the rendered list', () => {
+    render(<Harness activeId={'missing'} ids={makeIds(16)} />);
+
+    expect(calls).toHaveLength(0);
+  });
+
+  it('scrolls once the async-fetched rows mount (ready signal changes)', () => {
+    // Topic opened with a restored activeThreadId before threads have loaded.
+    const { rerender, container } = render(<Harness activeId={'t5'} ids={[]} />);
+    expect(calls).toHaveLength(0);
+
+    // Threads arrive: the effect re-runs because `ready` (length) changed.
+    rerender(<Harness activeId={'t5'} ids={makeIds(10)} />);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].el).toBe(container.querySelector('[data-thread-id="t5"]'));
+  });
+});

--- a/src/hooks/useScrollActiveThreadIntoView.ts
+++ b/src/hooks/useScrollActiveThreadIntoView.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Scroll the active thread row into view inside the capped (max-height) thread
+ * list.
+ *
+ * When a topic is opened or reloaded with `activeThreadId` restored from the
+ * `?thread=` query and that thread sits below the first visible rows, the
+ * scroll container mounts at `scrollTop = 0`. Since the topic row itself is not
+ * highlighted while a thread is active, the user lands on a valid thread with no
+ * visible selection in the sidebar. This nudges the capped list so the active
+ * row is visible.
+ *
+ * Returns a ref to attach to the scroll container. Each thread row must carry a
+ * `data-thread-id` attribute so the active row can be located.
+ *
+ * @param activeThreadId - the currently active thread id (from the store)
+ * @param ready - a value that changes once the rows have mounted (e.g.
+ *   `threads.length`); ensures the effect re-runs after the list renders, not
+ *   only when `activeThreadId` changes, so a restored thread still scrolls into
+ *   view once the async-fetched list arrives.
+ */
+export const useScrollActiveThreadIntoView = (activeThreadId?: string | null, ready?: unknown) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!activeThreadId) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const activeRow = container.querySelector<HTMLElement>(
+      `[data-thread-id="${CSS.escape(activeThreadId)}"]`,
+    );
+    // `block: 'nearest'` only scrolls when the row is out of view, so an
+    // already-visible selection (e.g. the first few rows) stays put.
+    activeRow?.scrollIntoView({ block: 'nearest' });
+  }, [activeThreadId, ready]);
+
+  return containerRef;
+};

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/index.tsx
@@ -59,8 +59,14 @@ const ThreadItem = memo<ThreadItemProps>(({ title, id, isSubagent }) => {
         data-thread-id={id}
         disabled={editing}
         icon={<Icon color={cssVar.colorTextDescription} icon={CornerDownRight} size={'small'} />}
-        style={isSubagent ? { paddingInlineStart: SUBAGENT_PADDING_INLINE_START } : undefined}
+        // The capped ThreadList is a flex column, so rows shrink to fit its
+        // max-height instead of overflowing — the scroll never engages. Pin the
+        // row min-height to the NavItem height (36) to force overflow → scroll.
         title={title}
+        style={{
+          minHeight: 36,
+          ...(isSubagent && { paddingInlineStart: SUBAGENT_PADDING_INLINE_START }),
+        }}
         onClick={handleClick}
       />
       <Editing id={id} title={title} toggleEditing={toggleEditing} />

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/index.tsx
@@ -56,6 +56,7 @@ const ThreadItem = memo<ThreadItemProps>(({ title, id, isSubagent }) => {
         actions={<Actions dropdownMenu={dropdownMenu} />}
         active={active && !isInAgentSubRoute}
         contextMenuItems={dropdownMenu}
+        data-thread-id={id}
         disabled={editing}
         icon={<Icon color={cssVar.colorTextDescription} icon={CornerDownRight} size={'small'} />}
         style={isSubagent ? { paddingInlineStart: SUBAGENT_PADDING_INLINE_START } : undefined}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
@@ -8,6 +8,11 @@ import { threadSelectors } from '@/store/chat/selectors';
 
 import ThreadItem from './ThreadItem';
 
+// Cap the nested thread list so a topic with many threads doesn't push the rest
+// of the topic list off-screen; the overflow scrolls within the list itself.
+// ~9 rows (NavItem 36px + 1px gap).
+const MAX_HEIGHT = 9 * 37;
+
 const ThreadList = memo(({ topicId }: { topicId: string }) => {
   const threads = useChatStore(threadSelectors.getThreadsByTopic(topicId));
 
@@ -16,7 +21,7 @@ const ThreadList = memo(({ topicId }: { topicId: string }) => {
   if (!threads || threads.length === 0) return;
 
   return (
-    <Flexbox gap={1} paddingBlock={1}>
+    <Flexbox gap={1} paddingBlock={1} style={{ maxHeight: MAX_HEIGHT, overflowY: 'auto' }}>
       {threads?.map((item, index) => (
         <ThreadItem
           id={item.id}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
@@ -1,5 +1,5 @@
 import { ThreadType } from '@lobechat/types';
-import { Flexbox } from '@lobehub/ui';
+import { ScrollShadow } from '@lobehub/ui';
 import { memo } from 'react';
 
 import { useFetchThreads } from '@/hooks/useFetchThreads';
@@ -25,11 +25,12 @@ const ThreadList = memo(({ topicId }: { topicId: string }) => {
   if (!threads || threads.length === 0) return;
 
   return (
-    <Flexbox
+    <ScrollShadow
       gap={1}
       paddingBlock={1}
       ref={containerRef}
-      style={{ maxHeight: MAX_HEIGHT, overflowY: 'auto' }}
+      size={12}
+      style={{ maxHeight: MAX_HEIGHT }}
     >
       {threads?.map((item, index) => (
         <ThreadItem
@@ -40,7 +41,7 @@ const ThreadList = memo(({ topicId }: { topicId: string }) => {
           title={item.title}
         />
       ))}
-    </Flexbox>
+    </ScrollShadow>
   );
 });
 

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
@@ -3,6 +3,7 @@ import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
 
 import { useFetchThreads } from '@/hooks/useFetchThreads';
+import { useScrollActiveThreadIntoView } from '@/hooks/useScrollActiveThreadIntoView';
 import { useChatStore } from '@/store/chat';
 import { threadSelectors } from '@/store/chat/selectors';
 
@@ -15,13 +16,21 @@ const MAX_HEIGHT = 9 * 37;
 
 const ThreadList = memo(({ topicId }: { topicId: string }) => {
   const threads = useChatStore(threadSelectors.getThreadsByTopic(topicId));
+  const activeThreadId = useChatStore((s) => s.activeThreadId);
 
   useFetchThreads(topicId);
+
+  const containerRef = useScrollActiveThreadIntoView(activeThreadId, threads?.length);
 
   if (!threads || threads.length === 0) return;
 
   return (
-    <Flexbox gap={1} paddingBlock={1} style={{ maxHeight: MAX_HEIGHT, overflowY: 'auto' }}>
+    <Flexbox
+      gap={1}
+      paddingBlock={1}
+      ref={containerRef}
+      style={{ maxHeight: MAX_HEIGHT, overflowY: 'auto' }}
+    >
       {threads?.map((item, index) => (
         <ThreadItem
           id={item.id}

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/index.tsx
@@ -53,6 +53,7 @@ const ThreadItem = memo<ThreadItemProps>(({ title, id, isSubagent }) => {
         actions={<Actions dropdownMenu={dropdownMenu} />}
         active={active && !isInAgentSubRoute}
         contextMenuItems={dropdownMenu}
+        data-thread-id={id}
         disabled={editing}
         icon={<Icon color={cssVar.colorTextDescription} icon={CornerDownRight} size={'small'} />}
         style={isSubagent ? { paddingInlineStart: SUBAGENT_PADDING_INLINE_START } : undefined}

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/index.tsx
@@ -56,8 +56,14 @@ const ThreadItem = memo<ThreadItemProps>(({ title, id, isSubagent }) => {
         data-thread-id={id}
         disabled={editing}
         icon={<Icon color={cssVar.colorTextDescription} icon={CornerDownRight} size={'small'} />}
-        style={isSubagent ? { paddingInlineStart: SUBAGENT_PADDING_INLINE_START } : undefined}
+        // The capped ThreadList is a flex column, so rows shrink to fit its
+        // max-height instead of overflowing — the scroll never engages. Pin the
+        // row min-height to the NavItem height (36) to force overflow → scroll.
         title={title}
+        style={{
+          minHeight: 36,
+          ...(isSubagent && { paddingInlineStart: SUBAGENT_PADDING_INLINE_START }),
+        }}
         onClick={handleClick}
       />
       <Editing id={id} title={title} toggleEditing={toggleEditing} />

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
@@ -3,6 +3,7 @@ import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
 
 import { useFetchThreads } from '@/hooks/useFetchThreads';
+import { useScrollActiveThreadIntoView } from '@/hooks/useScrollActiveThreadIntoView';
 import { useChatStore } from '@/store/chat';
 import { threadSelectors } from '@/store/chat/selectors';
 
@@ -14,15 +15,22 @@ import ThreadItem from './ThreadItem';
 const MAX_HEIGHT = 9 * 37;
 
 const ThreadList = memo(() => {
-  const [id] = useChatStore((s) => [s.activeTopicId]);
+  const [id, activeThreadId] = useChatStore((s) => [s.activeTopicId, s.activeThreadId]);
   const threads = useChatStore(threadSelectors.getThreadsByTopic(id));
 
   useFetchThreads(id);
 
+  const containerRef = useScrollActiveThreadIntoView(activeThreadId, threads?.length);
+
   if (!threads || threads.length === 0) return;
 
   return (
-    <Flexbox gap={1} paddingBlock={1} style={{ maxHeight: MAX_HEIGHT, overflowY: 'auto' }}>
+    <Flexbox
+      gap={1}
+      paddingBlock={1}
+      ref={containerRef}
+      style={{ maxHeight: MAX_HEIGHT, overflowY: 'auto' }}
+    >
       {threads?.map((item, index) => (
         <ThreadItem
           id={item.id}

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
@@ -8,6 +8,11 @@ import { threadSelectors } from '@/store/chat/selectors';
 
 import ThreadItem from './ThreadItem';
 
+// Cap the nested thread list so a topic with many threads doesn't push the rest
+// of the topic list off-screen; the overflow scrolls within the list itself.
+// ~9 rows (NavItem 36px + 1px gap).
+const MAX_HEIGHT = 9 * 37;
+
 const ThreadList = memo(() => {
   const [id] = useChatStore((s) => [s.activeTopicId]);
   const threads = useChatStore(threadSelectors.getThreadsByTopic(id));
@@ -17,7 +22,7 @@ const ThreadList = memo(() => {
   if (!threads || threads.length === 0) return;
 
   return (
-    <Flexbox gap={1} paddingBlock={1}>
+    <Flexbox gap={1} paddingBlock={1} style={{ maxHeight: MAX_HEIGHT, overflowY: 'auto' }}>
       {threads?.map((item, index) => (
         <ThreadItem
           id={item.id}

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/index.tsx
@@ -1,5 +1,5 @@
 import { ThreadType } from '@lobechat/types';
-import { Flexbox } from '@lobehub/ui';
+import { ScrollShadow } from '@lobehub/ui';
 import { memo } from 'react';
 
 import { useFetchThreads } from '@/hooks/useFetchThreads';
@@ -25,11 +25,12 @@ const ThreadList = memo(() => {
   if (!threads || threads.length === 0) return;
 
   return (
-    <Flexbox
+    <ScrollShadow
       gap={1}
       paddingBlock={1}
       ref={containerRef}
-      style={{ maxHeight: MAX_HEIGHT, overflowY: 'auto' }}
+      size={12}
+      style={{ maxHeight: MAX_HEIGHT }}
     >
       {threads?.map((item, index) => (
         <ThreadItem
@@ -40,7 +41,7 @@ const ThreadList = memo(() => {
           title={item.title}
         />
       ))}
-    </Flexbox>
+    </ScrollShadow>
   );
 });
 


### PR DESCRIPTION
## 💻 变更类型 | Change Type

- [x] 💄 style

## 🔀 变更说明 | Description of Change

When an active topic has many threads (e.g. a subagent run that spawns dozens of sub-threads), the nested thread list under the topic grows unbounded and pushes the rest of the topic list far down / off-screen.

This caps the nested thread list at ~9 rows (`9 * 37px`, where each `NavItem` is 36px tall + 1px gap) and scrolls the overflow **within the list itself**, so long thread lists stay contained while the surrounding topic list remains reachable.

Applied to both sidebar variants:
- `agent/_layout/Sidebar/Topic/TopicListContent/ThreadList`
- `group/_layout/Sidebar/Topic/TopicListContent/ThreadList`

| Before | After |
| --- | --- |
| Thread list expands without bound, pushing other topics off-screen | Thread list capped, overflow scrolls inside |

## 📝 补充信息 | Additional Information

- [x] 💄 The change is UI/style only; no behavior or data changes.
- [ ] ✅ Verify the list scrolls once a topic has more than ~9 threads, and stays static below that.