### PR TITLE
🐛 fix(chat): preserve subAgentId/documentId in message bucket key context

### DIFF
--- a/packages/database/src/models/__tests__/topics/topic.create.test.ts
+++ b/packages/database/src/models/__tests__/topics/topic.create.test.ts
@@ -392,9 +392,26 @@ describe('TopicModel - Create', () => {
 
       await serverDB.transaction(async (tx) => {
         await tx.insert(topics).values({ id: topicId, sessionId, userId, title: 'Original Topic' });
+        // Distinct createdAt so `duplicate`'s `orderBy(createdAt)` is
+        // deterministic — inserting both in one tx would otherwise give them the
+        // same `now()` default, leaving the tied rows in arbitrary order.
         await tx.insert(messages).values([
-          { id: 'message1', role: 'user', topicId, userId, content: 'User message' },
-          { id: 'message2', role: 'assistant', topicId, userId, content: 'Assistant message' },
+          {
+            id: 'message1',
+            role: 'user',
+            topicId,
+            userId,
+            content: 'User message',
+            createdAt: new Date('2024-01-01T00:00:00Z'),
+          },
+          {
+            id: 'message2',
+            role: 'assistant',
+            topicId,
+            userId,
+            content: 'Assistant message',
+            createdAt: new Date('2024-01-01T00:00:01Z'),
+          },
         ]);
       });
 

--- a/src/store/chat/slices/message/actions/query.ts
+++ b/src/store/chat/slices/message/actions/query.ts
@@ -59,16 +59,14 @@ export class MessageQueryActionImpl {
 
     // Priority 1: Use explicit context if provided (preserving scope)
     if (params?.context) {
+      // Spread the whole context so every bucket-key field carries through —
+      // notably `documentId` (page scope: keeps writes in the
+      // `page_<agent>_<documentId>` bucket the editor reads from, instead of
+      // `page_<agent>_new`) and `subAgentId` (group_agent scope's subTopicId).
+      // Only agentId/topicId need a fallback to the active conversation.
       ctx = {
+        ...params.context,
         agentId: params.context.agentId ?? this.#get().activeAgentId,
-        // Preserve groupId from context
-        groupId: params.context.groupId,
-        // Preserve scope from context
-        isNew: params.context.isNew,
-
-        scope: params.context.scope,
-
-        threadId: params.context.threadId,
         topicId:
           params.context.topicId !== undefined ? params.context.topicId : this.#get().activeTopicId,
       };

--- a/src/store/chat/slices/operation/__tests__/actions.test.ts
+++ b/src/store/chat/slices/operation/__tests__/actions.test.ts
@@ -1121,6 +1121,31 @@ describe('Operation Actions', () => {
       expect(context.isNew).toBe(true);
     });
 
+    it('should preserve documentId from operation context (page scope)', () => {
+      const { result } = renderHook(() => useChatStore());
+
+      let operationId: string;
+
+      act(() => {
+        operationId = result.current.startOperation({
+          type: 'sendMessage',
+          context: {
+            agentId: 'page-agent',
+            documentId: 'doc-1',
+            scope: 'page',
+          },
+        }).operationId;
+      });
+
+      const context = result.current.internal_getConversationContext({ operationId: operationId! });
+
+      // Dropping documentId here sinks page-scoped optimistic writes into the
+      // `page_<agent>_new` bucket while the editor reads `page_<agent>_doc-1`,
+      // leaving the copilot stuck on the loading skeleton.
+      expect(context.documentId).toBe('doc-1');
+      expect(context.scope).toBe('page');
+    });
+
     it('should fallback to global state when no operationId provided', () => {
       const { result } = renderHook(() => useChatStore());
 

--- a/src/store/chat/slices/operation/actions.ts
+++ b/src/store/chat/slices/operation/actions.ts
@@ -65,17 +65,23 @@ export class OperationActionsImpl {
           context.operationId,
         );
       } else {
-        const { agentId, topicId, threadId, scope, isNew, groupId } = operation.context;
+        const { agentId, topicId, threadId, scope, isNew, groupId, documentId } = operation.context;
         log(
-          '[internal_getConversationContext] get from operation %s: agentId=%s, topicId=%s, threadId=%s, scope=%s, groupId=%s',
+          '[internal_getConversationContext] get from operation %s: agentId=%s, topicId=%s, threadId=%s, scope=%s, groupId=%s, documentId=%s',
           context.operationId,
           agentId,
           topicId,
           threadId,
           scope,
           groupId,
+          documentId,
         );
-        return { agentId: agentId!, topicId, threadId, scope, isNew, groupId };
+        // Spread the whole operation context so every bucket-key field carries
+        // through — notably `documentId` (page-scoped optimistic writes resolve
+        // to the same `page_<agent>_<documentId>` bucket the editor reads from,
+        // not `page_<agent>_new`) and `subAgentId` (group_agent scope's
+        // subTopicId). Only agentId needs the non-null assertion.
+        return { ...operation.context, agentId: agentId! };
       }
     }
 


### PR DESCRIPTION
## What

`replaceMessages` (`query.ts`) and `internal_getConversationContext` (`operation/actions.ts`) rebuilt the conversation context from a hand-picked field whitelist before computing the message-map bucket key. The whitelist silently dropped `subAgentId` (and other `ConversationContext` fields).

Since `messageMapKey` uses `subAgentId` as the **group_agent** scope's `subTopicId` (`messageMapKey.ts`), group-agent writes collapsed into the wrong bucket. `documentId` (page scope) was already special-cased by comment but the pattern was fragile.

## Change

Spread the whole context instead of a whitelist, and only special-case the fields that genuinely need a fallback/assertion:

- `query.ts` — `{ ...params.context, agentId: ?? activeAgentId, topicId: ?? activeTopicId }`
- `operation/actions.ts` — `{ ...operation.context, agentId: agentId! }`

Every bucket-key field (`subAgentId`, `documentId`, `agentDocumentId`, …) now carries through. Extra `OperationContext` fields are harmless — `toMessageMapContext` only reads the ones it cares about.

## Notes

- Behavior change for **group_agent**-scoped writes: they previously lost `subAgentId` and landed in the wrong bucket; they now route correctly. Worth a smoke test in a group chat.
- Added a test covering `documentId` preservation in `internal_getConversationContext`.

## Test

- `bunx vitest run src/store/chat/slices/operation/__tests__/actions.test.ts` — 46/46 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)