### PR TITLE
🐛 fix(updater): render update release notes as Markdown instead of raw source

### DIFF
--- a/src/features/Electron/updater/UpdateNotification.tsx
+++ b/src/features/Electron/updater/UpdateNotification.tsx
@@ -1,6 +1,6 @@
 import { type UpdateInfo } from '@lobechat/electron-client-ipc';
 import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
-import { Button, Flexbox, Icon } from '@lobehub/ui';
+import { Button, Flexbox, Icon, Markdown } from '@lobehub/ui';
 import { Modal } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { CircleFadingArrowUp } from 'lucide-react';
@@ -134,12 +134,18 @@ export const UpdateNotification: React.FC = () => {
             <div style={{ color: cssVar.colorTextSecondary, fontSize: 12 }}>
               {updateInfo?.version}
             </div>
-            {updateInfo?.releaseNotes && (
-              <div
-                className={styles.releaseNote}
-                dangerouslySetInnerHTML={{ __html: updateInfo.releaseNotes }}
-              />
-            )}
+            {updateInfo?.releaseNotes &&
+              (typeof updateInfo.releaseNotes === 'string' ? (
+                <div className={styles.releaseNote}>
+                  <Markdown>{updateInfo.releaseNotes}</Markdown>
+                </div>
+              ) : (
+                <div className={styles.releaseNote}>
+                  {updateInfo.releaseNotes.map((note) => (
+                    <Markdown key={note.version}>{note.note ?? ''}</Markdown>
+                  ))}
+                </div>
+              ))}
             <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
               <Button size="small" onClick={() => autoUpdateService.installLater()}>
                 {t('updater.installLater')}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

The desktop "update available" modal rendered release notes with `dangerouslySetInnerHTML`, but `UpdateInfo.releaseNotes` is a **Markdown source string** (e.g. `## Canary Build`, GFM tables, `**bold**`). As a result the raw Markdown was shown literally — `##`, `|---|---|`, `**` etc. appeared as plain text instead of formatted content.

This PR renders the notes with `@lobehub/ui`'s `<Markdown>` component:

- `releaseNotes: string` → `<Markdown>{releaseNotes}</Markdown>`
- `releaseNotes: ReleaseNoteInfo[]` → render each note's `note` field via `<Markdown>`

The existing `styles.releaseNote` scroll container (max-height + overflow) is preserved.

#### 🧪 How to Test

Verified locally in the Electron app by broadcasting a real `updateDownloaded` IPC with a representative Markdown release-notes payload (headings, list, bold, inline code, GFM table) and opening the modal.

DOM assertion on the rendered notes:

- Real elements: `h2:1, h3:3, table:1, th:2, td:4, strong:3, code:2`
- No raw-source leakage: `rawHeadingLeak / rawPipeLeak / rawBoldLeak` all `false` (no literal `##` / `|---|` / `**`)

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Markdown shown as raw text (`## 🤖 Canary Build`, `\|----\|----\|`, `**...**` literal) | Headings, list, bold, inline code and GFM table render as formatted content |

#### 📝 Additional Information

Frontend-only change to `src/features/Electron/updater/UpdateNotification.tsx`; no API/contract impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)