### PR TITLE
🐛 fix(skill): stop connected integrations duplicating in chat-input skill panel

### DIFF
--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -809,7 +809,8 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
       isComposioEnabledInEnv
         ? COMPOSIO_APP_TYPES.filter(
             (type) =>
-              installedComposioIds.has(type.identifier) || recommendedComposioIds.has(type.identifier),
+              installedComposioIds.has(type.identifier) ||
+              recommendedComposioIds.has(type.identifier),
           ).map((type) => {
             const server = getServerByName(type.identifier);
             const icon = (
@@ -1232,8 +1233,12 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
     });
   }, [lobehubSkillItems, composioServerItems, installedLobehubIds, installedComposioIds]);
 
-  // Distinguish community plugins and custom plugins
-  const communityPlugins = list.filter((item) => item.type !== 'customPlugin');
+  // Distinguish community plugins and custom plugins.
+  // Whitelist `type === 'plugin'` (matching /settings/skill) so connected
+  // integrations (Composio/LobeHub Skill gateway plugins with other sources like
+  // 'self'/'builtin') don't leak in here and duplicate the brand-icon items
+  // already rendered under the LobeHub group.
+  const communityPlugins = list.filter((item) => item.type === 'plugin');
   const customPlugins = list.filter((item) => item.type === 'customPlugin');
 
   // Function to map plugins to list items


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

The chat-input **`+` → Skills** panel listed connected integrations (Gmail, Google Calendar, Google Drive, …) **twice**:

1. Once as a brand-icon item under the **LobeHub** group (via `skillItems` / Composio / LobeHub Skill).
2. Again as a generic **plug-icon "community plugin"**.

**Root cause:** community plugins were filtered with a *blacklist* (`item.type !== 'customPlugin'`). Since `type` resolves to `p.source || p.type`, integration gateway plugins whose source is `'self'` / `'builtin'` leaked into the community group and got re-rendered with the generic MCP icon.

The `/settings/skill` page already avoids this by *whitelisting* `type === 'plugin'` (`SkillList.tsx`). This PR aligns the chat-input panel (`useControls.tsx`) with the same whitelist, so only genuine community MCP plugins land in the community group.

#### 🧪 How to Test

- [x] Tested locally

1. Connect an integration that installs a gateway plugin (e.g. Gmail / Google Calendar / Google Drive).
2. Open the chat input `+` → **Skills** panel.
3. Each integration now appears **once** (brand-icon item under LobeHub), no duplicate plug-icon row.
4. Genuine community MCP plugins and custom plugins still render as before.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Gmail / Google Calendar / Google Drive shown twice (brand icon + plug icon) | Shown once |