### PR TITLE
🐛 fix(sidebar): anchor spacer immediately after the accordion block

### DIFF
--- a/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.test.ts
+++ b/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { getAvailableSidebarItems } from './CustomizeSidebarModal';
+import { SIDEBAR_SPACER_ID } from '@/store/global/selectors/systemStatus';
+
+import { getAvailableSidebarItems, getSortableSidebarItemIds } from './CustomizeSidebarModal';
 
 describe('CustomizeSidebarModal', () => {
   it('keeps Memory available in personal mode', () => {
@@ -13,5 +15,15 @@ describe('CustomizeSidebarModal', () => {
     const items = getAvailableSidebarItems(true);
 
     expect(items.some((item) => item.id === 'memory')).toBe(false);
+  });
+
+  it('keeps the spacer in the sortable item set', () => {
+    expect(getSortableSidebarItemIds(false).has(SIDEBAR_SPACER_ID)).toBe(true);
+    expect(getSortableSidebarItemIds(true).has(SIDEBAR_SPACER_ID)).toBe(true);
+  });
+
+  it('keeps workspace-only exclusions in the sortable item set', () => {
+    expect(getSortableSidebarItemIds(false).has('memory')).toBe(true);
+    expect(getSortableSidebarItemIds(true).has('memory')).toBe(false);
   });
 });

--- a/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
+++ b/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
@@ -20,19 +20,26 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { ActionIcon, Button, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
-import { createModal, type ModalInstance } from '@lobehub/ui/base-ui';
+import { ActionIcon, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
+import { Button, createModal, type ModalInstance, useModalContext } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { t } from 'i18next';
 import { ArrowDownToLine, Eye, EyeOff, GripVertical, PinIcon, RotateCcw } from 'lucide-react';
-import { memo, useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { getRouteById } from '@/config/routes';
 import { useGlobalStore } from '@/store/global';
+import { DEFAULT_HOME_SIDEBAR_EXPANDED_KEYS } from '@/store/global/initialState';
 import { systemStatusSelectors } from '@/store/global/selectors';
-import { SIDEBAR_ACCORDION_KEYS, SIDEBAR_SPACER_ID } from '@/store/global/selectors/systemStatus';
+import {
+  DEFAULT_HIDDEN_SECTIONS,
+  DEFAULT_SIDEBAR_ITEMS,
+  SIDEBAR_ACCORDION_KEYS,
+  SIDEBAR_SPACER_ID,
+} from '@/store/global/selectors/systemStatus';
 
 // ---------------------------------------------------------------------------
 // Types & constants
@@ -120,6 +127,12 @@ const styles = createStaticStyles(({ css }) => ({
     flex: 1;
     block-size: 1px;
     background: ${cssVar.colorBorderSecondary};
+  `,
+  footer: css`
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    padding-block-start: 16px;
   `,
 }));
 
@@ -329,7 +342,9 @@ const flattenItems = (outer: string[], inner: string[], bindSpacerToAccordion: b
   );
 
 const CustomizeSidebarContent = memo(() => {
-  const [storeItems, hiddenSections, updateSystemStatus] = useGlobalStore((s) => [
+  const { close } = useModalContext();
+  const { t: commonT } = useTranslation('common');
+  const [storeItems, storeHiddenSections, updateSystemStatus] = useGlobalStore((s) => [
     systemStatusSelectors.sidebarItems(s),
     systemStatusSelectors.hiddenSidebarSections(s),
     s.updateSystemStatus,
@@ -344,14 +359,11 @@ const CustomizeSidebarContent = memo(() => {
     [storeItems, sortableItemIds],
   );
 
-  // Local state for drag operations — only persisted on dragEnd
+  // Local draft state — persisted only when the user confirms the modal.
   const [items, setItems] = useState<string[]>(filteredStoreItems);
+  const [hiddenSections, setHiddenSections] = useState<string[]>(storeHiddenSections);
+  const [shouldResetExpandedKeys, setShouldResetExpandedKeys] = useState(false);
   const [activeId, setActiveId] = useState<string | null>(null);
-
-  // Sync local state when store changes (e.g. reset)
-  useEffect(() => {
-    setItems(filteredStoreItems);
-  }, [filteredStoreItems]);
 
   // Derive outer (with group placeholder) and inner (accordion items)
   const { bindSpacerToAccordion, innerItems, outerItems } = useMemo(() => {
@@ -389,10 +401,38 @@ const CustomizeSidebarContent = memo(() => {
       const newHidden = isHidden
         ? hiddenSections.filter((k) => k !== key)
         : [...hiddenSections, key];
-      updateSystemStatus({ hiddenSidebarSections: newHidden });
+      setHiddenSections(newHidden);
     },
-    [hiddenSections, updateSystemStatus],
+    [hiddenSections],
   );
+
+  const handleResetDefault = useCallback(() => {
+    setItems(DEFAULT_SIDEBAR_ITEMS.filter((id) => sortableItemIds.has(id)));
+    setHiddenSections(DEFAULT_HIDDEN_SECTIONS);
+    setShouldResetExpandedKeys(true);
+  }, [sortableItemIds]);
+
+  const handleConfirm = useCallback(() => {
+    updateSystemStatus(
+      {
+        hiddenSidebarSections: hiddenSections,
+        sidebarItems: mergeAvailableSidebarItems(storeItems, items, sortableItemIds),
+        ...(shouldResetExpandedKeys
+          ? { sidebarExpandedKeys: DEFAULT_HOME_SIDEBAR_EXPANDED_KEYS }
+          : {}),
+      },
+      'customizeSidebar',
+    );
+    close();
+  }, [
+    close,
+    hiddenSections,
+    items,
+    shouldResetExpandedKeys,
+    sortableItemIds,
+    storeItems,
+    updateSystemStatus,
+  ]);
 
   // Collision detection: restrict targets to the same container as the active item.
   // - Active in inner (recents/agent) → only collide with inner items
@@ -447,24 +487,13 @@ const CustomizeSidebarContent = memo(() => {
       }
 
       setItems(next);
-      updateSystemStatus({
-        sidebarItems: mergeAvailableSidebarItems(storeItems, next, sortableItemIds),
-      });
     },
-    [
-      bindSpacerToAccordion,
-      innerItems,
-      outerItems,
-      sortableItemIds,
-      storeItems,
-      updateSystemStatus,
-    ],
+    [bindSpacerToAccordion, innerItems, outerItems],
   );
 
   const handleDragCancel = useCallback(() => {
     setActiveId(null);
-    setItems(filteredStoreItems);
-  }, [filteredStoreItems]);
+  }, []);
 
   const renderItem = (id: string) =>
     isSpacer(id) ? (
@@ -474,34 +503,52 @@ const CustomizeSidebarContent = memo(() => {
     );
 
   return (
-    <DndContext
-      collisionDetection={collisionDetection}
-      sensors={sensors}
-      onDragCancel={handleDragCancel}
-      onDragEnd={handleDragEnd}
-      onDragStart={handleDragStart}
-    >
-      <SortableContext items={outerItems} strategy={verticalListSortingStrategy}>
-        <Flexbox gap={2}>
-          {outerItems.map((id) =>
-            id === ACCORDION_GROUP_ID ? (
-              <AccordionGroup key={id}>
-                <SortableContext items={innerItems} strategy={verticalListSortingStrategy}>
-                  {innerItems.map(renderItem)}
-                </SortableContext>
-                {bindSpacerToAccordion && <BoundSpacerItem />}
-              </AccordionGroup>
-            ) : (
-              renderItem(id)
-            ),
-          )}
-        </Flexbox>
-      </SortableContext>
+    <>
+      <DndContext
+        collisionDetection={collisionDetection}
+        sensors={sensors}
+        onDragCancel={handleDragCancel}
+        onDragEnd={handleDragEnd}
+        onDragStart={handleDragStart}
+      >
+        <SortableContext items={outerItems} strategy={verticalListSortingStrategy}>
+          <Flexbox gap={2}>
+            {outerItems.map((id) =>
+              id === ACCORDION_GROUP_ID ? (
+                <AccordionGroup key={id}>
+                  <SortableContext items={innerItems} strategy={verticalListSortingStrategy}>
+                    {innerItems.map(renderItem)}
+                  </SortableContext>
+                  {bindSpacerToAccordion && <BoundSpacerItem />}
+                </AccordionGroup>
+              ) : (
+                renderItem(id)
+              ),
+            )}
+          </Flexbox>
+        </SortableContext>
 
-      <DragOverlay dropAnimation={{ sideEffects: defaultDropAnimationSideEffects({}) }}>
-        {activeId ? <OverlayItem id={activeId} /> : null}
-      </DragOverlay>
-    </DndContext>
+        {createPortal(
+          <DragOverlay dropAnimation={{ sideEffects: defaultDropAnimationSideEffects({}) }}>
+            {activeId ? <OverlayItem id={activeId} /> : null}
+          </DragOverlay>,
+          document.body,
+        )}
+      </DndContext>
+      <div className={styles.footer}>
+        <Button
+          block
+          htmlType="button"
+          icon={<Icon icon={RotateCcw} size={14} />}
+          onClick={handleResetDefault}
+        >
+          {commonT('navPanel.resetDefault')}
+        </Button>
+        <Button block htmlType="button" type="primary" onClick={handleConfirm}>
+          {commonT('confirm')}
+        </Button>
+      </div>
+    </>
   );
 });
 
@@ -512,16 +559,7 @@ const CustomizeSidebarContent = memo(() => {
 export const openCustomizeSidebarModal = (): ModalInstance =>
   createModal({
     content: <CustomizeSidebarContent />,
-    footer: (
-      <Button
-        block
-        icon={<Icon icon={RotateCcw} />}
-        type={'text'}
-        onClick={() => useGlobalStore.getState().resetSidebarCustomization()}
-      >
-        {t('navPanel.resetDefault', { ns: 'common' })}
-      </Button>
-    ),
+    footer: null,
     maskClosable: true,
     title: t('navPanel.customizeSidebar', { ns: 'common' }),
     width: 360,

--- a/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
+++ b/src/routes/(main)/home/_layout/Body/CustomizeSidebarModal.tsx
@@ -26,7 +26,6 @@ import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { t } from 'i18next';
 import { ArrowDownToLine, Eye, EyeOff, GripVertical, PinIcon, RotateCcw } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
-import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
@@ -61,6 +60,9 @@ const ALL_SIDEBAR_ITEMS: SidebarItemConfig[] = [
 
 export const getAvailableSidebarItems = (isWorkspaceMode: boolean): SidebarItemConfig[] =>
   ALL_SIDEBAR_ITEMS.filter((item) => !(isWorkspaceMode && item.id === 'memory'));
+
+export const getSortableSidebarItemIds = (isWorkspaceMode: boolean): Set<string> =>
+  new Set([...getAvailableSidebarItems(isWorkspaceMode).map((item) => item.id), SIDEBAR_SPACER_ID]);
 
 const ITEM_MAP = new Map(ALL_SIDEBAR_ITEMS.map((item) => [item.id, item]));
 
@@ -333,13 +335,13 @@ const CustomizeSidebarContent = memo(() => {
     s.updateSystemStatus,
   ]);
   const isWorkspaceMode = !!useActiveWorkspaceSlug();
-  const availableItemIds = useMemo(
-    () => new Set(getAvailableSidebarItems(isWorkspaceMode).map((item) => item.id)),
+  const sortableItemIds = useMemo(
+    () => getSortableSidebarItemIds(isWorkspaceMode),
     [isWorkspaceMode],
   );
   const filteredStoreItems = useMemo(
-    () => storeItems.filter((id) => availableItemIds.has(id)),
-    [storeItems, availableItemIds],
+    () => storeItems.filter((id) => sortableItemIds.has(id)),
+    [storeItems, sortableItemIds],
   );
 
   // Local state for drag operations — only persisted on dragEnd
@@ -446,14 +448,14 @@ const CustomizeSidebarContent = memo(() => {
 
       setItems(next);
       updateSystemStatus({
-        sidebarItems: mergeAvailableSidebarItems(storeItems, next, availableItemIds),
+        sidebarItems: mergeAvailableSidebarItems(storeItems, next, sortableItemIds),
       });
     },
     [
-      availableItemIds,
       bindSpacerToAccordion,
       innerItems,
       outerItems,
+      sortableItemIds,
       storeItems,
       updateSystemStatus,
     ],
@@ -496,12 +498,9 @@ const CustomizeSidebarContent = memo(() => {
         </Flexbox>
       </SortableContext>
 
-      {createPortal(
-        <DragOverlay dropAnimation={{ sideEffects: defaultDropAnimationSideEffects({}) }}>
-          {activeId ? <OverlayItem id={activeId} /> : null}
-        </DragOverlay>,
-        document.body,
-      )}
+      <DragOverlay dropAnimation={{ sideEffects: defaultDropAnimationSideEffects({}) }}>
+        {activeId ? <OverlayItem id={activeId} /> : null}
+      </DragOverlay>
     </DndContext>
   );
 });

--- a/src/store/global/selectors/systemStatus.test.ts
+++ b/src/store/global/selectors/systemStatus.test.ts
@@ -159,7 +159,9 @@ describe('systemStatusSelectors', () => {
       expect(systemStatusSelectors.sidebarItems(initialState)).toEqual(DEFAULT_SIDEBAR_ITEMS);
     });
 
-    it('should preserve stored order and inject the spacer before the first bottom item', () => {
+    it('should re-anchor the spacer immediately after the accordion block', () => {
+      // Stored order has pages/tasks between the accordion and the first default-bottom item.
+      // The invariant moves them into the bottom group (after the spacer).
       const stored = [
         'agent',
         'recents',
@@ -176,9 +178,9 @@ describe('systemStatusSelectors', () => {
       expect(systemStatusSelectors.sidebarItems(s)).toEqual([
         'agent',
         'recents',
+        SIDEBAR_SPACER_ID,
         'pages',
         'tasks',
-        SIDEBAR_SPACER_ID,
         'image',
         'community',
         'resource',
@@ -186,7 +188,7 @@ describe('systemStatusSelectors', () => {
       ]);
     });
 
-    it('should respect the stored spacer position', () => {
+    it('should preserve a canonically-positioned spacer', () => {
       const stored = [
         'pages',
         'recents',
@@ -204,23 +206,56 @@ describe('systemStatusSelectors', () => {
       expect(systemStatusSelectors.sidebarItems(s)).toEqual(stored);
     });
 
-    it('should append missing known keys to the end and keep the spacer anchored', () => {
+    it('should re-anchor the spacer when stored above the accordion', () => {
+      // Simulates the dropdown-menu "move agent down" path that previously left
+      // the spacer floating above the accordion block.
+      const stored = [
+        'tasks',
+        'pages',
+        SIDEBAR_SPACER_ID,
+        'recents',
+        'agent',
+        'image',
+        'community',
+        'resource',
+        'memory',
+      ];
+      const s: GlobalState = merge(initialState, {
+        status: { sidebarItems: stored },
+      });
+      expect(systemStatusSelectors.sidebarItems(s)).toEqual([
+        'tasks',
+        'pages',
+        'recents',
+        'agent',
+        SIDEBAR_SPACER_ID,
+        'image',
+        'community',
+        'resource',
+        'memory',
+      ]);
+    });
+
+    it('should slot missing top-group defaults before the accordion block', () => {
       const s: GlobalState = merge(initialState, {
         status: { sidebarItems: ['agent', 'recents'] },
       });
       const items = systemStatusSelectors.sidebarItems(s);
-      // stored order preserved at the front
-      expect(items.slice(0, 2)).toEqual(['agent', 'recents']);
+      const spacerIdx = items.indexOf(SIDEBAR_SPACER_ID);
       // every known key is present
       expect(items).toContain('pages');
+      expect(items).toContain('tasks');
       expect(items).toContain('community');
       expect(items).toContain('resource');
       expect(items).toContain('memory');
-      // spacer sits directly before the first bottom-class item
-      const firstBottomIdx = items.findIndex((k) =>
-        ['image', 'community', 'resource', 'memory'].includes(k),
-      );
-      expect(items[firstBottomIdx - 1]).toBe(SIDEBAR_SPACER_ID);
+      // accordion block is flush against the spacer, in stored order
+      expect(items[spacerIdx - 2]).toBe('agent');
+      expect(items[spacerIdx - 1]).toBe('recents');
+      // missing top-group defaults slot in just before the accordion
+      expect(items.indexOf('tasks')).toBeLessThan(spacerIdx - 2);
+      expect(items.indexOf('pages')).toBeLessThan(spacerIdx - 2);
+      // missing bottom-group defaults sit after the spacer
+      expect(items.indexOf('image')).toBeGreaterThan(spacerIdx);
     });
 
     it('should migrate legacy `sidebarSectionOrder` accordion order into the default layout', () => {
@@ -287,26 +322,38 @@ describe('systemStatusSelectors', () => {
   });
 
   describe('reorderSidebarItems', () => {
-    const DEFAULT = ['pages', 'recents', 'agent', 'community', 'resource', 'memory'];
+    // Mirrors the shape returned by the sidebarItems selector — spacer is always
+    // present, anchored immediately after the accordion block.
+    const DEFAULT = [
+      'pages',
+      'recents',
+      'agent',
+      SIDEBAR_SPACER_ID,
+      'community',
+      'resource',
+      'memory',
+    ];
 
     it('should move a non-accordion item normally', () => {
-      // move `community` (idx 3) up to idx 0
-      expect(reorderSidebarItems(DEFAULT, 3, 0)).toEqual([
+      // move `community` (idx 4) up to idx 0
+      expect(reorderSidebarItems(DEFAULT, 4, 0)).toEqual([
         'community',
         'pages',
         'recents',
         'agent',
+        SIDEBAR_SPACER_ID,
         'resource',
         'memory',
       ]);
     });
 
-    it('should snap a non-accordion item out when dragged between accordion items (drag down)', () => {
-      // `pages` (idx 0) dragged down to idx 2 (between recents & agent)
-      // after drag-down: push past the accordion block
+    it('should snap a top-group item past the accordion when dragged between accordion items (drag down)', () => {
+      // `pages` (idx 0) dragged down to idx 2 (between recents & agent) →
+      // pushed past the accordion, lands in the bottom group.
       expect(reorderSidebarItems(DEFAULT, 0, 2)).toEqual([
         'recents',
         'agent',
+        SIDEBAR_SPACER_ID,
         'pages',
         'community',
         'resource',
@@ -314,24 +361,27 @@ describe('systemStatusSelectors', () => {
       ]);
     });
 
-    it('should snap a non-accordion item out when dragged between accordion items (drag up)', () => {
-      // `community` (idx 3) dragged up to idx 2 (between recents & agent)
-      // after drag-up: place before the accordion block
-      expect(reorderSidebarItems(DEFAULT, 3, 2)).toEqual([
+    it('should snap a bottom-group item before the accordion when dragged between accordion items (drag up)', () => {
+      // `community` (idx 4) dragged up to idx 2 (between recents & agent) →
+      // lands ahead of the accordion (top group).
+      expect(reorderSidebarItems(DEFAULT, 4, 2)).toEqual([
         'pages',
         'community',
         'recents',
         'agent',
+        SIDEBAR_SPACER_ID,
         'resource',
         'memory',
       ]);
     });
 
     it('should move the whole accordion block when moving `recents` up past the block boundary', () => {
-      // `recents` (idx 1) moveUp → idx 0. Block [recents, agent] slides to top.
+      // `recents` (idx 1) moveUp → idx 0. Block [recents, agent] slides to top,
+      // spacer follows it.
       expect(reorderSidebarItems(DEFAULT, 1, 0)).toEqual([
         'recents',
         'agent',
+        SIDEBAR_SPACER_ID,
         'pages',
         'community',
         'resource',
@@ -339,16 +389,10 @@ describe('systemStatusSelectors', () => {
       ]);
     });
 
-    it('should move the whole accordion block when moving `agent` down past the block boundary', () => {
-      // `agent` (idx 2) moveDown → idx 3. Block slides past community.
-      expect(reorderSidebarItems(DEFAULT, 2, 3)).toEqual([
-        'pages',
-        'community',
-        'recents',
-        'agent',
-        'resource',
-        'memory',
-      ]);
+    it('should snap the accordion back when moving `agent` down past the spacer', () => {
+      // `agent` (idx 2) moveDown → idx 3 (past spacer). Normalization re-anchors
+      // the spacer behind the accordion, making the move a visible no-op.
+      expect(reorderSidebarItems(DEFAULT, 2, 3)).toBe(DEFAULT);
     });
 
     it('should swap recents and agent within the block', () => {
@@ -357,6 +401,7 @@ describe('systemStatusSelectors', () => {
         'pages',
         'agent',
         'recents',
+        SIDEBAR_SPACER_ID,
         'community',
         'resource',
         'memory',
@@ -365,6 +410,26 @@ describe('systemStatusSelectors', () => {
 
     it('should be a no-op when from === to', () => {
       expect(reorderSidebarItems(DEFAULT, 2, 2)).toBe(DEFAULT);
+    });
+
+    it('should keep the spacer behind the accordion after moving a non-accordion item', () => {
+      const items = [
+        'tasks',
+        'pages',
+        'recents',
+        'agent',
+        SIDEBAR_SPACER_ID,
+        'image',
+        'community',
+        'resource',
+        'memory',
+      ];
+      // Move `pages` (idx 1) to the very end. Spacer stays right after `agent`.
+      const next = reorderSidebarItems(items, 1, items.length - 1);
+      const spacerIdx = next.indexOf(SIDEBAR_SPACER_ID);
+      expect(next[spacerIdx - 1]).toBe('agent');
+      expect(next[spacerIdx - 2]).toBe('recents');
+      expect(next.at(-1)).toBe('pages');
     });
   });
 });

--- a/src/store/global/selectors/systemStatus.ts
+++ b/src/store/global/selectors/systemStatus.ts
@@ -85,21 +85,68 @@ const DEFAULT_BOTTOM_KEYS = new Set(
   DEFAULT_SIDEBAR_ITEMS.slice(DEFAULT_SIDEBAR_ITEMS.indexOf(SIDEBAR_SPACER_ID) + 1),
 );
 
-/** Insert the spacer sentinel into `order` if missing — anchored before the first
- * default "bottom" item (image/community/...), falling back to the end. */
-const ensureSpacer = (order: string[]): string[] => {
-  if (order.includes(SIDEBAR_SPACER_ID)) return order;
-  const insertAt = order.findIndex((k) => DEFAULT_BOTTOM_KEYS.has(k));
-  if (insertAt === -1) return [...order, SIDEBAR_SPACER_ID];
-  return [...order.slice(0, insertAt), SIDEBAR_SPACER_ID, ...order.slice(insertAt)];
+const arraysEqual = (a: string[], b: string[]): boolean => {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
 };
 
-/** Append any known keys missing from `order` so new items don't disappear on upgrade. */
+// Invariant: spacer always sits immediately after the recents+agent block. Any
+// stored position is ignored — the spacer is re-anchored on every read so legacy
+// states (e.g. from the move-up/down dropdown that used to leave the spacer
+// floating above the accordion) self-heal.
+const normalizeSpacerPosition = (order: string[]): string[] => {
+  const withoutSpacer = order.filter((k) => k !== SIDEBAR_SPACER_ID);
+
+  let insertAt = -1;
+  for (let i = withoutSpacer.length - 1; i >= 0; i--) {
+    if (SIDEBAR_ACCORDION_KEYS.has(withoutSpacer[i])) {
+      insertAt = i + 1;
+      break;
+    }
+  }
+  if (insertAt === -1) {
+    const bottomIdx = withoutSpacer.findIndex((k) => DEFAULT_BOTTOM_KEYS.has(k));
+    insertAt = bottomIdx === -1 ? withoutSpacer.length : bottomIdx;
+  }
+
+  return [...withoutSpacer.slice(0, insertAt), SIDEBAR_SPACER_ID, ...withoutSpacer.slice(insertAt)];
+};
+
+// Backfill missing default keys into their canonical group — top-group defaults
+// slot in just before the accordion (keeping accordion flush with the spacer),
+// bottom-group defaults go after the spacer. Without this split a new top-group
+// default added in a future version would silently appear in the bottom group
+// for existing users.
 const withAllKnownKeys = (order: string[]): string[] => {
   const present = new Set(order);
-  const missing = DEFAULT_SIDEBAR_ITEMS.filter((k) => k !== SIDEBAR_SPACER_ID && !present.has(k));
-  const withMissing = missing.length === 0 ? order : [...order, ...missing];
-  return ensureSpacer(withMissing);
+  const missingTop: string[] = [];
+  const missingBottom: string[] = [];
+  for (const k of DEFAULT_SIDEBAR_ITEMS) {
+    if (k === SIDEBAR_SPACER_ID || present.has(k)) continue;
+    (DEFAULT_BOTTOM_KEYS.has(k) ? missingBottom : missingTop).push(k);
+  }
+
+  const withSpacer = normalizeSpacerPosition(order);
+  if (missingTop.length === 0 && missingBottom.length === 0) return withSpacer;
+
+  const spacerIdx = withSpacer.indexOf(SIDEBAR_SPACER_ID);
+  let accordionStartIdx = spacerIdx;
+  for (let i = 0; i < spacerIdx; i++) {
+    if (SIDEBAR_ACCORDION_KEYS.has(withSpacer[i])) {
+      accordionStartIdx = i;
+      break;
+    }
+  }
+
+  return [
+    ...withSpacer.slice(0, accordionStartIdx),
+    ...missingTop,
+    ...withSpacer.slice(accordionStartIdx, spacerIdx + 1),
+    ...missingBottom,
+    ...withSpacer.slice(spacerIdx + 1),
+  ];
 };
 
 const accordionIndices = (items: string[]): number[] => {
@@ -110,17 +157,7 @@ const accordionIndices = (items: string[]): number[] => {
   return out;
 };
 
-/**
- * Reorder sidebar items while keeping the accordion block (recents + agent) contiguous.
- * - If moving an accordion item across the block boundary, moves the whole block.
- * - If moving a non-accordion item into the middle of the block, snaps it to the side
- *   matching the drag direction.
- */
-export const reorderSidebarItems = (items: string[], from: number, to: number): string[] => {
-  if (from === to || from < 0 || to < 0 || from >= items.length || to >= items.length) {
-    return items;
-  }
-
+const reorderInner = (items: string[], from: number, to: number): string[] => {
   const key = items[from];
   const accIdx = accordionIndices(items);
 
@@ -166,6 +203,21 @@ export const reorderSidebarItems = (items: string[], from: number, to: number): 
   }
 
   return moved;
+};
+
+/**
+ * Reorder sidebar items while keeping the accordion block (recents + agent) contiguous
+ * and the spacer immediately after the accordion block. Returns the original `items`
+ * reference when the move resolves to a no-op (e.g. dragging the accordion past the
+ * spacer, which the invariant snaps right back), so callers can short-circuit on
+ * reference equality.
+ */
+export const reorderSidebarItems = (items: string[], from: number, to: number): string[] => {
+  if (from === to || from < 0 || to < 0 || from >= items.length || to >= items.length) {
+    return items;
+  }
+  const normalized = normalizeSpacerPosition(reorderInner(items, from, to));
+  return arraysEqual(normalized, items) ? items : normalized;
 };
 
 const sidebarItems = (s: GlobalState): string[] => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A — discovered while inspecting `src/features/NavPanel/SideBarLayout.tsx` and tracing the spacer logic.

#### 🔀 Description of Change

The home sidebar's flex spacer (`__spacer__`) drifts away from the recents+agent accordion block via two reachable paths:

1. **Dropdown-menu "move up/down" leaks spacer above the accordion.** `useDropdownMenu` (and `Recents/index.tsx`) calls `reorderSidebarItems` on `agent` or `recents`. The block-move branch happily lands the accordion past the spacer's old position, leaving `[..., __spacer__, recents, agent, ...]` persisted.
2. **`CustomizeSidebarModal` silently relocates that spacer on the next drag.** `flattenItems` always re-emits the spacer immediately after the accordion-group placeholder when `bindSpacerToAccordion` is true. So any subsequent drag (even of an unrelated item like `pages`) writes a different spacer position than the one the user had — a silent edit.

Latent bug: `withAllKnownKeys` appends every missing default to the tail of the order, then runs `ensureSpacer` which is a no-op when the spacer already exists. The day a new top-group default is added to `DEFAULT_SIDEBAR_ITEMS`, every existing user gets it dumped in the bottom group.

**Fix:** make "spacer sits immediately after the accordion block" a single, enforced invariant in the selector.

- `normalizeSpacerPosition(order)` — strips any stored spacer and re-anchors it after the last accordion item (fallback: before the first default-bottom item / end). Runs on every read so legacy state self-heals.
- `withAllKnownKeys` — splits missing defaults into top vs bottom by their position in `DEFAULT_SIDEBAR_ITEMS`; top defaults slot in just before the accordion (keeping it flush with the spacer), bottom defaults sit after the spacer.
- `reorderSidebarItems` — extracted as `reorderInner`, wrapped with `normalizeSpacerPosition`. When the normalized result equals the input, returns the input reference so callers' `next === items` short-circuit still fires (e.g. moving agent past the spacer becomes a visible no-op without spurious renders).

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bunx vitest run src/store/global/selectors/systemStatus.test.ts 'src/routes/(main)/home/_layout/Body/'` — 33/33 passing, including new regressions:

- "should re-anchor the spacer when stored above the accordion" — explicit cover of the dropdown-menu path.
- "should snap the accordion back when moving `agent` down past the spacer" — proves the no-op short-circuit.
- "should slot missing top-group defaults before the accordion block" — proves the bottom-dump latent bug is closed.

Existing `reorderSidebarItems` tests were updated to use a realistic `DEFAULT` (with the spacer present), since the selector always returns a normalized list.

#### 📝 Additional Information

Behavioral change for any user whose persisted `sidebarItems` had the spacer in a non-canonical position: it self-heals on next read to `[..., recents, agent, __spacer__, ...]`. No migration code path needed — the normalization is idempotent and runs in the selector. The `CustomizeSidebarModal`'s `flattenItems` already enforced the same invariant on writes; this PR makes the read side and the dropdown-menu reorder path agree with it.