### PR TITLE
🐛 fix(skill): dedupe skill panel rows & allow deleting pending integrations

### DIFF
--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -837,14 +837,17 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
     [removeComposioConnection, togglePlugin],
   );
 
-  // Composio server list items - only show installed or recommended
+  // Composio server list items - show installed, recommended, or any id that
+  // still lingers in the agent's plugins (so an orphaned, never-authorized
+  // entry can be removed even when it isn't a recommended app).
   const composioServerItems = useMemo(
     () =>
       isComposioEnabledInEnv
         ? COMPOSIO_APP_TYPES.filter(
             (type) =>
               installedComposioIds.has(type.identifier) ||
-              recommendedComposioIds.has(type.identifier),
+              recommendedComposioIds.has(type.identifier) ||
+              checkedSet.has(type.identifier),
           ).map((type) => {
             const server = getServerByName(type.identifier);
             const icon = (
@@ -888,36 +891,40 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
               />
             );
 
-            // Server exists but isn't connected yet (pending auth / re-authorize):
-            // keep the Connect/Re-authorize action, but also expose a delete-only
-            // menu (via the "..." button and right-click) so an accidental or
-            // failed authorization can still be removed.
-            if (server) {
+            // Expose a delete-only menu (via the "..." button and right-click)
+            // whenever the entry is removable but not yet connected, while
+            // keeping the Connect/Re-authorize action. This covers two states:
+            //   - a server exists but isn't ACTIVE (pending auth / re-authorize)
+            //   - no server yet, but the id already lingers in the agent's
+            //     plugins (added optimistically, never authorized)
+            // so an accidental or failed authorization can always be cleaned up.
+            const removableId = server?.identifier ?? type.identifier;
+            if (server || checkedSet.has(type.identifier)) {
               return {
                 extra: renderPolicyMenu(
-                  server.identifier,
+                  removableId,
                   {
                     displayName: type.label,
-                    onDelete: () => removeComposioServer(server.identifier),
+                    onDelete: () => removeComposioServer(removableId),
                   },
                   undefined,
                   true,
                 ),
                 icon,
-                key: server.identifier,
+                key: removableId,
                 label: (
                   <span
                     onContextMenu={(event) => {
                       event.preventDefault();
                       event.stopPropagation();
-                      openSkillPolicyMenu(server.identifier);
+                      openSkillPolicyMenu(removableId);
                     }}
                   >
                     {serverItem}
                   </span>
                 ),
                 popoverContent,
-                searchText: `${type.label} ${server.identifier}`,
+                searchText: `${type.label} ${removableId}`,
               } as SkillMenuItem;
             }
 
@@ -941,6 +948,7 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
       removeComposioServer,
       renderPolicyMenu,
       openSkillPolicyMenu,
+      checkedSet,
     ],
   );
 

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -82,6 +82,7 @@ interface SkillConfigureConfig {
 }
 
 type SkillMenuItem = NonNullable<ItemType> & {
+  extra?: ReactNode;
   popoverContent?: ReactNode;
   searchText?: string;
 };
@@ -478,7 +479,16 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
   }, []);
 
   const renderPolicyMenu = useCallback(
-    (id: string, deleteConfig?: SkillDeleteConfig, configureConfig?: SkillConfigureConfig) => {
+    (
+      id: string,
+      deleteConfig?: SkillDeleteConfig,
+      configureConfig?: SkillConfigureConfig,
+      // When true, hide the Pinned/Auto activation options and show only the
+      // configure/delete actions. Used for integrations that exist but aren't
+      // connected yet (pending auth / re-authorize), where activation is
+      // meaningless but the user still needs a way to remove the entry.
+      deleteOnly = false,
+    ) => {
       const mode: SkillPolicyMode = checkedSet.has(id) ? 'pinned' : 'auto';
       const renderCheck = (value: SkillPolicyMode) =>
         mode === value ? (
@@ -513,23 +523,27 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
           onClick={(event) => event.stopPropagation()}
           onContextMenu={(event) => event.stopPropagation()}
         >
-          {renderPolicyItem(
-            'pinned',
-            <Icon
-              className={cx(mode === 'pinned' ? styles.iconPinned : styles.iconDefault)}
-              icon={Pin}
-              size={15}
-            />,
+          {!deleteOnly &&
+            renderPolicyItem(
+              'pinned',
+              <Icon
+                className={cx(mode === 'pinned' ? styles.iconPinned : styles.iconDefault)}
+                icon={Pin}
+                size={15}
+              />,
+            )}
+          {!deleteOnly &&
+            renderPolicyItem(
+              'auto',
+              <Icon
+                className={cx(mode === 'auto' ? styles.iconAuto : styles.iconDefault)}
+                icon={Zap}
+                size={15}
+              />,
+            )}
+          {!deleteOnly && (configureConfig || deleteConfig) && (
+            <div className={cx(styles.deleteDivider)} />
           )}
-          {renderPolicyItem(
-            'auto',
-            <Icon
-              className={cx(mode === 'auto' ? styles.iconAuto : styles.iconDefault)}
-              icon={Zap}
-              size={15}
-            />,
-          )}
-          {(configureConfig || deleteConfig) && <div className={cx(styles.deleteDivider)} />}
           {configureConfig && (
             <button
               className={cx(styles.policyItem)}
@@ -844,21 +858,56 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
               });
             }
 
+            const serverItem = (
+              <ComposioServerItem
+                agentId={agentId}
+                appSlug={type.appSlug}
+                identifier={type.identifier}
+                label={type.label}
+                server={server}
+              />
+            );
+
+            // Server exists but isn't connected yet (pending auth / re-authorize):
+            // keep the Connect/Re-authorize action, but also expose a delete-only
+            // menu (via the "..." button and right-click) so an accidental or
+            // failed authorization can still be removed.
+            if (server) {
+              return {
+                extra: renderPolicyMenu(
+                  server.identifier,
+                  {
+                    displayName: type.label,
+                    onDelete: () => removeComposioConnection(server.identifier),
+                  },
+                  undefined,
+                  true,
+                ),
+                icon,
+                key: server.identifier,
+                label: (
+                  <span
+                    onContextMenu={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      openSkillPolicyMenu(server.identifier);
+                    }}
+                  >
+                    {serverItem}
+                  </span>
+                ),
+                popoverContent,
+                searchText: `${type.label} ${server.identifier}`,
+              } as SkillMenuItem;
+            }
+
             return {
               icon,
               key: type.identifier,
-              label: (
-                <ComposioServerItem
-                  agentId={agentId}
-                  appSlug={type.appSlug}
-                  identifier={type.identifier}
-                  label={type.label}
-                  server={server}
-                />
-              ),
+              label: serverItem,
               popoverContent,
               searchText: type.label,
-            };
+            } as SkillMenuItem;
           })
         : [],
     [
@@ -870,6 +919,8 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
       createManagedSkillItem,
       getServerByName,
       removeComposioConnection,
+      renderPolicyMenu,
+      openSkillPolicyMenu,
     ],
   );
 
@@ -1320,14 +1371,23 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
   ];
 
   const normalizedSearchKeyword = searchKeyword.trim().toLowerCase();
+  // Deduplicate by key: the same app can be sourced from more than one list
+  // (e.g. a Composio/LobeHub integration item plus an installed plugin sharing
+  // the same identifier), which would otherwise render the row twice. Keep the
+  // first occurrence so the richer integration item (LobeHub group, listed
+  // first) wins over a generic plugin duplicate.
+  const seenSkillKeys = new Set<string>();
   const allSkillItems = [
     ...lobehubGroupChildren,
     ...communityGroupChildren,
     ...customGroupChildren,
-  ].filter(
-    (item): item is SkillMenuItem =>
-      Boolean(item) && (item as { type?: string }).type !== 'divider',
-  );
+  ].filter((item): item is SkillMenuItem => {
+    if (!item || (item as { type?: string }).type === 'divider') return false;
+    const key = String(item.key);
+    if (seenSkillKeys.has(key)) return false;
+    seenSkillKeys.add(key);
+    return true;
+  });
   const filterBySearch = (items: SkillMenuItem[]) => {
     if (!normalizedSearchKeyword) return items;
 

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -817,6 +817,20 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
     [allLobehubSkillServers],
   );
 
+  // Remove a Composio connection AND drop its identifier from the agent's
+  // plugins. `ComposioServerItem.handleConnect` optimistically adds the new
+  // server id to `plugins` before OAuth completes, so deleting the connection
+  // alone would leave an orphan id behind — which both keeps the row counted as
+  // pinned and makes a later reconnect's toggle flip the freshly-connected skill
+  // back off. `togglePlugin(id, false)` is a no-op when the id is absent.
+  const removeComposioServer = useCallback(
+    async (identifier: string) => {
+      await removeComposioConnection(identifier);
+      await togglePlugin(identifier, false);
+    },
+    [removeComposioConnection, togglePlugin],
+  );
+
   // Composio server list items - only show installed or recommended
   const composioServerItems = useMemo(
     () =>
@@ -847,7 +861,7 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
                 badge: <Icon icon={McpIcon} size={12} />,
                 deleteConfig: {
                   displayName: type.label,
-                  onDelete: () => removeComposioConnection(server.identifier),
+                  onDelete: () => removeComposioServer(server.identifier),
                 },
                 extraTag: type.author === 'LobeHub' ? officialTag : undefined,
                 icon,
@@ -878,7 +892,7 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
                   server.identifier,
                   {
                     displayName: type.label,
-                    onDelete: () => removeComposioConnection(server.identifier),
+                    onDelete: () => removeComposioServer(server.identifier),
                   },
                   undefined,
                   true,
@@ -918,7 +932,7 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
       t,
       createManagedSkillItem,
       getServerByName,
-      removeComposioConnection,
+      removeComposioServer,
       renderPolicyMenu,
       openSkillPolicyMenu,
     ],

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -826,7 +826,13 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
   const removeComposioServer = useCallback(
     async (identifier: string) => {
       await removeComposioConnection(identifier);
-      await togglePlugin(identifier, false);
+      // Best-effort cleanup: dropping the optimistic plugin id must never break
+      // the delete itself, so swallow any failure here.
+      try {
+        await togglePlugin(identifier, false);
+      } catch (error) {
+        console.error('[Composio] Failed to unpin plugin after delete:', error);
+      }
     },
     [removeComposioConnection, togglePlugin],
   );


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

Two related fixes for the chat-input **`+` → Skills** panel (follow-up to #15869).

**1. Dedupe by key**
The same app can be sourced from more than one list — e.g. a Composio/LobeHub integration item **plus** an installed plugin sharing the same identifier — which rendered the same row multiple times (the "three Google Calendar" report). Added a key-based dedup pass on the final skill list, keeping the first (richer) occurrence so the integration item (LobeHub group, listed first) wins over a generic plugin duplicate.

**2. Deletable pending integrations**
A Composio server that **exists but isn't `ACTIVE`** (pending auth / re-authorize — e.g. after the user closes the OAuth popup, or an accidental connect) only rendered a `Connect`/`Re-authorize` link with **no `...` menu**, so it could never be removed. These rows now get a **delete-only policy menu** (via the `...` button and right-click), backed by `removeComposioConnection`, while keeping the `Re-authorize` action.

`renderPolicyMenu` gained a `deleteOnly` mode that hides the meaningless **Pinned/Auto** options for not-yet-connected entries.

#### 🧪 How to Test

- [x] Tested locally

1. **Dedup:** with an integration that also has a same-identifier installed plugin, open the `+` → Skills panel → the app appears only once.
2. **Pending delete:** start a Composio connect (e.g. Supabase / Google Calendar) and close the OAuth popup before finishing. The row shows `Re-authorize`. Right-click it (or click `...`) → an **Uninstall** option now appears and removes the pending connection.
3. Active integrations and normal plugins still show the full Pinned / Auto / Uninstall menu as before.

#### 📝 Additional Information

No new i18n keys (reuses `tools.builtins.uninstall*`, `tools.composio.reauthorize`). Scope is Composio pending/re-authorize states (matching the reported flow); connected LobeHub-skill delete is out of scope here.