### PR TITLE
🐛 fix(device): gate listDevices request behind login state

### DIFF
--- a/src/features/ChatInput/ControlBar/WorkingDirectoryPicker.tsx
+++ b/src/features/ChatInput/ControlBar/WorkingDirectoryPicker.tsx
@@ -26,6 +26,8 @@ import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 import { deviceSelectors, useDeviceStore } from '@/store/device';
 import { useElectronStore } from '@/store/electron';
+import { useUserStore } from '@/store/user';
+import { authSelectors } from '@/store/user/selectors';
 
 import { openAddWorkingDirModal } from './AddWorkingDirModal';
 import DirIcon from './DirIcon';
@@ -246,8 +248,10 @@ const WorkingDirectoryPicker = memo<WorkingDirectoryPickerProps>(({ agentId }) =
   const { t } = useTranslation('device');
   const [open, setOpen] = useState(false);
 
-  // Populate the device store (SWR dedupes across callers).
-  useDeviceStore((s) => s.useFetchDevices)();
+  // Populate the device store (SWR dedupes across callers). Devices sit behind an
+  // authed lambda procedure, so only fetch once signed in (desktop always fetches).
+  const isLogin = useUserStore(authSelectors.isLogin);
+  useDeviceStore((s) => s.useFetchDevices)(isLogin || isDesktop);
   // One-time fold of legacy localStorage recents into device.workingDirs.
   useMigrateDeviceRecents();
 

--- a/src/hooks/useEffectiveWorkingDirectory.ts
+++ b/src/hooks/useEffectiveWorkingDirectory.ts
@@ -11,6 +11,8 @@ import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 import { deviceSelectors, useDeviceStore } from '@/store/device';
 import { useElectronStore } from '@/store/electron';
+import { useUserStore } from '@/store/user';
+import { authSelectors } from '@/store/user/selectors';
 
 /**
  * The agent's effective working directory under the unified precedence:
@@ -25,7 +27,10 @@ import { useElectronStore } from '@/store/electron';
  */
 export const useEffectiveWorkingDirectory = (agentId?: string): string | undefined => {
   // Self-populate the device store (SWR dedupes by key across all callers).
-  useDeviceStore((s) => s.useFetchDevices)();
+  // Devices live behind an authed lambda procedure, so only fetch once signed in
+  // (desktop always fetches — it relies on the local device's saved cwd).
+  const isLogin = useUserStore(authSelectors.isLogin);
+  useDeviceStore((s) => s.useFetchDevices)(isLogin || isDesktop);
 
   const agencyConfig = useAgentStore((s) =>
     agentId ? agentByIdSelectors.getAgencyConfigById(agentId)(s) : undefined,

--- a/src/routes/(main)/settings/devices/features/DeviceList.tsx
+++ b/src/routes/(main)/settings/devices/features/DeviceList.tsx
@@ -17,6 +17,8 @@ import { useTranslation } from 'react-i18next';
 
 import { lambdaQuery } from '@/libs/trpc/client';
 import { useElectronStore } from '@/store/electron';
+import { useUserStore } from '@/store/user';
+import { authSelectors } from '@/store/user/selectors';
 
 import ConnectDeviceModal from './ConnectDeviceModal';
 import DeviceDetailPanel from './DeviceDetailPanel';
@@ -163,7 +165,11 @@ const ConnectOption = memo<ConnectOptionProps>(({ icon, title, desc, badge, onCl
 
 const DeviceList = memo(() => {
   const { t } = useTranslation('setting');
+  // Devices come from an authed lambda procedure, so only query once signed in
+  // (desktop always queries — it lists the local device's registered cwd).
+  const isLogin = useUserStore(authSelectors.isLogin);
   const { data: devices, isLoading } = lambdaQuery.device.listDevices.useQuery(undefined, {
+    enabled: isLogin || isDesktop,
     staleTime: 30_000,
   });
 

--- a/src/store/device/action.ts
+++ b/src/store/device/action.ts
@@ -128,7 +128,7 @@ export class DeviceActionImpl {
     }
   };
 
-  useFetchDevices = (enabled = true): SWRResponse<DeviceListItem[]> =>
+  useFetchDevices = (enabled = false): SWRResponse<DeviceListItem[]> =>
     useClientDataSWR<DeviceListItem[]>(
       enabled ? deviceKeys.listDevices() : null,
       () => deviceService.listDevices(),


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

`device.listDevices` is served by an **authed** lambda procedure, but the client fired it unconditionally — so logged-out web users sent a bare request that 401s.

Root cause: none of the call sites threaded login state into the SWR / query key.

- `useEffectiveWorkingDirectory` (broadly mounted in chat to resolve the agent cwd) called `useFetchDevices()` with no argument → `enabled` defaulted to `true`.
- `WorkingDirectoryPicker` did the same.
- The settings `DeviceList` queried `lambdaQuery.device.listDevices.useQuery` directly with no `enabled` gate.

Fix:

- Thread `isLogin || isDesktop` (matching the existing `useInitUserState` convention) into all three call sites. Desktop still always fetches — it relies on the local device's saved working directories.
- Flip `useFetchDevices`'s default from `true` → `false` so the safe default is opt-in; any future caller that forgets the flag won't fire a request.

#### 🧪 How to Test

- [x] Tested locally

1. Open the web app **logged out** → confirm no `device.listDevices` request fires (previously a 401 request went out on chat load).
2. Log in → confirm devices load in the working-directory picker and settings → devices page.
3. On desktop → confirm device list / working dirs still resolve as before.

#### 📝 Additional Information

Client-only change, no server / schema / migration impact.