### PR TITLE
⚡️ perf: dedupe unread count polling

### DIFF
--- a/src/libs/swr/index.ts
+++ b/src/libs/swr/index.ts
@@ -3,6 +3,8 @@ import useSWR from 'swr';
 
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
 
+const CLIENT_POLLING_SWR_DEDUPING_INTERVAL = 30_000;
+
 /**
  * Append the active workspace id to the SWR cache key so workspace-scoped
  * fetches never collide across contexts. Personal mode (no active workspace)
@@ -43,7 +45,10 @@ export const useClientDataSWR: SWRHook = (key, fetch, config) => {
     dedupingInterval: 0,
     focusThrottleInterval: 5 * 60 * 1000,
     // Custom error retry logic: don't retry on 401 errors
-    onErrorRetry: (error: any, key: any, config: any, revalidate: any, { retryCount }: any) => {
+    onErrorRetry: (error: any, ...args: any[]) => {
+      const revalidate = args[2];
+      const { retryCount } = args[3];
+
       // Check if error is marked as non-retryable (e.g., 401 authentication errors)
       if (error?.meta?.shouldRetry === false) {
         return;
@@ -61,6 +66,21 @@ export const useClientDataSWR: SWRHook = (key, fetch, config) => {
     ...config,
   });
 };
+
+/**
+ * Polling-friendly variant of useClientDataSWR.
+ *
+ * Keeps the global zero-deduping behavior untouched for interactive data while
+ * giving polling call sites a request-dedupe window. Call sites can tune the
+ * interval based on whether they want to preserve every poll tick or collapse
+ * repeated ticks into fewer network requests.
+ */
+// @ts-ignore
+export const useClientPollingSWR: SWRHook = (key, fetch, config) =>
+  useClientDataSWR(key, fetch, {
+    dedupingInterval: CLIENT_POLLING_SWR_DEDUPING_INTERVAL,
+    ...config,
+  });
 
 /**
  * This type of request method is a relatively "static" request mode, which will only be triggered on the first request.

--- a/src/routes/(main)/home/_layout/Header/components/useInboxUnreadCount.test.ts
+++ b/src/routes/(main)/home/_layout/Header/components/useInboxUnreadCount.test.ts
@@ -3,18 +3,22 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { inboxKeys } from '@/libs/swr/keys';
 
-import { INBOX_UNREAD_COUNT_REFRESH_INTERVAL, useInboxUnreadCount } from './useInboxUnreadCount';
+import {
+  INBOX_UNREAD_COUNT_DEDUPING_INTERVAL,
+  INBOX_UNREAD_COUNT_REFRESH_INTERVAL,
+  useInboxUnreadCount,
+} from './useInboxUnreadCount';
 
 const mocks = vi.hoisted(() => ({
   state: {
     enableBusinessFeatures: true,
     isSignedIn: false,
   },
-  useClientDataSWR: vi.fn(() => ({ data: undefined })),
+  useClientPollingSWR: vi.fn(() => ({ data: undefined })),
 }));
 
 vi.mock('@/libs/swr', () => ({
-  useClientDataSWR: mocks.useClientDataSWR,
+  useClientPollingSWR: mocks.useClientPollingSWR,
 }));
 
 vi.mock('@/services/notification', () => ({
@@ -47,8 +51,8 @@ vi.mock('@/store/user/selectors', () => ({
 beforeEach(() => {
   mocks.state.enableBusinessFeatures = true;
   mocks.state.isSignedIn = false;
-  mocks.useClientDataSWR.mockClear();
-  mocks.useClientDataSWR.mockReturnValue({ data: undefined });
+  mocks.useClientPollingSWR.mockClear();
+  mocks.useClientPollingSWR.mockReturnValue({ data: undefined });
 });
 
 describe('useInboxUnreadCount', () => {
@@ -56,7 +60,8 @@ describe('useInboxUnreadCount', () => {
     const { result } = renderHook(() => useInboxUnreadCount());
 
     expect(result.current.enabled).toBe(false);
-    expect(mocks.useClientDataSWR).toHaveBeenCalledWith(null, expect.any(Function), {
+    expect(mocks.useClientPollingSWR).toHaveBeenCalledWith(null, expect.any(Function), {
+      dedupingInterval: INBOX_UNREAD_COUNT_DEDUPING_INTERVAL,
       refreshInterval: INBOX_UNREAD_COUNT_REFRESH_INTERVAL,
     });
   });
@@ -67,16 +72,21 @@ describe('useInboxUnreadCount', () => {
     const { result } = renderHook(() => useInboxUnreadCount());
 
     expect(result.current.enabled).toBe(true);
-    expect(mocks.useClientDataSWR).toHaveBeenCalledWith(
+    expect(mocks.useClientPollingSWR).toHaveBeenCalledWith(
       inboxKeys.unreadCount(),
       expect.any(Function),
       {
+        dedupingInterval: INBOX_UNREAD_COUNT_DEDUPING_INTERVAL,
         refreshInterval: INBOX_UNREAD_COUNT_REFRESH_INTERVAL,
       },
     );
   });
 
-  it('keeps unread count polling on the same 10 second cadence', () => {
+  it('keeps the 10 second polling timer while deduping repeated requests', () => {
     expect(INBOX_UNREAD_COUNT_REFRESH_INTERVAL).toBe(10_000);
+    expect(INBOX_UNREAD_COUNT_DEDUPING_INTERVAL).toBe(30_000);
+    expect(INBOX_UNREAD_COUNT_DEDUPING_INTERVAL).toBeGreaterThan(
+      INBOX_UNREAD_COUNT_REFRESH_INTERVAL,
+    );
   });
 });

--- a/src/routes/(main)/home/_layout/Header/components/useInboxUnreadCount.ts
+++ b/src/routes/(main)/home/_layout/Header/components/useInboxUnreadCount.ts
@@ -1,10 +1,11 @@
-import { useClientDataSWR } from '@/libs/swr';
+import { useClientPollingSWR } from '@/libs/swr';
 import { inboxKeys } from '@/libs/swr/keys';
 import { notificationService } from '@/services/notification';
 import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/selectors';
 
+export const INBOX_UNREAD_COUNT_DEDUPING_INTERVAL = 30_000;
 export const INBOX_UNREAD_COUNT_REFRESH_INTERVAL = 10_000;
 
 export const useInboxUnreadCount = () => {
@@ -12,10 +13,13 @@ export const useInboxUnreadCount = () => {
   const isLogin = useUserStore(authSelectors.isLogin);
   const enabled = enableBusinessFeatures && isLogin === true;
 
-  const { data: unreadCount = 0 } = useClientDataSWR<number>(
+  const { data: unreadCount = 0 } = useClientPollingSWR<number>(
     enabled ? inboxKeys.unreadCount() : null,
     () => notificationService.getUnreadCount(),
-    { refreshInterval: INBOX_UNREAD_COUNT_REFRESH_INTERVAL },
+    {
+      dedupingInterval: INBOX_UNREAD_COUNT_DEDUPING_INTERVAL,
+      refreshInterval: INBOX_UNREAD_COUNT_REFRESH_INTERVAL,
+    },
   );
 
   return { enabled, unreadCount };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Add a polling-oriented SWR helper that keeps the existing client data behavior while allowing polling requests to use a request dedupe window.
- Move inbox unread-count polling to the polling helper with a 30s dedupe window while keeping the 10s polling timer.
- Update the unread-count hook regression test to cover the polling helper config.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### Automated Tests

- `bunx vitest run --silent='passed-only' "src/routes/(main)/home/_layout/Header/components/useInboxUnreadCount.test.ts"`
- `vscode-cli get-diagnostics`

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No UI changes. This keeps the global `useClientDataSWR` zero-deduping behavior intact for interactive data, and applies deduping only to the unread-count polling call site.