### PR TITLE
♻️ refactor(agent): scope agent route/profile to explicit route agentId (LOBE-10402 P2)

### DIFF
--- a/src/hooks/useRouteAgentId.ts
+++ b/src/hooks/useRouteAgentId.ts
@@ -1,0 +1,20 @@
+import { INBOX_SESSION_ID } from '@lobechat/const';
+import { useParams } from 'react-router-dom';
+
+import { useAgentStore } from '@/store/agent';
+import { builtinAgentSelectors } from '@/store/agent/selectors';
+
+/**
+ * The agentId of the current `/agent/:aid/*` route.
+ *
+ * Use this (instead of the global, hijack-prone `agentStore.activeAgentId`) to
+ * scope `*ById` selectors in agent route components — sidebar, header, profile.
+ * `AgentIdSync` redirects builtin slugs to their real id, but resolve the inbox
+ * slug here too so the very first render before the redirect still works.
+ */
+export const useRouteAgentId = (): string => {
+  const { aid } = useParams<{ aid?: string }>();
+  const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
+
+  return (aid === INBOX_SESSION_ID ? inboxAgentId : aid) || '';
+};

--- a/src/routes/(main)/agent/_layout/Sidebar/Header/Agent/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Header/Agent/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ActionIcon, Avatar, Block, Text } from '@lobehub/ui';
+import isEqual from 'fast-deep-equal';
 import { ChevronsUpDownIcon } from 'lucide-react';
 import { type PropsWithChildren } from 'react';
 import React, { memo } from 'react';
@@ -9,21 +10,21 @@ import { useTranslation } from 'react-i18next';
 import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@/const/meta';
 import { SkeletonItem } from '@/features/NavPanel/components/SkeletonList';
+import { useRouteAgentId } from '@/hooks/useRouteAgentId';
 import { useAgentStore } from '@/store/agent';
-import { agentSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
+import { agentByIdSelectors, agentSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
 
 import SwitchPanel from './SwitchPanel';
 
 const Agent = memo<PropsWithChildren>(() => {
   const { t } = useTranslation(['chat', 'common']);
 
-  const [isLoading, isInbox, title, avatar, backgroundColor] = useAgentStore((s) => [
-    agentSelectors.isAgentConfigLoading(s),
-    builtinAgentSelectors.isInboxAgent(s),
-    agentSelectors.currentAgentTitle(s),
-    agentSelectors.currentAgentAvatar(s),
-    agentSelectors.currentAgentBackgroundColor(s),
-  ]);
+  const agentId = useRouteAgentId();
+  const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
+  const isInbox = !!inboxAgentId && agentId === inboxAgentId;
+  const isLoading = useAgentStore(agentByIdSelectors.isAgentConfigLoadingById(agentId));
+  const meta = useAgentStore(agentSelectors.getAgentMetaById(agentId), isEqual);
+  const { avatar, backgroundColor, title } = meta;
 
   const displayTitle = isInbox
     ? title || 'Lobe AI'

--- a/src/routes/(main)/agent/_layout/Sidebar/Header/Nav.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Header/Nav.test.tsx
@@ -101,8 +101,8 @@ vi.mock('@/store/agent', () => ({
 }));
 
 vi.mock('@/store/agent/selectors', () => ({
-  agentSelectors: {
-    currentAgentHeterogeneousProviderType: () => undefined,
+  agentByIdSelectors: {
+    getAgencyConfigById: () => () => undefined,
   },
 }));
 

--- a/src/routes/(main)/agent/_layout/Sidebar/Header/Nav.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Header/Nav.tsx
@@ -20,7 +20,7 @@ import { usePathname } from '@/libs/router/navigation';
 import { useActionSWR } from '@/libs/swr';
 import { topicActionKeys } from '@/libs/swr/keys';
 import { useAgentStore } from '@/store/agent';
-import { agentSelectors } from '@/store/agent/selectors';
+import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { useGlobalStore } from '@/store/global';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
@@ -41,7 +41,7 @@ const Nav = memo(() => {
   const { isAgentEditable } = useServerConfigStore(featureFlagsSelectors);
   const toggleCommandMenu = useGlobalStore((s) => s.toggleCommandMenu);
   const heterogeneousProviderType = useAgentStore(
-    agentSelectors.currentAgentHeterogeneousProviderType,
+    (s) => agentByIdSelectors.getAgencyConfigById(agentId ?? '')(s)?.heterogeneousProvider?.type,
   );
   const hideProfile = !isAgentEditable;
   // Claude Code agents can use message channels; other hetero providers (e.g. codex) still hide it.

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useAgentTopicGroupMode.ts
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useAgentTopicGroupMode.ts
@@ -1,7 +1,8 @@
 import { useCallback, useMemo } from 'react';
 
+import { useRouteAgentId } from '@/hooks/useRouteAgentId';
 import { useAgentStore } from '@/store/agent';
-import { agentSelectors } from '@/store/agent/selectors';
+import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useUserStore } from '@/store/user';
 import { preferenceSelectors } from '@/store/user/selectors';
 import type { TopicGroupMode } from '@/types/topic';
@@ -9,9 +10,12 @@ import type { TopicGroupMode } from '@/types/topic';
 import { resolveAgentTopicGroupMode } from '../utils/topicGroupMode';
 
 export const useAgentTopicGroupMode = () => {
-  const agentType = useAgentStore(agentSelectors.currentAgentHeterogeneousProviderType);
+  const agentId = useRouteAgentId();
+  const agentType = useAgentStore(
+    (s) => agentByIdSelectors.getAgencyConfigById(agentId)(s)?.heterogeneousProvider?.type,
+  );
   const agentTopicGroupMode = useAgentStore(
-    (s) => agentSelectors.currentAgentConfig(s)?.chatConfig?.topicGroupMode,
+    (s) => chatConfigByIdSelectors.getChatConfigById(agentId)(s)?.topicGroupMode,
   );
   const updateAgentChatConfig = useAgentStore((s) => s.updateAgentChatConfig);
   const globalMode = useUserStore(preferenceSelectors.topicGroupMode);

--- a/src/routes/(main)/agent/profile/features/AgentSettings/Content.test.tsx
+++ b/src/routes/(main)/agent/profile/features/AgentSettings/Content.test.tsx
@@ -70,12 +70,16 @@ vi.mock('@/store/agent', () => {
 
 vi.mock('@/store/agent/selectors', () => ({
   agentSelectors: {
-    currentAgentConfig: (state: typeof mocks.agentState) => state.config,
-    currentAgentMeta: (state: typeof mocks.agentState) => state.meta,
+    getAgentConfigById: () => (state: typeof mocks.agentState) => state.config,
+    getAgentMetaById: () => (state: typeof mocks.agentState) => state.meta,
   },
   builtinAgentSelectors: {
-    isInboxAgent: (state: typeof mocks.agentState) => state.isInbox,
+    inboxAgentId: () => 'inbox-agent',
   },
+}));
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ aid: mocks.agentState.isInbox ? 'inbox-agent' : 'other-agent' }),
 }));
 
 vi.mock('@/store/serverConfig', () => ({

--- a/src/routes/(main)/agent/profile/features/AgentSettings/Content.tsx
+++ b/src/routes/(main)/agent/profile/features/AgentSettings/Content.tsx
@@ -7,12 +7,12 @@ import isEqual from 'fast-deep-equal';
 import { ActivityIcon, MessageSquareHeartIcon } from 'lucide-react';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { shallow } from 'zustand/shallow';
 
 import Menu from '@/components/Menu';
 import { DEFAULT_AVATAR, DEFAULT_INBOX_AVATAR } from '@/const/meta';
 import { AgentSettings as Settings } from '@/features/AgentSetting';
 import { usePermission } from '@/hooks/usePermission';
+import { useRouteAgentId } from '@/hooks/useRouteAgentId';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
 import { ChatSettingsTabs } from '@/store/global/initialState';
@@ -22,12 +22,11 @@ const Content = memo(() => {
   const { t } = useTranslation('setting');
   const theme = useTheme();
   const { allowed: canEdit } = usePermission('edit_own_content');
-  const [agentId, isInbox] = useAgentStore(
-    (s) => [s.activeAgentId, builtinAgentSelectors.isInboxAgent(s)],
-    shallow,
-  );
-  const config = useAgentStore(agentSelectors.currentAgentConfig, isEqual);
-  const meta = useAgentStore(agentSelectors.currentAgentMeta, isEqual);
+  const agentId = useRouteAgentId();
+  const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
+  const isInbox = !!inboxAgentId && agentId === inboxAgentId;
+  const config = useAgentStore(agentSelectors.getAgentConfigById(agentId), isEqual);
+  const meta = useAgentStore(agentSelectors.getAgentMetaById(agentId), isEqual);
   const { enableAgentSelfIteration } = useServerConfigStore(featureFlagsSelectors);
   const [tab, setTab] = useState(ChatSettingsTabs.Opening);
 

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.test.tsx
@@ -57,8 +57,15 @@ vi.mock('@/store/agent', () => ({
 
 vi.mock('@/store/agent/selectors', () => ({
   agentSelectors: {
-    currentAgentConfig: (s: any) => s.config,
+    getAgentConfigById: () => (s: any) => s.config,
   },
+  builtinAgentSelectors: {
+    inboxAgentId: (s: any) => s.inboxId,
+  },
+}));
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ aid: 'agent-1' }),
 }));
 
 vi.mock('../ProfileEditor/MentionList', () => ({

--- a/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
+++ b/src/routes/(main)/agent/profile/features/EditorCanvas/index.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { createChatInputRichPlugins } from '@/features/ChatInput/InputEditor/plugins';
 import { EditingIndicator } from '@/features/EditLock';
 import { usePermission } from '@/hooks/usePermission';
+import { useRouteAgentId } from '@/hooks/useRouteAgentId';
 import { EMPTY_EDITOR_STATE } from '@/libs/editor/constants';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
@@ -24,7 +25,8 @@ const EditorCanvas = memo(() => {
   const { allowed: canEdit } = usePermission('edit_own_content');
   const [editorInit, setEditorInit] = useState(false);
   const [contentInit, setContentInit] = useState(false);
-  const config = useAgentStore(agentSelectors.currentAgentConfig, isEqual);
+  const agentId = useRouteAgentId();
+  const config = useAgentStore(agentSelectors.getAgentConfigById(agentId), isEqual);
   const editorData = config?.editorData;
   const systemRole = config?.systemRole;
   const updateConfig = useAgentStore((s) => s.updateAgentConfig);

--- a/src/routes/(main)/agent/profile/features/Header/AgentForkTag.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/AgentForkTag.tsx
@@ -6,6 +6,7 @@ import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
+import { useRouteAgentId } from '@/hooks/useRouteAgentId';
 import { marketApiService } from '@/services/marketApi';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
@@ -21,7 +22,8 @@ const AgentForkTag = memo(() => {
   const [forkSource, setForkSource] = useState<AgentForkSourceResponse['source']>(null);
   const [loading, setLoading] = useState(false);
 
-  const meta = useAgentStore(agentSelectors.currentAgentMeta);
+  const agentId = useRouteAgentId();
+  const meta = useAgentStore(agentSelectors.getAgentMetaById(agentId));
   const marketIdentifier = meta?.marketIdentifier;
 
   useEffect(() => {

--- a/src/routes/(main)/agent/profile/features/Header/AgentPublishButton/PublishButton.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/AgentPublishButton/PublishButton.tsx
@@ -7,10 +7,11 @@ import { useTranslation } from 'react-i18next';
 
 import { message } from '@/components/AntdStaticMethods';
 import { usePermission } from '@/hooks/usePermission';
+import { useRouteAgentId } from '@/hooks/useRouteAgentId';
 import { useMarketAuth } from '@/layout/AuthProvider/MarketAuth';
 import { resolveMarketAuthError } from '@/layout/AuthProvider/MarketAuth/errors';
 import { useAgentStore } from '@/store/agent';
-import { agentSelectors } from '@/store/agent/selectors';
+import { agentByIdSelectors, agentSelectors } from '@/store/agent/selectors';
 
 import { useVersionReviewStatus } from '../AgentVersionReviewTag';
 import ForkConfirmModal from './ForkConfirmModal';
@@ -36,8 +37,9 @@ const PublishButton = memo<MarketPublishButtonProps>(({ action, onPublishSuccess
   const { isUnderReview, loading: reviewStatusLoading } = useVersionReviewStatus();
 
   // Agent data for validation
-  const meta = useAgentStore(agentSelectors.currentAgentMeta, isEqual);
-  const systemRole = useAgentStore(agentSelectors.currentAgentSystemRole);
+  const agentId = useRouteAgentId();
+  const meta = useAgentStore(agentSelectors.getAgentMetaById(agentId), isEqual);
+  const systemRole = useAgentStore(agentByIdSelectors.getAgentSystemRoleById(agentId));
 
   // Fork confirmation modal state
   const [showForkModal, setShowForkModal] = useState(false);

--- a/src/routes/(main)/agent/profile/features/Header/AgentPublishButton/useMarketPublish.ts
+++ b/src/routes/(main)/agent/profile/features/Header/AgentPublishButton/useMarketPublish.ts
@@ -4,11 +4,16 @@ import { useTranslation } from 'react-i18next';
 
 import { useHasActiveWorkspace } from '@/business/client/hooks/useHasActiveWorkspace';
 import { message } from '@/components/AntdStaticMethods';
+import { useRouteAgentId } from '@/hooks/useRouteAgentId';
 import { useTokenCount } from '@/hooks/useTokenCount';
 import { useMarketAuth } from '@/layout/AuthProvider/MarketAuth';
 import { lambdaClient } from '@/libs/trpc/client';
 import { useAgentStore } from '@/store/agent';
-import { agentChatConfigSelectors, agentSelectors } from '@/store/agent/selectors';
+import {
+  agentByIdSelectors,
+  agentSelectors,
+  chatConfigByIdSelectors,
+} from '@/store/agent/selectors';
 import { useGlobalStore } from '@/store/global';
 import { globalGeneralSelectors } from '@/store/global/selectors';
 
@@ -45,17 +50,18 @@ export const useMarketPublish = ({ action, onSuccess }: UseMarketPublishOptions)
   const { isAuthenticated } = useMarketAuth();
 
   // Agent data from store
-  const meta = useAgentStore(agentSelectors.currentAgentMeta, isEqual);
+  const agentId = useRouteAgentId();
+  const meta = useAgentStore(agentSelectors.getAgentMetaById(agentId), isEqual);
   const updateAgentMeta = useAgentStore((s) => s.updateAgentMeta);
-  const systemRole = useAgentStore(agentSelectors.currentAgentSystemRole);
-  const config = useAgentStore(agentSelectors.currentAgentConfig, isEqual);
+  const systemRole = useAgentStore(agentByIdSelectors.getAgentSystemRoleById(agentId));
+  const config = useAgentStore(agentSelectors.getAgentConfigById(agentId), isEqual);
   const editorData = config?.editorData;
   const language = useGlobalStore(globalGeneralSelectors.currentLanguage);
-  const agentConfig = useAgentStore(agentSelectors.currentAgentConfig);
-  const chatConfig = useAgentStore(agentChatConfigSelectors.currentChatConfig);
-  const plugins = useAgentStore(agentSelectors.currentAgentPlugins);
-  const model = useAgentStore(agentSelectors.currentAgentModel);
-  const provider = useAgentStore(agentSelectors.currentAgentModelProvider);
+  const agentConfig = useAgentStore(agentSelectors.getAgentConfigById(agentId));
+  const chatConfig = useAgentStore(chatConfigByIdSelectors.getChatConfigById(agentId));
+  const plugins = useAgentStore(agentByIdSelectors.getAgentPluginsById(agentId));
+  const model = useAgentStore(agentByIdSelectors.getAgentModelById(agentId));
+  const provider = useAgentStore(agentByIdSelectors.getAgentModelProviderById(agentId));
   const tokenUsage = useTokenCount(systemRole);
   const hasActiveWorkspace = useHasActiveWorkspace();
 

--- a/src/routes/(main)/agent/profile/features/Header/AgentStatusTag.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/AgentStatusTag.tsx
@@ -4,6 +4,7 @@ import { Tag } from '@lobehub/ui';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useRouteAgentId } from '@/hooks/useRouteAgentId';
 import { marketApiService } from '@/services/marketApi';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
@@ -18,7 +19,8 @@ const AgentStatusTag = memo(() => {
   const [status, setStatus] = useState<AgentStatus | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const meta = useAgentStore(agentSelectors.currentAgentMeta);
+  const agentId = useRouteAgentId();
+  const meta = useAgentStore(agentSelectors.getAgentMetaById(agentId));
   const marketIdentifier = meta?.marketIdentifier;
 
   useEffect(() => {

--- a/src/routes/(main)/agent/profile/features/Header/AgentVersionReviewTag.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/AgentVersionReviewTag.tsx
@@ -4,6 +4,7 @@ import { Tag } from '@lobehub/ui';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useRouteAgentId } from '@/hooks/useRouteAgentId';
 import { marketApiService } from '@/services/marketApi';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
@@ -26,7 +27,8 @@ const AgentVersionReviewTag = memo(() => {
   const [versions, setVersions] = useState<AgentVersion[] | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const meta = useAgentStore(agentSelectors.currentAgentMeta);
+  const agentId = useRouteAgentId();
+  const meta = useAgentStore(agentSelectors.getAgentMetaById(agentId));
   const marketIdentifier = meta?.marketIdentifier;
 
   useEffect(() => {
@@ -79,7 +81,8 @@ export const useVersionReviewStatus = () => {
   const [isUnderReview, setIsUnderReview] = useState(false);
   const [loading, setLoading] = useState(false);
 
-  const meta = useAgentStore(agentSelectors.currentAgentMeta);
+  const agentId = useRouteAgentId();
+  const meta = useAgentStore(agentSelectors.getAgentMetaById(agentId));
   const marketIdentifier = meta?.marketIdentifier;
 
   useEffect(() => {

--- a/src/routes/(main)/agent/profile/features/Header/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.test.tsx
@@ -50,6 +50,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@lobechat/const', () => ({
+  INBOX_SESSION_ID: 'inbox',
   isDesktop: false,
 }));
 
@@ -129,6 +130,7 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('react-router-dom', () => ({
   useNavigate: () => mocks.navigate,
+  useParams: () => ({ aid: 'agent-1' }),
 }));
 
 vi.mock('@/components/AntdStaticMethods', () => ({
@@ -170,14 +172,19 @@ vi.mock('@/store/agent', () => ({
 }));
 
 vi.mock('@/store/agent/selectors', () => ({
+  agentByIdSelectors: {
+    getAgentSystemRoleById: () => (state: typeof mocks.agentState) => state.systemRole,
+    isAgentHeterogeneousById: () => (state: typeof mocks.agentState) =>
+      state.isCurrentAgentHeterogeneous,
+  },
   agentSelectors: {
     canCurrentAgentPublishToCommunity: (state: typeof mocks.agentState) =>
       state.canCurrentAgentPublishToCommunity,
-    currentAgentConfig: (state: typeof mocks.agentState) => state.config,
-    currentAgentMeta: (state: typeof mocks.agentState) => state.meta,
-    currentAgentSystemRole: (state: typeof mocks.agentState) => state.systemRole,
-    isCurrentAgentHeterogeneous: (state: typeof mocks.agentState) =>
-      state.isCurrentAgentHeterogeneous,
+    getAgentConfigById: () => (state: typeof mocks.agentState) => state.config,
+    getAgentMetaById: () => (state: typeof mocks.agentState) => state.meta,
+  },
+  builtinAgentSelectors: {
+    inboxAgentId: () => undefined,
   },
 }));
 

--- a/src/routes/(main)/agent/profile/features/Header/index.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.tsx
@@ -17,10 +17,11 @@ import ToggleRightPanelButton from '@/features/RightPanel/ToggleRightPanelButton
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useCommunityPublishGuard } from '@/hooks/useCommunityPublishGuard';
 import { usePermission } from '@/hooks/usePermission';
+import { useRouteAgentId } from '@/hooks/useRouteAgentId';
 import { useMarketAuth } from '@/layout/AuthProvider/MarketAuth';
 import { resolveMarketAuthError } from '@/layout/AuthProvider/MarketAuth/errors';
 import { useAgentStore } from '@/store/agent';
-import { agentSelectors } from '@/store/agent/selectors';
+import { agentByIdSelectors, agentSelectors } from '@/store/agent/selectors';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { useHomeStore } from '@/store/home';
@@ -94,11 +95,11 @@ const Header = memo(() => {
   const { t } = useTranslation(['setting', 'marketAuth', 'chat', 'file', 'common']);
   const navigate = useWorkspaceAwareNavigate();
 
-  const meta = useAgentStore(agentSelectors.currentAgentMeta, isEqual);
-  const config = useAgentStore(agentSelectors.currentAgentConfig, isEqual);
-  const systemRole = useAgentStore(agentSelectors.currentAgentSystemRole);
-  const activeAgentId = useAgentStore((s) => s.activeAgentId);
-  const isHeterogeneous = useAgentStore(agentSelectors.isCurrentAgentHeterogeneous);
+  const agentId = useRouteAgentId();
+  const meta = useAgentStore(agentSelectors.getAgentMetaById(agentId), isEqual);
+  const config = useAgentStore(agentSelectors.getAgentConfigById(agentId), isEqual);
+  const systemRole = useAgentStore(agentByIdSelectors.getAgentSystemRoleById(agentId));
+  const isHeterogeneous = useAgentStore(agentByIdSelectors.isAgentHeterogeneousById(agentId));
   const canPublishToCommunity = useAgentStore(agentSelectors.canCurrentAgentPublishToCommunity);
   const [showAgentBuilderPanel, toggleAgentBuilderPanel, isStatusInit] = useGlobalStore((s) => [
     systemStatusSelectors.showAgentBuilderPanel(s),
@@ -205,17 +206,17 @@ const Header = memo(() => {
   }, [canEdit, publish]);
 
   const handleDelete = useCallback(() => {
-    if (!canEdit || !activeAgentId) return;
+    if (!canEdit || !agentId) return;
     confirmModal({
       okButtonProps: { danger: true },
       onOk: async () => {
-        await removeAgent(activeAgentId);
+        await removeAgent(agentId);
         message.success(t('confirmRemoveSessionSuccess', { ns: 'chat' }));
         navigate('/');
       },
       title: t('confirmRemoveSessionItemAlert', { ns: 'chat' }),
     });
-  }, [activeAgentId, canEdit, navigate, removeAgent, t]);
+  }, [agentId, canEdit, navigate, removeAgent, t]);
 
   const handleExportMarkdown = useCallback(async () => {
     try {
@@ -262,8 +263,8 @@ const Header = memo(() => {
     }
   }, [config.model, config.plugins, config.provider, editor, meta, systemRole, t]);
 
-  const importMenuItem = useBusinessAgentImportMenuItem(activeAgentId ?? undefined);
-  const transferMenuItems = useAgentTransferMenuItem(activeAgentId ?? undefined);
+  const importMenuItem = useBusinessAgentImportMenuItem(agentId || undefined);
+  const transferMenuItems = useAgentTransferMenuItem(agentId || undefined);
 
   const menuItems = useMemo(() => {
     const businessTransferMenuItems = transferMenuItems ?? [];

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.test.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.test.tsx
@@ -57,8 +57,15 @@ vi.mock('@/store/agent', () => ({
 
 vi.mock('@/store/agent/selectors', () => ({
   agentSelectors: {
-    currentAgentMeta: (s: any) => s.meta,
+    getAgentMetaById: () => (s: any) => s.meta,
   },
+  builtinAgentSelectors: {
+    inboxAgentId: (s: any) => s.inboxId,
+  },
+}));
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ aid: 'agent-1' }),
 }));
 
 vi.mock('@/store/file', () => ({

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/AgentHeader.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import EmojiPicker from '@/components/EmojiPicker';
 import BackgroundSwatches from '@/features/AgentSetting/AgentMeta/BackgroundSwatches';
 import { usePermission } from '@/hooks/usePermission';
+import { useRouteAgentId } from '@/hooks/useRouteAgentId';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { useFileStore } from '@/store/file';
@@ -25,8 +26,9 @@ const AgentHeader = memo(() => {
   const locale = useGlobalStore(globalGeneralSelectors.currentLanguage);
   const { allowed: canEdit } = usePermission('edit_own_content');
 
-  // Get current meta from store
-  const meta = useAgentStore(agentSelectors.currentAgentMeta, isEqual);
+  // Get the routed agent's meta from store
+  const agentId = useRouteAgentId();
+  const meta = useAgentStore(agentSelectors.getAgentMetaById(agentId), isEqual);
   const updateMeta = useAgentStore((s) => s.updateAgentMeta);
 
   // File upload

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/index.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/index.tsx
@@ -10,8 +10,9 @@ import { useTranslation } from 'react-i18next';
 
 import ModelSelect from '@/features/ModelSelect';
 import { usePermission } from '@/hooks/usePermission';
+import { useRouteAgentId } from '@/hooks/useRouteAgentId';
 import { useAgentStore } from '@/store/agent';
-import { agentSelectors } from '@/store/agent/selectors';
+import { agentByIdSelectors, agentSelectors } from '@/store/agent/selectors';
 
 import AgentSettings from '../AgentSettings';
 import EditorCanvas from '../EditorCanvas';
@@ -24,9 +25,10 @@ import RemoteAgentConfigCard from './RemoteAgentConfigCard';
 const ProfileEditor = memo(() => {
   const { t } = useTranslation('setting');
   const { allowed: canEdit } = usePermission('edit_own_content');
-  const config = useAgentStore(agentSelectors.currentAgentConfig, isEqual);
+  const agentId = useRouteAgentId();
+  const config = useAgentStore(agentSelectors.getAgentConfigById(agentId), isEqual);
   const updateConfig = useAgentStore((s) => s.updateAgentConfig);
-  const isHeterogeneous = useAgentStore(agentSelectors.isCurrentAgentHeterogeneous);
+  const isHeterogeneous = useAgentStore(agentByIdSelectors.isAgentHeterogeneousById(agentId));
   const heterogeneousProvider = config.agencyConfig?.heterogeneousProvider;
 
   const updateHeterogeneousCommand = async (command: string) => {


### PR DESCRIPTION
**LOBE-10402 Phase 2** — 接续 #15866(Phase 1 已合入 canary)。

## 改动

把 agent **路由层**(sidebar header + topic-group hook + 整个 `/agent/:aid` profile)从全局 `current*` 迁到 `*ById(agentId)`,agentId 来自路由。

新增 `useRouteAgentId()` hook:`useParams().aid` + inbox slug 解析,集中处理路由 agentId(供 sidebar/profile 复用)。

涉及:`Sidebar/Header/{Agent,Nav}`、`Sidebar/Topic/hooks/useAgentTopicGroupMode`、`profile/features/{Header,ProfileEditor,AgentSettings,EditorCanvas,...}`、`AgentPublishButton/{PublishButton,useMarketPublish}`。

### 额外修正
- profile Header 的 **删除 / 转移 / 导入** 不再作用于全局 `activeAgentId`,改用路由 agent —— 杜绝劫持场景下"看 A 删 B"。
- `isCurrentAgentHeterogeneous`(大写 C)被最初的 grep 漏掉,本期一并迁移。

`current*` selector 仍保留(group / mobile / hooks-services 还在用),收尾阶段统一删。

## 验证
- `bun run type-check` ✅ 0 错误
- 受影响单测全绿:Nav / Header / Content / EditorCanvas / AgentHeader(11 用例),mock 已同步更新(useParams + byId selectors + inboxAgentId + INBOX_SESSION_ID)

Refs LOBE-10402

🤖 Generated with [Claude Code](https://claude.com/claude-code)