### PR TITLE
🐛 fix(agent-runtime): forward model extend params on server-side agent runtime

### DIFF
--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -38,7 +38,12 @@ import {
   ToolResolver,
 } from '@lobechat/context-engine';
 import { parse } from '@lobechat/conversation-flow';
-import { consumeStreamUntilDone } from '@lobechat/model-runtime';
+import {
+  applyModelExtendParams,
+  type ChatStreamPayload,
+  consumeStreamUntilDone,
+  type ModelExtendParams,
+} from '@lobechat/model-runtime';
 import {
   context as otelContext,
   SpanKind,
@@ -67,6 +72,7 @@ import {
 } from '@lobechat/types';
 import { sanitizeToolCallArguments, serializePartsForStorage } from '@lobechat/utils';
 import debug from 'debug';
+import type { ExtendParamsType } from 'model-bank';
 
 import { composioEnv } from '@/config/composio';
 import { type MessageModel, MessageModel as MessageModelClass } from '@/database/models/message';
@@ -873,6 +879,7 @@ export const createRuntimeExecutors = (
       type ContentPart = { text: string; type: 'text' } | { image: string; type: 'image' };
       let shouldReplayAssistantReasoning = false;
       let preserveThinkingForPayload: boolean | undefined;
+      let resolvedExtendParams: ModelExtendParams | undefined;
 
       // Process messages through serverMessagesEngine to inject system role, knowledge, etc.
       // Rebuild params from agentConfig at execution time (capabilities built dynamically)
@@ -888,19 +895,36 @@ export const createRuntimeExecutors = (
             : undefined;
         const preserveThinkingRequested = preserveThinkingConfigured === true;
 
+        const readExtendParams = (
+          card: (typeof builtinModels)[number] | undefined,
+        ): string[] | undefined =>
+          card &&
+          'settings' in card &&
+          card.settings &&
+          typeof card.settings === 'object' &&
+          'extendParams' in card.settings
+            ? (card.settings as { extendParams?: string[] }).extendParams
+            : undefined;
+
         const modelCard = builtinModels.find(
           (item) =>
             item.providerId === provider &&
             (item.id === model || item.config?.deploymentName === model),
         );
-        const modelExtendParams =
-          modelCard &&
-          'settings' in modelCard &&
-          modelCard.settings &&
-          typeof modelCard.settings === 'object' &&
-          'extendParams' in modelCard.settings
-            ? (modelCard.settings as { extendParams?: string[] }).extendParams
-            : undefined;
+
+        let modelExtendParams = readExtendParams(modelCard);
+
+        // Aggregation providers (e.g. `lobehub`) may serve a model without copying
+        // its origin `settings.extendParams`. Fall back to the canonical model card
+        // (matched by id across any provider) so reasoning/thinking params like
+        // `thinkingLevel` still reach the model. Mirrors the client-side
+        // `transformToAiModelList` re-namespacing behavior.
+        if (!modelExtendParams || modelExtendParams.length === 0) {
+          const canonicalCard = builtinModels.find(
+            (item) => item.id === model || item.config?.deploymentName === model,
+          );
+          modelExtendParams = readExtendParams(canonicalCard);
+        }
 
         const modelSupportsPreserveThinkingFromCard =
           Array.isArray(modelExtendParams) && modelExtendParams.includes('preserveThinking');
@@ -915,6 +939,19 @@ export const createRuntimeExecutors = (
           modelSupportsPreserveThinking && typeof preserveThinkingConfigured === 'boolean'
             ? preserveThinkingConfigured
             : undefined;
+
+        // Resolve model extend params (thinkingLevel, reasoning effort, urlContext, …)
+        // from the agent chat config so the server-side agent runtime forwards the same
+        // runtime params the client chat service does. Without this, e.g. Gemini 3 Pro's
+        // `thinkingLevel` never reaches the request and thought summaries come back empty.
+        if (agentConfig.chatConfig) {
+          resolvedExtendParams = applyModelExtendParams({
+            chatConfig: agentConfig.chatConfig,
+            extendParams: modelExtendParams as ExtendParamsType[] | undefined,
+            model,
+          });
+        }
+
         const messagesForContext = shouldReplayAssistantReasoning
           ? (llmPayload.messages as UIChatMessage[])
           : stripAssistantReasoningForReplay(llmPayload.messages as UIChatMessage[]);
@@ -1356,6 +1393,9 @@ export const createRuntimeExecutors = (
         model,
         stream,
         tools,
+        // ModelExtendParams keeps provider-specific effort/thinking values as loose
+        // strings (e.g. hy3's 'no_think'); the runtime payload narrows them, so cast.
+        ...(resolvedExtendParams as Partial<ChatStreamPayload>),
         ...(typeof preserveThinkingForPayload === 'boolean' && {
           preserveThinking: preserveThinkingForPayload,
         }),

--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -58,6 +58,9 @@ vi.mock('@/server/services/message', () => ({
 // @lobechat/model-runtime resolves to @cloud/business-model-runtime which has
 // cloud-specific dependencies that are unavailable in the test environment
 vi.mock('@lobechat/model-runtime', () => ({
+  // The executor resolves extend params via this helper; an empty result keeps
+  // the runtime payload unchanged, matching this suite's pre-existing behavior.
+  applyModelExtendParams: vi.fn(() => ({})),
   consumeStreamUntilDone: vi.fn().mockResolvedValue(undefined),
   // `llmErrorClassification.ts` reads these at module-load time; an empty
   // spec map is fine here because this suite never exercises the runtime

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.test.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.test.ts
@@ -17,6 +17,9 @@ import {
 } from './types';
 
 vi.mock('@lobechat/model-runtime', () => ({
+  // RuntimeExecutors (loaded transitively) resolves extend params via this
+  // helper; an empty result keeps the runtime payload unchanged.
+  applyModelExtendParams: vi.fn(() => ({})),
   getModelPropertyWithFallback: vi.fn(),
   // `llmErrorClassification.ts` reads these at module-load time; an empty
   // spec map is fine here because this suite never exercises the runtime

--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -79,4 +79,10 @@ export { consumeStreamUntilDone } from './utils/consumeStream';
 export { AgentRuntimeError } from './utils/createError';
 export { getModelPropertyWithFallback } from './utils/getFallbackModelProperty';
 export { getModelPricing } from './utils/getModelPricing';
+export {
+  applyModelExtendParams,
+  type ApplyModelExtendParamsContext,
+  type ModelExtendParams,
+  resolveDefaultThinkingLevelForModel,
+} from './utils/modelExtendParams';
 export { parseDataUri } from './utils/uriParser';

--- a/packages/model-runtime/src/utils/modelExtendParams.test.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.test.ts
@@ -1,0 +1,90 @@
+import type { LobeAgentChatConfig } from '@lobechat/types';
+import { describe, expect, it } from 'vitest';
+
+import { applyModelExtendParams, resolveDefaultThinkingLevelForModel } from './modelExtendParams';
+
+const chatConfig = (config: Partial<LobeAgentChatConfig> = {}): LobeAgentChatConfig =>
+  ({ ...config }) as LobeAgentChatConfig;
+
+describe('applyModelExtendParams', () => {
+  it('returns empty when the model has no extend params', () => {
+    expect(
+      applyModelExtendParams({
+        chatConfig: chatConfig({ enableReasoning: true }),
+        extendParams: undefined,
+        model: 'gpt-4',
+      }),
+    ).toEqual({});
+
+    expect(
+      applyModelExtendParams({
+        chatConfig: chatConfig({ thinkingLevel3: 'high' }),
+        extendParams: [],
+        model: 'gemini-3.1-pro-preview',
+      }),
+    ).toEqual({});
+  });
+
+  // LOBE-10442: Gemini 3 Pro via the agent path billed reasoning tokens but
+  // returned empty thinking summaries because thinkingLevel never reached the
+  // request. With the model's extendParams present, thinkingLevel must default
+  // to 'high' even when the chat config does not set thinkingLevel3.
+  it('defaults thinkingLevel to high for gemini-3.1-pro-preview (thinkingLevel3)', () => {
+    const result = applyModelExtendParams({
+      chatConfig: chatConfig({}),
+      extendParams: ['thinkingLevel3', 'urlContext'],
+      model: 'gemini-3.1-pro-preview',
+    });
+
+    expect(result.thinkingLevel).toBe('high');
+  });
+
+  it('honors an explicit thinkingLevel3 config value', () => {
+    const result = applyModelExtendParams({
+      chatConfig: chatConfig({ thinkingLevel3: 'medium' }),
+      extendParams: ['thinkingLevel3'],
+      model: 'gemini-3.1-pro-preview',
+    });
+
+    expect(result.thinkingLevel).toBe('medium');
+  });
+
+  it('forwards urlContext only when enabled in the chat config', () => {
+    expect(
+      applyModelExtendParams({
+        chatConfig: chatConfig({ urlContext: true }),
+        extendParams: ['thinkingLevel3', 'urlContext'],
+        model: 'gemini-3.1-pro-preview',
+      }).urlContext,
+    ).toBe(true);
+
+    expect(
+      applyModelExtendParams({
+        chatConfig: chatConfig({}),
+        extendParams: ['thinkingLevel3', 'urlContext'],
+        model: 'gemini-3.1-pro-preview',
+      }).urlContext,
+    ).toBeUndefined();
+  });
+
+  it('resolves reasoning effort variants', () => {
+    expect(
+      applyModelExtendParams({
+        chatConfig: chatConfig({ reasoningEffort: 'high' }),
+        extendParams: ['reasoningEffort'],
+        model: 'some-model',
+      }).reasoning_effort,
+    ).toBe('high');
+  });
+});
+
+describe('resolveDefaultThinkingLevelForModel', () => {
+  it('falls back to high without a model', () => {
+    expect(resolveDefaultThinkingLevelForModel()).toBe('high');
+  });
+
+  it('uses per-model defaults', () => {
+    expect(resolveDefaultThinkingLevelForModel('gemini-3.5-flash')).toBe('medium');
+    expect(resolveDefaultThinkingLevelForModel('gemini-3.1-flash-lite')).toBe('minimal');
+  });
+});

--- a/packages/model-runtime/src/utils/modelExtendParams.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.ts
@@ -1,0 +1,318 @@
+import type { LobeAgentChatConfig } from '@lobechat/types';
+import type { ExtendParamsType } from 'model-bank';
+
+/**
+ * Extended parameters for model runtime
+ */
+export interface ModelExtendParams {
+  deepseekV4ReasoningEffort?: string;
+  effort?: string;
+  enabledContextCaching?: boolean;
+  imageAspectRatio?: string;
+  imageResolution?: string;
+  preserveThinking?: boolean;
+  reasoning_effort?: string;
+  thinking?: {
+    budget_tokens?: number;
+    type?: string;
+  };
+  thinkingBudget?: number;
+  thinkingLevel?: string;
+  urlContext?: boolean;
+  verbosity?: string;
+}
+
+type ThinkingLevelExtendParam =
+  | 'thinkingLevel'
+  | 'thinkingLevel2'
+  | 'thinkingLevel3'
+  | 'thinkingLevel4';
+
+type ThinkingLevelValue = NonNullable<LobeAgentChatConfig['thinkingLevel']>;
+
+const DEFAULT_THINKING_LEVEL_BY_EXTEND_PARAM = {
+  thinkingLevel: 'high',
+  thinkingLevel2: 'high',
+  thinkingLevel3: 'high',
+  thinkingLevel4: 'minimal',
+} as const satisfies Record<ThinkingLevelExtendParam, ThinkingLevelValue>;
+
+const MODEL_THINKING_LEVEL_DEFAULTS: Partial<
+  Record<string, Partial<Record<ThinkingLevelExtendParam, ThinkingLevelValue>>>
+> = {
+  'gemini-3.5-flash': {
+    thinkingLevel: 'medium',
+  },
+  'gemini-3.1-flash-lite': {
+    thinkingLevel: 'minimal',
+  },
+  'gemini-3.1-flash-lite-preview': {
+    thinkingLevel: 'minimal',
+  },
+} as const;
+
+/**
+ * Preserves legacy `thinking` preferences for users created before `enableReasoning`.
+ * Without this fallback, an old `thinking: 'enabled'` or `thinking: 'disabled'`
+ * setting would be treated as unset by models that now expose the `enableReasoning` switch.
+ */
+const resolveEnableReasoningValue = (chatConfig: LobeAgentChatConfig): boolean | undefined => {
+  if (Object.hasOwn(chatConfig, 'enableReasoning')) return chatConfig.enableReasoning;
+
+  if (chatConfig.thinking === 'enabled') return true;
+  if (chatConfig.thinking === 'disabled') return false;
+
+  return undefined;
+};
+
+const resolveThinkingLevelDefault = (
+  model: string,
+  extendParam: ThinkingLevelExtendParam,
+): ThinkingLevelValue => {
+  return (
+    MODEL_THINKING_LEVEL_DEFAULTS[model]?.[extendParam] ??
+    DEFAULT_THINKING_LEVEL_BY_EXTEND_PARAM[extendParam]
+  );
+};
+
+const isThinkingLevelExtendParam = (
+  extendParam: ExtendParamsType,
+): extendParam is ThinkingLevelExtendParam => extendParam in DEFAULT_THINKING_LEVEL_BY_EXTEND_PARAM;
+
+export const resolveDefaultThinkingLevelForModel = (model?: string): ThinkingLevelValue => {
+  if (!model) return DEFAULT_THINKING_LEVEL_BY_EXTEND_PARAM.thinkingLevel;
+
+  return resolveThinkingLevelDefault(model, 'thinkingLevel');
+};
+
+export interface ApplyModelExtendParamsContext {
+  chatConfig: LobeAgentChatConfig;
+  /**
+   * The model's supported extend params (`settings.extendParams` from its model card).
+   */
+  extendParams: ExtendParamsType[] | undefined;
+  model: string;
+}
+
+/**
+ * Resolves extended runtime parameters from a model's supported `extendParams`
+ * list and the agent chat config.
+ *
+ * This is the provider/store-agnostic core shared by the client chat service
+ * (`resolveModelExtendParams`) and the server-side agent runtime, so both paths
+ * forward the same runtime params (thinking level, reasoning effort, url context, …)
+ * to the model. Callers are responsible for looking up the `extendParams` list.
+ */
+export const applyModelExtendParams = (ctx: ApplyModelExtendParamsContext): ModelExtendParams => {
+  const { extendParams: modelExtendParams, chatConfig, model } = ctx;
+  const extendParams: ModelExtendParams = {};
+
+  if (!modelExtendParams || modelExtendParams.length === 0) {
+    return extendParams;
+  }
+
+  // Reasoning configuration
+  if (modelExtendParams.includes('enableReasoning')) {
+    const enableReasoning = resolveEnableReasoningValue(chatConfig);
+
+    if (enableReasoning) {
+      const thinking: NonNullable<ModelExtendParams['thinking']> = {
+        type: 'enabled',
+      };
+
+      // Determine which budget field to use based on model support
+      let budgetTokens: number | undefined;
+      if (modelExtendParams.includes('reasoningBudgetToken32k')) {
+        budgetTokens = chatConfig.reasoningBudgetToken32k || 1024;
+      } else if (modelExtendParams.includes('reasoningBudgetToken80k')) {
+        budgetTokens = chatConfig.reasoningBudgetToken80k || 1024;
+      } else {
+        budgetTokens = chatConfig.reasoningBudgetToken || 1024;
+      }
+
+      thinking.budget_tokens = budgetTokens;
+      extendParams.thinking = thinking;
+    } else {
+      extendParams.thinking = {
+        budget_tokens: 0,
+        type: 'disabled',
+      };
+    }
+  } else if (modelExtendParams.includes('reasoningBudgetToken32k')) {
+    // For models that only have reasoningBudgetToken32k without enableReasoning
+    extendParams.thinking = {
+      budget_tokens: chatConfig.reasoningBudgetToken32k || 1024,
+      type: 'enabled',
+    };
+  } else if (modelExtendParams.includes('reasoningBudgetToken80k')) {
+    // For models that only have reasoningBudgetToken80k without enableReasoning
+    extendParams.thinking = {
+      budget_tokens: chatConfig.reasoningBudgetToken80k || 1024,
+      type: 'enabled',
+    };
+  } else if (modelExtendParams.includes('reasoningBudgetToken')) {
+    // For models that only have reasoningBudgetToken without enableReasoning
+    extendParams.thinking = {
+      budget_tokens: chatConfig.reasoningBudgetToken || 1024,
+    };
+  }
+
+  // Adaptive thinking (Claude Opus/Sonnet 4.6)
+  if (modelExtendParams.includes('enableAdaptiveThinking')) {
+    if (chatConfig.enableAdaptiveThinking) {
+      extendParams.thinking = {
+        type: 'adaptive',
+      };
+    } else if (!modelExtendParams.includes('enableReasoning')) {
+      // Only disable when the model has no enableReasoning fallback
+      extendParams.thinking = {
+        type: 'disabled',
+      };
+    }
+    // When adaptive is off and model also has enableReasoning, let enableReasoning result stand
+  }
+
+  // Context caching
+  if (modelExtendParams.includes('disableContextCaching') && chatConfig.disableContextCaching) {
+    extendParams.enabledContextCaching = false;
+  }
+
+  // Preserve historical thinking content (provider support required)
+  if (
+    modelExtendParams.includes('preserveThinking') &&
+    typeof chatConfig.preserveThinking === 'boolean'
+  ) {
+    extendParams.preserveThinking = chatConfig.preserveThinking;
+  }
+
+  // Reasoning effort variants
+  if (modelExtendParams.includes('reasoningEffort') && chatConfig.reasoningEffort) {
+    extendParams.reasoning_effort = chatConfig.reasoningEffort;
+  }
+
+  if (modelExtendParams.includes('gpt5ReasoningEffort') && chatConfig.gpt5ReasoningEffort) {
+    extendParams.reasoning_effort = chatConfig.gpt5ReasoningEffort;
+  }
+
+  if (modelExtendParams.includes('gpt5_1ReasoningEffort') && chatConfig.gpt5_1ReasoningEffort) {
+    extendParams.reasoning_effort = chatConfig.gpt5_1ReasoningEffort;
+  }
+
+  if (modelExtendParams.includes('gpt5_2ReasoningEffort') && chatConfig.gpt5_2ReasoningEffort) {
+    extendParams.reasoning_effort = chatConfig.gpt5_2ReasoningEffort;
+  }
+
+  if (
+    modelExtendParams.includes('gpt5_2ProReasoningEffort') &&
+    chatConfig.gpt5_2ProReasoningEffort
+  ) {
+    extendParams.reasoning_effort = chatConfig.gpt5_2ProReasoningEffort;
+  }
+
+  if (modelExtendParams.includes('grok4_20ReasoningEffort') && chatConfig.grok4_20ReasoningEffort) {
+    extendParams.reasoning_effort = chatConfig.grok4_20ReasoningEffort;
+  }
+
+  if (modelExtendParams.includes('grok4_3ReasoningEffort') && chatConfig.grok4_3ReasoningEffort) {
+    extendParams.reasoning_effort = chatConfig.grok4_3ReasoningEffort;
+  }
+
+  if (modelExtendParams.includes('hy3ReasoningEffort') && chatConfig.hy3ReasoningEffort) {
+    extendParams.reasoning_effort = chatConfig.hy3ReasoningEffort;
+  }
+
+  if (modelExtendParams.includes('ring2_6ReasoningEffort') && chatConfig.ring2_6ReasoningEffort) {
+    extendParams.reasoning_effort = chatConfig.ring2_6ReasoningEffort;
+  }
+
+  if (modelExtendParams.includes('codexMaxReasoningEffort') && chatConfig.codexMaxReasoningEffort) {
+    extendParams.reasoning_effort = chatConfig.codexMaxReasoningEffort;
+  }
+
+  // DeepSeek reasoning effort is reconciled last to avoid invalid combinations.
+  if (modelExtendParams.includes('deepseekV4ReasoningEffort')) {
+    const deepseekV4ReasoningEffort = chatConfig.deepseekV4ReasoningEffort;
+
+    if (typeof deepseekV4ReasoningEffort === 'string') {
+      if (deepseekV4ReasoningEffort === 'none') {
+        delete extendParams.reasoning_effort;
+        extendParams.thinking = {
+          type: 'disabled',
+        };
+      } else {
+        extendParams.reasoning_effort = deepseekV4ReasoningEffort;
+        extendParams.thinking = {
+          type: 'enabled',
+        };
+      }
+    }
+  }
+
+  if (modelExtendParams.includes('effort') && chatConfig.effort) {
+    extendParams.effort = chatConfig.effort;
+  }
+
+  if (modelExtendParams.includes('opus47Effort') && chatConfig.opus47Effort) {
+    extendParams.effort = chatConfig.opus47Effort;
+  }
+
+  if (modelExtendParams.includes('step3_5ReasoningEffort') && chatConfig.step3_5ReasoningEffort) {
+    extendParams.reasoning_effort = chatConfig.step3_5ReasoningEffort;
+  }
+
+  // Text verbosity
+  if (modelExtendParams.includes('textVerbosity') && chatConfig.textVerbosity) {
+    extendParams.verbosity = chatConfig.textVerbosity;
+  }
+
+  // Thinking configuration
+  if (modelExtendParams.includes('thinking') && chatConfig.thinking) {
+    extendParams.thinking = { type: chatConfig.thinking };
+  }
+
+  if (modelExtendParams.includes('thinkingBudget') && chatConfig.thinkingBudget !== undefined) {
+    extendParams.thinkingBudget = chatConfig.thinkingBudget;
+  }
+
+  const supportedThinkingLevelParams = modelExtendParams.filter(isThinkingLevelExtendParam);
+
+  for (const supportedThinkingLevelParam of supportedThinkingLevelParams) {
+    const value = chatConfig[supportedThinkingLevelParam];
+
+    if (typeof value === 'string') {
+      extendParams.thinkingLevel = value;
+      break;
+    }
+  }
+
+  if (!extendParams.thinkingLevel && supportedThinkingLevelParams.length > 0) {
+    extendParams.thinkingLevel = resolveThinkingLevelDefault(
+      model,
+      supportedThinkingLevelParams[0],
+    );
+  }
+
+  // URL context
+  if (modelExtendParams.includes('urlContext') && chatConfig.urlContext) {
+    extendParams.urlContext = chatConfig.urlContext;
+  }
+
+  // Image generation params
+  if (modelExtendParams.includes('imageAspectRatio') && chatConfig.imageAspectRatio) {
+    extendParams.imageAspectRatio = chatConfig.imageAspectRatio;
+  }
+
+  if (modelExtendParams.includes('imageAspectRatio2') && chatConfig.imageAspectRatio2) {
+    extendParams.imageAspectRatio = chatConfig.imageAspectRatio2;
+  }
+
+  if (modelExtendParams.includes('imageResolution') && chatConfig.imageResolution) {
+    extendParams.imageResolution = chatConfig.imageResolution;
+  }
+
+  if (modelExtendParams.includes('imageResolution2') && chatConfig.imageResolution2) {
+    extendParams.imageResolution = chatConfig.imageResolution2;
+  }
+
+  return extendParams;
+};

--- a/src/services/chat/mecha/modelParamsResolver.ts
+++ b/src/services/chat/mecha/modelParamsResolver.ts
@@ -1,7 +1,14 @@
+import {
+  applyModelExtendParams,
+  type ModelExtendParams,
+  resolveDefaultThinkingLevelForModel,
+} from '@lobechat/model-runtime';
 import type { LobeAgentChatConfig } from '@lobechat/types';
-import type { ExtendParamsType } from 'model-bank';
 
 import { aiModelSelectors, getAiInfraStoreState } from '@/store/aiInfra';
+
+export type { ModelExtendParams };
+export { resolveDefaultThinkingLevelForModel };
 
 /**
  * Context for resolving model parameters
@@ -13,98 +20,14 @@ export interface ModelParamsContext {
 }
 
 /**
- * Extended parameters for model runtime
- */
-export interface ModelExtendParams {
-  deepseekV4ReasoningEffort?: string;
-  effort?: string;
-  enabledContextCaching?: boolean;
-  imageAspectRatio?: string;
-  imageResolution?: string;
-  preserveThinking?: boolean;
-  reasoning_effort?: string;
-  thinking?: {
-    budget_tokens?: number;
-    type?: string;
-  };
-  thinkingBudget?: number;
-  thinkingLevel?: string;
-  urlContext?: boolean;
-  verbosity?: string;
-}
-
-type ThinkingLevelExtendParam =
-  | 'thinkingLevel'
-  | 'thinkingLevel2'
-  | 'thinkingLevel3'
-  | 'thinkingLevel4';
-
-type ThinkingLevelValue = NonNullable<LobeAgentChatConfig['thinkingLevel']>;
-
-const DEFAULT_THINKING_LEVEL_BY_EXTEND_PARAM = {
-  thinkingLevel: 'high',
-  thinkingLevel2: 'high',
-  thinkingLevel3: 'high',
-  thinkingLevel4: 'minimal',
-} as const satisfies Record<ThinkingLevelExtendParam, ThinkingLevelValue>;
-
-const MODEL_THINKING_LEVEL_DEFAULTS: Partial<
-  Record<string, Partial<Record<ThinkingLevelExtendParam, ThinkingLevelValue>>>
-> = {
-  'gemini-3.5-flash': {
-    thinkingLevel: 'medium',
-  },
-  'gemini-3.1-flash-lite': {
-    thinkingLevel: 'minimal',
-  },
-  'gemini-3.1-flash-lite-preview': {
-    thinkingLevel: 'minimal',
-  },
-} as const;
-
-/**
- * Preserves legacy `thinking` preferences for users created before `enableReasoning`.
- * Without this fallback, an old `thinking: 'enabled'` or `thinking: 'disabled'`
- * setting would be treated as unset by models that now expose the `enableReasoning` switch.
- */
-const resolveEnableReasoningValue = (chatConfig: LobeAgentChatConfig): boolean | undefined => {
-  if (Object.hasOwn(chatConfig, 'enableReasoning')) return chatConfig.enableReasoning;
-
-  if (chatConfig.thinking === 'enabled') return true;
-  if (chatConfig.thinking === 'disabled') return false;
-
-  return undefined;
-};
-
-const resolveThinkingLevelDefault = (
-  model: string,
-  extendParam: ThinkingLevelExtendParam,
-): ThinkingLevelValue => {
-  return (
-    MODEL_THINKING_LEVEL_DEFAULTS[model]?.[extendParam] ??
-    DEFAULT_THINKING_LEVEL_BY_EXTEND_PARAM[extendParam]
-  );
-};
-
-const isThinkingLevelExtendParam = (
-  extendParam: ExtendParamsType,
-): extendParam is ThinkingLevelExtendParam => extendParam in DEFAULT_THINKING_LEVEL_BY_EXTEND_PARAM;
-
-export const resolveDefaultThinkingLevelForModel = (model?: string): ThinkingLevelValue => {
-  if (!model) return DEFAULT_THINKING_LEVEL_BY_EXTEND_PARAM.thinkingLevel;
-
-  return resolveThinkingLevelDefault(model, 'thinkingLevel');
-};
-
-/**
- * Resolves extended parameters for model runtime based on model capabilities and chat config
+ * Resolves extended parameters for model runtime based on model capabilities and chat config.
  *
- * This function checks what extended parameters the model supports and applies
- * the corresponding values from chat config.
+ * Looks up the model's supported `extendParams` from the aiInfra store, then delegates the
+ * actual resolution to the shared `applyModelExtendParams` (in `@lobechat/model-runtime`) so the
+ * client chat service and the server-side agent runtime stay in sync.
  */
 export const resolveModelExtendParams = (ctx: ModelParamsContext): ModelExtendParams => {
   const { model, provider, chatConfig } = ctx;
-  const extendParams: ModelExtendParams = {};
 
   const aiInfraStoreState = getAiInfraStoreState();
 
@@ -114,217 +37,10 @@ export const resolveModelExtendParams = (ctx: ModelParamsContext): ModelExtendPa
   )(aiInfraStoreState);
 
   if (!isModelHasExtendParams) {
-    return extendParams;
+    return {};
   }
 
   const modelExtendParams = aiModelSelectors.modelExtendParams(model, provider)(aiInfraStoreState);
 
-  if (!modelExtendParams) {
-    return extendParams;
-  }
-
-  // Reasoning configuration
-  if (modelExtendParams.includes('enableReasoning')) {
-    const enableReasoning = resolveEnableReasoningValue(chatConfig);
-
-    if (enableReasoning) {
-      const thinking: NonNullable<ModelExtendParams['thinking']> = {
-        type: 'enabled',
-      };
-
-      // Determine which budget field to use based on model support
-      let budgetTokens: number | undefined;
-      if (modelExtendParams.includes('reasoningBudgetToken32k')) {
-        budgetTokens = chatConfig.reasoningBudgetToken32k || 1024;
-      } else if (modelExtendParams.includes('reasoningBudgetToken80k')) {
-        budgetTokens = chatConfig.reasoningBudgetToken80k || 1024;
-      } else {
-        budgetTokens = chatConfig.reasoningBudgetToken || 1024;
-      }
-
-      thinking.budget_tokens = budgetTokens;
-      extendParams.thinking = thinking;
-    } else {
-      extendParams.thinking = {
-        budget_tokens: 0,
-        type: 'disabled',
-      };
-    }
-  } else if (modelExtendParams.includes('reasoningBudgetToken32k')) {
-    // For models that only have reasoningBudgetToken32k without enableReasoning
-    extendParams.thinking = {
-      budget_tokens: chatConfig.reasoningBudgetToken32k || 1024,
-      type: 'enabled',
-    };
-  } else if (modelExtendParams.includes('reasoningBudgetToken80k')) {
-    // For models that only have reasoningBudgetToken80k without enableReasoning
-    extendParams.thinking = {
-      budget_tokens: chatConfig.reasoningBudgetToken80k || 1024,
-      type: 'enabled',
-    };
-  } else if (modelExtendParams.includes('reasoningBudgetToken')) {
-    // For models that only have reasoningBudgetToken without enableReasoning
-    extendParams.thinking = {
-      budget_tokens: chatConfig.reasoningBudgetToken || 1024,
-    };
-  }
-
-  // Adaptive thinking (Claude Opus/Sonnet 4.6)
-  if (modelExtendParams.includes('enableAdaptiveThinking')) {
-    if (chatConfig.enableAdaptiveThinking) {
-      extendParams.thinking = {
-        type: 'adaptive',
-      };
-    } else if (!modelExtendParams.includes('enableReasoning')) {
-      // Only disable when the model has no enableReasoning fallback
-      extendParams.thinking = {
-        type: 'disabled',
-      };
-    }
-    // When adaptive is off and model also has enableReasoning, let enableReasoning result stand
-  }
-
-  // Context caching
-  if (modelExtendParams.includes('disableContextCaching') && chatConfig.disableContextCaching) {
-    extendParams.enabledContextCaching = false;
-  }
-
-  // Preserve historical thinking content (provider support required)
-  if (
-    modelExtendParams.includes('preserveThinking') &&
-    typeof chatConfig.preserveThinking === 'boolean'
-  ) {
-    extendParams.preserveThinking = chatConfig.preserveThinking;
-  }
-
-  // Reasoning effort variants
-  if (modelExtendParams.includes('reasoningEffort') && chatConfig.reasoningEffort) {
-    extendParams.reasoning_effort = chatConfig.reasoningEffort;
-  }
-
-  if (modelExtendParams.includes('gpt5ReasoningEffort') && chatConfig.gpt5ReasoningEffort) {
-    extendParams.reasoning_effort = chatConfig.gpt5ReasoningEffort;
-  }
-
-  if (modelExtendParams.includes('gpt5_1ReasoningEffort') && chatConfig.gpt5_1ReasoningEffort) {
-    extendParams.reasoning_effort = chatConfig.gpt5_1ReasoningEffort;
-  }
-
-  if (modelExtendParams.includes('gpt5_2ReasoningEffort') && chatConfig.gpt5_2ReasoningEffort) {
-    extendParams.reasoning_effort = chatConfig.gpt5_2ReasoningEffort;
-  }
-
-  if (
-    modelExtendParams.includes('gpt5_2ProReasoningEffort') &&
-    chatConfig.gpt5_2ProReasoningEffort
-  ) {
-    extendParams.reasoning_effort = chatConfig.gpt5_2ProReasoningEffort;
-  }
-
-  if (modelExtendParams.includes('grok4_20ReasoningEffort') && chatConfig.grok4_20ReasoningEffort) {
-    extendParams.reasoning_effort = chatConfig.grok4_20ReasoningEffort;
-  }
-
-  if (modelExtendParams.includes('grok4_3ReasoningEffort') && chatConfig.grok4_3ReasoningEffort) {
-    extendParams.reasoning_effort = chatConfig.grok4_3ReasoningEffort;
-  }
-
-  if (modelExtendParams.includes('hy3ReasoningEffort') && chatConfig.hy3ReasoningEffort) {
-    extendParams.reasoning_effort = chatConfig.hy3ReasoningEffort;
-  }
-
-  if (modelExtendParams.includes('ring2_6ReasoningEffort') && chatConfig.ring2_6ReasoningEffort) {
-    extendParams.reasoning_effort = chatConfig.ring2_6ReasoningEffort;
-  }
-
-  if (modelExtendParams.includes('codexMaxReasoningEffort') && chatConfig.codexMaxReasoningEffort) {
-    extendParams.reasoning_effort = chatConfig.codexMaxReasoningEffort;
-  }
-
-  // DeepSeek reasoning effort is reconciled last to avoid invalid combinations.
-  if (modelExtendParams.includes('deepseekV4ReasoningEffort')) {
-    const deepseekV4ReasoningEffort = chatConfig.deepseekV4ReasoningEffort;
-
-    if (typeof deepseekV4ReasoningEffort === 'string') {
-      if (deepseekV4ReasoningEffort === 'none') {
-        delete extendParams.reasoning_effort;
-        extendParams.thinking = {
-          type: 'disabled',
-        };
-      } else {
-        extendParams.reasoning_effort = deepseekV4ReasoningEffort;
-        extendParams.thinking = {
-          type: 'enabled',
-        };
-      }
-    }
-  }
-
-  if (modelExtendParams.includes('effort') && chatConfig.effort) {
-    extendParams.effort = chatConfig.effort;
-  }
-
-  if (modelExtendParams.includes('opus47Effort') && chatConfig.opus47Effort) {
-    extendParams.effort = chatConfig.opus47Effort;
-  }
-
-  if (modelExtendParams.includes('step3_5ReasoningEffort') && chatConfig.step3_5ReasoningEffort) {
-    extendParams.reasoning_effort = chatConfig.step3_5ReasoningEffort;
-  }
-
-  // Text verbosity
-  if (modelExtendParams.includes('textVerbosity') && chatConfig.textVerbosity) {
-    extendParams.verbosity = chatConfig.textVerbosity;
-  }
-
-  // Thinking configuration
-  if (modelExtendParams.includes('thinking') && chatConfig.thinking) {
-    extendParams.thinking = { type: chatConfig.thinking };
-  }
-
-  if (modelExtendParams.includes('thinkingBudget') && chatConfig.thinkingBudget !== undefined) {
-    extendParams.thinkingBudget = chatConfig.thinkingBudget;
-  }
-
-  const supportedThinkingLevelParams = modelExtendParams.filter(isThinkingLevelExtendParam);
-
-  for (const supportedThinkingLevelParam of supportedThinkingLevelParams) {
-    const value = chatConfig[supportedThinkingLevelParam];
-
-    if (typeof value === 'string') {
-      extendParams.thinkingLevel = value;
-      break;
-    }
-  }
-
-  if (!extendParams.thinkingLevel && supportedThinkingLevelParams.length > 0) {
-    extendParams.thinkingLevel = resolveThinkingLevelDefault(
-      model,
-      supportedThinkingLevelParams[0],
-    );
-  }
-
-  // URL context
-  if (modelExtendParams.includes('urlContext') && chatConfig.urlContext) {
-    extendParams.urlContext = chatConfig.urlContext;
-  }
-
-  // Image generation params
-  if (modelExtendParams.includes('imageAspectRatio') && chatConfig.imageAspectRatio) {
-    extendParams.imageAspectRatio = chatConfig.imageAspectRatio;
-  }
-
-  if (modelExtendParams.includes('imageAspectRatio2') && chatConfig.imageAspectRatio2) {
-    extendParams.imageAspectRatio = chatConfig.imageAspectRatio2;
-  }
-
-  if (modelExtendParams.includes('imageResolution') && chatConfig.imageResolution) {
-    extendParams.imageResolution = chatConfig.imageResolution;
-  }
-
-  if (modelExtendParams.includes('imageResolution2') && chatConfig.imageResolution2) {
-    extendParams.imageResolution = chatConfig.imageResolution2;
-  }
-
-  return extendParams;
+  return applyModelExtendParams({ chatConfig, extendParams: modelExtendParams, model });
 };


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] ♻️ refactor

#### 🔗 Related Issue

Fixes LOBE-10442

#### 🔀 Description of Change

**Problem:** On the server-driven agent runtime path (e.g. `provider=lobehub`), reasoning/thinking params such as Gemini 3 Pro's `thinkingLevel` were never forwarded to the model, so thought summaries came back empty. The client chat service resolved these via `resolveModelExtendParams`, but the server-side `RuntimeExecutors` had no equivalent step — the two paths had drifted.

**Fix:** Extract the resolution core into a shared, provider/store-agnostic helper so both paths use the same logic.

- Add `applyModelExtendParams` (+ `resolveDefaultThinkingLevelForModel`, `ModelExtendParams` type) to `@lobechat/model-runtime`.
- Client `resolveModelExtendParams` keeps only the aiInfra-store `extendParams` lookup and delegates resolution to the shared core (re-exports kept for back-compat; ~300 lines of duplicated logic removed).
- Server `RuntimeExecutors` reads the model card's `settings.extendParams`, with a **canonical-card fallback by model id** for aggregation providers (e.g. `lobehub`) whose cards don't copy the origin `extendParams` — mirroring the client's `transformToAiModelList` re-namespacing. It then resolves and spreads the params into the runtime payload.

This eliminates the client/server logic drift as a side effect.

#### 🧪 How to Test

Run a Gemini 3 Pro (or other thinking-capable) model through the **server-side agent runtime** path (`provider=lobehub`) with a thinking level configured, and confirm the thought summary is now populated.

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

New unit tests cover `applyModelExtendParams` (`packages/model-runtime/src/utils/modelExtendParams.test.ts`, 7 cases, passing).

#### 📝 Additional Information

The resolved params are spread as `...(resolvedExtendParams as Partial<ChatStreamPayload>)` — `ModelExtendParams` keeps provider-specific effort/thinking values as loose strings (e.g. hy3's `no_think`) which the runtime payload narrows, hence the cast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)