### PR TITLE
🐛 fix(agent-signal): preserve preference memory receipt routing

### DIFF
--- a/apps/server/src/services/agentSignal/policies/analyzeIntent/actions/memoryActionResult.ts
+++ b/apps/server/src/services/agentSignal/policies/analyzeIntent/actions/memoryActionResult.ts
@@ -54,6 +54,17 @@ const MEMORY_WRITE_TARGET_BY_API_NAME: Record<string, { idKey: string; layer: La
   [MemoryApiName.updateIdentityMemory]: { idKey: 'identityId', layer: LayersEnum.Identity },
 };
 const TOOL_NAME_SEPARATOR = '____';
+const DEFAULT_MEMORY_TARGET_TITLE = 'Memory saved';
+
+const getMemoryWriteApiNameFromToolName = (name: unknown) => {
+  const toolName = getString(name);
+  if (!toolName) return;
+
+  const slashIndex = toolName.indexOf('/');
+  const apiName = slashIndex >= 0 ? toolName.slice(slashIndex + 1) : toolName;
+
+  return MEMORY_WRITE_API_NAME_SET.has(apiName) ? apiName : undefined;
+};
 
 const hasSuccessfulMemoryWrite = (state: AgentState) => {
   const byTool = state.usage?.tools?.byTool ?? [];
@@ -70,6 +81,19 @@ const hasFailedMemoryWrite = (state: AgentState) => {
     (entry) =>
       MEMORY_WRITE_TOOL_NAMES.has(entry.name) && entry.calls > 0 && entry.calls === entry.errors,
   );
+};
+
+const getSuccessfulMemoryWriteTargetConfig = (state: AgentState) => {
+  const byTool = state.usage?.tools?.byTool ?? [];
+
+  for (const entry of byTool) {
+    if (entry.calls <= entry.errors) continue;
+
+    const apiName = getMemoryWriteApiNameFromToolName(entry.name);
+    if (!apiName) continue;
+
+    return MEMORY_WRITE_TARGET_BY_API_NAME[apiName];
+  }
 };
 
 const getString = (value: unknown) => {
@@ -257,6 +281,15 @@ export const resolveMemoryActionTargetFromState = (
       if (target) return target;
     }
   }
+
+  const targetConfig = getSuccessfulMemoryWriteTargetConfig(state);
+  if (!targetConfig) return;
+
+  return {
+    memoryLayer: targetConfig.layer,
+    title: DEFAULT_MEMORY_TARGET_TITLE,
+    type: 'memory',
+  };
 };
 
 /**

--- a/apps/server/src/services/agentSignal/services/selfIteration/completion/__test__/buildSelfIterationReceipts.test.ts
+++ b/apps/server/src/services/agentSignal/services/selfIteration/completion/__test__/buildSelfIterationReceipts.test.ts
@@ -1,3 +1,4 @@
+import { LayersEnum } from '@lobechat/types';
 import { describe, expect, it } from 'vitest';
 
 import type { AgentSignalOperationMarker } from '@/server/services/agentSignal/operationMarker';
@@ -65,6 +66,42 @@ describe('buildSelfIterationReceipts', () => {
       id: 'mem_1',
       summary: 'Saved tone preference',
       title: 'Saved tone preference',
+      type: 'memory',
+    });
+  });
+
+  it('preserves structured memory target metadata for layer-specific navigation', () => {
+    const [, memory] = buildSelfIterationReceipts({
+      ...baseInput,
+      mutations: [
+        {
+          apiName: 'writeMemory',
+          data: {
+            kind: 'mutation',
+            resourceId: 'pref_1',
+            status: 'applied',
+            summary: 'Use concise implementation notes.',
+            target: {
+              id: 'pref_1',
+              memoryId: 'mem_1',
+              memoryLayer: LayersEnum.Preference,
+              title: 'Prefers concise implementation notes',
+              type: 'memory',
+            },
+          },
+          kind: 'mutation',
+          toolCallId: 'call_pref',
+        },
+      ],
+    });
+
+    expect(memory.title).toBe('Prefers concise implementation notes');
+    expect(memory.target).toEqual({
+      id: 'pref_1',
+      memoryId: 'mem_1',
+      memoryLayer: LayersEnum.Preference,
+      summary: 'Use concise implementation notes.',
+      title: 'Prefers concise implementation notes',
       type: 'memory',
     });
   });

--- a/apps/server/src/services/agentSignal/services/selfIteration/completion/__test__/completionLoop.integration.test.ts
+++ b/apps/server/src/services/agentSignal/services/selfIteration/completion/__test__/completionLoop.integration.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
+import { LayersEnum } from '@lobechat/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import { createCompletionPolicy } from '../../../../policies/completionPolicy';
@@ -149,7 +150,18 @@ describe('S2 completion loop (policy → handler → projection → persist)', (
         mutations: [
           {
             apiName: 'writeMemory',
-            data: { resourceId: 'mem_1', status: 'applied', summary: 'Saved tone preference' },
+            data: {
+              resourceId: 'pref_1',
+              status: 'applied',
+              summary: 'Saved tone preference',
+              target: {
+                id: 'pref_1',
+                memoryId: 'mem_1',
+                memoryLayer: LayersEnum.Preference,
+                title: 'Tone preference',
+                type: 'memory',
+              },
+            },
             kind: 'mutation',
           },
         ],
@@ -169,7 +181,12 @@ describe('S2 completion loop (policy → handler → projection → persist)', (
     expect(memory.anchorMessageId).toBe('assistant_msg_1');
     expect(memory.triggerMessageId).toBe('user_msg_1');
     expect(memory.topicId).toBe('topic_1');
-    expect(memory.target).toMatchObject({ id: 'mem_1', type: 'memory' });
+    expect(memory.target).toMatchObject({
+      id: 'pref_1',
+      memoryId: 'mem_1',
+      memoryLayer: LayersEnum.Preference,
+      type: 'memory',
+    });
   });
 
   it('no-ops when the completion carries no self-iteration payload (no marker stamped)', async () => {

--- a/apps/server/src/services/agentSignal/services/selfIteration/completion/__test__/extractCompletionPayload.test.ts
+++ b/apps/server/src/services/agentSignal/services/selfIteration/completion/__test__/extractCompletionPayload.test.ts
@@ -1,4 +1,5 @@
 import { MemoryApiName, MemoryIdentifier } from '@lobechat/builtin-tool-memory';
+import { LayersEnum } from '@lobechat/types';
 import { describe, expect, it } from 'vitest';
 
 import { extractSelfIterationCompletionPayload } from '../extractCompletionPayload';
@@ -57,7 +58,7 @@ describe('extractSelfIterationCompletionPayload', () => {
     expect(result?.artifacts).toHaveLength(1);
   });
 
-  it('synthesizes a writeMemory mutation for a memory-kind run from finalState usage', () => {
+  it('synthesizes a writeMemory mutation with a preference target for a memory-kind run', () => {
     const result = extractSelfIterationCompletionPayload(
       buildState(
         {
@@ -66,6 +67,34 @@ describe('extractSelfIterationCompletionPayload', () => {
           userId: 'user_1',
         },
         {
+          messages: [
+            {
+              id: 'msg_preference',
+              role: 'assistant',
+              tool_calls: [
+                {
+                  function: {
+                    arguments: JSON.stringify({
+                      summary: 'Prefer direct implementation with focused tests.',
+                      title: 'Prefers direct implementation',
+                      withPreference: {
+                        conclusionDirectives: 'Prefer direct implementation with focused tests.',
+                      },
+                    }),
+                    name: `${MemoryIdentifier}____${MemoryApiName.addPreferenceMemory}`,
+                  },
+                  id: 'call_preference',
+                  type: 'function',
+                },
+              ],
+            },
+            {
+              content:
+                'Preference memory "Prefers direct implementation" saved with memoryId: "mem_1" and preferenceId: "pref_1"',
+              role: 'tool',
+              tool_call_id: 'call_preference',
+            },
+          ],
           status: 'finished',
           usage: {
             tools: {
@@ -87,6 +116,48 @@ describe('extractSelfIterationCompletionPayload', () => {
     expect(result?.mutations).toHaveLength(1);
     expect(result?.mutations[0].apiName).toBe('writeMemory');
     expect((result?.mutations[0].data as { status?: string }).status).toBe('applied');
+    expect((result?.mutations[0].data as { resourceId?: string }).resourceId).toBe('pref_1');
+    expect((result?.mutations[0].data as { target?: Record<string, unknown> }).target).toEqual({
+      id: 'pref_1',
+      memoryId: 'mem_1',
+      memoryLayer: LayersEnum.Preference,
+      summary: 'Prefer direct implementation with focused tests.',
+      title: 'Prefers direct implementation',
+      type: 'memory',
+    });
+  });
+
+  it('falls back to the successful memory tool api when finalState lacks tool call details', () => {
+    const result = extractSelfIterationCompletionPayload(
+      buildState(
+        {
+          agentId: 'agent_user_1',
+          agentSignal: { kind: 'memory', sourceId: 'mem-src_fallback' },
+          userId: 'user_1',
+        },
+        {
+          status: 'finished',
+          usage: {
+            tools: {
+              byTool: [
+                {
+                  calls: 1,
+                  errors: 0,
+                  name: `${MemoryIdentifier}/${MemoryApiName.addPreferenceMemory}`,
+                },
+              ],
+            },
+          },
+        },
+      ),
+    );
+
+    expect(result?.mutations).toHaveLength(1);
+    expect((result?.mutations[0].data as { target?: Record<string, unknown> }).target).toEqual({
+      memoryLayer: LayersEnum.Preference,
+      title: 'Memory saved',
+      type: 'memory',
+    });
   });
 
   it('yields no memory mutation when the memory run did not apply a write', () => {

--- a/apps/server/src/services/agentSignal/services/selfIteration/completion/buildSelfIterationReceipts.ts
+++ b/apps/server/src/services/agentSignal/services/selfIteration/completion/buildSelfIterationReceipts.ts
@@ -1,3 +1,5 @@
+import { LayersEnum } from '@lobechat/types';
+
 import type { AgentSignalOperationMarker } from '@/server/services/agentSignal/operationMarker';
 
 import type { AgentSignalReceipt } from '../../receiptService';
@@ -52,6 +54,9 @@ const str = (value: unknown): string | undefined =>
 /** A `skipped_unsupported` / `skipped_stale` tool status collapses to `skipped`. */
 const isSkippedStatus = (status: unknown): boolean =>
   typeof status === 'string' && status.startsWith('skipped');
+
+const isMemoryLayer = (value: unknown): value is LayersEnum =>
+  Object.values(LayersEnum).includes(value as LayersEnum);
 
 export interface BuildSelfIterationReceiptsInput {
   agentId: string;
@@ -151,9 +156,15 @@ export const buildSelfIterationReceipts = (
       ? 'skipped'
       : (SUCCESS_STATUS_BY_API[apiName] ?? 'applied');
 
+    const target = isRecord(data.target) ? data.target : undefined;
+    const targetId = str(target?.id) ?? str(data.resourceId);
+    const memoryId = kind === 'memory' ? str(target?.memoryId) : undefined;
+    const memoryLayer =
+      kind === 'memory' && isMemoryLayer(target?.memoryLayer) ? target.memoryLayer : undefined;
     const summaryText = str(data.summary);
-    const resourceId = str(data.resourceId);
-    const title = summaryText ?? DEFAULT_TITLE_BY_API[apiName] ?? 'Agent Signal action';
+    const targetTitle = str(target?.title);
+    const title =
+      targetTitle ?? summaryText ?? DEFAULT_TITLE_BY_API[apiName] ?? 'Agent Signal action';
 
     return [
       {
@@ -172,7 +183,9 @@ export const buildSelfIterationReceipts = (
           ? {}
           : {
               target: {
-                ...(resourceId ? { id: resourceId } : {}),
+                ...(targetId ? { id: targetId } : {}),
+                ...(memoryId ? { memoryId } : {}),
+                ...(memoryLayer ? { memoryLayer } : {}),
                 ...(summaryText ? { summary: summaryText } : {}),
                 title,
                 type: kind,

--- a/apps/server/src/services/agentSignal/services/selfIteration/completion/extractCompletionPayload.ts
+++ b/apps/server/src/services/agentSignal/services/selfIteration/completion/extractCompletionPayload.ts
@@ -49,9 +49,10 @@ const extractMemoryMutations = (finalState: AgentState): ToolResultWithKind[] =>
       apiName: 'writeMemory',
       data: {
         kind: 'mutation',
+        ...(result.target ? { target: result.target } : {}),
         resourceId: result.target?.id ?? result.target?.memoryId,
         status: 'applied',
-        summary: result.detail,
+        summary: result.detail ?? result.target?.summary,
       },
       kind: 'mutation',
     },

--- a/src/features/Conversation/ChatList/components/AgentSignalReceiptList.test.tsx
+++ b/src/features/Conversation/ChatList/components/AgentSignalReceiptList.test.tsx
@@ -247,7 +247,7 @@ describe('AgentSignalReceiptList', () => {
             sourceType: 'client.gateway.runtime_end',
             status: 'applied',
             target: {
-              title: 'Decision-first PR review preference',
+              title: 'Remember this PR review workflow',
               type: 'memory',
             },
             title: 'Memory saved',
@@ -258,9 +258,44 @@ describe('AgentSignalReceiptList', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /Decision-first PR review preference/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Remember this PR review workflow/ }));
 
     expect(mocks.navigate).toHaveBeenCalledWith('/memory');
+  });
+
+  it('opens legacy preference memory receipts without layer metadata on the preferences route', () => {
+    render(
+      <AgentSignalReceiptList
+        receipts={[
+          {
+            agentId: 'agent-1',
+            createdAt: 1,
+            detail: 'Saved this for future replies',
+            id: 'receipt-1',
+            kind: 'memory',
+            sourceId: 'source-1',
+            sourceType: 'client.gateway.runtime_end',
+            status: 'applied',
+            target: {
+              id: 'base-memory-1',
+              title: 'AmAzing- prefers the assistant to respond in Chinese.',
+              type: 'memory',
+            },
+            title: 'Memory saved',
+            topicId: 'topic-1',
+            userId: 'user-1',
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /AmAzing- prefers the assistant to respond in Chinese./,
+      }),
+    );
+
+    expect(mocks.navigate).toHaveBeenCalledWith('/memory/preferences');
   });
 
   it('opens memory receipts on their layer detail route when target metadata is available', () => {

--- a/src/features/Conversation/ChatList/components/AgentSignalReceiptList.tsx
+++ b/src/features/Conversation/ChatList/components/AgentSignalReceiptList.tsx
@@ -39,6 +39,8 @@ const RECEIPT_LUCIDE_ICON_BY_KIND = {
   review: ClipboardCheck,
 } as const satisfies Partial<Record<AgentSignalReceiptView['kind'], LucideIcon>>;
 
+const LEGACY_PREFERENCE_MEMORY_PATTERN = /\bprefer(?:s|red|ence)?\b|偏好|喜好/i;
+
 const renderReceiptIcon = (kind: AgentSignalReceiptView['kind']) => {
   if (kind === 'skill') return <SkillsIcon size={28} />;
   const LucideIconComponent = RECEIPT_LUCIDE_ICON_BY_KIND[kind];
@@ -56,12 +58,23 @@ interface AgentSignalReceiptItemProps {
 const getMemoryRoute = (target?: AgentSignalReceiptView['target']) => {
   if (target?.type !== 'memory') return;
 
-  if (!target.memoryLayer) return '/memory';
+  const hasLayerMetadata = Boolean(target.memoryLayer);
+  const memoryLayer =
+    target.memoryLayer ??
+    (LEGACY_PREFERENCE_MEMORY_PATTERN.test(`${target.title} ${target.summary ?? ''}`)
+      ? LayersEnum.Preference
+      : undefined);
 
-  const route = MEMORY_ROUTE_BY_LAYER[target.memoryLayer];
+  if (!memoryLayer) return '/memory';
+
+  const route = MEMORY_ROUTE_BY_LAYER[memoryLayer];
   if (!route) return '/memory';
 
-  return target.id ? `${route.path}?${route.idParam}=${encodeURIComponent(target.id)}` : route.path;
+  const layerSpecificId = hasLayerMetadata ? target.id : undefined;
+
+  return layerSpecificId
+    ? `${route.path}?${route.idParam}=${encodeURIComponent(layerSpecificId)}`
+    : route.path;
 };
 
 const AgentSignalReceiptItem = memo<AgentSignalReceiptItemProps>(({ receipt }) => {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None found.

#### 🔀 Description of Change

This PR fixes Agent Signal receipt routing for preference memory updates. The async completion path now preserves structured memory targets, including `memoryLayer`, `memoryId`, and preference ids, so new preference-memory receipts route to `/memory/preferences` instead of the generic memory page.

It also adds a conservative frontend fallback for existing memory receipts that were created without `memoryLayer`, so known preference receipts can still open the preference memory detail page.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validated with:

```bash
bunx vitest run --silent='passed-only' src/features/Conversation/ChatList/components/AgentSignalReceiptList.test.tsx apps/server/src/services/agentSignal/services/selfIteration/completion/__test__/extractCompletionPayload.test.ts apps/server/src/services/agentSignal/services/selfIteration/completion/__test__/buildSelfIterationReceipts.test.ts apps/server/src/services/agentSignal/services/selfIteration/completion/__test__/completionLoop.integration.test.ts apps/server/src/services/agentSignal/policies/analyzeIntent/actions/__tests__/userMemory.test.ts
pnpm exec eslint apps/server/src/services/agentSignal/policies/analyzeIntent/actions/memoryActionResult.ts apps/server/src/services/agentSignal/services/selfIteration/completion/extractCompletionPayload.ts apps/server/src/services/agentSignal/services/selfIteration/completion/buildSelfIterationReceipts.ts src/features/Conversation/ChatList/components/AgentSignalReceiptList.tsx --concurrency=auto
pnpm exec prettier --check apps/server/src/services/agentSignal/policies/analyzeIntent/actions/memoryActionResult.ts apps/server/src/services/agentSignal/services/selfIteration/completion/extractCompletionPayload.ts apps/server/src/services/agentSignal/services/selfIteration/completion/buildSelfIterationReceipts.ts src/features/Conversation/ChatList/components/AgentSignalReceiptList.tsx
```

Browser verification:

- Opened the debug proxy locally.
- Checked topic `tpc_lq1GPrrV4nKb`.
- Confirmed the preference memory signal card opens `/memory/preferences?preferenceId=mem_9phUzjWs7WI5`.

#### 📸 Screenshots / Videos

N/A. This changes routing behavior and was verified in the browser.

#### 📝 Additional Information

The working tree has unrelated unstaged local edits outside this PR. They were not staged, committed, or included in this branch diff.