### PR TITLE
🐛 fix(chat): show cached message refresh hint

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -44,6 +44,7 @@
   "builtinCopilot": "Built-in Copilot",
   "chatList.expandMessage": "Expand Message",
   "chatList.longMessageDetail": "View Details",
+  "chatList.refreshing": "Fetching latest messages...",
   "chatMode.agent": "Agent",
   "chatMode.agentCap.env": "Runtime env",
   "chatMode.agentCap.files": "File access",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -44,6 +44,7 @@
   "builtinCopilot": "内置 Copilot",
   "chatList.expandMessage": "展开消息",
   "chatList.longMessageDetail": "查看详情",
+  "chatList.refreshing": "正在获取最新消息...",
   "chatMode.agent": "智能",
   "chatMode.agentCap.env": "运行环境",
   "chatMode.agentCap.files": "文件访问",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -53,6 +53,7 @@ export default {
   'builtinCopilot': 'Built-in Copilot',
   'chatList.expandMessage': 'Expand Message',
   'chatList.longMessageDetail': 'View Details',
+  'chatList.refreshing': 'Fetching latest messages...',
   'clearCurrentMessages': 'Clear current session messages',
   'compressedHistory': 'Compressed History',
   'compression.cancel': 'Uncompress',

--- a/src/features/ChatInput/Desktop/AgentModeNotice.test.tsx
+++ b/src/features/ChatInput/Desktop/AgentModeNotice.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AgentModeNotice from './AgentModeNotice';
+
+interface TestModel {
+  abilities?: {
+    functionCall?: boolean;
+  };
+  id: string;
+  providerId: string;
+}
+
+const testState = vi.hoisted(() => ({
+  agent: {
+    enableAgentMode: true,
+    model: 'gpt-4o',
+    provider: 'openai',
+  },
+  aiInfra: {
+    enabledAiModels: [] as TestModel[],
+    isInitAiProviderRuntimeState: false,
+  },
+}));
+
+type StoreSelector<T = unknown, S = Record<PropertyKey, unknown>> = (state: S) => T;
+
+vi.mock('@lobehub/ui', () => ({
+  Alert: ({ title }: { title: ReactNode }) => <div role="alert">{title}</div>,
+}));
+
+vi.mock('antd-style', () => ({
+  createStaticStyles: () => ({ alert: 'alert' }),
+  cx: (...classes: string[]) => classes.filter(Boolean).join(' '),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/features/ChatInput/hooks/useAgentId', () => ({
+  useAgentId: () => 'agent-id',
+}));
+
+vi.mock('@/store/agent', () => ({
+  useAgentStore: <T,>(selector: StoreSelector<T, typeof testState.agent>) =>
+    selector(testState.agent),
+}));
+
+vi.mock('@/store/agent/selectors', () => ({
+  agentByIdSelectors: {
+    getAgentEnableModeById: () => (s: typeof testState.agent) => s.enableAgentMode,
+    getAgentModelById: () => (s: typeof testState.agent) => s.model,
+    getAgentModelProviderById: () => (s: typeof testState.agent) => s.provider,
+  },
+}));
+
+vi.mock('@/store/aiInfra', () => ({
+  aiModelSelectors: {
+    isModelSupportToolUse: (model: string, provider: string) => (s: typeof testState.aiInfra) =>
+      s.enabledAiModels.find((item) => item.id === model && item.providerId === provider)?.abilities
+        ?.functionCall || false,
+  },
+  aiProviderSelectors: {
+    isInitAiProviderRuntimeState: (s: typeof testState.aiInfra) => s.isInitAiProviderRuntimeState,
+  },
+  useAiInfraStore: <T,>(selector: StoreSelector<T, typeof testState.aiInfra>) =>
+    selector(testState.aiInfra),
+}));
+
+describe('AgentModeNotice', () => {
+  beforeEach(() => {
+    testState.agent.enableAgentMode = true;
+    testState.agent.model = 'gpt-4o';
+    testState.agent.provider = 'openai';
+    testState.aiInfra.enabledAiModels = [];
+    testState.aiInfra.isInitAiProviderRuntimeState = false;
+  });
+
+  it('does not render before the model runtime config is ready', () => {
+    render(<AgentModeNotice />);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders after the model runtime config is ready when the model lacks tool use', () => {
+    testState.aiInfra.isInitAiProviderRuntimeState = true;
+    testState.aiInfra.enabledAiModels = [
+      { abilities: { functionCall: false }, id: 'gpt-4o', providerId: 'openai' },
+    ];
+
+    render(<AgentModeNotice />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent('input.agentModeUnsupportedModel');
+  });
+
+  it('does not render when the ready model supports tool use', () => {
+    testState.aiInfra.isInitAiProviderRuntimeState = true;
+    testState.aiInfra.enabledAiModels = [
+      { abilities: { functionCall: true }, id: 'gpt-4o', providerId: 'openai' },
+    ];
+
+    render(<AgentModeNotice />);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('does not render when agent mode is disabled', () => {
+    testState.agent.enableAgentMode = false;
+    testState.aiInfra.isInitAiProviderRuntimeState = true;
+    testState.aiInfra.enabledAiModels = [
+      { abilities: { functionCall: false }, id: 'gpt-4o', providerId: 'openai' },
+    ];
+
+    render(<AgentModeNotice />);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/ChatInput/Desktop/AgentModeNotice.tsx
+++ b/src/features/ChatInput/Desktop/AgentModeNotice.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
-import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
+import { aiModelSelectors, aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 
 const styles = createStaticStyles(({ css }) => ({
   alert: css`
@@ -38,9 +38,12 @@ const AgentModeNotice = memo(() => {
     agentByIdSelectors.getAgentModelProviderById(agentId)(s),
   ]);
 
-  const supportToolUse = useAiInfraStore(aiModelSelectors.isModelSupportToolUse(model, provider));
+  const [isModelConfigReady, supportToolUse] = useAiInfraStore((s) => [
+    aiProviderSelectors.isInitAiProviderRuntimeState(s),
+    aiModelSelectors.isModelSupportToolUse(model, provider)(s),
+  ]);
 
-  if (!enableAgentMode || supportToolUse) return null;
+  if (!enableAgentMode || !isModelConfigReady || supportToolUse) return null;
 
   return (
     <Alert

--- a/src/features/Conversation/ChatList/components/RefreshingHint.tsx
+++ b/src/features/Conversation/ChatList/components/RefreshingHint.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Flexbox } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  container: css`
+    pointer-events: none;
+
+    min-height: 16px;
+    padding-block: 0 10px;
+
+    font-size: 12px;
+    line-height: 16px;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  loader: css`
+    opacity: 0.58;
+  `,
+}));
+
+const RefreshingHint = memo(() => {
+  const { t } = useTranslation('chat');
+
+  return (
+    <Flexbox
+      horizontal
+      align={'center'}
+      aria-live={'polite'}
+      className={styles.container}
+      gap={6}
+      justify={'center'}
+      role={'status'}
+    >
+      <span className={styles.loader}>
+        <NeuralNetworkLoading size={12} />
+      </span>
+      <span>{t('chatList.refreshing')}</span>
+    </Flexbox>
+  );
+});
+
+RefreshingHint.displayName = 'ConversationRefreshingHint';
+
+export default RefreshingHint;

--- a/src/features/Conversation/ChatList/index.tsx
+++ b/src/features/Conversation/ChatList/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { type ReactNode } from 'react';
-import { memo, useCallback } from 'react';
+import type { ReactNode } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 
 import { useFetchAgentDocuments } from '@/hooks/useFetchAgentDocuments';
 import { useFetchTopicMemories } from '@/hooks/useFetchMemoryForTopic';
@@ -19,6 +19,7 @@ import type { WorkflowExpandLevelDefault } from '../Messages/AssistantGroup/comp
 import { MessageActionProvider } from '../Messages/Contexts/MessageActionProvider';
 import { dataSelectors, useConversationStore } from '../store';
 import AgentSignalReceiptList from './components/AgentSignalReceiptList';
+import RefreshingHint from './components/RefreshingHint';
 import VirtualizedList from './components/VirtualizedList';
 import { useAgentSignalReceipts } from './hooks/useAgentSignalReceipts';
 
@@ -92,7 +93,7 @@ const ChatList = memo<ChatListProps>(
     // assistant placeholder.
     const isStreaming = useChatStore(operationSelectors.isAgentRuntimeRunningByContext(context));
     const { enableAgentSelfIteration } = useServerConfigStore(featureFlagsSelectors);
-    useFetchMessages(context, { revalidateOnFocus: !isStreaming, skipFetch });
+    const messagesSWR = useFetchMessages(context, { revalidateOnFocus: !isStreaming, skipFetch });
     const displayMessages = useConversationStore(dataSelectors.displayMessages);
     const displayMessageIds = useConversationStore(dataSelectors.displayMessageIds);
     const latestMessageId = displayMessageIds.at(-1);
@@ -138,6 +139,23 @@ const ChatList = memo<ChatListProps>(
       [displayMessageIds.length, defaultWorkflowExpandLevel, receiptsByAnchor],
     );
     const messagesInit = useConversationStore(dataSelectors.messagesInit);
+    const showRefreshingHint =
+      messagesInit &&
+      displayMessageIds.length > 0 &&
+      messagesSWR.isValidating &&
+      !messagesSWR.isLoading &&
+      !isStreaming;
+
+    const mergedFooterSlot = useMemo(() => {
+      if (!showRefreshingHint && !footerSlot) return;
+
+      return (
+        <>
+          {showRefreshingHint && <RefreshingHint />}
+          {footerSlot}
+        </>
+      );
+    }, [footerSlot, showRefreshingHint]);
 
     // When topicId is null (new conversation), show welcome directly without waiting for fetch
     // because there's no server data to fetch - only local optimistic updates exist
@@ -167,7 +185,7 @@ const ChatList = memo<ChatListProps>(
       <MessageActionProvider withSingletonActionsBar={!disableActionsBar}>
         <VirtualizedList
           dataSource={displayMessageIds}
-          footerSlot={footerSlot}
+          footerSlot={mergedFooterSlot}
           headerSlot={headerSlot}
           itemContent={itemContent ?? defaultItemContent}
         />

--- a/src/features/Conversation/ChatList/index.tsx
+++ b/src/features/Conversation/ChatList/index.tsx
@@ -139,12 +139,9 @@ const ChatList = memo<ChatListProps>(
       [displayMessageIds.length, defaultWorkflowExpandLevel, receiptsByAnchor],
     );
     const messagesInit = useConversationStore(dataSelectors.messagesInit);
+    // ConversationArea can render store-backed cached messages before SWR has local data.
     const showRefreshingHint =
-      messagesInit &&
-      displayMessageIds.length > 0 &&
-      messagesSWR.isValidating &&
-      !messagesSWR.isLoading &&
-      !isStreaming;
+      messagesInit && displayMessageIds.length > 0 && messagesSWR.isValidating && !isStreaming;
 
     const mergedFooterSlot = useMemo(() => {
       if (!showRefreshingHint && !footerSlot) return;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Show a subtle refresh hint at the bottom of the conversation when cached messages are visible and SWR is revalidating.
- Keep the hint out of initial loading, empty, and active streaming states.
- Add localized copy for `chatList.refreshing` in default, en-US, and zh-CN locales.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx eslint src/features/Conversation/ChatList/index.tsx src/features/Conversation/ChatList/components/RefreshingHint.tsx
git diff --check
bunx vitest run --silent='passed-only' src/features/Conversation/store/slices/data/action.test.ts
```

#### 📸 Screenshots / Videos

N/A - small inline status hint only.

#### 📝 Additional Information

The PR branch was cut cleanly from `origin/canary`; unrelated local `AgentModeNotice` work in the original worktree was not included.
