### PR TITLE
🐛 fix(desktop): remove web onboarding aliases

### DIFF
--- a/src/spa/router/desktopRouter.config.desktop.tsx
+++ b/src/spa/router/desktopRouter.config.desktop.tsx
@@ -747,28 +747,11 @@ export const desktopRoutes: RouteObject[] = [
     : []),
 ];
 
-// Desktop onboarding route (Electron only in .desktop.tsx)
+// Desktop owns its onboarding flow. Web-only onboarding routes are intentionally
+// absent from Electron so personal onboarding redirects fail visibly instead of
+// looping back into desktop login.
 desktopRoutes.push({
   element: <DesktopOnboarding />,
   errorElement: <ErrorBoundary />,
   path: '/desktop-onboarding',
-});
-
-// Web onboarding aliases redirect to the desktop-specific onboarding flow.
-desktopRoutes.push({
-  element: redirectElement('/desktop-onboarding'),
-  errorElement: <ErrorBoundary />,
-  path: '/onboarding',
-});
-
-desktopRoutes.push({
-  element: redirectElement('/desktop-onboarding'),
-  errorElement: <ErrorBoundary />,
-  path: '/onboarding/agent',
-});
-
-desktopRoutes.push({
-  element: redirectElement('/desktop-onboarding'),
-  errorElement: <ErrorBoundary />,
-  path: '/onboarding/classic',
 });

--- a/src/spa/router/desktopRouter.sync.test.tsx
+++ b/src/spa/router/desktopRouter.sync.test.tsx
@@ -14,6 +14,8 @@ const KNOWN_DIVERGENCES: Record<string, string> = {
   '/desktop-onboarding': '/onboarding',
 };
 
+const WEB_ONLY_PATHS = new Set(['/onboarding', '/onboarding/agent', '/onboarding/classic']);
+
 function extractIndexCount(source: string) {
   return [...source.matchAll(/index:\s*true/g)].length;
 }
@@ -48,7 +50,9 @@ function extractPaths(source: string) {
 }
 
 function normalizePaths(paths: string[]) {
-  return [...new Set(paths.map((path) => KNOWN_DIVERGENCES[path] ?? path))].sort();
+  return [...new Set(paths.map((path) => KNOWN_DIVERGENCES[path] ?? path))]
+    .filter((path) => !WEB_ONLY_PATHS.has(path))
+    .sort();
 }
 
 async function readDesktopRouterSources() {


### PR DESCRIPTION
## Summary
- Remove the Web-only onboarding route aliases from the Electron desktop router.
- Keep only /desktop-onboarding in the Electron sync route tree.
- Teach the desktop router sync test that /onboarding, /onboarding/agent, and /onboarding/classic are web-only paths.
- Verified from the installed 2.2.4 app asar that useUserStateRedirect compiles to desktopRedirect, so this is not an isDesktop injection failure.

## Why
When Cloud personal onboarding logic navigates to /onboarding in Electron, the previous route alias translated it to /desktop-onboarding and sent returning users back to the desktop login screen. Removing the aliases stops the Web-only onboarding path from being converted into the desktop login flow. If that redirect source still fires, the desktop catch-all route will expose it as a normal unmatched-path redirect back to / instead of entering /desktop-onboarding.

## Test
- bunx eslint src/spa/router/desktopRouter.config.desktop.tsx src/spa/router/desktopRouter.sync.test.tsx
- git diff --check origin/canary
- node static route parity check: missingInSync=[], extraInSync=[]
- Attempted: bunx vitest run --silent=passed-only src/spa/router/desktopRouter.sync.test.tsx; blocked by local worktree dependency resolution where packages/builtin-tool-agent-builder resolves through the sibling lobe-chat worktree and cannot resolve @/services/agent.