### PR TITLE
chore: remove LOBE-XXX markers from code comments (2026-06-16)

### DIFF
--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -104,7 +104,7 @@ const ASYNC_TOOL_VERIFY_DELAY_MS = 15_000;
  * shot) so a transient miss — a read-replica lag, a sibling dying between
  * backfill and resume — is retried rather than leaving the parent stuck in
  * `waiting_for_async_tool` forever. With exponential backoff from a 15s base,
- * 5 attempts span ~15s → ~7.75min total before giving up. See LOBE-10385.
+ * 5 attempts span ~15s → ~7.75min total before giving up. For details see: async sub-agent suspend/resume stability hardening — bounded watchdog retry with exponential backoff instead of single-shot verification.
  */
 const ASYNC_TOOL_VERIFY_MAX_ATTEMPTS = 5;
 
@@ -645,7 +645,7 @@ export class AgentRuntimeService {
     // CAS guarantees at most one real resume regardless of how many checks run.
     // Opt back into `scheduleVerifyOnHold` with the next attempt so an
     // unsatisfied barrier re-arms (bounded backoff) instead of giving up after
-    // a single shot — the core LOBE-10385 fix.
+    // a single shot — bounded watchdog retry ensures transient misses are recovered.
     if (verifyAsyncToolBarrier) {
       const attempt = asyncToolVerifyAttempt ?? 1;
       log(
@@ -1832,7 +1832,7 @@ export class AgentRuntimeService {
    * miss (read-replica lag, a sibling dying between backfill and resume) is thus
    * retried instead of permanently stranding the parent. Once attempts are
    * exhausted the chain stops and the `verify_exhausted` metric fires so the
-   * orphan is observable. See LOBE-10385.
+   * orphan is observable. For details see: async sub-agent suspend/resume stability hardening — bounded watchdog retry with exponential backoff.
    */
   private async maybeScheduleAsyncToolVerify(
     parentOperationId: string,

--- a/packages/model-runtime/src/utils/modelExtendParams.test.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.test.ts
@@ -25,7 +25,7 @@ describe('applyModelExtendParams', () => {
     ).toEqual({});
   });
 
-  // LOBE-10442: Gemini 3 Pro via the agent path billed reasoning tokens but
+  // Gemini 3 Pro via the agent path (provider=lobehub) billed reasoning tokens but
   // returned empty thinking summaries because thinkingLevel never reached the
   // request. With the model's extendParams present, thinkingLevel must default
   // to 'high' even when the chat config does not set thinkingLevel3.

--- a/packages/observability-otel/src/modules/agent-runtime/index.ts
+++ b/packages/observability-otel/src/modules/agent-runtime/index.ts
@@ -23,7 +23,7 @@ export const tracer = trace.getTracer('@lobechat/agent-runtime', '0.0.1');
  *
  * Lets orphaned `waiting_for_async_tool` parents be detected via the
  * `barrier_held` / `no_pending` / `verify_exhausted` series instead of
- * accumulating silently. See LOBE-10385.
+ * accumulating silently. For details see: async sub-agent suspend/resume stability hardening — bounded watchdog retry with exponential backoff.
  */
 export const asyncToolResumeCounter = meter.createCounter('agent_runtime_async_tool_resume_total', {
   description: 'Count of async sub-agent parent resume attempts grouped by outcome.',

--- a/src/store/chat/slices/aiChat/actions/runLifecycle/buildRunLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/runLifecycle/buildRunLifecycle.ts
@@ -22,7 +22,7 @@ import type { AgentRunLifecycle, RunCompleteEvent, RunCompleteResult, RunScope }
  * `client.runtime.complete` signal status. Relocated verbatim from
  * `streamingExecutor` — kept identical for behavior preservation.
  *
- * NOTE (LOBE-10382): `waiting_for_human` is encoded as `cancelled` and
+ * NOTE: `waiting_for_human` is encoded as `cancelled` (a parked state mis-encoded as terminal) and
  * `waiting_for_async_tool` falls through to `undefined`. Both are parked, not
  * terminal — this mis-encoding is locked by characterization tests and fixed
  * when the parked/resumed signal is unified.
@@ -88,10 +88,10 @@ const NOOP = async () => {};
 /**
  * Assemble the store/UI run-lifecycle hooks for a single run.
  *
- * Phase 1 (LOBE-10378, behavior-preserving): the implementations are the CLIENT
+ * Phase 1 (behavior-preserving): the implementations are the CLIENT
  * completion effects relocated verbatim from `streamingExecutor`, so wiring the
  * client executor to these hooks keeps the characterization net green. The
- * gateway/hetero adapters are wired in LOBE-10379, where the currently-missing
+ * gateway/hetero adapters are wired in the follow-up transport unification, where the currently-missing
  * effects (title / notification / queue on gateway) are folded in.
  */
 export const buildRunLifecycle = (

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -753,7 +753,7 @@ export class StreamingExecutorActionImpl {
       stepCount,
     );
 
-    // Run-completion side effects are assembled once (LOBE-10378) and invoked at
+    // Run-completion side effects are assembled once and invoked at
     // this boundary. The bodies are relocated verbatim into `buildRunLifecycle`,
     // so the streamingExecutor characterization net stays green (behavior-preserving).
     const runScope: RunScope = scope === 'sub_agent' ? 'sub_agent' : 'top_level';


### PR DESCRIPTION
## Summary

Remove LOBE-XXX ticket reference markers from code comments and replace them with descriptive context drawn from the corresponding Linear issues. These markers served as internal tracking anchors during development but are inappropriate for the open-source codebase.

## Files Changed

| File | Changes |
|------|---------|
| `apps/server/src/services/agentRuntime/AgentRuntimeService.ts` | 3 references to LOBE-10385 → async sub-agent suspend/resume stability hardening context |
| `packages/observability-otel/src/modules/agent-runtime/index.ts` | 1 reference to LOBE-10385 → same async sub-agent context |
| `src/store/chat/slices/aiChat/actions/runLifecycle/buildRunLifecycle.ts` | LOBE-10378/10379/10382 → run lifecycle contract and transport unification context |
| `src/store/chat/slices/aiChat/actions/streamingExecutor.ts` | LOBE-10378 reference removed |
| `packages/model-runtime/src/utils/modelExtendParams.test.ts` | LOBE-10442 → Gemini 3 Pro reasoning token forwarding context |

## Details

Each LOBE-XXX marker has been replaced with a descriptive sentence summarizing the issue context:

- **LOBE-10385**: Async sub-agent suspend/resume stability hardening — bounded watchdog retry with exponential backoff instead of single-shot verification
- **LOBE-10382**: `waiting_for_human` is a parked state mis-encoded as terminal `cancelled`
- **LOBE-10378**: Client run-completion effects refactored into `buildRunLifecycle`
- **LOBE-10379**: Gateway/hetero transport unification follow-up for lifecycle hooks
- **LOBE-10442**: Gemini 3 Pro (provider=lobehub) thinkingLevel never reached the request, causing empty reasoning summaries despite billed tokens

Automated daily scan on 2026-06-16.