### PR TITLE
🐛 fix(file-upload): match leading `**/` gitignore patterns at root

### DIFF
--- a/src/utils/gitignore.test.ts
+++ b/src/utils/gitignore.test.ts
@@ -62,6 +62,16 @@ node_modules/
       expect(shouldIgnoreFile('folder/.DS_Store', ['.DS_Store'])).toBe(true);
     });
 
+    it('should match leading "**/" patterns at any depth, including the root', () => {
+      // Per gitignore spec a leading `**/` matches in all directories, so
+      // `**/foo` is equivalent to `foo` and must also match at the root.
+      expect(shouldIgnoreFile('node_modules/index.js', ['**/node_modules'])).toBe(true);
+      expect(shouldIgnoreFile('src/node_modules/index.js', ['**/node_modules'])).toBe(true);
+      expect(shouldIgnoreFile('build.log', ['**/*.log'])).toBe(true);
+      expect(shouldIgnoreFile('src/build.log', ['**/*.log'])).toBe(true);
+      expect(shouldIgnoreFile('src/main.ts', ['**/*.log'])).toBe(false);
+    });
+
     it('should handle negation patterns', () => {
       const patterns = ['*.log', '!important.log'];
       expect(shouldIgnoreFile('test.log', patterns)).toBe(true);

--- a/src/utils/gitignore.ts
+++ b/src/utils/gitignore.ts
@@ -39,6 +39,14 @@ const gitignorePatternToRegex = (pattern: string): RegExp => {
     regexPattern = regexPattern.slice(1);
   }
 
+  // A leading `**/` matches in all directories per the gitignore spec:
+  // `**/foo` is equivalent to `foo` and must also match at the root. Strip it
+  // so the remainder anchors with `(^|/)` instead of requiring (via `.*/`) at
+  // least one parent directory, which would miss root-level matches.
+  if (regexPattern.startsWith('**/') && regexPattern.length > 3) {
+    regexPattern = regexPattern.slice(3);
+  }
+
   // Escape special regex characters except *, ?, and /
   regexPattern = regexPattern.replaceAll(/[$()+.[\\\]^{|}]/g, '\\$&');
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

The folder-upload `.gitignore` filter (`src/utils/gitignore.ts`) mishandles patterns that start with `**/`.

Per the [gitignore spec](https://git-scm.com/docs/gitignore#_pattern_format):

> A leading `**/` followed by a slash means match in all directories. For example, `**/foo` matches file or directory `foo` anywhere, the same as pattern `foo`.

`gitignorePatternToRegex` translates `**` to `.*`, so `**/foo` becomes `(^|/).*/foo(/|$)`. The `.*/` requires at least one parent directory, so the pattern only matches **nested** paths and silently misses root-level entries. As a result, very common patterns fail during folder uploads:

- `**/node_modules` does **not** ignore root `node_modules/index.js`
- `**/*.log` does **not** ignore root `build.log`

The fix strips a leading `**/` from the pattern so the remainder anchors with `(^|/)` (the existing "match in any directory" behavior), which correctly matches both root and nested paths. Behavior of all other pattern shapes (`*.log`, `node_modules/`, `.DS_Store`, `/build`, negation, mid-pattern `**`) is unchanged.

#### 🧪 How to Test

```bash
bunx vitest run --silent='passed-only' src/utils/gitignore.test.ts
```

Added a regression case under `shouldIgnoreFile`:

```ts
expect(shouldIgnoreFile('node_modules/index.js', ['**/node_modules'])).toBe(true);
expect(shouldIgnoreFile('src/node_modules/index.js', ['**/node_modules'])).toBe(true);
expect(shouldIgnoreFile('build.log', ['**/*.log'])).toBe(true);
expect(shouldIgnoreFile('src/build.log', ['**/*.log'])).toBe(true);
expect(shouldIgnoreFile('src/main.ts', ['**/*.log'])).toBe(false);
```

This case fails on `canary` (`expected false to be true`) and passes with the fix; the full `gitignore.test.ts` suite (20 tests) is green.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

Pure-logic change, no API or schema impact. Only `src/utils/gitignore.ts` and its test are touched.
