### PR TITLE
✨ feat(connector): add edit/delete to skill submenu; add custom connectors to profile + dropdown

### DIFF
--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -29,6 +29,7 @@ import type { ReactNode } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { CustomConnectorModal } from '@/features/Connectors';
 import DevModal from '@/features/PluginDevModal';
 import { createSkillStoreModal } from '@/features/SkillStore';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
@@ -417,6 +418,7 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
     installCustomPlugin,
     updateNewCustomPlugin,
     uninstallBuiltinTool,
+    deleteConnector,
   ] = useToolStore((s) => [
     s.uninstallCustomPlugin,
     s.removeComposioConnection,
@@ -424,8 +426,10 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
     s.installCustomPlugin,
     s.updateNewCustomPlugin,
     s.uninstallBuiltinTool,
+    s.deleteConnector,
   ]);
   const [editingPluginId, setEditingPluginId] = useState<string | null>(null);
+  const [editingConnectorDbId, setEditingConnectorDbId] = useState<string | null>(null);
   const editingCustomPlugin = useToolStore(
     pluginSelectors.getCustomPluginById(editingPluginId ?? ''),
     isEqual,
@@ -1267,6 +1271,11 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
 
         return createManagedSkillItem({
           badge: <Icon icon={McpIcon} size={12} />,
+          configureConfig: { onConfigure: () => setEditingConnectorDbId(connector.id) },
+          deleteConfig: {
+            displayName: title,
+            onDelete: () => deleteConnector(connector.id),
+          },
           icon,
           id: connector.identifier,
           popoverContent,
@@ -1274,7 +1283,7 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
           title,
         });
       }),
-    [customConnectors, t, createManagedSkillItem],
+    [customConnectors, t, createManagedSkillItem, deleteConnector],
   );
 
   // Skills list items (including LobeHub Skill and Composio)
@@ -1916,25 +1925,33 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
   ]);
 
   const editPluginDrawer = (
-    <DevModal
-      mode={'edit'}
-      open={!!editingPluginId}
-      value={editingCustomPlugin}
-      onValueChange={updateNewCustomPlugin}
-      onDelete={() => {
-        if (!canEdit) return;
-        if (editingPluginId) uninstallPlugin(editingPluginId);
-        setEditingPluginId(null);
-      }}
-      onOpenChange={(open) => {
-        if (!open) setEditingPluginId(null);
-      }}
-      onSave={async (devPlugin) => {
-        if (!canEdit) return;
-        await installCustomPlugin(devPlugin);
-        setEditingPluginId(null);
-      }}
-    />
+    <>
+      <DevModal
+        mode={'edit'}
+        open={!!editingPluginId}
+        value={editingCustomPlugin}
+        onValueChange={updateNewCustomPlugin}
+        onDelete={() => {
+          if (!canEdit) return;
+          if (editingPluginId) uninstallPlugin(editingPluginId);
+          setEditingPluginId(null);
+        }}
+        onOpenChange={(open) => {
+          if (!open) setEditingPluginId(null);
+        }}
+        onSave={async (devPlugin) => {
+          if (!canEdit) return;
+          await installCustomPlugin(devPlugin);
+          setEditingPluginId(null);
+        }}
+      />
+      <CustomConnectorModal
+        connectorId={editingConnectorDbId ?? undefined}
+        open={!!editingConnectorDbId}
+        onClose={() => setEditingConnectorDbId(null)}
+        onEditSuccess={() => setEditingConnectorDbId(null)}
+      />
+    </>
   );
 
   return {

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -1274,7 +1274,16 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
           configureConfig: { onConfigure: () => setEditingConnectorDbId(connector.id) },
           deleteConfig: {
             displayName: title,
-            onDelete: () => deleteConnector(connector.id),
+            onDelete: async () => {
+              await deleteConnector(connector.id);
+              // Mirror removeComposioServer: drop the identifier from agent.plugins so
+              // no orphaned pin survives the connector deletion.
+              try {
+                await togglePlugin(connector.identifier, false);
+              } catch (error) {
+                console.error('[Connector] Failed to unpin plugin after delete:', error);
+              }
+            },
           },
           icon,
           id: connector.identifier,
@@ -1283,7 +1292,7 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
           title,
         });
       }),
-    [customConnectors, t, createManagedSkillItem, deleteConnector],
+    [customConnectors, t, createManagedSkillItem, deleteConnector, togglePlugin],
   );
 
   // Skills list items (including LobeHub Skill and Composio)

--- a/src/features/ProfileEditor/AgentTool.tsx
+++ b/src/features/ProfileEditor/AgentTool.tsx
@@ -38,6 +38,7 @@ import {
   pluginSelectors,
 } from '@/store/tool/selectors';
 import { type LobeToolMetaWithAvailability } from '@/store/tool/slices/builtin/selectors';
+import { connectorSelectors } from '@/store/tool/slices/connector';
 
 import PluginTag from './PluginTag';
 import PopoverContent from './PopoverContent';
@@ -136,6 +137,14 @@ const AgentTool = memo<AgentToolProps>(
 
     // Load user's LobeHub Skill connections via SWR
     useFetchLobehubSkillConnections(isLobehubSkillEnabled);
+
+    // Custom connectors (user-added OAuth MCP servers) from the connector store
+    const customConnectors = useToolStore(connectorSelectors.customConnectors, isEqual);
+    const isConnectorsInit = useToolStore((s) => s.isConnectorsInit);
+    const fetchConnectors = useToolStore((s) => s.fetchConnectors);
+    useEffect(() => {
+      if (!isConnectorsInit) fetchConnectors();
+    }, [isConnectorsInit, fetchConnectors]);
 
     // Toggle web browsing via searchMode - use byId action
     const toggleWebBrowsing = useCallback(async () => {
@@ -584,10 +593,43 @@ const AgentTool = memo<AgentToolProps>(
       [marketAgentSkillItems, communityPluginItems],
     );
 
-    // Custom group children (User Agent Skills + custom plugins)
+    // Custom connector list items (user-added OAuth MCP servers)
+    const customConnectorItems = useMemo(
+      () =>
+        customConnectors.map((connector) => {
+          return {
+            icon: <Icon icon={McpIcon} size={SKILL_ICON_SIZE} style={{ marginInlineEnd: 0 }} />,
+            key: connector.identifier,
+            label: (
+              <ToolItem
+                checked={plugins.includes(connector.identifier)}
+                id={connector.identifier}
+                label={connector.name || connector.identifier}
+                onUpdate={async () => {
+                  setUpdating(true);
+                  await togglePlugin(connector.identifier);
+                  setUpdating(false);
+                }}
+              />
+            ),
+            popoverContent: (
+              <ToolItemDetailPopover
+                description={connector.mcpServerUrl ?? ''}
+                icon={<Icon icon={McpIcon} size={36} />}
+                identifier={connector.identifier}
+                sourceLabel={t('skillStore.tabs.custom')}
+                title={connector.name || connector.identifier}
+              />
+            ),
+          };
+        }),
+      [customConnectors, plugins, togglePlugin, t],
+    );
+
+    // Custom group children (User Agent Skills + custom plugins + custom connectors)
     const customGroupChildren = useMemo(
-      () => [...userAgentSkillItems, ...customPluginItems],
-      [userAgentSkillItems, customPluginItems],
+      () => [...userAgentSkillItems, ...customPluginItems, ...customConnectorItems],
+      [userAgentSkillItems, customPluginItems, customConnectorItems],
     );
 
     // All tab items (marketplace tab)
@@ -675,6 +717,9 @@ const AgentTool = memo<AgentToolProps>(
       // 7. User agent skills
       for (const skill of userAgentSkills) all.add(skill.identifier);
 
+      // 8. Custom connectors
+      for (const connector of customConnectors) all.add(connector.identifier);
+
       return all;
     }, [
       builtinList,
@@ -684,6 +729,7 @@ const AgentTool = memo<AgentToolProps>(
       installedBuiltinSkills,
       marketAgentSkills,
       userAgentSkills,
+      customConnectors,
     ]);
 
     // Track whether initial cleanup has been performed

--- a/src/features/ProfileEditor/AgentTool.tsx
+++ b/src/features/ProfileEditor/AgentTool.tsx
@@ -741,6 +741,10 @@ const AgentTool = memo<AgentToolProps>(
       if (cleanupDoneRef.current) return;
       if (validIdentifiers.size === 0) return;
       if (plugins.length === 0) return;
+      // Don't prune until the connector store has loaded — connector identifiers
+      // are absent from validIdentifiers until fetchConnectors() resolves, so
+      // running cleanup before that would incorrectly mark enabled connectors as stale.
+      if (!isConnectorsInit) return;
 
       // Defer cleanup to avoid race with async data loading (SWR, Composio, etc.)
       const timer = setTimeout(() => {

--- a/src/features/ProfileEditor/PluginTag.tsx
+++ b/src/features/ProfileEditor/PluginTag.tsx
@@ -3,6 +3,7 @@
 import { type ComposioAppType, type LobehubSkillProviderType } from '@lobechat/const';
 import { COMPOSIO_APP_TYPES, LOBEHUB_SKILL_PROVIDERS } from '@lobechat/const';
 import { Avatar, Icon, Tag } from '@lobehub/ui';
+import { McpIcon } from '@lobehub/ui/icons';
 import { createStaticStyles, cssVar } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { AlertCircle, Loader2, X } from 'lucide-react';
@@ -21,6 +22,7 @@ import {
   pluginSelectors,
 } from '@/store/tool/selectors';
 import { type LobeToolMetaWithAvailability } from '@/store/tool/slices/builtin/selectors';
+import { connectorSelectors } from '@/store/tool/slices/connector/selectors';
 
 /**
  * Composio server icon component
@@ -115,6 +117,9 @@ const PluginTag = memo<PluginTagProps>(
     const allLobehubSkillServers = useToolStore(lobehubSkillStoreSelectors.getServers, isEqual);
     const isLobehubSkillEnabled = useServerConfigStore(serverConfigSelectors.enableLobehubSkill);
 
+    // Custom connector state
+    const customConnectors = useToolStore(connectorSelectors.customConnectors, isEqual);
+
     // Check if plugin is installed
     const isInstalled = useToolStore(pluginSelectors.isPluginInstalled(identifier));
 
@@ -154,6 +159,19 @@ const PluginTag = memo<PluginTagProps>(
         }
       }
 
+      // Check if it's a custom connector
+      const customConnector = customConnectors.find((c) => c.identifier === identifier);
+      if (customConnector) {
+        return {
+          availableInWeb: true,
+          icon: McpIcon,
+          isInstalled: true,
+          label: customConnector.name || customConnector.identifier,
+          title: customConnector.name || customConnector.identifier,
+          type: 'custom-connector' as const,
+        };
+      }
+
       const builtinMeta = builtinList.find((p) => p.identifier === identifier);
       if (builtinMeta) {
         // availableInWeb is only present when using allMetaList
@@ -190,6 +208,7 @@ const PluginTag = memo<PluginTagProps>(
       allComposioServers,
       isLobehubSkillEnabled,
       allLobehubSkillServers,
+      customConnectors,
     ]);
 
     // Fetch from remote if not found locally
@@ -232,6 +251,11 @@ const PluginTag = memo<PluginTagProps>(
       // LobeHub Skill type has icon property
       if (meta.type === 'lobehub-skill' && 'icon' in meta && 'label' in meta) {
         return <LobehubSkillIcon icon={meta.icon} label={meta.label} />;
+      }
+
+      // Custom connector type
+      if (meta.type === 'custom-connector') {
+        return <Icon fill={cssVar.colorText} icon={McpIcon} size={16} />;
       }
 
       // Builtin type has avatar


### PR DESCRIPTION
## Summary

- **`useControls.tsx`** — Custom connector items in the chat input `+` skill submenu previously had no edit or delete actions. Now the `...` button and right-click context menu both expose:
  - **Edit** (Configure) → opens `CustomConnectorModal` in edit mode for the selected connector
  - **Delete** → calls `deleteConnector` with a confirmation modal

- **`AgentTool.tsx` (ProfileEditor)** — The `+` add skill dropdown in the `/profile` agent config page was missing custom connectors entirely. Now it:
  - Fetches custom connectors from the connector store on mount
  - Renders them as toggleable items (checkbox-style, same pattern as plugins) in the **Custom** group
  - Includes connector identifiers in `validIdentifiers` so stale-plugin auto-cleanup doesn't incorrectly remove enabled connectors

## Test plan

- [ ] Add a custom HTTP MCP connector, open the chat input `+` → Skills submenu — connector appears in Custom group; right-click or click `...` shows Edit and Delete options
- [ ] Click Edit → `CustomConnectorModal` opens pre-filled with existing connector data
- [ ] Click Delete → confirmation modal appears; confirming removes the connector
- [ ] Navigate to `/profile` for any agent → click `+` Add — Custom group shows user-added connectors; clicking one adds/removes its identifier from `agent.plugins`
- [ ] Re-open the profile page with a connector already enabled — the connector item is checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)