### PR TITLE
🐛 fix(device): lock a run to the explicitly selected device, never offer device-switching

### DIFF
--- a/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -659,6 +659,59 @@ describe('createServerAgentToolsEngine', () => {
       expect(result.enabledToolIds).not.toContain(RemoteDeviceManifest.identifier);
     });
 
+    it('should disable RemoteDevice when a device is explicitly bound (locked to the selection)', () => {
+      // A user-selected (bound) device locks the run to that device — the
+      // activate-device tool is never offered, so the model cannot switch.
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: { plugins: [RemoteDeviceManifest.identifier] },
+        canUseDevice: true,
+        deviceContext: {
+          autoActivated: true,
+          boundDeviceId: 'device-001',
+          deviceOnline: true,
+          gatewayConfigured: true,
+        },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        toolIds: [RemoteDeviceManifest.identifier],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).not.toContain(RemoteDeviceManifest.identifier);
+    });
+
+    it('should disable RemoteDevice when the bound device is OFFLINE — no silent hop to another machine', () => {
+      // The bound device going offline makes the plan device-unrouted, so
+      // `autoActivated` is false. Without the `boundDeviceId` gate the tool
+      // would resurface and let the model activate a *different* online device.
+      // The explicit selection must keep the run locked instead.
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: { plugins: [RemoteDeviceManifest.identifier] },
+        canUseDevice: true,
+        deviceContext: {
+          boundDeviceId: 'device-001',
+          deviceOnline: true,
+          gatewayConfigured: true,
+        },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        toolIds: [RemoteDeviceManifest.identifier],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).not.toContain(RemoteDeviceManifest.identifier);
+    });
+
     it('should enable RemoteDevice in bot conversations when caller is trusted (canUseDevice=true)', () => {
       // The `!isBotConversation` clause was dropped in — the
       // confused-deputy concern that motivated it is now handled at a

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
@@ -231,12 +231,20 @@ export const createServerAgentToolsEngine = (
     // Only auto-enable in bot conversations; otherwise let user's plugin selection take effect
     ...(isBotConversation && { [MessageManifest.identifier]: true }),
     // Remote-device proxy: shown only for device-capable targets when the
-    // server has a proxy but no specific device is auto-activated yet (user
-    // must pick). External bot senders never reach it: the plan degrades
-    // denied targets to `none` (→ not deviceCapable) and the physical
-    // manifest walls drop it for `canUseDevice=false` turns.
+    // server has a proxy, no specific device is auto-activated yet, AND the
+    // user has NOT explicitly selected a device. Once a device is explicitly
+    // selected (`boundDeviceId`), the run is locked to it: we never expose the
+    // activate-device tool, so the model can never switch to another machine —
+    // not even when the selected device is offline (the run stays unrouted
+    // until that device comes back, rather than silently hopping elsewhere).
+    // External bot senders never reach it: the plan degrades denied targets to
+    // `none` (→ not deviceCapable) and the physical manifest walls drop it for
+    // `canUseDevice=false` turns.
     [RemoteDeviceManifest.identifier]:
-      deviceCapable && hasDeviceProxy && !deviceContext?.autoActivated,
+      deviceCapable &&
+      hasDeviceProxy &&
+      !deviceContext?.autoActivated &&
+      !deviceContext?.boundDeviceId,
     [AgentDocumentsManifest.identifier]: hasAgentDocuments,
     [WebBrowsingManifest.identifier]: isSearchEnabled,
   };


### PR DESCRIPTION
## 💻 变更类型 | Change Type

- [x] 🐛 fix

## 🔀 描述 | Description

当用户**明确选择**了某台设备（`boundDeviceId`）后，运行应锁定在这台设备上——模型不应再拿到任何「激活 / 切换设备」的 tool。

### 问题

remote-device 的 `activateDevice` tool 此前只由 `!autoActivated` 控制。这留了一个洞：当被选中的设备**离线**时，execution plan 变成 `device-unrouted`，`autoActivated` 变为 `false`，于是 `activateDevice` tool 又重新出现——模型就能静默切换到**另一台在线设备**。这正是我们要去掉的「设备离线后自动替换到另一台设备」的行为。

### 改动

**`apps/server/src/modules/Mecha/AgentToolsEngine/index.ts`** — remote-device tool 的开启条件追加 `!deviceContext?.boundDeviceId`：

```ts
[RemoteDeviceManifest.identifier]:
  deviceCapable &&
  hasDeviceProxy &&
  !deviceContext?.autoActivated &&
  !deviceContext?.boundDeviceId,
```

- 一旦设备被明确选择（`boundDeviceId`），无论在线与否都不再提供 activate-device tool，运行被锁定在这台设备上；选中的设备离线时运行保持 unrouted、等待它恢复，而不是跳到别的机器。
- 未选择设备（unbound）的情况不变：tool 照常提供，模型/用户可以挑选设备。

> 注：`requestedDeviceId`（如桌面 local 预设）这条路径已被 `autoActivated` 覆盖（plan 解析为 device → activeDeviceId 置位 → tool 已被抑制），无需额外处理。

## 📝 补充信息 | Additional Information

- ✅ `bunx vitest run apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts`（39 passed，新增 2 个：bound 在线 / bound 离线均不暴露 activate tool）
- ✅ `bunx vitest run src/helpers/executionTarget.test.ts apps/server/src/services/aiAgent/__tests__/execAgent.device.test.ts`（49 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)