### PR TITLE
 💄 style(topic): unread-reply indicator on collapsed project groups

### DIFF
--- a/locales/en-US/topic.json
+++ b/locales/en-US/topic.json
@@ -154,6 +154,8 @@
   "projectStatus.failed_other": "{{count}} failed topics",
   "projectStatus.loading_one": "{{count}} loading topic",
   "projectStatus.loading_other": "{{count}} loading topics",
+  "projectStatus.unread_one": "{{count}} topic with unread reply",
+  "projectStatus.unread_other": "{{count}} topics with unread replies",
   "projectStatus.waitingForHuman_one": "{{count}} topic awaiting input",
   "projectStatus.waitingForHuman_other": "{{count}} topics awaiting input",
   "renameModal.description": "Keep it short and easy to recognize.",

--- a/locales/zh-CN/topic.json
+++ b/locales/zh-CN/topic.json
@@ -154,6 +154,8 @@
   "projectStatus.failed_other": "{{count}} 个错误话题",
   "projectStatus.loading_one": "{{count}} 个加载中话题",
   "projectStatus.loading_other": "{{count}} 个加载中话题",
+  "projectStatus.unread_one": "{{count}} 个有未读回复的话题",
+  "projectStatus.unread_other": "{{count}} 个有未读回复的话题",
   "projectStatus.waitingForHuman_one": "{{count}} 个等待处理的话题",
   "projectStatus.waitingForHuman_other": "{{count}} 个等待处理的话题",
   "renameModal.description": "保持简短且易于识别。",

--- a/packages/database/src/models/device.ts
+++ b/packages/database/src/models/device.ts
@@ -73,7 +73,10 @@ export class DeviceModel {
 
   query = async (): Promise<DeviceItem[]> => {
     return this.db.query.devices.findMany({
-      orderBy: [desc(devices.lastSeenAt)],
+      // `lastSeenAt` is written from a JS `new Date()` (ms precision), so two
+      // rapid registers can tie on it and leave the order undefined. Break ties
+      // by `createdAt` (DB-side now(), µs precision) for a stable ordering.
+      orderBy: [desc(devices.lastSeenAt), desc(devices.createdAt)],
       where: eq(devices.userId, this.userId),
     });
   };

--- a/packages/locales/src/default/topic.ts
+++ b/packages/locales/src/default/topic.ts
@@ -71,6 +71,8 @@ export default {
   'projectStatus.failed_other': '{{count}} failed topics',
   'projectStatus.loading_one': '{{count}} loading topic',
   'projectStatus.loading_other': '{{count}} loading topics',
+  'projectStatus.unread_one': '{{count}} topic with unread reply',
+  'projectStatus.unread_other': '{{count}} topics with unread replies',
   'projectStatus.waitingForHuman_one': '{{count}} topic awaiting input',
   'projectStatus.waitingForHuman_other': '{{count}} topics awaiting input',
   'management.actions.newChat': 'New chat',

--- a/packages/shared-tool-ui/src/Render/Linear/index.tsx
+++ b/packages/shared-tool-ui/src/Render/Linear/index.tsx
@@ -225,22 +225,15 @@ const LinearRender = memo<BuiltinRenderProps<Record<string, unknown>, unknown, u
       () => buildLinearRenderModel({ apiName, args, content, pluginError }),
       [apiName, args, content, pluginError],
     );
-    const hasRequest = hasItems(model.requestFields) || hasItems(model.requestLinks);
     const hasResult =
       hasItems(model.resultEntities) || Boolean(model.resultText) || Boolean(model.rawResultJson);
 
-    if (!hasRequest && !hasResult && !model.errorText) return null;
+    // Request args are intentionally not rendered here — the Inspector already
+    // surfaces the tool inputs, so duplicating them in the render is redundant.
+    if (!hasResult && !model.errorText) return null;
 
     return (
       <Flexbox className={styles.container} gap={12}>
-        {hasRequest && (
-          <Section title={model.actionLabel || 'Request'}>
-            <Block gap={8} padding={10} variant={'outlined'} width={'100%'}>
-              <FieldGrid fields={model.requestFields} />
-              <LinkList links={model.requestLinks} />
-            </Block>
-          </Section>
-        )}
         {hasItems(model.resultEntities) && (
           <Section title={'Result'}>
             <Flexbox gap={8}>

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
@@ -1,5 +1,5 @@
 import { AccordionItem, ActionIcon, Center, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
-import { createStaticStyles, cssVar, cx } from 'antd-style';
+import { createStaticStyles, cssVar, cx, keyframes } from 'antd-style';
 import {
   FolderClosedIcon,
   FolderOpenIcon,
@@ -18,6 +18,7 @@ import { resolveExecutionTarget } from '@/helpers/executionTarget';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
+import { operationSelectors } from '@/store/chat/selectors';
 
 import TopicItem from '../../List/Item';
 import { type GroupItemComponentProps } from '../GroupedAccordion';
@@ -28,6 +29,17 @@ import {
 } from './statusCounts';
 
 const PROJECT_GROUP_PREFIX = 'project:';
+
+const rippleAnim = keyframes`
+  0% {
+    transform: scale(1);
+    opacity: 0.7;
+  }
+  100% {
+    transform: scale(3);
+    opacity: 0;
+  }
+`;
 
 const styles = createStaticStyles(({ css }) => ({
   statusBadge: css`
@@ -56,6 +68,40 @@ const styles = createStaticStyles(({ css }) => ({
   statusBadgeWaiting: css`
     color: ${cssVar.colorInfo};
     background: color-mix(in srgb, ${cssVar.colorInfo} 14%, transparent);
+  `,
+  unreadDot: css`
+    position: relative;
+    z-index: 1;
+
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+
+    background: ${cssVar.colorInfo};
+  `,
+  unreadRipple: css`
+    position: absolute;
+    inset: 0;
+
+    width: 6px;
+    height: 6px;
+    margin: auto;
+    border: 1px solid ${cssVar.colorInfo};
+    border-radius: 50%;
+
+    background: transparent;
+
+    animation: ${rippleAnim} 1.8s ease-out infinite;
+  `,
+  unreadWrapper: css`
+    position: relative;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 14px;
+    height: 18px;
   `,
   addTopicAction: css`
     pointer-events: none;
@@ -138,6 +184,22 @@ const CollapsedStatusBadges = memo<{ counts: ProjectTopicStatusCounts }>(({ coun
 
 CollapsedStatusBadges.displayName = 'CollapsedProjectStatusBadges';
 
+const CollapsedUnreadDot = memo<{ count: number }>(({ count }) => {
+  const { t } = useTranslation('topic');
+  const label = t('projectStatus.unread', { count });
+
+  return (
+    <Tooltip title={label}>
+      <span aria-label={label} className={styles.unreadWrapper} role="status">
+        <span className={styles.unreadRipple} />
+        <span className={styles.unreadDot} />
+      </span>
+    </Tooltip>
+  );
+});
+
+CollapsedUnreadDot.displayName = 'CollapsedProjectUnreadDot';
+
 const GroupItem = memo<GroupItemComponentProps>(
   ({ group, activeTopicId, activeThreadId, expanded }) => {
     const { t } = useTranslation('topic');
@@ -179,14 +241,21 @@ const GroupItem = memo<GroupItemComponentProps>(
       () => getProjectTopicStatusCounts(children, new Set(loadingTopicIds)),
       [children, loadingTopicIds],
     );
+    const childTopicIds = useMemo(() => children.map((topic) => topic.id), [children]);
+    const unreadCount = useChatStore(
+      operationSelectors.unreadCompletedCountForTopics(childTopicIds),
+    );
     const hasCollapsedStatus = !expanded && hasProjectTopicStatusCounts(statusCounts);
+    const hasCollapsedUnread = !expanded && unreadCount > 0;
+    const hasCollapsedIndicators = hasCollapsedStatus || hasCollapsedUnread;
     const ProjectFolderIcon = expanded ? FolderOpenIcon : FolderClosedIcon;
     const action =
-      canAddTopic || hasCollapsedStatus ? (
+      canAddTopic || hasCollapsedIndicators ? (
         <Flexbox horizontal align={'center'} gap={4}>
           {hasCollapsedStatus && <CollapsedStatusBadges counts={statusCounts} />}
+          {hasCollapsedUnread && <CollapsedUnreadDot count={unreadCount} />}
           {canAddTopic && (
-            <span className={hasCollapsedStatus ? styles.addTopicAction : undefined}>
+            <span className={hasCollapsedIndicators ? styles.addTopicAction : undefined}>
               <ActionIcon
                 icon={PlusIcon}
                 size={'small'}
@@ -205,7 +274,7 @@ const GroupItem = memo<GroupItemComponentProps>(
     return (
       <AccordionItem
         action={action}
-        alwaysShowAction={hasCollapsedStatus}
+        alwaysShowAction={hasCollapsedIndicators}
         itemKey={id}
         paddingBlock={4}
         paddingInline={4}

--- a/src/store/chat/slices/operation/selectors.ts
+++ b/src/store/chat/slices/operation/selectors.ts
@@ -588,6 +588,21 @@ const isTopicUnreadCompleted =
     return false;
   };
 
+/**
+ * Number of topics with unread completed generation among the given topic ids.
+ * Used to surface an aggregated unread indicator on a collapsed topic group.
+ */
+const unreadCompletedCountForTopics =
+  (topicIds: string[]) =>
+  (s: ChatStoreState): number => {
+    const sets = Object.values(s.unreadCompletedTopicsByAgent);
+    let count = 0;
+    for (const topicId of topicIds) {
+      if (sets.some((set) => set.has(topicId))) count += 1;
+    }
+    return count;
+  };
+
 // ━━━ Message Queue Selectors ━━━
 
 /**
@@ -670,6 +685,7 @@ export const operationSelectors = {
   isRegenerating,
   isSendingMessage,
   isTopicUnreadCompleted,
+  unreadCompletedCountForTopics,
 
   // Message Queue
   getQueuedMessages,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🐛 fix
- [x] 💄 style

#### 🔀 Description of Change

Bundles three small, independent improvements (one commit each):

1. **✨ `feat(topic)`** — When a project topic group is collapsed, surface an aggregated unread indicator (animated ripple dot) if any child topic has an unread completed generation, so users notice replies without expanding. Adds an `unreadCompletedCountForTopics` chat operation selector and `projectStatus.unread` locale keys (en-US / zh-CN).
2. **🐛 `fix(device)`** — `lastSeenAt` is written from a JS `new Date()` (ms precision), so two rapid registers can tie on it and leave ordering undefined. Break ties by `createdAt` (DB-side `now()`, µs precision) for stable device ordering.
3. **💄 `style(tool-ui)`** — Drop the redundant Request section from the Linear render; the Inspector already surfaces tool inputs.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

- Collapse a project topic group that has a topic with an unread completed reply → ripple dot appears with a tooltip; expanding clears it.
- Device list ordering stays stable across rapid registrations.
- Linear tool result no longer duplicates request args.

#### 📝 Additional Information

i18n: en-US and zh-CN keys shipped by hand; other locales handled by the daily auto-i18n job.