### PR TITLE
✨ feat(changelog): collapse Improvements & Fixes sections by default

### DIFF
--- a/src/components/ChangelogModal/ChangelogContent.tsx
+++ b/src/components/ChangelogModal/ChangelogContent.tsx
@@ -3,10 +3,13 @@ import { Image } from '@lobehub/ui/mdx';
 import { Divider } from 'antd';
 import { Fragment, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
+import { type Components } from 'react-markdown';
 import useSWR from 'swr';
 import urlJoin from 'url-join';
 
 import { CustomMDX } from '@/components/mdx';
+import CollapsibleSection from '@/components/mdx/CollapsibleSection';
+import remarkCollapsibleSections from '@/components/mdx/remarkCollapsibleSections';
 import { OFFICIAL_SITE } from '@/const/url';
 import { changelogKeys } from '@/libs/swr/keys';
 import { lambdaClient } from '@/libs/trpc/client';
@@ -54,7 +57,11 @@ const PostItem = ({ id, versionRange, locale, showDivider = true }: PostItemProp
           />
         )}
         <Suspense fallback={<div>Loading...</div>}>
-          <CustomMDX source={data.content} />
+          <CustomMDX
+            components={{ 'collapsible-section': CollapsibleSection } as Components}
+            remarkPlugins={[remarkCollapsibleSections]}
+            source={data.content}
+          />
         </Suspense>
         <VersionTag range={versionRange} />
       </Typography>

--- a/src/components/mdx/CollapsibleSection.tsx
+++ b/src/components/mdx/CollapsibleSection.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { Collapse } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { kebabCase } from 'es-toolkit';
+import { type FC, type ReactNode } from 'react';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  collapse: css`
+    margin-block: 1em;
+  `,
+  label: css`
+    font-size: 1.25em;
+    font-weight: 600;
+    line-height: 1.4;
+    color: ${cssVar.colorText};
+  `,
+}));
+
+interface CollapsibleSectionProps {
+  children?: ReactNode;
+  title?: string;
+}
+
+/**
+ * Renders a changelog section ("Improvements" / "Fixes") inside a Collapse that
+ * is collapsed by default. Injected by `remarkCollapsibleSections` as the
+ * `<collapsible-section>` element.
+ */
+const CollapsibleSection: FC<CollapsibleSectionProps> = ({ children, title = '' }) => {
+  const id = kebabCase(title);
+
+  return (
+    <Collapse
+      className={styles.collapse}
+      defaultActiveKey={[]}
+      expandIconPlacement={'end'}
+      gap={8}
+      variant={'outlined'}
+      items={[
+        {
+          children,
+          key: id || 'section',
+          label: <span className={styles.label}>{title}</span>,
+        },
+      ]}
+    />
+  );
+};
+
+CollapsibleSection.displayName = 'CollapsibleSection';
+
+export default CollapsibleSection;

--- a/src/components/mdx/index.tsx
+++ b/src/components/mdx/index.tsx
@@ -2,7 +2,7 @@ import { type TypographyProps } from '@lobehub/ui';
 import { Typography as Typo } from '@lobehub/ui';
 import { mdxComponents } from '@lobehub/ui/mdx';
 import { type FC } from 'react';
-import Markdown, { type Components } from 'react-markdown';
+import Markdown, { type Components, type Options } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 import CodeBlock from './CodeBlock';
@@ -31,10 +31,16 @@ export const Typography = ({
 interface CustomMDXProps {
   components?: Components;
   mobile?: boolean;
+  remarkPlugins?: Options['remarkPlugins'];
   source: string;
 }
 
-export const CustomMDX: FC<CustomMDXProps> = ({ mobile, source, components: extraComponents }) => {
+export const CustomMDX: FC<CustomMDXProps> = ({
+  mobile,
+  source,
+  components: extraComponents,
+  remarkPlugins: extraRemarkPlugins,
+}) => {
   const components: Components = {
     ...(mdxComponents as Components),
     a: Link as Components['a'],
@@ -45,7 +51,7 @@ export const CustomMDX: FC<CustomMDXProps> = ({ mobile, source, components: extr
 
   return (
     <Typography mobile={mobile}>
-      <Markdown components={components} remarkPlugins={[remarkGfm]}>
+      <Markdown components={components} remarkPlugins={[remarkGfm, ...(extraRemarkPlugins ?? [])]}>
         {source}
       </Markdown>
     </Typography>

--- a/src/components/mdx/remarkCollapsibleSections.ts
+++ b/src/components/mdx/remarkCollapsibleSections.ts
@@ -1,0 +1,74 @@
+/**
+ * remark plugin — collapse the changelog "Improvements" and "Fixes" sections.
+ *
+ * Each changelog entry uses standardized section headings (Features /
+ * Improvements / Fixes). "Improvements" and "Fixes" are long, low-signal lists,
+ * so in the changelog modal we wrap each of those headings (plus the content
+ * that follows it, up to the next same-or-higher heading) in a
+ * `<collapsible-section>` element that renders collapsed by default to save
+ * vertical space; "Features" stays expanded.
+ *
+ * Built for react-markdown: we emit a node with `data.hName`, so
+ * mdast-util-to-hast turns it into a `<collapsible-section>` hast element, which
+ * is resolved to the CollapsibleSection component via the `components` map
+ * passed to <Markdown>. Headings inside code blocks are untouched because we
+ * only walk the document's top-level children (fenced code is a single node).
+ */
+
+interface MdastNode {
+  children?: MdastNode[];
+  data?: { hName?: string; hProperties?: Record<string, unknown> };
+  depth?: number;
+  type: string;
+  value?: string;
+}
+
+/** Section headings rendered collapsed by default (matched case-insensitively). */
+export const COLLAPSIBLE_HEADINGS = new Set(['fixes', 'improvements']);
+
+const nodeToText = (node: MdastNode): string => {
+  if (typeof node.value === 'string') return node.value;
+  if (node.children) return node.children.map(nodeToText).join('');
+  return '';
+};
+
+const collapseSections = (tree: MdastNode) => {
+  const children = tree.children;
+  if (!children) return;
+
+  const next: MdastNode[] = [];
+
+  for (let i = 0; i < children.length; i++) {
+    const node = children[i];
+    const depth = node.depth ?? 0;
+    const title = node.type === 'heading' ? nodeToText(node).trim() : '';
+    const isCollapsible = depth >= 2 && COLLAPSIBLE_HEADINGS.has(title.toLowerCase());
+
+    if (!isCollapsible) {
+      next.push(node);
+      continue;
+    }
+
+    // Collect the section body: every node until the next same-or-higher heading.
+    const body: MdastNode[] = [];
+    let j = i + 1;
+    for (; j < children.length; j++) {
+      const sibling = children[j];
+      if (sibling.type === 'heading' && (sibling.depth ?? 0) <= depth) break;
+      body.push(sibling);
+    }
+    i = j - 1;
+
+    next.push({
+      children: body,
+      data: { hName: 'collapsible-section', hProperties: { title } },
+      type: 'collapsibleSection',
+    });
+  }
+
+  tree.children = next;
+};
+
+const remarkCollapsibleSections = () => collapseSections;
+
+export default remarkCollapsibleSections;


### PR DESCRIPTION
#### 💻 Change Type

- [X] ✨ feat

#### 🔗 Related Issue

#### 🔀 Description of Change

In the changelog modal (What's New), every entry renders its full body, so the long **Improvements** and **Fixes** sections take up a lot of vertical space. This makes those two standardized sections **collapsed by default**, while **Features** stays expanded.

How it works:

* `remarkCollapsibleSections` — a remark plugin that walks each entry's top-level headings and wraps any exact `Improvements` / `Fixes` heading (plus the content beneath it, up to the next same-or-higher heading) into a `<collapsible-section>` element. Because the changelog is rendered with `react-markdown` (not MDX), the plugin emits the element via `data.hName`, which `mdast-util-to-hast` turns into a real hast element resolved through react-markdown's `components` map — the react-markdown equivalent of an MDX component.
* `CollapsibleSection` — renders the section inside an `@lobehub/ui` `Collapse`, collapsed by default.
* `CustomMDX` — now accepts and merges caller-supplied `remarkPlugins` (previously only `remarkGfm`).
* `ChangelogContent` — opts in to the plugin and maps `collapsible-section` → `CollapsibleSection`. Scoped here only, so `CustomMDX` stays generic.

Matching is exact + case-insensitive (`improvements` / `fixes`), aligned with the standardized changelog headings (Features / Improvements / Fixes).

#### 🧪 How to Test

- [X] Tested locally

Open the **What's New / changelog** modal and confirm the `Improvements` and `Fixes` sections render collapsed (chevron to expand), while `Features` stays open.

Also verified in isolation against the project's `react-markdown@10.1.0`: a sample entry renders `Features` as a normal `<h2>` and wraps `Improvements`/`Fixes` (with their list bodies) in the collapsible element. `eslint` is clean on the changed files and `type-check` reports no errors in them.

#### 📸 Screenshots / Videos

<!-- linear:table-colwidths:400,400 -->
| Before | After |
| -- | -- |
| All sections expanded; long Improvements/Fixes lists | Improvements & Fixes collapsed by default; Features expanded |
