### PR TITLE
✨ feat(desktop): support agent avatar icon in desktop notifications

### DIFF
--- a/apps/desktop/src/main/controllers/NotificationCtr.ts
+++ b/apps/desktop/src/main/controllers/NotificationCtr.ts
@@ -2,18 +2,73 @@ import type {
   DesktopNotificationResult,
   ShowDesktopNotificationParams,
 } from '@lobechat/electron-client-ipc';
-import { app, Notification } from 'electron';
+import type { NativeImage } from 'electron';
+import { app, nativeImage, Notification } from 'electron';
 import * as electronIs from 'electron-is';
 
 import { getIpcContext } from '@/utils/ipc';
 import { createLogger } from '@/utils/logger';
+import { netFetch } from '@/utils/net-fetch';
 
 import { ControllerModule, IpcMethod } from './index';
 
 const logger = createLogger('controllers:NotificationCtr');
 
+/** Avatars are small thumbnails; downscale to keep the cache and payload light. */
+const NOTIFICATION_ICON_SIZE = 64;
+/** Don't let a slow avatar host hold up the notification. */
+const NOTIFICATION_ICON_FETCH_TIMEOUT = 3000;
+
 export default class NotificationCtr extends ControllerModule {
   static override readonly groupName = 'notification';
+
+  /** Resolved avatars keyed by source URL/dataURL so we fetch each agent once. */
+  private iconCache = new Map<string, NativeImage>();
+
+  /**
+   * Resolve a notification icon source (http(s) URL or data URL) into a
+   * `NativeImage`. Network fetches are time-boxed and every failure mode
+   * (timeout, non-200, empty image) resolves to `undefined` so a missing or
+   * slow avatar never blocks or breaks the notification itself.
+   */
+  private async resolveNotificationIcon(source?: string): Promise<NativeImage | undefined> {
+    if (!source) return undefined;
+
+    const cached = this.iconCache.get(source);
+    if (cached) return cached;
+
+    try {
+      let image: NativeImage | undefined;
+
+      if (source.startsWith('data:')) {
+        image = nativeImage.createFromDataURL(source);
+      } else if (/^https?:\/\//.test(source)) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), NOTIFICATION_ICON_FETCH_TIMEOUT);
+        try {
+          const response = await netFetch(source, { signal: controller.signal });
+          if (response.ok) {
+            const buffer = Buffer.from(await response.arrayBuffer());
+            image = nativeImage.createFromBuffer(buffer);
+          }
+        } finally {
+          clearTimeout(timer);
+        }
+      }
+
+      if (!image || image.isEmpty()) return undefined;
+
+      const resized = image.resize({
+        height: NOTIFICATION_ICON_SIZE,
+        width: NOTIFICATION_ICON_SIZE,
+      });
+      this.iconCache.set(source, resized);
+      return resized;
+    } catch (error) {
+      logger.debug('Failed to resolve notification icon, sending without it:', error);
+      return undefined;
+    }
+  }
 
   @IpcMethod()
   async getNotificationPermissionStatus(): Promise<string> {
@@ -130,10 +185,15 @@ export default class NotificationCtr extends ControllerModule {
 
       logger.info('Showing desktop notification:', params.title);
 
+      // Best-effort avatar; never blocks or fails the notification if it can't load.
+      // Only suspend when an icon is actually requested so the common path stays sync.
+      const icon = params.icon ? await this.resolveNotificationIcon(params.icon) : undefined;
+
       const notification = new Notification({
         body: params.body,
         // Add more configuration to ensure notifications display properly
         hasReply: false,
+        ...(icon ? { icon } : {}),
         silent: params.silent || false,
         timeoutType: 'default',
         title: params.title,

--- a/apps/desktop/src/main/controllers/__tests__/NotificationCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/NotificationCtr.test.ts
@@ -19,6 +19,8 @@ vi.mock('@/utils/logger', () => ({
   }),
 }));
 
+const { netFetchMock } = vi.hoisted(() => ({ netFetchMock: vi.fn() }));
+
 // Mock electron
 vi.mock('electron', () => {
   const mockNotificationInstance = {
@@ -27,6 +29,10 @@ vi.mock('electron', () => {
   };
   const MockNotification = vi.fn(() => mockNotificationInstance) as any;
   MockNotification.isSupported = vi.fn(() => true);
+
+  // A resized NativeImage stub; `resize` returns itself so callers get a stable ref.
+  const mockResizedImage: any = { isEmpty: () => false };
+  mockResizedImage.resize = vi.fn(() => mockResizedImage);
 
   return {
     ipcMain: {
@@ -39,8 +45,15 @@ vi.mock('electron', () => {
       },
       setAppUserModelId: vi.fn(),
     },
+    nativeImage: {
+      createFromBuffer: vi.fn(() => mockResizedImage),
+      createFromDataURL: vi.fn(() => mockResizedImage),
+    },
   };
 });
+
+// net-fetch is used for remote (http) avatar resolution
+vi.mock('@/utils/net-fetch', () => ({ netFetch: netFetchMock }));
 
 // Mock electron-is
 vi.mock('electron-is', () => ({
@@ -362,6 +375,95 @@ describe('NotificationCtr', () => {
       expect(result).toEqual({
         error: 'Unknown error',
         success: false,
+      });
+    });
+
+    describe('icon (avatar)', () => {
+      const httpResponse = (ok: boolean) => ({
+        arrayBuffer: async () => new ArrayBuffer(8),
+        ok,
+      });
+
+      beforeEach(() => {
+        mockBrowserWindow.isVisible.mockReturnValue(false);
+      });
+
+      it('converts a data URL avatar into a NativeImage icon', async () => {
+        const { Notification, nativeImage } = await import('electron');
+        vi.mocked(Notification.isSupported).mockReturnValue(true);
+
+        const promise = controller.showDesktopNotification({
+          ...params,
+          icon: 'data:image/png;base64,AAAA',
+        });
+        await vi.advanceTimersByTimeAsync(100);
+        await promise;
+
+        expect(nativeImage.createFromDataURL).toHaveBeenCalledWith('data:image/png;base64,AAAA');
+        expect(Notification).toHaveBeenCalledWith(
+          expect.objectContaining({ icon: expect.anything() }),
+        );
+      });
+
+      it('fetches a remote avatar and caches it across notifications', async () => {
+        const { Notification, nativeImage } = await import('electron');
+        vi.mocked(Notification.isSupported).mockReturnValue(true);
+        netFetchMock.mockResolvedValue(httpResponse(true));
+
+        const first = controller.showDesktopNotification({
+          ...params,
+          icon: 'https://cdn.example.com/a.png',
+        });
+        await vi.advanceTimersByTimeAsync(100);
+        await first;
+
+        const second = controller.showDesktopNotification({
+          ...params,
+          icon: 'https://cdn.example.com/a.png',
+        });
+        await vi.advanceTimersByTimeAsync(100);
+        await second;
+
+        // Fetched + decoded only once; the second call hits the cache.
+        expect(netFetchMock).toHaveBeenCalledTimes(1);
+        expect(nativeImage.createFromBuffer).toHaveBeenCalledTimes(1);
+        expect(Notification).toHaveBeenLastCalledWith(
+          expect.objectContaining({ icon: expect.anything() }),
+        );
+      });
+
+      it('sends the notification without an icon when the remote fetch fails', async () => {
+        const { Notification } = await import('electron');
+        vi.mocked(Notification.isSupported).mockReturnValue(true);
+        netFetchMock.mockRejectedValue(new Error('network down'));
+
+        const promise = controller.showDesktopNotification({
+          ...params,
+          icon: 'https://cdn.example.com/broken.png',
+        });
+        await vi.advanceTimersByTimeAsync(100);
+        const result = await promise;
+
+        expect(result).toEqual({ success: true });
+        const lastCall = vi.mocked(Notification).mock.calls.at(-1)?.[0] as Record<string, unknown>;
+        expect(lastCall.icon).toBeUndefined();
+      });
+
+      it('ignores a non-200 remote avatar response', async () => {
+        const { Notification, nativeImage } = await import('electron');
+        vi.mocked(Notification.isSupported).mockReturnValue(true);
+        netFetchMock.mockResolvedValue(httpResponse(false));
+
+        const promise = controller.showDesktopNotification({
+          ...params,
+          icon: 'https://cdn.example.com/404.png',
+        });
+        await vi.advanceTimersByTimeAsync(100);
+        await promise;
+
+        expect(nativeImage.createFromBuffer).not.toHaveBeenCalled();
+        const lastCall = vi.mocked(Notification).mock.calls.at(-1)?.[0] as Record<string, unknown>;
+        expect(lastCall.icon).toBeUndefined();
       });
     });
   });

--- a/packages/electron-client-ipc/src/types/notification.ts
+++ b/packages/electron-client-ipc/src/types/notification.ts
@@ -2,6 +2,13 @@ export interface ShowDesktopNotificationParams {
   body: string;
   force?: boolean;
   /**
+   * Image source for the notification's avatar — an absolute `http(s)` URL or a
+   * `data:` URL. The main process converts it to a `NativeImage`: Win/Linux show
+   * it as the notification's main icon, macOS as the right-side thumbnail. Emoji
+   * or relative-path avatars should be omitted (the OS falls back to the app icon).
+   */
+  icon?: string;
+  /**
    * SPA path to navigate to when the user clicks the notification.
    * Reuses the existing `navigate` main-broadcast pipeline, so it requires
    * `DesktopNavigationBridge` to be mounted on the renderer side.


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Part of LOBE-10458 (Desktop notification app-layer improvements). This PR lands only the **main-process + IPC** half — the agent-avatar icon plumbing. The renderer call-site convergence (unifying title/body/click across the run paths) is handled separately.

#### 🔀 Description of Change

Adds support for showing the agent avatar as the desktop notification icon, without touching any renderer call site:

- **IPC type**: added an optional `icon?: string` to `ShowDesktopNotificationParams` — an `http(s)` or `data:` URL.
- **Main process (`NotificationCtr`)**: resolves `params.icon` into a `NativeImage` and passes it to the `Notification` (right-side thumbnail on macOS, main icon on Win/Linux). The resolver is deliberately robust:
  - per-URL cache, so each agent's avatar is fetched/decoded once;
  - time-boxed remote fetch (3s, via `AbortController`) so a slow avatar host can't stall the notification;
  - fail-soft on every error path (non-200, empty image, timeout, decode failure) → the notification still fires, just without an icon;
  - only awaits when an `icon` is actually present, keeping the common no-icon path fully synchronous.

The existing handler already unifies **title** (`params.title`), **body** (`params.body`), and **click → navigate** (`params.navigate` broadcast in the click handler); this change extends that same interface with `icon`. No caller passes `icon` yet — that wires up during the call-site convergence.

#### 🧪 How to Test

- [x] Added/updated tests

`NotificationCtr` test suite (27 passing) covers the new icon path:
- data-URL avatar → `NativeImage` icon
- remote avatar fetched once and cached across notifications
- remote fetch failure → notification sent without an icon
- non-200 response → ignored, no icon

```bash
cd apps/desktop && bunx vitest run src/main/controllers/__tests__/NotificationCtr.test.ts
```

#### 📝 Additional Information

No behavior change for existing callers: `icon` is optional and the no-icon path is unchanged (and stays synchronous). Emoji / relative-path avatars are expected to be omitted by callers so the OS falls back to the app icon.