### PR TITLE
✨ feat(desktop): unified agent-completion desktop notification helper

### DIFF
--- a/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/heterogeneousAgentExecutor.ts
@@ -3,7 +3,6 @@ import type {
   AgentInterventionResponseData,
   AgentStreamEvent,
 } from '@lobechat/agent-gateway-client';
-import { isDesktop } from '@lobechat/const';
 import {
   CLAUDE_CODE_CLI_INSTALL_DOCS_URL,
   CODEX_CLI_INSTALL_DOCS_URL,
@@ -36,8 +35,7 @@ import { heterogeneousAgentService } from '@/services/electron/heterogeneousAgen
 import { messageService } from '@/services/message';
 import { threadService } from '@/services/thread';
 import { type ChatStore, useChatStore } from '@/store/chat/store';
-import { resolveNotificationNavigatePath } from '@/store/chat/utils/desktopNotification';
-import { markdownToTxt } from '@/utils/markdownToTxt';
+import { notifyDesktopAgentCompleted } from '@/store/chat/utils/desktopNotification';
 
 import { messageMapKey } from '../../../utils/messageMapKey';
 import { mergeQueuedMessages, reconstructUploadFilesFromQueue } from '../../operation/types';
@@ -45,33 +43,6 @@ import { createGatewayEventHandler } from './gatewayEventHandler';
 
 /** Mirrors `idGenerator('threads', 16)` on the server so sync-allocated ids have the same shape. */
 const generateThreadId = () => `thd_${createNanoId(16)()}`;
-
-/**
- * Fire desktop notification + dock badge when a CC/Codex/ACP run finishes.
- * Notification only shows when the window is hidden (enforced in main); the
- * badge is always set so a minimized/backgrounded app still signals completion.
- */
-const notifyCompletion = async (title: string, body: string, context: ConversationContext) => {
-  if (!isDesktop) return;
-  try {
-    const { desktopNotificationService } = await import('@/services/electron/desktopNotification');
-    const navigatePath = resolveNotificationNavigatePath({
-      agentId: context.agentId,
-      groupId: context.groupId,
-      topicId: context.topicId,
-    });
-    await Promise.allSettled([
-      desktopNotificationService.showNotification({
-        body,
-        navigate: navigatePath ? { path: navigatePath } : undefined,
-        title,
-      }),
-      desktopNotificationService.setBadgeCount(1),
-    ]);
-  } catch (error) {
-    console.error('[HeterogeneousAgent] Desktop notification failed:', error);
-  }
-};
 
 const CLI_AUTH_REQUIRED_PATTERNS = [
   /failed to authenticate/i,
@@ -1364,14 +1335,7 @@ export const executeHeterogeneousAgent = async (
         // Signal completion to the user — dock badge + (window-hidden) notification.
         // Skip for aborted runs and for error terminations.
         if (!isAborted() && !isErrorTerminal) {
-          const body = finalContent
-            ? markdownToTxt(finalContent)
-            : t('notification.finishChatGeneration', { ns: 'electron' });
-          notifyCompletion(
-            t('notification.finishChatGeneration', { ns: 'electron' }),
-            body,
-            context,
-          );
+          notifyDesktopAgentCompleted(get, { badge: true, content: finalContent, context });
         }
       },
 

--- a/src/store/chat/utils/desktopNotification.test.ts
+++ b/src/store/chat/utils/desktopNotification.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ChatStore } from '@/store/chat/store';
+
+import {
+  buildNotificationBody,
+  resolveNotificationNavigatePath,
+  resolveNotificationTitle,
+} from './desktopNotification';
+import { topicMapKey } from './topicMapKey';
+
+const mockGet = (topicDataMap?: Record<string, any>) =>
+  (() => ({ topicDataMap })) as unknown as () => ChatStore;
+
+describe('resolveNotificationNavigatePath', () => {
+  it('deep-links a 1:1 chat to its topic', () => {
+    expect(resolveNotificationNavigatePath({ agentId: 'a1', topicId: 't1' })).toContain('a1');
+  });
+
+  it('returns undefined without an agent/group', () => {
+    expect(resolveNotificationNavigatePath({})).toBeUndefined();
+  });
+});
+
+describe('resolveNotificationTitle', () => {
+  it('prefers the topic title', () => {
+    const get = mockGet({
+      [topicMapKey({ agentId: 'a1' })]: { items: [{ id: 't1', title: 'My Topic' }] },
+    });
+    expect(resolveNotificationTitle(get, { agentId: 'a1', topicId: 't1' }, 'fallback')).toBe(
+      'My Topic',
+    );
+  });
+
+  it('uses the provided fallback when nothing resolves', () => {
+    const get = mockGet();
+    expect(resolveNotificationTitle(get, { agentId: 'a1' }, 'fallback')).toBe('fallback');
+  });
+
+  it('does not throw when the topic data slice is missing', () => {
+    const get = mockGet();
+    expect(() =>
+      resolveNotificationTitle(get, { agentId: 'a1', topicId: 't1' }, 'fallback'),
+    ).not.toThrow();
+  });
+});
+
+describe('buildNotificationBody', () => {
+  it('strips markdown to plain text', () => {
+    expect(buildNotificationBody('**bold** reply', 'fallback')).toBe('bold reply');
+  });
+
+  it('falls back when there is no content', () => {
+    expect(buildNotificationBody(undefined, 'fallback')).toBe('fallback');
+    expect(buildNotificationBody('   ', 'fallback')).toBe('fallback');
+  });
+
+  it('truncates an overlong body with an ellipsis', () => {
+    const long = 'a'.repeat(400);
+    const result = buildNotificationBody(long, 'fallback');
+    expect(result.endsWith('…')).toBe(true);
+    expect(result.length).toBe(257); // 256 chars + ellipsis
+  });
+});

--- a/src/store/chat/utils/desktopNotification.ts
+++ b/src/store/chat/utils/desktopNotification.ts
@@ -10,6 +10,7 @@ import { t } from 'i18next';
 import { getAgentStoreState } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import type { ChatStore } from '@/store/chat/store';
+import { markdownToTxt } from '@/utils/markdownToTxt';
 
 import { topicMapKey } from './topicMapKey';
 
@@ -18,6 +19,9 @@ export interface DesktopNotificationContext {
   groupId?: ConversationContext['groupId'];
   topicId?: ConversationContext['topicId'];
 }
+
+/** Cap the notification body so a long reply doesn't overflow the OS banner. */
+const NOTIFICATION_BODY_MAX_LENGTH = 256;
 
 /**
  * Resolve the SPA path that should be opened when the user clicks a desktop
@@ -36,15 +40,18 @@ export const resolveNotificationNavigatePath = (
   return undefined;
 };
 
-const resolveNotificationTitle = (
+/**
+ * Resolve the notification title from the conversation context. Prefers the
+ * topic title, then the agent name, and finally the caller-provided fallback.
+ */
+export const resolveNotificationTitle = (
   get: () => ChatStore,
   context: DesktopNotificationContext,
+  fallbackTitle: string,
 ): string => {
-  const title = t('desktopNotification.humanApprovalRequired.title', { ns: 'chat' });
-
   if (context.topicId && context.agentId) {
     const key = topicMapKey({ agentId: context.agentId, groupId: context.groupId });
-    const topicData = get().topicDataMap[key];
+    const topicData = get().topicDataMap?.[key];
     const topic = topicData?.items?.find((item) => item.id === context.topicId);
 
     if (topic?.title) return topic.title;
@@ -56,7 +63,19 @@ const resolveNotificationTitle = (
     if (agentMeta?.title) return agentMeta.title;
   }
 
-  return title;
+  return fallbackTitle;
+};
+
+/** Convert the assistant's markdown reply to a length-capped plain-text body. */
+export const buildNotificationBody = (
+  content: string | undefined,
+  fallbackBody: string,
+): string => {
+  const text = content ? markdownToTxt(content).trim() : '';
+  if (!text) return fallbackBody;
+  return text.length > NOTIFICATION_BODY_MAX_LENGTH
+    ? `${text.slice(0, NOTIFICATION_BODY_MAX_LENGTH)}…`
+    : text;
 };
 
 export const notifyDesktopHumanApprovalRequired = async (
@@ -67,7 +86,11 @@ export const notifyDesktopHumanApprovalRequired = async (
 
   try {
     const { desktopNotificationService } = await import('@/services/electron/desktopNotification');
-    const title = resolveNotificationTitle(get, context);
+    const title = resolveNotificationTitle(
+      get,
+      context,
+      t('desktopNotification.humanApprovalRequired.title', { ns: 'chat' }),
+    );
 
     const navigatePath = resolveNotificationNavigatePath(context);
 
@@ -83,5 +106,46 @@ export const notifyDesktopHumanApprovalRequired = async (
     ]);
   } catch (error) {
     console.error('Human approval desktop notification failed:', error);
+  }
+};
+
+export interface AgentCompletedNotificationOptions {
+  /** Whether to also bump the dock/taskbar badge to 1. */
+  badge?: boolean;
+  /** The assistant's final reply (markdown); rendered as the notification body. */
+  content?: string;
+  context: DesktopNotificationContext;
+}
+
+/**
+ * Unified "agent run finished" desktop notification. Title is the topic/agent
+ * name, body is the actual reply (length-capped), and clicking deep-links to
+ * the conversation. This is the single injection point the run paths should
+ * call so every completion notification stays consistent — callers only pass
+ * their context + content, never assemble title/body/navigate themselves.
+ */
+export const notifyDesktopAgentCompleted = async (
+  get: () => ChatStore,
+  { context, content, badge }: AgentCompletedNotificationOptions,
+): Promise<void> => {
+  if (!isDesktop) return;
+
+  try {
+    const { desktopNotificationService } = await import('@/services/electron/desktopNotification');
+    const fallback = t('notification.finishChatGeneration', { ns: 'electron' });
+    const navigatePath = resolveNotificationNavigatePath(context);
+
+    const tasks: Promise<unknown>[] = [
+      desktopNotificationService.showNotification({
+        body: buildNotificationBody(content, fallback),
+        navigate: navigatePath ? { path: navigatePath } : undefined,
+        title: resolveNotificationTitle(get, context, fallback),
+      }),
+    ];
+    if (badge) tasks.push(desktopNotificationService.setBadgeCount(1));
+
+    await Promise.allSettled(tasks);
+  } catch (error) {
+    console.error('Agent completion desktop notification failed:', error);
   }
 };


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Part of LOBE-10458 (Desktop notification app-layer improvements).

This PR adds **only the shared injection helper**. Wiring the three run paths to it is intentionally left out — the call entry points are being converged separately, and this helper is the single point they'll inject into.

#### 🔀 Description of Change

Adds a unified "agent run finished" notification helper in the notification utility layer (`src/store/chat/utils/desktopNotification.ts`, alongside the existing `resolveNotificationNavigatePath` / human-approval notification):

- **`notifyDesktopAgentCompleted(get, { context, content, badge? })`** — the single entry point for completion notifications. Callers pass only their conversation context + the assistant reply; the helper assembles a consistent notification:
  - **title** = topic title → agent name → generic fallback (`resolveNotificationTitle`)
  - **body** = `markdownToTxt(content)`, length-capped (`buildNotificationBody`)
  - **click** = deep-links to the agent/topic conversation (`resolveNotificationNavigatePath`)
- Exports `resolveNotificationTitle` (now takes an explicit `fallbackTitle`) and `buildNotificationBody`; hardens the topic lookup (`topicDataMap?.[key]`) so a missing store slice can't crash a notification.

No call site is modified, and there is **no avatar/icon work** in this PR.

#### 🧪 How to Test

- [x] Added/updated tests

`desktopNotification.test.ts` covers navigate-path resolution, title fallback (incl. missing store slice), and body markdown-stripping + truncation.

```bash
bunx vitest run src/store/chat/utils/desktopNotification.test.ts
```

#### 📝 Additional Information

Behavior-neutral for now: the helper isn't called by any run path yet, so no user-facing notification changes ship in this PR. It becomes active once the run-path entry points are converged and injected.