### PR TITLE
🐛 fix(agent-gateway-client): drive resume completion off authoritative DO status

### DIFF
--- a/packages/agent-gateway-client/src/client.test.ts
+++ b/packages/agent-gateway-client/src/client.test.ts
@@ -319,6 +319,109 @@ describe('AgentStreamClient', () => {
     });
   });
 
+  // Regression guard for LOBE-10443: a fresh subscriber (no lastEventId) on a
+  // hibernated DO replays zero events. The client must NOT guess "completed"
+  // from silence (the old 3s timeout did, which cleared the shared
+  // runningOperation and cancelled the run on every device). Completion is now
+  // driven purely by the DO's authoritative `resume_complete` status.
+  describe('resume_complete (authoritative status)', () => {
+    async function connectAndAuthResume(client: AgentStreamClient): Promise<MockWebSocket> {
+      client.connect();
+      await vi.advanceTimersByTimeAsync(1);
+      const ws = getLatestWs();
+      ws.simulateMessage({ type: 'auth_success' });
+      return ws;
+    }
+
+    it('never auto-completes from silence — no resume_complete, no events', async () => {
+      const client = createClient({ resumeOnConnect: true });
+      const onComplete = vi.fn();
+      client.on('session_complete', onComplete);
+
+      await connectAndAuthResume(client);
+      // DO is silent (hibernated buffer, slow status). Far past the old 3s window.
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      expect(onComplete).not.toHaveBeenCalled();
+      expect(client.connectionStatus).toBe('connected');
+    });
+
+    it('does NOT complete when DO reports status running', async () => {
+      const client = createClient({ resumeOnConnect: true });
+      const onComplete = vi.fn();
+      client.on('session_complete', onComplete);
+
+      const ws = await connectAndAuthResume(client);
+      // DO replayed nothing (hibernated buffer) but tells us the run is alive.
+      ws.simulateMessage({ status: 'running', type: 'resume_complete' });
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(onComplete).not.toHaveBeenCalled();
+      expect(client.connectionStatus).toBe('connected');
+    });
+
+    it('still streams live events after a running resume_complete', async () => {
+      const client = createClient({ resumeOnConnect: true });
+      const events: any[] = [];
+      client.on('agent_event', (e) => events.push(e));
+
+      const ws = await connectAndAuthResume(client);
+      ws.simulateMessage({ status: 'running', type: 'resume_complete' });
+
+      ws.simulateMessage({
+        event: {
+          data: { content: 'live' },
+          operationId: 'op-123',
+          stepIndex: 0,
+          timestamp: 1,
+          type: 'stream_chunk',
+        },
+        id: 'evt-9',
+        type: 'agent_event',
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].data.content).toBe('live');
+    });
+
+    it('completes when DO reports a terminal status', async () => {
+      const client = createClient({ resumeOnConnect: true });
+      const onComplete = vi.fn();
+      client.on('session_complete', onComplete);
+
+      const ws = await connectAndAuthResume(client);
+      ws.simulateMessage({ status: 'completed', type: 'resume_complete' });
+
+      expect(onComplete).toHaveBeenCalledOnce();
+      expect(client.connectionStatus).toBe('disconnected');
+    });
+
+    it('flushes replayed events before completing on a terminal status', async () => {
+      const client = createClient({ resumeOnConnect: true });
+      const events: any[] = [];
+      const order: string[] = [];
+      client.on('agent_event', (e) => {
+        events.push(e);
+        order.push('event');
+      });
+      client.on('session_complete', () => order.push('complete'));
+
+      const ws = await connectAndAuthResume(client);
+      // Buffered during resume replay…
+      ws.simulateMessage({
+        event: { data: {}, operationId: 'op-123', stepIndex: 0, timestamp: 1, type: 'step_start' },
+        id: 'evt-1',
+        type: 'agent_event',
+      });
+      // …then the terminal authoritative status.
+      ws.simulateMessage({ status: 'completed', type: 'resume_complete' });
+
+      expect(events).toHaveLength(1);
+      expect(order).toEqual(['event', 'complete']);
+    });
+  });
+
   describe('heartbeat', () => {
     it('should send heartbeats at 30s intervals', async () => {
       const client = createClient();

--- a/packages/agent-gateway-client/src/client.test.ts
+++ b/packages/agent-gateway-client/src/client.test.ts
@@ -159,7 +159,7 @@ describe('AgentStreamClient', () => {
 
       // First message is auth, second is resume
       expect(ws.sent).toHaveLength(2);
-      expect(JSON.parse(ws.sent[1])).toEqual({ lastEventId: '', type: 'resume' });
+      expect(JSON.parse(ws.sent[1])).toEqual({ lastEventId: '', type: 'resume', wantStatus: true });
     });
 
     it('should not connect if already connected', async () => {
@@ -267,7 +267,7 @@ describe('AgentStreamClient', () => {
 
       // Resume should use the tracked lastEventId
       const resumeMsg = JSON.parse(ws2.sent[1]);
-      expect(resumeMsg).toEqual({ lastEventId: 'evt-5', type: 'resume' });
+      expect(resumeMsg).toEqual({ lastEventId: 'evt-5', type: 'resume', wantStatus: true });
     });
 
     it('should disconnect on agent_runtime_end', async () => {

--- a/packages/agent-gateway-client/src/client.ts
+++ b/packages/agent-gateway-client/src/client.ts
@@ -15,7 +15,6 @@ const INITIAL_RECONNECT_DELAY = 1000; // 1s
 const MAX_RECONNECT_DELAY = 30_000; // 30s
 const MAX_MISSED_HEARTBEATS = 3;
 const RESUME_FLUSH_DELAY = 500; // 500ms debounce after last resume event
-const RESUME_TIMEOUT = 3000; // 3s: if no events after resume request, session is already done
 
 // ─── Typed Event Emitter (browser-compatible, no node:events) ───
 
@@ -235,20 +234,20 @@ export class AgentStreamClient extends TypedEmitter {
           // Enter resume mode only for explicit reconnect scenarios (page reload).
           // Buffer all events until resume replay completes, then deduplicate and emit.
           // This is NOT enabled for normal first-connect to avoid delaying live streaming.
+          //
+          // The replay is terminated by an authoritative `resume_complete` (the
+          // DO's stored status, which survives hibernation) — that message is
+          // what exits resume mode and decides completion. We deliberately do
+          // NOT arm a timeout to guess completion from silence: an empty replay
+          // no longer means "finished" (the DO may simply have hibernated its
+          // event buffer), and guessing was exactly the LOBE-10443 multi-device
+          // false-cancel bug. If `resume_complete` never arrives (e.g. a
+          // rolled-back DO that predates LOBE-10443), we just keep waiting — a
+          // safe, recoverable state, with heartbeat loss still forcing reconnect
+          // — instead of cancelling a live run.
           if (this.resumeOnConnect && !this.lastEventId) {
             this.resumeMode = true;
             this.resumeBuffer = [];
-
-            // Safety timeout: if no events arrive after resume, the session has already
-            // completed and the DO has nothing to replay. Exit resume mode and signal completion.
-            this.resumeFlushTimer = setTimeout(() => {
-              if (this.resumeMode && this.resumeBuffer.length === 0) {
-                this.resumeMode = false;
-                this.sessionEnded = true;
-                this.emit('session_complete');
-                this.disconnect();
-              }
-            }, RESUME_TIMEOUT);
           }
 
           // Request all buffered events (covers events pushed before WS connected)
@@ -300,6 +299,37 @@ export class AgentStreamClient extends TypedEmitter {
             this.sessionEnded = true;
             this.disconnect();
           }
+          break;
+        }
+
+        case 'resume_complete': {
+          // Authoritative status from the DO, sent right after resume replay
+          // (LOBE-10443) — this is the definitive end-of-replay marker, so
+          // cancel the pending debounce flush and act on it immediately.
+          if (this.resumeFlushTimer) {
+            clearTimeout(this.resumeFlushTimer);
+            this.resumeFlushTimer = null;
+          }
+
+          // Emit any events buffered during resume, in order, before deciding.
+          if (this.resumeMode) {
+            this.flushResumeBuffer();
+          }
+
+          const terminal =
+            message.status === 'completed' ||
+            message.status === 'error' ||
+            message.status === 'interrupted';
+
+          if (terminal) {
+            this.sessionEnded = true;
+            this.emit('session_complete');
+            this.disconnect();
+          }
+          // Non-terminal (running / waiting_input / waiting_confirmation): the
+          // run is alive. Stay connected and keep streaming live events — do NOT
+          // fire session_complete. This is the core fix: a fresh subscriber on a
+          // hibernated DO no longer false-completes and clears runningOperation.
           break;
         }
 

--- a/packages/agent-gateway-client/src/client.ts
+++ b/packages/agent-gateway-client/src/client.ts
@@ -250,8 +250,13 @@ export class AgentStreamClient extends TypedEmitter {
             this.resumeBuffer = [];
           }
 
-          // Request all buffered events (covers events pushed before WS connected)
-          this.sendMessage({ lastEventId: this.lastEventId, type: 'resume' });
+          // Request all buffered events (covers events pushed before WS connected).
+          // `wantStatus` opts into the authoritative `resume_complete` reply
+          // (LOBE-10443): this client knows how to consume it, so a current
+          // gateway will hand back the real session status. Legacy gateways
+          // ignore the flag and just replay — we then rely on live events, never
+          // guessing completion from silence.
+          this.sendMessage({ lastEventId: this.lastEventId, type: 'resume', wantStatus: true });
           this.emit('connected');
           break;
         }

--- a/packages/agent-gateway-client/src/types.ts
+++ b/packages/agent-gateway-client/src/types.ts
@@ -162,6 +162,12 @@ export interface AuthMessage {
 export interface ResumeMessage {
   lastEventId: string;
   type: 'resume';
+  /**
+   * Opt into the authoritative `resume_complete` reply (LOBE-10443). Set by
+   * this client so a current gateway hands back the stored session status;
+   * legacy gateways ignore it and replay only.
+   */
+  wantStatus?: boolean;
 }
 
 export interface HeartbeatMessage {

--- a/packages/agent-gateway-client/src/types.ts
+++ b/packages/agent-gateway-client/src/types.ts
@@ -229,12 +229,37 @@ export interface SessionCompleteMessage {
   type: 'session_complete';
 }
 
+/**
+ * Authoritative session status. Mirrors the gateway DO's `SessionStatus`.
+ */
+export type SessionStatus =
+  | 'running'
+  | 'waiting_input'
+  | 'waiting_confirmation'
+  | 'completed'
+  | 'error'
+  | 'interrupted';
+
+/**
+ * Server → Client: sent right after a `resume` replay, carrying the DO's
+ * authoritative `status` from storage. Because the DO's in-memory event buffer
+ * is wiped by hibernation, an empty replay is ambiguous — the run may still be
+ * alive. This message resolves that ambiguity so the client never guesses
+ * "completed" from silence (which would clear the shared `runningOperation` and
+ * cancel the run on every device). See LOBE-10443.
+ */
+export interface ResumeCompleteMessage {
+  status: SessionStatus;
+  type: 'resume_complete';
+}
+
 export type ServerMessage =
   | AgentEventMessage
   | AuthExpiredMessage
   | AuthFailedMessage
   | AuthSuccessMessage
   | HeartbeatAckMessage
+  | ResumeCompleteMessage
   | SessionCompleteMessage;
 
 // ─── Connection Status ───


### PR DESCRIPTION
## 背景 / Linear: LOBE-10443

设备 A 在跑 agent(gateway 模式)时,第二台设备 B 打开同一 topic,会让正在运行的 run 立刻被误判完成并清空共享的 `runningOperation` —— 两端 UI 都翻成已结束,但服务端 agent loop 其实还活着(表现为"被 cancel")。

**根因**:gateway DO 的事件 buffer 是内存态,Cloudflare hibernation 后丢失 → 全新订阅者(设备 B,无 lastEventId)的 resume 回放为空 → 客户端无法区分「真完成」和「buffer 被 hibernation 清空」→ 旧的 3s 静默超时**误判 `session_complete`** → 清空 DB 里共享的 `runningOperation` → 两端不再重连。

## 客户端改动

1. **移除「3s 静默猜完成」**:不再从沉默推断 `session_complete`。完成与否纯粹由 DO 下发的权威状态决定。
2. **消费 `resume_complete`**:terminal 状态 → 完成并断开;`running` / `waiting_*` → 保持连接续流,绝不误清 `runningOperation`。
3. **resume 带 `wantStatus: true`** opt-in:向(修订后的)gateway 显式声明「我懂 `resume_complete`」。

### 对新旧 gateway 都安全
- **新 gateway**,客户端按真实状态走。
- **旧 gateway**:忽略该标志、只回放;客户端靠实时流渲染,`resume_complete` 没来就继续等(心跳丢失仍触发重连),**绝不**靠静默猜完成。
- 因此**不依赖部署顺序**。



## 测试

`packages/agent-gateway-client/src/client.test.ts`(**33/33 通过**,type-check 干净):
- 永不从静默自动完成(无 `resume_complete`、无事件 → 不完成、保持连接)。
- `resume_complete=running` → 不完成、续流;terminal → 完成;完成前先 flush 回放事件。
- resume 消息带 `wantStatus: true`。