### PR TITLE
✨ feat(mobile): expose deviceRouter on mobileRouter

### DIFF
--- a/apps/server/src/routers/mobile/index.ts
+++ b/apps/server/src/routers/mobile/index.ts
@@ -13,6 +13,7 @@ import { aiProviderRouter } from '../lambda/aiProvider';
 import { briefRouter } from '../lambda/brief';
 import { chunkRouter } from '../lambda/chunk';
 import { configRouter } from '../lambda/config';
+import { deviceRouter } from '../lambda/device';
 import { documentRouter } from '../lambda/document';
 import { fileRouter } from '../lambda/file';
 import { homeRouter } from '../lambda/home';
@@ -36,6 +37,7 @@ export const mobileRouter = router({
   aiProvider: aiProviderRouter,
   chunk: chunkRouter,
   config: configRouter,
+  device: deviceRouter,
   document: documentRouter,
   file: fileRouter,
   healthcheck: publicProcedure.query(() => "i'm live!"),


### PR DESCRIPTION
## Summary
- Mounts the existing `deviceRouter` (from `apps/server/src/routers/lambda/device.ts`) on the mobile tRPC root router so the mobile client can call `device.listDevices` and the rest of the device RPCs.
- Unblocks LobeHub Mobile's chat-input execution-target picker (mirror of web's `HeteroDeviceSwitcher`) so mobile can show the registered devices / sandbox / none options consistently with web.

## Why this is safe
- `deviceProcedure` only composes `authedProcedure.use(serverDatabase)`, both of which are already part of the mobile route's context (`createLambdaContext` — same as the lambda route).
- No schema, middleware, or context changes.

## Test plan
- [ ] Hit `/trpc/mobile/device.listDevices` from a signed-in mobile client and verify it returns the same `DeviceListItem[]` as `/trpc/lambda/device.listDevices`.
- [ ] Verify other device RPCs (`gitBranch`, `checkCapability`, …) are reachable via the mobile router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)