### PR TITLE
🐛 fix(boot): one continuous loading screen instead of brand-logo flash on cold start

### DIFF
--- a/src/layout/GlobalProvider/CacheHydrationGate.tsx
+++ b/src/layout/GlobalProvider/CacheHydrationGate.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { Center, Flexbox } from '@lobehub/ui';
-import { type PropsWithChildren, useEffect, useState } from 'react';
+import { type PropsWithChildren, useEffect, useLayoutEffect, useState } from 'react';
 import { useSyncExternalStore } from 'react';
 
-import { ProductLogo } from '@/components/Branding';
 import { cacheHydration } from '@/libs/swr/cacheHydration';
 import { useCacheScope } from '@/libs/swr/useCacheScope';
 import { useUserStore } from '@/store/user';
@@ -12,7 +10,7 @@ import { authSelectors } from '@/store/user/selectors';
 
 /**
  * Max time to wait for the IndexedDB cache tier before rendering anyway, so a
- * slow / hung IndexedDB never blocks the app indefinitely.
+ * slow / hung IndexedDB (or auth) never blocks the app indefinitely.
  */
 const HYDRATION_TIMEOUT = 1500;
 
@@ -22,9 +20,19 @@ const HYDRATION_TIMEOUT = 1500;
  * Holds the routed app until the *current identity scope's* IndexedDB cache
  * tier has hydrated, so local-first data (messages, topics, …) is present in
  * the SWR cache synchronously by the time components mount — including on a
- * deep-link cold load. Before auth resolves the scope is `anon:*` (whose
- * IndexedDB tier is empty and resolves instantly), so this only ever waits the
- * few milliseconds an IndexedDB read takes for the signed-in scope.
+ * deep-link cold load.
+ *
+ * While booting it renders nothing and lets the static HTML `#loading-screen`
+ * (a fixed, top-most overlay defined in index.html) stay visible, then removes
+ * it in the same layout pass that mounts the children. That keeps the boot a
+ * single continuous loading screen — static loader → app — with no second
+ * in-React logo and no flash.
+ *
+ * We deliberately gate through the pre-auth (anon) phase too: before auth
+ * resolves the scope is `anon:*`, and un-gating there would paint the app for a
+ * frame before auth flips the scope to the signed-in one and re-hydration kicks
+ * in — the old `app → logo → app` flicker. Waiting on `isAuthLoaded && ready`
+ * collapses that into one uninterrupted loader.
  */
 const CacheHydrationGate = ({ children }: PropsWithChildren) => {
   const scope = useCacheScope();
@@ -36,27 +44,26 @@ const CacheHydrationGate = ({ children }: PropsWithChildren) => {
     () => true, // SSR: nothing to hydrate
   );
 
-  // Safety valve: never block longer than HYDRATION_TIMEOUT.
+  // Safety valve: never block longer than HYDRATION_TIMEOUT, even if auth or
+  // IndexedDB hangs. A single boot-level timer (the workspace remount keyed on
+  // activeWorkspaceId gives a fresh gate — and timer — when the scope changes).
   const [timedOut, setTimedOut] = useState(false);
   useEffect(() => {
-    if (ready) return;
-    setTimedOut(false);
     const timer = setTimeout(() => setTimedOut(true), HYDRATION_TIMEOUT);
     return () => clearTimeout(timer);
-  }, [ready, scope]);
+  }, []);
 
-  // Only gate once auth has resolved (so we wait on the real scope, not anon).
-  // While gating, mirror the boot loading screen (centered brand logo) rather
-  // than blanking the page, so the hand-off from the static HTML loading screen
-  // to the routed app stays seamless instead of flashing white.
-  if (isAuthLoaded && !ready && !timedOut)
-    return (
-      <Flexbox height={'100%'} style={{ userSelect: 'none' }} width={'100%'}>
-        <Center flex={1} gap={16} width={'100%'}>
-          <ProductLogo size={48} type={'combine'} />
-        </Center>
-      </Flexbox>
-    );
+  const booting = !(isAuthLoaded && ready) && !timedOut;
+
+  // Hand off from the static loader to the app in one layout pass: children are
+  // already committed to the DOM by the time this runs, so removing the loader
+  // here (before paint) reveals the app with no intermediate blank/logo frame.
+  useLayoutEffect(() => {
+    if (booting) return;
+    document.getElementById('loading-screen')?.remove();
+  }, [booting]);
+
+  if (booting) return null;
 
   return <>{children}</>;
 };

--- a/src/layout/SPAGlobalProvider/index.tsx
+++ b/src/layout/SPAGlobalProvider/index.tsx
@@ -3,7 +3,7 @@
 import { TooltipGroup } from '@lobehub/ui';
 import { StyleProvider } from 'antd-style';
 import { domMax, LazyMotion } from 'motion/react';
-import { lazy, memo, type PropsWithChildren, Suspense, useLayoutEffect } from 'react';
+import { lazy, memo, type PropsWithChildren, Suspense } from 'react';
 
 import { LobeAnalyticsProviderWrapper } from '@/components/Analytics/LobeAnalyticsProviderWrapper';
 import { DragUploadProvider } from '@/components/DragUploadZone/DragUploadProvider';
@@ -35,10 +35,10 @@ const ContextMenuHost = lazy(() =>
 );
 
 const SPAGlobalProvider = memo<PropsWithChildren>(({ children }) => {
-  useLayoutEffect(() => {
-    document.getElementById('loading-screen')?.remove();
-  }, []);
-
+  // The static HTML #loading-screen is removed by CacheHydrationGate once the
+  // SWR cache has hydrated, so the boot stays one continuous loading screen
+  // (static loader → app) instead of flashing the loader away before the app
+  // and its local-first data are ready.
   const serverConfig: SPAServerConfig | undefined = window.__SERVER_CONFIG__;
 
   const locale = document.documentElement.lang || 'en-US';


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

On cold start, the app flashed a full-screen centered LobeHub logo while the SWR cache hydrated — an `app → logo → app` flicker that affected every page (home included), not just one feature.

**Root cause** — `CacheHydrationGate` held the routed app behind its own full-screen `<ProductLogo>` until the current identity scope's **IndexedDB SWR cache tier** finished hydrating. But it only gated *after* auth resolved (`isAuthLoaded && !ready`). Boot sequence:

1. `SPAGlobalProvider` mounts → removes the static HTML `#loading-screen`.
2. Auth not resolved yet → gate renders the app shell.
3. Auth resolves → scope flips `anon → user` → `reloadScope()` resets hydration readiness → gate flips to the **full-screen logo**.
4. IndexedDB hydration completes → flips back to the app.

That mid-boot `app → logo → app` flip is the flash.

**Fix**

- `CacheHydrationGate` now renders nothing while booting and keeps the static HTML `#loading-screen` (a fixed, top-most overlay from `index.html`) visible, then removes it in the **same layout pass** that mounts the children — one continuous `static loader → app` hand-off, with no second in-React logo and no blank gap.
- It also gates through the pre-auth (anon) phase, so the scope flip no longer causes a mid-boot flash; a single boot-level timeout (1.5s) is the safety valve.
- `SPAGlobalProvider` no longer removes `#loading-screen` on mount — that's now owned by the gate, so the loader stays until the app and its local-first data are actually ready.

Net: the only boot visual is the single static loader, then the real app with content skeletons.

#### 🧪 How to Test

- [x] Tested locally

Verified in Electron over CDP by triggering real cold reloads (`location.reload()`, confirmed via `performance.now()` resetting) and sampling the boot DOM state machine across the reload:

- `#loading-screen` stays present (`ls:true`) with an empty `#root` until React mounts children, then loader removed + children mounted in the same transition (`ls:false, kids:2`) — no `ls:false && kids:0` blank frame.
- No in-React brand logo at any point (`rootBrandLogo` always false), and no route-level `BrandTextLoading` full-screen logo (`brandLoading` always false) — the flash isn't merely relocated.
- The first post-hand-off frame is the app layout with content skeletons (sidebar / chat shell / input), not a logo or blank screen.

> Note: verified in dev mode (Vite on-demand compile), so absolute durations aren't representative of production; the verification is about the **boot state-machine ordering / absence of the logo flash**.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| full-screen centered LobeHub logo flashes mid-boot (`app → logo → app`) | single continuous static loader → app with skeletons; no second logo |

🤖 Generated with [Claude Code](https://claude.com/claude-code)