### PR TITLE
⚡️ perf: write message mutations through to the message:list SWR cache

### DIFF
--- a/src/store/chat/slices/message/action.test.ts
+++ b/src/store/chat/slices/message/action.test.ts
@@ -1220,6 +1220,72 @@ describe('chatMessage actions', () => {
     });
   });
 
+  describe('replaceMessages cache write-through', () => {
+    beforeEach(() => {
+      (mutate as Mock).mockClear();
+    });
+
+    it('seeds the message:list SWR cache for the same bucket without revalidating', async () => {
+      const { result } = renderHook(() => useChatStore());
+
+      const context = { agentId: 'wt-agent', topicId: 'wt-topic' };
+      const messages = [{ id: 'm1', role: 'user', content: 'hi' }] as any;
+
+      await act(async () => {
+        result.current.replaceMessages(messages, { context });
+      });
+
+      expect(mutate).toHaveBeenCalledTimes(1);
+      const [matcher, dataArg, options] = (mutate as Mock).mock.calls[0];
+
+      // seeds, never refetches
+      expect(options).toEqual({ revalidate: false });
+      expect(dataArg).toEqual(messages);
+
+      // matcher targets exactly this bucket, not other buckets / domains
+      expect(typeof matcher).toBe('function');
+      expect(matcher(['message:list', context, 1])).toBe(true);
+      // workspace-augmented variant of the same bucket still matches
+      expect(matcher(['message:list', context, 1, 'workspace-1'])).toBe(true);
+      expect(matcher(['message:list', { agentId: 'wt-agent', topicId: 'other' }, 1])).toBe(false);
+      expect(matcher(['topic:list', 'container', {}])).toBe(false);
+    });
+
+    it('skips write-through for the useFetchMessages onData sync path', async () => {
+      const { result } = renderHook(() => useChatStore());
+
+      await act(async () => {
+        result.current.replaceMessages([{ id: 'm2', role: 'user', content: 'hi' }] as any, {
+          action: 'useFetchMessages',
+          context: { agentId: 'wt-agent-2', topicId: 'wt-topic-2' },
+        });
+      });
+
+      expect(mutate).not.toHaveBeenCalled();
+    });
+
+    it('skips write-through while the context is streaming', async () => {
+      const { result } = renderHook(() => useChatStore());
+
+      const context = { agentId: 'wt-agent-3', topicId: 'wt-topic-3' };
+
+      await act(async () => {
+        // A running AI-runtime op marks the context as streaming.
+        result.current.startOperation({ type: 'execAgentRuntime', context });
+      });
+
+      (mutate as Mock).mockClear();
+
+      await act(async () => {
+        result.current.replaceMessages([{ id: 'm3', role: 'user', content: 'hi' }] as any, {
+          context,
+        });
+      });
+
+      expect(mutate).not.toHaveBeenCalled();
+    });
+  });
+
   describe('Public API with context parameter', () => {
     describe('deleteMessage with context', () => {
       it('should pass context to optimisticDeleteMessages', async () => {

--- a/src/store/chat/slices/message/action.test.ts
+++ b/src/store/chat/slices/message/action.test.ts
@@ -1284,6 +1284,38 @@ describe('chatMessage actions', () => {
 
       expect(mutate).not.toHaveBeenCalled();
     });
+
+    it('still seeds the cache when the store-set is a no-op (optimistic echo)', async () => {
+      const { result } = renderHook(() => useChatStore());
+
+      const context = { agentId: 'wt-noop', topicId: 'wt-noop-topic' };
+      const messages = [{ id: 'm-noop', role: 'user', content: 'hi' }] as any;
+      const key = messageMapKey(context);
+
+      // An optimistic dispatch already applied this exact state to the in-memory
+      // store, but never touched the SWR cache.
+      act(() => {
+        useChatStore.setState({ dbMessagesMap: { [key]: messages } });
+      });
+
+      (mutate as Mock).mockClear();
+
+      await act(async () => {
+        result.current.replaceMessages(messages, {
+          action: 'optimisticUpdateMessageContent',
+          context,
+        });
+      });
+
+      // store-set is a no-op (messagesMap bucket never populated)...
+      expect(result.current.messagesMap[key]).toBeUndefined();
+      // ...but the cache is still seeded so a later switch-back is not stale
+      expect(mutate).toHaveBeenCalledTimes(1);
+      const [matcher, dataArg, options] = (mutate as Mock).mock.calls[0];
+      expect(options).toEqual({ revalidate: false });
+      expect(dataArg).toEqual(messages);
+      expect(matcher(['message:list', context, 1])).toBe(true);
+    });
   });
 
   describe('Public API with context parameter', () => {

--- a/src/store/chat/slices/message/actions/query.ts
+++ b/src/store/chat/slices/message/actions/query.ts
@@ -98,6 +98,18 @@ export class MessageQueryActionImpl {
     // Get raw messages from dbMessagesMap and apply reducer
     const nextDbMap = { ...this.#get().dbMessagesMap, [messagesKey]: reconciled };
 
+    // Write through BEFORE the equality early-return below. Optimistic flows
+    // (optimisticUpdateMessageContent / optimisticDeleteMessage[s]) call
+    // `internal_dispatchMessage` first — which already applies the mutation to
+    // `dbMessagesMap` WITHOUT touching the SWR cache — and then
+    // `replaceMessages(result.messages)`. When the server echo equals the
+    // already-applied in-memory state, the `isEqual` return fires and the
+    // store-set is correctly skipped; but the SWR/IndexedDB cache was never
+    // updated by the dispatch, so a later remount would hydrate the
+    // pre-mutation snapshot (stale content / deleted rows). Seeding here keeps
+    // the cache correct even on a store no-op.
+    this.#writeThroughMessageCache(ctx, messagesKey, reconciled, params?.action);
+
     if (isEqual(nextDbMap, this.#get().dbMessagesMap)) return;
 
     // Parse messages using conversation-flow
@@ -113,8 +125,6 @@ export class MessageQueryActionImpl {
       false,
       params?.action ?? 'replaceMessages',
     );
-
-    this.#writeThroughMessageCache(ctx, messagesKey, reconciled, params?.action);
   };
 
   /**
@@ -126,6 +136,10 @@ export class MessageQueryActionImpl {
    * recreated on every topic/session switch and re-hydrates from this cache, a
    * stale cache is what forces a refetch on every switch. Keeping the cache in
    * sync here lets a switch-back hydrate from a FRESH cache.
+   *
+   * Called even when the `replaceMessages` store-set is a no-op (see caller),
+   * because an optimistic dispatch may have already applied this exact state to
+   * the store while leaving the cache stale.
    *
    * Skipped in two cases:
    * - `useFetchMessages` onData — SWR already holds that exact value, so

--- a/src/store/chat/slices/message/actions/query.ts
+++ b/src/store/chat/slices/message/actions/query.ts
@@ -6,6 +6,7 @@ import { type SWRResponse } from 'swr';
 import { mutate, useClientDataSWRWithSync } from '@/libs/swr';
 import { messageKeys } from '@/libs/swr/keys';
 import { messageService } from '@/services/message';
+import { operationSelectors } from '@/store/chat/slices/operation/selectors';
 import { type ChatStore } from '@/store/chat/store';
 import { type StoreSetter } from '@/store/types';
 
@@ -111,6 +112,49 @@ export class MessageQueryActionImpl {
       },
       false,
       params?.action ?? 'replaceMessages',
+    );
+
+    this.#writeThroughMessageCache(ctx, messagesKey, reconciled, params?.action);
+  };
+
+  /**
+   * Write the settled in-memory messages back into the `message:list` SWR cache
+   * (and, transitively, the persisted IndexedDB tier) for this exact bucket.
+   *
+   * Why: message mutations otherwise only touch the in-memory store, so the SWR
+   * cache stays stale until a network refetch. Because the Conversation store is
+   * recreated on every topic/session switch and re-hydrates from this cache, a
+   * stale cache is what forces a refetch on every switch. Keeping the cache in
+   * sync here lets a switch-back hydrate from a FRESH cache.
+   *
+   * Skipped in two cases:
+   * - `useFetchMessages` onData — SWR already holds that exact value, so
+   *   re-writing it would double the IndexedDB persist on every fetch.
+   * - while the context is streaming — `internal_dispatchMessage` bridges every
+   *   token here via `onMessagesChange`, and a write-through per token would
+   *   thrash. `agent_runtime_end` clears the running flag *before* its final
+   *   `replaceMessages`, so the settled snapshot still writes through.
+   */
+  #writeThroughMessageCache = (
+    ctx: MessageMapKeyInput,
+    messagesKey: string,
+    messages: UIChatMessage[],
+    action?: string,
+  ): void => {
+    if (action === 'useFetchMessages') return;
+    if (operationSelectors.isAgentRuntimeRunningByContext(ctx)(this.#get())) return;
+
+    // Match every `message:list` entry whose context resolves to the same bucket
+    // (any page-size / version / workspace-augmented variant). `revalidate: false`
+    // seeds the cache without firing a network request.
+    void mutate(
+      (key) => {
+        if (!Array.isArray(key) || key[0] !== messageKeys.list.root) return false;
+        const keyCtx = key[1] as ConversationContext | undefined;
+        return !!keyCtx && messageMapKey(keyCtx) === messagesKey;
+      },
+      messages,
+      { revalidate: false },
     );
   };
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ⚡️ perf
- [x] 🐛 fix

#### 🔀 Description of Change

Switching topic/session re-pulls messages from the network **every time**, and the refetch was load-bearing — not just redundant.

**Root cause:** the Conversation store is recreated on every context switch (`ConversationProvider` is keyed by `contextKey`), so it re-hydrates `dbMessages`/`displayMessages` from the `message:list` SWR/IndexedDB cache. But message mutations (send / stream / edit / delete) only ever updated the in-memory store — they **never wrote back to the SWR cache**. The only `mutate` on the message key was `refreshMessages`, which is invalidate-only (no data). So the cache stayed at the pre-mutation snapshot, and a network refetch on every switch was the only thing keeping the view correct.

This PR makes `replaceMessages` (the single sink for committed message state) seed the cache for the **exact** bucket:

```ts
mutate(matcher, messages, { revalidate: false })
```

- **Precise bucket match** — `messageMapKey(keyCtx) === messagesKey`, so a `main` write can't pollute a `thread`/`page` bucket; matches the workspace-augmented key variant too.
- **Skips the fetch-sync path** (`action === 'useFetchMessages'`) — SWR already holds that value; re-writing would double the IndexedDB persist on every fetch.
- **Skips while streaming** — `internal_dispatchMessage` bridges every token here via `onMessagesChange`; a per-token IndexedDB write would thrash. `agent_runtime_end` calls `completeOperation` (clears the running flag) *before* its final `replaceMessages`, so the settled snapshot still writes through — one cache write per turn.

**Result:** the cache is always current, so a switch-back hydrates from a fresh cache (no stale flash, no forced refetch). This also unblocks the planned follow-up — adding a `dedupingInterval` to the message list to actually cut switch-refetch frequency — which would have shown stale data without this write-through in place.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

New focused tests in `action.test.ts`: seeds the cache with a precise bucket matcher + `revalidate: false`; skips the `useFetchMessages` onData path; skips while the context is streaming.

- `action.test.ts`: 55 passed
- regression: `replaceMessages.orphanTool` + full `aiChat/actions/__tests__` (gateway / streaming / heterogeneous agent): 323 passed
- `type-check`: clean

#### 📝 Additional Information

Follow-up (separate PR): give `message:list` a sensible `dedupingInterval` so switching back to a recently-viewed conversation no longer triggers a background revalidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)