### PR TITLE
🐛 fix(react-scan): default scanner UI to off

### DIFF
--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -35,6 +35,6 @@ if (typeof window !== 'undefined') {
 
 if (__DEV__) {
   void import('react-scan').then(({ scan }) => {
-    scan({ enabled: true });
+    scan({ enabled: false, showToolbar: true });
   });
 }


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Set the React Scan development toolbar's initial scanning state to off while keeping the toolbar visible. Developers can still enable scanning manually from the React Scan UI when needed.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Static verification:

- `git diff --check`

Not run:

- Vitest: this worktree has no `node_modules`, and `pnpm install --frozen-lockfile` is blocked by the existing lockfile/overrides mismatch.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

N/A
