### PR TITLE
🐛 fix(agent-documents): filter `.tool-results` archive from document lists by default

### DIFF
--- a/apps/server/src/routers/lambda/agentDocument.ts
+++ b/apps/server/src/routers/lambda/agentDocument.ts
@@ -372,12 +372,16 @@ export const agentDocumentRouter = router({
     .input(
       z.object({
         agentId: z.string(),
+        // Reveal the auto-created `.tool-results` archive. Off by default so
+        // user-facing lists stay clean; the agent document-listing tool opts in.
+        includeArchivedToolResults: z.boolean().optional().default(false),
         scope: z.enum(['agent', 'currentTopic']).optional().default('agent'),
         sourceType: z.enum(['all', 'file', 'web']).optional().default('all'),
         topicId: z.string().optional(),
       }),
     )
     .query(async ({ ctx, input }) => {
+      const { includeArchivedToolResults } = input;
       if (input.scope === 'currentTopic') {
         if (!input.topicId) throw new Error('topicId is required to list current topic documents');
 
@@ -385,10 +389,13 @@ export const agentDocumentRouter = router({
           input.agentId,
           input.topicId,
           input.sourceType,
+          { includeArchivedToolResults },
         );
       }
 
-      return ctx.agentDocumentService.listDocuments(input.agentId, input.sourceType);
+      return ctx.agentDocumentService.listDocuments(input.agentId, input.sourceType, {
+        includeArchivedToolResults,
+      });
     }),
 
   /**

--- a/apps/server/src/services/agentDocuments/index.test.ts
+++ b/apps/server/src/services/agentDocuments/index.test.ts
@@ -96,6 +96,7 @@ describe('AgentDocumentsService', () => {
     findContextByAgent: vi.fn(),
     findByDocumentIds: vi.fn(),
     findByFilename: vi.fn(),
+    findByParentAndFilename: vi.fn(),
     findSkillDocsByAgent: vi.fn(),
     hasByAgent: vi.fn(),
     listByAgent: vi.fn(),
@@ -455,6 +456,64 @@ describe('AgentDocumentsService', () => {
         sourceType: 'web',
       });
       expect(mockModel.findByDocumentIds).not.toHaveBeenCalled();
+    });
+
+    it('should hide an archived tool result whose `.tool-results` folder is not topic-associated', async () => {
+      // The archive folder is created by mkdir but only the archived file gets
+      // associated with the topic, so the folder never appears in the list.
+      mockTopicDocumentModel.findByTopicId.mockResolvedValue([
+        { id: 'archive-child', title: 'dump' },
+      ]);
+      mockModel.listByDocumentIds.mockResolvedValue([
+        {
+          documentId: 'archive-child',
+          filename: 'topic_call.txt',
+          id: 'agent-doc-archive-child',
+          parentId: 'archive-root',
+          title: 'dump',
+        },
+      ]);
+      mockModel.findByParentAndFilename.mockResolvedValue({
+        documentId: 'archive-root',
+        fileType: 'custom/folder',
+        filename: '.tool-results',
+        id: 'agent-doc-archive-root',
+        parentId: null,
+      });
+
+      const service = new AgentDocumentsService(db, userId);
+      const result = await service.listDocumentsForTopic('agent-1', 'topic-1');
+
+      expect(mockModel.findByParentAndFilename).toHaveBeenCalledWith(
+        'agent-1',
+        null,
+        '.tool-results',
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('should keep the archived tool result when includeArchivedToolResults is set', async () => {
+      mockTopicDocumentModel.findByTopicId.mockResolvedValue([
+        { id: 'archive-child', title: 'dump' },
+      ]);
+      mockModel.listByDocumentIds.mockResolvedValue([
+        {
+          documentId: 'archive-child',
+          filename: 'topic_call.txt',
+          id: 'agent-doc-archive-child',
+          parentId: 'archive-root',
+          title: 'dump',
+        },
+      ]);
+
+      const service = new AgentDocumentsService(db, userId);
+      const result = await service.listDocumentsForTopic('agent-1', 'topic-1', undefined, {
+        includeArchivedToolResults: true,
+      });
+
+      expect(result.map((d) => d.documentId)).toEqual(['archive-child']);
+      // No folder lookup needed when archives are included.
+      expect(mockModel.findByParentAndFilename).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/src/services/agentDocuments/index.test.ts
+++ b/apps/server/src/services/agentDocuments/index.test.ts
@@ -333,6 +333,65 @@ describe('AgentDocumentsService', () => {
       expect(mockModel.listByAgent).toHaveBeenCalledWith('agent-1', { sourceType: 'web' });
       expect(mockModel.findByAgent).not.toHaveBeenCalled();
     });
+
+    it('should hide the .tool-results archive folder and its children by default', async () => {
+      mockModel.listByAgent.mockResolvedValue([
+        {
+          documentId: 'archive-root',
+          fileType: 'custom/folder',
+          filename: '.tool-results',
+          id: 'doc-archive',
+          parentId: null,
+          title: '.tool-results',
+        },
+        {
+          documentId: 'archive-child',
+          filename: 'dump.md',
+          id: 'doc-child',
+          parentId: 'archive-root',
+          title: 'dump',
+        },
+        {
+          documentId: 'documents-1',
+          filename: 'a.md',
+          id: 'doc-1',
+          parentId: null,
+          title: 'A',
+        },
+      ]);
+
+      const service = new AgentDocumentsService(db, userId);
+      const result = await service.listDocuments('agent-1');
+
+      expect(result.map((d) => d.documentId)).toEqual(['documents-1']);
+    });
+
+    it('should include the .tool-results archive when includeArchivedToolResults is set', async () => {
+      mockModel.listByAgent.mockResolvedValue([
+        {
+          documentId: 'archive-root',
+          fileType: 'custom/folder',
+          filename: '.tool-results',
+          id: 'doc-archive',
+          parentId: null,
+          title: '.tool-results',
+        },
+        {
+          documentId: 'documents-1',
+          filename: 'a.md',
+          id: 'doc-1',
+          parentId: null,
+          title: 'A',
+        },
+      ]);
+
+      const service = new AgentDocumentsService(db, userId);
+      const result = await service.listDocuments('agent-1', undefined, {
+        includeArchivedToolResults: true,
+      });
+
+      expect(result.map((d) => d.documentId)).toEqual(['archive-root', 'documents-1']);
+    });
   });
 
   describe('listDocumentsForTopic', () => {

--- a/apps/server/src/services/agentDocuments/index.ts
+++ b/apps/server/src/services/agentDocuments/index.ts
@@ -73,9 +73,9 @@ type ProjectableAgentDocument = Pick<
 
 /**
  * Hide the auto-created `.tool-results/` archive (root folder + its children)
- * from user-facing document lists. Agents still discover archived entries via
- * the tool-oriented `listDocuments` / `listDocumentsForTopic` paths, which hit
- * the model directly.
+ * from user-facing document lists. Applied by default everywhere, including
+ * `listDocuments` / `listDocumentsForTopic`. The tool runtime that lets agents
+ * discover archived entries opts back in via `includeArchivedToolResults`.
  */
 const excludeArchivedToolResults = <
   T extends Pick<AgentDocument, 'documentId' | 'parentId' | 'filename' | 'fileType'>,
@@ -613,16 +613,23 @@ export class AgentDocumentsService {
     }
   }
 
-  async listDocuments(agentId: string, sourceType?: AgentDocumentListSourceType) {
-    if (!sourceType) return this.agentDocumentModel.listByAgent(agentId);
+  async listDocuments(
+    agentId: string,
+    sourceType?: AgentDocumentListSourceType,
+    options?: { includeArchivedToolResults?: boolean },
+  ) {
+    const docs = sourceType
+      ? await this.agentDocumentModel.listByAgent(agentId, { sourceType })
+      : await this.agentDocumentModel.listByAgent(agentId);
 
-    return this.agentDocumentModel.listByAgent(agentId, { sourceType });
+    return options?.includeArchivedToolResults ? docs : excludeArchivedToolResults(docs);
   }
 
   async listDocumentsForTopic(
     agentId: string,
     topicId: string,
     sourceType?: AgentDocumentListSourceType,
+    options?: { includeArchivedToolResults?: boolean },
   ) {
     const topicDocs = await this.topicDocumentModel.findByTopicId(topicId);
     const documentIds = topicDocs.map((doc) => doc.id);
@@ -631,9 +638,11 @@ export class AgentDocumentsService {
       : await this.agentDocumentModel.listByDocumentIds(agentId, documentIds);
     const docsByDocumentId = new Map(docs.map((doc) => [doc.documentId, doc]));
 
-    return topicDocs
+    const ordered = topicDocs
       .map((topicDoc) => docsByDocumentId.get(topicDoc.id))
       .filter((doc): doc is AgentDocumentListItem => Boolean(doc));
+
+    return options?.includeArchivedToolResults ? ordered : excludeArchivedToolResults(ordered);
   }
 
   async getDocumentByFilename(agentId: string, filename: string) {

--- a/apps/server/src/services/agentDocuments/index.ts
+++ b/apps/server/src/services/agentDocuments/index.ts
@@ -71,18 +71,13 @@ type ProjectableAgentDocument = Pick<
   'content' | 'editorData' | 'fileType' | 'templateId'
 >;
 
-/**
- * Hide the auto-created `.tool-results/` archive (root folder + its children)
- * from user-facing document lists. Applied by default everywhere, including
- * `listDocuments` / `listDocumentsForTopic`. The tool runtime that lets agents
- * discover archived entries opts back in via `includeArchivedToolResults`.
- */
-const excludeArchivedToolResults = <
+/** Collect ids of root `.tool-results` archive folders present in a doc list. */
+const collectArchiveFolderIds = <
   T extends Pick<AgentDocument, 'documentId' | 'parentId' | 'filename' | 'fileType'>,
 >(
   docs: T[],
-): T[] => {
-  const archiveFolderIds = new Set(
+): Set<string> =>
+  new Set(
     docs
       .filter(
         (d) =>
@@ -92,6 +87,24 @@ const excludeArchivedToolResults = <
       )
       .map((d) => d.documentId),
   );
+
+/**
+ * Hide the auto-created `.tool-results/` archive (root folder + its children)
+ * from user-facing document lists. Applied by default everywhere, including
+ * `listDocuments` / `listDocumentsForTopic`. The tool runtime that lets agents
+ * discover archived entries opts back in via `includeArchivedToolResults`.
+ *
+ * `archiveFolderIds` lets callers whose list may not contain the folder row
+ * supply the ids explicitly — the topic path only sees the archived file
+ * (which is topic-associated), never the folder, so it can't be derived from
+ * the list alone.
+ */
+const excludeArchivedToolResults = <
+  T extends Pick<AgentDocument, 'documentId' | 'parentId' | 'filename' | 'fileType'>,
+>(
+  docs: T[],
+  archiveFolderIds: Set<string> = collectArchiveFolderIds(docs),
+): T[] => {
   if (archiveFolderIds.size === 0) return docs;
   return docs.filter(
     (d) =>
@@ -642,7 +655,22 @@ export class AgentDocumentsService {
       .map((topicDoc) => docsByDocumentId.get(topicDoc.id))
       .filter((doc): doc is AgentDocumentListItem => Boolean(doc));
 
-    return options?.includeArchivedToolResults ? ordered : excludeArchivedToolResults(ordered);
+    if (options?.includeArchivedToolResults) return ordered;
+
+    // The `.tool-results` folder is never topic-associated (only the archived
+    // file is), so it isn't in `ordered`. Look it up directly so the archived
+    // file can be filtered out by its parent id.
+    const archiveFolder = await this.agentDocumentModel.findByParentAndFilename(
+      agentId,
+      null,
+      TOOL_RESULTS_DIR_NAME,
+    );
+    const archiveFolderIds =
+      archiveFolder?.fileType === DOCUMENT_FOLDER_TYPE
+        ? new Set([archiveFolder.documentId])
+        : new Set<string>();
+
+    return excludeArchivedToolResults(ordered, archiveFolderIds);
   }
 
   async getDocumentByFilename(agentId: string, filename: string) {

--- a/apps/server/src/services/toolExecution/serverRuntimes/agentDocuments.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/agentDocuments.test.ts
@@ -26,7 +26,10 @@ describe('agentDocumentsRuntime', () => {
       });
       const result = await runtime.listDocuments({}, { agentId: 'agent-1' });
 
-      expect(listDocuments).toHaveBeenCalledWith('agent-1', 'all');
+      // The agent runtime opts into seeing the archived `.tool-results`.
+      expect(listDocuments).toHaveBeenCalledWith('agent-1', 'all', {
+        includeArchivedToolResults: true,
+      });
       expect(result).toEqual({
         content: JSON.stringify([
           { filename: 'rules.md', id: 'doc-1', title: 'Rules' },

--- a/apps/server/src/services/toolExecution/serverRuntimes/agentDocuments.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/agentDocuments.ts
@@ -155,7 +155,11 @@ export const agentDocumentsRuntime: ServerRuntimeRegistration = {
           ),
         ),
       listDocuments: async ({ agentId, sourceType }) => {
-        const docs = await service.listDocuments(agentId, sourceType);
+        // Agents discover archived tool results via this path (see
+        // `excludeArchivedToolResults`), so keep the `.tool-results` archive visible.
+        const docs = await service.listDocuments(agentId, sourceType, {
+          includeArchivedToolResults: true,
+        });
         return docs.map((d) => ({
           documentId: d.documentId,
           filename: d.filename,
@@ -164,7 +168,9 @@ export const agentDocumentsRuntime: ServerRuntimeRegistration = {
         }));
       },
       listTopicDocuments: async ({ agentId, sourceType, topicId }) => {
-        const docs = await service.listDocumentsForTopic(agentId, topicId, sourceType);
+        const docs = await service.listDocumentsForTopic(agentId, topicId, sourceType, {
+          includeArchivedToolResults: true,
+        });
         return docs.map((d) => ({
           documentId: d.documentId,
           filename: d.filename,

--- a/src/services/agentDocument.ts
+++ b/src/services/agentDocument.ts
@@ -58,6 +58,7 @@ class AgentDocumentService {
 
   listDocuments = async (params: {
     agentId: string;
+    includeArchivedToolResults?: boolean;
     scope?: 'agent' | 'currentTopic';
     sourceType?: 'all' | 'file' | 'web';
     topicId?: string;

--- a/src/store/tool/slices/builtin/executors/lobe-agent-documents.ts
+++ b/src/store/tool/slices/builtin/executors/lobe-agent-documents.ts
@@ -27,7 +27,13 @@ const runtime = new AgentDocumentsExecutionRuntime({
       trigger,
     }),
   listDocuments: async ({ agentId, sourceType }) => {
-    const docs = await agentDocumentService.listDocuments({ agentId, sourceType });
+    // The agent listing tool surfaces archived `.tool-results` so the model can
+    // discover them; user-facing lists keep the default (filtered) behavior.
+    const docs = await agentDocumentService.listDocuments({
+      agentId,
+      includeArchivedToolResults: true,
+      sourceType,
+    });
     return docs.map((d) => ({
       documentId: d.documentId,
       filename: d.filename,
@@ -38,6 +44,7 @@ const runtime = new AgentDocumentsExecutionRuntime({
   listTopicDocuments: async ({ agentId, sourceType, topicId }) => {
     const docs = await agentDocumentService.listDocuments({
       agentId,
+      includeArchivedToolResults: true,
       scope: 'currentTopic',
       sourceType,
       topicId,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

The auto-created `.tool-results` archive folder was leaking into the user-facing **documents** panel (showing up as a top-level `.tool-results` folder alongside real documents).

Root cause: the `excludeArchivedToolResults` filter was only applied in `getAgentDocuments` / `getAgentContextDocuments`, but the documents panel fetches via `listDocuments` / `listDocumentsForTopic`, which were unfiltered.

Fix — do the filtering on the **backend, by default**:

- `AgentDocumentsService.listDocuments` / `listDocumentsForTopic` now exclude the `.tool-results` archive (root folder + its children) by default, with an opt-in `{ includeArchivedToolResults }` option.
- Both agent document-listing tool runtimes opt back in, so agents can still discover archived tool results:
  - server runtime (`serverRuntimes/agentDocuments.ts`)
  - client runtime — threaded through the TRPC `listDocuments` endpoint → frontend service → builtin tool executor.

Net effect: all user-facing paths (documents panel, context, skills) are clean by default; only the agent's explicit listing tool sees the archive.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added unit tests covering (1) the `.tool-results` folder + children being hidden by default and (2) the `includeArchivedToolResults` opt-in returning them. `agentDocuments/index.test.ts` — 35 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)