### PR TITLE
✨ feat(chat): add compact floating chat input

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -391,6 +391,7 @@
   "operation.heterogeneousAgentFallback": "External agent",
   "operation.sendMessage": "Sending message",
   "owner": "Group owner",
+  "pageCopilot.inlinePlaceholder": "Ask or edit this page",
   "pageCopilot.title": "Page Agent",
   "pageCopilot.welcome": "**Clearer, sharper writing**\n\nDraft, rewrite, or polish—tell me your intent and I'll refine the rest.",
   "pageSelection.lines": "Lines {{start}}-{{end}}",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -391,6 +391,7 @@
   "operation.heterogeneousAgentFallback": "外部智能体",
   "operation.sendMessage": "消息发送中",
   "owner": "群主",
+  "pageCopilot.inlinePlaceholder": "询问或修改这篇文稿",
   "pageCopilot.title": "文稿助理",
   "pageCopilot.welcome": "**让文字更清晰、更到位**\n\n起草、改写、润色都可以。你把意图说清楚，其余交给我打磨",
   "pageSelection.lines": "第 {{start}}-{{end}} 行",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -468,6 +468,7 @@ export default {
   'owner': 'Group owner',
   'pageCopilot.title': 'Page Agent',
   'pageCopilot.welcome': `**Clearer, sharper writing**\n\nDraft, rewrite, or polish—tell me your intent and I'll refine the rest.`,
+  'pageCopilot.inlinePlaceholder': 'Ask or edit this page',
   'pageSelection.lines': 'Lines {{start}}-{{end}}',
   'pageSelection.reference': 'Selected Text',
   'pin': 'Pin',

--- a/src/features/FloatingChatPanel/ChatBody.test.tsx
+++ b/src/features/FloatingChatPanel/ChatBody.test.tsx
@@ -3,7 +3,7 @@
  */
 import { render, screen } from '@testing-library/react';
 import type { CSSProperties, ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import ChatBody from './ChatBody';
 
@@ -36,12 +36,46 @@ vi.mock('@lobehub/ui', () => ({
 }));
 
 vi.mock('@/features/Conversation', () => ({
-  ChatInput: () => <div data-testid="floating-chat-input">chat input</div>,
   ChatList: () => <div data-testid="floating-chat-list">chat list</div>,
 }));
 
+const mockConversationState = vi.hoisted(() => ({
+  displayMessageIds: [] as string[],
+}));
+
+vi.mock('@/features/Conversation/store', () => ({
+  dataSelectors: {
+    displayMessageIds: (s: { displayMessageIds: string[] }) => s.displayMessageIds,
+  },
+  useConversationStore: (selector: (state: { displayMessageIds: string[] }) => unknown) =>
+    selector(mockConversationState),
+}));
+
+vi.mock('./MiniChatInput', () => ({
+  default: () => <div data-testid="floating-chat-input">mini input</div>,
+}));
+
 describe('FloatingChatPanel ChatBody', () => {
-  it('keeps the chat input after the list while leaving scroll ownership to the virtual list', () => {
+  beforeEach(() => {
+    mockConversationState.displayMessageIds = [];
+  });
+
+  it('renders only the mini input before the conversation starts', () => {
+    render(<ChatBody />);
+
+    const body = screen.getByTestId('floating-chat-panel-body');
+    const input = screen.getByTestId('floating-chat-input');
+
+    expect(body).toHaveAttribute('data-flex', '1');
+    expect(body).toHaveAttribute('data-height', '100%');
+    expect(body).toContainElement(input);
+    expect(screen.queryByTestId('floating-chat-panel-list')).not.toBeInTheDocument();
+    expect(body).toHaveStyle({ overflow: 'hidden' });
+  });
+
+  it('keeps the mini input after the list once messages exist', () => {
+    mockConversationState.displayMessageIds = ['message-1'];
+
     render(<ChatBody />);
 
     const body = screen.getByTestId('floating-chat-panel-body');

--- a/src/features/FloatingChatPanel/ChatBody.tsx
+++ b/src/features/FloatingChatPanel/ChatBody.tsx
@@ -3,9 +3,14 @@
 import { Flexbox } from '@lobehub/ui';
 import { memo } from 'react';
 
-import { ChatInput, ChatList } from '@/features/Conversation';
+import { ChatList } from '@/features/Conversation';
+import { dataSelectors, useConversationStore } from '@/features/Conversation/store';
+
+import MiniChatInput from './MiniChatInput';
 
 const ChatBody = memo(() => {
+  const hasMessages = useConversationStore((s) => dataSelectors.displayMessageIds(s).length > 0);
+
   return (
     <Flexbox
       data-testid="floating-chat-panel-body"
@@ -14,19 +19,21 @@ const ChatBody = memo(() => {
       style={{ minHeight: 0, overflow: 'hidden' }}
       width={'100%'}
     >
-      <Flexbox
-        data-testid="floating-chat-panel-list"
-        flex={1}
-        width={'100%'}
-        style={{
-          minHeight: 0,
-          overflow: 'hidden',
-          position: 'relative',
-        }}
-      >
-        <ChatList />
-      </Flexbox>
-      <ChatInput leftActions={['typo', 'stt']} rightActions={['contextWindow']} />
+      {hasMessages && (
+        <Flexbox
+          data-testid="floating-chat-panel-list"
+          flex={1}
+          width={'100%'}
+          style={{
+            minHeight: 0,
+            overflow: 'hidden',
+            position: 'relative',
+          }}
+        >
+          <ChatList />
+        </Flexbox>
+      )}
+      <MiniChatInput />
     </Flexbox>
   );
 });

--- a/src/features/FloatingChatPanel/MiniChatInput.tsx
+++ b/src/features/FloatingChatPanel/MiniChatInput.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { ChatInput as EditorChatInput, ChatInputActionBar } from '@lobehub/editor/react';
+import { Flexbox } from '@lobehub/ui';
+import { createStaticStyles } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { ActionKeys, ChatInputFeature } from '@/features/ChatInput';
+import { actionMap } from '@/features/ChatInput/ActionBar/config';
+import type { ActionBarContextValue } from '@/features/ChatInput/ActionBar/context';
+import { ActionBarContext } from '@/features/ChatInput/ActionBar/context';
+import InputEditor from '@/features/ChatInput/InputEditor';
+import SendButton from '@/features/ChatInput/SendArea/SendButton';
+import { useChatInputStore } from '@/features/ChatInput/store';
+import TypoBar from '@/features/ChatInput/TypoBar';
+import { ChatInput } from '@/features/Conversation';
+
+const Typo = actionMap.typo;
+const STT = actionMap.stt;
+
+const MINI_LEFT_ACTIONS: ActionKeys[] = ['typo', 'stt'];
+const EMPTY_RIGHT_ACTIONS: ActionKeys[] = [];
+const MINI_CHAT_INPUT_FEATURE = {
+  inputCompletion: true,
+  mention: false,
+  slash: true,
+} satisfies ChatInputFeature;
+const MINI_SEND_BUTTON_PROPS = { size: 28 };
+
+const MINI_ACTION_CONTEXT = {
+  actionSize: { blockSize: 26, size: 15 },
+  borderRadius: 8,
+  dropdownPlacement: 'top',
+} satisfies ActionBarContextValue;
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  container: css`
+    flex-shrink: 0;
+
+    width: 100%;
+    padding-block: 8px 10px;
+    padding-inline: 12px;
+    border-block-start: 1px solid ${cssVar.colorBorderSecondary};
+
+    background: ${cssVar.colorBgContainer};
+  `,
+  input: css`
+    border-color: ${cssVar.colorBorderSecondary};
+    border-radius: 10px !important;
+
+    background: ${cssVar.colorFillTertiary};
+    box-shadow: none;
+
+    transition:
+      border-color 0.2s ease,
+      background 0.2s ease;
+
+    &:focus-within {
+      border-color: ${cssVar.colorPrimary};
+      background: ${cssVar.colorBgContainer};
+    }
+  `,
+}));
+
+const MiniChatInputInner = memo(() => {
+  const { t } = useTranslation('chat');
+  const [showTypoBar, slashMenuRef] = useChatInputStore((s) => [s.showTypoBar, s.slashMenuRef]);
+
+  return (
+    <Flexbox className={styles.container} data-testid="floating-chat-panel-input">
+      <EditorChatInput
+        className={styles.input}
+        defaultHeight={34}
+        header={showTypoBar && <TypoBar />}
+        maxHeight={136}
+        minHeight={34}
+        resize={false}
+        slashMenuRef={slashMenuRef}
+        footer={
+          <ChatInputActionBar
+            right={<SendButton />}
+            style={{ padding: '0 6px 6px' }}
+            left={
+              <ActionBarContext value={MINI_ACTION_CONTEXT}>
+                <Flexbox horizontal align={'center'} gap={2}>
+                  <Typo />
+                  <STT />
+                </Flexbox>
+              </ActionBarContext>
+            }
+          />
+        }
+      >
+        <InputEditor defaultRows={1} placeholder={t('pageCopilot.inlinePlaceholder')} />
+      </EditorChatInput>
+    </Flexbox>
+  );
+});
+
+MiniChatInputInner.displayName = 'FloatingChatPanelMiniChatInputInner';
+
+const MiniChatInput = memo(() => {
+  return (
+    <ChatInput
+      allowExpand={false}
+      feature={MINI_CHAT_INPUT_FEATURE}
+      leftActions={MINI_LEFT_ACTIONS}
+      rightActions={EMPTY_RIGHT_ACTIONS}
+      sendButtonProps={MINI_SEND_BUTTON_PROPS}
+      showControlBar={false}
+    >
+      <MiniChatInputInner />
+    </ChatInput>
+  );
+});
+
+MiniChatInput.displayName = 'FloatingChatPanelMiniChatInput';
+
+export default MiniChatInput;

--- a/src/features/FloatingChatPanel/index.test.tsx
+++ b/src/features/FloatingChatPanel/index.test.tsx
@@ -192,7 +192,7 @@ describe('FloatingChatPanel', () => {
   it('applies default shell props', () => {
     const { getByTestId } = render(<FloatingChatPanel agentId="a" topicId="t" />);
     const sheet = getByTestId('floating-panel-shell');
-    expect(sheet.dataset.snapPoints).toBe(JSON.stringify([180, 320, 520, 800]));
+    expect(sheet.dataset.snapPoints).toBe(JSON.stringify([128, 320, 520, 800]));
     expect(sheet.dataset.variant).toBe('embedded');
     expect(sheet.dataset.dismissible).toBe('false');
   });

--- a/src/features/FloatingChatPanel/index.tsx
+++ b/src/features/FloatingChatPanel/index.tsx
@@ -4,7 +4,7 @@ import { ThreadType, type UIChatMessage } from '@lobechat/types';
 import { FloatingSheet, type FloatingSheetProps } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import type { ReactNode } from 'react';
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   type ActionsBarConfig,
@@ -24,9 +24,10 @@ import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 import ChatBody from './ChatBody';
 import { useSingleInstanceGuard } from './guard';
 
-const SNAP_POINTS = [180, 320, 520, 800] as const;
+const SNAP_POINTS = [128, 320, 520, 800] as const;
 const MAX_SNAP_POINT = SNAP_POINTS.at(-1)!;
 const REST_SNAP_POINT = SNAP_POINTS[0];
+const CONVERSATION_SNAP_POINT = SNAP_POINTS[1];
 
 const styles = createStaticStyles(({ css }) => ({
   sheet: css`
@@ -241,6 +242,14 @@ const FloatingChatPanel = memo<FloatingChatPanelProps>(
 
     const [open, setOpen] = useState(true);
     const [activeSnapPoint, setActiveSnapPoint] = useState<number>(REST_SNAP_POINT);
+    const hasAutoExpandedExistingThreadRef = useRef(false);
+    const hasPanelMessages = (messages?.length ?? 0) > 0;
+
+    useEffect(() => {
+      if (!hasPanelMessages || hasAutoExpandedExistingThreadRef.current) return;
+      hasAutoExpandedExistingThreadRef.current = true;
+      setActiveSnapPoint((point) => (point === REST_SNAP_POINT ? CONVERSATION_SNAP_POINT : point));
+    }, [hasPanelMessages]);
 
     const agentChatConfig = useAgentStore(chatConfigByIdSelectors.getChatConfigById(agentId));
     const chatFollowUpHooks = useChatFollowUp({
@@ -275,7 +284,7 @@ const FloatingChatPanel = memo<FloatingChatPanelProps>(
       headerActions,
 
       maxHeight: MAX_SNAP_POINT,
-      minHeight: SNAP_POINTS[1],
+      minHeight: REST_SNAP_POINT,
       mode: 'inline',
       onOpenChange: setOpen,
       onSnapPointChange: setActiveSnapPoint,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Add a compact floating chat input for the page copilot panel.
- Keep the message list hidden until the floating conversation has messages.
- Reduce the resting snap point and auto-expand existing conversations to the conversation snap point.
- Add the inline input placeholder to default, en-US, and zh-CN chat locales.
- Update FloatingChatPanel tests for the empty and populated conversation states.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
git diff --check
bunx vitest run --silent='passed-only' 'src/features/FloatingChatPanel/ChatBody.test.tsx' 'src/features/FloatingChatPanel/index.test.tsx'
bun run type-check
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Created as a dedicated PR separate from #15898.
