### PR TITLE
chore: clean up LOBE-XXX code comment markers (2026-06-17)

### DIFF
--- a/apps/server/src/services/document/index.ts
+++ b/apps/server/src/services/document/index.ts
@@ -311,8 +311,8 @@ export class DocumentService {
    */
   async runWithDocumentLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
     if (!this.workspaceId) {
-      // TEMP DIAGNOSTIC (LOBE-10470): distinguishes "no-op because workspaceId is
-      // missing at runtime" from "lock actually evaluated". Remove once verified.
+      // Diagnostic: distinguishes "no-op because workspaceId is
+      // missing at runtime" from "lock actually evaluated".
       log('runWithDocumentLock skip: no workspaceId (id=%s userId=%s)', id, this.userId);
       return fn();
     }
@@ -330,7 +330,7 @@ export class DocumentService {
       heldBeforeByUser && holderBefore?.ownerId ? holderBefore.ownerId : `server:${randomUUID()}`;
 
     const lock = await this.acquireDocumentLockWithOwner(id, ownerId);
-    // TEMP DIAGNOSTIC (LOBE-10470): one reproduction reveals workspaceId/holder/acquire.
+    // Diagnostic: surfaces workspaceId/holder/acquire for debugging lock issues.
     log(
       'runWithDocumentLock: id=%s userId=%s ws=%s holderBefore=%s acquired=%o',
       id,

--- a/packages/agent-gateway-client/src/client.test.ts
+++ b/packages/agent-gateway-client/src/client.test.ts
@@ -319,7 +319,7 @@ describe('AgentStreamClient', () => {
     });
   });
 
-  // Regression guard for LOBE-10443: a fresh subscriber (no lastEventId) on a
+  // Regression guard: a fresh subscriber (no lastEventId) on a
   // hibernated DO replays zero events. The client must NOT guess "completed"
   // from silence (the old 3s timeout did, which cleared the shared
   // runningOperation and cancelled the run on every device). Completion is now

--- a/packages/agent-gateway-client/src/client.ts
+++ b/packages/agent-gateway-client/src/client.ts
@@ -240,9 +240,9 @@ export class AgentStreamClient extends TypedEmitter {
           // what exits resume mode and decides completion. We deliberately do
           // NOT arm a timeout to guess completion from silence: an empty replay
           // no longer means "finished" (the DO may simply have hibernated its
-          // event buffer), and guessing was exactly the LOBE-10443 multi-device
+          // event buffer), and guessing was exactly the multi-device
           // false-cancel bug. If `resume_complete` never arrives (e.g. a
-          // rolled-back DO that predates LOBE-10443), we just keep waiting — a
+          // rolled-back DO that predates the authoritative resume_complete fix), we just keep waiting — a
           // safe, recoverable state, with heartbeat loss still forcing reconnect
           // — instead of cancelling a live run.
           if (this.resumeOnConnect && !this.lastEventId) {
@@ -252,7 +252,7 @@ export class AgentStreamClient extends TypedEmitter {
 
           // Request all buffered events (covers events pushed before WS connected).
           // `wantStatus` opts into the authoritative `resume_complete` reply
-          // (LOBE-10443): this client knows how to consume it, so a current
+          // this client knows how to consume it, so a current
           // gateway will hand back the real session status. Legacy gateways
           // ignore the flag and just replay — we then rely on live events, never
           // guessing completion from silence.
@@ -309,7 +309,7 @@ export class AgentStreamClient extends TypedEmitter {
 
         case 'resume_complete': {
           // Authoritative status from the DO, sent right after resume replay
-          // (LOBE-10443) — this is the definitive end-of-replay marker, so
+          // — this is the definitive end-of-replay marker, so
           // cancel the pending debounce flush and act on it immediately.
           if (this.resumeFlushTimer) {
             clearTimeout(this.resumeFlushTimer);

--- a/packages/agent-gateway-client/src/types.ts
+++ b/packages/agent-gateway-client/src/types.ts
@@ -163,7 +163,7 @@ export interface ResumeMessage {
   lastEventId: string;
   type: 'resume';
   /**
-   * Opt into the authoritative `resume_complete` reply (LOBE-10443). Set by
+   * Opt into the authoritative `resume_complete` reply. Set by
    * this client so a current gateway hands back the stored session status;
    * legacy gateways ignore it and replay only.
    */
@@ -252,7 +252,7 @@ export type SessionStatus =
  * is wiped by hibernation, an empty replay is ambiguous — the run may still be
  * alive. This message resolves that ambiguity so the client never guesses
  * "completed" from silence (which would clear the shared `runningOperation` and
- * cancel the run on every device). See LOBE-10443.
+ * cancel the run on every device).
  */
 export interface ResumeCompleteMessage {
   status: SessionStatus;

--- a/packages/conversation-flow/src/__tests__/dualForm.test.ts
+++ b/packages/conversation-flow/src/__tests__/dualForm.test.ts
@@ -4,7 +4,7 @@ import { parse } from '../parse';
 import type { Message } from '../types/shared';
 
 /**
- * Dual-form message-chain reader (LOBE-10445, phase 1)
+ * Dual-form message-chain reader (phase 1)
  *
  * Two persisted chain shapes must parse to equivalent display output:
  *
@@ -106,7 +106,7 @@ const shape = (flatList: Message[]) =>
     role: m.role,
   }));
 
-describe('dual-form message chain (LOBE-10445)', () => {
+describe('dual-form message chain', () => {
   // Canonical turn: u1 → a1(tc1) → a2(tc2) → a3(final, no tool)
   const canonical: StepSpec[] = [
     { content: 'step1', id: 'a1', tools: ['tc1'] },

--- a/packages/conversation-flow/src/transformation/ContextTreeBuilder.ts
+++ b/packages/conversation-flow/src/transformation/ContextTreeBuilder.ts
@@ -156,7 +156,7 @@ export class ContextTreeBuilder {
       return;
     }
 
-    // Priority 6: Branch — multiple NON-TOOL children (LOBE-10445 invariant 2).
+    // Priority 6: Branch — multiple NON-TOOL children (dual-form reader invariant: tool children are inline data, not branch candidates).
     // Tool children are inline data of their assistant (handled by Priority 4),
     // never branch candidates.
     const nonToolChildren = idNode.children.filter(
@@ -206,7 +206,7 @@ export class ContextTreeBuilder {
   private isAssistantGroupNode(message: Message, idNode: IdNode): boolean {
     if (message.role !== 'assistant') return false;
 
-    // Role-aware (LOBE-10445): an assistant heads a group when it has ANY tool
+    // Role-aware (dual-form reader): an assistant heads a group when it has ANY tool
     // child — not only when ALL children are tools. In the assistant-anchored
     // form the next step's assistant is a sibling of the tool results, so a
     // group head legitimately has a mix of tool + assistant children. (In the

--- a/packages/conversation-flow/src/transformation/FlatListBuilder.ts
+++ b/packages/conversation-flow/src/transformation/FlatListBuilder.ts
@@ -290,7 +290,7 @@ export class FlatListBuilder {
 
       // Priority 3a: Compare mode from user message metadata
       const childMessages = this.childrenMap.get(message.id) ?? [];
-      // Non-tool children only are branch candidates (LOBE-10445 invariant 2):
+      // Non-tool children only are branch candidates (dual-form reader invariant: tool children are inline, not branches):
       // a tool child is inline data of its assistant, never a sibling branch.
       const nonToolChildMessages = childMessages.filter(
         (childId) => this.messageMap.get(childId)?.role !== 'tool',

--- a/packages/conversation-flow/src/transformation/MessageCollector.ts
+++ b/packages/conversation-flow/src/transformation/MessageCollector.ts
@@ -135,7 +135,7 @@ export class MessageCollector {
     const toolMessages = this.collectToolMessages(currentAssistant, allMessages);
     allToolMessages.push(...toolMessages);
 
-    // Find the next step's assistant. Role-aware dual-form walk (LOBE-10445):
+    // Find the next step's assistant. Role-aware dual-form walk:
     // the continuation may hang off this assistant directly (assistant-anchored
     // / new form) OR off one of its tool results (tool-anchored / old form).
     const continuation = this.findFlatChainContinuation(

--- a/src/features/PageEditor/usePageLockedBySelf.test.tsx
+++ b/src/features/PageEditor/usePageLockedBySelf.test.tsx
@@ -77,7 +77,7 @@ describe('usePageLockedBySelf', () => {
     expect(result.current).toBe(false);
   });
 
-  it('returns true when I hold the lock and the lock is reported as "by other" (future LOBE-10480 path)', () => {
+  it('returns true when I hold the lock and the lock is reported as "by other" (future session-scoped lock path)', () => {
     mockPageState.current.lockHolderId = 'user-me';
     isLockedByOtherMock.mockReturnValue(true);
     const { result } = renderHook(() => usePageLockedBySelf());

--- a/src/features/PageEditor/usePageLockedBySelf.ts
+++ b/src/features/PageEditor/usePageLockedBySelf.ts
@@ -19,7 +19,7 @@ import { usePageLockedByOther } from './usePageLockedByOther';
  * `{their own name} is editing this document` (which reads like another person
  * has taken the page) and instead show a self-aware message.
  *
- * Forward-compatible with the LOBE-10480 session-aware refactor: once
+ * Forward-compatible with the session-aware (session-scoped lease-backed) lock refactor: once
  * `usePageLockedByOther` returns true for a different-session-same-user holder,
  * this hook will pick that up automatically — for now it relies primarily on
  * the `saveBlockedByLock` signal that CONFLICT save responses set.


### PR DESCRIPTION
## Summary

Automated daily cleanup of LOBE-XXX format comment markers from the codebase.

## Changes

All LOBE-XXX references in comments have been replaced with descriptive inline context:

- **LOBE-10443** (multi-device resume race): authoritative resume_complete mechanism
- **LOBE-10445** (dual-form reader): inline invariant explanations
- **LOBE-10470** (write lock): TEMP DIAGNOSTIC → plain diagnostic
- **LOBE-10480** (session lock): session-aware refactor description

## Files changed (10 files, 18 insertions, 18 deletions)

apps/server/src/services/document/index.ts
packages/agent-gateway-client/src/client.test.ts
packages/agent-gateway-client/src/client.ts
packages/agent-gateway-client/src/types.ts
packages/conversation-flow/src/__tests__/dualForm.test.ts
packages/conversation-flow/src/transformation/ContextTreeBuilder.ts
packages/conversation-flow/src/transformation/FlatListBuilder.ts
packages/conversation-flow/src/transformation/MessageCollector.ts
src/features/PageEditor/usePageLockedBySelf.test.tsx
src/features/PageEditor/usePageLockedBySelf.ts