### PR TITLE
🐛 fix(agent): centralize inbox agent meta fallback across read paths

### DIFF
--- a/apps/server/src/routers/lambda/messenger.ts
+++ b/apps/server/src/routers/lambda/messenger.ts
@@ -122,6 +122,12 @@ const messengerProcedure = authedProcedure.use(serverDatabase).use(async (opts) 
       // userId), and per-agent authorization happens in-handler via
       // `resolveAuthorizedAgentScope`.
       messengerLinkModel: new MessengerAccountLinkModel(ctx.serverDB, ctx.userId),
+      // The bindable-agents scope is request-driven — the cascading scope
+      // picker passes the workspace via input, not the ambient header — so
+      // expose a workspace-parameterized AgentModel factory rather than a
+      // single pre-scoped instance.
+      getAgentModel: (workspaceId?: string | null) =>
+        new AgentModel(ctx.serverDB, ctx.userId, workspaceId ?? undefined),
     },
   });
 });
@@ -456,11 +462,7 @@ export const messengerRouter = router({
 
       // The inbox meta fallback, the virtual-or-inbox filter, and the inbox
       // pinning all live in the model — the router only shapes the response.
-      const rows = await new AgentModel(
-        serverDB,
-        userId,
-        workspaceId ?? undefined,
-      ).listMessengerBindableAgents();
+      const rows = await ctx.getAgentModel(workspaceId).listMessengerBindableAgents();
 
       return rows.map(({ slug, ...rest }) => ({
         avatar: rest.avatar,

--- a/apps/server/src/routers/lambda/messenger.ts
+++ b/apps/server/src/routers/lambda/messenger.ts
@@ -1,4 +1,3 @@
-import { INBOX_SESSION_ID } from '@lobechat/const';
 import { TRPCError } from '@trpc/server';
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
@@ -460,17 +459,10 @@ export const messengerRouter = router({
         }
       }
 
-      // The inbox meta fallback, the virtual-or-inbox filter, and the inbox
-      // pinning all live in the model — the router only shapes the response.
-      const rows = await ctx.getAgentModel(workspaceId).listMessengerBindableAgents();
-
-      return rows.map(({ slug, ...rest }) => ({
-        avatar: rest.avatar,
-        backgroundColor: rest.backgroundColor,
-        id: rest.id,
-        isInbox: slug === INBOX_SESSION_ID,
-        title: rest.title,
-      }));
+      // Inbox meta fallback, the virtual-or-inbox filter, inbox pinning, and the
+      // `isInbox` flag all live in the model. Blank non-inbox titles stay null
+      // here so the web picker can apply its own i18n default.
+      return ctx.getAgentModel(workspaceId).listMessengerBindableAgents();
     }),
 
   /**

--- a/apps/server/src/routers/lambda/messenger.ts
+++ b/apps/server/src/routers/lambda/messenger.ts
@@ -1,6 +1,6 @@
-import { DEFAULT_INBOX_AVATAR, INBOX_SESSION_ID } from '@lobechat/const';
+import { INBOX_SESSION_ID } from '@lobechat/const';
 import { TRPCError } from '@trpc/server';
-import { and, desc, eq, ne, or } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 
 import { withScopedPermission } from '@/business/server/trpc-middlewares/rbacPermission';
@@ -12,6 +12,7 @@ import {
   isMessengerPlatformEnabled,
   type MessengerPlatform,
 } from '@/config/messenger';
+import { AgentModel } from '@/database/models/agent';
 import {
   MessengerAccountLinkConflictError,
   MessengerAccountLinkModel,
@@ -23,7 +24,6 @@ import { RbacModel } from '@/database/models/rbac';
 import { WorkspaceModel } from '@/database/models/workspace';
 import { agents, users } from '@/database/schemas';
 import type { LobeChatDatabase } from '@/database/type';
-import { buildWorkspaceWhere } from '@/database/utils/workspace';
 import { authedProcedure, publicProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { getServerFeatureFlagsStateFromRuntimeConfig } from '@/server/featureFlags';
@@ -454,43 +454,20 @@ export const messengerRouter = router({
         }
       }
 
-      const rows = await serverDB
-        .select({
-          avatar: agents.avatar,
-          backgroundColor: agents.backgroundColor,
-          id: agents.id,
-          slug: agents.slug,
-          title: agents.title,
-        })
-        .from(agents)
-        .where(
-          and(
-            buildWorkspaceWhere({ userId, workspaceId: workspaceId ?? undefined }, agents),
-            or(ne(agents.virtual, true), eq(agents.slug, INBOX_SESSION_ID)),
-          ),
-        )
-        .orderBy(desc(agents.updatedAt));
+      // The inbox meta fallback, the virtual-or-inbox filter, and the inbox
+      // pinning all live in the model — the router only shapes the response.
+      const rows = await new AgentModel(
+        serverDB,
+        userId,
+        workspaceId ?? undefined,
+      ).listMessengerBindableAgents();
 
-      const mapped = rows
-        .filter((row) => row.id)
-        .map((row) => ({
-          avatar: row.avatar || (row.slug === INBOX_SESSION_ID ? DEFAULT_INBOX_AVATAR : null),
-          backgroundColor: row.backgroundColor,
-          id: row.id,
-          slug: row.slug,
-          title: row.title || (row.slug === INBOX_SESSION_ID ? 'LobeAI' : null),
-        }));
-
-      // Pin the inbox/LobeAI agent to the top regardless of updatedAt — it's
-      // the implicit "default" agent and should always be the first option.
-      const inboxIdx = mapped.findIndex((row) => row.slug === INBOX_SESSION_ID);
-      if (inboxIdx > 0) {
-        const [inbox] = mapped.splice(inboxIdx, 1);
-        mapped.unshift(inbox);
-      }
-      return mapped.map(({ slug, ...rest }) => ({
-        ...rest,
+      return rows.map(({ slug, ...rest }) => ({
+        avatar: rest.avatar,
+        backgroundColor: rest.backgroundColor,
+        id: rest.id,
         isInbox: slug === INBOX_SESSION_ID,
+        title: rest.title,
       }));
     }),
 

--- a/apps/server/src/routers/lambda/topic.ts
+++ b/apps/server/src/routers/lambda/topic.ts
@@ -37,7 +37,9 @@ const topicProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) =>
   return opts.next({
     ctx: {
       agentMigrationRepo: new AgentMigrationRepo(ctx.serverDB, ctx.userId, wsId),
+      agentModel: new AgentModel(ctx.serverDB, ctx.userId, wsId),
       agentOperationModel: new AgentOperationModel(ctx.serverDB, ctx.userId, wsId),
+      chatGroupModel: new ChatGroupModel(ctx.serverDB, ctx.userId, wsId),
       topicImporterRepo: new TopicImporterRepo(ctx.serverDB, ctx.userId, wsId),
       topicModel: new TopicModel(ctx.serverDB, ctx.userId, wsId),
       topicShareModel: new TopicShareModel(ctx.serverDB, ctx.userId, wsId),
@@ -447,13 +449,6 @@ export const topicRouter = router({
       // Collect all agentIds to fetch agent info
       const allAgentIds = [...new Set(topicAgentIdMap.values())];
 
-      const agentModel = new AgentModel(ctx.serverDB, ctx.userId, ctx.workspaceId ?? undefined);
-      const chatGroupModel = new ChatGroupModel(
-        ctx.serverDB,
-        ctx.userId,
-        ctx.workspaceId ?? undefined,
-      );
-
       // Batch query agent info (already normalized for the inbox agent)
       const agentInfoMap = new Map<
         string,
@@ -461,7 +456,7 @@ export const topicRouter = router({
       >();
 
       if (allAgentIds.length > 0) {
-        const agentInfos = await agentModel.getAgentAvatarsByIds(allAgentIds);
+        const agentInfos = await ctx.agentModel.getAgentAvatarsByIds(allAgentIds);
 
         for (const agent of agentInfos) {
           agentInfoMap.set(agent.id, agent);
@@ -484,7 +479,7 @@ export const topicRouter = router({
 
         // Query group member avatars (already normalized for the inbox agent)
         const groupMembersMap: Map<string, RecentTopicGroupMember[]> =
-          await chatGroupModel.getMemberAvatarsByGroupIds(allGroupIds);
+          await ctx.chatGroupModel.getMemberAvatarsByGroupIds(allGroupIds);
 
         // Build group info map
         for (const group of chatGroupInfos) {

--- a/apps/server/src/routers/lambda/topic.ts
+++ b/apps/server/src/routers/lambda/topic.ts
@@ -17,6 +17,7 @@ import { TopicShareModel } from '@/database/models/topicShare';
 import { AgentMigrationRepo } from '@/database/repositories/agentMigration';
 import { TopicImporterRepo } from '@/database/repositories/topicImporter';
 import { agents, chatGroups, chatGroupsAgents } from '@/database/schemas';
+import { normalizeInboxAgentAvatar, normalizeInboxAgentMeta } from '@/database/utils/inboxAgent';
 import { router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { type BatchTaskResult } from '@/types/service';
@@ -448,7 +449,13 @@ export const topicRouter = router({
       // Batch query agent info
       const agentInfoMap = new Map<
         string,
-        { avatar: string | null; backgroundColor: string | null; id: string; title: string | null }
+        {
+          avatar: string | null;
+          backgroundColor: string | null;
+          id: string;
+          slug: string | null;
+          title: string | null;
+        }
       >();
 
       if (allAgentIds.length > 0) {
@@ -457,6 +464,7 @@ export const topicRouter = router({
             avatar: agents.avatar,
             backgroundColor: agents.backgroundColor,
             id: agents.id,
+            slug: agents.slug,
             title: agents.title,
           })
           .from(agents)
@@ -486,6 +494,7 @@ export const topicRouter = router({
           .select({
             agentAvatar: agents.avatar,
             agentBackgroundColor: agents.backgroundColor,
+            agentSlug: agents.slug,
             chatGroupId: chatGroupsAgents.chatGroupId,
             order: chatGroupsAgents.order,
           })
@@ -498,7 +507,7 @@ export const topicRouter = router({
         for (const member of groupMembersRaw) {
           const members = groupMembersMap.get(member.chatGroupId) || [];
           members.push({
-            avatar: member.agentAvatar,
+            avatar: normalizeInboxAgentAvatar(member.agentAvatar, { slug: member.agentSlug }),
             backgroundColor: member.agentBackgroundColor,
           });
           groupMembersMap.set(member.chatGroupId, members);
@@ -548,7 +557,19 @@ export const topicRouter = router({
 
         // Always return agent with id if agentId exists (even if avatar/title are null)
         // Frontend needs agent.id to generate links
-        const validAgent = agentInfo ? cleanObject(agentInfo) : null;
+        const validAgent = agentInfo
+          ? cleanObject(
+              normalizeInboxAgentMeta(
+                {
+                  avatar: agentInfo.avatar,
+                  backgroundColor: agentInfo.backgroundColor,
+                  id: agentInfo.id,
+                  title: agentInfo.title,
+                },
+                { slug: agentInfo.slug },
+              ),
+            )
+          : null;
 
         return {
           agent: validAgent,

--- a/apps/server/src/routers/lambda/topic.ts
+++ b/apps/server/src/routers/lambda/topic.ts
@@ -4,20 +4,21 @@ import {
   type RecentTopicGroupMember,
 } from '@lobechat/types';
 import { cleanObject } from '@lobechat/utils';
-import { eq, inArray } from 'drizzle-orm';
+import { inArray } from 'drizzle-orm';
 import { after } from 'next/server';
 import { z } from 'zod';
 
 import { withScopedPermission } from '@/business/server/trpc-middlewares/rbacPermission';
 import { wsCompatProcedure } from '@/business/server/trpc-middlewares/workspaceAuth';
+import { AgentModel } from '@/database/models/agent';
 import { AgentOperationModel } from '@/database/models/agentOperation';
+import { ChatGroupModel } from '@/database/models/chatGroup';
 import { MessageModel } from '@/database/models/message';
 import { TopicModel } from '@/database/models/topic';
 import { TopicShareModel } from '@/database/models/topicShare';
 import { AgentMigrationRepo } from '@/database/repositories/agentMigration';
 import { TopicImporterRepo } from '@/database/repositories/topicImporter';
-import { agents, chatGroups, chatGroupsAgents } from '@/database/schemas';
-import { normalizeInboxAgentAvatar, normalizeInboxAgentMeta } from '@/database/utils/inboxAgent';
+import { chatGroups } from '@/database/schemas';
 import { router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { type BatchTaskResult } from '@/types/service';
@@ -446,29 +447,21 @@ export const topicRouter = router({
       // Collect all agentIds to fetch agent info
       const allAgentIds = [...new Set(topicAgentIdMap.values())];
 
-      // Batch query agent info
+      const agentModel = new AgentModel(ctx.serverDB, ctx.userId, ctx.workspaceId ?? undefined);
+      const chatGroupModel = new ChatGroupModel(
+        ctx.serverDB,
+        ctx.userId,
+        ctx.workspaceId ?? undefined,
+      );
+
+      // Batch query agent info (already normalized for the inbox agent)
       const agentInfoMap = new Map<
         string,
-        {
-          avatar: string | null;
-          backgroundColor: string | null;
-          id: string;
-          slug: string | null;
-          title: string | null;
-        }
+        { avatar: string | null; backgroundColor: string | null; id: string; title: string | null }
       >();
 
       if (allAgentIds.length > 0) {
-        const agentInfos = await ctx.serverDB
-          .select({
-            avatar: agents.avatar,
-            backgroundColor: agents.backgroundColor,
-            id: agents.id,
-            slug: agents.slug,
-            title: agents.title,
-          })
-          .from(agents)
-          .where(inArray(agents.id, allAgentIds));
+        const agentInfos = await agentModel.getAgentAvatarsByIds(allAgentIds);
 
         for (const agent of agentInfos) {
           agentInfoMap.set(agent.id, agent);
@@ -489,29 +482,9 @@ export const topicRouter = router({
           .from(chatGroups)
           .where(inArray(chatGroups.id, allGroupIds));
 
-        // Query group member agents (get avatar info)
-        const groupMembersRaw = await ctx.serverDB
-          .select({
-            agentAvatar: agents.avatar,
-            agentBackgroundColor: agents.backgroundColor,
-            agentSlug: agents.slug,
-            chatGroupId: chatGroupsAgents.chatGroupId,
-            order: chatGroupsAgents.order,
-          })
-          .from(chatGroupsAgents)
-          .leftJoin(agents, eq(chatGroupsAgents.agentId, agents.id))
-          .where(inArray(chatGroupsAgents.chatGroupId, allGroupIds));
-
-        // Group members by chatGroupId
-        const groupMembersMap = new Map<string, RecentTopicGroupMember[]>();
-        for (const member of groupMembersRaw) {
-          const members = groupMembersMap.get(member.chatGroupId) || [];
-          members.push({
-            avatar: normalizeInboxAgentAvatar(member.agentAvatar, { slug: member.agentSlug }),
-            backgroundColor: member.agentBackgroundColor,
-          });
-          groupMembersMap.set(member.chatGroupId, members);
-        }
+        // Query group member avatars (already normalized for the inbox agent)
+        const groupMembersMap: Map<string, RecentTopicGroupMember[]> =
+          await chatGroupModel.getMemberAvatarsByGroupIds(allGroupIds);
 
         // Build group info map
         for (const group of chatGroupInfos) {
@@ -557,19 +530,7 @@ export const topicRouter = router({
 
         // Always return agent with id if agentId exists (even if avatar/title are null)
         // Frontend needs agent.id to generate links
-        const validAgent = agentInfo
-          ? cleanObject(
-              normalizeInboxAgentMeta(
-                {
-                  avatar: agentInfo.avatar,
-                  backgroundColor: agentInfo.backgroundColor,
-                  id: agentInfo.id,
-                  title: agentInfo.title,
-                },
-                { slug: agentInfo.slug },
-              ),
-            )
-          : null;
+        const validAgent = agentInfo ? cleanObject(agentInfo) : null;
 
         return {
           agent: validAgent,

--- a/apps/server/src/services/agent/index.test.ts
+++ b/apps/server/src/services/agent/index.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { DEFAULT_AGENT_CONFIG } from '@lobechat/const';
+import { DEFAULT_AGENT_CONFIG, DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AgentModel } from '@/database/models/agent';
@@ -190,10 +190,12 @@ describe('AgentService', () => {
       expect(result?.provider).toBe('anthropic');
     });
 
-    it('should merge avatar from builtin-agents package definition', async () => {
+    it('should fallback inbox title and avatar', async () => {
       const mockAgent = {
+        avatar: null,
         id: 'agent-1',
         slug: 'inbox',
+        title: null,
         model: 'gpt-4',
       };
 
@@ -207,8 +209,8 @@ describe('AgentService', () => {
       const newService = new AgentService(mockDb, mockUserId);
       const result = await newService.getBuiltinAgent('inbox');
 
-      // Avatar should be merged from BUILTIN_AGENTS definition
-      expect((result as any)?.avatar).toBe('/avatars/lobe-ai.png');
+      expect((result as any)?.avatar).toBe(DEFAULT_INBOX_AVATAR);
+      expect((result as any)?.title).toBe(DEFAULT_INBOX_TITLE);
     });
 
     it('should not include avatar for non-builtin agents', async () => {

--- a/apps/server/src/services/agent/index.ts
+++ b/apps/server/src/services/agent/index.ts
@@ -10,6 +10,7 @@ import { type PartialDeep } from 'type-fest';
 import { AgentModel } from '@/database/models/agent';
 import { SessionModel } from '@/database/models/session';
 import { UserModel } from '@/database/models/user';
+import { normalizeInboxAgentAvatar, normalizeInboxAgentTitle } from '@/database/utils/inboxAgent';
 import { getRedisConfig } from '@/envs/redis';
 import {
   getJSONFromRedis,
@@ -83,14 +84,20 @@ export class AgentService {
 
     const mergedConfig = this.mergeDefaultConfig(agent, defaultAgentConfig);
     if (!mergedConfig) return null;
+    const identity = { slug: (mergedConfig as { slug?: string | null }).slug ?? slug };
+    const normalizedConfig = {
+      ...mergedConfig,
+      avatar: normalizeInboxAgentAvatar(mergedConfig.avatar, identity),
+      title: normalizeInboxAgentTitle(mergedConfig.title, identity),
+    };
 
     // Use builtin avatar as fallback only when DB has no custom avatar
     const builtinAgent = BUILTIN_AGENTS[slug as BuiltinAgentSlug];
-    if (builtinAgent?.avatar && !mergedConfig.avatar) {
-      return { ...mergedConfig, avatar: builtinAgent.avatar };
+    if (builtinAgent?.avatar && !normalizedConfig.avatar) {
+      return { ...normalizedConfig, avatar: builtinAgent.avatar };
     }
 
-    return mergedConfig;
+    return normalizedConfig;
   }
 
   /**

--- a/apps/server/src/services/messenger/MessengerRouter.ts
+++ b/apps/server/src/services/messenger/MessengerRouter.ts
@@ -1,5 +1,4 @@
 import { createIoRedisState } from '@chat-adapter/state-ioredis';
-import { INBOX_SESSION_ID } from '@lobechat/const';
 import {
   Chat,
   ConsoleLogger,
@@ -8,16 +7,14 @@ import {
   type SlashCommandEvent,
 } from 'chat';
 import debug from 'debug';
-import { and, desc, eq, ne, or } from 'drizzle-orm';
 
 import type { MessengerPlatform } from '@/config/messenger';
 import { getServerDB } from '@/database/core/db-adaptor';
+import { AgentModel } from '@/database/models/agent';
 import { MessengerAccountLinkModel } from '@/database/models/messengerAccountLink';
 import { WorkspaceModel } from '@/database/models/workspace';
 import type { MessengerAccountLinkItem } from '@/database/schemas';
-import { agents } from '@/database/schemas';
 import type { LobeChatDatabase } from '@/database/type';
-import { buildWorkspaceWhere } from '@/database/utils/workspace';
 import { getServerFeatureFlagsStateFromRuntimeConfig } from '@/server/featureFlags';
 import { getAgentRuntimeRedisClient } from '@/server/modules/AgentRuntime/redis';
 import { AiAgentService } from '@/server/services/aiAgent';
@@ -1511,33 +1508,19 @@ export class MessengerRouter {
     userId: string,
     workspaceId?: string | null,
   ): Promise<AgentSummary[]> {
-    const rows = await serverDB
-      .select({ id: agents.id, slug: agents.slug, title: agents.title })
-      .from(agents)
-      .where(
-        and(
-          buildWorkspaceWhere({ userId, workspaceId: workspaceId ?? undefined }, agents),
-          or(ne(agents.virtual, true), eq(agents.slug, INBOX_SESSION_ID)),
-        ),
-      )
-      .orderBy(desc(agents.updatedAt));
+    // The virtual-or-inbox filter, the inbox title fallback, and the inbox
+    // pinning all live in the model; here we only apply the generic
+    // "Custom Agent" fallback for real agents without a title.
+    const rows = await new AgentModel(
+      serverDB,
+      userId,
+      workspaceId ?? undefined,
+    ).listMessengerBindableAgents();
 
-    const mapped = rows
-      .filter((row) => row.id)
-      .map((row) => ({
-        id: row.id,
-        slug: row.slug,
-        title:
-          (row.title && row.title.trim()) ||
-          (row.slug === INBOX_SESSION_ID ? 'LobeAI' : 'Custom Agent'),
-      }));
-
-    const inboxIdx = mapped.findIndex((row) => row.slug === INBOX_SESSION_ID);
-    if (inboxIdx > 0) {
-      const [inbox] = mapped.splice(inboxIdx, 1);
-      mapped.unshift(inbox);
-    }
-    return mapped.map(({ slug: _slug, ...rest }) => rest);
+    return rows.map((row) => ({
+      id: row.id,
+      title: (row.title && row.title.trim()) || 'Custom Agent',
+    }));
   }
 
   private async dispatchToAgent(

--- a/apps/server/src/services/messenger/MessengerRouter.ts
+++ b/apps/server/src/services/messenger/MessengerRouter.ts
@@ -1508,19 +1508,17 @@ export class MessengerRouter {
     userId: string,
     workspaceId?: string | null,
   ): Promise<AgentSummary[]> {
-    // The virtual-or-inbox filter, the inbox title fallback, and the inbox
-    // pinning all live in the model; here we only apply the generic
-    // "Custom Agent" fallback for real agents without a title.
+    // The filter, ordering, pinning, and title fallback all live in the model.
+    // This text-only channel has no client-side i18n default, so it asks the
+    // model to fill blank titles with a generic "Custom Agent" label.
     const rows = await new AgentModel(
       serverDB,
       userId,
       workspaceId ?? undefined,
-    ).listMessengerBindableAgents();
+    ).listMessengerBindableAgents({ fallbackTitle: 'Custom Agent' });
 
-    return rows.map((row) => ({
-      id: row.id,
-      title: (row.title && row.title.trim()) || 'Custom Agent',
-    }));
+    // `fallbackTitle` guarantees a non-null title for every row.
+    return rows.map((row) => ({ id: row.id, title: row.title! }));
   }
 
   private async dispatchToAgent(

--- a/packages/const/src/meta.ts
+++ b/packages/const/src/meta.ts
@@ -7,5 +7,6 @@ export const DEFAULT_SUPERVISOR_AVATAR = '🎙️';
 export const DEFAULT_SUPERVISOR_ID = 'supervisor';
 export const DEFAULT_BACKGROUND_COLOR = undefined;
 export const DEFAULT_AGENT_META: MetaData = {};
+export const DEFAULT_INBOX_TITLE = 'Lobe AI';
 export const DEFAULT_INBOX_AVATAR = BRANDING_LOGO_URL || '/avatars/lobe-ai.png';
 export const DEFAULT_USER_AVATAR_URL = BRANDING_LOGO_URL || '/icons/icon-192x192.png';

--- a/packages/database/src/models/__tests__/agent.getAvatars.test.ts
+++ b/packages/database/src/models/__tests__/agent.getAvatars.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE, INBOX_SESSION_ID } from '@lobechat/const';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
@@ -78,7 +79,7 @@ describe('AgentModel.getAgentAvatarsByIds', () => {
       avatar: null,
       backgroundColor: null,
       id: 'agent-inbox',
-      slug: 'inbox',
+      slug: INBOX_SESSION_ID,
       title: null,
       userId,
     });
@@ -88,10 +89,10 @@ describe('AgentModel.getAgentAvatarsByIds', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
-      avatar: '/avatars/lobe-ai.png',
+      avatar: DEFAULT_INBOX_AVATAR,
       backgroundColor: null,
       id: 'agent-inbox',
-      title: 'Lobe AI',
+      title: DEFAULT_INBOX_TITLE,
     });
   });
 

--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -2217,4 +2217,48 @@ describe('AgentModel', () => {
       expect(result).toHaveLength(1);
     });
   });
+
+  describe('listMessengerBindableAgents', () => {
+    it('should keep the inbox, exclude other virtual agents, pin inbox first, and fallback its meta', async () => {
+      await serverDB.insert(agents).values([
+        // Inbox is the oldest, yet must be pinned to the top.
+        {
+          avatar: null,
+          id: 'mb-inbox',
+          slug: INBOX_SESSION_ID,
+          title: null,
+          updatedAt: new Date('2023-01-01'),
+          userId,
+          virtual: true,
+        },
+        {
+          id: 'mb-normal',
+          title: 'Normal',
+          updatedAt: new Date('2024-01-01'),
+          userId,
+        },
+        { id: 'mb-virtual', title: 'Virtual', userId, virtual: true },
+      ]);
+
+      const result = await agentModel.listMessengerBindableAgents();
+
+      expect(result.map((r) => r.id)).toEqual(['mb-inbox', 'mb-normal']);
+      expect(result[0]).toMatchObject({
+        avatar: DEFAULT_INBOX_AVATAR,
+        id: 'mb-inbox',
+        title: DEFAULT_INBOX_TITLE,
+      });
+    });
+
+    it('should only list the current user agents', async () => {
+      await serverDB.insert(agents).values([
+        { id: 'mb-mine', title: 'Mine', userId },
+        { id: 'mb-theirs', title: 'Theirs', userId: userId2 },
+      ]);
+
+      const result = await agentModel.listMessengerBindableAgents();
+
+      expect(result.map((r) => r.id)).toEqual(['mb-mine']);
+    });
+  });
 });

--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { INBOX_SESSION_ID } from '@lobechat/const';
+import { DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE, INBOX_SESSION_ID } from '@lobechat/const';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -1185,6 +1185,8 @@ describe('AgentModel', () => {
         expect(result).toBeDefined();
         expect(result?.id).toBe(agent.id);
         expect(result?.slug).toBe(INBOX_SESSION_ID);
+        expect(result?.title).toBe(DEFAULT_INBOX_TITLE);
+        expect(result?.avatar).toBe(DEFAULT_INBOX_AVATAR);
       });
 
       it('should find inbox from legacy session and update agent slug', async () => {
@@ -1747,6 +1749,25 @@ describe('AgentModel', () => {
       expect(result.some((a: { title: string | null }) => a.title === 'Null Virtual Agent')).toBe(
         true,
       );
+    });
+
+    it('should fallback inbox agent meta by slug', async () => {
+      await serverDB.insert(agents).values({
+        avatar: null,
+        id: 'inbox-agent-query',
+        slug: INBOX_SESSION_ID,
+        title: null,
+        userId,
+        virtual: null as unknown as boolean,
+      });
+
+      const result = await agentModel.queryAgents();
+      const inbox = result.find((agent) => agent.id === 'inbox-agent-query');
+
+      expect(inbox).toMatchObject({
+        avatar: DEFAULT_INBOX_AVATAR,
+        title: DEFAULT_INBOX_TITLE,
+      });
     });
 
     it('should filter by keyword in title and description', async () => {

--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -2246,8 +2246,27 @@ describe('AgentModel', () => {
       expect(result[0]).toMatchObject({
         avatar: DEFAULT_INBOX_AVATAR,
         id: 'mb-inbox',
+        isInbox: true,
         title: DEFAULT_INBOX_TITLE,
       });
+      expect(result[1]).toMatchObject({ id: 'mb-normal', isInbox: false, title: 'Normal' });
+    });
+
+    it('should fall back a blank non-inbox title to options.fallbackTitle (null by default)', async () => {
+      await serverDB.insert(agents).values([
+        { id: 'mb-blank', title: null, userId },
+        { id: 'mb-named', title: 'Named', userId },
+      ]);
+
+      const withoutFallback = await agentModel.listMessengerBindableAgents();
+      expect(withoutFallback.find((r) => r.id === 'mb-blank')?.title).toBeNull();
+
+      const withFallback = await agentModel.listMessengerBindableAgents({
+        fallbackTitle: 'Custom Agent',
+      });
+      expect(withFallback.find((r) => r.id === 'mb-blank')?.title).toBe('Custom Agent');
+      // A real title is never overridden by the fallback.
+      expect(withFallback.find((r) => r.id === 'mb-named')?.title).toBe('Named');
     });
 
     it('should only list the current user agents', async () => {

--- a/packages/database/src/models/__tests__/chatGroup.test.ts
+++ b/packages/database/src/models/__tests__/chatGroup.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { DEFAULT_INBOX_AVATAR, INBOX_SESSION_ID } from '@lobechat/const';
 import { CHAT_GROUP_SESSION_ID_PREFIX } from '@lobechat/types';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -1023,6 +1024,34 @@ describe('ChatGroupModel', () => {
       const result = await workspaceChatGroupModel.getGroupsWithAgents(['workspace-agent']);
 
       expect(result).toEqual([expect.objectContaining({ id: 'workspace-group', workspaceId })]);
+    });
+  });
+
+  describe('getMemberAvatarsByGroupIds', () => {
+    it('should group member avatars by chatGroupId in member order with inbox fallback', async () => {
+      await serverDB.insert(agentsTable).values([
+        { avatar: '/custom.png', id: 'member-custom', slug: 'custom', userId },
+        { avatar: null, id: 'member-inbox', slug: INBOX_SESSION_ID, userId },
+      ]);
+      await serverDB.insert(chatGroups).values({ id: 'group-avatars', title: 'G', userId });
+      await serverDB.insert(chatGroupsAgents).values([
+        { agentId: 'member-inbox', chatGroupId: 'group-avatars', order: 1, userId },
+        { agentId: 'member-custom', chatGroupId: 'group-avatars', order: 0, userId },
+      ]);
+
+      const result = await chatGroupModel.getMemberAvatarsByGroupIds(['group-avatars']);
+
+      // Ordered by `order`: custom (0) before inbox (1); inbox avatar falls back.
+      expect(result.get('group-avatars')).toEqual([
+        { avatar: '/custom.png', backgroundColor: null },
+        { avatar: DEFAULT_INBOX_AVATAR, backgroundColor: null },
+      ]);
+    });
+
+    it('should return an empty map for no group ids', async () => {
+      const result = await chatGroupModel.getMemberAvatarsByGroupIds([]);
+
+      expect(result.size).toBe(0);
     });
   });
 });

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -1,5 +1,5 @@
 import { getAgentPersistConfig } from '@lobechat/builtin-agents';
-import { DEFAULT_INBOX_AVATAR, INBOX_SESSION_ID } from '@lobechat/const';
+import { INBOX_SESSION_ID } from '@lobechat/const';
 import type { AgentRankItem } from '@lobechat/types';
 import { and, count, desc, eq, gt, ilike, inArray, isNull, ne, or, sql } from 'drizzle-orm';
 import type { PartialDeep } from 'type-fest';
@@ -24,6 +24,7 @@ import {
   topics,
 } from '../schemas';
 import type { LobeChatDatabase } from '../type';
+import { normalizeInboxAgentMeta } from '../utils/inboxAgent';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
 
 export class AgentModel {
@@ -43,12 +44,13 @@ export class AgentModel {
    * the recents filter: real agents plus the inbox, excluding other virtual agents.
    */
   rank = async (limit: number = 10): Promise<AgentRankItem[]> => {
-    return this.db
+    const rows = await this.db
       .select({
         avatar: agents.avatar,
         backgroundColor: agents.backgroundColor,
         count: count(topics.id).as('count'),
         id: agents.id,
+        slug: agents.slug,
         title: agents.title,
       })
       .from(agents)
@@ -58,6 +60,8 @@ export class AgentModel {
       .having(({ count }) => gt(count, 0))
       .orderBy(desc(sql`count`))
       .limit(limit);
+
+    return rows.map(({ slug, ...row }) => normalizeInboxAgentMeta(row, { slug }));
   };
 
   /**
@@ -158,12 +162,13 @@ export class AgentModel {
     const { keyword, limit = 9999, offset = 0 } = params ?? {};
     const searchCondition = this.buildQueryAgentsWhere(keyword);
 
-    return this.db
+    const rows = await this.db
       .select({
         avatar: agents.avatar,
         backgroundColor: agents.backgroundColor,
         description: agents.description,
         id: agents.id,
+        slug: agents.slug,
         title: agents.title,
       })
       .from(agents)
@@ -171,6 +176,8 @@ export class AgentModel {
       .orderBy(desc(agents.updatedAt))
       .limit(limit)
       .offset(offset);
+
+    return rows.map(({ slug, ...row }) => normalizeInboxAgentMeta(row, { slug }));
   };
 
   /**
@@ -204,11 +211,7 @@ export class AgentModel {
       .from(agents)
       .where(and(this.ownership(), inArray(agents.id, ids)));
 
-    return rows.map(({ slug, ...row }) => ({
-      ...row,
-      avatar: row.avatar || (slug === INBOX_SESSION_ID ? DEFAULT_INBOX_AVATAR : null),
-      title: row.title || (slug === INBOX_SESSION_ID ? 'Lobe AI' : null),
-    }));
+    return rows.map(({ slug, ...row }) => normalizeInboxAgentMeta(row, { slug }));
   };
 
   /**
@@ -235,6 +238,7 @@ export class AgentModel {
    */
   private enrichAgentWithKnowledge = async (agent: AgentItem) => {
     const knowledge = await this.getAgentAssignedKnowledge(agent.id);
+    const normalizedAgent = normalizeInboxAgentMeta(agent, { slug: agent.slug });
 
     // Fetch document content for enabled files
     const enabledFileIds = knowledge.files
@@ -256,7 +260,7 @@ export class AgentModel {
       }));
     }
 
-    return { ...agent, ...knowledge, files };
+    return { ...normalizedAgent, ...knowledge, files };
   };
 
   getAgentAssignedKnowledge = async (id: string) => {
@@ -672,7 +676,7 @@ export class AgentModel {
       where: and(eq(agents.slug, slug), this.ownership()),
     });
 
-    if (existing) return existing;
+    if (existing) return normalizeInboxAgentMeta(existing, { slug: existing.slug });
 
     // For inbox agent, it has special compatibility handling:
     // Historical inbox was stored as session with slug='inbox' and linked agent via agentsToSessions
@@ -696,7 +700,7 @@ export class AgentModel {
           .where(eq(agents.id, result[0].agent.id))
           .returning();
 
-        return updatedAgent;
+        return normalizeInboxAgentMeta(updatedAgent, { slug: updatedAgent.slug });
       }
     }
 
@@ -733,13 +737,13 @@ export class AgentModel {
       .onConflictDoNothing()
       .returning();
 
-    if (result[0]) return result[0];
+    if (result[0]) return normalizeInboxAgentMeta(result[0], { slug: result[0].slug });
 
-    return (
-      (await this.db.query.agents.findFirst({
-        where: and(eq(agents.slug, slug), this.ownership()),
-      })) ?? null
-    );
+    const agent = await this.db.query.agents.findFirst({
+      where: and(eq(agents.slug, slug), this.ownership()),
+    });
+
+    return agent ? normalizeInboxAgentMeta(agent, { slug: agent.slug }) : null;
   };
 
   /**

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -217,17 +217,26 @@ export class AgentModel {
   /**
    * List agents bindable by the System Bot messenger picker: real agents plus
    * the inbox (other virtual agents excluded), ordered by `updatedAt DESC` with
-   * the inbox pinned to the top. Inbox meta falls back to the LobeAI defaults.
+   * the inbox pinned to the top.
+   *
+   * Title fallback is fully owned here: the inbox resolves to the LobeAI
+   * default, and any other agent with a blank title resolves to
+   * `options.fallbackTitle` (default `null`, so a caller that omits it can let
+   * the client supply its own i18n default).
    */
-  listMessengerBindableAgents = async (): Promise<
+  listMessengerBindableAgents = async (options?: {
+    fallbackTitle?: string | null;
+  }): Promise<
     Array<{
       avatar: string | null;
       backgroundColor: string | null;
       id: string;
-      slug: string | null;
+      isInbox: boolean;
       title: string | null;
     }>
   > => {
+    const fallbackTitle = options?.fallbackTitle ?? null;
+
     const rows = await this.db
       .select({
         avatar: agents.avatar,
@@ -242,11 +251,22 @@ export class AgentModel {
 
     const normalized = rows
       .filter((row) => row.id)
-      .map(({ slug, ...row }) => ({ ...normalizeInboxAgentMeta(row, { slug }), slug }));
+      .map(({ slug, ...row }) => {
+        const meta = normalizeInboxAgentMeta(row, { slug });
+        return {
+          avatar: meta.avatar,
+          backgroundColor: meta.backgroundColor,
+          id: meta.id,
+          isInbox: slug === INBOX_SESSION_ID,
+          // The inbox title is already resolved by normalizeInboxAgentMeta; any
+          // other blank title falls back to the caller-provided default.
+          title: meta.title?.trim() || fallbackTitle,
+        };
+      });
 
     // Pin the inbox agent to the top regardless of updatedAt — it's the
     // implicit "default" agent and should always be the first option.
-    const inboxIdx = normalized.findIndex((row) => row.slug === INBOX_SESSION_ID);
+    const inboxIdx = normalized.findIndex((row) => row.isInbox);
     if (inboxIdx > 0) {
       const [inbox] = normalized.splice(inboxIdx, 1);
       normalized.unshift(inbox);

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -215,6 +215,47 @@ export class AgentModel {
   };
 
   /**
+   * List agents bindable by the System Bot messenger picker: real agents plus
+   * the inbox (other virtual agents excluded), ordered by `updatedAt DESC` with
+   * the inbox pinned to the top. Inbox meta falls back to the LobeAI defaults.
+   */
+  listMessengerBindableAgents = async (): Promise<
+    Array<{
+      avatar: string | null;
+      backgroundColor: string | null;
+      id: string;
+      slug: string | null;
+      title: string | null;
+    }>
+  > => {
+    const rows = await this.db
+      .select({
+        avatar: agents.avatar,
+        backgroundColor: agents.backgroundColor,
+        id: agents.id,
+        slug: agents.slug,
+        title: agents.title,
+      })
+      .from(agents)
+      .where(and(this.ownership(), or(ne(agents.virtual, true), eq(agents.slug, INBOX_SESSION_ID))))
+      .orderBy(desc(agents.updatedAt));
+
+    const normalized = rows
+      .filter((row) => row.id)
+      .map(({ slug, ...row }) => ({ ...normalizeInboxAgentMeta(row, { slug }), slug }));
+
+    // Pin the inbox agent to the top regardless of updatedAt — it's the
+    // implicit "default" agent and should always be the first option.
+    const inboxIdx = normalized.findIndex((row) => row.slug === INBOX_SESSION_ID);
+    if (inboxIdx > 0) {
+      const [inbox] = normalized.splice(inboxIdx, 1);
+      normalized.unshift(inbox);
+    }
+
+    return normalized;
+  };
+
+  /**
    * Get agent config by ID or slug (single query with OR condition)
    */
   getAgentConfig = async (idOrSlug: string) => {

--- a/packages/database/src/models/agentSignal/nightlyReview.ts
+++ b/packages/database/src/models/agentSignal/nightlyReview.ts
@@ -16,6 +16,7 @@ import {
 
 import { agents, messagePlugins, messages, topics, users, userSettings } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
+import { normalizeInboxAgentTitle } from '../../utils/inboxAgent';
 
 /**
  * Normalizes database aggregate timestamps.
@@ -170,7 +171,7 @@ export class AgentSignalNightlyReviewModel {
    * Returns:
    * - Agent targets with message/topic/failure counts
    */
-  listActiveAgentTargets = (
+  listActiveAgentTargets = async (
     userId: string,
     options: ListAgentSignalNightlyReviewTargetsOptions,
   ) => {
@@ -187,6 +188,7 @@ export class AgentSignalNightlyReviewModel {
         firstActivityAt: sql<Date>`MIN(${messages.createdAt})`.mapWith(parseAggregateTimestamp),
         lastActivityAt: sql<Date>`MAX(${messages.createdAt})`.mapWith(parseAggregateTimestamp),
         messageCount: count(messages.id),
+        slug: agents.slug,
         timezone: sql<string>`COALESCE(${userSettings.general}->>'timezone', 'UTC')`,
         title: agents.title,
         topicCount: countDistinct(messages.topicId),
@@ -223,9 +225,14 @@ export class AgentSignalNightlyReviewModel {
           ),
         ),
       )
-      .groupBy(agents.id, agents.title, userSettings.general)
+      .groupBy(agents.id, agents.title, agents.slug, userSettings.general)
       .orderBy(sql`MAX(${messages.createdAt}) DESC`);
 
-    return options.limit !== undefined ? query.limit(options.limit) : query;
+    const rows = await (options.limit !== undefined ? query.limit(options.limit) : query);
+
+    return rows.map(({ slug, ...row }) => ({
+      ...row,
+      title: normalizeInboxAgentTitle(row.title, { slug }),
+    }));
   };
 }

--- a/packages/database/src/models/brief.ts
+++ b/packages/database/src/models/brief.ts
@@ -4,6 +4,7 @@ import { agents } from '../schemas/agent';
 import type { BriefItem, NewBrief } from '../schemas/task';
 import { briefs, tasks } from '../schemas/task';
 import type { LobeChatDatabase } from '../type';
+import { normalizeInboxAgentAvatar, normalizeInboxAgentTitle } from '../utils/inboxAgent';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
 
 export interface UnresolvedBriefRow {
@@ -86,11 +87,12 @@ export class BriefModel {
    */
   async listUnresolvedEnriched(options?: { limit?: number }): Promise<UnresolvedBriefRow[]> {
     const { limit = 20 } = options ?? {};
-    return this.db
+    const rows = await this.db
       .select({
         agentAvatar: agents.avatar,
         agentBackgroundColor: agents.backgroundColor,
         agentRowId: agents.id,
+        agentSlug: agents.slug,
         agentTitle: agents.title,
         brief: briefs,
         taskStatus: tasks.status,
@@ -108,6 +110,16 @@ export class BriefModel {
         desc(briefs.createdAt),
       )
       .limit(limit);
+
+    return rows.map(({ agentSlug, ...row }) => ({
+      ...row,
+      agentAvatar: normalizeInboxAgentAvatar(row.agentAvatar, {
+        slug: agentSlug,
+      }),
+      agentTitle: normalizeInboxAgentTitle(row.agentTitle, {
+        slug: agentSlug,
+      }),
+    }));
   }
 
   /**

--- a/packages/database/src/models/chatGroup.ts
+++ b/packages/database/src/models/chatGroup.ts
@@ -6,8 +6,9 @@ import type {
   NewChatGroup,
   NewChatGroupAgent,
 } from '../schemas';
-import { chatGroups, chatGroupsAgents } from '../schemas';
+import { agents, chatGroups, chatGroupsAgents } from '../schemas';
 import type { LobeChatDatabase } from '../type';
+import { normalizeInboxAgentAvatar } from '../utils/inboxAgent';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
 
 export class ChatGroupModel {
@@ -23,6 +24,37 @@ export class ChatGroupModel {
 
   private ownership = () =>
     buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, chatGroups);
+
+  /**
+   * Get member avatar metas (avatar + backgroundColor) grouped by chatGroupId,
+   * ordered by member order. Inbox members fall back to the default avatar.
+   */
+  getMemberAvatarsByGroupIds = async (
+    groupIds: string[],
+  ): Promise<Map<string, Array<{ avatar: string | null; backgroundColor: string | null }>>> => {
+    const map = new Map<string, Array<{ avatar: string | null; backgroundColor: string | null }>>();
+    if (groupIds.length === 0) return map;
+
+    const rows = await this.db
+      .select({
+        avatar: agents.avatar,
+        backgroundColor: agents.backgroundColor,
+        chatGroupId: chatGroupsAgents.chatGroupId,
+        slug: agents.slug,
+      })
+      .from(chatGroupsAgents)
+      .innerJoin(agents, eq(chatGroupsAgents.agentId, agents.id))
+      .where(inArray(chatGroupsAgents.chatGroupId, groupIds))
+      .orderBy(chatGroupsAgents.order);
+
+    for (const { avatar, backgroundColor, chatGroupId, slug } of rows) {
+      const list = map.get(chatGroupId) ?? [];
+      list.push({ avatar: normalizeInboxAgentAvatar(avatar, { slug }), backgroundColor });
+      map.set(chatGroupId, list);
+    }
+
+    return map;
+  };
 
   // ******* Query Methods ******* //
 

--- a/packages/database/src/models/topicShare.ts
+++ b/packages/database/src/models/topicShare.ts
@@ -4,6 +4,11 @@ import { and, asc, eq, sql } from 'drizzle-orm';
 
 import { agents, chatGroups, chatGroupsAgents, topics, topicShares } from '../schemas';
 import type { LobeChatDatabase } from '../type';
+import {
+  normalizeInboxAgentAvatar,
+  normalizeInboxAgentMeta,
+  normalizeInboxAgentTitle,
+} from '../utils/inboxAgent';
 import { buildWorkspaceWhere } from '../utils/workspace';
 
 export type TopicShareData = NonNullable<
@@ -153,6 +158,7 @@ export class TopicShareModel {
           avatar: agents.avatar,
           backgroundColor: agents.backgroundColor,
           id: agents.id,
+          slug: agents.slug,
           title: agents.title,
         })
         .from(chatGroupsAgents)
@@ -161,10 +167,21 @@ export class TopicShareModel {
         .orderBy(asc(chatGroupsAgents.order))
         .limit(4);
 
-      groupMembers = members;
+      groupMembers = members.map(({ slug, ...member }) =>
+        normalizeInboxAgentMeta(member, { slug }),
+      );
     }
 
-    return { ...share, groupMembers };
+    return {
+      ...share,
+      agentAvatar: normalizeInboxAgentAvatar(share.agentAvatar, {
+        slug: share.agentSlug,
+      }),
+      agentTitle: normalizeInboxAgentTitle(share.agentTitle, {
+        slug: share.agentSlug,
+      }),
+      groupMembers,
+    };
   };
 
   /**

--- a/packages/database/src/repositories/agentGroup/index.ts
+++ b/packages/database/src/repositories/agentGroup/index.ts
@@ -21,6 +21,7 @@ import {
 } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
 import { idGenerator } from '../../utils/idGenerator';
+import { normalizeInboxAgentMeta } from '../../utils/inboxAgent';
 import { buildWorkspaceWhere } from '../../utils/workspace';
 
 interface CopyAgentGroupToWorkspaceOptions {
@@ -485,6 +486,7 @@ export class AgentGroupRepository {
         avatar: agents.avatar,
         description: agents.description,
         id: agents.id,
+        slug: agents.slug,
         title: agents.title,
         virtual: agents.virtual,
       })
@@ -496,11 +498,16 @@ export class AgentGroupRepository {
 
     for (const agent of agentDetails) {
       if (agent.virtual) {
+        const meta = normalizeInboxAgentMeta(
+          { avatar: agent.avatar, title: agent.title },
+          { slug: agent.slug },
+        );
+
         virtualAgents.push({
-          avatar: agent.avatar,
+          avatar: meta.avatar,
           description: agent.description,
           id: agent.id,
-          title: agent.title,
+          title: meta.title,
         });
       } else {
         nonVirtualAgentIds.push(agent.id);

--- a/packages/database/src/repositories/home/index.test.ts
+++ b/packages/database/src/repositories/home/index.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE, INBOX_SESSION_ID } from '@lobechat/const';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
@@ -80,6 +81,41 @@ describe('HomeRepository', () => {
         sessionId: session.id,
         title: 'Test Agent',
         type: 'agent',
+      });
+    });
+
+    it('should fallback inbox agent meta by slug', async () => {
+      const [agent] = await serverDB
+        .insert(agents)
+        .values({
+          avatar: null,
+          slug: INBOX_SESSION_ID,
+          title: null,
+          userId,
+          virtual: false,
+        })
+        .returning();
+
+      const [session] = await serverDB
+        .insert(sessions)
+        .values({
+          userId,
+        })
+        .returning();
+
+      await serverDB.insert(agentsToSessions).values({
+        agentId: agent.id,
+        sessionId: session.id,
+        userId,
+      });
+
+      const result = await homeRepo.getSidebarAgentList();
+
+      expect(result.ungrouped[0]).toMatchObject({
+        avatar: DEFAULT_INBOX_AVATAR,
+        id: agent.id,
+        sessionId: session.id,
+        title: DEFAULT_INBOX_TITLE,
       });
     });
 

--- a/packages/database/src/repositories/home/index.ts
+++ b/packages/database/src/repositories/home/index.ts
@@ -4,19 +4,13 @@ import {
   type SidebarGroup,
 } from '@lobechat/types';
 import { cleanObject } from '@lobechat/utils';
-import { and, desc, eq, inArray, not, sql } from 'drizzle-orm';
+import { and, desc, eq, not, sql } from 'drizzle-orm';
 
-import {
-  agents,
-  agentsToSessions,
-  chatGroups,
-  chatGroupsAgents,
-  sessionGroups,
-  sessions,
-} from '../../schemas';
+import { ChatGroupModel } from '../../models/chatGroup';
+import { agents, agentsToSessions, chatGroups, sessionGroups, sessions } from '../../schemas';
 import { type LobeChatDatabase } from '../../type';
 import { sanitizeBm25Query } from '../../utils/bm25';
-import { normalizeInboxAgentAvatar, normalizeInboxAgentMeta } from '../../utils/inboxAgent';
+import { normalizeInboxAgentMeta } from '../../utils/inboxAgent';
 import { buildWorkspaceWhere } from '../../utils/workspace';
 
 // Re-export types for backward compatibility
@@ -325,28 +319,22 @@ export class HomeRepository {
 
     if (chatGroupIds.length === 0) return memberAvatarsMap;
 
-    const memberAvatars = await this.db
-      .select({
-        avatar: agents.avatar,
-        backgroundColor: agents.backgroundColor,
-        chatGroupId: chatGroupsAgents.chatGroupId,
-        slug: agents.slug,
-      })
-      .from(chatGroupsAgents)
-      .innerJoin(agents, eq(chatGroupsAgents.agentId, agents.id))
-      .where(inArray(chatGroupsAgents.chatGroupId, chatGroupIds))
-      .orderBy(chatGroupsAgents.order);
+    const metasMap = await new ChatGroupModel(
+      this.db,
+      this.userId,
+      this.workspaceId,
+    ).getMemberAvatarsByGroupIds(chatGroupIds);
 
-    for (const member of memberAvatars) {
-      const existing = memberAvatarsMap.get(member.chatGroupId) || [];
-      const avatar = normalizeInboxAgentAvatar(member.avatar, { slug: member.slug });
-      if (avatar) {
-        existing.push({
-          avatar,
-          background: member.backgroundColor ?? undefined,
-        });
-      }
-      memberAvatarsMap.set(member.chatGroupId, existing);
+    for (const [chatGroupId, members] of metasMap) {
+      memberAvatarsMap.set(
+        chatGroupId,
+        members
+          .filter((member) => member.avatar)
+          .map((member) => ({
+            avatar: member.avatar as string,
+            background: member.backgroundColor ?? undefined,
+          })),
+      );
     }
 
     return memberAvatarsMap;

--- a/packages/database/src/repositories/home/index.ts
+++ b/packages/database/src/repositories/home/index.ts
@@ -16,6 +16,7 @@ import {
 } from '../../schemas';
 import { type LobeChatDatabase } from '../../type';
 import { sanitizeBm25Query } from '../../utils/bm25';
+import { normalizeInboxAgentAvatar, normalizeInboxAgentMeta } from '../../utils/inboxAgent';
 import { buildWorkspaceWhere } from '../../utils/workspace';
 
 // Re-export types for backward compatibility
@@ -61,6 +62,7 @@ export class HomeRepository {
         sessionGroupId: sessions.groupId,
         sessionId: sessions.id,
         sessionPinned: sessions.pinned,
+        slug: agents.slug,
         title: agents.title,
         updatedAt: agents.updatedAt,
       })
@@ -116,6 +118,7 @@ export class HomeRepository {
       sessionGroupId: string | null;
       sessionId: string | null;
       sessionPinned: boolean | null;
+      slug: string | null;
       title: string | null;
       updatedAt: Date;
     }>,
@@ -140,19 +143,26 @@ export class HomeRepository {
     // For pinned status: agents.pinned takes priority, fallback to sessions.pinned for backward compatibility
     // For groupId: agents.sessionGroupId takes priority, fallback to sessions.groupId for backward compatibility
     const allItems: Array<SidebarAgentItem & { groupId: string | null }> = [
-      ...agentItems.map((a) => ({
-        avatar: a.avatar,
-        backgroundColor: a.backgroundColor,
-        description: a.description,
-        groupId: a.agentSessionGroupId ?? a.sessionGroupId,
-        heterogeneousType: a.agencyConfig?.heterogeneousProvider?.type ?? null,
-        id: a.id,
-        pinned: a.pinned ?? a.sessionPinned ?? false,
-        sessionId: a.sessionId,
-        title: a.title,
-        type: 'agent' as const,
-        updatedAt: a.updatedAt,
-      })),
+      ...agentItems.map((a) => {
+        const meta = normalizeInboxAgentMeta(
+          { avatar: a.avatar, title: a.title },
+          { slug: a.slug },
+        );
+
+        return {
+          avatar: meta.avatar,
+          backgroundColor: a.backgroundColor,
+          description: a.description,
+          groupId: a.agentSessionGroupId ?? a.sessionGroupId,
+          heterogeneousType: a.agencyConfig?.heterogeneousProvider?.type ?? null,
+          id: a.id,
+          pinned: a.pinned ?? a.sessionPinned ?? false,
+          sessionId: a.sessionId,
+          title: meta.title,
+          type: 'agent' as const,
+          updatedAt: a.updatedAt,
+        };
+      }),
       ...chatGroupItems.map((g) => ({
         // If group has custom avatar, use it (string); otherwise fallback to member avatars (array)
         avatar: g.avatar ? g.avatar : (memberAvatarsMap.get(g.id) ?? null),
@@ -224,6 +234,7 @@ export class HomeRepository {
           pinned: agents.pinned,
           sessionId: sessions.id,
           sessionPinned: sessions.pinned,
+          slug: agents.slug,
           title: agents.title,
           updatedAt: agents.updatedAt,
         })
@@ -266,19 +277,24 @@ export class HomeRepository {
 
     // 3. Combine and format results
     const results: SidebarAgentItem[] = [
-      ...agentResults.map((a) =>
-        cleanObject({
-          avatar: a.avatar,
+      ...agentResults.map((a) => {
+        const meta = normalizeInboxAgentMeta(
+          { avatar: a.avatar, title: a.title },
+          { slug: a.slug },
+        );
+
+        return cleanObject({
+          avatar: meta.avatar,
           backgroundColor: a.backgroundColor,
           description: a.description,
           id: a.id,
           pinned: a.pinned ?? a.sessionPinned ?? false,
           sessionId: a.sessionId,
-          title: a.title,
+          title: meta.title,
           type: 'agent' as const,
           updatedAt: a.updatedAt,
-        }),
-      ),
+        });
+      }),
       ...chatGroupResults.map((g) =>
         cleanObject({
           avatar: g.avatar ? g.avatar : (memberAvatarsMap.get(g.id) ?? null),
@@ -314,6 +330,7 @@ export class HomeRepository {
         avatar: agents.avatar,
         backgroundColor: agents.backgroundColor,
         chatGroupId: chatGroupsAgents.chatGroupId,
+        slug: agents.slug,
       })
       .from(chatGroupsAgents)
       .innerJoin(agents, eq(chatGroupsAgents.agentId, agents.id))
@@ -322,9 +339,10 @@ export class HomeRepository {
 
     for (const member of memberAvatars) {
       const existing = memberAvatarsMap.get(member.chatGroupId) || [];
-      if (member.avatar) {
+      const avatar = normalizeInboxAgentAvatar(member.avatar, { slug: member.slug });
+      if (avatar) {
         existing.push({
-          avatar: member.avatar,
+          avatar,
           background: member.backgroundColor ?? undefined,
         });
       }

--- a/packages/database/src/repositories/search/index.ts
+++ b/packages/database/src/repositories/search/index.ts
@@ -14,6 +14,7 @@ import {
 } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
 import { sanitizeBm25Query } from '../../utils/bm25';
+import { normalizeInboxAgentMeta, normalizeInboxAgentTitle } from '../../utils/inboxAgent';
 import { buildWorkspaceWhere } from '../../utils/workspace';
 
 export type SearchResultType =
@@ -418,19 +419,26 @@ export class SearchRepo {
       .orderBy(sql`paradedb.score(${agents.id}) DESC`)
       .limit(limit);
 
-    return this.mapScoresToRelevance(rows).map((row) => ({
-      avatar: row.avatar,
-      backgroundColor: row.backgroundColor,
-      createdAt: row.createdAt,
-      description: row.description,
-      id: row.id,
-      relevance: row.relevance,
-      slug: row.slug,
-      tags: (row.tags as string[]) || [],
-      title: row.title || '',
-      type: 'agent' as const,
-      updatedAt: row.updatedAt,
-    }));
+    return this.mapScoresToRelevance(rows).map((row) => {
+      const meta = normalizeInboxAgentMeta(
+        { avatar: row.avatar, title: row.title },
+        { slug: row.slug },
+      );
+
+      return {
+        avatar: meta.avatar,
+        backgroundColor: row.backgroundColor,
+        createdAt: row.createdAt,
+        description: row.description,
+        id: row.id,
+        relevance: row.relevance,
+        slug: row.slug,
+        tags: (row.tags as string[]) || [],
+        title: meta.title || '',
+        type: 'agent' as const,
+        updatedAt: row.updatedAt,
+      };
+    });
   }
 
   /**
@@ -454,6 +462,7 @@ export class SearchRepo {
         agentBackgroundColor: agents.backgroundColor,
         agentId: topics.agentId,
         agentMatchedId: agents.id,
+        agentSlug: agents.slug,
         agentTitle: agents.title,
         content: topics.content,
         createdAt: topics.createdAt,
@@ -480,9 +489,14 @@ export class SearchRepo {
       .map((row) => ({
         agent: row.agentMatchedId
           ? {
-              avatar: row.agentAvatar,
+              avatar: normalizeInboxAgentMeta(
+                { avatar: row.agentAvatar, title: row.agentTitle },
+                { slug: row.agentSlug },
+              ).avatar,
               backgroundColor: row.agentBackgroundColor,
-              title: row.agentTitle,
+              title: normalizeInboxAgentTitle(row.agentTitle, {
+                slug: row.agentSlug,
+              }),
             }
           : null,
         agentId: row.agentId,
@@ -513,6 +527,7 @@ export class SearchRepo {
     const rows = await this.db
       .select({
         agentId: messages.agentId,
+        agentSlug: agents.slug,
         agentTitle: agents.title,
         content: messages.content,
         createdAt: messages.createdAt,
@@ -541,7 +556,10 @@ export class SearchRepo {
         agentId: row.agentId,
         content: row.content || '',
         createdAt: row.createdAt,
-        description: row.agentTitle || 'General Chat',
+        description:
+          normalizeInboxAgentTitle(row.agentTitle, {
+            slug: row.agentSlug,
+          }) || 'General Chat',
         id: row.id,
         model: row.model,
         relevance: row.relevance,

--- a/packages/database/src/utils/inboxAgent.ts
+++ b/packages/database/src/utils/inboxAgent.ts
@@ -1,0 +1,53 @@
+import { DEFAULT_INBOX_AVATAR, DEFAULT_INBOX_TITLE, INBOX_SESSION_ID } from '@lobechat/const';
+
+interface InboxAgentIdentity {
+  slug?: string | null;
+}
+
+interface InboxAgentMeta {
+  avatar: string | null;
+  title: string | null;
+}
+
+const isBlank = (value: string | null | undefined) => !value || value.trim().length === 0;
+
+export const isInboxAgentIdentity = ({ slug }: InboxAgentIdentity) => slug === INBOX_SESSION_ID;
+
+export function normalizeInboxAgentTitle(
+  title: string | null,
+  identity: InboxAgentIdentity,
+): string | null;
+export function normalizeInboxAgentTitle(
+  title: string | null | undefined,
+  identity: InboxAgentIdentity,
+): string | null | undefined;
+export function normalizeInboxAgentTitle(
+  title: string | null | undefined,
+  identity: InboxAgentIdentity,
+) {
+  return isInboxAgentIdentity(identity) && isBlank(title) ? DEFAULT_INBOX_TITLE : title;
+}
+
+export function normalizeInboxAgentAvatar(
+  avatar: string | null,
+  identity: InboxAgentIdentity,
+): string | null;
+export function normalizeInboxAgentAvatar(
+  avatar: string | null | undefined,
+  identity: InboxAgentIdentity,
+): string | null | undefined;
+export function normalizeInboxAgentAvatar(
+  avatar: string | null | undefined,
+  identity: InboxAgentIdentity,
+) {
+  return isInboxAgentIdentity(identity) && isBlank(avatar) ? DEFAULT_INBOX_AVATAR : avatar;
+}
+
+export const normalizeInboxAgentMeta = <T extends InboxAgentMeta>(
+  agent: T,
+  identity: InboxAgentIdentity = agent as T & InboxAgentIdentity,
+): T => ({
+  ...agent,
+  avatar: normalizeInboxAgentAvatar(agent.avatar, identity),
+  title: normalizeInboxAgentTitle(agent.title, identity),
+});

--- a/packages/openapi/src/services/agent.service.ts
+++ b/packages/openapi/src/services/agent.service.ts
@@ -5,7 +5,6 @@ import type { NewAgent } from '@/database/schemas';
 import { agents, agentsToSessions } from '@/database/schemas';
 import type { LobeChatDatabase } from '@/database/type';
 import { idGenerator, randomSlug } from '@/database/utils/idGenerator';
-import { normalizeInboxAgentMeta } from '@/database/utils/inboxAgent';
 
 import { BaseService } from '../common/base.service';
 import { processPaginationConditions } from '../helpers/pagination';
@@ -62,7 +61,9 @@ export class AgentService extends BaseService {
       this.log('info', `found ${agentsList.length} agents`);
 
       return {
-        agents: agentsList.map((agent) => normalizeInboxAgentMeta(agent, { slug: agent.slug })),
+        // The inbox agent is `virtual=true` and excluded by the filter above, so
+        // there is no inbox meta to normalize here — this surface lists real agents.
+        agents: agentsList,
         total: totalResult[0]?.count ?? 0,
       };
     } catch (error) {
@@ -186,7 +187,7 @@ export class AgentService extends BaseService {
           id: updatedAgent.id,
           slug: updatedAgent.slug,
         });
-        return normalizeInboxAgentMeta(updatedAgent, { slug: updatedAgent.slug });
+        return updatedAgent;
       });
     } catch (error) {
       this.handleServiceError(error, 'update agent');

--- a/packages/openapi/src/services/agent.service.ts
+++ b/packages/openapi/src/services/agent.service.ts
@@ -61,8 +61,6 @@ export class AgentService extends BaseService {
       this.log('info', `found ${agentsList.length} agents`);
 
       return {
-        // The inbox agent is `virtual=true` and excluded by the filter above, so
-        // there is no inbox meta to normalize here — this surface lists real agents.
         agents: agentsList,
         total: totalResult[0]?.count ?? 0,
       };

--- a/packages/openapi/src/services/agent.service.ts
+++ b/packages/openapi/src/services/agent.service.ts
@@ -5,6 +5,7 @@ import type { NewAgent } from '@/database/schemas';
 import { agents, agentsToSessions } from '@/database/schemas';
 import type { LobeChatDatabase } from '@/database/type';
 import { idGenerator, randomSlug } from '@/database/utils/idGenerator';
+import { normalizeInboxAgentMeta } from '@/database/utils/inboxAgent';
 
 import { BaseService } from '../common/base.service';
 import { processPaginationConditions } from '../helpers/pagination';
@@ -61,7 +62,7 @@ export class AgentService extends BaseService {
       this.log('info', `found ${agentsList.length} agents`);
 
       return {
-        agents: agentsList,
+        agents: agentsList.map((agent) => normalizeInboxAgentMeta(agent, { slug: agent.slug })),
         total: totalResult[0]?.count ?? 0,
       };
     } catch (error) {
@@ -99,7 +100,10 @@ export class AgentService extends BaseService {
 
         // Insert into database
         const [createdAgent] = await tx.insert(agents).values(newAgentData).returning();
-        this.log('info', 'agent created successfully', { id: createdAgent.id, slug: createdAgent.slug });
+        this.log('info', 'agent created successfully', {
+          id: createdAgent.id,
+          slug: createdAgent.slug,
+        });
 
         return createdAgent;
       });
@@ -123,7 +127,9 @@ export class AgentService extends BaseService {
       });
 
       if (!permissionResult.isPermitted) {
-        throw this.createAuthorizationError(permissionResult.message || 'No permission to update this agent');
+        throw this.createAuthorizationError(
+          permissionResult.message || 'No permission to update this agent',
+        );
       }
 
       return await this.db.transaction(async (tx) => {
@@ -176,8 +182,11 @@ export class AgentService extends BaseService {
           .where(and(...whereConditions))
           .returning();
 
-        this.log('info', 'agent updated successfully', { id: updatedAgent.id, slug: updatedAgent.slug });
-        return updatedAgent;
+        this.log('info', 'agent updated successfully', {
+          id: updatedAgent.id,
+          slug: updatedAgent.slug,
+        });
+        return normalizeInboxAgentMeta(updatedAgent, { slug: updatedAgent.slug });
       });
     } catch (error) {
       this.handleServiceError(error, 'update agent');
@@ -201,7 +210,9 @@ export class AgentService extends BaseService {
       });
 
       if (!permissionResult.isPermitted) {
-        throw this.createAuthorizationError(permissionResult.message || 'No permission to delete this agent');
+        throw this.createAuthorizationError(
+          permissionResult.message || 'No permission to delete this agent',
+        );
       }
 
       // Check if the Agent to be deleted exists
@@ -220,7 +231,9 @@ export class AgentService extends BaseService {
         });
 
         if (!migrateTarget) {
-          throw this.createBusinessError(`Migration target agent ID ${request.migrateSessionTo} not found`);
+          throw this.createBusinessError(
+            `Migration target agent ID ${request.migrateSessionTo} not found`,
+          );
         }
 
         // Migrate session associations to the target Agent
@@ -262,7 +275,9 @@ export class AgentService extends BaseService {
       });
 
       if (!permissionResult.isPermitted) {
-        throw this.createAuthorizationError(permissionResult.message || 'No permission to access this agent');
+        throw this.createAuthorizationError(
+          permissionResult.message || 'No permission to access this agent',
+        );
       }
 
       if (!this.userId) {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] ♻️ refactor

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

The inbox agent's title/avatar fallback was duplicated and inconsistent across the codebase: only a handful of read paths backfilled the default `Lobe AI` title and inbox avatar when the DB row stored `null`, so other paths (sidebar, search, briefs, topic share, openapi, nightly review, etc.) surfaced a blank inbox agent.

This PR extracts the fallback into a single shared util `packages/database/src/utils/inboxAgent.ts`:

- `isInboxAgentIdentity` / `normalizeInboxAgentTitle` / `normalizeInboxAgentAvatar` / `normalizeInboxAgentMeta`
- Identity is determined by `slug === INBOX_SESSION_ID`; blank values fall back to `DEFAULT_INBOX_TITLE` (`'Lobe AI'`) and `DEFAULT_INBOX_AVATAR`.
- Adds `DEFAULT_INBOX_TITLE` to `@lobechat/const` (previously the literal `'Lobe AI'` was inlined in the model).

The util is then applied consistently across every agent read path:

- `AgentModel`: `rank`, `queryAgents`, `getAgentAvatarsByIds`, `enrichAgentWithKnowledge`, and the `findOrCreate`/inbox-resolution branches
- Repositories: `home` (sidebar list + group member avatars), `search`, `agentGroup`
- Models: `brief`, `topicShare`, `agentSignal/nightlyReview`
- `apps/server`: `AgentService.getBuiltinAgent`, `topic` router (group members + validated agent)
- `packages/openapi`: `AgentService.list` / `update`

The query selects now include `agents.slug` so the identity check has the data it needs (with matching `groupBy` updates in the nightly-review aggregate).

#### 🧪 How to Test

- [x] Added/updated tests

Added DB tests covering the slug-based fallback for `queryAgents`, `getAgentAvatarsByIds`, the home sidebar list, and the builtin-agent service. Existing tests were updated to assert against the new `DEFAULT_INBOX_TITLE` / `DEFAULT_INBOX_AVATAR` constants.

#### 📝 Additional Information

No schema/migration changes. The selects add the existing `slug` column only; behavior change is limited to read-side normalization of the inbox agent's meta.