### PR TITLE
🐛 fix(model-runtime): strip null/empty members from enum for Gemini

### DIFF
--- a/packages/builtin-tool-memory/src/manifest.ts
+++ b/packages/builtin-tool-memory/src/manifest.ts
@@ -920,7 +920,7 @@ export const MemoryManifest: BuiltinToolManifest = {
               },
               memoryType: {
                 description: 'Memory type, use null for omitting the field',
-                enum: [...MEMORY_TYPES, null],
+                enum: MEMORY_TYPES,
                 type: ['string', 'null'],
               },
               summary: {

--- a/packages/model-runtime/src/core/contextBuilders/google.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.test.ts
@@ -1434,7 +1434,7 @@ describe('google contextBuilders', () => {
       expect(result.parametersJsonSchema).toEqual(tool.function.parameters);
     });
 
-    it('should pass through nullable types without sanitization', () => {
+    it('should keep nullable type but strip null/empty members from enum (Gemini proto)', () => {
       const tool: ChatCompletionTool = {
         function: {
           description: 'A tool with nullable enum',
@@ -1442,7 +1442,7 @@ describe('google contextBuilders', () => {
           parameters: {
             properties: {
               status: {
-                enum: ['active', 'inactive', null],
+                enum: ['active', 'inactive', null, ''],
                 type: ['string', 'null'],
               },
             },
@@ -1454,8 +1454,53 @@ describe('google contextBuilders', () => {
 
       const result = buildGoogleTool(tool);
 
-      // nullable types and null enum values should be passed through as-is
-      expect(result.parametersJsonSchema).toEqual(tool.function.parameters);
+      // Gemini proto only accepts non-empty STRING enum members; null/'' get coerced
+      // to '' and rejected with "enum[i]: cannot be empty", so they must be filtered.
+      // The nullable `type` is preserved to keep the field optional.
+      expect(result.parametersJsonSchema).toEqual({
+        properties: {
+          status: {
+            enum: ['active', 'inactive'],
+            type: ['string', 'null'],
+          },
+        },
+        type: 'object',
+      });
+    });
+
+    // Regression for LOBE-10456: the memory tool's `memoryType` enum carried a
+    // trailing `null` sentinel (`[...MEMORY_TYPES, null]`), which Gemini rejected
+    // with `enum[10]: cannot be empty`. The sanitizer must drop the null member.
+    it('should strip the null sentinel from a memory-style nullable enum', () => {
+      const memoryTypes = ['fact', 'event', 'people', 'preference'];
+      const tool: ChatCompletionTool = {
+        function: {
+          description: 'updateIdentityMemory-style tool',
+          name: 'updateIdentityMemory',
+          parameters: {
+            properties: {
+              set: {
+                properties: {
+                  memoryType: {
+                    description: 'Memory type, use null for omitting the field',
+                    enum: [...memoryTypes, null],
+                    type: ['string', 'null'],
+                  },
+                },
+                type: 'object',
+              },
+            },
+            type: 'object',
+          },
+        },
+        type: 'function',
+      };
+
+      const result = buildGoogleTool(tool) as any;
+
+      expect(result.parametersJsonSchema.properties.set.properties.memoryType.enum).toEqual(
+        memoryTypes,
+      );
     });
 
     it('should pass through const values without conversion', () => {

--- a/packages/model-runtime/src/core/contextBuilders/google.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.ts
@@ -362,17 +362,26 @@ export const sanitizeGeminiSchema = (schema: any): any => {
   const isObjectType = (t: unknown): boolean =>
     typeof t === 'string' ? t === 'object' : Array.isArray(t) && t.includes('object');
 
-  // Strip enum from non-STRING types and empty enums
-  // Gemini proto: "enum: only allowed for STRING type"
-  if (
-    sanitized.enum !== undefined &&
-    (!isStringType(sanitized.type) || !Array.isArray(sanitized.enum) || sanitized.enum.length === 0)
-  ) {
-    console.warn(
-      '[google] sanitizeGeminiSchema stripped enum — not allowed for non-STRING type or empty',
-      { type: sanitized.type, enumLength: sanitized.enum?.length },
-    );
-    delete sanitized.enum;
+  // Sanitize enum for Gemini proto compliance:
+  // - enum is only allowed on STRING type fields
+  // - enum members must be non-empty strings. Gemini's schema proto only accepts
+  //   STRING enum members, so a `null`/non-string sentinel gets coerced to "" and
+  //   rejected with "enum[i]: cannot be empty". Filter such members out first.
+  if (sanitized.enum !== undefined) {
+    if (Array.isArray(sanitized.enum)) {
+      sanitized.enum = sanitized.enum.filter((v: unknown) => typeof v === 'string' && v !== '');
+    }
+    if (
+      !isStringType(sanitized.type) ||
+      !Array.isArray(sanitized.enum) ||
+      sanitized.enum.length === 0
+    ) {
+      console.warn(
+        '[google] sanitizeGeminiSchema stripped enum — not allowed for non-STRING type, empty, or no valid string members',
+        { type: sanitized.type, enumLength: sanitized.enum?.length },
+      );
+      delete sanitized.enum;
+    }
   }
 
   // Strip required from non-OBJECT types and empty required arrays

--- a/packages/model-runtime/src/providers/google/generateObject.test.ts
+++ b/packages/model-runtime/src/providers/google/generateObject.test.ts
@@ -400,8 +400,8 @@ describe('Google generateObject', () => {
       expect(sanitizeGeminiSchema(undefined)).toBeUndefined();
     });
 
-    // nullable string enums should be preserved
-    it('should preserve enum on nullable STRING types (type: array with string)', () => {
+    // nullable string enums should keep string members but drop the null sentinel
+    it('should strip null members from enum on nullable STRING types (type: array with string)', () => {
       const schema = {
         properties: {
           status: {
@@ -414,10 +414,12 @@ describe('Google generateObject', () => {
 
       const result = sanitizeGeminiSchema(schema);
 
+      // Gemini proto only accepts STRING enum members; null is filtered out while
+      // nullability stays expressed via type: ['string', 'null'].
       expect(result).toEqual({
         properties: {
           status: {
-            enum: ['active', 'inactive', null],
+            enum: ['active', 'inactive'],
             type: ['string', 'null'],
           },
         },
@@ -1396,8 +1398,8 @@ describe('Google generateObject', () => {
       warnSpy.mockRestore();
     });
 
-    // buildGoogleTool should preserve nullable string enum
-    it('should preserve enum on nullable STRING type in tool parameters', () => {
+    // buildGoogleTool should keep string enum members but drop the null sentinel
+    it('should strip null members from enum on nullable STRING type in tool parameters', () => {
       const tool: any = {
         function: {
           description: 'A tool with nullable enum',
@@ -1419,11 +1421,11 @@ describe('Google generateObject', () => {
 
       const result = buildGoogleTool(tool);
 
-      // nullable types and null enum values should be passed through as-is
+      // nullable type is passed through, but the null enum member is filtered out
       expect(result.parametersJsonSchema).toEqual({
         properties: {
           status: {
-            enum: ['active', 'inactive', null],
+            enum: ['active', 'inactive'],
             type: ['string', 'null'],
           },
         },


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-10456

#### 🔀 Description of Change

The memory tool's `updateIdentityMemory.set.memoryType` declared its enum as `[...MEMORY_TYPES, null]`. `MEMORY_TYPES` has 10 members (index 0–9), so the trailing `null` sentinel lands at index **10** — matching the reported `enum[10]: cannot be empty`.

Root cause: Gemini's schema proto only accepts **STRING** enum members. When the schema is converted, the `null` member is coerced to an empty string `""` and rejected. OpenAI/Anthropic don't validate enum members, so the failure only surfaced on Gemini.

The existing `sanitizeGeminiSchema` didn't catch it: it only strips an enum when the field is non-STRING, not an array, or an empty array. Here `type: ['string', 'null']` is treated as a string type and the enum has length 11, so all three guards passed and the `null` leaked through.

Fixed in two layers:

1. **Source (`packages/builtin-tool-memory`)** — drop the `null` sentinel from the `memoryType` enum. Nullability is already expressed by `type: ['string', 'null']`, so the enum doesn't need to list `null`.
2. **Conversion fallback (`packages/model-runtime`)** — `sanitizeGeminiSchema` now filters out null/non-string/empty members from any enum array, and strips the `enum` entirely if no valid members remain. This protects against any other tool repeating the same pattern upstream.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added a regression test in `google.test.ts` reproducing the `[...MEMORY_TYPES, null]` shape and asserting the null sentinel is stripped while the nullable `type` is preserved. Updated the previous test that wrongly asserted null enum members pass through unchanged. All 46 tests in the file pass.

#### 📝 Additional Information

Scope is small and surgical — no behavior change for valid string enums; the `memoryType` field stays nullable via `type`.