### PR TITLE
🐛 fix(trusted-client): skip Market trusted token for synthetic eval userIds

### DIFF
--- a/src/libs/trusted-client/index.test.ts
+++ b/src/libs/trusted-client/index.test.ts
@@ -1,0 +1,54 @@
+import { buildTrustedClientPayload, createTrustedClientToken } from '@lobehub/market-sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { generateTrustedClientToken, isSyntheticTrustedClientUserId } from './index';
+
+vi.mock('@/envs/app', () => ({
+  appEnv: {
+    MARKET_TRUSTED_CLIENT_ID: 'client-id',
+    MARKET_TRUSTED_CLIENT_SECRET: 'client-secret',
+  },
+}));
+
+vi.mock('@lobehub/market-sdk', () => ({
+  buildTrustedClientPayload: vi.fn((params) => ({ ...params, nonce: 'n', timestamp: 0 })),
+  createTrustedClientToken: vi.fn(() => 'signed-token'),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('isSyntheticTrustedClientUserId', () => {
+  it('flags eval_ and qstash_smoke_ prefixed ids', () => {
+    expect(isSyntheticTrustedClientUserId('eval_123')).toBe(true);
+    expect(isSyntheticTrustedClientUserId('qstash_smoke_abc')).toBe(true);
+  });
+
+  it('does not flag real user ids or near-misses', () => {
+    expect(isSyntheticTrustedClientUserId('user_2abc')).toBe(false);
+    // "evaluator_" starts with "eval" but not the "eval_" prefix
+    expect(isSyntheticTrustedClientUserId('evaluator_1')).toBe(false);
+    // prefix must be at the start
+    expect(isSyntheticTrustedClientUserId('abc-eval_1')).toBe(false);
+  });
+});
+
+describe('generateTrustedClientToken', () => {
+  it('returns undefined for synthetic eval/smoke userIds without signing', () => {
+    expect(generateTrustedClientToken({ userId: 'eval_xyz' })).toBeUndefined();
+    expect(generateTrustedClientToken({ userId: 'qstash_smoke_1' })).toBeUndefined();
+    expect(buildTrustedClientPayload).not.toHaveBeenCalled();
+    expect(createTrustedClientToken).not.toHaveBeenCalled();
+  });
+
+  it('signs a token for a real userId', () => {
+    const token = generateTrustedClientToken({ email: 'a@b.com', userId: 'user_real' });
+
+    expect(token).toBe('signed-token');
+    expect(buildTrustedClientPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ clientId: 'client-id', userId: 'user_real' }),
+    );
+    expect(createTrustedClientToken).toHaveBeenCalledWith(expect.anything(), 'client-secret');
+  });
+});

--- a/src/libs/trusted-client/index.ts
+++ b/src/libs/trusted-client/index.ts
@@ -18,6 +18,19 @@ export interface TrustedClientUserInfo {
 export { getSessionUser } from './getSessionUser';
 
 /**
+ * Synthetic user ids used by local agent-evals / smoke scripts (e.g. `eval_*`,
+ * `qstash_smoke_*`). These are never real platform accounts — no real userId
+ * carries these prefixes — so Market rejects any trusted-client token built
+ * from them with `invalid_trust_token / Invalid userId format`. We skip token
+ * generation for them to avoid the doomed round-trip and the noisy prep drag it
+ * causes during evals.
+ */
+const SYNTHETIC_USER_ID_PATTERN = /^(?:eval|qstash_smoke)_/;
+
+export const isSyntheticTrustedClientUserId = (userId: string): boolean =>
+  SYNTHETIC_USER_ID_PATTERN.test(userId);
+
+/**
  * Check if trusted client authentication is enabled
  */
 export const isTrustedClientEnabled = (): boolean => {
@@ -35,6 +48,12 @@ export const generateTrustedClientToken = (userInfo: TrustedClientUserInfo): str
   const { MARKET_TRUSTED_CLIENT_SECRET, MARKET_TRUSTED_CLIENT_ID } = appEnv;
 
   if (!MARKET_TRUSTED_CLIENT_SECRET || !MARKET_TRUSTED_CLIENT_ID) {
+    return undefined;
+  }
+
+  // Synthetic eval/smoke userIds can never be valid Market accounts; skip
+  // signing a token Market is guaranteed to reject.
+  if (isSyntheticTrustedClientUserId(userInfo.userId)) {
     return undefined;
   }
 


### PR DESCRIPTION
## 💻 Change Type

- [x] 🐛 fix

## 🔗 Related Links

- Linear / GitHub issue: N/A
- Related PRs: paired cloud-repo PR bumps the gitlink + ships the agent-evals script recipes that hit this path
- Reference docs / code / articles: N/A

## 🔀 Description of Change

Local agent-evals / smoke scripts drive `execAgent` with synthetic userIds (`eval_*`, `qstash_smoke_*`). During prep, `generateTrustedClientToken` signs a trusted-client token and calls Market, which rejects these with `invalid_trust_token / Invalid userId format` — no real platform account ever carries those prefixes.

This skips token generation for synthetic userIds so we avoid the doomed Market round-trip and the noisy prep drag it causes during evals.

- Add `isSyntheticTrustedClientUserId` (matches `^(?:eval|qstash_smoke)_`) and short-circuit `generateTrustedClientToken` before signing.
- Add unit tests covering the prefix matcher (including near-misses like `evaluator_`, `abc-eval_1`) and the token short-circuit / real-userId signing paths.

## 🧭 Key Decisions / Non-goals

- Anchored prefix match (`^`) so only true synthetic prefixes are skipped; real userIds and near-misses still sign normally.
- Behavior is unchanged for any real account — this only suppresses a guaranteed-to-fail call for local eval/smoke fixtures.