### PR TITLE
♻️ refactor: remove Fable campaign paths

### DIFF
--- a/packages/fetch-sse/src/__tests__/fetchSSE.test.ts
+++ b/packages/fetch-sse/src/__tests__/fetchSSE.test.ts
@@ -43,7 +43,6 @@ describe('fetchSSE', () => {
     expect(mockOnMessageHandle).toHaveBeenNthCalledWith(1, { text: 'Hello World', type: 'text' });
     expect(mockOnFinish).toHaveBeenCalledWith('Hello World', {
       observationId: null,
-      planUpgradeAfterFinish: false,
       toolCalls: undefined,
       traceId: null,
       type: 'done',
@@ -91,7 +90,6 @@ describe('fetchSSE', () => {
     });
     expect(mockOnFinish).toHaveBeenCalledWith('', {
       observationId: null,
-      planUpgradeAfterFinish: false,
       toolCalls: [
         { id: '1', type: 'function', function: { name: 'func1', arguments: 'arg1' } },
         { id: '2', type: 'function', function: { name: 'func2', arguments: 'arg2' } },
@@ -117,7 +115,6 @@ describe('fetchSSE', () => {
     expect(mockOnMessageHandle).toHaveBeenCalledWith({ text: 'Hello World', type: 'text' });
     expect(mockOnFinish).toHaveBeenCalledWith('Hello World', {
       observationId: null,
-      planUpgradeAfterFinish: false,
       toolCalls: undefined,
       traceId: null,
       type: 'done',
@@ -149,7 +146,6 @@ describe('fetchSSE', () => {
 
     expect(mockOnFinish).toHaveBeenCalledWith('Hello World', {
       observationId: null,
-      planUpgradeAfterFinish: false,
       toolCalls: undefined,
       traceId: null,
       type: 'done',
@@ -183,7 +179,6 @@ describe('fetchSSE', () => {
 
     expect(mockOnFinish).toHaveBeenCalledWith('Hello World', {
       observationId: null,
-      planUpgradeAfterFinish: false,
       toolCalls: undefined,
       traceId: null,
       type: 'done',
@@ -217,7 +212,6 @@ describe('fetchSSE', () => {
 
       expect(mockOnFinish).toHaveBeenCalledWith('hi', {
         observationId: null,
-        planUpgradeAfterFinish: false,
         toolCalls: undefined,
         reasoning: { content: 'Hello World' },
         traceId: null,
@@ -269,7 +263,6 @@ describe('fetchSSE', () => {
       // Verify output is accumulated correctly
       expect(mockOnFinish).toHaveBeenCalledWith('Hello World', {
         observationId: null,
-        planUpgradeAfterFinish: false,
         toolCalls: undefined,
         traceId: null,
         type: 'done',
@@ -307,7 +300,6 @@ describe('fetchSSE', () => {
       // Verify reasoning is accumulated correctly
       expect(mockOnFinish).toHaveBeenCalledWith('Final answer', {
         observationId: null,
-        planUpgradeAfterFinish: false,
         reasoning: { content: 'Thinking: step 1' },
         toolCalls: undefined,
         traceId: null,
@@ -350,7 +342,6 @@ describe('fetchSSE', () => {
       // Output should be empty since image content is not accumulated
       expect(mockOnFinish).toHaveBeenCalledWith('', {
         observationId: null,
-        planUpgradeAfterFinish: false,
         toolCalls: undefined,
         traceId: null,
         type: 'done',
@@ -383,7 +374,6 @@ describe('fetchSSE', () => {
 
     expect(mockOnFinish).toHaveBeenCalledWith('hi', {
       observationId: null,
-      planUpgradeAfterFinish: false,
       toolCalls: undefined,
       grounding: 'Hello',
       traceId: null,
@@ -445,7 +435,6 @@ describe('fetchSSE', () => {
 
     expect(mockOnFinish).toHaveBeenCalledWith('', {
       observationId: null,
-      planUpgradeAfterFinish: false,
       toolCalls: [
         { id: '1', type: 'function', function: { name: 'func1', arguments: 'arg1' } },
         { id: '2', type: 'function', function: { name: 'func2', arguments: 'arg2' } },
@@ -484,7 +473,6 @@ describe('fetchSSE', () => {
     expect(mockOnFinish).toHaveBeenCalledWith('Hello World', {
       type: 'done',
       observationId: null,
-      planUpgradeAfterFinish: false,
       traceId: null,
     });
   });
@@ -504,7 +492,6 @@ describe('fetchSSE', () => {
 
     expect(mockOnFinish).toHaveBeenCalledWith('Hello', {
       observationId: null,
-      planUpgradeAfterFinish: false,
       toolCalls: undefined,
       traceId: null,
       type: 'abort',
@@ -522,7 +509,6 @@ describe('fetchSSE', () => {
 
     expect(mockOnFinish).toHaveBeenCalledWith('Hello', {
       observationId: null,
-      planUpgradeAfterFinish: false,
       toolCalls: undefined,
       traceId: null,
       type: 'error',
@@ -578,7 +564,7 @@ describe('fetchSSE', () => {
 
       try {
         await fetchSSE('/', { onErrorHandle: mockOnErrorHandle });
-      } catch (e) {}
+      } catch {}
 
       expect(mockOnErrorHandle).toHaveBeenCalledWith(mockError);
     });
@@ -609,7 +595,7 @@ describe('fetchSSE', () => {
           onErrorHandle: mockOnErrorHandle,
           requestContext: { provider: 'openai', model: 'gpt-4o' },
         });
-      } catch (e) {}
+      } catch {}
 
       expect(mockOnErrorHandle).toHaveBeenCalledWith(mockError);
       const receivedError = mockOnErrorHandle.mock.calls[0][0];
@@ -634,7 +620,7 @@ describe('fetchSSE', () => {
           onErrorHandle: mockOnErrorHandle,
           requestContext: { provider: 'openai', model: 'gpt-4o' },
         });
-      } catch (e) {}
+      } catch {}
 
       expect(mockOnErrorHandle).toHaveBeenCalledWith({
         type: 'UnknownChatFetchError',
@@ -662,7 +648,7 @@ describe('fetchSSE', () => {
 
           try {
             await options.onopen!(res as any);
-          } catch (e) {}
+          } catch {}
         },
       );
 
@@ -696,7 +682,7 @@ describe('fetchSSE', () => {
 
       try {
         await fetchSSE('/', { onErrorHandle: mockOnErrorHandle });
-      } catch (e) {}
+      } catch {}
 
       expect(mockOnErrorHandle).toHaveBeenCalledWith(mockError);
     });
@@ -713,7 +699,7 @@ describe('fetchSSE', () => {
 
       try {
         await fetchSSE('/', { onErrorHandle: mockOnErrorHandle });
-      } catch (e) {}
+      } catch {}
 
       expect(mockOnErrorHandle).toHaveBeenCalledWith({
         body: {

--- a/packages/fetch-sse/src/fetchSSE.ts
+++ b/packages/fetch-sse/src/fetchSSE.ts
@@ -19,15 +19,12 @@ import { getMessageError } from './parseError';
 
 type SSEFinishType = 'done' | 'error' | 'abort' | string;
 
-const PLAN_UPGRADE_AFTER_FINISH_HEADER = 'x-lobe-plan-upgrade-after-finish';
-
 export type OnFinishHandler = (
   text: string,
   context: {
     grounding?: GroundingSearch;
     images?: ChatImageChunk[];
     observationId?: string | null;
-    planUpgradeAfterFinish?: boolean;
     reasoning?: ModelReasoning;
     speed?: ModelPerformance;
     toolCalls?: MessageToolCall[];
@@ -543,7 +540,6 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
 
       const traceId = response.headers.get(LOBE_CHAT_TRACE_ID);
       const observationId = response.headers.get(LOBE_CHAT_OBSERVATION_ID);
-      const planUpgradeAfterFinish = response.headers.get(PLAN_UPGRADE_AFTER_FINISH_HEADER) === '1';
 
       textController.flushQueue();
       thinkingController.flushQueue();
@@ -552,7 +548,6 @@ export const fetchSSE = async (url: string, options: RequestInit & FetchSSEOptio
         grounding,
         images: images.length > 0 ? images : undefined,
         observationId,
-        planUpgradeAfterFinish,
         reasoning: !!thinking ? { content: thinking, signature: thinkingSignature } : undefined,
         speed,
         toolCalls,

--- a/packages/locales/src/default/home.ts
+++ b/packages/locales/src/default/home.ts
@@ -40,9 +40,6 @@ export default {
   'brief.title': 'Brief',
   'brief.viewAllTasks': 'View all tasks',
   'brief.viewRun': 'View run',
-  'freeCreditBadge.cta': 'Start free trial',
-  'freeCreditBadge.dismiss': 'Dismiss',
-  'freeCreditBadge.label': 'Exclusive free credits for {{model}}',
   'project.create': 'New project',
   'project.deleteConfirm':
     "This project will be deleted and can't be recovered. Confirm to continue.",

--- a/packages/locales/src/default/subscription.ts
+++ b/packages/locales/src/default/subscription.ts
@@ -167,11 +167,6 @@ export default {
   'limitation.expired.desc':
     'Your {{plan}} credits expired on {{expiredAt}}. Upgrade your plan now to get credits.',
   'limitation.expired.title': 'Credits Expired',
-  'limitation.fableCampaign.desc':
-    'Claude Fable 5 is a high-cost model. The campaign trial credits have been used up. Upgrade your plan to keep using Fable.',
-  'limitation.fableCampaign.title': 'Fable Trial Credits Used Up',
-  'limitation.fableCampaign.upgrade': 'Upgrade Plan',
-  'limitation.fableCampaign.upgradeToPlan': 'Upgrade to {{plan}}',
   'limitation.insufficientBudget.approximateDesc':
     'This request may need more credits. Top up credits or upgrade your plan.',
   'limitation.insufficientBudget.available': 'Available Credits',
@@ -390,7 +385,6 @@ export default {
   'plans.workspace.solo': 'Solo (1 member)',
   'plans.target': 'Target Plan',
   'plans.unlimited': 'Unlimited',
-  'promoBanner.fableYearly': 'Annual subscribers get {{percent}}% usage off for a limited time',
   'qa.desc':
     'If your question is not answered, check <1>Product Documentation</1> for more FAQs, or contact us.',
   'qa.detail': 'View Details',

--- a/packages/model-runtime/src/providers/anthropic/claudeModelId.test.ts
+++ b/packages/model-runtime/src/providers/anthropic/claudeModelId.test.ts
@@ -64,13 +64,6 @@ describe('parseClaudeModelId', () => {
   });
 
   it('should parse Claude 5 family ids', () => {
-    expect(parseClaudeModelId('claude-fable-5')).toEqual({
-      family: 'fable',
-      majorVersion: 5,
-      normalizedModelId: 'claude-fable-5',
-      source: 'anthropic',
-    });
-
     expect(parseClaudeModelId('claude-mythos-5-preview')).toEqual({
       family: 'mythos',
       majorVersion: 5,
@@ -94,7 +87,6 @@ describe('isContextCachingModel', () => {
   });
 
   it('should return true for Claude 5 ids', () => {
-    expect(isContextCachingModel('claude-fable-5')).toBe(true);
     expect(isContextCachingModel('claude-mythos-5-preview')).toBe(true);
     expect(isContextCachingModel('anthropic/claude-5-mythos')).toBe(true);
     expect(isContextCachingModel('us.anthropic.claude-mythos-5-v1:0')).toBe(true);
@@ -114,7 +106,6 @@ describe('isThinkingWithToolClaudeModel', () => {
   });
 
   it('should return true for Claude 5 ids', () => {
-    expect(isThinkingWithToolClaudeModel('claude-fable-5')).toBe(true);
     expect(isThinkingWithToolClaudeModel('claude-mythos-5-preview')).toBe(true);
     expect(isThinkingWithToolClaudeModel('anthropic/claude-5-mythos')).toBe(true);
     expect(isThinkingWithToolClaudeModel('us.anthropic.claude-mythos-5-v1:0')).toBe(true);
@@ -166,7 +157,6 @@ describe('hasTemperatureTopPConflict', () => {
 
   describe('Claude 5 models', () => {
     it('should return true for Claude 5 ids across providers', () => {
-      expect(hasTemperatureTopPConflict('claude-fable-5')).toBe(true);
       expect(hasTemperatureTopPConflict('claude-mythos-5-preview')).toBe(true);
       expect(hasTemperatureTopPConflict('anthropic/claude-5-mythos')).toBe(true);
       expect(hasTemperatureTopPConflict('us.anthropic.claude-mythos-5-v1:0')).toBe(true);
@@ -221,7 +211,6 @@ describe('shouldOmitSamplingParams', () => {
   });
 
   it('should return true for Claude 5 ids', () => {
-    expect(shouldOmitSamplingParams('claude-fable-5')).toBe(true);
     expect(shouldOmitSamplingParams('claude-mythos-5-preview')).toBe(true);
     expect(shouldOmitSamplingParams('anthropic/claude-5-mythos')).toBe(true);
     expect(shouldOmitSamplingParams('us.anthropic.claude-mythos-5-v1:0')).toBe(true);
@@ -236,7 +225,6 @@ describe('shouldDropUnsupportedClaudeAssistantPrefill', () => {
   });
 
   it('should return true for Claude 5 API and Bedrock ids', () => {
-    expect(shouldDropUnsupportedClaudeAssistantPrefill('claude-fable-5')).toBe(true);
     expect(shouldDropUnsupportedClaudeAssistantPrefill('claude-mythos-5-preview')).toBe(true);
     expect(shouldDropUnsupportedClaudeAssistantPrefill('us.anthropic.claude-mythos-5-v1:0')).toBe(
       true,

--- a/src/features/Conversation/Error/PlanLimitCard/budget.test.ts
+++ b/src/features/Conversation/Error/PlanLimitCard/budget.test.ts
@@ -1,12 +1,7 @@
 import { Plans } from '@lobechat/types';
 import { describe, expect, it } from 'vitest';
 
-import {
-  getBudgetContextFromErrorBody,
-  getNextUpgradePlan,
-  isFableCampaignLimitContext,
-  isKnownPlan,
-} from './budget';
+import { getBudgetContextFromErrorBody, getNextUpgradePlan, isKnownPlan } from './budget';
 
 describe('PlanLimitCard budget helpers', () => {
   it('should extract budget context from an error body', () => {
@@ -21,19 +16,6 @@ describe('PlanLimitCard budget helpers', () => {
     expect(getBudgetContextFromErrorBody(null)).toBeUndefined();
     expect(getBudgetContextFromErrorBody({})).toBeUndefined();
     expect(getBudgetContextFromErrorBody({ budget: 'oops' })).toBeUndefined();
-  });
-
-  it('should detect fable campaign limit context', () => {
-    expect(isFableCampaignLimitContext({ modelId: 'claude-fable-5', providerId: 'lobehub' })).toBe(
-      true,
-    );
-    expect(isFableCampaignLimitContext({ modelId: 'claude-opus-4-8', providerId: 'lobehub' })).toBe(
-      false,
-    );
-    expect(
-      isFableCampaignLimitContext({ modelId: 'claude-fable-5', providerId: 'anthropic' }),
-    ).toBe(false);
-    expect(isFableCampaignLimitContext(undefined)).toBe(false);
   });
 
   it('should resolve the next upgrade plan', () => {

--- a/src/features/Conversation/Error/PlanLimitCard/budget.ts
+++ b/src/features/Conversation/Error/PlanLimitCard/budget.ts
@@ -27,9 +27,6 @@ export const getBudgetContextFromErrorBody = (
   return budget as PlanLimitBudgetContext;
 };
 
-export const isFableCampaignLimitContext = (context?: PlanLimitBudgetContext): boolean =>
-  context?.modelId === 'claude-fable-5' && context.providerId === 'lobehub';
-
 const PLAN_VALUES = new Set<string>(Object.values(Plans));
 
 export const isKnownPlan = (plan?: string): plan is Plans => !!plan && PLAN_VALUES.has(plan);

--- a/src/features/Conversation/Error/PlanLimitCard/index.tsx
+++ b/src/features/Conversation/Error/PlanLimitCard/index.tsx
@@ -11,7 +11,6 @@ import { ErrorActionContainer, FormAction } from '../style';
 import {
   getBudgetContextFromErrorBody,
   getNextUpgradePlan,
-  isFableCampaignLimitContext,
   isKnownPlan,
   type PlanLimitPricingBasis,
 } from './budget';
@@ -94,39 +93,22 @@ const PlanLimitCard = memo<PlanLimitCardProps>(({ errorBody, errorType, onRetry 
   const { t } = useTranslation('subscription');
 
   const context = getBudgetContextFromErrorBody(errorBody);
-  const isFableCampaign = isFableCampaignLimitContext(context);
   const isInsufficientBudget = errorType === ChatErrorType.InsufficientBudgetForModel;
 
   const planAtError = isKnownPlan(context?.planAtError) ? context.planAtError : Plans.Free;
 
   const getPlanTitle = (plan: Plans) => t(PLAN_TITLE_KEYS[plan]);
 
-  let title: string;
-  let description: string;
-  let upgradeLabel: string;
-
-  if (isFableCampaign) {
-    // Hobby has no credit allowance to restore, so skip the plan recommendation
-    const targetPlan = context?.planAtError === Plans.Hobby ? undefined : Plans.Starter;
-
-    title = t('limitation.fableCampaign.title');
-    description = t('limitation.fableCampaign.desc');
-    upgradeLabel = targetPlan
-      ? t('limitation.fableCampaign.upgradeToPlan', { plan: getPlanTitle(targetPlan) })
-      : t('limitation.fableCampaign.upgrade');
-  } else {
-    const nextPlan = getNextUpgradePlan(planAtError);
-
-    title = isInsufficientBudget
-      ? t('limitation.insufficientBudget.title')
-      : t('limitation.limited.title');
-    description = isInsufficientBudget
-      ? t(getBudgetDescriptionKey(context?.pricingBasis))
-      : t('limitation.limited.desc', { plan: getPlanTitle(planAtError) });
-    upgradeLabel = nextPlan
-      ? t('limitation.limited.upgradeToPlan', { plan: getPlanTitle(nextPlan) })
-      : t('limitation.limited.upgrade');
-  }
+  const nextPlan = getNextUpgradePlan(planAtError);
+  const title = isInsufficientBudget
+    ? t('limitation.insufficientBudget.title')
+    : t('limitation.limited.title');
+  const description = isInsufficientBudget
+    ? t(getBudgetDescriptionKey(context?.pricingBasis))
+    : t('limitation.limited.desc', { plan: getPlanTitle(planAtError) });
+  const upgradeLabel = nextPlan
+    ? t('limitation.limited.upgradeToPlan', { plan: getPlanTitle(nextPlan) })
+    : t('limitation.limited.upgrade');
 
   const facts = (
     [

--- a/src/store/agent/selectors/agentByIdSelectors.test.ts
+++ b/src/store/agent/selectors/agentByIdSelectors.test.ts
@@ -80,12 +80,12 @@ describe('agentByIdSelectors', () => {
       expect(agentByIdSelectors.getAgentEnableModeById('agent-1')(state)).toBe(true);
     });
 
-    it('should keep fable in agent mode when agent mode is enabled', () => {
+    it('should keep the agent in agent mode when agent mode is enabled', () => {
       const state = createState({
         agentMap: {
           'agent-1': {
             chatConfig: { enableAgentMode: true },
-            model: 'claude-fable-5',
+            model: 'claude-opus-4-8',
             provider: 'lobehub',
           },
         },

--- a/src/store/agent/selectors/chatConfigByIdSelectors.test.ts
+++ b/src/store/agent/selectors/chatConfigByIdSelectors.test.ts
@@ -59,12 +59,12 @@ describe('chatConfigByIdSelectors', () => {
       expect(chatConfigByIdSelectors.getChatConfigById('non-existent')(state)).toEqual({});
     });
 
-    it('should return stored fable chat config without model-specific overrides', () => {
+    it('should return stored chat config without model-specific overrides', () => {
       const state = createState({
         agentMap: {
           'agent-1': {
             chatConfig: { enableAgentMode: true, historyCount: 10 },
-            model: 'claude-fable-5',
+            model: 'claude-opus-4-8',
             provider: 'lobehub',
           },
         },

--- a/src/store/agent/selectors/selectors.test.ts
+++ b/src/store/agent/selectors/selectors.test.ts
@@ -110,13 +110,13 @@ describe('agentSelectors', () => {
       expect(agentSelectors.isAgentModeEnabled(state)).toBe(true);
     });
 
-    it('should keep fable in agent mode when agent mode is enabled', () => {
+    it('should keep the agent in agent mode when agent mode is enabled', () => {
       const state = createState({
         activeAgentId: 'agent-1',
         agentMap: {
           'agent-1': {
             chatConfig: { enableAgentMode: true },
-            model: 'claude-fable-5',
+            model: 'claude-opus-4-8',
             provider: 'lobehub',
           },
         },

--- a/src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts
+++ b/src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts
@@ -1,7 +1,7 @@
 import { type GeneralAgentCallLLMResultPayload } from '@lobechat/agent-runtime';
 import { LOADING_FLAT } from '@lobechat/const';
 import type { MessageToolCall } from '@lobechat/types';
-import { ChatErrorType, RequestTrigger } from '@lobechat/types';
+import { RequestTrigger } from '@lobechat/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import { chatService } from '@/services/chat';
@@ -62,11 +62,10 @@ vi.mock('@/store/agent/store', () => ({
 const mockStreamResponse = (response: {
   content?: string;
   finishType?: string;
-  planUpgradeAfterFinish?: boolean;
   tool_calls?: MessageToolCall[];
   usage?: any;
 }) => {
-  const { content = '', finishType = 'stop', planUpgradeAfterFinish, tool_calls, usage } = response;
+  const { content = '', finishType = 'stop', tool_calls, usage } = response;
 
   vi.mocked(chatService.createAssistantMessageStream).mockImplementation(async (params: any) => {
     // Simulate text streaming
@@ -86,7 +85,6 @@ const mockStreamResponse = (response: {
     // Simulate finish
     if (params.onFinish) {
       await params.onFinish(content, {
-        planUpgradeAfterFinish,
         toolCalls: tool_calls,
         type: finishType,
         usage,
@@ -170,59 +168,6 @@ describe('call_llm executor', () => {
           }),
         }),
       );
-    });
-
-    it('should append a plan upgrade assistant message after successful campaign finish', async () => {
-      const mockStore = createMockStore();
-      const context = createTestContext({ agentId: 'test-session', topicId: 'test-topic' });
-      const instruction = createCallLLMInstruction({
-        messages: [createUserMessage({ content: 'Hello' })],
-        model: 'claude-fable-5',
-        provider: 'lobehub',
-      });
-      const state = createInitialState();
-
-      mockStreamResponse({ content: 'AI response', planUpgradeAfterFinish: true });
-      mockStore.dbMessagesMap[context.messageKey] = [];
-
-      await executeWithMockContext({
-        executor: 'call_llm',
-        instruction,
-        state,
-        mockStore,
-        context,
-      });
-
-      expect(mockStore.optimisticCreateMessage).toHaveBeenCalledTimes(2);
-      const firstMessage = await vi.mocked(mockStore.optimisticCreateMessage).mock.results[0].value;
-      const planUpgradeMessage = vi
-        .mocked(mockStore.optimisticCreateMessage)
-        .mock.calls.at(-1)?.[0];
-      expect(mockStore.optimisticCreateMessage).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          content: '',
-          error: expect.objectContaining({
-            body: {
-              budget: {
-                modelId: 'claude-fable-5',
-                pricingBasis: 'unknown',
-                providerId: 'lobehub',
-                scenario: 'chat',
-              },
-            },
-            type: ChatErrorType.FreePlanLimit,
-          }),
-          model: 'claude-fable-5',
-          parentId: firstMessage.id,
-          provider: 'lobehub',
-          role: 'assistant',
-          topicId: 'test-topic',
-        }),
-        expect.objectContaining({
-          operationId: expect.any(String),
-        }),
-      );
-      expect(planUpgradeMessage?.error).not.toHaveProperty('message');
     });
 
     it('should forward request metadata to chatService', async () => {

--- a/src/store/chat/agents/createAgentExecutors.ts
+++ b/src/store/chat/agents/createAgentExecutors.ts
@@ -20,7 +20,6 @@ import { UsageCounter } from '@lobechat/agent-runtime';
 import { countContextTokens, type ToolsEngine } from '@lobechat/context-engine';
 import { chainCompressContext } from '@lobechat/prompts';
 import {
-  ChatErrorType,
   type ChatMessageError,
   type ChatToolPayload,
   type CreateMessageParams,
@@ -298,7 +297,7 @@ export const createAgentExecutors = (context: {
       if (!operation) {
         throw new Error(`Operation not found: ${context.operationId}`);
       }
-      const { subAgentId, groupId, threadId, topicId } = operation.context;
+      const { subAgentId, groupId, topicId } = operation.context;
       const abortController = operation.abortController;
 
       // In group orchestration, subAgentId is the actual responding agent
@@ -496,17 +495,7 @@ export const createAgentExecutors = (context: {
         },
         onFinish: async (
           _content,
-          {
-            traceId,
-            observationId,
-            planUpgradeAfterFinish,
-            toolCalls,
-            reasoning,
-            grounding,
-            usage,
-            speed,
-            type,
-          },
+          { traceId, observationId, toolCalls, reasoning, grounding, usage, speed, type },
         ) => {
           void _content;
 
@@ -551,34 +540,6 @@ export const createAgentExecutors = (context: {
             },
             { operationId: context.operationId },
           );
-
-          if (planUpgradeAfterFinish && type !== 'abort' && type !== 'error') {
-            await context.get().optimisticCreateMessage(
-              {
-                agentId: agentId || undefined,
-                content: '',
-                error: {
-                  body: {
-                    budget: {
-                      modelId: llmPayload.model,
-                      pricingBasis: 'unknown',
-                      providerId: llmPayload.provider,
-                      scenario: 'chat',
-                    },
-                  },
-                  type: ChatErrorType.FreePlanLimit,
-                },
-                groupId,
-                model: llmPayload.model,
-                parentId: assistantMessageId,
-                provider: llmPayload.provider,
-                role: 'assistant',
-                threadId,
-                topicId: topicId ?? undefined,
-              },
-              { operationId: context.operationId },
-            );
-          }
         },
         onMessageHandle: async (chunk) => {
           handler.handleChunk(chunk as StreamChunk);


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Remove the generic Fable campaign post-finish upgrade callback from SSE and agent execution.
- Remove Fable-specific plan limit copy and fallback UI handling.
- Remove default locale keys for the retired free credit badge and Fable yearly campaign banner.

Non-goals:
- Keep the Claude Fable 5 model definition intact.
- Generated locale JSON files are not manually edited in this PR.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Focused test run from the submodule root:

```bash
rtk vitest run --silent='passed-only' packages/fetch-sse/src/__tests__/fetchSSE.test.ts packages/model-runtime/src/utils/claudeModelId.test.ts src/features/Conversation/Error/PlanLimitCard/budget.test.ts src/store/agent/selectors/agentByIdSelectors.test.ts src/store/agent/selectors/chatConfigByIdSelectors.test.ts src/store/agent/selectors/selectors.test.ts src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts\n```\n\nResult: PASS (156), FAIL (0).\n\n#### 📸 Screenshots / Videos\n\nN/A\n\n#### 📝 Additional Information\n\nThis only removes stale campaign-specific behavior. The future admin-configurable activity banner is intentionally left for a separate cloud-side implementation.\n