### PR TITLE
🐛 fix(cmdk): merge Image/AI Video into one "Generation" navigate entry

### DIFF
--- a/packages/app-config/src/routes/index.ts
+++ b/packages/app-config/src/routes/index.ts
@@ -126,9 +126,35 @@ export const getRouteById = (id: string): NavigationRoute | undefined =>
   NAVIGATION_ROUTES.find((r) => r.id === id);
 
 /**
- * Get navigable routes for CMDK (excludes settings which has separate handling)
+ * Get navigable routes for CMDK (excludes settings which has separate handling).
+ *
+ * Image and video share a single "Generation" destination in the app sidebar
+ * (see useNavLayout's bottomMenuItems → tab.generation → /image), so the command
+ * palette mirrors that: one "Generation" entry pointing at /image, instead of
+ * separate "Image" / "AI Video" entries. The merged keywords keep both image and
+ * video terms searchable, and reusing tab.generation keeps the label in sync with
+ * the sidebar across every locale.
  */
 export const getNavigableRoutes = (): NavigationRoute[] =>
   NAVIGATION_ROUTES.filter((r) =>
-    ['community', 'video', 'image', 'resource', 'page', 'memory'].includes(r.id),
+    ['community', 'image', 'resource', 'page', 'memory'].includes(r.id),
+  ).map((r) =>
+    r.id === 'image'
+      ? {
+          ...r,
+          cmdkKey: 'tab.generation',
+          keywords: [
+            'generation',
+            'generate',
+            'image',
+            'painting',
+            'art',
+            'draw',
+            'video',
+            'seedance',
+            'kling',
+          ],
+          keywordsKey: undefined,
+        }
+      : r,
   );


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

The command palette (cmdk) **Navigate** group listed two separate destinations — **"Image"** (`cmdk.painting` → `/image`) and **"AI Video"** (`cmdk.video` → `/video`) — but the app sidebar has since combined both into a single **"Generation"** item.

The sidebar's source of truth is `useNavLayout`'s `bottomMenuItems`, which renders one entry: `t('tab.generation')` → `/image`. The cmdk navigate list was left out of sync, so it still showed the old split entries.

This aligns the cmdk with the sidebar by updating `getNavigableRoutes()` (whose **only** consumer is the cmdk navigate group in `MainMenu.tsx`):

- Drops the standalone `video` entry from the navigable list.
- Relabels the `image` entry to **"Generation"** by reusing the existing `tab.generation` key — so the cmdk label stays identical to the sidebar across **all** locales, with no new i18n keys.
- Merges image + video search keywords (`generation`, `image`, `painting`, `art`, `draw`, `video`, `seedance`, `kling`) so typing either still surfaces the entry.

What is **not** touched:

- `NAVIGATION_ROUTES` keeps both `image` and `video` route definitions intact — the `/video` route, `getRouteById('video')`, and the Electron navigation are unaffected.
- This only changes the cmdk presentation, mirroring the sidebar's existing behavior (Generation → `/image`).

#### 🧪 How to Test

1. Open the command palette → the **Navigate** group shows a single **"Generation"** item (no separate "AI Video" / "Image").
2. It navigates to `/image` (same as clicking **Generation** in the sidebar).
3. Type `image`, `video`, `painting`, `seedance`, or `kling` → the **Generation** entry still matches.

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

Reuses the already-shipped `tab.generation` label, so no locale changes are required. `getNavigableRoutes()` is cmdk-only, so the blast radius is limited to the command palette's navigate list. `bun run type-check` shows no new errors introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
