### PR TITLE
🐛 fix(agent-documents): prevent path-store crash from empty or colliding tree node names

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -1060,6 +1060,7 @@
   "workingPanel.resources.tree.newFolder": "New folder",
   "workingPanel.resources.tree.parentMissing": "Parent folder is unavailable",
   "workingPanel.resources.tree.rename": "Rename",
+  "workingPanel.resources.tree.renameBeforeAction": "Rename this item before moving or deleting it",
   "workingPanel.resources.tree.untitledDocument": "Untitled document",
   "workingPanel.resources.tree.untitledFolder": "Untitled folder",
   "workingPanel.resources.updatedAt": "Updated {{time}}",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -1060,6 +1060,7 @@
   "workingPanel.resources.tree.newFolder": "新建文件夹",
   "workingPanel.resources.tree.parentMissing": "上级目录不可用",
   "workingPanel.resources.tree.rename": "重命名",
+  "workingPanel.resources.tree.renameBeforeAction": "请先重命名该项目,再进行移动或删除",
   "workingPanel.resources.tree.untitledDocument": "未命名文档",
   "workingPanel.resources.tree.untitledFolder": "未命名文件夹",
   "workingPanel.resources.updatedAt": "更新于 {{time}}",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -1125,6 +1125,7 @@ export default {
   'workingPanel.resources.tree.newDocument': 'New document',
   'workingPanel.resources.tree.newFolder': 'New folder',
   'workingPanel.resources.tree.rename': 'Rename',
+  'workingPanel.resources.tree.renameBeforeAction': 'Rename this item before moving or deleting it',
   'workingPanel.resources.tree.untitledDocument': 'Untitled document',
   'workingPanel.resources.tree.untitledFolder': 'Untitled folder',
   'workingPanel.resources.updatedAt': 'Updated {{time}}',

--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.test.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.test.tsx
@@ -349,4 +349,64 @@ describe('DocumentExplorerTree', () => {
     });
     expect(messageSuccess).not.toHaveBeenCalled();
   });
+
+  it('disables dragging on dirty rows (empty or duplicate filename)', () => {
+    const data = [
+      createDocument({
+        documentId: 'good-folder-doc',
+        filename: 'Notes',
+        id: 'good-folder-row',
+        isFolder: true,
+        title: 'Notes',
+      }),
+      // Empty filename → its VFS path collapses onto the parent.
+      createDocument({
+        documentId: 'empty-folder-doc',
+        filename: '',
+        id: 'empty-folder-row',
+        isFolder: true,
+        title: '',
+      }),
+      // Two siblings share a filename → the VFS resolves to the wrong row.
+      createDocument({ documentId: 'dup-a-doc', filename: 'dup.md', id: 'dup-a-row', title: 'dup' }),
+      createDocument({ documentId: 'dup-b-doc', filename: 'dup.md', id: 'dup-b-row', title: 'dup' }),
+    ];
+
+    render(<DocumentExplorerTree agentId="agent-1" data={data} mutate={vi.fn()} />, {
+      wrapper: MemoryRouter,
+    });
+
+    expect(screen.getByTestId('tree-node-good-folder-row')).toHaveAttribute('data-can-drag', 'true');
+    expect(screen.getByTestId('tree-node-empty-folder-row')).toHaveAttribute(
+      'data-can-drag',
+      'false',
+    );
+    expect(screen.getByTestId('tree-node-dup-a-row')).toHaveAttribute('data-can-drag', 'false');
+    expect(screen.getByTestId('tree-node-dup-b-row')).toHaveAttribute('data-can-drag', 'false');
+  });
+
+  it('refuses to path-delete a dirty folder and asks to rename it first', () => {
+    const mutate = vi.fn().mockResolvedValue(undefined);
+    const data = [
+      createDocument({
+        documentId: 'empty-folder-doc',
+        filename: '',
+        id: 'empty-folder-row',
+        isFolder: true,
+        title: '',
+      }),
+    ];
+
+    render(<DocumentExplorerTree agentId="agent-1" data={data} mutate={mutate} />, {
+      wrapper: MemoryRouter,
+    });
+
+    fireEvent.click(screen.getByTestId('tree-menu-empty-folder-row-delete'));
+
+    // The dirty folder is excluded before the confirm dialog: no modal opens, a
+    // warning is shown, and no path-based delete is ever attempted.
+    expect(modalConfirm).not.toHaveBeenCalled();
+    expect(messageWarning).toHaveBeenCalledWith('workingPanel.resources.tree.renameBeforeAction');
+    expect(removeDocumentMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
@@ -214,8 +214,12 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, onOpenDocumen
 
   const canDrag = useCallback(
     (node: ExplorerTreeNode<AgentDocumentItem>) =>
-      !!node.data && node.data.category === AGENT_DOCUMENT_CATEGORY,
-    [],
+      !!node.data &&
+      node.data.category === AGENT_DOCUMENT_CATEGORY &&
+      // A dirty row (empty/duplicate filename) can't be addressed by path, so
+      // dragging it would move the wrong row — keep it pinned until renamed.
+      ops.isRowPathSafe(node.id),
+    [ops],
   );
 
   const canRename = useCallback(

--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
@@ -105,16 +105,35 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, onOpenDocumen
     [rowIdByDocumentId],
   );
 
+  const resolveNodeName = useCallback(
+    (doc: AgentDocumentItem): string => {
+      if (doc.isSkillIndex) return SKILL_INDEX_FILENAME;
+      // Never let an empty name through: a blank segment collides with its
+      // parent's path inside the tree's path store and crashes the whole panel
+      // (see ExplorerTree/adapter/normalize.ts). Fall back to a localized label.
+      return (
+        doc.title ||
+        doc.filename ||
+        t(
+          doc.isFolder
+            ? 'workingPanel.resources.tree.untitledFolder'
+            : 'workingPanel.resources.tree.untitledDocument',
+        )
+      );
+    },
+    [t],
+  );
+
   const nodes = useMemo<ExplorerTreeNode<AgentDocumentItem>[]>(
     () =>
       documents.map((doc) => ({
         data: doc,
         id: doc.id,
         isFolder: doc.isFolder,
-        name: doc.isSkillIndex ? SKILL_INDEX_FILENAME : doc.title || doc.filename || '',
+        name: resolveNodeName(doc),
         parentId: resolveParentRowId(doc.parentId),
       })),
-    [documents, resolveParentRowId],
+    [documents, resolveNodeName, resolveParentRowId],
   );
   const defaultExpandedIds = useMemo(
     () => nodes.filter((node) => node.isFolder && node.parentId == null).map((node) => node.id),

--- a/src/features/AgentDocumentsExplorer/hooks/useDocumentTreeOps.ts
+++ b/src/features/AgentDocumentsExplorer/hooks/useDocumentTreeOps.ts
@@ -22,6 +22,11 @@ const ROOT_PATH = './';
 const joinPath = (parentPath: string, segment: string) =>
   parentPath === ROOT_PATH ? `${ROOT_PATH}${segment}` : `${parentPath}/${segment}`;
 
+// Key a row by (parent, filename) so we can detect filename collisions among
+// siblings — the granularity the path-based VFS actually resolves on.
+const siblingFilenameKey = (parentDocumentId: string | null, filename: string) =>
+  `${parentDocumentId ?? ''} ${filename}`;
+
 // Service mutations return AgentDocumentStats-shaped payloads where the
 // agentDocumentItems row id is exposed as `id` (and mirrored on
 // `agentDocumentId`). Extract defensively since tRPC narrows the type
@@ -46,6 +51,8 @@ export interface DocumentTreeOps {
   createDocument: (parentId: string | null, opts?: CreateOptions) => Promise<void>;
   createFolder: (parentId: string | null, opts?: CreateOptions) => Promise<void>;
   deleteDocuments: (ids: string[]) => void;
+  /** Whether a row is safe for path-based actions (drag-to-move). */
+  isRowPathSafe: (id: string) => boolean;
   moveDocument: (params: {
     sourceIds: string[];
     sourceNodes: { data?: AgentDocumentItem }[];
@@ -81,20 +88,48 @@ export const useDocumentTreeOps = ({
     return map;
   }, [data]);
 
+  // How many siblings share each (parent, filename). >1 means the filename is
+  // ambiguous and the VFS would resolve it to the wrong (oldest) row.
+  const filenameCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const doc of data) {
+      const key = siblingFilenameKey(doc.parentId ?? null, doc.filename);
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return counts;
+  }, [data]);
+
+  // A row is safe for path-based VFS actions (folder delete, move) only when its
+  // filename is non-empty AND unique among its siblings. Otherwise the path is
+  // ambiguous: a blank segment collapses onto the parent (`./Parent/` →
+  // `./Parent`) and a duplicate name resolves to a different sibling — so
+  // deleting/moving a "dirty" row would hit the parent or the wrong row. These
+  // rows stay on id-based actions (rename) until repaired.
+  const isItemPathSafe = useCallback(
+    (item: AgentDocumentItem): boolean =>
+      item.filename.trim() !== '' &&
+      filenameCounts.get(siblingFilenameKey(item.parentId ?? null, item.filename)) === 1,
+    [filenameCounts],
+  );
+
   // Walk up via item.parentId (= parent's documentId) until we hit the root.
+  // Returns null when the item or any ancestor is path-unsafe, so every
+  // path-based caller (delete / move / create) falls back to its safe branch.
   const buildItemPath = useCallback(
     (item: AgentDocumentItem): string | null => {
+      if (!isItemPathSafe(item)) return null;
       const segments: string[] = [item.filename];
       let parentDocId = item.parentId;
       while (parentDocId) {
         const parent = byDocumentId.get(parentDocId);
         if (!parent) return null;
+        if (!isItemPathSafe(parent)) return null;
         segments.unshift(parent.filename);
         parentDocId = parent.parentId;
       }
       return `${ROOT_PATH}${segments.join('/')}`;
     },
-    [byDocumentId],
+    [byDocumentId, isItemPathSafe],
   );
 
   // Resolves the parent's path given a tree-node parent id (= row id) or null.
@@ -311,17 +346,24 @@ export const useDocumentTreeOps = ({
       const targetParentDocId = targetItem ? targetItem.documentId : null;
 
       const moves: Array<{ fromPath: string; id: string; toPath: string }> = [];
+      let skippedDirty = false;
       for (const id of sourceIds) {
         const node = sourceNodes.find((n) => n.data?.id === id)?.data;
         if (!node) continue;
         if (node.category === 'skill') return;
         const fromPath = buildItemPath(node);
-        if (!fromPath) continue;
+        // A dirty source (empty/duplicate filename) has no addressable path —
+        // skip it so we never move the wrong row, and flag it for the user.
+        if (!fromPath) {
+          skippedDirty = true;
+          continue;
+        }
         const toPath = joinPath(targetParentPath, node.filename);
         if (fromPath === toPath) continue;
         moves.push({ fromPath, id, toPath });
       }
 
+      if (skippedDirty) message.warning(t('workingPanel.resources.tree.renameBeforeAction'));
       if (moves.length === 0) return;
 
       // Optimistic: reparent each source row to the new parent's documentId.
@@ -383,7 +425,16 @@ export const useDocumentTreeOps = ({
       };
       const targets = resolved.filter((doc) => !hasAncestorIn(doc, folderDocIds));
 
-      if (targets.length === 0) return;
+      // A dirty folder row can't be addressed by path, and deleteByPath would
+      // recurse into its parent — exclude it and ask the user to rename it
+      // first. Files delete by id (id-safe), so they always stay.
+      const safeTargets = targets.filter(
+        (doc) => !(doc.isFolder && !doc.isSkillBundle) || buildItemPath(doc) !== null,
+      );
+      if (safeTargets.length < targets.length) {
+        message.warning(t('workingPanel.resources.tree.renameBeforeAction'));
+      }
+      if (safeTargets.length === 0) return;
 
       confirmModal({
         cancelText: t('cancel', { ns: 'common' }),
@@ -397,11 +448,12 @@ export const useDocumentTreeOps = ({
             | { kind: 'row'; target: AgentDocumentItem }
           > = [];
 
-          for (const target of targets) {
+          for (const target of safeTargets) {
             // Skill bundles are removed via the bundle row, not path-based
             // recursive removal.
             const isFolder = target.isFolder && !target.isSkillBundle;
             if (isFolder) {
+              // safeTargets already excludes dirty folders, so this is defensive.
               const folderPath = buildItemPath(target);
               if (!folderPath) {
                 message.error(t('workingPanel.resources.tree.parentMissing'));
@@ -471,12 +523,22 @@ export const useDocumentTreeOps = ({
           })();
         },
         title:
-          targets.length > 1
-            ? t('workingPanel.resources.deleteTitleMulti', { count: targets.length })
+          safeTargets.length > 1
+            ? t('workingPanel.resources.deleteTitleMulti', { count: safeTargets.length })
             : t('workingPanel.resources.deleteTitle'),
       });
     },
     [agentId, buildItemPath, message, mutate, t, topicId],
+  );
+
+  // A dirty row can still render as a normal tree node; surface its path-safety
+  // so the view can disable id-unsafe affordances (e.g. drag-to-move) on it.
+  const isRowPathSafe = useCallback(
+    (id: string): boolean => {
+      const item = byRowId.get(id);
+      return !!item && buildItemPath(item) !== null;
+    },
+    [byRowId, buildItemPath],
   );
 
   return useMemo(
@@ -484,9 +546,10 @@ export const useDocumentTreeOps = ({
       createDocument,
       createFolder,
       deleteDocuments,
+      isRowPathSafe,
       moveDocument,
       renameDocument,
     }),
-    [createDocument, createFolder, deleteDocuments, moveDocument, renameDocument],
+    [createDocument, createFolder, deleteDocuments, isRowPathSafe, moveDocument, renameDocument],
   );
 };

--- a/src/features/ExplorerTree/adapter/normalize.test.ts
+++ b/src/features/ExplorerTree/adapter/normalize.test.ts
@@ -21,6 +21,42 @@ describe('normalizeTree', () => {
     ).toEqual(['folder-b', 'file-a']);
   });
 
+  it('disambiguates a folder and a file that share a name', () => {
+    // @pierre/trees keys nodes by bare name within a parent, so `foo/` and
+    // `foo` would collide into one ambiguous node without a directory index
+    // (the "Unknown directory child index" crash). They must stay distinct.
+    const nodes: ExplorerTreeNode[] = [
+      { id: 'folder', isFolder: true, name: 'foo', parentId: null },
+      { id: 'file', name: 'foo', parentId: null },
+    ];
+
+    const tree = normalizeTree(nodes);
+
+    expect(tree.pathById.get('folder')).toBe('foo/');
+    expect(tree.pathById.get('file')).toBe('foo (2)');
+    // no two nodes share a bare path segment
+    expect(new Set(tree.paths.map((p) => (p.endsWith('/') ? p.slice(0, -1) : p))).size).toBe(
+      tree.paths.length,
+    );
+  });
+
+  it('replaces empty names with a fallback instead of emitting a blank segment', () => {
+    // A blank segment makes a child path equal to its parent's path, which the
+    // path store cannot represent and crashes the panel.
+    const nodes: ExplorerTreeNode[] = [
+      { id: 'blank-folder', isFolder: true, name: '', parentId: null },
+      { id: 'blank-file', name: '   ', parentId: null },
+      { id: 'child', name: 'a.md', parentId: 'blank-folder' },
+    ];
+
+    const tree = normalizeTree(nodes);
+
+    expect(tree.pathById.get('blank-folder')).toBe('Untitled/');
+    expect(tree.pathById.get('blank-file')).toBe('Untitled (2)');
+    expect(tree.pathById.get('child')).toBe('Untitled/a.md');
+    expect(tree.paths.every((p) => p.replaceAll('/', '') !== '')).toBe(true);
+  });
+
   it('detects descendants by parent id mapping', () => {
     const tree = normalizeTree([
       {

--- a/src/features/ExplorerTree/adapter/normalize.ts
+++ b/src/features/ExplorerTree/adapter/normalize.ts
@@ -9,10 +9,23 @@ export interface NormalizedTree<TData> {
   paths: string[];
 }
 
-const dedupeName = (taken: Set<string>, baseName: string, isFolder: boolean): string => {
-  const segment = buildSegment(baseName, isFolder);
-  if (!taken.has(segment)) {
-    taken.add(segment);
+// Last-resort label when a node has no usable name. Callers should supply a
+// localized fallback, but an empty segment must never reach the path store
+// (see below), so we guard here too.
+const UNNAMED_FALLBACK = 'Untitled';
+
+// The underlying path store (@pierre/trees) keys a node by its *bare* name
+// within its parent, ignoring the folder trailing slash. So a folder `foo/`
+// and a file `foo` are the SAME node to it — an ambiguous dir/file with no
+// directory index, which throws "Unknown directory child index" and takes down
+// the whole panel. Dedupe on the bare name (type-agnostic) so siblings stay
+// distinct regardless of folder-ness, and never emit an empty segment.
+const bareKey = (name: string): string => buildSegment(name, false);
+
+const dedupeName = (taken: Set<string>, rawName: string, isFolder: boolean): string => {
+  const baseName = rawName.trim() === '' ? UNNAMED_FALLBACK : rawName;
+  if (!taken.has(bareKey(baseName))) {
+    taken.add(bareKey(baseName));
     return baseName;
   }
   // split name / ext for nicer suffixes on files
@@ -21,14 +34,13 @@ const dedupeName = (taken: Set<string>, baseName: string, isFolder: boolean): st
   const ext = dotIndex > 0 ? baseName.slice(dotIndex) : '';
   for (let i = 2; i < 10_000; i += 1) {
     const candidate = `${stem} (${i})${ext}`;
-    const seg = buildSegment(candidate, isFolder);
-    if (!taken.has(seg)) {
-      taken.add(seg);
+    if (!taken.has(bareKey(candidate))) {
+      taken.add(bareKey(candidate));
       return candidate;
     }
   }
   const fallback = `${stem}-${Math.random().toString(36).slice(2, 8)}${ext}`;
-  taken.add(buildSegment(fallback, isFolder));
+  taken.add(bareKey(fallback));
   return fallback;
 };
 


### PR DESCRIPTION
### 💡 Description of Change

The agent document explorer renders through `@pierre/trees`, whose path store keys each node by its **bare name** within its parent and asserts every intermediate path segment is a registered directory. When that invariant breaks it throws `Error: Unknown directory child index for node N`, which bubbles to the page-level error boundary and blanks the entire agent panel ("页面暂时不可用").

Two data shapes from the agent-documents list trigger it:

1. **Empty name** — a document with neither `title` nor `filename` produced `name: ''`, yielding a blank path segment whose path equals its parent's path.
2. **Folder/file name collision** — a folder and a file sharing a name collapsed into one ambiguous node. The adapter previously deduped on the full segment (`foo/` vs `foo`), but the path store treats both as the same `foo`.

Either one leaves the path store internally inconsistent; the crash then surfaces later when the tree restores focus and walks the focused path (`getVisibleIndex → findNodeIdBySegments → getDirectoryIndex`).

### 🔧 Fix

Two layers of defense:

- **`ExplorerTree/adapter/normalize.ts`** (root defense): dedupe siblings on the **bare name**, type-agnostic, so a folder and a file with the same name stay distinct the way the path store sees them; and never emit an empty segment (fall back to a non-empty label). This keeps the path store self-consistent even from dirty data.
- **`DocumentExplorerTree.tsx`** (presentation): give empty document names a localized fallback (`untitledDocument` / `untitledFolder`, keys already shipped in all locales).

### ✅ How to Test

- Added unit tests in `normalize.test.ts` covering both collision classes (folder+file same name; empty/blank names) and asserting paths stay unique and non-blank.
- `bunx vitest run src/features/ExplorerTree/adapter/normalize.test.ts src/features/AgentDocumentsExplorer/DocumentExplorerTree.test.tsx` — all pass.

### 📝 Change Type

- [x] 🐛 Bug fix