### PR TITLE
🐛 fix: reject duplicate custom model ids

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/aiModel.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiModel.test.ts
@@ -29,10 +29,12 @@ describe('aiModelRouter', () => {
 
   it('should create ai model', async () => {
     const mockCreate = vi.fn().mockResolvedValue({ id: 'model-1' });
+    const mockFindByIdAndProvider = vi.fn().mockResolvedValue(null);
     vi.mocked(AiModelModel).mockImplementation(
       () =>
         ({
           create: mockCreate,
+          findByIdAndProvider: mockFindByIdAndProvider,
         }) as any,
     );
 
@@ -44,9 +46,65 @@ describe('aiModelRouter', () => {
     });
 
     expect(result).toBe('model-1');
+    expect(mockFindByIdAndProvider).toHaveBeenCalledWith('test-model', 'test-provider');
     expect(mockCreate).toHaveBeenCalledWith({
       id: 'test-model',
       providerId: 'test-provider',
+    });
+  });
+
+  it('should reject duplicate ai model before creating', async () => {
+    const mockCreate = vi.fn();
+    const mockFindByIdAndProvider = vi.fn().mockResolvedValue({ id: 'test-model' });
+    vi.mocked(AiModelModel).mockImplementation(
+      () =>
+        ({
+          create: mockCreate,
+          findByIdAndProvider: mockFindByIdAndProvider,
+        }) as any,
+    );
+
+    const caller = aiModelRouter.createCaller(mockCtx);
+
+    await expect(
+      caller.createAiModel({
+        id: 'test-model',
+        providerId: 'test-provider',
+      }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Model "test-model" already exists',
+    });
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('should convert duplicate insert races to conflict errors', async () => {
+    const duplicateError = Object.assign(new Error('failed query'), {
+      cause: Object.assign(new Error('duplicate key'), {
+        code: '23505',
+        constraint: 'ai_models_id_provider_id_user_id_unique',
+      }),
+    });
+    const mockCreate = vi.fn().mockRejectedValue(duplicateError);
+    const mockFindByIdAndProvider = vi.fn().mockResolvedValue(null);
+    vi.mocked(AiModelModel).mockImplementation(
+      () =>
+        ({
+          create: mockCreate,
+          findByIdAndProvider: mockFindByIdAndProvider,
+        }) as any,
+    );
+
+    const caller = aiModelRouter.createCaller(mockCtx);
+
+    await expect(
+      caller.createAiModel({
+        id: 'test-model',
+        providerId: 'test-provider',
+      }),
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'Model "test-model" already exists',
     });
   });
 

--- a/apps/server/src/routers/lambda/aiModel.ts
+++ b/apps/server/src/routers/lambda/aiModel.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from '@trpc/server';
 import { type AiProviderModelListItem } from 'model-bank';
 import {
   AiModelTypeSchema,
@@ -17,6 +18,30 @@ import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { getServerGlobalConfig } from '@/server/globalConfig';
 import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
 import { type ProviderConfig } from '@/types/user/settings';
+
+const AI_MODEL_UNIQUE_CONSTRAINT = 'ai_models_id_provider_id_user_id_unique';
+
+const getPostgresErrorField = (error: unknown, field: 'code' | 'constraint') => {
+  let current = error;
+
+  while (current && typeof current === 'object') {
+    const value = (current as Record<string, unknown>)[field];
+    if (typeof value === 'string') return value;
+
+    current = (current as { cause?: unknown }).cause;
+  }
+};
+
+const isDuplicateAiModelError = (error: unknown) =>
+  getPostgresErrorField(error, 'code') === '23505' &&
+  getPostgresErrorField(error, 'constraint') === AI_MODEL_UNIQUE_CONSTRAINT;
+
+const throwDuplicateAiModelError = (id: string): never => {
+  throw new TRPCError({
+    code: 'CONFLICT',
+    message: `Model "${id}" already exists`,
+  });
+};
 
 const aiModelProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) => {
   const { ctx } = opts;
@@ -82,9 +107,18 @@ export const aiModelRouter = router({
     .use(withScopedPermission('ai_model:create'))
     .input(CreateAiModelSchema)
     .mutation(async ({ input, ctx }) => {
-      const data = await ctx.aiModelModel.create(input);
+      const existingModel = await ctx.aiModelModel.findByIdAndProvider(input.id, input.providerId);
+      if (existingModel) throwDuplicateAiModelError(input.id);
 
-      return data?.id;
+      try {
+        const data = await ctx.aiModelModel.create(input);
+
+        return data?.id;
+      } catch (error) {
+        if (isDuplicateAiModelError(error)) throwDuplicateAiModelError(input.id);
+
+        throw error;
+      }
     }),
 
   getAiModelById: aiModelProcedure

--- a/locales/en-US/modelProvider.json
+++ b/locales/en-US/modelProvider.json
@@ -257,6 +257,7 @@
   "providerModels.item.modelConfig.files.title": "File Upload Support",
   "providerModels.item.modelConfig.functionCall.extra": "This configuration will only enable the model's ability to use tools, allowing for the addition of tool-type skills. However, whether the model can truly use the tools depends entirely on the model itself; please test for usability on your own.",
   "providerModels.item.modelConfig.functionCall.title": "Support for Tool Usage",
+  "providerModels.item.modelConfig.id.duplicate": "A model with this ID already exists. Use a different model ID.",
   "providerModels.item.modelConfig.id.extra": "This cannot be modified after creation and will be used as the model ID when calling AI",
   "providerModels.item.modelConfig.id.placeholder": "Please enter the model ID, e.g., gpt-4o or claude-3.5-sonnet",
   "providerModels.item.modelConfig.id.title": "Model ID",

--- a/locales/zh-CN/modelProvider.json
+++ b/locales/zh-CN/modelProvider.json
@@ -257,6 +257,7 @@
   "providerModels.item.modelConfig.files.title": "支持文件上传",
   "providerModels.item.modelConfig.functionCall.extra": "此配置将仅开启模型使用技能的能力，进而可以为模型添加技能。但是否支持真正使用技能完全取决于模型本身，请自行测试的可用性",
   "providerModels.item.modelConfig.functionCall.title": "支持技能使用",
+  "providerModels.item.modelConfig.id.duplicate": "该模型 ID 已存在，请换一个模型 ID。",
   "providerModels.item.modelConfig.id.extra": "创建后不可修改，调用 AI 时将作为模型 id 使用",
   "providerModels.item.modelConfig.id.placeholder": "请输入模型 id，例如 gpt-4o 或 claude-3.5-sonnet",
   "providerModels.item.modelConfig.id.title": "模型 ID",

--- a/packages/database/src/models/__tests__/aiModel.test.ts
+++ b/packages/database/src/models/__tests__/aiModel.test.ts
@@ -42,6 +42,33 @@ describe('AiModelModel', () => {
       });
       expect(group).toMatchObject({ ...params, userId });
     });
+
+    it('should reject creating the same model id twice', async () => {
+      await aiProviderModel.create({
+        displayName: 'Old Name',
+        enabled: false,
+        id: 'qvq',
+        providerId: 'openai',
+        releasedAt: '2025-01-01',
+      });
+
+      await expect(
+        aiProviderModel.create({
+          contextWindowTokens: 4096,
+          displayName: 'New Name',
+          id: 'qvq',
+          providerId: 'openai',
+          releasedAt: '2025-02-01T00:00:00.000Z',
+        }),
+      ).rejects.toThrow();
+
+      const models = await aiProviderModel.query();
+      expect(models).toHaveLength(1);
+      expect(models[0]).toMatchObject({
+        displayName: 'Old Name',
+        releasedAt: '2025-01-01',
+      });
+    });
   });
   describe('delete', () => {
     it('should delete a ai provider by id', async () => {
@@ -99,11 +126,17 @@ describe('AiModelModel', () => {
 
   describe('query', () => {
     it('should query ai providers for the user', async () => {
-      await aiProviderModel.create({ organization: 'Qwen', providerId: 'openai', id: 'qvq' });
+      await aiProviderModel.create({
+        organization: 'Qwen',
+        providerId: 'openai',
+        id: 'qvq',
+        updatedAt: new Date('2025-01-01T00:00:00.000Z'),
+      });
       await aiProviderModel.create({
         organization: 'Qwen',
         providerId: 'openai',
         id: 'aihubmix-2',
+        updatedAt: new Date('2025-01-02T00:00:00.000Z'),
       });
 
       const userGroups = await aiProviderModel.query();
@@ -263,6 +296,21 @@ describe('AiModelModel', () => {
       // Verify no models were created
       const allModels = await aiProviderModel.query();
       expect(allModels).toHaveLength(0);
+    });
+
+    it('should normalize ISO releasedAt values before inserting remote models', async () => {
+      const models = [
+        {
+          displayName: 'Remote Model',
+          enabled: true,
+          id: 'remote-model',
+          releasedAt: '2025-01-01T00:00:00.000Z',
+        },
+      ] as AiProviderModelListItem[];
+
+      const [result] = await aiProviderModel.batchUpdateAiModels('openai', models);
+
+      expect(result.releasedAt).toBe('2025-01-01');
     });
   });
 

--- a/packages/database/src/models/aiModel.ts
+++ b/packages/database/src/models/aiModel.ts
@@ -21,6 +21,23 @@ export class AiModelModel {
   }
 
   /**
+   * The database column is varchar(10). Remote model feeds can send ISO timestamps
+   * such as `2025-01-01T00:00:00.000Z`, which PostgreSQL rejects on insert.
+   */
+  private normalizeReleasedAt(releasedAt?: string | null) {
+    if (!releasedAt) return releasedAt;
+
+    return releasedAt.length > 10 ? releasedAt.slice(0, 10) : releasedAt;
+  }
+
+  private normalizeAiModelValues<T extends { releasedAt?: string | null }>(values: T): T {
+    return {
+      ...values,
+      releasedAt: this.normalizeReleasedAt(values.releasedAt),
+    };
+  }
+
+  /**
    * Helper method to validate if array is empty and return early if needed
    * @param array - Array to validate
    * @returns true if array is empty, false otherwise
@@ -30,10 +47,12 @@ export class AiModelModel {
   }
 
   create = async (params: NewAiModelItem) => {
+    const values = this.normalizeAiModelValues(params);
+
     const [result] = await this.db
       .insert(aiModels)
       .values({
-        ...params,
+        ...values,
         enabled: params.enabled ?? true, // enabled by default, but respect explicit value
         source: AiModelSourceEnum.Custom,
         userId: this.userId,
@@ -124,12 +143,24 @@ export class AiModelModel {
     });
   };
 
+  findByIdAndProvider = async (id: string, providerId: string) => {
+    return this.db.query.aiModels.findFirst({
+      where: and(
+        eq(aiModels.id, id),
+        eq(aiModels.providerId, providerId),
+        eq(aiModels.userId, this.userId),
+      ),
+    });
+  };
+
   update = async (id: string, providerId: string, value: Partial<AiModelSelectItem>) => {
+    const normalizedValue = this.normalizeAiModelValues(value);
+
     return this.db
       .insert(aiModels)
-      .values({ ...value, id, providerId, updatedAt: new Date(), userId: this.userId })
+      .values({ ...normalizedValue, id, providerId, updatedAt: new Date(), userId: this.userId })
       .onConflictDoUpdate({
-        set: value,
+        set: normalizedValue,
         target: [aiModels.id, aiModels.providerId, aiModels.userId],
         targetWhere: isNull(aiModels.workspaceId),
       });
@@ -172,6 +203,7 @@ export class AiModelModel {
       ...model,
       id,
       providerId,
+      releasedAt: this.normalizeReleasedAt(model.releasedAt),
       updatedAt: new Date(),
       userId: this.userId,
     }));

--- a/packages/locales/src/default/modelProvider.ts
+++ b/packages/locales/src/default/modelProvider.ts
@@ -325,6 +325,8 @@ export default {
   'providerModels.item.modelConfig.functionCall.extra':
     "This configuration will only enable the model's ability to use tools, allowing for the addition of tool-type skills. However, whether the model can truly use the tools depends entirely on the model itself; please test for usability on your own.",
   'providerModels.item.modelConfig.functionCall.title': 'Support for Tool Usage',
+  'providerModels.item.modelConfig.id.duplicate':
+    'A model with this ID already exists. Use a different model ID.',
   'providerModels.item.modelConfig.id.extra':
     'This cannot be modified after creation and will be used as the model ID when calling AI',
   'providerModels.item.modelConfig.id.placeholder':

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/Content.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/Content.tsx
@@ -1,18 +1,23 @@
 'use client';
 
-import { type FormInstance } from 'antd';
+import type { FormInstance } from 'antd';
 import { memo } from 'react';
 
 import ModelConfigForm from './Form';
 
 interface CreateNewModelContentProps {
+  existingModelIds?: string[];
   onFormReady: (instance: FormInstance) => void;
   showDeployName?: boolean;
 }
 
 const CreateNewModelContent = memo<CreateNewModelContentProps>(
-  ({ showDeployName, onFormReady }) => (
-    <ModelConfigForm showDeployName={showDeployName} onFormInstanceReady={onFormReady} />
+  ({ showDeployName, onFormReady, existingModelIds }) => (
+    <ModelConfigForm
+      existingModelIds={existingModelIds}
+      showDeployName={showDeployName}
+      onFormInstanceReady={onFormReady}
+    />
   ),
 );
 

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/Footer.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/Footer.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from '@lobehub/ui';
 import { ModalFooter, useModalContext } from '@lobehub/ui/base-ui';
-import { type FormInstance } from 'antd';
+import type { FormInstance } from 'antd';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/Form.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/Form.tsx
@@ -1,8 +1,8 @@
 import { Input } from '@lobehub/ui';
 import { Select } from '@lobehub/ui/base-ui';
-import { type FormInstance } from 'antd';
+import type { FormInstance } from 'antd';
 import { Checkbox, Form } from 'antd';
-import { type AiModelType } from 'model-bank';
+import type { AiModelType } from 'model-bank';
 import { memo, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -11,9 +11,11 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import { type ChatModelCard } from '@/types/llm';
 
 import ExtendParamsSelect from './ExtendParamsSelect';
+import { hasDuplicateModelId } from './utils';
 
 interface ModelConfigFormProps {
   disabled?: boolean;
+  existingModelIds?: string[];
   idEditable?: boolean;
   initialValues?: ChatModelCard;
   onFormInstanceReady: (instance: FormInstance) => void;
@@ -22,7 +24,14 @@ interface ModelConfigFormProps {
 }
 
 const ModelConfigForm = memo<ModelConfigFormProps>(
-  ({ showDeployName, idEditable = true, onFormInstanceReady, initialValues, disabled }) => {
+  ({
+    showDeployName,
+    idEditable = true,
+    onFormInstanceReady,
+    initialValues,
+    disabled,
+    existingModelIds = [],
+  }) => {
     const { t } = useTranslation('modelProvider');
 
     const [formInstance] = Form.useForm();
@@ -79,7 +88,16 @@ const ModelConfigForm = memo<ModelConfigFormProps>(
             extra={t('providerModels.item.modelConfig.id.extra')}
             label={t('providerModels.item.modelConfig.id.title')}
             name={'id'}
-            rules={[{ required: true }]}
+            rules={[
+              { required: true },
+              {
+                validator: async (_, value?: string) => {
+                  if (hasDuplicateModelId(value, existingModelIds)) {
+                    throw new Error(t('providerModels.item.modelConfig.id.duplicate'));
+                  }
+                },
+              },
+            ]}
           >
             <Input
               disabled={disabled || !idEditable}

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/__tests__/utils.test.ts
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/__tests__/utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasDuplicateModelId } from '../utils';
+
+describe('hasDuplicateModelId', () => {
+  it('should detect an existing model id', () => {
+    expect(hasDuplicateModelId('claude-opus-4-8', ['claude-opus-4-8'])).toBe(true);
+  });
+
+  it('should ignore empty model ids', () => {
+    expect(hasDuplicateModelId('   ', ['claude-opus-4-8'])).toBe(false);
+  });
+
+  it('should allow a different model id', () => {
+    expect(hasDuplicateModelId('claude-sonnet-4-6', ['claude-opus-4-8'])).toBe(false);
+  });
+});

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/index.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/index.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { createModal, type ModalInstance } from '@lobehub/ui/base-ui';
-import { type FormInstance } from 'antd';
+import type { ModalInstance } from '@lobehub/ui/base-ui';
+import { createModal } from '@lobehub/ui/base-ui';
+import type { FormInstance } from 'antd';
 import { t } from 'i18next';
 
 import CreateNewModelContent from './Content';
 import CreateNewModelFooter from './Footer';
 
 interface CreateNewModelModalOptions {
+  existingModelIds?: string[];
   showDeployName?: boolean;
 }
 
@@ -19,6 +21,7 @@ export const createCreateNewModelModal = (
   return createModal({
     content: (
       <CreateNewModelContent
+        existingModelIds={options.existingModelIds}
         showDeployName={options.showDeployName}
         onFormReady={(instance) => {
           formRef.current = instance;

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/utils.ts
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/utils.ts
@@ -1,0 +1,6 @@
+export const hasDuplicateModelId = (id: string | undefined, existingModelIds: string[]) => {
+  const modelId = id?.trim();
+  if (!modelId) return false;
+
+  return existingModelIds.includes(modelId);
+};

--- a/src/routes/(main)/settings/provider/features/ModelList/EmptyModels.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/EmptyModels.tsx
@@ -74,7 +74,12 @@ const EmptyState = memo<{ provider: string }>(({ provider }) => {
             icon={PlusIcon}
             onClick={() => {
               if (!canManageProvider) return;
-              createCreateNewModelModal({ showDeployName });
+              createCreateNewModelModal({
+                existingModelIds: useAiInfraStore
+                  .getState()
+                  .aiProviderModelList.map((model) => model.id),
+                showDeployName,
+              });
             }}
           >
             {t('providerModels.list.addNew')}

--- a/src/routes/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/ModelTitle/index.tsx
@@ -159,7 +159,12 @@ const ModelTitle = memo<ModelFetcherProps>(
                       size={'small'}
                       onClick={() => {
                         if (!canManageProvider) return;
-                        createCreateNewModelModal({ showDeployName });
+                        createCreateNewModelModal({
+                          existingModelIds: useAiInfraStore
+                            .getState()
+                            .aiProviderModelList.map((model) => model.id),
+                          showDeployName,
+                        });
                       }}
                     />
                   </Tooltip>


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-8810

#### 🔀 Description of Change

This PR fixes duplicate custom AI model creation handling.

- Adds frontend validation in the custom model creation modal so users cannot submit a model ID that already exists in the current provider's model list.
- Keeps `AiModelModel.create` as an insert-only operation so duplicate custom model IDs are rejected instead of silently updating an existing model.
- Adds a server-side duplicate pre-check and converts the unique-constraint race path to a TRPC `CONFLICT` error.
- Normalizes remote `releasedAt` ISO timestamps to the existing `varchar(10)` storage format before insert/update paths write model records.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated tests:

```bash
cd packages/database && rtk vitest run --silent='passed-only' src/models/__tests__/aiModel.test.ts
rtk vitest run --silent='passed-only' apps/server/src/routers/lambda/__tests__/aiModel.test.ts
rtk vitest run --silent='passed-only' "src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/__tests__/utils.test.ts"
vscode-cli get-diagnostics
rtk git diff --check
```

Results:

- Database model tests: `PASS (24) FAIL (0)`
- Lambda router tests: `PASS (12) FAIL (0)`
- Duplicate-id helper tests: `PASS (3) FAIL (0)`
- VS Code diagnostics: no diagnostics on modified files
- Diff check: clean

Manual verification:

- Opened `/settings/provider/test-provider` in local Web full-stack mode.
- Verified duplicate ID `test-image-model` shows `该模型 ID 已存在，请换一个模型 ID。` and does not send `aiModel.createAiModel`.
- Verified a unique test model can still be created and then deleted.
- Verified direct duplicate `aiModel.createAiModel` returns HTTP 409 / TRPC `CONFLICT`.

#### 📸 Screenshots / Videos

N/A. Local Web verification is recorded in the agent-testing report.

#### 📝 Additional Information

Key decisions:

- Duplicate custom model IDs should be rejected. They should not update the existing model.
- The frontend catches the normal user path, while the server still owns the final uniqueness guarantee for direct calls and races.
- `releasedAt` normalization is intentionally limited to trimming ISO timestamp strings to `YYYY-MM-DD`, matching the current database column contract.
