### PR TITLE
🐛 fix(agent): stop chat mode from auto-injecting local-system tools

### DIFF
--- a/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
@@ -28,7 +28,11 @@ import { ToolsEngine } from '@lobechat/context-engine';
 import { type RuntimeEnvMode, type RuntimePlatform } from '@lobechat/types';
 import debug from 'debug';
 
-import { executionTargetToRuntimeMode, resolveExecutionTarget } from '@/helpers/executionTarget';
+import {
+  executionTargetToRuntimeMode,
+  resolveExecutionTarget,
+  resolveToolMode,
+} from '@/helpers/executionTarget';
 import {
   buildAllowedBuiltinTools,
   DEVICE_TOOL_IDENTIFIERS,
@@ -170,9 +174,7 @@ export const createServerAgentToolsEngine = (
   const isSearchEnabled = searchMode !== 'off';
   // Tool mode: explicit `toolMode` wins; otherwise derive from `enableAgentMode`
   // (undefined = agent). `custom` = toolset is exactly the agent's plugins.
-  const toolMode: 'agent' | 'chat' | 'custom' =
-    agentConfig.chatConfig?.toolMode ??
-    (agentConfig.chatConfig?.enableAgentMode === false ? 'chat' : 'agent');
+  const toolMode = resolveToolMode(agentConfig.chatConfig ?? undefined);
   const isChatMode = toolMode === 'chat';
   const isCustomMode = toolMode === 'custom';
 

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1902,15 +1902,13 @@ export class AiAgentService {
       // Chat mode is orthogonal to `executionTarget` (the UI toggle only writes
       // `enableAgentMode`), so a default/stored `local` target would otherwise
       // resolve a device and `buildStepToolDelta` would re-inject local-system.
-      // Pass `isChatMode` so the plan degrades to `none` — same canonical
-      // derivation the tools engine uses (`toolMode` wins; else `enableAgentMode`).
-      const toolMode =
-        agentConfig.chatConfig?.toolMode ??
-        (agentConfig.chatConfig?.enableAgentMode === false ? 'chat' : 'agent');
+      // Pass `chatConfig` so the plan degrades to `none` in chat mode — the
+      // chat-mode derivation lives in `resolveExecutionPlan` (`resolveToolMode`),
+      // the same source of truth the tools engine uses.
       executionPlan = resolveExecutionPlan({
         agencyConfig: agentConfig.agencyConfig,
         canUseDevice,
-        isChatMode: toolMode === 'chat',
+        chatConfig: agentConfig.chatConfig ?? undefined,
         isDesktop: gatewayConfigured,
         onlineDeviceIds: onlineDevices.map((device) => device.deviceId),
         requestedDeviceId,

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1898,9 +1898,19 @@ export class AiAgentService {
       // `isDesktop` uses `gatewayConfigured` as a proxy: a device-gateway
       // deployment serves desktop-class users, so the unset-target default
       // resolves to `local` there and `none` otherwise.
+      //
+      // Chat mode is orthogonal to `executionTarget` (the UI toggle only writes
+      // `enableAgentMode`), so a default/stored `local` target would otherwise
+      // resolve a device and `buildStepToolDelta` would re-inject local-system.
+      // Pass `isChatMode` so the plan degrades to `none` — same canonical
+      // derivation the tools engine uses (`toolMode` wins; else `enableAgentMode`).
+      const toolMode =
+        agentConfig.chatConfig?.toolMode ??
+        (agentConfig.chatConfig?.enableAgentMode === false ? 'chat' : 'agent');
       executionPlan = resolveExecutionPlan({
         agencyConfig: agentConfig.agencyConfig,
         canUseDevice,
+        isChatMode: toolMode === 'chat',
         isDesktop: gatewayConfigured,
         onlineDeviceIds: onlineDevices.map((device) => device.deviceId),
         requestedDeviceId,

--- a/src/helpers/executionTarget.test.ts
+++ b/src/helpers/executionTarget.test.ts
@@ -258,21 +258,24 @@ describe('resolveExecutionPlan', () => {
     });
   });
 
-  describe('isChatMode — no execution environment, even on a local target', () => {
+  describe('chat mode — no execution environment, even on a local target', () => {
     it('degrades every device-capable target to none despite an online device', () => {
       // regression: chat mode only removes local-system from the rule-layer
       // whitelist; the device track resolved an `activeDeviceId` from the
       // default/stored `local` target and `buildStepToolDelta` re-injected
       // local-system. The plan now honours chat mode at the source.
       for (const executionTarget of ['local', 'device'] as const) {
-        expect(
-          resolveExecutionPlan({
-            agencyConfig: cfg({ boundDeviceId: 'device-a', executionTarget }),
-            isChatMode: true,
-            isDesktop: true,
-            onlineDeviceIds: ONLINE_A,
-          }),
-        ).toEqual({ kind: 'none', target: 'none' });
+        // both ways of expressing chat mode degrade the plan
+        for (const chatConfig of [{ enableAgentMode: false }, { toolMode: 'chat' as const }]) {
+          expect(
+            resolveExecutionPlan({
+              agencyConfig: cfg({ boundDeviceId: 'device-a', executionTarget }),
+              chatConfig,
+              isDesktop: true,
+              onlineDeviceIds: ONLINE_A,
+            }),
+          ).toEqual({ kind: 'none', target: 'none' });
+        }
       }
     });
 
@@ -280,7 +283,7 @@ describe('resolveExecutionPlan', () => {
       expect(
         resolveExecutionPlan({
           agencyConfig: undefined,
-          isChatMode: true,
+          chatConfig: { enableAgentMode: false },
           isDesktop: true,
           onlineDeviceIds: ONLINE_A,
         }),
@@ -288,18 +291,31 @@ describe('resolveExecutionPlan', () => {
       expect(
         resolveExecutionPlan({
           agencyConfig: cfg({ executionTarget: 'sandbox' }),
-          isChatMode: true,
+          chatConfig: { enableAgentMode: false },
           isDesktop: true,
           onlineDeviceIds: ONLINE_A,
         }),
       ).toEqual({ kind: 'none', target: 'none' });
     });
 
+    it('does not degrade agent mode (toolMode wins over enableAgentMode)', () => {
+      // explicit toolMode='agent' must keep device routing even if
+      // enableAgentMode is somehow false
+      expect(
+        resolveExecutionPlan({
+          agencyConfig: cfg({ executionTarget: 'local' }),
+          chatConfig: { enableAgentMode: false, toolMode: 'agent' },
+          isDesktop: true,
+          onlineDeviceIds: ONLINE_A,
+        }),
+      ).toEqual({ deviceId: 'device-a', kind: 'device', target: 'local' });
+    });
+
     it('ignores chat mode for hetero agents (they always need a runtime)', () => {
       expect(
         resolveExecutionPlan({
           agencyConfig: cfg({ boundDeviceId: 'device-a', executionTarget: 'device' }),
-          isChatMode: true,
+          chatConfig: { enableAgentMode: false },
           isDesktop: false,
           isHetero: true,
           onlineDeviceIds: ONLINE_A,

--- a/src/helpers/executionTarget.test.ts
+++ b/src/helpers/executionTarget.test.ts
@@ -258,6 +258,56 @@ describe('resolveExecutionPlan', () => {
     });
   });
 
+  describe('isChatMode — no execution environment, even on a local target', () => {
+    it('degrades every device-capable target to none despite an online device', () => {
+      // regression: chat mode only removes local-system from the rule-layer
+      // whitelist; the device track resolved an `activeDeviceId` from the
+      // default/stored `local` target and `buildStepToolDelta` re-injected
+      // local-system. The plan now honours chat mode at the source.
+      for (const executionTarget of ['local', 'device'] as const) {
+        expect(
+          resolveExecutionPlan({
+            agencyConfig: cfg({ boundDeviceId: 'device-a', executionTarget }),
+            isChatMode: true,
+            isDesktop: true,
+            onlineDeviceIds: ONLINE_A,
+          }),
+        ).toEqual({ kind: 'none', target: 'none' });
+      }
+    });
+
+    it('degrades the unset desktop default (local) and sandbox to none', () => {
+      expect(
+        resolveExecutionPlan({
+          agencyConfig: undefined,
+          isChatMode: true,
+          isDesktop: true,
+          onlineDeviceIds: ONLINE_A,
+        }),
+      ).toEqual({ kind: 'none', target: 'none' });
+      expect(
+        resolveExecutionPlan({
+          agencyConfig: cfg({ executionTarget: 'sandbox' }),
+          isChatMode: true,
+          isDesktop: true,
+          onlineDeviceIds: ONLINE_A,
+        }),
+      ).toEqual({ kind: 'none', target: 'none' });
+    });
+
+    it('ignores chat mode for hetero agents (they always need a runtime)', () => {
+      expect(
+        resolveExecutionPlan({
+          agencyConfig: cfg({ boundDeviceId: 'device-a', executionTarget: 'device' }),
+          isChatMode: true,
+          isDesktop: false,
+          isHetero: true,
+          onlineDeviceIds: ONLINE_A,
+        }),
+      ).toEqual({ deviceId: 'device-a', kind: 'device', target: 'device' });
+    });
+  });
+
   describe('canUseDevice=false — hetero degrades to sandbox, never a machine', () => {
     it('sends denied hetero device-capable targets to the sandbox', () => {
       // regression: the hetero early-dispatch used to omit the policy, so an

--- a/src/helpers/executionTarget.ts
+++ b/src/helpers/executionTarget.ts
@@ -129,6 +129,17 @@ export interface ResolveExecutionPlanParams {
    * Defaults to `true` (first-party callers).
    */
   canUseDevice?: boolean;
+  /**
+   * `true` when the run is in chat mode (`chatConfig.toolMode === 'chat'`, or
+   * `enableAgentMode === false`). Chat mode means "no execution environment" —
+   * plain chat. It is orthogonal to `executionTarget`: the UI toggle only
+   * writes `enableAgentMode` and never touches the target, so a stored/default
+   * `local` target would otherwise still resolve a device and `buildStepToolDelta`
+   * would re-inject local-system. Force the whole plan to `none` here so the
+   * single device decision honours chat mode at the source. Ignored for hetero
+   * agents (they always need a runtime). Defaults to `false`.
+   */
+  isChatMode?: boolean;
   isDesktop: boolean;
   isHetero?: boolean;
   /**
@@ -165,11 +176,19 @@ export const resolveExecutionPlan = (params: ResolveExecutionPlanParams): Execut
   const {
     agencyConfig,
     canUseDevice = true,
+    isChatMode = false,
     isDesktop,
     isHetero,
     onlineDeviceIds,
     requestedDeviceId,
   } = params;
+
+  // Chat mode = no execution environment (plain chat). It's orthogonal to the
+  // execution target, so collapse the whole plan to `none` here — this is the
+  // single point that stops a default/stored `local` target from resolving a
+  // device and letting `buildStepToolDelta` re-inject local-system. Hetero
+  // agents always need a runtime, so they never take this path.
+  if (isChatMode && !isHetero) return { kind: 'none', target: 'none' };
 
   const target = resolveExecutionTarget(agencyConfig, { isDesktop, isHetero });
   const wantsDevice = !!requestedDeviceId || target === 'device' || target === 'local';

--- a/src/helpers/executionTarget.ts
+++ b/src/helpers/executionTarget.ts
@@ -1,4 +1,22 @@
-import type { DeviceExecutionTarget, LobeAgentAgencyConfig, RuntimeEnvMode } from '@lobechat/types';
+import type {
+  DeviceExecutionTarget,
+  LobeAgentAgencyConfig,
+  LobeAgentChatConfig,
+  RuntimeEnvMode,
+} from '@lobechat/types';
+
+/**
+ * The agent's tool mode — explicit `chatConfig.toolMode` wins; otherwise derive
+ * from `enableAgentMode` (undefined = agent). `chat` = no execution
+ * environment (plain chat); `custom` = toolset is exactly the agent's plugins.
+ *
+ * Single source of truth so client (selectors), server tools engine, and
+ * `resolveExecutionPlan` all agree on what counts as chat mode.
+ */
+export const resolveToolMode = (
+  chatConfig: LobeAgentChatConfig | undefined,
+): 'agent' | 'chat' | 'custom' =>
+  chatConfig?.toolMode ?? (chatConfig?.enableAgentMode === false ? 'chat' : 'agent');
 
 export interface ResolveExecutionTargetOptions {
   /**
@@ -130,16 +148,15 @@ export interface ResolveExecutionPlanParams {
    */
   canUseDevice?: boolean;
   /**
-   * `true` when the run is in chat mode (`chatConfig.toolMode === 'chat'`, or
-   * `enableAgentMode === false`). Chat mode means "no execution environment" —
-   * plain chat. It is orthogonal to `executionTarget`: the UI toggle only
-   * writes `enableAgentMode` and never touches the target, so a stored/default
-   * `local` target would otherwise still resolve a device and `buildStepToolDelta`
-   * would re-inject local-system. Force the whole plan to `none` here so the
-   * single device decision honours chat mode at the source. Ignored for hetero
-   * agents (they always need a runtime). Defaults to `false`.
+   * The agent's chat config. Chat mode (`resolveToolMode` → `chat`) means "no
+   * execution environment" — plain chat. It is orthogonal to `executionTarget`:
+   * the UI toggle only writes `enableAgentMode` and never touches the target, so
+   * a stored/default `local` target would otherwise still resolve a device and
+   * `buildStepToolDelta` would re-inject local-system. The plan honours chat
+   * mode at the source (degraded to `none`) — except for hetero agents, which
+   * always need a runtime.
    */
-  isChatMode?: boolean;
+  chatConfig?: LobeAgentChatConfig;
   isDesktop: boolean;
   isHetero?: boolean;
   /**
@@ -176,7 +193,7 @@ export const resolveExecutionPlan = (params: ResolveExecutionPlanParams): Execut
   const {
     agencyConfig,
     canUseDevice = true,
-    isChatMode = false,
+    chatConfig,
     isDesktop,
     isHetero,
     onlineDeviceIds,
@@ -188,7 +205,7 @@ export const resolveExecutionPlan = (params: ResolveExecutionPlanParams): Execut
   // single point that stops a default/stored `local` target from resolving a
   // device and letting `buildStepToolDelta` re-inject local-system. Hetero
   // agents always need a runtime, so they never take this path.
-  if (isChatMode && !isHetero) return { kind: 'none', target: 'none' };
+  if (resolveToolMode(chatConfig) === 'chat' && !isHetero) return { kind: 'none', target: 'none' };
 
   const target = resolveExecutionTarget(agencyConfig, { isDesktop, isHetero });
   const wantsDevice = !!requestedDeviceId || target === 'device' || target === 'local';

--- a/src/store/agent/selectors/chatConfigByIdSelectors.ts
+++ b/src/store/agent/selectors/chatConfigByIdSelectors.ts
@@ -5,7 +5,7 @@ import {
 } from '@lobechat/const';
 import { type LobeAgentChatConfig, type RuntimeEnvMode } from '@lobechat/types';
 
-import { resolveRuntimeMode } from '@/helpers/executionTarget';
+import { resolveRuntimeMode, resolveToolMode } from '@/helpers/executionTarget';
 import { type AgentStoreState } from '@/store/agent/initialState';
 
 import { agentSelectors } from './selectors';
@@ -82,16 +82,13 @@ const getSkillActivateModeById =
     getChatConfigById(agentId)(s).skillActivateMode ?? 'auto';
 
 /**
- * Resolve the agent's tool mode — explicit `toolMode` wins; otherwise derive
- * from `enableAgentMode` (undefined = agent). Mirrors the server tools engine
- * so client and server agree on chat mode.
+ * Resolve the agent's tool mode via the shared `resolveToolMode` helper, so
+ * client and server agree on what counts as chat mode.
  */
 const getToolModeById =
   (agentId: string) =>
-  (s: AgentStoreState): 'agent' | 'chat' | 'custom' => {
-    const chatConfig = getChatConfigById(agentId)(s);
-    return chatConfig.toolMode ?? (chatConfig.enableAgentMode === false ? 'chat' : 'agent');
-  };
+  (s: AgentStoreState): 'agent' | 'chat' | 'custom' =>
+    resolveToolMode(getChatConfigById(agentId)(s));
 
 const isChatModeById = (agentId: string) => (s: AgentStoreState) =>
   getToolModeById(agentId)(s) === 'chat';

--- a/src/store/agent/selectors/chatConfigByIdSelectors.ts
+++ b/src/store/agent/selectors/chatConfigByIdSelectors.ts
@@ -81,6 +81,21 @@ const getSkillActivateModeById =
   (s: AgentStoreState): 'auto' | 'manual' =>
     getChatConfigById(agentId)(s).skillActivateMode ?? 'auto';
 
+/**
+ * Resolve the agent's tool mode — explicit `toolMode` wins; otherwise derive
+ * from `enableAgentMode` (undefined = agent). Mirrors the server tools engine
+ * so client and server agree on chat mode.
+ */
+const getToolModeById =
+  (agentId: string) =>
+  (s: AgentStoreState): 'agent' | 'chat' | 'custom' => {
+    const chatConfig = getChatConfigById(agentId)(s);
+    return chatConfig.toolMode ?? (chatConfig.enableAgentMode === false ? 'chat' : 'agent');
+  };
+
+const isChatModeById = (agentId: string) => (s: AgentStoreState) =>
+  getToolModeById(agentId)(s) === 'chat';
+
 export const chatConfigByIdSelectors = {
   getChatConfigById,
   getEnableHistoryCountById,
@@ -92,7 +107,9 @@ export const chatConfigByIdSelectors = {
   getSearchFCModelById,
   getSearchModeById,
   getSkillActivateModeById,
+  getToolModeById,
   getUseModelBuiltinSearchById,
+  isChatModeById,
   isEnableSearchById,
   isLocalSystemEnabledById,
   isMemoryToolEnabledById,

--- a/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gateway.test.ts
@@ -51,8 +51,9 @@ vi.mock('@/store/user/selectors', () => ({
 // device resolution, no electron IPC).
 const mockEnv = vi.hoisted(() => ({ isDesktop: false }));
 const mockGateway = vi.hoisted(() => ({ getDeviceInfo: vi.fn() }));
-// Effective runtime mode === 'local' (what isLocalSystemEnabledById returns).
-const mockRuntime = vi.hoisted(() => ({ isLocal: false }));
+// Effective runtime mode === 'local' (what isLocalSystemEnabledById returns)
+// and chat mode (what isChatModeById returns).
+const mockRuntime = vi.hoisted(() => ({ isChatMode: false, isLocal: false }));
 const mockAgentStore = vi.hoisted(() => ({
   state: { activeAgentId: undefined, agentMap: {} } as any,
 }));
@@ -78,6 +79,7 @@ vi.mock('@/store/agent/selectors', () => ({
   chatConfigByIdSelectors: {
     getChatConfigById: (agentId: string) => (state: any) =>
       state.agentMap?.[agentId]?.chatConfig ?? {},
+    isChatModeById: () => () => mockRuntime.isChatMode,
     isLocalSystemEnabledById: () => () => mockRuntime.isLocal,
   },
 }));
@@ -884,6 +886,7 @@ describe('GatewayActionImpl', () => {
       afterEach(() => {
         mockEnv.isDesktop = false;
         mockRuntime.isLocal = false;
+        mockRuntime.isChatMode = false;
         mockGateway.getDeviceInfo.mockReset();
       });
 
@@ -914,6 +917,23 @@ describe('GatewayActionImpl', () => {
       it('does not resolve a deviceId when a non-local runtime mode is selected', async () => {
         mockEnv.isDesktop = true;
         mockRuntime.isLocal = false;
+
+        await send();
+
+        expect(mockGateway.getDeviceInfo).not.toHaveBeenCalled();
+        expect(aiAgentService.execAgentTask).toHaveBeenCalledWith(
+          expect.objectContaining({ deviceId: undefined }),
+          expect.anything(),
+        );
+      });
+
+      // Regression guard (chat mode → no execution environment): chat mode must
+      // not resolve this machine's deviceId even on a local target, otherwise
+      // the server presets activeDeviceId and re-injects lobe-local-system.
+      it('does not resolve a deviceId in chat mode, even when local mode is set', async () => {
+        mockEnv.isDesktop = true;
+        mockRuntime.isLocal = true;
+        mockRuntime.isChatMode = true;
 
         await send();
 

--- a/src/store/chat/slices/aiChat/actions/gateway.ts
+++ b/src/store/chat/slices/aiChat/actions/gateway.ts
@@ -42,7 +42,14 @@ import { createGatewayEventHandler } from './gatewayEventHandler';
 const resolveLocalDeviceId = async (agentId?: string): Promise<string | undefined> => {
   if (!isDesktop || !agentId) return undefined;
 
-  const isLocal = chatConfigByIdSelectors.isLocalSystemEnabledById(agentId)(getAgentStoreState());
+  const agentState = getAgentStoreState();
+  // Chat mode means "no execution environment" — never resolve a device, even
+  // when the target is `local`. The server enforces this too (it auto-activates
+  // a single online device), but skipping the deviceId round-trip here avoids
+  // sending an id the server would only discard.
+  if (chatConfigByIdSelectors.isChatModeById(agentId)(agentState)) return undefined;
+
+  const isLocal = chatConfigByIdSelectors.isLocalSystemEnabledById(agentId)(agentState);
   if (!isLocal) return undefined;
 
   try {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No matching GitHub issue. -->

#### 🔀 Description of Change

**Bug:** In chat mode, the agent still auto-enabled the `local-system` tool, even though chat mode is supposed to mean "no execution environment".

**Root cause:** Chat mode and the device track are orthogonal:

1. The **Chat / Agent** UI toggle only writes `chatConfig.enableAgentMode` — it never touches `agencyConfig.executionTarget`.
2. With `executionTarget` unset, it defaults to `local` on gateway deployments. `resolveExecutionPlan` then resolves an `activeDeviceId` (auto-activating a single online device).
3. The tool-engine rule layer (`chatModeRules`) *correctly* excludes `local-system` — but device injection is a **separate track**: `buildStepToolDelta` re-injects `LocalSystemManifest` whenever `activeDeviceId` is set, with no chat-mode check. So the tool gets smuggled back in through the back door.

**Fix (single authoritative point, server-side):**

- `resolveExecutionPlan` now accepts `isChatMode` and degrades the whole plan to `{ kind: 'none', target: 'none' }`. Degrading the **target** (not just the kind) is essential — `aiAgent` also injects `local-system` via the `target === 'local'` path. With no `activeDeviceId`, `buildStepToolDelta` no longer injects anything.
- `aiAgent/index.ts` derives `isChatMode` using the same canonical rule as the tools engine (`toolMode` wins; else `enableAgentMode === false`) and passes it in.
- Client `resolveLocalDeviceId` skips the deviceId round-trip in chat mode (new `chatConfigByIdSelectors.isChatModeById` selector). The server stays authoritative — it auto-activates a single online device regardless of what the client sends — so this is an optimization, not the real gate.

Hetero agents (Claude Code / Codex) always need a runtime, so they bypass the chat-mode short-circuit.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`resolveExecutionPlan` unit tests cover the new chat-mode degradation (every device-capable target → `none`, unset desktop default + sandbox → `none`, hetero unaffected). Selector tests and `bun run type-check` pass.

#### 📝 Additional Information

Pure logic/gating fix — no migrations, no UI, no breaking changes.