### PR TITLE
🐛 fix(agent-runtime): load snapshot store via static import, not dynamic require

### DIFF
--- a/apps/server/src/services/agentRuntime/__tests__/snapshotStore.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/snapshotStore.test.ts
@@ -3,69 +3,78 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createDefaultSnapshotStore, shouldUseAgentS3Tracing } from '../snapshotStore';
 
-const s3SnapshotStoreMock = vi.fn(() => ({ kind: 's3' }));
-const fileSnapshotStoreMock = vi.fn(() => ({ kind: 'file' }));
+const s3Store = { kind: 's3' } as any;
+const fileStore = { kind: 'file' } as any;
+const createS3 = vi.fn(() => s3Store);
+const createFile = vi.fn(() => fileStore);
+const factories = { createFile, createS3 };
 
 const setEnv = (nodeEnv: string, agentS3Tracing?: string) => {
   vi.stubEnv('NODE_ENV', nodeEnv);
   vi.stubEnv('ENABLE_AGENT_S3_TRACING', agentS3Tracing);
 };
 
-const loadModule = vi.fn((moduleName: string) => {
-  if (moduleName === '@/server/modules/AgentTracing') {
-    return { S3SnapshotStore: s3SnapshotStoreMock };
-  }
-
-  if (moduleName === '@lobechat/agent-tracing') {
-    return { FileSnapshotStore: fileSnapshotStoreMock };
-  }
-
-  throw new Error(`Unexpected module: ${moduleName}`);
-});
-
 describe('agent runtime snapshot store defaults', () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('enables S3 tracing by default in production when env is unset', () => {
     setEnv('production');
 
     expect(shouldUseAgentS3Tracing()).toBe(true);
-    expect(createDefaultSnapshotStore(loadModule)).toEqual({ kind: 's3' });
-    expect(loadModule).toHaveBeenCalledWith('@/server/modules/AgentTracing');
-    expect(s3SnapshotStoreMock).toHaveBeenCalledTimes(1);
-    expect(fileSnapshotStoreMock).not.toHaveBeenCalled();
+    expect(createDefaultSnapshotStore(factories)).toBe(s3Store);
+    expect(createS3).toHaveBeenCalledTimes(1);
+    expect(createFile).not.toHaveBeenCalled();
   });
 
   it('uses the local file snapshot store in development when env is unset', () => {
     setEnv('development');
 
     expect(shouldUseAgentS3Tracing()).toBe(false);
-    expect(createDefaultSnapshotStore(loadModule)).toEqual({ kind: 'file' });
-    expect(loadModule).toHaveBeenCalledWith('@lobechat/agent-tracing');
-    expect(s3SnapshotStoreMock).not.toHaveBeenCalled();
-    expect(fileSnapshotStoreMock).toHaveBeenCalledTimes(1);
+    expect(createDefaultSnapshotStore(factories)).toBe(fileStore);
+    expect(createS3).not.toHaveBeenCalled();
+    expect(createFile).toHaveBeenCalledTimes(1);
   });
 
   it('lets ENABLE_AGENT_S3_TRACING=1 force S3 tracing outside production', () => {
     setEnv('development', '1');
 
     expect(shouldUseAgentS3Tracing()).toBe(true);
-    expect(createDefaultSnapshotStore(loadModule)).toEqual({ kind: 's3' });
-    expect(loadModule).toHaveBeenCalledWith('@/server/modules/AgentTracing');
-    expect(s3SnapshotStoreMock).toHaveBeenCalledTimes(1);
-    expect(fileSnapshotStoreMock).not.toHaveBeenCalled();
+    expect(createDefaultSnapshotStore(factories)).toBe(s3Store);
+    expect(createS3).toHaveBeenCalledTimes(1);
+    expect(createFile).not.toHaveBeenCalled();
   });
 
   it('lets an explicit ENABLE_AGENT_S3_TRACING value disable the production default', () => {
     setEnv('production', '0');
 
     expect(shouldUseAgentS3Tracing()).toBe(false);
-    expect(createDefaultSnapshotStore(loadModule)).toBeNull();
-    expect(loadModule).not.toHaveBeenCalled();
-    expect(s3SnapshotStoreMock).not.toHaveBeenCalled();
-    expect(fileSnapshotStoreMock).not.toHaveBeenCalled();
+    expect(createDefaultSnapshotStore(factories)).toBeNull();
+    expect(createS3).not.toHaveBeenCalled();
+    expect(createFile).not.toHaveBeenCalled();
+  });
+
+  it('degrades to null (never throws) when S3 store construction fails', () => {
+    setEnv('production');
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const boom = vi.fn(() => {
+      throw new Error('missing S3 creds');
+    });
+
+    expect(createDefaultSnapshotStore({ createS3: boom })).toBeNull();
+    expect(boom).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('constructs a real store via the default (non-injected) path', () => {
+    // Guards the regression: the default path must build a store with NO dynamic
+    // require. In dev that is the statically-imported FileSnapshotStore
+    // (S3 needs creds, so dev is the safe env to assert a non-null default).
+    setEnv('development');
+
+    expect(createDefaultSnapshotStore()).not.toBeNull();
   });
 });

--- a/apps/server/src/services/agentRuntime/snapshotStore.ts
+++ b/apps/server/src/services/agentRuntime/snapshotStore.ts
@@ -1,19 +1,8 @@
-import type { ISnapshotStore } from '@lobechat/agent-tracing';
+import { FileSnapshotStore, type ISnapshotStore } from '@lobechat/agent-tracing';
+
+import { S3SnapshotStore } from '@/server/modules/AgentTracing';
 
 const ENABLE_AGENT_S3_TRACING_VALUE = '1';
-
-type SnapshotStoreConstructor = new () => ISnapshotStore;
-type SnapshotStoreModuleLoader = (moduleName: string) => unknown;
-
-interface FileSnapshotStoreModule {
-  FileSnapshotStore: SnapshotStoreConstructor;
-}
-
-interface S3SnapshotStoreModule {
-  S3SnapshotStore: SnapshotStoreConstructor;
-}
-
-const nodeRequire: SnapshotStoreModuleLoader = (moduleName) => require(moduleName);
 
 export const shouldUseAgentS3Tracing = () => {
   const explicitValue = process.env.ENABLE_AGENT_S3_TRACING;
@@ -24,6 +13,18 @@ export const shouldUseAgentS3Tracing = () => {
 };
 
 /**
+ * Constructor injection for tests. The defaults are the statically-imported
+ * stores — never load them via a dynamic `require(moduleName)`: the module name
+ * goes through an indirection the bundler can't statically analyze, so the `@/`
+ * build-time alias fails to resolve at runtime and the store silently becomes
+ * `null` (this once disabled ALL production snapshots).
+ */
+export interface SnapshotStoreFactories {
+  createFile?: () => ISnapshotStore;
+  createS3?: () => ISnapshotStore;
+}
+
+/**
  * Create default snapshot store based on environment.
  * - ENABLE_AGENT_S3_TRACING=1 -> S3SnapshotStore
  * - NODE_ENV=production with ENABLE_AGENT_S3_TRACING unset -> S3SnapshotStore
@@ -31,28 +32,22 @@ export const shouldUseAgentS3Tracing = () => {
  * - Otherwise -> null (no tracing)
  */
 export const createDefaultSnapshotStore = (
-  loadModule: SnapshotStoreModuleLoader = nodeRequire,
+  factories: SnapshotStoreFactories = {},
 ): ISnapshotStore | null => {
   if (shouldUseAgentS3Tracing()) {
     try {
-      const { S3SnapshotStore } = loadModule(
-        '@/server/modules/AgentTracing',
-      ) as S3SnapshotStoreModule;
-      return new S3SnapshotStore();
-    } catch {
-      // S3SnapshotStore not available
+      return (factories.createS3 ?? (() => new S3SnapshotStore()))();
+    } catch (e) {
+      // Tracing is best-effort — a misconfigured S3 (e.g. missing creds) must
+      // never break the agent run. But surface it loudly: a swallowed failure
+      // here previously disabled all production snapshots without a trace.
+      console.error('[snapshotStore] failed to create S3SnapshotStore, tracing disabled:', e);
+      return null;
     }
   }
 
   if (process.env.NODE_ENV === 'development') {
-    try {
-      const { FileSnapshotStore } = loadModule(
-        '@lobechat/agent-tracing',
-      ) as FileSnapshotStoreModule;
-      return new FileSnapshotStore();
-    } catch {
-      // agent-tracing not available
-    }
+    return (factories.createFile ?? (() => new FileSnapshotStore()))();
   }
 
   return null;


### PR DESCRIPTION
## 💻 Change Type

- [x] 🐛 fix

## 🔀 Description

#15841 extracted the snapshot store creation behind a `loadModule(moduleName)` indirection. **The bundler can't statically analyze a `require()` whose argument is passed through that indirection**, so the build-time alias `@/server/modules/AgentTracing` fails to resolve at runtime (`MODULE_NOT_FOUND`), the `catch {}` swallows it, and `createDefaultSnapshotStore` returns `null`.

**Impact (production P0):** since **v2.2.5**, trace snapshots for **every** production operation have not been uploaded. `CompletionLifecycle` still writes `trace_s3_key` to the DB, but no partial/final object ever lands in S3 — `agent-tracing inspect <opId>` 404s on every operation. The dev path requires the real package name `@lobechat/agent-tracing` (resolvable by Node at runtime), so only production breaks, making it hard to spot. The existing tests always inject a mock `loadModule`, so they never exercise the real load path and CI stayed green.

### Fix

- statically `import` `S3SnapshotStore` / `FileSnapshotStore` and `new` them (the backend has no need for dynamic loading)
- keep testability via injected constructor factories, not an injected module loader
- surface S3 construction failures with `console.error` instead of a silent `catch {}` (still best-effort: degrades to null, never breaks the agent run)
- add a test that exercises the real (non-injected) default path to lock the regression out

### Verification

- `snapshotStore.test.ts` 6/6 passing (including the new regression guard)
- `tsc --noEmit` (apps/server) clean

> After deploy, confirm production `ENABLE_AGENT_S3_TRACING` is not explicitly set to a non-`1` value. Operations that ran before the fix have no snapshot — only new operations recover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)