### PR TITLE
🐛 fix(agent-documents): present documents as clickable links, centralize result strings

### DIFF
--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentDocuments.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentDocuments.test.ts
@@ -283,7 +283,9 @@ describe('AgentDocumentsExecutionRuntime.createDocument', () => {
     expect(result.content).toContain(
       'https://app.example.com/agent/agent-1/docs/docs_document-row-id',
     );
-    expect(result.content).toContain('Use id agent-doc-assoc-id for further edits');
+    expect(result.content).toContain('clickable markdown link');
+    expect(result.content).toContain('Internal id agent-doc-assoc-id');
+    expect(result.content).toContain('never show it to the user');
   });
 
   it('refuses to run without agentId', async () => {

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentDocuments.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentDocuments.test.ts
@@ -220,7 +220,9 @@ describe('agentDocumentsRuntime auto-pin to task', () => {
       { agentId: 'agent-1' },
     );
 
-    expect(result.content).toBe('Created document "Daily Brief" (agent-doc-assoc-id).');
+    expect(result.content).toBe(
+      'Created document "Daily Brief" (internal id: agent-doc-assoc-id).',
+    );
   });
 });
 

--- a/packages/builtin-tool-agent-documents/package.json
+++ b/packages/builtin-tool-agent-documents/package.json
@@ -9,6 +9,9 @@
     "./executionRuntime": "./src/ExecutionRuntime/index.ts"
   },
   "main": "./src/index.ts",
+  "dependencies": {
+    "@lobechat/prompts": "workspace:*"
+  },
   "devDependencies": {
     "@lobechat/types": "workspace:*"
   },

--- a/packages/builtin-tool-agent-documents/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-agent-documents/src/ExecutionRuntime/index.ts
@@ -1,3 +1,12 @@
+import {
+  formatCopyDocumentResult,
+  formatCreateDocumentResult,
+  formatModifyDocumentResult,
+  formatRemoveDocumentResult,
+  formatRenameDocumentResult,
+  formatReplaceDocumentResult,
+  formatUpdateLoadRuleResult,
+} from '@lobechat/prompts';
 import type { BuiltinServerRuntimeOutput } from '@lobechat/types';
 
 import type {
@@ -155,6 +164,17 @@ export class AgentDocumentsExecutionRuntime {
     return context.agentId;
   }
 
+  /**
+   * Resolve a shareable document url so every document-referencing result can
+   * hand the user a clickable link instead of a raw internal id. Returns
+   * undefined when no url builder is configured or the `documents` row id is
+   * unknown — callers fall back to the id-only result wording in that case.
+   */
+  private buildDocumentUrl(agentId: string, documentId?: string): MaybePromise<string | undefined> {
+    if (!documentId) return undefined;
+    return this.options.getDocumentUrl?.({ agentId, documentId });
+  }
+
   private getCurrentDocumentId(context?: AgentDocumentOperationContext) {
     if (context?.scope !== 'page') return;
     return context.currentDocumentId ?? undefined;
@@ -252,12 +272,20 @@ export class AgentDocumentsExecutionRuntime {
       scope === 'currentTopic'
         ? await this.service.listTopicDocuments({ agentId, scope, sourceType, topicId: topicId! })
         : await this.service.listDocuments({ agentId, scope, sourceType });
-    const list = docs.map((d) => ({
-      ...(d.documentId ? { documentId: d.documentId } : {}),
-      filename: d.filename ?? d.title ?? '',
-      id: d.id,
-      title: d.title,
-    }));
+    const list = await Promise.all(
+      docs.map(async (d) => {
+        const url = await this.buildDocumentUrl(agentId, d.documentId);
+        return {
+          ...(d.documentId ? { documentId: d.documentId } : {}),
+          filename: d.filename ?? d.title ?? '',
+          id: d.id,
+          title: d.title,
+          // The clickable link lets the agent reference any listed document to
+          // the user; omitted when no url builder is configured.
+          ...(url ? { url } : {}),
+        };
+      }),
+    );
 
     return {
       content: JSON.stringify(list),
@@ -303,14 +331,10 @@ export class AgentDocumentsExecutionRuntime {
     // The document route is keyed by the `documents` id; the URL lets the agent
     // hand the user a clickable link. `created.id` (the agentDocuments row id)
     // is kept separately because subsequent edit/read/remove calls key off it.
-    const url = created.documentId
-      ? await this.options.getDocumentUrl?.({ agentId, documentId: created.documentId })
-      : undefined;
+    const url = await this.buildDocumentUrl(agentId, created.documentId);
 
     return {
-      content: url
-        ? `Created document "${title}". Share this link with the user as a clickable markdown link: ${url}. (Internal id ${created.id} — for your own further edit/read/remove calls only; never show it to the user.)`
-        : `Created document "${title}" (${created.id}).`,
+      content: formatCreateDocumentResult({ id: created.id, title, url }),
       state: { agentDocumentId: created.id, documentId: created.documentId },
       success: true,
     };
@@ -362,8 +386,14 @@ export class AgentDocumentsExecutionRuntime {
     const doc = await this.service.replaceDocumentContent({ ...args, agentId });
     if (!doc) return { content: `Failed to update document ${args.id}.`, success: false };
 
+    const url = await this.buildDocumentUrl(agentId, doc.documentId ?? existing.documentId);
+
     return {
-      content: `Updated document ${args.id}.`,
+      content: formatReplaceDocumentResult({
+        id: args.id,
+        title: doc.title ?? existing.title,
+        url,
+      }),
       state: { id: args.id, updated: true },
       success: true,
     };
@@ -401,8 +431,15 @@ export class AgentDocumentsExecutionRuntime {
       success: true,
     }));
 
+    const url = await this.buildDocumentUrl(agentId, updated.documentId ?? existing.documentId);
+
     return {
-      content: `Modified document ${args.id}. Applied ${results.length} operation(s).`,
+      content: formatModifyDocumentResult({
+        id: args.id,
+        operationCount: results.length,
+        title: updated.title ?? existing.title,
+        url,
+      }),
       state: {
         id: args.id,
         results,
@@ -429,7 +466,7 @@ export class AgentDocumentsExecutionRuntime {
     if (!deleted) return { content: `Document not found: ${args.id}`, success: false };
 
     return {
-      content: `Removed document ${args.id}.`,
+      content: formatRemoveDocumentResult({ id: args.id }),
       state: { deleted: true, id: args.id },
       success: true,
     };
@@ -457,8 +494,10 @@ export class AgentDocumentsExecutionRuntime {
     const doc = await this.service.renameDocument({ ...args, agentId });
     if (!doc) return { content: `Failed to rename document ${args.id}.`, success: false };
 
+    const url = await this.buildDocumentUrl(agentId, doc.documentId ?? existing.documentId);
+
     return {
-      content: `Renamed document ${args.id} to "${args.newTitle}".`,
+      content: formatRenameDocumentResult({ id: args.id, title: args.newTitle, url }),
       state: { id: args.id, newTitle: args.newTitle, renamed: true },
       success: true,
     };
@@ -479,8 +518,15 @@ export class AgentDocumentsExecutionRuntime {
     const copied = await this.service.copyDocument({ ...args, agentId });
     if (!copied) return { content: `Document not found: ${args.id}`, success: false };
 
+    const url = await this.buildDocumentUrl(agentId, copied.documentId);
+
     return {
-      content: `Copied document ${args.id} to ${copied.id}.`,
+      content: formatCopyDocumentResult({
+        fromId: args.id,
+        id: copied.id,
+        title: copied.title,
+        url,
+      }),
       state: { copiedFromId: args.id, newDocumentId: copied.id },
       success: true,
     };
@@ -501,8 +547,10 @@ export class AgentDocumentsExecutionRuntime {
     const updated = await this.service.updateLoadRule({ ...args, agentId });
     if (!updated) return { content: `Document not found: ${args.id}`, success: false };
 
+    const url = await this.buildDocumentUrl(agentId, updated.documentId);
+
     return {
-      content: `Updated load rule for document ${args.id}.`,
+      content: formatUpdateLoadRuleResult({ id: args.id, title: updated.title, url }),
       state: { applied: true, rule: args.rule },
       success: true,
     };

--- a/packages/builtin-tool-agent-documents/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-agent-documents/src/ExecutionRuntime/index.ts
@@ -309,7 +309,7 @@ export class AgentDocumentsExecutionRuntime {
 
     return {
       content: url
-        ? `Created document "${title}" (${url}). Use id ${created.id} for further edits.`
+        ? `Created document "${title}". Share this link with the user as a clickable markdown link: ${url}. (Internal id ${created.id} — for your own further edit/read/remove calls only; never show it to the user.)`
         : `Created document "${title}" (${created.id}).`,
       state: { agentDocumentId: created.id, documentId: created.documentId },
       success: true,

--- a/packages/builtin-tool-agent-documents/src/systemRole.ts
+++ b/packages/builtin-tool-agent-documents/src/systemRole.ts
@@ -46,7 +46,8 @@ export const systemPrompt = `You have access to an Agent Documents tool for crea
 <response_format>
 When using this tool:
 1. Confirm the action taken.
-2. Include key identifiers (document ID/title) in the response.
-3. Clearly explain if something is not found or if an operation failed.
+2. When a document is created or updated and the tool result includes a document link (URL), always present it to the user as a clickable markdown link, e.g. [document title](url). This is the primary way the user opens the document.
+3. Never expose the internal document ID to the user. It exists only for your own subsequent read/edit/remove calls; surfacing a raw ID to the user is not actionable for them.
+4. Clearly explain if something is not found or if an operation failed.
 </response_format>
 `;

--- a/packages/prompts/src/prompts/agentDocuments/formatResults.test.ts
+++ b/packages/prompts/src/prompts/agentDocuments/formatResults.test.ts
@@ -14,56 +14,42 @@ const URL = 'https://app.example.com/agent/agent-1/docs/docs_row';
 
 describe('agentDocuments formatResults', () => {
   describe('with a url present', () => {
-    it('tells the agent to share a clickable link and hides the internal id', () => {
-      const content = formatCreateDocumentResult({
-        id: 'assoc-id',
-        title: 'Daily Brief',
-        url: URL,
-      });
-
-      expect(content).toContain('Created document "Daily Brief"');
-      expect(content).toContain('clickable markdown link');
-      expect(content).toContain(URL);
-      expect(content).toContain('Internal id assoc-id');
-      expect(content).toContain('never show it to the user');
+    it('formats create with a clickable link and the internal id hidden', () => {
+      expect(formatCreateDocumentResult({ id: 'assoc-id', title: 'Daily Brief', url: URL })).toBe(
+        `Created document "Daily Brief". Share this link with the user as a clickable markdown link: ${URL}. (Internal id assoc-id — for your own further edit/read/remove calls only; never show it to the user.)`,
+      );
     });
 
-    it('covers replace / rename / update-load-rule with the same link policy', () => {
-      for (const content of [
-        formatReplaceDocumentResult({ id: 'a', title: 'T', url: URL }),
-        formatRenameDocumentResult({ id: 'a', title: 'New Title', url: URL }),
-        formatUpdateLoadRuleResult({ id: 'a', title: 'T', url: URL }),
-      ]) {
-        expect(content).toContain('clickable markdown link');
-        expect(content).toContain(URL);
-        expect(content).toContain('never show it to the user');
-      }
+    it('formats replace', () => {
+      expect(formatReplaceDocumentResult({ id: 'a', title: 'T', url: URL })).toBe(
+        `Updated document "T". Share this link with the user as a clickable markdown link: ${URL}. (Internal id a — for your own further edit/read/remove calls only; never show it to the user.)`,
+      );
     });
 
-    it('includes the operation count for modify', () => {
-      const content = formatModifyDocumentResult({
-        id: 'a',
-        operationCount: 3,
-        title: 'T',
-        url: URL,
-      });
-
-      expect(content).toContain('applied 3 operation(s)');
-      expect(content).toContain(URL);
+    it('formats rename with the new title', () => {
+      expect(formatRenameDocumentResult({ id: 'a', title: 'New Title', url: URL })).toBe(
+        `Renamed document to "New Title". Share this link with the user as a clickable markdown link: ${URL}. (Internal id a — for your own further edit/read/remove calls only; never show it to the user.)`,
+      );
     });
 
-    it('names both source and new document for copy', () => {
-      const content = formatCopyDocumentResult({
-        fromId: 'src-id',
-        id: 'new-id',
-        title: 'Copy',
-        url: URL,
-      });
+    it('formats update-load-rule', () => {
+      expect(formatUpdateLoadRuleResult({ id: 'a', title: 'T', url: URL })).toBe(
+        `Updated load rule for document "T". Share this link with the user as a clickable markdown link: ${URL}. (Internal id a — for your own further edit/read/remove calls only; never show it to the user.)`,
+      );
+    });
 
-      expect(content).toContain('Copied document src-id');
-      expect(content).toContain('"Copy"');
-      expect(content).toContain(URL);
-      expect(content).toContain('Internal id new-id');
+    it('formats modify with the operation count', () => {
+      expect(formatModifyDocumentResult({ id: 'a', operationCount: 3, title: 'T', url: URL })).toBe(
+        `Modified document "T", applied 3 operation(s). Share this link with the user as a clickable markdown link: ${URL}. (Internal id a — for your own further edit/read/remove calls only; never show it to the user.)`,
+      );
+    });
+
+    it('formats copy naming both source and new document', () => {
+      expect(
+        formatCopyDocumentResult({ fromId: 'src-id', id: 'new-id', title: 'Copy', url: URL }),
+      ).toBe(
+        `Copied document src-id to a new document "Copy". Share this link with the user as a clickable markdown link: ${URL}. (Internal id new-id — for your own further edit/read/remove calls only; never show it to the user.)`,
+      );
     });
   });
 

--- a/packages/prompts/src/prompts/agentDocuments/formatResults.test.ts
+++ b/packages/prompts/src/prompts/agentDocuments/formatResults.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatCopyDocumentResult,
+  formatCreateDocumentResult,
+  formatModifyDocumentResult,
+  formatRemoveDocumentResult,
+  formatRenameDocumentResult,
+  formatReplaceDocumentResult,
+  formatUpdateLoadRuleResult,
+} from './formatResults';
+
+const URL = 'https://app.example.com/agent/agent-1/docs/docs_row';
+
+describe('agentDocuments formatResults', () => {
+  describe('with a url present', () => {
+    it('tells the agent to share a clickable link and hides the internal id', () => {
+      const content = formatCreateDocumentResult({
+        id: 'assoc-id',
+        title: 'Daily Brief',
+        url: URL,
+      });
+
+      expect(content).toContain('Created document "Daily Brief"');
+      expect(content).toContain('clickable markdown link');
+      expect(content).toContain(URL);
+      expect(content).toContain('Internal id assoc-id');
+      expect(content).toContain('never show it to the user');
+    });
+
+    it('covers replace / rename / update-load-rule with the same link policy', () => {
+      for (const content of [
+        formatReplaceDocumentResult({ id: 'a', title: 'T', url: URL }),
+        formatRenameDocumentResult({ id: 'a', title: 'New Title', url: URL }),
+        formatUpdateLoadRuleResult({ id: 'a', title: 'T', url: URL }),
+      ]) {
+        expect(content).toContain('clickable markdown link');
+        expect(content).toContain(URL);
+        expect(content).toContain('never show it to the user');
+      }
+    });
+
+    it('includes the operation count for modify', () => {
+      const content = formatModifyDocumentResult({
+        id: 'a',
+        operationCount: 3,
+        title: 'T',
+        url: URL,
+      });
+
+      expect(content).toContain('applied 3 operation(s)');
+      expect(content).toContain(URL);
+    });
+
+    it('names both source and new document for copy', () => {
+      const content = formatCopyDocumentResult({
+        fromId: 'src-id',
+        id: 'new-id',
+        title: 'Copy',
+        url: URL,
+      });
+
+      expect(content).toContain('Copied document src-id');
+      expect(content).toContain('"Copy"');
+      expect(content).toContain(URL);
+      expect(content).toContain('Internal id new-id');
+    });
+  });
+
+  describe('without a url', () => {
+    it('falls back to exposing the id as the only handle', () => {
+      expect(formatCreateDocumentResult({ id: 'assoc-id', title: 'Daily Brief' })).toBe(
+        'Created document "Daily Brief" (internal id: assoc-id).',
+      );
+    });
+
+    it('uses a generic label when no title is provided', () => {
+      expect(formatReplaceDocumentResult({ id: 'assoc-id' })).toBe(
+        'Updated document the document (internal id: assoc-id).',
+      );
+    });
+  });
+
+  it('reports removal with only the id (no live url to share)', () => {
+    expect(formatRemoveDocumentResult({ id: 'assoc-id' })).toBe('Removed document assoc-id.');
+  });
+});

--- a/packages/prompts/src/prompts/agentDocuments/formatResults.ts
+++ b/packages/prompts/src/prompts/agentDocuments/formatResults.ts
@@ -1,0 +1,94 @@
+export interface AgentDocumentWriteResultParams {
+  /**
+   * The `agentDocuments` association row id. It is the handle the agent uses for
+   * subsequent read/edit/remove calls — it is NOT actionable for the end user,
+   * so it must never be surfaced to them when a shareable url exists.
+   */
+  id: string;
+  /** Document title, used as the human-facing label. */
+  title?: string;
+  /**
+   * Shareable url that opens the document. When present, the agent is told to
+   * relay it as a clickable markdown link; otherwise the id is the only handle.
+   */
+  url?: string;
+}
+
+const titleLabel = (title?: string): string => (title ? `"${title}"` : 'the document');
+
+/**
+ * Render a write-class tool result with a consistent link/id policy.
+ *
+ * `lead` is the action clause without trailing punctuation, e.g.
+ * `Created document "Daily Brief"`. When a url is present the agent must hand
+ * the user a clickable link and keep the internal id to itself; when it is
+ * absent (no url builder configured) the id is the only handle, so it is shown.
+ */
+const formatWriteResult = (lead: string, { id, url }: { id: string; url?: string }): string =>
+  url
+    ? `${lead}. Share this link with the user as a clickable markdown link: ${url}. ` +
+      `(Internal id ${id} — for your own further edit/read/remove calls only; never show it to the user.)`
+    : `${lead} (internal id: ${id}).`;
+
+export const formatCreateDocumentResult = ({
+  id,
+  title,
+  url,
+}: AgentDocumentWriteResultParams): string =>
+  formatWriteResult(`Created document ${titleLabel(title)}`, { id, url });
+
+export const formatReplaceDocumentResult = ({
+  id,
+  title,
+  url,
+}: AgentDocumentWriteResultParams): string =>
+  formatWriteResult(`Updated document ${titleLabel(title)}`, { id, url });
+
+export interface FormatModifyDocumentResultParams extends AgentDocumentWriteResultParams {
+  operationCount: number;
+}
+
+export const formatModifyDocumentResult = ({
+  id,
+  title,
+  url,
+  operationCount,
+}: FormatModifyDocumentResultParams): string =>
+  formatWriteResult(
+    `Modified document ${titleLabel(title)}, applied ${operationCount} operation(s)`,
+    { id, url },
+  );
+
+export const formatRenameDocumentResult = ({
+  id,
+  title,
+  url,
+}: AgentDocumentWriteResultParams): string =>
+  formatWriteResult(`Renamed document to ${titleLabel(title)}`, { id, url });
+
+export interface FormatCopyDocumentResultParams extends AgentDocumentWriteResultParams {
+  /** The source document's id that was copied from. */
+  fromId: string;
+}
+
+export const formatCopyDocumentResult = ({
+  id,
+  title,
+  url,
+  fromId,
+}: FormatCopyDocumentResultParams): string =>
+  formatWriteResult(`Copied document ${fromId} to a new document ${titleLabel(title)}`, {
+    id,
+    url,
+  });
+
+export const formatUpdateLoadRuleResult = ({
+  id,
+  title,
+  url,
+}: AgentDocumentWriteResultParams): string =>
+  formatWriteResult(`Updated load rule for document ${titleLabel(title)}`, { id, url });
+
+/** A removed document has no live url to share, so only the id is reported. */
+export const formatRemoveDocumentResult = ({ id }: { id: string }): string =>
+  `Removed document ${id}.`;

--- a/packages/prompts/src/prompts/agentDocuments/index.ts
+++ b/packages/prompts/src/prompts/agentDocuments/index.ts
@@ -1,0 +1,1 @@
+export * from './formatResults';

--- a/packages/prompts/src/prompts/index.ts
+++ b/packages/prompts/src/prompts/index.ts
@@ -1,4 +1,5 @@
 export * from './agentBuilder';
+export * from './agentDocuments';
 export * from './agentGroup';
 export * from './agentSignal';
 export * from './agentSkillManager';


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] ♻️ refactor

#### 🔀 Description of Change

When `createDocument` succeeded, the agent told the user the **internal document id** (e.g. `保存在文档 ID 3db0caa8-…`) instead of a clickable link. A raw id is not actionable for the user — and it didn't even match the `docs_…` segment used in the actual document URL. Diagnosed from operation `op_1781710702792_…_uakGEBF8` (topic `tpc_YDPT4oDmh5TP`): the tool result contained the correct URL, but the model surfaced the id instead.

**Commit 1 — fix the create path & prompt:**
- `systemRole.ts` — the `<response_format>` section literally instructed the model to *"Include key identifiers (document ID/title)"*. Replaced with: present the URL as a markdown link, and never expose the internal id to the user.
- `ExecutionRuntime` — reworded the create result so the URL is unambiguously the user-facing link.

**Commit 2 — generalize & centralize (per review feedback):**
- **Every document-referencing result now carries the URL**, not just create: `replace` / `modify` / `rename` / `copy` / `updateLoadRule` all build the url via a shared `buildDocumentUrl` helper, and `listDocuments` adds a per-item `url` so the agent can link any existing document. `removeDocument` stays id-only (the document is gone); `readDocument` returns raw content untouched.
- **Result strings moved out of the runtime into `@lobechat/prompts`** (`prompts/agentDocuments/formatResults`), mirroring the existing `fileSystem` formatters, with a single link/id policy in one place instead of hand-written at each return site.

#### 🧪 How to Test

- [x] Added/updated tests

- New `formatResults.test.ts` in `@lobechat/prompts` (7 cases: link-present policy, id-only fallback, modify count, copy source+new).
- Updated `agentDocuments.test.ts` (server runtime) — 22 tests pass.
- `bun run type-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)