### PR TITLE
chore: remove LOBE-10456 marker from google.test.ts regression comment

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/google.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.test.ts
@@ -1556,7 +1556,7 @@ describe('google contextBuilders', () => {
       });
     });
 
-    // Regression for LOBE-10456: the memory tool's `memoryType` enum carried a
+    // Regression: the memory tool's `memoryType` enum carried a trailing `null` sentinel
     // trailing `null` sentinel (`[...MEMORY_TYPES, null]`), which Gemini rejected
     // with `enum[10]: cannot be empty`. The sanitizer must drop the null member.
     it('should strip the null sentinel from a memory-style nullable enum', () => {


### PR DESCRIPTION
## Summary

Daily automatic scan and cleanup of `LOBE-XXX` format code comments (2026-06-18).

## Changes

- **1 file changed**, 1 marker resolved

### Cleaned Marker

| Marker | File | Linear Issue | Resolution |
|--------|------|--------------|------------|
| LOBE-10456 | `packages/model-runtime/src/core/contextBuilders/google.test.ts` | [Gemini tool schema: memoryType enum null sentinel rejected](https://linear.app/lobehub/issue/LOBE-10456) — ✅ Done | Replaced with plain descriptive regression comment explaining the null sentinel enum sanitizer behavior |

### Skipped (Legitimate Data)

`LOBE-10205` appears across multiple test files and fixtures as a **Linear issue ID data value** (not a comment marker), so it was left unchanged:
- `packages/shared-tool-ui/src/Render/Linear/utils.test.ts`
- `packages/builtin-tools/src/codex/mcpToolUtils.test.ts`
- `src/features/DevPanel/RenderGallery/fixtures/` (claude-code.ts, codex.ts)

## diff

```diff
-    // Regression for LOBE-10456: the memory tool's `memoryType` enum carried a
+    // Regression: the memory tool's `memoryType` enum carried a trailing `null` sentinel
```