### PR TITLE
✨ feat(database,userMemories): delete persona document when clearing all memories

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/userMemory.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/userMemory.test.ts
@@ -12,6 +12,7 @@ const mockFindById = vi.fn();
 
 const mockCountTopicsForMemoryExtractor = vi.fn();
 const mockDeleteAll = vi.fn();
+const mockDeletePersona = vi.fn();
 const { mockTriggerProcessUsers } = vi.hoisted(() => ({
   mockTriggerProcessUsers: vi.fn(),
 }));
@@ -41,6 +42,12 @@ vi.mock('@/database/models/userMemory', () => ({
     deleteAll: mockDeleteAll,
   })),
   UserMemoryPreferenceModel: vi.fn(() => ({})),
+}));
+
+vi.mock('@/database/models/userMemory/persona', () => ({
+  UserPersonaModel: vi.fn(() => ({
+    deletePersona: mockDeletePersona,
+  })),
 }));
 
 vi.mock('@/envs/app', () => ({
@@ -301,11 +308,13 @@ describe('userMemoryRouter.deleteAll', () => {
 
   it('purges all user memories through the aggregate model', async () => {
     mockDeleteAll.mockResolvedValue(undefined);
+    mockDeletePersona.mockResolvedValue(undefined);
 
     const caller = createCaller();
     const result = await caller.deleteAll();
 
     expect(mockDeleteAll).toHaveBeenCalledOnce();
+    expect(mockDeletePersona).toHaveBeenCalledOnce();
     expect(result).toEqual({ success: true });
   });
 });

--- a/apps/server/src/routers/lambda/userMemory.ts
+++ b/apps/server/src/routers/lambda/userMemory.ts
@@ -104,6 +104,7 @@ export const userMemoryRouter = router({
 
   deleteAll: userMemoryWriteProcedure.mutation(async ({ ctx }) => {
     await ctx.userMemoryModel.deleteAll();
+    await ctx.personaModel.deletePersona();
 
     return { success: true };
   }),

--- a/packages/database/src/models/userMemory/persona.ts
+++ b/packages/database/src/models/userMemory/persona.ts
@@ -68,6 +68,20 @@ export class UserPersonaModel {
     return result;
   };
 
+  deletePersona = async (profile = 'default'): Promise<void> => {
+    const existing = await this.getLatestPersonaDocument(profile);
+    if (!existing) return;
+
+    await this.db
+      .delete(userPersonaDocuments)
+      .where(
+        and(
+          eq(userPersonaDocuments.userId, this.userId),
+          eq(userPersonaDocuments.profile, profile),
+        ),
+      );
+  };
+
   upsertPersona = async (
     params: UpsertUserPersonaParams,
   ): Promise<{ diff?: UserPersonaDocumentHistoriesItem; document: UserPersonaDocument }> => {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- No related issue -->

#### 🔀 Description of Change

Clearing all memories via `deleteAll` does not remove the user's persona document, leaving stale persona content that references deleted memories.

This PR deletes the persona document alongside all memories.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- N/A -->