### PR TITLE
🐛 fix(agent-documents): skill index page title, empty state & context-aware default tab

### DIFF
--- a/.agents/skills/ux/SKILL.md
+++ b/.agents/skills/ux/SKILL.md
@@ -46,6 +46,13 @@ Every data surface has **four** states — design all of them, not just "has dat
       over skeleton rows or a blank body. _(Meaningful)_
 - [ ] **Distinguish the empty variants** — "no data yet" (onboarding CTA) vs
       "no match for filters" (clear-filters affordance) are different screens. _(Certainty)_
+- [ ] **Always-rendered chrome still needs a body empty state.** When a surface
+      keeps its toolbar / header mounted even with no data (so a create / `+`
+      affordance stays reachable), the **body** below it must still render an empty
+      placeholder — persistent chrome is not an excuse to leave the content area
+      blank. ✅ The agent **Documents** tab keeps its new-folder / new-doc toolbar
+      and renders an `Empty` below it when there are no documents — ❌ not a toolbar
+      over dead space. _(Meaningful)_
 - [ ] **Loading state** designed (skeleton / NeuralNetworkLoading), not a flash of
       blank or layout shift. _(Natural)_
 - [ ] **Error state** designed — surface the reason and a retry/back path. _(Meaningful)_
@@ -95,6 +102,33 @@ the selection is restored rather than freshly clicked.
       ✅ The default "LobeAI" (inbox) agent is `virtual` and excluded from the
       sidebar list, so the move picker re-adds it. An empty picker must mean
       "genuinely none", never "we filtered out the only option". _(Meaningful)_
+
+### 1.5 Default view reflects entry intent & data state・Certainty・Meaningful
+
+A surface with multiple tabs / views / panels has a **landing** selection. Don't
+hardcode it to "the first tab" — derive it from **(a) how the user got here** (the
+intent their navigation carried) and **(b) which views actually have data**. A
+static default that lands the user on an empty tab while a sibling holds exactly
+what they came for reads as broken. This pairs with §1.1: the empty state is the
+fallback _within_ a view; this rule is about not landing on that empty view in the
+first place when a better one exists.
+
+- [ ] **Open on the tab the entry implies.** When navigation carries intent — the
+      user clicked a Skill, a file, a record of a specific type — land on the view
+      that shows it, not the static first tab. ✅ Opening a document page by clicking
+      a **skill** lands the right panel on the **Skills** tab; opening a plain
+      document lands on **Documents**. _(Meaningful)_
+- [ ] **Fall back to a populated view when the default would be empty.** If the
+      default tab has no data but a sibling does, default to the populated one so
+      the surface opens on content. ✅ An agent with only skills (no documents)
+      opens the panel on **Skills** instead of an empty **Documents** tab. _(Certainty)_
+- [ ] **Decide from resolved state, not mid-load.** Compute the default once the
+      data has loaded — choosing off an empty _in-flight_ list flips the tab as data
+      arrives. Hold the static default while loading, switch on resolved-empty. _(Certainty)_
+- [ ] **A manual choice wins and sticks.** Once the user picks a tab, stop
+      auto-selecting — track "user-picked" separately (e.g. a nullable `pickedTab`
+      that overrides the derived default) so later data changes don't yank them off
+      their choice. _(Natural)_
 
 ---
 
@@ -250,10 +284,11 @@ The product should grow with the user — deeper power shows up as needs deepen.
 
 **Read — viewing data & lists**
 
-- [ ] Empty / loading / error states are all designed; empty is a real page with a CTA.
+- [ ] Empty / loading / error states are all designed; empty is a real page with a CTA. Always-rendered chrome (toolbar/header) still gets a body empty state.
 - [ ] List designed across 1 → 10k rows (virtual scroll / pagination / batch as needed).
 - [ ] Capped/scrollable/virtualized list scrolls the restored active item into view on mount (`block: 'nearest'`, re-run after async rows mount).
 - [ ] Pickers show all valid targets (default/inbox included); empty = truly none.
+- [ ] Multi-tab/view surface lands on the tab the entry intent implies (and falls back to a populated view, decided from resolved state); a manual pick sticks.
 
 **Edit — entering & changing content**
 

--- a/src/features/AgentDocumentPage/RightPanel/index.tsx
+++ b/src/features/AgentDocumentPage/RightPanel/index.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { AGENT_DOCUMENT_CATEGORY } from '@lobechat/const';
+import { AGENT_DOCUMENT_CATEGORY, AGENT_DOCUMENT_SKILL_CATEGORY } from '@lobechat/const';
 import { ActionIcon, Flexbox } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { PanelRightCloseIcon } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
 
 import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { isDesktop } from '@/const/version';
@@ -18,6 +19,7 @@ import { agentDocumentService, agentDocumentSWRKeys } from '@/services/agentDocu
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, agentSelectors } from '@/store/agent/selectors';
 import { useGlobalStore } from '@/store/global';
+import { standardizeIdentifier } from '@/utils/identifier';
 
 type AgentDocumentPanelTab = 'documents' | 'skills';
 
@@ -71,6 +73,7 @@ const AgentDocumentRightPanel = memo(() => {
   const { t } = useTranslation('chat');
   // null = not yet picked by the user → follow the auto default below.
   const [pickedTab, setPickedTab] = useState<AgentDocumentPanelTab | null>(null);
+  const { docId } = useParams<{ docId?: string }>();
   const toggleRightPanel = useGlobalStore((s) => s.toggleRightPanel);
   const activeAgentId = useAgentStore((s) => s.activeAgentId);
   const isHetero = useAgentStore(agentSelectors.isCurrentAgentHeterogeneous);
@@ -98,8 +101,23 @@ const AgentDocumentRightPanel = memo(() => {
     () => documentList.some((doc) => doc.category === AGENT_DOCUMENT_CATEGORY),
     [documentList],
   );
+  // The open doc itself decides the default tab: a skill entry (SKILL.md or any
+  // file inside a skill bundle) lands on Skills even when normal documents
+  // exist — otherwise the skill-entry flow would open on the wrong tab.
+  const isSkillEntry = useMemo(
+    () =>
+      docId
+        ? documentList.some(
+            (doc) =>
+              standardizeIdentifier(doc.documentId) === docId &&
+              doc.category === AGENT_DOCUMENT_SKILL_CATEGORY,
+          )
+        : false,
+    [docId, documentList],
+  );
   const activeTab: AgentDocumentPanelTab =
-    pickedTab ?? (!isDocumentListLoading && !hasDocuments ? 'skills' : 'documents');
+    pickedTab ??
+    (isSkillEntry || (!isDocumentListLoading && !hasDocuments) ? 'skills' : 'documents');
 
   return (
     <RightPanel stableLayout defaultWidth={360} maxWidth={720} minWidth={300}>

--- a/src/features/PageEditor/store/action.test.ts
+++ b/src/features/PageEditor/store/action.test.ts
@@ -18,6 +18,50 @@ describe('PageEditorStore - rightPanelMode', () => {
   });
 });
 
+describe('PageEditorStore - metaReadOnly', () => {
+  it('ignores setTitle when meta is read-only (manual UI, AI, or extraction)', () => {
+    const store = createStore({ metaReadOnly: true, title: 'Skill name' });
+
+    store.getState().setTitle('SKILL.md');
+
+    // title unchanged and the doc never gets marked dirty → no autosave fires
+    expect(store.getState().title).toBe('Skill name');
+    expect(store.getState().isMetaDirty).toBeFalsy();
+  });
+
+  it('ignores setEmoji when meta is read-only', () => {
+    const store = createStore({ emoji: '🧩', metaReadOnly: true });
+
+    store.getState().setEmoji('📄');
+
+    expect(store.getState().emoji).toBe('🧩');
+    expect(store.getState().isMetaDirty).toBeFalsy();
+  });
+
+  it('does not persist meta for a read-only doc even if marked dirty out-of-band', async () => {
+    const store = createStore({
+      documentId: 'docs_1',
+      isMetaDirty: true,
+      metaReadOnly: true,
+      title: 'SKILL.md',
+    });
+
+    await store.getState().performMetaSave();
+
+    // bails before flipping to 'saving' → never reaches the DocumentService write
+    expect(store.getState().metaSaveStatus).toBe('idle');
+  });
+
+  it('still allows setTitle when meta is editable', () => {
+    const store = createStore({ title: 'Old' });
+
+    store.getState().setTitle('New');
+
+    expect(store.getState().title).toBe('New');
+    expect(store.getState().isMetaDirty).toBe(true);
+  });
+});
+
 describe('PageEditorStore - setLockState', () => {
   it('records the holder owner session alongside the holder id', () => {
     const store = createStore();

--- a/src/features/PageEditor/store/action.ts
+++ b/src/features/PageEditor/store/action.ts
@@ -149,11 +149,15 @@ export const store: (initState?: Partial<State>) => StateCreator<Store> =
           lastSavedTitle,
           lastSavedEmoji,
           isMetaDirty,
+          metaReadOnly,
           onTitleChange,
           onEmojiChange,
         } = get();
 
-        if (!documentId || !isMetaDirty) return;
+        // Backstop: never persist meta for a read-only doc, even if something
+        // marked it dirty out-of-band. A title save also rewrites the filename
+        // (DocumentService.updateDocument), which would desync a managed skill.
+        if (!documentId || !isMetaDirty || metaReadOnly) return;
 
         set({ metaSaveStatus: 'saving' });
 
@@ -189,7 +193,9 @@ export const store: (initState?: Partial<State>) => StateCreator<Store> =
       },
 
       setEmoji: (emoji: string | undefined) => {
-        const { lastSavedEmoji, triggerDebouncedMetaSave } = get();
+        const { lastSavedEmoji, metaReadOnly, triggerDebouncedMetaSave } = get();
+
+        if (metaReadOnly) return;
 
         const isDirty = emoji !== lastSavedEmoji;
         set({ emoji, isMetaDirty: isDirty });
@@ -226,7 +232,12 @@ export const store: (initState?: Partial<State>) => StateCreator<Store> =
       },
 
       setTitle: (title: string) => {
-        const { lastSavedTitle, triggerDebouncedMetaSave } = get();
+        const { lastSavedTitle, metaReadOnly, triggerDebouncedMetaSave } = get();
+
+        // Ignore title writes from every source — manual UI, AI / page-agent
+        // editTitle, title extraction — when the doc's meta is read-only. The
+        // visible name is owned elsewhere (e.g. a skill bundle title).
+        if (metaReadOnly) return;
 
         const isDirty = title !== lastSavedTitle;
         set({ isMetaDirty: isDirty, title });


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] 💄 style
- [x] 📝 docs

#### 🔀 Description of Change

Polish for the standalone agent-document route (`/agent/:aid/docs/:docId`) and its right panel. Three user-reported issues:

**1. Opening a skill showed `SKILL.md` as the title instead of the skill name.**
A skill's index document is stored with `title: 'SKILL.md'` by design (so it renders as the `SKILL.md` file inside the bundle tree). On the standalone page that meant the breadcrumb and the big editable title both read `SKILL.md`. We now resolve the page title to the parent **skill bundle's** title (the real skill name) via `useAgentDocumentItem`.

The title is locked read-only for skill index docs (`metaReadOnly` flag threaded through `PageEditor` → provider → store → `TitleSection`): the visible name is the bundle title, and renames must go through the skill APIs. This avoids two bugs — the generic rename API rejects managed skill docs (`METHOD_NOT_SUPPORTED`), and `PageEditor`'s own meta save would otherwise overwrite the `SKILL.md` filename and desync the bundle.

**2. The Documents tab had no empty state.** It kept its new-folder / new-doc toolbar mounted but left the body blank when there were no documents. Added a centered `Empty` placeholder below the toolbar in `DocumentExplorerTree`.

**3. The right panel always opened on the Documents tab, even when empty.** When the user arrives by clicking a **skill** (or the agent has only skills, no documents), it now defaults to the **Skills** tab — derived from the resolved data state, with a manual pick still taking precedence.

Also hardens `ExplorerTree`'s `normalize` adapter (with tests) and distills the two reusable lessons into the **ux** skill: persistent chrome still needs a body empty state, and a multi-tab surface's landing tab should follow entry intent + data state rather than a hardcoded first tab.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- Open an agent that has skills but no documents → right panel lands on **Skills**.
- Click a skill → opens the `SKILL.md` page; breadcrumb + title show the **skill name**, title is read-only.
- Switch to the **Documents** tab on an agent with no documents → empty placeholder shows, toolbar still usable.
- `bunx vitest run src/features/ExplorerTree/adapter/normalize.test.ts`

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Title showed `SKILL.md`; Documents tab blank when empty | Skill name shown; empty-state placeholder; auto-lands on Skills tab |