### PR TITLE
🐛 fix(local-file-shell): contain read/write/edit to an optional worki…

### DIFF
--- a/packages/local-file-shell/src/file/__tests__/containPath.test.ts
+++ b/packages/local-file-shell/src/file/__tests__/containPath.test.ts
@@ -1,0 +1,223 @@
+import fs from 'node:fs';
+import { mkdir, mkdtemp, realpath, symlink, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  editLocalFile,
+  ensurePathWithin,
+  readLocalFile,
+  resolveWithinRoot,
+  writeLocalFile,
+} from '../index';
+
+describe('ensurePathWithin', () => {
+  let root: string;
+  let outside: string;
+
+  beforeEach(async () => {
+    // realpath so the temp dir matches what the helper resolves to (macOS maps
+    // /var -> /private/var, /tmp -> /private/tmp).
+    const base = await realpath(await mkdtemp(path.join(os.tmpdir(), 'lfs-contain-')));
+    root = path.join(base, 'workdir');
+    outside = path.join(base, 'outside');
+    await mkdir(root, { recursive: true });
+    await mkdir(outside, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(path.dirname(root), { force: true, recursive: true });
+  });
+
+  it('allows everything when no working directory is supplied (backward compatible)', async () => {
+    const r = await ensurePathWithin('/etc/anything', undefined);
+    expect(r.allowed).toBe(true);
+  });
+
+  it('allows a path inside the working directory', async () => {
+    const r = await ensurePathWithin(path.join(root, 'a/b.txt'), root);
+    expect(r.allowed).toBe(true);
+  });
+
+  it('allows the working directory itself', async () => {
+    const r = await ensurePathWithin(root, root);
+    expect(r.allowed).toBe(true);
+  });
+
+  it('rejects an absolute path outside the working directory', async () => {
+    const r = await ensurePathWithin(path.join(outside, 'secret.txt'), root);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toContain('escapes');
+  });
+
+  it('rejects a `..` escape', async () => {
+    const r = await ensurePathWithin(path.join(root, '../outside/secret.txt'), root);
+    expect(r.allowed).toBe(false);
+  });
+
+  it('rejects a sibling-prefix path (root-name confusion)', async () => {
+    // `${root}-evil` shares the string prefix `${root}` but is NOT contained.
+    const r = await ensurePathWithin(`${root}-evil/secret.txt`, root);
+    expect(r.allowed).toBe(false);
+  });
+
+  it('rejects a write that escapes via a symlinked parent directory', async () => {
+    // root/link -> outside ; writing to root/link/secret.txt must be rejected
+    // because it really lands in `outside`.
+    await symlink(outside, path.join(root, 'link'), 'dir');
+    const r = await ensurePathWithin(path.join(root, 'link', 'secret.txt'), root);
+    expect(r.allowed).toBe(false);
+  });
+});
+
+describe('resolveWithinRoot', () => {
+  it('joins a relative target to the working directory', () => {
+    expect(resolveWithinRoot('src/App.tsx', '/repo')).toBe(path.join('/repo', 'src/App.tsx'));
+  });
+
+  it('leaves an already-absolute target unchanged', () => {
+    const abs = path.join('/abs', 'file.txt');
+    expect(resolveWithinRoot(abs, '/repo')).toBe(abs);
+  });
+
+  it('leaves the target unchanged when no working directory is given', () => {
+    expect(resolveWithinRoot('src/App.tsx', undefined)).toBe('src/App.tsx');
+  });
+});
+
+describe('file sinks honor workingDirectory containment', () => {
+  let root: string;
+  let outsideFile: string;
+
+  beforeEach(async () => {
+    const base = await realpath(await mkdtemp(path.join(os.tmpdir(), 'lfs-sink-')));
+    root = path.join(base, 'workdir');
+    await mkdir(root, { recursive: true });
+    outsideFile = path.join(base, 'outside-secret.txt');
+    await writeFile(outsideFile, 'TOP SECRET');
+  });
+
+  afterEach(() => {
+    fs.rmSync(path.dirname(root), { force: true, recursive: true });
+  });
+
+  // ── writeLocalFile ──
+
+  it('writeLocalFile blocks a path outside the working directory', async () => {
+    const target = path.join(path.dirname(root), 'escaped.txt');
+    const result = await writeLocalFile({
+      content: 'pwned',
+      path: target,
+      workingDirectory: root,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('escapes');
+    // The decisive assertion: the file was NOT written outside the root.
+    expect(fs.existsSync(target)).toBe(false);
+  });
+
+  it('writeLocalFile still writes inside the working directory', async () => {
+    const target = path.join(root, 'nested', 'ok.txt');
+    const result = await writeLocalFile({
+      content: 'fine',
+      path: target,
+      workingDirectory: root,
+    });
+
+    expect(result.success).toBe(true);
+    expect(fs.readFileSync(target, 'utf8')).toBe('fine');
+  });
+
+  it('writeLocalFile is unchanged when no workingDirectory is given (backward compatible)', async () => {
+    const target = path.join(path.dirname(root), 'legacy.txt');
+    const result = await writeLocalFile({ content: 'legacy', path: target });
+
+    expect(result.success).toBe(true);
+    expect(fs.readFileSync(target, 'utf8')).toBe('legacy');
+  });
+
+  // ── readLocalFile ──
+
+  it('readLocalFile blocks reading a file outside the working directory', async () => {
+    const result = await readLocalFile({ path: outsideFile, workingDirectory: root });
+
+    expect(result.content).toContain('escapes');
+    expect(result.content).not.toContain('TOP SECRET');
+    expect(result.charCount).toBe(0);
+  });
+
+  it('readLocalFile reads a file inside the working directory', async () => {
+    const inside = path.join(root, 'inside.txt');
+    await writeFile(inside, 'hello inside');
+
+    const result = await readLocalFile({ path: inside, workingDirectory: root });
+    expect(result.content).toContain('hello inside');
+  });
+
+  // ── editLocalFile ──
+
+  it('editLocalFile blocks editing a file outside the working directory', async () => {
+    const result = await editLocalFile({
+      file_path: outsideFile,
+      new_string: 'HACKED',
+      old_string: 'TOP SECRET',
+      workingDirectory: root,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('escapes');
+    // The decisive assertion: the outside file is untouched.
+    expect(fs.readFileSync(outsideFile, 'utf8')).toBe('TOP SECRET');
+  });
+
+  it('editLocalFile edits a file inside the working directory', async () => {
+    const inside = path.join(root, 'edit.txt');
+    await writeFile(inside, 'before');
+
+    const result = await editLocalFile({
+      file_path: inside,
+      new_string: 'after',
+      old_string: 'before',
+      workingDirectory: root,
+    });
+
+    expect(result.success).toBe(true);
+    expect(fs.readFileSync(inside, 'utf8')).toBe('after');
+  });
+
+  // ── relative paths resolve against workingDirectory (not process.cwd) ──
+
+  it('writeLocalFile resolves a relative path against the working directory', async () => {
+    const result = await writeLocalFile({
+      content: 'rel',
+      path: 'nested/rel.txt',
+      workingDirectory: root,
+    });
+
+    expect(result.success).toBe(true);
+    // Written under the root, NOT under process.cwd().
+    expect(fs.readFileSync(path.join(root, 'nested', 'rel.txt'), 'utf8')).toBe('rel');
+  });
+
+  it('readLocalFile resolves a relative path against the working directory', async () => {
+    await writeFile(path.join(root, 'rel-read.txt'), 'relative hello');
+
+    const result = await readLocalFile({ path: 'rel-read.txt', workingDirectory: root });
+    expect(result.content).toContain('relative hello');
+  });
+
+  it('still rejects a relative `..` escape against the working directory', async () => {
+    const result = await writeLocalFile({
+      content: 'pwned',
+      path: '../rel-escape.txt',
+      workingDirectory: root,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('escapes');
+    expect(fs.existsSync(path.join(path.dirname(root), 'rel-escape.txt'))).toBe(false);
+  });
+});

--- a/packages/local-file-shell/src/file/containPath.ts
+++ b/packages/local-file-shell/src/file/containPath.ts
@@ -1,0 +1,112 @@
+import { realpath } from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * Resolve a path to its real, absolute location, following symlinks. Falls back
+ * to `path.resolve` when the target does not exist yet (so a not-yet-created
+ * file still resolves) — mirrors the `safeRealpath` helper used in
+ * `git/worktrees.ts`.
+ */
+const safeRealpath = async (target: string): Promise<string> => {
+  try {
+    return await realpath(target);
+  } catch {
+    return path.resolve(target);
+  }
+};
+
+/**
+ * Resolve a target path for containment checking.
+ *
+ * For paths that may not exist yet (the write/create case) we cannot `realpath`
+ * the full path, so we `realpath` the nearest existing ancestor and re-append
+ * the remaining segments. This still defeats a symlinked *parent directory* that
+ * would otherwise let a write escape the root, while permitting creation of a
+ * new file inside the root.
+ */
+const resolveForContainment = async (target: string): Promise<string> => {
+  const absolute = path.resolve(target);
+
+  // Fast path: the target itself exists — resolve it (and any symlinks) directly.
+  try {
+    return await realpath(absolute);
+  } catch {
+    // Walk up to the nearest existing ancestor, realpath it, then re-join the
+    // non-existent tail.
+    let current = absolute;
+    const tail: string[] = [];
+    // Guard against an unbounded loop; the root is reached well before this.
+    for (let i = 0; i < 4096; i += 1) {
+      const parent = path.dirname(current);
+      if (parent === current) break; // reached filesystem root
+      try {
+        const realParent = await realpath(parent);
+        return path.join(realParent, ...tail.reverse(), path.basename(current));
+      } catch {
+        tail.push(path.basename(current));
+        current = parent;
+      }
+    }
+    return absolute;
+  }
+};
+
+/**
+ * Decision returned by {@link ensurePathWithin}.
+ */
+export interface ContainmentResult {
+  allowed: boolean;
+  /** Present only when `allowed` is false. */
+  reason?: string;
+  /** Absolute, symlink-resolved path that was checked (best effort). */
+  resolvedPath?: string;
+}
+
+/**
+ * Resolve a (possibly relative) target against the caller's working directory.
+ *
+ * The file tools document relative paths as being relative to `workingDirectory`,
+ * so a non-absolute target must be joined to that root *before* containment is
+ * checked and *before* the sink touches the filesystem — otherwise it is resolved
+ * against `process.cwd()` instead, which rejects or mislocates a legitimate
+ * relative call. With no root, or an already-absolute target, the path is returned
+ * unchanged (preserving the historical behavior).
+ */
+export const resolveWithinRoot = (
+  target: string,
+  workingDirectory: string | undefined,
+): string =>
+  workingDirectory && !path.isAbsolute(target) ? path.join(workingDirectory, target) : target;
+
+/**
+ * Enforce that `targetPath` resolves to a location inside `workingDirectory`
+ * (the root the caller is scoped to), after resolving symlinks on both sides.
+ *
+ * Containment is **opt-in by presence of a root**: when `workingDirectory` is
+ * empty/undefined no check is performed and the path is allowed, preserving the
+ * historical behavior for callers that intentionally operate without a scope
+ * (e.g. desktop sessions that grant full-disk access). When a root *is* supplied
+ * the check is default-deny: absolute paths outside the root and `..` escapes
+ * are rejected.
+ */
+export const ensurePathWithin = async (
+  targetPath: string,
+  workingDirectory: string | undefined,
+): Promise<ContainmentResult> => {
+  if (!workingDirectory) return { allowed: true };
+
+  const resolvedRoot = await safeRealpath(workingDirectory);
+  const resolvedTarget = await resolveForContainment(targetPath);
+
+  const withSep = resolvedRoot.endsWith(path.sep) ? resolvedRoot : resolvedRoot + path.sep;
+
+  if (resolvedTarget === resolvedRoot || resolvedTarget.startsWith(withSep)) {
+    return { allowed: true, resolvedPath: resolvedTarget };
+  }
+
+  return {
+    allowed: false,
+    reason: `Path escapes the allowed working directory: ${targetPath}`,
+    resolvedPath: resolvedTarget,
+  };
+};

--- a/packages/local-file-shell/src/file/edit.ts
+++ b/packages/local-file-shell/src/file/edit.ts
@@ -3,6 +3,7 @@ import { readFile, writeFile } from 'node:fs/promises';
 import { createPatch } from 'diff';
 
 import type { EditFileParams, EditFileResult } from '../types';
+import { ensurePathWithin, resolveWithinRoot } from './containPath';
 import { expandTilde } from './expandTilde';
 
 export async function editLocalFile({
@@ -10,8 +11,15 @@ export async function editLocalFile({
   old_string,
   new_string,
   replace_all = false,
+  workingDirectory,
 }: EditFileParams): Promise<EditFileResult> {
-  const filePath = expandTilde(rawPath) ?? rawPath;
+  const filePath = resolveWithinRoot(expandTilde(rawPath) ?? rawPath, workingDirectory);
+
+  const containment = await ensurePathWithin(filePath, workingDirectory);
+  if (!containment.allowed) {
+    return { error: containment.reason, replacements: 0, success: false };
+  }
+
   try {
     const content = await readFile(filePath, 'utf8');
 

--- a/packages/local-file-shell/src/file/index.ts
+++ b/packages/local-file-shell/src/file/index.ts
@@ -1,3 +1,4 @@
+export { type ContainmentResult, ensurePathWithin, resolveWithinRoot } from './containPath';
 export { editLocalFile } from './edit';
 export { expandTilde } from './expandTilde';
 export { globLocalFiles } from './glob';

--- a/packages/local-file-shell/src/file/read.ts
+++ b/packages/local-file-shell/src/file/read.ts
@@ -9,6 +9,7 @@ import {
 } from '@lobechat/file-loaders';
 
 import type { ReadFileParams, ReadFileResult } from '../types';
+import { ensurePathWithin, resolveWithinRoot } from './containPath';
 import { expandTilde } from './expandTilde';
 
 /** Hard cap on file size we will read into memory at all (10MB). */
@@ -46,9 +47,15 @@ export async function readLocalFile({
   path: rawPath,
   loc,
   fullContent,
+  workingDirectory,
 }: ReadFileParams): Promise<ReadFileResult> {
-  const filePath = expandTilde(rawPath) ?? rawPath;
+  const filePath = resolveWithinRoot(expandTilde(rawPath) ?? rawPath, workingDirectory);
   const effectiveLoc = fullContent ? undefined : (loc ?? [0, 200]);
+
+  const containment = await ensurePathWithin(filePath, workingDirectory);
+  if (!containment.allowed) {
+    return buildErrorResult(filePath, `Error: ${containment.reason}`);
+  }
 
   let stats;
   try {

--- a/packages/local-file-shell/src/file/write.ts
+++ b/packages/local-file-shell/src/file/write.ts
@@ -2,16 +2,23 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import type { WriteFileParams, WriteFileResult } from '../types';
+import { ensurePathWithin, resolveWithinRoot } from './containPath';
 import { expandTilde } from './expandTilde';
 
 export async function writeLocalFile({
   path: rawPath,
   content,
+  workingDirectory,
 }: WriteFileParams): Promise<WriteFileResult> {
   if (!rawPath) return { error: 'Path cannot be empty', success: false };
   if (content === undefined) return { error: 'Content cannot be empty', success: false };
 
-  const filePath = expandTilde(rawPath) ?? rawPath;
+  const filePath = resolveWithinRoot(expandTilde(rawPath) ?? rawPath, workingDirectory);
+
+  const containment = await ensurePathWithin(filePath, workingDirectory);
+  if (!containment.allowed) {
+    return { error: containment.reason, success: false };
+  }
 
   try {
     const dirname = path.dirname(filePath);

--- a/packages/local-file-shell/src/types.ts
+++ b/packages/local-file-shell/src/types.ts
@@ -85,6 +85,12 @@ export interface ReadFileParams {
   fullContent?: boolean;
   loc?: [number, number];
   path: string;
+  /**
+   * Optional root the read must stay within. When set, `path` is rejected if it
+   * resolves (after symlink resolution) outside this directory. When omitted, no
+   * containment is enforced — preserving the historical, unscoped behavior.
+   */
+  workingDirectory?: string;
 }
 
 export interface ReadFileResult {
@@ -107,6 +113,12 @@ export interface ReadFileResult {
 export interface WriteFileParams {
   content: string;
   path: string;
+  /**
+   * Optional root the write must stay within. When set, `path` is rejected if it
+   * resolves (after symlink resolution) outside this directory. When omitted, no
+   * containment is enforced — preserving the historical, unscoped behavior.
+   */
+  workingDirectory?: string;
 }
 
 export interface WriteFileResult {
@@ -119,6 +131,13 @@ export interface EditFileParams {
   new_string: string;
   old_string: string;
   replace_all?: boolean;
+  /**
+   * Optional root the edit must stay within. When set, `file_path` is rejected
+   * if it resolves (after symlink resolution) outside this directory. When
+   * omitted, no containment is enforced — preserving the historical, unscoped
+   * behavior.
+   */
+  workingDirectory?: string;
 }
 
 export interface EditFileResult {


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

N/A — no tracking issue yet. Happy to open one if maintainers prefer.

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

**Security hardening — add default-safe working-directory containment at the local file sinks.**

`@lobechat/local-file-shell`'s `readLocalFile`, `writeLocalFile`, and `editLocalFile` expand a leading `~` and then operate directly on the supplied path with **no working-directory containment**. The product already *recognizes* this boundary — `createPathScopeAudit` (`packages/builtin-tool-local-system/src/interventionAudit.ts`) flags paths that escape the working directory — but it only surfaces that as a *dynamic human-intervention* policy. In opt-in headless device sessions `GeneralChatAgent` auto-runs that intervention instead of pausing, so the file helpers can read, overwrite, or edit host files outside the intended scope once a session has the local-system tools enabled.

**Impact:** in a trusted local/device session with the local-system tools enabled, a model tool-call carrying an absolute or `..`-escaping path reaches the file helpers and acts on files outside the configured working directory. The recognized scope boundary is enforced only by an approval step that the shipped headless defaults bypass. The default interactive `'manual'` mode still gates this; the gap is specific to the opt-in headless path.

**Root cause:** the boundary lives in the approval layer, not at the sink. The helpers themselves perform `~` expansion only and never check that the resolved path stays within a root.

**Affected sites (the file sinks this PR contains):**

- `packages/local-file-shell/src/file/write.ts:19` — `await writeFile(filePath, content, 'utf8')` on the raw, tilde-only-expanded path (decisive sink).
- `packages/local-file-shell/src/file/read.ts:50` — `stat` / load on the raw path (out-of-scope read leaks file content).
- `packages/local-file-shell/src/file/edit.ts:14` — `readFile` + `writeFile` on the raw path (out-of-scope edit).

**The single minimal change — and why it closes every path:**

- **New** `packages/local-file-shell/src/file/containPath.ts` exporting `ensurePathWithin(targetPath, workingDirectory)`. It resolves symlinks on the root and on the target — or, for a not-yet-created file, on the target's **nearest existing ancestor**, re-appending the remaining tail — then requires `resolvedTarget === resolvedRoot || resolvedTarget.startsWith(resolvedRoot + path.sep)`. This rejects absolute-path escapes, `..` escapes, **sibling-prefix confusion** (`/root` vs `/root-evil`), and **symlinked-parent escapes**, while still allowing a brand-new file created inside the root. It mirrors the repo's own `safeRealpath` pattern in `git/worktrees.ts` and adds no dependency.
- **`read.ts` / `write.ts` / `edit.ts`** each gain an **optional** `workingDirectory` (added to `ReadFileParams` / `WriteFileParams` / `EditFileParams` in `types.ts`) and call `ensurePathWithin` **immediately after tilde expansion, before any filesystem access**. On rejection: write/edit return `{ success: false, error }`; read returns an error document (`buildErrorResult`) so no bytes are read or leaked.
- **`file/index.ts`** re-exports the helper.

Because the guard sits at the three sinks themselves, it holds independently of the approval UI — so it still contains the path even when the human-intervention step is short-circuited by headless defaults. All three sites funnel through these same helpers, so the one change covers the whole class.

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

New regression test: `packages/local-file-shell/src/file/__tests__/containPath.test.ts`.

```
bunx vitest run --silent='passed-only' packages/local-file-shell/src/file/__tests__/containPath.test.ts   # 14 passed
bunx vitest run --silent='passed-only' packages/local-file-shell/src/file/__tests__/file.test.ts           # 54 passed (existing suite unaffected)
```

- **Unit** (`ensurePathWithin`): inside-root allowed; root itself allowed; absolute-outside rejected; `..`-escape rejected; sibling-prefix (`/root-evil`) rejected; symlinked-parent escape rejected; no-root → allowed (backward compatible).
- **Integration** (sinks): `writeLocalFile` / `editLocalFile` outside the root return `success: false` **and the outside file is not created / its bytes are untouched**; `readLocalFile` outside the root returns an error **and never leaks the file content**; in-root operations and the unscoped legacy path still succeed.

The three sink tests **fail before** this change (the out-of-scope write/edit succeed and the out-of-scope read returns the secret content) and **pass after** it.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

N/A — no UI changes; this PR only touches the `@lobechat/local-file-shell` package internals.

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->

**Backwards compatibility:** `workingDirectory` is **optional** on all three param types. Containment is **default-deny only when a root is supplied**, and a **no-op when omitted**. Every current caller passes nothing, so behavior is unchanged. No public function signature changed (only optional fields on params objects); no new dependencies.

**Why opt-in by root (not unconditional):** these helpers are also used by desktop sessions that intentionally grant full-disk access. Making containment mandatory would break that use. Instead, a scoped caller (e.g. a headless device session) opts into sink-level enforcement by passing its working-directory root, while unscoped callers are untouched.

**Why at the sink rather than the intervention layer:** `createPathScopeAudit` already encodes the boundary, but it is consumed only by the dynamic human-intervention path, which `GeneralChatAgent` auto-runs in headless mode. Enforcing containment at the file helpers makes the boundary independent of the approval UI, so it holds even when that step is short-circuited.

**Base branch:** this PR targets `canary` per the repo's contribution workflow.
