### PR TITLE
🐛 fix(desktop): require re-auth for expired sessions

### DIFF
--- a/src/features/Electron/AuthRequiredModal/index.test.tsx
+++ b/src/features/Electron/AuthRequiredModal/index.test.tsx
@@ -1,0 +1,152 @@
+import { act, fireEvent, render, renderHook, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAuthRequiredModal } from './index';
+
+interface ModalProps {
+  content?: ReactNode;
+  footer?: ReactNode;
+  maskClosable?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  open?: boolean;
+  styles?: {
+    close?: React.CSSProperties;
+  };
+  title?: ReactNode;
+}
+
+const createModalMock = vi.hoisted(() => vi.fn());
+const modalInstance = vi.hoisted(() => ({
+  close: vi.fn(),
+  update: vi.fn(),
+}));
+const translations = vi.hoisted(() => ({ current: {} as Record<string, string> }));
+const electronStore = vi.hoisted(() => ({
+  current: {
+    clearRemoteServerSyncError: vi.fn(),
+    connectRemoteServer: vi.fn(),
+    dataSyncConfig: undefined as { remoteServerUrl?: string; storageMode?: string } | undefined,
+    isConnectionDrawerOpen: false,
+    isInitRemoteServerConfig: true,
+    refreshServerConfig: vi.fn(),
+  },
+}));
+
+vi.mock('@lobechat/electron-client-ipc', () => ({
+  useWatchBroadcast: vi.fn(),
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+  }: {
+    children?: ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button disabled={disabled} type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Icon: () => <span data-testid="modal-icon" />,
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  createModal: (props: ModalProps) => {
+    createModalMock(props);
+
+    return modalInstance;
+  },
+  ModalFooter: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (namespace?: string) => ({
+    t: (key: string) => translations.current[`${namespace}:${key}`] ?? key,
+  }),
+}));
+
+vi.mock('@/store/electron', () => {
+  const useElectronStore = Object.assign(
+    <T,>(selector: (state: typeof electronStore.current) => T): T =>
+      selector(electronStore.current),
+    { getState: () => electronStore.current },
+  );
+
+  return { useElectronStore };
+});
+
+describe('useAuthRequiredModal', () => {
+  beforeEach(() => {
+    createModalMock.mockClear();
+    modalInstance.close.mockClear();
+    modalInstance.update.mockClear();
+    electronStore.current.clearRemoteServerSyncError.mockClear();
+    electronStore.current.connectRemoteServer.mockClear();
+    translations.current = {};
+  });
+
+  it('renders the title from auth translations after the namespace becomes available', () => {
+    const { result } = renderHook(() => useAuthRequiredModal());
+
+    act(() => {
+      result.current.open();
+    });
+
+    const [modalProps] = createModalMock.mock.calls[0] as [ModalProps];
+    translations.current['auth:authModal.title'] = 'Session Expired';
+
+    render(<>{modalProps.title}</>);
+
+    expect(screen.getByText('Session Expired')).toBeInTheDocument();
+    expect(screen.queryByText('authModal.title')).not.toBeInTheDocument();
+  });
+
+  it('keeps the close button available while removing the Later action', () => {
+    translations.current = {
+      'auth:authModal.later': 'Later',
+      'auth:authModal.signIn': 'Sign In Again',
+      'auth:authModal.signingIn': 'Signing in...',
+    };
+    const { result } = renderHook(() => useAuthRequiredModal());
+
+    act(() => {
+      result.current.open();
+    });
+
+    const [modalProps] = createModalMock.mock.calls[0] as [ModalProps];
+
+    expect(modalProps.maskClosable).toBe(false);
+    expect(modalProps.styles?.close).toBeUndefined();
+
+    render(
+      <>
+        {modalProps.content}
+        {modalProps.footer}
+      </>,
+    );
+
+    expect(screen.queryByText('Later')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Sign In Again'));
+
+    expect(electronStore.current.clearRemoteServerSyncError).toHaveBeenCalled();
+    expect(electronStore.current.connectRemoteServer).toHaveBeenCalledWith({
+      remoteServerUrl: undefined,
+      storageMode: 'cloud',
+    });
+
+    act(() => {
+      modalProps.onOpenChange?.(false);
+    });
+
+    act(() => {
+      result.current.open();
+    });
+
+    expect(createModalMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/Electron/AuthRequiredModal/index.tsx
+++ b/src/features/Electron/AuthRequiredModal/index.tsx
@@ -2,12 +2,8 @@
 
 import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
 import { Button, Flexbox, Icon } from '@lobehub/ui';
-import {
-  createModal,
-  type ImperativeModalProps,
-  ModalFooter,
-  type ModalInstance,
-} from '@lobehub/ui/base-ui';
+import type { ImperativeModalProps, ModalInstance } from '@lobehub/ui/base-ui';
+import { createModal, ModalFooter } from '@lobehub/ui/base-ui';
 import debug from 'debug';
 import { AlertCircle, LogIn } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
@@ -75,17 +71,13 @@ AuthRequiredModalContent.displayName = 'AuthRequiredModalContent';
 
 interface FooterProps {
   isSigningIn: boolean;
-  onLater: () => void;
   onSignIn: () => void;
 }
 
-const AuthRequiredFooter = memo<FooterProps>(({ isSigningIn, onLater, onSignIn }) => {
+const AuthRequiredFooter = memo<FooterProps>(({ isSigningIn, onSignIn }) => {
   const { t } = useTranslation('auth');
   return (
     <ModalFooter>
-      <Button disabled={isSigningIn} onClick={onLater}>
-        {t('authModal.later')}
-      </Button>
       <Button icon={<Icon icon={LogIn} />} loading={isSigningIn} type="primary" onClick={onSignIn}>
         {isSigningIn ? t('authModal.signingIn') : t('authModal.signIn')}
       </Button>
@@ -94,8 +86,19 @@ const AuthRequiredFooter = memo<FooterProps>(({ isSigningIn, onLater, onSignIn }
 });
 AuthRequiredFooter.displayName = 'AuthRequiredFooter';
 
-export const useAuthRequiredModal = () => {
+const AuthRequiredModalTitle = memo(() => {
   const { t } = useTranslation('auth');
+
+  return (
+    <Flexbox horizontal align="center" gap={8}>
+      <Icon icon={AlertCircle} />
+      {t('authModal.title')}
+    </Flexbox>
+  );
+});
+AuthRequiredModalTitle.displayName = 'AuthRequiredModalTitle';
+
+export const useAuthRequiredModal = () => {
   const instanceRef = useRef<ModalInstance | null>(null);
 
   const open = useCallback(() => {
@@ -113,11 +116,7 @@ export const useAuthRequiredModal = () => {
     };
 
     const renderFooter = () => (
-      <AuthRequiredFooter
-        isSigningIn={isSigningIn}
-        onLater={handleClose}
-        onSignIn={() => signIn()}
-      />
+      <AuthRequiredFooter isSigningIn={isSigningIn} onSignIn={() => signIn()} />
     );
 
     instanceRef.current = createModal({
@@ -132,21 +131,21 @@ export const useAuthRequiredModal = () => {
             isSigningIn = next;
             instanceRef.current?.update?.({
               footer: renderFooter(),
-              maskClosable: !next,
+              maskClosable: false,
             } as Partial<ImperativeModalProps>);
           }}
         />
       ),
       footer: renderFooter(),
       maskClosable: false,
-      title: (
-        <Flexbox horizontal align="center" gap={8}>
-          <Icon icon={AlertCircle} />
-          {t('authModal.title')}
-        </Flexbox>
-      ),
+      onOpenChange: (nextOpen) => {
+        if (!nextOpen) {
+          instanceRef.current = null;
+        }
+      },
+      title: <AuthRequiredModalTitle />,
     });
-  }, [t]);
+  }, []);
 
   return { open };
 };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No related issue found.

#### 🔀 Description of Change

- Render the desktop auth-required modal title through a translated React component so delayed i18n namespace loading cannot leave the raw translation key on screen.
- Remove the footer `Later` action for expired desktop sessions while keeping the mask non-closable and the standard modal close button available.
- Add regression coverage for delayed title translation and the updated expired-session modal actions.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/features/Electron/AuthRequiredModal/index.test.tsx'
```

#### 📸 Screenshots / Videos

N/A. Covered by focused component regression tests.

#### 📝 Additional Information

Unrelated local task-store changes were left out of this PR.