### PR TITLE
♻️ refactor: drop dead markUserValidAction business slot

### DIFF
--- a/src/business/client/markUserValidAction.ts
+++ b/src/business/client/markUserValidAction.ts
@@ -1,1 +1,0 @@
-export const markUserValidAction = async () => {};

--- a/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationLifecycle.ts
@@ -23,7 +23,6 @@ import { nanoid } from '@lobechat/utils';
 import { TRPCClientError } from '@trpc/client';
 import { t } from 'i18next';
 
-import { markUserValidAction } from '@/business/client/markUserValidAction';
 import { message as antdMessage } from '@/components/AntdStaticMethods';
 import { agentService } from '@/services/agent';
 import { aiChatService } from '@/services/aiChat';
@@ -56,7 +55,6 @@ import {
 import { getElectronStoreState } from '@/store/electron';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
-import { getServerConfigStoreState, serverConfigSelectors } from '@/store/serverConfig';
 import { pageAgentRuntime } from '@/store/tool/slices/builtin/executors/lobe-page-agent';
 import { type StoreSetter } from '@/store/types';
 import { useUserMemoryStore } from '@/store/userMemory';
@@ -972,14 +970,6 @@ export class ConversationLifecycleActionImpl {
     // Clear editor temp state after message created
     if (data) {
       this.#get().updateOperationMetadata(operationId, { inputEditorTempState: null });
-    }
-
-    const serverConfigState = getServerConfigStoreState();
-    const enableBusinessFeatures =
-      !!serverConfigState && serverConfigSelectors.enableBusinessFeatures(serverConfigState);
-
-    if (enableBusinessFeatures) {
-      markUserValidAction();
     }
 
     if (!data) return;

--- a/src/store/image/slices/createImage/action.ts
+++ b/src/store/image/slices/createImage/action.ts
@@ -1,8 +1,6 @@
 import { handleGenerationPromptModerationError } from '@/business/client/handleGenerationPromptModerationError';
 import { handleLobeHubModelDeprecatedError } from '@/business/client/handleLobeHubModelDeprecatedError';
-import { markUserValidAction } from '@/business/client/markUserValidAction';
 import { imageService } from '@/services/image';
-import { getServerConfigStoreState, serverConfigSelectors } from '@/store/serverConfig';
 import { type StoreSetter } from '@/store/types';
 
 import { type ImageStore } from '../../store';
@@ -72,14 +70,6 @@ export class CreateImageActionImpl {
           false,
           'createImage/startCreateImageWithNewTopic',
         );
-      }
-
-      const serverConfigState = getServerConfigStoreState();
-      const enableBusinessFeatures =
-        !!serverConfigState && serverConfigSelectors.enableBusinessFeatures(serverConfigState);
-
-      if (enableBusinessFeatures) {
-        markUserValidAction();
       }
 
       // 5. Create image via service

--- a/src/store/video/slices/createVideo/action.ts
+++ b/src/store/video/slices/createVideo/action.ts
@@ -2,10 +2,8 @@ import { t } from 'i18next';
 
 import { handleGenerationPromptModerationError } from '@/business/client/handleGenerationPromptModerationError';
 import { handleLobeHubModelDeprecatedError } from '@/business/client/handleLobeHubModelDeprecatedError';
-import { markUserValidAction } from '@/business/client/markUserValidAction';
 import { message } from '@/components/AntdStaticMethods';
 import { videoService } from '@/services/video';
-import { getServerConfigStoreState, serverConfigSelectors } from '@/store/serverConfig';
 import { type StoreSetter } from '@/store/types';
 
 import { type VideoStore } from '../../store';
@@ -92,14 +90,6 @@ export class CreateVideoActionImpl {
           false,
           'createVideo/startCreateVideoWithNewTopic',
         );
-      }
-
-      const serverConfigState = getServerConfigStoreState();
-      const enableBusinessFeatures =
-        !!serverConfigState && serverConfigSelectors.enableBusinessFeatures(serverConfigState);
-
-      if (enableBusinessFeatures) {
-        markUserValidAction();
       }
 
       // 4. Create video via service


### PR DESCRIPTION
#### 💻 Change Type

- [x] ♻️ refactor

#### 🔗 Related Issue

<!-- Internal cloud follow-up to the referral reward grant flow simplification -->

#### 🔀 Description of Change

The `markUserValidAction` business slot was an open-source no-op meant to be overridden by the cloud repo for referral anti-abuse (only count a referral after the referred user performs a valid action).

The cloud override was removed when the referral reward grant flow was simplified, so the open-source slot became an orphaned no-op that no consumer overrides anymore. This PR removes the dead code:

- Delete the empty slot `src/business/client/markUserValidAction.ts`
- Remove its now-dead call sites in the image, video and chat stores
- Drop the `serverConfig` business-feature gate (`getServerConfigStoreState` / `serverConfigSelectors.enableBusinessFeatures`) that only guarded these calls

Net: 1 file deleted, 30 lines removed across 3 stores. No behavior change — the slot was a no-op in every build.

#### 🧪 How to Test

- [x] No tests needed

No runtime behavior changes; the removed slot was an empty async no-op with no overriding consumer.

#### 📝 Additional Information

Pure dead-code cleanup.