### PR TITLE
🐛 fix(agent): make working-directory clear button actually clear

### DIFF
--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -2138,6 +2138,56 @@ describe('AgentModel', () => {
       expect((result?.params as any)?.temperature).toBeNull();
       expect((result?.params as any)?.topP).toBe(0.5);
     });
+
+    it('should delete a workingDirByDevice entry when value is undefined', async () => {
+      const [agent] = await serverDB
+        .insert(agents)
+        .values({
+          userId,
+          title: 'Cwd Agent',
+          agencyConfig: {
+            executionTarget: 'local',
+            workingDirByDevice: { 'device-a': '/a', 'device-b': '/b' },
+          },
+        } as NewAgent)
+        .returning();
+
+      await agentModel.updateConfig(agent.id, {
+        agencyConfig: { workingDirByDevice: { 'device-a': undefined } } as any,
+      });
+
+      const result = await serverDB.query.agents.findFirst({
+        where: eq(agents.id, agent.id),
+      });
+
+      // device-a cleared; device-b and sibling fields preserved
+      expect((result?.agencyConfig as any)?.workingDirByDevice).toEqual({ 'device-b': '/b' });
+      expect((result?.agencyConfig as any)?.executionTarget).toBe('local');
+    });
+
+    it('should still upsert a workingDirByDevice entry when value is a path', async () => {
+      const [agent] = await serverDB
+        .insert(agents)
+        .values({
+          userId,
+          title: 'Cwd Agent',
+          agencyConfig: { workingDirByDevice: { 'device-a': '/a' } },
+        } as NewAgent)
+        .returning();
+
+      await agentModel.updateConfig(agent.id, {
+        agencyConfig: { workingDirByDevice: { 'device-a': '/a', 'device-b': '/b' } } as any,
+      });
+
+      const result = await serverDB.query.agents.findFirst({
+        where: eq(agents.id, agent.id),
+      });
+
+      expect((result?.agencyConfig as any)?.workingDirByDevice).toEqual({
+        'device-a': '/a',
+        'device-b': '/b',
+      });
+    });
   });
 
   describe('rank', () => {

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -1,6 +1,7 @@
 import { getAgentPersistConfig } from '@lobechat/builtin-agents';
 import { INBOX_SESSION_ID } from '@lobechat/const';
 import type { AgentRankItem } from '@lobechat/types';
+import { pruneWorkingDirByDeviceDeletes } from '@lobechat/types';
 import { and, count, desc, eq, gt, ilike, inArray, isNull, ne, or, sql } from 'drizzle-orm';
 import type { PartialDeep } from 'type-fest';
 
@@ -640,6 +641,10 @@ export class AgentModel {
 
     // Apply the processed parameters
     mergedValue.params = Object.keys(updatedParams).length > 0 ? updatedParams : undefined;
+
+    // agencyConfig.workingDirByDevice: a per-device entry is cleared by sending
+    // `undefined`, which merge() skips — prune those keys so the delete persists.
+    pruneWorkingDirByDeviceDeletes(mergedValue.agencyConfig, data.agencyConfig);
 
     // Final cleanup: ensure no undefined or null values enter the database
     if (mergedValue.params) {

--- a/packages/types/src/agent/agencyConfig.test.ts
+++ b/packages/types/src/agent/agencyConfig.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { pruneWorkingDirByDeviceDeletes } from './agencyConfig';
+
+describe('pruneWorkingDirByDeviceDeletes', () => {
+  it('deletes keys whose patch value is undefined', () => {
+    const merged = { workingDirByDevice: { 'device-a': '/a', 'device-b': '/b' } };
+    pruneWorkingDirByDeviceDeletes(merged, { workingDirByDevice: { 'device-a': undefined } });
+    expect(merged.workingDirByDevice).toEqual({ 'device-b': '/b' });
+  });
+
+  it('leaves defined patch values untouched', () => {
+    const merged = { workingDirByDevice: { 'device-a': '/a' } };
+    pruneWorkingDirByDeviceDeletes(merged, { workingDirByDevice: { 'device-a': '/a' } });
+    expect(merged.workingDirByDevice).toEqual({ 'device-a': '/a' });
+  });
+
+  it('is a no-op when the patch has no workingDirByDevice', () => {
+    const merged = { workingDirByDevice: { 'device-a': '/a' } };
+    pruneWorkingDirByDeviceDeletes(merged, {});
+    pruneWorkingDirByDeviceDeletes(merged, undefined);
+    pruneWorkingDirByDeviceDeletes(merged, null);
+    expect(merged.workingDirByDevice).toEqual({ 'device-a': '/a' });
+  });
+
+  it('is a no-op when the merged target has no workingDirByDevice', () => {
+    expect(() =>
+      pruneWorkingDirByDeviceDeletes({}, { workingDirByDevice: { 'device-a': undefined } }),
+    ).not.toThrow();
+    expect(() =>
+      pruneWorkingDirByDeviceDeletes(undefined, { workingDirByDevice: { 'device-a': undefined } }),
+    ).not.toThrow();
+  });
+});

--- a/packages/types/src/agent/agencyConfig.ts
+++ b/packages/types/src/agent/agencyConfig.ts
@@ -92,3 +92,28 @@ export interface LobeAgentAgencyConfig {
    */
   workingDirByDevice?: Record<string, string>;
 }
+
+/**
+ * Apply "undefined means delete" semantics to a `workingDirByDevice` patch.
+ *
+ * Deep-merge (used by both the client optimistic store and the server persist
+ * path) can only add/overwrite keys — it silently skips `undefined` sources, so
+ * it can never *remove* a per-device entry. To clear a device's cwd the patch
+ * carries `{ [deviceId]: undefined }`; this prunes those keys from the merged
+ * map after the merge has run.
+ *
+ * Mutates `merged` in place (safe on an immer draft) and is a no-op when the
+ * patch touches no device entries.
+ */
+export const pruneWorkingDirByDeviceDeletes = (
+  merged: { workingDirByDevice?: Record<string, string | undefined> } | null | undefined,
+  patch: { workingDirByDevice?: Record<string, string | undefined> } | null | undefined,
+): void => {
+  const incoming = patch?.workingDirByDevice;
+  const target = merged?.workingDirByDevice;
+  if (!incoming || !target) return;
+
+  for (const key of Object.keys(incoming)) {
+    if (incoming[key] === undefined) delete target[key];
+  }
+};

--- a/src/features/ChatInput/ControlBar/useCommitWorkingDirectory.ts
+++ b/src/features/ChatInput/ControlBar/useCommitWorkingDirectory.ts
@@ -51,9 +51,13 @@ export const useCommitWorkingDirectory = (agentId: string) => {
       } else {
         if (targetDeviceId) {
           const prev = agencyConfig?.workingDirByDevice ?? {};
-          const nextMap = { ...prev };
-          if (newPath) nextMap[targetDeviceId] = newPath;
-          else delete nextMap[targetDeviceId];
+          // Clearing sends `undefined` rather than dropping the key: deep-merge
+          // (client store + server persist) can't remove a key, so the delete is
+          // carried as an explicit `undefined` and pruned after each merge.
+          const nextMap: Record<string, string | undefined> = {
+            ...prev,
+            [targetDeviceId]: newPath || undefined,
+          };
           await updateAgentConfigById(agentId, {
             agencyConfig: { ...agencyConfig, workingDirByDevice: nextMap },
           });

--- a/src/store/agent/slices/agent/action.test.ts
+++ b/src/store/agent/slices/agent/action.test.ts
@@ -291,6 +291,31 @@ describe('AgentSlice Actions', () => {
       // Should be the same reference if no change
       expect(result.current.agentMap).toBe(prevAgentMap);
     });
+
+    it('should drop a workingDirByDevice entry when patched with undefined', () => {
+      const { result } = renderHook(() => useAgentStore());
+
+      act(() => {
+        result.current.internal_dispatchAgentMap('agent-1', {
+          agencyConfig: {
+            executionTarget: 'local',
+            workingDirByDevice: { 'device-a': '/a', 'device-b': '/b' },
+          },
+        });
+      });
+
+      act(() => {
+        // merge() alone would re-add device-a; the prune step honors the delete
+        result.current.internal_dispatchAgentMap('agent-1', {
+          agencyConfig: { workingDirByDevice: { 'device-a': undefined } },
+        } as any);
+      });
+
+      expect(result.current.agentMap['agent-1']?.agencyConfig).toEqual({
+        executionTarget: 'local',
+        workingDirByDevice: { 'device-b': '/b' },
+      });
+    });
   });
 
   describe('internal_createAbortController', () => {

--- a/src/store/agent/slices/agent/action.ts
+++ b/src/store/agent/slices/agent/action.ts
@@ -1,6 +1,6 @@
 import { isDesktop } from '@lobechat/const';
 import { type AgentContextDocument } from '@lobechat/context-engine';
-import { isChatGroupSessionId } from '@lobechat/types';
+import { isChatGroupSessionId, pruneWorkingDirByDeviceDeletes } from '@lobechat/types';
 import { getSingletonAnalyticsOptional } from '@lobehub/analytics';
 import isEqual from 'fast-deep-equal';
 import { produce } from 'immer';
@@ -445,6 +445,9 @@ export class AgentSliceActionImpl {
         draft[id] = config;
       } else {
         draft[id] = merge(draft[id], config);
+        // merge() can't drop keys; honor `undefined` as a per-device delete so
+        // clearing a working directory takes effect optimistically.
+        pruneWorkingDirByDeviceDeletes(draft[id].agencyConfig, config.agencyConfig);
       }
     });
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- no matching tracked issue -->

#### 🔀 Description of Change

The working-directory picker's **clear** action ("清除目录") looked dead when the selection came from the agent-level per-device choice (`agencyConfig.workingDirByDevice[deviceId]`, i.e. no active topic override).

**Root cause.** Clearing built a `workingDirByDevice` map with the device key removed, but the write goes through deep-merge on **both** layers:

- client optimistic store — `internal_dispatchAgentMap` → `merge(draft, config)`
- server persist — `AgentModel.updateConfig` → `merge(agent, restData)`

`merge` (es-toolkit `mergeWith`) only adds/overwrites keys (and replaces arrays); it can never *drop* a key. So the cleared entry was re-merged back from the prior value, the picker kept showing the directory, and the button appeared broken. (Only `params` had dedicated "`undefined` means delete" handling — `workingDirByDevice` did not.)

**Fix — carry the delete as an explicit `undefined` marker, then prune it after each merge:**

1. `packages/types/src/agent/agencyConfig.ts` — new shared helper `pruneWorkingDirByDeviceDeletes(merged, patch)` that removes keys whose patch value is `undefined` (mutates in place; safe on an immer draft). Used by both layers to avoid duplicating the logic.
2. `src/features/.../useCommitWorkingDirectory.ts` — `writeCwd` now sends `{ [deviceId]: undefined }` on clear instead of dropping the key.
3. `src/store/agent/slices/agent/action.ts` — prune after `merge()` in `internal_dispatchAgentMap` so the clear reflects optimistically.
4. `packages/database/src/models/agent.ts` — prune after `merge()` in `updateConfig` so the delete persists, mirroring the existing `params` pattern.

End-to-end viability confirmed: the lambda TRPC client uses **superjson** (so `undefined` survives the wire), and the `updateAgentConfig` input schema is `passthrough().partial()` with `agencyConfig` as `z.custom` (no validation barrier for `undefined` values).

**Backward compatible:** the server change is purely additive — an older client never sends `undefined`, so the prune step is a no-op for it. No DB migration.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

New/updated tests:
- `pruneWorkingDirByDeviceDeletes` unit tests (delete / keep / no-op cases)
- client `internal_dispatchAgentMap`: a `{ [deviceId]: undefined }` patch drops the entry (merge alone would re-add it)
- server `updateConfig`: undefined value deletes the device entry (siblings + other agencyConfig fields preserved); a path value still upserts

All affected suites pass: `agencyConfig.test.ts` (types), `action.test.ts` (agent store, 29), `agent.test.ts` (database model, 123). `bun run type-check` is clean for the touched files (one unrelated pre-existing `taskTemplate`/`MarketSDK` error exists on `canary`).

Manual: on desktop, pick an agent-level working directory (no topic open), open the picker, click 清除目录 — the selection now clears and falls back to the next precedence level.

#### 📸 Screenshots / Videos

N/A — behavior fix, no visual change.