### PR TITLE
🐛 fix(desktop): close DevTools with window shortcut

### DIFF
--- a/apps/desktop/src/main/menus/impls/BaseMenuPlatform.ts
+++ b/apps/desktop/src/main/menus/impls/BaseMenuPlatform.ts
@@ -1,5 +1,5 @@
 // apps/desktop/src/main/menus/impl/BaseMenuPlatform.ts
-import type { MenuItemConstructorOptions } from 'electron';
+import type { BaseWindow, MenuItemConstructorOptions } from 'electron';
 import { BrowserWindow } from 'electron';
 
 import type { App } from '@/core/App';
@@ -32,6 +32,26 @@ export abstract class BaseMenuPlatform {
         this.buildZoomMenuItemOption(action, label, alternateAccelerator, false),
       ),
     ];
+  }
+
+  protected closeFocusedTabOrWindow(targetWindow?: BaseWindow | null): void {
+    const focused =
+      targetWindow && 'webContents' in targetWindow
+        ? (targetWindow as BrowserWindow)
+        : BrowserWindow.getFocusedWindow();
+    if (!focused) return;
+
+    if (focused.webContents.isDevToolsOpened()) {
+      focused.webContents.closeDevTools();
+      return;
+    }
+
+    const mainWindow = this.app.browserManager.getMainWindow();
+    if (focused === mainWindow.browserWindow) {
+      mainWindow.broadcast('closeCurrentTabOrWindow');
+    } else {
+      focused.close();
+    }
   }
 
   private buildZoomMenuItemOption(

--- a/apps/desktop/src/main/menus/impls/linux.test.ts
+++ b/apps/desktop/src/main/menus/impls/linux.test.ts
@@ -1,4 +1,4 @@
-import { app, dialog, Menu, shell } from 'electron';
+import { app, BrowserWindow, dialog, Menu, shell } from 'electron';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { App } from '@/core/App';
@@ -7,6 +7,9 @@ import { LinuxMenu } from './linux';
 
 // Mock Electron modules
 vi.mock('electron', () => ({
+  BrowserWindow: class BrowserWindow {
+    static getFocusedWindow = vi.fn();
+  },
   Menu: {
     buildFromTemplate: vi.fn((template) => ({ template })),
     setApplicationMenu: vi.fn(),
@@ -337,6 +340,100 @@ describe('LinuxMenu', () => {
       expect(closeItem.accelerator).toBe('CmdOrCtrl+W');
       expect(typeof closeItem.click).toBe('function');
       expect(closeItem.role).toBeUndefined();
+    });
+
+    it('should close open DevTools before delegating CmdOrCtrl+W to renderer window logic', () => {
+      linuxMenu.buildAndSetAppMenu();
+
+      const template = (Menu.buildFromTemplate as any).mock.calls[0][0];
+      const fileMenu = template.find((item: any) => item.label === 'File');
+      const closeItem = fileMenu.submenu.find((item: any) => item.label === 'Close');
+      const focusedWindow = {
+        close: vi.fn(),
+        webContents: {
+          closeDevTools: vi.fn(),
+          isDevToolsOpened: vi.fn(() => true),
+        },
+      };
+
+      closeItem.click(undefined, focusedWindow);
+
+      expect(focusedWindow.webContents.closeDevTools).toHaveBeenCalled();
+      expect(focusedWindow.close).not.toHaveBeenCalled();
+      expect(mockApp.browserManager.getMainWindow).not.toHaveBeenCalled();
+    });
+
+    it('should broadcast tab close when CmdOrCtrl+W targets the main window', () => {
+      linuxMenu.buildAndSetAppMenu();
+
+      const template = (Menu.buildFromTemplate as any).mock.calls[0][0];
+      const fileMenu = template.find((item: any) => item.label === 'File');
+      const closeItem = fileMenu.submenu.find((item: any) => item.label === 'Close');
+      const mainBrowserWindow = {
+        close: vi.fn(),
+        webContents: {
+          closeDevTools: vi.fn(),
+          isDevToolsOpened: vi.fn(() => false),
+        },
+      };
+      const broadcast = vi.fn();
+      vi.mocked(mockApp.browserManager.getMainWindow).mockReturnValue({
+        broadcast,
+        browserWindow: mainBrowserWindow,
+      } as any);
+
+      closeItem.click(undefined, mainBrowserWindow);
+
+      expect(broadcast).toHaveBeenCalledWith('closeCurrentTabOrWindow');
+      expect(mainBrowserWindow.close).not.toHaveBeenCalled();
+    });
+
+    it('should close non-main windows when CmdOrCtrl+W has no DevTools panel to close', () => {
+      linuxMenu.buildAndSetAppMenu();
+
+      const template = (Menu.buildFromTemplate as any).mock.calls[0][0];
+      const fileMenu = template.find((item: any) => item.label === 'File');
+      const closeItem = fileMenu.submenu.find((item: any) => item.label === 'Close');
+      const mainBrowserWindow = {
+        webContents: {
+          isDevToolsOpened: vi.fn(() => false),
+        },
+      };
+      const focusedWindow = {
+        close: vi.fn(),
+        webContents: {
+          closeDevTools: vi.fn(),
+          isDevToolsOpened: vi.fn(() => false),
+        },
+      };
+      vi.mocked(mockApp.browserManager.getMainWindow).mockReturnValue({
+        broadcast: vi.fn(),
+        browserWindow: mainBrowserWindow,
+      } as any);
+
+      closeItem.click(undefined, focusedWindow);
+
+      expect(focusedWindow.close).toHaveBeenCalled();
+    });
+
+    it('should use the focused window when Electron does not pass a menu target window', () => {
+      linuxMenu.buildAndSetAppMenu();
+
+      const template = (Menu.buildFromTemplate as any).mock.calls[0][0];
+      const fileMenu = template.find((item: any) => item.label === 'File');
+      const closeItem = fileMenu.submenu.find((item: any) => item.label === 'Close');
+      const focusedWindow = {
+        close: vi.fn(),
+        webContents: {
+          closeDevTools: vi.fn(),
+          isDevToolsOpened: vi.fn(() => true),
+        },
+      };
+      vi.mocked(BrowserWindow.getFocusedWindow).mockReturnValue(focusedWindow as any);
+
+      closeItem.click();
+
+      expect(focusedWindow.webContents.closeDevTools).toHaveBeenCalled();
     });
 
     it('should use role for minimize (accelerator handled by Electron)', () => {

--- a/apps/desktop/src/main/menus/impls/linux.ts
+++ b/apps/desktop/src/main/menus/impls/linux.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 
 import type { MenuItemConstructorOptions } from 'electron';
-import { app, BrowserWindow, clipboard, dialog, Menu, shell } from 'electron';
+import { app, clipboard, dialog, Menu, shell } from 'electron';
 
 import { isDev } from '@/const/env';
 import { HETERO_AGENT_DIR } from '@/const/heteroAgent';
@@ -122,16 +122,7 @@ export class LinuxMenu extends BaseMenuPlatform implements IMenuPlatform {
           { type: 'separator' },
           {
             accelerator: 'CmdOrCtrl+W',
-            click: () => {
-              const focused = BrowserWindow.getFocusedWindow();
-              if (!focused) return;
-              const mainWindow = this.app.browserManager.getMainWindow();
-              if (focused === mainWindow.browserWindow) {
-                mainWindow.broadcast('closeCurrentTabOrWindow');
-              } else {
-                focused.close();
-              }
-            },
+            click: (_item, targetWindow) => this.closeFocusedTabOrWindow(targetWindow),
             label: t('window.close'),
           },
           { label: t('window.minimize'), role: 'minimize' },

--- a/apps/desktop/src/main/menus/impls/macOS.ts
+++ b/apps/desktop/src/main/menus/impls/macOS.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 
 import type { MenuItemConstructorOptions } from 'electron';
-import { app, BrowserWindow, clipboard, Menu, shell } from 'electron';
+import { app, clipboard, Menu, shell } from 'electron';
 
 import { isDev } from '@/const/env';
 import { HETERO_AGENT_DIR } from '@/const/heteroAgent';
@@ -164,16 +164,7 @@ export class MacOSMenu extends BaseMenuPlatform implements IMenuPlatform {
           { type: 'separator' },
           {
             accelerator: 'CmdOrCtrl+W',
-            click: () => {
-              const focused = BrowserWindow.getFocusedWindow();
-              if (!focused) return;
-              const mainWindow = this.app.browserManager.getMainWindow();
-              if (focused === mainWindow.browserWindow) {
-                mainWindow.broadcast('closeCurrentTabOrWindow');
-              } else {
-                focused.close();
-              }
-            },
+            click: (_item, targetWindow) => this.closeFocusedTabOrWindow(targetWindow),
             label: t('window.close'),
           },
         ],

--- a/apps/desktop/src/main/menus/impls/windows.ts
+++ b/apps/desktop/src/main/menus/impls/windows.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 
 import type { MenuItemConstructorOptions } from 'electron';
-import { app, BrowserWindow, clipboard, Menu, shell } from 'electron';
+import { app, clipboard, Menu, shell } from 'electron';
 
 import { isDev } from '@/const/env';
 import { HETERO_AGENT_DIR } from '@/const/heteroAgent';
@@ -185,16 +185,7 @@ export class WindowsMenu extends BaseMenuPlatform implements IMenuPlatform {
           { label: t('window.minimize'), role: 'minimize' },
           {
             accelerator: 'CmdOrCtrl+W',
-            click: () => {
-              const focused = BrowserWindow.getFocusedWindow();
-              if (!focused) return;
-              const mainWindow = this.app.browserManager.getMainWindow();
-              if (focused === mainWindow.browserWindow) {
-                mainWindow.broadcast('closeCurrentTabOrWindow');
-              } else {
-                focused.close();
-              }
-            },
+            click: (_item, targetWindow) => this.closeFocusedTabOrWindow(targetWindow),
             label: t('window.close'),
           },
         ],


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Centralizes the desktop menu close shortcut handling across macOS, Windows, and Linux.
- Makes `CmdOrCtrl+W` close an open Electron DevTools panel before delegating to renderer tab/window close behavior.
- Preserves the existing smart close behavior for the main window and direct close behavior for secondary windows.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
cd apps/desktop
bunx vitest run --silent='passed-only' 'src/main/menus/impls/linux.test.ts'
bunx vitest run --silent='passed-only' 'src/main/menus/impls/macOS.test.ts'
bunx vitest run --silent='passed-only' 'src/main/menus/impls/windows.test.ts'
```

`bun run type-check` was also run from `apps/desktop`. The new `BaseWindow` menu callback type errors were fixed; the remaining failures are pre-existing cross-package resolution and generic/Zod errors outside this change, including `packages/model-bank` imports of `@/types/llm`.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This change handles the shortcut at the Electron main-process menu boundary because an attached DevTools panel is not closed by the renderer-only tab/window logic.