### PR TITLE
🐛 fix(model-runtime): classify upstream-message fallbacks out of UpstreamHttpError

### DIFF
--- a/packages/model-runtime/src/errors/match.test.ts
+++ b/packages/model-runtime/src/errors/match.test.ts
@@ -268,3 +268,36 @@ describe('formatErrorRef / parseErrorRef', () => {
     expect(parseErrorRef('E9999')).toBeUndefined();
   });
 });
+
+describe('matchErrorPattern — refines the UpstreamHttpError fallback bucket', () => {
+  // Real messages that were landing as the bare-HTTP fallback (a 4xx
+  // ProviderBizError whose message matched nothing → codeFromHttpStatus →
+  // UpstreamHttpError). Each must now resolve to a precise code.
+  const cases: [string, string][] = [
+    [
+      'Hệ thống đang bận, vui lòng thử lại sau ít phút.',
+      AgentRuntimeErrorType.ProviderServiceUnavailable,
+    ],
+    ['服务器问题调试中', AgentRuntimeErrorType.ProviderServiceUnavailable],
+    ['1m 上下文已经全量可用，请启用 1m 上下文后重试', AgentRuntimeErrorType.ExceededContextWindow],
+    [
+      'Request body too large for gpt-4o model. Max size: 1000000 tokens.',
+      AgentRuntimeErrorType.ExceededContextWindow,
+    ],
+    ["Model 'glm-5.2:cloud' is not allowed on this server.", AgentRuntimeErrorType.ModelNotFound],
+    ['User has been banned (request id: 2026...)', AgentRuntimeErrorType.PermissionDenied],
+    ['Only Codex clients can use this group', AgentRuntimeErrorType.PermissionDenied],
+    [
+      "messages.content.type 参数非法，取值范围 ['text']",
+      AgentRuntimeErrorType.InvalidRequestFormat,
+    ],
+    ['参数错误超过100个', AgentRuntimeErrorType.InvalidRequestFormat],
+    ['max_tokens must be at least 1, got -1.', AgentRuntimeErrorType.InvalidRequestFormat],
+  ];
+
+  it.each(cases)('classifies %j', (message, expected) => {
+    expect(
+      matchErrorPattern({ errorType: AgentRuntimeErrorType.ProviderBizError, message })?.code,
+    ).toBe(expected);
+  });
+});

--- a/packages/model-runtime/src/errors/patterns.ts
+++ b/packages/model-runtime/src/errors/patterns.ts
@@ -122,6 +122,17 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     match: sub('content exceeds maximum length of 100KB'),
   },
   { code: AgentRuntimeErrorType.ExceededContextWindow, match: sub('免费API限制模型输入token小于') },
+  { code: AgentRuntimeErrorType.ExceededContextWindow, match: sub('Request body too large') },
+  {
+    code: AgentRuntimeErrorType.ExceededContextWindow,
+    match: sub('conversation is too long'),
+    note: 'Anthropic suggests /compact when the context overflows',
+  },
+  {
+    code: AgentRuntimeErrorType.ExceededContextWindow,
+    match: sub('上下文已经全量可用'),
+    note: 'proxy gates 1m context — request overflowed the default window',
+  },
 
   // ─────────────────────────────────────────────────────────────────────────
   // InsufficientQuota — account balance / billing exhausted (long-term)
@@ -496,6 +507,13 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   { code: AgentRuntimeErrorType.ProviderServiceUnavailable, match: sub('502: Bad gateway') },
   { code: AgentRuntimeErrorType.ProviderServiceUnavailable, match: sub('502 <!DOCTYPE html>') },
   { code: AgentRuntimeErrorType.ProviderServiceUnavailable, match: sub('503 Gateway Error') },
+  {
+    code: AgentRuntimeErrorType.ProviderServiceUnavailable,
+    match: sub('Hệ thống đang bận'),
+    note: 'Vietnamese proxy: system busy, retry shortly',
+  },
+  { code: AgentRuntimeErrorType.ProviderServiceUnavailable, match: sub('服务器问题调试中') },
+  { code: AgentRuntimeErrorType.ProviderServiceUnavailable, match: sub('undergoing an upgrade') },
 
   // ─────────────────────────────────────────────────────────────────────────
   // ProviderNetworkError — connection / timeout
@@ -629,6 +647,19 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     match: sub('reached its end of life on'),
     note: 'newapi-style 410 Gone',
   },
+  {
+    code: AgentRuntimeErrorType.ModelNotFound,
+    match: sub('is not allowed on this server'),
+    note: 'ollama allow-list rejects the requested model',
+  },
+  {
+    code: AgentRuntimeErrorType.ModelNotFound,
+    match: sub('Publisher Model'),
+    note: 'Vertex: publisher model path not found',
+  },
+  { code: AgentRuntimeErrorType.ModelNotFound, match: sub('你请求的模型') },
+  { code: AgentRuntimeErrorType.ModelNotFound, match: sub('不存在或未上线') },
+  { code: AgentRuntimeErrorType.ModelNotFound, match: sub('has no provider supported') },
 
   // ─────────────────────────────────────────────────────────────────────────
   // InvalidProviderAPIKey
@@ -697,6 +728,13 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   { code: AgentRuntimeErrorType.PermissionDenied, match: sub('This token has no access to model') },
   { code: AgentRuntimeErrorType.PermissionDenied, match: sub('该令牌无权访问模型') },
   { code: AgentRuntimeErrorType.PermissionDenied, match: sub('您的 IP 不在令牌允许访问的列表中') },
+  { code: AgentRuntimeErrorType.PermissionDenied, match: sub('User has been banned') },
+  {
+    code: AgentRuntimeErrorType.PermissionDenied,
+    match: sub('Only Codex clients can use this group'),
+    note: 'proxy restricts the group to Codex clients',
+  },
+  { code: AgentRuntimeErrorType.PermissionDenied, match: sub('not available for trial users') },
 
   // ─────────────────────────────────────────────────────────────────────────
   // AccountDeactivated
@@ -907,6 +945,27 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   },
   { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('Unknown name "definitions"') },
   { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub("function_response.response' (") },
+  // Malformed-request rejections harvested from the UpstreamHttpError fallback
+  // bucket. Mix of upstream-proxy quirks and request-shape rejections; a few may
+  // also surface harness request-building bugs (negative max_tokens, illegal
+  // content-block type) — classifying keeps them visible under a precise code
+  // instead of the bare HTTP fallback.
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('参数非法，取值范围') },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('参数错误超过') },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('Param Incorrect') },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('tokenization failed') },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('invalid image detail') },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub("invalid 'parameters' schema") },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub("can't find closing '}'") },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('Unsupported parameter(s):') },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('messages parameter is illegal') },
+  {
+    code: AgentRuntimeErrorType.InvalidRequestFormat,
+    match: sub('GenerateContentRequest proto is invalid'),
+    note: 'Gemini: malformed function_response / content in request',
+  },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('max_tokens must be at least') },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('Yêu cầu không hợp lệ') },
 
   // ─────────────────────────────────────────────────────────────────────────
   // UserConfigError

--- a/packages/model-runtime/src/errors/refine.test.ts
+++ b/packages/model-runtime/src/errors/refine.test.ts
@@ -168,4 +168,40 @@ describe('refineErrorCode', () => {
       }),
     ).toBeUndefined();
   });
+
+  describe('re-refines the fallback buckets themselves', () => {
+    // formatErrorForState is idempotent: an inner pass can demote a
+    // ProviderBizError to UpstreamHttpError (4xx + no recognized message), then
+    // an outer pass re-enriches. UpstreamHttpError must stay refinable so the
+    // later pass can still upgrade it once the message is recognizable.
+    it('upgrades an UpstreamHttpError once its message matches a pattern', () => {
+      expect(
+        refineErrorCode({
+          errorType: AgentRuntimeErrorType.UpstreamHttpError,
+          message: 'Hệ thống đang bận, vui lòng thử lại sau ít phút.',
+        }),
+      ).toBe(AgentRuntimeErrorType.ProviderServiceUnavailable);
+    });
+
+    it('leaves an UpstreamHttpError untouched when nothing matches', () => {
+      // No status fallback for UpstreamHttpError (status-refinable is
+      // ProviderBizError only), so an unrecognized 4xx residual stays put.
+      expect(
+        refineErrorCode({
+          errorType: AgentRuntimeErrorType.UpstreamHttpError,
+          httpStatus: 409,
+          message: 'conflict, no details',
+        }),
+      ).toBeUndefined();
+    });
+
+    it('upgrades a bare-500 (InternalServerError) once its message matches', () => {
+      expect(
+        refineErrorCode({
+          errorType: String(ChatErrorType.InternalServerError),
+          message: '参数错误超过100个',
+        }),
+      ).toBe(AgentRuntimeErrorType.InvalidRequestFormat);
+    });
+  });
 });

--- a/packages/model-runtime/src/errors/refine.ts
+++ b/packages/model-runtime/src/errors/refine.ts
@@ -9,16 +9,24 @@ import { matchErrorPattern } from './match';
 /**
  * Codes whose message is worth running through `matchErrorPattern`.
  *
- * Besides the `ProviderBizError` upstream catch-all, this covers the two
- * fallback wrappers `formatErrorForState` produces for un-typed throws: a raw
- * `Error` is wrapped as `InternalServerError` (HTTP 500) and any other value as
+ * Besides the `ProviderBizError` upstream catch-all, this covers the fallback
+ * wrappers `formatErrorForState` produces for un-typed throws: a raw `Error` is
+ * wrapped as `InternalServerError` (HTTP 500) and any other value as
  * `AgentRuntimeError`. They must be pattern-refinable so persistence-layer
  * throws (`Failed query: …`) and state-store drops reach the registry — without
  * them those land as a bare, un-classified 500.
+ *
+ * `UpstreamHttpError` is itself a fallback bucket — it's what the status
+ * fallback below emits for a 4xx whose message matched nothing. It must stay
+ * refinable too: `formatErrorForState` is idempotent and re-enriches an
+ * already-normalized error, so a code demoted to `UpstreamHttpError` on an inner
+ * pass would otherwise be frozen there. Keeping it open lets a later pass (or a
+ * historical batch-rewrite) still upgrade it once the message is recognizable.
  */
 const PATTERN_REFINABLE_CODES = new Set<string>([
   AgentRuntimeErrorType.AgentRuntimeError,
   AgentRuntimeErrorType.ProviderBizError,
+  AgentRuntimeErrorType.UpstreamHttpError,
   String(ChatErrorType.InternalServerError),
 ]);
 


### PR DESCRIPTION
### 💡 Background

The agent-gateway error dashboard has a large `UpstreamHttpError` / `ProviderBizError` "fallback" bucket — ~37% of all errors. `UpstreamHttpError` is not a real error type: `refineErrorCode` produces it as the **terminal residue** when an incoming 4xx `ProviderBizError` matches **no** message pattern (`codeFromHttpStatus`: 4xx + no recognized message → `UpstreamHttpError`). So that bucket is just "4xx errors `patterns.ts` doesn't recognize yet".

Auditing the bucket, ~90% of the distinct messages are recognizable and belong to existing precise codes. They were only un-classified because the message signatures weren't in the registry.

### 🔨 Changes

**1. Add ~30 message patterns** (harvested from the production dashboard) to `ERROR_PATTERNS`, so these get a precise code **before** the status fallback demotes them:

| Target code | Examples |
| --- | --- |
| `ExceededContextWindow` | `Request body too large`, `conversation is too long` (/compact), `1m 上下文已经全量可用` |
| `ProviderServiceUnavailable` | `Hệ thống đang bận` (VN "system busy"), `服务器问题调试中`, `undergoing an upgrade` |
| `ModelNotFound` | `is not allowed on this server` (ollama), `Publisher Model …` (Vertex), `你请求的模型`, `不存在或未上线`, `has no provider supported` |
| `PermissionDenied` | `User has been banned`, `Only Codex clients can use this group`, `not available for trial users` |
| `InvalidRequestFormat` | `参数非法，取值范围`, `参数错误超过`, `Param Incorrect`, `tokenization failed`, `invalid image detail`, `invalid 'parameters' schema`, `Unsupported parameter(s):`, `messages parameter is illegal`, `GenerateContentRequest proto is invalid`, `max_tokens must be at least` |

All patterns are provider-agnostic (matched on the upstream message), so user-configured custom proxies benefit too.

**2. Make the `UpstreamHttpError` fallback re-refinable.** `UpstreamHttpError` was missing from `PATTERN_REFINABLE_CODES`, so once an error was demoted to it, it could never be upgraded — even though `formatErrorForState` is idempotent and re-enriches an already-normalized error on the outer catch. A code demoted on an inner pass was therefore frozen there even when the message became recognizable. Adding it lets a later pass (or a historical batch-rewrite) still upgrade it. Bare `500` is already covered via `InternalServerError`. Kept out of the HTTP-status fallback to avoid re-bucketing loops.

### ⚠️ Notes for review

- **Classification only — not suppression.** This just buckets errors under a precise code instead of the bare-HTTP fallback; nothing is hidden. Whether a code is then treated as user-side / filtered from the dashboard is decided downstream by `ERROR_CODE_SPECS` / the gateway filter, unchanged here.
- A few `InvalidRequestFormat` entries (`max_tokens must be at least 1, got -N`, illegal `content.type`, malformed `GenerateContentRequest` proto) **may surface harness request-building bugs** rather than upstream quirks. Classifying them keeps them visible under a precise, greppable code so they can be investigated — see the inline comment in `patterns.ts`.
- Deliberately **left unclassified**: `Corrupted thought signature` (harness-suspect, worth a separate look) and genuinely generic strings (`openai_error`, bare `<html> Bad Request`).

### 🧪 Tests

- Added 10 real-message regression cases to `match.test.ts` and 3 re-refinement cases to `refine.test.ts`.
- `bunx vitest run src/errors` → 87 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)