### PR TITLE
chore: clean LOBE-XXX code comment markers (2026-06-19)

### DIFF
--- a/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -529,7 +529,7 @@ export class HeterogeneousPersistenceHandler {
     if (snapshot.model) state.main.turnModel = snapshot.model;
     if (snapshot.provider) state.main.turnProvider = snapshot.provider;
 
-    // Recover the chain spine from the DB (LOBE-10445 phase 2). The next normal
+    // Recover the chain spine from the DB. The next normal
     // turn parents off the run's latest NON-tool / NON-signal main-thread
     // message; reading it straight from the DB (independent of
     // `currentAssistantId`, which can regress to the seed placeholder on a cold
@@ -649,7 +649,7 @@ export class HeterogeneousPersistenceHandler {
     if (!currentAssistant) return undefined;
 
     const toolRows = messages.filter((m) => m.role === 'tool' && m.tool_call_id);
-    // Chain rule (LOBE-10445 phase 2): the next turn's assistant parents off the
+    // Chain rule: the next turn's assistant parents off the
     // prior assistant (the spine), not its last child tool — recover the anchor
     // as the current assistant itself (matches the subagent reducer, and is
     // fork-resistant since it reads the thread's real latest assistant from DB).

--- a/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.coldReplicaChainAnchor.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.coldReplicaChainAnchor.test.ts
@@ -18,7 +18,7 @@ import {
  * chain parent were derived from that in-memory pointer, every later `newStep`
  * would open off the seed → orphan sibling forks.
  *
- * LOBE-10445 phase 2 anchors the chain to the run's latest NON-tool / NON-signal
+ * The phase 2 rewrite anchors the chain to the run's latest NON-tool / NON-signal
  * main-thread message (`getLastMainThreadSpineMessageId`), read straight from the
  * DB and ordered by createdAt — independent of `currentAssistantId`. So step 2
  * chains off step 1's assistant even though the in-memory pointer regressed.

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -2363,7 +2363,7 @@ export class MessageModel {
    * Id of the latest main-thread (`threadId IS NULL`) "spine" message in a
    * topic: the most recent message that is NOT a tool and NOT a signal-tagged
    * reactive turn (Monitor stdout callbacks etc.). This is the chain anchor for
-   * the heterogeneous-agent write side (LOBE-10445 phase 2): the next normal
+   * the heterogeneous-agent write side: the next normal
    * turn parents off it, producing a `user → asst → asst …` spine with tools as
    * inline children.
    *

--- a/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.ts
+++ b/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.ts
@@ -100,7 +100,7 @@ const delegateSubagent = (
 // ─── Chain rule ───
 
 /**
- * Parent for the NEXT turn's assistant (LOBE-10445 phase 2 — write-side spine).
+ * Parent for the NEXT turn's assistant (write-side spine).
  *
  * Normal turns parent off the run's spine (`lastSpineMessageId`, the most recent
  * non-tool / non-signal main message) so the persisted shape is

--- a/packages/heterogeneous-agents/src/mainAgentCoordinator/types.ts
+++ b/packages/heterogeneous-agents/src/mainAgentCoordinator/types.ts
@@ -27,8 +27,8 @@ import type { ExternalSignalContext, ToolCallPayload } from '../types';
  * by delegating subagent-scoped events to `reduceSubagentRuns`, so a single
  * `reduce` call is the only entry point both engines need.
  *
- * The CHAIN RULE lives here and is authoritative for both engines (LOBE-10445
- * phase 2): the next turn's assistant parents off the most recent NON-tool,
+ * The CHAIN RULE lives here and is authoritative for both engines:
+ * the next turn's assistant parents off the most recent NON-tool,
  * NON-signal main-thread message — the run's "spine" (`lastSpineMessageId`) —
  * so the persisted shape is `user → asst → asst …` with tools as inline
  * children. The read side (`conversation-flow`) reconstructs the
@@ -82,7 +82,7 @@ export interface MainAgentRunState {
   /** Set once a terminal event has been reduced (idempotent finalize). */
   ended: boolean;
   /**
-   * Chain rule (LOBE-10445 phase 2): the most recent NON-tool, NON-signal
+   * Chain rule: the most recent NON-tool, NON-signal
    * main-thread message — the run's spine. The next NORMAL turn's assistant
    * parents off this (signal-tagged reactive turns parent off `lastToolMsgIdEver`
    * instead). Advances on every normal turn; a signal turn does NOT advance it,
@@ -95,7 +95,7 @@ export interface MainAgentRunState {
   lastTextSnapshotSeq: number;
   /**
    * Run-lifetime id of the most recent main-agent tool message. Since
-   * LOBE-10445 phase 2 this anchors ONLY signal-tagged reactive turns (Monitor
+   * this anchors ONLY signal-tagged reactive turns (Monitor
    * stdout pushes) onto a tool, so the reader renders them as tool-child
    * callbacks; normal turns parent off `lastSpineMessageId`. Only advances on
    * tool batches; never reset across turns.

--- a/packages/heterogeneous-agents/src/subagentCoordinator/reducer.ts
+++ b/packages/heterogeneous-agents/src/subagentCoordinator/reducer.ts
@@ -349,7 +349,7 @@ const reduceToolsChunk = (
     })),
   });
 
-  // Chain rule (LOBE-10445 phase 2): the next turn's assistant parents off the
+  // Chain rule: the next turn's assistant parents off the
   // prior assistant (the spine), NOT this batch's last tool — so
   // `lastChainParentId` stays at `currentAssistantId` here, tools become inline
   // children, and the read side reconstructs the zigzag. (Subagent threads have


### PR DESCRIPTION
## Summary

Daily automated scan and cleanup of `LOBE-XXX` format code comment markers.

## Changes

Removed **LOBE-10445** issue references from JSDoc and inline comments across 6 files. The issue (message-chain spine refactoring, assistant-anchored write side) is in-progress with PRs #15930 and #15908. All architectural descriptions preserved; only the marker tag removed.

### Files changed

| File | Change |
|------|--------|
| `packages/database/src/models/message.ts` | Removed `LOBE-10445 phase 2` from JSDoc |
| `packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.ts` | Removed `LOBE-10445 phase 2` from JSDoc |
| `packages/heterogeneous-agents/src/mainAgentCoordinator/types.ts` | Removed 3 `LOBE-10445` references from JSDoc |
| `packages/heterogeneous-agents/src/subagentCoordinator/reducer.ts` | Removed `LOBE-10445 phase 2` from comment |
| `apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts` | Removed 2 `LOBE-10445 phase 2` references |
| `apps/server/.../HeterogeneousPersistenceHandler.coldReplicaChainAnchor.test.ts` | Replaced `LOBE-10445 phase 2` with descriptive text |

### Not cleaned (legitimate test data)

`LOBE-10205` in test fixtures and tool test data — these are Linear issue ID values used as runtime test data, not comment markers.

---

Auto-generated at 2026-06-19