### PR TITLE
🐛 fix(hetero-agent): gate CC usage-limit guide on rejected status

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -176,6 +176,38 @@ describe('ClaudeCodeAdapter', () => {
       });
     });
 
+    it('does not treat an allowed rate_limit_event window as a quota limit on a later network error', () => {
+      const adapter = new ClaudeCodeAdapter();
+      // CC stamps a rate_limit_info onto an *allowed* request — it carries the
+      // rolling-window metadata (resetsAt / rateLimitType) even though nothing
+      // was rejected. A later ECONNRESET must surface as a generic error, NOT
+      // inherit this window and render a bogus "usage limit reached" guide.
+      const rawError = 'API Error: Unable to connect to API (ECONNRESET)';
+
+      adapter.adapt({ subtype: 'init', type: 'system' });
+      adapter.adapt({
+        rate_limit_info: {
+          isUsingOverage: false,
+          rateLimitType: 'five_hour',
+          resetsAt: 1_781_853_000,
+          status: 'allowed',
+        },
+        type: 'rate_limit_event',
+      });
+
+      const events = adapter.adapt({
+        api_error_status: null,
+        is_error: true,
+        result: rawError,
+        type: 'result',
+      });
+
+      expect(events.map((e) => e.type)).toEqual(['stream_end', 'error']);
+      expect(events[1].data).toMatchObject({ error: rawError, message: rawError });
+      expect(events[1].data).not.toHaveProperty('code', 'rate_limit');
+      expect(events[1].data).not.toHaveProperty('rateLimitInfo');
+    });
+
     it('classifies rate-limit failures from paired rate_limit_event + result events', () => {
       const adapter = new ClaudeCodeAdapter();
       const rawError = "You've hit your limit · resets 9am (Asia/Shanghai)";

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -218,18 +218,27 @@ const CLI_OVERLOADED_PATTERNS = [
 ] as const;
 
 /**
- * The one reliable discriminator between a user-side plan/quota limit and a
- * transient server throttle: only the genuine user limit carries a concrete
- * reset window in the structured `rate_limit_event` — `resetsAt` (epoch
- * seconds) and/or a named `rateLimitType` (e.g. `seven_day`). Anthropic's
- * transient throttle emits a rate_limit_event too, but with just
- * `status: 'rejected'` and no reset info. Status codes (429 / 529) alone are
- * ambiguous, so this structured signal — not the HTTP status, not the message
- * text — is what decides whether we show the "usage limit reached, resets at
- * X" guide vs the "temporarily overloaded, retry" guide.
+ * Discriminates a user-side plan/quota limit from everything else.
+ *
+ * Two signals must BOTH hold:
+ *  1. The request was actually `status: 'rejected'`. Anthropic stamps a
+ *     `rate_limit_info` onto its events even when the request goes through
+ *     (`status: 'allowed'`) — that block is just the rolling-window metadata
+ *     (`resetsAt`, `rateLimitType`) for an *allowed* call, NOT evidence the
+ *     limit was hit. Leaning on the presence of a reset window alone made a
+ *     later unrelated terminal failure (e.g. an `ECONNRESET` network drop)
+ *     inherit the last allowed event's window and render a bogus "usage limit
+ *     reached, resets at X" guide. The `status` is the gate.
+ *  2. A concrete reset window (`resetsAt` epoch seconds and/or a named
+ *     `rateLimitType` such as `seven_day`). A bare `rejected` with no window is
+ *     Anthropic's transient server throttle — left to the overloaded (retry)
+ *     classifier, not the usage-limit guide.
+ *
+ * Status codes (429 / 529) and message text are deliberately not consulted
+ * here — only this structured signal decides the "usage limit reached" guide.
  */
 const isUserQuotaRateLimit = (info?: HeterogeneousRateLimitInfo): boolean =>
-  !!info && (info.resetsAt != null || info.rateLimitType != null);
+  !!info && info.status === 'rejected' && (info.resetsAt != null || info.rateLimitType != null);
 
 const getCliResultMessage = (result: unknown): string | undefined => {
   if (typeof result === 'string') return result;


### PR DESCRIPTION
## 🐛 Bug Fix

### Description of Change

The Claude Code adapter was misclassifying unrelated terminal failures as user-side quota limits.

CC stamps a `rate_limit_info` block onto its events **even when the request goes through** (`status: 'allowed'`) — that block carries the rolling-window metadata (`resetsAt`, `rateLimitType`) for an allowed call, not evidence the limit was hit. The previous discriminator keyed only on the presence of a reset window:

```ts
!!info && (info.resetsAt != null || info.rateLimitType != null)
```

So a later unrelated failure (e.g. an `ECONNRESET` network drop) would inherit the last allowed event's window and render a bogus **"usage limit reached, resets at X"** guide to the user.

### Fix

`isUserQuotaRateLimit` now requires **both** signals before classifying a failure as a user-side quota limit:

1. `status === 'rejected'` — the request was actually rejected (the gate).
2. A concrete reset window (`resetsAt` and/or named `rateLimitType`).

A bare `rejected` with no window stays with the overloaded (retry) classifier. Status codes (429 / 529) and message text are still deliberately not consulted.

### How to Test

- [x] Added a regression test: an allowed `rate_limit_event` window followed by an `ECONNRESET` result now surfaces as a generic `error` (no `code: 'rate_limit'`, no `rateLimitInfo`).
- [x] All 92 adapter tests pass (`bunx vitest run packages/heterogeneous-agents/src/adapters/claudeCode.test.ts`).