### PR TITLE
🐛 fix(hetero-agent): recover signal-turn tool anchor on cold replicas

### DIFF
--- a/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -535,10 +535,21 @@ export class HeterogeneousPersistenceHandler {
     // `currentAssistantId`, which can regress to the seed placeholder on a cold
     // / non-sticky replica — see the multi-replica caveat on the class) keeps
     // consecutive cold-replica steps chained linearly instead of forking onto a
-    // stale node. Signal turns still anchor off `lastToolMsgIdEver`, which is
-    // maintained in-memory across the run's tool batches.
+    // stale node.
     const spineId = await this.deps.messageModel.getLastMainThreadSpineMessageId?.(state.topicId);
     if (spineId) state.main.lastSpineMessageId = spineId;
+
+    // Recover the signal-turn anchor from the DB too. A signal-tagged reactive
+    // turn (Monitor stdout callback, post-task summary) parents off the run's
+    // most recent tool (`lastToolMsgIdEver`) so the reader renders it as a
+    // tool-child. That accumulator is maintained in-memory across the run's tool
+    // batches — but a cold replica that processes the signal turn WITHOUT having
+    // seen the prior tool batch has it `undefined`, so the turn would fall back
+    // to the spine (an assistant) and be dropped (excluded from spine
+    // continuation AND from tool-only task-completion collection). Reading the
+    // latest main-thread tool from the DB keeps reactive turns rooted on a tool.
+    const lastToolId = await this.deps.messageModel.getLastMainThreadToolMessageId?.(state.topicId);
+    if (lastToolId) state.main.lastToolMsgIdEver = lastToolId;
   }
 
   /**

--- a/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.coldReplicaChainAnchor.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.coldReplicaChainAnchor.test.ts
@@ -31,6 +31,7 @@ import {
 interface FakeMessage {
   content: string;
   id: string;
+  metadata?: Record<string, any> | null;
   parentId?: string | null;
   role: 'user' | 'assistant' | 'tool';
   seq: number;
@@ -79,6 +80,7 @@ const createHarness = () => {
       const msg: FakeMessage = {
         content: input.content ?? '',
         id: msgId,
+        metadata: input.metadata ?? null,
         parentId: input.parentId ?? null,
         role: input.role!,
         seq: seq++,
@@ -113,6 +115,13 @@ const createHarness = () => {
             !m.threadId &&
             !(m as any).metadata?.signal,
         )
+        .sort((a, b) => b.seq - a.seq)[0];
+      return match?.id;
+    }),
+    getLastMainThreadToolMessageId: vi.fn(async (topicId: string) => {
+      // Most recent main-thread tool message — the signal-turn anchor.
+      const match = [...messages.values()]
+        .filter((m) => m.topicId === topicId && m.role === 'tool' && !m.threadId)
         .sort((a, b) => b.seq - a.seq)[0];
       return match?.id;
     }),
@@ -177,6 +186,29 @@ const stepBatch = (stepIndex: number, ccMsgId: string, toolCallId: string): Agen
   }),
 ];
 
+/**
+ * A toolless, signal-tagged reactive turn (post-task summary the LLM emits after
+ * CC delivers a long-running tool's `task_notification`). The writer stamps
+ * `externalSignal` at stream_start, so the reducer parents it off
+ * `lastToolMsgIdEver` — a tool message — instead of the spine assistant.
+ */
+const signalTurnBatch = (
+  stepIndex: number,
+  ccMsgId: string,
+  sourceToolCallId: string,
+): AgentStreamEvent[] => [
+  buildEvent('stream_start', stepIndex, {
+    externalSignal: { sourceToolCallId, sourceToolName: 'Bash', type: 'task-completion' },
+    messageId: ccMsgId,
+    newStep: true,
+    provider: 'claude-code',
+  }),
+  buildEvent('stream_chunk', stepIndex, {
+    chunkType: 'text',
+    content: 'All done — task finished.',
+  }),
+];
+
 describe('HeterogeneousPersistenceHandler — chain anchor survives a regressed currentAssistantId', () => {
   beforeEach(() => __resetOperationStatesForTesting());
   afterEach(() => __resetOperationStatesForTesting());
@@ -223,5 +255,42 @@ describe('HeterogeneousPersistenceHandler — chain anchor survives a regressed 
       (m) => m.role === 'assistant' && m.parentId === a1.id,
     );
     expect(a1AssistantChildren).toHaveLength(1);
+  });
+
+  it("roots a cold-replica signal turn on the run's last tool, not the spine assistant", async () => {
+    const h = createHarness();
+
+    // Step 1 on a cold replica: a normal tool-using turn → a1 (parent SEED) plus
+    // its tool message.
+    await h.handler.ingest({
+      assistantMessageId: SEED,
+      events: stepBatch(1, 'cc-A', 'tc-A'),
+      operationId: OP,
+      topicId: TOPIC,
+    });
+    __resetOperationStatesForTesting();
+
+    // Step 2 on ANOTHER cold replica: a toolless task-completion signal turn.
+    // In-memory `lastToolMsgIdEver` is undefined here (this replica never saw the
+    // step-1 tool batch). Without DB recovery the turn falls back to the spine
+    // assistant (a1) and the read side drops it; with recovery it roots on the
+    // run's last tool.
+    await h.handler.ingest({
+      assistantMessageId: SEED,
+      events: signalTurnBatch(2, 'cc-B', 'tc-A'),
+      operationId: OP,
+      topicId: TOPIC,
+    });
+
+    const signalMsg = [...h.messages.values()].find(
+      (m) => m.role === 'assistant' && m.metadata?.signal,
+    );
+    expect(signalMsg).toBeDefined();
+
+    // Its parent must be a TOOL message (the run's last tool), not an assistant —
+    // otherwise it is orphaned (excluded from spine continuation AND from the
+    // tool-child task-completion collection).
+    const parent = h.messages.get(signalMsg!.parentId!);
+    expect(parent?.role).toBe('tool');
   });
 });

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -2399,6 +2399,42 @@ export class MessageModel {
     return row?.id;
   };
 
+  /**
+   * Id of the latest main-thread (`threadId IS NULL`) tool message in a topic —
+   * the anchor a signal-tagged reactive turn (Monitor stdout callback,
+   * post-task summary) parents off, so the read side renders it as a tool-child
+   * (`collectFlatSignalCallbacks` / `collectFlatTaskCompletions`) rather than a
+   * spine turn.
+   *
+   * Symmetric to {@link getLastMainThreadSpineMessageId}, and read from the DB
+   * for the same reason: the reducer keeps `lastToolMsgIdEver` in memory, but a
+   * cold / non-sticky replica that processes a signal turn WITHOUT having seen
+   * the prior tool batch has it `undefined` — falling back to the spine anchor
+   * (an assistant). A signal turn anchored on an assistant is then dropped: it
+   * is excluded from spine continuation (signal-tagged) AND from task-completion
+   * collection (which only scans tool children), so the message vanishes.
+   * Recovering the anchor here keeps the reactive turn rooted on a tool. No
+   * `createdAt` floor: a topic runs at most one operation at a time, so the
+   * latest tool IS this run's most recent context.
+   */
+  getLastMainThreadToolMessageId = async (topicId: string): Promise<string | undefined> => {
+    const [row] = await this.db
+      .select({ id: messages.id })
+      .from(messages)
+      .where(
+        and(
+          eq(messages.topicId, topicId),
+          eq(messages.role, 'tool'),
+          isNull(messages.threadId),
+          this.ownership(),
+        ),
+      )
+      .orderBy(desc(messages.createdAt))
+      .limit(1);
+
+    return row?.id;
+  };
+
   updateTranslate = async (id: string, translate: Partial<ChatTranslate>) => {
     const result = await this.db.query.messageTranslates.findFirst({
       where: and(eq(messageTranslates.id, id), this.translatesOwnership()),


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

**Symptom:** the final post-task summary assistant message silently disappears from a topic (observed on `tpc_SZXNHtiNeqxv`). The message is persisted in the DB but never renders.

**Root cause — a cold-replica regression from the assistant-anchored write-spine refactor (#15930):**

A toolless, **signal-tagged** turn (post-task summary fired after a long-running tool's `task_notification`; Monitor stdout callbacks) parents off the run's most recent tool (`lastToolMsgIdEver`) so the read side renders it as a *tool-child* (`collectFlatSignalCallbacks` / `collectFlatTaskCompletions`).

`lastToolMsgIdEver` is only maintained **in-memory** across a run's tool batches. #15883 had a DB recovery query (`getLastMainThreadToolMessageIdSince`) for it; #15930 removed that query when it introduced `getLastMainThreadSpineMessageId`, but kept the assumption (handler comment) that *"signal turns still anchor off `lastToolMsgIdEver`, which is maintained in-memory."*

That assumption breaks on a **cold / non-sticky replica** (WS reconnect storm spreads one run's batches across replicas). A replica that processes the signal turn *without* having seen the prior tool batch has `lastToolMsgIdEver === undefined`, so the turn falls back to `lastSpineMessageId` — an **assistant**. A signal turn parented on an assistant is then dropped by the read side on **both** paths:
- excluded from spine continuation (it's signal-tagged, filtered by `!getMessageSignal(m)`), and
- excluded from task-completion collection (which only scans **tool** children).

→ the message is orphaned and vanishes.

Concretely on `tpc_SZXNHtiNeqxv`: the final summary `msg_q5C4…` (`task-completion`, no tools) anchored to the spine-grandparent `msg_fohm…` instead of the prior step `msg_e5Ks…`, becoming an invisible sibling fork.

**Fix:** recover the signal-turn anchor from the DB too, symmetric to the spine recovery already in `refreshMainStateFromDb`:
- add `MessageModel.getLastMainThreadToolMessageId(topicId)` — latest `threadId IS NULL`, `role = 'tool'` by `createdAt` (mirrors `getLastMainThreadSpineMessageId`; same "one operation per topic" rationale, no `createdAt` floor);
- restore `state.main.lastToolMsgIdEver` from it in `refreshMainStateFromDb`, so a reactive turn on a cold replica stays rooted on a tool.

#### 🧪 How to Test

- [x] Added/updated tests

New regression case in `HeterogeneousPersistenceHandler.coldReplicaChainAnchor.test.ts` models the cross-replica window: a toolless `task-completion` turn ingested on a fresh replica (after the prior tool batch ran on another replica) anchors to the run's last **tool**, not the spine assistant. Verified it fails without the fix (`expected 'assistant' to be 'tool'`) and passes with it. Full `heterogeneousAgent` suite: 99/99 pass.

#### 📝 Additional Information

No schema/migration changes — the new method is a read query. The read side (`conversation-flow`) is unchanged; this keeps the persisted parent on a tool so the existing collection logic finds it.