### PR TITLE
🐛 fix: suppress agent mode notice for CLI agents

### DIFF
--- a/src/features/ChatInput/Desktop/AgentModeNotice.test.tsx
+++ b/src/features/ChatInput/Desktop/AgentModeNotice.test.tsx
@@ -14,6 +14,7 @@ interface TestModel {
 
 const testState = vi.hoisted(() => ({
   agent: {
+    agencyConfig: undefined as { heterogeneousProvider?: { type: string } } | undefined,
     enableAgentMode: true,
     model: 'gpt-4o',
     provider: 'openai',
@@ -51,6 +52,8 @@ vi.mock('@/store/agent', () => ({
 vi.mock('@/store/agent/selectors', () => ({
   agentByIdSelectors: {
     getAgentEnableModeById: () => (s: typeof testState.agent) => s.enableAgentMode,
+    isAgentHeterogeneousById: () => (s: typeof testState.agent) =>
+      Boolean(s.agencyConfig?.heterogeneousProvider),
     getAgentModelById: () => (s: typeof testState.agent) => s.model,
     getAgentModelProviderById: () => (s: typeof testState.agent) => s.provider,
   },
@@ -71,6 +74,7 @@ vi.mock('@/store/aiInfra', () => ({
 
 describe('AgentModeNotice', () => {
   beforeEach(() => {
+    testState.agent.agencyConfig = undefined;
     testState.agent.enableAgentMode = true;
     testState.agent.model = 'gpt-4o';
     testState.agent.provider = 'openai';
@@ -108,6 +112,18 @@ describe('AgentModeNotice', () => {
 
   it('does not render when agent mode is disabled', () => {
     testState.agent.enableAgentMode = false;
+    testState.aiInfra.isInitAiProviderRuntimeState = true;
+    testState.aiInfra.enabledAiModels = [
+      { abilities: { functionCall: false }, id: 'gpt-4o', providerId: 'openai' },
+    ];
+
+    render(<AgentModeNotice />);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('does not render for heterogeneous agents', () => {
+    testState.agent.agencyConfig = { heterogeneousProvider: { type: 'codex' } };
     testState.aiInfra.isInitAiProviderRuntimeState = true;
     testState.aiInfra.enabledAiModels = [
       { abilities: { functionCall: false }, id: 'gpt-4o', providerId: 'openai' },

--- a/src/features/ChatInput/Desktop/AgentModeNotice.tsx
+++ b/src/features/ChatInput/Desktop/AgentModeNotice.tsx
@@ -32,8 +32,9 @@ const AgentModeNotice = memo(() => {
   const { t } = useTranslation('chat');
   const agentId = useAgentId();
 
-  const [enableAgentMode, model, provider] = useAgentStore((s) => [
+  const [enableAgentMode, isHeterogeneousAgent, model, provider] = useAgentStore((s) => [
     agentByIdSelectors.getAgentEnableModeById(agentId)(s),
+    agentByIdSelectors.isAgentHeterogeneousById(agentId)(s),
     agentByIdSelectors.getAgentModelById(agentId)(s),
     agentByIdSelectors.getAgentModelProviderById(agentId)(s),
   ]);
@@ -43,7 +44,8 @@ const AgentModeNotice = memo(() => {
     aiModelSelectors.isModelSupportToolUse(model, provider)(s),
   ]);
 
-  if (!enableAgentMode || !isModelConfigReady || supportToolUse) return null;
+  if (isHeterogeneousAgent || !enableAgentMode || !isModelConfigReady || supportToolUse)
+    return null;
 
   return (
     <Alert


### PR DESCRIPTION
# Pull Request

## 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

## 🔗 Related Links

- Linear / GitHub issue: N/A
- Related PRs: https://github.com/lobehub-biz/lobehub-cloud/pull/820
- Reference docs / code / articles: `src/features/ChatInput/Desktop/AgentModeNotice.tsx`

## 🔀 Description of Change

Suppress the generic Agent mode unsupported-model warning for heterogeneous agents such as Codex and Claude Code. These agents are driven by an external CLI runtime, so their tool capability should not be inferred from the normal chat model `functionCall` flag.

## 🧭 Key Decisions / Non-goals

- Heterogeneous agents bypass this notice entirely because they do not depend on normal LLM tool-calling capability for execution.
- Keep the existing warning behavior unchanged for normal chat agents whose selected model lacks `abilities.functionCall`.
- No model config, provider routing, or account entitlement behavior is changed.

## 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

### Automated Tests

- `rtk vitest run src/features/ChatInput/Desktop/AgentModeNotice.test.tsx`
- `bun run type-check` from the cloud repo root

### Manual Verification

- Verified the production `glm-5.2` client config has `abilities.functionCall: true`; the reported warning was specific to a Codex heterogeneous agent with no normal model/provider config.

### Post-Deploy Verification

- Open a Codex or Claude Code agent and confirm the generic unsupported-model warning is not shown.
- Open a normal chat agent with a model that lacks tool calling and confirm the warning still appears.

## 📸 Screenshots / Videos

N/A

## 🚀 Rollout / Deployment Checklist

- [x] Environment variables: N/A
- [x] Redis / Edge Config / feature flags: N/A
- [x] Database migration or data backfill: N/A
- [x] Third-party console changes: N/A
- [x] Rollback plan: revert this PR if the notice needs to apply to heterogeneous agents again.

## 📝 Additional Information

N/A
