### PR TITLE
🐛 fix: provide Market auth to SPA modals

### DIFF
--- a/src/layout/SPAGlobalProvider/index.test.tsx
+++ b/src/layout/SPAGlobalProvider/index.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type SPAGlobalProviderComponent from './index';
+
+let SPAGlobalProvider: typeof SPAGlobalProviderComponent;
+
+vi.mock('@lobehub/ui', async () => {
+  const React = await import('react');
+  const Passthrough = ({ children }: { children?: ReactNode }) =>
+    React.createElement(React.Fragment, null, children);
+
+  return {
+    ContextMenuHost: () => React.createElement('div', { 'data-testid': 'context-menu-host' }),
+    ModalHost: () => React.createElement('div', { 'data-testid': 'legacy-modal-host' }),
+    TooltipGroup: Passthrough,
+  };
+});
+
+vi.mock('@lobehub/ui/base-ui', async () => {
+  const React = await import('react');
+
+  return {
+    ModalHost: () => React.createElement('div', { 'data-testid': 'base-modal-host' }),
+    ToastHost: () => React.createElement('div', { 'data-testid': 'toast-host' }),
+  };
+});
+
+vi.mock('antd-style', async () => {
+  const React = await import('react');
+
+  return {
+    StyleProvider: ({ children }: { children?: ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+vi.mock('motion/react', async () => {
+  const React = await import('react');
+
+  return {
+    LazyMotion: ({ children }: { children?: ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    domMax: {},
+  };
+});
+
+vi.mock('@/components/Analytics/LobeAnalyticsProviderWrapper', async () => {
+  const React = await import('react');
+
+  return {
+    LobeAnalyticsProviderWrapper: ({ children }: { children?: ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+vi.mock('@/components/DragUploadZone/DragUploadProvider', async () => {
+  const React = await import('react');
+
+  return {
+    DragUploadProvider: ({ children }: { children?: ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+vi.mock('@/const/version', () => ({
+  isDesktop: false,
+}));
+
+vi.mock('@/features/AgentMockDevtools', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/features/DevFeatureFlagPanel', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/layout/AuthProvider', async () => {
+  const React = await import('react');
+
+  return {
+    default: ({ children }: { children?: ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+vi.mock('@/layout/AuthProvider/MarketAuth', async () => {
+  const React = await import('react');
+
+  return {
+    MarketAuthProvider: ({ children }: { children?: ReactNode }) =>
+      React.createElement('div', { 'data-testid': 'market-auth-provider' }, children),
+  };
+});
+
+vi.mock('@/layout/GlobalProvider/AppTheme', async () => {
+  const React = await import('react');
+
+  return {
+    default: ({ children }: { children?: ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+vi.mock('@/layout/GlobalProvider/CacheHydrationGate', async () => {
+  const React = await import('react');
+
+  return {
+    default: ({ children }: { children?: ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+vi.mock('@/layout/GlobalProvider/DynamicFavicon', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/layout/GlobalProvider/FaviconProvider', async () => {
+  const React = await import('react');
+
+  return {
+    FaviconProvider: ({ children }: { children?: ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+vi.mock('@/layout/GlobalProvider/GroupWizardProvider', async () => {
+  const React = await import('react');
+
+  return {
+    GroupWizardProvider: ({ children }: { children?: ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+vi.mock('@/layout/GlobalProvider/Query', async () => {
+  const React = await import('react');
+
+  return {
+    default: ({ children }: { children?: ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+vi.mock('@/layout/GlobalProvider/ServerVersionOutdatedAlert', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/layout/GlobalProvider/StoreInitialization', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/store/serverConfig/Provider', async () => {
+  const React = await import('react');
+
+  return {
+    ServerConfigStoreProvider: ({ children }: { children?: ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+vi.mock('./Locale', async () => {
+  const React = await import('react');
+
+  return {
+    default: ({ children }: { children?: ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  };
+});
+
+describe('SPAGlobalProvider', () => {
+  beforeAll(async () => {
+    SPAGlobalProvider = (await import('./index')).default;
+  });
+
+  beforeEach(() => {
+    vi.stubGlobal('__DEV__', false);
+    Reflect.deleteProperty(window, '__SERVER_CONFIG__');
+  });
+
+  it('provides Market auth from the SPA global provider', () => {
+    render(
+      <SPAGlobalProvider>
+        <div data-testid="spa-route-content" />
+      </SPAGlobalProvider>,
+    );
+
+    const routeContent = screen.getByTestId('spa-route-content');
+
+    expect(routeContent.closest('[data-testid="market-auth-provider"]')).not.toBeNull();
+  });
+});

--- a/src/layout/SPAGlobalProvider/index.tsx
+++ b/src/layout/SPAGlobalProvider/index.tsx
@@ -11,6 +11,7 @@ import { isDesktop } from '@/const/version';
 import AgentMockDevtools from '@/features/AgentMockDevtools';
 import DevFeatureFlagPanel from '@/features/DevFeatureFlagPanel';
 import AuthProvider from '@/layout/AuthProvider';
+import { MarketAuthProvider } from '@/layout/AuthProvider/MarketAuth';
 import AppTheme from '@/layout/GlobalProvider/AppTheme';
 import CacheHydrationGate from '@/layout/GlobalProvider/CacheHydrationGate';
 import DynamicFavicon from '@/layout/GlobalProvider/DynamicFavicon';
@@ -50,31 +51,33 @@ const SPAGlobalProvider = memo<PropsWithChildren>(({ children }) => {
         >
           <QueryProvider>
             <AuthProvider>
-              <StoreInitialization />
+              <MarketAuthProvider isDesktop={isDesktop}>
+                <StoreInitialization />
 
-              {isDesktop && <ServerVersionOutdatedAlert />}
-              <FaviconProvider>
-                <DynamicFavicon />
-                <GroupWizardProvider>
-                  <DragUploadProvider>
-                    <LazyMotion features={domMax}>
-                      <TooltipGroup layoutAnimation={false}>
-                        <StyleProvider speedy={import.meta.env.PROD}>
-                          <LobeAnalyticsProviderWrapper>
-                            <CacheHydrationGate>{children}</CacheHydrationGate>
-                          </LobeAnalyticsProviderWrapper>
-                        </StyleProvider>
-                      </TooltipGroup>
-                      <Suspense>
-                        <ModalHost />
-                        <BaseModalHost />
-                        <ToastHost />
-                        <ContextMenuHost />
-                      </Suspense>
-                    </LazyMotion>
-                  </DragUploadProvider>
-                </GroupWizardProvider>
-              </FaviconProvider>
+                {isDesktop && <ServerVersionOutdatedAlert />}
+                <FaviconProvider>
+                  <DynamicFavicon />
+                  <GroupWizardProvider>
+                    <DragUploadProvider>
+                      <LazyMotion features={domMax}>
+                        <TooltipGroup layoutAnimation={false}>
+                          <StyleProvider speedy={import.meta.env.PROD}>
+                            <LobeAnalyticsProviderWrapper>
+                              <CacheHydrationGate>{children}</CacheHydrationGate>
+                            </LobeAnalyticsProviderWrapper>
+                          </StyleProvider>
+                        </TooltipGroup>
+                        <Suspense>
+                          <ModalHost />
+                          <BaseModalHost />
+                          <ToastHost />
+                          <ContextMenuHost />
+                        </Suspense>
+                      </LazyMotion>
+                    </DragUploadProvider>
+                  </GroupWizardProvider>
+                </FaviconProvider>
+              </MarketAuthProvider>
             </AuthProvider>
           </QueryProvider>
           <Suspense>

--- a/src/routes/(main)/_layout/index.tsx
+++ b/src/routes/(main)/_layout/index.tsx
@@ -26,7 +26,6 @@ import HotkeyHelperPanel from '@/features/HotkeyHelperPanel';
 import NavPanel from '@/features/NavPanel';
 import { RouteMetaBridge } from '@/features/RouteMeta';
 import { usePlatform } from '@/hooks/usePlatform';
-import { MarketAuthProvider } from '@/layout/AuthProvider/MarketAuth';
 import CmdkLazy from '@/layout/GlobalProvider/CmdkLazy';
 import dynamic from '@/libs/next/dynamic';
 import { DndContextWrapper } from '@/routes/(main)/resource/features/DndContextWrapper';
@@ -78,14 +77,12 @@ const Layout: FC = () => {
           >
             <NavPanel />
             <DesktopLayoutContainer>
-              <MarketAuthProvider isDesktop={isDesktop}>
-                <DesktopHomeLayout>
-                  <DesktopHome />
-                </DesktopHomeLayout>
-                <Suspense fallback={<Loading debugId="DesktopMainLayout > Outlet" />}>
-                  <Outlet />
-                </Suspense>
-              </MarketAuthProvider>
+              <DesktopHomeLayout>
+                <DesktopHome />
+              </DesktopHomeLayout>
+              <Suspense fallback={<Loading debugId="DesktopMainLayout > Outlet" />}>
+                <Outlet />
+              </Suspense>
             </DesktopLayoutContainer>
           </Flexbox>
         </DndContextWrapper>

--- a/src/routes/(mobile)/_layout/index.tsx
+++ b/src/routes/(mobile)/_layout/index.tsx
@@ -7,7 +7,6 @@ import { Outlet, useLocation } from 'react-router';
 import WorkspaceContextSlot from '@/business/client/WorkspaceContextSlot';
 import Loading from '@/components/Loading/BrandTextLoading';
 import { RouteMetaBridge } from '@/features/RouteMeta';
-import { MarketAuthProvider } from '@/layout/AuthProvider/MarketAuth';
 import dynamic from '@/libs/next/dynamic';
 import { featureFlagsSelectors, useServerConfigStore } from '@/store/serverConfig';
 
@@ -34,12 +33,10 @@ const MobileMainLayout: FC = () => {
     <WorkspaceContextSlot>
       <RouteMetaBridge />
       <Suspense fallback={null}>{showCloudPromotion && <CloudBanner mobile />}</Suspense>
-      <MarketAuthProvider isDesktop={false}>
-        <Suspense fallback={<Loading debugId="MobileMainLayout > Outlet" />}>
-          <Outlet />
-          {showNav && <NavBar />}
-        </Suspense>
-      </MarketAuthProvider>
+      <Suspense fallback={<Loading debugId="MobileMainLayout > Outlet" />}>
+        <Outlet />
+        {showNav && <NavBar />}
+      </Suspense>
     </WorkspaceContextSlot>
   );
 };

--- a/src/routes/(popup)/_layout/index.tsx
+++ b/src/routes/(popup)/_layout/index.tsx
@@ -7,9 +7,7 @@ import { type FC } from 'react';
 import { HotkeysProvider } from 'react-hotkeys-hook';
 import { Outlet } from 'react-router';
 
-import { isDesktop } from '@/const/version';
 import ProtocolUrlHandler from '@/features/ProtocolUrlHandler';
-import { MarketAuthProvider } from '@/layout/AuthProvider/MarketAuth';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 
@@ -26,20 +24,18 @@ const PopupLayout: FC = () => {
 
   return (
     <HotkeysProvider initiallyActiveScopes={[HotkeyScopeEnum.Global]}>
-      <MarketAuthProvider isDesktop={isDesktop}>
-        <Flexbox
-          className={styles.container}
-          height={'100%'}
-          style={{ overflow: 'hidden' }}
-          width={'100%'}
-        >
-          <PopupTitleBar title={topicTitle} />
-          <Flexbox flex={1} style={{ minHeight: 0, overflow: 'hidden', position: 'relative' }}>
-            <Outlet />
-          </Flexbox>
-          <ProtocolUrlHandler />
+      <Flexbox
+        className={styles.container}
+        height={'100%'}
+        style={{ overflow: 'hidden' }}
+        width={'100%'}
+      >
+        <PopupTitleBar title={topicTitle} />
+        <Flexbox flex={1} style={{ minHeight: 0, overflow: 'hidden', position: 'relative' }}>
+          <Outlet />
         </Flexbox>
-      </MarketAuthProvider>
+        <ProtocolUrlHandler />
+      </Flexbox>
     </HotkeysProvider>
   );
 };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A - user-reported crash from the homepage task-template modal flow.

Related cloud PR: https://github.com/lobehub-biz/lobehub-cloud/pull/821

#### 🔀 Description of Change

- Move `MarketAuthProvider` up into `SPAGlobalProvider` so route content and imperative SPA modal hosts share the same Market auth context.
- Remove the duplicate route-level Market auth providers from main, mobile, and popup layouts.
- Add a regression test that keeps SPA route content under the global Market auth provider.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated tests:

- `rtk vitest run src/layout/SPAGlobalProvider/index.test.tsx`
- `vscode-cli get-diagnostics`

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This keeps the fix in the open-source SPA provider layer and does not expose any cloud-specific business logic.
