### PR TITLE
⚡️ perf: persist model config cache

### DIFF
--- a/src/libs/swr/localStorageProvider.test.ts
+++ b/src/libs/swr/localStorageProvider.test.ts
@@ -93,6 +93,24 @@ describe('createCacheProvider — tiering', () => {
     expect(await localDataCache.entriesByScope('s1')).toEqual([]);
   });
 
+  it('persists model config keys in the local tier', async () => {
+    const scope = { value: 's1' };
+    const { provider } = buildProvider(scope, {
+      idbPatterns: [...CACHE_TIERS.idb],
+      localPatterns: [...CACHE_TIERS.local],
+    });
+    const map = provider();
+    const key = 'modelConfig:lobehub';
+
+    map.set(key, { data: { homeNewModels: [{ model: 'gpt-image-2', type: 'image' }] } });
+
+    await until(() => localStorage.getItem(getScopedCacheKey('s1')) !== null);
+
+    const stored = JSON.parse(localStorage.getItem(getScopedCacheKey('s1'))!);
+    expect(stored.map(([k]: [string]) => k)).toContain(key);
+    expect(await localDataCache.entriesByScope('s1')).toEqual([]);
+  });
+
   it('routes idb-tier keys to IndexedDB and reloads them on a fresh provider', async () => {
     const scope = { value: 's1' };
     const { provider } = buildProvider(scope);
@@ -212,6 +230,7 @@ describe('createCacheProvider — tiering', () => {
     expect(CACHE_TIERS.idb).toContain('topic:');
     expect(CACHE_TIERS.local).toContain('recent:list');
     expect(CACHE_TIERS.local).toContain('taskTemplate:');
+    expect(CACHE_TIERS.local).toContain('modelConfig:');
   });
 });
 

--- a/src/libs/swr/localStorageProvider.ts
+++ b/src/libs/swr/localStorageProvider.ts
@@ -441,6 +441,7 @@ export const CACHE_TIERS = {
     'fetchRecentPages',
     'group:list',
     'taskTemplate:', // home task-template recommendations
+    'modelConfig:', // small remote model config shells used by home starter chips
   ],
 } as const;
 


### PR DESCRIPTION
## 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

## 🔗 Related Links

- Linear / GitHub issue: N/A
- Related PRs: N/A
- Reference docs / code / articles: `src/libs/swr/localStorageProvider.ts`

## 🔀 Description of Change

Persist `modelConfig:` SWR keys in the existing localStorage cache tier so small remote model config payloads can be restored on the next app load.

## 🧭 Key Decisions / Non-goals

- Keep this in the generic SWR tier config instead of adding feature-specific localStorage reads in the home UI.
- Store this in the localStorage tier because the model config shell is small and useful for synchronous first paint; IndexedDB remains reserved for larger entity data.
- This does not add cloud-specific business logic to the open-source submodule.

## 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

### Automated Tests

- `rtk vitest run src/libs/swr/localStorageProvider.test.ts`

### Manual Verification

- `vscode-cli get-diagnostics`

### Post-Deploy Verification

- Verify the home starter chips still render after a fresh load and continue using cached model config data before the network refresh completes.

## 📸 Screenshots / Videos

N/A

## 🚀 Rollout / Deployment Checklist

- [x] Environment variables: N/A
- [x] Redis / Edge Config / feature flags: N/A
- [x] Database migration or data backfill: N/A
- [x] Third-party console changes: N/A
- [x] Rollback plan: revert this PR

## 📝 Additional Information

N/A