### PR TITLE
✨ feat: inject model knowledge cutoff

### DIFF
--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -72,7 +72,7 @@ import {
 } from '@lobechat/types';
 import { sanitizeToolCallArguments, serializePartsForStorage } from '@lobechat/utils';
 import debug from 'debug';
-import type { ExtendParamsType } from 'model-bank';
+import { type ExtendParamsType, ModelProvider } from 'model-bank';
 
 import { composioEnv } from '@/config/composio';
 import { type MessageModel, MessageModel as MessageModelClass } from '@/database/models/message';
@@ -911,6 +911,12 @@ export const createRuntimeExecutors = (
             item.providerId === provider &&
             (item.id === model || item.config?.deploymentName === model),
         );
+        const canonicalModelCard = builtinModels.find(
+          (item) => item.id === model || item.config?.deploymentName === model,
+        );
+        const modelKnowledgeCutoff =
+          modelCard?.knowledgeCutoff ??
+          (provider === ModelProvider.LobeHub ? canonicalModelCard?.knowledgeCutoff : undefined);
 
         let modelExtendParams = readExtendParams(modelCard);
 
@@ -920,10 +926,7 @@ export const createRuntimeExecutors = (
         // `thinkingLevel` still reach the model. Mirrors the client-side
         // `transformToAiModelList` re-namespacing behavior.
         if (!modelExtendParams || modelExtendParams.length === 0) {
-          const canonicalCard = builtinModels.find(
-            (item) => item.id === model || item.config?.deploymentName === model,
-          );
-          modelExtendParams = readExtendParams(canonicalCard);
+          modelExtendParams = readExtendParams(canonicalModelCard);
         }
 
         const modelSupportsPreserveThinkingFromCard =
@@ -1300,6 +1303,7 @@ export const createRuntimeExecutors = (
           },
           messages: messagesForContext,
           model,
+          modelKnowledgeCutoff,
           provider,
           systemRole: agentConfig.systemRole ?? undefined,
           toolDiscoveryConfig,

--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -14,6 +14,7 @@ const mockBuiltinModels = vi.hoisted(() => [
   {
     abilities: { functionCall: true, video: false, vision: true },
     id: 'gpt-4',
+    knowledgeCutoff: '2024-06',
     providerId: 'openai',
   },
   {
@@ -77,6 +78,9 @@ vi.mock('@/business/client/model-bank/loadModels', () => ({
 // model-bank is a TypeScript source file that cannot be dynamically imported in vitest
 vi.mock('model-bank', () => ({
   LOBE_DEFAULT_MODEL_LIST: mockBuiltinModels,
+  ModelProvider: {
+    LobeHub: 'lobehub',
+  },
 }));
 
 // composioEnv uses @t3-oss/env-nextjs which throws in jsdom (treats it as client context)
@@ -1573,6 +1577,87 @@ describe('RuntimeExecutors', () => {
         expect(chatMessages.at(-1)).toEqual(
           expect.objectContaining({ content: 'Hello', role: 'user' }),
         );
+      });
+
+      it('should pass model knowledge cutoff into serverMessagesEngine', async () => {
+        const ctxWithConfig: RuntimeExecutorContext = {
+          ...ctx,
+          agentConfig: {
+            plugins: [],
+            systemRole: 'You are a helpful assistant',
+          },
+        };
+        const executors = createRuntimeExecutors(ctxWithConfig);
+        const state = createMockState();
+
+        const instruction = {
+          payload: {
+            messages: [{ content: 'Hello', role: 'user' }],
+            model: 'gpt-4',
+            provider: 'openai',
+          },
+          type: 'call_llm' as const,
+        };
+
+        await executors.call_llm!(instruction, state);
+
+        expect(engineSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ modelKnowledgeCutoff: '2024-06' }),
+        );
+      });
+
+      it('should resolve LobeHub routed model knowledge cutoff by model id fallback', async () => {
+        const ctxWithConfig: RuntimeExecutorContext = {
+          ...ctx,
+          agentConfig: {
+            plugins: [],
+            systemRole: 'You are a helpful assistant',
+          },
+        };
+        const executors = createRuntimeExecutors(ctxWithConfig);
+        const state = createMockState();
+
+        await executors.call_llm!(
+          {
+            payload: {
+              messages: [{ content: 'Hello', role: 'user' }],
+              model: 'gpt-4',
+              provider: 'lobehub',
+            },
+            type: 'call_llm' as const,
+          },
+          state,
+        );
+
+        expect(engineSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ modelKnowledgeCutoff: '2024-06' }),
+        );
+      });
+
+      it('should omit model knowledge cutoff for unknown non-LobeHub providers', async () => {
+        const ctxWithConfig: RuntimeExecutorContext = {
+          ...ctx,
+          agentConfig: {
+            plugins: [],
+            systemRole: 'You are a helpful assistant',
+          },
+        };
+        const executors = createRuntimeExecutors(ctxWithConfig);
+        const state = createMockState();
+
+        await executors.call_llm!(
+          {
+            payload: {
+              messages: [{ content: 'Hello', role: 'user' }],
+              model: 'gpt-4',
+              provider: 'custom-openai',
+            },
+            type: 'call_llm' as const,
+          },
+          state,
+        );
+
+        expect(engineSpy.mock.calls[0][0]).toHaveProperty('modelKnowledgeCutoff', undefined);
       });
 
       it('should keep current turn when agent historyCount is 0', async () => {

--- a/apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts
@@ -70,6 +70,25 @@ describe('serverMessagesEngine', () => {
       expect(result[0].content).toBe(systemRole + '\n\n' + getCurrentDateContent());
     });
 
+    it('should inject model knowledge cutoff when provided', async () => {
+      const messages = createBasicMessages();
+
+      const result = await serverMessagesEngine({
+        messages,
+        model: 'gpt-4',
+        modelKnowledgeCutoff: '2024-06',
+        provider: 'openai',
+        systemRole: 'You are a helpful assistant',
+      });
+
+      expect(result[0].role).toBe('system');
+      expect(result[0].content).toBe(
+        'You are a helpful assistant\n\n' +
+          getCurrentDateContent() +
+          '\n\nModel knowledge cutoff: 2024-06',
+      );
+    });
+
     it('should handle empty messages', async () => {
       const result = await serverMessagesEngine({
         messages: [],

--- a/apps/server/src/modules/Mecha/ContextEngineering/index.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/index.ts
@@ -51,6 +51,7 @@ const createServerVariableGenerators = (params: {
 export const serverMessagesEngine = async ({
   messages = [],
   model,
+  modelKnowledgeCutoff,
   provider,
   systemRole,
   inputTemplate,
@@ -121,6 +122,7 @@ export const serverMessagesEngine = async ({
 
     // Model info
     model,
+    modelKnowledgeCutoff,
 
     provider,
     systemRole,

--- a/apps/server/src/modules/Mecha/ContextEngineering/types.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/types.ts
@@ -132,6 +132,8 @@ export interface ServerMessagesEngineParams {
 
   /** Model ID */
   model: string;
+  /** Model knowledge cutoff date, e.g. `2024-06`. Omit when unknown. */
+  modelKnowledgeCutoff?: string;
 
   /** Page content context (optional, for document editing) */
   pageContentContext?: PageContentContext;

--- a/packages/context-engine/src/engine/messages/MessagesEngine.ts
+++ b/packages/context-engine/src/engine/messages/MessagesEngine.ts
@@ -41,6 +41,7 @@ import {
   HistorySummaryProvider,
   KnowledgeInjector,
   LocalSystemToolSnapshotInjector,
+  ModelKnowledgeCutoffProvider,
   OnboardingActionHintInjector,
   OnboardingContextInjector,
   OnboardingSyntheticStateInjector,
@@ -136,6 +137,7 @@ export class MessagesEngine {
   private buildProcessors(): ContextProcessor[] {
     const {
       model,
+      modelKnowledgeCutoff,
       provider,
       systemRole,
       inputTemplate,
@@ -244,6 +246,8 @@ export class MessagesEngine {
       }),
       // System date
       new SystemDateProvider({ enabled: isSystemDateEnabled, timezone }),
+      // Model knowledge cutoff
+      new ModelKnowledgeCutoffProvider({ knowledgeCutoff: modelKnowledgeCutoff }),
       // Skill context (available skills list + activated skill content).
       // Disabled in chat mode — pairs with the tools-engine gate so the LLM
       // sees neither the manifests nor the discovery prompt.

--- a/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts
+++ b/packages/context-engine/src/engine/messages/__tests__/MessagesEngine.test.ts
@@ -114,6 +114,35 @@ describe('MessagesEngine', () => {
       expect(result.messages[0].content).toBe(systemRole);
     });
 
+    it('should inject model knowledge cutoff when provided', async () => {
+      const params = createBasicParams({
+        modelKnowledgeCutoff: '2024-06',
+        systemRole: 'You are a helpful assistant',
+      });
+      const engine = new MessagesEngine(params);
+
+      const result = await engine.process();
+
+      expect(result.messages[0]).toEqual({
+        content: 'You are a helpful assistant\n\nModel knowledge cutoff: 2024-06',
+        role: 'system',
+      });
+      expect(result.metadata.modelKnowledgeCutoffInjected).toBe(true);
+    });
+
+    it('should skip model knowledge cutoff injection when unknown', async () => {
+      const params = createBasicParams({ systemRole: 'You are a helpful assistant' });
+      const engine = new MessagesEngine(params);
+
+      const result = await engine.process();
+
+      expect(result.messages[0]).toEqual({
+        content: 'You are a helpful assistant',
+        role: 'system',
+      });
+      expect(result.metadata.modelKnowledgeCutoffInjected).toBeUndefined();
+    });
+
     it('should inject history summary when provided', async () => {
       const historySummary = 'We discussed AI and machine learning';
       const params = createBasicParams({ historySummary });

--- a/packages/context-engine/src/engine/messages/types.ts
+++ b/packages/context-engine/src/engine/messages/types.ts
@@ -215,6 +215,8 @@ export interface MessagesEngineParams {
   messages: UIChatMessage[];
   /** Model ID */
   model: string;
+  /** Model knowledge cutoff date, e.g. `2024-06`. Omit when unknown. */
+  modelKnowledgeCutoff?: string;
   /** Provider ID */
   provider: string;
 

--- a/packages/context-engine/src/providers/ModelKnowledgeCutoffProvider.ts
+++ b/packages/context-engine/src/providers/ModelKnowledgeCutoffProvider.ts
@@ -1,0 +1,48 @@
+import debug from 'debug';
+
+import { BaseSystemRoleProvider } from '../base/BaseSystemRoleProvider';
+import type { PipelineContext, ProcessorOptions } from '../types';
+
+declare module '../types' {
+  interface PipelineContextMetadataOverrides {
+    modelKnowledgeCutoffInjected?: boolean;
+  }
+}
+
+const log = debug('context-engine:provider:ModelKnowledgeCutoffProvider');
+
+export interface ModelKnowledgeCutoffProviderConfig {
+  enabled?: boolean;
+  knowledgeCutoff?: string;
+}
+
+export class ModelKnowledgeCutoffProvider extends BaseSystemRoleProvider {
+  readonly name = 'ModelKnowledgeCutoffProvider';
+
+  constructor(
+    private config: ModelKnowledgeCutoffProviderConfig = {},
+    options: ProcessorOptions = {},
+  ) {
+    super(options);
+  }
+
+  protected buildSystemRoleContent(_context: PipelineContext): string | null {
+    if (this.config.enabled === false) {
+      log('Model knowledge cutoff injection disabled, skipping');
+      return null;
+    }
+
+    const knowledgeCutoff = this.config.knowledgeCutoff?.trim();
+
+    if (!knowledgeCutoff) {
+      log('No model knowledge cutoff configured, skipping injection');
+      return null;
+    }
+
+    return `Model knowledge cutoff: ${knowledgeCutoff}`;
+  }
+
+  protected onInjected(context: PipelineContext): void {
+    context.metadata.modelKnowledgeCutoffInjected = true;
+  }
+}

--- a/packages/context-engine/src/providers/__tests__/ModelKnowledgeCutoffProvider.test.ts
+++ b/packages/context-engine/src/providers/__tests__/ModelKnowledgeCutoffProvider.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import { ModelKnowledgeCutoffProvider } from '../ModelKnowledgeCutoffProvider';
+
+const createContext = (messages: any[] = []) => ({
+  initialState: {
+    messages: [],
+    model: 'gpt-4',
+    provider: 'openai',
+    systemRole: '',
+    tools: [],
+  },
+  isAborted: false,
+  messages,
+  metadata: {
+    maxTokens: 4096,
+    model: 'gpt-4',
+  },
+});
+
+describe('ModelKnowledgeCutoffProvider', () => {
+  it('should inject model knowledge cutoff', async () => {
+    const provider = new ModelKnowledgeCutoffProvider({ knowledgeCutoff: '2024-06' });
+    const context = createContext([
+      { content: 'Hello', createdAt: Date.now(), id: '1', role: 'user', updatedAt: Date.now() },
+    ]);
+
+    const result = await provider.process(context);
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0].role).toBe('system');
+    expect(result.messages[0].content).toBe('Model knowledge cutoff: 2024-06');
+    expect(result.metadata.modelKnowledgeCutoffInjected).toBe(true);
+  });
+
+  it('should append cutoff to existing system message', async () => {
+    const provider = new ModelKnowledgeCutoffProvider({ knowledgeCutoff: '2024-06' });
+    const context = createContext([
+      {
+        content: 'You are a helpful assistant.',
+        createdAt: Date.now(),
+        id: 'sys',
+        role: 'system',
+        updatedAt: Date.now(),
+      },
+      { content: 'Hello', createdAt: Date.now(), id: '1', role: 'user', updatedAt: Date.now() },
+    ]);
+
+    const result = await provider.process(context);
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0].content).toBe(
+      'You are a helpful assistant.\n\nModel knowledge cutoff: 2024-06',
+    );
+    expect(result.metadata.modelKnowledgeCutoffInjected).toBe(true);
+  });
+
+  it('should trim cutoff before injection', async () => {
+    const provider = new ModelKnowledgeCutoffProvider({ knowledgeCutoff: '  2024-06  ' });
+    const context = createContext([]);
+
+    const result = await provider.process(context);
+
+    expect(result.messages[0].content).toBe('Model knowledge cutoff: 2024-06');
+  });
+
+  it('should skip injection when cutoff is missing', async () => {
+    const provider = new ModelKnowledgeCutoffProvider({});
+    const context = createContext([
+      { content: 'Hello', createdAt: Date.now(), id: '1', role: 'user', updatedAt: Date.now() },
+    ]);
+
+    const result = await provider.process(context);
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.metadata.modelKnowledgeCutoffInjected).toBeUndefined();
+  });
+
+  it('should skip injection when disabled', async () => {
+    const provider = new ModelKnowledgeCutoffProvider({
+      enabled: false,
+      knowledgeCutoff: '2024-06',
+    });
+    const context = createContext([
+      { content: 'Hello', createdAt: Date.now(), id: '1', role: 'user', updatedAt: Date.now() },
+    ]);
+
+    const result = await provider.process(context);
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.metadata.modelKnowledgeCutoffInjected).toBeUndefined();
+  });
+});

--- a/packages/context-engine/src/providers/index.ts
+++ b/packages/context-engine/src/providers/index.ts
@@ -19,6 +19,7 @@ export { GroupContextInjector } from './GroupContextInjector';
 export { HistorySummaryProvider } from './HistorySummary';
 export { KnowledgeInjector } from './KnowledgeInjector';
 export { LocalSystemToolSnapshotInjector } from './LocalSystemToolSnapshotInjector';
+export { ModelKnowledgeCutoffProvider } from './ModelKnowledgeCutoffProvider';
 export { OnboardingActionHintInjector } from './OnboardingActionHintInjector';
 export { OnboardingContextInjector } from './OnboardingContextInjector';
 export { OnboardingSyntheticStateInjector } from './OnboardingSyntheticStateInjector';
@@ -90,6 +91,7 @@ export type {
 export type { HistorySummaryConfig } from './HistorySummary';
 export type { KnowledgeInjectorConfig } from './KnowledgeInjector';
 export type { LocalSystemToolSnapshotInjectorConfig } from './LocalSystemToolSnapshotInjector';
+export type { ModelKnowledgeCutoffProviderConfig } from './ModelKnowledgeCutoffProvider';
 export type {
   OnboardingContext,
   OnboardingContextInjectorConfig,

--- a/packages/model-bank/src/aiModels/__tests__/index.test.ts
+++ b/packages/model-bank/src/aiModels/__tests__/index.test.ts
@@ -62,6 +62,11 @@ describe('loadModels', () => {
 
 describe('knowledgeCutoff backfill', () => {
   it('fills knowledgeCutoff from the canonical map for builtin models', () => {
+    const fable = LOBE_DEFAULT_MODEL_LIST.find(
+      (m) => m.providerId === 'anthropic' && m.id === 'claude-fable-5',
+    );
+    expect(fable?.knowledgeCutoff).toBe('2026-01');
+
     const opus = LOBE_DEFAULT_MODEL_LIST.find(
       (m) => m.providerId === 'anthropic' && m.id === 'claude-opus-4-8',
     );
@@ -72,6 +77,11 @@ describe('knowledgeCutoff backfill', () => {
       (m) => m.providerId === 'bedrock' && m.id === 'global.anthropic.claude-opus-4-7',
     );
     expect(bedrockOpus?.knowledgeCutoff).toBe('2026-01');
+
+    const vertexGemini3Pro = LOBE_DEFAULT_MODEL_LIST.find(
+      (m) => m.providerId === 'vertexai' && m.id === 'gemini-3-pro-preview',
+    );
+    expect(vertexGemini3Pro?.knowledgeCutoff).toBe('2025-01');
   });
 
   it('keeps an explicit knowledgeCutoff over the map value', async () => {

--- a/packages/model-bank/src/aiModels/anthropic.ts
+++ b/packages/model-bank/src/aiModels/anthropic.ts
@@ -17,6 +17,7 @@ const anthropicChatModels: AIChatModelCard[] = [
     family: 'claude-mythos',
     generation: 'mythos-5',
     id: 'claude-fable-5',
+    knowledgeCutoff: '2026-01',
     maxOutput: 128_000,
     pricing: {
       units: [

--- a/packages/model-bank/src/aiModels/vertexai.ts
+++ b/packages/model-bank/src/aiModels/vertexai.ts
@@ -264,7 +264,10 @@ const vertexaiChatModels: AIChatModelCard[] = [
     description:
       'Gemini 3 Pro is Google’s most powerful agent and vibe-coding model, delivering richer visuals and deeper interaction on top of state-of-the-art reasoning.',
     displayName: 'Gemini 3 Pro Preview',
+    family: 'gemini',
+    generation: 'gemini-3',
     id: 'gemini-3-pro-preview', // deprecated on 2026-03-26
+    knowledgeCutoff: '2025-01',
     maxOutput: 65_536,
     pricing: {
       units: [

--- a/packages/model-bank/src/const/knowledgeCutoff.ts
+++ b/packages/model-bank/src/const/knowledgeCutoff.ts
@@ -17,6 +17,7 @@ export const MODEL_KNOWLEDGE_CUTOFFS: Record<string, string> = {
   'claude-3-haiku': '2023-08',
   'claude-3-opus': '2023-08',
   'claude-3-sonnet': '2023-08',
+  'claude-fable-5': '2026-01',
   'claude-haiku-4-5': '2025-02',
   'claude-opus-4': '2025-01',
   'claude-opus-4-1': '2025-01',

--- a/src/services/chat/helper.test.ts
+++ b/src/services/chat/helper.test.ts
@@ -3,7 +3,12 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { useAiInfraStore } from '@/store/aiInfra';
 
-import { isCanUseAudio, isCanUseVideo, isCanUseVision } from './helper';
+import {
+  getRuntimeModelKnowledgeCutoff,
+  isCanUseAudio,
+  isCanUseVideo,
+  isCanUseVision,
+} from './helper';
 
 describe('chat helper', () => {
   afterEach(() => {
@@ -42,5 +47,54 @@ describe('chat helper', () => {
     expect(isCanUseVision('gemini-3.1-flash-lite-preview', ModelProvider.OpenAI)).toBe(false);
     expect(isCanUseVideo('gemini-3.1-flash-lite-preview', ModelProvider.OpenAI)).toBe(false);
     expect(isCanUseAudio('gemini-3.1-flash-lite-preview', ModelProvider.OpenAI)).toBe(false);
+  });
+
+  it('should resolve exact model knowledge cutoff', () => {
+    useAiInfraStore.setState({
+      enabledAiModels: [
+        {
+          id: 'gpt-4o',
+          knowledgeCutoff: '2023-10',
+          providerId: ModelProvider.OpenAI,
+          type: 'chat',
+        } as EnabledAiModel,
+      ],
+    });
+
+    expect(getRuntimeModelKnowledgeCutoff('gpt-4o', ModelProvider.OpenAI)).toBe('2023-10');
+  });
+
+  it('should resolve LobeHub routed model knowledge cutoff by model id fallback', () => {
+    useAiInfraStore.setState({
+      enabledAiModels: [
+        {
+          id: 'gemini-3.1-flash-lite-preview',
+          knowledgeCutoff: '2025-01',
+          providerId: ModelProvider.Google,
+          type: 'chat',
+        } as EnabledAiModel,
+      ],
+    });
+
+    expect(
+      getRuntimeModelKnowledgeCutoff('gemini-3.1-flash-lite-preview', ModelProvider.LobeHub),
+    ).toBe('2025-01');
+  });
+
+  it('should not fallback model knowledge cutoff across non-LobeHub providers', () => {
+    useAiInfraStore.setState({
+      enabledAiModels: [
+        {
+          id: 'gemini-3.1-flash-lite-preview',
+          knowledgeCutoff: '2025-01',
+          providerId: ModelProvider.Google,
+          type: 'chat',
+        } as EnabledAiModel,
+      ],
+    });
+
+    expect(
+      getRuntimeModelKnowledgeCutoff('gemini-3.1-flash-lite-preview', ModelProvider.OpenAI),
+    ).toBeUndefined();
   });
 });

--- a/src/services/chat/helper.ts
+++ b/src/services/chat/helper.ts
@@ -1,17 +1,25 @@
+import type { EnabledAiModel } from 'model-bank';
 import { ModelProvider } from 'model-bank';
 
 import { getAiInfraStoreState } from '@/store/aiInfra';
 import { aiProviderSelectors } from '@/store/aiInfra/selectors';
 
-const getModelAbilities = (model: string, provider: string) => {
+export const getEnabledRuntimeModel = (
+  model: string,
+  provider: string,
+): EnabledAiModel | undefined => {
   const state = getAiInfraStoreState();
   const exactModel = state.enabledAiModels?.find(
     (item) => item.id === model && item.providerId === provider,
   );
 
-  if (exactModel || provider !== ModelProvider.LobeHub) return exactModel?.abilities;
+  if (exactModel || provider !== ModelProvider.LobeHub) return exactModel;
 
-  return state.enabledAiModels?.find((item) => item.id === model)?.abilities;
+  return state.enabledAiModels?.find((item) => item.id === model);
+};
+
+const getModelAbilities = (model: string, provider: string) => {
+  return getEnabledRuntimeModel(model, provider)?.abilities;
 };
 
 export const isCanUseVision = (model: string, provider: string): boolean => {
@@ -25,6 +33,11 @@ export const isCanUseVideo = (model: string, provider: string): boolean => {
 export const isCanUseAudio = (model: string, provider: string): boolean => {
   return getModelAbilities(model, provider)?.audio || false;
 };
+
+export const getRuntimeModelKnowledgeCutoff = (
+  model: string,
+  provider: string,
+): string | undefined => getEnabledRuntimeModel(model, provider)?.knowledgeCutoff;
 
 /**
  * TODO: we need to update this function to auto find deploymentName with provider setting config

--- a/src/services/chat/mecha/contextEngineering.test.ts
+++ b/src/services/chat/mecha/contextEngineering.test.ts
@@ -187,6 +187,23 @@ describe('contextEngineering', () => {
     expect(agentService.queryAgents).toHaveBeenCalledWith({ limit: 12 });
   });
 
+  it('should inject runtime model knowledge cutoff', async () => {
+    vi.spyOn(helpers, 'getRuntimeModelKnowledgeCutoff').mockReturnValue('2024-06');
+
+    const output = await contextEngineering({
+      messages: [{ content: 'Hello', role: 'user' }] as UIChatMessage[],
+      model: 'gpt-4',
+      provider: 'openai',
+      systemRole: 'You are a helpful assistant',
+    });
+
+    expect(helpers.getRuntimeModelKnowledgeCutoff).toHaveBeenCalledWith('gpt-4', 'openai');
+    expect(output[0]).toEqual({
+      content: expect.stringContaining('Model knowledge cutoff: 2024-06'),
+      role: 'system',
+    });
+  });
+
   describe('handle with files content in server mode', () => {
     it('should includes files', async () => {
       runtimeFlags.isServerMode = true;

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -69,7 +69,12 @@ import {
 } from '@/store/tool/selectors';
 import { ComposioServerStatus } from '@/store/tool/slices/composioStore';
 
-import { isCanUseAudio, isCanUseVideo, isCanUseVision } from '../helper';
+import {
+  getRuntimeModelKnowledgeCutoff,
+  isCanUseAudio,
+  isCanUseVideo,
+  isCanUseVision,
+} from '../helper';
 import { combineUserMemoryData, resolveTopicMemories, resolveUserPersona } from './memoryManager';
 import { resolveClientSkills } from './skillEngineering';
 
@@ -691,6 +696,7 @@ export const contextEngineering = async ({
 
     // Model info
     model,
+    modelKnowledgeCutoff: getRuntimeModelKnowledgeCutoff(model, provider),
     provider,
 
     // runtime context

--- a/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
+++ b/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
@@ -68,14 +68,30 @@ describe('aiProvider action helpers', () => {
       const model = {
         ...createChatModel({ id: 'online-chat-model', providerId: 'lobehub' }),
         description: 'Inline description',
+        knowledgeCutoff: '2024-06',
         pricing,
       };
 
       const result = await normalizeChatModel(model);
 
       expect(result.description).toBe('Inline description');
+      expect(result.knowledgeCutoff).toBe('2024-06');
       expect(result.pricing).toBe(pricing);
       expect(fallbackSpy).not.toHaveBeenCalled();
+    });
+
+    it('fetches fallback model knowledge cutoff when missing', async () => {
+      const fallbackSpy = vi
+        .mocked(runtimeModule.getModelPropertyWithFallback)
+        .mockImplementation(async (_id, key) => {
+          if (key === 'knowledgeCutoff') return '2024-06';
+          return undefined;
+        });
+
+      const result = await normalizeChatModel(createChatModel({ id: 'gpt-4o' }));
+
+      expect(result.knowledgeCutoff).toBe('2024-06');
+      expect(fallbackSpy).toHaveBeenCalledWith('gpt-4o', 'knowledgeCutoff', 'openai');
     });
   });
 

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -42,6 +42,7 @@ export type ProviderModelListItem = {
   description?: string;
   displayName: string;
   id: string;
+  knowledgeCutoff?: string;
   parameters?: ModelParamsSchema;
   pricePerImage?: number;
   pricePerVideo?: number;
@@ -80,8 +81,9 @@ const createProviderModelCollector = (
 };
 
 export const normalizeChatModel = async (model: EnabledAiModel): Promise<ProviderModelListItem> => {
-  const [description, pricing] = await Promise.all([
+  const [description, knowledgeCutoff, pricing] = await Promise.all([
     getModelProperty<string>(model, 'description'),
+    getModelProperty<string>(model, 'knowledgeCutoff'),
     getModelProperty<Pricing>(model, 'pricing'),
   ]);
 
@@ -92,6 +94,7 @@ export const normalizeChatModel = async (model: EnabledAiModel): Promise<Provide
     id: model.id,
     releasedAt: model.releasedAt,
     ...(description && { description }),
+    ...(knowledgeCutoff && { knowledgeCutoff }),
     ...(pricing && { pricing }),
   };
 };


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-10584

#### 🔀 Description of Change

- Add `ModelKnowledgeCutoffProvider` to inject factual model knowledge cutoff metadata into the system message.
- Pass `modelKnowledgeCutoff` through `MessagesEngine`, client context engineering, and server context engineering.
- Resolve the cutoff from the current runtime model card, with model-id fallback only for LobeHub routed models.
- Preserve `knowledgeCutoff` in normalized provider model lists.
- Backfill missing official-provider metadata for recent Anthropic/Gemini models: `claude-fable-5` and Vertex AI `gemini-3-pro-preview`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated tests:

- `rtk vitest run src/providers/__tests__/ModelKnowledgeCutoffProvider.test.ts` from `packages/context-engine`
- `rtk vitest run src/engine/messages/__tests__/MessagesEngine.test.ts` from `packages/context-engine`
- `rtk vitest run src/services/chat/helper.test.ts`
- `rtk vitest run src/services/chat/mecha/contextEngineering.test.ts`
- `rtk vitest run src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts`
- `rtk vitest run apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts`
- `rtk vitest run apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts`
- `rtk vitest run src/aiModels/__tests__/index.test.ts` from `packages/model-bank`
- `rtk vitest run src/const/__tests__/knowledgeCutoff.test.ts` from `packages/model-bank`
- `bunx tsc --noEmit` from `packages/model-bank`
- `vscode-cli get-diagnostics`

#### 📸 Screenshots / Videos

N/A - no UI changes.

#### 📝 Additional Information

Key decisions:

- Injection is automatic in `MessagesEngine`; individual `systemRole` prompts do not need to hand-write a placeholder.
- Unknown model cutoff values are omitted rather than replaced with a generic fallback.
- This PR only injects factual metadata and does not add a strict freshness guardrail.
- No database, environment variable, or custom-model UI changes are included.
- Official metadata sources used: OpenAI model docs, Anthropic Claude models overview / system prompt release notes, and Google Gemini / Vertex AI model docs.
- DeepSeek official docs currently list V4 model details but do not publish a knowledge cutoff, so DeepSeek remains intentionally empty.