### PR TITLE
🐛 fix(hetero-agent): don't treat an inline tool's task_notification as a post-task summary

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -2590,6 +2590,51 @@ describe('ClaudeCodeAdapter', () => {
       ).toBeUndefined();
     });
 
+    /**
+     * Real-world regression (recorded on tpc_joZS2mksoY5L): a slow `git commit`
+     * (running a lint-staged hook) makes CC track the Bash call as a task and
+     * emit `task_started` + `task_notification` back-to-back, with NO out-of-band
+     * callback turn in between, immediately followed by the tool_result. That is
+     * an inline synchronous tool, not a Monitor-style long-running task — the next
+     * turn is the normal main-chain continuation and must NOT be tagged
+     * `task-completion` (doing so mis-anchors it and drops it from the rendered
+     * chain).
+     */
+    it('does NOT tag the next turn when a task started and ended with no callbacks (inline tool)', () => {
+      const adapter = new ClaudeCodeAdapter();
+      init(adapter);
+
+      // A Bash `git commit` tool_use.
+      adapter.adapt({
+        message: {
+          content: [
+            {
+              id: 'toolu_commit',
+              input: { command: 'git commit' },
+              name: 'Bash',
+              type: 'tool_use',
+            },
+          ],
+          id: 'msg_01',
+        },
+        type: 'assistant',
+      });
+
+      // CC tracks the slow commit as a task, then notifies completion
+      // back-to-back — NO callback turn opened while it was alive.
+      adapter.adapt(ccTaskStarted('task_1', 'toolu_commit'));
+      adapter.adapt(ccTaskNotification('task_1'));
+
+      // The commit's tool_result is consumed inline by the next turn.
+      adapter.adapt(ccUser('toolu_commit', 'committed'));
+
+      // Next turn is plain continuation — must carry NO externalSignal.
+      const next = adapter.adapt(ccMessageStart('msg_02'));
+      expect(
+        next.find((e) => e.type === 'stream_start' && e.data?.newStep)!.data.externalSignal,
+      ).toBeUndefined();
+    });
+
     it('clears unconsumed task-completion lineage on `result`', () => {
       const adapter = new ClaudeCodeAdapter();
       init(adapter);
@@ -2604,13 +2649,18 @@ describe('ClaudeCodeAdapter', () => {
       adapter.adapt(ccTaskStarted('task_1', 'toolu_mon'));
       adapter.adapt(ccUser('toolu_mon', 'Monitor started'));
       adapter.adapt(ccMessageStart('msg_02'));
+      // A signal callback fires while the task is alive (callbackCount > 0), so
+      // `task_notification` genuinely arms pendingTaskCompletion — otherwise (an
+      // inline tool with no callbacks) nothing is armed and this test would pass
+      // vacuously, no longer guarding the `result` clear path.
+      adapter.adapt(ccMessageStart('msg_03'));
       adapter.adapt(ccTaskNotification('task_1'));
       // Run ends before the summary turn fires (unusual but possible).
       adapter.adapt({ result: 'ok', type: 'result', usage: undefined });
 
       // A later turn (e.g. follow-up user message) must NOT inherit
-      // the unconsumed task-completion lineage.
-      const next = adapter.adapt(ccMessageStart('msg_03'));
+      // the unconsumed task-completion lineage — `result` dropped it.
+      const next = adapter.adapt(ccMessageStart('msg_04'));
       expect(
         next.find((e) => e.type === 'stream_start' && e.data?.newStep)!.data.externalSignal,
       ).toBeUndefined();

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -672,8 +672,19 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
       // task-ended notification) can be tagged with `task-completion`.
       // Last-task-wins if multiple tasks end before a summary fires — in
       // practice CC summarizes once per LLM call.
+      //
+      // Gate on `callbackCount > 0`: only a task that actually fired out-of-band
+      // callback turns while alive is a genuine long-running task whose ending
+      // produces a post-task summary (the summary "keeps it inside the same
+      // AssistantGroup as the preceding callbacks" — so there must BE preceding
+      // callbacks). A task that fires `task_started` and `task_notification`
+      // back-to-back with no intervening callback turn was an inline synchronous
+      // tool that CC merely tracked as a task (e.g. a slow `git commit` running a
+      // lint-staged hook); its `tool_result` is consumed by the next turn in the
+      // normal main chain. Tagging that turn `task-completion` mis-anchors it and
+      // drops it from the rendered chain — so leave it untagged.
       const ending = this.activeTasks.get(raw.task_id);
-      if (ending) {
+      if (ending && ending.callbackCount > 0) {
         this.pendingTaskCompletion = {
           sourceToolCallId: ending.toolUseId,
           sourceToolName: ending.sourceToolName,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

LOBE-10583. Root-caused from the raw CC trace of `tpc_joZS2mksoY5L` (a device run).

#### 🔀 Description of Change

**Symptom:** an assistant turn silently disappears from a hetero topic (stored in DB, never rendered). Seen on `tpc_joZS2mksoY5L` (twice) and `tpc_SZXNHtiNeqxv`.

**Root cause (from the raw `stdout.jsonl`):** the CC stream is a perfectly linear 6-turn chain. A slow `git commit` (running a lint-staged hook) makes Claude Code track the Bash call as a task and emit `task_started` + `task_notification` **back-to-back** — no out-of-band callback turn in between — immediately followed by the tool_result. That's an ordinary **inline synchronous tool**, not a Monitor-style long-running task.

The adapter armed `pendingTaskCompletion` on **every** `task_notification`, so the next normal turn (which just consumes the commit's tool_result and keeps working — reading a file, opening the PR) got stamped `signal.type = 'task-completion'`. Downstream, a signal-tagged turn is anchored off the source tool and kept off the spine, and the turn after it re-anchors to the pre-task assistant — so the continuation forks off the main chain and vanishes from the rendered topic.

This is an **adapter-layer** bug; it has nothing to do with the server cold-ingest path or the message-chain reducer (an earlier iteration of this PR wrongly touched those — reverted).

**Fix (at the source):** only arm `pendingTaskCompletion` when the ending task actually fired callback turns while alive (`callbackCount > 0`). That's the signature of a genuine long-running task whose completion produces a post-task summary (the summary is designed to render *after* the preceding callbacks). A task that starts and ends with zero callbacks was an inline tool → leave the next turn untagged so it stays a normal main-chain step. Erring this way is safe: a mis-classified genuine summary just renders inline instead of disappearing.

#### 🧪 How to Test

- [x] Added/updated tests

`claudeCode.test.ts`: `task_started` + `task_notification` with no intervening callback → the next turn carries **no** `externalSignal`. The existing Monitor flow (a `tool-stdout` callback fires before `task_notification`, so `callbackCount > 0`) still tags `task-completion`. Verified the new test fails without the gate. Full `heterogeneous-agents` suite: 258/258.

#### 📝 Additional Information

No schema/DB/reducer changes — single adapter gate.