### PR TITLE
✨ feat: fold completed agent turns into a compact summary, keep latest expanded

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -945,6 +945,7 @@
   "translate.clear": "Clear Translation",
   "tts.action": "Text-to-Speech",
   "tts.clear": "Clear Speech",
+  "turnProcess.done": "Processed",
   "untitledAgent": "Untitled Agent",
   "untitledGroup": "Untitled Group",
   "updateAgent": "Update Agent Information",

--- a/locales/en-US/labs.json
+++ b/locales/en-US/labs.json
@@ -7,6 +7,8 @@
   "features.assistantMessageGroup.title": "Agent Message Grouping",
   "features.fleet.desc": "Show the Fleet entry in the title bar — a side-by-side dashboard of all running tasks across your agents.",
   "features.fleet.title": "Fleet View",
+  "features.foldFinishedTurn.desc": "Collapse the process (reasoning and tool calls) of finished, non-latest agent turns under a \"Processed\" header. The final answer stays visible; click to expand the process.",
+  "features.foldFinishedTurn.title": "Fold Finished Turns",
   "features.groupChat.desc": "Enable multi-agent group chat coordination.",
   "features.groupChat.title": "Group Chat (Multi-Agent)",
   "features.imessage.desc": "Connect agents to iMessage through the local LobeHub Desktop BlueBubbles bridge.",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -945,6 +945,7 @@
   "translate.clear": "删除翻译",
   "tts.action": "语音朗读",
   "tts.clear": "删除语音",
+  "turnProcess.done": "已处理",
   "untitledAgent": "未命名助理",
   "untitledGroup": "未命名群组",
   "updateAgent": "更新助理信息",

--- a/locales/zh-CN/labs.json
+++ b/locales/zh-CN/labs.json
@@ -7,6 +7,8 @@
   "features.assistantMessageGroup.title": "代理消息分组",
   "features.fleet.desc": "在标题栏显示 Fleet 入口——把当前账号下所有运行中的任务并排展示的看板。",
   "features.fleet.title": "Fleet 并排视图",
+  "features.foldFinishedTurn.desc": "将已完成、非最新回合的过程（推理与工具调用）折叠进「已处理」标题，最终回答始终显示；点击可展开过程。",
+  "features.foldFinishedTurn.title": "折叠已完成回合",
   "features.groupChat.desc": "启用多代理协同群聊功能。",
   "features.groupChat.title": "群聊（多代理）",
   "features.imessage.desc": "通过本地 LobeHub 桌面 BlueBubbles 桥接器将代理连接到 iMessage。",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -1041,6 +1041,7 @@ export default {
   'translate.clear': 'Clear Translation',
   'tts.action': 'Text-to-Speech',
   'tts.clear': 'Clear Speech',
+  'turnProcess.done': 'Processed',
   'untitledAgent': 'Untitled Agent',
   'untitledGroup': 'Untitled Group',
   'updateAgent': 'Update Agent Information',

--- a/packages/locales/src/default/labs.ts
+++ b/packages/locales/src/default/labs.ts
@@ -11,6 +11,9 @@ export default {
   'features.fleet.desc':
     'Show the Fleet entry in the title bar — a side-by-side dashboard of all running tasks across your agents.',
   'features.fleet.title': 'Fleet View',
+  'features.foldFinishedTurn.desc':
+    'Collapse the process (reasoning and tool calls) of finished, non-latest agent turns under a "Processed" header. The final answer stays visible; click to expand the process.',
+  'features.foldFinishedTurn.title': 'Fold Finished Turns',
   'features.imessage.desc':
     'Connect agents to iMessage through the local LobeHub Desktop BlueBubbles bridge.',
   'features.imessage.title': 'iMessage Channel',

--- a/packages/types/src/user/preference.ts
+++ b/packages/types/src/user/preference.ts
@@ -51,6 +51,10 @@ export const UserLabSchema = z.object({
    */
   enableFleet: z.boolean().optional(),
   /**
+   * fold a finished, non-latest agent turn's process under a "已处理" header
+   */
+  enableFoldFinishedTurn: z.boolean().optional(),
+  /**
    * enable multi-agent group chat mode
    */
   enableGroupChat: z.boolean().optional(),

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -152,6 +152,7 @@ describe('Group', () => {
 
     render(
       <Group
+        isLatestItem
         id="assistant-1"
         messageIndex={0}
         blocks={[
@@ -183,6 +184,7 @@ describe('Group', () => {
   it('keeps a short mixed status block inline when there is only one tool call', () => {
     render(
       <Group
+        isLatestItem
         id="assistant-1"
         messageIndex={0}
         blocks={[
@@ -215,6 +217,7 @@ describe('Group', () => {
 
     const { container } = render(
       <Group
+        isLatestItem
         id="assistant-1"
         messageIndex={0}
         blocks={[
@@ -271,6 +274,7 @@ describe('Group', () => {
   it('folds consecutive short mixed single-tool blocks into one workflow segment', () => {
     const { container } = render(
       <Group
+        isLatestItem
         id="assistant-1"
         messageIndex={0}
         blocks={[
@@ -315,6 +319,7 @@ describe('Group', () => {
   it('keeps assistant runtime errors outside the workflow collapse', () => {
     const { container } = render(
       <Group
+        isLatestItem
         id="assistant-1"
         messageIndex={0}
         blocks={[
@@ -367,6 +372,7 @@ describe('Group', () => {
   it('renders a single tool call inline instead of folding it', () => {
     render(
       <Group
+        isLatestItem
         id="assistant-1"
         messageIndex={0}
         blocks={[
@@ -397,6 +403,7 @@ describe('Group', () => {
     mockIsGenerating = true;
     render(
       <Group
+        isLatestItem
         id="assistant-1"
         messageIndex={0}
         blocks={[
@@ -416,6 +423,7 @@ describe('Group', () => {
     mockIsGenerating = true;
     render(
       <Group
+        isLatestItem
         id="assistant-1"
         messageIndex={0}
         blocks={[
@@ -435,6 +443,7 @@ describe('Group', () => {
     mockIsGenerating = false;
     render(
       <Group
+        isLatestItem
         id="assistant-1"
         messageIndex={0}
         blocks={[
@@ -453,6 +462,7 @@ describe('Group', () => {
   it('only animates the last block in a multi-block group', () => {
     const { container } = render(
       <Group
+        isLatestItem
         id="assistant-1"
         messageIndex={0}
         blocks={[
@@ -489,6 +499,7 @@ describe('Group', () => {
 
     const { container } = render(
       <Group
+        isLatestItem
         id="assistant-1"
         messageIndex={0}
         blocks={[
@@ -523,6 +534,7 @@ describe('Group', () => {
 
     const { container } = render(
       <Group
+        isLatestItem
         id="assistant-1"
         messageIndex={0}
         blocks={[

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -12,11 +12,14 @@ import { MessageAggregationContext } from '../../Contexts/MessageAggregationCont
 import { POST_TOOL_FINAL_ANSWER_SCORE_THRESHOLD } from '../constants';
 import {
   areWorkflowToolsComplete,
+  formatReasoningDuration,
   getPostToolAnswerSplitIndex,
   scoreBlockContentAsAnswerLike,
 } from '../toolDisplayNames';
 import { CollapsedMessage } from './CollapsedMessage';
 import GroupItem from './GroupItem';
+import ProcessFold from './ProcessFold';
+import { type GroupRenderSegment, shouldFoldProcess, splitFinalAnswer } from './segments';
 import type { RenderableAssistantContentBlock } from './types';
 import WorkflowCollapse, { type WorkflowExpandLevelDefault } from './WorkflowCollapse';
 
@@ -36,21 +39,40 @@ interface GroupChildrenProps {
   contentId?: string;
   defaultWorkflowExpandLevel?: WorkflowExpandLevelDefault;
   disableEditing?: boolean;
+  /** Lab flag: fold finished non-latest turns' process under a "已处理" header. */
+  enableProcessFold?: boolean;
   id: string;
+  /** Whether this turn is the latest item in the conversation. */
+  isLatestItem?: boolean;
   messageIndex: number;
 }
 
-interface AnswerSegment {
-  block: RenderableAssistantContentBlock;
-  kind: 'answer';
-}
-
-interface WorkflowSegment {
-  blocks: RenderableAssistantContentBlock[];
-  kind: 'workflow';
-}
-
-type GroupRenderSegment = AnswerSegment | WorkflowSegment;
+/**
+ * Wall-clock span of a turn = last − first `createdAt` across the turn's own
+ * assistant-step messages (the group's child blocks resolved against the raw
+ * `dbMessages`). The group record's own `createdAt/updatedAt` only covers its
+ * final step, so it under-reports multi-step turns.
+ */
+const getTurnDurationMs = (
+  dbMessages: { createdAt?: Date | number | string | null; id: string }[] | undefined,
+  blocks: AssistantContentBlock[],
+): number => {
+  if (!Array.isArray(dbMessages) || blocks.length < 2) return 0;
+  const ids = new Set(blocks.map((block) => block.id));
+  let min = Infinity;
+  let max = -Infinity;
+  for (const message of dbMessages) {
+    if (!ids.has(message.id) || message.createdAt == null) continue;
+    const time =
+      message.createdAt instanceof Date
+        ? message.createdAt.getTime()
+        : new Date(message.createdAt).getTime();
+    if (Number.isNaN(time)) continue;
+    if (time < min) min = time;
+    if (time > max) max = time;
+  }
+  return max > min ? max - min : 0;
+};
 
 interface PartitionedBlocks {
   /** True while generating if long post-tool answer was moved outside the fold (tool phase UI may show “done”). */
@@ -367,11 +389,14 @@ const Group = memo<GroupChildrenProps>(
     messageIndex,
     id,
     content,
+    isLatestItem,
+    enableProcessFold,
   }) => {
     const [isCollapsed, isGenerating] = useConversationStore((s) => [
       messageStateSelectors.isMessageCollapsed(id)(s),
       messageStateSelectors.isAssistantGroupItemGenerating(id)(s),
     ]);
+    const turnDurationMs = useConversationStore((s) => getTurnDurationMs(s.dbMessages, blocks));
     const contextValue = useMemo(() => ({ assistantGroupId: id }), [id]);
     const lastBlockId = blocks.at(-1)?.id;
 
@@ -406,64 +431,93 @@ const Group = memo<GroupChildrenProps>(
       );
     }
 
-    return (
-      <MessageAggregationContext value={contextValue}>
-        <Flexbox className={styles.container} gap={8}>
-          {segments.map((segment, index) => {
-            if (segment.kind === 'workflow') {
-              if (segment.blocks.length === 0) return null;
+    const renderSegment = (segment: GroupRenderSegment, index: number) => {
+      if (segment.kind === 'workflow') {
+        if (segment.blocks.length === 0) return null;
 
-              if (shouldInlineWorkflowSegment(segment.blocks)) {
-                return segment.blocks.map((block, blockIndex) => {
-                  const item = withMarkdownStreamingState(block, lastBlockId);
-                  if (!isGenerating && isEmptyBlock(item)) return null;
-
-                  return (
-                    <GroupItem
-                      {...item}
-                      assistantId={id}
-                      contentId={contentId}
-                      disableEditing={disableEditing}
-                      key={item.renderKey ?? `${id}.workflow-inline.${index}.${blockIndex}`}
-                      messageIndex={messageIndex}
-                    />
-                  );
-                });
-              }
-
-              return (
-                <WorkflowCollapse
-                  assistantMessageId={id}
-                  defaultWorkflowExpandLevel={defaultWorkflowExpandLevel}
-                  disableEditing={disableEditing}
-                  key={segment.blocks[0]?.renderKey ?? `${id}.workflow.${index}`}
-                  blocks={segment.blocks.map((block) =>
-                    withMarkdownStreamingState(block, lastBlockId),
-                  )}
-                  workflowChromeComplete={
-                    workflowChromeComplete ||
-                    (hasRenderedContentAfter(segments, index) &&
-                      !hasPendingIntervention(segment.blocks))
-                  }
-                />
-              );
-            }
-
-            const item = segment.block;
+        if (shouldInlineWorkflowSegment(segment.blocks)) {
+          return segment.blocks.map((block, blockIndex) => {
+            const item = withMarkdownStreamingState(block, lastBlockId);
             if (!isGenerating && isEmptyBlock(item)) return null;
 
             return (
               <GroupItem
-                {...withMarkdownStreamingState(item, lastBlockId)}
+                {...item}
                 assistantId={id}
                 contentId={contentId}
                 disableEditing={disableEditing}
-                key={item.renderKey ?? `${id}.${item.id}.${index}`}
+                key={item.renderKey ?? `${id}.workflow-inline.${index}.${blockIndex}`}
                 messageIndex={messageIndex}
               />
             );
-          })}
-          {showTailRunningIndicator && <ContentLoading id={id} />}
+          });
+        }
+
+        return (
+          <WorkflowCollapse
+            assistantMessageId={id}
+            defaultWorkflowExpandLevel={defaultWorkflowExpandLevel}
+            disableEditing={disableEditing}
+            key={segment.blocks[0]?.renderKey ?? `${id}.workflow.${index}`}
+            blocks={segment.blocks.map((block) => withMarkdownStreamingState(block, lastBlockId))}
+            workflowChromeComplete={
+              workflowChromeComplete ||
+              (hasRenderedContentAfter(segments, index) && !hasPendingIntervention(segment.blocks))
+            }
+          />
+        );
+      }
+
+      const item = segment.block;
+      if (!isGenerating && isEmptyBlock(item)) return null;
+
+      return (
+        <GroupItem
+          {...withMarkdownStreamingState(item, lastBlockId)}
+          assistantId={id}
+          contentId={contentId}
+          disableEditing={disableEditing}
+          key={item.renderKey ?? `${id}.${item.id}.${index}`}
+          messageIndex={messageIndex}
+        />
+      );
+    };
+
+    // Codex-style turn folding: once a turn is finished and no longer the latest
+    // one, fold its whole process (reasoning + tools + intermediate prose) under
+    // a single "已处理 {duration}" header, leaving the final answer always
+    // visible. The latest / still-generating turn renders in full.
+    const { processSegments, finalSegments } = splitFinalAnswer(segments);
+    const foldProcess = shouldFoldProcess({
+      enabled: enableProcessFold,
+      isGenerating,
+      isLatestItem,
+      processSegments,
+    });
+
+    const durationText =
+      turnDurationMs >= 1000 ? formatReasoningDuration(turnDurationMs) : undefined;
+
+    return (
+      <MessageAggregationContext value={contextValue}>
+        <Flexbox className={styles.container} gap={8}>
+          {foldProcess ? (
+            <>
+              <ProcessFold durationText={durationText}>
+                <Flexbox gap={8}>
+                  {processSegments.map((segment, index) => renderSegment(segment, index))}
+                </Flexbox>
+              </ProcessFold>
+              {finalSegments.map((segment, index) =>
+                renderSegment(segment, processSegments.length + index),
+              )}
+            </>
+          ) : (
+            <>
+              {segments.map((segment, index) => renderSegment(segment, index))}
+              {showTailRunningIndicator && <ContentLoading id={id} />}
+            </>
+          )}
         </Flexbox>
       </MessageAggregationContext>
     );

--- a/src/features/Conversation/Messages/AssistantGroup/components/ProcessFold.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ProcessFold.tsx
@@ -1,0 +1,62 @@
+import { Accordion, AccordionItem, Flexbox, Text } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+import { type Key, memo, type ReactNode, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const styles = createStaticStyles(({ css }) => ({
+  duration: css`
+    flex: none;
+    font-size: 12px;
+    color: ${cssVar.colorTextQuaternary};
+  `,
+}));
+
+const PROCESS_KEY = 'process';
+
+interface ProcessFoldProps {
+  /** Rendered process (reasoning + tools + intermediate prose); shown only when expanded. */
+  children: ReactNode;
+  /** Whether the process starts expanded. */
+  defaultExpanded?: boolean;
+  /** Formatted turn duration, e.g. "3m 37s". Hidden when absent. */
+  durationText?: string;
+}
+
+/**
+ * Codex-style "已处理 {duration}" header that folds a finished turn's *process*
+ * (reasoning + tool calls + intermediate narration) into one persistent,
+ * toggleable row. The turn's final answer is rendered separately and stays
+ * visible regardless of this state. Reuses the same Accordion chrome as
+ * WorkflowCollapse so the right-aligned expand chevron matches. Purely a view
+ * affordance — never persisted.
+ */
+const ProcessFold = memo<ProcessFoldProps>(
+  ({ children, durationText, defaultExpanded = false }) => {
+    const { t } = useTranslation('chat');
+    const [expanded, setExpanded] = useState(defaultExpanded);
+    const expandedKeys = useMemo(() => (expanded ? [PROCESS_KEY] : []), [expanded]);
+
+    const title = (
+      <Flexbox horizontal align={'center'} gap={6} style={{ minWidth: 0 }}>
+        <Text type={'secondary'}>{t('turnProcess.done')}</Text>
+        {durationText && <span className={styles.duration}>{durationText}</span>}
+      </Flexbox>
+    );
+
+    return (
+      <Accordion
+        expandedKeys={expandedKeys}
+        variant={'borderless'}
+        onExpandedChange={(keys: Key[]) => setExpanded(keys.includes(PROCESS_KEY))}
+      >
+        <AccordionItem itemKey={PROCESS_KEY} paddingBlock={4} paddingInline={4} title={title}>
+          {children}
+        </AccordionItem>
+      </Accordion>
+    );
+  },
+);
+
+ProcessFold.displayName = 'ProcessFold';
+
+export default ProcessFold;

--- a/src/features/Conversation/Messages/AssistantGroup/components/segments.test.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/components/segments.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldFoldProcess, splitFinalAnswer } from './segments';
+
+const a = (id: string) => ({ block: { id } as any, kind: 'answer' as const });
+const w = (id: string) => ({ blocks: [{ id } as any], kind: 'workflow' as const });
+
+describe('splitFinalAnswer', () => {
+  it('treats the trailing run of answer segments as the final answer', () => {
+    const segments = [w('t1'), a('intro'), w('t2'), a('final')];
+    const { processSegments, finalSegments } = splitFinalAnswer(segments);
+    // intro prose + both tool segments fold into the process
+    expect(processSegments).toEqual([w('t1'), a('intro'), w('t2')]);
+    expect(finalSegments).toEqual([a('final')]);
+  });
+
+  it('keeps multiple trailing answer segments together as the final answer', () => {
+    const segments = [w('t1'), a('a1'), a('a2')];
+    const { processSegments, finalSegments } = splitFinalAnswer(segments);
+    expect(processSegments).toEqual([w('t1')]);
+    expect(finalSegments).toEqual([a('a1'), a('a2')]);
+  });
+
+  it('folds everything when the turn ends on a workflow segment', () => {
+    const segments = [a('intro'), w('t1')];
+    const { processSegments, finalSegments } = splitFinalAnswer(segments);
+    expect(processSegments).toEqual([a('intro'), w('t1')]);
+    expect(finalSegments).toEqual([]);
+  });
+
+  it('treats a pure-answer turn as all final, nothing to fold', () => {
+    const segments = [a('only')];
+    const { processSegments, finalSegments } = splitFinalAnswer(segments);
+    expect(processSegments).toEqual([]);
+    expect(finalSegments).toEqual([a('only')]);
+  });
+});
+
+describe('shouldFoldProcess', () => {
+  const proc = [w('t1')];
+
+  it('folds a finished, non-latest turn that has a workflow when enabled', () => {
+    expect(shouldFoldProcess({ enabled: true, isGenerating: false, processSegments: proc })).toBe(
+      true,
+    );
+  });
+
+  it('never folds when the lab flag is disabled', () => {
+    expect(shouldFoldProcess({ enabled: false, isGenerating: false, processSegments: proc })).toBe(
+      false,
+    );
+    expect(shouldFoldProcess({ isGenerating: false, processSegments: proc })).toBe(false);
+  });
+
+  it('never folds the latest turn', () => {
+    expect(
+      shouldFoldProcess({
+        enabled: true,
+        isGenerating: false,
+        isLatestItem: true,
+        processSegments: proc,
+      }),
+    ).toBe(false);
+  });
+
+  it('never folds while generating', () => {
+    expect(shouldFoldProcess({ enabled: true, isGenerating: true, processSegments: proc })).toBe(
+      false,
+    );
+  });
+
+  it('does not fold when the process has no workflow (e.g. pure prose)', () => {
+    expect(
+      shouldFoldProcess({ enabled: true, isGenerating: false, processSegments: [a('p1')] }),
+    ).toBe(false);
+  });
+});

--- a/src/features/Conversation/Messages/AssistantGroup/components/segments.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/components/segments.ts
@@ -1,0 +1,55 @@
+import type { RenderableAssistantContentBlock } from './types';
+
+export interface AnswerSegment {
+  block: RenderableAssistantContentBlock;
+  kind: 'answer';
+}
+
+export interface WorkflowSegment {
+  blocks: RenderableAssistantContentBlock[];
+  kind: 'workflow';
+}
+
+export type GroupRenderSegment = AnswerSegment | WorkflowSegment;
+
+/**
+ * Split a turn's render segments into its process and its final answer.
+ *
+ * The trailing run of `answer` segments is the final answer (always shown);
+ * everything before it — tools, reasoning, intermediate prose — is the process
+ * that folds under the Codex-style "已处理 {duration}" header.
+ */
+export const splitFinalAnswer = (
+  segments: GroupRenderSegment[],
+): { finalSegments: GroupRenderSegment[]; processSegments: GroupRenderSegment[] } => {
+  let splitIndex = segments.length;
+  while (splitIndex > 0 && segments[splitIndex - 1].kind === 'answer') {
+    splitIndex -= 1;
+  }
+  return {
+    finalSegments: segments.slice(splitIndex),
+    processSegments: segments.slice(0, splitIndex),
+  };
+};
+
+/**
+ * Whether a turn folds its process under the "已处理" header. Gated by the
+ * `enabled` lab flag, then: only a finished (not generating), non-latest turn
+ * that actually has a workflow to fold. The latest / still-generating turn
+ * always renders in full.
+ */
+export const shouldFoldProcess = ({
+  enabled,
+  isGenerating,
+  isLatestItem,
+  processSegments,
+}: {
+  enabled?: boolean;
+  isGenerating: boolean;
+  isLatestItem?: boolean;
+  processSegments: GroupRenderSegment[];
+}): boolean =>
+  !!enabled &&
+  !isLatestItem &&
+  !isGenerating &&
+  processSegments.some((segment) => segment.kind === 'workflow');

--- a/src/features/Conversation/Messages/AssistantGroup/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/index.tsx
@@ -14,7 +14,11 @@ import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';
 import { useGlobalStore } from '@/store/global';
 import { useUserStore } from '@/store/user';
-import { userGeneralSettingsSelectors, userProfileSelectors } from '@/store/user/selectors';
+import {
+  labPreferSelectors,
+  userGeneralSettingsSelectors,
+  userProfileSelectors,
+} from '@/store/user/selectors';
 
 import { ReactionDisplay } from '../../components/Reaction';
 import { useAgentMeta } from '../../hooks';
@@ -51,7 +55,7 @@ interface GroupMessageProps {
 }
 
 const GroupMessage = memo<GroupMessageProps>(
-  ({ defaultWorkflowExpandLevel, id, index, disableEditing, footerRender }) => {
+  ({ defaultWorkflowExpandLevel, id, index, disableEditing, footerRender, isLatestItem }) => {
     // Get message and actionsConfig from ConversationStore
     const item = useConversationStore(dataSelectors.getDisplayMessageById(id), isEqual)!;
 
@@ -99,6 +103,7 @@ const GroupMessage = memo<GroupMessageProps>(
     const interrupted = groupInterrupted || blockInterrupted;
 
     const isDevMode = useUserStore((s) => userGeneralSettingsSelectors.config(s).isDevMode);
+    const enableProcessFold = useUserStore(labPreferSelectors.enableFoldFinishedTurn);
     const addReaction = useConversationStore((s) => s.addReaction);
     const removeReaction = useConversationStore((s) => s.removeReaction);
     const userId = useUserStore(userProfileSelectors.userId)!;
@@ -191,7 +196,9 @@ const GroupMessage = memo<GroupMessageProps>(
               contentId={contentId}
               defaultWorkflowExpandLevel={defaultWorkflowExpandLevel}
               disableEditing={disableEditing}
+              enableProcessFold={enableProcessFold}
               id={id}
+              isLatestItem={isLatestItem}
               messageIndex={index}
             />
           )}

--- a/src/routes/(main)/settings/advanced/index.tsx
+++ b/src/routes/(main)/settings/advanced/index.tsx
@@ -50,6 +50,7 @@ const Page = memo(() => {
     enableImessage,
     enableFleet,
     enableTaskVerify,
+    enableFoldFinishedTurn,
     updateLab,
   ] = useUserStore((s) => [
     preferenceSelectors.isPreferenceInit(s),
@@ -59,6 +60,7 @@ const Page = memo(() => {
     labPreferSelectors.enableImessage(s),
     labPreferSelectors.enableFleet(s),
     labPreferSelectors.enableTaskVerify(s),
+    labPreferSelectors.enableFoldFinishedTurn(s),
     s.updateLab,
   ]);
 
@@ -178,6 +180,19 @@ const Page = memo(() => {
       className: styles.labItem,
       desc: tLabs('features.taskVerify.desc'),
       label: tLabs('features.taskVerify.title'),
+      minWidth: undefined,
+    },
+    {
+      children: (
+        <Switch
+          checked={enableFoldFinishedTurn}
+          loading={!isPreferenceInit}
+          onChange={(checked) => updateLab({ enableFoldFinishedTurn: checked })}
+        />
+      ),
+      className: styles.labItem,
+      desc: tLabs('features.foldFinishedTurn.desc'),
+      label: tLabs('features.foldFinishedTurn.title'),
       minWidth: undefined,
     },
     ...(isDesktop

--- a/src/store/user/slices/preference/selectors/labPrefer.ts
+++ b/src/store/user/slices/preference/selectors/labPrefer.ts
@@ -10,6 +10,8 @@ export const labPreferSelectors = {
   enableAgentSelfIteration: (s: UserState): boolean =>
     s.preference.lab?.enableAgentSelfIteration ?? false,
   enableFleet: (s: UserState): boolean => s.preference.lab?.enableFleet ?? false,
+  enableFoldFinishedTurn: (s: UserState): boolean =>
+    s.preference.lab?.enableFoldFinishedTurn ?? false,
   enableImessage: (s: UserState): boolean => s.preference.lab?.enableImessage ?? false,
   enableInputMarkdown: (s: UserState): boolean =>
     s.preference.lab?.enableInputMarkdown ?? DEFAULT_PREFERENCE.lab?.enableInputMarkdown ?? true,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

让"做完所有事情"的 agent 会话默认只展示最新一轮结果：已完成、非最新的 `assistantGroup` 轮次折叠成**一行紧凑摘要**（最终回答首行 + 本轮耗时），点击可展开，已展开的历史轮提供收起控件。Codex 风格的历史折叠，把对话聚焦在最终汇报上、降低干扰。

**实现层级：turn 组件级 + 临时视图状态**（这是对上一版方向的修正）：

- 折叠是纯视图行为，**完全不触碰**已持久化的 `metadata.collapsed` / `isMessageCollapsed`（那是另一套"把单条消息折成预览"的手动功能）。
- 状态是临时的（`useState`，不写库），刷新后回到默认，符合 Codex 行为；模式与现有 `WorkflowCollapse`（工具调用折叠）一致，只是提升到整轮粒度。

具体改动：

- `CollapsedTurn.tsx`：紧凑摘要行（chevron + 摘要 + 耗时）。
- `turnCollapse.ts`：纯函数 `resolveTurnCollapse` 推导折叠态（含单测）。
- `AssistantGroup/index.tsx`：默认折叠"非最新且非生成中"的轮；`isLatestItem` 已有；临时 toggle + 收起控件。
- i18n：`turnCollapse.*`（en-US / zh-CN）。

设计取舍：仅作用于 `assistantGroup`；最新一条消息与生成中的轮永远展开；用户手动展开/收起仅临时生效。

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

本地 Electron 打开 11 轮真实会话：首次打开非最新的 agent 轮全部折成一行摘要（DOM 计 10 个 `CollapsedTurn` 行，旧的 `Expand Message` = 0，证明未走 MessageCollapsed）；点击展开 → 出现收起控件；再点收起 → 折回。`bun run type-check` 通过；`resolveTurnCollapse` 6 个单测通过。