### PR TITLE
🐛 fix(model-runtime): converge 2nd residue wave + unmap payload-too-large from ECW

### DIFF
--- a/packages/model-runtime/src/errors/match.test.ts
+++ b/packages/model-runtime/src/errors/match.test.ts
@@ -280,10 +280,6 @@ describe('matchErrorPattern — refines the UpstreamHttpError fallback bucket', 
     ],
     ['服务器问题调试中', AgentRuntimeErrorType.ProviderServiceUnavailable],
     ['1m 上下文已经全量可用，请启用 1m 上下文后重试', AgentRuntimeErrorType.ExceededContextWindow],
-    [
-      'Request body too large for gpt-4o model. Max size: 1000000 tokens.',
-      AgentRuntimeErrorType.ExceededContextWindow,
-    ],
     ["Model 'glm-5.2:cloud' is not allowed on this server.", AgentRuntimeErrorType.ModelNotFound],
     ['User has been banned (request id: 2026...)', AgentRuntimeErrorType.PermissionDenied],
     ['Only Codex clients can use this group', AgentRuntimeErrorType.PermissionDenied],
@@ -299,5 +295,72 @@ describe('matchErrorPattern — refines the UpstreamHttpError fallback bucket', 
     expect(
       matchErrorPattern({ errorType: AgentRuntimeErrorType.ProviderBizError, message })?.code,
     ).toBe(expected);
+  });
+});
+
+describe('matchErrorPattern — second residue convergence round', () => {
+  const cases: [string, string][] = [
+    ['The provided model identifier is invalid.', AgentRuntimeErrorType.ModelNotFound],
+    [
+      'Incorrect model ID. Please request to view the model page',
+      AgentRuntimeErrorType.ModelNotFound,
+    ],
+    ['<html><head><title>403 Forbidden</title></head>', AgentRuntimeErrorType.PermissionDenied],
+    [
+      'Access denied due to Virtual Network/Firewall rules.',
+      AgentRuntimeErrorType.PermissionDenied,
+    ],
+    [
+      'This channel does not allow the current client (detected: r9)',
+      AgentRuntimeErrorType.PermissionDenied,
+    ],
+    [
+      "However, the model's context length is 200000 tokens.",
+      AgentRuntimeErrorType.ExceededContextWindow,
+    ],
+    [
+      'Image inference is not supported on this endpoint. Please use /images/generations',
+      AgentRuntimeErrorType.CapabilityNotSupported,
+    ],
+    ['当前模型不支持SSE调用方式。', AgentRuntimeErrorType.CapabilityNotSupported],
+    [
+      'This model is unavailable for free. The paid version is available now',
+      AgentRuntimeErrorType.InsufficientQuota,
+    ],
+    ['fetch failed', AgentRuntimeErrorType.ProviderNetworkError],
+    ['404 page not found', AgentRuntimeErrorType.UserConfigError],
+    [
+      '{"errors":[{"code":7003,"message":"No route for that URI"}]}',
+      AgentRuntimeErrorType.UserConfigError,
+    ],
+    [
+      'invalid params, invalid reasoning.type: "enabled" (allowed: adaptive, disabled)',
+      AgentRuntimeErrorType.InvalidRequestFormat,
+    ],
+    [
+      'Error from provider (Moonshot AI): invalid thinking: only type=enabled is allowed',
+      AgentRuntimeErrorType.InvalidRequestFormat,
+    ],
+    [
+      'function_declarations[0].parameters.properties[set]',
+      AgentRuntimeErrorType.InvalidRequestFormat,
+    ],
+    ['<!doctype html><meta charset="utf-8">', AgentRuntimeErrorType.UpstreamGatewayError],
+  ];
+
+  it.each(cases)('classifies %j', (message, expected) => {
+    expect(
+      matchErrorPattern({ errorType: AgentRuntimeErrorType.ProviderBizError, message })?.code,
+    ).toBe(expected);
+  });
+
+  it('does NOT classify a payload-size (413) rejection as ExceededContextWindow', () => {
+    // A request-body / 413 size limit is not the same as the model context
+    // window — it must stay out of ExceededContextWindow.
+    const code = matchErrorPattern({
+      errorType: AgentRuntimeErrorType.ProviderBizError,
+      message: 'Request body too large for gpt-4o model. Max size: 1000000 tokens.',
+    })?.code;
+    expect(code).not.toBe(AgentRuntimeErrorType.ExceededContextWindow);
   });
 });

--- a/packages/model-runtime/src/errors/patterns.ts
+++ b/packages/model-runtime/src/errors/patterns.ts
@@ -122,7 +122,6 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     match: sub('content exceeds maximum length of 100KB'),
   },
   { code: AgentRuntimeErrorType.ExceededContextWindow, match: sub('免费API限制模型输入token小于') },
-  { code: AgentRuntimeErrorType.ExceededContextWindow, match: sub('Request body too large') },
   {
     code: AgentRuntimeErrorType.ExceededContextWindow,
     match: sub('conversation is too long'),
@@ -133,6 +132,12 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     match: sub('上下文已经全量可用'),
     note: 'proxy gates 1m context — request overflowed the default window',
   },
+  {
+    code: AgentRuntimeErrorType.ExceededContextWindow,
+    match: sub("the model's context length"),
+    note: 'OpenAI-style: passed N input + requested M output > context length',
+  },
+  { code: AgentRuntimeErrorType.ExceededContextWindow, match: sub('input tokens and requested') },
 
   // ─────────────────────────────────────────────────────────────────────────
   // InsufficientQuota — account balance / billing exhausted (long-term)
@@ -141,6 +146,12 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     code: AgentRuntimeErrorType.InsufficientQuota,
     match: sub('insufficient balance', { caseInsensitive: true }),
   },
+  {
+    code: AgentRuntimeErrorType.InsufficientQuota,
+    match: sub('unavailable for free. The paid version'),
+  },
+  { code: AgentRuntimeErrorType.InsufficientQuota, match: sub('used all available credits') },
+  { code: AgentRuntimeErrorType.InsufficientQuota, match: sub('CodingPlan subscription') },
   {
     code: AgentRuntimeErrorType.InsufficientQuota,
     match: sub('insufficient quota', { caseInsensitive: true }),
@@ -531,6 +542,7 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     // generic "Connection error." surfaces on the top-level message.
     match: sub('Connection error.'),
   },
+  { code: AgentRuntimeErrorType.ProviderNetworkError, match: sub('fetch failed') },
 
   // ─────────────────────────────────────────────────────────────────────────
   // StateStoreReadError — a state-store READ failed: either a blocking read
@@ -660,6 +672,11 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   { code: AgentRuntimeErrorType.ModelNotFound, match: sub('你请求的模型') },
   { code: AgentRuntimeErrorType.ModelNotFound, match: sub('不存在或未上线') },
   { code: AgentRuntimeErrorType.ModelNotFound, match: sub('has no provider supported') },
+  { code: AgentRuntimeErrorType.ModelNotFound, match: sub('model identifier is invalid') },
+  { code: AgentRuntimeErrorType.ModelNotFound, match: sub('Incorrect model ID') },
+  { code: AgentRuntimeErrorType.ModelNotFound, match: sub('not available for integrator') },
+  { code: AgentRuntimeErrorType.ModelNotFound, match: sub('is not available. Please use') },
+  { code: AgentRuntimeErrorType.ModelNotFound, match: sub('The requested model is not available') },
 
   // ─────────────────────────────────────────────────────────────────────────
   // InvalidProviderAPIKey
@@ -735,6 +752,12 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     note: 'proxy restricts the group to Codex clients',
   },
   { code: AgentRuntimeErrorType.PermissionDenied, match: sub('not available for trial users') },
+  { code: AgentRuntimeErrorType.PermissionDenied, match: sub('403 Forbidden') },
+  {
+    code: AgentRuntimeErrorType.PermissionDenied,
+    match: sub('Access denied due to Virtual Network'),
+  },
+  { code: AgentRuntimeErrorType.PermissionDenied, match: sub('does not allow the current client') },
 
   // ─────────────────────────────────────────────────────────────────────────
   // AccountDeactivated
@@ -760,6 +783,11 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   // CapabilityNotSupported
   // ─────────────────────────────────────────────────────────────────────────
   { code: AgentRuntimeErrorType.CapabilityNotSupported, match: sub('not implemented') },
+  {
+    code: AgentRuntimeErrorType.CapabilityNotSupported,
+    match: sub('Image inference is not supported on this endpoint'),
+  },
+  { code: AgentRuntimeErrorType.CapabilityNotSupported, match: sub('不支持SSE调用方式') },
   { code: AgentRuntimeErrorType.CapabilityNotSupported, match: sub('The model is not a VLM') },
   { code: AgentRuntimeErrorType.CapabilityNotSupported, match: sub('is not a multimodal model') },
   {
@@ -966,6 +994,31 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   },
   { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('max_tokens must be at least') },
   { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('Yêu cầu không hợp lệ') },
+  // More malformed/oversized-request rejections harvested from the
+  // UpstreamHttpError residue — provider-side validation + custom-proxy schema
+  // bridges, all upstream-side.
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('allowed: adaptive, disabled') },
+  {
+    code: AgentRuntimeErrorType.InvalidRequestFormat,
+    match: sub('invalid thinking: only type=enabled'),
+  },
+  {
+    code: AgentRuntimeErrorType.InvalidRequestFormat,
+    match: sub('Request contains an invalid argument'),
+  },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub("Input should be 'enabled'") },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('参数非法。请检查文档') },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('"code":"BAD_REQUEST') },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('Field required') },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('invalid image detail') },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('field MaxTokens invalid') },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('field ReasoningEffort invalid') },
+  { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('request validation errors') },
+  {
+    code: AgentRuntimeErrorType.InvalidRequestFormat,
+    match: sub('function_declarations'),
+    note: 'custom gemini proxies mangle tool schema; lobehub-native schema bug fixed in #14740',
+  },
 
   // ─────────────────────────────────────────────────────────────────────────
   // UserConfigError
@@ -998,6 +1051,11 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     code: AgentRuntimeErrorType.UserConfigError,
     match: sub('is not allowed for this virtual key'),
   },
+  // Endpoint / base-URL misconfiguration: upstream returns a routing 404 for a
+  // path the user's proxy config never exposed.
+  { code: AgentRuntimeErrorType.UserConfigError, match: sub('page not found') },
+  { code: AgentRuntimeErrorType.UserConfigError, match: sub('No route for that URI') },
+  { code: AgentRuntimeErrorType.UserConfigError, match: sub('url.not_found') },
 
   // ─────────────────────────────────────────────────────────────────────────
   // UpstreamGatewayError — proxy / gateway-layer failure (openresty, litellm,
@@ -1016,6 +1074,11 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     code: AgentRuntimeErrorType.UpstreamGatewayError,
     match: sub('525 <!DOCTYPE html>'),
     note: 'Cloudflare 525 SSL handshake',
+  },
+  {
+    code: AgentRuntimeErrorType.UpstreamGatewayError,
+    match: sub('<!doctype html', { caseInsensitive: true }),
+    note: 'bare HTML error body from a proxy/gateway (no status prefix)',
   },
 
   // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### 💡 Background

Follow-up to #16024. After the first wave classified ~300 fallback records, ~730 `UpstreamHttpError`/`ProviderBizError` residue remained. Auditing it (provider-agnostic, all `provider != lobehub`): **~320 are recognizable and belong to precise codes**, ~60 are harness-suspect (tracked separately in LOBE-10560), ~350 are genuinely generic.

### 🔨 Changes

Add ~40 patterns so the recognizable residue stops landing in the bare-HTTP bucket:

| Code | Examples |
| --- | --- |
| `ModelNotFound` | `The provided model identifier is invalid`, `Incorrect model ID`, `not available for integrator`, `is not available. Please use` |
| `PermissionDenied` | `403 Forbidden` (HTML), `Access denied due to Virtual Network/Firewall`, `does not allow the current client` |
| `UserConfigError` | `404 page not found`, `No route for that URI`, `url.not_found` (base-URL / endpoint misconfig) |
| `InvalidRequestFormat` | reasoning/thinking `type: enabled (allowed: adaptive, disabled)`, Gemini `Request contains an invalid argument`, `function_declarations` schema (custom proxies), pydantic `Field required` / `field MaxTokens/ReasoningEffort invalid`, `参数非法。请检查文档` |
| `ExceededContextWindow` | `…the model's context length is N tokens` (genuine overflow) |
| `CapabilityNotSupported` | `Image inference is not supported on this endpoint`, `不支持SSE调用方式` |
| `InsufficientQuota` | `unavailable for free. The paid version`, `used all available credits`, `CodingPlan subscription` |
| `ProviderNetworkError` | undici `fetch failed` |
| `UpstreamGatewayError` | bare `<!doctype html>` error bodies |

### ⚠️ Correction to #16024

**Unmap `Request body too large` from `ExceededContextWindow`.** A payload / 413 size limit is not the model context window — they're different failure modes. It now stays in the bare-HTTP bucket (no precise home). Added a regression guard asserting it is NOT classified as ECW.

### 🧠 Notes

- `function_declarations` schema errors are **all on custom proxies** here (user-side passthrough); lobehub's own Gemini-schema bug was fixed in #14740 with 0 recurrence — so they're `InvalidRequestFormat`, not a harness regression.
- Harness-suspect residue (dangling `tool_use_id`, `add_generation_prompt` assistant-last, empty assistant message, corrupted thought signature, provider-can't-fetch-our-image) is deliberately **NOT** classified — those are our own message-construction bugs and are tracked in LOBE-10560.

### 🧪 Tests

`bunx vitest run src/errors` → **103 passed** (added 2nd-round cases + payload-not-ECW guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)