### PR TITLE
✨ feat(cli): seed device default working directory on `lh connect`

### DIFF
--- a/apps/cli/src/commands/connect.ts
+++ b/apps/cli/src/commands/connect.ts
@@ -485,8 +485,9 @@ async function runConnect(options: ConnectOptions, isDaemonChild: boolean) {
   if (identity) {
     try {
       // Reuse the already-resolved auth (respects `--token` mode) so we don't
-      // re-discover creds and exit when none are found.
-      await registerDevice(auth, identity);
+      // re-discover creds and exit when none are found. Seed the default working
+      // directory with the launch dir (applied only on first registration).
+      await registerDevice(auth, identity, { defaultCwd: process.cwd() });
     } catch (err) {
       error(`Device registration failed (non-fatal): ${(err as Error).message}`);
     }

--- a/apps/cli/src/device/register.ts
+++ b/apps/cli/src/device/register.ts
@@ -25,13 +25,20 @@ export function resolveDeviceIdentity(
  * device row exists right after auth) and `lh connect` (so the row exists
  * before the WS opens). Best-effort by contract: callers should wrap this in a
  * try/catch and treat any failure as non-fatal.
+ *
+ * `defaultCwd` seeds the user-owned "default working directory" on the device's
+ * first registration only — the server preserves any value the user has since
+ * set. `lh connect` passes its launch directory so a freshly connected device
+ * defaults to a sensible working directory; `lh login` omits it.
  */
 export async function registerDevice(
   auth: { serverUrl: string; token: string; tokenType: 'apiKey' | 'jwt' | 'serviceToken' },
   identity: DeviceIdentity,
+  options?: { defaultCwd?: string },
 ): Promise<void> {
   const trpc = createLambdaClient(auth);
   await trpc.device.register.mutate({
+    defaultCwd: options?.defaultCwd,
     deviceId: identity.deviceId,
     hostname: os.hostname(),
     identitySource: identity.identitySource,

--- a/apps/server/src/routers/lambda/device.ts
+++ b/apps/server/src/routers/lambda/device.ts
@@ -611,6 +611,9 @@ export const deviceRouter = router({
   register: deviceProcedure
     .input(
       z.object({
+        // Seeds the user-owned default working directory on first registration
+        // only (e.g. the dir `lh connect` ran from); preserved on re-register.
+        defaultCwd: z.string().nullable().optional(),
         deviceId: z.string().min(1).max(64),
         hostname: z.string().nullable().optional(),
         identitySource: z.enum(['machine-id', 'fallback']),

--- a/packages/database/src/models/__tests__/device.test.ts
+++ b/packages/database/src/models/__tests__/device.test.ts
@@ -96,6 +96,36 @@ describe('DeviceModel', () => {
         workingDirs: [{ path: '/Users/me/work' }, { path: '/Users/me/tmp', repoType: 'github' }],
       });
     });
+
+    it('should seed defaultCwd on the first registration', async () => {
+      await deviceModel.register({
+        defaultCwd: '/Users/me/project',
+        deviceId: 'dev-1',
+        identitySource: 'machine-id',
+      });
+
+      const row = await deviceModel.findByDeviceId('dev-1');
+      expect(row?.defaultCwd).toBe('/Users/me/project');
+    });
+
+    it('should NOT overwrite an existing defaultCwd when re-register seeds a new one', async () => {
+      await deviceModel.register({
+        defaultCwd: '/Users/me/first',
+        deviceId: 'dev-1',
+        identitySource: 'machine-id',
+      });
+
+      // Reconnect from a different directory — the seed must not win over the
+      // value already stored (which the user may have since edited).
+      await deviceModel.register({
+        defaultCwd: '/Users/me/second',
+        deviceId: 'dev-1',
+        identitySource: 'machine-id',
+      });
+
+      const row = await deviceModel.findByDeviceId('dev-1');
+      expect(row?.defaultCwd).toBe('/Users/me/first');
+    });
   });
 
   describe('query', () => {

--- a/packages/database/src/models/device.ts
+++ b/packages/database/src/models/device.ts
@@ -6,6 +6,12 @@ import { devices } from '../schemas';
 import type { LobeChatDatabase } from '../type';
 
 export interface RegisterDeviceParams {
+  /**
+   * Seed value for the user-owned default working directory. Only applied on the
+   * very first insert (e.g. the directory `lh connect` was launched from); a
+   * re-register never overwrites a value the user has since set.
+   */
+  defaultCwd?: string | null;
   deviceId: string;
   hostname?: string | null;
   identitySource: string;
@@ -43,13 +49,15 @@ export class DeviceModel {
    * Auto-register from desktop/CLI. Upserts on the (userId, deviceId) unique
    * index. On conflict only the machine-reported fields + lastSeenAt are
    * refreshed — friendlyName / defaultCwd / workingDirs are user-owned and
-   * must survive re-registration.
+   * must survive re-registration. `defaultCwd` is therefore seeded on the first
+   * insert only and intentionally left out of the conflict `set`.
    */
   register = async (params: RegisterDeviceParams) => {
     const now = new Date();
     const [result] = await this.db
       .insert(devices)
       .values({
+        defaultCwd: params.defaultCwd,
         deviceId: params.deviceId,
         hostname: params.hostname,
         identitySource: params.identitySource,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

When `lh connect` registers the device, the server-side **默认工作目录 (default working directory)** is left empty until the user fills it in by hand. This seeds it with the directory the CLI was launched from, so a freshly connected device has a sensible default.

Behavior:

- `lh connect` passes `process.cwd()` to `device.register` as `defaultCwd`.
- The value is **seeded on the first registration only**. `DeviceModel.register`'s upsert intentionally keeps `defaultCwd` out of its conflict `set` (alongside `friendlyName` / `workingDirs`), so reconnecting from another directory — or any value the user edits in the devices UI — is preserved.
- `lh login` does **not** seed it: it only authenticates and may run from anywhere. Only the serving `connect` process, whose cwd is meaningful for remote tool calls, seeds the value.

Layers touched (all backward compatible — `defaultCwd` is an optional input, ignored by an older server, unsent by an older CLI):

- `packages/database` — `RegisterDeviceParams.defaultCwd`; seeded on insert, preserved on conflict.
- `apps/server` — `device.register` input accepts optional `defaultCwd`.
- `apps/cli` — `registerDevice(..., { defaultCwd })`; `lh connect` passes `process.cwd()`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

`packages/database` device model tests cover seeding on first registration and preservation on re-register:

```bash
cd packages/database
bunx vitest run --silent='passed-only' src/models/__tests__/device.test.ts
```

Manual: run `lh connect` from a project directory on a brand-new device, then check the device in `app.lobehub.com/settings/devices` — 默认工作目录 shows that directory. Reconnect from a different directory and confirm the original value is preserved.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| 默认工作目录 empty after connect | 默认工作目录 seeded with the `lh connect` launch dir |

#### 📝 Additional Information

The seed-vs-overwrite choice is deliberate: `defaultCwd` is a user-owned field, so the CLI only provides a one-time default and never clobbers later edits.