### PR TITLE
🐛 fix: preserve gateway error semantics

### DIFF
--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
@@ -16,7 +16,35 @@ describe('formatErrorForState', () => {
 
       expect(result.type).toBe(AgentRuntimeErrorType.InvalidProviderAPIKey);
       expect(result.message).toBe('Invalid API key');
-      expect(result.body).toEqual({ detail: 'Unauthorized' });
+      expect(result.body).toEqual({
+        detail: 'Unauthorized',
+        message: 'Invalid API key',
+        provider: 'openai',
+      });
+    });
+
+    it('preserves top-level context from ChatCompletionErrorPayload', () => {
+      const budget = { required: 12 };
+
+      const result = formatErrorForState({
+        budget,
+        error: { message: 'Budget exceeded' },
+        errorType: ChatErrorType.FreePlanLimit,
+        provider: 'lobehub',
+      });
+
+      expect(result).toMatchObject({
+        attribution: 'user',
+        body: {
+          budget,
+          message: 'Budget exceeded',
+          provider: 'lobehub',
+        },
+        category: 'quota',
+        httpStatus: 402,
+        message: 'Budget exceeded',
+        type: ChatErrorType.FreePlanLimit,
+      });
     });
 
     it('wraps standard Error as InternalServerError', () => {

--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
@@ -227,6 +227,24 @@ describe('formatErrorForState', () => {
       });
     });
 
+    it('merges payload status into an existing _responseBody error object', () => {
+      const result = formatErrorForState({
+        _responseBody: { error: { message: 'Payment required' }, provider: 'lobehub' },
+        error: { status: 402 },
+        errorType: AgentRuntimeErrorType.ProviderBizError,
+        message: 'opaque upstream message',
+      });
+
+      expect(result).toMatchObject({
+        body: {
+          error: { message: 'Payment required', status: 402 },
+          provider: 'lobehub',
+        },
+        category: 'quota',
+        type: AgentRuntimeErrorType.InsufficientQuota,
+      });
+    });
+
     it('keeps a genuine residual as ProviderBizError (E8002)', () => {
       const result = formatErrorForState({
         errorType: AgentRuntimeErrorType.ProviderBizError,

--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
@@ -208,6 +208,25 @@ describe('formatErrorForState', () => {
       expect(result.category).toBe('quota');
     });
 
+    it('keeps payload.error available when _responseBody is present', () => {
+      const result = formatErrorForState({
+        _responseBody: { provider: 'lobehub' },
+        error: { status: 402 },
+        errorType: AgentRuntimeErrorType.ProviderBizError,
+        message: 'opaque upstream message',
+      });
+
+      expect(result).toMatchObject({
+        body: {
+          error: { status: 402 },
+          message: 'opaque upstream message',
+          provider: 'lobehub',
+        },
+        category: 'quota',
+        type: AgentRuntimeErrorType.InsufficientQuota,
+      });
+    });
+
     it('keeps a genuine residual as ProviderBizError (E8002)', () => {
       const result = formatErrorForState({
         errorType: AgentRuntimeErrorType.ProviderBizError,

--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.ts
@@ -42,6 +42,17 @@ interface ChatCompletionErrorPayloadLike {
   provider?: unknown;
 }
 
+const mergePayloadError = (
+  sourceBody: Record<string, unknown>,
+  payload: ChatCompletionErrorPayloadLike,
+): unknown | undefined => {
+  if (payload._responseBody === undefined || payload.error === undefined) return undefined;
+  if (!('error' in sourceBody)) return payload.error;
+  if (isRecord(sourceBody.error) && isRecord(payload.error)) {
+    return { ...payload.error, ...sourceBody.error };
+  }
+};
+
 const buildPayloadBody = (
   payload: ChatCompletionErrorPayloadLike,
   originalError: unknown,
@@ -58,17 +69,14 @@ const buildPayloadBody = (
   if (typeof payload.provider === 'string') context.provider = payload.provider;
 
   if (isRecord(sourceBody)) {
-    const shouldAttachPayloadError =
-      payload._responseBody !== undefined &&
-      payload.error !== undefined &&
-      !('error' in sourceBody);
+    const payloadError = mergePayloadError(sourceBody, payload);
 
     return {
       ...sourceBody,
       // `_responseBody` is the display-facing body, but gateway/model-runtime
       // still carries status/provider details in `error` for some failures:
-      // `{ _responseBody: {...}, error: { status: 402 } }`.
-      ...(shouldAttachPayloadError ? { error: payload.error } : {}),
+      // `{ _responseBody: { error: { message } }, error: { status: 402 } }`.
+      ...(payloadError === undefined ? {} : { error: payloadError }),
       ...(payload.budget !== undefined && !('budget' in sourceBody)
         ? { budget: payload.budget }
         : {}),

--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.ts
@@ -58,8 +58,17 @@ const buildPayloadBody = (
   if (typeof payload.provider === 'string') context.provider = payload.provider;
 
   if (isRecord(sourceBody)) {
+    const shouldAttachPayloadError =
+      payload._responseBody !== undefined &&
+      payload.error !== undefined &&
+      !('error' in sourceBody);
+
     return {
       ...sourceBody,
+      // `_responseBody` is the display-facing body, but gateway/model-runtime
+      // still carries status/provider details in `error` for some failures:
+      // `{ _responseBody: {...}, error: { status: 402 } }`.
+      ...(shouldAttachPayloadError ? { error: payload.error } : {}),
       ...(payload.budget !== undefined && !('budget' in sourceBody)
         ? { budget: payload.budget }
         : {}),

--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.ts
@@ -1,5 +1,6 @@
 import { getErrorCodeSpec, refineErrorCode } from '@lobechat/model-runtime';
 import { AgentRuntimeErrorType, ChatErrorType, type ChatMessageError } from '@lobechat/types';
+import { isRecord } from '@lobechat/utils';
 
 /** Pull a usable HTTP status out of the nested upstream error object. */
 const extractHttpStatus = (body: unknown): number | undefined => {
@@ -17,6 +18,63 @@ const extractProvider = (body: unknown): string | undefined => {
   if (!body || typeof body !== 'object') return undefined;
   const p = (body as { provider?: unknown }).provider;
   return typeof p === 'string' ? p : undefined;
+};
+
+const extractMessage = (value: unknown): string | undefined => {
+  if (!isRecord(value)) return undefined;
+
+  const message = value.message;
+  if (typeof message === 'string' && message) return message;
+
+  const nestedError = value.error;
+  if (isRecord(nestedError)) {
+    const nestedMessage = nestedError.message;
+    if (typeof nestedMessage === 'string' && nestedMessage) return nestedMessage;
+  }
+};
+
+interface ChatCompletionErrorPayloadLike {
+  _responseBody?: unknown;
+  budget?: unknown;
+  error?: unknown;
+  errorType: ChatMessageError['type'];
+  message?: string;
+  provider?: unknown;
+}
+
+const buildPayloadBody = (
+  payload: ChatCompletionErrorPayloadLike,
+  originalError: unknown,
+  message: string,
+): unknown => {
+  // Runtime payloads often keep UI context (for example quota hints) next to
+  // `error`, while `error` itself only carries the display message. Merge both
+  // layers so normalizing `{ errorType, error }` does not drop the fields the
+  // chat error renderer needs later.
+  const sourceBody = payload._responseBody ?? payload.error ?? originalError;
+  const context: Record<string, unknown> = {};
+
+  if (payload.budget !== undefined) context.budget = payload.budget;
+  if (typeof payload.provider === 'string') context.provider = payload.provider;
+
+  if (isRecord(sourceBody)) {
+    return {
+      ...sourceBody,
+      ...(payload.budget !== undefined && !('budget' in sourceBody)
+        ? { budget: payload.budget }
+        : {}),
+      ...(typeof payload.provider === 'string' && !('provider' in sourceBody)
+        ? { provider: payload.provider }
+        : {}),
+      ...('message' in sourceBody ? {} : { message }),
+    };
+  }
+
+  return {
+    ...context,
+    ...(sourceBody === undefined ? {} : { error: sourceBody }),
+    message,
+  };
 };
 
 /**
@@ -79,14 +137,16 @@ const enrichWithSpec = (formatted: ChatMessageError): ChatMessageError => {
  */
 export const formatErrorForState = (error: unknown): ChatMessageError => {
   if (error && typeof error === 'object' && 'errorType' in error) {
-    const payload = error as {
-      error?: unknown;
-      errorType: ChatMessageError['type'];
-      message?: string;
-    };
+    const payload = error as ChatCompletionErrorPayloadLike;
+    const message =
+      (payload.message && payload.message !== 'error' ? payload.message : undefined) ??
+      extractMessage(payload._responseBody) ??
+      extractMessage(payload.error) ??
+      String(payload.errorType);
+
     return enrichWithSpec({
-      body: payload.error || error,
-      message: payload.message || String(payload.errorType),
+      body: buildPayloadBody(payload, error, message),
+      message,
       type: payload.errorType,
     });
   }

--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -7,6 +7,7 @@ import {
 } from '@/database/models/agentOperation';
 import { MessageModel } from '@/database/models/message';
 import { type LobeChatDatabase } from '@/database/type';
+import { formatErrorForState } from '@/server/modules/AgentRuntime/formatErrorForState';
 import { buildFinalSnapshotKey } from '@/server/modules/AgentTracing';
 import { emitAgentSignalSourceEvent } from '@/server/services/agentSignal';
 import { toAgentSignalTraceEvents } from '@/server/services/agentSignal/observability/traceEvents';
@@ -361,13 +362,20 @@ export class CompletionLifecycle {
 
         const assistantMessageId = metadata?.assistantMessageId;
         if (assistantMessageId && state?.error) {
-          const errorMessage = this.extractErrorMessage(state.error) || String(state.error);
+          // Preserve the semantic error type written by the runtime. Rebuilding
+          // this as a generic AgentRuntimeError would lose UI routing data such
+          // as quota context and force the client into the fallback card.
+          const messageError = formatErrorForState(state.error);
+          const errorMessage =
+            this.extractErrorMessage(messageError) ||
+            this.extractErrorMessage(state.error) ||
+            String(state.error);
           try {
             await this.messageModel.update(assistantMessageId, {
               error: {
-                body: { message: errorMessage },
+                ...messageError,
+                body: messageError.body ?? { message: errorMessage },
                 message: errorMessage,
-                type: 'AgentRuntimeError',
               },
             });
           } catch (updateError) {

--- a/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { ChatErrorType } from '@lobechat/types';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { CompletionLifecycle } from '../CompletionLifecycle';
@@ -194,6 +195,50 @@ describe('CompletionLifecycle.buildLifecycleEvent', () => {
     expect(event.lastAssistantContent).toBeUndefined();
     expect(event.attachments).toBeUndefined();
     expect(event.agentId).toBe('a');
+  });
+});
+
+describe('CompletionLifecycle.dispatchHooks — error persistence', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists budget errors without downgrading them to AgentRuntimeError', async () => {
+    const lifecycle = buildLifecycle();
+    const updateMessage = vi.fn().mockResolvedValue({ success: true });
+    const budget = { required: 12 };
+
+    (lifecycle as any).messageModel = { update: updateMessage };
+    vi.spyOn(lifecycle as any, 'persistCompletion').mockResolvedValue(undefined);
+    vi.spyOn(hookDispatcher, 'dispatch').mockResolvedValue(undefined as any);
+    vi.spyOn(hookDispatcher, 'unregister').mockImplementation(() => {});
+
+    await lifecycle.dispatchHooks(
+      'op-1',
+      {
+        error: {
+          budget,
+          error: { message: 'Budget exceeded' },
+          errorType: ChatErrorType.FreePlanLimit,
+          provider: 'lobehub',
+        },
+        metadata: { _hooks: [], assistantMessageId: 'msg-1' },
+        status: 'error',
+      },
+      'error',
+    );
+
+    expect(updateMessage).toHaveBeenCalledWith('msg-1', {
+      error: expect.objectContaining({
+        body: expect.objectContaining({
+          budget,
+          message: 'Budget exceeded',
+          provider: 'lobehub',
+        }),
+        message: 'Budget exceeded',
+        type: ChatErrorType.FreePlanLimit,
+      }),
+    });
   });
 });
 

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -1128,6 +1128,37 @@ describe('createGatewayEventHandler', () => {
       );
     });
 
+    it('error event preserves _responseBody while merging payload error metadata', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+
+      handler(
+        makeEvent('error', {
+          _responseBody: {
+            error: { message: 'Payment required' },
+            provider: 'lobehub',
+          },
+          error: { status: 402 },
+          errorType: 'ProviderBizError',
+        }),
+      );
+      await flush();
+
+      expect(messageService.updateMessageError).toHaveBeenCalledWith(
+        'msg-initial',
+        expect.objectContaining({
+          body: expect.objectContaining({
+            error: { message: 'Payment required', status: 402 },
+            message: 'Payment required',
+            provider: 'lobehub',
+          }),
+          message: 'Payment required',
+          type: 'ProviderBizError',
+        }),
+        expect.anything(),
+      );
+    });
+
     // Contrast probe: agent_runtime_end on the SAME operation (which has a
     // context.agentId) DOES mark unread completed — proving the negative
     // assertion above is the error path's own behavior, not a missing agentId.

--- a/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
@@ -1098,6 +1098,36 @@ describe('createGatewayEventHandler', () => {
       expect(store.markUnreadCompleted).not.toHaveBeenCalled();
     });
 
+    it('error event preserves runtime payload errorType and budget context', async () => {
+      const store = createMockStore();
+      const handler = createHandler(store);
+      const budget = { required: 12 };
+
+      handler(
+        makeEvent('error', {
+          budget,
+          error: { message: 'Budget exceeded' },
+          errorType: 'FreePlanLimit',
+          provider: 'lobehub',
+        }),
+      );
+      await flush();
+
+      expect(messageService.updateMessageError).toHaveBeenCalledWith(
+        'msg-initial',
+        expect.objectContaining({
+          body: expect.objectContaining({
+            budget,
+            message: 'Budget exceeded',
+            provider: 'lobehub',
+          }),
+          message: 'Budget exceeded',
+          type: 'FreePlanLimit',
+        }),
+        expect.anything(),
+      );
+    });
+
     // Contrast probe: agent_runtime_end on the SAME operation (which has a
     // context.agentId) DOES mark unread completed — proving the negative
     // assertion above is the error path's own behavior, not a missing agentId.

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -178,11 +178,51 @@ const getMessageFromErrorData = (data: unknown): string | undefined => {
     }
   }
 
+  const responseBody = data._responseBody;
+  const responseBodyMessage = getMessageFromErrorData(responseBody);
+  if (responseBodyMessage) return responseBodyMessage;
+
   const body = data.body;
   if (isRecord(body)) {
     const bodyMessage = body.message;
     if (typeof bodyMessage === 'string' && bodyMessage) return bodyMessage;
   }
+};
+
+const mergeGatewayPayloadError = (
+  sourceBody: Record<string, unknown>,
+  payloadError: unknown,
+): Record<string, unknown> => {
+  if (payloadError === undefined) return sourceBody;
+  if (!('error' in sourceBody)) return { ...sourceBody, error: payloadError };
+  if (isRecord(sourceBody.error) && isRecord(payloadError)) {
+    return { ...sourceBody, error: { ...payloadError, ...sourceBody.error } };
+  }
+  return sourceBody;
+};
+
+const buildGatewayRuntimeErrorBody = (
+  data: Record<string, unknown>,
+  message: string,
+): Record<string, unknown> => {
+  const sourceBody = isRecord(data._responseBody)
+    ? data._responseBody
+    : isRecord(data.error)
+      ? data.error
+      : {};
+  const mergedBody =
+    data._responseBody === undefined
+      ? sourceBody
+      : mergeGatewayPayloadError(sourceBody, data.error);
+
+  return {
+    ...mergedBody,
+    ...(data.budget === undefined || 'budget' in mergedBody ? {} : { budget: data.budget }),
+    ...(typeof data.provider === 'string' && !('provider' in mergedBody)
+      ? { provider: data.provider }
+      : {}),
+    ...('message' in mergedBody ? {} : { message }),
+  };
 };
 
 const toChatMessageError = (data: unknown): ChatMessageError => {
@@ -204,15 +244,9 @@ const toChatMessageError = (data: unknown): ChatMessageError => {
   // it as the same semantic error instead of falling back to AgentRuntimeError.
   if (isRecord(data) && isErrorType(data.errorType)) {
     const message = getMessageFromErrorData(data) || String(data.errorType);
-    const errorBody = isRecord(data.error) ? data.error : {};
 
     return {
-      body: {
-        ...errorBody,
-        ...(data.budget === undefined ? {} : { budget: data.budget }),
-        ...(typeof data.provider === 'string' ? { provider: data.provider } : {}),
-        message,
-      },
+      body: buildGatewayRuntimeErrorBody(data, message),
       message,
       type: data.errorType,
     };

--- a/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
+++ b/src/store/chat/slices/aiChat/actions/gatewayEventHandler.ts
@@ -14,6 +14,7 @@ import type {
   UIChatMessage,
 } from '@lobechat/types';
 import { AgentRuntimeErrorType } from '@lobechat/types';
+import { isRecord } from '@lobechat/utils';
 
 import { messageService } from '@/services/message';
 import { emitClientAgentSignalSourceEvent } from '@/store/chat/slices/aiChat/actions/agentSignalBridge';
@@ -155,21 +156,69 @@ const findNextAssistantMessageId = (
   }
 };
 
+const isErrorType = (value: unknown): value is ChatMessageError['type'] =>
+  typeof value === 'string' || typeof value === 'number';
+
+const getMessageFromErrorData = (data: unknown): string | undefined => {
+  if (!isRecord(data)) return undefined;
+
+  const message = data.message;
+  if (typeof message === 'string' && message) return message;
+
+  const error = data.error;
+  if (typeof error === 'string' && error) return error;
+  if (isRecord(error)) {
+    const errorMessage = error.message;
+    if (typeof errorMessage === 'string' && errorMessage) return errorMessage;
+
+    const nestedError = error.error;
+    if (isRecord(nestedError)) {
+      const nestedMessage = nestedError.message;
+      if (typeof nestedMessage === 'string' && nestedMessage) return nestedMessage;
+    }
+  }
+
+  const body = data.body;
+  if (isRecord(body)) {
+    const bodyMessage = body.message;
+    if (typeof bodyMessage === 'string' && bodyMessage) return bodyMessage;
+  }
+};
+
 const toChatMessageError = (data: unknown): ChatMessageError => {
-  if (typeof data === 'object' && data && 'type' in data && typeof data.type === 'string') {
-    const error = data as ChatMessageError;
+  if (isRecord(data) && isErrorType(data.type)) {
+    const message =
+      typeof data.message === 'string' && data.message
+        ? data.message
+        : getMessageFromErrorData({ body: data.body });
+
     return {
-      ...error,
-      message: error.message || error.body?.message,
+      ...data,
+      ...(message ? { message } : {}),
+      type: data.type,
     };
   }
 
-  const message =
-    typeof data === 'object' && data && 'message' in data && typeof data.message === 'string'
-      ? data.message
-      : typeof data === 'object' && data && 'error' in data && typeof data.error === 'string'
-        ? data.error
-        : 'Unknown error';
+  // Gateway realtime error events can carry the model-runtime payload shape
+  // (`errorType` + `error`) before the terminal DB message is refreshed. Treat
+  // it as the same semantic error instead of falling back to AgentRuntimeError.
+  if (isRecord(data) && isErrorType(data.errorType)) {
+    const message = getMessageFromErrorData(data) || String(data.errorType);
+    const errorBody = isRecord(data.error) ? data.error : {};
+
+    return {
+      body: {
+        ...errorBody,
+        ...(data.budget === undefined ? {} : { budget: data.budget }),
+        ...(typeof data.provider === 'string' ? { provider: data.provider } : {}),
+        message,
+      },
+      message,
+      type: data.errorType,
+    };
+  }
+
+  const message = getMessageFromErrorData(data) || 'Unknown error';
 
   return {
     body: { message },


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-10592

#### 🔀 Description of Change

Preserve semantic chat/runtime error payloads across the gateway runtime lifecycle instead of collapsing terminal message errors into a generic `AgentRuntimeError`.

This updates the runtime error normalization path to keep top-level context such as quota metadata and provider details when converting `{ errorType, error }` payloads into `ChatMessageError`. The terminal lifecycle now persists the normalized semantic error, and the gateway realtime error handler recognizes `errorType` payloads before falling back to `AgentRuntimeError`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts src/store/chat/slices/aiChat/actions/__tests__/gatewayEventHandler.test.ts
```

Also checked diagnostics from the cloud workspace root:

```bash
vscode-cli get-diagnostics
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Key decisions:

- Preserve the existing semantic `errorType` instead of remapping quota-style chat errors to `AgentRuntimeError`.
- Keep this in the generic error contract path, not in the UI renderer, so other semantic chat errors are not downgraded by the gateway terminal path.
- No UI changes, data migrations, feature flags, or provider configuration changes.