### PR TITLE
🐛 fix(device): tolerate CRLF line endings when editing files & surface real edit errors

### DIFF
--- a/packages/local-file-shell/src/file/__tests__/file.test.ts
+++ b/packages/local-file-shell/src/file/__tests__/file.test.ts
@@ -304,6 +304,39 @@ describe('file operations', () => {
       expect(result.linesAdded).toBeGreaterThan(0);
       expect(result.linesDeleted).toBeGreaterThan(0);
     });
+
+    it('should match a multi-line LF old_string against a CRLF file (Windows)', async () => {
+      const filePath = path.join(tmpDir, 'crlf.txt');
+      await writeFile(filePath, 'line1\r\nline2\r\nline3\r\n');
+
+      // LLM emits `\n` even though the file on disk uses `\r\n`.
+      const result = await editLocalFile({
+        file_path: filePath,
+        new_string: 'lineA\nlineB',
+        old_string: 'line1\nline2',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.replacements).toBe(1);
+      // Existing CRLF line-ending style is preserved.
+      expect(fs.readFileSync(filePath, 'utf8')).toBe('lineA\r\nlineB\r\nline3\r\n');
+    });
+
+    it('should replace_all with an LF old_string against a CRLF file', async () => {
+      const filePath = path.join(tmpDir, 'crlf-all.txt');
+      await writeFile(filePath, 'a\r\nb\r\na\r\nb\r\n');
+
+      const result = await editLocalFile({
+        file_path: filePath,
+        new_string: 'x\ny',
+        old_string: 'a\nb',
+        replace_all: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.replacements).toBe(2);
+      expect(fs.readFileSync(filePath, 'utf8')).toBe('x\r\ny\r\nx\r\ny\r\n');
+    });
   });
 
   // ─── listLocalFiles ───

--- a/packages/local-file-shell/src/file/edit.ts
+++ b/packages/local-file-shell/src/file/edit.ts
@@ -16,7 +16,24 @@ export async function editLocalFile({
   try {
     const content = await readFile(filePath, 'utf8');
 
-    if (!content.includes(old_string)) {
+    // Resolve the search/replace strings against the file's actual line endings.
+    // LLMs almost always emit `\n` even when the on-disk file uses CRLF (the norm
+    // on Windows), so a literal match would fail and the edit appears broken. When
+    // the raw old_string isn't present but its CRLF-adjusted form is, edit against
+    // that — keeping the file's existing line-ending style and producing a minimal
+    // diff instead of rewriting every line.
+    let search = old_string;
+    let replace = new_string;
+    if (!content.includes(search) && content.includes('\r\n')) {
+      const toCRLF = (s: string) => s.replaceAll('\r\n', '\n').replaceAll('\n', '\r\n');
+      const crlfSearch = toCRLF(search);
+      if (content.includes(crlfSearch)) {
+        search = crlfSearch;
+        replace = toCRLF(replace);
+      }
+    }
+
+    if (!content.includes(search)) {
       return {
         error: 'The specified old_string was not found in the file',
         replacements: 0,
@@ -28,16 +45,16 @@ export async function editLocalFile({
     let replacements: number;
 
     if (replace_all) {
-      const regex = new RegExp(old_string.replaceAll(/[$()*+.?[\\\]^{|}]/g, '\\$&'), 'g');
+      const regex = new RegExp(search.replaceAll(/[$()*+.?[\\\]^{|}]/g, '\\$&'), 'g');
       const matches = content.match(regex);
       replacements = matches ? matches.length : 0;
-      newContent = content.replaceAll(old_string, new_string);
+      newContent = content.replaceAll(search, replace);
     } else {
-      const index = content.indexOf(old_string);
+      const index = content.indexOf(search);
       if (index === -1) {
         return { error: 'Old string not found', replacements: 0, success: false };
       }
-      newContent = content.slice(0, index) + new_string + content.slice(index + old_string.length);
+      newContent = content.slice(0, index) + replace + content.slice(index + search.length);
       replacements = 1;
     }
 

--- a/packages/tool-runtime/src/LocalSystemExecutionRuntime.ts
+++ b/packages/tool-runtime/src/LocalSystemExecutionRuntime.ts
@@ -264,6 +264,13 @@ export class LocalSystemExecutionRuntime extends ComputerRuntime {
 
       case 'editLocalFile': {
         return {
+          // Surface raw.error at the top level so ComputerRuntime.errorOutput has
+          // a real message to render. Without this, a failed edit (e.g. old_string
+          // not found — common on Windows when CRLF/LF differ) left result.error
+          // undefined and the tool message collapsed to the generic
+          // "[UNKNOWN_EXEC_ERROR] Tool execution failed", hiding the real reason
+          // and blocking the model from self-correcting. Mirrors grep/glob above.
+          error: raw.error ? { message: String(raw.error) } : undefined,
           result: {
             diffText: raw.diffText,
             error: raw.error,

--- a/packages/tool-runtime/src/__tests__/LocalSystemExecutionRuntime.test.ts
+++ b/packages/tool-runtime/src/__tests__/LocalSystemExecutionRuntime.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  type ILocalSystemService,
+  LocalSystemExecutionRuntime,
+} from '../LocalSystemExecutionRuntime';
+
+const createService = (overrides: Partial<ILocalSystemService> = {}): ILocalSystemService => ({
+  editLocalFile: vi.fn(),
+  getCommandOutput: vi.fn(),
+  globFiles: vi.fn(),
+  grepContent: vi.fn(),
+  killCommand: vi.fn(),
+  listLocalFiles: vi.fn(),
+  moveLocalFiles: vi.fn(),
+  readLocalFile: vi.fn(),
+  readLocalFiles: vi.fn(),
+  renameLocalFile: vi.fn(),
+  runCommand: vi.fn(),
+  searchLocalFiles: vi.fn(),
+  writeFile: vi.fn(),
+  ...overrides,
+});
+
+describe('LocalSystemExecutionRuntime.editFile', () => {
+  it('surfaces the underlying error message instead of UNKNOWN_EXEC_ERROR', async () => {
+    const service = createService({
+      editLocalFile: vi.fn().mockResolvedValue({
+        error: 'The specified old_string was not found in the file',
+        replacements: 0,
+        success: false,
+      }),
+    });
+    const runtime = new LocalSystemExecutionRuntime(service);
+
+    const output = await runtime.editFile({
+      all: false,
+      path: 'C:/foo.ts',
+      replace: 'bar',
+      search: 'foo',
+    });
+
+    expect(output.success).toBe(true);
+    expect(output.content).toBe('The specified old_string was not found in the file');
+    expect(output.content).not.toContain('UNKNOWN_EXEC_ERROR');
+  });
+
+  it('returns a formatted success result on a successful edit', async () => {
+    const service = createService({
+      editLocalFile: vi.fn().mockResolvedValue({
+        diffText: 'diff',
+        linesAdded: 1,
+        linesDeleted: 1,
+        replacements: 1,
+        success: true,
+      }),
+    });
+    const runtime = new LocalSystemExecutionRuntime(service);
+
+    const output = await runtime.editFile({
+      all: false,
+      path: 'C:/foo.ts',
+      replace: 'bar',
+      search: 'foo',
+    });
+
+    expect(output.success).toBe(true);
+    expect((output.state as { replacements: number }).replacements).toBe(1);
+    expect(output.content).not.toContain('UNKNOWN_EXEC_ERROR');
+  });
+});

--- a/packages/tool-runtime/vitest.config.mts
+++ b/packages/tool-runtime/vitest.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none found -->

#### 🔀 Description of Change

Editing files on a remote device frequently failed on **Windows** with an opaque `"[UNKNOWN_EXEC_ERROR] Tool execution failed"`. Two stacked bugs were behind it:

**Root cause — CRLF line endings (`packages/local-file-shell/src/file/edit.ts`)**
`editLocalFile` did an exact `content.includes(old_string)` match. Windows files are usually `\r\n`, but the model almost always emits `old_string` with `\n`, so the match never succeeded and the edit silently failed (Mac/Linux LF files were fine). Now, when the exact match fails **and the file uses CRLF**, we retry against a CRLF-adjusted search/replace and write back preserving the file's existing line endings.

- The check is gated on **file content** (`\r\n` present), **not the OS** — so CRLF files cloned onto macOS/Linux are also handled, and LF files on Windows are left untouched.
- Double-guarded: it only runs after the exact match already failed, and only switches when the CRLF variant actually matches — so it can never break a currently-working edit.

**Error visibility (`packages/tool-runtime/src/LocalSystemExecutionRuntime.ts`)**
`normalizeResult` nested the failure message under `result.result.error`, but `ComputerRuntime.errorOutput` only reads the top-level `result.error` → every failed edit collapsed into `[UNKNOWN_EXEC_ERROR]`. Now `raw.error` is surfaced at the top level (mirroring the existing `grep`/`glob` cases), so the model sees the real reason ("old_string not found") and can self-correct.

Both paths are shared by local execution (`LocalSystemExecutor`) and the remote device gateway (`GatewayConnectionCtr`), so **local and remote device editing both benefit**.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- `packages/local-file-shell/src/file/__tests__/file.test.ts`: new cases for an LF `old_string` matching a CRLF file (single + `replace_all`), asserting CRLF style is preserved (56 passed).
- `packages/tool-runtime/src/__tests__/LocalSystemExecutionRuntime.test.ts`: new — asserts a failed edit returns the real error instead of `UNKNOWN_EXEC_ERROR`, and the success path is intact (2 passed).
- `packages/tool-runtime/vitest.config.mts`: the package had no vitest config and was inheriting the root web-app `tests/setup.ts` (which fails to resolve `@/locales`); added a minimal `environment: 'node'` config like other leaf packages.

#### 📝 Additional Information

No behavior change for the common LF-on-LF case (exact match still hits first). Edge case: classic Mac single-`\r` endings are not converted, but that only falls back to the normal "not found" error — no file corruption.