### PR TITLE
🐛 fix(bot): recover MIME type for QQ c2c file attachments so audio reaches the model

### DIFF
--- a/apps/server/src/services/aiAgent/ingestAttachment.ts
+++ b/apps/server/src/services/aiAgent/ingestAttachment.ts
@@ -129,8 +129,14 @@ export async function ingestAttachment(
     throw new Error('AttachmentSource must have either buffer or url');
   }
 
-  // 2. MIME correction from filename
-  if (mimeType === 'application/octet-stream' && source.name) {
+  // 2. MIME correction from filename.
+  // Recover whenever we don't have a usable MIME type — both the generic
+  // `application/octet-stream` and bogus non-MIME values some platforms send
+  // (e.g. QQ labels c2c file attachments as `"file"`). Without the `includes('/')`
+  // guard, a value like `"file"` slips through and an `.m4a` never gets
+  // classified as audio, so it's parsed as a document instead of passed to
+  // audio-capable models.
+  if ((mimeType === 'application/octet-stream' || !mimeType.includes('/')) && source.name) {
     const inferred = mime.getType(source.name);
     if (inferred) {
       log('ingestAttachment: inferred mimeType from filename: %s -> %s', source.name, inferred);

--- a/packages/chat-adapter-qq/package.json
+++ b/packages/chat-adapter-qq/package.json
@@ -16,7 +16,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "chat": "^4.23.0"
+    "chat": "^4.23.0",
+    "mime": "^4.1.0"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",

--- a/packages/chat-adapter-qq/src/adapter.test.ts
+++ b/packages/chat-adapter-qq/src/adapter.test.ts
@@ -295,6 +295,27 @@ describe('QQAdapter', () => {
       expect(message?.attachments[0].type).toBe('file');
     });
 
+    it('should infer mime type from filename when content_type is the bare "file" label', async () => {
+      // QQ delivers c2c file attachments with content_type === 'file' (a coarse
+      // category, not a real MIME type). It must be recovered from the filename
+      // so an .m4a is classified as audio instead of an unreadable document.
+      const attachment = makeAttachment({
+        content_type: 'file',
+        filename: 'Broadstone Amelia 5.m4a',
+      });
+      const payload = makeWebhookPayload(QQ_EVENT_TYPES.GROUP_AT_MESSAGE_CREATE, {
+        attachments: [attachment],
+        content: 'audio file',
+      });
+      await adapter.handleWebhook(makeRequest(payload));
+
+      const factory = vi.mocked(mockChat.processMessage).mock.calls[0]?.[2];
+      const message = await factory?.();
+
+      expect(message?.attachments[0].mimeType).toBe('audio/mp4');
+      expect(message?.attachments[0].type).toBe('audio');
+    });
+
     it('should map multiple attachments', async () => {
       const attachments = [
         makeAttachment({ content_type: 'image/png', filename: 'a.png' }),

--- a/packages/chat-adapter-qq/src/adapter.ts
+++ b/packages/chat-adapter-qq/src/adapter.ts
@@ -14,6 +14,7 @@ import type {
   WebhookOptions,
 } from 'chat';
 import { Message, parseMarkdown } from 'chat';
+import mime from 'mime';
 
 import { QQApiClient } from './api';
 import { signWebhookResponse } from './crypto';
@@ -395,18 +396,33 @@ export class QQAdapter implements Adapter<QQThreadId, QQRawMessage> {
     if (!qqAttachments || qqAttachments.length === 0) return [];
 
     return qqAttachments.map((a) => {
-      const type = this.resolveAttachmentType(a.content_type);
+      // QQ's `content_type` is not always a real MIME type — for c2c file
+      // attachments it comes back as the coarse category label `"file"`. Trusting
+      // it verbatim mislabels e.g. an `.m4a` as `"file"` instead of `audio/mp4`,
+      // which then defeats the filename-based MIME recovery in ingestAttachment
+      // (that only re-infers for `application/octet-stream`). Fall back to the
+      // filename when content_type isn't a usable MIME type.
+      const mimeType = this.resolveMimeType(a.content_type, a.filename);
       return {
         fetchData: () => this.fetchAttachmentData(a.url),
         height: a.height,
-        mimeType: a.content_type,
+        mimeType,
         name: a.filename,
         size: a.size,
-        type,
+        type: this.resolveAttachmentType(mimeType),
         url: a.url,
         width: a.width,
       } as Attachment;
     });
+  }
+
+  /**
+   * Resolve a usable MIME type from QQ's `content_type`, falling back to
+   * filename-based inference when QQ sends a non-MIME value (e.g. `"file"`).
+   */
+  private resolveMimeType(contentType: string | undefined, filename?: string): string {
+    if (contentType && contentType.includes('/')) return contentType;
+    return (filename && mime.getType(filename)) || 'application/octet-stream';
   }
 
   private resolveAttachmentType(contentType: string): 'image' | 'video' | 'audio' | 'file' {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

QQ delivers **c2c file attachments** with `content_type` set to the coarse category label `"file"` rather than a real MIME type. The QQ adapter trusted it verbatim (`mimeType: a.content_type`), so an uploaded `.m4a` was stored in `files.file_type = "file"`.

Because that isn't an `audio/*` type, `ingestAttachment` did not classify it as audio and instead routed it down the **document-parse** path, attempting to extract text from the binary. That failed, the model only received a "file content could not be extracted" note, and the user saw the bot reply that the audio was unreadable — **even though the same file works fine via WeChat and the web upload**, because those paths infer the MIME type from the filename (`mime.getType(name)`).

The bogus `"file"` value also slipped past `ingestAttachment`'s own filename-based MIME recovery, which only re-inferred when the type was exactly `application/octet-stream`.

Two fixes:

1. **`chat-adapter-qq`** — fall back to `mime.getType(filename)` when `content_type` is not a usable MIME type (matches the WeChat adapter), and derive the attachment `type` from the resolved MIME instead of the raw label.
2. **`ingestAttachment`** — broaden the filename-recovery condition to *any* non-MIME value (`!mimeType.includes('/')`), not just `application/octet-stream`, so a stray platform label can't poison classification for any adapter.

Diagnosed from two production ops on the same audio file: QQ → `file_type="file"` → "无法读取"; WeChat/web → `file_type="audio/mp4"` → works.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Added a `chat-adapter-qq` regression test: QQ attachment with `content_type: "file"` + filename `*.m4a` now resolves `mimeType: "audio/mp4"` and `type: "audio"`. Full `chat-adapter-qq` suite passes (35 tests).

#### 📝 Additional Information

No DB migration. No schema change. Behavior for attachments that already carry a valid MIME `content_type` is unchanged.