### PR TITLE
🐛 fix: resolve resource header i18n namespace fallback

### DIFF
--- a/src/features/ResourceManager/components/Explorer/Header/index.tsx
+++ b/src/features/ResourceManager/components/Explorer/Header/index.tsx
@@ -131,7 +131,7 @@ const Header = memo(() => {
   ) : !libraryId ? (
     <Flexbox style={{ marginLeft: 8 }}>
       {category === FilesTabs.All
-        ? t('resource', { defaultValue: 'Resource' })
+        ? t('resource', { ns: 'file' })
         : t(`tab.${category as FilesTabs}` as any, { ns: 'file' })}
     </Flexbox>
   ) : (


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

The resource explorer header always rendered the literal English "Resource" even under non-English locales (e.g. Chinese showed "Resource" instead of "资源").

Root cause: `t('resource', { defaultValue: 'Resource' })` did not specify the `file` namespace. Since the `useTranslation` hook's default namespace is the first entry (`components`), and a `defaultValue` was provided, i18next returns the `defaultValue` once the key is missing from the default namespace instead of falling back to the `file` namespace — where the `resource` key actually lives (zh-CN: "资源", en-US: "Resource").

Fix: pass `{ ns: 'file' }` explicitly, matching the adjacent `t(\`tab.${category}\`, { ns: 'file' })` call. No new locale keys needed — `resource` already exists in `file.json`.

#### 🧪 How to Test

- [x] Tested locally

Open `/resource` under a non-English locale; the header now shows the localized "资源" instead of "Resource".

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Header shows "Resource" | Header shows localized "资源" |