### PR TITLE
🐛 fix: avoid flashing unauthorized state in tool auth alert

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/AgentWelcome/ToolAuthAlert.tsx
+++ b/src/routes/(main)/agent/features/Conversation/AgentWelcome/ToolAuthAlert.tsx
@@ -342,6 +342,11 @@ const ToolAuthAlert = memo(() => {
   const agentId = useConversationStore(contextSelectors.agentId);
   const plugins = useAgentStore(agentByIdSelectors.getAgentPluginsById(agentId), isEqual);
   const composioServers = useToolStore(composioStoreSelectors.getServers, isEqual);
+  // Connections load asynchronously via `useFetchUserComposioConnections` (fired by
+  // ChatInput on the same page). Until they arrive, `composioServers` is the empty
+  // fallback — don't treat a missing server as "needs auth" or the card flashes a
+  // false unauthorized state on refresh before the real status loads.
+  const isComposioServersInit = useToolStore((s) => s.isComposioServersInit);
   const { isAuthenticated: isMarketAuthenticated } = useMarketAuth();
 
   // Filter out tools that need authorization
@@ -353,8 +358,16 @@ const ToolAuthAlert = memo(() => {
       const composioType = COMPOSIO_APP_TYPES.find((t) => t.identifier === pluginId);
       if (composioType) {
         const server = composioServers.find((s) => s.identifier === pluginId);
-        // Not installed or pending auth
-        if (!server || server.status === ComposioServerStatus.PENDING_AUTH) {
+        // A missing server only means "not installed" once connections have loaded;
+        // before that, skip it to avoid flashing a false unauthorized state.
+        if (!server) {
+          if (isComposioServersInit) {
+            result.push({ ...composioType, authType: 'composio', server });
+          }
+          continue;
+        }
+        // Pending auth
+        if (server.status === ComposioServerStatus.PENDING_AUTH) {
           result.push({ ...composioType, authType: 'composio', server });
         }
         continue;
@@ -368,7 +381,7 @@ const ToolAuthAlert = memo(() => {
     }
 
     return result;
-  }, [plugins, composioServers, isMarketAuthenticated]);
+  }, [plugins, composioServers, isComposioServersInit, isMarketAuthenticated]);
 
   // Don't render if no pending auth tools
   if (pendingAuthTools.length === 0) {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The "complete skill authorization" alert on the agent welcome screen briefly flashed an unauthorized state on refresh, even when the skill (e.g. Gmail) was already authorized.

Root cause: Composio connections load asynchronously via `useFetchUserComposioConnections` (fired by `ChatInput` on the same page). Before they arrive, `composioServers` is the empty fallback `[]`, so `ToolAuthAlert` treated every Composio plugin's missing server as "needs auth" and rendered the card — until the SWR data landed and `composioServers` was populated, at which point the card disappeared.

Fix: gate the "missing server → needs auth" branch on the existing `isComposioServersInit` flag. A missing server is only treated as unauthorized once connections have loaded; before that it is skipped, so no false unauthorized card flashes. Servers already in `PENDING_AUTH` still render immediately (behavior unchanged).

#### 🧪 How to Test

Open an agent welcome screen with an already-authorized Composio skill (e.g. Gmail) and refresh. The auth alert should no longer flash before disappearing.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

`ToolAuthAlert` itself does not fetch connections; it relies on `ChatInput` (same page) to trigger `useFetchUserComposioConnections`, so `isComposioServersInit` reliably flips to `true` and genuinely unauthorized skills are never permanently hidden.