### PR TITLE
🐛 fix(chat): treat parked runs as non-terminal in client run-lifecycle

### DIFF
--- a/src/store/chat/slices/aiChat/actions/__tests__/streamingExecutor.test.ts
+++ b/src/store/chat/slices/aiChat/actions/__tests__/streamingExecutor.test.ts
@@ -2221,16 +2221,13 @@ describe('StreamingExecutor actions', () => {
       // 1. User can see the tool intervention UI without loading indicator
       // 2. A new operation will be created when user approves/rejects
       expect(result.current.operations[operationId!].status).toBe('completed');
-      expect(agentSignalBridgeMock.emitClientAgentSignalSourceEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          payload: expect.objectContaining({
-            operationId,
-            status: 'cancelled',
-          }),
-          sourceId: `${operationId}:client:complete`,
-          sourceType: 'client.runtime.complete',
-        }),
+      // Parked ≠ terminal: NO `client.runtime.complete` is emitted — the run has
+      // not ended, it is waiting for human approval (LOBE-10382). Previously this
+      // mis-emitted a terminal `cancelled` complete signal.
+      const completeCall = agentSignalBridgeMock.emitClientAgentSignalSourceEvent.mock.calls.find(
+        (c: any) => c[0]?.sourceType === 'client.runtime.complete',
       );
+      expect(completeCall).toBeUndefined();
     });
 
     it('should fail operation when state is error', async () => {
@@ -2569,8 +2566,9 @@ describe('StreamingExecutor actions', () => {
       expect(result.current.operations[operationId].status).toBe('completed');
     });
 
-    // Parked states (run ≠ operation). These lock the CURRENT per-state handling that
-    // the unified run-lifecycle + normalized parked signal — cross-transport parked / resumed / terminal signal normalization will rewrite.
+    // Parked states (run ≠ operation): parked is NOT terminal, so it fires no
+    // terminal side effects and emits no `client.runtime.complete`. The run
+    // resumes under a new operation when the user acts (LOBE-10382).
     const pinStep = (operationId: string, status: AgentState['status']) => {
       vi.spyOn(agentRuntime.AgentRuntime.prototype, 'step').mockResolvedValue({
         events: [],
@@ -2579,7 +2577,7 @@ describe('StreamingExecutor actions', () => {
       });
     };
 
-    it('on waiting_for_async_tool: leaves the op uncompleted and emits an undefined complete-signal status', async () => {
+    it('on waiting_for_async_tool (parked): leaves the op running and emits NO complete signal', async () => {
       const { result } = renderHook(() => useChatStore());
       const drainQueuedMessages = vi.fn(() => []);
       restoreExecutor();
@@ -2599,18 +2597,16 @@ describe('StreamingExecutor actions', () => {
       pinStep(operationId, 'waiting_for_async_tool');
       await runExecutor(result, operationId);
 
-      // CURRENT BEHAVIOR (suspected gap, locked as baseline for cross-transport parked/resumed/terminal signal normalization): the completion switch
-      // has no `waiting_for_async_tool` case, so the op is never completed (stays
-      // 'running') and the queue is not drained.
+      // Parked ≠ terminal: `waiting_for_async_tool` routes to `onRunParked`, which
+      // keeps the op RUNNING until the async tool resolves and drains nothing.
       expect(result.current.operations[operationId].status).toBe('running');
       expect(drainQueuedMessages).not.toHaveBeenCalled();
 
-      // normalizeClientRuntimeCompleteStatus falls through for async_tool → undefined.
+      // No `client.runtime.complete` — the run has not ended (LOBE-10382).
       const completeCall = agentSignalBridgeMock.emitClientAgentSignalSourceEvent.mock.calls.find(
         (c: any) => c[0]?.sourceType === 'client.runtime.complete',
       );
-      expect(completeCall).toBeTruthy();
-      expect(completeCall![0].payload.status).toBeUndefined();
+      expect(completeCall).toBeUndefined();
     });
 
     it('on waiting_for_human (parked): completes the op for the UI but does NOT drain queue or mark unread', async () => {

--- a/src/store/chat/slices/aiChat/actions/runLifecycle/buildRunLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/runLifecycle/buildRunLifecycle.ts
@@ -15,17 +15,21 @@ import { messageMapKey } from '../../../../utils/messageMapKey';
 import { topicMapKey } from '../../../../utils/topicMapKey';
 import type { OperationStatus } from '../../../operation/types';
 import { mergeQueuedMessages, reconstructUploadFilesFromQueue } from '../../../operation/types';
-import type { AgentRunLifecycle, RunCompleteEvent, RunCompleteResult, RunScope } from './types';
+import type {
+  AgentRunLifecycle,
+  RunCompleteEvent,
+  RunCompleteResult,
+  RunParkedEvent,
+  RunScope,
+} from './types';
 
 /**
  * Normalize the runtime/operation status into the cross-runtime
- * `client.runtime.complete` signal status. Relocated verbatim from
- * `streamingExecutor` — kept identical for behavior preservation.
+ * `client.runtime.complete` signal status.
  *
- * NOTE: `waiting_for_human` is encoded as `cancelled` (a parked state mis-encoded as terminal) and
- * `waiting_for_async_tool` falls through to `undefined`. Both are parked, not
- * terminal — this mis-encoding is locked by characterization tests and fixed
- * when the parked/resumed signal is unified.
+ * Only TERMINAL states reach here: parked states (`waiting_for_human` /
+ * `waiting_for_async_tool`) are routed to `onRunParked` by the executor and
+ * never emit a completion signal — a run is not complete while it is parked.
  */
 const normalizeClientRuntimeCompleteStatus = (
   runtimeStatus: AgentState['status'] | undefined,
@@ -33,7 +37,6 @@ const normalizeClientRuntimeCompleteStatus = (
 ): 'cancelled' | 'completed' | 'failed' | undefined => {
   if (operationStatus === 'cancelled') return 'cancelled';
   if (operationStatus === 'failed') return 'failed';
-  if (runtimeStatus === 'waiting_for_human') return 'cancelled';
   if (operationStatus === 'completed') return 'completed';
   if (runtimeStatus === 'done') return 'completed';
   if (runtimeStatus === 'error' || runtimeStatus === 'interrupted') return 'failed';
@@ -88,11 +91,11 @@ const NOOP = async () => {};
 /**
  * Assemble the store/UI run-lifecycle hooks for a single run.
  *
- * Phase 1 (behavior-preserving): the implementations are the CLIENT
- * completion effects relocated verbatim from `streamingExecutor`, so wiring the
- * client executor to these hooks keeps the characterization net green. The
- * gateway/hetero adapters are wired in the follow-up transport unification, where the currently-missing
- * effects (title / notification / queue on gateway) are folded in.
+ * The hook bodies are the CLIENT completion effects (the fullest set today), to
+ * be reused as the shared implementation when gateway/hetero are wired in the
+ * follow-up entry convergence. `completeRun` handles only TERMINAL states;
+ * parked states route to `onRunParked` and fire no terminal side effects — a
+ * run is not complete while it is parked (see LOBE-10382).
  */
 export const buildRunLifecycle = (
   get: () => ChatStore,
@@ -257,12 +260,8 @@ export const buildRunLifecycle = (
           });
           break;
         }
-        case 'waiting_for_human': {
-          // Parked for human intervention: complete this op so the loading UI
-          // clears; a new operation runs when the user approves/rejects.
-          get().completeOperation(operationId);
-          break;
-        }
+        // Parked states (`waiting_for_human` / `waiting_for_async_tool`) never
+        // reach `completeRun` — the executor routes them to `onRunParked`.
       }
 
       emitComplete(operationId, runtimeStatus);
@@ -270,7 +269,20 @@ export const buildRunLifecycle = (
       return { requeued: false };
     },
     onRunError: NOOP,
-    onRunParked: NOOP,
+    onRunParked: async ({ operationId, reason }: RunParkedEvent) => {
+      // Parked is NOT terminal: fire NO terminal side effects (title / queue
+      // drain / notification / markUnread) and emit NO `client.runtime.complete`
+      // — the run has not ended, it is waiting out-of-band.
+      //
+      // - `waiting_for_human`: complete this operation so the loading spinner
+      //   clears for the approval UI; a NEW operation resumes the run when the
+      //   user approves / rejects / submits / skips.
+      // - `waiting_for_async_tool`: keep the operation running until the async
+      //   tool / sub-agent result resolves and drives the run forward.
+      if (reason === 'waiting_for_human') {
+        get().completeOperation(operationId);
+      }
+    },
     onRunResumed: NOOP,
     onRunStarted: NOOP,
     onTerminalPersisted: NOOP,

--- a/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
+++ b/src/store/chat/slices/aiChat/actions/streamingExecutor.ts
@@ -5,7 +5,12 @@ import {
   type Cost,
   type Usage,
 } from '@lobechat/agent-runtime';
-import { AgentRuntime, computeStepContext, GeneralChatAgent } from '@lobechat/agent-runtime';
+import {
+  AgentRuntime,
+  computeStepContext,
+  GeneralChatAgent,
+  isParkedStatus,
+} from '@lobechat/agent-runtime';
 import { LobeAgentManifest } from '@lobechat/builtin-tool-lobe-agent';
 import { createPathScopeAudit } from '@lobechat/builtin-tool-local-system';
 import { PageAgentIdentifier } from '@lobechat/builtin-tool-page-agent';
@@ -53,7 +58,7 @@ import {
   selectTodosFromMessages,
 } from '../../message/selectors/dbMessage';
 import { buildRunLifecycle } from './runLifecycle/buildRunLifecycle';
-import type { RunScope } from './runLifecycle/types';
+import type { RunParkedReason, RunScope } from './runLifecycle/types';
 
 const log = debug('lobe-store:streaming-executor');
 
@@ -765,14 +770,28 @@ export class StreamingExecutorActionImpl {
       runScope,
       runtimeType: 'client',
     });
-    const completeEvent = {
+    const lifecycleEventBase = {
       context,
       operationId,
       runId: operationId,
       runScope,
-      runtimeStatus: state.status,
       runtimeType: 'client' as const,
     };
+
+    // Parked (`waiting_for_human` / `waiting_for_async_tool`) is NOT terminal:
+    // route to `onRunParked`, which clears the loading UI for human approval but
+    // fires NO terminal side effects (title / queue drain / notification /
+    // complete signal). The run resumes under a new operation when the user
+    // approves / rejects / submits / skips.
+    if (isParkedStatus(state.status)) {
+      await runLifecycle.onRunParked({
+        ...lifecycleEventBase,
+        reason: state.status as RunParkedReason,
+      });
+      return;
+    }
+
+    const completeEvent = { ...lifecycleEventBase, runtimeStatus: state.status };
 
     const { requeued } = await runLifecycle.completeRun(completeEvent);
     // A queued follow-up sendMessage was scheduled — skip the post-run notification.


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-10382
Part of LOBE-10376 (前端 Agent Runtime 生命周期统一改造)

#### 🔀 Description of Change

A parked run — `waiting_for_human` (pending tool approval) or `waiting_for_async_tool` (deferred tool / sub-agent) — is **not** finished. It is paused waiting out-of-band and resumes under a *new* operation when the user approves / rejects / submits / skips. The client run-lifecycle wrongly drove parked states through the **terminal** path:

- `normalizeClientRuntimeCompleteStatus` mis-encoded `waiting_for_human` as a terminal `cancelled`, so a `client.runtime.complete` signal fired while the run was merely parked;
- `waiting_for_async_tool` fell through `completeRun`'s switch and emitted a complete signal with an `undefined` status.

This change routes parked states to `onRunParked` (previously a NOOP) instead of `completeRun`:

- **`waiting_for_human`** → complete the operation so the loading spinner clears for the approval UI; a new operation resumes the run.
- **`waiting_for_async_tool`** → keep the operation running until the async result drives the run forward.
- **neither** fires terminal side effects (title gen / queue drain / desktop notification / mark-unread) nor emits `client.runtime.complete` — a run is not complete while parked.

Drops the `waiting_for_human → cancelled` line from the normalizer and the parked branch from `completeRun` (parked no longer reaches it). This makes the client lifecycle a **correct** shared implementation before gateway/hetero reuse it in the follow-up entry-convergence step — fixing the bug here, before it gets copied to three transports.

Scope note: `onRunResumed` stays a NOOP — making it meaningful needs the resume-entry wiring + cross-operation run identity, deferred to the entry-convergence step (LOBE-10379). The core parked mis-encoding is fully fixed here.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Updated the parked-state characterization in `streamingExecutor.test.ts` to lock the corrected behavior (parked no longer emits `client.runtime.complete`; `waiting_for_human` op still completes for the UI, `waiting_for_async_tool` op stays running). Verified:

- `streamingExecutor.test.ts` — 43/43 green
- adjacent net (`conversationControl`, `gatewayEventHandler`, `agentSignalBridge`) — green (confirms gateway/hetero untouched)
- `bun run type-check` — clean

#### 📝 Additional Information

Store/UI-layer change only; no schema, API, or gateway/hetero changes. Rebased on latest `canary`.