### PR TITLE
✨ feat(subscription): add referral invite entry

### DIFF
--- a/locales/en-US/common.json
+++ b/locales/en-US/common.json
@@ -491,6 +491,7 @@
   "userPanel.email": "Email Support",
   "userPanel.feedback": "Contact Us",
   "userPanel.help": "Help Center",
+  "userPanel.inviteFriend": "Invite a friend",
   "userPanel.moveGuide": "The settings button has been moved here",
   "userPanel.plans": "Subscription Plans",
   "userPanel.profile": "Account",

--- a/locales/en-US/subscription.json
+++ b/locales/en-US/subscription.json
@@ -409,7 +409,7 @@
   "referral.hero.description": "Share your referral link below. After your friend makes their first payment, you each earn {{reward}}M credits.",
   "referral.hero.title": "Invite friends, you both earn <0>{{reward}}M credits</0>",
   "referral.inviteCode.description": "Share your exclusive referral code to invite friends to register",
-  "referral.inviteCode.title": "My Referral Code",
+  "referral.inviteCode.title": "My Exclusive Referral Code",
   "referral.inviteLink.description": "Copy the link and share with friends. Both of you earn credits after your friend makes a payment",
   "referral.inviteLink.title": "Referral Link",
   "referral.rules.antiAbuse": "If fraudulent activity is detected (e.g., mass registration of disposable email accounts), the associated accounts will be permanently banned",

--- a/locales/en-US/subscription.json
+++ b/locales/en-US/subscription.json
@@ -406,6 +406,8 @@
   "referral.errors.invalidFormat": "Invalid referral code format, please enter 2-8 letters, numbers or underscores",
   "referral.errors.selfReferral": "You cannot use your own invite code",
   "referral.errors.updateFailed": "Update failed, please try again later",
+  "referral.hero.description": "Share your referral link below. After your friend makes their first payment, you each earn {{reward}}M credits.",
+  "referral.hero.title": "Invite friends, you both earn <0>{{reward}}M credits</0>",
   "referral.inviteCode.description": "Share your exclusive referral code to invite friends to register",
   "referral.inviteCode.title": "My Referral Code",
   "referral.inviteLink.description": "Copy the link and share with friends. Both of you earn credits after your friend makes a payment",

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -491,6 +491,7 @@
   "userPanel.email": "邮件支持",
   "userPanel.feedback": "联系我们",
   "userPanel.help": "帮助中心",
+  "userPanel.inviteFriend": "邀请好友",
   "userPanel.moveGuide": "设置按钮搬到这里啦",
   "userPanel.plans": "订阅方案",
   "userPanel.profile": "账户管理",

--- a/locales/zh-CN/subscription.json
+++ b/locales/zh-CN/subscription.json
@@ -406,6 +406,8 @@
   "referral.errors.invalidFormat": "推荐码格式无效，请输入 2-8 位字母、数字或下划线",
   "referral.errors.selfReferral": "不能使用自己的邀请码",
   "referral.errors.updateFailed": "更新失败，请稍后重试",
+  "referral.hero.description": "把下方的推荐链接分享给好友，好友完成首次付费后，你和好友将各自获得 {{reward}}M 积分。",
+  "referral.hero.title": "邀请好友，双方各得 <0>{{reward}}M 积分</0>",
   "referral.inviteCode.description": "分享您的专属推荐码，邀请好友注册",
   "referral.inviteCode.title": "我的推荐码",
   "referral.inviteLink.description": "复制链接并分享给好友，好友付费后双方均可获得奖励",

--- a/locales/zh-CN/subscription.json
+++ b/locales/zh-CN/subscription.json
@@ -409,7 +409,7 @@
   "referral.hero.description": "把下方的推荐链接分享给好友，好友完成首次付费后，你和好友将各自获得 {{reward}}M 积分。",
   "referral.hero.title": "邀请好友，双方各得 <0>{{reward}}M 积分</0>",
   "referral.inviteCode.description": "分享您的专属推荐码，邀请好友注册",
-  "referral.inviteCode.title": "我的推荐码",
+  "referral.inviteCode.title": "我的专属推荐码",
   "referral.inviteLink.description": "复制链接并分享给好友，好友付费后双方均可获得奖励",
   "referral.inviteLink.title": "推荐链接",
   "referral.rules.antiAbuse": "如检测到通过不正当手段获取积分（如批量注册临时邮箱账号），相关账号将被永久封禁",

--- a/packages/locales/src/default/common.ts
+++ b/packages/locales/src/default/common.ts
@@ -575,6 +575,7 @@ export default {
   'userPanel.email': 'Email Support',
   'userPanel.feedback': 'Contact Us',
   'userPanel.help': 'Help Center',
+  'userPanel.inviteFriend': 'Invite a friend',
   'userPanel.moveGuide': 'The settings button has been moved here',
   'userPanel.plans': 'Subscription Plans',
   'userPanel.profile': 'Account',

--- a/packages/locales/src/default/subscription.ts
+++ b/packages/locales/src/default/subscription.ts
@@ -467,6 +467,9 @@ export default {
     'Invalid referral code format, please enter 2-8 letters, numbers or underscores',
   'referral.errors.selfReferral': 'You cannot use your own invite code',
   'referral.errors.updateFailed': 'Update failed, please try again later',
+  'referral.hero.description':
+    'Share your referral link below. After your friend makes their first payment, you each earn {{reward}}M credits.',
+  'referral.hero.title': 'Invite friends, you both earn <0>{{reward}}M credits</0>',
   'referral.inviteCode.description':
     'Share your exclusive referral code to invite friends to register',
   'referral.inviteCode.title': 'My Referral Code',

--- a/packages/locales/src/default/subscription.ts
+++ b/packages/locales/src/default/subscription.ts
@@ -472,7 +472,7 @@ export default {
   'referral.hero.title': 'Invite friends, you both earn <0>{{reward}}M credits</0>',
   'referral.inviteCode.description':
     'Share your exclusive referral code to invite friends to register',
-  'referral.inviteCode.title': 'My Referral Code',
+  'referral.inviteCode.title': 'My Exclusive Referral Code',
   'referral.inviteLink.description':
     'Copy the link and share with friends. Both of you earn credits after your friend makes a payment',
   'referral.inviteLink.title': 'Referral Link',

--- a/src/routes/(main)/home/_layout/Footer/index.test.tsx
+++ b/src/routes/(main)/home/_layout/Footer/index.test.tsx
@@ -23,6 +23,7 @@ vi.mock('react-i18next', () => ({
         'userPanel.docs': 'Docs',
         'userPanel.feedback': 'Feedback',
         'userPanel.help': 'Help',
+        'userPanel.inviteFriend': 'Invite a friend',
         'userPanel.setting': 'Settings',
       })[key] || key,
   }),
@@ -33,6 +34,7 @@ interface RenderFooterOptions {
   agentStarted?: boolean;
   classicFinished?: boolean;
   desktop?: boolean;
+  enableBusinessFeatures?: boolean;
   enabled?: boolean;
   mobile?: boolean;
   readSlugs?: string[];
@@ -69,6 +71,7 @@ const renderFooter = async ({
   classicFinished = true,
   desktop = false,
   enabled = true,
+  enableBusinessFeatures = false,
   mobile = false,
   readSlugs = [],
   serverConfigInit = true,
@@ -83,6 +86,7 @@ const renderFooter = async ({
 
   mockGlobalState = createGlobalState(readSlugs);
   mockServerConfigState = {
+    enableBusinessFeatures,
     featureFlags: { enableAgentOnboarding: enabled },
     isMobile: mobile,
     serverConfigInit,
@@ -152,8 +156,19 @@ const renderFooter = async ({
         </div>
       ) : null,
   }));
+  vi.doMock('@/features/Billboard', () => ({
+    default: () => null,
+  }));
+  vi.doMock('@/features/Billboard/MenuItems', () => ({
+    useBillboardMenuItems: () => [],
+  }));
   vi.doMock('@/features/User/UserPanel/ThemeButton', () => ({
     default: () => null,
+  }));
+  vi.doMock('@/features/Workspace/WorkspaceLink', () => ({
+    default: ({ children, to }: { children: React.ReactNode; to: string }) => (
+      <a href={to}>{children}</a>
+    ),
   }));
   function createNavLayoutState() {
     return {
@@ -185,6 +200,9 @@ const renderFooter = async ({
     return selector(mockServerConfigState);
   }
   vi.doMock('@/store/serverConfig', () => ({
+    serverConfigSelectors: {
+      enableBusinessFeatures: (s: Record<string, unknown>) => !!s.enableBusinessFeatures,
+    },
     useServerConfigStore: selectFromServerConfigStore,
   }));
   function selectFromUserStore(selector: (state: Record<string, unknown>) => unknown) {
@@ -214,7 +232,10 @@ afterEach(() => {
   vi.doUnmock('@/components/ChangelogModal');
   vi.doUnmock('@/components/FeedbackModal');
   vi.doUnmock('@/components/HighlightNotification');
+  vi.doUnmock('@/features/Billboard');
+  vi.doUnmock('@/features/Billboard/MenuItems');
   vi.doUnmock('@/features/User/UserPanel/ThemeButton');
+  vi.doUnmock('@/features/Workspace/WorkspaceLink');
   vi.doUnmock('@/hooks/useNavLayout');
   vi.doUnmock('@/store/global');
   vi.doUnmock('@/store/serverConfig');

--- a/src/routes/(main)/home/_layout/Footer/index.tsx
+++ b/src/routes/(main)/home/_layout/Footer/index.tsx
@@ -14,6 +14,7 @@ import {
   FlaskConical,
   MessageCircle,
   Rocket,
+  Send,
   Settings2,
   SettingsIcon,
 } from 'lucide-react';
@@ -34,7 +35,7 @@ import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 import { useNavLayout } from '@/hooks/useNavLayout';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors/systemStatus';
-import { useServerConfigStore } from '@/store/serverConfig';
+import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import { userGeneralSettingsSelectors } from '@/store/user/slices/settings/selectors/general';
 
@@ -73,6 +74,7 @@ const Footer = memo(() => {
   const enableAgentOnboarding = useServerConfigStore((s) => s.featureFlags.enableAgentOnboarding);
   const isMobile = useServerConfigStore((s) => !!s.isMobile);
   const serverConfigInit = useServerConfigStore((s) => s.serverConfigInit);
+  const enableBusinessFeatures = useServerConfigStore(serverConfigSelectors.enableBusinessFeatures);
   const [agentOnboardingFinished, agentOnboardingStarted, classicOnboardingFinished, isDevMode] =
     useUserStore((s) => [
       !!s.agentOnboarding?.finishedAt,
@@ -264,6 +266,17 @@ const Footer = memo(() => {
             },
           ]
         : []),
+      ...(enableBusinessFeatures
+        ? [
+            {
+              icon: <Icon icon={Send} />,
+              key: 'inviteFriend',
+              label: (
+                <WorkspaceLink to="/settings/referral">{t('userPanel.inviteFriend')}</WorkspaceLink>
+              ),
+            },
+          ]
+        : []),
       {
         icon: <Icon icon={Book} />,
         key: 'docs',
@@ -338,6 +351,7 @@ const Footer = memo(() => {
       footer.layout,
       footer.hideGitHub,
       footer.showEvalEntry,
+      enableBusinessFeatures,
       handleOpenChangelogModal,
       handleOpenFeedbackModal,
       handleOpenProductHuntCard,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

- Add a business-gated `Invite a friend` entry to the footer help menu.
- Add shared common locale strings for the menu entry.
- Add subscription locale strings used by the cloud referral hero.
- Rename the referral code card title to `My Exclusive Referral Code` / `我的专属推荐码`.
- Update the Footer test mocks for the new server config selector and workspace link dependency.

This is the submodule PR for the cloud referral update. A companion cloud PR will update the referral page UI and gitlink.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation:

```bash
bunx vitest run --silent='passed-only' 'src/routes/(main)/home/_layout/Footer/index.test.tsx'
```

Result: passed in `/Users/liuxing/LobeHub/lobehub` with 8 tests.

Note: the same command in `/Users/liuxing/LobeHub/lobehub-cloud/lobehub` fails because Vite denies the parent `node_modules/.pnpm/pdfjs-dist/.../pdf.worker.min.mjs?url` import in that checkout. The standalone `lobehub` checkout passes the same focused test.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

The cloud companion PR should point its `lobehub` gitlink at this branch's commit.
