### PR TITLE
chore: clean up LOBE-XXX code markers (2026-06-20)

### DIFF
--- a/packages/builtin-tools/src/codex/mcpToolUtils.test.ts
+++ b/packages/builtin-tools/src/codex/mcpToolUtils.test.ts
@@ -5,7 +5,7 @@ import { getCodexLinearMcpApiName, getMcpInputRecord } from './mcpToolUtils';
 describe('getCodexLinearMcpApiName', () => {
   it('maps Codex Apps fetch calls to entity-specific Linear APIs', () => {
     expect(
-      getCodexLinearMcpApiName({ input: { id: 'issue:LOBE-10205' }, toolName: 'linear_fetch' }),
+      getCodexLinearMcpApiName({ input: { id: 'issue:TEST-0000' }, toolName: 'linear_fetch' }),
     ).toBe('get_issue');
     expect(
       getCodexLinearMcpApiName({ input: { id: 'project:Desktop' }, toolName: 'linear_fetch' }),
@@ -41,7 +41,7 @@ describe('getCodexLinearMcpApiName', () => {
 
   it('treats bare issue identifiers as issue fetch calls', () => {
     expect(
-      getCodexLinearMcpApiName({ input: { id: 'LOBE-10205' }, toolName: 'linear_fetch' }),
+      getCodexLinearMcpApiName({ input: { id: 'TEST-0000' }, toolName: 'linear_fetch' }),
     ).toBe('get_issue');
   });
 
@@ -55,7 +55,7 @@ describe('getCodexLinearMcpApiName', () => {
     ).toBe('');
     expect(
       getCodexLinearMcpApiName({
-        input: { id: 'LOBE-10205' },
+        input: { id: 'TEST-0000' },
         server: 'github',
         toolName: 'fetch',
       }),
@@ -65,7 +65,7 @@ describe('getCodexLinearMcpApiName', () => {
   it('allows bare fetch only when the input has a Linear entity prefix', () => {
     expect(
       getCodexLinearMcpApiName({
-        input: { id: 'issue:LOBE-10205' },
+        input: { id: 'issue:TEST-0000' },
         server: 'node_repl',
         toolName: 'fetch',
       }),
@@ -92,8 +92,8 @@ describe('getCodexLinearMcpApiName', () => {
 
 describe('getMcpInputRecord', () => {
   it('parses JSON string MCP arguments', () => {
-    expect(getMcpInputRecord({ arguments: '{"id":"issue:LOBE-10205"}' })).toEqual({
-      id: 'issue:LOBE-10205',
+    expect(getMcpInputRecord({ arguments: '{"id":"issue:TEST-0000"}' })).toEqual({
+      id: 'issue:TEST-0000',
     });
   });
 });

--- a/packages/database/src/schemas/aiInfra.ts
+++ b/packages/database/src/schemas/aiInfra.ts
@@ -24,9 +24,10 @@ export const aiProviders = pgTable(
     name: text('name'),
 
     /**
-     * Surrogate primary key for the workspace-scoped rebuild (LOBE-10056). The
-     * business uniqueness now lives in the workspace-scoped partial unique
-     * indexes below, so the PK no longer carries it.
+     * Surrogate primary key for the workspace-scoped rebuild. Migration 0110
+     * replaced the composite PK (id, provider_id, user_id) with this single-col
+     * surrogate so that workspace-scoped partial unique indexes can enforce
+     * business uniqueness. The PK itself no longer carries unique semantics.
      */
     _id: uuid('_id').defaultRandom().notNull().primaryKey(),
 
@@ -77,9 +78,10 @@ export const aiModels = pgTable(
     id: varchar('id', { length: 150 }).notNull(),
 
     /**
-     * Surrogate primary key for the workspace-scoped rebuild (LOBE-10056). The
-     * business uniqueness now lives in the workspace-scoped partial unique
-     * indexes below, so the PK no longer carries it.
+     * Surrogate primary key for the workspace-scoped rebuild. Migration 0110
+     * replaced the composite PK (id, provider_id, user_id) with this single-col
+     * surrogate so that workspace-scoped partial unique indexes can enforce
+     * business uniqueness. The PK itself no longer carries unique semantics.
      */
     _id: uuid('_id').defaultRandom().notNull().primaryKey(),
 

--- a/src/features/DevPanel/RenderGallery/fixtures/claude-code.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/claude-code.ts
@@ -8,7 +8,7 @@ const linearIssueApiName = 'mcp__claude_ai_Linear__save_issue';
 const linearIssueResult = {
   description:
     '## 背景\n\n当前客户端侧有三种 agent runtime 路径，它们都在处理同一类 agent run 生命周期，但生命周期控制点不一致。\n\n## 目标\n\n建立一套共享的 post-complete hooks，让 queue message、topic title、Agent Signal、unread completion 和 notification 都通过同一入口收敛。',
-  id: 'LOBE-10205',
+  id: 'TEST-0000',
   links: [
     {
       title: 'PR #15766: refactor(chat): unify agent run lifecycle',
@@ -17,7 +17,7 @@ const linearIssueResult = {
   ],
   state: { name: 'In Review' },
   title: '统一三种客户端 Agent Runtime 的 run 生命周期 hooks',
-  url: 'https://linear.app/lobehub/issue/LOBE-10205',
+  url: 'https://linear.app/lobehub/issue/TEST-0000',
 };
 
 export default defineFixtures({
@@ -418,7 +418,7 @@ export default defineFixtures({
     }),
     [linearIssueApiName]: single({
       args: {
-        id: 'LOBE-10205',
+        id: 'TEST-0000',
         links: linearIssueResult.links,
         state: 'In Review',
       },

--- a/src/features/DevPanel/RenderGallery/fixtures/codex.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/codex.ts
@@ -24,7 +24,7 @@ const modifiedRegistryDiff = `diff --git a/packages/builtin-tools/src/renders.ts
 const linearIssueResult = {
   description:
     '## 背景\n\n当前客户端侧有三种 agent runtime 路径，它们都在处理同一类 agent run 生命周期，但生命周期控制点不一致。\n\n## 目标\n\n建立一套共享的 post-complete hooks，让 queue message、topic title、Agent Signal、unread completion 和 notification 都通过同一入口收敛。',
-  id: 'LOBE-10205',
+  id: 'TEST-0000',
   links: [
     {
       title: 'PR #15766: refactor(chat): unify agent run lifecycle',
@@ -33,7 +33,7 @@ const linearIssueResult = {
   ],
   state: { name: 'In Review' },
   title: '统一三种客户端 Agent Runtime 的 run 生命周期 hooks',
-  url: 'https://linear.app/lobehub/issue/LOBE-10205',
+  url: 'https://linear.app/lobehub/issue/TEST-0000',
 };
 
 export default defineFixtures({
@@ -155,7 +155,7 @@ export default defineFixtures({
       {
         args: {
           arguments: {
-            id: 'LOBE-10205',
+            id: 'TEST-0000',
             links: linearIssueResult.links,
             state: 'In Review',
           },
@@ -166,7 +166,7 @@ export default defineFixtures({
         label: 'Linear update issue',
         pluginState: {
           arguments: {
-            id: 'LOBE-10205',
+            id: 'TEST-0000',
             links: linearIssueResult.links,
             state: 'In Review',
           },


### PR DESCRIPTION
## Summary

Automated daily scan and cleanup of `LOBE-XXX` format code markers from the LobeHub codebase.

## Changes

### `packages/database/src/schemas/aiInfra.ts`
- Replaced `LOBE-10056` comment markers with descriptive migration context explaining the surrogate `_id` PK from migration 0110 (replaced composite PK with single-col surrogate for workspace-scoped partial unique indexes).

### `packages/builtin-tools/src/codex/mcpToolUtils.test.ts`
- Replaced `LOBE-10205` test fixture issue IDs with generic `TEST-0000`.

### `src/features/DevPanel/RenderGallery/fixtures/claude-code.ts`
- Replaced `LOBE-10205` test fixture issue IDs with generic `TEST-0000`.

### `src/features/DevPanel/RenderGallery/fixtures/codex.ts`
- Replaced `LOBE-10205` test fixture issue IDs with generic `TEST-0000`.

## Files Changed

| File | Changes |
|------|---------|
| packages/database/src/schemas/aiInfra.ts | Updated 2 comments |
| packages/builtin-tools/src/codex/mcpToolUtils.test.ts | Updated 6 test values |
| src/features/DevPanel/RenderGallery/fixtures/claude-code.ts | Updated 3 fixture values |
| src/features/DevPanel/RenderGallery/fixtures/codex.ts | Updated 4 fixture values |

## Verification
- No `LOBE-` references remain in source files (.ts, .tsx, .js, .jsx, .json)
- Excluded `.github/`, `docs/`, `node_modules`, build artifacts
- All changes are comment updates or test fixture value changes — no logic affected