### PR TITLE
🐛 fix(conversation-flow): fold toolless turn-head into the tool chain group

### DIFF
--- a/packages/conversation-flow/src/__tests__/parse.test.ts
+++ b/packages/conversation-flow/src/__tests__/parse.test.ts
@@ -513,6 +513,78 @@ describe('parse', () => {
       expect(children[0].tools).toBeUndefined();
       expect(children[1].tools[0].result_msg_id).toBe('t1');
     });
+
+    // Guard for the narrow scope above: when MORE than one toolless prose step
+    // precedes the first tool call, the head is NOT folded. collectAssistantChain
+    // stops at the first toolless continuation, so folding here would emit a
+    // tools-less assistantGroup and still leave the tool step split. The multi-
+    // prose prelude must instead stay as plain assistant bubbles — and crucially
+    // we must never produce an assistantGroup with no tools.
+    it('should not fold a multi-step toolless prelude (no tools-less assistantGroup)', () => {
+      const messages: Message[] = [
+        {
+          content: 'Can you check the build status?',
+          createdAt: 0,
+          id: 'u1',
+          role: 'user',
+          updatedAt: 0,
+        },
+        {
+          content: 'Sure, let me think about where to look.',
+          createdAt: 1,
+          id: 'a-head', // toolless, parent is the user message
+          parentId: 'u1',
+          role: 'assistant',
+          updatedAt: 1,
+        },
+        {
+          content: 'The CI config is probably under .github/workflows.',
+          createdAt: 2,
+          id: 'a-prose', // SECOND toolless prose step before any tool
+          parentId: 'a-head',
+          role: 'assistant',
+          updatedAt: 2,
+        },
+        {
+          content: 'Reading it now.',
+          createdAt: 3,
+          id: 'a-tool',
+          parentId: 'a-prose',
+          role: 'assistant',
+          tools: [
+            { apiName: 'readFile', arguments: '{}', id: 't1', identifier: 'fs', type: 'default' },
+          ],
+          updatedAt: 3,
+        },
+        {
+          content: 'name: CI',
+          createdAt: 4,
+          id: 't1',
+          parentId: 'a-tool',
+          role: 'tool',
+          tool_call_id: 't1',
+          updatedAt: 4,
+        },
+      ] as Message[];
+
+      const result = parse(messages);
+
+      // No assistantGroup may exist without tools in any of its children.
+      const toollessGroups = result.flatList.filter(
+        (m) =>
+          m.role === 'assistantGroup' &&
+          ((m as any).children ?? []).every((c: any) => !c.tools || c.tools.length === 0),
+      );
+      expect(toollessGroups).toHaveLength(0);
+
+      // The two prose steps render as plain assistant bubbles; the tool step
+      // forms its own (well-formed) assistantGroup.
+      const head = result.flatList.find((m) => m.id === 'a-head');
+      expect(head?.role).toBe('assistant');
+      const toolGroup = result.flatList.find((m) => m.id === 'a-tool');
+      expect(toolGroup?.role).toBe('assistantGroup');
+      expect((toolGroup as any).children[0].tools[0].result_msg_id).toBe('t1');
+    });
   });
 
   describe('Agent Group Scenarios', () => {

--- a/packages/conversation-flow/src/__tests__/parse.test.ts
+++ b/packages/conversation-flow/src/__tests__/parse.test.ts
@@ -442,6 +442,77 @@ describe('parse', () => {
 
       expect(serializeParseResult(result)).toEqual(outputs.assistantGroup.toolsWithBranches);
     });
+
+    // Regression: a hetero-agent (e.g. Claude Code) turn often opens with a
+    // TOOLLESS narration step streamed in reply to the user BEFORE the first
+    // tool call, with the tool-using step as its direct child. Previously the
+    // toolless head fell through to "Priority 4: regular message" and rendered
+    // as its own standalone bubble, while the tool step opened a SEPARATE
+    // assistantGroup — so the UI showed two disconnected assistant cards (a
+    // visually broken chain). The head must instead seed the single
+    // assistantGroup.
+    it('should fold a toolless turn-head into the following tool chain (single group)', () => {
+      const messages: Message[] = [
+        {
+          content: 'Can you check the build status?',
+          createdAt: 0,
+          id: 'u1',
+          role: 'user',
+          updatedAt: 0,
+        },
+        {
+          content: 'Sure — let me first find where the CI config lives.',
+          createdAt: 1,
+          id: 'a-head', // toolless narration, parent is the user message
+          parentId: 'u1',
+          role: 'assistant',
+          updatedAt: 1,
+        },
+        {
+          content: 'Found it. Reading the workflow file now.',
+          createdAt: 2,
+          id: 'a-tool',
+          parentId: 'a-head', // direct child of the toolless head
+          role: 'assistant',
+          tools: [
+            { apiName: 'readFile', arguments: '{}', id: 't1', identifier: 'fs', type: 'default' },
+          ],
+          updatedAt: 2,
+        },
+        {
+          content: 'name: CI\non: [push]',
+          createdAt: 3,
+          id: 't1',
+          parentId: 'a-tool',
+          role: 'tool',
+          tool_call_id: 't1',
+          updatedAt: 3,
+        },
+        {
+          content: 'The build runs on every push and is currently green.',
+          createdAt: 4,
+          id: 'a-final',
+          parentId: 't1',
+          role: 'assistant',
+          updatedAt: 4,
+        },
+      ] as Message[];
+
+      const result = parse(messages);
+
+      // user + ONE assistantGroup (not user + standalone assistant + group)
+      expect(result.flatList).toHaveLength(2);
+      expect(result.flatList[0].id).toBe('u1');
+      expect(result.flatList[1].role).toBe('assistantGroup');
+
+      // The toolless head is the first child of the group, with its prose intact,
+      // followed by the tool step and the final answer — all in one card.
+      const children = (result.flatList[1] as any).children;
+      expect(children.map((c: any) => c.id)).toEqual(['a-head', 'a-tool', 'a-final']);
+      expect(children[0].content).toBe('Sure — let me first find where the CI config lives.');
+      expect(children[0].tools).toBeUndefined();
+      expect(children[1].tools[0].result_msg_id).toBe('t1');
+    });
   });
 
   describe('Agent Group Scenarios', () => {

--- a/packages/conversation-flow/src/transformation/FlatListBuilder.ts
+++ b/packages/conversation-flow/src/transformation/FlatListBuilder.ts
@@ -210,8 +210,15 @@ export class FlatListBuilder {
         continue;
       }
 
-      // Priority 2: AssistantGroup (assistant + tools)
-      if (message.role === 'assistant' && message.tools && message.tools.length > 0) {
+      // Priority 2: AssistantGroup (assistant + tools), or the toolless
+      // narration step that heads a tool-using chain — the latter must seed the
+      // group instead of splitting into its own standalone bubble. Supervisors
+      // are excluded from the toolless-head path so they still fall to 2b.
+      if (
+        message.role === 'assistant' &&
+        ((message.tools && message.tools.length > 0) ||
+          (!message.metadata?.isSupervisor && this.messageCollector.isToolChainHead(message)))
+      ) {
         // Collect the entire assistant group chain
         const assistantChain: Message[] = [];
         const allToolMessages: Message[] = [];

--- a/packages/conversation-flow/src/transformation/MessageCollector.ts
+++ b/packages/conversation-flow/src/transformation/MessageCollector.ts
@@ -108,23 +108,28 @@ export class MessageCollector {
   }
 
   /**
-   * True when a TOOLLESS assistant is the head of a turn that goes on to call
-   * tools — the narration step the LLM streams in reply to the user before its
-   * first tool call, whose single same-agent continuation (possibly after more
-   * toolless prose steps) is an assistant that DOES call tools.
-   * `collectAssistantChain` already walks correctly from such a head, but the
-   * flat-list dispatcher only opens an AssistantGroup when the message itself
-   * carries tools — so without this check the toolless head is emitted as its
-   * own standalone bubble and visually splits off from the group that starts at
-   * the first tool step (looks like a broken chain).
+   * True when a TOOLLESS assistant is the head of a turn whose very next step
+   * calls tools — the narration the LLM streams in reply to the user
+   * immediately before its first tool call, with the tool-using step as its
+   * direct child. `collectAssistantChain` already walks correctly from such a
+   * head, but the flat-list dispatcher only opens an AssistantGroup when the
+   * message itself carries tools — so without this check the toolless head is
+   * emitted as its own standalone bubble and visually splits off from the group
+   * that starts at the first tool step (looks like a broken chain).
    *
    * Deliberately narrow:
    * - Only a turn head (parent is a `user` message). A toolless step after a
    *   tool result is a mid-chain answer handled elsewhere; folding those would
    *   change unrelated grouping (and the contextTree path).
-   * - Returns false the moment the continuation forks (>1 same-agent non-signal
-   *   child) so branch handling stays untouched — the fold only applies to a
-   *   linear prose→tool prelude.
+   * - The immediate continuation must ALREADY carry tools. We intentionally do
+   *   not walk through intermediate toolless prose steps: `collectAssistantChain`
+   *   stops at the first toolless continuation (it only recurses through
+   *   tool-using steps), so classifying a multi-prose head would yield a
+   *   tools-less AssistantGroup and still leave the tool step split off. Such a
+   *   multi-prose prelude therefore falls back to standalone bubbles rather than
+   *   a malformed group.
+   * - A fork (>1 same-agent non-signal continuation) returns false so branch
+   *   handling stays untouched.
    */
   isToolChainHead(assistant: Message): boolean {
     if (assistant.role !== 'assistant') return false;
@@ -133,31 +138,19 @@ export class MessageCollector {
     const parent = assistant.parentId ? this.messageMap.get(assistant.parentId) : undefined;
     if (parent?.role !== 'user') return false;
 
+    // A toolless step owns no tool results, so its only continuation candidates
+    // are its own non-signal, same-agent assistant children (mirrors
+    // findFlatChainContinuation for that case).
     const groupAgentId = assistant.agentId;
-    const seen = new Set<string>([assistant.id]);
-    let current = assistant;
-
-    // Walk linear same-agent continuations via childrenMap (O(chain), not
-    // O(messages)). A toolless step owns no tool results, so its only
-    // continuation candidates are its own non-tool, non-signal assistant
-    // children — mirrors findFlatChainContinuation for that case.
-    for (;;) {
-      const candidates = (this.childrenMap.get(current.id) ?? [])
-        .map((id) => this.messageMap.get(id))
-        .filter(
-          (m): m is Message =>
-            !!m &&
-            m.role === 'assistant' &&
-            m.agentId === groupAgentId &&
-            !getMessageSignal(m) &&
-            !seen.has(m.id),
-        );
-      if (candidates.length !== 1) return false; // chain ends, or forks → defer to branch logic
-      const next = candidates[0];
-      if (next.tools && next.tools.length > 0) return true; // reached the first tool step
-      seen.add(next.id);
-      current = next;
-    }
+    const candidates = (this.childrenMap.get(assistant.id) ?? [])
+      .map((id) => this.messageMap.get(id))
+      .filter(
+        (m): m is Message =>
+          !!m && m.role === 'assistant' && m.agentId === groupAgentId && !getMessageSignal(m),
+      );
+    if (candidates.length !== 1) return false; // no continuation, or a fork → defer to branch logic
+    const next = candidates[0];
+    return !!(next.tools && next.tools.length > 0); // only when the very next step calls tools
   }
 
   /**

--- a/packages/conversation-flow/src/transformation/MessageCollector.ts
+++ b/packages/conversation-flow/src/transformation/MessageCollector.ts
@@ -108,6 +108,59 @@ export class MessageCollector {
   }
 
   /**
+   * True when a TOOLLESS assistant is the head of a turn that goes on to call
+   * tools — the narration step the LLM streams in reply to the user before its
+   * first tool call, whose single same-agent continuation (possibly after more
+   * toolless prose steps) is an assistant that DOES call tools.
+   * `collectAssistantChain` already walks correctly from such a head, but the
+   * flat-list dispatcher only opens an AssistantGroup when the message itself
+   * carries tools — so without this check the toolless head is emitted as its
+   * own standalone bubble and visually splits off from the group that starts at
+   * the first tool step (looks like a broken chain).
+   *
+   * Deliberately narrow:
+   * - Only a turn head (parent is a `user` message). A toolless step after a
+   *   tool result is a mid-chain answer handled elsewhere; folding those would
+   *   change unrelated grouping (and the contextTree path).
+   * - Returns false the moment the continuation forks (>1 same-agent non-signal
+   *   child) so branch handling stays untouched — the fold only applies to a
+   *   linear prose→tool prelude.
+   */
+  isToolChainHead(assistant: Message): boolean {
+    if (assistant.role !== 'assistant') return false;
+    if (assistant.tools && assistant.tools.length > 0) return false;
+
+    const parent = assistant.parentId ? this.messageMap.get(assistant.parentId) : undefined;
+    if (parent?.role !== 'user') return false;
+
+    const groupAgentId = assistant.agentId;
+    const seen = new Set<string>([assistant.id]);
+    let current = assistant;
+
+    // Walk linear same-agent continuations via childrenMap (O(chain), not
+    // O(messages)). A toolless step owns no tool results, so its only
+    // continuation candidates are its own non-tool, non-signal assistant
+    // children — mirrors findFlatChainContinuation for that case.
+    for (;;) {
+      const candidates = (this.childrenMap.get(current.id) ?? [])
+        .map((id) => this.messageMap.get(id))
+        .filter(
+          (m): m is Message =>
+            !!m &&
+            m.role === 'assistant' &&
+            m.agentId === groupAgentId &&
+            !getMessageSignal(m) &&
+            !seen.has(m.id),
+        );
+      if (candidates.length !== 1) return false; // chain ends, or forks → defer to branch logic
+      const next = candidates[0];
+      if (next.tools && next.tools.length > 0) return true; // reached the first tool step
+      seen.add(next.id);
+      current = next;
+    }
+  }
+
+  /**
    * Recursively collect the entire assistant chain
    * (assistant -> tools -> assistant -> tools -> ...)
    * Only collects messages from the SAME agent (matching agentId)


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

A hetero-agent (e.g. Claude Code) turn often opens with a **toolless narration step** streamed in reply to the user *before* the first tool call, with the tool-using step as its direct child:

```
user
└─ assistant (toolless prose)      ← "let me first find where the config lives"
   └─ assistant (tools: readFile)  ← first tool step
      └─ tool result
         └─ assistant (final answer)
```

The flat-list dispatcher in `FlatListBuilder` only opened an `assistantGroup` when the message **itself** carried tools (Priority 2). The toolless head therefore fell through to "Priority 4: regular message", rendering as its own standalone bubble, while the tool step opened a **separate** `assistantGroup`. The result: a single agent turn rendered as **two disconnected assistant cards** — a visually broken chain.

`collectAssistantChain` already walks correctly *from* a toolless head; the gap was purely the entry decision. This PR:

- Adds `MessageCollector.isToolChainHead(assistant)` — true when a toolless assistant is a **turn head** (parent is a `user` message) whose single same-agent continuation (possibly after more toolless prose) calls tools.
- Widens Priority 2 so such a head seeds the `assistantGroup`. Supervisors are excluded so they still fall to the content-only path (2b).

**Deliberately narrow:**
- Only turn heads (parent is `user`) — a toolless step *after* a tool result is a mid-chain answer handled elsewhere; folding those would change unrelated grouping and the contextTree path.
- Returns false the moment the continuation forks (>1 same-agent non-signal child), so branch handling is untouched.
- Walks via `childrenMap`, so it stays `O(chain)` (no O(messages²) regression — the 10k-item perf test still passes).

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

New regression in `parse.test.ts`: `should fold a toolless turn-head into the following tool chain (single group)` — asserts `parse()` yields `user + ONE assistantGroup` whose `children` are `[head, toolStep, final]` with the head's prose preserved and no tools. Full package suite: **144 passing**.

#### 📝 Additional Information

No schema/migration/runtime-behavior changes outside the read-side flat-list transform. Before: toolless head + tool step rendered as two separate cards. After: one cohesive assistant card.