### PR TITLE
🐛 fix(conversation): surface terminal errors on assistant turns that already streamed content

### DIFF
--- a/src/features/Conversation/ChatItem/components/ErrorContent.test.tsx
+++ b/src/features/Conversation/ChatItem/components/ErrorContent.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ErrorContent from './ErrorContent';
+
+const deleteMessageMock = vi.fn();
+const updateMessageErrorMock = vi.fn();
+let messageContent: string | undefined = '';
+
+// Drive the Alert's `afterClose` directly via a click, so we exercise
+// ErrorContent's dismiss branching without the real close animation.
+vi.mock('@lobehub/ui', () => ({
+  Alert: ({ afterClose }: { afterClose?: () => void }) => (
+    <button type="button" onClick={() => afterClose?.()}>
+      close
+    </button>
+  ),
+  Skeleton: { Button: () => <div>loading</div> },
+}));
+
+vi.mock('antd', () => ({
+  Button: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/features/Conversation', () => ({
+  useConversationStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      deleteMessage: deleteMessageMock,
+      updateMessageError: updateMessageErrorMock,
+    }),
+}));
+
+vi.mock('@/features/Conversation/store', () => ({
+  dataSelectors: {
+    getDisplayMessageById: (id: string) => () => ({ content: messageContent, id }),
+  },
+}));
+
+describe('ErrorContent dismiss behavior', () => {
+  beforeEach(() => {
+    deleteMessageMock.mockClear();
+    updateMessageErrorMock.mockClear();
+  });
+
+  it('clears only the error (keeps the message) when the turn already streamed content', () => {
+    messageContent = 'already streamed text';
+    render(<ErrorContent error={{ message: 'boom' } as any} id="msg-1" />);
+
+    fireEvent.click(screen.getByText('close'));
+
+    expect(updateMessageErrorMock).toHaveBeenCalledWith('msg-1', null);
+    expect(deleteMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('deletes the message when it is just an empty error', () => {
+    messageContent = '';
+    render(<ErrorContent error={{ message: 'boom' } as any} id="msg-1" />);
+
+    fireEvent.click(screen.getByText('close'));
+
+    expect(deleteMessageMock).toHaveBeenCalledWith('msg-1');
+    expect(updateMessageErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/Conversation/ChatItem/components/ErrorContent.tsx
+++ b/src/features/Conversation/ChatItem/components/ErrorContent.tsx
@@ -5,6 +5,7 @@ import { memo, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useConversationStore } from '@/features/Conversation';
+import { dataSelectors } from '@/features/Conversation/store';
 
 import { type ChatItemProps } from '../type';
 
@@ -17,7 +18,13 @@ export interface ErrorContentProps {
 
 const ErrorContent = memo<ErrorContentProps>(({ customErrorRender, error, id, onRegenerate }) => {
   const { t } = useTranslation('common');
-  const [deleteMessage] = useConversationStore((s) => [s.deleteMessage]);
+  const [deleteMessage, updateMessageError] = useConversationStore((s) => [
+    s.deleteMessage,
+    s.updateMessageError,
+  ]);
+  const messageContent = useConversationStore((s) =>
+    id ? dataSelectors.getDisplayMessageById(id)(s)?.content : undefined,
+  );
 
   if (!error) return;
 
@@ -51,7 +58,13 @@ const ErrorContent = memo<ErrorContentProps>(({ customErrorRender, error, id, on
       title={error.message}
       afterClose={() => {
         error?.afterClose?.();
-        if (id) {
+        if (!id) return;
+        // A turn can carry a terminal error on top of content it already
+        // streamed. Dismissing the error must not delete that content — just
+        // clear the error and keep the message.
+        if (messageContent && messageContent.trim() !== '') {
+          updateMessageError(id, null);
+        } else {
           deleteMessage(id);
         }
       }}

--- a/src/features/Conversation/Messages/Assistant/index.tsx
+++ b/src/features/Conversation/Messages/Assistant/index.tsx
@@ -66,14 +66,6 @@ const AssistantMessage = memo<AssistantMessageProps>(
 
     const errorContent = useErrorContent(error);
 
-    const shouldForceShowError =
-      error?.type === 'ProviderBizError' &&
-      (error?.body as any)?.provider === 'google' &&
-      !!(
-        (error?.body as any)?.context?.promptFeedback?.blockReason ||
-        (error?.body as any)?.context?.finishReason
-      );
-
     // remove line breaks in artifact tag to make the ast transform easier
     const message = !editing ? normalizeThinkTags(processWithArtifact(content)) : content;
 
@@ -106,6 +98,10 @@ const AssistantMessage = memo<AssistantMessageProps>(
         belowMessage={hasEmptyErrorMessage ? footerRender : undefined}
         customErrorRender={(error) => <ErrorMessageExtra data={item} error={error} />}
         editing={editing}
+        // ChatItem renders this as the primary block when the message is empty,
+        // or inside messageExtra (below the content) when the turn streamed
+        // content before erroring — so don't gate it on empty content.
+        error={errorContent && error ? errorContent : undefined}
         id={id}
         loading={generating || isCreating}
         message={message}
@@ -122,11 +118,6 @@ const AssistantMessage = memo<AssistantMessageProps>(
             )}
             {!disableEditing && actionBarHolder}
           </>
-        }
-        error={
-          errorContent && error && (message === LOADING_FLAT || !message || shouldForceShowError)
-            ? errorContent
-            : undefined
         }
         messageExtra={
           <>

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.test.tsx
@@ -144,4 +144,35 @@ describe('AssistantGroup ContentBlock', () => {
 
     expect(screen.getByText('guide:claude-code:rate_limit')).toBeInTheDocument();
   });
+
+  it('renders the error below the content when a turn errors after streaming content', () => {
+    render(
+      <ContentBlock
+        assistantId="assistant-1"
+        content="The assistant already wrote this before the turn died."
+        id="block-1"
+        error={
+          {
+            body: {
+              agentType: 'claude-code',
+              code: HeterogeneousAgentSessionErrorCode.RateLimit,
+              message: "You've hit your limit · resets 2:50pm (Asia/Shanghai)",
+              rateLimitInfo: {
+                rateLimitType: 'five_hour',
+                resetsAt: 1_778_741_400,
+                status: 'rejected',
+              },
+              stderr: "You've hit your limit · resets 2:50pm (Asia/Shanghai)",
+            },
+            message: "You've hit your limit · resets 2:50pm (Asia/Shanghai)",
+            type: 'AgentRuntimeError',
+          } as any
+        }
+      />,
+    );
+
+    // Content is preserved AND the error is surfaced, instead of being dropped.
+    expect(screen.getByText('message content')).toBeInTheDocument();
+    expect(screen.getByText('guide:claude-code:rate_limit')).toBeInTheDocument();
+  });
 });

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlock.tsx
@@ -50,25 +50,25 @@ const ContentBlock = memo<ContentBlockProps>(
       continueGeneration(assistantId);
     }, [assistantId, continueGeneration, deleteMessage, id]);
 
+    const errorBlock = error ? (
+      <ErrorContent
+        error={errorContent && error ? errorContent : undefined}
+        id={id}
+        customErrorRender={(alertError) => (
+          <ErrorMessageExtra
+            data={{ error, id }}
+            error={alertError}
+            onRegenerate={handleRegenerate}
+          />
+        )}
+        onRegenerate={handleRegenerate}
+      />
+    ) : null;
+
+    // Nothing was streamed before the turn died: the error stands in for the
+    // whole block.
     if (error && (content === LOADING_FLAT || !content)) {
-      return (
-        <ErrorContent
-          id={id}
-          customErrorRender={(alertError) => (
-            <ErrorMessageExtra
-              data={{ error, id }}
-              error={alertError}
-              onRegenerate={handleRegenerate}
-            />
-          )}
-          error={
-            errorContent && error && (content === LOADING_FLAT || !content)
-              ? errorContent
-              : undefined
-          }
-          onRegenerate={handleRegenerate}
-        />
-      );
+      return errorBlock;
     }
 
     return (
@@ -101,6 +101,11 @@ const ContentBlock = memo<ContentBlockProps>(
             <Tools disableEditing={disableEditing} messageId={id} />
           </SafeBoundary>
         )}
+
+        {/* A terminal error (e.g. upstream overload) can land on a turn that
+            already streamed content + a successful tool call. Surface it below
+            the content instead of silently dropping it. */}
+        {errorBlock && <SafeBoundary>{errorBlock}</SafeBoundary>}
       </Flexbox>
     );
   },


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

When an assistant turn streams content (and possibly a successful tool call) and *then* hits a **terminal error** — e.g. an upstream `529 overloaded` / rate-limit — the error was attached to the message in DB but **silently dropped on the read side**. The message rendered as if it had completed cleanly: no error banner, no retry button. The user couldn't tell the turn was actually killed.

Root cause: the error UI was gated behind **empty content** in two render paths:

- **Hetero-agent (Claude Code / Codex) path** — `AssistantGroup/components/ContentBlock.tsx`: `if (error && (content === LOADING_FLAT || !content)) renderError`. With non-empty content it fell through to the normal render, which never reads `error`.
- **Normal LLM path** — `Messages/Assistant/index.tsx`: the `error` prop passed to `ChatItem` was gated on `(message === LOADING_FLAT || !message || shouldForceShowError)`. `ChatItem` already renders the error inside `messageExtra` (below content) when the message is non-empty — but only if the prop reaches it. The `shouldForceShowError` hack was the *only* way a content-bearing error surfaced, and only for Google `ProviderBizError`.

Fix:

- `ContentBlock`: extract the error block and also render it **below the content** (via `SafeBoundary`) when a turn errors after streaming output; keep the "error replaces the whole block" behavior when nothing was streamed.
- `Assistant/index.tsx`: stop gating the `ChatItem` `error` prop on empty content — `ChatItem` already places it correctly (primary block when empty, `messageExtra` below content otherwise). Removes the now-redundant `shouldForceShowError` (subsumed: all content-bearing errors now surface, including the Google case).

#### 🧪 How to Test

- [x] Added/updated tests

Added a `ContentBlock` test asserting that when **content and error coexist**, both the message content **and** the error renderer appear (previously the error was dropped).

#### 📝 Additional Information

Surfaced from a real topic where a Claude Code turn produced text + a successful `Bash` call, then the continuation LLM call hit `529 overloaded`; the UI showed a normal-looking completed message with no error indication.