### PR TITLE
🐛 fix(bot): warn when a WeChat file attachment can't be retrieved instead of silently dropping it

### DIFF
--- a/apps/server/src/services/bot/platforms/wechat/client.test.ts
+++ b/apps/server/src/services/bot/platforms/wechat/client.test.ts
@@ -263,9 +263,10 @@ describe('WechatGatewayClient', () => {
         expect.anything(), // WechatApiClient instance
         raw,
       );
-      expect(result).toEqual([
-        { buffer, mimeType: 'image/jpeg', name: 'image.jpg', size: undefined },
-      ]);
+      expect(result).toEqual({
+        files: [{ buffer, mimeType: 'image/jpeg', name: 'image.jpg', size: undefined }],
+        warnings: undefined,
+      });
     });
 
     it('returns undefined when downloadMediaFromRawMessage resolves to an empty array', async () => {
@@ -274,6 +275,34 @@ describe('WechatGatewayClient', () => {
       const result = await client.extractFiles!(makeMessage({ item_list: [{ type: 99 }] }));
       expect(mockDownloadMediaFromRawMessage).toHaveBeenCalledTimes(1);
       expect(result).toBeUndefined();
+    });
+
+    it('warns when a FILE item has no downloadable media (e.g. oversized) and was dropped', async () => {
+      // WeChat relays oversized files as metadata only — no CDN media handle —
+      // so downloadMediaFromRawMessage returns nothing for them. We must surface
+      // a warning instead of silently passing only the `[file: name]` text.
+      mockDownloadMediaFromRawMessage.mockResolvedValue([]);
+      const client = createClient();
+      const result = (await client.extractFiles!(
+        makeMessage({
+          item_list: [
+            {
+              file_item: {
+                file_name: 'October 11, 2023 Alta Town Council Meeting Audio.mp3',
+                len: '132800970',
+              },
+              type: 4, // MessageItemType.FILE
+            },
+          ],
+        }),
+      )) as { files?: unknown[]; warnings?: string[] } | undefined;
+      expect(result?.files).toBeUndefined();
+      expect(result?.warnings).toHaveLength(1);
+      expect(result?.warnings?.[0]).toContain(
+        'October 11, 2023 Alta Town Council Meeting Audio.mp3',
+      );
+      expect(result?.warnings?.[0]).toContain('126.6 MB');
+      expect(result?.warnings?.[0]).toContain('could not be retrieved');
     });
 
     it('maps file attachments preserving name + size', async () => {
@@ -303,9 +332,10 @@ describe('WechatGatewayClient', () => {
           ],
         }),
       );
-      expect(result).toEqual([
-        { buffer, mimeType: 'application/pdf', name: 'report.pdf', size: 4096 },
-      ]);
+      expect(result).toEqual({
+        files: [{ buffer, mimeType: 'application/pdf', name: 'report.pdf', size: 4096 }],
+        warnings: undefined,
+      });
     });
 
     it('maps multiple attachments in a single message', async () => {
@@ -324,10 +354,13 @@ describe('WechatGatewayClient', () => {
           ],
         }),
       );
-      expect(result).toEqual([
-        { buffer: imageBuf, mimeType: 'image/jpeg', name: 'image.jpg', size: undefined },
-        { buffer: voiceBuf, mimeType: 'audio/silk', name: undefined, size: undefined },
-      ]);
+      expect(result).toEqual({
+        files: [
+          { buffer: imageBuf, mimeType: 'image/jpeg', name: 'image.jpg', size: undefined },
+          { buffer: voiceBuf, mimeType: 'audio/silk', name: undefined, size: undefined },
+        ],
+        warnings: undefined,
+      });
     });
 
     it('propagates errors from downloadMediaFromRawMessage as undefined gracefully', async () => {

--- a/apps/server/src/services/bot/platforms/wechat/client.ts
+++ b/apps/server/src/services/bot/platforms/wechat/client.ts
@@ -2,6 +2,7 @@ import type { WechatRawMessage } from '@lobechat/chat-adapter-wechat';
 import {
   createWechatAdapter,
   downloadMediaFromRawMessage,
+  MessageItemType,
   MessageState,
   MessageType,
   WechatApiClient,
@@ -20,6 +21,7 @@ import {
   type BotPlatformRuntimeContext,
   type BotProviderConfig,
   ClientFactory,
+  type ExtractFilesResult,
   type MessengerContent,
   messengerContentText,
   type PlatformClient,
@@ -347,30 +349,63 @@ class WechatGatewayClient implements PlatformClient {
    * `parseRawEvent` runs at adapter parse time — including the cascading
    * image fallback (CDN main → thumb → direct URL).
    */
-  async extractFiles(message: Message): Promise<AttachmentSource[] | undefined> {
+  async extractFiles(message: Message): Promise<ExtractFilesResult | undefined> {
     const raw = (message as any).raw as WechatRawMessage | undefined;
     if (!raw?.item_list?.length) return undefined;
 
     log('extractFiles: msgId=%s, items=%d', (message as any).id, raw.item_list.length);
 
     const attachments = await downloadMediaFromRawMessage(this.api, raw);
-    if (attachments.length === 0) {
+
+    // Detect FILE items that arrived as metadata only. WeChat does not relay a
+    // downloadable CDN media descriptor for oversized files, so
+    // downloadMediaFromRawMessage silently drops them. Without a warning the
+    // agent only sees the bare `[file: name]` text placeholder (from the
+    // adapter's extractText) and hallucinates that it received the file — e.g.
+    // claiming it can't "hear" an audio it never actually got. Surface a
+    // warning so the model can tell the user the file couldn't be retrieved.
+    const downloadedNames = new Set(
+      attachments.map((att: any) => att.name).filter(Boolean) as string[],
+    );
+    const warnings: string[] = [];
+    for (const item of raw.item_list) {
+      if (item.type !== MessageItemType.FILE || !item.file_item) continue;
+      const fileName = item.file_item.file_name;
+      if (fileName && downloadedNames.has(fileName)) continue;
+      const sizeBytes = Number(item.file_item.len);
+      const sizeHint =
+        Number.isFinite(sizeBytes) && sizeBytes > 0
+          ? ` (${(sizeBytes / (1024 * 1024)).toFixed(1)} MB)`
+          : '';
+      warnings.push(
+        `File "${fileName || 'unknown'}"${sizeHint} could not be retrieved from WeChat ` +
+          `(it may be too large) and was not processed.`,
+      );
+    }
+
+    if (attachments.length === 0 && warnings.length === 0) {
       log('extractFiles: no media items resolved for msgId=%s', (message as any).id);
       return undefined;
     }
 
     log(
-      'extractFiles: resolved %d media item(s) for msgId=%s',
+      'extractFiles: resolved %d media item(s), %d warning(s) for msgId=%s',
       attachments.length,
+      warnings.length,
       (message as any).id,
     );
 
-    return attachments.map((att: any) => ({
+    const files: AttachmentSource[] = attachments.map((att: any) => ({
       buffer: att.buffer,
       mimeType: att.mimeType,
       name: att.name,
       size: att.size,
     }));
+
+    return {
+      files: files.length > 0 ? files : undefined,
+      warnings: warnings.length > 0 ? warnings : undefined,
+    };
   }
 
   getMessenger(platformThreadId: string): PlatformMessenger {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

When a user sends a large file to a **WeChat (iLink/ClawBot)** bot, WeChat relays it as **metadata only** — the inbound `FILE` item has no downloadable CDN media descriptor (`encrypt_query_param`). `downloadMediaFromRawMessage` therefore silently breaks for that item and returns no attachment, so:

- `extractFiles` returned nothing → no file was ingested → `files=0` reached the agent;
- the only thing the model received was the bare `[file: <name>]` text placeholder that the adapter's `extractText` **always** emits for a FILE item;
- the model then hallucinated around the filename. Real case: a **132 MB** `.mp3` produced the reply *"系统似乎没有把这段语音内容转录发给我，我暂时还'听'不到"* — i.e. it "received" a file it never actually got.

Nothing surfaced this failure. `WechatGatewayClient.extractFiles` calls `downloadMediaFromRawMessage(this.api, raw)` **without a logger**, so the helper's own CDN-download `warn` is a no-op — no log, no user-facing signal. Confirmed against production Vercel logs: the raw attachment arrived as `{ hasBuffer: false, hasFetchData: false, hasUrl: false, mimeType: 'audio/mpeg', size: 132800970 }`, `files=0` reached `executeWithCallback`, and there was **no warning anywhere**.

This is distinct from #16063 (QQ MIME mislabel): here the MIME was correct, the file just never downloaded.

**Fix:** `extractFiles` now walks the raw `item_list` and, for any `FILE` item that wasn't downloaded, returns a warning (with a size hint) via the existing `ExtractFilesResult.warnings` channel. Those warnings are already injected into the context engine and surfaced to the user — the same mechanism Telegram uses for its 20 MB cap. The agent can now tell the user the file couldn't be retrieved instead of pretending it processed it.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Updated `wechat/client.test.ts` for the new `{ files, warnings }` return shape and added a regression test: a FILE item with no downloadable media (the 132 MB `.mp3` case) now yields a single warning containing the filename, `126.6 MB`, and "could not be retrieved", with `files` undefined. Full `wechat/client.test.ts` suite passes (15 tests); type-check clean for the changed files.

#### 📝 Additional Information

No DB migration, no schema change. Behavior is unchanged for files that download successfully. Scope is limited to `FILE` items (voice/image are unaffected, avoiding false positives on voice items that legitimately carry only transcription text).