### PR TITLE
✨ feat(analytics): track home footer menu clicks and exposure

### DIFF
--- a/src/routes/(main)/home/_layout/Footer/index.test.tsx
+++ b/src/routes/(main)/home/_layout/Footer/index.test.tsx
@@ -32,10 +32,12 @@ vi.mock('react-i18next', () => ({
 interface RenderFooterOptions {
   agentFinished?: boolean;
   agentStarted?: boolean;
+  billboardItems?: unknown[];
   classicFinished?: boolean;
   desktop?: boolean;
   enableBusinessFeatures?: boolean;
   enabled?: boolean;
+  homeSidebar?: boolean;
   mobile?: boolean;
   readSlugs?: string[];
   serverConfigInit?: boolean;
@@ -68,10 +70,12 @@ const createGlobalState = (readSlugs: string[] = []) => ({
 const renderFooter = async ({
   agentFinished = false,
   agentStarted = false,
+  billboardItems = [],
   classicFinished = true,
   desktop = false,
   enabled = true,
   enableBusinessFeatures = false,
+  homeSidebar = false,
   mobile = false,
   readSlugs = [],
   serverConfigInit = true,
@@ -160,7 +164,10 @@ const renderFooter = async ({
     default: () => null,
   }));
   vi.doMock('@/features/Billboard/MenuItems', () => ({
-    useBillboardMenuItems: () => [],
+    useBillboardMenuItems: () => billboardItems,
+  }));
+  vi.doMock('@/features/NavPanel', () => ({
+    useActiveNavKey: () => (homeSidebar ? 'home' : 'discover'),
   }));
   vi.doMock('@/features/User/UserPanel/ThemeButton', () => ({
     default: () => null,
@@ -234,6 +241,7 @@ afterEach(() => {
   vi.doUnmock('@/components/HighlightNotification');
   vi.doUnmock('@/features/Billboard');
   vi.doUnmock('@/features/Billboard/MenuItems');
+  vi.doUnmock('@/features/NavPanel');
   vi.doUnmock('@/features/User/UserPanel/ThemeButton');
   vi.doUnmock('@/features/Workspace/WorkspaceLink');
   vi.doUnmock('@/hooks/useNavLayout');
@@ -353,5 +361,26 @@ describe('Footer help menu tracking', () => {
     await user.click(screen.getByRole('button', { name: 'Help' }));
 
     expect(screen.queryByText('Invite a friend')).not.toBeInTheDocument();
+  }, 20000);
+
+  it('excludes billboard items from the opened keys to keep per-key CTR aligned', async () => {
+    const user = userEvent.setup();
+    await renderFooter({
+      billboardItems: [{ key: 'billboard-promo', label: 'Promo', onClick: vi.fn() }],
+      enableBusinessFeatures: true,
+      homeSidebar: true,
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Help' }));
+
+    const openedCall = analyticsTrack.mock.calls.find(
+      ([event]) => event?.name === 'home_footer_menu_opened',
+    );
+    const keys = (openedCall![0].properties.keys as string).split(',');
+    // own items are tracked and reported as exposure...
+    expect(keys).toContain('inviteFriend');
+    // ...but billboard items (which emit their own billboard_* events) are not,
+    // so their CTR denominator never gets an orphaned exposure.
+    expect(keys).not.toContain('billboard-promo');
   }, 20000);
 });

--- a/src/routes/(main)/home/_layout/Footer/index.test.tsx
+++ b/src/routes/(main)/home/_layout/Footer/index.test.tsx
@@ -318,3 +318,40 @@ describe('Footer agent onboarding promotion', () => {
     expect(screen.queryByTestId('highlight-notification')).not.toBeInTheDocument();
   });
 });
+
+describe('Footer help menu tracking', () => {
+  it('tracks menu open with the visible item keys', async () => {
+    const user = userEvent.setup();
+    await renderFooter({ enableBusinessFeatures: true });
+
+    await user.click(screen.getByRole('button', { name: 'Help' }));
+
+    const openedCall = analyticsTrack.mock.calls.find(
+      ([event]) => event?.name === 'home_footer_menu_opened',
+    );
+    expect(openedCall).toBeTruthy();
+    expect((openedCall![0].properties.keys as string).split(',')).toContain('inviteFriend');
+  }, 20000);
+
+  it('tracks a unified click event when the invite friend entry is clicked', async () => {
+    const user = userEvent.setup();
+    await renderFooter({ enableBusinessFeatures: true });
+
+    await user.click(screen.getByRole('button', { name: 'Help' }));
+    await user.click(await screen.findByText('Invite a friend'));
+
+    expect(analyticsTrack).toHaveBeenCalledWith({
+      name: 'home_footer_menu_clicked',
+      properties: { key: 'inviteFriend', spm: 'homepage.footer.inviteFriend.clicked' },
+    });
+  }, 20000);
+
+  it('does not render the invite friend entry without business features', async () => {
+    const user = userEvent.setup();
+    await renderFooter({ enableBusinessFeatures: false });
+
+    await user.click(screen.getByRole('button', { name: 'Help' }));
+
+    expect(screen.queryByText('Invite a friend')).not.toBeInTheDocument();
+  }, 20000);
+});

--- a/src/routes/(main)/home/_layout/Footer/index.tsx
+++ b/src/routes/(main)/home/_layout/Footer/index.tsx
@@ -88,6 +88,20 @@ const injectMenuTracking = (
     };
   });
 
+/**
+ * Collect the keys of click-trackable items — the exact same set wrapped by
+ * `injectMenuTracking` (non-divider items with a key). Used so the menu-open
+ * exposure event reports only keys that can later emit `home_footer_menu_clicked`,
+ * keeping per-key CTR denominators and numerators aligned. Billboard items are
+ * excluded here (they emit their own `billboard_*` events).
+ */
+const collectMenuKeys = (items: FooterMenuItems): string[] =>
+  items
+    .filter((item) => item && (item as { type?: string }).type !== 'divider')
+    .map((item) => (item as { key?: string | number }).key)
+    .filter((key): key is string | number => Boolean(key))
+    .map(String);
+
 const Footer = memo(() => {
   const { t } = useTranslation('common');
   const navigate = useNavigate();
@@ -291,7 +305,10 @@ const Footer = memo(() => {
     t,
   ]);
 
-  const helpMenuItems: MenuProps['items'] = useMemo(() => {
+  const { helpMenuItems, trackedMenuKeys } = useMemo<{
+    helpMenuItems: MenuProps['items'];
+    trackedMenuKeys: string[];
+  }>(() => {
     const ownItems: FooterMenuItems = [
       ...(footer.showSettingsEntry && !isDevMode
         ? [
@@ -383,12 +400,15 @@ const Footer = memo(() => {
         : []),
     ];
 
-    return [
-      ...injectMenuTracking(ownItems, trackMenuClick),
-      ...(isHomeSidebar && billboardMenuItems && billboardMenuItems.length > 0
-        ? [{ type: 'divider' as const }, ...billboardMenuItems]
-        : []),
-    ];
+    return {
+      helpMenuItems: [
+        ...injectMenuTracking(ownItems, trackMenuClick),
+        ...(isHomeSidebar && billboardMenuItems && billboardMenuItems.length > 0
+          ? [{ type: 'divider' as const }, ...billboardMenuItems]
+          : []),
+      ],
+      trackedMenuKeys: collectMenuKeys(ownItems),
+    };
   }, [
     trackMenuClick,
     footer.showSettingsEntry,
@@ -409,21 +429,16 @@ const Footer = memo(() => {
   const handleMenuOpenChange = useCallback(
     (open: boolean) => {
       if (!open) return;
-      const keys = (helpMenuItems ?? [])
-        .filter((item) => item && (item as { type?: string }).type !== 'divider')
-        .map((item) => (item as { key?: string | number }).key)
-        .filter((key): key is string | number => key !== undefined)
-        .map(String);
       try {
         analytics?.track({
           name: 'home_footer_menu_opened',
-          properties: { keys: keys.join(','), spm: 'homepage.footer.opened' },
+          properties: { keys: trackedMenuKeys.join(','), spm: 'homepage.footer.opened' },
         });
       } catch {
         // silently ignore tracking errors to avoid affecting business logic
       }
     },
-    [analytics, helpMenuItems],
+    [analytics, trackedMenuKeys],
   );
 
   return (

--- a/src/routes/(main)/home/_layout/Footer/index.tsx
+++ b/src/routes/(main)/home/_layout/Footer/index.tsx
@@ -63,6 +63,31 @@ interface PromotionCard {
   title: string;
 }
 
+type FooterMenuItems = NonNullable<MenuProps['items']>;
+
+/**
+ * Wrap each clickable menu item with a unified click tracker, preserving any
+ * existing onClick. Skips dividers and items without a key. Used to measure
+ * which footer menu entries get clicked (breakdown by `key`).
+ */
+const injectMenuTracking = (
+  items: FooterMenuItems,
+  track: (key: string) => void,
+): FooterMenuItems =>
+  items.map((item) => {
+    if (!item || (item as { type?: string }).type === 'divider') return item;
+    const key = (item as { key?: string | number }).key;
+    if (!key) return item;
+    const originalOnClick = (item as { onClick?: (info: unknown) => void }).onClick;
+    return {
+      ...item,
+      onClick: (info: unknown) => {
+        track(String(key));
+        originalOnClick?.(info);
+      },
+    };
+  });
+
 const Footer = memo(() => {
   const { t } = useTranslation('common');
   const navigate = useNavigate();
@@ -132,6 +157,20 @@ const Footer = memo(() => {
     (eventName: string, properties: Record<string, string>) => {
       try {
         analytics?.track({ name: eventName, properties });
+      } catch {
+        // silently ignore tracking errors to avoid affecting business logic
+      }
+    },
+    [analytics],
+  );
+
+  const trackMenuClick = useCallback(
+    (key: string) => {
+      try {
+        analytics?.track({
+          name: 'home_footer_menu_clicked',
+          properties: { key, spm: `homepage.footer.${key}.clicked` },
+        });
       } catch {
         // silently ignore tracking errors to avoid affecting business logic
       }
@@ -252,8 +291,8 @@ const Footer = memo(() => {
     t,
   ]);
 
-  const helpMenuItems: MenuProps['items'] = useMemo(
-    () => [
+  const helpMenuItems: MenuProps['items'] = useMemo(() => {
+    const ownItems: FooterMenuItems = [
       ...(footer.showSettingsEntry && !isDevMode
         ? [
             {
@@ -342,25 +381,49 @@ const Footer = memo(() => {
             },
           ]
         : []),
+    ];
+
+    return [
+      ...injectMenuTracking(ownItems, trackMenuClick),
       ...(isHomeSidebar && billboardMenuItems && billboardMenuItems.length > 0
         ? [{ type: 'divider' as const }, ...billboardMenuItems]
         : []),
-    ],
-    [
-      footer.showSettingsEntry,
-      footer.layout,
-      footer.hideGitHub,
-      footer.showEvalEntry,
-      enableBusinessFeatures,
-      handleOpenChangelogModal,
-      handleOpenFeedbackModal,
-      handleOpenProductHuntCard,
-      isDevMode,
-      shouldShowProductHuntMenuEntry,
-      t,
-      billboardMenuItems,
-      isHomeSidebar,
-    ],
+    ];
+  }, [
+    trackMenuClick,
+    footer.showSettingsEntry,
+    footer.layout,
+    footer.hideGitHub,
+    footer.showEvalEntry,
+    enableBusinessFeatures,
+    handleOpenChangelogModal,
+    handleOpenFeedbackModal,
+    handleOpenProductHuntCard,
+    isDevMode,
+    shouldShowProductHuntMenuEntry,
+    t,
+    billboardMenuItems,
+    isHomeSidebar,
+  ]);
+
+  const handleMenuOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) return;
+      const keys = (helpMenuItems ?? [])
+        .filter((item) => item && (item as { type?: string }).type !== 'divider')
+        .map((item) => (item as { key?: string | number }).key)
+        .filter((key): key is string | number => key !== undefined)
+        .map(String);
+      try {
+        analytics?.track({
+          name: 'home_footer_menu_opened',
+          properties: { keys: keys.join(','), spm: 'homepage.footer.opened' },
+        });
+      } catch {
+        // silently ignore tracking errors to avoid affecting business logic
+      }
+    },
+    [analytics, helpMenuItems],
   );
 
   return (
@@ -368,7 +431,11 @@ const Footer = memo(() => {
       {footer.layout === 'expanded' ? (
         <Flexbox horizontal align={'center'} gap={2} justify={'space-between'} padding={8}>
           <Flexbox horizontal align={'center'} flex={1} gap={2}>
-            <DropdownMenu items={helpMenuItems} placement="topLeft">
+            <DropdownMenu
+              items={helpMenuItems}
+              placement="topLeft"
+              onOpenChange={handleMenuOpenChange}
+            >
               <ActionIcon
                 aria-label={t('userPanel.help')}
                 data-billboard-anchor=""
@@ -389,7 +456,11 @@ const Footer = memo(() => {
         </Flexbox>
       ) : (
         <Flexbox horizontal align={'center'} gap={2} padding={8}>
-          <DropdownMenu items={helpMenuItems} placement="topLeft">
+          <DropdownMenu
+            items={helpMenuItems}
+            placement="topLeft"
+            onOpenChange={handleMenuOpenChange}
+          >
             <ActionIcon aria-label={t('userPanel.help')} icon={CircleHelp} size={16} />
           </DropdownMenu>
           {isDevMode && (


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

<!-- no linked issue -->

#### 🔀 Description of Change

Adds analytics instrumentation to the home footer help menu, so we can answer two product questions: **(1)** is the newly added "Invite a friend" entry (#16073) actually driving referral behavior, and **(2)** is the footer menu well-composed — which entries get clicked, which don't.

Rather than one bespoke event per item, this uses a **single unified click event keyed by item**, plus an exposure event for the denominator:

| Event | Properties | Fired when | Answers |
| --- | --- | --- | --- |
| `home_footer_menu_clicked` | `key`, `spm` | Any menu item clicked | Which entries get clicked most/least (breakdown by `key`); the referral entry is `key=inviteFriend` |
| `home_footer_menu_opened` | `keys`, `spm` | Menu is opened | Denominator / visibility — `keys` lists the entries visible in that open (different users see different sets, e.g. `inviteFriend` is business-only) |

Implementation notes:

- `injectMenuTracking` wraps each own menu item's `onClick` (preserves any existing handler, skips dividers/keyless items). Billboard items are **not** wrapped — they already emit their own `billboard_*` events.
- Exposure is tracked via `DropdownMenu`'s `onOpenChange`, carrying the currently visible `keys` so click-through rate can be computed per entry without being skewed by visibility.
- `spm` follows the existing dotted convention: `homepage.footer.<key>.clicked` / `homepage.footer.opened`.

##### How to use in PostHog (project 297843)

- **Menu composition**: `home_footer_menu_clicked` → breakdown by `key`.
- **Click-through rate**: `home_footer_menu_clicked` ÷ `home_footer_menu_opened` (per `key`) — distinguishes "not seen" from "seen but not clicked".
- **Referral funnel, step 1**: filter `key=inviteFriend`.

##### ⚠️ Still missing — two segments this PR cannot cover

The referral page renders as a cross-origin iframe (`/embed/subscription/referral`), so the core activation actions can't be tracked from this repo. To complete the end-to-end referral funnel, the following must be added elsewhere (same instrumentation blind spot as the task system):

| Stage | Suggested event | Where to add |
| --- | --- | --- |
| Activation (copy code / copy link / share) | `referral_code_copied` / `referral_link_copied` / `referral_invite_shared` (with channel) | Cloud `/embed/subscription/referral` project — emit to the **same PostHog project** so events merge into one funnel |
| Acquisition (invited user signs up) | `referral_signup` (with referrer) | `business-server` (signup carries `?referral=`) |
| Value (invited user first payment) | `referral_rewarded` (`referralStatus: registered → rewarded`) | `business-server`, associating inviter ↔ invitee |

> To rigorously prove the entry *causes* more referrals (not just correlates), the entry should later be moved from the `enableBusinessFeatures` hard gate to a PostHog feature flag for A/B; otherwise only attribution share + before/after (confounded) is possible.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Footer test suite (`Footer/index.test.tsx`) covers menu-open tracking, the unified click event on the invite entry, and that the entry is hidden without business features — 11/11 passing. `type-check` clean.

#### 📝 Additional Information

Frontend-only change. No schema, server, or migration impact.
