### PR TITLE
🐛 fix(desktop): swallow transient net errors in main process

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -3,6 +3,11 @@ import './pre-app-init';
 import fixPath from 'fix-path';
 
 import { App } from './core/App';
+import { installProcessErrorHandlers } from './process-error-handlers';
+
+// Guard the main process against transient network blips (Wi-Fi/VPN switch,
+// system sleep) emitted by Electron's net stack as uncaught exceptions.
+installProcessErrorHandlers();
 
 const app = new App();
 

--- a/apps/desktop/src/main/process-error-handlers.ts
+++ b/apps/desktop/src/main/process-error-handlers.ts
@@ -1,0 +1,77 @@
+import { createLogger } from '@/utils/logger';
+
+const logger = createLogger('main:process-error-handlers');
+
+/**
+ * Transient Chromium network errors emitted by Electron's `net` stack
+ * (`SimpleURLLoaderWrapper`). These happen during normal operation — switching
+ * Wi-Fi / VPN, the machine sleeping, the network interface dropping — and are
+ * NOT application bugs. Electron emits them as an `error` event on the internal
+ * loader; when nothing is listening they bubble up as an `uncaughtException`
+ * and pop the "A JavaScript error occurred in the main process" dialog, even
+ * though the request layer already handles the failure via promise rejection.
+ *
+ * We swallow these specific cases so transient connectivity blips never crash
+ * the main process. Everything else is re-thrown to preserve normal crash
+ * visibility.
+ *
+ * @see https://github.com/electron/electron/issues/24948
+ */
+const TRANSIENT_NET_ERROR_CODES = new Set([
+  'ERR_NETWORK_CHANGED',
+  'ERR_NETWORK_IO_SUSPENDED',
+  'ERR_INTERNET_DISCONNECTED',
+  'ERR_NETWORK_ACCESS_DENIED',
+  'ERR_CONNECTION_RESET',
+  'ERR_CONNECTION_ABORTED',
+  'ERR_CONNECTION_CLOSED',
+  'ERR_NAME_NOT_RESOLVED',
+  'ERR_TIMED_OUT',
+]);
+
+const isTransientNetError = (error: unknown): boolean => {
+  if (!error) return false;
+
+  const message = error instanceof Error ? error.message : String(error);
+
+  // Electron net errors are formatted as `net::ERR_XXX`.
+  const match = message.match(/net::(ERR_[A-Z_]+)/);
+  if (match && TRANSIENT_NET_ERROR_CODES.has(match[1])) return true;
+
+  // Belt-and-suspenders: these only ever originate from the net loader.
+  const stack = error instanceof Error ? (error.stack ?? '') : '';
+  return /net::ERR_/.test(message) && stack.includes('SimpleURLLoaderWrapper');
+};
+
+/**
+ * Install global guards for the Electron main process. Must be called as early
+ * as possible (before the rest of the app boots) so it catches errors from any
+ * module's top-level / async work.
+ */
+export const installProcessErrorHandlers = () => {
+  process.on('uncaughtException', (error) => {
+    if (isTransientNetError(error)) {
+      logger.warn('Ignoring transient network error in main process:', error.message);
+      return;
+    }
+
+    // Re-throw so genuine bugs still surface as a crash instead of being
+    // silently swallowed by this handler.
+    logger.error('Uncaught exception in main process:', error);
+    throw error;
+  });
+
+  process.on('unhandledRejection', (reason) => {
+    if (isTransientNetError(reason)) {
+      logger.warn(
+        'Ignoring transient network rejection in main process:',
+        reason instanceof Error ? reason.message : String(reason),
+      );
+      return;
+    }
+
+    logger.error('Unhandled rejection in main process:', reason);
+  });
+
+  logger.info('Process error handlers installed');
+};

--- a/apps/desktop/src/main/process-error-handlers.ts
+++ b/apps/desktop/src/main/process-error-handlers.ts
@@ -70,7 +70,13 @@ export const installProcessErrorHandlers = () => {
       return;
     }
 
+    // Installing this listener overrides Node's default
+    // `--unhandled-rejections=throw`, so we must re-throw to preserve the fatal
+    // behavior. Throwing here surfaces as an uncaughtException (handled above,
+    // which also re-throws non-transient errors), instead of leaving the app
+    // partially booted on a genuine failure (e.g. an unawaited app.bootstrap()).
     logger.error('Unhandled rejection in main process:', reason);
+    throw reason;
   });
 
   logger.info('Process error handlers installed');


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No tracking issue; reported via in-app crash dialogs (ERR_NETWORK_CHANGED / ERR_NETWORK_IO_SUSPENDED). -->

#### 🔀 Description of Change

Users hit the **"A JavaScript error occurred in the main process"** dialog with:

- `Uncaught Exception: Error: net::ERR_NETWORK_CHANGED`
- `Uncaught Exception: Error: net::ERR_NETWORK_IO_SUSPENDED`

Both stacks point at `SimpleURLLoaderWrapper.emit (node:events:509:28)` — Electron's `net` stack internals.

**Root cause.** Our own code never calls `net.request` directly (only `net.fetch` via `netFetch`, all try/catch-wrapped). The leaking `net.request` lives inside **electron-updater** (`electronHttpExecutor.js` → `electron.net.request`). It normally attaches `request.on("error", reject)`, but transient connectivity blips — Wi-Fi/VPN switch, system sleep, the network interface dropping — can surface on edge paths (redirect `abort()`, differential-download streaming, error firing during teardown) **after** the promise already settled. The main process had **no** global `uncaughtException` guard, so these benign network blips crashed it.

Since the offending request is inside a third-party lib, we can't patch the listener from the call site. A process-level guard is the only clean interception point.

**Fix.** Add `src/main/process-error-handlers.ts`, installed first thing in `index.ts`:

- Swallows a whitelist of transient **net-stack** errors (`ERR_NETWORK_CHANGED`, `ERR_NETWORK_IO_SUSPENDED`, `ERR_INTERNET_DISCONNECTED`, `ERR_CONNECTION_RESET`, …) — logs a warning and moves on.
- **Re-throws everything else** so genuine bugs still surface as a crash. This is intentionally not a blanket "catch-all and ignore."
- Also guards `unhandledRejection` symmetrically.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Transient network errors are hard to reproduce deterministically (they require an in-flight updater request at the exact moment the network changes / the machine sleeps). The logic change is small and isolated; primary validation is observing the crash dialog no longer appears in the field.

#### 📝 Additional Information

- Scope is limited to the Electron desktop main process — no renderer / server / shared-package changes.
- Only net-stack errors are swallowed; non-network exceptions keep their original crash behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)