### PR TITLE
⬆️ fix(model-runtime): upgrade openai SDK to v6 to drop node-fetch@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -392,7 +392,7 @@
     "ogl": "^1.0.11",
     "oidc-provider": "^9.6.0",
     "ollama": "^0.6.3",
-    "openai": "^4.104.0",
+    "openai": "^6.42.0",
     "openapi-fetch": "^0.14.1",
     "partial-json": "^0.1.7",
     "path-browserify-esm": "^1.0.6",

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@lobechat/context-engine": "workspace:*",
     "@lobechat/types": "workspace:*",
-    "openai": "^4.104.0"
+    "openai": "^6.42.0"
   }
 }

--- a/packages/model-runtime/package.json
+++ b/packages/model-runtime/package.json
@@ -33,7 +33,7 @@
     "model-bank": "workspace:*",
     "nanoid": "^5.1.6",
     "ollama": "^0.6.2",
-    "openai": "^4.104.0",
+    "openai": "^6.42.0",
     "replicate": "^1.4.0",
     "tokenx": "^1.3.0",
     "type-fest": "^5.2.0",

--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
@@ -84,12 +84,15 @@ interface RouterInstance {
   runtime?: RuntimeClass;
 }
 
-type ConstructorOptions<T extends Record<string, any> = any> = ClientOptions & T;
+// OpenAI SDK v6 widened `apiKey` to `string | ApiKeySetter`; lobehub only ever
+// passes a plain string, so narrow it back to keep `.trim()` / string assignments valid.
+type LobeClientOptions = Omit<ClientOptions, 'apiKey'> & { apiKey?: string };
+type ConstructorOptions<T extends Record<string, any> = any> = LobeClientOptions & T;
 
 type Routers =
   | RouterInstance[]
   | ((
-      options: ClientOptions & Record<string, any>,
+      options: LobeClientOptions & Record<string, any>,
       runtimeContext: {
         model?: string;
       },
@@ -199,7 +202,7 @@ export const createRouterRuntime = ({
   ...params
 }: CreateRouterRuntimeOptions) => {
   return class UniformRuntime implements LobeRuntimeAI {
-    public _options: ClientOptions & Record<string, any>;
+    public _options: LobeClientOptions & Record<string, any>;
     private _routers: Routers;
     private _params: any;
     private _id: string;
@@ -213,7 +216,7 @@ export const createRouterRuntime = ({
       metadata.routeAttempt = routeAttempt;
     }
 
-    constructor(options: ClientOptions & Record<string, any> = {}) {
+    constructor(options: LobeClientOptions & Record<string, any> = {}) {
       const startedAt = Date.now();
       this._options = {
         ...options,

--- a/packages/model-runtime/src/core/contextBuilders/anthropic.ts
+++ b/packages/model-runtime/src/core/contextBuilders/anthropic.ts
@@ -460,17 +460,19 @@ export const buildAnthropicTools = (
 ) => {
   if (!tools) return;
 
-  return tools.map(
-    (tool, index): Anthropic.Tool => ({
+  return tools.map((tool, index): Anthropic.Tool => {
+    // OpenAI SDK v6 made `ChatCompletionTool` a function|custom union; lobehub only sends function tools.
+    const { function: fn } = tool as OpenAI.ChatCompletionFunctionTool;
+    return {
       cache_control:
         options.enabledContextCaching && index === tools.length - 1
           ? { type: 'ephemeral' }
           : undefined,
-      description: tool.function.description,
-      input_schema: tool.function.parameters as Anthropic.Tool.InputSchema,
-      name: tool.function.name,
-    }),
-  );
+      description: fn.description,
+      input_schema: fn.parameters as Anthropic.Tool.InputSchema,
+      name: fn.name,
+    };
+  });
 };
 
 export const buildSearchTool = (): Anthropic.WebSearchTool20250305 => {

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -890,7 +890,7 @@ describe('LobeOpenAICompatibleFactory', () => {
             status: 400,
           },
           'Error message',
-          {},
+          new Headers(),
         );
 
         vi.spyOn(instance['client'].chat.completions, 'create').mockRejectedValue(apiError);
@@ -931,7 +931,7 @@ describe('LobeOpenAICompatibleFactory', () => {
             message: 'api is undefined',
           },
         };
-        const apiError = new OpenAI.APIError(400, errorInfo, 'module error', {});
+        const apiError = new OpenAI.APIError(400, errorInfo, 'module error', new Headers());
 
         vi.spyOn(instance['client'].chat.completions, 'create').mockRejectedValue(apiError);
 
@@ -960,7 +960,7 @@ describe('LobeOpenAICompatibleFactory', () => {
         const errorInfo = {
           cause: { message: 'api is undefined' },
         };
-        const apiError = new OpenAI.APIError(400, errorInfo, 'module error', {});
+        const apiError = new OpenAI.APIError(400, errorInfo, 'module error', new Headers());
 
         instance = new LobeMockProvider({
           apiKey: 'test',
@@ -1044,7 +1044,7 @@ describe('LobeOpenAICompatibleFactory', () => {
             status: 400,
           },
           'Error message',
-          {},
+          new Headers(),
         );
 
         vi.spyOn(instance['client'].chat.completions, 'create').mockRejectedValue(apiError);
@@ -1080,7 +1080,7 @@ describe('LobeOpenAICompatibleFactory', () => {
             status: 400,
           },
           'Error message',
-          {},
+          new Headers(),
         );
 
         vi.spyOn(instance['client'].chat.completions, 'create').mockRejectedValue(apiError);
@@ -1118,7 +1118,7 @@ describe('LobeOpenAICompatibleFactory', () => {
             status: 429,
           },
           'Error message',
-          {},
+          new Headers(),
         );
 
         vi.spyOn(instance['client'].chat.completions, 'create').mockRejectedValue(apiError);
@@ -2349,7 +2349,7 @@ describe('LobeOpenAICompatibleFactory', () => {
           status: 400,
         },
         'Error message',
-        {},
+        new Headers(),
       );
 
       vi.spyOn(instance['client'].responses, 'create').mockRejectedValue(apiError);

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -99,7 +99,10 @@ export const CHAT_MODELS_BLOCK_LIST = [
   'dall-e',
 ];
 
-type ConstructorOptions<T extends Record<string, any> = any> = ClientOptions & T;
+// OpenAI SDK v6 widened `apiKey` to `string | ApiKeySetter`; lobehub only ever
+// passes a plain string, so narrow it back to keep `.trim()` / string assignments valid.
+type LobeClientOptions = Omit<ClientOptions, 'apiKey'> & { apiKey?: string };
+type ConstructorOptions<T extends Record<string, any> = any> = LobeClientOptions & T;
 type OpenAIExtraParams = { prompt_cache_key?: string; safety_identifier?: string };
 type ChatCompletionCreateParamsWithPromptCacheKey = Omit<
   OpenAI.ChatCompletionCreateParamsNonStreaming,
@@ -316,7 +319,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
     baseURL!: string;
     protected _options: ConstructorOptions<T>;
 
-    constructor(options: ClientOptions & Record<string, any> = {}) {
+    constructor(options: LobeClientOptions & Record<string, any> = {}) {
       const _options = {
         ...options,
         apiKey: options.apiKey?.trim() || DEFAULT_API_KEY,
@@ -1541,10 +1544,14 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       log('received %d tool calls from Chat Completions API', toolCalls?.length || 0);
 
       try {
-        const result = toolCalls.map((item) => ({
-          arguments: JSON.parse(item.function.arguments),
-          name: item.function.name,
-        }));
+        const result = toolCalls.map((item) => {
+          // OpenAI SDK v6 made tool calls a function|custom union; lobehub only emits function calls.
+          const { function: fn } = item as OpenAI.ChatCompletionMessageFunctionToolCall;
+          return {
+            arguments: JSON.parse(fn.arguments),
+            name: fn.name,
+          };
+        });
         log(
           'successfully parsed tool calls: %O',
           result.map((r) => r.name),

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/nonStreamToStream.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/nonStreamToStream.ts
@@ -36,12 +36,16 @@ export const transformResponseToStream = (data: OpenAI.ChatCompletion) =>
             content: choice.message.content,
             role: choice.message.role,
             tool_calls: choice.message.tool_calls?.map(
-              (tool, index): OpenAI.ChatCompletionChunk.Choice.Delta.ToolCall => ({
-                function: tool.function,
-                id: tool.id,
-                index,
-                type: tool.type,
-              }),
+              (tool, index): OpenAI.ChatCompletionChunk.Choice.Delta.ToolCall => {
+                // OpenAI SDK v6 made tool calls a function|custom union; lobehub only emits function calls.
+                const fnTool = tool as OpenAI.ChatCompletionMessageFunctionToolCall;
+                return {
+                  function: fnTool.function,
+                  id: fnTool.id,
+                  index,
+                  type: fnTool.type,
+                };
+              },
             ),
           },
           finish_reason: null,

--- a/packages/model-runtime/src/core/streams/openai/responsesStream.ts
+++ b/packages/model-runtime/src/core/streams/openai/responsesStream.ts
@@ -132,7 +132,8 @@ const transformOpenAIStream = (
       }
 
       case 'response.output_text.annotation.added': {
-        const citations = chunk.annotation;
+        // OpenAI SDK v6 types the annotation payload as `unknown`; narrow to the URL-citation shape we read.
+        const citations = chunk.annotation as { title?: string; url?: string };
 
         if (streamContext.returnedCitationArray) {
           streamContext.returnedCitationArray.push({

--- a/packages/model-runtime/src/core/streams/spark.ts
+++ b/packages/model-runtime/src/core/streams/spark.ts
@@ -35,12 +35,16 @@ export function transformSparkResponseToStream(data: OpenAI.ChatCompletion) {
               content: choice.message.content,
               role: choice.message.role,
               tool_calls: toolCallsArray.map(
-                (tool, index): OpenAI.ChatCompletionChunk.Choice.Delta.ToolCall => ({
-                  function: tool.function,
-                  id: tool.id,
-                  index,
-                  type: tool.type,
-                }),
+                (tool, index): OpenAI.ChatCompletionChunk.Choice.Delta.ToolCall => {
+                  // OpenAI SDK v6 made tool calls a function|custom union; lobehub only emits function calls.
+                  const fnTool = tool as OpenAI.ChatCompletionMessageFunctionToolCall;
+                  return {
+                    function: fnTool.function,
+                    id: fnTool.id,
+                    index,
+                    type: fnTool.type,
+                  };
+                },
               ),
             },
             finish_reason: null,

--- a/packages/model-runtime/src/providerTestUtils.test.ts
+++ b/packages/model-runtime/src/providerTestUtils.test.ts
@@ -62,7 +62,7 @@ describe('testProvider', () => {
                     status: 400,
                   },
                   'Test Error',
-                  {},
+                  new Headers(),
                 ),
               ),
             },

--- a/packages/model-runtime/src/providerTestUtils.ts
+++ b/packages/model-runtime/src/providerTestUtils.ts
@@ -138,7 +138,7 @@ export const testProvider = ({
                 status: 400,
               },
               'Error message',
-              {},
+              new Headers(),
             );
 
             if (test?.useResponsesAPI) {
@@ -183,7 +183,7 @@ export const testProvider = ({
                 message: 'api is undefined',
               },
             };
-            const apiError = new OpenAI.APIError(400, errorInfo, 'module error', {});
+            const apiError = new OpenAI.APIError(400, errorInfo, 'module error', new Headers());
 
             if (test?.useResponsesAPI) {
               vi.mocked(instance['client'].responses.create).mockRejectedValue(apiError);
@@ -216,7 +216,7 @@ export const testProvider = ({
             const errorInfo = {
               cause: { message: 'api is undefined' },
             };
-            const apiError = new OpenAI.APIError(400, errorInfo, 'module error', {});
+            const apiError = new OpenAI.APIError(400, errorInfo, 'module error', new Headers());
 
             instance = new Runtime({
               apiKey: 'test',

--- a/packages/model-runtime/src/providers/bfl/index.ts
+++ b/packages/model-runtime/src/providers/bfl/index.ts
@@ -13,7 +13,8 @@ export class LobeBflAI implements LobeRuntimeAI {
   private apiKey: string;
   baseURL?: string;
 
-  constructor({ apiKey, baseURL }: ClientOptions = {}) {
+  // OpenAI SDK v6 widened `apiKey` to `string | ApiKeySetter`; lobehub only uses the string form.
+  constructor({ apiKey, baseURL }: Omit<ClientOptions, 'apiKey'> & { apiKey?: string } = {}) {
     if (!apiKey) throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidProviderAPIKey);
 
     this.apiKey = apiKey;

--- a/packages/model-runtime/src/providers/fal/index.ts
+++ b/packages/model-runtime/src/providers/fal/index.ts
@@ -15,7 +15,8 @@ const log = debug('lobe-image:fal');
 type FluxDevOutput = Awaited<ReturnType<typeof fal.subscribe<'fal-ai/flux/dev'>>>['data'];
 
 export class LobeFalAI implements LobeRuntimeAI {
-  constructor({ apiKey }: ClientOptions = {}) {
+  // OpenAI SDK v6 widened `apiKey` to `string | ApiKeySetter`; lobehub only uses the string form.
+  constructor({ apiKey }: Omit<ClientOptions, 'apiKey'> & { apiKey?: string } = {}) {
     if (!apiKey) throw AgentRuntimeError.createError(AgentRuntimeErrorType.InvalidProviderAPIKey);
 
     fal.config({

--- a/packages/model-runtime/src/providers/google/index.test.ts
+++ b/packages/model-runtime/src/providers/google/index.test.ts
@@ -303,7 +303,7 @@ describe('LobeGoogleAI', () => {
             message: 'api is undefined',
           },
         };
-        const apiError = new OpenAI.APIError(400, errorInfo, 'module error', {});
+        const apiError = new OpenAI.APIError(400, errorInfo, 'module error', new Headers());
 
         vi.spyOn(instance['client'].models, 'generateContentStream').mockRejectedValue(apiError);
 

--- a/packages/model-runtime/src/providers/openai/index.test.ts
+++ b/packages/model-runtime/src/providers/openai/index.test.ts
@@ -71,7 +71,7 @@ describe('LobeOpenAI', () => {
             status: 400,
           },
           'Error message',
-          {},
+          new Headers(),
         );
 
         vi.spyOn(instance['client'].chat.completions, 'create').mockRejectedValue(apiError);
@@ -112,7 +112,7 @@ describe('LobeOpenAI', () => {
             message: 'api is undefined',
           },
         };
-        const apiError = new OpenAI.APIError(400, errorInfo, 'module error', {});
+        const apiError = new OpenAI.APIError(400, errorInfo, 'module error', new Headers());
 
         vi.spyOn(instance['client'].chat.completions, 'create').mockRejectedValue(apiError);
 
@@ -141,7 +141,7 @@ describe('LobeOpenAI', () => {
         const errorInfo = {
           cause: { message: 'api is undefined' },
         };
-        const apiError = new OpenAI.APIError(400, errorInfo, 'module error', {});
+        const apiError = new OpenAI.APIError(400, errorInfo, 'module error', new Headers());
 
         instance = new LobeOpenAI({
           apiKey: 'test',

--- a/packages/model-runtime/src/providers/siliconcloud/index.test.ts
+++ b/packages/model-runtime/src/providers/siliconcloud/index.test.ts
@@ -235,9 +235,7 @@ describe('LobeSiliconCloudAI - custom features', () => {
           message: 'Value error, current model does not support parameter `enable_thinking`.',
         },
       };
-      const apiError = new OpenAI.APIError(400, errorInfo, 'Request failed', {
-        status: 400,
-      } as any);
+      const apiError = new OpenAI.APIError(400, errorInfo, 'Request failed', undefined);
 
       vi.spyOn(instance['client'].chat.completions, 'create').mockRejectedValue(apiError);
 

--- a/packages/model-runtime/src/providers/taichu/index.test.ts
+++ b/packages/model-runtime/src/providers/taichu/index.test.ts
@@ -48,7 +48,7 @@ describe('LobeTaichuAI', () => {
           message: 'api is undefined',
         },
       };
-      const apiError = new OpenAI.APIError(400, errorInfo, 'module error', {});
+      const apiError = new OpenAI.APIError(400, errorInfo, 'module error', new Headers());
 
       const mockCreate = vi
         .spyOn(instance['client'].chat.completions, 'create')

--- a/packages/model-runtime/src/utils/handleOpenAIError.test.ts
+++ b/packages/model-runtime/src/utils/handleOpenAIError.test.ts
@@ -11,7 +11,7 @@ describe('handleOpenAIError', () => {
         472,
         { error: { message: 'API error', type: 'invalid_request' } },
         'test-message',
-        { status: 400 } as any,
+        undefined,
       );
 
       const result = handleOpenAIError(apiError);
@@ -25,9 +25,7 @@ describe('handleOpenAIError', () => {
 
     it('should handle OpenAI APIError with cause', () => {
       const cause = { message: 'Network error', code: 'ECONNRESET' };
-      const apiError = new OpenAI.APIError(472, null as any, 'test-message', {
-        status: 500,
-      } as any);
+      const apiError = new OpenAI.APIError(472, null as any, 'test-message', undefined);
       (apiError as any).cause = cause;
 
       const result = handleOpenAIError(apiError);
@@ -38,16 +36,13 @@ describe('handleOpenAIError', () => {
     });
 
     it('should handle OpenAI APIError without error or cause', () => {
-      const headers = { 'content-type': 'application/json' };
-      const apiError = new OpenAI.APIError(472, null as any, 'test-message', {
-        status: 401,
-        headers,
-      } as any);
+      const headers = new Headers({ 'content-type': 'application/json' });
+      const apiError = new OpenAI.APIError(472, null as any, 'test-message', headers);
 
       const result = handleOpenAIError(apiError);
 
       expect(result.errorResult).toEqual({
-        headers: { headers, status: 401 },
+        headers: apiError.headers,
         status: 472,
       });
       expect(result.message).toBe(apiError.message);
@@ -57,9 +52,7 @@ describe('handleOpenAIError', () => {
     it('should handle OpenAI APIError with both error and cause', () => {
       const errorObject = { message: 'API error', type: 'rate_limit' };
       const cause = { message: 'Rate limit exceeded' };
-      const apiError = new OpenAI.APIError(472, { error: errorObject }, 'test-message', {
-        status: 429,
-      } as any);
+      const apiError = new OpenAI.APIError(472, { error: errorObject }, 'test-message', undefined);
       (apiError as any).cause = cause;
 
       const result = handleOpenAIError(apiError);


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] 👷 build

#### 🔗 Related Issue

N/A — follow-up to the Vercel `ERR_STREAM_PREMATURE_CLOSE` incident (Jun 19, node-fetch@2 streaming regression under the Node.js June-2026 security release).

#### 🔀 Description of Change

The OpenAI SDK **v4** (`openai@^4.104.0`, used by `model-runtime` / `agent-runtime` / root) bundles **`node-fetch@2`** internally. Its gzip response-stream handling breaks under Vercel's Node.js June-2026 rollout and throws `ERR_STREAM_PREMATURE_CLOSE` (`at Gunzip`), which surfaced as **"LLM stream error: Premature close"** across *all* providers (deepseek / openai / glm / doubao / …) during the Jun-19 incident. Vercel mitigated by reverting Node.js but will re-land it, so the fragility will recur.

**Fix: bump `openai` `^4.104.0` → `^6.42.0`.** SDK v6 uses native `fetch` (undici) and no longer depends on `node-fetch@2`, removing it from the LLM call path entirely.

Migration touch-ups for v6's type changes (all behavior-preserving):
- **`apiKey`** — v6 widened `ClientOptions['apiKey']` to `string | ApiKeySetter`; lobehub only ever passes a string, so narrowed it back via a local `LobeClientOptions` alias (factory + router runtime + bfl/fal).
- **tool unions** — v6 made `ChatCompletionTool` / `ChatCompletionMessageToolCall` `function | custom` unions; access `.function` via the function-tool variant (anthropic builder, factory tool-call parsing, `nonStreamToStream`, `spark`).
- **`APIError` headers** — v6's `APIError` calls `headers.get()`; tests now pass real `Headers` instead of plain objects.

No production logic changed — only types/narrowing + test fixtures.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [x] `bun run type-check` — 0 errors
- [x] `model-runtime` suite — 175 files, 4109 passed / 0 failed
- [x] `agent-runtime` suite — 266 passed

#### 📝 Additional Information

`node-fetch@2` is still pulled transitively by non-LLM-path deps (octokit / gaxios / klavis); those are not in the hot streaming path and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)