### PR TITLE
feat(model-providers): add Kevoryn AI API provider

### DIFF
--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -35,6 +35,7 @@ import HunyuanProvider from './hunyuan';
 import InfiniAIProvider from './infiniai';
 import InternLMProvider from './internlm';
 import JinaProvider from './jina';
+import KevorynProvider from './kevoryn';
 import KimiCodingPlanProvider from './kimiCodingPlan';
 import LMStudioProvider from './lmstudio';
 import LobeHubProvider from './lobehub';
@@ -105,6 +106,7 @@ export const LOBE_DEFAULT_MODEL_LIST: ChatModelCard[] = [
   VLLMProvider.chatModels,
   XinferenceProvider.chatModels,
   OpenRouterProvider.chatModels,
+  KevorynProvider.chatModels,
   TogetherAIProvider.chatModels,
   FireworksAIProvider.chatModels,
   PerplexityProvider.chatModels,
@@ -158,6 +160,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   AzureAIProvider,
   AiHubMixProvider,
   OpenRouterProvider,
+  KevorynProvider,
   FalProvider,
   OllamaProvider,
   OllamaCloudProvider,
@@ -270,6 +273,7 @@ export { default as HunyuanProviderCard } from './hunyuan';
 export { default as InfiniAIProviderCard } from './infiniai';
 export { default as InternLMProviderCard } from './internlm';
 export { default as JinaProviderCard } from './jina';
+export { default as KevorynProviderCard } from './kevoryn';
 export { default as KimiCodingPlanProviderCard } from './kimiCodingPlan';
 export { default as LMStudioProviderCard } from './lmstudio';
 export { default as LobeHubProviderCard } from './lobehub';

--- a/packages/model-bank/src/modelProviders/kevoryn.ts
+++ b/packages/model-bank/src/modelProviders/kevoryn.ts
@@ -1,0 +1,25 @@
+import type { ModelProviderCard } from '@/types/llm';
+
+// Kevoryn — AI API Gateway, 66+ models with one key
+// https://kevoryn.com
+const Kevoryn: ModelProviderCard = {
+  chatModels: [],
+  checkModel: 'deepseek-v4-pro',
+  description:
+    'Kevoryn is an AI API gateway providing unified access to 66+ frontier models (GPT-5.5, Claude Opus 4.8, Gemini 3.1 Pro, DeepSeek V4, Kimi K2.6, Qwen 3.6, MiniMax M2.7) through a single OpenAI-compatible endpoint. Supports direct access from China without a VPN, with WeChat/Alipay payment.',
+  enabled: true,
+  id: 'kevoryn',
+  modelList: { showModelFetcher: true },
+  modelsUrl: 'https://kevoryn.com/models',
+  name: 'Kevoryn',
+  settings: {
+    proxyUrl: {
+      placeholder: 'https://api.kevoryn.com/v1',
+    },
+    sdkType: 'openai',
+    showModelFetcher: true,
+  },
+  url: 'https://kevoryn.com',
+};
+
+export default Kevoryn;


### PR DESCRIPTION
## Summary

Add Kevoryn (https://kevoryn.com) as a model provider.

Kevoryn is an AI API gateway providing unified access to **66+ frontier models** through a single OpenAI-compatible endpoint.

## Changes
- Create `kevoryn.ts` provider config (OpenAI SDK type, model fetcher)
- Register in `DEFAULT_MODEL_PROVIDER_LIST` and legacy list
- Add export entry