### PR TITLE
 🔨 chore(docker-compose): Explicitly enable pg_search in the Paradedb container

### DIFF
--- a/docker-compose/deploy/docker-compose.yml
+++ b/docker-compose/deploy/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - '5432:5432'
     volumes:
       - './data:/var/lib/postgresql/data'
+    command: ['postgres', '-c', 'shared_preload_libraries=pg_search']
     environment:
       - 'POSTGRES_DB=${LOBE_DB_NAME}'
       - 'POSTGRES_PASSWORD=${POSTGRES_PASSWORD}'

--- a/docker-compose/dev/docker-compose.yml
+++ b/docker-compose/dev/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - '5432:5432'
     volumes:
       - './data:/var/lib/postgresql/data'
+    command: ['postgres', '-c', 'shared_preload_libraries=pg_search']
     environment:
       - 'POSTGRES_DB=${LOBE_DB_NAME}'
       - 'POSTGRES_PASSWORD=${POSTGRES_PASSWORD}'

--- a/docker-compose/production/grafana/docker-compose.yml
+++ b/docker-compose/production/grafana/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     environment:
       - 'POSTGRES_DB=${LOBE_DB_NAME}'
       - 'POSTGRES_PASSWORD=${POSTGRES_PASSWORD}'
+    command: ['postgres', '-c', 'shared_preload_libraries=pg_search']
     healthcheck:
       test: ['CMD-SHELL', 'pg_isready -U postgres']
       interval: 5s


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

N/A — no tracking issue yet. Happy to open one if maintainers prefer.

#### 🔀 Description of Change
Explicitly enable pg_search in the Paradedb container to avoid potential errors when LobeHub starts up.
Add a startup command to the ParadeDB container in the Docker Compose configuration to ensure `pg_search` is properly preloaded:

```yaml
command: ['postgres', '-c', 'shared_preload_libraries=pg_search']
```

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->
ParadeDB introduced a breaking change in `v0.23.x` ( [[PR #4914](https://github.com/paradedb/paradedb/pull/4914)](https://github.com/paradedb/paradedb/pull/4914) / [[PR #4923](https://github.com/paradedb/paradedb/pull/4923)](https://github.com/paradedb/paradedb/pull/4923)) that unconditionally requires `pg_search` to be declared in `shared_preload_libraries` across **all supported PostgreSQL versions**. Without this, attempting to use full-text search will trigger an error at runtime.
<!-- Breaking changes? Migration guide? Performance impact? -->
