### PR TITLE
🐛 fix(security): escape JSON-LD output in StructuredData to prevent XSS

### DIFF
--- a/src/components/StructuredData/index.tsx
+++ b/src/components/StructuredData/index.tsx
@@ -1,9 +1,21 @@
 import { type FC } from 'react';
 
-const StructuredData: FC<{ ld: any }> = ({ ld }) => {
+/**
+ * Safely serialize JSON-LD to prevent XSS.
+ * `JSON.stringify` can produce strings containing `</script>` which would
+ * break out of the `<script>` element. We escape angle brackets as Unicode
+ * escape sequences so the JSON stays valid but is safe inside HTML.
+ */
+const safeJsonLdStringify = (data: unknown): string =>
+  JSON.stringify(data)
+    .replaceAll('<', '\\u003c')
+    .replaceAll('>', '\\u003e')
+    .replaceAll('&', '\\u0026');
+
+const StructuredData: FC<{ ld: Record<string, unknown> }> = ({ ld }) => {
   return (
     <script
-      dangerouslySetInnerHTML={{ __html: JSON.stringify(ld) }}
+      dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(ld) }}
       id="structured-data"
       type="application/ld+json"
     />


### PR DESCRIPTION
## Description

JSON.stringify can produce output containing </script> which breaks out of the script element when used with dangerouslySetInnerHTML. This escapes angle brackets and ampersands as Unicode escape sequences to prevent script injection while keeping the JSON valid.

Also replaces the 'any' prop type with 'Record<string, unknown>' for better type safety.