### PR TITLE
♻️ refactor: replace catch (error: any) with type-safe error handling

### DIFF
--- a/apps/server/src/router-hono/agent/handlers/runStep.ts
+++ b/apps/server/src/router-hono/agent/handlers/runStep.ts
@@ -205,13 +205,14 @@ export async function runStep(c: Context): Promise<Response> {
     );
 
     return c.json(responseData);
-  } catch (error: any) {
+  } catch (error) {
     const executionTime = Date.now() - startTime;
     console.error('Error in execution: %O', error);
+    const errorMessage = error instanceof Error ? error.message : String(error);
 
     return c.json(
       {
-        error: error.message,
+        error: errorMessage,
         executionTime,
         operationId: body?.operationId,
         stepIndex: body?.stepIndex || 0,

--- a/src/app/(backend)/webapi/create-image/comfyui/route.ts
+++ b/src/app/(backend)/webapi/create-image/comfyui/route.ts
@@ -31,11 +31,11 @@ const handler = async (req: Request, { jwtPayload }: { jwtPayload?: any }) => {
     });
 
     return NextResponse.json(result);
-  } catch (error: any) {
+  } catch (error) {
     console.error('[ComfyUI WebAPI] Error:', error);
 
     // Extract AgentRuntimeError from TRPCError's cause
-    const agentError = error?.cause;
+    const agentError = error instanceof Error ? error.cause : undefined;
 
     // If we have an AgentRuntimeError in the cause, return it
     if (agentError && typeof agentError === 'object' && 'errorType' in agentError) {

--- a/src/components/FeedbackModal/FeedbackContent.tsx
+++ b/src/components/FeedbackModal/FeedbackContent.tsx
@@ -89,7 +89,7 @@ const FeedbackContent = memo<FeedbackContentProps>(({ initialValues }) => {
       form.resetFields();
       setScreenshotUrl(null);
       close();
-    } catch (error: any) {
+    } catch (error) {
       console.error('[FeedbackModal] Submission failed:', error);
       toast.error(t('feedback.errors.submitFailed'));
     } finally {

--- a/src/features/AgentSetting/store/action.ts
+++ b/src/features/AgentSetting/store/action.ts
@@ -256,8 +256,10 @@ export const store: StateCreator<Store, [['zustand/devtools', never]]> = (set, g
       try {
         await get().onConfigChange?.(nextConfig);
         get().updateSaveStatus('saved');
-      } catch (error: any) {
-        if (error?.name === 'AbortError' || error?.message?.includes('aborted')) {
+      } catch (error) {
+        const name = error instanceof Error ? error.name : 'Error';
+        const msg = error instanceof Error ? error.message : '';
+        if (name === 'AbortError' || msg.includes('aborted')) {
           get().updateSaveStatus('idle');
         } else {
           console.error('[AgentSettings] Failed to save config:', error);
@@ -276,8 +278,10 @@ export const store: StateCreator<Store, [['zustand/devtools', never]]> = (set, g
       try {
         await get().onMetaChange?.(nextValue);
         get().updateSaveStatus('saved');
-      } catch (error: any) {
-        if (error?.name === 'AbortError' || error?.message?.includes('aborted')) {
+      } catch (error) {
+        const name = error instanceof Error ? error.name : 'Error';
+        const msg = error instanceof Error ? error.message : '';
+        if (name === 'AbortError' || msg.includes('aborted')) {
           get().updateSaveStatus('idle');
         } else {
           console.error('[AgentSettings] Failed to save meta:', error);

--- a/src/features/Settings/system-tools/features/CliTestSection.tsx
+++ b/src/features/Settings/system-tools/features/CliTestSection.tsx
@@ -23,7 +23,7 @@ const CliTestSection = memo(() => {
     try {
       const result = await electronSystemService.runCliCommand(args);
       setResults((prev) => [...prev, { args, ...result }]);
-    } catch (error: any) {
+    } catch (error) {
       setResults((prev) => [...prev, { args, exitCode: -1, stderr: String(error), stdout: '' }]);
     } finally {
       setRunning(false);

--- a/src/routes/(main)/community/(detail)/group_agent/features/Sidebar/ActionButton/ForkGroupAndChat.tsx
+++ b/src/routes/(main)/community/(detail)/group_agent/features/Sidebar/ActionButton/ForkGroupAndChat.tsx
@@ -264,7 +264,7 @@ const ForkGroupAndChat = memo<{ mobile?: boolean }>(() => {
 
       // Step 8: Navigate to chat
       navigate(urlJoin('/group', result.groupId));
-    } catch (error: any) {
+    } catch (error) {
       console.error('Fork group failed:', error);
       toast.error(t('fork.failed'));
     } finally {

--- a/src/store/agent/slices/agent/action.ts
+++ b/src/store/agent/slices/agent/action.ts
@@ -693,8 +693,10 @@ export class AgentSliceActionImpl {
         this.#get().invalidateAvailableAgents();
       }
       updateSaveStatus('saved');
-    } catch (error: any) {
-      if (error?.name === 'AbortError' || error?.message?.includes('aborted')) {
+    } catch (error) {
+      const name = error instanceof Error ? error.name : 'Error';
+      const msg = error instanceof Error ? error.message : '';
+      if (name === 'AbortError' || msg.includes('aborted')) {
         updateSaveStatus('idle');
       } else {
         console.error('[AgentStore] Failed to save config:', error);
@@ -738,8 +740,10 @@ export class AgentSliceActionImpl {
         this.#get().invalidateAvailableAgents();
       }
       updateSaveStatus('saved');
-    } catch (error: any) {
-      if (error?.name === 'AbortError' || error?.message?.includes('aborted')) {
+    } catch (error) {
+      const name = error instanceof Error ? error.name : 'Error';
+      const msg = error instanceof Error ? error.message : '';
+      if (name === 'AbortError' || msg.includes('aborted')) {
         updateSaveStatus('idle');
       } else {
         console.error('[AgentStore] Failed to save meta:', error);


### PR DESCRIPTION
## Description

TypeScript infers \unknown\ by default when useUnknownInCatchVariables is enabled. This refactors all \catch (error: any)\ patterns to use \catch (error)\ and adds proper \instanceof Error\ type narrowing before accessing error properties.