### PR TITLE
🐛 fix(store): prevent NaN in aiProvider sorting by handling undefined sort fields

### DIFF
--- a/src/store/aiInfra/slices/aiProvider/selectors.ts
+++ b/src/store/aiInfra/slices/aiProvider/selectors.ts
@@ -7,7 +7,7 @@ import { type GlobalLLMProviderKey } from '@/types/user/settings';
 
 // List
 const enabledAiProviderList = (s: AIProviderStoreState) =>
-  s.aiProviderList.filter((item) => item.enabled).sort((a, b) => a.sort! - b.sort!);
+  s.aiProviderList.filter((item) => item.enabled).sort((a, b) => (a.sort ?? 0) - (b.sort ?? 0));
 
 const disabledAiProviderList = (s: AIProviderStoreState) =>
   s.aiProviderList.filter((item) => !item.enabled && item.source !== AiProviderSourceEnum.Custom);


### PR DESCRIPTION
## Description

Replaced unsafe \.sort! - b.sort!\ with \(a.sort ?? 0) - (b.sort ?? 0)\ to guarantee safe integer comparison and avoid crashes when sort fields are undefined.