### PR TITLE
♻️ refactor(service): remove redundant "return await" from aiAgent service

### DIFF
--- a/src/services/aiAgent.ts
+++ b/src/services/aiAgent.ts
@@ -131,7 +131,7 @@ class AiAgentService {
     params: ExecAgentTaskParams,
     options?: { signal?: AbortSignal },
   ): Promise<ExecAgentResult> {
-    return await lambdaClient.aiAgent.execAgent.mutate(params, options);
+    return lambdaClient.aiAgent.execAgent.mutate(params, options);
   }
 
   /**
@@ -144,11 +144,11 @@ class AiAgentService {
    * Get a fresh JWT token for Gateway WebSocket reconnection.
    */
   async refreshGatewayToken(topicId: string): Promise<{ token: string }> {
-    return await lambdaClient.aiAgent.refreshGatewayToken.query({ topicId });
+    return lambdaClient.aiAgent.refreshGatewayToken.query({ topicId });
   }
 
   async execSubAgentTask(params: ExecSubAgentTaskParams) {
-    return await lambdaClient.aiAgent.execSubAgentTask.mutate(params);
+    return lambdaClient.aiAgent.execSubAgentTask.mutate(params);
   }
 
   /**
@@ -156,14 +156,14 @@ class AiAgentService {
    * Works for both Group and Single Agent mode tasks
    */
   async getSubAgentTaskStatus(params: GetSubAgentTaskStatusParams) {
-    return await lambdaClient.aiAgent.getSubAgentTaskStatus.query(params);
+    return lambdaClient.aiAgent.getSubAgentTaskStatus.query(params);
   }
 
   /**
    * Interrupt a running task
    */
   async interruptTask(params: InterruptTaskParams) {
-    return await lambdaClient.aiAgent.interruptTask.mutate(params);
+    return lambdaClient.aiAgent.interruptTask.mutate(params);
   }
 
   /**
@@ -173,7 +173,7 @@ class AiAgentService {
    * It creates the Thread but does NOT execute the task - execution happens locally.
    */
   async createClientTaskThread(params: CreateClientTaskThreadParams) {
-    return await lambdaClient.aiAgent.createClientTaskThread.mutate(params);
+    return lambdaClient.aiAgent.createClientTaskThread.mutate(params);
   }
 
   /**
@@ -184,7 +184,7 @@ class AiAgentService {
    * - Thread messages query should not filter by agentId
    */
   async createClientGroupAgentTaskThread(params: CreateClientGroupAgentTaskThreadParams) {
-    return await lambdaClient.aiAgent.createClientGroupAgentTaskThread.mutate(params);
+    return lambdaClient.aiAgent.createClientGroupAgentTaskThread.mutate(params);
   }
 
   /**
@@ -193,7 +193,7 @@ class AiAgentService {
    * This method is called by desktop client after task execution finishes.
    */
   async updateClientTaskThreadStatus(params: UpdateClientTaskThreadStatusParams) {
-    return await lambdaClient.aiAgent.updateClientTaskThreadStatus.mutate(params);
+    return lambdaClient.aiAgent.updateClientTaskThreadStatus.mutate(params);
   }
 }
 


### PR DESCRIPTION
## Description

Removes 8 redundant "return await" statements from the aiAgent service. Returning a promise directly without await avoids generating an unnecessary microtask during execution, which is a standard ESLint and TypeScript best practice.