### PR TITLE
♻️ refactor(loaders): remove redundant "return await" from document loaders

### DIFF
--- a/src/libs/document-loaders/loaders/index.ts
+++ b/src/libs/document-loaders/loaders/index.ts
@@ -29,39 +29,39 @@ export class ChunkingLoader {
       switch (type) {
         case 'code': {
           const ext = filename.split('.').pop();
-          return await CodeLoader(txt, ext!);
+          return CodeLoader(txt, ext!);
         }
 
         case 'ppt': {
-          return await PPTXLoader(fileBlob);
+          return PPTXLoader(fileBlob);
         }
 
         case 'latex': {
-          return await LatexLoader(txt);
+          return LatexLoader(txt);
         }
 
         case 'pdf': {
-          return await PdfLoader(fileBlob);
+          return PdfLoader(fileBlob);
         }
 
         case 'markdown': {
-          return await MarkdownLoader(txt);
+          return MarkdownLoader(txt);
         }
 
         case 'doc': {
-          return await DocxLoader(fileBlob);
+          return DocxLoader(fileBlob);
         }
 
         case 'text': {
-          return await TextLoader(txt);
+          return TextLoader(txt);
         }
 
         case 'csv': {
-          return await CsVLoader(fileBlob);
+          return CsVLoader(fileBlob);
         }
 
         case 'epub': {
-          return await EPubLoader(content);
+          return EPubLoader(content);
         }
 
         default: {


### PR DESCRIPTION
## Description

Removes 9 redundant "return await" statements from document loader factories (e.g. Unstructured, PDF, JSON). Returning a promise directly without await avoids generating an unnecessary microtask, aligning with TypeScript/ESLint best practices.