### PR TITLE
🐛 fix(agent): stop hiding agent-documents tool when an agent has zero documents

### DIFF
--- a/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
@@ -9,7 +9,6 @@
  * - Gets model capabilities from provided function
  * - No dependency on frontend stores (useToolStore, useAgentStore, etc.)
  */
-import { AgentDocumentsManifest } from '@lobechat/builtin-tool-agent-documents';
 import { CloudSandboxManifest } from '@lobechat/builtin-tool-cloud-sandbox';
 import { KnowledgeBaseManifest } from '@lobechat/builtin-tool-knowledge-base';
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
@@ -135,7 +134,6 @@ export const createServerAgentToolsEngine = (
     disableLocalSystem = false,
     executionPlan,
     globalMemoryEnabled = false,
-    hasAgentDocuments = false,
     hasEnabledKnowledgeBases = false,
     isBotConversation = false,
     model,
@@ -247,7 +245,6 @@ export const createServerAgentToolsEngine = (
       hasDeviceProxy &&
       !deviceContext?.autoActivated &&
       !deviceContext?.boundDeviceId,
-    [AgentDocumentsManifest.identifier]: hasAgentDocuments,
     [WebBrowsingManifest.identifier]: isSearchEnabled,
   };
 

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/types.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/types.ts
@@ -101,8 +101,6 @@ export interface ServerCreateAgentToolsEngineParams {
   executionPlan?: ExecutionPlan;
   /** Whether the user's global memory setting is enabled */
   globalMemoryEnabled?: boolean;
-  /** Whether agent has agent documents */
-  hasAgentDocuments?: boolean;
   /** Whether agent has enabled knowledge bases */
   hasEnabledKnowledgeBases?: boolean;
   /** Whether the request originates from a bot conversation (auto-enables message tool) */

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1986,7 +1986,6 @@ export class AiAgentService {
         disableLocalSystem,
         executionPlan,
         globalMemoryEnabled,
-        hasAgentDocuments,
         hasEnabledKnowledgeBases,
         isBotConversation,
         model,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

The server tool engine gated `lobe-agent-documents` behind a `hasAgentDocuments` system rule in `agentModeRules`. Because that rule sits **after** the plugin spread in the rules object, it overrode the agent's own plugin selection down to `false` whenever the agent had no existing (non-deleted) documents:

```ts
const agentModeRules = {
  ...Object.fromEntries((agentConfig.plugins ?? []).map((id) => [id, true])), // lobe-agent-documents: true ✓
  // ...system rules...
  [AgentDocumentsManifest.identifier]: hasAgentDocuments,                     // overrides → false ✗
};
```

This created a **dead state**: once a user deleted every document on an agent, `hasByAgent()` returned `false`, the tool was dropped from the LLM payload, and the agent could **never create its first document again** — it silently fell back to dumping content as plain chat text.

Real case: a meeting-memo agent (`会议 Memo 整理助手`) had `lobe-agent-documents` in its plugins and had created 16 documents. The user bulk-deleted all 16, and ~12 minutes later the next bot run mounted **0** document tools and just printed the memo as text.

This PR drops the override so the tool is governed by the normal plugin-enable layer (the inbox agent injects it into default plugins, and users keep it in `agentConfig.plugins`). The now-unused `hasAgentDocuments` param is removed from `ServerCreateAgentToolsEngineParams` and its call site; the `hasDocuments()` DB lookup stays for operation telemetry only.

#### 🧪 How to Test

- [x] Tested locally (`apps/server` type-check passes for the touched files)
- [ ] Added/updated tests
- [x] No tests needed

Repro for verification: take an agent that has `lobe-agent-documents` in its plugins, delete all of its documents, then trigger a turn — before this change the document tool is absent from the payload; after, it is mounted and the agent can create a new document.

#### 📝 Additional Information

Chat mode is unaffected (`lobe-agent-documents` was never in `chatModeRules`). No UI change — the tool is **not** added to `alwaysOnToolIds`, so the chat-input Pinned popover is untouched.