### PR TITLE
♻️ refactor(services): remove redundant "return await" from remaining services

### DIFF
--- a/src/services/agentRuntime/index.ts
+++ b/src/services/agentRuntime/index.ts
@@ -9,7 +9,7 @@ class AgentRuntimeService {
    * Handle human intervention
    */
   async handleHumanIntervention(request: HumanInterventionRequest): Promise<any> {
-    return await lambdaClient.aiAgent.processHumanIntervention.mutate({
+    return lambdaClient.aiAgent.processHumanIntervention.mutate({
       action: request.action,
       data: request.data,
       operationId: request.operationId,

--- a/src/services/export/index.ts
+++ b/src/services/export/index.ts
@@ -3,7 +3,7 @@ import { type ExportDatabaseData } from '@/types/export';
 
 class ExportService {
   exportData = async (): Promise<ExportDatabaseData> => {
-    return await lambdaClient.exporter.exportData.mutate();
+    return lambdaClient.exporter.exportData.mutate();
   };
 }
 

--- a/src/services/upload.ts
+++ b/src/services/upload.ts
@@ -125,7 +125,7 @@ class UploadService {
   uploadDataToS3 = async (data: object, options: UploadFileToS3Options = {}) => {
     const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
     const file = new File([blob], options.filename || 'data.json', { type: 'application/json' });
-    return await this.uploadFileToS3(file, options);
+    return this.uploadFileToS3(file, options);
   };
 
   uploadToServerS3 = async (


### PR DESCRIPTION
## Description

Removes unnecessary "return await" statements from upload, export, and agentRuntime services. Returning a promise directly without await avoids creating a redundant microtask, which is an ESLint/TypeScript best practice.