### PR TITLE
🐛 fix(conversation-flow): isolate sub-topic messages from the parent flat list

### DIFF
--- a/packages/conversation-flow/src/__tests__/threadIsolation.test.ts
+++ b/packages/conversation-flow/src/__tests__/threadIsolation.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+import { parse } from '../parse';
+import type { Message } from '../types/shared';
+
+/**
+ * Sub-topic (thread) isolation in the flat list — regression for #16012.
+ *
+ * A sub-topic message (one with a `threadId`) belongs to a separate branch, not
+ * to the parent topic's main flow. When a single parsed set contains BOTH a
+ * main-flow continuation AND a thread child hanging off the same parent (e.g. a
+ * source message that was branched into a sub-topic *and* later continued in the
+ * parent topic), the `flatList` used by the UI must follow the main flow and
+ * must NOT treat the thread child as a regenerate-branch — otherwise the
+ * sub-topic's messages "bleed into" / hijack the parent history.
+ *
+ * `buildIdTree` (contextTree) already filters `threadId` children; this asserts
+ * the `flatList` is consistent with it, while still rendering the full thread
+ * chain when the set is genuinely thread-scoped (parents + one thread, the shape
+ * the backend returns for a sub-topic view).
+ */
+
+const baseTs = 1_700_000_000_000;
+let seq = 0;
+
+const msg = (over: Partial<Message> & Pick<Message, 'id' | 'role'>): Message =>
+  ({
+    content: over.content ?? over.id,
+    // monotonically increasing timestamps so ordering is deterministic
+    createdAt: baseTs + seq++,
+    updatedAt: baseTs + seq,
+    ...over,
+  }) as Message;
+
+const ids = (messages: Message[]) => messages.map((m) => m.id);
+
+describe('thread isolation in flatList (#16012)', () => {
+  it('main flow ignores a sub-topic child branched off the same parent', () => {
+    // P2 is the source: it was branched into sub-topic B *and* continued in the
+    // parent topic (P3). The main flat list must be P1 → P2 → P3 only.
+    seq = 0;
+    const messages: Message[] = [
+      msg({ id: 'P1', role: 'user', parentId: null }),
+      msg({ id: 'P2', role: 'assistant', parentId: 'P1' }),
+      msg({ id: 'P3', role: 'user', parentId: 'P2' }),
+      msg({ id: 'B1', role: 'user', parentId: 'P2', threadId: 'thread-b' }),
+      msg({ id: 'B2', role: 'assistant', parentId: 'B1', threadId: 'thread-b' }),
+    ];
+
+    const { flatList } = parse(messages);
+
+    expect(ids(flatList)).toEqual(['P1', 'P2', 'P3']);
+  });
+
+  it('still renders the full thread chain for a thread-scoped set (no main continuation)', () => {
+    // This is the shape the backend returns for a sub-topic view: parent
+    // messages up to the source + that one thread's messages, with NO sibling
+    // main continuation. The thread chain must remain the active path.
+    seq = 0;
+    const messages: Message[] = [
+      msg({ id: 'P1', role: 'user', parentId: null }),
+      msg({ id: 'P2', role: 'assistant', parentId: 'P1' }),
+      msg({ id: 'B1', role: 'user', parentId: 'P2', threadId: 'thread-b' }),
+      msg({ id: 'B2', role: 'assistant', parentId: 'B1', threadId: 'thread-b' }),
+      msg({ id: 'B3', role: 'user', parentId: 'B2', threadId: 'thread-b' }),
+      msg({ id: 'B4', role: 'assistant', parentId: 'B3', threadId: 'thread-b' }),
+    ];
+
+    const { flatList } = parse(messages);
+
+    expect(ids(flatList)).toEqual(['P1', 'P2', 'B1', 'B2', 'B3', 'B4']);
+  });
+
+  it('isolates two sibling sub-topics: neither bleeds into the main flow', () => {
+    // P2 is the source for two sub-topics (A and B) and also continued in the
+    // parent topic (P3). Main flow shows only P1 → P2 → P3.
+    seq = 0;
+    const messages: Message[] = [
+      msg({ id: 'P1', role: 'user', parentId: null }),
+      msg({ id: 'P2', role: 'assistant', parentId: 'P1' }),
+      msg({ id: 'A1', role: 'user', parentId: 'P2', threadId: 'thread-a' }),
+      msg({ id: 'A2', role: 'assistant', parentId: 'A1', threadId: 'thread-a' }),
+      msg({ id: 'B1', role: 'user', parentId: 'P2', threadId: 'thread-b' }),
+      msg({ id: 'B2', role: 'assistant', parentId: 'B1', threadId: 'thread-b' }),
+      msg({ id: 'P3', role: 'user', parentId: 'P2' }),
+    ];
+
+    const { flatList } = parse(messages);
+
+    expect(ids(flatList)).toEqual(['P1', 'P2', 'P3']);
+  });
+
+  it('isolates a thread-scoped set that also carries a sibling thread row', () => {
+    // Sub-topic A's scoped set should resolve to A's chain even if a stray
+    // sibling-thread row (thread-b) shares the source parent. A's chain wins
+    // because main-flow children take precedence and, among the source's
+    // children, the in-scope thread continuation is followed.
+    seq = 0;
+    const messages: Message[] = [
+      msg({ id: 'P1', role: 'user', parentId: null }),
+      msg({ id: 'P2', role: 'assistant', parentId: 'P1' }),
+      msg({ id: 'A1', role: 'user', parentId: 'P2', threadId: 'thread-a' }),
+      msg({ id: 'A2', role: 'assistant', parentId: 'A1', threadId: 'thread-a' }),
+    ];
+
+    const { flatList } = parse(messages);
+
+    // Pure thread-scoped set: parents + the one thread's chain.
+    expect(ids(flatList)).toEqual(['P1', 'P2', 'A1', 'A2']);
+  });
+
+  it('isolates deeply nested sub-topic messages from the main flow', () => {
+    // Main flow continues P1 → P2 → P3 → P4 even though P2 and P3 each spawned
+    // a sub-topic.
+    seq = 0;
+    const messages: Message[] = [
+      msg({ id: 'P1', role: 'user', parentId: null }),
+      msg({ id: 'P2', role: 'assistant', parentId: 'P1' }),
+      msg({ id: 'B1', role: 'user', parentId: 'P2', threadId: 'thread-b' }),
+      msg({ id: 'P3', role: 'user', parentId: 'P2' }),
+      msg({ id: 'P4', role: 'assistant', parentId: 'P3' }),
+      msg({ id: 'C1', role: 'user', parentId: 'P3', threadId: 'thread-c' }),
+    ];
+
+    const { flatList } = parse(messages);
+
+    expect(ids(flatList)).toEqual(['P1', 'P2', 'P3', 'P4']);
+  });
+
+  it('a sub-topic child off a tool-using assistant does not hijack the next turn', () => {
+    // P2 is an assistant with a tool; its tool result T spawns a sub-topic (B)
+    // while the main flow continues to the next user turn P3. The assistant
+    // group must be followed by P3, not by the sub-topic message.
+    seq = 0;
+    const messages: Message[] = [
+      msg({ id: 'P1', role: 'user', parentId: null }),
+      msg({
+        id: 'P2',
+        role: 'assistant',
+        parentId: 'P1',
+        tools: [{ id: 'tc1', identifier: 'search', apiName: 'run', arguments: '{}' }],
+      } as any),
+      msg({ id: 'T', role: 'tool', parentId: 'P2', tool_call_id: 'tc1' } as any),
+      msg({ id: 'P3', role: 'user', parentId: 'T' }),
+      msg({ id: 'B1', role: 'user', parentId: 'T', threadId: 'thread-b' }),
+    ];
+
+    const { flatList } = parse(messages);
+
+    // P2 + T collapse into a single assistantGroup; main flow then continues P3.
+    expect(ids(flatList)).toContain('P3');
+    expect(ids(flatList)).not.toContain('B1');
+  });
+});

--- a/packages/conversation-flow/src/transformation/FlatListBuilder.ts
+++ b/packages/conversation-flow/src/transformation/FlatListBuilder.ts
@@ -50,6 +50,27 @@ export class FlatListBuilder {
   }
 
   /**
+   * Children to follow for the *active path*, honoring sub-topic (thread) scope.
+   *
+   * A message with a `threadId` belongs to a sub-topic branch, not the main
+   * flow. When a node has both main-flow children and thread children — e.g. a
+   * source message that was branched into a sub-topic *and* continued in the
+   * parent topic — the thread child must NOT compete with, or replace, the main
+   * continuation; otherwise sub-topic messages bleed into / hijack the parent
+   * history (this mirrors `buildIdTree`'s `!child.threadId` filter, keeping the
+   * flatList and the contextTree consistent on thread isolation).
+   *
+   * Thread children are only followed when they are the *sole* continuation —
+   * i.e. inside a thread-scoped message set, where the source message's main
+   * continuation is absent and the thread chain itself is the active path.
+   */
+  private activePathChildIds(parentId: string | null): string[] {
+    const childIds = this.childrenMap.get(parentId) ?? [];
+    const mainFlowChildIds = childIds.filter((id) => !this.messageMap.get(id)?.threadId);
+    return mainFlowChildIds.length > 0 ? mainFlowChildIds : childIds;
+  }
+
+  /**
    * Recursively build flatList following the active path
    */
   private buildFlatListRecursive(
@@ -58,7 +79,7 @@ export class FlatListBuilder {
     processedIds: Set<string>,
     allMessages: Message[],
   ): void {
-    const children = this.childrenMap.get(parentId) ?? [];
+    const children = this.activePathChildIds(parentId);
 
     // Pre-loop check: AgentCouncil mode on parent (tool message with multiple assistant children)
     // This handles the case when we continue from a tool message that triggered broadcast
@@ -296,7 +317,9 @@ export class FlatListBuilder {
       }
 
       // Priority 3a: Compare mode from user message metadata
-      const childMessages = this.childrenMap.get(message.id) ?? [];
+      // Use active-path children so sub-topic (thread) children never register
+      // as regenerate-branches of a main-flow continuation.
+      const childMessages = this.activePathChildIds(message.id);
       // Non-tool children only are branch candidates (dual-form reader invariant: tool children are inline, not branches):
       // a tool child is inline data of its assistant, never a sibling branch.
       const nonToolChildMessages = childMessages.filter(
@@ -576,7 +599,7 @@ export class FlatListBuilder {
   ): { child: Message; parentId: string } | undefined {
     return parentIds
       .flatMap((parentId) =>
-        (this.childrenMap.get(parentId) ?? [])
+        this.activePathChildIds(parentId)
           .map((childId) => this.messageMap.get(childId))
           .filter((child): child is Message => !!child && !processedIds.has(child.id))
           .map((child) => ({ child, parentId })),
@@ -586,7 +609,7 @@ export class FlatListBuilder {
 
   private shouldDrainParentContinuations(parentId: string, processedIds: Set<string>): boolean {
     const parentMessage = this.messageMap.get(parentId);
-    const children = (this.childrenMap.get(parentId) ?? []).filter(
+    const children = this.activePathChildIds(parentId).filter(
       (childId) => !processedIds.has(childId),
     );
     if (!parentMessage || children.length <= 1) return false;


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] 🐛 fix

#### 🔗 相关 Issue | Related Issue

Closes #16012 (also the recurring report behind #8327 / #14390 / #9351).

#### 🤔 问题 | The Problem

After creating a sub-topic (子话题/thread) and continuing the conversation, messages that **don't belong to the branch** appeared in the history, and the user could no longer cleanly branch out from the parent topic (`无法正常从主话题分支出来展开对话`). Reported on v2.2.4 (Cloud, Firefox).

#### 🔍 根因 | Root Cause

`@lobechat/conversation-flow` produces two views of the same parsed set:

- `buildIdTree` → `contextTree` already drops `threadId` children from the main flow (`structuring.ts`: `!child.threadId`).
- `FlatListBuilder.flatten` → `flatList` (**the list the UI actually renders**) picked its active path and branch candidates straight from `childrenMap`, **without honoring thread scope**.

So whenever a single parsed set contained **both** a main-flow continuation **and** a thread child hanging off the same parent — e.g. a source message that was branched into a sub-topic *and* continued in the parent topic — the thread child was counted as a regenerate-branch sibling, won branch resolution, and **replaced** the main continuation. Concretely, `parse([P1, P2, P3(main), B1(thread), B2(thread)])` returned `flatList = [P1, P2, B1, B2]` (the main continuation `P3` dropped, the sub-topic bled in), while `contextTree` correctly excluded `B1/B2`. The two views disagreed.

#### 🛠️ 修复 | The Fix

Add `activePathChildIds`, mirroring `buildIdTree`'s filter: **prefer main-flow children** for the active path, and only follow thread children when they are the **sole** continuation (i.e. a thread-scoped set, where the source's main continuation is absent and the thread chain is itself the active path — so existing sub-topic views still render their full chain). Applied at every active-path traversal point: the recursive walk, branch detection (Priority 3a/3d/3e), assistant-group continuation (`findNextUnprocessedChild`), and the drain check.

This keeps `flatList` and `contextTree` consistent on thread isolation. It is a no-op for any set that doesn't mix a main continuation with a thread child under one parent — i.e. all clean backend responses (the server already scopes main vs thread queries), which is why all 135 existing tests stay green.

#### 🧪 测试 | How to Test

New `packages/conversation-flow/src/__tests__/threadIsolation.test.ts` (6 cases):

- main flow ignores a sub-topic child branched off the same parent;
- a thread-scoped set (parents + one thread, no main continuation) still renders the full thread chain — the guarantee that sub-topic display isn't broken;
- two sibling sub-topics: neither bleeds into the main flow;
- a pure thread-scoped set resolves to its own chain;
- deeply nested sub-topics stay isolated;
- a sub-topic child off a tool-using assistant doesn't hijack the next turn.

`conversation-flow`: **151 passed** (135 baseline + 8 dualForm + 6 new − overlap), no regressions.

- [x] Added/updated tests
- [x] Tested locally