### PR TITLE
🐛 fix(bot): surface perceivable agent-failure causes in IM instead of a bare Operation ID

### DIFF
--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -422,14 +422,24 @@ export class CompletionLifecycle {
       ? Date.now() - new Date(state.createdAt).getTime()
       : undefined;
 
+    // On the error path, normalize the runtime error once so the lifecycle
+    // event carries the stable taxonomy fields (errorType + attribution). Bot
+    // reply renderers switch on these to surface a perceivable cause (network /
+    // quota / provider outage …) instead of an opaque Operation ID. Mirrors the
+    // same normalization dispatchHooks runs before writing the error onto the
+    // assistant message row.
+    const formattedError = state?.error ? formatErrorForState(state.error) : undefined;
+
     return {
       event: {
         agentId: metadata?.agentId || '',
         attachments: attachments.length > 0 ? attachments : undefined,
         cost: state?.cost?.total,
         duration,
+        errorAttribution: formattedError?.attribution,
         errorDetail: state?.error,
         errorMessage: this.extractErrorMessage(state?.error) || String(state?.error || ''),
+        errorType: formattedError?.type === undefined ? undefined : String(formattedError.type),
         finalState: state,
         lastAssistantContent,
         llmCalls: state?.usage?.llm?.apiCalls,

--- a/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
@@ -196,6 +196,30 @@ describe('CompletionLifecycle.buildLifecycleEvent', () => {
     expect(event.attachments).toBeUndefined();
     expect(event.agentId).toBe('a');
   });
+
+  it('populates errorType + attribution from the normalized error on the error path', () => {
+    // Regression: the event previously carried only errorDetail/errorMessage, so
+    // bot reply renderers never saw the stable code/attribution and always fell
+    // back to the opaque Operation ID. buildLifecycleEvent must normalize the
+    // runtime error via formatErrorForState and surface these taxonomy fields.
+    const state = {
+      error: { error: { message: 'fetch failed' }, errorType: 'ProviderNetworkError' },
+      metadata: { agentId: 'agent-1', userId: 'user-1' },
+    };
+
+    const { event } = callBuild(state, 'error');
+
+    expect(event.errorType).toBe('ProviderNetworkError');
+    expect(event.errorAttribution).toBe('system');
+    expect(event.errorMessage).toBe('fetch failed');
+  });
+
+  it('leaves errorType + attribution undefined when there is no error', () => {
+    const { event } = callBuild({ messages: [], metadata: {} }, 'done');
+
+    expect(event.errorType).toBeUndefined();
+    expect(event.errorAttribution).toBeUndefined();
+  });
 });
 
 describe('CompletionLifecycle.dispatchHooks — error persistence', () => {

--- a/apps/server/src/services/bot/AgentBridgeService.ts
+++ b/apps/server/src/services/bot/AgentBridgeService.ts
@@ -1229,6 +1229,7 @@ export class AgentBridgeService {
                       errorMsg,
                       event.operationId,
                       replyLocale,
+                      event.errorAttribution,
                     );
                     // Wrap in `{ markdown }` so the Chat SDK adapter sets the
                     // platform's markdown parse_mode (e.g. Telegram `Markdown`,

--- a/apps/server/src/services/bot/BotCallbackService.ts
+++ b/apps/server/src/services/bot/BotCallbackService.ts
@@ -55,6 +55,13 @@ export interface BotCallbackBody {
   cost?: number;
   duration?: number;
   elapsedMs?: number;
+  /**
+   * Error ownership from the model-runtime error taxonomy (`user` | `provider`
+   * | `harness` | `system`). Drives the user-facing error message tier when the
+   * exact `errorType` has no precise copy. Forwarded verbatim from the agent
+   * lifecycle event.
+   */
+  errorAttribution?: string;
   errorMessage?: string;
   errorType?: string;
   executionTimeMs?: number;
@@ -379,8 +386,15 @@ export class BotCallbackService {
     charLimit?: number,
     canEdit = true,
   ): Promise<void> {
-    const { reason, lastAssistantContent, errorMessage, errorType, operationId, attachments } =
-      body;
+    const {
+      reason,
+      lastAssistantContent,
+      errorAttribution,
+      errorMessage,
+      errorType,
+      operationId,
+      attachments,
+    } = body;
 
     if (reason === 'error') {
       log(
@@ -389,7 +403,13 @@ export class BotCallbackService {
         errorType,
         errorMessage,
       );
-      const errorBody = renderAgentError(errorType, errorMessage, operationId, replyLocale);
+      const errorBody = renderAgentError(
+        errorType,
+        errorMessage,
+        operationId,
+        replyLocale,
+        errorAttribution,
+      );
       const errorText = client.formatMarkdown?.(errorBody) ?? errorBody;
       await this.deliverFirstChunk(messenger, progressMessageId, errorText, canEdit);
       return;

--- a/apps/server/src/services/bot/__tests__/replyTemplate.test.ts
+++ b/apps/server/src/services/bot/__tests__/replyTemplate.test.ts
@@ -417,7 +417,7 @@ describe('replyTemplate', () => {
       expect(zh).toContain('命令会话已断开');
     });
 
-    it('falls back to the generic op-id template for unknown error codes', () => {
+    it('falls back to the generic op-id template for unknown error codes without attribution', () => {
       expect(renderAgentError('SomeNewErrorCode', undefined, 'op-1')).toBe(
         '**Agent Execution Failed**\nOperation ID: `op-1`',
       );
@@ -425,6 +425,63 @@ describe('replyTemplate', () => {
 
     it('falls back to the generic header when neither errorType nor operationId is known', () => {
       expect(renderAgentError(undefined, undefined, undefined)).toBe('**Agent Execution Failed**');
+    });
+
+    it('surfaces a network message for ProviderNetworkError instead of a bare op id', () => {
+      const en = renderAgentError('ProviderNetworkError', 'fetch failed', 'op-net');
+      expect(en).toContain('Network error talking to the model provider');
+      expect(en).toContain('op-net');
+      expect(en).not.toContain('**Agent Execution Failed**\nOperation ID');
+
+      const zh = renderAgentError('ProviderNetworkError', 'fetch failed', 'op-net', 'zh-CN');
+      expect(zh).toContain('网络连接异常');
+    });
+
+    it('maps provider-capacity codes to the temporarily-unavailable copy', () => {
+      const unavailable = renderAgentError('ProviderServiceUnavailable', undefined, 'op-1');
+      const noChannel = renderAgentError('NoAvailableChannel', undefined, 'op-1');
+      expect(unavailable).toContain('temporarily unavailable');
+      expect(unavailable).toBe(noChannel);
+
+      expect(renderAgentError('RateLimitExceeded', undefined, 'op-1')).toContain(
+        'Too many requests',
+      );
+      expect(renderAgentError('ModelEmptyCompletion', undefined, 'op-1')).toContain(
+        'empty response',
+      );
+    });
+
+    it('gives OperationInactivityTimeout retry-oriented copy', () => {
+      expect(renderAgentError('OperationInactivityTimeout', undefined, 'op-1')).toContain(
+        'timed out',
+      );
+    });
+
+    it('falls back by attribution when the exact code is unknown', () => {
+      // network/system → transient network copy
+      expect(
+        renderAgentError('SomeNewNetworkCode', undefined, 'op-1', 'en-US', 'system'),
+      ).toContain('Network error talking to the model provider');
+      // provider → temporarily-unavailable copy
+      expect(renderAgentError('SomeNewCode', undefined, 'op-1', 'en-US', 'provider')).toContain(
+        'temporarily unavailable',
+      );
+      // harness → internal-error copy, op id kept for support
+      const harness = renderAgentError('SomeNewCode', undefined, 'op-h', 'en-US', 'harness');
+      expect(harness).toContain('Something went wrong on our side');
+      expect(harness).toContain('op-h');
+      // user → generic check-your-settings copy
+      expect(renderAgentError('SomeNewCode', undefined, 'op-1', 'en-US', 'user')).toContain(
+        "couldn't be completed",
+      );
+    });
+
+    it('prefers the precise code copy over the attribution fallback', () => {
+      // ProviderNetworkError has precise copy even though attribution=system
+      // would also resolve; the precise tier must win.
+      const out = renderAgentError('InvalidProviderAPIKey', undefined, 'op-1', 'en-US', 'system');
+      expect(out).toContain('Invalid or missing API key');
+      expect(out).not.toContain('Network error');
     });
   });
 

--- a/apps/server/src/services/bot/replyTemplate.ts
+++ b/apps/server/src/services/bot/replyTemplate.ts
@@ -237,11 +237,19 @@ type SystemStrings = {
   errorExceededContextWindow: string;
   errorInvalidProviderAPIKey: string;
   errorCommandConnectionClosed: string;
+  errorContentModeration: string;
+  errorEmptyCompletion: string;
+  errorHarnessInternal: string;
   errorLocationNotSupported: string;
   errorModelNotFound: string;
   errorNoAvailableProvider: string;
   errorPermissionDenied: string;
+  errorProviderUnavailable: string;
   errorQuotaLimitReached: string;
+  errorRateLimited: string;
+  errorTimeout: string;
+  errorTransientNetwork: string;
+  errorUserGeneric: string;
   errorWithDetails: (details: string, operationId?: string) => string;
   errorWithId: (operationId: string) => string;
   groupRejectedAllowlist: string;
@@ -293,6 +301,12 @@ const SYSTEM_STRINGS: Partial<Record<BotReplyLocale, SystemStrings>> = {
       "**Context window exceeded.**\nThe conversation is too long for this model. Send `/new` to start a fresh topic, or switch to a model with a larger context window in the agent's settings.",
     errorCommandConnectionClosed:
       '**Command session disconnected.**\nThe agent lost its command connection before finishing. Please retry. If this keeps happening, check the sandbox or device connection and review the server logs for the operation.',
+    errorContentModeration:
+      "**Blocked by the content-safety filter.**\nThe model provider's safety filter rejected the request or response. Please rephrase and try again.",
+    errorEmptyCompletion:
+      "**The model returned an empty response.**\nThe model finished without producing any output. Please try again, or switch to a different model in the agent's settings.",
+    errorHarnessInternal:
+      '**Something went wrong on our side.**\nThe agent run hit an internal error, which has been logged. Please try again — if it keeps happening, share the Operation ID below with support.',
     errorInvalidProviderAPIKey:
       "**Invalid or missing API key.**\nThe configured model provider rejected its API key. Please verify the key in the agent's provider settings (it may be expired, revoked, or mistyped) and try again.",
     errorLocationNotSupported:
@@ -303,8 +317,18 @@ const SYSTEM_STRINGS: Partial<Record<BotReplyLocale, SystemStrings>> = {
       "**No model provider configured.**\nThis bot's agent has no available model provider — please add an API key and enable a provider in the agent's settings, then try again.",
     errorPermissionDenied:
       "**Permission denied by the model provider.**\nThe API key doesn't have access to the requested model or operation. Please check the key's permissions, or switch to a model your account is authorized to use.",
+    errorProviderUnavailable:
+      "**Model provider temporarily unavailable.**\nThe model provider is overloaded or unavailable right now. Please wait a moment and try again, or switch to a different model in the agent's settings.",
     errorQuotaLimitReached:
       "**Provider quota exhausted.**\nThe configured model provider is out of quota or rate-limited. Please wait a moment and try again, top up the account, or switch to a different provider in the agent's settings.",
+    errorRateLimited:
+      "**Too many requests.**\nThe model provider is rate-limiting requests right now. Please wait a moment before trying again, or switch to a different model in the agent's settings.",
+    errorTimeout:
+      '**The agent run timed out.**\nThe operation ran too long without progress and was stopped. Please try again; if the task is large, try breaking it into smaller steps.',
+    errorTransientNetwork:
+      "**Network error talking to the model provider.**\nThe connection to the model provider timed out or dropped. This is usually temporary — please try again in a moment. If it keeps happening, try a different model in the agent's settings.",
+    errorUserGeneric:
+      "**The agent run couldn't be completed.**\nPlease check your input or the agent's settings and try again.",
     errorWithDetails: (details, operationId) =>
       operationId
         ? `**Agent Execution Failed**\nOperation ID: \`${operationId}\`\nDetails:\n\`\`\`\n${details}\n\`\`\``
@@ -350,6 +374,12 @@ const SYSTEM_STRINGS: Partial<Record<BotReplyLocale, SystemStrings>> = {
       '**上下文已超出模型上限**\n当前对话长度超过了该模型的上下文窗口。可以发送 `/new` 开启新话题，或在 Agent 设置中切换到上下文更大的模型后重试。',
     errorCommandConnectionClosed:
       '**命令会话已断开**\nAgent 在完成前丢失了命令连接。请重试；如果该问题持续出现，请检查 sandbox 或设备连接，并结合 Operation ID 查看服务端日志。',
+    errorContentModeration:
+      '**被内容安全策略拦截**\n模型 Provider 的安全策略拒绝了本次请求或回复。请调整内容后重试。',
+    errorEmptyCompletion:
+      '**模型未返回任何内容**\n模型执行结束但没有产生输出。请重试，或在 Agent 设置中切换到其他模型。',
+    errorHarnessInternal:
+      '**我们这边出了点问题**\nAgent 执行遇到内部错误，已记录。请重试；如果持续出现，请把下方 Operation ID 提供给支持人员。',
     errorInvalidProviderAPIKey:
       '**API Key 无效或缺失**\n所配置的模型 Provider 拒绝了 API Key，可能已过期、被吊销或填写错误。请到 Agent 的 Provider 设置中检查并更新 API Key 后重试。',
     errorLocationNotSupported:
@@ -360,8 +390,17 @@ const SYSTEM_STRINGS: Partial<Record<BotReplyLocale, SystemStrings>> = {
       '**未配置可用的模型 Provider**\n该机器人的 Agent 当前没有可用的模型 Provider，请在 Agent 设置中添加 API Key 并启用一个 Provider 后重试。',
     errorPermissionDenied:
       '**模型 Provider 拒绝访问**\nAPI Key 没有访问该模型或操作的权限。请检查 Key 的权限范围，或在 Agent 设置中切换到当前账户已授权的模型。',
+    errorProviderUnavailable:
+      '**模型 Provider 暂时不可用**\n模型 Provider 当前过载或不可用。请稍后重试，或在 Agent 设置中切换到其他模型。',
     errorQuotaLimitReached:
       '**Provider 配额已用尽**\n所配置的模型 Provider 已达到配额上限或被限流。请稍后重试、为账户充值，或在 Agent 设置中切换到其他 Provider。',
+    errorRateLimited:
+      '**请求过于频繁**\n模型 Provider 正在限流。请稍后再试，或在 Agent 设置中切换到其他模型。',
+    errorTimeout:
+      '**Agent 执行超时**\n操作长时间无进展，已被中止。请重试；如果任务较大，可尝试拆分成更小的步骤。',
+    errorTransientNetwork:
+      '**与模型 Provider 的网络连接异常**\n连接模型 Provider 时超时或中断。通常是临时问题，请稍后重试；如果反复出现，可在 Agent 设置中换一个模型。',
+    errorUserGeneric: '**Agent 执行未能完成**\n请检查你的输入或 Agent 设置后重试。',
     errorWithDetails: (details, operationId) =>
       operationId
         ? `**Agent 执行失败**\nOperation ID: \`${operationId}\`\n详细信息：\n\`\`\`\n${details}\n\`\`\``
@@ -389,14 +428,19 @@ export function renderError(operationId?: string, lng?: BotReplyLocale): string 
 
 /**
  * Map known `AgentRuntimeError` codes to the `SystemStrings` field that
- * carries the friendly, actionable copy for that failure mode. Codes not in
- * this map fall back to the generic `Operation ID` template — opaque enough
- * not to leak internal error strings, but still traceable in logs.
+ * carries the friendly, actionable copy for that failure mode. This is the
+ * precise tier: when we recognize the exact code we show copy tailored to it.
+ *
+ * Codes not in this map fall back to {@link FALLBACK_ERROR_BY_ATTRIBUTION}
+ * (a per-`attribution` tier), and only then to the generic `Operation ID`
+ * template.
  *
  * When adding a new code: extend `SystemStrings`, drop the copy into both the
  * `en-US` and `zh-CN` dictionaries, then add the mapping here.
  */
 const FRIENDLY_ERROR_BY_TYPE: Record<string, keyof SystemStrings> = {
+  // ── user-fixable config / input (attribution: user) ──
+  ContentModeration: 'errorContentModeration',
   ExceededContextWindow: 'errorExceededContextWindow',
   InsufficientQuota: 'errorQuotaLimitReached',
   InvalidProviderAPIKey: 'errorInvalidProviderAPIKey',
@@ -405,7 +449,39 @@ const FRIENDLY_ERROR_BY_TYPE: Record<string, keyof SystemStrings> = {
   NoAvailableProvider: 'errorNoAvailableProvider',
   PermissionDenied: 'errorPermissionDenied',
   QuotaLimitReached: 'errorQuotaLimitReached',
+  // ── transient provider / capacity (attribution: provider) ──
+  ModelEmptyCompletion: 'errorEmptyCompletion',
+  NoAvailableChannel: 'errorProviderUnavailable',
+  ProviderServiceUnavailable: 'errorProviderUnavailable',
+  RateLimitExceeded: 'errorRateLimited',
+  // ── network / infra (attribution: system) ──
+  ProviderNetworkError: 'errorTransientNetwork',
+  // ── harness watchdog: harness-owned but retry-friendly, so it gets its
+  //    own retry-oriented copy rather than the generic internal-error tier ──
+  OperationInactivityTimeout: 'errorTimeout',
 };
+
+/**
+ * When a specific error code has no precise copy above, fall back to a message
+ * keyed on the error's `attribution` (from the model-runtime error taxonomy) so
+ * the user still learns *who owns the failure* and whether to retry — instead of
+ * a bare Operation ID. Unknown / absent attribution falls through to the legacy
+ * template.
+ */
+const FALLBACK_ERROR_BY_ATTRIBUTION: Record<string, keyof SystemStrings> = {
+  harness: 'errorHarnessInternal',
+  provider: 'errorProviderUnavailable',
+  system: 'errorTransientNetwork',
+  user: 'errorUserGeneric',
+};
+
+/**
+ * Append the Operation ID as a traceable footer so operators can still grep
+ * logs for the failure even when the user-facing copy is a friendly, actionable
+ * message rather than the raw "Operation ID" line.
+ */
+const appendOperationId = (value: string, operationId: string | undefined): string =>
+  operationId ? `${value}\nOperation ID: \`${operationId}\`` : value;
 
 const isCommandConnectionClosedError = (
   errorType: string | undefined,
@@ -418,34 +494,39 @@ const isCommandConnectionClosedError = (
 };
 
 /**
- * Render an agent-execution failure for the user. Switches on the stable
- * `errorType` code (from `AgentRuntimeError.chat`) to surface a friendly,
- * actionable message for known failure modes.
+ * Render an agent-execution failure for the user, in three tiers:
  *
- * For unknown error codes — or when `errorType` is missing — falls back to
- * the legacy `Operation ID` template.
+ * 1. **Precise** — switch on the stable `errorType` code (from
+ *    `AgentRuntimeError.chat`) for copy tailored to that exact failure mode.
+ * 2. **Attribution** — when the code is unknown, fall back to a message keyed
+ *    on `attribution` (network / provider / harness / user) so the user still
+ *    learns who owns the failure and whether to retry.
+ * 3. **Legacy** — when neither is known, the opaque `Operation ID` template.
+ *
+ * The Operation ID is appended as a footer to every tier (not the whole
+ * message) so it stays traceable in logs without being the only thing the
+ * user sees.
  */
 export function renderAgentError(
   errorType: string | undefined,
   errorMessage: string | undefined,
   operationId: string | undefined,
   lng?: BotReplyLocale,
+  attribution?: string,
 ): string {
   const strings = getSystemStrings(lng);
 
   if (isCommandConnectionClosedError(errorType, errorMessage)) {
-    const value = strings.errorCommandConnectionClosed;
-    return operationId ? `${value}\nOperation ID: \`${operationId}\`` : value;
+    return appendOperationId(strings.errorCommandConnectionClosed, operationId);
   }
 
-  const stringKey = errorType ? FRIENDLY_ERROR_BY_TYPE[errorType] : undefined;
+  const stringKey =
+    (errorType ? FRIENDLY_ERROR_BY_TYPE[errorType] : undefined) ??
+    (attribution ? FALLBACK_ERROR_BY_ATTRIBUTION[attribution] : undefined);
   if (stringKey) {
     const value = strings[stringKey];
     if (typeof value === 'string') {
-      // Append the operationId as a traceable footer so operators can still
-      // grep logs for the failure even when the user-facing copy is a
-      // friendly, actionable message rather than the raw "Operation ID" line.
-      return operationId ? `${value}\nOperation ID: \`${operationId}\`` : value;
+      return appendOperationId(value, operationId);
     }
   }
 

--- a/packages/agent-runtime/src/types/hooks.ts
+++ b/packages/agent-runtime/src/types/hooks.ts
@@ -61,6 +61,13 @@ export interface AgentHookEvent {
   duration?: number;
   /** Elapsed time since operation started in ms (afterStep only) */
   elapsedMs?: number;
+  /**
+   * Error ownership from the model-runtime error taxonomy (`who should fix it`):
+   * `user` | `provider` | `harness` | `system`. Lets consumers pick a
+   * user-facing message tier (and decide whether to keep the Operation ID
+   * prominent) without re-deriving the error spec themselves.
+   */
+  errorAttribution?: string;
   // Content
   errorDetail?: string;
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-10612

#### 🔀 Description of Change

When an agent run failed in an IM/bot channel (Telegram / WeChat / Discord / Slack / Lark / QQ), users only saw an opaque line:

```
Agent Execution Failed
Operation ID: op_1781928769527_agt_..._Ao4dm1w9
```

— never the root cause. A real case: `gemini-3.1-pro-preview` hung ~12 min, returned 0 tokens, then died with `ProviderNetworkError — fetch failed`; the user just saw the opaque op id and couldn't tell whether it was their fault, whether to retry, or whether to switch models.

**Two gaps caused this:**

1. **Plumbing** — `CompletionLifecycle.buildLifecycleEvent` never populated `errorType` on the lifecycle event, so the bot renderer always hit the opaque fallback. The existing `FRIENDLY_ERROR_BY_TYPE` map (8 codes with friendly copy) was effectively **dead code on the bot path** — even `ExceededContextWindow` / `InvalidProviderAPIKey` only showed an op id.
2. **Coverage** — that map only covered user-fixable config codes; the highest-volume transient failures (network, rate limit, provider outage, timeout, empty completion, content moderation) had no copy.

**Fix:**

- `buildLifecycleEvent` normalizes `state.error` via `formatErrorForState` and emits `errorType` + `errorAttribution` on the event (`AgentHookEvent` gains `errorAttribution`). Mirrors the same normalization `dispatchHooks` already runs.
- `renderAgentError` now renders in **three tiers**: precise code copy → **attribution-based fallback** (network / provider / harness / user, from the model-runtime error taxonomy) → legacy Operation ID. Adds en-US + zh-CN copy for `ProviderNetworkError`, `ProviderServiceUnavailable` / `NoAvailableChannel`, `RateLimitExceeded`, `ModelEmptyCompletion`, `ContentModeration`, and `OperationInactivityTimeout`. The **Operation ID is demoted to a footer** (kept prominent only for harness-internal errors, where support needs it).
- Both consumers — `AgentBridgeService` (in-process hook) and `BotCallbackService` (webhook) — forward `errorAttribution` to the renderer. The webhook path needs no extra change: the `bot-completion` hook has no `eventFields` whitelist, so new event fields propagate automatically.

After this, the `ProviderNetworkError` case renders as *"Network error talking to the model provider … usually temporary, please try again"* + a collapsed Operation ID, and the 8 pre-existing friendly messages finally take effect on the bot path.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `replyTemplate.test.ts` — added cases for network codes, provider-capacity codes, timeout, attribution-based fallback per tier, and precise-code-wins-over-attribution (74 passed).
- `CompletionLifecycle.test.ts` — added cases asserting `errorType` + `errorAttribution` are populated on the error path and stay `undefined` otherwise (19 passed).
- `BotCallbackService` / `AgentBridgeService` / `completionWebhook` / AgentRuntime module suites all green (~450 tests).
- These bot system strings are a self-contained en/zh dictionary (not react-i18next namespaces), so both locales are hand-written here; no `pnpm i18n` needed.

#### 📝 Additional Information

Out of scope (noted in LOBE-10612 as follow-ups): IM notification dedup (the screenshot showed 2 ops → 5 messages, client-side retries), and a shorter TTFB timeout for preview endpoints that hang before responding.