### PR TITLE
🐛 fix(bot): keep command-disconnect copy and use provider-neutral system fallback

### DIFF
--- a/apps/server/src/services/bot/__tests__/replyTemplate.test.ts
+++ b/apps/server/src/services/bot/__tests__/replyTemplate.test.ts
@@ -417,6 +417,69 @@ describe('replyTemplate', () => {
       expect(zh).toContain('命令会话已断开');
     });
 
+    it('keeps command-disconnect copy after the error is refined to a StateStore code', () => {
+      // formatErrorForState pattern-refines "Command aborted due to connection
+      // close" to StateStorePersistError (write) / StateStoreReadError (read).
+      // The specific disconnect guidance must still win over the harness/system
+      // tiers now that errorType is always populated.
+      const persist = renderAgentError(
+        'StateStorePersistError',
+        'Command aborted due to connection close',
+        'op-1',
+        'en-US',
+        'harness',
+      );
+      expect(persist).toContain('Command session disconnected');
+
+      const read = renderAgentError(
+        'StateStoreReadError',
+        'Command aborted due to connection close',
+        'op-1',
+        'en-US',
+        'system',
+      );
+      expect(read).toContain('Command session disconnected');
+    });
+
+    it('uses provider-neutral copy for system infra errors (no model-provider blame)', () => {
+      // StateStoreReadError is system-attributed but the LLM provider is not
+      // involved — the fallback must not suggest switching models / blame the
+      // provider the way the network copy does.
+      const en = renderAgentError(
+        'StateStoreReadError',
+        'Agent state not found for operation',
+        'op-1',
+        'en-US',
+        'system',
+      );
+      expect(en).toContain('temporary system error');
+      expect(en).not.toContain('model provider');
+      expect(en).not.toMatch(/switch to a different model/i);
+      expect(en).toContain('op-1');
+
+      const zh = renderAgentError(
+        'StateStoreReadError',
+        'Agent state not found for operation',
+        'op-1',
+        'zh-CN',
+        'system',
+      );
+      expect(zh).toContain('临时系统错误');
+    });
+
+    it('still gives ProviderNetworkError the provider-specific network copy', () => {
+      // Regression guard: the provider-neutral system fallback must not swallow
+      // the one system-attributed code that IS about the model provider.
+      const out = renderAgentError(
+        'ProviderNetworkError',
+        'fetch failed',
+        'op-1',
+        'en-US',
+        'system',
+      );
+      expect(out).toContain('Network error talking to the model provider');
+    });
+
     it('falls back to the generic op-id template for unknown error codes without attribution', () => {
       expect(renderAgentError('SomeNewErrorCode', undefined, 'op-1')).toBe(
         '**Agent Execution Failed**\nOperation ID: `op-1`',
@@ -458,10 +521,10 @@ describe('replyTemplate', () => {
     });
 
     it('falls back by attribution when the exact code is unknown', () => {
-      // network/system → transient network copy
-      expect(
-        renderAgentError('SomeNewNetworkCode', undefined, 'op-1', 'en-US', 'system'),
-      ).toContain('Network error talking to the model provider');
+      // system → provider-neutral infra copy (must not blame the model provider)
+      expect(renderAgentError('SomeNewInfraCode', undefined, 'op-1', 'en-US', 'system')).toContain(
+        'temporary system error',
+      );
       // provider → temporarily-unavailable copy
       expect(renderAgentError('SomeNewCode', undefined, 'op-1', 'en-US', 'provider')).toContain(
         'temporarily unavailable',

--- a/apps/server/src/services/bot/replyTemplate.ts
+++ b/apps/server/src/services/bot/replyTemplate.ts
@@ -247,6 +247,7 @@ type SystemStrings = {
   errorProviderUnavailable: string;
   errorQuotaLimitReached: string;
   errorRateLimited: string;
+  errorSystemInfra: string;
   errorTimeout: string;
   errorTransientNetwork: string;
   errorUserGeneric: string;
@@ -323,6 +324,8 @@ const SYSTEM_STRINGS: Partial<Record<BotReplyLocale, SystemStrings>> = {
       "**Provider quota exhausted.**\nThe configured model provider is out of quota or rate-limited. Please wait a moment and try again, top up the account, or switch to a different provider in the agent's settings.",
     errorRateLimited:
       "**Too many requests.**\nThe model provider is rate-limiting requests right now. Please wait a moment before trying again, or switch to a different model in the agent's settings.",
+    errorSystemInfra:
+      '**A temporary system error occurred.**\nThe request hit a transient infrastructure issue on our side and could not be completed. Please try again in a moment.',
     errorTimeout:
       '**The agent run timed out.**\nThe operation ran too long without progress and was stopped. Please try again; if the task is large, try breaking it into smaller steps.',
     errorTransientNetwork:
@@ -396,6 +399,8 @@ const SYSTEM_STRINGS: Partial<Record<BotReplyLocale, SystemStrings>> = {
       '**Provider 配额已用尽**\n所配置的模型 Provider 已达到配额上限或被限流。请稍后重试、为账户充值，或在 Agent 设置中切换到其他 Provider。',
     errorRateLimited:
       '**请求过于频繁**\n模型 Provider 正在限流。请稍后再试，或在 Agent 设置中切换到其他模型。',
+    errorSystemInfra:
+      '**发生了临时系统错误**\n由于我们这边的临时基础设施问题，本次请求未能完成。请稍后重试。',
     errorTimeout:
       '**Agent 执行超时**\n操作长时间无进展，已被中止。请重试；如果任务较大，可尝试拆分成更小的步骤。',
     errorTransientNetwork:
@@ -455,6 +460,9 @@ const FRIENDLY_ERROR_BY_TYPE: Record<string, keyof SystemStrings> = {
   ProviderServiceUnavailable: 'errorProviderUnavailable',
   RateLimitExceeded: 'errorRateLimited',
   // ── network / infra (attribution: system) ──
+  // ProviderNetworkError is the one system-attributed code that *is* about the
+  // model provider, so it keeps the provider-specific "switch model" copy. Other
+  // system codes (state-store reads) hit the provider-neutral `system` fallback.
   ProviderNetworkError: 'errorTransientNetwork',
   // ── harness watchdog: harness-owned but retry-friendly, so it gets its
   //    own retry-oriented copy rather than the generic internal-error tier ──
@@ -471,7 +479,11 @@ const FRIENDLY_ERROR_BY_TYPE: Record<string, keyof SystemStrings> = {
 const FALLBACK_ERROR_BY_ATTRIBUTION: Record<string, keyof SystemStrings> = {
   harness: 'errorHarnessInternal',
   provider: 'errorProviderUnavailable',
-  system: 'errorTransientNetwork',
+  // Provider-neutral: `system` covers infra failures (state-store reads, etc.)
+  // where the LLM provider/model is not involved, so the copy must NOT blame the
+  // provider or suggest switching models. ProviderNetworkError, the one
+  // provider-related system code, is mapped precisely above.
+  system: 'errorSystemInfra',
   user: 'errorUserGeneric',
 };
 
@@ -483,11 +495,23 @@ const FALLBACK_ERROR_BY_ATTRIBUTION: Record<string, keyof SystemStrings> = {
 const appendOperationId = (value: string, operationId: string | undefined): string =>
   operationId ? `${value}\nOperation ID: \`${operationId}\`` : value;
 
+// `command aborted due to connection close` reaches us under a few stable
+// codes: the raw `500` fallback, or — once `formatErrorForState` pattern-refines
+// the Upstash/ioredis disconnect — `StateStorePersistError` (write path) /
+// `StateStoreReadError` (blocking-read path). The message stays the precise
+// signal; the type gate just has to let these through so the specific
+// "command session disconnected" guidance still wins over the generic tiers.
+const COMMAND_CONNECTION_CLOSED_TYPES = new Set([
+  '500',
+  'StateStorePersistError',
+  'StateStoreReadError',
+]);
+
 const isCommandConnectionClosedError = (
   errorType: string | undefined,
   errorMessage: string | undefined,
 ) => {
-  if (errorType && errorType !== '500') return false;
+  if (errorType && !COMMAND_CONNECTION_CLOSED_TYPES.has(errorType)) return false;
   if (!errorMessage) return false;
 
   return /command aborted due to connection close/i.test(errorMessage);

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx
@@ -5,7 +5,7 @@ import {
   isRemoteHeterogeneousType,
 } from '@lobechat/heterogeneous-agents';
 import { Alert, Button, Flexbox } from '@lobehub/ui';
-import { memo } from 'react';
+import { memo, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
 import urlJoin from 'url-join';
@@ -29,6 +29,36 @@ import HeteroControlBar from './HeteroControlBar';
 // can still toggle the rich-text formatting bar.
 const leftActions: ActionKeys[] = ['typo'];
 const rightActions: ActionKeys[] = [];
+
+/**
+ * GuardBanner
+ *
+ * A deliberately thin, single-line warning that sits just above the input. We
+ * fold the headline and the hint onto one line (no separate `description`
+ * block, no oversized 24px icon) so the guard stays a compact strip instead of
+ * eating a chunk of the conversation area.
+ */
+const GuardBanner = memo<{ action: ReactNode; hint?: string; title: string }>(
+  ({ title, hint, action }) => (
+    <WideScreenContainer>
+      <Flexbox align={'center'} paddingBlock={'0 8px'} paddingInline={12}>
+        <Alert
+          action={action}
+          style={{ maxWidth: 880, width: '100%' }}
+          type={'warning'}
+          title={
+            <Flexbox horizontal align={'baseline'} gap={6} style={{ flexWrap: 'wrap' }}>
+              <span>{title}</span>
+              {hint && <span style={{ fontWeight: 400, opacity: 0.75 }}>{hint}</span>}
+            </Flexbox>
+          }
+        />
+      </Flexbox>
+    </WideScreenContainer>
+  ),
+);
+
+GuardBanner.displayName = 'GuardBanner';
 
 /**
  * HeterogeneousChatInput
@@ -100,26 +130,20 @@ const HeterogeneousChatInput = memo(() => {
     }
 
     return (
-      <WideScreenContainer>
-        <Flexbox align={'center'} paddingBlock={'0 8px'} paddingInline={12}>
-          <Alert
-            description={desc}
-            style={{ maxWidth: 880, width: '100%' }}
-            title={title}
-            type={'warning'}
-            action={
-              <Flexbox horizontal gap={6}>
-                <Button size={'small'} onClick={refresh}>
-                  {t('platformAgent.deviceGuard.refresh')}
-                </Button>
-                <Button size={'small'} type={'primary'} onClick={goToAgentProfile}>
-                  {t('platformAgent.deviceGuard.configure')}
-                </Button>
-              </Flexbox>
-            }
-          />
-        </Flexbox>
-      </WideScreenContainer>
+      <GuardBanner
+        hint={desc}
+        title={title}
+        action={
+          <Flexbox horizontal gap={4}>
+            <Button size={'small'} variant={'filled'} onClick={refresh}>
+              {t('platformAgent.deviceGuard.refresh')}
+            </Button>
+            <Button size={'small'} type={'primary'} onClick={goToAgentProfile}>
+              {t('platformAgent.deviceGuard.configure')}
+            </Button>
+          </Flexbox>
+        }
+      />
     );
   };
 
@@ -127,21 +151,15 @@ const HeterogeneousChatInput = memo(() => {
     if (isDeviceExecution || isConfigured) return null;
 
     return (
-      <WideScreenContainer>
-        <Flexbox align={'center'} paddingBlock={'0 8px'} paddingInline={12}>
-          <Alert
-            description={t('heteroAgent.cloudNotConfigured.desc')}
-            style={{ maxWidth: 880, width: '100%' }}
-            title={t('heteroAgent.cloudNotConfigured.title')}
-            type={'warning'}
-            action={
-              <Button size={'small'} type={'primary'} onClick={goToConfig}>
-                {t('heteroAgent.cloudNotConfigured.action')}
-              </Button>
-            }
-          />
-        </Flexbox>
-      </WideScreenContainer>
+      <GuardBanner
+        hint={t('heteroAgent.cloudNotConfigured.desc')}
+        title={t('heteroAgent.cloudNotConfigured.title')}
+        action={
+          <Button size={'small'} type={'primary'} onClick={goToConfig}>
+            {t('heteroAgent.cloudNotConfigured.action')}
+          </Button>
+        }
+      />
     );
   };
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up to #16120 (Related to LOBE-10612) — review-flagged regressions in the IM agent-failure error rendering.

#### 🔀 Description of Change

#16120 made `buildLifecycleEvent` always populate `event.errorType`. That exposed two issues for state-store (Upstash/ioredis) failures, both fixed here:

**1. Command-disconnect guidance was lost for refined errors.**
`formatErrorForState` pattern-refines `Command aborted due to connection close` into `StateStorePersistError` (write path) / `StateStoreReadError` (read path) — see `packages/model-runtime/src/errors/patterns.ts`. `renderAgentError`'s command-disconnect special case only accepted an `undefined`/`500` type, so once a real code was present it was skipped, and users got the generic internal-error copy instead of the specific *"Command session disconnected"* guidance. Fix: widen the type gate to also accept the refined state-store codes, keeping the message (`/command aborted due to connection close/i`) as the precise signal.

**2. System fallback gave provider-specific advice for non-provider failures.**
The `system` attribution fallback rendered `errorTransientNetwork`, whose copy says *"the connection to the model provider timed out … switch to a different model"*. For system-attributed infra failures like `StateStoreReadError` (Redis/Upstash state reads, `specs.ts`), the provider/model isn't involved, so that advice is misleading. Fix: add a provider-neutral `errorSystemInfra` string (en-US + zh-CN) and point the `system` fallback at it. `ProviderNetworkError` — the one system-attributed code that *is* about the model provider — keeps its precise network copy.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`replyTemplate.test.ts` (77 passed) adds:
- command-disconnect copy survives `StateStorePersistError` / `StateStoreReadError` refinement;
- `system` infra errors render provider-neutral copy (asserts it does NOT mention "model provider" or "switch to a different model");
- `ProviderNetworkError` still gets the provider-specific network copy (regression guard);
- updated the existing attribution-fallback test for the new neutral `system` copy.

Touched files type-check clean (the standalone `type-check` surfaces pre-existing `model-runtime` openai-SDK `Headers` errors unrelated to this change).

#### 📝 Additional Information

The bot system strings are a self-contained en/zh dictionary (not react-i18next namespaces), so both locales are hand-written here; no `pnpm i18n` needed.