### PR TITLE
💄 feat(linear): render builtin Linear tool cards and drop the Result label

### DIFF
--- a/packages/builtin-tools/src/linear/index.ts
+++ b/packages/builtin-tools/src/linear/index.ts
@@ -1,12 +1,17 @@
 import { LINEAR_TOOL_NAMES, LinearInspector } from '@lobechat/shared-tool-ui/inspectors';
-import type { BuiltinInspector } from '@lobechat/types';
+import { LinearRender } from '@lobechat/shared-tool-ui/renders';
+import type { BuiltinInspector, BuiltinRender } from '@lobechat/types';
 
 // LobeHub built-in Linear skill: tool calls arrive with
 // `identifier='linear'` and bare `apiName` like 'get_issue'. The shared
-// inspector tolerates both bare and MCP-prefixed names, so we just register
-// it under every supported tool suffix.
+// inspector / render tolerate both bare and MCP-prefixed names, so we just
+// register them under every supported tool suffix.
 export const LinearIdentifier = 'linear';
 
 export const LinearInspectors: Record<string, BuiltinInspector> = Object.fromEntries(
   LINEAR_TOOL_NAMES.map((name) => [name, LinearInspector]),
+);
+
+export const LinearRenders: Record<string, BuiltinRender> = Object.fromEntries(
+  LINEAR_TOOL_NAMES.map((name) => [name, LinearRender as BuiltinRender]),
 );

--- a/packages/builtin-tools/src/register.ts
+++ b/packages/builtin-tools/src/register.ts
@@ -152,7 +152,7 @@ import { CodexInspectors, CodexRenders } from './codex';
 import { GithubIdentifier, GithubInspectors, GithubRenders } from './github';
 import { registerBuiltinInspectors } from './inspectors';
 import { registerBuiltinInterventions } from './interventions';
-import { LinearIdentifier, LinearInspectors } from './linear';
+import { LinearIdentifier, LinearInspectors, LinearRenders } from './linear';
 import { NotebookIdentifier, NotebookRenders } from './notebook';
 import { registerBuiltinPlaceholders } from './placeholders';
 import { registerBuiltinPortals } from './portals';
@@ -199,6 +199,7 @@ export const registerBuiltinToolSurfaces = (): void => {
       command_execution: RunCommandRender as BuiltinRender,
     },
     [GithubIdentifier]: GithubRenders,
+    [LinearIdentifier]: LinearRenders,
   });
 
   registerBuiltinInspectors({

--- a/packages/shared-tool-ui/src/Render/Linear/index.tsx
+++ b/packages/shared-tool-ui/src/Render/Linear/index.tsx
@@ -247,29 +247,25 @@ const LinearRender = memo<BuiltinRenderProps<Record<string, unknown>, unknown, u
     return (
       <Flexbox className={styles.container} gap={12}>
         {hasItems(model.resultEntities) && (
-          <Section title={'Result'}>
-            <Flexbox gap={8}>
-              {model.resultEntities.map((entity, index) => (
-                <EntityCard
-                  entity={entity}
-                  key={`${entity.id || entity.title || 'entity'}:${index}`}
-                />
-              ))}
-            </Flexbox>
-          </Section>
+          <Flexbox gap={8}>
+            {model.resultEntities.map((entity, index) => (
+              <EntityCard
+                entity={entity}
+                key={`${entity.id || entity.title || 'entity'}:${index}`}
+              />
+            ))}
+          </Flexbox>
         )}
         {model.resultText && (
-          <Section title={'Result'}>
-            <Highlighter
-              wrap
-              language={'text'}
-              showLanguage={false}
-              style={{ maxHeight: 220, overflow: 'auto', paddingInline: 8 }}
-              variant={'filled'}
-            >
-              {model.resultText}
-            </Highlighter>
-          </Section>
+          <Highlighter
+            wrap
+            language={'text'}
+            showLanguage={false}
+            style={{ maxHeight: 220, overflow: 'auto', paddingInline: 8 }}
+            variant={'filled'}
+          >
+            {model.resultText}
+          </Highlighter>
         )}
         {model.rawResultJson && (
           <details className={styles.rawDetails}>


### PR DESCRIPTION
## 💻 变更类型 | Change Type

- [x] 💄 style (UI / 渲染体验)
- [x] ✨ feat (接通内置 Linear 渲染)

## 🔀 变更说明 | Description of Change

Two small render improvements for Linear tool calls:

1. **Wire up the builtin Linear render.** The `linear` builtin identifier previously only registered an *inspector* in `register.ts` — no render. So native LobeHub Linear tool calls (`identifier='linear'`, bare `apiName` like `get_issue`) never rendered the entity card; only the heterogeneous CC/codex path got it (via `McpToolRender → SharedLinearRender`). This adds a `LinearRenders` map (every `LINEAR_TOOL_NAMES` → the shared `LinearRender`, mirroring how GitHub is wired) and registers it under `LinearIdentifier`, so the native path renders the same card.

2. **Drop the redundant "Result" label.** The entity card (title / id / Team / Project / Priority / dates) and the plain result text are self-explanatory, so the `Section title="Result"` wrapper above them was noise. Removed it; the `Error` and `Raw result` labels stay (they still need the semantic hint).

## 📝 补充信息 | Additional Information

- `bun run type-check`: no errors in the changed files (remaining output is pre-existing antd version-duplication noise in unrelated files).
- Linear render tests: 8/8 passing (they assert the data model, not the "Result" string).

## 📌 How to Test

1. Trigger a Linear builtin tool call (e.g. `get_issue`) from a native LobeHub agent and confirm the entity card now renders.
2. Confirm the "Result" label no longer appears above Linear cards / result text on both the native and the heterogeneous (CC/codex) paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)