### PR TITLE
✨ feat(chat): add Manage button to execution device switcher

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -246,6 +246,7 @@
   "heteroAgent.executionTarget.loading": "Loading devices…",
   "heteroAgent.executionTarget.local": "This device",
   "heteroAgent.executionTarget.localDesc": "Run as a local process on this desktop app",
+  "heteroAgent.executionTarget.manage": "Manage",
   "heteroAgent.executionTarget.noDevices": "No remote devices yet. Run `lh connect` on another machine to add one.",
   "heteroAgent.executionTarget.none": "No device",
   "heteroAgent.executionTarget.noneDesc": "No device enabled",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -246,6 +246,7 @@
   "heteroAgent.executionTarget.loading": "正在加载设备…",
   "heteroAgent.executionTarget.local": "本机",
   "heteroAgent.executionTarget.localDesc": "在当前桌面端以本地进程运行",
+  "heteroAgent.executionTarget.manage": "管理",
   "heteroAgent.executionTarget.noDevices": "暂无远程设备。在另一台机器上执行 `lh connect` 即可接入。",
   "heteroAgent.executionTarget.none": "无设备",
   "heteroAgent.executionTarget.noneDesc": "不启用任何设备",

--- a/packages/builtin-tools/src/linear/index.ts
+++ b/packages/builtin-tools/src/linear/index.ts
@@ -1,12 +1,17 @@
 import { LINEAR_TOOL_NAMES, LinearInspector } from '@lobechat/shared-tool-ui/inspectors';
-import type { BuiltinInspector } from '@lobechat/types';
+import { LinearRender } from '@lobechat/shared-tool-ui/renders';
+import type { BuiltinInspector, BuiltinRender } from '@lobechat/types';
 
 // LobeHub built-in Linear skill: tool calls arrive with
 // `identifier='linear'` and bare `apiName` like 'get_issue'. The shared
-// inspector tolerates both bare and MCP-prefixed names, so we just register
-// it under every supported tool suffix.
+// inspector / render tolerate both bare and MCP-prefixed names, so we just
+// register them under every supported tool suffix.
 export const LinearIdentifier = 'linear';
 
 export const LinearInspectors: Record<string, BuiltinInspector> = Object.fromEntries(
   LINEAR_TOOL_NAMES.map((name) => [name, LinearInspector]),
+);
+
+export const LinearRenders: Record<string, BuiltinRender> = Object.fromEntries(
+  LINEAR_TOOL_NAMES.map((name) => [name, LinearRender as BuiltinRender]),
 );

--- a/packages/builtin-tools/src/register.ts
+++ b/packages/builtin-tools/src/register.ts
@@ -152,7 +152,7 @@ import { CodexInspectors, CodexRenders } from './codex';
 import { GithubIdentifier, GithubInspectors, GithubRenders } from './github';
 import { registerBuiltinInspectors } from './inspectors';
 import { registerBuiltinInterventions } from './interventions';
-import { LinearIdentifier, LinearInspectors } from './linear';
+import { LinearIdentifier, LinearInspectors, LinearRenders } from './linear';
 import { NotebookIdentifier, NotebookRenders } from './notebook';
 import { registerBuiltinPlaceholders } from './placeholders';
 import { registerBuiltinPortals } from './portals';
@@ -199,6 +199,7 @@ export const registerBuiltinToolSurfaces = (): void => {
       command_execution: RunCommandRender as BuiltinRender,
     },
     [GithubIdentifier]: GithubRenders,
+    [LinearIdentifier]: LinearRenders,
   });
 
   registerBuiltinInspectors({

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -197,6 +197,7 @@ export default {
   'heteroAgent.executionTarget.loading': 'Loading devices…',
   'heteroAgent.executionTarget.local': 'This device',
   'heteroAgent.executionTarget.localDesc': 'Run as a local process on this desktop app',
+  'heteroAgent.executionTarget.manage': 'Manage',
   'heteroAgent.executionTarget.noDevices':
     'No remote devices yet. Run `lh connect` on another machine to add one.',
   'heteroAgent.executionTarget.none': 'No device',

--- a/packages/shared-tool-ui/src/Render/Linear/index.tsx
+++ b/packages/shared-tool-ui/src/Render/Linear/index.tsx
@@ -247,29 +247,25 @@ const LinearRender = memo<BuiltinRenderProps<Record<string, unknown>, unknown, u
     return (
       <Flexbox className={styles.container} gap={12}>
         {hasItems(model.resultEntities) && (
-          <Section title={'Result'}>
-            <Flexbox gap={8}>
-              {model.resultEntities.map((entity, index) => (
-                <EntityCard
-                  entity={entity}
-                  key={`${entity.id || entity.title || 'entity'}:${index}`}
-                />
-              ))}
-            </Flexbox>
-          </Section>
+          <Flexbox gap={8}>
+            {model.resultEntities.map((entity, index) => (
+              <EntityCard
+                entity={entity}
+                key={`${entity.id || entity.title || 'entity'}:${index}`}
+              />
+            ))}
+          </Flexbox>
         )}
         {model.resultText && (
-          <Section title={'Result'}>
-            <Highlighter
-              wrap
-              language={'text'}
-              showLanguage={false}
-              style={{ maxHeight: 220, overflow: 'auto', paddingInline: 8 }}
-              variant={'filled'}
-            >
-              {model.resultText}
-            </Highlighter>
-          </Section>
+          <Highlighter
+            wrap
+            language={'text'}
+            showLanguage={false}
+            style={{ maxHeight: 220, overflow: 'auto', paddingInline: 8 }}
+            variant={'filled'}
+          >
+            {model.resultText}
+          </Highlighter>
         )}
         {model.rawResultJson && (
           <details className={styles.rawDetails}>

--- a/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
@@ -17,11 +17,13 @@ import {
   MonitorDownIcon,
   MonitorIcon,
   MonitorOffIcon,
+  SettingsIcon,
   SparklesIcon,
 } from 'lucide-react';
 import { memo, type ReactNode, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
 import { lambdaQuery } from '@/libs/trpc/client';
 import { gatewayConnectionService } from '@/services/electron/gatewayConnection';
@@ -232,6 +234,27 @@ const styles = createStaticStyles(({ css }) => ({
     font-weight: 500;
     color: ${cssVar.colorTextTertiary};
   `,
+  manageButton: css`
+    cursor: pointer;
+
+    display: flex;
+    gap: 3px;
+    align-items: center;
+
+    padding: 0;
+    border: none;
+
+    font-size: 11px;
+    color: ${cssVar.colorTextQuaternary};
+
+    background: none;
+
+    transition: color 0.2s;
+
+    &:hover {
+      color: ${cssVar.colorPrimary};
+    }
+  `,
 }));
 
 interface OptionRowProps {
@@ -295,6 +318,7 @@ interface HeteroDeviceSwitcherProps {
 const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
   const { t } = useTranslation('chat');
   const [open, setOpen] = useState(false);
+  const navigate = useWorkspaceAwareNavigate();
 
   const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));
   const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
@@ -437,7 +461,19 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
             </span>
           </Tooltip>
         </Flexbox>
-        {isDesktop || showWebDownloadCard ? null : (
+        {isDesktop || showWebDownloadCard ? (
+          <button
+            className={styles.manageButton}
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              navigate('/settings/devices');
+            }}
+          >
+            <Icon icon={SettingsIcon} size={11} />
+            <span>{t('heteroAgent.executionTarget.manage')}</span>
+          </button>
+        ) : (
           <a
             className={styles.headerLink}
             href="https://lobehub.com/downloads"


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

The execution-device dropdown (`HeteroDeviceSwitcher`) header had an empty slot on the right side on desktop, since the existing download link there is web-only.

This PR fills that slot with a **Manage** button that navigates to the device settings page (`/settings/devices`) and closes the popover.

- Shown on desktop, and on web when there are no devices (where the small download link isn't rendered).
- On web *with* devices, the existing "Get Desktop App" link is unchanged.
- Navigation uses `useWorkspaceAwareNavigate`; `devices` is a personal-only settings tab so the path is not workspace-prefixed.
- Added i18n key `heteroAgent.executionTarget.manage` (en-US "Manage" / zh-CN "管理"); other locales handled by the daily auto-i18n CI job.

#### 🧪 How to Test

- [x] Tested locally

1. Open an agent chat, click the execution-device switcher in the control bar.
2. On desktop, confirm a "Manage" button appears in the top-right of the dropdown header.
3. Click it → popover closes and routes to Settings → Devices.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Empty top-right slot | "Manage" button → `/settings/devices` |