### PR TITLE
⚡️ perf: dedupe message:list switch-back revalidate with a 30s window

### DIFF
--- a/src/store/chat/slices/message/actions/query.ts
+++ b/src/store/chat/slices/message/actions/query.ts
@@ -19,6 +19,24 @@ import { reconcileAssistantToolLinks } from '../utils/reconcileTools';
  * Handles fetching, refreshing, and replacing message data
  */
 
+/**
+ * Dedupe window for the `message:list` switch-back revalidate.
+ *
+ * The Conversation store is recreated on every topic/session switch, which
+ * remounts `useFetchMessages`. At the `useClientDataSWR` default
+ * (`dedupingInterval: 0`) that fires a network revalidate on every single
+ * switch. Message mutations now write through to this cache (see
+ * `replaceMessages` → `#writeThroughMessageCache`), so a switch-back within
+ * this window hydrates from a FRESH cache and the refetch is pure redundancy.
+ *
+ * 30s covers the typical "switch away, glance at another conversation, switch
+ * back" loop while keeping cross-device / server-agent updates within an
+ * acceptable staleness bound — `revalidateOnFocus` (5min throttle) and
+ * `revalidateOnReconnect` remain the longer-tail backstop, and a running
+ * conversation keeps its live gateway stream regardless of this window.
+ */
+const MESSAGE_LIST_DEDUPING_INTERVAL = 30 * 1000;
+
 type Setter = StoreSetter<ChatStore>;
 export const messageQuery = (set: Setter, get: () => ChatStore, _api?: unknown) =>
   new MessageQueryActionImpl(set, get, _api);
@@ -199,6 +217,10 @@ export class MessageQueryActionImpl {
       shouldFetch ? messageKeys.list(context) : null,
       () => messageService.getMessages(context),
       {
+        // Skip the redundant switch-back refetch within this window — the cache
+        // is kept current by mutation write-through, so a remount hydrates from
+        // a fresh cache instead of forcing a network revalidate every switch.
+        dedupingInterval: MESSAGE_LIST_DEDUPING_INTERVAL,
         onData: (data) => {
           if (!data || !context.topicId) return;
 


### PR DESCRIPTION
> Follow-up to #15927 (already merged to `canary`). That PR made message mutations write through to the `message:list` cache; this PR cashes in that guarantee to stop the redundant switch-back refetch.

#### 💻 Change Type

- [x] ⚡️ perf

#### 🔀 Description of Change

`useFetchMessages` runs through `useClientDataSWR`, whose default is **`dedupingInterval: 0`**. The Conversation store is keyed by `contextKey` and recreated on every topic/session switch, so the hook remounts and — at interval `0` — fires a network revalidate on **every single switch**. That is the `正在获取最新消息…` ("fetching latest messages") flash on switch-back.

#15927 made message mutations (send / stream / edit / delete) write through to this exact cache, so a switch-back now hydrates from a **fresh** cache and the on-mount refetch is pure redundancy. This PR adds a dedupe window to skip it:

```ts
dedupingInterval: MESSAGE_LIST_DEDUPING_INTERVAL, // 30 * 1000
```

**Why 30s** — a deliberate balance:

- **Not `2000`** (SWR's usual default): a "switch away, glance at another conversation, switch back" loop easily exceeds 2s, so the flash would still fire.
- **Not `5 * 60 * 1000`** (`focusThrottleInterval`): `message:list` is not purely local — server-side agents, sub-agent callbacks, and **other devices** mutate the backend without touching this client's write-through, so too long a window delays picking those up.
- **30s** covers the typical switch-back loop while keeping cross-device / async-agent staleness bounded. Backstops stay intact: `revalidateOnFocus` (5min throttle) and `revalidateOnReconnect` still force a refresh on the longer tail, and a **running** conversation keeps its live gateway stream regardless of this window.

#### 🧪 How to Test

- [x] `type-check`: clean
- Verified end-to-end on Electron against the live backend: with #15927's write-through in place, local mutations (edit / delete / streaming-complete) write through to the IndexedDB cache tier, so the 30s window never serves stale local state on switch-back; switching away and back to a recently-viewed conversation no longer triggers a background revalidate.

No new unit test: this is a single SWR config constant whose effect (switch-back dedupe) is SWR-guaranteed behavior, not new branching logic — the cache-correctness it relies on is covered by #15927's `action.test.ts` suite.

#### 📝 Additional Information

Completes the follow-up called out in #15927's description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)