### PR TITLE
🐛 fix(store): prevent crash from unsafe non-null assertion on topic maps

### DIFF
--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -668,7 +668,7 @@ export class ChatTopicActionImpl {
         {
           agentTopicsViewMap: {
             ...this.#get().agentTopicsViewMap,
-            [key]: { ...this.#get().agentTopicsViewMap[key]!, isLoadingMore: false },
+            [key]: { ...(this.#get().agentTopicsViewMap[key] || {}), isLoadingMore: false } as any,
           },
         },
         false,
@@ -755,7 +755,7 @@ export class ChatTopicActionImpl {
         {
           topicDataMap: {
             ...this.#get().topicDataMap,
-            [key]: { ...this.#get().topicDataMap[key]!, isLoadingMore: false },
+            [key]: { ...(this.#get().topicDataMap[key] || {}), isLoadingMore: false } as any,
           },
         },
         false,


### PR DESCRIPTION
## Description

Replaces unsafe \!\ assertions on \gentTopicsViewMap[key]\ and \	opicDataMap[key]\ with a safe fallback \|| {}\. This ensures that if the state lacks a specific key when a network error occurs during \loadMore\, spreading the undefined object won't throw a runtime crash.