### PR TITLE
♻️ refactor(eval): replace unsafe "catch (error: any)" with safe Error cast

### DIFF
--- a/src/routes/(main)/eval/bench/[benchmarkId]/features/RunsTab/RunCard.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/features/RunsTab/RunCard.tsx
@@ -215,8 +215,8 @@ const RunCard = memo<RunCardProps>(({ benchmarkId, run, onRefresh, onEdit }) => 
         try {
           await startRun(run.id, run.status !== 'idle');
           await onRefresh?.();
-        } catch (error: any) {
-          toast.error(error?.message || 'Failed to start run');
+        } catch (error) {
+          toast.error((error as Error)?.message || 'Failed to start run');
         }
       },
       title: t('run.actions.start'),

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/IdleState/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/IdleState/index.tsx
@@ -117,8 +117,8 @@ const IdleState = memo<IdleStateProps>(({ run }) => {
         try {
           setStarting(true);
           await startRun(run.id, run.status !== 'idle');
-        } catch (error: any) {
-          toast.error(error?.message || 'Failed to start run');
+        } catch (error) {
+          toast.error((error as Error)?.message || 'Failed to start run');
         } finally {
           setStarting(false);
         }

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/RunHeader/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/RunHeader/index.tsx
@@ -228,8 +228,8 @@ const RunHeader = memo<RunHeaderProps>(({ run, benchmarkId, hideStart }) => {
         try {
           setStarting(true);
           await startRun(run.id, run.status !== 'idle');
-        } catch (error: any) {
-          toast.error(error?.message || 'Failed to start run');
+        } catch (error) {
+          toast.error((error as Error)?.message || 'Failed to start run');
         } finally {
           setStarting(false);
         }

--- a/src/routes/(main)/eval/features/DatasetCreateModal/Content.tsx
+++ b/src/routes/(main)/eval/features/DatasetCreateModal/Content.tsx
@@ -154,8 +154,8 @@ const DatasetCreateContent: FC<DatasetCreateContentProps> = ({
         name: result.name,
         preset: selectedPreset,
       });
-    } catch (error: any) {
-      toast.error(error?.message || t('dataset.create.error'));
+    } catch (error) {
+      toast.error((error as Error)?.message || t('dataset.create.error'));
     } finally {
       onLoadingChange?.(false);
     }


### PR DESCRIPTION
## Description

Replaces "catch (error: any)" with standard "catch (error)" across the eval route components. To safely extract the error message for toast notifications, the unknown error is safely cast as "(error as Error)?.message", eliminating the unsafe "any" typing.