### PR TITLE
♻️ refactor(community): remove unsafe "catch (error: any)" in fork actions

### DIFF
--- a/src/routes/(main)/community/(detail)/group_agent/features/Sidebar/ActionButton/ForkGroupAndChat.tsx
+++ b/src/routes/(main)/community/(detail)/group_agent/features/Sidebar/ActionButton/ForkGroupAndChat.tsx
@@ -264,7 +264,7 @@ const ForkGroupAndChat = memo<{ mobile?: boolean }>(() => {
 
       // Step 8: Navigate to chat
       navigate(urlJoin('/group', result.groupId));
-    } catch (error: any) {
+    } catch (error) {
       console.error('Fork group failed:', error);
       toast.error(t('fork.failed'));
     } finally {


### PR DESCRIPTION
## Description

Replaces "catch (error: any)" with standard "catch (error)" in the community route's fork action handlers. console.error safely accepts unknown errors, so bypassing TypeScript's safety with "any" is unnecessary.