### PR TITLE
🐛 fix: keep legacy Klavis endpoint and route gpt-5-mini

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/klavis.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/klavis.test.ts
@@ -1,0 +1,14 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import type { AuthContext } from '@/libs/trpc/lambda/context';
+
+import { lambdaRouter } from '../index';
+
+describe('lambdaRouter klavis compatibility', () => {
+  it('keeps the legacy getKlavisPlugins path as a noop', async () => {
+    const caller = lambdaRouter.createCaller({ userId: 'user-1' } satisfies AuthContext);
+
+    await expect(caller.klavis.getKlavisPlugins()).resolves.toEqual([]);
+  });
+});

--- a/apps/server/src/routers/lambda/__tests__/klavis.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/klavis.test.ts
@@ -6,8 +6,8 @@ import type { AuthContext } from '@/libs/trpc/lambda/context';
 import { lambdaRouter } from '../index';
 
 describe('lambdaRouter klavis compatibility', () => {
-  it('keeps the legacy getKlavisPlugins path as a noop', async () => {
-    const caller = lambdaRouter.createCaller({ userId: 'user-1' } satisfies AuthContext);
+  it('keeps the legacy getKlavisPlugins path as an unauthenticated noop', async () => {
+    const caller = lambdaRouter.createCaller({ userId: null } satisfies AuthContext);
 
     await expect(caller.klavis.getKlavisPlugins()).resolves.toEqual([]);
   });

--- a/apps/server/src/routers/lambda/index.ts
+++ b/apps/server/src/routers/lambda/index.ts
@@ -52,6 +52,7 @@ import { generationTopicRouter } from './generationTopic';
 import { homeRouter } from './home';
 import { imageRouter } from './image';
 import { importerRouter } from './importer';
+import { klavisRouter } from './klavis';
 import { knowledgeRouter } from './knowledge';
 import { knowledgeBaseRouter } from './knowledgeBase';
 import { llmGenerationTracingRouter } from './llmGenerationTracing';
@@ -119,6 +120,7 @@ export const lambdaRouter = router({
   importer: importerRouter,
   composio: composioRouter,
 
+  klavis: klavisRouter,
   knowledge: knowledgeRouter,
   knowledgeBase: knowledgeBaseRouter,
   llmGenerationTracing: llmGenerationTracingRouter,

--- a/apps/server/src/routers/lambda/klavis.ts
+++ b/apps/server/src/routers/lambda/klavis.ts
@@ -1,0 +1,10 @@
+import { authedProcedure, router } from '@/libs/trpc/lambda';
+
+export const klavisRouter = router({
+  /**
+   * Legacy compatibility for clients released before the Klavis to Composio migration.
+   */
+  getKlavisPlugins: authedProcedure.query(() => []),
+});
+
+export type KlavisRouter = typeof klavisRouter;

--- a/apps/server/src/routers/lambda/klavis.ts
+++ b/apps/server/src/routers/lambda/klavis.ts
@@ -1,10 +1,10 @@
-import { authedProcedure, router } from '@/libs/trpc/lambda';
+import { publicProcedure, router } from '@/libs/trpc/lambda';
 
 export const klavisRouter = router({
   /**
    * Legacy compatibility for clients released before the Klavis to Composio migration.
    */
-  getKlavisPlugins: authedProcedure.query(() => []),
+  getKlavisPlugins: publicProcedure.query(() => []),
 });
 
 export type KlavisRouter = typeof klavisRouter;

--- a/packages/model-runtime/src/providers/openai/openaiModelId.test.ts
+++ b/packages/model-runtime/src/providers/openai/openaiModelId.test.ts
@@ -63,7 +63,6 @@ describe('parseOpenAIModelId', () => {
 describe('isGPT5ResponsesModel', () => {
   it('should preserve current base GPT-5 chat-completions models', () => {
     expect(isGPT5ResponsesModel('gpt-5')).toBe(false);
-    expect(isGPT5ResponsesModel('gpt-5-mini')).toBe(false);
     expect(isGPT5ResponsesModel('gpt-5-chat-latest')).toBe(false);
     expect(isGPT5ResponsesModel('gpt-5.2-chat-latest')).toBe(false);
     expect(isGPT5ResponsesModel('gpt-5.3-chat-latest')).toBe(false);
@@ -71,6 +70,9 @@ describe('isGPT5ResponsesModel', () => {
   });
 
   it('should match existing GPT-5 Responses models', () => {
+    expect(isGPT5ResponsesModel('gpt-5-mini')).toBe(true);
+    expect(isGPT5ResponsesModel('gpt-5-mini-2025-08-07')).toBe(true);
+    expect(isGPT5ResponsesModel('gpt-5-foo-mini')).toBe(false);
     expect(isGPT5ResponsesModel('gpt-5-pro')).toBe(true);
     expect(isGPT5ResponsesModel('gpt-5-pro-2025-10-06')).toBe(true);
     expect(isGPT5ResponsesModel('gpt-5.1-codex-mini')).toBe(true);

--- a/packages/model-runtime/src/providers/openai/openaiModelId.ts
+++ b/packages/model-runtime/src/providers/openai/openaiModelId.ts
@@ -124,12 +124,15 @@ const isNativeGPT5Model = (model: string): ParsedOpenAIModelId | undefined => {
 const hasModifier = (parsed: ParsedOpenAIModelId, modifier: string): boolean =>
   parsed.modifiers.includes(modifier);
 
+const baseGPT5MiniResponsesModels = new Set(['gpt-5-mini', 'gpt-5-mini-2025-08-07']);
+
 export const isGPT5ResponsesModel = (model: string): boolean => {
   const parsed = isNativeGPT5Model(model);
   if (!parsed) return false;
 
   if (hasModifier(parsed, 'chat')) return false;
   if (hasModifier(parsed, 'codex') || hasModifier(parsed, 'pro')) return true;
+  if (baseGPT5MiniResponsesModels.has(parsed.normalizedModelId)) return true;
 
   return parsed.minorVersion !== undefined && parsed.minorVersion >= 2;
 };


### PR DESCRIPTION
## Summary
- Restore the legacy public `klavis.getKlavisPlugins` tRPC path as a side-effect-free compatibility endpoint.
- Register the legacy `klavis` namespace on the root lambda router so older clients receive an empty plugin list instead of `NOT_FOUND` or `UNAUTHORIZED`, even without a session cookie.
- Route only `gpt-5-mini` and `gpt-5-mini-2025-08-07` through the built-in Responses API model rules.
- Keep base `gpt-5`, GPT-5 chat variants, OpenRouter-prefixed ids, and unknown future base mini-style ids unchanged.
- Add regression tests for both the unauthenticated legacy Klavis path and the GPT-5 mini routing rule.

## Related Links
- Issue: N/A
- Cloud PR: https://github.com/lobehub-biz/lobehub-cloud/pull/847

## Tests
- `rtk vitest run apps/server/src/routers/lambda/__tests__/klavis.test.ts`
- `cd packages/model-runtime && rtk vitest run src/providers/openai/openaiModelId.test.ts`

## Manual Verification
- Local AzureOpenAI smoke test showed `gpt-5-mini` matching built-in Responses API model rules and successfully calling `/openai/v1/responses`.