### PR TITLE
🐛 fix: route gpt-5-mini through responses api

### DIFF
--- a/packages/model-runtime/src/providers/openai/openaiModelId.test.ts
+++ b/packages/model-runtime/src/providers/openai/openaiModelId.test.ts
@@ -63,7 +63,6 @@ describe('parseOpenAIModelId', () => {
 describe('isGPT5ResponsesModel', () => {
   it('should preserve current base GPT-5 chat-completions models', () => {
     expect(isGPT5ResponsesModel('gpt-5')).toBe(false);
-    expect(isGPT5ResponsesModel('gpt-5-mini')).toBe(false);
     expect(isGPT5ResponsesModel('gpt-5-chat-latest')).toBe(false);
     expect(isGPT5ResponsesModel('gpt-5.2-chat-latest')).toBe(false);
     expect(isGPT5ResponsesModel('gpt-5.3-chat-latest')).toBe(false);
@@ -71,6 +70,9 @@ describe('isGPT5ResponsesModel', () => {
   });
 
   it('should match existing GPT-5 Responses models', () => {
+    expect(isGPT5ResponsesModel('gpt-5-mini')).toBe(true);
+    expect(isGPT5ResponsesModel('gpt-5-mini-2025-08-07')).toBe(true);
+    expect(isGPT5ResponsesModel('gpt-5-foo-mini')).toBe(false);
     expect(isGPT5ResponsesModel('gpt-5-pro')).toBe(true);
     expect(isGPT5ResponsesModel('gpt-5-pro-2025-10-06')).toBe(true);
     expect(isGPT5ResponsesModel('gpt-5.1-codex-mini')).toBe(true);

--- a/packages/model-runtime/src/providers/openai/openaiModelId.ts
+++ b/packages/model-runtime/src/providers/openai/openaiModelId.ts
@@ -124,12 +124,15 @@ const isNativeGPT5Model = (model: string): ParsedOpenAIModelId | undefined => {
 const hasModifier = (parsed: ParsedOpenAIModelId, modifier: string): boolean =>
   parsed.modifiers.includes(modifier);
 
+const baseGPT5MiniResponsesModels = new Set(['gpt-5-mini', 'gpt-5-mini-2025-08-07']);
+
 export const isGPT5ResponsesModel = (model: string): boolean => {
   const parsed = isNativeGPT5Model(model);
   if (!parsed) return false;
 
   if (hasModifier(parsed, 'chat')) return false;
   if (hasModifier(parsed, 'codex') || hasModifier(parsed, 'pro')) return true;
+  if (baseGPT5MiniResponsesModels.has(parsed.normalizedModelId)) return true;
 
   return parsed.minorVersion !== undefined && parsed.minorVersion >= 2;
 };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Route `gpt-5-mini` through the OpenAI Responses API model rules. This keeps the change intentionally narrow: only `gpt-5-mini` and its dated snapshot `gpt-5-mini-2025-08-07` are added to the Responses path. Base `gpt-5`, chat variants, OpenRouter-prefixed ids, and future unknown base mini-style ids remain unchanged.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

##### Automated Tests

```bash
rtk vitest run src/providers/openai/openaiModelId.test.ts
# PASS (20) FAIL (0)
```

##### Manual Verification

Local AzureOpenAI chat smoke test showed `gpt-5-mini` matching built-in Responses API rules and calling `/openai/v1/responses` successfully.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

The scope is deliberately limited to `gpt-5-mini`; this PR does not broadly move all base GPT-5 models to Responses API.