### PR TITLE
🐛 fix(group): stop orphaning group conversations when activeGroupId is transiently empty

### DIFF
--- a/src/routes/(main)/group/features/Conversation/useGroupContext.ts
+++ b/src/routes/(main)/group/features/Conversation/useGroupContext.ts
@@ -13,16 +13,20 @@ import { useChatStore } from '@/store/chat';
  * Used for group chat pages where multiple agents participate.
  */
 export function useGroupContext(): ConversationContext {
-  const [topicId, threadId, groupId] = useChatStore((s) => [
+  const [topicId, threadId] = useChatStore((s) => [
     s.activeTopicId ?? null,
     s.activeThreadId ?? null,
-    s.activeGroupId ?? null,
   ]);
 
   const currentGroup = useAgentGroupStore((s) =>
     s.activeGroupId ? agentGroupSelectors.getGroupById(s.activeGroupId)(s) : undefined,
   );
   const supervisorAgentId = currentGroup?.supervisorAgentId;
+  // Derive groupId from the resolved group — the same source as supervisorAgentId —
+  // instead of the route-synced chatStore.activeGroupId. When that global is
+  // transiently empty, sourcing groupId from it writes group messages/topics with an
+  // agentId but groupId=null, orphaning them out of the group's history view.
+  const groupId = currentGroup?.id ?? null;
 
   // Group context uses supervisorAgentId as agentId for message storage
   // When in group mode (not group_agent thread mode), the supervisor is responding

--- a/src/store/chat/slices/aiAgent/actions/__tests__/groupOrchestration.test.ts
+++ b/src/store/chat/slices/aiAgent/actions/__tests__/groupOrchestration.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useClientDataSWR } from '@/libs/swr';
+import { useAgentGroupStore } from '@/store/agentGroup';
 import { useChatStore } from '@/store/chat/store';
 
 // Keep zustand mock as it's needed globally
@@ -241,6 +242,90 @@ describe('groupOrchestration actions', () => {
           }),
         }),
       );
+    });
+  });
+
+  describe('#resolveGroupId fallback (chat store has no active group)', () => {
+    afterEach(() => {
+      useAgentGroupStore.setState({ activeGroupId: undefined, groupMap: {} }, false);
+    });
+
+    it('resolves the group from this run’s supervisor', async () => {
+      // Chat store active group is cleared (e.g. left the group route in a popup)…
+      useChatStore.setState({ activeGroupId: undefined }, false);
+      // …but the group is still known via its supervisor.
+      useAgentGroupStore.setState(
+        {
+          activeGroupId: undefined,
+          groupMap: {
+            [TEST_IDS.GROUP_ID]: {
+              agents: [],
+              id: TEST_IDS.GROUP_ID,
+              supervisorAgentId: TEST_IDS.SUPERVISOR_AGENT_ID,
+            } as any,
+          },
+        },
+        false,
+      );
+
+      const { result } = renderHook(() => useChatStore());
+      const internal_execGroupOrchestrationSpy = vi.fn().mockResolvedValue({ status: 'done' });
+      act(() => {
+        useChatStore.setState({
+          internal_execGroupOrchestration: internal_execGroupOrchestrationSpy,
+        });
+      });
+
+      await act(async () => {
+        await result.current.triggerSpeak({
+          agentId: 'target-agent-id',
+          instruction: 'hi',
+          skipCallSupervisor: false,
+          supervisorAgentId: TEST_IDS.SUPERVISOR_AGENT_ID,
+        });
+      });
+
+      expect(internal_execGroupOrchestrationSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ groupId: TEST_IDS.GROUP_ID }),
+      );
+    });
+
+    it('skips instead of running against a stale popup group from a different supervisor', async () => {
+      useChatStore.setState({ activeGroupId: undefined }, false);
+      // A stale popup group lingers in the agentGroup store, but it is NOT this
+      // run’s supervisor — the trigger must skip, not run against it.
+      useAgentGroupStore.setState(
+        {
+          activeGroupId: 'stale-popup-group',
+          groupMap: {
+            'stale-popup-group': {
+              agents: [],
+              id: 'stale-popup-group',
+              supervisorAgentId: 'some-other-supervisor',
+            } as any,
+          },
+        },
+        false,
+      );
+
+      const { result } = renderHook(() => useChatStore());
+      const internal_execGroupOrchestrationSpy = vi.fn().mockResolvedValue({ status: 'done' });
+      act(() => {
+        useChatStore.setState({
+          internal_execGroupOrchestration: internal_execGroupOrchestrationSpy,
+        });
+      });
+
+      await act(async () => {
+        await result.current.triggerSpeak({
+          agentId: 'target-agent-id',
+          instruction: 'hi',
+          skipCallSupervisor: false,
+          supervisorAgentId: TEST_IDS.SUPERVISOR_AGENT_ID,
+        });
+      });
+
+      expect(internal_execGroupOrchestrationSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/store/chat/slices/aiAgent/actions/groupOrchestration.ts
+++ b/src/store/chat/slices/aiAgent/actions/groupOrchestration.ts
@@ -7,6 +7,7 @@ import { type SWRResponse } from 'swr';
 import { useClientDataSWR } from '@/libs/swr';
 import { aiAgentService } from '@/services/aiAgent';
 import { getChatGroupStoreState } from '@/store/agentGroup';
+import { agentGroupByIdSelectors } from '@/store/agentGroup/selectors';
 import { createGroupOrchestrationExecutors } from '@/store/chat/agents/GroupOrchestration';
 import { type ChatStore } from '@/store/chat/store';
 import { type GroupOrchestrationCallbacks } from '@/store/tool/slices/builtin/types';
@@ -50,13 +51,20 @@ export class GroupOrchestrationActionImpl {
   }
 
   /**
-   * Resolve the active groupId for orchestration. The chat store's activeGroupId is
-   * route-synced and can be transiently empty; fall back to the agentGroup store (the
-   * authoritative group identity) so the supervisor doesn't silently skip triggering
-   * member agents.
+   * Resolve the groupId for an orchestration run. Prefer the chat store's
+   * route-synced activeGroupId; when it's transiently empty, resolve the group from
+   * the supervisor that owns THIS run — NOT the global agentGroup activeGroupId,
+   * which can be a stale popup group (popup agent routes only clear the chat store)
+   * and would make a non-group popup trigger work in the wrong group. Returns
+   * undefined for a non-group supervisor, so the trigger safely skips as before.
    */
-  #resolveActiveGroupId = (): string | undefined =>
-    this.#get().activeGroupId ?? getChatGroupStoreState().activeGroupId;
+  #resolveGroupId = (supervisorAgentId: string): string | undefined => {
+    const activeGroupId = this.#get().activeGroupId;
+    if (activeGroupId) return activeGroupId;
+    return agentGroupByIdSelectors.groupBySupervisorAgentId(supervisorAgentId)(
+      getChatGroupStoreState(),
+    )?.id;
+  };
 
   getGroupOrchestrationCallbacks = (): GroupOrchestrationCallbacks => {
     return {
@@ -80,7 +88,7 @@ export class GroupOrchestrationActionImpl {
       skipCallSupervisor,
     );
 
-    const groupId = this.#resolveActiveGroupId();
+    const groupId = this.#resolveGroupId(supervisorAgentId);
     if (!groupId) {
       log('[triggerSpeak] No active group, skipping');
       return;
@@ -114,7 +122,7 @@ export class GroupOrchestrationActionImpl {
       toolMessageId,
     );
 
-    const groupId = this.#resolveActiveGroupId();
+    const groupId = this.#resolveGroupId(supervisorAgentId);
     if (!groupId) {
       log('[triggerBroadcast] No active group, skipping');
       return;
@@ -146,7 +154,7 @@ export class GroupOrchestrationActionImpl {
       reason,
     );
 
-    const groupId = this.#resolveActiveGroupId();
+    const groupId = this.#resolveGroupId(supervisorAgentId);
     if (!groupId) {
       log('[triggerDelegate] No active group, skipping');
       return;
@@ -190,7 +198,7 @@ export class GroupOrchestrationActionImpl {
       runInClient,
     );
 
-    const groupId = this.#resolveActiveGroupId();
+    const groupId = this.#resolveGroupId(supervisorAgentId);
     if (!groupId) {
       log('[triggerExecuteTask] No active group, skipping');
       return;
@@ -223,7 +231,7 @@ export class GroupOrchestrationActionImpl {
       skipCallSupervisor,
     );
 
-    const groupId = this.#resolveActiveGroupId();
+    const groupId = this.#resolveGroupId(supervisorAgentId);
     if (!groupId) {
       log('[triggerExecuteTasks] No active group, skipping');
       return;

--- a/src/store/chat/slices/aiAgent/actions/groupOrchestration.ts
+++ b/src/store/chat/slices/aiAgent/actions/groupOrchestration.ts
@@ -6,6 +6,7 @@ import { type SWRResponse } from 'swr';
 
 import { useClientDataSWR } from '@/libs/swr';
 import { aiAgentService } from '@/services/aiAgent';
+import { getChatGroupStoreState } from '@/store/agentGroup';
 import { createGroupOrchestrationExecutors } from '@/store/chat/agents/GroupOrchestration';
 import { type ChatStore } from '@/store/chat/store';
 import { type GroupOrchestrationCallbacks } from '@/store/tool/slices/builtin/types';
@@ -48,6 +49,15 @@ export class GroupOrchestrationActionImpl {
     this.#get = get;
   }
 
+  /**
+   * Resolve the active groupId for orchestration. The chat store's activeGroupId is
+   * route-synced and can be transiently empty; fall back to the agentGroup store (the
+   * authoritative group identity) so the supervisor doesn't silently skip triggering
+   * member agents.
+   */
+  #resolveActiveGroupId = (): string | undefined =>
+    this.#get().activeGroupId ?? getChatGroupStoreState().activeGroupId;
+
   getGroupOrchestrationCallbacks = (): GroupOrchestrationCallbacks => {
     return {
       triggerSpeak: this.#get().triggerSpeak,
@@ -70,7 +80,7 @@ export class GroupOrchestrationActionImpl {
       skipCallSupervisor,
     );
 
-    const groupId = this.#get().activeGroupId;
+    const groupId = this.#resolveActiveGroupId();
     if (!groupId) {
       log('[triggerSpeak] No active group, skipping');
       return;
@@ -104,7 +114,7 @@ export class GroupOrchestrationActionImpl {
       toolMessageId,
     );
 
-    const groupId = this.#get().activeGroupId;
+    const groupId = this.#resolveActiveGroupId();
     if (!groupId) {
       log('[triggerBroadcast] No active group, skipping');
       return;
@@ -136,7 +146,7 @@ export class GroupOrchestrationActionImpl {
       reason,
     );
 
-    const groupId = this.#get().activeGroupId;
+    const groupId = this.#resolveActiveGroupId();
     if (!groupId) {
       log('[triggerDelegate] No active group, skipping');
       return;
@@ -180,7 +190,7 @@ export class GroupOrchestrationActionImpl {
       runInClient,
     );
 
-    const groupId = this.#get().activeGroupId;
+    const groupId = this.#resolveActiveGroupId();
     if (!groupId) {
       log('[triggerExecuteTask] No active group, skipping');
       return;
@@ -213,7 +223,7 @@ export class GroupOrchestrationActionImpl {
       skipCallSupervisor,
     );
 
-    const groupId = this.#get().activeGroupId;
+    const groupId = this.#resolveActiveGroupId();
     if (!groupId) {
       log('[triggerExecuteTasks] No active group, skipping');
       return;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Related to LOBE-10402 (this is a hot-path slice of the group `current*`/global-`activeGroupId` cleanup).

#### 🔀 Description of Change

Group conversations were intermittently **disappearing with no history**. Root cause: in a group chat the `agentId` is sourced from the resolved `agentGroupStore.currentGroup.supervisorAgentId` (stable), but `groupId` was sourced from `chatStore.activeGroupId` — a route-synced **global** that can be transiently empty. When the two diverge, messages and topics get persisted with an `agentId` but `groupId = null`, orphaning the whole conversation out of the group's history view.

Production impact was platform-wide: the share of messages written with a `group_id` collapsed from ~2.9% (Jun 13) to **0%** (Jun 21), and the count of groups still writing `group_id` went from ~40/day to 0 — a gradual ramp consistent with client cache rollout. The same empty global also makes the orchestration triggers bail on `if (!groupId) return`, so the supervisor silently stops triggering member agents and degrades to a solo reply (the "very unstable" symptom).

**Fix — make `groupId` co-derive with `agentId` from the resolved group instead of the fragile global:**

- `useGroupContext`: derive `groupId` from `currentGroup.id` (same source as `supervisorAgentId`). This covers all ConversationStore writes (message create, topic create, compression, metadata) since they all read `context.groupId`. A resolved supervisor now always carries its groupId.
- `groupOrchestration`: resolve the active groupId with a fallback to the agentGroup store (`#resolveActiveGroupId`), so a transiently empty `chatStore.activeGroupId` no longer skips member triggering.

This is the immediate stop-the-bleed slice; the systemic cleanup (read paths like `useFetchTopics`, deleting the `current*` selectors) is tracked by LOBE-10402.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`type-check` passes; `groupOrchestration.test.ts` (5/5) passes. To reproduce the original bug: open a group chat, force `chatStore.activeGroupId` empty while `currentGroup` is loaded, send a message — before this change the message persists with `group_id = null` and members are not triggered; after, it persists under the group and orchestration proceeds.

#### 📝 Additional Information

The fix only changes the *source* of `groupId`; the fallback in orchestration is a no-op whenever `chatStore.activeGroupId` is correctly populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)