### PR TITLE
♻️ refactor(chat): converge remaining run entries onto the unified lifecycle

### DIFF
--- a/src/features/Conversation/store/slices/generation/action.ts
+++ b/src/features/Conversation/store/slices/generation/action.ts
@@ -62,6 +62,28 @@ const buildRetryInitialContext = (editorData: Record<string, any> | null | undef
 };
 
 /**
+ * Settle a regenerate / continue entry's OUTER tracking operation and fire its
+ * thin UI completion hook (`onRegenerateComplete` / `onContinueComplete`).
+ *
+ * Each of these entries owns an outer tracking op distinct from the executor's
+ * run op (`${messageKey}/${parentMessageId}`). The unified run lifecycle
+ * (`buildRunLifecycle`, inside the executor) already drove the run-level terminal
+ * side effects — title / queue drain / notification / complete signal — so the
+ * entry only retires its own tracking op and broadcasts the UI hook. Five runtime
+ * branches (regenerate × client/gateway/hetero, continue × client/gateway) shared
+ * this identical two-line tail; centralized here so they converge on one adapter
+ * instead of hand-rolling completion at each call site.
+ */
+const settleGenerationEntry = (
+  chatStore: ReturnType<typeof useChatStore.getState>,
+  operationId: string,
+  notify?: () => void,
+) => {
+  chatStore.completeOperation(operationId);
+  notify?.();
+};
+
+/**
  * Branch a hetero (Claude Code / Codex) turn off an existing user message.
  *
  * Used by regenerate (parent = user msg, prompt = original user content).
@@ -350,10 +372,10 @@ export const generationSlice: StateCreator<
         await chatStore.executeGatewayAgent({
           context,
           message: '',
-          onComplete: () => {
-            chatStore.completeOperation(operationId);
-            if (hooks.onContinueComplete) hooks.onContinueComplete(displayMessageId);
-          },
+          onComplete: () =>
+            settleGenerationEntry(chatStore, operationId, () =>
+              hooks.onContinueComplete?.(displayMessageId),
+            ),
           parentMessageId: dbMessageId,
         });
         return;
@@ -368,12 +390,9 @@ export const generationSlice: StateCreator<
         parentOperationId: operationId,
       });
 
-      chatStore.completeOperation(operationId);
-
-      // ===== Hook: onContinueComplete =====
-      if (hooks.onContinueComplete) {
-        hooks.onContinueComplete(displayMessageId);
-      }
+      settleGenerationEntry(chatStore, operationId, () =>
+        hooks.onContinueComplete?.(displayMessageId),
+      );
     } catch (error) {
       chatStore.failOperation(operationId, {
         message: error instanceof Error ? error.message : String(error),
@@ -515,12 +534,10 @@ export const generationSlice: StateCreator<
         await chatStore.executeGatewayAgent({
           context,
           message: item.content,
-          onComplete: () => {
-            chatStore.completeOperation(operationId);
-            if (hooks.onRegenerateComplete) {
-              hooks.onRegenerateComplete(messageId);
-            }
-          },
+          onComplete: () =>
+            settleGenerationEntry(chatStore, operationId, () =>
+              hooks.onRegenerateComplete?.(messageId),
+            ),
           parentMessageId: messageId,
         });
 
@@ -545,8 +562,9 @@ export const generationSlice: StateCreator<
           parentOperationId: operationId,
           prompt: item.content,
         });
-        chatStore.completeOperation(operationId);
-        if (hooks.onRegenerateComplete) hooks.onRegenerateComplete(messageId);
+        settleGenerationEntry(chatStore, operationId, () =>
+          hooks.onRegenerateComplete?.(messageId),
+        );
         return;
       }
 
@@ -561,12 +579,7 @@ export const generationSlice: StateCreator<
         parentOperationId: operationId,
       });
 
-      chatStore.completeOperation(operationId);
-
-      // ===== Hook: onRegenerateComplete =====
-      if (hooks.onRegenerateComplete) {
-        hooks.onRegenerateComplete(messageId);
-      }
+      settleGenerationEntry(chatStore, operationId, () => hooks.onRegenerateComplete?.(messageId));
     } catch (error) {
       chatStore.failOperation(operationId, {
         message: error instanceof Error ? error.message : String(error),

--- a/src/store/chat/slices/aiChat/actions/conversationControl.ts
+++ b/src/store/chat/slices/aiChat/actions/conversationControl.ts
@@ -9,7 +9,10 @@ import {
 
 import { getAgentStoreState } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
-import { selectRuntimeType } from '@/store/chat/slices/aiChat/actions/agentDispatcher';
+import {
+  type AgentRuntimeType,
+  selectRuntimeType,
+} from '@/store/chat/slices/aiChat/actions/agentDispatcher';
 import { operationSelectors } from '@/store/chat/slices/operation/selectors';
 import { AI_RUNTIME_OPERATION_TYPES } from '@/store/chat/slices/operation/types';
 import { type ChatStore } from '@/store/chat/store';
@@ -19,6 +22,8 @@ import { displayMessageSelectors } from '../../../selectors';
 import { messageMapKey } from '../../../utils/messageMapKey';
 import { type OptimisticUpdateContext } from '../../message/actions/optimisticUpdate';
 import { dbMessageSelectors } from '../../message/selectors';
+import { buildRunLifecycle } from './runLifecycle/buildRunLifecycle';
+import { type RunScope } from './runLifecycle/types';
 
 /**
  * Actions for controlling conversation operations like cancellation and error handling
@@ -220,6 +225,41 @@ export class ConversationControlActionImpl {
     );
   };
 
+  /**
+   * Broadcast that a parked run is resuming under a NEW operation. The resume
+   * entries (approve / reject / reject-continue / submit / skip) call this at
+   * dispatch so the park → resume transition flows through the unified run
+   * lifecycle's `onRunResumed` seam instead of being invisible to it.
+   *
+   * Behavior-neutral: fires no terminal side effects and mutates no store state
+   * (see `buildRunLifecycle.onRunResumed`). `buildRunLifecycle` is a pure factory,
+   * so constructing a throwaway instance here purely to broadcast the resume is
+   * cheap and side-effect-free; `[6]` AgentRunner is where the lifecycle becomes a
+   * single per-run instance threaded through dispatch.
+   */
+  #emitRunResumed = (
+    context: ConversationContext,
+    params: { operationId: string; parentMessageId: string; runtimeType: AgentRuntimeType },
+  ) => {
+    const { operationId, parentMessageId, runtimeType } = params;
+    const runScope: RunScope = context.scope === 'sub_agent' ? 'sub_agent' : 'top_level';
+    void buildRunLifecycle(this.#get, {
+      context,
+      parentMessageId,
+      parentMessageType: 'tool',
+      runId: operationId,
+      runScope,
+      runtimeType,
+    }).onRunResumed({
+      context,
+      operationId,
+      resumedOperationId: operationId,
+      runId: operationId,
+      runScope,
+      runtimeType,
+    });
+  };
+
   approveToolCalling = async (
     toolMessageId: string,
     _assistantGroupId: string,
@@ -254,6 +294,13 @@ export class ConversationControlActionImpl {
     });
 
     const optimisticContext = { operationId };
+
+    // Park → resume: a new op continues the run paused on this tool's approval.
+    this.#emitRunResumed(effectiveContext, {
+      operationId,
+      parentMessageId: toolMessageId,
+      runtimeType: this.#shouldUseGatewayResume(effectiveContext) ? 'gateway' : 'client',
+    });
 
     // 2. Update intervention status to approved
     await this.#get().optimisticUpdateMessagePlugin(
@@ -397,6 +444,13 @@ export class ConversationControlActionImpl {
 
     const optimisticContext: OptimisticUpdateContext = { operationId };
     const shouldCreateUserMessage = options?.createUserMessage !== false;
+
+    // Park → resume: a new op continues the run paused on this tool interaction.
+    this.#emitRunResumed(effectiveContext, {
+      operationId,
+      parentMessageId: toolMessageId,
+      runtimeType: 'client',
+    });
 
     // 1. Mark intervention as approved and set tool result to user's response
     await this.#get().optimisticUpdateMessagePlugin(
@@ -569,6 +623,13 @@ export class ConversationControlActionImpl {
     });
 
     const optimisticContext: OptimisticUpdateContext = { operationId };
+
+    // Park → resume: a new op continues the run paused on this tool interaction.
+    this.#emitRunResumed(effectiveContext, {
+      operationId,
+      parentMessageId: toolMessageId,
+      runtimeType: 'client',
+    });
 
     // 1. Mark intervention as rejected (skipped) with reason
     await this.#get().optimisticUpdateMessagePlugin(
@@ -961,6 +1022,12 @@ export class ConversationControlActionImpl {
         return;
       }
       const pausedOpIds = this.#getRunningServerOps(effectiveContext).map((op) => op.id);
+      // Park → resume: the new gateway op continues the run paused on this tool.
+      this.#emitRunResumed(effectiveContext, {
+        operationId,
+        parentMessageId: messageId,
+        runtimeType: 'gateway',
+      });
       try {
         await this.#get().executeGatewayAgent({
           context: effectiveContext,
@@ -1031,6 +1098,12 @@ export class ConversationControlActionImpl {
       });
 
       const optimisticContext = { operationId };
+      // Park → resume: the new gateway op continues the run paused on this tool.
+      this.#emitRunResumed(effectiveContext, {
+        operationId,
+        parentMessageId: messageId,
+        runtimeType: 'gateway',
+      });
       await this.#get().optimisticUpdateMessagePlugin(
         messageId,
         { intervention: { rejectedReason: reason, status: 'rejected' } as any },
@@ -1086,6 +1159,13 @@ export class ConversationControlActionImpl {
         scope,
         messageId,
       },
+    });
+
+    // Park → resume: this local op continues the run paused on the rejected tool.
+    this.#emitRunResumed(effectiveContext, {
+      operationId,
+      parentMessageId: messageId,
+      runtimeType: 'client',
     });
 
     // Get current messages for state construction using context

--- a/src/store/chat/slices/aiChat/actions/runLifecycle/buildRunLifecycle.test.ts
+++ b/src/store/chat/slices/aiChat/actions/runLifecycle/buildRunLifecycle.test.ts
@@ -248,3 +248,44 @@ describe('buildRunLifecycle.afterUserMessagePersisted — topic title (all runti
     expect(store.summaryTopicTitle).not.toHaveBeenCalled();
   });
 });
+
+describe('buildRunLifecycle.onRunResumed — park → resume broadcast seam', () => {
+  const resumedEvent = (runtimeType: AgentRuntimeType, runScope: 'sub_agent' | 'top_level') => ({
+    context: CONTEXT,
+    operationId: OP,
+    resumedOperationId: 'op2',
+    runId: OP,
+    runScope,
+    runtimeType,
+  });
+
+  it.each<AgentRuntimeType>(['client', 'gateway', 'hetero'])(
+    'is behavior-neutral for %s: fires NO terminal side effects and emits no completion signal',
+    async (runtimeType) => {
+      const { get, store } = makeStore();
+
+      await expect(
+        lifecycle(runtimeType, get).onRunResumed(resumedEvent(runtimeType, 'top_level')),
+      ).resolves.toBeUndefined();
+
+      // The run is continuing, not completing — none of the terminal mutations
+      // (op completion / unread / queue drain) nor the completion signal may fire.
+      expect(store.completeOperation).not.toHaveBeenCalled();
+      expect(store.failOperation).not.toHaveBeenCalled();
+      expect(store.markTopicUnread).not.toHaveBeenCalled();
+      expect(store.drainQueuedMessages).not.toHaveBeenCalled();
+      expect(agentSignalBridgeMock.emitClientAgentSignalSourceEvent).not.toHaveBeenCalled();
+    },
+  );
+
+  it('is a no-op for a sub_agent resume (top-level only, like the other run-scoped hooks)', async () => {
+    const { get, store } = makeStore();
+
+    await expect(
+      lifecycle('client', get, 'sub_agent').onRunResumed(resumedEvent('client', 'sub_agent')),
+    ).resolves.toBeUndefined();
+
+    expect(store.completeOperation).not.toHaveBeenCalled();
+    expect(agentSignalBridgeMock.emitClientAgentSignalSourceEvent).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/chat/slices/aiChat/actions/runLifecycle/buildRunLifecycle.ts
+++ b/src/store/chat/slices/aiChat/actions/runLifecycle/buildRunLifecycle.ts
@@ -1,6 +1,7 @@
 import type { AgentState } from '@lobechat/agent-runtime';
 import { isDesktop } from '@lobechat/const';
 import type { ConversationContext, UIChatMessage } from '@lobechat/types';
+import debug from 'debug';
 import { t } from 'i18next';
 
 import { getAgentStoreState } from '@/store/agent';
@@ -22,9 +23,12 @@ import type {
   RunCompleteEvent,
   RunCompleteResult,
   RunParkedEvent,
+  RunResumedEvent,
   RunScope,
   UserMessagePersistedEvent,
 } from './types';
+
+const log = debug('lobe-store:run-lifecycle');
 
 /**
  * Normalize the runtime/operation status into the cross-runtime
@@ -428,7 +432,23 @@ export const buildRunLifecycle = (
         get().completeOperation(operationId);
       }
     },
-    onRunResumed: NOOP,
+    onRunResumed: async ({ operationId, resumedOperationId, runId }: RunResumedEvent) => {
+      // A NEW operation resumes the SAME logical run after a park
+      // (`waiting_for_human` → approve / reject / reject-continue / submit / skip).
+      // This is the single broadcast seam for that transition: it fires NO terminal
+      // side effects (the run is continuing, not completing) and mutates NO store
+      // state — the resume operation is already started by its entry. Behavior-
+      // neutral today; the structural marker is what `[6]` AgentRunner builds on to
+      // thread a stable cross-operation `runId`. Top-level only, mirroring the other
+      // run-scoped hooks (a parked sub-agent is not a user-facing resume).
+      if (adapter.runScope === 'sub_agent') return;
+      log(
+        'run resumed (parkedOp=%s → resumeOp=%s, runId=%s)',
+        operationId,
+        resumedOperationId,
+        runId,
+      );
+    },
     onRunStarted: NOOP,
     onTerminalPersisted: NOOP,
   };


### PR DESCRIPTION
## 背景

LOBE-10376「前端 Agent Runtime 生命周期统一改造」步骤 **[5] 其余入口收敛**(`Fixes LOBE-10380`)。

深挖后确认:sendMessage 之外入口的**功能性收敛已由执行器提前达成**——client 在 `streamingExecutor`、gateway 在 `gateway.ts` 各自 `buildRunLifecycle` 并在终态/parked 边界调用,所以无论从哪个入口进,终态副作用(title / queue drain / notification / complete signal)早已走统一 lifecycle,硬约束「终态只触发一次」也由 `onRunParked` 路由满足。

本 PR 按**行为保持**范围清掉剩余的结构残渣(要点 1 + 要点 2),不引入跨 operation 稳定 `runId`(留给 [6] AgentRunner)。

## 改动

- **`generation/action.ts`(要点 1)**:将 regenerate/continue 共 5 处重复的「`completeOperation(outerOp)` + `onRegenerateComplete`/`onContinueComplete`」尾巴(regenerate × client/gateway/hetero、continue × client/gateway)收成单一 `settleGenerationEntry` 薄适配。外层 op 是入口自有的追踪 op(非冗余,执行器退的是内层 run op),仍由入口退;run 级终态副作用早由执行器内 `buildRunLifecycle` 驱动。**行为完全保持。**
- **`buildRunLifecycle.onRunResumed`(要点 2)**:实现 park → resume 广播 seam(原为 NOOP)。**行为中性**:top-level gated,不触发任何终态副作用、不 mutate 任何 store 状态——它是 [6] AgentRunner 用来串「跨 operation 稳定 runId」的结构标记。
- **`conversationControl.ts`**:在全部 6 个 resume 派发点接上 `#emitRunResumed`(approve / reject / reject-continue × gateway+client / submit / skip)。`buildRunLifecycle` 是无副作用纯工厂,入口侧构造一次性实例广播 resume 廉价且安全,也正是设计文档的终态形态。
- **tests**:新增 4 条锁定 `onRunResumed` 在 client/gateway/hetero 三 runtime 下的行为中性。

## 范围与边界

- **不在范围**:`submitHeteroIntervention` 走 IPC 直通且本就不产生新 run-complete;跨 operation 稳定 `runId` 与 runner 结构归一属 [6]。
- `onRunResumed` 当前 body 仅 `debug` 日志(`lobe-store:run-lifecycle`),无观察副作用——它是为 [6] 预留的接线点,本 PR 先把「谁在 resume」这条信息接通。

## 验证

- ✅ characterization 全程保绿:`generation/action`(26)、`conversationControl`(34)、`buildRunLifecycle`(17,含新增 4)、`streamingExecutor`(43)、`gateway`(34)、`gatewayEventHandler`(61)
- ✅ 改动文件 type-check 无错误;eslint / prettier 通过(lint-staged 已校验)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
