### PR TITLE
🐛 fix(group): stamp groupId on server-runtime-persisted messages

### DIFF
--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -368,6 +368,7 @@ const buildServerVirtualSubAgentRunner = (
       const placeholder = await ctx.messageModel.create({
         agentId,
         content: '',
+        groupId: state.metadata?.groupId ?? undefined,
         parentId: parentMessageId,
         plugin: chatToolPayload as any,
         pluginState: { status: 'pending' },
@@ -459,6 +460,7 @@ const buildServerAgentMemberRunner = (
       const groupTool = await ctx.messageModel.create({
         agentId,
         content: '',
+        groupId,
         parentId: parentMessageId,
         plugin: chatToolPayload as any,
         pluginState: { expectedMembers, onComplete, status: 'pending' },
@@ -479,6 +481,7 @@ const buildServerAgentMemberRunner = (
           const anchor = await ctx.messageModel.create({
             agentId,
             content: '',
+            groupId,
             parentId: groupTool.id,
             plugin: { ...(chatToolPayload as any), id: memberToolCallId },
             pluginState: { status: 'pending' },
@@ -852,6 +855,7 @@ export const createRuntimeExecutors = (
       assistantMessageItem = await ctx.messageModel.create({
         agentId: state.metadata!.agentId!,
         content: '',
+        groupId: state.metadata?.groupId ?? undefined,
         model,
         parentId,
         provider,
@@ -2833,6 +2837,7 @@ export const createRuntimeExecutors = (
             const toolMessage = await ctx.messageModel.create({
               agentId: state.metadata!.agentId!,
               content: executionResult.content,
+              groupId: state.metadata?.groupId ?? undefined,
               metadata: { toolExecutionTimeMs: executionTime },
               parentId: payload.parentMessageId,
               plugin: chatToolPayload as any,
@@ -3368,6 +3373,7 @@ export const createRuntimeExecutors = (
               const toolMessage = await ctx.messageModel.create({
                 agentId: state.metadata!.agentId!,
                 content: executionResult.content,
+                groupId: state.metadata?.groupId ?? undefined,
                 metadata: { toolExecutionTimeMs: executionTime },
                 parentId: parentMessageId,
                 plugin: chatToolPayload as any,
@@ -3680,6 +3686,7 @@ export const createRuntimeExecutors = (
       const taskMessage = await ctx.messageModel.create({
         agentId: agentId!,
         content: '',
+        groupId: state.metadata?.groupId ?? undefined,
         metadata: {
           instruction: task.instruction,
           taskTitle: task.description,
@@ -3808,6 +3815,7 @@ export const createRuntimeExecutors = (
         const taskMessage = await ctx.messageModel.create({
           agentId: agentId!,
           content: '',
+          groupId: state.metadata?.groupId ?? undefined,
           metadata: {
             instruction: task.instruction,
             taskTitle: task.description,
@@ -4060,6 +4068,7 @@ export const createRuntimeExecutors = (
           const toolMessage = await ctx.messageModel.create({
             agentId: state.metadata!.agentId!,
             content: '',
+            groupId: state.metadata?.groupId ?? undefined,
             parentId: parentAssistantId,
             plugin: toolPayload as any,
             pluginIntervention: { status: 'pending' },
@@ -4170,6 +4179,7 @@ export const createRuntimeExecutors = (
         const toolMessage = await ctx.messageModel.create({
           agentId: state.metadata!.agentId!,
           content: result.content,
+          groupId: state.metadata?.groupId ?? undefined,
           metadata: { toolExecutionTimeMs: 0 },
           parentId: parentMessageId,
           plugin: toolPayload as any,
@@ -4263,6 +4273,7 @@ export const createRuntimeExecutors = (
         const toolMessage = await ctx.messageModel.create({
           agentId: state.metadata!.agentId!,
           content: 'Tool execution was aborted by user.',
+          groupId: state.metadata?.groupId ?? undefined,
           parentId: parentMessageId,
           plugin: toolPayload as any,
           pluginIntervention: { status: 'aborted' },

--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -289,6 +289,7 @@ export class CompletionLifecycle {
       await messageModel.create({
         agentId: op.agentId ?? undefined,
         content: '',
+        groupId: op.chatGroupId ?? undefined,
         metadata: { verifyOperationId: operationId },
         parentId: assistantMessageId,
         role: 'verify',


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Server-side twin of #16149 (client orphaning). Same root family as LOBE-10402.

#### 🔀 Description of Change

#16149 fixed the **client** orphaning (group messages written with `agentId` but `groupId=null`). But when an agent-group conversation runs on the **server runtime** (e.g. `execute_task`, server-initiated/cron/signal runs, human-intervention resume), the server persists its own assistant/tool/task/verify messages — and several `messageModel.create` calls **omitted `groupId`**, even though the operation carries it:
- `state.metadata.groupId` (seeded from `appContext.groupId`, which now comes from the corrected client `context.groupId`)
- `op.chatGroupId` on the operation row

Those messages landed with `group_id = null` and fell out of the group's history — the server-side twin of the bug. It was also inconsistent: the group-tool, member-anchor and sub-agent creates already threaded it; the assistant/tool/task/verify creates did not.

**Fix** — thread the already-available groupId through every group-capable create:
- `RuntimeExecutors.ts`: new assistant message, tool messages (streaming / blocked / aborted / sub-agent placeholder), task messages (×2), group tool, member anchor.
- `CompletionLifecycle.ts`: verify message (uses `op.chatGroupId`).

Auditable invariant: every `messageModel.create` in `RuntimeExecutors.ts` now threads `groupId`.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

`type-check` clean. The value is `undefined` for non-group runs (no behavior change) and the real groupId for group runs, so server-persisted group messages now stay attached to the group.

#### 📝 Additional Information

Stacked with #16149 (client) — that PR makes `appContext.groupId` correct; this one makes the server runtime stamp it onto the messages it writes. Together they close the client + server halves of the group-message orphaning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)