### PR TITLE
✨ feat(verify): add portable builder self-evidence verify skill

### DIFF
--- a/packages/builtin-skills/src/index.ts
+++ b/packages/builtin-skills/src/index.ts
@@ -10,6 +10,16 @@ export { ArtifactsIdentifier } from './artifacts';
 export { LobeHubIdentifier } from './lobehub';
 export { TaskIdentifier } from './task';
 
+/**
+ * The portable verify skill is distributed to external builders (Claude Code /
+ * Codex) by pulling it to disk (`lh verify init`), NOT by loading it into the
+ * homogeneous agent runtime. So it is exported as a named skill for the pull
+ * endpoint to import directly, but deliberately left OUT of `builtinSkills`
+ * below — keeping it out of every app-layer consumer of that array (server
+ * runtime, agentDocumentVfs, tool store / picker).
+ */
+export { VerifyIdentifier, VerifySkill } from './verify';
+
 export const builtinSkills: BuiltinSkill[] = [
   AgentBrowserSkill,
   ArtifactsSkill,

--- a/packages/builtin-skills/src/verify/SKILL.md
+++ b/packages/builtin-skills/src/verify/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: verify
+description: >
+  Self-evidence for task delivery verification. When you run a task that has a
+  verify plan, this skill is the full operating manual: what to prove, which
+  surface to prove it on (CLI / web / desktop), how to drive that surface with
+  agent-browser, how to get past auth, and how to upload each artifact with
+  `lh verify upload-evidence` so the delivery is judged on real proof — not your
+  word that it works. Triggers on 'verify the task', 'collect evidence', 'prove
+  it works', 'upload evidence', 'verify plan', 'requiredEvidence', or any run
+  that must self-certify its delivery.
+---
+
+# Verify (Builder Self-Evidence)
+
+You are the **builder** for a task. A separate review step will judge your
+delivery against a **verify plan** — a list of criteria, some of which demand
+**evidence** (a screenshot, a DOM snapshot, CLI output…). A criterion that
+declares `requiredEvidence` **cannot pass on your text alone**: if the artifact
+is missing, the structural gate marks it `uncertain` and the delivery is held.
+
+So while you do the work, capture the proof and upload it. The loop:
+
+```
+discover plan  →  pick the surface  →  capture evidence per criterion  →  upload each  →  self-check coverage
+```
+
+Everything here is portable: the hard dependencies are the `lh` CLI (already
+authed in your environment) and, for UI proof, `agent-browser`. No repo scripts,
+no local report directory.
+
+## Prerequisites
+
+- **`lh` is authed.** Confirm with `lh verify run list --json` (an empty `[]`
+  means authed; an auth error means stop and surface it).
+- **You know your operation id.** It is provided as `$LOBE_OPERATION_ID` in the
+  environment (or named in your task prompt). Every command below keys off it.
+  If it is unset, there is no plan to satisfy — skip this skill.
+- **For UI evidence, `agent-browser` is installed.** `npm i -g agent-browser`
+  then `agent-browser install` (downloads Chrome). Full reference:
+  [references/agent-browser.md](references/agent-browser.md).
+
+## Step 1 — Discover the plan (what to prove + where to attach)
+
+Two reads, joined by `checkItemId`:
+
+```bash
+# (a) the frozen plan: each item's id, title, and required evidence types
+lh verify plan state "$LOBE_OPERATION_ID" --json
+
+# (b) the pending result rows: maps each checkItemId → checkResultId (the upload handle)
+lh verify result list --operation "$LOBE_OPERATION_ID" --json
+```
+
+From (a), each `verifyPlan[]` item carries `id` (the **checkItemId**), `title`,
+`required`, and `verifierConfig.requiredEvidence` (`[{ type, hint }]` — the
+artifacts you MUST capture). From (b), each row gives `checkItemId` → `id` (the
+**checkResultId** you upload against). Join them so you have, per criterion: the
+evidence types required and the checkResultId to attach them to. Exact shapes and
+a worked join: [references/plan-format.md](references/plan-format.md).
+
+> Only items with a non-empty `requiredEvidence` need an artifact. Items without
+> it are judged on the deliverable text alone — don't fabricate evidence.
+
+## Step 2 — Pick the surface by what you changed
+
+The criterion's `hint` usually implies the surface. Match the change you made to
+the cheapest surface that can actually prove it, and escalate only if needed:
+
+| What your task changed                                         | Surface                                                  | Why                                                                        | Guide                                             |
+| -------------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------- |
+| Backend / CLI / library / data logic                           | **CLI** 端                                               | Fastest, text-assertable, zero UI flakiness — upload stdout as `text`      | [surfaces/cli.md](surfaces/cli.md)                |
+| Web app frontend / styles / interactions                       | **Web** 端 (agent-browser → running web app)             | The product shape users see; screenshot/DOM the rendered result            | [surfaces/web.md](surfaces/web.md)                |
+| New/changed API **plus** the UI consuming it                   | **Web** 端，full-stack (agent-browser + network capture) | One surface where request/response and rendered result are both observable | [surfaces/web.md](surfaces/web.md#web-full-stack) |
+| Desktop (Electron) app behavior                                | **Electron** 端 (agent-browser `--cdp`)                  | Only the real desktop shell exercises desktop-only code paths              | [surfaces/electron.md](surfaces/electron.md)      |
+| Native macOS app / OS-level behavior agent-browser can't reach | **Native** 端 (Computer Use: osascript + screencapture)  | The only way to drive non-Chromium apps and OS chrome (local macOS only)   | [surfaces/native.md](surfaces/native.md)          |
+
+Rules of thumb:
+
+- **Don't open a browser for a backend change.** If a criterion is satisfied by a
+  command's output or a test passing, capture that as `text` — it's the strongest,
+  cheapest proof.
+- **Web vs Electron:** use **web** when the behavior is identical in a normal
+  browser against the app's dev server or deployed URL. Use **Electron** only when
+  the criterion depends on desktop-only behavior (native windows, IPC, the
+  packaged shell, OS integration) — that code path doesn't exist in a plain web
+  page. Switching conditions per 端: [surfaces/web.md](surfaces/web.md) and
+  [surfaces/electron.md](surfaces/electron.md).
+- **Auth is a gate, scoped to the 端.** If the state under test is behind a
+  login, authenticate that 端 first or every capture lands on the sign-in
+  page. Recipes and boundaries: [references/auth.md](references/auth.md).
+
+## Step 3 — Capture, then upload each artifact
+
+Capture each required `type` (recipes per surface in
+[references/evidence.md](references/evidence.md)), then upload one artifact per
+call, attached to the criterion's `checkResultId`:
+
+```bash
+# CHECK_RESULT_ID is the checkResultId for this criterion (from Step 1).
+# file artifact (screenshot / dom / video)
+lh verify evidence upload --check "$CHECK_RESULT_ID" --type screenshot \
+  --file ./proof/login.png --by agent-browser \
+  --desc "Logged-in home renders the workspace switcher"
+
+# inline text artifact (stdout / computed value) — no file
+lh verify evidence upload --check "$CHECK_RESULT_ID" --type text \
+  --content "$(your-cli command --json)" --by cli \
+  --desc "command reports success after the change"
+```
+
+`--by` records provenance: `agent-browser` | `cdp` | `cli` | `program`. Use
+`--file` for binaries, `--content` for text — exactly one of them.
+
+## Step 4 — Self-check coverage (do not skip)
+
+Before you declare the task done, prove every required artifact landed. For each
+criterion with `requiredEvidence`, list what you uploaded and confirm each `type`
+is present:
+
+```bash
+lh verify evidence list "$CHECK_RESULT_ID" --json
+```
+
+Coverage rule: for each required criterion, **every** `requiredEvidence[].type`
+must appear at least once in its evidence list. Report it explicitly, e.g.
+`coverage: 2/2 criteria, all required evidence uploaded`. If a type is missing, go
+back to Step 3 — a missing artifact holds the delivery at `uncertain` no matter
+how good the work is.
+
+## Worked example (web criterion, one screenshot)
+
+Plan item: _"Settings page shows the new 'Beta features' toggle"_,
+`requiredEvidence: [{ type: screenshot }]`, `required: true`.
+
+```bash
+OP="$LOBE_OPERATION_ID"
+
+# 1. discover: find this item's checkResultId
+lh verify plan state "$OP" --json              # → item id vci_settings, requires screenshot
+lh verify result list --operation "$OP" --json # → { checkItemId: vci_settings, id: vcr_77 }
+
+# 2. 端 = web (frontend change). Auth the session if needed (see references/auth.md).
+agent-browser --session app open "http://localhost:3000/settings"
+agent-browser --session app wait --text "Beta features"
+agent-browser --session app screenshot ./proof/settings-beta.png
+
+# 3. upload against the handle
+lh verify evidence upload --check vcr_77 --type screenshot \
+  --file ./proof/settings-beta.png --by agent-browser \
+  --desc "Settings page renders the new Beta features toggle"
+
+# 4. self-check
+lh verify evidence list vcr_77 --json # → one screenshot present → 1/1 covered
+```
+
+## Portability rules
+
+- **Prefer engine-level capture over OS capture.** `agent-browser screenshot` /
+  `dom` / `eval` render from the browser engine and run headless; `screencapture`
+  / osascript are macOS-only and break in the cloud.
+- **Upload as you go, not at the end.** Evidence uploaded mid-run is keyed to the
+  criterion immediately; a crash near the end doesn't lose your proof.
+- **Don't invent evidence.** Only capture the types a criterion declares.
+  Over-uploading noise makes the review harder, not easier.
+
+## Reference map
+
+```
+verify/
+├── SKILL.md                      # this router: the loop + 端 decision + example
+├── surfaces/                     # 不同端的验收方案 — pick one per criterion
+│   ├── cli.md                    # backend / CLI 端 → text evidence from command output
+│   ├── web.md                    # web 端 (frontend / full-stack) via agent-browser
+│   ├── electron.md               # desktop 端 (Electron) via agent-browser --cdp
+│   └── native.md                 # native macOS app / OS-level 端 via Computer Use
+└── references/                   # 跨端共享知识
+    ├── plan-format.md            # verify contract: plan shape + checkItemId↔checkResultId join
+    ├── evidence.md               # evidence type → capture recipe; upload; coverage; portability
+    ├── agent-browser.md          # full agent-browser CLI reference (any Chromium app)
+    ├── computer-use.md           # macOS Computer Use toolkit (osascript + screencapture)
+    ├── recording.md              # GIF / MP4 recording for time-based evidence
+    └── auth.md                   # portable auth: session/state/vault/cookie injection + boundaries
+```

--- a/packages/builtin-skills/src/verify/index.ts
+++ b/packages/builtin-skills/src/verify/index.ts
@@ -1,0 +1,54 @@
+import type { BuiltinSkill } from '@lobechat/types';
+
+import { toResourceMeta } from '../lobehub/helpers';
+import agentBrowser from './references/agent-browser.md';
+import auth from './references/auth.md';
+import computerUse from './references/computer-use.md';
+import evidence from './references/evidence.md';
+import planFormat from './references/plan-format.md';
+import recording from './references/recording.md';
+import content from './SKILL.md';
+import cli from './surfaces/cli.md';
+import electron from './surfaces/electron.md';
+import native from './surfaces/native.md';
+import web from './surfaces/web.md';
+
+export const VerifyIdentifier = 'verify';
+
+/**
+ * Portable builder-side verify skill. Unlike the repo-local `agent-testing`
+ * skill (macOS scripts + local report dirs + LobeHub-specific probes), this one
+ * depends only on the `lh` CLI and `agent-browser`, so any external builder
+ * (Claude Code / Codex) can run it from a task's working directory: discover the
+ * plan → pick a surface → capture evidence per criterion → `lh verify
+ * upload-evidence` → self-check coverage.
+ *
+ * The references carry the full operating manual (agent-browser CLI, web vs
+ * Electron decision + setup, auth recipes, capture recipes), with all
+ * LobeHub-only coupling generalized away.
+ *
+ * Resource keys keep the `.md` extension so a disk pull (`.claude/skills/verify/
+ * references/*.md`) maps 1:1 to real files and the in-SKILL relative links
+ * resolve.
+ */
+export const VerifySkill: BuiltinSkill = {
+  avatar: '✅',
+  content,
+  description:
+    'Self-evidence for task delivery verification — discover the verify plan, pick the right surface (CLI / web / desktop), drive it with agent-browser, get past auth, capture portable evidence per criterion, and upload each with `lh verify upload-evidence` so the delivery is judged on real proof.',
+  identifier: VerifyIdentifier,
+  name: 'Verify',
+  resources: toResourceMeta({
+    'references/agent-browser.md': agentBrowser,
+    'references/auth.md': auth,
+    'references/computer-use.md': computerUse,
+    'references/evidence.md': evidence,
+    'references/plan-format.md': planFormat,
+    'references/recording.md': recording,
+    'surfaces/cli.md': cli,
+    'surfaces/electron.md': electron,
+    'surfaces/native.md': native,
+    'surfaces/web.md': web,
+  }),
+  source: 'builtin',
+};

--- a/packages/builtin-skills/src/verify/references/agent-browser.md
+++ b/packages/builtin-skills/src/verify/references/agent-browser.md
@@ -1,0 +1,213 @@
+# agent-browser CLI reference
+
+Generic reference for the `agent-browser` CLI — automate Chromium-based apps
+(Electron, Chrome, web) via Chrome DevTools Protocol. This is the capture engine
+for all UI evidence in this skill. Per - 端 patterns live in
+[../surfaces/web.md](../surfaces/web.md) and
+[../surfaces/electron.md](../surfaces/electron.md); auth recipes in
+[auth.md](./auth.md).
+
+Install via `npm i -g agent-browser`, `brew install agent-browser`, or
+`cargo install agent-browser`. Run `agent-browser install` to download Chrome.
+Run `agent-browser upgrade` to update.
+
+## Core workflow
+
+Every browser automation follows this pattern:
+
+1. **Navigate**: `agent-browser open <url>`
+2. **Snapshot**: `agent-browser snapshot -i` (get element refs like `@e1`, `@e2`)
+3. **Interact**: use refs to click, fill, select
+4. **Re-snapshot**: after navigation or DOM changes, get fresh refs
+
+```bash
+agent-browser open https://example.com/form
+agent-browser snapshot -i
+# Output: @e1 [input type="email"], @e2 [input type="password"], @e3 [button] "Submit"
+
+agent-browser fill @e1 "user@example.com"
+agent-browser fill @e2 "password123"
+agent-browser click @e3
+agent-browser wait --load networkidle
+agent-browser snapshot -i # check result
+```
+
+## Command chaining
+
+```bash
+agent-browser open https://example.com && agent-browser wait --load networkidle && agent-browser snapshot -i
+```
+
+Use `&&` when you don't need to read intermediate output. Run commands separately
+when you need to parse output first (e.g. snapshot to discover refs, then interact).
+
+## Essential commands
+
+```bash
+# Navigation
+agent-browser open <url>              # Navigate (aliases: goto, navigate)
+agent-browser close                   # Close browser
+agent-browser close --all             # Close all active sessions
+
+# Snapshot
+agent-browser snapshot -i             # Interactive elements with refs (recommended)
+agent-browser snapshot -i -C          # Include contenteditable (rich text editors)
+agent-browser snapshot -s "#selector" # Scope to CSS selector
+
+# Interaction (use @refs from snapshot)
+agent-browser click @e1               # Click element
+agent-browser click @e1 --new-tab     # Click and open in new tab
+agent-browser fill @e2 "text"         # Clear and type text (NOT for contenteditable)
+agent-browser type @e2 "text"         # Type without clearing (use for chat inputs)
+agent-browser select @e1 "option"     # Select dropdown option
+agent-browser check @e1               # Check checkbox
+agent-browser press Enter             # Press key
+agent-browser keyboard type "text"    # Type at current focus (no selector)
+agent-browser scroll down 500         # Scroll page
+agent-browser scroll down 500 --selector "div.content"  # Scroll within container
+
+# Get information
+agent-browser get text @e1            # Get element text
+agent-browser get url                 # Get current URL
+agent-browser get title               # Get page title
+
+# Wait
+agent-browser wait @e1                # Wait for element
+agent-browser wait --load networkidle # Wait for network idle
+agent-browser wait --url "**/page"    # Wait for URL pattern
+agent-browser wait 2000               # Wait milliseconds
+agent-browser wait --text "Welcome"   # Wait for text to appear
+agent-browser wait --fn "!document.body.innerText.includes('Loading...')"  # Wait for condition
+agent-browser wait "#spinner" --state hidden  # Wait for element to disappear
+
+# Network (key for full-stack evidence)
+agent-browser network requests                 # Inspect tracked requests
+agent-browser network requests --type xhr,fetch  # Filter by resource type
+agent-browser network requests --method POST   # Filter by HTTP method
+agent-browser network har start                # Start HAR recording
+agent-browser network har stop ./capture.har   # Stop and save HAR file
+
+# Viewport & device emulation
+agent-browser set viewport 1920 1080          # Set viewport size (default 1280x720)
+agent-browser set viewport 1920 1080 2        # 2x retina
+agent-browser set device "iPhone 14"          # Emulate device (viewport + UA)
+
+# Capture (evidence!)
+agent-browser screenshot ./shot.png   # Screenshot to a path
+agent-browser screenshot --full       # Full page screenshot
+agent-browser screenshot --annotate   # Annotated screenshot with numbered element labels
+agent-browser pdf output.pdf          # Save as PDF
+
+# Dialogs (alert, confirm, prompt, beforeunload)
+agent-browser dialog accept           # Accept dialog
+agent-browser dialog accept "input"   # Accept prompt dialog with text
+agent-browser dialog dismiss          # Dismiss/cancel dialog
+agent-browser dialog status           # Check if dialog is open
+```
+
+## Batch execution
+
+```bash
+echo '[
+  ["open", "https://example.com"],
+  ["snapshot", "-i"],
+  ["click", "@e1"],
+  ["screenshot", "result.png"]
+]' | agent-browser batch --json
+```
+
+## Semantic locators (alternative to refs)
+
+```bash
+agent-browser find text "Sign In" click
+agent-browser find label "Email" fill "user@test.com"
+agent-browser find role button click --name "Submit"
+agent-browser find placeholder "Search" type "query"
+agent-browser find testid "submit-btn" click
+```
+
+## JavaScript evaluation (eval)
+
+Use eval to read app state, dump DOM/HTML, or assert computed values for `text` /
+`dom_snapshot` evidence.
+
+```bash
+# Simple expressions
+agent-browser eval 'document.title'
+
+# Complex JS: use --stdin with heredoc (RECOMMENDED — avoids shell quoting bugs)
+agent-browser eval --stdin << 'EVALEOF'
+JSON.stringify(
+  Array.from(document.querySelectorAll("img"))
+    .filter(i => !i.alt)
+    .map(i => ({ src: i.src.split("/").pop(), width: i.width }))
+)
+EVALEOF
+
+# Base64 encoding (avoids all shell escaping issues)
+agent-browser eval -b "$(echo -n 'document.title' | base64)"
+```
+
+> If the app under test exposes a global state object (a store, a debug handle),
+> eval is how you read it for assertion. Don't assume a specific global name —
+> discover it from the app you are verifying.
+
+## Ref lifecycle
+
+Refs (`@e1`, `@e2`, …) are invalidated when the page changes. Always re-snapshot
+after clicking links/buttons that navigate, form submissions, or dynamic content
+loading. After a hot-reload (HMR) during dev, refs also break — re-snapshot.
+
+## Annotated screenshots (vision mode)
+
+```bash
+agent-browser screenshot --annotate
+# Output includes the image path and a legend:
+#   [1] @e1 button "Submit"
+#   [2] @e2 link "Home"
+agent-browser click @e2 # click using ref from annotated screenshot
+```
+
+## Parallel sessions
+
+```bash
+agent-browser --session site1 open https://site-a.com
+agent-browser --session site2 open https://site-b.com
+agent-browser session list
+```
+
+A named `--session` auto-saves and restores cookies + localStorage, which is the
+basis for the auth recipes in [auth.md](./auth.md).
+
+## Connect to an existing browser / app
+
+```bash
+agent-browser --auto-connect snapshot # Auto-discover a running Chrome
+agent-browser --cdp 9222 snapshot     # Explicit CDP port (Electron apps, see ../surfaces/electron.md)
+```
+
+## Cloud providers & engine selection
+
+```bash
+agent-browser -p browserbase open example.com      # run against a cloud browser
+agent-browser --engine lightpanda open example.com # 10x faster, 10x less memory
+```
+
+Providers: `agentcore`, `browserbase`, `browserless`, `browseruse`, `kernel`.
+
+## Gotchas
+
+- **Daemon can get stuck** — if commands hang, `agent-browser close --all` or
+  `pkill -f agent-browser` to reset.
+- **HMR invalidates everything** — after code changes during dev, refs break;
+  re-snapshot or restart.
+- **`snapshot -i` doesn't find contenteditable** — use `snapshot -i -C` for rich
+  text editors; `fill` doesn't work on contenteditable, use `type`.
+- **Screenshots written to a path are easiest** — `agent-browser screenshot
+./proof/x.png` then upload that path; with no path they land in
+  `~/.agent-browser/tmp/screenshots/`.
+- **Dialogs block all commands** — if commands time out, check
+  `agent-browser dialog status`.
+- **Default timeout is 25s** — override with `AGENT_BROWSER_DEFAULT_TIMEOUT` (ms)
+  or use explicit waits.
+- **Shell quoting corrupts eval** — use `eval --stdin <<'EVALEOF'` for complex JS.

--- a/packages/builtin-skills/src/verify/references/auth.md
+++ b/packages/builtin-skills/src/verify/references/auth.md
@@ -1,0 +1,106 @@
+# Auth — getting past the login gate (portable)
+
+If the state a criterion checks is behind a login, you must authenticate the
+surface **before** capturing — otherwise every screenshot lands on the sign-in
+page and the evidence is worthless. Auth is a gate, but it is **surface-scoped**:
+authenticate only the surface you're proving on, not all of them.
+
+This file is portable to any Chromium-based app. It does not assume any specific
+auth provider, cookie name, or seed script — discover those from the app you are
+verifying.
+
+## Decision flow
+
+1. **Is the target behind auth at all?** Open it; if it renders the state under
+   test without a login wall, skip this file.
+2. **Pick the cheapest mechanism that works for the surface** (table below).
+3. **Verify the session is authenticated** before you start capturing: navigate
+   to a protected URL and assert you did _not_ get redirected to the sign-in page
+   (`agent-browser ... get url` should not be the login route).
+
+## Mechanisms (web / Chrome surface)
+
+`agent-browser` has four built-in ways to carry auth — prefer these over manual
+login, which is unreliable in headless/off-screen windows.
+
+```bash
+# 1. Named session — auto-saves & restores cookies + localStorage across commands
+agent-browser --session app open https://app.example.com/login
+# ... complete login once (or inject state) ...
+agent-browser --session app open https://app.example.com/dashboard # restored
+
+# 2. State file — export/import a Playwright-style storageState
+agent-browser state save auth.json
+agent-browser state load auth.json
+
+# 3. Auth vault — store credentials encrypted, replay the login form
+echo "$PASSWORD" | agent-browser auth save app --url https://app.example.com/login \
+  --username user --password-stdin
+agent-browser auth login app
+
+# 4. Persistent profile — a dedicated user-data dir that keeps you logged in
+agent-browser --profile ~/.app-profile open https://app.example.com/login
+```
+
+### Programmatic login (when the app has an email/password endpoint)
+
+If the app exposes a sign-in API, the most reliable headless path is to POST
+credentials, capture the returned cookies, and load them as a state file — no UI
+login needed. Shape (adapt the endpoint + cookie handling to the app):
+
+```bash
+# POST credentials, save the cookie jar, convert to a storageState file,
+# then load it into the agent-browser session and verify you're not on /signin.
+# (endpoint, field names, and cookie names are app-specific — inspect them first)
+```
+
+### Cookie-injection fallback (local dev only)
+
+When headless login isn't available, copy the session cookie out of a browser
+where you're already logged in and inject it:
+
+1. In a logged-in browser, open DevTools → **Network** tab → click any
+   same-origin request → **Request Headers** → copy the full `Cookie:` value.
+   It MUST come from a Network request, **not** `document.cookie` — HttpOnly
+   session cookies are invisible to `document.cookie`.
+2. Build a state file with those cookies and `agent-browser state load` it (or use
+   the session). Match the cookie **domain exactly** — e.g. `localhost`, not
+   `127.0.0.1`, and no leading dot for local dev.
+3. Verify: open a protected URL, confirm you're not redirected to sign-in.
+
+Common failure modes:
+
+| Symptom                                    | Cause                                                   | Fix                                            |
+| ------------------------------------------ | ------------------------------------------------------- | ---------------------------------------------- |
+| Still redirects to sign-in after injection | Copied from `document.cookie` → missed HttpOnly session | Re-copy from a Network request's headers       |
+| "no cookies found"                         | Pasted the wrong value                                  | Keep the raw `Cookie:` header verbatim         |
+| Works briefly then expires                 | Session token rotated (logged out elsewhere)            | Re-copy and re-inject                          |
+| Domain mismatch                            | Cookie domain must match the URL host exactly           | Use the literal host, no leading dot for local |
+
+## Desktop (Electron) {#desktop}
+
+A desktop app usually keeps its own persistent login state in its user-data
+directory: **log in once inside the app** and it survives restarts. No injection.
+Once connected over CDP, verify auth by reading the app's own signed-in state
+(eval its global / a protected element) rather than assuming.
+
+## CLI / backend surface
+
+For text evidence from a CLI, the CLI carries its own auth (an API key or a stored
+login). The `lh` CLI you use to upload evidence is already authed; a different
+product CLI under test uses its own mechanism — ensure it's configured before
+capturing its output.
+
+## Boundaries — read before touching cookies
+
+- **Local dev only.** These injection recipes are for local/dev targets. Don't
+  inject cookies on production: production cookies are typically
+  `Secure; HttpOnly` over HTTPS and must not be copied around.
+- **Treat any cookie/token as a secret.** Never paste it into shared logs, PR
+  descriptions, commit messages, or evidence you upload. Evidence artifacts are
+  visible to reviewers — a screenshot or text dump must not contain a live token.
+- **Injection is one-way.** It seeds the automation session; it does not flow back
+  into your own browser.
+- **Exercising the login UI itself needs a real browser flow.** If the criterion
+  is _about_ the sign-in screen, drive a real Chromium with remote debugging
+  rather than injecting past it.

--- a/packages/builtin-skills/src/verify/references/computer-use.md
+++ b/packages/builtin-skills/src/verify/references/computer-use.md
@@ -1,0 +1,129 @@
+# macOS Computer Use (osascript) toolkit
+
+`agent-browser` drives Chromium surfaces (web, Electron). For everything it can't
+reach, this is the escape hatch: **macOS Computer Use** via `osascript`
+(AppleScript) and `screencapture`. Use it to drive native apps, handle OS-level
+chrome, and read the screen when no CDP target exists.
+
+This is the native/OS counterpart of [agent-browser.md](./agent-browser.md). It is
+**macOS-only and not cloud-portable** — prefer CDP automation when both can reach
+the target; reach here only when CDP can't.
+
+## When you need it
+
+- **Native (non-Chromium) app under test** — the thing you're verifying is a native
+  macOS app agent-browser can't attach to. Drive it here (see
+  [../surfaces/native.md](../surfaces/native.md)).
+- **OS-level steps inside a web/Electron flow** — a native file picker, a system
+  permission prompt, a Save dialog, dock/menu-bar interaction, or a Spotlight/
+  app-switch the page can't script. Drop to Computer Use for that step, then return
+  to agent-browser.
+- **Reading the screen** when no DOM/CDP is available — screenshot + visual read, or
+  select-all-copy + `pbpaste`.
+
+## Core patterns
+
+### Activate an app
+
+```bash
+osascript -e 'tell application "AppName" to activate'
+```
+
+### Type / press keys
+
+```bash
+osascript -e 'tell application "System Events" to keystroke "Hello world"'
+osascript -e 'tell application "System Events" to key code 36' # Enter (hardware code, layout-independent)
+osascript -e 'tell application "System Events" to key code 48' # Tab
+osascript -e 'tell application "System Events" to key code 53' # Escape
+```
+
+### Paste from clipboard (fast; required for long / non-ASCII text)
+
+```bash
+osascript -e 'set the clipboard to "Your long or 中文 / emoji message"'
+osascript -e 'tell application "System Events" to keystroke "v" using command down'
+```
+
+### Keyboard shortcuts (modifiers)
+
+```bash
+osascript -e 'tell application "System Events" to keystroke "f" using command down'               # Cmd+F
+osascript -e 'tell application "System Events" to keystroke "k" using {command down, shift down}' # Cmd+Shift+K
+```
+
+### Click at screen coordinates
+
+```bash
+osascript -e 'tell application "System Events" to click at {500, 300}'
+```
+
+### Window position / size / id
+
+```bash
+osascript -e '
+tell application "System Events" to tell process "AppName"
+  get {position, size} of window 1
+end tell'
+```
+
+### Screenshot (OS-level)
+
+```bash
+screencapture /tmp/shot.png                 # full screen
+screencapture -i /tmp/shot.png              # interactive region select
+screencapture -l "$WINDOW_ID" /tmp/shot.png # specific window
+```
+
+Get a window id:
+
+```bash
+osascript -e 'tell application "System Events" to tell process "AppName" to get id of window 1'
+```
+
+### Read accessibility elements
+
+```bash
+osascript -e '
+tell application "System Events" to tell process "AppName"
+  get value of text field 1 of window 1
+end tell'
+```
+
+> `entire contents of window 1` dumps the whole UI tree but is **extremely slow**
+> on complex apps — prefer a screenshot + visual read, or the clipboard read below.
+
+### Read screen text via clipboard
+
+```bash
+osascript -e '
+tell application "System Events"
+  keystroke "a" using command down
+  keystroke "c" using command down
+end tell'
+sleep 0.5
+pbpaste
+```
+
+## Capturing as evidence
+
+- A `screencapture` PNG → `--type screenshot --by cli`.
+- For time-based native behavior, OS screen-record to MP4/GIF — see
+  [recording.md](./recording.md#path-2--os-screen-recording-macos-local-only).
+- Text read via `pbpaste` → `--type text --content "$(pbpaste)"`.
+
+## Gotchas
+
+- **Accessibility permission required.** First run prompts for it; grant the host
+  (Terminal / iTerm / the agent runner) in System Settings → Privacy & Security →
+  Accessibility, or every `System Events` call silently fails.
+- **`keystroke` is slow and mangles non-ASCII** — use clipboard paste (`Cmd+V`) for
+  anything long or for Chinese / emoji / special characters.
+- **`key code 36` is Enter** by hardware code, so it works regardless of keyboard
+  layout. Some apps send-on-Enter — use `Shift+Enter` for a newline within input.
+- **Add small `delay`/`sleep` between actions** — native apps need time to process
+  UI events; back-to-back commands drop.
+- **App name varies by locale** — e.g. `微信` vs `WeChat`; handle the name the
+  running OS uses.
+- **Not cloud-portable.** Everything here needs a real macOS session with a display.
+  Keep evidence CDP-based when the target is reachable that way.

--- a/packages/builtin-skills/src/verify/references/evidence.md
+++ b/packages/builtin-skills/src/verify/references/evidence.md
@@ -1,0 +1,101 @@
+# Capturing portable evidence
+
+The goal is an artifact a human (and the review agent) can open and believe. Pick
+the lightest capture that proves the criterion, and prefer engine-level capture so
+it works the same locally and headless/cloud. UI capture uses `agent-browser`
+([agent-browser.md](./agent-browser.md)) on the 端 you chose
+([web](../surfaces/web.md) / [electron](../surfaces/electron.md); backend/CLI →
+[cli](../surfaces/cli.md)).
+
+## Evidence type → how to capture
+
+### `screenshot` — UI state
+
+Screenshots via CDP (the browser engine) need no real display:
+
+```bash
+# web (named session)
+agent-browser --session app open "<url>"
+agent-browser --session app click @e1 # act, after snapshot -i to get refs
+agent-browser --session app screenshot ./proof/after.png
+
+# desktop (Electron, over CDP)
+agent-browser --cdp 9222 screenshot ./proof/desktop.png
+```
+
+Avoid macOS `screencapture` / osascript unless the criterion is explicitly
+native/local-only — they don't run in the cloud.
+
+### `dom_snapshot` — structure / content proof
+
+When the proof is "this element/text exists with these values", a DOM dump is
+smaller and more assertable than a pixel screenshot:
+
+```bash
+agent-browser --session app eval "document.querySelector('[data-testid=list]').outerHTML" > ./proof/list.html
+```
+
+Upload as `--type dom_snapshot --file ./proof/list.html`.
+
+### `text` — stdout, logs, computed values
+
+Backend / CLI behavior is best proven by the command output itself — upload inline,
+no file:
+
+```bash
+lh verify evidence upload --check "$CHECK_RESULT_ID" --type text \
+  --content "$(your-cli command --json)" \
+  --by cli --desc "command reports success after the change"
+```
+
+A network capture (HAR) or a request/response pair from a full-stack run also
+uploads as `text` (`--file ./proof/capture.har` or `--content`).
+
+### `transcript` — conversation / request log
+
+A saved agent conversation, request/response pair, or event log file:
+`--type transcript --file ./proof/run.jsonl`.
+
+### `gif` / `video` — behavior over time
+
+Required whenever a criterion asserts change over time (streaming output, a ticking
+timer, a loading→loaded transition, an animation, a multi-step flow) — a static
+screenshot cannot prove these. Record a clip and upload `--type gif` / `--type
+video --file …`. Full recipes (portable CDP frame-sequence → MP4/GIF, OS screen
+recording, GIF-vs-MP4): [recording.md](./recording.md).
+
+## Provenance (`--by`)
+
+Tag how the artifact was produced so the reviewer can weigh it:
+
+- `agent-browser` — captured through agent-browser (screenshots, DOM, eval)
+- `cdp` — captured directly via Chrome DevTools Protocol
+- `cli` — command stdout / computed text
+- `program` — produced by a script or test you ran
+
+## Headless / cloud portability
+
+The decisive constraint per 端 is **how a screenshot is captured**: engine-level
+capture (CDP) needs no display; OS-level capture is macOS-only.
+
+| 端         | macOS (local) | Linux / cloud (headless)                                        | Screenshot mechanism                             |
+| ---------- | ------------- | --------------------------------------------------------------- | ------------------------------------------------ |
+| CLI / text | ✅            | ✅                                                              | n/a — text output                                |
+| Web        | ✅            | ✅ headless Chromium works natively                             | CDP — no display needed                          |
+| Electron   | ✅            | ⚠️ runs but needs a display server: wrap launch with `xvfb-run` | CDP works under Xvfb; OS-window capture does NOT |
+
+Checklist:
+
+- ✅ `agent-browser screenshot` / `eval` (DOM, console) — engine-level, headless-safe
+- ✅ `--type text --content …` — pure text, always works
+- ❌ `screencapture`, osascript, native-app screen recording — macOS-only, not
+  cloud-safe
+
+When a run must stay cloud-portable, prefer CDP-based evidence over OS-level
+capture wherever both exist.
+
+## Don't leak secrets
+
+Evidence is visible to reviewers. Never capture a screenshot or text dump that
+contains a live token, cookie, password, or other secret — see
+[auth.md](./auth.md#boundaries--read-before-touching-cookies).

--- a/packages/builtin-skills/src/verify/references/plan-format.md
+++ b/packages/builtin-skills/src/verify/references/plan-format.md
@@ -1,0 +1,84 @@
+# Verify plan — machine-readable format
+
+The plan is the contract between the task config and you, the builder. It is
+exposed through two `lh` reads keyed off your operation id. This file documents
+their shapes and how to join them into a per-criterion worklist.
+
+## (a) `lh verify plan state $LOBE_OPERATION_ID --json`
+
+Returns the run's verify state plus the **frozen plan** (immutable once
+confirmed):
+
+```jsonc
+{
+  "verifyStatus": "planned",
+  "verifyPlanConfirmedAt": "2026-06-21T07:00:00.000Z",
+  "verifyPlan": [
+    {
+      "id": "vci_a1b2c3", // checkItemId — the stable join key
+      "index": 0,
+      "title": "Login flow reaches the workspace",
+      "description": "After sign-in the home renders the workspace switcher",
+      "required": true, // true ⇒ blocks delivery if unproven
+      "verifierType": "llm",
+      "verifierConfig": {
+        "requiredEvidence": [
+          // the artifacts you MUST capture
+          { "type": "screenshot", "hint": "logged-in home with workspace switcher" },
+        ],
+      },
+    },
+  ],
+}
+```
+
+- `verifyPlan[].id` is the **checkItemId** — never use `index` as a key, it is
+  display ordering only.
+- `verifyPlan[].verifierConfig.requiredEvidence` is the list of `{ type, hint }`
+  you must satisfy. Absent or empty ⇒ this criterion is judged on text alone.
+- `hint` is guidance for what the artifact should show — it is not validated, but
+  follow it so the reviewer can recognize the proof.
+
+## (b) `lh verify result list --operation $LOBE_OPERATION_ID --json`
+
+Returns one pending **check result** row per plan item — these carry the upload
+handle:
+
+```jsonc
+[
+  {
+    "id": "vcr_x9y8z7", // checkResultId — pass this to upload-evidence
+    "checkItemId": "vci_a1b2c3", // joins back to verifyPlan[].id
+    "checkItemTitle": "Login flow reaches the workspace",
+    "required": true,
+    "status": "pending",
+  },
+]
+```
+
+If this returns rows with `status: "pending"`, the handles are ready. If it is
+empty, the run did not pre-build result handles — surface that rather than
+guessing an id.
+
+## The join → your worklist
+
+Join (a) and (b) on `checkItemId` to get, per criterion, _what to prove_ and
+_where to attach it_:
+
+| checkItemId  | title                            | requiredEvidence | checkResultId |
+| ------------ | -------------------------------- | ---------------- | ------------- |
+| `vci_a1b2c3` | Login flow reaches the workspace | `screenshot`     | `vcr_x9y8z7`  |
+
+For each row with non-empty `requiredEvidence`: capture each type, then
+`lh verify evidence upload --check "$CHECK_RESULT_ID" --type TYPE …`.
+
+To build the worklist, dump both reads and join them in your runtime:
+
+```bash
+OP="$LOBE_OPERATION_ID"
+lh verify plan state "$OP" --json > /tmp/plan.json
+lh verify result list --operation "$OP" --json > /tmp/results.json
+# join on the id fields:
+#   plan:   verifyPlan[].id          == checkItemId
+#   result: [].checkItemId → [].id   == checkResultId
+```

--- a/packages/builtin-skills/src/verify/references/recording.md
+++ b/packages/builtin-skills/src/verify/references/recording.md
@@ -1,0 +1,97 @@
+# Recording — GIF & MP4 evidence
+
+When a criterion asserts behavior **over time** — streaming output, a loading→
+loaded transition, a ticking timer, an animation, a multi-step flow — a static
+screenshot can't prove it. Record a clip and upload it as `gif` or `video`
+evidence. This is a first-class capability, not a nice-to-have: time-based claims
+are unverifiable without it.
+
+Two ways to record. **Prefer the CDP frame-sequence path** — it's headless/
+cloud-portable; OS screen recording is macOS-only.
+
+## Path 1 — CDP frame sequence → MP4/GIF (portable, recommended)
+
+Capture a sequence of `agent-browser` screenshots while the behavior happens, then
+assemble with `ffmpeg`. Works on web (`--session`) and Electron (`--cdp`), and runs
+headless (no display, cloud-safe) because frames come from the browser engine, not
+the OS screen. It also sidesteps the corrupt-MP4-on-kill problem that ffmpeg screen
+capture has.
+
+```bash
+# 1. capture frames while driving the scenario
+FRAMES=$(mktemp -d)
+TARGET="--session app" # or "--cdp 9222" for Electron
+i=0
+# start your scenario in the background or in another step, then:
+while [ $i -lt 40 ]; do # ~20s at 0.5s/frame
+  printf -v n "%06d" $i
+  agent-browser $TARGET screenshot "$FRAMES/frame_$n.png"
+  i=$((i + 1))
+  sleep 0.5
+done
+
+# 2a. assemble an MP4 (~2 fps)
+ffmpeg -y -framerate 2 -i "$FRAMES/frame_%06d.png" \
+  -c:v libx264 -crf 23 -pix_fmt yuv420p ./proof/flow.mp4
+
+# 2b. or a GIF (good palette = legible inline)
+ffmpeg -y -framerate 2 -i "$FRAMES/frame_%06d.png" \
+  -vf "scale=900:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" \
+  ./proof/flow.gif
+
+rm -rf "$FRAMES"
+```
+
+Tune the frame interval to the behavior: faster (`0.25s`) for quick animations,
+slower (`1s`) for long flows. Keep the clip scoped — a few seconds of the actual
+behavior, not the whole session.
+
+## Path 2 — OS screen recording (macOS, local only)
+
+When you must capture the real screen — native windows, OS chrome, a non-Chromium
+app driven via [computer-use.md](./computer-use.md) — record at the OS level. This
+is **macOS-only and not cloud-portable**.
+
+```bash
+# built-in: record the screen to MP4 (Ctrl-C / kill to stop; or -V N for N seconds)
+screencapture -v ./proof/demo.mp4
+screencapture -V 15 ./proof/demo.mp4 # fixed 15s capture
+
+# ffmpeg avfoundation (list devices first: ffmpeg -f avfoundation -list_devices true -i "")
+ffmpeg -y -f avfoundation -framerate 30 -i "1:none" -t 15 \
+  -c:v libx264 -crf 23 -pix_fmt yuv420p ./proof/demo.mp4
+```
+
+Convert an MP4 to GIF when you need an inline-renderable artifact:
+
+```bash
+ffmpeg -y -i ./proof/demo.mp4 \
+  -vf "fps=8,scale=900:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" \
+  ./proof/demo.gif
+```
+
+## GIF vs MP4 — which to upload
+
+- **GIF** — short (≤ \~10s) UI behavior that should render inline in the report
+  (loading state, a toast, a streamed line appearing). Renders without a player.
+- **MP4** — longer demos or multi-step flows where file size matters and a player
+  is acceptable. Larger, but better quality per byte.
+
+## Upload
+
+```bash
+lh verify evidence upload --check "$CHECK_RESULT_ID" --type gif \
+  --file ./proof/flow.gif --by agent-browser \
+  --desc "Response streams in token-by-token after send"
+
+lh verify evidence upload --check "$CHECK_RESULT_ID" --type video \
+  --file ./proof/demo.mp4 --by cdp --desc "End-to-end import flow completes"
+```
+
+## Prerequisites & portability
+
+- **ffmpeg** — `brew install ffmpeg` (or `bun add -g ffmpeg-static`). Needed for
+  both paths' assembly/conversion.
+- **agent-browser** — for the CDP frame path ([agent-browser.md](./agent-browser.md)).
+- Path 1 is headless/cloud-safe; Path 2 is macOS-only — see
+  [evidence.md](./evidence.md#headless--cloud-portability).

--- a/packages/builtin-skills/src/verify/surfaces/cli.md
+++ b/packages/builtin-skills/src/verify/surfaces/cli.md
@@ -1,0 +1,54 @@
+# CLI /backend 端验收
+
+The default surface for backend, CLI, library, and data-logic changes. The proof
+is the command's own output — text, not pixels. This is the cheapest and strongest
+evidence: a passing assertion or a correct JSON result is harder to fake than a
+screenshot, and it runs anywhere (no browser, no display).
+
+Use this surface when your change is verifiable by running something and reading
+what it prints. Escalate to [web.md](./web.md) or [electron.md](./electron.md)
+only when the criterion is actually about rendered UI.
+
+## How to verify
+
+1. Run the command, test, or query that exercises the change. Prefer a machine
+   output mode (`--json`, a structured dump) so the proof is assertable, not prose.
+2. Capture the output and upload it as `text` evidence — inline with `--content`
+   for short output, or `--file` for a larger dump.
+
+```bash
+# CHECK_RESULT_ID is the criterion's checkResultId (from discovery).
+# short result → inline
+lh verify evidence upload --check "$CHECK_RESULT_ID" --type text \
+  --content "$(your-cli command --json)" \
+  --by cli --desc "command reports the new field after the change"
+
+# larger output (test log, full dump) → file
+your-cli command --json > ./proof/result.json
+lh verify evidence upload --check "$CHECK_RESULT_ID" --type text \
+  --file ./proof/result.json --by cli --desc "full result set"
+
+# a test run is itself proof
+your-test-runner path/to/spec > ./proof/test.log 2>&1
+lh verify evidence upload --check "$CHECK_RESULT_ID" --type text \
+  --file ./proof/test.log --by program --desc "regression spec passes"
+```
+
+Provenance: `cli` for command stdout, `program` for a script/test you ran. See
+[../references/evidence.md](../references/evidence.md) for the evidence contract.
+
+## Auth
+
+The `lh` CLI you upload with is already authed. A _different_ product CLI under
+test carries its own auth (API key or stored login) — configure it before
+capturing its output. See [../references/auth.md](../references/auth.md#cli--backend-surface).
+
+## Boundaries
+
+- **Don't open a browser for a backend change.** If the criterion is satisfied by
+  output, a screenshot adds noise, not proof.
+- **Make the assertion legible.** Upload the specific lines/fields that prove the
+  criterion (or describe them in `--desc`), not a 10k-line log the reviewer must
+  scan.
+- **Never upload secrets.** Strip tokens/keys from output before uploading — see
+  [../references/auth.md](../references/auth.md#boundaries--read-before-touching-cookies).

--- a/packages/builtin-skills/src/verify/surfaces/electron.md
+++ b/packages/builtin-skills/src/verify/surfaces/electron.md
@@ -1,0 +1,99 @@
+# 桌面端 (Electron) 验收
+
+Use this surface for **desktop-only behavior** — native windows, IPC / main-process
+code, tray/menu, auto-update, OS integration, or a packaged-only path. That code
+doesn't exist in a plain web page, so [web.md](./web.md) can't prove it. You drive
+the running app's renderer over CDP with `agent-browser`
+([../references/agent-browser.md](../references/agent-browser.md)).
+
+For a change that behaves identically in a browser, prefer [web.md](./web.md) —
+it's lighter and cloud-portable. Use Electron only when the criterion calls out
+the desktop shell.
+
+## Setup
+
+1. Start the desktop app in dev/debug mode with a CDP port open (commonly 9222).
+   How you start it is app-specific (its own dev command); the requirement is a
+   reachable CDP endpoint.
+2. Connect agent-browser to that port:
+
+```bash
+agent-browser --cdp 9222 snapshot -i
+agent-browser --cdp 9222 get url # sanity-check you attached to the app
+agent-browser --cdp 9222 screenshot ./proof/desktop-state.png
+```
+
+3. Auth: a desktop app usually keeps its own persistent login state in its
+   user-data dir — log in once in the app and it survives restarts; no injection
+   needed (see [../references/auth.md](../references/auth.md#desktop)).
+
+## Reading app state
+
+If the app exposes a global state handle, eval it to assert behavior (discover the
+actual global name from the app — don't assume one):
+
+```bash
+agent-browser --cdp 9222 eval --stdin << 'EVALEOF'
+(function () {
+  // example shape — replace with the app's real global / selectors
+  var s = window.__APP_STATE__ && window.__APP_STATE__();
+  return JSON.stringify({ route: location.hash || location.pathname, ready: !!s });
+})()
+EVALEOF
+```
+
+## Capturing console errors during a run
+
+```bash
+# install an interceptor before exercising the feature
+agent-browser --cdp 9222 eval --stdin << 'EVALEOF'
+(function () {
+  window.__ERRORS__ = [];
+  var orig = console.error;
+  console.error = function () {
+    window.__ERRORS__.push(Array.from(arguments).map(String).join(' '));
+    orig.apply(console, arguments);
+  };
+  return 'installed';
+})()
+EVALEOF
+# ... drive the feature ...
+agent-browser --cdp 9222 eval "JSON.stringify(window.__ERRORS__)" # → text evidence
+```
+
+## Gotchas
+
+- **Dev builds often auto-open DevTools, which hijacks the CDP target.** Symptom:
+  `get url` returns a `devtools://…` URL instead of the app. Fix: close the
+  DevTools target and reconnect:
+
+  ```bash
+  DT_ID=$(curl -s http://localhost:9222/json/list | python3 -c "import json,sys; ts=json.load(sys.stdin); print(next(t['id'] for t in ts if t['type']=='page' and t['url'].startswith('devtools://')))")
+  curl -s "http://localhost:9222/json/close/$DT_ID" > /dev/null
+  agent-browser close --all && agent-browser --cdp 9222 get url
+  ```
+
+- **Clean up all processes when done.** `pkill -f "Electron"` only kills the main
+  process; helper processes (GPU, renderer, network) survive. Prefer the app's own
+  stop command or kill by the project's electron binary path.
+
+- **Don't resize the window after load** — many apps trigger a full reload on
+  resize, invalidating refs and state.
+
+## Time-based behavior & OS-level steps
+
+- **Behavior over time** needs a clip — record CDP frames into MP4/GIF:
+  [../references/recording.md](../references/recording.md).
+- **Native chrome around the app** (file pickers, system dialogs, menu-bar/dock,
+  permission prompts) lives outside the renderer — drive it with Computer Use:
+  [../references/computer-use.md](../references/computer-use.md).
+
+## Boundaries — headless / cloud
+
+Electron runs on Linux but has no true headless mode — it needs a display server.
+In a headless/cloud environment, wrap the launch with `xvfb-run` (virtual
+framebuffer). Everything CDP-based keeps working under Xvfb (connection, snapshots,
+eval, `agent-browser screenshot` — captured from the renderer, not the OS screen).
+What does NOT work: OS-window capture (`screencapture`), osascript, and native
+screen recording — all macOS-only. Keep evidence CDP-based to stay cloud-portable
+(see [../references/evidence.md](../references/evidence.md#headless--cloud-portability)).

--- a/packages/builtin-skills/src/verify/surfaces/native.md
+++ b/packages/builtin-skills/src/verify/surfaces/native.md
@@ -1,0 +1,55 @@
+# 原生 macOS 应用端验收 (Computer Use)
+
+Use this 端 when the thing under test is a **native macOS app** that `agent-browser`
+can't drive — anything not Chromium-based: a native desktop app, a chat client you
+verify against (Slack/WeChat/…), Finder/system UI, or any OS-level behavior. You
+drive it with macOS Computer Use (osascript + screencapture) — the toolkit is in
+[../references/computer-use.md](../references/computer-use.md).
+
+Prefer the other 端 when they can reach the target: [web.md](./web.md) /
+[electron.md](./electron.md) for Chromium UIs, [cli.md](./cli.md) for backend.
+Native is the **local-macOS escape hatch** — it is not cloud-portable (needs a real
+display + Accessibility permission), so reach for it only when CDP can't.
+
+## How to verify
+
+1. Activate the app and navigate to the state under test (keystrokes / shortcuts /
+   clicks — see the toolkit).
+2. Drive the action that exercises your change.
+3. Capture proof: a `screencapture` PNG, a screen recording for time-based behavior
+   ([../references/recording.md](../references/recording.md#path-2--os-screen-recording-macos-local-only)),
+   or screen text via select-all-copy + `pbpaste`.
+
+```bash
+APP="YourApp"
+osascript -e "tell application \"$APP\" to activate"
+sleep 1
+# ... navigate + act via osascript (see computer-use.md) ...
+sleep 2 # let the result settle
+screencapture -l "$(osascript -e "tell application \"System Events\" to tell process \"$APP\" to get id of window 1")" ./proof/native-result.png
+```
+
+Upload as evidence (provenance `cli`, since osascript/screencapture are
+shell-driven):
+
+```bash
+lh verify evidence upload --check "$CHECK_RESULT_ID" --type screenshot \
+  --file ./proof/native-result.png --by cli \
+  --desc "Native app shows the expected state after the change"
+```
+
+## Mid-flow use from another 端
+
+You don't have to commit the whole run to this 端. A web or Electron flow can drop
+into Computer Use for a single OS-level step it can't script — a native file picker,
+a system permission prompt, a Save dialog — then hand control back to agent-browser.
+Capture the proof on whichever 端 owns the criterion.
+
+## Boundaries
+
+- **macOS + display only.** No headless/cloud — see
+  [../references/computer-use.md](../references/computer-use.md#gotchas).
+- **Accessibility permission is mandatory** or every `System Events` call silently
+  no-ops. Grant it to the host once.
+- **Prefer CDP when reachable.** A Chromium target driven over CDP is more robust
+  and portable than coordinate clicks; use native only when there's no CDP path.

--- a/packages/builtin-skills/src/verify/surfaces/web.md
+++ b/packages/builtin-skills/src/verify/surfaces/web.md
@@ -1,0 +1,69 @@
+# Web 端验收
+
+Default surface for frontend and full-stack changes — the browser is the one place
+network requests and rendered UI are observable together, so you can assert both
+sides of a contract in one run. Driven by `agent-browser`
+([../references/agent-browser.md](../references/agent-browser.md)).
+
+Use web when the behavior is the same in a normal browser against the app's dev
+server or a deployed URL. If the criterion depends on the desktop shell, use
+[electron.md](./electron.md) instead; if it's backend/CLI, use [cli.md](./cli.md).
+
+## Setup
+
+1. Have the app reachable at a URL: a local dev server you started (e.g.
+   `http://localhost:<port>`), or a deployed/preview URL the task targets.
+2. If the state under test is behind login, authenticate the agent-browser
+   session first — see [../references/auth.md](../references/auth.md). Use a named
+   `--session` so cookies persist across commands.
+
+```bash
+SESSION=app
+agent-browser --session $SESSION open "http://localhost:3000/"
+agent-browser --session $SESSION snapshot -i
+# interact via refs, then capture
+agent-browser --session $SESSION screenshot ./proof/state.png
+```
+
+Use the authenticated session as the evidence source. Do **not** use a separate
+ordinary-Chrome screenshot as proof — it doesn't prove the automated session
+reached the state. Ordinary Chrome is only a cookie source for auth fallback.
+
+## Full-stack — assert both layers {#web-full-stack}
+
+When the criterion spans a new/changed API and the UI consuming it, capture both
+the network exchange and the rendered result:
+
+```bash
+SESSION=app
+agent-browser --session $SESSION network har start
+# ... drive the scenario that triggers the API ...
+agent-browser --session $SESSION network requests --type xhr,fetch # inspect calls
+agent-browser --session $SESSION network har stop ./proof/capture.har
+agent-browser --session $SESSION screenshot ./proof/result.png
+```
+
+Upload the screenshot (`--type screenshot`) and the network proof (the HAR as
+`--type text --file ./proof/capture.har`, or a focused request/response as
+`--type text --content …`). Asserting only one layer leaves the contract half-proven.
+
+## Local frontend against a remote backend
+
+If you can only run the frontend locally but the backend is remote, drive the
+frontend URL the same way — just remember the backend is not your branch, so it
+proves frontend behavior, not backend changes.
+
+## Time-based behavior & OS-level steps
+
+- **Behavior over time** (streaming, loading→loaded, animation) needs a clip, not a
+  screenshot — record it: [../references/recording.md](../references/recording.md).
+- **A native step the page can't script** (file picker, OS permission prompt, Save
+  dialog) — drop to Computer Use for that step, then return:
+  [../references/computer-use.md](../references/computer-use.md).
+
+## Boundaries
+
+- **Headless / cloud:** web is cloud-native — headless Chromium and CDP screenshots
+  work without a display. Prefer CDP capture over OS-level capture (see
+  [../references/evidence.md](../references/evidence.md#headless--cloud-portability)).
+- **HMR breaks refs.** After a hot reload during dev, re-snapshot before interacting.


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Part of LOBE-10641 (Block 2 · builder execution-time verify) — implements sub-task 2.2 LOBE-10619 (通用化 agent-testing → portable verify skill).

#### 🔀 Description of Change

Adds a **portable verify skill** under `@lobechat/builtin-skills` so an external builder (Claude Code / Codex) running a task can self-certify its delivery with real evidence instead of just claiming it works.

The loop the skill drives:

```
discover plan → pick the 端 (surface) → capture evidence per criterion → upload via `lh verify upload-evidence` → self-check coverage
```

**What's in it** (`packages/builtin-skills/src/verify/`):

- `SKILL.md` — the router: the verify loop, a per-**端** decision matrix (CLI / web / electron / native), and a worked example.
- `surfaces/` — verification approach per 端: `cli.md` (backend → text evidence), `web.md` (frontend / full-stack), `electron.md` (desktop via CDP), `native.md` (native macOS app / OS-level via Computer Use).
- `references/` — cross-端 shared knowledge: `plan-format.md` (the machine-readable plan contract + `checkItemId↔checkResultId` join), `evidence.md` (evidence types, upload contract, coverage, headless/cloud portability), `agent-browser.md` (full CLI reference), `computer-use.md` (macOS osascript/screencapture toolkit), `recording.md` (GIF/MP4), `auth.md` (portable auth recipes + boundaries).

Distilled from the repo-local `agent-testing` skill with **all LobeHub coupling generalized away** (no `init-dev-env`/`setup-auth`/`app-probe` scripts, no `__LOBE_STORES`, no better-auth specifics).

**Deliberately kept out of the application layer:** `VerifySkill` is exported as a named symbol (for a future `lh verify init` to pull to disk) but is **not** added to the `builtinSkills` runtime array, so it never leaks into the homogeneous agent runtime, `agentDocumentVfs`, or the tool picker. The only non-skill change is a 10-line edit to `packages/builtin-skills/src/index.ts` (the named export).

This is the static, reusable HOW. The per-run dynamic WHAT (resolved criteria + `checkResultId` handles injected into the builder prompt) and the `lh verify init` disk-pull distribution are follow-ups (sub-tasks 2.3 / 2.4 / init command).

#### 🧪 How to Test

- [x] Tested locally
- [x] No tests needed

No runtime behavior change — the skill is markdown/metadata not wired into any app-layer consumer. Verified the existing builtin-skill enumeration paths still pass:

```bash
bunx vitest run --silent='passed-only' \
  'apps/server/src/services/agentDocumentVfs/mounts/skills/providers/ProviderSkillsReadonly.test.ts' \
  'apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts' \
  'src/store/tool/slices/builtin/selectors.test.ts'
```

Also validated all intra-skill cross-links + heading anchors resolve.

#### 📝 Additional Information

Markdown placeholders use shell-variable form (`"$CHECK_RESULT_ID"`, `"$LOBE_OPERATION_ID"`) rather than `<angle-bracket>` tokens, because the repo's remark/prettier lint hook treats `<...>` as HTML and reorders command flags inside fenced code blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)