### PR TITLE
chore: clean up LOBE-10066 marker comments (2026-06-22)

### DIFF
--- a/packages/model-runtime/src/core/contextBuilders/google.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.ts
@@ -446,7 +446,7 @@ export const sanitizeGeminiSchema = (schema: any): any => {
 
   // Recursively sanitize items (for array types). A node carrying `items` is an
   // array node; backfill a missing `type` so Gemini's predicate validator
-  // (`$type == Type.ARRAY`) accepts it. See LOBE-10066.
+  // (`$type == Type.ARRAY`) accepts it. See https://linear.app/lobehub/issue/LOBE-10066
   if ('items' in sanitized) {
     sanitized.items = sanitizeGeminiSchema(sanitized.items);
     if (sanitized.type === undefined) sanitized.type = 'array';

--- a/packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.test.ts
@@ -15,7 +15,7 @@ describe('normalizeToolJsonSchema', () => {
     expect(normalizeToolJsonSchema('foo')).toBe('foo');
   });
 
-  // LOBE-10066: deepseek variant — array property with `items: true`
+  // DeepSeek variant: array property with `items: true` causes upstream rejection
   it('rewrites `items: true` to an empty object schema', () => {
     const result = normalizeToolJsonSchema({
       properties: {
@@ -28,7 +28,7 @@ describe('normalizeToolJsonSchema', () => {
     expect(result.properties.sourceIds.type).toBe('array');
   });
 
-  // LOBE-10066: gemini variant — array property carrying `items` but missing `type`
+  // Gemini variant: array property carrying `items` but missing `type` causes upstream rejection
   it('backfills `type: array` on a node that carries `items` without a type', () => {
     const result = normalizeToolJsonSchema({
       properties: {

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -133,7 +133,7 @@ describe('LobeOpenAICompatibleFactory', () => {
       expect(result).toBeInstanceOf(Response);
     });
 
-    // LOBE-10066: MCP tool schemas with `items: true` or array props missing
+    // MCP tool schemas with `items: true` or array props missing `type`
     // `type` must be normalized before reaching the upstream validator.
     it('should normalize tool parameter schemas before sending to upstream', async () => {
       (instance['client'].chat.completions.create as Mock).mockResolvedValue(

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -511,7 +511,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         // Normalize tool parameter schemas before they fan out to the
         // Chat-Completions / Responses paths. User MCP tools may emit boolean
         // sub-schemas (`items: true`) or array properties missing `type`, which
-        // upstream validators (OpenAI/DeepSeek, Gemini) reject. See LOBE-10066.
+        // upstream validators (OpenAI/DeepSeek, Gemini) reject. See https://linear.app/lobehub/issue/LOBE-10066
         if (payload.tools) payload.tools = normalizeToolsParameters(payload.tools as any) as any;
 
         let processedPayload: any = payload;


### PR DESCRIPTION
## Summary

Daily automatic scan and cleanup of `LOBE-XXX` format comments in the codebase.

## Changes

4 files changed with 5 replacements:

| File | Change |
|------|--------|
| `packages/model-runtime/src/core/openaiCompatibleFactory/index.ts` | Replaced `See LOBE-10066` with full Linear issue URL |
| `packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts` | Replaced `LOBE-10066:` prefix marker with descriptive comment |
| `packages/model-runtime/src/core/contextBuilders/google.ts` | Replaced `See LOBE-10066` with full Linear issue URL |
| `packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.test.ts` | Replaced 2 `LOBE-10066:` prefix markers with descriptive comments |

## Context

All references were to [LOBE-10066](https://linear.app/lobehub/issue/LOBE-10066) — a resolved issue about normalizing MCP tool array `items` schemas to prevent upstream validation errors from DeepSeek (`items: true` rejection) and Gemini (missing `type: ARRAY`).

Generated on 2026-06-22