### PR TITLE
🐛 fix: drop legacy task template recommendations

### DIFF
--- a/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.test.ts
+++ b/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.test.ts
@@ -314,6 +314,25 @@ describe('useDailyBriefRecommendationsUI', () => {
     expect(mockUseFetchLobehubConnectorConnections).toHaveBeenCalledWith(false);
   });
 
+  it('drops recommendations with unknown connector identifiers', () => {
+    const templateWithUnknownConnector = {
+      ...template,
+      connectors: [{ identifier: 'nonexistent-x', required: true, source: 'lobehub' }],
+    };
+    mockUseSWR.mockReturnValue({
+      data: { data: [templateWithUnknownConnector], success: true },
+      isLoading: false,
+      isValidating: false,
+      mutate: mockMutate,
+    });
+
+    const { result } = renderHook(() => useDailyBriefRecommendationsUI());
+
+    expect(result.current).toEqual({ mode: 'hidden' });
+    expect(mockUseFetchUserComposioConnections).toHaveBeenCalledWith(false);
+    expect(mockUseFetchLobehubConnectorConnections).toHaveBeenCalledWith(false);
+  });
+
   it('normalizes cached rows before removing a card', () => {
     mockUseSWR.mockReturnValue({
       data: { data: [template, null], success: true },

--- a/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.test.ts
+++ b/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.test.ts
@@ -295,6 +295,25 @@ describe('useDailyBriefRecommendationsUI', () => {
     expect(mockUseFetchLobehubConnectorConnections).toHaveBeenCalledWith(false);
   });
 
+  it('drops recommendations with malformed connector entries', () => {
+    const templateWithMalformedConnectors = {
+      ...template,
+      connectors: [null],
+    };
+    mockUseSWR.mockReturnValue({
+      data: { data: [templateWithMalformedConnectors], success: true },
+      isLoading: false,
+      isValidating: false,
+      mutate: mockMutate,
+    });
+
+    const { result } = renderHook(() => useDailyBriefRecommendationsUI());
+
+    expect(result.current).toEqual({ mode: 'hidden' });
+    expect(mockUseFetchUserComposioConnections).toHaveBeenCalledWith(false);
+    expect(mockUseFetchLobehubConnectorConnections).toHaveBeenCalledWith(false);
+  });
+
   it('drops legacy recommendations from pre-Market task-template servers', () => {
     const legacyServerTemplate = {
       category: 'engineering',

--- a/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.test.ts
+++ b/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.test.ts
@@ -270,6 +270,53 @@ describe('useDailyBriefRecommendationsUI', () => {
     });
   });
 
+  it('drops recommendations that are missing connectors', () => {
+    const templateWithoutConnectors = {
+      category: 'engineering',
+      cronPattern: '0 9 * * *',
+      description: 'Description',
+      id: 102,
+      identifier: 'legacy-daily-engineering',
+      instruction: 'Instruction',
+      interests: ['coding'],
+      title: 'Legacy title',
+    } satisfies Omit<TaskTemplate, 'connectors'>;
+    mockUseSWR.mockReturnValue({
+      data: { data: [templateWithoutConnectors], success: true },
+      isLoading: false,
+      isValidating: false,
+      mutate: mockMutate,
+    });
+
+    const { result } = renderHook(() => useDailyBriefRecommendationsUI());
+
+    expect(result.current).toEqual({ mode: 'hidden' });
+    expect(mockUseFetchUserComposioConnections).toHaveBeenCalledWith(false);
+    expect(mockUseFetchLobehubConnectorConnections).toHaveBeenCalledWith(false);
+  });
+
+  it('drops legacy recommendations from pre-Market task-template servers', () => {
+    const legacyServerTemplate = {
+      category: 'engineering',
+      cronPattern: '0 9 * * *',
+      id: 'oss-intel-daily',
+      interests: ['coding'],
+      requiresSkills: [{ provider: 'github', source: 'lobehub' }],
+    };
+    mockUseSWR.mockReturnValue({
+      data: { data: [legacyServerTemplate], success: true },
+      isLoading: false,
+      isValidating: false,
+      mutate: mockMutate,
+    });
+
+    const { result } = renderHook(() => useDailyBriefRecommendationsUI());
+
+    expect(result.current).toEqual({ mode: 'hidden' });
+    expect(mockUseFetchUserComposioConnections).toHaveBeenCalledWith(false);
+    expect(mockUseFetchLobehubConnectorConnections).toHaveBeenCalledWith(false);
+  });
+
   it('logs recommendation request errors instead of treating them as normal empty data', async () => {
     const error = new Error('market down');
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.test.ts
+++ b/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.test.ts
@@ -5,7 +5,7 @@ import type { TaskTemplate } from '@lobechat/const';
 import { renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { taskTemplateKeys } from '@/libs/swr/keys';
+import { TASK_TEMPLATE_RECOMMENDATION_CACHE_VERSION, taskTemplateKeys } from '@/libs/swr/keys';
 import { taskTemplateService } from '@/services/taskTemplate';
 
 import {
@@ -142,6 +142,9 @@ describe('resolveDailyBriefRecommendationRequest', () => {
 
     expect(ai.key).toEqual(research.key);
     expect(ai.key).toEqual(taskTemplateKeys.listDailyRecommend('seed', 3, 'zh-CN'));
+    expect(ai.key?.[0]).toBe(
+      `taskTemplate:listDailyRecommend:v${TASK_TEMPLATE_RECOMMENDATION_CACHE_VERSION}`,
+    );
   });
 
   it('keeps refresh seed, count, and locale in the cache key', () => {

--- a/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.test.ts
+++ b/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.test.ts
@@ -336,6 +336,21 @@ describe('useDailyBriefRecommendationsUI', () => {
     expect(mockUseFetchLobehubConnectorConnections).toHaveBeenCalledWith(false);
   });
 
+  it('treats non-array recommendation payloads as empty data', () => {
+    mockUseSWR.mockReturnValue({
+      data: { data: { ...template }, success: true },
+      isLoading: false,
+      isValidating: false,
+      mutate: mockMutate,
+    });
+
+    const { result } = renderHook(() => useDailyBriefRecommendationsUI());
+
+    expect(result.current).toEqual({ mode: 'hidden' });
+    expect(mockUseFetchUserComposioConnections).toHaveBeenCalledWith(false);
+    expect(mockUseFetchLobehubConnectorConnections).toHaveBeenCalledWith(false);
+  });
+
   it('normalizes cached rows before removing a card', () => {
     mockUseSWR.mockReturnValue({
       data: { data: [template, null], success: true },
@@ -352,10 +367,14 @@ describe('useDailyBriefRecommendationsUI', () => {
     result.current.onCreated(template.id);
 
     const updater = mockMutate.mock.calls[0][0] as (current?: {
-      data: unknown[];
+      data: unknown;
       success: boolean;
     }) => unknown;
     expect(updater({ data: [template, null], success: true })).toEqual({
+      data: [],
+      success: true,
+    });
+    expect(updater({ data: { ...template }, success: true })).toEqual({
       data: [],
       success: true,
     });

--- a/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.test.ts
+++ b/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.test.ts
@@ -314,6 +314,32 @@ describe('useDailyBriefRecommendationsUI', () => {
     expect(mockUseFetchLobehubConnectorConnections).toHaveBeenCalledWith(false);
   });
 
+  it('normalizes cached rows before removing a card', () => {
+    mockUseSWR.mockReturnValue({
+      data: { data: [template, null], success: true },
+      isLoading: false,
+      isValidating: false,
+      mutate: mockMutate,
+    });
+
+    const { result } = renderHook(() => useDailyBriefRecommendationsUI());
+
+    expect(result.current.mode).toBe('cards');
+    if (result.current.mode !== 'cards') return;
+
+    result.current.onCreated(template.id);
+
+    const updater = mockMutate.mock.calls[0][0] as (current?: {
+      data: unknown[];
+      success: boolean;
+    }) => unknown;
+    expect(updater({ data: [template, null], success: true })).toEqual({
+      data: [],
+      success: true,
+    });
+    expect(mockMutate.mock.calls[0][1]).toEqual({ revalidate: false });
+  });
+
   it('drops legacy recommendations from pre-Market task-template servers', () => {
     const legacyServerTemplate = {
       category: 'engineering',

--- a/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
+++ b/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
@@ -19,6 +19,7 @@ import { useToolStore } from '@/store/tool';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/slices/auth/selectors';
 
+import { getProviderMeta } from './providerMeta';
 import { useResolvedInterestKeys } from './useResolvedInterestKeys';
 
 const REFRESH_SEED_STORAGE_KEY = 'lobehub:taskTemplate:refreshSeed';
@@ -47,10 +48,11 @@ const isTaskTemplateConnectorSource = (value: unknown): value is TaskTemplateCon
 
 const isTaskTemplateConnector = (value: unknown): value is TaskTemplateConnector => {
   if (!isRecord(value)) return false;
+  if (typeof value.identifier !== 'string') return false;
+  if (!isTaskTemplateConnectorSource(value.source)) return false;
   return (
-    typeof value.identifier === 'string' &&
     typeof value.required === 'boolean' &&
-    isTaskTemplateConnectorSource(value.source)
+    Boolean(getProviderMeta({ identifier: value.identifier, source: value.source }))
   );
 };
 

--- a/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
+++ b/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
@@ -35,6 +35,33 @@ interface UseDailyBriefRecommendationsUIOptions {
   count?: number;
 }
 
+const isRecord = (value: unknown): value is Record<PropertyKey, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const isTaskTemplateRecommendationCandidate = (value: unknown): value is TaskTemplate => {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.category === 'string' &&
+    Array.isArray(value.connectors) &&
+    typeof value.cronPattern === 'string' &&
+    typeof value.description === 'string' &&
+    typeof value.id === 'number' &&
+    typeof value.identifier === 'string' &&
+    typeof value.instruction === 'string' &&
+    Array.isArray(value.interests) &&
+    typeof value.title === 'string'
+  );
+};
+
+/**
+ * v2.2.6 returned legacy recommendation rows before `connectors` and text fields existed.
+ * Drop legacy rows from version-skewed self-host servers so they cannot crash the home screen.
+ */
+const normalizeTaskTemplateRecommendation = (template: unknown): TaskTemplate | undefined => {
+  if (!isTaskTemplateRecommendationCandidate(template)) return undefined;
+  return template;
+};
+
 interface ResolveDailyBriefRecommendationRequestParams {
   interestKeys: string[] | null;
   isLogin: boolean | undefined;
@@ -205,7 +232,14 @@ export function useDailyBriefRecommendationsUI(
     [message, mutate, removeTemplateFromList, t],
   );
 
-  const templates = useMemo(() => data?.data ?? [], [data]);
+  const templates = useMemo(
+    () =>
+      (data?.data ?? []).flatMap((template) => {
+        const normalized = normalizeTaskTemplateRecommendation(template);
+        return normalized ? [normalized] : [];
+      }),
+    [data],
+  );
   const requiredSources = useMemo(() => {
     const sources = new Set<TaskTemplateConnectorSource>();
     for (const tmpl of templates) {

--- a/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
+++ b/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
@@ -81,11 +81,18 @@ const normalizeTaskTemplateRecommendation = (template: unknown): TaskTemplate | 
   return template;
 };
 
-const normalizeTaskTemplateRecommendations = (templates: unknown[]): TaskTemplate[] =>
-  templates.flatMap((template) => {
+/**
+ * Persisted SWR data can be stale or corrupted, for example `{ data: { ... } }`.
+ * Treat non-array payloads as empty so home rendering and cache mutations stay defensive.
+ */
+const normalizeTaskTemplateRecommendations = (templates: unknown): TaskTemplate[] => {
+  if (!Array.isArray(templates)) return [];
+
+  return templates.flatMap((template) => {
     const normalized = normalizeTaskTemplateRecommendation(template);
     return normalized ? [normalized] : [];
   });
+};
 
 interface ResolveDailyBriefRecommendationRequestParams {
   interestKeys: string[] | null;

--- a/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
+++ b/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
@@ -1,4 +1,8 @@
-import type { TaskTemplate, TaskTemplateConnectorSource } from '@lobechat/const';
+import type {
+  TaskTemplate,
+  TaskTemplateConnector,
+  TaskTemplateConnectorSource,
+} from '@lobechat/const';
 import { TASK_TEMPLATE_RECOMMEND_COUNT } from '@lobechat/const';
 import { createNanoId } from '@lobechat/utils';
 import { useSessionStorageState } from 'ahooks';
@@ -38,11 +42,24 @@ interface UseDailyBriefRecommendationsUIOptions {
 const isRecord = (value: unknown): value is Record<PropertyKey, unknown> =>
   typeof value === 'object' && value !== null;
 
+const isTaskTemplateConnectorSource = (value: unknown): value is TaskTemplateConnectorSource =>
+  value === 'composio' || value === 'lobehub';
+
+const isTaskTemplateConnector = (value: unknown): value is TaskTemplateConnector => {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.identifier === 'string' &&
+    typeof value.required === 'boolean' &&
+    isTaskTemplateConnectorSource(value.source)
+  );
+};
+
 const isTaskTemplateRecommendationCandidate = (value: unknown): value is TaskTemplate => {
   if (!isRecord(value)) return false;
   return (
     typeof value.category === 'string' &&
     Array.isArray(value.connectors) &&
+    value.connectors.every(isTaskTemplateConnector) &&
     typeof value.cronPattern === 'string' &&
     typeof value.description === 'string' &&
     typeof value.id === 'number' &&

--- a/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
+++ b/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts
@@ -79,6 +79,12 @@ const normalizeTaskTemplateRecommendation = (template: unknown): TaskTemplate | 
   return template;
 };
 
+const normalizeTaskTemplateRecommendations = (templates: unknown[]): TaskTemplate[] =>
+  templates.flatMap((template) => {
+    const normalized = normalizeTaskTemplateRecommendation(template);
+    return normalized ? [normalized] : [];
+  });
+
 interface ResolveDailyBriefRecommendationRequestParams {
   interestKeys: string[] | null;
   isLogin: boolean | undefined;
@@ -220,7 +226,12 @@ export function useDailyBriefRecommendationsUI(
       mutate(
         (current) =>
           current
-            ? { ...current, data: current.data.filter((tmpl) => tmpl.id !== templateId) }
+            ? {
+                ...current,
+                data: normalizeTaskTemplateRecommendations(current.data).filter(
+                  (tmpl) => tmpl.id !== templateId,
+                ),
+              }
             : current,
         { revalidate: false },
       );
@@ -249,14 +260,7 @@ export function useDailyBriefRecommendationsUI(
     [message, mutate, removeTemplateFromList, t],
   );
 
-  const templates = useMemo(
-    () =>
-      (data?.data ?? []).flatMap((template) => {
-        const normalized = normalizeTaskTemplateRecommendation(template);
-        return normalized ? [normalized] : [];
-      }),
-    [data],
-  );
+  const templates = useMemo(() => normalizeTaskTemplateRecommendations(data?.data ?? []), [data]);
   const requiredSources = useMemo(() => {
     const sources = new Set<TaskTemplateConnectorSource>();
     for (const tmpl of templates) {

--- a/src/libs/swr/keys.ts
+++ b/src/libs/swr/keys.ts
@@ -746,11 +746,20 @@ export const topicActionKeys = {
 export const homeKeys = {
   dailyBrief: def('home:dailyBrief', (userId: string) => ['home:dailyBrief', userId]),
 };
+
+/**
+ * Daily task-template recommendation cache schema version. Bump this when the
+ * persisted recommendation row shape changes incompatibly so desktop clients
+ * stop reading stale localStorage SWR entries.
+ */
+export const TASK_TEMPLATE_RECOMMENDATION_CACHE_VERSION = 2;
+const TASK_TEMPLATE_DAILY_RECOMMEND_ROOT = `taskTemplate:listDailyRecommend:v${TASK_TEMPLATE_RECOMMENDATION_CACHE_VERSION}`;
+
 export const taskTemplateKeys = {
   listDailyRecommend: def(
-    'taskTemplate:listDailyRecommend',
+    TASK_TEMPLATE_DAILY_RECOMMEND_ROOT,
     (refreshSeed: unknown, recommendationCount: number, locale: string) => [
-      'taskTemplate:listDailyRecommend',
+      TASK_TEMPLATE_DAILY_RECOMMEND_ROOT,
       refreshSeed,
       recommendationCount,
       locale,

--- a/src/libs/swr/localStorageProvider.test.ts
+++ b/src/libs/swr/localStorageProvider.test.ts
@@ -3,6 +3,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { taskTemplateKeys } from './keys';
 import { localDataCache } from './localDataCache';
 import {
   CACHE_TIERS,
@@ -82,7 +83,7 @@ describe('createCacheProvider — tiering', () => {
       localPatterns: [...CACHE_TIERS.local],
     });
     const map = provider();
-    const key = 'taskTemplate:listDailyRecommend:ai,,3,zh-CN';
+    const key = JSON.stringify(taskTemplateKeys.listDailyRecommend('', 3, 'zh-CN'));
 
     map.set(key, { data: [{ id: 1, title: 'Daily brief' }] });
 

--- a/src/store/user/slices/common/action.test.ts
+++ b/src/store/user/slices/common/action.test.ts
@@ -51,6 +51,9 @@ describe('createCommonSlice', () => {
       expect(
         isTaskTemplateRecommendationKey(taskTemplateKeys.listDailyRecommend('seed', 3, 'zh-CN')),
       ).toBe(true);
+      expect(
+        isTaskTemplateRecommendationKey(['taskTemplate:listDailyRecommend', 'seed', 3, 'zh-CN']),
+      ).toBe(false);
       expect(isTaskTemplateRecommendationKey(userKeys.initState())).toBe(false);
     });
   });


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #16123

#### 🔀 Description of Change

- Add a runtime guard before task-template recommendations enter the connector-aware UI path.
- Drop legacy or malformed recommendation rows instead of rendering them and crashing the home screen.
- Keep valid Market recommendation rows unchanged.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated tests:

- `rtk vitest run src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.test.ts`
- `vscode-cli get-diagnostics --not-recommend-file-paths lobehub/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.ts lobehub/src/features/RecommendTaskTemplates/useDailyBriefRecommendationsUI.test.ts`
- `git diff --check`

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Key Decisions / Non-goals:

- This PR intentionally does not migrate or partially adapt the old task-template schema. Legacy rows lack the new fields needed by the current card and task creation flow, so the recommendation module hides them instead.
- This only guards the recommendation UI boundary. It does not change Market recommendation generation or task creation semantics.
