### PR TITLE
🐛 fix(connector): run legacy MCP guard before the manifest check

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/connector.syncPluginTools.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/connector.syncPluginTools.test.ts
@@ -126,6 +126,38 @@ describe('connectorRouter.syncPluginTools — customPlugin guard', () => {
       code: 'NOT_FOUND',
     });
   });
+
+  it('defers (not NOT_FOUND) for customPlugin+mcp rows whose manifest is NULL', async () => {
+    // This is the exact #15674 victim profile: legacy custom MCP whose
+    // `tools/list` never succeeded after the v2.2.3 break, so `manifest` is
+    // NULL on the row. The customPlugin migration guard MUST run before the
+    // manifest check, otherwise the user gets a NOT_FOUND, the SkillDetail
+    // fallback never renders, and the migration modal never surfaces.
+    pluginModelMock.findById.mockResolvedValueOnce({
+      type: 'customPlugin',
+      manifest: null,
+      customParams: { mcp: { type: 'http', url: 'http://10.9.16.224:9100/mcp' } },
+    });
+
+    const result = await callerFor().syncPluginTools({ identifier: 'dockpit' });
+
+    expect(result).toEqual({ connectorId: null, toolCount: 0 });
+    expect(connectorModelMock.create).not.toHaveBeenCalled();
+  });
+
+  it('still throws NOT_FOUND for non-customPlugin rows with no manifest', async () => {
+    // Marketplace rows are expected to always carry a manifest. If a plugin
+    // row exists but its manifest is missing AND it isn't a customPlugin with
+    // an MCP blob to migrate, we can't bootstrap a connector from it — the
+    // NOT_FOUND signal stays as it was for that genuinely broken case.
+    pluginModelMock.findById.mockResolvedValueOnce({
+      type: 'plugin',
+      manifest: null,
+    });
+    await expect(
+      callerFor().syncPluginTools({ identifier: 'broken-marketplace' }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
 });
 
 describe('connectorRouter.create — sourceType handling on existing rows', () => {

--- a/apps/server/src/routers/lambda/connector.ts
+++ b/apps/server/src/routers/lambda/connector.ts
@@ -496,19 +496,31 @@ export const connectorRouter = router({
     .mutation(async ({ input, ctx }) => {
       const plugin = await ctx.pluginModel.findById(input.identifier);
 
-      if (!plugin || !plugin.manifest) {
+      if (!plugin) {
         throw new TRPCError({
           code: 'NOT_FOUND',
-          message: `Plugin '${input.identifier}' not found or has no manifest`,
+          message: `Plugin '${input.identifier}' not found`,
         });
       }
 
+      // The customPlugin migration guard MUST run before the manifest check.
+      // The users hit by #15674 are the ones whose legacy custom MCP never
+      // successfully reported a `tools/list` after the v2.2.3 break, so their
+      // `user_installed_plugins.manifest` is NULL / empty. If we threw
+      // NOT_FOUND here the SkillDetail fallback would never render and the
+      // migration modal would never surface — exactly the users we are
+      // trying to rescue. Hand off to the frontend migration flow first;
+      // returning null tells the caller "no connector row produced" and the
+      // "Configure" button opens CustomConnectorModal in migration mode.
       if (plugin.type === 'customPlugin' && plugin.customParams?.mcp) {
-        // Hand off to the frontend migration flow. Returning null tells the
-        // caller "no connector row produced"; the SkillDetail panel falls back
-        // to the legacy plugin display, and the "Configure" button surfaces
-        // CustomConnectorModal in migration mode.
         return { connectorId: null, toolCount: 0 };
+      }
+
+      if (!plugin.manifest) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: `Plugin '${input.identifier}' has no manifest`,
+        });
       }
 
       const connectorId = await upsertConnectorEntry(ctx.connectorModel, {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up to #16172 (Codex review). Refs lobehub/lobehub#15674.

#### 🔀 Description of Change

In the merged #16172, `syncPluginTools` still throws `NOT_FOUND` on `!plugin.manifest` **before** reaching the new `customPlugin + customParams.mcp` guard. The exact users hit by #15674 are the ones whose legacy custom MCP never successfully reported a `tools/list` after the v2.2.3 break, so `user_installed_plugins.manifest` is NULL on their row — they fall through the manifest check, get NOT_FOUND, and the SkillDetail fallback never renders. The migration modal never surfaces and those agents stay stuck without tools.

Split the existence check from the manifest check and slot the customPlugin migration guard between them:

```ts
if (!plugin) throw NOT_FOUND('not found');
if (plugin.type === 'customPlugin' && plugin.customParams?.mcp) {
  return { connectorId: null, toolCount: 0 };  // hand off to frontend migration
}
if (!plugin.manifest) throw NOT_FOUND('has no manifest');
```

Behavior for non-customPlugin broken rows (genuinely missing manifest, no migration to do) is unchanged — still NOT_FOUND.

The previous PR's tests always mocked a non-null `manifest` on the customPlugin row, so they never exercised this code path. Adding two new tests fixes that.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' apps/server/src/routers/lambda/__tests__/connector.syncPluginTools.test.ts
# 9 tests (7 prior + 2 new): manifest-NULL customPlugin defers, manifest-NULL non-customPlugin still NOT_FOUND
```

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Manifest-less legacy custom MCP → server throws NOT_FOUND → SkillDetail empty, no Configure button | Manifest-less legacy custom MCP → server returns `{ connectorId: null }` → SkillDetail falls back, Configure opens migration modal |

#### 📝 Additional Information

Backstop for #16172. Without this, the migration flow is unreachable for the worst-affected cohort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
