### PR TITLE
Add Keenable web search provider (keyless by default)

### DIFF
--- a/apps/server/src/services/search/impls/index.ts
+++ b/apps/server/src/services/search/impls/index.ts
@@ -6,6 +6,7 @@ import { FirecrawlImpl } from './firecrawl';
 import { GoogleImpl } from './google';
 import { JinaImpl } from './jina';
 import { KagiImpl } from './kagi';
+import { KeenableImpl } from './keenable';
 import { Search1APIImpl } from './search1api';
 import { SearXNGImpl } from './searxng';
 import { TavilyImpl } from './tavily';
@@ -23,6 +24,7 @@ export enum SearchImplType {
   Google = 'google',
   Jina = 'jina',
   Kagi = 'kagi',
+  Keenable = 'keenable',
   Search1API = 'search1api',
   SearXNG = 'searxng',
   Tavily = 'tavily',
@@ -65,6 +67,10 @@ export const createSearchServiceImpl = (
 
     case SearchImplType.Kagi: {
       return new KagiImpl();
+    }
+
+    case SearchImplType.Keenable: {
+      return new KeenableImpl();
     }
 
     case SearchImplType.SearXNG: {

--- a/apps/server/src/services/search/impls/keenable/index.test.ts
+++ b/apps/server/src/services/search/impls/keenable/index.test.ts
@@ -1,0 +1,140 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { KeenableImpl } from './index';
+
+const createMockResponse = (body: object, ok = true, status = 200, statusText = 'OK') =>
+  ({
+    ok,
+    status,
+    statusText,
+    json: vi.fn().mockResolvedValue(body),
+    text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+  }) as unknown as Response;
+
+const makeKeenableResponse = (results: object[]) => ({ query: 'test', results });
+
+describe('KeenableImpl', () => {
+  let impl: KeenableImpl;
+
+  beforeEach(() => {
+    impl = new KeenableImpl();
+    vi.stubGlobal('fetch', vi.fn());
+    delete process.env.KEENABLE_API_KEY;
+    delete process.env.KEENABLE_API_URL;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.KEENABLE_API_KEY;
+    delete process.env.KEENABLE_API_URL;
+  });
+
+  describe('query', () => {
+    it('should return mapped results for a successful query', async () => {
+      const keenableResults = [
+        {
+          title: 'Example Title',
+          url: 'https://example.com/page',
+          description: 'Example description',
+          published_at: '2026-01-15T10:30:00Z',
+        },
+      ];
+
+      vi.mocked(fetch).mockResolvedValueOnce(
+        createMockResponse(makeKeenableResponse(keenableResults)),
+      );
+
+      const result = await impl.query('test query');
+
+      expect(result.query).toBe('test query');
+      expect(result.resultNumbers).toBe(1);
+      expect(result.results[0]).toMatchObject({
+        title: 'Example Title',
+        url: 'https://example.com/page',
+        content: 'Example description',
+        engines: ['keenable'],
+        category: 'general',
+        score: 1,
+        parsedUrl: 'example.com',
+      });
+    });
+
+    it('uses the keyless public endpoint and no API key header by default', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(makeKeenableResponse([])));
+
+      await impl.query('test');
+
+      const [url, options] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://api.keenable.ai/v1/search/public');
+      expect((options.headers as Record<string, string>)['X-API-Key']).toBeUndefined();
+      expect((options.headers as Record<string, string>)['X-Keenable-Title']).toBe('LobeChat');
+      expect(options.method).toBe('POST');
+    });
+
+    it('uses the keyed endpoint and X-API-Key when a key is set', async () => {
+      process.env.KEENABLE_API_KEY = 'secret-key';
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(makeKeenableResponse([])));
+
+      await impl.query('test');
+
+      const [url, options] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('https://api.keenable.ai/v1/search');
+      expect((options.headers as Record<string, string>)['X-API-Key']).toBe('secret-key');
+    });
+
+    it('falls back to keyless when the key is blank', async () => {
+      process.env.KEENABLE_API_KEY = '   ';
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(makeKeenableResponse([])));
+
+      await impl.query('test');
+
+      const url = vi.mocked(fetch).mock.calls[0][0] as string;
+      expect(url).toBe('https://api.keenable.ai/v1/search/public');
+    });
+
+    it('honours KEENABLE_API_URL override', async () => {
+      process.env.KEENABLE_API_URL = 'https://staging.keenable.ai';
+      vi.mocked(fetch).mockResolvedValueOnce(createMockResponse(makeKeenableResponse([])));
+
+      await impl.query('test');
+
+      const url = vi.mocked(fetch).mock.calls[0][0] as string;
+      expect(url).toBe('https://staging.keenable.ai/v1/search/public');
+    });
+
+    it('should throw SERVICE_UNAVAILABLE when fetch throws a network error', async () => {
+      vi.mocked(fetch).mockRejectedValue(new Error('Network error'));
+
+      await expect(impl.query('test')).rejects.toMatchObject({
+        code: 'SERVICE_UNAVAILABLE',
+        message: 'Failed to connect to Keenable.',
+      });
+    });
+
+    it('should throw SERVICE_UNAVAILABLE when response is not ok', async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        createMockResponse({ error: 'Unauthorized' }, false, 401, 'Unauthorized'),
+      );
+
+      await expect(impl.query('test')).rejects.toMatchObject({
+        code: 'SERVICE_UNAVAILABLE',
+        message: 'Keenable request failed: Unauthorized',
+      });
+    });
+
+    it('should throw INTERNAL_SERVER_ERROR when response JSON parsing fails', async () => {
+      vi.mocked(fetch).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockRejectedValue(new Error('Invalid JSON')),
+        text: vi.fn().mockResolvedValue('invalid json'),
+      } as unknown as Response);
+
+      await expect(impl.query('test')).rejects.toMatchObject({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to parse Keenable response.',
+      });
+    });
+  });
+});

--- a/apps/server/src/services/search/impls/keenable/index.test.ts
+++ b/apps/server/src/services/search/impls/keenable/index.test.ts
@@ -32,11 +32,14 @@ describe('KeenableImpl', () => {
 
   describe('query', () => {
     it('should return mapped results for a successful query', async () => {
+      // A realistic result: the API returns both fields and `description` is
+      // frequently empty, with `snippet` carrying the page text.
       const keenableResults = [
         {
           title: 'Example Title',
           url: 'https://example.com/page',
-          description: 'Example description',
+          description: '',
+          snippet: 'Example page text',
           published_at: '2026-01-15T10:30:00Z',
         },
       ];
@@ -52,12 +55,53 @@ describe('KeenableImpl', () => {
       expect(result.results[0]).toMatchObject({
         title: 'Example Title',
         url: 'https://example.com/page',
-        content: 'Example description',
+        content: 'Example page text',
         engines: ['keenable'],
         category: 'general',
         score: 1,
         parsedUrl: 'example.com',
       });
+    });
+
+    it('falls back to description when snippet is absent', async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        createMockResponse(
+          makeKeenableResponse([
+            {
+              title: 'Example Title',
+              url: 'https://example.com/page',
+              description: 'A description',
+            },
+          ]),
+        ),
+      );
+
+      const result = await impl.query('test query');
+
+      expect(result.results[0].content).toBe('A description');
+    });
+
+    it('collapses whitespace and caps the content', async () => {
+      // Snippets are raw page text: newlines in them, and far longer than the
+      // snippet the other providers return.
+      vi.mocked(fetch).mockResolvedValueOnce(
+        createMockResponse(
+          makeKeenableResponse([
+            {
+              title: 'Example Title',
+              url: 'https://example.com/page',
+              description: '',
+              snippet: 'line one\n\nline two' + ' padding'.repeat(500),
+            },
+          ]),
+        ),
+      );
+
+      const { content } = (await impl.query('test query')).results[0];
+
+      expect(content).toHaveLength(500);
+      expect(content).not.toContain('\n');
+      expect(content.startsWith('line one line two')).toBe(true);
     });
 
     it('uses the keyless public endpoint and no API key header by default', async () => {

--- a/apps/server/src/services/search/impls/keenable/index.ts
+++ b/apps/server/src/services/search/impls/keenable/index.ts
@@ -1,0 +1,122 @@
+import {
+  type SearchParams,
+  type UniformSearchResponse,
+  type UniformSearchResult,
+} from '@lobechat/types';
+import { TRPCError } from '@trpc/server';
+import debug from 'debug';
+import urlJoin from 'url-join';
+
+import { type SearchServiceImpl } from '../type';
+import { type KeenableResponse, type KeenableSearchParameters } from './type';
+
+const log = debug('lobe-search:Keenable');
+
+const DEFAULT_BASE_URL = 'https://api.keenable.ai';
+
+/**
+ * Keenable implementation of the search service.
+ *
+ * Keenable is a web search API built for AI agents. Unlike the other providers,
+ * it works without an API key by default (keyless public endpoint); setting
+ * `KEENABLE_API_KEY` uses the authenticated endpoint and lifts rate limits.
+ */
+export class KeenableImpl implements SearchServiceImpl {
+  private get apiKey(): string | undefined {
+    return process.env.KEENABLE_API_KEY?.trim() || undefined;
+  }
+
+  private get baseUrl(): string {
+    return (process.env.KEENABLE_API_URL || DEFAULT_BASE_URL).replace(/\/$/, '');
+  }
+
+  async query(query: string, params: SearchParams = {}): Promise<UniformSearchResponse> {
+    log('Starting Keenable query with query: "%s", params: %o', query, params);
+
+    // Keyless public endpoint by default; the keyed endpoint when a key is set.
+    const path = this.apiKey ? '/v1/search' : '/v1/search/public';
+    const endpoint = urlJoin(this.baseUrl, path);
+
+    const body: KeenableSearchParameters = {
+      mode: 'pro',
+      query,
+    };
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      // Attribution header the Keenable backend segments traffic by.
+      'User-Agent': 'keenable-lobechat',
+      'X-Keenable-Title': 'LobeChat',
+    };
+    if (this.apiKey) headers['X-API-Key'] = this.apiKey;
+
+    let response: Response;
+    const startAt = Date.now();
+    let costTime: number;
+    try {
+      log('Sending request to endpoint: %s', endpoint);
+      response = await fetch(endpoint, {
+        body: JSON.stringify(body),
+        headers,
+        method: 'POST',
+      });
+      log('Received response with status: %d', response.status);
+      costTime = Date.now() - startAt;
+    } catch (error) {
+      log.extend('error')('Keenable fetch error: %o', error);
+      throw new TRPCError({
+        cause: error,
+        code: 'SERVICE_UNAVAILABLE',
+        message: 'Failed to connect to Keenable.',
+      });
+    }
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      log.extend('error')(
+        `Keenable request failed with status ${response.status}: %s`,
+        errorBody.length > 200 ? `${errorBody.slice(0, 200)}...` : errorBody,
+      );
+      throw new TRPCError({
+        cause: errorBody,
+        code: 'SERVICE_UNAVAILABLE',
+        message: `Keenable request failed: ${response.statusText}`,
+      });
+    }
+
+    try {
+      const keenableResponse = (await response.json()) as KeenableResponse;
+
+      log('Parsed Keenable response: %o', keenableResponse);
+
+      const mappedResults = (keenableResponse.results || []).map(
+        (result): UniformSearchResult => ({
+          category: 'general',
+          content: result.description || '',
+          engines: ['keenable'],
+          parsedUrl: result.url ? new URL(result.url).hostname : '',
+          publishedDate: result.published_at || undefined,
+          score: 1,
+          title: result.title || '',
+          url: result.url,
+        }),
+      );
+
+      log('Mapped %d results to SearchResult format', mappedResults.length);
+
+      return {
+        costTime,
+        query,
+        resultNumbers: mappedResults.length,
+        results: mappedResults,
+      };
+    } catch (error) {
+      log.extend('error')('Error parsing Keenable response: %o', error);
+      throw new TRPCError({
+        cause: error,
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'Failed to parse Keenable response.',
+      });
+    }
+  }
+}

--- a/apps/server/src/services/search/impls/keenable/index.ts
+++ b/apps/server/src/services/search/impls/keenable/index.ts
@@ -15,6 +15,27 @@ const log = debug('lobe-search:Keenable');
 const DEFAULT_BASE_URL = 'https://api.keenable.ai';
 
 /**
+ * Keenable returns whole-page text where the other providers return a short
+ * snippet, so cap it to keep `content` the same size as theirs.
+ */
+const MAX_CONTENT_CHARS = 500;
+
+/**
+ * Picks a result's text.
+ *
+ * Keenable returns both `snippet` and `description`: `snippet` carries the page
+ * text and `description` is frequently empty, so prefer whichever has content.
+ * Snippets are raw page text with newlines in them, hence the whitespace
+ * collapse and the cap.
+ */
+const resultContent = (result: { description?: string; snippet?: string }): string =>
+  (result.snippet || result.description || '')
+    .split(/\s+/)
+    .filter(Boolean)
+    .join(' ')
+    .slice(0, MAX_CONTENT_CHARS);
+
+/**
  * Keenable implementation of the search service.
  *
  * Keenable is a web search API built for AI agents. Unlike the other providers,
@@ -92,7 +113,7 @@ export class KeenableImpl implements SearchServiceImpl {
       const mappedResults = (keenableResponse.results || []).map(
         (result): UniformSearchResult => ({
           category: 'general',
-          content: result.description || '',
+          content: resultContent(result),
           engines: ['keenable'],
           parsedUrl: result.url ? new URL(result.url).hostname : '',
           publishedDate: result.published_at || undefined,

--- a/apps/server/src/services/search/impls/keenable/type.ts
+++ b/apps/server/src/services/search/impls/keenable/type.ts
@@ -1,0 +1,20 @@
+export interface KeenableSearchParameters {
+  mode?: 'pro' | 'realtime';
+  published_after?: string;
+  published_before?: string;
+  query: string;
+  site?: string;
+}
+
+interface KeenableResult {
+  acquired_at?: string;
+  description?: string;
+  published_at?: string | null;
+  title?: string;
+  url: string;
+}
+
+export interface KeenableResponse {
+  query?: string;
+  results: KeenableResult[];
+}

--- a/apps/server/src/services/search/impls/keenable/type.ts
+++ b/apps/server/src/services/search/impls/keenable/type.ts
@@ -1,5 +1,5 @@
 export interface KeenableSearchParameters {
-  mode?: 'pro' | 'realtime';
+  mode?: 'pro';
   published_after?: string;
   published_before?: string;
   query: string;
@@ -8,8 +8,11 @@ export interface KeenableSearchParameters {
 
 interface KeenableResult {
   acquired_at?: string;
+  /** Frequently empty; `snippet` is where the page text is. */
   description?: string;
   published_at?: string | null;
+  /** Raw page text, newlines included. */
+  snippet?: string;
   title?: string;
   url: string;
 }

--- a/docs/self-hosting/advanced/online-search.mdx
+++ b/docs/self-hosting/advanced/online-search.mdx
@@ -106,6 +106,7 @@ Supported search engines include:
 | `google`     | Uses [Google Programmable Search Engine](https://programmablesearchengine.google.com/). | `GOOGLE_PSE_API_KEY` `GOOGLE_PSE_ENGINE_ID`                                 |
 | `jina`       | Semantic search provided by [Jina AI](https://jina.ai/).                                | `JINA_READER_API_KEY`                                                       |
 | `kagi`       | Premium search API by [Kagi](https://kagi.com/), requires a subscription key.           | `KAGI_API_KEY`                                                              |
+| `keenable`   | [Keenable](https://keenable.ai/), built for AI agents. Works keyless by default.        | `KEENABLE_API_KEY` (optional)                                              |
 | `search1api` | Aggregated search capabilities from [Search1API](https://www.search1api.com).           | `SEARCH1API_API_KEY` `SEARCH1API_CRAWL_API_KEY` `SEARCH1API_SEARCH_API_KEY` |
 | `searxng`    | Use a self-hosted or public [SearXNG](https://searx.space/) instance.                   | `SEARXNG_URL`                                                               |
 | `tavily`     | [Tavily](https://www.tavily.com/), offers fast web summaries and answers.               | `TAVILY_API_KEY`                                                            |

--- a/docs/self-hosting/advanced/online-search.zh-CN.mdx
+++ b/docs/self-hosting/advanced/online-search.zh-CN.mdx
@@ -101,6 +101,7 @@ SEARCH_PROVIDERS="searxng"
 | `google`     | 使用 [Google Programmable Search Engine](https://programmablesearchengine.google.com/)。 | `GOOGLE_PSE_API_KEY` `GOOGLE_PSE_ENGINE_ID`                                 |
 | `jina`       | 使用 [Jina AI](https://jina.ai/) 提供的语义搜索服务。                                             | `JINA_READER_API_KEY`                                                       |
 | `kagi`       | [Kagi](https://kagi.com/) 提供的高级搜索 API，需订阅 Key。                                        | `KAGI_API_KEY`                                                              |
+| `keenable`   | [Keenable](https://keenable.ai/)，为 AI 智能体打造，默认无需 Key 即可使用。                       | `KEENABLE_API_KEY`（可选）                                                  |
 | `search1api` | 使用 [Search1API](https://www.search1api.com) 聚合搜索能力。                                   | `SEARCH1API_API_KEY` `SEARCH1API_CRAWL_API_KEY` `SEARCH1API_SEARCH_API_KEY` |
 | `searxng`    | 使用自托管或公共 [SearXNG](https://searx.space/) 实例。                                          | `SEARXNG_URL`                                                               |
 | `tavily`     | [Tavily](https://www.tavily.com/)，快速网页摘要与答案返回。                                        | `TAVILY_API_KEY`                                                            |


### PR DESCRIPTION
Adds Keenable as a web search provider, alongside the existing
SearXNG/Tavily/Brave/Exa/etc. providers.

The difference from the other providers is that it doesn't require an API key.
By default it uses Keenable's keyless public endpoint, so it works with just
`SEARCH_PROVIDERS=keenable`. Setting `KEENABLE_API_KEY` switches to the
authenticated endpoint and lifts the rate limits.

### Changes

- `apps/server/src/services/search/impls/keenable/`: `KeenableImpl` implementing
  `SearchServiceImpl`, following the Tavily/Brave impls. Maps results to the
  uniform `{title, url, content, engines, ...}` shape.
- Registered in the impls registry (`SearchImplType.Keenable`).
- Unit test mirroring the existing brave/exa impl tests.
- `SEARCH_PROVIDERS` docs table (en + zh-CN).

### Config

- `KEENABLE_API_KEY`: optional. Blank = keyless free tier; set it to lift limits.
- `KEENABLE_API_URL`: optional base-URL override (defaults to `https://api.keenable.ai`).

Verified the provider against the public endpoint (keyless) and that the new
files type-check / parse clean.
