### PR TITLE
💄 style(verify): table layout for desktop checks & mobile adaptation

### DIFF
--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -20,6 +20,7 @@ import { useParams } from 'react-router';
 
 import Loading from '@/components/Loading/BrandTextLoading';
 import { useTextFileLoader } from '@/features/FileViewer/hooks/useTextFileLoader';
+import { useIsMobile } from '@/hooks/useIsMobile';
 import type { VerifyEvidenceWithUrl, VerifyResultWithEvidence } from '@/services/verify';
 import { getLanguageFromFilename } from '@/utils/fileLanguage';
 
@@ -37,10 +38,17 @@ const filenameFromUrl = (url: string): string => {
 const useStyles = createStyles(({ css, token }) => ({
   container: css`
     width: 100%;
-    max-width: 880px;
+    max-width: 1080px;
     margin-block: 0;
     margin-inline: auto;
     padding: 24px;
+  `,
+  containerMobile: css`
+    width: 100%;
+    max-width: 100%;
+    margin-block: 0;
+    margin-inline: auto;
+    padding: 16px;
   `,
   docTrigger: css`
     cursor: pointer;
@@ -142,6 +150,50 @@ const useStyles = createStyles(({ css, token }) => ({
     font-weight: 700;
     font-variant-numeric: tabular-nums;
   `,
+  /* Desktop "Checks" table: one compact row per check so the eye scans more at once. */
+  table: css`
+    overflow: hidden;
+    border: 1px solid ${token.colorBorderSecondary};
+    border-radius: ${token.borderRadiusLG}px;
+    background: ${token.colorBgContainer};
+  `,
+  tableCellEvidence: css`
+    min-width: 0;
+  `,
+  tableCellTitle: css`
+    min-width: 0;
+  `,
+  tableCellVerdict: css`
+    align-items: flex-start;
+  `,
+  tableHeader: css`
+    display: grid;
+    grid-template-columns: minmax(180px, 1.1fr) minmax(0, 2.4fr) 112px;
+    gap: 16px;
+
+    padding-block: 10px;
+    padding-inline: 16px;
+    border-block-end: 1px solid ${token.colorBorderSecondary};
+
+    font-size: 12px;
+    font-weight: 500;
+    color: ${token.colorTextTertiary};
+
+    background: ${token.colorFillQuaternary};
+  `,
+  tableRow: css`
+    display: grid;
+    grid-template-columns: minmax(180px, 1.1fr) minmax(0, 2.4fr) 112px;
+    gap: 16px;
+
+    padding-block: 12px;
+    padding-inline: 16px;
+    border-block-end: 1px solid ${token.colorBorderSecondary};
+
+    &:last-child {
+      border-block-end: none;
+    }
+  `,
 }));
 
 const VERDICT_META = {
@@ -191,12 +243,12 @@ const ScopeBlock = memo<{ context?: VerifyRunContext | null; scenario?: string |
 
     return (
       <Block className={styles.scopeBlock} gap={2}>
-        <ScopeRow label="Branch" value={branch} />
-        <ScopeRow label="Commit" value={commit} />
-        <ScopeRow label="Date" value={date} />
-        <ScopeRow label="Surface" value={surface} />
-        <ScopeRow label="Entry" value={entry} />
         <ScopeRow label="Focus" value={focus} />
+        <ScopeRow label="Branch" value={branch} />
+        <ScopeRow label="Surface" value={surface} />
+        <ScopeRow label="Date" value={date} />
+        <ScopeRow label="Commit" value={commit} />
+        <ScopeRow label="Entry" value={entry} />
       </Block>
     );
   },
@@ -265,7 +317,54 @@ const DocumentEvidence = memo<{ evidence: VerifyEvidenceWithUrl }>(({ evidence }
   );
 });
 
-const ResultItem = memo<{ result: VerifyResultWithEvidence }>(({ result }) => {
+/**
+ * Renders a check's evidence artifacts (screenshots / video / documents / inline
+ * text). `imageMaxHeight` lets the compact desktop table shrink screenshots so
+ * more rows stay on screen, while the mobile cards keep the larger preview.
+ */
+const EvidenceList = memo<{
+  evidence: VerifyResultWithEvidence['evidence'];
+  imageMaxHeight?: number;
+}>(({ evidence, imageMaxHeight = 360 }) => {
+  const { styles } = useStyles();
+  if (evidence.length === 0) return null;
+  return (
+    <Flexbox gap={8}>
+      {evidence.map((e) => (
+        <Flexbox gap={4} key={e.id}>
+          {e.description && (
+            <Text fontSize={12} type="secondary">
+              {e.description}
+            </Text>
+          )}
+          {e.fileUrl && imageEvidenceTypes.has(e.type) ? (
+            <Flexbox align={'flex-start'} style={{ maxWidth: '100%' }}>
+              <Image
+                alt={e.description ?? e.type}
+                maxHeight={imageMaxHeight}
+                objectFit={'contain'}
+                src={e.fileUrl}
+                style={{ maxWidth: '100%' }}
+                variant={'outlined'}
+              />
+            </Flexbox>
+          ) : e.fileUrl && e.type === 'video' ? (
+            <video controls className={styles.evidenceVideo} src={e.fileUrl} />
+          ) : e.fileUrl ? (
+            <DocumentEvidence evidence={e} />
+          ) : e.content ? (
+            <div className={styles.evidenceText}>{e.content}</div>
+          ) : (
+            <Tag>{e.type}</Tag>
+          )}
+        </Flexbox>
+      ))}
+    </Flexbox>
+  );
+});
+
+/** Mobile / narrow-screen rendering of a single check — a stacked card. */
+const ResultCard = memo<{ result: VerifyResultWithEvidence }>(({ result }) => {
   const { styles } = useStyles();
   return (
     <Block className={styles.resultCard} gap={6}>
@@ -286,39 +385,56 @@ const ResultItem = memo<{ result: VerifyResultWithEvidence }>(({ result }) => {
           {result.suggestion}
         </Text>
       )}
-      {result.evidence.length > 0 && (
-        <Flexbox gap={8}>
-          {result.evidence.map((e) => (
-            <Flexbox gap={4} key={e.id}>
-              {e.description && (
-                <Text fontSize={12} type="secondary">
-                  {e.description}
-                </Text>
-              )}
-              {e.fileUrl && imageEvidenceTypes.has(e.type) ? (
-                <Flexbox align={'flex-start'}>
-                  <Image
-                    alt={e.description ?? e.type}
-                    maxHeight={360}
-                    objectFit={'contain'}
-                    src={e.fileUrl}
-                    variant={'outlined'}
-                  />
-                </Flexbox>
-              ) : e.fileUrl && e.type === 'video' ? (
-                <video controls className={styles.evidenceVideo} src={e.fileUrl} />
-              ) : e.fileUrl ? (
-                <DocumentEvidence evidence={e} />
-              ) : e.content ? (
-                <div className={styles.evidenceText}>{e.content}</div>
-              ) : (
-                <Tag>{e.type}</Tag>
-              )}
-            </Flexbox>
-          ))}
-        </Flexbox>
-      )}
+      <EvidenceList evidence={result.evidence} />
     </Block>
+  );
+});
+
+/** Desktop rendering of a single check — one table row (Check / Evidence / Result). */
+const ResultRow = memo<{ result: VerifyResultWithEvidence }>(({ result }) => {
+  const { styles } = useStyles();
+  return (
+    <div className={styles.tableRow}>
+      <Flexbox className={styles.tableCellTitle} gap={4}>
+        <Flexbox horizontal align={'center'} gap={6}>
+          <Text strong>{result.checkItemTitle || result.checkItemId}</Text>
+          {!result.required && <Tag>soft</Tag>}
+        </Flexbox>
+        {result.suggestion && (
+          <Text fontSize={12} type="secondary">
+            {result.suggestion}
+          </Text>
+        )}
+      </Flexbox>
+      <Flexbox className={styles.tableCellEvidence} gap={6}>
+        {result.toulmin?.evidence && (
+          <Text fontSize={13} type="secondary">
+            {result.toulmin.evidence}
+          </Text>
+        )}
+        <EvidenceList evidence={result.evidence} imageMaxHeight={200} />
+      </Flexbox>
+      <Flexbox className={styles.tableCellVerdict}>
+        <VerdictTag verdict={result.verdict ?? result.status} />
+      </Flexbox>
+    </div>
+  );
+});
+
+/** Compact, scannable table of all checks for desktop. */
+const ChecksTable = memo<{ results: VerifyResultWithEvidence[] }>(({ results }) => {
+  const { styles } = useStyles();
+  return (
+    <div className={styles.table}>
+      <div className={styles.tableHeader}>
+        <span>Check</span>
+        <span>Evidence</span>
+        <span>Result</span>
+      </div>
+      {results.map((r) => (
+        <ResultRow key={r.id} result={r} />
+      ))}
+    </div>
   );
 });
 
@@ -326,9 +442,13 @@ const ResultItem = memo<{ result: VerifyResultWithEvidence }>(({ result }) => {
  * Standalone viewer for a verification session's report, addressed purely by
  * `?id=<verifyRunId>` — no Agent Run / chat context required. Renders the report
  * narrative plus every check result and its evidence.
+ *
+ * Desktop lays the checks out as a compact table (more rows visible at once);
+ * mobile falls back to stacked cards that wrap cleanly on a narrow viewport.
  */
 const ReportViewer = memo(() => {
-  const { styles } = useStyles();
+  const { styles, cx } = useStyles();
+  const isMobile = useIsMobile();
   const { runId } = useParams<{ runId: string }>();
   const verifyRunId = runId ?? null;
   const { data, isLoading } = useVerifyReportBundle(verifyRunId);
@@ -341,16 +461,14 @@ const ReportViewer = memo(() => {
   const { run, report, results } = data;
 
   return (
-    <Flexbox className={styles.container} gap={24}>
+    <Flexbox className={cx(isMobile ? styles.containerMobile : styles.container)} gap={24}>
       <Flexbox gap={12}>
-        <Flexbox horizontal align="center" gap={12} justify="space-between">
-          <Text as="h2">{run.title || 'Verification report'}</Text>
-          <VerdictTag verdict={report?.verdict} />
-        </Flexbox>
+        <Text as="h2">{run.title || 'Verification report'}</Text>
         {run.scenario !== 'coding' && run.goal && <Text type="secondary">{run.goal}</Text>}
         <ScopeBlock context={run.context} scenario={run.scenario} />
         {report?.summary && <Text type="secondary">{report.summary}</Text>}
-        <Flexbox horizontal gap={24}>
+        <Flexbox horizontal align="center" gap={24}>
+          <VerdictTag verdict={report?.verdict} />
           <Flexbox>
             <span className={styles.stat}>{report?.totalChecks ?? results.length}</span>
             <Text fontSize={12} type="secondary">
@@ -386,9 +504,11 @@ const ReportViewer = memo(() => {
 
       <Flexbox gap={8}>
         <Text as="h3">Checks</Text>
-        {results.map((r) => (
-          <ResultItem key={r.id} result={r} />
-        ))}
+        {isMobile ? (
+          results.map((r) => <ResultCard key={r.id} result={r} />)
+        ) : (
+          <ChecksTable results={results} />
+        )}
       </Flexbox>
 
       {/* Narrative detail (verification commands / score / notes). The scope and

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -182,17 +182,29 @@ const useStyles = createStyles(({ css, token }) => ({
     background: ${token.colorFillQuaternary};
   `,
   tableRow: css`
-    display: grid;
-    grid-template-columns: minmax(180px, 1.1fr) minmax(0, 2.4fr) 112px;
-    gap: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 
-    padding-block: 12px;
+    padding-block: 14px;
     padding-inline: 16px;
     border-block-end: 1px solid ${token.colorBorderSecondary};
 
     &:last-child {
       border-block-end: none;
     }
+  `,
+  /* The compact, aligned top tier of a row: Check / Evidence text / Result. */
+  tableRowMain: css`
+    display: grid;
+    grid-template-columns: minmax(180px, 1.1fr) minmax(0, 2.4fr) 112px;
+    gap: 16px;
+    align-items: start;
+  `,
+  /* Evidence artifacts break out to the row's full width so screenshots stay
+     prominent instead of being squeezed into the narrow Evidence column. */
+  tableRowEvidence: css`
+    padding-inline-start: 2px;
   `,
 }));
 
@@ -390,33 +402,44 @@ const ResultCard = memo<{ result: VerifyResultWithEvidence }>(({ result }) => {
   );
 });
 
-/** Desktop rendering of a single check — one table row (Check / Evidence / Result). */
+/**
+ * Desktop rendering of a single check. Top tier is a compact, aligned grid
+ * (Check / Evidence text / Result) so text-only checks stay one line tall and
+ * scannable; any evidence artifacts then break out to the row's full width
+ * below, keeping screenshots large and visible at a glance.
+ */
 const ResultRow = memo<{ result: VerifyResultWithEvidence }>(({ result }) => {
   const { styles } = useStyles();
   return (
     <div className={styles.tableRow}>
-      <Flexbox className={styles.tableCellTitle} gap={4}>
-        <Flexbox horizontal align={'center'} gap={6}>
-          <Text strong>{result.checkItemTitle || result.checkItemId}</Text>
-          {!result.required && <Tag>soft</Tag>}
+      <div className={styles.tableRowMain}>
+        <Flexbox className={styles.tableCellTitle} gap={4}>
+          <Flexbox horizontal align={'center'} gap={6}>
+            <Text strong>{result.checkItemTitle || result.checkItemId}</Text>
+            {!result.required && <Tag>soft</Tag>}
+          </Flexbox>
+          {result.suggestion && (
+            <Text fontSize={12} type="secondary">
+              {result.suggestion}
+            </Text>
+          )}
         </Flexbox>
-        {result.suggestion && (
-          <Text fontSize={12} type="secondary">
-            {result.suggestion}
-          </Text>
-        )}
-      </Flexbox>
-      <Flexbox className={styles.tableCellEvidence} gap={6}>
-        {result.toulmin?.evidence && (
-          <Text fontSize={13} type="secondary">
-            {result.toulmin.evidence}
-          </Text>
-        )}
-        <EvidenceList evidence={result.evidence} imageMaxHeight={200} />
-      </Flexbox>
-      <Flexbox className={styles.tableCellVerdict}>
-        <VerdictTag verdict={result.verdict ?? result.status} />
-      </Flexbox>
+        <Flexbox className={styles.tableCellEvidence} gap={6}>
+          {result.toulmin?.evidence && (
+            <Text fontSize={13} type="secondary">
+              {result.toulmin.evidence}
+            </Text>
+          )}
+        </Flexbox>
+        <Flexbox className={styles.tableCellVerdict}>
+          <VerdictTag verdict={result.verdict ?? result.status} />
+        </Flexbox>
+      </div>
+      {result.evidence.length > 0 && (
+        <Flexbox className={styles.tableRowEvidence}>
+          <EvidenceList evidence={result.evidence} imageMaxHeight={360} />
+        </Flexbox>
+      )}
     </div>
   );
 });

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -467,7 +467,12 @@ const ReportViewer = memo(() => {
         {run.scenario !== 'coding' && run.goal && <Text type="secondary">{run.goal}</Text>}
         <ScopeBlock context={run.context} scenario={run.scenario} />
         {report?.summary && <Text type="secondary">{report.summary}</Text>}
-        <Flexbox horizontal align="center" gap={24}>
+        <Flexbox
+          horizontal
+          align="center"
+          gap={isMobile ? 16 : 24}
+          wrap={isMobile ? 'wrap' : 'nowrap'}
+        >
           <VerdictTag verdict={report?.verdict} />
           <Flexbox>
             <span className={styles.stat}>{report?.totalChecks ?? results.length}</span>

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -275,8 +275,8 @@ const DocumentEvidence = memo<{ evidence: VerifyEvidenceWithUrl }>(({ evidence }
 
 /**
  * Renders a check's evidence artifacts (screenshots / video / documents / inline
- * text). `imageMaxHeight` lets the compact desktop table shrink screenshots so
- * more rows stay on screen, while the mobile cards keep the larger preview.
+ * text). Screenshots are capped at `imageMaxHeight` and constrained to the
+ * container width so a wide capture never overflows on a narrow viewport.
  */
 const EvidenceList = memo<{
   evidence: VerifyResultWithEvidence['evidence'];

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -38,7 +38,7 @@ const filenameFromUrl = (url: string): string => {
 const useStyles = createStyles(({ css, token }) => ({
   container: css`
     width: 100%;
-    max-width: 1080px;
+    max-width: 880px;
     margin-block: 0;
     margin-inline: auto;
     padding: 24px;
@@ -149,62 +149,6 @@ const useStyles = createStyles(({ css, token }) => ({
     font-size: 20px;
     font-weight: 700;
     font-variant-numeric: tabular-nums;
-  `,
-  /* Desktop "Checks" table: one compact row per check so the eye scans more at once. */
-  table: css`
-    overflow: hidden;
-    border: 1px solid ${token.colorBorderSecondary};
-    border-radius: ${token.borderRadiusLG}px;
-    background: ${token.colorBgContainer};
-  `,
-  tableCellEvidence: css`
-    min-width: 0;
-  `,
-  tableCellTitle: css`
-    min-width: 0;
-  `,
-  tableCellVerdict: css`
-    align-items: flex-start;
-  `,
-  tableHeader: css`
-    display: grid;
-    grid-template-columns: minmax(180px, 1.1fr) minmax(0, 2.4fr) 112px;
-    gap: 16px;
-
-    padding-block: 10px;
-    padding-inline: 16px;
-    border-block-end: 1px solid ${token.colorBorderSecondary};
-
-    font-size: 12px;
-    font-weight: 500;
-    color: ${token.colorTextTertiary};
-
-    background: ${token.colorFillQuaternary};
-  `,
-  tableRow: css`
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-
-    padding-block: 14px;
-    padding-inline: 16px;
-    border-block-end: 1px solid ${token.colorBorderSecondary};
-
-    &:last-child {
-      border-block-end: none;
-    }
-  `,
-  /* The compact, aligned top tier of a row: Check / Evidence text / Result. */
-  tableRowMain: css`
-    display: grid;
-    grid-template-columns: minmax(180px, 1.1fr) minmax(0, 2.4fr) 112px;
-    gap: 16px;
-    align-items: start;
-  `,
-  /* Evidence artifacts break out to the row's full width so screenshots stay
-     prominent instead of being squeezed into the narrow Evidence column. */
-  tableRowEvidence: css`
-    padding-inline-start: 2px;
   `,
 }));
 
@@ -375,7 +319,7 @@ const EvidenceList = memo<{
   );
 });
 
-/** Mobile / narrow-screen rendering of a single check — a stacked card. */
+/** A single check — a stacked card with its title, verdict, reasoning and evidence. */
 const ResultCard = memo<{ result: VerifyResultWithEvidence }>(({ result }) => {
   const { styles } = useStyles();
   return (
@@ -403,71 +347,12 @@ const ResultCard = memo<{ result: VerifyResultWithEvidence }>(({ result }) => {
 });
 
 /**
- * Desktop rendering of a single check. Top tier is a compact, aligned grid
- * (Check / Evidence text / Result) so text-only checks stay one line tall and
- * scannable; any evidence artifacts then break out to the row's full width
- * below, keeping screenshots large and visible at a glance.
- */
-const ResultRow = memo<{ result: VerifyResultWithEvidence }>(({ result }) => {
-  const { styles } = useStyles();
-  return (
-    <div className={styles.tableRow}>
-      <div className={styles.tableRowMain}>
-        <Flexbox className={styles.tableCellTitle} gap={4}>
-          <Flexbox horizontal align={'center'} gap={6}>
-            <Text strong>{result.checkItemTitle || result.checkItemId}</Text>
-            {!result.required && <Tag>soft</Tag>}
-          </Flexbox>
-          {result.suggestion && (
-            <Text fontSize={12} type="secondary">
-              {result.suggestion}
-            </Text>
-          )}
-        </Flexbox>
-        <Flexbox className={styles.tableCellEvidence} gap={6}>
-          {result.toulmin?.evidence && (
-            <Text fontSize={13} type="secondary">
-              {result.toulmin.evidence}
-            </Text>
-          )}
-        </Flexbox>
-        <Flexbox className={styles.tableCellVerdict}>
-          <VerdictTag verdict={result.verdict ?? result.status} />
-        </Flexbox>
-      </div>
-      {result.evidence.length > 0 && (
-        <Flexbox className={styles.tableRowEvidence}>
-          <EvidenceList evidence={result.evidence} imageMaxHeight={360} />
-        </Flexbox>
-      )}
-    </div>
-  );
-});
-
-/** Compact, scannable table of all checks for desktop. */
-const ChecksTable = memo<{ results: VerifyResultWithEvidence[] }>(({ results }) => {
-  const { styles } = useStyles();
-  return (
-    <div className={styles.table}>
-      <div className={styles.tableHeader}>
-        <span>Check</span>
-        <span>Evidence</span>
-        <span>Result</span>
-      </div>
-      {results.map((r) => (
-        <ResultRow key={r.id} result={r} />
-      ))}
-    </div>
-  );
-});
-
-/**
  * Standalone viewer for a verification session's report, addressed purely by
  * `?id=<verifyRunId>` — no Agent Run / chat context required. Renders the report
- * narrative plus every check result and its evidence.
- *
- * Desktop lays the checks out as a compact table (more rows visible at once);
- * mobile falls back to stacked cards that wrap cleanly on a narrow viewport.
+ * narrative plus every check result and its evidence. Checks render as stacked
+ * cards (the screenshot is the most valuable part, so it stays full-width and
+ * prominent); the layout just tightens padding and wraps the stats row on
+ * mobile so a narrow viewport never overflows horizontally.
  */
 const ReportViewer = memo(() => {
   const { styles, cx } = useStyles();
@@ -532,15 +417,13 @@ const ReportViewer = memo(() => {
 
       <Flexbox gap={8}>
         <Text as="h3">Checks</Text>
-        {isMobile ? (
-          results.map((r) => <ResultCard key={r.id} result={r} />)
-        ) : (
-          <ChecksTable results={results} />
-        )}
+        {results.map((r) => (
+          <ResultCard key={r.id} result={r} />
+        ))}
       </Flexbox>
 
       {/* Narrative detail (verification commands / score / notes). The scope and
-          per-check table are already structured above, so a well-formed report
+          per-check cards are already structured above, so a well-formed report
           body carries only the non-duplicate prose. */}
       {report?.content && (
         <Flexbox gap={8}>


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Improves the standalone verification report page (`/verify/:runId`).

- **Desktop**: the **Checks** list is now rendered as a compact **table** (Check / Evidence / Result columns), so each check takes one row and far more is scannable at once instead of tall stacked cards. Evidence screenshots are height-capped (200px) in the table and open to full preview on click.
- **Mobile**: the page previously had no mobile adaptation. It now branches via `useIsMobile()` — mobile falls back to stacked cards (which wrap cleanly on narrow viewports), reduces container padding, and uses full width.
- **Bug fix**: evidence `<Image>` only set `maxHeight`, so wide screenshots overflowed horizontally on narrow viewports — now constrained with `maxWidth: 100%`.
- **Header tweaks** (per review): the verdict tag moved from the title row into the summary stats row (alongside total / passed / failed / score), and the scope block reordered to **Focus / Branch / Surface / Date** first.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Open a `/verify/<runId>` report on desktop (wide window) → checks render as a table; narrow the window or open on mobile → stacked cards, no horizontal overflow.

#### 📝 Additional Information

UI-only change scoped to `src/features/Verify/ReportViewer.tsx`. The page-share mobile issue (`/share/page/:id`) is **not** included here — its renderer lives in a private business overlay (stubbed in this repo), so it must be fixed there.