### PR TITLE
🐛 fix(group): surface supervisor reply when it parents to any council member

### DIFF
--- a/packages/conversation-flow/src/__tests__/parse.test.ts
+++ b/packages/conversation-flow/src/__tests__/parse.test.ts
@@ -455,6 +455,21 @@ describe('parse', () => {
         expect(summary!.role).toBe('supervisor');
         // No duplication regardless of which member carries the reply
         expect(result.flatList.filter((m) => m.id === 'msg-supervisor-summary')).toHaveLength(1);
+
+        // contextTree must stay in agreement with flatList — the reply has to surface in
+        // both exported views, otherwise a contextTree consumer still sees the chain vanish.
+        const collectIds = (nodes: any[], acc: string[] = []): string[] => {
+          for (const node of nodes) {
+            if (node.id) acc.push(node.id);
+            if (Array.isArray(node.members)) collectIds(node.members, acc);
+            if (Array.isArray(node.children)) collectIds(node.children, acc);
+            if (Array.isArray(node.columns)) collectIds(node.columns, acc);
+          }
+          return acc;
+        };
+        const contextIds = collectIds(result.contextTree as any[]);
+        expect(contextIds).toContain('msg-supervisor-summary');
+        expect(contextIds.filter((id) => id === 'msg-supervisor-summary')).toHaveLength(1);
       },
     );
   });

--- a/packages/conversation-flow/src/__tests__/parse.test.ts
+++ b/packages/conversation-flow/src/__tests__/parse.test.ts
@@ -434,6 +434,29 @@ describe('parse', () => {
 
       expect(serializeParseResult(result)).toEqual(outputs.agentCouncil.withSupervisorReply);
     });
+
+    // Regression: the supervisor's post-council reply must surface no matter which council
+    // member it parents to. Broadcast agents finish near-simultaneously (tied createdAt), so
+    // the writer's createdAt-last member can differ from the array order; previously the reader
+    // only walked the last member and stranded the reply, making the supervisor message vanish.
+    it.each([['msg-agent-backend-1'], ['msg-agent-devops-1'], ['msg-agent-architect-1']])(
+      'should surface supervisor final reply when it parents to council member %s',
+      (memberId) => {
+        const messages = inputs.agentCouncil.withSupervisorReply.map((message) =>
+          message.id === 'msg-supervisor-summary'
+            ? { ...message, parentId: memberId }
+            : message,
+        );
+
+        const result = parse(messages);
+        const summary = result.flatList.find((m) => m.id === 'msg-supervisor-summary');
+
+        expect(summary).toBeDefined();
+        expect(summary!.role).toBe('supervisor');
+        // No duplication regardless of which member carries the reply
+        expect(result.flatList.filter((m) => m.id === 'msg-supervisor-summary')).toHaveLength(1);
+      },
+    );
   });
 
   describe('Assistant Group Scenarios', () => {

--- a/packages/conversation-flow/src/transformation/ContextTreeBuilder.ts
+++ b/packages/conversation-flow/src/transformation/ContextTreeBuilder.ts
@@ -101,12 +101,18 @@ export class ContextTreeBuilder {
       const agentCouncilNode = this.createAgentCouncilNodeFromChildren(message, idNode);
       contextTree.push(agentCouncilNode);
 
-      // Continue processing children of the last member (for supervisor final reply)
-      // The supervisor's reply has parentId pointing to the last agent's message
-      const lastChild = idNode.children.at(-1);
-      if (lastChild && lastChild.children.length > 0) {
-        // Process the first child of the last agent (supervisor's reply)
-        this.transformToLinear(lastChild.children[0], contextTree);
+      // Continue from every member to surface the supervisor's post-council reply.
+      // The reply attaches to exactly ONE member, but which member is non-deterministic:
+      // broadcast agents finish near-simultaneously so their createdAt values tie, and the
+      // writer anchors the reply to the createdAt-last member while the tree preserves
+      // input-array order — the two can disagree. Walking only children.at(-1) would strand
+      // the reply. Only the member carrying it has children, so iterating every member emits
+      // it exactly once and keeps contextTree in agreement with flatList (FlatListBuilder
+      // applies the same all-member continuation).
+      for (const child of idNode.children) {
+        if (child.children.length > 0) {
+          this.transformToLinear(child.children[0], contextTree);
+        }
       }
       return;
     }

--- a/packages/conversation-flow/src/transformation/FlatListBuilder.ts
+++ b/packages/conversation-flow/src/transformation/FlatListBuilder.ts
@@ -74,11 +74,16 @@ export class FlatListBuilder {
         );
         flatList.push(agentCouncilMessage);
 
-        // Continue processing children of the last member (for supervisor final reply)
-        // The last member's children should be processed next
-        const lastMemberId = children.at(-1);
-        if (lastMemberId) {
-          this.buildFlatListRecursive(lastMemberId, flatList, processedIds, allMessages);
+        // Continue from each member's children to surface the supervisor's post-council reply.
+        // The reply attaches to exactly ONE member, but which member is non-deterministic:
+        // broadcast agents finish near-simultaneously so their createdAt values tie, and the
+        // writer anchors the reply to the createdAt-last member while childrenMap preserves
+        // input-array order — the two can disagree. Walking only children.at(-1) would strand
+        // the reply (and everything after it) whenever they disagree. Members are already in
+        // processedIds, so recursing into every member only emits the reply chain; the
+        // processedIds guard keeps it from duplicating anything.
+        for (const memberId of children) {
+          this.buildFlatListRecursive(memberId, flatList, processedIds, allMessages);
         }
         return;
       }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

In an agent group, the Supervisor's post-broadcast summary (综合收束) could **silently vanish from the conversation** — users reported "Supervisor 消息丢失".

**Root cause — a write/read ordering mismatch around broadcast (AgentCouncil) rounds:**

- **Writer** (`createGroupOrchestrationExecutors.call_supervisor`) anchors the summary to `getMessages().at(-1)` = the **`createdAt`-last** advisor.
- **Reader** (`FlatListBuilder`, council continuation) only continued from `children.at(-1)` = the **input-array-last** advisor (`childrenMap` preserves array order, not `createdAt` order).

Broadcast advisors finish near-simultaneously (`Promise.all`, sub-millisecond `createdAt` ties), so "createdAt-last" ≠ "array-last". Whenever they disagree, the summary hangs off a council member the reader never descends into, so it — and everything after it — is stranded and never rendered.

This is also why a follow-up user turn could fork at the pre-broadcast supervisor: `sendMessage` resolves the next `parentId` from this same flat list, and the stranded summary wasn't in it.

**Fix:** continue from **every** council member's children instead of just the last. Members are already in `processedIds`, so only the member carrying the reply chain emits anything and the guard prevents duplicates. This heals existing conversations (summary renders again) **and** prevents new forks (the next user turn now anchors to the visible summary).

#### 🧪 How to Test

- [x] Added/updated tests

Added 3 regression cases in `parse.test.ts` asserting the supervisor reply surfaces no matter which council member it parents to (first/middle/last), with no duplication. Full `conversation-flow` suite green (148/148).

Impact (prod): the precise "supervisor-summary-stranded" signature affects ~137 advisory rounds across ~107 topics / ~89 groups; structural since 2026-01 (a separate Linear issue tracks the impact sizing).