### PR TITLE
✨ feat(desktop): always open a fresh tab on the "+" button

### DIFF
--- a/src/features/Electron/navigation/useTabNavigation.ts
+++ b/src/features/Electron/navigation/useTabNavigation.ts
@@ -33,17 +33,25 @@ export const useTabNavigation = () => {
     if (prevLocationRef.current === currentUrl) return;
     prevLocationRef.current = currentUrl;
 
-    const id = normalizeTabUrl(currentUrl);
+    const normalized = normalizeTabUrl(currentUrl);
     const { tabs, activeTabId } = useElectronStore.getState();
 
-    const existing = tabs.find((t) => t.id === id);
-    if (existing) {
-      if (existing.id !== activeTabId) activateTab(existing.id);
+    const activeTab = activeTabId ? tabs.find((t) => t.id === activeTabId) : null;
+    if (activeTab && normalizeTabUrl(activeTab.url) === normalized) {
+      // Keep the active tab's url in sync (e.g. query/hash variations that
+      // normalize the same) without re-activating.
+      if (activeTab.url !== currentUrl) updateTab(activeTab.id, currentUrl);
       return;
     }
 
-    if (activeTabId && tabs.some((t) => t.id === activeTabId)) {
-      updateTab(activeTabId, currentUrl);
+    const existing = tabs.find((t) => normalizeTabUrl(t.url) === normalized);
+    if (existing) {
+      activateTab(existing.id);
+      return;
+    }
+
+    if (activeTab) {
+      updateTab(activeTab.id, currentUrl);
     } else {
       // First launch (or stale activeTabId): make the current page visible as a tab,
       // so the tab bar and its "+" entry are always discoverable.
@@ -54,9 +62,11 @@ export const useTabNavigation = () => {
   useEffect(() => {
     if (!currentRouteMeta || !currentRouteMetaUrl) return;
 
-    const { activeTabId } = useElectronStore.getState();
+    const { activeTabId, tabs } = useElectronStore.getState();
     if (!activeTabId) return;
-    if (activeTabId !== normalizeTabUrl(currentRouteMetaUrl)) return;
+    const activeTab = tabs.find((t) => t.id === activeTabId);
+    if (!activeTab) return;
+    if (normalizeTabUrl(activeTab.url) !== normalizeTabUrl(currentRouteMetaUrl)) return;
 
     updateTabCache(activeTabId, currentRouteMeta);
   }, [currentRouteMeta, currentRouteMetaUrl, updateTabCache]);

--- a/src/features/Electron/titlebar/TabBar/hooks/useResolvedTabs.ts
+++ b/src/features/Electron/titlebar/TabBar/hooks/useResolvedTabs.ts
@@ -31,11 +31,14 @@ export const resolveTab = (
   isActive: boolean,
   t: Translate,
   liveDynamic?: DynamicRouteMeta | null,
-  liveDynamicTabId?: string | null,
+  liveDynamicUrl?: string | null,
 ): ResolvedTab => {
   const staticMeta = matchRouteMeta(routes, tab.url).static;
 
-  const live = isActive && liveDynamicTabId === tab.id ? liveDynamic : undefined;
+  const live =
+    isActive && liveDynamicUrl && normalizeTabUrl(tab.url) === normalizeTabUrl(liveDynamicUrl)
+      ? liveDynamic
+      : undefined;
 
   const title =
     pickMeaningful(live?.title) ??
@@ -68,7 +71,6 @@ export const useResolvedTabs = (): UseResolvedTabsResult => {
   const currentRouteMetaUrl = useElectronStore((s) => s.currentRouteMetaUrl);
 
   const translate = t as unknown as Translate;
-  const currentRouteMetaTabId = currentRouteMetaUrl ? normalizeTabUrl(currentRouteMetaUrl) : null;
 
   const tabs = useMemo(
     () =>
@@ -79,10 +81,10 @@ export const useResolvedTabs = (): UseResolvedTabsResult => {
           tab.id === activeTabId,
           translate,
           currentRouteMeta,
-          currentRouteMetaTabId,
+          currentRouteMetaUrl,
         ),
       ),
-    [tabRefs, activeTabId, currentRouteMeta, currentRouteMetaTabId, translate],
+    [tabRefs, activeTabId, currentRouteMeta, currentRouteMetaUrl, translate],
   );
 
   return { activeTabId, tabs };

--- a/src/features/Electron/titlebar/TabBar/index.tsx
+++ b/src/features/Electron/titlebar/TabBar/index.tsx
@@ -32,7 +32,6 @@ import TabItem from './TabItem';
 const TAB_WIDTH = 180;
 const TAB_GAP = 0;
 
-// The "+" button always opens a fresh Home tab, regardless of the active page.
 const NEW_TAB_URL = '/';
 
 // Tabs only reorder along the horizontal axis, so lock the drag transform to X.
@@ -48,7 +47,7 @@ const TabBar = () => {
   const scrolledActiveTabIdRef = useRef<string | null>(null);
   const { tabs, activeTabId } = useResolvedTabs();
   const activateTab = useElectronStore((s) => s.activateTab);
-  const addTab = useElectronStore((s) => s.addTab);
+  const addNewTab = useElectronStore((s) => s.addNewTab);
   const removeTab = useElectronStore((s) => s.removeTab);
   const closeOtherTabs = useElectronStore((s) => s.closeOtherTabs);
   const closeLeftTabs = useElectronStore((s) => s.closeLeftTabs);
@@ -177,11 +176,10 @@ const TabBar = () => {
   const handleNewTab = useCallback(() => {
     if (!canCreate) return;
 
-    // Always open a fresh Home tab. If a Home tab already exists, addTab just
-    // activates it instead of stacking duplicates.
-    addTab(NEW_TAB_URL, undefined, true);
+    // Always open a fresh Home tab, even if a Home tab already exists.
+    addNewTab(NEW_TAB_URL);
     startTransition(() => navigate(NEW_TAB_URL));
-  }, [canCreate, addTab, navigate]);
+  }, [canCreate, addNewTab, navigate]);
 
   useWatchBroadcast('createNewTab', () => {
     handleNewTab();

--- a/src/store/electron/actions/__tests__/tabPages.test.ts
+++ b/src/store/electron/actions/__tests__/tabPages.test.ts
@@ -23,16 +23,18 @@ describe('tabPages actions', () => {
   });
 
   describe('addTab', () => {
-    it('uses the normalized URL as the tab id', () => {
+    it('creates a tab with a stable generated id and activates it', () => {
       const { result } = renderHook(() => useElectronStore());
 
+      let createdId = '';
       act(() => {
-        result.current.addTab('/agent/abc?b=2&a=1');
+        createdId = result.current.addTab('/agent/abc?b=2&a=1');
       });
 
       expect(result.current.tabs).toHaveLength(1);
-      expect(result.current.tabs[0].id).toBe('/agent/abc?a=1&b=2');
-      expect(result.current.activeTabId).toBe('/agent/abc?a=1&b=2');
+      expect(result.current.tabs[0].id).toBe(createdId);
+      expect(result.current.tabs[0].url).toBe('/agent/abc?b=2&a=1');
+      expect(result.current.activeTabId).toBe(createdId);
     });
 
     it('dedupes tabs that resolve to the same normalized URL', () => {
@@ -58,8 +60,26 @@ describe('tabPages actions', () => {
     });
   });
 
+  describe('addNewTab', () => {
+    it('always creates a fresh tab even when the URL already has a tab', () => {
+      const { result } = renderHook(() => useElectronStore());
+
+      act(() => {
+        result.current.addNewTab('/');
+        result.current.addNewTab('/');
+        result.current.addNewTab('/');
+      });
+
+      expect(result.current.tabs).toHaveLength(3);
+      const ids = result.current.tabs.map((t) => t.id);
+      expect(new Set(ids).size).toBe(3);
+      expect(result.current.tabs.every((t) => t.url === '/')).toBe(true);
+      expect(result.current.activeTabId).toBe(result.current.tabs[2].id);
+    });
+  });
+
   describe('updateTab', () => {
-    it('drops cached data when the tab navigates to a different page', () => {
+    it('drops cached data when the tab navigates to a different page but keeps the id stable', () => {
       const { result } = renderHook(() => useElectronStore());
       const agentTab = buildTab('/agent/abc', { title: 'Claude Code' });
 
@@ -72,9 +92,10 @@ describe('tabPages actions', () => {
       });
 
       const updatedTab = result.current.tabs[0];
-      expect(updatedTab.id).toBe('/');
+      expect(updatedTab.id).toBe(agentTab.id);
+      expect(updatedTab.url).toBe('/');
       expect(updatedTab.cached).toBeUndefined();
-      expect(result.current.activeTabId).toBe('/');
+      expect(result.current.activeTabId).toBe(agentTab.id);
     });
 
     it('keeps cached data when the normalized URL is unchanged', () => {

--- a/src/store/electron/actions/tabPages.ts
+++ b/src/store/electron/actions/tabPages.ts
@@ -1,3 +1,5 @@
+import { nanoid } from 'nanoid';
+
 import { guardedMergeCache } from '@/features/Electron/titlebar/TabBar/resolveRouteMeta';
 import { getTabPages, saveTabPages } from '@/features/Electron/titlebar/TabBar/storage';
 import { type TabItem } from '@/features/Electron/titlebar/TabBar/types';
@@ -6,6 +8,8 @@ import { type DynamicRouteMeta } from '@/spa/router/routeMeta';
 import { type StoreSetter } from '@/store/types';
 
 import { type ElectronStore } from '../store';
+
+const generateTabId = (): string => `tab_${nanoid(8)}`;
 
 // ======== Types ======== //
 
@@ -46,33 +50,23 @@ export class TabPagesActionImpl {
   };
 
   addTab = (url: string, cached?: DynamicRouteMeta, activate = true): string => {
-    const id = normalizeTabUrl(url);
+    const normalized = normalizeTabUrl(url);
     const { tabs } = this.#get();
-    const existing = tabs.find((t) => t.id === id);
+    const existing = tabs.find((t) => normalizeTabUrl(t.url) === normalized);
 
     if (existing) {
       if (activate) {
-        this.#set({ activeTabId: id }, false, 'activateExistingTab');
+        this.#set({ activeTabId: existing.id }, false, 'activateExistingTab');
         this.#persist();
       }
-      return id;
+      return existing.id;
     }
 
-    const newTab: TabItem = {
-      cached,
-      id,
-      lastVisited: Date.now(),
-      url,
-    };
+    return this.#createTab(url, cached, activate);
+  };
 
-    const newTabs = [...tabs, newTab];
-    this.#set(
-      { activeTabId: activate ? id : this.#get().activeTabId, tabs: newTabs },
-      false,
-      'addTab',
-    );
-    this.#persist();
-    return id;
+  addNewTab = (url: string, cached?: DynamicRouteMeta): string => {
+    return this.#createTab(url, cached, true);
   };
 
   getActiveTab = (): TabItem | null => {
@@ -157,27 +151,24 @@ export class TabPagesActionImpl {
   };
 
   updateTab = (id: string, url: string): string => {
-    const { tabs, activeTabId } = this.#get();
+    const { tabs } = this.#get();
     const index = tabs.findIndex((t) => t.id === id);
     if (index < 0) return id;
 
-    const nextId = normalizeTabUrl(url);
     const prev = tabs[index];
+    const sameTarget = normalizeTabUrl(url) === normalizeTabUrl(prev.url);
 
     const newTabs = [...tabs];
     newTabs[index] = {
       ...prev,
-      cached: nextId === prev.id ? prev.cached : undefined,
-      id: nextId,
+      cached: sameTarget ? prev.cached : undefined,
       lastVisited: Date.now(),
       url,
     };
 
-    const newActiveTabId = activeTabId === id ? nextId : activeTabId;
-
-    this.#set({ activeTabId: newActiveTabId, tabs: newTabs }, false, 'updateTab');
+    this.#set({ tabs: newTabs }, false, 'updateTab');
     this.#persist();
-    return nextId;
+    return id;
   };
 
   updateTabCache = (id: string, cached: DynamicRouteMeta): void => {
@@ -193,6 +184,25 @@ export class TabPagesActionImpl {
 
     this.#set({ tabs: newTabs }, false, 'updateTabCache');
     this.#persist();
+  };
+
+  #createTab = (url: string, cached: DynamicRouteMeta | undefined, activate: boolean): string => {
+    const { tabs, activeTabId } = this.#get();
+    const id = generateTabId();
+    const newTab: TabItem = {
+      cached,
+      id,
+      lastVisited: Date.now(),
+      url,
+    };
+
+    this.#set(
+      { activeTabId: activate ? id : activeTabId, tabs: [...tabs, newTab] },
+      false,
+      'addTab',
+    );
+    this.#persist();
+    return id;
   };
 
   #persist = (): void => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

The desktop tabbar's "+" button used to dedupe by URL — clicking "+" while a Home tab already existed just reactivated the existing tab. Per product feedback, drop that dedupe so every click on "+" opens a fresh Home tab.

To support multiple tabs that share the same URL, tab identity is decoupled from URL:

- Tab `id` is now a stable `nanoid` generated at creation time (was: `normalize(url)`).
- `addTab(url)` still dedupes by URL — sidebar/page-item clicks behave unchanged.
- New `addNewTab(url)` action always creates a fresh tab; the "+" button uses it.
- `updateTab(id, url)` keeps the id stable when navigating; only updates `url` and clears stale cache.
- `useTabNavigation` and `useResolvedTabs` look up tabs by URL match instead of id equality.

Legacy persisted tabs (id == url) keep working — the id is just an opaque unique string now.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Steps:
1. Open the desktop app, click "+" multiple times → each click opens a new Home tab.
2. Click an existing page in the sidebar → still activates the existing tab (no dup).
3. Navigate inside a tab → tab id stays stable, cache clears on URL change.

#### 📝 Additional Information

No schema or storage migration required.