### PR TITLE
✨ feat(topic): show creator avatar for others' topics in workspace sidebar

### DIFF
--- a/packages/database/src/models/__tests__/topics/topic.query.test.ts
+++ b/packages/database/src/models/__tests__/topics/topic.query.test.ts
@@ -305,6 +305,89 @@ describe('TopicModel - Query', () => {
       expect(result.items[1].id).toBe('group-topic-5');
     });
 
+    it('should return the creator userId for workspace group topics from multiple members', async () => {
+      // Workspace group topics are shared across members; the sidebar shows a
+      // creator avatar for topics authored by someone other than the viewer, so
+      // the query must surface each row's `userId` (the creator).
+      await serverDB.insert(workspaces).values({
+        id: 'topic-ws',
+        name: 'Workspace',
+        primaryOwnerId: userId,
+        slug: 'topic-ws',
+      });
+      await serverDB.transaction(async (tx) => {
+        await tx
+          .insert(chatGroups)
+          .values({ id: 'ws-group', title: 'WS Group', userId, workspaceId: 'topic-ws' });
+        await tx.insert(topics).values([
+          {
+            id: 'mine',
+            userId,
+            groupId: 'ws-group',
+            workspaceId: 'topic-ws',
+            updatedAt: new Date('2023-05-02'),
+          },
+          {
+            id: 'theirs',
+            userId: userId2,
+            groupId: 'ws-group',
+            workspaceId: 'topic-ws',
+            updatedAt: new Date('2023-05-01'),
+          },
+        ]);
+      });
+
+      // Query as `userId` scoped to the workspace — both members' topics return.
+      const result = await new TopicModel(serverDB, userId, 'topic-ws').query({
+        groupId: 'ws-group',
+      });
+
+      expect(result.items).toMatchObject([
+        { id: 'mine', userId },
+        { id: 'theirs', userId: userId2 },
+      ]);
+    });
+
+    it('should return the creator userId for workspace agent topics from multiple members', async () => {
+      // Workspace agents are shared; the sidebar shows a creator avatar for
+      // topics authored by another member, so the agentId-scoped query must
+      // surface each row's `userId` (the creator).
+      await serverDB.insert(workspaces).values({
+        id: 'topic-ws-agent',
+        name: 'Workspace',
+        primaryOwnerId: userId,
+        slug: 'topic-ws-agent',
+      });
+      await serverDB.transaction(async (tx) => {
+        await tx.insert(agents).values({ id: 'ws-agent', userId, workspaceId: 'topic-ws-agent' });
+        await tx.insert(topics).values([
+          {
+            id: 'agent-mine',
+            userId,
+            agentId: 'ws-agent',
+            workspaceId: 'topic-ws-agent',
+            updatedAt: new Date('2023-05-02'),
+          },
+          {
+            id: 'agent-theirs',
+            userId: userId2,
+            agentId: 'ws-agent',
+            workspaceId: 'topic-ws-agent',
+            updatedAt: new Date('2023-05-01'),
+          },
+        ]);
+      });
+
+      const result = await new TopicModel(serverDB, userId, 'topic-ws-agent').query({
+        agentId: 'ws-agent',
+      });
+
+      expect(result.items).toMatchObject([
+        { id: 'agent-mine', userId },
+        { id: 'agent-theirs', userId: userId2 },
+      ]);
+    });
+
     it('should return topics based on pagination parameters', async () => {
       await serverDB.insert(topics).values([
         { id: 'topic1', sessionId, userId, updatedAt: new Date('2023-01-01') },

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -298,6 +298,10 @@ export class TopicModel {
                 status: topics.status,
                 title: topics.title,
                 updatedAt: topics.updatedAt,
+                // Creator id — in workspace mode the list mixes topics from all
+                // members, so the sidebar uses this to show a creator avatar for
+                // topics authored by someone other than the current user.
+                userId: topics.userId,
                 ...detailColumns,
               } as any)
               .from(topics)
@@ -360,6 +364,9 @@ export class TopicModel {
                 status: topics.status,
                 title: topics.title,
                 updatedAt: topics.updatedAt,
+                // Creator id — workspace agents are shared, so the sidebar shows
+                // a creator avatar for topics authored by another member.
+                userId: topics.userId,
                 ...detailColumns,
               } as any)
               .from(topics)

--- a/src/features/TopicCreatorAvatar/index.test.tsx
+++ b/src/features/TopicCreatorAvatar/index.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import TopicCreatorAvatar from './index';
+
+const CURRENT_USER_ID = 'me';
+
+const useAuthorInfoMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/business/client/hooks/useAuthorInfo', () => ({
+  useAuthorInfo: useAuthorInfoMock,
+}));
+
+// `useUserStore(selector)` → run the selector against a fixed state so the
+// component sees a stable current user id.
+vi.mock('@/store/user', () => ({
+  useUserStore: (selector: (s: { userId: string }) => unknown) =>
+    selector({ userId: CURRENT_USER_ID }),
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  userProfileSelectors: { userId: (s: { userId: string }) => s.userId },
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  Avatar: ({ avatar, title }: { avatar?: string; title?: string }) => (
+    <span data-avatar={avatar ?? ''} data-testid="avatar" data-title={title ?? ''} />
+  ),
+  Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+}));
+
+describe('TopicCreatorAvatar', () => {
+  it("renders another member's avatar for topics they created", () => {
+    useAuthorInfoMock.mockReturnValue({ avatar: 'https://x/y.png', fullName: 'Alice' });
+
+    const { getByTestId } = render(<TopicCreatorAvatar userId="someone-else" />);
+
+    // The slot is queried with the *creator* id (not the current user).
+    expect(useAuthorInfoMock).toHaveBeenCalledWith('someone-else');
+    const avatar = getByTestId('avatar');
+    expect(avatar.getAttribute('data-avatar')).toBe('https://x/y.png');
+    expect(avatar.getAttribute('data-title')).toBe('Alice');
+  });
+
+  it("renders nothing for the current user's own topics", () => {
+    useAuthorInfoMock.mockReturnValue(undefined);
+
+    const { queryByTestId } = render(<TopicCreatorAvatar userId={CURRENT_USER_ID} />);
+
+    // Own topic → slot is called with undefined so it never resolves a profile.
+    expect(useAuthorInfoMock).toHaveBeenCalledWith(undefined);
+    expect(queryByTestId('avatar')).toBeNull();
+  });
+
+  it('renders nothing when the creator is not a resolvable workspace member', () => {
+    useAuthorInfoMock.mockReturnValue(undefined);
+
+    const { queryByTestId } = render(<TopicCreatorAvatar userId="ghost" />);
+
+    expect(queryByTestId('avatar')).toBeNull();
+  });
+
+  it('renders nothing when no userId is provided (personal / default topic)', () => {
+    useAuthorInfoMock.mockReturnValue(undefined);
+
+    const { queryByTestId } = render(<TopicCreatorAvatar />);
+
+    expect(useAuthorInfoMock).toHaveBeenCalledWith(undefined);
+    expect(queryByTestId('avatar')).toBeNull();
+  });
+});

--- a/src/features/TopicCreatorAvatar/index.tsx
+++ b/src/features/TopicCreatorAvatar/index.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Avatar, Tooltip } from '@lobehub/ui';
+import { memo } from 'react';
+
+import { useAuthorInfo } from '@/business/client/hooks/useAuthorInfo';
+import { useUserStore } from '@/store/user';
+import { userProfileSelectors } from '@/store/user/selectors';
+
+interface TopicCreatorAvatarProps {
+  /** Size of the avatar in px. */
+  size?: number;
+  /** Creator (author) of the topic. */
+  userId?: string;
+}
+
+/**
+ * In a workspace the topic list mixes topics from every member. Show the
+ * creator's avatar for topics authored by someone *other* than the current
+ * user so the list reads as a shared space.
+ *
+ * Renders nothing for own / personal topics: `useAuthorInfo` is a business slot
+ * that resolves to a no-op (open-source) or the active workspace member profile
+ * (cloud), and we pass `undefined` for the current user so it never resolves.
+ */
+const TopicCreatorAvatar = memo<TopicCreatorAvatarProps>(({ userId, size = 16 }) => {
+  const currentUserId = useUserStore(userProfileSelectors.userId);
+  const isOther = !!userId && userId !== currentUserId;
+  const author = useAuthorInfo(isOther ? userId : undefined);
+
+  if (!author) return null;
+
+  return (
+    <Tooltip title={author.fullName}>
+      <Avatar
+        avatar={author.avatar ?? undefined}
+        size={size}
+        style={{ flex: 'none' }}
+        title={author.fullName ?? undefined}
+      />
+    </Tooltip>
+  );
+});
+
+TopicCreatorAvatar.displayName = 'TopicCreatorAvatar';
+
+export default TopicCreatorAvatar;

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/AllTopicsDrawer/Content.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/AllTopicsDrawer/Content.tsx
@@ -173,6 +173,7 @@ const Content = memo<ContentProps>(({ open, searchKeyword }) => {
             status={topic.status}
             threadId={activeThreadId}
             title={topic.title}
+            userId={topic.userId}
           />
         </Flexbox>
       ))}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -14,6 +14,7 @@ import { isDesktop } from '@/const/version';
 import DirIcon from '@/features/ChatInput/ControlBar/DirIcon';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';
 import NavItem from '@/features/NavPanel/components/NavItem';
+import TopicCreatorAvatar from '@/features/TopicCreatorAvatar';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { getPlatformIcon } from '@/routes/(main)/agent/channel/const';
 import { useAgentStore } from '@/store/agent';
@@ -149,10 +150,12 @@ interface TopicItemProps {
   status?: ChatTopicStatus | null;
   threadId?: string;
   title: string;
+  /** Creator of the topic; drives the workspace creator avatar. */
+  userId?: string;
 }
 
 const TopicItem = memo<TopicItemProps>(
-  ({ id, title, fav, active, threadId, metadata, status, showWorkingDirectory }) => {
+  ({ id, title, fav, active, threadId, metadata, status, showWorkingDirectory, userId }) => {
     const { t } = useTranslation('topic');
     const { isDarkMode } = useTheme();
     const activeAgentId = useAgentStore((s) => s.activeAgentId);
@@ -327,7 +330,6 @@ const TopicItem = memo<TopicItemProps>(
           disabled={editing}
           extra={<RunningElapsedTime agentId={activeAgentId} topicId={id} />}
           href={href}
-          slots={{ titlePrefix: draftPrefix }}
           title={title === '...' ? <DotsLoading gap={3} size={4} /> : title}
           titleColor={cssVar.colorText}
           icon={(() => {
@@ -380,6 +382,14 @@ const TopicItem = memo<TopicItemProps>(
               />
             );
           })()}
+          slots={{
+            titlePrefix: (
+              <>
+                <TopicCreatorAvatar userId={userId} />
+                {draftPrefix}
+              </>
+            ),
+          }}
           onClick={handleClick}
           onDoubleClick={() => void handleDoubleClick()}
         />

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
@@ -334,6 +334,7 @@ const GroupItem = memo<GroupItemComponentProps>(
               status={topic.status}
               threadId={activeThreadId}
               title={topic.title}
+              userId={topic.userId}
             />
           ))}
         </Flexbox>

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByStatusMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByStatusMode/GroupItem.tsx
@@ -63,6 +63,7 @@ const GroupItem = memo<GroupItemComponentProps>(({ group, activeTopicId, activeT
             status={topic.status}
             threadId={activeThreadId}
             title={topic.title}
+            userId={topic.userId}
           />
         ))}
       </Flexbox>

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/GroupItem.tsx
@@ -39,6 +39,7 @@ const GroupItem = memo<GroupItemComponentProps>(({ group, activeTopicId, activeT
             status={topic.status}
             threadId={activeThreadId}
             title={topic.title}
+            userId={topic.userId}
           />
         ))}
       </Flexbox>

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
@@ -52,6 +52,7 @@ const FlatMode = memo(() => {
           status={topic.status}
           threadId={activeThreadId}
           title={topic.title}
+          userId={topic.userId}
         />
       ))}
       {isExpandingPageSize && <SkeletonList rows={3} />}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/SearchResult/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/SearchResult/index.tsx
@@ -39,6 +39,7 @@ const SearchResult = memo(() => {
           metadata={topic.metadata}
           status={topic.status}
           title={topic.title}
+          userId={topic.userId}
         />
       ))}
     </>

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -17,6 +17,7 @@ import DotsLoading from '@/components/DotsLoading';
 import { isDesktop } from '@/const/version';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';
 import NavItem from '@/features/NavPanel/components/NavItem';
+import TopicCreatorAvatar from '@/features/TopicCreatorAvatar';
 import { useFocusTopicPopup } from '@/features/TopicPopupGuard/useTopicPopupsRegistry';
 import { useAgentGroupStore } from '@/store/agentGroup';
 import { useChatStore } from '@/store/chat';
@@ -85,9 +86,11 @@ interface TopicItemProps {
   status?: ChatTopicStatus | null;
   threadId?: string;
   title: string;
+  /** Creator of the topic; drives the workspace creator avatar. */
+  userId?: string;
 }
 
-const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, status }) => {
+const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, status, userId }) => {
   const { t } = useTranslation('topic');
   const toggleMobileTopic = useGlobalStore((s) => s.toggleMobileTopic);
   const [activeGroupId, switchTopic] = useAgentGroupStore((s) => [s.activeGroupId, s.switchTopic]);
@@ -294,7 +297,12 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
         })()}
         slots={{
           iconPostfix: unreadNode,
-          titlePrefix: draftPrefix,
+          titlePrefix: (
+            <>
+              <TopicCreatorAvatar userId={userId} />
+              {draftPrefix}
+            </>
+          ),
         }}
         onClick={handleClick}
         onDoubleClick={() => void handleDoubleClick()}

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/GroupItem.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/GroupItem.tsx
@@ -45,6 +45,7 @@ const GroupItem = memo<GroupItemProps>(({ group, activeTopicId, activeThreadId }
             status={topic.status}
             threadId={activeThreadId}
             title={topic.title}
+            userId={topic.userId}
           />
         ))}
       </Flexbox>

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/FlatMode/index.tsx
@@ -47,6 +47,7 @@ const FlatMode = memo(() => {
           status={topic.status}
           threadId={activeThreadId}
           title={topic.title}
+          userId={topic.userId}
         />
       ))}
       {isExpandingPageSize && <SkeletonList rows={3} />}


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

In a workspace, the topic list mixes topics from every member. This surfaces the **creator's avatar** for topics authored by **someone other than the current user**, so the list reads as a shared space. Your own (and personal-mode) topics are unchanged.

**Implementation**

- New shared component `src/features/TopicCreatorAvatar` — resolves the creator profile via the existing `useAuthorInfo` business slot (cloud → active workspace member `{ avatar, fullName }`; open-source → no-op). Renders a small avatar + name tooltip, and nothing for own/personal topics or when the creator isn't a resolvable member.
- Wired into **both** workspace topic sidebars:
  - **agent** sidebar `TopicItem` + all mappers (FlatMode, ByTime, ByProject, ByStatus, SearchResult, AllTopicsDrawer)
  - **group** sidebar `TopicItem` + mappers
- Server: `TopicModel.query` now returns the creator `userId` from the **agent** and **group** branches (workspace queries already return all members' topics; only the creator id was missing from the `select`).

No new i18n keys (the tooltip shows member data, not translated copy). Workspace members are already preloaded by `bootstrapWorkspaceData`, so no extra fetch.

#### 🧪 How to Test

- [x] Added/updated tests
- [x] Tested locally

- **Backend** (`packages/database`): `bunx vitest run 'src/models/__tests__/topics/topic.query.test.ts' -t "creator userId"` — query returns the correct creator `userId` for multi-member workspace topics on both the agent and group branches.
- **Frontend**: `bunx vitest run 'src/features/TopicCreatorAvatar/index.test.tsx'` — avatar renders for other members; nothing for self / non-member / no-id.

To see it manually: open a workspace agent/group whose topic list has topics from multiple members on the **Web** app — other members' rows show their avatar. (Note: the local-mode Electron desktop reads topics from a local PGlite mirror, so it won't reflect this server-side change.)

#### 📸 Screenshots / Videos

Workspace member avatars resolve live (confirmed in desktop: 14 members loaded with avatars). Visual of the rendered row to be added from the Web surface.
