### PR TITLE
✨ feat(inbox): enable user-interaction tool for inbox agent

### DIFF
--- a/packages/builtin-agents/src/agents/inbox/index.ts
+++ b/packages/builtin-agents/src/agents/inbox/index.ts
@@ -1,4 +1,5 @@
 import { AgentDocumentsIdentifier } from '@lobechat/builtin-tool-agent-documents';
+import { UserInteractionIdentifier } from '@lobechat/builtin-tool-user-interaction';
 
 import type { BuiltinAgentDefinition } from '../../types';
 import { BUILTIN_AGENT_SLUGS } from '../../types';
@@ -12,7 +13,7 @@ import { createSystemRole } from './systemRole';
 export const INBOX: BuiltinAgentDefinition = {
   avatar: '/avatars/lobe-ai.png',
   runtime: (ctx) => ({
-    plugins: [AgentDocumentsIdentifier, ...(ctx.plugins || [])],
+    plugins: [AgentDocumentsIdentifier, UserInteractionIdentifier, ...(ctx.plugins || [])],
     systemRole: createSystemRole(ctx.userLocale),
   }),
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Add the built-in `UserInteractionIdentifier` tool to the inbox agent's runtime plugin list, mirroring how it is already wired for the web-onboarding agent.

After this change, `getAgentRuntimeConfig('inbox', ctx)` returns:

\`\`\`
plugins: ['lobe-agent-documents', 'lobe-user-interaction', ...ctx.plugins]
\`\`\`

Both the client chat resolver (\`src/services/chat/mecha/agentConfigResolver.ts\`) and the server agent runner (\`apps/server/src/services/aiAgent/index.ts\`) share this single source, so the user-interaction tool becomes available to the inbox agent across both pure-client and server-side chat paths.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Verified at runtime in the local SPA (debug proxy + Vite HMR):

\`\`\`js
getAgentRuntimeConfig('inbox', { plugins: ['user-plugin-a','user-plugin-b'] })
// → plugins: ["lobe-agent-documents","lobe-user-interaction","user-plugin-a","user-plugin-b"]
\`\`\`

#### 📸 Screenshots / Videos

N/A — no UI surface change; tool becomes available to the inbox agent.

#### 📝 Additional Information

No breaking changes. The new plugin is appended ahead of user-supplied plugins, preserving existing user plugin ordering after the built-ins.