### PR TITLE
🐛 fix(agent): preserve agency config across nested updates

### DIFF
--- a/src/store/agent/slices/agent/action.test.ts
+++ b/src/store/agent/slices/agent/action.test.ts
@@ -513,6 +513,47 @@ describe('AgentSlice Actions', () => {
       });
     });
 
+    it('should send the latest local agencyConfig when persisting a nested patch', async () => {
+      const { result } = renderHook(() => useAgentStore());
+      const latestAgencyConfig = {
+        boundDeviceId: 'current-device',
+        executionTarget: 'local',
+        heterogeneousProvider: {
+          command: 'claude',
+          env: { CLAUDE_CODE_CRED_KEY: 'cred-key' },
+          type: 'claude-code',
+        },
+        workingDirByDevice: { 'current-device': '/repos/lobehub' },
+      } as const;
+      const nextAgencyConfig = {
+        ...latestAgencyConfig,
+        heterogeneousProvider: { ...latestAgencyConfig.heterogeneousProvider, effort: 'high' },
+      };
+
+      vi.mocked(agentService.updateAgentConfig).mockResolvedValue({
+        agent: { agencyConfig: nextAgencyConfig } as any,
+        success: true,
+      });
+
+      act(() => {
+        useAgentStore.setState({
+          agentMap: { 'agent-1': { agencyConfig: latestAgencyConfig } as any },
+        });
+      });
+
+      await act(async () => {
+        await result.current.updateAgentConfigById('agent-1', {
+          agencyConfig: { heterogeneousProvider: { effort: 'high' } },
+        } as any);
+      });
+
+      expect(agentService.updateAgentConfig).toHaveBeenCalledWith(
+        'agent-1',
+        { agencyConfig: nextAgencyConfig },
+        expect.any(AbortSignal),
+      );
+    });
+
     // Note: refreshSessions is no longer called after optimistic update
     // as the implementation now uses API returned data directly
   });

--- a/src/store/agent/slices/agent/action.ts
+++ b/src/store/agent/slices/agent/action.ts
@@ -1,6 +1,10 @@
 import { isDesktop } from '@lobechat/const';
 import { type AgentContextDocument } from '@lobechat/context-engine';
-import { isChatGroupSessionId, pruneWorkingDirByDeviceDeletes } from '@lobechat/types';
+import {
+  isChatGroupSessionId,
+  type LobeAgentAgencyConfig,
+  pruneWorkingDirByDeviceDeletes,
+} from '@lobechat/types';
 import { getSingletonAnalyticsOptional } from '@lobehub/analytics';
 import isEqual from 'fast-deep-equal';
 import { produce } from 'immer';
@@ -39,6 +43,28 @@ type AgentMetaUpdate = Partial<
     'avatar' | 'backgroundColor' | 'description' | 'marketIdentifier' | 'tags' | 'title'
   >
 >;
+type AgencyConfigPatch = PartialDeep<LobeAgentAgencyConfig>;
+
+const preserveWorkingDirDeleteMarkers = (
+  merged: LobeAgentAgencyConfig,
+  patch: AgencyConfigPatch,
+): void => {
+  const incoming = patch.workingDirByDevice;
+  if (!incoming) return;
+
+  const deletions = Object.keys(incoming).filter((key) => incoming[key] === undefined);
+  if (deletions.length === 0) return;
+
+  const workingDirByDevice = {
+    ...merged.workingDirByDevice,
+  } as Record<string, string | undefined>;
+
+  for (const key of deletions) {
+    workingDirByDevice[key] = undefined;
+  }
+
+  merged.workingDirByDevice = workingDirByDevice as Record<string, string>;
+};
 
 /**
  * Agent Slice Actions
@@ -456,20 +482,40 @@ export class AgentSliceActionImpl {
     this.#set({ agentMap }, false, 'dispatchAgentMap');
   };
 
+  #mergeLatestAgencyConfigPatch = (
+    id: string,
+    data: PartialDeep<LobeAgentConfig>,
+  ): PartialDeep<LobeAgentConfig> => {
+    const agencyConfigPatch = data.agencyConfig;
+    if (!agencyConfigPatch) return data;
+
+    const currentAgencyConfig = this.#get().agentMap[id]?.agencyConfig;
+    const agencyConfig = merge(
+      currentAgencyConfig ?? {},
+      agencyConfigPatch,
+    ) as LobeAgentAgencyConfig;
+
+    pruneWorkingDirByDeviceDeletes(agencyConfig, agencyConfigPatch);
+    preserveWorkingDirDeleteMarkers(agencyConfig, agencyConfigPatch);
+
+    return { ...data, agencyConfig };
+  };
+
   optimisticUpdateAgentConfig = async (
     id: string,
     data: PartialDeep<LobeAgentConfig>,
     signal?: AbortSignal,
   ): Promise<void> => {
     const { internal_dispatchAgentMap, updateSaveStatus } = this.#get();
+    const mergedData = this.#mergeLatestAgencyConfigPatch(id, data);
 
     // 1. Optimistic update (instant UI feedback)
-    internal_dispatchAgentMap(id, data);
+    internal_dispatchAgentMap(id, mergedData);
     updateSaveStatus('saving');
 
     try {
       // 2. API call returns updated agent data
-      const result = await agentService.updateAgentConfig(id, data, signal);
+      const result = await agentService.updateAgentConfig(id, mergedData, signal);
 
       // 3. Use returned data directly (no refetch needed!)
       if (result?.success && result.agent) {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #15522

#### 🔀 Description of Change

- Merge nested `agencyConfig` patches with the latest local agent config before optimistic updates and persistence.
- Preserve current execution target, bound device, provider env, and per-device working directory when a later nested update aborts an earlier config save.
- Add regression coverage for persisting a provider-only patch after local device state has already changed.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' src/store/agent/slices/agent/action.test.ts
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

`bun run type-check` currently reports pre-existing repository-level type errors unrelated to this change. Filtering its output for `src/store/agent/slices/agent/action` returns no matches.
