### PR TITLE
📝 docs: document db enum guidance

### DIFF
--- a/.agents/skills/drizzle/SKILL.md
+++ b/.agents/skills/drizzle/SKILL.md
@@ -109,6 +109,21 @@ finalDecision: varchar('final_decision', { length: 32 })
   .default('unknown');
 ```
 
+### Database Enums
+
+Default to **not** using PostgreSQL/Drizzle `pgEnum`. Database enums are
+expensive to evolve safely: adding members needs migrations, removing or
+renaming members is awkward, and deployment order becomes more fragile.
+
+For product/business states, use `text()` or `varchar()` with a TypeScript value
+type via `$type<...>()`. Keep those TS-only value types in the domain/shared type
+module, then import them into the schema. For cloud DB schemas, that usually
+means `cloudDB/types.ts`.
+
+Do not copy existing DB enums as a pattern. Treat them as legacy or explicitly
+reviewed exceptions. If a new `pgEnum` seems necessary, stop and justify why the
+value set is effectively immutable and why the migration cost is acceptable.
+
 ### Field Descriptions
 
 For columns whose meaning is not obvious from the name alone, add JSDoc on the


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to lobehub-biz/lobehub-cloud#857

#### 🔀 Description of Change

Document the default Drizzle schema guidance for avoiding PostgreSQL database enums. The guidance recommends `text()` / `varchar()` plus TypeScript value types for product and business states, and treats existing database enums as legacy or explicitly reviewed exceptions.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

N/A; documentation only.

#### 📝 Additional Information

This is an agent workflow documentation update only.