### PR TITLE
✨ feat(image): support drag-and-drop reference image upload

### DIFF
--- a/locales/en-US/image.json
+++ b/locales/en-US/image.json
@@ -7,6 +7,7 @@
   "config.header.title": "Image",
   "config.height.label": "Height",
   "config.imageNum.label": "Number of Images",
+  "config.imageUpload.maxCountReached": "You can add up to {{count}} reference images",
   "config.imageUrl.label": "Reference Image",
   "config.imageUrls.label": "Reference Images",
   "config.model.label": "Model",

--- a/locales/en-US/video.json
+++ b/locales/en-US/video.json
@@ -5,6 +5,7 @@
   "config.endImageUrl.label": "End Frame",
   "config.generateAudio.label": "Generate Audio",
   "config.header.title": "Video",
+  "config.imageUpload.maxCountReached": "You can add up to {{count}} reference images",
   "config.imageUrl.label": "Start Frame",
   "config.prompt.placeholder": "Describe the video you want to generate",
   "config.prompt.placeholderWithRef": "Describe the scene you want to generate with the image",

--- a/locales/zh-CN/image.json
+++ b/locales/zh-CN/image.json
@@ -7,6 +7,7 @@
   "config.header.title": "图片",
   "config.height.label": "高度",
   "config.imageNum.label": "图片数量",
+  "config.imageUpload.maxCountReached": "最多可添加 {{count}} 张参考图",
   "config.imageUrl.label": "参考图",
   "config.imageUrls.label": "参考图",
   "config.model.label": "模型",

--- a/locales/zh-CN/video.json
+++ b/locales/zh-CN/video.json
@@ -5,6 +5,7 @@
   "config.endImageUrl.label": "结束画面",
   "config.generateAudio.label": "生成音频",
   "config.header.title": "视频",
+  "config.imageUpload.maxCountReached": "最多可添加 {{count}} 张参考图",
   "config.imageUrl.label": "起始画面",
   "config.prompt.placeholder": "描述你想生成的视频内容",
   "config.prompt.placeholderWithRef": "结合图片，描述你想生成的画面",

--- a/packages/locales/src/default/image.ts
+++ b/packages/locales/src/default/image.ts
@@ -7,6 +7,7 @@ export default {
   'config.header.title': 'Image',
   'config.height.label': 'Height',
   'config.imageNum.label': 'Number of Images',
+  'config.imageUpload.maxCountReached': 'You can add up to {{count}} reference images',
   'config.imageUrl.label': 'Reference Image',
   'config.imageUrls.label': 'Reference Images',
   'config.model.label': 'Model',

--- a/packages/locales/src/default/video.ts
+++ b/packages/locales/src/default/video.ts
@@ -5,6 +5,7 @@ export default {
   'config.endImageUrl.label': 'End Frame',
   'config.generateAudio.label': 'Generate Audio',
   'config.header.title': 'Video',
+  'config.imageUpload.maxCountReached': 'You can add up to {{count}} reference images',
   'config.imageUrl.label': 'Start Frame',
   'config.promptExtend.label': 'Prompt Extend',
   'config.prompt.placeholder': 'Describe the video you want to generate',

--- a/src/features/ModelSwitchPanel/components/List/index.tsx
+++ b/src/features/ModelSwitchPanel/components/List/index.tsx
@@ -105,7 +105,9 @@ export const List: FC<ListProps> = ({
       className={styles.list}
       flex={1}
       ref={listRef}
-      style={{ height: listHeight }}
+      // No fixed height: flex-shrink within the height-capped panel so the list
+      // scrolls internally on short viewports while the toolbar stays pinned.
+      style={{ minHeight: 0 }}
       onScroll={handleListScroll}
     >
       {listItems.map((item, index) => {

--- a/src/features/ModelSwitchPanel/components/PanelContent.tsx
+++ b/src/features/ModelSwitchPanel/components/PanelContent.tsx
@@ -72,11 +72,23 @@ export const PanelContent: FC<PanelContentProps> = ({
       <Rnd
         disableDragging
         enableResizing={ENABLE_RESIZING}
+        // Rnd needs a numeric `size.height`, but a fixed height overflows the top
+        // edge when the upward-opening popup meets a short viewport. Pass the
+        // clamp through Rnd's own `maxHeight` (a `style.maxHeight` gets overridden
+        // by Rnd's internal default) so CSS caps the box to the space base-ui
+        // exposes via `--available-height`; the inner list then flex-shrinks and
+        // scrolls. Height resize is disabled, so this doesn't fight drag logic.
+        maxHeight={`min(${panelHeight}px, var(--available-height, ${panelHeight}px))`}
         maxWidth={MAX_WIDTH}
         minWidth={MIN_WIDTH}
         position={{ x: 0, y: 0 }}
         size={{ height: panelHeight, width: panelWidth }}
-        style={{ display: 'flex', flexDirection: 'column', position: 'relative' }}
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          minHeight: 0,
+          position: 'relative',
+        }}
         onResizeStop={(_e, _direction, ref) => {
           handlePanelWidthChange(ref.offsetWidth);
         }}
@@ -91,7 +103,13 @@ export const PanelContent: FC<PanelContentProps> = ({
       style={{
         display: 'flex',
         flexDirection: 'column',
-        height: panelHeight,
+        // Clamp the panel to the viewport space base-ui exposes via
+        // `--available-height` (falling back to the natural height before it's
+        // measured). The trigger usually sits at the page bottom and the popup
+        // opens upward; a fixed height would overflow the top edge and clip the
+        // search box + first items on short viewports. Keeping a *concrete*
+        // height (not max-height) lets the inner list flex-shrink and scroll.
+        height: `min(${panelHeight}px, var(--available-height, ${panelHeight}px))`,
         position: 'relative',
         width: DEFAULT_WIDTH,
       }}

--- a/src/routes/(main)/(create)/features/CreateGenerationPage.tsx
+++ b/src/routes/(main)/(create)/features/CreateGenerationPage.tsx
@@ -2,22 +2,38 @@
 
 import { Flexbox } from '@lobehub/ui';
 import { AnimatePresence, m as motion } from 'motion/react';
-import type { ComponentType } from 'react';
+import type { ComponentType, CSSProperties } from 'react';
 import { memo } from 'react';
 import { useMatch } from 'react-router';
 
+import DragUploadZone from '@/components/DragUploadZone';
 import NavHeader from '@/features/NavHeader';
 import WideScreenContainer from '@/features/WideScreenContainer';
 import WideScreenButton from '@/features/WideScreenContainer/WideScreenButton';
 import { useQueryState } from '@/hooks/useQueryParam';
 
+const dropZoneStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  width: '100%',
+};
+
 interface CreateGenerationPageProps {
+  /** Disable the drop zone overlay/handling (e.g. model has no reference support). */
+  dragDisabled?: boolean;
+  /**
+   * When provided, the whole creation area becomes a drag-and-drop upload zone.
+   * Files dropped anywhere below the nav header are routed here.
+   */
+  onUploadFiles?: (files: File[]) => void | Promise<void>;
   path: string;
   PromptInput: ComponentType<{ disableAnimation?: boolean; showTitle?: boolean }>;
   Workspace: ComponentType<{ embedInput?: boolean }>;
 }
 
-const CreateGenerationPage = memo<CreateGenerationPageProps>(({ path, Workspace, PromptInput }) => {
+const CreateGenerationPage = memo<CreateGenerationPageProps>(
+  ({ path, Workspace, PromptInput, dragDisabled, onUploadFiles }) => {
   const isPersonalPath = useMatch({ end: true, path });
   const isWorkspacePath = useMatch({ end: true, path: `/:workspaceSlug${path}` });
   const [topic] = useQueryState('topic');
@@ -25,26 +41,12 @@ const CreateGenerationPage = memo<CreateGenerationPageProps>(({ path, Workspace,
 
   if (!isPersonalPath && !isWorkspacePath) return null;
 
-  return (
-    <>
-      <NavHeader
-        right={<WideScreenButton />}
-        styles={{
-          center: {
-            alignItems: 'center',
-            display: 'flex',
-            justifyContent: 'center',
-            minWidth: 0,
-          },
-          left: { flex: 1, minWidth: 0 },
-          right: { flex: 1, minWidth: 0 },
-        }}
-      />
-      <Flexbox
-        height={'100%'}
-        style={{ flexDirection: 'column', overflow: 'hidden', position: 'relative' }}
-        width={'100%'}
-      >
+  const content = (
+    <Flexbox
+      height={'100%'}
+      style={{ flexDirection: 'column', overflow: 'hidden', position: 'relative' }}
+      width={'100%'}
+    >
         <Flexbox flex={1} style={{ minHeight: 0, overflowY: 'auto' }} width={'100%'}>
           <WideScreenContainer wrapperStyle={{ minHeight: '100%' }}>
             <AnimatePresence initial={false} mode="wait">
@@ -94,7 +96,31 @@ const CreateGenerationPage = memo<CreateGenerationPageProps>(({ path, Workspace,
             </motion.div>
           )}
         </AnimatePresence>
-      </Flexbox>
+    </Flexbox>
+  );
+
+  return (
+    <>
+      <NavHeader
+        right={<WideScreenButton />}
+        styles={{
+          center: {
+            alignItems: 'center',
+            display: 'flex',
+            justifyContent: 'center',
+            minWidth: 0,
+          },
+          left: { flex: 1, minWidth: 0 },
+          right: { flex: 1, minWidth: 0 },
+        }}
+      />
+      {onUploadFiles ? (
+        <DragUploadZone disabled={dragDisabled} style={dropZoneStyle} onUploadFiles={onUploadFiles}>
+          {content}
+        </DragUploadZone>
+      ) : (
+        content
+      )}
     </>
   );
 });

--- a/src/routes/(main)/(create)/features/CreateGenerationPage.tsx
+++ b/src/routes/(main)/(create)/features/CreateGenerationPage.tsx
@@ -34,19 +34,19 @@ interface CreateGenerationPageProps {
 
 const CreateGenerationPage = memo<CreateGenerationPageProps>(
   ({ path, Workspace, PromptInput, dragDisabled, onUploadFiles }) => {
-  const isPersonalPath = useMatch({ end: true, path });
-  const isWorkspacePath = useMatch({ end: true, path: `/:workspaceSlug${path}` });
-  const [topic] = useQueryState('topic');
-  const isHome = !topic;
+    const isPersonalPath = useMatch({ end: true, path });
+    const isWorkspacePath = useMatch({ end: true, path: `/:workspaceSlug${path}` });
+    const [topic] = useQueryState('topic');
+    const isHome = !topic;
 
-  if (!isPersonalPath && !isWorkspacePath) return null;
+    if (!isPersonalPath && !isWorkspacePath) return null;
 
-  const content = (
-    <Flexbox
-      height={'100%'}
-      style={{ flexDirection: 'column', overflow: 'hidden', position: 'relative' }}
-      width={'100%'}
-    >
+    const content = (
+      <Flexbox
+        height={'100%'}
+        style={{ flexDirection: 'column', overflow: 'hidden', position: 'relative' }}
+        width={'100%'}
+      >
         <Flexbox flex={1} style={{ minHeight: 0, overflowY: 'auto' }} width={'100%'}>
           <WideScreenContainer wrapperStyle={{ minHeight: '100%' }}>
             <AnimatePresence initial={false} mode="wait">
@@ -96,34 +96,42 @@ const CreateGenerationPage = memo<CreateGenerationPageProps>(
             </motion.div>
           )}
         </AnimatePresence>
-    </Flexbox>
-  );
+      </Flexbox>
+    );
 
-  return (
-    <>
-      <NavHeader
-        right={<WideScreenButton />}
-        styles={{
-          center: {
-            alignItems: 'center',
-            display: 'flex',
-            justifyContent: 'center',
-            minWidth: 0,
-          },
-          left: { flex: 1, minWidth: 0 },
-          right: { flex: 1, minWidth: 0 },
-        }}
-      />
-      {onUploadFiles ? (
-        <DragUploadZone disabled={dragDisabled} style={dropZoneStyle} onUploadFiles={onUploadFiles}>
-          {content}
-        </DragUploadZone>
-      ) : (
-        content
-      )}
-    </>
-  );
-});
+    return (
+      <>
+        <NavHeader
+          right={<WideScreenButton />}
+          styles={{
+            center: {
+              alignItems: 'center',
+              display: 'flex',
+              justifyContent: 'center',
+              minWidth: 0,
+            },
+            left: { flex: 1, minWidth: 0 },
+            right: { flex: 1, minWidth: 0 },
+          }}
+        />
+        {onUploadFiles ? (
+          <DragUploadZone
+            disabled={dragDisabled}
+            // Generation upload only accepts images; keep the overlay copy/icons
+            // image-only so a dropped PDF/text file isn't falsely invited.
+            enabledFiles={false}
+            style={dropZoneStyle}
+            onUploadFiles={onUploadFiles}
+          >
+            {content}
+          </DragUploadZone>
+        ) : (
+          content
+        )}
+      </>
+    );
+  },
+);
 
 CreateGenerationPage.displayName = 'CreateGenerationPage';
 

--- a/src/routes/(main)/(create)/features/GenerationInput/InlineImageReference.tsx
+++ b/src/routes/(main)/(create)/features/GenerationInput/InlineImageReference.tsx
@@ -36,15 +36,31 @@ interface InlineImageReferenceProps {
   maxFileSize?: number;
   onAdd: (data: UploadData) => void;
   onRemove: (url: string) => void;
+  /** Optional batch upload handler to enable multi-select on the add card. */
+  onUploadFiles?: (files: File[]) => void | Promise<void>;
+  /** In-flight upload previews (object URLs) rendered with a spinner. */
+  uploadingPreviews?: string[];
 }
 
 const InlineImageReference = memo<InlineImageReferenceProps>(
-  ({ images, onAdd, onRemove, maxFileSize, maxCount = 5 }) => {
+  ({
+    images,
+    onAdd,
+    onRemove,
+    onUploadFiles,
+    maxFileSize,
+    maxCount = 5,
+    uploadingPreviews = [],
+  }) => {
     const [isHovered, setIsHovered] = useState(false);
 
-    const canAddMore = images.length < maxCount;
-    const hasImages = images.length > 0;
-    const shouldCollapse = hasImages && !isHovered;
+    const totalCount = images.length + uploadingPreviews.length;
+    const canAddMore = totalCount < maxCount;
+    const hasItems = totalCount > 0;
+    const shouldCollapse = hasItems && !isHovered;
+
+    const stackOffset = (index: number) =>
+      index > 0 ? (shouldCollapse ? STACK_OFFSET : EXPAND_OFFSET) : 0;
 
     return (
       <Flexbox
@@ -61,11 +77,26 @@ const InlineImageReference = memo<InlineImageReferenceProps>(
             key={url}
             maxFileSize={maxFileSize}
             style={{
-              marginInlineStart: index > 0 ? (shouldCollapse ? STACK_OFFSET : EXPAND_OFFSET) : 0,
+              marginInlineStart: stackOffset(index),
               zIndex: index + 1,
             }}
             onRemove={() => onRemove(url)}
             onUpload={onAdd}
+          />
+        ))}
+
+        {uploadingPreviews.map((url, index) => (
+          <UploadCard
+            loading
+            imageUrl={url}
+            key={`uploading-${url}`}
+            maxFileSize={maxFileSize}
+            style={{
+              marginInlineStart: stackOffset(images.length + index),
+              zIndex: images.length + index + 1,
+            }}
+            onRemove={() => {}}
+            onUpload={() => {}}
           />
         ))}
 
@@ -74,19 +105,23 @@ const InlineImageReference = memo<InlineImageReferenceProps>(
             <UploadCard
               className={styles.addCirclePos}
               maxFileSize={maxFileSize}
+              multiple={!!onUploadFiles}
               variant="circle"
               onRemove={() => {}}
               onUpload={onAdd}
+              onUploadFiles={onUploadFiles}
             />
           ) : (
             <UploadCard
               maxFileSize={maxFileSize}
+              multiple={!!onUploadFiles}
               style={{
-                marginInlineStart: hasImages ? EXPAND_OFFSET : 0,
-                zIndex: images.length + 1,
+                marginInlineStart: hasItems ? EXPAND_OFFSET : 0,
+                zIndex: totalCount + 1,
               }}
               onRemove={() => {}}
               onUpload={onAdd}
+              onUploadFiles={onUploadFiles}
             />
           ))}
       </Flexbox>

--- a/src/routes/(main)/(create)/features/GenerationInput/InlineVideoFrames.tsx
+++ b/src/routes/(main)/(create)/features/GenerationInput/InlineVideoFrames.tsx
@@ -49,6 +49,10 @@ interface InlineVideoFramesProps {
   onImageChange: (data: UploadData | null) => void;
   onImageUrlsChange?: (data: UploadData) => void;
   onRemoveImageUrl?: (url: string) => void;
+  /** Optional batch upload handler to enable multi-select on the add card. */
+  onUploadFiles?: (files: File[]) => void | Promise<void>;
+  /** In-flight upload previews (object URLs) rendered with a spinner. */
+  uploadingPreviews?: string[];
 }
 
 const InlineVideoFrames = memo<InlineVideoFramesProps>(
@@ -60,9 +64,11 @@ const InlineVideoFrames = memo<InlineVideoFramesProps>(
     onEndImageChange,
     onImageUrlsChange,
     onRemoveImageUrl,
+    onUploadFiles,
     isSupportEndImage = true,
     maxCount = 5,
     maxFileSize,
+    uploadingPreviews = [],
   }) => {
     const { t } = useTranslation('video');
     const [isHovered, setIsHovered] = useState(false);
@@ -78,8 +84,10 @@ const InlineVideoFrames = memo<InlineVideoFramesProps>(
     }, [imageUrl, imageUrls]);
 
     const hasRefFrames = refFrameUrls.length > 0;
-    const canAddMore = refFrameUrls.length < maxCount;
-    const shouldCollapse = hasRefFrames && !isHovered;
+    const totalCount = refFrameUrls.length + uploadingPreviews.length;
+    const hasItems = totalCount > 0;
+    const canAddMore = totalCount < maxCount;
+    const shouldCollapse = hasItems && !isHovered;
     const showEndFrame = isSupportEndImage && hasRefFrames;
 
     return (
@@ -127,14 +135,37 @@ const InlineVideoFrames = memo<InlineVideoFramesProps>(
             );
           })}
 
+          {/* In-flight upload placeholders (with spinner) */}
+          {uploadingPreviews.map((url, index) => (
+            <UploadCard
+              loading
+              imageUrl={url}
+              key={`uploading-${url}`}
+              maxFileSize={maxFileSize}
+              style={{
+                marginInlineStart:
+                  refFrameUrls.length + index > 0
+                    ? shouldCollapse
+                      ? STACK_OFFSET
+                      : EXPAND_OFFSET
+                    : 0,
+                zIndex: refFrameUrls.length + index + 1,
+              }}
+              onRemove={() => {}}
+              onUpload={() => {}}
+            />
+          ))}
+
           {/* Add new frame button */}
           {canAddMore &&
             (shouldCollapse ? (
               <UploadCard
                 className={styles.addCirclePos}
                 maxFileSize={maxFileSize}
+                multiple={!!onUploadFiles}
                 variant="circle"
                 onRemove={() => {}}
+                onUploadFiles={onUploadFiles}
                 onUpload={(data) => {
                   if (onImageUrlsChange) {
                     onImageUrlsChange(data);
@@ -148,11 +179,13 @@ const InlineVideoFrames = memo<InlineVideoFramesProps>(
                 imageUrl={null}
                 label={t('config.referenceImage.label')}
                 maxFileSize={maxFileSize}
+                multiple={!!onUploadFiles}
                 style={{
-                  marginInlineStart: hasRefFrames ? EXPAND_OFFSET : 0,
-                  zIndex: refFrameUrls.length + 1,
+                  marginInlineStart: hasItems ? EXPAND_OFFSET : 0,
+                  zIndex: totalCount + 1,
                 }}
                 onRemove={() => {}}
+                onUploadFiles={onUploadFiles}
                 onUpload={(data) => {
                   if (hasRefFrames) {
                     if (onImageUrlsChange) {

--- a/src/routes/(main)/(create)/features/GenerationInput/UploadCard.tsx
+++ b/src/routes/(main)/(create)/features/GenerationInput/UploadCard.tsx
@@ -126,9 +126,19 @@ interface UploadCardProps {
   closeClassName?: string;
   imageUrl?: string | null;
   label?: string;
+  /** Show an upload spinner overlay (for externally-managed batch uploads). */
+  loading?: boolean;
   maxFileSize?: number;
+  /** Allow selecting multiple files at once (requires `onUploadFiles`). */
+  multiple?: boolean;
   onRemove: () => void;
   onUpload: (data: UploadData) => void;
+  /**
+   * Batch upload handler. When provided, file selection is delegated to the
+   * parent (which uploads + lands all files together) instead of the card's
+   * internal single-file upload, enabling multi-select.
+   */
+  onUploadFiles?: (files: File[]) => void | Promise<void>;
   style?: CSSProperties;
   variant?: 'card' | 'circle';
 }
@@ -137,9 +147,12 @@ const UploadCard = memo<UploadCardProps>(
   ({
     imageUrl,
     label,
+    loading = false,
     onUpload,
+    onUploadFiles,
     onRemove,
     maxFileSize,
+    multiple = false,
     className,
     closeClassName,
     style,
@@ -150,12 +163,25 @@ const UploadCard = memo<UploadCardProps>(
     const [isUploading, setIsUploading] = useState(false);
     const [uploadPreview, setUploadPreview] = useState<string | null>(null);
 
+    // Combine internal single-upload spinner with externally-driven batch loading.
+    const uploading = isUploading || loading;
+
     const handleFileSelect = useCallback(() => {
+      if (loading) return;
       inputRef.current?.click();
-    }, []);
+    }, [loading]);
 
     const handleFileChange = useCallback(
       async (e: ChangeEvent<HTMLInputElement>) => {
+        // When a batch handler is provided, delegate all selected files to the
+        // parent so multiple references can be uploaded and landed at once.
+        if (onUploadFiles) {
+          const files = Array.from(e.target.files ?? []);
+          if (files.length === 0) return;
+          await onUploadFiles(files);
+          return;
+        }
+
         const file = e.target.files?.[0];
         if (!file) return;
 
@@ -184,7 +210,7 @@ const UploadCard = memo<UploadCardProps>(
           setIsUploading(false);
         }
       },
-      [maxFileSize, uploadWithProgress, onUpload],
+      [maxFileSize, uploadWithProgress, onUpload, onUploadFiles],
     );
 
     const showPreview = uploadPreview || imageUrl;
@@ -192,6 +218,7 @@ const UploadCard = memo<UploadCardProps>(
     const fileInput = (
       <input
         accept="image/*"
+        multiple={multiple}
         ref={inputRef}
         style={{ display: 'none' }}
         type="file"
@@ -236,13 +263,13 @@ const UploadCard = memo<UploadCardProps>(
                 src={uploadPreview || imageUrl!}
                 style={{ objectFit: 'cover' }}
               />
-              {isUploading && (
+              {uploading && (
                 <div className={uploadCardStyles.uploadOverlay}>
                   <Spin percent={'auto'} size="small" />
                 </div>
               )}
             </div>
-            {!isUploading && (
+            {!uploading && (
               <ActionIcon
                 glass
                 className={cx(uploadCardStyles.closeButton, closeClassName, 'upload-card-close')}

--- a/src/routes/(main)/(create)/features/GenerationInput/useReferenceImageUpload.ts
+++ b/src/routes/(main)/(create)/features/GenerationInput/useReferenceImageUpload.ts
@@ -84,8 +84,10 @@ export const useReferenceImageUpload = ({
     [slots],
   );
 
-  /** Whether the current model accepts any reference image at all. */
-  const canDropImage = maxCount > 0;
+  // Gate on permission too: without `create_content` the upload handler bails
+  // immediately, so a true flag here would show an active drop zone that
+  // silently accepts and discards the drop.
+  const canDropImage = canCreate && maxCount > 0;
 
   const handleUploadFiles = useCallback(
     async (files: File[]) => {

--- a/src/routes/(main)/(create)/features/GenerationInput/useReferenceImageUpload.ts
+++ b/src/routes/(main)/(create)/features/GenerationInput/useReferenceImageUpload.ts
@@ -93,7 +93,12 @@ export const useReferenceImageUpload = ({
     async (files: File[]) => {
       if (!canCreate) return;
 
-      const imageFiles = files.filter((file) => file.type.startsWith('image/'));
+      // Keep files whose type is an image OR empty: OS/browser drops of images
+      // with uncommon extensions can arrive with an empty `File.type`. Discarding
+      // them here would silently drop a valid reference before the upload pipeline
+      // (which sniffs the MIME from bytes) gets a chance. Known non-image types
+      // (PDF/video/text) still carry a populated `type` and are rejected.
+      const imageFiles = files.filter((file) => file.type === '' || file.type.startsWith('image/'));
       if (imageFiles.length === 0) return;
 
       // Drop files over the model's size limit before consuming capacity, so an

--- a/src/routes/(main)/(create)/features/GenerationInput/useReferenceImageUpload.ts
+++ b/src/routes/(main)/(create)/features/GenerationInput/useReferenceImageUpload.ts
@@ -1,0 +1,179 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+
+import { useFileStore } from '@/store/file';
+
+import type { UploadData } from './UploadCard';
+
+/**
+ * A single destination for dropped reference images (e.g. start frame, reference
+ * array, end frame). Slots are filled in array order: dropped files top up the
+ * first slot with remaining room, then overflow into the next.
+ */
+export interface ReferenceUploadSlot {
+  /** Maximum number of image URLs this slot can hold. */
+  capacity: number;
+  /** Replace this slot's full content with the given URLs (already capped to capacity). */
+  set: (urls: string[]) => void;
+  /** URLs currently landed in this slot. */
+  values: string[];
+}
+
+interface UseReferenceImageUploadOptions {
+  /** Append object-URL placeholders for in-flight uploads (store-backed, shared). */
+  addUploadingPreviews: (urls: string[]) => void;
+  /** Whether the user is permitted to add references. */
+  canCreate: boolean;
+  /** Largest accepted file size in bytes; larger files are skipped. */
+  maxFileSize?: number;
+  /** Set image dimensions from the first uploaded image (image page only). */
+  onFirstDimensions?: (dimensions: { height: number; width: number }) => void;
+  /** Called with the effective max count when a drop exceeds the remaining room. */
+  onLimitExceeded?: (maxCount: number) => void;
+  /** Remove this batch's object-URL placeholders once the upload settles. */
+  removeUploadingPreviews: (urls: string[]) => void;
+  /** Ordered destination slots; dropped files fill them by priority. */
+  slots: ReferenceUploadSlot[];
+  /** Object-URL placeholders for in-flight uploads (store-backed, shared). */
+  uploadingPreviews: string[];
+}
+
+const extractUrlAndDimensions = (data?: UploadData) => {
+  const url = typeof data === 'string' ? data : data?.url;
+  const dimensions = typeof data === 'object' ? data?.dimensions : undefined;
+  return { dimensions, url };
+};
+
+/**
+ * Store-agnostic core for drag/click reference-image upload, shared by the image
+ * and video creation pages.
+ *
+ * Callers describe their model's accepted reference slots (`slots`) and the
+ * store-backed in-flight preview state; this hook owns the tricky parts:
+ * filtering, capacity/limit handling, instant object-URL placeholders, the batch
+ * upload, single-shot landing across slots (avoiding the stale-closure race a
+ * per-file loop would cause), and placeholder cleanup.
+ *
+ * The page-specific differences (which store, end-frame slot, auto-dimensions)
+ * are injected via `slots` / `onFirstDimensions`, so the upload mechanics live
+ * in exactly one place.
+ */
+export const useReferenceImageUpload = ({
+  slots,
+  canCreate,
+  maxFileSize,
+  uploadingPreviews,
+  addUploadingPreviews,
+  removeUploadingPreviews,
+  onFirstDimensions,
+  onLimitExceeded,
+}: UseReferenceImageUploadOptions) => {
+  const uploadWithProgress = useFileStore((s) => s.uploadWithProgress);
+
+  const maxCount = useMemo(() => slots.reduce((sum, slot) => sum + slot.capacity, 0), [slots]);
+
+  const imagePreviewUrls = useMemo(
+    () => slots.flatMap((slot) => slot.values).filter(Boolean),
+    [slots],
+  );
+
+  /** Whether the current model accepts any reference image at all. */
+  const canDropImage = maxCount > 0;
+
+  const handleUploadFiles = useCallback(
+    async (files: File[]) => {
+      if (!canCreate) return;
+
+      const imageFiles = files.filter((file) => file.type.startsWith('image/'));
+      if (imageFiles.length === 0) return;
+
+      // Account for both landed images and any in-flight uploads.
+      const remaining = maxCount - imagePreviewUrls.length - uploadingPreviews.length;
+      if (remaining <= 0) {
+        onLimitExceeded?.(maxCount);
+        return;
+      }
+
+      // Only take as many as there is still room for, and warn when truncating.
+      const accepted = imageFiles.slice(0, remaining);
+      if (imageFiles.length > remaining) {
+        onLimitExceeded?.(maxCount);
+      }
+
+      // Show instant local previews (with spinner) for the whole batch.
+      const previews = accepted.map((file) => URL.createObjectURL(file));
+      addUploadingPreviews(previews);
+
+      try {
+        const results = await Promise.all(
+          accepted.map(async (file): Promise<UploadData | null> => {
+            if (maxFileSize && file.size > maxFileSize) return null;
+
+            const result = await uploadWithProgress({
+              file,
+              onStatusUpdate: () => {},
+              skipCheckFileType: true,
+            });
+
+            if (!result?.url) return null;
+            return result.dimensions
+              ? { dimensions: result.dimensions, url: result.url }
+              : result.url;
+          }),
+        );
+
+        // Collect successful URLs and the first available dimensions.
+        const uploadedUrls: string[] = [];
+        let firstDimensions: { height: number; width: number } | undefined;
+        for (const data of results) {
+          if (!data) continue;
+          const { url, dimensions } = extractUrlAndDimensions(data);
+          if (!url) continue;
+          if (!firstDimensions && dimensions) firstDimensions = dimensions;
+          uploadedUrls.push(url);
+        }
+
+        if (firstDimensions) onFirstDimensions?.(firstDimensions);
+
+        // Distribute uploaded URLs across slots by priority, appending to existing
+        // content. Each slot is set once to avoid a stale-closure race.
+        let pool = uploadedUrls;
+        for (const slot of slots) {
+          if (pool.length === 0) break;
+          const room = slot.capacity - slot.values.length;
+          if (room <= 0) continue;
+          const take = pool.slice(0, room);
+          pool = pool.slice(room);
+          slot.set([...slot.values, ...take]);
+        }
+      } finally {
+        // Drop this batch's placeholders, then release the object URLs.
+        removeUploadingPreviews(previews);
+        previews.forEach((url) => URL.revokeObjectURL(url));
+      }
+    },
+    [
+      slots,
+      canCreate,
+      maxCount,
+      maxFileSize,
+      imagePreviewUrls,
+      uploadingPreviews,
+      uploadWithProgress,
+      addUploadingPreviews,
+      removeUploadingPreviews,
+      onFirstDimensions,
+      onLimitExceeded,
+    ],
+  );
+
+  return {
+    canDropImage,
+    handleUploadFiles,
+    imagePreviewUrls,
+    maxCount,
+    maxFileSize,
+    uploadingPreviews,
+  };
+};

--- a/src/routes/(main)/(create)/features/GenerationInput/useReferenceImageUpload.ts
+++ b/src/routes/(main)/(create)/features/GenerationInput/useReferenceImageUpload.ts
@@ -14,9 +14,15 @@ import type { UploadData } from './UploadCard';
 export interface ReferenceUploadSlot {
   /** Maximum number of image URLs this slot can hold. */
   capacity: number;
+  /**
+   * Read this slot's URLs fresh from the store. Used at landing time so a batch
+   * that finishes after a concurrent one merges against the latest content
+   * instead of overwriting it with a stale render-time snapshot.
+   */
+  getCurrentValues: () => string[];
   /** Replace this slot's full content with the given URLs (already capped to capacity). */
   set: (urls: string[]) => void;
-  /** URLs currently landed in this slot. */
+  /** URLs currently landed in this slot (render-time snapshot for previews/capacity). */
   values: string[];
 }
 
@@ -88,6 +94,13 @@ export const useReferenceImageUpload = ({
       const imageFiles = files.filter((file) => file.type.startsWith('image/'));
       if (imageFiles.length === 0) return;
 
+      // Drop files over the model's size limit before consuming capacity, so an
+      // oversized file doesn't steal a slot from a valid one later in the drop.
+      const uploadableFiles = maxFileSize
+        ? imageFiles.filter((file) => file.size <= maxFileSize)
+        : imageFiles;
+      if (uploadableFiles.length === 0) return;
+
       // Account for both landed images and any in-flight uploads.
       const remaining = maxCount - imagePreviewUrls.length - uploadingPreviews.length;
       if (remaining <= 0) {
@@ -96,8 +109,8 @@ export const useReferenceImageUpload = ({
       }
 
       // Only take as many as there is still room for, and warn when truncating.
-      const accepted = imageFiles.slice(0, remaining);
-      if (imageFiles.length > remaining) {
+      const accepted = uploadableFiles.slice(0, remaining);
+      if (uploadableFiles.length > remaining) {
         onLimitExceeded?.(maxCount);
       }
 
@@ -106,10 +119,10 @@ export const useReferenceImageUpload = ({
       addUploadingPreviews(previews);
 
       try {
-        const results = await Promise.all(
+        // `allSettled` isolates per-file failures: a single rejected upload no
+        // longer discards the whole batch, so the images that did land stay.
+        const settled = await Promise.allSettled(
           accepted.map(async (file): Promise<UploadData | null> => {
-            if (maxFileSize && file.size > maxFileSize) return null;
-
             const result = await uploadWithProgress({
               file,
               onStatusUpdate: () => {},
@@ -121,6 +134,9 @@ export const useReferenceImageUpload = ({
               ? { dimensions: result.dimensions, url: result.url }
               : result.url;
           }),
+        );
+        const results = settled.map((outcome) =>
+          outcome.status === 'fulfilled' ? outcome.value : null,
         );
 
         // Collect successful URLs and the first available dimensions.
@@ -136,16 +152,19 @@ export const useReferenceImageUpload = ({
 
         if (firstDimensions) onFirstDimensions?.(firstDimensions);
 
-        // Distribute uploaded URLs across slots by priority, appending to existing
-        // content. Each slot is set once to avoid a stale-closure race.
+        // Distribute uploaded URLs across slots by priority, appending to the
+        // slot's *current* store content (read fresh, not the render-time
+        // snapshot) so a concurrent batch that already landed isn't overwritten.
+        // The loop is synchronous, so each batch's landing is atomic.
         let pool = uploadedUrls;
         for (const slot of slots) {
           if (pool.length === 0) break;
-          const room = slot.capacity - slot.values.length;
+          const current = slot.getCurrentValues();
+          const room = slot.capacity - current.length;
           if (room <= 0) continue;
           const take = pool.slice(0, room);
           pool = pool.slice(room);
-          slot.set([...slot.values, ...take]);
+          slot.set([...current, ...take]);
         }
       } finally {
         // Drop this batch's placeholders, then release the object URLs.

--- a/src/routes/(main)/(create)/image/features/PromptInput/index.tsx
+++ b/src/routes/(main)/(create)/image/features/PromptInput/index.tsx
@@ -4,7 +4,7 @@ import { ModelIcon } from '@lobehub/icons';
 import { ActionIcon, Flexbox, Segmented, Text } from '@lobehub/ui';
 import { Divider, Switch } from 'antd';
 import { Images } from 'lucide-react';
-import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import { memo, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { loginRequired } from '@/components/Error/loginRequiredNotification';
@@ -30,7 +30,6 @@ import {
   SeedNumberInput,
   SizeSelect,
   StepsSliderInput,
-  useAutoDimensions,
 } from '@/routes/(main)/(create)/image/features/ConfigPanel';
 import ImageModelItem from '@/routes/(main)/(create)/image/features/ConfigPanel/components/ModelSelect/ImageModelItem';
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
@@ -44,6 +43,7 @@ import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/slices/auth/selectors';
 
 import PromptTitle from './Title';
+import { useImageReferenceUpload } from './useImageReferenceUpload';
 
 interface PromptInputProps {
   disableAnimation?: boolean;
@@ -126,22 +126,22 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
   const { t } = useTranslation('image');
   const { allowed: canCreate } = usePermission('create_content');
   const { value, setValue } = useGenerationConfigParam('prompt');
-  const { value: imageUrl, setValue: setImageUrl } = useGenerationConfigParam('imageUrl');
   const {
-    value: imageUrls,
-    setValue: setImageUrls,
-    maxCount: imageUrlsMaxCount,
-    maxFileSize: imageUrlsMaxFileSize,
-  } = useGenerationConfigParam('imageUrls');
-  const { maxFileSize: imageUrlMaxFileSize } = useGenerationConfigParam('imageUrl');
+    canDropImage,
+    handleAddImage,
+    handleRemoveImage,
+    handleUploadFiles,
+    imagePreviewUrls,
+    maxCount,
+    maxFileSize,
+    uploadingPreviews,
+  } = useImageReferenceUpload();
   const isCreating = useImageStore(createImageSelectors.isCreating);
   const createImage = useImageStore((s) => s.createImage);
   const setModelAndProviderOnSelect = useImageStore((s) => s.setModelAndProviderOnSelect);
   const currentModel = useImageStore(imageGenerationConfigSelectors.model);
   const currentProvider = useImageStore(imageGenerationConfigSelectors.provider);
   const isInit = useImageStore((s) => s.isInit);
-  const isSupportImageUrl = useImageStore(isSupportedParamSelector('imageUrl'));
-  const isSupportImageUrls = useImageStore(isSupportedParamSelector('imageUrls'));
   const isSupportQuality = useImageStore(isSupportedParamSelector('quality'));
   const isSupportResolution = useImageStore(isSupportedParamSelector('resolution'));
   const isSupportSize = useImageStore(isSupportedParamSelector('size'));
@@ -154,7 +154,6 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
   const isLogin = useUserStore(authSelectors.isLogin);
   const enabledImageModelList = useAiInfraStore(aiProviderSelectors.enabledImageModelList);
   const { showDimensionControl } = useDimensionControl();
-  const { autoSetDimensions, extractUrlAndDimensions } = useAutoDimensions();
 
   useFetchAiImageConfig();
 
@@ -208,65 +207,8 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
     }
   }, [promptParam, isLogin, canCreate, setValue, setPromptParam, createImage]);
 
-  const imagePreviewUrls = useMemo(
-    () => [imageUrl, ...(imageUrls ?? [])].filter(Boolean) as string[],
-    [imageUrl, imageUrls],
-  );
-
-  const handleAddImage = useCallback(
-    (data: string | { dimensions?: { height: number; width: number }; url: string }) => {
-      if (!canCreate) return;
-
-      const { url, dimensions } = extractUrlAndDimensions(data);
-      if (!url) return;
-
-      if (dimensions) {
-        autoSetDimensions(dimensions);
-      }
-
-      if (isSupportImageUrl && !imageUrl) {
-        setImageUrl(url);
-      } else if (isSupportImageUrls) {
-        setImageUrls([...(imageUrls ?? []), url] as any);
-      } else if (isSupportImageUrl) {
-        setImageUrl(url);
-      }
-    },
-    [
-      isSupportImageUrl,
-      isSupportImageUrls,
-      imageUrl,
-      imageUrls,
-      setImageUrl,
-      setImageUrls,
-      autoSetDimensions,
-      extractUrlAndDimensions,
-      canCreate,
-    ],
-  );
-
-  const handleRemoveImage = useCallback(
-    (url: string) => {
-      if (!canCreate) return;
-
-      if (url === imageUrl) {
-        setImageUrl(null);
-      } else {
-        setImageUrls((imageUrls ?? []).filter((item) => item !== url) as any);
-      }
-    },
-    [canCreate, imageUrl, imageUrls, setImageUrl, setImageUrls],
-  );
-
-  const showInlineRef = isSupportImageUrl || isSupportImageUrls;
+  const showInlineRef = canDropImage;
   const hasRefImages = imagePreviewUrls.length > 0;
-
-  const maxCount = useMemo(() => {
-    let count = 0;
-    if (isSupportImageUrl) count += 1;
-    if (isSupportImageUrls) count += imageUrlsMaxCount ?? 4;
-    return count;
-  }, [isSupportImageUrl, isSupportImageUrls, imageUrlsMaxCount]);
 
   return (
     <Flexbox gap={32} width={'100%'}>
@@ -284,9 +226,11 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
             <InlineImageReference
               images={imagePreviewUrls}
               maxCount={maxCount}
-              maxFileSize={imageUrlsMaxFileSize ?? imageUrlMaxFileSize}
+              maxFileSize={maxFileSize}
+              uploadingPreviews={uploadingPreviews}
               onAdd={handleAddImage}
               onRemove={handleRemoveImage}
+              onUploadFiles={handleUploadFiles}
             />
           ) : undefined
         }

--- a/src/routes/(main)/(create)/image/features/PromptInput/useImageReferenceUpload.ts
+++ b/src/routes/(main)/(create)/image/features/PromptInput/useImageReferenceUpload.ts
@@ -6,8 +6,11 @@ import { useTranslation } from 'react-i18next';
 import { message } from '@/components/AntdStaticMethods';
 import { usePermission } from '@/hooks/usePermission';
 import type { UploadData } from '@/routes/(main)/(create)/features/GenerationInput/UploadCard';
+import {
+  type ReferenceUploadSlot,
+  useReferenceImageUpload,
+} from '@/routes/(main)/(create)/features/GenerationInput/useReferenceImageUpload';
 import { useAutoDimensions } from '@/routes/(main)/(create)/image/features/ConfigPanel';
-import { useFileStore } from '@/store/file';
 import { useImageStore } from '@/store/image';
 import { imageGenerationConfigSelectors } from '@/store/image/selectors';
 import { useGenerationConfigParam } from '@/store/image/slices/generationConfig/hooks';
@@ -15,14 +18,12 @@ import { useGenerationConfigParam } from '@/store/image/slices/generationConfig/
 const isSupportedParamSelector = imageGenerationConfigSelectors.isSupportedParam;
 
 /**
- * Shared image reference upload logic for the image creation page.
+ * Image-page binding for the shared {@link useReferenceImageUpload} core.
  *
- * Centralizes "which params the model supports", the derived upload limits, and
- * the add/remove/batch-upload handlers so both the inline reference cards
- * (PromptInput) and the page-level drag-and-drop zone stay in sync.
- *
- * `handleUploadFiles` lands all dropped files in a single state update to avoid
- * the stale-closure race that calling `handleAddImage` in a loop would cause.
+ * Describes the image model's reference slots (`imageUrl` then `imageUrls`),
+ * wires the store-backed in-flight preview state, and auto-sets dimensions from
+ * the first dropped image. Also keeps the single add/remove handlers used by the
+ * inline reference cards.
  */
 export const useImageReferenceUpload = () => {
   const { t } = useTranslation('image');
@@ -44,32 +45,56 @@ export const useImageReferenceUpload = () => {
   } = useGenerationConfigParam('imageUrls');
 
   const { autoSetDimensions, extractUrlAndDimensions } = useAutoDimensions();
-  const uploadWithProgress = useFileStore((s) => s.uploadWithProgress);
 
-  // Object-URL previews shown with a spinner while a batch upload is in flight,
-  // so dropped images appear instantly instead of only on completion. Kept in
-  // the store so the inline cards and the page-level drag zone (two separate
-  // hook instances) reflect the same in-flight uploads.
   const uploadingPreviews = useImageStore(imageGenerationConfigSelectors.uploadingImagePreviews);
   const addUploadingImagePreviews = useImageStore((s) => s.addUploadingImagePreviews);
   const removeUploadingImagePreviews = useImageStore((s) => s.removeUploadingImagePreviews);
 
-  /** Whether the current model accepts any reference image at all. */
-  const canDropImage = isSupportImageUrl || isSupportImageUrls;
+  const slots = useMemo<ReferenceUploadSlot[]>(() => {
+    const list: ReferenceUploadSlot[] = [];
+    if (isSupportImageUrl) {
+      list.push({
+        capacity: 1,
+        set: (urls) => setImageUrl((urls[0] ?? null) as any),
+        values: imageUrl ? [imageUrl] : [],
+      });
+    }
+    if (isSupportImageUrls) {
+      list.push({
+        capacity: imageUrlsMaxCount ?? 4,
+        set: (urls) => setImageUrls(urls as any),
+        values: imageUrls ?? [],
+      });
+    }
+    return list;
+  }, [
+    isSupportImageUrl,
+    isSupportImageUrls,
+    imageUrl,
+    imageUrls,
+    imageUrlsMaxCount,
+    setImageUrl,
+    setImageUrls,
+  ]);
 
-  const maxFileSize = imageUrlsMaxFileSize ?? imageUrlMaxFileSize;
-
-  const maxCount = useMemo(() => {
-    let count = 0;
-    if (isSupportImageUrl) count += 1;
-    if (isSupportImageUrls) count += imageUrlsMaxCount ?? 4;
-    return count;
-  }, [isSupportImageUrl, isSupportImageUrls, imageUrlsMaxCount]);
-
-  const imagePreviewUrls = useMemo(
-    () => [imageUrl, ...(imageUrls ?? [])].filter(Boolean) as string[],
-    [imageUrl, imageUrls],
+  const onLimitExceeded = useCallback(
+    (maxCount: number) => {
+      message.warning(t('config.imageUpload.maxCountReached', { count: maxCount }));
+    },
+    [t],
   );
+
+  const { canDropImage, handleUploadFiles, imagePreviewUrls, maxCount, maxFileSize } =
+    useReferenceImageUpload({
+      addUploadingPreviews: addUploadingImagePreviews,
+      canCreate,
+      maxFileSize: imageUrlsMaxFileSize ?? imageUrlMaxFileSize,
+      onFirstDimensions: autoSetDimensions,
+      onLimitExceeded,
+      removeUploadingPreviews: removeUploadingImagePreviews,
+      slots,
+      uploadingPreviews,
+    });
 
   const handleAddImage = useCallback(
     (data: UploadData) => {
@@ -114,95 +139,6 @@ export const useImageReferenceUpload = () => {
       }
     },
     [canCreate, imageUrl, imageUrls, setImageUrl, setImageUrls],
-  );
-
-  const handleUploadFiles = useCallback(
-    async (files: File[]) => {
-      if (!canCreate) return;
-
-      const imageFiles = files.filter((file) => file.type.startsWith('image/'));
-      if (imageFiles.length === 0) return;
-
-      // Account for both landed images and any in-flight uploads.
-      const remaining = maxCount - imagePreviewUrls.length - uploadingPreviews.length;
-      if (remaining <= 0) {
-        message.warning(t('config.imageUpload.maxCountReached', { count: maxCount }));
-        return;
-      }
-
-      // Only take as many as the model still has room for, and warn when truncating.
-      const accepted = imageFiles.slice(0, remaining);
-      if (imageFiles.length > remaining) {
-        message.warning(t('config.imageUpload.maxCountReached', { count: maxCount }));
-      }
-
-      // Show instant local previews (with spinner) for the whole batch.
-      const previews = accepted.map((file) => URL.createObjectURL(file));
-      addUploadingImagePreviews(previews);
-
-      try {
-        const results = await Promise.all(
-          accepted.map(async (file): Promise<UploadData | null> => {
-            if (maxFileSize && file.size > maxFileSize) return null;
-
-            const result = await uploadWithProgress({
-              file,
-              onStatusUpdate: () => {},
-              skipCheckFileType: true,
-            });
-
-            if (!result?.url) return null;
-            return result.dimensions
-              ? { dimensions: result.dimensions, url: result.url }
-              : result.url;
-          }),
-        );
-
-        // Land all uploads in one state update to avoid a stale-closure race.
-        let nextImageUrl = imageUrl;
-        const nextImageUrls = [...(imageUrls ?? [])];
-        let firstDimensions: { height: number; width: number } | undefined;
-
-        for (const data of results) {
-          if (!data) continue;
-          const { url, dimensions } = extractUrlAndDimensions(data);
-          if (!url) continue;
-
-          if (!firstDimensions && dimensions) firstDimensions = dimensions;
-
-          if (isSupportImageUrl && !nextImageUrl) nextImageUrl = url;
-          else if (isSupportImageUrls) nextImageUrls.push(url);
-          else if (isSupportImageUrl) nextImageUrl = url;
-        }
-
-        if (firstDimensions) autoSetDimensions(firstDimensions);
-        if (nextImageUrl !== imageUrl) setImageUrl(nextImageUrl as any);
-        if (nextImageUrls.length !== (imageUrls?.length ?? 0)) setImageUrls(nextImageUrls as any);
-      } finally {
-        // Drop this batch's placeholders, then release the object URLs.
-        removeUploadingImagePreviews(previews);
-        previews.forEach((url) => URL.revokeObjectURL(url));
-      }
-    },
-    [
-      canCreate,
-      maxCount,
-      maxFileSize,
-      imagePreviewUrls,
-      uploadingPreviews,
-      imageUrl,
-      imageUrls,
-      isSupportImageUrl,
-      isSupportImageUrls,
-      setImageUrl,
-      setImageUrls,
-      uploadWithProgress,
-      addUploadingImagePreviews,
-      removeUploadingImagePreviews,
-      autoSetDimensions,
-      extractUrlAndDimensions,
-      t,
-    ],
   );
 
   return {

--- a/src/routes/(main)/(create)/image/features/PromptInput/useImageReferenceUpload.ts
+++ b/src/routes/(main)/(create)/image/features/PromptInput/useImageReferenceUpload.ts
@@ -1,0 +1,218 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { message } from '@/components/AntdStaticMethods';
+import { usePermission } from '@/hooks/usePermission';
+import type { UploadData } from '@/routes/(main)/(create)/features/GenerationInput/UploadCard';
+import { useAutoDimensions } from '@/routes/(main)/(create)/image/features/ConfigPanel';
+import { useFileStore } from '@/store/file';
+import { useImageStore } from '@/store/image';
+import { imageGenerationConfigSelectors } from '@/store/image/selectors';
+import { useGenerationConfigParam } from '@/store/image/slices/generationConfig/hooks';
+
+const isSupportedParamSelector = imageGenerationConfigSelectors.isSupportedParam;
+
+/**
+ * Shared image reference upload logic for the image creation page.
+ *
+ * Centralizes "which params the model supports", the derived upload limits, and
+ * the add/remove/batch-upload handlers so both the inline reference cards
+ * (PromptInput) and the page-level drag-and-drop zone stay in sync.
+ *
+ * `handleUploadFiles` lands all dropped files in a single state update to avoid
+ * the stale-closure race that calling `handleAddImage` in a loop would cause.
+ */
+export const useImageReferenceUpload = () => {
+  const { t } = useTranslation('image');
+  const { allowed: canCreate } = usePermission('create_content');
+
+  const isSupportImageUrl = useImageStore(isSupportedParamSelector('imageUrl'));
+  const isSupportImageUrls = useImageStore(isSupportedParamSelector('imageUrls'));
+
+  const {
+    value: imageUrl,
+    setValue: setImageUrl,
+    maxFileSize: imageUrlMaxFileSize,
+  } = useGenerationConfigParam('imageUrl');
+  const {
+    value: imageUrls,
+    setValue: setImageUrls,
+    maxCount: imageUrlsMaxCount,
+    maxFileSize: imageUrlsMaxFileSize,
+  } = useGenerationConfigParam('imageUrls');
+
+  const { autoSetDimensions, extractUrlAndDimensions } = useAutoDimensions();
+  const uploadWithProgress = useFileStore((s) => s.uploadWithProgress);
+
+  // Object-URL previews shown with a spinner while a batch upload is in flight,
+  // so dropped images appear instantly instead of only on completion. Kept in
+  // the store so the inline cards and the page-level drag zone (two separate
+  // hook instances) reflect the same in-flight uploads.
+  const uploadingPreviews = useImageStore(imageGenerationConfigSelectors.uploadingImagePreviews);
+  const addUploadingImagePreviews = useImageStore((s) => s.addUploadingImagePreviews);
+  const removeUploadingImagePreviews = useImageStore((s) => s.removeUploadingImagePreviews);
+
+  /** Whether the current model accepts any reference image at all. */
+  const canDropImage = isSupportImageUrl || isSupportImageUrls;
+
+  const maxFileSize = imageUrlsMaxFileSize ?? imageUrlMaxFileSize;
+
+  const maxCount = useMemo(() => {
+    let count = 0;
+    if (isSupportImageUrl) count += 1;
+    if (isSupportImageUrls) count += imageUrlsMaxCount ?? 4;
+    return count;
+  }, [isSupportImageUrl, isSupportImageUrls, imageUrlsMaxCount]);
+
+  const imagePreviewUrls = useMemo(
+    () => [imageUrl, ...(imageUrls ?? [])].filter(Boolean) as string[],
+    [imageUrl, imageUrls],
+  );
+
+  const handleAddImage = useCallback(
+    (data: UploadData) => {
+      if (!canCreate) return;
+
+      const { url, dimensions } = extractUrlAndDimensions(data);
+      if (!url) return;
+
+      if (dimensions) {
+        autoSetDimensions(dimensions);
+      }
+
+      if (isSupportImageUrl && !imageUrl) {
+        setImageUrl(url);
+      } else if (isSupportImageUrls) {
+        setImageUrls([...(imageUrls ?? []), url] as any);
+      } else if (isSupportImageUrl) {
+        setImageUrl(url);
+      }
+    },
+    [
+      isSupportImageUrl,
+      isSupportImageUrls,
+      imageUrl,
+      imageUrls,
+      setImageUrl,
+      setImageUrls,
+      autoSetDimensions,
+      extractUrlAndDimensions,
+      canCreate,
+    ],
+  );
+
+  const handleRemoveImage = useCallback(
+    (url: string) => {
+      if (!canCreate) return;
+
+      if (url === imageUrl) {
+        setImageUrl(null);
+      } else {
+        setImageUrls((imageUrls ?? []).filter((item) => item !== url) as any);
+      }
+    },
+    [canCreate, imageUrl, imageUrls, setImageUrl, setImageUrls],
+  );
+
+  const handleUploadFiles = useCallback(
+    async (files: File[]) => {
+      if (!canCreate) return;
+
+      const imageFiles = files.filter((file) => file.type.startsWith('image/'));
+      if (imageFiles.length === 0) return;
+
+      // Account for both landed images and any in-flight uploads.
+      const remaining = maxCount - imagePreviewUrls.length - uploadingPreviews.length;
+      if (remaining <= 0) {
+        message.warning(t('config.imageUpload.maxCountReached', { count: maxCount }));
+        return;
+      }
+
+      // Only take as many as the model still has room for, and warn when truncating.
+      const accepted = imageFiles.slice(0, remaining);
+      if (imageFiles.length > remaining) {
+        message.warning(t('config.imageUpload.maxCountReached', { count: maxCount }));
+      }
+
+      // Show instant local previews (with spinner) for the whole batch.
+      const previews = accepted.map((file) => URL.createObjectURL(file));
+      addUploadingImagePreviews(previews);
+
+      try {
+        const results = await Promise.all(
+          accepted.map(async (file): Promise<UploadData | null> => {
+            if (maxFileSize && file.size > maxFileSize) return null;
+
+            const result = await uploadWithProgress({
+              file,
+              onStatusUpdate: () => {},
+              skipCheckFileType: true,
+            });
+
+            if (!result?.url) return null;
+            return result.dimensions
+              ? { dimensions: result.dimensions, url: result.url }
+              : result.url;
+          }),
+        );
+
+        // Land all uploads in one state update to avoid a stale-closure race.
+        let nextImageUrl = imageUrl;
+        const nextImageUrls = [...(imageUrls ?? [])];
+        let firstDimensions: { height: number; width: number } | undefined;
+
+        for (const data of results) {
+          if (!data) continue;
+          const { url, dimensions } = extractUrlAndDimensions(data);
+          if (!url) continue;
+
+          if (!firstDimensions && dimensions) firstDimensions = dimensions;
+
+          if (isSupportImageUrl && !nextImageUrl) nextImageUrl = url;
+          else if (isSupportImageUrls) nextImageUrls.push(url);
+          else if (isSupportImageUrl) nextImageUrl = url;
+        }
+
+        if (firstDimensions) autoSetDimensions(firstDimensions);
+        if (nextImageUrl !== imageUrl) setImageUrl(nextImageUrl as any);
+        if (nextImageUrls.length !== (imageUrls?.length ?? 0)) setImageUrls(nextImageUrls as any);
+      } finally {
+        // Drop this batch's placeholders, then release the object URLs.
+        removeUploadingImagePreviews(previews);
+        previews.forEach((url) => URL.revokeObjectURL(url));
+      }
+    },
+    [
+      canCreate,
+      maxCount,
+      maxFileSize,
+      imagePreviewUrls,
+      uploadingPreviews,
+      imageUrl,
+      imageUrls,
+      isSupportImageUrl,
+      isSupportImageUrls,
+      setImageUrl,
+      setImageUrls,
+      uploadWithProgress,
+      addUploadingImagePreviews,
+      removeUploadingImagePreviews,
+      autoSetDimensions,
+      extractUrlAndDimensions,
+      t,
+    ],
+  );
+
+  return {
+    canDropImage,
+    handleAddImage,
+    handleRemoveImage,
+    handleUploadFiles,
+    imagePreviewUrls,
+    maxCount,
+    maxFileSize,
+    uploadingPreviews,
+  };
+};

--- a/src/routes/(main)/(create)/image/features/PromptInput/useImageReferenceUpload.ts
+++ b/src/routes/(main)/(create)/image/features/PromptInput/useImageReferenceUpload.ts
@@ -51,10 +51,15 @@ export const useImageReferenceUpload = () => {
   const removeUploadingImagePreviews = useImageStore((s) => s.removeUploadingImagePreviews);
 
   const slots = useMemo<ReferenceUploadSlot[]>(() => {
+    const readParams = () => imageGenerationConfigSelectors.parameters(useImageStore.getState());
     const list: ReferenceUploadSlot[] = [];
     if (isSupportImageUrl) {
       list.push({
         capacity: 1,
+        getCurrentValues: () => {
+          const v = readParams()?.imageUrl;
+          return v ? [v] : [];
+        },
         set: (urls) => setImageUrl((urls[0] ?? null) as any),
         values: imageUrl ? [imageUrl] : [],
       });
@@ -62,6 +67,10 @@ export const useImageReferenceUpload = () => {
     if (isSupportImageUrls) {
       list.push({
         capacity: imageUrlsMaxCount ?? 4,
+        getCurrentValues: () => {
+          const v = readParams()?.imageUrls;
+          return Array.isArray(v) ? v : [];
+        },
         set: (urls) => setImageUrls(urls as any),
         values: imageUrls ?? [],
       });

--- a/src/routes/(main)/(create)/image/index.tsx
+++ b/src/routes/(main)/(create)/image/index.tsx
@@ -6,10 +6,21 @@ import CreateGenerationPage from '@/routes/(main)/(create)/features/CreateGenera
 
 import ImageWorkspace from './features/ImageWorkspace';
 import PromptInput from './features/PromptInput';
+import { useImageReferenceUpload } from './features/PromptInput/useImageReferenceUpload';
 
-const DesktopImagePage = memo(() => (
-  <CreateGenerationPage PromptInput={PromptInput} Workspace={ImageWorkspace} path="/image" />
-));
+const DesktopImagePage = memo(() => {
+  const { canDropImage, handleUploadFiles } = useImageReferenceUpload();
+
+  return (
+    <CreateGenerationPage
+      PromptInput={PromptInput}
+      Workspace={ImageWorkspace}
+      dragDisabled={!canDropImage}
+      path="/image"
+      onUploadFiles={handleUploadFiles}
+    />
+  );
+});
 
 DesktopImagePage.displayName = 'DesktopImagePage';
 

--- a/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
+++ b/src/routes/(main)/(create)/video/features/PromptInput/index.tsx
@@ -34,6 +34,7 @@ import { useVideoGenerationConfigParam } from '@/store/video/slices/generationCo
 import { generateUniqueSeeds } from '@/utils/number';
 
 import PromptTitle from './Title';
+import { useVideoReferenceUpload } from './useVideoReferenceUpload';
 
 interface PromptInputProps {
   disableAnimation?: boolean;
@@ -311,6 +312,7 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
   const isSupportWebSearch = useVideoStore(isSupportedParamSelector('webSearch'));
   const isLogin = useUserStore(authSelectors.isLogin);
   const { value: duration } = useVideoGenerationConfigParam('duration');
+  const { handleUploadFiles, uploadingPreviews } = useVideoReferenceUpload();
   useFetchAiVideoConfig();
 
   // Read query parameters
@@ -458,9 +460,11 @@ const PromptInput = ({ showTitle = false }: PromptInputProps) => {
                 isSupportEndImage={isSupportEndImageUrl}
                 maxCount={maxCount}
                 maxFileSize={imageUrlsMaxFileSize ?? imageUrlMaxFileSize}
+                uploadingPreviews={uploadingPreviews}
                 onEndImageChange={handleEndImageChange}
                 onImageUrlsChange={handleAddImage}
                 onRemoveImageUrl={handleRemoveImage}
+                onUploadFiles={handleUploadFiles}
                 onImageChange={(data) => {
                   if (data === null) {
                     handleRemoveImage(imageUrl || '');

--- a/src/routes/(main)/(create)/video/features/PromptInput/useVideoReferenceUpload.ts
+++ b/src/routes/(main)/(create)/video/features/PromptInput/useVideoReferenceUpload.ts
@@ -1,0 +1,111 @@
+'use client';
+
+import { useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { message } from '@/components/AntdStaticMethods';
+import { usePermission } from '@/hooks/usePermission';
+import {
+  type ReferenceUploadSlot,
+  useReferenceImageUpload,
+} from '@/routes/(main)/(create)/features/GenerationInput/useReferenceImageUpload';
+import { useVideoStore } from '@/store/video';
+import { videoGenerationConfigSelectors } from '@/store/video/selectors';
+import { useVideoGenerationConfigParam } from '@/store/video/slices/generationConfig/hooks';
+
+const isSupportedParamSelector = videoGenerationConfigSelectors.isSupportedParam;
+
+/**
+ * Video-page binding for the shared {@link useReferenceImageUpload} core.
+ *
+ * Describes the video model's reference slots by priority — start frame
+ * (`imageUrl`) → reference array (`imageUrls`) → end frame (`endImageUrl`) — so a
+ * drop fills them in order. Single-image models accept one; first/end-frame
+ * models map a 2-image drop to start + end (the end frame's `requiresImageUrl`
+ * is satisfied because the start frame slot fills first).
+ */
+export const useVideoReferenceUpload = () => {
+  const { t } = useTranslation('video');
+  const { allowed: canCreate } = usePermission('create_content');
+
+  const isSupportImageUrl = useVideoStore(isSupportedParamSelector('imageUrl'));
+  const isSupportImageUrls = useVideoStore(isSupportedParamSelector('imageUrls'));
+  const isSupportEndImageUrl = useVideoStore(isSupportedParamSelector('endImageUrl'));
+
+  const {
+    value: imageUrl,
+    setValue: setImageUrl,
+    maxFileSize: imageUrlMaxFileSize,
+  } = useVideoGenerationConfigParam('imageUrl');
+  const {
+    value: imageUrls,
+    setValue: setImageUrls,
+    maxCount: imageUrlsMaxCount,
+    maxFileSize: imageUrlsMaxFileSize,
+  } = useVideoGenerationConfigParam('imageUrls');
+  const {
+    value: endImageUrl,
+    setValue: setEndImageUrl,
+    maxFileSize: endImageUrlMaxFileSize,
+  } = useVideoGenerationConfigParam('endImageUrl');
+
+  const uploadingPreviews = useVideoStore(videoGenerationConfigSelectors.uploadingImagePreviews);
+  const addUploadingImagePreviews = useVideoStore((s) => s.addUploadingImagePreviews);
+  const removeUploadingImagePreviews = useVideoStore((s) => s.removeUploadingImagePreviews);
+
+  const slots = useMemo<ReferenceUploadSlot[]>(() => {
+    const list: ReferenceUploadSlot[] = [];
+    if (isSupportImageUrl) {
+      list.push({
+        capacity: 1,
+        set: (urls) => setImageUrl((urls[0] ?? null) as any),
+        values: imageUrl ? [imageUrl] : [],
+      });
+    }
+    if (isSupportImageUrls) {
+      list.push({
+        capacity: imageUrlsMaxCount ?? 4,
+        set: (urls) => setImageUrls(urls as any),
+        values: imageUrls ?? [],
+      });
+    }
+    if (isSupportEndImageUrl) {
+      list.push({
+        capacity: 1,
+        set: (urls) => setEndImageUrl((urls[0] ?? null) as any),
+        values: endImageUrl ? [endImageUrl] : [],
+      });
+    }
+    return list;
+  }, [
+    isSupportImageUrl,
+    isSupportImageUrls,
+    isSupportEndImageUrl,
+    imageUrl,
+    imageUrls,
+    endImageUrl,
+    imageUrlsMaxCount,
+    setImageUrl,
+    setImageUrls,
+    setEndImageUrl,
+  ]);
+
+  const onLimitExceeded = useCallback(
+    (maxCount: number) => {
+      message.warning(t('config.imageUpload.maxCountReached', { count: maxCount }));
+    },
+    [t],
+  );
+
+  const { canDropImage, handleUploadFiles, maxCount, maxFileSize } = useReferenceImageUpload({
+    addUploadingPreviews: addUploadingImagePreviews,
+    canCreate,
+    maxFileSize: imageUrlsMaxFileSize ?? imageUrlMaxFileSize ?? endImageUrlMaxFileSize,
+    onLimitExceeded,
+    removeUploadingPreviews: removeUploadingImagePreviews,
+    slots,
+    uploadingPreviews,
+  });
+
+  return { canDropImage, handleUploadFiles, maxCount, maxFileSize, uploadingPreviews };
+};

--- a/src/routes/(main)/(create)/video/features/PromptInput/useVideoReferenceUpload.ts
+++ b/src/routes/(main)/(create)/video/features/PromptInput/useVideoReferenceUpload.ts
@@ -54,10 +54,15 @@ export const useVideoReferenceUpload = () => {
   const removeUploadingImagePreviews = useVideoStore((s) => s.removeUploadingImagePreviews);
 
   const slots = useMemo<ReferenceUploadSlot[]>(() => {
+    const readParams = () => videoGenerationConfigSelectors.parameters(useVideoStore.getState());
     const list: ReferenceUploadSlot[] = [];
     if (isSupportImageUrl) {
       list.push({
         capacity: 1,
+        getCurrentValues: () => {
+          const v = readParams()?.imageUrl;
+          return v ? [v] : [];
+        },
         set: (urls) => setImageUrl((urls[0] ?? null) as any),
         values: imageUrl ? [imageUrl] : [],
       });
@@ -65,6 +70,10 @@ export const useVideoReferenceUpload = () => {
     if (isSupportImageUrls) {
       list.push({
         capacity: imageUrlsMaxCount ?? 4,
+        getCurrentValues: () => {
+          const v = readParams()?.imageUrls;
+          return Array.isArray(v) ? v : [];
+        },
         set: (urls) => setImageUrls(urls as any),
         values: imageUrls ?? [],
       });
@@ -72,6 +81,10 @@ export const useVideoReferenceUpload = () => {
     if (isSupportEndImageUrl) {
       list.push({
         capacity: 1,
+        getCurrentValues: () => {
+          const v = readParams()?.endImageUrl;
+          return v ? [v] : [];
+        },
         set: (urls) => setEndImageUrl((urls[0] ?? null) as any),
         values: endImageUrl ? [endImageUrl] : [],
       });

--- a/src/routes/(main)/(create)/video/index.tsx
+++ b/src/routes/(main)/(create)/video/index.tsx
@@ -5,11 +5,22 @@ import { memo } from 'react';
 import CreateGenerationPage from '@/routes/(main)/(create)/features/CreateGenerationPage';
 
 import PromptInput from './features/PromptInput';
+import { useVideoReferenceUpload } from './features/PromptInput/useVideoReferenceUpload';
 import VideoWorkspace from './features/VideoWorkspace';
 
-const DesktopVideoPage = memo(() => (
-  <CreateGenerationPage PromptInput={PromptInput} Workspace={VideoWorkspace} path="/video" />
-));
+const DesktopVideoPage = memo(() => {
+  const { canDropImage, handleUploadFiles } = useVideoReferenceUpload();
+
+  return (
+    <CreateGenerationPage
+      PromptInput={PromptInput}
+      Workspace={VideoWorkspace}
+      dragDisabled={!canDropImage}
+      path="/video"
+      onUploadFiles={handleUploadFiles}
+    />
+  );
+});
 
 DesktopVideoPage.displayName = 'DesktopVideoPage';
 

--- a/src/store/image/slices/generationConfig/action.ts
+++ b/src/store/image/slices/generationConfig/action.ts
@@ -324,6 +324,24 @@ export class GenerationConfigActionImpl {
     this.#set(() => ({ imageNum }), false, `setImageNum/${imageNum}`);
   };
 
+  addUploadingImagePreviews = (urls: string[]): void => {
+    this.#set(
+      (state) => ({ uploadingImagePreviews: [...state.uploadingImagePreviews, ...urls] }),
+      false,
+      'addUploadingImagePreviews',
+    );
+  };
+
+  removeUploadingImagePreviews = (urls: string[]): void => {
+    this.#set(
+      (state) => ({
+        uploadingImagePreviews: state.uploadingImagePreviews.filter((url) => !urls.includes(url)),
+      }),
+      false,
+      'removeUploadingImagePreviews',
+    );
+  };
+
   reuseSettings = (
     model: string,
     provider: string,

--- a/src/store/image/slices/generationConfig/initialState.ts
+++ b/src/store/image/slices/generationConfig/initialState.ts
@@ -19,6 +19,13 @@ export interface GenerationConfigState {
   activeAspectRatio: string | null; // string - virtual ratio; null - native ratio
 
   /**
+   * Object-URL previews for reference images currently being uploaded. Shared
+   * across the inline reference cards and the page-level drag-upload zone so
+   * both surfaces show the same in-flight loading placeholders.
+   */
+  uploadingImagePreviews: string[];
+
+  /**
    * Marks whether the configuration has been initialized (including restoration from memory)
    */
   isInit: boolean;
@@ -35,5 +42,6 @@ export const initialGenerationConfigState: GenerationConfigState = {
   parametersSchema: nanoBanana2Parameters,
   isAspectRatioLocked: false,
   activeAspectRatio: null,
+  uploadingImagePreviews: [],
   isInit: false,
 };

--- a/src/store/image/slices/generationConfig/selectors.ts
+++ b/src/store/image/slices/generationConfig/selectors.ts
@@ -5,6 +5,7 @@ import { type GenerationConfigState } from './initialState';
 export const model = (s: GenerationConfigState) => s.model;
 export const provider = (s: GenerationConfigState) => s.provider;
 export const imageNum = (s: GenerationConfigState) => s.imageNum;
+const uploadingImagePreviews = (s: GenerationConfigState) => s.uploadingImagePreviews;
 
 const parameters = (s: GenerationConfigState) => s.parameters;
 const parametersSchema = (s: GenerationConfigState) => s.parametersSchema;
@@ -22,4 +23,5 @@ export const imageGenerationConfigSelectors = {
   isSupportedParam,
   parameters,
   parametersSchema,
+  uploadingImagePreviews,
 };

--- a/src/store/video/slices/generationConfig/action.test.ts
+++ b/src/store/video/slices/generationConfig/action.test.ts
@@ -107,3 +107,28 @@ describe('video generationConfig actions', () => {
     expect(result.current.parameters?.duration).toBe(modelBDefaultValues.duration);
   });
 });
+
+describe('uploading image previews', () => {
+  it('should append and remove in-flight upload previews', () => {
+    const { result } = renderHook(() => useVideoStore());
+
+    act(() => {
+      useVideoStore.setState({ uploadingImagePreviews: [] });
+    });
+
+    act(() => {
+      result.current.addUploadingImagePreviews(['blob:a', 'blob:b']);
+    });
+    expect(result.current.uploadingImagePreviews).toEqual(['blob:a', 'blob:b']);
+
+    act(() => {
+      result.current.addUploadingImagePreviews(['blob:c']);
+    });
+    expect(result.current.uploadingImagePreviews).toEqual(['blob:a', 'blob:b', 'blob:c']);
+
+    act(() => {
+      result.current.removeUploadingImagePreviews(['blob:a', 'blob:c']);
+    });
+    expect(result.current.uploadingImagePreviews).toEqual(['blob:b']);
+  });
+});

--- a/src/store/video/slices/generationConfig/action.ts
+++ b/src/store/video/slices/generationConfig/action.ts
@@ -147,6 +147,24 @@ export class GenerationConfigActionImpl {
       `setParamOnInput/${paramName}`,
     );
   };
+
+  addUploadingImagePreviews = (urls: string[]): void => {
+    this.#set(
+      (state) => ({ uploadingImagePreviews: [...state.uploadingImagePreviews, ...urls] }),
+      false,
+      'addUploadingImagePreviews',
+    );
+  };
+
+  removeUploadingImagePreviews = (urls: string[]): void => {
+    this.#set(
+      (state) => ({
+        uploadingImagePreviews: state.uploadingImagePreviews.filter((url) => !urls.includes(url)),
+      }),
+      false,
+      'removeUploadingImagePreviews',
+    );
+  };
 }
 
 export type GenerationConfigAction = Pick<

--- a/src/store/video/slices/generationConfig/initialState.ts
+++ b/src/store/video/slices/generationConfig/initialState.ts
@@ -50,6 +50,13 @@ export interface VideoGenerationConfigState {
   model: string;
 
   /**
+   * Object-URL previews for reference images currently being uploaded. Shared
+   * across the inline reference frames and the page-level drag-upload zone so
+   * both surfaces show the same in-flight loading placeholders.
+   */
+  uploadingImagePreviews: string[];
+
+  /**
    * Marks whether the configuration has been initialized (including restoration from memory)
    */
   isInit: boolean;
@@ -63,5 +70,6 @@ export const initialGenerationConfigState: VideoGenerationConfigState = {
   provider: DEFAULT_AI_VIDEO_PROVIDER,
   parameters: DEFAULT_VIDEO_GENERATION_PARAMETERS,
   parametersSchema: seedance20Params,
+  uploadingImagePreviews: [],
   isInit: false,
 };

--- a/src/store/video/slices/generationConfig/selectors.ts
+++ b/src/store/video/slices/generationConfig/selectors.ts
@@ -4,6 +4,7 @@ import { type VideoGenerationConfigState } from './initialState';
 
 const model = (s: VideoGenerationConfigState) => s.model;
 const provider = (s: VideoGenerationConfigState) => s.provider;
+const uploadingImagePreviews = (s: VideoGenerationConfigState) => s.uploadingImagePreviews;
 
 const parameters = (s: VideoGenerationConfigState) => s.parameters;
 const parametersSchema = (s: VideoGenerationConfigState) => s.parametersSchema;
@@ -20,4 +21,5 @@ export const videoGenerationConfigSelectors = {
   parameters,
   parametersSchema,
   provider,
+  uploadingImagePreviews,
 };


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

<!-- Reported by a user on Discord: image generation did not support drag-and-drop of reference images. -->

#### 🔀 Description of Change

Make the **entire image creation area** accept drag-and-drop of reference images, replacing the previous click-only inline upload card.

- **Whole-area drop zone**: mount `DragUploadZone` over the creation content area (everything below the nav header). The drop zone is gated on whether the current model accepts reference images — unsupported models show no overlay and ignore drops.
- **Multi-image, model-aware**: the number of images accepted respects the current model's capacity. Single-image models (`imageUrl`, maxCount 1) take 1; multi-image models (`imageUrls`) fill the remaining slots. Over-limit drops are truncated to the available slots with a toast.
- **Instant feedback**: dropped/selected files render immediately as object-URL preview cards with a spinner while the upload is in flight, instead of appearing only after upload completes.
- **Multi-select on click**: the inline add card now supports selecting multiple files at once.

Shared logic lives in a new `useImageReferenceUpload` hook so the inline reference cards and the page-level drag zone stay in sync.

#### 🧪 How to Test

1. Open the image creation page, pick a model that supports reference images.
2. Drag one or more images anywhere over the right-side creation area → overlay appears → previews show with spinner → images land as references.
3. Drag more than the model allows → only the remaining slots fill, with a toast.
4. Switch to a model without reference-image support → no overlay, drops ignored.
5. Click the inline "+" card → multi-select files.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

**Key decisions:**
- In-flight upload previews are kept in the **image store** (not local `useState`) because the inline cards and the drag zone are two separate hook instances; local state would not be visible across both, so drag-path uploads would show no loading state.
- Batch upload lands all files in a **single state update** to avoid a stale-closure race that calling the single-add handler in a loop would cause.
- The drop zone covers the content area **below the nav header** (matching the existing agent-chat `DragUploadZone` pattern), not the header itself.
- `UploadCard` / `InlineImageReference` gained optional `multiple` / `onUploadFiles` / `loading` / `uploadingPreviews` props — fully backward compatible, so the video creation page is unaffected.