### PR TITLE
✨ feat: add PostHog LobeHub skill integration

### DIFF
--- a/apps/server/src/routers/tools/market.test.ts
+++ b/apps/server/src/routers/tools/market.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { marketRouter } from './market';
+
+const mockMarketSDK = vi.hoisted(() => ({
+  skills: {
+    callTool: vi.fn(),
+    listLiveTools: vi.fn(),
+    listTools: vi.fn(),
+  },
+}));
+
+vi.mock('@/libs/trpc/lambda/middleware', () => ({
+  marketUserInfo: vi.fn((opts: any) => opts.next({ ctx: opts.ctx })),
+  serverDatabase: vi.fn((opts: any) => opts.next({ ctx: opts.ctx })),
+  telemetry: vi.fn((opts: any) => opts.next({ ctx: opts.ctx })),
+}));
+
+vi.mock('@/libs/trpc/lambda/middleware/marketSDK', () => ({
+  marketSDK: vi.fn((opts: any) =>
+    opts.next({
+      ctx: {
+        ...opts.ctx,
+        marketSDK: mockMarketSDK,
+      },
+    }),
+  ),
+  requireMarketAuth: vi.fn((opts: any) => opts.next({ ctx: opts.ctx })),
+}));
+
+vi.mock('debug', () => ({
+  default: vi.fn(() => vi.fn()),
+}));
+
+describe('tools marketRouter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should fall back to static tools when live discovery fails', async () => {
+    const caller = marketRouter.createCaller({ userId: 'user-1' } as any);
+    mockMarketSDK.skills.listLiveTools.mockRejectedValue(new Error('Live discovery failed'));
+    mockMarketSDK.skills.listTools.mockResolvedValue({
+      tools: [
+        {
+          description: 'Run a PostHog query',
+          inputSchema: { properties: { query: { type: 'string' } }, type: 'object' },
+          name: 'query',
+        },
+      ],
+    });
+
+    await expect(caller.connectListTools({ provider: 'posthog' })).resolves.toEqual({
+      provider: 'posthog',
+      tools: [
+        {
+          description: 'Run a PostHog query',
+          inputSchema: { properties: { query: { type: 'string' } }, type: 'object' },
+          name: 'query',
+        },
+      ],
+    });
+
+    expect(mockMarketSDK.skills.listLiveTools).toHaveBeenCalledWith('posthog');
+    expect(mockMarketSDK.skills.listTools).toHaveBeenCalledWith('posthog');
+  });
+
+  it('should preserve failed tool call error payloads', async () => {
+    const caller = marketRouter.createCaller({ userId: 'user-1' } as any);
+    mockMarketSDK.skills.callTool.mockResolvedValue({
+      data: null,
+      error: { code: 'POSTHOG_QUERY_FAILED', message: 'Query failed' },
+      success: false,
+    });
+
+    await expect(
+      caller.connectCallTool({
+        args: { query: 'select * from events' },
+        provider: 'posthog',
+        toolName: 'query',
+      }),
+    ).resolves.toEqual({
+      data: null,
+      error: { code: 'POSTHOG_QUERY_FAILED', message: 'Query failed' },
+      success: false,
+    });
+
+    expect(mockMarketSDK.skills.callTool).toHaveBeenCalledWith('posthog', {
+      args: { query: 'select * from events' },
+      tool: 'query',
+      topicId: undefined,
+    });
+  });
+});

--- a/apps/server/src/routers/tools/market.ts
+++ b/apps/server/src/routers/tools/market.ts
@@ -138,6 +138,29 @@ const callCloudMcpEndpointSchema = z.object({
   toolName: z.string(),
 });
 
+const listSkillToolsWithLiveFallback = async (
+  skills: {
+    listLiveTools?: (provider: string) => Promise<any>;
+    listTools: (provider: string) => Promise<any>;
+  },
+  provider: string,
+) => {
+  if (typeof skills.listLiveTools === 'function') {
+    try {
+      const response = await skills.listLiveTools(provider);
+      if (response) return response;
+    } catch (error) {
+      log(
+        'listSkillToolsWithLiveFallback: live discovery failed for %s, falling back to static tools: %O',
+        provider,
+        error,
+      );
+    }
+  }
+
+  return skills.listTools(provider);
+};
+
 // ============================== Type Exports ==============================
 export type ExecInSandboxInput = z.infer<typeof execInSandboxSchema>;
 /** @deprecated Use ExecInSandboxInput */
@@ -425,6 +448,7 @@ export const marketRouter = router({
 
         return {
           data: response.data,
+          error: (response as any).error,
           success: response.success,
         };
       } catch (error) {
@@ -594,7 +618,7 @@ export const marketRouter = router({
       log('connectListTools: provider=%s', input.provider);
 
       try {
-        const response = await ctx.marketSDK.skills.listTools(input.provider);
+        const response = await listSkillToolsWithLiveFallback(ctx.marketSDK.skills, input.provider);
         return {
           provider: input.provider,
           tools: response.tools || [],

--- a/apps/server/src/routers/tools/market.ts
+++ b/apps/server/src/routers/tools/market.ts
@@ -14,6 +14,7 @@ import { isTrustedClientEnabled } from '@/libs/trusted-client';
 import { DiscoverService } from '@/server/services/discover';
 import { FileService } from '@/server/services/file';
 import { MarketService } from '@/server/services/market';
+import { listSkillToolsWithLiveFallback } from '@/server/services/market/listSkillToolsWithLiveFallback';
 import {
   contentBlocksToString,
   processContentBlocks,
@@ -137,29 +138,6 @@ const callCloudMcpEndpointSchema = z.object({
   meta: metaSchema,
   toolName: z.string(),
 });
-
-const listSkillToolsWithLiveFallback = async (
-  skills: {
-    listLiveTools?: (provider: string) => Promise<any>;
-    listTools: (provider: string) => Promise<any>;
-  },
-  provider: string,
-) => {
-  if (typeof skills.listLiveTools === 'function') {
-    try {
-      const response = await skills.listLiveTools(provider);
-      if (response) return response;
-    } catch (error) {
-      log(
-        'listSkillToolsWithLiveFallback: live discovery failed for %s, falling back to static tools: %O',
-        provider,
-        error,
-      );
-    }
-  }
-
-  return skills.listTools(provider);
-};
 
 // ============================== Type Exports ==============================
 export type ExecInSandboxInput = z.infer<typeof execInSandboxSchema>;
@@ -618,7 +596,17 @@ export const marketRouter = router({
       log('connectListTools: provider=%s', input.provider);
 
       try {
-        const response = await listSkillToolsWithLiveFallback(ctx.marketSDK.skills, input.provider);
+        const response = await listSkillToolsWithLiveFallback(
+          ctx.marketSDK.skills,
+          input.provider,
+          (error) => {
+            log(
+              'listSkillToolsWithLiveFallback: live discovery failed for %s, falling back to static tools: %O',
+              input.provider,
+              error,
+            );
+          },
+        );
         return {
           provider: input.provider,
           tools: response.tools || [],

--- a/apps/server/src/services/market/index.test.ts
+++ b/apps/server/src/services/market/index.test.ts
@@ -49,6 +49,7 @@ vi.mock('@lobehub/market-sdk', () => {
     },
     skills: {
       callTool: vi.fn(),
+      listLiveTools: vi.fn(),
       listTools: vi.fn(),
     },
     user: {
@@ -300,6 +301,28 @@ describe('MarketService', () => {
         success: false,
       });
     });
+
+    it('should return error result when the skill call response is unsuccessful', async () => {
+      const service = new MarketService();
+      const mockCallTool = vi.fn().mockResolvedValue({
+        data: null,
+        error: { code: 'POSTHOG_QUERY_FAILED', message: 'Query failed' },
+        success: false,
+      });
+      (service as any).market.skills.callTool = mockCallTool;
+
+      const result = await service.executeLobehubSkill({
+        args: { query: 'select * from events' },
+        provider: 'posthog',
+        toolName: 'query',
+      });
+
+      expect(result).toEqual({
+        content: 'Query failed',
+        error: { code: 'POSTHOG_QUERY_FAILED', message: 'Query failed' },
+        success: false,
+      });
+    });
   });
 
   describe('getLobehubSkillManifests', () => {
@@ -411,6 +434,45 @@ describe('MarketService', () => {
       expect(manifests[0].meta).toMatchObject({
         description: 'LobeHub Skill: Notion',
         title: 'Notion',
+      });
+    });
+
+    it('should build PostHog manifests from live tool discovery', async () => {
+      const service = new MarketService();
+      (service as any).market.connect.listConnections = vi.fn().mockResolvedValue({
+        connections: [{ icon: 'posthog-icon', providerId: 'posthog', providerName: 'Workspace' }],
+      });
+      (service as any).market.skills.listLiveTools = vi.fn().mockResolvedValue({
+        instruction: 'Use PostHog analytics tools with the connected workspace.',
+        tools: [
+          {
+            description: 'Run a PostHog query',
+            inputSchema: { properties: { query: { type: 'string' } }, type: 'object' },
+            name: 'query',
+          },
+        ],
+      });
+      (service as any).market.skills.listTools = vi.fn().mockResolvedValue({ tools: [] });
+
+      const manifests = await service.getLobehubSkillManifests();
+
+      expect((service as any).market.skills.listLiveTools).toHaveBeenCalledWith('posthog');
+      expect((service as any).market.skills.listTools).not.toHaveBeenCalled();
+      expect(manifests).toHaveLength(1);
+      expect(manifests[0]).toMatchObject({
+        identifier: 'posthog',
+        meta: {
+          avatar: 'posthog-icon',
+          description: 'LobeHub Skill: PostHog',
+          tags: ['lobehub-skill', 'posthog'],
+          title: 'PostHog',
+        },
+        systemRole: 'Use PostHog analytics tools with the connected workspace.',
+      });
+      expect(manifests[0].api[0]).toEqual({
+        description: 'Run a PostHog query',
+        name: 'query',
+        parameters: { properties: { query: { type: 'string' } }, type: 'object' },
       });
     });
 

--- a/apps/server/src/services/market/index.test.ts
+++ b/apps/server/src/services/market/index.test.ts
@@ -323,6 +323,92 @@ describe('MarketService', () => {
         success: false,
       });
     });
+
+    it('should use response data as the failure message when no structured error is provided', async () => {
+      const service = new MarketService();
+      const mockCallTool = vi.fn().mockResolvedValue({
+        data: 'PostHog query timed out',
+        success: false,
+      });
+      (service as any).market.skills.callTool = mockCallTool;
+
+      const result = await service.executeLobehubSkill({
+        args: { query: 'select * from events' },
+        provider: 'posthog',
+        toolName: 'query',
+      });
+
+      expect(result).toEqual({
+        content: 'PostHog query timed out',
+        error: { code: 'LOBEHUB_SKILL_ERROR', message: 'PostHog query timed out' },
+        success: false,
+      });
+    });
+
+    it('should use a generic failure message when an unsuccessful response has no detail', async () => {
+      const service = new MarketService();
+      const mockCallTool = vi.fn().mockResolvedValue({
+        data: null,
+        success: false,
+      });
+      (service as any).market.skills.callTool = mockCallTool;
+
+      const result = await service.executeLobehubSkill({
+        args: {},
+        provider: 'posthog',
+        toolName: 'query',
+      });
+
+      expect(result).toEqual({
+        content: 'LobeHub Skill call failed',
+        error: { code: 'LOBEHUB_SKILL_ERROR', message: 'LobeHub Skill call failed' },
+        success: false,
+      });
+    });
+  });
+
+  describe('listSkillTools', () => {
+    it('should use live tool discovery when available', async () => {
+      const service = new MarketService();
+      const liveResponse = {
+        instruction: 'Use live PostHog tools.',
+        tools: [{ inputSchema: { type: 'object' }, name: 'query' }],
+      };
+      (service as any).market.skills.listLiveTools = vi.fn().mockResolvedValue(liveResponse);
+      (service as any).market.skills.listTools = vi.fn().mockResolvedValue({ tools: [] });
+
+      await expect(service.listSkillTools('posthog')).resolves.toBe(liveResponse);
+
+      expect((service as any).market.skills.listLiveTools).toHaveBeenCalledWith('posthog');
+      expect((service as any).market.skills.listTools).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to static tools when live discovery throws', async () => {
+      const service = new MarketService();
+      const staticResponse = {
+        tools: [{ inputSchema: { type: 'object' }, name: 'query' }],
+      };
+      (service as any).market.skills.listLiveTools = vi.fn().mockRejectedValue(new Error('boom'));
+      (service as any).market.skills.listTools = vi.fn().mockResolvedValue(staticResponse);
+
+      await expect(service.listSkillTools('posthog')).resolves.toBe(staticResponse);
+
+      expect((service as any).market.skills.listLiveTools).toHaveBeenCalledWith('posthog');
+      expect((service as any).market.skills.listTools).toHaveBeenCalledWith('posthog');
+    });
+
+    it('should fall back to static tools when live discovery returns no response', async () => {
+      const service = new MarketService();
+      const staticResponse = {
+        tools: [{ inputSchema: { type: 'object' }, name: 'query' }],
+      };
+      (service as any).market.skills.listLiveTools = vi.fn().mockResolvedValue(null);
+      (service as any).market.skills.listTools = vi.fn().mockResolvedValue(staticResponse);
+
+      await expect(service.listSkillTools('posthog')).resolves.toBe(staticResponse);
+
+      expect((service as any).market.skills.listTools).toHaveBeenCalledWith('posthog');
+    });
   });
 
   describe('getLobehubSkillManifests', () => {

--- a/apps/server/src/services/market/index.test.ts
+++ b/apps/server/src/services/market/index.test.ts
@@ -345,6 +345,28 @@ describe('MarketService', () => {
       });
     });
 
+    it('should stringify response data objects as the failure message', async () => {
+      const service = new MarketService();
+      const mockCallTool = vi.fn().mockResolvedValue({
+        data: { detail: 'PostHog query timed out', status: 504 },
+        success: false,
+      });
+      (service as any).market.skills.callTool = mockCallTool;
+
+      const result = await service.executeLobehubSkill({
+        args: { query: 'select * from events' },
+        provider: 'posthog',
+        toolName: 'query',
+      });
+
+      const message = JSON.stringify({ detail: 'PostHog query timed out', status: 504 });
+      expect(result).toEqual({
+        content: message,
+        error: { code: 'LOBEHUB_SKILL_ERROR', message },
+        success: false,
+      });
+    });
+
     it('should use a generic failure message when an unsuccessful response has no detail', async () => {
       const service = new MarketService();
       const mockCallTool = vi.fn().mockResolvedValue({
@@ -394,6 +416,19 @@ describe('MarketService', () => {
       await expect(service.listSkillTools('posthog')).resolves.toBe(staticResponse);
 
       expect((service as any).market.skills.listLiveTools).toHaveBeenCalledWith('posthog');
+      expect((service as any).market.skills.listTools).toHaveBeenCalledWith('posthog');
+    });
+
+    it('should fall back to static tools when live discovery returns no tools', async () => {
+      const service = new MarketService();
+      const staticResponse = {
+        tools: [{ inputSchema: { type: 'object' }, name: 'query' }],
+      };
+      (service as any).market.skills.listLiveTools = vi.fn().mockResolvedValue({ tools: [] });
+      (service as any).market.skills.listTools = vi.fn().mockResolvedValue(staticResponse);
+
+      await expect(service.listSkillTools('posthog')).resolves.toBe(staticResponse);
+
       expect((service as any).market.skills.listTools).toHaveBeenCalledWith('posthog');
     });
 

--- a/apps/server/src/services/market/index.ts
+++ b/apps/server/src/services/market/index.ts
@@ -6,6 +6,8 @@ import { type NextRequest } from 'next/server';
 import { type TrustedClientUserInfo } from '@/libs/trusted-client';
 import { generateTrustedClientToken, getTrustedClientTokenForSession } from '@/libs/trusted-client';
 
+import { listSkillToolsWithLiveFallback } from './listSkillToolsWithLiveFallback';
+
 const log = debug('lobe-server:market-service');
 
 const MARKET_BASE_URL = process.env.MARKET_BASE_URL || 'https://market.lobehub.com';
@@ -257,7 +259,20 @@ export class MarketService {
    * List available tools for a provider
    */
   async listSkillTools(providerId: string) {
-    return this.listSkillToolsWithLiveFallback(providerId);
+    return listSkillToolsWithLiveFallback(
+      this.market.skills as {
+        listLiveTools?: (providerId: string) => Promise<any>;
+        listTools: (providerId: string) => Promise<any>;
+      },
+      providerId,
+      (error) => {
+        log(
+          'listSkillToolsWithLiveFallback: live discovery failed for %s, falling back to static tools: %O',
+          providerId,
+          error,
+        );
+      },
+    );
   }
 
   /**
@@ -265,28 +280,6 @@ export class MarketService {
    */
   async callSkillTool(provider: string, params: { args: Record<string, any>; tool: string }) {
     return this.market.skills.callTool(provider, params);
-  }
-
-  private async listSkillToolsWithLiveFallback(providerId: string) {
-    const skills = this.market.skills as {
-      listLiveTools?: (providerId: string) => Promise<any>;
-      listTools: (providerId: string) => Promise<any>;
-    };
-
-    if (typeof skills.listLiveTools === 'function') {
-      try {
-        const response = await skills.listLiveTools(providerId);
-        if (response) return response;
-      } catch (error) {
-        log(
-          'listSkillToolsWithLiveFallback: live discovery failed for %s, falling back to static tools: %O',
-          providerId,
-          error,
-        );
-      }
-    }
-
-    return skills.listTools(providerId);
   }
 
   /**
@@ -600,7 +593,7 @@ export class MarketService {
           };
           const providerLabel = PROVIDER_LABELS[providerId] || providerId;
 
-          const { tools, instruction } = await this.listSkillToolsWithLiveFallback(providerId);
+          const { tools, instruction } = await this.listSkillTools(providerId);
           if (!tools || tools.length === 0) continue;
 
           const manifest: LobeToolManifest = {

--- a/apps/server/src/services/market/index.ts
+++ b/apps/server/src/services/market/index.ts
@@ -506,10 +506,15 @@ export class MarketService {
 
       if (!response.success) {
         const responseError = (response as any).error;
-        const message =
-          responseError?.message ||
-          (typeof response.data === 'string' ? response.data : undefined) ||
-          'LobeHub Skill call failed';
+        let dataMessage: string | undefined;
+
+        if (typeof response.data === 'string') {
+          dataMessage = response.data;
+        } else if (response.data !== undefined && response.data !== null) {
+          dataMessage = JSON.stringify(response.data);
+        }
+
+        const message = responseError?.message || dataMessage || 'LobeHub Skill call failed';
 
         return {
           content: message,

--- a/apps/server/src/services/market/index.ts
+++ b/apps/server/src/services/market/index.ts
@@ -257,7 +257,7 @@ export class MarketService {
    * List available tools for a provider
    */
   async listSkillTools(providerId: string) {
-    return this.market.skills.listTools(providerId);
+    return this.listSkillToolsWithLiveFallback(providerId);
   }
 
   /**
@@ -265,6 +265,28 @@ export class MarketService {
    */
   async callSkillTool(provider: string, params: { args: Record<string, any>; tool: string }) {
     return this.market.skills.callTool(provider, params);
+  }
+
+  private async listSkillToolsWithLiveFallback(providerId: string) {
+    const skills = this.market.skills as {
+      listLiveTools?: (providerId: string) => Promise<any>;
+      listTools: (providerId: string) => Promise<any>;
+    };
+
+    if (typeof skills.listLiveTools === 'function') {
+      try {
+        const response = await skills.listLiveTools(providerId);
+        if (response) return response;
+      } catch (error) {
+        log(
+          'listSkillToolsWithLiveFallback: live discovery failed for %s, falling back to static tools: %O',
+          providerId,
+          error,
+        );
+      }
+    }
+
+    return skills.listTools(providerId);
   }
 
   /**
@@ -489,9 +511,26 @@ export class MarketService {
 
       log('executeLobehubSkill: response: %O', response);
 
+      if (!response.success) {
+        const responseError = (response as any).error;
+        const message =
+          responseError?.message ||
+          (typeof response.data === 'string' ? response.data : undefined) ||
+          'LobeHub Skill call failed';
+
+        return {
+          content: message,
+          error: {
+            code: responseError?.code || 'LOBEHUB_SKILL_ERROR',
+            message,
+          },
+          success: false,
+        };
+      }
+
       return {
         content: typeof response.data === 'string' ? response.data : JSON.stringify(response.data),
-        success: response.success,
+        success: true,
       };
     } catch (error) {
       const err = error as Error;
@@ -555,12 +594,13 @@ export class MarketService {
             linear: 'Linear',
             microsoft: 'Outlook Calendar',
             notion: 'Notion',
+            posthog: 'PostHog',
             twitter: 'X (Twitter)',
             vercel: 'Vercel',
           };
           const providerLabel = PROVIDER_LABELS[providerId] || providerId;
 
-          const { tools, instruction } = await this.market.skills.listTools(providerId);
+          const { tools, instruction } = await this.listSkillToolsWithLiveFallback(providerId);
           if (!tools || tools.length === 0) continue;
 
           const manifest: LobeToolManifest = {

--- a/apps/server/src/services/market/listSkillToolsWithLiveFallback.test.ts
+++ b/apps/server/src/services/market/listSkillToolsWithLiveFallback.test.ts
@@ -53,6 +53,20 @@ describe('listSkillToolsWithLiveFallback', () => {
     expect(skills.listTools).toHaveBeenCalledWith('posthog');
   });
 
+  it('should fall back to static tools when live discovery returns no tools', async () => {
+    const staticResponse = {
+      tools: [{ inputSchema: { type: 'object' }, name: 'query' }],
+    };
+    const skills = {
+      listLiveTools: vi.fn().mockResolvedValue({ instruction: 'No live tools yet.', tools: [] }),
+      listTools: vi.fn().mockResolvedValue(staticResponse),
+    };
+
+    await expect(listSkillToolsWithLiveFallback(skills, 'posthog')).resolves.toBe(staticResponse);
+
+    expect(skills.listTools).toHaveBeenCalledWith('posthog');
+  });
+
   it('should use static tools when live discovery is unavailable', async () => {
     const staticResponse = {
       tools: [{ inputSchema: { type: 'object' }, name: 'query' }],

--- a/apps/server/src/services/market/listSkillToolsWithLiveFallback.test.ts
+++ b/apps/server/src/services/market/listSkillToolsWithLiveFallback.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+
+import { listSkillToolsWithLiveFallback } from './listSkillToolsWithLiveFallback';
+
+describe('listSkillToolsWithLiveFallback', () => {
+  it('should return live tools when live discovery succeeds', async () => {
+    const liveResponse = {
+      instruction: 'Use live PostHog tools.',
+      tools: [{ inputSchema: { type: 'object' }, name: 'query' }],
+    };
+    const skills = {
+      listLiveTools: vi.fn().mockResolvedValue(liveResponse),
+      listTools: vi.fn().mockResolvedValue({ tools: [] }),
+    };
+
+    await expect(listSkillToolsWithLiveFallback(skills, 'posthog')).resolves.toBe(liveResponse);
+
+    expect(skills.listLiveTools).toHaveBeenCalledWith('posthog');
+    expect(skills.listTools).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to static tools when live discovery throws', async () => {
+    const error = new Error('Live discovery failed');
+    const staticResponse = {
+      tools: [{ inputSchema: { type: 'object' }, name: 'query' }],
+    };
+    const onLiveDiscoveryError = vi.fn();
+    const skills = {
+      listLiveTools: vi.fn().mockRejectedValue(error),
+      listTools: vi.fn().mockResolvedValue(staticResponse),
+    };
+
+    await expect(
+      listSkillToolsWithLiveFallback(skills, 'posthog', onLiveDiscoveryError),
+    ).resolves.toBe(staticResponse);
+
+    expect(onLiveDiscoveryError).toHaveBeenCalledWith(error);
+    expect(skills.listTools).toHaveBeenCalledWith('posthog');
+  });
+
+  it('should fall back to static tools when live discovery returns no response', async () => {
+    const staticResponse = {
+      tools: [{ inputSchema: { type: 'object' }, name: 'query' }],
+    };
+    const skills = {
+      listLiveTools: vi.fn().mockResolvedValue(undefined),
+      listTools: vi.fn().mockResolvedValue(staticResponse),
+    };
+
+    await expect(listSkillToolsWithLiveFallback(skills, 'posthog')).resolves.toBe(staticResponse);
+
+    expect(skills.listTools).toHaveBeenCalledWith('posthog');
+  });
+
+  it('should use static tools when live discovery is unavailable', async () => {
+    const staticResponse = {
+      tools: [{ inputSchema: { type: 'object' }, name: 'query' }],
+    };
+    const skills = {
+      listTools: vi.fn().mockResolvedValue(staticResponse),
+    };
+
+    await expect(listSkillToolsWithLiveFallback(skills, 'posthog')).resolves.toBe(staticResponse);
+
+    expect(skills.listTools).toHaveBeenCalledWith('posthog');
+  });
+});

--- a/apps/server/src/services/market/listSkillToolsWithLiveFallback.ts
+++ b/apps/server/src/services/market/listSkillToolsWithLiveFallback.ts
@@ -11,7 +11,7 @@ export const listSkillToolsWithLiveFallback = async (
   if (typeof skills.listLiveTools === 'function') {
     try {
       const response = await skills.listLiveTools(providerId);
-      if (response) return response;
+      if (Array.isArray(response?.tools) && response.tools.length > 0) return response;
     } catch (error) {
       onLiveDiscoveryError?.(error);
     }

--- a/apps/server/src/services/market/listSkillToolsWithLiveFallback.ts
+++ b/apps/server/src/services/market/listSkillToolsWithLiveFallback.ts
@@ -1,0 +1,21 @@
+export interface SkillToolsClient {
+  listLiveTools?: (providerId: string) => Promise<any>;
+  listTools: (providerId: string) => Promise<any>;
+}
+
+export const listSkillToolsWithLiveFallback = async (
+  skills: SkillToolsClient,
+  providerId: string,
+  onLiveDiscoveryError?: (error: unknown) => void,
+) => {
+  if (typeof skills.listLiveTools === 'function') {
+    try {
+      const response = await skills.listLiveTools(providerId);
+      if (response) return response;
+    } catch (error) {
+      onLiveDiscoveryError?.(error);
+    }
+  }
+
+  return skills.listTools(providerId);
+};

--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -1215,6 +1215,8 @@
   "tools.lobehubSkill.providers.microsoft.readme": "Integrate with Outlook Calendar to view, create, and manage your events seamlessly. Schedule meetings, check availability, set reminders, and coordinate your time—all through natural language commands.",
   "tools.lobehubSkill.providers.notion.description": "Notion is a collaborative productivity and note-taking application.",
   "tools.lobehubSkill.providers.notion.readme": "Connect to Notion to access and manage your workspace. Create pages, search content, update databases, and organize your knowledge base—all through natural conversation with your AI assistant.",
+  "tools.lobehubSkill.providers.posthog.description": "PostHog is an open-source product analytics platform for analyzing events, funnels, cohorts, feature flags, experiments, and user behavior.",
+  "tools.lobehubSkill.providers.posthog.readme": "Connect to PostHog to query product analytics, inspect dashboards, review feature flags and experiments, and understand user behavior through natural conversation with your AI assistant.",
   "tools.lobehubSkill.providers.twitter.description": "X (Twitter) is a social media platform for sharing real-time updates, news, and engaging with your audience through posts, replies, and direct messages.",
   "tools.lobehubSkill.providers.twitter.readme": "Connect to X (Twitter) to post tweets, manage your timeline, and engage with your audience. Create content, schedule posts, monitor mentions, and build your social media presence through conversational AI.",
   "tools.lobehubSkill.providers.vercel.description": "Vercel is a cloud platform for frontend developers, providing hosting and serverless functions to deploy web applications with ease.",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -1215,6 +1215,8 @@
   "tools.lobehubSkill.providers.microsoft.readme": "集成 Outlook 日历以无缝查看、创建和管理事件。安排会议、查看可用时间、设置提醒，并通过自然语言指令协调时间。",
   "tools.lobehubSkill.providers.notion.description": "Notion 是一款协作型效率与笔记应用。",
   "tools.lobehubSkill.providers.notion.readme": "连接 Notion 以访问和管理您的工作区。创建页面、搜索内容、更新数据库，并通过与 AI 助手的自然对话组织知识库。",
+  "tools.lobehubSkill.providers.posthog.description": "PostHog 是一个开源产品分析平台，可用于分析事件、漏斗、用户群组、功能开关、实验和用户行为。",
+  "tools.lobehubSkill.providers.posthog.readme": "连接 PostHog 以查询产品分析、查看仪表盘、审查功能开关和实验，并通过与 AI 助手的自然对话理解用户行为。",
   "tools.lobehubSkill.providers.twitter.description": "X（原 Twitter）是一个社交媒体平台，用于分享实时动态、新闻，并通过推文、回复和私信与受众互动。",
   "tools.lobehubSkill.providers.twitter.readme": "连接 X（原 Twitter）以发布推文、管理时间线并与受众互动。创建内容、安排发布、监控提及，并通过对话式 AI 构建社交媒体影响力。",
   "tools.lobehubSkill.providers.vercel.description": "Vercel 是一个面向前端开发者的云平台，提供托管服务和无服务器函数，可轻松部署 Web 应用。",

--- a/packages/const/src/lobehubSkill.ts
+++ b/packages/const/src/lobehubSkill.ts
@@ -1,5 +1,5 @@
 import type { IconType } from '@icons-pack/react-simple-icons';
-import { SiGithub, SiLinear, SiVercel, SiX } from '@icons-pack/react-simple-icons';
+import { SiGithub, SiLinear, SiPosthog, SiVercel, SiX } from '@icons-pack/react-simple-icons';
 
 export interface LobehubSkillProviderType {
   /**
@@ -93,6 +93,18 @@ export const LOBEHUB_SKILL_PROVIDERS: LobehubSkillProviderType[] = [
     readme:
       'Connect to Notion to access and manage your workspace. Create pages, search content, update databases, and organize your knowledge base—all through natural conversation with your AI assistant.',
     label: 'Notion',
+  },
+  {
+    author: 'LobeHub',
+    authorUrl: 'https://lobehub.com',
+    defaultVisible: true,
+    description:
+      'PostHog is an open-source product analytics platform for analyzing events, funnels, cohorts, feature flags, experiments, and user behavior.',
+    icon: SiPosthog,
+    id: 'posthog',
+    label: 'PostHog',
+    readme:
+      'Connect to PostHog to query product analytics, inspect dashboards, review feature flags and experiments, and understand user behavior through natural conversation with your AI assistant.',
   },
   {
     author: 'LobeHub',

--- a/packages/const/src/recommendedSkill.ts
+++ b/packages/const/src/recommendedSkill.ts
@@ -19,6 +19,7 @@ export const RECOMMENDED_SKILLS: RecommendedSkillItem[] = [
   { id: 'lobe-message', type: RecommendedSkillType.Builtin },
   // LobeHub skills
   { id: 'notion', type: RecommendedSkillType.Lobehub },
+  { id: 'posthog', type: RecommendedSkillType.Lobehub },
   { id: 'twitter', type: RecommendedSkillType.Lobehub },
   // Composio skills
   { id: 'gmail', type: RecommendedSkillType.Composio },

--- a/packages/const/src/taskTemplate.test.ts
+++ b/packages/const/src/taskTemplate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { RECOMMENDED_SKILLS, RecommendedSkillType } from './recommendedSkill';
 import {
   TASK_TEMPLATE_ICONS,
   TASK_TEMPLATE_RECOMMEND_COUNT,
@@ -17,5 +18,12 @@ describe('taskTemplate constants', () => {
 
   it('keeps icon identifiers stable for renderers', () => {
     expect(TASK_TEMPLATE_ICONS).toEqual(['github']);
+  });
+
+  it('keeps PostHog visible in recommended LobeHub skills', () => {
+    expect(RECOMMENDED_SKILLS).toContainEqual({
+      id: 'posthog',
+      type: RecommendedSkillType.Lobehub,
+    });
   });
 });

--- a/packages/locales/src/default/setting.ts
+++ b/packages/locales/src/default/setting.ts
@@ -2481,6 +2481,10 @@ When I am ___, I need ___
     'Notion is a collaborative productivity and note-taking application.',
   'tools.lobehubSkill.providers.notion.readme':
     'Connect to Notion to access and manage your workspace. Create pages, search content, update databases, and organize your knowledge base—all through natural conversation with your AI assistant.',
+  'tools.lobehubSkill.providers.posthog.description':
+    'PostHog is an open-source product analytics platform for analyzing events, funnels, cohorts, feature flags, experiments, and user behavior.',
+  'tools.lobehubSkill.providers.posthog.readme':
+    'Connect to PostHog to query product analytics, inspect dashboards, review feature flags and experiments, and understand user behavior through natural conversation with your AI assistant.',
   'tools.lobehubSkill.providers.twitter.description':
     'X (Twitter) is a social media platform for sharing real-time updates, news, and engaging with your audience through posts, replies, and direct messages.',
   'tools.lobehubSkill.providers.twitter.readme':

--- a/src/features/RecommendTaskTemplates/providerMeta.test.ts
+++ b/src/features/RecommendTaskTemplates/providerMeta.test.ts
@@ -16,6 +16,12 @@ describe('getProviderMeta', () => {
     expect(meta?.icon).toBeDefined();
   });
 
+  it('resolves posthog as a lobehub source provider', () => {
+    const meta = getProviderMeta({ identifier: 'posthog', source: 'lobehub' });
+    expect(meta).toMatchObject({ identifier: 'posthog', label: 'PostHog', source: 'lobehub' });
+    expect(meta?.icon).toBeDefined();
+  });
+
   it('resolves composio source via COMPOSIO_APP_TYPES', () => {
     const meta = getProviderMeta({ identifier: 'gmail', source: 'composio' });
     expect(meta).toMatchObject({ identifier: 'gmail', label: 'Gmail', source: 'composio' });

--- a/src/store/tool/slices/lobehubSkillStore/action.test.ts
+++ b/src/store/tool/slices/lobehubSkillStore/action.test.ts
@@ -75,6 +75,41 @@ describe('lobehubSkillStore actions', () => {
       });
     });
 
+    it('should return failure when the tool response is unsuccessful', async () => {
+      const { result } = renderHook(() => useToolStore());
+
+      act(() => {
+        useToolStore.setState({
+          lobehubSkillExecutingToolIds: new Set(),
+          lobehubSkillLoadingIds: new Set(),
+          lobehubSkillServers: [],
+        });
+      });
+
+      vi.mocked(toolsClient.market.connectCallTool.mutate).mockResolvedValue({
+        data: null,
+        error: { code: 'POSTHOG_QUERY_FAILED', message: 'Query failed' },
+        success: false,
+      } as any);
+
+      let callResult;
+      await act(async () => {
+        callResult = await result.current.callLobehubSkillTool({
+          args: { query: 'select * from events' },
+          provider: 'posthog',
+          toolName: 'query',
+        });
+      });
+
+      expect(callResult).toEqual({
+        data: null,
+        error: 'Query failed',
+        errorCode: 'POSTHOG_QUERY_FAILED',
+        success: false,
+      });
+      expect(result.current.lobehubSkillExecutingToolIds.has('posthog:query')).toBe(false);
+    });
+
     it('should track executing state during tool call', async () => {
       const { result } = renderHook(() => useToolStore());
 

--- a/src/store/tool/slices/lobehubSkillStore/action.test.ts
+++ b/src/store/tool/slices/lobehubSkillStore/action.test.ts
@@ -1,5 +1,7 @@
 import type * as LobechatConstModule from '@lobechat/const';
 import { act, renderHook, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import { SWRConfig } from 'swr';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { toolsClient } from '@/libs/trpc/client';
@@ -38,6 +40,14 @@ vi.mock('@/libs/trpc/client', () => ({
     },
   },
 }));
+
+const createSWRWrapper = () => {
+  const value = { dedupingInterval: 0, provider: () => new Map() };
+
+  return function SWRTestWrapper({ children }: { children: ReactNode }) {
+    return createElement(SWRConfig, { value }, children);
+  };
+};
 
 describe('lobehubSkillStore actions', () => {
   describe('callLobehubSkillTool', () => {
@@ -108,6 +118,73 @@ describe('lobehubSkillStore actions', () => {
         success: false,
       });
       expect(result.current.lobehubSkillExecutingToolIds.has('posthog:query')).toBe(false);
+    });
+
+    it('should use string response data as the failure message when no structured error is provided', async () => {
+      const { result } = renderHook(() => useToolStore());
+
+      act(() => {
+        useToolStore.setState({
+          lobehubSkillExecutingToolIds: new Set(),
+          lobehubSkillLoadingIds: new Set(),
+          lobehubSkillServers: [],
+        });
+      });
+
+      vi.mocked(toolsClient.market.connectCallTool.mutate).mockResolvedValue({
+        data: 'PostHog query timed out',
+        success: false,
+      } as any);
+
+      let callResult;
+      await act(async () => {
+        callResult = await result.current.callLobehubSkillTool({
+          args: { query: 'select * from events' },
+          provider: 'posthog',
+          toolName: 'query',
+        });
+      });
+
+      expect(callResult).toEqual({
+        data: 'PostHog query timed out',
+        error: 'PostHog query timed out',
+        errorCode: undefined,
+        success: false,
+      });
+      expect(result.current.lobehubSkillExecutingToolIds.has('posthog:query')).toBe(false);
+    });
+
+    it('should use a generic failure message when an unsuccessful response has no detail', async () => {
+      const { result } = renderHook(() => useToolStore());
+
+      act(() => {
+        useToolStore.setState({
+          lobehubSkillExecutingToolIds: new Set(),
+          lobehubSkillLoadingIds: new Set(),
+          lobehubSkillServers: [],
+        });
+      });
+
+      vi.mocked(toolsClient.market.connectCallTool.mutate).mockResolvedValue({
+        data: null,
+        success: false,
+      } as any);
+
+      let callResult;
+      await act(async () => {
+        callResult = await result.current.callLobehubSkillTool({
+          args: {},
+          provider: 'posthog',
+          toolName: 'query',
+        });
+      });
+
+      expect(callResult).toEqual({
+        data: null,
+        error: 'LobeHub Skill call failed',
+        errorCode: undefined,
+        success: false,
+      });
     });
 
     it('should track executing state during tool call', async () => {
@@ -866,6 +943,56 @@ describe('lobehubSkillStore actions', () => {
       await waitFor(() => {
         expect(toolsClient.market.connectListConnections.query).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('useFetchProviderTools', () => {
+    it('should fetch and normalize provider tools', async () => {
+      vi.mocked(toolsClient.market.connectListTools.query).mockResolvedValue({
+        provider: 'posthog',
+        tools: [
+          {
+            description: 'Run a PostHog query',
+            inputSchema: { properties: { query: { type: 'string' } }, type: 'object' },
+            name: 'query',
+          },
+        ],
+      } as any);
+
+      const { result } = renderHook(
+        () => useToolStore.getState().useFetchProviderTools('posthog'),
+        { wrapper: createSWRWrapper() },
+      );
+
+      await waitFor(() => {
+        expect(toolsClient.market.connectListTools.query).toHaveBeenCalledWith({
+          provider: 'posthog',
+        });
+      });
+
+      const normalized = await result.current.mutate();
+
+      expect(normalized).toEqual([
+        {
+          description: 'Run a PostHog query',
+          inputSchema: { properties: { query: { type: 'string' } }, type: 'object' },
+          name: 'query',
+        },
+      ]);
+    });
+
+    it('should not fetch tools when provider is undefined', () => {
+      vi.mocked(toolsClient.market.connectListTools.query).mockClear();
+
+      const { result } = renderHook(
+        () => useToolStore.getState().useFetchProviderTools(undefined),
+        {
+          wrapper: createSWRWrapper(),
+        },
+      );
+
+      expect(result.current.data).toEqual([]);
+      expect(toolsClient.market.connectListTools.query).not.toHaveBeenCalled();
     });
   });
 

--- a/src/store/tool/slices/lobehubSkillStore/action.test.ts
+++ b/src/store/tool/slices/lobehubSkillStore/action.test.ts
@@ -154,6 +154,39 @@ describe('lobehubSkillStore actions', () => {
       expect(result.current.lobehubSkillExecutingToolIds.has('posthog:query')).toBe(false);
     });
 
+    it('should stringify response data objects as the failure message', async () => {
+      const { result } = renderHook(() => useToolStore());
+
+      act(() => {
+        useToolStore.setState({
+          lobehubSkillExecutingToolIds: new Set(),
+          lobehubSkillLoadingIds: new Set(),
+          lobehubSkillServers: [],
+        });
+      });
+
+      vi.mocked(toolsClient.market.connectCallTool.mutate).mockResolvedValue({
+        data: { detail: 'PostHog query timed out', status: 504 },
+        success: false,
+      } as any);
+
+      let callResult;
+      await act(async () => {
+        callResult = await result.current.callLobehubSkillTool({
+          args: { query: 'select * from events' },
+          provider: 'posthog',
+          toolName: 'query',
+        });
+      });
+
+      expect(callResult).toEqual({
+        data: { detail: 'PostHog query timed out', status: 504 },
+        error: JSON.stringify({ detail: 'PostHog query timed out', status: 504 }),
+        errorCode: undefined,
+        success: false,
+      });
+    });
+
     it('should use a generic failure message when an unsuccessful response has no detail', async () => {
       const { result } = renderHook(() => useToolStore());
 

--- a/src/store/tool/slices/lobehubSkillStore/action.ts
+++ b/src/store/tool/slices/lobehubSkillStore/action.ts
@@ -68,6 +68,19 @@ export class LobehubSkillStoreActionImpl {
         n('callLobehubSkillTool/success'),
       );
 
+      if (response.success === false) {
+        const responseError = (response as any).error;
+
+        return {
+          data: response.data,
+          error:
+            responseError?.message ||
+            (typeof response.data === 'string' ? response.data : 'LobeHub Skill call failed'),
+          errorCode: responseError?.code,
+          success: false,
+        };
+      }
+
       return { data: response.data, success: true };
     } catch (error) {
       console.error('[LobehubSkill] Failed to call tool:', error);

--- a/src/store/tool/slices/lobehubSkillStore/action.ts
+++ b/src/store/tool/slices/lobehubSkillStore/action.ts
@@ -70,12 +70,17 @@ export class LobehubSkillStoreActionImpl {
 
       if (response.success === false) {
         const responseError = (response as any).error;
+        let dataMessage: string | undefined;
+
+        if (typeof response.data === 'string') {
+          dataMessage = response.data;
+        } else if (response.data !== undefined && response.data !== null) {
+          dataMessage = JSON.stringify(response.data);
+        }
 
         return {
           data: response.data,
-          error:
-            responseError?.message ||
-            (typeof response.data === 'string' ? response.data : 'LobeHub Skill call failed'),
+          error: responseError?.message || dataMessage || 'LobeHub Skill call failed',
           errorCode: responseError?.code,
           success: false,
         };


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Adds PostHog as a built-in LobeHub Skill provider in the main app.

- Registers PostHog in the LobeHub Skill provider constants with the `SiPosthog` icon, copy, and default visibility.
- Adds PostHog to the recommended LobeHub Skill list and mirrors the provider copy into `en-US` and `zh-CN` settings locales.
- Uses Market live tool discovery when available, with a static tool fallback for compatibility.
- Preserves failed LobeHub Skill call responses so the client can surface provider/MCP errors instead of treating every response as a success.
- Adds tests for provider metadata, recommendation visibility, live discovery fallback, and failed call handling.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx prettier --write apps/server/src/routers/tools/market.ts apps/server/src/services/market/index.test.ts apps/server/src/services/market/index.ts locales/en-US/setting.json locales/zh-CN/setting.json packages/const/src/lobehubSkill.ts packages/const/src/recommendedSkill.ts packages/const/src/taskTemplate.test.ts packages/locales/src/default/setting.ts src/features/RecommendTaskTemplates/providerMeta.test.ts src/store/tool/slices/lobehubSkillStore/action.test.ts src/store/tool/slices/lobehubSkillStore/action.ts
bunx eslint --fix apps/server/src/routers/tools/market.ts apps/server/src/services/market/index.test.ts apps/server/src/services/market/index.ts packages/const/src/lobehubSkill.ts packages/const/src/recommendedSkill.ts packages/const/src/taskTemplate.test.ts packages/locales/src/default/setting.ts src/features/RecommendTaskTemplates/providerMeta.test.ts src/store/tool/slices/lobehubSkillStore/action.test.ts src/store/tool/slices/lobehubSkillStore/action.ts
bunx vitest run --silent='passed-only' apps/server/src/services/market/index.test.ts src/store/tool/slices/lobehubSkillStore/action.test.ts src/features/RecommendTaskTemplates/providerMeta.test.ts
bunx vitest run --config packages/const/vitest.config.mts --silent='passed-only' packages/const/src/taskTemplate.test.ts
git diff --check
bun run type-check
```

#### 📸 Screenshots / Videos

N/A. UI is metadata-driven; PostHog uses the bundled `SiPosthog` icon.

#### 📝 Additional Information

This PR expects the Market-side PostHog provider/scopes work to be deployed so full OAuth and live MCP tool discovery can complete end to end.