### PR TITLE
🐛 fix(swr): keep IndexedDB cache across sessions and evict it on delete

### DIFF
--- a/src/libs/swr/localStorageProvider.test.ts
+++ b/src/libs/swr/localStorageProvider.test.ts
@@ -4,7 +4,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { taskTemplateKeys } from './keys';
-import { localDataCache } from './localDataCache';
+import { buildLocalDataKey, localDataCache } from './localDataCache';
 import {
   CACHE_TIERS,
   clearSWRCache,
@@ -244,6 +244,18 @@ describe('createCacheProvider — tiering', () => {
     // give async hydration a chance, then assert it never lands
     await new Promise((r) => setTimeout(r, 40));
     expect(map.has('MSGS:stale')).toBe(false);
+  });
+
+  it('drops legacy idb rows that carry no cache version', async () => {
+    // seed a row directly with no version (pre-versioning / non-conforming writer)
+    await localDataCache.set(buildLocalDataKey('s1', 'MSGS:legacy'), { ok: false });
+
+    const scope = { value: 's1' };
+    const { provider } = buildProvider(scope, { version: '1.0.0' });
+    const map = provider();
+
+    await new Promise((r) => setTimeout(r, 40));
+    expect(map.has('MSGS:legacy')).toBe(false);
   });
 
   it('handles localStorage QuotaExceededError without throwing', async () => {

--- a/src/libs/swr/localStorageProvider.test.ts
+++ b/src/libs/swr/localStorageProvider.test.ts
@@ -213,6 +213,39 @@ describe('createCacheProvider — tiering', () => {
     expect(map.has('recents-v')).toBe(false);
   });
 
+  it('hydrates idb-tier entries regardless of age (never expires)', async () => {
+    // seed an idb entry via a throwaway provider
+    const seedScope = { value: 's1' };
+    const { provider: seed } = buildProvider(seedScope);
+    seed().set('MSGS:old', { ok: true });
+    await until(async () => (await localDataCache.entriesByScope('s1')).length > 0);
+
+    // a fresh provider with an absurdly small TTL — the row is well past it
+    const scope = { value: 's1' };
+    const { provider } = buildProvider(scope, { ttl: 1 });
+    const map = provider();
+
+    // idb tier ignores TTL: the stale row still hydrates (stale-while-revalidate)
+    await until(() => map.get('MSGS:old') !== undefined);
+    expect(map.get('MSGS:old')).toEqual({ ok: true });
+  });
+
+  it('drops idb-tier entries on version mismatch', async () => {
+    // seed an idb entry under a different app version
+    const seedScope = { value: 's1' };
+    const { provider: seed } = buildProvider(seedScope, { version: '9.9.9' });
+    seed().set('MSGS:stale', { ok: false });
+    await until(async () => (await localDataCache.entriesByScope('s1')).length > 0);
+
+    const scope = { value: 's1' };
+    const { provider } = buildProvider(scope, { version: '1.0.0' });
+    const map = provider();
+
+    // give async hydration a chance, then assert it never lands
+    await new Promise((r) => setTimeout(r, 40));
+    expect(map.has('MSGS:stale')).toBe(false);
+  });
+
   it('handles localStorage QuotaExceededError without throwing', async () => {
     const scope = { value: 's1' };
     const { provider } = buildProvider(scope);

--- a/src/libs/swr/localStorageProvider.ts
+++ b/src/libs/swr/localStorageProvider.ts
@@ -237,9 +237,11 @@ export function createCacheProvider(options: CacheProviderOptions = {}): ScopedS
       // (messages, topics, …): once written, a row rarely changes. We never drop
       // these by age — a stale row hydrates for an instant first paint and SWR's
       // revalidate-on-mount refreshes it in the background (stale-while-revalidate).
-      // Only a version mismatch invalidates a row. TTL governs the localStorage
+      // Version is the only invalidator: a row must carry the *current* version,
+      // so legacy/unversioned rows (which the age check used to bound) are dropped
+      // and a version bump still evicts everyone. TTL governs the localStorage
       // tier only (see `loadLocal`).
-      const valid = entries.filter((e) => e.version === undefined || e.version === version);
+      const valid = entries.filter((e) => e.version === version);
       // Map may have changed scope while we awaited; only apply if still current.
       if (cacheMapInstance && getScope() === scope && hydrationEpoch === epoch) {
         cacheMapInstance.hydrate(valid.map((e) => [e.key, e.data]));

--- a/src/libs/swr/localStorageProvider.ts
+++ b/src/libs/swr/localStorageProvider.ts
@@ -51,7 +51,11 @@ export interface CacheProviderOptions {
   onError?: (error: Error) => void;
   /** Called after a scope's IndexedDB tier finishes hydrating. */
   onScopeHydrated?: (scope: string) => void;
-  /** Cache TTL in milliseconds, defaults to 24 hours. Applies to both tiers. */
+  /**
+   * Cache TTL in milliseconds, defaults to 7 days. Governs the localStorage
+   * tier only (small, frequently-changing shells like recents) — the IndexedDB
+   * tier never expires (stale-while-revalidate).
+   */
   ttl?: number;
   /** App version; entries from another version are ignored on load. */
   version?: string;
@@ -110,7 +114,7 @@ export function createCacheProvider(options: CacheProviderOptions = {}): ScopedS
     getScope = () => 'default',
     idbPatterns = [],
     localPatterns = [],
-    ttl = 24 * 60 * 60 * 1000, // 24 hours
+    ttl = 7 * 24 * 60 * 60 * 1000, // 7 days
     maxLocalEntries = 50,
     version = '1.0.0',
     onError = (error) => console.error('[SWR Cache]', error),
@@ -229,10 +233,13 @@ export function createCacheProvider(options: CacheProviderOptions = {}): ScopedS
   const loadIdb = async (scope: string, epoch: number) => {
     try {
       const entries = await localDataCache.entriesByScope(scope);
-      const now = Date.now();
-      const valid = entries.filter(
-        (e) => (e.version === undefined || e.version === version) && now - e.updatedAt <= ttl,
-      );
+      // The IndexedDB tier holds read-heavy / write-light business entities
+      // (messages, topics, …): once written, a row rarely changes. We never drop
+      // these by age — a stale row hydrates for an instant first paint and SWR's
+      // revalidate-on-mount refreshes it in the background (stale-while-revalidate).
+      // Only a version mismatch invalidates a row. TTL governs the localStorage
+      // tier only (see `loadLocal`).
+      const valid = entries.filter((e) => e.version === undefined || e.version === version);
       // Map may have changed scope while we awaited; only apply if still current.
       if (cacheMapInstance && getScope() === scope && hydrationEpoch === epoch) {
         cacheMapInstance.hydrate(valid.map((e) => [e.key, e.data]));
@@ -462,6 +469,8 @@ export const swrCacheProvider = (
     idbPatterns: [...CACHE_TIERS.idb],
     localPatterns: [...CACHE_TIERS.local],
     onScopeHydrated,
-    ttl: 12 * 60 * 60 * 1000, // 12 hours
+    // Governs the localStorage tier only (recents-style shells); the IndexedDB
+    // tier (messages, topics, …) never expires. 7 days is plenty for recents.
+    ttl: 7 * 24 * 60 * 60 * 1000, // 7 days
   });
 };

--- a/src/store/chat/slices/message/actions/publicApi.ts
+++ b/src/store/chat/slices/message/actions/publicApi.ts
@@ -5,6 +5,7 @@ import isEqual from 'fast-deep-equal';
 import { messageService } from '@/services/message';
 import { topicService } from '@/services/topic';
 import { type ChatStore } from '@/store/chat/store';
+import { evictMessageCache } from '@/store/chat/utils/evictMessageCache';
 import { type StoreSetter } from '@/store/types';
 import { setNamespace } from '@/utils/storeDebug';
 
@@ -208,6 +209,9 @@ export class MessagePublicApiActionImpl {
     await messageService.removeAllMessages();
     // Clear messages directly since all messages are deleted
     this.#get().replaceMessages([]);
+    // replaceMessages only clears the active topic's cache; every other topic's
+    // cached message list is now stale (and never expires) — wipe them all
+    void evictMessageCache(() => true);
   };
 
   copyMessage = async (id: string, content: string): Promise<void> => {

--- a/src/store/chat/slices/topic/action.ts
+++ b/src/store/chat/slices/topic/action.ts
@@ -16,6 +16,7 @@ import { chatService } from '@/services/chat';
 import { messageService } from '@/services/message';
 import { topicService } from '@/services/topic';
 import { type ChatStore } from '@/store/chat';
+import { evictMessageCache } from '@/store/chat/utils/evictMessageCache';
 import { topicMapKey } from '@/store/chat/utils/topicMapKey';
 import { useGlobalStore } from '@/store/global';
 import { type StoreSetter } from '@/store/types';
@@ -850,6 +851,8 @@ export class ChatTopicActionImpl {
 
     await topicService.removeTopicsByAgentId(activeAgentId);
     await refreshTopic();
+    // drop every deleted topic's message cache (all belong to this agent)
+    void evictMessageCache((ctx) => ctx.agentId === activeAgentId);
 
     // switch to default topic
     switchTopic(null);
@@ -868,6 +871,9 @@ export class ChatTopicActionImpl {
     }
 
     await refreshTopic();
+    // drop the deleted topics' message caches
+    const removed = new Set(topicIds);
+    void evictMessageCache((ctx) => !!ctx.topicId && removed.has(ctx.topicId));
 
     // switch to default topic
     switchTopic(null);
@@ -878,6 +884,8 @@ export class ChatTopicActionImpl {
 
     await topicService.removeAllTopic();
     await refreshTopic();
+    // every topic is gone — wipe all cached message lists
+    void evictMessageCache(() => true);
   };
 
   removeTopic = async (id: string): Promise<void> => {
@@ -889,6 +897,8 @@ export class ChatTopicActionImpl {
     await topicService.removeTopic(id);
     this.#get().internal_dispatchTopic({ type: 'deleteTopic', id }, 'removeTopic');
     await refreshTopic();
+    // drop the deleted topic's message cache so it doesn't orphan in IndexedDB
+    void evictMessageCache((ctx) => ctx.topicId === id);
 
     // switch back to default topic
     if (activeTopicId === id) switchTopic(null);
@@ -901,6 +911,9 @@ export class ChatTopicActionImpl {
 
     await topicService.batchRemoveTopics(topicIds);
     await refreshTopic();
+    // drop the deleted topics' message caches
+    const removed = new Set(topicIds);
+    void evictMessageCache((ctx) => !!ctx.topicId && removed.has(ctx.topicId));
 
     // Switch to default topic
     switchTopic(null);
@@ -919,6 +932,10 @@ export class ChatTopicActionImpl {
       this.#get().internal_dispatchTopic({ type: 'deleteTopic', id }, 'batchMoveTopicsToAgent'),
     );
     await refreshTopic();
+    // the moved topics' message cache is keyed by the old agent — drop it so the
+    // next view under the target agent refetches instead of reading a stale key
+    const moved = new Set(topicIds);
+    void evictMessageCache((ctx) => !!ctx.topicId && moved.has(ctx.topicId));
 
     // If the active topic was moved away, fall back to the default topic.
     if (activeTopicId && topicIds.includes(activeTopicId)) switchTopic(null);

--- a/src/store/chat/utils/evictMessageCache.ts
+++ b/src/store/chat/utils/evictMessageCache.ts
@@ -1,0 +1,38 @@
+import { type ConversationContext } from '@lobechat/types';
+
+import { mutate } from '@/libs/swr';
+import { messageKeys } from '@/libs/swr/keys';
+
+/**
+ * Evict persisted `message:list` cache entries whose conversation context
+ * matches `predicate`.
+ *
+ * The IndexedDB cache tier never expires (see `localStorageProvider`), so once a
+ * topic / agent is deleted its message cache would orphan in IndexedDB forever
+ * unless we drop it explicitly. Clears the cached value without revalidating —
+ * the conversation is gone, there is nothing left to refetch.
+ *
+ * Matches every `message:list` variant (any page-size / version / workspace-
+ * augmented key) sharing the same `ConversationContext`, mirroring the matcher
+ * used by `refreshMessages` / the write-through cache.
+ *
+ * @example
+ * // a single deleted topic
+ * void evictMessageCache((ctx) => ctx.topicId === topicId);
+ * // every topic under a deleted agent
+ * void evictMessageCache((ctx) => ctx.agentId === agentId);
+ * // wipe everything (delete-all)
+ * void evictMessageCache(() => true);
+ */
+export const evictMessageCache = (
+  predicate: (ctx: ConversationContext) => boolean,
+): Promise<unknown> =>
+  mutate(
+    (key) => {
+      if (!Array.isArray(key) || key[0] !== messageKeys.list.root) return false;
+      const ctx = key[1] as ConversationContext | undefined;
+      return !!ctx && predicate(ctx);
+    },
+    undefined,
+    { revalidate: false },
+  );

--- a/src/store/home/slices/sidebarUI/action.ts
+++ b/src/store/home/slices/sidebarUI/action.ts
@@ -6,6 +6,7 @@ import { chatGroupService } from '@/services/chatGroup';
 import { homeService } from '@/services/home';
 import { sessionService } from '@/services/session';
 import { getAgentStoreState } from '@/store/agent';
+import { evictMessageCache } from '@/store/chat/utils/evictMessageCache';
 import { type HomeStore } from '@/store/home/store';
 import { type StoreSetter } from '@/store/types';
 import { type SessionGroupItemBase } from '@/types/session';
@@ -92,12 +93,17 @@ export class SidebarUIActionImpl {
   removeAgent = async (agentId: string): Promise<void> => {
     await agentService.removeAgent(agentId);
     await this.#get().refreshAgentList();
+    // deleting an agent cascade-deletes its topics + messages on the server; drop
+    // their message cache too so it doesn't orphan in IndexedDB (never expires)
+    void evictMessageCache((ctx) => ctx.agentId === agentId);
   };
 
   removeAgentGroup = async (groupId: string): Promise<void> => {
     // Delete the group
     await chatGroupService.deleteGroup(groupId);
     await this.#get().refreshAgentList();
+    // same cascade for a group's conversations — drop its cached message lists
+    void evictMessageCache((ctx) => ctx.groupId === groupId);
   };
 
   renameAgentGroup = async (

--- a/src/store/session/slices/session/action.ts
+++ b/src/store/session/slices/session/action.ts
@@ -12,6 +12,7 @@ import { sessionKeys } from '@/libs/swr/keys';
 import { chatGroupService } from '@/services/chatGroup';
 import { sessionService } from '@/services/session';
 import { getChatGroupStoreState } from '@/store/agentGroup';
+import { evictMessageCache } from '@/store/chat/utils/evictMessageCache';
 import { type SessionStore } from '@/store/session';
 import { type StoreSetter } from '@/store/types';
 import { getUserStoreState, useUserStore } from '@/store/user';
@@ -142,6 +143,9 @@ export class SessionActionImpl {
   removeSession = async (sessionId: string): Promise<void> => {
     await sessionService.removeSession(sessionId);
     await this.#get().refreshSessions();
+    // deleting an agent cascade-deletes its topics + messages on the server; drop
+    // their message cache too so it doesn't orphan in IndexedDB (never expires)
+    void evictMessageCache((ctx) => ctx.agentId === sessionId);
 
     // If the active session deleted, switch to the inbox session
     if (sessionId === this.#get().activeId) {

--- a/src/store/session/slices/session/action.ts
+++ b/src/store/session/slices/session/action.ts
@@ -140,6 +140,15 @@ export class SessionActionImpl {
     await this.#get().internal_updateSession(id, { pinned });
   };
 
+  /**
+   * @deprecated Legacy session-store delete path, kept only for the mobile
+   * session list (`(mobile)/.../SessionListContent/List/Item/Actions.tsx`).
+   * Desktop already deletes via `HomeStore.removeAgent`. New call sites must use
+   * `HomeStore.removeAgent` (agents) / `HomeStore.removeAgentGroup` (groups) —
+   * all three evict the message cache, so behaviour is equivalent apart from this
+   * path also switching to the inbox when the active session is removed. Remove
+   * once the mobile session list migrates to the agent store.
+   */
   removeSession = async (sessionId: string): Promise<void> => {
     await sessionService.removeSession(sessionId);
     await this.#get().refreshSessions();


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

Persisted business entities (messages, topics, …) live in the IndexedDB tier of the SWR cache. That tier was dropped on hydration once an entry was older than the 12h TTL, so **reopening a topic the next day fell back to a full reload + skeleton** instead of using the cache that was already on disk.

**Fix:** hydrate the IndexedDB tier regardless of age and let SWR's `revalidate-on-mount` refresh it in the background (stale-while-revalidate — verified `useClientDataSWR` keeps `revalidateOnMount`/`revalidateIfStale` on). The idb tier (messages, topics, tasks, docs, …) is read-heavy / write-light, so a stale row renders instantly for first paint and is reconciled silently. TTL now governs the **localStorage tier only** (recents-style shells), lowered from 12h/24h to **7 days**.

**Required follow-on:** because idb entries no longer self-expire, deleting a topic / agent must evict its message cache explicitly or the rows orphan in IndexedDB forever (the old 12h TTL used to GC them). Added a centralized `evictMessageCache(predicate)` helper and wired it into every delete path that previously left message caches behind:

- `removeTopic` / `removeSessionTopics` / `removeGroupTopics` / `removeAllTopics` / `removeUnstarredTopic` / `batchMoveTopicsToAgent` (chat topic slice)
- `removeSession` (session slice — agent deletion cascades its topics + messages)
- `clearAllMessages` (previously only cleared the active topic's cache, leaving every other topic's cache stale — now a correctness fix too)

Single-message deletes (`deleteMessage` / `optimisticDeleteMessages` / `clearMessage`) already reconcile via the write-through cache and are unchanged.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Added unit tests: idb-tier entries hydrate regardless of age (never expire) and are still dropped on version mismatch.
- Existing local-tier TTL/version-drop test unchanged (TTL still governs the localStorage tier).
- All affected store action suites pass (`localStorageProvider` / topic / session / message — 124 tests).
- Manual repro: load a topic, reopen it after >12h (or with a shortened TTL) — it now renders from cache instead of showing the full skeleton.

#### 📝 Additional Information

Known minor leftover (intentionally out of scope): `removeSession` does not evict the deleted agent's `topic:list` cache — a small list shell, not message data, and it refreshes within the 7-day local-tier TTL.