### PR TITLE
✨ feat(task): record creator conversation origin on createTask

### DIFF
--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -2674,6 +2674,8 @@ export const createRuntimeExecutors = (
                   chatToolPayload,
                   payload.parentMessageId,
                 ),
+                // Assistant message owning this tool call (≠ source user message).
+                assistantMessageId: payload.parentMessageId,
                 documentId: state.metadata?.documentId,
                 editingAgentId: state.metadata?.editingAgentId,
                 execSubAgent: ctx.execSubAgent,
@@ -3268,6 +3270,8 @@ export const createRuntimeExecutors = (
                       chatToolPayload,
                       payload.parentMessageId,
                     ),
+                    // Assistant message owning this tool call (≠ source user message).
+                    assistantMessageId: payload.parentMessageId,
                     documentId: state.metadata?.documentId,
                     execSubAgent: ctx.execSubAgent,
                     executionTimeoutMs: timeoutMs,

--- a/apps/server/src/services/task/index.ts
+++ b/apps/server/src/services/task/index.ts
@@ -1,4 +1,5 @@
 import type {
+  TaskContext,
   TaskDetailActivity,
   TaskDetailActivityAuthor,
   TaskDetailData,
@@ -34,6 +35,9 @@ export interface CreateTaskInput {
   assigneeAgentId?: string;
   assigneeUserId?: string;
   automationMode?: 'heartbeat' | 'schedule';
+  // Runtime-state pockets stored on the task row (tasks.context JSONB). Used at
+  // creation to record `context.origin` — the creator conversation pointer.
+  context?: TaskContext;
   createdByAgentId?: string;
   description?: string;
   editorData?: unknown;

--- a/apps/server/src/services/toolExecution/serverRuntimes/task.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/task.ts
@@ -41,15 +41,25 @@ const resolveWorkspaceId = async (
 export interface TaskRuntimeDeps {
   agentId?: string;
   agentModel: AgentModel;
+  // Assistant message that carried the createTask tool call — the tool-call
+  // anchor, NOT the source user message. Recorded as `context.origin.messageId`.
+  assistantMessageId?: string;
+  // Pointers to the conversation that invoked the createTask tool. Recorded into
+  // `tasks.context.origin` so the task's handoff result can later be delivered
+  // back to this session (LOBE-10625). All optional — a task can be created
+  // outside an agent turn (e.g. via the API).
+  operationId?: string;
   scope?: string | null;
   taskCaller: ReturnType<typeof taskRouter.createCaller>;
   taskId?: string;
   taskModel: TaskModel;
   taskService: TaskService;
+  toolCallId?: string;
+  topicId?: string;
 }
 
 export const createTaskRuntime = (deps: TaskRuntimeDeps) => {
-  const { agentId, scope, taskId } = deps;
+  const { agentId, assistantMessageId, operationId, scope, taskId, toolCallId, topicId } = deps;
   // Models are read through `deps` (not destructured) so callers can swap them
   // in lazily — e.g. after async workspace resolution in the runtime factory.
   const agentModel = () => deps.agentModel;
@@ -97,8 +107,18 @@ export const createTaskRuntime = (deps: TaskRuntimeDeps) => {
     const assigneeResult = await resolveAssigneeAgent(args.assigneeAgentId);
     if (!assigneeResult.success) return { content: assigneeResult.content, success: false };
 
+    // Capture where this task was spawned from so the lifecycle can later
+    // bridge the handoff result back to the creator conversation (LOBE-10625).
+    // Only persist the pocket when we actually have a creator agent + topic;
+    // tasks created outside an agent turn (e.g. via API) have no origin.
+    const origin =
+      agentId && topicId
+        ? { agentId, messageId: assistantMessageId, operationId, toolCallId, topicId }
+        : undefined;
+
     const task = await taskService().createTask({
       assigneeAgentId: args.assigneeAgentId ?? (scope === 'task' ? undefined : agentId),
+      context: origin ? { origin } : undefined,
       createdByAgentId: agentId,
       instruction: args.instruction,
       name: args.name,
@@ -584,7 +604,8 @@ export const taskRuntime: ServerRuntimeRegistration = {
 
     const db = context.serverDB;
     const userId = context.userId;
-    const { agentId, taskId, scope } = context;
+    const { agentId, assistantMessageId, operationId, taskId, toolCallId, topicId, scope } =
+      context;
 
     // Models are wired in lazily after the workspaceId is resolved from the
     // owning task row. `createTaskRuntime` reads them through this shared
@@ -592,8 +613,12 @@ export const taskRuntime: ServerRuntimeRegistration = {
     // method without re-creating the runtime.
     const deps = {
       agentId,
+      assistantMessageId,
+      operationId,
       scope,
       taskId,
+      toolCallId,
+      topicId,
       // Initial personal-mode models cover the no-task-context case. Replaced
       // before the first call when `taskId` is set.
       agentModel: new AgentModel(db, userId),

--- a/apps/server/src/services/toolExecution/types.ts
+++ b/apps/server/src/services/toolExecution/types.ts
@@ -119,6 +119,14 @@ export interface ToolExecutionContext {
    * result; the member barrier backfills + resumes/finishes the parked supervisor.
    */
   agentMember?: ServerAgentMemberRunner;
+  /**
+   * The assistant message that carries this tool call (the runtime's
+   * `payload.parentMessageId`). Distinct from `messageId`, which is the source
+   * *user* message. Tools that need to anchor back to the exact tool-call turn
+   * (e.g. createTask recording its `context.origin`) must use this, not
+   * `messageId`.
+   */
+  assistantMessageId?: string;
   /** Current page document ID for page-scoped conversations */
   documentId?: string | null;
   /**

--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -137,7 +137,27 @@ export interface TaskSchedulerContext {
   tickMessageId?: string;
 }
 
+// Pointer back to the agent conversation that spawned this task via the
+// `createTask` tool. Captured at creation so the task lifecycle can deliver the
+// handoff result back to that session once the task completes (LOBE-10625).
+export interface TaskOriginContext {
+  // The agent that invoked the createTask tool (the task's creator session).
+  agentId?: string;
+  // The assistant message that carried the createTask tool call — the tool-call
+  // anchor, sourced from the runtime's `payload.parentMessageId` (NOT the source
+  // user message). A later bridge can backfill the tool message under this.
+  messageId?: string;
+  // The operation that was running when the task was created.
+  operationId?: string;
+  // The tool call id of the createTask invocation. Doubles as the dedupe key
+  // for the eventual result-bridge delivery.
+  toolCallId?: string;
+  // The topic the creator conversation lives in — the default delivery target.
+  topicId?: string;
+}
+
 export interface TaskContext {
+  origin?: TaskOriginContext;
   scheduler?: TaskSchedulerContext;
 }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Part of LOBE-10625 — *task 完成后把 handoff 结果回灌创建者 agent 会话（即发即忘，不挂起）*

This is **PR 1 / the foundation** (the "store origin pointer" step). The result-bridge hook + agent-signal injection lands in a follow-up PR.

#### 🔀 Description of Change

When the `createTask` tool is invoked from inside an agent conversation, we now snapshot *where it was spawned from* into the task row, so a later lifecycle hook can deliver the task's handoff result back to that creator session.

- **`packages/types`** — new `TaskOriginContext` interface (`agentId / topicId / messageId / toolCallId / operationId`), exposed as the `origin?` pocket on the existing `TaskContext` JSONB shape (alongside `scheduler?`).
- **`apps/server` task service** — `CreateTaskInput` gains an optional `context?: TaskContext`, threaded straight through to `taskModel.create` (the `context` jsonb column already exists).
- **`apps/server` task tool runtime** — `TaskRuntimeDeps` + the runtime factory now forward `messageId / operationId / toolCallId / topicId` (all already carried on `ToolExecutionContext`); `createTaskImpl` assembles `context.origin` and persists it.

**Purely additive — no behavior change yet.** The `origin` pocket is only written when both a creator `agentId` and `topicId` are present, so tasks created outside an agent turn (e.g. via the API) stay untouched. Nothing on the trunk reads `context.origin` yet.

#### 🧪 How to Test

- [x] Tested locally (`bun run type-check` passes)
- [ ] Added/updated tests
- [x] No tests needed

After this lands, a task created by an agent via the `createTask` tool will have `tasks.context.origin` populated with the creator conversation's pointers; tasks created via API/no-agent context will not.

#### 📝 Additional Information

Lands the data foundation early so newly created tasks start carrying `origin` before the bridge logic (PR 2) ships.