### PR TITLE
🐛 fix(settings): expose OAuth connector disconnect action

### DIFF
--- a/src/features/Connectors/ConnectorDetail/index.test.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ConnectorSourceType } from '@/database/schemas';
+
+import ConnectorDetail from './index';
+
+const mocks = vi.hoisted(() => ({
+  toolState: {
+    connectorTools: {
+      createTools: [],
+      deleteTools: [],
+      readTools: [],
+      updateTools: [],
+    },
+    connectors: [] as Array<{
+      id: string;
+      identifier: string;
+      metadata?: { description?: string };
+      mcpConnectionType?: string;
+      name: string;
+      sourceType: string;
+    }>,
+    deleteConnector: vi.fn(),
+    disconnectConnector: vi.fn(),
+    fetchConnectors: vi.fn(),
+    resetConnectorPermissions: vi.fn(),
+    syncBuiltinTool: vi.fn(),
+    syncConnectorTools: vi.fn(),
+    syncPluginTools: vi.fn(),
+    syncing: false,
+    uninstallBuiltinTool: vi.fn(),
+    uninstallMCPPlugin: vi.fn(),
+    updateToolPermission: vi.fn(),
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+vi.mock('antd', () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+  }: {
+    children?: ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@/store/tool', () => ({
+  useToolStore<T>(selector: (state: typeof mocks.toolState) => T): T {
+    return selector(mocks.toolState);
+  },
+}));
+
+vi.mock('@/store/tool/slices/connector', () => ({
+  connectorSelectors: {
+    connectorById:
+      (connectorId: string) =>
+      (state: typeof mocks.toolState): (typeof mocks.toolState.connectors)[number] | undefined =>
+        state.connectors.find((connector) => connector.id === connectorId),
+    connectorToolsGrouped: () => (state: typeof mocks.toolState) => state.connectorTools,
+    isSyncing: () => (state: typeof mocks.toolState) => state.syncing,
+  },
+}));
+
+vi.mock('../CustomConnectorModal', () => ({
+  default: () => <div data-testid="custom-connector-modal" />,
+}));
+
+vi.mock('./ToolPermissionGroup', () => ({
+  default: ({ label }: { label: string }) => <div data-testid="permission-group">{label}</div>,
+}));
+
+describe('ConnectorDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.toolState.connectorTools = {
+      createTools: [],
+      deleteTools: [],
+      readTools: [],
+      updateTools: [],
+    };
+    mocks.toolState.connectors = [
+      {
+        id: 'connector-1',
+        identifier: 'notion',
+        metadata: { description: 'Workspace notes' },
+        name: 'Notion',
+        sourceType: ConnectorSourceType.marketplace,
+      },
+    ];
+    mocks.toolState.syncing = false;
+  });
+
+  it('uses lifecycle actions instead of the generic marketplace uninstall action', () => {
+    render(
+      <ConnectorDetail
+        connectorId="connector-1"
+        lifecycleActions={<button>Disconnect Notion</button>}
+      />,
+    );
+
+    expect(screen.getByText('Notion')).toBeInTheDocument();
+    expect(screen.getByText('Workspace notes')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Disconnect Notion' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Uninstall' })).not.toBeInTheDocument();
+  });
+
+  it('falls back to the marketplace uninstall action when no lifecycle override is provided', () => {
+    render(<ConnectorDetail connectorId="connector-1" />);
+
+    expect(screen.getByRole('button', { name: 'Uninstall' })).toBeInTheDocument();
+  });
+});

--- a/src/features/Connectors/ConnectorDetail/index.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.tsx
@@ -1,6 +1,7 @@
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { Button } from 'antd';
 import { PencilIcon, RefreshCwIcon, Trash2 } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -14,10 +15,11 @@ import ToolPermissionGroup from './ToolPermissionGroup';
 
 interface ConnectorDetailProps {
   connectorId: string;
+  lifecycleActions?: ReactNode;
   onDelete?: () => void;
 }
 
-const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId, onDelete }) => {
+const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId, lifecycleActions, onDelete }) => {
   const { t } = useTranslation('tool');
   const [customModalOpen, setCustomModalOpen] = useState(false);
 
@@ -125,41 +127,47 @@ const ConnectorDetail = memo<ConnectorDetailProps>(({ connectorId, onDelete }) =
               {t('connector.edit', 'Edit')}
             </Button>
           )}
-          {/* Disconnect / Delete for custom MCP connectors */}
-          {isMcpConnector && (
+          {lifecycleActions !== undefined ? (
+            lifecycleActions
+          ) : (
             <>
-              <Button danger size="small" onClick={() => disconnectConnector(connectorId)}>
-                {t('connector.disconnect', 'Disconnect')}
-              </Button>
-              <Button
-                danger
-                icon={<Trash2 size={14} />}
-                size="small"
-                onClick={() => {
-                  confirmModal({
-                    okButtonProps: { danger: true },
-                    onOk: async () => {
-                      await deleteConnector(connectorId);
-                      onDelete?.();
-                    },
-                    title: t('connector.deleteConfirm', 'Delete this connector?'),
-                  });
-                }}
-              >
-                {t('connector.delete', 'Delete')}
-              </Button>
+              {/* Disconnect / Delete for custom MCP connectors */}
+              {isMcpConnector && (
+                <>
+                  <Button danger size="small" onClick={() => disconnectConnector(connectorId)}>
+                    {t('connector.disconnect', 'Disconnect')}
+                  </Button>
+                  <Button
+                    danger
+                    icon={<Trash2 size={14} />}
+                    size="small"
+                    onClick={() => {
+                      confirmModal({
+                        okButtonProps: { danger: true },
+                        onOk: async () => {
+                          await deleteConnector(connectorId);
+                          onDelete?.();
+                        },
+                        title: t('connector.deleteConfirm', 'Delete this connector?'),
+                      });
+                    }}
+                  >
+                    {t('connector.delete', 'Delete')}
+                  </Button>
+                </>
+              )}
+              {/* Uninstall for builtin and marketplace tools */}
+              {(isBuiltin || isMarketplace) && (
+                <Button
+                  danger
+                  icon={<Trash2 size={14} />}
+                  size="small"
+                  onClick={handleUninstall}
+                >
+                  {t('connector.uninstall', 'Uninstall')}
+                </Button>
+              )}
             </>
-          )}
-          {/* Uninstall for builtin and marketplace tools */}
-          {(isBuiltin || isMarketplace) && (
-            <Button
-              danger
-              icon={<Trash2 size={14} />}
-              size="small"
-              onClick={handleUninstall}
-            >
-              {t('connector.uninstall', 'Uninstall')}
-            </Button>
           )}
         </div>
       </div>

--- a/src/features/SkillStore/SkillList/LobeHub/useSkillConnect.test.ts
+++ b/src/features/SkillStore/SkillList/LobeHub/useSkillConnect.test.ts
@@ -1,0 +1,169 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ComposioServerStatus } from '@/store/tool/slices/composioStore';
+import { LobehubSkillStatus } from '@/store/tool/slices/lobehubSkillStore/types';
+
+import { useSkillConnect } from './useSkillConnect';
+
+const mocks = vi.hoisted(() => {
+  const toolState = {
+    checkLobehubSkillStatus: vi.fn(),
+    composioServers: [] as Array<{ identifier: string; status: string }>,
+    createComposioConnection: vi.fn(),
+    getLobehubSkillAuthorizeUrl: vi.fn(),
+    lobehubSkillServers: [] as Array<{
+      identifier: string;
+      isConnected: boolean;
+      name: string;
+      status: string;
+    }>,
+    refreshComposioConnectionStatus: vi.fn(),
+    removeComposioConnection: vi.fn(),
+    revokeLobehubSkill: vi.fn(),
+  };
+
+  const useToolStore = Object.assign(
+    vi.fn(<T>(selector: (state: typeof toolState) => T): T => selector(toolState)),
+    {
+      getState: vi.fn(() => toolState),
+    },
+  );
+
+  return {
+    toolState,
+    useToolStore,
+    userState: { userId: 'user-id' },
+  };
+});
+
+vi.mock('@/store/tool', () => ({
+  useToolStore: mocks.useToolStore,
+}));
+
+vi.mock('@/store/tool/selectors', () => ({
+  composioStoreSelectors: {
+    getServerByIdentifier:
+      (identifier: string) =>
+      (
+        state: typeof mocks.toolState,
+      ): (typeof mocks.toolState.composioServers)[number] | undefined =>
+        state.composioServers.find((server) => server.identifier === identifier),
+  },
+  lobehubSkillStoreSelectors: {
+    getServerByIdentifier:
+      (identifier: string) =>
+      (
+        state: typeof mocks.toolState,
+      ): (typeof mocks.toolState.lobehubSkillServers)[number] | undefined =>
+        state.lobehubSkillServers.find((server) => server.identifier === identifier),
+  },
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: <T>(selector: (state: typeof mocks.userState) => T): T => selector(mocks.userState),
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  userProfileSelectors: {
+    userId: (state: typeof mocks.userState) => state.userId,
+  },
+}));
+
+describe('useSkillConnect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.toolState.composioServers = [];
+    mocks.toolState.lobehubSkillServers = [];
+  });
+
+  it('keeps a LobeHub connector selected when revoke does not change its connected status', async () => {
+    mocks.toolState.lobehubSkillServers = [
+      {
+        identifier: 'notion',
+        isConnected: true,
+        name: 'Notion',
+        status: LobehubSkillStatus.CONNECTED,
+      },
+    ];
+    mocks.toolState.revokeLobehubSkill.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useSkillConnect({ identifier: 'notion', type: 'lobehub' }));
+
+    let disconnected = true;
+    await act(async () => {
+      disconnected = await result.current.handleDisconnect();
+    });
+
+    expect(mocks.toolState.revokeLobehubSkill).toHaveBeenCalledWith('notion');
+    expect(disconnected).toBe(false);
+  });
+
+  it('reports a LobeHub connector as disconnected after revoke updates the latest store state', async () => {
+    mocks.toolState.lobehubSkillServers = [
+      {
+        identifier: 'notion',
+        isConnected: true,
+        name: 'Notion',
+        status: LobehubSkillStatus.CONNECTED,
+      },
+    ];
+    mocks.toolState.revokeLobehubSkill.mockImplementation(async () => {
+      mocks.toolState.lobehubSkillServers[0].status = LobehubSkillStatus.NOT_CONNECTED;
+      mocks.toolState.lobehubSkillServers[0].isConnected = false;
+    });
+
+    const { result } = renderHook(() => useSkillConnect({ identifier: 'notion', type: 'lobehub' }));
+
+    let disconnected = false;
+    await act(async () => {
+      disconnected = await result.current.handleDisconnect();
+    });
+
+    expect(disconnected).toBe(true);
+  });
+
+  it('keeps a Composio connector selected when removal leaves the latest account active', async () => {
+    mocks.toolState.composioServers = [
+      {
+        identifier: 'slack',
+        status: ComposioServerStatus.ACTIVE,
+      },
+    ];
+    mocks.toolState.removeComposioConnection.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useSkillConnect({ identifier: 'slack', type: 'composio' }));
+
+    let disconnected = true;
+    await act(async () => {
+      disconnected = await result.current.handleDisconnect();
+    });
+
+    expect(mocks.toolState.removeComposioConnection).toHaveBeenCalledWith('slack');
+    expect(disconnected).toBe(false);
+  });
+
+  it('reports a Composio connector as disconnected once the active account is gone', async () => {
+    mocks.toolState.composioServers = [
+      {
+        identifier: 'slack',
+        status: ComposioServerStatus.ACTIVE,
+      },
+    ];
+    mocks.toolState.removeComposioConnection.mockImplementation(async () => {
+      mocks.toolState.composioServers = [];
+    });
+
+    const { result } = renderHook(() => useSkillConnect({ identifier: 'slack', type: 'composio' }));
+
+    let disconnected = false;
+    await act(async () => {
+      disconnected = await result.current.handleDisconnect();
+    });
+
+    expect(disconnected).toBe(true);
+  });
+});

--- a/src/features/SkillStore/SkillList/LobeHub/useSkillConnect.ts
+++ b/src/features/SkillStore/SkillList/LobeHub/useSkillConnect.ts
@@ -231,10 +231,26 @@ export const useSkillConnect = ({ identifier, serverName, type }: UseSkillConnec
 
   const handleDisconnect = useCallback(async () => {
     if (type === 'lobehub' && lobehubServer) {
-      await revokeLobehubConnect(lobehubServer.identifier);
+      const provider = lobehubServer.identifier;
+      await revokeLobehubConnect(provider);
+
+      const latestServer = useToolStore
+        .getState()
+        .lobehubSkillServers.find((server) => server.identifier === provider);
+
+      return latestServer?.status !== LobehubSkillStatus.CONNECTED;
     } else if (type === 'composio' && composioServer) {
-      await removeComposioConnection(composioServer.identifier);
+      const serverIdentifier = composioServer.identifier;
+      await removeComposioConnection(serverIdentifier);
+
+      const latestServer = useToolStore
+        .getState()
+        .composioServers.find((server) => server.identifier === serverIdentifier);
+
+      return latestServer?.status !== ComposioServerStatus.ACTIVE;
     }
+
+    return true;
   }, [type, lobehubServer, composioServer, revokeLobehubConnect, removeComposioConnection]);
 
   const isConnected =

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.test.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.test.tsx
@@ -1,0 +1,341 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LobehubSkillStatus } from '@/store/tool/slices/lobehubSkillStore/types';
+
+import SkillDetail from './index';
+
+const mocks = vi.hoisted(() => {
+  const toolState = {
+    builtinSkills: [],
+    checkLobehubSkillStatus: vi.fn(),
+    composioServers: [] as Array<{ identifier: string; status: string }>,
+    connectors: [] as Array<{ id: string; identifier: string }>,
+    createComposioConnection: vi.fn(),
+    deleteAgentSkill: vi.fn(),
+    fetchConnectors: vi.fn(),
+    getLobehubSkillAuthorizeUrl: vi.fn(),
+    installBuiltinTool: vi.fn(),
+    installedBuiltinIds: [] as string[],
+    lobehubSkillServers: [] as Array<{
+      identifier: string;
+      isConnected: boolean;
+      name: string;
+      status: string;
+      tools?: Array<{
+        description?: string;
+        inputSchema: Record<string, unknown>;
+        name: string;
+      }>;
+    }>,
+    refreshComposioConnectionStatus: vi.fn(),
+    removeComposioConnection: vi.fn(),
+    revokeLobehubSkill: vi.fn(),
+    syncBuiltinTool: vi.fn(),
+    syncPluginTools: vi.fn(),
+    syncToolsFromClient: vi.fn(),
+    uninstallBuiltinTool: vi.fn(),
+  };
+
+  function selectToolStore<T>(selector: (state: typeof toolState) => T): T {
+    return selector(toolState);
+  }
+
+  const useToolStoreWithState = Object.assign(vi.fn(selectToolStore), {
+    getState: vi.fn(() => toolState),
+  });
+
+  return {
+    confirmModal: vi.fn(),
+    permissions: {
+      create_content: true,
+      edit_own_content: true,
+    },
+    toolState,
+    useToolStore: useToolStoreWithState,
+    userState: { userId: 'user-id' },
+  };
+});
+
+vi.mock('@lobechat/const', () => ({
+  COMPOSIO_APP_TYPES: [],
+  getLobehubSkillProviderById: (identifier: string) =>
+    identifier === 'notion'
+      ? {
+          label: 'Notion',
+        }
+      : undefined,
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  Avatar: () => <div data-testid="avatar" />,
+  Markdown: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Skeleton: () => <div data-testid="skeleton" />,
+}));
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  confirmModal: mocks.confirmModal,
+}));
+
+vi.mock('antd', () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+  }: {
+    children?: ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('antd-style', () => ({
+  createStaticStyles: (
+    creator: (tokens: {
+      css: () => string;
+      cssVar: Record<string, string>;
+    }) => Record<string, string>,
+  ) =>
+    creator({
+      css: () => '',
+      cssVar: {
+        colorBorderSecondary: 'colorBorderSecondary',
+        colorText: 'colorText',
+        colorTextSecondary: 'colorTextSecondary',
+        colorTextTertiary: 'colorTextTertiary',
+      },
+    }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string; name?: string } | string) => {
+      const translations: Record<string, string> = {
+        'tools.lobehubSkill.connect': 'Connect',
+        'tools.lobehubSkill.disconnect': 'Disconnect',
+        'tools.lobehubSkill.disconnectConfirm.desc': `Disconnect ${(options as { name?: string })?.name}?`,
+        'tools.lobehubSkill.disconnectConfirm.title': `Disconnect ${(options as { name?: string })?.name}`,
+      };
+
+      if (translations[key]) return translations[key];
+      if (typeof options === 'object' && options?.defaultValue) return options.defaultValue;
+
+      return key;
+    },
+  }),
+}));
+
+vi.mock('@/features/AgentSkillDetail', () => ({
+  default: () => <div data-testid="agent-skill-detail" />,
+}));
+
+vi.mock('@/features/Connectors', () => ({
+  ConnectorDetail: ({
+    connectorId,
+    lifecycleActions,
+  }: {
+    connectorId: string;
+    lifecycleActions?: ReactNode;
+  }) => (
+    <div data-testid="connector-detail">
+      <span>{connectorId}</span>
+      {lifecycleActions}
+    </div>
+  ),
+}));
+
+vi.mock('@/hooks/usePermission', () => ({
+  usePermission: (action: 'create_content' | 'edit_own_content') => ({
+    allowed: mocks.permissions[action],
+    reason: '',
+  }),
+}));
+
+vi.mock('@/store/tool', () => ({
+  useToolStore: mocks.useToolStore,
+}));
+
+vi.mock('@/store/tool/selectors', () => ({
+  builtinToolSelectors: {
+    isBuiltinToolInstalled:
+      (identifier: string) =>
+      (state: typeof mocks.toolState): boolean =>
+        state.installedBuiltinIds.includes(identifier),
+  },
+  composioStoreSelectors: {
+    getServerByIdentifier:
+      (identifier: string) =>
+      (
+        state: typeof mocks.toolState,
+      ): (typeof mocks.toolState.composioServers)[number] | undefined =>
+        state.composioServers.find((server) => server.identifier === identifier),
+  },
+  lobehubSkillStoreSelectors: {
+    getServerByIdentifier:
+      (identifier: string) =>
+      (
+        state: typeof mocks.toolState,
+      ): (typeof mocks.toolState.lobehubSkillServers)[number] | undefined =>
+        state.lobehubSkillServers.find((server) => server.identifier === identifier),
+  },
+}));
+
+vi.mock('@/store/tool/slices/connector', () => ({
+  connectorSelectors: {
+    connectorByIdentifier:
+      (identifier: string) =>
+      (state: typeof mocks.toolState): (typeof mocks.toolState.connectors)[number] | undefined =>
+        state.connectors.find((connector) => connector.identifier === identifier),
+  },
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore<T>(selector: (state: typeof mocks.userState) => T): T {
+    return selector(mocks.userState);
+  },
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  userProfileSelectors: {
+    userId: (state: typeof mocks.userState) => state.userId,
+  },
+}));
+
+const connectedNotionServer = () => ({
+  identifier: 'notion',
+  isConnected: true,
+  name: 'Notion',
+  status: LobehubSkillStatus.CONNECTED,
+});
+
+describe('SkillDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.permissions.create_content = true;
+    mocks.permissions.edit_own_content = true;
+    mocks.toolState.composioServers = [];
+    mocks.toolState.connectors = [];
+    mocks.toolState.installedBuiltinIds = [];
+    mocks.toolState.lobehubSkillServers = [];
+  });
+
+  it('shows a disconnect action for a connected LobeHub connector without configurable tools', async () => {
+    mocks.toolState.lobehubSkillServers = [connectedNotionServer()];
+
+    render(<SkillDetail identifier="notion" type="lobehub-connector" />);
+
+    expect(
+      await screen.findByText('This skill does not expose configurable tool permissions.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Notion')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Disconnect' })).toBeEnabled();
+    expect(mocks.toolState.syncToolsFromClient).not.toHaveBeenCalled();
+  });
+
+  it('syncs LobeHub tools and passes the disconnect action into connector permissions detail', async () => {
+    mocks.toolState.connectors = [{ id: 'connector-1', identifier: 'notion' }];
+    mocks.toolState.lobehubSkillServers = [
+      {
+        ...connectedNotionServer(),
+        tools: [
+          {
+            description: 'Search pages',
+            inputSchema: { type: 'object' },
+            name: 'search',
+          },
+        ],
+      },
+    ];
+
+    render(<SkillDetail identifier="notion" type="lobehub-connector" />);
+
+    expect(await screen.findByTestId('connector-detail')).toHaveTextContent('connector-1');
+    expect(screen.getByRole('button', { name: 'Disconnect' })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.toolState.syncToolsFromClient).toHaveBeenCalledWith({
+        identifier: 'notion',
+        name: 'Notion',
+        sourceType: 'marketplace',
+        tools: [
+          {
+            description: 'Search pages',
+            inputSchema: { type: 'object' },
+            toolName: 'search',
+          },
+        ],
+      }),
+    );
+  });
+
+  it('only leaves connector permissions detail after disconnect actually succeeds', async () => {
+    const user = userEvent.setup();
+    mocks.toolState.connectors = [{ id: 'connector-1', identifier: 'notion' }];
+    mocks.toolState.lobehubSkillServers = [
+      {
+        ...connectedNotionServer(),
+        tools: [
+          {
+            inputSchema: { type: 'object' },
+            name: 'search',
+          },
+        ],
+      },
+    ];
+    mocks.confirmModal.mockImplementation(({ onOk }: { onOk?: () => Promise<void> }) => {
+      void onOk?.();
+    });
+    mocks.toolState.revokeLobehubSkill.mockResolvedValue(undefined);
+
+    render(<SkillDetail identifier="notion" type="lobehub-connector" />);
+
+    await user.click(await screen.findByRole('button', { name: 'Disconnect' }));
+
+    expect(mocks.confirmModal).toHaveBeenCalled();
+    expect(await screen.findByTestId('connector-detail')).toBeInTheDocument();
+    expect(
+      screen.queryByText('This skill does not expose configurable tool permissions.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('returns to the no-permissions state after a successful disconnect', async () => {
+    const user = userEvent.setup();
+    const server = {
+      ...connectedNotionServer(),
+      tools: [
+        {
+          inputSchema: { type: 'object' },
+          name: 'search',
+        },
+      ],
+    };
+    mocks.toolState.connectors = [{ id: 'connector-1', identifier: 'notion' }];
+    mocks.toolState.lobehubSkillServers = [server];
+    mocks.confirmModal.mockImplementation(({ onOk }: { onOk?: () => Promise<void> }) => {
+      void onOk?.();
+    });
+    mocks.toolState.revokeLobehubSkill.mockImplementation(async () => {
+      server.isConnected = false;
+      server.status = LobehubSkillStatus.NOT_CONNECTED;
+    });
+
+    render(<SkillDetail identifier="notion" type="lobehub-connector" />);
+
+    await user.click(await screen.findByRole('button', { name: 'Disconnect' }));
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('This skill does not expose configurable tool permissions.'),
+      ).toBeInTheDocument(),
+    );
+    expect(screen.getByRole('button', { name: 'Connect' })).toBeInTheDocument();
+  });
+});

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
@@ -1,15 +1,17 @@
 'use client';
 
+import { getLobehubSkillProviderById } from '@lobechat/const';
 import { Avatar, Markdown, Skeleton } from '@lobehub/ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { Button } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
-import { Plus, Trash2 } from 'lucide-react';
-import { lazy, memo, Suspense, useEffect, useState } from 'react';
+import { Plus, SquareArrowOutUpRight, Trash2, Unplug } from 'lucide-react';
+import { lazy, memo, Suspense, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { ConnectorDetail } from '@/features/Connectors';
+import { useSkillConnect } from '@/features/SkillStore/SkillList/LobeHub/useSkillConnect';
 import { usePermission } from '@/hooks/usePermission';
 import { useToolStore } from '@/store/tool';
 import { builtinToolSelectors, lobehubSkillStoreSelectors } from '@/store/tool/selectors';
@@ -52,6 +54,19 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     font-size: 14px;
     color: ${cssVar.colorTextTertiary};
   `,
+  noPermissionsHeader: css`
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    justify-content: space-between;
+
+    margin-block-end: 8px;
+  `,
+  noPermissionsTitle: css`
+    font-size: 16px;
+    font-weight: 600;
+    color: ${cssVar.colorText};
+  `,
 }));
 
 interface SkillDetailProps {
@@ -59,6 +74,72 @@ interface SkillDetailProps {
   onDelete?: () => void;
   type: ToolDetailType;
 }
+
+interface LobehubConnectorActionProps {
+  identifier: string;
+  label: string;
+  onDisconnected?: () => void;
+}
+
+const LobehubConnectorAction = memo<LobehubConnectorActionProps>(
+  ({ identifier, label, onDisconnected }) => {
+    const { t } = useTranslation('setting');
+    const { allowed: canCreate } = usePermission('create_content');
+    const { allowed: canEdit } = usePermission('edit_own_content');
+    const { handleConnect, handleDisconnect, isConnected, isConnecting } = useSkillConnect({
+      identifier,
+      type: 'lobehub',
+    });
+
+    const handleConfirmDisconnect = useCallback(() => {
+      if (!canEdit) return;
+
+      confirmModal({
+        cancelText: t('cancel', { ns: 'common' }),
+        content: t('tools.lobehubSkill.disconnectConfirm.desc', { name: label }),
+        okButtonProps: { danger: true },
+        okText: t('tools.lobehubSkill.disconnect'),
+        onOk: async () => {
+          const disconnected = await handleDisconnect();
+          if (disconnected) onDisconnected?.();
+        },
+        title: t('tools.lobehubSkill.disconnectConfirm.title', { name: label }),
+      });
+    }, [canEdit, handleDisconnect, label, onDisconnected, t]);
+
+    if (isConnected) {
+      return (
+        <Button
+          danger
+          disabled={!canEdit}
+          icon={<Unplug size={14} />}
+          loading={isConnecting}
+          size="small"
+          onClick={handleConfirmDisconnect}
+        >
+          {t('tools.lobehubSkill.disconnect')}
+        </Button>
+      );
+    }
+
+    return (
+      <Button
+        disabled={!canCreate || !canEdit}
+        icon={<SquareArrowOutUpRight size={14} />}
+        loading={isConnecting}
+        size="small"
+        onClick={() => {
+          if (!canCreate || !canEdit) return;
+          handleConnect();
+        }}
+      >
+        {t('tools.lobehubSkill.connect')}
+      </Button>
+    );
+  },
+);
+
+LobehubConnectorAction.displayName = 'LobehubConnectorAction';
 
 /**
  * Right panel for the Settings > Skill master-detail layout.
@@ -86,6 +167,12 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type, onDelete }) => {
 
   // For lobehub-connector: get the server's tool list from the store
   const lobehubServer = useToolStore(lobehubSkillStoreSelectors.getServerByIdentifier(identifier));
+  const lobehubProvider =
+    type === 'lobehub-connector' ? getLobehubSkillProviderById(identifier) : undefined;
+  const lobehubLabel =
+    type === 'lobehub-connector'
+      ? lobehubProvider?.label || lobehubServer?.name || identifier
+      : identifier;
 
   // For builtin-skill: look up from store
   const builtinSkill = useToolStore(
@@ -99,6 +186,18 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type, onDelete }) => {
     type === 'plugin' ||
     type === 'mcp-connector' ||
     type === 'lobehub-connector';
+
+  const renderLobehubConnectorAction = (onDisconnected?: () => void) => {
+    if (type !== 'lobehub-connector') return undefined;
+
+    return (
+      <LobehubConnectorAction
+        identifier={identifier}
+        label={lobehubLabel}
+        onDisconnected={onDisconnected}
+      />
+    );
+  };
 
   useEffect(() => {
     if (!isConnectorType) return;
@@ -139,8 +238,17 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type, onDelete }) => {
     };
 
     ensureConnector();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [identifier, type, isConnectorType]);
+  }, [
+    fetchConnectors,
+    identifier,
+    isConnectorType,
+    lobehubServer?.name,
+    lobehubServer?.tools,
+    syncBuiltinTool,
+    syncPluginTools,
+    syncToolsFromClient,
+    type,
+  ]);
 
   const handleUninstallBuiltin = () => {
     confirmModal({
@@ -254,13 +362,22 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type, onDelete }) => {
   if (noManifest || !connector) {
     return (
       <div className={styles.noPermissions}>
-        <div style={{ fontSize: 16, fontWeight: 600, marginBottom: 8 }}>{identifier}</div>
+        <div className={styles.noPermissionsHeader}>
+          <div className={styles.noPermissionsTitle}>{lobehubLabel}</div>
+          {renderLobehubConnectorAction()}
+        </div>
         This skill does not expose configurable tool permissions.
       </div>
     );
   }
 
-  return <ConnectorDetail connectorId={connector.id} onDelete={onDelete} />;
+  return (
+    <ConnectorDetail
+      connectorId={connector.id}
+      lifecycleActions={renderLobehubConnectorAction(() => setNoManifest(true))}
+      onDelete={onDelete}
+    />
+  );
 });
 
 SkillDetail.displayName = 'SkillDetail';


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Add a Connect / Disconnect action to the Settings > Skills OAuth connector detail panel.
- Keep the disconnect action available when an OAuth connector has no configurable tool permissions.
- Allow OAuth connector details to override the generic marketplace lifecycle action so connected LobeHub OAuth connectors show Disconnect instead of Uninstall.
- Re-sync the LobeHub connector detail when its async tool list becomes available.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validated with:

- \`bunx eslint 'src/routes/(main)/settings/skill/features/SkillDetail/index.tsx' 'src/features/Connectors/ConnectorDetail/index.tsx'\`
- \`bun run type-check\`

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No matching GitHub issue found for this focused UI defect.