### PR TITLE
🐛 fix(group): persist groupId on execAgent-created topics so group conversations stay in the group

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
@@ -6,7 +6,7 @@
  * InMemory implementations when Redis is not available (test environment).
  */
 import { type LobeChatDatabase } from '@lobechat/database';
-import { agents, messages, threads, topics } from '@lobechat/database/schemas';
+import { agents, chatGroups, messages, threads, topics } from '@lobechat/database/schemas';
 import { getTestDB } from '@lobechat/database/test-utils';
 import { and, eq } from 'drizzle-orm';
 import OpenAI from 'openai';
@@ -255,6 +255,40 @@ describe('execAgent', () => {
 
       expect(result.success).toBe(true);
       expect(result.operationId).toBeDefined();
+    });
+
+    // Regression: LOBE-10604 / LOBE-10627 — a group conversation that reaches
+    // execAgent without a pre-created topicId must still persist groupId on the
+    // new topic. Otherwise the topic is created group-less, only surfaces under
+    // the member agent's list, and never appears in the group sidebar (which
+    // queries `topics.groupId`), so the conversation "disappears" from the group.
+    it('should persist groupId on the created topic when running in a group context', async () => {
+      mockResponsesCreate.mockResolvedValue(
+        createMockResponsesAPIStream('Hello from group context') as any,
+      );
+
+      const [group] = await serverDB
+        .insert(chatGroups)
+        .values({ title: 'Regression Group', userId })
+        .returning();
+
+      const caller = aiAgentRouter.createCaller(createTestContext());
+
+      const result = await caller.execAgent({
+        agentId: testAgentId,
+        appContext: { groupId: group.id },
+        prompt: 'Hello, group via execAgent',
+      });
+
+      expect(result.success).toBe(true);
+
+      const createdTopics = await serverDB
+        .select()
+        .from(topics)
+        .where(eq(topics.agentId, testAgentId));
+
+      expect(createdTopics).toHaveLength(1);
+      expect(createdTopics[0].groupId).toBe(group.id);
     });
   });
 

--- a/apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
@@ -258,11 +258,13 @@ describe('execAgent', () => {
     });
 
     // Regression: LOBE-10604 / LOBE-10627 — a group conversation that reaches
-    // execAgent without a pre-created topicId must still persist groupId on the
-    // new topic. Otherwise the topic is created group-less, only surfaces under
-    // the member agent's list, and never appears in the group sidebar (which
-    // queries `topics.groupId`), so the conversation "disappears" from the group.
-    it('should persist groupId on the created topic when running in a group context', async () => {
+    // execAgent without a pre-created topicId must persist groupId on BOTH the
+    // new topic AND the user/assistant messages. Otherwise:
+    //   - the topic is group-less and never appears in the group sidebar
+    //     (which queries `topics.groupId`), and
+    //   - the messages are group-less, so reopening the topic returns an empty
+    //     conversation (the group read filters on `messages.groupId`).
+    it('should persist groupId on the topic and messages when running in a group context', async () => {
       mockResponsesCreate.mockResolvedValue(
         createMockResponsesAPIStream('Hello from group context') as any,
       );
@@ -274,9 +276,14 @@ describe('execAgent', () => {
 
       const caller = aiAgentRouter.createCaller(createTestContext());
 
+      // autoStart:false — we only assert topic/message *creation* carries
+      // groupId; no need to run the full agent loop (keeps the test fast and
+      // deterministic). The user message + assistant placeholder are still
+      // created before the run gate.
       const result = await caller.execAgent({
         agentId: testAgentId,
         appContext: { groupId: group.id },
+        autoStart: false,
         prompt: 'Hello, group via execAgent',
       });
 
@@ -289,6 +296,16 @@ describe('execAgent', () => {
 
       expect(createdTopics).toHaveLength(1);
       expect(createdTopics[0].groupId).toBe(group.id);
+
+      // The user + assistant turn must also carry groupId, or the group read
+      // path (messageModel.query filters messages.groupId) returns nothing.
+      const createdMessages = await serverDB
+        .select()
+        .from(messages)
+        .where(eq(messages.topicId, createdTopics[0].id));
+
+      expect(createdMessages.length).toBeGreaterThanOrEqual(2);
+      expect(createdMessages.every((m) => m.groupId === group.id)).toBe(true);
     });
   });
 

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1160,6 +1160,14 @@ export class AiAgentService {
       const fallbackTitleSource = markdownToTxt(prompt);
       const newTopic = await this.topicModel.create({
         agentId: resolvedAgentId,
+        // Persist the group association when running inside a group conversation.
+        // Without it the topic is created group-less and only shows under the
+        // member agent's topic list — never in the group sidebar (which queries
+        // `topics.groupId`), so the conversation silently "disappears" from the
+        // group. execGroupAgent normally pre-creates the topic, but any path
+        // that reaches execAgent without a topicId (e.g. the async/queue run)
+        // must carry the groupId through too. (LOBE-10604 / LOBE-10627)
+        groupId: appContext?.groupId,
         metadata,
         title:
           title !== undefined
@@ -1169,9 +1177,10 @@ export class AiAgentService {
       });
       topicId = newTopic.id;
       log(
-        'execAgent: created new topic %s with trigger %s, cronJobId %s',
+        'execAgent: created new topic %s with trigger %s, groupId %s, cronJobId %s',
         topicId,
         trigger || 'default',
+        appContext?.groupId || 'none',
         cronJobId || 'none',
       );
     } else {

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1258,6 +1258,10 @@ export class AiAgentService {
           agentId: persistAgentId,
           content: prompt,
           files: runAttachments.fileIds,
+          // Group reads filter on messages.groupId (MessageModel.query group
+          // branch), so a group turn must stamp groupId or the message never
+          // shows when the topic is reopened. (LOBE-10604 / LOBE-10627)
+          groupId: appContext?.groupId,
           metadata: requestTriggerMetadata,
           role: 'user',
           threadId: appContext?.threadId ?? undefined,
@@ -1276,6 +1280,9 @@ export class AiAgentService {
     const assistantMessageRecord = await this.messageModel.create({
       agentId: persistAgentId,
       content: LOADING_FLAT,
+      // Stamp groupId so the assistant turn is visible in the group read path
+      // (MessageModel.query filters group chats by messages.groupId).
+      groupId: appContext?.groupId,
       model: isHeteroAgent ? undefined : model,
       parentId: parentMessageId ?? userMessageRecord?.id,
       provider: isHeteroAgent ? heteroType : provider,

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1261,7 +1261,7 @@ export class AiAgentService {
           // Group reads filter on messages.groupId (MessageModel.query group
           // branch), so a group turn must stamp groupId or the message never
           // shows when the topic is reopened. (LOBE-10604 / LOBE-10627)
-          groupId: appContext?.groupId,
+          groupId: appContext?.groupId ?? undefined,
           metadata: requestTriggerMetadata,
           role: 'user',
           threadId: appContext?.threadId ?? undefined,
@@ -1282,7 +1282,7 @@ export class AiAgentService {
       content: LOADING_FLAT,
       // Stamp groupId so the assistant turn is visible in the group read path
       // (MessageModel.query filters group chats by messages.groupId).
-      groupId: appContext?.groupId,
+      groupId: appContext?.groupId ?? undefined,
       model: isHeteroAgent ? undefined : model,
       parentId: parentMessageId ?? userMessageRecord?.id,
       provider: isHeteroAgent ? heteroType : provider,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-10604
Fixes LOBE-10627
Closes #16074
Closes #16118

Likely regression from #15574 (heterogeneous-agents: refine execution target + topic sidebar, June 9) per LOBE-10627.

#### 🔀 Description of Change

When a group conversation reaches `execAgent` without a pre-created `topicId` (e.g. the async / queue run), `execAgent` created the topic with `agentId` + `trigger` but **no `groupId`**. The topic then lived only under the member agent's topic list and never appeared in the group sidebar — which queries `topics.groupId` — so the conversation silently "disappeared" from the group (reported as *new topics never showing in the sidebar* / *"taken over by supervisor"*).

Ground-truth confirmed against the live backend: the orphaned topics came back with `status='active'`, `trigger='chat'`, `groupId=null`, and only surfaced under the supervisor agent's topic scope — not the group's. `trigger='chat'` (execAgent's trigger, vs `execGroupAgent`'s `null`) pinned the creating call to `execAgent`.

**Fix:** pass `appContext?.groupId` into the `topicModel.create` call in `execAgent`.
- No-op on the normal path where `execGroupAgent` pre-creates the topic (execAgent reuses it).
- Fixes the path where `execAgent` itself creates the topic.
- Harmless for non-group runs (`appContext.groupId` is undefined → stored as `null`, unchanged behaviour).

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Added a regression test in `execAgent.integration.test.ts`: calling `execAgent` with a group `appContext` (and no `topicId`) must persist `groupId` on the created topic.

- With the fix: `execAgent` (15) + `execGroupAgent` (11) integration suites pass; `type-check` clean.
- Reverting the one-line fix makes the new test fail (`expected null to be 'cg_...'`), proving the bug reproduces on canary and the test is a real guard.

#### 📝 Additional Information

Server-only change; can merge to `canary` independently. The desktop hydration-placeholder fix (LOBE-10699) is a separate SPA branch/PR.