### PR TITLE
💄 style(create): use light spinner on dark upload mask

### DIFF
--- a/src/routes/(main)/(create)/features/GenerationInput/UploadCard.tsx
+++ b/src/routes/(main)/(create)/features/GenerationInput/UploadCard.tsx
@@ -118,6 +118,13 @@ export const uploadCardStyles = createStaticStyles(({ css }) => ({
     border-radius: 3px;
 
     background: ${cssVar.colorBgMask};
+
+    /* The mask is a dark scrim in both themes, so force a light spinner for
+       contrast — the default indicator inherits a dark text color and smears
+       into the scrim. */
+    .ant-spin-dot-item {
+      background-color: ${cssVar.colorWhite};
+    }
   `,
 }));
 
@@ -265,7 +272,7 @@ const UploadCard = memo<UploadCardProps>(
               />
               {uploading && (
                 <div className={uploadCardStyles.uploadOverlay}>
-                  <Spin percent={'auto'} size="small" />
+                  <Spin size="small" />
                 </div>
               )}
             </div>

--- a/src/routes/(main)/(create)/features/GenerationInput/UploadCard.tsx
+++ b/src/routes/(main)/(create)/features/GenerationInput/UploadCard.tsx
@@ -119,11 +119,12 @@ export const uploadCardStyles = createStaticStyles(({ css }) => ({
 
     background: ${cssVar.colorBgMask};
 
-    /* The mask is a dark scrim in both themes, so force a light spinner for
-       contrast — the default indicator inherits a dark text color and smears
-       into the scrim. */
-    .ant-spin-dot-item {
-      background-color: ${cssVar.colorWhite};
+    /* antd resets the Spin's own color to colorText (near-black in the light
+       theme) and the percent ring's stroke is \`currentcolor\`, so it smears into
+       the dark mask. The mask is a dark scrim in both themes — override the Spin
+       color to white for contrast. */
+    .ant-spin {
+      color: ${cssVar.colorWhite};
     }
   `,
 }));
@@ -272,7 +273,7 @@ const UploadCard = memo<UploadCardProps>(
               />
               {uploading && (
                 <div className={uploadCardStyles.uploadOverlay}>
-                  <Spin size="small" />
+                  <Spin percent={'auto'} size="small" />
                 </div>
               )}
             </div>


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

Related to #16207 (drag-and-drop reference image upload)

#### 🔀 Description of Change

The reference-image upload card shows a `Spin` over a `colorBgMask` scrim while an upload is in flight. `colorBgMask` is a dark translucent layer in **both** light and dark themes, but the indicator was a `<Spin percent="auto">` whose ring inherits a dark text color — so in light mode it rendered as a gray-black smear that barely separated from the scrim.

- Drop `percent="auto"` (the auto progress ring is the dark-colored element) and use the plain `<Spin size="small">` dot indicator.
- Force the dots to `colorWhite` within the overlay, since the mask is always dark regardless of theme.

This matches the sibling `ImageUpload` component, which already keeps a high-contrast indicator over the same mask.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Drop an image onto the image/video creation page in **light mode** and watch the in-flight upload card — the spinner is now white and clearly readable over the dark scrim.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Dark gray-black ring smearing into the mask | White dot spinner, clear contrast |