### PR TITLE
fix: strip top_p and temperature from Copilot Responses API payload

### DIFF
--- a/packages/model-runtime/src/providers/githubCopilot/index.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.ts
@@ -276,12 +276,12 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
           max_tokens,
           verbosity,
           preserveThinking: _pt,
+          frequency_penalty,
+          presence_penalty,
+          top_p,
+          temperature,
           ...responseRest
         } = rest as any;
-
-        delete responseRest.apiMode;
-        delete responseRest.frequency_penalty;
-        delete responseRest.presence_penalty;
 
         const input = await convertOpenAIResponseInputs(messages as any, {
           forceImageBase64: true,

--- a/packages/model-runtime/src/providers/githubCopilot/index.ts
+++ b/packages/model-runtime/src/providers/githubCopilot/index.ts
@@ -280,6 +280,7 @@ export class LobeGithubCopilotAI implements LobeRuntimeAI {
           presence_penalty,
           top_p,
           temperature,
+          apiMode,
           ...responseRest
         } = rest as any;
 


### PR DESCRIPTION
## Summary

The GitHub Copilot Responses API (used by GPT-5.4 models) does not support `top_p` or `temperature` parameters. When these are included, the API returns a 400 error.

In the OpenAI Chat Completion API, `top_p` and `temperature` are valid — but the Responses API rejects them. This PR strips them from the payload before sending, matching the existing pattern for `frequency_penalty` and `presence_penalty`.

## Change

In `packages/model-runtime/src/providers/githubCopilot/index.ts`, the Responses API handler now destructures `top_p` and `temperature` out of `responseRest`, so they are silently dropped instead of forwarded to the Copilot API.

Removed the separate `delete` lines since the destructuring now covers all unsupported params.

## Related

- Issue: #16239
- Issue comment detailing root cause: https://github.com/lobehub/lobehub/issues/16239#issuecomment-12345