### PR TITLE
🐛 fix(modal): patch regressions from #16212 imperative createModal migration

### DIFF
--- a/src/features/CreatePlatformAgent/index.tsx
+++ b/src/features/CreatePlatformAgent/index.tsx
@@ -113,7 +113,7 @@ const COMING_SOON_PLATFORMS = new Set<RemoteHeterogeneousAgentType>(['amp', 'ope
 
 const CreatePlatformAgentContent = memo<CreatePlatformAgentContentProps>(({ groupId }) => {
   const { t } = useTranslation('chat');
-  const { close } = useModalContext();
+  const { close, setCanDismissByClickOutside } = useModalContext();
   const navigate = useNavigate();
   const storeCreateAgent = useAgentStore((s) => s.createAgent);
   const refreshAgentList = useHomeStore((s) => s.refreshAgentList);
@@ -133,6 +133,9 @@ const CreatePlatformAgentContent = memo<CreatePlatformAgentContentProps>(({ grou
   const [agentProfile, setAgentProfile] = useState<AgentProfile | null>(null);
   const [fetchingProfile, setFetchingProfile] = useState(false);
   const [creating, setCreating] = useState(false);
+  useEffect(() => {
+    setCanDismissByClickOutside(!creating);
+  }, [creating, setCanDismissByClickOutside]);
   const [capabilityResult, setCapabilityResult] = useState<
     { available: boolean; reason?: string; version?: string } | undefined
   >(undefined);

--- a/src/features/SkillStore/SkillList/ImportFromGithubModal.tsx
+++ b/src/features/SkillStore/SkillList/ImportFromGithubModal.tsx
@@ -5,7 +5,7 @@ import { Button, createModal, type ModalInstance, useModalContext } from '@lobeh
 import { GithubIcon } from '@lobehub/ui/icons';
 import { App, Typography } from 'antd';
 import { ArrowLeftRight, Sparkles } from 'lucide-react';
-import { memo, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { usePermission } from '@/hooks/usePermission';
@@ -13,13 +13,17 @@ import { useToolStore } from '@/store/tool';
 
 const ImportFromGithubContent = memo(() => {
   const { t } = useTranslation(['setting', 'common']);
-  const { close } = useModalContext();
+  const { close, setCanDismissByClickOutside } = useModalContext();
   const { message } = App.useApp();
   const importAgentSkillFromGitHub = useToolStore((s) => s.importAgentSkillFromGitHub);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [url, setUrl] = useState('');
   const { allowed: canCreate } = usePermission('create_content');
+
+  useEffect(() => {
+    setCanDismissByClickOutside(!loading);
+  }, [loading, setCanDismissByClickOutside]);
 
   const handleImport = async () => {
     const trimmed = url.trim();

--- a/src/features/SkillStore/SkillList/ImportFromUrlModal.tsx
+++ b/src/features/SkillStore/SkillList/ImportFromUrlModal.tsx
@@ -4,7 +4,7 @@ import { Alert, Flexbox, Icon, Input } from '@lobehub/ui';
 import { Button, createModal, type ModalInstance, useModalContext } from '@lobehub/ui/base-ui';
 import { App, Typography } from 'antd';
 import { ArrowLeftRight, Link, Sparkles } from 'lucide-react';
-import { memo, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { usePermission } from '@/hooks/usePermission';
@@ -12,13 +12,17 @@ import { useToolStore } from '@/store/tool';
 
 const ImportFromUrlContent = memo(() => {
   const { t } = useTranslation(['setting', 'common']);
-  const { close } = useModalContext();
+  const { close, setCanDismissByClickOutside } = useModalContext();
   const { message } = App.useApp();
   const importAgentSkillFromUrl = useToolStore((s) => s.importAgentSkillFromUrl);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [url, setUrl] = useState('');
   const { allowed: canCreate } = usePermission('create_content');
+
+  useEffect(() => {
+    setCanDismissByClickOutside(!loading);
+  }, [loading, setCanDismissByClickOutside]);
 
   const handleImport = async () => {
     const trimmed = url.trim();

--- a/src/routes/(main)/agent/profile/features/AgentSettings/Content.test.tsx
+++ b/src/routes/(main)/agent/profile/features/AgentSettings/Content.test.tsx
@@ -85,15 +85,18 @@ describe('AgentSettings Content', () => {
     mocks.serverState.featureFlags.enableAgentSelfIteration = true;
   });
 
-  it('falls back to self iteration when inbox hides opening', () => {
+  it('exposes both tabs for inbox when feature is on', () => {
     render(<Content />);
 
     const layout = screen.getByTestId('layout');
-    expect(layout).toHaveAttribute('data-active', ChatSettingsTabs.SelfIteration);
-    expect(layout).toHaveAttribute('data-tabs', ChatSettingsTabs.SelfIteration);
+    expect(layout).toHaveAttribute('data-active', ChatSettingsTabs.Opening);
+    expect(layout).toHaveAttribute(
+      'data-tabs',
+      `${ChatSettingsTabs.Opening},${ChatSettingsTabs.SelfIteration}`,
+    );
     expect(screen.getByTestId('agent-settings-content')).toHaveAttribute(
       'data-tab',
-      ChatSettingsTabs.SelfIteration,
+      ChatSettingsTabs.Opening,
     );
   });
 
@@ -108,6 +111,16 @@ describe('AgentSettings Content', () => {
       'data-tabs',
       `${ChatSettingsTabs.Opening},${ChatSettingsTabs.SelfIteration}`,
     );
+  });
+
+  it('falls back to opening when feature flag is off (inbox)', () => {
+    mocks.serverState.featureFlags.enableAgentSelfIteration = false;
+
+    render(<Content />);
+
+    const layout = screen.getByTestId('layout');
+    expect(layout).toHaveAttribute('data-active', ChatSettingsTabs.Opening);
+    expect(layout).toHaveAttribute('data-tabs', ChatSettingsTabs.Opening);
   });
 
   it('exposes only opening when feature flag is off', () => {

--- a/src/routes/(main)/agent/profile/features/AgentSettings/Content.tsx
+++ b/src/routes/(main)/agent/profile/features/AgentSettings/Content.tsx
@@ -41,10 +41,10 @@ const Content = memo(() => {
   const availableTabs = useMemo(
     () =>
       [
-        !isInbox ? ChatSettingsTabs.Opening : null,
+        ChatSettingsTabs.Opening,
         enableAgentSelfIteration ? ChatSettingsTabs.SelfIteration : null,
       ].filter(Boolean) as ChatSettingsTabs[],
-    [isInbox, enableAgentSelfIteration],
+    [enableAgentSelfIteration],
   );
 
   const activeTab = availableTabs.includes(tab) ? tab : availableTabs[0];

--- a/src/routes/(main)/agent/profile/features/Header/index.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.tsx
@@ -1,10 +1,10 @@
 import { isDesktop } from '@lobechat/const';
 import { ActionIcon, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
-import { confirmModal } from '@lobehub/ui/base-ui';
+import { confirmModal, type ModalInstance } from '@lobehub/ui/base-ui';
 import isEqual from 'fast-deep-equal';
 import type { TFunction } from 'i18next';
 import { BotMessageSquareIcon, Download, MoreHorizontal, Settings2Icon, Trash } from 'lucide-react';
-import { memo, useCallback, useMemo } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useAgentTransferMenuItem } from '@/business/client/hooks/useAgentTransferMenuItem';
@@ -163,6 +163,15 @@ const Header = memo(() => {
   const importMenuItem = useBusinessAgentImportMenuItem(activeAgentId ?? undefined);
   const transferMenuItems = useAgentTransferMenuItem(activeAgentId ?? undefined, meta);
 
+  const settingsModalRef = useRef<ModalInstance | null>(null);
+  useEffect(
+    () => () => {
+      settingsModalRef.current?.close();
+      settingsModalRef.current = null;
+    },
+    [],
+  );
+
   const menuItems = useMemo(() => {
     const businessTransferMenuItems = transferMenuItems ?? [];
 
@@ -171,7 +180,10 @@ const Header = memo(() => {
         icon: <Icon icon={Settings2Icon} />,
         key: 'advanced-settings',
         label: t('advancedSettings', { ns: 'setting' }),
-        onClick: () => openAgentSettingsModal(),
+        onClick: () => {
+          settingsModalRef.current?.close();
+          settingsModalRef.current = openAgentSettingsModal();
+        },
       },
       { type: 'divider' as const },
       {

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/RemoteAgentConfigCard.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/RemoteAgentConfigCard.tsx
@@ -90,7 +90,7 @@ interface ChangeDeviceContentProps {
 const ChangeDeviceContent = memo<ChangeDeviceContentProps>(
   ({ currentDeviceId, isWorkspaceAgent, onConfirm, platform }) => {
     const { t } = useTranslation('setting');
-    const { close } = useModalContext();
+    const { close, setCanDismissByClickOutside } = useModalContext();
 
     const [selectedDeviceId, setSelectedDeviceId] = useState<string | undefined>(currentDeviceId);
     const [capabilityResult, setCapabilityResult] = useState<
@@ -98,6 +98,10 @@ const ChangeDeviceContent = memo<ChangeDeviceContentProps>(
     >(undefined);
     const [checkingCapability, setCheckingCapability] = useState(false);
     const [saving, setSaving] = useState(false);
+
+    useEffect(() => {
+      setCanDismissByClickOutside(!saving);
+    }, [saving, setCanDismissByClickOutside]);
 
     const { data: devices, isLoading: loadingDevices } = lambdaQuery.device.listDevices.useQuery(
       undefined,

--- a/src/routes/(main)/group/profile/features/GroupProfile/index.tsx
+++ b/src/routes/(main)/group/profile/features/GroupProfile/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ActionIcon, Button, DropdownMenu, Flexbox } from '@lobehub/ui';
+import { type ModalInstance } from '@lobehub/ui/base-ui';
 import { Divider } from 'antd';
 import { useTheme } from 'antd-style';
 import { MoreHorizontalIcon, PlayIcon, Settings2Icon } from 'lucide-react';
@@ -45,6 +46,15 @@ const GroupProfile = memo(() => {
   const updateGroup = useAgentGroupStore((s) => s.updateGroup);
   const router = useQueryRoute();
   const transferMenuItems = useAgentGroupTransferMenuItem(groupId ?? undefined);
+
+  const settingsModalRef = useRef<ModalInstance | null>(null);
+  useEffect(
+    () => () => {
+      settingsModalRef.current?.close();
+      settingsModalRef.current = null;
+    },
+    [],
+  );
 
   // Collaborative edit lock for workspace groups (same model as pages): read-only
   // when another member is editing; acquired implicitly on the first edit.
@@ -166,7 +176,8 @@ const GroupProfile = memo(() => {
             onClick={() => {
               if (!canEdit) return;
 
-              openGroupAgentSettingsModal();
+              settingsModalRef.current?.close();
+              settingsModalRef.current = openGroupAgentSettingsModal();
             }}
           >
             {t('advancedSettings')}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up to #16212.

#### 🔀 Description of Change

Patches three regressions introduced when 13 modals were migrated from declarative antd `Modal` / `@lobehub/ui` `Modal` to base-ui imperative `createModal()`:

1. **Inbox agent "Advanced Settings" is blank.** `Content.tsx` was filtering the Opening tab out for inbox. With `enableAgentSelfIteration` defaulting to `false` in prod, `availableTabs` ended up empty and the new flattened `SettingsModalLayout` (no sidebar) rendered a header with empty content. Fix: stop excluding Opening for inbox — the openingMessage/openingQuestions chatConfig is meaningful for inbox too. Existing test updated.
2. **Mask-click dismisses modals during in-flight async work.** `CreatePlatformAgent` wizard, `ImportFromGithubModal`, `ImportFromUrlModal`, and `RemoteAgentConfigCard`'s change-device modal all set `maskClosable: true` but did not gate dismissal on the loading state, orphaning ongoing requests on backdrop click. Fix: pull `setCanDismissByClickOutside` from `useModalContext` and toggle it on the loading flag — mirroring the existing `UploadSkillModal` pattern.
3. **Modal outlives its host route.** `openAgentSettingsModal` / `openGroupAgentSettingsModal` mount at body level via `createModal`, so navigating away from the agent/group profile page leaves the modal on screen editing whatever store state remains. Fix: track the returned `ModalInstance` via a ref in the host component (`Header`, `GroupProfile`) and close it on unmount; reopening also closes any prior instance.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Manual checks:

- Open Lobe AI (inbox) → ⋯ → Advanced Settings → confirm the Opening form renders (with `enableAgentSelfIteration` off).
- Start the platform-agent wizard and confirm clicking outside is ignored while the creation request is in flight.
- Open Advanced Settings on an agent profile, click a sidebar item to switch agent — the modal closes.
- Updated `Content.test.tsx` (4/4 passing) and `Header/index.test.tsx` (4/4 passing).

#### 📸 Screenshots / Videos

N/A — bug fix to existing UI; no visual additions.

#### 📝 Additional Information

No store / API / migration changes. Scoped to client-side modal lifecycle.