### PR TITLE
🔨 chore: respect NO_PROXY for dev auth fetches

### DIFF
--- a/src/libs/better-auth/define-config.test.ts
+++ b/src/libs/better-auth/define-config.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   betterAuth: vi.fn((options) => options),
+  EnvHttpProxyAgent: vi.fn((options) => ({ options })),
+  setGlobalDispatcher: vi.fn(),
 }));
 
 vi.mock('@better-auth/expo', () => ({
@@ -46,8 +48,8 @@ vi.mock('better-auth/plugins', () => ({
 }));
 
 vi.mock('undici', () => ({
-  ProxyAgent: vi.fn(),
-  setGlobalDispatcher: vi.fn(),
+  EnvHttpProxyAgent: mocks.EnvHttpProxyAgent,
+  setGlobalDispatcher: mocks.setGlobalDispatcher,
 }));
 
 vi.mock('@/envs/app', () => ({
@@ -103,6 +105,24 @@ vi.mock('@/server/services/user', () => ({
 }));
 
 describe('defineConfig', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    process.env = { ...originalEnv, NODE_ENV: 'test' };
+    delete process.env.HTTP_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.HTTPS_PROXY;
+    delete process.env.https_proxy;
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
   it('should revoke existing sessions after password reset by default', async () => {
     const { defineConfig } = await import('./define-config');
 
@@ -115,5 +135,33 @@ describe('defineConfig', () => {
         }),
       }),
     );
+  });
+
+  it('should respect NO_PROXY when configuring the development proxy dispatcher', async () => {
+    process.env.NODE_ENV = 'development';
+    process.env.HTTP_PROXY = 'http://127.0.0.1:7890';
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:7890';
+    process.env.NO_PROXY = 'example.com,localhost';
+
+    await import('./define-config');
+
+    expect(mocks.EnvHttpProxyAgent).toHaveBeenCalledWith({
+      httpProxy: 'http://127.0.0.1:7890',
+      httpsProxy: 'http://127.0.0.1:7890',
+      noProxy: 'example.com,localhost,127.0.0.1,[::1]',
+    });
+    expect(mocks.setGlobalDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          noProxy: 'example.com,localhost,127.0.0.1,[::1]',
+        }),
+      }),
+    );
+  });
+
+  it('should preserve NO_PROXY wildcard semantics', async () => {
+    const { mergeLocalNoProxy } = await import('./define-config');
+
+    expect(mergeLocalNoProxy('*')).toBe('*');
   });
 });

--- a/src/libs/better-auth/define-config.ts
+++ b/src/libs/better-auth/define-config.ts
@@ -9,7 +9,7 @@ import { type BetterAuthOptions } from 'better-auth/minimal';
 import { betterAuth } from 'better-auth/minimal';
 import { admin, emailOTP, genericOAuth, magicLink } from 'better-auth/plugins';
 import { type BetterAuthPlugin } from 'better-auth/types';
-import { ProxyAgent, setGlobalDispatcher } from 'undici';
+import { EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
 
 import { appEnv } from '@/envs/app';
 import { authEnv } from '@/envs/auth';
@@ -27,18 +27,39 @@ import { parseSSOProviders } from '@/libs/better-auth/utils/server';
 import { EmailService } from '@/server/services/email';
 import { UserService } from '@/server/services/user';
 
-// Configure HTTP proxy for OAuth provider requests in development (e.g., Google token exchange)
-// Node.js native fetch doesn't respect system proxy settings
+const LOCAL_NO_PROXY_HOSTS = ['localhost', '127.0.0.1', '[::1]'];
+
+export const mergeLocalNoProxy = (noProxy?: string): string => {
+  const entries = new Set(
+    (noProxy || '')
+      .split(/[,\s]+/)
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  );
+
+  if (entries.has('*')) return '*';
+
+  for (const host of LOCAL_NO_PROXY_HOSTS) {
+    entries.add(host);
+  }
+
+  return [...entries].join(',');
+};
+
+// Configure HTTP proxy for OAuth provider requests in development (e.g., Google token exchange).
+// Node.js native fetch doesn't respect system proxy settings. Keep localhost direct so Next can
+// fetch local Vite templates such as /index.auth.html without depending on the system proxy.
 // Ref: https://github.com/better-auth/better-auth/issues/7396
 if (process.env.NODE_ENV === 'development') {
-  const proxyUrl =
-    process.env.HTTPS_PROXY ||
-    process.env.https_proxy ||
-    process.env.HTTP_PROXY ||
-    process.env.http_proxy;
+  const httpProxy = process.env.HTTP_PROXY || process.env.http_proxy;
+  const httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy || httpProxy;
 
-  if (proxyUrl) {
-    const proxyAgent = new ProxyAgent(proxyUrl);
+  if (httpProxy || httpsProxy) {
+    const proxyAgent = new EnvHttpProxyAgent({
+      ...(httpProxy && { httpProxy }),
+      ...(httpsProxy && { httpsProxy }),
+      noProxy: mergeLocalNoProxy(process.env.NO_PROXY || process.env.no_proxy),
+    });
     setGlobalDispatcher(proxyAgent);
   }
 }


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

N/A. Searched recent open issues for desktop local dev, NO_PROXY, and OIDC auth; no direct match found.

#### 🔀 Description of Change

- Use undici EnvHttpProxyAgent for development proxy setup so NO_PROXY is honored.
- Always keep localhost, 127.0.0.1, and [::1] out of the development proxy path while preserving existing NO_PROXY entries.
- Preserve wildcard NO_PROXY=* semantics.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- cd lobehub && rtk vitest run src/libs/better-auth/define-config.test.ts

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This is a generic development proxy compatibility change. It does not add cloud-specific business logic or cloud-only configuration to the open-source submodule.