### PR TITLE
🔨 chore: fix dev auth proxy test env setup

### DIFF
--- a/src/libs/better-auth/define-config.test.ts
+++ b/src/libs/better-auth/define-config.test.ts
@@ -138,10 +138,13 @@ describe('defineConfig', () => {
   });
 
   it('should respect NO_PROXY when configuring the development proxy dispatcher', async () => {
-    process.env.NODE_ENV = 'development';
-    process.env.HTTP_PROXY = 'http://127.0.0.1:7890';
-    process.env.HTTPS_PROXY = 'http://127.0.0.1:7890';
-    process.env.NO_PROXY = 'example.com,localhost';
+    process.env = {
+      ...process.env,
+      HTTP_PROXY: 'http://127.0.0.1:7890',
+      HTTPS_PROXY: 'http://127.0.0.1:7890',
+      NODE_ENV: 'development',
+      NO_PROXY: 'example.com,localhost',
+    };
 
     await import('./define-config');
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

Related to https://github.com/lobehub/lobehub/pull/16247

#### 🔀 Description of Change

- Rebuild `process.env` in the development proxy test instead of assigning directly to the readonly `NODE_ENV` property.
- Fixes the `TS2540: Cannot assign to 'NODE_ENV'` type-check failure seen on the previous submodule PR.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

- `cd lobehub && rtk vitest run src/libs/better-auth/define-config.test.ts`
- `cd lobehub && bun run type-check >/tmp/lobehub-type-check-after-env-fix.log 2>&1; rg "define-config.test.ts\\(141,17\\)|Cannot assign to 'NODE_ENV'|TS2540" /tmp/lobehub-type-check-after-env-fix.log` returns no match.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

N/A
