### PR TITLE
💄 style(chat): move hetero model selector into input action bar

### DIFF
--- a/src/features/ChatInput/ControlBar/HeteroModel.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroModel.tsx
@@ -456,7 +456,7 @@ const HeteroModel = memo(() => {
     <DropdownMenuRoot open={open} onOpenChange={handleOpenChange}>
       <DropdownMenuTrigger nativeButton={false}>{trigger}</DropdownMenuTrigger>
       <DropdownMenuPortal>
-        <DropdownMenuPositioner placement="topRight" sideOffset={8}>
+        <DropdownMenuPositioner placement="topLeft" sideOffset={8}>
           <DropdownMenuPopup className={styles.popup} style={{ width: 208 }}>
             <div className={styles.sectionTitle}>{t('heteroAgent.modelSelector.reasoning')}</div>
             <div className={styles.scroll}>

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/HeteroControlBar.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/HeteroControlBar.tsx
@@ -7,13 +7,10 @@ import { CircleAlertIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import HeteroModel from '@/features/ChatInput/ControlBar/HeteroModel';
 import WorkspaceControls from '@/features/ChatInput/ControlBar/WorkspaceControls';
 import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
-
-import { shouldShowHeteroModelSelector } from './shouldShowHeteroModelSelector';
 
 const styles = createStaticStyles(({ css }) => ({
   bar: css`
@@ -68,24 +65,17 @@ const HeteroControlBar = memo(() => {
 
   // All hooks must be called unconditionally (Rules of Hooks)
   const isLoading = useAgentStore(agentByIdSelectors.isAgentConfigLoadingById(agentId));
-  const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));
-  const showModelSelector = shouldShowHeteroModelSelector({
-    boundDeviceId: agencyConfig?.boundDeviceId,
-    executionTarget: agencyConfig?.executionTarget,
-    isDesktopClient: isDesktop,
-  });
 
   // On web there's no full-access badge / skeleton — just the workspace controls
-  // (the cloud repo switcher is rendered inside WorkspaceControls).
+  // (the cloud repo switcher is rendered inside WorkspaceControls). The CLI
+  // model + thinking-effort selector now lives in the input's bottom-left action
+  // bar (see HeterogeneousChatInput), not in this strip.
   if (!isDesktop) {
     if (!agentId) return null;
     return (
-      <Flexbox horizontal align={'center'} className={styles.bar} justify={'space-between'}>
+      <Flexbox horizontal align={'center'} className={styles.bar}>
         <Flexbox horizontal align={'center'} className={styles.leftGroup} gap={4}>
           <WorkspaceControls alwaysShowWorkspace agentId={agentId} />
-        </Flexbox>
-        <Flexbox horizontal align={'center'} className={styles.rightGroup} gap={4}>
-          {showModelSelector && <HeteroModel />}
         </Flexbox>
       </Flexbox>
     );
@@ -113,7 +103,6 @@ const HeteroControlBar = memo(() => {
         <WorkspaceControls alwaysShowWorkspace agentId={agentId} />
       </Flexbox>
       <Flexbox horizontal align={'center'} className={styles.rightGroup} gap={4}>
-        {showModelSelector && <HeteroModel />}
         <Tooltip title={tChat('heteroAgent.fullAccess.tooltip')}>{fullAccessBadge}</Tooltip>
       </Flexbox>
     </Flexbox>

--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/index.tsx
@@ -4,8 +4,9 @@ import {
   HETEROGENEOUS_TYPE_LABELS,
   isRemoteHeterogeneousType,
 } from '@lobechat/heterogeneous-agents';
+import { type ChatInputActionsProps } from '@lobehub/editor/react';
 import { Alert, Button, Flexbox } from '@lobehub/ui';
-import { memo, type ReactNode } from 'react';
+import { memo, type ReactNode, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
 import urlJoin from 'url-join';
@@ -13,6 +14,7 @@ import urlJoin from 'url-join';
 import { useHeteroAgentCloudConfig } from '@/business/client/hooks/useHeteroAgentCloudConfig';
 import { isDesktop } from '@/const/version';
 import { type ActionKeys } from '@/features/ChatInput';
+import HeteroModel from '@/features/ChatInput/ControlBar/HeteroModel';
 import { ChatInput } from '@/features/Conversation';
 import { contextSelectors, useConversationStore } from '@/features/Conversation/store';
 import WideScreenContainer from '@/features/WideScreenContainer';
@@ -23,11 +25,14 @@ import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 
 import HeteroControlBar from './HeteroControlBar';
+import { shouldShowHeteroModelSelector } from './shouldShowHeteroModelSelector';
 
 // Heterogeneous agents (e.g. Claude Code) bring their own toolchain and memory,
 // so most LobeHub-side pickers don't apply. Typo is kept so the user can still
-// toggle the rich-text formatting bar. Local CLI model + thinking effort live
-// in the control bar next to workspace controls, not beside the send button.
+// toggle the rich-text formatting bar. The CLI model + thinking-effort selector
+// is injected right after it via `extraActionItems`, so it sits in the input's
+// bottom-left corner (consistent with where the model picker lives in a normal
+// agent chat), rather than off in the control-bar strip below the box.
 const leftActions: ActionKeys[] = ['typo'];
 
 /**
@@ -90,6 +95,27 @@ const HeterogeneousChatInput = memo(() => {
     clientExecutionAvailable: isDesktop,
   });
   const isRemoteAgent = !!providerType && isRemoteHeterogeneousType(providerType);
+
+  // The model + thinking-effort selector only applies to local-CLI providers
+  // (claude-code / codex) and only when this surface actually dispatches the run.
+  // Gating here (rather than letting HeteroModel self-hide) keeps the action bar
+  // from rendering an empty slot. Uses the raw `executionTarget` to mirror the
+  // gate the control bar applied before the selector moved into the input.
+  const isSelectableHeteroProvider = providerType === 'claude-code' || providerType === 'codex';
+  const showHeteroModel =
+    isSelectableHeteroProvider &&
+    shouldShowHeteroModelSelector({
+      boundDeviceId: agencyConfig?.boundDeviceId,
+      executionTarget: agencyConfig?.executionTarget,
+      isDesktopClient: isDesktop,
+    });
+  const extraActionItems = useMemo<ChatInputActionsProps['items']>(
+    () =>
+      showHeteroModel
+        ? [{ alwaysDisplay: true, children: <HeteroModel />, key: 'heteroModel' }]
+        : [],
+    [showHeteroModel],
+  );
 
   // A run goes to an `lh connect` device when the provider is a remote-only type
   // (openclaw / hermes) OR a local-CLI type (claude-code / codex) resolves to a
@@ -174,6 +200,7 @@ const HeterogeneousChatInput = memo(() => {
       {renderDeviceGuard()}
       <ChatInput
         controlBarSlot={<HeteroControlBar />}
+        extraActionItems={extraActionItems}
         leftActions={leftActions}
         sendButtonProps={{ disabled: inputDisabled, shape: 'round' }}
         skipScrollMarginWithList={!hasGuard}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Move the heterogeneous CLI model and reasoning-effort selector from the control bar into the chat input action bar.
- Keep the selector gated to selectable local CLI providers and execution targets that can consume the model arguments.
- Adjust the selector dropdown placement for the new bottom-left input position.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' 'src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/shouldShowHeteroModelSelector.test.ts'
```

#### 📸 Screenshots / Videos

Not captured.

#### 📝 Additional Information

The desktop dev app was started with `pnpm run dev:desktop` for local verification.
