### PR TITLE
🐛 fix(desktop): remount dynamic meta runner on tab URL changes

### DIFF
--- a/src/features/Electron/titlebar/TabBar/TabCacheBridges.test.tsx
+++ b/src/features/Electron/titlebar/TabBar/TabCacheBridges.test.tsx
@@ -1,5 +1,7 @@
-import { cleanup, render, waitFor } from '@testing-library/react';
+import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { MessageSquare } from 'lucide-react';
+import type * as ReactModule from 'react';
+import { useMemo, useState } from 'react';
 import { type RouteObject } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -9,17 +11,28 @@ import TabCacheBridges from './TabCacheBridges';
 import { type TabItem } from './types';
 
 const mocks = vi.hoisted(() => {
+  const listeners = new Set<() => void>();
+  const routes = { current: [] as RouteObject[] };
   const tabs: { current: TabItem[] } = { current: [] };
+  const emit = () => {
+    for (const listener of listeners) listener();
+  };
 
   return {
     getTabs: () => tabs.current,
-    routes: { current: [] as RouteObject[] },
+    routes,
     setRoutes: (next: RouteObject[]) => {
       tabs.current = [];
-      mocks.routes.current = next;
+      routes.current = next;
+      emit();
     },
     setTabs: (next: TabItem[]) => {
       tabs.current = next;
+      emit();
+    },
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
     },
     updateTabCache: vi.fn<(id: string, cached: DynamicRouteMeta) => void>(),
   };
@@ -36,10 +49,17 @@ interface ElectronState {
   updateTabCache: typeof mocks.updateTabCache;
 }
 
-vi.mock('@/store/electron', () => ({
-  useElectronStore: (selector: (state: ElectronState) => unknown) =>
-    selector({ tabs: mocks.getTabs(), updateTabCache: mocks.updateTabCache }),
-}));
+vi.mock('@/store/electron', async () => {
+  const React = await vi.importActual<typeof ReactModule>('react');
+
+  return {
+    useElectronStore: (selector: (state: ElectronState) => unknown) => {
+      const tabs = React.useSyncExternalStore(mocks.subscribe, mocks.getTabs, mocks.getTabs);
+
+      return selector({ tabs, updateTabCache: mocks.updateTabCache });
+    },
+  };
+});
 
 const dynamicSource: Record<string, DynamicRouteMeta> = {};
 const resolveTopicMeta = (params: Record<string, string | undefined>): DynamicRouteMeta => {
@@ -73,6 +93,47 @@ const tab = (url: string): TabItem => ({
   lastVisited: 1,
   url,
 });
+
+const stableTab = (id: string, url: string): TabItem => ({
+  id,
+  lastVisited: 1,
+  url,
+});
+
+const workspaceHomeMetaWithHook: RouteMeta = {
+  titleKey: 'navigation.home',
+  useDynamicMeta: () => {
+    const [title] = useState('Workspace Home');
+
+    return { title };
+  },
+};
+
+const agentMetaWithExtraHook: RouteMeta = {
+  icon: MessageSquare,
+  titleKey: 'navigation.chat',
+  useDynamicMeta: () => {
+    const [prefix] = useState('Agent');
+    const suffix = useMemo(() => 'Detail', []);
+
+    return { title: `${prefix} ${suffix}` };
+  },
+};
+
+const buildWorkspaceRoutesWithChangingMetaHooks = (): RouteObject[] => [
+  {
+    children: [
+      {
+        children: [
+          { handle: { meta: workspaceHomeMetaWithHook }, index: true },
+          { handle: { meta: agentMetaWithExtraHook }, path: 'agent/:aid' },
+        ],
+        path: ':workspaceSlug',
+      },
+    ],
+    path: '/',
+  },
+];
 
 describe('TabCacheBridges', () => {
   afterEach(() => {
@@ -141,6 +202,32 @@ describe('TabCacheBridges', () => {
 
     await waitFor(() => {
       expect(mocks.updateTabCache).not.toHaveBeenCalled();
+    });
+  });
+
+  it('remounts the dynamic meta runner when a tab url switches route meta hooks', async () => {
+    mocks.routes.current = buildWorkspaceRoutesWithChangingMetaHooks();
+    mocks.setTabs([stableTab('workspace-tab', '/acme')]);
+
+    render(<TabCacheBridges />);
+
+    await waitFor(() => {
+      expect(mocks.updateTabCache).toHaveBeenCalledWith(
+        'workspace-tab',
+        expect.objectContaining({ title: 'Workspace Home' }),
+      );
+    });
+
+    mocks.updateTabCache.mockClear();
+    act(() => {
+      mocks.setTabs([stableTab('workspace-tab', '/acme/agent/a1')]);
+    });
+
+    await waitFor(() => {
+      expect(mocks.updateTabCache).toHaveBeenCalledWith(
+        'workspace-tab',
+        expect.objectContaining({ title: 'Agent Detail' }),
+      );
     });
   });
 });

--- a/src/features/Electron/titlebar/TabBar/TabCacheBridges.tsx
+++ b/src/features/Electron/titlebar/TabBar/TabCacheBridges.tsx
@@ -30,6 +30,7 @@ const TabCacheBridge = memo<TabCacheBridgeProps>(({ tab }) => {
 
   return (
     <DynamicMetaRunner
+      key={tab.url}
       params={matched.params}
       useDynamicMeta={useDynamicMeta}
       onResolve={handleResolve}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No existing issue or open PR found for this specific desktop workspace titlebar render error.

#### 🔀 Description of Change

Remount the desktop tab cache dynamic meta runner when a tab URL changes. The previous implementation reused the same `DynamicMetaRunner` instance while swapping `useDynamicMeta` from workspace home meta to agent route meta, which can change the hook order and trigger React's `Rendered more hooks than during the previous render` error.

This fixes the `Render Error` that appears in the desktop titlebar after entering an agent from a workspace home route.

The PR also adds a regression test that updates the same tab from a workspace home URL to an agent URL where the two route meta hooks have different hook shapes.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd lobehub && bunx vitest run --silent='passed-only' src/features/Electron/titlebar/TabBar/TabCacheBridges.test.tsx
```

Manual verification: reproduced the issue in Electron desktop from the LobeHub workspace, then verified the titlebar no longer shows `Render Error` after entering an agent.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Titlebar showed `Render Error` after entering a workspace agent | Titlebar stays normal after entering a workspace agent |

#### 📝 Additional Information

Checked GitHub for existing work using keywords including `DynamicMetaRunner`, `TabCacheBridges`, `workspaceHomeRouteMeta`, `Render Error`, `Rendered more hooks`, and desktop workspace agent/titlebar terms. Only a previously merged tab-title PR (#15244) appeared for the file-level keywords; no open PR was found for this issue.
