### PR TITLE
🐛 fix(route-meta): render dynamic meta as components

### DIFF
--- a/src/features/AgentDocumentPage/routeMeta.ts
+++ b/src/features/AgentDocumentPage/routeMeta.ts
@@ -1,26 +1,34 @@
 import { FileTextIcon } from 'lucide-react';
 
+import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
 import { matchesRouteWorkspace, useRouteWorkspaceId } from '@/features/RouteMeta/workspaceScope';
 import { useClientDataSWR } from '@/libs/swr';
 import { portalKeys } from '@/libs/swr/keys';
 import { documentService } from '@/services/document';
-import { type DynamicRouteMeta, routeMeta } from '@/spa/router/routeMeta';
+import type { DynamicRouteMetaProps } from '@/spa/router/routeMeta';
+import { routeMeta } from '@/spa/router/routeMeta';
 import { getIdFromIdentifier } from '@/utils/identifier';
 
+const AgentDocumentDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
+  const routeWorkspaceId = useRouteWorkspaceId(params);
+  const documentId = params.docId ? getIdFromIdentifier(params.docId, 'docs') : '';
+  // Deduped against the Document Header's SWR fetch (same key), so this adds
+  // no extra request — it just surfaces the title into the breadcrumb.
+  const { data } = useClientDataSWR(documentId ? portalKeys.documentHeader(documentId) : null, () =>
+    documentService.getDocumentById(documentId),
+  );
+  const document = matchesRouteWorkspace(data?.workspaceId, routeWorkspaceId) ? data : undefined;
+
+  usePublishDynamicRouteMeta(
+    { title: document?.filename || document?.title || undefined },
+    onResolve,
+  );
+
+  return null;
+};
+
 export const agentDocumentRouteMeta = routeMeta({
+  DynamicMeta: AgentDocumentDynamicMeta,
   icon: FileTextIcon,
   titleKey: 'navigation.document',
-  useDynamicMeta: (params): DynamicRouteMeta => {
-    const routeWorkspaceId = useRouteWorkspaceId(params);
-    const documentId = params.docId ? getIdFromIdentifier(params.docId, 'docs') : '';
-    // Deduped against the Document Header's SWR fetch (same key), so this adds
-    // no extra request — it just surfaces the title into the breadcrumb.
-    const { data } = useClientDataSWR(
-      documentId ? portalKeys.documentHeader(documentId) : null,
-      () => documentService.getDocumentById(documentId),
-    );
-    const document = matchesRouteWorkspace(data?.workspaceId, routeWorkspaceId) ? data : undefined;
-
-    return { title: document?.filename || document?.title || undefined };
-  },
 });

--- a/src/features/AgentTasks/routeMeta.ts
+++ b/src/features/AgentTasks/routeMeta.ts
@@ -1,7 +1,9 @@
 import { ListTodoIcon } from 'lucide-react';
 
+import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
 import { matchesRouteWorkspace, useRouteWorkspaceId } from '@/features/RouteMeta/workspaceScope';
-import { type DynamicRouteMeta, routeMeta } from '@/spa/router/routeMeta';
+import type { DynamicRouteMetaProps } from '@/spa/router/routeMeta';
+import { routeMeta } from '@/spa/router/routeMeta';
 import { useTaskStore } from '@/store/task';
 import { taskDetailSelectors } from '@/store/task/selectors';
 
@@ -10,18 +12,25 @@ export const tasksRouteMeta = routeMeta({
   titleKey: 'navigation.tasks',
 });
 
+const TaskDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
+  const routeWorkspaceId = useRouteWorkspaceId(params);
+  const detail = useTaskStore((s) => {
+    const item = taskDetailSelectors.taskDetailById(params.taskId ?? '')(s);
+    return matchesRouteWorkspace(item?.workspaceId, routeWorkspaceId) ? item : undefined;
+  });
+
+  usePublishDynamicRouteMeta(
+    {
+      title: detail?.name || undefined,
+    },
+    onResolve,
+  );
+
+  return null;
+};
+
 export const taskRouteMeta = routeMeta({
+  DynamicMeta: TaskDynamicMeta,
   icon: ListTodoIcon,
   titleKey: 'navigation.task',
-  useDynamicMeta: (params): DynamicRouteMeta => {
-    const routeWorkspaceId = useRouteWorkspaceId(params);
-    const detail = useTaskStore((s) => {
-      const item = taskDetailSelectors.taskDetailById(params.taskId ?? '')(s);
-      return matchesRouteWorkspace(item?.workspaceId, routeWorkspaceId) ? item : undefined;
-    });
-
-    return {
-      title: detail?.name || undefined,
-    };
-  },
 });

--- a/src/features/Electron/titlebar/TabBar/TabCacheBridges.test.tsx
+++ b/src/features/Electron/titlebar/TabBar/TabCacheBridges.test.tsx
@@ -1,14 +1,19 @@
-import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { cleanup, render, waitFor } from '@testing-library/react';
 import { MessageSquare } from 'lucide-react';
 import type * as ReactModule from 'react';
-import { useMemo, useState } from 'react';
-import { type RouteObject } from 'react-router';
+import { useState } from 'react';
+import type { RouteObject } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { type DynamicRouteMeta, type RouteMeta } from '@/spa/router/routeMeta';
+import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
+import {
+  type DynamicRouteMeta,
+  type DynamicRouteMetaProps,
+  type RouteMeta,
+} from '@/spa/router/routeMeta';
 
 import TabCacheBridges from './TabCacheBridges';
-import { type TabItem } from './types';
+import type { TabItem } from './types';
 
 const mocks = vi.hoisted(() => {
   const listeners = new Set<() => void>();
@@ -67,10 +72,16 @@ const resolveTopicMeta = (params: Record<string, string | undefined>): DynamicRo
   return dynamicSource[key] ?? {};
 };
 
+const TopicDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
+  usePublishDynamicRouteMeta(resolveTopicMeta(params), onResolve);
+
+  return null;
+};
+
 const agentMeta: RouteMeta = {
+  DynamicMeta: TopicDynamicMeta,
   icon: MessageSquare,
   titleKey: 'navigation.chat',
-  useDynamicMeta: resolveTopicMeta,
 };
 
 const staticMeta: RouteMeta = {
@@ -88,52 +99,11 @@ const buildRoutes = (): RouteObject[] => [
   },
 ];
 
-const tab = (url: string): TabItem => ({
-  id: url,
-  lastVisited: 1,
-  url,
-});
-
-const stableTab = (id: string, url: string): TabItem => ({
+const tab = (url: string, id = url): TabItem => ({
   id,
   lastVisited: 1,
   url,
 });
-
-const workspaceHomeMetaWithHook: RouteMeta = {
-  titleKey: 'navigation.home',
-  useDynamicMeta: () => {
-    const [title] = useState('Workspace Home');
-
-    return { title };
-  },
-};
-
-const agentMetaWithExtraHook: RouteMeta = {
-  icon: MessageSquare,
-  titleKey: 'navigation.chat',
-  useDynamicMeta: () => {
-    const [prefix] = useState('Agent');
-    const suffix = useMemo(() => 'Detail', []);
-
-    return { title: `${prefix} ${suffix}` };
-  },
-};
-
-const buildWorkspaceRoutesWithChangingMetaHooks = (): RouteObject[] => [
-  {
-    children: [
-      {
-        children: [
-          { handle: { meta: workspaceHomeMetaWithHook }, index: true },
-          { handle: { meta: agentMetaWithExtraHook }, path: 'agent/:aid' },
-        ],
-        path: ':workspaceSlug',
-      },
-    ],
-    path: '/',
-  },
-];
 
 describe('TabCacheBridges', () => {
   afterEach(() => {
@@ -194,7 +164,7 @@ describe('TabCacheBridges', () => {
     });
   });
 
-  it('skips tabs whose route has no useDynamicMeta', async () => {
+  it('skips tabs whose route has no DynamicMeta', async () => {
     mocks.routes.current = buildRoutes();
     mocks.setTabs([tab('/settings')]);
 
@@ -205,29 +175,67 @@ describe('TabCacheBridges', () => {
     });
   });
 
-  it('remounts the dynamic meta runner when a tab url switches route meta hooks', async () => {
-    mocks.routes.current = buildWorkspaceRoutesWithChangingMetaHooks();
-    mocks.setTabs([stableTab('workspace-tab', '/acme')]);
+  it('keeps hook order stable when the same tab changes dynamic meta component', async () => {
+    const ShorterHookDynamicMeta = ({ onResolve }: DynamicRouteMetaProps) => {
+      const [title] = useState('Workspace');
 
-    render(<TabCacheBridges />);
+      usePublishDynamicRouteMeta({ title }, onResolve);
 
-    await waitFor(() => {
-      expect(mocks.updateTabCache).toHaveBeenCalledWith(
-        'workspace-tab',
-        expect.objectContaining({ title: 'Workspace Home' }),
+      return null;
+    };
+    const LongerHookDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
+      const [agentTitle] = useState(`Agent ${params.aid}`);
+      const [topicTitle] = useState('Topic');
+
+      usePublishDynamicRouteMeta({ title: `${agentTitle} · ${topicTitle}` }, onResolve);
+
+      return null;
+    };
+    const shorterHookMeta: RouteMeta = {
+      DynamicMeta: ShorterHookDynamicMeta,
+    };
+    const longerHookMeta: RouteMeta = {
+      DynamicMeta: LongerHookDynamicMeta,
+    };
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      mocks.routes.current = [
+        {
+          children: [
+            { handle: { meta: shorterHookMeta }, path: 'workspace' },
+            { handle: { meta: longerHookMeta }, path: 'agent/:aid' },
+          ],
+          path: '/',
+        },
+      ];
+      mocks.setTabs([tab('/workspace', 'tab-1')]);
+
+      const { rerender } = render(<TabCacheBridges />);
+
+      await waitFor(() => {
+        expect(mocks.updateTabCache).toHaveBeenLastCalledWith(
+          'tab-1',
+          expect.objectContaining({ title: 'Workspace' }),
+        );
+      });
+
+      mocks.updateTabCache.mockClear();
+      mocks.setTabs([tab('/agent/a1', 'tab-1')]);
+      rerender(<TabCacheBridges />);
+
+      await waitFor(() => {
+        expect(mocks.updateTabCache).toHaveBeenLastCalledWith(
+          'tab-1',
+          expect.objectContaining({ title: 'Agent a1 · Topic' }),
+        );
+      });
+
+      expect(consoleError.mock.calls.flat().join('\n')).not.toMatch(
+        /change in the order of Hooks|Rendered more hooks/,
       );
-    });
-
-    mocks.updateTabCache.mockClear();
-    act(() => {
-      mocks.setTabs([stableTab('workspace-tab', '/acme/agent/a1')]);
-    });
-
-    await waitFor(() => {
-      expect(mocks.updateTabCache).toHaveBeenCalledWith(
-        'workspace-tab',
-        expect.objectContaining({ title: 'Agent Detail' }),
-      );
-    });
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });

--- a/src/features/Electron/titlebar/TabBar/TabCacheBridges.tsx
+++ b/src/features/Electron/titlebar/TabBar/TabCacheBridges.tsx
@@ -4,11 +4,11 @@ import { memo, useCallback } from 'react';
 
 import DynamicMetaRunner from '@/features/RouteMeta/DynamicMetaRunner';
 import { desktopRoutes } from '@/spa/router/desktopRouter.config';
-import { type DynamicRouteMeta } from '@/spa/router/routeMeta';
+import type { DynamicRouteMeta } from '@/spa/router/routeMeta';
 import { useElectronStore } from '@/store/electron';
 
 import { matchRouteMeta } from './resolveRouteMeta';
-import { type TabItem } from './types';
+import type { TabItem } from './types';
 
 interface TabCacheBridgeProps {
   tab: TabItem;
@@ -17,7 +17,7 @@ interface TabCacheBridgeProps {
 const TabCacheBridge = memo<TabCacheBridgeProps>(({ tab }) => {
   const updateTabCache = useElectronStore((s) => s.updateTabCache);
   const matched = matchRouteMeta(desktopRoutes, tab.url);
-  const useDynamicMeta = matched.meta?.useDynamicMeta;
+  const DynamicMeta = matched.meta?.DynamicMeta;
 
   const handleResolve = useCallback(
     (resolved: DynamicRouteMeta) => {
@@ -26,13 +26,13 @@ const TabCacheBridge = memo<TabCacheBridgeProps>(({ tab }) => {
     [tab.id, updateTabCache],
   );
 
-  if (!useDynamicMeta) return null;
+  if (!DynamicMeta) return null;
 
   return (
     <DynamicMetaRunner
       key={tab.url}
+      DynamicMeta={DynamicMeta}
       params={matched.params}
-      useDynamicMeta={useDynamicMeta}
       onResolve={handleResolve}
     />
   );

--- a/src/features/Pages/routeMeta.ts
+++ b/src/features/Pages/routeMeta.ts
@@ -1,24 +1,33 @@
 import { FilePenIcon } from 'lucide-react';
 
+import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
 import { matchesRouteWorkspace, useRouteWorkspaceId } from '@/features/RouteMeta/workspaceScope';
-import { type DynamicRouteMeta, routeMeta } from '@/spa/router/routeMeta';
+import type { DynamicRouteMetaProps } from '@/spa/router/routeMeta';
+import { routeMeta } from '@/spa/router/routeMeta';
 import { usePageStore } from '@/store/page';
 import { listSelectors } from '@/store/page/slices/list/selectors';
 import { getIdFromIdentifier } from '@/utils/identifier';
 
+const PageDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
+  const routeWorkspaceId = useRouteWorkspaceId(params);
+  const pageId = params.id ? getIdFromIdentifier(params.id, 'docs') : '';
+  const document = usePageStore((s) => {
+    const item = listSelectors.getDocumentById(pageId)(s);
+    return matchesRouteWorkspace(item?.workspaceId, routeWorkspaceId) ? item : undefined;
+  });
+
+  usePublishDynamicRouteMeta(
+    {
+      title: document?.title || undefined,
+    },
+    onResolve,
+  );
+
+  return null;
+};
+
 export const pageRouteMeta = routeMeta({
+  DynamicMeta: PageDynamicMeta,
   icon: FilePenIcon,
   titleKey: 'navigation.page',
-  useDynamicMeta: (params): DynamicRouteMeta => {
-    const routeWorkspaceId = useRouteWorkspaceId(params);
-    const pageId = params.id ? getIdFromIdentifier(params.id, 'docs') : '';
-    const document = usePageStore((s) => {
-      const item = listSelectors.getDocumentById(pageId)(s);
-      return matchesRouteWorkspace(item?.workspaceId, routeWorkspaceId) ? item : undefined;
-    });
-
-    return {
-      title: document?.title || undefined,
-    };
-  },
 });

--- a/src/features/RouteMeta/DynamicMetaRunner.tsx
+++ b/src/features/RouteMeta/DynamicMetaRunner.tsx
@@ -4,46 +4,25 @@ import debug from 'debug';
 import { memo } from 'react';
 
 import { SafeBoundary } from '@/components/ErrorBoundary';
-import {
-  type DynamicRouteMeta,
-  type DynamicRouteMetaProps,
-  type RouteMeta,
-  type RouteMetaParams,
-} from '@/spa/router/routeMeta';
-
-import { usePublishDynamicRouteMeta } from './usePublishDynamicRouteMeta';
+import { type DynamicRouteMetaProps, type RouteMeta } from '@/spa/router/routeMeta';
 
 const log = debug('lobe-client:route-meta');
 
-interface DynamicMetaRunnerProps {
-  DynamicMeta?: RouteMeta['DynamicMeta'];
-  onResolve: (meta: DynamicRouteMeta) => void;
-  params: RouteMetaParams;
+interface DynamicMetaRunnerProps extends DynamicRouteMetaProps {
+  DynamicMeta: NonNullable<RouteMeta['DynamicMeta']>;
 }
 
-const EmptyDynamicMeta = memo<DynamicRouteMetaProps>(({ onResolve }) => {
-  usePublishDynamicRouteMeta({}, onResolve);
+const DynamicMetaRunner = memo<DynamicMetaRunnerProps>(({ DynamicMeta, onResolve, params }) => (
+  <SafeBoundary
+    onError={(error) => {
+      log('DynamicMeta threw, falling back to static meta: %O', error);
+      onResolve({});
+    }}
+  >
+    <DynamicMeta params={params} onResolve={onResolve} />
+  </SafeBoundary>
+));
 
-  return null;
-});
-
-EmptyDynamicMeta.displayName = 'EmptyDynamicMeta';
-
-const DynamicMetaRunner = memo<DynamicMetaRunnerProps>(({ DynamicMeta, onResolve, params }) => {
-  const MetaComponent = DynamicMeta ?? EmptyDynamicMeta;
-
-  return (
-    <SafeBoundary
-      onError={(error) => {
-        log('DynamicMeta threw, falling back to static meta: %O', error);
-        onResolve({});
-      }}
-    >
-      <MetaComponent params={params} onResolve={onResolve} />
-    </SafeBoundary>
-  );
-});
-
-DynamicMetaRunner.displayName = 'DynamicMetaRunnerBoundary';
+DynamicMetaRunner.displayName = 'DynamicMetaRunner';
 
 export default DynamicMetaRunner;

--- a/src/features/RouteMeta/DynamicMetaRunner.tsx
+++ b/src/features/RouteMeta/DynamicMetaRunner.tsx
@@ -1,45 +1,48 @@
 'use client';
 
 import debug from 'debug';
-import { memo, useEffect } from 'react';
+import { memo } from 'react';
 
 import { SafeBoundary } from '@/components/ErrorBoundary';
 import {
   type DynamicRouteMeta,
+  type DynamicRouteMetaProps,
   type RouteMeta,
   type RouteMetaParams,
 } from '@/spa/router/routeMeta';
 
+import { usePublishDynamicRouteMeta } from './usePublishDynamicRouteMeta';
+
 const log = debug('lobe-client:route-meta');
 
 interface DynamicMetaRunnerProps {
+  DynamicMeta?: RouteMeta['DynamicMeta'];
   onResolve: (meta: DynamicRouteMeta) => void;
   params: RouteMetaParams;
-  useDynamicMeta?: RouteMeta['useDynamicMeta'];
 }
 
-const Runner = memo<DynamicMetaRunnerProps>(({ useDynamicMeta, params, onResolve }) => {
-  const { avatar, backgroundColor, title } = useDynamicMeta?.(params) ?? {};
-
-  useEffect(() => {
-    onResolve({ avatar, backgroundColor, title });
-  }, [avatar, backgroundColor, title, onResolve]);
+const EmptyDynamicMeta = memo<DynamicRouteMetaProps>(({ onResolve }) => {
+  usePublishDynamicRouteMeta({}, onResolve);
 
   return null;
 });
 
-Runner.displayName = 'DynamicMetaRunner';
+EmptyDynamicMeta.displayName = 'EmptyDynamicMeta';
 
-const DynamicMetaRunner = memo<DynamicMetaRunnerProps>((props) => (
-  <SafeBoundary
-    onError={(error) => {
-      log('useDynamicMeta threw, falling back to static meta: %O', error);
-      props.onResolve({});
-    }}
-  >
-    <Runner {...props} />
-  </SafeBoundary>
-));
+const DynamicMetaRunner = memo<DynamicMetaRunnerProps>(({ DynamicMeta, onResolve, params }) => {
+  const MetaComponent = DynamicMeta ?? EmptyDynamicMeta;
+
+  return (
+    <SafeBoundary
+      onError={(error) => {
+        log('DynamicMeta threw, falling back to static meta: %O', error);
+        onResolve({});
+      }}
+    >
+      <MetaComponent params={params} onResolve={onResolve} />
+    </SafeBoundary>
+  );
+});
 
 DynamicMetaRunner.displayName = 'DynamicMetaRunnerBoundary';
 

--- a/src/features/RouteMeta/RouteMetaBridge.test.tsx
+++ b/src/features/RouteMeta/RouteMetaBridge.test.tsx
@@ -226,4 +226,23 @@ describe('RouteMetaBridge', () => {
       );
     });
   });
+
+  it('publishes empty dynamic meta for a static route without DynamicMeta', async () => {
+    mocks.setMatches([
+      {
+        data: undefined,
+        handle: { meta: { titleKey: 'navigation.settings' } },
+        id: 'routes/settings',
+        params: {},
+        pathname: '/settings',
+      },
+    ]);
+
+    render(<RouteMetaBridge />);
+
+    await waitFor(() => {
+      expect(document.title).toBe(`translated:navigation.settings · ${BRANDING_NAME}`);
+      expect(mocks.setCurrentRouteMeta).toHaveBeenLastCalledWith({}, '/settings');
+    });
+  });
 });

--- a/src/features/RouteMeta/RouteMetaBridge.test.tsx
+++ b/src/features/RouteMeta/RouteMetaBridge.test.tsx
@@ -3,7 +3,10 @@ import { act, cleanup, render, waitFor } from '@testing-library/react';
 import type * as ReactModule from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import type { DynamicRouteMeta, DynamicRouteMetaProps } from '@/spa/router/routeMeta';
+
 import RouteMetaBridge from './RouteMetaBridge';
+import { usePublishDynamicRouteMeta } from './usePublishDynamicRouteMeta';
 
 const mocks = vi.hoisted(() => {
   interface MockMatch {
@@ -39,6 +42,18 @@ const mocks = vi.hoisted(() => {
   };
 });
 
+const createDynamicMeta = (
+  resolve: (params: Record<string, string | undefined>) => DynamicRouteMeta,
+) => {
+  const TestDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
+    usePublishDynamicRouteMeta(resolve(params), onResolve);
+
+    return null;
+  };
+
+  return TestDynamicMeta;
+};
+
 vi.mock('@/const/version', () => ({
   isDesktop: true,
 }));
@@ -67,7 +82,10 @@ vi.mock('react-router', async () => {
 });
 
 describe('RouteMetaBridge', () => {
-  const resolveDynamicMeta = () => ({ title: 'Chat A' });
+  const ChatDynamicMeta = createDynamicMeta(() => ({ title: 'Chat A' }));
+  const TopicDynamicMeta = createDynamicMeta((params) => ({
+    title: `Topic ${params.topicId ?? params.topic}`,
+  }));
 
   afterEach(() => {
     cleanup();
@@ -82,8 +100,8 @@ describe('RouteMetaBridge', () => {
         data: undefined,
         handle: {
           meta: {
+            DynamicMeta: ChatDynamicMeta,
             titleKey: 'navigation.chat',
-            useDynamicMeta: resolveDynamicMeta,
           },
         },
         id: 'routes/agent',
@@ -145,10 +163,8 @@ describe('RouteMetaBridge', () => {
         data: undefined,
         handle: {
           meta: {
+            DynamicMeta: TopicDynamicMeta,
             titleKey: 'navigation.chat',
-            useDynamicMeta: (params: Record<string, string | undefined>) => ({
-              title: `Topic ${params.topicId}`,
-            }),
           },
         },
         id: 'routes/agent',
@@ -185,10 +201,8 @@ describe('RouteMetaBridge', () => {
         data: undefined,
         handle: {
           meta: {
+            DynamicMeta: TopicDynamicMeta,
             titleKey: 'navigation.groupChat',
-            useDynamicMeta: (params: Record<string, string | undefined>) => ({
-              title: `Topic ${params.topic}`,
-            }),
           },
         },
         id: 'routes/group',

--- a/src/features/RouteMeta/RouteMetaBridge.tsx
+++ b/src/features/RouteMeta/RouteMetaBridge.tsx
@@ -52,6 +52,7 @@ const RouteMetaBridge = memo(() => {
   const matched = useMatchedRouteMeta();
   const currentUrl = location.pathname + location.search;
   const matchedRouteId = matched?.routeId ?? null;
+  const DynamicMeta = matched?.meta.DynamicMeta;
   const [dynamic, setDynamic] = useState<DynamicRouteMetaState>({ meta: {}, routeId: null });
 
   const publishRouteMeta = useCallback(
@@ -79,23 +80,24 @@ const RouteMetaBridge = memo(() => {
   const title = matched ? currentDynamic.title || (titleKey ? translate(titleKey) : '') : '';
 
   useEffect(() => {
-    if (matchedRouteId) return;
+    if (DynamicMeta) return;
 
-    setDynamic({ meta: {}, routeId: null });
+    setDynamic({ meta: {}, routeId: matchedRouteId });
     if (isDesktop) {
-      setCurrentRouteMeta(null);
+      if (matchedRouteId) publishRouteMeta({}, currentUrl);
+      else setCurrentRouteMeta(null);
     }
-  }, [matchedRouteId, publishRouteMeta, setCurrentRouteMeta]);
+  }, [DynamicMeta, matchedRouteId, currentUrl, publishRouteMeta, setCurrentRouteMeta]);
 
   useEffect(() => {
     document.title = title ? `${title} · ${BRANDING_NAME}` : BRANDING_NAME;
   }, [title]);
 
-  if (!matched) return null;
+  if (!matched || !DynamicMeta) return null;
 
   return (
     <DynamicMetaRunner
-      DynamicMeta={matched.meta.DynamicMeta}
+      DynamicMeta={DynamicMeta}
       key={matched.routeId}
       params={routeMetaParams}
       onResolve={handleResolve}

--- a/src/features/RouteMeta/RouteMetaBridge.tsx
+++ b/src/features/RouteMeta/RouteMetaBridge.tsx
@@ -95,9 +95,9 @@ const RouteMetaBridge = memo(() => {
 
   return (
     <DynamicMetaRunner
+      DynamicMeta={matched.meta.DynamicMeta}
       key={matched.routeId}
       params={routeMetaParams}
-      useDynamicMeta={matched.meta.useDynamicMeta}
       onResolve={handleResolve}
     />
   );

--- a/src/features/RouteMeta/mobileRouteMeta.ts
+++ b/src/features/RouteMeta/mobileRouteMeta.ts
@@ -1,20 +1,29 @@
 import { t } from 'i18next';
 import { Settings } from 'lucide-react';
 
+import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
+import type { DynamicRouteMetaProps } from '@/spa/router/routeMeta';
 import { routeMeta } from '@/spa/router/routeMeta';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 
-export const mobileAgentSettingsRouteMeta = routeMeta({
-  icon: Settings,
-  titleKey: 'navigation.chat',
-  useDynamicMeta: (params) => {
-    const meta = useAgentStore(agentSelectors.getAgentMetaById(params.aid ?? ''));
+const MobileAgentSettingsDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
+  const meta = useAgentStore(agentSelectors.getAgentMetaById(params.aid ?? ''));
 
-    return {
+  usePublishDynamicRouteMeta(
+    {
       title: meta.title
         ? t('header.sessionWithName', { name: meta.title, ns: 'setting' })
         : t('header.session', { ns: 'setting' }),
-    };
-  },
+    },
+    onResolve,
+  );
+
+  return null;
+};
+
+export const mobileAgentSettingsRouteMeta = routeMeta({
+  DynamicMeta: MobileAgentSettingsDynamicMeta,
+  icon: Settings,
+  titleKey: 'navigation.chat',
 });

--- a/src/features/RouteMeta/usePublishDynamicRouteMeta.ts
+++ b/src/features/RouteMeta/usePublishDynamicRouteMeta.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+import type { DynamicRouteMeta } from '@/spa/router/routeMeta';
+
+export const usePublishDynamicRouteMeta = (
+  { avatar, backgroundColor, title }: DynamicRouteMeta,
+  onResolve: (meta: DynamicRouteMeta) => void,
+) => {
+  useEffect(() => {
+    onResolve({ avatar, backgroundColor, title });
+  }, [avatar, backgroundColor, onResolve, title]);
+};

--- a/src/features/Verify/routeMeta.ts
+++ b/src/features/Verify/routeMeta.ts
@@ -1,8 +1,23 @@
 import { ClipboardCheckIcon } from 'lucide-react';
 
-import { type DynamicRouteMeta, routeMeta } from '@/spa/router/routeMeta';
+import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
+import type { DynamicRouteMetaProps } from '@/spa/router/routeMeta';
+import { routeMeta } from '@/spa/router/routeMeta';
 
 import { useVerifyReportBundle } from './hooks';
+
+const VerifyDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
+  const { data } = useVerifyReportBundle(params.runId ?? null);
+
+  usePublishDynamicRouteMeta(
+    {
+      title: data?.run.title || 'Verification report',
+    },
+    onResolve,
+  );
+
+  return null;
+};
 
 /**
  * Standalone verification-report route (`/verify/:runId`). Drives the browser
@@ -10,12 +25,6 @@ import { useVerifyReportBundle } from './hooks';
  * so we don't hand-roll `document.title`.
  */
 export const verifyRouteMeta = routeMeta({
+  DynamicMeta: VerifyDynamicMeta,
   icon: ClipboardCheckIcon,
-  useDynamicMeta: (params): DynamicRouteMeta => {
-    const { data } = useVerifyReportBundle(params.runId ?? null);
-
-    return {
-      title: data?.run.title || 'Verification report',
-    };
-  },
 });

--- a/src/features/Workspace/routeMeta.test.tsx
+++ b/src/features/Workspace/routeMeta.test.tsx
@@ -1,5 +1,5 @@
-import { renderHook } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { workspaceHomeRouteMeta } from './routeMeta';
 
@@ -12,41 +12,59 @@ vi.mock('@/business/client/hooks/useWorkspaces', () => ({
 }));
 
 describe('workspaceHomeRouteMeta', () => {
-  it('uses the workspace avatar and name for the workspace home tab', () => {
+  afterEach(() => {
+    cleanup();
+    mocks.workspaces = [];
+  });
+
+  const renderDynamicMeta = (workspaceSlug: string) => {
+    const DynamicMeta = workspaceHomeRouteMeta.DynamicMeta!;
+    const onResolve = vi.fn();
+
+    render(<DynamicMeta params={{ workspaceSlug }} onResolve={onResolve} />);
+
+    return onResolve;
+  };
+
+  it('uses the workspace avatar and name for the workspace home tab', async () => {
     mocks.workspaces = [
       { avatar: 'https://example.com/avatar.png', id: 'ws-1', name: 'Acme', slug: 'acme' },
     ];
 
-    const { result } = renderHook(() =>
-      workspaceHomeRouteMeta.useDynamicMeta?.({ workspaceSlug: 'acme' }),
-    );
+    const onResolve = renderDynamicMeta('acme');
 
-    expect(result.current).toEqual({
-      avatar: 'https://example.com/avatar.png',
-      title: 'Acme',
+    await waitFor(() => {
+      expect(onResolve).toHaveBeenLastCalledWith({
+        avatar: 'https://example.com/avatar.png',
+        backgroundColor: undefined,
+        title: 'Acme',
+      });
     });
   });
 
-  it('uses the workspace name as the avatar placeholder source when no avatar is set', () => {
+  it('uses the workspace name as the avatar placeholder source when no avatar is set', async () => {
     mocks.workspaces = [{ avatar: null, id: 'ws-1', name: 'Acme', slug: 'acme' }];
 
-    const { result } = renderHook(() =>
-      workspaceHomeRouteMeta.useDynamicMeta?.({ workspaceSlug: 'acme' }),
-    );
+    const onResolve = renderDynamicMeta('acme');
 
-    expect(result.current).toEqual({
-      avatar: 'Acme',
-      title: 'Acme',
+    await waitFor(() => {
+      expect(onResolve).toHaveBeenLastCalledWith({
+        avatar: 'Acme',
+        backgroundColor: undefined,
+        title: 'Acme',
+      });
     });
   });
 
-  it('returns no dynamic meta while the workspace slug is unresolved', () => {
-    mocks.workspaces = [];
+  it('returns no dynamic meta while the workspace slug is unresolved', async () => {
+    const onResolve = renderDynamicMeta('acme');
 
-    const { result } = renderHook(() =>
-      workspaceHomeRouteMeta.useDynamicMeta?.({ workspaceSlug: 'acme' }),
-    );
-
-    expect(result.current).toEqual({});
+    await waitFor(() => {
+      expect(onResolve).toHaveBeenLastCalledWith({
+        avatar: undefined,
+        backgroundColor: undefined,
+        title: undefined,
+      });
+    });
   });
 });

--- a/src/features/Workspace/routeMeta.ts
+++ b/src/features/Workspace/routeMeta.ts
@@ -1,19 +1,28 @@
 'use client';
 
 import { useWorkspaces } from '@/business/client/hooks/useWorkspaces';
-import { type DynamicRouteMeta, routeMeta } from '@/spa/router/routeMeta';
+import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
+import type { DynamicRouteMetaProps } from '@/spa/router/routeMeta';
+import { routeMeta } from '@/spa/router/routeMeta';
+
+const WorkspaceHomeDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
+  const workspaces = useWorkspaces();
+  const workspace = workspaces.find((item) => item.slug === params.workspaceSlug);
+
+  usePublishDynamicRouteMeta(
+    workspace
+      ? {
+          avatar: workspace.avatar || workspace.name,
+          title: workspace.name,
+        }
+      : {},
+    onResolve,
+  );
+
+  return null;
+};
 
 export const workspaceHomeRouteMeta = routeMeta({
+  DynamicMeta: WorkspaceHomeDynamicMeta,
   titleKey: 'navigation.home',
-  useDynamicMeta: (params): DynamicRouteMeta => {
-    const workspaces = useWorkspaces();
-    const workspace = workspaces.find((item) => item.slug === params.workspaceSlug);
-
-    if (!workspace) return {};
-
-    return {
-      avatar: workspace.avatar || workspace.name,
-      title: workspace.name,
-    };
-  },
 });

--- a/src/routes/(main)/agent/features/routeMeta.ts
+++ b/src/routes/(main)/agent/features/routeMeta.ts
@@ -1,7 +1,9 @@
 import { MessageSquare } from 'lucide-react';
 
+import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
 import { matchesRouteWorkspace, useRouteWorkspaceId } from '@/features/RouteMeta/workspaceScope';
-import { type DynamicRouteMeta, routeMeta } from '@/spa/router/routeMeta';
+import type { DynamicRouteMetaProps } from '@/spa/router/routeMeta';
+import { routeMeta } from '@/spa/router/routeMeta';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
@@ -21,27 +23,34 @@ const useTopicTitle = (
     return topic?.title || undefined;
   });
 
-export const agentRouteMeta = routeMeta({
-  icon: MessageSquare,
-  titleKey: 'navigation.chat',
-  useDynamicMeta: (params): DynamicRouteMeta => {
-    const routeWorkspaceId = useRouteWorkspaceId(params);
-    const meta = useAgentStore((s) => {
-      const agentId = params.aid ?? '';
-      const agent = s.agentMap[agentId];
+const AgentDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
+  const routeWorkspaceId = useRouteWorkspaceId(params);
+  const meta = useAgentStore((s) => {
+    const agentId = params.aid ?? '';
+    const agent = s.agentMap[agentId];
 
-      if (!matchesRouteWorkspace(agent?.workspaceId, routeWorkspaceId)) return {};
+    if (!matchesRouteWorkspace(agent?.workspaceId, routeWorkspaceId)) return {};
 
-      return agentSelectors.getAgentMetaById(agentId)(s);
-    });
-    const topicTitle = useTopicTitle(params.aid, params.topicId ?? params.topic, routeWorkspaceId);
-    const hasMeta = Object.keys(meta).length > 0;
-    const agentTitle = hasMeta ? meta.title : undefined;
+    return agentSelectors.getAgentMetaById(agentId)(s);
+  });
+  const topicTitle = useTopicTitle(params.aid, params.topicId ?? params.topic, routeWorkspaceId);
+  const hasMeta = Object.keys(meta).length > 0;
+  const agentTitle = hasMeta ? meta.title : undefined;
 
-    return {
+  usePublishDynamicRouteMeta(
+    {
       avatar: meta.avatar,
       backgroundColor: meta.backgroundColor,
       title: [topicTitle, agentTitle].filter(Boolean).join(' · ') || undefined,
-    };
-  },
+    },
+    onResolve,
+  );
+
+  return null;
+};
+
+export const agentRouteMeta = routeMeta({
+  DynamicMeta: AgentDynamicMeta,
+  icon: MessageSquare,
+  titleKey: 'navigation.chat',
 });

--- a/src/routes/(main)/group/features/routeMeta.ts
+++ b/src/routes/(main)/group/features/routeMeta.ts
@@ -1,7 +1,9 @@
 import { Users } from 'lucide-react';
 
+import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
 import { matchesRouteWorkspace, useRouteWorkspaceId } from '@/features/RouteMeta/workspaceScope';
-import { type DynamicRouteMeta, routeMeta } from '@/spa/router/routeMeta';
+import type { DynamicRouteMetaProps } from '@/spa/router/routeMeta';
+import { routeMeta } from '@/spa/router/routeMeta';
 import { useChatStore } from '@/store/chat';
 import { topicMapKey } from '@/store/chat/utils/topicMapKey';
 import { useSessionStore } from '@/store/session';
@@ -24,19 +26,26 @@ const useTopicTitle = (
     return topic?.title || undefined;
   });
 
+const GroupDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
+  const routeWorkspaceId = useRouteWorkspaceId(params);
+  const group = useSessionStore((s) => {
+    const item = sessionGroupSelectors.getGroupById(params.gid ?? '')(s);
+    return matchesRouteWorkspace(getWorkspaceId(item), routeWorkspaceId) ? item : undefined;
+  });
+  const topicTitle = useTopicTitle(params.gid, params.topic, routeWorkspaceId);
+
+  usePublishDynamicRouteMeta(
+    {
+      title: topicTitle || group?.name || undefined,
+    },
+    onResolve,
+  );
+
+  return null;
+};
+
 export const groupRouteMeta = routeMeta({
+  DynamicMeta: GroupDynamicMeta,
   icon: Users,
   titleKey: 'navigation.groupChat',
-  useDynamicMeta: (params): DynamicRouteMeta => {
-    const routeWorkspaceId = useRouteWorkspaceId(params);
-    const group = useSessionStore((s) => {
-      const item = sessionGroupSelectors.getGroupById(params.gid ?? '')(s);
-      return matchesRouteWorkspace(getWorkspaceId(item), routeWorkspaceId) ? item : undefined;
-    });
-    const topicTitle = useTopicTitle(params.gid, params.topic, routeWorkspaceId);
-
-    return {
-      title: topicTitle || group?.name || undefined,
-    };
-  },
 });

--- a/src/routes/(main)/settings/features/routeMeta.ts
+++ b/src/routes/(main)/settings/features/routeMeta.ts
@@ -1,25 +1,30 @@
 import { Settings } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
-import { type DynamicRouteMeta, routeMeta } from '@/spa/router/routeMeta';
+import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
+import type { DynamicRouteMetaProps } from '@/spa/router/routeMeta';
+import { routeMeta } from '@/spa/router/routeMeta';
 import { SettingsTabs } from '@/store/global/initialState';
 
 import { useCategory } from '../hooks/useCategory';
 
+const SettingsDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
+  const { t: tAuth } = useTranslation('auth');
+  const groups = useCategory();
+  const activeTab = (params.tab as SettingsTabs) || SettingsTabs.Profile;
+
+  const label =
+    activeTab === SettingsTabs.Profile
+      ? tAuth('tab.profile')
+      : groups.flatMap((group) => group.items).find((item) => item.key === activeTab)?.label;
+
+  usePublishDynamicRouteMeta({ title: label || undefined }, onResolve);
+
+  return null;
+};
+
 export const settingsRouteMeta = routeMeta({
+  DynamicMeta: SettingsDynamicMeta,
   icon: Settings,
   titleKey: 'navigation.settings',
-  useDynamicMeta: (params): DynamicRouteMeta => {
-    const { t: tAuth } = useTranslation('auth');
-    const groups = useCategory();
-    const activeTab = (params.tab as SettingsTabs) || SettingsTabs.Profile;
-
-    if (activeTab === SettingsTabs.Profile) return { title: tAuth('tab.profile') };
-
-    const label = groups
-      .flatMap((group) => group.items)
-      .find((item) => item.key === activeTab)?.label;
-
-    return { title: label || undefined };
-  },
 });

--- a/src/routes/share/t/[id]/routeMeta.ts
+++ b/src/routes/share/t/[id]/routeMeta.ts
@@ -1,23 +1,32 @@
 import { MessageSquare } from 'lucide-react';
 import useSWR from 'swr';
 
+import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
 import { shareKeys } from '@/libs/swr/keys';
 import { lambdaClient } from '@/libs/trpc/client';
+import type { DynamicRouteMetaProps } from '@/spa/router/routeMeta';
 import { routeMeta } from '@/spa/router/routeMeta';
 
+const ShareTopicDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
+  const shareId = params.id;
+  const { data } = useSWR(
+    shareId ? shareKeys.topic(shareId) : null,
+    () => lambdaClient.share.getSharedTopic.query({ shareId: shareId! }),
+    { revalidateOnFocus: false },
+  );
+
+  usePublishDynamicRouteMeta(
+    {
+      title: data?.title || undefined,
+    },
+    onResolve,
+  );
+
+  return null;
+};
+
 export const shareTopicRouteMeta = routeMeta({
+  DynamicMeta: ShareTopicDynamicMeta,
   icon: MessageSquare,
   titleKey: 'navigation.chat',
-  useDynamicMeta: (params) => {
-    const shareId = params.id;
-    const { data } = useSWR(
-      shareId ? shareKeys.topic(shareId) : null,
-      () => lambdaClient.share.getSharedTopic.query({ shareId: shareId! }),
-      { revalidateOnFocus: false },
-    );
-
-    return {
-      title: data?.title || undefined,
-    };
-  },
 });

--- a/src/spa/router/routeMeta.ts
+++ b/src/spa/router/routeMeta.ts
@@ -1,4 +1,5 @@
-import { type LucideIcon } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { ComponentType } from 'react';
 
 export interface StaticRouteMeta {
   icon?: LucideIcon;
@@ -13,8 +14,13 @@ export interface DynamicRouteMeta {
 
 export type RouteMetaParams = Record<string, string | undefined>;
 
+export interface DynamicRouteMetaProps {
+  onResolve: (meta: DynamicRouteMeta) => void;
+  params: RouteMetaParams;
+}
+
 export interface RouteMeta extends StaticRouteMeta {
-  useDynamicMeta?: (params: RouteMetaParams) => DynamicRouteMeta;
+  DynamicMeta?: ComponentType<DynamicRouteMetaProps>;
 }
 
 export interface RouteHandle {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No matching open issue -->

#### 🔀 Description of Change

Dynamic route meta was previously produced by calling a `useDynamicMeta(params)` hook imperatively inside a runner component. Because each route segment supplies its own `useDynamicMeta`, the hook identity changed across route transitions, risking React rules-of-hooks violations (hook count/order changing between renders) and making error boundaries hard to reason about.

This converts the contract from a hook into a component:

- `RouteMeta.useDynamicMeta` → `RouteMeta.DynamicMeta` (a `ComponentType<DynamicRouteMetaProps>`).
- Each route's `routeMeta` now exports a `DynamicMeta` component that calls its hooks internally and publishes the resolved meta via the new `usePublishDynamicRouteMeta(meta, onResolve)` helper.
- `DynamicMetaRunner` renders the supplied `DynamicMeta` component (falling back to an `EmptyDynamicMeta`) inside `SafeBoundary`, so a throwing meta component cleanly falls back to static meta.

All route meta definitions (Agent, AgentDocumentPage, AgentTasks, Pages, Verify, Workspace, group, settings, share, mobile) are migrated to the new component shape; tests updated accordingly.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Verified tab title / avatar / background updates correctly across route transitions in both desktop tabs and mobile, including the fallback-to-static path when a dynamic meta component throws.

#### 📝 Additional Information

Internal refactor of the route-meta contract — no user-facing API change.