### PR TITLE
✨ feat(verify): feed builder-captured evidence to the agent verifier

### DIFF
--- a/apps/server/src/services/verify/__tests__/agentVerifier.test.ts
+++ b/apps/server/src/services/verify/__tests__/agentVerifier.test.ts
@@ -145,4 +145,30 @@ describe('createVerifierAgentRunner', () => {
 
     expect(execParams().prompt).not.toContain('## Captured evidence');
   });
+
+  it('attaches file-backed evidence to the verifier run so it can see the artifact', async () => {
+    getBuiltinAgentMock.mockResolvedValue({ id: 'builtin-verify' });
+
+    const runner = createVerifierAgentRunner({ ...baseParams })!;
+    await runner({
+      ...runnerArgs,
+      evidence: [
+        { description: 'toolbar', fileId: 'file-shot-1', type: 'screenshot' },
+        { content: 'inline only', type: 'dom_snapshot' }, // no fileId
+        { description: 'demo', fileId: 'file-vid-1', type: 'video' },
+      ],
+    });
+
+    // Only the file-backed artifacts are forwarded to execAgent (inline-text has none).
+    expect(execParams().fileIds).toEqual(['file-shot-1', 'file-vid-1']);
+  });
+
+  it('does not pass fileIds when no evidence is file-backed', async () => {
+    getBuiltinAgentMock.mockResolvedValue({ id: 'builtin-verify' });
+
+    const runner = createVerifierAgentRunner({ ...baseParams })!;
+    await runner({ ...runnerArgs, evidence: [{ content: 'text', type: 'text' }] });
+
+    expect(execParams().fileIds).toBeUndefined();
+  });
 });

--- a/apps/server/src/services/verify/__tests__/agentVerifier.test.ts
+++ b/apps/server/src/services/verify/__tests__/agentVerifier.test.ts
@@ -117,4 +117,32 @@ describe('createVerifierAgentRunner', () => {
     expect(existsByIdMock).not.toHaveBeenCalled();
     expect(execParams().slug).toBe(BUILTIN_AGENT_SLUGS.verifyAgent);
   });
+
+  it('injects the builder-captured evidence into the verifier prompt (LOBE-10638)', async () => {
+    getBuiltinAgentMock.mockResolvedValue({ id: 'builtin-verify' });
+
+    const runner = createVerifierAgentRunner({ ...baseParams })!;
+    await runner({
+      ...runnerArgs,
+      evidence: [
+        { description: 'toolbar screenshot', type: 'screenshot' },
+        { content: 'aria-label="Send"', description: 'DOM', type: 'dom_snapshot' },
+      ],
+    });
+
+    const prompt: string = execParams().prompt;
+    expect(prompt).toContain('## Captured evidence');
+    expect(prompt).toContain('toolbar screenshot');
+    expect(prompt).toContain('[artifact captured]'); // screenshot referenced by presence
+    expect(prompt).toContain('aria-label="Send"'); // inline dom text quoted
+  });
+
+  it('omits the captured-evidence section when no evidence was provided', async () => {
+    getBuiltinAgentMock.mockResolvedValue({ id: 'builtin-verify' });
+
+    const runner = createVerifierAgentRunner({ ...baseParams })!;
+    await runner(runnerArgs);
+
+    expect(execParams().prompt).not.toContain('## Captured evidence');
+  });
 });

--- a/apps/server/src/services/verify/agentVerifier.ts
+++ b/apps/server/src/services/verify/agentVerifier.ts
@@ -131,6 +131,13 @@ export const createVerifierAgentRunner = (params: {
       return null;
     }
 
+    // Attach the builder-captured file artifacts (screenshots / videos / large
+    // text) so a multimodal verifier can SEE them — the prompt only references
+    // them by presence + caption, which is blind for visual checks (LOBE-10638).
+    const evidenceFileIds = (evidence ?? [])
+      .map((e) => e.fileId)
+      .filter((id): id is string => Boolean(id));
+
     // Dynamic import breaks the static cycle: aiAgent → agentRuntime completion
     // → verify lifecycle → this runner → aiAgent.
     const { AiAgentService } = await import('@/server/services/aiAgent');
@@ -139,6 +146,7 @@ export const createVerifierAgentRunner = (params: {
       ...(extraPluginIds.length ? { additionalPluginIds: extraPluginIds } : {}),
       appContext: { threadId: thread.id, topicId },
       autoStart: true,
+      ...(evidenceFileIds.length ? { fileIds: evidenceFileIds } : {}),
       // Only the builtin fallback inherits the parent run's model/provider; a
       // pinned agent keeps its own (critical for heterogeneous runtimes).
       ...(inheritModel && model ? { model } : {}),

--- a/apps/server/src/services/verify/agentVerifier.ts
+++ b/apps/server/src/services/verify/agentVerifier.ts
@@ -10,6 +10,7 @@ import { ThreadModel } from '@/database/models/thread';
 import type { LobeChatDatabase } from '@/database/type';
 
 import type { VerifierAgentRunner } from './executor';
+import { describeEvidence, type JudgeEvidence } from './prompts';
 
 const log = debug('lobe-server:verify-agent-verifier');
 
@@ -17,21 +18,30 @@ const log = debug('lobe-server:verify-agent-verifier');
  * Build the instruction for a verifier sub-agent investigating one check. The
  * sub-agent reports its verdict by calling the `submitVerifyResult` tool with the
  * `checkItemId` injected here — it does not write to the DB directly.
+ *
+ * `evidence` is what the builder self-captured during the run (LOBE-10638): the
+ * verifier judges against the run goal AND this evidence — it's the verifier's
+ * primary Data, not a competing verdict.
  */
 export const buildVerifierPrompt = (params: {
   checkItem: VerifyCheckItem;
   deliverable: string;
+  evidence?: JudgeEvidence[];
   goal: string;
   instruction?: string;
 }): string => {
-  const { checkItem, deliverable, goal, instruction } = params;
+  const { checkItem, deliverable, evidence, goal, instruction } = params;
+  const capturedEvidence = describeEvidence(evidence);
   return [
     `## Check to verify\ncheckItemId: ${checkItem.id}\nTitle: ${checkItem.title}`,
     checkItem.description ? `Summary: ${checkItem.description}` : '',
     instruction ? `\n## Judging instruction\n${instruction}` : '',
     `\n## Run goal\n${goal}`,
     deliverable ? `\n## Deliverable / final output\n${deliverable}` : '',
-    `\n## Your task\nInvestigate whether the deliverable satisfies this check, following the judging instruction. Gather concrete evidence. When done, call \`submitVerifyResult\` exactly once with checkItemId="${checkItem.id}" and your verdict (passed / failed / uncertain) plus evidence and reasoning.`,
+    capturedEvidence
+      ? `\n## Captured evidence (builder self-evidence — primary Data, weight above prose)${capturedEvidence}`
+      : '',
+    `\n## Your task\nInvestigate whether the deliverable satisfies this check, judging against the run goal and the judging instruction. Weight the captured evidence above as primary Data; gather more yourself only where it's missing or insufficient. When done, call \`submitVerifyResult\` exactly once with checkItemId="${checkItem.id}" and your verdict (passed / failed / uncertain) plus evidence and reasoning.`,
   ]
     .filter(Boolean)
     .join('\n');
@@ -69,7 +79,7 @@ export const createVerifierAgentRunner = (params: {
     params;
   if (!topicId) return undefined;
 
-  return async ({ checkItem, goal, operationId }) => {
+  return async ({ checkItem, evidence, goal, operationId }) => {
     // The detailed instruction is the criterion's rule body, stored in a document.
     const instruction = checkItem.documentId
       ? ((await new DocumentModel(db, userId, workspaceId).findById(checkItem.documentId))
@@ -133,7 +143,7 @@ export const createVerifierAgentRunner = (params: {
       // pinned agent keeps its own (critical for heterogeneous runtimes).
       ...(inheritModel && model ? { model } : {}),
       parentOperationId: operationId,
-      prompt: buildVerifierPrompt({ checkItem, deliverable, goal, instruction }),
+      prompt: buildVerifierPrompt({ checkItem, deliverable, evidence, goal, instruction }),
       ...(inheritModel && provider ? { provider } : {}),
       ...agentRef,
       userInterventionConfig: { approvalMode: 'headless' },

--- a/apps/server/src/services/verify/executor.ts
+++ b/apps/server/src/services/verify/executor.ts
@@ -41,6 +41,8 @@ const log = debug('lobe-server:verify-executor');
 export interface VerifierAgentRunner {
   (args: {
     checkItem: VerifyCheckItem;
+    /** Evidence the builder captured for this item — input to the verifier's judgment. */
+    evidence?: JudgeEvidence[];
     goal: string;
     operationId: string;
   }): Promise<{ verifierOperationId: string } | null>;
@@ -150,7 +152,9 @@ export class VerifyExecutorService {
     await Promise.all([
       this.runProgramItems(verifyRunId, programItems),
       this.runLlmItems(params, verifyRunId, llmItems, evidenceByItem),
-      ...agentItems.map((item) => this.runAgentItem(params, verifyRunId, item)),
+      ...agentItems.map((item) =>
+        this.runAgentItem(params, verifyRunId, item, evidenceByItem.get(item.id) ?? []),
+      ),
     ]);
 
     await this.statusService.recompute(params.operationId);
@@ -235,6 +239,7 @@ export class VerifyExecutorService {
     params: ExecuteVerifyParams,
     verifyRunId: string,
     item: VerifyCheckItem,
+    evidence: JudgeEvidence[],
   ): Promise<void> {
     if (!params.runVerifierAgent) {
       await this.resultModel.updateByCheckItem(verifyRunId, item.id, {
@@ -247,6 +252,7 @@ export class VerifyExecutorService {
     try {
       const spawned = await params.runVerifierAgent({
         checkItem: item,
+        evidence,
         goal: params.goal,
         operationId: params.operationId,
       });

--- a/apps/server/src/services/verify/executor.ts
+++ b/apps/server/src/services/verify/executor.ts
@@ -166,7 +166,14 @@ export class VerifyExecutorService {
     const byItem: EvidenceByItem = new Map();
     for (const row of rows) {
       const list = byItem.get(row.checkItemId) ?? [];
-      list.push({ content: row.content, description: row.description, type: row.type });
+      // Keep `fileId` so the agent verifier can attach the actual artifact (the
+      // LLM judge ignores it and renders text only).
+      list.push({
+        content: row.content,
+        description: row.description,
+        fileId: row.fileId,
+        type: row.type,
+      });
       byItem.set(row.checkItemId, list);
     }
     return byItem;

--- a/apps/server/src/services/verify/prompts.ts
+++ b/apps/server/src/services/verify/prompts.ts
@@ -52,6 +52,12 @@ export const buildPlanPrompt = ({
 export interface JudgeEvidence {
   content?: string | null;
   description?: string | null;
+  /**
+   * Stored artifact id (screenshot / video / large text). The text prompt only
+   * references it by presence + caption; the agent verifier attaches the actual
+   * file to its run via `execAgent({ fileIds })` so it can SEE the artifact.
+   */
+  fileId?: string | null;
   type: VerifyEvidenceType;
 }
 

--- a/apps/server/src/services/verify/prompts.ts
+++ b/apps/server/src/services/verify/prompts.ts
@@ -68,7 +68,7 @@ export interface JudgePromptInput {
   mode: 'single' | 'batch';
 }
 
-const describeEvidence = (evidence: JudgeEvidence[] | undefined): string => {
+export const describeEvidence = (evidence: JudgeEvidence[] | undefined): string => {
   if (!evidence?.length) return '';
   const lines = evidence.map((e) => {
     const caption = e.description ? ` — ${e.description}` : '';


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Closes LOBE-10638 · Part of LOBE-10642 / LOBE-10614

#### 🔀 Description of Change

The LLM judge already reads the run's captured evidence (#16130), but the **agent-type verifier did not**: `buildVerifierPrompt` only received `checkItem + deliverable + goal`, so an agent verifier — now the **holistic primary path** (LOBE-10755) — judged blind to the screenshots / DOM / text the builder self-captured, re-investigating from scratch and wasting that evidence.

This threads the per-item evidence through to the agent verifier so it judges against the run goal **and** the builder's self-evidence (evidence is the verifier's input, not a competing verdict — the builder still self-evidences, holistic included):

- `VerifyExecutorService.runAgentItem` passes `evidenceByItem.get(item.id)` into the runner.
- `VerifierAgentRunner` carries `evidence`; `buildVerifierPrompt` renders a `## Captured evidence` section (reusing the judge's `describeEvidence`, so formatting matches the LLM judge) and instructs the verifier to weight it as primary Data and only gather more where it's missing.

#### 🧪 How to Test

- [x] Tested locally (`bun run type-check` clean re: this diff; pre-existing `@lobehub/ui/base-ui` `Tabs` errors unrelated)
- [x] Added/updated tests
- [ ] No tests needed

New tests: the verifier prompt includes the captured evidence (screenshot referenced by presence, inline DOM text quoted) when provided, and omits the section when none. Full verify suite green (23).

#### 📝 Additional Information

Independent of #16255 (touches `executor` / `agentVerifier` / `prompts`, not the holistic-plan / bridge files) — reviewable on its own. Surfaced while locally verifying the holistic agent verify path: the builder self-evidences, but the verifier couldn't see it.