### PR TITLE
chore: clean up LOBE-XXX marker comments from source code (2026-06-25)

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
@@ -257,9 +257,8 @@ describe('execAgent', () => {
       expect(result.operationId).toBeDefined();
     });
 
-    // Regression: LOBE-10604 / LOBE-10627 — a group conversation that reaches
-    // execAgent without a pre-created topicId must persist groupId on BOTH the
-    // new topic AND the user/assistant messages. Otherwise:
+    // Regression: a group conversation that reaches execAgent without a pre-created
+    // topicId must persist groupId on BOTH the new topic AND the user/assistant messages. Otherwise:
     //   - the topic is group-less and never appears in the group sidebar
     //     (which queries `topics.groupId`), and
     //   - the messages are group-less, so reopening the topic returns an empty

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1183,7 +1183,7 @@ export class AiAgentService {
         // `topics.groupId`), so the conversation silently "disappears" from the
         // group. execGroupAgent normally pre-creates the topic, but any path
         // that reaches execAgent without a topicId (e.g. the async/queue run)
-        // must carry the groupId through too. (LOBE-10604 / LOBE-10627)
+        // must carry the groupId through too.
         groupId: appContext?.groupId,
         metadata,
         title:
@@ -1277,7 +1277,7 @@ export class AiAgentService {
           files: runAttachments.fileIds,
           // Group reads filter on messages.groupId (MessageModel.query group
           // branch), so a group turn must stamp groupId or the message never
-          // shows when the topic is reopened. (LOBE-10604 / LOBE-10627)
+          // shows when the topic is reopened.
           groupId: appContext?.groupId ?? undefined,
           metadata: requestTriggerMetadata,
           role: 'user',

--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -214,8 +214,8 @@ export class TaskLifecycleService {
       await this.taskModel.updateStatus(taskId, 'paused');
     }
 
-    // Bridge the finished task's handoff back to the creator conversation
-    // (LOBE-10625). Runs HERE — after all status transitions above — so the
+    // Bridge the finished task's handoff back to the creator conversation.
+    // Runs HERE — after all status transitions above — so the
     // bridge reads the settled task status. Doing it as a separate webhook
     // racing `on-topic-complete` could observe the pre-transition status and
     // silently drop the only callback for automation tasks that become terminal

--- a/apps/server/src/services/taskResultBridge/index.ts
+++ b/apps/server/src/services/taskResultBridge/index.ts
@@ -79,8 +79,8 @@ export interface DeliverTaskResultParams {
 }
 
 /**
- * Delivers a finished task's handoff back to the conversation that created it
- * (LOBE-10625). Fire-and-forget: appends a `role='taskCallback'` card into the
+ * Delivers a finished task's handoff back to the conversation that created it.
+ * Fire-and-forget: appends a `role='taskCallback'` card into the
  * creator topic and runs the creator agent off history so it reads the result
  * and continues — without impersonating a user turn.
  *

--- a/apps/server/src/services/toolExecution/serverRuntimes/task.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/task.ts
@@ -46,7 +46,7 @@ export interface TaskRuntimeDeps {
   assistantMessageId?: string;
   // Pointers to the conversation that invoked the createTask tool. Recorded into
   // `tasks.context.origin` so the task's handoff result can later be delivered
-  // back to this session (LOBE-10625). All optional — a task can be created
+  // back to this session. All optional — a task can be created
   // outside an agent turn (e.g. via the API).
   operationId?: string;
   scope?: string | null;
@@ -108,7 +108,7 @@ export const createTaskRuntime = (deps: TaskRuntimeDeps) => {
     if (!assigneeResult.success) return { content: assigneeResult.content, success: false };
 
     // Capture where this task was spawned from so the lifecycle can later
-    // bridge the handoff result back to the creator conversation (LOBE-10625).
+    // bridge the handoff result back to the creator conversation.
     // Only persist the pocket when we actually have a creator agent + topic;
     // tasks created outside an agent turn (e.g. via API) have no origin.
     const origin =

--- a/packages/context-engine/src/engine/messages/MessagesEngine.ts
+++ b/packages/context-engine/src/engine/messages/MessagesEngine.ts
@@ -413,7 +413,7 @@ export class MessagesEngine {
       // auto-repair failure feedback as a user turn for the repair run
       new VerifyMessageProcessor(),
       // Task-callback cards: surface a finished task's handoff as a user turn
-      // so the creator agent reads it and continues (LOBE-10625)
+      // so the creator agent reads it and continues
       new TaskCallbackMessageProcessor(),
       // Supervisor role restore
       new SupervisorRoleRestoreProcessor(),

--- a/packages/context-engine/src/processors/TaskCallbackMessage.ts
+++ b/packages/context-engine/src/processors/TaskCallbackMessage.ts
@@ -16,7 +16,7 @@ const log = debug('context-engine:processor:TaskCallbackMessageProcessor');
  *
  * `role='taskCallback'` messages are the result-bridge cards: when a task
  * dispatched from this conversation finishes, the lifecycle injects one carrying
- * the handoff summary (LOBE-10625). `taskCallback` is not a valid model role, so
+ * the handoff summary. `taskCallback` is not a valid model role, so
  * it can't reach the model as-is. We surface it as a `user` turn wrapped in a
  * `<task_result>` tag — so the creator agent reads it as the task reporting back
  * (not as human input) and continues the conversation off it.

--- a/packages/conversation-flow/src/__tests__/taskCallback.test.ts
+++ b/packages/conversation-flow/src/__tests__/taskCallback.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { parse } from '../parse';
 import type { Message } from '../types/shared';
 
-// A task-callback card injected by the result-bridge (LOBE-10625) must survive
+// A task-callback card injected by the result-bridge must survive
 // the display-flow transform as a standalone `role='taskCallback'` node so the
 // renderer can show it as a card — both as a leaf and mid-chain (when the
 // creator agent's continuation parents under it).

--- a/packages/model-runtime/src/core/contextBuilders/google.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.ts
@@ -446,7 +446,7 @@ export const sanitizeGeminiSchema = (schema: any): any => {
 
   // Recursively sanitize items (for array types). A node carrying `items` is an
   // array node; backfill a missing `type` so Gemini's predicate validator
-  // (`$type == Type.ARRAY`) accepts it. See LOBE-10066.
+  // (`$type == Type.ARRAY`) accepts it. See `normalizeToolJsonSchema`.
   if ('items' in sanitized) {
     sanitized.items = sanitizeGeminiSchema(sanitized.items);
     if (sanitized.type === undefined) sanitized.type = 'array';

--- a/packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.test.ts
@@ -15,7 +15,7 @@ describe('normalizeToolJsonSchema', () => {
     expect(normalizeToolJsonSchema('foo')).toBe('foo');
   });
 
-  // LOBE-10066: deepseek variant — array property with `items: true`
+  // deepseek variant — array property with `items: true` (boolean schema rejected by upstream validators)
   it('rewrites `items: true` to an empty object schema', () => {
     const result = normalizeToolJsonSchema({
       properties: {
@@ -28,7 +28,7 @@ describe('normalizeToolJsonSchema', () => {
     expect(result.properties.sourceIds.type).toBe('array');
   });
 
-  // LOBE-10066: gemini variant — array property carrying `items` but missing `type`
+  // gemini variant — array property carrying `items` but missing `type` (rejected by Gemini's proto validator)
   it('backfills `type: array` on a node that carries `items` without a type', () => {
     const result = normalizeToolJsonSchema({
       properties: {

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -133,8 +133,8 @@ describe('LobeOpenAICompatibleFactory', () => {
       expect(result).toBeInstanceOf(Response);
     });
 
-    // LOBE-10066: MCP tool schemas with `items: true` or array props missing
-    // `type` must be normalized before reaching the upstream validator.
+    // MCP tool schemas with `items: true` or array props missing `type`
+    // must be normalized before reaching the upstream validator.
     it('should normalize tool parameter schemas before sending to upstream', async () => {
       (instance['client'].chat.completions.create as Mock).mockResolvedValue(
         Promise.resolve(new ReadableStream()),

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -532,7 +532,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         // Normalize tool parameter schemas before they fan out to the
         // Chat-Completions / Responses paths. User MCP tools may emit boolean
         // sub-schemas (`items: true`) or array properties missing `type`, which
-        // upstream validators (OpenAI/DeepSeek, Gemini) reject. See LOBE-10066.
+        // upstream validators (OpenAI/DeepSeek, Gemini) reject.
         if (payload.tools) payload.tools = normalizeToolsParameters(payload.tools as any) as any;
 
         let processedPayload: any = payload;

--- a/packages/types/src/message/common/metadata.ts
+++ b/packages/types/src/message/common/metadata.ts
@@ -408,8 +408,8 @@ export interface MessageMetadata {
 
 /**
  * Pointer carried on a `role='taskCallback'` message — the result-bridge card
- * that reports a finished task's handoff back to its creator conversation
- * (LOBE-10625). The handoff summary itself lives in the message `content`; this
+ * that reports a finished task's handoff back to its creator conversation.
+ * The handoff summary itself lives in the message `content`; this
  * pointer drives the card header (identifier + outcome) and the jump link.
  */
 export interface MessageTaskCallback {

--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -139,7 +139,7 @@ export interface TaskSchedulerContext {
 
 // Pointer back to the agent conversation that spawned this task via the
 // `createTask` tool. Captured at creation so the task lifecycle can deliver the
-// handoff result back to that session once the task completes (LOBE-10625).
+// handoff result back to that session once the task completes.
 export interface TaskOriginContext {
   // The agent that invoked the createTask tool (the task's creator session).
   agentId?: string;

--- a/src/features/Conversation/Messages/TaskCallback/index.tsx
+++ b/src/features/Conversation/Messages/TaskCallback/index.tsx
@@ -50,7 +50,7 @@ const reasonMeta: Record<
 
 /**
  * Renders a `role='taskCallback'` message — the result-bridge card that reports
- * a finished task's handoff back into its creator conversation (LOBE-10625). The
+ * a finished task's handoff back into its creator conversation. The
  * task pointer (identifier / reason / taskId) is carried on
  * `metadata.taskCallback`; the handoff summary lives in the message content.
  * Renders as a standalone card (no avatar bubble), like the verify card.


### PR DESCRIPTION
## Summary

Automated scan and cleanup of `LOBE-XXX` marker comments from the source code.

## Changes

15 files changed — removed or replaced LOBE marker annotations with descriptive context:

### LOBE-10625 (12 occurrences) — Task handoff bridge
The task result bridge delivers a finished task's handoff back to its creator conversation. Removed the marker while keeping the descriptive comments intact.

| File | Change |
|---|---|
| `src/features/Conversation/Messages/TaskCallback/index.tsx` | Remove `(LOBE-10625)` |
| `packages/conversation-flow/src/__tests__/taskCallback.test.ts` | Remove `(LOBE-10625)` |
| `packages/types/src/message/common/metadata.ts` | Remove `(LOBE-10625)` |
| `packages/types/src/task/index.ts` | Remove `(LOBE-10625)` |
| `packages/context-engine/src/processors/TaskCallbackMessage.ts` | Remove `(LOBE-10625)` |
| `packages/context-engine/src/engine/messages/MessagesEngine.ts` | Remove `(LOBE-10625)` |
| `apps/server/src/services/taskResultBridge/index.ts` | Remove `(LOBE-10625)` |
| `apps/server/src/services/taskLifecycle/index.ts` | Remove `(LOBE-10625)` |
| `apps/server/src/services/toolExecution/serverRuntimes/task.ts` | Remove `(LOBE-10625)` x2 |

### LOBE-10066 (3 occurrences) — Tool schema normalization
MCP tool schemas with `items: true` or array props missing `type` are normalized before reaching providers. Replaced markers with descriptive context.

| File | Change |
|---|---|
| `packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.test.ts` | Replace `LOBE-10066:` with descriptive comment |
| `packages/model-runtime/src/core/contextBuilders/google.ts` | Replace `See LOBE-10066` with `See normalizeToolJsonSchema` |
| `packages/model-runtime/src/core/openaiCompatibleFactory/index.ts` | Remove `See LOBE-10066` |
| `packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts` | Remove `LOBE-10066:` prefix |

### LOBE-10604 / LOBE-10627 (3 occurrences) — Group topic groupId persistence
groupId must be persisted on topics and messages created via execAgent. Replaced markers with descriptive context.

| File | Change |
|---|---|
| `apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts` | Replace `LOBE-10604 / LOBE-10627` |
| `apps/server/src/services/aiAgent/index.ts` | Remove `(LOBE-10604 / LOBE-10627)` x2 |

## Preserved

Linear URL references in `@see` tags are intentionally preserved:
- `packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.ts` — `@see https://linear.app/lobehub/issue/LOBE-10066`
- `packages/model-runtime/src/core/contextBuilders/google.ts` — `See https://linear.app/lobehub/issue/LOBE-10066`

Auto-generated on 2026-06-25