### PR TITLE
♻️ refactor(group): align group topic route with agent `/:gid/:topicId`

### DIFF
--- a/apps/server/src/routers/lambda/recent.ts
+++ b/apps/server/src/routers/lambda/recent.ts
@@ -1,8 +1,8 @@
+import { AGENT_CHAT_TOPIC_URL, GROUP_CHAT_TOPIC_URL } from '@lobechat/const';
 import type { TaskStatus } from '@lobechat/types';
 import { z } from 'zod';
 
 import { wsCompatProcedure } from '@/business/server/trpc-middlewares/workspaceAuth';
-import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { RecentModel } from '@/database/models/recent';
 import { router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
@@ -44,7 +44,7 @@ export const recentRouter = router({
         switch (item.type) {
           case 'topic': {
             if (item.routeGroupId) {
-              routePath = `/group/${item.routeGroupId}?topic=${item.id}`;
+              routePath = GROUP_CHAT_TOPIC_URL(item.routeGroupId, item.id);
             } else if (item.routeId) {
               routePath = AGENT_CHAT_TOPIC_URL(item.routeId, item.id);
             } else {

--- a/apps/server/src/routers/lambda/recent.ts
+++ b/apps/server/src/routers/lambda/recent.ts
@@ -2,7 +2,7 @@ import type { TaskStatus } from '@lobechat/types';
 import { z } from 'zod';
 
 import { wsCompatProcedure } from '@/business/server/trpc-middlewares/workspaceAuth';
-import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { RecentModel } from '@/database/models/recent';
 import { router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
@@ -46,7 +46,7 @@ export const recentRouter = router({
             if (item.routeGroupId) {
               routePath = `/group/${item.routeGroupId}?topic=${item.id}`;
             } else if (item.routeId) {
-              routePath = SESSION_CHAT_TOPIC_URL(item.routeId, item.id);
+              routePath = AGENT_CHAT_TOPIC_URL(item.routeId, item.id);
             } else {
               routePath = '/';
             }

--- a/packages/agent-manager-runtime/src/AgentManagerRuntime.ts
+++ b/packages/agent-manager-runtime/src/AgentManagerRuntime.ts
@@ -116,7 +116,6 @@ export class AgentManagerRuntime {
         content: `Successfully created agent "${params.title}" with ID: ${result.agentId}`,
         state: {
           agentId: result.agentId,
-          sessionId: result.sessionId,
           success: true,
         } as CreateAgentState,
         success: true,

--- a/packages/agent-manager-runtime/src/__tests__/AgentManagerRuntime.test.ts
+++ b/packages/agent-manager-runtime/src/__tests__/AgentManagerRuntime.test.ts
@@ -122,7 +122,6 @@ describe('AgentManagerRuntime', () => {
     it('should create an agent successfully', async () => {
       vi.mocked(mockAgentService.createAgent).mockResolvedValue({
         agentId: 'new-agent-id',
-        sessionId: 'new-session-id',
       });
 
       const result = await runtime.createAgent({
@@ -136,7 +135,6 @@ describe('AgentManagerRuntime', () => {
       expect(result.content).toContain('My New Agent');
       expect(result.state).toMatchObject({
         agentId: 'new-agent-id',
-        sessionId: 'new-session-id',
         success: true,
       });
     });

--- a/packages/agent-manager-runtime/src/types.ts
+++ b/packages/agent-manager-runtime/src/types.ts
@@ -11,7 +11,6 @@ export interface IAgentService {
   countAgents: (params?: { keyword?: string }) => Promise<number>;
   createAgent: (params: { config: Record<string, unknown> }) => Promise<{
     agentId?: string;
-    sessionId?: string;
   }>;
   duplicateAgent: (agentId: string, newTitle?: string) => Promise<{ agentId: string } | null>;
   getAgentConfigById: (agentId: string) => Promise<LobeAgentConfig | null>;

--- a/packages/builtin-tool-agent-management/src/client/Render/CreateAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Render/CreateAgent/index.tsx
@@ -68,21 +68,21 @@ export const CreateAgentRender = memo<BuiltinRenderProps<CreateAgentParams, Crea
     const { title, description, systemRole, plugins, model, provider, avatar, backgroundColor } =
       args || {};
 
-    const handleNavigateToSession = useCallback(() => {
-      const targetId = pluginState?.sessionId ?? pluginState?.agentId;
+    const handleNavigateToAgent = useCallback(() => {
+      const targetId = pluginState?.agentId;
       if (!targetId) return;
       navigate(AGENT_CHAT_URL(targetId));
-    }, [navigate, pluginState?.sessionId, pluginState?.agentId]);
+    }, [navigate, pluginState?.agentId]);
 
     // After tool execution succeeds, render a clickable agent card
-    if (pluginState?.success && (pluginState.agentId || pluginState.sessionId)) {
+    if (pluginState?.success && pluginState.agentId) {
       return (
         <Flexbox
           horizontal
           align={'center'}
           className={styles.agentCard}
           gap={12}
-          onClick={handleNavigateToSession}
+          onClick={handleNavigateToAgent}
         >
           <Avatar
             avatar={avatar || '🤖'}

--- a/packages/builtin-tool-agent-management/src/client/Render/CreateAgent/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Render/CreateAgent/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SESSION_CHAT_URL } from '@lobechat/const';
+import { AGENT_CHAT_URL } from '@lobechat/const';
 import type { BuiltinRenderProps } from '@lobechat/types';
 import { Avatar, Block, Flexbox, Markdown, Tag } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
@@ -71,7 +71,7 @@ export const CreateAgentRender = memo<BuiltinRenderProps<CreateAgentParams, Crea
     const handleNavigateToSession = useCallback(() => {
       const targetId = pluginState?.sessionId ?? pluginState?.agentId;
       if (!targetId) return;
-      navigate(SESSION_CHAT_URL(targetId));
+      navigate(AGENT_CHAT_URL(targetId));
     }, [navigate, pluginState?.sessionId, pluginState?.agentId]);
 
     // After tool execution succeeds, render a clickable agent card

--- a/packages/builtin-tool-agent-management/src/systemRole.ts
+++ b/packages/builtin-tool-agent-management/src/systemRole.ts
@@ -282,11 +282,11 @@ After successfully creating, duplicating, or finding an agent, render a clickabl
 
 **Format:**
 \`\`\`
-<lobeAgents identifier="{sessionId or agentId}" title="{title}" description="{description}" avatar="{avatar}" backgroundColor="{backgroundColor}" />
+<lobeAgents identifier="{agentId}" title="{title}" description="{description}" avatar="{avatar}" backgroundColor="{backgroundColor}" />
 \`\`\`
 
 **Attribute rules:**
-- **identifier** (required): Use \`sessionId\` from the tool result if available, otherwise use \`agentId\`
+- **identifier** (required): Use \`agentId\` from the tool result
 - **title** (required): The agent's display name
 - **description** (optional): Brief description of the agent
 - **avatar** (optional): Emoji or image URL used for the agent

--- a/packages/builtin-tool-agent-management/src/types.ts
+++ b/packages/builtin-tool-agent-management/src/types.ts
@@ -104,10 +104,6 @@ export interface CreateAgentState {
    */
   error?: string;
   /**
-   * The associated session ID
-   */
-  sessionId?: string;
-  /**
    * Whether the creation was successful
    */
   success: boolean;

--- a/packages/const/src/url.ts
+++ b/packages/const/src/url.ts
@@ -40,17 +40,17 @@ export const AGENTS_INDEX_GITHUB = 'https://github.com/lobehub/lobe-chat-agents'
 export const AGENTS_INDEX_GITHUB_ISSUE = urlJoin(AGENTS_INDEX_GITHUB, 'issues/new');
 export const AGENTS_OFFICIAL_URL = 'https://lobehub.com/agent';
 
-export const SESSION_CHAT_URL = (agentId: string, mobile?: boolean) => {
+export const AGENT_CHAT_URL = (agentId: string, mobile?: boolean) => {
   if (mobile) return `/agent/${agentId}`;
   return `/agent/${agentId}`;
 };
 
-export const SESSION_CHAT_TOPIC_URL = (agentId: string, topicId: string, mobile?: boolean) => {
+export const AGENT_CHAT_TOPIC_URL = (agentId: string, topicId: string, mobile?: boolean) => {
   if (mobile) return urlJoin('/agent', agentId, topicId);
   return urlJoin('/agent', agentId, topicId);
 };
 
-export const SESSION_CHAT_TOPIC_PAGE_URL = (agentId: string, topicId: string, mobile?: boolean) => {
+export const AGENT_CHAT_TOPIC_PAGE_URL = (agentId: string, topicId: string, mobile?: boolean) => {
   if (mobile) return urlJoin('/agent', agentId, topicId, 'page');
   return urlJoin('/agent', agentId, topicId, 'page');
 };
@@ -58,6 +58,9 @@ export const SESSION_CHAT_TOPIC_PAGE_URL = (agentId: string, topicId: string, mo
 export const AGENT_PROFILE_URL = (agentId: string) => `/agent/${agentId}/profile`;
 
 export const GROUP_CHAT_URL = (groupId: string) => `/group/${groupId}`;
+
+export const GROUP_CHAT_TOPIC_URL = (groupId: string, topicId: string) =>
+  urlJoin('/group', groupId, topicId);
 
 export const LIBRARY_URL = (id: string) => urlJoin('/resource/library', id);
 

--- a/packages/database/src/repositories/search/index.ts
+++ b/packages/database/src/repositories/search/index.ts
@@ -75,6 +75,7 @@ export interface TopicSearchResult extends BaseSearchResult {
   } | null;
   agentId: string | null;
   favorite: boolean | null;
+  groupId: string | null;
   sessionId: string | null;
   type: 'topic';
 }
@@ -97,6 +98,7 @@ export interface FolderSearchResult extends BaseSearchResult {
 export interface MessageSearchResult extends BaseSearchResult {
   agentId: string | null;
   content: string;
+  groupId: string | null;
   model: string | null;
   role: string;
   topicId: string | null;
@@ -467,6 +469,7 @@ export class SearchRepo {
         content: topics.content,
         createdAt: topics.createdAt,
         favorite: topics.favorite,
+        groupId: topics.groupId,
         id: topics.id,
         score: sql<number>`paradedb.score(${topics.id})`,
         sessionId: topics.sessionId,
@@ -503,6 +506,7 @@ export class SearchRepo {
         createdAt: row.createdAt,
         description: this.truncate(row.content),
         favorite: row.favorite,
+        groupId: row.groupId,
         id: row.id,
         relevance: row.relevance,
         sessionId: row.sessionId,
@@ -531,6 +535,7 @@ export class SearchRepo {
         agentTitle: agents.title,
         content: messages.content,
         createdAt: messages.createdAt,
+        groupId: messages.groupId,
         id: messages.id,
         model: messages.model,
         role: messages.role,
@@ -560,6 +565,7 @@ export class SearchRepo {
           normalizeInboxAgentTitle(row.agentTitle, {
             slug: row.agentSlug,
           }) || 'General Chat',
+        groupId: row.groupId,
         id: row.id,
         model: row.model,
         relevance: row.relevance,

--- a/src/features/AgentHome/RecentTopics.tsx
+++ b/src/features/AgentHome/RecentTopics.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 import useSWR from 'swr';
 
-import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 import { agentHomeKeys } from '@/libs/swr/keys';
 import { topicService } from '@/services/topic';
@@ -40,7 +40,7 @@ const AgentRecentTopics = memo(() => {
           <WorkspaceLink
             key={topic.id}
             style={{ color: 'inherit', flexShrink: 0, textDecoration: 'none' }}
-            to={SESSION_CHAT_TOPIC_URL(aid!, topic.id)}
+            to={AGENT_CHAT_TOPIC_URL(aid!, topic.id)}
           >
             <Block
               clickable

--- a/src/features/AgentHome/RecentTopics.tsx
+++ b/src/features/AgentHome/RecentTopics.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import { Block, Flexbox, Text } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { BotMessageSquareIcon } from 'lucide-react';
@@ -8,7 +9,6 @@ import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 import useSWR from 'swr';
 
-import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 import { agentHomeKeys } from '@/libs/swr/keys';
 import { topicService } from '@/services/topic';

--- a/src/features/AgentTopicManager/EmptyState.tsx
+++ b/src/features/AgentTopicManager/EmptyState.tsx
@@ -1,13 +1,12 @@
 'use client';
 
+import { AGENT_CHAT_URL } from '@lobechat/const';
 import { Button, Flexbox, Icon, Text } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { MessagesSquare } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
-
-import { AGENT_CHAT_URL } from '@/const/url';
 
 interface EmptyStateProps {
   agentId: string;

--- a/src/features/AgentTopicManager/EmptyState.tsx
+++ b/src/features/AgentTopicManager/EmptyState.tsx
@@ -7,7 +7,7 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
-import { SESSION_CHAT_URL } from '@/const/url';
+import { AGENT_CHAT_URL } from '@/const/url';
 
 interface EmptyStateProps {
   agentId: string;
@@ -33,7 +33,7 @@ const EmptyState = memo<EmptyStateProps>(({ agentId, hasFilters, onClearFilters 
       {hasFilters ? (
         <Button onClick={onClearFilters}>{t('management.empty.filtered.action')}</Button>
       ) : (
-        <Button type={'primary'} onClick={() => navigate(SESSION_CHAT_URL(agentId))}>
+        <Button type={'primary'} onClick={() => navigate(AGENT_CHAT_URL(agentId))}>
           {t('management.empty.noTopics.action')}
         </Button>
       )}

--- a/src/features/AgentTopicManager/MoveTopicsModal/Content.tsx
+++ b/src/features/AgentTopicManager/MoveTopicsModal/Content.tsx
@@ -11,7 +11,7 @@ import { useNavigate } from 'react-router';
 
 import { message } from '@/components/AntdStaticMethods';
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
-import { SESSION_CHAT_URL } from '@/const/url';
+import { AGENT_CHAT_URL } from '@/const/url';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import AgentItem from '@/features/PageEditor/Copilot/AgentSelector/AgentItem';
 import { useFetchAgentList } from '@/hooks/useFetchAgentList';
@@ -205,7 +205,7 @@ const MoveTopicsContent = memo<MoveTopicsContentProps>(({ onMoved, sourceAgentId
           <Button
             type={'primary'}
             onClick={() => {
-              navigate(SESSION_CHAT_URL(target.id));
+              navigate(AGENT_CHAT_URL(target.id));
               close();
             }}
           >

--- a/src/features/AgentTopicManager/MoveTopicsModal/Content.tsx
+++ b/src/features/AgentTopicManager/MoveTopicsModal/Content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DEFAULT_INBOX_AVATAR } from '@lobechat/const';
+import { AGENT_CHAT_URL, DEFAULT_INBOX_AVATAR } from '@lobechat/const';
 import { Button, Flexbox, Icon, Text } from '@lobehub/ui';
 import { useModalContext } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
@@ -11,7 +11,6 @@ import { useNavigate } from 'react-router';
 
 import { message } from '@/components/AntdStaticMethods';
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
-import { AGENT_CHAT_URL } from '@/const/url';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import AgentItem from '@/features/PageEditor/Copilot/AgentSelector/AgentItem';
 import { useFetchAgentList } from '@/hooks/useFetchAgentList';

--- a/src/features/AgentTopicManager/TopicCard.tsx
+++ b/src/features/AgentTopicManager/TopicCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import { formatPrice, formatTokenNumber } from '@lobechat/utils/format';
 import { Block, Checkbox, Flexbox, Icon, Tag, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
@@ -8,7 +9,6 @@ import { memo, type MouseEvent, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
-import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { useActivityTime } from '@/hooks/useActivityTime';
 import type { ChatTopic } from '@/types/topic';
 

--- a/src/features/AgentTopicManager/TopicCard.tsx
+++ b/src/features/AgentTopicManager/TopicCard.tsx
@@ -8,7 +8,7 @@ import { memo, type MouseEvent, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
-import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { useActivityTime } from '@/hooks/useActivityTime';
 import type { ChatTopic } from '@/types/topic';
 
@@ -95,7 +95,7 @@ const TopicCard = memo<TopicCardProps>(({ topic, agentId }) => {
         toggleSelected(topic.id);
         return;
       }
-      navigate(SESSION_CHAT_TOPIC_URL(agentId, topic.id));
+      navigate(AGENT_CHAT_TOPIC_URL(agentId, topic.id));
     },
     [selectMode, topic.id, agentId, toggleSelected, navigate],
   );

--- a/src/features/AgentTopicManager/TopicListView.tsx
+++ b/src/features/AgentTopicManager/TopicListView.tsx
@@ -8,7 +8,7 @@ import { Fragment, memo, type MouseEvent, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
-import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { useActivityTime } from '@/hooks/useActivityTime';
 import { useTopicItemDropdownMenu } from '@/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu';
 import type { ChatTopic } from '@/types/topic';
@@ -159,7 +159,7 @@ const Row = memo<RowProps>(({ topic, agentId }) => {
         toggleSelected(topic.id);
         return;
       }
-      navigate(SESSION_CHAT_TOPIC_URL(agentId, topic.id));
+      navigate(AGENT_CHAT_TOPIC_URL(agentId, topic.id));
     },
     [selectMode, topic.id, agentId, toggleSelected, navigate],
   );

--- a/src/features/AgentTopicManager/TopicListView.tsx
+++ b/src/features/AgentTopicManager/TopicListView.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import type { GroupedTopic } from '@lobechat/types';
 import { ActionIcon, Checkbox, DropdownMenu, Flexbox, Icon, Tag, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
@@ -8,7 +9,6 @@ import { Fragment, memo, type MouseEvent, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
-import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { useActivityTime } from '@/hooks/useActivityTime';
 import { useTopicItemDropdownMenu } from '@/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu';
 import type { ChatTopic } from '@/types/topic';

--- a/src/features/CommandMenu/SearchResults.tsx
+++ b/src/features/CommandMenu/SearchResults.tsx
@@ -19,7 +19,7 @@ import {
 import { memo, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { type SearchResult } from '@/database/repositories/search';
 import { useCommandMenuContext } from '@/features/CommandMenu/CommandMenuContext';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
@@ -76,7 +76,7 @@ const SearchResults = memo<SearchResultsProps>(
         }
         case 'topic': {
           if (result.agentId) {
-            navigate(SESSION_CHAT_TOPIC_URL(result.agentId, result.id));
+            navigate(AGENT_CHAT_TOPIC_URL(result.agentId, result.id));
           } else {
             navigate(`/chat?topic=${result.id}`);
           }
@@ -85,7 +85,7 @@ const SearchResults = memo<SearchResultsProps>(
         case 'message': {
           // Navigate to the topic/agent where the message is
           if (result.topicId && result.agentId) {
-            navigate(`${SESSION_CHAT_TOPIC_URL(result.agentId, result.topicId)}#${result.id}`);
+            navigate(`${AGENT_CHAT_TOPIC_URL(result.agentId, result.topicId)}#${result.id}`);
           } else if (result.topicId) {
             navigate(`/chat?topic=${result.topicId}#${result.id}`);
           } else if (result.agentId) {

--- a/src/features/CommandMenu/SearchResults.tsx
+++ b/src/features/CommandMenu/SearchResults.tsx
@@ -1,4 +1,9 @@
-import { DEFAULT_AVATAR } from '@lobechat/const';
+import {
+  AGENT_CHAT_TOPIC_URL,
+  DEFAULT_AVATAR,
+  GROUP_CHAT_TOPIC_URL,
+  GROUP_CHAT_URL,
+} from '@lobechat/const';
 import { Avatar, Flexbox } from '@lobehub/ui';
 import { Command } from 'cmdk';
 import dayjs from 'dayjs';
@@ -19,7 +24,6 @@ import {
 import { memo, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { AGENT_CHAT_TOPIC_URL, GROUP_CHAT_TOPIC_URL, GROUP_CHAT_URL } from '@/const/url';
 import { type SearchResult } from '@/database/repositories/search';
 import { useCommandMenuContext } from '@/features/CommandMenu/CommandMenuContext';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';

--- a/src/features/CommandMenu/SearchResults.tsx
+++ b/src/features/CommandMenu/SearchResults.tsx
@@ -19,7 +19,7 @@ import {
 import { memo, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_URL, GROUP_CHAT_TOPIC_URL, GROUP_CHAT_URL } from '@/const/url';
 import { type SearchResult } from '@/database/repositories/search';
 import { useCommandMenuContext } from '@/features/CommandMenu/CommandMenuContext';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
@@ -77,21 +77,25 @@ const SearchResults = memo<SearchResultsProps>(
         case 'topic': {
           if (result.agentId) {
             navigate(AGENT_CHAT_TOPIC_URL(result.agentId, result.id));
+          } else if (result.groupId) {
+            navigate(GROUP_CHAT_TOPIC_URL(result.groupId, result.id));
           } else {
-            navigate(`/chat?topic=${result.id}`);
+            navigate('/');
           }
           break;
         }
         case 'message': {
-          // Navigate to the topic/agent where the message is
+          // Navigate to the topic/agent (or group) where the message lives
           if (result.topicId && result.agentId) {
             navigate(`${AGENT_CHAT_TOPIC_URL(result.agentId, result.topicId)}#${result.id}`);
-          } else if (result.topicId) {
-            navigate(`/chat?topic=${result.topicId}#${result.id}`);
+          } else if (result.topicId && result.groupId) {
+            navigate(`${GROUP_CHAT_TOPIC_URL(result.groupId, result.topicId)}#${result.id}`);
           } else if (result.agentId) {
             navigate(`/agent/${result.agentId}#${result.id}`);
+          } else if (result.groupId) {
+            navigate(`${GROUP_CHAT_URL(result.groupId)}#${result.id}`);
           } else {
-            navigate(`/chat#${result.id}`);
+            navigate('/');
           }
           break;
         }

--- a/src/features/Conversation/Markdown/plugins/LobeAgents/Render/index.tsx
+++ b/src/features/Conversation/Markdown/plugins/LobeAgents/Render/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SESSION_CHAT_URL } from '@lobechat/const';
+import { AGENT_CHAT_URL } from '@lobechat/const';
 import { Avatar, Flexbox } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { ArrowRight } from 'lucide-react';
@@ -67,7 +67,7 @@ const Render = memo<LobeAgentsProps>(
 
     const handleClick = useCallback(() => {
       if (!identifier) return;
-      navigate(SESSION_CHAT_URL(identifier));
+      navigate(AGENT_CHAT_URL(identifier));
     }, [navigate, identifier]);
 
     if (!identifier) return null;

--- a/src/features/DesktopFileMenuBridge/index.tsx
+++ b/src/features/DesktopFileMenuBridge/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SESSION_CHAT_URL } from '@lobechat/const';
+import { AGENT_CHAT_URL } from '@lobechat/const';
 import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
 import { useCallback } from 'react';
 
@@ -30,7 +30,7 @@ const DesktopFileMenuBridge = () => {
       useChatStore.getState().switchTopic(null);
       return;
     }
-    navigate(SESSION_CHAT_URL(inboxAgentId, false));
+    navigate(AGENT_CHAT_URL(inboxAgentId, false));
   }, [activeAgentId, inboxAgentId, navigate]);
 
   // Handle create new agent from File menu

--- a/src/features/Electron/ScreenCapture/OverlayMessageDispatcher.tsx
+++ b/src/features/Electron/ScreenCapture/OverlayMessageDispatcher.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { SESSION_CHAT_URL } from '@lobechat/const';
+import { AGENT_CHAT_URL } from '@lobechat/const';
 import {
   type OverlayDispatchMessagePayload,
   useWatchBroadcast,
@@ -49,7 +49,7 @@ const OverlayMessageDispatcher = memo(() => {
       // replace: true drops prev search params (e.g. a stale `message=`) so
       // MessageFromUrl's message-param effect cannot double-fire alongside
       // the overlay dispatch path.
-      router.push(SESSION_CHAT_URL(agentId, false), { query: {}, replace: true });
+      router.push(AGENT_CHAT_URL(agentId, false), { query: {}, replace: true });
     },
     [router],
   );

--- a/src/features/Onboarding/Agent/index.tsx
+++ b/src/features/Onboarding/Agent/index.tsx
@@ -2,7 +2,7 @@
 
 import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
 import { setAgentTemplatesFetcher } from '@lobechat/builtin-tool-web-onboarding/agentMarketplace';
-import { SESSION_CHAT_TOPIC_URL } from '@lobechat/const';
+import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import type { SendMessageParams } from '@lobechat/types';
 import { RequestTrigger } from '@lobechat/types';
 import { Button, ErrorBoundary, Flexbox } from '@lobehub/ui';
@@ -124,7 +124,7 @@ const AgentOnboardingPage = memo(() => {
   const onboardingFinished = !!agentOnboarding?.finishedAt;
   const finishTargetUrl = useMemo(() => {
     if (!onboardingFinished || !inboxAgentId || !effectiveTopicId) return undefined;
-    return SESSION_CHAT_TOPIC_URL(inboxAgentId, effectiveTopicId);
+    return AGENT_CHAT_TOPIC_URL(inboxAgentId, effectiveTopicId);
   }, [onboardingFinished, inboxAgentId, effectiveTopicId]);
 
   const viewingHistoricalTopic =
@@ -265,7 +265,7 @@ const AgentOnboardingPage = memo(() => {
         targetUrl:
           // A threaded signup target (if any) wins over the onboarding topic on finish
           peekOnboardingCallbackUrl() ??
-          (inboxAgentId && topicId ? SESSION_CHAT_TOPIC_URL(inboxAgentId, topicId) : undefined),
+          (inboxAgentId && topicId ? AGENT_CHAT_TOPIC_URL(inboxAgentId, topicId) : undefined),
       });
     },
     [inboxAgentId],

--- a/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.test.tsx
+++ b/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.test.tsx
@@ -42,7 +42,7 @@ vi.mock('@/components/RenameModal', () => ({
 }));
 
 vi.mock('@/const/url', () => ({
-  SESSION_CHAT_TOPIC_URL: (agentId: string, topicId: string) => `/agent/${agentId}/${topicId}`,
+  AGENT_CHAT_TOPIC_URL: (agentId: string, topicId: string) => `/agent/${agentId}/${topicId}`,
 }));
 
 vi.mock('@/const/version', () => ({

--- a/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.test.tsx
+++ b/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.test.tsx
@@ -41,10 +41,6 @@ vi.mock('@/components/RenameModal', () => ({
   openRenameModal: vi.fn(),
 }));
 
-vi.mock('@/const/url', () => ({
-  AGENT_CHAT_TOPIC_URL: (agentId: string, topicId: string) => `/agent/${agentId}/${topicId}`,
-}));
-
 vi.mock('@/const/version', () => ({
   isDesktop: true,
 }));

--- a/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx
+++ b/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx
@@ -22,7 +22,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { openRenameModal } from '@/components/RenameModal';
-import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { isDesktop } from '@/const/version';
 import { openShareModal } from '@/features/ShareModal';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
@@ -159,7 +159,7 @@ export const useDropdownMenu = ({
                 onClick: () => {
                   if (!agentId) return;
                   const url = buildWorkspaceAwarePath(
-                    SESSION_CHAT_TOPIC_URL(agentId, topicId),
+                    AGENT_CHAT_TOPIC_URL(agentId, topicId),
                     activeWorkspaceSlug,
                   );
                   addTab(url);
@@ -199,7 +199,7 @@ export const useDropdownMenu = ({
           label: t('actions.copyLink', { ns: 'topic' }),
           onClick: () => {
             if (!agentId) return;
-            const url = `${appOrigin}${SESSION_CHAT_TOPIC_URL(agentId, topicId)}`;
+            const url = `${appOrigin}${AGENT_CHAT_TOPIC_URL(agentId, topicId)}`;
             void navigator.clipboard.writeText(url);
             message.success(t('actions.copyLinkSuccess', { ns: 'topic' }));
           },

--- a/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx
+++ b/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx
@@ -1,3 +1,4 @@
+import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import type { ChatTopicStatus } from '@lobechat/types';
 import type { MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
@@ -22,7 +23,6 @@ import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { openRenameModal } from '@/components/RenameModal';
-import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { isDesktop } from '@/const/version';
 import { openShareModal } from '@/features/ShareModal';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';

--- a/src/features/Portal/LocalFile/Header.tsx
+++ b/src/features/Portal/LocalFile/Header.tsx
@@ -1,13 +1,17 @@
 'use client';
 
-import { DESKTOP_HEADER_ICON_SMALL_SIZE, isDesktop } from '@lobechat/const';
+import {
+  AGENT_CHAT_TOPIC_PAGE_URL,
+  AGENT_CHAT_TOPIC_URL,
+  DESKTOP_HEADER_ICON_SMALL_SIZE,
+  isDesktop,
+} from '@lobechat/const';
 import { ActionIcon } from '@lobehub/ui';
 import { ArrowLeft, FolderOpen, X } from 'lucide-react';
 import { Fragment, memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router';
 
-import { AGENT_CHAT_TOPIC_PAGE_URL, AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import NavHeader from '@/features/NavHeader';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { localFileService } from '@/services/electron/localFileService';

--- a/src/features/Portal/LocalFile/Header.tsx
+++ b/src/features/Portal/LocalFile/Header.tsx
@@ -7,7 +7,7 @@ import { Fragment, memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router';
 
-import { SESSION_CHAT_TOPIC_PAGE_URL, SESSION_CHAT_TOPIC_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_PAGE_URL, AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import NavHeader from '@/features/NavHeader';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { localFileService } from '@/services/electron/localFileService';
@@ -30,7 +30,7 @@ const Header = memo(() => {
   const isTopicPageRoute =
     !!params.aid &&
     !!params.topicId &&
-    location.pathname.startsWith(SESSION_CHAT_TOPIC_PAGE_URL(params.aid, params.topicId));
+    location.pathname.startsWith(AGENT_CHAT_TOPIC_PAGE_URL(params.aid, params.topicId));
   const handleOpenFileFolder = useCallback(() => {
     if (!activeLocalFilePath) return;
 
@@ -64,7 +64,7 @@ const Header = memo(() => {
             size={DESKTOP_HEADER_ICON_SMALL_SIZE}
             onClick={() => {
               if (params.aid && params.topicId && isTopicPageRoute) {
-                navigate(SESSION_CHAT_TOPIC_URL(params.aid, params.topicId));
+                navigate(AGENT_CHAT_TOPIC_URL(params.aid, params.topicId));
                 return;
               }
 

--- a/src/features/Portal/components/Header.tsx
+++ b/src/features/Portal/components/Header.tsx
@@ -7,7 +7,7 @@ import { Fragment, type ReactNode } from 'react';
 import { memo } from 'react';
 import { useLocation, useParams } from 'react-router';
 
-import { SESSION_CHAT_TOPIC_PAGE_URL, SESSION_CHAT_TOPIC_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_PAGE_URL, AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import NavHeader from '@/features/NavHeader';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useChatStore } from '@/store/chat';
@@ -25,7 +25,7 @@ const Header = memo<{ rightExtra?: ReactNode; title: ReactNode }>(({ title, righ
   const isTopicPageRoute =
     !!params.aid &&
     !!params.topicId &&
-    location.pathname.startsWith(SESSION_CHAT_TOPIC_PAGE_URL(params.aid, params.topicId));
+    location.pathname.startsWith(AGENT_CHAT_TOPIC_PAGE_URL(params.aid, params.topicId));
 
   return (
     <NavHeader
@@ -47,7 +47,7 @@ const Header = memo<{ rightExtra?: ReactNode; title: ReactNode }>(({ title, righ
             size={DESKTOP_HEADER_ICON_SMALL_SIZE}
             onClick={() => {
               if (params.aid && params.topicId && isTopicPageRoute) {
-                navigate(SESSION_CHAT_TOPIC_URL(params.aid, params.topicId));
+                navigate(AGENT_CHAT_TOPIC_URL(params.aid, params.topicId));
                 return;
               }
 

--- a/src/features/Portal/components/Header.tsx
+++ b/src/features/Portal/components/Header.tsx
@@ -1,13 +1,16 @@
 'use client';
 
-import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@lobechat/const';
+import {
+  AGENT_CHAT_TOPIC_PAGE_URL,
+  AGENT_CHAT_TOPIC_URL,
+  DESKTOP_HEADER_ICON_SMALL_SIZE,
+} from '@lobechat/const';
 import { ActionIcon, Flexbox } from '@lobehub/ui';
 import { ArrowLeft, X } from 'lucide-react';
 import { Fragment, type ReactNode } from 'react';
 import { memo } from 'react';
 import { useLocation, useParams } from 'react-router';
 
-import { AGENT_CHAT_TOPIC_PAGE_URL, AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import NavHeader from '@/features/NavHeader';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useChatStore } from '@/store/chat';

--- a/src/hooks/useInterceptingRoutes.test.ts
+++ b/src/hooks/useInterceptingRoutes.test.ts
@@ -32,7 +32,7 @@ describe('useOpenChatSettings', () => {
     useAgentStore.setState({ activeAgentId: undefined });
   });
 
-  it('navigates to mobile chat settings with session info', () => {
+  it('navigates to mobile agent settings route for the active agent', () => {
     useAgentStore.setState({ activeAgentId: '123' });
     vi.mocked(useIsMobile).mockReturnValue(true);
     const { result } = renderHook(() => useOpenChatSettings(ChatSettingsTabs.Opening));
@@ -41,9 +41,7 @@ describe('useOpenChatSettings', () => {
       result.current();
     });
 
-    expect(mockNavigate).toHaveBeenCalledWith(
-      `/chat/settings?session=123&showMobileWorkspace=true`,
-    );
+    expect(mockNavigate).toHaveBeenCalledWith(`/agent/123/settings?showMobileWorkspace=true`);
   });
 
   it('opens desktop agent settings overlay when not on mobile', () => {

--- a/src/hooks/useInterceptingRoutes.ts
+++ b/src/hooks/useInterceptingRoutes.ts
@@ -16,7 +16,7 @@ export const useOpenChatSettings = (tab: ChatSettingsTabs = ChatSettingsTabs.Ope
 
   return useMemo(() => {
     if (isMobile)
-      return () => navigate(`/chat/settings?session=${activeAgentId}&showMobileWorkspace=true`);
+      return () => navigate(`/agent/${activeAgentId}/settings?showMobileWorkspace=true`);
 
     return () => {
       openAgentSettingsModal();

--- a/src/hooks/useNavigateToAgent.ts
+++ b/src/hooks/useNavigateToAgent.ts
@@ -1,4 +1,4 @@
-import { SESSION_CHAT_URL } from '@lobechat/const';
+import { AGENT_CHAT_URL } from '@lobechat/const';
 import { useCallback } from 'react';
 
 import { useQueryRoute } from '@/hooks/useQueryRoute';
@@ -12,7 +12,7 @@ export const useNavigateToAgent = () => {
     (agentId: string) => {
       clearPortalStack();
 
-      router.push(SESSION_CHAT_URL(agentId, false));
+      router.push(AGENT_CHAT_URL(agentId, false));
     },
     [clearPortalStack, router],
   );

--- a/src/routes/(main)/agent/_layout/Sidebar/Header/Nav.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Header/Nav.test.tsx
@@ -52,7 +52,7 @@ vi.mock('react-router', async () => {
 });
 
 vi.mock('@/const/url', () => ({
-  SESSION_CHAT_URL: (agentId: string) => `/agent/${agentId}`,
+  AGENT_CHAT_URL: (agentId: string) => `/agent/${agentId}`,
 }));
 
 vi.mock('@/features/NavPanel/components/NavItem', () => ({

--- a/src/routes/(main)/agent/_layout/Sidebar/Header/Nav.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Header/Nav.test.tsx
@@ -51,10 +51,6 @@ vi.mock('react-router', async () => {
   };
 });
 
-vi.mock('@/const/url', () => ({
-  AGENT_CHAT_URL: (agentId: string) => `/agent/${agentId}`,
-}));
-
 vi.mock('@/features/NavPanel/components/NavItem', () => ({
   default: ({
     active,

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
@@ -54,9 +54,6 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@/const/version', () => ({ isDesktop: false }));
-vi.mock('@/const/url', () => ({
-  AGENT_CHAT_TOPIC_URL: (agentId: string, topicId: string) => `/agent/${agentId}/${topicId}`,
-}));
 vi.mock('@/features/NavPanel/components/NavItem', () => ({
   default: ({
     active,

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
@@ -55,7 +55,7 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('@/const/version', () => ({ isDesktop: false }));
 vi.mock('@/const/url', () => ({
-  SESSION_CHAT_TOPIC_URL: (agentId: string, topicId: string) => `/agent/${agentId}/${topicId}`,
+  AGENT_CHAT_TOPIC_URL: (agentId: string, topicId: string) => `/agent/${agentId}/${topicId}`,
 }));
 vi.mock('@/features/NavPanel/components/NavItem', () => ({
   default: ({

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -1,3 +1,4 @@
+import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import type { ChatTopicMetadata, ChatTopicStatus } from '@lobechat/types';
 import { formatElapsedClockTime } from '@lobechat/utils';
 import { Flexbox, Icon, Skeleton, Tag, Text, Tooltip } from '@lobehub/ui';
@@ -9,7 +10,6 @@ import { useTranslation } from 'react-i18next';
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import DotsLoading from '@/components/DotsLoading';
 import RingLoadingIcon from '@/components/RingLoading';
-import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { isDesktop } from '@/const/version';
 import DirIcon from '@/features/ChatInput/ControlBar/DirIcon';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import DotsLoading from '@/components/DotsLoading';
 import RingLoadingIcon from '@/components/RingLoading';
-import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { isDesktop } from '@/const/version';
 import DirIcon from '@/features/ChatInput/ControlBar/DirIcon';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';
@@ -169,10 +169,7 @@ const TopicItem = memo<TopicItemProps>(
     // Construct href for cmd+click support
     const href = useMemo(() => {
       if (!activeAgentId || !id) return undefined;
-      return buildWorkspaceAwarePath(
-        SESSION_CHAT_TOPIC_URL(activeAgentId, id),
-        activeWorkspaceSlug,
-      );
+      return buildWorkspaceAwarePath(AGENT_CHAT_TOPIC_URL(activeAgentId, id), activeWorkspaceSlug);
     }, [activeAgentId, activeWorkspaceSlug, id]);
 
     const [editing, isLoading] = useChatStore((s) => [
@@ -226,9 +223,7 @@ const TopicItem = memo<TopicItemProps>(
         void navigateToTopic(id, { skipPopupFocus: true });
         return;
       }
-      addTab(
-        buildWorkspaceAwarePath(SESSION_CHAT_TOPIC_URL(activeAgentId, id), activeWorkspaceSlug),
-      );
+      addTab(buildWorkspaceAwarePath(AGENT_CHAT_TOPIC_URL(activeAgentId, id), activeWorkspaceSlug));
       void navigateToTopic(id);
     }, [id, activeAgentId, activeWorkspaceSlug, addTab, focusTopicPopup, navigateToTopic]);
 

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -1,3 +1,4 @@
+import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import type { ChatTopicStatus } from '@lobechat/types';
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
@@ -23,7 +24,6 @@ import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { openRenameModal } from '@/components/RenameModal';
-import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { isDesktop } from '@/const/version';
 import { createMoveTopicsModal } from '@/features/AgentTopicManager/MoveTopicsModal';
 import { openShareModal } from '@/features/ShareModal';

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -23,7 +23,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { openRenameModal } from '@/components/RenameModal';
-import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { isDesktop } from '@/const/version';
 import { createMoveTopicsModal } from '@/features/AgentTopicManager/MoveTopicsModal';
 import { openShareModal } from '@/features/ShareModal';
@@ -155,7 +155,7 @@ export const useTopicItemDropdownMenu = ({
               onClick: () => {
                 if (!activeAgentId) return;
                 const url = buildWorkspaceAwarePath(
-                  SESSION_CHAT_TOPIC_URL(activeAgentId, id),
+                  AGENT_CHAT_TOPIC_URL(activeAgentId, id),
                   activeWorkspaceSlug,
                 );
                 addTab(url);
@@ -190,7 +190,7 @@ export const useTopicItemDropdownMenu = ({
         label: t('actions.copyLink'),
         onClick: () => {
           if (!activeAgentId) return;
-          const url = `${appOrigin}${SESSION_CHAT_TOPIC_URL(activeAgentId, id)}`;
+          const url = `${appOrigin}${AGENT_CHAT_TOPIC_URL(activeAgentId, id)}`;
           navigator.clipboard.writeText(url);
           message.success(t('actions.copyLinkSuccess'));
         },

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.test.tsx
@@ -93,10 +93,6 @@ vi.mock('@/business/client/hooks/useActiveWorkspaceSlug', () => ({
   useActiveWorkspaceSlug: () => activeWorkspaceSlugMock.value,
 }));
 
-vi.mock('@/const/url', () => ({
-  AGENT_CHAT_URL: (agentId: string) => `/agent/${agentId}`,
-}));
-
 vi.mock('@/const/version', () => ({ isDesktop: true }));
 
 vi.mock('@/features/ChatInput/ControlBar/useCommitWorkingDirectory', () => ({

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.test.tsx
@@ -94,7 +94,7 @@ vi.mock('@/business/client/hooks/useActiveWorkspaceSlug', () => ({
 }));
 
 vi.mock('@/const/url', () => ({
-  SESSION_CHAT_URL: (agentId: string) => `/agent/${agentId}`,
+  AGENT_CHAT_URL: (agentId: string) => `/agent/${agentId}`,
 }));
 
 vi.mock('@/const/version', () => ({ isDesktop: true }));

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
@@ -1,3 +1,4 @@
+import { AGENT_CHAT_URL } from '@lobechat/const';
 import { AccordionItem, ActionIcon, Center, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx, keyframes } from 'antd-style';
 import {
@@ -14,7 +15,6 @@ import { useParams } from 'react-router';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import RingLoadingIcon from '@/components/RingLoading';
-import { AGENT_CHAT_URL } from '@/const/url';
 import { isDesktop } from '@/const/version';
 import { useCommitWorkingDirectory } from '@/features/ChatInput/ControlBar/useCommitWorkingDirectory';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
@@ -14,7 +14,7 @@ import { useParams } from 'react-router';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import RingLoadingIcon from '@/components/RingLoading';
-import { SESSION_CHAT_URL } from '@/const/url';
+import { AGENT_CHAT_URL } from '@/const/url';
 import { isDesktop } from '@/const/version';
 import { useCommitWorkingDirectory } from '@/features/ChatInput/ControlBar/useCommitWorkingDirectory';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
@@ -241,11 +241,7 @@ const GroupItem = memo<GroupItemComponentProps>(
       await commitAgentDefault(workingDirectory);
       useChatStore.getState().switchTopic(null, { skipRefreshMessage: true });
       router.push(
-        buildPrefixedAgentRoutePath(
-          SESSION_CHAT_URL(targetAgentId),
-          agentRoute,
-          activeWorkspaceSlug,
-        ),
+        buildPrefixedAgentRoutePath(AGENT_CHAT_URL(targetAgentId), agentRoute, activeWorkspaceSlug),
       );
     }, [
       workingDirectory,

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useThreadNavigation.ts
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useThreadNavigation.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useParams } from 'react-router';
 
-import { SESSION_CHAT_TOPIC_URL, SESSION_CHAT_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_URL, AGENT_CHAT_URL } from '@/const/url';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { usePathname } from '@/libs/router/navigation';
 import { useChatStore } from '@/store/chat';
@@ -21,8 +21,8 @@ export const useThreadNavigation = () => {
   const isInAgentSubRoute = useCallback(() => {
     if (!params.aid) return false;
     const agentBasePath = params.topicId
-      ? SESSION_CHAT_TOPIC_URL(params.aid, params.topicId)
-      : SESSION_CHAT_URL(params.aid);
+      ? AGENT_CHAT_TOPIC_URL(params.aid, params.topicId)
+      : AGENT_CHAT_URL(params.aid);
 
     // If pathname has more segments after /agent/:aid, it's a sub-route
     return (
@@ -38,8 +38,8 @@ export const useThreadNavigation = () => {
       if (isInAgentSubRoute() && params.aid) {
         router.push(
           params.topicId
-            ? SESSION_CHAT_TOPIC_URL(params.aid, params.topicId)
-            : SESSION_CHAT_URL(params.aid),
+            ? AGENT_CHAT_TOPIC_URL(params.aid, params.topicId)
+            : AGENT_CHAT_URL(params.aid),
         );
       }
 

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useThreadNavigation.ts
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useThreadNavigation.ts
@@ -1,7 +1,7 @@
+import { AGENT_CHAT_TOPIC_URL, AGENT_CHAT_URL } from '@lobechat/const';
 import { useCallback } from 'react';
 import { useParams } from 'react-router';
 
-import { AGENT_CHAT_TOPIC_URL, AGENT_CHAT_URL } from '@/const/url';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { usePathname } from '@/libs/router/navigation';
 import { useChatStore } from '@/store/chat';

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useTopicNavigation.ts
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useTopicNavigation.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useParams } from 'react-router';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
-import { SESSION_CHAT_TOPIC_URL, SESSION_CHAT_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_URL, AGENT_CHAT_URL } from '@/const/url';
 import { useFocusTopicPopup } from '@/features/TopicPopupGuard/useTopicPopupsRegistry';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { usePathname } from '@/libs/router/navigation';
@@ -65,8 +65,8 @@ export const useTopicNavigation = () => {
       // If in agent sub-route, navigate back to agent chat first
       if (isInAgentSubRoute() && routeAgentId) {
         const basePath = topicId
-          ? SESSION_CHAT_TOPIC_URL(routeAgentId, topicId)
-          : SESSION_CHAT_URL(routeAgentId);
+          ? AGENT_CHAT_TOPIC_URL(routeAgentId, topicId)
+          : AGENT_CHAT_URL(routeAgentId);
         const targetPath = buildPrefixedAgentRoutePath(basePath, agentRoute, activeWorkspaceSlug);
 
         // Include topicId in URL when navigating from sub-route

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useTopicNavigation.ts
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useTopicNavigation.ts
@@ -1,8 +1,8 @@
+import { AGENT_CHAT_TOPIC_URL, AGENT_CHAT_URL } from '@lobechat/const';
 import { useCallback, useMemo } from 'react';
 import { useParams } from 'react-router';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
-import { AGENT_CHAT_TOPIC_URL, AGENT_CHAT_URL } from '@/const/url';
 import { useFocusTopicPopup } from '@/features/TopicPopupGuard/useTopicPopupsRegistry';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { usePathname } from '@/libs/router/navigation';

--- a/src/routes/(main)/agent/features/Conversation/ChatHydration/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ChatHydration/index.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import { AGENT_CHAT_TOPIC_URL, AGENT_CHAT_URL } from '@lobechat/const';
 import { memo, useLayoutEffect, useRef } from 'react';
 import { useLocation, useParams, useSearchParams } from 'react-router';
 
-import { AGENT_CHAT_TOPIC_URL, AGENT_CHAT_URL } from '@/const/url';
 import { useClearActiveTopicUnread } from '@/features/Conversation/hooks';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useQueryState } from '@/hooks/useQueryParam';

--- a/src/routes/(main)/agent/features/Conversation/ChatHydration/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ChatHydration/index.tsx
@@ -3,7 +3,7 @@
 import { memo, useLayoutEffect, useRef } from 'react';
 import { useLocation, useParams, useSearchParams } from 'react-router';
 
-import { SESSION_CHAT_TOPIC_URL, SESSION_CHAT_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_URL, AGENT_CHAT_URL } from '@/const/url';
 import { useClearActiveTopicUnread } from '@/features/Conversation/hooks';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useQueryState } from '@/hooks/useQueryParam';
@@ -62,7 +62,7 @@ const ChatHydration = memo(() => {
         const nextSearchParams = new URLSearchParams(searchParamsRef.current);
         nextSearchParams.delete('topic');
 
-        const nextPath = state ? SESSION_CHAT_TOPIC_URL(aid, state) : SESSION_CHAT_URL(aid);
+        const nextPath = state ? AGENT_CHAT_TOPIC_URL(aid, state) : AGENT_CHAT_URL(aid);
         const nextUrl = `${nextPath}${getSearchSuffix(nextSearchParams)}${locationRef.current.hash}`;
         const currentUrl = `${locationRef.current.pathname}${locationRef.current.search}${locationRef.current.hash}`;
 

--- a/src/routes/(main)/agent/features/Conversation/Header/ViewSwitcher/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/ViewSwitcher/index.tsx
@@ -8,7 +8,7 @@ import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router';
 
-import { SESSION_CHAT_TOPIC_PAGE_URL, SESSION_CHAT_TOPIC_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_PAGE_URL, AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
@@ -53,7 +53,7 @@ const ViewSwitcher = memo(() => {
 
   const currentTab = useMemo((): ViewTab => {
     if (!aid || !topicId) return 'chat';
-    if (location.pathname.startsWith(SESSION_CHAT_TOPIC_PAGE_URL(aid, topicId))) return 'page';
+    if (location.pathname.startsWith(AGENT_CHAT_TOPIC_PAGE_URL(aid, topicId))) return 'page';
     return 'chat';
   }, [aid, topicId, location.pathname]);
 
@@ -96,11 +96,11 @@ const ViewSwitcher = memo(() => {
 
     switch (key as ViewTab) {
       case 'chat': {
-        if (topicId) navigate(SESSION_CHAT_TOPIC_URL(aid, topicId));
+        if (topicId) navigate(AGENT_CHAT_TOPIC_URL(aid, topicId));
         break;
       }
       case 'page': {
-        if (topicId) navigate(SESSION_CHAT_TOPIC_PAGE_URL(aid, topicId));
+        if (topicId) navigate(AGENT_CHAT_TOPIC_PAGE_URL(aid, topicId));
         break;
       }
       case 'task': {

--- a/src/routes/(main)/agent/features/Conversation/Header/ViewSwitcher/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/ViewSwitcher/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AGENT_CHAT_TOPIC_PAGE_URL, AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import { Flexbox } from '@lobehub/ui';
 import { Tabs } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
@@ -8,7 +9,6 @@ import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useParams } from 'react-router';
 
-import { AGENT_CHAT_TOPIC_PAGE_URL, AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';

--- a/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/AddAgent.tsx
+++ b/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/AddAgent.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AGENT_CHAT_URL } from '@lobechat/const';
 import { Button, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
@@ -8,7 +9,6 @@ import { ChevronDownIcon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { AGENT_CHAT_URL } from '@/const/url';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { usePermission } from '@/hooks/usePermission';
 import { agentService } from '@/services/agent';

--- a/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/AddAgent.tsx
+++ b/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/AddAgent.tsx
@@ -8,7 +8,7 @@ import { ChevronDownIcon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { SESSION_CHAT_URL } from '@/const/url';
+import { AGENT_CHAT_URL } from '@/const/url';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { usePermission } from '@/hooks/usePermission';
 import { agentService } from '@/services/agent';
@@ -104,7 +104,7 @@ const AddAgent = memo<{ mobile?: boolean }>(({ mobile }) => {
     try {
       const result = await createAgentWithMarketIdentifier(true);
       message.success(t('assistants.addAgentSuccess'));
-      navigate(SESSION_CHAT_URL(result!.agentId, mobile));
+      navigate(AGENT_CHAT_URL(result!.agentId, mobile));
     } finally {
       setIsLoading(false);
     }

--- a/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/ForkAndChat.tsx
+++ b/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/ForkAndChat.tsx
@@ -8,7 +8,7 @@ import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
-import { SESSION_CHAT_URL } from '@/const/url';
+import { AGENT_CHAT_URL } from '@/const/url';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { usePermission } from '@/hooks/usePermission';
 import { useMarketAuth } from '@/layout/AuthProvider/MarketAuth';
@@ -78,7 +78,7 @@ const ForkAndChat = memo<{ mobile?: boolean }>(({ mobile }) => {
       if (existingAgentId) {
         // User has already forked this agent, navigate to existing fork
         message.info(t('fork.alreadyForked'));
-        navigate(SESSION_CHAT_URL(existingAgentId, mobile));
+        navigate(AGENT_CHAT_URL(existingAgentId, mobile));
         return;
       }
 
@@ -151,7 +151,7 @@ const ForkAndChat = memo<{ mobile?: boolean }>(({ mobile }) => {
       message.success(t('fork.success'));
 
       // Step 6: Navigate to chat
-      navigate(SESSION_CHAT_URL(result!.agentId, mobile));
+      navigate(AGENT_CHAT_URL(result!.agentId, mobile));
     } catch (error: any) {
       console.error('Fork failed:', error);
       message.error(t('fork.failed'));

--- a/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/ForkAndChat.tsx
+++ b/src/routes/(main)/community/(detail)/agent/features/Sidebar/ActionButton/ForkAndChat.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { AGENT_CHAT_URL } from '@lobechat/const';
 import { Button } from '@lobehub/ui';
 import { App } from 'antd';
 import { createStaticStyles } from 'antd-style';
@@ -8,7 +9,6 @@ import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
-import { AGENT_CHAT_URL } from '@/const/url';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { usePermission } from '@/hooks/usePermission';
 import { useMarketAuth } from '@/layout/AuthProvider/MarketAuth';

--- a/src/routes/(main)/community/(detail)/skill/features/Sidebar/Platform.tsx
+++ b/src/routes/(main)/community/(detail)/skill/features/Sidebar/Platform.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DEFAULT_INBOX_AVATAR, SESSION_CHAT_URL } from '@lobechat/const';
+import { AGENT_CHAT_URL, DEFAULT_INBOX_AVATAR } from '@lobechat/const';
 import { Claude, Cline, Cursor, OpenAI } from '@lobehub/icons';
 import {
   Avatar,
@@ -205,7 +205,7 @@ const Platform = memo<PlatformProps>(
       });
 
       // Navigate to LobeAI chat session
-      navigate(SESSION_CHAT_URL(inboxAgentId, mobile));
+      navigate(AGENT_CHAT_URL(inboxAgentId, mobile));
     }, [agentPrompt, inboxAgentId, mobile, navigate, sendMessage]);
 
     return (

--- a/src/routes/(main)/group/_layout/GroupIdSync.tsx
+++ b/src/routes/(main)/group/_layout/GroupIdSync.tsx
@@ -10,7 +10,7 @@ import { useChatStore } from '@/store/chat';
 const GroupIdSync = () => {
   const useAgentGroupStoreUpdater = createStoreUpdater(useAgentGroupStore);
   const useChatStoreUpdater = createStoreUpdater(useChatStore);
-  const params = useParams<{ gid?: string }>();
+  const params = useParams<{ gid?: string; topicId?: string }>();
   const prevGroupId = usePrevious(params.gid);
   const router = useQueryRoute();
 
@@ -24,11 +24,13 @@ const GroupIdSync = () => {
   // Reset activeTopicId when switching to a different group
   // This prevents messages from being saved to the wrong topic bucket
   useEffect(() => {
-    // Only reset topic when switching between groups (not on initial mount)
-    if (prevGroupId !== undefined && prevGroupId !== params.gid) {
+    // Only reset topic when switching between groups (not on initial mount).
+    // Preserve the topic if the URL already carries one (e.g. tab navigation).
+    const isSwitchingGroup = prevGroupId !== undefined && prevGroupId !== params.gid;
+    if (isSwitchingGroup && !params.topicId) {
       useChatStore.getState().switchTopic(null, { skipRefreshMessage: true });
     }
-  }, [params.gid, prevGroupId]);
+  }, [params.gid, params.topicId, prevGroupId]);
 
   // Clear activeGroupId when unmounting (leaving group page)
   useUnmount(() => {

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -1,3 +1,4 @@
+import { GROUP_CHAT_TOPIC_URL } from '@lobechat/const';
 import type { ChatTopicStatus } from '@lobechat/types';
 import { Flexbox, Icon, Skeleton, Tag, Text, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
@@ -15,7 +16,6 @@ import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import DotsLoading from '@/components/DotsLoading';
-import { GROUP_CHAT_TOPIC_URL } from '@/const/url';
 import { isDesktop } from '@/const/version';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';
 import NavItem from '@/features/NavPanel/components/NavItem';

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import DotsLoading from '@/components/DotsLoading';
+import { GROUP_CHAT_TOPIC_URL } from '@/const/url';
 import { isDesktop } from '@/const/version';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';
 import NavItem from '@/features/NavPanel/components/NavItem';
@@ -100,7 +101,7 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
   // Construct href for cmd+click support
   const href = useMemo(() => {
     if (!activeGroupId || !id) return undefined;
-    return buildWorkspaceAwarePath(`/group/${activeGroupId}?topic=${id}`, activeWorkspaceSlug);
+    return buildWorkspaceAwarePath(GROUP_CHAT_TOPIC_URL(activeGroupId, id), activeWorkspaceSlug);
   }, [activeGroupId, activeWorkspaceSlug, id]);
 
   const [editing, isLoading] = useChatStore((s) => [
@@ -148,7 +149,7 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
       toggleMobileTopic(false);
       return;
     }
-    addTab(buildWorkspaceAwarePath(`/group/${activeGroupId}?topic=${id}`, activeWorkspaceSlug));
+    addTab(buildWorkspaceAwarePath(GROUP_CHAT_TOPIC_URL(activeGroupId, id), activeWorkspaceSlug));
     switchTopic(id);
     toggleMobileTopic(false);
   }, [

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -1,3 +1,4 @@
+import { GROUP_CHAT_TOPIC_URL } from '@lobechat/const';
 import type { ChatTopicStatus } from '@lobechat/types';
 import { type MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
@@ -19,7 +20,6 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
-import { GROUP_CHAT_TOPIC_URL } from '@/const/url';
 import { isDesktop } from '@/const/version';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -19,6 +19,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
+import { GROUP_CHAT_TOPIC_URL } from '@/const/url';
 import { isDesktop } from '@/const/version';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
@@ -118,7 +119,7 @@ export const useTopicItemDropdownMenu = ({
               onClick: () => {
                 if (!activeGroupId) return;
                 const url = buildWorkspaceAwarePath(
-                  `/group/${activeGroupId}?topic=${id}`,
+                  GROUP_CHAT_TOPIC_URL(activeGroupId, id),
                   activeWorkspaceSlug,
                 );
                 addTab(url);
@@ -153,7 +154,7 @@ export const useTopicItemDropdownMenu = ({
         label: t('actions.copyLink'),
         onClick: () => {
           if (!activeGroupId) return;
-          const url = `${appOrigin}/group/${activeGroupId}?topic=${id}`;
+          const url = `${appOrigin}${GROUP_CHAT_TOPIC_URL(activeGroupId, id)}`;
           navigator.clipboard.writeText(url);
           message.success(t('actions.copyLinkSuccess'));
         },

--- a/src/routes/(main)/group/features/Conversation/ChatHydration/index.tsx
+++ b/src/routes/(main)/group/features/Conversation/ChatHydration/index.tsx
@@ -1,9 +1,9 @@
 'use client';
 
+import { GROUP_CHAT_TOPIC_URL, GROUP_CHAT_URL } from '@lobechat/const';
 import { memo, useLayoutEffect, useRef } from 'react';
 import { useLocation, useParams, useSearchParams } from 'react-router';
 
-import { GROUP_CHAT_TOPIC_URL, GROUP_CHAT_URL } from '@/const/url';
 import { useClearActiveTopicUnread } from '@/features/Conversation/hooks';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useQueryState } from '@/hooks/useQueryParam';

--- a/src/routes/(main)/group/features/Conversation/ChatHydration/index.tsx
+++ b/src/routes/(main)/group/features/Conversation/ChatHydration/index.tsx
@@ -1,37 +1,80 @@
 'use client';
 
-import { memo, useLayoutEffect } from 'react';
-import { createStoreUpdater } from 'zustand-utils';
+import { memo, useLayoutEffect, useRef } from 'react';
+import { useLocation, useParams, useSearchParams } from 'react-router';
 
+import { GROUP_CHAT_TOPIC_URL, GROUP_CHAT_URL } from '@/const/url';
 import { useClearActiveTopicUnread } from '@/features/Conversation/hooks';
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { useQueryState } from '@/hooks/useQueryParam';
 import { useChatStore } from '@/store/chat';
 
+const getSearchSuffix = (searchParams: URLSearchParams) => {
+  const search = searchParams.toString();
+
+  return search ? `?${search}` : '';
+};
+
 // sync outside state to useChatStore
 const ChatHydration = memo(() => {
-  const useStoreUpdater = createStoreUpdater(useChatStore);
+  const location = useLocation();
+  const navigate = useWorkspaceAwareNavigate();
+  const params = useParams<{ gid?: string; topicId?: string }>();
+  const [searchParams] = useSearchParams();
 
-  // two-way bindings the topic params to chat store
-  const [topic, setTopic] = useQueryState('topic', { history: 'replace', throttleMs: 500 });
   const [thread, setThread] = useQueryState('thread', { history: 'replace', throttleMs: 500 });
-  useStoreUpdater('activeTopicId', topic!);
-  useStoreUpdater('activeThreadId', thread!);
+  const routeTopicId = params.topicId;
 
-  // Hydration sets activeTopicId directly (not via switchTopic), so clear any
-  // lingering persisted unread once the topic loads.
+  // Route hydration sets activeTopicId directly (below) instead of going through
+  // switchTopic, so clear any lingering persisted unread once the topic loads.
   useClearActiveTopicUnread();
+
+  useLayoutEffect(() => {
+    const target = routeTopicId ?? null;
+    if (useChatStore.getState().activeTopicId !== target) {
+      useChatStore.setState({ activeTopicId: target! }, false, 'ChatHydration/syncTopicFromUrl');
+    }
+  }, [routeTopicId]);
+
+  useLayoutEffect(() => {
+    const target = thread ?? null;
+    if (useChatStore.getState().activeThreadId !== target) {
+      useChatStore.setState({ activeThreadId: target! }, false, 'ChatHydration/syncThreadFromUrl');
+    }
+  }, [thread]);
+
+  const locationRef = useRef(location);
+  const paramsRef = useRef(params);
+  const searchParamsRef = useRef(searchParams);
+
+  locationRef.current = location;
+  paramsRef.current = params;
+  searchParamsRef.current = searchParams;
 
   useLayoutEffect(() => {
     const unsubscribeTopic = useChatStore.subscribe(
       (s) => s.activeTopicId,
       (state) => {
-        setTopic(!state ? null : state);
+        const { gid } = paramsRef.current;
+
+        if (!gid) return;
+
+        const nextSearchParams = new URLSearchParams(searchParamsRef.current);
+        nextSearchParams.delete('topic');
+
+        const nextPath = state ? GROUP_CHAT_TOPIC_URL(gid, state) : GROUP_CHAT_URL(gid);
+        const nextUrl = `${nextPath}${getSearchSuffix(nextSearchParams)}${locationRef.current.hash}`;
+        const currentUrl = `${locationRef.current.pathname}${locationRef.current.search}${locationRef.current.hash}`;
+
+        if (currentUrl !== nextUrl) {
+          navigate(nextUrl, { replace: true });
+        }
       },
     );
     const unsubscribeThread = useChatStore.subscribe(
       (s) => s.activeThreadId,
       (state) => {
-        setThread(!state ? null : state);
+        setThread(state || null);
       },
     );
 
@@ -39,7 +82,7 @@ const ChatHydration = memo(() => {
       unsubscribeTopic();
       unsubscribeThread();
     };
-  }, [setTopic, setThread]); // ✅ Now setValue is stable and can be safely added to the dependency array
+  }, [navigate, setThread]);
 
   return null;
 });

--- a/src/routes/(main)/group/features/routeMeta.ts
+++ b/src/routes/(main)/group/features/routeMeta.ts
@@ -32,7 +32,7 @@ const GroupDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
     const item = sessionGroupSelectors.getGroupById(params.gid ?? '')(s);
     return matchesRouteWorkspace(getWorkspaceId(item), routeWorkspaceId) ? item : undefined;
   });
-  const topicTitle = useTopicTitle(params.gid, params.topic, routeWorkspaceId);
+  const topicTitle = useTopicTitle(params.gid, params.topicId ?? params.topic, routeWorkspaceId);
 
   usePublishDynamicRouteMeta(
     {

--- a/src/routes/(main)/home/_layout/Body/Agent/List/usePreservedAgentUrl.ts
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/usePreservedAgentUrl.ts
@@ -1,4 +1,4 @@
-import { SESSION_CHAT_URL } from '@lobechat/const';
+import { AGENT_CHAT_URL } from '@lobechat/const';
 import { useMemo } from 'react';
 import { useLocation } from 'react-router';
 
@@ -20,6 +20,6 @@ export const usePreservedAgentUrl = (agentId: string): string => {
     if (subPath && PRESERVED_AGENT_SUB_PATHS.has(subPath)) {
       return `/agent/${agentId}/${subPath}`;
     }
-    return SESSION_CHAT_URL(agentId, false);
+    return AGENT_CHAT_URL(agentId, false);
   }, [agentId, pathname]);
 };

--- a/src/routes/(main)/home/_layout/Body/Agent/ModalProvider.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/ModalProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DEFAULT_INBOX_TITLE, SESSION_CHAT_URL } from '@lobechat/const';
+import { AGENT_CHAT_URL, DEFAULT_INBOX_TITLE } from '@lobechat/const';
 import { type ReactNode, useCallback } from 'react';
 import { createContext, memo, use, useMemo, useState } from 'react';
 
@@ -112,7 +112,7 @@ const CreateModalRenderer = memo<CreateModalRendererProps>(({ open, type, groupI
   const handleTryInLobeAI = useCallback(() => {
     if (!inboxAgentId) return;
 
-    navigate(SESSION_CHAT_URL(inboxAgentId, false));
+    navigate(AGENT_CHAT_URL(inboxAgentId, false));
   }, [inboxAgentId, navigate]);
 
   return (

--- a/src/routes/(main)/home/_layout/Body/InboxEntry.tsx
+++ b/src/routes/(main)/home/_layout/Body/InboxEntry.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { DEFAULT_INBOX_AVATAR, SESSION_CHAT_URL } from '@lobechat/const';
+import { AGENT_CHAT_URL, DEFAULT_INBOX_AVATAR } from '@lobechat/const';
 import { Avatar, Icon } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { Loader2 } from 'lucide-react';
@@ -52,7 +52,7 @@ const InboxEntry = memo(() => {
 
   const title = inboxMeta.title || 'Lobe AI';
   const avatar = inboxMeta.avatar || DEFAULT_INBOX_AVATAR;
-  const url = SESSION_CHAT_URL(inboxAgentId, false);
+  const url = AGENT_CHAT_URL(inboxAgentId, false);
 
   const avatarNode = <Avatar emojiScaleWithBackground avatar={avatar} shape={'square'} size={24} />;
 

--- a/src/routes/(main)/home/features/InputArea/useSend.ts
+++ b/src/routes/(main)/home/features/InputArea/useSend.ts
@@ -1,4 +1,4 @@
-import { SESSION_CHAT_TOPIC_URL, SESSION_CHAT_URL } from '@lobechat/const';
+import { AGENT_CHAT_TOPIC_URL, AGENT_CHAT_URL } from '@lobechat/const';
 import { useCallback } from 'react';
 
 import type { SendButtonHandler } from '@/features/ChatInput/store/initialState';
@@ -127,11 +127,11 @@ export const useSend = () => {
               files: fileList,
               message,
               onTopicCreated: (topicId) => {
-                router.replace(SESSION_CHAT_TOPIC_URL(activeAgentId, topicId, false));
+                router.replace(AGENT_CHAT_TOPIC_URL(activeAgentId, topicId, false));
               },
             });
 
-            router.push(SESSION_CHAT_URL(activeAgentId, false));
+            router.push(AGENT_CHAT_URL(activeAgentId, false));
           }
         }
       } finally {

--- a/src/routes/(main)/memory/features/SourceLink.tsx
+++ b/src/routes/(main)/memory/features/SourceLink.tsx
@@ -3,7 +3,7 @@ import { cssVar } from 'antd-style';
 import { Link2 } from 'lucide-react';
 import { memo } from 'react';
 
-import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { type MemorySource } from '@/database/repositories/userMemory';
 import Link from '@/libs/router/Link';
 
@@ -14,7 +14,7 @@ const SourceLink = memo<{ source?: MemorySource | null }>(({ source }) => {
 
   return (
     <Link
-      href={SESSION_CHAT_TOPIC_URL(source.agentId, source.id)}
+      href={AGENT_CHAT_TOPIC_URL(source.agentId, source.id)}
       style={{
         flex: 1,
         maxWidth: '100%',

--- a/src/routes/(main)/memory/features/SourceLink.tsx
+++ b/src/routes/(main)/memory/features/SourceLink.tsx
@@ -1,9 +1,9 @@
+import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import { Button, Icon, Text } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { Link2 } from 'lucide-react';
 import { memo } from 'react';
 
-import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { type MemorySource } from '@/database/repositories/userMemory';
 import Link from '@/libs/router/Link';
 

--- a/src/routes/(main)/settings/stats/features/rankings/AssistantsRank.tsx
+++ b/src/routes/(main)/settings/stats/features/rankings/AssistantsRank.tsx
@@ -6,7 +6,7 @@ import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DEFAULT_AVATAR } from '@/const/meta';
-import { SESSION_CHAT_URL } from '@/const/url';
+import { AGENT_CHAT_URL } from '@/const/url';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import Link from '@/libs/router/Link';
 import { useClientDataSWR } from '@/libs/swr';
@@ -31,7 +31,7 @@ export const AssistantsRank = memo<{ mobile?: boolean }>(({ mobile }) => {
 
   const mapData = (item: AgentRankItem) => {
     const isInbox = item.id === inboxAgentId;
-    const path = SESSION_CHAT_URL(item.id, mobile);
+    const path = AGENT_CHAT_URL(item.id, mobile);
     const link = mobile
       ? qs.stringifyUrl({ query: { showMobileWorkspace: true }, url: path })
       : path;

--- a/src/routes/(main)/settings/stats/features/rankings/AssistantsRank.tsx
+++ b/src/routes/(main)/settings/stats/features/rankings/AssistantsRank.tsx
@@ -1,3 +1,4 @@
+import { AGENT_CHAT_URL } from '@lobechat/const';
 import { BarList } from '@lobehub/charts';
 import { ActionIcon, Avatar, Modal } from '@lobehub/ui';
 import { MaximizeIcon } from 'lucide-react';
@@ -6,7 +7,6 @@ import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DEFAULT_AVATAR } from '@/const/meta';
-import { AGENT_CHAT_URL } from '@/const/url';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import Link from '@/libs/router/Link';
 import { useClientDataSWR } from '@/libs/swr';

--- a/src/routes/(main)/settings/stats/features/rankings/TopicsRank.tsx
+++ b/src/routes/(main)/settings/stats/features/rankings/TopicsRank.tsx
@@ -1,3 +1,4 @@
+import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import { BarList } from '@lobehub/charts';
 import { ActionIcon, Icon, Modal } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
@@ -6,7 +7,6 @@ import qs from 'query-string';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import Link from '@/libs/router/Link';
 import { useClientDataSWR } from '@/libs/swr';

--- a/src/routes/(main)/settings/stats/features/rankings/TopicsRank.tsx
+++ b/src/routes/(main)/settings/stats/features/rankings/TopicsRank.tsx
@@ -6,7 +6,7 @@ import qs from 'query-string';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_URL } from '@/const/url';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import Link from '@/libs/router/Link';
 import { useClientDataSWR } from '@/libs/swr';
@@ -33,7 +33,7 @@ export const TopicsRank = memo<{ mobile?: boolean }>(({ mobile }) => {
     // Topics without an agentId fall back to the inbox agent, mirroring the
     // previous `sessionId || INBOX` behavior in the agent-centric model.
     const agentId = item.agentId ?? inboxAgentId;
-    const path = agentId ? SESSION_CHAT_TOPIC_URL(agentId, item.id) : '/';
+    const path = agentId ? AGENT_CHAT_TOPIC_URL(agentId, item.id) : '/';
     const link =
       mobile && agentId
         ? qs.stringifyUrl({ query: { showMobileWorkspace: true }, url: path })

--- a/src/routes/(mobile)/(home)/features/SessionListContent/Inbox/index.tsx
+++ b/src/routes/(mobile)/(home)/features/SessionListContent/Inbox/index.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 import { Link } from 'react-router';
 
 import { DEFAULT_INBOX_AVATAR } from '@/const/meta';
-import { SESSION_CHAT_URL } from '@/const/url';
+import { AGENT_CHAT_URL } from '@/const/url';
 import { useNavigateToAgent } from '@/hooks/useNavigateToAgent';
 import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';
@@ -21,7 +21,7 @@ const Inbox = memo(() => {
   return (
     <Link
       aria-label={'Lobe AI'}
-      to={SESSION_CHAT_URL(inboxAgentId, mobile)}
+      to={AGENT_CHAT_URL(inboxAgentId, mobile)}
       onClick={(e) => {
         e.preventDefault();
         navigateToAgent(inboxAgentId);

--- a/src/routes/(mobile)/(home)/features/SessionListContent/Inbox/index.tsx
+++ b/src/routes/(mobile)/(home)/features/SessionListContent/Inbox/index.tsx
@@ -1,8 +1,8 @@
+import { AGENT_CHAT_URL } from '@lobechat/const';
 import { memo } from 'react';
 import { Link } from 'react-router';
 
 import { DEFAULT_INBOX_AVATAR } from '@/const/meta';
-import { AGENT_CHAT_URL } from '@/const/url';
 import { useNavigateToAgent } from '@/hooks/useNavigateToAgent';
 import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';

--- a/src/routes/(mobile)/(home)/features/SessionListContent/List/index.tsx
+++ b/src/routes/(mobile)/(home)/features/SessionListContent/List/index.tsx
@@ -4,7 +4,7 @@ import { memo } from 'react';
 import LazyLoad from 'react-lazy-load';
 import { Link } from 'react-router';
 
-import { SESSION_CHAT_URL } from '@/const/index';
+import { AGENT_CHAT_URL } from '@/const/index';
 import { useNavigateToAgent } from '@/hooks/useNavigateToAgent';
 import { useServerConfigStore } from '@/store/serverConfig';
 import { getSessionStoreState, useSessionStore } from '@/store/session';
@@ -43,7 +43,7 @@ const SessionList = memo<SessionListProps>(({ dataSource, groupId, showAddButton
       <LazyLoad className={styles} key={id}>
         <Link
           aria-label={id}
-          to={SESSION_CHAT_URL((res as any).config?.id, mobile)}
+          to={AGENT_CHAT_URL((res as any).config?.id, mobile)}
           onClick={(e) => {
             e.preventDefault();
             navigateToAgent((res as any).config?.id);

--- a/src/routes/(mobile)/chat/features/ChatHeader/index.tsx
+++ b/src/routes/(mobile)/chat/features/ChatHeader/index.tsx
@@ -3,7 +3,6 @@
 import { ChatHeader } from '@lobehub/ui/mobile';
 import { memo, useState } from 'react';
 
-import { INBOX_SESSION_ID } from '@/const/session';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import ShareButton from '@/routes/(main)/agent/features/Conversation/Header/ShareButton';
 
@@ -20,7 +19,9 @@ const MobileHeader = memo(() => {
       right={<ShareButton mobile open={open} setOpen={setOpen} />}
       style={{ width: '100%' }}
       onBackClick={() =>
-        router.push('/agent', { query: { session: INBOX_SESSION_ID }, replace: true })
+        // `/agent` index redirects to `..` (mobile home / session list), preserving
+        // workspace scope; the old `?session=` query was never read by the target.
+        router.push('/agent', { replace: true })
       }
     />
   );

--- a/src/spa/router/desktopRouter.config.desktop.tsx
+++ b/src/spa/router/desktopRouter.config.desktop.tsx
@@ -228,6 +228,11 @@ export const sharedMainAreaChildren: RouteObject[] = [
             element: <GroupProfilePage />,
             path: 'profile',
           },
+          {
+            element: <GroupPage />,
+            handle: { meta: groupRouteMeta },
+            path: ':topicId',
+          },
         ],
         element: <DesktopGroupLayout />,
         errorElement: <ErrorBoundary />,

--- a/src/spa/router/desktopRouter.config.tsx
+++ b/src/spa/router/desktopRouter.config.tsx
@@ -31,6 +31,11 @@ import { dynamicElement, dynamicLayout, ErrorBoundary, redirectElement } from '@
 
 const agentChatElement = dynamicElement(() => import('@/routes/(main)/agent'), 'Desktop > Chat');
 
+const groupChatElement = dynamicElement(
+  () => import('@/routes/(main)/group'),
+  'Desktop > Agent Group',
+);
+
 /**
  * Children shared between the root tree (`/`) and the workspace tree
  * (`/:workspaceSlug`). Personal-only segments (settings, index, catch-all,
@@ -151,7 +156,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
       {
         children: [
           {
-            element: dynamicElement(() => import('@/routes/(main)/group'), 'Desktop > Agent Group'),
+            element: groupChatElement,
             handle: { meta: groupRouteMeta },
             index: true,
           },
@@ -161,6 +166,11 @@ export const sharedMainAreaChildren: RouteObject[] = [
               'Desktop > Agent Group > Profile',
             ),
             path: 'profile',
+          },
+          {
+            element: groupChatElement,
+            handle: { meta: groupRouteMeta },
+            path: ':topicId',
           },
         ],
         element: dynamicLayout(

--- a/src/store/agentGroup/slices/lifecycle.ts
+++ b/src/store/agentGroup/slices/lifecycle.ts
@@ -1,6 +1,6 @@
+import { GROUP_CHAT_TOPIC_URL, GROUP_CHAT_URL } from '@lobechat/const';
 import { type NewChatGroup } from '@lobechat/types';
 
-import { GROUP_CHAT_TOPIC_URL, GROUP_CHAT_URL } from '@/const/url';
 import { chatGroupService } from '@/services/chatGroup';
 import { useChatStore } from '@/store/chat';
 import { getHomeStoreState } from '@/store/home';

--- a/src/store/agentGroup/slices/lifecycle.ts
+++ b/src/store/agentGroup/slices/lifecycle.ts
@@ -1,6 +1,6 @@
 import { type NewChatGroup } from '@lobechat/types';
-import urlJoin from 'url-join';
 
+import { GROUP_CHAT_TOPIC_URL, GROUP_CHAT_URL } from '@/const/url';
 import { chatGroupService } from '@/services/chatGroup';
 import { useChatStore } from '@/store/chat';
 import { getHomeStoreState } from '@/store/home';
@@ -74,10 +74,12 @@ export class ChatGroupLifecycleAction {
     // Update chat store's activeTopicId
     useChatStore.getState().switchTopic(topicId ?? undefined);
 
-    // Navigate with replace to avoid stale query params
-    router.push(urlJoin('/group', activeGroupId), {
-      query: { topic: topicId ?? null },
-      replace: true,
-    });
+    // Navigate to the topic path (or group root for a new topic), aligning with
+    // the agent route's `/agent/:aid/:topicId` scheme. Replace to avoid stacking
+    // history entries on rapid topic switches.
+    const target = topicId
+      ? GROUP_CHAT_TOPIC_URL(activeGroupId, topicId)
+      : GROUP_CHAT_URL(activeGroupId);
+    router.push(target, { replace: true });
   };
 }

--- a/src/store/chat/utils/desktopNotification.ts
+++ b/src/store/chat/utils/desktopNotification.ts
@@ -1,9 +1,4 @@
-import {
-  GROUP_CHAT_URL,
-  isDesktop,
-  SESSION_CHAT_TOPIC_URL,
-  SESSION_CHAT_URL,
-} from '@lobechat/const';
+import { AGENT_CHAT_TOPIC_URL, AGENT_CHAT_URL, GROUP_CHAT_URL, isDesktop } from '@lobechat/const';
 import type { ConversationContext } from '@lobechat/types';
 import { t } from 'i18next';
 
@@ -30,9 +25,9 @@ export const resolveNotificationNavigatePath = (
 ): string | undefined => {
   if (context.groupId) return GROUP_CHAT_URL(context.groupId);
   if (context.agentId && context.topicId) {
-    return SESSION_CHAT_TOPIC_URL(context.agentId, context.topicId);
+    return AGENT_CHAT_TOPIC_URL(context.agentId, context.topicId);
   }
-  if (context.agentId) return SESSION_CHAT_URL(context.agentId);
+  if (context.agentId) return AGENT_CHAT_URL(context.agentId);
   return undefined;
 };
 

--- a/src/store/global/actions/general.ts
+++ b/src/store/global/actions/general.ts
@@ -1,8 +1,8 @@
+import { AGENT_CHAT_TOPIC_URL, GROUP_CHAT_TOPIC_URL } from '@lobechat/const';
 import isEqual from 'fast-deep-equal';
 import { gt, parse, valid } from 'semver';
 import type { SWRResponse } from 'swr';
 
-import { AGENT_CHAT_TOPIC_URL, GROUP_CHAT_TOPIC_URL } from '@/const/url';
 import { CURRENT_VERSION, isDesktop } from '@/const/version';
 import { useOnlyFetchOnceSWR } from '@/libs/swr';
 import { globalKeys } from '@/libs/swr/keys';

--- a/src/store/global/actions/general.ts
+++ b/src/store/global/actions/general.ts
@@ -2,7 +2,7 @@ import isEqual from 'fast-deep-equal';
 import { gt, parse, valid } from 'semver';
 import type { SWRResponse } from 'swr';
 
-import { SESSION_CHAT_TOPIC_URL } from '@/const/url';
+import { AGENT_CHAT_TOPIC_URL, GROUP_CHAT_TOPIC_URL } from '@/const/url';
 import { CURRENT_VERSION, isDesktop } from '@/const/version';
 import { useOnlyFetchOnceSWR } from '@/libs/swr';
 import { globalKeys } from '@/libs/swr/keys';
@@ -69,7 +69,7 @@ export class GlobalGeneralActionImpl {
 
   openTopicInNewWindow = async (agentId: string, topicId: string): Promise<void> => {
     const popupPath = `/popup/agent/${agentId}/${topicId}`;
-    const browserUrl = SESSION_CHAT_TOPIC_URL(agentId, topicId);
+    const browserUrl = AGENT_CHAT_TOPIC_URL(agentId, topicId);
 
     if (isDesktop) {
       try {
@@ -100,7 +100,7 @@ export class GlobalGeneralActionImpl {
 
   openGroupTopicInNewWindow = async (groupId: string, topicId: string): Promise<void> => {
     const popupPath = `/popup/group/${groupId}/${topicId}`;
-    const browserUrl = `/group/${groupId}?topic=${topicId}`;
+    const browserUrl = GROUP_CHAT_TOPIC_URL(groupId, topicId);
 
     if (isDesktop) {
       try {

--- a/src/store/global/actions/workspacePane.ts
+++ b/src/store/global/actions/workspacePane.ts
@@ -1,7 +1,7 @@
 import { produce } from 'immer';
 
 import { INBOX_SESSION_ID } from '@/const/session';
-import { SESSION_CHAT_URL } from '@/const/url';
+import { AGENT_CHAT_URL } from '@/const/url';
 import type { GlobalStore } from '@/store/global';
 import type { ModelDetailPanelExpandedKey, WorkingSidebarTab } from '@/store/global/initialState';
 import type { StoreSetter } from '@/store/types';
@@ -24,7 +24,7 @@ export class GlobalWorkspacePaneActionImpl {
   }
 
   switchBackToChat = (sessionId?: string): void => {
-    const target = SESSION_CHAT_URL(sessionId || INBOX_SESSION_ID, this.#get().isMobile);
+    const target = AGENT_CHAT_URL(sessionId || INBOX_SESSION_ID, this.#get().isMobile);
     getStableNavigate()?.(target);
   };
 

--- a/src/store/global/actions/workspacePane.ts
+++ b/src/store/global/actions/workspacePane.ts
@@ -1,7 +1,7 @@
+import { AGENT_CHAT_URL } from '@lobechat/const';
 import { produce } from 'immer';
 
 import { INBOX_SESSION_ID } from '@/const/session';
-import { AGENT_CHAT_URL } from '@/const/url';
 import type { GlobalStore } from '@/store/global';
 import type { ModelDetailPanelExpandedKey, WorkingSidebarTab } from '@/store/global/initialState';
 import type { StoreSetter } from '@/store/types';


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] ♻️ refactor

#### 🔗 Related Issue

<!-- no matching tracked issue -->

#### 🔀 Description of Change

**1. Group topic routing now matches agent (`/group/:gid/:topicId`)**

Group chat previously kept the active topic in a `?topic=` query param, while agent uses a path segment (`/agent/:aid/:topicId`). Opening a topic-less group URL (e.g. `/group/cg_xxx`) left the conversation in a broken state. This aligns group with the agent scheme:

- Added a `:topicId` child route under `group/:gid` in **both** desktop router configs (`desktopRouter.config.tsx` + `.desktop.tsx`); `desktopRouter.sync.test` stays green.
- Group `ChatHydration` now two-way-binds the `:topicId` path param (mirrors agent), and `GroupIdSync` preserves a URL-carried topic on group switch.
- `switchTopic` and all group topic URL builders (sidebar item href / open-in-tab / dropdown "open in new tab" + "copy link", new-window) now produce `/group/:gid/:topicId`.

**2. Rename `SESSION_CHAT_*` URL helpers → `AGENT_CHAT_*`**

These helpers build `/agent/...` URLs — the "session" name is legacy and misleading. Renamed across the repo (43 files) for clarity and symmetry with `GROUP_CHAT_*`:

| Old | New |
| --- | --- |
| `SESSION_CHAT_URL` | `AGENT_CHAT_URL` |
| `SESSION_CHAT_TOPIC_URL` | `AGENT_CHAT_TOPIC_URL` |
| `SESSION_CHAT_TOPIC_PAGE_URL` | `AGENT_CHAT_TOPIC_PAGE_URL` |

Also added a `GROUP_CHAT_TOPIC_URL(groupId, topicId)` helper (parallel to `GROUP_CHAT_URL`) and routed all group topic URL construction through it.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Open a group, click between topics — URL becomes `/group/:gid/:topicId`; refresh restores the same topic.
- "Copy link" / "Open in new tab" / new-window on a group topic produce the path-param URL.
- `desktopRouter.sync.test.tsx` and the renamed URL-helper mocks (agent topic/dropdown/Nav/GroupItem) pass.

#### 📝 Additional Information

Type-check is clean for all touched files; the only standalone `type-check` errors locally are pre-existing `@lobehub/ui/base-ui` `Tabs` export noise from a stale local package build, unrelated to this change.