### PR TITLE
🐛 fix(builtin-tool): surface real task & agent data in tool cards

### DIFF
--- a/packages/builtin-tool-agent-management/src/client/Inspector/GetAgentDetail/index.tsx
+++ b/packages/builtin-tool-agent-management/src/client/Inspector/GetAgentDetail/index.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import type { BuiltinInspectorProps } from '@lobechat/types';
-import { Flexbox } from '@lobehub/ui';
+import { Avatar, Flexbox, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cx } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { highlightTextStyles, shinyTextStyles } from '@/styles';
 
-import type { GetAgentDetailParams } from '../../../types';
+import type { GetAgentDetailParams, GetAgentDetailState } from '../../../types';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   root: css`
@@ -24,35 +24,55 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-export const GetAgentDetailInspector = memo<BuiltinInspectorProps<GetAgentDetailParams>>(
-  ({ args, partialArgs, isArgumentsStreaming }) => {
-    const { t } = useTranslation('plugin');
+export const GetAgentDetailInspector = memo<
+  BuiltinInspectorProps<GetAgentDetailParams, GetAgentDetailState>
+>(({ args, partialArgs, isArgumentsStreaming, pluginState }) => {
+  const { t } = useTranslation('plugin');
 
-    const agentId = args?.agentId || partialArgs?.agentId;
+  const agentId = args?.agentId || partialArgs?.agentId;
+  // Once the result lands, show the resolved agent name instead of the opaque
+  // `agt_xxx` id; keep the id reachable via tooltip.
+  const meta = pluginState?.meta;
+  const title = meta?.title;
 
-    if (isArgumentsStreaming && !agentId) {
-      return (
-        <div className={cx(styles.root, shinyTextStyles.shinyText)}>
-          <span>{t('builtins.lobe-agent-management.apiName.getAgentDetail')}</span>
-        </div>
-      );
-    }
-
+  if (isArgumentsStreaming && !agentId) {
     return (
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={cx(styles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
-        gap={8}
-      >
-        <span className={styles.title}>
-          {t('builtins.lobe-agent-management.inspector.getAgentDetail.title')}
-        </span>
-        {agentId && <span className={highlightTextStyles.primary}>{agentId}</span>}
-      </Flexbox>
+      <div className={cx(styles.root, shinyTextStyles.shinyText)}>
+        <span>{t('builtins.lobe-agent-management.apiName.getAgentDetail')}</span>
+      </div>
     );
-  },
-);
+  }
+
+  return (
+    <Flexbox
+      horizontal
+      align={'center'}
+      className={cx(styles.root, isArgumentsStreaming && shinyTextStyles.shinyText)}
+      gap={8}
+    >
+      <span className={styles.title}>
+        {t('builtins.lobe-agent-management.inspector.getAgentDetail.title')}
+      </span>
+      {title ? (
+        <Tooltip title={agentId}>
+          <Flexbox horizontal align={'center'} gap={6}>
+            {meta?.avatar && (
+              <Avatar
+                avatar={meta.avatar}
+                background={meta.backgroundColor}
+                shape={'square'}
+                size={16}
+              />
+            )}
+            <span className={highlightTextStyles.primary}>{title}</span>
+          </Flexbox>
+        </Tooltip>
+      ) : (
+        agentId && <span className={highlightTextStyles.primary}>{agentId}</span>
+      )}
+    </Flexbox>
+  );
+});
 
 GetAgentDetailInspector.displayName = 'GetAgentDetailInspector';
 

--- a/packages/builtin-tool-task/src/client/Render/CreateTask/index.tsx
+++ b/packages/builtin-tool-task/src/client/Render/CreateTask/index.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import type { BuiltinRenderProps } from '@lobechat/types';
-import { ActionIcon, Block, Text } from '@lobehub/ui';
+import { ActionIcon, Block, Markdown, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { PanelRight, PanelRightClose } from 'lucide-react';
 import { memo, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import TaskPriorityTag from '@/features/AgentTasks/features/TaskPriorityTag';
+import TaskStatusTag from '@/features/AgentTasks/features/TaskStatusTag';
 import { useChatStore } from '@/store/chat';
 import { chatPortalSelectors } from '@/store/chat/selectors';
 
@@ -17,6 +19,16 @@ import type { CreateTaskParams, CreateTaskState } from '../../../types';
 const autoOpened = new Set<string>();
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
+  description: css`
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
+
+    font-size: 12px;
+    line-height: 1.5;
+    color: ${cssVar.colorTextTertiary};
+  `,
   identifier: css`
     flex-shrink: 0;
 
@@ -31,14 +43,15 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     background: ${cssVar.colorFillTertiary};
   `,
   instruction: css`
+    /* The instruction is model-facing markdown; render it as a faded preview
+       rather than flattening it to plain text. Full content lives in the
+       expanded detail panel. */
     overflow: hidden;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 3;
+    max-height: 132px;
 
-    font-size: 12px;
-    line-height: 1.5;
-    color: ${cssVar.colorTextTertiary};
+    mask-image: linear-gradient(to bottom, black 78%, transparent);
+
+    mask-image: linear-gradient(to bottom, black 78%, transparent);
   `,
   row: css`
     display: flex;
@@ -94,11 +107,17 @@ export const CreateTaskRender = memo<BuiltinRenderProps<CreateTaskParams, Create
       openTaskDetail(identifier);
     }, [identifier, openTaskDetail]);
 
-    if (!args?.name && !identifier) return null;
+    // Prefer the resolved task (`pluginState`); fall back to `args` while the
+    // call is still streaming and no result has landed yet.
+    const name = pluginState?.name ?? args?.name;
 
-    const name = args?.name;
+    if (!name && !identifier) return null;
+
+    const status = pluginState?.status;
+    const priority = pluginState?.priority ?? undefined;
+    const description = pluginState?.description;
     const instruction = args?.instruction;
-    const parent = args?.parentIdentifier;
+    const parent = pluginState?.parentIdentifier ?? args?.parentIdentifier;
     const isExpanded = !!identifier && showTaskDetail && activeTaskDetailId === identifier;
 
     const toggle = () => {
@@ -118,6 +137,8 @@ export const CreateTaskRender = memo<BuiltinRenderProps<CreateTaskParams, Create
           <div className={styles.row}>
             {identifier && <span className={styles.identifier}>{identifier}</span>}
             {name && <Text className={styles.title}>{name}</Text>}
+            {status && <TaskStatusTag disableDropdown size={14} status={status} />}
+            {!!priority && <TaskPriorityTag disableDropdown priority={priority} size={14} />}
             {identifier && (
               <ActionIcon
                 active={isExpanded}
@@ -131,7 +152,15 @@ export const CreateTaskRender = memo<BuiltinRenderProps<CreateTaskParams, Create
               />
             )}
           </div>
-          {instruction && <div className={styles.instruction}>{instruction}</div>}
+          {description ? (
+            <div className={styles.description}>{description}</div>
+          ) : instruction ? (
+            <div className={styles.instruction}>
+              <Markdown fontSize={12} variant={'chat'}>
+                {instruction}
+              </Markdown>
+            </div>
+          ) : null}
           {parent && (
             <Text as={'span'} color={cssVar.colorTextTertiary} fontSize={11}>
               {`Subtask of ${parent}`}

--- a/packages/builtin-tool-task/src/client/executor/index.ts
+++ b/packages/builtin-tool-task/src/client/executor/index.ts
@@ -194,7 +194,18 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
           priority: task.priority,
           status: task.status,
         }),
-        state: { identifier: task.identifier, success: true },
+        // Structure the freshly-created task into `state` so the renderer and
+        // the Debug "skill state" panel have real data without re-deriving from
+        // `args` (the only other source after a conversation reopen).
+        state: {
+          description: task.description,
+          identifier: task.identifier,
+          name: task.name,
+          parentIdentifier,
+          priority: task.priority,
+          status: task.status as TaskStatus,
+          success: true,
+        },
         success: true,
       };
     } catch (error) {

--- a/packages/builtin-tool-task/src/types.ts
+++ b/packages/builtin-tool-task/src/types.ts
@@ -55,7 +55,17 @@ export interface CreateTaskParams {
 }
 
 export interface CreateTaskState {
+  /** Short human-facing description, when the task has one. */
+  description?: string | null;
   identifier?: string;
+  /** Display name of the created task. */
+  name?: string | null;
+  /** Parent task identifier when created as a subtask. */
+  parentIdentifier?: string;
+  /** Priority level (0 = none … 4 = low). */
+  priority?: number | null;
+  /** Lifecycle status the task was created in (usually `backlog`). */
+  status?: TaskStatus;
   success: boolean;
 }
 


### PR DESCRIPTION
### 💻 变更类型 | Change Type

<!-- 🐛 fix -->

- [x] 🐛 fix

### 🔀 变更说明 | Description of Change

Two builtin tools were dropping data that was already in hand, so their tool cards rendered placeholders or raw text.

**`createTask` (`builtin-tool-task`)** — the executor had the full created `task` but only stored `{ success, identifier }` in `state`. The Debug "skill state" panel therefore showed almost nothing, and the Render card read `args.instruction` directly, flattening the model-facing markdown into line-clamped plain text (the "没眼看" card).

- Widened `CreateTaskState` and backfilled it from the created task: `name / status / priority / description / parentIdentifier`.
- Reworked the Render card: header shows `identifier + name + status tag + priority tag` (reusing `TaskStatusTag` / `TaskPriorityTag` in `disableDropdown` form), and the body renders the instruction as a faded Markdown preview (full content stays one click away in the detail panel) — no more flattened raw markdown.

**`getAgentDetail` (`builtin-tool-agent-management`)** — the state was already complete (`meta.title/avatar`, `config.model/provider/runtime`) and the expanded Render used it, but the collapsed Inspector ignored `pluginState` and only showed the opaque `agt_xxx` id.

- Inspector now reads `pluginState`: shows the resolved agent title (+ avatar) once the result lands, degrading the id to a tooltip.

### 📝 补充信息 | Additional Information

- No schema / migration changes; `state` is JSON on the tool result.
- `createTasks` batch and `extractIdentifier` still read `state.identifier`, unchanged.

### ✅ How to Test

- [x] Type-check passes for the touched files.
- In a chat, ask the agent to create a task → card shows name + status/priority tags + a readable instruction preview; Debug "skill state" tab shows the structured task.
- Ask the agent to get an agent's detail → collapsed Inspector shows the agent name + avatar (id on hover) instead of `agt_xxx`.