### PR TITLE
🐛 fix(task): align topic drawer layout

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailPage.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailPage.tsx
@@ -38,7 +38,7 @@ const TaskDetailPage = memo<TaskDetailPageProps>(({ taskId, showTaskAgentPanelTo
 
   if (isNotFound) {
     return (
-      <Flexbox flex={1} height={'100%'} style={{ minHeight: 0 }}>
+      <Flexbox flex={1} height={'100%'} style={{ minHeight: 0, position: 'relative' }}>
         <NavHeader
           left={<Breadcrumb taskId={taskId} />}
           styles={{ left: { paddingLeft: 4, gap: 8 } }}
@@ -59,7 +59,7 @@ const TaskDetailPage = memo<TaskDetailPageProps>(({ taskId, showTaskAgentPanelTo
   }
 
   return (
-    <Flexbox flex={1} height={'100%'} style={{ minHeight: 0 }}>
+    <Flexbox flex={1} height={'100%'} style={{ minHeight: 0, position: 'relative' }}>
       <NavHeader
         left={
           <>

--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment happy-dom
  */
 import { render } from '@testing-library/react';
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import TopicChatDrawer from './index';
@@ -52,43 +52,74 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
+const serializeSize = (size: unknown) =>
+  size === undefined ? '' : typeof size === 'string' ? size : JSON.stringify(size);
+
 vi.mock('@lobehub/ui', () => ({
   ActionIcon: ({
     disabled,
+    icon,
     onClick,
+    size,
     title,
   }: {
     disabled?: boolean;
+    icon?: { name?: string };
     onClick?: () => void;
+    size?: unknown;
     title?: string;
   }) => (
-    <button disabled={disabled} title={title} onClick={onClick}>
+    <button
+      data-icon={icon?.name}
+      data-size={serializeSize(size)}
+      data-testid="header-action-icon"
+      disabled={disabled}
+      title={title}
+      onClick={onClick}
+    >
       {title}
     </button>
   ),
   copyToClipboard: vi.fn(),
   Drawer: ({
     children,
+    closeIconProps,
     extra,
     open,
+    styles,
     title,
   }: {
     children?: ReactNode;
+    closeIconProps?: { size?: unknown };
     extra?: ReactNode;
     open?: boolean;
+    styles?: { title?: CSSProperties };
     title?: ReactNode;
   }) =>
     open ? (
       <div data-testid="topic-drawer">
-        {title}
+        <div data-testid="drawer-title-slot" style={styles?.title}>
+          {title}
+        </div>
         {extra}
+        <button data-size={serializeSize(closeIconProps?.size)} data-testid="drawer-close-icon" />
         {children}
       </div>
     ) : null,
   DropdownMenu: ({ children }: { children?: ReactNode }) => <>{children}</>,
-  Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Flexbox: ({
+    children,
+    flex,
+    style,
+  }: {
+    children?: ReactNode;
+    flex?: CSSProperties['flex'];
+    style?: CSSProperties;
+  }) => <div style={{ flex, ...style }}>{children}</div>,
   Freeze: ({ children }: { children?: ReactNode; frozen?: boolean }) => <>{children}</>,
-  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  Text: ({ children, style }: { children?: ReactNode; style?: CSSProperties }) => (
+    <span style={style}>{children}</span>
+  ),
 }));
 
 vi.mock('antd-style', () => ({
@@ -195,5 +226,32 @@ describe('TopicChatDrawer', () => {
     const { getByTitle } = render(<TopicChatDrawer />);
 
     expect(getByTitle('requires member')).toBeDisabled();
+  });
+
+  it('constrains long drawer titles before the header actions', () => {
+    const { getByTestId, getByText } = render(<TopicChatDrawer />);
+
+    const title = getByText('Topic 1');
+
+    expect(title).toHaveStyle({ flex: '0 1 auto', minWidth: '0' });
+    expect(title.parentElement).toHaveStyle({ maxWidth: '100%', overflow: 'hidden' });
+    expect(getByTestId('drawer-title-slot')).toHaveStyle({
+      boxSizing: 'border-box',
+      maxWidth: '100%',
+      overflow: 'hidden',
+      paddingInlineEnd: '48px',
+    });
+  });
+
+  it('keeps the share button box aligned with the default close button', () => {
+    const { getAllByTestId, getByTestId } = render(<TopicChatDrawer />);
+
+    const icons = getAllByTestId('header-action-icon');
+    const moreIcon = icons.find((icon) => !icon.getAttribute('title'));
+    const shareIcon = icons.find((icon) => icon.getAttribute('title') === 'share');
+
+    expect(moreIcon).toHaveAttribute('data-size', 'small');
+    expect(shareIcon).toHaveAttribute('data-size', JSON.stringify({ blockSize: 36, size: 18 }));
+    expect(getByTestId('drawer-close-icon')).toHaveAttribute('data-size', '');
   });
 });

--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
@@ -36,6 +36,8 @@ import { authSelectors } from '@/store/user/selectors';
 import TopicStatusIcon from '../TopicStatusIcon';
 import FeedbackInput from './FeedbackInput';
 
+const SHARE_ICON_SIZE = { blockSize: 36, size: 18 } as const;
+
 interface TopicChatDrawerBodyProps {
   agentId: string;
   topicId: string;
@@ -159,13 +161,19 @@ const TopicChatDrawer = memo(() => {
   );
 
   const title = (
-    <Flexbox horizontal align={'center'} gap={8} style={{ minWidth: 0 }}>
+    <Flexbox
+      horizontal
+      align={'center'}
+      flex={1}
+      gap={8}
+      style={{ maxWidth: '100%', minWidth: 0, overflow: 'hidden' }}
+    >
       <TopicStatusIcon size={16} status={status} />
-      <Text ellipsis weight={500}>
+      <Text ellipsis style={{ flex: '0 1 auto', minWidth: 0 }} weight={500}>
         {activity?.title || t('taskDetail.topicDrawer.untitled')}
       </Text>
       {activity?.seq != null && (
-        <Text fontSize={12} type={'secondary'}>
+        <Text fontSize={12} style={{ flex: 'none' }} type={'secondary'}>
           #{activity.seq}
         </Text>
       )}
@@ -179,7 +187,7 @@ const TopicChatDrawer = memo(() => {
     <ActionIcon
       disabled={!canShare}
       icon={Share2}
-      size={'small'}
+      size={SHARE_ICON_SIZE}
       title={canShare ? t('share', { ns: 'common' }) : reason}
       onClick={enableTopicLinkShare || !canShare ? undefined : openShareModal}
     />
@@ -213,6 +221,13 @@ const TopicChatDrawer = memo(() => {
       styles={{
         body: { padding: 0 },
         bodyContent: { height: '100%' },
+        title: {
+          boxSizing: 'border-box',
+          maxWidth: '100%',
+          minWidth: 0,
+          overflow: 'hidden',
+          paddingInlineEnd: 48,
+        },
         wrapper: {
           border: `1px solid ${cssVar.colorBorderSecondary}`,
           borderRadius: 12,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

- Constrain the task topic drawer title area so inline Drawer rendering does not overflow or misalign the panel.
- Keep long topic titles ellipsized while preserving compact spacing for topic sequence and menu actions.
- Align the share action visually with the default close button without changing the close button behavior.
- Add focused regression tests for the drawer positioning context, title constraints, and header action sizing.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Command:

```bash
bunx vitest run --silent='passed-only' src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx src/features/AgentTasks/AgentTaskDetail/TaskDetailPage.test.tsx
```

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Topic drawer title could overflow or leave misaligned header actions. | Topic drawer title is constrained and header actions align with the close button. |

#### 📝 Additional Information

The PR was prepared from a clean worktree based on `origin/canary`; unrelated desktop menu changes present in the original checkout were not included.