### PR TITLE
⚡️ perf(conversation): disable text streaming animation when a tool already follows the text

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.test.tsx
@@ -37,13 +37,16 @@ vi.mock('../../../store', () => ({
   useConversationStore: (selector: (state: unknown) => unknown) => selector({}),
 }));
 
+const useMarkdownMock = vi.fn(() => ({}));
+
 vi.mock('../useMarkdown', () => ({
-  useMarkdown: () => ({}),
+  useMarkdown: (...args: unknown[]) => useMarkdownMock(...args),
 }));
 
 describe('MessageContent', () => {
   afterEach(() => {
     cleanup();
+    useMarkdownMock.mockClear();
     mockStoreContent = 'original full content';
     mockStoreHasTools = true;
   });
@@ -61,5 +64,32 @@ describe('MessageContent', () => {
     render(<MessageContent id="block-1" />);
 
     expect(screen.getByTestId('markdown')).toHaveTextContent('original full content');
+  });
+
+  it('disables markdown streaming when the block already has tools below the text', () => {
+    render(<MessageContent hasToolsOverride contentOverride="lead sentence" id="block-1" />);
+
+    expect(useMarkdownMock).toHaveBeenCalledWith('block-1', true);
+  });
+
+  it('keeps markdown streaming enabled when the block has no tools and is not disabled', () => {
+    render(
+      <MessageContent contentOverride="lead sentence" hasToolsOverride={false} id="block-1" />,
+    );
+
+    expect(useMarkdownMock).toHaveBeenCalledWith('block-1', false);
+  });
+
+  it('disables markdown streaming when disableStreaming is set even without tools', () => {
+    render(
+      <MessageContent
+        disableStreaming
+        contentOverride="lead sentence"
+        hasToolsOverride={false}
+        id="block-1"
+      />,
+    );
+
+    expect(useMarkdownMock).toHaveBeenCalledWith('block-1', true);
   });
 });

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
@@ -33,7 +33,10 @@ const MessageContent = memo<MessageContentProps>(
     const hasTools = hasToolsOverride ?? storeHasTools;
 
     const message = normalizeThinkTags(processWithArtifact(content ?? ''));
-    const { drawer, markdownProps } = useMarkdown(id, disableStreaming);
+    // Once a tool call exists below this block's text, the text is already
+    // finalized — skip the streaming/fade-in animation so settled content above
+    // a tool doesn't keep re-animating.
+    const { drawer, markdownProps } = useMarkdown(id, disableStreaming || hasTools);
 
     if (!content && !hasTools) return <ContentLoading id={id} />;
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ⚡️ perf

#### 🔀 Description of Change

In `AssistantGroup`, a **mixed block** (assistant prose + a tool call in the same message item) can be the **last block** in the group. In that case `withMarkdownStreamingState` leaves `disableMarkdownStreaming = false`, so the block's text keeps the streaming/fade-in animation — even though a tool is already rendered directly below it and the text is already finalized. The settled text then re-plays its fade-in animation.

`AssistantGroup/components/MessageContent.tsx` already subscribes to the block's `hasTools`, so we OR it into the streaming-disable flag:

```ts
const { drawer, markdownProps } = useMarkdown(id, disableStreaming || hasTools);
```

This flows through `useMarkdown → useChatMarkdown` as `enableStream: false`, making `animated = false`. Behavior:

- Text still streaming, no tool yet → animates normally.
- A tool appears below the text → text renders statically (no re-animation).

#### 🧪 How to Test

- [x] Added/updated tests

Added 3 cases in `MessageContent.test.tsx` (turned the `useMarkdown` mock into a spy):
- block has tools → `useMarkdown(id, true)`
- no tools, not disabled → `useMarkdown(id, false)`
- `disableStreaming` set without tools → `useMarkdown(id, true)`

`bunx vitest run src/features/Conversation/Messages/AssistantGroup/components/MessageContent.test.tsx` → 5 passed. Type-check clean for changed files.

#### 📝 Additional Information

Scoped to the grouped-assistant renderer only; no behavior change for the single `Assistant` renderer.