### PR TITLE
✨ feat(ci): auto-handle MCP marketplace submission issues

### DIFF
--- a/.claude/prompts/team-assignment.md
+++ b/.claude/prompts/team-assignment.md
@@ -121,6 +121,15 @@ Quick reference for assigning issues based on labels.
 
 - Assign to @arvinxx for general issues
 
+**MCP marketplace listing/submission requests — do NOT mention (auto-handled):**
+
+Requests to **add / submit / list a new MCP server** to the marketplace are now processed automatically by the **MCP Submission Handler** workflow (it redirects installable servers to the self-service CLI and closes them, and labels remote-only servers `mcp:remote` for manual review). For these, **do NOT post any @mention comment — apply labels only.**
+
+- Recognize them by: titles like `[Request] Add <name> to the MCP marketplace`, `[MCP] Add/Submit <name>`, `[MCP Submission] …`, `[MCP Plugin] …`; the body asks to list/index a specific MCP server and links its repo or endpoint.
+- This does **NOT** apply to the following — they still get a normal @mention:
+  - Bugs about the marketplace pipeline or an existing listing — e.g. "scoring stuck", "shows outdated version", "rescan/re-index listing", "not syncing". → `@ONLY-yours @arvinxx`
+  - Feature requests about the marketplace product itself (search, catalog browser, etc.). → `@ONLY-yours`
+
 ## Comment Templates
 
 **Single owner:**

--- a/.github/scripts/auto-handle-mcp-submission.ts
+++ b/.github/scripts/auto-handle-mcp-submission.ts
@@ -1,0 +1,403 @@
+#!/usr/bin/env bun
+/**
+ * Auto-handle "Add my MCP server to the marketplace" issues.
+ *
+ * MCP listing requests are now self-service via the @lobehub/market-cli, so we
+ * no longer take them through GitHub issues. This script runs when an issue is
+ * opened: if it is a *new-server listing request* (and NOT a marketplace bug or
+ * CLI feedback), it labels the issue `mcp-submission`, posts the redirect
+ * template (pointing at the CLI, with the author's own repo filled in), and
+ * closes it as `not_planned`. The comment invites the author to reopen if it
+ * was closed by mistake.
+ *
+ * Anything that is not a confident match is left untouched for normal triage.
+ */
+
+declare global {
+  // @ts-ignore
+  var process: {
+    env: Record<string, string | undefined>;
+    exitCode?: number;
+  };
+}
+
+const MARKER = '<!-- bot:mcp-submission -->';
+const LABEL = 'mcp-submission';
+const LABEL_REMOTE = 'mcp:remote';
+const REPO_PLACEHOLDER = 'https://github.com/<owner>/<repo>';
+
+interface GitHubLabel {
+  name: string;
+}
+
+interface GitHubIssue {
+  body: string | null;
+  labels: GitHubLabel[];
+  number: number;
+  state: string;
+  title: string;
+  user: { login: string };
+}
+
+interface GitHubComment {
+  body: string;
+}
+
+async function githubRequest<T>(
+  endpoint: string,
+  token: string,
+  method: string = 'GET',
+  body?: unknown,
+): Promise<T> {
+  const response = await fetch(`https://api.github.com${endpoint}`, {
+    headers: {
+      'Accept': 'application/vnd.github+json',
+      'Authorization': `Bearer ${token}`,
+      'User-Agent': 'auto-handle-mcp-submission-script',
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    method,
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API ${method} ${endpoint} failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  // Some endpoints (e.g. label add) return 200 with a body; others may be empty.
+  const text = await response.text();
+  return (text ? JSON.parse(text) : undefined) as T;
+}
+
+/**
+ * Pull the first plausible "server repo" GitHub URL out of the issue body.
+ * Skips links to lobehub's own org and the MCP registry org so we land on the
+ * submitter's repository.
+ */
+function extractRepoUrl(body: string): string | null {
+  // github.com first-path segments that are NOT repositories (attachments,
+  // pasted screenshots, org pages, etc.). `user-attachments` is the big one —
+  // pasted images land at github.com/user-attachments/assets/... and must never
+  // be mistaken for a server repo.
+  const reserved = new Set([
+    'about',
+    'apps',
+    'collections',
+    'explore',
+    'features',
+    'join',
+    'login',
+    'marketplace',
+    'notifications',
+    'orgs',
+    'pricing',
+    'readme',
+    'search',
+    'settings',
+    'sponsors',
+    'topics',
+    'user-attachments',
+  ]);
+  // Our own org and the upstream registry — skip so we land on the submitter's repo.
+  const ignoredOwners = new Set(['lobehub', 'lobechat', 'modelcontextprotocol']);
+  const regex = /https?:\/\/github\.com\/([\w.-]+)\/([\w.-]+)/gi;
+
+  for (const match of body.matchAll(regex)) {
+    const owner = match[1];
+    let repo = match[2];
+    // Strip trailing junk like ".git", ")", ".", ","
+    repo = repo.replace(/\.git$/i, '').replace(/[).,]+$/, '');
+    if (!owner || !repo) continue;
+    const ownerLc = owner.toLowerCase();
+    if (reserved.has(ownerLc)) continue;
+    if (ignoredOwners.has(ownerLc)) continue;
+    return `https://github.com/${owner}/${repo}`;
+  }
+
+  return null;
+}
+
+interface Classification {
+  // How the server is delivered — only `local` (installable) servers can be
+  // self-published via the CLI; `remote` (URL-only) and `unknown` must go to a human.
+  delivery: 'local' | 'remote' | 'unknown';
+  isSubmission: boolean;
+  reason: string;
+  repoUrl: string | null;
+}
+
+/**
+ * Decide whether an issue is a *new MCP server listing request*.
+ *
+ * High precision on purpose — this drives a hard auto-close. We require an
+ * add/submit intent + the word "mcp" + a GitHub repo URL, and explicitly bail
+ * out on the two confusable categories observed in real issues:
+ *   - marketplace / existing-listing bugs (scoring stuck, outdated version…)
+ *   - feedback about the publishing CLI itself (which we actively welcome)
+ */
+function classify(title: string, body: string): Classification {
+  const text = `${title}\n${body}`.toLowerCase();
+  const repoUrl = extractRepoUrl(body);
+
+  const hasMcp = /\bmcp\b/.test(text);
+
+  // Explicit "add / submit my server" intent. The `[MCP Submission]` and
+  // `[MCP Plugin]` title prefixes are themselves a declaration of intent.
+  const hasAddVerb =
+    /\b(?:add|submit|submission|submitting|list(?:ing)?|publish|index|register|include)\b/.test(
+      text,
+    ) ||
+    /上架|收录|添加|提交|登记/.test(text) ||
+    /^\s*\[mcp\s*(?:submission|plugin)\]/i.test(title);
+
+  // Marketplace framing — keeps us on listing requests and off random MCP bug
+  // reports that merely mention "mcp" and a verb in passing. A leading `[MCP…`
+  // title tag counts as context.
+  const hasMarketContext =
+    /marketplace|市场|上架|收录|登记/.test(text) || /^\s*\[mcp\b/i.test(title);
+
+  // Problem with the marketplace pipeline or an already-listed server — NOT a
+  // new submission. Leave these for humans.
+  const isMarketplaceBug =
+    /scoring|re-?scan|re-?index|stuck|outdated|out of date|stale|not updating|won'?t update|wrong version|shows? (?:old|outdated|wrong)|disappeared|removed from|missing from|not show(?:ing)?|not syncing|sync(?:ing)? (?:from|issue)|canonical cache/.test(
+      text,
+    );
+
+  // Feedback about the publishing CLI / flow — we explicitly invite these, so
+  // never auto-close them.
+  const isCliFeedback =
+    /market-cli|publish-mcp|publishing skill/.test(text) ||
+    /\bcli\b.+(?:fail|error|issue|problem|bug|not work|can'?t|unable)/.test(text) ||
+    /(?:fail|error|unable|can'?t|cannot).*(?:submit|publish|login|connect|verify ownership)/.test(
+      text,
+    );
+
+  // Delivery method. The CLI can only self-publish *installable* servers
+  // (npm / npx / uvx / pip / docker / stdio). A bare GitHub repo URL does NOT
+  // count — some remote-only servers link a repo yet ship "no install, no npm".
+  // Servers that also offer a remote endpoint but ARE installable stay `local`,
+  // because the CLI can still serve the installable path.
+  const hasInstallSignal =
+    /\bnpx\b|\buvx\b|\bpipx\b|\bpip install\b|\bdocker run\b/.test(text) ||
+    /"command"\s*:/.test(text) ||
+    /\bstdio\b/.test(text) ||
+    /npmjs\.com\/package\//.test(text);
+  const hasRemoteSignal =
+    /"url"\s*:/.test(text) ||
+    /\bstreamable[- ]?http\b|\bsse\b/.test(text) ||
+    /transport[^a-z]{0,8}(?:sse|http|streamable)/.test(text) ||
+    /\bremote(?:ly)? (?:hosted|mcp|server)\b|\bhosted mcp\b/.test(text);
+  // An explicit "no install / no npm / remote-only" statement is decisive: the
+  // server ships only as a URL, so it overrides any incidental stdio/command
+  // mention (e.g. a body that says "unlike stdio servers, this one is remote").
+  const isRemoteOnly =
+    /\bno install\b|\bno npm\b|\bremote[- ]only\b|no local install|installation[- ]free/.test(text);
+  const delivery: Classification['delivery'] = isRemoteOnly
+    ? 'remote'
+    : hasInstallSignal
+      ? 'local'
+      : hasRemoteSignal
+        ? 'remote'
+        : 'unknown';
+
+  if (!hasMcp) return { delivery, isSubmission: false, reason: 'no "mcp" keyword', repoUrl };
+  if (!hasAddVerb)
+    return { delivery, isSubmission: false, reason: 'no add/submit intent', repoUrl };
+  if (!hasMarketContext)
+    return { delivery, isSubmission: false, reason: 'no marketplace context', repoUrl };
+  // A server reference is required, but for remote submissions the endpoint itself
+  // counts — only the local (CLI) path needs an actual repo URL (for `plugin submit`).
+  if (!repoUrl && delivery !== 'remote')
+    return {
+      delivery,
+      isSubmission: false,
+      reason: 'no server reference (repo URL or endpoint)',
+      repoUrl,
+    };
+  if (isMarketplaceBug)
+    return {
+      delivery,
+      isSubmission: false,
+      reason: 'looks like a marketplace/listing bug',
+      repoUrl,
+    };
+  if (isCliFeedback)
+    return { delivery, isSubmission: false, reason: 'looks like CLI/publishing feedback', repoUrl };
+
+  return {
+    delivery,
+    isSubmission: true,
+    reason: `new MCP server listing request (${delivery})`,
+    repoUrl,
+  };
+}
+
+function buildComment(repoUrl: string | null): string {
+  const submitUrl = repoUrl ?? REPO_PLACEHOLDER;
+
+  return `${MARKER}
+👋 Thanks for this! Heads-up: **we no longer take MCP listing requests via issues** — there's now a self-service flow, so you can list and manage your server yourself without waiting on us.
+
+**Easiest — let your coding agent do it.** Paste this into Claude Code / Cursor / Codex / etc.:
+
+\`\`\`text
+Read https://lobehub.com/publish-mcp/skill.md and follow the instructions to publish my MCP server to the LobeHub Marketplace
+\`\`\`
+
+It reads our publishing skill and drives the CLI for you (login → verify GitHub ownership → submit your repo).
+
+**Prefer to run it yourself?** Use the official CLI directly (Node.js ≥ 22):
+
+\`\`\`bash
+npx -y @lobehub/market-cli login            # browser login
+npx -y @lobehub/market-cli github connect    # verify you own the repo
+npx -y @lobehub/market-cli plugin submit ${submitUrl}
+npx -y @lobehub/market-cli plugin list --output json   # import is async (~a few min)
+\`\`\`
+
+After that you self-manage everything — versions, metadata, delist, delete — via \`plugin publish\` / \`unpublish\` / \`delete\`. Full guide: **https://lobehub.com/publish-mcp/skill.md**
+
+Self-publish works from a **GitHub repo you own**. Not your repo and you just want it indexed? Use the **"Request a Server"** button at **https://lobehub.com/mcp**.
+
+I'll close this as a listing request — **if you think it was closed by mistake, just reopen this issue (or leave a comment) and we'll take another look.** The CLI just launched, so if you hit _any_ problem using it, a new issue is very welcome — that feedback is exactly what we want right now. Thanks! 🙏`;
+}
+
+async function ensureLabel(
+  owner: string,
+  repo: string,
+  token: string,
+  name: string,
+  color: string,
+  description: string,
+): Promise<void> {
+  const res = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/labels/${encodeURIComponent(name)}`,
+    {
+      headers: {
+        'Accept': 'application/vnd.github+json',
+        'Authorization': `Bearer ${token}`,
+        'User-Agent': 'auto-handle-mcp-submission-script',
+      },
+    },
+  );
+
+  if (res.ok) return;
+  if (res.status !== 404) {
+    throw new Error(`Checking label "${name}" failed: ${res.status} ${res.statusText}`);
+  }
+
+  console.log(`[INFO] Label "${name}" missing — creating it`);
+  await githubRequest(`/repos/${owner}/${repo}/labels`, token, 'POST', {
+    color,
+    description,
+    name,
+  });
+}
+
+async function addLabel(
+  owner: string,
+  repo: string,
+  token: string,
+  issueNumber: number,
+  name: string,
+): Promise<void> {
+  await githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}/labels`, token, 'POST', {
+    labels: [name],
+  });
+  console.log(`[INFO] Added label "${name}"`);
+}
+
+async function main(): Promise<void> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error('GITHUB_TOKEN environment variable is required');
+
+  const owner = process.env.GITHUB_REPOSITORY_OWNER || 'lobehub';
+  const repo = process.env.GITHUB_REPOSITORY_NAME || 'lobehub';
+  const issueNumber = Number(process.env.ISSUE_NUMBER);
+  if (!issueNumber) throw new Error('ISSUE_NUMBER environment variable is required');
+
+  console.log(`[INFO] Processing ${owner}/${repo}#${issueNumber}`);
+
+  const issue = await githubRequest<GitHubIssue>(
+    `/repos/${owner}/${repo}/issues/${issueNumber}`,
+    token,
+  );
+
+  if (issue.state !== 'open') {
+    console.log('[SKIP] Issue is not open');
+    return;
+  }
+
+  // Idempotency is handled per-step below (label adds are idempotent, the close is a
+  // no-op on an already-closed issue, and the redirect comment is guarded by its
+  // marker), so a re-run after a partial failure safely completes the missing steps.
+  const { delivery, isSubmission, reason, repoUrl } = classify(issue.title || '', issue.body || '');
+  console.log(`[INFO] Classification: ${isSubmission ? 'SUBMISSION' : 'skip'} — ${reason}`);
+  if (repoUrl) console.log(`[INFO] Extracted repo: ${repoUrl}`);
+
+  if (!isSubmission) {
+    console.log('[DONE] Not a listing request — leaving for normal triage');
+    return;
+  }
+
+  // Every detected listing request gets the category label.
+  await ensureLabel(owner, repo, token, LABEL, 'c5def5', 'MCP marketplace listing request');
+  await addLabel(owner, repo, token, issueNumber, LABEL);
+
+  // Remote-only or unknown-delivery servers cannot be self-published through the
+  // CLI, so we must NOT send the "use the CLI" redirect or close them. Flag for a
+  // maintainer and leave open.
+  if (delivery !== 'local') {
+    if (delivery === 'remote') {
+      await ensureLabel(
+        owner,
+        repo,
+        token,
+        LABEL_REMOTE,
+        'fbca04',
+        'Remote-only MCP server — not self-serviceable via the CLI, needs manual handling',
+      );
+      await addLabel(owner, repo, token, issueNumber, LABEL_REMOTE);
+    }
+    console.log(
+      `[DONE] ${delivery} delivery — left open for manual handling (no comment, no close)`,
+    );
+    return;
+  }
+
+  // Local / installable server — redirect to the self-service CLI and close.
+  // Guard the comment with its marker so a re-run never double-posts.
+  const comments = await githubRequest<GitHubComment[]>(
+    `/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+    token,
+  );
+  if (comments.some((c) => (c.body || '').includes(MARKER))) {
+    console.log('[INFO] Redirect comment already present — not reposting');
+  } else {
+    await githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}/comments`, token, 'POST', {
+      body: buildComment(repoUrl),
+    });
+    console.log('[INFO] Posted CLI redirect comment');
+  }
+
+  // Closing an already-closed issue is a harmless no-op, so this step is re-run safe.
+  await githubRequest(`/repos/${owner}/${repo}/issues/${issueNumber}`, token, 'PATCH', {
+    state: 'closed',
+    state_reason: 'not_planned',
+  });
+  console.log(`[SUCCESS] Closed #${issueNumber} (local submission) as not planned`);
+}
+
+// Run only when executed directly, so `classify`/`extractRepoUrl` can be
+// imported by unit tests without firing the GitHub side effects.
+// @ts-ignore - import.meta.main is provided by Bun
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(`[ERROR] ${error}`);
+    process.exitCode = 1;
+  });
+}
+
+export { classify, extractRepoUrl };

--- a/.github/scripts/auto-handle-mcp-submission.ts
+++ b/.github/scripts/auto-handle-mcp-submission.ts
@@ -179,28 +179,35 @@ function classify(title: string, body: string): Classification {
   // count — some remote-only servers link a repo yet ship "no install, no npm".
   // Servers that also offer a remote endpoint but ARE installable stay `local`,
   // because the CLI can still serve the installable path.
-  const hasInstallSignal =
+  // Strong, unambiguous "installable" signals — these prove the CLI can publish it.
+  const hasStrongInstall =
     /\bnpx\b|\buvx\b|\bpipx\b|\bpip install\b|\bdocker run\b/.test(text) ||
     /"command"\s*:/.test(text) ||
-    /\bstdio\b/.test(text) ||
     /npmjs\.com\/package\//.test(text);
+  // A bare "stdio" mention is weak — remote submissions often name it in a negation
+  // or comparison ("Transport: SSE, not stdio"), so it must not outrank a remote signal.
+  const hasStdioMention = /\bstdio\b/.test(text);
   const hasRemoteSignal =
     /"url"\s*:/.test(text) ||
     /\bstreamable[- ]?http\b|\bsse\b/.test(text) ||
     /transport[^a-z]{0,8}(?:sse|http|streamable)/.test(text) ||
-    /\bremote(?:ly)? (?:hosted|mcp|server)\b|\bhosted mcp\b/.test(text);
-  // An explicit "no install / no npm / remote-only" statement is decisive: the
-  // server ships only as a URL, so it overrides any incidental stdio/command
-  // mention (e.g. a body that says "unlike stdio servers, this one is remote").
+    /\bremote(?:ly)? (?:hosted|mcp|server)\b|\bhosted mcp\b/.test(text) ||
+    // a bare endpoint URL (non-GitHub) labelled "url:" / "endpoint:" is a remote reference
+    /\b(?:endpoint|url)\b[^\n]{1,15}https?:\/\/(?!github\.com)/.test(text);
+  // An explicit "no install / no npm / remote-only" statement is decisive: the server
+  // ships only as a URL, so it overrides any incidental stdio/command mention.
   const isRemoteOnly =
     /\bno install\b|\bno npm\b|\bremote[- ]only\b|no local install|installation[- ]free/.test(text);
+  // Precedence: explicit remote-only > strong install > any remote signal > lone stdio mention.
   const delivery: Classification['delivery'] = isRemoteOnly
     ? 'remote'
-    : hasInstallSignal
+    : hasStrongInstall
       ? 'local'
       : hasRemoteSignal
         ? 'remote'
-        : 'unknown';
+        : hasStdioMention
+          ? 'local'
+          : 'unknown';
 
   if (!hasMcp) return { delivery, isSubmission: false, reason: 'no "mcp" keyword', repoUrl };
   if (!hasAddVerb)

--- a/.github/workflows/claude-auto-e2e-testing.yml
+++ b/.github/workflows/claude-auto-e2e-testing.yml
@@ -1,5 +1,5 @@
 name: Claude Auto E2E Testing
-description: Automatically add E2E tests to improve user journey coverage
+# Automatically add E2E tests to improve user journey coverage
 
 on:
   schedule:

--- a/.github/workflows/claude-auto-testing.yml
+++ b/.github/workflows/claude-auto-testing.yml
@@ -1,5 +1,5 @@
 name: Claude Auto Testing Coverage
-description: Automatically add unit tests to improve code coverage
+# Automatically add unit tests to improve code coverage
 
 on:
   schedule:

--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -1,5 +1,5 @@
 name: Claude Issue Dedupe
-description: Automatically dedupe GitHub issues using Claude Code
+# Automatically dedupe GitHub issues using Claude Code
 on:
   issues:
     types: [opened]

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -1,5 +1,5 @@
 name: Claude Issue Triage
-description: Automatically triage GitHub issues using Claude Code
+# Automatically triage GitHub issues using Claude Code
 on:
   issues:
     types: [opened, labeled]
@@ -72,7 +72,7 @@ jobs:
             **IMPORTANT**:
             - Follow ALL steps in the issue-triage.md guide
             - Apply labels according to the guide's rules
-            - ${{ steps.check-team.outputs.is_team == 'true' && 'The issue author is a team member. Do NOT post any @mention comment.' || 'Post a mention comment to the appropriate team member(s) based on team-assignment.md' }}
+            - ${{ steps.check-team.outputs.is_team == 'true' && 'The issue author is a team member. Do NOT post any @mention comment.' || 'Post a mention comment to the appropriate team member(s) based on team-assignment.md. EXCEPTION: if team-assignment.md marks the issue category as auto-handled / no-mention (e.g. MCP marketplace listing/submission requests), do NOT post any @mention comment — apply labels only.' }}
             - Replace [ISSUE_NUMBER] with: ${{ github.event.issue.number }}
 
             **Start the triage process now.**

--- a/.github/workflows/claude-translate-comments.yml
+++ b/.github/workflows/claude-translate-comments.yml
@@ -1,5 +1,5 @@
 name: Claude Translate Non-English Comments
-description: Automatically detect and translate non-English comments to English in codebase
+# Automatically detect and translate non-English comments to English in codebase
 
 on:
   schedule:

--- a/.github/workflows/issue-auto-close-duplicates.yml
+++ b/.github/workflows/issue-auto-close-duplicates.yml
@@ -1,5 +1,5 @@
 name: Auto-close duplicate issues
-description: Auto-closes issues that are duplicates of existing issues
+# Auto-closes issues that are duplicates of existing issues
 on:
   schedule:
     - cron: '0 2 * * *'

--- a/.github/workflows/mcp-submission-handler.yml
+++ b/.github/workflows/mcp-submission-handler.yml
@@ -1,0 +1,46 @@
+name: MCP Submission Handler
+# Auto-close "Add my MCP server to the marketplace" issues and redirect to the self-service CLI
+
+on:
+  issues:
+    types: [opened, labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to (re)process'
+        required: true
+        type: string
+
+jobs:
+  handle-mcp-submission:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Run on new issues, on a manual `trigger:mcp-triage` label, or manual dispatch.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.action == 'opened' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'trigger:mcp-triage')
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+
+      - name: Handle MCP submission issue
+        run: bun run .github/scripts/auto-handle-mcp-submission.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}
+
+      - name: Remove trigger label
+        if: github.event.action == 'labeled' && github.event.label.name == 'trigger:mcp-triage'
+        run: gh issue edit ${{ github.event.issue.number }} --remove-label "trigger:mcp-triage"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🔨 chore

#### 🔗 Related Issue

Addresses the steady stream of "Add my MCP server to the marketplace" issues (~104 in the last ~8 months) now that listing is self-service via `@lobehub/market-cli`. This PR intentionally does **not** auto-close any existing open issues — backfilling the current backlog is a separate, opt-in step.

#### 🔀 Description of Change

New GitHub Action that triages "Add my MCP server to the marketplace" issues when they're opened, classifying by how the server is delivered:

- **Local / installable** (`npx` / `npm` / `uvx` / `pip` / `docker` / stdio): posts a redirect comment pointing at the self-service CLI (with the submitter's repo filled in) and closes as `not planned`. The comment invites the author to reopen if mis-closed.
- **Remote-only** (URL / SSE / streamable-http, no installable package): the CLI can't publish these, so they're labeled `mcp:remote` and left **open** for manual review.
- **Unknown / not a submission**: left untouched for normal triage. Guardrails skip marketplace-pipeline / existing-listing bugs (scoring stuck, stale listing, rescan) and publishing-CLI feedback (which we actively welcome).

Also in this PR:
- **Silences the triage `@`-mention** for these listing requests (marketplace bugs and product feature requests still get mentioned).
- **Lint cleanup (separate commit):** converts invalid top-level `description:` keys in workflow files to `#` comments — top-level `description` isn't valid GitHub Actions syntax (only valid nested under `workflow_call` / `workflow_dispatch` inputs), so editors flag it. No runtime change.

Key files:
- `.github/scripts/auto-handle-mcp-submission.ts` — deterministic classifier + action (exits non-zero on failure; re-runs are idempotent).
- `.github/workflows/mcp-submission-handler.yml` — triggers on `issues: opened`, a `trigger:mcp-triage` label, or `workflow_dispatch`. Reuses the existing `GH_TOKEN`; no new infrastructure.

#### 🧪 How to Test

- [x] Tested locally

Validated with local unit tests (classification, delivery detection, guardrails) and a read-only dry-run over the 24 currently-open submission issues:

| Outcome | Count |
| --- | --- |
| close (local) | 6 |
| label `mcp:remote`, leave open | 11 |
| unknown, leave open | 1 |
| skip (bug / feature request) | 6 |

Zero false closes on a general (non-MCP) issue sample. `main()` is guarded by `import.meta.main` so the classifier can be unit-tested without side effects.

To verify on a real issue after merge: **Actions → MCP Submission Handler → Run workflow** and enter an issue number (safe to dry-run on a single issue first).

#### 📝 Additional Information

- The workflow only fires from the default branch (`canary`) and only on **newly opened** issues — existing open issues are not processed retroactively.
- Remote-only submissions are deliberately left open (the CLI can't publish a URL-only server); the maintainer queue is `is:open label:mcp:remote`.
