### PR TITLE
🐛 fix(group): pass groupId in server message queries so group context isn't empty

### DIFF
--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -600,10 +600,14 @@ export class AgentRuntimeService {
   async queryUiMessages(agentState: AgentState): Promise<UIChatMessage[] | undefined> {
     const agentId: string | undefined = agentState?.metadata?.agentId;
     const topicId: string | undefined = agentState?.metadata?.topicId;
+    // groupId scopes group conversations. Without it the query falls into the
+    // standard branch (`groupId IS NULL`) and returns ZERO group messages, so
+    // the step_start uiMessages snapshot would be empty and clobber the client.
+    const groupId: string | undefined = agentState?.metadata?.groupId;
     if (!agentId || !topicId) return undefined;
 
     try {
-      return await this.messageService.queryMessages({ agentId, topicId });
+      return await this.messageService.queryMessages({ agentId, groupId, topicId });
     } catch (error) {
       // Stream events must never fail the step. If the DB hiccups, fall back
       // to letting the client refresh as before.
@@ -2264,6 +2268,10 @@ export class AgentRuntimeService {
     const dbMessages = await this.messageModel.query(
       {
         agentId: state.metadata?.agentId,
+        // Group runs must pass groupId, else the query filters `groupId IS NULL`
+        // and returns no group messages — the next LLM step then gets an empty
+        // context and the provider rejects it ("at least one message is required").
+        groupId: state.metadata?.groupId,
         threadId: state.metadata?.threadId,
         topicId: state.metadata?.topicId,
       },
@@ -2412,6 +2420,9 @@ export class AgentRuntimeService {
     try {
       const dbMessages = await this.messageModel.query({
         agentId: state.metadata?.agentId,
+        // Group runs need groupId or the query returns no group messages
+        // (standard branch filters `groupId IS NULL`), losing the device context.
+        groupId: state.metadata?.groupId,
         threadId: state.metadata?.threadId,
         topicId: state.metadata?.topicId,
       });


### PR DESCRIPTION
## Problem

The agent runtime's DB message queries for a run passed only `agentId` + `topicId`, never `groupId`. For **group** runs, `MessageModel.query` then falls into the standard branch where `matchGroup(undefined)` becomes `groupId IS NULL`, so it returns **zero** group messages (group rows always carry a non-null `groupId`).

`state.metadata.groupId` is already populated (spread from `appContext` in `createOperation`) — it just wasn't being forwarded.

This single omission caused two distinct, confirmed failures in group conversations:

1. **Blank conversation right after sending.** `queryUiMessages` builds the gateway `step_start` `uiMessages` snapshot. An empty snapshot makes the client run `replaceMessages([])`, clobbering the just-rendered user + assistant messages → the group conversation goes blank while the agent is still running. (Verified earlier by instrumenting `replaceMessages`: the `len:0` write carried `action: 'gateway/step_start'`.)
2. **`messages: at least one message is required` (provider 400).** `refreshMessagesFromDB` rebuilds the LLM context on parked/async resume (e.g. a supervisor's group-orchestration tools that suspend/resume). Empty messages → the provider (e.g. deepseek-v4-pro) rejects the request.

## Fix

Forward `groupId: state.metadata?.groupId` in the three runtime DB-message queries:

- `queryUiMessages` (step_start SoT snapshot)
- `refreshMessagesFromDB` (parked/async resume context)
- `computeDeviceContext` (device context lookup)

The DB layer already does the right thing once `groupId` is present (group branch filters by `groupId + topicId`).

## Notes / verification

- `bun run type-check` clean for this change (two pre-existing canary errors — `builtin-tool-claude-code` base-ui `Tabs` and `MessageContent.test` — are unrelated).
- End-to-end verification needs a deploy or a local full-stack group run (desktop currently talks to cloud); the mechanism is verified at the code + DB-query level (`matchGroup(undefined)` = `isNull(groupId)`).
- The client-side counterparts of this same `groupId`-scoping bug (topic-title generation, dbMessage/operation selectors) are addressed in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)