### PR TITLE
🐛 fix(group): include groupId in client message-key reads for group conversations

### DIFF
--- a/.agents/skills/agent-testing/references/probe-mock-patterns.md
+++ b/.agents/skills/agent-testing/references/probe-mock-patterns.md
@@ -1396,3 +1396,39 @@ nodeintegration, plugins, disablewebsecurity, allowpopups, preload, …`). The h
 - **Works**: use client observables (`messages.model`, thread ids, and chat-store operations) for web;
   use CLI/server execution and `agent_operations` for the server runtime. A change affecting both paths
   needs evidence from both paths.
+
+### E32. ✅ WORKS — driving `heteroIngest`/`heteroFinish` directly needs an OIDC token, and bun's spawn-ENOENT message differs from node's
+
+- **Situation**: E2E-testing the hetero server-ingest chain by running `lh hetero exec --topic <t> --operation-id <op>` manually (the exact command a device daemon spawns), against a local dev
+  server, with the seeded CLI API key.
+- **Doesn't work**: the seeded `LOBE_API_KEY`. `heteroAuthedProcedure` requires `ctx.oidcAuth`
+  (`packages/trpc/src/lambda/middleware/heteroOperationAuth.ts`) — an API key never populates it, so
+  `heteroFinish` 401s. Also note the local no-`.env` env has no `JWKS_KEY` (E22), so the server
+  cannot even validate a JWT until restarted with one.
+- **Works** — production-shape auth in three steps:
+  1. `node scripts/generate-oidc-jwk.mjs > /tmp/jwks.json`
+  2. restart the dev server with `JWKS_KEY="$(cat /tmp/jwks.json)"` (must be present at start)
+  3. sign a 4h `hetero-operation` JWT with the SAME key via `signOperationJwt(<userId>)`
+     (`packages/trpc/src/utils/internalJwt.ts`; run a small `.mts` inside the repo with `bunx tsx`),
+     then run the CLI with `LOBEHUB_JWT=<token> LOBEHUB_SERVER=<app-url>` — the CLI forwards it as
+     the `Oidc-Auth` header.
+     The fixture side needs `topics.metadata.runningOperation = { operationId, assistantMessageId }`
+     seeded, and the operationId must embed real ids (`op_<ts>_agt_<id>_tpc_<id>_<suffix>`).
+- **Bonus trap**: under bun, a spawn failure reads `ENOENT: no such file or directory,
+posix_spawn '<cmd>'` — NOT node's `spawn <cmd> ENOENT`. Any stderr-text pattern keyed to the node
+  format silently misses on bun; classification/assertions should key on the raw error's
+  `err.code === 'ENOENT'` (runtime-agnostic) and treat text matching as fallback only.
+- **Persistence shape worth knowing**: a process-level failure that produced ZERO stream events
+  never creates op state, so `HeterogeneousPersistenceHandler.finish` early-returns — the message
+  error is written by `CompletionLifecycle.completeOperation`'s onError branch instead
+  (`body: messageError.body ?? { message }`). Assert on `messages.error`, not on which writer ran.
+
+### E33. ✅ WORKS — keep the Electron supervisor session alive in process-reaping runners
+
+- **Situation**: `electron-dev.sh start <id>` reports `Ready`, but CDP and the Vite port disappear
+  immediately after the shell command returns. The Electron log contains no crash or product error.
+- **Doesn't work**: repeatedly restarting and treating the vanished CDP endpoint as an app crash.
+- **Works**: keep the launcher shell alive for the test session (for example, run `start` followed by
+  a short periodic wait loop in the same PTY), drive CDP from a second shell, then stop with
+  `electron-dev.sh stop <id>` and terminate the holder. Some execution harnesses reap descendants when
+  the command cell closes even though the launcher normally survives an interactive terminal.

--- a/src/store/chat/slices/agentRun/actions/entries/conversationControl.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationControl.ts
@@ -222,11 +222,18 @@ export class ConversationControlActionImpl {
   };
 
   cancelSendMessageInServer = (topicId?: string): void => {
-    const { activeAgentId, activeTopicId } = this.#get();
+    const { activeAgentId, activeGroupId, activeThreadId, activeTopicId } = this.#get();
 
     // Determine which operation to cancel
     const targetTopicId = topicId ?? activeTopicId;
-    const contextKey = messageMapKey({ agentId: activeAgentId, topicId: targetTopicId });
+    // Include groupId/threadId so the key matches how the operation was stored
+    // (operationsByContext is keyed by the full messageMapKey).
+    const contextKey = messageMapKey({
+      agentId: activeAgentId,
+      groupId: activeGroupId,
+      threadId: activeThreadId,
+      topicId: targetTopicId,
+    });
 
     // Cancel operations in the operation system
     const operationIds = this.#get().operationsByContext[contextKey] || [];
@@ -239,7 +246,15 @@ export class ConversationControlActionImpl {
     });
 
     // Restore editor state if it's the active session
-    if (contextKey === messageMapKey({ agentId: activeAgentId, topicId: activeTopicId })) {
+    if (
+      contextKey ===
+      messageMapKey({
+        agentId: activeAgentId,
+        groupId: activeGroupId,
+        threadId: activeThreadId,
+        topicId: activeTopicId,
+      })
+    ) {
       // Find the latest sendMessage operation with editor state
       for (const opId of [...operationIds].reverse()) {
         const op = this.#get().operations[opId];
@@ -252,8 +267,13 @@ export class ConversationControlActionImpl {
   };
 
   clearSendMessageError = (): void => {
-    const { activeAgentId, activeTopicId } = this.#get();
-    const contextKey = messageMapKey({ agentId: activeAgentId, topicId: activeTopicId });
+    const { activeAgentId, activeGroupId, activeThreadId, activeTopicId } = this.#get();
+    const contextKey = messageMapKey({
+      agentId: activeAgentId,
+      groupId: activeGroupId,
+      threadId: activeThreadId,
+      topicId: activeTopicId,
+    });
     const operationIds = this.#get().operationsByContext[contextKey] || [];
 
     // Clear error message from all sendMessage operations in current context

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
@@ -209,8 +209,12 @@ export const buildRunLifecycle = (
         console.info('[dev] sliced topic title (NEXT_PUBLIC_DEV_DISABLE_AUTO_TOPIC=1):', title);
       };
 
+      // Use the full conversation context (incl. groupId/threadId) so group
+      // topics read their real messages instead of an empty main-scope bucket —
+      // an empty read makes topic-title generation summarize nothing and emit a
+      // degenerate "空对话标题" title.
       const readStoreChats = () =>
-        displayMessageSelectors.getDisplayMessagesByKey(messageMapKey({ agentId, topicId }))(get());
+        displayMessageSelectors.getDisplayMessagesByKey(messageMapKey(context))(get());
 
       // New topic → always title. Use caller-provided messages when present
       // (client's freshly-created rows aren't in the store under topicId yet);

--- a/src/store/chat/slices/agentRun/selectors.ts
+++ b/src/store/chat/slices/agentRun/selectors.ts
@@ -13,7 +13,12 @@ const isIntentUnderstanding = (id: string) => (s: ChatStoreState) =>
   isMessageInSearchWorkflow(id)(s);
 
 const isCurrentSendMessageLoading = (s: ChatStoreState) => {
-  const contextKey = messageMapKey({ agentId: s.activeAgentId, topicId: s.activeTopicId });
+  const contextKey = messageMapKey({
+    agentId: s.activeAgentId,
+    groupId: s.activeGroupId,
+    threadId: s.activeThreadId,
+    topicId: s.activeTopicId,
+  });
   const operationIds = s.operationsByContext[contextKey] || [];
 
   // Check if there's any running sendMessage operation
@@ -24,7 +29,12 @@ const isCurrentSendMessageLoading = (s: ChatStoreState) => {
 };
 
 const isCurrentSendMessageError = (s: ChatStoreState) => {
-  const contextKey = messageMapKey({ agentId: s.activeAgentId, topicId: s.activeTopicId });
+  const contextKey = messageMapKey({
+    agentId: s.activeAgentId,
+    groupId: s.activeGroupId,
+    threadId: s.activeThreadId,
+    topicId: s.activeTopicId,
+  });
   const operationIds = s.operationsByContext[contextKey] || [];
 
   // Find the latest sendMessage operation with error

--- a/src/store/chat/slices/message/selectors/dbMessage.ts
+++ b/src/store/chat/slices/message/selectors/dbMessage.ts
@@ -28,7 +28,12 @@ import { messageMapKey } from '../../../utils/messageMapKey';
  * Get the current chat key for accessing dbMessagesMap
  */
 export const currentDbChatKey = (s: ChatStoreState) =>
-  messageMapKey({ agentId: s.activeAgentId, topicId: s.activeTopicId });
+  messageMapKey({
+    agentId: s.activeAgentId,
+    groupId: s.activeGroupId,
+    threadId: s.activeThreadId,
+    topicId: s.activeTopicId,
+  });
 
 /**
  * Get raw messages from database by key

--- a/src/store/chat/slices/operation/selectors.ts
+++ b/src/store/chat/slices/operation/selectors.ts
@@ -21,10 +21,18 @@ const getAllOperations = (s: ChatStoreState): Operation[] => {
  * Get operations for current context (active agent and topic)
  */
 const getCurrentContextOperations = (s: ChatStoreState): Operation[] => {
-  const { activeAgentId, activeTopicId } = s;
+  const { activeAgentId, activeGroupId, activeThreadId, activeTopicId } = s;
   if (!activeAgentId) return [];
 
-  const contextKey = messageMapKey({ agentId: activeAgentId, topicId: activeTopicId });
+  // Must include groupId/threadId so the key matches how operations are stored
+  // (operationsByContext is keyed by the full messageMapKey(context)); otherwise
+  // group operations are never found.
+  const contextKey = messageMapKey({
+    agentId: activeAgentId,
+    groupId: activeGroupId,
+    threadId: activeThreadId,
+    topicId: activeTopicId,
+  });
   const operationIds = s.operationsByContext[contextKey] || [];
   return operationIds.map((id) => s.operations[id]).filter(Boolean);
 };


### PR DESCRIPTION
## Problem

Several client selectors / actions built the `messagesMap` / `operationsByContext` key from `activeAgentId` + `activeTopicId` only, **omitting `groupId`** (and `threadId`). In a group conversation, messages and operations are stored under the `group_<groupId>_<topicId>` key, so these reads landed on an empty main-scope bucket and returned nothing.

Same `groupId`-scoping bug family as the server-side queries (see the companion server PR #16288).

### Symptoms

- **Empty topic titles ("空对话标题").** `buildRunLifecycle.readStoreChats` read the conversation with a groupId-less key → title generation summarized an empty message set → the model emitted a degenerate "空对话标题" title for group topics. (The string isn't a hardcoded fallback — it's literally what the summarizer returns for empty input.)
- **Broken per-context state in groups.** `dbMessage` / `operation` / `sendMessage-loading|error` selectors returned empty for groups, so per-context operation tracking, cancel, and clear-error in group chats silently no-op'd.

## Fix

Read with the full conversation context (`groupId` + `threadId`), matching the write side (`operationsByContext` is keyed by `messageMapKey(context)`) and the canonical `currentDisplayChatKey`:

- `buildRunLifecycle`: `messageMapKey(context)` instead of `{ agentId, topicId }`
- `dbMessage.currentDbChatKey`
- `operation.getCurrentContextOperations`
- `agentRun.isCurrentSendMessageLoading` / `isCurrentSendMessageError`
- `conversationControl.cancelSendMessageInServer` / `clearSendMessageError`

## Verification

- Type-check clean for the changed files.
- `streamingExecutor.ts` sub-agent inherit path was intentionally left as-is — it is explicitly gated to the non-group (`!groupId`) case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)