### PR TITLE
🐛 fix(agent): surface real reason when cross-agent callAgent fails

### DIFF
--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -395,11 +395,14 @@ const buildServerVirtualSubAgentRunner = (
         timeout,
         title: description,
         topicId,
-      })) as { operationId?: string; success?: boolean; threadId?: string } | undefined;
+      })) as
+        | { error?: string; operationId?: string; success?: boolean; threadId?: string }
+        | undefined;
 
       // 3. If the child op never started, no completion bridge will fire — parking
       //    the parent on it would hang forever. Drop the placeholder and signal
-      //    `started: false` so callSubAgent surfaces an inline tool error instead.
+      //    `started: false` (with the underlying reason) so callSubAgent surfaces
+      //    an inline tool error instead.
       if (!result?.success) {
         try {
           await ctx.messageModel.deleteMessage(placeholder.id);
@@ -410,7 +413,12 @@ const buildServerVirtualSubAgentRunner = (
             error,
           );
         }
-        return { started: false, subOperationId: result?.operationId, threadId: '' };
+        return {
+          error: result?.error,
+          started: false,
+          subOperationId: result?.operationId,
+          threadId: '',
+        };
       }
 
       return {

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.test.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.test.ts
@@ -2102,7 +2102,10 @@ describe('AgentRuntimeService', () => {
       );
     });
 
-    it('writes an error note + pluginError when the child failed', async () => {
+    it('writes an error note + pluginError when the child failed, surfacing the real reason', async () => {
+      // The parent agent's LLM only sees `content`; without the inlined reason it
+      // gets the opaque generic note and cannot tell why the dispatch failed
+      // (issue #16257). The structured error still rides on pluginError.
       await service.completeSubAgentBridge({
         ...bridgeParams,
         finalState: { ...childState, error: { message: 'boom' } } as any,
@@ -2112,11 +2115,39 @@ describe('AgentRuntimeService', () => {
       expect(updateToolMessage).toHaveBeenCalledWith(
         'tool-msg-1',
         expect.objectContaining({
-          content: 'Sub-agent did not complete (error).',
+          content: 'Sub-agent did not complete (error): boom',
           pluginError: { message: 'boom' },
           pluginState: expect.objectContaining({ status: 'error' }),
         }),
       );
+    });
+
+    it('falls back to the generic note when the failed child has no error detail', async () => {
+      await service.completeSubAgentBridge({
+        ...bridgeParams,
+        finalState: { ...childState, error: undefined } as any,
+        reason: 'error',
+      });
+
+      expect(updateToolMessage).toHaveBeenCalledWith(
+        'tool-msg-1',
+        expect.objectContaining({
+          content: 'Sub-agent did not complete (error).',
+          pluginState: expect.objectContaining({ status: 'error' }),
+        }),
+      );
+    });
+
+    it('truncates an oversized child error so it cannot bloat the parent context', async () => {
+      const huge = 'x'.repeat(500);
+      await service.completeSubAgentBridge({
+        ...bridgeParams,
+        finalState: { ...childState, error: { message: huge } } as any,
+        reason: 'error',
+      });
+
+      const call = updateToolMessage.mock.calls.at(-1)?.[1];
+      expect(call.content).toBe(`Sub-agent did not complete (error): ${'x'.repeat(300)}…`);
     });
 
     it('throws when the backfill reports success: false so the webhook path redelivers', async () => {

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -132,6 +132,25 @@ const formatErrorForMetadata = (error: unknown): Record<string, any> | undefined
   return { message: String(error) };
 };
 
+/**
+ * Extract a short, human-readable reason string from a failed operation's
+ * `state.error`, for inlining into the tool-result `content` a parent agent
+ * sees. Without this the supervising agent only gets the opaque generic note
+ * ("Sub-agent did not complete (error).") and cannot tell *why* a `callAgent`
+ * dispatch failed — so it can't retry, switch target, or report the cause; it
+ * silently falls back to answering itself (issue #16257). The full structured
+ * error still rides on `pluginError`; this is just the readable summary.
+ */
+const formatSubAgentErrorReason = (error: unknown): string | undefined => {
+  const message = formatErrorForMetadata(error)?.message;
+  if (typeof message !== 'string') return undefined;
+  const trimmed = message.trim();
+  if (!trimmed) return undefined;
+  // Keep the tool result compact — a runaway provider error body would otherwise
+  // bloat the parent's LLM context.
+  return trimmed.length > 300 ? `${trimmed.slice(0, 300)}…` : trimmed;
+};
+
 const toAgentSignalSnapshotEvents = (
   emission: Awaited<ReturnType<typeof emitAgentSignalSourceEvent>> | undefined,
 ) => {
@@ -1934,8 +1953,11 @@ export class AgentRuntimeService {
     const lastAssistant = [...messages]
       .reverse()
       .find((m: { role?: string }) => m?.role === 'assistant');
+    const errorReason = failed ? formatSubAgentErrorReason(finalState?.error) : undefined;
     const content = failed
-      ? `Sub-agent did not complete (${reason}).`
+      ? errorReason
+        ? `Sub-agent did not complete (${reason}): ${errorReason}`
+        : `Sub-agent did not complete (${reason}).`
       : (lastAssistant?.content as string | undefined) ||
         'Sub-agent completed without a textual answer.';
 
@@ -2102,8 +2124,11 @@ export class AgentRuntimeService {
       .reverse()
       .find((m: { role?: string }) => m?.role === 'assistant');
     const agentLabel = (finalState?.metadata?.agentId as string | undefined) ?? 'member';
+    const memberErrorReason = failed ? formatSubAgentErrorReason(finalState?.error) : undefined;
     const anchorContent = failed
-      ? `Agent member did not complete (${reason}).`
+      ? memberErrorReason
+        ? `Agent member did not complete (${reason}): ${memberErrorReason}`
+        : `Agent member did not complete (${reason}).`
       : mode === 'in_group'
         ? `Agent ${agentLabel} responded in the group.`
         : (lastAssistant?.content as string | undefined) ||

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentManagement.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/agentManagement.test.ts
@@ -158,6 +158,29 @@ describe('agentManagementRuntime', () => {
       expect(result.deferred).toBeUndefined();
     });
 
+    it('surfaces the underlying start error so the failure is diagnosable', async () => {
+      const run = vi.fn().mockResolvedValue({
+        error: 'Agent not found: agent-target',
+        started: false,
+        threadId: '',
+      });
+      const runtime = createRuntime();
+
+      const result = await runtime.callAgent(
+        { agentId: 'agent-target', instruction: 'Do delegated work' },
+        { subAgent: { run }, toolManifestMap: {} },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.content).toBe(
+        'Agent "agent-target" failed to start: Agent not found: agent-target',
+      );
+      expect(result.error).toMatchObject({
+        code: 'AGENT_CALL_START_FAILED',
+        message: 'Agent "agent-target" failed to start: Agent not found: agent-target',
+      });
+    });
+
     it('rejects nested server callAgent execution', async () => {
       const run = vi.fn();
       const runtime = createRuntime();

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/lobeAgent.test.ts
@@ -561,6 +561,22 @@ describe('lobeAgentRuntime', () => {
       expect(result).toMatchObject({ error: { code: 'SUB_AGENT_START_FAILED' } });
     });
 
+    it('surfaces the underlying reason when the sub-agent fails to start', async () => {
+      const runtime = lobeAgentRuntime.factory(baseContext);
+      const run = vi
+        .fn()
+        .mockResolvedValue({ error: 'QStash queue unavailable', started: false, threadId: '' });
+
+      const result = await runtime.callSubAgent(
+        { description: 'Research', instruction: 'Find the answer' },
+        { ...baseContext, subAgent: { run } } as ToolExecutionContext,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.content).toBe('Sub-agent failed to start: QStash queue unavailable');
+      expect(result).toMatchObject({ error: { code: 'SUB_AGENT_START_FAILED' } });
+    });
+
     it('fails (not deferred) when no sub-agent runner is available', async () => {
       const runtime = lobeAgentRuntime.factory(baseContext);
 

--- a/apps/server/src/services/toolExecution/serverRuntimes/agentManagement.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/agentManagement.ts
@@ -71,7 +71,7 @@ export const agentManagementRuntime: ServerRuntimeRegistration = {
         }
 
         const description = taskTitle || `Call agent ${agentId}`;
-        const { started, subOperationId, threadId } = await ctx.subAgent.run({
+        const { started, error, subOperationId, threadId } = await ctx.subAgent.run({
           agentId,
           description,
           instruction,
@@ -79,12 +79,11 @@ export const agentManagementRuntime: ServerRuntimeRegistration = {
         });
 
         if (!started) {
+          const detail = error ? `: ${error}` : '.';
+          const message = `Agent "${agentId}" failed to start${detail}`;
           return {
-            content: `Agent "${agentId}" failed to start.`,
-            error: {
-              code: 'AGENT_CALL_START_FAILED',
-              message: `Agent "${agentId}" failed to start.`,
-            },
+            content: message,
+            error: { code: 'AGENT_CALL_START_FAILED', message },
             success: false,
           };
         }

--- a/apps/server/src/services/toolExecution/serverRuntimes/lobeAgent.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/lobeAgent.ts
@@ -151,7 +151,7 @@ class LobeAgentExecutionRuntime {
       return buildError('instruction is required.', 'INVALID_ARGUMENTS');
     }
 
-    const { started, threadId, subOperationId } = await ctx.subAgent.run({
+    const { started, error, threadId, subOperationId } = await ctx.subAgent.run({
       description,
       instruction,
       timeout,
@@ -162,7 +162,10 @@ class LobeAgentExecutionRuntime {
     // (non-deferred) tool error so the parent's LLM sees the failure and the
     // batch continues instead of hanging in `waiting_for_async_tool`.
     if (!started) {
-      return buildError('Sub-agent failed to start.', 'SUB_AGENT_START_FAILED');
+      return buildError(
+        error ? `Sub-agent failed to start: ${error}` : 'Sub-agent failed to start.',
+        'SUB_AGENT_START_FAILED',
+      );
     }
 
     return {

--- a/apps/server/src/services/toolExecution/types.ts
+++ b/apps/server/src/services/toolExecution/types.ts
@@ -28,6 +28,13 @@ export interface ServerSubAgentRunParams {
 
 export interface ServerSubAgentRunResult {
   /**
+   * Reason the child failed to start, when `started` is false. Surfaced to the
+   * parent agent's tool result so a `callAgent` dispatch failure is diagnosable
+   * (e.g. "Agent not found", config/scheduling error) instead of an opaque
+   * "failed to start" — see issue #16257.
+   */
+  error?: string;
+  /**
    * Whether the child op was actually forked. `false` means the child failed to
    * start (e.g. the operation row could not be created/scheduled): no completion
    * bridge will ever fire, so the caller must surface an inline tool error


### PR DESCRIPTION
## 💡 Background / 背景

Fixes #16257.

In the cloud environment, when one Agent calls another via `callAgent` (e.g. a Router Agent dispatching to a sub-agent), the call returned an opaque **`Sub-agent did not complete (error)`** / **`failed to start`** with no cause. The supervising LLM therefore could not tell *why* the dispatch failed — it couldn't retry, switch target, or report the reason, so it silently fell back to answering itself. Calling *self* worked, which made it look like cross-agent `callAgent` was broken.

## 🔍 Root cause / 根因

The cross-agent dispatch **logic is correct** — the static trace (`agentManagement.callAgent` → `ctx.subAgent.run` → `buildServerVirtualSubAgentRunner` → `execVirtualSubAgent` → `execAgentThreadRun` → `execAgent`) threads target `agentId` / parent topicId / isolation threadId / workspaceId correctly, and the in-memory integration test (`serverCallAgent.integration.test.ts`) passes end-to-end.

The real problem was **diagnosability**: when the target agent's own run terminally errored (a config/runtime reason — provider/key/model/tool on the *target's* resolved config), the underlying reason was captured on `pluginError` but **dropped from the tool-result `content`** the parent's LLM actually reads. So every cross-agent failure collapsed to the same generic string. The maintainer bot explicitly asked to distinguish "never spawned" vs "spawned but not bridged" — that information existed but never reached the parent.

## 🔧 What changed / 改动

Thread the child's failure reason all the way to the parent's tool result:

- **`toolExecution/types.ts`** — add `error?: string` to `ServerSubAgentRunResult`.
- **`RuntimeExecutors.ts`** — on the `started: false` path, propagate `result.error` from `execVirtualSubAgent` (which already returns `error: result.error` on `success: false`).
- **`serverRuntimes/agentManagement.ts`** (`callAgent`) & **`serverRuntimes/lobeAgent.ts`** (`callSubAgent`) — inline the underlying reason into both `content` and `error.message` instead of a flat "failed to start".
- **`AgentRuntimeService.ts`** — new `formatSubAgentErrorReason()` helper inlines a **truncated (300-char)** reason into `content` on the completion-bridge error path for both `completeSubAgentBridge` and `completeGroupActionMember`. Falls back to the generic note when no detail is available; the full structured error still rides on `pluginError`.

Truncation keeps a runaway provider error body from bloating the parent's LLM context.

## ✅ Tests / 测试

Added coverage (all green):
- `AgentRuntimeService.test.ts` — surfaces the real reason; falls back to generic note when no detail; truncates oversized errors.
- `agentManagement.test.ts` — `callAgent` surfaces the underlying start error.
- `lobeAgent.test.ts` — `callSubAgent` surfaces the underlying start error.

Ran `AgentRuntimeService` + `agentManagement` + `lobeAgent` + `serverCallAgent.integration` suites → **130 passed**, plus the full `services/agentRuntime` directory → **271 passed**. No regressions.

## ⚠️ Note / 说明

This makes the failure **diagnosable** — it does not by itself make a mis-configured target agent *run*. The cloud-only failure (queue mode needs real QStash) could not be reproduced locally; the fix is verified by static trace + unit/integration coverage of every changed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)