### PR TITLE
🐛 fix(task): anchor taskCallback on the topic's live leaf to avoid a hidden fork

### DIFF
--- a/apps/server/src/services/taskResultBridge/index.test.ts
+++ b/apps/server/src/services/taskResultBridge/index.test.ts
@@ -9,10 +9,14 @@ import { TaskResultBridgeService } from './index';
 // `MessageModel.create` is a class-field arrow (instance prop, not on the
 // prototype) and `AiAgentService`'s constructor builds many sub-services — mock
 // both modules so we observe the calls without standing up the real graph.
-const { createMsg, execAgent } = vi.hoisted(() => ({ createMsg: vi.fn(), execAgent: vi.fn() }));
+const { createMsg, execAgent, getLastLeaf } = vi.hoisted(() => ({
+  createMsg: vi.fn(),
+  execAgent: vi.fn(),
+  getLastLeaf: vi.fn(),
+}));
 
 vi.mock('@/database/models/message', () => ({
-  MessageModel: vi.fn(() => ({ create: createMsg })),
+  MessageModel: vi.fn(() => ({ create: createMsg, getLastMainThreadSpineMessageId: getLastLeaf })),
 }));
 
 vi.mock('../aiAgent', () => ({
@@ -46,6 +50,9 @@ describe('TaskResultBridgeService.deliver', () => {
 
   beforeEach(() => {
     createMsg.mockReset().mockResolvedValue({ id: 'task-cb-task-1-topic-done' } as any);
+    // The creator topic's current leaf at delivery time — the live tail of the
+    // conversation, NOT origin.messageId (the stale create-task message).
+    getLastLeaf.mockReset().mockResolvedValue('msg-current-leaf');
     execAgent
       .mockReset()
       .mockResolvedValue({ operationId: 'op-new', topicId: 'topic-origin' } as any);
@@ -73,7 +80,8 @@ describe('TaskResultBridgeService.deliver', () => {
     const [params, id] = createMsg.mock.calls[0] as [any, string];
     expect(params).toMatchObject({
       agentId: 'agent-creator',
-      parentId: 'msg-anchor',
+      // anchored on the topic's live leaf, not origin.messageId ('msg-anchor')
+      parentId: 'msg-current-leaf',
       role: 'taskCallback',
       topicId: 'topic-origin',
     });

--- a/apps/server/src/services/taskResultBridge/index.test.ts
+++ b/apps/server/src/services/taskResultBridge/index.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { MessageModel } from '@/database/models/message';
 import { TaskModel } from '@/database/models/task';
 import { TaskTopicModel } from '@/database/models/taskTopic';
 
@@ -103,6 +104,14 @@ describe('TaskResultBridgeService.deliver', () => {
       parentMessageId: 'task-cb-task-1-topic-done',
       suppressUserMessage: true,
     });
+  });
+
+  it('scopes the MessageModel to the bridge workspace so workspace tasks find their leaf', async () => {
+    await new TaskResultBridgeService(db, TEST_USER, 'ws-1').deliver(baseParams);
+
+    // Personal-mode model (workspace_id IS NULL) would miss the team topic's
+    // leaf and create the callback parentless — the lookup must be ws-scoped.
+    expect(MessageModel).toHaveBeenCalledWith(db, TEST_USER, 'ws-1');
   });
 
   it('skips tasks with no origin (e.g. API-created)', async () => {

--- a/apps/server/src/services/taskResultBridge/index.ts
+++ b/apps/server/src/services/taskResultBridge/index.ts
@@ -139,7 +139,11 @@ export class TaskResultBridgeService {
     // can redeliver the `on-topic-complete` webhook (which drives this bridge) —
     // the second create loses the PK race and we skip.
     const messageId = `task-cb-${taskId}-${topicId ?? params.operationId}`;
-    const messageModel = new MessageModel(this.db, this.userId);
+    // Pass workspaceId: a workspace-scoped task's origin topic lives under the
+    // team workspace, so the leaf lookup + create must use the matching
+    // ownership predicate — a personal-mode model (workspace_id IS NULL) finds
+    // no leaf and the callback would be created parentless (LOBE-10784).
+    const messageModel = new MessageModel(this.db, this.userId, this.workspaceId);
 
     // Anchor the callback on the creator topic's CURRENT leaf at delivery time —
     // NOT origin.messageId (the assistant turn that called createTask). A task

--- a/apps/server/src/services/taskResultBridge/index.ts
+++ b/apps/server/src/services/taskResultBridge/index.ts
@@ -140,6 +140,15 @@ export class TaskResultBridgeService {
     // the second create loses the PK race and we skip.
     const messageId = `task-cb-${taskId}-${topicId ?? params.operationId}`;
     const messageModel = new MessageModel(this.db, this.userId);
+
+    // Anchor the callback on the creator topic's CURRENT leaf at delivery time —
+    // NOT origin.messageId (the assistant turn that called createTask). A task
+    // runs for minutes while the creator agent keeps talking, so origin.messageId
+    // is a stale mid-conversation node; parenting there forks a hidden sibling
+    // branch the linear UI never follows, so the user never sees the result
+    // (LOBE-10784).
+    const parentId = await messageModel.getLastMainThreadSpineMessageId(origin.topicId);
+
     try {
       await messageModel.create(
         {
@@ -148,7 +157,7 @@ export class TaskResultBridgeService {
           metadata: {
             taskCallback: { identifier: taskIdentifier, reason, taskId, topicId },
           },
-          parentId: origin.messageId,
+          parentId,
           role: 'taskCallback',
           topicId: origin.topicId,
         },


### PR DESCRIPTION
## 🐛 Bug Fix

Fixes LOBE-10784

### Problem

When a parent agent (e.g. LobeAI) dispatches a Task to another agent and the task finishes, the user saw **no callback result** in the conversation — it looked like the task completed without reporting back.

The backend path was actually fine and the `taskCallback` card *was* written back. The bug was the **anchor**: the card's `parentId` was set to `origin.messageId` — the assistant turn that originally called `createTask`. A task runs for minutes while the creator agent keeps talking, so that anchor is a **stale mid-conversation node**. Parenting there forks a **sibling branch** in the message tree; the linear UI only follows the active branch (the create-task one), so the callback branch is collapsed/hidden and the user never sees the result.

### Fix

Resolve the creator topic's **current main-thread leaf at delivery time** via `MessageModel.getLastMainThreadSpineMessageId(topicId)` and anchor the callback there, keeping it on the active spine. This reuses the same canonical leaf-resolution the heterogeneous-agent write path uses (excludes inline `tool` children and signal-tagged reactive turns, reads straight from the DB ordered by `createdAt` so it's immune to cold-replica in-memory pointer regression).

`role='taskCallback'` is unchanged — the bug is purely the anchor, orthogonal to the message role.

### Change Type

- [x] 🐛 Bug Fix

### How to Test

- [x] Unit tests: `apps/server/src/services/taskResultBridge/index.test.ts` — the happy path now asserts the callback anchors on the topic's live leaf (not `origin.messageId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)