### PR TITLE
🐛 fix(agent-runtime): keep DeepSeek V4 thinking answers out of the reasoning channel

### DIFF
--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -43,6 +43,7 @@ import {
   type ChatStreamPayload,
   consumeStreamUntilDone,
   isDeepSeekThinkingEligibleModel,
+  isDeepSeekV4FamilyModel,
   isKimiAlwaysPreserveThinkingModel,
   type ModelExtendParams,
 } from '@lobechat/model-runtime';
@@ -953,12 +954,18 @@ export const createRuntimeExecutors = (
         // thinking block. Under large agentic context that degenerate history makes
         // the model emit its final answer *inside* the thinking block with empty
         // visible text (controlled replay: ~30% answer-in-thinking with the
-        // placeholder vs ~2.5% when the genuine reasoning is replayed). Skip only
-        // when the user explicitly turned thinking off.
-        const deepseekThinkingDisabled =
+        // placeholder vs ~2.5% when the genuine reasoning is replayed). The only
+        // opt-out is a V4 model whose thinking the user explicitly disabled via
+        // `deepseekV4ReasoningEffort: 'none'`. That flag is V4-specific and may
+        // linger on an agent after switching models, so it must NOT suppress
+        // replay for `deepseek-reasoner`, which is thinking-only and always
+        // forces reasoning history in the payload builder — suppressing it there
+        // would reintroduce the 400/answer-hidden behavior.
+        const deepseekV4ThinkingDisabled =
+          isDeepSeekV4FamilyModel(model) &&
           agentConfig.chatConfig?.deepseekV4ReasoningEffort === 'none';
         const deepseekForcesPreserveThinking =
-          isDeepSeekThinkingEligibleModel(model) && !deepseekThinkingDisabled;
+          isDeepSeekThinkingEligibleModel(model) && !deepseekV4ThinkingDisabled;
         const modelForcesPreserveThinking =
           kimiForcesPreserveThinking || deepseekForcesPreserveThinking;
         const providerSupportsPreserveThinkingFallback =

--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -42,6 +42,7 @@ import {
   applyModelExtendParams,
   type ChatStreamPayload,
   consumeStreamUntilDone,
+  isDeepSeekThinkingEligibleModel,
   isKimiAlwaysPreserveThinkingModel,
   type ModelExtendParams,
 } from '@lobechat/model-runtime';
@@ -941,9 +942,25 @@ export const createRuntimeExecutors = (
         const modelSupportsPreserveThinkingFromCard =
           Array.isArray(modelExtendParams) && modelExtendParams.includes('preserveThinking');
         // Kimi K2.7+ Code has preserved thinking always active and cannot opt out.
-        const modelForcesPreserveThinking =
+        const kimiForcesPreserveThinking =
           (provider === 'moonshot' || provider === BRANDING_PROVIDER) &&
           isKimiAlwaysPreserveThinkingModel(model);
+        // DeepSeek V4 / reasoner thinking models MUST replay the real assistant
+        // reasoning in history — this is mandatory, not opt-in. Their
+        // Anthropic-compatible API rejects an assistant tool-call turn whose
+        // thinking block is missing (HTTP 400), so stripping reasoning leaves the
+        // payload builder no choice but to emit a whitespace-only placeholder
+        // thinking block. Under large agentic context that degenerate history makes
+        // the model emit its final answer *inside* the thinking block with empty
+        // visible text (controlled replay: ~30% answer-in-thinking with the
+        // placeholder vs ~2.5% when the genuine reasoning is replayed). Skip only
+        // when the user explicitly turned thinking off.
+        const deepseekThinkingDisabled =
+          agentConfig.chatConfig?.deepseekV4ReasoningEffort === 'none';
+        const deepseekForcesPreserveThinking =
+          isDeepSeekThinkingEligibleModel(model) && !deepseekThinkingDisabled;
+        const modelForcesPreserveThinking =
+          kimiForcesPreserveThinking || deepseekForcesPreserveThinking;
         const providerSupportsPreserveThinkingFallback =
           provider === 'qwen' || provider === 'zhipu' || provider === 'moonshot';
         const modelSupportsPreserveThinking =
@@ -1571,6 +1588,10 @@ export const createRuntimeExecutors = (
             const reasoningImageUploads: Promise<void>[] = [];
             let hasContentImages = false;
             let hasReasoningImages = false;
+            // Set when a terminal turn's answer was salvaged from the reasoning
+            // channel (see the answer-in-thinking guard below) — surfaced in
+            // message metadata for observability.
+            let answerSalvagedFromReasoning = false;
             textBuffer = '';
             reasoningBuffer = '';
 
@@ -1841,6 +1862,36 @@ export const createRuntimeExecutors = (
                 throw new ModelEmptyError();
               }
 
+              // Answer-in-thinking salvage: some thinking-mode models — notably
+              // DeepSeek V4 over the Anthropic-compatible API — occasionally emit
+              // the final user-facing answer inside the reasoning channel and stop
+              // naturally with an empty text block. The reasoning is then rendered
+              // as a collapsed "thinking" panel, so the user sees a blank reply.
+              // When a turn ends naturally with no tool calls and no visible
+              // content but non-empty text reasoning, promote the reasoning to be
+              // the answer. This is a backstop; the primary fix is replaying the
+              // real assistant reasoning in history (see modelForcesPreserveThinking
+              // above) which sharply reduces how often the model does this.
+              const isTerminalNaturalStop =
+                currentStepFinishReason === 'end_turn' || currentStepFinishReason === 'stop';
+              if (
+                isTerminalNaturalStop &&
+                toolsCalling.length === 0 &&
+                tool_calls.length === 0 &&
+                content.trim().length === 0 &&
+                thinkingContent.trim().length > 0 &&
+                !hasReasoningImages
+              ) {
+                log(
+                  '[%s] answer-in-thinking salvage: promoting %d chars of reasoning to content',
+                  operationLogId,
+                  thinkingContent.length,
+                );
+                content = thinkingContent;
+                thinkingContent = '';
+                answerSalvagedFromReasoning = true;
+              }
+
               log(
                 `[${operationLogId}] finish model-runtime calling | content: %d chars | reasoning: %d chars | tools: %d | usage: %s`,
                 content.length,
@@ -1934,6 +1985,9 @@ export const createRuntimeExecutors = (
                 }
                 if (hasContentImages) {
                   metadata.isMultimodal = true;
+                }
+                if (answerSalvagedFromReasoning) {
+                  metadata.answerSalvagedFromReasoning = true;
                 }
 
                 // Sanitize tool_call `arguments` before persisting to DB so malformed

--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -74,6 +74,12 @@ vi.mock('@lobechat/model-runtime', () => ({
   // retry classifier path.
   ERROR_CODE_SPECS: {},
   getErrorCodeSpec: () => undefined,
+  isDeepSeekThinkingEligibleModel: (model: string) =>
+    typeof model === 'string' &&
+    (model.toLowerCase().includes('deepseek-reasoner') ||
+      model.toLowerCase().includes('deepseek-v4')),
+  isDeepSeekV4FamilyModel: (model: string) =>
+    typeof model === 'string' && model.toLowerCase().includes('deepseek-v4'),
   isKimiAlwaysPreserveThinkingModel: (model: string) =>
     /^kimi-k2\.(?:[7-9]|\d{2,})-code(?:$|-)/.test(model),
   refineErrorCode: () => undefined,

--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -87,4 +87,5 @@ export {
   type ModelExtendParams,
   resolveDefaultThinkingLevelForModel,
 } from './utils/modelExtendParams';
+export { isDeepSeekThinkingEligibleModel, isDeepSeekV4FamilyModel } from './utils/modelParse';
 export { parseDataUri } from './utils/uriParser';


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

**Symptom:** With `deepseek-v4-pro` (and other DeepSeek V4 thinking models served over the Anthropic-compatible API), the assistant's final answer is sometimes emitted **inside the `thinking`/reasoning block with an empty `text` block** (`stop_reason=end_turn`). The UI renders reasoning as a collapsible "thinking" panel, so the user sees a **blank reply** while the real answer is hidden. The reasoning typically starts with a stray control word (`响应`/`回复`/`response`).

**Root cause (verified by controlled replay):** DeepSeek's Anthropic-compatible thinking mode **requires** the real assistant reasoning to be replayed in history — an assistant tool-call turn whose thinking block is missing is rejected with **HTTP 400**. Because `deepseek-v4-pro`'s model card lacks `preserveThinking`, `shouldReplayAssistantReasoning` was always `false`, so the runtime **stripped reasoning on replay**, forcing `buildDeepSeekAnthropicPayload` to substitute a whitespace-only placeholder `{thinking:" "}` block. Under large agentic context that degenerate history makes the model dump its final answer into the thinking channel.

**Evidence** (replay of real, anonymized 159k-token context against `api.deepseek.com/anthropic`, N=40/condition):

| history thinking block | answer-in-thinking rate |
| --- | --- |
| whitespace placeholder `" "` (current behavior) | **~30%** |
| genuine reasoning replayed | **~2.5%** |
| no thinking block at all | — (all **HTTP 400**) |

**Impact** (7-day, `model='deepseek-v4-pro'`): ~5% of terminal answer turns (peak 6.65%), 595 users / 946 topics; a clear step-up around 2026-06-16. Concentrated in long agentic conversations. `deepseek-reasoner` and third-party OpenAI-compatible variants are essentially unaffected.

**Fix (two layers):**
1. **Root cause** — force preserve-thinking for DeepSeek V4 / reasoner thinking models (skipped when the user explicitly disables thinking via `deepseekV4ReasoningEffort='none'`), so the genuine reasoning is replayed instead of a placeholder. Drops the rate ~10x.
2. **Backstop** — when a turn stops naturally (`end_turn`/`stop`) with no tool calls, empty content and non-empty text reasoning, promote the reasoning to be the answer so it is never lost. Surfaced via `metadata.answerSalvagedFromReasoning` for observability.

Files: `apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts`, `packages/model-runtime/src/index.ts` (export `isDeepSeekThinkingEligibleModel`).

#### 🧪 How to Test

- [x] Tested locally

Reproduced and verified against `api.deepseek.com/anthropic` with a controlled replay harness (placeholder vs real-reasoning vs no-thinking-block history) — see the rate table above. `bun run type-check` clean for the changed files.

- [ ] Added/updated tests
- [x] No tests needed