### PR TITLE
✨ feat(task): add setTaskVerify tool for agent-set verify gate

### DIFF
--- a/apps/server/src/services/toolExecution/serverRuntimes/task.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/task.ts
@@ -461,6 +461,86 @@ export const createTaskRuntime = (deps: TaskRuntimeDeps) => {
       return { content: formatTaskEdited(task.identifier, changes), success: true };
     },
 
+    setTaskVerify: async (args: {
+      enabled?: boolean | null;
+      identifier: string;
+      maxIterations?: number | null;
+      requirement?: string | null;
+      verifierAgentId?: string | null;
+      verifyCriteriaIds?: string[] | null;
+      verifyRubricId?: string | null;
+    }) => {
+      const task = await taskModel().resolve(args.identifier);
+      if (!task) return { content: `Task not found: ${args.identifier}`, success: false };
+
+      // Mirrors the client executor: only forward keys the caller actually
+      // provided. The TRPC contract (task.updateVerifyConfig) treats `null` as
+      // "clear" and omission as "leave untouched", so an undefined field must
+      // NOT reach the payload.
+      const verify: {
+        enabled?: boolean | null;
+        maxIterations?: number | null;
+        requirement?: string | null;
+        verifierAgentId?: string | null;
+        verifyCriteriaIds?: string[] | null;
+        verifyRubricId?: string | null;
+      } = {};
+      const changes: string[] = [];
+
+      if (args.enabled !== undefined) {
+        verify.enabled = args.enabled;
+        changes.push(
+          args.enabled === null
+            ? 'verify enabled cleared'
+            : `verify ${args.enabled ? 'enabled' : 'disabled'}`,
+        );
+      }
+      if (args.requirement !== undefined) {
+        verify.requirement = args.requirement;
+        changes.push(
+          args.requirement ? 'acceptance requirement set' : 'acceptance requirement cleared',
+        );
+      }
+      if (args.maxIterations !== undefined) {
+        verify.maxIterations = args.maxIterations;
+        changes.push(
+          args.maxIterations === null
+            ? 'max iterations cleared'
+            : `max iterations → ${args.maxIterations}`,
+        );
+      }
+      if (args.verifierAgentId !== undefined) {
+        verify.verifierAgentId = args.verifierAgentId;
+        changes.push(
+          args.verifierAgentId
+            ? `verifier agent → ${args.verifierAgentId}`
+            : 'verifier agent cleared',
+        );
+      }
+      if (args.verifyRubricId !== undefined) {
+        verify.verifyRubricId = args.verifyRubricId;
+        changes.push(
+          args.verifyRubricId ? `verify rubric → ${args.verifyRubricId}` : 'verify rubric cleared',
+        );
+      }
+      if (args.verifyCriteriaIds !== undefined) {
+        verify.verifyCriteriaIds = args.verifyCriteriaIds;
+        changes.push(
+          args.verifyCriteriaIds?.length
+            ? `verify criteria → ${args.verifyCriteriaIds.length} item(s)`
+            : 'verify criteria cleared',
+        );
+      }
+
+      if (Object.keys(verify).length === 0) {
+        return { content: 'No verify fields provided; nothing to update.', success: false };
+      }
+
+      await taskCaller().updateVerifyConfig({ id: task.id, verify });
+
+      return { content: formatTaskEdited(task.identifier, changes), success: true };
+    },
+
     runTask: async (args: { continueTopicId?: string; identifier?: string; prompt?: string }) => {
       const id = args.identifier?.trim() || taskId;
       if (!id) {

--- a/locales/en-US/plugin.json
+++ b/locales/en-US/plugin.json
@@ -343,6 +343,7 @@
   "builtins.lobe-task.apiName.runTask": "Run task",
   "builtins.lobe-task.apiName.runTasks": "Run tasks",
   "builtins.lobe-task.apiName.setTaskSchedule": "Set schedule",
+  "builtins.lobe-task.apiName.setTaskVerify": "Set verify",
   "builtins.lobe-task.apiName.updateTaskComment": "Update comment",
   "builtins.lobe-task.apiName.updateTaskStatus": "Update status",
   "builtins.lobe-task.apiName.viewTask": "View task",

--- a/locales/zh-CN/plugin.json
+++ b/locales/zh-CN/plugin.json
@@ -343,6 +343,7 @@
   "builtins.lobe-task.apiName.runTask": "启动任务",
   "builtins.lobe-task.apiName.runTasks": "批量启动任务",
   "builtins.lobe-task.apiName.setTaskSchedule": "设置调度",
+  "builtins.lobe-task.apiName.setTaskVerify": "设置验收",
   "builtins.lobe-task.apiName.updateTaskComment": "更新评论",
   "builtins.lobe-task.apiName.updateTaskStatus": "更新状态",
   "builtins.lobe-task.apiName.viewTask": "查看任务",

--- a/packages/builtin-tool-task/src/client/Inspector/SetTaskVerify/index.tsx
+++ b/packages/builtin-tool-task/src/client/Inspector/SetTaskVerify/index.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import type { BuiltinInspectorProps } from '@lobechat/types';
+import { createStaticStyles, cx } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { inspectorTextStyles, shinyTextStyles } from '@/styles';
+
+import type { SetTaskVerifyParams, SetTaskVerifyState } from '../../../types';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  identifierChip: css`
+    flex-shrink: 0;
+
+    padding-block: 2px;
+    padding-inline: 8px;
+    border-radius: 999px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    color: ${cssVar.colorTextSecondary};
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  modeChip: css`
+    flex-shrink: 0;
+
+    padding-block: 2px;
+    padding-inline: 8px;
+    border-radius: 999px;
+
+    font-size: 12px;
+    color: ${cssVar.colorInfo};
+
+    background: ${cssVar.colorInfoBg};
+  `,
+  separator: css`
+    flex-shrink: 0;
+    color: ${cssVar.colorTextQuaternary};
+  `,
+}));
+
+export const SetTaskVerifyInspector = memo<
+  BuiltinInspectorProps<SetTaskVerifyParams, SetTaskVerifyState>
+>(({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
+  const { t } = useTranslation('plugin');
+
+  const identifier = args?.identifier || partialArgs?.identifier;
+  const enabled = args?.enabled ?? partialArgs?.enabled;
+  const modeLabel = enabled === undefined ? undefined : enabled ? 'on' : 'off';
+
+  return (
+    <div
+      style={{ flexWrap: 'wrap', gap: 4 }}
+      className={cx(
+        inspectorTextStyles.root,
+        (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
+      )}
+    >
+      <span>{t('builtins.lobe-task.apiName.setTaskVerify')}</span>
+      {identifier && <span className={styles.identifierChip}>{identifier}</span>}
+      {modeLabel && (
+        <>
+          <span className={styles.separator}>·</span>
+          <span className={styles.modeChip}>{modeLabel}</span>
+        </>
+      )}
+    </div>
+  );
+});
+
+SetTaskVerifyInspector.displayName = 'SetTaskVerifyInspector';
+
+export default SetTaskVerifyInspector;

--- a/packages/builtin-tool-task/src/client/Inspector/index.ts
+++ b/packages/builtin-tool-task/src/client/Inspector/index.ts
@@ -9,6 +9,7 @@ import { ListTasksInspector } from './ListTasks';
 import { RunTaskInspector } from './RunTask';
 import { RunTasksInspector } from './RunTasks';
 import { SetTaskScheduleInspector } from './SetTaskSchedule';
+import { SetTaskVerifyInspector } from './SetTaskVerify';
 import {
   AddTaskCommentInspector,
   DeleteTaskCommentInspector,
@@ -34,6 +35,7 @@ export const TaskInspectors: Record<string, BuiltinInspector> = {
   [TaskApiName.runTask]: RunTaskInspector as BuiltinInspector,
   [TaskApiName.runTasks]: RunTasksInspector as BuiltinInspector,
   [TaskApiName.setTaskSchedule]: SetTaskScheduleInspector as BuiltinInspector,
+  [TaskApiName.setTaskVerify]: SetTaskVerifyInspector as BuiltinInspector,
   [TaskApiName.updateTaskComment]: UpdateTaskCommentInspector as BuiltinInspector,
   [TaskApiName.updateTaskStatus]: UpdateTaskStatusInspector as BuiltinInspector,
   [TaskApiName.viewTask]: ViewTaskInspector as BuiltinInspector,
@@ -47,6 +49,7 @@ export { ListTasksInspector } from './ListTasks';
 export { RunTaskInspector } from './RunTask';
 export { RunTasksInspector } from './RunTasks';
 export { SetTaskScheduleInspector } from './SetTaskSchedule';
+export { SetTaskVerifyInspector } from './SetTaskVerify';
 export {
   AddTaskCommentInspector,
   DeleteTaskCommentInspector,

--- a/packages/builtin-tool-task/src/client/executor/index.ts
+++ b/packages/builtin-tool-task/src/client/executor/index.ts
@@ -55,6 +55,7 @@ const DETAIL_MUTATING_APIS = new Set<string>([
   TaskApiName.editTask,
   TaskApiName.runTask,
   TaskApiName.setTaskSchedule,
+  TaskApiName.setTaskVerify,
   TaskApiName.updateTaskComment,
   TaskApiName.updateTaskStatus,
   TaskApiName.viewTask,
@@ -522,6 +523,110 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
       return {
         content: `Failed to set task schedule: ${message}`,
         error: { message, type: 'SetTaskScheduleFailed' },
+        success: false,
+      };
+    }
+  };
+
+  setTaskVerify = async (
+    params: {
+      enabled?: boolean | null;
+      identifier: string;
+      maxIterations?: number | null;
+      requirement?: string | null;
+      verifierAgentId?: string | null;
+      verifyCriteriaIds?: string[] | null;
+      verifyRubricId?: string | null;
+    },
+    _ctx?: BuiltinToolContext,
+  ): Promise<BuiltinToolResult> => {
+    try {
+      log('[TaskExecutor] setTaskVerify - params:', params);
+
+      const { identifier } = params;
+
+      // Only forward keys the caller actually provided. The TRPC contract
+      // (task.updateVerifyConfig) treats `null` as "clear" and omission as
+      // "leave untouched", so an undefined field must NOT reach the payload.
+      const verify: {
+        enabled?: boolean | null;
+        maxIterations?: number | null;
+        requirement?: string | null;
+        verifierAgentId?: string | null;
+        verifyCriteriaIds?: string[] | null;
+        verifyRubricId?: string | null;
+      } = {};
+      const changes: string[] = [];
+
+      if (params.enabled !== undefined) {
+        verify.enabled = params.enabled;
+        changes.push(
+          params.enabled === null
+            ? 'verify enabled cleared'
+            : `verify ${params.enabled ? 'enabled' : 'disabled'}`,
+        );
+      }
+      if (params.requirement !== undefined) {
+        verify.requirement = params.requirement;
+        changes.push(
+          params.requirement ? 'acceptance requirement set' : 'acceptance requirement cleared',
+        );
+      }
+      if (params.maxIterations !== undefined) {
+        verify.maxIterations = params.maxIterations;
+        changes.push(
+          params.maxIterations === null
+            ? 'max iterations cleared'
+            : `max iterations → ${params.maxIterations}`,
+        );
+      }
+      if (params.verifierAgentId !== undefined) {
+        verify.verifierAgentId = params.verifierAgentId;
+        changes.push(
+          params.verifierAgentId
+            ? `verifier agent → ${params.verifierAgentId}`
+            : 'verifier agent cleared',
+        );
+      }
+      if (params.verifyRubricId !== undefined) {
+        verify.verifyRubricId = params.verifyRubricId;
+        changes.push(
+          params.verifyRubricId
+            ? `verify rubric → ${params.verifyRubricId}`
+            : 'verify rubric cleared',
+        );
+      }
+      if (params.verifyCriteriaIds !== undefined) {
+        verify.verifyCriteriaIds = params.verifyCriteriaIds;
+        changes.push(
+          params.verifyCriteriaIds?.length
+            ? `verify criteria → ${params.verifyCriteriaIds.length} item(s)`
+            : 'verify criteria cleared',
+        );
+      }
+
+      if (Object.keys(verify).length === 0) {
+        return {
+          content: 'No verify fields provided; nothing to update.',
+          error: { message: 'No verify fields provided.', type: 'NoFields' },
+          success: false,
+        };
+      }
+
+      await taskService.updateVerifyConfig({ id: identifier, verify });
+      await getTaskStoreState().internal_refreshTaskDetail(identifier);
+
+      return {
+        content: formatTaskEdited(identifier, changes),
+        state: { enabled: params.enabled, identifier, success: true },
+        success: true,
+      };
+    } catch (error) {
+      log('[TaskExecutor] setTaskVerify - error:', error);
+      const message = error instanceof Error ? error.message : 'Failed to set task verify config';
+      return {
+        content: `Failed to set task verify config: ${message}`,
+        error: { message, type: 'SetTaskVerifyFailed' },
         success: false,
       };
     }

--- a/packages/builtin-tool-task/src/manifest.ts
+++ b/packages/builtin-tool-task/src/manifest.ts
@@ -342,6 +342,52 @@ export const TaskManifest: BuiltinToolManifest = {
     },
     {
       description:
+        'Configure (or clear) a task\'s delivery-acceptance (verify) gate — the evidence-driven check that runs when the task\'s topic completes, so the assigned agent\'s "done" is verified by a separate reviewer instead of blindly trusted. STRONGLY RECOMMENDED whenever you dispatch an executable task to another agent (assigneeAgentId set): turn the gate on with enabled=true and state a one-sentence `requirement` describing what "done" means; the server synthesizes acceptance criteria from it. Pass verifyRubricId to reuse a saved rubric, or verifyCriteriaIds for explicit criteria. Pass null to any field to clear it; omitted fields are left untouched.',
+      name: TaskApiName.setTaskVerify,
+      parameters: {
+        properties: {
+          enabled: {
+            description:
+              'Whether the verify gate runs when the task completes. Pass true to require verification, false to disable, null to clear.',
+            type: ['boolean', 'null'],
+          },
+          identifier: {
+            description: 'The identifier of the task to configure (e.g. "TASK-1").',
+            type: 'string',
+          },
+          maxIterations: {
+            description:
+              'Cap on verify repair / re-run iterations (1-10). Pass null to clear (uses the default).',
+            type: ['number', 'null'],
+          },
+          requirement: {
+            description:
+              'One-sentence acceptance requirement describing what "done" means for this task (e.g. "All unit tests pass and the new endpoint returns 200"). The server synthesizes acceptance criteria from it when no explicit criteria are given. Pass null to clear.',
+            type: ['string', 'null'],
+          },
+          verifierAgentId: {
+            description:
+              'Agent ID that executes the verify run. Omit to use the built-in verify agent. Pass null to clear an existing value.',
+            type: ['string', 'null'],
+          },
+          verifyCriteriaIds: {
+            description:
+              'Explicit acceptance criteria ids to check against. Pass null to clear; omit when relying on requirement-synthesized criteria.',
+            items: { type: 'string' },
+            type: ['array', 'null'],
+          },
+          verifyRubricId: {
+            description:
+              'Reuse a saved rubric template by id instead of ad-hoc criteria. Pass null to clear.',
+            type: ['string', 'null'],
+          },
+        },
+        required: ['identifier'],
+        type: 'object',
+      },
+    },
+    {
+      description:
         "Update a task's status. Use to mark tasks as completed, canceled, paused, resumed, or failed. To START a task (transition into running), use runTask — it actually launches the agent. updateTaskStatus only flips the status flag without execution. If identifier is omitted, this only works when there is a current task context.",
       name: TaskApiName.updateTaskStatus,
       parameters: {

--- a/packages/builtin-tool-task/src/systemRole.ts
+++ b/packages/builtin-tool-task/src/systemRole.ts
@@ -7,6 +7,7 @@ export const systemPrompt = `You have access to Task management tools. Use them 
 - **addTaskComment / updateTaskComment / deleteTaskComment**: Record, revise, or remove task comments. Use viewTask to inspect existing comments and their comment ids
 - **editTask**: Modify a task's fields (name, description, instruction, priority), parent (parentIdentifier), or dependencies (addDependencies/removeDependencies, batch). Use parentIdentifier=null to move a task to the top level. For status changes use updateTaskStatus; for schedule configuration use setTaskSchedule
 - **setTaskSchedule**: Configure (or clear) the recurring schedule of a task. Use this to turn a task into a periodically running one, switch automation modes, or disable automation. See "Schedule fields" below for the supported params
+- **setTaskVerify**: Configure (or clear) a task's delivery-acceptance (verify) gate. Use this to define how a task's result is checked when it completes, so the executing agent's "done" is verified by a separate reviewer rather than blindly trusted. See "Verify fields" below
 - **runTask**: Actually START a task — kicks off the assigned agent in a new (or continued) topic. Use this to launch execution; do NOT use updateTaskStatus(running) to start a task, that only flips a flag without executing. The task must have an assigneeAgentId
 - **runTasks**: Start multiple tasks in one call. Prefer this when launching a batch of related subtasks (e.g. all subtasks you just created); cuts down on tool calls and makes the start atomic from the user's perspective
 - **updateTaskStatus**: Change a task's status. If you mark a task as failed, include an error message explaining why. Use this to mark tasks completed/cancelled/paused/failed — NOT to start them (use runTask for that). Omitting identifier only works when there is a current task context
@@ -18,7 +19,18 @@ Schedule fields (setTaskSchedule):
 - **heartbeatInterval**: seconds between ticks; used by heartbeat mode (recommend ≥600s). Pass 0 to clear
 - **maxExecutions**: cap on total scheduled runs; null means unlimited
 
+Verify fields (setTaskVerify):
+- **enabled**: true to require a verify gate when the task completes, false to disable, null to clear
+- **requirement**: a one-sentence description of what "done" means for the task; the server synthesizes acceptance criteria from it. This is usually all you need
+- **verifyRubricId**: reuse a saved rubric template instead of an ad-hoc requirement
+- **verifyCriteriaIds**: explicit acceptance criteria ids, when you want exact checks rather than a synthesized requirement
+- **verifierAgentId**: agent that runs the verification; omit to use the built-in verify agent
+- **maxIterations**: cap on verify repair / re-run iterations (1-10)
+
+When you dispatch an executable task to another agent (you set assigneeAgentId, then runTask), do NOT trust its self-reported "done" blindly — set a verify gate so the result is independently checked. Right after creating such a task, call setTaskVerify(identifier, enabled=true, requirement="<one sentence acceptance criteria>") before runTask. Skip verify only for trivial or non-deliverable tasks (e.g. pure status bookkeeping).
+
 When planning work:
 1. Create tasks for each major piece of work (use parentIdentifier to organize as subtasks)
 2. Use editTask with addDependencies to control execution order
-3. Use updateTaskStatus to mark the current task as completed when you finish all work`;
+3. For executable tasks dispatched to an agent, use setTaskVerify to attach acceptance criteria before running them
+4. Use updateTaskStatus to mark the current task as completed when you finish all work`;

--- a/packages/builtin-tool-task/src/types.ts
+++ b/packages/builtin-tool-task/src/types.ts
@@ -31,6 +31,9 @@ export const TaskApiName = {
   /** Configure (or clear) the recurring schedule of a task */
   setTaskSchedule: 'setTaskSchedule',
 
+  /** Configure (or clear) the delivery-acceptance (verify) gate of a task */
+  setTaskVerify: 'setTaskVerify',
+
   /** Update a task comment */
   updateTaskComment: 'updateTaskComment',
 
@@ -224,6 +227,30 @@ export interface SetTaskScheduleParams {
 
 export interface SetTaskScheduleState {
   automationMode?: TaskAutomationMode | null;
+  identifier: string;
+  success: boolean;
+}
+
+// ==================== setTaskVerify ====================
+
+export interface SetTaskVerifyParams {
+  /** Turn the verify gate on/off. Pass null to clear the flag. */
+  enabled?: boolean | null;
+  identifier: string;
+  /** Cap on verify repair / re-run iterations (1-10). Pass null to clear. */
+  maxIterations?: number | null;
+  /** One-sentence acceptance requirement; the source criteria are synthesized from. Pass null to clear. */
+  requirement?: string | null;
+  /** Agent that executes the verify run. Pass null to fall back to the built-in verify agent. */
+  verifierAgentId?: string | null;
+  /** Ad-hoc acceptance criteria ids (references verify_criteria.id). Pass null to clear. */
+  verifyCriteriaIds?: string[] | null;
+  /** Reuse a rubric template (references verify_rubrics.id). Pass null to clear. */
+  verifyRubricId?: string | null;
+}
+
+export interface SetTaskVerifyState {
+  enabled?: boolean | null;
   identifier: string;
   success: boolean;
 }

--- a/packages/locales/src/default/plugin.ts
+++ b/packages/locales/src/default/plugin.ts
@@ -348,6 +348,7 @@ export default {
   'builtins.lobe-task.apiName.runTask': 'Run task',
   'builtins.lobe-task.apiName.runTasks': 'Run tasks',
   'builtins.lobe-task.apiName.setTaskSchedule': 'Set schedule',
+  'builtins.lobe-task.apiName.setTaskVerify': 'Set verify',
   'builtins.lobe-task.apiName.updateTaskComment': 'Update comment',
   'builtins.lobe-task.apiName.updateTaskStatus': 'Update status',
   'builtins.lobe-task.apiName.viewTask': 'View task',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Fixes LOBE-10786
Related to LOBE-10614 (Verify task-level delivery acceptance), LOBE-10755 (holistic single-item plan)

#### 🔀 Description of Change

Agents creating tasks through the builtin task tool had **no entry** to set the delivery-acceptance (verify) config (`tasks.config.verify`). So any task the agent autonomously created and dispatched to an executor (router / auto-dispatch / issue→task→CC) ran **without an acceptance gate** — LOBE-10614's "evidence-driven + review gate + repair loop" was effectively bypassed for the most common task source. Verify could only be configured by a human in the Task Detail UI.

This is a **tool-surface gap**, not a prompt gap: the write path already existed end-to-end (`taskService.updateVerifyConfig` → `task.updateVerifyConfig` TRPC → `TaskModel.updateVerifyConfig`); no agent-facing tool exposed it.

**Fix: a dedicated `setTaskVerify` tool**, chosen over inlining on `createTask`/`editTask` because:

- `tasks.config.verify` is config-domain JSONB, exactly parallel to `tasks.config.schedule` — which already has its own dedicated `setTaskSchedule` tool rather than being crammed into create/edit. `editTask` already delegates config concerns out (status→`updateTaskStatus`, schedule→`setTaskSchedule`); verify follows the same precedent.
- Reuses the existing `updateVerifyConfig` path — **zero new server/model/service code**.
- Keeps the hot `createTask`/`createTasks` (batch) tools token-lean (no 6-field verify block repeated per item).

Changes:
- `setTaskVerify` tool: `identifier`, `enabled`, `requirement`, `verifierAgentId`, `verifyRubricId`, `verifyCriteriaIds`, `maxIterations` — all nullable (`null` clears, omit leaves untouched), matching the TRPC contract.
- Executor method wired to `taskService.updateVerifyConfig`; registered in `DETAIL_MUTATING_APIS`.
- Inspector component + registry entry; i18n label (`apiName.setTaskVerify`) in default/en-US/zh-CN.
- **Prompt guidance**: when dispatching an executable task to another agent, set `setTaskVerify(enabled=true, requirement="…")` before `runTask` — don't trust self-reported "done". Per LOBE-10755 the server synthesizes acceptance criteria from `requirement` when none are given.

> Not in scope (issue's option 2, pending owner decision): server-side **default-enable** verify for dispatched tasks. This PR covers option 1 (tool entry) + option 3 (prompt) and leaves the default-mandatory behavior as a follow-up.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

`bun run type-check` passes for the changed package (the two remaining errors are pre-existing, in `builtin-tool-claude-code` re: a `Tabs` export). To exercise: have an agent create a task and call `setTaskVerify({ identifier, enabled: true, requirement: "…" })`; confirm `tasks.config.verify` is persisted and the verify gate fires on topic completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)