### PR TITLE
🐛 fix(task): open task detail portal from onAfterCall instead of render effect

### DIFF
--- a/packages/builtin-tool-task/src/client/Render/CreateTask/index.tsx
+++ b/packages/builtin-tool-task/src/client/Render/CreateTask/index.tsx
@@ -4,7 +4,7 @@ import type { BuiltinRenderProps } from '@lobechat/types';
 import { ActionIcon, Block, Markdown, Text } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { PanelRight, PanelRightClose } from 'lucide-react';
-import { memo, useEffect, useRef } from 'react';
+import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import TaskPriorityTag from '@/features/AgentTasks/features/TaskPriorityTag';
@@ -13,10 +13,6 @@ import { useChatStore } from '@/store/chat';
 import { chatPortalSelectors } from '@/store/chat/selectors';
 
 import type { CreateTaskParams, CreateTaskState } from '../../../types';
-
-// Tracks task identifiers we've already auto-expanded so re-mounting the card
-// (scrolling the message back into view) doesn't reopen a portal the user closed.
-const autoOpened = new Set<string>();
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   description: css`
@@ -48,8 +44,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
        expanded detail panel. */
     overflow: hidden;
     max-height: 132px;
-
-    mask-image: linear-gradient(to bottom, black 78%, transparent);
 
     mask-image: linear-gradient(to bottom, black 78%, transparent);
   `,
@@ -93,19 +87,9 @@ export const CreateTaskRender = memo<BuiltinRenderProps<CreateTaskParams, Create
     );
 
     const identifier = pluginState?.identifier;
-    // Identifier present at first render means this card mounted already-resolved
-    // (e.g. an old task when reopening the conversation) — only the fresh
-    // undefined → defined transition counts as "just created".
-    const identifierAtMount = useRef(identifier);
-
-    // Once the task is freshly created, auto-expand its detail in the right-side
-    // portal so the user can review it without leaving the conversation.
-    useEffect(() => {
-      if (!identifier || identifierAtMount.current === identifier) return;
-      if (autoOpened.has(identifier)) return;
-      autoOpened.add(identifier);
-      openTaskDetail(identifier);
-    }, [identifier, openTaskDetail]);
+    // Auto-expanding the freshly created task's detail portal is driven by the
+    // executor's `onAfterCall` hook (gateway `tool_end`), not a render effect —
+    // see `client/executor`. The card itself only handles the manual toggle.
 
     // Prefer the resolved task (`pluginState`); fall back to `args` while the
     // call is still streaming and no result has landed yet.

--- a/packages/builtin-tool-task/src/client/executor/index.ts
+++ b/packages/builtin-tool-task/src/client/executor/index.ts
@@ -19,6 +19,7 @@ import { BaseExecutor } from '@lobechat/types';
 import debug from 'debug';
 
 import { taskService } from '@/services/task';
+import { getChatStoreState } from '@/store/chat';
 import { getTaskStoreState } from '@/store/task';
 import { findSubtaskParentId } from '@/store/task/slices/detail/reducer';
 
@@ -78,6 +79,16 @@ class TaskExecutor extends BaseExecutor<typeof TaskApiName> {
 
     const store = getTaskStoreState();
     const identifier = extractIdentifier(params, result);
+
+    // Auto-expand the freshly created task's detail in the right-side portal so
+    // the user can review it without leaving the conversation. This fires once
+    // per `createTask` tool call (on the gateway `tool_end` event), which is why
+    // it lives here rather than in the renderer: the gateway re-fetches and
+    // remounts the message after `tool_end`, so a render-mount effect never sees
+    // the undefined → defined identifier transition and would never open.
+    if (apiName === TaskApiName.createTask && identifier) {
+      getChatStoreState().openTaskDetail(identifier);
+    }
 
     // Build the set of task-detail keys to revalidate. Mirrors the pattern
     // used by `updateTask` in the detail slice so subtask deletions / edits

--- a/packages/builtin-tool-task/src/client/executor/onAfterCall.test.ts
+++ b/packages/builtin-tool-task/src/client/executor/onAfterCall.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TaskApiName } from '../../types';
+
+const mocks = vi.hoisted(() => ({
+  getChatStoreState: vi.fn(),
+  getTaskStoreState: vi.fn(),
+  openTaskDetail: vi.fn(),
+}));
+
+vi.mock('@/store/chat', () => ({
+  getChatStoreState: mocks.getChatStoreState,
+}));
+
+vi.mock('@/store/task', () => ({
+  getTaskStoreState: mocks.getTaskStoreState,
+}));
+
+vi.mock('@/store/task/slices/detail/reducer', () => ({
+  findSubtaskParentId: vi.fn(() => undefined),
+}));
+
+vi.mock('@/services/task', () => ({
+  taskService: {},
+}));
+
+// Imported after mocks so the executor module resolves the stubbed stores.
+const { taskExecutor } = await import('./index');
+
+describe('TaskExecutor.onAfterCall — portal auto-open', () => {
+  beforeEach(() => {
+    mocks.openTaskDetail.mockClear();
+    mocks.getChatStoreState.mockReturnValue({ openTaskDetail: mocks.openTaskDetail });
+    mocks.getTaskStoreState.mockReturnValue({
+      activeTaskId: undefined,
+      internal_refreshTaskDetail: vi.fn().mockResolvedValue(undefined),
+      refreshTaskList: vi.fn().mockResolvedValue(undefined),
+      taskDetailMap: {},
+    });
+  });
+
+  it('opens the task detail portal after a successful createTask', async () => {
+    await taskExecutor.onAfterCall({
+      apiName: TaskApiName.createTask,
+      params: {},
+      result: { content: '', state: { identifier: 'task-123' }, success: true },
+    } as any);
+
+    expect(mocks.openTaskDetail).toHaveBeenCalledWith('task-123');
+  });
+
+  it('does not open the portal for non-createTask APIs', async () => {
+    await taskExecutor.onAfterCall({
+      apiName: TaskApiName.editTask,
+      params: { identifier: 'task-1' },
+      result: { content: '', state: { identifier: 'task-1' }, success: true },
+    } as any);
+
+    expect(mocks.openTaskDetail).not.toHaveBeenCalled();
+  });
+
+  it('does not open the portal when createTask failed', async () => {
+    await taskExecutor.onAfterCall({
+      apiName: TaskApiName.createTask,
+      params: {},
+      result: { content: '', success: false },
+    } as any);
+
+    expect(mocks.openTaskDetail).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

In **gateway mode** the agent runs server-side and the client re-fetches and **remounts** the `createTask` message on `tool_end`. So the renderer's mount-time `useEffect` never observes the `undefined → defined` identifier transition, and the right-side **TaskDetail portal never auto-opens** for a freshly created task.

This moves the auto-expand out of `CreateTaskRender` and into `TaskExecutor.onAfterCall`, which the client-side `gatewayEventHandler` invokes exactly once per tool call on `tool_end`:

- `executor/index.ts` — on a successful `createTask`, call `getChatStoreState().openTaskDetail(identifier)`. Fires deterministically on the real tool completion, independent of render timing.
- `Render/CreateTask/index.tsx` — drop the mount-effect plus its `autoOpened` `Set` and `identifierAtMount` ref hacks. The card keeps only the manual open/close toggle.

Behavior-preserving for the interactive case; fixes the gateway case where it previously never opened.

> Note: only the **gateway** client path is covered. The hetero (Claude Code / Codex) path does not currently dispatch `onAfterCall`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Unit: `packages/builtin-tool-task/src/client/executor/onAfterCall.test.ts` — createTask success opens the portal; non-createTask (editTask) and failed createTask do not.
- Regression: `gatewayEventHandler.test.ts` (61) still green — `tool_end → onAfterCall` dispatch unchanged.
- E2E (isolated local env, authed): called the real `taskExecutor.onAfterCall({apiName:'createTask', identifier})` in a live session; `chat` store flipped `showPortal: false → true` with `portalStack` top `{taskId, type:'taskDetail'}`, and the TaskDetail panel rendered with that id.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Gateway createTask: portal does not auto-open | Portal auto-opens to the new task's TaskDetail |

#### 📝 Additional Information

Verification report: https://app.lobehub.com/verify/ea861246-ea18-4810-8d49-01e65502366c

🤖 Generated with [Claude Code](https://claude.com/claude-code)