### PR TITLE
🐛 fix(task): stop task detail deadlocking when assignee agent is gone

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/useActiveTaskDetail.test.ts
+++ b/src/features/AgentTasks/AgentTaskDetail/useActiveTaskDetail.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useActiveTaskDetail } from './useActiveTaskDetail';
+
+const mocks = vi.hoisted(() => ({
+  agentState: {} as any,
+  isLogin: true as boolean | undefined,
+  taskState: {} as any,
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: () => mocks.isLogin,
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  authSelectors: { isLogin: (s: any) => s?.isLogin },
+}));
+
+vi.mock('@/store/task', () => ({
+  useTaskStore: (selector: any) => selector(mocks.taskState),
+}));
+
+vi.mock('@/store/agent', () => ({
+  useAgentStore: (selector: any) => selector(mocks.agentState),
+}));
+
+const buildTaskState = (
+  overrides: {
+    agentId?: string | null;
+    detail?: boolean;
+    taskError?: unknown;
+  } = {},
+) => {
+  const { agentId = 'agt_assignee', detail = true, taskError } = overrides;
+  return {
+    activeTaskId: undefined,
+    setActiveTaskId: vi.fn(),
+    taskDetailMap: detail ? { 'T-194': { agentId } } : {},
+    // `useFetchTaskDetail` is read off the store and called with the id.
+    useFetchTaskDetail: () => ({ error: taskError }),
+  };
+};
+
+const buildAgentState = (overrides: { inMap?: boolean; isLoading?: boolean } = {}) => {
+  const { inMap = false, isLoading = false } = overrides;
+  return {
+    agentMap: inMap ? { agt_assignee: { id: 'agt_assignee' } } : {},
+    useHydrateAgentConfig: () => ({ isLoading }),
+  };
+};
+
+describe('useActiveTaskDetail', () => {
+  beforeEach(() => {
+    mocks.isLogin = true;
+    mocks.taskState = buildTaskState();
+    mocks.agentState = buildAgentState();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does NOT deadlock when the assignee agent was deleted / moved to another workspace', () => {
+    // The ownership-scoped fetch resolves to null: SWR settles (isLoading=false),
+    // the agent never lands in agentMap, and there is no error. The detail page
+    // must still render instead of spinning forever.
+    mocks.taskState = buildTaskState({ agentId: 'agt_moved_away' });
+    mocks.agentState = buildAgentState({ inMap: false, isLoading: false });
+
+    const { result } = renderHook(() => useActiveTaskDetail('T-194'));
+
+    expect(result.current.isInitialLoading).toBe(false);
+    expect(result.current.isNotFound).toBe(false);
+  });
+
+  it('keeps the skeleton up while the assignee config fetch is genuinely in-flight', () => {
+    mocks.agentState = buildAgentState({ inMap: false, isLoading: true });
+
+    const { result } = renderHook(() => useActiveTaskDetail('T-194'));
+
+    expect(result.current.isInitialLoading).toBe(true);
+  });
+
+  it('releases once the assignee config is hydrated into the map', () => {
+    mocks.agentState = buildAgentState({ inMap: true, isLoading: false });
+
+    const { result } = renderHook(() => useActiveTaskDetail('T-194'));
+
+    expect(result.current.isInitialLoading).toBe(false);
+  });
+
+  it('does not block on the assignee when the task has no assignee', () => {
+    mocks.taskState = buildTaskState({ agentId: null });
+    mocks.agentState = buildAgentState({ inMap: false, isLoading: true });
+
+    const { result } = renderHook(() => useActiveTaskDetail('T-194'));
+
+    expect(result.current.isInitialLoading).toBe(false);
+  });
+
+  it('stays loading while the task detail itself is still resolving', () => {
+    mocks.taskState = buildTaskState({ detail: false });
+
+    const { result } = renderHook(() => useActiveTaskDetail('T-194'));
+
+    expect(result.current.isInitialLoading).toBe(true);
+    expect(result.current.isNotFound).toBe(false);
+  });
+
+  it('reports not-found when the task fetch errored and there is no cached detail', () => {
+    mocks.taskState = buildTaskState({ detail: false, taskError: new Error('not found') });
+
+    const { result } = renderHook(() => useActiveTaskDetail('T-194'));
+
+    expect(result.current.isNotFound).toBe(true);
+    expect(result.current.isInitialLoading).toBe(false);
+  });
+});

--- a/src/features/AgentTasks/AgentTaskDetail/useActiveTaskDetail.ts
+++ b/src/features/AgentTasks/AgentTaskDetail/useActiveTaskDetail.ts
@@ -53,7 +53,7 @@ export const useActiveTaskDetail = (taskId?: string): ActiveTaskDetailState => {
 
   // Hydrate-only (never touches `activeAgentId`); no-ops on an empty id, so it
   // simply activates once the assignee is known from the task detail.
-  const { error: agentConfigError } = useHydrateAgentConfig(isLogin, assigneeAgentId ?? '');
+  const { isLoading: agentConfigLoading } = useHydrateAgentConfig(isLogin, assigneeAgentId ?? '');
 
   if (!taskId) return { isInitialLoading: false, isNotFound: false };
 
@@ -62,10 +62,15 @@ export const useActiveTaskDetail = (taskId?: string): ActiveTaskDetailState => {
   // resolving — keep the skeleton up instead of flashing empty/404.
   const isTaskResolving = !hasTaskDetail && !isNotFound;
 
-  // Block on the assignee config only when there is one and a fetch can run;
-  // release on success (in map) or failure (error) so we never deadlock.
+  // Block on the assignee config only while its fetch is genuinely in-flight and
+  // we don't already have it cached. Gating on `isLoading` (not "absent from the
+  // map") is what avoids the deadlock: a settled fetch that resolves to `null` —
+  // the assignee was deleted or moved to another workspace, so the ownership-
+  // scoped query returns null *without* erroring — leaves `isLoading=false` and
+  // no error, releasing the gate instead of waiting forever for a config that
+  // will never land in the map.
   const isAssigneeResolving =
-    !!assigneeAgentId && isLogin === true && !assigneeInMap && !agentConfigError;
+    !!assigneeAgentId && isLogin === true && !assigneeInMap && agentConfigLoading;
 
   return {
     isInitialLoading: isTaskResolving || (hasTaskDetail && isAssigneeResolving),


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 🐛 fix

### 🔀 变更说明 | Description of Change

The task detail page (`/task/:taskId`) renders an intact header (breadcrumb shows the task title) but a permanently blank body — it never opens — for any task whose **assignee agent was deleted or moved to another workspace**.

**Root cause** — `useActiveTaskDetail` gated the initial-loading skeleton on whether the assignee's config had landed in `agentMap`:

```ts
const isAssigneeResolving =
  !!assigneeAgentId && isLogin === true && !assigneeInMap && !agentConfigError;
```

When the assignee is gone, the ownership-scoped `agentModel.getAgentConfigById` returns `null` **without throwing** (`packages/database/src/models/agent.ts`). So the SWR fetch settles *successfully*, but `useHydrateAgentConfig`'s `onData` does `if (!data) return` and never dispatches into `agentMap`. The result: `assigneeInMap` stays `false`, `agentConfigError` stays `undefined`, `isAssigneeResolving` is `true` forever → `isInitialLoading` is `true` forever → the body is stuck on `<Loading/>` and the page never opens.

**Fix** — gate on the SWR `isLoading` flag instead of "absent from the map". A settled fetch (null result, error, or a null key for group/unauthenticated cases) leaves `isLoading=false`, releasing the gate, while `assigneeInMap` is preserved as the already-cached fast-path so there's no skeleton flash on revalidation.

### 📝 补充信息 | Additional Information

`TaskModelConfig` / `TaskDetailAssignee` already fall back gracefully when the assignee config is absent, so releasing the gate renders the page correctly instead of deadlocking.

Follow-ups considered but intentionally out of scope (happy to do in a separate PR):
- An error boundary around the task detail body so a future render throw degrades to one broken section instead of a blank page.
- A "this agent is no longer available" hint when the assignee can't be resolved.

### ✅ 测试 | How to Test

- [x] New unit test `useActiveTaskDetail.test.ts` (6 cases): the regression case (assignee deleted/moved → settles to `null` → **no deadlock**), plus in-flight, cached, no-assignee, task-resolving, and not-found branches.

```bash
bunx vitest run --silent='passed-only' 'src/features/AgentTasks/AgentTaskDetail/useActiveTaskDetail.test.ts'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)