### PR TITLE
🐛 fix(floating-panel): disable ChatInput internal expand and control bar in floating panel

### DIFF
--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.test.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.test.tsx
@@ -64,6 +64,7 @@ vi.mock('react-i18next', () => ({
 vi.mock('@/features/ExplorerTree', () => {
   interface MockExplorerTreeProps {
     canDrag?: (node: ExplorerTreeNode<unknown>) => boolean;
+    defaultExpandedIds?: string[];
     getContextMenuItems?: (node: ExplorerTreeNode<unknown>) => unknown[] | undefined;
     header?: ReactNode;
     nodes: ExplorerTreeNode<unknown>[];
@@ -78,6 +79,7 @@ vi.mock('@/features/ExplorerTree', () => {
 
   const ExplorerTree = ({
     canDrag,
+    defaultExpandedIds,
     getContextMenuItems,
     header,
     nodes,
@@ -121,7 +123,10 @@ vi.mock('@/features/ExplorerTree', () => {
         });
 
     return (
-      <div data-testid="explorer-tree">
+      <div
+        data-default-expanded-ids={JSON.stringify(defaultExpandedIds ?? [])}
+        data-testid="explorer-tree"
+      >
         {header}
         {renderNodes(null)}
       </div>
@@ -299,6 +304,34 @@ describe('DocumentExplorerTree', () => {
 
     expect(openDocumentMock).toHaveBeenCalledWith('doc-content-1', 'agent-doc-row-1');
     expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('does not default-expand document folders', () => {
+    const data = [
+      createDocument({
+        documentId: 'folder-doc',
+        fileType: CUSTOM_FOLDER_FILE_TYPE,
+        filename: 'Notes',
+        id: 'folder-row',
+        isFolder: true,
+        title: 'Notes',
+      }),
+      createDocument({
+        documentId: 'nested-folder-doc',
+        fileType: CUSTOM_FOLDER_FILE_TYPE,
+        filename: 'Archive',
+        id: 'nested-folder-row',
+        isFolder: true,
+        parentId: 'folder-doc',
+        title: 'Archive',
+      }),
+    ];
+
+    render(<DocumentExplorerTree agentId="agent-1" data={data} mutate={vi.fn()} />, {
+      wrapper: MemoryRouter,
+    });
+
+    expect(screen.getByTestId('explorer-tree')).toHaveAttribute('data-default-expanded-ids', '[]');
   });
 
   it('shows delete recovery action for a managed skill bundle without SKILL.md', async () => {

--- a/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
+++ b/src/features/AgentDocumentsExplorer/DocumentExplorerTree.tsx
@@ -138,10 +138,6 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, onOpenDocumen
       })),
     [documents, resolveNodeName, resolveParentRowId],
   );
-  const defaultExpandedIds = useMemo(
-    () => nodes.filter((node) => node.isFolder && node.parentId == null).map((node) => node.id),
-    [nodes],
-  );
   const treeStyleVars = useMemo(
     () => getExplorerTreeStyleVars({ reserveChevronSlot: nodes.some((node) => node.isFolder) }),
     [nodes],
@@ -395,7 +391,6 @@ const DocumentExplorerTree = memo<Props>(({ agentId, data, mutate, onOpenDocumen
           canDrag={canDrag}
           canDrop={canDrop}
           canRename={canRename}
-          defaultExpandedIds={defaultExpandedIds}
           getContextMenuItems={getContextMenuItems}
           header={toolbar}
           iconSet="complete"

--- a/src/features/FloatingChatPanel/InputRow.test.tsx
+++ b/src/features/FloatingChatPanel/InputRow.test.tsx
@@ -8,17 +8,20 @@ import InputRow from './InputRow';
 
 vi.mock('@/features/Conversation', () => ({
   ChatInput: ({
+    allowExpand,
     compact,
     leftActions,
     rightActions,
     showControlBar,
   }: {
+    allowExpand?: boolean;
     compact?: boolean;
     leftActions?: string[];
     rightActions?: string[];
     showControlBar?: boolean;
   }) => (
     <div
+      data-allow-expand={String(allowExpand ?? true)}
       data-compact={String(compact ?? false)}
       data-left-actions={JSON.stringify(leftActions ?? [])}
       data-right-actions={JSON.stringify(rightActions ?? [])}
@@ -36,6 +39,7 @@ describe('FloatingChatPanel InputRow', () => {
   it('renders ChatInput in compact mode with empty actions and no control bar while collapsed', () => {
     render(<InputRow isCollapsed onExpand={() => {}} />);
     const input = screen.getByTestId('chat-input');
+    expect(input.dataset.allowExpand).toBe('false');
     expect(input.dataset.compact).toBe('true');
     expect(input.dataset.leftActions).toBe('[]');
     expect(input.dataset.rightActions).toBe('[]');
@@ -45,10 +49,11 @@ describe('FloatingChatPanel InputRow', () => {
   it('renders ChatInput at full size with all actions while expanded', () => {
     render(<InputRow isCollapsed={false} onExpand={() => {}} />);
     const input = screen.getByTestId('chat-input');
+    expect(input.dataset.allowExpand).toBe('false');
     expect(input.dataset.compact).toBe('false');
     expect(input.dataset.leftActions).toBe(JSON.stringify(['typo']));
     expect(input.dataset.rightActions).toBe(JSON.stringify(['contextWindow']));
-    expect(input.dataset.showControlBar).toBe('true');
+    expect(input.dataset.showControlBar).toBe('false');
   });
 
   it('keeps the expand bar hidden while collapsed and unfocused — hover alone never reveals it', () => {
@@ -112,10 +117,11 @@ describe('FloatingChatPanel InputRow', () => {
     expect(input.dataset.compact).toBe('true');
 
     fireEvent.focus(screen.getByTestId('floating-chat-panel-input-row'));
+    expect(input.dataset.allowExpand).toBe('false');
     expect(input.dataset.compact).toBe('false');
     expect(input.dataset.leftActions).toBe(JSON.stringify(['typo']));
     expect(input.dataset.rightActions).toBe(JSON.stringify(['contextWindow']));
-    expect(input.dataset.showControlBar).toBe('true');
+    expect(input.dataset.showControlBar).toBe('false');
   });
 
   it('restores compact rendering once focus leaves the row entirely', () => {

--- a/src/features/FloatingChatPanel/InputRow.tsx
+++ b/src/features/FloatingChatPanel/InputRow.tsx
@@ -103,10 +103,11 @@ const InputRow = memo<InputRowProps>(({ isCollapsed, onExpand }) => {
         <HoverExpandBar visible={isCollapsed && focused} onExpand={onExpand} />
         <div className={s.surface}>
           <ChatInput
+            allowExpand={false}
             compact={effectiveCompact}
             leftActions={effectiveCompact ? EMPTY_ACTIONS : EXPANDED_LEFT_ACTIONS}
             rightActions={effectiveCompact ? EMPTY_ACTIONS : EXPANDED_RIGHT_ACTIONS}
-            showControlBar={!effectiveCompact}
+            showControlBar={false}
           />
         </div>
       </div>

--- a/src/features/FloatingChatPanel/index.test.tsx
+++ b/src/features/FloatingChatPanel/index.test.tsx
@@ -87,17 +87,20 @@ const mergedHooksCaptured = vi.hoisted(() => ({
 
 vi.mock('@/features/Conversation', () => ({
   ChatInput: ({
+    allowExpand,
     compact,
     leftActions,
     rightActions,
     showControlBar,
   }: {
+    allowExpand?: boolean;
     compact?: boolean;
     leftActions?: string[];
     rightActions?: string[];
     showControlBar?: boolean;
   }) => (
     <div
+      data-allow-expand={String(allowExpand ?? true)}
       data-compact={String(compact ?? false)}
       data-left-actions={JSON.stringify(leftActions ?? [])}
       data-right-actions={JSON.stringify(rightActions ?? [])}
@@ -250,6 +253,7 @@ describe('FloatingChatPanel', () => {
   it('renders a minimal ChatInput while collapsed (no left/right actions)', () => {
     const { getByTestId } = render(<FloatingChatPanel agentId="a" topicId="t" />);
     const input = getByTestId('chat-input');
+    expect(input.dataset.allowExpand).toBe('false');
     expect(input.dataset.leftActions).toBe('[]');
     expect(input.dataset.rightActions).toBe('[]');
   });
@@ -267,6 +271,7 @@ describe('FloatingChatPanel', () => {
     expect(sheet.dataset.activeSnap).toBe('420');
     expect(getByTestId('floating-chat-panel').dataset.collapsed).toBe('false');
     const input = getByTestId('chat-input');
+    expect(input.dataset.allowExpand).toBe('false');
     expect(input.dataset.leftActions).toBe(JSON.stringify(['typo']));
     expect(input.dataset.rightActions).toBe(JSON.stringify(['contextWindow']));
   });


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Two small UI fixes:

1. **FloatingChatPanel InputRow** — adds `allowExpand={false}` to `ChatInput` so its internal toggle-expand button is suppressed (redundant with the panel's own `HoverExpandBar`). Also removes the action control bar (`showControlBar={false}`) — the floating panel manages its own toolbar state and the control bar is never needed here.

2. **DocumentExplorerTree** — removes `defaultExpandedIds` that was passing top-level folder IDs to always expand them on mount. They now start collapsed, matching the expected default behavior.

#### 🧪 How to Test

- Floating panel: collapsed state shows minimal ChatInput, expanded state shows all actions but no redundant expand button
- Document tree: folders start collapsed on first render

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

N/A (no visual regressions)
