### PR TITLE
✨ feat(task): surface natural-language verify requirement in collapsed & empty states

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -978,6 +978,7 @@
   "verifyConfig.disabled": "Acceptance disabled",
   "verifyConfig.done": "Done",
   "verifyConfig.edit": "Edit",
+  "verifyConfig.empty.materializeHint": "This requirement is already in effect. You can break it down further into a structured, item-by-item checklist.",
   "verifyConfig.empty.subtitle": "Describe how you want to accept the result in one sentence, and AI will turn it into an editable checklist.",
   "verifyConfig.empty.title": "Delivery Acceptance",
   "verifyConfig.enable": "Enable acceptance check",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -978,6 +978,7 @@
   "verifyConfig.disabled": "验收已禁用",
   "verifyConfig.done": "完成",
   "verifyConfig.edit": "编辑",
+  "verifyConfig.empty.materializeHint": "该验收要求已生效，可进一步拆解为结构化的逐条验收标准。",
   "verifyConfig.empty.subtitle": "用一句话描述你希望怎么验收，AI 会帮你拆解成可编辑的验收清单。",
   "verifyConfig.empty.title": "交付验收",
   "verifyConfig.enable": "启用验收检查",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -1312,6 +1312,8 @@ export default {
   'verifyConfig.disabled': 'Acceptance disabled',
   'verifyConfig.done': 'Done',
   'verifyConfig.edit': 'Edit',
+  'verifyConfig.empty.materializeHint':
+    'This requirement is already in effect. You can break it down further into a structured, item-by-item checklist.',
   'verifyConfig.empty.title': 'Delivery Acceptance',
   'verifyConfig.empty.subtitle':
     'Describe how you want to accept the result in one sentence, and AI will turn it into an editable checklist.',

--- a/src/features/AgentTasks/AgentTaskDetail/TaskVerifyConfig.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskVerifyConfig.tsx
@@ -4,6 +4,8 @@ import {
   ActionIcon,
   Block,
   Button,
+  type DropdownItem,
+  DropdownMenu,
   Flexbox,
   Icon,
   Select,
@@ -18,6 +20,7 @@ import { createStaticStyles, cssVar } from 'antd-style';
 import {
   ChevronRight,
   ChevronUp,
+  MoreHorizontal,
   Plus,
   RotateCcw,
   ShieldCheck,
@@ -42,6 +45,11 @@ import { labPreferSelectors } from '@/store/user/selectors';
 const SAVE_DEBOUNCE_MS = 600;
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
+  collapsedRequirement: css`
+    /* full requirement, wrapping to as many lines as it needs — readable at a glance */
+    max-width: 480px;
+    line-height: 1.5;
+  `,
   list: css`
     width: 100%;
   `,
@@ -352,11 +360,20 @@ const TaskVerifyConfig = memo(() => {
 
   // ---- Collapsed trigger (default): a "+" row; reveals the editor on click ----
   if (!expanded) {
+    // A task may have verify configured via the natural-language requirement only
+    // (config.verify.requirement) without ever materializing structured criteria.
+    // Treat that as "configured" too, so the panel never reads as "never set".
+    const requirementPreview = requirement.trim();
+    const isConfigured = savedCount > 0 || requirementPreview.length > 0;
+    // When the gate is a requirement sentence (no structured criteria), show the
+    // full requirement wrapping below the title — readable at a glance, not a weak
+    // one-line ellipsis. Criteria-count / hint variants stay as a compact pill.
+    const showRequirement = savedCount === 0 && requirementPreview.length > 0;
     return (
       <Block
         clickable
         horizontal
-        align={'center'}
+        align={showRequirement ? 'flex-start' : 'center'}
         gap={8}
         paddingBlock={4}
         paddingInline={8}
@@ -366,18 +383,32 @@ const TaskVerifyConfig = memo(() => {
       >
         <Icon
           color={cssVar.colorTextDescription}
-          icon={savedCount > 0 ? ShieldCheck : Plus}
+          icon={isConfigured ? ShieldCheck : Plus}
           size={16}
+          style={showRequirement ? { marginTop: 2 } : undefined}
         />
-        <Text color={cssVar.colorTextSecondary} fontSize={13} weight={500}>
-          {t('verifyConfig.empty.title')}
-        </Text>
-        {savedCount > 0 ? (
-          <Tag>{t('verifyConfig.criteriaCount', { count: savedCount })}</Tag>
+        {showRequirement ? (
+          <Flexbox gap={2}>
+            <Text color={cssVar.colorTextSecondary} fontSize={13} weight={500}>
+              {t('verifyConfig.empty.title')}
+            </Text>
+            <Text className={styles.collapsedRequirement} fontSize={14}>
+              {requirementPreview}
+            </Text>
+          </Flexbox>
         ) : (
-          <Text className={styles.subtitle} fontSize={12}>
-            {t('verifyConfig.collapsedHint')}
-          </Text>
+          <>
+            <Text color={cssVar.colorTextSecondary} fontSize={13} weight={500}>
+              {t('verifyConfig.empty.title')}
+            </Text>
+            {savedCount > 0 ? (
+              <Tag>{t('verifyConfig.criteriaCount', { count: savedCount })}</Tag>
+            ) : (
+              <Text className={styles.subtitle} fontSize={12}>
+                {t('verifyConfig.collapsedHint')}
+              </Text>
+            )}
+          </>
         )}
       </Block>
     );
@@ -397,6 +428,23 @@ const TaskVerifyConfig = memo(() => {
 
   // ---- A. empty ----
   if (!hasConfig) {
+    // Secondary "add criteria" paths (manual / from template) collapse into a
+    // single overflow menu so the empty state keeps one clear focus: the
+    // requirement textarea. Both live in the header, not as body buttons.
+    const addMenuItems: DropdownItem[] = [
+      {
+        icon: <Icon icon={Plus} />,
+        key: 'manual-add',
+        label: t('verifyConfig.manualAdd'),
+        onClick: handleManualAdd,
+      },
+      {
+        icon: <Icon icon={ChevronRight} />,
+        key: 'from-template',
+        label: t('verifyConfig.fromTemplate'),
+        onClick: () => setShowTemplatePicker((v) => !v),
+      },
+    ];
     return (
       <Block className={styles.section} variant={'outlined'}>
         <Flexbox gap={12}>
@@ -405,31 +453,46 @@ const TaskVerifyConfig = memo(() => {
               <Icon icon={ShieldCheck} size={18} />
               <Text weight={600}>{t('verifyConfig.empty.title')}</Text>
             </Flexbox>
-            <ActionIcon icon={ChevronUp} size={'small'} onClick={() => setExpanded(false)} />
+            {/* Actions live top-right, de-emphasized, so they never outweigh the
+                requirement input that is the empty state's primary focus. */}
+            <Flexbox horizontal align={'center'} gap={4}>
+              <Button
+                disabled={!requirement.trim()}
+                icon={Sparkles}
+                size={'small'}
+                onClick={handleGenerate}
+              >
+                {t('verifyConfig.generate')}
+              </Button>
+              <DropdownMenu items={addMenuItems} placement={'bottomRight'}>
+                <ActionIcon icon={MoreHorizontal} size={'small'} />
+              </DropdownMenu>
+              <ActionIcon icon={ChevronUp} size={'small'} onClick={() => setExpanded(false)} />
+            </Flexbox>
           </Flexbox>
-          <Text className={styles.subtitle}>{t('verifyConfig.empty.subtitle')}</Text>
+          <Text className={styles.subtitle}>
+            {requirement.trim()
+              ? t('verifyConfig.empty.materializeHint')
+              : t('verifyConfig.empty.subtitle')}
+          </Text>
           <TextArea
             autoSize={{ maxRows: 4, minRows: 2 }}
             placeholder={t('verifyConfig.requirementPlaceholder')}
             value={requirement}
             onChange={(e) => handleRequirementChange(e.target.value)}
+            onBlur={() => {
+              const trimmed = requirement.trim();
+              // A no-op blur (focus the field, click away) must NOT enable a gate:
+              // an empty requirement with no criteria would persist
+              // { enabled: true, requirement: null }, which the server reads as a
+              // holistic "verify everything" gate while the collapsed UI still
+              // looks unconfigured. Skip entirely when nothing is configured;
+              // otherwise tie `enabled` to whether a real requirement exists, so
+              // clearing the field disables the requirement-only gate.
+              if (!trimmed && !verify?.requirement && savedCount === 0) return;
+              commit(drafts, { enabled: trimmed.length > 0, requirement });
+            }}
           />
-          <Flexbox horizontal align={'center'} gap={8}>
-            <Button
-              disabled={!requirement.trim()}
-              icon={Sparkles}
-              type={'primary'}
-              onClick={handleGenerate}
-            >
-              {t('verifyConfig.generate')}
-            </Button>
-            <Button size={'small'} type={'text'} onClick={handleManualAdd}>
-              {t('verifyConfig.manualAdd')}
-            </Button>
-            <Button size={'small'} type={'text'} onClick={() => setShowTemplatePicker((v) => !v)}>
-              {t('verifyConfig.fromTemplate')}
-            </Button>
-          </Flexbox>
           {showTemplatePicker ? (
             <Select
               options={rubricOptions}


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

A task's delivery-acceptance gate can be configured via the natural-language `requirement` alone, without ever materializing structured criteria. Previously such a task still read as "never configured" (a `+` add row), and a typed requirement was lost unless the user generated criteria. This PR treats a requirement-only config as configured:

- **Collapsed trigger**: when `requirement` is set but there are no saved criteria, show the `ShieldCheck` icon + a truncated requirement preview (`max-width: 360px`, ellipsis) instead of the `+` icon and `collapsedHint`. Tasks with materialized criteria still show the criteria-count tag (unchanged), and tasks with neither still show `+` / `collapsedHint`.
- **Expanded empty state**: when a `requirement` exists, the subtitle becomes `verifyConfig.empty.materializeHint` ("…break it down further into a structured, item-by-item checklist") instead of the generic `subtitle`.
- **Persistence**: commit the requirement on the empty-state `TextArea` `onBlur`, so a typed natural-language requirement survives even when the user never clicks "generate".

Adds the `verifyConfig.empty.materializeHint` locale key (en-US source + zh-CN).

#### 🧪 How to Test

Agentic end-to-end verification (independent local Web env, agent-browser). 5/5 checks passed:

1. Collapsed, requirement-only task → `ShieldCheck` + requirement preview (not `+`/hint).
2. Expanded empty with requirement → `materializeHint` subtitle.
3. Empty `TextArea` `onBlur` persists requirement → survives reload; preview truncates at 360px with ellipsis.
4. Control: no requirement → `+` icon + `collapsedHint`; empty state shows default subtitle.
5. Regression: requirement + criteria → criteria-count tag still wins.

Full evidence-backed report: https://app.lobehub.com/verify/e06b6b0e-17f7-4756-9917-a0dd6c0aec30

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| State | Screenshot |
| ----- | ---------- |
| Collapsed — requirement preview (ShieldCheck) | see verify report case 1 |
| Expanded empty — materializeHint | see verify report case 2 |
| Persisted after reload — ellipsis @360px | see verify report case 3 |
| Control — `+` / collapsedHint | see verify report case 4 |

#### 📝 Additional Information

UI-only feature change behind the existing Labs `enableTaskVerify` toggle. No schema or API changes.