### PR TITLE
🐛 fix(auth-spa): clean stale SPA assets before auth build

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "build:next:raw": "next build",
     "build:raw": "bun run build:spa:raw && bun run build:spa:auth && bun run build:spa:copy && bun run build:next:raw",
     "build:spa": "cross-env NODE_OPTIONS=--max-old-space-size=8192 pnpm run build:spa:raw",
-    "build:spa:auth": "rm -rf public/_spa-auth && cross-env NODE_OPTIONS=--max-old-space-size=8192 AUTH=true vite build",
+    "build:spa:auth": "rm -rf public/_spa public/_spa-auth && cross-env NODE_OPTIONS=--max-old-space-size=8192 AUTH=true vite build",
     "build:spa:copy": "tsx scripts/copySpaBuild.mts && tsx scripts/generateSpaTemplates.mts",
     "build:spa:mobile": "cross-env NODE_OPTIONS=--max-old-space-size=8192 MOBILE=true vite build",
     "build:spa:raw": "rm -rf public/_spa && vite build",

--- a/scripts/copySpaBuild.mts
+++ b/scripts/copySpaBuild.mts
@@ -1,8 +1,9 @@
-import { cpSync, existsSync, mkdirSync } from 'node:fs';
+import { cpSync, existsSync, mkdirSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 const root = path.resolve(import.meta.dirname, '..');
 const copyDirs = ['assets', 'i18n', 'vendor'] as const;
+const copyRootFilePatterns = [/^favicon.*\.ico$/, /^apple-touch-icon\.png$/] as const;
 const targets = [
   { distDir: 'desktop', publicDir: 'public/_spa' },
   { distDir: 'mobile', publicDir: 'public/_spa' },
@@ -10,16 +11,29 @@ const targets = [
 ] as const;
 
 for (const { distDir, publicDir } of targets) {
+  const distRoot = path.resolve(root, `dist/${distDir}`);
   const spaDir = path.resolve(root, publicDir);
   mkdirSync(spaDir, { recursive: true });
 
   for (const dir of copyDirs) {
-    const sourceDir = path.resolve(root, `dist/${distDir}/${dir}`);
+    const sourceDir = path.resolve(distRoot, dir);
     const targetDir = path.resolve(spaDir, dir);
 
     if (!existsSync(sourceDir)) continue;
 
     cpSync(sourceDir, targetDir, { recursive: true });
     console.log(`Copied dist/${distDir}/${dir} -> ${publicDir}/${dir}`);
+  }
+
+  if (!existsSync(distRoot)) continue;
+
+  for (const file of readdirSync(distRoot)) {
+    const sourceFile = path.resolve(distRoot, file);
+
+    if (!statSync(sourceFile).isFile()) continue;
+    if (!copyRootFilePatterns.some((pattern) => pattern.test(file))) continue;
+
+    cpSync(sourceFile, path.resolve(spaDir, file));
+    console.log(`Copied dist/${distDir}/${file} -> ${publicDir}/${file}`);
   }
 }


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

This PR prevents stale generated SPA assets from being copied into the auth SPA build output.

Previously, running the auth SPA build while `public/_spa` existed allowed Vite's public directory copy step to place the main SPA payload under `dist/auth/_spa`. That made auth bundle analysis include unrelated main-SPA chunks such as `vendor-ai-runtime`, even though those chunks are not part of the real auth first-screen bundle.

The auth build script now removes both generated public SPA directories before invoking `AUTH=true vite build`. The later `build:spa:copy` step remains responsible for copying both completed build outputs into `public/_spa` and `public/_spa-auth`.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Validated locally with:

- `bun run lint` after clearing stale ignored `.next` output from an earlier local build
- `bunx vitest --coverage --silent='passed-only' --reporter=default --reporter=blob --shard=1/2 --exclude '**/apps/server/**'`
- `bunx vitest --coverage --silent='passed-only' --reporter=default --reporter=blob --shard=2/2 --exclude '**/apps/server/**'`
- `bunx vitest --merge-reports --reporter=default --coverage`
- `bunx vitest --coverage --silent='passed-only' --reporter=default --coverage.reportsDirectory=./apps/server/coverage --dir apps/server`
- Package coverage loop from `.github/workflows/test.yml`
- `pnpm --filter @lobechat/database test:coverage` with a local `paradedb/paradedb:latest` service
- `cd apps/desktop && pnpm install && pnpm type-check && pnpm test`
- `SKIP_LINT=1 bun run build`
- `find dist/auth public/_spa-auth -type f | rg 'vendor-ai|ai-runtime|/_spa($|/)'` returned no matches

I also started the E2E workflow locally through browser install, database migration, and partial Cucumber execution. It was intentionally stopped before completion when this PR was requested, so it is not listed as a passing validation item.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

`SKIP_LINT=1 bun run build` completed successfully. The Next.js build emitted existing QStash token warnings in the local environment, but exited with code 0.
