### PR TITLE
🐛 fix(group): pass groupId when re-querying messages in RuntimeExecutors

### DIFF
--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -2294,6 +2294,9 @@ export const createRuntimeExecutors = (
       const dbMessages = await ctx.messageModel.query(
         {
           agentId: state.metadata?.agentId,
+          // Group runs need groupId or the query filters `groupId IS NULL` and
+          // returns no group messages (here the compression candidate set).
+          groupId: state.metadata?.groupId,
           threadId: state.metadata?.threadId,
           topicId,
         },
@@ -3635,6 +3638,11 @@ export const createRuntimeExecutors = (
     const latestMessages = await ctx.messageModel.query(
       {
         agentId: state.metadata?.agentId,
+        // Group runs must pass groupId, else the query falls into the standard
+        // branch (`groupId IS NULL`) and returns zero group messages — the next
+        // call_llm step then gets an empty context and the provider rejects it
+        // ("at least one message is required").
+        groupId: state.metadata?.groupId,
         threadId: state.metadata?.threadId,
         topicId: state.metadata?.topicId,
       },
@@ -4089,6 +4097,9 @@ export const createRuntimeExecutors = (
       try {
         const dbMessages = await ctx.messageModel.query({
           agentId: state.metadata?.agentId,
+          // Group runs need groupId or the query returns no group messages, so
+          // the existing tool-message lookup on resume would find nothing.
+          groupId: state.metadata?.groupId,
           threadId: state.metadata?.threadId,
           topicId: state.metadata?.topicId,
         });
@@ -4121,6 +4132,9 @@ export const createRuntimeExecutors = (
         try {
           const dbMessages = await ctx.messageModel.query({
             agentId: state.metadata?.agentId,
+            // Group runs need groupId or the query returns no group messages, so
+            // the parent-assistant fallback lookup would find nothing.
+            groupId: state.metadata?.groupId,
             threadId: state.metadata?.threadId,
             topicId: state.metadata?.topicId,
           });


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

Group conversations intermittently fail a post-tool LLM step with `400 messages: at least one message is required` (observed on supervisor runs, e.g. `deepseek-v4-pro`).

**Root cause.** After a tool batch completes, the `call_tools_batch` executor refreshes `newState.messages` from the DB:

```ts
const latestMessages = await ctx.messageModel.query({
  agentId: state.metadata?.agentId,
  threadId: state.metadata?.threadId,
  topicId: state.metadata?.topicId,
}); // ← no groupId
```

For a group topic every message carries a non-null `group_id`, so this query falls into the standard `group_id IS NULL` branch and returns **zero** rows. `newState.messages` becomes empty, the next `call_llm` step builds a payload containing only the system message, and the provider rejects the empty conversation.

`AgentRuntimeService` already threads `groupId` through its message queries (`queryUiMessages`, `refreshMessagesFromDB`, `computeDeviceContext`) for exactly this reason — `RuntimeExecutors` had the same omission. This PR passes `state.metadata?.groupId` in the four affected sites:

- the post-tool `call_tools_batch` refresh that feeds the next LLM call (the actual failure),
- the compression candidate-message query,
- the two resume-mode lookups (existing tool messages by `tool_call_id`, and the parent-assistant fallback).

`groupId` is `undefined` for non-group runs, so this is a no-op outside group conversations.

#### 🧪 How to Test

- [x] Reproduced from a real trace: a group supervisor op where step 0 (`user_input`) built `[system, user, user]` and produced tool calls, but step 2 (`tools_batch_result`) collapsed to `[system]` only → `400 ... at least one message is required`. All six topic messages existed in DB with the correct `group_id`.
- [ ] Added/updated tests

A group conversation that calls at least one tool and then continues should no longer error on the follow-up LLM step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)