### PR TITLE
🐛 fix(brief): surface resolve failures so 「确认完成」 is never a silent no-op

### DIFF
--- a/locales/en-US/home.json
+++ b/locales/en-US/home.json
@@ -34,6 +34,7 @@
   "brief.editResult": "Edit",
   "brief.expandAll": "Show more",
   "brief.feedbackSent": "Feedback shared",
+  "brief.resolveFailed": "Could not complete this action. It may have already been handled — please refresh and try again.",
   "brief.resolved": "Marked as resolved",
   "brief.title": "Brief",
   "brief.viewAllTasks": "View all tasks",

--- a/locales/zh-CN/home.json
+++ b/locales/zh-CN/home.json
@@ -34,6 +34,7 @@
   "brief.editResult": "编辑",
   "brief.expandAll": "展开全部",
   "brief.feedbackSent": "反馈已提交",
+  "brief.resolveFailed": "操作未能完成，可能已被处理，请刷新后重试。",
   "brief.resolved": "已标记为已解决",
   "brief.title": "简报",
   "brief.viewAllTasks": "查看全部任务",

--- a/packages/locales/src/default/home.ts
+++ b/packages/locales/src/default/home.ts
@@ -36,6 +36,8 @@ export default {
   'brief.editResult': 'Edit',
   'brief.expandAll': 'Show more',
   'brief.feedbackSent': 'Feedback shared',
+  'brief.resolveFailed':
+    'Could not complete this action. It may have already been handled — please refresh and try again.',
   'brief.resolved': 'Marked as resolved',
   'brief.title': 'Brief',
   'brief.viewAllTasks': 'View all tasks',

--- a/src/features/DailyBrief/BriefCardActions.tsx
+++ b/src/features/DailyBrief/BriefCardActions.tsx
@@ -6,6 +6,7 @@ import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { shallow } from 'zustand/shallow';
 
+import { message } from '@/components/AntdStaticMethods';
 import { useBriefStore } from '@/store/brief';
 import { useTaskStore } from '@/store/task';
 
@@ -114,32 +115,50 @@ const BriefCardActions = memo<BriefCardActionsProps>(
         try {
           await resolveBrief(briefId, key);
           await onAfterResolve?.();
+        } catch (error) {
+          // Without this, a failed resolve (e.g. a stale card whose brief was
+          // already resolved/removed → NOT_FOUND, or a permission denial) is
+          // swallowed and the click silently does nothing. Surface it, then
+          // reconcile with the server so a stale card drops instead of leaving
+          // a dead button.
+          console.error('[BriefCardActions] resolve failed:', error);
+          message.error(t('brief.resolveFailed'));
+          await onAfterResolve?.();
         } finally {
           setLoadingKey(null);
         }
       },
-      [briefId, resolveBrief, onAfterResolve],
+      [briefId, resolveBrief, onAfterResolve, t],
     );
 
     const handleCommentSubmit = useCallback(
       async (text: string) => {
         if (!commentMode) return;
 
-        if (commentMode.type === 'comment') {
-          setLoadingKey(commentMode.key);
-          try {
-            await resolveBrief(briefId, commentMode.key, text);
+        try {
+          if (commentMode.type === 'comment') {
+            setLoadingKey(commentMode.key);
+            try {
+              await resolveBrief(briefId, commentMode.key, text);
+              await onAfterResolve?.();
+            } finally {
+              setLoadingKey(null);
+            }
+          } else if (taskId) {
+            // Free-form feedback must resolve the brief (so the heartbeat
+            // re-arm gate stops blocking on this urgent brief) AND re-run
+            // the task so the agent picks up `resolvedComment` next turn.
+            await submitFeedback(briefId, taskId, text);
+            await onAfterAddComment?.();
             await onAfterResolve?.();
-          } finally {
-            setLoadingKey(null);
           }
-        } else if (taskId) {
-          // Free-form feedback must resolve the brief (so the heartbeat
-          // re-arm gate stops blocking on this urgent brief) AND re-run
-          // the task so the agent picks up `resolvedComment` next turn.
-          await submitFeedback(briefId, taskId, text);
-          await onAfterAddComment?.();
-          await onAfterResolve?.();
+        } catch (error) {
+          // Surface the failure instead of silently swallowing it; keep the
+          // comment editor open (don't clear commentMode) so the typed text
+          // isn't lost and the user can retry.
+          console.error('[BriefCardActions] submit feedback failed:', error);
+          message.error(t('brief.resolveFailed'));
+          return;
         }
 
         setCommentMode(null);
@@ -150,6 +169,7 @@ const BriefCardActions = memo<BriefCardActionsProps>(
         resolveBrief,
         submitFeedback,
         taskId,
+        t,
         onAfterResolve,
         onAfterAddComment,
       ],

--- a/src/store/brief/slices/list/action.ts
+++ b/src/store/brief/slices/list/action.ts
@@ -1,3 +1,4 @@
+import { TRPCClientError } from '@trpc/client';
 import isEqual from 'fast-deep-equal';
 import { type SWRResponse } from 'swr';
 
@@ -11,6 +12,11 @@ import { type StoreSetter } from '@/store/types';
 import { setNamespace } from '@/utils/storeDebug';
 
 const n = setNamespace('briefList');
+
+/** True when a mutation targeted a brief that no longer exists server-side. */
+const isBriefGoneError = (error: unknown): boolean =>
+  error instanceof TRPCClientError &&
+  (error.data as { code?: string } | null | undefined)?.code === 'NOT_FOUND';
 
 type Setter = StoreSetter<BriefStore>;
 
@@ -37,6 +43,14 @@ export class BriefListActionImpl {
     this.#set({ briefs: updated }, false, n('internal_updateBrief'));
   };
 
+  /** Drop a brief from the home feed locally (no server call) — used to
+   * reconcile a stale card whose brief is already gone server-side. */
+  internal_dismissBrief = (id: string) => {
+    const briefs = this.#get().briefs;
+    if (!briefs.some((b) => b.id === id)) return;
+    this.#set({ briefs: briefs.filter((b) => b.id !== id) }, false, n('internal_dismissBrief'));
+  };
+
   deleteBrief = async (id: string) => {
     await briefService.delete(id);
     const briefs = this.#get().briefs.filter((b) => b.id !== id);
@@ -49,7 +63,16 @@ export class BriefListActionImpl {
   };
 
   resolveBrief = async (id: string, action?: string, comment?: string) => {
-    await briefService.resolve(id, { action, comment });
+    try {
+      await briefService.resolve(id, { action, comment });
+    } catch (error) {
+      // A stale card whose brief was already resolved/removed elsewhere yields
+      // NOT_FOUND. Drop it from the home feed so the card self-heals even on
+      // surfaces (the DailyBrief home list) that don't pass an onAfterResolve
+      // refetch. Re-throw so the caller still surfaces the failure toast.
+      if (isBriefGoneError(error)) this.internal_dismissBrief(id);
+      throw error;
+    }
     this.internal_updateBrief(id, {
       resolvedAction: action,
       resolvedAt: new Date().toISOString(),


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

The brief **result** card's「确认完成」button (and the inline resolve / feedback actions in `BriefCardActions`) could appear to "do nothing" when clicked.

Root cause: `handleResolve` / `handleCommentSubmit` call `resolveBrief` inside `try/finally` with **no `catch`**, and the `resolveBrief` store action doesn't catch either. So when the `brief.resolve` mutation throws, the error is swallowed — no toast, the button stays, nothing visibly happens. The mutation most commonly throws for:

- a **stale card** whose brief was already resolved/removed elsewhere → server returns `NOT_FOUND` ("Brief not found"), or
- a workspace **permission denial** (`brief.resolve` runs through `withScopedPermission('task:update')`).

Fix:
- Catch resolve/feedback failures and show an error toast (`brief.resolveFailed`, en-US + zh-CN) — never a silent no-op.
- On failure, re-run `onAfterResolve` to reconcile with the server, so a stale card (`NOT_FOUND`) **self-heals** (drops) instead of leaving a dead button.
- Keep the comment editor open on feedback failure so the typed text survives a retry.

The happy path is unchanged (catch only runs on throw).

#### 🧪 How to Test

Verified in an independent local env (agent-browser + DB), task-activity result card:

1. **Success**: click「确认完成」on a valid brief → `brief.resolve` 200, DB `resolved_action='approve'`, card flips to "已标记为已解决", no toast.
2. **Failure (before fix → silent)**: delete the brief server-side, then click → resolve returns `404 NOT_FOUND`; previously the card kept showing「确认完成」with no feedback.
3. **Failure (after fix)**: same scenario now shows the error toast and the stale card disappears (self-heals on refetch).

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

UI-only / client-side robustness fix; no schema or API changes. `BriefCardActions` is shared by the DailyBrief home feed and the task-detail activity feed, so both surfaces benefit.