### PR TITLE
🐛 fix(task): topic activity keeps the agent that ran it, not the task's current assignee

### DIFF
--- a/apps/server/src/services/task/index.ts
+++ b/apps/server/src/services/task/index.ts
@@ -564,8 +564,13 @@ export class TaskService {
     const agentIds = new Set<string>();
     const userIds = new Set<string>();
 
-    // Topics are created by the task's assignee agent
-    if (task.assigneeAgentId && topics.length > 0) agentIds.add(task.assigneeAgentId);
+    // Each topic keeps the agent that actually ran it (topics.agentId), so an
+    // earlier run's avatar stays correct after the task is reassigned. Fall back
+    // to the current assignee only when a topic has no recorded agent.
+    for (const t of topics) {
+      const topicAgentId = t.agentId ?? task.assigneeAgentId;
+      if (topicAgentId) agentIds.add(topicAgentId);
+    }
     // Briefs may have an agentId
     for (const b of briefs) {
       if (b.agentId) agentIds.add(b.agentId);
@@ -600,8 +605,9 @@ export class TaskService {
       ...(createdActivity ? [createdActivity] : []),
       ...topics.map((t) => {
         const handoff = t.handoff as TaskTopicHandoff | null;
+        const topicAgentId = t.agentId ?? task.assigneeAgentId;
         return {
-          author: task.assigneeAgentId ? authorMap.get(task.assigneeAgentId) : undefined,
+          author: topicAgentId ? authorMap.get(topicAgentId) : undefined,
           completedAt: toISO(t.completedAt),
           id: t.topicId ?? undefined,
           operationId: t.operationId ?? null,

--- a/packages/database/src/models/taskTopic.ts
+++ b/packages/database/src/models/taskTopic.ts
@@ -222,6 +222,10 @@ export class TaskTopicModel {
   async findWithHandoff(taskId: string, limit: number) {
     return this.db
       .select({
+        // The agent that actually ran this topic — used so each activity row
+        // keeps its own avatar instead of inheriting the task's *current*
+        // assignee (which changes when the task is reassigned).
+        agentId: topics.agentId,
         completedAt: topics.completedAt,
         createdAt: taskTopics.createdAt,
         handoff: taskTopics.handoff,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

In the task detail **activity** feed, every completed topic row rendered its author from the task's **current** `assigneeAgentId`. So reassigning the task to a different agent retroactively changed the avatars of topics an earlier agent had already run — confusing, since those runs were not done by the new agent.

`topics.agentId` already records the agent that actually ran each topic, so this is a **read-time** fix — no schema change / migration:

- `TaskTopicModel.findWithHandoff` now also selects `topics.agentId`.
- `getTaskDetail` resolves each topic activity's `author` from the topic's own `agentId`, falling back to the task assignee only when a topic has no recorded agent (older rows). The author-id resolution set is updated accordingly.

Briefs already used their own `agentId`; only topic rows had this bug.

#### 🧪 How to Test

Verified in an independent local env via the `task.detail` API:

1. Task T-7's single topic was run by agent **Verify E2E Agent** (`topics.agentId = agt_verify_e2e`); task assignee = same.
2. Reassigned the task's `assignee_agent_id` to **E2E Bridge Agent** (`agt_e2e_bridge`).
3. `task.detail` → the topic activity's `author.id` stayed `agt_verify_e2e` ("Verify E2E Agent"), while the task header showed the new assignee. Before the fix it would have followed the assignee.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

Server-side read path only (`apps/server` task service + `packages/database` task-topic model); no API shape or schema change.