### PR TITLE
💄 fix(task): task-callback opens the side portal instead of navigating away

### DIFF
--- a/src/features/Conversation/Messages/TaskCallback/index.tsx
+++ b/src/features/Conversation/Messages/TaskCallback/index.tsx
@@ -7,7 +7,7 @@ import { CircleAlert, CircleCheck, CircleSlash, SquareArrowOutUpRight } from 'lu
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { useNavigateToTaskDetail } from '@/features/AgentTasks/shared/taskDetailPath';
+import { useChatStore } from '@/store/chat';
 
 import { dataSelectors, useConversationStore } from '../../store';
 
@@ -58,7 +58,9 @@ const reasonMeta: Record<
 const TaskCallbackMessage = memo<TaskCallbackMessageProps>(({ id }) => {
   const { styles, theme } = useStyles();
   const { t } = useTranslation('chat');
-  const navigateToTask = useNavigateToTaskDetail();
+  // Open the task in the right-side detail portal (in-context), instead of
+  // navigating away from the conversation to the full task page.
+  const openTaskDetail = useChatStore((s) => s.openTaskDetail);
   const item = useConversationStore(dataSelectors.getDisplayMessageById(id), isEqual);
 
   const callback = item?.metadata?.taskCallback;
@@ -81,7 +83,7 @@ const TaskCallbackMessage = memo<TaskCallbackMessageProps>(({ id }) => {
             icon={SquareArrowOutUpRight}
             size={'small'}
             type={'text'}
-            onClick={() => navigateToTask(callback.taskId)}
+            onClick={() => openTaskDetail(callback.identifier)}
           >
             {t('taskCallback.viewTask')}
           </Button>


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style / fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

The「查看任务」(View task) button on the **task-callback** result card — the card that reports a finished task's handoff back into its creator conversation — navigated to the full task page, pulling the user out of the conversation.

It now opens the task in the **right-side TaskDetail portal**, the same in-context behavior the `createTask` / `runTask` result cards already use:

- replace `useNavigateToTaskDetail()` → `useChatStore(s => s.openTaskDetail)` and call `openTaskDetail(callback.identifier)` (the identifier the portal/result-cards key on),
- swap the external-link icon (`SquareArrowOutUpRight`) for a side-panel icon (`PanelRight`) to match the new behavior.

#### 🧪 How to Test

Verified in an independent local env on a creator conversation that has a `taskCallback` card:

1. Open the conversation → the "任务已完成 T-4" card shows「查看任务」.
2. Click it → the URL stays on `/agent/.../<topic>` (no navigation), and the right-side portal opens showing the T-4 task detail.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

Conversation stays on the left; task opens in the right-side portal (see PR — verified locally).

#### 📝 Additional Information

UI-only; no API/schema change.