### PR TITLE
🐛 fix(desktop): stop update prompt from resurfacing after install-later, polish card

### DIFF
--- a/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/UpdaterManager.ts
@@ -8,6 +8,7 @@ import type {
 import { app as electronApp } from 'electron';
 import log from 'electron-log';
 import { autoUpdater } from 'electron-updater';
+import semver from 'semver';
 
 import { isDev, isWindows } from '@/const/env';
 import { getDesktopEnv } from '@/env';
@@ -33,6 +34,14 @@ export class UpdaterManager {
   private activeGeneration: number = 0;
   /** Whether a recheck is needed after the current check completes */
   private pendingRecheck: boolean = false;
+  /**
+   * Version the user acknowledged with "install later" in the current process.
+   * While set, equal-version update-available/downloaded events are processed
+   * for menu state but never re-broadcast to the renderer, so the prompt does
+   * not reappear within the session. Cleared when a strictly newer version
+   * arrives (or on channel switch).
+   */
+  private installLaterVersion: string | null = null;
 
   private stage: UpdaterStage = 'idle';
   private latestUpdateInfo: UpdateInfo | null = null;
@@ -148,6 +157,8 @@ export class UpdaterManager {
 
     autoUpdater.allowPrerelease = channel !== 'stable';
     this.configureUpdateProvider();
+
+    this.installLaterVersion = null;
 
     this.mainWindow.broadcast('updateChannelChanged', channel);
 
@@ -292,6 +303,10 @@ export class UpdaterManager {
     logger.info('Update will be installed on next restart');
 
     autoUpdater.autoInstallOnAppQuit = true;
+    if (this.latestUpdateInfo?.version) {
+      this.installLaterVersion = this.latestUpdateInfo.version;
+      logger.info(`Suppressing further prompts for version ${this.installLaterVersion}`);
+    }
     this.mainWindow.broadcast('updateWillInstallLater');
   };
 
@@ -442,7 +457,16 @@ export class UpdaterManager {
 
       if (this.isStaleCheck()) return;
 
+      this.maybeClearInstallLaterGuard(info.version);
+
       this.updateAvailable = true;
+
+      if (this.installLaterVersion) {
+        logger.info(
+          `Skipping auto-download — install-later acknowledged for v${this.installLaterVersion}, incoming v${info.version}`,
+        );
+        return;
+      }
 
       // Always auto-download
       logger.info('Update found, starting download automatically...');
@@ -497,11 +521,40 @@ export class UpdaterManager {
     autoUpdater.on('update-downloaded', (info) => {
       logger.info(`Update downloaded: ${info.version}`);
       this.downloading = false;
+
+      this.maybeClearInstallLaterGuard(info.version);
+
       this.setStage('downloaded', { updateInfo: info });
+
+      if (this.installLaterVersion) {
+        logger.info(
+          `Not re-broadcasting updateDownloaded — install-later acknowledged for v${this.installLaterVersion}, incoming v${info.version}`,
+        );
+        return;
+      }
+
       this.mainWindow.broadcast('updateDownloaded', info);
     });
 
     logger.debug('Updater events registered');
+  }
+
+  /**
+   * Clear the install-later guard when a strictly newer version arrives.
+   * Equal or older versions keep the guard so the prompt stays suppressed.
+   */
+  private maybeClearInstallLaterGuard(incomingVersion: string | undefined) {
+    if (!this.installLaterVersion || !incomingVersion) return;
+    try {
+      if (semver.gt(incomingVersion, this.installLaterVersion)) {
+        logger.info(
+          `Clearing install-later guard (was v${this.installLaterVersion}, incoming v${incomingVersion})`,
+        );
+        this.installLaterVersion = null;
+      }
+    } catch (error) {
+      logger.warn('Failed to compare versions for install-later guard:', error);
+    }
   }
 
   /** Check if the current active check has been superseded by a channel switch */

--- a/apps/desktop/src/main/core/infrastructure/__tests__/UpdaterManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/UpdaterManager.test.ts
@@ -420,6 +420,92 @@ describe('UpdaterManager', () => {
     });
   });
 
+  describe('install-later session guard', () => {
+    beforeEach(async () => {
+      await updaterManager.initialize();
+      vi.mocked(autoUpdater.downloadUpdate).mockResolvedValue([] as any);
+    });
+
+    const fireDownloaded = (version: string) => {
+      registeredEvents.get('update-downloaded')?.({ version });
+    };
+    const fireAvailable = (version: string) => {
+      registeredEvents.get('update-available')?.({ version });
+    };
+
+    it('suppresses re-broadcast of updateDownloaded for the install-later version', () => {
+      fireDownloaded('2.2.6');
+      expect(mockBroadcast).toHaveBeenCalledWith(
+        'updateDownloaded',
+        expect.objectContaining({ version: '2.2.6' }),
+      );
+
+      updaterManager.installLater();
+
+      mockBroadcast.mockClear();
+      fireDownloaded('2.2.6');
+
+      expect(mockBroadcast).not.toHaveBeenCalledWith('updateDownloaded', expect.anything());
+      expect(mockBroadcast).toHaveBeenCalledWith(
+        'updaterStateChanged',
+        expect.objectContaining({ stage: 'downloaded' }),
+      );
+    });
+
+    it('skips auto-download on update-available for the install-later version', () => {
+      fireDownloaded('2.2.6');
+      updaterManager.installLater();
+
+      vi.mocked(autoUpdater.downloadUpdate).mockClear();
+
+      fireAvailable('2.2.6');
+
+      expect(autoUpdater.downloadUpdate).not.toHaveBeenCalled();
+    });
+
+    it('clears the guard and re-broadcasts when a newer version arrives', () => {
+      fireDownloaded('2.2.6');
+      updaterManager.installLater();
+      mockBroadcast.mockClear();
+
+      fireAvailable('2.2.7');
+      fireDownloaded('2.2.7');
+
+      expect(mockBroadcast).toHaveBeenCalledWith(
+        'updateDownloaded',
+        expect.objectContaining({ version: '2.2.7' }),
+      );
+    });
+
+    it('keeps the guard when an older version arrives', () => {
+      fireDownloaded('2.2.6');
+      updaterManager.installLater();
+      mockBroadcast.mockClear();
+
+      fireDownloaded('2.2.5');
+
+      expect(mockBroadcast).not.toHaveBeenCalledWith(
+        'updateDownloaded',
+        expect.objectContaining({ version: '2.2.5' }),
+      );
+    });
+
+    it('clears the guard on channel switch', () => {
+      fireDownloaded('2.2.6');
+      updaterManager.installLater();
+
+      updaterManager.switchChannel('canary');
+
+      mockBroadcast.mockClear();
+      fireDownloaded('2.2.6');
+
+      expect(mockBroadcast).toHaveBeenCalledWith(
+        'updateDownloaded',
+        expect.objectContaining({ version: '2.2.6' }),
+      );
+    });
+  });
+
   describe('event handlers', () => {
     beforeEach(async () => {
       await updaterManager.initialize();

--- a/src/features/Electron/updater/UpdateNotification.tsx
+++ b/src/features/Electron/updater/UpdateNotification.tsx
@@ -1,191 +1,268 @@
-import { type UpdateInfo } from '@lobechat/electron-client-ipc';
-import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
-import { Button, Flexbox, Icon, Markdown } from '@lobehub/ui';
-import { Button as BaseButton, createModal, useModalContext } from '@lobehub/ui/base-ui';
-import { createStaticStyles, cssVar } from 'antd-style';
-import { t } from 'i18next';
-import { CircleFadingArrowUp } from 'lucide-react';
-import React, { memo, useState } from 'react';
+'use client';
+
+import { type UpdateInfo, useWatchBroadcast } from '@lobechat/electron-client-ipc';
+import { Icon } from '@lobehub/ui';
+import { Button as BaseButton } from '@lobehub/ui/base-ui';
+import { createStaticStyles } from 'antd-style';
+import { CheckCircle2, CircleFadingArrowUp, X } from 'lucide-react';
+import { AnimatePresence, m } from 'motion/react';
+import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { usePlatform } from '@/hooks/usePlatform';
 import { autoUpdateService } from '@/services/electron/autoUpdate';
 
+const MAC_CARD_RADIUS = 10;
+const DEFAULT_CARD_RADIUS = 8;
+const ENTER_EXIT_EASE = [0.16, 1, 0.3, 1] as const;
+
+type ViewState = 'prompt' | 'confirming' | null;
+
 const styles = createStaticStyles(({ css, cssVar }) => ({
+  card: css`
+    pointer-events: auto;
+
+    overflow: hidden;
+
+    min-width: 360px;
+
+    color: ${cssVar.colorText};
+
+    background: color-mix(in srgb, ${cssVar.colorBgElevated} 85%, transparent);
+    backdrop-filter: blur(20px) saturate(1.5);
+    box-shadow: ${cssVar.boxShadowSecondary};
+  `,
+  closeButton: css`
+    cursor: pointer;
+
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+
+    width: 24px;
+    height: 24px;
+    border: 0;
+    border-radius: 6px;
+
+    color: ${cssVar.colorTextTertiary};
+
+    background: transparent;
+
+    transition:
+      background 120ms ease,
+      color 120ms ease;
+
+    &:hover {
+      color: ${cssVar.colorText};
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
   container: css`
+    pointer-events: none;
+
     position: fixed;
     z-index: 1000;
     inset-block-end: 16px;
     inset-inline-start: 16px;
   `,
+  confirmRow: css`
+    display: flex;
+    gap: 12px;
+    align-items: center;
 
-  releaseNote: css`
-    overflow: scroll;
+    padding-block: 10px;
+    padding-inline: 12px;
+  `,
+  confirmSub: css`
+    display: block;
+    margin-block-start: 2px;
+    font-size: 11px;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  confirmText: css`
+    flex: 1;
+    font-size: 13px;
+    line-height: 1.3;
+    color: ${cssVar.colorText};
+  `,
+  iconAccent: css`
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
 
-    max-height: 300px;
-    padding: 8px;
+    width: 28px;
+    height: 28px;
     border-radius: 8px;
 
-    background: ${cssVar.colorFillQuaternary};
+    color: ${cssVar.colorSuccess};
+
+    background: color-mix(in srgb, ${cssVar.colorSuccess} 16%, transparent);
+  `,
+  iconNeutral: css`
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+
+    width: 28px;
+    height: 28px;
+    border-radius: 8px;
+
+    color: ${cssVar.colorTextSecondary};
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  labelStack: css`
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+  `,
+  promptActions: css`
+    display: flex;
+    gap: 4px;
+    align-items: center;
+  `,
+  promptRow: css`
+    display: flex;
+    gap: 12px;
+    align-items: center;
+
+    padding-block: 10px;
+    padding-inline: 12px;
+  `,
+  title: css`
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1.2;
+    color: ${cssVar.colorText};
+  `,
+  version: css`
+    margin-block-start: 2px;
+
+    font-size: 11px;
+    font-variant-numeric: tabular-nums;
+    color: ${cssVar.colorTextTertiary};
+    letter-spacing: -0.01em;
   `,
 }));
 
-interface UpdateDetailContentProps {
-  updateInfo: UpdateInfo;
-}
-
-const UpdateDetailContent = memo<UpdateDetailContentProps>(({ updateInfo }) => {
+export const UpdateNotification = memo(() => {
   const { t: tElectron } = useTranslation('electron');
-  const { close } = useModalContext();
-  const [isInstalling, setIsInstalling] = useState(false);
+  const { isMacOS } = usePlatform();
 
-  return (
-    <Flexbox gap={12} style={{ maxWidth: 480 }}>
-      <div style={{ color: cssVar.colorTextSecondary, fontSize: 12 }}>{updateInfo.version}</div>
-      {updateInfo.releaseNotes &&
-        (typeof updateInfo.releaseNotes === 'string' ? (
-          <div className={styles.releaseNote}>
-            <Markdown>{updateInfo.releaseNotes}</Markdown>
-          </div>
-        ) : (
-          <div className={styles.releaseNote}>
-            {updateInfo.releaseNotes.map((note) => (
-              <Markdown key={note.version}>{note.note ?? ''}</Markdown>
-            ))}
-          </div>
-        ))}
-      <Flexbox horizontal gap={8} justify={'flex-end'}>
-        <BaseButton
-          size={'small'}
-          onClick={() => {
-            autoUpdateService.installLater();
-            close();
-          }}
-        >
-          {tElectron('updater.installLater')}
-        </BaseButton>
-        <BaseButton
-          loading={isInstalling}
-          size={'small'}
-          type={'primary'}
-          onClick={() => {
-            setIsInstalling(true);
-            autoUpdateService.installNow();
-          }}
-        >
-          {tElectron('updater.restartAndInstall')}
-        </BaseButton>
-      </Flexbox>
-    </Flexbox>
-  );
-});
-
-UpdateDetailContent.displayName = 'UpdateDetailContent';
-
-const openUpdateDetailModal = (updateInfo: UpdateInfo) =>
-  createModal({
-    content: <UpdateDetailContent updateInfo={updateInfo} />,
-    footer: null,
-    maskClosable: true,
-    title: t('updater.updateReady', { ns: 'electron' }),
-    width: 520,
-  });
-
-export const UpdateNotification: React.FC = () => {
-  const { t: tElectron } = useTranslation('electron');
-  const [updateAvailable, setUpdateAvailable] = useState(false);
-  const [updateDownloaded, setUpdateDownloaded] = useState(false);
+  const [view, setView] = useState<ViewState>(null);
   const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null);
-  const [installConfirmMode, setInstallConfirmMode] = useState<
-    'unconfirm' | 'installLater' | 'installNow' | null
-  >('unconfirm');
   const [isInstalling, setIsInstalling] = useState(false);
 
   useWatchBroadcast('updateDownloaded', (info: UpdateInfo) => {
     setUpdateInfo(info);
-    setUpdateDownloaded(true);
-    setUpdateAvailable(false);
-    setInstallConfirmMode('unconfirm');
+    setIsInstalling(false);
+    setView('prompt');
   });
 
   useWatchBroadcast('updateWillInstallLater', () => {
-    setInstallConfirmMode('installLater');
-
-    setTimeout(() => setInstallConfirmMode(null), 5000);
+    setView('confirming');
   });
 
-  if (!updateDownloaded && !updateAvailable) return null;
+  const cardRadius = isMacOS ? MAC_CARD_RADIUS : DEFAULT_CARD_RADIUS;
 
-  if (installConfirmMode === 'installLater') {
-    return (
-      <div
-        style={{
-          backgroundColor: cssVar.colorBgElevated,
-          borderRadius: cssVar.borderRadius,
-          bottom: 20,
-          boxShadow: cssVar.boxShadow,
-          color: cssVar.colorText,
-          left: 16,
-          padding: '10px 16px',
-          position: 'fixed',
-          zIndex: 1000,
-        }}
-      >
-        {tElectron('updater.willInstallLater')}
-      </div>
-    );
-  }
+  const handleInstallLater = () => {
+    autoUpdateService.installLater();
+  };
 
-  if (installConfirmMode === 'unconfirm')
-    return (
-      <div className={styles.container}>
-        <div
-          style={{
-            alignItems: 'center',
-            background: cssVar.colorBgElevated,
-            border: `1px solid ${cssVar.colorBorderSecondary}`,
-            borderRadius: 12,
-            boxShadow: cssVar.boxShadow,
-            color: cssVar.colorText,
-            display: 'flex',
-            gap: 8,
-            padding: '8px 10px',
-          }}
+  const handleInstallNow = () => {
+    setIsInstalling(true);
+    autoUpdateService.installNow();
+  };
+
+  const handleDismiss = () => {
+    setView(null);
+  };
+
+  return (
+    <AnimatePresence>
+      {view !== null && (
+        <m.div
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          aria-live="polite"
+          className={styles.container}
+          exit={{ opacity: 0, scale: 0.96, y: 8 }}
+          initial={{ opacity: 0, scale: 0.96, y: 8 }}
+          transition={{ duration: 0.2, ease: ENTER_EXIT_EASE }}
         >
-          <Icon icon={CircleFadingArrowUp} style={{ fontSize: 16 }} />
-          <div
-            style={{ cursor: 'pointer', fontSize: 12 }}
-            onClick={() => {
-              if (updateInfo) openUpdateDetailModal(updateInfo);
-            }}
-          >
-            {tElectron('updater.updateReady')}
-            {updateInfo?.version ? ` · ${updateInfo.version}` : ''}
-          </div>
-          <div style={{ flex: 1 }} />
-          <Button
-            size="small"
-            type="text"
-            onClick={() => {
-              autoUpdateService.installLater();
-            }}
-          >
-            {tElectron('updater.later')}
-          </Button>
+          <m.div layout className={styles.card} style={{ borderRadius: cardRadius }}>
+            <AnimatePresence initial={false} mode="wait">
+              {view === 'prompt' && (
+                <m.div
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  initial={{ opacity: 0 }}
+                  key="prompt"
+                  transition={{ duration: 0.16 }}
+                >
+                  <div className={styles.promptRow}>
+                    <div className={styles.iconNeutral}>
+                      <Icon icon={CircleFadingArrowUp} style={{ fontSize: 16 }} />
+                    </div>
+                    <div className={styles.labelStack}>
+                      <span className={styles.title}>{tElectron('updater.updateReady')}</span>
+                      {updateInfo?.version && (
+                        <span className={styles.version}>v{updateInfo.version}</span>
+                      )}
+                    </div>
+                    <div className={styles.promptActions}>
+                      <BaseButton size="small" onClick={handleInstallLater}>
+                        {tElectron('updater.later')}
+                      </BaseButton>
+                      <BaseButton
+                        loading={isInstalling}
+                        size="small"
+                        type="primary"
+                        onClick={handleInstallNow}
+                      >
+                        {tElectron('updater.upgradeNow')}
+                      </BaseButton>
+                    </div>
+                  </div>
+                </m.div>
+              )}
+              {view === 'confirming' && (
+                <m.div
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  initial={{ opacity: 0 }}
+                  key="confirming"
+                  transition={{ duration: 0.16 }}
+                >
+                  <div className={styles.confirmRow}>
+                    <div className={styles.iconAccent}>
+                      <Icon icon={CheckCircle2} style={{ fontSize: 16 }} />
+                    </div>
+                    <div className={styles.confirmText}>
+                      {tElectron('updater.willInstallLater')}
+                      {updateInfo?.version && (
+                        <span className={styles.confirmSub}>v{updateInfo.version}</span>
+                      )}
+                    </div>
+                    <button
+                      aria-label="Dismiss"
+                      className={styles.closeButton}
+                      type="button"
+                      onClick={handleDismiss}
+                    >
+                      <Icon icon={X} style={{ fontSize: 14 }} />
+                    </button>
+                  </div>
+                </m.div>
+              )}
+            </AnimatePresence>
+          </m.div>
+        </m.div>
+      )}
+    </AnimatePresence>
+  );
+});
 
-          <Button
-            loading={isInstalling}
-            size="small"
-            type="primary"
-            onClick={() => {
-              setIsInstalling(true);
-              autoUpdateService.installNow();
-            }}
-          >
-            {tElectron('updater.upgradeNow')}
-          </Button>
-        </div>
-      </div>
-    );
-
-  return null;
-};
+UpdateNotification.displayName = 'UpdateNotification';


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] 💄 style

#### 🔗 Related Issue

Fixes [LOBE-10608](https://linear.app/lobehub/issue/LOBE-10608/bug-update-notification-reappears-after-being-dismissed-the-update)

#### 🔀 Description of Change

The desktop update notification reappeared roughly an hour after the user clicked **Later**, contradicting the "will be installed on next launch" confirmation. Root cause is on the main process — `electron-updater` keeps the downloaded file across re-checks, so the next auto-check re-emits `update-available` → re-runs `downloadUpdate()` → re-emits `update-downloaded`, which the renderer translates into a new prompt.

**Main process fix** — `UpdaterManager` now records `installLaterVersion` when the user defers an update, and:

- skips re-broadcasting `updateDownloaded` when the same version fires again,
- skips the auto-download for the same `update-available`,
- clears the guard on `semver.gt(incoming, installLaterVersion)` so a strictly newer release still surfaces normally,
- clears the guard on channel switch (`switchChannel`).

Scope is the running process — the next genuine launch already handles the install via `autoInstallOnAppQuit = true`.

**Renderer polish (same card, refreshed)** — `UpdateNotification.tsx` is rewritten:

- Borderless frosted card (`color-mix(colorBgElevated 85%, transparent)` + `backdrop-filter: blur(20px) saturate(1.5)` + `boxShadowSecondary`), aligned with the existing `SaveBar` lineage.
- Corner radius matches the system window: `10` on macOS, `8` elsewhere (via `usePlatform()`).
- Motion via `motion/react`: card enter `y 8 → 0`, `opacity 0 → 1`, `scale 0.96 → 1` over 200 ms ease=[0.16, 1, 0.3, 1]; prompt ↔ confirming swap via `AnimatePresence mode="wait"` with layout-driven height tween.
- Confirming state moves in-place (no separate toast), with a manual close button instead of the previous 5-second progress-bar auto-dismiss.
- Inline styles → `createStaticStyles`; dead `updateAvailable` state and the unused `openUpdateDetailModal`/`UpdateDetailContent` are removed.

#### 🧪 How to Test

- [x] Added/updated tests — 5 new cases in `UpdaterManager.test.ts` cover: same-version suppression, skipped auto-download, newer-version reset, older-version still suppressed, channel switch clears the guard. All 38 active tests pass (5 pre-existing skipped).
- [x] Tested locally — verified the renderer card visually in Electron dev mode (prompt → confirming → manual dismiss).

Steps to reproduce the fix manually on macOS:

1. `bun run dev:desktop`
2. Menu → **Dev → Updater Simulation → Simulate Download Complete** (the existing dev-menu trigger).
3. Click **Later** → confirming state appears with the green check + close button.
4. Trigger **Simulate Download Complete** again — the prompt should NOT reappear for the same version. (Before this fix, it did.)
5. Reset and trigger with a higher mock version (or relaunch) — the prompt should reappear, proving the guard clears for new versions.

#### 📝 Additional Information

The Dosu auto-comment on the GitHub issue pointed at the SWR-based web version check (`useCheckLatestVersion`). That path is unaffected — the real loop on Electron is entirely on the main process. No localStorage / persistent dismissal is needed because the literal "next launch" semantic + `autoInstallOnAppQuit = true` already covers the cross-session case.