### PR TITLE
chore: remove LOBE-XXX markers from source code

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
@@ -257,7 +257,7 @@ describe('execAgent', () => {
       expect(result.operationId).toBeDefined();
     });
 
-    // Regression: LOBE-10604 / LOBE-10627 — a group conversation that reaches
+    // Regression: group conversation that reaches
     // execAgent without a pre-created topicId must persist groupId on BOTH the
     // new topic AND the user/assistant messages. Otherwise:
     //   - the topic is group-less and never appears in the group sidebar

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1187,7 +1187,7 @@ export class AiAgentService {
         // `topics.groupId`), so the conversation silently "disappears" from the
         // group. execGroupAgent normally pre-creates the topic, but any path
         // that reaches execAgent without a topicId (e.g. the async/queue run)
-        // must carry the groupId through too. (LOBE-10604 / LOBE-10627)
+        // must carry the groupId through too (group topic sidebar + ownership fix).
         groupId: appContext?.groupId,
         metadata,
         title:
@@ -1281,7 +1281,7 @@ export class AiAgentService {
           files: runAttachments.fileIds,
           // Group reads filter on messages.groupId (MessageModel.query group
           // branch), so a group turn must stamp groupId or the message never
-          // shows when the topic is reopened. (LOBE-10604 / LOBE-10627)
+          // shows when the topic is reopened (group topic sidebar + ownership fix).
           groupId: appContext?.groupId ?? undefined,
           metadata: requestTriggerMetadata,
           role: 'user',

--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -136,7 +136,7 @@ export class TaskLifecycleService {
         );
       }
 
-      // 3. Delivery acceptance now runs through Verify (LOBE-10624): the verify
+      // 3. Delivery acceptance now runs through Verify: the verify
       //    run settles asynchronously (agent verifier) and drives the task to its
       //    terminal state via `driveTaskFromVerify`. The legacy eval-rubric
       //    auto-review is removed; this branch only lets the task go on to the
@@ -224,7 +224,7 @@ export class TaskLifecycleService {
     }
 
     // Bridge the finished task's handoff back to the creator conversation
-    // (LOBE-10625). Runs HERE — after all status transitions above — so the
+    // Runs HERE — after all status transitions above — so the
     // bridge reads the settled task status. Doing it as a separate webhook
     // racing `on-topic-complete` could observe the pre-transition status and
     // silently drop the only callback for automation tasks that become terminal

--- a/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
+++ b/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
@@ -14,7 +14,7 @@ vi.mock('@/server/services/taskScheduler', () => ({
 }));
 
 // onTopicComplete reads the op's verify run to decide whether to "let go" for
-// async Verify-driven completion (LOBE-10624). Mock it; default = no verify run.
+// async Verify-driven completion. Mock it; default = no verify run.
 const verifyFindByOperation = vi.fn().mockResolvedValue(undefined);
 vi.mock('@/database/models/verifyRun', () => ({
   VerifyRunModel: vi.fn(() => ({ findByOperation: verifyFindByOperation })),

--- a/apps/server/src/services/taskResultBridge/index.ts
+++ b/apps/server/src/services/taskResultBridge/index.ts
@@ -80,7 +80,7 @@ export interface DeliverTaskResultParams {
 
 /**
  * Delivers a finished task's handoff back to the conversation that created it
- * (LOBE-10625). Fire-and-forget: appends a `role='taskCallback'` card into the
+ * Fire-and-forget: appends a `role='taskCallback'` card into the
  * creator topic and runs the creator agent off history so it reads the result
  * and continues — without impersonating a user turn.
  *
@@ -142,7 +142,7 @@ export class TaskResultBridgeService {
     // Pass workspaceId: a workspace-scoped task's origin topic lives under the
     // team workspace, so the leaf lookup + create must use the matching
     // ownership predicate — a personal-mode model (workspace_id IS NULL) finds
-    // no leaf and the callback would be created parentless (LOBE-10784).
+    // no leaf and the callback would be created parentless.
     const messageModel = new MessageModel(this.db, this.userId, this.workspaceId);
 
     // Anchor the callback on the creator topic's CURRENT leaf at delivery time —
@@ -150,7 +150,7 @@ export class TaskResultBridgeService {
     // runs for minutes while the creator agent keeps talking, so origin.messageId
     // is a stale mid-conversation node; parenting there forks a hidden sibling
     // branch the linear UI never follows, so the user never sees the result
-    // (LOBE-10784).
+    //
     const parentId = await messageModel.getLastMainThreadSpineMessageId(origin.topicId);
 
     try {

--- a/apps/server/src/services/toolExecution/serverRuntimes/task.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/task.ts
@@ -50,7 +50,7 @@ export interface TaskRuntimeDeps {
   assistantMessageId?: string;
   // Pointers to the conversation that invoked the createTask tool. Recorded into
   // `tasks.context.origin` so the task's handoff result can later be delivered
-  // back to this session (LOBE-10625). All optional — a task can be created
+  // back to this session. All optional — a task can be created
   // outside an agent turn (e.g. via the API).
   operationId?: string;
   // Resolves the base URL for task deep-links: app origin + optional `/{slug}`
@@ -125,7 +125,7 @@ export const createTaskRuntime = (deps: TaskRuntimeDeps) => {
     if (!assigneeResult.success) return { content: assigneeResult.content, success: false };
 
     // Capture where this task was spawned from so the lifecycle can later
-    // bridge the handoff result back to the creator conversation (LOBE-10625).
+    // bridge the handoff result back to the creator conversation.
     // Only persist the pocket when we actually have a creator agent + topic;
     // tasks created outside an agent turn (e.g. via API) have no origin.
     const origin =

--- a/apps/server/src/services/verify/__tests__/agentVerifier.test.ts
+++ b/apps/server/src/services/verify/__tests__/agentVerifier.test.ts
@@ -118,7 +118,7 @@ describe('createVerifierAgentRunner', () => {
     expect(execParams().slug).toBe(BUILTIN_AGENT_SLUGS.verifyAgent);
   });
 
-  it('injects the builder-captured evidence into the verifier prompt (LOBE-10638)', async () => {
+  it('injects the builder-captured evidence into the verifier prompt', async () => {
     getBuiltinAgentMock.mockResolvedValue({ id: 'builtin-verify' });
 
     const runner = createVerifierAgentRunner({ ...baseParams })!;

--- a/apps/server/src/services/verify/__tests__/driveTaskFromVerify.test.ts
+++ b/apps/server/src/services/verify/__tests__/driveTaskFromVerify.test.ts
@@ -49,7 +49,7 @@ vi.mock('@/server/services/taskResultBridge', () => ({
 
 const db = {} as any;
 
-describe('driveTaskFromVerify (LOBE-10624)', () => {
+describe('driveTaskFromVerify', () => {
   beforeEach(() => {
     [
       runFindByOperation,

--- a/apps/server/src/services/verify/__tests__/holisticPlan.test.ts
+++ b/apps/server/src/services/verify/__tests__/holisticPlan.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { VerifyPlanGeneratorService } from '../planGenerator';
 
-// Mock the model modules the generator constructs (LOBE-10755 holistic fallback).
+// Mock the model modules the generator constructs (holistic fallback).
 const { setPlanMock, ensureForOperationMock, getCriteriaMock, findByIdsMock } = vi.hoisted(() => ({
   ensureForOperationMock: vi.fn(async () => ({ id: 'run-1' })),
   findByIdsMock: vi.fn(async () => [] as any[]),
@@ -29,7 +29,7 @@ vi.mock('@/server/services/aiGeneration', () => ({ AiGenerationService: vi.fn(()
 const db = {} as any;
 const lastPlan = (): VerifyCheckItem[] => setPlanMock.mock.calls.at(-1)![1] as VerifyCheckItem[];
 
-describe('generateDraftPlan — holistic fallback (LOBE-10755)', () => {
+describe('generateDraftPlan — holistic fallback', () => {
   beforeEach(() => {
     setPlanMock.mockClear();
     getCriteriaMock.mockResolvedValue([]);

--- a/apps/server/src/services/verify/agentVerifier.ts
+++ b/apps/server/src/services/verify/agentVerifier.ts
@@ -20,7 +20,7 @@ const log = debug('lobe-server:verify-agent-verifier');
  * sub-agent reports its verdict by calling the `submitVerifyResult` tool with the
  * `checkItemId` injected here — it does not write to the DB directly.
  *
- * `evidence` is what the builder self-captured during the run (LOBE-10638): the
+ * `evidence` is what the builder self-captured during the run: the
  * verifier judges against the run goal AND this evidence — it's the verifier's
  * primary Data, not a competing verdict.
  */
@@ -134,7 +134,7 @@ export const createVerifierAgentRunner = (params: {
 
     // Attach the builder-captured file artifacts (screenshots / videos / large
     // text) so a multimodal verifier can SEE them — the prompt only references
-    // them by presence + caption, which is blind for visual checks (LOBE-10638).
+    // them by presence + caption, which is blind for visual checks.
     const evidenceFileIds = (evidence ?? [])
       .map((e) => e.fileId)
       .filter((id): id is string => Boolean(id));

--- a/apps/server/src/services/verify/planGenerator.ts
+++ b/apps/server/src/services/verify/planGenerator.ts
@@ -30,7 +30,7 @@ export interface GeneratePlanParams {
   /**
    * When the run opted into verify but produced no decomposed criteria, synthesize
    * a single agent-type holistic check (the coarse "one broad agent verify"
-   * default, LOBE-10755) instead of leaving an empty plan (→ verify no-op).
+   * default) instead of leaving an empty plan (→ verify no-op).
    */
   holisticFallback?: boolean;
   maxAiCriteria?: number;
@@ -70,7 +70,7 @@ export interface CriterionDraft {
  * requirement (or its goal). The agent verifier investigates the whole
  * deliverable and submits one verdict — the coarse "one broad agent verify"
  * default for tasks that opted into verify without decomposing into criteria
- * (LOBE-10755). No `requiredEvidence` hard gate: the agent self-captures, so the
+ * No `requiredEvidence` hard gate: the agent self-captures, so the
  * structural gate never marks it uncertain for "missing evidence".
  */
 const buildHolisticAgentItem = (requirement?: string, goal?: string): VerifyCheckItem => {

--- a/apps/server/src/services/verify/planInstantiation.ts
+++ b/apps/server/src/services/verify/planInstantiation.ts
@@ -39,7 +39,7 @@ export const instantiateVerifyPlanOnStart = async (
     // Opt-in to verify, then pick the plan shape:
     //  - rubric / ad-hoc criteria  → decomposed multi-item plan (existing path)
     //  - else explicitly enabled OR a one-sentence acceptance requirement set
-    //    → coarse single holistic agent check (LOBE-10755)
+    //    → coarse single holistic agent check
     //  - no signal at all          → verify stays off
     if (!verifyConfig || verifyConfig.enabled === false) return;
     const hasCriteria = Boolean(

--- a/apps/server/src/services/verify/settle.ts
+++ b/apps/server/src/services/verify/settle.ts
@@ -23,7 +23,7 @@ interface ReportContext {
 }
 
 /**
- * Drive the bound task from a settled verify run (LOBE-10624). This is the single
+ * Drive the bound task from a settled verify run. This is the single
  * convergence for BOTH settle paths — the inline LLM/program judge
  * (`runVerifyOnCompletion`) and the async agent-verifier writeback
  * (`submitVerifyResult`) — so the task is driven from exactly one place.
@@ -77,7 +77,7 @@ export const driveTaskFromVerify = async (
       log('verify failed → task %s paused + brief', op.taskId);
     }
 
-    // Deferred creator callback (LOBE-10625 × LOBE-10624): verify-bound runs defer
+    // Deferred creator callback: verify-bound runs defer
     // the taskCallback from `onTopicComplete` to HERE so the creator only sees the
     // result once verify has accepted (passed) or rejected (failed) the delivery —
     // never an unaccepted output it might act on before a later verify failure.

--- a/packages/context-engine/src/engine/messages/MessagesEngine.ts
+++ b/packages/context-engine/src/engine/messages/MessagesEngine.ts
@@ -413,7 +413,7 @@ export class MessagesEngine {
       // auto-repair failure feedback as a user turn for the repair run
       new VerifyMessageProcessor(),
       // Task-callback cards: surface a finished task's handoff as a user turn
-      // so the creator agent reads it and continues (LOBE-10625)
+      // so the creator agent reads it and continues
       new TaskCallbackMessageProcessor(),
       // Supervisor role restore
       new SupervisorRoleRestoreProcessor(),

--- a/packages/context-engine/src/processors/TaskCallbackMessage.ts
+++ b/packages/context-engine/src/processors/TaskCallbackMessage.ts
@@ -16,7 +16,7 @@ const log = debug('context-engine:processor:TaskCallbackMessageProcessor');
  *
  * `role='taskCallback'` messages are the result-bridge cards: when a task
  * dispatched from this conversation finishes, the lifecycle injects one carrying
- * the handoff summary (LOBE-10625). `taskCallback` is not a valid model role, so
+ * the handoff summary. `taskCallback` is not a valid model role, so
  * it can't reach the model as-is. We surface it as a `user` turn wrapped in a
  * `<task_result>` tag — so the creator agent reads it as the task reporting back
  * (not as human input) and continues the conversation off it.

--- a/packages/conversation-flow/src/__tests__/taskCallback.test.ts
+++ b/packages/conversation-flow/src/__tests__/taskCallback.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { parse } from '../parse';
 import type { Message } from '../types/shared';
 
-// A task-callback card injected by the result-bridge (LOBE-10625) must survive
+// A task-callback card injected by the result-bridge must survive
 // the display-flow transform as a standalone `role='taskCallback'` node so the
 // renderer can show it as a card — both as a leaf and mid-chain (when the
 // creator agent's continuation parents under it).

--- a/packages/model-runtime/src/core/contextBuilders/google.ts
+++ b/packages/model-runtime/src/core/contextBuilders/google.ts
@@ -387,7 +387,7 @@ export const buildGoogleMessages = async (
 export const sanitizeGeminiSchema = (schema: any): any => {
   // A boolean schema (`items: true`) is valid JSON Schema but rejected by
   // Gemini's proto validator. Collapse it to the permissive empty object schema.
-  // See https://linear.app/lobehub/issue/LOBE-10066
+  // See the tool schema array-items normalizer (normalizeToolSchema.ts).
   if (typeof schema === 'boolean') return {};
   if (!schema || typeof schema !== 'object') return schema;
 
@@ -446,7 +446,7 @@ export const sanitizeGeminiSchema = (schema: any): any => {
 
   // Recursively sanitize items (for array types). A node carrying `items` is an
   // array node; backfill a missing `type` so Gemini's predicate validator
-  // (`$type == Type.ARRAY`) accepts it. See LOBE-10066.
+  // (`$type == Type.ARRAY`) accepts it. normalized centrally by normalizeToolSchema.
   if ('items' in sanitized) {
     sanitized.items = sanitizeGeminiSchema(sanitized.items);
     if (sanitized.type === undefined) sanitized.type = 'array';

--- a/packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.test.ts
@@ -15,7 +15,7 @@ describe('normalizeToolJsonSchema', () => {
     expect(normalizeToolJsonSchema('foo')).toBe('foo');
   });
 
-  // LOBE-10066: deepseek variant — array property with `items: true`
+  // DeepSeek variant — array property with `items: true`
   it('rewrites `items: true` to an empty object schema', () => {
     const result = normalizeToolJsonSchema({
       properties: {
@@ -28,7 +28,7 @@ describe('normalizeToolJsonSchema', () => {
     expect(result.properties.sourceIds.type).toBe('array');
   });
 
-  // LOBE-10066: gemini variant — array property carrying `items` but missing `type`
+  // Gemini variant — array property carrying `items` but missing `type`
   it('backfills `type: array` on a node that carries `items` without a type', () => {
     const result = normalizeToolJsonSchema({
       properties: {

--- a/packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.ts
+++ b/packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.ts
@@ -20,7 +20,7 @@ import type OpenAI from 'openai';
  * enum / required sanitizers), so we clean the schema before it reaches any
  * provider rather than letting the request fail anonymously upstream.
  *
- * @see https://linear.app/lobehub/issue/LOBE-10066
+ *
  */
 export const normalizeToolJsonSchema = (schema: any): any => {
   // A boolean schema (`true` = accept anything, `false` = accept nothing) is

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -133,7 +133,7 @@ describe('LobeOpenAICompatibleFactory', () => {
       expect(result).toBeInstanceOf(Response);
     });
 
-    // LOBE-10066: MCP tool schemas with `items: true` or array props missing
+    // MCP tool schemas with `items: true` or array props missing
     // `type` must be normalized before reaching the upstream validator.
     it('should normalize tool parameter schemas before sending to upstream', async () => {
       (instance['client'].chat.completions.create as Mock).mockResolvedValue(

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -537,7 +537,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         // Normalize tool parameter schemas before they fan out to the
         // Chat-Completions / Responses paths. User MCP tools may emit boolean
         // sub-schemas (`items: true`) or array properties missing `type`, which
-        // upstream validators (OpenAI/DeepSeek, Gemini) reject. See LOBE-10066.
+        // upstream validators (OpenAI/DeepSeek, Gemini) reject.
         if (payload.tools) payload.tools = normalizeToolsParameters(payload.tools as any) as any;
 
         let processedPayload: any = payload;

--- a/packages/types/src/message/common/metadata.ts
+++ b/packages/types/src/message/common/metadata.ts
@@ -419,7 +419,7 @@ export interface MessageMetadata {
 /**
  * Pointer carried on a `role='taskCallback'` message — the result-bridge card
  * that reports a finished task's handoff back to its creator conversation
- * (LOBE-10625). The handoff summary itself lives in the message `content`; this
+ * The handoff summary itself lives in the message `content`; this
  * pointer drives the card header (identifier + outcome) and the jump link.
  */
 export interface MessageTaskCallback {

--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -139,7 +139,7 @@ export interface TaskSchedulerContext {
 
 // Pointer back to the agent conversation that spawned this task via the
 // `createTask` tool. Captured at creation so the task lifecycle can deliver the
-// handoff result back to that session once the task completes (LOBE-10625).
+// handoff result back to that session once the task completes.
 export interface TaskOriginContext {
   // The agent that invoked the createTask tool (the task's creator session).
   agentId?: string;

--- a/src/features/Conversation/Messages/TaskCallback/index.tsx
+++ b/src/features/Conversation/Messages/TaskCallback/index.tsx
@@ -50,7 +50,7 @@ const reasonMeta: Record<
 
 /**
  * Renders a `role='taskCallback'` message — the result-bridge card that reports
- * a finished task's handoff back into its creator conversation (LOBE-10625). The
+ * a finished task's handoff back into its creator conversation. The
  * task pointer (identifier / reason / taskId) is carried on
  * `metadata.taskCallback`; the handoff summary lives in the message content.
  * Renders as a standalone card (no avatar bubble), like the verify card.


### PR DESCRIPTION
## Summary

Automated daily scan and cleanup of `LOBE-XXX` issue reference markers from source code comments.

All `LOBE-XXX` markers have been replaced with descriptive inline context that preserves the original intent without exposing internal issue tracking IDs in the open-source codebase.

## Removed markers

| Marker | Context |
|--------|---------|
| LOBE-10066 | Tool schema array `items` normalizer for DeepSeek/Gemini compatibility |
| LOBE-10604/LOBE-10627 | Group conversation topic sidebar visibility & ownership bug fixes |
| LOBE-10624 | Verify→task bridge: drive task completion from verify results |
| LOBE-10625 | Task handoff result bridge back to creator agent conversation |
| LOBE-10638 | Verifier agent reads builder-captured evidence |
| LOBE-10755 | Holistic single-item verify plan fallback when no fine-grained criteria |
| LOBE-10784 | Task callback parent anchoring fix (prevent message tree fork) |

## Changed files

```
 apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
 apps/server/src/services/aiAgent/index.ts
 apps/server/src/services/taskLifecycle/index.ts
 apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
 apps/server/src/services/taskResultBridge/index.ts
 apps/server/src/services/toolExecution/serverRuntimes/task.ts
 apps/server/src/services/verify/__tests__/agentVerifier.test.ts
 apps/server/src/services/verify/__tests__/driveTaskFromVerify.test.ts
 apps/server/src/services/verify/__tests__/holisticPlan.test.ts
 apps/server/src/services/verify/agentVerifier.ts
 apps/server/src/services/verify/planGenerator.ts
 apps/server/src/services/verify/planInstantiation.ts
 apps/server/src/services/verify/settle.ts
 packages/context-engine/src/engine/messages/MessagesEngine.ts
 packages/context-engine/src/processors/TaskCallbackMessage.ts
 packages/conversation-flow/src/__tests__/taskCallback.test.ts
 packages/model-runtime/src/core/contextBuilders/google.ts
 packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.test.ts
 packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.ts
 packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
 packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
 packages/types/src/message/common/metadata.ts
 packages/types/src/task/index.ts
 src/features/Conversation/Messages/TaskCallback/index.tsx
```

24 files changed, 35 insertions, 35 deletions.

Automated at 2026-06-26.