### PR TITLE
✨ feat(nav-panel): add overridable slot above sidebar footer

### DIFF
--- a/src/business/client/features/NavPanelUpgradeEntry.tsx
+++ b/src/business/client/features/NavPanelUpgradeEntry.tsx
@@ -1,7 +1,7 @@
 /**
- * Rendered above the home sidebar footer. Open-source builds keep this slot
- * empty; cloud overrides it via the `@/business/...` path alias to surface a
- * contextual upgrade CTA for users on a free-tier plan.
+ * Rendered above the home sidebar footer. The open-source build keeps this
+ * slot empty; downstream builds can override the module via their own
+ * `@/business/...` mapping to surface optional sidebar content here.
  */
 const NavPanelUpgradeEntry = () => null;
 

--- a/src/business/client/features/NavPanelUpgradeEntry.tsx
+++ b/src/business/client/features/NavPanelUpgradeEntry.tsx
@@ -1,0 +1,8 @@
+/**
+ * Rendered above the home sidebar footer. Open-source builds keep this slot
+ * empty; cloud overrides it via the `@/business/...` path alias to surface a
+ * contextual upgrade CTA for users on a free-tier plan.
+ */
+const NavPanelUpgradeEntry = () => null;
+
+export default NavPanelUpgradeEntry;

--- a/src/features/NavPanel/components/NavPanelDraggable.tsx
+++ b/src/features/NavPanel/components/NavPanelDraggable.tsx
@@ -5,6 +5,7 @@ import { createStaticStyles, cssVar } from 'antd-style';
 import { type ReactNode } from 'react';
 import { memo, Suspense, useMemo, useRef } from 'react';
 
+import NavPanelUpgradeEntry from '@/business/client/features/NavPanelUpgradeEntry';
 import { isDesktop } from '@/const/version';
 import { TOGGLE_BUTTON_ID } from '@/features/NavPanel/ToggleLeftPanelButton';
 import Footer from '@/routes/(main)/home/_layout/Footer';
@@ -159,6 +160,9 @@ export const NavPanelDraggable = memo<NavPanelDraggableProps>(({ activeContent }
           {activeContent.node}
         </div>
       </div>
+      <Suspense fallback={null}>
+        <NavPanelUpgradeEntry />
+      </Suspense>
       <Suspense>
         <Footer />
       </Suspense>


### PR DESCRIPTION
## 💻 Change Type

- [x] ✨ feat

## 🔗 Related Links

- Linear / GitHub issue: N/A
- Related PRs: N/A
- Reference docs / code / articles: N/A

## 🔀 Description of Change

Add an overridable component slot above the home sidebar footer so downstream builds can surface a contextual entry there (such as an upgrade CTA for free-tier users) without having to fork `NavPanelDraggable`.

- New stub `src/business/client/features/NavPanelUpgradeEntry.tsx` that returns `null` in open-source builds
- `NavPanelDraggable` mounts the slot in its own `<Suspense fallback={null}>` boundary directly above `<Footer />`, so downstream overrides can lazy-load freely without disturbing the footer

Behavior in this repo is unchanged — the slot is intentionally empty by default.

## 🧭 Key Decisions / Non-goals

- **Why a new slot instead of adding `bottom` to `SideBarLayout`?** `SideBarLayout` is shared by every sidebar (home, files, agents, etc.), but this slot semantically belongs at the home-panel chrome level (alongside `Footer`). Putting it in `NavPanelDraggable` keeps the layout primitive single-purpose and avoids paying for the slot on every panel variant.
- **Why a separate `<Suspense>` boundary?** Downstream overrides may use lazy data (subscription store, plan flags). Wrapping the override in its own boundary keeps a downstream suspense from blocking the footer render.
- **Naming hints upgrade-only usage.** The slot is named `NavPanelUpgradeEntry` to match the most common downstream use case; it isn't a constraint — the override can render anything. Open to renaming to `NavPanelBottomSlot` if reviewers prefer a generic name.
- **Non-goal**: change the open-source sidebar appearance, ship a default upgrade UI in this repo, or refactor the footer.

## 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

### Automated Tests

- N/A — pure structural addition, default behavior unchanged

### Manual Verification

1. `bun run dev` and open the home sidebar.
2. Confirm the sidebar looks identical to `main` (the slot resolves to `null`).
3. Temporarily replace the stub with `() => <div style={{padding:8,background:'red'}}>SLOT</div>` to confirm it renders directly above the footer.

### Post-Deploy Verification

- N/A

## 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Sidebar unchanged | Sidebar unchanged (slot defaults to `null`) |

## 🚀 Rollout / Deployment Checklist

- [x] Environment variables: N/A
- [x] Redis / Edge Config / feature flags: N/A
- [x] Database migration or data backfill: N/A
- [x] Third-party console changes: N/A
- [x] Rollback plan: revert this PR — no behavior change in open-source builds