### PR TITLE
✨ feat(aihubmix): support custom / backup base URL

### DIFF
--- a/packages/model-bank/src/modelProviders/aihubmix.ts
+++ b/packages/model-bank/src/modelProviders/aihubmix.ts
@@ -9,6 +9,9 @@ const AiHubMix: ModelProviderCard = {
   modelsUrl: 'https://docs.aihubmix.com/cn/api/Model-List',
   name: 'AiHubMix',
   settings: {
+    proxyUrl: {
+      placeholder: 'https://aihubmix.com',
+    },
     sdkType: 'router',
     showModelFetcher: true,
     supportResponsesApi: true,

--- a/packages/model-runtime/src/providers/aihubmix/index.test.ts
+++ b/packages/model-runtime/src/providers/aihubmix/index.test.ts
@@ -73,6 +73,24 @@ describe('LobeAiHubMixAI', () => {
 
       expect(deepseekRouter?.models).toContain('deepseek-v4-flash-free');
     });
+
+    it('should thread a custom baseURL through all routes, defaulting to aihubmix.com', () => {
+      const custom = (params.routers as any)(
+        { apiKey: 'test', baseURL: 'https://my-aihubmix-mirror.com' },
+        {},
+      );
+      const baseOf = (apiType: string) =>
+        custom.find((r: any) => r.apiType === apiType).options.baseURL;
+      expect(baseOf('anthropic')).toBe('https://my-aihubmix-mirror.com');
+      expect(baseOf('google')).toBe('https://my-aihubmix-mirror.com/gemini');
+      expect(baseOf('openai')).toBe('https://my-aihubmix-mirror.com/v1');
+
+      // Falls back to the default gateway when no custom baseURL is set
+      const def = (params.routers as any)({ apiKey: 'test' }, {});
+      expect(def.find((r: any) => r.apiType === 'anthropic').options.baseURL).toBe(
+        'https://aihubmix.com',
+      );
+    });
   });
 
   describe('chat', () => {
@@ -105,6 +123,30 @@ describe('LobeAiHubMixAI', () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://aihubmix.com/api/v1/models',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Authorization': 'Bearer test_api_key',
+            'APP-Code': 'LobeHub',
+          }),
+        }),
+      );
+    });
+
+    it('should fetch the model list from a custom base URL when configured', async () => {
+      const customInstance = new LobeAiHubMixAI({
+        apiKey: 'test_api_key',
+        baseURL: 'https://my-aihubmix-mirror.com',
+      });
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: mockModels }), { status: 200 }),
+      );
+
+      await customInstance.models();
+
+      // The /api/v1/models catalog endpoint follows the configured gateway,
+      // derived from the client baseURL (trailing /v1 stripped), not the default.
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://my-aihubmix-mirror.com/api/v1/models',
         expect.objectContaining({
           headers: expect.objectContaining({
             'Authorization': 'Bearer test_api_key',

--- a/packages/model-runtime/src/providers/aihubmix/index.test.ts
+++ b/packages/model-runtime/src/providers/aihubmix/index.test.ts
@@ -85,6 +85,18 @@ describe('LobeAiHubMixAI', () => {
       expect(baseOf('google')).toBe('https://my-aihubmix-mirror.com/gemini');
       expect(baseOf('openai')).toBe('https://my-aihubmix-mirror.com/v1');
 
+      // A custom endpoint that already includes the API version is normalized,
+      // so the route suffixes are not doubled (…/v1/v1, …/v1/gemini).
+      const versioned = (params.routers as any)(
+        { apiKey: 'test', baseURL: 'https://my-aihubmix-mirror.com/v1' },
+        {},
+      );
+      const vBaseOf = (apiType: string) =>
+        versioned.find((r: any) => r.apiType === apiType).options.baseURL;
+      expect(vBaseOf('anthropic')).toBe('https://my-aihubmix-mirror.com');
+      expect(vBaseOf('google')).toBe('https://my-aihubmix-mirror.com/gemini');
+      expect(vBaseOf('openai')).toBe('https://my-aihubmix-mirror.com/v1');
+
       // Falls back to the default gateway when no custom baseURL is set
       const def = (params.routers as any)({ apiKey: 'test' }, {});
       expect(def.find((r: any) => r.apiType === 'anthropic').options.baseURL).toBe(

--- a/packages/model-runtime/src/providers/aihubmix/index.ts
+++ b/packages/model-runtime/src/providers/aihubmix/index.ts
@@ -196,7 +196,10 @@ export const params: CreateRouterRuntimeOptions = {
     }
   },
   routers: (options, runtimeContext) => {
-    const baseURL = options.baseURL?.trim() || DEFAULT_BASE_URL;
+    // Normalize the configured endpoint: strip a trailing version suffix (e.g. /v1)
+    // so the per-route suffixes below aren't doubled (…/v1/v1, …/v1/gemini) when a
+    // user sets a baseURL that already includes the version.
+    const baseURL = options.baseURL?.trim().replace(/\/v\d+[a-z]*\/?$/, '') || DEFAULT_BASE_URL;
 
     return [
       {

--- a/packages/model-runtime/src/providers/aihubmix/index.ts
+++ b/packages/model-runtime/src/providers/aihubmix/index.ts
@@ -141,7 +141,10 @@ const mapAiHubMixModel = (m: any): { [key: string]: any; id: string } => {
   };
 };
 
-const baseURL = 'https://aihubmix.com';
+// Default AiHubMix gateway. Users can point the provider at a custom or backup
+// endpoint (e.g. a mirror domain) via the "API endpoint" setting (keyVaults.baseURL);
+// the configured baseURL flows through every route below and the model-list fetch.
+const DEFAULT_BASE_URL = 'https://aihubmix.com';
 
 export const params: CreateRouterRuntimeOptions = {
   debug: {
@@ -154,6 +157,12 @@ export const params: CreateRouterRuntimeOptions = {
   models: async ({ client }) => {
     const apiKey = (client as any).apiKey as string;
 
+    // Derive the gateway root from the configured client baseURL (stripping the
+    // trailing /v1 etc.), falling back to the default gateway. This way a user who
+    // points AiHubMix at a custom/backup endpoint fetches the model list from it too.
+    const clientBaseURL = ((client as any).baseURL as string) || urlJoin(DEFAULT_BASE_URL, '/v1');
+    const rootBaseURL = clientBaseURL.replace(/\/v\d+[a-z]*\/?$/, '') || DEFAULT_BASE_URL;
+
     // AiHubMix exposes two model list endpoints:
     // - https://aihubmix.com/v1/models     — returns per-user-group list only (~256 models)
     // - https://aihubmix.com/api/v1/models — returns the complete model catalog (800+)
@@ -164,7 +173,7 @@ export const params: CreateRouterRuntimeOptions = {
     const timeoutId = setTimeout(() => controller.abort(), 10_000);
 
     try {
-      const response = await fetch('https://aihubmix.com/api/v1/models', {
+      const response = await fetch(urlJoin(rootBaseURL, '/api/v1/models'), {
         headers: {
           'Authorization': `Bearer ${apiKey}`,
           'APP-Code': 'LobeHub',
@@ -186,51 +195,55 @@ export const params: CreateRouterRuntimeOptions = {
       clearTimeout(timeoutId);
     }
   },
-  routers: (_options, runtimeContext) => [
-    {
-      apiType: 'anthropic',
-      models: LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter(
-        (id) => detectModelProvider(id) === 'anthropic',
-      ),
-      options: { baseURL },
-    },
-    {
-      apiType: 'google',
-      models: LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter(
-        (id) => detectModelProvider(id) === 'google',
-      ),
-      options: { baseURL: urlJoin(baseURL, '/gemini') },
-    },
-    {
-      apiType: 'xai',
-      models: LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter(
-        (id) => detectModelProvider(id) === 'xai',
-      ),
-      options: { baseURL: urlJoin(baseURL, '/v1') },
-    },
-    {
-      apiType: 'deepseek',
-      // Match the whole DeepSeek family (deepseek-v4*, deepseek-chat, ...), not
-      // just the two legacy ids — the deepseek runtime simulates structured
-      // output via tool calling, while the generic openai fallback sends
-      // response_format json_schema which DeepSeek upstreams reject.
-      models: resolveProviderRouteModels(
-        'deepseek',
-        LOBE_DEFAULT_MODEL_LIST,
-        runtimeContext?.model,
-      ),
-      options: { baseURL: urlJoin(baseURL, '/v1') },
-    },
-    {
-      apiType: 'openai',
-      options: {
-        baseURL: urlJoin(baseURL, '/v1'),
-        chatCompletion: {
-          useResponseModels: [...Array.from(responsesAPIModels), /gpt-\d(?!\d)/, /^o\d/],
+  routers: (options, runtimeContext) => {
+    const baseURL = options.baseURL?.trim() || DEFAULT_BASE_URL;
+
+    return [
+      {
+        apiType: 'anthropic',
+        models: LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter(
+          (id) => detectModelProvider(id) === 'anthropic',
+        ),
+        options: { baseURL },
+      },
+      {
+        apiType: 'google',
+        models: LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter(
+          (id) => detectModelProvider(id) === 'google',
+        ),
+        options: { baseURL: urlJoin(baseURL, '/gemini') },
+      },
+      {
+        apiType: 'xai',
+        models: LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter(
+          (id) => detectModelProvider(id) === 'xai',
+        ),
+        options: { baseURL: urlJoin(baseURL, '/v1') },
+      },
+      {
+        apiType: 'deepseek',
+        // Match the whole DeepSeek family (deepseek-v4*, deepseek-chat, ...), not
+        // just the two legacy ids — the deepseek runtime simulates structured
+        // output via tool calling, while the generic openai fallback sends
+        // response_format json_schema which DeepSeek upstreams reject.
+        models: resolveProviderRouteModels(
+          'deepseek',
+          LOBE_DEFAULT_MODEL_LIST,
+          runtimeContext?.model,
+        ),
+        options: { baseURL: urlJoin(baseURL, '/v1') },
+      },
+      {
+        apiType: 'openai',
+        options: {
+          baseURL: urlJoin(baseURL, '/v1'),
+          chatCompletion: {
+            useResponseModels: [...Array.from(responsesAPIModels), /gpt-\d(?!\d)/, /^o\d/],
+          },
         },
       },
-    },
-  ],
+    ];
+  },
 };
 
 export const LobeAiHubMixAI = createRouterRuntime(params);

--- a/packages/model-runtime/src/providers/aihubmix/index.ts
+++ b/packages/model-runtime/src/providers/aihubmix/index.ts
@@ -142,9 +142,14 @@ const mapAiHubMixModel = (m: any): { [key: string]: any; id: string } => {
 };
 
 // Default AiHubMix gateway. Users can point the provider at a custom or backup
-// endpoint (e.g. a mirror domain) via the "API endpoint" setting (keyVaults.baseURL);
-// the configured baseURL flows through every route below and the model-list fetch.
+// endpoint (e.g. a mirror domain) via the provider's "API endpoint" setting.
 const DEFAULT_BASE_URL = 'https://aihubmix.com';
+
+// Resolve the gateway for a request from the configured baseURL (default
+// DEFAULT_BASE_URL), stripping a trailing version suffix (e.g. /v1) so the
+// per-route suffixes below aren't doubled (…/v1/v1, …/v1/gemini).
+const resolveBaseURL = (options: { baseURL?: string }) =>
+  options.baseURL?.trim().replace(/\/v\d+[a-z]*\/?$/, '') || DEFAULT_BASE_URL;
 
 export const params: CreateRouterRuntimeOptions = {
   debug: {
@@ -195,58 +200,51 @@ export const params: CreateRouterRuntimeOptions = {
       clearTimeout(timeoutId);
     }
   },
-  routers: (options, runtimeContext) => {
-    // Normalize the configured endpoint: strip a trailing version suffix (e.g. /v1)
-    // so the per-route suffixes below aren't doubled (…/v1/v1, …/v1/gemini) when a
-    // user sets a baseURL that already includes the version.
-    const baseURL = options.baseURL?.trim().replace(/\/v\d+[a-z]*\/?$/, '') || DEFAULT_BASE_URL;
-
-    return [
-      {
-        apiType: 'anthropic',
-        models: LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter(
-          (id) => detectModelProvider(id) === 'anthropic',
-        ),
-        options: { baseURL },
-      },
-      {
-        apiType: 'google',
-        models: LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter(
-          (id) => detectModelProvider(id) === 'google',
-        ),
-        options: { baseURL: urlJoin(baseURL, '/gemini') },
-      },
-      {
-        apiType: 'xai',
-        models: LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter(
-          (id) => detectModelProvider(id) === 'xai',
-        ),
-        options: { baseURL: urlJoin(baseURL, '/v1') },
-      },
-      {
-        apiType: 'deepseek',
-        // Match the whole DeepSeek family (deepseek-v4*, deepseek-chat, ...), not
-        // just the two legacy ids — the deepseek runtime simulates structured
-        // output via tool calling, while the generic openai fallback sends
-        // response_format json_schema which DeepSeek upstreams reject.
-        models: resolveProviderRouteModels(
-          'deepseek',
-          LOBE_DEFAULT_MODEL_LIST,
-          runtimeContext?.model,
-        ),
-        options: { baseURL: urlJoin(baseURL, '/v1') },
-      },
-      {
-        apiType: 'openai',
-        options: {
-          baseURL: urlJoin(baseURL, '/v1'),
-          chatCompletion: {
-            useResponseModels: [...Array.from(responsesAPIModels), /gpt-\d(?!\d)/, /^o\d/],
-          },
+  routers: (options, runtimeContext) => [
+    {
+      apiType: 'anthropic',
+      models: LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter(
+        (id) => detectModelProvider(id) === 'anthropic',
+      ),
+      options: { baseURL: resolveBaseURL(options) },
+    },
+    {
+      apiType: 'google',
+      models: LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter(
+        (id) => detectModelProvider(id) === 'google',
+      ),
+      options: { baseURL: urlJoin(resolveBaseURL(options), '/gemini') },
+    },
+    {
+      apiType: 'xai',
+      models: LOBE_DEFAULT_MODEL_LIST.map((m) => m.id).filter(
+        (id) => detectModelProvider(id) === 'xai',
+      ),
+      options: { baseURL: urlJoin(resolveBaseURL(options), '/v1') },
+    },
+    {
+      apiType: 'deepseek',
+      // Match the whole DeepSeek family (deepseek-v4*, deepseek-chat, ...), not
+      // just the two legacy ids — the deepseek runtime simulates structured
+      // output via tool calling, while the generic openai fallback sends
+      // response_format json_schema which DeepSeek upstreams reject.
+      models: resolveProviderRouteModels(
+        'deepseek',
+        LOBE_DEFAULT_MODEL_LIST,
+        runtimeContext?.model,
+      ),
+      options: { baseURL: urlJoin(resolveBaseURL(options), '/v1') },
+    },
+    {
+      apiType: 'openai',
+      options: {
+        baseURL: urlJoin(resolveBaseURL(options), '/v1'),
+        chatCompletion: {
+          useResponseModels: [...Array.from(responsesAPIModels), /gpt-\d(?!\d)/, /^o\d/],
         },
       },
-    ];
-  },
+    },
+  ],
 };
 
 export const LobeAiHubMixAI = createRouterRuntime(params);


### PR DESCRIPTION
## ✨ What's changed

The AiHubMix provider hardcodes its gateway to `https://aihubmix.com` in both the chat routing and the model-list fetch, so users cannot point it at a mirror or backup endpoint when the primary is unreachable. This makes the base URL user-configurable, defaulting to `https://aihubmix.com` — the same capability the **New API** provider already has.

## 🔨 Changes

- **`packages/model-runtime/src/providers/aihubmix/index.ts`**
  - `routers` now reads `options.baseURL` (falling back to `https://aihubmix.com`) and threads it through all five routes (Anthropic root, `/gemini`, `/v1`).
  - The model-list fetch derives the gateway root from the client `baseURL` (stripping the trailing `/v1`), so a custom endpoint serves the model catalog too.
  - Most line changes here are re-indentation from wrapping the `routers` arrow in a block body; the logical change is small.
- **`packages/model-bank/src/modelProviders/aihubmix.ts`**
  - Add `settings.proxyUrl` so the endpoint field renders in the provider config UI.

## ✅ Default behaviour preserved

With no custom endpoint set, everything continues to hit `https://aihubmix.com` exactly as before.

## 🧪 Test

`pnpm exec vitest run src/providers/aihubmix/index.test.ts` → **14 / 14 passed**
