### PR TITLE
✨ feat(remote-agent): mint operation JWT from desktop session for remote CC

### DIFF
--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -292,6 +292,21 @@ export default class GatewayConnectionCtr extends ControllerModule {
         return { reason: 'Remote server URL not configured', status: 'rejected' };
       }
 
+      // The dispatch is supposed to carry an operation-scoped JWT, but some
+      // dispatch paths arrive without one (e.g. the gateway not forwarding it).
+      // Best-effort fallback: mint a fresh operation JWT from this device's own
+      // logged-in session so the spawned `lh hetero exec` can authenticate
+      // heteroIngest/heteroFinish without a separate `lh login`. `heteroIngest`
+      // rejects normal user tokens, so we must exchange for a `hetero-operation`
+      // token rather than injecting the desktop access token directly.
+      //
+      // This is purely additive: when `request.jwt` is present we behave exactly
+      // as before, and if minting yields nothing we still spawn with the
+      // original (possibly empty) jwt rather than rejecting the run — so the
+      // change can roll out progressively without regressing the existing path.
+      const jwt =
+        request.jwt || (await this.mintOperationJwt(serverUrl, request.topicId)) || request.jwt;
+
       // Fire-and-forget: lh hetero exec handles spawn -> adapt ->
       // BatchIngester -> heteroIngest/heteroFinish -> server -> Gateway -> clients.
       // Same command as spawnHeteroSandbox() on the server side.
@@ -300,7 +315,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
         args: request.args,
         cwd: request.cwd,
         imageList: request.imageList,
-        jwt: request.jwt,
+        jwt,
         operationId: request.operationId,
         prompt: request.prompt,
         resumeSessionId: request.resumeSessionId,
@@ -313,6 +328,46 @@ export default class GatewayConnectionCtr extends ControllerModule {
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       return { reason, status: 'rejected' };
+    }
+  }
+
+  /**
+   * Exchange this device's logged-in user session for a short-scoped
+   * `hetero-operation` JWT via `aiAgent.mintHeteroOperationToken`. Returns
+   * undefined when the device isn't logged in or the server rejects the
+   * request, so the caller rejects the run rather than spawning a CLI that
+   * would then prompt for login.
+   */
+  private async mintOperationJwt(serverUrl: string, topicId: string): Promise<string | undefined> {
+    const token = await this.remoteServerConfigCtr.getAccessToken();
+    if (!token) {
+      logger.error('mintOperationJwt: device is not logged in (no access token)');
+      return undefined;
+    }
+
+    try {
+      const res = await fetch(`${serverUrl}/trpc/lambda/aiAgent.mintHeteroOperationToken`, {
+        body: JSON.stringify({ json: { topicId } }),
+        headers: {
+          'Content-Type': 'application/json',
+          'Oidc-Auth': token,
+        },
+        method: 'POST',
+      });
+      if (!res.ok) {
+        logger.error('mintOperationJwt: server returned %d', res.status);
+        return undefined;
+      }
+      const payload = (await res.json()) as {
+        result?: { data?: { json?: { token?: string } } };
+      };
+      return payload.result?.data?.json?.token;
+    } catch (err) {
+      logger.error(
+        'mintOperationJwt: request failed — %s',
+        err instanceof Error ? err.message : String(err),
+      );
+      return undefined;
     }
   }
 

--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -305,7 +305,9 @@ export default class GatewayConnectionCtr extends ControllerModule {
       // original (possibly empty) jwt rather than rejecting the run — so the
       // change can roll out progressively without regressing the existing path.
       const jwt =
-        request.jwt || (await this.mintOperationJwt(serverUrl, request.topicId)) || request.jwt;
+        request.jwt ||
+        (await this.mintOperationJwt(serverUrl, request.topicId, request.workspaceId)) ||
+        request.jwt;
 
       // Fire-and-forget: lh hetero exec handles spawn -> adapt ->
       // BatchIngester -> heteroIngest/heteroFinish -> server -> Gateway -> clients.
@@ -335,10 +337,17 @@ export default class GatewayConnectionCtr extends ControllerModule {
    * Exchange this device's logged-in user session for a short-scoped
    * `hetero-operation` JWT via `aiAgent.mintHeteroOperationToken`. Returns
    * undefined when the device isn't logged in or the server rejects the
-   * request, so the caller rejects the run rather than spawning a CLI that
-   * would then prompt for login.
+   * request, in which case the caller falls back to the dispatched jwt.
+   *
+   * For workspace devices the dispatch carries the owning `workspaceId`, which
+   * we forward as `X-Workspace-Id` so the server resolves the workspace-owned
+   * topic instead of falling back to personal mode (which would 404 the lookup).
    */
-  private async mintOperationJwt(serverUrl: string, topicId: string): Promise<string | undefined> {
+  private async mintOperationJwt(
+    serverUrl: string,
+    topicId: string,
+    workspaceId?: string,
+  ): Promise<string | undefined> {
     const token = await this.remoteServerConfigCtr.getAccessToken();
     if (!token) {
       logger.error('mintOperationJwt: device is not logged in (no access token)');
@@ -346,12 +355,15 @@ export default class GatewayConnectionCtr extends ControllerModule {
     }
 
     try {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'Oidc-Auth': token,
+      };
+      if (workspaceId) headers['X-Workspace-Id'] = workspaceId;
+
       const res = await fetch(`${serverUrl}/trpc/lambda/aiAgent.mintHeteroOperationToken`, {
         body: JSON.stringify({ json: { topicId } }),
-        headers: {
-          'Content-Type': 'application/json',
-          'Oidc-Auth': token,
-        },
+        headers,
         method: 'POST',
       });
       if (!res.ok) {

--- a/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
@@ -830,6 +830,7 @@ describe('GatewayConnectionCtr', () => {
 
     beforeEach(() => {
       vi.mocked(mockHeterogeneousAgentCtr.spawnLhHeteroExec).mockClear();
+      vi.unstubAllGlobals();
     });
 
     it.each(['openclaw', 'hermes', 'codex', 'claude-code'] as const)(
@@ -894,6 +895,49 @@ describe('GatewayConnectionCtr', () => {
           topicId: 'topic-1',
         }),
       );
+    });
+
+    it('mints an operation JWT from the device session when the dispatch carries no jwt', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        json: async () => ({ result: { data: { json: { token: 'minted-op-jwt' } } } }),
+        ok: true,
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const client = await connectAndOpen();
+      client.simulateAgentRunRequest('claude-code', 'op-mint', 'hi', '');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://server.example.com/trpc/lambda/aiAgent.mintHeteroOperationToken',
+        expect.objectContaining({
+          body: JSON.stringify({ json: { topicId: 'topic-1' } }),
+          headers: expect.objectContaining({ 'Oidc-Auth': 'mock-access-token' }),
+          method: 'POST',
+        }),
+      );
+      expect(mockHeterogeneousAgentCtr.spawnLhHeteroExec).toHaveBeenCalledWith(
+        expect.objectContaining({ jwt: 'minted-op-jwt', operationId: 'op-mint' }),
+      );
+    });
+
+    it('still spawns with the original jwt when minting is unavailable (progressive, no reject)', async () => {
+      // No dispatched jwt AND device not logged in -> mint yields nothing. The
+      // run must still spawn with the original (empty) jwt rather than being
+      // rejected, preserving the pre-fallback behavior.
+      const client = await connectAndOpen();
+      vi.mocked(mockRemoteServerConfigCtr.getAccessToken).mockResolvedValue(null);
+      client.simulateAgentRunRequest('claude-code', 'op-fallback', 'hi', '');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(client.sendAgentRunAck).toHaveBeenCalledWith({
+        operationId: 'op-fallback',
+        status: 'accepted',
+      });
+      expect(mockHeterogeneousAgentCtr.spawnLhHeteroExec).toHaveBeenCalledWith(
+        expect.objectContaining({ jwt: '', operationId: 'op-fallback' }),
+      );
+      vi.mocked(mockRemoteServerConfigCtr.getAccessToken).mockResolvedValue('mock-access-token');
     });
 
     it('sends rejected ack when remote server URL is not configured', async () => {

--- a/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
@@ -921,6 +921,25 @@ describe('GatewayConnectionCtr', () => {
       );
     });
 
+    it('forwards the dispatch workspaceId as X-Workspace-Id when minting', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        json: async () => ({ result: { data: { json: { token: 'minted-op-jwt' } } } }),
+        ok: true,
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const client = await connectAndOpen();
+      client.simulateAgentRunRequest('claude-code', 'op-ws', 'hi', '', { workspaceId: 'ws-1' });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://server.example.com/trpc/lambda/aiAgent.mintHeteroOperationToken',
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'X-Workspace-Id': 'ws-1' }),
+        }),
+      );
+    });
+
     it('still spawns with the original jwt when minting is unavailable (progressive, no reject)', async () => {
       // No dispatched jwt AND device not logged in -> mint yields nothing. The
       // run must still spawn with the original (empty) jwt rather than being

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.test.ts
@@ -46,6 +46,12 @@ vi.mock('@/server/modules/Mecha', () => ({
   ]),
 }));
 
+// Mock JWT signing — signing needs JWKS_KEY which isn't set in the test env.
+vi.mock('@/libs/trpc/utils/internalJwt', () => ({
+  signOperationJwt: vi.fn().mockResolvedValue('mock-operation-jwt'),
+  signUserJWT: vi.fn().mockResolvedValue('mock-user-jwt'),
+}));
+
 // Mock AiChatService to avoid S3 dependency
 vi.mock('@/server/services/aiChat', () => ({
   AiChatService: vi.fn().mockImplementation(() => ({
@@ -431,6 +437,49 @@ describe('AI Agent Router Integration Tests', () => {
       // Should have 1 assistant message with parentId pointing to the user message
       expect(assistantMessages).toHaveLength(1);
       expect(assistantMessages[0].parentId).toBe(userMsg.id);
+    });
+  });
+
+  describe('mintHeteroOperationToken', () => {
+    it('mints a hetero-operation token when the topic has a running operation', async () => {
+      const [topic] = await serverDB
+        .insert(topics)
+        .values({
+          title: 'Running Topic',
+          agentId: testAgentId,
+          metadata: {
+            runningOperation: { assistantMessageId: 'msg-running', operationId: 'op-running' },
+          },
+          sessionId: testSessionId,
+          userId,
+        })
+        .returning();
+
+      const { signOperationJwt } = await import('@/libs/trpc/utils/internalJwt');
+      const caller = aiAgentRouter.createCaller(createTestContext());
+
+      const result = await caller.mintHeteroOperationToken({ topicId: topic.id });
+
+      expect(result.token).toBe('mock-operation-jwt');
+      expect(signOperationJwt).toHaveBeenCalledWith(userId);
+    });
+
+    it('throws NOT_FOUND when the topic has no running operation', async () => {
+      const [topic] = await serverDB
+        .insert(topics)
+        .values({
+          title: 'Idle Topic',
+          agentId: testAgentId,
+          sessionId: testSessionId,
+          userId,
+        })
+        .returning();
+
+      const caller = aiAgentRouter.createCaller(createTestContext());
+
+      await expect(caller.mintHeteroOperationToken({ topicId: topic.id })).rejects.toThrow(
+        'No running operation found on this topic',
+      );
     });
   });
 });

--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -21,7 +21,7 @@ import { TopicModel } from '@/database/models/topic';
 import { topics } from '@/database/schemas';
 import { heteroAuthedProcedure, router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
-import { signUserJWT } from '@/libs/trpc/utils/internalJwt';
+import { signOperationJwt, signUserJWT } from '@/libs/trpc/utils/internalJwt';
 import { AgentRuntimeService } from '@/server/services/agentRuntime';
 import { AiAgentService } from '@/server/services/aiAgent';
 import { AiChatService } from '@/server/services/aiChat';
@@ -1495,6 +1495,35 @@ export const aiAgentRouter = router({
       }
 
       const token = await signUserJWT(ctx.userId);
+
+      return { token };
+    }),
+
+  /**
+   * Mint a fresh operation-scoped JWT for a device that received a remote
+   * agent-run dispatch (remote Claude Code / Codex). The device authenticates
+   * with its own logged-in user session (a normal OIDC token) and exchanges it
+   * for a `hetero-operation` JWT — the only token `heteroIngest` /
+   * `heteroFinish` accept — so the spawned `lh hetero exec` can stream results
+   * back without requiring a separate `lh login` on the device.
+   *
+   * Used by the desktop gateway path as a fallback when the dispatch did not
+   * carry a usable `jwt`. Gated on the topic belonging to the caller and having
+   * a running operation, mirroring `refreshGatewayToken`.
+   */
+  mintHeteroOperationToken: aiAgentProcedure
+    .input(z.object({ topicId: z.string() }))
+    .mutation(async ({ input, ctx }) => {
+      const topic = await ctx.topicModel.findById(input.topicId);
+
+      if (!topic?.metadata?.runningOperation) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'No running operation found on this topic',
+        });
+      }
+
+      const token = await signOperationJwt(ctx.userId);
 
       return { token };
     }),

--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -1508,10 +1508,14 @@ export const aiAgentRouter = router({
    * back without requiring a separate `lh login` on the device.
    *
    * Used by the desktop gateway path as a fallback when the dispatch did not
-   * carry a usable `jwt`. Gated on the topic belonging to the caller and having
-   * a running operation, mirroring `refreshGatewayToken`.
+   * carry a usable `jwt`. Uses `aiAgentWriteProcedure` so the caller must hold
+   * the same `message:create` scope that `execAgent` requires — the minted
+   * token can write to / finalize the run via heteroIngest/heteroFinish, so a
+   * read-only workspace member must not be able to obtain one. Also gated on the
+   * topic belonging to the caller and having a running operation, mirroring
+   * `refreshGatewayToken`.
    */
-  mintHeteroOperationToken: aiAgentProcedure
+  mintHeteroOperationToken: aiAgentWriteProcedure
     .input(z.object({ topicId: z.string() }))
     .mutation(async ({ input, ctx }) => {
       const topic = await ctx.topicModel.findById(input.topicId);

--- a/packages/device-gateway-client/src/types.ts
+++ b/packages/device-gateway-client/src/types.ts
@@ -222,6 +222,14 @@ export interface AgentRunRequestMessage {
   systemContext?: string;
   topicId: string;
   type: 'agent_run_request';
+  /**
+   * Workspace that owns the dispatched topic, when the run targets a workspace
+   * device. The device forwards it as `X-Workspace-Id` when calling back to the
+   * server (e.g. minting a fallback operation JWT) so workspace-owned topics
+   * resolve instead of falling back to personal mode. Omitted for personal runs
+   * and by older servers.
+   */
+  workspaceId?: string;
 }
 
 /** Client → Server: acknowledgement for an agent_run_request. */


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

When a remote Claude Code / Codex run is dispatched to a **desktop device** through the gateway, the desktop spawns `lh hetero exec`, which streams results back to the cloud via `aiAgent.heteroIngest` / `heteroFinish`. Those endpoints are gated by `heteroOperationAuth`, which accepts **only** tokens with `purpose: 'hetero-operation'`. The desktop forwards the operation JWT it receives in the dispatch (`request.jwt`) as `LOBEHUB_JWT`.

The problem: when the dispatch arrives **without a usable `jwt`**, the CLI falls back to its own credential file (`~/.lobehub/credentials.json`), which is empty for a user who only logged in on the **desktop app** (the desktop stores its session in Electron `safeStorage`, a completely separate store). The CLI then prompts `lh login` even though the desktop is logged in — the desktop session is never reused.

**Why not just inject the desktop's access token directly?** A normal user OIDC token is rejected by `heteroIngest`/`heteroFinish` (wrong `purpose`), and the desktop can't self-sign a `hetero-operation` token because the JWKS private key is server-only.

**Fix:** add a fallback that exchanges the desktop's own logged-in session for a fresh operation JWT:

- **Server** — new `aiAgent.mintHeteroOperationToken` procedure (normal `userAuth`). Given a `topicId` with a running operation (ownership-gated, mirrors `refreshGatewayToken`), it returns `signOperationJwt(userId)`.
- **Desktop** — `GatewayConnectionCtr.executeAgentRun` now resolves the JWT as `request.jwt || mintOperationJwt(...)`. The mint call authenticates with the device's `safeStorage` access token and injects the returned `hetero-operation` JWT into the spawned CLI. If the device isn't logged in / the mint fails, the run is rejected (graceful, no unauthenticated spawn).

This reuses the desktop login (no separate `lh login`) while keeping the narrow-scope, 4h operation token the CLI subprocess actually requires. It also makes the device independent of the gateway forwarding `request.jwt`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `apps/server/src/routers/lambda/__tests__/aiAgent.test.ts` — `mintHeteroOperationToken` mints when a running operation exists; throws `NOT_FOUND` otherwise.
- `apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts` — dispatch without `jwt` mints from the device session and forwards the minted token to `spawnLhHeteroExec`; rejects the run when the device is not logged in.
- `bun run type-check` clean.

#### 📝 Additional Information

Single PR is safe despite spanning server + desktop: they merge atomically to `canary`, and at runtime the cloud server (deployed from `canary`) goes live before the desktop change reaches users via an app release, so the endpoint always exists before any client calls it. The desktop change also degrades gracefully (404 → rejected run, no regression) if the endpoint is ever absent.