### PR TITLE
🐛 fix: allow disabling zhipu tool stream

### DIFF
--- a/packages/model-runtime/src/providers/zhipu/index.test.ts
+++ b/packages/model-runtime/src/providers/zhipu/index.test.ts
@@ -439,6 +439,29 @@ describe('LobeZhipuAI - custom features', () => {
 
         expect(payload.tool_stream).toBe(expected);
       });
+
+      it('should allow compatible channels to disable tool_stream without disabling Zhipu payload handling', () => {
+        const payload = params.chatCompletion.handlePayload(
+          {
+            max_tokens: 4096,
+            messages: [
+              { content: 'Hello', reasoning: { content: 'cached thought' }, role: 'user' },
+            ],
+            model: 'glm-5.2',
+            preserveThinking: true,
+            stream: true,
+            temperature: 0.5,
+            thinking: { type: 'enabled' },
+          },
+          { disableToolStream: true },
+        );
+
+        expect(payload.tool_stream).toBeUndefined();
+        expect(payload.thinking).toEqual({ clear_thinking: false, type: 'enabled' });
+        expect(payload.messages).toEqual([
+          { content: 'Hello', reasoning_content: 'cached thought', role: 'user' },
+        ]);
+      });
     });
 
     describe('GLM-5.2 optional params', () => {

--- a/packages/model-runtime/src/providers/zhipu/index.ts
+++ b/packages/model-runtime/src/providers/zhipu/index.ts
@@ -19,10 +19,15 @@ export interface ZhipuModelCard {
   modelName: string;
 }
 
+interface ZhipuRuntimeOptions {
+  [key: string]: unknown;
+  disableToolStream?: boolean;
+}
+
 export const params = {
   baseURL: 'https://open.bigmodel.cn/api/paas/v4',
   chatCompletion: {
-    handlePayload: (payload) => {
+    handlePayload: (payload, options: ZhipuRuntimeOptions = {}) => {
       const {
         enabledSearch,
         max_tokens,
@@ -106,6 +111,10 @@ export const params = {
         },
       );
 
+      // Example: Fireworks serves GLM-5.2 but rejects the Z.ai-only `tool_stream` field.
+      const shouldEnableToolStream =
+        !options.disableToolStream && stream && isToolStreamSupportedGLMModel(model);
+
       return {
         ...rest,
         ...resolvedParams,
@@ -113,7 +122,7 @@ export const params = {
         model,
         stream,
         thinking: resolvedThinking,
-        tool_stream: stream && isToolStreamSupportedGLMModel(model) ? true : undefined,
+        tool_stream: shouldEnableToolStream ? true : undefined,
         tools: zhipuTools,
       } as any;
     },
@@ -210,6 +219,6 @@ export const params = {
     return processModelList(standardModelList, MODEL_LIST_CONFIGS.zhipu, 'zhipu');
   },
   provider: ModelProvider.ZhiPu,
-} satisfies OpenAICompatibleFactoryOptions;
+} satisfies OpenAICompatibleFactoryOptions<ZhipuRuntimeOptions>;
 
-export const LobeZhipuAI = createOpenAICompatibleRuntime(params);
+export const LobeZhipuAI = createOpenAICompatibleRuntime<ZhipuRuntimeOptions>(params);


### PR DESCRIPTION
# Pull Request

## 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

## 🔗 Related Links

- Linear / GitHub issue: N/A
- Related PRs: N/A
- Reference docs / code / articles:
  - https://docs.z.ai/guides/overview/migrate-to-glm-new
  - https://docs.fireworks.ai/api-reference/post-chatcompletions
  - https://docs.fireworks.ai/guides/function-calling

## 🔀 Description of Change

Adds a Zhipu runtime option, `disableToolStream`, for OpenAI-compatible GLM channels that should keep Zhipu payload handling but reject the Z.ai-only `tool_stream` request field.

By default, supported GLM streaming requests still include `tool_stream: true`. When `disableToolStream` is set on a runtime/channel option, the provider omits `tool_stream` while preserving Zhipu-specific handling such as `thinking`, `preserveThinking`, and `reasoning_content` conversion.

## 🧭 Key Decisions / Non-goals

- Keep the request routed through the Zhipu runtime instead of switching compatible channels to a generic OpenAI runtime, so GLM-specific payload handling remains active.
- Make this a runtime option rather than a base URL special case, so any compatible upstream that rejects `tool_stream` can opt out explicitly.
- This does not change the default behavior for native Z.ai/BigModel GLM routes.

## 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

### Automated Tests

- `cd lobehub/packages/model-runtime && rtk vitest run src/providers/zhipu/index.test.ts`
- `vscode-cli get-diagnostics --not-recommend-file-paths lobehub/packages/model-runtime/src/providers/zhipu/index.ts lobehub/packages/model-runtime/src/providers/zhipu/index.test.ts`
- `git -C lobehub diff --check`

### Manual Verification

- N/A

### Post-Deploy Verification

- For a compatible GLM channel that rejects `tool_stream`, set `disableToolStream: true` in its runtime option and verify streaming chat requests no longer fail with an unknown `tool_stream` parameter.

## 📸 Screenshots / Videos

N/A

## 🚀 Rollout / Deployment Checklist

- [ ] Environment variables: N/A
- [ ] Redis / Edge Config / feature flags: Set `disableToolStream: true` only on compatible Zhipu runtime channels that reject the `tool_stream` field.
- [ ] Database migration or data backfill: N/A
- [ ] Third-party console changes: N/A
- [ ] Rollback plan: Remove the channel option or roll back this runtime change.

## 📝 Additional Information

N/A
