### PR TITLE
🐛 fix(devtools): prevent feature flag rows from collapsing

### DIFF
--- a/src/features/DevFeatureFlagPanel/FlagRow.tsx
+++ b/src/features/DevFeatureFlagPanel/FlagRow.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Flexbox, Text } from '@lobehub/ui';
-import { Tabs } from '@lobehub/ui/base-ui';
+import { Segmented } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { snakeCase } from 'es-toolkit/compat';
 import { memo, useMemo } from 'react';
@@ -12,6 +12,9 @@ import { type FeatureFlagKey } from '@/store/serverConfig/slices/featureFlagOver
 type SegmentedValue = 'true' | 'false' | 'inherit';
 
 const styles = createStaticStyles(({ css }) => ({
+  control: css`
+    flex: none;
+  `,
   meta: css`
     font-family: ${cssVar.fontFamilyCode};
     font-size: 10px;
@@ -53,9 +56,9 @@ const styles = createStaticStyles(({ css }) => ({
 }));
 
 const segmentOptions = [
-  { key: 'true' as const, label: 'true' },
-  { key: 'false' as const, label: 'false' },
-  { key: 'inherit' as const, label: 'inherit' },
+  { label: 'true', value: 'true' as const },
+  { label: 'false', value: 'false' as const },
+  { label: 'inherit', value: 'inherit' as const },
 ];
 
 interface FlagRowProps {
@@ -93,11 +96,12 @@ const FlagRow = memo<FlagRowProps>(({ flagKey }) => {
         </Text>
         <span className={styles.meta}>server: {String(original)}</span>
       </Flexbox>
-      <Tabs
-        activeKey={value}
-        items={segmentOptions}
+      <Segmented
+        className={styles.control}
+        options={segmentOptions}
         size={'small'}
-        onChange={(key) => handleChange(key as SegmentedValue)}
+        value={value}
+        onChange={handleChange}
       />
     </div>
   );


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No related issue found.

#### 🔀 Description of Change

- Replaces the feature flag override row control from base-ui `Tabs` to base-ui `Segmented`.
- Keeps the tri-state override selector at content width with `flex: none`, preventing it from forcing the flag-name column to collapse.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Validation performed:

- `bunx eslint src/features/DevFeatureFlagPanel/FlagRow.tsx`
- `git diff --check`
- Opened the SPA debug proxy in Chrome, enabled `LOBE_DEV_FEATURE_FLAG_PANEL_ENABLED`, opened the dev feature flag panel, and verified rows no longer wrap flag names into one-character columns.

Note: full `bun run type-check` still reports existing unrelated monorepo type issues; filtering for `DevFeatureFlagPanel|FlagRow` produced no related errors.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| ![Before: collapsed feature flag row labels](https://litter.catbox.moe/hlte9x.jpg) | ![After: feature flag rows use segmented controls without collapsing labels](https://litter.catbox.moe/u7hulh.png) |

#### 📝 Additional Information

The prior `Tabs` root has a page-navigation layout contract and uses full width. This row only needs a compact three-state value selector, so `Segmented` matches the interaction semantics and avoids the layout pressure.