### PR TITLE
♻️ refactor(settings): Analytics telemetry switch → @lobehub/ui/base-ui Switch

### DIFF
--- a/src/routes/(main)/settings/about/features/Analytics.tsx
+++ b/src/routes/(main)/settings/about/features/Analytics.tsx
@@ -3,7 +3,7 @@
 import { BRANDING_NAME } from '@lobechat/business-const';
 import { type FormGroupItemType } from '@lobehub/ui';
 import { Form } from '@lobehub/ui';
-import { Switch } from 'antd';
+import { Switch } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 


### PR DESCRIPTION
## 💻 Change Type

- [x] ♻️ refactor

## 🔀 Description of Change

Per the component-priority guideline (base-ui first, then root, then antd — see `.agents/skills/react/SKILL.md`), swap the antd `Switch` used inside the Analytics FormGroup item for the `@lobehub/ui/base-ui` `Switch`. Props are compatible (`checked` + `onChange` signature unchanged), so this is a straight import swap.

## 📷 Screenshots

N/A — visually equivalent.

## ✅ Checklist

- [x] Component priority: base-ui used where available
- [x] No prop/behaviour changes