### PR TITLE
🐛 fix(agent-group): inject orchestration tools when a user agent runs as group supervisor

### DIFF
--- a/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -1,4 +1,6 @@
 // @vitest-environment node
+import { GroupAgentBuilderManifest } from '@lobechat/builtin-tool-group-agent-builder';
+import { GroupManagementManifest } from '@lobechat/builtin-tool-group-management';
 import { KnowledgeBaseManifest } from '@lobechat/builtin-tool-knowledge-base';
 import { LobeAgentManifest } from '@lobechat/builtin-tool-lobe-agent';
 import { LocalSystemManifest } from '@lobechat/builtin-tool-local-system';
@@ -321,6 +323,48 @@ describe('createServerAgentToolsEngine', () => {
     });
 
     expect(result.enabledToolIds).not.toContain(KnowledgeBaseManifest.identifier);
+  });
+
+  it('should auto-enable group orchestration tools when isGroupSupervisor is true', () => {
+    const context = createMockContext();
+    const engine = createServerAgentToolsEngine(context, {
+      // Supervisor agent does not declare the group tools itself — they ship
+      // only with the builtin group-supervisor, so the engine must inject them.
+      agentConfig: { plugins: [] },
+      isGroupSupervisor: true,
+      model: 'gpt-4',
+      provider: 'openai',
+    });
+
+    const result = engine.generateToolsDetailed({
+      toolIds: [],
+      model: 'gpt-4',
+      provider: 'openai',
+    });
+
+    expect(result.enabledToolIds).toContain(GroupManagementManifest.identifier);
+    // group-agent-builder has no server runtime, so it is deliberately NOT
+    // advertised on a server-side supervisor run (it would throw if called).
+    expect(result.enabledToolIds).not.toContain(GroupAgentBuilderManifest.identifier);
+  });
+
+  it('should not enable group orchestration tools for a non-supervisor run', () => {
+    const context = createMockContext();
+    const engine = createServerAgentToolsEngine(context, {
+      agentConfig: { plugins: [] },
+      isGroupSupervisor: false,
+      model: 'gpt-4',
+      provider: 'openai',
+    });
+
+    const result = engine.generateToolsDetailed({
+      toolIds: [],
+      model: 'gpt-4',
+      provider: 'openai',
+    });
+
+    expect(result.enabledToolIds).not.toContain(GroupManagementManifest.identifier);
+    expect(result.enabledToolIds).not.toContain(GroupAgentBuilderManifest.identifier);
   });
 
   it('should include default tools (WebBrowsing, KnowledgeBase)', () => {

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
@@ -21,6 +21,7 @@ import {
   builtinTools,
   chatModeAllowedToolIds,
   defaultToolIds,
+  groupSupervisorToolIds,
 } from '@lobechat/builtin-tools';
 import { createEnableChecker, type LobeToolManifest } from '@lobechat/context-engine';
 import { ToolsEngine } from '@lobechat/context-engine';
@@ -136,6 +137,7 @@ export const createServerAgentToolsEngine = (
     globalMemoryEnabled = false,
     hasEnabledKnowledgeBases = false,
     isBotConversation = false,
+    isGroupSupervisor = false,
     model,
     provider,
   } = params;
@@ -230,6 +232,10 @@ export const createServerAgentToolsEngine = (
     [MemoryManifest.identifier]: globalMemoryEnabled,
     // Only auto-enable in bot conversations; otherwise let user's plugin selection take effect
     ...(isBotConversation && { [MessageManifest.identifier]: true }),
+    // Group supervisor: enable the orchestration toolset (see
+    // `groupSupervisorToolIds`). The same list also feeds the candidate set
+    // below, so the bundle has a single source of truth.
+    ...(isGroupSupervisor && Object.fromEntries(groupSupervisorToolIds.map((id) => [id, true]))),
     // Remote-device proxy: shown only for device-capable targets when the
     // server has a proxy, no specific device is auto-activated yet, AND the
     // user has NOT explicitly selected a device. Once a device is explicitly
@@ -258,11 +264,16 @@ export const createServerAgentToolsEngine = (
     builtinTools: buildAllowedBuiltinTools({ canUseDevice, disableLocalSystem }),
     // Add default tools based on configuration. Custom mode = exactly the
     // agent's plugins; chat mode = strict allow-list; agent mode = full defaults.
+    // Agent mode: the supervisor's orchestration tools are neither in the
+    // agent's plugins nor in `defaultToolIds`, so add them to the candidate set
+    // here (the `agentModeRules` above then enable them). Enabling a tool that
+    // isn't a candidate is a no-op — the checker only filters
+    // `union(toolIds, defaultToolIds)`.
     defaultToolIds: isCustomMode
       ? (agentConfig.plugins ?? [])
       : isChatMode
         ? chatModeAllowedToolIds
-        : defaultToolIds,
+        : [...defaultToolIds, ...(isGroupSupervisor ? groupSupervisorToolIds : [])],
     // Post-merge wall: a plugin or Skill/Composio manifest claiming a
     // device identifier survives `buildAllowedBuiltinTools` (which only
     // filters the builtin source). Excluding the identifiers here drops

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/types.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/types.ts
@@ -105,6 +105,14 @@ export interface ServerCreateAgentToolsEngineParams {
   hasEnabledKnowledgeBases?: boolean;
   /** Whether the request originates from a bot conversation (auto-enables message tool) */
   isBotConversation?: boolean;
+  /**
+   * Whether this run is the group's supervisor (orchestrationRole === 'supervisor').
+   * The group-orchestration tools ship only with the builtin group-supervisor
+   * agent, so a user agent acting as supervisor would otherwise have no tool to
+   * dispatch members and would silently degrade to a single-agent monologue.
+   * When true the engine auto-enables the group-management + agent-builder tools.
+   */
+  isGroupSupervisor?: boolean;
   /** Model name for function calling compatibility check */
   model: string;
   /** Provider name for function calling compatibility check */

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -51,6 +51,7 @@ import { AgentModel } from '@/database/models/agent';
 import { AgentOperationModel } from '@/database/models/agentOperation';
 import { AgentSkillModel } from '@/database/models/agentSkill';
 import { AiModelModel } from '@/database/models/aiModel';
+import { ChatGroupModel } from '@/database/models/chatGroup';
 import { ConnectorModel } from '@/database/models/connector';
 import { ConnectorToolModel } from '@/database/models/connectorTool';
 import { DeviceModel } from '@/database/models/device';
@@ -2199,6 +2200,31 @@ export class AiAgentService {
         activeDeviceId ?? 'none',
       );
 
+      // `appContext.orchestrationRole` is client-supplied (the execAgent /
+      // execAgents schema accepts it, and execGroupAgent stamps it for whatever
+      // agentId the caller passed), so it must NOT alone authorize the
+      // group-orchestration toolset — otherwise any run marked
+      // `{ orchestrationRole: 'supervisor', groupId }` could dispatch group
+      // members. Verify against the persisted, ownership-scoped membership that
+      // the executing agent really is this group's supervisor.
+      let isGroupSupervisor = false;
+      if (appContext?.orchestrationRole === 'supervisor' && appContext?.groupId) {
+        const groupAgents = await new ChatGroupModel(
+          this.db,
+          this.userId,
+          this.workspaceId,
+        ).getGroupAgents(appContext.groupId);
+        isGroupSupervisor = groupAgents.some(
+          (member) => member.agentId === resolvedAgentId && member.role === 'supervisor',
+        );
+        if (!isGroupSupervisor)
+          log(
+            'execAgent: orchestrationRole=supervisor but agent %s is not the supervisor of group %s — denying group tools',
+            resolvedAgentId,
+            appContext.groupId,
+          );
+      }
+
       const toolsEngine = createServerAgentToolsEngine(toolsContext, {
         additionalManifests: [
           ...lobehubSkillManifests,
@@ -2223,6 +2249,7 @@ export class AiAgentService {
         globalMemoryEnabled,
         hasEnabledKnowledgeBases,
         isBotConversation,
+        isGroupSupervisor,
         model,
         provider,
       });

--- a/packages/builtin-tools/src/index.ts
+++ b/packages/builtin-tools/src/index.ts
@@ -105,6 +105,27 @@ export const chatModeAllowedToolIds = [
 ];
 
 /**
+ * Tool IDs that make up the group supervisor's orchestration toolset:
+ * dispatching members (speak / broadcast / delegate / executeAgentTask).
+ *
+ * These ship only with the builtin `group-supervisor` agent, but a group can
+ * run a user's own agent as supervisor (`execGroupAgent` passes the configured
+ * supervisor agentId, not the builtin slug). Such a run is verified as the
+ * group's supervisor, and the tools engine uses this list — the single source
+ * of truth — to both add these tools to the agent-mode candidate set and enable
+ * them. Without it the supervisor has no way to dispatch members and degrades
+ * to a single-agent monologue.
+ *
+ * NOTE: `lobe-group-agent-builder` (member CRUD: searchAgent / inviteAgent /
+ * createAgent) is deliberately excluded — it has no server runtime registered
+ * (`apps/server/.../serverRuntimes`), so advertising it on a server-side
+ * supervisor run would throw `Builtin tool "lobe-group-agent-builder" is not
+ * implemented` the moment the model called it. Add it back here once a server
+ * runtime exists.
+ */
+export const groupSupervisorToolIds = [GroupManagementManifest.identifier];
+
+/**
  * Tool IDs whose enabled state is decided by runtime / system conditions
  * (e.g. cloud runtime, agent has documents attached, knowledge base configured,
  * desktop gateway available), NOT by the user's plugin selection.

--- a/packages/model-runtime/src/providers/aihubmix/index.ts
+++ b/packages/model-runtime/src/providers/aihubmix/index.ts
@@ -148,7 +148,7 @@ const DEFAULT_BASE_URL = 'https://aihubmix.com';
 // Resolve the gateway for a request from the configured baseURL (default
 // DEFAULT_BASE_URL), stripping a trailing version suffix (e.g. /v1) so the
 // per-route suffixes below aren't doubled (…/v1/v1, …/v1/gemini).
-const resolveBaseURL = (options: { baseURL?: string }) =>
+const resolveBaseURL = (options: { baseURL?: string | null }) =>
   options.baseURL?.trim().replace(/\/v\d+[a-z]*\/?$/, '') || DEFAULT_BASE_URL;
 
 export const params: CreateRouterRuntimeOptions = {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

A chat group can run a **user's own agent** as supervisor — `execGroupAgent` passes the configured supervisor `agentId`, not the builtin `group-supervisor` slug. The group-orchestration tools (`lobe-group-management`, `lobe-group-agent-builder`) ship **only** with that builtin agent's plugins and are never dynamically injected.

As a result, such a run got the supervisor **role/prompt** (`orchestrationRole: 'supervisor'`, `metadata.isSupervisor: true`) but **no tool to dispatch members** — so the supervisor silently degraded to a single-agent monologue, role-playing every "team member" itself in one LLM thread instead of fanning out to the participant agents.

Notably this is **not** a groupId-propagation bug: `groupId`, `topics.group_id` and `agent_operations.chat_group_id` were all written correctly. The only thing missing was the toolset.

**Fix** — resolve the toolset at the tools-resolution layer (`AgentToolsEngine`), not via imperative plugin mutation in `execAgent`:

- Add a single named bundle `groupSupervisorToolIds` in `@lobechat/builtin-tools` (sibling of `alwaysOnToolIds` / `chatModeAllowedToolIds`) — the single source of truth for the supervisor orchestration toolset.
- The server tools engine adds it to the **agent-mode candidate set** and **enables it** whenever the run is the supervisor (`isGroupSupervisor`), mirroring the existing `isBotConversation` → message-tool pattern. Both the candidate injection and the enable rule derive from the same bundle, so future changes to the toolset are a one-line edit.
- Plumb `isGroupSupervisor` from `execAgent` (`appContext.orchestrationRole === 'supervisor' && groupId`).

Non-supervisor agents are unaffected: the tools become inert candidates with no enable rule (the enable checker disables any candidate not present in its rules map).

#### 🧪 How to Test

- [x] Added/updated tests

Added two unit tests to `AgentToolsEngine`: a supervisor run (`isGroupSupervisor: true`, empty plugins) auto-enables both group tools; a non-supervisor run does not. `bun run type-check` and the full `AgentToolsEngine` suite (41 tests) pass.

#### 📝 Additional Information

Discovered while diagnosing a group brainstorm topic where the supervisor answered alone despite a fully-configured 9-member group.