### PR TITLE
✨ feat(remote-agent): reuse desktop session for remote CC instead of operation JWT

### DIFF
--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -292,6 +292,20 @@ export default class GatewayConnectionCtr extends ControllerModule {
         return { reason: 'Remote server URL not configured', status: 'rejected' };
       }
 
+      // Reuse this device's own logged-in session as the run identity. The
+      // access token is a full user OIDC token (7-day TTL, longer than any run),
+      // which heteroIngest/heteroFinish now accept (ownership-gated), AND which
+      // gives the spawned Claude Code's nested `lh` calls a real login state —
+      // unlike the narrow `hetero-operation` token, which only works for the
+      // ingest endpoints. We deliberately do NOT pass the refresh token to the
+      // CLI: the device stays the single refresher (refresh tokens rotate), and
+      // the 7-day access token outlives the run so no mid-run refresh is needed.
+      //
+      // Fall back to the dispatched `request.jwt` when the device has no access
+      // token (e.g. not logged in), preserving the prior behavior gracefully.
+      const accessToken = await this.remoteServerConfigCtr.getAccessToken();
+      const jwt = accessToken || request.jwt;
+
       // Fire-and-forget: lh hetero exec handles spawn -> adapt ->
       // BatchIngester -> heteroIngest/heteroFinish -> server -> Gateway -> clients.
       // Same command as spawnHeteroSandbox() on the server side.
@@ -300,7 +314,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
         args: request.args,
         cwd: request.cwd,
         imageList: request.imageList,
-        jwt: request.jwt,
+        jwt,
         operationId: request.operationId,
         prompt: request.prompt,
         resumeSessionId: request.resumeSessionId,

--- a/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
@@ -887,12 +887,42 @@ describe('GatewayConnectionCtr', () => {
       expect(mockHeterogeneousAgentCtr.spawnLhHeteroExec).toHaveBeenCalledWith(
         expect.objectContaining({
           agentType: 'openclaw',
-          jwt: 'mock-jwt',
+          // Reuses the device's own session token as the run identity, not the
+          // dispatched operation jwt.
+          jwt: 'mock-access-token',
           operationId: 'op-xyz',
           prompt: 'hello',
           serverUrl: 'https://server.example.com',
           topicId: 'topic-1',
         }),
+      );
+    });
+
+    it('reuses the device access token as the run jwt instead of request.jwt', async () => {
+      const client = await connectAndOpen();
+      client.simulateAgentRunRequest('claude-code', 'op-auth', 'hi', 'dispatched-operation-jwt');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockHeterogeneousAgentCtr.spawnLhHeteroExec).toHaveBeenCalledWith(
+        expect.objectContaining({ jwt: 'mock-access-token' }),
+      );
+    });
+
+    it('falls back to request.jwt when the device has no access token', async () => {
+      const client = await connectAndOpen();
+      // Set after connect so the auto-connect getAccessToken call isn't the one
+      // that returns null — only the executeAgentRun lookup should see no token.
+      vi.mocked(mockRemoteServerConfigCtr.getAccessToken).mockResolvedValueOnce(null);
+      client.simulateAgentRunRequest(
+        'claude-code',
+        'op-fallback',
+        'hi',
+        'dispatched-operation-jwt',
+      );
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockHeterogeneousAgentCtr.spawnLhHeteroExec).toHaveBeenCalledWith(
+        expect.objectContaining({ jwt: 'dispatched-operation-jwt' }),
       );
     });
 

--- a/apps/server/src/routers/lambda/__tests__/aiAgent.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiAgent.test.ts
@@ -433,4 +433,58 @@ describe('AI Agent Router Integration Tests', () => {
       expect(assistantMessages[0].parentId).toBe(userMsg.id);
     });
   });
+
+  describe('heteroIngest/heteroFinish ownership guard', () => {
+    // Build a context that drives heteroOperationAuth to the desired kind:
+    // - omit `purpose` → a normal user OIDC token → kind 'user' (ownership-gated)
+    // - `purpose: 'hetero-operation'` → the server-minted token → kind 'operation'
+    const heteroCtx = (opts: { purpose?: string; sub?: string } = {}) => {
+      const sub = opts.sub ?? userId;
+      return {
+        jwtPayload: { userId: sub },
+        oidcAuth: { sub, ...(opts.purpose ? { purpose: opts.purpose } : {}) },
+        userId: sub,
+      };
+    };
+
+    // A schema-valid event so the request passes input validation and reaches
+    // the ownership guard (the guard throws before any event is processed).
+    const sampleEvent = {
+      data: {},
+      operationId: 'op-x',
+      stepIndex: 0,
+      timestamp: 1,
+      type: 'stream_chunk' as const,
+    };
+
+    it('rejects an owner token targeting a topic it does not own', async () => {
+      const caller = aiAgentRouter.createCaller(heteroCtx() as any);
+
+      await expect(
+        caller.heteroIngest({
+          agentType: 'claude-code',
+          events: [sampleEvent],
+          operationId: 'op-x',
+          topicId: 'topic-not-owned',
+        }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+
+    it('rejects an owner token on heteroFinish for a topic it does not own', async () => {
+      const caller = aiAgentRouter.createCaller(heteroCtx() as any);
+
+      await expect(
+        caller.heteroFinish({
+          agentType: 'claude-code',
+          operationId: 'op-x',
+          result: 'success',
+          topicId: 'topic-not-owned',
+        }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+
+    // The operation-token path (kind 'operation', whose sub may be a workspaceId
+    // that never matches topics.userId) is intentionally exempt from this guard;
+    // that kind assignment is covered by heteroOperationAuth.test.ts.
+  });
 });

--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -1213,6 +1213,19 @@ export const aiAgentRouter = router({
         .from(topics)
         .where(and(eq(topics.id, topicId), eq(topics.userId, ctx.userId)))
         .limit(1);
+
+      // Owner-token callers (a logged-in desktop reusing its own session) must
+      // prove they own the target topic — `topicRow` is already filtered by
+      // `userId`, so a missing row means the topic isn't theirs. The
+      // operation-token path is exempt: its `sub` may be a workspaceId that
+      // never matches `topics.userId`, and it's trusted as server-minted.
+      if (ctx.heteroAuthKind === 'user' && !topicRow) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Topic not found or not owned by the caller',
+        });
+      }
+
       const wsId = topicRow?.workspaceId ?? undefined;
       const heteroService = new HeterogeneousAgentService(ctx.serverDB, ctx.userId, {
         workspaceId: wsId,
@@ -1230,6 +1243,9 @@ export const aiAgentRouter = router({
       });
       return { ack: true as const };
     } catch (error: any) {
+      // Preserve deliberate auth errors (e.g. the ownership FORBIDDEN) instead
+      // of masking them as a generic 500.
+      if (error instanceof TRPCError) throw error;
       log('heteroIngest failed: %s', error?.message);
       throw new TRPCError({
         cause: error,
@@ -1258,6 +1274,15 @@ export const aiAgentRouter = router({
         .from(topics)
         .where(and(eq(topics.id, topicId), eq(topics.userId, ctx.userId)))
         .limit(1);
+
+      // See heteroIngest: owner tokens must own the topic; operation tokens are exempt.
+      if (ctx.heteroAuthKind === 'user' && !topicRow) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Topic not found or not owned by the caller',
+        });
+      }
+
       const wsId = topicRow?.workspaceId ?? undefined;
       const heteroService = new HeterogeneousAgentService(ctx.serverDB, ctx.userId, {
         workspaceId: wsId,
@@ -1279,6 +1304,9 @@ export const aiAgentRouter = router({
 
       return { ack: true as const };
     } catch (err: any) {
+      // Preserve deliberate auth errors (e.g. the ownership FORBIDDEN) instead
+      // of masking them as a generic 500.
+      if (err instanceof TRPCError) throw err;
       log('heteroFinish failed: %s', err?.message);
       throw new TRPCError({
         cause: err,

--- a/packages/trpc/src/lambda/middleware/__tests__/heteroOperationAuth.test.ts
+++ b/packages/trpc/src/lambda/middleware/__tests__/heteroOperationAuth.test.ts
@@ -1,4 +1,3 @@
-import { TRPCError } from '@trpc/server';
 import { describe, expect, it } from 'vitest';
 
 import { createCallerFactory } from '@/libs/trpc/lambda';
@@ -8,45 +7,55 @@ import { heteroOperationAuth } from '../heteroOperationAuth';
 
 // Minimal router that exercises heteroOperationAuth
 const testRouter = trpc.router({
-  ping: trpc.procedure.use(heteroOperationAuth).query(({ ctx }) => ctx.userId),
+  ping: trpc.procedure
+    .use(heteroOperationAuth)
+    .query(({ ctx }) => ({ kind: (ctx as any).heteroAuthKind, userId: ctx.userId })),
 });
 
 const createCaller = createCallerFactory(testRouter);
 
 describe('heteroOperationAuth middleware', () => {
-  it('passes through and exposes userId when purpose is hetero-operation', async () => {
+  it('accepts a hetero-operation token as kind "operation"', async () => {
     const caller = createCaller({
       oidcAuth: { purpose: 'hetero-operation', sub: 'user-abc' },
     } as any);
 
     const result = await caller.ping();
 
-    expect(result).toBe('user-abc');
+    expect(result).toEqual({ kind: 'operation', userId: 'user-abc' });
+  });
+
+  it('accepts a normal user OIDC token (no purpose) as kind "user"', async () => {
+    const caller = createCaller({
+      oidcAuth: { sub: 'user-abc' },
+    } as any);
+
+    const result = await caller.ping();
+
+    expect(result).toEqual({ kind: 'user', userId: 'user-abc' });
+  });
+
+  it('accepts a cli-sandbox token as kind "user"', async () => {
+    const caller = createCaller({
+      oidcAuth: { purpose: 'cli-sandbox', sub: 'user-abc' },
+    } as any);
+
+    const result = await caller.ping();
+
+    expect(result).toEqual({ kind: 'user', userId: 'user-abc' });
   });
 
   it('rejects when oidcAuth is absent', async () => {
     const caller = createCaller({} as any);
 
-    await expect(caller.ping()).rejects.toMatchObject({
-      code: 'UNAUTHORIZED',
-    });
+    await expect(caller.ping()).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 
-  it('rejects a cli-sandbox token (wrong purpose)', async () => {
+  it('rejects when oidcAuth has no sub', async () => {
     const caller = createCaller({
-      oidcAuth: { purpose: 'cli-sandbox', sub: 'user-abc' },
+      oidcAuth: { purpose: 'hetero-operation' },
     } as any);
 
-    await expect(caller.ping()).rejects.toMatchObject({
-      code: 'UNAUTHORIZED',
-    });
-  });
-
-  it('rejects when purpose is undefined', async () => {
-    const caller = createCaller({
-      oidcAuth: { sub: 'user-abc' },
-    } as any);
-
-    await expect(caller.ping()).rejects.toThrow(TRPCError);
+    await expect(caller.ping()).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 });

--- a/packages/trpc/src/lambda/middleware/heteroOperationAuth.ts
+++ b/packages/trpc/src/lambda/middleware/heteroOperationAuth.ts
@@ -3,23 +3,38 @@ import { TRPCError } from '@trpc/server';
 import { trpc } from '../init';
 
 /**
- * Auth middleware for hetero-agent ingest/finish endpoints.
- * Accepts ONLY tokens signed with `purpose: 'hetero-operation'` (4h expiry).
- * All other tokens — including normal user OIDC tokens — are rejected,
- * so this procedure cannot be called from the browser or CLI without the
- * dedicated operation JWT issued by execAgent.
+ * Auth middleware for hetero-agent ingest/finish endpoints. Accepts two callers:
+ *
+ * - A `hetero-operation` token (4h expiry) — the narrow, server-minted JWT
+ *   issued by execAgent for the cloud sandbox / workspace device. Its `sub` may
+ *   be a userId or, for workspace runs, a workspaceId. Behaves exactly as before.
+ * - A normal user OIDC token — a logged-in desktop reusing its own session for a
+ *   remote run dispatched to it, so the spawned `lh hetero exec` can stream
+ *   results back without a server round-trip to mint a dedicated token.
+ *
+ * The owner-token path is safe because heteroIngest / heteroFinish additionally
+ * gate every write on `topics.userId === ctx.userId` (see the `heteroAuthKind`
+ * ownership check in the handlers), so an owner token can only touch its own
+ * running operation — it cannot reach another user's topic.
+ *
+ * `heteroAuthKind` is forwarded so handlers can apply the strict ownership guard
+ * to owner tokens only, while leaving the operation-token path (whose `sub` may
+ * be a workspaceId that never matches `topics.userId`) untouched.
  */
 export const heteroOperationAuth = trpc.middleware(async (opts) => {
   const { ctx, next } = opts;
 
-  if (!ctx.oidcAuth || ctx.oidcAuth.purpose !== 'hetero-operation') {
+  const sub = ctx.oidcAuth?.sub as string | undefined;
+  if (!ctx.oidcAuth || !sub) {
     throw new TRPCError({
       code: 'UNAUTHORIZED',
-      message: 'This endpoint requires a hetero-operation token',
+      message: 'This endpoint requires an authenticated token',
     });
   }
 
+  const heteroAuthKind = ctx.oidcAuth.purpose === 'hetero-operation' ? 'operation' : 'user';
+
   return next({
-    ctx: { oidcAuth: ctx.oidcAuth, userId: ctx.oidcAuth.sub as string },
+    ctx: { heteroAuthKind, oidcAuth: ctx.oidcAuth, userId: sub },
   });
 });


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

When a remote Claude Code / Codex run is dispatched to a logged-in **desktop** device, the desktop spawns `lh hetero exec`, which spawns the agent. The agent's nested `lh` calls inherit `LOBEHUB_JWT` from the env. Previously this was the narrow `hetero-operation` token, which **only** works for `heteroIngest` / `heteroFinish` — so the spawned agent's `lh` never had a real login state, and the run depended on the gateway forwarding a usable `request.jwt`.

This reuses the device's **own logged-in session** as the run identity instead:

- **desktop** — `executeAgentRun` injects the device access token (a full user OIDC token, **7-day TTL** > any run) as the spawn jwt, falling back to `request.jwt` when the device has no token. The refresh token is deliberately **not** shared: the device stays the single refresher (refresh tokens rotate, `rotateRefreshToken: true`) and the access token outlives the run, so no mid-run refresh is needed.
- **server** — `heteroOperationAuth` now also accepts a normal user OIDC token (not only `hetero-operation`), forwarding a `heteroAuthKind` discriminator. `heteroIngest` / `heteroFinish` gate the **owner-token** path on `topics.userId === ctx.userId` (`FORBIDDEN` otherwise). The operation-token path is **untouched** — its `sub` may be a workspaceId that never matches `topics.userId`, and it stays trusted as server-minted.

Net effect: the spawned agent's `lh` gets a genuine login state, while the server-minted operation token is preserved for the cloud-sandbox path. The `validateOIDCJWT` layer already accepts any JWKS-signed token regardless of `purpose`, so the user token works on all normal endpoints; the only gate that rejected it was `heteroOperationAuth`, now relaxed with an ownership check.

**Why a single PR is safe across server + desktop:** this relaxes an *existing* endpoint's auth (no new procedure / contract symbol), so both halves build independently. The only coupling is deploy-timing — the desktop's owner token needs the server relaxation live — and the cloud server (deployed from `canary`) goes live before the desktop change reaches users via an app release. The desktop also degrades gracefully (falls back to `request.jwt`).

**Out of scope:** workspace-owned devices keep the dispatched `hetero-operation` token (whose `sub` is a workspaceId and which routes callbacks to the workspace principal). That path is intentionally left untouched and evaluated separately.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `packages/trpc/.../heteroOperationAuth.test.ts` — operation token → kind `operation`; normal / cli-sandbox token → kind `user`; missing `sub` / `oidcAuth` → rejected.
- `apps/server/.../aiAgent.test.ts` — owner token hitting a topic it does not own is `FORBIDDEN` on both `heteroIngest` and `heteroFinish`.
- `apps/desktop/.../GatewayConnectionCtr.test.ts` — the run jwt is the device access token (not `request.jwt`); falls back to `request.jwt` when the device has no access token.
- Root `bun run type-check` clean (covers the trpc + server changes).

#### 📝 Additional Information

Supersedes the closed #16330 (which minted a dedicated operation token from the desktop session via a new server endpoint). This approach drops the mint endpoint entirely: relaxing the ingest gate to accept owner tokens lets one real user identity serve both the harness ingest and the agent's nested `lh`.