### PR TITLE
🐛 fix(group): inject real member roster into durable group supervisor context

### DIFF
--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -156,38 +156,6 @@ const LLM_RETRY_MAX_DELAY_MS = 30_000;
  */
 const EMPTY_COMPLETION_MAX_RETRIES = 2;
 
-const buildBotAgentGroupContext = (params: {
-  agentConfig?: any;
-  agentId?: string;
-  botContext?: unknown;
-}): AgentGroupConfig | undefined => {
-  if (!params.botContext || !params.agentId) return undefined;
-
-  const title = params.agentConfig?.title;
-  const description = params.agentConfig?.description;
-  const name = typeof title === 'string' && title.trim() ? title.trim() : 'Current Agent';
-
-  return {
-    agentMap: {
-      [params.agentId]: {
-        name,
-        role: 'participant',
-      },
-    },
-    currentAgentId: params.agentId,
-    currentAgentName: name,
-    currentAgentRole: 'participant',
-    members: [
-      {
-        id: params.agentId,
-        name,
-        role: 'participant',
-      },
-    ],
-    systemPrompt: typeof description === 'string' ? description : undefined,
-  };
-};
-
 /**
  * Output-token count at or below this — combined with no content, reasoning,
  * tool calls, or images — marks a turn as an empty completion.
@@ -1384,11 +1352,11 @@ export const createRuntimeExecutors = (
         const contextEngineInput = {
           agentDocuments,
           ...(agentBuilderContext && { agentBuilderContext }),
-          agentGroup: buildBotAgentGroupContext({
-            agentConfig,
-            agentId: state.metadata?.agentId,
-            botContext: state.metadata?.botContext ?? ctx.botContext,
-          }),
+          // The group/bot member roster is resolved once at op creation
+          // (AiAgentService.execAgent → buildGroupAgentContext) and snapshotted
+          // into op metadata, mirroring agentConfig/botContext — no per-step DB
+          // lookup here.
+          agentGroup: state.metadata?.agentGroup as AgentGroupConfig | undefined,
           additionalVariables: {
             ...state.metadata?.deviceSystemInfo,
             ...lobehubSkillVariables,

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -395,6 +395,7 @@ export class AgentRuntimeService {
       operationId,
       initialContext,
       agentConfig,
+      agentGroup,
       modelRuntimeConfig,
       userId,
       autoStart = true,
@@ -486,6 +487,7 @@ export class AgentRuntimeService {
         metadata: {
           activeDeviceId,
           agentConfig,
+          agentGroup,
           botContext,
           botPlatformContext,
           deviceAccessPolicy,

--- a/apps/server/src/services/agentRuntime/types.ts
+++ b/apps/server/src/services/agentRuntime/types.ts
@@ -1,5 +1,6 @@
 import { type AgentRuntimeContext, type AgentState } from '@lobechat/agent-runtime';
 import type {
+  AgentGroupConfig,
   BotPlatformContext,
   LobeToolManifest,
   OperationSkillSet,
@@ -308,6 +309,13 @@ export interface ExecGroupMemberResult {
 export interface OperationCreationParams {
   activeDeviceId?: string;
   agentConfig?: any;
+  /**
+   * Multi-agent group (or bot-conversation fallback) context, resolved once at
+   * op creation and forwarded into `state.metadata.agentGroup`. The per-step
+   * context engine reads it back to inject the participant roster (with real
+   * `agt_*` IDs) — no per-step DB lookup, mirroring `botContext`.
+   */
+  agentGroup?: AgentGroupConfig;
   appContext: {
     agentId?: string;
     /**

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -16,6 +16,7 @@ import { TaskIdentifier } from '@lobechat/builtin-tool-task';
 import { builtinTools, manualModeExcludeToolIds } from '@lobechat/builtin-tools';
 import { LOADING_FLAT } from '@lobechat/const';
 import type {
+  AgentGroupConfig,
   AgentManagementContext,
   BotPlatformContext,
   LobeToolManifest,
@@ -178,6 +179,72 @@ const isVisualUnderstandingConfigured = () => {
     // The env proxy rejects server-only keys in client-like runtimes; treat that as disabled.
     return false;
   }
+};
+
+/**
+ * Build the multi-agent group context from a group's member roster, mirroring
+ * the client `contextEngineering.ts` `agentGroup` build. Carries every member's
+ * real `agt_*` ID so the supervisor dispatches members by ID instead of role
+ * name (role names don't resolve → "Agent member(s) failed to start."). Resolves
+ * the responding agent's own role/name so GroupContextInjector marks it with
+ * `you="true"` and the orchestration filter activates for participants.
+ */
+const buildGroupAgentContext = (
+  currentAgentId: string,
+  group: { content?: string | null; title?: string | null } | undefined,
+  roster: Array<{ agentId: string; role: string | null; title: string | null }>,
+): AgentGroupConfig | undefined => {
+  if (roster.length === 0) return undefined;
+
+  const agentMap: AgentGroupConfig['agentMap'] = {};
+  const members: NonNullable<AgentGroupConfig['members']> = [];
+  let currentAgentName: string | undefined;
+  let currentAgentRole: 'supervisor' | 'participant' | undefined;
+
+  for (const member of roster) {
+    const role = member.role === 'supervisor' ? 'supervisor' : 'participant';
+    const name = member.title?.trim() || 'Untitled Agent';
+    agentMap[member.agentId] = { name, role };
+    members.push({ id: member.agentId, name, role });
+
+    if (member.agentId === currentAgentId) {
+      currentAgentName = name;
+      currentAgentRole = role;
+    }
+  }
+
+  return {
+    agentMap,
+    currentAgentId,
+    currentAgentName,
+    currentAgentRole,
+    groupTitle: group?.title || undefined,
+    members,
+    systemPrompt: group?.content || undefined,
+  };
+};
+
+/**
+ * Bot-conversation fallback: a single bot agent has no real group, so build a
+ * degenerate one-member context purely to give it its `<group_context>`
+ * identity block. Only used when there is no `groupId`.
+ */
+const buildBotConversationGroupContext = (
+  currentAgentId: string,
+  agentConfig: { description?: unknown; title?: unknown } | undefined,
+): AgentGroupConfig => {
+  const title = agentConfig?.title;
+  const description = agentConfig?.description;
+  const name = typeof title === 'string' && title.trim() ? title.trim() : 'Current Agent';
+
+  return {
+    agentMap: { [currentAgentId]: { name, role: 'participant' } },
+    currentAgentId,
+    currentAgentName: name,
+    currentAgentRole: 'participant',
+    members: [{ id: currentAgentId, name, role: 'participant' }],
+    systemPrompt: typeof description === 'string' ? description : undefined,
+  };
 };
 
 /**
@@ -1847,6 +1914,9 @@ export class AiAgentService {
     const agentMemoryEnabled = agentConfig.chatConfig?.memory?.enabled;
     let globalMemoryEnabled = agentMemoryEnabled ?? false;
     let userTimezone: string | undefined;
+    // Resolved once below (alongside the group-tool authorization fetch) and
+    // forwarded into op metadata for the per-step context engine.
+    let operationAgentGroup: AgentGroupConfig | undefined;
     try {
       const userModel = new UserModel(this.db, this.userId);
       const settings = await userModel.getUserSettings();
@@ -2200,29 +2270,38 @@ export class AiAgentService {
         activeDeviceId ?? 'none',
       );
 
-      // `appContext.orchestrationRole` is client-supplied (the execAgent /
-      // execAgents schema accepts it, and execGroupAgent stamps it for whatever
-      // agentId the caller passed), so it must NOT alone authorize the
-      // group-orchestration toolset — otherwise any run marked
-      // `{ orchestrationRole: 'supervisor', groupId }` could dispatch group
-      // members. Verify against the persisted, ownership-scoped membership that
-      // the executing agent really is this group's supervisor.
+      // Resolve the operation's group context ONCE here and snapshot it into op
+      // metadata below — the per-step context engine reads it back without a DB
+      // lookup, mirroring agentConfig/botContext. The same roster fetch also
+      // authorizes the group-orchestration toolset.
       let isGroupSupervisor = false;
-      if (appContext?.orchestrationRole === 'supervisor' && appContext?.groupId) {
-        const groupAgents = await new ChatGroupModel(
-          this.db,
-          this.userId,
-          this.workspaceId,
-        ).getGroupAgents(appContext.groupId);
-        isGroupSupervisor = groupAgents.some(
-          (member) => member.agentId === resolvedAgentId && member.role === 'supervisor',
-        );
-        if (!isGroupSupervisor)
-          log(
-            'execAgent: orchestrationRole=supervisor but agent %s is not the supervisor of group %s — denying group tools',
-            resolvedAgentId,
-            appContext.groupId,
+      if (appContext?.groupId) {
+        const chatGroupModel = new ChatGroupModel(this.db, this.userId, this.workspaceId);
+        const [group, roster] = await Promise.all([
+          chatGroupModel.findById(appContext.groupId),
+          chatGroupModel.getGroupAgentsWithMeta(appContext.groupId),
+        ]);
+
+        // `appContext.orchestrationRole` is client-supplied (execGroupAgent stamps
+        // it for whatever agentId the caller passed), so it must NOT alone
+        // authorize the group-orchestration toolset — otherwise any run marked
+        // `{ orchestrationRole: 'supervisor', groupId }` could dispatch members.
+        // Verify against the persisted, ownership-scoped membership instead.
+        if (appContext.orchestrationRole === 'supervisor') {
+          isGroupSupervisor = roster.some(
+            (member) => member.agentId === resolvedAgentId && member.role === 'supervisor',
           );
+          if (!isGroupSupervisor)
+            log(
+              'execAgent: orchestrationRole=supervisor but agent %s is not the supervisor of group %s — denying group tools',
+              resolvedAgentId,
+              appContext.groupId,
+            );
+        }
+
+        operationAgentGroup = buildGroupAgentContext(resolvedAgentId, group, roster);
+      } else if (botContext) {
+        operationAgentGroup = buildBotConversationGroupContext(resolvedAgentId, agentConfig);
       }
 
       const toolsEngine = createServerAgentToolsEngine(toolsContext, {
@@ -3035,6 +3114,7 @@ export class AiAgentService {
       const result = await this.agentRuntimeService.createOperation({
         activeDeviceId,
         agentConfig,
+        agentGroup: operationAgentGroup,
         deviceSystemInfo: Object.keys(deviceSystemInfo).length > 0 ? deviceSystemInfo : undefined,
         executionPlan,
         userTimezone,

--- a/packages/database/src/models/chatGroup.ts
+++ b/packages/database/src/models/chatGroup.ts
@@ -326,13 +326,17 @@ export class ChatGroupModel {
   }
 
   /**
-   * Read-only roster of a group's agents joined with their agent meta
+   * Read-only roster of a group's **enabled** agents joined with their agent meta
    * (title/description) and membership role, ordered by member order.
    *
    * Used to inject the group member list — with the real `agt_*` IDs — into the
    * supervisor/member runtime context so the orchestration model dispatches
    * members by their actual IDs instead of hallucinating role names (which then
    * fail to resolve to an agent, surfacing as "Agent member(s) failed to start").
+   *
+   * Disabled members are excluded (matching `getEnabledGroupAgents`): advertising
+   * them in `<group_participants>` would let the supervisor invoke a disabled
+   * agent, since the group-management runtime accepts whatever id it dispatches.
    */
   async getGroupAgentsWithMeta(groupId: string): Promise<
     Array<{
@@ -351,7 +355,13 @@ export class ChatGroupModel {
       })
       .from(chatGroupsAgents)
       .innerJoin(agents, eq(chatGroupsAgents.agentId, agents.id))
-      .where(and(eq(chatGroupsAgents.chatGroupId, groupId), this.agentsOwnership()))
+      .where(
+        and(
+          eq(chatGroupsAgents.chatGroupId, groupId),
+          eq(chatGroupsAgents.enabled, true),
+          this.agentsOwnership(),
+        ),
+      )
       .orderBy(chatGroupsAgents.order);
   }
 

--- a/packages/database/src/models/chatGroup.ts
+++ b/packages/database/src/models/chatGroup.ts
@@ -325,6 +325,36 @@ export class ChatGroupModel {
     });
   }
 
+  /**
+   * Read-only roster of a group's agents joined with their agent meta
+   * (title/description) and membership role, ordered by member order.
+   *
+   * Used to inject the group member list — with the real `agt_*` IDs — into the
+   * supervisor/member runtime context so the orchestration model dispatches
+   * members by their actual IDs instead of hallucinating role names (which then
+   * fail to resolve to an agent, surfacing as "Agent member(s) failed to start").
+   */
+  async getGroupAgentsWithMeta(groupId: string): Promise<
+    Array<{
+      agentId: string;
+      description: string | null;
+      role: string | null;
+      title: string | null;
+    }>
+  > {
+    return this.db
+      .select({
+        agentId: chatGroupsAgents.agentId,
+        description: agents.description,
+        role: chatGroupsAgents.role,
+        title: agents.title,
+      })
+      .from(chatGroupsAgents)
+      .innerJoin(agents, eq(chatGroupsAgents.agentId, agents.id))
+      .where(and(eq(chatGroupsAgents.chatGroupId, groupId), this.agentsOwnership()))
+      .orderBy(chatGroupsAgents.order);
+  }
+
   async getEnabledGroupAgents(groupId: string): Promise<ChatGroupAgentItem[]> {
     return this.db.query.chatGroupsAgents.findMany({
       orderBy: [chatGroupsAgents.order],


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- internal: group supervisor orchestration -->

#### 🔀 Description of Change

**Problem.** In a durable (server-side) group chat, the supervisor would dispatch members by their **role name** instead of their agent ID — e.g. `broadcast({ agentIds: ["LobeHub 产品经理", "LobeHub 前端架构师", ...] })` — and every member came back with **`Agent member(s) failed to start.`**

**Root cause.** The server group-supervisor path never injects the group's **member roster** into the orchestration context:

- The builtin `group-supervisor` `systemRole` tells the model "Only invoke agents defined in the participants list / never fabricate agent IDs" — but has **no placeholder for that list**.
- The only server-side `agentGroup` builder, `buildBotAgentGroupContext`, was introduced for **bot conversations** (#15560) and returns `undefined` without a `botContext`, building at most a degenerate single-agent context. Real group chats fell straight through to `undefined`, so the supervisor saw **no `agt_*` IDs at all**.

With no roster, the model falls back to the only identifiers it can see — the human-readable role names from the conversation. Those don't resolve to a real agent, so `execGroupMember → execAgent` fails to start each member → `START_FAILED`.

**Fix.** Resolve the group context **once at op creation** (reusing the membership fetch that already authorizes the group toolset) and **snapshot it into op metadata**, so the per-step context engine reads it back **without a DB lookup** — mirroring how `agentConfig` / `botContext` already flow through `state.metadata`. The pipeline is already wired (`serverMessagesEngine` forwards `agentGroup` → `MessagesEngine` → `GroupContextInjector`, which renders `<group_participants><member name="…" id="agt_*"/>`); it was just never given data on the durable path.

- **`ChatGroupModel.getGroupAgentsWithMeta`** (new, read-only): joins `chat_groups_agents` with `agents` to return each member's real `agentId` + `title` + `role`.
- **`execAgent`**: builds the full `AgentGroupConfig` from the roster (real members) — or, for a bot conversation, a clearly-named single-agent fallback — and passes it to `createOperation`.
- **`createOperation`**: forwards `agentGroup` into `state.metadata.agentGroup`.
- **`RuntimeExecutors`**: reads the snapshot from metadata (no per-step query) and drops the misleadingly-named bot-only builder from the hot path.

As a bonus, participant member ops now also receive `agentMap`, so `GroupOrchestrationFilterProcessor` activates for them (and not the supervisor) — matching the client.

**Cost / design.** The roster is resolved exactly once per operation (the supervisor-auth fetch was already happening; this reuses it), consistent with the codebase's snapshot-at-creation metadata pattern — **no per-step DB query**. Non-group, non-bot chats produce `undefined` and skip injection. No operation-state/resume changes.

#### 🧪 How to Test

- [x] Tested locally (`bun run type-check` passes)
- [ ] Added/updated tests
- [x] No tests needed

Repro: start a server-side (durable) group chat and ask an open-ended question that triggers `broadcast`. Before this change the supervisor passes role-name strings as `agentIds` and gets `Agent member(s) failed to start.`; after, it passes real `agt_*` IDs and members run.

#### 📝 Additional Information

The supervisor's `<group_participants>` block now lists every member with its real `agt_*` id (and `you="true"` on the responding agent), so orchestration tool calls reference real IDs.