### PR TITLE
⚡️ perf: drop /api /trpc /webapi from proxy matcher

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,8 +5,14 @@ const { middleware } = defineConfig();
 // required to be literal
 export const config = {
   matcher: [
-    // include any files in the api or trpc folders that might have an extension
-    '/(api|trpc|webapi)(.*)',
+    // NOTE: `/api`, `/trpc`, `/webapi` are intentionally NOT matched. The
+    // middleware is a no-op for them — `defaultMiddleware` short-circuits the
+    // rewrite half via `backendApiEndpoints`, and they're all public routes, so
+    // the better-auth session lookup is skipped. Auth lives in the route
+    // handlers (`checkAuth`, trpc `protectedProcedure`), which return JSON 401s
+    // rather than the HTML redirect-to-signin. Skipping the matcher avoids a
+    // needless middleware invocation on the hottest backend traffic. (/oidc and
+    // /oauth stay matched below — their middleware pass is still load-bearing.)
     // include the /
     '/',
     '/community',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ⚡️ perf

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

`/api`, `/trpc`, `/webapi` are removed from the proxy (`middleware`) matcher in `src/proxy.ts`. The proxy is already a **no-op** for these backend routes:

- **Rewrite half** — `defaultMiddleware` short-circuits via `backendApiEndpoints` (`return NextResponse.next()`), so no locale/device/rewrite work happens for them.
- **Auth half** — `/trpc(.*)` and `/webapi(.*)` are fully in `isPublicRoute`, and every `/api/*` route handler directory is covered by the public matcher too, so the better-auth `getSession()` lookup is already skipped.

Authentication for these routes is enforced **inside the handlers** (`checkAuth`, trpc `protectedProcedure`), which return proper JSON `401`s — not the proxy's HTML `redirect-to-signin`, which is the wrong response shape for an API call anyway.

Keeping them in the matcher only costs a middleware invocation per request on the hottest backend traffic (`/trpc`, `/webapi`, `/api/agent/stream`) with zero behavioral benefit.

`/oidc` and `/oauth` stay matched — their proxy pass **is** load-bearing (e.g. `/oidc/consent` relies on the redirect-to-signin), so only `/api|/trpc|/webapi` are dropped.

#### 🧪 How to Test

- [x] No tests needed

Pure matcher narrowing; the proxy behaviour for these routes is unchanged (it was already a no-op). `define-config.test.ts` continues to pass.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

A matching change is being made in the LobeHub Cloud repo's `src/proxy.ts` override (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)