### PR TITLE
🐛 fix(desktop): restore minimized window on notification click

### DIFF
--- a/apps/desktop/src/main/controllers/NotificationCtr.ts
+++ b/apps/desktop/src/main/controllers/NotificationCtr.ts
@@ -152,11 +152,13 @@ export default class NotificationCtr extends ControllerModule {
 
       notification.on('click', () => {
         logger.debug('User clicked notification, showing main window');
-        const mainWindow = this.app.browserManager.getMainWindow();
-        mainWindow.show();
-        mainWindow.browserWindow.focus();
+        // Reuse the shared show path so a *minimized* window is restored first.
+        // A bare `Browser.show()` cannot un-minimize on macOS, which made the
+        // notification intermittently fail to surface the app (worked only when
+        // the window was hidden, not when minimized to the Dock).
+        this.app.browserManager.showMainWindow();
         if (params.navigate?.path) {
-          mainWindow.broadcast('navigate', params.navigate);
+          this.app.browserManager.getMainWindow().broadcast('navigate', params.navigate);
         }
       });
 

--- a/apps/desktop/src/main/controllers/__tests__/NotificationCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/NotificationCtr.test.ts
@@ -60,12 +60,14 @@ const mockBrowserWindow = {
 };
 
 const mockMainWindow = {
+  broadcast: vi.fn(),
   browserWindow: mockBrowserWindow,
   show: vi.fn(),
 };
 
 const mockBrowserManager = {
   getMainWindow: vi.fn(() => mockMainWindow),
+  showMainWindow: vi.fn(),
 };
 
 const mockApp = {
@@ -329,8 +331,9 @@ describe('NotificationCtr', () => {
       // Simulate click
       clickHandler();
 
-      expect(mockMainWindow.show).toHaveBeenCalled();
-      expect(mockBrowserWindow.focus).toHaveBeenCalled();
+      // Delegates to the shared show path, which restores a minimized window
+      // before showing/focusing — a bare `show()` cannot un-minimize on macOS.
+      expect(mockBrowserManager.showMainWindow).toHaveBeenCalled();
     });
 
     it('should handle notification error', async () => {


### PR DESCRIPTION
## Summary

Clicking a desktop notification **intermittently** failed to bring the app to the front. It worked when the window was hidden (e.g. `Cmd+H` / closed to tray) but did nothing when the window was **minimized to the Dock** (`Cmd+M` / yellow button) — which is why it looked random.

### Root cause

The notification `click` handler called a bare `Browser.show()` + `focus()`:

```ts
const mainWindow = this.app.browserManager.getMainWindow();
mainWindow.show();
mainWindow.browserWindow.focus();
```

On macOS `BrowserWindow.show()` can surface a *hidden* window but **cannot un-minimize a minimized one** — that requires `restore()` first. The shared `browserManager.showMainWindow()` already does exactly this and is what the Dock icon, tray, and second-instance activation use:

```ts
if (window.isMinimized()) window.restore();
browser.show();
window.focus();
```

The click handler simply wasn't using it.

### Fix

Delegate the notification click to `browserManager.showMainWindow()` so the window surfaces regardless of prior state (hidden **or** minimized), consistent with every other "bring to front" entry point. The `navigate` deep-link behavior is unchanged.

## Test

- Updated `NotificationCtr.test.ts` to assert the handler delegates to `showMainWindow()`.
- `bunx vitest run apps/desktop/.../NotificationCtr.test.ts` → 23 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)