### PR TITLE
💄 style(home): tag group conversations in the sidebar instead of agent runtime

### DIFF
--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentGroupItem/index.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentGroupItem/index.tsx
@@ -1,6 +1,6 @@
 import { GROUP_CHAT_URL } from '@lobechat/const';
 import { type SidebarAgentItem } from '@lobechat/types';
-import { ActionIcon, Icon } from '@lobehub/ui';
+import { ActionIcon, Flexbox, Icon, Tag } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
 import { Loader2, PinIcon } from 'lucide-react';
 import { type CSSProperties, type DragEvent } from 'react';
@@ -34,6 +34,18 @@ const GroupItem = memo<GroupItemProps>(({ item, style, className, onNavigate }) 
 
   // Get display title with fallback
   const displayTitle = title || t('untitledAgent');
+
+  // Group conversations show a "群组" tag so they stand out from single agents.
+  const titleNode = (
+    <Flexbox horizontal align="center" gap={4}>
+      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {displayTitle}
+      </span>
+      <Tag size={'small'} style={{ flexShrink: 0 }}>
+        {t('group.title')}
+      </Tag>
+    </Flexbox>
+  );
 
   // Get URL for this group
   const groupUrl = GROUP_CHAT_URL(id);
@@ -115,7 +127,7 @@ const GroupItem = memo<GroupItemProps>(({ item, style, className, onNavigate }) 
         icon={avatarIcon}
         key={id}
         style={style}
-        title={displayTitle}
+        title={titleNode}
         onDoubleClick={handleDoubleClick}
         onDragEnd={handleDragEnd}
         onDragStart={handleDragStart}

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/index.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/index.tsx
@@ -1,12 +1,11 @@
 import { type SidebarAgentItem } from '@lobechat/types';
-import { ActionIcon, Flexbox, Icon } from '@lobehub/ui';
+import { ActionIcon, Icon } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { Loader2, PinIcon } from 'lucide-react';
 import { type CSSProperties, type DragEvent } from 'react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import HeterogeneousTag from '@/features/HeterogeneousTag';
 import NavItem from '@/features/NavPanel/components/NavItem';
 import WorkspaceLink from '@/features/Workspace/WorkspaceLink';
 import { usePrefetchAgent } from '@/hooks/usePrefetchAgent';
@@ -80,7 +79,7 @@ interface AgentItemProps {
 }
 
 const AgentItem = memo<AgentItemProps>(({ item, style, className, onNavigate }) => {
-  const { id, avatar, backgroundColor, title, pinned, heterogeneousType } = item;
+  const { id, avatar, backgroundColor, title, pinned } = item;
   // Unread count is server-computed (topics.status === 'unread') and carried on
   // the sidebar list item, so it stays accurate across agents whose topics
   // aren't loaded into the chat store on this client.
@@ -98,19 +97,6 @@ const AgentItem = memo<AgentItemProps>(({ item, style, className, onNavigate }) 
 
   // Get display title with fallback
   const displayTitle = title || t('untitledAgent');
-
-  // Heterogeneous agents (Claude Code, Codex, …) show their runtime as a tag
-  // so they stand out from built-in agents in the sidebar.
-  const titleNode = heterogeneousType ? (
-    <Flexbox horizontal align="center" gap={4}>
-      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-        {displayTitle}
-      </span>
-      <HeterogeneousTag type={heterogeneousType} />
-    </Flexbox>
-  ) : (
-    displayTitle
-  );
 
   const agentUrl = usePreservedAgentUrl(id);
 
@@ -217,7 +203,7 @@ const AgentItem = memo<AgentItemProps>(({ item, style, className, onNavigate }) 
         icon={avatarIcon}
         key={id}
         style={style}
-        title={titleNode}
+        title={displayTitle}
         onDoubleClick={handleDoubleClick}
         onDragEnd={handleDragEnd}
         onDragStart={handleDragStart}


### PR DESCRIPTION
## Summary

Adjusts the sidebar agent/group list badges:

- **Removed** the heterogeneous runtime tag (`Claude Code` / `Codex`) from single-agent list items — they now show just the agent title.
- **Added** a `群组` / `Group` tag to group conversation items (`type === 'group'`, e.g. "LobeHub 开发小组") so multi-agent groups stand out from regular agents.

Reuses the existing `chat:group.title` i18n key (already "群组" in zh-CN, "Group" in en-US), so no new locale strings are needed.

## Changes

- `AgentItem`: drop `HeterogeneousTag` rendering + now-unused `Flexbox` / `HeterogeneousTag` imports and the `heterogeneousType` destructure.
- `AgentGroupItem`: render a small `Tag` with `t('group.title')` next to the group title.

## Test plan

- [ ] Single agents (incl. Claude Code / Codex) render with no runtime badge.
- [ ] Group conversations render with a `群组` / `Group` tag.
- [ ] Tag label follows the active locale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)