### PR TITLE
💄 style(tool): compact single-row Linear list render

### DIFF
--- a/locales/en-US/plugin.json
+++ b/locales/en-US/plugin.json
@@ -29,6 +29,7 @@
   "builtins.codex.mcpTool.result": "Result",
   "builtins.codex.mcpTool.unknownTool": "MCP tool",
   "builtins.codex.webSearch.query": "Query",
+  "builtins.linear.render.updatedAt": "Updated {{time}}",
   "builtins.lobe-activator.apiName.activateTools": "Activate Tools",
   "builtins.lobe-activator.inspector.activateTools.notFoundCount": "{{count}} not found",
   "builtins.lobe-agent-builder.apiName.getAvailableModels": "Get available models",

--- a/locales/zh-CN/plugin.json
+++ b/locales/zh-CN/plugin.json
@@ -29,6 +29,7 @@
   "builtins.codex.mcpTool.result": "结果",
   "builtins.codex.mcpTool.unknownTool": "MCP 工具",
   "builtins.codex.webSearch.query": "搜索词",
+  "builtins.linear.render.updatedAt": "更新于 {{time}}",
   "builtins.lobe-activator.apiName.activateTools": "激活工具",
   "builtins.lobe-activator.inspector.activateTools.notFoundCount": "{{count}} 个未找到",
   "builtins.lobe-agent-builder.apiName.getAvailableModels": "获取可用模型",

--- a/packages/locales/src/default/plugin.ts
+++ b/packages/locales/src/default/plugin.ts
@@ -317,6 +317,7 @@ export default {
   'builtins.lobe-page-agent.apiName.updateNode': 'Update node',
   'builtins.lobe-page-agent.apiName.wrapNodes': 'Wrap nodes',
   'builtins.lobe-page-agent.title': 'Page',
+  'builtins.linear.render.updatedAt': 'Updated {{time}}',
   'builtins.lobe-activator.apiName.activateTools': 'Activate Tools',
   'builtins.lobe-activator.inspector.activateTools.notFoundCount': '{{count}} not found',
   'builtins.lobe-skill-store.apiName.importFromMarket': 'Import from Market',

--- a/packages/shared-tool-ui/src/Render/Linear/index.tsx
+++ b/packages/shared-tool-ui/src/Render/Linear/index.tsx
@@ -1,14 +1,18 @@
 'use client';
 
 import type { BuiltinRenderProps } from '@lobechat/types';
+import { fromNow } from '@lobechat/utils/time';
 import { Block, Flexbox, Highlighter, Icon, Markdown, Tag, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { ExternalLink, Link2 } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { memo, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import {
   buildLinearRenderModel,
+  formatIsoDate,
+  isUuidLike,
   type LinearEntity,
   type LinearField,
   type LinearLink,
@@ -32,41 +36,53 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   entityHeader: css`
     display: flex;
-    gap: 8px;
-    align-items: flex-start;
+    gap: 12px;
+    align-items: center;
     justify-content: space-between;
 
     min-width: 0;
   `,
-  fieldGrid: css`
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  headLeft: css`
+    display: flex;
     gap: 6px;
-  `,
-  fieldItem: css`
-    overflow: hidden;
+    align-items: center;
 
     min-width: 0;
-    padding-block: 6px;
-    padding-inline: 8px;
-    border-radius: 6px;
-
-    background: ${cssVar.colorFillQuaternary};
   `,
-  fieldLabel: css`
-    display: block;
-    margin-block-end: 2px;
-    font-size: 11px;
+  timeItem: css`
+    flex-shrink: 0;
+    font-size: 12px;
     color: ${cssVar.colorTextTertiary};
+    white-space: nowrap;
   `,
-  fieldValue: css`
-    overflow: hidden;
-    display: block;
+  metaItem: css`
+    display: inline-flex;
+    gap: 4px;
+    align-items: baseline;
 
     min-width: 0;
 
     font-size: 12px;
-    color: ${cssVar.colorText};
+    line-height: 1.5;
+  `,
+  metaLabel: css`
+    flex-shrink: 0;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  metaRow: css`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 16px;
+    align-items: baseline;
+
+    min-width: 0;
+  `,
+  metaValue: css`
+    overflow: hidden;
+
+    min-width: 0;
+
+    color: ${cssVar.colorTextSecondary};
     text-overflow: ellipsis;
     white-space: nowrap;
   `,
@@ -133,23 +149,23 @@ const Section = memo<{ children: ReactNode; title: string }>(({ children, title 
 ));
 Section.displayName = 'LinearRenderSection';
 
-const FieldGrid = memo<{ fields: LinearField[] }>(({ fields }) => {
+const MetaRow = memo<{ fields: LinearField[] }>(({ fields }) => {
   if (!hasItems(fields)) return null;
 
   return (
-    <div className={styles.fieldGrid}>
+    <div className={styles.metaRow}>
       {fields.map((field) => (
-        <div className={styles.fieldItem} key={`${field.key}:${field.value}`}>
-          <span className={styles.fieldLabel}>{field.label}</span>
-          <span className={styles.fieldValue} title={field.value}>
+        <span className={styles.metaItem} key={`${field.key}:${field.value}`}>
+          <span className={styles.metaLabel}>{field.label}</span>
+          <span className={styles.metaValue} title={field.value}>
             {field.value}
           </span>
-        </div>
+        </span>
       ))}
     </div>
   );
 });
-FieldGrid.displayName = 'LinearRenderFieldGrid';
+MetaRow.displayName = 'LinearRenderMetaRow';
 
 const LinkList = memo<{ links: LinearLink[] }>(({ links }) => {
   if (!hasItems(links)) return null;
@@ -177,47 +193,53 @@ const LinkList = memo<{ links: LinearLink[] }>(({ links }) => {
 LinkList.displayName = 'LinearRenderLinkList';
 
 const EntityCard = memo<{ entity: LinearEntity }>(({ entity }) => {
-  // Comments / attachments have no human-readable title — only a UUID `id`.
-  // Never promote that UUID into the card title; keep the id as a secondary tag
-  // (linked when a url exists) and let the description carry the card.
-  const { title, id, url } = entity;
+  const { t } = useTranslation('plugin');
+  const { title, id, url, state, updatedAt } = entity;
+
+  // A bare UUID id only earns a slot when there's no title to carry the card
+  // (e.g. comments / attachments, where it's also the link target). Human ids
+  // like `LOBE-123` always stay.
+  const showId = Boolean(id) && (!title || !isUuidLike(id!));
 
   return (
-    <Block gap={10} padding={10} variant={'outlined'} width={'100%'}>
+    <Block gap={8} padding={10} variant={'outlined'} width={'100%'}>
       <div className={styles.entityHeader}>
-        <Flexbox gap={4} style={{ minWidth: 0 }}>
+        <div className={styles.headLeft}>
           {title &&
             (url ? (
               <a className={styles.titleLink} href={url} rel={'noreferrer'} target={'_blank'}>
-                <Text ellipsis={{ rows: 2 }} weight={600}>
+                <Text ellipsis weight={600}>
                   {title}
                 </Text>
                 <Icon icon={ExternalLink} size={12} />
               </a>
             ) : (
-              <Text ellipsis={{ rows: 2 }} weight={600}>
+              <Text ellipsis weight={600}>
                 {title}
               </Text>
             ))}
-          <Flexbox horizontal gap={4} wrap={'wrap'}>
-            {id &&
-              (url && !title ? (
-                <a className={styles.titleLink} href={url} rel={'noreferrer'} target={'_blank'}>
-                  <Tag size={'small'}>{id}</Tag>
-                  <Icon icon={ExternalLink} size={12} />
-                </a>
-              ) : (
+          {showId &&
+            (url && !title ? (
+              <a className={styles.titleLink} href={url} rel={'noreferrer'} target={'_blank'}>
                 <Tag size={'small'}>{id}</Tag>
-              ))}
-            {entity.state && (
-              <Tag size={'small'} variant={'outlined'}>
-                {entity.state}
-              </Tag>
-            )}
-          </Flexbox>
-        </Flexbox>
+                <Icon icon={ExternalLink} size={12} />
+              </a>
+            ) : (
+              <Tag size={'small'}>{id}</Tag>
+            ))}
+          {state && (
+            <Tag size={'small'} variant={'outlined'}>
+              {state}
+            </Tag>
+          )}
+        </div>
+        {updatedAt && (
+          <span className={styles.timeItem} title={formatIsoDate(updatedAt)}>
+            {t('builtins.linear.render.updatedAt', { time: fromNow(updatedAt) })}
+          </span>
+        )}
       </div>
-      <FieldGrid fields={entity.fields} />
+      <MetaRow fields={entity.fields} />
       {entity.description && (
         <div className={styles.description}>
           <Markdown fontSize={13} variant={'chat'}>

--- a/packages/shared-tool-ui/src/Render/Linear/utils.test.ts
+++ b/packages/shared-tool-ui/src/Render/Linear/utils.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildLinearRenderModel } from './utils';
+import { buildLinearRenderModel, isUuidLike } from './utils';
+
+describe('isUuidLike', () => {
+  it('matches bare UUIDs but not human Linear ids', () => {
+    expect(isUuidLike('55a0597c-be21-4e73-a1ff-1a45aedf0184')).toBe(true);
+    expect(isUuidLike('LOBE-123')).toBe(false);
+    expect(isUuidLike('TEST-456')).toBe(false);
+    expect(isUuidLike('Engineering')).toBe(false);
+  });
+});
 
 describe('buildLinearRenderModel', () => {
   it('summarizes Linear update issue input and result without exposing raw JSON first', () => {
@@ -94,12 +103,11 @@ describe('buildLinearRenderModel', () => {
     });
     // `status` is surfaced via the state tag, so it should not duplicate as a field.
     expect(entity.fields.find((field) => field.key === 'status')).toBeUndefined();
-    // ISO timestamps render as a concrete date + time.
-    expect(entity.fields).toContainEqual({
-      key: 'createdAt',
-      label: 'Created At',
-      value: '2024-01-02 03:04:05',
-    });
+    // updatedAt is pulled out of the field grid and kept as raw ISO for the
+    // header's relative-time rendering; createdAt is dropped entirely.
+    expect(entity.updatedAt).toBe('2024-01-02T03:04:05.000Z');
+    expect(entity.fields.find((field) => field.key === 'createdAt')).toBeUndefined();
+    expect(entity.fields.find((field) => field.key === 'updatedAt')).toBeUndefined();
     expect(entity.fields).toContainEqual({ key: 'priority', label: 'Priority', value: 'Medium' });
   });
 
@@ -118,14 +126,11 @@ describe('buildLinearRenderModel', () => {
     expect(model.resultEntities).toHaveLength(1);
     const [entity] = model.resultEntities;
     // No human title — the render must not promote the UUID id to the title.
+    // The titleless UUID id is retained (it's the card's only handle / link target).
     expect(entity.title).toBeUndefined();
     expect(entity.id).toBe('ff0dabda-eb1f-4dfe-b525-09114c0d6bd0');
     expect(entity.description).toBe('## Mock comment body');
-    expect(entity.fields).toContainEqual({
-      key: 'createdAt',
-      label: 'Created At',
-      value: '2024-01-02 03:04:05',
-    });
+    expect(entity.updatedAt).toBe('2024-01-02T03:04:05.038Z');
   });
 
   it('still unwraps list_* payloads from their nested collection', () => {

--- a/packages/shared-tool-ui/src/Render/Linear/utils.ts
+++ b/packages/shared-tool-ui/src/Render/Linear/utils.ts
@@ -28,6 +28,9 @@ const FIELD_KEYS = [
   'query',
   'url',
 ] as const;
+// updatedAt is pulled out of the generic field grid and rendered as a relative
+// timestamp on the entity header instead (see LinearEntity below). createdAt is
+// intentionally dropped — it adds noise without signalling recency.
 const ENTITY_FIELD_KEYS = [
   'state',
   'status',
@@ -38,8 +41,6 @@ const ENTITY_FIELD_KEYS = [
   'milestone',
   'priority',
   'parentId',
-  'createdAt',
-  'updatedAt',
 ] as const;
 const RESULT_ARRAY_KEYS = [
   'issues',
@@ -71,8 +72,17 @@ export interface LinearEntity {
   links: LinearLink[];
   state?: string;
   title?: string;
+  /** Raw ISO last-update timestamp; rendered as relative time on the header. */
+  updatedAt?: string;
   url?: string;
 }
+
+// A bare UUID (e.g. a team/comment internal id) carries no meaning for the
+// reader; suppress it when the entity already has a human-readable title. Linear
+// human ids like `LOBE-123` never match this shape, so they stay visible.
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+
+export const isUuidLike = (value: string): boolean => UUID_PATTERN.test(value);
 
 export interface LinearRenderModel {
   actionLabel: string;
@@ -143,7 +153,7 @@ const DATE_FIELD_KEYS = new Set([
 // concrete date + time as `YYYY-MM-DD HH:mm:ss` (dropping the millisecond / `Z`
 // noise) instead of the raw ISO string. Date-only values (e.g. `dueDate`) are
 // left untouched.
-const formatIsoDate = (value: string): string => {
+export const formatIsoDate = (value: string): string => {
   const match = /^(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}(?::\d{2})?)/u.exec(value);
   return match ? `${match[1]} ${match[2]}` : value;
 };
@@ -254,8 +264,18 @@ const buildEntity = (record: Record<PropertyKey, unknown>): LinearEntity | undef
     (field) => !((field.key === 'state' || field.key === 'status') && field.value === state),
   );
   const links = getLinearLinks(record.links);
+  const updatedAt = trimString(record.updatedAt);
 
-  if (!id && !title && !url && !state && !description && fields.length === 0 && links.length === 0)
+  if (
+    !id &&
+    !title &&
+    !url &&
+    !state &&
+    !description &&
+    !updatedAt &&
+    fields.length === 0 &&
+    links.length === 0
+  )
     return;
 
   return {
@@ -265,6 +285,7 @@ const buildEntity = (record: Record<PropertyKey, unknown>): LinearEntity | undef
     links,
     state,
     title,
+    updatedAt,
     url,
   };
 };

--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -48,6 +48,16 @@ export const isNewReleaseDate = (date: string, days = 14) => {
   return dayjs().diff(dayjs(date), 'day') < days;
 };
 
+/**
+ * Locale-aware "3 days ago" / "3 天前" relative time. Returns an empty string
+ * for missing or unparseable input so callers can render it unconditionally.
+ */
+export const fromNow = (time?: string | Date | number | null): string => {
+  if (!time) return '';
+  const date = dayjs(time);
+  return date.isValid() ? date.fromNow() : '';
+};
+
 export interface FormatActivityTimeOptions {
   formatOtherYear?: string;
   formatThisYear?: string;

--- a/src/features/DevPanel/RenderGallery/fixtures/index.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/index.ts
@@ -9,6 +9,7 @@ import { buildSchemaSample, humanize, single, type ToolsetFixtureModule } from '
 import claudeCode from './claude-code';
 import codex from './codex';
 import github from './github';
+import linear from './linear';
 import lobeActivator from './lobe-activator';
 import lobeAgent from './lobe-agent';
 import lobeAgentBuilder from './lobe-agent-builder';
@@ -80,6 +81,7 @@ const toolsetModules: ToolsetFixtureModule[] = [
   claudeCode,
   codex,
   github,
+  linear,
   lobeActivator,
   lobeAgent,
   lobeAgentBuilder,

--- a/src/features/DevPanel/RenderGallery/fixtures/linear.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/linear.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { defineFixtures, single } from './_helpers';
+
+// list_teams returns a flat collection of entities whose only metadata is
+// createdAt / updatedAt — the canonical case for the compact inline meta row.
+export default defineFixtures({
+  identifier: 'linear',
+  apiList: [{ description: 'List all teams in the workspace', name: 'list_teams' }],
+  fixtures: {
+    list_teams: single({
+      args: {},
+      content: JSON.stringify({
+        teams: [
+          {
+            createdAt: '2024-10-17T07:58:43.000Z',
+            id: '55a0597c-be21-4e73-a1ff-1a45aedf0184',
+            name: 'Engineering',
+            updatedAt: '2026-06-27T07:15:25.000Z',
+          },
+          {
+            createdAt: '2025-11-12T09:06:23.000Z',
+            id: '86bed308-b8fd-4c90-aa64-144b80e8f3f2',
+            name: 'Packaging',
+            updatedAt: '2026-06-27T07:15:25.000Z',
+          },
+          {
+            createdAt: '2026-02-04T10:38:25.000Z',
+            id: '6c136d2c-fe29-41bf-9fc8-3aefa39e895b',
+            name: 'Benchmark',
+            updatedAt: '2026-06-23T07:13:04.000Z',
+          },
+          {
+            createdAt: '2026-01-22T09:36:47.000Z',
+            id: '158f2b2d-34ba-48a3-84c9-084f5dd6d2f4',
+            name: 'QA',
+            updatedAt: '2026-06-15T07:09:01.000Z',
+          },
+        ],
+      }),
+    }),
+  },
+});


### PR DESCRIPTION
## Summary

The Linear `list_*` tool result (e.g. **List teams**) rendered each entity as a tall card with a grid of chunky per-field boxes — visually inefficient, especially for teams whose only metadata is timestamps. This reworks it into **one tight row per entity**.

| before | after |
| --- | --- |
| title + UUID tag, then two large stacked `Created At` / `Updated At` boxes | title on the left · relative **updated** time on the right |

## What changed

- **Single-row layout** — `EntityCard` is now one horizontal row: title (+ meaningful id / state) on the left, update time on the right. `description` / links still stack below for issues/comments.
- **Hide meaningless UUIDs** — a bare UUID id is suppressed when the entity already has a title; human ids like `LOBE-123` always stay, and title-less entities (comments/attachments) keep the UUID as their only handle/link target. New exported `isUuidLike` helper.
- **Relative update time** — `updatedAt` moved out of the field grid and rendered as locale-aware relative time via a new `fromNow` util (`更新于 3 天前` / `Updated 3 days ago`), with the full timestamp in the native `title` tooltip. `createdAt` is dropped entirely (noise without recency signal).
- **i18n** — adds `builtins.linear.render.updatedAt` (en-US source + zh-CN).
- **Devtools fixture** — Linear had no RenderGallery fixture, so its render couldn't be previewed; adds a `list_teams` fixture at `/devtools/linear`.

## Testing

- `packages/shared-tool-ui` unit tests: 9 passed (incl. new `isUuidLike` cases + updated entity-model assertions).
- `bun run type-check`: pass.
- Verified visually in the devtools RenderGallery (`/devtools/linear`, Success): each team renders as a single row, no UUID, `更新于 X` on the right.

Verify report (screenshots): https://app.lobehub.com/verify/efd2ae35-6f50-446a-9f29-f736eb28cb5b

🤖 Generated with [Claude Code](https://claude.com/claude-code)