### PR TITLE
💄 style(task): lay verify requirement flat under collapsed trigger

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/TaskVerifyConfig.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskVerifyConfig.tsx
@@ -46,8 +46,9 @@ const SAVE_DEBOUNCE_MS = 600;
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   collapsedRequirement: css`
-    /* full requirement, wrapping to as many lines as it needs — readable at a glance */
-    max-width: 480px;
+    /* full requirement, wrapping to as many lines as it needs — readable at a glance.
+       Inset past the trigger icon so it reads flat under the title, not as a clickable row. */
+    padding-inline: 32px 8px;
     line-height: 1.5;
   `,
   list: css`
@@ -365,15 +366,16 @@ const TaskVerifyConfig = memo(() => {
     // Treat that as "configured" too, so the panel never reads as "never set".
     const requirementPreview = requirement.trim();
     const isConfigured = savedCount > 0 || requirementPreview.length > 0;
-    // When the gate is a requirement sentence (no structured criteria), show the
-    // full requirement wrapping below the title — readable at a glance, not a weak
-    // one-line ellipsis. Criteria-count / hint variants stay as a compact pill.
+    // When the gate is a requirement sentence (no structured criteria), render the
+    // requirement as flat body text BELOW the trigger — it's readable content, not
+    // a clickable target. Only the compact title row stays clickable-to-expand, so
+    // hovering the requirement doesn't light up a big clickable block.
     const showRequirement = savedCount === 0 && requirementPreview.length > 0;
-    return (
+    const trigger = (
       <Block
         clickable
         horizontal
-        align={showRequirement ? 'flex-start' : 'center'}
+        align={'center'}
         gap={8}
         paddingBlock={4}
         paddingInline={8}
@@ -385,32 +387,27 @@ const TaskVerifyConfig = memo(() => {
           color={cssVar.colorTextDescription}
           icon={isConfigured ? ShieldCheck : Plus}
           size={16}
-          style={showRequirement ? { marginTop: 2 } : undefined}
         />
-        {showRequirement ? (
-          <Flexbox gap={2}>
-            <Text color={cssVar.colorTextSecondary} fontSize={13} weight={500}>
-              {t('verifyConfig.empty.title')}
-            </Text>
-            <Text className={styles.collapsedRequirement} fontSize={14}>
-              {requirementPreview}
-            </Text>
-          </Flexbox>
-        ) : (
-          <>
-            <Text color={cssVar.colorTextSecondary} fontSize={13} weight={500}>
-              {t('verifyConfig.empty.title')}
-            </Text>
-            {savedCount > 0 ? (
-              <Tag>{t('verifyConfig.criteriaCount', { count: savedCount })}</Tag>
-            ) : (
-              <Text className={styles.subtitle} fontSize={12}>
-                {t('verifyConfig.collapsedHint')}
-              </Text>
-            )}
-          </>
+        <Text color={cssVar.colorTextSecondary} fontSize={13} weight={500}>
+          {t('verifyConfig.empty.title')}
+        </Text>
+        {savedCount > 0 ? (
+          <Tag>{t('verifyConfig.criteriaCount', { count: savedCount })}</Tag>
+        ) : showRequirement ? null : (
+          <Text className={styles.subtitle} fontSize={12}>
+            {t('verifyConfig.collapsedHint')}
+          </Text>
         )}
       </Block>
+    );
+    if (!showRequirement) return trigger;
+    return (
+      <Flexbox gap={2}>
+        {trigger}
+        <Text className={styles.collapsedRequirement} fontSize={14}>
+          {requirementPreview}
+        </Text>
+      </Flexbox>
     );
   }
 


### PR DESCRIPTION
### 💻 Change Type

- [x] 💄 style

### 🔀 Description of Change

In the task **delivery-acceptance** panel (`TaskVerifyConfig`), when a task is gated by a natural-language verify requirement only (no structured criteria), the collapsed trigger wrapped **both** the title and the requirement paragraph inside a single clickable `<Block onClick={expand}>`. As a result the requirement text sat *inside* the clickable region and lit up the whole block on hover — it read as a button rather than content.

This change:
- Keeps only the compact title row (`icon + 交付验收`) as the clickable expand trigger.
- Renders the requirement as **flat body text below** the trigger (a sibling, not a child) — readable content, not a click target.
- Drops the `max-width: 480px` cap so the requirement fills the row width.

Expand/collapse behavior is unchanged; the other collapsed variants (criteria-count pill, "not configured" hint) are untouched.

#### Before / After (collapsed, requirement-only)

- **Before:** title + requirement share one ~960px clickable `<Block>`; hovering the text highlights the whole block.
- **After:** clickable trigger shrinks to the `53×20px` title row; requirement is a separate full-width element below (`requirementInsideClickable = false`), no hover highlight.

### 📝 Additional Information

Verified in the desktop app (Electron, against production data) on task T-209:
- Collapsed: requirement is a sibling of the trigger, not inside it (confirmed via DOM measurement).
- Hovering the requirement no longer highlights a clickable block.
- Clicking the title still expands the editor.