### PR TITLE
💄 style: refine desktop update notice

### DIFF
--- a/src/features/Electron/updater/UpdateNotification.tsx
+++ b/src/features/Electron/updater/UpdateNotification.tsx
@@ -24,12 +24,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
     overflow: hidden;
 
-    min-width: 360px;
+    min-width: 430px;
 
     color: ${cssVar.colorText};
 
-    background: color-mix(in srgb, ${cssVar.colorBgElevated} 85%, transparent);
-    backdrop-filter: blur(20px) saturate(1.5);
+    background: ${cssVar.colorBgElevated};
+    backdrop-filter: none;
     box-shadow: ${cssVar.boxShadowSecondary};
   `,
   closeButton: css`
@@ -117,7 +117,11 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   labelStack: css`
     display: flex;
     flex: 1;
-    flex-direction: column;
+    flex-direction: row;
+    gap: 6px;
+    align-items: baseline;
+
+    min-width: 0;
   `,
   promptActions: css`
     display: flex;
@@ -137,14 +141,14 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     font-weight: 500;
     line-height: 1.2;
     color: ${cssVar.colorText};
+    white-space: nowrap;
   `,
   version: css`
-    margin-block-start: 2px;
-
     font-size: 11px;
     font-variant-numeric: tabular-nums;
     color: ${cssVar.colorTextTertiary};
-    letter-spacing: -0.01em;
+    white-space: nowrap;
+    letter-spacing: 0;
   `,
 }));
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

- Changed the desktop updater notice card from a translucent blurred background to a solid elevated background.
- Kept the update title and version on a single line to avoid an oversized two-line notice.
- Increased the minimum card width slightly so the prompt and actions fit cleanly.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Verified in the real Electron desktop window by triggering the updater simulation and inspecting the lower-left update notice.

#### 📸 Screenshots / Videos

Validated locally in the Electron desktop client.

#### 📝 Additional Information

No runtime behavior changes. This PR only adjusts updater notice presentation.
