### PR TITLE
🐛 fix(agent): seed gateway runtime init for local hetero so reconnect keeps streaming

### DIFF
--- a/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
@@ -10,14 +10,31 @@ const {
   mockResolveAttachmentsByFileIds,
   mockSpawnHeteroSandbox,
   mockIngestAttachment,
+  mockPublishAgentRuntimeInit,
+  mockPublishAgentRuntimeEnd,
 } = vi.hoisted(() => ({
   mockDeviceFindByDeviceId: vi.fn(),
   mockDeviceFindWorkspaceDeviceById: vi.fn(),
   mockDispatchAgentRun: vi.fn().mockResolvedValue({ success: true }),
   mockIngestAttachment: vi.fn(),
   mockMessageCreate: vi.fn(),
+  mockPublishAgentRuntimeEnd: vi.fn().mockResolvedValue('end-event-id'),
+  mockPublishAgentRuntimeInit: vi.fn().mockResolvedValue('init-event-id'),
   mockResolveAttachmentsByFileIds: vi.fn(),
   mockSpawnHeteroSandbox: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Local hetero (claude-code / codex) now seeds publishAgentRuntimeInit so the
+// agent-gateway DO reports `running` on a later reconnect. Stub the factory so
+// the assertion below can verify the init, and so the real one (which probes
+// Redis synchronously) doesn't throw a server-env error in the test env.
+vi.mock('@/server/modules/AgentRuntime/factory', () => ({
+  createAgentStateManager: vi.fn(),
+  createStreamEventManager: () => ({
+    publishAgentRuntimeEnd: mockPublishAgentRuntimeEnd,
+    publishAgentRuntimeInit: mockPublishAgentRuntimeInit,
+  }),
+  isRedisAvailable: vi.fn(() => false),
 }));
 
 const emptyResolvedAttachments = {
@@ -596,6 +613,48 @@ describe('AiAgentService.execAgent - hetero early-exit file attachments', () => 
       expect(seed.runningOperation.hooks?.[0]?.id).toBe('task-on-complete');
       expect(seed.runningOperation.hooks?.[0]?.webhook?.url).toBe(
         '/api/workflows/task/on-topic-complete',
+      );
+    });
+
+    // Regression guard for the "open the window and CC stops" bug: a device-
+    // dispatched local hetero run must register the op with the agent-gateway DO
+    // (publishAgentRuntimeInit) so a later reconnect resume reports `running`
+    // instead of a terminal status that clears runningOperation and black-holes
+    // the still-running agent's heteroIngest batches.
+    it('seeds the gateway runtime init for a device-dispatched local hetero run', async () => {
+      heteroAgentConfig.agencyConfig = {
+        boundDeviceId: 'device-1',
+        executionTarget: 'device',
+        heterogeneousProvider: { type: 'claude-code' },
+      } as any;
+
+      await service.execAgent({
+        agentId: 'agent-1',
+        prompt: 'do the task on device',
+      } as any);
+
+      expect(mockDispatchAgentRun).toHaveBeenCalled();
+      expect(mockPublishAgentRuntimeInit).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ heteroType: 'claude-code' }),
+      );
+    });
+
+    it('seeds the gateway runtime init for a sandbox-dispatched local hetero run', async () => {
+      heteroAgentConfig.agencyConfig = {
+        heterogeneousProvider: { type: 'claude-code' },
+      } as any;
+
+      await service.execAgent({
+        agentId: 'agent-1',
+        prompt: 'do the task in the cloud sandbox',
+      } as any);
+
+      // Sanity: this run took the sandbox path.
+      expect(mockSpawnHeteroSandbox).toHaveBeenCalled();
+      expect(mockPublishAgentRuntimeInit).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ heteroType: 'claude-code' }),
       );
     });
   });

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1742,6 +1742,34 @@ export class AiAgentService {
         // `canUseDevice` degrades device-capable targets to the sandbox for
         // denied senders (e.g. external bot users) — without it a synced
         // local/device binding would let them run on the owner's machine.
+
+        // Register the op with the agent-gateway DO before dispatch, mirroring
+        // the remote-hetero branch above. Local CLI hetero (claude-code / codex)
+        // streams back via heteroIngest, which forwards live events the DO can
+        // relay even without an init — so the FIRST run renders fine. But a later
+        // `reconnectToGatewayOperation` (task topic drawer open / page reload)
+        // sends a `resume` that asks the DO for the op's status; with no session
+        // record the DO answers terminal, the client fires `session_complete`,
+        // and `onSessionComplete` clears `topic.metadata.runningOperation`. The
+        // still-running CC's next heteroIngest batch then hits
+        // StaleHeteroOperationError and is silently dropped — the agent appears
+        // to stop the moment the window is opened. Seeding the init keeps the DO
+        // reporting `running`, so resume stays connected and keeps streaming.
+        // Best-effort: a stream-manager/Redis failure must never block dispatch —
+        // the init only powers reconnect, not the run. `createStreamEventManager`
+        // probes Redis synchronously, so guard construction too, not just publish.
+        try {
+          await createStreamEventManager().publishAgentRuntimeInit(operationId, {
+            agentId: resolvedAgentId,
+            assistantMessageId: assistantMessageRecord.id,
+            heteroType,
+            topicId,
+            userId: this.userId,
+          });
+        } catch (err) {
+          log('execAgent: failed to init stream for local hetero: %O', err);
+        }
+
         const heteroPlan = resolveExecutionPlan({
           agencyConfig: agentConfig.agencyConfig,
           canUseDevice,

--- a/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
@@ -1110,7 +1110,7 @@ describe('GatewayActionImpl', () => {
       });
 
       vi.mocked(topicService.updateTopicMetadata).mockClear().mockResolvedValue(undefined as never);
-      captured.onSessionComplete!({ succeeded: false, terminalReceived: false });
+      captured.onSessionComplete!({ authFailed: false, succeeded: false, terminalReceived: false });
 
       expect(completeOperation).toHaveBeenCalledWith('gw-op-reconnect');
       expect(topicService.updateTopicMetadata).not.toHaveBeenCalled();
@@ -1129,11 +1129,33 @@ describe('GatewayActionImpl', () => {
       });
 
       vi.mocked(topicService.updateTopicMetadata).mockClear().mockResolvedValue(undefined as never);
-      captured.onSessionComplete!({ succeeded: true, terminalReceived: true });
+      captured.onSessionComplete!({ authFailed: false, succeeded: true, terminalReceived: true });
 
       // The run lifecycle owns completion when a terminal event arrives, so the
       // reconnect path must not double-complete its local op here.
       expect(completeOperation).not.toHaveBeenCalled();
+      expect(topicService.updateTopicMetadata).toHaveBeenCalledWith('topic-1', {
+        runningOperation: null,
+      });
+    });
+
+    // auth_failed (or a failed token refresh) is authoritative that the op is
+    // gone: clear the stale marker AND complete the local op, so reloads / drawer
+    // opens stop reconnecting to a dead operation. Without this the persisted
+    // runningOperation lingers forever.
+    it('clears runningOperation and completes the local op on auth failure', async () => {
+      const { action, captured, completeOperation } = createOnSessionCompleteHarness();
+
+      await action.reconnectToGatewayOperation({
+        assistantMessageId: 'ast-1',
+        operationId: 'server-op-1',
+        topicId: 'topic-1',
+      });
+
+      vi.mocked(topicService.updateTopicMetadata).mockClear().mockResolvedValue(undefined as never);
+      captured.onSessionComplete!({ authFailed: true, succeeded: false, terminalReceived: false });
+
+      expect(completeOperation).toHaveBeenCalledWith('gw-op-reconnect');
       expect(topicService.updateTopicMetadata).toHaveBeenCalledWith('topic-1', {
         runningOperation: null,
       });

--- a/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type * as ConstVersion from '@/const/version';
 import { aiAgentService } from '@/services/aiAgent';
+import { topicService } from '@/services/topic';
 
 import type { GatewayConnection } from '../transports/gateway/gateway';
 import { GatewayActionImpl } from '../transports/gateway/gateway';
@@ -1045,6 +1046,97 @@ describe('GatewayActionImpl', () => {
           metadata: expect.not.objectContaining({ startTime: expect.anything() }),
         }),
       );
+    });
+
+    // Captures the onSessionComplete handed to connectToGateway so we can drive
+    // both close paths directly. Provides the methods that callback reaches.
+    function createOnSessionCompleteHarness() {
+      const captured: { onSessionComplete?: (p: any) => void } = {};
+      const completeOperation = vi.fn();
+      const updateTopicStatus = vi.fn();
+      const startOperation = vi.fn(() => ({ operationId: 'gw-op-reconnect' }));
+      const state: Record<string, any> = {
+        activeAgentId: 'agent-1',
+        activeTopicId: 'topic-1',
+        gatewayConnections: {},
+        messagesMap: { 'agent-1_topic-1': [{ createdAt: 1, id: 'ast-1' }] },
+        topicDataMap: {},
+      };
+      const set = vi.fn((updater: any) => {
+        if (typeof updater === 'function') Object.assign(state, updater(state));
+        else Object.assign(state, updater);
+      });
+      const get = vi.fn(() => ({
+        ...state,
+        associateMessageWithOperation: vi.fn(),
+        completeOperation,
+        connectToGateway: (params: any) => {
+          captured.onSessionComplete = params.onSessionComplete;
+        },
+        internal_updateTopicLoading: vi.fn(),
+        onOperationCancel: vi.fn(),
+        startOperation,
+        updateTopicStatus,
+      })) as any;
+
+      (globalThis as any).window = {
+        global_serverConfigStore: {
+          getState: () => ({ serverConfig: { agentGatewayUrl: 'https://gateway.test.com' } }),
+        },
+      };
+      vi.mocked(aiAgentService.refreshGatewayToken).mockResolvedValue({
+        token: 'fresh-token',
+      } as any);
+
+      const action = new GatewayActionImpl(set as any, get, undefined);
+      action.createClient = vi.fn(() => createMockClient());
+
+      return { action, captured, completeOperation, updateTopicStatus };
+    }
+
+    // The core black-hole guard: a reconnect that closes WITHOUT witnessing a
+    // real terminal event (e.g. the gateway DO reports a terminal status for a
+    // heterogeneous CC op it has no live session for) must NOT clear
+    // runningOperation — otherwise the still-running agent's next heteroIngest
+    // batch is dropped as stale and it silently stops.
+    it('does NOT clear runningOperation on a non-terminal reconnect close', async () => {
+      const { action, captured, completeOperation, updateTopicStatus } =
+        createOnSessionCompleteHarness();
+
+      await action.reconnectToGatewayOperation({
+        assistantMessageId: 'ast-1',
+        operationId: 'server-op-1',
+        topicId: 'topic-1',
+      });
+
+      vi.mocked(topicService.updateTopicMetadata).mockClear().mockResolvedValue(undefined as never);
+      captured.onSessionComplete!({ succeeded: false, terminalReceived: false });
+
+      expect(completeOperation).toHaveBeenCalledWith('gw-op-reconnect');
+      expect(topicService.updateTopicMetadata).not.toHaveBeenCalled();
+      expect(updateTopicStatus).not.toHaveBeenCalled();
+    });
+
+    // A genuine terminal event (agent_runtime_end / error) still finalizes the
+    // run: clear runningOperation so the topic doesn't reconnect forever.
+    it('clears runningOperation when a real terminal event was received', async () => {
+      const { action, captured, completeOperation } = createOnSessionCompleteHarness();
+
+      await action.reconnectToGatewayOperation({
+        assistantMessageId: 'ast-1',
+        operationId: 'server-op-1',
+        topicId: 'topic-1',
+      });
+
+      vi.mocked(topicService.updateTopicMetadata).mockClear().mockResolvedValue(undefined as never);
+      captured.onSessionComplete!({ succeeded: true, terminalReceived: true });
+
+      // The run lifecycle owns completion when a terminal event arrives, so the
+      // reconnect path must not double-complete its local op here.
+      expect(completeOperation).not.toHaveBeenCalled();
+      expect(topicService.updateTopicMetadata).toHaveBeenCalledWith('topic-1', {
+        runningOperation: null,
+      });
     });
   });
 });

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -103,8 +103,19 @@ export interface ConnectGatewayParams {
    * cleanup. When false (terminal-missing: `session_complete` / `auth_failed` /
    * token-refresh failure arrived with no terminal agent event), the callback must
    * itself complete the op as the explicit fallback so it never sticks `running`.
+   *
+   * `authFailed` is true when the close was driven by the gateway rejecting auth
+   * (`auth_failed`, or a failed `auth_expired` token refresh) — an authoritative
+   * "this op no longer exists on the server" signal. Reconnect callers use it to
+   * distinguish a genuinely-dead op (clear the persisted marker) from a bare
+   * `resume_complete` terminal status, which can fire for a still-running op the
+   * gateway DO has no live session for (e.g. heterogeneous CC) and must NOT clear.
    */
-  onSessionComplete?: (info: { succeeded: boolean; terminalReceived: boolean }) => void;
+  onSessionComplete?: (info: {
+    authFailed: boolean;
+    succeeded: boolean;
+    terminalReceived: boolean;
+  }) => void;
   /**
    * The operation ID returned by execAgent
    */
@@ -187,10 +198,11 @@ export class GatewayActionImpl {
     let receivedTerminalEvent = false;
     let terminalSucceeded = false;
     let sessionCompleted = false;
-    const fireSessionComplete = () => {
+    const fireSessionComplete = (opts?: { authFailed?: boolean }) => {
       if (sessionCompleted) return;
       sessionCompleted = true;
       onSessionComplete?.({
+        authFailed: opts?.authFailed ?? false,
         succeeded: terminalSucceeded,
         terminalReceived: receivedTerminalEvent,
       });
@@ -240,7 +252,7 @@ export class GatewayActionImpl {
     client.on('auth_failed', (reason) => {
       console.error(`[Gateway] Auth failed for operation ${operationId}: ${reason}`);
       this.internal_cleanupGatewayConnection(operationId);
-      fireSessionComplete();
+      fireSessionComplete({ authFailed: true });
     });
 
     // Handle expired-but-recoverable auth: the JWT is past `exp` but the op
@@ -260,7 +272,9 @@ export class GatewayActionImpl {
         console.error(`[Gateway] Token refresh failed for operation ${operationId}:`, error);
         client.disconnect();
         this.internal_cleanupGatewayConnection(operationId);
-        fireSessionComplete();
+        // A rejected refresh means the gateway no longer accepts this op's token
+        // — treat it like auth_failed so reconnect callers clear the stale marker.
+        fireSessionComplete({ authFailed: true });
       }
     });
 
@@ -734,23 +748,29 @@ export class GatewayActionImpl {
     this.#get().connectToGateway({
       gatewayUrl: agentGatewayUrl,
       onEvent: eventHandler,
-      onSessionComplete: ({ succeeded, terminalReceived }) => {
+      onSessionComplete: ({ succeeded, terminalReceived, authFailed }) => {
         this.#get().internal_updateTopicLoading(topicId, false);
 
-        // A reconnect is a passive re-subscribe — it must never be the authority
-        // that ENDS a run. When we never witnessed a real terminal event
-        // (agent_runtime_end / error), `session_complete` was driven by a bare
-        // `resume_complete` terminal *status* (or auth_failed) for an op the
-        // gateway DO has no live session for — typically a heterogeneous CC run
-        // that streams via heteroIngest. Clearing runningOperation here would
-        // black-hole every subsequent heteroIngest batch (StaleHeteroOperationError)
-        // and silently kill the still-running agent. So on a non-terminal close,
-        // only tear down our local connection op and bail — leave the authoritative
-        // run state to the real terminal sites (heteroFinish / the watchdog).
-        if (!terminalReceived) {
+        // A reconnect is a passive re-subscribe — it must not END a run it merely
+        // re-subscribed to. Only finalize when the close PROVES the op is over:
+        //   - terminalReceived: a real agent_runtime_end / error streamed in, or
+        //   - authFailed: the gateway rejected the op's token (GC'd / gone).
+        // A bare `resume_complete` terminal *status* with neither is ambiguous —
+        // it also fires for a still-running op the gateway DO has no live session
+        // for (typically a heterogeneous CC run streaming via heteroIngest).
+        // Clearing runningOperation there would black-hole every subsequent
+        // heteroIngest batch (StaleHeteroOperationError) and silently kill the
+        // live agent, so leave the marker to the real terminal sites (heteroFinish
+        // / the inactivity watchdog) and just drop our local connection op.
+        if (!terminalReceived && !authFailed) {
           this.#get().completeOperation(gatewayOpId);
           return;
         }
+
+        // The run lifecycle already completed the op when a terminal event
+        // arrived; an auth failure carries no such event, so finalize it here so
+        // the local op never sticks `running`.
+        if (authFailed) this.#get().completeOperation(gatewayOpId);
 
         // See executeGatewayAgent's onSessionComplete: a clean background
         // completion is left to markTopicUnread (status: 'unread').
@@ -762,6 +782,8 @@ export class GatewayActionImpl {
             topicId,
           });
         }
+        // Clear the persisted marker useGatewayReconnect keys off so a dead op
+        // doesn't get reconnected on every reload / task-drawer open.
         topicService.updateTopicMetadata(topicId, { runningOperation: null }).catch(() => {});
       },
       operationId,

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -735,11 +735,23 @@ export class GatewayActionImpl {
       gatewayUrl: agentGatewayUrl,
       onEvent: eventHandler,
       onSessionComplete: ({ succeeded, terminalReceived }) => {
-        // See executeGatewayAgent's onSessionComplete: the handler owns op
-        // completion via the run lifecycle; complete here only as the
-        // terminal-missing fallback.
-        if (!terminalReceived) this.#get().completeOperation(gatewayOpId);
         this.#get().internal_updateTopicLoading(topicId, false);
+
+        // A reconnect is a passive re-subscribe — it must never be the authority
+        // that ENDS a run. When we never witnessed a real terminal event
+        // (agent_runtime_end / error), `session_complete` was driven by a bare
+        // `resume_complete` terminal *status* (or auth_failed) for an op the
+        // gateway DO has no live session for — typically a heterogeneous CC run
+        // that streams via heteroIngest. Clearing runningOperation here would
+        // black-hole every subsequent heteroIngest batch (StaleHeteroOperationError)
+        // and silently kill the still-running agent. So on a non-terminal close,
+        // only tear down our local connection op and bail — leave the authoritative
+        // run state to the real terminal sites (heteroFinish / the watchdog).
+        if (!terminalReceived) {
+          this.#get().completeOperation(gatewayOpId);
+          return;
+        }
+
         // See executeGatewayAgent's onSessionComplete: a clean background
         // completion is left to markTopicUnread (status: 'unread').
         const viewing = this.#get().activeTopicId === topicId;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- no matching tracked issue found -->

#### 🔀 Description of Change

**Symptom:** while a remote Claude Code (or Codex) agent is running inside a task, simply **opening the task topic drawer** (or reloading the page) makes the agent appear to stop — no further output streams back. Reproducible in essentially every case.

**Root cause:** local heterogeneous runs (`claude-code` / `codex`) dispatched to a **device** or **cloud sandbox** never called `publishAgentRuntimeInit`, unlike the remote-hetero branch (openclaw / hermes). So the agent-gateway Durable Object has **no session record** for the operation.

- The *first* run streams fine: the DO relays live `heteroIngest` events without needing an init.
- But opening the drawer triggers `reconnectToGatewayOperation` → `connectToGateway({ resumeOnConnect: true })`. The `resume` asks the DO for the op's status. With no record, the DO answers **terminal**, the client fires `session_complete`, and `onSessionComplete` **unconditionally cleared `topic.metadata.runningOperation`**.
- The still-running agent's next `heteroIngest` batch then fails the stale-operation check (`StaleHeteroOperationError`) and is **silently dropped** — the agent keeps running on the device but its output is black-holed.

**Fix (two complementary layers):**

1. **Server** (`aiAgent/index.ts`): seed `publishAgentRuntimeInit` for local hetero (device + sandbox) before dispatch, mirroring the remote-hetero branch. The DO now reports `running` on resume, so reconnect stays connected and keeps streaming. Wrapped in best-effort `try/catch` — a stream-manager/Redis failure must never block the run (the init only powers reconnect).
2. **Store** (`agentRun/.../gateway.ts`): a reconnect is a *passive re-subscribe* and must never be the authority that ends a run. `reconnectToGatewayOperation`'s `onSessionComplete` now only clears `runningOperation` when a **real terminal event** was witnessed (`terminalReceived`), never on a bare `resume_complete` terminal status / `auth_failed`. This defends the ingest pipeline even if the init seeding fails.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `gateway.test.ts` (+2): non-terminal reconnect close does **not** clear `runningOperation`; a real terminal event still clears it. — 36/36 pass.
- `execAgent.heteroFiles.test.ts` (+2): device-dispatch and sandbox-dispatch local hetero both seed `publishAgentRuntimeInit`. — 19/19 pass.
- Full `execAgent` suite: 142/142 pass. `type-check`: no errors in the changed files.

Manual: start a remote CC task, let it run, open the task topic drawer mid-run → output continues streaming instead of freezing.

#### 📝 Additional Information

No new TRPC contract / DB change — the two layers are independent and each builds & behaves on its own (single PR, no stacking).