### PR TITLE
✨ feat(mobile): expose agentSkills router to mobileRouter

### DIFF
--- a/apps/server/src/routers/mobile/index.ts
+++ b/apps/server/src/routers/mobile/index.ts
@@ -6,6 +6,7 @@ import { mobileSubscriptionRouter } from '@/business/server/mobile-routers/mobil
 import { publicProcedure, router } from '@/libs/trpc/lambda';
 
 import { agentRouter } from '../lambda/agent';
+import { agentSkillsRouter } from '../lambda/agentSkills';
 import { aiAgentRouter } from '../lambda/aiAgent';
 import { aiChatRouter } from '../lambda/aiChat';
 import { aiModelRouter } from '../lambda/aiModel';
@@ -31,6 +32,7 @@ import { userRouter } from '../lambda/user';
 
 export const mobileRouter = router({
   agent: agentRouter,
+  agentSkills: agentSkillsRouter,
   aiAgent: aiAgentRouter,
   aiChat: aiChatRouter,
   brief: briefRouter,


### PR DESCRIPTION
## Summary

Mount the existing \`agentSkillsRouter\` (from \`lambda/agentSkills.ts\`) on \`mobileRouter\` so the mobile client can call \`trpcClient.agentSkills.importFromMarket({ identifier })\` to install a community SKILL.md from the marketplace.

## Why

lobehub-mobile [LOBE-10653](https://linear.app/lobehub/issue/LOBE-10653/对齐web端技能选择) needs to install community skills from the Skill Store. The natural path — sending the fetched manifest to \`plugin.createOrInstallPlugin\` — gets blocked by Cloudflare WAF for security-themed skills (e.g. \`prompt-guard\`) because the SKILL.md \`content\` field contains prompt-injection attack patterns the WAF flags as malicious. Web sidesteps this entirely by calling \`agentSkills.importFromMarket\` with the identifier only and letting the server fetch the manifest itself — same pattern mobile needs.

## Diff

\`\`\`
apps/server/src/routers/mobile/index.ts | 2 ++
\`\`\`

- 1 import (\`agentSkillsRouter\`)
- 1 router field (\`agentSkills: agentSkillsRouter\`)

Mirrors the plugin-router exposure landed in #16360.

## Test plan

- [x] Type-check passes (CI)
- [ ] After merge → cloud sync → mobile sync, install a SKILL.md from the mobile Skill Store and confirm no WAF 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)