### PR TITLE
♻️ chore: replace LOBE-123 example ids with LIN-123

### DIFF
--- a/packages/shared-tool-ui/src/Render/Linear/index.tsx
+++ b/packages/shared-tool-ui/src/Render/Linear/index.tsx
@@ -46,7 +46,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     display: flex;
     gap: 6px;
     align-items: center;
-
     min-width: 0;
   `,
   timeItem: css`
@@ -198,7 +197,7 @@ const EntityCard = memo<{ entity: LinearEntity }>(({ entity }) => {
 
   // A bare UUID id only earns a slot when there's no title to carry the card
   // (e.g. comments / attachments, where it's also the link target). Human ids
-  // like `LOBE-123` always stay.
+  // like `LIN-123` always stay.
   const showId = Boolean(id) && (!title || !isUuidLike(id!));
 
   return (

--- a/packages/shared-tool-ui/src/Render/Linear/utils.test.ts
+++ b/packages/shared-tool-ui/src/Render/Linear/utils.test.ts
@@ -5,7 +5,7 @@ import { buildLinearRenderModel, isUuidLike } from './utils';
 describe('isUuidLike', () => {
   it('matches bare UUIDs but not human Linear ids', () => {
     expect(isUuidLike('55a0597c-be21-4e73-a1ff-1a45aedf0184')).toBe(true);
-    expect(isUuidLike('LOBE-123')).toBe(false);
+    expect(isUuidLike('LIN-123')).toBe(false);
     expect(isUuidLike('TEST-456')).toBe(false);
     expect(isUuidLike('Engineering')).toBe(false);
   });

--- a/packages/shared-tool-ui/src/Render/Linear/utils.ts
+++ b/packages/shared-tool-ui/src/Render/Linear/utils.ts
@@ -79,7 +79,7 @@ export interface LinearEntity {
 
 // A bare UUID (e.g. a team/comment internal id) carries no meaning for the
 // reader; suppress it when the entity already has a human-readable title. Linear
-// human ids like `LOBE-123` never match this shape, so they stay visible.
+// human ids like `LIN-123` never match this shape, so they stay visible.
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 
 export const isUuidLike = (value: string): boolean => UUID_PATTERN.test(value);


### PR DESCRIPTION
## Summary

Remove `LOBE-123` example references from Linear entity renderer code, replacing them with the standard Linear issue ID format (`LIN-123`). These were example/mock references used to demonstrate UUID detection logic, not issue-tracking markers — but since the codebase policy requires removing all `LOBE-` patterns from source code, these examples are replaced with the publicly documented Linear convention.

## Changes

| File | Change |
|------|--------|
| `packages/shared-tool-ui/src/Render/Linear/utils.ts` | Comment: `LOBE-123` → `LIN-123` |
| `packages/shared-tool-ui/src/Render/Linear/index.tsx` | Comment: `LOBE-123` → `LIN-123` |
| `packages/shared-tool-ui/src/Render/Linear/utils.test.ts` | Test assertion: `LOBE-123` → `LIN-123` |

All changes are semantically identical — both `LOBE-123` and `LIN-123` are non-UUID human-readable identifiers that the `isUuidLike()` function correctly rejects.