### PR TITLE
🐛 fix(conversation-flow): keep a mid-chain toolless prose step in one AssistantGroup

### DIFF
--- a/packages/conversation-flow/src/transformation/MessageCollector.ts
+++ b/packages/conversation-flow/src/transformation/MessageCollector.ts
@@ -118,16 +118,16 @@ export class MessageCollector {
    * that starts at the first tool step (looks like a broken chain).
    *
    * Deliberately narrow:
-   * - Only a turn head (parent is a `user` message). A toolless step after a
-   *   tool result is a mid-chain answer handled elsewhere; folding those would
-   *   change unrelated grouping (and the contextTree path).
+   * - Only a turn head (parent is a `user` message). A toolless step wedged
+   *   mid-chain (between two tool steps) is bridged by `collectAssistantChain`
+   *   itself so the chain stays in one group — see the toolless-continuation
+   *   branch there; it must NOT also be opened as a head here or the same run
+   *   would split.
    * - The immediate continuation must ALREADY carry tools. We intentionally do
    *   not walk through intermediate toolless prose steps: `collectAssistantChain`
-   *   stops at the first toolless continuation (it only recurses through
-   *   tool-using steps), so classifying a multi-prose head would yield a
-   *   tools-less AssistantGroup and still leave the tool step split off. Such a
-   *   multi-prose prelude therefore falls back to standalone bubbles rather than
-   *   a malformed group.
+   *   bridges at most ONE toolless prose step before a tool step (a multi-prose
+   *   prelude — toolless → toolless — still falls back to standalone bubbles
+   *   rather than a malformed group).
    * - A fork (>1 same-agent non-signal continuation) returns false so branch
    *   handling stays untouched.
    */
@@ -202,9 +202,35 @@ export class MessageCollector {
         allToolMessages,
         processedIds,
       );
-    } else {
-      // Final assistant without tools — caller marks the whole chain processed
-      assistantChain.push(continuation);
+      return;
+    }
+
+    // Toolless continuation. By default this is the final narrated answer and the
+    // chain ends here. EXCEPTION: a single toolless prose step wedged BETWEEN two
+    // tool steps — the model narrates mid-turn right before its next tool call —
+    // is part of THIS chain. Ending here would split the following tool step into
+    // its own AssistantGroup and visually break one continuous run into two
+    // bubbles (regression). Mirror `isToolChainHead`, which already bridges this
+    // shape at a turn head (parent === user): walk through the prose step only
+    // when its sole continuation ALREADY carries tools. A multi-prose prelude
+    // (toolless → toolless) still ends here, matching the documented fallback.
+    assistantChain.push(continuation);
+    const onward = this.findFlatChainContinuation(
+      continuation,
+      [], // a toolless step owns no tool results
+      allMessages,
+      processedIds,
+      groupAgentId,
+    );
+    if (onward && onward.tools && onward.tools.length > 0) {
+      processedIds.add(continuation.id);
+      this.collectAssistantChain(
+        onward,
+        allMessages,
+        assistantChain,
+        allToolMessages,
+        processedIds,
+      );
     }
   }
 

--- a/packages/conversation-flow/src/transformation/__tests__/MessageCollector.test.ts
+++ b/packages/conversation-flow/src/transformation/__tests__/MessageCollector.test.ts
@@ -816,5 +816,55 @@ describe('MessageCollector', () => {
 
       expect(assistantChain.map((m) => m.id)).toEqual(['ast-A', 'ast-B', 'ast-C']);
     });
+
+    it('bridges a toolless prose step wedged between two tool steps (no visual split)', () => {
+      // Regression: the model narrates mid-turn (toolless assistant) right before
+      // its next tool call. The prose step is part of ONE continuous run, but the
+      // chain used to terminate at it — splitting the following tool step into a
+      // second AssistantGroup that renders as a separate "Claude Code" bubble.
+      // assistant-anchored shape: the prose is a sibling of ast-A's tool result.
+      const astA = mkAssistant('ast-A', { parentId: 'user-1', tools: [bashTool('tc-1')] });
+      const toolA = mkTool('tool-1', { parentId: 'ast-A', tool_call_id: 'tc-1' });
+      const prose = mkAssistant('ast-prose', { createdAt: 1, parentId: 'ast-A' });
+      const astC = mkAssistant('ast-C', { parentId: 'ast-prose', tools: [bashTool('tc-2')] });
+      const toolC = mkTool('tool-2', { parentId: 'ast-C', tool_call_id: 'tc-2' });
+      const astFinal = mkAssistant('ast-final', { parentId: 'tool-2' });
+
+      const allMessages: Message[] = [astA, toolA, prose, astC, toolC, astFinal];
+      const collector = new MessageCollector(new Map(), new Map());
+
+      const assistantChain: Message[] = [];
+      const allToolMessages: Message[] = [];
+      collector.collectAssistantChain(
+        astA,
+        allMessages,
+        assistantChain,
+        allToolMessages,
+        new Set(),
+      );
+
+      // One unbroken chain — prose step folded in, both tool steps kept together.
+      expect(assistantChain.map((m) => m.id)).toEqual(['ast-A', 'ast-prose', 'ast-C', 'ast-final']);
+      expect(allToolMessages.map((m) => m.id)).toEqual(['tool-1', 'tool-2']);
+    });
+
+    it('does NOT bridge a multi-prose prelude (toolless → toolless ends the chain)', () => {
+      // The bridge is intentionally narrow: it folds at most ONE prose step before
+      // a tool step. Two consecutive toolless steps still terminate the chain so
+      // they fall back to standalone bubbles rather than a malformed group.
+      const astA = mkAssistant('ast-A', { parentId: 'user-1', tools: [bashTool('tc-1')] });
+      const toolA = mkTool('tool-1', { parentId: 'ast-A', tool_call_id: 'tc-1' });
+      const prose1 = mkAssistant('ast-prose-1', { createdAt: 1, parentId: 'ast-A' });
+      const prose2 = mkAssistant('ast-prose-2', { createdAt: 2, parentId: 'ast-prose-1' });
+      const astC = mkAssistant('ast-C', { parentId: 'ast-prose-2', tools: [bashTool('tc-2')] });
+
+      const allMessages: Message[] = [astA, toolA, prose1, prose2, astC];
+      const collector = new MessageCollector(new Map(), new Map());
+
+      const assistantChain: Message[] = [];
+      collector.collectAssistantChain(astA, allMessages, assistantChain, [], new Set());
+
+      expect(assistantChain.map((m) => m.id)).toEqual(['ast-A', 'ast-prose-1']);
+    });
   });
 });


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

A device-run hetero agent (Claude Code) sometimes narrates mid-turn — a **toolless assistant step streamed right before its next tool call**. That prose step is part of one continuous run, but `collectAssistantChain` used to terminate the chain at it. The following tool step then opened a **second** `AssistantGroup`, so a single run rendered as **two separate "Claude Code" bubbles** with split run-time headers — looks like a broken chain even though the `parentId` tree is fully intact.

Root cause is purely in the render/transformation layer (`MessageCollector`), not the persistence/`parentId` chain. Repro topic `tpc_ncV3wT0IXqEP` (device CC, 0 `agent_operations` rows — durations & grouping are reconstructed from the message tree):

```
…UAjA1F9K  asst(tools)                       ← tool step
  └ …SxWQPOQj "The hard location.href…" asst  ← toolless mid-chain narration  ← chain terminated HERE
       └ …4U8mzqSY "Vite is healthy…" asst(tools)  ← forced into a 2nd AssistantGroup
```

**Fix:** `collectAssistantChain` now bridges a single toolless prose step wedged between two tool steps and keeps walking the tool chain — mirroring the turn-head case already handled by `isToolChainHead`. The bridge stays deliberately narrow: a multi-prose prelude (toolless → toolless) still ends the chain and falls back to standalone bubbles, matching the existing documented behavior.

No change to the `parentId` persistence path or the `contextTree` (LLM-context) path.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added two regression tests to `MessageCollector.test.ts`:
- bridges a toolless prose step wedged between two tool steps → one unbroken chain `[ast-A, ast-prose, ast-C, ast-final]`, both tool steps kept together.
- does NOT bridge a multi-prose prelude (toolless → toolless) → chain ends, preserving the documented fallback.

`MessageCollector` 19/19 pass; full `conversation-flow` transformation suite 152/152 pass.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| One continuous run split into two "Claude Code" cards (3m53s / 1m30s), the mid-turn narration divorced from the actions it describes | Single AssistantGroup card spanning the whole run |

🤖 Generated with [Claude Code](https://claude.com/claude-code)