### PR TITLE
🐛 fix(trpc): harden superjson transformer against prototype-pollution keys in batch output

### DIFF
--- a/apps/server/src/routers/async/caller.ts
+++ b/apps/server/src/routers/async/caller.ts
@@ -1,10 +1,10 @@
 import { createTRPCClient, httpLink } from '@trpc/client';
-import superjson from 'superjson';
 import urlJoin from 'url-join';
 
 import { appEnv } from '@/envs/app';
 import { LOBE_CHAT_AUTH_HEADER } from '@/envs/auth';
 import { createAsyncCallerFactory } from '@/libs/trpc/async';
+import { transformer } from '@/libs/trpc/transformer';
 import { signInternalJWT } from '@/libs/trpc/utils/internalJwt';
 import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
 
@@ -27,7 +27,7 @@ export const createAsyncServerClient = async (userId: string) => {
     links: [
       httpLink({
         headers,
-        transformer: superjson,
+        transformer,
         // Use INTERNAL_APP_URL for server-to-server calls to bypass CDN/proxy
         url: urlJoin(appEnv.INTERNAL_APP_URL!, '/trpc/async'),
       }),

--- a/packages/trpc/src/async/init.ts
+++ b/packages/trpc/src/async/init.ts
@@ -1,7 +1,7 @@
 import { initTRPC } from '@trpc/server';
 import debug from 'debug';
-import superjson from 'superjson';
 
+import { transformer } from '../transformer';
 import { type AsyncContext } from './context';
 
 const log = debug('lobe-async:init');
@@ -13,7 +13,7 @@ export const asyncTrpc = initTRPC.context<AsyncContext>().create({
     log('tRPC error formatter called: %O', shape);
     return shape;
   },
-  transformer: superjson,
+  transformer,
 });
 
 log('Async tRPC initialized successfully');

--- a/packages/trpc/src/client/async.ts
+++ b/packages/trpc/src/client/async.ts
@@ -1,13 +1,14 @@
 import { createTRPCClient, httpBatchLink } from '@trpc/client';
-import superjson from 'superjson';
 
 import { type AsyncRouter } from '@/server/routers/async';
+
+import { transformer } from '../transformer';
 
 export const asyncClient = createTRPCClient<AsyncRouter>({
   links: [
     httpBatchLink({
       maxURLLength: 2083,
-      transformer: superjson,
+      transformer,
       url: '/trpc/async',
     }),
   ],

--- a/packages/trpc/src/client/lambda.ts
+++ b/packages/trpc/src/client/lambda.ts
@@ -4,10 +4,11 @@ import { createTRPCReact } from '@trpc/react-query';
 import { observable } from '@trpc/server/observable';
 import debug from 'debug';
 import { type ModelProvider } from 'model-bank';
-import superjson from 'superjson';
 
 import { isDesktop } from '@/const/version';
 import { type LambdaRouter } from '@/server/routers/lambda';
+
+import { transformer } from '../transformer';
 
 const log = debug('lobe-image:lambda-client');
 
@@ -133,7 +134,7 @@ const linkOptions = {
     log('Headers: %O', headers);
     return headers;
   },
-  transformer: superjson,
+  transformer,
   url: '/trpc/lambda',
 };
 

--- a/packages/trpc/src/client/tools.ts
+++ b/packages/trpc/src/client/tools.ts
@@ -1,8 +1,9 @@
 import { createTRPCClient, httpBatchLink, type TRPCLink } from '@trpc/client';
 import { observable } from '@trpc/server/observable';
-import superjson from 'superjson';
 
 import { type ToolsRouter } from '@/server/routers/tools';
+
+import { transformer } from '../transformer';
 
 // 401 error debouncing for market auth
 let lastMarket401Time = 0;
@@ -75,7 +76,7 @@ export const toolsClient = createTRPCClient<ToolsRouter>({
         return headers;
       },
       maxURLLength: 2083,
-      transformer: superjson,
+      transformer,
       url: '/trpc/tools',
     }),
   ],

--- a/packages/trpc/src/lambda/init.ts
+++ b/packages/trpc/src/lambda/init.ts
@@ -8,8 +8,8 @@
  * @link https://trpc.io/docs/v11/procedures
  */
 import { initTRPC } from '@trpc/server';
-import superjson from 'superjson';
 
+import { transformer } from '../transformer';
 import { type LambdaContext } from './context';
 
 export const trpc = initTRPC.context<LambdaContext>().create({
@@ -29,5 +29,5 @@ export const trpc = initTRPC.context<LambdaContext>().create({
   /**
    * @link https://trpc.io/docs/v11/data-transformers
    */
-  transformer: superjson,
+  transformer,
 });

--- a/packages/trpc/src/transformer.test.ts
+++ b/packages/trpc/src/transformer.test.ts
@@ -1,0 +1,57 @@
+import superjson from 'superjson';
+import { describe, expect, it } from 'vitest';
+
+import { transformer } from './transformer';
+
+describe('trpc transformer (prototype-pollution hardened superjson)', () => {
+  it('reproduces the superjson serialize guard that bare superjson throws on', () => {
+    // sanity check: the bare transformer is the thing that 500s the batch
+    expect(() => superjson.serialize({ prototype: 1 })).toThrow(/Detected property prototype/);
+  });
+
+  it('serializes output containing a literal `prototype` key instead of throwing', () => {
+    const payload = { data: [{ id: 'doc-1', metadata: { prototype: 'oops', title: 'Doc' } }] };
+
+    expect(() => transformer.serialize(payload)).not.toThrow();
+
+    const roundTripped = transformer.deserialize(transformer.serialize(payload));
+    expect(roundTripped).toEqual({
+      data: [{ id: 'doc-1', metadata: { title: 'Doc' } }],
+    });
+  });
+
+  it('strips `__proto__` / `constructor` / `prototype` own keys at any depth', () => {
+    // `{ __proto__: ... }` literal sets the prototype, so build an own key via JSON.parse
+    const poisoned = JSON.parse('{"__proto__": {"polluted": true}, "constructor": 1, "keep": 2}');
+    const payload = { nested: { list: [poisoned] }, prototype: 'x' };
+
+    const result = transformer.deserialize(transformer.serialize(payload)) as any;
+
+    expect(result).toEqual({ nested: { list: [{ keep: 2 }] } });
+    // and global prototype was not polluted in the process
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it('preserves superjson-handled special types (Date, Map, undefined)', () => {
+    const date = new Date('2026-06-23T04:00:00.000Z');
+    const payload = {
+      map: new Map([['a', 1]]),
+      missing: undefined,
+      when: date,
+    };
+
+    const result = transformer.deserialize(transformer.serialize(payload)) as typeof payload;
+
+    expect(result.when).toBeInstanceOf(Date);
+    expect(result.when.toISOString()).toBe('2026-06-23T04:00:00.000Z');
+    expect(result.map).toBeInstanceOf(Map);
+    expect(result.map.get('a')).toBe(1);
+    expect('missing' in result).toBe(true);
+  });
+
+  it('round-trips normal data identically to bare superjson', () => {
+    const payload = { items: [{ count: 3, tags: ['a', 'b'] }], total: 1 };
+
+    expect(transformer.deserialize(transformer.serialize(payload))).toEqual(payload);
+  });
+});

--- a/packages/trpc/src/transformer.ts
+++ b/packages/trpc/src/transformer.ts
@@ -1,0 +1,88 @@
+import superjson from 'superjson';
+
+/**
+ * superjson (>= 2.2.x) hardens its **serializer** against prototype pollution:
+ * while walking an object graph it throws
+ * `Detected property ${key}. This is a prototype pollution risk, ...`
+ * the moment it meets an own key named `__proto__`, `constructor` or
+ * `prototype` (see `superjson/dist/plainer.js` -> `walker`).
+ *
+ * On the tRPC server the response of every procedure is serialized through this
+ * transformer. With `httpBatchLink`, a batch packs many procedures into one
+ * response that is serialized **as a whole, after every procedure has already
+ * resolved** — outside each procedure's own try/catch. So if a *single*
+ * procedure returns data that happens to contain one of those literal keys
+ * (typically a JSONB `metadata` / content value persisted by an agent or tool),
+ * superjson throws and the **entire batch 500s**, taking down unrelated reads
+ * (subscription / topics / messages / memories ...). See LOBE-10706.
+ *
+ * These keys must never travel over the wire anyway — keeping them would be the
+ * very prototype-pollution risk superjson guards against. So instead of letting
+ * one poisoned record break a whole workspace load, we strip them from the value
+ * *before* serialization. The deserializer is left untouched, so untrusted
+ * inbound payloads still hit superjson's built-in guard.
+ */
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  if (value === null || typeof value !== 'object') return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+};
+
+/**
+ * Recursively remove prototype-pollution keys from plain objects / arrays.
+ *
+ * Copy-on-write: when a subtree contains no dangerous key the original
+ * reference is returned untouched, so the common (clean) case allocates
+ * nothing. Non-plain values (Date, Map, Set, class instances, primitives, ...)
+ * are returned as-is so superjson keeps handling their special types.
+ */
+const stripPrototypePollution = (value: unknown, seen: WeakSet<object>): unknown => {
+  if (Array.isArray(value)) {
+    let result: unknown[] | undefined;
+    for (let i = 0; i < value.length; i++) {
+      const sanitized = stripPrototypePollution(value[i], seen);
+      if (sanitized !== value[i] && !result) result = value.slice(0, i);
+      if (result) result.push(sanitized);
+    }
+    return result ?? value;
+  }
+
+  if (isPlainObject(value)) {
+    // guard against the (unrealistic for JSON-derived data) circular reference
+    if (seen.has(value)) return value;
+    seen.add(value);
+
+    const keys = Object.keys(value);
+    let result: Record<string, unknown> | undefined;
+
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
+      const dangerous = DANGEROUS_KEYS.has(key);
+      const sanitized = dangerous ? undefined : stripPrototypePollution(value[key], seen);
+
+      // first divergence -> lazily clone the keys seen so far
+      if ((dangerous || sanitized !== value[key]) && !result) {
+        result = {};
+        for (let j = 0; j < i; j++) result[keys[j]] = value[keys[j]];
+      }
+
+      if (result && !dangerous) result[key] = sanitized;
+    }
+
+    return result ?? value;
+  }
+
+  return value;
+};
+
+/**
+ * Drop-in replacement for the bare `superjson` tRPC transformer that is
+ * resilient to prototype-pollution keys in procedure output. Use this anywhere
+ * `transformer: superjson` was previously passed.
+ */
+export const transformer = {
+  deserialize: superjson.deserialize,
+  serialize: (object: unknown) => superjson.serialize(stripPrototypePollution(object, new WeakSet())),
+};


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-10706

#### 🔀 Description of Change

**Symptom.** Vercel `/trpc/lambda` returns a 500 on the app's init batch:

```
Error [TRPCError]: Detected property prototype. This is a prototype pollution risk, please remove it from your object.
```

The init batch packs ~9 read procedures (`subscription.getSubscription`, `notebook.listDocuments`, `userMemories.retrieveMemoryForTopic`, `agentDocument.getDocuments`, `plugin.getPlugins`, `thread.getThreads`, `topic.getTopics`, `message.getMessages`, `agentSkills.list`). When the guard fires the **entire batch 500s**, so the session can't load its workspace (subscription / topics / messages / memories all fail at once).

**Root cause.** The message comes from superjson's **serializer** (`superjson/dist/plainer.js` → `walker`), *not* its deserializer (which throws a different `"… is not allowed as a property"` message via `accessDeep`). superjson ≥ 2.2.x refuses to serialize any object graph that contains an own key named `__proto__` / `constructor` / `prototype`.

On the tRPC server, every procedure response is serialized through the configured transformer (bare `superjson`). With `httpBatchLink`, the batch response is serialized **as a single unit after all procedures have already resolved** — i.e. *outside* each procedure's own `try/catch`. So if **one** procedure returns data that happens to contain such a literal key (in practice a JSONB `metadata` / content value persisted earlier by an agent or tool), superjson throws and takes down the whole batch, even though every procedure individually succeeded. This is why the failure is at the batch (de)serialization layer and not attributable to a specific procedure.

**Fix.** Introduce a shared, prototype-pollution-hardened transformer (`packages/trpc/src/transformer.ts`) and use it everywhere `transformer: superjson` was passed (lambda/async server inits, lambda/async/tools clients, async server caller). It strips `__proto__` / `constructor` / `prototype` keys from the value **before** serialization:

- **copy-on-write** — clean subtrees (the overwhelmingly common case) are returned by reference, so normal responses allocate nothing;
- **special types preserved** — `Date` / `Map` / `Set` / class instances / `undefined` are left untouched so superjson keeps encoding them correctly;
- **`deserialize` is untouched** — untrusted inbound payloads still hit superjson's built-in guard, so this does not weaken prototype-pollution protection for request input. These keys must never travel the wire anyway, so dropping them from output is the safe resolution.

#### 🧪 How to Test

`packages/trpc/src/transformer.test.ts` covers it:
- reproduces the bare-superjson throw (`Detected property prototype`),
- confirms the new transformer serializes the same payload without throwing,
- strips the keys at any depth (objects + arrays), incl. an own `__proto__` built via `JSON.parse`, and asserts the global prototype is not polluted,
- preserves `Date` / `Map` / `undefined` round-trips,
- round-trips normal data identically to bare superjson.

```
cd packages/trpc && bunx vitest run --silent='passed-only' src/transformer.test.ts
```

- [x] Tested locally
- [x] Added/updated tests
- [x] `bun run type-check` passes

#### 📝 Additional Information

This fixes the entire class of bug for all server-side output serialization paths (lambda / async / tools, and the cloud payment & referral routers, which all build on the lambda init transformer). Cloud-side payment/referral *clients* still use bare superjson, but they only serialize request *input* (structured billing data) and were not part of the failing path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)