### PR TITLE
🐛 fix(conversation): keep final answer visible when a bookkeeping tool trails a folded turn

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -505,12 +505,12 @@ const Group = memo<GroupChildrenProps>(
             <>
               <ProcessFold durationText={durationText} stepCount={blocks.length}>
                 <Flexbox gap={8}>
-                  {processSegments.map((segment, index) => renderSegment(segment, index))}
+                  {processSegments.map((segment) =>
+                    renderSegment(segment, segments.indexOf(segment)),
+                  )}
                 </Flexbox>
               </ProcessFold>
-              {finalSegments.map((segment, index) =>
-                renderSegment(segment, processSegments.length + index),
-              )}
+              {finalSegments.map((segment) => renderSegment(segment, segments.indexOf(segment)))}
             </>
           ) : (
             <>

--- a/src/features/Conversation/Messages/AssistantGroup/components/segments.test.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/components/segments.test.ts
@@ -21,10 +21,26 @@ describe('splitFinalAnswer', () => {
     expect(finalSegments).toEqual([a('a1'), a('a2')]);
   });
 
-  it('folds everything when the turn ends on a workflow segment', () => {
+  it('keeps the final answer visible when a trailing bookkeeping tool follows it', () => {
+    // The agent writes its summary, then ends the turn on a "mark task done" tool
+    // call. The answer must stay out of the fold; only the trailing tool folds.
+    const segments = [w('t1'), a('intro'), w('t2'), a('summary'), w('mark-done')];
+    const { processSegments, finalSegments } = splitFinalAnswer(segments);
+    expect(processSegments).toEqual([w('t1'), a('intro'), w('t2'), w('mark-done')]);
+    expect(finalSegments).toEqual([a('summary')]);
+  });
+
+  it('surfaces the lone answer even when the turn ends on a workflow segment', () => {
     const segments = [a('intro'), w('t1')];
     const { processSegments, finalSegments } = splitFinalAnswer(segments);
-    expect(processSegments).toEqual([a('intro'), w('t1')]);
+    expect(processSegments).toEqual([w('t1')]);
+    expect(finalSegments).toEqual([a('intro')]);
+  });
+
+  it('folds everything when the turn has no answer segment at all', () => {
+    const segments = [w('t1'), w('t2')];
+    const { processSegments, finalSegments } = splitFinalAnswer(segments);
+    expect(processSegments).toEqual([w('t1'), w('t2')]);
     expect(finalSegments).toEqual([]);
   });
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/segments.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/components/segments.ts
@@ -15,20 +15,38 @@ export type GroupRenderSegment = AnswerSegment | WorkflowSegment;
 /**
  * Split a turn's render segments into its process and its final answer.
  *
- * The trailing run of `answer` segments is the final answer (always shown);
- * everything before it — tools, reasoning, intermediate prose — is the process
- * that folds under the Codex-style "已处理 {duration}" header.
+ * The final answer is the *last run* of `answer` segments — even when one or
+ * more bookkeeping tool calls (e.g. "mark task done", "update issue") trail it.
+ * Those trailing workflow segments fold into the process alongside the leading
+ * reasoning/tools so the answer text stays visible, rather than disappearing
+ * inside the fold whenever a turn happens to end on a tool call. Everything that
+ * is not the final answer — leading tools/reasoning/intermediate prose and any
+ * trailing bookkeeping tools — folds under the Codex-style "已处理 {duration}"
+ * header. A turn with no answer segment at all has no final answer to surface.
  */
 export const splitFinalAnswer = (
   segments: GroupRenderSegment[],
 ): { finalSegments: GroupRenderSegment[]; processSegments: GroupRenderSegment[] } => {
-  let splitIndex = segments.length;
-  while (splitIndex > 0 && segments[splitIndex - 1].kind === 'answer') {
-    splitIndex -= 1;
+  let lastAnswerIndex = -1;
+  for (let i = segments.length - 1; i >= 0; i--) {
+    if (segments[i].kind === 'answer') {
+      lastAnswerIndex = i;
+      break;
+    }
   }
+
+  if (lastAnswerIndex === -1) {
+    return { finalSegments: [], processSegments: segments };
+  }
+
+  let runStart = lastAnswerIndex;
+  while (runStart > 0 && segments[runStart - 1].kind === 'answer') {
+    runStart -= 1;
+  }
+
   return {
-    finalSegments: segments.slice(splitIndex),
-    processSegments: segments.slice(0, splitIndex),
+    finalSegments: segments.slice(runStart, lastAnswerIndex + 1),
+    processSegments: [...segments.slice(0, runStart), ...segments.slice(lastAnswerIndex + 1)],
   };
 };
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No matching GitHub/Linear issue found. -->

#### 🔀 Description of Change

When a finished, non-latest turn has its process folded (the `enableFoldFinishedTurn` lab feature), the assistant's final answer disappeared and only the `共运行 N 步` header showed — nothing below it.

**Root cause:** `splitFinalAnswer` defined the "final answer" as the *trailing run* of `answer` segments. When a turn ends on a workflow segment — e.g. the agent's last step is a bookkeeping tool call such as "mark task done" / "update issue" — `finalSegments` came out empty, so the real summary text (which preceded that last tool) was folded entirely into the process. This was even pinned by a test (`folds everything when the turn ends on a workflow segment`).

**Fix:** Redefine the final answer as the *last run* of `answer` segments, regardless of trailing tool calls. Trailing bookkeeping workflow segments now fold alongside the leading reasoning/tools, so the answer text stays visible. Because `processSegments` is no longer guaranteed to be a contiguous prefix, `Group.tsx` now resolves each segment's true index in the full `segments` array (used for `hasRenderedContentAfter` and React key stability).

A turn with no `answer` segment at all still folds entirely (no final answer to surface).

#### 🧪 How to Test

- [x] Added/updated tests

Updated `segments.test.ts`: replaced the old "ends on workflow → fold everything" assertion with three cases — summary followed by a trailing `mark-done` tool (the screenshot scenario), a lone answer followed by a tool, and a pure-workflow turn with no answer. `segments.test.ts` + `Group.test.tsx` pass (23 tests); both changed source files type-check clean.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Folded turn shows only `共运行 N 步`, final summary hidden | Final summary stays visible below the fold; only the trailing tool folds |

#### 📝 Additional Information

Pure UI / render-partitioning change in `src/features/Conversation/Messages/AssistantGroup`. No server contract, schema, or store-shape changes. Only affects the `enableFoldFinishedTurn` lab path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)