### PR TITLE
💄 style(intervention): promote "don't ask again" to a first-class approval option

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -923,6 +923,7 @@
   "tool.intervention.onboarding.userProfile.responseLanguage": "Response language",
   "tool.intervention.onboarding.userProfile.title": "Confirm your profile update",
   "tool.intervention.optionApprove": "Approve",
+  "tool.intervention.optionApproveRemember": "Approve, and don't ask again for similar actions",
   "tool.intervention.pending": "Pending",
   "tool.intervention.reject": "Reject",
   "tool.intervention.rejectOnly": "Reject",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -923,6 +923,7 @@
   "tool.intervention.onboarding.userProfile.responseLanguage": "回复语言",
   "tool.intervention.onboarding.userProfile.title": "确认您的资料更新",
   "tool.intervention.optionApprove": "批准",
+  "tool.intervention.optionApproveRemember": "批准，且类似操作不再询问",
   "tool.intervention.pending": "等待中",
   "tool.intervention.reject": "拒绝",
   "tool.intervention.rejectOnly": "仅拒绝",
@@ -1240,5 +1241,12 @@
   "workingPanel.space": "空间",
   "workingPanel.title": "工作面板",
   "you": "你",
-  "zenMode": "专注模式"
+  "zenMode": "专注模式",
+  "globalApproval.collapse": "收起",
+  "globalApproval.goToConversation": "打开会话",
+  "globalApproval.pendingCount_one": "{{count}} 项待审批",
+  "globalApproval.pendingCount_other": "{{count}} 项待审批",
+  "globalApproval.subtitle": "等待你的审批",
+  "globalApproval.title": "需要审批",
+  "globalApproval.userRequestLabel": "用户请求"
 }

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -998,6 +998,7 @@ export default {
   'tool.intervention.approvalMode': 'Approval Mode',
   'tool.intervention.approve': 'Approve',
   'tool.intervention.optionApprove': 'Approve',
+  'tool.intervention.optionApproveRemember': "Approve, and don't ask again for similar actions",
   'tool.intervention.rememberSimilar': "Don't ask again for similar actions",
   'tool.intervention.submit': 'Submit',
   'tool.intervention.mode.allowList': 'Allow List',

--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/ApprovalActions.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/ApprovalActions.tsx
@@ -1,9 +1,8 @@
 import { Button, Flexbox } from '@lobehub/ui';
-import { Checkbox } from 'antd';
 import { createStaticStyles, cx } from 'antd-style';
 import { CornerDownLeft } from 'lucide-react';
 import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useUserStore } from '@/store/user';
@@ -25,7 +24,7 @@ interface ApprovalActionsProps {
   toolCallId: string;
 }
 
-type Choice = 'approve' | 'reject';
+type Choice = 'approve' | 'approve-remember' | 'reject';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   container: css`
@@ -111,11 +110,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
       color: ${cssVar.colorTextSecondary};
     }
   `,
-  rememberRow: css`
-    margin-block: -2px 4px;
-    padding-block: 4px;
-    padding-inline-start: 42px;
-  `,
   shortcutHint: css`
     display: inline-flex;
     align-items: center;
@@ -135,13 +129,20 @@ const ApprovalActions = memo<ApprovalActionsProps>(
   ({ approvalMode, apiName, assistantGroupId, identifier, messageId, onBeforeApprove }) => {
     const { t } = useTranslation('chat');
     const [choice, setChoice] = useState<Choice>('approve');
-    const [remember, setRemember] = useState(false);
     const [reason, setReason] = useState('');
     const [loading, setLoading] = useState(false);
     const rejectInputRef = useRef<HTMLInputElement>(null);
 
     const isMessageCreating = messageId.startsWith('tmp_');
     const isAllowListMode = approvalMode === 'allow-list';
+
+    // Ordered choices drive both the numbered rows and the 1/2/3 shortcuts.
+    // "Approve & don't ask again" is a first-class option (allow-list only)
+    // rather than a checkbox nested under approve.
+    const choices = useMemo<Choice[]>(
+      () => (isAllowListMode ? ['approve', 'approve-remember', 'reject'] : ['approve', 'reject']),
+      [isAllowListMode],
+    );
 
     const [approveToolCall, rejectAndContinueToolCall] = useConversationStore((s) => [
       s.approveToolCall,
@@ -153,14 +154,14 @@ const ApprovalActions = memo<ApprovalActionsProps>(
       if (loading || isMessageCreating) return;
       setLoading(true);
       try {
-        if (choice === 'approve') {
+        if (choice === 'reject') {
+          await rejectAndContinueToolCall(messageId, reason.trim() || undefined);
+        } else {
           if (onBeforeApprove) await onBeforeApprove();
           await approveToolCall(messageId, assistantGroupId ?? '');
-          if (isAllowListMode && remember) {
+          if (isAllowListMode && choice === 'approve-remember') {
             await addToolToAllowList(`${identifier}/${apiName}`);
           }
-        } else {
-          await rejectAndContinueToolCall(messageId, reason.trim() || undefined);
         }
       } finally {
         setLoading(false);
@@ -179,7 +180,6 @@ const ApprovalActions = memo<ApprovalActionsProps>(
       onBeforeApprove,
       reason,
       rejectAndContinueToolCall,
-      remember,
     ]);
 
     // When choice flips to reject (via click on row, '2', or arrow), pull focus
@@ -201,21 +201,25 @@ const ApprovalActions = memo<ApprovalActionsProps>(
           if (tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable) return;
         }
         if (e.metaKey || e.ctrlKey || e.altKey) return;
+        // Digit keys select the matching numbered row directly.
+        if (/^[1-9]$/.test(e.key)) {
+          const next = choices[Number(e.key) - 1];
+          if (next) {
+            e.preventDefault();
+            setChoice(next);
+          }
+          return;
+        }
         switch (e.key) {
-          case '1': {
-            e.preventDefault();
-            setChoice('approve');
-            break;
-          }
-          case '2': {
-            e.preventDefault();
-            setChoice('reject');
-            break;
-          }
           case 'ArrowUp':
           case 'ArrowDown': {
             e.preventDefault();
-            setChoice((c) => (c === 'approve' ? 'reject' : 'approve'));
+            setChoice((c) => {
+              const idx = choices.indexOf(c);
+              const delta = e.key === 'ArrowUp' ? -1 : 1;
+              const nextIdx = (idx + delta + choices.length) % choices.length;
+              return choices[nextIdx];
+            });
             break;
           }
           case 'Enter': {
@@ -231,7 +235,7 @@ const ApprovalActions = memo<ApprovalActionsProps>(
       return () => {
         window.removeEventListener('keydown', handler);
       };
-    }, [handleSubmit]);
+    }, [choices, handleSubmit]);
 
     const handleRejectInputKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
       if (e.metaKey || e.ctrlKey || e.altKey) return;
@@ -240,60 +244,67 @@ const ApprovalActions = memo<ApprovalActionsProps>(
         void handleSubmit();
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
-        setChoice('approve');
+        const idx = choices.indexOf('reject');
+        const prev = choices[idx - 1];
+        if (prev) setChoice(prev);
         rejectInputRef.current?.blur();
       }
+    };
+
+    const rejectNumber = choices.indexOf('reject') + 1;
+
+    const approveLabel: Record<'approve' | 'approve-remember', string> = {
+      'approve': t('tool.intervention.optionApprove'),
+      'approve-remember': t('tool.intervention.optionApproveRemember'),
     };
 
     return (
       <Flexbox className={styles.container}>
         <div className={styles.optionList} role="radiogroup">
-          <div
-            aria-checked={choice === 'approve'}
-            className={cx(styles.option, choice === 'approve' && styles.optionSelected)}
-            role="radio"
-            onClick={() => setChoice('approve')}
-          >
-            <span className={styles.number}>1.</span>
-            <span className={styles.optionLabel}>{t('tool.intervention.optionApprove')}</span>
-          </div>
+          {choices.map((c, index) => {
+            if (c === 'reject') {
+              return (
+                <div
+                  aria-checked={choice === 'reject'}
+                  className={cx(styles.option, choice === 'reject' && styles.optionSelected)}
+                  key={c}
+                  role="radio"
+                  onClick={() => {
+                    setChoice('reject');
+                    rejectInputRef.current?.focus();
+                  }}
+                >
+                  <span className={styles.number}>{rejectNumber}.</span>
+                  <input
+                    aria-label={t('tool.intervention.rejectReasonPlaceholder')}
+                    className={styles.rejectInput}
+                    disabled={loading || isMessageCreating}
+                    placeholder={t('tool.intervention.rejectReasonPlaceholder')}
+                    ref={rejectInputRef}
+                    type="text"
+                    value={reason}
+                    onChange={(e) => setReason(e.target.value)}
+                    onClick={(e) => e.stopPropagation()}
+                    onFocus={() => setChoice('reject')}
+                    onKeyDown={handleRejectInputKeyDown}
+                  />
+                </div>
+              );
+            }
 
-          {isAllowListMode && choice === 'approve' && (
-            <div className={styles.rememberRow}>
-              <Checkbox
-                checked={remember}
-                disabled={loading || isMessageCreating}
-                onChange={(e) => setRemember(e.target.checked)}
+            return (
+              <div
+                aria-checked={choice === c}
+                className={cx(styles.option, choice === c && styles.optionSelected)}
+                key={c}
+                role="radio"
+                onClick={() => setChoice(c)}
               >
-                {t('tool.intervention.rememberSimilar')}
-              </Checkbox>
-            </div>
-          )}
-
-          <div
-            aria-checked={choice === 'reject'}
-            className={cx(styles.option, choice === 'reject' && styles.optionSelected)}
-            role="radio"
-            onClick={() => {
-              setChoice('reject');
-              rejectInputRef.current?.focus();
-            }}
-          >
-            <span className={styles.number}>2.</span>
-            <input
-              aria-label={t('tool.intervention.rejectReasonPlaceholder')}
-              className={styles.rejectInput}
-              disabled={loading || isMessageCreating}
-              placeholder={t('tool.intervention.rejectReasonPlaceholder')}
-              ref={rejectInputRef}
-              type="text"
-              value={reason}
-              onChange={(e) => setReason(e.target.value)}
-              onClick={(e) => e.stopPropagation()}
-              onFocus={() => setChoice('reject')}
-              onKeyDown={handleRejectInputKeyDown}
-            />
-          </div>
+                <span className={styles.number}>{index + 1}.</span>
+                <span className={styles.optionLabel}>{approveLabel[c]}</span>
+              </div>
+            );
+          })}
         </div>
 
         <div className={styles.footer}>


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

<!-- No tracked issue; UI polish requested directly. -->

#### 🔀 Description of Change

In allow-list approval mode, **"Don't ask again for similar actions"** was rendered as an antd `Checkbox` nested under the Approve option. This makes the choice easy to miss and reads as a secondary toggle rather than a distinct decision.

This PR promotes it to a **first-class second option** — "Approve, and don't ask again for similar actions" — so the approval card is a flat, numbered radio list:

1. Approve
2. Approve, and don't ask again for similar actions  *(allow-list mode only)*
3. Tell the agent what you'd like instead *(reject)*

Implementation notes:
- The option order is now data-driven (`choices`), so the numbered rows, the `1/2/3` digit shortcuts, and the `↑/↓` cycling all follow the same list. In non-allow-list modes the list stays `Approve / Reject` (unchanged behavior).
- Removed the nested `Checkbox` (and its `remember` state / `rememberRow` style); "remember" is now expressed purely by selecting option 2, which still calls `addToolToAllowList` on submit.
- New i18n key `tool.intervention.optionApproveRemember` (en-US source + zh-CN hand translation); the now-unused `rememberSimilar` key is left in place.

#### 🧪 How to Test

- [x] Tested locally

Verified in the Electron desktop app (allow-list approval mode) by triggering a tool call that requires approval. The card renders the three numbered options, and selecting option 2 toggles the radio state correctly (`aria-checked` flips from option 1 to option 2). Confirmed on both the inline intervention card and the top-center global approval notification card.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Approve option with a nested "Don't ask again" checkbox | Flat list: 1. Approve / 2. Approve, and don't ask again / 3. Tell the agent… |

Verification report: https://app.lobehub.com/verify/cfbf3aed-b8f3-49db-97ec-f15e12674d6f

🤖 Generated with [Claude Code](https://claude.com/claude-code)