### PR TITLE
✨ feat(verify): add deleteRun so `lh verify run delete` can remove a published session

### DIFF
--- a/apps/cli/src/commands/verify.test.ts
+++ b/apps/cli/src/commands/verify.test.ts
@@ -11,6 +11,7 @@ const { mockTrpcClient } = vi.hoisted(() => ({
   mockTrpcClient: {
     verify: {
       createRubric: { mutate: vi.fn() },
+      deleteRun: { mutate: vi.fn() },
       getRubric: { query: vi.fn() },
       getSkillBundle: { query: vi.fn() },
       updateRubric: { mutate: vi.fn() },
@@ -91,6 +92,34 @@ describe('verify rubric config commands', () => {
     const printed = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n');
     expect(printed).toContain('Standard');
     expect(printed).toContain('4');
+  });
+});
+
+describe('verify run delete command', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    mockGetTrpcClient.mockResolvedValue(mockTrpcClient);
+    mockTrpcClient.verify.deleteRun.mutate.mockReset().mockResolvedValue({
+      id: 'run-1',
+      success: true,
+    });
+  });
+
+  afterEach(() => consoleSpy.mockRestore());
+
+  const run = async (args: string[]) => {
+    const program = new Command();
+    program.exitOverride();
+    registerVerifyCommand(program);
+    await program.parseAsync(['node', 'lh', 'verify', ...args]);
+  };
+
+  it('deletes the run without prompting when --yes is passed', async () => {
+    await run(['run', 'delete', 'run-1', '--yes']);
+
+    expect(mockTrpcClient.verify.deleteRun.mutate).toHaveBeenCalledWith({ verifyRunId: 'run-1' });
   });
 });
 

--- a/apps/cli/src/commands/verify.ts
+++ b/apps/cli/src/commands/verify.ts
@@ -571,6 +571,27 @@ export function registerVerifyCommand(program: Command) {
       console.log(JSON.stringify(item, null, 2));
     });
 
+  run
+    .command('delete <runId>')
+    .description('Delete a verification session (cascades its results, evidence and report)')
+    .option('-y, --yes', 'Skip the confirmation prompt')
+    .option('--json [fields]', 'Output JSON')
+    .action(async (runId: string, options: { json?: boolean | string; yes?: boolean }) => {
+      const client = await getTrpcClient();
+      if (!options.yes) {
+        const ok = await confirm(
+          `Delete run ${pc.bold(runId)} and all its results, evidence and report? This cannot be undone.`,
+        );
+        if (!ok) return void console.log('Aborted.');
+      }
+      const result = await client.verify.deleteRun.mutate({ verifyRunId: runId });
+      if (options.json !== undefined) {
+        outputJson(result, typeof options.json === 'string' ? options.json : undefined);
+        return;
+      }
+      console.log(`${pc.green('✓')} Deleted run ${pc.bold(result.id)}`);
+    });
+
   // ════════════ result (check result entity) ════════════
   const result = verify.command('result').description('Check results (verify_check_results)');
 

--- a/apps/server/src/routers/lambda/__tests__/verify.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/verify.test.ts
@@ -5,6 +5,7 @@ import { FileService } from '@/server/services/file';
 
 const modelMocks = vi.hoisted(() => ({
   createEvidence: vi.fn(),
+  deleteRun: vi.fn(),
   findRunByOperation: vi.fn(),
   findRunById: vi.fn(),
   findResultById: vi.fn(),
@@ -26,6 +27,7 @@ vi.mock('@/database/models/verifyCheckResult', () => ({
 
 vi.mock('@/database/models/verifyRun', () => ({
   VerifyRunModel: vi.fn(() => ({
+    delete: modelMocks.deleteRun,
     findByOperation: modelMocks.findRunByOperation,
     findById: modelMocks.findRunById,
   })),
@@ -89,6 +91,28 @@ describe('verifyRouter', () => {
 
       expect(modelMocks.findRunById).toHaveBeenCalledWith('other-user-run');
       expect(modelMocks.upsertByCheckItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteRun', () => {
+    it("rejects a run outside the caller's scope before deleting", async () => {
+      modelMocks.findRunById.mockResolvedValueOnce(undefined);
+
+      await expect(createCaller().deleteRun({ verifyRunId: 'other-user-run' })).rejects.toThrow(
+        'Verification run not found',
+      );
+
+      expect(modelMocks.findRunById).toHaveBeenCalledWith('other-user-run');
+      expect(modelMocks.deleteRun).not.toHaveBeenCalled();
+    });
+
+    it('deletes a run the caller owns and returns its id', async () => {
+      modelMocks.findRunById.mockResolvedValueOnce({ id: 'run-1' });
+
+      const res = await createCaller().deleteRun({ verifyRunId: 'run-1' });
+
+      expect(modelMocks.deleteRun).toHaveBeenCalledWith('run-1');
+      expect(res).toEqual({ id: 'run-1', success: true });
     });
   });
 

--- a/apps/server/src/routers/lambda/verify.ts
+++ b/apps/server/src/routers/lambda/verify.ts
@@ -445,6 +445,17 @@ export const verifyRouter = router({
     .input(verifyRunIdInputSchema)
     .query(async ({ ctx, input }) => ctx.runModel.findById(input.verifyRunId)),
 
+  // Delete a whole verification session: the run row cascades to its check
+  // results (→ their evidence) and its report via the schema FKs, so one delete
+  // tears down the published bundle. Ownership-scoped: resolveVerifyRun 404s a
+  // run that isn't the caller's before we touch it.
+  deleteRun: verifyProcedure.input(verifyRunIdInputSchema).mutation(async ({ ctx, input }) => {
+    const run = await resolveVerifyRun(ctx, input.verifyRunId);
+
+    await ctx.runModel.delete(run.id);
+    return { id: run.id, success: true };
+  }),
+
   listRuns: verifyProcedure.query(async ({ ctx }) => ctx.runModel.query()),
 
   listResultsByRun: verifyProcedure.input(verifyRunIdInputSchema).query(async ({ ctx, input }) => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

The verify pipeline could **create** and **read** verification sessions but never **delete** one. A mistakenly-published report — its run plus the check results, evidence and report that cascade from it — was therefore stuck permanently, with no CLI or API way to remove it.

This adds the missing teardown:

- **Server** — a new `verify.deleteRun` TRPC mutation. It resolves the run through the existing `resolveVerifyRun` helper (ownership-scoped — a run that isn't the caller's 404s before anything is touched) and calls the model's already-present, workspace-scoped `VerifyRunModel.delete`.
- **CLI** — `lh verify run delete <runId>`. Prompts for confirmation by default; `--yes` (`-y`) skips it; `--json` for scripting.

Deleting the `verify_runs` row cascades to its check results (→ their evidence) and its report via the existing schema FKs (`onDelete: 'cascade'`), so a single call tears down the whole published bundle — no manual child cleanup needed.

No schema/migration changes: the model method and FK cascades already existed; this only exposes them through the contract and the CLI.

#### 🧪 How to Test

- [x] Added/updated tests

- Server: `bunx vitest run apps/server/src/routers/lambda/__tests__/verify.test.ts` — covers the ownership guard (rejects another user's run before deleting) and the happy path (deletes an owned run, returns `{ id, success: true }`).
- CLI: `bunx vitest run apps/cli/src/commands/verify.test.ts` — covers `run delete <id> --yes` calling `deleteRun` without prompting.

#### 📝 Additional Information

Single atomic PR by design: the CLI calls the new `deleteRun` contract, so both halves land together — the trunk is never in a half-built state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)