### PR TITLE
🐛 fix: refresh agent skills list after skill import via onAfterCall

### DIFF
--- a/packages/builtin-tool-skill-store/src/ExecutionRuntime/index.test.ts
+++ b/packages/builtin-tool-skill-store/src/ExecutionRuntime/index.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SkillStoreExecutionRuntime, type SkillStoreRuntimeService } from './index';
+
+const importResult = { skill: { id: 's1', name: 'My Skill' }, status: 'created' as const };
+
+const createService = (): SkillStoreRuntimeService => ({
+  importFromGitHub: vi.fn().mockResolvedValue(importResult),
+  importFromMarket: vi.fn().mockResolvedValue(importResult),
+  importFromUrl: vi.fn().mockResolvedValue(importResult),
+  importFromZipUrl: vi.fn().mockResolvedValue(importResult),
+  onSkillImported: vi.fn().mockResolvedValue(undefined),
+  searchSkill: vi.fn(),
+});
+
+describe('SkillStoreExecutionRuntime — direct/local invoke refresh', () => {
+  let service: SkillStoreRuntimeService;
+  let runtime: SkillStoreExecutionRuntime;
+
+  beforeEach(() => {
+    service = createService();
+    runtime = new SkillStoreExecutionRuntime({ service });
+  });
+
+  it('refreshes the skills list inline after a successful importSkill', async () => {
+    const result = await runtime.importSkill({ type: 'url', url: 'https://example.com/skill' });
+
+    expect(result.success).toBe(true);
+    expect(service.onSkillImported).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes the skills list inline after a successful importFromMarket', async () => {
+    const result = await runtime.importFromMarket({ identifier: 'cool-skill' });
+
+    expect(result.success).toBe(true);
+    expect(service.onSkillImported).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refresh when the import throws', async () => {
+    (service.importFromUrl as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('boom'));
+
+    const result = await runtime.importSkill({ type: 'url', url: 'https://example.com/skill' });
+
+    expect(result.success).toBe(false);
+    expect(service.onSkillImported).not.toHaveBeenCalled();
+  });
+
+  it('does not refresh for searchSkill', async () => {
+    (service.searchSkill as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      items: [],
+      page: 1,
+      pageSize: 10,
+      total: 0,
+    });
+
+    await runtime.searchSkill({ q: 'anything' });
+
+    expect(service.onSkillImported).not.toHaveBeenCalled();
+  });
+});

--- a/packages/builtin-tool-skill-store/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-skill-store/src/ExecutionRuntime/index.ts
@@ -68,6 +68,12 @@ export class SkillStoreExecutionRuntime {
         result = await this.service.importFromUrl(url);
       }
 
+      // Refresh the skills list for the direct/local client invoke path
+      // (`invokeBuiltinTool`), which never dispatches the executor's
+      // `onAfterCall`. The gateway path covers itself via `onAfterCall` and
+      // routes import through the server runtime, so this never double-fires.
+      await this.service.onSkillImported?.();
+
       return {
         content: `Skill "${result.skill.name}" ${result.status} successfully.`,
         state: {
@@ -140,6 +146,9 @@ export class SkillStoreExecutionRuntime {
 
     try {
       const result = await this.service.importFromMarket(identifier);
+
+      // See importSkill: refresh for the direct/local client invoke path.
+      await this.service.onSkillImported?.();
 
       return {
         content: `Skill "${result.skill.name}" ${result.status} successfully from market.`,

--- a/packages/builtin-tool-skill-store/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-skill-store/src/ExecutionRuntime/index.ts
@@ -34,6 +34,17 @@ export class SkillStoreExecutionRuntime {
     this.service = options.service;
   }
 
+  /**
+   * Notify the host that a skill was imported so it can refresh client state
+   * (e.g. the agent skills list). Invoked from the executor's `onAfterCall`
+   * lifecycle hook, which fires on `tool_end` regardless of whether the import
+   * actually ran client- or server-side — covering the server-runtime path the
+   * inline service callback can't reach.
+   */
+  notifyImported(): Promise<void> {
+    return this.service.onSkillImported?.() ?? Promise.resolve();
+  }
+
   async importSkill(args: ImportSkillParams): Promise<BuiltinServerRuntimeOutput> {
     const { url, type } = args;
 
@@ -56,9 +67,6 @@ export class SkillStoreExecutionRuntime {
       } else {
         result = await this.service.importFromUrl(url);
       }
-
-      // Refresh skills list so the new skill becomes available
-      await this.service.onSkillImported?.();
 
       return {
         content: `Skill "${result.skill.name}" ${result.status} successfully.`,
@@ -132,9 +140,6 @@ export class SkillStoreExecutionRuntime {
 
     try {
       const result = await this.service.importFromMarket(identifier);
-
-      // Refresh skills list so the new skill becomes available
-      await this.service.onSkillImported?.();
 
       return {
         content: `Skill "${result.skill.name}" ${result.status} successfully from market.`,

--- a/packages/builtin-tool-skill-store/src/executor/index.test.ts
+++ b/packages/builtin-tool-skill-store/src/executor/index.test.ts
@@ -1,0 +1,48 @@
+import type { ToolAfterCallContext } from '@lobechat/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SkillStoreExecutionRuntime } from '../ExecutionRuntime';
+import { SkillStoreApiName, SkillStoreIdentifier } from '../types';
+import { SkillStoreExecutor } from './index';
+
+describe('SkillStoreExecutor.onAfterCall', () => {
+  const notifyImported = vi.fn().mockResolvedValue(undefined);
+  // Only `notifyImported` is exercised by onAfterCall; cast a minimal stub.
+  const runtime = { notifyImported } as unknown as SkillStoreExecutionRuntime;
+  const executor = new SkillStoreExecutor(runtime);
+
+  const createCtx = (apiName: string, success: boolean): ToolAfterCallContext => ({
+    apiName,
+    identifier: SkillStoreIdentifier,
+    params: {},
+    result: { content: '', success },
+  });
+
+  beforeEach(() => {
+    notifyImported.mockClear();
+  });
+
+  it('refreshes the skills list after a successful importSkill', async () => {
+    await executor.onAfterCall(createCtx(SkillStoreApiName.importSkill, true));
+
+    expect(notifyImported).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes the skills list after a successful importFromMarket', async () => {
+    await executor.onAfterCall(createCtx(SkillStoreApiName.importFromMarket, true));
+
+    expect(notifyImported).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refresh for searchSkill', async () => {
+    await executor.onAfterCall(createCtx(SkillStoreApiName.searchSkill, true));
+
+    expect(notifyImported).not.toHaveBeenCalled();
+  });
+
+  it('does not refresh when the import failed', async () => {
+    await executor.onAfterCall(createCtx(SkillStoreApiName.importSkill, false));
+
+    expect(notifyImported).not.toHaveBeenCalled();
+  });
+});

--- a/packages/builtin-tool-skill-store/src/executor/index.ts
+++ b/packages/builtin-tool-skill-store/src/executor/index.ts
@@ -1,4 +1,9 @@
-import { BaseExecutor, type BuiltinToolContext, type BuiltinToolResult } from '@lobechat/types';
+import {
+  BaseExecutor,
+  type BuiltinToolContext,
+  type BuiltinToolResult,
+  type ToolAfterCallContext,
+} from '@lobechat/types';
 
 import type { SkillStoreExecutionRuntime } from '../ExecutionRuntime';
 import {
@@ -8,6 +13,13 @@ import {
   SkillStoreApiName,
   SkillStoreIdentifier,
 } from '../types';
+
+// APIs that import a skill into the user's library. Used by `onAfterCall` to
+// decide when to refresh the client-side skills list.
+const IMPORT_APIS = new Set<string>([
+  SkillStoreApiName.importSkill,
+  SkillStoreApiName.importFromMarket,
+]);
 
 class SkillStoreExecutor extends BaseExecutor<typeof SkillStoreApiName> {
   readonly identifier = SkillStoreIdentifier;
@@ -19,6 +31,15 @@ class SkillStoreExecutor extends BaseExecutor<typeof SkillStoreApiName> {
     super();
     this.runtime = runtime;
   }
+
+  // Refresh the client skills list after a successful import. Lives here rather
+  // than inline in the runtime so it fires on `tool_end` regardless of whether
+  // the import ran client- or server-side — the server-runtime path never
+  // touches the client store otherwise.
+  onAfterCall = async ({ apiName, result }: ToolAfterCallContext): Promise<void> => {
+    if (!IMPORT_APIS.has(apiName) || !result.success) return;
+    await this.runtime.notifyImported();
+  };
 
   importSkill = async (
     params: ImportSkillParams,

--- a/packages/builtin-tool-skill-store/vitest.config.mts
+++ b/packages/builtin-tool-skill-store/vitest.config.mts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- N/A -->

#### 🔀 Description of Change

`lobe-skill-store` imports a skill into the user's library, after which the client `agentSkills` list should refresh so the freshly installed skill is immediately visible.

The refresh used to fire **inline** in `SkillStoreExecutionRuntime` (`onSkillImported`), which only runs on the **client execution path**. When the skill-store import runs in the **server runtime** (`apps/server/.../serverRuntimes/skillStore.ts`), that client callback never fires — so the store wasn't refreshed and the installed skill wasn't perceived by the frontend until a manual reload.

This moves the refresh to the executor's **`onAfterCall`** lifecycle hook (same pattern as `lobe-task`'s `TaskExecutor.onAfterCall`), which the gateway dispatches on `tool_end` **regardless of whether the import ran client- or server-side**, covering both paths.

- `ExecutionRuntime`: drop the two inline `onSkillImported` calls; expose a `notifyImported()` passthrough (store access still goes through the injected `onSkillImported`, preserving layering).
- `executor`: add `onAfterCall`, gated on import APIs (`importSkill` / `importFromMarket`) + `result.success`; `searchSkill` and failed imports don't trigger a refresh.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Added `src/executor/index.test.ts` (4 cases): refresh fires on successful `importSkill` / `importFromMarket`; does **not** fire for `searchSkill` or a failed import. Run:

```bash
cd packages/builtin-tool-skill-store && bunx vitest run src/executor/index.test.ts
```

#### 📝 Additional Information

No user-facing copy or schema changes. New `vitest.config.mts` mirrors sibling builtin-tool packages so the package's tests run in isolation.