### PR TITLE
🐛 fix(agent-runtime): arm bounded verify when async-tool parent state is missing

### DIFF
--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.test.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.test.ts
@@ -1857,6 +1857,52 @@ describe('AgentRuntimeService', () => {
       expect(mockQueueService.scheduleMessage).not.toHaveBeenCalled();
     });
 
+    it('arms a verify when the parent state is missing/expired and scheduleVerifyOnHold is set', async () => {
+      // Redis read replica hasn't seen the park yet, or the child outran the
+      // parent's park. A missing state must retry, not strand on the first miss.
+      mockCoordinator.loadAgentState.mockResolvedValue(null);
+      const casSpy = vi.spyOn(AgentOperationModel.prototype, 'tryResumeFromAsyncTool');
+
+      const won = await service.tryResumeParentFromAsyncTool(
+        { parentOperationId: parentOpId },
+        { scheduleVerifyOnHold: true },
+      );
+
+      expect(won).toBe(false);
+      expect(casSpy).not.toHaveBeenCalled();
+      expect(mockQueueService.scheduleMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operationId: parentOpId,
+          payload: { asyncToolVerifyAttempt: 1, verifyAsyncToolBarrier: true },
+          // No state to read stepCount from — falls back to 0.
+          stepIndex: 0,
+        }),
+      );
+    });
+
+    it('does not arm a verify on missing state when scheduleVerifyOnHold is not set', async () => {
+      // The clean-done bridge path resumes without opting into the watchdog;
+      // a missing state there must stay a silent no-op, not schedule a re-check.
+      mockCoordinator.loadAgentState.mockResolvedValue(null);
+
+      const won = await service.tryResumeParentFromAsyncTool({ parentOperationId: parentOpId });
+
+      expect(won).toBe(false);
+      expect(mockQueueService.scheduleMessage).not.toHaveBeenCalled();
+    });
+
+    it('stops re-arming on missing state once the bounded attempts are exhausted', async () => {
+      mockCoordinator.loadAgentState.mockResolvedValue(null);
+
+      const won = await service.tryResumeParentFromAsyncTool(
+        { parentOperationId: parentOpId },
+        { scheduleVerifyOnHold: true, verifyAttempt: 6 },
+      );
+
+      expect(won).toBe(false);
+      expect(mockQueueService.scheduleMessage).not.toHaveBeenCalled();
+    });
+
     it('schedules a finish step when the parked tool requests onComplete=finish (skipCallSupervisor / delegate)', async () => {
       mockCoordinator.loadAgentState.mockResolvedValue({
         pendingToolsCalling: [{ id: 'tc1' }],

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -1758,11 +1758,16 @@ export class AgentRuntimeService {
 
     const state = await this.coordinator.loadAgentState(parentOperationId);
     if (!state) {
-      // State expired (Redis TTL) or never persisted — nothing left to resume.
-      // Surface it: a missing state at completion time is how a parent silently
-      // strands. There is no stepCount/status to arm a verify against.
-      log('[%s] async-tool resume: parent state missing/expired, cannot resume', parentOperationId);
+      // State expired (Redis TTL) or never persisted. A missing state at
+      // completion time is a classic way a parent silently strands — but it is
+      // often transient: a read replica that hasn't seen the park yet, or the
+      // child outrunning the parent's park before its snapshot lands. Arm the
+      // bounded verify so a later re-check can resume once the state is visible,
+      // instead of giving up on the first miss. A genuinely-gone parent just
+      // exhausts the attempt cap (verify_exhausted) rather than stranding here.
+      log('[%s] async-tool resume: parent state missing/expired, arming verify', parentOperationId);
       asyncToolResumeCounter.add(1, { outcome: 'no_state' });
+      await this.maybeScheduleAsyncToolVerify(parentOperationId, null, options);
       return false;
     }
 
@@ -1861,12 +1866,16 @@ export class AgentRuntimeService {
    */
   private async maybeScheduleAsyncToolVerify(
     parentOperationId: string,
-    state: AgentState,
+    state: AgentState | null,
     options?: { scheduleVerifyOnHold?: boolean; verifyAttempt?: number },
   ): Promise<void> {
     if (!options?.scheduleVerifyOnHold || !this.queueService) return;
 
-    const status = state.status as string;
+    // `state` is null when the parked snapshot is missing/expired at completion
+    // time (no_state). We can't read a status to skip a terminal op, but the
+    // bounded attempt cap below keeps a genuinely-gone parent from re-arming
+    // forever, so it's safe to retry instead of stranding on a transient miss.
+    const status = state?.status as string | undefined;
     if (status === 'done' || status === 'error' || status === 'interrupted') return;
 
     const attempt = options.verifyAttempt ?? 1;
@@ -1878,7 +1887,7 @@ export class AgentRuntimeService {
         '[%s] async-tool barrier verify exhausted after %d attempts, giving up (status: %s)',
         parentOperationId,
         ASYNC_TOOL_VERIFY_MAX_ATTEMPTS,
-        status,
+        status ?? 'missing',
       );
       asyncToolResumeCounter.add(1, { outcome: 'verify_exhausted' });
       return;
@@ -1891,7 +1900,7 @@ export class AgentRuntimeService {
       attempt,
       ASYNC_TOOL_VERIFY_MAX_ATTEMPTS,
       delay,
-      status,
+      status ?? 'missing',
     );
 
     try {
@@ -1902,7 +1911,7 @@ export class AgentRuntimeService {
         operationId: parentOperationId,
         payload: { asyncToolVerifyAttempt: attempt, verifyAsyncToolBarrier: true },
         priority: 'high',
-        stepIndex: state.stepCount,
+        stepIndex: state?.stepCount ?? 0,
       });
     } catch (error) {
       log(


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Related to LOBE-10860 (sub-agent finishes but parent op永久卡在 `waiting_for_async_tool`).

#### 🔀 Description of Change

When a sub-agent completes and tries to resume its parked parent via `tryResumeParentFromAsyncTool`, a **missing parent state** (Redis TTL expiry, read-replica lag, or the child outrunning the parent's park before its snapshot lands) hit the `no_state` branch — which returned early **without arming any verify re-check**. The bounded-retry hardening from #15855 covered `barrier_held` / `no_pending` / `not-yet-parked`, but the `no_state` exit was left to give up on the first miss. That is a structural way a parent silently strands in `waiting_for_async_tool` forever.

Real-world instance: a sub-agent died mid-`runCommand` (untimed sandbox call → killed by serverless max-duration), its inactivity watchdog fired and `finalize-abandoned` + `completeSubAgentBridge` ran (placeholder tool message was backfilled), but the final barrier+CAS resume gave up at `no_state` and the parent never woke.

This PR makes the `no_state` branch arm the **same bounded verify** as the other not-yet-resumable branches:

- `no_state` now calls `maybeScheduleAsyncToolVerify(parentOperationId, null, options)` instead of a bare `return false`. A later re-check can resume once the state becomes visible; a genuinely-gone parent just exhausts the attempt cap (`verify_exhausted`) rather than stranding on the first miss.
- `maybeScheduleAsyncToolVerify` now tolerates a `null` state (no status to skip terminal ops; `stepIndex` falls back to `0`; logs fall back to `'missing'`).
- Behavior stays opt-in: only callers that pass `scheduleVerifyOnHold: true` (the bridge / verify paths) retry. The clean-done direct-resume path (no options) remains a silent no-op.

Not in scope (left for follow-up on LOBE-10860): adding a hard timeout to `runCommand`'s sandbox call, and a DB-level reaper backstop once `verify_exhausted` is reached.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

`AgentRuntimeService.test.ts` — 92/92 pass, including 3 new cases:
- arms a verify when parent state is missing/expired **and** `scheduleVerifyOnHold` is set
- does **not** arm a verify on missing state when `scheduleVerifyOnHold` is not set (clean-done path stays a no-op)
- stops re-arming on missing state once the bounded attempts are exhausted

#### 📝 Additional Information

Targets `canary` per release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)