### PR TITLE
✨ feat(mobile): expose taskTemplate router to mobileRouter

### DIFF
--- a/apps/server/src/routers/mobile/index.ts
+++ b/apps/server/src/routers/mobile/index.ts
@@ -25,6 +25,7 @@ import { pushTokenRouter } from '../lambda/pushToken';
 import { sessionRouter } from '../lambda/session';
 import { sessionGroupRouter } from '../lambda/sessionGroup';
 import { taskRouter } from '../lambda/task';
+import { taskTemplateRouter } from '../lambda/taskTemplate';
 import { topicRouter } from '../lambda/topic';
 import { uploadRouter } from '../lambda/upload';
 import { userRouter } from '../lambda/user';
@@ -52,6 +53,7 @@ export const mobileRouter = router({
   sessionGroup: sessionGroupRouter,
   subscription: mobileSubscriptionRouter,
   task: taskRouter,
+  taskTemplate: taskTemplateRouter,
   topic: topicRouter,
   upload: uploadRouter,
   user: userRouter,


### PR DESCRIPTION
## Summary

Mount the existing `taskTemplate` lambda router under the mobile root so the mobile client (lobehub-mobile) can call `listDailyRecommend`, `dismiss`, and `recordCreated` directly via `trpcClient.taskTemplate.*`.

The lambda router (`apps/server/src/routers/lambda/taskTemplate.ts`) already exists and is in use by the web client — this PR only wires it into the mobile entrypoint.

## Why

Mobile is adding the "Recommended task templates" surface (parallel to web's `RecommendTaskTemplates`). Without this mount, the mobile client gets `No procedure found on path "taskTemplate.recordCreated"` when adding a template-driven task.

## Test plan

- `apps/server/src/routers/lambda/taskTemplate.ts` schemas already covered by existing tests.
- After deploy, the mobile client can fetch / dismiss / record recommendations against `app.lobehub.com`.

## Follow-up

A companion cloud-repo PR will bump the submodule hash to include this commit.