### PR TITLE
♻️ refactor: replace LOBE-XXX markers with contextual comments (2026-06-29)

### DIFF
--- a/apps/server/src/modules/AgentRuntime/AgentStateManager.ts
+++ b/apps/server/src/modules/AgentRuntime/AgentStateManager.ts
@@ -25,9 +25,9 @@ export interface AgentOperationMetadata {
   /**
    * When set, the Gateway stream notifier mirrors this operation's stream events
    * onto the named operation's Gateway channel as well (single-connection
-   * multiplexing, LOBE-10868). Used so a broadcast member's streaming events
-   * also flow down the supervisor's existing WebSocket — the supervisor's own
-   * operationId — instead of stranding on a member channel nobody subscribes to.
+   * multiplexing). Used so a broadcast member's streaming events also flow down
+   * the supervisor's existing WebSocket — the supervisor's own operationId —
+   * instead of stranding on a member channel nobody subscribes to.
    */
   mirrorToOperationId?: string;
   modelRuntimeConfig?: any;

--- a/apps/server/src/modules/AgentRuntime/GatewayStreamNotifier.ts
+++ b/apps/server/src/modules/AgentRuntime/GatewayStreamNotifier.ts
@@ -31,7 +31,7 @@ export class GatewayStreamNotifier implements IStreamEventManager {
    * supervisor op), every Gateway push for that operation is additionally
    * delivered to the mirror op's channel — so member streaming events ride down
    * the supervisor's single WebSocket instead of stranding on a per-member
-   * channel nobody subscribes to (single-connection multiplexing, LOBE-10868).
+   * channel nobody subscribes to (single-connection multiplexing).
    *
    * Two population paths, so this works both in-process AND across queue workers:
    *  - fast path: set at `publishAgentRuntimeInit` from the initial state (the

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -528,7 +528,7 @@ export class AgentRuntimeService {
       // For an in-group broadcast/speak member, mirror its Gateway stream events
       // onto the supervisor op's channel (parentOperationId) so they flow down the
       // supervisor's existing WebSocket — the client subscribes to one connection,
-      // not one per member (single-connection multiplexing, LOBE-10868).
+      // not one per member (single-connection multiplexing).
       const mirrorToOperationId =
         appContext?.orchestrationRole === 'member' ? (parentOperationId ?? undefined) : undefined;
       await this.coordinator.createAgentOperation(operationId, {

--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -269,9 +269,10 @@ export class CompletionLifecycle {
                 payload: {
                   agentId: metadata?.agentId,
                   // Anchor the deferred skill synthesis to the completed assistant
-                  // turn (LOBE-10802): the completion-stage skill handler walks
-                  // this id back to the user message to read the parked candidate
-                  // and seeds the skill under the assistant group. Resolved from
+                  // turn: the completion-stage skill handler walks this id back
+                  // to the user message to read the parked candidate and seeds
+                  // the skill under the assistant group — instead of synthesizing
+                  // from the user prompt alone at inbound time. Resolved from
                   // the final assistant message row when operation metadata omits
                   // it (the server execAgent path).
                   anchorMessageId: assistantMessageId,
@@ -482,8 +483,10 @@ export class CompletionLifecycle {
     // Operation-level metadata only carries `assistantMessageId` on the client
     // runtime path; a server `execAgent` turn leaves it unset (`{}` in DB). Fall
     // back to the persisted id on the final assistant message row in state so the
-    // completion event can anchor deferred skill synthesis to this turn
-    // (LOBE-10802). A metadata value, when present, still wins.
+    // completion event can anchor deferred skill synthesis to this turn (skill
+    // synthesis deferred from inbound to turn completion so it uses the full
+    // trajectory — tool sequence + final product — not just the user prompt).
+    // A metadata value, when present, still wins.
     const assistantMessageId =
       metadata?.assistantMessageId ?? (lastAssistantMessage as { id?: string } | undefined)?.id;
 

--- a/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
@@ -227,11 +227,13 @@ describe('CompletionLifecycle.buildLifecycleEvent', () => {
   });
 
   it('resolves assistantMessageId from the final assistant message row when metadata omits it', () => {
-    // Regression (LOBE-10802): a server execAgent turn carries operation-level
-    // metadata ({} in DB) with no assistantMessageId, so the completion event
-    // previously shipped assistantMessageId=undefined and the deferred
-    // skill-synthesis handler no-oped. The id must fall back to the persisted
-    // id on the final assistant message row in state.
+    // Regression: a server execAgent turn carries operation-level metadata
+    // ({} in DB) with no assistantMessageId, so the completion event previously
+    // shipped assistantMessageId=undefined and the deferred skill-synthesis
+    // handler no-oped. The id must fall back to the persisted id on the final
+    // assistant message row in state (deferred skill synthesis needs the
+    // anchor to seed the skill under the assistant group, not under the user
+    // message).
     const state = {
       messages: [
         { content: 'user prompt', id: 'msg-user', role: 'user' },
@@ -416,10 +418,12 @@ describe('CompletionLifecycle.emitSignalEvents — assistant anchor', () => {
   });
 
   it('ships the resolved assistantMessageId on the completed payload for a server turn', async () => {
-    // Regression (LOBE-10802): on a server execAgent turn the operation metadata
-    // has no assistantMessageId, so the agent.execution.completed event used to
-    // carry assistantMessageId=undefined and the deferred skill-synthesis handler
-    // no-oped. The payload must now anchor to the final assistant message row.
+    // Regression: on a server execAgent turn the operation metadata has no
+    // assistantMessageId, so the agent.execution.completed event used to carry
+    // assistantMessageId=undefined and the deferred skill-synthesis handler
+    // no-oped. The payload must now anchor to the final assistant message row
+    // (so deferred skill synthesis seeds the skill under the completed turn's
+    // assistant group, not as a floating mainline root).
     const emitSpy = vi
       .spyOn(agentSignalService, 'emitAgentSignalSourceEvent')
       .mockResolvedValue(undefined as any);

--- a/apps/server/src/services/agentSignal/policies/analyzeIntent/__tests__/completionSkillSynthesis.test.ts
+++ b/apps/server/src/services/agentSignal/policies/analyzeIntent/__tests__/completionSkillSynthesis.test.ts
@@ -9,7 +9,10 @@ import { createCompletionSkillSynthesisSourceHandler } from '../completionSkillS
 import type { PendingSkillSynthesis, RecordedSkillIntent } from '../skillIntentRecord';
 
 /**
- * LOBE-10802 — deferred skill synthesis on `agent.execution.completed`.
+ * Deferred skill synthesis on `agent.execution.completed` — skill synthesis
+ * moved from user-message-inbound to turn-completion so the evidence carries the
+ * full trajectory (tool sequence + final product) instead of just the user
+ * prompt.
  *
  * These tests pin the completion-stage handler in isolation: the parked
  * candidate is read, the turn trajectory (tool sequence + final product) is
@@ -261,10 +264,11 @@ describe('createCompletionSkillSynthesisSourceHandler', () => {
 });
 
 /**
- * End-to-end across the seam the LOBE-10802 bug lived in: emit the completion
- * event from a *server execAgent* state whose operation metadata carries NO
- * per-turn `assistantMessageId` (DB shape: `{}` + agentId/topicId/userId), then
- * feed the emitted payload straight into the completion-skill-synthesis handler.
+ * End-to-end across the seam the deferred skill synthesis bug lived in: emit the
+ * completion event from a *server execAgent* state whose operation metadata
+ * carries NO per-turn `assistantMessageId` (DB shape: `{}` + agentId/topicId/
+ * userId), then feed the emitted payload straight into the completion-skill-
+ * synthesis handler.
  *
  * The whole logic chain runs in-process — no QStash, no HTTP. The earlier
  * handler tests hardcoded `assistantMessageId` in `createSource()`, which masked

--- a/apps/server/src/services/agentSignal/policies/analyzeIntent/__tests__/feedbackAction.test.ts
+++ b/apps/server/src/services/agentSignal/policies/analyzeIntent/__tests__/feedbackAction.test.ts
@@ -431,11 +431,11 @@ describe('feedbackActionPlanner', () => {
   });
 
   /**
-   * @example
-   * LOBE-10802: a server execAgent inbound skill candidate (trigger is neither
+   * A server execAgent inbound skill candidate (trigger is neither
    * `client.runtime.*` nor an agent-signal self-iteration run) is parked WITH a
    * synthesis payload and NOT dispatched on the user prompt alone — the deferred
-   * completion-stage handler synthesizes it off the full trajectory instead.
+   * completion-stage handler synthesizes it off the full trajectory instead of
+   * just the user prompt.
    */
   it('parks a server-inbound skill candidate until agent.execution.completed', async () => {
     const store = createStore();

--- a/apps/server/src/services/agentSignal/policies/analyzeIntent/actions/skillManagement.ts
+++ b/apps/server/src/services/agentSignal/policies/analyzeIntent/actions/skillManagement.ts
@@ -156,9 +156,10 @@ export const executeSkillManagementAction = async (
     const { assistantMessageId, messageId, topicId } = action.payload;
 
     // Anchor the skill seed under the completed assistant turn when the synthesis
-    // ran deferred at `agent.execution.completed` (LOBE-10802); fall back to the
-    // user message for the legacy inbound dispatch. Anchoring to the assistant
-    // message keeps the seed inside the assistant group instead of surfacing as a
+    // ran deferred at `agent.execution.completed` (skill delayed to turn
+    // completion so evidence carries the full trajectory); fall back to the user
+    // message for the legacy inbound dispatch. Anchoring to the assistant message
+    // keeps the seed inside the assistant group instead of surfacing as a
     // floating `parent_id=null` mainline root.
     const anchorMessageId = assistantMessageId ?? messageId;
 

--- a/apps/server/src/services/agentSignal/policies/analyzeIntent/completionSkillSynthesis.ts
+++ b/apps/server/src/services/agentSignal/policies/analyzeIntent/completionSkillSynthesis.ts
@@ -127,7 +127,7 @@ const renderTrajectoryMessage = (message: CompletedTurnMessage): string => {
  * Assembles the completed-turn trajectory (user request, the tool-call sequence,
  * tool results, and the final assistant product) into one XML envelope used as
  * the deferred skill synthesis context. This is the evidence the inbound prompt
- * alone could not provide (LOBE-10802 acceptance: evidence carries the tool
+ * alone could not provide (deferred synthesis: evidence carries the tool
  * sequence + final product, not just the user prompt).
  */
 const assembleTrajectoryContext = async (input: {
@@ -182,7 +182,8 @@ export type CompletionSkillSynthesisOptions = SkillManagementActionHandlerOption
 
 /**
  * Builds the `agent.execution.completed` source handler that performs deferred
- * skill synthesis (LOBE-10802).
+ * skill synthesis (skill synthesis delayed to turn completion so evidence
+ * carries the full trajectory instead of just the user prompt).
  *
  * For a normal, non-error, non-self-iteration server execAgent turn it:
  * 1. Hydrates the completed turn (assistant -> user parent).

--- a/apps/server/src/services/agentSignal/policies/analyzeIntent/feedbackAction.ts
+++ b/apps/server/src/services/agentSignal/policies/analyzeIntent/feedbackAction.ts
@@ -126,10 +126,12 @@ const detectClientComplete = (signal: FeedbackDomainSignal) => {
 
 /**
  * Detects a server execAgent inbound skill candidate that should be parked and
- * synthesized after the run finishes (LOBE-10802), rather than dispatched on the
- * user message alone. The client-runtime lane parks/synthesizes through its own
- * `client.runtime.start` / `client.runtime.complete` pair and is never re-routed
- * here; agent-signal self-iteration runs are suppressed upstream but guarded too.
+ * synthesized after the run finishes (deferred skill synthesis so the evidence
+ * carries the full trajectory, not just the user prompt), rather than dispatched
+ * on the user message alone. The client-runtime lane parks/synthesizes through
+ * its own `client.runtime.start` / `client.runtime.complete` pair and is never
+ * re-routed here; agent-signal self-iteration runs are suppressed upstream but
+ * guarded too.
  */
 const detectServerInboundDeferredSkill = (signal: FeedbackDomainSignal): boolean => {
   const { trigger } = signal.payload;
@@ -486,12 +488,12 @@ export const createFeedbackActionPlannerSignalHandler = (
           };
         }
 
-        // Defer server execAgent inbound synthesis to agent.execution.completed
-        // (LOBE-10802): park the candidate with its synthesis payload so the
-        // completion-stage handler synthesizes from the full trajectory (tool
-        // sequence + final product) instead of the user prompt alone. Only when
-        // the intent-record store is wired — otherwise fall through to the legacy
-        // inbound dispatch so synthesis is never silently dropped.
+        // Defer server execAgent inbound synthesis to agent.execution.completed:
+        // park the candidate with its synthesis payload so the completion-stage
+        // handler synthesizes from the full trajectory (tool sequence + final
+        // product) instead of the user prompt alone. Only when the intent-record
+        // store is wired — otherwise fall through to the legacy inbound dispatch
+        // so synthesis is never silently dropped.
         const skillIntentWriter = options.procedure?.procedureState?.skillIntentRecords?.write;
         if (skillIntentWriter && detectServerInboundDeferredSkill(signal)) {
           await skillIntentWriter(

--- a/apps/server/src/services/agentSignal/policies/analyzeIntent/index.ts
+++ b/apps/server/src/services/agentSignal/policies/analyzeIntent/index.ts
@@ -86,8 +86,9 @@ export const createAnalyzeIntentPolicy = (options: CreateAnalyzeIntentPolicyOpti
             procedureState:
               options.skillManagement.procedureState ?? options.procedure?.procedureState,
           }),
-          // Deferred skill synthesis (LOBE-10802): synthesize the parked skill
-          // candidate after `agent.execution.completed`, off the full trajectory.
+          // Deferred skill synthesis: synthesize the parked skill candidate after
+          // `agent.execution.completed`, off the full trajectory (tool sequence
+          // + final product) rather than the user prompt alone.
           createCompletionSkillSynthesisSourceHandler({
             ...options.skillManagement,
             procedureState:

--- a/apps/server/src/services/agentSignal/policies/analyzeIntent/skillIntentRecord.ts
+++ b/apps/server/src/services/agentSignal/policies/analyzeIntent/skillIntentRecord.ts
@@ -94,9 +94,11 @@ export interface RecordedSkillIntent {
   feedbackMessageId: string;
   /**
    * Synthesis payload for the deferred completion-stage skill run. Present when
-   * a server execAgent inbound turn parked a candidate to synthesize after
-   * `agent.execution.completed` (LOBE-10802); absent for the client-runtime
-   * lane, which re-derives the source at `client.runtime.complete`.
+   * a server execAgent inbound turn parked a candidate to synthesize at
+   * `agent.execution.completed` (skill synthesis deferred to turn completion so
+   * the evidence carries the full trajectory, not just the user prompt); absent
+   * for the client-runtime lane, which re-derives the source at
+   * `client.runtime.complete`.
    */
   pendingSynthesis?: PendingSkillSynthesis;
   /** Optional private-safe reason suitable for traces and eval assertions. */

--- a/apps/server/src/services/agentSignal/policies/types.ts
+++ b/apps/server/src/services/agentSignal/policies/types.ts
@@ -319,8 +319,8 @@ export interface AgentSignalPolicyActionPayloadMap {
     agentId?: string;
     /**
      * Assistant message that completed the turn. When present (deferred
-     * completion-stage synthesis, LOBE-10802) the skill seed anchors here
-     * instead of under the user message, so it is not a floating mainline root.
+     * completion-stage synthesis) the skill seed anchors here instead of under
+     * the user message, so it is not a floating mainline root.
      */
     assistantMessageId?: string;
     conflictPolicy?: AgentSignalFeedbackDomainConflictPolicy;

--- a/packages/agent-gateway-client/src/client.test.ts
+++ b/packages/agent-gateway-client/src/client.test.ts
@@ -307,9 +307,10 @@ describe('AgentStreamClient', () => {
     });
 
     it('should NOT disconnect on a forwarded terminal for a different operationId', async () => {
-      // Multiplexed WS (LOBE-10868): a broadcast member's agent_runtime_end is
-      // mirrored onto the supervisor's channel. It must be emitted (so the member
-      // handler can finalize that member) but must NOT close the supervisor WS.
+      // Single-connection WS multiplexing: a broadcast member's
+      // agent_runtime_end is mirrored onto the supervisor's channel. It must
+      // be emitted (so the member handler can finalize that member) but must
+      // NOT close the supervisor WS.
       const client = createClient(); // operationId: 'op-123'
       const events: any[] = [];
       client.on('agent_event', (e) => events.push(e));

--- a/packages/agent-gateway-client/src/client.ts
+++ b/packages/agent-gateway-client/src/client.ts
@@ -283,13 +283,13 @@ export class AgentStreamClient extends TypedEmitter {
           const agentEvent: AgentStreamEvent = message.event;
           if (message.id) this.lastEventId = message.id;
 
-          // A single WS can be multiplexed: alongside this op's events it may
+          // A single WebSocket is multiplexed: alongside this op's events it may
           // carry forwarded events from other operations (e.g. broadcast council
-          // members mirrored onto the supervisor's channel, LOBE-10868). A
-          // terminal event ends the SESSION only when it belongs to THIS op —
-          // a member finishing must not disconnect the supervisor's socket and
-          // stop sibling/supervisor streaming. Events with no operationId
-          // (legacy gateway) are treated as this op's, preserving old behavior.
+          // members mirrored onto the supervisor's channel). A terminal event
+          // ends the SESSION only when it belongs to THIS op — a member
+          // finishing must not disconnect the supervisor's socket and stop
+          // sibling/supervisor streaming. Events with no operationId (legacy
+          // gateway) are treated as this op's, preserving old behavior.
           const isOwnTerminal =
             (agentEvent.type === 'agent_runtime_end' || agentEvent.type === 'error') &&
             (!agentEvent.operationId || agentEvent.operationId === this.operationId);

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -212,8 +212,8 @@ export class GatewayActionImpl {
 
     // Forward agent events to caller, and track terminal events.
     //
-    // Only THIS op's terminal counts. On a multiplexed connection (LOBE-10868)
-    // the supervisor's WS also carries forwarded member terminals; a member
+    // Only THIS op's terminal counts. On a multiplexed connection the
+    // supervisor's WS also carries forwarded member terminals; a member
     // finishing must not mark the supervisor run complete or stomp its unread
     // status. Match on the event's operationId (absent ⇒ legacy single-op WS,
     // treat as this op's to preserve prior behavior).
@@ -608,9 +608,9 @@ export class GatewayActionImpl {
     });
 
     // Demux the supervisor's WebSocket: with single-connection multiplexing
-    // (LOBE-10868) this WS also carries each broadcast member's streaming events
-    // (forwarded server-side onto the supervisor op channel). Route owner events
-    // to the full handler and member events to render-only member handlers so a
+    // this WS also carries each broadcast member's streaming events (forwarded
+    // server-side onto the supervisor op channel). Route owner events to the
+    // full handler and member events to render-only member handlers so a
     // member's chunks stream into its own council column instead of corrupting
     // the supervisor bubble.
     const eventRouter = createGatewayEventRouter({

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventRouter.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventRouter.ts
@@ -30,11 +30,11 @@ export interface GatewayEventRouterParams {
  * one `operationId`.
  *
  * The Gateway connection model is moving from per-operation (one WS per op) to
- * single-connection multiplexing (LOBE-10868): a broadcast supervisor's WS now
- * also receives the streaming events of each of its members, forwarded
- * server-side onto the supervisor's op channel. Every `AgentStreamEvent` already
- * carries its own `operationId`, so the routing key is intrinsic to the event —
- * we just need to fan it out to the right handler.
+ * single-connection multiplexing: a broadcast supervisor's WS now also receives
+ * the streaming events of each of its members, forwarded server-side onto the
+ * supervisor's op channel. Every `AgentStreamEvent` already carries its own
+ * `operationId`, so the routing key is intrinsic to the event — we just need to
+ * fan it out to the right handler.
  *
  * - Events for `ownerOperationId` → `ownerHandler` (existing behavior, unchanged).
  * - Events for any other operationId → a render-only member handler, created

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.ts
@@ -40,8 +40,9 @@ export interface GatewayMemberStreamHandlerParams {
 
 /**
  * A render-only handler for a broadcast council member whose streaming events
- * are multiplexed onto the supervisor's Gateway WebSocket (LOBE-10868, option
- * B: server forwards member events onto the supervisor op channel).
+ * are multiplexed onto the supervisor's Gateway WebSocket (server forwards
+ * member events onto the supervisor op channel, single-connection
+ * multiplexing).
  *
  * Scope is deliberately narrow — it owns ONLY the member's live text/reasoning/
  * tool-call streaming into its council column. It does NOT drive any run


### PR DESCRIPTION
## Summary

Daily scan and cleanup of `LOBE-XXX` markers in source code. Replaced all remaining references with inline context that directly explains the architectural rationale.

## Changes

**18 files changed** (+90/-70 lines)

### LOBE-10802 — Deferred skill synthesis (13 files)
Replaced markers with inline explanation: skill synthesis is deferred from user-message-inbound to `agent.execution.completed` so the evidence carries the full trajectory (tool sequence + final product) instead of just the user prompt.

### LOBE-10868 — Single-connection WS multiplexing (5 files)
Replaced markers with inline explanation: member stream events are mirrored onto the supervisor's Gateway WebSocket (single-connection multiplexing) instead of being stranded on per-member channels nobody subscribes to.

### Files modified
```
apps/server/src/modules/AgentRuntime/AgentStateManager.ts
apps/server/src/modules/AgentRuntime/GatewayStreamNotifier.ts
apps/server/src/services/agentRuntime/AgentRuntimeService.ts
apps/server/src/services/agentRuntime/CompletionLifecycle.ts
apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
apps/server/src/services/agentSignal/policies/analyzeIntent/__tests__/completionSkillSynthesis.test.ts
apps/server/src/services/agentSignal/policies/analyzeIntent/__tests__/feedbackAction.test.ts
apps/server/src/services/agentSignal/policies/analyzeIntent/actions/skillManagement.ts
apps/server/src/services/agentSignal/policies/analyzeIntent/completionSkillSynthesis.ts
apps/server/src/services/agentSignal/policies/analyzeIntent/feedbackAction.ts
apps/server/src/services/agentSignal/policies/analyzeIntent/index.ts
apps/server/src/services/agentSignal/policies/analyzeIntent/skillIntentRecord.ts
apps/server/src/services/agentSignal/policies/types.ts
packages/agent-gateway-client/src/client.ts
packages/agent-gateway-client/src/client.test.ts
src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventRouter.ts
src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.ts
```

Auto-generated at 