### PR TITLE
🐛 fix(task): anchor sub-agent elapsed time to the task tool createdAt

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://lobehub.com",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lobehub/lobe-chat.git"
+    "url": "https://github.com/lobehub/lobehub.git"
   },
   "author": "LobeHub",
   "main": "./dist/main/index.js",

--- a/src/features/Conversation/Messages/GroupTasks/TaskItem/ClientTaskItem.tsx
+++ b/src/features/Conversation/Messages/GroupTasks/TaskItem/ClientTaskItem.tsx
@@ -100,7 +100,10 @@ const ClientTaskItem = memo<ClientTaskItemProps>(({ item }) => {
       const toolCalls = blocks.reduce((sum, block) => sum + (block.tools?.length || 0), 0);
       return {
         isLoading: false,
-        startTime: assistantGroupMessage?.createdAt,
+        // Anchor elapsed time to the task tool's createdAt (when the sub-agent was
+        // invoked) rather than the in-thread first assistant's createdAt (when the
+        // thread finished initializing) — the latter excludes init / approval wait.
+        startTime: item.createdAt,
         steps: blocks.length,
         toolCalls,
       };
@@ -118,7 +121,7 @@ const ClientTaskItem = memo<ClientTaskItemProps>(({ item }) => {
     isCompleted,
     isError,
     blocks,
-    assistantGroupMessage?.createdAt,
+    item.createdAt,
     taskDetail?.duration,
     taskDetail?.totalSteps,
     taskDetail?.totalToolCalls,
@@ -167,7 +170,7 @@ const ClientTaskItem = memo<ClientTaskItemProps>(({ item }) => {
             messages={threadMessages}
             model={model ?? undefined}
             provider={provider ?? undefined}
-            startTime={assistantGroupMessage?.createdAt}
+            startTime={item.createdAt}
             totalCost={taskDetail?.totalCost}
           />
         )}

--- a/src/features/Conversation/Messages/Tasks/TaskItem/ClientTaskItem.tsx
+++ b/src/features/Conversation/Messages/Tasks/TaskItem/ClientTaskItem.tsx
@@ -85,7 +85,10 @@ const ClientTaskItem = memo<ClientTaskItemProps>(({ item }) => {
       const toolCalls = blocks.reduce((sum, block) => sum + (block.tools?.length || 0), 0);
       return {
         isLoading: false,
-        startTime: assistantGroupMessage?.createdAt,
+        // Anchor elapsed time to the task tool's createdAt (when the sub-agent was
+        // invoked) rather than the in-thread first assistant's createdAt (when the
+        // thread finished initializing) — the latter excludes init / approval wait.
+        startTime: item.createdAt,
         steps: blocks.length,
         toolCalls,
       };
@@ -103,7 +106,7 @@ const ClientTaskItem = memo<ClientTaskItemProps>(({ item }) => {
     isCompleted,
     isError,
     blocks,
-    assistantGroupMessage?.createdAt,
+    item.createdAt,
     taskDetail?.duration,
     taskDetail?.totalSteps,
     taskDetail?.totalToolCalls,
@@ -141,7 +144,7 @@ const ClientTaskItem = memo<ClientTaskItemProps>(({ item }) => {
             messages={threadMessages}
             model={model ?? undefined}
             provider={provider ?? undefined}
-            startTime={assistantGroupMessage?.createdAt}
+            startTime={item.createdAt}
             totalCost={taskDetail?.totalCost}
           />
         )}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] 🔨 chore

#### 🔀 Description of Change

Two small, independent fixes bundled together:

**1. Sub-agent task elapsed time (frontend display)**

The client-mode sub-agent task ("调用子助理") rendered its live elapsed time counting from the **in-thread first assistant message's `createdAt`** — i.e. the moment the isolation thread finished initializing. That start reference is too late: it excludes the init / manual-approval wait between invoking the tool and the thread actually starting, so the displayed start time was inaccurate and the elapsed time too short.

The fix anchors the elapsed-time `startTime` to the **task tool message's own `createdAt`** (`item.createdAt` — when the sub-agent was invoked) in both the single-agent (`Tasks/TaskItem/ClientTaskItem`) and group (`GroupTasks/TaskItem/ClientTaskItem`) task items. This is purely a frontend-display change; no backend / persisted data is touched.

**2. Desktop repository URL**

`apps/desktop/package.json` `repository.url` still pointed at the old `lobehub/lobe-chat` remote. Aligned it with the root `package.json` and the electron-builder publish config, which already use `lobehub/lobehub`.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Dispatch a sub-agent (e.g. with manual approval enabled so there is a wait before the thread starts) and confirm the live elapsed time now counts from when the tool was invoked, not from when the thread finished initializing.

#### 📝 Additional Information

The completed-task duration shown after a sub-agent finishes still comes from the server-computed `taskDetail.duration` (thread `startedAt` → `completedAt`) and is intentionally left unchanged here, since this PR scopes to the frontend start-time display only.