### PR TITLE
🐛 fix(verify): isolate verifier runtime from hetero parents

### DIFF
--- a/apps/server/src/services/verify/__tests__/agentVerifier.test.ts
+++ b/apps/server/src/services/verify/__tests__/agentVerifier.test.ts
@@ -8,10 +8,17 @@ import { createVerifierAgentRunner } from '../agentVerifier';
 // AgentModel/ThreadModel expose their methods as arrow-function class fields
 // (instance props, not on the prototype), so they can't be spied via the
 // prototype — mock the modules instead. Hoisted so the factories can close over them.
-const { existsByIdMock, getBuiltinAgentMock, threadCreateMock, execAgentMock } = vi.hoisted(() => ({
+const {
+  existsByIdMock,
+  getBuiltinAgentMock,
+  threadCreateMock,
+  execAgentMock,
+  settleVerifierCheckFromTerminalMock,
+} = vi.hoisted(() => ({
   execAgentMock: vi.fn(async (_params: any) => ({ operationId: 'verifier-op-1' })),
   existsByIdMock: vi.fn(),
   getBuiltinAgentMock: vi.fn(),
+  settleVerifierCheckFromTerminalMock: vi.fn(),
   threadCreateMock: vi.fn(async () => ({ id: 'thread-1' })),
 }));
 
@@ -34,6 +41,9 @@ vi.mock('@/database/models/thread', () => ({
 // The runner dynamically imports AiAgentService to break a static cycle.
 vi.mock('@/server/services/aiAgent', () => ({
   AiAgentService: vi.fn().mockImplementation(() => ({ execAgent: execAgentMock })),
+}));
+vi.mock('../verifierTerminal', () => ({
+  settleVerifierCheckFromTerminal: settleVerifierCheckFromTerminalMock,
 }));
 
 const checkItem: VerifyCheckItem = {
@@ -90,7 +100,7 @@ describe('createVerifierAgentRunner', () => {
     expect(params.additionalPluginIds).toEqual([VerifyToolIdentifier]);
   });
 
-  it('falls back to the builtin verify agent (by slug) inheriting parent model/provider', async () => {
+  it('falls back to the builtin verify agent (by slug) with the provided verify model config', async () => {
     existsByIdMock.mockResolvedValue(false); // pinned id no longer exists
     getBuiltinAgentMock.mockResolvedValue({ id: 'builtin-verify' });
 
@@ -105,6 +115,52 @@ describe('createVerifierAgentRunner', () => {
     expect(params.provider).toBe('openai');
     // The builtin verify agent already declares the tool — not re-injected.
     expect(params.additionalPluginIds).toBeUndefined();
+  });
+
+  it('registers a verifier-terminal hook for local and queued completion handling', async () => {
+    getBuiltinAgentMock.mockResolvedValue({ id: 'builtin-verify' });
+
+    const runner = createVerifierAgentRunner({ ...baseParams, workspaceId: 'ws-1' })!;
+    await runner(runnerArgs);
+
+    const hooks = execParams().hooks;
+    expect(hooks).toEqual([
+      expect.objectContaining({
+        id: 'verify-agent-terminal',
+        type: 'onComplete',
+        webhook: expect.objectContaining({
+          body: {
+            checkItemId: 'check-1',
+            parentOperationId: 'parent-op-1',
+            userId: 'u',
+            workspaceId: 'ws-1',
+          },
+          delivery: 'qstash',
+          url: '/api/workflows/verify/on-verifier-complete',
+        }),
+      }),
+    ]);
+
+    await hooks[0].handler({
+      agentId: 'agent',
+      errorMessage: 'bad key',
+      operationId: 'verifier-op-1',
+      reason: 'error',
+      userId: 'u',
+    });
+
+    expect(settleVerifierCheckFromTerminalMock).toHaveBeenCalledWith(
+      db,
+      'u',
+      {
+        checkItemId: 'check-1',
+        errorMessage: 'bad key',
+        parentOperationId: 'parent-op-1',
+        reason: 'error',
+        verifierOperationId: 'verifier-op-1',
+      },
+      'ws-1',
+    );
   });
 
   it('uses the builtin agent when no verifierAgentId is pinned', async () => {

--- a/apps/server/src/services/verify/__tests__/modelConfig.test.ts
+++ b/apps/server/src/services/verify/__tests__/modelConfig.test.ts
@@ -1,0 +1,123 @@
+import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
+import { DEFAULT_PROVIDER } from '@lobechat/business-const';
+import { DEFAULT_MODEL } from '@lobechat/const';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { isHeterogeneousVerifyProvider, resolveVerifyModelConfig } from '../modelConfig';
+
+const { getAgentModelConfigMock, getBuiltinAgentMock } = vi.hoisted(() => ({
+  getAgentModelConfigMock: vi.fn(),
+  getBuiltinAgentMock: vi.fn(),
+}));
+
+vi.mock('@/database/models/agent', () => ({
+  AgentModel: vi.fn().mockImplementation(() => ({
+    getAgentModelConfig: getAgentModelConfigMock,
+    getBuiltinAgent: getBuiltinAgentMock,
+  })),
+}));
+
+const db = {} as any;
+
+describe('resolveVerifyModelConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getBuiltinAgentMock.mockResolvedValue({ id: 'builtin-verify' });
+  });
+
+  it('recognizes heterogeneous providers that cannot run Verify LLM calls', () => {
+    expect(isHeterogeneousVerifyProvider('claude-code')).toBe(true);
+    expect(isHeterogeneousVerifyProvider('codex')).toBe(true);
+    expect(isHeterogeneousVerifyProvider('openai')).toBe(false);
+    expect(isHeterogeneousVerifyProvider(null)).toBe(false);
+  });
+
+  it('uses a pinned verifier agent model before the parent run model', async () => {
+    getAgentModelConfigMock.mockResolvedValueOnce({
+      model: 'deepseek-v4-pro',
+      provider: 'lobehub',
+    });
+
+    await expect(
+      resolveVerifyModelConfig(
+        db,
+        'u',
+        {
+          parentModel: 'gpt-parent',
+          parentProvider: 'openai',
+          verifierAgentId: 'agt-verifier',
+        },
+        'ws',
+      ),
+    ).resolves.toEqual({ model: 'deepseek-v4-pro', provider: 'lobehub' });
+
+    expect(getAgentModelConfigMock).toHaveBeenCalledWith('agt-verifier');
+    expect(getBuiltinAgentMock).not.toHaveBeenCalled();
+  });
+
+  it('filters a heterogeneous parent and falls back to the builtin verifier model', async () => {
+    getAgentModelConfigMock.mockResolvedValueOnce({
+      model: 'deepseek-v4-pro',
+      provider: 'lobehub',
+    });
+
+    await expect(
+      resolveVerifyModelConfig(db, 'u', {
+        parentModel: 'claude-opus-4-8',
+        parentProvider: 'claude-code',
+      }),
+    ).resolves.toEqual({ model: 'deepseek-v4-pro', provider: 'lobehub' });
+
+    expect(getBuiltinAgentMock).toHaveBeenCalledWith(BUILTIN_AGENT_SLUGS.verifyAgent);
+    expect(getAgentModelConfigMock).toHaveBeenCalledWith(BUILTIN_AGENT_SLUGS.verifyAgent);
+  });
+
+  it('keeps a normal parent model when no verifier agent is pinned', async () => {
+    await expect(
+      resolveVerifyModelConfig(db, 'u', {
+        parentModel: 'gpt-5.4',
+        parentProvider: 'openai',
+      }),
+    ).resolves.toEqual({ model: 'gpt-5.4', provider: 'openai' });
+
+    expect(getBuiltinAgentMock).not.toHaveBeenCalled();
+    expect(getAgentModelConfigMock).not.toHaveBeenCalled();
+  });
+
+  it('does not fall back to the parent model when a pinned verifier model is unusable', async () => {
+    getAgentModelConfigMock
+      .mockResolvedValueOnce({
+        model: 'claude-opus-4-8',
+        provider: 'claude-code',
+      })
+      .mockResolvedValueOnce({
+        model: 'deepseek-v4-pro',
+        provider: 'lobehub',
+      });
+
+    await expect(
+      resolveVerifyModelConfig(db, 'u', {
+        parentModel: 'gpt-parent',
+        parentProvider: 'openai',
+        verifierAgentId: 'agt-verifier',
+      }),
+    ).resolves.toEqual({ model: 'deepseek-v4-pro', provider: 'lobehub' });
+
+    expect(getAgentModelConfigMock).toHaveBeenNthCalledWith(1, 'agt-verifier');
+    expect(getAgentModelConfigMock).toHaveBeenNthCalledWith(2, BUILTIN_AGENT_SLUGS.verifyAgent);
+  });
+
+  it('falls back to the platform defaults when no runnable agent model is available', async () => {
+    getAgentModelConfigMock.mockResolvedValueOnce({
+      model: 'claude-opus-4-8',
+      provider: 'claude-code',
+    });
+
+    await expect(
+      resolveVerifyModelConfig(db, 'u', {
+        parentModel: null,
+        parentProvider: null,
+      }),
+    ).resolves.toEqual({ model: DEFAULT_MODEL, provider: DEFAULT_PROVIDER });
+  });
+});

--- a/apps/server/src/services/verify/__tests__/verifierTerminal.test.ts
+++ b/apps/server/src/services/verify/__tests__/verifierTerminal.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { settleVerifierCheckFromTerminal } from '../verifierTerminal';
+
+const {
+  findRunByOperationMock,
+  finalizeVerifyRunMock,
+  listResultsByRunMock,
+  recomputeMock,
+  updateByCheckItemMock,
+} = vi.hoisted(() => ({
+  finalizeVerifyRunMock: vi.fn(),
+  findRunByOperationMock: vi.fn(),
+  listResultsByRunMock: vi.fn(),
+  recomputeMock: vi.fn(),
+  updateByCheckItemMock: vi.fn(),
+}));
+
+vi.mock('@/database/models/verifyRun', () => ({
+  VerifyRunModel: vi.fn().mockImplementation(() => ({
+    findByOperation: findRunByOperationMock,
+  })),
+}));
+vi.mock('@/database/models/verifyCheckResult', () => ({
+  VerifyCheckResultModel: vi.fn().mockImplementation(() => ({
+    listByRun: listResultsByRunMock,
+    updateByCheckItem: updateByCheckItemMock,
+  })),
+}));
+vi.mock('../statusService', () => ({
+  VerifyStatusService: vi.fn().mockImplementation(() => ({ recompute: recomputeMock })),
+}));
+vi.mock('../settle', () => ({
+  finalizeVerifyRun: finalizeVerifyRunMock,
+}));
+
+const db = {} as any;
+
+describe('settleVerifierCheckFromTerminal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findRunByOperationMock.mockResolvedValue({ id: 'run-1' });
+    listResultsByRunMock.mockResolvedValue([
+      {
+        checkItemId: 'check-1',
+        status: 'running',
+      },
+    ]);
+  });
+
+  it('marks a still-running verifier result failed/uncertain and finalizes the parent run', async () => {
+    await settleVerifierCheckFromTerminal(
+      db,
+      'u',
+      {
+        checkItemId: 'check-1',
+        errorMessage: 'InvalidProviderAPIKey',
+        parentOperationId: 'parent-op',
+        reason: 'error',
+        verifierOperationId: 'verifier-op',
+      },
+      'ws',
+    );
+
+    expect(updateByCheckItemMock).toHaveBeenCalledWith(
+      'run-1',
+      'check-1',
+      expect.objectContaining({
+        status: 'failed',
+        toulmin: {
+          limitation: 'Verifier failed before submitting a verdict: InvalidProviderAPIKey',
+        },
+        verdict: 'uncertain',
+        verifierOperationId: 'verifier-op',
+      }),
+    );
+    expect(recomputeMock).toHaveBeenCalledWith('parent-op');
+    expect(finalizeVerifyRunMock).toHaveBeenCalledWith(db, 'u', 'parent-op', {}, 'ws');
+  });
+
+  it('does not overwrite a result already written by submitVerifyResult', async () => {
+    listResultsByRunMock.mockResolvedValue([{ checkItemId: 'check-1', status: 'passed' }]);
+
+    await settleVerifierCheckFromTerminal(db, 'u', {
+      checkItemId: 'check-1',
+      parentOperationId: 'parent-op',
+      reason: 'done',
+      verifierOperationId: 'verifier-op',
+    });
+
+    expect(updateByCheckItemMock).not.toHaveBeenCalled();
+    expect(recomputeMock).not.toHaveBeenCalled();
+    expect(finalizeVerifyRunMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/services/verify/agentVerifier.ts
+++ b/apps/server/src/services/verify/agentVerifier.ts
@@ -8,10 +8,12 @@ import { AgentModel } from '@/database/models/agent';
 import { DocumentModel } from '@/database/models/document';
 import { ThreadModel } from '@/database/models/thread';
 import type { LobeChatDatabase } from '@/database/type';
+import type { AgentHook, AgentHookEvent } from '@/server/services/agentRuntime/hooks/types';
 import { AiAgentService } from '@/server/services/aiAgent';
 
 import type { VerifierAgentRunner } from './executor';
 import { describeEvidence, type JudgeEvidence } from './prompts';
+import { settleVerifierCheckFromTerminal } from './verifierTerminal';
 
 const log = debug('lobe-server:verify-agent-verifier');
 
@@ -61,13 +63,14 @@ export const buildVerifierPrompt = (params: {
  * config (executionTarget / device / provider) — so picking a heterogeneous
  * agent (e.g. Codex) naturally gives the verifier device + browser access. When
  * unset (or the pinned agent no longer exists) it falls back to the builtin
- * verify agent, which inherits the parent run's model/provider (its own default
- * may not point at a configured provider).
+ * verify agent, which receives a verify-safe provider/model resolved by the
+ * lifecycle layer. That resolver intentionally filters heterogeneous runtime
+ * identifiers (e.g. claude-code / codex) that cannot run LobeHub LLM calls.
  */
 export const createVerifierAgentRunner = (params: {
   db: LobeChatDatabase;
   deliverable: string;
-  /** Inherit the parent run's model so the builtin fallback uses a configured provider. */
+  /** Verify-safe model selected by the completion lifecycle. */
   model?: string | null;
   provider?: string | null;
   topicId?: string | null;
@@ -91,11 +94,11 @@ export const createVerifierAgentRunner = (params: {
 
     // Resolve which agent verifies. A pinned agent runs as itself (`agentId`) so
     // its own agency config drives execution target/provider — we don't override
-    // its model/provider. The builtin fallback runs by `slug` and inherits the
-    // parent run's model/provider.
+    // its model/provider. The builtin fallback runs by `slug` with the verify-safe
+    // model/provider selected by lifecycle.
     let threadAgentId: string;
     let agentRef: { agentId: string } | { slug: string };
-    let inheritModel = false;
+    let useProvidedModelConfig = false;
     // A pinned agent (selected for its runtime/device) carries only its own
     // configured plugins, so it lacks the verify writeback tool — inject it, else
     // the verdict never lands and the check result is stuck `running`. The builtin
@@ -118,7 +121,7 @@ export const createVerifierAgentRunner = (params: {
       }
       threadAgentId = builtin.id;
       agentRef = { slug: BUILTIN_AGENT_SLUGS.verifyAgent };
-      inheritModel = true;
+      useProvidedModelConfig = true;
     }
 
     const thread = await new ThreadModel(db, userId, workspaceId).create({
@@ -139,6 +142,38 @@ export const createVerifierAgentRunner = (params: {
       .map((e) => e.fileId)
       .filter((id): id is string => Boolean(id));
 
+    const terminalHookBody = {
+      checkItemId: checkItem.id,
+      parentOperationId: operationId,
+      userId,
+      ...(workspaceId ? { workspaceId } : {}),
+    };
+    const hooks: AgentHook[] = [
+      {
+        handler: async (event: AgentHookEvent) => {
+          await settleVerifierCheckFromTerminal(
+            db,
+            userId,
+            {
+              checkItemId: checkItem.id,
+              errorMessage: event.errorMessage,
+              parentOperationId: operationId,
+              reason: event.reason,
+              verifierOperationId: event.operationId,
+            },
+            workspaceId,
+          );
+        },
+        id: 'verify-agent-terminal',
+        type: 'onComplete' as const,
+        webhook: {
+          body: terminalHookBody,
+          delivery: 'qstash' as const,
+          url: '/api/workflows/verify/on-verifier-complete',
+        },
+      },
+    ];
+
     // The aiAgent → agentRuntime completion → verify lifecycle → this runner →
     // aiAgent import cycle is safe statically: every use here is call-time (inside
     // this runner), so the module is fully initialized before it runs.
@@ -148,12 +183,13 @@ export const createVerifierAgentRunner = (params: {
       appContext: { threadId: thread.id, topicId },
       autoStart: true,
       ...(evidenceFileIds.length ? { fileIds: evidenceFileIds } : {}),
-      // Only the builtin fallback inherits the parent run's model/provider; a
-      // pinned agent keeps its own (critical for heterogeneous runtimes).
-      ...(inheritModel && model ? { model } : {}),
+      hooks,
+      // Only the builtin fallback receives lifecycle's verify-safe model/provider;
+      // a pinned agent keeps its own runtime config.
+      ...(useProvidedModelConfig && model ? { model } : {}),
       parentOperationId: operationId,
       prompt: buildVerifierPrompt({ checkItem, deliverable, evidence, goal, instruction }),
-      ...(inheritModel && provider ? { provider } : {}),
+      ...(useProvidedModelConfig && provider ? { provider } : {}),
       ...agentRef,
       userInterventionConfig: { approvalMode: 'headless' },
     });

--- a/apps/server/src/services/verify/executor.ts
+++ b/apps/server/src/services/verify/executor.ts
@@ -62,6 +62,7 @@ export interface ExecuteVerifyParams {
 
 const verdictToStatus = (verdict: VerifyVerdict): VerifyCheckResultStatus =>
   verdict === 'passed' ? 'passed' : 'failed';
+const terminalResultStatuses = new Set<VerifyCheckResultStatus>(['passed', 'failed', 'skipped']);
 
 /** Group a run's evidence rows by the plan item they back, for judge injection. */
 type EvidenceByItem = Map<string, JudgeEvidence[]>;
@@ -263,10 +264,26 @@ export class VerifyExecutorService {
         goal: params.goal,
         operationId: params.operationId,
       });
+
+      if (!spawned?.verifierOperationId) {
+        await this.resultModel.updateByCheckItem(verifyRunId, item.id, {
+          completedAt: new Date(),
+          status: 'failed',
+          toulmin: { limitation: 'Agent verifier failed to start.' },
+          verdict: 'uncertain',
+        });
+        return;
+      }
+
+      const current = (await this.resultModel.listByRun(verifyRunId)).find(
+        (result) => result.checkItemId === item.id,
+      );
+      if (current && terminalResultStatuses.has(current.status)) return;
+
       await this.resultModel.updateByCheckItem(verifyRunId, item.id, {
         startedAt: new Date(),
         status: 'running',
-        verifierOperationId: spawned?.verifierOperationId ?? null,
+        verifierOperationId: spawned.verifierOperationId,
       });
     } catch (error) {
       log('agent verifier spawn failed for item %s: %O', item.id, error);

--- a/apps/server/src/services/verify/index.ts
+++ b/apps/server/src/services/verify/index.ts
@@ -7,6 +7,7 @@ export {
 } from './executor';
 export { computeFalseFlags, VerifyFeedbackService } from './feedbackService';
 export { runVerifyOnCompletion } from './lifecycle';
+export { isHeterogeneousVerifyProvider, resolveVerifyModelConfig } from './modelConfig';
 export { type GeneratePlanParams, VerifyPlanGeneratorService } from './planGenerator';
 export { instantiateVerifyPlanOnStart } from './planInstantiation';
 export {
@@ -18,3 +19,4 @@ export {
 export { type GenerateReportParams, VerifyReporterService } from './reporter';
 export { driveTaskFromVerify, finalizeVerifyRun } from './settle';
 export { VerifyStatusService } from './statusService';
+export { settleVerifierCheckFromTerminal } from './verifierTerminal';

--- a/apps/server/src/services/verify/lifecycle.ts
+++ b/apps/server/src/services/verify/lifecycle.ts
@@ -7,6 +7,7 @@ import type { LobeChatDatabase } from '@/database/type';
 
 import { createVerifierAgentRunner } from './agentVerifier';
 import { VerifyExecutorService } from './executor';
+import { resolveVerifyModelConfig } from './modelConfig';
 import { finalizeVerifyRun } from './settle';
 
 const log = debug('lobe-server:verify-lifecycle');
@@ -47,8 +48,8 @@ export const runVerifyOnCompletion = async (
     if (run.status !== 'planned') return;
 
     const op = await new AgentOperationModel(db, userId, workspaceId).findById(params.operationId);
-    if (!op?.model || !op?.provider) {
-      log('op %s missing model/provider, cannot run verify', params.operationId);
+    if (!op) {
+      log('op %s missing, cannot run verify', params.operationId);
       return;
     }
 
@@ -62,19 +63,30 @@ export const runVerifyOnCompletion = async (
       verifierAgentId = verifyConfig?.verifierAgentId ?? undefined;
     }
 
+    const modelConfig = await resolveVerifyModelConfig(
+      db,
+      userId,
+      {
+        parentModel: op.model,
+        parentProvider: op.provider,
+        verifierAgentId,
+      },
+      workspaceId,
+    );
+
     const executor = new VerifyExecutorService(db, userId, workspaceId);
     await executor.execute({
       deliverable: params.deliverable,
       goal: params.goal,
-      modelConfig: { model: op.model, provider: op.provider },
+      modelConfig,
       operationId: params.operationId,
       // `agent`-type checks run as the task-pinned verify agent (or the builtin
       // one), which writes its verdict back via the submitVerifyResult tool.
       runVerifierAgent: createVerifierAgentRunner({
         db,
         deliverable: params.deliverable,
-        model: op.model,
-        provider: op.provider,
+        model: modelConfig.model,
+        provider: modelConfig.provider,
         topicId: op.topicId,
         userId,
         verifierAgentId,
@@ -95,7 +107,7 @@ export const runVerifyOnCompletion = async (
         report: {
           deliverable: params.deliverable,
           goal: params.goal,
-          modelConfig: { model: op.model, provider: op.provider },
+          modelConfig,
         },
       },
       workspaceId,

--- a/apps/server/src/services/verify/modelConfig.ts
+++ b/apps/server/src/services/verify/modelConfig.ts
@@ -1,0 +1,67 @@
+import { BUILTIN_AGENT_SLUGS } from '@lobechat/builtin-agents';
+import { DEFAULT_PROVIDER } from '@lobechat/business-const';
+import { DEFAULT_MODEL } from '@lobechat/const';
+
+import { AgentModel } from '@/database/models/agent';
+import type { LobeChatDatabase } from '@/database/type';
+
+export interface VerifyModelConfig {
+  model: string;
+  provider: string;
+}
+
+interface ResolveVerifyModelConfigParams {
+  parentModel?: string | null;
+  parentProvider?: string | null;
+  verifierAgentId?: string | null;
+}
+
+const HETEROGENEOUS_PROVIDER_IDS = new Set([
+  'amp',
+  'claude-code',
+  'codex',
+  'hermes',
+  'opencode',
+  'openclaw',
+]);
+
+export const isHeterogeneousVerifyProvider = (provider?: string | null): boolean =>
+  Boolean(provider && HETEROGENEOUS_PROVIDER_IDS.has(provider));
+
+const isUsableVerifyModelConfig = (
+  config?: { model?: string | null; provider?: string | null } | null,
+): config is VerifyModelConfig =>
+  Boolean(config?.model && config?.provider && !isHeterogeneousVerifyProvider(config.provider));
+
+/**
+ * Pick the model used by Verify's LobeHub LLM calls. Heterogeneous parent runs
+ * expose CLI/runtime identifiers (e.g. `claude-code`) that are not valid model
+ * runtime providers, so Verify must resolve its own runnable provider/model.
+ */
+export const resolveVerifyModelConfig = async (
+  db: LobeChatDatabase,
+  userId: string,
+  params: ResolveVerifyModelConfigParams,
+  workspaceId?: string,
+): Promise<VerifyModelConfig> => {
+  const agentModel = new AgentModel(db, userId, workspaceId);
+
+  const hasPinnedVerifier = Boolean(params.verifierAgentId);
+
+  if (params.verifierAgentId) {
+    const verifierConfig = await agentModel.getAgentModelConfig(params.verifierAgentId);
+    if (isUsableVerifyModelConfig(verifierConfig)) return verifierConfig;
+  }
+
+  const parentConfig = {
+    model: params.parentModel,
+    provider: params.parentProvider,
+  };
+  if (!hasPinnedVerifier && isUsableVerifyModelConfig(parentConfig)) return parentConfig;
+
+  await agentModel.getBuiltinAgent(BUILTIN_AGENT_SLUGS.verifyAgent);
+  const builtinConfig = await agentModel.getAgentModelConfig(BUILTIN_AGENT_SLUGS.verifyAgent);
+  if (isUsableVerifyModelConfig(builtinConfig)) return builtinConfig;
+
+  return { model: DEFAULT_MODEL, provider: DEFAULT_PROVIDER };
+};

--- a/apps/server/src/services/verify/verifierTerminal.ts
+++ b/apps/server/src/services/verify/verifierTerminal.ts
@@ -1,0 +1,73 @@
+import debug from 'debug';
+
+import { VerifyCheckResultModel } from '@/database/models/verifyCheckResult';
+import { VerifyRunModel } from '@/database/models/verifyRun';
+import type { LobeChatDatabase } from '@/database/type';
+
+import { finalizeVerifyRun } from './settle';
+import { VerifyStatusService } from './statusService';
+
+const log = debug('lobe-server:verify-verifier-terminal');
+
+const TERMINAL_RESULT_STATUSES = new Set(['passed', 'failed', 'skipped']);
+
+export interface SettleVerifierCheckFromTerminalParams {
+  checkItemId: string;
+  errorMessage?: string;
+  parentOperationId: string;
+  reason?: string;
+  verifierOperationId: string;
+}
+
+/**
+ * Fallback for agent verifiers that terminate before calling
+ * `submitVerifyResult`. The normal tool-write path wins; this only closes rows
+ * still stuck in pending/running once the verifier child op is terminal.
+ */
+export const settleVerifierCheckFromTerminal = async (
+  db: LobeChatDatabase,
+  userId: string,
+  params: SettleVerifierCheckFromTerminalParams,
+  workspaceId?: string,
+): Promise<void> => {
+  const { checkItemId, errorMessage, parentOperationId, reason, verifierOperationId } = params;
+
+  try {
+    const run = await new VerifyRunModel(db, userId, workspaceId).findByOperation(
+      parentOperationId,
+    );
+    if (!run) return;
+
+    const resultModel = new VerifyCheckResultModel(db, userId, workspaceId);
+    const result = (await resultModel.listByRun(run.id)).find(
+      (item) => item.checkItemId === checkItemId,
+    );
+
+    if (!result || TERMINAL_RESULT_STATUSES.has(result.status)) return;
+
+    const limitation =
+      reason === 'done'
+        ? 'Verifier completed without submitting a verdict.'
+        : `Verifier failed before submitting a verdict${errorMessage ? `: ${errorMessage}` : '.'}`;
+
+    await resultModel.updateByCheckItem(run.id, checkItemId, {
+      completedAt: new Date(),
+      status: 'failed',
+      suggestion: 'Review the verifier configuration and rerun verification.',
+      toulmin: { limitation },
+      verdict: 'uncertain',
+      verifierOperationId,
+    });
+
+    await new VerifyStatusService(db, userId, workspaceId).recompute(parentOperationId);
+    await finalizeVerifyRun(db, userId, parentOperationId, {}, workspaceId);
+  } catch (error) {
+    log(
+      'settleVerifierCheckFromTerminal failed for parent=%s verifier=%s check=%s: %O',
+      parentOperationId,
+      verifierOperationId,
+      checkItemId,
+      error,
+    );
+  }
+};

--- a/src/server/workflows-hono/index.ts
+++ b/src/server/workflows-hono/index.ts
@@ -3,11 +3,13 @@ import { Hono } from 'hono';
 import agentSignalApp from './agent-signal';
 import memoryUserMemoryApp from './memory-user-memory';
 import taskApp from './task';
+import verifyApp from './verify';
 
 const app = new Hono().basePath('/api/workflows');
 
 app.route('/agent-signal', agentSignalApp);
 app.route('/memory-user-memory', memoryUserMemoryApp);
 app.route('/task', taskApp);
+app.route('/verify', verifyApp);
 
 export default app;

--- a/src/server/workflows-hono/verify/handlers/onVerifierComplete.ts
+++ b/src/server/workflows-hono/verify/handlers/onVerifierComplete.ts
@@ -1,0 +1,65 @@
+import debug from 'debug';
+import type { Context } from 'hono';
+
+import { getServerDB } from '@/database/server';
+import { settleVerifierCheckFromTerminal } from '@/server/services/verify/verifierTerminal';
+
+const log = debug('lobe-server:workflows:verify:on-verifier-complete');
+
+export interface OnVerifierCompletePayload {
+  checkItemId: string;
+  errorMessage?: string;
+  hookId?: string;
+  hookType?: string;
+  operationId: string;
+  parentOperationId: string;
+  reason?: string;
+  userId: string;
+  workspaceId?: string;
+}
+
+export async function onVerifierComplete(c: Context) {
+  try {
+    const body = (await c.req.json()) as OnVerifierCompletePayload;
+    const {
+      checkItemId,
+      errorMessage,
+      operationId,
+      parentOperationId,
+      reason,
+      userId,
+      workspaceId,
+    } = body;
+
+    if (!checkItemId || !operationId || !parentOperationId || !userId) {
+      return c.json({ error: 'Missing required fields' }, 400);
+    }
+
+    log(
+      'Received: parent=%s verifier=%s check=%s reason=%s',
+      parentOperationId,
+      operationId,
+      checkItemId,
+      reason,
+    );
+
+    const db = await getServerDB();
+    await settleVerifierCheckFromTerminal(
+      db,
+      userId,
+      {
+        checkItemId,
+        errorMessage,
+        parentOperationId,
+        reason,
+        verifierOperationId: operationId,
+      },
+      workspaceId,
+    );
+
+    return c.json({ success: true });
+  } catch (error) {
+    console.error('[verify/on-verifier-complete] Error:', error);
+    return c.json({ error: error instanceof Error ? error.message : 'Internal error' }, 500);
+  }
+}

--- a/src/server/workflows-hono/verify/index.ts
+++ b/src/server/workflows-hono/verify/index.ts
@@ -1,0 +1,10 @@
+import { Hono } from 'hono';
+
+import { qstashAuth } from '../middlewares/qstashAuth';
+import { onVerifierComplete } from './handlers/onVerifierComplete';
+
+const app = new Hono();
+
+app.post('/on-verifier-complete', qstashAuth(), onVerifierComplete);
+
+export default app;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-10885

#### 🔀 Description of Change

- Resolve a Verify-specific runnable model/provider instead of passing a heterogeneous parent operation's runtime identifiers into LobeHub LLM calls.
- Prefer a pinned verifier agent's own model config, keep pinned verifier sub-ops on their own runtime config, and fall back to the builtin Verify agent/default model when the parent provider is heterogeneous.
- Add a verifier terminal fallback hook and QStash workflow callback so verifier child op failures or completions without `submitVerifyResult` close the parent check as `failed`/`uncertain`, recompute the verify run, and run finalization.
- Avoid overwriting already-terminal check results back to `running` if a fast verifier terminal hook wins the race.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' apps/server/src/services/verify/__tests__/agentVerifier.test.ts apps/server/src/services/verify/__tests__/modelConfig.test.ts apps/server/src/services/verify/__tests__/verifierTerminal.test.ts
bunx vitest run --silent='passed-only' apps/server/src/services/verify/__tests__
```

`bun run type-check` was also run, but the current workspace fails on pre-existing unrelated global errors, including missing `@lobechat/types` exports in `packages/const` / `packages/prompts` and duplicate React/antd type instances between root and `apps/desktop` dependencies.

#### 📸 Screenshots / Videos

N/A - backend Verify runtime fix.

#### 📝 Additional Information

This keeps Verify inside the task topic run/delivery-checker flow. Verifier child operations remain implementation detail and are surfaced through the parent verify result instead of becoming a separate user-facing Activity.
