### PR TITLE
🐛 fix(review-panel): prevent group header shrink

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/FileRow.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/FileRow.tsx
@@ -15,6 +15,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
        implementation. */
     content-visibility: auto;
     contain-intrinsic-size: auto 32px;
+    flex: none;
 
     /* Every row carries its own top border — separates file-from-file AND
        file-from-header without doubling up when a group is collapsed. */

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/GroupHeader.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/GroupHeader.tsx
@@ -24,6 +24,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     inset-block-start: 0;
 
     display: flex;
+    flex: none;
     gap: 6px;
     align-items: center;
 
@@ -31,7 +32,9 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
        so the header stays the same size whether or not the fold button is
        rendered. Without this, expanding/collapsing a group would jitter the
        sticky header height because the button toggles between rendered and
-       not. padding-inline keeps the left-edge alignment with file rows. */
+       not. flex:none keeps the column flex list from compressing the sticky
+       header during expand/collapse. padding-inline keeps the left-edge
+       alignment with file rows. */
     block-size: 32px;
     padding-inline: 10px;
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

- Prevent Review group headers from shrinking inside the column flex list during expand/collapse.
- Prevent Review file rows from shrinking in the same list so row heights remain stable while diffs open and close.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validated with:

- `git diff --check HEAD~1..HEAD`
- `bunx prettier --check src/routes/'(main)'/agent/features/Conversation/WorkingSidebar/Review/GroupHeader.tsx src/routes/'(main)'/agent/features/Conversation/WorkingSidebar/Review/FileRow.tsx`
- `bunx eslint src/routes/'(main)'/agent/features/Conversation/WorkingSidebar/Review/GroupHeader.tsx src/routes/'(main)'/agent/features/Conversation/WorkingSidebar/Review/FileRow.tsx`
- `bun run type-check`
- `bun run dev:spa` and local Chrome smoke test against `http://127.0.0.1:9877/`

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Reported in chat: Review group header can be compressed during collapse/expand | CSS-only fix; local app smoke test passed |

#### 📝 Additional Information

The original dirty hotfix worktree was left untouched. This PR was created from an isolated worktree based on `origin/canary`.