### PR TITLE
🐛 fix(hetero-agent): title subagent thread from a reasoning/text-first event

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -2493,6 +2493,54 @@ describe('ClaudeCodeAdapter', () => {
       expect(secondChunk!.data.subagent.spawnMetadata).toBeUndefined();
     });
 
+    it('stamps spawnMetadata on a reasoning-FIRST subagent event (titles the Thread correctly)', () => {
+      // A thinking Explore agent reasons before its first tool call. The
+      // executor lazy-creates + titles the Thread off the FIRST subagent event
+      // it sees, so the metadata must ride the reasoning chunk too — otherwise
+      // the Thread is born with the generic "Subagent" title.
+      const adapter = new ClaudeCodeAdapter();
+      adapter.adapt(init);
+      adapter.adapt(
+        mainAssistant('msg_main', {
+          id: 'toolu_agent',
+          input: {
+            description: 'Find git remote url lobe-chat',
+            prompt: 'locate the remote',
+            subagent_type: 'Explore',
+          },
+          name: 'Agent',
+          type: 'tool_use',
+        }),
+      );
+
+      // First subagent event is a reasoning block — no tool call yet.
+      const first = adapter.adapt(
+        subAgent('msg_sub_1', 'toolu_agent', { thinking: 'Let me look…', type: 'thinking' }),
+      );
+      const reasoningChunk = first.find(
+        (e) => e.type === 'stream_chunk' && e.data.chunkType === 'reasoning',
+      );
+      expect(reasoningChunk!.data.subagent.spawnMetadata).toEqual({
+        description: 'Find git remote url lobe-chat',
+        prompt: 'locate the remote',
+        subagentType: 'Explore',
+      });
+
+      // The later tool event for the same parent must NOT re-announce.
+      const second = adapter.adapt(
+        subAgent('msg_sub_2', 'toolu_agent', {
+          id: 'toolu_child',
+          input: {},
+          name: 'Bash',
+          type: 'tool_use',
+        }),
+      );
+      const toolChunk = second.find(
+        (e) => e.type === 'stream_chunk' && e.data.chunkType === 'tools_calling',
+      );
+      expect(toolChunk!.data.subagent.spawnMetadata).toBeUndefined();
+    });
+
     it('extracts spawnMetadata from the `Agent` spawn-tool variant too (not just Task)', () => {
       // Real CC traces emit `Agent` for general-purpose subagents, not just
       // `Task` — the adapter should cache input for ANY main-agent tool and

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -2541,6 +2541,49 @@ describe('ClaudeCodeAdapter', () => {
       expect(toolChunk!.data.subagent.spawnMetadata).toBeUndefined();
     });
 
+    it('does NOT burn the one-shot on a first event that emits no chunk', () => {
+      // The very first subagent event can carry nothing the reducer consumes —
+      // an empty text/thinking block or a usage-only `content: []`. That event
+      // never reaches `ensureRun` (no chunk), so it must NOT mark the parent
+      // announced; the metadata has to survive for the next REAL chunk, which is
+      // the one that actually lazy-creates + titles the Thread.
+      const adapter = new ClaudeCodeAdapter();
+      adapter.adapt(init);
+      adapter.adapt(
+        mainAssistant('msg_main', {
+          id: 'toolu_agent',
+          input: {
+            description: 'Find git remote url lobe-chat',
+            prompt: 'locate the remote',
+            subagent_type: 'Explore',
+          },
+          name: 'Agent',
+          type: 'tool_use',
+        }),
+      );
+
+      // First subagent event: empty content + an empty text block — emits nothing.
+      const first = adapter.adapt({
+        message: { content: [{ text: '', type: 'text' }], id: 'msg_sub_0', usage: {} },
+        parent_tool_use_id: 'toolu_agent',
+        type: 'assistant',
+      });
+      expect(first.some((e) => e.type === 'stream_chunk')).toBe(false);
+
+      // Second event is the first REAL chunk — it must still carry spawnMetadata.
+      const second = adapter.adapt(
+        subAgent('msg_sub_1', 'toolu_agent', { thinking: 'Let me look…', type: 'thinking' }),
+      );
+      const reasoningChunk = second.find(
+        (e) => e.type === 'stream_chunk' && e.data.chunkType === 'reasoning',
+      );
+      expect(reasoningChunk!.data.subagent.spawnMetadata).toEqual({
+        description: 'Find git remote url lobe-chat',
+        prompt: 'locate the remote',
+        subagentType: 'Explore',
+      });
+    });
+
     it('extracts spawnMetadata from the `Agent` spawn-tool variant too (not just Task)', () => {
       // Real CC traces emit `Agent` for general-purpose subagents, not just
       // `Task` — the adapter should cache input for ANY main-agent tool and

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -43,6 +43,7 @@ import type {
   HeterogeneousTerminalErrorData,
   StreamChunkData,
   SubagentEventContext,
+  SubagentSpawnMetadata,
   ToolCallPayload,
   ToolResultData,
   UsageData,
@@ -557,11 +558,39 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
   /**
    * Set of parent tool_use ids whose spawn metadata has already been
    * announced on a subagent event. Guarantees `spawnMetadata` appears
-   * exactly once per subagent run — on the first subagent chunk for that
+   * exactly once per subagent run — on the first subagent event for that
    * parent — so the executor's lazy-create logic isn't tempted to
    * recreate the Thread on every chunk.
    */
   private announcedSpawns = new Set<string>();
+
+  /**
+   * Build the spawn metadata (`description` / `prompt` / `subagent_type`) for a
+   * subagent's parent tool_use exactly once, from the cached Task/Agent input.
+   *
+   * MUST be invoked for the FIRST subagent event of any kind — reasoning, text,
+   * OR tool — because the executor lazy-creates the Thread (and titles it from
+   * `description`) on whichever event it sees first. A reasoning- or text-first
+   * subagent (the normal case for a thinking Explore agent that reasons before
+   * its first tool call) would otherwise create the Thread with no metadata,
+   * yielding the generic "Subagent" title and an empty seed prompt. Returns
+   * undefined on every later event for the same parent (and when the parent's
+   * args were never cached), so the metadata still rides exactly one event.
+   */
+  private buildSpawnMetadataOnce(parentToolCallId: string): SubagentSpawnMetadata | undefined {
+    if (this.announcedSpawns.has(parentToolCallId)) return undefined;
+    this.announcedSpawns.add(parentToolCallId);
+    const args = this.mainToolInputsById.get(parentToolCallId);
+    if (!args) return undefined;
+    // CC's subagent-spawn tools (Task, Agent, ...) share the same input shape
+    // (`description`, `prompt`, `subagent_type`). Pull the fields defensively —
+    // any unknown spawn-tool variant matching this shape benefits automatically.
+    return {
+      description: typeof args.description === 'string' ? args.description : undefined,
+      prompt: typeof args.prompt === 'string' ? args.prompt : undefined,
+      subagentType: typeof args.subagent_type === 'string' ? args.subagent_type : undefined,
+    };
+  }
   /**
    * Tool name keyed by main-agent `tool_use.id`. Used to label the
    * resulting {@link ExternalSignalContext} when a Monitor-style task
@@ -943,9 +972,22 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
     if (!Array.isArray(content)) return [];
 
     const messageId: string | undefined = raw.message?.id;
-    const subagentCtx = {
+    const baseCtx: SubagentEventContext = {
       parentToolCallId: parentToolUseId,
       subagentMessageId: messageId ?? '',
+    };
+
+    // Build spawn metadata once per parent and hand it to the FIRST chunk this
+    // event emits (reasoning, text, OR tool). The executor lazy-creates +
+    // titles the Thread off whichever subagent event it sees first, so a
+    // reasoning/text-first subagent must carry the metadata too — not just the
+    // tool path — or the Thread is born with the generic "Subagent" title.
+    let pendingSpawnMetadata = this.buildSpawnMetadataOnce(parentToolUseId);
+    const nextSubagentCtx = (): SubagentEventContext => {
+      if (!pendingSpawnMetadata) return baseCtx;
+      const ctx: SubagentEventContext = { ...baseCtx, spawnMetadata: pendingSpawnMetadata };
+      pendingSpawnMetadata = undefined;
+      return ctx;
     };
 
     const textParts: string[] = [];
@@ -995,7 +1037,7 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
         this.makeChunkEvent({
           chunkType: 'reasoning',
           reasoning: reasoningParts.join(''),
-          subagent: subagentCtx,
+          subagent: nextSubagentCtx(),
         }),
       );
     }
@@ -1004,11 +1046,19 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
         this.makeChunkEvent({
           chunkType: 'text',
           content: textParts.join(''),
-          subagent: subagentCtx,
+          subagent: nextSubagentCtx(),
         }),
       );
     }
-    events.push(...this.emitToolChunk(newToolCalls, messageId, subagentCtx));
+    // Only consume the pending spawn metadata for the tool chunk when this
+    // event actually carries tools (else it would be lost on the no-op chunk).
+    events.push(
+      ...this.emitToolChunk(
+        newToolCalls,
+        messageId,
+        newToolCalls.length > 0 ? nextSubagentCtx() : baseCtx,
+      ),
+    );
 
     const usage = toUsageData(raw.message?.usage);
     if (usage) {
@@ -1017,7 +1067,7 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
           model: raw.message?.model,
           phase: 'turn_metadata',
           provider: 'claude-code',
-          subagent: subagentCtx,
+          subagent: baseCtx,
           usage,
         }),
       );
@@ -1038,15 +1088,14 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
    * so an echoed tool_use does not re-open a closed lifecycle.
    *
    * When `subagentCtx` is provided, the chunk + each tool_start event
-   * gets the context stamped as a peer field. The FIRST chunk for a new
-   * parent (tracked via `announcedSpawns`) also carries `spawnMetadata`
-   * built from the cached Task args, so the executor can lazy-create
-   * the Thread without knowing about CC-specific argument shapes.
+   * gets the context stamped as a peer field — including any `spawnMetadata`
+   * the caller already attached (`handleSubagentAssistant` builds it once per
+   * parent and hands it to the first emitted chunk, tool or otherwise).
    */
   private emitToolChunk(
     newToolCalls: ToolCallPayload[],
     messageId: string | undefined,
-    subagentCtx?: { parentToolCallId: string; subagentMessageId: string },
+    subagentCtx?: SubagentEventContext,
   ): HeterogeneousAgentEvent[] {
     if (newToolCalls.length === 0) return [];
 
@@ -1057,30 +1106,10 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
     const cumulative = [...existing, ...freshTools];
     this.toolCallsByMessageId.set(msgKey, cumulative);
 
-    // Build the `subagent` peer field — stamped on the chunk + each
-    // tool_start. Only the first emission for a new parent carries
-    // spawnMetadata; subsequent ones carry just the lineage ids.
-    const subagent: SubagentEventContext | undefined = subagentCtx
-      ? {
-          parentToolCallId: subagentCtx.parentToolCallId,
-          subagentMessageId: subagentCtx.subagentMessageId,
-        }
-      : undefined;
-    if (subagent && !this.announcedSpawns.has(subagent.parentToolCallId)) {
-      const args = this.mainToolInputsById.get(subagent.parentToolCallId);
-      if (args) {
-        // CC's subagent-spawn tools (Task, Agent, ...) share the same
-        // input shape (`description`, `prompt`, `subagent_type`). We pull
-        // the fields defensively — any unknown spawn-tool variant that
-        // happens to match this shape benefits automatically.
-        subagent.spawnMetadata = {
-          description: typeof args.description === 'string' ? args.description : undefined,
-          prompt: typeof args.prompt === 'string' ? args.prompt : undefined,
-          subagentType: typeof args.subagent_type === 'string' ? args.subagent_type : undefined,
-        };
-      }
-      this.announcedSpawns.add(subagent.parentToolCallId);
-    }
+    // The `subagent` peer field — stamped on the chunk + each tool_start —
+    // is passed through verbatim (carrying `spawnMetadata` when the caller
+    // designated this the first emission for the parent).
+    const subagent: SubagentEventContext | undefined = subagentCtx;
 
     const chunkData: StreamChunkData = {
       chunkType: 'tools_calling',

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -566,20 +566,13 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
 
   /**
    * Build the spawn metadata (`description` / `prompt` / `subagent_type`) for a
-   * subagent's parent tool_use exactly once, from the cached Task/Agent input.
-   *
-   * MUST be invoked for the FIRST subagent event of any kind — reasoning, text,
-   * OR tool — because the executor lazy-creates the Thread (and titles it from
-   * `description`) on whichever event it sees first. A reasoning- or text-first
-   * subagent (the normal case for a thinking Explore agent that reasons before
-   * its first tool call) would otherwise create the Thread with no metadata,
-   * yielding the generic "Subagent" title and an empty seed prompt. Returns
-   * undefined on every later event for the same parent (and when the parent's
-   * args were never cached), so the metadata still rides exactly one event.
+   * subagent's parent tool_use from the cached Task/Agent input. Pure: it neither
+   * reads nor mutates {@link announcedSpawns} — the caller gates "exactly once"
+   * and only marks the parent announced when the metadata is actually attached to
+   * an EMITTED chunk (see `handleSubagentAssistant`). Returns undefined when the
+   * parent's args were never cached.
    */
-  private buildSpawnMetadataOnce(parentToolCallId: string): SubagentSpawnMetadata | undefined {
-    if (this.announcedSpawns.has(parentToolCallId)) return undefined;
-    this.announcedSpawns.add(parentToolCallId);
+  private buildSpawnMetadata(parentToolCallId: string): SubagentSpawnMetadata | undefined {
     const args = this.mainToolInputsById.get(parentToolCallId);
     if (!args) return undefined;
     // CC's subagent-spawn tools (Task, Agent, ...) share the same input shape
@@ -982,11 +975,21 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
     // titles the Thread off whichever subagent event it sees first, so a
     // reasoning/text-first subagent must carry the metadata too — not just the
     // tool path — or the Thread is born with the generic "Subagent" title.
-    let pendingSpawnMetadata = this.buildSpawnMetadataOnce(parentToolUseId);
+    //
+    // `announcedSpawns` is marked only when the metadata is ACTUALLY attached to
+    // an emitted chunk (inside `nextSubagentCtx`), not merely built here. A first
+    // event that emits nothing the reducer consumes (empty text/thinking block,
+    // an unsupported block, or a usage-only `content: []`) must NOT burn the
+    // one-shot — otherwise the next real chunk would create the Thread with the
+    // fallback title, the exact bug this guards against.
+    let pendingSpawnMetadata = this.announcedSpawns.has(parentToolUseId)
+      ? undefined
+      : this.buildSpawnMetadata(parentToolUseId);
     const nextSubagentCtx = (): SubagentEventContext => {
       if (!pendingSpawnMetadata) return baseCtx;
       const ctx: SubagentEventContext = { ...baseCtx, spawnMetadata: pendingSpawnMetadata };
       pendingSpawnMetadata = undefined;
+      this.announcedSpawns.add(parentToolUseId);
       return ctx;
     };
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

Remote CC (Claude Code) sub-agent Threads were showing the generic title **"Subagent"** in the sidebar instead of the spawn description (e.g. _"Find git remote url lobe-chat"_), even though the main bubble's `Agent` tool card rendered the description correctly.

**Root cause.** The sub-agent Thread title is computed exactly once, at lazy-create time, from `spawnMetadata.description` (`subagentCoordinator/reducer.ts`):

```ts
const title =
  spawnMetadata?.description?.slice(0, 80) ||
  spawnMetadata?.subagentType ||
  'Subagent';
```

But the adapter only attached `spawnMetadata` to the first **tool** chunk (`emitToolChunk`). The server, however, lazy-creates and titles the Thread on the **first sub-agent event of any kind** — `reduceTextChunk` and `reduceToolsChunk` both call `ensureRun`. A reasoning- or text-first sub-agent — the normal case for a thinking `Explore` agent that reasons before its first tool call — created the Thread off a bare context, so the title fell back to `'Subagent'`. The later tool chunk carried the metadata, but the run already existed, so the title was never corrected. This is independent of the cold-replica duplication bug (#15788) — there is no duplication here (1 agent → 1 thread, just the wrong title).

**Fix (adapter-only).** The adapter runs device/CLI-side and ships `spawnMetadata` on the wire `AgentStreamEvent`; the server just reads it.

- Extract `buildSpawnMetadataOnce(parentToolCallId)`.
- `handleSubagentAssistant` now attaches the metadata to the **first emitted chunk** (reasoning / text **OR** tool) via a consume-once `nextSubagentCtx()` closure.
- `emitToolChunk` no longer builds metadata itself — it just passes the context through.

Side benefit: the seed `prompt` (the Thread's `role:'user'` message) is now also recovered for **tool-less** sub-agents, which previously emitted no tool chunk at all.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

New regression test `claudeCode.test.ts` → _"stamps spawnMetadata on a reasoning-FIRST subagent event"_, asserting the reasoning chunk carries the description and the later tool chunk does not re-announce. The existing "first event only" contract is preserved.

```
src/adapters/claudeCode.test.ts        98 passed
src/subagentCoordinator/reducer.test.ts 14 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)