### PR TITLE
💄 style(desktop): enlarge updater modal actions

### DIFF
--- a/src/features/Electron/updater/UpdateNotification.tsx
+++ b/src/features/Electron/updater/UpdateNotification.tsx
@@ -102,7 +102,6 @@ const UpdateDetailContent = memo<UpdateDetailContentProps>(({ updateInfo }) => {
         ))}
       <Flexbox horizontal gap={8} justify={'flex-end'}>
         <BaseButton
-          size={'small'}
           onClick={() => {
             autoUpdateService.installLater();
             close();
@@ -112,7 +111,6 @@ const UpdateDetailContent = memo<UpdateDetailContentProps>(({ updateInfo }) => {
         </BaseButton>
         <BaseButton
           loading={isInstalling}
-          size={'small'}
           type={'primary'}
           onClick={() => {
             setIsInstalling(true);


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None found.

#### 🔀 Description of Change

- Use the default base-ui button size for the desktop updater release-note modal footer actions.
- Keep the compact left-bottom updater notification buttons unchanged.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Validation performed:

```bash
bunx eslint src/features/Electron/updater/UpdateNotification.tsx --quiet
git diff --check origin/canary..HEAD
```

#### 📸 Screenshots / Videos

Not captured. This modal depends on the Electron updater downloaded-update state, and the change is limited to button sizing.

#### 📝 Additional Information

No migration or configuration changes.
