### PR TITLE
🐛 fix(agent-builder): strip conflicting agent tools in builder mode

### DIFF
--- a/packages/builtin-agents/package.json
+++ b/packages/builtin-agents/package.json
@@ -10,6 +10,11 @@
   },
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "scripts": {
+    "test": "vitest",
+    "test:coverage": "vitest --coverage --silent='passed-only'",
+    "test:update": "vitest -u"
+  },
   "dependencies": {
     "@lobechat/builtin-tool-agent-builder": "workspace:*",
     "@lobechat/builtin-tool-agent-documents": "workspace:*",

--- a/packages/builtin-agents/src/agents/agent-builder/index.test.ts
+++ b/packages/builtin-agents/src/agents/agent-builder/index.test.ts
@@ -1,0 +1,41 @@
+import { AgentBuilderIdentifier } from '@lobechat/builtin-tool-agent-builder';
+import { describe, expect, it } from 'vitest';
+
+import { getAgentRuntimeConfig } from '../../index';
+import { BUILTIN_AGENT_SLUGS } from '../../types';
+
+const resolvePlugins = (plugins?: string[]) =>
+  getAgentRuntimeConfig(BUILTIN_AGENT_SLUGS.agentBuilder, { plugins })?.plugins ?? [];
+
+describe('AGENT_BUILDER runtime plugins', () => {
+  it('always includes the Agent Builder tool', () => {
+    expect(resolvePlugins()).toEqual([AgentBuilderIdentifier]);
+  });
+
+  it('strips conflicting agent-editing / orchestration tools', () => {
+    const plugins = resolvePlugins([
+      'lobe-agent-management',
+      'lobe-group-management',
+      'lobe-group-agent-builder',
+      'lobe-agent',
+    ]);
+
+    expect(plugins).toEqual([AgentBuilderIdentifier]);
+  });
+
+  it('keeps functional plugins (web browsing, Gmail/Composio, etc.)', () => {
+    const plugins = resolvePlugins([
+      'lobe-web-browsing',
+      'lobe-image-generation',
+      'gmail',
+      'lobe-agent-management', // conflicting → removed
+    ]);
+
+    expect(plugins).toEqual([
+      AgentBuilderIdentifier,
+      'lobe-web-browsing',
+      'lobe-image-generation',
+      'gmail',
+    ]);
+  });
+});

--- a/packages/builtin-agents/src/agents/agent-builder/index.ts
+++ b/packages/builtin-agents/src/agents/agent-builder/index.ts
@@ -7,6 +7,37 @@ import { BUILTIN_AGENT_SLUGS } from '../../types';
 import { systemRoleTemplate } from './systemRole';
 
 /**
+ * Builtin tools that conflict with the Agent Builder when they coexist in the
+ * same conversation. In Agent Builder mode the Agent Builder tool is the SOLE
+ * authority for editing the agent being configured, so these agent-editing /
+ * orchestration tools are stripped from `ctx.plugins`:
+ *
+ * - `lobe-agent-management`: duplicate edit APIs (updatePrompt / updateAgent /
+ *   installPlugin) PLUS a `<self_management>` prompt whose `<current_agent>`
+ *   points at the builder ITSELF and tells the model to "prefer Agent Management
+ *   and modify the current agent (yourself)". With both toolsets present this is
+ *   what makes an ambiguous "help me change ..." edit the builder's own config
+ *   instead of the agent on the left.
+ * - `lobe-group-management` / `lobe-group-agent-builder`: group agent CRUD /
+ *   callAgent — a second, overlapping "edit/orchestrate agents" surface.
+ * - `lobe-agent`: sub-agent dispatch / planning / todos — orchestration noise
+ *   that competes with the builder's single "configure this agent" job.
+ *
+ * Functional plugins the edited agent carries (web browsing, image generation,
+ * Gmail / Composio integrations, marketplace MCP, etc.) are intentionally kept —
+ * the builder may still use them, and only the conflicting tools above are
+ * removed. Identifiers are the stable persisted plugin ids (see each tool's
+ * `*Identifier`); using literals here mirrors `EXCLUDED_TOOLS` in the tool-store
+ * selectors and avoids pulling extra package deps into builtin-agents.
+ */
+const AGENT_BUILDER_CONFLICTING_TOOLS = new Set<string>([
+  'lobe-agent-management',
+  'lobe-group-management',
+  'lobe-group-agent-builder',
+  'lobe-agent',
+]);
+
+/**
  * Agent Builder - used for configuring AI agents through natural conversation
  */
 export const AGENT_BUILDER: BuiltinAgentDefinition = {
@@ -20,7 +51,10 @@ export const AGENT_BUILDER: BuiltinAgentDefinition = {
 
   // Runtime config - static systemRole
   runtime: (ctx) => ({
-    plugins: [AgentBuilderIdentifier, ...(ctx.plugins || [])],
+    plugins: [
+      AgentBuilderIdentifier,
+      ...(ctx.plugins || []).filter((id) => !AGENT_BUILDER_CONFLICTING_TOOLS.has(id)),
+    ],
     systemRole: systemRoleTemplate,
   }),
 

--- a/packages/builtin-agents/vitest.config.mts
+++ b/packages/builtin-agents/vitest.config.mts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'lcov', 'text-summary'],
+    },
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- internal: Agent Builder tool disambiguation — builder edits itself on ambiguous requests -->

Follow-up to #16326 (gateway-mode context injection & editor sync).

#### 🔀 Description of Change

In **Agent Builder mode** the builder should be the **sole authority** for editing the agent being configured. But the edited agent's other builtin tools flow into the builder session via `ctx.plugins`, so **Agent Management**, **group management/builder**, and **LobeAgent** end up coexisting with the builder in the same conversation.

This is what makes the builder **edit itself** on an ambiguous request. **Agent Management** is the worst offender:

- Duplicate edit APIs — `updatePrompt` / `updateAgent` / `installPlugin` overlap the builder's own.
- Its `<self_management>` prompt sets `<current_agent>` to the **builder itself** and instructs the model to *"prefer Agent Management and modify the current agent (yourself)"* — directly contradicting the builder's `<current_agent_context>` (which is the agent on the left, `editingAgentId`).

With both toolsets present, a vague *"帮我改一下…"* gets routed to Agent Management's self-management path and the builder reconfigures **its own** config instead of the edited agent.

**Fix:** filter the conflicting agent-editing / orchestration tools out of the Agent Builder's runtime `plugins` at a single chokepoint (`packages/builtin-agents/src/agents/agent-builder/index.ts`) that covers **both** the client (`agentConfigResolver`) and gateway (`RuntimeExecutors`) paths. Stripped: `lobe-agent-management`, `lobe-group-management`, `lobe-group-agent-builder`, `lobe-agent`. **Functional plugins are kept** — web browsing, image generation, Gmail / Composio, marketplace MCP, etc. — so the builder can still use them.

Also adds the package's first `vitest.config.mts` + `test` scripts (it had none, so its tests couldn't run) and a focused test for the filter.

#### 🧪 How to Test

In Agent Builder mode, open an agent whose config enables Agent Management / LobeAgent (or any agent in a context where those tools are injected):

1. Ask the builder a vague edit request (e.g. "帮我把这个调得更友好一点") — it now edits **the agent on the left**, never its own config.
2. Confirm functional plugins still work — e.g. ask it to search the marketplace / reference web-browsing tools.
3. `cd packages/builtin-agents && bunx vitest run src/agents/agent-builder/index.test.ts` → 3 passing.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📝 Additional Information

Scope is limited to the `agent-builder` builtin agent's runtime. `group-agent-builder` is intentionally left untouched (it legitimately needs group agent CRUD / callAgent).