### PR TITLE
♿️ style(form): add autocomplete hints and keyboard-operable links

### DIFF
--- a/src/components/FormInput/FormPassword.tsx
+++ b/src/components/FormInput/FormPassword.tsx
@@ -33,6 +33,9 @@ const FormPassword = memo<FormPasswordProps>(({ onChange, value: defaultValue, .
         if (isComposingRef.current) return;
         onChange?.(value);
       }}
+      // Secret field (API keys, tokens): suppress autofill of the saved login
+      // password. Overridable by callers via {...props}.
+      autoComplete="new-password"
       {...props}
       value={value}
     />

--- a/src/features/Auth/ResetPassword/ResetPasswordContent.tsx
+++ b/src/features/Auth/ResetPassword/ResetPasswordContent.tsx
@@ -44,6 +44,7 @@ export const ResetPasswordContent = ({
         ]}
       >
         <InputPassword
+          autoComplete="new-password"
           placeholder={t('betterAuth.resetPassword.newPasswordPlaceholder')}
           size="large"
           prefix={
@@ -70,6 +71,7 @@ export const ResetPasswordContent = ({
         ]}
       >
         <InputPassword
+          autoComplete="new-password"
           placeholder={t('betterAuth.resetPassword.confirmPasswordPlaceholder')}
           size="large"
           prefix={

--- a/src/features/Auth/SignIn/SignInEmailStep.tsx
+++ b/src/features/Auth/SignIn/SignInEmailStep.tsx
@@ -151,6 +151,8 @@ export const SignInEmailStep = ({
             ]}
           >
             <Input
+              autoComplete="username"
+              inputMode="email"
               placeholder={t('betterAuth.signin.emailPlaceholder')}
               ref={emailInputRef}
               size="large"
@@ -186,7 +188,18 @@ export const SignInEmailStep = ({
           description={
             <>
               {t('betterAuth.signin.socialOnlyHint')}{' '}
-              <a className={styles.setPasswordLink} onClick={onSetPassword}>
+              <a
+                className={styles.setPasswordLink}
+                role="button"
+                tabIndex={0}
+                onClick={onSetPassword}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onSetPassword();
+                  }
+                }}
+              >
                 {t('betterAuth.signin.setPassword')}
               </a>
             </>

--- a/src/features/Auth/SignIn/SignInPasswordStep.tsx
+++ b/src/features/Auth/SignIn/SignInPasswordStep.tsx
@@ -40,8 +40,16 @@ export const SignInPasswordStep = ({
         <>
           <Text fontSize={13} type={'secondary'}>
             <a
+              role="button"
               style={{ color: 'inherit', cursor: 'pointer', textDecoration: 'underline' }}
+              tabIndex={0}
               onClick={onForgotPassword}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  void onForgotPassword();
+                }
+              }}
             >
               {t('betterAuth.signin.forgotPassword')}
             </a>
@@ -70,6 +78,7 @@ export const SignInPasswordStep = ({
           style={{ marginBottom: 0 }}
         >
           <InputPassword
+            autoComplete="current-password"
             placeholder={t('betterAuth.signin.passwordPlaceholder')}
             ref={passwordInputRef}
             size="large"

--- a/src/features/Auth/SignUp/BetterAuthSignUpForm.tsx
+++ b/src/features/Auth/SignUp/BetterAuthSignUpForm.tsx
@@ -62,9 +62,12 @@ const BetterAuthSignUpForm = () => {
           ]}
         >
           <Input
+            autoComplete="email"
+            inputMode="email"
             placeholder={t('betterAuth.signup.emailPlaceholder')}
             ref={emailInputRef}
             size="large"
+            type="email"
             prefix={
               <Icon
                 icon={Mail}
@@ -93,6 +96,7 @@ const BetterAuthSignUpForm = () => {
           ]}
         >
           <Input.Password
+            autoComplete="new-password"
             placeholder={t('betterAuth.signup.passwordPlaceholder')}
             ref={passwordInputRef}
             size="large"
@@ -122,6 +126,7 @@ const BetterAuthSignUpForm = () => {
           ]}
         >
           <Input.Password
+            autoComplete="new-password"
             placeholder={t('betterAuth.signup.confirmPasswordPlaceholder')}
             size="large"
             prefix={

--- a/src/features/Connectors/AddConnectorModal/index.tsx
+++ b/src/features/Connectors/AddConnectorModal/index.tsx
@@ -313,9 +313,7 @@ const AddConnectorModal = memo<AddConnectorModalProps>(({ open, onClose, connect
     ? t('connector.add.editTitle', 'Edit Connector')
     : t('connector.add.title', 'Add custom connector');
 
-  const okText = isEditMode
-    ? t('connector.add.update', 'Save')
-    : t('connector.add.confirm', 'Add');
+  const okText = isEditMode ? t('connector.add.update', 'Save') : t('connector.add.confirm', 'Add');
 
   return (
     <Modal
@@ -374,6 +372,7 @@ const AddConnectorModal = memo<AddConnectorModalProps>(({ open, onClose, connect
                 onChange={(e) => setClientId(e.target.value)}
               />
               <Input.Password
+                autoComplete="new-password"
                 placeholder={t('connector.add.clientSecret', 'OAuth Client Secret (optional)')}
                 value={clientSecret}
                 onChange={(e) => setClientSecret(e.target.value)}

--- a/src/features/PluginDevModal/MCPManifestForm/index.tsx
+++ b/src/features/PluginDevModal/MCPManifestForm/index.tsx
@@ -281,7 +281,10 @@ const MCPManifestForm = ({
                   name={AUTH_TOKEN}
                   rules={[{ message: t('dev.mcp.auth.token.required'), required: true }]}
                 >
-                  <InputPassword placeholder={t('dev.mcp.auth.token.placeholder')} />
+                  <InputPassword
+                    autoComplete="new-password"
+                    placeholder={t('dev.mcp.auth.token.placeholder')}
+                  />
                 </FormItem>
               )}
               {enableOAuth && authType === 'oauth2' && (
@@ -298,7 +301,10 @@ const MCPManifestForm = ({
                     label={t('dev.mcp.auth.oauth.clientSecret.label')}
                     name={AUTH_CLIENT_SECRET}
                   >
-                    <InputPassword placeholder={t('dev.mcp.auth.oauth.clientSecret.placeholder')} />
+                    <InputPassword
+                      autoComplete="new-password"
+                      placeholder={t('dev.mcp.auth.oauth.clientSecret.placeholder')}
+                    />
                   </FormItem>
                   <div
                     style={{

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/CloudHeterogeneousConfig.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/CloudHeterogeneousConfig.tsx
@@ -183,6 +183,7 @@ const TokenSection = memo<TokenSectionProps>(({ existingCred, onSaved, onEnvChan
       ) : (
         <Flexbox horizontal gap={8}>
           <Input.Password
+            autoComplete="new-password"
             autoFocus={!!existingCred}
             disabled={!canEdit}
             placeholder={t('heterogeneousStatus.cloud.tokenPlaceholder')}

--- a/src/routes/(main)/settings/apikey/features/ApiKeyDatePicker/index.tsx
+++ b/src/routes/(main)/settings/apikey/features/ApiKeyDatePicker/index.tsx
@@ -34,7 +34,20 @@ const ApiKeyDatePicker: FC<ApiKeyDatePickerProps> = ({ value, onChange, ...props
       showNow={false}
       renderExtraFooter={() => (
         <Flex justify="center">
-          <a onClick={() => handleOnChange(null)}>{t('apikey.display.neverExpires')}</a>
+          <a
+            role="button"
+            style={{ cursor: 'pointer' }}
+            tabIndex={0}
+            onClick={() => handleOnChange(null)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleOnChange(null);
+              }
+            }}
+          >
+            {t('apikey.display.neverExpires')}
+          </a>
         </Flex>
       )}
       onChange={handleOnChange}

--- a/src/routes/(main)/settings/creds/features/CreateCredModal/KVCredForm.tsx
+++ b/src/routes/(main)/settings/creds/features/CreateCredModal/KVCredForm.tsx
@@ -125,6 +125,7 @@ const KVCredForm: FC<KVCredFormProps> = ({ type, disabled, onBack, onSuccess }) 
                     style={{ flex: 2, marginBottom: 0 }}
                   >
                     <Input.Password
+                      autoComplete="new-password"
                       disabled={disabled}
                       placeholder={t('creds.form.valuePlaceholder')}
                     />

--- a/src/routes/(main)/settings/creds/features/EditCredModal/EditKVForm.tsx
+++ b/src/routes/(main)/settings/creds/features/EditCredModal/EditKVForm.tsx
@@ -160,6 +160,7 @@ const EditKVForm: FC<EditKVFormProps> = ({ cred, onCancel, onSuccess }) => {
                     style={{ flex: 2, marginBottom: 0 }}
                   >
                     <Input.Password
+                      autoComplete="new-password"
                       disabled={!canManageCredentials}
                       placeholder={t('creds.form.valuePlaceholder')}
                     />

--- a/src/routes/(main)/settings/profile/features/EmailRow.tsx
+++ b/src/routes/(main)/settings/profile/features/EmailRow.tsx
@@ -72,8 +72,11 @@ const EmailRow = () => {
       <Flexbox gap={12}>
         <Input
           autoFocus
+          autoComplete="email"
+          inputMode="email"
           placeholder={t('profile.emailPlaceholder')}
           status={error ? 'error' : undefined}
+          type="email"
           value={editValue}
           onPressEnter={handleSave}
           onChange={(e) => {

--- a/src/routes/(main)/settings/proxy/features/ProxyForm.tsx
+++ b/src/routes/(main)/settings/proxy/features/ProxyForm.tsx
@@ -265,7 +265,12 @@ const ProxyForm = () => {
               rules: [{ validator: validateProxyUsername }],
             },
             {
-              children: <Input.Password placeholder={t('proxy.password_placeholder')} />,
+              children: (
+                <Input.Password
+                  autoComplete="new-password"
+                  placeholder={t('proxy.password_placeholder')}
+                />
+              ),
               label: t('proxy.password'),
               name: 'proxyPassword',
               rules: [{ validator: validateProxyPassword }],


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔀 Description of Change

Form micro-detail polish across the auth flow and settings, applied with the `interface-details` skill (rules `form-*` / `button-2`). All low-risk attribute/semantics additions — no behavior changes to existing flows.

**Email inputs — mobile keyboard + autofill**
- Sign-up and profile email-change fields: `type="email"` + `inputMode="email"` + `autoComplete="email"` so mobile shows the email keyboard and password managers can autofill.
- Sign-in identifier uses `autoComplete="username"` + `inputMode="email"` (no `type="email"`, since that field also accepts a plain username and native validation would reject it).

**Password `autoComplete` — by field purpose**
- Account auth: sign-in `current-password`; sign-up + reset-password `new-password` so managers reliably save/generate.
- Secret fields (API keys, tokens, KV creds, proxy/connector secrets): `new-password` to stop the browser autofilling the saved login password into a secret box. Applied once on the shared `FormPassword` (covers ~15 provider/channel consumers) plus the forms using `Input.Password` directly.

**`button-2` — keyboard-operable links**
- Converted three bare `<a onClick>` controls (set password, forgot password, "never expires") to keyboard-operable: `role="button"` + `tabIndex={0}` + Enter/Space `onKeyDown`. Tab now reaches them and Enter/Space activates.

#### 🧪 How to Test

- [x] Tested locally
- [x] No tests needed

`bun run type-check` passes. Manual: on mobile the email field shows the email keyboard; a password manager offers to save/generate on sign-up; tabbing reaches the "forgot password" / "set password" links and Enter activates them.

#### 📝 Additional Information

Not included here (tracked separately): the forgot-password double-click loading guard (`button-4`, needs a loading state) and the broader async-action-guard sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)