### PR TITLE
🐛 fix: Fix conversation-flow multi-prose assistant chains

### DIFF
--- a/packages/conversation-flow/src/__tests__/parse.test.ts
+++ b/packages/conversation-flow/src/__tests__/parse.test.ts
@@ -637,76 +637,125 @@ describe('parse', () => {
       expect(children[1].tools[0].result_msg_id).toBe('t1');
     });
 
-    // Guard for the narrow scope above: when MORE than one toolless prose step
-    // precedes the first tool call, the head is NOT folded. collectAssistantChain
-    // stops at the first toolless continuation, so folding here would emit a
-    // tools-less assistantGroup and still leave the tool step split. The multi-
-    // prose prelude must instead stay as plain assistant bubbles — and crucially
-    // we must never produce an assistantGroup with no tools.
-    it('should not fold a multi-step toolless prelude (no tools-less assistantGroup)', () => {
+    // Regression: Codex can stream several plain assistant progress messages
+    // between tool-using steps. They are still one continuous run and must stay
+    // inside the same assistantGroup instead of rendering as disconnected
+    // standalone Codex bubbles.
+    it('should fold multiple toolless assistant continuations into one tool chain', () => {
       const messages: Message[] = [
         {
-          content: 'Can you check the build status?',
+          content: 'Can you connect to CF and inspect usage?',
           createdAt: 0,
           id: 'u1',
           role: 'user',
           updatedAt: 0,
         },
         {
-          content: 'Sure, let me think about where to look.',
+          content: 'OAuth token can access the CF REST API.',
           createdAt: 1,
-          id: 'a-head', // toolless, parent is the user message
+          id: 'a-rest',
           parentId: 'u1',
           role: 'assistant',
+          tools: [
+            {
+              apiName: 'command',
+              arguments: '{}',
+              id: 't-rest',
+              identifier: 'codex',
+              type: 'default',
+            },
+          ],
           updatedAt: 1,
         },
         {
-          content: 'The CI config is probably under .github/workflows.',
+          content: 'account list',
           createdAt: 2,
-          id: 'a-prose', // SECOND toolless prose step before any tool
-          parentId: 'a-head',
-          role: 'assistant',
+          id: 't-rest',
+          parentId: 'a-rest',
+          role: 'tool',
+          tool_call_id: 't-rest',
           updatedAt: 2,
         },
         {
-          content: 'Reading it now.',
+          content: 'GraphQL root only has viewer.',
           createdAt: 3,
-          id: 'a-tool',
-          parentId: 'a-prose',
+          id: 'a-viewer',
+          parentId: 'a-rest',
           role: 'assistant',
-          tools: [
-            { apiName: 'readFile', arguments: '{}', id: 't1', identifier: 'fs', type: 'default' },
-          ],
           updatedAt: 3,
         },
         {
-          content: 'name: CI',
+          content: 'GraphQL schema confirms lowercase viewer.',
           createdAt: 4,
-          id: 't1',
-          parentId: 'a-tool',
-          role: 'tool',
-          tool_call_id: 't1',
+          id: 'a-schema',
+          parentId: 'a-viewer',
+          role: 'assistant',
           updatedAt: 4,
+        },
+        {
+          content: 'Now reading the account analytics fields.',
+          createdAt: 5,
+          id: 'a-analytics',
+          parentId: 'a-schema',
+          role: 'assistant',
+          tools: [
+            {
+              apiName: 'command',
+              arguments: '{}',
+              id: 't-analytics',
+              identifier: 'codex',
+              type: 'default',
+            },
+          ],
+          updatedAt: 5,
+        },
+        {
+          content: 'workersInvocationsAdaptive',
+          createdAt: 6,
+          id: 't-analytics',
+          parentId: 'a-analytics',
+          role: 'tool',
+          tool_call_id: 't-analytics',
+          updatedAt: 6,
+        },
+        {
+          content: 'I found the Workers and Durable Objects usage datasets.',
+          createdAt: 7,
+          id: 'a-final',
+          parentId: 'a-analytics',
+          role: 'assistant',
+          updatedAt: 7,
         },
       ] as Message[];
 
       const result = parse(messages);
 
-      // No assistantGroup may exist without tools in any of its children.
-      const toollessGroups = result.flatList.filter(
-        (m) =>
-          m.role === 'assistantGroup' &&
-          ((m as any).children ?? []).every((c: any) => !c.tools || c.tools.length === 0),
-      );
-      expect(toollessGroups).toHaveLength(0);
+      expect(result.flatList).toHaveLength(2);
+      expect(result.flatList[0].id).toBe('u1');
+      expect(result.flatList[1].role).toBe('assistantGroup');
 
-      // The two prose steps render as plain assistant bubbles; the tool step
-      // forms its own (well-formed) assistantGroup.
-      const head = result.flatList.find((m) => m.id === 'a-head');
-      expect(head?.role).toBe('assistant');
-      const toolGroup = result.flatList.find((m) => m.id === 'a-tool');
-      expect(toolGroup?.role).toBe('assistantGroup');
-      expect((toolGroup as any).children[0].tools[0].result_msg_id).toBe('t1');
+      const children = (result.flatList[1] as any).children;
+      expect(children.map((c: any) => c.id)).toEqual([
+        'a-rest',
+        'a-viewer',
+        'a-schema',
+        'a-analytics',
+        'a-final',
+      ]);
+      expect(children[0].tools[0].result_msg_id).toBe('t-rest');
+      expect(children[1].tools).toBeUndefined();
+      expect(children[2].tools).toBeUndefined();
+      expect(children[3].tools[0].result_msg_id).toBe('t-analytics');
+
+      const contextGroup = result.contextTree.find((node: any) => node.id === 'a-rest') as any;
+      expect(contextGroup?.type).toBe('assistantGroup');
+      expect(contextGroup.children.map((node: any) => node.id)).toEqual([
+        'a-rest',
+        'a-viewer',
+        'a-schema',
+        'a-analytics',
+        'a-final',
+      ]);
     });
   });
 

--- a/packages/conversation-flow/src/transformation/ContextTreeBuilder.ts
+++ b/packages/conversation-flow/src/transformation/ContextTreeBuilder.ts
@@ -218,7 +218,10 @@ export class ContextTreeBuilder {
     // group head legitimately has a mix of tool + assistant children. (In the
     // old tool-anchored form a tool-using assistant only ever had tool children,
     // so this stays a no-op for legacy data.)
-    return idNode.children.some((child) => this.messageMap.get(child.id)?.role === 'tool');
+    return (
+      idNode.children.some((child) => this.messageMap.get(child.id)?.role === 'tool') ||
+      this.messageCollector.isToolChainHead(message)
+    );
   }
 
   /**

--- a/packages/conversation-flow/src/transformation/MessageCollector.ts
+++ b/packages/conversation-flow/src/transformation/MessageCollector.ts
@@ -108,14 +108,13 @@ export class MessageCollector {
   }
 
   /**
-   * True when a TOOLLESS assistant is the head of a turn whose very next step
-   * calls tools — the narration the LLM streams in reply to the user
-   * immediately before its first tool call, with the tool-using step as its
-   * direct child. `collectAssistantChain` already walks correctly from such a
-   * head, but the flat-list dispatcher only opens an AssistantGroup when the
-   * message itself carries tools — so without this check the toolless head is
-   * emitted as its own standalone bubble and visually splits off from the group
-   * that starts at the first tool step (looks like a broken chain).
+   * True when a TOOLLESS assistant is the head of a turn that eventually reaches
+   * a tool-using step — the narration the LLM streams in reply to the user
+   * before its first tool call. `collectAssistantChain` already walks correctly
+   * from such a head, but the flat-list dispatcher only opens an AssistantGroup
+   * when the message itself carries tools — so without this check the toolless
+   * head is emitted as its own standalone bubble and visually splits off from the
+   * group that starts at the first tool step (looks like a broken chain).
    *
    * Deliberately narrow:
    * - Only a turn head (parent is a `user` message). A toolless step wedged
@@ -123,11 +122,9 @@ export class MessageCollector {
    *   itself so the chain stays in one group — see the toolless-continuation
    *   branch there; it must NOT also be opened as a head here or the same run
    *   would split.
-   * - The immediate continuation must ALREADY carry tools. We intentionally do
-   *   not walk through intermediate toolless prose steps: `collectAssistantChain`
-   *   bridges at most ONE toolless prose step before a tool step (a multi-prose
-   *   prelude — toolless → toolless — still falls back to standalone bubbles
-   *   rather than a malformed group).
+   * - The continuation path must eventually carry tools. Consecutive toolless
+   *   prose steps are still part of the same hetero-agent run, so walk through
+   *   them instead of splitting the visible chain into standalone bubbles.
    * - A fork (>1 same-agent non-signal continuation) returns false so branch
    *   handling stays untouched.
    */
@@ -138,19 +135,19 @@ export class MessageCollector {
     const parent = assistant.parentId ? this.messageMap.get(assistant.parentId) : undefined;
     if (parent?.role !== 'user') return false;
 
-    // A toolless step owns no tool results, so its only continuation candidates
-    // are its own non-signal, same-agent assistant children (mirrors
-    // findFlatChainContinuation for that case).
     const groupAgentId = assistant.agentId;
-    const candidates = (this.childrenMap.get(assistant.id) ?? [])
-      .map((id) => this.messageMap.get(id))
-      .filter(
-        (m): m is Message =>
-          !!m && m.role === 'assistant' && m.agentId === groupAgentId && !getMessageSignal(m),
-      );
-    if (candidates.length !== 1) return false; // no continuation, or a fork → defer to branch logic
-    const next = candidates[0];
-    return !!(next.tools && next.tools.length > 0); // only when the very next step calls tools
+    const allMessages = [...this.messageMap.values()];
+    const visited = new Set<string>([assistant.id]);
+    let current: Message = assistant;
+
+    while (true) {
+      const next = this.findFlatChainContinuation(current, [], allMessages, visited, groupAgentId);
+      if (!next) return false;
+      if (next.tools && next.tools.length > 0) return true;
+
+      visited.add(next.id);
+      current = next;
+    }
   }
 
   /**
@@ -205,27 +202,30 @@ export class MessageCollector {
       return;
     }
 
-    // Toolless continuation. By default this is the final narrated answer and the
-    // chain ends here. EXCEPTION: a single toolless prose step wedged BETWEEN two
-    // tool steps — the model narrates mid-turn right before its next tool call —
-    // is part of THIS chain. Ending here would split the following tool step into
-    // its own AssistantGroup and visually break one continuous run into two
-    // bubbles (regression). Mirror `isToolChainHead`, which already bridges this
-    // shape at a turn head (parent === user): walk through the prose step only
-    // when its sole continuation ALREADY carries tools. A multi-prose prelude
-    // (toolless → toolless) still ends here, matching the documented fallback.
-    assistantChain.push(continuation);
-    const onward = this.findFlatChainContinuation(
-      continuation,
-      [], // a toolless step owns no tool results
-      allMessages,
-      processedIds,
-      groupAgentId,
-    );
-    if (onward && onward.tools && onward.tools.length > 0) {
-      processedIds.add(continuation.id);
+    // Toolless continuations are still part of the same hetero-agent run. The
+    // model can emit several prose-only progress updates before the next tool
+    // call, so keep walking until the chain either ends in a toolless final
+    // answer or reaches the next tool-using assistant.
+    let toollessContinuation: Message | undefined = continuation;
+    while (
+      toollessContinuation &&
+      (!toollessContinuation.tools || toollessContinuation.tools.length === 0)
+    ) {
+      assistantChain.push(toollessContinuation);
+      processedIds.add(toollessContinuation.id);
+
+      toollessContinuation = this.findFlatChainContinuation(
+        toollessContinuation,
+        [], // a toolless step owns no tool results
+        allMessages,
+        processedIds,
+        groupAgentId,
+      );
+    }
+
+    if (toollessContinuation) {
       this.collectAssistantChain(
-        onward,
+        toollessContinuation,
         allMessages,
         assistantChain,
         allToolMessages,

--- a/packages/conversation-flow/src/transformation/__tests__/MessageCollector.test.ts
+++ b/packages/conversation-flow/src/transformation/__tests__/MessageCollector.test.ts
@@ -848,23 +848,39 @@ describe('MessageCollector', () => {
       expect(allToolMessages.map((m) => m.id)).toEqual(['tool-1', 'tool-2']);
     });
 
-    it('does NOT bridge a multi-prose prelude (toolless → toolless ends the chain)', () => {
-      // The bridge is intentionally narrow: it folds at most ONE prose step before
-      // a tool step. Two consecutive toolless steps still terminate the chain so
-      // they fall back to standalone bubbles rather than a malformed group.
+    it('bridges multiple toolless prose steps before the next tool step', () => {
+      // Codex can stream several plain assistant progress updates before the
+      // next command. They are still one run and should not split into
+      // standalone bubbles between tool-using steps.
       const astA = mkAssistant('ast-A', { parentId: 'user-1', tools: [bashTool('tc-1')] });
       const toolA = mkTool('tool-1', { parentId: 'ast-A', tool_call_id: 'tc-1' });
       const prose1 = mkAssistant('ast-prose-1', { createdAt: 1, parentId: 'ast-A' });
       const prose2 = mkAssistant('ast-prose-2', { createdAt: 2, parentId: 'ast-prose-1' });
       const astC = mkAssistant('ast-C', { parentId: 'ast-prose-2', tools: [bashTool('tc-2')] });
+      const toolC = mkTool('tool-2', { parentId: 'ast-C', tool_call_id: 'tc-2' });
+      const astFinal = mkAssistant('ast-final', { parentId: 'ast-C' });
 
-      const allMessages: Message[] = [astA, toolA, prose1, prose2, astC];
+      const allMessages: Message[] = [astA, toolA, prose1, prose2, astC, toolC, astFinal];
       const collector = new MessageCollector(new Map(), new Map());
 
       const assistantChain: Message[] = [];
-      collector.collectAssistantChain(astA, allMessages, assistantChain, [], new Set());
+      const allToolMessages: Message[] = [];
+      collector.collectAssistantChain(
+        astA,
+        allMessages,
+        assistantChain,
+        allToolMessages,
+        new Set(),
+      );
 
-      expect(assistantChain.map((m) => m.id)).toEqual(['ast-A', 'ast-prose-1']);
+      expect(assistantChain.map((m) => m.id)).toEqual([
+        'ast-A',
+        'ast-prose-1',
+        'ast-prose-2',
+        'ast-C',
+        'ast-final',
+      ]);
+      expect(allToolMessages.map((m) => m.id)).toEqual(['tool-1', 'tool-2']);
     });
   });
 });


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to the Codex topic rendering case where multiple plain assistant progress messages appeared as disconnected bubbles.

#### 🔀 Description of Change

This fixes conversation-flow parsing for hetero-agent runs where Codex streams multiple toolless assistant progress messages between tool-using steps.

Root cause: `MessageCollector.collectAssistantChain` only bridged a single toolless continuation before the next tool step. When Codex emitted two or more plain assistant messages in a row, the chain stopped early and the UI rendered those messages as standalone assistant bubbles.

Changes:

- Walk through consecutive toolless assistant continuations until the next tool-using assistant or final answer.
- Allow toolless turn heads to seed an `assistantGroup` when their continuation path eventually reaches a tool step.
- Keep `contextTree` grouping in sync with `flatList` for the same shape.
- Add parse and collector regressions for the Codex-style `tool assistant -> plain assistant -> plain assistant -> tool assistant` chain.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --dir packages/conversation-flow --config packages/conversation-flow/vitest.config.mts
```

Result: 10 test files passed, 154 tests passed.

#### 📸 Screenshots / Videos

N/A. Parser behavior regression only.

#### 📝 Additional Information

The PR was prepared from a clean worktree based on `origin/canary` so it only includes the conversation-flow parser/test changes.