### PR TITLE
🐛 fix(hetero-agent): chain execAgent user turns

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
@@ -168,10 +168,32 @@ describe('execAgent', () => {
         .insert(topics)
         .values({ agentId: testAgentId, title: 'Existing Topic', userId })
         .returning();
+      const [seedUserMessage] = (await serverDB
+        .insert(messages)
+        .values({
+          agentId: testAgentId,
+          content: 'Initial question',
+          role: 'user',
+          topicId: existingTopic.id,
+          userId,
+        })
+        .returning()) as any[];
+      const [latestAssistantMessage] = (await serverDB
+        .insert(messages)
+        .values({
+          agentId: testAgentId,
+          content: 'Initial answer',
+          parentId: seedUserMessage.id,
+          role: 'assistant',
+          topicId: existingTopic.id,
+          userId,
+        })
+        .returning()) as any[];
 
       const result = await caller.execAgent({
         agentId: testAgentId,
         appContext: { topicId: existingTopic.id },
+        autoStart: false,
         prompt: 'Follow up question',
       });
 
@@ -180,6 +202,20 @@ describe('execAgent', () => {
       const allTopics = await serverDB.select().from(topics).where(eq(topics.agentId, testAgentId));
       expect(allTopics).toHaveLength(1);
       expect(allTopics[0].id).toBe(existingTopic.id);
+
+      const allMessages = await serverDB
+        .select()
+        .from(messages)
+        .where(eq(messages.topicId, existingTopic.id));
+      const followUpUserMessage = allMessages.find(
+        (message) => message.role === 'user' && message.content === 'Follow up question',
+      );
+      expect(followUpUserMessage?.parentId).toBe(latestAssistantMessage.id);
+
+      const followUpAssistantMessage = allMessages.find(
+        (message) => message.role === 'assistant' && message.parentId === followUpUserMessage?.id,
+      );
+      expect(followUpAssistantMessage).toBeDefined();
     });
   });
 

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1342,6 +1342,13 @@ export class AiAgentService {
     // exclude this freshly-created turn — history must be the PRIOR turns only,
     // otherwise the new prompt is double-counted in the LLM context.
     const selfMessageIds = new Set<string>();
+    const userMessageParentId =
+      runFromHistory || parentMessageId
+        ? undefined
+        : await this.messageModel.getLatestSpineMessageId?.({
+            threadId: appContext?.threadId ?? null,
+            topicId,
+          });
     const userMessageRecord = runFromHistory
       ? undefined
       : await this.messageModel.create({
@@ -1353,6 +1360,7 @@ export class AiAgentService {
           // shows when the topic is reopened (group topic sidebar + ownership fix).
           groupId: appContext?.groupId ?? undefined,
           metadata: requestTriggerMetadata,
+          parentId: userMessageParentId,
           role: 'user',
           threadId: appContext?.threadId ?? undefined,
           topicId,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-10925

#### 🔀 Description of Change

Fixes the hetero `execAgent` write path so follow-up user turns in an existing topic are chained to the current spine head instead of being persisted as new root messages.

Root cause: the normal `aiChat` route already resolves a server-authoritative parent via `getLatestSpineMessageId`, but Claude Code / Codex hetero runs go through `AiAgentService.execAgent`, which created the user message without `parentId`. That split one topic into multiple independent root trees.

Changes:

- Resolve `userMessageParentId` from `MessageModel.getLatestSpineMessageId({ topicId, threadId })` before creating a non-resume user turn.
- Keep `runFromHistory` / `parentMessageId` resume behavior unchanged.
- Add an integration assertion that a follow-up `execAgent` turn in an existing topic parents the new user message to the previous latest assistant spine message.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
bunx eslint apps/server/src/services/aiAgent/index.ts apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
git diff --check -- apps/server/src/services/aiAgent/index.ts apps/server/src/routers/lambda/__tests__/integration/aiAgent/execAgent.integration.test.ts
```

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

The problematic production sample was `tpc_7sdPOmW62AW2`: 12 main-thread user root messages, no dangling parent rows. This PR prevents new hetero `execAgent` turns from creating that shape.