### PR TITLE
🐛 fix(cli): avoid app bundle cwd for remote agent runs

### DIFF
--- a/apps/cli/src/device/agentRun.test.ts
+++ b/apps/cli/src/device/agentRun.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events';
+import { homedir } from 'node:os';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -27,6 +28,7 @@ const baseParams = {
 
 describe('spawnHeteroAgentRun', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     spawnMock.mockReset();
   });
 
@@ -90,6 +92,32 @@ describe('spawnHeteroAgentRun', () => {
 
     await expect(ackPromise).resolves.toEqual({ reason: 'spawn ENOENT', status: 'rejected' });
     expect(child.stdin.write).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the daemon cwd when no cwd is provided', () => {
+    vi.spyOn(process, 'cwd').mockReturnValue('/work/from-daemon');
+    const child = makeFakeChild();
+    spawnMock.mockReturnValue(child);
+
+    void spawnHeteroAgentRun({ ...baseParams });
+
+    const [, args, opts] = spawnMock.mock.calls[0];
+    expect(args).toContain('/work/from-daemon');
+    expect(opts.cwd).toBe('/work/from-daemon');
+  });
+
+  it('falls back to home when no cwd is provided and the daemon cwd is an app bundle', () => {
+    vi.spyOn(process, 'cwd').mockReturnValue('/Applications/LobeHub.app/Contents/MacOS');
+    const child = makeFakeChild();
+    const logger = { info: vi.fn() };
+    spawnMock.mockReturnValue(child);
+
+    void spawnHeteroAgentRun({ ...baseParams }, logger);
+
+    const [, args, opts] = spawnMock.mock.calls[0];
+    expect(args).toContain(homedir());
+    expect(opts.cwd).toBe(homedir());
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('falling back to home'));
   });
 
   it('appends --resume when resuming a session', () => {

--- a/apps/cli/src/device/agentRun.ts
+++ b/apps/cli/src/device/agentRun.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { homedir } from 'node:os';
 
 import {
   buildHeteroExecStdinPayload,
@@ -30,6 +31,28 @@ interface SpawnHeteroAgentRunLogger {
   error?: (msg: string) => void;
   info?: (msg: string) => void;
 }
+
+const APP_BUNDLE_PATH_PATTERN = /(?:^|[/\\])[^/\\]+\.app(?:[/\\]|$)/i;
+
+const resolveAgentRunCwd = (
+  cwd: string | undefined,
+  logger?: SpawnHeteroAgentRunLogger,
+): string => {
+  if (cwd) return cwd;
+
+  const daemonCwd = process.cwd();
+  if (APP_BUNDLE_PATH_PATTERN.test(daemonCwd)) {
+    const home = homedir();
+    if (home) {
+      logger?.info?.(
+        `agent_run_request cwd missing; daemon cwd is app bundle (${daemonCwd}), falling back to home (${home})`,
+      );
+      return home;
+    }
+  }
+
+  return daemonCwd;
+};
 
 /**
  * Spawn `lh hetero exec` for a gateway-dispatched agent run. Mirrors the
@@ -65,7 +88,7 @@ export function spawnHeteroAgentRun(
     systemContext,
     topicId,
   } = params;
-  const workDir = cwd ?? process.cwd();
+  const workDir = resolveAgentRunCwd(cwd, logger);
 
   // Server-ingest mode (--topic + --operation-id): events are batch-POSTed to
   // the server, not rendered. `--input-json -` reads the prompt from stdin.


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to remote Claude Code runs where the bound device has no configured working directory.

#### 🔀 Description of Change

When the server dispatches a remote agent run without an explicit cwd, the CLI device runner previously fell back to `process.cwd()`. If the daemon is launched from `LobeHub.app`, that can make Claude Code start inside the app bundle instead of a user workspace.

This PR adds a small cwd resolver for device-side agent runs:

- keep using the explicit cwd when the server provides one
- keep using the daemon cwd for normal non-app startup paths
- fall back to the user's home directory when cwd is missing and daemon cwd is inside a `.app` bundle
- log the fallback so the behavior is visible during remote run diagnosis

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation run:

```bash
bunx vitest run apps/cli/src/device/agentRun.test.ts --config apps/cli/vitest.config.mts --silent='passed-only'
```

Result: passed, 1 test file, 8 tests.

Also ran `git diff --check` successfully.

Note: `bun run type-check` was attempted in `apps/cli`, but it currently fails on existing unrelated repo-wide TypeScript/path configuration errors, including unresolved `@/server/routers/lambda`, `__ELECTRON__`, and `@/types/llm` references.

#### 📸 Screenshots / Videos

No UI changes.

#### 📝 Additional Information

This does not try to treat cwd mismatch as the direct cause of Claude auth failures. It only prevents remote agent execution from silently landing in the app bundle when cwd metadata is missing for the bound device.