### PR TITLE
✨ feat(home): add market agent entry

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -1,6 +1,7 @@
 {
   "ModelSwitch.title": "Model",
   "active": "Active",
+  "addAgentFromMarket": "Add from Market",
   "agentBuilder.installPlugin.authRequired": "Cloud MCP requires sign-in to continue",
   "agentBuilder.installPlugin.cancel": "Cancel",
   "agentBuilder.installPlugin.clickApproveToConnect": "Click \"Approve\" to connect and authorize this Integration",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -1,6 +1,7 @@
 {
   "ModelSwitch.title": "模型",
   "active": "活跃",
+  "addAgentFromMarket": "从市场添加助理",
   "agentBuilder.installPlugin.authRequired": "云端 MCP 需要登录后才能继续",
   "agentBuilder.installPlugin.cancel": "取消",
   "agentBuilder.installPlugin.clickApproveToConnect": "点击「批准」连接并授权此连接器",

--- a/packages/const/package.json
+++ b/packages/const/package.json
@@ -8,6 +8,7 @@
     "./desktopGlobalShortcuts": "./src/desktopGlobalShortcuts.ts",
     "./hotkeys": "./src/hotkeys.ts",
     "./rbac": "./src/rbac.ts",
+    "./url": "./src/url.ts",
     "./visualRef": "./src/visualRef.ts"
   },
   "main": "./src/index.ts",

--- a/packages/const/src/url.ts
+++ b/packages/const/src/url.ts
@@ -6,6 +6,12 @@ export const OFFICIAL_DOMAIN = 'lobehub.com';
 
 export const OG_URL = '/og/og.webp?v=1';
 
+export const LobeHubPath = {
+  webapi: {
+    modelConfig: '/webapi/lobehub-model-config',
+  },
+} as const;
+
 export const GITHUB = 'https://github.com/lobehub/lobe-chat';
 export const GITHUB_ISSUES = urlJoin(GITHUB, 'issues/new/choose');
 export const CHANGELOG = 'https://lobehub.com/changelog';

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -442,6 +442,7 @@ export default {
   'codexInstallGuide.menuNotification.title': 'Codex CLI not found',
   'codexInstallGuide.reason': 'LobeHub could not start Codex: {{message}}',
   'codexInstallGuide.title': 'Install Codex CLI',
+  'addAgentFromMarket': 'Add from Market',
   'newAgent': 'Create Agent',
   'newClaudeCodeAgent': 'Add Claude Code',
   'newCodexAgent': 'Add Codex',

--- a/src/routes/(main)/home/_layout/Body/Agent/index.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/index.tsx
@@ -25,32 +25,9 @@ const Agent = memo<AgentProps>(({ itemKey }) => {
   const { openConfigGroupModal } = useAgentModal();
 
   // Create menu items
-  const {
-    createAgentMenuItem,
-    createGroupChatMenuItem,
-    createHeterogeneousAgentMenuItems,
-    createPlatformAgentMenuItem,
-    isLoading,
-  } = useCreateMenuItems();
+  const { createTopLevelMenuItems, isLoading } = useCreateMenuItems();
 
-  const addMenuItems = useMemo(() => {
-    const heterogeneousItems = createHeterogeneousAgentMenuItems();
-    const platformItem = createPlatformAgentMenuItem();
-
-    return [
-      createAgentMenuItem(),
-      createGroupChatMenuItem(),
-      ...(heterogeneousItems.length > 0
-        ? [{ type: 'divider' as const }, ...heterogeneousItems]
-        : []),
-      ...(platformItem ? [{ type: 'divider' as const }, platformItem] : []),
-    ];
-  }, [
-    createAgentMenuItem,
-    createGroupChatMenuItem,
-    createHeterogeneousAgentMenuItems,
-    createPlatformAgentMenuItem,
-  ]);
+  const addMenuItems = useMemo(() => createTopLevelMenuItems(), [createTopLevelMenuItems]);
 
   const handleOpenConfigGroupModal = useCallback(() => {
     openConfigGroupModal();

--- a/src/routes/(main)/home/_layout/Header/components/AddButton.tsx
+++ b/src/routes/(main)/home/_layout/Header/components/AddButton.tsx
@@ -15,16 +15,8 @@ const AddButton = memo(() => {
   const { allowed: canCreate, reason } = usePermission('create_content');
 
   // Create menu items
-  const {
-    createAgentMenuItem,
-    createGroupChatMenuItem,
-    createHeterogeneousAgentMenuItems,
-    createPageMenuItem,
-    createPlatformAgentMenuItem,
-    openCreateModal,
-    isMutatingAgent,
-    isCreatingGroup,
-  } = useCreateMenuItems();
+  const { createTopLevelMenuItems, openCreateModal, isMutatingAgent, isCreatingGroup } =
+    useCreateMenuItems();
 
   const handleMainIconClick = useCallback(
     (e: React.MouseEvent) => {
@@ -36,26 +28,7 @@ const AddButton = memo(() => {
     [canCreate, openCreateModal],
   );
 
-  const dropdownItems = useMemo(() => {
-    const heterogeneousItems = createHeterogeneousAgentMenuItems();
-    const platformItem = createPlatformAgentMenuItem();
-
-    return [
-      createAgentMenuItem(),
-      createGroupChatMenuItem(),
-      createPageMenuItem(),
-      ...(heterogeneousItems.length > 0
-        ? [{ type: 'divider' as const }, ...heterogeneousItems]
-        : []),
-      ...(platformItem ? [{ type: 'divider' as const }, platformItem] : []),
-    ];
-  }, [
-    createAgentMenuItem,
-    createGroupChatMenuItem,
-    createHeterogeneousAgentMenuItems,
-    createPageMenuItem,
-    createPlatformAgentMenuItem,
-  ]);
+  const dropdownItems = useMemo(() => createTopLevelMenuItems(), [createTopLevelMenuItems]);
 
   // When viewer (no create_content): keep the icons visible per UX rule
   // (disabled-not-hidden), but the click handler short-circuits and the

--- a/src/routes/(main)/home/_layout/hooks/useCreateMenuItems.test.tsx
+++ b/src/routes/(main)/home/_layout/hooks/useCreateMenuItems.test.tsx
@@ -138,13 +138,56 @@ vi.mock('@/store/user/selectors', () => ({
 const isActionItem = (
   item: unknown,
 ): item is {
+  label?: unknown;
   key: string;
-  onClick?: (info: { domEvent?: { stopPropagation?: () => void } }) => Promise<void>;
+  onClick?: (info: { domEvent?: { stopPropagation?: () => void } }) => Promise<void> | void;
 } => !!item && typeof item === 'object' && 'key' in item;
 
 describe('useCreateMenuItems', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('adds the market agent entry to the top-level create menu', async () => {
+    const { result } = renderHook(() => useCreateMenuItems());
+
+    const items = result.current.createTopLevelMenuItems();
+    const itemKeys = items.map((item) =>
+      isActionItem(item)
+        ? item.key
+        : item && typeof item === 'object' && 'type' in item
+          ? item.type
+          : item,
+    );
+
+    expect(itemKeys).toEqual([
+      'newAgent',
+      'newGroupChat',
+      'newPage',
+      'divider',
+      'newClaudeCodeAgent',
+      'newCodexAgent',
+      'divider',
+      'addAgentFromMarket',
+    ]);
+
+    const marketItem = items.find(
+      (item) => isActionItem(item) && item.key === 'addAgentFromMarket',
+    );
+
+    if (!isActionItem(marketItem)) {
+      throw new Error('Expected market agent menu item');
+    }
+
+    expect(marketItem.label).toBe('addAgentFromMarket');
+
+    const stopPropagation = vi.fn();
+    await act(async () => {
+      await marketItem.onClick?.({ domEvent: { stopPropagation } });
+    });
+
+    expect(stopPropagation).toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith('/community/agent');
   });
 
   it('creates the Claude Code agent normally when the CLI is available', async () => {

--- a/src/routes/(main)/home/_layout/hooks/useCreateMenuItems.tsx
+++ b/src/routes/(main)/home/_layout/hooks/useCreateMenuItems.tsx
@@ -4,7 +4,14 @@ import { Icon } from '@lobehub/ui';
 import { GroupBotSquareIcon } from '@lobehub/ui/icons';
 import { App } from 'antd';
 import type { ItemType } from 'antd/es/menu/interface';
-import { BotIcon, FileTextIcon, FolderCogIcon, FolderPlus, MonitorSmartphone } from 'lucide-react';
+import {
+  BotIcon,
+  FileTextIcon,
+  FolderCogIcon,
+  FolderPlus,
+  MonitorSmartphone,
+  Store,
+} from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWRMutation from 'swr/mutation';
@@ -236,6 +243,25 @@ export const useCreateMenuItems = () => {
   );
 
   /**
+   * Add market agent menu item
+   */
+  const createMarketAgentMenuItem = useCallback(
+    (): ItemType => ({
+      icon: <Icon icon={Store} />,
+      disabled: !canCreate,
+      key: 'addAgentFromMarket',
+      label: t('addAgentFromMarket'),
+      onClick: (info) => {
+        info.domEvent?.stopPropagation();
+        if (!canCreate) return;
+
+        navigate('/community/agent');
+      },
+    }),
+    [canCreate, navigate, t],
+  );
+
+  /**
    * Create heterogeneous agent menu items (Desktop only)
    */
   const createHeterogeneousAgentMenuItems = useCallback(
@@ -380,6 +406,36 @@ export const useCreateMenuItems = () => {
     [canCreate, t, createPage],
   );
 
+  /**
+   * Top-level create menu shown by the Agent section and header add buttons.
+   *
+   * Regression example: the Agent section + menu used to expose only local creation actions,
+   * so users had no visible entry to `/community/agent`.
+   */
+  const createTopLevelMenuItems = useCallback((): ItemType[] => {
+    const heterogeneousItems = createHeterogeneousAgentMenuItems();
+    const platformItem = createPlatformAgentMenuItem();
+
+    return [
+      createAgentMenuItem(),
+      createGroupChatMenuItem(),
+      createPageMenuItem(),
+      ...(heterogeneousItems.length > 0
+        ? [{ type: 'divider' as const }, ...heterogeneousItems]
+        : []),
+      ...(platformItem ? [{ type: 'divider' as const }, platformItem] : []),
+      { type: 'divider' as const },
+      createMarketAgentMenuItem(),
+    ];
+  }, [
+    createAgentMenuItem,
+    createGroupChatMenuItem,
+    createHeterogeneousAgentMenuItems,
+    createMarketAgentMenuItem,
+    createPageMenuItem,
+    createPlatformAgentMenuItem,
+  ]);
+
   return {
     configMenuItem,
     createAgent,
@@ -390,10 +446,12 @@ export const useCreateMenuItems = () => {
     createHeterogeneousAgent,
     createHeterogeneousAgentMenuItems,
     createGroupWithMembers,
+    createMarketAgentMenuItem,
     createPage,
     createPageMenuItem,
     createPlatformAgentMenuItem,
     createSessionGroupMenuItem,
+    createTopLevelMenuItems,
     openCreateModal,
 
     // Loading states


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-10861

#### 🔀 Description of Change

- Add an "Add from Market" entry at the bottom of the top-level Agent create menus.
- Share the top-level create menu composition between the Agent section and header add button.
- Export `LobeHubPath.webapi.modelConfig` from `@lobechat/const/url` so consumers can reuse the public model-config endpoint without duplicating the path string.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated Tests:

- `cd lobehub && rtk vitest run --silent='passed-only' "src/routes/(main)/home/_layout/hooks/useCreateMenuItems.test.tsx"`
- `bun run type-check`

Manual Verification:

- `cd lobehub && bun -e "import { LobeHubPath } from '@lobechat/const/url'; console.log(LobeHubPath.webapi.modelConfig)"`

#### 📸 Screenshots / Videos

N/A. Menu behavior is covered by the hook regression test.

#### 📝 Additional Information

- `LobeHubPath` is intentionally scoped to a generic LobeHub webapi path. It does not expose cloud payment, billing, or workflow implementation details in the open-source package.
