### PR TITLE
🐛 fix(market): degrade skill discovery failures

### DIFF
--- a/apps/server/src/services/market/index.test.ts
+++ b/apps/server/src/services/market/index.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { generateTrustedClientToken, getTrustedClientTokenForSession } from '@/libs/trusted-client';
 
-import { extractAccessToken, MarketService } from './index';
+import { extractAccessToken, LOBEHUB_SKILL_DISCOVERY_TIMEOUT_MS, MarketService } from './index';
 
 // Mock dependencies before importing the module under test
 vi.mock('@lobehub/market-sdk', () => {
@@ -629,6 +629,25 @@ describe('MarketService', () => {
 
       const manifests = await service.getLobehubSkillManifests();
       expect(manifests).toEqual([]);
+    });
+
+    it('should time out listConnections and degrade to empty manifests', async () => {
+      const service = new MarketService();
+      const signal = new AbortController().signal;
+      const timeoutSpy = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(signal);
+      const timeoutError = new Error('The operation was aborted due to timeout');
+      timeoutError.name = 'TimeoutError';
+      (service as any).market.connect.listConnections = vi.fn().mockRejectedValue(timeoutError);
+
+      try {
+        const manifests = await service.getLobehubSkillManifests();
+
+        expect(manifests).toEqual([]);
+        expect(timeoutSpy).toHaveBeenCalledWith(LOBEHUB_SKILL_DISCOVERY_TIMEOUT_MS);
+        expect((service as any).market.connect.listConnections).toHaveBeenCalledWith({ signal });
+      } finally {
+        timeoutSpy.mockRestore();
+      }
     });
 
     it('should continue building other manifests when one connection fails', async () => {

--- a/apps/server/src/services/market/index.ts
+++ b/apps/server/src/services/market/index.ts
@@ -11,6 +11,7 @@ import { listSkillToolsWithLiveFallback } from './listSkillToolsWithLiveFallback
 const log = debug('lobe-server:market-service');
 
 const MARKET_BASE_URL = process.env.MARKET_BASE_URL || 'https://market.lobehub.com';
+export const LOBEHUB_SKILL_DISCOVERY_TIMEOUT_MS = 3_000;
 
 // ============================== Helper Functions ==============================
 
@@ -561,7 +562,9 @@ export class MarketService {
   async getLobehubSkillManifests(): Promise<LobeToolManifest[]> {
     try {
       // 1. Get user's connected skills
-      const { connections } = await this.market.connect.listConnections();
+      const { connections } = await this.market.connect.listConnections({
+        signal: AbortSignal.timeout(LOBEHUB_SKILL_DISCOVERY_TIMEOUT_MS),
+      });
       if (!connections || connections.length === 0) {
         log('getLobehubSkillManifests: no connected skills found');
         return [];

--- a/src/store/tool/slices/lobehubSkillStore/action.test.ts
+++ b/src/store/tool/slices/lobehubSkillStore/action.test.ts
@@ -5,6 +5,7 @@ import { SWRConfig } from 'swr';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { toolsClient } from '@/libs/trpc/client';
+import { useUserStore } from '@/store/user';
 
 import { useToolStore } from '../../store';
 import { LobehubSkillStatus } from './types';
@@ -13,6 +14,7 @@ vi.mock('zustand/traditional');
 
 beforeEach(() => {
   vi.clearAllMocks();
+  useUserStore.setState({ isSignedIn: false });
 });
 
 vi.mock('@lobechat/const', async (importOriginal) => {
@@ -943,6 +945,23 @@ describe('lobehubSkillStore actions', () => {
       expect(toolsClient.market.connectListConnections.query).not.toHaveBeenCalled();
     });
 
+    it('should not fetch when user is not signed in', () => {
+      act(() => {
+        useToolStore.setState({
+          lobehubSkillServers: [],
+          lobehubSkillLoadingIds: new Set(),
+          lobehubSkillExecutingToolIds: new Set(),
+        });
+        useUserStore.setState({ isSignedIn: false });
+      });
+
+      vi.mocked(toolsClient.market.connectListConnections.query).mockClear();
+
+      renderHook(() => useToolStore.getState().useFetchLobehubSkillConnections(true));
+
+      expect(toolsClient.market.connectListConnections.query).not.toHaveBeenCalled();
+    });
+
     it('should fetch connections when enabled', async () => {
       act(() => {
         useToolStore.setState({
@@ -950,6 +969,7 @@ describe('lobehubSkillStore actions', () => {
           lobehubSkillLoadingIds: new Set(),
           lobehubSkillExecutingToolIds: new Set(),
         });
+        useUserStore.setState({ isSignedIn: true });
       });
 
       const mockConnections = {

--- a/src/store/tool/slices/lobehubSkillStore/action.ts
+++ b/src/store/tool/slices/lobehubSkillStore/action.ts
@@ -6,6 +6,8 @@ import useSWR from 'swr';
 import { toolKeys } from '@/libs/swr/keys';
 import { toolsClient } from '@/libs/trpc/client';
 import { type StoreSetter } from '@/store/types';
+import { useUserStore } from '@/store/user';
+import { authSelectors } from '@/store/user/selectors';
 import { setNamespace } from '@/utils/storeDebug';
 
 import { type ToolStore } from '../../store';
@@ -289,8 +291,10 @@ export class LobehubSkillStoreActionImpl {
   };
 
   useFetchLobehubSkillConnections = (enabled: boolean): SWRResponse<LobehubSkillServer[]> => {
+    const isSignedIn = useUserStore(authSelectors.isLogin);
+
     return useSWR<LobehubSkillServer[]>(
-      enabled ? toolKeys.lobehubSkillConnections() : null,
+      enabled && isSignedIn ? toolKeys.lobehubSkillConnections() : null,
       async () => {
         const response = await toolsClient.market.connectListConnections.query();
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None found.

#### 🔀 Description of Change

- Add a bounded timeout to LobeHub Skill connection discovery so server-side agent runs degrade to empty manifests when Market connections are slow or unavailable.
- Keep the main message generation path moving instead of blocking on `market.connect.listConnections` during tool discovery.
- Gate client-side LobeHub Skill connection prefetch on signed-in state to avoid unauthenticated `market.connectListConnections` requests.
- Add regression coverage for both the server discovery timeout fallback and signed-out prefetch guard.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' apps/server/src/services/market/index.test.ts
bunx vitest run --silent='passed-only' src/store/tool/slices/lobehubSkillStore/action.test.ts
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

The server fallback only affects LobeHub Skill manifest discovery. If discovery times out, connected LobeHub Skills are omitted for that run, while the rest of the agent/tool pipeline continues.
