### PR TITLE
🐛 fix: truncate oversized codex command output

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/codex.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/codex.test.ts
@@ -483,6 +483,49 @@ describe('CodexAdapter', () => {
     });
   });
 
+  it('truncates oversized Codex command output before forwarding tool results', () => {
+    const adapter = new CodexAdapter();
+    const oversizedOutput = 'x'.repeat(25_010);
+
+    adapter.adapt({
+      item: {
+        command: '/bin/zsh -lc find .',
+        id: 'item_oversized',
+        status: 'in_progress',
+        type: 'command_execution',
+      },
+      type: 'item.started',
+    });
+
+    const completed = adapter.adapt({
+      item: {
+        aggregated_output: oversizedOutput,
+        command: '/bin/zsh -lc find .',
+        exit_code: 0,
+        id: 'item_oversized',
+        status: 'completed',
+        type: 'command_execution',
+      },
+      type: 'item.completed',
+    });
+
+    const result = completed[0];
+
+    expect(result.type).toBe('tool_result');
+    expect(result.data.content).toHaveLength(25_078);
+    expect(result.data.content).toContain(
+      '[Output truncated: 10 characters omitted. Original length: 25010 characters]',
+    );
+    expect(result.data.pluginState).toMatchObject({
+      omittedOutputCharacters: 10,
+      originalOutputLength: 25_010,
+      outputTruncated: true,
+      success: true,
+    });
+    expect(result.data.pluginState.output).toBe(result.data.content);
+    expect(result.data.pluginState.stdout).toBe(result.data.content);
+  });
+
   it('maps todo_list items into shared todo plugin state', () => {
     const adapter = new CodexAdapter();
 

--- a/packages/heterogeneous-agents/src/adapters/codex.ts
+++ b/packages/heterogeneous-agents/src/adapters/codex.ts
@@ -18,6 +18,7 @@ const CODEX_FILE_CHANGE_API = 'file_change';
 const CODEX_MCP_TOOL_CALL_API = 'mcp_tool_call';
 const CODEX_TODO_LIST_API = 'todo_list';
 const CODEX_USAGE_SETTINGS_URL = 'https://chatgpt.com/codex/settings/usage';
+const CODEX_COMMAND_OUTPUT_MAX_LENGTH = 25_000;
 
 const CODEX_USER_RATE_LIMIT_PATTERNS = [
   /you'?ve hit your usage limit/i,
@@ -411,22 +412,57 @@ const isSuccessfulToolCompletion = (item: CodexToolItem): boolean => {
   return item.status !== 'cancelled' && item.status !== 'error' && item.status !== 'failed';
 };
 
+const truncateCodexCommandOutput = (content: string) => {
+  if (!content || content.length <= CODEX_COMMAND_OUTPUT_MAX_LENGTH) {
+    return {
+      output: content,
+      truncated: false,
+    };
+  }
+
+  let cutoff = CODEX_COMMAND_OUTPUT_MAX_LENGTH;
+  const lastCharCode = content.charCodeAt(cutoff - 1);
+  if (lastCharCode >= 0xd8_00 && lastCharCode <= 0xdb_ff) {
+    cutoff -= 1;
+  }
+
+  const omittedCharacters = content.length - cutoff;
+  const notice = `\n\n[Output truncated: ${omittedCharacters} characters omitted. Original length: ${content.length} characters]`;
+
+  return {
+    omittedCharacters,
+    originalLength: content.length,
+    output: content.slice(0, cutoff) + notice,
+    truncated: true,
+  };
+};
+
 const getToolResultData = (item: CodexToolItem): ToolResultData => {
   const isSuccess = isSuccessfulToolCompletion(item);
   const output = getToolContent(item, isSuccess);
 
   if (isCommandExecutionItem(item)) {
     const exitCode = item.exit_code ?? undefined;
+    const truncatedOutput = truncateCodexCommandOutput(output);
 
     return {
-      content: output,
+      content: truncatedOutput.output,
       isError: !isSuccess,
       pluginState: {
         ...(exitCode !== undefined ? { exitCode } : {}),
-        ...(isSuccess ? {} : { error: output || `Command failed (${exitCode ?? 'unknown'})` }),
+        ...(isSuccess
+          ? {}
+          : { error: truncatedOutput.output || `Command failed (${exitCode ?? 'unknown'})` }),
         isBackground: false,
-        output,
-        stdout: output,
+        ...(truncatedOutput.truncated
+          ? {
+              omittedOutputCharacters: truncatedOutput.omittedCharacters,
+              originalOutputLength: truncatedOutput.originalLength,
+              outputTruncated: true,
+            }
+          : {}),
+        output: truncatedOutput.output,
+        stdout: truncatedOutput.output,
         success: isSuccess,
       },
       toolCallId: item.id,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None

#### 🔀 Description of Change

- Truncate oversized Codex `command_execution` output before forwarding it as a tool result.
- Preserve raw CLI traces, while limiting renderer/DB payloads to 25k characters plus a truncation notice.
- Include truncation metadata in `pluginState` so renders/debug views can tell output was shortened.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd lobehub/packages/heterogeneous-agents && bunx vitest run --silent='passed-only' src/adapters/codex.test.ts
cd lobehub && bunx vitest run --silent='passed-only' src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
git -C lobehub diff --check -- packages/heterogeneous-agents/src/adapters/codex.ts packages/heterogeneous-agents/src/adapters/codex.test.ts
```

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Large Codex command stdout can be forwarded and rendered as MB-scale tool result payloads. | Codex command output is capped to 25k chars with a truncation notice and metadata. |

#### 📝 Additional Information

This keeps the full raw CLI stdout in hetero tracing. Only the UI/persisted tool result payload is truncated.