### PR TITLE
✨ feat(desktop): add remote server request user agent

### DIFF
--- a/apps/desktop/src/main/controllers/AuthCtr.ts
+++ b/apps/desktop/src/main/controllers/AuthCtr.ts
@@ -13,6 +13,7 @@ import GatewayConnectionService from '@/services/gatewayConnectionSrv';
 import { appendVercelCookie } from '@/utils/http-headers';
 import { createLogger } from '@/utils/logger';
 import { netFetch } from '@/utils/net-fetch';
+import { setDesktopUserAgentHeader } from '@/utils/user-agent';
 
 import { ControllerModule, IpcMethod } from './index';
 import RemoteServerConfigCtr from './RemoteServerConfigCtr';
@@ -370,6 +371,7 @@ export default class AuthCtr extends ControllerModule {
       // Use Electron net.fetch to respect system CA store (self-signed/private CA certs)
       const headers: Record<string, string> = { 'Content-Type': 'application/json' };
       appendVercelCookie(headers);
+      setDesktopUserAgentHeader(headers);
       const response = await netFetch(url.toString(), { headers, method: 'GET' });
 
       // Check response status
@@ -488,6 +490,7 @@ export default class AuthCtr extends ControllerModule {
         'Content-Type': 'application/x-www-form-urlencoded',
       };
       appendVercelCookie(tokenHeaders);
+      setDesktopUserAgentHeader(tokenHeaders);
       const response = await netFetch(tokenUrl.toString(), {
         body,
         headers: tokenHeaders,

--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -29,6 +29,7 @@ import { type ILocalSystemService, LocalSystemExecutionRuntime } from '@lobechat
 import GatewayConnectionService from '@/services/gatewayConnectionSrv';
 import ImessageBridgeService from '@/services/imessageBridgeSrv';
 import { createLogger } from '@/utils/logger';
+import { setDesktopUserAgentHeader } from '@/utils/user-agent';
 
 import HeterogeneousAgentCtr from './HeterogeneousAgentCtr';
 import { ControllerModule, IpcMethod } from './index';
@@ -1066,6 +1067,7 @@ export default class GatewayConnectionCtr extends ControllerModule {
         'Oidc-Auth': token,
       };
       if (workspaceId) headers['X-Workspace-Id'] = workspaceId;
+      setDesktopUserAgentHeader(headers);
 
       await fetch(`${serverUrl}/trpc/lambda/agentNotify.notify`, {
         body: JSON.stringify({ json: body }),
@@ -1095,12 +1097,15 @@ export default class GatewayConnectionCtr extends ControllerModule {
     ]);
     if (!serverUrl || !token) return;
 
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Oidc-Auth': token,
+    };
+    setDesktopUserAgentHeader(headers);
+
     await fetch(`${serverUrl}/trpc/lambda/device.register`, {
       body: JSON.stringify({ json: info }),
-      headers: {
-        'Content-Type': 'application/json',
-        'Oidc-Auth': token,
-      },
+      headers,
       method: 'POST',
     });
   }

--- a/apps/desktop/src/main/controllers/RemoteServerConfigCtr.ts
+++ b/apps/desktop/src/main/controllers/RemoteServerConfigCtr.ts
@@ -9,6 +9,7 @@ import GatewayConnectionService from '@/services/gatewayConnectionSrv';
 import { appendVercelCookie } from '@/utils/http-headers';
 import { createLogger } from '@/utils/logger';
 import { netFetch } from '@/utils/net-fetch';
+import { setDesktopUserAgentHeader } from '@/utils/user-agent';
 
 import { ControllerModule, IpcMethod } from './index';
 
@@ -441,6 +442,7 @@ export default class RemoteServerConfigCtr extends ControllerModule {
         'Content-Type': 'application/x-www-form-urlencoded',
       };
       appendVercelCookie(headers);
+      setDesktopUserAgentHeader(headers);
       const response = await netFetch(tokenUrl.toString(), { body, headers, method: 'POST' });
 
       if (!response.ok) {
@@ -547,6 +549,7 @@ export default class RemoteServerConfigCtr extends ControllerModule {
           requestHeaders['Oidc-Auth'] = token;
           logger.debug(`Injected Oidc-Auth token for: ${details.url}`);
         }
+        setDesktopUserAgentHeader(requestHeaders);
 
         callback({ requestHeaders });
       },

--- a/apps/desktop/src/main/controllers/RemoteServerSyncCtr.ts
+++ b/apps/desktop/src/main/controllers/RemoteServerSyncCtr.ts
@@ -5,7 +5,7 @@ import https from 'node:https';
 import { URL } from 'node:url';
 
 import type { ProxyTRPCStreamRequestParams } from '@lobechat/electron-client-ipc';
-import type {IpcMainEvent, WebContents } from 'electron';
+import type { IpcMainEvent, WebContents } from 'electron';
 import { ipcMain } from 'electron';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { HttpsProxyAgent } from 'https-proxy-agent';
@@ -13,6 +13,7 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import { defaultProxySettings } from '@/const/store';
 import { appendVercelCookie } from '@/utils/http-headers';
 import { createLogger } from '@/utils/logger';
+import { setDesktopUserAgentHeader } from '@/utils/user-agent';
 
 import { ControllerModule } from './index';
 import RemoteServerConfigCtr from './RemoteServerConfigCtr';
@@ -191,8 +192,9 @@ export default class RemoteServerSyncCtr extends ControllerModule {
     url: URL;
   }) {
     // Prepare headers, cloning and adding Oidc-Auth
-    const requestHeaders: OutgoingHttpHeaders = { ...headers , ['Oidc-Auth']: accessToken,}; // Use OutgoingHttpHeaders
+    const requestHeaders: OutgoingHttpHeaders = { ...headers, ['Oidc-Auth']: accessToken };
     appendVercelCookie(requestHeaders);
+    setDesktopUserAgentHeader(requestHeaders);
 
     // Let node handle Host, Content-Length etc. Remove potentially problematic headers
     delete requestHeaders['host'];

--- a/apps/desktop/src/main/controllers/__tests__/AuthCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/AuthCtr.test.ts
@@ -23,6 +23,9 @@ const { ipcMainHandleMock } = vi.hoisted(() => ({
 
 // Mock electron
 vi.mock('electron', () => ({
+  app: {
+    getVersion: vi.fn(() => '1.2.3'),
+  },
   BrowserWindow: {
     getAllWindows: vi.fn(() => []),
   },
@@ -199,6 +202,11 @@ describe('AuthCtr', () => {
           (call[0] as string).includes('/oidc/handoff'),
         );
         expect(pollingCalls.length).toBeGreaterThan(0);
+        expect(pollingCalls[0][1]).toEqual(
+          expect.objectContaining({
+            headers: expect.objectContaining({ 'User-Agent': 'LobeHub Desktop/1.2.3' }),
+          }),
+        );
       });
 
       it('should use self-hosted server URL when storageMode is selfHost', async () => {

--- a/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
@@ -146,6 +146,7 @@ vi.mock('electron', () => ({
   app: {
     getAppPath: vi.fn(() => '/mock/app'),
     getPath: vi.fn((name: string) => `/mock/${name}`),
+    getVersion: vi.fn(() => '1.2.3'),
   },
   ipcMain: { handle: ipcMainHandleMock },
   powerSaveBlocker: {
@@ -332,6 +333,7 @@ describe('GatewayConnectionCtr', () => {
       expect(options.deviceId).toBe('stored-device-id');
       expect(options.gatewayUrl).toBe('https://device-gateway.lobehub.com');
       expect(options.logger).toBeDefined();
+      expect(options.userAgent).toBe('LobeHub Desktop/1.2.3');
     });
 
     it('should use custom gateway URL from store when set', async () => {

--- a/apps/desktop/src/main/controllers/__tests__/RemoteServerConfigCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/RemoteServerConfigCtr.test.ts
@@ -26,6 +26,9 @@ vi.mock('@/utils/logger', () => ({
 
 // Mock electron
 vi.mock('electron', () => ({
+  app: {
+    getVersion: vi.fn(() => '1.2.3'),
+  },
   ipcMain: {
     handle: ipcMainHandleMock,
   },
@@ -499,6 +502,9 @@ describe('RemoteServerConfigCtr', () => {
         'https://server.com/oidc/token',
         expect.objectContaining({
           body: expect.stringContaining('grant_type=refresh_token'),
+          headers: expect.objectContaining({
+            'User-Agent': 'LobeHub Desktop/1.2.3',
+          }),
           method: 'POST',
         }),
       );

--- a/apps/desktop/src/main/core/__tests__/App.test.ts
+++ b/apps/desktop/src/main/core/__tests__/App.test.ts
@@ -11,6 +11,7 @@ vi.mock('electron', () => ({
     getAppPath: vi.fn(() => '/mock/app/path'),
     getLocale: vi.fn(() => 'en-US'),
     getPath: vi.fn(() => '/mock/user/path'),
+    getVersion: vi.fn(() => '1.2.3'),
     requestSingleInstanceLock: vi.fn(() => true),
     isReady: vi.fn(() => true),
     whenReady: vi.fn(() => Promise.resolve()),

--- a/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
@@ -59,6 +59,7 @@ const {
         setBadge: vi.fn(),
         show: vi.fn(),
       },
+      getVersion: vi.fn(() => '1.2.3'),
       setActivationPolicy: vi.fn(),
       setBadgeCount: vi.fn(),
     },

--- a/apps/desktop/src/main/core/infrastructure/BackendProxyProtocolManager.ts
+++ b/apps/desktop/src/main/core/infrastructure/BackendProxyProtocolManager.ts
@@ -7,6 +7,7 @@ import { getDesktopEnv } from '@/env';
 import { appendVercelCookie } from '@/utils/http-headers';
 import { createLogger } from '@/utils/logger';
 import { netFetch } from '@/utils/net-fetch';
+import { setDesktopUserAgentHeader } from '@/utils/user-agent';
 
 import type { RendererRequestInterceptor } from './RendererProtocolManager';
 
@@ -180,6 +181,7 @@ export class BackendProxyProtocolManager {
       headers.set('Oidc-Auth', token);
     }
     appendVercelCookie(headers);
+    setDesktopUserAgentHeader(headers);
 
     const requestInit: RequestInit & { duplex?: 'half' } = {
       headers,

--- a/apps/desktop/src/main/core/infrastructure/__tests__/BackendProxyProtocolManager.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/BackendProxyProtocolManager.test.ts
@@ -27,6 +27,9 @@ vi.mock('@/utils/logger', () => ({
 }));
 
 vi.mock('electron', () => ({
+  app: {
+    getVersion: vi.fn(() => '1.2.3'),
+  },
   BrowserWindow: {
     getAllWindows: vi.fn(),
   },
@@ -87,6 +90,7 @@ describe('BackendProxyProtocolManager', () => {
     expect(init.method).toBe('GET');
     const headers = init.headers as Headers;
     expect(headers.get('Oidc-Auth')).toBe('token-123');
+    expect(headers.get('User-Agent')).toBe('LobeHub Desktop/1.2.3');
     expect(headers.get('X-Test')).toBe('1');
 
     expect(response!.status).toBe(200);

--- a/apps/desktop/src/main/services/gatewayConnectionSrv.ts
+++ b/apps/desktop/src/main/services/gatewayConnectionSrv.ts
@@ -19,6 +19,7 @@ import { app, powerSaveBlocker } from 'electron';
 import { isDev } from '@/const/env';
 import { getDesktopEnv } from '@/env';
 import { createLogger } from '@/utils/logger';
+import { getDesktopUserAgent } from '@/utils/user-agent';
 
 import { ServiceModule } from './index';
 
@@ -331,6 +332,7 @@ export default class GatewayConnectionService extends ServiceModule {
       gatewayUrl,
       logger,
       token,
+      userAgent: getDesktopUserAgent(),
       userId: userId || undefined,
     });
 

--- a/apps/desktop/src/main/utils/__tests__/user-agent.test.ts
+++ b/apps/desktop/src/main/utils/__tests__/user-agent.test.ts
@@ -1,0 +1,33 @@
+import { app } from 'electron';
+import { describe, expect, it, vi } from 'vitest';
+
+import { getDesktopUserAgent, setDesktopUserAgentHeader } from '../user-agent';
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: vi.fn(() => '1.2.3'),
+  },
+}));
+
+describe('user-agent utilities', () => {
+  it('builds desktop user agent from Electron app version', () => {
+    expect(getDesktopUserAgent()).toBe('LobeHub Desktop/1.2.3');
+  });
+
+  it('sets User-Agent on Headers', () => {
+    const headers = new Headers({ 'user-agent': 'old' });
+
+    setDesktopUserAgentHeader(headers);
+
+    expect(headers.get('User-Agent')).toBe('LobeHub Desktop/1.2.3');
+  });
+
+  it('replaces case-insensitive User-Agent keys on plain objects', () => {
+    const headers: Record<string, string> = { 'user-agent': 'old' };
+
+    setDesktopUserAgentHeader(headers);
+
+    expect(headers).toEqual({ 'User-Agent': 'LobeHub Desktop/1.2.3' });
+    expect(app.getVersion).toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/utils/user-agent.ts
+++ b/apps/desktop/src/main/utils/user-agent.ts
@@ -1,0 +1,24 @@
+import { app } from 'electron';
+
+type RequestHeaders = Headers | Record<string, number | string | string[] | undefined>;
+
+const DESKTOP_USER_AGENT_NAME = 'LobeHub Desktop';
+
+export const getDesktopUserAgent = () => `${DESKTOP_USER_AGENT_NAME}/${app.getVersion()}`;
+
+export const setDesktopUserAgentHeader = (headers: RequestHeaders) => {
+  const userAgent = getDesktopUserAgent();
+
+  if (headers instanceof Headers) {
+    headers.set('User-Agent', userAgent);
+    return;
+  }
+
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === 'user-agent') {
+      delete headers[key];
+    }
+  }
+
+  headers['User-Agent'] = userAgent;
+};

--- a/packages/device-gateway-client/src/client.test.ts
+++ b/packages/device-gateway-client/src/client.test.ts
@@ -15,7 +15,10 @@ vi.mock('ws', async () => {
     static CLOSED = 3;
     readyState = 1; // OPEN
 
-    constructor(public url: string) {
+    constructor(
+      public url: string,
+      public options?: unknown,
+    ) {
       super();
       if (mockWsShouldThrow) {
         mockWsShouldThrow = false;
@@ -168,6 +171,21 @@ describe('GatewayClient', () => {
       c.connect();
       const ws = (c as any).ws;
       expect(ws.url).toContain('ws://localhost:3000/ws');
+      c.disconnect();
+    });
+
+    it('should include user agent header when provided', () => {
+      const c = new GatewayClient({
+        autoReconnect: false,
+        gatewayUrl: 'https://gateway.test.com',
+        token: 'tok',
+        userAgent: 'LobeHub Desktop/1.2.3',
+      });
+      c.connect();
+      const ws = (c as any).ws;
+      expect(ws.options).toEqual({
+        headers: { 'User-Agent': 'LobeHub Desktop/1.2.3' },
+      });
       c.disconnect();
     });
   });

--- a/packages/device-gateway-client/src/client.ts
+++ b/packages/device-gateway-client/src/client.ts
@@ -68,6 +68,7 @@ export interface GatewayClientOptions {
   serverUrl?: string;
   token: string;
   tokenType?: 'apiKey' | 'jwt' | 'serviceToken';
+  userAgent?: string;
   userId?: string;
   /**
    * When set, the connection enrolls as a WORKSPACE-owned device: the gateway
@@ -92,6 +93,7 @@ export class GatewayClient extends EventEmitter {
   private gatewayUrl: string;
   private token: string;
   private tokenType?: 'apiKey' | 'jwt' | 'serviceToken';
+  private userAgent?: string;
   private userId?: string;
   private workspaceId?: string;
   private serverUrl?: string;
@@ -102,6 +104,7 @@ export class GatewayClient extends EventEmitter {
     super();
     this.token = options.token;
     this.tokenType = options.tokenType;
+    this.userAgent = options.userAgent;
     this.gatewayUrl = options.gatewayUrl || DEFAULT_GATEWAY_URL;
     this.deviceId = options.deviceId || randomUUID();
     this.connectionId = options.connectionId || randomUUID();
@@ -220,7 +223,8 @@ export class GatewayClient extends EventEmitter {
       const wsUrl = this.buildWsUrl();
       this.logger.debug(`Connecting to: ${wsUrl}`);
 
-      const ws = new WebSocket(wsUrl);
+      const wsOptions = this.userAgent ? { headers: { 'User-Agent': this.userAgent } } : undefined;
+      const ws = new WebSocket(wsUrl, wsOptions);
 
       ws.on('open', this.handleOpen);
       ws.on('message', this.handleMessage);


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Adds a desktop-specific User-Agent for requests from LobeHub Desktop to LobeHub Cloud:

`LobeHub Desktop/<app version>`

The header is applied through a shared main-process utility and wired into the desktop Cloud request paths, including backend proxy requests, OIDC handoff/token flows, stream proxy forwarding, device registration/notify calls, and device-gateway WebSocket handshakes.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validated in the main checkout:

```bash
cd apps/desktop && bunx vitest run --silent='passed-only' src/main/utils/__tests__/user-agent.test.ts src/main/core/infrastructure/__tests__/BackendProxyProtocolManager.test.ts src/main/controllers/__tests__/RemoteServerConfigCtr.test.ts src/main/controllers/__tests__/AuthCtr.test.ts src/main/controllers/__tests__/GatewayConnectionCtr.test.ts
cd apps/desktop && bun run type-check
cd packages/device-gateway-client && bunx vitest run --silent='passed-only' src/client.test.ts
cd packages/device-gateway-client && bunx tsc --noEmit -p tsconfig.json
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

The PR branch was prepared in a clean worktree from `origin/canary` so it excludes unrelated local changes from the original checkout.
