### PR TITLE
✅ test(e2e): parallelize semantic e2e validation

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -85,8 +85,26 @@ jobs:
         env:
           SKIP_LINT: '1'
 
+      - name: Start E2E server
+        run: |
+          bunx next start -p 3006 > /tmp/lobehub-e2e-server.log 2>&1 &
+          echo $! > /tmp/lobehub-e2e-server.pid
+          for i in {1..60}; do
+            if curl -fsS http://localhost:3006 > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat /tmp/lobehub-e2e-server.log
+          exit 1
+
       - name: Run E2E tests
         run: bun run e2e
+        env:
+          BASE_URL: http://localhost:3006
+          E2E_PARALLEL: '3'
+          E2E_REPORTS: '0'
+          HEADLESS: 'true'
 
       - name: Upload E2E test artifacts (on failure)
         if: failure()

--- a/e2e/cucumber.config.js
+++ b/e2e/cucumber.config.js
@@ -1,16 +1,19 @@
 /**
  * @type {import('@cucumber/cucumber').IConfiguration}
  */
+const reportsEnabled = !['0', 'false'].includes(String(process.env.E2E_REPORTS).toLowerCase());
+const parsedParallel = Number(process.env.E2E_PARALLEL || process.env.CUCUMBER_PARALLEL || 1);
+const requestedParallel = Number.isFinite(parsedParallel) ? parsedParallel : 1;
+const canRunInParallel = Boolean(process.env.BASE_URL);
+
 export default {
-  format: [
-    'progress-bar',
-    'html:reports/cucumber-report.html',
-    'json:reports/cucumber-report.json',
-  ],
+  format: reportsEnabled
+    ? ['progress-bar', 'html:reports/cucumber-report.html', 'json:reports/cucumber-report.json']
+    : ['progress-bar'],
   formatOptions: {
     snippetInterface: 'async-await',
   },
-  parallel: 1,
+  parallel: canRunInParallel ? Math.max(1, requestedParallel) : 1,
   paths: ['src/features/**/*.feature'],
   publishQuiet: true,
   require: ['src/steps/**/*.ts', 'src/support/**/*.ts'],

--- a/e2e/src/steps/agent/conversation.steps.ts
+++ b/e2e/src/steps/agent/conversation.steps.ts
@@ -103,34 +103,14 @@ Given('用户进入 Lobe AI 对话页面', { timeout: 30_000 }, async function (
   llmMockManager.setResponse('hello', presetResponses.greeting);
   await llmMockManager.setup(this.page);
 
-  console.log('   📍 Step: 导航到首页...');
-  // Navigate to home page first
-  await this.page.goto('/');
-  await this.page.waitForLoadState('networkidle', { timeout: WAIT_TIMEOUT });
-
-  console.log('   📍 Step: 查找 Lobe AI...');
-  // Find and click on "Lobe AI" agent in the sidebar/home
-  const lobeAIAgent = this.page.locator('text=Lobe AI').first();
-  await expect(lobeAIAgent).toBeVisible({ timeout: WAIT_TIMEOUT });
-
-  console.log('   📍 Step: 点击 Lobe AI...');
-  await lobeAIAgent.click();
-
-  console.log('   📍 Step: 等待聊天界面加载...');
-  // Wait for the chat interface to be ready
-  await this.page.waitForLoadState('networkidle', { timeout: WAIT_TIMEOUT });
+  console.log('   📍 Step: 直接进入 Lobe AI 对话路由...');
+  await this.page.goto('/agent/inbox', { waitUntil: 'domcontentloaded' });
 
   console.log('   📍 Step: 查找输入框...');
-  // The input is a rich text editor with contenteditable
-  // There are 2 ChatInput components (desktop & mobile), find the visible one
-
-  // Wait for the page to be ready, then find visible chat input
-  await this.page.waitForTimeout(1000);
-
   await focusChatInput.call(this);
 
   // Wait for any animations to complete
-  await this.page.waitForTimeout(300);
+  await this.page.waitForTimeout(100);
 
   console.log('   ✅ 已进入 Lobe AI 对话页面');
 });

--- a/e2e/src/steps/agent/scroll.steps.ts
+++ b/e2e/src/steps/agent/scroll.steps.ts
@@ -124,10 +124,10 @@ async function scrollBy(world: CustomWorld, deltaY: number): Promise<void> {
 
 async function setAutoScrollEnabled(world: CustomWorld, desired: boolean): Promise<void> {
   await world.page.goto('/settings/chat-appearance');
-  // `networkidle` can take a while on the very first compile in dev mode
+  // The first local dev compile can take a while, so keep an explicit timeout.
   // (Next.js builds the settings route on demand); a generous timeout avoids
   // flakes when the test suite warms up a cold server.
-  await world.page.waitForLoadState('networkidle', { timeout: 60_000 });
+  await world.page.waitForLoadState('domcontentloaded', { timeout: 60_000 });
 
   // Match both EN ("Auto-scroll During AI Response") and zh-CN ("AI 回复时自动滚动").
   const title = world.page.getByText(/Auto-scroll During AI Response|AI 回复时自动滚动/);

--- a/e2e/src/steps/common/auth.steps.ts
+++ b/e2e/src/steps/common/auth.steps.ts
@@ -1,8 +1,8 @@
 import { Given, When } from '@cucumber/cucumber';
-import { expect } from '@playwright/test';
+import { expect, request } from '@playwright/test';
 
-import { TEST_USER, createTestSession } from '../../support/seedTestUser';
-import { CustomWorld } from '../../support/world';
+import { TEST_USER } from '../../support/seedTestUser';
+import type { CustomWorld } from '../../support/world';
 
 /**
  * Login via UI - fills in the login form and submits
@@ -30,30 +30,31 @@ Given('I am logged in as the test user', async function (this: CustomWorld) {
 });
 
 /**
- * Login via session injection - faster, bypasses UI
- * Creates a session directly in the database and sets the cookie
+ * Login via the auth API - faster than UI and uses real better-auth cookies.
  */
 Given('I am logged in with a session', async function (this: CustomWorld) {
-  const sessionToken = await createTestSession();
+  const PORT = process.env.PORT ? Number(process.env.PORT) : 3006;
+  const baseURL = process.env.BASE_URL || `http://localhost:${PORT}`;
+  const api = await request.newContext({ baseURL });
 
-  if (!sessionToken) {
-    throw new Error('Failed to create test session');
+  try {
+    const response = await api.post('/api/auth/sign-in/email', {
+      data: {
+        email: TEST_USER.email,
+        password: TEST_USER.password,
+      },
+    });
+
+    if (!response.ok()) {
+      throw new Error(`Auth API sign-in failed: ${response.status()} ${await response.text()}`);
+    }
+
+    await this.browserContext.addCookies((await api.storageState()).cookies);
+  } finally {
+    await api.dispose();
   }
 
-  // Set the session cookie (Better Auth uses 'better-auth.session_token' by default)
-  await this.browserContext.addCookies([
-    {
-      domain: 'localhost',
-      httpOnly: true,
-      name: 'better-auth.session_token',
-      path: '/',
-      sameSite: 'Lax',
-      secure: false,
-      value: sessionToken,
-    },
-  ]);
-
-  console.log('✅ Session cookie set for test user');
+  console.log('✅ Session cookies set for test user');
 });
 
 /**

--- a/e2e/src/steps/common/auth.steps.ts
+++ b/e2e/src/steps/common/auth.steps.ts
@@ -62,7 +62,7 @@ Given('I am logged in with a session', async function (this: CustomWorld) {
  */
 When('I navigate to the signin page', async function (this: CustomWorld) {
   await this.page.goto('/signin');
-  await this.page.waitForLoadState('networkidle');
+  await this.page.waitForLoadState('domcontentloaded');
 });
 
 /**

--- a/e2e/src/steps/community/detail-pages.steps.ts
+++ b/e2e/src/steps/community/detail-pages.steps.ts
@@ -1,14 +1,14 @@
 import { Given, Then, When } from '@cucumber/cucumber';
 import { expect } from '@playwright/test';
 
-import { CustomWorld } from '../../support/world';
+import type { CustomWorld } from '../../support/world';
 
 // ============================================
 // Given Steps (Preconditions)
 // ============================================
 
 Given('I wait for the page to fully load', async function (this: CustomWorld) {
-  // Use domcontentloaded instead of networkidle to avoid hanging on persistent connections
+  // Use domcontentloaded to avoid hanging on persistent connections.
   await this.page.waitForLoadState('domcontentloaded', { timeout: 10_000 });
   // Short wait for React hydration
   await this.page.waitForTimeout(1000);
@@ -19,7 +19,7 @@ Given('I wait for the page to fully load', async function (this: CustomWorld) {
 // ============================================
 
 When('I click the back button', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Store current URL to verify navigation
   const currentUrl = this.page.url();
@@ -51,7 +51,7 @@ When('I click the back button', async function (this: CustomWorld) {
     await this.page.goBack();
   }
 
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
   await this.page.waitForTimeout(500);
 
   const newUrl = this.page.url();
@@ -64,7 +64,7 @@ When('I click the back button', async function (this: CustomWorld) {
 
 // Assistant Detail Page Assertions
 Then('I should be on an assistant detail page', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const currentUrl = this.page.url();
   // Check if URL matches assistant detail page pattern
@@ -76,7 +76,7 @@ Then('I should be on an assistant detail page', async function (this: CustomWorl
 });
 
 Then('I should see the assistant title', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Look for title element (h1, h2, or prominent text)
   const title = this.page
@@ -90,7 +90,7 @@ Then('I should see the assistant title', async function (this: CustomWorld) {
 });
 
 Then('I should see the assistant description', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Look for description element
   const description = this.page
@@ -102,7 +102,7 @@ Then('I should see the assistant description', async function (this: CustomWorld
 });
 
 Then('I should see the assistant author information', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Look for author information
   const author = this.page
@@ -116,7 +116,7 @@ Then('I should see the assistant author information', async function (this: Cust
 });
 
 Then('I should see the add to workspace button', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Look for add button (might be "Add", "Install", "Add to Workspace", etc.)
   const addButton = this.page
@@ -131,7 +131,7 @@ Then('I should see the add to workspace button', async function (this: CustomWor
 });
 
 Then('I should be on the assistant list page', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const currentUrl = this.page.url();
   // Check if URL is assistant list (not detail page) or community home
@@ -148,7 +148,7 @@ Then('I should be on the assistant list page', async function (this: CustomWorld
 
 // Model Detail Page Assertions
 Then('I should be on a model detail page', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const currentUrl = this.page.url();
   // Check if URL matches model detail page pattern
@@ -160,7 +160,7 @@ Then('I should be on a model detail page', async function (this: CustomWorld) {
 });
 
 Then('I should see the model title', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const title = this.page
     .locator('h1, h2, [data-testid="detail-title"], [data-testid="model-title"]')
@@ -172,7 +172,7 @@ Then('I should see the model title', async function (this: CustomWorld) {
 });
 
 Then('I should see the model description', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Model detail page shows description below the title, it might be a placeholder like "model.description"
   // or actual content. Just verify the page structure is correct.
@@ -187,7 +187,7 @@ Then('I should see the model description', async function (this: CustomWorld) {
 });
 
 Then('I should see the model parameters information', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Look for parameters or specs section
   const params = this.page
@@ -200,7 +200,7 @@ Then('I should see the model parameters information', async function (this: Cust
 });
 
 Then('I should be on the model list page', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const currentUrl = this.page.url();
   // Check if URL is model list (not detail page) or community home
@@ -216,7 +216,7 @@ Then('I should be on the model list page', async function (this: CustomWorld) {
 
 // Provider Detail Page Assertions
 Then('I should be on a provider detail page', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const currentUrl = this.page.url();
   // Check if URL matches provider detail page pattern
@@ -228,7 +228,7 @@ Then('I should be on a provider detail page', async function (this: CustomWorld)
 });
 
 Then('I should see the provider title', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const title = this.page
     .locator('h1, h2, [data-testid="detail-title"], [data-testid="provider-title"]')
@@ -240,7 +240,7 @@ Then('I should see the provider title', async function (this: CustomWorld) {
 });
 
 Then('I should see the provider description', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const description = this.page
     .locator(
@@ -251,7 +251,7 @@ Then('I should see the provider description', async function (this: CustomWorld)
 });
 
 Then('I should see the provider website link', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Look for website link
   const websiteLink = this.page
@@ -264,7 +264,7 @@ Then('I should see the provider website link', async function (this: CustomWorld
 });
 
 Then('I should be on the provider list page', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const currentUrl = this.page.url();
   // Check if URL is provider list (not detail page) or community home
@@ -280,7 +280,7 @@ Then('I should be on the provider list page', async function (this: CustomWorld)
 
 // MCP Detail Page Assertions
 Then('I should be on an MCP detail page', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const currentUrl = this.page.url();
   // Check if URL matches MCP detail page pattern
@@ -292,7 +292,7 @@ Then('I should be on an MCP detail page', async function (this: CustomWorld) {
 });
 
 Then('I should see the MCP title', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const title = this.page
     .locator('h1, h2, [data-testid="detail-title"], [data-testid="mcp-title"]')
@@ -304,7 +304,7 @@ Then('I should see the MCP title', async function (this: CustomWorld) {
 });
 
 Then('I should see the MCP description', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const description = this.page
     .locator('p, [data-testid="detail-description"], [data-testid="mcp-description"], .description')
@@ -313,7 +313,7 @@ Then('I should see the MCP description', async function (this: CustomWorld) {
 });
 
 Then('I should see the install button', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Look for install button
   const installButton = this.page
@@ -326,7 +326,7 @@ Then('I should see the install button', async function (this: CustomWorld) {
 });
 
 Then('I should be on the MCP list page', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const currentUrl = this.page.url();
   // Check if URL is MCP list (not detail page) or community home

--- a/e2e/src/steps/community/interactions.steps.ts
+++ b/e2e/src/steps/community/interactions.steps.ts
@@ -8,7 +8,7 @@ import type { CustomWorld } from '../../support/world';
 // ============================================
 
 When('I type {string} in the search bar', async function (this: CustomWorld, searchText: string) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const searchBar = this.page.locator('input[type="text"]').first();
   await searchBar.waitFor({ state: 'visible', timeout: 30_000 });
@@ -20,13 +20,13 @@ When('I type {string} in the search bar', async function (this: CustomWorld, sea
 
 When('I wait for the search results to load', async function (this: CustomWorld) {
   // Wait for network to be idle after typing
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
   // Add a small delay to ensure UI updates
   await this.page.waitForTimeout(500);
 });
 
 When('I click on a category in the category menu', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Find the category menu items - they are clickable elements in the sidebar
   // The UI shows categories like "All", "Academic", "Career", etc.
@@ -66,7 +66,7 @@ When('I click on a category in the category menu', async function (this: CustomW
 });
 
 When('I click on a category in the category filter', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Find the category filter items - MCP page has categories like "Developer Tools", "Productivity Tools"
   // Use the same selector pattern as the category menu
@@ -107,13 +107,13 @@ When('I click on a category in the category filter', async function (this: Custo
 
 When('I wait for the filtered results to load', async function (this: CustomWorld) {
   // Wait for network to be idle after filtering
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
   // Add a small delay to ensure UI updates
   await this.page.waitForTimeout(500);
 });
 
 When('I click the next page button', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Wait for initial cards to load first
   const assistantCards = this.page.locator('[data-testid="assistant-item"]');
@@ -135,13 +135,13 @@ When('I click the next page button', async function (this: CustomWorld) {
 
 When('I wait for the next page to load', async function (this: CustomWorld) {
   // Wait for network to be idle after page change
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
   // Add a small delay to ensure UI updates
   await this.page.waitForTimeout(500);
 });
 
 When('I click on the first assistant card', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const firstCard = this.page
     .locator('[data-testid="assistant-item"][data-agent-type="agent"]')
@@ -162,7 +162,7 @@ When('I click on the first assistant card', async function (this: CustomWorld) {
 });
 
 When('I click on the first model card', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const firstCard = this.page.locator('[data-testid="model-item"]').first();
   await firstCard.waitFor({ state: 'visible', timeout: 30_000 });
@@ -181,7 +181,7 @@ When('I click on the first model card', async function (this: CustomWorld) {
 });
 
 When('I click on the first provider card', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const firstCard = this.page.locator('[data-testid="provider-item"]').first();
   await firstCard.waitFor({ state: 'visible', timeout: 30_000 });
@@ -200,7 +200,7 @@ When('I click on the first provider card', async function (this: CustomWorld) {
 });
 
 When('I click on the first MCP card', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const firstCard = this.page.locator('[data-testid="mcp-item"]').first();
   await firstCard.waitFor({ state: 'visible', timeout: 30_000 });
@@ -219,7 +219,7 @@ When('I click on the first MCP card', async function (this: CustomWorld) {
 });
 
 When('I click on the sort dropdown', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const sortDropdown = this.page
     .locator(
@@ -251,7 +251,7 @@ When('I select a sort option', async function (this: CustomWorld) {
 
 When('I wait for the sorted results to load', async function (this: CustomWorld) {
   // Wait for network to be idle after sorting
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
   // Add a small delay to ensure UI updates
   await this.page.waitForTimeout(500);
 });
@@ -259,7 +259,7 @@ When('I wait for the sorted results to load', async function (this: CustomWorld)
 When(
   'I click on the {string} link in the featured assistants section',
   async function (this: CustomWorld, linkText: string) {
-    await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+    await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
     // Find the featured assistants section and the "more" link
     const moreLink = this.page
@@ -274,7 +274,7 @@ When(
 When(
   'I click on the {string} link in the featured MCP tools section',
   async function (this: CustomWorld, linkText: string) {
-    await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+    await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
     // The home page might not have a direct MCP section with a "more" link
     // Try to find MCP-specific link first, then fall back to direct navigation
@@ -321,7 +321,7 @@ When(
 );
 
 When('I click on the first featured assistant card', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const firstCard = this.page.locator('[data-testid="assistant-item"]').first();
   await firstCard.waitFor({ state: 'visible', timeout: 30_000 });
@@ -344,7 +344,7 @@ When('I click on the first featured assistant card', async function (this: Custo
 // ============================================
 
 Then('I should see filtered assistant cards', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const assistantItems = this.page.locator('[data-testid="assistant-item"]');
 
@@ -359,7 +359,7 @@ Then('I should see filtered assistant cards', async function (this: CustomWorld)
 Then(
   'I should see assistant cards filtered by the selected category',
   async function (this: CustomWorld) {
-    await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+    await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
     const assistantItems = this.page.locator('[data-testid="assistant-item"]');
 
@@ -392,7 +392,7 @@ Then('the URL should contain the category parameter', async function (this: Cust
 });
 
 Then('I should see different assistant cards', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const assistantItems = this.page.locator('[data-testid="assistant-item"]');
 
@@ -432,7 +432,7 @@ Then('the URL should contain the page parameter', async function (this: CustomWo
 });
 
 Then('I should be navigated to the assistant detail page', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const currentUrl = this.page.url();
   // Verify that URL changed and contains /agent/ followed by an identifier
@@ -446,7 +446,7 @@ Then('I should be navigated to the assistant detail page', async function (this:
 });
 
 Then('I should see the assistant detail content', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Look for assistant detail page content
   const detailContent = this.page.locator('[data-testid="assistant-detail-content"]');
@@ -454,7 +454,7 @@ Then('I should see the assistant detail content', async function (this: CustomWo
 });
 
 Then('I should see model cards in the sorted order', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const modelItems = this.page.locator('[data-testid="model-item"]');
 
@@ -467,7 +467,7 @@ Then('I should see model cards in the sorted order', async function (this: Custo
 });
 
 Then('I should be navigated to the model detail page', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const currentUrl = this.page.url();
   // Verify that URL changed and contains /model/ followed by an identifier
@@ -482,7 +482,7 @@ Then('I should be navigated to the model detail page', async function (this: Cus
 
 Then('I should see the model detail content', async function (this: CustomWorld) {
   // Wait for page to load
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Model detail page should have tabs like "Overview", "Model Parameters"
   // Wait for these specific elements to appear
@@ -500,7 +500,7 @@ Then('I should see the model detail content', async function (this: CustomWorld)
 });
 
 Then('I should be navigated to the provider detail page', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const currentUrl = this.page.url();
   // Verify that URL changed and contains /provider/ followed by an identifier
@@ -515,7 +515,7 @@ Then('I should be navigated to the provider detail page', async function (this: 
 
 Then('I should see the provider detail content', async function (this: CustomWorld) {
   // Wait for page to load
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Provider detail page should have provider name/title and model list
   // Wait for the provider title to appear
@@ -533,7 +533,7 @@ Then('I should see the provider detail content', async function (this: CustomWor
 Then(
   'I should see MCP cards filtered by the selected category',
   async function (this: CustomWorld) {
-    await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+    await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
     const mcpItems = this.page.locator('[data-testid="mcp-item"]');
 
@@ -547,7 +547,7 @@ Then(
 );
 
 Then('I should be navigated to the MCP detail page', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   const currentUrl = this.page.url();
   // Verify that URL changed and contains /mcp/ followed by an identifier
@@ -561,7 +561,7 @@ Then('I should be navigated to the MCP detail page', async function (this: Custo
 });
 
 Then('I should see the MCP detail content', async function (this: CustomWorld) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
 
   // Look for MCP detail page content
   const detailContent = this.page.locator('[data-testid="mcp-detail-content"]');
@@ -569,7 +569,7 @@ Then('I should see the MCP detail content', async function (this: CustomWorld) {
 });
 
 Then('I should be navigated to {string}', async function (this: CustomWorld, expectedPath: string) {
-  await this.page.waitForLoadState('networkidle', { timeout: 30_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
   await this.page.waitForTimeout(500); // Extra wait for client-side routing
 
   const currentUrl = this.page.url();

--- a/e2e/src/steps/home/sidebarAgent.steps.ts
+++ b/e2e/src/steps/home/sidebarAgent.steps.ts
@@ -6,6 +6,8 @@
  * - Pin/Unpin
  * - Delete
  */
+import { randomBytes } from 'node:crypto';
+
 import { Given, Then, When } from '@cucumber/cucumber';
 import { expect } from '@playwright/test';
 
@@ -67,8 +69,9 @@ async function createTestAgent(title: string = 'Test Agent'): Promise<string> {
     await client.connect();
 
     const now = new Date().toISOString();
-    const agentId = `agent_e2e_test_${Date.now()}`;
-    const slug = `test-agent-${Date.now()}`;
+    const suffix = randomBytes(6).toString('hex');
+    const agentId = `agent_e2e_test_${suffix}`;
+    const slug = `test-agent-${suffix}`;
 
     await client.query(
       `INSERT INTO agents (id, slug, title, user_id, created_at, updated_at)
@@ -95,7 +98,7 @@ Given('用户在 Home 页面有一个 Agent', { timeout: 30_000 }, async functio
 
   console.log('   📍 Step: 导航到 Home 页面...');
   await this.page.goto('/');
-  await this.page.waitForLoadState('networkidle', { timeout: 15_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 15_000 });
   await this.page.waitForTimeout(1000);
 
   console.log('   📍 Step: 查找新创建的 Agent...');

--- a/e2e/src/steps/home/sidebarGroup.steps.ts
+++ b/e2e/src/steps/home/sidebarGroup.steps.ts
@@ -6,6 +6,8 @@
  * - Pin/Unpin
  * - Delete
  */
+import { randomBytes } from 'node:crypto';
+
 import { Given, Then, When } from '@cucumber/cucumber';
 import { expect } from '@playwright/test';
 
@@ -27,7 +29,7 @@ async function createTestGroup(title: string = 'Test Group'): Promise<string> {
     await client.connect();
 
     const now = new Date().toISOString();
-    const groupId = `group_e2e_test_${Date.now()}`;
+    const groupId = `group_e2e_test_${randomBytes(6).toString('hex')}`;
 
     await client.query(
       `INSERT INTO chat_groups (id, title, user_id, created_at, updated_at)
@@ -54,7 +56,7 @@ Given('用户在 Home 页面有一个 Agent Group', async function (this: Custom
 
   console.log('   📍 Step: 导航到 Home 页面...');
   await this.page.goto('/');
-  await this.page.waitForLoadState('networkidle', { timeout: 15_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 15_000 });
   await this.page.waitForTimeout(1000);
 
   console.log('   📍 Step: 查找新创建的 Agent Group...');

--- a/e2e/src/steps/hooks.ts
+++ b/e2e/src/steps/hooks.ts
@@ -4,7 +4,7 @@ import { type Cookie, request } from 'playwright';
 import { mockManager } from '../mocks';
 import { seedTestUser, TEST_USER } from '../support/seedTestUser';
 import { startWebServer, stopWebServer } from '../support/webServer';
-import type { CustomWorld } from '../support/world';
+import { closeSharedBrowser, type CustomWorld } from '../support/world';
 
 process.env['E2E'] = '1';
 // Set default timeout for all steps to 30 seconds
@@ -131,6 +131,8 @@ After(async function (this: CustomWorld, { pickle, result }) {
 
 AfterAll(async function () {
   console.log('\n🏁 Test suite completed');
+
+  await closeSharedBrowser();
 
   // Stop web server if we started it
   if (!process.env.BASE_URL && process.env.CI) {

--- a/e2e/src/steps/hooks.ts
+++ b/e2e/src/steps/hooks.ts
@@ -1,5 +1,5 @@
 import { After, AfterAll, Before, BeforeAll, setDefaultTimeout, Status } from '@cucumber/cucumber';
-import { chromium, type Cookie } from 'playwright';
+import { type Cookie, request } from 'playwright';
 
 import { mockManager } from '../mocks';
 import { seedTestUser, TEST_USER } from '../support/seedTestUser';
@@ -35,63 +35,27 @@ BeforeAll({ timeout: 600_000 }, async function () {
     });
   }
 
-  // Login once and cache the session cookies
-  console.log('🔐 Performing one-time login to cache session...');
-
-  const browser = await chromium.launch({ headless: process.env.HEADLESS !== 'false' });
-  const context = await browser.newContext();
-  const page = await context.newPage();
+  console.log('🔐 Signing in once through the auth API...');
+  const api = await request.newContext({ baseURL: baseUrl });
 
   try {
-    // Navigate to signin page
-    await page.goto(`${baseUrl}/signin`, { waitUntil: 'networkidle' });
+    const response = await api.post('/api/auth/sign-in/email', {
+      data: {
+        email: TEST_USER.email,
+        password: TEST_USER.password,
+      },
+    });
 
-    // Wait for the page to fully hydrate
-    await page.waitForTimeout(2000);
-
-    // Check if we can find the email input
-    const emailInput = page
-      .locator('input[id="email"], input[name="email"], input[type="text"]')
-      .first();
-    const emailInputVisible = await emailInput.isVisible().catch(() => false);
-
-    if (!emailInputVisible) {
-      console.log(
-        '⚠️  Login form not available, skipping authentication (tests requiring auth may fail)',
-      );
-      return;
+    if (!response.ok()) {
+      throw new Error(`Auth API sign-in failed: ${response.status()} ${await response.text()}`);
     }
 
-    // Step 1: Enter email
-    console.log('   Step 1: Entering email...');
-    await emailInput.fill(TEST_USER.email);
-
-    // Click the next button
-    const nextButton = page.locator('form button').first();
-    await nextButton.click();
-
-    // Step 2: Wait for password step and enter password
-    console.log('   Step 2: Entering password...');
-    const passwordInput = page
-      .locator('input[id="password"], input[name="password"], input[type="password"]')
-      .first();
-    await passwordInput.waitFor({ state: 'visible', timeout: 30_000 });
-    await passwordInput.fill(TEST_USER.password);
-
-    // Click submit button
-    const submitButton = page.locator('form button').first();
-    await submitButton.click();
-
-    // Wait for navigation away from signin page
-    await page.waitForURL((url) => !url.pathname.includes('/signin'), { timeout: 30_000 });
-    await page.waitForLoadState('networkidle');
-
-    // Cache the session cookies
-    sessionCookies = await context.cookies();
-    console.log(`✅ Login successful, cached ${sessionCookies.length} cookies`);
+    sessionCookies = (await api.storageState()).cookies;
   } finally {
-    await browser.close();
+    await api.dispose();
   }
+
+  console.log(`✅ Auth API login successful, cached ${sessionCookies.length} cookies`);
 });
 
 Before(async function (this: CustomWorld, { pickle }) {
@@ -137,7 +101,7 @@ After(async function (this: CustomWorld, { pickle, result }) {
     )
     ?.name.replace('@', '');
 
-  if (result?.status === Status.FAILED) {
+  if (result?.status === Status.FAILED && this.page) {
     const screenshot = await this.takeScreenshot(`${testId || 'failure'}-${Date.now()}`);
     this.attach(screenshot, 'image/png');
 
@@ -150,6 +114,11 @@ After(async function (this: CustomWorld, { pickle, result }) {
     }
 
     console.log(`❌ Failed: ${pickle.name}`);
+    if (result.message) {
+      console.log(`   Error: ${result.message}`);
+    }
+  } else if (result?.status === Status.FAILED) {
+    console.log(`❌ Failed before page initialization: ${pickle.name}`);
     if (result.message) {
       console.log(`   Error: ${result.message}`);
     }

--- a/e2e/src/steps/page/editor-meta.steps.ts
+++ b/e2e/src/steps/page/editor-meta.steps.ts
@@ -84,7 +84,7 @@ Given('用户打开一个文稿编辑器', async function (this: CustomWorld) {
 
   // Navigate to page module
   await this.page.goto('/page');
-  await this.page.waitForLoadState('networkidle', { timeout: 15_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 15_000 });
   await waitForPageWorkspaceReady(this);
 
   // Create a new page via UI
@@ -93,7 +93,7 @@ Given('用户打开一个文稿编辑器', async function (this: CustomWorld) {
 
   // Wait for navigation to page editor
   await this.page.waitForURL(/\/page\/.+/, { timeout: WAIT_TIMEOUT });
-  await this.page.waitForLoadState('networkidle');
+  await this.page.waitForLoadState('domcontentloaded');
   await this.page.waitForTimeout(500);
 
   console.log('   ✅ 已打开文稿编辑器');
@@ -104,14 +104,14 @@ Given('用户打开一个带有 Emoji 的文稿', async function (this: CustomWo
 
   // First create and open a page
   await this.page.goto('/page');
-  await this.page.waitForLoadState('networkidle', { timeout: 15_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 15_000 });
   await waitForPageWorkspaceReady(this);
 
   await clickNewPageButton(this);
   await this.page.waitForTimeout(1500);
 
   await this.page.waitForURL(/\/page\/.+/, { timeout: WAIT_TIMEOUT });
-  await this.page.waitForLoadState('networkidle');
+  await this.page.waitForLoadState('domcontentloaded');
   await this.page.waitForTimeout(500);
 
   // Add emoji by clicking the "Choose Icon" button

--- a/e2e/src/steps/page/page-crud.steps.ts
+++ b/e2e/src/steps/page/page-crud.steps.ts
@@ -171,7 +171,7 @@ async function clickNewPageButton(world: CustomWorld): Promise<void> {
 Given('用户在 Page 页面', { timeout: 30_000 }, async function (this: CustomWorld) {
   console.log('   📍 Step: 导航到 Page 页面...');
   await this.page.goto('/page');
-  await this.page.waitForLoadState('networkidle', { timeout: 15_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 15_000 });
   await waitForPageWorkspaceReady(this);
 
   console.log('   ✅ 已进入 Page 页面');
@@ -180,7 +180,7 @@ Given('用户在 Page 页面', { timeout: 30_000 }, async function (this: Custom
 Given('用户在 Page 页面有一个文稿', async function (this: CustomWorld) {
   console.log('   📍 Step: 导航到 Page 页面...');
   await this.page.goto('/page');
-  await this.page.waitForLoadState('networkidle', { timeout: 15_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 15_000 });
 
   console.log('   📍 Step: 通过 UI 创建新文稿...');
   await clickNewPageButton(this);
@@ -288,7 +288,7 @@ Given('用户在 Page 页面有一个文稿', async function (this: CustomWorld)
 Given('用户在 Page 页面有一个文稿 {string}', async function (this: CustomWorld, title: string) {
   console.log('   📍 Step: 导航到 Page 页面...');
   await this.page.goto('/page');
-  await this.page.waitForLoadState('networkidle', { timeout: 15_000 });
+  await this.page.waitForLoadState('domcontentloaded', { timeout: 15_000 });
 
   console.log('   📍 Step: 通过 UI 创建新文稿...');
   await clickNewPageButton(this);

--- a/e2e/src/support/seedTestUser.ts
+++ b/e2e/src/support/seedTestUser.ts
@@ -2,13 +2,19 @@ import { randomBytes } from 'node:crypto';
 
 import bcrypt from 'bcryptjs';
 
+const runId = process.env.E2E_RUN_ID || process.env.GITHUB_RUN_ID || 'local';
+const workerId = process.env.CUCUMBER_WORKER_ID || process.env.E2E_WORKER_ID || 'local';
+const testScope = runId === 'local' ? workerId : `${runId}_${workerId}`;
+const workerSuffix = testScope.replaceAll(/[^\w-]/g, '_');
+const isParallelWorker = workerSuffix !== 'local';
+
 // Test user credentials - these are used for e2e testing only
 export const TEST_USER = {
-  email: 'e2e-test@lobehub.com',
-  fullName: 'E2E Test User',
-  id: 'user_e2e_test_user_001',
+  email: isParallelWorker ? `e2e-test+${workerSuffix}@lobehub.com` : 'e2e-test@lobehub.com',
+  fullName: isParallelWorker ? `E2E Test User ${workerSuffix}` : 'E2E Test User',
+  id: isParallelWorker ? `user_e2e_test_user_${workerSuffix}` : 'user_e2e_test_user_001',
   password: 'TestPassword123!',
-  username: 'e2e_test_user',
+  username: isParallelWorker ? `e2e_test_user_${workerSuffix}` : 'e2e_test_user',
 };
 
 /**
@@ -41,7 +47,9 @@ export async function seedTestUser(): Promise<void> {
 
     const now = new Date().toISOString();
     // Use fixed account ID to avoid conflicts when multiple workers run concurrently
-    const accountId = 'e2e_test_account_001';
+    const accountId = isParallelWorker
+      ? `e2e_test_account_${workerSuffix}`
+      : 'e2e_test_account_001';
 
     // Use upsert to handle concurrent worker execution
     // Insert user or do nothing if already exists (handles all unique constraints)

--- a/e2e/src/support/world.ts
+++ b/e2e/src/support/world.ts
@@ -1,7 +1,10 @@
-import { IWorldOptions, World, setWorldConstructor } from '@cucumber/cucumber';
-import { Browser, BrowserContext, Page, Response, chromium } from '@playwright/test';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+
+import type { IWorldOptions } from '@cucumber/cucumber';
+import { setWorldConstructor, World } from '@cucumber/cucumber';
+import type { Browser, BrowserContext, Page, Response } from '@playwright/test';
+import { chromium } from '@playwright/test';
 
 /**
  * Default timeout for waiting operations (e.g., waitForURL, toBeVisible)
@@ -14,6 +17,23 @@ export interface TestContext {
   jsErrors: Error[];
   lastResponse?: Response | null;
   previousUrl?: string;
+}
+
+let sharedBrowser: Browser | undefined;
+
+async function getSharedBrowser(): Promise<Browser> {
+  if (!sharedBrowser) {
+    sharedBrowser = await chromium.launch({
+      headless: process.env.HEADLESS !== 'false',
+    });
+  }
+
+  return sharedBrowser;
+}
+
+export async function closeSharedBrowser(): Promise<void> {
+  await sharedBrowser?.close();
+  sharedBrowser = undefined;
 }
 
 export class CustomWorld extends World {
@@ -46,9 +66,7 @@ export class CustomWorld extends World {
     const PORT = process.env.PORT ? Number(process.env.PORT) : 3006;
     const BASE_URL = process.env.BASE_URL || `http://localhost:${PORT}`;
 
-    this.browser = await chromium.launch({
-      headless: process.env.HEADLESS !== 'false',
-    });
+    this.browser = await getSharedBrowser();
 
     this.browserContext = await this.browser.newContext({
       baseURL: BASE_URL,
@@ -78,7 +96,6 @@ export class CustomWorld extends World {
   async cleanup() {
     await this.page?.close();
     await this.browserContext?.close();
-    await this.browser?.close();
   }
 
   async takeScreenshot(name: string): Promise<Buffer> {

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "ES2020",
-    "lib": ["ES2020"],
+    "lib": ["ES2022", "DOM"],
     "types": ["node", "@cucumber/cucumber", "@playwright/test"],
     "esModuleInterop": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

This PR modernizes the e2e execution layer while keeping the BDD feature semantics intact.

- Replace the global e2e one-time UI sign-in with Auth API sign-in and cached Better Auth cookies.
- Update the session login step to use the same Auth API cookie flow instead of direct DB session-token injection.
- Change `用户进入 Lobe AI 对话页面` to navigate directly to `/agent/inbox` and wait for the chat input, instead of loading the homepage and clicking the `Lobe AI` entry.
- Reuse one Chromium browser per Cucumber worker while still creating a fresh browser context/page per scenario.
- Add run/worker-scoped test users so Cucumber workers do not mutate the same account state in parallel.
- Randomize direct DB fixture ids for Home Agent/Group scenarios.
- Replace e2e `networkidle` waits with `domcontentloaded`, leaving visible UI assertions to determine readiness.
- Make Cucumber reports optional through `E2E_REPORTS=0`; CI now validates only and does not generate html/json reports by default.
- Run e2e CI against an externally started Next server with `BASE_URL=http://localhost:3006` and `E2E_PARALLEL=3`.
- Update `e2e/tsconfig.json` so the e2e package type-checks under the currently resolved TypeScript version.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run locally:

```bash
cd e2e && ./node_modules/.bin/tsc --noEmit
```

```bash
E2E_REPORTS=0 BASE_URL=http://localhost:3006 E2E_PARALLEL=3 ./node_modules/.bin/cucumber-js --config cucumber.config.js --dry-run
```

```bash
E2E_REPORTS=0 BASE_URL=http://localhost:${SPA_PORT} E2E_PARALLEL=3 HEADLESS=true bun run test:smoke
```

```bash
E2E_REPORTS=0 E2E_RUN_ID=local-full-<timestamp> BASE_URL=http://localhost:${SPA_PORT} E2E_PARALLEL=3 HEADLESS=true bun run test
```

Local results:

- `@AGENT-CHAT-001` before direct-route/Auth API change: `0m10.353s`
- `@AGENT-CHAT-001` after direct-route/Auth API change: `0m08.578s` to `0m09.311s`
- `@smoke`, parallel 3: `16 scenarios`, `91 steps`, `0m44.295s`
- `@smoke`, serial: `16 scenarios`, `91 steps`, `0m50.624s`
- Full e2e suite, parallel 3: `82 scenarios`, `491 steps`, `5m17.324s` wall time, `15m47.687s` cumulative step execution time

#### 📸 Screenshots / Videos

N/A. This is an e2e execution-path change, not a product UI change.

#### 📝 Additional Information

Concurrency is intentionally conservative at `E2E_PARALLEL=3`. The full local run shows the suite can execute in parallel with isolated worker users; if CI remains stable, this can be tuned upward later.
