### PR TITLE
🐛 fix(skills): restore case-insensitive activation and use kebab-case builtin names

### DIFF
--- a/apps/cli/src/commands/verify.test.ts
+++ b/apps/cli/src/commands/verify.test.ts
@@ -176,7 +176,7 @@ describe('verify init command', () => {
       content: '# Verify SKILL',
       files: { 'references/plan-format.md': 'plan', 'surfaces/cli.md': 'cli' },
       identifier: 'verify',
-      name: 'Verify',
+      name: 'verify',
     });
     dir = mkdtempSync(path.join(tmpdir(), 'verify-init-'));
   });
@@ -214,7 +214,7 @@ describe('verify init command', () => {
       content: '# Updated SKILL',
       files: {},
       identifier: 'verify',
-      name: 'Verify',
+      name: 'verify',
     });
 
     await run(['init', '--dir', dir]); // no --force → keep existing

--- a/packages/builtin-skills/src/agent-browser/index.ts
+++ b/packages/builtin-skills/src/agent-browser/index.ts
@@ -10,6 +10,6 @@ export const AgentBrowserSkill: BuiltinSkill = {
   description:
     'Browser automation CLI for AI agents (agent-browser v0.31.1). Use when tasks involve website or Electron interaction such as navigation, form filling, clicking, screenshot capture, scraping data, login flows, and end-to-end app testing.',
   identifier: AgentBrowserIdentifier,
-  name: 'Agent Browser',
+  name: 'agent-browser',
   source: 'builtin',
 };

--- a/packages/builtin-skills/src/artifacts/index.ts
+++ b/packages/builtin-skills/src/artifacts/index.ts
@@ -10,6 +10,6 @@ export const ArtifactsSkill: BuiltinSkill = {
   description:
     'Generate visual and interactive artifacts like SVG graphics, HTML pages, and React components',
   identifier: ArtifactsIdentifier,
-  name: 'Artifacts',
+  name: 'artifacts',
   source: 'builtin',
 };

--- a/packages/builtin-skills/src/find-skills/index.ts
+++ b/packages/builtin-skills/src/find-skills/index.ts
@@ -9,6 +9,6 @@ export const FindSkillsSkill: BuiltinSkill = {
   description:
     'Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", or express interest in extending capabilities',
   identifier: FindSkillsIdentifier,
-  name: 'Find Skills',
+  name: 'find-skills',
   source: 'builtin',
 };

--- a/packages/builtin-skills/src/lobehub/index.ts
+++ b/packages/builtin-skills/src/lobehub/index.ts
@@ -38,7 +38,7 @@ export const LobeHubSkill: BuiltinSkill = {
   description:
     "Manage the LobeHub platform via the `lh` CLI — INCLUDING modifying THIS agent's own configuration. ACTIVATE this skill whenever the user asks you to: change your system prompt / instructions / persona, enable or disable tools / plugins / skills, switch model or provider, attach knowledge bases or files, edit the opening message, rename the topic, OR operate on any other platform resource (agents, topics, memory, documents, search, content generation, model/provider/plugin management, bot integrations, evals, usage stats). ALSO ACTIVATE when the user asks to connect, link, or set up a messaging platform bot — including Discord, Telegram, Slack, Feishu (飞书), Lark, QQ, or WeChat (微信) — or uses phrases like '帮我链接 Discord', 'connect my Slack', '接入飞书', '配置 QQ 机器人', 'link WeChat'. Without activation you cannot persist any change — you can only describe what you would do.",
   identifier: LobeHubIdentifier,
-  name: 'LobeHub',
+  name: 'lobehub',
   resources: toResourceMeta({
     'references/agent': agent,
     'references/bot': bot,

--- a/packages/builtin-skills/src/task/index.ts
+++ b/packages/builtin-skills/src/task/index.ts
@@ -11,7 +11,7 @@ export const TaskSkill: BuiltinSkill = {
   content,
   description: 'Task management and execution — create, track, review, and complete tasks via CLI.',
   identifier: TaskIdentifier,
-  name: 'Task',
+  name: 'task',
   resources: toResourceMeta({
     'references/commands': commands,
   }),

--- a/packages/builtin-skills/src/verify/index.ts
+++ b/packages/builtin-skills/src/verify/index.ts
@@ -37,7 +37,7 @@ export const VerifySkill: BuiltinSkill = {
   description:
     'Self-evidence for task delivery verification — discover the verify plan, pick the right surface (CLI / web / desktop), drive it with agent-browser, get past auth, capture portable evidence per criterion, and submit each with `lh verify submit` so the delivery is judged on real proof.',
   identifier: VerifyIdentifier,
-  name: 'Verify',
+  name: 'verify',
   resources: toResourceMeta({
     'references/agent-browser.md': agentBrowser,
     'references/auth.md': auth,

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts
@@ -343,4 +343,61 @@ describe('SkillsExecutionRuntime', () => {
       expect(result.state).toMatchObject({ name: 'artifacts', source: 'builtin' });
     });
   });
+
+  describe('case-insensitive name matching', () => {
+    it('activateSkill matches a builtin regardless of casing', async () => {
+      const runtime = new SkillsExecutionRuntime({
+        builtinSkills: [
+          {
+            content: 'browser content',
+            description: 'browser',
+            identifier: 'lobe-agent-browser',
+            name: 'agent-browser',
+            source: 'builtin',
+          },
+        ],
+        service: createMockService(),
+      });
+
+      for (const name of ['agent-browser', 'Agent-Browser', 'AGENT-BROWSER']) {
+        const result = await runtime.activateSkill({ name });
+        expect(result.success).toBe(true);
+        expect(result.content).toContain('browser content');
+      }
+    });
+
+    it('activateSkill matches a project skill regardless of casing', async () => {
+      const readFile = vi.fn().mockResolvedValue('# project skill body');
+      const runtime = new SkillsExecutionRuntime({
+        deviceFileAccess: { listFiles: vi.fn(), readFile },
+        projectSkills: [{ location: '/work/.agents/skills/my-skill/SKILL.md', name: 'my-skill' }],
+        service: createMockService(),
+      });
+
+      const result = await runtime.activateSkill({ name: 'My-Skill' });
+      expect(result.success).toBe(true);
+      expect(result.content).toContain('# project skill body');
+      expect(result.state).toMatchObject({ source: 'project' });
+    });
+
+    it('readReference matches a builtin regardless of casing', async () => {
+      const runtime = new SkillsExecutionRuntime({
+        builtinSkills: [
+          {
+            content: 'main',
+            description: '',
+            identifier: 'lobehub',
+            name: 'lobehub',
+            resources: { 'references/kb': { content: 'kb body', fileHash: 'h', size: 7 } },
+            source: 'builtin',
+          },
+        ],
+        service: createMockService(),
+      });
+
+      const result = await runtime.readReference({ id: 'LobeHub', path: 'references/kb' });
+      expect(result.success).toBe(true);
+      expect(result.content).toBe('kb body');
+    });
+  });
 });

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
@@ -122,6 +122,16 @@ const hasHiddenSegment = (rel: string): boolean =>
   rel.split('/').some((seg) => seg.startsWith('.'));
 
 /**
+ * Case-insensitive lookup by `name`. The model frequently emits a different
+ * casing than what's registered (e.g. `Agent-Browser` for `agent-browser`,
+ * `lobehub` for `LobeHub`); normalize both sides before comparing.
+ */
+const findByNameCI = <T extends { name: string }>(items: T[], target: string): T | undefined => {
+  const lower = target.toLowerCase();
+  return items.find((s) => s.name.toLowerCase() === lower);
+};
+
+/**
  * Hint appended to activated project-skill content so the model knows how to
  * discover the rest of the skill's directory. We deliberately don't enumerate
  * the tree here — the model has `local-system.globFiles` available and can
@@ -250,7 +260,7 @@ export class SkillsExecutionRuntime {
     try {
       // Project skills resolve references relative to the SKILL.md directory,
       // read through the device file access (local-system over the gateway).
-      const projectSkill = this.projectSkills.find((s) => s.name === id);
+      const projectSkill = findByNameCI(this.projectSkills, id);
       if (projectSkill) {
         if (!this.deviceFileAccess) {
           return {
@@ -328,7 +338,7 @@ export class SkillsExecutionRuntime {
 
       // Fall back to builtin skills (includes agent-document skill bundles
       // via the `agent-skills:` identifier prefix).
-      const builtinSkill = this.builtinSkills.find((s) => s.name === id);
+      const builtinSkill = findByNameCI(this.builtinSkills, id);
       if (builtinSkill?.resources) {
         const meta = builtinSkill.resources[path];
         if (meta?.content !== undefined) {
@@ -365,7 +375,7 @@ export class SkillsExecutionRuntime {
     const { name } = args;
 
     // Project skills (filesystem SKILL.md) take precedence over db/builtin.
-    const projectSkill = this.projectSkills.find((s) => s.name === name);
+    const projectSkill = findByNameCI(this.projectSkills, name);
     if (projectSkill) {
       if (!this.deviceFileAccess) {
         return {
@@ -433,7 +443,7 @@ export class SkillsExecutionRuntime {
 
     // Fall back to builtin skills (includes agent-document skill bundles via
     // the `agent-skills:` identifier prefix).
-    const builtinSkill = this.builtinSkills.find((s) => s.name === name);
+    const builtinSkill = findByNameCI(this.builtinSkills, name);
     if (builtinSkill) {
       let content = builtinSkill.content;
       const hasResources = !!(

--- a/packages/database/src/models/__tests__/agentSkill.test.ts
+++ b/packages/database/src/models/__tests__/agentSkill.test.ts
@@ -336,5 +336,21 @@ describe('AgentSkillModel', () => {
       const result = await agentSkillModel.findByName('Other Skill');
       expect(result).toBeUndefined();
     });
+
+    it('matches case-insensitively so model casing drift still resolves', async () => {
+      await serverDB.insert(agentSkills).values({
+        name: 'agent-browser',
+        description: 'browser CLI',
+        identifier: 'lobe-agent-browser',
+        source: 'user',
+        manifest: createManifest(),
+        userId,
+      });
+
+      for (const query of ['agent-browser', 'Agent-Browser', 'AGENT-BROWSER']) {
+        const result = await agentSkillModel.findByName(query);
+        expect(result?.name).toBe('agent-browser');
+      }
+    });
   });
 });

--- a/packages/database/src/models/agentSkill.ts
+++ b/packages/database/src/models/agentSkill.ts
@@ -1,6 +1,6 @@
 import type { SkillItem, SkillListItem } from '@lobechat/types';
 import { merge } from '@lobechat/utils';
-import { and, desc, eq, ilike, inArray, or } from 'drizzle-orm';
+import { and, desc, eq, ilike, inArray, or, sql } from 'drizzle-orm';
 
 import type { NewAgentSkill } from '../schemas';
 import { agentSkills } from '../schemas';
@@ -82,7 +82,7 @@ export class AgentSkillModel {
     const [result] = await this.db
       .select(skillItemColumns)
       .from(agentSkills)
-      .where(and(eq(agentSkills.name, name), this.scopeWhere()))
+      .where(and(sql`lower(${agentSkills.name}) = ${name.toLowerCase()}`, this.scopeWhere()))
       .limit(1);
     return result;
   };


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Related to #14008 — that fix shipped in `017c1fcaa` but the skills runtime portion was silently reverted by the project-skill refactor (#15110).

#### 🔀 Description of Change

`activateSkill` was returning **Skill not found** for legitimate builtin skills (e.g. the model emits `agent-browser`, but the builtin registered itself as `Agent Browser`). Two compounding causes:

1. **Naming convention mismatch.** Every other skill source uses kebab-case (`.agents/skills/*/SKILL.md` frontmatter, `agentSkillManager/create` enforces lowercase-hyphen, identifiers are kebab) — but the six builtin skills were registered as Title Case (`'Agent Browser'`, `'LobeHub'`, `'Find Skills'`, …). With kebab-case dominating the injected `<available_skills>` list, the model normalized the odd-one-out builtins to kebab too. Strict `===` matching then failed.
2. **Lost case-insensitive fallback.** PR #14008 introduced `name.toLowerCase()` normalization in `SkillsExecutionRuntime`. The project-skill refactor (PR #15110) rewrote that file and dropped the normalization, restoring strict equality.

**Changes:**

- Rename the 6 builtin skill `name` fields to kebab-case so the listed `<skill name=…>` matches model output directly:
  - `Agent Browser → agent-browser`, `Artifacts → artifacts`, `Find Skills → find-skills`, `LobeHub → lobehub`, `Task → task`, `Verify → verify`
- Re-introduce case-insensitive matching as a backstop for any future drift (`AgentBrowser`, `LOBEHUB`, etc.):
  - `packages/builtin-tool-skills/src/ExecutionRuntime/index.ts` — new `findByNameCI` helper, applied to project + builtin lookups in both `activateSkill` and `readReference`
  - `packages/database/src/models/agentSkill.ts` — `findByName` now uses `sql\`lower(\${col}) = \${lower}\`` for DB-side case-insensitive equality
- Update the CLI verify mock (`apps/cli/src/commands/verify.test.ts`) to reflect the new `name: 'verify'`

**Not touched:**

- `tools.builtins.<identifier>.title` i18n strings — they index by identifier and provide human-readable Title Case display values; unaffected by the `name`-field rename.
- The parallel activator runtime (`builtin-tool-activator`, `serverRuntimes/activator.ts`) — same regression class but separate scope; can follow up if needed.
- Builtin skill `description` / `content` references to the CLI binary `agent-browser` (the tool name, not the skill name) — naturally consistent now that the skill name aligns.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

New regression coverage:

- `packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts` — 3 cases: builtin / project / readReference all match `agent-browser`, `Agent-Browser`, `AGENT-BROWSER`
- `packages/database/src/models/__tests__/agentSkill.test.ts` — `findByName` matches across casings

Runs:

- `bunx tsgo --noEmit` → exit 0
- `packages/builtin-tool-skills` `ExecutionRuntime` tests: skill-matching (12) + new case-insensitive (3) all pass
- `packages/database` `agentSkill` tests: 16/16 pass
- `apps/cli` `verify.test.ts`: 9/9 pass

#### 📝 Additional Information

The DB `findByName` SQL change uses `lower(name) = ?` without a functional index, which is fine at current scale (skills resolution is per-activation, not per-request). A functional index on `lower(name)` can be added later if it shows up in slow query logs.