### PR TITLE
fix(types): remove @ts-expect-error suppressions from production files

### DIFF
--- a/src/components/server/ServerLayout.tsx
+++ b/src/components/server/ServerLayout.tsx
@@ -1,6 +1,6 @@
-import { type FC, type PropsWithChildren, type ReactNode } from 'react';
+import type { FC, PropsWithChildren, ReactNode } from 'react';
 
-import { type DynamicLayoutProps } from '@/types/next';
+import type { DynamicLayoutProps } from '@/types/next';
 import { RouteVariants } from '@/utils/server/routeVariants';
 
 interface ServerLayoutProps<T> {
@@ -13,9 +13,8 @@ interface ServerLayoutInnerProps extends DynamicLayoutProps {
 }
 
 const ServerLayout =
-  <T extends PropsWithChildren>({ Desktop, Mobile }: ServerLayoutProps<T>): FC<T> =>
-  // @ts-expect-error
-  async (props: ServerLayoutInnerProps) => {
+  <T extends PropsWithChildren>({ Desktop, Mobile }: ServerLayoutProps<T>) =>
+  async (props: ServerLayoutInnerProps): Promise<ReactNode> => {
     const { params: paramsPromise, ...res } = props;
     if (!paramsPromise) {
       throw new Error(

--- a/src/features/NavPanel/components/BackButton.tsx
+++ b/src/features/NavPanel/components/BackButton.tsx
@@ -1,6 +1,7 @@
-import { type ActionIconProps } from '@lobehub/ui';
+import type { ActionIconProps } from '@lobehub/ui';
 import { ActionIcon } from '@lobehub/ui';
 import { ChevronLeftIcon } from 'lucide-react';
+import type { MouseEventHandler } from 'react';
 import { memo } from 'react';
 import { Link } from 'react-router';
 
@@ -10,12 +11,16 @@ import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath
 
 export const BACK_BUTTON_ID = 'lobe-back-button';
 
-const BackButton = memo<ActionIconProps & { to?: string }>(({ to = '/', onClick, ...rest }) => {
+interface BackButtonProps extends Omit<ActionIconProps, 'onClick'> {
+  onClick?: MouseEventHandler<HTMLAnchorElement>;
+  to?: string;
+}
+
+const BackButton = memo<BackButtonProps>(({ to = '/', onClick, ...rest }) => {
   const activeSlug = useActiveWorkspaceSlug();
   const resolvedTo = buildWorkspaceAwarePath(to, activeSlug);
 
   return (
-    // @ts-expect-error
     <Link to={resolvedTo} onClick={onClick}>
       <ActionIcon
         icon={ChevronLeftIcon}

--- a/src/libs/better-auth/sso/index.ts
+++ b/src/libs/better-auth/sso/index.ts
@@ -1,5 +1,5 @@
-import { type GenericOAuthConfig } from 'better-auth/plugins';
-import { type SocialProviders } from 'better-auth/social-providers';
+import type { GenericOAuthConfig } from 'better-auth/plugins';
+import type { SocialProviders } from 'better-auth/social-providers';
 
 import { appEnv } from '@/envs/app';
 import { authEnv } from '@/envs/auth';
@@ -23,6 +23,7 @@ import Microsoft from './providers/microsoft';
 import Okta from './providers/okta';
 import Wechat from './providers/wechat';
 import Zitadel from './providers/zitadel';
+import type { BuiltinProviderDefinition, GenericProviderDefinition } from './types';
 
 const providerDefinitions = [
   Apple,
@@ -43,6 +44,39 @@ const providerDefinitions = [
   Feishu,
   Wechat,
 ] as const;
+
+/**
+ * Binds the env (E) and config (R) type parameters within a single call so that
+ * `build(checkEnvs())` type-checks. The provider registry stores a union of provider
+ * definitions whose `build`/`checkEnvs` are only correlated within a single member, so
+ * resolving them through this helper keeps the call site fully typed without suppressions.
+ */
+const resolveProviderConfig = <E extends Record<string, string | undefined>, R>(
+  definition: { build: (env: E) => R; checkEnvs: () => E | false },
+  rawProvider: string,
+): R => {
+  /**
+   * Providers expose checkEnvs predicates so we can fail fast when credentials are missing instead
+   * of encountering harder-to-trace errors later in the Better-Auth pipeline.
+   */
+  const env = definition.checkEnvs();
+  if (!env) {
+    throw new Error(
+      `[Better-Auth] ${rawProvider} SSO provider environment variables are not set correctly!`,
+    );
+  }
+
+  return definition.build(env);
+};
+
+/** Binds the provider id to its matching config type so the indexed write is type-safe. */
+const assignSocialProvider = <Id extends keyof SocialProviders>(
+  providers: SocialProviders,
+  id: Id,
+  config: SocialProviders[Id],
+): void => {
+  providers[id] = config;
+};
 
 const builtInProviderIds = new Set(BUILTIN_BETTER_AUTH_PROVIDERS);
 
@@ -74,40 +108,34 @@ export const initBetterAuthSSOProviders = () => {
       throw new Error(`[Better-Auth] Unknown SSO provider: ${rawProvider}`);
     }
 
-    /**
-     * Providers expose checkEnvs predicates so we can fail fast when credentials are missing instead
-     * of encountering harder-to-trace errors later in the Better-Auth pipeline.
-     */
-    const env = definition.checkEnvs();
-    if (!env) {
-      throw new Error(
-        `[Better-Auth] ${rawProvider} SSO provider environment variables are not set correctly!`,
-      );
-    }
-
     if (definition.type === 'builtin') {
-      const providerId = definition.id;
+      // The registry stores the union of specific provider definitions; narrow to the base
+      // shape so `build`/`checkEnvs` share a single env type and resolve through the helper.
+      const builtinDefinition = definition as unknown as BuiltinProviderDefinition<
+        Record<string, string | undefined>
+      >;
+      const providerId = builtinDefinition.id;
       if (socialProviders[providerId]) {
         throw new Error(`[Better-Auth] Duplicate SSO provider: ${providerId}`);
       }
 
-      // @ts-expect-error - build expects specific env type, but we use union definition type
-      const config = definition.build(env);
+      const config = resolveProviderConfig(builtinDefinition, rawProvider);
       if (config) {
-        // @ts-expect-error hard to type
-        socialProviders[providerId] = config;
+        assignSocialProvider(socialProviders, providerId, config);
       }
 
       continue;
     }
 
-    // @ts-expect-error - build expects specific env type, but we use union definition type
-    const config = definition.build(env);
+    const genericDefinition = definition as unknown as GenericProviderDefinition<
+      Record<string, string | undefined>
+    >;
+    const config = resolveProviderConfig(genericDefinition, rawProvider);
 
     if (config) {
       // the generic oidc callback url is /api/auth/oauth2/callback/{providerId}
       // different from builtin providers' /api/auth/callback/{providerId}
-      config.redirectURI = `${appEnv.APP_URL}/api/auth/callback/${definition.id}`;
+      config.redirectURI = `${appEnv.APP_URL}/api/auth/callback/${genericDefinition.id}`;
       genericOAuthProviders.push(config);
     }
   }


### PR DESCRIPTION
Replace @ts-expect-error suppressions that had leaked into production code with proper typings (closes #16444):

- ServerLayout: type the async server component as `(props) => Promise<ReactNode>` instead of forcing it through `FC<T>`
- BackButton: re-type `onClick` as `MouseEventHandler<HTMLAnchorElement>` via a dedicated props interface so it matches react-router `<Link>`
- better-auth/sso: resolve provider build/checkEnvs through generic helpers (resolveProviderConfig, assignSocialProvider) and narrow the stored union to the base provider interface, keeping runtime behavior identical

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

https://github.com/lobehub/lobehub/issues/16444

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

Fixed #16444

#### 🔀 Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

- bun run type-check — 0 errors project-wide
- Grep guard — no ts-expect-error / ts-ignore / any remain in the three files
- Targeted tests — google.test.ts + define-config.test.ts: 4 passed
- ESLint on all three files — clean (import ordering correct)