### PR TITLE
🐛 fix(chat): scope input history by user and agent

### DIFF
--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -31,6 +31,7 @@ import {
   labPreferSelectors,
   settingsSelectors,
   systemAgentSelectors,
+  userProfileSelectors,
 } from '@/store/user/selectors';
 
 import { useAgentId } from '../hooks/useAgentId';
@@ -94,7 +95,10 @@ const InputEditor = memo<{
   const state = useEditorState(editor);
   const { allowed: canCreateContent } = usePermission('create_content');
   const hotkey = useUserStore(settingsSelectors.getHotkeyById(HotkeyEnum.AddUserMessage));
+  const userId = useUserStore(userProfileSelectors.userId);
   const { enableScope, disableScope } = useHotkeysContext();
+  const agentId = useAgentId();
+  const inputHistoryScope = useMemo(() => ({ agentId, userId }), [agentId, userId]);
 
   const { compositionProps, isComposingRef } = useIMECompositionEvent();
 
@@ -108,13 +112,13 @@ const InputEditor = memo<{
     enabled: isInputHistoryEnabled,
     getMarkdownContent,
     isComposingRef,
+    scope: inputHistoryScope,
   });
 
   // --- Category-based mention system ---
   const categories = useMentionCategories();
 
   // Get agent's model info for vision support check and handle paste upload
-  const agentId = useAgentId();
   const model = useAgentStore((s) => agentByIdSelectors.getAgentModelById(agentId)(s));
   const provider = useAgentStore((s) => agentByIdSelectors.getAgentModelProviderById(agentId)(s));
   const heterogeneousType = useAgentStore(

--- a/src/features/ChatInput/hooks/useChatInputHistory.test.ts
+++ b/src/features/ChatInput/hooks/useChatInputHistory.test.ts
@@ -193,6 +193,39 @@ describe('useChatInputHistory', () => {
     expect(editor.focus).toHaveBeenCalledTimes(2);
   });
 
+  it('reads history from the current scope only', () => {
+    addInputHistory({ agentId: 'agent-1', markdown: 'scoped prompt', userId: 'user-a' });
+    addInputHistory({ agentId: 'agent-2', markdown: 'other agent prompt', userId: 'user-a' });
+
+    const editor = {
+      cleanDocument: vi.fn(),
+      focus: vi.fn(),
+      setDocument: vi.fn(),
+    } as unknown as IEditor;
+    const isComposingRef = { current: false };
+
+    const { result } = renderHook(() =>
+      useChatInputHistory({
+        editor,
+        enabled: true,
+        getMarkdownContent: () => '',
+        isComposingRef,
+        scope: { agentId: 'agent-1', userId: 'user-a' },
+      }),
+    );
+
+    act(() => {
+      result.current.handleKeyDown(createKeyDownEvent('ArrowUp'));
+    });
+
+    expect(editor.setDocument).toHaveBeenCalledWith('markdown', 'scoped prompt', {
+      keepHistory: true,
+    });
+    expect(editor.setDocument).not.toHaveBeenCalledWith('markdown', 'other agent prompt', {
+      keepHistory: true,
+    });
+  });
+
   it('falls back to markdown when saved JSON cannot be restored', () => {
     const incompatibleEditorData = { root: { children: [{ text: 'item', type: 'list' }] } };
     addInputHistory({ json: incompatibleEditorData, markdown: '- fallback prompt' });

--- a/src/features/ChatInput/hooks/useChatInputHistory.ts
+++ b/src/features/ChatInput/hooks/useChatInputHistory.ts
@@ -1,8 +1,8 @@
 import type { IEditor } from '@lobehub/editor';
 import type { RefObject } from 'react';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
-import type { ChatInputHistoryEntry } from '../inputHistoryStorage';
+import type { ChatInputHistoryEntry, ChatInputHistoryScope } from '../inputHistoryStorage';
 import { getInputHistory } from '../inputHistoryStorage';
 
 interface InputHistoryNavigatorOptions {
@@ -100,9 +100,8 @@ interface UseChatInputHistoryOptions {
   enabled: boolean;
   getMarkdownContent: () => string;
   isComposingRef: RefObject<boolean>;
+  scope?: ChatInputHistoryScope;
 }
-
-const HISTORY_SET_DOCUMENT_OPTIONS = { keepHistory: true };
 
 const focusEditorAfterHistoryNavigation = (editor: IEditor, onFocusRestored: () => void) => {
   requestAnimationFrame(() => {
@@ -115,16 +114,16 @@ const focusEditorAfterHistoryNavigation = (editor: IEditor, onFocusRestored: () 
 
 const restoreHistoryEntryDocument = (editor: IEditor, entry: ChatInputHistoryEntry) => {
   if (!entry.json) {
-    editor.setDocument('markdown', entry.markdown, HISTORY_SET_DOCUMENT_OPTIONS);
+    editor.setDocument('markdown', entry.markdown, { keepHistory: true });
     return;
   }
 
   try {
-    editor.setDocument('json', entry.json, HISTORY_SET_DOCUMENT_OPTIONS);
+    editor.setDocument('json', entry.json, { keepHistory: true });
   } catch {
     // Example: a rich-input list/code node can fail after rich input is disabled;
     // markdown stays portable across different chat input plugin sets.
-    editor.setDocument('markdown', entry.markdown, HISTORY_SET_DOCUMENT_OPTIONS);
+    editor.setDocument('markdown', entry.markdown, { keepHistory: true });
   }
 };
 
@@ -133,8 +132,8 @@ export const useChatInputHistory = ({
   enabled,
   getMarkdownContent,
   isComposingRef,
+  scope,
 }: UseChatInputHistoryOptions) => {
-  const navigatorRef = useRef<InputHistoryNavigator | null>(null);
   const skipNextBlurResetRef = useRef(false);
   const skipNextChangeResetRef = useRef(false);
 
@@ -168,26 +167,18 @@ export const useChatInputHistory = ({
     });
   }, [runHistoryDocumentMutation]);
 
-  const getNavigator = useCallback(() => {
-    if (!navigatorRef.current) {
-      navigatorRef.current = createInputHistoryNavigator({
-        applyEntry: restoreEntry,
-        clearInput,
-        getEntries: getInputHistory,
-        getMarkdownContent,
-      });
-    }
-
-    return navigatorRef.current;
-  }, [clearInput, getMarkdownContent, restoreEntry]);
-
-  useEffect(() => {
-    navigatorRef.current = null;
-  }, [getNavigator]);
+  const navigator = useMemo(() => {
+    return createInputHistoryNavigator({
+      applyEntry: restoreEntry,
+      clearInput,
+      getEntries: () => getInputHistory(scope),
+      getMarkdownContent,
+    });
+  }, [clearInput, getMarkdownContent, restoreEntry, scope]);
 
   const reset = useCallback(() => {
-    navigatorRef.current?.reset();
-  }, []);
+    navigator.reset();
+  }, [navigator]);
 
   const handleEditorBlur = useCallback(() => {
     if (skipNextBlurResetRef.current) {
@@ -215,9 +206,9 @@ export const useChatInputHistory = ({
 
       if (shouldIgnoreInputHistoryKeyDown(event, isComposingRef.current)) return false;
 
-      return getNavigator().handleKeyDown(event);
+      return navigator.handleKeyDown(event);
     },
-    [editor, enabled, getNavigator, isComposingRef],
+    [editor, enabled, isComposingRef, navigator],
   );
 
   return {

--- a/src/features/ChatInput/inputHistoryStorage.test.ts
+++ b/src/features/ChatInput/inputHistoryStorage.test.ts
@@ -4,6 +4,7 @@ import {
   addInputHistory,
   CHAT_INPUT_HISTORY_STORAGE_KEY,
   getInputHistory,
+  getInputHistoryStorageKey,
 } from './inputHistoryStorage';
 
 describe('inputHistoryStorage', () => {
@@ -37,8 +38,29 @@ describe('inputHistoryStorage', () => {
   it('ignores empty markdown', () => {
     addInputHistory({ markdown: '   ' });
 
-    expect(localStorage.getItem(CHAT_INPUT_HISTORY_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(getInputHistoryStorageKey())).toBeNull();
     expect(getInputHistory()).toEqual([]);
+  });
+
+  it('isolates history by user and agent', () => {
+    vi.spyOn(Date, 'now')
+      .mockReturnValueOnce(1000)
+      .mockReturnValueOnce(2000)
+      .mockReturnValueOnce(3000);
+
+    addInputHistory({ agentId: 'agent-1', markdown: 'user A prompt', userId: 'user-a' });
+    addInputHistory({ agentId: 'agent-1', markdown: 'user B prompt', userId: 'user-b' });
+    addInputHistory({ agentId: 'agent-2', markdown: 'user A agent 2 prompt', userId: 'user-a' });
+
+    expect(getInputHistory({ agentId: 'agent-1', userId: 'user-a' })).toEqual([
+      { createdAt: 1000, markdown: 'user A prompt' },
+    ]);
+    expect(getInputHistory({ agentId: 'agent-1', userId: 'user-b' })).toEqual([
+      { createdAt: 2000, markdown: 'user B prompt' },
+    ]);
+    expect(getInputHistory({ agentId: 'agent-2', userId: 'user-a' })).toEqual([
+      { createdAt: 3000, markdown: 'user A agent 2 prompt' },
+    ]);
   });
 
   it('deduplicates by trimmed markdown and keeps the latest editor state', () => {
@@ -68,7 +90,7 @@ describe('inputHistoryStorage', () => {
   });
 
   it('treats corrupt storage as empty and recovers on next write', () => {
-    localStorage.setItem(CHAT_INPUT_HISTORY_STORAGE_KEY, '{not json');
+    localStorage.setItem(getInputHistoryStorageKey(), '{not json');
 
     expect(getInputHistory()).toEqual([]);
 
@@ -79,7 +101,7 @@ describe('inputHistoryStorage', () => {
 
   it('drops malformed entries when reading', () => {
     localStorage.setItem(
-      CHAT_INPUT_HISTORY_STORAGE_KEY,
+      getInputHistoryStorageKey(),
       JSON.stringify([
         { createdAt: 1, markdown: 'good prompt' },
         { createdAt: 2, markdown: '   ' },
@@ -88,5 +110,18 @@ describe('inputHistoryStorage', () => {
     );
 
     expect(getInputHistory()).toEqual([{ createdAt: 1, markdown: 'good prompt' }]);
+  });
+
+  it('drops the legacy global key instead of reading it', () => {
+    const legacyStorageKey = 'lobechat:chat-input-history:v1';
+
+    localStorage.setItem(
+      legacyStorageKey,
+      JSON.stringify([{ createdAt: 1, markdown: 'legacy prompt' }]),
+    );
+
+    expect(getInputHistory({ agentId: 'agent-1', userId: 'user-a' })).toEqual([]);
+    expect(localStorage.getItem(legacyStorageKey)).toBeNull();
+    expect(localStorage.getItem(CHAT_INPUT_HISTORY_STORAGE_KEY)).toBeNull();
   });
 });

--- a/src/features/ChatInput/inputHistoryStorage.ts
+++ b/src/features/ChatInput/inputHistoryStorage.ts
@@ -1,7 +1,7 @@
 import type { UnknownRecord } from '@lobechat/utils/object';
 import { isRecord } from '@lobechat/utils/object';
 
-export const CHAT_INPUT_HISTORY_STORAGE_KEY = 'lobechat:chat-input-history:v1';
+export const CHAT_INPUT_HISTORY_STORAGE_KEY = 'lobechat:chat-input-history:v2';
 
 export const MAX_INPUT_HISTORY_ITEMS = 50;
 
@@ -11,10 +11,34 @@ export interface ChatInputHistoryEntry {
   markdown: string;
 }
 
-interface AddInputHistoryParams {
+export interface ChatInputHistoryScope {
+  agentId?: string;
+  userId?: string;
+}
+
+interface AddInputHistoryParams extends ChatInputHistoryScope {
   json?: UnknownRecord;
   markdown: string;
 }
+
+const ANONYMOUS_INPUT_HISTORY_SCOPE = 'anonymous';
+const GLOBAL_AGENT_INPUT_HISTORY_SCOPE = 'global';
+const LEGACY_GLOBAL_INPUT_HISTORY_STORAGE_KEY = 'lobechat:chat-input-history:v1';
+
+/**
+ * Example: user A's prompt must not appear when user B opens another agent and presses ArrowUp.
+ */
+export const getInputHistoryStorageKey = ({
+  agentId,
+  userId,
+}: ChatInputHistoryScope = {}): string =>
+  [
+    CHAT_INPUT_HISTORY_STORAGE_KEY,
+    'user',
+    encodeURIComponent(userId || ANONYMOUS_INPUT_HISTORY_SCOPE),
+    'agent',
+    encodeURIComponent(agentId || GLOBAL_AGENT_INPUT_HISTORY_SCOPE),
+  ].join(':');
 
 const isHistoryEntry = (value: unknown): value is ChatInputHistoryEntry => {
   if (!isRecord(value)) return false;
@@ -29,11 +53,21 @@ const isHistoryEntry = (value: unknown): value is ChatInputHistoryEntry => {
   );
 };
 
-const readAll = (): ChatInputHistoryEntry[] => {
+const removeLegacyGlobalHistory = () => {
+  try {
+    window.localStorage.removeItem(LEGACY_GLOBAL_INPUT_HISTORY_STORAGE_KEY);
+  } catch {
+    // Ignore storage failures; scoped history should still work when possible.
+  }
+};
+
+const readAll = (scope?: ChatInputHistoryScope): ChatInputHistoryEntry[] => {
   if (typeof window === 'undefined') return [];
 
+  removeLegacyGlobalHistory();
+
   try {
-    const raw = window.localStorage.getItem(CHAT_INPUT_HISTORY_STORAGE_KEY);
+    const raw = window.localStorage.getItem(getInputHistoryStorageKey(scope));
     if (!raw) return [];
 
     const parsed = JSON.parse(raw);
@@ -45,23 +79,32 @@ const readAll = (): ChatInputHistoryEntry[] => {
   }
 };
 
-const writeAll = (items: ChatInputHistoryEntry[]): boolean => {
+const writeAll = (items: ChatInputHistoryEntry[], scope?: ChatInputHistoryScope): boolean => {
   if (typeof window === 'undefined') return false;
 
+  removeLegacyGlobalHistory();
+
   try {
-    window.localStorage.setItem(CHAT_INPUT_HISTORY_STORAGE_KEY, JSON.stringify(items));
+    window.localStorage.setItem(getInputHistoryStorageKey(scope), JSON.stringify(items));
     return true;
   } catch {
     return false;
   }
 };
 
-export const getInputHistory = (): ChatInputHistoryEntry[] => readAll();
+export const getInputHistory = (scope?: ChatInputHistoryScope): ChatInputHistoryEntry[] =>
+  readAll(scope);
 
-export const addInputHistory = ({ json, markdown }: AddInputHistoryParams): void => {
+export const addInputHistory = ({
+  agentId,
+  json,
+  markdown,
+  userId,
+}: AddInputHistoryParams): void => {
   const normalizedMarkdown = markdown.trim();
   if (!normalizedMarkdown) return;
 
+  const scope = { agentId, userId };
   const createdAt = Date.now();
   const nextEntry: ChatInputHistoryEntry = {
     createdAt,
@@ -69,7 +112,7 @@ export const addInputHistory = ({ json, markdown }: AddInputHistoryParams): void
     ...(json ? { json } : {}),
   };
 
-  const dedupedItems = readAll().filter((item) => item.markdown.trim() !== normalizedMarkdown);
+  const dedupedItems = readAll(scope).filter((item) => item.markdown.trim() !== normalizedMarkdown);
 
-  writeAll([nextEntry, ...dedupedItems].slice(0, MAX_INPUT_HISTORY_ITEMS));
+  writeAll([nextEntry, ...dedupedItems].slice(0, MAX_INPUT_HISTORY_ITEMS), scope);
 };

--- a/src/features/ChatInput/store/action.test.ts
+++ b/src/features/ChatInput/store/action.test.ts
@@ -32,6 +32,7 @@ describe('ChatInput store actions', () => {
       getDocument: vi.fn((type: string) => (type === 'markdown' ? 'Hello' : editorData)),
     };
     const store = createStore({
+      agentId: 'agent-1',
       editor: editor as unknown as IEditor,
       onSend: ({ clearContent }) => {
         clearContent();
@@ -40,7 +41,7 @@ describe('ChatInput store actions', () => {
 
     store.getState().handleSendButton();
 
-    expect(getInputHistory()[0]).toMatchObject({
+    expect(getInputHistory({ agentId: 'agent-1' })[0]).toMatchObject({
       json: editorData,
       markdown: 'Hello',
     });
@@ -61,6 +62,7 @@ describe('ChatInput store actions', () => {
     store.getState().handleSendButton();
 
     expect(getInputHistory()).toEqual([]);
+    expect(editor.getDocument).not.toHaveBeenCalled();
   });
 
   it('does not record history when no send handler is configured', () => {

--- a/src/features/ChatInput/store/action.test.ts
+++ b/src/features/ChatInput/store/action.test.ts
@@ -1,12 +1,15 @@
 import type { IEditor } from '@lobehub/editor';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useAgentStore } from '@/store/agent';
+
 import { getInputHistory } from '../inputHistoryStorage';
 import { createStore, selectors } from '.';
 
 describe('ChatInput store actions', () => {
   beforeEach(() => {
     localStorage.clear();
+    useAgentStore.setState({ activeAgentId: undefined });
     vi.restoreAllMocks();
   });
 
@@ -45,6 +48,29 @@ describe('ChatInput store actions', () => {
       json: editorData,
       markdown: 'Hello',
     });
+  });
+
+  it('records sent input in the active agent history when no agent id is provided', () => {
+    useAgentStore.setState({ activeAgentId: 'active-agent' });
+
+    const editorData = { root: { children: [{ text: 'Hello' }] } };
+    const editor = {
+      cleanDocument: vi.fn(),
+      focus: vi.fn(),
+      getDocument: vi.fn((type: string) => (type === 'markdown' ? 'Hello' : editorData)),
+    };
+    const store = createStore({
+      editor: editor as unknown as IEditor,
+      onSend: vi.fn(),
+    });
+
+    store.getState().handleSendButton();
+
+    expect(getInputHistory({ agentId: 'active-agent' })[0]).toMatchObject({
+      json: editorData,
+      markdown: 'Hello',
+    });
+    expect(getInputHistory()).toEqual([]);
   });
 
   it('does not record history when the input history feature is disabled', () => {

--- a/src/features/ChatInput/store/action.ts
+++ b/src/features/ChatInput/store/action.ts
@@ -1,5 +1,8 @@
 import { type StateCreator } from 'zustand/vanilla';
 
+import { useUserStore } from '@/store/user';
+import { userProfileSelectors } from '@/store/user/selectors';
+
 import { removeDraft } from '../draftStorage';
 import { addInputHistory } from '../inputHistoryStorage';
 import { type PublicState, type State } from './initialState';
@@ -50,8 +53,15 @@ export const store: CreateStore = (publicState) => (set, get) => ({
     if (get().sendButtonProps?.disabled) return;
 
     const onSend = get().onSend;
-    const markdown = get().getMarkdownContent();
-    const json = get().getJSONState();
+    const historyEnabled = !!onSend && (get().feature?.inputHistory ?? true);
+    const historySnapshot = historyEnabled
+      ? {
+          agentId: get().agentId,
+          json: get().getJSONState(),
+          markdown: get().getMarkdownContent(),
+          userId: userProfileSelectors.userId(useUserStore.getState()),
+        }
+      : undefined;
 
     onSend?.({
       clearContent: () => editor?.cleanDocument(),
@@ -60,8 +70,8 @@ export const store: CreateStore = (publicState) => (set, get) => ({
       getMarkdownContent: get().getMarkdownContent,
     });
 
-    if (onSend && (get().feature?.inputHistory ?? true)) {
-      addInputHistory({ json, markdown });
+    if (historySnapshot) {
+      addInputHistory(historySnapshot);
     }
 
     const { draftKey } = get();

--- a/src/features/ChatInput/store/action.ts
+++ b/src/features/ChatInput/store/action.ts
@@ -1,5 +1,6 @@
 import { type StateCreator } from 'zustand/vanilla';
 
+import { useAgentStore } from '@/store/agent';
 import { useUserStore } from '@/store/user';
 import { userProfileSelectors } from '@/store/user/selectors';
 
@@ -29,6 +30,12 @@ type CreateStore = (
   initState?: Partial<PublicState>,
 ) => StateCreator<Store, [['zustand/devtools', never]]>;
 
+const getEffectiveAgentId = (agentId?: string): string => {
+  // Example: a ChatInput without an agentId prop reads history from activeAgentId,
+  // so sending must write history to the same scope.
+  return agentId !== undefined ? agentId : useAgentStore.getState().activeAgentId || '';
+};
+
 export const store: CreateStore = (publicState) => (set, get) => ({
   ...initialState,
   ...publicState,
@@ -56,7 +63,7 @@ export const store: CreateStore = (publicState) => (set, get) => ({
     const historyEnabled = !!onSend && (get().feature?.inputHistory ?? true);
     const historySnapshot = historyEnabled
       ? {
-          agentId: get().agentId,
+          agentId: getEffectiveAgentId(get().agentId),
           json: get().getJSONState(),
           markdown: get().getMarkdownContent(),
           userId: userProfileSelectors.userId(useUserStore.getState()),


### PR DESCRIPTION
# Pull Request

## 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

## 🔗 Related Links

- Linear / GitHub issue: https://linear.app/lobehub/issue/LOBE-10819/聊天输入框按上方向键能输入之前的输入
- Related PRs: N/A
- Reference docs / code / articles: N/A

## 🔀 Description of Change

Scope chat input history by user and agent so prompt history restored with ArrowUp is not shared across accounts or agents in the same browser profile.

This also drops the legacy global history key when the scoped history storage is accessed, rebuilds the input history navigator synchronously when its dependencies change, and skips editor markdown/JSON serialization when input history is disabled.

## 🧭 Key Decisions / Non-goals

- The legacy `lobechat:chat-input-history:v1` global history is not migrated. It is removed instead, because migrating it into any scoped bucket could expose prompts from a previous user or agent.
- The new storage key scopes by `userId` and `agentId`, with anonymous/global fallbacks for contexts where those values are unavailable.
- This remains an open-source ChatInput fix only; no cloud-specific business logic is introduced.

## 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

### Automated Tests

- `cd lobehub && rtk vitest run src/features/ChatInput/inputHistoryStorage.test.ts src/features/ChatInput/hooks/useChatInputHistory.test.ts src/features/ChatInput/store/action.test.ts`
- `vscode-cli get-diagnostics`

### Manual Verification

- Send a prompt in Agent A, clear the input, and press ArrowUp; the prompt should restore.
- Switch to Agent B and press ArrowUp in an empty input; Agent A's prompt should not appear.
- Switch accounts in the same browser profile and press ArrowUp; the previous account's prompt should not appear.
- Confirm the legacy `lobechat:chat-input-history:v1` key is removed after history is read or written.

### Post-Deploy Verification

- Smoke-test ArrowUp/ArrowDown input history navigation in two different agents and, if available, two different accounts in the same browser profile.

## 📸 Screenshots / Videos

N/A

## 🚀 Rollout / Deployment Checklist

- [x] Environment variables: N/A
- [x] Redis / Edge Config / feature flags: N/A
- [x] Database migration or data backfill: N/A
- [x] Third-party console changes: N/A
- [x] Rollback plan: revert this PR; scoped history data is client-side localStorage only.

## 📝 Additional Information

N/A