### PR TITLE
♻️ refactor: migrate editor styles to createStaticStyles

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -399,11 +399,6 @@
       "count": 1
     }
   },
-  "src/features/Conversation/Messages/Verify/index.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/features/Conversation/Messages/components/Extras/TTS/Player.tsx": {
     "no-restricted-imports": {
       "count": 1
@@ -485,11 +480,6 @@
     }
   },
   "src/features/DocumentModal/index.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/features/EditorCanvas/LinearFilePlugin.tsx": {
     "no-restricted-imports": {
       "count": 1
     }
@@ -690,11 +680,6 @@
     }
   },
   "src/features/PageEditor/History/index.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/features/PageEditor/PageEditor.tsx": {
     "no-restricted-imports": {
       "count": 1
     }

--- a/src/features/Conversation/Messages/Verify/index.tsx
+++ b/src/features/Conversation/Messages/Verify/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { createStyles } from 'antd-style';
+import { createStaticStyles, useTheme } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { memo } from 'react';
 
@@ -11,12 +11,12 @@ import { phaseCardBackground, phaseFromStatus } from '@/features/Verify/utils';
 
 import { dataSelectors, useConversationStore } from '../../store';
 
-const useStyles = createStyles(({ css, token }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   card: css`
     overflow: hidden;
-    border: 1px solid ${token.colorBorderSecondary};
+    border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: 16px;
-    background: ${token.colorBgElevated};
+    background: ${cssVar.colorBgElevated};
   `,
 }));
 
@@ -33,7 +33,7 @@ interface VerifyMessageProps {
  * group (no avatar bubble).
  */
 const VerifyMessage = memo<VerifyMessageProps>(({ id }) => {
-  const { styles, theme } = useStyles();
+  const theme = useTheme();
   const item = useConversationStore(dataSelectors.getDisplayMessageById(id), isEqual);
   const operationId = item?.metadata?.verifyOperationId;
   // Sequence number among all verify messages in the thread (not the repair round).

--- a/src/features/EditorCanvas/LinearFilePlugin.tsx
+++ b/src/features/EditorCanvas/LinearFilePlugin.tsx
@@ -3,7 +3,7 @@
 import { downloadFile } from '@lobechat/utils/client';
 import { FilePlugin, UploadPlugin, useLexicalComposerContext } from '@lobehub/editor';
 import { ActionIcon } from '@lobehub/ui';
-import { createStyles } from 'antd-style';
+import { createStaticStyles } from 'antd-style';
 import { DownloadIcon } from 'lucide-react';
 import { type FC, memo, useLayoutEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import FileIcon from '@/components/FileIcon';
 import { formatSize } from '@/utils/format';
 
-const useStyles = createStyles(({ css, cssVar, token }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   card: css`
     cursor: pointer;
 
@@ -23,17 +23,17 @@ const useStyles = createStyles(({ css, cssVar, token }) => ({
     width: 100%;
     padding-block: 10px;
     padding-inline: 12px;
-    border: 1px solid ${token.colorBorderSecondary};
-    border-radius: ${token.borderRadiusLG}px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusLG};
 
-    color: ${token.colorText};
+    color: ${cssVar.colorText};
 
-    background: ${token.colorBgContainer};
+    background: ${cssVar.colorBgContainer};
 
     transition: background ${cssVar.motionDurationMid};
 
     &:hover {
-      background: ${token.colorFillTertiary};
+      background: ${cssVar.colorFillTertiary};
     }
 
     &:hover [data-lobehub-file-download] {
@@ -53,18 +53,18 @@ const useStyles = createStyles(({ css, cssVar, token }) => ({
   name: css`
     overflow: hidden;
 
-    font-size: ${token.fontSize}px;
+    font-size: ${cssVar.fontSize};
     font-weight: 500;
     line-height: 1.4;
-    color: ${token.colorText};
+    color: ${cssVar.colorText};
     text-overflow: ellipsis;
     white-space: nowrap;
   `,
   size: css`
     margin-block-start: 2px;
-    font-size: ${token.fontSizeSM}px;
+    font-size: ${cssVar.fontSizeSM};
     line-height: 1.4;
-    color: ${token.colorTextTertiary};
+    color: ${cssVar.colorTextTertiary};
   `,
   state: css`
     display: flex;
@@ -73,12 +73,12 @@ const useStyles = createStyles(({ css, cssVar, token }) => ({
 
     padding-block: 10px;
     padding-inline: 12px;
-    border: 1px solid ${token.colorBorderSecondary};
-    border-radius: ${token.borderRadiusLG}px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusLG};
 
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
 
-    background: ${token.colorBgContainer};
+    background: ${cssVar.colorBgContainer};
   `,
 }));
 
@@ -95,7 +95,6 @@ interface LinearFileCardProps {
 }
 
 export const LinearFileCard = memo<LinearFileCardProps>(({ node }) => {
-  const { styles } = useStyles();
   const { t } = useTranslation('editor');
 
   const { fileUrl, message, name, size, status } = node;

--- a/src/features/PageEditor/PageEditor.tsx
+++ b/src/features/PageEditor/PageEditor.tsx
@@ -2,7 +2,7 @@
 
 import { DEFAULT_BLOCK_ANCHOR_PADDING, EditorProvider } from '@lobehub/editor/react';
 import { Flexbox } from '@lobehub/ui';
-import { createStyles, cssVar } from 'antd-style';
+import { createStaticStyles, cssVar } from 'antd-style';
 import type { CSSProperties, FC, ReactNode, UIEvent } from 'react';
 import { memo, useCallback, useEffect, useRef } from 'react';
 
@@ -81,7 +81,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const useTableOverrideStyles = createStyles(({ css }) => ({
+const tableOverrideStyles = createStaticStyles(({ css }) => ({
   editorContent: css`
     .lobe-editor-table-scroll-wrapper.lobe-editor-table-scroll-wrapper {
       --lobe-block-anchor-padding: var(--lobe-pageeditor-table-bleed-inline);
@@ -149,7 +149,6 @@ const PageEditorCanvas = memo<PageEditorCanvasProps>(({ header, fullWidthHeader,
   const editor = usePageEditorStore((s) => s.editor);
   const documentId = usePageEditorStore((s) => s.documentId);
   const wideScreen = useGlobalStore(systemStatusSelectors.wideScreen);
-  const { styles: overrideStyles } = useTableOverrideStyles();
   const tableBleedInline = wideScreen
     ? `${TABLE_BASE_BLEED}px`
     : `calc(${TABLE_BASE_BLEED}px + max((100cqi - ${CONVERSATION_MIN_WIDTH}px) / 2, 0px))`;
@@ -301,7 +300,11 @@ const PageEditorCanvas = memo<PageEditorCanvasProps>(({ header, fullWidthHeader,
             editor?.focus();
           }}
         >
-          <Flexbox className={overrideStyles.editorContent} flex={1} style={editorContentStyle}>
+          <Flexbox
+            className={tableOverrideStyles.editorContent}
+            flex={1}
+            style={editorContentStyle}
+          >
             <TitleSection />
             <PageMetaBar />
             {/* Surfaces local heartbeat health (unstable/lost) for the holder.


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #16440

#### 🔀 Description of Change

- Migrates the three editor-related `createStyles` call sites named in #16440 to `createStaticStyles`.
- Replaces static Ant Design token reads with `cssVar.*` so the generated CSS can be computed once at module load.
- Keeps the remaining runtime theme read in the verify message card via `useTheme()` because `phaseCardBackground(phase, theme)` still depends on the active theme object.
- Removes the matching `no-restricted-imports` suppression entries for the migrated files.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validation run locally:

```bash
python3 - <<'PY'
from pathlib import Path
files = [
  'src/features/Conversation/Messages/Verify/index.tsx',
  'src/features/EditorCanvas/LinearFilePlugin.tsx',
  'src/features/PageEditor/PageEditor.tsx',
]
supp = Path('eslint-suppressions.json').read_text()
for f in files:
    text = Path(f).read_text()
    assert 'createStyles' not in text
    assert 'createStaticStyles' in text
    assert f not in supp
print('source probe PASS')
PY
```

```bash
pnpm exec prettier --check src/features/Conversation/Messages/Verify/index.tsx src/features/EditorCanvas/LinearFilePlugin.tsx src/features/PageEditor/PageEditor.tsx eslint-suppressions.json
pnpm exec eslint src/features/Conversation/Messages/Verify/index.tsx src/features/EditorCanvas/LinearFilePlugin.tsx src/features/PageEditor/PageEditor.tsx --quiet
pnpm exec stylelint src/features/Conversation/Messages/Verify/index.tsx src/features/EditorCanvas/LinearFilePlugin.tsx src/features/PageEditor/PageEditor.tsx
pnpm exec tsx -e "import { createStaticStyles, useTheme, cssVar } from 'antd-style'; console.log(typeof createStaticStyles, typeof useTheme, typeof cssVar.borderRadiusLG, cssVar.fontSize)"
git diff --check
```

Type-check note:

- `bun run type-check` did not finish within 600s in this local checkout.
- A focused temp `tsgo` config over the changed entry files exits before checking the files because this checkout reports `error TS2688: Cannot find type definition file for 'vitest/globals'` from the root `compilerOptions.types`.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A — no intentional visual change; this only changes static CSS generation for existing styles. | N/A — no intentional visual change; CSS variables map to the same Ant Design tokens. |

#### 📝 Additional Information

- Branch is based on `canary`.
- The migrated files no longer import `createStyles`, and their `eslint-suppressions.json` entries are removed.
- Live issue check: #16440 is still open, unassigned, and has no human claim/comment at the time of preparation.
- Open PR duplicate search for #16440 / the three target files returned no matching open PRs at the time of preparation.
