### PR TITLE
✨ feat(desktop): background process tracker — Tier 1 foundation

### DIFF
--- a/apps/cli/src/tools/shell.ts
+++ b/apps/cli/src/tools/shell.ts
@@ -10,8 +10,8 @@ import { log } from '../utils/logger';
 
 const processManager = new ShellProcessManager();
 
-export function cleanupAllProcesses() {
-  processManager.cleanupAll();
+export async function cleanupAllProcesses() {
+  await processManager.cleanupAll();
 }
 
 export async function runCommand(params: RunCommandParams) {
@@ -23,5 +23,5 @@ export async function getCommandOutput(params: GetCommandOutputParams) {
 }
 
 export async function killCommand(params: KillCommandParams) {
-  return processManager.kill(params.shell_id);
+  return processManager.killTree(params.shell_id);
 }

--- a/apps/desktop/src/main/controllers/ShellCommandCtr.ts
+++ b/apps/desktop/src/main/controllers/ShellCommandCtr.ts
@@ -52,6 +52,6 @@ export default class ShellCommandCtr extends ControllerModule {
 
   @IpcMethod()
   async handleKillCommand({ shell_id }: KillCommandParams): Promise<KillCommandResult> {
-    return processManager.kill(shell_id);
+    return processManager.killTree(shell_id);
   }
 }

--- a/apps/desktop/src/main/controllers/ShellCommandCtr.ts
+++ b/apps/desktop/src/main/controllers/ShellCommandCtr.ts
@@ -6,7 +6,7 @@ import type {
   RunCommandParams,
   RunCommandResult,
 } from '@lobechat/electron-client-ipc';
-import { runCommand, ShellProcessManager } from '@lobechat/local-file-shell';
+import { runCommand } from '@lobechat/local-file-shell';
 
 import { createLogger } from '@/utils/logger';
 
@@ -15,13 +15,15 @@ import { ControllerModule, IpcMethod } from './index';
 
 const logger = createLogger('controllers:ShellCommandCtr');
 
-const processManager = new ShellProcessManager();
-
 /** Prefix for a simple `lh`/`lobe`/`lobehub` invocation (keyword + boundary, args via slice). */
 const SIMPLE_LH_PREFIX = /^\s*(?:lh|lobe|lobehub)(?=\s|$)/;
 
 export default class ShellCommandCtr extends ControllerModule {
   static override readonly groupName = 'shellCommand';
+
+  private get processManager() {
+    return this.app.shellProcessManager;
+  }
 
   @IpcMethod()
   async handleRunCommand(params: RunCommandParams): Promise<RunCommandResult> {
@@ -42,16 +44,16 @@ export default class ShellCommandCtr extends ControllerModule {
       }
     }
 
-    return runCommand(params, { logger, processManager });
+    return runCommand(params, { logger, processManager: this.processManager });
   }
 
   @IpcMethod()
   async handleGetCommandOutput(params: GetCommandOutputParams): Promise<GetCommandOutputResult> {
-    return processManager.getOutput(params);
+    return this.processManager.getOutput(params);
   }
 
   @IpcMethod()
   async handleKillCommand({ shell_id }: KillCommandParams): Promise<KillCommandResult> {
-    return processManager.killTree(shell_id);
+    return this.processManager.killTree(shell_id);
   }
 }

--- a/apps/desktop/src/main/controllers/__tests__/ShellCommandCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/ShellCommandCtr.test.ts
@@ -99,28 +99,18 @@ describe('ShellCommandCtr (thin wrapper)', () => {
     expect(result.success).toBe(true);
   });
 
-  it('should route lh commands to CliCtr.runCliCommand bypassing processManager', async () => {
-    const result = await ctr.handleRunCommand({
-      command: 'lh status --json',
-      description: 'lh status',
-    });
+  it.each([
+    ['lh status --json', 'status --json'],
+    ['lobe status', 'status'],
+    ['lobehub --version', '--version'],
+  ])('routes "%s" through CliCtr and bypasses processManager', async (command, args) => {
+    const result = await ctr.handleRunCommand({ command, description: command });
 
-    expect(mockCliCtr.runCliCommand).toHaveBeenCalledWith('status --json');
+    expect(mockCliCtr.runCliCommand).toHaveBeenCalledWith(args);
     expect(result.success).toBe(true);
     expect(result.stdout).toContain('cli output');
     expect(mockRunCommand).not.toHaveBeenCalled();
     expect(mockShellProcessManager.getOutput).not.toHaveBeenCalled();
     expect(mockShellProcessManager.killTree).not.toHaveBeenCalled();
-  });
-
-  it('should route lobehub commands to CliCtr.runCliCommand', async () => {
-    const result = await ctr.handleRunCommand({
-      command: 'lobehub search test',
-      description: 'lobehub search',
-    });
-
-    expect(mockCliCtr.runCliCommand).toHaveBeenCalledWith('search test');
-    expect(result.success).toBe(true);
-    expect(mockRunCommand).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/controllers/__tests__/ShellCommandCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/ShellCommandCtr.test.ts
@@ -5,8 +5,9 @@ import type { App } from '@/core/App';
 import CliCtr from '../CliCtr';
 import ShellCommandCtr from '../ShellCommandCtr';
 
-const { ipcMainHandleMock } = vi.hoisted(() => ({
+const { ipcMainHandleMock, mockRunCommand } = vi.hoisted(() => ({
   ipcMainHandleMock: vi.fn(),
+  mockRunCommand: vi.fn(),
 }));
 
 vi.mock('electron', () => ({
@@ -18,17 +19,16 @@ vi.mock('electron', () => ({
 vi.mock('@/utils/logger', () => ({
   createLogger: () => ({
     debug: vi.fn(),
+    error: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
-    error: vi.fn(),
   }),
 }));
 
-// Mock child_process for the shared package
-vi.mock('node:child_process', () => ({
-  execFile: vi.fn(),
-  spawn: vi.fn(),
-}));
+vi.mock('@lobechat/local-file-shell', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, runCommand: mockRunCommand };
+});
 
 vi.mock('../CliCtr', () => ({
   default: class CliCtr {},
@@ -38,109 +38,68 @@ const mockCliCtr = {
   runCliCommand: vi.fn().mockResolvedValue({ exitCode: 0, stderr: '', stdout: 'cli output\n' }),
 };
 
+const mockShellProcessManager = {
+  getOutput: vi.fn(),
+  killTree: vi.fn(),
+};
+
 const mockApp = {
   getController: vi.fn((c: unknown) => (c === CliCtr ? mockCliCtr : undefined)),
+  shellProcessManager: mockShellProcessManager,
 } as unknown as App;
 
 describe('ShellCommandCtr (thin wrapper)', () => {
   let ctr: ShellCommandCtr;
-  let mockSpawn: any;
-  let mockChildProcess: any;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.clearAllMocks();
-
-    const childProcessModule = await import('node:child_process');
-    mockSpawn = vi.mocked(childProcessModule.spawn);
-
-    mockChildProcess = {
-      stdout: { on: vi.fn() },
-      stderr: { on: vi.fn() },
-      off: vi.fn(),
-      on: vi.fn(),
-      once: vi.fn(),
-      kill: vi.fn(),
-      exitCode: null,
-    };
-
-    mockSpawn.mockReturnValue(mockChildProcess);
+    mockCliCtr.runCliCommand.mockResolvedValue({ exitCode: 0, stderr: '', stdout: 'cli output\n' });
     ctr = new ShellCommandCtr(mockApp);
   });
 
-  it('should delegate handleRunCommand to shared runCommand', async () => {
-    mockChildProcess.on.mockImplementation((event: string, callback: any) => {
-      if (event === 'exit') setTimeout(() => callback(0), 10);
-      return mockChildProcess;
-    });
-    mockChildProcess.once.mockImplementation((event: string, callback: any) => {
-      if (event === 'exit') setTimeout(() => callback(0), 10);
-      return mockChildProcess;
-    });
-    mockChildProcess.stdout.on.mockImplementation((event: string, callback: any) => {
-      if (event === 'data') setTimeout(() => callback(Buffer.from('output\n')), 5);
-      return mockChildProcess.stdout;
-    });
-    mockChildProcess.stderr.on.mockImplementation(() => mockChildProcess.stderr);
-
-    const result = await ctr.handleRunCommand({
-      command: 'echo test',
-      description: 'test',
+  it('should delegate handleRunCommand to runCommand with processManager from app', async () => {
+    mockRunCommand.mockResolvedValue({
+      exit_code: 0,
+      output: 'output',
+      stderr: '',
+      stdout: 'output',
+      success: true,
     });
 
+    const params = { command: 'echo test', description: 'test' };
+    const result = await ctr.handleRunCommand(params);
+
+    expect(mockRunCommand).toHaveBeenCalledWith(
+      params,
+      expect.objectContaining({ processManager: mockShellProcessManager }),
+    );
     expect(result.success).toBe(true);
-    expect(result.stdout).toContain('output');
   });
 
-  it('should delegate handleGetCommandOutput to processManager', async () => {
-    mockChildProcess.on.mockImplementation((event: string, callback: any) => {
-      if (event === 'exit') setTimeout(() => callback(0), 10);
-      return mockChildProcess;
-    });
-    mockChildProcess.once.mockImplementation((event: string, callback: any) => {
-      if (event === 'exit') setTimeout(() => callback(0), 10);
-      return mockChildProcess;
-    });
-    mockChildProcess.stdout.on.mockImplementation((event: string, callback: any) => {
-      if (event === 'data') setTimeout(() => callback(Buffer.from('bg output\n')), 5);
-      return mockChildProcess.stdout;
-    });
-    mockChildProcess.stderr.on.mockImplementation(() => mockChildProcess.stderr);
-
-    const runResult = await ctr.handleRunCommand({
-      command: 'test',
-      run_in_background: true,
+  it('should delegate handleGetCommandOutput to app.shellProcessManager.getOutput', async () => {
+    mockShellProcessManager.getOutput.mockResolvedValue({
+      output: 'bg output',
+      stderr: '',
+      stdout: 'bg output',
+      success: true,
     });
 
-    await new Promise((r) => setTimeout(r, 20));
+    const result = await ctr.handleGetCommandOutput({ shell_id: 'sh-1' });
 
-    const result = await ctr.handleGetCommandOutput({
-      shell_id: runResult.shell_id!,
-    });
-
+    expect(mockShellProcessManager.getOutput).toHaveBeenCalledWith({ shell_id: 'sh-1' });
     expect(result.success).toBe(true);
-    expect(result.stdout).toContain('bg output');
   });
 
-  it('should delegate handleKillCommand to processManager', async () => {
-    mockChildProcess.on.mockImplementation(() => mockChildProcess);
-    mockChildProcess.once.mockImplementation(() => mockChildProcess);
-    mockChildProcess.stdout.on.mockImplementation(() => mockChildProcess.stdout);
-    mockChildProcess.stderr.on.mockImplementation(() => mockChildProcess.stderr);
+  it('should delegate handleKillCommand to app.shellProcessManager.killTree', async () => {
+    mockShellProcessManager.killTree.mockResolvedValue({ success: true });
 
-    const runResult = await ctr.handleRunCommand({
-      command: 'test',
-      run_in_background: true,
-    });
+    const result = await ctr.handleKillCommand({ shell_id: 'sh-1' });
 
-    const result = await ctr.handleKillCommand({
-      shell_id: runResult.shell_id!,
-    });
-
+    expect(mockShellProcessManager.killTree).toHaveBeenCalledWith('sh-1');
     expect(result.success).toBe(true);
-    expect(mockChildProcess.kill).toHaveBeenCalled();
   });
 
-  it('should route lh commands to CliCtr.runCliCommand', async () => {
+  it('should route lh commands to CliCtr.runCliCommand bypassing processManager', async () => {
     const result = await ctr.handleRunCommand({
       command: 'lh status --json',
       description: 'lh status',
@@ -149,7 +108,9 @@ describe('ShellCommandCtr (thin wrapper)', () => {
     expect(mockCliCtr.runCliCommand).toHaveBeenCalledWith('status --json');
     expect(result.success).toBe(true);
     expect(result.stdout).toContain('cli output');
-    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(mockRunCommand).not.toHaveBeenCalled();
+    expect(mockShellProcessManager.getOutput).not.toHaveBeenCalled();
+    expect(mockShellProcessManager.killTree).not.toHaveBeenCalled();
   });
 
   it('should route lobehub commands to CliCtr.runCliCommand', async () => {
@@ -160,14 +121,6 @@ describe('ShellCommandCtr (thin wrapper)', () => {
 
     expect(mockCliCtr.runCliCommand).toHaveBeenCalledWith('search test');
     expect(result.success).toBe(true);
-  });
-
-  it('should return error for non-existent shell_id', async () => {
-    const result = await ctr.handleGetCommandOutput({
-      shell_id: 'non-existent',
-    });
-
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('not found');
+    expect(mockRunCommand).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/core/App.ts
+++ b/apps/desktop/src/main/core/App.ts
@@ -478,13 +478,14 @@ export class App {
     this.ipcServer = new ElectronIPCServer(name, ipcServerEvents);
   }
 
+  private cleanupStarted = false;
+
   private cleanupTimeoutMs = 3000;
 
   private handleBeforeQuit = (event: Electron.Event) => {
-    // Re-entry guard. Electron fires before-quit again after our app.quit()
-    // call below; on the second pass we must let the default behavior win.
-    if (this.isQuiting) return;
-    this.isQuiting = true;
+    if (this.cleanupStarted) return;
+    this.cleanupStarted = true;
+    this.isQuiting = true; // preserve existing downstream contract
     event.preventDefault();
 
     void this.runShutdownCleanup();
@@ -505,6 +506,11 @@ export class App {
         ]),
         new Promise<void>((resolve) => setTimeout(resolve, this.cleanupTimeoutMs)),
       ]);
+
+      // Suppress any late-fired emits from in-flight SIGKILL callbacks and write
+      // a final consistent snapshot before quitting.
+      this.shellProcessPersister.detach();
+      await this.shellProcessPersister.flush();
     } catch (error) {
       logger.warn('Background process cleanup threw unexpectedly:', error);
     }

--- a/apps/desktop/src/main/core/App.ts
+++ b/apps/desktop/src/main/core/App.ts
@@ -478,17 +478,37 @@ export class App {
     this.ipcServer = new ElectronIPCServer(name, ipcServerEvents);
   }
 
-  // Add before-quit handler function
-  private handleBeforeQuit = () => {
-    logger.info('Application is preparing to quit');
-    this.isQuiting = true;
+  private cleanupTimeoutMs = 3000;
 
-    // Destroy tray
+  private handleBeforeQuit = (event: Electron.Event) => {
+    // Re-entry guard. Electron fires before-quit again after our app.quit()
+    // call below; on the second pass we must let the default behavior win.
+    if (this.isQuiting) return;
+    this.isQuiting = true;
+    event.preventDefault();
+
+    void this.runShutdownCleanup();
+  };
+
+  private runShutdownCleanup = async (): Promise<void> => {
     if (process.platform === 'win32') {
       this.trayManager.destroyAll();
     }
-
-    // Execute cleanup operations
     this.staticFileServerManager.destroy();
+
+    logger.info('Quitting: cleaning up background processes...');
+    try {
+      await Promise.race([
+        Promise.allSettled([
+          this.shellProcessManager.cleanupAll(),
+          // binaryManager.closeAllSessions() — wired in PR-4 when BinaryManager.lifecycle ships
+        ]),
+        new Promise<void>((resolve) => setTimeout(resolve, this.cleanupTimeoutMs)),
+      ]);
+    } catch (error) {
+      logger.warn('Background process cleanup threw unexpectedly:', error);
+    }
+    logger.info('Cleanup finished; quitting now.');
+    app.quit();
   };
 }

--- a/apps/desktop/src/main/core/App.ts
+++ b/apps/desktop/src/main/core/App.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import type { ElectronIPCEventHandler } from '@lobechat/electron-server-ipc';
 import { ElectronIPCServer } from '@lobechat/electron-server-ipc';
+import { ShellProcessManager } from '@lobechat/local-file-shell';
 import { app, nativeTheme, protocol } from 'electron';
 import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
 import * as electronIs from 'electron-is';
@@ -35,6 +36,7 @@ import { IoCContainer } from './infrastructure/IoCContainer';
 import { LocalFileProtocolManager } from './infrastructure/LocalFileProtocolManager';
 import { ProtocolManager } from './infrastructure/ProtocolManager';
 import { RendererUrlManager } from './infrastructure/RendererUrlManager';
+import { ShellProcessPersister } from './infrastructure/ShellProcessPersister';
 import { StaticFileServerManager } from './infrastructure/StaticFileServerManager';
 import { StoreManager } from './infrastructure/StoreManager';
 import { UpdaterManager } from './infrastructure/UpdaterManager';
@@ -65,6 +67,8 @@ export class App {
   rendererUrlManager: RendererUrlManager;
   localFileProtocolManager: LocalFileProtocolManager;
   binaryManager: BinaryManager;
+  shellProcessManager: ShellProcessManager;
+  shellProcessPersister: ShellProcessPersister;
   screenCaptureManager: ScreenCaptureManager;
   chromeFlags: string[] = ['OverlayScrollbar', 'FluentOverlayScrollbar', 'FluentScrollbar'];
 
@@ -148,6 +152,8 @@ export class App {
     this.staticFileServerManager = new StaticFileServerManager(this);
     this.protocolManager = new ProtocolManager(this);
     this.binaryManager = new BinaryManager(this);
+    this.shellProcessManager = new ShellProcessManager();
+    this.shellProcessPersister = new ShellProcessPersister(this.shellProcessManager);
     this.screenCaptureManager = new ScreenCaptureManager(this);
 
     // Register built-in binary specs

--- a/apps/desktop/src/main/core/__tests__/App.test.ts
+++ b/apps/desktop/src/main/core/__tests__/App.test.ts
@@ -1,6 +1,7 @@
+// Import after mocks are set up
+import { app } from 'electron';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Import after mocks are set up
 import { App } from '../App';
 
 const mockPathExistsSync = vi.fn();
@@ -16,6 +17,7 @@ vi.mock('electron', () => ({
     isReady: vi.fn(() => true),
     whenReady: vi.fn(() => Promise.resolve()),
     on: vi.fn(),
+    quit: vi.fn(),
     commandLine: {
       appendSwitch: vi.fn(),
     },
@@ -196,6 +198,66 @@ describe('App', () => {
       const storagePath = appInstance.appStoragePath;
 
       expect(storagePath).toBe('/mock/storage/path');
+    });
+  });
+
+  describe('handleBeforeQuit + runShutdownCleanup', () => {
+    beforeEach(() => {
+      import.meta.glob = vi.fn(() => ({}));
+      appInstance = new App();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('calls cleanupAll and then app.quit', async () => {
+      appInstance.shellProcessManager = {
+        cleanupAll: vi.fn().mockResolvedValue(undefined),
+      } as any;
+
+      await (appInstance as any).runShutdownCleanup();
+
+      expect(appInstance.shellProcessManager.cleanupAll).toHaveBeenCalled();
+      expect(app.quit).toHaveBeenCalled();
+    });
+
+    it('calls app.quit even when cleanupAll never resolves (timeout)', async () => {
+      vi.useFakeTimers();
+      appInstance.shellProcessManager = {
+        cleanupAll: vi.fn().mockReturnValue(new Promise(() => {})),
+      } as any;
+      (appInstance as any).cleanupTimeoutMs = 50;
+
+      const cleanupPromise = (appInstance as any).runShutdownCleanup();
+      await vi.advanceTimersByTimeAsync(50);
+      await cleanupPromise;
+
+      expect(app.quit).toHaveBeenCalled();
+    });
+
+    it('calls app.quit when cleanupAll rejects', async () => {
+      appInstance.shellProcessManager = {
+        cleanupAll: vi.fn().mockRejectedValue(new Error('boom')),
+      } as any;
+
+      await (appInstance as any).runShutdownCleanup();
+
+      expect(app.quit).toHaveBeenCalled();
+    });
+
+    it('handleBeforeQuit re-entry guard prevents double preventDefault', () => {
+      (appInstance as any).runShutdownCleanup = vi.fn().mockResolvedValue(undefined);
+
+      const event1 = { preventDefault: vi.fn() };
+      (appInstance as any).handleBeforeQuit(event1);
+      expect(event1.preventDefault).toHaveBeenCalledOnce();
+      expect(appInstance.isQuiting).toBe(true);
+
+      const event2 = { preventDefault: vi.fn() };
+      (appInstance as any).handleBeforeQuit(event2);
+      expect(event2.preventDefault).not.toHaveBeenCalled();
+      expect(appInstance.isQuiting).toBe(true);
     });
   });
 });

--- a/apps/desktop/src/main/core/__tests__/App.test.ts
+++ b/apps/desktop/src/main/core/__tests__/App.test.ts
@@ -1,6 +1,6 @@
 // Import after mocks are set up
 import { app } from 'electron';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 
 import { App } from '../App';
 
@@ -215,17 +215,30 @@ describe('App', () => {
       appInstance.shellProcessManager = {
         cleanupAll: vi.fn().mockResolvedValue(undefined),
       } as any;
+      appInstance.shellProcessPersister = {
+        detach: vi.fn(),
+        flush: vi.fn().mockResolvedValue(undefined),
+      } as any;
 
       await (appInstance as any).runShutdownCleanup();
 
       expect(appInstance.shellProcessManager.cleanupAll).toHaveBeenCalled();
       expect(app.quit).toHaveBeenCalled();
+
+      const cleanupOrder = (appInstance.shellProcessManager.cleanupAll as Mock).mock
+        .invocationCallOrder[0];
+      const quitOrder = (app.quit as Mock).mock.invocationCallOrder[0];
+      expect(cleanupOrder).toBeLessThan(quitOrder!);
     });
 
     it('calls app.quit even when cleanupAll never resolves (timeout)', async () => {
       vi.useFakeTimers();
       appInstance.shellProcessManager = {
         cleanupAll: vi.fn().mockReturnValue(new Promise(() => {})),
+      } as any;
+      appInstance.shellProcessPersister = {
+        detach: vi.fn(),
+        flush: vi.fn().mockResolvedValue(undefined),
       } as any;
       (appInstance as any).cleanupTimeoutMs = 50;
 
@@ -239,6 +252,10 @@ describe('App', () => {
     it('calls app.quit when cleanupAll rejects', async () => {
       appInstance.shellProcessManager = {
         cleanupAll: vi.fn().mockRejectedValue(new Error('boom')),
+      } as any;
+      appInstance.shellProcessPersister = {
+        detach: vi.fn(),
+        flush: vi.fn().mockResolvedValue(undefined),
       } as any;
 
       await (appInstance as any).runShutdownCleanup();

--- a/apps/desktop/src/main/core/infrastructure/ShellProcessPersister.ts
+++ b/apps/desktop/src/main/core/infrastructure/ShellProcessPersister.ts
@@ -1,0 +1,170 @@
+import { execFile } from 'node:child_process';
+import * as fs from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+import type { ShellProcessManager, ShellProcessMeta } from '@lobechat/local-file-shell';
+import { app } from 'electron';
+
+import { createLogger } from '@/utils/logger';
+
+const execFileAsync = promisify(execFile);
+const logger = createLogger('core:ShellProcessPersister');
+
+export type StartTimeFingerprint = string;
+
+export interface RecoveredShellProcess extends ShellProcessMeta {
+  startTimeFingerprint: StartTimeFingerprint;
+}
+
+export interface ShellProcessPersisterOptions {
+  debounceMs?: number;
+  filePath?: string;
+}
+
+interface PersistedEntry extends ShellProcessMeta {
+  startTimeFingerprint: StartTimeFingerprint;
+}
+
+interface PersistedSnapshot {
+  entries: PersistedEntry[];
+  version: number;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: unknown) {
+    const err = e as NodeJS.ErrnoException;
+    if (err.code === 'EPERM') return true;
+    return false;
+  }
+}
+
+async function getStartTimeFingerprint(pid: number): Promise<StartTimeFingerprint> {
+  if (process.platform === 'win32') return '';
+
+  if (process.platform === 'linux') {
+    try {
+      const raw = await fs.readFile(`/proc/${pid}/stat`, 'utf8');
+      const afterComm = raw.slice(raw.lastIndexOf(')') + 1).trim();
+      const fields = afterComm.split(/\s+/);
+      return fields[19] ?? '';
+    } catch {
+      return '';
+    }
+  }
+
+  if (process.platform === 'darwin') {
+    try {
+      const { stdout } = await execFileAsync('/bin/ps', ['-o', 'lstart=', '-p', String(pid)], {
+        timeout: 3000,
+      });
+      return stdout.trim();
+    } catch {
+      return '';
+    }
+  }
+
+  return '';
+}
+
+async function writeAtomic(filePath: string, data: string): Promise<void> {
+  const tmp = `${filePath}.${process.pid}.tmp`;
+  await fs.writeFile(tmp, data, 'utf8');
+  await fs.rename(tmp, filePath);
+}
+
+export class ShellProcessPersister {
+  private changeListener: () => void;
+  private debounceMs: number;
+  private filePath: string;
+  private manager: ShellProcessManager;
+  private timer: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(manager: ShellProcessManager, options?: ShellProcessPersisterOptions) {
+    this.manager = manager;
+    this.filePath = options?.filePath ?? path.join(app.getPath('userData'), 'processes.json');
+    this.debounceMs = options?.debounceMs ?? 200;
+
+    this.changeListener = () => this.scheduleWrite();
+    manager.events.on('change', this.changeListener);
+  }
+
+  detach(): void {
+    this.manager.events.off('change', this.changeListener);
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  async flush(): Promise<void> {
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+    await this.writeSnapshot();
+  }
+
+  async recover(): Promise<RecoveredShellProcess[]> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(this.filePath, 'utf8');
+    } catch (e: unknown) {
+      const err = e as NodeJS.ErrnoException;
+      if (err.code !== 'ENOENT') {
+        logger.error('Failed to read process snapshot:', e);
+      }
+      return [];
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (e) {
+      logger.error('Failed to parse process snapshot:', e);
+      return [];
+    }
+
+    const snapshot = parsed as PersistedSnapshot;
+    if (snapshot.version !== 1) return [];
+
+    const results: RecoveredShellProcess[] = [];
+    for (const entry of snapshot.entries) {
+      const pid = entry.pid;
+      if (pid === undefined || !isProcessAlive(pid)) continue;
+      const fingerprint = await getStartTimeFingerprint(pid);
+      if (!fingerprint || fingerprint !== entry.startTimeFingerprint) continue;
+      results.push(entry as RecoveredShellProcess);
+    }
+    return results;
+  }
+
+  private scheduleWrite(): void {
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer);
+    }
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      this.writeSnapshot().catch(() => {});
+    }, this.debounceMs);
+  }
+
+  private async writeSnapshot(): Promise<void> {
+    try {
+      const entries: PersistedEntry[] = [];
+      for (const meta of this.manager.list()) {
+        if (meta.pid === undefined) continue;
+        const fingerprint = await getStartTimeFingerprint(meta.pid);
+        if (!fingerprint) continue;
+        entries.push({ ...meta, startTimeFingerprint: fingerprint });
+      }
+      const snapshot: PersistedSnapshot = { entries, version: 1 };
+      await writeAtomic(this.filePath, JSON.stringify(snapshot));
+    } catch (e) {
+      logger.error('Failed to write process snapshot:', e);
+    }
+  }
+}

--- a/apps/desktop/src/main/core/infrastructure/ShellProcessPersister.ts
+++ b/apps/desktop/src/main/core/infrastructure/ShellProcessPersister.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -71,29 +72,28 @@ async function getStartTimeFingerprint(pid: number): Promise<StartTimeFingerprin
 }
 
 async function writeAtomic(filePath: string, data: string): Promise<void> {
-  const tmp = `${filePath}.${process.pid}.tmp`;
+  const tmp = `${filePath}.${process.pid}.${randomUUID()}.tmp`;
   await fs.writeFile(tmp, data, 'utf8');
   await fs.rename(tmp, filePath);
 }
 
 export class ShellProcessPersister {
-  private changeListener: () => void;
   private debounceMs: number;
   private filePath: string;
   private manager: ShellProcessManager;
   private timer: ReturnType<typeof setTimeout> | undefined;
+  private unsubscribe: () => void;
 
   constructor(manager: ShellProcessManager, options?: ShellProcessPersisterOptions) {
     this.manager = manager;
     this.filePath = options?.filePath ?? path.join(app.getPath('userData'), 'processes.json');
     this.debounceMs = options?.debounceMs ?? 200;
 
-    this.changeListener = () => this.scheduleWrite();
-    manager.events.on('change', this.changeListener);
+    this.unsubscribe = manager.subscribe(() => this.scheduleWrite());
   }
 
   detach(): void {
-    this.manager.events.off('change', this.changeListener);
+    this.unsubscribe();
     if (this.timer !== undefined) {
       clearTimeout(this.timer);
       this.timer = undefined;

--- a/apps/desktop/src/main/core/infrastructure/__tests__/ShellProcessPersister.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/ShellProcessPersister.test.ts
@@ -94,9 +94,9 @@ describe('ShellProcessPersister', () => {
     const manager = new ShellProcessManager();
     const persister = new ShellProcessPersister(manager, { debounceMs: 200, filePath });
 
-    manager.events.emit('change');
-    manager.events.emit('change');
-    manager.events.emit('change');
+    (manager as any).emitChange();
+    (manager as any).emitChange();
+    (manager as any).emitChange();
 
     await vi.advanceTimersByTimeAsync(200);
 
@@ -240,7 +240,7 @@ describe('ShellProcessPersister', () => {
     const persister = new ShellProcessPersister(manager, { debounceMs: 200, filePath });
 
     persister.detach();
-    manager.events.emit('change');
+    (manager as any).emitChange();
     await vi.advanceTimersByTimeAsync(200);
 
     expect(writeFileMock).not.toHaveBeenCalled();
@@ -251,7 +251,7 @@ describe('ShellProcessPersister', () => {
     const manager = new ShellProcessManager();
     const persister = new ShellProcessPersister(manager, { debounceMs: 200, filePath });
 
-    manager.events.emit('change');
+    (manager as any).emitChange();
     await persister.flush();
 
     await vi.advanceTimersByTimeAsync(200);

--- a/apps/desktop/src/main/core/infrastructure/__tests__/ShellProcessPersister.test.ts
+++ b/apps/desktop/src/main/core/infrastructure/__tests__/ShellProcessPersister.test.ts
@@ -1,0 +1,262 @@
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import * as fs from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import type { ShellProcess } from '@lobechat/local-file-shell';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof fs;
+  return {
+    ...actual,
+    rename: vi.fn(actual.rename),
+    writeFile: vi.fn(actual.writeFile),
+  };
+});
+
+const { mockUserDataDir, setUserDataDir } = vi.hoisted(() => {
+  const ref = { current: '' };
+  return {
+    mockUserDataDir: ref,
+    setUserDataDir: (dir: string) => {
+      ref.current = dir;
+    },
+  };
+});
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (key: string) => {
+      if (key === 'userData') return mockUserDataDir.current;
+      throw new Error(`unexpected app.getPath('${key}') in test`);
+    },
+  },
+}));
+
+vi.mock('@/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+const { ShellProcessPersister } = await import('../ShellProcessPersister');
+const { ShellProcessManager } = await import('@lobechat/local-file-shell');
+
+function makeMockProcess(pid: number, exitCode: number | null = null): ChildProcess {
+  const proc = new EventEmitter() as ChildProcess;
+  Object.defineProperty(proc, 'exitCode', { configurable: true, value: exitCode, writable: true });
+  Object.defineProperty(proc, 'pid', { configurable: true, value: pid, writable: true });
+  proc.kill = vi.fn() as unknown as ChildProcess['kill'];
+  return proc;
+}
+
+function makeShellProcess(proc: ChildProcess, overrides: Partial<ShellProcess> = {}): ShellProcess {
+  return {
+    command: 'test-cmd',
+    exitCode: proc.exitCode,
+    lastReadStderr: 0,
+    lastReadStdout: 0,
+    process: proc,
+    processId: 'pid-test',
+    runInBackground: true,
+    stderr: [],
+    stdout: [],
+    ...overrides,
+  };
+}
+
+const writeFileMock = vi.mocked(fs.writeFile);
+
+let workspace: string;
+let filePath: string;
+
+beforeEach(async () => {
+  workspace = await mkdtemp(path.join(tmpdir(), 'persister-'));
+  filePath = path.join(workspace, 'processes.json');
+  setUserDataDir(workspace);
+  writeFileMock.mockClear();
+});
+
+afterEach(async () => {
+  vi.useRealTimers();
+  await rm(workspace, { force: true, recursive: true });
+});
+
+describe('ShellProcessPersister', () => {
+  it('1. debounce: 3 rapid change events produce exactly one writeFile call', async () => {
+    vi.useFakeTimers();
+    const manager = new ShellProcessManager();
+    const persister = new ShellProcessPersister(manager, { debounceMs: 200, filePath });
+
+    manager.events.emit('change');
+    manager.events.emit('change');
+    manager.events.emit('change');
+
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    persister.detach();
+  });
+
+  describe.runIf(process.platform === 'linux' || process.platform === 'darwin')(
+    'fingerprint-dependent (posix only)',
+    () => {
+      it('2. snapshot shape: flush writes version:1 entries with non-empty startTimeFingerprint', async () => {
+        const manager = new ShellProcessManager();
+        const persister = new ShellProcessPersister(manager, { filePath });
+        const proc = makeMockProcess(process.pid);
+        manager.register('sh-1', makeShellProcess(proc, { command: 'foo' }));
+
+        await persister.flush();
+
+        const raw = await fs.readFile(filePath, 'utf8');
+        const parsed = JSON.parse(raw);
+        expect(parsed.version).toBe(1);
+        expect(parsed.entries).toHaveLength(1);
+        expect(parsed.entries[0].pid).toBe(process.pid);
+        expect(parsed.entries[0].command).toBe('foo');
+        expect(typeof parsed.entries[0].startTimeFingerprint).toBe('string');
+        expect(parsed.entries[0].startTimeFingerprint.length).toBeGreaterThan(0);
+
+        persister.detach();
+      });
+
+      it('6. recover() happy path: returns entry whose fingerprint matches', async () => {
+        const manager = new ShellProcessManager();
+        const persister = new ShellProcessPersister(manager, { filePath });
+        const proc = makeMockProcess(process.pid);
+        manager.register('sh-happy', makeShellProcess(proc, { command: 'bar' }));
+        await persister.flush();
+
+        const survivors = await persister.recover();
+
+        expect(survivors).toHaveLength(1);
+        expect(survivors[0]!.pid).toBe(process.pid);
+        expect(typeof survivors[0]!.startTimeFingerprint).toBe('string');
+        expect(survivors[0]!.startTimeFingerprint.length).toBeGreaterThan(0);
+
+        persister.detach();
+      });
+    },
+  );
+
+  it('3. recover() on missing file returns []', async () => {
+    const manager = new ShellProcessManager();
+    const persister = new ShellProcessPersister(manager, {
+      filePath: path.join(workspace, 'nonexistent.json'),
+    });
+
+    const result = await persister.recover();
+
+    expect(result).toEqual([]);
+    persister.detach();
+  });
+
+  it('4. recover() on malformed JSON returns [] without throwing', async () => {
+    await writeFile(filePath, 'not json', 'utf8');
+    const manager = new ShellProcessManager();
+    const persister = new ShellProcessPersister(manager, { filePath });
+
+    const result = await persister.recover();
+
+    expect(result).toEqual([]);
+    persister.detach();
+  });
+
+  it('5. recover() on wrong version returns []', async () => {
+    await writeFile(filePath, JSON.stringify({ entries: [], version: 2 }), 'utf8');
+    const manager = new ShellProcessManager();
+    const persister = new ShellProcessPersister(manager, { filePath });
+
+    const result = await persister.recover();
+
+    expect(result).toEqual([]);
+    persister.detach();
+  });
+
+  it('7. recover() drops entries for dead PIDs', async () => {
+    const snapshot = {
+      entries: [
+        {
+          command: 'ghost',
+          exitCode: null,
+          pgid: undefined,
+          pid: 999_999,
+          processId: 'dead-1',
+          runInBackground: true,
+          shellId: 'sh-dead',
+          startTimeFingerprint: 'some-fingerprint',
+          startedAt: Date.now(),
+        },
+      ],
+      version: 1,
+    };
+    await writeFile(filePath, JSON.stringify(snapshot), 'utf8');
+    const manager = new ShellProcessManager();
+    const persister = new ShellProcessPersister(manager, { filePath });
+
+    const result = await persister.recover();
+
+    expect(result).toEqual([]);
+    persister.detach();
+  });
+
+  it('8. recover() drops entry with PID-reuse mismatch', async () => {
+    const snapshot = {
+      entries: [
+        {
+          command: 'mismatched',
+          exitCode: null,
+          pgid: undefined,
+          pid: process.pid,
+          processId: 'reuse-1',
+          runInBackground: true,
+          shellId: 'sh-reuse',
+          startTimeFingerprint: 'definitely-not-current',
+          startedAt: Date.now(),
+        },
+      ],
+      version: 1,
+    };
+    await writeFile(filePath, JSON.stringify(snapshot), 'utf8');
+    const manager = new ShellProcessManager();
+    const persister = new ShellProcessPersister(manager, { filePath });
+
+    const result = await persister.recover();
+
+    expect(result).toEqual([]);
+    persister.detach();
+  });
+
+  it('9. detach() stops listening — no write after detach', async () => {
+    vi.useFakeTimers();
+    const manager = new ShellProcessManager();
+    const persister = new ShellProcessPersister(manager, { debounceMs: 200, filePath });
+
+    persister.detach();
+    manager.events.emit('change');
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(writeFileMock).not.toHaveBeenCalled();
+  });
+
+  it('10. flush() cancels pending debounce — only one write total', async () => {
+    vi.useFakeTimers();
+    const manager = new ShellProcessManager();
+    const persister = new ShellProcessPersister(manager, { debounceMs: 200, filePath });
+
+    manager.events.emit('change');
+    await persister.flush();
+
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(writeFileMock).toHaveBeenCalledTimes(1);
+    persister.detach();
+  });
+});

--- a/packages/local-file-shell/package.json
+++ b/packages/local-file-shell/package.json
@@ -10,7 +10,8 @@
     "debug": "^4.4.3",
     "diff": "^8.0.2",
     "execa": "^9.6.1",
-    "fast-glob": "^3.3.3"
+    "fast-glob": "^3.3.3",
+    "tree-kill": "^1.2.2"
   },
   "devDependencies": {
     "@types/debug": "^4.1.12"

--- a/packages/local-file-shell/src/shell/__tests__/process-manager.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/process-manager.test.ts
@@ -2,7 +2,7 @@ import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 
 import treeKill from 'tree-kill';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { type ShellProcess, ShellProcessManager } from '../process-manager';
 
@@ -409,6 +409,61 @@ describe('ShellProcessManager', () => {
       await manager.killByPid(999, true);
 
       expect(treeKillMock).toHaveBeenCalledWith(999, 'SIGKILL', expect.any(Function));
+    });
+  });
+
+  describe('events', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('register emits change once', () => {
+      const listener = vi.fn();
+      manager.events.on('change', listener);
+      const proc = createMockProcess(null, 10);
+      manager.register('sh-evt-1', createShellProcess(proc));
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('natural exit emits change with endedAt already set', () => {
+      const proc = createMockProcess(null, 11);
+      const sp = createShellProcess(proc);
+      manager.register('sh-evt-2', sp);
+      let capturedEndedAt: number | undefined;
+      manager.events.on('change', () => {
+        capturedEndedAt = sp.endedAt;
+      });
+      proc.emit('exit', 0);
+      expect(capturedEndedAt).toBeDefined();
+    });
+
+    it('killTree emits change once after SIGKILL cleanup', async () => {
+      vi.useFakeTimers();
+      treeKillMock.mockImplementation((_pid, _signal, cb) => {
+        cb?.();
+      });
+      const proc = createMockProcess(null, 12);
+      manager.register('sh-evt-3', createShellProcess(proc));
+      const listener = vi.fn();
+      manager.events.on('change', listener);
+      listener.mockClear();
+      await manager.killTree('sh-evt-3');
+      expect(listener).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(3000);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('throwing listener does not prevent subsequent listeners from firing', () => {
+      const proc = createMockProcess(null, 13);
+      const throwingListener = vi.fn(() => {
+        throw new Error('listener error');
+      });
+      const normalListener = vi.fn();
+      manager.events.on('change', throwingListener);
+      manager.events.on('change', normalListener);
+      manager.register('sh-evt-4', createShellProcess(proc));
+      expect(throwingListener).toHaveBeenCalledTimes(1);
+      expect(normalListener).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/local-file-shell/src/shell/__tests__/process-manager.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/process-manager.test.ts
@@ -306,18 +306,25 @@ describe('ShellProcessManager', () => {
   });
 
   describe('killTree', () => {
-    it('happy path: resolves success and invokes tree-kill with SIGTERM', async () => {
-      treeKillMock.mockImplementation((_pid, _signal, cb) => {
-        cb?.();
-      });
+    it('happy path: resolves success after SIGKILL escalation', async () => {
+      vi.useFakeTimers();
+      try {
+        treeKillMock.mockImplementation((_pid, _signal, cb) => {
+          cb?.();
+        });
 
-      const proc = createMockProcess(null, 42);
-      manager.register('sh-1', createShellProcess(proc));
+        const proc = createMockProcess(null, 42);
+        manager.register('sh-1', createShellProcess(proc));
 
-      const result = await manager.killTree('sh-1');
+        const killPromise = manager.killTree('sh-1');
+        await vi.advanceTimersByTimeAsync(3000);
+        const result = await killPromise;
 
-      expect(result).toEqual({ error: undefined, success: true });
-      expect(treeKillMock).toHaveBeenCalledWith(42, 'SIGTERM', expect.any(Function));
+        expect(result).toEqual({ error: undefined, success: true });
+        expect(treeKillMock).toHaveBeenCalledWith(42, 'SIGTERM', expect.any(Function));
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('SIGKILL fallback fires 3s after SIGTERM callback', async () => {
@@ -330,11 +337,12 @@ describe('ShellProcessManager', () => {
         const proc = createMockProcess(null, 42);
         manager.register('sh-1', createShellProcess(proc));
 
-        await manager.killTree('sh-1');
+        const killPromise = manager.killTree('sh-1');
 
         expect(treeKillMock).toHaveBeenCalledTimes(1);
 
         await vi.advanceTimersByTimeAsync(3000);
+        await killPromise;
 
         expect(treeKillMock).toHaveBeenCalledTimes(2);
         expect(treeKillMock.mock.calls[1]?.[1]).toBe('SIGKILL');
@@ -351,17 +359,24 @@ describe('ShellProcessManager', () => {
     });
 
     it('returns error when tree-kill callback receives an error', async () => {
-      treeKillMock.mockImplementation((_pid, _signal, cb) => {
-        cb?.(new Error('kill failed'));
-      });
+      vi.useFakeTimers();
+      try {
+        treeKillMock.mockImplementation((_pid, _signal, cb) => {
+          cb?.(new Error('kill failed'));
+        });
 
-      const proc = createMockProcess(null, 42);
-      manager.register('sh-1', createShellProcess(proc));
+        const proc = createMockProcess(null, 42);
+        manager.register('sh-1', createShellProcess(proc));
 
-      const result = await manager.killTree('sh-1');
+        const killPromise = manager.killTree('sh-1');
+        await vi.advanceTimersByTimeAsync(3000);
+        const result = await killPromise;
 
-      expect(result.success).toBe(false);
-      expect(result.error).toBe('kill failed');
+        expect(result.success).toBe(false);
+        expect(result.error).toBe('kill failed');
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('removes entry from registry in SIGKILL callback', async () => {
@@ -374,8 +389,9 @@ describe('ShellProcessManager', () => {
         const proc = createMockProcess(null, 42);
         manager.register('sh-1', createShellProcess(proc));
 
-        await manager.killTree('sh-1');
+        const killPromise = manager.killTree('sh-1');
         await vi.advanceTimersByTimeAsync(3000);
+        await killPromise;
 
         const listResult = await manager.getOutput({ shell_id: 'sh-1' });
         expect(listResult.success).toBe(false);
@@ -412,14 +428,14 @@ describe('ShellProcessManager', () => {
     });
   });
 
-  describe('events', () => {
+  describe('subscribe', () => {
     afterEach(() => {
       vi.useRealTimers();
     });
 
     it('register emits change once', () => {
       const listener = vi.fn();
-      manager.events.on('change', listener);
+      manager.subscribe(listener);
       const proc = createMockProcess(null, 10);
       manager.register('sh-evt-1', createShellProcess(proc));
       expect(listener).toHaveBeenCalledTimes(1);
@@ -430,7 +446,7 @@ describe('ShellProcessManager', () => {
       const sp = createShellProcess(proc);
       manager.register('sh-evt-2', sp);
       let capturedEndedAt: number | undefined;
-      manager.events.on('change', () => {
+      manager.subscribe(() => {
         capturedEndedAt = sp.endedAt;
       });
       proc.emit('exit', 0);
@@ -445,11 +461,12 @@ describe('ShellProcessManager', () => {
       const proc = createMockProcess(null, 12);
       manager.register('sh-evt-3', createShellProcess(proc));
       const listener = vi.fn();
-      manager.events.on('change', listener);
+      manager.subscribe(listener);
       listener.mockClear();
-      await manager.killTree('sh-evt-3');
+      const killPromise = manager.killTree('sh-evt-3');
       expect(listener).not.toHaveBeenCalled();
       await vi.advanceTimersByTimeAsync(3000);
+      await killPromise;
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
@@ -459,16 +476,30 @@ describe('ShellProcessManager', () => {
         throw new Error('listener error');
       });
       const normalListener = vi.fn();
-      manager.events.on('change', throwingListener);
-      manager.events.on('change', normalListener);
+      manager.subscribe(throwingListener);
+      manager.subscribe(normalListener);
       manager.register('sh-evt-4', createShellProcess(proc));
       expect(throwingListener).toHaveBeenCalledTimes(1);
       expect(normalListener).toHaveBeenCalledTimes(1);
     });
+
+    it('subscribe() returns a working unsubscribe', () => {
+      const listener = vi.fn();
+      const unsub = manager.subscribe(listener);
+      const proc = createMockProcess(null, 14);
+      manager.register('sh-evt-5', createShellProcess(proc));
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      unsub();
+
+      const proc2 = createMockProcess(null, 15);
+      manager.register('sh-evt-6', createShellProcess(proc2));
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('cleanupAll', () => {
-    it('serializes killTree calls for all registered entries', async () => {
+    it('parallelizes killTree calls for all registered entries with escalationDelayMs:500', async () => {
       const p1 = createMockProcess(null, 100);
       const p2 = createMockProcess(null, 101);
       const p3 = createMockProcess(null, 102);
@@ -480,18 +511,21 @@ describe('ShellProcessManager', () => {
       await manager.cleanupAll();
 
       expect(killTreeSpy).toHaveBeenCalledTimes(3);
-      expect(killTreeSpy).toHaveBeenCalledWith('a');
-      expect(killTreeSpy).toHaveBeenCalledWith('b');
-      expect(killTreeSpy).toHaveBeenCalledWith('c');
+      expect(killTreeSpy).toHaveBeenCalledWith('a', { escalationDelayMs: 500 });
+      expect(killTreeSpy).toHaveBeenCalledWith('b', { escalationDelayMs: 500 });
+      expect(killTreeSpy).toHaveBeenCalledWith('c', { escalationDelayMs: 500 });
     });
 
-    it('clears registry after all entries are processed', async () => {
+    it('clears registry when killTree deletes entries (via SIGKILL callback)', async () => {
       const p1 = createMockProcess(null, 100);
       const p2 = createMockProcess(null, 101);
       manager.register('a', createShellProcess(p1));
       manager.register('b', createShellProcess(p2));
 
-      vi.spyOn(manager, 'killTree').mockResolvedValue({ success: true });
+      vi.spyOn(manager, 'killTree').mockImplementation(async (id: string) => {
+        (manager as any).processes.delete(id);
+        return { success: true };
+      });
       await manager.cleanupAll();
 
       expect((await manager.getOutput({ shell_id: 'a' })).success).toBe(false);

--- a/packages/local-file-shell/src/shell/__tests__/process-manager.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/process-manager.test.ts
@@ -1,31 +1,48 @@
 import type { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 
+import treeKill from 'tree-kill';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { type ShellProcess, ShellProcessManager } from '../process-manager';
 
-function createMockProcess(exitCode: number | null = null): ChildProcess {
-  const process = new EventEmitter() as ChildProcess;
-  // Node types expose `exitCode` as readonly; make the test double writable so
-  // we can simulate the child process exiting.
-  Object.defineProperty(process, 'exitCode', {
+vi.mock('tree-kill', () => ({
+  default: vi.fn(),
+}));
+
+const treeKillMock = vi.mocked(treeKill);
+
+function createMockProcess(exitCode: number | null = null, pid?: number): ChildProcess {
+  const proc = new EventEmitter() as ChildProcess;
+  Object.defineProperty(proc, 'exitCode', {
     configurable: true,
     value: exitCode,
     writable: true,
   });
-  process.kill = vi.fn() as unknown as ChildProcess['kill'];
-  return process;
+  Object.defineProperty(proc, 'pid', {
+    configurable: true,
+    value: pid,
+    writable: true,
+  });
+  proc.kill = vi.fn() as unknown as ChildProcess['kill'];
+  return proc;
 }
 
-function createShellProcess(process: ChildProcess): ShellProcess {
+function createShellProcess(
+  proc: ChildProcess,
+  overrides: Partial<ShellProcess> = {},
+): ShellProcess {
   return {
-    exitCode: process.exitCode,
+    command: 'test-command',
+    exitCode: proc.exitCode,
     lastReadStderr: 0,
     lastReadStdout: 0,
-    process,
+    process: proc,
+    processId: 'test-process-id',
+    runInBackground: false,
     stderr: [],
     stdout: [],
+    ...overrides,
   };
 }
 
@@ -33,6 +50,7 @@ describe('ShellProcessManager', () => {
   let manager: ShellProcessManager;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     manager = new ShellProcessManager();
   });
 
@@ -241,72 +259,203 @@ describe('ShellProcessManager', () => {
     });
   });
 
-  describe('kill', () => {
-    it('should kill process successfully', () => {
-      const process = createMockProcess();
-      manager.register('test-1', createShellProcess(process));
+  describe('list / listAll', () => {
+    it('register + list returns one alive entry with correct shape', () => {
+      const proc = createMockProcess(null, 42);
+      manager.register(
+        'sh-1',
+        createShellProcess(proc, {
+          command: 'sleep 60',
+          cwd: '/tmp',
+          processId: 'uuid-abc',
+          runInBackground: true,
+        }),
+      );
 
-      const result = manager.kill('test-1');
-
-      expect(result.success).toBe(true);
-      expect(process.kill).toHaveBeenCalled();
-    });
-
-    it('should return error for non-existent shell_id', () => {
-      const result = manager.kill('non-existent');
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('not found');
-    });
-
-    it('should remove process from registry after killing', async () => {
-      const process = createMockProcess();
-      manager.register('test-1', createShellProcess(process));
-
-      manager.kill('test-1');
-
-      const result = await manager.getOutput({ shell_id: 'test-1' });
-      expect(result.success).toBe(false);
-      expect(result.error).toContain('not found');
-    });
-
-    it('should handle kill error gracefully', () => {
-      const process = createMockProcess();
-      (process.kill as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
-        throw new Error('Kill failed');
+      const entries = manager.list();
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({
+        command: 'sleep 60',
+        cwd: '/tmp',
+        exitCode: null,
+        pgid: undefined,
+        pid: 42,
+        processId: 'uuid-abc',
+        runInBackground: true,
+        shellId: 'sh-1',
       });
-      manager.register('test-1', createShellProcess(process));
+      expect(typeof entries[0]!.startedAt).toBe('number');
+    });
 
-      const result = manager.kill('test-1');
+    it('list excludes exited entries; listAll includes them', () => {
+      const proc = createMockProcess(0, 42);
+      const sp = createShellProcess(proc, { exitCode: 0 });
+      manager.register('sh-1', sp);
+
+      expect(manager.list()).toHaveLength(0);
+      expect(manager.listAll()).toHaveLength(1);
+    });
+
+    it('list excludes entries where process.exitCode is non-null', () => {
+      const proc = createMockProcess(null, 42);
+      manager.register('sh-1', createShellProcess(proc));
+      (proc as { exitCode: number | null }).exitCode = 0;
+
+      expect(manager.list()).toHaveLength(0);
+    });
+  });
+
+  describe('killTree', () => {
+    it('happy path: resolves success and invokes tree-kill with SIGTERM', async () => {
+      treeKillMock.mockImplementation((_pid, _signal, cb) => {
+        cb?.();
+      });
+
+      const proc = createMockProcess(null, 42);
+      manager.register('sh-1', createShellProcess(proc));
+
+      const result = await manager.killTree('sh-1');
+
+      expect(result).toEqual({ error: undefined, success: true });
+      expect(treeKillMock).toHaveBeenCalledWith(42, 'SIGTERM', expect.any(Function));
+    });
+
+    it('SIGKILL fallback fires 3s after SIGTERM callback', async () => {
+      vi.useFakeTimers();
+      try {
+        treeKillMock.mockImplementation((_pid, _signal, cb) => {
+          cb?.();
+        });
+
+        const proc = createMockProcess(null, 42);
+        manager.register('sh-1', createShellProcess(proc));
+
+        await manager.killTree('sh-1');
+
+        expect(treeKillMock).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(3000);
+
+        expect(treeKillMock).toHaveBeenCalledTimes(2);
+        expect(treeKillMock.mock.calls[1]?.[1]).toBe('SIGKILL');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('returns error when shellId is not found', async () => {
+      const result = await manager.killTree('unknown');
 
       expect(result.success).toBe(false);
-      expect(result.error).toBe('Kill failed');
+      expect(result.error).toMatch(/not found/);
+    });
+
+    it('returns error when tree-kill callback receives an error', async () => {
+      treeKillMock.mockImplementation((_pid, _signal, cb) => {
+        cb?.(new Error('kill failed'));
+      });
+
+      const proc = createMockProcess(null, 42);
+      manager.register('sh-1', createShellProcess(proc));
+
+      const result = await manager.killTree('sh-1');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('kill failed');
+    });
+
+    it('removes entry from registry in SIGKILL callback', async () => {
+      vi.useFakeTimers();
+      try {
+        treeKillMock.mockImplementation((_pid, _signal, cb) => {
+          cb?.();
+        });
+
+        const proc = createMockProcess(null, 42);
+        manager.register('sh-1', createShellProcess(proc));
+
+        await manager.killTree('sh-1');
+        await vi.advanceTimersByTimeAsync(3000);
+
+        const listResult = await manager.getOutput({ shell_id: 'sh-1' });
+        expect(listResult.success).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('killByPid', () => {
+    it('calls tree-kill with the given pid; does not touch registry', async () => {
+      treeKillMock.mockImplementation((_pid, _signal, cb) => {
+        cb?.();
+      });
+
+      const proc = createMockProcess(null, 42);
+      manager.register('sh-1', createShellProcess(proc));
+
+      const result = await manager.killByPid(999);
+
+      expect(result).toEqual({ error: undefined, success: true });
+      expect(treeKillMock).toHaveBeenCalledWith(999, 'SIGTERM', expect.any(Function));
+      expect(manager.listAll()).toHaveLength(1);
+    });
+
+    it('uses SIGKILL when force is true', async () => {
+      treeKillMock.mockImplementation((_pid, _signal, cb) => {
+        cb?.();
+      });
+
+      await manager.killByPid(999, true);
+
+      expect(treeKillMock).toHaveBeenCalledWith(999, 'SIGKILL', expect.any(Function));
     });
   });
 
   describe('cleanupAll', () => {
-    it('should kill all registered processes', async () => {
-      const p1 = createMockProcess();
-      const p2 = createMockProcess();
-      manager.register('test-1', createShellProcess(p1));
-      manager.register('test-2', createShellProcess(p2));
+    it('serializes killTree calls for all registered entries', async () => {
+      const p1 = createMockProcess(null, 100);
+      const p2 = createMockProcess(null, 101);
+      const p3 = createMockProcess(null, 102);
+      manager.register('a', createShellProcess(p1));
+      manager.register('b', createShellProcess(p2));
+      manager.register('c', createShellProcess(p3));
 
-      manager.cleanupAll();
+      const killTreeSpy = vi.spyOn(manager, 'killTree').mockResolvedValue({ success: true });
+      await manager.cleanupAll();
 
-      expect(p1.kill).toHaveBeenCalled();
-      expect(p2.kill).toHaveBeenCalled();
-      expect((await manager.getOutput({ shell_id: 'test-1' })).success).toBe(false);
-      expect((await manager.getOutput({ shell_id: 'test-2' })).success).toBe(false);
+      expect(killTreeSpy).toHaveBeenCalledTimes(3);
+      expect(killTreeSpy).toHaveBeenCalledWith('a');
+      expect(killTreeSpy).toHaveBeenCalledWith('b');
+      expect(killTreeSpy).toHaveBeenCalledWith('c');
     });
 
-    it('should handle kill errors during cleanup', () => {
-      const p1 = createMockProcess();
-      (p1.kill as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
-        throw new Error('fail');
-      });
-      manager.register('test-1', createShellProcess(p1));
+    it('clears registry after all entries are processed', async () => {
+      const p1 = createMockProcess(null, 100);
+      const p2 = createMockProcess(null, 101);
+      manager.register('a', createShellProcess(p1));
+      manager.register('b', createShellProcess(p2));
 
-      expect(() => manager.cleanupAll()).not.toThrow();
+      vi.spyOn(manager, 'killTree').mockResolvedValue({ success: true });
+      await manager.cleanupAll();
+
+      expect((await manager.getOutput({ shell_id: 'a' })).success).toBe(false);
+      expect((await manager.getOutput({ shell_id: 'b' })).success).toBe(false);
+    });
+
+    it('continues processing remaining entries when one killTree fails', async () => {
+      const p1 = createMockProcess(null, 100);
+      const p2 = createMockProcess(null, 101);
+      manager.register('a', createShellProcess(p1));
+      manager.register('b', createShellProcess(p2));
+
+      const killTreeSpy = vi
+        .spyOn(manager, 'killTree')
+        .mockRejectedValueOnce(new Error('fail'))
+        .mockResolvedValueOnce({ success: true });
+
+      await expect(manager.cleanupAll()).resolves.toBeUndefined();
+      expect(killTreeSpy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/local-file-shell/src/shell/__tests__/runner.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/runner.test.ts
@@ -85,7 +85,7 @@ describe('runCommand', () => {
         { processManager },
       );
 
-      expect(result.output).toContain('red');
+      expect(result.output).toContain('\x1B[31m');
     });
 
     it('should truncate very long output', async () => {

--- a/packages/local-file-shell/src/shell/__tests__/runner.test.ts
+++ b/packages/local-file-shell/src/shell/__tests__/runner.test.ts
@@ -1,13 +1,27 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import type * as ChildProcessNS from 'node:child_process';
+import { spawn } from 'node:child_process';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ShellProcessManager } from '../process-manager';
 import { runCommand } from '../runner';
 
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof ChildProcessNS>('node:child_process');
+  return { ...actual, spawn: vi.fn(actual.spawn) };
+});
+
+const spawnMock = vi.mocked(spawn);
+
 describe('runCommand', () => {
   const processManager = new ShellProcessManager();
 
-  afterEach(() => {
-    processManager.cleanupAll();
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await processManager.cleanupAll();
   });
 
   describe('foreground observation mode', () => {
@@ -28,7 +42,7 @@ describe('runCommand', () => {
 
       expect(first.shell_id).toBe('sh-1');
       expect(second.shell_id).toBe('sh-2');
-      localManager.cleanupAll();
+      await localManager.cleanupAll();
     });
 
     it('should capture stderr', async () => {
@@ -65,13 +79,13 @@ describe('runCommand', () => {
       expect(result.shell_id).toBeDefined();
     }, 10_000);
 
-    it('should strip ANSI codes from output', async () => {
+    it('should pass ANSI codes through to output', async () => {
       const result = await runCommand(
         { command: 'printf "\\033[31mred\\033[0m"' },
         { processManager },
       );
 
-      expect(result.output).not.toContain('\u001B');
+      expect(result.output).toContain('red');
     });
 
     it('should truncate very long output', async () => {
@@ -155,7 +169,7 @@ describe('runCommand', () => {
         { processManager },
       );
 
-      const result = processManager.kill(bgResult.shell_id!);
+      const result = await processManager.killTree(bgResult.shell_id!);
       expect(result.success).toBe(true);
     });
 
@@ -166,7 +180,7 @@ describe('runCommand', () => {
     });
 
     it('should return error when killing unknown shell_id', async () => {
-      const result = processManager.kill('unknown-id');
+      const result = await processManager.killTree('unknown-id');
       expect(result.success).toBe(false);
       expect(result.error).toContain('not found');
     });
@@ -213,6 +227,49 @@ describe('runCommand', () => {
       await new Promise((r) => setTimeout(r, 100));
       const output = await processManager.getOutput({ shell_id: bgResult.shell_id! });
       expect(output.exit_code).toBe(0);
+    });
+  });
+
+  describe('env stamp and spawn options', () => {
+    it('sets LOBEHUB_PROCESS_ID in the spawned environment', async () => {
+      const result = await runCommand({ command: 'echo $LOBEHUB_PROCESS_ID' }, { processManager });
+
+      expect(result.stdout?.trim()).toMatch(
+        /^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/,
+      );
+    });
+
+    it('sets detached: true on spawn', async () => {
+      await runCommand({ command: 'echo ok' }, { processManager });
+
+      const spawnOpts = spawnMock.mock.calls.at(-1)?.[2];
+      expect(spawnOpts?.detached).toBe(true);
+    });
+
+    it('populates new metadata fields on the registered ShellProcess', async () => {
+      const registerSpy = vi.spyOn(processManager, 'register');
+      await runCommand(
+        { command: 'echo ok', cwd: '/tmp', run_in_background: true },
+        { processManager },
+      );
+
+      const sp = registerSpy.mock.calls.at(-1)?.[1];
+      expect(sp).toBeDefined();
+      expect(sp!.command).toBe('echo ok');
+      expect(sp!.cwd).toBe('/tmp');
+      expect(sp!.runInBackground).toBe(true);
+      expect(sp!.processId).toMatch(/^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$/);
+      expect(typeof sp!.startedAt).toBe('number');
+    });
+
+    it('sets pgid to childProcess.pid on POSIX', async () => {
+      if (process.platform === 'win32') return;
+
+      const registerSpy = vi.spyOn(processManager, 'register');
+      await runCommand({ command: 'echo ok' }, { processManager });
+
+      const sp = registerSpy.mock.calls.at(-1)?.[1];
+      expect(sp!.pgid).toBe(sp!.process.pid);
     });
   });
 

--- a/packages/local-file-shell/src/shell/index.ts
+++ b/packages/local-file-shell/src/shell/index.ts
@@ -1,4 +1,4 @@
-export type { ShellProcess } from './process-manager';
+export type { ShellProcess, ShellProcessMeta } from './process-manager';
 export { ShellProcessManager } from './process-manager';
 export type { RunCommandOptions } from './runner';
 export { runCommand } from './runner';

--- a/packages/local-file-shell/src/shell/process-manager.ts
+++ b/packages/local-file-shell/src/shell/process-manager.ts
@@ -1,5 +1,4 @@
 import type { ChildProcess } from 'node:child_process';
-import { EventEmitter } from 'node:events';
 
 import treeKill from 'tree-kill';
 
@@ -37,8 +36,12 @@ export interface ShellProcessMeta {
   startedAt: number;
 }
 
+interface KillTreeOptions {
+  escalationDelayMs?: number;
+}
+
 export class ShellProcessManager {
-  readonly events = new EventEmitter();
+  private subscribers = new Set<() => void>();
 
   private nextShellId = 1;
 
@@ -165,21 +168,37 @@ export class ShellProcessManager {
     };
   }
 
-  killTree(shellId: string): Promise<KillCommandResult> {
-    return new Promise((resolve) => {
-      const sp = this.processes.get(shellId);
-      if (!sp) return resolve({ error: `Shell ID ${shellId} not found`, success: false });
-      const pid = sp.process.pid;
-      if (!pid) return resolve({ error: 'process has no pid', success: false });
+  subscribe(listener: () => void): () => void {
+    const wrapped = () => {
+      try {
+        listener();
+      } catch {
+        // Swallow — subscribers are responsible for their own logging.
+      }
+    };
+    this.subscribers.add(wrapped);
+    return () => {
+      this.subscribers.delete(wrapped);
+    };
+  }
 
-      treeKill(pid, 'SIGTERM', (err) => {
+  killTree(shellId: string, options: KillTreeOptions = {}): Promise<KillCommandResult> {
+    const sp = this.processes.get(shellId);
+    if (!sp) return Promise.resolve({ error: `Shell ID ${shellId} not found`, success: false });
+    const pid = sp.process.pid;
+    if (!pid) return Promise.resolve({ error: 'process has no pid', success: false });
+
+    const escalationDelayMs = options.escalationDelayMs ?? 3000;
+
+    return new Promise<KillCommandResult>((resolve) => {
+      treeKill(pid, 'SIGTERM', (termErr) => {
         setTimeout(() => {
           treeKill(pid, 'SIGKILL', () => {
             this.processes.delete(shellId);
             this.emitChange();
+            resolve({ error: termErr?.message, success: !termErr });
           });
-        }, 3000);
-        resolve({ error: err?.message, success: !err });
+        }, escalationDelayMs);
       });
     });
   }
@@ -192,26 +211,21 @@ export class ShellProcessManager {
     });
   }
 
-  async cleanupAll(): Promise<void> {
+  async cleanupAll(perEntryTimeoutMs = 1000): Promise<void> {
     const ids = [...this.processes.keys()];
-    for (const shellId of ids) {
-      await Promise.race([
-        this.killTree(shellId).catch(() => {}),
-        new Promise<void>((resolve) => setTimeout(resolve, 1000)),
-      ]);
-    }
-    this.processes.clear();
+    await Promise.allSettled(
+      ids.map((id) =>
+        Promise.race([
+          this.killTree(id, { escalationDelayMs: 500 }).catch(() => undefined),
+          new Promise<void>((resolve) => setTimeout(resolve, perEntryTimeoutMs)),
+        ]),
+      ),
+    );
+    // No .clear(): killTree's SIGKILL callback deletes each entry.
   }
 
   private emitChange(): void {
-    const listeners = this.events.rawListeners('change') as (() => void)[];
-    for (const fn of listeners) {
-      try {
-        fn();
-      } catch {
-        // subscriber errors must not propagate to the caller
-      }
-    }
+    for (const fn of this.subscribers) fn();
   }
 
   private toMeta(shellId: string, sp: ShellProcess): ShellProcessMeta {

--- a/packages/local-file-shell/src/shell/process-manager.ts
+++ b/packages/local-file-shell/src/shell/process-manager.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
 
 import treeKill from 'tree-kill';
 
@@ -37,6 +38,8 @@ export interface ShellProcessMeta {
 }
 
 export class ShellProcessManager {
+  readonly events = new EventEmitter();
+
   private nextShellId = 1;
 
   private processes = new Map<string, ShellProcess>();
@@ -53,11 +56,13 @@ export class ShellProcessManager {
 
     const markEnded = () => {
       shellProcess.endedAt ??= Date.now();
+      this.emitChange();
     };
 
     shellProcess.process.once('exit', markEnded);
     shellProcess.process.once('error', markEnded);
     this.processes.set(shellId, shellProcess);
+    this.emitChange();
   }
 
   list(): ShellProcessMeta[] {
@@ -171,6 +176,7 @@ export class ShellProcessManager {
         setTimeout(() => {
           treeKill(pid, 'SIGKILL', () => {
             this.processes.delete(shellId);
+            this.emitChange();
           });
         }, 3000);
         resolve({ error: err?.message, success: !err });
@@ -195,6 +201,17 @@ export class ShellProcessManager {
       ]);
     }
     this.processes.clear();
+  }
+
+  private emitChange(): void {
+    const listeners = this.events.rawListeners('change') as (() => void)[];
+    for (const fn of listeners) {
+      try {
+        fn();
+      } catch {
+        // subscriber errors must not propagate to the caller
+      }
+    }
   }
 
   private toMeta(shellId: string, sp: ShellProcess): ShellProcessMeta {

--- a/packages/local-file-shell/src/shell/process-manager.ts
+++ b/packages/local-file-shell/src/shell/process-manager.ts
@@ -225,7 +225,9 @@ export class ShellProcessManager {
   }
 
   private emitChange(): void {
-    for (const fn of this.subscribers) fn();
+    // Snapshot first: a listener that unsubscribes during emit must not skip later listeners.
+    const snapshot = Array.from(this.subscribers);
+    for (const fn of snapshot) fn();
   }
 
   private toMeta(shellId: string, sp: ShellProcess): ShellProcessMeta {

--- a/packages/local-file-shell/src/shell/process-manager.ts
+++ b/packages/local-file-shell/src/shell/process-manager.ts
@@ -1,5 +1,7 @@
 import type { ChildProcess } from 'node:child_process';
 
+import treeKill from 'tree-kill';
+
 import type { GetCommandOutputParams, GetCommandOutputResult, KillCommandResult } from '../types';
 import { truncateOutput } from './utils';
 
@@ -7,14 +9,31 @@ const DEFAULT_OBSERVATION_TIMEOUT_MS = 30_000;
 const MAX_OBSERVATION_TIMEOUT_MS = 120_000;
 
 export interface ShellProcess {
+  command: string;
+  cwd?: string;
   endedAt?: number;
   exitCode: number | null;
   lastReadStderr: number;
   lastReadStdout: number;
+  pgid?: number;
   process: ChildProcess;
+  processId: string;
+  runInBackground: boolean;
   startedAt?: number;
   stderr: string[];
   stdout: string[];
+}
+
+export interface ShellProcessMeta {
+  command: string;
+  cwd?: string;
+  exitCode: number | null;
+  pgid: number | undefined;
+  pid: number | undefined;
+  processId: string;
+  runInBackground: boolean;
+  shellId: string;
+  startedAt: number;
 }
 
 export class ShellProcessManager {
@@ -39,6 +58,20 @@ export class ShellProcessManager {
     shellProcess.process.once('exit', markEnded);
     shellProcess.process.once('error', markEnded);
     this.processes.set(shellId, shellProcess);
+  }
+
+  list(): ShellProcessMeta[] {
+    const result: ShellProcessMeta[] = [];
+    for (const [shellId, sp] of this.processes) {
+      if (sp.exitCode === null && sp.process.exitCode === null) {
+        result.push(this.toMeta(shellId, sp));
+      }
+    }
+    return result;
+  }
+
+  listAll(): ShellProcessMeta[] {
+    return [...this.processes.entries()].map(([shellId, sp]) => this.toMeta(shellId, sp));
   }
 
   async getOutput({
@@ -127,29 +160,54 @@ export class ShellProcessManager {
     };
   }
 
-  kill(shell_id: string): KillCommandResult {
-    const shellProcess = this.processes.get(shell_id);
-    if (!shellProcess) {
-      return { error: `Shell ID ${shell_id} not found`, success: false };
-    }
+  killTree(shellId: string): Promise<KillCommandResult> {
+    return new Promise((resolve) => {
+      const sp = this.processes.get(shellId);
+      if (!sp) return resolve({ error: `Shell ID ${shellId} not found`, success: false });
+      const pid = sp.process.pid;
+      if (!pid) return resolve({ error: 'process has no pid', success: false });
 
-    try {
-      shellProcess.process.kill();
-      this.processes.delete(shell_id);
-      return { success: true };
-    } catch (error) {
-      return { error: (error as Error).message, success: false };
-    }
+      treeKill(pid, 'SIGTERM', (err) => {
+        setTimeout(() => {
+          treeKill(pid, 'SIGKILL', () => {
+            this.processes.delete(shellId);
+          });
+        }, 3000);
+        resolve({ error: err?.message, success: !err });
+      });
+    });
   }
 
-  cleanupAll(): void {
-    for (const [id, sp] of this.processes) {
-      try {
-        sp.process.kill();
-      } catch {
-        // Ignore
-      }
-      this.processes.delete(id);
+  async killByPid(pid: number, force?: boolean): Promise<KillCommandResult> {
+    return new Promise((resolve) => {
+      treeKill(pid, force ? 'SIGKILL' : 'SIGTERM', (err) => {
+        resolve({ error: err?.message, success: !err });
+      });
+    });
+  }
+
+  async cleanupAll(): Promise<void> {
+    const ids = [...this.processes.keys()];
+    for (const shellId of ids) {
+      await Promise.race([
+        this.killTree(shellId).catch(() => {}),
+        new Promise<void>((resolve) => setTimeout(resolve, 1000)),
+      ]);
     }
+    this.processes.clear();
+  }
+
+  private toMeta(shellId: string, sp: ShellProcess): ShellProcessMeta {
+    return {
+      command: sp.command,
+      cwd: sp.cwd,
+      exitCode: sp.exitCode,
+      pgid: sp.pgid,
+      pid: sp.process.pid,
+      processId: sp.processId,
+      runInBackground: sp.runInBackground,
+      shellId,
+      startedAt: sp.startedAt ?? 0,
+    };
   }
 }

--- a/packages/local-file-shell/src/shell/runner.ts
+++ b/packages/local-file-shell/src/shell/runner.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 
 import type { RunCommandParams, RunCommandResult } from '../types';
 import type { ShellProcess, ShellProcessManager } from './process-manager';
@@ -32,21 +33,32 @@ export async function runCommand(
   logger?.debug(`${logPrefix} Starting`, { background: run_in_background, cwd, timeout });
 
   const shellConfig = getShellConfig(command);
-  const childEnv = extraEnv ? { ...process.env, ...extraEnv } : process.env;
+  const processId = randomUUID();
+  const childEnv = {
+    ...(extraEnv ? { ...process.env, ...extraEnv } : process.env),
+    LOBEHUB_PROCESS_ID: processId,
+  };
 
   try {
     const shellId = processManager.createShellId();
     const childProcess = spawn(shellConfig.cmd, shellConfig.args, {
       cwd,
+      detached: true,
       env: childEnv,
       shell: false,
     });
 
     const shellProcess: ShellProcess = {
+      command,
+      cwd,
       exitCode: null,
       lastReadStderr: 0,
       lastReadStdout: 0,
+      pgid: process.platform === 'win32' ? undefined : childProcess.pid,
       process: childProcess,
+      processId,
+      runInBackground: run_in_background ?? false,
+      startedAt: Date.now(),
       stderr: [],
       stdout: [],
     };


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Motivated by an Activity Monitor screenshot showing `agent-browser` daemon (and its `~/.agent-browser/default.sock`) still running after the desktop app quit. The user discovered weeks-old `agent-browser` processes their LobeHub agents had spawned and forgotten about. Tier 1 lays the groundwork; later PRs (see _Follow-up_ below) add the UI, the `&`-orphan scanner, and per-binary lifecycle hooks for self-daemonizing binaries.

#### 🔀 Description of Change

Foundational backend for tracking shell processes the desktop app spawns on behalf of chat-agent tool calls. Three real problems exist today:

1. **Explicitly-backgrounded shells** (`run_in_background: true` via the local-system-exec IPC) are registered in a process manager that has no `list()`, no UI surface, and a `cleanupAll()` that nothing ever invokes — so the user has no visibility and on app quit nothing is cleaned up.
2. **`ShellProcessManager.kill()` only kills the shell wrapper**, not its descendants. Spawning via `/bin/sh -c "<cmd>"` means killing `sh` rarely propagates to the actual workload; the documented Node.js behavior. Effectively the existing kill path is broken.
3. **`App.handleBeforeQuit` was synchronous** — even if `cleanupAll()` were wired in, Electron does not await async `before-quit` handlers, so any returned promise is silently dropped.

This PR rebuilds the foundation so subsequent PRs (UI, orphan scanner, binary lifecycle) have something safe to layer on.

##### What lands

- **`ShellProcessManager`** now carries per-entry metadata (`pgid`, `command`, `cwd`, `runInBackground`, `processId`, `startedAt`), spawns with `detached: true` (POSIX → `setsid` → new process group; Windows skipped — `pgid` left undefined), stamps every child env with `LOBEHUB_PROCESS_ID=<uuid>` (consumed by PR-3's orphan scanner), and exposes `list()` / `listAll()` / `killByPid()`. `killTree()` replaces `kill()` and uses `tree-kill` for actual descendant termination; SIGKILL escalation is now **awaited** inside the returned promise so shutdown can rely on it. `cleanupAll()` is async, parallelized via `Promise.allSettled`, and uses a short 500 ms escalation delay so dozens of stubborn processes fit inside the outer 3 s shutdown budget. A `subscribe(fn)` API replaces the prior in-place `EventEmitter` so a single change-source can fan out to future IPC push subscribers.
- **`ShellProcessPersister`** (new file in `apps/desktop/src/main/core/infrastructure/`) debounces a JSON snapshot of the live registry to `userData/processes.json` on every `change` (200 ms debounce, atomic write via `<file>.<pid>.<uuid>.tmp` + `rename`), and exposes a `recover()` that validates each entry with a PID-alive check plus a platform-specific start-time fingerprint (Linux `/proc/<pid>/stat` field 22; macOS `ps -o lstart=`; Windows skipped — Windows entries are always dropped on recover). `recover()` is implemented and tested here but not yet called — PR-4 wires it.
- **`App.shellProcessManager` and `App.shellProcessPersister`** become fields, constructed in the App constructor and reachable from any controller via `this.app.*`. Replaces a module-local `const processManager` singleton inside `ShellCommandCtr`.
- **`App.handleBeforeQuit`** uses the `event.preventDefault()` + `cleanupStarted` flag + `Promise.race([Promise.allSettled([cleanupAll()]), 3000ms]) + persister.detach() + persister.flush() + app.quit()` pattern, so cleanup actually runs before the app dies. Critically, the re-entry guard is a **separate** `cleanupStarted` flag, **not** `isQuiting` — `UpdaterManager.installNow` presets `isQuiting = true` before triggering `autoUpdater.quitAndInstall`, so guarding on `isQuiting` would silently skip cleanup during auto-update (exactly the path most likely to leak processes). The handler still sets `isQuiting = true` to preserve the downstream contract Browser / WindowStateManager consume. A marker comment in the cleanup array notes where PR-4 will wire `binaryManager.closeAllSessions()`.
- **Dependency**: `tree-kill ^1.2.2` added to `packages/local-file-shell`.

##### What's deliberately NOT here (deferred)

- **PR-2**: `BackgroundProcessesIndicator` UI inside `ChatInput/ControlBar` rightGroup, the IPC surface to drive it (`shellCommand.list / killProcess`, `binary.listAllSessions / closeSession`), redaction at the IPC boundary, i18n. The persister already produces the data; PR-2 reads it.
- **PR-3**: `ProcessScanner` that uses the `LOBEHUB_PROCESS_ID` env stamp to find orphaned children whose parent shells exited (the `command &` / `nohup` cases). Reads `/proc/<pid>/environ` on Linux; `ps eww` on macOS; no-op on Windows.
- **PR-4**: `BinaryManager.lifecycle` hook so `agent-browser` (and any future daemon-style binary) can surface its own sessions via `agent-browser session list --json` / `close` rather than relying on PID tracking. Calls `recover()` from this PR on startup to surface orphans from a previous crash. Adds `binaryManager.closeAllSessions()` into the cleanup race that already has a comment marker for it.

Design rationale, per-tier coverage, race-condition handling, persistence schema, and platform support matrix live in the spec (gitignored at `docs/superpowers/specs/2026-06-30-background-process-tracker-design.md`).

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

**Unit tests added/extended** (75 / 75 passing on darwin):

| File | New / Δ | Coverage |
|---|---|---|
| `packages/local-file-shell/src/shell/__tests__/process-manager.test.ts` | 30 tests (+25) | metadata, `list()` alive filter, `killTree` SIGTERM + awaited SIGKILL escalation, `killByPid`, parallel `cleanupAll` with per-entry race, `subscribe(fn)` + unsubscribe + throw isolation, `emitChange` iterates a snapshot |
| `packages/local-file-shell/src/shell/__tests__/runner.test.ts` | 24 tests (+4) | env `LOBEHUB_PROCESS_ID` stamp, `detached: true`, pgid population, metadata flow into register |
| `apps/desktop/src/main/core/infrastructure/__tests__/ShellProcessPersister.test.ts` | 10 tests (new) | debounce, atomic write (real fs into `mkdtemp`), missing-file / malformed-JSON / wrong-version recovery, alive PID + matching fingerprint kept, dead PID dropped, PID-reuse drop, `detach` stops listening, `flush` cancels pending debounce |
| `apps/desktop/src/main/controllers/__tests__/ShellCommandCtr.test.ts` | 6 tests (rewrite) | controller now reads `this.app.shellProcessManager`; `lh` / `lobe` / `lobehub` prefix all dispatch to `CliCtr` |
| `apps/desktop/src/main/core/__tests__/App.test.ts` | 5 tests (+4) | `runShutdownCleanup` awaits `cleanupAll`, honors the 3 s timeout, survives a thrown cleanup, asserts call order (`cleanupAll` before `app.quit`), re-entry guard via `cleanupStarted` |

**Manual smoke (not scripted; recommend the reviewer try one):** run `bunx vitest run --silent='passed-only'` per the table; spawn a long-running `sleep 60` via the local-system IPC with `run_in_background: true`; quit the desktop and verify the child is gone via `ps -A`; restart and verify `userData/processes.json` was either empty (clean quit) or recoverable.

#### 📸 Screenshots / Videos

No UI in this PR (deferred to PR-2). Settings → System Tools panel renders unchanged.

#### 📝 Additional Information

**Behavioral changes worth flagging in QA:**

- `runner.ts` now spawns shells with `detached: true` unconditionally. On macOS / Linux this gives the shell its own process group (intended). On Windows this can spawn a new console window — should be invisible without `stdio: 'inherit'`, but worth a quick QA pass.
- `killTree` no longer resolves until both SIGTERM AND the 3 s SIGKILL fallback have fired. Existing callers (`ShellCommandCtr.handleKillCommand`) await it; behaviorally the IPC `shellCommand.killCommand` now takes up to 3 s instead of returning instantly. Should be invisible to any UI that just awaits the promise.
- `userData/processes.json` is a new on-disk artifact. Schema: `{ version: 1, entries: [...] }`. Future incompatible schema bumps will be rejected by `recover()` (returns `[]`). Persisted `command` / `cwd` are NOT redacted at this layer — PR-2 will redact at the IPC boundary before display; secrets pasted into commands could appear in this file. The file lives in the user's `userData` (not synced unless the user backs that directory up themselves).
- On Windows, `getStartTimeFingerprint` returns `''` and all entries are dropped on `recover()` — Windows users get no orphan recovery in v1. Documented as deferred in the spec.

**Why a separate `cleanupStarted` flag** (the trickiest correctness call here): `UpdaterManager.installNow` already presets `app.isQuiting = true` and then calls `autoUpdater.quitAndInstall`. If the new handler had guarded on `isQuiting`, it would have short-circuited and never run cleanup during the most leak-prone path (auto-update). Splitting "I'm-quitting" from "cleanup-has-started" keeps both contracts intact. Caught in the whole-branch review before the PR landed; fix is `App.ts` only — `UpdaterManager.ts` is unchanged.