### PR TITLE
🐛 fix(connector): persist custom headers alongside any auth type

### DIFF
--- a/apps/server/src/services/connector/sync.test.ts
+++ b/apps/server/src/services/connector/sync.test.ts
@@ -5,7 +5,10 @@ import type { ConnectorCredentials } from '@/database/schemas';
 
 import { buildConnectorMcpParams, buildHttpAuthFromCredentials } from './sync';
 
-const httpConnector = (credentials: ConnectorCredentials | null): DecryptedConnector =>
+const httpConnector = (
+  credentials: ConnectorCredentials | null,
+  metadata?: Record<string, unknown>,
+): DecryptedConnector =>
   ({
     credentials,
     id: 'c1',
@@ -14,6 +17,7 @@ const httpConnector = (credentials: ConnectorCredentials | null): DecryptedConne
     mcpConnectionType: 'http',
     mcpServerUrl: 'https://mcp.example.com',
     mcpStdioConfig: null,
+    metadata: metadata ?? null,
     name: 'My Connector',
     oidcConfig: null,
   }) as any;
@@ -87,6 +91,54 @@ describe('buildConnectorMcpParams', () => {
     ).toEqual({
       auth: undefined,
       headers: { Authorization: 'Token x' },
+      name: 'My Connector',
+      type: 'http',
+      url: 'https://mcp.example.com',
+    });
+  });
+
+  it('merges metadata.customHeaders alongside bearer auth', () => {
+    expect(
+      buildConnectorMcpParams(
+        httpConnector(
+          { token: 'tok', type: 'bearer' },
+          { customHeaders: { 'X-Tenant': 't1' } },
+        ),
+      ),
+    ).toEqual({
+      auth: { token: 'tok', type: 'bearer' },
+      headers: { 'X-Tenant': 't1' },
+      name: 'My Connector',
+      type: 'http',
+      url: 'https://mcp.example.com',
+    });
+  });
+
+  it('applies metadata.customHeaders with no auth credential', () => {
+    expect(
+      buildConnectorMcpParams(
+        httpConnector(null, { customHeaders: { 'X-Api-Key': 'abc' } }),
+      ),
+    ).toEqual({
+      auth: undefined,
+      headers: { 'X-Api-Key': 'abc' },
+      name: 'My Connector',
+      type: 'http',
+      url: 'https://mcp.example.com',
+    });
+  });
+
+  it('lets metadata.customHeaders override legacy header-credential keys', () => {
+    expect(
+      buildConnectorMcpParams(
+        httpConnector(
+          { headers: { Authorization: 'Token old' }, type: 'header' },
+          { customHeaders: { Authorization: 'Token new' } },
+        ),
+      ),
+    ).toEqual({
+      auth: undefined,
+      headers: { Authorization: 'Token new' },
       name: 'My Connector',
       type: 'http',
       url: 'https://mcp.example.com',

--- a/apps/server/src/services/connector/sync.ts
+++ b/apps/server/src/services/connector/sync.ts
@@ -29,9 +29,16 @@ export const buildConnectorMcpParams = (
   }
   if (!connector.mcpServerUrl) throw new Error('Connector has no MCP server URL configured');
   const { auth, headers } = buildHttpAuthFromCredentials(connector.credentials);
+  // Custom headers live in `metadata.customHeaders` (plaintext, independent of
+  // the single-kind `credentials` column) so they can coexist with any auth
+  // type. Merge them on top of any header-type credential headers (older rows
+  // stored custom headers as a 'header' credential before this split).
+  const customHeaders = connector.metadata?.customHeaders as Record<string, string> | undefined;
+  const mergedHeaders =
+    headers || customHeaders ? { ...headers, ...customHeaders } : undefined;
   return {
     auth,
-    headers,
+    headers: mergedHeaders,
     name: connector.name,
     type: 'http',
     url: connector.mcpServerUrl,

--- a/src/features/Connectors/CustomConnectorModal/index.tsx
+++ b/src/features/Connectors/CustomConnectorModal/index.tsx
@@ -168,6 +168,16 @@ const CustomConnectorModal = memo<CustomConnectorModalProps>(
             ? 'header'
             : 'none';
 
+      // Custom headers now live in metadata; older rows stored them as a
+      // 'header'-type credential. Read metadata first, fall back to the legacy
+      // credential so existing connectors still pre-fill their headers — and do
+      // so regardless of the auth radio (headers can coexist with bearer auth).
+      const customHeaders =
+        (connector.metadata?.customHeaders as Record<string, string> | undefined) ??
+        (credentials?.type === 'header'
+          ? (credentials as { headers: Record<string, string> }).headers
+          : undefined);
+
       return {
         customParams: {
           description: connector.metadata?.description as string | undefined,
@@ -180,10 +190,7 @@ const CustomConnectorModal = memo<CustomConnectorModalProps>(
             },
             command: mcpStdioConfig?.command,
             env: mcpStdioConfig?.env,
-            headers:
-              authType === 'header'
-                ? (credentials as { headers: Record<string, string> })?.headers
-                : undefined,
+            headers: customHeaders,
             type: (connector.mcpConnectionType ?? 'http') as 'http' | 'stdio',
             url: connector.mcpServerUrl ?? undefined,
           },
@@ -250,21 +257,26 @@ const CustomConnectorModal = memo<CustomConnectorModalProps>(
 
         if (newUrl !== undefined) patch.mcpServerUrl = newUrl;
 
+        // Custom headers live in metadata (independent of the auth credential and
+        // of the server URL), so always re-sync them from the form. Merge into the
+        // existing metadata — a jsonb update replaces the whole column, so other
+        // keys (e.g. description) must be carried over. Also migrates legacy rows
+        // that stored headers as a 'header' credential (cleared below).
+        const headers = cleanRecord(mcp.headers);
+        const nextMetadata: Record<string, unknown> = { ...(connector?.metadata ?? {}) };
+        if (headers) nextMetadata.customHeaders = headers;
+        else delete nextMetadata.customHeaders;
+        patch.metadata = nextMetadata;
+
         if (urlChanged) {
-          // Clear stale credentials whenever the server URL changes.
+          // Clear stale auth credentials whenever the server URL changes.
           patch.credentials = null;
         } else if (authType === 'bearer' && mcp.auth?.token?.trim()) {
           patch.credentials = { token: mcp.auth.token.trim(), type: 'bearer' as const };
         } else if (authType !== 'oauth2') {
-          // Auth radio 'none' covers both "no auth" and "header auth" (headers live in
-          // the Advanced section, not the auth radio). Mirror the create-mode logic:
-          // any filled headers → header credentials; empty → clear credentials.
-          const headers = cleanRecord(mcp.headers);
-          if (headers) {
-            patch.credentials = { headers, type: 'header' as const };
-          } else {
-            patch.credentials = null;
-          }
+          // 'none' / header-only auth: no separate auth credential — custom headers
+          // are persisted via metadata above, so clear the credentials column.
+          patch.credentials = null;
         }
 
         if (authType === 'oauth2') {
@@ -345,16 +357,22 @@ const CustomConnectorModal = memo<CustomConnectorModalProps>(
         return;
       }
 
-      // None / bearer / custom headers: store credentials and sync the tool list.
+      // The auth credential (bearer token) and custom headers are stored
+      // separately: the credential goes in the encrypted single-kind
+      // `credentials` column, while custom headers live in
+      // `metadata.customHeaders` so they can coexist with no-auth OR bearer
+      // (the credentials column can only hold one credential kind at a time).
       const credentials =
         authType === 'bearer' && mcp.auth?.token?.trim()
           ? ({ token: mcp.auth.token.trim(), type: 'bearer' } as const)
-          : (() => {
-              const headers = cleanRecord(mcp.headers);
-              return headers ? ({ headers, type: 'header' } as const) : undefined;
-            })();
+          : undefined;
+      const headers = cleanRecord(mcp.headers);
 
-      const newConnectorId = await createConnector({ ...base, credentials });
+      const newConnectorId = await createConnector({
+        ...base,
+        credentials,
+        metadata: headers ? { customHeaders: headers } : undefined,
+      });
       await syncConnectorTools(newConnectorId);
     };
 

--- a/src/features/Connectors/CustomConnectorModal/index.tsx
+++ b/src/features/Connectors/CustomConnectorModal/index.tsx
@@ -262,11 +262,18 @@ const CustomConnectorModal = memo<CustomConnectorModalProps>(
         // existing metadata — a jsonb update replaces the whole column, so other
         // keys (e.g. description) must be carried over. Also migrates legacy rows
         // that stored headers as a 'header' credential (cleared below).
+        //
+        // Guard on `connector`: only rewrite metadata once the connector record is
+        // loaded, so we never overwrite a populated column with `{}` (which would
+        // drop sibling keys like description). In practice the form can't be
+        // submitted before `connector` resolves, but this keeps it safe.
         const headers = cleanRecord(mcp.headers);
-        const nextMetadata: Record<string, unknown> = { ...(connector?.metadata ?? {}) };
-        if (headers) nextMetadata.customHeaders = headers;
-        else delete nextMetadata.customHeaders;
-        patch.metadata = nextMetadata;
+        if (connector) {
+          const nextMetadata: Record<string, unknown> = { ...(connector.metadata ?? {}) };
+          if (headers) nextMetadata.customHeaders = headers;
+          else delete nextMetadata.customHeaders;
+          patch.metadata = nextMetadata;
+        }
 
         if (urlChanged) {
           // Clear stale auth credentials whenever the server URL changes.

--- a/src/libs/mcp/buildConnectorManifests.test.ts
+++ b/src/libs/mcp/buildConnectorManifests.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DecryptedConnector } from '@/database/models/connector';
+import type { ConnectorCredentials, UserConnectorToolItem } from '@/database/schemas';
+
+import { buildConnectorManifests } from './buildConnectorManifests';
+
+const httpConnector = (
+  credentials: ConnectorCredentials | null,
+  metadata?: Record<string, unknown>,
+): DecryptedConnector =>
+  ({
+    credentials,
+    id: 'c1',
+    identifier: 'my-conn',
+    isEnabled: true,
+    mcpConnectionType: 'http',
+    mcpServerUrl: 'https://mcp.example.com',
+    mcpStdioConfig: null,
+    metadata: metadata ?? null,
+    name: 'My Connector',
+    oidcConfig: null,
+  }) as any;
+
+const tool = (): UserConnectorToolItem =>
+  ({
+    crudType: 'read',
+    id: 't1',
+    inputSchema: { properties: {}, type: 'object' },
+    permission: 'auto',
+    toolName: 'doThing',
+    userConnectorId: 'c1',
+  }) as any;
+
+const mcpParamsOf = (connector: DecryptedConnector) => {
+  const [manifest] = buildConnectorManifests([connector], [tool()]);
+  // mcpParams is a runtime-only field not in the public ToolManifest type.
+  return (manifest as any).mcpParams as { auth?: unknown; headers?: Record<string, string> };
+};
+
+describe('buildConnectorManifests mcpParams headers', () => {
+  it('merges metadata.customHeaders alongside bearer auth', () => {
+    const params = mcpParamsOf(
+      httpConnector({ token: 'tok', type: 'bearer' }, { customHeaders: { 'X-Tenant': 't1' } }),
+    );
+
+    expect(params.auth).toEqual({ token: 'tok', type: 'bearer' });
+    expect(params.headers).toEqual({ 'X-Tenant': 't1' });
+  });
+
+  it('applies metadata.customHeaders with no auth credential', () => {
+    const params = mcpParamsOf(httpConnector(null, { customHeaders: { 'X-Api-Key': 'abc' } }));
+
+    expect(params.auth).toBeUndefined();
+    expect(params.headers).toEqual({ 'X-Api-Key': 'abc' });
+  });
+
+  it('lets metadata.customHeaders override legacy header-credential keys', () => {
+    const params = mcpParamsOf(
+      httpConnector(
+        { headers: { Authorization: 'Token old' }, type: 'header' },
+        { customHeaders: { Authorization: 'Token new' } },
+      ),
+    );
+
+    expect(params.headers).toEqual({ Authorization: 'Token new' });
+  });
+
+  it('leaves headers undefined when there are none (unchanged behavior)', () => {
+    const params = mcpParamsOf(httpConnector({ token: 'tok', type: 'bearer' }));
+
+    expect(params.auth).toEqual({ token: 'tok', type: 'bearer' });
+    expect(params.headers).toBeUndefined();
+  });
+});

--- a/src/libs/mcp/buildConnectorManifests.ts
+++ b/src/libs/mcp/buildConnectorManifests.ts
@@ -96,10 +96,17 @@ function buildMcpParams(connector: DecryptedConnector) {
   }
 
   const { auth, headers } = buildHttpAuthFromCredentials(connector.credentials);
+  // Custom headers live in `metadata.customHeaders` (independent of the
+  // single-kind `credentials` column) so they can coexist with bearer/no-auth.
+  // Merge them on top of any header-type credential headers (legacy rows), to
+  // mirror the sync/callTool path in services/connector/sync.ts.
+  const customHeaders = connector.metadata?.customHeaders as Record<string, string> | undefined;
+  const mergedHeaders =
+    headers || customHeaders ? { ...headers, ...customHeaders } : undefined;
 
   return {
     auth,
-    headers,
+    headers: mergedHeaders,
     name: connector.identifier,
     type: 'http' as const,
     url: connector.mcpServerUrl ?? '',

--- a/src/store/tool/slices/connector/action.ts
+++ b/src/store/tool/slices/connector/action.ts
@@ -68,6 +68,7 @@ export class ConnectorActionImpl {
         | null;
       isEnabled?: boolean;
       mcpServerUrl?: string;
+      metadata?: Record<string, unknown>;
       name?: string;
       oidcConfig?: {
         clientId?: string;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] ✅ test

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Custom MCP headers added under **Advanced** in the "Add Custom Connector" form were silently lost after Install + re-open to edit — but only for some auth types.

**Root cause:** custom headers were persisted into the connector `credentials` column, whose decrypted shape is a single-kind discriminated union (`bearer | apikey | header | oauth2`). A row can hold exactly **one** credential kind, so headers (`type: 'header'`) were mutually exclusive with a bearer token or OAuth:

- **No auth + headers** → stored as `{ type: 'header' }` → round-tripped fine ✅
- **API Key (bearer) + headers** → stored as `{ type: 'bearer' }`, headers dropped at save ❌
- **OAuth + headers** → only `oidcConfig` written, headers never touched ❌

The runtime (`buildHttpAuthFromCredentials`) was likewise auth-XOR-headers.

**Fix:** decouple custom headers from the auth credential. Store them in `metadata.customHeaders` (plaintext jsonb — **no schema migration**) and merge them into the request headers at runtime, on top of any legacy header-type credential. Headers can now coexist with **No auth** and **API Key**.

- `sync.ts` — merge `metadata.customHeaders` in `buildConnectorMcpParams` (covers both tool-sync and tool-call paths)
- `CustomConnectorModal/index.tsx` — write headers to `metadata` on create/edit; read from `metadata` on load, with a legacy `{ type: 'header' }` fallback so existing connectors still pre-fill (and auto-migrate on next save)
- `action.ts` — allow `metadata` in the `updateConnector` patch

**Out of scope:** OAuth + headers. The OAuth callback / token-refresh overwrites the whole `credentials` column on every write, so OAuth-scheme headers would need a separate persistence path; tracked for a follow-up.

> ⚠️ Note: `metadata.customHeaders` is stored **plaintext**. Since headers can carry secrets (e.g. `Authorization`, `X-Api-Key`), a future hardening could move them to a dedicated encrypted column (requires a migration).

#### 🧪 How to Test

1. Settings → Skills → **Add Custom Connector** → Streamable HTTP.
2. Pick **API Key**, fill the token, expand **Advanced**, add a custom header (e.g. `X-Tenant: t1`), Install.
3. Re-open the connector for edit → the custom header is now pre-filled ✅ (previously empty).
4. At request time both `Authorization: Bearer <token>` and the custom header are sent.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Unit tests (`apps/server/src/services/connector/sync.test.ts`, 12 passing) cover the bearer+headers merge, no-auth headers, and metadata-overrides-legacy-header cases.

#### 📸 Screenshots / Videos

<!-- N/A — behavior fix; no visual change -->

#### 📝 Additional Information

No DB migration. Backward compatible: existing rows that stored headers as a `header` credential are still honored at runtime and migrate to `metadata.customHeaders` on the next edit-save.