### PR TITLE
refactor: migrate createStyles to createStaticStyles

### DIFF
--- a/create_issues.ps1
+++ b/create_issues.ps1
@@ -1,0 +1,106 @@
+$repo = "lobehub/lobehub"
+
+# Issue 1
+$title1 = "[Tech Debt] Migrate createStyles to createStaticStyles for zero-runtime CSS-in-JS"
+$body1 = @"
+### Description
+According to the LobeHub development guidelines (`AGENTS.md` and `.cursor/docs/createStaticStyles_migration_guide.md`), `createStaticStyles` with `cssVar.*` should be preferred for zero-runtime overhead. Currently, there are several instances in the codebase using the older `createStyles` method that can be migrated to avoid runtime CSS generation overhead.
+
+### Locations to update
+- [src/features/Conversation/Messages/Verify/index.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/features/Conversation/Messages/Verify/index.tsx#L14)
+- [src/features/EditorCanvas/LinearFilePlugin.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/features/EditorCanvas/LinearFilePlugin.tsx#L14)
+- [src/features/PageEditor/PageEditor.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/features/PageEditor/PageEditor.tsx#L84)
+
+### Expected Behavior
+Refactor these styling blocks to use `createStaticStyles` where runtime computation is not genuinely required, improving rendering performance.
+"@
+$body1 | Out-File "issue1.md" -Encoding utf8
+gh issue create --repo $repo --title $title1 --body-file "issue1.md"
+
+# Issue 2
+$title2 = "[Tech Debt] Replace antd and @lobehub/ui primitive components with @lobehub/ui/base-ui"
+$body2 = @"
+### Description
+The contribution guidelines state that component priority should be `@lobehub/ui/base-ui` (headless primitives) first. However, the codebase still imports components like `Modal` and `Select` directly from `antd` or the root `@lobehub/ui` package. This breaks encapsulation and inflates the bundle size unnecessarily.
+
+### Locations to update
+**antd imports:**
+- [src/features/Electron/updater/UpdateNotification.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/features/Electron/updater/UpdateNotification.tsx#L4)
+- [src/features/ResourceManager/components/Editor/index.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/features/ResourceManager/components/Editor/index.tsx#L4)
+- [src/routes/(main)/community/(detail)/workspace/features/WorkspaceStatusFilter.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/routes/(main)/community/(detail)/workspace/features/WorkspaceStatusFilter.tsx#L3)
+
+**@lobehub/ui root imports (should be base-ui):**
+- [src/features/DocumentModal/index.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/features/DocumentModal/index.tsx#L3)
+- [src/routes/(main)/agent/profile/features/AgentSettings/index.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/routes/(main)/agent/profile/features/AgentSettings/index.tsx#L3)
+
+### Expected Behavior
+Update the import paths for primitives like `Modal`, `Select`, `DropdownMenu`, etc., to `@lobehub/ui/base-ui` across these components.
+"@
+$body2 | Out-File "issue2.md" -Encoding utf8
+gh issue create --repo $repo --title $title2 --body-file "issue2.md"
+
+# Issue 3
+$title3 = "[Refactor] Remove unnecessary return await from async functions"
+$body3 = @"
+### Description
+The codebase contains numerous `return await` statements within async functions (especially inside the TRPC routers). As per the code review checklist (`AGENTS.md`), `return await` is considered an anti-pattern (unless inside a `try/catch` block) because it adds an unnecessary microtask to the execution stack. 
+
+### Locations to update
+Hundreds of instances exist, particularly in:
+- `apps/server/src/routers/lambda/agentDocument.ts` (e.g., [line 467](https://github.com/lobehub/lobe-chat/blob/main/apps/server/src/routers/lambda/agentDocument.ts#L467))
+- `apps/server/src/routers/lambda/agentSkills.ts`
+
+### Expected Behavior
+Run a linting rule or a codemod to identify and safely remove `return await` across the codebase where it isn't wrapped in a `try/catch`.
+"@
+$body3 | Out-File "issue3.md" -Encoding utf8
+gh issue create --repo $repo --title $title3 --body-file "issue3.md"
+
+# Issue 4
+$title4 = "[Tech Debt] Clean up console.log leftovers in production frontend code"
+$body4 = @"
+### Description
+The code review checklist prohibits leaving `console.log` statements in the codebase. While some are valid inside scripts, there are several `console.log` leftovers in the frontend source code that should be replaced with the `@lobehub/debug` utility (or removed entirely) to avoid polluting the production console.
+
+### Locations to update
+- [src/business/client/BusinessSettingPages/SubscriptionIframeWrapper.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/business/client/BusinessSettingPages/SubscriptionIframeWrapper.tsx#L79)
+
+### Expected Behavior
+Remove these leftover `console.log` statements or migrate them to use the appropriate `lobe-*` debug namespace.
+"@
+$body4 | Out-File "issue4.md" -Encoding utf8
+gh issue create --repo $repo --title $title4 --body-file "issue4.md"
+
+# Issue 5
+$title5 = "[Types] Resolve @ts-expect-error suppressions in production code"
+$body5 = @"
+### Description
+While `@ts-expect-error` and `any` types are sometimes necessary in test files to mock edge cases, they are currently bleeding into production files. This suppresses potential runtime errors and degrades overall type safety.
+
+### Locations to update
+- [src/components/server/ServerLayout.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/components/server/ServerLayout.tsx#L17)
+- [src/features/NavPanel/components/BackButton.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/features/NavPanel/components/BackButton.tsx#L18)
+- [src/libs/better-auth/sso/index.ts](https://github.com/lobehub/lobe-chat/blob/main/src/libs/better-auth/sso/index.ts#L94)
+
+### Expected Behavior
+Review these instances and replace them with proper TypeScript typings and interfaces.
+"@
+$body5 | Out-File "issue5.md" -Encoding utf8
+gh issue create --repo $repo --title $title5 --body-file "issue5.md"
+
+# Issue 6
+$title6 = "[Architecture] Split RuntimeExecutors.ts into smaller modules"
+$body6 = @"
+### Description
+According to the LobeHub Code Style guidelines: *"When a single file grows beyond ~800 lines, consider splitting it into multiple files"*. 
+
+Currently, `RuntimeExecutors.ts` has grown to over 4,200 lines of code, making it difficult to navigate, review, and maintain for both developers and AI agents.
+
+### Location to update
+- [apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts](https://github.com/lobehub/lobe-chat/blob/main/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts)
+
+### Expected Behavior
+Refactor this monolithic file by extracting sub-components, helper functions, types, and logic blocks into smaller, focused modules within the `AgentRuntime` directory.
+"@
+$body6 | Out-File "issue6.md" -Encoding utf8
+gh issue create --repo $repo --title $title6 --body-file "issue6.md"

--- a/issue1.md
+++ b/issue1.md
@@ -1,0 +1,10 @@
+﻿### Description
+According to the LobeHub development guidelines (AGENTS.md and .cursor/docs/createStaticStyles_migration_guide.md), createStaticStyles with cssVar.* should be preferred for zero-runtime overhead. Currently, there are several instances in the codebase using the older createStyles method that can be migrated to avoid runtime CSS generation overhead.
+
+### Locations to update
+- [src/features/Conversation/Messages/Verify/index.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/features/Conversation/Messages/Verify/index.tsx#L14)
+- [src/features/EditorCanvas/LinearFilePlugin.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/features/EditorCanvas/LinearFilePlugin.tsx#L14)
+- [src/features/PageEditor/PageEditor.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/features/PageEditor/PageEditor.tsx#L84)
+
+### Expected Behavior
+Refactor these styling blocks to use createStaticStyles where runtime computation is not genuinely required, improving rendering performance.

--- a/issue2.md
+++ b/issue2.md
@@ -1,0 +1,15 @@
+﻿### Description
+The contribution guidelines state that component priority should be @lobehub/ui/base-ui (headless primitives) first. However, the codebase still imports components like Modal and Select directly from ntd or the root @lobehub/ui package. This breaks encapsulation and inflates the bundle size unnecessarily.
+
+### Locations to update
+**antd imports:**
+- [src/features/Electron/updater/UpdateNotification.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/features/Electron/updater/UpdateNotification.tsx#L4)
+- [src/features/ResourceManager/components/Editor/index.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/features/ResourceManager/components/Editor/index.tsx#L4)
+- [src/routes/(main)/community/(detail)/workspace/features/WorkspaceStatusFilter.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/routes/(main)/community/(detail)/workspace/features/WorkspaceStatusFilter.tsx#L3)
+
+**@lobehub/ui root imports (should be base-ui):**
+- [src/features/DocumentModal/index.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/features/DocumentModal/index.tsx#L3)
+- [src/routes/(main)/agent/profile/features/AgentSettings/index.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/routes/(main)/agent/profile/features/AgentSettings/index.tsx#L3)
+
+### Expected Behavior
+Update the import paths for primitives like Modal, Select, DropdownMenu, etc., to @lobehub/ui/base-ui across these components.

--- a/issue3.md
+++ b/issue3.md
@@ -1,0 +1,10 @@
+﻿### Description
+The codebase contains numerous eturn await statements within async functions (especially inside the TRPC routers). As per the code review checklist (AGENTS.md), eturn await is considered an anti-pattern (unless inside a 	ry/catch block) because it adds an unnecessary microtask to the execution stack. 
+
+### Locations to update
+Hundreds of instances exist, particularly in:
+- pps/server/src/routers/lambda/agentDocument.ts (e.g., [line 467](https://github.com/lobehub/lobe-chat/blob/main/apps/server/src/routers/lambda/agentDocument.ts#L467))
+- pps/server/src/routers/lambda/agentSkills.ts
+
+### Expected Behavior
+Run a linting rule or a codemod to identify and safely remove eturn await across the codebase where it isn't wrapped in a 	ry/catch.

--- a/issue4.md
+++ b/issue4.md
@@ -1,0 +1,8 @@
+﻿### Description
+The code review checklist prohibits leaving console.log statements in the codebase. While some are valid inside scripts, there are several console.log leftovers in the frontend source code that should be replaced with the @lobehub/debug utility (or removed entirely) to avoid polluting the production console.
+
+### Locations to update
+- [src/business/client/BusinessSettingPages/SubscriptionIframeWrapper.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/business/client/BusinessSettingPages/SubscriptionIframeWrapper.tsx#L79)
+
+### Expected Behavior
+Remove these leftover console.log statements or migrate them to use the appropriate lobe-* debug namespace.

--- a/issue5.md
+++ b/issue5.md
@@ -1,0 +1,10 @@
+﻿### Description
+While @ts-expect-error and ny types are sometimes necessary in test files to mock edge cases, they are currently bleeding into production files. This suppresses potential runtime errors and degrades overall type safety.
+
+### Locations to update
+- [src/components/server/ServerLayout.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/components/server/ServerLayout.tsx#L17)
+- [src/features/NavPanel/components/BackButton.tsx](https://github.com/lobehub/lobe-chat/blob/main/src/features/NavPanel/components/BackButton.tsx#L18)
+- [src/libs/better-auth/sso/index.ts](https://github.com/lobehub/lobe-chat/blob/main/src/libs/better-auth/sso/index.ts#L94)
+
+### Expected Behavior
+Review these instances and replace them with proper TypeScript typings and interfaces.

--- a/issue6.md
+++ b/issue6.md
@@ -1,0 +1,10 @@
+﻿### Description
+According to the LobeHub Code Style guidelines: *"When a single file grows beyond ~800 lines, consider splitting it into multiple files"*. 
+
+Currently, RuntimeExecutors.ts has grown to over 4,200 lines of code, making it difficult to navigate, review, and maintain for both developers and AI agents.
+
+### Location to update
+- [apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts](https://github.com/lobehub/lobe-chat/blob/main/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts)
+
+### Expected Behavior
+Refactor this monolithic file by extracting sub-components, helper functions, types, and logic blocks into smaller, focused modules within the AgentRuntime directory.

--- a/scratch/body-crawler.md
+++ b/scratch/body-crawler.md
@@ -1,0 +1,7 @@
+### 🛠️ Problem
+Large HTML pages parsed via JSDOM and `@mozilla/readability` were failing because they were nested inside `document.body.innerHTML`, producing malformed DOM trees where `<html>` and `<head>` tags were parsed as body content. This prevented Readability from extracting metadata and article content, causing web crawler requests to return empty/too-short markdown for large modern pages.
+
+### ⚙️ Solution
+Use `document.write(html)` instead of `document.body.innerHTML = html` on the happy-dom document, which properly parses complete HTML document hierarchies (retaining meta tags, html attributes like lang, etc.). Update snapshot tests to reflect the improved metadata extraction.
+
+Fixes #15180

--- a/scratch/fix_prs.mjs
+++ b/scratch/fix_prs.mjs
@@ -1,0 +1,42 @@
+import { execSync } from 'child_process';
+
+const prs = [
+  {
+    num: 16138,
+    title: '♻️ refactor(community): remove unsafe "catch (error: any)" in fork actions',
+    body: '## Description\n\nReplaces "catch (error: any)" with standard "catch (error)" in the community route\'s fork action handlers. console.error safely accepts unknown errors, so bypassing TypeScript\'s safety with "any" is unnecessary.'
+  },
+  {
+    num: 16137,
+    title: '♻️ refactor(eval): replace unsafe "catch (error: any)" with safe Error cast',
+    body: '## Description\n\nReplaces "catch (error: any)" with standard "catch (error)" across the eval route components. To safely extract the error message for toast notifications, the unknown error is safely cast as "(error as Error)?.message", eliminating the unsafe "any" typing.'
+  },
+  {
+    num: 16108,
+    title: '♻️ refactor(services): remove redundant "return await" from remaining services',
+    body: '## Description\n\nRemoves unnecessary "return await" statements from upload, export, and agentRuntime services. Returning a promise directly without await avoids creating a redundant microtask, which is an ESLint/TypeScript best practice.'
+  },
+  {
+    num: 16105,
+    title: '♻️ refactor(loaders): remove redundant "return await" from document loaders',
+    body: '## Description\n\nRemoves 9 redundant "return await" statements from document loader factories (e.g. Unstructured, PDF, JSON). Returning a promise directly without await avoids generating an unnecessary microtask, aligning with TypeScript/ESLint best practices.'
+  },
+  {
+    num: 16104,
+    title: '♻️ refactor(service): remove redundant "return await" from aiAgent service',
+    body: '## Description\n\nRemoves 8 redundant "return await" statements from the aiAgent service. Returning a promise directly without await avoids generating an unnecessary microtask during execution, which is a standard ESLint and TypeScript best practice.'
+  },
+  {
+    num: 16100,
+    title: '♻️ refactor: remove fragile "as any" monkey-patch on ReadableStream controller',
+    body: '## Description\n\nRemoves an unsafe "as any" monkey-patch where an internal "_cleanup" function was manually attached to a ReadableStream controller. I replaced this anti-pattern with a standard AbortController approach to manage stream interruption cleanly and type-safely.'
+  }
+];
+
+for (const pr of prs) {
+  console.log(`Updating PR ${pr.num}...`);
+  // Use spawnSync or execFileSync so we can pass arguments safely without shell escaping issues
+  import('child_process').then(cp => {
+    cp.execFileSync('gh', ['pr', 'edit', pr.num.toString(), '--title', pr.title, '--body', pr.body], { stdio: 'inherit' });
+  });
+}

--- a/src/features/Conversation/Messages/Verify/index.tsx
+++ b/src/features/Conversation/Messages/Verify/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { createStyles } from 'antd-style';
+import { createStaticStyles, useTheme } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { memo } from 'react';
 
@@ -11,12 +11,12 @@ import { phaseCardBackground, phaseFromStatus } from '@/features/Verify/utils';
 
 import { dataSelectors, useConversationStore } from '../../store';
 
-const useStyles = createStyles(({ css, token }) => ({
+const useStyles = createStaticStyles(({ css, cssVar }) => ({
   card: css`
     overflow: hidden;
-    border: 1px solid ${token.colorBorderSecondary};
+    border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: 16px;
-    background: ${token.colorBgElevated};
+    background: ${cssVar.colorBgElevated};
   `,
 }));
 
@@ -33,7 +33,8 @@ interface VerifyMessageProps {
  * group (no avatar bubble).
  */
 const VerifyMessage = memo<VerifyMessageProps>(({ id }) => {
-  const { styles, theme } = useStyles();
+  const styles = useStyles();
+  const theme = useTheme();
   const item = useConversationStore(dataSelectors.getDisplayMessageById(id), isEqual);
   const operationId = item?.metadata?.verifyOperationId;
   // Sequence number among all verify messages in the thread (not the repair round).

--- a/src/features/EditorCanvas/LinearFilePlugin.tsx
+++ b/src/features/EditorCanvas/LinearFilePlugin.tsx
@@ -3,7 +3,7 @@
 import { downloadFile } from '@lobechat/utils/client';
 import { FilePlugin, UploadPlugin, useLexicalComposerContext } from '@lobehub/editor';
 import { ActionIcon } from '@lobehub/ui';
-import { createStyles } from 'antd-style';
+import { createStaticStyles } from 'antd-style';
 import { DownloadIcon } from 'lucide-react';
 import { type FC, memo, useLayoutEffect } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import FileIcon from '@/components/FileIcon';
 import { formatSize } from '@/utils/format';
 
-const useStyles = createStyles(({ css, cssVar, token }) => ({
+const useStyles = createStaticStyles(({ css, cssVar }) => ({
   card: css`
     cursor: pointer;
 
@@ -23,17 +23,17 @@ const useStyles = createStyles(({ css, cssVar, token }) => ({
     width: 100%;
     padding-block: 10px;
     padding-inline: 12px;
-    border: 1px solid ${token.colorBorderSecondary};
-    border-radius: ${token.borderRadiusLG}px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusLG};
 
-    color: ${token.colorText};
+    color: ${cssVar.colorText};
 
-    background: ${token.colorBgContainer};
+    background: ${cssVar.colorBgContainer};
 
     transition: background ${cssVar.motionDurationMid};
 
     &:hover {
-      background: ${token.colorFillTertiary};
+      background: ${cssVar.colorFillTertiary};
     }
 
     &:hover [data-lobehub-file-download] {
@@ -53,18 +53,18 @@ const useStyles = createStyles(({ css, cssVar, token }) => ({
   name: css`
     overflow: hidden;
 
-    font-size: ${token.fontSize}px;
+    font-size: ${cssVar.fontSize};
     font-weight: 500;
     line-height: 1.4;
-    color: ${token.colorText};
+    color: ${cssVar.colorText};
     text-overflow: ellipsis;
     white-space: nowrap;
   `,
   size: css`
     margin-block-start: 2px;
-    font-size: ${token.fontSizeSM}px;
+    font-size: ${cssVar.fontSizeSM};
     line-height: 1.4;
-    color: ${token.colorTextTertiary};
+    color: ${cssVar.colorTextTertiary};
   `,
   state: css`
     display: flex;
@@ -73,12 +73,12 @@ const useStyles = createStyles(({ css, cssVar, token }) => ({
 
     padding-block: 10px;
     padding-inline: 12px;
-    border: 1px solid ${token.colorBorderSecondary};
-    border-radius: ${token.borderRadiusLG}px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusLG};
 
-    color: ${token.colorTextSecondary};
+    color: ${cssVar.colorTextSecondary};
 
-    background: ${token.colorBgContainer};
+    background: ${cssVar.colorBgContainer};
   `,
 }));
 
@@ -95,7 +95,7 @@ interface LinearFileCardProps {
 }
 
 export const LinearFileCard = memo<LinearFileCardProps>(({ node }) => {
-  const { styles } = useStyles();
+  const styles = useStyles();
   const { t } = useTranslation('editor');
 
   const { fileUrl, message, name, size, status } = node;

--- a/src/features/PageEditor/PageEditor.tsx
+++ b/src/features/PageEditor/PageEditor.tsx
@@ -2,7 +2,7 @@
 
 import { DEFAULT_BLOCK_ANCHOR_PADDING, EditorProvider } from '@lobehub/editor/react';
 import { Flexbox } from '@lobehub/ui';
-import { createStyles, cssVar } from 'antd-style';
+import { createStaticStyles, cssVar } from 'antd-style';
 import type { CSSProperties, FC, ReactNode, UIEvent } from 'react';
 import { memo, useCallback, useEffect, useRef } from 'react';
 
@@ -81,7 +81,7 @@ const styles = StyleSheet.create({
   },
 });
 
-const useTableOverrideStyles = createStyles(({ css }) => ({
+const useTableOverrideStyles = createStaticStyles(({ css }) => ({
   editorContent: css`
     .lobe-editor-table-scroll-wrapper.lobe-editor-table-scroll-wrapper {
       --lobe-block-anchor-padding: var(--lobe-pageeditor-table-bleed-inline);
@@ -149,7 +149,7 @@ const PageEditorCanvas = memo<PageEditorCanvasProps>(({ header, fullWidthHeader,
   const editor = usePageEditorStore((s) => s.editor);
   const documentId = usePageEditorStore((s) => s.documentId);
   const wideScreen = useGlobalStore(systemStatusSelectors.wideScreen);
-  const { styles: overrideStyles } = useTableOverrideStyles();
+  const overrideStyles = useTableOverrideStyles();
   const tableBleedInline = wideScreen
     ? `${TABLE_BASE_BLEED}px`
     : `calc(${TABLE_BASE_BLEED}px + max((100cqi - ${CONVERSATION_MIN_WIDTH}px) / 2, 0px))`;


### PR DESCRIPTION
Closes #16440

Migrates remaining components to use createStaticStyles for zero-runtime CSS-in-JS according to the migration guide.