### PR TITLE
refactor: replace primitive components with base-ui

### DIFF
--- a/src/features/ChatInput/Desktop/ContextContainer/ContextItem/FilePreviewModal.tsx
+++ b/src/features/ChatInput/Desktop/ContextContainer/ContextItem/FilePreviewModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Modal } from '@lobehub/ui';
+import { Modal } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 
 import FileViewer from '@/features/FileViewer';

--- a/src/features/DocumentModal/index.tsx
+++ b/src/features/DocumentModal/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Modal } from '@lobehub/ui';
+import { Modal } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 
 import { PageAgentPanelOverrideProvider } from '@/features/PageEditor/RightPanel/OverrideContext';

--- a/src/features/PluginDetailModal/index.tsx
+++ b/src/features/PluginDetailModal/index.tsx
@@ -1,4 +1,4 @@
-import { Modal } from '@lobehub/ui';
+import { Modal } from '@lobehub/ui/base-ui';
 import { Tabs, type TabsItem } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/UserLevelSkills.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/UserLevelSkills.tsx
@@ -1,4 +1,4 @@
-import { Modal } from '@lobehub/ui';
+import { Modal } from '@lobehub/ui/base-ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import isEqual from 'fast-deep-equal';

--- a/src/routes/(main)/community/(detail)/workspace/features/WorkspaceStatusFilter.tsx
+++ b/src/routes/(main)/community/(detail)/workspace/features/WorkspaceStatusFilter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Select } from 'antd';
+import { Select } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/routes/(main)/resource/features/modal/FullscreenModal.tsx
+++ b/src/routes/(main)/resource/features/modal/FullscreenModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Modal } from '@lobehub/ui';
+import { Modal } from '@lobehub/ui/base-ui';
 import { ConfigProvider } from 'antd';
 import { createStaticStyles, cx } from 'antd-style';
 import { type ReactNode } from 'react';

--- a/src/routes/(mobile)/chat/features/Topic/features/TopicModal.tsx
+++ b/src/routes/(mobile)/chat/features/Topic/features/TopicModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Modal } from '@lobehub/ui';
+import { Modal } from '@lobehub/ui/base-ui';
 import type { PropsWithChildren } from 'react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';


### PR DESCRIPTION
Closes #16441

Replaces imports of primitive components like Modal and Select from antd or @lobehub/ui root to @lobehub/ui/base-ui.