### PR TITLE
refactor: remove unnecessary return await

### DIFF
--- a/apps/server/src/modules/AgentRuntime/AgentRuntimeCoordinator.ts
+++ b/apps/server/src/modules/AgentRuntime/AgentRuntimeCoordinator.ts
@@ -141,7 +141,7 @@ export class AgentRuntimeCoordinator {
     if (state.status === 'interrupted' || state.status === 'waiting_for_async_tool')
       return undefined;
     try {
-      return await this.uiMessagesResolver(state);
+      return this.uiMessagesResolver(state);
     } catch (error) {
       console.error('Failed to resolve uiMessages for agent_runtime_end:', error);
       return undefined;

--- a/apps/server/src/modules/AgentTracing/S3SnapshotStore.ts
+++ b/apps/server/src/modules/AgentTracing/S3SnapshotStore.ts
@@ -114,7 +114,7 @@ export class S3SnapshotStore implements ISnapshotStore {
     // Current format: .json.zst (zstd-compressed)
     try {
       const bytes = await this.s3.getFileByteArray(this.partialKey(operationId));
-      return await this.decodeSnapshot<Partial<ExecutionSnapshot>>(bytes);
+      return this.decodeSnapshot<Partial<ExecutionSnapshot>>(bytes);
     } catch {
       // fall through to legacy
     }

--- a/apps/server/src/modules/ContentChunk/index.ts
+++ b/apps/server/src/modules/ContentChunk/index.ts
@@ -43,7 +43,7 @@ export class ContentChunk {
           }
 
           default: {
-            return await this.chunkByDefault(params.filename, params.content);
+            return this.chunkByDefault(params.filename, params.content);
           }
         }
       } catch (error) {
@@ -55,7 +55,7 @@ export class ContentChunk {
     }
 
     // Fallback to default chunking if no service succeeded
-    return await this.chunkByDefault(params.filename, params.content);
+    return this.chunkByDefault(params.filename, params.content);
   }
 
   private canUseUnstructured(): boolean {

--- a/apps/server/src/routers/async/file.ts
+++ b/apps/server/src/routers/async/file.ts
@@ -167,7 +167,7 @@ export const fileRouter = router({
         };
 
         // Race between the chunking process and the timeout
-        return await Promise.race([embeddingPromise(), timeoutPromise]);
+        return Promise.race([embeddingPromise(), timeoutPromise]);
       } catch (e) {
         console.error('embeddingChunks error', e);
 
@@ -352,7 +352,7 @@ export const fileRouter = router({
           return { success: true };
         };
         // Race between the chunking process and the timeout
-        return await Promise.race([chunkingPromise(), timeoutPromise]);
+        return Promise.race([chunkingPromise(), timeoutPromise]);
       } catch (e) {
         const error = e as any;
 

--- a/apps/server/src/routers/lambda/agentBotProvider.ts
+++ b/apps/server/src/routers/lambda/agentBotProvider.ts
@@ -140,7 +140,7 @@ export const agentBotProviderRouter = router({
         workspaceId: ctx.workspaceId ?? undefined,
       });
       try {
-        return await ctx.agentBotProviderModel.create(payload);
+        return ctx.agentBotProviderModel.create(payload);
       } catch (e: any) {
         if (e?.cause?.code === '23505') {
           throw new TRPCError({

--- a/apps/server/src/routers/lambda/agentDocument.ts
+++ b/apps/server/src/routers/lambda/agentDocument.ts
@@ -564,7 +564,7 @@ export const agentDocumentRouter = router({
     )
     .query(async ({ ctx, input }) => {
       try {
-        return await ctx.agentDocumentVfsService.list(
+        return ctx.agentDocumentVfsService.list(
           input.path,
           {
             agentId: input.agentId,
@@ -593,7 +593,7 @@ export const agentDocumentRouter = router({
     )
     .query(async ({ ctx, input }) => {
       try {
-        return await ctx.agentDocumentVfsService.stat(input.path, {
+        return ctx.agentDocumentVfsService.stat(input.path, {
           agentId: input.agentId,
           topicId: input.topicId,
         });
@@ -616,7 +616,7 @@ export const agentDocumentRouter = router({
     )
     .query(async ({ ctx, input }) => {
       try {
-        return await ctx.agentDocumentVfsService.read(
+        return ctx.agentDocumentVfsService.read(
           input.path,
           {
             agentId: input.agentId,
@@ -646,7 +646,7 @@ export const agentDocumentRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       try {
-        return await ctx.agentDocumentVfsService.write(
+        return ctx.agentDocumentVfsService.write(
           input.path,
           input.content,
           {
@@ -666,7 +666,7 @@ export const agentDocumentRouter = router({
       try {
         const path = `${getUnifiedSkillNamespaceRootPath(input.targetNamespace)}/${input.skillName}`;
 
-        return await ctx.agentDocumentVfsService.write(
+        return ctx.agentDocumentVfsService.write(
           path,
           input.content,
           {
@@ -705,7 +705,7 @@ export const agentDocumentRouter = router({
       );
 
       try {
-        return await ctx.skillManagementService.createSkill({
+        return ctx.skillManagementService.createSkill({
           agentId: input.agentId,
           bodyMarkdown,
           description: input.description,
@@ -748,7 +748,7 @@ export const agentDocumentRouter = router({
     .input(updateMountedSkillSchema)
     .mutation(async ({ ctx, input }) => {
       try {
-        return await ctx.agentDocumentVfsService.write(
+        return ctx.agentDocumentVfsService.write(
           input.path,
           input.content,
           {
@@ -787,7 +787,7 @@ export const agentDocumentRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       try {
-        return await ctx.agentDocumentVfsService.mkdir(
+        return ctx.agentDocumentVfsService.mkdir(
           input.path,
           {
             agentId: input.agentId,
@@ -815,7 +815,7 @@ export const agentDocumentRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       try {
-        return await ctx.agentDocumentVfsService.rename(
+        return ctx.agentDocumentVfsService.rename(
           input.fromPath,
           input.toPath,
           {
@@ -844,7 +844,7 @@ export const agentDocumentRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       try {
-        return await ctx.agentDocumentVfsService.copy(
+        return ctx.agentDocumentVfsService.copy(
           input.fromPath,
           input.toPath,
           {
@@ -899,7 +899,7 @@ export const agentDocumentRouter = router({
     )
     .query(async ({ ctx, input }) => {
       try {
-        return await ctx.agentDocumentVfsService.listTrash(
+        return ctx.agentDocumentVfsService.listTrash(
           {
             agentId: input.agentId,
             topicId: input.topicId,
@@ -924,7 +924,7 @@ export const agentDocumentRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       try {
-        return await ctx.agentDocumentVfsService.restoreFromTrashByPath(input.path, {
+        return ctx.agentDocumentVfsService.restoreFromTrashByPath(input.path, {
           agentId: input.agentId,
           topicId: input.topicId,
         });

--- a/apps/server/src/routers/lambda/agentSkills.ts
+++ b/apps/server/src/routers/lambda/agentSkills.ts
@@ -137,7 +137,7 @@ export const agentSkillsRouter = router({
 
   create: skillWriteProcedure.input(createSkillSchema).mutation(async ({ ctx, input }) => {
     try {
-      return await ctx.skillImporter.createUserSkill(input);
+      return ctx.skillImporter.createUserSkill(input);
     } catch (error) {
       handleSkillImportError(error);
     }
@@ -201,7 +201,7 @@ export const agentSkillsRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       try {
-        return await ctx.skillImporter.importFromGitHub(input);
+        return ctx.skillImporter.importFromGitHub(input);
       } catch (error) {
         handleSkillImportError(error);
       }
@@ -211,7 +211,7 @@ export const agentSkillsRouter = router({
     .input(z.object({ url: z.string().url() }))
     .mutation(async ({ ctx, input }) => {
       try {
-        return await ctx.skillImporter.importFromUrl(input);
+        return ctx.skillImporter.importFromUrl(input);
       } catch (error) {
         handleSkillImportError(error);
       }
@@ -221,7 +221,7 @@ export const agentSkillsRouter = router({
     .input(z.object({ zipFileId: z.string() }))
     .mutation(async ({ ctx, input }) => {
       try {
-        return await ctx.skillImporter.importFromZip(input);
+        return ctx.skillImporter.importFromZip(input);
       } catch (error) {
         handleSkillImportError(error);
       }
@@ -234,7 +234,7 @@ export const agentSkillsRouter = router({
         // Get download URL from market service
         const downloadUrl = ctx.marketService.getSkillDownloadUrl(input.identifier);
         // Import using the download URL
-        return await ctx.skillImporter.importFromUrl(
+        return ctx.skillImporter.importFromUrl(
           { url: downloadUrl },
           { identifier: input.identifier, source: 'market' },
         );
@@ -292,7 +292,7 @@ export const agentSkillsRouter = router({
       }
 
       try {
-        return await ctx.skillResourceService.readResource(skill.resources, input.path);
+        return ctx.skillResourceService.readResource(skill.resources, input.path);
       } catch (error) {
         if (error instanceof SkillResourceError) {
           throw new TRPCError({ code: 'NOT_FOUND', message: error.message });

--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -1298,7 +1298,7 @@ export const aiAgentRouter = router({
         userId: ctx.userId,
         workspaceId: ctx.workspaceId,
       });
-      return await ctx.aiAgentService.execAgent({
+      return ctx.aiAgentService.execAgent({
         agentId,
         appContext,
         autoStart,
@@ -1610,7 +1610,7 @@ export const aiAgentRouter = router({
         });
 
         // External procedure name stays `execSubAgentTask`; the service method is `execSubAgent`.
-        return await ctx.aiAgentService.execSubAgent({
+        return ctx.aiAgentService.execSubAgent({
           agentId,
           groupId,
           instruction,

--- a/apps/server/src/routers/lambda/aiProvider.ts
+++ b/apps/server/src/routers/lambda/aiProvider.ts
@@ -166,7 +166,7 @@ export const aiProviderRouter = router({
     }),
 
   getAiProviderList: aiProviderProcedure.query(async ({ ctx }) => {
-    return await ctx.aiInfraRepos.getAiProviderList();
+    return ctx.aiInfraRepos.getAiProviderList();
   }),
 
   getAiProviderRuntimeState: aiProviderProcedure

--- a/apps/server/src/routers/lambda/changelog.ts
+++ b/apps/server/src/routers/lambda/changelog.ts
@@ -15,7 +15,7 @@ const changelogProcedure = publicProcedure.use(async ({ next }) => {
 export const changelogRouter = router({
   getIndex: changelogProcedure.query(async ({ ctx }) => {
     try {
-      return await ctx.changelogService.getChangelogIndex();
+      return ctx.changelogService.getChangelogIndex();
     } catch (e) {
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
@@ -33,7 +33,7 @@ export const changelogRouter = router({
     )
     .query(async ({ input, ctx }) => {
       try {
-        return await ctx.changelogService.getPostById(input.id, { locale: input.locale as any });
+        return ctx.changelogService.getPostById(input.id, { locale: input.locale as any });
       } catch (e) {
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',

--- a/apps/server/src/routers/lambda/connector.ts
+++ b/apps/server/src/routers/lambda/connector.ts
@@ -721,7 +721,7 @@ export const connectorRouter = router({
       // update/delete/reset.
       assertWorkspaceRowManageable(ctx, target.userId, 'connector');
       try {
-        return await syncConnectorToolsById(input.id, ctx);
+        return syncConnectorToolsById(input.id, ctx);
       } catch (err: any) {
         throw new TRPCError({
           cause: err,
@@ -746,7 +746,7 @@ export const connectorRouter = router({
     )
     .mutation(async ({ input, ctx }) => {
       try {
-        return await callConnectorToolById(input, ctx);
+        return callConnectorToolById(input, ctx);
       } catch (err: any) {
         if (err instanceof ConnectorToolCallError) {
           throw new TRPCError({ cause: err, code: err.code, message: err.message });

--- a/apps/server/src/routers/lambda/knowledgeBase.ts
+++ b/apps/server/src/routers/lambda/knowledgeBase.ts
@@ -67,7 +67,7 @@ export const knowledgeBaseRouter = router({
       assertWorkspaceRowManageable(ctx, kb.userId, 'knowledge base');
 
       try {
-        return await ctx.knowledgeBaseModel.addFilesToKnowledgeBase(
+        return ctx.knowledgeBaseModel.addFilesToKnowledgeBase(
           input.knowledgeBaseId,
           input.ids,
         );

--- a/apps/server/src/routers/lambda/market/agent.ts
+++ b/apps/server/src/routers/lambda/market/agent.ts
@@ -131,7 +131,7 @@ const withActingAccountHeader = async <T>(
   headers['x-lobe-owner-account-id'] = String(actAs);
 
   try {
-    return await operation();
+    return operation();
   } finally {
     if (previous === undefined) {
       delete headers['x-lobe-owner-account-id'];

--- a/apps/server/src/routers/lambda/market/agentGroup.ts
+++ b/apps/server/src/routers/lambda/market/agentGroup.ts
@@ -97,7 +97,7 @@ const withActingAccountHeader = async <T>(
   headers['x-lobe-owner-account-id'] = String(actAs);
 
   try {
-    return await operation();
+    return operation();
   } finally {
     if (previous === undefined) {
       delete headers['x-lobe-owner-account-id'];

--- a/apps/server/src/routers/lambda/market/index.ts
+++ b/apps/server/src/routers/lambda/market/index.ts
@@ -79,7 +79,7 @@ export const marketRouter = router({
       log('getAgentsByPlugin input: %O', input);
 
       try {
-        return await ctx.discoverService.getAgentsByPlugin(input);
+        return ctx.discoverService.getAgentsByPlugin(input);
       } catch (error) {
         log('Error fetching agents by plugin: %O', error);
         throw new TRPCError({
@@ -104,7 +104,7 @@ export const marketRouter = router({
       log('  getAssistantCategories: marketProcedure\n input: %O', input);
 
       try {
-        return await ctx.discoverService.getAssistantCategories(input);
+        return ctx.discoverService.getAssistantCategories(input);
       } catch (error) {
         log('Error fetching assistant categories: %O', error);
         throw new TRPCError({
@@ -127,7 +127,7 @@ export const marketRouter = router({
       log('getAssistantDetail input: %O', input);
 
       try {
-        return await ctx.discoverService.getAssistantDetail(input);
+        return ctx.discoverService.getAssistantDetail(input);
       } catch (error) {
         log('Error fetching assistants detail: %O', error);
         throw new TRPCError({
@@ -149,7 +149,7 @@ export const marketRouter = router({
       log('getAssistantIdentifiers called with input: %O', input);
 
       try {
-        return await ctx.discoverService.getAssistantIdentifiers(input);
+        return ctx.discoverService.getAssistantIdentifiers(input);
       } catch (error) {
         log('Error fetching assistant identifiers: %O', error);
         throw new TRPCError({
@@ -181,7 +181,7 @@ export const marketRouter = router({
       log('getAssistantList input: %O', input);
 
       try {
-        return await ctx.discoverService.getAssistantList(input);
+        return ctx.discoverService.getAssistantList(input);
       } catch (error) {
         log('Error fetching assistant list: %O', error);
         throw new TRPCError({
@@ -205,7 +205,7 @@ export const marketRouter = router({
       log('getGroupAgentCategories input: %O', input);
 
       try {
-        return await ctx.discoverService.getGroupAgentCategories(input);
+        return ctx.discoverService.getGroupAgentCategories(input);
       } catch (error) {
         log('Error fetching group agent categories: %O', error);
         throw new TRPCError({
@@ -227,7 +227,7 @@ export const marketRouter = router({
       log('getGroupAgentDetail input: %O', input);
 
       try {
-        return await ctx.discoverService.getGroupAgentDetail(input);
+        return ctx.discoverService.getGroupAgentDetail(input);
       } catch (error) {
         log('Error fetching group agent detail: %O', error);
         throw new TRPCError({
@@ -241,7 +241,7 @@ export const marketRouter = router({
     log('getGroupAgentIdentifiers called');
 
     try {
-      return await ctx.discoverService.getGroupAgentIdentifiers();
+      return ctx.discoverService.getGroupAgentIdentifiers();
     } catch (error) {
       log('Error fetching group agent identifiers: %O', error);
       throw new TRPCError({
@@ -270,7 +270,7 @@ export const marketRouter = router({
       log('getGroupAgentList input: %O', input);
 
       try {
-        return await ctx.discoverService.getGroupAgentList(input);
+        return ctx.discoverService.getGroupAgentList(input);
       } catch (error) {
         log('Error fetching group agent list: %O', error);
         throw new TRPCError({
@@ -291,7 +291,7 @@ export const marketRouter = router({
     .query(async ({ input, ctx }) => {
       log('getLegacyPluginList input: %O', input);
       try {
-        return await ctx.discoverService.getLegacyPluginList(input);
+        return ctx.discoverService.getLegacyPluginList(input);
       } catch (error) {
         log('Error fetching legacy plugin list: %O', error);
         throw new TRPCError({
@@ -315,7 +315,7 @@ export const marketRouter = router({
       log('getMcpCategories input: %O', input);
 
       try {
-        return await ctx.discoverService.getMcpCategories(input);
+        return ctx.discoverService.getMcpCategories(input);
       } catch (error) {
         log('Error fetching mcp categories: %O', error);
         throw new TRPCError({
@@ -337,7 +337,7 @@ export const marketRouter = router({
       log('getMcpDetail input: %O', input);
 
       try {
-        return await ctx.discoverService.getMcpDetail(input);
+        return ctx.discoverService.getMcpDetail(input);
       } catch (error) {
         console.error('Error fetching mcp detail: %O', error);
         throw new TRPCError({
@@ -366,7 +366,7 @@ export const marketRouter = router({
       log('getMcpList input: %O', input);
 
       try {
-        return await ctx.discoverService.getMcpList(input);
+        return ctx.discoverService.getMcpList(input);
       } catch (error) {
         log('Error fetching mcp list: %O', error);
         throw new TRPCError({
@@ -389,7 +389,7 @@ export const marketRouter = router({
       log('getMcpManifest input: %O', input);
 
       try {
-        return await ctx.discoverService.getMcpManifest(input);
+        return ctx.discoverService.getMcpManifest(input);
       } catch (error) {
         log('Error fetching mcp manifest: %O', error);
         throw new TRPCError({
@@ -412,7 +412,7 @@ export const marketRouter = router({
       log('getModelCategories input: %O', input);
 
       try {
-        return await ctx.discoverService.getModelCategories(input);
+        return ctx.discoverService.getModelCategories(input);
       } catch (error) {
         log('Error fetching model categories: %O', error);
         throw new TRPCError({
@@ -433,7 +433,7 @@ export const marketRouter = router({
       log('getModelDetail input: %O', input);
 
       try {
-        return await ctx.discoverService.getModelDetail(input);
+        return ctx.discoverService.getModelDetail(input);
       } catch (error) {
         log('Error fetching model details: %O', error);
         throw new TRPCError({
@@ -447,7 +447,7 @@ export const marketRouter = router({
     log('getModelIdentifiers called');
 
     try {
-      return await ctx.discoverService.getModelIdentifiers();
+      return ctx.discoverService.getModelIdentifiers();
     } catch (error) {
       log('Error fetching model identifiers: %O', error);
       throw new TRPCError({
@@ -475,7 +475,7 @@ export const marketRouter = router({
       log('getModelList input: %O', input);
 
       try {
-        return await ctx.discoverService.getModelList(input);
+        return ctx.discoverService.getModelList(input);
       } catch (error) {
         log('Error fetching model list: %O', error);
         throw new TRPCError({
@@ -499,7 +499,7 @@ export const marketRouter = router({
       log('getPluginCategories input: %O', input);
 
       try {
-        return await ctx.discoverService.getPluginCategories(input);
+        return ctx.discoverService.getPluginCategories(input);
       } catch (error) {
         log('Error fetching plugin categories: %O', error);
         throw new TRPCError({
@@ -521,7 +521,7 @@ export const marketRouter = router({
       log('getPluginDetail input: %O', input);
 
       try {
-        return await ctx.discoverService.getPluginDetail(input);
+        return ctx.discoverService.getPluginDetail(input);
       } catch (error) {
         log('Error fetching plugin details: %O', error);
         throw new TRPCError({
@@ -535,7 +535,7 @@ export const marketRouter = router({
     log('getPluginIdentifiers called');
 
     try {
-      return await ctx.discoverService.getPluginIdentifiers();
+      return ctx.discoverService.getPluginIdentifiers();
     } catch (error) {
       log('Error fetching plugin identifiers: %O', error);
       throw new TRPCError({
@@ -563,7 +563,7 @@ export const marketRouter = router({
       log('getPluginList input: %O', input);
 
       try {
-        return await ctx.discoverService.getPluginList(input);
+        return ctx.discoverService.getPluginList(input);
       } catch (error) {
         log('Error fetching plugin list: %O', error);
         throw new TRPCError({
@@ -586,7 +586,7 @@ export const marketRouter = router({
       log('getProviderDetail input: %O', input);
 
       try {
-        return await ctx.discoverService.getProviderDetail(input);
+        return ctx.discoverService.getProviderDetail(input);
       } catch (error) {
         log('Error fetching provider details: %O', error);
         throw new TRPCError({
@@ -600,7 +600,7 @@ export const marketRouter = router({
     log('getProviderIdentifiers called');
 
     try {
-      return await ctx.discoverService.getProviderIdentifiers();
+      return ctx.discoverService.getProviderIdentifiers();
     } catch (error) {
       log('Error fetching provider identifiers: %O', error);
       throw new TRPCError({
@@ -627,7 +627,7 @@ export const marketRouter = router({
       log('getProviderList input: %O', input);
 
       try {
-        return await ctx.discoverService.getProviderList(input);
+        return ctx.discoverService.getProviderList(input);
       } catch (error) {
         log('Error fetching provider list: %O', error);
         throw new TRPCError({
@@ -649,7 +649,7 @@ export const marketRouter = router({
       log('getUserInfo input: %O', input);
 
       try {
-        return await ctx.discoverService.getUserInfo(input);
+        return ctx.discoverService.getUserInfo(input);
       } catch (error) {
         log('Error fetching user info: %O', error);
         throw new TRPCError({

--- a/apps/server/src/routers/lambda/market/skill.ts
+++ b/apps/server/src/routers/lambda/market/skill.ts
@@ -84,7 +84,7 @@ export const skillRouter = router({
       log('getSkillCategories input: %O', input);
 
       try {
-        return await ctx.marketService.getSkillCategories();
+        return ctx.marketService.getSkillCategories();
       } catch (error) {
         log('Error fetching skill categories: %O', error);
         throw mapMarketError(error, 'Failed to fetch skill categories');

--- a/apps/server/src/routers/lambda/task.ts
+++ b/apps/server/src/routers/lambda/task.ts
@@ -836,7 +836,7 @@ export const taskRouter = router({
           ctx.userId,
           ctx.workspaceId ?? undefined,
         );
-        return await runner.runTask({
+        return runner.runTask({
           continueTopicId: input.continueTopicId,
           extraPrompt: input.prompt,
           taskId: task.id,

--- a/apps/server/src/routers/lambda/upload.ts
+++ b/apps/server/src/routers/lambda/upload.ts
@@ -11,7 +11,7 @@ export const uploadRouter = router({
     .mutation(async ({ input }) => {
       const s3 = new FileS3();
 
-      return await s3.createPreSignedUrl(input.pathname);
+      return s3.createPreSignedUrl(input.pathname);
     }),
 });
 

--- a/apps/server/src/routers/lambda/usage.ts
+++ b/apps/server/src/routers/lambda/usage.ts
@@ -46,7 +46,7 @@ export const usageRouter = router({
       }),
     )
     .query(async ({ ctx, input }) => {
-      return await ctx.usageRecordService.findAndGroupByDateRange(
+      return ctx.usageRecordService.findAndGroupByDateRange(
         input.startAt,
         input.endAt,
         input.agentId,
@@ -61,7 +61,7 @@ export const usageRouter = router({
       }),
     )
     .query(async ({ ctx, input }) => {
-      return await ctx.usageRecordService.findAndGroupByDay(input.mo, input.agentId);
+      return ctx.usageRecordService.findAndGroupByDay(input.mo, input.agentId);
     }),
 
   findByMonth: usageProcedure
@@ -72,6 +72,6 @@ export const usageRouter = router({
       }),
     )
     .query(async ({ ctx, input }) => {
-      return await ctx.usageRecordService.findByMonth(input.mo, input.agentId);
+      return ctx.usageRecordService.findByMonth(input.mo, input.agentId);
     }),
 });

--- a/apps/server/src/routers/lambda/userMemories.ts
+++ b/apps/server/src/routers/lambda/userMemories.ts
@@ -263,7 +263,7 @@ export const userMemoriesRouter = router({
     .input(z.object({ id: z.string(), layer: z.nativeEnum(LayersEnum) }))
     .query(async ({ ctx, input }) => {
       try {
-        return await ctx.memoryModel.getMemoryDetail(input);
+        return ctx.memoryModel.getMemoryDetail(input);
       } catch (error) {
         console.error('Failed to retrieve memory detail:', error);
         return null;
@@ -291,7 +291,7 @@ export const userMemoriesRouter = router({
       const fallbackPageSize = params.pageSize ?? 20;
 
       try {
-        return await ctx.activityModel.queryList(params);
+        return ctx.activityModel.queryList(params);
       } catch (error) {
         console.error('Failed to query activities:', error);
         return { items: [], page: fallbackPage, pageSize: fallbackPageSize, total: 0 };
@@ -318,7 +318,7 @@ export const userMemoriesRouter = router({
       const fallbackPageSize = params.pageSize ?? 20;
 
       try {
-        return await ctx.experienceModel.queryList(params);
+        return ctx.experienceModel.queryList(params);
       } catch (error) {
         console.error('Failed to query experiences:', error);
         return { items: [], page: fallbackPage, pageSize: fallbackPageSize, total: 0 };
@@ -346,7 +346,7 @@ export const userMemoriesRouter = router({
       const fallbackPageSize = params.pageSize ?? 20;
 
       try {
-        return await ctx.identityModel.queryList(params);
+        return ctx.identityModel.queryList(params);
       } catch (error) {
         console.error('Failed to query identities:', error);
         return { items: [], page: fallbackPage, pageSize: fallbackPageSize, total: 0 };
@@ -357,7 +357,7 @@ export const userMemoriesRouter = router({
     .input(z.object({ limit: z.coerce.number().int().min(1).max(100).optional() }).optional())
     .query(async ({ ctx, input }) => {
       try {
-        return await ctx.identityModel.queryForInjection(input?.limit ?? 50);
+        return ctx.identityModel.queryForInjection(input?.limit ?? 50);
       } catch (error) {
         console.error('Failed to query identities for injection:', error);
         return [];
@@ -375,7 +375,7 @@ export const userMemoriesRouter = router({
     )
     .query(async ({ ctx, input }) => {
       try {
-        return await ctx.memoryModel.queryIdentityRoles(input ?? {});
+        return ctx.memoryModel.queryIdentityRoles(input ?? {});
       } catch (error) {
         console.error('Failed to query identity roles:', error);
         return { roles: [], tags: [] };
@@ -414,7 +414,7 @@ export const userMemoriesRouter = router({
       const fallbackPageSize = params.pageSize ?? 20;
 
       try {
-        return await ctx.memoryModel.queryMemories({
+        return ctx.memoryModel.queryMemories({
           ...params,
           order: params.order ?? 'desc',
           sort: params.sort,
@@ -437,7 +437,7 @@ export const userMemoriesRouter = router({
     )
     .query(async ({ ctx, input }) => {
       try {
-        return await ctx.memoryModel.queryTags(input ?? {});
+        return ctx.memoryModel.queryTags(input ?? {});
       } catch (error) {
         console.error('Failed to query memory tags:', error);
         return [];
@@ -448,7 +448,7 @@ export const userMemoriesRouter = router({
     .input(queryTaxonomyOptionsSchema.optional())
     .query(async ({ ctx, input }) => {
       try {
-        return await ctx.memoryModel.queryTaxonomyOptions(input ?? {});
+        return ctx.memoryModel.queryTaxonomyOptions(input ?? {});
       } catch (error) {
         console.error('Failed to query memory taxonomy options:', error);
         return EMPTY_TAXONOMY_RESULT;
@@ -963,7 +963,7 @@ export const userMemoriesRouter = router({
 
   searchMemory: memoryProcedure.input(searchMemorySchema).query(async ({ input, ctx }) => {
     try {
-      return await searchUserMemories(ctx, input);
+      return searchUserMemories(ctx, input);
     } catch (error) {
       console.error('Failed to retrieve memories:', error);
       return EMPTY_SEARCH_RESULT;

--- a/apps/server/src/routers/tools/_helpers/marketConnections.ts
+++ b/apps/server/src/routers/tools/_helpers/marketConnections.ts
@@ -62,7 +62,7 @@ export const listOptionalMarketConnectionsWithTimeout = async (
   timeoutMs = MARKET_CONNECTIONS_REQUEST_TIMEOUT_MS,
 ): Promise<ListConnectionsResponse> => {
   try {
-    return await listMarketConnectionsWithTimeout(marketConnect, timeoutMs);
+    return listMarketConnectionsWithTimeout(marketConnect, timeoutMs);
   } catch (error) {
     if (isMarketConnectionsAuthError(error)) {
       return { connections: [], success: true };

--- a/apps/server/src/routers/tools/composio.ts
+++ b/apps/server/src/routers/tools/composio.ts
@@ -101,7 +101,7 @@ export const composioToolsRouter = router({
       const content = data?.data || data?.result || data;
       const contentStr = typeof content === 'string' ? content : JSON.stringify(content);
 
-      return await MCPService.processToolCallResult({
+      return MCPService.processToolCallResult({
         content: [{ text: contentStr, type: 'text' }],
         isError: false,
       });

--- a/apps/server/src/routers/tools/mcp.ts
+++ b/apps/server/src/routers/tools/mcp.ts
@@ -85,7 +85,7 @@ export const mcpRouter = router({
   getStreamableMcpServerManifest: mcpProcedure
     .input(GetStreamableMcpServerManifestInputSchema)
     .query(async ({ input }) => {
-      return await mcpService.getStreamableMcpServerManifest(
+      return mcpService.getStreamableMcpServerManifest(
         input.identifier,
         input.url,
         input.metadata,
@@ -102,7 +102,7 @@ export const mcpRouter = router({
       checkStdioEnvironment(input);
 
       // Pass the validated MCPClientParams to the service
-      return await mcpService.listTools(input);
+      return mcpService.listTools(input);
     }),
 
   // listResources now accepts MCPClientParams directly
@@ -113,7 +113,7 @@ export const mcpRouter = router({
       checkStdioEnvironment(input);
 
       // Pass the validated MCPClientParams to the service
-      return await mcpService.listResources(input);
+      return mcpService.listResources(input);
     }),
 
   // listPrompts now accepts MCPClientParams directly
@@ -124,7 +124,7 @@ export const mcpRouter = router({
       checkStdioEnvironment(input);
 
       // Pass the validated MCPClientParams to the service
-      return await mcpService.listPrompts(input);
+      return mcpService.listPrompts(input);
     }),
 
   // callTool now accepts MCPClientParams, toolName, and args

--- a/apps/server/src/routers/tools/search.ts
+++ b/apps/server/src/routers/tools/search.ts
@@ -58,7 +58,7 @@ export const searchRouter = router({
       }),
     )
     .query(async ({ input }) => {
-      return await searchService.query(input.query, input.optionalParams);
+      return searchService.query(input.query, input.optionalParams);
     }),
 
   webSearch: searchProcedure
@@ -71,6 +71,6 @@ export const searchRouter = router({
       }),
     )
     .query(async ({ input }) => {
-      return await searchService.webSearch(input);
+      return searchService.webSearch(input);
     }),
 });

--- a/apps/server/src/services/agentSignal/featureGate.ts
+++ b/apps/server/src/services/agentSignal/featureGate.ts
@@ -92,7 +92,7 @@ export const isAgentSelfIterationFeatureEnabledForUser = async (userId: string) 
  */
 export const isAgentSignalEnabledForUser = async (_db: LobeChatDatabase, userId: string) => {
   try {
-    return await isAgentSelfIterationFeatureEnabledForUser(userId);
+    return isAgentSelfIterationFeatureEnabledForUser(userId);
   } catch {
     return false;
   }

--- a/apps/server/src/services/agentSignal/services/receiptRollbackService.ts
+++ b/apps/server/src/services/agentSignal/services/receiptRollbackService.ts
@@ -132,7 +132,7 @@ export const rollbackAgentSignalReceipt = async (
   }
 
   try {
-    return await documentService.runWithDocumentLock(
+    return documentService.runWithDocumentLock(
       resolvedInput.documentId,
       async (lockOwnerId) => {
         const current = await documentService.getDocumentById(resolvedInput.documentId);
@@ -152,7 +152,7 @@ export const rollbackAgentSignalReceipt = async (
 
         const history = await (async () => {
           try {
-            return await documentService.getDocumentHistoryItem({
+            return documentService.getDocumentHistoryItem({
               documentId: resolvedInput.documentId,
               historyId: resolvedInput.historyId,
             });

--- a/apps/server/src/services/bot/AgentBridgeService.ts
+++ b/apps/server/src/services/bot/AgentBridgeService.ts
@@ -355,7 +355,7 @@ export class AgentBridgeService {
     AgentBridgeService.startupControllers.set(threadId, controller);
 
     try {
-      return await task(controller.signal);
+      return task(controller.signal);
     } finally {
       if (AgentBridgeService.startupControllers.get(threadId) === controller) {
         AgentBridgeService.startupControllers.delete(threadId);

--- a/apps/server/src/services/bot/BotMessageRouter.ts
+++ b/apps/server/src/services/bot/BotMessageRouter.ts
@@ -273,7 +273,7 @@ export class BotMessageRouter {
     this.loadingPromises.set(key, promise);
 
     try {
-      return await promise;
+      return promise;
     } finally {
       this.loadingPromises.delete(key);
     }

--- a/apps/server/src/services/bot/platforms/telegram/api.ts
+++ b/apps/server/src/services/bot/platforms/telegram/api.ts
@@ -458,11 +458,11 @@ export class TelegramApi {
     };
 
     try {
-      return await attempt();
+      return attempt();
     } catch (error) {
       if (!isTransientNetworkError(error)) throw error;
       log('Telegram API %s: transient network error, retrying once: %O', method, error);
-      return await attempt();
+      return attempt();
     }
   }
 
@@ -529,11 +529,11 @@ export class TelegramApi {
     };
 
     try {
-      return await attempt();
+      return attempt();
     } catch (error) {
       if (!isTransientNetworkError(error)) throw error;
       log('Telegram API %s: transient network error, retrying once: %O', method, error);
-      return await attempt();
+      return attempt();
     }
   }
 

--- a/apps/server/src/services/comfyui/core/comfyUIClientService.ts
+++ b/apps/server/src/services/comfyui/core/comfyUIClientService.ts
@@ -161,8 +161,8 @@ export class ComfyUIClientService {
    * Uses unified TTL cache for performance optimization
    */
   async getCheckpoints(): Promise<string[]> {
-    return await this.cacheManager.get('checkpoints', async () => {
-      return await this.client.getCheckpoints();
+    return this.cacheManager.get('checkpoints', async () => {
+      return this.client.getCheckpoints();
     });
   }
 
@@ -172,8 +172,8 @@ export class ComfyUIClientService {
    * Uses unified TTL cache for performance optimization
    */
   async getLoras(): Promise<string[]> {
-    return await this.cacheManager.get('loras', async () => {
-      return await this.client.getLoras();
+    return this.cacheManager.get('loras', async () => {
+      return this.client.getLoras();
     });
   }
 
@@ -185,7 +185,7 @@ export class ComfyUIClientService {
    */
   async getNodeDefs(nodeName?: string): Promise<any> {
     const allNodeDefs = await this.cacheManager.get('nodeDefs', async () => {
-      return await this.client.getNodeDefs();
+      return this.client.getNodeDefs();
     });
 
     // Return specific node or all nodes
@@ -221,7 +221,7 @@ export class ComfyUIClientService {
    * Delegates to ConnectionService for connection management
    */
   async validateConnection(): Promise<boolean> {
-    return await this.connectionService.validateConnection(
+    return this.connectionService.validateConnection(
       this.baseURL,
       this.authService.getAuthHeaders(),
     );

--- a/apps/server/src/services/deviceGateway/index.ts
+++ b/apps/server/src/services/deviceGateway/index.ts
@@ -97,7 +97,7 @@ export class DeviceGateway {
     if (!client) return { deviceCount: 0, online: false };
 
     try {
-      return await client.queryDeviceStatus(userId, workspaceId);
+      return client.queryDeviceStatus(userId, workspaceId);
     } catch {
       return { deviceCount: 0, online: false };
     }
@@ -1296,7 +1296,7 @@ export class DeviceGateway {
     if (!client) return { error: 'GATEWAY_NOT_CONFIGURED', success: false };
 
     try {
-      return await client.dispatchAgentRun(params);
+      return client.dispatchAgentRun(params);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       log('dispatchAgentRun: error — %s', message);
@@ -1328,7 +1328,7 @@ export class DeviceGateway {
     );
 
     try {
-      return await client.executeToolCall(
+      return client.executeToolCall(
         {
           deviceId: params.deviceId,
           operationId: params.operationId,
@@ -1381,7 +1381,7 @@ export class DeviceGateway {
     );
 
     try {
-      return await client.executeMcpCall({ ...mcpCall, timeout });
+      return client.executeMcpCall({ ...mcpCall, timeout });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       log('executeMcpCall: error — %s', message);
@@ -1412,7 +1412,7 @@ export class DeviceGateway {
     );
 
     try {
-      return await client.executeMessageApi(
+      return client.executeMessageApi(
         {
           deviceId: params.deviceId,
           timeout,

--- a/apps/server/src/services/discover/index.ts
+++ b/apps/server/src/services/discover/index.ts
@@ -121,7 +121,7 @@ export class DiscoverService {
         try {
           // Dynamic import
           const { machineId } = await import('node-machine-id');
-          return await machineId();
+          return machineId();
         } catch (error) {
           console.error('Failed to get machine-id:', error);
         }

--- a/apps/server/src/services/document/index.ts
+++ b/apps/server/src/services/document/index.ts
@@ -451,7 +451,7 @@ export class DocumentService {
     }
 
     try {
-      return await fn(ownerId);
+      return fn(ownerId);
     } finally {
       // Only release a lease we freshly claimed. When the same user already
       // held it, leave their session alive — releasing would briefly flip

--- a/apps/server/src/services/file/impls/s3.ts
+++ b/apps/server/src/services/file/impls/s3.ts
@@ -159,7 +159,7 @@ export class S3StaticFileImpl implements FileServiceImpl {
 
     const key = await this.getStorageKeyFromUrl(url);
 
-    return await this.getCachedPreSignedUrlForPreview(key, expiresIn);
+    return this.getCachedPreSignedUrlForPreview(key, expiresIn);
   }
 
   async uploadContent(path: string, content: string) {
@@ -176,7 +176,7 @@ export class S3StaticFileImpl implements FileServiceImpl {
     // stable media URLs and can reuse provider-side prefix caches.
     const publicUrlBase = fileEnv.S3_SET_ACL ? fileEnv.S3_PUBLIC_DOMAIN : undefined;
     if (!publicUrlBase) {
-      return await this.getCachedPreSignedUrlForPreview(key, expiresIn);
+      return this.getCachedPreSignedUrlForPreview(key, expiresIn);
     }
 
     if (fileEnv.S3_ENABLE_PATH_STYLE) {

--- a/apps/server/src/services/gateway/index.ts
+++ b/apps/server/src/services/gateway/index.ts
@@ -1273,7 +1273,7 @@ export class GatewayService {
     const client = getMessageGatewayClient(platform);
     try {
       const { state } = await client.getStatus(provider.id);
-      return await updateBotRuntimeStatus({
+      return updateBotRuntimeStatus({
         applicationId,
         errorCode: state.errorCode,
         errorMessage: state.error,

--- a/apps/server/src/services/memory/userMemory/extract.ts
+++ b/apps/server/src/services/memory/userMemory/extract.ts
@@ -833,7 +833,7 @@ export class MemoryExtractionExecutor {
     const normalized = text.trim();
     if (!normalized) return 0;
 
-    return await encodeAsync(normalized);
+    return encodeAsync(normalized);
   }
 
   private async trimTextToTokenLimit(text: string, tokenLimit?: number) {

--- a/apps/server/src/services/messenger/MessengerRouter.ts
+++ b/apps/server/src/services/messenger/MessengerRouter.ts
@@ -366,7 +366,7 @@ export class MessengerRouter {
     this.loadingPromises.set(key, promise);
 
     try {
-      return await promise;
+      return promise;
     } finally {
       this.loadingPromises.delete(key);
     }

--- a/apps/server/src/services/search/impls/searxng/client.ts
+++ b/apps/server/src/services/search/impls/searxng/client.ts
@@ -62,7 +62,7 @@ export class SearXNGClient {
       const response = await fetch(urlJoin(this.baseUrl, `/search?${searchParams}`));
 
       if (response.ok) {
-        return await response.json();
+        return response.json();
       }
 
       const body = await response.text().catch(() => '');

--- a/apps/server/src/services/search/index.ts
+++ b/apps/server/src/services/search/index.ts
@@ -97,7 +97,7 @@ export class SearchService {
     const results = await pMap(
       input.urls,
       async (url) => {
-        return await this.crawlWithRetry(crawler, url, input.impls);
+        return this.crawlWithRetry(crawler, url, input.impls);
       },
       { concurrency: this.crawlConcurrency },
     );
@@ -164,7 +164,7 @@ export class SearchService {
    */
   private async queryWithImpl(impl: SearchServiceImpl, query: string, params?: SearchParams) {
     try {
-      return await impl.query(query, params);
+      return impl.query(query, params);
     } catch (e) {
       console.error('[SearchService] query failed', {
         provider: impl.constructor.name || 'UnknownSearchImpl',

--- a/apps/server/src/services/toolExecution/index.ts
+++ b/apps/server/src/services/toolExecution/index.ts
@@ -224,7 +224,7 @@ export class ToolExecutionService {
     try {
       // Check if this is a cloud MCP endpoint
       if (mcpParams.type === 'cloud') {
-        return await this.executeCloudMCPTool(payload, context, mcpParams);
+        return this.executeCloudMCPTool(payload, context, mcpParams);
       }
 
       // MCP servers only the user's machine can reach must not be called from

--- a/apps/server/src/services/toolExecution/serverRuntimes/knowledgeBase.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/knowledgeBase.ts
@@ -68,7 +68,7 @@ export const knowledgeBaseRuntime: ServerRuntimeRegistration = {
       {
         addFilesToKnowledgeBase: async (knowledgeBaseId, ids) => {
           try {
-            return await knowledgeBaseModel.addFilesToKnowledgeBase(knowledgeBaseId, ids);
+            return knowledgeBaseModel.addFilesToKnowledgeBase(knowledgeBaseId, ids);
           } catch (e: any) {
             // PG unique-constraint violation on (knowledge_base_id, file_id).
             // Re-throw with a friendly message so the ExecutionRuntime's

--- a/src/app/(backend)/webapi/chat/[provider]/route.ts
+++ b/src/app/(backend)/webapi/chat/[provider]/route.ts
@@ -35,7 +35,7 @@ export const POST = checkAuth(async (req: Request, { params, userId, serverDB })
       traceOptions = createTraceOptions(data, { provider, trace: tracePayload });
     }
 
-    return await modelRuntime.chat(data, {
+    return modelRuntime.chat(data, {
       user: userId,
       ...traceOptions,
       signal: req.signal,

--- a/src/components/ChangelogModal/ChangelogContent.tsx
+++ b/src/components/ChangelogModal/ChangelogContent.tsx
@@ -29,7 +29,7 @@ interface PostItemProps extends ChangelogIndexItem {
 
 const PostItem = ({ id, versionRange, locale, showDivider = true }: PostItemProps) => {
   const { data } = useSWR(changelogKeys.post(id, locale), async () => {
-    return await lambdaClient.changelog.getPostById.query({ id, locale });
+    return lambdaClient.changelog.getPostById.query({ id, locale });
   });
 
   if (!data || !data.title) return null;

--- a/src/features/Conversation/types/hooks.ts
+++ b/src/features/Conversation/types/hooks.ts
@@ -211,7 +211,7 @@ export interface ConversationHooks {
    * @example
    * ```ts
    * onToolApprovalRequired: async (toolCall) => {
-   *   return await showCustomApprovalDialog(toolCall);
+   *   return showCustomApprovalDialog(toolCall);
    * }
    * ```
    */

--- a/src/libs/document-loaders/loaders/index.ts
+++ b/src/libs/document-loaders/loaders/index.ts
@@ -31,39 +31,39 @@ export class ChunkingLoader {
       switch (type) {
         case 'code': {
           const ext = filename.split('.').pop();
-          return await CodeLoader(txt, ext!);
+          return CodeLoader(txt, ext!);
         }
 
         case 'ppt': {
-          return await PPTXLoader(fileBlob);
+          return PPTXLoader(fileBlob);
         }
 
         case 'latex': {
-          return await LatexLoader(txt);
+          return LatexLoader(txt);
         }
 
         case 'pdf': {
-          return await PdfLoader(fileBlob);
+          return PdfLoader(fileBlob);
         }
 
         case 'markdown': {
-          return await MarkdownLoader(txt);
+          return MarkdownLoader(txt);
         }
 
         case 'doc': {
-          return await DocxLoader(fileBlob);
+          return DocxLoader(fileBlob);
         }
 
         case 'text': {
-          return await TextLoader(txt);
+          return TextLoader(txt);
         }
 
         case 'csv': {
-          return await CsVLoader(fileBlob);
+          return CsVLoader(fileBlob);
         }
 
         case 'epub': {
-          return await EPubLoader(content);
+          return EPubLoader(content);
         }
 
         case 'ipynb': {

--- a/src/libs/oidc-provider/jwt.ts
+++ b/src/libs/oidc-provider/jwt.ts
@@ -86,7 +86,7 @@ const getVerificationKey = async () => {
     const { importJWK } = await import('jose');
 
     // Now, in any environment, `importJWK` will correctly identify this object as a public key.
-    return await importJWK(publicKeyJwk, 'RS256');
+    return importJWK(publicKeyJwk, 'RS256');
   } catch (error) {
     log('Failed to get JWKS public key: %O', error);
     throw new Error(`JWKS_KEY public key retrieval failed: ${(error as Error).message}`, {

--- a/src/libs/qstash/index.ts
+++ b/src/libs/qstash/index.ts
@@ -172,7 +172,7 @@ export async function verifyQStashSignature(request: Request, rawBody: string): 
   const receiver = new Receiver({ currentSigningKey, nextSigningKey });
 
   try {
-    return await receiver.verify({ body: rawBody, signature });
+    return receiver.verify({ body: rawBody, signature });
   } catch (error) {
     log('QStash signature verification failed: %O', error);
     return false;

--- a/src/libs/swr/mutate.ts
+++ b/src/libs/swr/mutate.ts
@@ -68,5 +68,5 @@ export const getMutate = (): ScopedMutator => {
 export const mutate: ScopedMutator = (async (...args: Parameters<ScopedMutator>) => {
   const [key, ...rest] = args;
   const finalKey = typeof key === 'function' ? key : augmentKey(key, getActiveWorkspaceId());
-  return await getMutate()(finalKey as any, ...(rest as [any, any]));
+  return getMutate()(finalKey as any, ...(rest as [any, any]));
 }) as ScopedMutator;

--- a/src/services/agentRuntime/index.ts
+++ b/src/services/agentRuntime/index.ts
@@ -9,7 +9,7 @@ class AgentRuntimeService {
    * Handle human intervention
    */
   async handleHumanIntervention(request: HumanInterventionRequest): Promise<any> {
-    return await lambdaClient.aiAgent.processHumanIntervention.mutate({
+    return lambdaClient.aiAgent.processHumanIntervention.mutate({
       action: request.action,
       data: request.data,
       operationId: request.operationId,

--- a/src/services/aiAgent.ts
+++ b/src/services/aiAgent.ts
@@ -196,7 +196,7 @@ class AiAgentService {
     params: ExecAgentTaskParams,
     options?: { signal?: AbortSignal },
   ): Promise<ExecAgentResult> {
-    return await lambdaClient.aiAgent.execAgent.mutate(params, options);
+    return lambdaClient.aiAgent.execAgent.mutate(params, options);
   }
 
   /**
@@ -217,11 +217,11 @@ class AiAgentService {
    * Get a fresh JWT token for Gateway WebSocket reconnection.
    */
   async refreshGatewayToken(topicId: string): Promise<{ token: string }> {
-    return await lambdaClient.aiAgent.refreshGatewayToken.query({ topicId });
+    return lambdaClient.aiAgent.refreshGatewayToken.query({ topicId });
   }
 
   async execSubAgentTask(params: ExecSubAgentTaskParams) {
-    return await lambdaClient.aiAgent.execSubAgentTask.mutate(params);
+    return lambdaClient.aiAgent.execSubAgentTask.mutate(params);
   }
 
   /**
@@ -229,14 +229,14 @@ class AiAgentService {
    * Works for both Group and Single Agent mode tasks
    */
   async getSubAgentTaskStatus(params: GetSubAgentTaskStatusParams) {
-    return await lambdaClient.aiAgent.getSubAgentTaskStatus.query(params);
+    return lambdaClient.aiAgent.getSubAgentTaskStatus.query(params);
   }
 
   /**
    * Interrupt a running task
    */
   async interruptTask(params: InterruptTaskParams) {
-    return await lambdaClient.aiAgent.interruptTask.mutate(params);
+    return lambdaClient.aiAgent.interruptTask.mutate(params);
   }
 
   /**
@@ -257,7 +257,7 @@ class AiAgentService {
    * It creates the Thread but does NOT execute the task - execution happens locally.
    */
   async createClientTaskThread(params: CreateClientTaskThreadParams) {
-    return await lambdaClient.aiAgent.createClientTaskThread.mutate(params);
+    return lambdaClient.aiAgent.createClientTaskThread.mutate(params);
   }
 
   /**
@@ -268,7 +268,7 @@ class AiAgentService {
    * - Thread messages query should not filter by agentId
    */
   async createClientGroupAgentTaskThread(params: CreateClientGroupAgentTaskThreadParams) {
-    return await lambdaClient.aiAgent.createClientGroupAgentTaskThread.mutate(params);
+    return lambdaClient.aiAgent.createClientGroupAgentTaskThread.mutate(params);
   }
 
   /**
@@ -277,7 +277,7 @@ class AiAgentService {
    * This method is called by desktop client after task execution finishes.
    */
   async updateClientTaskThreadStatus(params: UpdateClientTaskThreadStatusParams) {
-    return await lambdaClient.aiAgent.updateClientTaskThreadStatus.mutate(params);
+    return lambdaClient.aiAgent.updateClientTaskThreadStatus.mutate(params);
   }
 }
 

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -478,7 +478,7 @@ class ChatService {
        */
       fetcher = async () => {
         try {
-          return await this.fetchOnClient({ payload, provider, runtimeProvider: sdkType, signal });
+          return this.fetchOnClient({ payload, provider, runtimeProvider: sdkType, signal });
         } catch (e) {
           const {
             errorType = ChatErrorType.BadRequest,

--- a/src/services/export/index.ts
+++ b/src/services/export/index.ts
@@ -3,7 +3,7 @@ import { type ExportDatabaseData } from '@/types/export';
 
 class ExportService {
   exportData = async (): Promise<ExportDatabaseData> => {
-    return await lambdaClient.exporter.exportData.mutate();
+    return lambdaClient.exporter.exportData.mutate();
   };
 }
 

--- a/src/services/upload.ts
+++ b/src/services/upload.ts
@@ -125,7 +125,7 @@ class UploadService {
   uploadDataToS3 = async (data: object, options: UploadFileToS3Options = {}) => {
     const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
     const file = new File([blob], options.filename || 'data.json', { type: 'application/json' });
-    return await this.uploadFileToS3(file, options);
+    return this.uploadFileToS3(file, options);
   };
 
   uploadToServerS3 = async (

--- a/src/services/utils/abortableRequest.ts
+++ b/src/services/utils/abortableRequest.ts
@@ -32,7 +32,7 @@ class AbortableRequestManager {
     this.controllers.set(key, controller);
 
     try {
-      return await fetcher(controller.signal);
+      return fetcher(controller.signal);
     } finally {
       // Clean up controller if it's still the active one
       if (this.controllers.get(key) === controller) {

--- a/src/store/chat/slices/agentRun/actions/lifecycle/agentSignalBridge.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/agentSignalBridge.ts
@@ -60,7 +60,7 @@ export const emitClientAgentSignalSourceEvent = async <
   const timestamp = input.timestamp ?? Date.now();
 
   try {
-    return await agentSignalService.emitClientGatewaySourceEvent({
+    return agentSignalService.emitClientGatewaySourceEvent({
       payload: input.payload,
       scopeKey: input.scopeKey,
       sourceId: input.sourceId ?? createSourceId(input.sourceType, timestamp),

--- a/src/store/chat/slices/agentRun/actions/transports/client/clientToolExecution.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/client/clientToolExecution.ts
@@ -372,7 +372,7 @@ export class ClientToolExecutionActionImpl {
     const budgetMs = executionTimeoutMs ?? FALLBACK_EXECUTION_TIMEOUT_MS;
     let timer: ReturnType<typeof setTimeout> | undefined;
     try {
-      return await Promise.race([
+      return Promise.race([
         task(),
         new Promise<never>((_, reject) => {
           timer = setTimeout(() => {

--- a/src/store/chat/slices/plugin/actions/publicApi.ts
+++ b/src/store/chat/slices/plugin/actions/publicApi.ts
@@ -49,13 +49,13 @@ export class PluginPublicApiActionImpl {
     switch (payload.type) {
       // @ts-ignore
       case 'mcp': {
-        return await this.#get().invokeMCPTypePlugin(id, payload);
+        return this.#get().invokeMCPTypePlugin(id, payload);
       }
 
       case 'builtin':
       default: {
         // Pass stepContext to builtin tools for dynamic state access
-        return await this.#get().invokeBuiltinTool(id, payload, stepContext);
+        return this.#get().invokeBuiltinTool(id, payload, stepContext);
       }
     }
   };

--- a/src/store/electron/actions/sync.ts
+++ b/src/store/electron/actions/sync.ts
@@ -113,7 +113,7 @@ export class ElectronRemoteServerActionImpl {
       electronKeys.remoteServerConfig(),
       async () => {
         try {
-          return await remoteServerService.getRemoteServerConfig();
+          return remoteServerService.getRemoteServerConfig();
         } catch (error) {
           console.error('Failed to get remote server configuration:', error);
           throw error;

--- a/src/store/file/slices/upload/action.test.ts
+++ b/src/store/file/slices/upload/action.test.ts
@@ -90,7 +90,7 @@ describe('FileUploadAction', () => {
       vi.spyOn(fileService, 'createFile').mockResolvedValue(mockFileResponse);
 
       const uploadResult = await act(async () => {
-        return await result.current.uploadBase64FileWithProgress(base64Data);
+        return result.current.uploadBase64FileWithProgress(base64Data);
       });
 
       expect(getImageDimensions).toHaveBeenCalledWith(base64Data);
@@ -137,7 +137,7 @@ describe('FileUploadAction', () => {
       vi.spyOn(fileService, 'createFile').mockResolvedValue(mockFileResponse);
 
       const uploadResult = await act(async () => {
-        return await result.current.uploadBase64FileWithProgress(base64Data);
+        return result.current.uploadBase64FileWithProgress(base64Data);
       });
 
       expect(getImageDimensions).toHaveBeenCalledWith(base64Data);
@@ -186,7 +186,7 @@ describe('FileUploadAction', () => {
       vi.mocked(handleFileUploadError).mockReturnValue(true);
 
       const uploadResult = await act(async () => {
-        return await result.current.uploadBase64FileWithProgress(base64Data);
+        return result.current.uploadBase64FileWithProgress(base64Data);
       });
 
       expect(uploadResult).toBeUndefined();
@@ -224,7 +224,7 @@ describe('FileUploadAction', () => {
         const uploadToS3Spy = vi.spyOn(uploadService, 'uploadFileToS3');
 
         const uploadResult = await act(async () => {
-          return await result.current.uploadWithProgress({
+          return result.current.uploadWithProgress({
             file: mockFile,
             onStatusUpdate,
           });
@@ -277,7 +277,7 @@ describe('FileUploadAction', () => {
         const uploadToS3Spy = vi.spyOn(uploadService, 'uploadFileToS3');
 
         const uploadResult = await act(async () => {
-          return await result.current.uploadWithProgress({
+          return result.current.uploadWithProgress({
             file: mockFile,
             onStatusUpdate,
           });
@@ -334,7 +334,7 @@ describe('FileUploadAction', () => {
         vi.spyOn(fileService, 'createFile').mockResolvedValue(mockFileResponse);
 
         const uploadResult = await act(async () => {
-          return await result.current.uploadWithProgress({
+          return result.current.uploadWithProgress({
             file: mockFile,
             onStatusUpdate,
           });
@@ -481,7 +481,7 @@ describe('FileUploadAction', () => {
         const createFileSpy = vi.spyOn(fileService, 'createFile');
 
         const uploadResult = await act(async () => {
-          return await result.current.uploadWithProgress({
+          return result.current.uploadWithProgress({
             file: mockFile,
             onStatusUpdate,
           });
@@ -926,7 +926,7 @@ describe('FileUploadAction', () => {
         vi.spyOn(fileService, 'createFile').mockResolvedValue(mockFileResponse);
 
         const uploadResult = await act(async () => {
-          return await result.current.uploadWithProgress({
+          return result.current.uploadWithProgress({
             file: mockFile,
           });
         });
@@ -955,7 +955,7 @@ describe('FileUploadAction', () => {
         vi.spyOn(fileService, 'createFile').mockResolvedValue(mockFileResponse);
 
         const uploadResult = await act(async () => {
-          return await result.current.uploadWithProgress({
+          return result.current.uploadWithProgress({
             file: mockFile,
           });
         });
@@ -985,7 +985,7 @@ describe('FileUploadAction', () => {
         });
 
         const result = await act(async () => {
-          return await uploadWithProgress({
+          return uploadWithProgress({
             file: mockFile,
             onStatusUpdate,
           });

--- a/src/store/library/slices/crud/action.test.ts
+++ b/src/store/library/slices/crud/action.test.ts
@@ -71,7 +71,7 @@ describe('KnowledgeBaseCrudAction', () => {
       const refreshSpy = vi.spyOn(result.current, 'refreshKnowledgeBaseList').mockResolvedValue();
 
       const id = await act(async () => {
-        return await result.current.createNewKnowledgeBase(params);
+        return result.current.createNewKnowledgeBase(params);
       });
 
       expect(knowledgeBaseService.createKnowledgeBase).toHaveBeenCalledWith(params);

--- a/src/store/userMemory/slices/agent/action.ts
+++ b/src/store/userMemory/slices/agent/action.ts
@@ -40,7 +40,7 @@ export class AgentMemoryActionImpl {
       async () => {
         // Retrieve memories using topic's context
         // The backend will use topic info to build the query
-        return await userMemoryService.retrieveMemoryForTopic(topicId!);
+        return userMemoryService.retrieveMemoryForTopic(topicId!);
       },
       {
         onData: (data) => {

--- a/src/utils/i18n/loadI18nNamespaceModule.desktop.ts
+++ b/src/utils/i18n/loadI18nNamespaceModule.desktop.ts
@@ -46,7 +46,7 @@ export const loadI18nNamespaceModuleWithFallback = async (
 ): Promise<NamespaceModule> => {
   const { onFallback, ...rest } = params;
   try {
-    return await loadI18nNamespaceModule(rest);
+    return loadI18nNamespaceModule(rest);
   } catch (error) {
     onFallback?.({ error, lng: rest.lng, ns: rest.ns });
     const loadDefault = defaultLoaders[getDefaultKey(rest.ns)];

--- a/src/utils/i18n/loadI18nNamespaceModule.ts
+++ b/src/utils/i18n/loadI18nNamespaceModule.ts
@@ -27,7 +27,7 @@ export const loadI18nNamespaceModuleWithFallback = async (
   const { onFallback, ...rest } = params;
 
   try {
-    return await loadI18nNamespaceModule(rest);
+    return loadI18nNamespaceModule(rest);
   } catch (error) {
     onFallback?.({ error, lng: rest.lng, ns: rest.ns });
     return import(`@/locales/default/${rest.ns}`);

--- a/src/utils/i18n/loadI18nNamespaceModule.vite.ts
+++ b/src/utils/i18n/loadI18nNamespaceModule.vite.ts
@@ -55,7 +55,7 @@ export const loadI18nNamespaceModuleWithFallback = async (
 ): Promise<NamespaceModule> => {
   const { onFallback, ...rest } = params;
   try {
-    return await loadI18nNamespaceModule(rest);
+    return loadI18nNamespaceModule(rest);
   } catch (error) {
     onFallback?.({ error, lng: rest.lng, ns: rest.ns });
     const loadDefault = defaultLoaders[getDefaultKey(rest.ns)];


### PR DESCRIPTION
Closes #16442

Removes redundant \eturn await\ statements across the codebase.