### PR TITLE
🐛 fix(skills): parse folded project skill descriptions

### DIFF
--- a/apps/desktop/src/main/controllers/__tests__/WorkspaceCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/WorkspaceCtr.test.ts
@@ -150,6 +150,33 @@ describe('WorkspaceCtr', () => {
       expect(result.skills.map((s) => s.name)).toEqual(['alpha']);
     });
 
+    it('parses folded block scalar descriptions', async () => {
+      vi.mocked(mockFsPromises.readdir).mockImplementation(async (dir: string) => {
+        if (dir === '/proj/.agents/skills') return [dirent('agent-testing', 'dir')];
+        if (dir === '/proj/.agents/skills/agent-testing') return [dirent('SKILL.md', 'file')];
+        throw new Error('ENOENT');
+      });
+      vi.mocked(mockFsPromises.readFile).mockResolvedValue(
+        [
+          '---',
+          'name: agent-testing',
+          'description: >',
+          '  Agentic end-to-end testing for LobeHub: backend verification via the CLI,',
+          '  frontend verification via agent-browser (Electron).',
+          '---',
+          'body',
+        ].join('\n'),
+      );
+
+      const result = await workspaceCtr.listProjectSkills({ scope: '/proj' });
+
+      expect(result.skills[0]).toMatchObject({
+        description:
+          'Agentic end-to-end testing for LobeHub: backend verification via the CLI, frontend verification via agent-browser (Electron).',
+        name: 'agent-testing',
+      });
+    });
+
     it('returns empty + null source when no skills exist', async () => {
       vi.mocked(mockFsPromises.readdir).mockRejectedValue(new Error('ENOENT'));
 

--- a/packages/device-control/package.json
+++ b/packages/device-control/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@lobechat/local-file-shell": "workspace:*",
-    "fast-glob": "^3.3.3"
+    "fast-glob": "^3.3.3",
+    "gray-matter": "^4.0.3"
   },
   "devDependencies": {
     "vitest": "^3.2.6"

--- a/packages/device-control/src/__tests__/dispatch.test.ts
+++ b/packages/device-control/src/__tests__/dispatch.test.ts
@@ -61,6 +61,30 @@ describe('executeDeviceRpc', () => {
     expect(result.source).toBe('.agents/skills');
   });
 
+  it('parses folded skill descriptions from frontmatter', async () => {
+    await mkdir(path.join(root, '.agents', 'skills', 'agent-testing'), { recursive: true });
+    await writeFile(
+      path.join(root, '.agents', 'skills', 'agent-testing', 'SKILL.md'),
+      [
+        '---',
+        'name: agent-testing',
+        'description: >',
+        '  Agentic end-to-end testing for LobeHub: backend verification via the CLI,',
+        '  frontend verification via agent-browser (Electron).',
+        '---',
+        'body',
+      ].join('\n'),
+    );
+
+    const result = (await executeDeviceRpc('listProjectSkills', { scope: root }, makeDeps())) as {
+      skills: { description?: string; name: string }[];
+    };
+
+    expect(result.skills.find((skill) => skill.name === 'agent-testing')?.description).toBe(
+      'Agentic end-to-end testing for LobeHub: backend verification via the CLI, frontend verification via agent-browser (Electron).',
+    );
+  });
+
   it('routes statPath and reports a directory + repo type', async () => {
     const result = (await executeDeviceRpc('statPath', { path: root }, makeDeps())) as {
       exists: boolean;

--- a/packages/device-control/src/workspace.ts
+++ b/packages/device-control/src/workspace.ts
@@ -2,6 +2,7 @@ import { readdir, readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
 
 import { detectRepoType } from '@lobechat/local-file-shell';
+import matter from 'gray-matter';
 
 import type {
   InitWorkspaceParams,
@@ -13,8 +14,6 @@ import type {
   WorkspaceInstructionsItem,
   WorkspaceScanDeps,
 } from './types';
-
-const SKILL_FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
 
 // Cap recursion to guard against pathological directory trees.
 const MAX_SKILL_FILE_COUNT = 1000;
@@ -49,31 +48,30 @@ const listSkillFilesRecursive = async (dir: string): Promise<string[]> => {
   return results.sort();
 };
 
-/**
- * Parse a minimal YAML frontmatter block for SKILL.md files. Only handles
- * `key: value` lines; multi-line block scalars fall back to the first line.
- */
-const parseSkillFrontmatter = (raw: string): Record<string, string> => {
-  const match = raw.match(SKILL_FRONTMATTER_RE);
-  if (!match) return {};
+interface SkillFrontmatterFields {
+  description?: string;
+  name?: string;
+}
 
-  const fields: Record<string, string> = {};
-  for (const line of match[1].split(/\r?\n/)) {
-    const colonIdx = line.indexOf(':');
-    if (colonIdx === -1) continue;
-    const key = line.slice(0, colonIdx).trim();
-    if (!key || key.startsWith('#')) continue;
-    let value = line.slice(colonIdx + 1).trim();
-    if (value.startsWith('|') || value.startsWith('>')) continue;
-    if (
-      (value.startsWith('"') && value.endsWith('"')) ||
-      (value.startsWith("'") && value.endsWith("'"))
-    ) {
-      value = value.slice(1, -1);
-    }
-    fields[key] = value;
+const readStringField = (data: Record<string, unknown>, field: keyof SkillFrontmatterFields) => {
+  const value = data[field];
+  return typeof value === 'string' ? value.trim() : undefined;
+};
+
+/**
+ * Parse SKILL.md YAML frontmatter. `gray-matter` handles block scalars such as
+ * `description: >`, keeping this path aligned with the server-side skill parser.
+ */
+const parseSkillFrontmatter = (raw: string): SkillFrontmatterFields => {
+  try {
+    const { data } = matter(raw) as { data: Record<string, unknown> };
+    return {
+      description: readStringField(data, 'description'),
+      name: readStringField(data, 'name'),
+    };
+  } catch {
+    return {};
   }
-  return fields;
 };
 
 /**


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Use `gray-matter` to parse project skill `SKILL.md` frontmatter in `@lobechat/device-control`.
- Restore descriptions for filesystem project skills whose frontmatter uses YAML block scalars such as `description: >`, including `agent-testing`, so ChatInput slash menu entries show their description.
- Add coverage for both the shared device-control RPC path and the Electron Workspace controller path.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/device-control && bunx vitest run --silent='passed-only' src/__tests__/dispatch.test.ts
cd apps/desktop && bunx vitest run --silent='passed-only' src/main/controllers/__tests__/WorkspaceCtr.test.ts
bunx eslint packages/device-control/src/workspace.ts packages/device-control/src/__tests__/dispatch.test.ts apps/desktop/src/main/controllers/__tests__/WorkspaceCtr.test.ts
git diff --check
```

#### 📸 Screenshots / Videos

N/A — parser-level fix for slash menu metadata.

#### 📝 Additional Information

The menu already consumes `skill.description`; the bug was in the project skill frontmatter scanner skipping YAML block scalar descriptions.
