### PR TITLE
♻️ refactor: migrate primitives to @lobehub/ui/base-ui

### DIFF
--- a/src/components/ChangelogModal/ChangelogModalContent.tsx
+++ b/src/components/ChangelogModal/ChangelogModalContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Center, Flexbox, ScrollArea } from '@lobehub/ui';
+import {  Center, Flexbox, ScrollArea  } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import useSWR from 'swr';

--- a/src/components/InlineRename/index.tsx
+++ b/src/components/InlineRename/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { type InputProps } from '@lobehub/ui';
-import { Input, Popover, stopPropagation } from '@lobehub/ui';
+import {  Input, Popover, stopPropagation  } from '@lobehub/ui/base-ui';
 import { type InputRef, type PopoverProps } from 'antd';
 import { type KeyboardEvent } from 'react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';

--- a/src/components/ManifestPreviewer/index.tsx
+++ b/src/components/ManifestPreviewer/index.tsx
@@ -1,4 +1,4 @@
-import { Highlighter, Popover } from '@lobehub/ui';
+import {  Highlighter, Popover  } from '@lobehub/ui/base-ui';
 import { type ReactNode } from 'react';
 import { memo } from 'react';
 

--- a/src/components/StreamingMarkdown/index.tsx
+++ b/src/components/StreamingMarkdown/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Markdown, ScrollArea } from '@lobehub/ui';
+import {  Markdown, ScrollArea  } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import type { RefObject } from 'react';
 import { memo, useEffect } from 'react';

--- a/src/components/TipGuide/index.tsx
+++ b/src/components/TipGuide/index.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Flexbox, Popover } from '@lobehub/ui';
+import {  ActionIcon, Flexbox, Popover  } from '@lobehub/ui/base-ui';
 import { type TooltipProps } from 'antd';
 import { ConfigProvider } from 'antd';
 import { createStaticStyles, cssVar, cx } from 'antd-style';

--- a/src/features/AgentBuilder/TopicSelector.tsx
+++ b/src/features/AgentBuilder/TopicSelector.tsx
@@ -1,5 +1,5 @@
-import { type DropdownMenuCheckboxItem } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu, Flexbox } from '@lobehub/ui';
+import {  type DropdownMenuCheckboxItem  } from '@lobehub/ui/base-ui';
+import {  ActionIcon, DropdownMenu, Flexbox  } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import dayjs from 'dayjs';
 import { Clock3Icon, PlusIcon } from 'lucide-react';

--- a/src/features/AgentMockDevtools/CaseTrigger.tsx
+++ b/src/features/AgentMockDevtools/CaseTrigger.tsx
@@ -1,5 +1,5 @@
 import type { MockCase } from '@lobechat/agent-mock';
-import { Flexbox, Input, Popover, Text, usePopoverContext } from '@lobehub/ui';
+import {  Flexbox, Input, Popover, Text, usePopoverContext  } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ChevronDown } from 'lucide-react';
 import { memo, type ReactNode, useMemo, useState } from 'react';

--- a/src/features/AgentProfileCard/AgentProfilePopup.tsx
+++ b/src/features/AgentProfileCard/AgentProfilePopup.tsx
@@ -2,7 +2,7 @@
 
 import { agentDisplayName, type AgentItem } from '@lobechat/types';
 import { ModelIcon } from '@lobehub/icons';
-import { ActionIcon, Flexbox, Icon, Popover, Skeleton, Text } from '@lobehub/ui';
+import {  ActionIcon, Flexbox, Icon, Popover, Skeleton, Text  } from '@lobehub/ui/base-ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
 import { createStaticStyles } from 'antd-style';
 import { BookOpen, FileText, Settings } from 'lucide-react';

--- a/src/features/AgentSidebar/Topic/Actions.tsx
+++ b/src/features/AgentSidebar/Topic/Actions.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { MoreHorizontal } from 'lucide-react';
 import { memo, useState } from 'react';
 

--- a/src/features/AgentSidebar/Topic/List/Item/Actions.tsx
+++ b/src/features/AgentSidebar/Topic/List/Item/Actions.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import { ActionIcon, DropdownMenu } from '@lobehub/ui/base-ui';
 import { MoreHorizontalIcon } from 'lucide-react';
 import { memo } from 'react';
 

--- a/src/features/AgentSidebar/Topic/TopicListContent/ThreadList/ThreadItem/Actions.tsx
+++ b/src/features/AgentSidebar/Topic/TopicListContent/ThreadList/ThreadItem/Actions.tsx
@@ -1,5 +1,5 @@
 import type { DropdownItem } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { MoreHorizontalIcon } from 'lucide-react';
 import { memo } from 'react';
 

--- a/src/features/AgentTaskManager/AgentSelectorAction.tsx
+++ b/src/features/AgentTaskManager/AgentSelectorAction.tsx
@@ -1,5 +1,5 @@
 import { agentDisplayName } from '@lobechat/types';
-import { Center, Flexbox, Popover } from '@lobehub/ui';
+import { Center, Flexbox, Popover } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { ChevronsUpDownIcon } from 'lucide-react';

--- a/src/features/AgentTaskManager/Toolbar.tsx
+++ b/src/features/AgentTaskManager/Toolbar.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Flexbox, Popover, Text } from '@lobehub/ui';
+import {  ActionIcon, Flexbox, Popover, Text  } from '@lobehub/ui/base-ui';
 import { Clock3Icon, PanelRightCloseIcon, PlusIcon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/AgentTasks/AgentTaskDetail/CommentCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/CommentCard.tsx
@@ -11,7 +11,7 @@ import {
   Icon,
   Markdown,
   Text,
-} from '@lobehub/ui';
+} from '@lobehub/ui/base-ui';
 import { Button, confirmModal } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { MessageCircle, MoreHorizontal, Pencil, Trash } from 'lucide-react';

--- a/src/features/AgentTasks/AgentTaskDetail/TaskArtifacts.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskArtifacts.tsx
@@ -1,5 +1,5 @@
 import type { TaskDetailWorkspaceNode } from '@lobechat/types';
-import {
+import { 
   ActionIcon,
   Block,
   type DropdownItem,
@@ -8,7 +8,7 @@ import {
   Icon,
   Tag,
   Text,
-} from '@lobehub/ui';
+ } from '@lobehub/ui/base-ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { FileLock2Icon, FileTextIcon, MoreHorizontal, Package, Trash } from 'lucide-react';

--- a/src/features/AgentTasks/AgentTaskDetail/TaskBriefCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskBriefCard.tsx
@@ -6,7 +6,7 @@ import {
   Flexbox,
   Icon,
   Text,
-} from '@lobehub/ui';
+} from '@lobehub/ui/base-ui';
 import { confirmModal, toast } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { Check, ChevronDownIcon, ChevronUpIcon, MoreHorizontal, Trash } from 'lucide-react';

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, copyToClipboard, type DropdownItem, DropdownMenu, Icon } from '@lobehub/ui';
+import { ActionIcon, copyToClipboard, type DropdownItem, DropdownMenu, Icon } from '@lobehub/ui/base-ui';
 import { confirmModal, toast } from '@lobehub/ui/base-ui';
 import { CopyIcon, EyeOffIcon, LinkIcon, MoreHorizontal, Trash, UsersIcon } from 'lucide-react';
 import { memo, useCallback, useMemo } from 'react';

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailRunPauseAction.tsx
@@ -1,4 +1,4 @@
-import { Flexbox, Text } from '@lobehub/ui';
+import { Flexbox, Text } from '@lobehub/ui/base-ui';
 import { Button, SplitButton } from '@lobehub/ui/base-ui';
 import { CalendarOffIcon, PlayIcon, RotateCcwIcon } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';

--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
@@ -10,7 +10,7 @@ import {
   stopPropagation,
   Tag,
   Text,
-} from '@lobehub/ui';
+} from '@lobehub/ui/base-ui';
 import { confirmModal, toast } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import {

--- a/src/features/AgentTasks/AgentTaskList/KanbanColumn.tsx
+++ b/src/features/AgentTasks/AgentTaskList/KanbanColumn.tsx
@@ -1,6 +1,6 @@
 import { useDndContext, useDraggable, useDroppable } from '@dnd-kit/core';
 import type { TaskStatus } from '@lobechat/types';
-import { ActionIcon, type DropdownItem, DropdownMenu, Icon, Text } from '@lobehub/ui';
+import {  ActionIcon, type DropdownItem, DropdownMenu, Icon, Text  } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
 import { EyeOff, MoreHorizontal, Plus } from 'lucide-react';
 import { memo, useMemo } from 'react';

--- a/src/features/AgentTasks/features/AssigneeAgentSelector.tsx
+++ b/src/features/AgentTasks/features/AssigneeAgentSelector.tsx
@@ -1,6 +1,6 @@
 import { DEFAULT_INBOX_AVATAR } from '@lobechat/const';
 import { agentDisplayName } from '@lobechat/types';
-import { Flexbox, Popover, Text, Tooltip } from '@lobehub/ui';
+import { Flexbox, Popover, Text, Tooltip } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import type { CSSProperties, KeyboardEvent, ReactNode } from 'react';

--- a/src/features/AgentTasks/features/TaskPriorityTag.tsx
+++ b/src/features/AgentTasks/features/TaskPriorityTag.tsx
@@ -1,5 +1,5 @@
 import type { IconType } from '@lobehub/icons';
-import { type DropdownItem, DropdownMenu, Icon, type MenuInfo, Tooltip } from '@lobehub/ui';
+import {  type DropdownItem, DropdownMenu, Icon, type MenuInfo, Tooltip  } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { Loader2Icon } from 'lucide-react';
 import type { ReactNode } from 'react';

--- a/src/features/AgentTasks/features/TaskStatusTag.tsx
+++ b/src/features/AgentTasks/features/TaskStatusTag.tsx
@@ -1,5 +1,5 @@
 import type { TaskStatus } from '@lobechat/types';
-import { type DropdownItem, DropdownMenu, Icon, type MenuInfo, Tooltip } from '@lobehub/ui';
+import {  type DropdownItem, DropdownMenu, Icon, type MenuInfo, Tooltip  } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import type { LucideIcon } from 'lucide-react';
 import { Loader2Icon } from 'lucide-react';

--- a/src/features/AgentTasks/features/TaskSubtaskProgressTag.tsx
+++ b/src/features/AgentTasks/features/TaskSubtaskProgressTag.tsx
@@ -1,6 +1,6 @@
 import type { TaskDetailSubtask } from '@lobechat/types';
-import { type DropdownMenuProps } from '@lobehub/ui';
-import { Block, DropdownMenu, Flexbox, Text } from '@lobehub/ui';
+import {  type DropdownMenuProps  } from '@lobehub/ui/base-ui';
+import {  Block, DropdownMenu, Flexbox, Text  } from '@lobehub/ui/base-ui';
 import { Progress } from 'antd';
 import { cssVar } from 'antd-style';
 import { memo, useMemo } from 'react';

--- a/src/features/AgentTopicManager/Toolbar.tsx
+++ b/src/features/AgentTopicManager/Toolbar.tsx
@@ -8,7 +8,7 @@ import {
   Icon,
   Text,
   Tooltip,
-} from '@lobehub/ui';
+} from '@lobehub/ui/base-ui';
 import { confirmModal, Tabs, toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import {

--- a/src/features/AgentTopicManager/TopicListView.tsx
+++ b/src/features/AgentTopicManager/TopicListView.tsx
@@ -2,7 +2,7 @@
 
 import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import type { GroupedTopic } from '@lobechat/types';
-import { ActionIcon, DropdownMenu, Flexbox, Icon, Tag, Text } from '@lobehub/ui';
+import { ActionIcon, DropdownMenu, Flexbox, Icon, Tag, Text } from '@lobehub/ui/base-ui';
 import { Checkbox } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { FolderIcon, MoreHorizontal, Star } from 'lucide-react';

--- a/src/features/AuthShell/AuthLangButton.tsx
+++ b/src/features/AuthShell/AuthLangButton.tsx
@@ -5,7 +5,7 @@ import {
   type DropdownMenuCheckboxItem,
   Flexbox,
   Text,
-} from '@lobehub/ui';
+} from '@lobehub/ui/base-ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { GlobeIcon } from 'lucide-react';
 import { memo, useMemo } from 'react';

--- a/src/features/AuthShell/AuthThemeButton.tsx
+++ b/src/features/AuthShell/AuthThemeButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ActionIcon, DropdownMenu, type DropdownMenuProps, Icon } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu, type DropdownMenuProps, Icon  } from '@lobehub/ui/base-ui';
 import { Monitor, Moon, Sun } from 'lucide-react';
 import { useTheme as useNextThemesTheme } from 'next-themes';
 import { memo, useMemo } from 'react';

--- a/src/features/ChatInput/ActionBar/AgentMode/index.tsx
+++ b/src/features/ChatInput/ActionBar/AgentMode/index.tsx
@@ -1,4 +1,4 @@
-import { Flexbox, Icon, Popover, Tooltip } from '@lobehub/ui';
+import {  Flexbox, Icon, Popover, Tooltip  } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import {
   ChevronDownIcon,

--- a/src/features/ChatInput/ActionBar/Tools/PopoverContent.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/PopoverContent.tsx
@@ -1,5 +1,5 @@
 import { type ItemType } from '@lobehub/ui';
-import { Flexbox, Icon, SearchBar, stopPropagation, usePopoverContext } from '@lobehub/ui';
+import {  Flexbox, Icon, SearchBar, stopPropagation, usePopoverContext  } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { Pin, Settings, Store, Zap } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';

--- a/src/features/ChatInput/ActionBar/Tools/ToolsList.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/ToolsList.tsx
@@ -1,5 +1,5 @@
 import type { ItemType } from '@lobehub/ui';
-import { Flexbox, Icon, Popover, Text } from '@lobehub/ui';
+import {  Flexbox, Icon, Popover, Text  } from '@lobehub/ui/base-ui';
 import { Divider } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import type { ReactNode } from 'react';

--- a/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
+++ b/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {
+import { 
   type BaseMenuItemType,
   type DropdownMenuPopupProps,
   type DropdownMenuProps,
@@ -8,15 +8,15 @@ import {
   type MenuItemType,
   type MenuProps,
   type PopoverTrigger,
-} from '@lobehub/ui';
-import {
+ } from '@lobehub/ui/base-ui';
+import { 
   DropdownMenuPopup,
   DropdownMenuPortal,
   DropdownMenuPositioner,
   DropdownMenuRoot,
   DropdownMenuTrigger,
   renderDropdownMenuItems,
-} from '@lobehub/ui';
+ } from '@lobehub/ui/base-ui';
 import { createGlobalStyle, createStaticStyles, cssVar, cx } from 'antd-style';
 import { type CSSProperties, type ReactNode } from 'react';
 import {

--- a/src/features/ChatInput/ActionBar/components/ActionPopover.tsx
+++ b/src/features/ChatInput/ActionBar/components/ActionPopover.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { type PopoverProps } from '@lobehub/ui';
-import { Flexbox, Popover } from '@lobehub/ui';
+import {  type PopoverProps  } from '@lobehub/ui/base-ui';
+import {  Flexbox, Popover  } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { type ReactNode } from 'react';
 import { memo, Suspense } from 'react';

--- a/src/features/ChatInput/ControlBar/ApprovalMode.tsx
+++ b/src/features/ChatInput/ControlBar/ApprovalMode.tsx
@@ -1,4 +1,4 @@
-import { type MenuProps } from '@lobehub/ui';
+import { type MenuProps } from '@lobehub/ui/base-ui';
 import { Center, DropdownMenu, Flexbox, Icon, Tooltip } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';

--- a/src/features/ChatInput/ControlBar/CloudRepoSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/CloudRepoSwitcher.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Github } from '@lobehub/icons';
-import { Flexbox, Icon, Popover, Tooltip } from '@lobehub/ui';
+import { Flexbox, Icon, Popover, Tooltip } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { CheckIcon, ChevronDownIcon, SquircleDashed } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';

--- a/src/features/ChatInput/ControlBar/ModeSelector.tsx
+++ b/src/features/ChatInput/ControlBar/ModeSelector.tsx
@@ -1,4 +1,4 @@
-import { Flexbox, Icon, Popover, Tooltip } from '@lobehub/ui';
+import {  Flexbox, Icon, Popover, Tooltip  } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import {
   ChevronDownIcon,

--- a/src/features/Conversation/Markdown/plugins/ImageSearchRef/Render.tsx
+++ b/src/features/Conversation/Markdown/plugins/ImageSearchRef/Render.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Flexbox, Popover } from '@lobehub/ui';
+import {  Flexbox, Popover  } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { memo } from 'react';

--- a/src/features/Conversation/Markdown/plugins/Mention/Render.tsx
+++ b/src/features/Conversation/Markdown/plugins/Mention/Render.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Avatar, Flexbox, Popover, Text } from '@lobehub/ui';
+import {  Avatar, Flexbox, Popover, Text  } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { memo } from 'react';

--- a/src/features/Conversation/Messages/AgentCouncil/components/AutoScrollShadow.tsx
+++ b/src/features/Conversation/Messages/AgentCouncil/components/AutoScrollShadow.tsx
@@ -1,4 +1,4 @@
-import { ScrollArea } from '@lobehub/ui';
+import {  ScrollArea  } from '@lobehub/ui/base-ui';
 import type { PropsWithChildren, RefObject } from 'react';
 import { memo, useEffect } from 'react';
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/ContentBlocksScroll.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { UIChatMessage } from '@lobechat/types';
-import { Flexbox, ScrollArea } from '@lobehub/ui';
+import {  Flexbox, ScrollArea  } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import type { RefObject } from 'react';
 import { memo, useMemo } from 'react';

--- a/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/UsageDetail/index.tsx
@@ -1,6 +1,6 @@
 import { type ModelPerformance, type ModelUsage } from '@lobechat/types';
 import { formatUsageValue } from '@lobechat/utils';
-import { Center, Flexbox, Icon, Popover } from '@lobehub/ui';
+import {  Center, Flexbox, Icon, Popover  } from '@lobehub/ui/base-ui';
 import { Divider } from 'antd';
 import { cssVar } from 'antd-style';
 import { BadgeCent, CoinsIcon } from 'lucide-react';

--- a/src/features/Conversation/components/Thinking/index.tsx
+++ b/src/features/Conversation/components/Thinking/index.tsx
@@ -1,4 +1,4 @@
-import { Accordion, AccordionItem, ScrollArea } from '@lobehub/ui';
+import {  Accordion, AccordionItem, ScrollArea  } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import type { CSSProperties, ReactNode, RefObject } from 'react';
 import { memo, useEffect, useState } from 'react';

--- a/src/features/EditingPopover/index.tsx
+++ b/src/features/EditingPopover/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PopoverPopup, PopoverPortal, PopoverPositioner, PopoverRoot } from '@lobehub/ui';
+import {  PopoverPopup, PopoverPortal, PopoverPositioner, PopoverRoot  } from '@lobehub/ui/base-ui';
 
 import AgentContent from './AgentContent';
 import GroupContent from './GroupContent';

--- a/src/features/Electron/titlebar/NavigationBar.tsx
+++ b/src/features/Electron/titlebar/NavigationBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
-import { ActionIcon, Flexbox, Popover, Tooltip } from '@lobehub/ui';
+import { ActionIcon, Flexbox, Popover, Tooltip } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import { ArrowLeft, ArrowRight, Clock } from 'lucide-react';
 import { memo, useCallback, useEffect, useState } from 'react';

--- a/src/features/Electron/titlebar/TabBar/index.tsx
+++ b/src/features/Electron/titlebar/TabBar/index.tsx
@@ -12,7 +12,7 @@ import {
 } from '@dnd-kit/core';
 import { horizontalListSortingStrategy, SortableContext } from '@dnd-kit/sortable';
 import { useWatchBroadcast } from '@lobechat/electron-client-ipc';
-import { ActionIcon, Flexbox } from '@lobehub/ui';
+import { ActionIcon, Flexbox } from '@lobehub/ui/base-ui';
 import { type DropdownItem, DropdownMenu } from '@lobehub/ui/base-ui';
 import { cx } from 'antd-style';
 import { ChevronDown, Plus } from 'lucide-react';

--- a/src/features/Home/Recents/Item.tsx
+++ b/src/features/Home/Recents/Item.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu, Flexbox, Icon  } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { FileTextIcon, HashIcon, MoreHorizontalIcon } from 'lucide-react';
 import { memo, useCallback, useState } from 'react';

--- a/src/features/Home/Recents/index.tsx
+++ b/src/features/Home/Recents/index.tsx
@@ -1,5 +1,5 @@
 import { type MenuProps } from '@lobehub/ui';
-import {
+import { 
   AccordionItem,
   ActionIcon,
   ContextMenuTrigger,
@@ -7,7 +7,7 @@ import {
   Flexbox,
   Icon,
   Text,
-} from '@lobehub/ui';
+ } from '@lobehub/ui/base-ui';
 import {
   ArrowDownIcon,
   ArrowUpIcon,

--- a/src/features/HomeSidebar/Body/Agent/Actions.tsx
+++ b/src/features/HomeSidebar/Body/Agent/Actions.tsx
@@ -1,5 +1,5 @@
 import type { MenuProps } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu, Flexbox } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu, Flexbox  } from '@lobehub/ui/base-ui';
 import { MoreHorizontalIcon, PlusIcon } from 'lucide-react';
 import { memo } from 'react';
 

--- a/src/features/HomeSidebar/Body/Agent/List/Group/Actions.tsx
+++ b/src/features/HomeSidebar/Body/Agent/List/Group/Actions.tsx
@@ -1,5 +1,5 @@
 import { type MenuProps } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { MoreHorizontalIcon } from 'lucide-react';
 import { memo } from 'react';
 

--- a/src/features/HomeSidebar/Body/Agent/List/Item/Actions.tsx
+++ b/src/features/HomeSidebar/Body/Agent/List/Item/Actions.tsx
@@ -1,5 +1,5 @@
 import { type DropdownItem } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { MoreHorizontalIcon } from 'lucide-react';
 import { memo } from 'react';
 

--- a/src/features/HomeSidebar/Body/index.tsx
+++ b/src/features/HomeSidebar/Body/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { MenuProps } from '@lobehub/ui';
-import { Accordion, ActionIcon, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
+import {  Accordion, ActionIcon, DropdownMenu, Flexbox, Icon  } from '@lobehub/ui/base-ui';
 import { EyeOffIcon, MoreHorizontalIcon, SlidersHorizontalIcon } from 'lucide-react';
 import type { Key, ReactElement } from 'react';
 import { memo, useCallback, useMemo } from 'react';

--- a/src/features/LibraryModal/AssignKnowledgeBase/Item/Action.tsx
+++ b/src/features/LibraryModal/AssignKnowledgeBase/Item/Action.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
+import { ActionIcon, DropdownMenu, Flexbox, Icon } from '@lobehub/ui/base-ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { InfoIcon, MoreVerticalIcon, Trash2 } from 'lucide-react';
 import { memo, useState } from 'react';

--- a/src/features/LocalFile/LocalFile.tsx
+++ b/src/features/LocalFile/LocalFile.tsx
@@ -1,4 +1,4 @@
-import { Flexbox, Popover } from '@lobehub/ui';
+import { Flexbox, Popover } from '@lobehub/ui/base-ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ExternalLink, FolderOpen } from 'lucide-react';

--- a/src/features/MCPPluginDetail/Deployment/index.tsx
+++ b/src/features/MCPPluginDetail/Deployment/index.tsx
@@ -1,6 +1,6 @@
 import { SiApple, SiLinux } from '@icons-pack/react-simple-icons';
 import { Microsoft } from '@lobehub/icons';
-import {
+import { 
   ActionIcon,
   Block,
   Collapse,
@@ -10,7 +10,7 @@ import {
   Popover,
   Snippet,
   Tag,
-} from '@lobehub/ui';
+ } from '@lobehub/ui/base-ui';
 import { Divider, Steps } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { startCase } from 'es-toolkit/compat';

--- a/src/features/MCPPluginDetail/Score/TotalScore.tsx
+++ b/src/features/MCPPluginDetail/Score/TotalScore.tsx
@@ -1,4 +1,4 @@
-import { Block, Center, Flexbox, Popover } from '@lobehub/ui';
+import {  Block, Center, Flexbox, Popover  } from '@lobehub/ui/base-ui';
 import { Progress } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { memo } from 'react';

--- a/src/features/MobileHome/SessionListContent/CollapseGroup/Actions.tsx
+++ b/src/features/MobileHome/SessionListContent/CollapseGroup/Actions.tsx
@@ -1,4 +1,4 @@
-import { type DropdownMenuProps, type MenuProps } from '@lobehub/ui';
+import { type DropdownMenuProps, type MenuProps } from '@lobehub/ui/base-ui';
 import { ActionIcon, DropdownMenu, Icon } from '@lobehub/ui';
 import { confirmModal, toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';

--- a/src/features/MobileHome/SessionListContent/List/Item/Actions.tsx
+++ b/src/features/MobileHome/SessionListContent/List/Item/Actions.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, DropdownMenu, Icon } from '@lobehub/ui';
+import { ActionIcon, DropdownMenu, Icon } from '@lobehub/ui/base-ui';
 import { confirmModal, toast } from '@lobehub/ui/base-ui';
 import { type ItemType } from 'antd/es/menu/interface';
 import isEqual from 'fast-deep-equal';

--- a/src/features/ModelSwitchPanel/components/List/GenerationListItemRenderer.tsx
+++ b/src/features/ModelSwitchPanel/components/List/GenerationListItemRenderer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {
+import { 
   ActionIcon,
   DropdownMenuPopup,
   DropdownMenuPortal,
@@ -10,7 +10,7 @@ import {
   Flexbox,
   Icon,
   menuSharedStyles,
-} from '@lobehub/ui';
+ } from '@lobehub/ui/base-ui';
 import { cssVar, cx } from 'antd-style';
 import { LucideArrowRight, LucideBolt } from 'lucide-react';
 import type { ComponentType } from 'react';

--- a/src/features/ModelSwitchPanel/components/List/GenerationMultipleProvidersItem.tsx
+++ b/src/features/ModelSwitchPanel/components/List/GenerationMultipleProvidersItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {
+import { 
   DropdownMenuPopup,
   DropdownMenuPortal,
   DropdownMenuPositioner,
@@ -8,7 +8,7 @@ import {
   DropdownMenuSubmenuTrigger,
   Flexbox,
   menuSharedStyles,
-} from '@lobehub/ui';
+ } from '@lobehub/ui/base-ui';
 import { cssVar, cx } from 'antd-style';
 import { Check } from 'lucide-react';
 import type { ComponentType } from 'react';

--- a/src/features/ModelSwitchPanel/components/List/ListItemRenderer.tsx
+++ b/src/features/ModelSwitchPanel/components/List/ListItemRenderer.tsx
@@ -1,4 +1,4 @@
-import {
+import { 
   ActionIcon,
   Block,
   DropdownMenuPopup,
@@ -9,7 +9,7 @@ import {
   Flexbox,
   Icon,
   menuSharedStyles,
-} from '@lobehub/ui';
+ } from '@lobehub/ui/base-ui';
 import { cssVar, cx } from 'antd-style';
 import { LucideArrowRight, LucideBolt } from 'lucide-react';
 import { memo, useEffect, useState } from 'react';

--- a/src/features/ModelSwitchPanel/components/List/MultipleProvidersModelItem.tsx
+++ b/src/features/ModelSwitchPanel/components/List/MultipleProvidersModelItem.tsx
@@ -1,4 +1,4 @@
-import {
+import { 
   DropdownMenuGroup,
   DropdownMenuGroupLabel,
   DropdownMenuItem,
@@ -12,7 +12,7 @@ import {
   Flexbox,
   menuSharedStyles,
   Tag,
-} from '@lobehub/ui';
+ } from '@lobehub/ui/base-ui';
 import { cx } from 'antd-style';
 import { Check } from 'lucide-react';
 import { memo, useState } from 'react';

--- a/src/features/ModelSwitchPanel/index.tsx
+++ b/src/features/ModelSwitchPanel/index.tsx
@@ -1,4 +1,4 @@
-import {
+import { 
   DropdownMenuPopup,
   DropdownMenuPortal,
   DropdownMenuPositioner,
@@ -6,7 +6,7 @@ import {
   DropdownMenuTrigger,
   stopPropagation,
   TooltipGroup,
-} from '@lobehub/ui';
+ } from '@lobehub/ui/base-ui';
 import { memo, useCallback, useState } from 'react';
 
 import { PanelContent } from './components/PanelContent';

--- a/src/features/ModelSwitchPanel/types.ts
+++ b/src/features/ModelSwitchPanel/types.ts
@@ -1,4 +1,4 @@
-import { type DropdownMenuPlacement } from '@lobehub/ui';
+import {  type DropdownMenuPlacement  } from '@lobehub/ui/base-ui';
 import { type AiModelForSelect } from 'model-bank';
 import { type ComponentType } from 'react';
 

--- a/src/features/OpenInAppButton/index.tsx
+++ b/src/features/OpenInAppButton/index.tsx
@@ -1,6 +1,6 @@
 import { isDesktop } from '@lobechat/const';
 import type { OpenInAppId } from '@lobechat/electron-client-ipc';
-import { DropdownMenu, type DropdownMenuProps, Icon, Tooltip } from '@lobehub/ui';
+import {  DropdownMenu, type DropdownMenuProps, Icon, Tooltip  } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ChevronDownIcon } from 'lucide-react';
 import { memo, useMemo } from 'react';

--- a/src/features/PageEditor/Copilot/AgentSelector/AgentSelectorAction.tsx
+++ b/src/features/PageEditor/Copilot/AgentSelector/AgentSelectorAction.tsx
@@ -1,5 +1,5 @@
 import { agentDisplayName } from '@lobechat/types';
-import { Center, Flexbox, Popover } from '@lobehub/ui';
+import { Center, Flexbox, Popover } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
 import { ChevronsUpDownIcon } from 'lucide-react';
 import { memo, Suspense, useCallback, useMemo, useState } from 'react';

--- a/src/features/PageEditor/Copilot/Toolbar.tsx
+++ b/src/features/PageEditor/Copilot/Toolbar.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Flexbox, Popover, Text } from '@lobehub/ui';
+import {  ActionIcon, Flexbox, Popover, Text  } from '@lobehub/ui/base-ui';
 import { Clock3Icon, PanelRightCloseIcon, PlusIcon } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/PageEditor/Copilot/TopicSelector/Actions.tsx
+++ b/src/features/PageEditor/Copilot/TopicSelector/Actions.tsx
@@ -1,5 +1,5 @@
 import { type DropdownItem } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { MoreHorizontalIcon } from 'lucide-react';
 import { memo } from 'react';
 

--- a/src/features/PageEditor/Header/index.tsx
+++ b/src/features/PageEditor/Header/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ActionIcon, Avatar, DropdownMenu, Text } from '@lobehub/ui';
+import {  ActionIcon, Avatar, DropdownMenu, Text  } from '@lobehub/ui/base-ui';
 import { ArrowLeftIcon, MoreHorizontal } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/Pages/PageLayout/Body/Actions.tsx
+++ b/src/features/Pages/PageLayout/Body/Actions.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { type MenuProps } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { MoreHorizontal } from 'lucide-react';
 import { memo } from 'react';
 

--- a/src/features/Pages/PageLayout/Body/List/Item/Actions.tsx
+++ b/src/features/Pages/PageLayout/Body/List/Item/Actions.tsx
@@ -1,5 +1,5 @@
 import { type DropdownItem } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { MoreHorizontalIcon } from 'lucide-react';
 import { memo } from 'react';
 

--- a/src/features/Pages/PageLayout/Body/List/Item/Editing.tsx
+++ b/src/features/Pages/PageLayout/Body/List/Item/Editing.tsx
@@ -1,4 +1,4 @@
-import { Block, Flexbox, Input, Popover, stopPropagation } from '@lobehub/ui';
+import {  Block, Flexbox, Input, Popover, stopPropagation  } from '@lobehub/ui/base-ui';
 import { memo, useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/features/PluginTag/index.tsx
+++ b/src/features/PluginTag/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Center, DropdownMenu, Icon, Tag } from '@lobehub/ui';
+import {  Center, DropdownMenu, Icon, Tag  } from '@lobehub/ui/base-ui';
 import isEqual from 'fast-deep-equal';
 import { LucideToyBrick } from 'lucide-react';
 import { memo, useMemo } from 'react';

--- a/src/features/Portal/Artifacts/Body/Renderer/SVG.tsx
+++ b/src/features/Portal/Artifacts/Body/Renderer/SVG.tsx
@@ -1,6 +1,6 @@
 import { BRANDING_NAME } from '@lobechat/business-const';
 import { copyImageToClipboard, sanitizeSVGContent } from '@lobechat/utils/client';
-import { Center, DropdownMenu, Flexbox, Tooltip } from '@lobehub/ui';
+import { Center, DropdownMenu, Flexbox, Tooltip } from '@lobehub/ui/base-ui';
 import { Button, toast } from '@lobehub/ui/base-ui';
 import { snapdom } from '@zumer/snapdom';
 import { css, cx } from 'antd-style';

--- a/src/features/ResourceHome/Layout/Body/LibraryList/Item/Actions.tsx
+++ b/src/features/ResourceHome/Layout/Body/LibraryList/Item/Actions.tsx
@@ -1,5 +1,5 @@
 import { type DropdownItem } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { MoreHorizontalIcon } from 'lucide-react';
 import { memo } from 'react';
 

--- a/src/features/ResourceLibrary/Layout/Header/LibraryHead.tsx
+++ b/src/features/ResourceLibrary/Layout/Header/LibraryHead.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ActionIcon, Block, Center, Skeleton, stopPropagation, Text } from '@lobehub/ui';
+import { ActionIcon, Block, Center, Skeleton, stopPropagation, Text } from '@lobehub/ui/base-ui';
 import type { DropdownItem } from '@lobehub/ui/base-ui';
 import { DropdownMenu } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';

--- a/src/features/ResourceManager/components/Explorer/ItemDropdown/DropdownMenu.tsx
+++ b/src/features/ResourceManager/components/Explorer/ItemDropdown/DropdownMenu.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, DropdownMenu as DropdownMenuUI } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu as DropdownMenuUI  } from '@lobehub/ui/base-ui';
 import { type ItemType } from 'antd/es/menu/interface';
 import { MoreHorizontalIcon } from 'lucide-react';
 import { memo } from 'react';

--- a/src/features/ResourceManager/components/Explorer/ToolBar/BatchActionsDropdown.tsx
+++ b/src/features/ResourceManager/components/Explorer/ToolBar/BatchActionsDropdown.tsx
@@ -1,4 +1,4 @@
-import { type DropdownItem } from '@lobehub/ui';
+import { type DropdownItem } from '@lobehub/ui/base-ui';
 import { DropdownMenu, Icon, Tooltip } from '@lobehub/ui';
 import { confirmModal, toast } from '@lobehub/ui/base-ui';
 import {

--- a/src/features/ResourceManager/components/Explorer/ToolBar/SortDropdown.tsx
+++ b/src/features/ResourceManager/components/Explorer/ToolBar/SortDropdown.tsx
@@ -1,4 +1,4 @@
-import { DropdownMenu, Icon } from '@lobehub/ui';
+import {  DropdownMenu, Icon  } from '@lobehub/ui/base-ui';
 import { type LucideIcon } from 'lucide-react';
 import { ArrowDownAZ, CalendarIcon, Check, HardDriveIcon } from 'lucide-react';
 import { memo, useMemo } from 'react';

--- a/src/features/ResourceManager/components/Explorer/ToolBar/ViewSwitcher.tsx
+++ b/src/features/ResourceManager/components/Explorer/ToolBar/ViewSwitcher.tsx
@@ -1,4 +1,4 @@
-import { DropdownMenu, Icon } from '@lobehub/ui';
+import {  DropdownMenu, Icon  } from '@lobehub/ui/base-ui';
 import { Check, Grid3x3Icon, ListIcon } from 'lucide-react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/ResourceManager/components/Header/AddButton.tsx
+++ b/src/features/ResourceManager/components/Header/AddButton.tsx
@@ -6,7 +6,7 @@ import {
   DERIVED_DOCUMENT_SOURCE_TYPE,
 } from '@lobechat/const';
 import { Notion } from '@lobehub/icons';
-import { type DropdownItem } from '@lobehub/ui';
+import { type DropdownItem } from '@lobehub/ui/base-ui';
 import { DropdownMenu, Icon, Tooltip } from '@lobehub/ui';
 import { Button, toast } from '@lobehub/ui/base-ui';
 import { Upload } from 'antd';

--- a/src/features/Settings/profile/features/SSOProvidersList/index.tsx
+++ b/src/features/Settings/profile/features/SSOProvidersList/index.tsx
@@ -1,5 +1,5 @@
 import { isDesktop } from '@lobechat/const';
-import { type MenuProps } from '@lobehub/ui';
+import { type MenuProps } from '@lobehub/ui/base-ui';
 import { ActionIcon, DropdownMenu, Flexbox, Text, Tooltip } from '@lobehub/ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { ArrowRight, Plus, Unlink } from 'lucide-react';

--- a/src/features/Settings/provider/ProviderMenu/Actions.tsx
+++ b/src/features/Settings/provider/ProviderMenu/Actions.tsx
@@ -1,5 +1,5 @@
 import { type MenuProps } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { MoreHorizontalIcon } from 'lucide-react';
 import { memo } from 'react';
 

--- a/src/features/Settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/features/Settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -1,4 +1,4 @@
-import { Flexbox, Popover } from '@lobehub/ui';
+import { Flexbox, Popover } from '@lobehub/ui/base-ui';
 import { Select, Switch } from '@lobehub/ui/base-ui';
 import { Space, Tag, theme, Typography } from 'antd';
 import { type ExtendParamsType } from 'model-bank';

--- a/src/features/Settings/provider/features/ModelList/DisabledModels.tsx
+++ b/src/features/Settings/provider/features/ModelList/DisabledModels.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, DropdownMenu, Flexbox, Icon, Text, TooltipGroup } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu, Flexbox, Icon, Text, TooltipGroup  } from '@lobehub/ui/base-ui';
 import { type ItemType } from 'antd/es/menu/interface';
 import isEqual from 'fast-deep-equal';
 import { ArrowDownUpIcon, LucideCheck } from 'lucide-react';

--- a/src/features/Settings/provider/features/ModelList/ModelTitle/index.tsx
+++ b/src/features/Settings/provider/features/ModelList/ModelTitle/index.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, DropdownMenu, Flexbox, Skeleton, Text, Tooltip } from '@lobehub/ui';
+import { ActionIcon, DropdownMenu, Flexbox, Skeleton, Text, Tooltip } from '@lobehub/ui/base-ui';
 import { Button, confirmModal, toast } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { CircleX, EllipsisVertical, LucideRefreshCcwDot, PlusIcon } from 'lucide-react';

--- a/src/features/Settings/skill/features/Actions.tsx
+++ b/src/features/Settings/skill/features/Actions.tsx
@@ -1,4 +1,4 @@
-import { DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
+import { DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui/base-ui';
 import { Button, confirmModal } from '@lobehub/ui/base-ui';
 import { MoreHorizontalIcon, Trash2 } from 'lucide-react';
 import { memo, useState } from 'react';

--- a/src/features/Settings/skill/features/AgentSkillItem.tsx
+++ b/src/features/Settings/skill/features/AgentSkillItem.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { type BuiltinSkill, type SkillListItem } from '@lobechat/types';
-import { Avatar, DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
+import { Avatar, DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui/base-ui';
 import { Button, confirmModal, createModal } from '@lobehub/ui/base-ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
 import { cssVar } from 'antd-style';

--- a/src/features/SharePopover/index.tsx
+++ b/src/features/SharePopover/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { copyToClipboard, Flexbox, Popover, Skeleton, Text, usePopoverContext } from '@lobehub/ui';
+import { copyToClipboard, Flexbox, Popover, Skeleton, Text, usePopoverContext } from '@lobehub/ui/base-ui';
 import { Button, Checkbox, confirmModal, Select, toast } from '@lobehub/ui/base-ui';
 import { Divider } from 'antd';
 import {

--- a/src/features/SkillStore/SkillList/AddSkillButton.tsx
+++ b/src/features/SkillStore/SkillList/AddSkillButton.tsx
@@ -1,4 +1,4 @@
-import { DropdownMenu, Flexbox, Icon, Text } from '@lobehub/ui';
+import { DropdownMenu, Flexbox, Icon, Text } from '@lobehub/ui/base-ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { GithubIcon } from '@lobehub/ui/icons';
 import { ChevronDown, FileArchive, Grid2x2Plus, Link, PenLine } from 'lucide-react';

--- a/src/features/SkillStore/SkillList/Builtin/Item.tsx
+++ b/src/features/SkillStore/SkillList/Builtin/Item.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {
+import { 
   ActionIcon,
   Avatar,
   Block,
@@ -8,7 +8,7 @@ import {
   Flexbox,
   Icon,
   stopPropagation,
-} from '@lobehub/ui';
+ } from '@lobehub/ui/base-ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { MoreVerticalIcon, Plus, Trash2 } from 'lucide-react';
 import { memo } from 'react';

--- a/src/features/SkillStore/SkillList/Community/Item.tsx
+++ b/src/features/SkillStore/SkillList/Community/Item.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ActionIcon, Block, DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
+import { ActionIcon, Block, DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui/base-ui';
 import { Button, confirmModal, createModal } from '@lobehub/ui/base-ui';
 import isEqual from 'fast-deep-equal';
 import { t as translate } from 'i18next';

--- a/src/features/SkillStore/SkillList/Community/MarketSkillItem.tsx
+++ b/src/features/SkillStore/SkillList/Community/MarketSkillItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ActionIcon, Avatar, Block, DropdownMenu, Flexbox, Icon, Tag } from '@lobehub/ui';
+import { ActionIcon, Avatar, Block, DropdownMenu, Flexbox, Icon, Tag } from '@lobehub/ui/base-ui';
 import { confirmModal, createModal } from '@lobehub/ui/base-ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
 import { createStaticStyles, cssVar } from 'antd-style';

--- a/src/features/SkillStore/SkillList/LobeHub/Item.tsx
+++ b/src/features/SkillStore/SkillList/LobeHub/Item.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ActionIcon, Block, DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
+import {  ActionIcon, Block, DropdownMenu, Flexbox, Icon, stopPropagation  } from '@lobehub/ui/base-ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { Loader2, MoreVerticalIcon, Plus, Unplug } from 'lucide-react';

--- a/src/features/User/UserPanel/LangButton.tsx
+++ b/src/features/User/UserPanel/LangButton.tsx
@@ -1,4 +1,4 @@
-import { type DropdownMenuCheckboxItem, type DropdownMenuProps } from '@lobehub/ui';
+import { type DropdownMenuCheckboxItem, type DropdownMenuProps } from '@lobehub/ui/base-ui';
 import { DropdownMenu, Flexbox, Icon, Text } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';

--- a/src/features/User/UserPanel/ThemeButton.tsx
+++ b/src/features/User/UserPanel/ThemeButton.tsx
@@ -1,5 +1,5 @@
-import { type DropdownMenuProps } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu, Icon } from '@lobehub/ui';
+import {  type DropdownMenuProps  } from '@lobehub/ui/base-ui';
+import {  ActionIcon, DropdownMenu, Icon  } from '@lobehub/ui/base-ui';
 import { Monitor, Moon, Sun } from 'lucide-react';
 import { useTheme as useNextThemesTheme } from 'next-themes';
 import { type FC, useMemo } from 'react';

--- a/src/features/User/UserPanel/index.tsx
+++ b/src/features/User/UserPanel/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Popover } from '@lobehub/ui';
+import {  Popover  } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import { type PropsWithChildren } from 'react';
 import { memo, Suspense, useState } from 'react';

--- a/src/routes/(main)/(create)/components/GenerationModelItem.tsx
+++ b/src/routes/(main)/(create)/components/GenerationModelItem.tsx
@@ -3,7 +3,7 @@
 import { BRANDING_PROVIDER } from '@lobechat/business-const';
 import { CREDITS_PER_DOLLAR } from '@lobechat/const/currency';
 import { ModelIcon } from '@lobehub/icons';
-import { Flexbox, Popover, Text } from '@lobehub/ui';
+import {  Flexbox, Popover, Text  } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
 import type { AiModelForSelect } from 'model-bank';
 import numeral from 'numeral';

--- a/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { MoreHorizontal } from 'lucide-react';
 import { memo } from 'react';
 

--- a/src/routes/(main)/agent/features/Conversation/Header/Tags/ThreadSwitcher.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/Tags/ThreadSwitcher.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Flexbox, Popover } from '@lobehub/ui';
+import {  Flexbox, Popover  } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/routes/(main)/agent/profile/features/Header/index.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.tsx
@@ -1,6 +1,6 @@
 import { isDesktop } from '@lobechat/const';
 import { getActivePluginIds, type LobeAgentConfig } from '@lobechat/types';
-import { ActionIcon, DropdownMenu, Flexbox, Icon } from '@lobehub/ui';
+import { ActionIcon, DropdownMenu, Flexbox, Icon } from '@lobehub/ui/base-ui';
 import { confirmModal, type ModalInstance } from '@lobehub/ui/base-ui';
 import { toast } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';

--- a/src/routes/(main)/community/(detail)/model/features/Sidebar/ActionButton/ChatWithModel.tsx
+++ b/src/routes/(main)/community/(detail)/model/features/Sidebar/ActionButton/ChatWithModel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ProviderIcon } from '@lobehub/icons';
-import { DropdownMenu } from '@lobehub/ui';
+import { DropdownMenu } from '@lobehub/ui/base-ui';
 import { Button, SplitButton } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';

--- a/src/routes/(main)/community/(detail)/user/features/UserGroupCard.tsx
+++ b/src/routes/(main)/community/(detail)/user/features/UserGroupCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {
+import { 
   Avatar,
   Block,
   DropdownMenu,
@@ -12,7 +12,7 @@ import {
   Text,
   Tooltip,
   TooltipGroup,
-} from '@lobehub/ui';
+ } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
 import {
   AlertTriangle,

--- a/src/routes/(main)/community/(list)/features/SortButton/index.tsx
+++ b/src/routes/(main)/community/(list)/features/SortButton/index.tsx
@@ -1,4 +1,4 @@
-import { type DropdownItem, type DropdownMenuCheckboxItem } from '@lobehub/ui';
+import { type DropdownItem, type DropdownMenuCheckboxItem } from '@lobehub/ui/base-ui';
 import { DropdownMenu, Icon } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
 import { ArrowDownWideNarrow, ChevronDown } from 'lucide-react';

--- a/src/routes/(main)/community/(list)/model/features/List/Item.tsx
+++ b/src/routes/(main)/community/(list)/model/features/List/Item.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ModelIcon, ProviderIcon } from '@lobehub/icons';
-import { Block, Flexbox, Icon, Popover, Tag, Text } from '@lobehub/ui';
+import {  Block, Flexbox, Icon, Popover, Tag, Text  } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import dayjs from 'dayjs';
 import { ClockIcon } from 'lucide-react';

--- a/src/routes/(main)/eval/bench/[benchmarkId]/_layout/Sidebar/Header/BenchmarkHead.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/_layout/Sidebar/Header/BenchmarkHead.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type DropdownItem } from '@lobehub/ui';
+import { type DropdownItem } from '@lobehub/ui/base-ui';
 import {
   ActionIcon,
   Block,

--- a/src/routes/(main)/group/_layout/Sidebar/Header/Agent/SwitchPanel.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Header/Agent/SwitchPanel.tsx
@@ -1,4 +1,4 @@
-import { Flexbox, Popover } from '@lobehub/ui';
+import {  Flexbox, Popover  } from '@lobehub/ui/base-ui';
 import { type PropsWithChildren } from 'react';
 import React, { memo, Suspense } from 'react';
 

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/Actions.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/Actions.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { MoreHorizontal } from 'lucide-react';
 import { memo, useState } from 'react';
 

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/Actions.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/Actions.tsx
@@ -1,5 +1,5 @@
 import type { DropdownItem } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { MoreHorizontalIcon } from 'lucide-react';
 import { memo } from 'react';
 

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/Editing.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/Editing.tsx
@@ -1,4 +1,4 @@
-import { Input, Popover, stopPropagation } from '@lobehub/ui';
+import {  Input, Popover, stopPropagation  } from '@lobehub/ui/base-ui';
 import { memo, useCallback, useState } from 'react';
 
 import { useOverlayPopoverPortalProps } from '@/features/NavPanel/OverlayContainer';

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/Actions.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/Actions.tsx
@@ -1,5 +1,5 @@
 import type { DropdownItem } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { MoreHorizontalIcon } from 'lucide-react';
 import { memo } from 'react';
 

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/Editing.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ThreadList/ThreadItem/Editing.tsx
@@ -1,4 +1,4 @@
-import { Input, Popover, stopPropagation } from '@lobehub/ui';
+import {  Input, Popover, stopPropagation  } from '@lobehub/ui/base-ui';
 import { memo, useCallback, useState } from 'react';
 
 import { useOverlayPopoverPortalProps } from '@/features/NavPanel/OverlayContainer';

--- a/src/routes/(main)/group/profile/features/AgentBuilder/TopicSelector.tsx
+++ b/src/routes/(main)/group/profile/features/AgentBuilder/TopicSelector.tsx
@@ -1,4 +1,4 @@
-import { type DropdownMenuCheckboxItem } from '@lobehub/ui';
+import { type DropdownMenuCheckboxItem } from '@lobehub/ui/base-ui';
 import { ActionIcon, DropdownMenu, Tag } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { Clock3Icon, PlusIcon } from 'lucide-react';

--- a/src/routes/(main)/memory/activities/features/ActivityDropdown.tsx
+++ b/src/routes/(main)/memory/activities/features/ActivityDropdown.tsx
@@ -1,5 +1,5 @@
 import { type ActionIconProps } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { type KeyboardEvent, type MouseEvent } from 'react';

--- a/src/routes/(main)/memory/contexts/features/ContextDropdown.tsx
+++ b/src/routes/(main)/memory/contexts/features/ContextDropdown.tsx
@@ -1,5 +1,5 @@
 import { type ActionIconProps } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { type KeyboardEvent, type MouseEvent } from 'react';

--- a/src/routes/(main)/memory/experiences/features/ExperienceDropdown.tsx
+++ b/src/routes/(main)/memory/experiences/features/ExperienceDropdown.tsx
@@ -1,5 +1,5 @@
 import { type ActionIconProps } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { type KeyboardEvent, type MouseEvent } from 'react';

--- a/src/routes/(main)/memory/identities/features/IdentityDropdown.tsx
+++ b/src/routes/(main)/memory/identities/features/IdentityDropdown.tsx
@@ -1,5 +1,5 @@
 import { type ActionIconProps } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { type KeyboardEvent, type MouseEvent } from 'react';

--- a/src/routes/(main)/memory/preferences/features/PreferenceDropdown.tsx
+++ b/src/routes/(main)/memory/preferences/features/PreferenceDropdown.tsx
@@ -1,5 +1,5 @@
 import { type ActionIconProps } from '@lobehub/ui';
-import { ActionIcon, DropdownMenu } from '@lobehub/ui';
+import {  ActionIcon, DropdownMenu  } from '@lobehub/ui/base-ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { type KeyboardEvent, type MouseEvent } from 'react';

--- a/src/routes/(popup)/agent/[aid]/QuickChatAgentSwitcher.tsx
+++ b/src/routes/(popup)/agent/[aid]/QuickChatAgentSwitcher.tsx
@@ -2,7 +2,7 @@
 
 import { INBOX_SESSION_ID } from '@lobechat/const';
 import { agentDisplayName } from '@lobechat/types';
-import { Avatar, Flexbox, Icon, Input, Popover, Tooltip } from '@lobehub/ui';
+import { Avatar, Flexbox, Icon, Input, Popover, Tooltip } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cx } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { MoreHorizontalIcon } from 'lucide-react';


### PR DESCRIPTION
��### Description
Per AGENTS.md guidelines, headless primitives should be imported from @lobehub/ui/base-ui rather than the root package to optimize bundle size.

### Changes
- Migrated DropdownMenu, Popover, ScrollArea, Switch, and Toast imports.
