### PR TITLE
✨ feat(agent): hide Files tab in chat mode

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
@@ -87,6 +87,9 @@ const AgentWorkingSidebar = memo(() => {
   const isLocalSystemEnabled = useAgentStore((s) =>
     activeAgentId ? chatConfigByIdSelectors.isLocalSystemEnabledById(activeAgentId)(s) : false,
   );
+  const isChatMode = useAgentStore((s) =>
+    activeAgentId ? chatConfigByIdSelectors.isChatModeById(activeAgentId)(s) : false,
+  );
   const isHetero = useAgentStore(agentSelectors.isCurrentAgentHeterogeneous);
   // Unified precedence (topic > per-device choice > legacy > device default), so
   // the sidebar resolves the same directory the runtime bar / git status do.
@@ -115,7 +118,10 @@ const AgentWorkingSidebar = memo(() => {
   // remote device RPC; local "This device" must keep Electron IPC + file-open
   // actions enabled.
   const remoteDeviceId = isDeviceMode ? agencyConfig.boundDeviceId : undefined;
-  const filesAvailable = (isLocalSystemEnabled || isDeviceMode) && !!workingDirectory;
+  // Files tab is an agent-mode affordance — in plain chat mode the working
+  // directory is irrelevant to the user, so hide the tab even when one resolves.
+  const filesAvailable =
+    !isChatMode && (isLocalSystemEnabled || isDeviceMode) && !!workingDirectory;
   const reviewAvailable =
     (isLocalSystemEnabled || isDeviceMode) && !!workingDirectory && !!repoType;
   const paramsAvailable = !isHetero;


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

The **Files** tab in the conversation working sidebar (空间 / 审查 / 文件 / 参数) is an agent-mode affordance — it surfaces the agent's working directory file tree. In plain **chat mode** the working directory is irrelevant to the user, so the tab shouldn't appear there.

This gates `filesAvailable` on `!isChatMode` (via the existing `chatConfigByIdSelectors.isChatModeById` selector). Because `resolveActiveTab()` already falls back away from `'files'` when `filesAvailable` is false, the tab disappears cleanly in chat mode and the panel defaults to 空间/审查/参数 as appropriate.

Note: the **审查** (Review) tab shares the same `(isLocalSystemEnabled || isDeviceMode) && workingDirectory` precondition, which in practice won't be satisfied in chat mode — so it is left untouched. Only the Files tab is explicitly chat-gated here.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Open an agent in **chat mode** with a working directory available → the 文件 tab should be hidden.
2. Switch the same agent to **agent mode** (local system or device) → the 文件 tab reappears.

#### 📝 Additional Information

Single-file change to `src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx`.