### PR TITLE
♻️ refactor(ui): fix exhaustive-deps warning in CodeEditorPane

### DIFF
--- a/src/components/CodeEditorPane/index.tsx
+++ b/src/components/CodeEditorPane/index.tsx
@@ -39,6 +39,9 @@ const CodeEditorPane = memo<CodeEditorPaneProps>(
     onChangeRef.current = onChange;
     onSaveRef.current = onSave;
 
+    // Capture initial values for first render to avoid exhaustive-deps on the mount effect
+    const initialConfigRef = useRef({ language, readOnly, value });
+
     useEffect(() => {
       if (!textareaRef.current) return;
       const dom = textareaRef.current;
@@ -49,10 +52,10 @@ const CodeEditorPane = memo<CodeEditorPaneProps>(
         const instance = CodeMirror.fromTextArea(dom, {
           lineNumbers: true,
           lineWrapping: true,
-          mode: language,
-          readOnly,
+          mode: initialConfigRef.current.language,
+          readOnly: initialConfigRef.current.readOnly,
           theme: 'default',
-          value,
+          value: initialConfigRef.current.value,
         });
         instance.view.dispatch({
           effects: instance.optionHelper.theme.reconfigure(
@@ -79,7 +82,6 @@ const CodeEditorPane = memo<CodeEditorPaneProps>(
           instanceRef.current = null;
         }
       };
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
��### Description
Fixed the eslint-disable-next-line react-hooks/exhaustive-deps warning in CodeEditorPane. The initial configuration variables for the CodeMirror instance (language, eadOnly, alue) are now captured in a stable initialConfigRef to explicitly indicate they are only used for the initial initialization on mount, and not intended to trigger a re-creation of the editor.

### Changes
- Replaced direct variable access with initialConfigRef.current.* in the mount useEffect.
- Removed the eslint-disable comment.
