### PR TITLE
🐛 fix(cli): finalize failed remote agent starts

### DIFF
--- a/apps/cli/src/commands/hetero.test.ts
+++ b/apps/cli/src/commands/hetero.test.ts
@@ -39,11 +39,13 @@ vi.mock('../utils/logger', () => ({
  */
 const createFakeHandle = ({
   events = [] as any[],
+  eventsError,
   exitCode = 0,
   signal = null as NodeJS.Signals | null,
   stderrChunks = [] as string[],
 }: {
   events?: any[];
+  eventsError?: Error;
   exitCode?: number | null;
   signal?: NodeJS.Signals | null;
   stderrChunks?: string[];
@@ -60,6 +62,7 @@ const createFakeHandle = ({
       return {
         async next() {
           if (i < events.length) return { done: false, value: events[i++] };
+          if (eventsError) throw eventsError;
           return { done: true, value: undefined };
         },
       };
@@ -414,6 +417,65 @@ describe('hetero exec command', () => {
       '/missing.png',
     ]);
 
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('finishes server-ingest runs with error when spawnAgent rejects before streaming', async () => {
+    mockSpawnAgent.mockReturnValue(Promise.reject(new Error('spawn claude ENOENT')));
+
+    await runCmd([
+      'hetero',
+      'exec',
+      '--type',
+      'claude-code',
+      '--prompt',
+      'hi',
+      '--topic',
+      'topic-1',
+      '--operation-id',
+      'op-server',
+      '--render',
+      'none',
+    ]);
+
+    expect(mockHeteroFinishMutate).toHaveBeenCalledTimes(1);
+    expect(mockHeteroFinishMutate.mock.calls[0][0]).toMatchObject({
+      agentType: 'claude-code',
+      error: { message: 'spawn claude ENOENT', type: 'AgentRuntimeError' },
+      operationId: 'op-server',
+      result: 'error',
+      topicId: 'topic-1',
+    });
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('finishes server-ingest runs with error when the agent event stream fails', async () => {
+    mockSpawnAgent.mockReturnValue(
+      createFakeHandle({ eventsError: new Error('spawn claude ENOENT') }),
+    );
+
+    await runCmd([
+      'hetero',
+      'exec',
+      '--type',
+      'claude-code',
+      '--prompt',
+      'hi',
+      '--topic',
+      'topic-1',
+      '--operation-id',
+      'op-server',
+      '--render',
+      'none',
+    ]);
+
+    expect(mockHeteroFinishMutate).toHaveBeenCalledTimes(1);
+    expect(mockHeteroFinishMutate.mock.calls[0][0]).toMatchObject({
+      error: { message: 'Error: spawn claude ENOENT', type: 'stream_error' },
+      operationId: 'op-server',
+      result: 'error',
+      topicId: 'topic-1',
+    });
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 

--- a/apps/cli/src/commands/hetero.ts
+++ b/apps/cli/src/commands/hetero.ts
@@ -524,7 +524,19 @@ const exec = async (options: ExecOptions): Promise<void> => {
       handle = await spawnAgent({ ...spawnOpts, onRawStdout: dumpAttempt?.writeStdout });
     } catch (err) {
       await dumpAttempt?.close();
-      log.error('Failed to start agent:', err instanceof Error ? err.message : String(err));
+      const message = err instanceof Error ? err.message : String(err);
+      log.error('Failed to start agent:', message);
+      if (serverIngester && sink) {
+        try {
+          await serverIngester.drain();
+          await sink.finish({
+            error: { message, type: 'AgentRuntimeError' },
+            result: 'error',
+          });
+        } catch {
+          // best-effort; process is exiting anyway
+        }
+      }
       process.exit(1);
     }
 
@@ -543,6 +555,13 @@ const exec = async (options: ExecOptions): Promise<void> => {
       dumpAttempt?.writeStderr(chunk);
     });
     handle.stderr.pipe(process.stderr);
+    const exit = handle.exit.catch((err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      if (stderrContent.length < STDERR_CAP) {
+        stderrContent += `${stderrContent ? '\n' : ''}${message}`;
+      }
+      return { code: 1, signal: null as NodeJS.Signals | null };
+    });
 
     // Ctrl-C → SIGINT to the child's process group.
     // Repeated Ctrl-C escalates to SIGKILL.
@@ -633,7 +652,7 @@ const exec = async (options: ExecOptions): Promise<void> => {
       process.off('SIGTERM', onSigterm);
     }
 
-    const { code, signal } = await handle.exit;
+    const { code, signal } = await exit;
     await stderrEnded;
     await dumpAttempt?.close();
 

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
@@ -567,6 +567,31 @@ describe('spawnAgent', () => {
     }).rejects.toThrow(/boom/);
   });
 
+  it('events iterator surfaces child spawn errors instead of hanging', async () => {
+    const fake = createFakeProc();
+    nextFakeProc = fake.proc;
+
+    const { spawnAgent } = await import('./spawnAgent');
+    const handle = await spawnAgent({
+      agentType: 'claude-code',
+      operationId: 'op-1',
+      prompt: 'go',
+    });
+    const exitError = handle.exit.catch((err) => err);
+
+    const drainEvents = async () => {
+      for await (const _e of handle.events) {
+        // drain
+      }
+    };
+
+    const spawnError = new Error('spawn claude ENOENT');
+    fake.proc.emit('error', spawnError);
+
+    await expect(drainEvents()).rejects.toThrow(/spawn claude ENOENT/);
+    await expect(exitError).resolves.toBe(spawnError);
+  });
+
   it('tees the child raw stdout to onRawStdout verbatim, before adapting', async () => {
     const fake = createFakeProc({ stdoutChunks: [ccInit, ccText] });
     nextFakeProc = fake.proc;

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.ts
@@ -278,19 +278,6 @@ export const spawnAgent = async (options: SpawnAgentOptions): Promise<SpawnAgent
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
-  const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
-    (resolve, reject) => {
-      proc.on('exit', (code, signal) => resolve({ code, signal }));
-      proc.on('error', (err) => reject(err));
-    },
-  );
-
-  if (proc.stdin) {
-    proc.stdin.write(inputPlan.stdin, () => {
-      proc.stdin?.end();
-    });
-  }
-
   const pipeline = new AgentStreamPipeline({
     agentType: options.agentType,
     cwd,
@@ -317,6 +304,28 @@ export const spawnAgent = async (options: SpawnAgentOptions): Promise<SpawnAgent
       w();
     }
   };
+
+  const failStream = (err: Error) => {
+    streamError = err;
+    streamEnded = true;
+    wake();
+  };
+
+  const exit = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+    (resolve, reject) => {
+      proc.on('exit', (code, signal) => resolve({ code, signal }));
+      proc.on('error', (err) => {
+        failStream(err);
+        reject(err);
+      });
+    },
+  );
+
+  if (proc.stdin) {
+    proc.stdin.write(inputPlan.stdin, () => {
+      proc.stdin?.end();
+    });
+  }
 
   // ALL pipeline work — push / flush — runs through this single chain so:
   //   1. multiple `'data'` chunks process in arrival order, even when an


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to remote Claude Code runs that remain stuck in `running` with only the placeholder assistant message after device dispatch.

#### 🔀 Description of Change

Fixes two failed-start paths in the remote heterogeneous agent CLI pipeline:

- `spawnAgent` now wakes the event iterator when the underlying child process emits `error` before stdout ends. Without this, `lh hetero exec` can wait forever in `for await (handle.events)` after a failed `claude` spawn.
- `lh hetero exec` now sends `heteroFinish(result: "error")` in server-ingest mode when `spawnAgent` rejects before streaming starts, instead of exiting and leaving the operation stuck as running.
- The wrapper also normalizes `handle.exit` rejection into a failed exit result so child spawn errors do not create unhandled rejections while the stream error path finalizes the server operation.

This does not add a diagnostic script; the previous diagnostic-only draft PR was closed as the wrong scope.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation run:

```bash
bunx vitest run src/spawn/spawnAgent.test.ts --config vitest.config.ts --silent='passed-only'
bunx vitest run src/commands/hetero.test.ts --config vitest.config.mts --silent='passed-only'
git diff --check HEAD~1..HEAD
```

Results:

- `packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts`: passed, 19 tests
- `apps/cli/src/commands/hetero.test.ts`: passed, 28 tests

#### 📸 Screenshots / Videos

No UI changes.

#### 📝 Additional Information

The intended behavior after this change is that a missing/unspawnable `claude` binary, early CLI spawn failure, or stream setup failure surfaces as a terminal failed operation instead of leaving the topic stuck with `...` and no trace snapshot.