### PR TITLE
🐛 fix(chat-input): wrap input-history ghost css in cx

### DIFF
--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -64,12 +64,12 @@ const className = cx(
 
 // Single-line dimmed preview of the highlighted history entry, shown through the
 // editor's placeholder slot while the input is empty (history popup open).
-const ghostClassName = css`
+const ghostClassName = cx(css`
   overflow: hidden;
   display: block;
   text-overflow: ellipsis;
   white-space: nowrap;
-`;
+`);
 
 type MentionOption = ISlashMenuOption | ISlashSectionOption;
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up hotfix for #16515 (LOBE-11003).

#### 🔀 Description of Change

The input-history ghost-preview style was defined with antd-style `css` and passed straight to a DOM `className`. `css` returns `SerializedStyles`, which is not assignable to `string`, breaking `type-check:vercel` (`TS2322`) and the production build.

Wrap it in `cx()` — the same pattern as the sibling `className` constant in this file — so it resolves to a string class name.

#### 🧪 How to Test

- [x] `tsgo --noEmit` passes locally
- [x] No tests needed (type-only fix)