### PR TITLE
🐛 fix(chat): gate agent mode by model tool ability

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -65,6 +65,7 @@
   "chatMode.agentCap.tools": "Tool calls",
   "chatMode.agentCap.web": "Web search",
   "chatMode.agentDesc": "Agent can use tools and environment to complete tasks automatically",
+  "chatMode.agentUnsupported": "The current model does not support tool calling",
   "chatMode.chat": "Chat",
   "chatMode.chatDesc": "No runtime environment or autonomy; uses fewer tokens",
   "chatMode.select": "Switch Mode",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -65,6 +65,7 @@
   "chatMode.agentCap.tools": "工具调用",
   "chatMode.agentCap.web": "联网搜索",
   "chatMode.agentDesc": "可以使用工具和运行环境自动完成任务",
+  "chatMode.agentUnsupported": "当前模型不支持工具调用",
   "chatMode.chat": "对话",
   "chatMode.chatDesc": "不启用运行环境和自主执行，更省 Token",
   "chatMode.select": "切换模式",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -594,6 +594,7 @@ export default {
   'chatMode.agentCap.tools': 'Tool calls',
   'chatMode.agentCap.web': 'Web search',
   'chatMode.agentDesc': 'Agent can use tools and environment to complete tasks automatically',
+  'chatMode.agentUnsupported': 'The current model does not support tool calling',
   'chatMode.chat': 'Chat',
   'chatMode.chatDesc': 'No runtime environment or autonomy; uses fewer tokens',
   'chatMode.select': 'Switch Mode',

--- a/packages/locales/src/default/models.ts
+++ b/packages/locales/src/default/models.ts
@@ -10,6 +10,8 @@ LOBE_DEFAULT_MODEL_LIST.forEach((model) => {
 
 // #region LobeHub online model descriptions
 const lobeHubOnlineModelLocales = {
+  'claude-sonnet-5.description':
+    "Claude Sonnet 5 is Anthropic's most agentic Sonnet model, built for sustained coding, tool use, and long-context workflows with Sonnet-tier speed and efficiency.",
   'gemini-3.1-flash-lite-image.description':
     "Gemini 3.1 Flash Lite Image (Nano Banana 2 Lite) is Google's fastest and most cost-efficient image generation model, built for high-volume generation and editing.",
   'grok-4.20-beta-0309-reasoning.description':
@@ -22,7 +24,7 @@ const lobeHubOnlineModelLocales = {
   'kimi-k2-thinking-turbo.description':
     'High-speed version of kimi-k2-thinking, suitable for scenarios requiring both deep reasoning and extremely fast responses.',
   'lobehub-glm-5.2-fast.description':
-    "The industry's fastest GLM-5.2. Same capabilities as GLM-5.2 with significantly faster response and reasoning speed. Limited-time launch pricing — 25% off.",
+    'Fast variant of GLM-5.2 with substantially lower latency. Same capabilities as GLM-5.2 — costs more, but responds much faster.',
   'gemini-3.1-flash-lite-image:image.description':
     "Gemini 3.1 Flash Lite Image (Nano Banana 2 Lite) is Google's fastest and most cost-efficient image generation model, built for high-volume generation and editing.",
   'seedream-5-0-260128.description':

--- a/packages/locales/src/default/models.ts
+++ b/packages/locales/src/default/models.ts
@@ -10,6 +10,8 @@ LOBE_DEFAULT_MODEL_LIST.forEach((model) => {
 
 // #region LobeHub online model descriptions
 const lobeHubOnlineModelLocales = {
+  'gemini-3.1-flash-lite-image.description':
+    "Gemini 3.1 Flash Lite Image (Nano Banana 2 Lite) is Google's fastest and most cost-efficient image generation model, built for high-volume generation and editing.",
   'grok-4.20-beta-0309-reasoning.description':
     'Intelligent, blazing-fast model that reasons before responding',
   'grok-4.20-beta-0309-non-reasoning.description': 'A non-reasoning variant for simple use cases',
@@ -21,6 +23,8 @@ const lobeHubOnlineModelLocales = {
     'High-speed version of kimi-k2-thinking, suitable for scenarios requiring both deep reasoning and extremely fast responses.',
   'lobehub-glm-5.2-fast.description':
     "The industry's fastest GLM-5.2. Same capabilities as GLM-5.2 with significantly faster response and reasoning speed. Limited-time launch pricing — 25% off.",
+  'gemini-3.1-flash-lite-image:image.description':
+    "Gemini 3.1 Flash Lite Image (Nano Banana 2 Lite) is Google's fastest and most cost-efficient image generation model, built for high-volume generation and editing.",
   'seedream-5-0-260128.description':
     'ByteDance-Seedream-5.0-lite by BytePlus features web-retrieval-augmented generation for real-time information, enhanced complex prompt interpretation, and improved reference consistency for professional visual creation.',
   'fal-ai/bytedance/seedream/v4.5.description':

--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -87,6 +87,7 @@ export {
   applyModelExtendParams,
   type ApplyModelExtendParamsContext,
   type ModelExtendParams,
+  resolveDefaultEnableAdaptiveThinkingForModel,
   resolveDefaultThinkingLevelForModel,
 } from './utils/modelExtendParams';
 export { isDeepSeekThinkingEligibleModel, isDeepSeekV4FamilyModel } from './utils/modelParse';

--- a/packages/model-runtime/src/providers/google/googleModelId.test.ts
+++ b/packages/model-runtime/src/providers/google/googleModelId.test.ts
@@ -97,12 +97,15 @@ describe('googleModelId', () => {
       'google/nano-banana-pro-preview',
       'gemini-2.5-flash-image',
       'gemini-3-pro-image-preview',
+      'gemini-3-pro-image-preview:image',
+      'gemini-3.1-flash-image-preview:image',
       'gemini-3.1-flash-lite-image',
+      'gemini-3.1-flash-lite-image:image',
     ])('detects Nano Banana model %s', (model) => {
       expect(isGoogleNanoBananaModel(model)).toBe(true);
     });
 
-    it.each(['gemini-3.5-pro', 'gemini-3.1-flash-lite', undefined])(
+    it.each(['gemini-3.5-pro', 'gemini-3.5-pro:image', 'gemini-3.1-flash-lite', undefined])(
       'does not detect non-Nano Banana model %s',
       (model) => {
         expect(isGoogleNanoBananaModel(model)).toBe(false);

--- a/packages/model-runtime/src/providers/google/googleModelId.test.ts
+++ b/packages/model-runtime/src/providers/google/googleModelId.test.ts
@@ -4,6 +4,7 @@ import {
   isGemini3OrAbove,
   isGeminiVersionAtLeast,
   isGoogleImageResponseModel,
+  isGoogleNanoBananaModel,
   isGoogleSafetyOffModel,
   normalizeGoogleModelId,
   parseGoogleModelId,
@@ -88,6 +89,25 @@ describe('googleModelId', () => {
       expect(shouldUseGoogleImageSearchTypes('gemini-3.1-flash-image-preview')).toBe(true);
       expect(shouldUseGoogleImageSearchTypes('gemini-3.5-pro-image-preview')).toBe(false);
     });
+  });
+
+  describe('Nano Banana helpers', () => {
+    it.each([
+      'nano-banana-pro-preview',
+      'google/nano-banana-pro-preview',
+      'gemini-2.5-flash-image',
+      'gemini-3-pro-image-preview',
+      'gemini-3.1-flash-lite-image',
+    ])('detects Nano Banana model %s', (model) => {
+      expect(isGoogleNanoBananaModel(model)).toBe(true);
+    });
+
+    it.each(['gemini-3.5-pro', 'gemini-3.1-flash-lite', undefined])(
+      'does not detect non-Nano Banana model %s',
+      (model) => {
+        expect(isGoogleNanoBananaModel(model)).toBe(false);
+      },
+    );
   });
 
   describe('payload guard helpers', () => {

--- a/packages/model-runtime/src/providers/google/googleModelId.ts
+++ b/packages/model-runtime/src/providers/google/googleModelId.ts
@@ -26,6 +26,17 @@ const SAFETY_OFF_MODELS = new Set(['gemini-2.0-flash-exp']);
 
 const IMAGE_RESPONSE_MODEL_ALIASES = new Set(['gemini-2.0-flash-exp', 'nano-banana-pro-preview']);
 
+const NANO_BANANA_MODEL_ALIASES = new Set([
+  'gemini-2.5-flash-image-preview',
+  'gemini-2.5-flash-image',
+  'gemini-3-pro-image',
+  'gemini-3-pro-image-preview',
+  'gemini-3.1-flash-image',
+  'gemini-3.1-flash-image-preview',
+  'gemini-3.1-flash-lite-image',
+  'nano-banana-pro-preview',
+]);
+
 // These models need the explicit image/web searchTypes payload when googleSearch is enabled.
 // Other search-capable models use the plain `{ googleSearch: {} }` shape.
 const IMAGE_SEARCH_TYPES_MODELS = new Set(['gemini-3.1-flash-image-preview']);
@@ -192,6 +203,16 @@ export const isGoogleImageResponseModel = (model: string): boolean => {
     hasModifier(parsed, 'image') &&
     (hasModifier(parsed, 'flash') || hasModifier(parsed, 'pro'))
   );
+};
+
+export const isGoogleNanoBananaModel = (model: string | undefined): boolean => {
+  if (!model) return false;
+
+  const normalizedModelId = normalizeGoogleModelId(model);
+  if (!normalizedModelId) return false;
+  if (NANO_BANANA_MODEL_ALIASES.has(normalizedModelId)) return true;
+
+  return parseGoogleModelId(model)?.family === 'nanoBanana';
 };
 
 export const shouldUseGoogleImageSearchTypes = (model: string): boolean => {

--- a/packages/model-runtime/src/providers/google/googleModelId.ts
+++ b/packages/model-runtime/src/providers/google/googleModelId.ts
@@ -26,6 +26,8 @@ const SAFETY_OFF_MODELS = new Set(['gemini-2.0-flash-exp']);
 
 const IMAGE_RESPONSE_MODEL_ALIASES = new Set(['gemini-2.0-flash-exp', 'nano-banana-pro-preview']);
 
+const LOBE_IMAGE_MODEL_ID_SUFFIX = ':image';
+
 const NANO_BANANA_MODEL_ALIASES = new Set([
   'gemini-2.5-flash-image-preview',
   'gemini-2.5-flash-image',
@@ -89,6 +91,16 @@ const extractGoogleModelId = (model: string): ExtractedGoogleModelId | undefined
 
 export const normalizeGoogleModelId = (model: string): string | undefined =>
   extractGoogleModelId(model)?.normalizedModelId;
+
+const normalizeGoogleModelIdForAlias = (model: string): string | undefined => {
+  const normalizedModelId = normalizeGoogleModelId(model);
+  if (!normalizedModelId) return;
+
+  // Lobe image model cards append `:image`, e.g. gemini-3.1-flash-lite-image:image.
+  return normalizedModelId.endsWith(LOBE_IMAGE_MODEL_ID_SUFFIX)
+    ? normalizedModelId.slice(0, -LOBE_IMAGE_MODEL_ID_SUFFIX.length)
+    : normalizedModelId;
+};
 
 const parseModifiers = (value?: string): string[] => (value ? value.split(/[-.:]/) : []);
 
@@ -208,9 +220,9 @@ export const isGoogleImageResponseModel = (model: string): boolean => {
 export const isGoogleNanoBananaModel = (model: string | undefined): boolean => {
   if (!model) return false;
 
-  const normalizedModelId = normalizeGoogleModelId(model);
-  if (!normalizedModelId) return false;
-  if (NANO_BANANA_MODEL_ALIASES.has(normalizedModelId)) return true;
+  const aliasModelId = normalizeGoogleModelIdForAlias(model);
+  if (!aliasModelId) return false;
+  if (NANO_BANANA_MODEL_ALIASES.has(aliasModelId)) return true;
 
   return parseGoogleModelId(model)?.family === 'nanoBanana';
 };

--- a/packages/model-runtime/src/utils/modelExtendParams.test.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.test.ts
@@ -1,7 +1,11 @@
 import type { LobeAgentChatConfig } from '@lobechat/types';
 import { describe, expect, it } from 'vitest';
 
-import { applyModelExtendParams, resolveDefaultThinkingLevelForModel } from './modelExtendParams';
+import {
+  applyModelExtendParams,
+  resolveDefaultEnableAdaptiveThinkingForModel,
+  resolveDefaultThinkingLevelForModel,
+} from './modelExtendParams';
 
 const chatConfig = (config: Partial<LobeAgentChatConfig> = {}): LobeAgentChatConfig =>
   ({ ...config }) as LobeAgentChatConfig;
@@ -102,6 +106,33 @@ describe('applyModelExtendParams', () => {
       budget_tokens: 2048,
       type: 'enabled',
     });
+  });
+
+  it('respects Claude Sonnet 5 adaptive thinking default when unset', () => {
+    const result = applyModelExtendParams({
+      chatConfig: chatConfig({}),
+      extendParams: ['enableAdaptiveThinking'],
+      model: 'claude-sonnet-5',
+    });
+
+    expect(result.thinking).toBeUndefined();
+  });
+
+  it('disables adaptive thinking only when explicitly turned off', () => {
+    const result = applyModelExtendParams({
+      chatConfig: chatConfig({ enableAdaptiveThinking: false }),
+      extendParams: ['enableAdaptiveThinking'],
+      model: 'claude-sonnet-5',
+    });
+
+    expect(result.thinking).toEqual({ type: 'disabled' });
+  });
+});
+
+describe('resolveDefaultEnableAdaptiveThinkingForModel', () => {
+  it('uses per-model defaults', () => {
+    expect(resolveDefaultEnableAdaptiveThinkingForModel('claude-sonnet-5')).toBe(true);
+    expect(resolveDefaultEnableAdaptiveThinkingForModel('claude-opus-4-8')).toBeUndefined();
   });
 });
 

--- a/packages/model-runtime/src/utils/modelExtendParams.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.ts
@@ -23,10 +23,7 @@ export interface ModelExtendParams {
 }
 
 type ThinkingLevelExtendParam =
-  | 'thinkingLevel'
-  | 'thinkingLevel2'
-  | 'thinkingLevel3'
-  | 'thinkingLevel4';
+  'thinkingLevel' | 'thinkingLevel2' | 'thinkingLevel3' | 'thinkingLevel4';
 
 type ThinkingLevelValue = NonNullable<LobeAgentChatConfig['thinkingLevel']>;
 
@@ -49,6 +46,10 @@ const MODEL_THINKING_LEVEL_DEFAULTS: Partial<
   'gemini-3.1-flash-lite-preview': {
     thinkingLevel: 'minimal',
   },
+} as const;
+
+const MODEL_ENABLE_ADAPTIVE_THINKING_DEFAULTS: Partial<Record<string, boolean>> = {
+  'claude-sonnet-5': true,
 } as const;
 
 /**
@@ -83,6 +84,14 @@ export const resolveDefaultThinkingLevelForModel = (model?: string): ThinkingLev
   if (!model) return DEFAULT_THINKING_LEVEL_BY_EXTEND_PARAM.thinkingLevel;
 
   return resolveThinkingLevelDefault(model, 'thinkingLevel');
+};
+
+export const resolveDefaultEnableAdaptiveThinkingForModel = (
+  model?: string,
+): boolean | undefined => {
+  if (!model) return;
+
+  return MODEL_ENABLE_ADAPTIVE_THINKING_DEFAULTS[model];
 };
 
 export interface ApplyModelExtendParamsContext {
@@ -157,14 +166,19 @@ export const applyModelExtendParams = (ctx: ApplyModelExtendParamsContext): Mode
     };
   }
 
-  // Adaptive thinking (Claude Opus/Sonnet 4.6)
+  // Adaptive thinking
   if (modelExtendParams.includes('enableAdaptiveThinking')) {
     if (chatConfig.enableAdaptiveThinking) {
       extendParams.thinking = {
         type: 'adaptive',
       };
-    } else if (!modelExtendParams.includes('enableReasoning')) {
-      // Only disable when the model has no enableReasoning fallback
+    } else if (
+      Object.hasOwn(chatConfig, 'enableAdaptiveThinking') &&
+      chatConfig.enableAdaptiveThinking === false &&
+      !modelExtendParams.includes('enableReasoning')
+    ) {
+      // Claude Sonnet 5 defaults adaptive thinking on; fresh configs used to
+      // serialize as `{ thinking: { type: 'disabled' } }` and override that.
       extendParams.thinking = {
         type: 'disabled',
       };

--- a/src/features/ChatInput/ActionBar/AgentMode/index.tsx
+++ b/src/features/ChatInput/ActionBar/AgentMode/index.tsx
@@ -14,10 +14,9 @@ import { useTranslation } from 'react-i18next';
 
 import { useBusinessAgentModeSync } from '@/business/client/hooks/useBusinessAgentMode';
 import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';
+import { useEffectiveAgentMode } from '@/features/ChatInput/hooks/useEffectiveAgentMode';
 import { useToggleAgentMode } from '@/features/ChatInput/hooks/useToggleAgentMode';
 import { usePermission } from '@/hooks/usePermission';
-import { useAgentStore } from '@/store/agent';
-import { agentByIdSelectors } from '@/store/agent/selectors';
 
 const styles = createStaticStyles(({ css }) => ({
   activeOption: css`
@@ -89,6 +88,14 @@ const styles = createStaticStyles(({ css }) => ({
       background: ${cssVar.colorFillSecondary};
     }
   `,
+  optionDisabled: css`
+    cursor: not-allowed;
+    opacity: 0.55;
+
+    &:hover {
+      background: transparent;
+    }
+  `,
   optionDesc: css`
     font-size: 12px;
     line-height: 1.4;
@@ -132,19 +139,19 @@ const AgentMode = memo(() => {
   const [open, setOpen] = useState(false);
   const { allowed: canCreateContent, reason } = usePermission('create_content');
 
-  const enableAgentMode = useAgentStore(agentByIdSelectors.getAgentEnableModeById(agentId));
-
-  const currentMode = enableAgentMode ? 'agent' : 'chat';
-  const CurrentIcon = enableAgentMode ? InfinityIcon : MessageCircleIcon;
+  const { canSelectAgentMode, currentMode, isAgentModeUnavailable } =
+    useEffectiveAgentMode(agentId);
+  const CurrentIcon = currentMode === 'agent' ? InfinityIcon : MessageCircleIcon;
 
   const handleSelect = useCallback(
     async (mode: 'chat' | 'agent') => {
       if (!canCreateContent) return;
+      if (mode === 'agent' && !canSelectAgentMode) return;
 
       setOpen(false);
       await toggleAgentMode(mode === 'agent');
     },
-    [canCreateContent, toggleAgentMode],
+    [canCreateContent, canSelectAgentMode, toggleAgentMode],
   );
 
   const handleOpenChange = useCallback(
@@ -169,14 +176,24 @@ const AgentMode = memo(() => {
   );
 
   const chatTooltip = t('chatMode.chatDesc');
+  const buttonTooltip = isAgentModeUnavailable
+    ? t('chatMode.agentUnsupported')
+    : currentMode === 'agent'
+      ? agentTooltip
+      : chatTooltip;
+  const agentDesc = canSelectAgentMode ? t('chatMode.agentDesc') : t('chatMode.agentUnsupported');
 
   const popoverContent = (
     <Flexbox gap={4} style={{ maxWidth: 320, minWidth: 280 }}>
       <Flexbox
         horizontal
         align="center"
-        className={cx(styles.option, currentMode === 'agent' && styles.activeOption)}
         gap={12}
+        className={cx(
+          styles.option,
+          currentMode === 'agent' && styles.activeOption,
+          !canSelectAgentMode && styles.optionDisabled,
+        )}
         onClick={() => handleSelect('agent')}
       >
         <Flexbox
@@ -190,7 +207,7 @@ const AgentMode = memo(() => {
         </Flexbox>
         <Flexbox flex={1}>
           <div className={styles.optionTitle}>{t('chatMode.agent')}</div>
-          <div className={styles.optionDesc}>{t('chatMode.agentDesc')}</div>
+          <div className={styles.optionDesc}>{agentDesc}</div>
         </Flexbox>
       </Flexbox>
 
@@ -251,13 +268,7 @@ const AgentMode = memo(() => {
       }}
       onOpenChange={handleOpenChange}
     >
-      <div>
-        {open ? (
-          button
-        ) : (
-          <Tooltip title={enableAgentMode ? agentTooltip : chatTooltip}>{button}</Tooltip>
-        )}
-      </div>
+      <div>{open ? button : <Tooltip title={buttonTooltip}>{button}</Tooltip>}</div>
     </Popover>
   );
 });

--- a/src/features/ChatInput/ControlBar/ModeSelector.tsx
+++ b/src/features/ChatInput/ControlBar/ModeSelector.tsx
@@ -14,10 +14,9 @@ import { useTranslation } from 'react-i18next';
 
 import { useBusinessAgentModeSync } from '@/business/client/hooks/useBusinessAgentMode';
 import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';
+import { useEffectiveAgentMode } from '@/features/ChatInput/hooks/useEffectiveAgentMode';
 import { useToggleAgentMode } from '@/features/ChatInput/hooks/useToggleAgentMode';
 import { usePermission } from '@/hooks/usePermission';
-import { useAgentStore } from '@/store/agent';
-import { agentByIdSelectors } from '@/store/agent/selectors';
 
 const styles = createStaticStyles(({ css }) => ({
   activeOption: css`
@@ -89,6 +88,14 @@ const styles = createStaticStyles(({ css }) => ({
       background: ${cssVar.colorFillSecondary};
     }
   `,
+  optionDisabled: css`
+    cursor: not-allowed;
+    opacity: 0.55;
+
+    &:hover {
+      background: transparent;
+    }
+  `,
   optionDesc: css`
     font-size: 12px;
     line-height: 1.4;
@@ -132,19 +139,19 @@ const ModeSelector = memo(() => {
   const [open, setOpen] = useState(false);
   const { allowed: canCreateContent, reason } = usePermission('create_content');
 
-  const enableAgentMode = useAgentStore(agentByIdSelectors.getAgentEnableModeById(agentId));
-
-  const currentMode = enableAgentMode ? 'agent' : 'chat';
-  const CurrentIcon = enableAgentMode ? InfinityIcon : MessageCircleIcon;
+  const { canSelectAgentMode, currentMode, isAgentModeUnavailable } =
+    useEffectiveAgentMode(agentId);
+  const CurrentIcon = currentMode === 'agent' ? InfinityIcon : MessageCircleIcon;
 
   const handleSelect = useCallback(
     async (mode: 'chat' | 'agent') => {
       if (!canCreateContent) return;
+      if (mode === 'agent' && !canSelectAgentMode) return;
 
       setOpen(false);
       await toggleAgentMode(mode === 'agent');
     },
-    [canCreateContent, toggleAgentMode],
+    [canCreateContent, canSelectAgentMode, toggleAgentMode],
   );
 
   const handleOpenChange = useCallback(
@@ -169,14 +176,24 @@ const ModeSelector = memo(() => {
   );
 
   const chatTooltip = t('chatMode.chatDesc');
+  const buttonTooltip = isAgentModeUnavailable
+    ? t('chatMode.agentUnsupported')
+    : currentMode === 'agent'
+      ? agentTooltip
+      : chatTooltip;
+  const agentDesc = canSelectAgentMode ? t('chatMode.agentDesc') : t('chatMode.agentUnsupported');
 
   const popoverContent = (
     <Flexbox gap={4} style={{ maxWidth: 320, minWidth: 280 }}>
       <Flexbox
         horizontal
         align="center"
-        className={cx(styles.option, currentMode === 'agent' && styles.activeOption)}
         gap={12}
+        className={cx(
+          styles.option,
+          currentMode === 'agent' && styles.activeOption,
+          !canSelectAgentMode && styles.optionDisabled,
+        )}
         onClick={() => handleSelect('agent')}
       >
         <Flexbox
@@ -190,7 +207,7 @@ const ModeSelector = memo(() => {
         </Flexbox>
         <Flexbox flex={1}>
           <div className={styles.optionTitle}>{t('chatMode.agent')}</div>
-          <div className={styles.optionDesc}>{t('chatMode.agentDesc')}</div>
+          <div className={styles.optionDesc}>{agentDesc}</div>
         </Flexbox>
       </Flexbox>
 
@@ -251,13 +268,7 @@ const ModeSelector = memo(() => {
       }}
       onOpenChange={handleOpenChange}
     >
-      <div>
-        {open ? (
-          button
-        ) : (
-          <Tooltip title={enableAgentMode ? agentTooltip : chatTooltip}>{button}</Tooltip>
-        )}
-      </div>
+      <div>{open ? button : <Tooltip title={buttonTooltip}>{button}</Tooltip>}</div>
     </Popover>
   );
 });

--- a/src/features/ChatInput/ControlBar/index.tsx
+++ b/src/features/ChatInput/ControlBar/index.tsx
@@ -7,6 +7,7 @@ import { agentByIdSelectors } from '@/store/agent/selectors';
 
 import ContextWindow from '../ActionBar/Token';
 import { useAgentId } from '../hooks/useAgentId';
+import { useEffectiveAgentMode } from '../hooks/useEffectiveAgentMode';
 import { useChatInputStore } from '../store';
 import ApprovalMode from './ApprovalMode';
 import ModeSelector from './ModeSelector';
@@ -44,10 +45,8 @@ const ControlBar = memo(() => {
     s.rightActions.flat().includes('contextWindow'),
   );
 
-  const [isLoading, enableAgentMode] = useAgentStore((s) => [
-    agentByIdSelectors.isAgentConfigLoadingById(agentId)(s),
-    agentByIdSelectors.getAgentEnableModeById(agentId)(s),
-  ]);
+  const isLoading = useAgentStore((s) => agentByIdSelectors.isAgentConfigLoadingById(agentId)(s));
+  const { isAgentRuntimeMode } = useEffectiveAgentMode(agentId);
 
   // Skeleton placeholder to prevent layout jump during loading
   if (!agentId || isLoading) {
@@ -64,11 +63,11 @@ const ControlBar = memo(() => {
       {/* Left: chat-mode switcher + (agent-only) execution device + working directory */}
       <Flexbox horizontal align={'center'} className={styles.leftGroup} gap={4}>
         <ModeSelector />
-        {enableAgentMode && <WorkspaceControls agentId={agentId} />}
+        {isAgentRuntimeMode && <WorkspaceControls agentId={agentId} />}
       </Flexbox>
 
       <Flexbox horizontal align={'center'} className={styles.rightGroup} gap={4}>
-        {enableAgentMode && <ApprovalMode />}
+        {isAgentRuntimeMode && <ApprovalMode />}
         {showContextWindow && <ContextWindow />}
       </Flexbox>
     </Flexbox>

--- a/src/features/ChatInput/CurrentModelNotice/useCurrentModelNotice.test.tsx
+++ b/src/features/ChatInput/CurrentModelNotice/useCurrentModelNotice.test.tsx
@@ -18,7 +18,6 @@ interface TestProviderWithModels {
 const testState = vi.hoisted(() => ({
   agent: {
     agencyConfig: undefined as { heterogeneousProvider?: { type: string } } | undefined,
-    enableAgentMode: true,
     model: 'gpt-4o',
     provider: 'openai',
   },
@@ -45,7 +44,6 @@ vi.mock('@/store/agent', () => ({
 
 vi.mock('@/store/agent/selectors', () => ({
   agentByIdSelectors: {
-    getAgentEnableModeById: () => (s: typeof testState.agent) => s.enableAgentMode,
     getAgentModelById: () => (s: typeof testState.agent) => s.model,
     getAgentModelProviderById: () => (s: typeof testState.agent) => s.provider,
     isAgentHeterogeneousById: () => (s: typeof testState.agent) =>
@@ -64,7 +62,6 @@ vi.mock('@/store/aiInfra', () => ({
 describe('useCurrentModelNotice', () => {
   beforeEach(() => {
     testState.agent.agencyConfig = undefined;
-    testState.agent.enableAgentMode = true;
     testState.agent.model = 'gpt-4o';
     testState.agent.provider = 'openai';
     testState.aiInfra.enabledChatModelList = [];
@@ -78,7 +75,6 @@ describe('useCurrentModelNotice', () => {
   });
 
   it('returns unavailable model copy when the ready model config no longer contains the selected model', () => {
-    testState.agent.enableAgentMode = false;
     testState.aiInfra.isInitAiProviderRuntimeState = true;
 
     const { result } = renderHook(() => useCurrentModelNotice());
@@ -86,7 +82,7 @@ describe('useCurrentModelNotice', () => {
     expect(result.current).toBe('input.modelUnavailable');
   });
 
-  it('returns unsupported tool-use copy only when agent mode is enabled and the selected model exists but lacks tool calls', () => {
+  it('does not return unsupported tool-use copy when the selected model exists but lacks tool calls', () => {
     testState.aiInfra.isInitAiProviderRuntimeState = true;
     testState.aiInfra.enabledChatModelList = [
       { children: [{ abilities: { functionCall: false }, id: 'gpt-4o' }], id: 'openai' },
@@ -94,7 +90,7 @@ describe('useCurrentModelNotice', () => {
 
     const { result } = renderHook(() => useCurrentModelNotice());
 
-    expect(result.current).toBe('input.agentModeUnsupportedModel');
+    expect(result.current).toBeUndefined();
   });
 
   it('returns unavailable model copy when the selected model is enabled globally but absent from the chat selector list', () => {
@@ -106,18 +102,6 @@ describe('useCurrentModelNotice', () => {
     const { result } = renderHook(() => useCurrentModelNotice());
 
     expect(result.current).toBe('input.modelUnavailable');
-  });
-
-  it('does not return unsupported tool-use copy when agent mode is disabled', () => {
-    testState.agent.enableAgentMode = false;
-    testState.aiInfra.isInitAiProviderRuntimeState = true;
-    testState.aiInfra.enabledChatModelList = [
-      { children: [{ abilities: { functionCall: false }, id: 'gpt-4o' }], id: 'openai' },
-    ];
-
-    const { result } = renderHook(() => useCurrentModelNotice());
-
-    expect(result.current).toBeUndefined();
   });
 
   it('does not return a notice when the ready model supports tool use', () => {

--- a/src/features/ChatInput/CurrentModelNotice/useCurrentModelNotice.ts
+++ b/src/features/ChatInput/CurrentModelNotice/useCurrentModelNotice.ts
@@ -5,15 +5,8 @@ import { agentByIdSelectors } from '@/store/agent/selectors';
 import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { type EnabledProviderWithModels } from '@/types/aiProvider';
 
-interface CurrentModelNoticeModel {
-  abilities?: {
-    functionCall?: boolean;
-  };
-}
-
 interface ResolveCurrentModelNoticeKeyParams {
-  currentChatModel?: CurrentModelNoticeModel;
-  enableAgentMode: boolean;
+  currentChatModel?: unknown;
   isHeterogeneousAgent: boolean;
   isModelConfigReady: boolean;
 }
@@ -30,7 +23,6 @@ const findEnabledChatModel = (
 
 export const resolveCurrentModelNoticeKey = ({
   currentChatModel,
-  enableAgentMode,
   isHeterogeneousAgent,
   isModelConfigReady,
 }: ResolveCurrentModelNoticeKeyParams) => {
@@ -39,16 +31,12 @@ export const resolveCurrentModelNoticeKey = ({
   // Example: an agent still references `gpt-4-32k`, or a model reclassified to
   // image/video; once absent from the chat selector, it should read as unavailable.
   if (!currentChatModel) return 'input.modelUnavailable';
-
-  if (enableAgentMode && !currentChatModel.abilities?.functionCall)
-    return 'input.agentModeUnsupportedModel';
 };
 
 export const useCurrentModelNotice = () => {
   const agentId = useAgentId();
 
-  const [enableAgentMode, isHeterogeneousAgent, model, provider] = useAgentStore((s) => [
-    agentByIdSelectors.getAgentEnableModeById(agentId)(s),
+  const [isHeterogeneousAgent, model, provider] = useAgentStore((s) => [
     agentByIdSelectors.isAgentHeterogeneousById(agentId)(s),
     agentByIdSelectors.getAgentModelById(agentId)(s),
     agentByIdSelectors.getAgentModelProviderById(agentId)(s),
@@ -62,7 +50,6 @@ export const useCurrentModelNotice = () => {
 
   return resolveCurrentModelNoticeKey({
     currentChatModel,
-    enableAgentMode,
     isHeterogeneousAgent,
     isModelConfigReady,
   });

--- a/src/features/ChatInput/InputEditor/Placeholder.tsx
+++ b/src/features/ChatInput/InputEditor/Placeholder.tsx
@@ -4,10 +4,10 @@ import { memo } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';
-import { useAgentStore } from '@/store/agent';
-import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useUserStore } from '@/store/user';
 import { preferenceSelectors } from '@/store/user/selectors';
+
+import { useEffectiveAgentMode } from '../hooks/useEffectiveAgentMode';
 
 export type PlaceholderVariant = 'default' | 'followUp';
 
@@ -26,7 +26,7 @@ const Placeholder = memo<PlaceholderProps>(
     const { t } = useTranslation('chat');
 
     const agentId = useAgentId();
-    const enableAgentMode = useAgentStore(agentByIdSelectors.getAgentEnableModeById(agentId));
+    const { isAgentRuntimeMode } = useEffectiveAgentMode(agentId);
 
     const isHeterogeneous = !!heterogeneousName;
 
@@ -40,7 +40,7 @@ const Placeholder = memo<PlaceholderProps>(
 
     const i18nKey = isHeterogeneous
       ? 'sendPlaceholderHeterogeneous'
-      : enableAgentMode
+      : isAgentRuntimeMode
         ? showAgentAssignmentHint
           ? 'sendPlaceholderWithAgentAssignment'
           : 'sendPlaceholder'

--- a/src/features/ChatInput/hooks/useEffectiveAgentMode.test.ts
+++ b/src/features/ChatInput/hooks/useEffectiveAgentMode.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveEffectiveAgentMode } from './useEffectiveAgentMode';
+
+describe('resolveEffectiveAgentMode', () => {
+  it('uses agent mode when the stored mode is enabled and the model supports tool use', () => {
+    expect(resolveEffectiveAgentMode({ enableAgentMode: true, supportToolUse: true })).toEqual({
+      canSelectAgentMode: true,
+      currentMode: 'agent',
+      isAgentModeUnavailable: false,
+      supportToolUse: true,
+    });
+  });
+
+  it('falls back to chat mode without changing the stored mode when the model lacks tool use', () => {
+    expect(resolveEffectiveAgentMode({ enableAgentMode: true, supportToolUse: false })).toEqual({
+      canSelectAgentMode: false,
+      currentMode: 'chat',
+      isAgentModeUnavailable: true,
+      supportToolUse: false,
+    });
+  });
+
+  it('keeps explicit chat mode even when the model supports tool use', () => {
+    expect(resolveEffectiveAgentMode({ enableAgentMode: false, supportToolUse: true })).toEqual({
+      canSelectAgentMode: true,
+      currentMode: 'chat',
+      isAgentModeUnavailable: false,
+      supportToolUse: true,
+    });
+  });
+});

--- a/src/features/ChatInput/hooks/useEffectiveAgentMode.test.ts
+++ b/src/features/ChatInput/hooks/useEffectiveAgentMode.test.ts
@@ -8,6 +8,7 @@ describe('resolveEffectiveAgentMode', () => {
       canSelectAgentMode: true,
       currentMode: 'agent',
       isAgentModeUnavailable: false,
+      isAgentRuntimeMode: true,
       supportToolUse: true,
     });
   });
@@ -17,6 +18,7 @@ describe('resolveEffectiveAgentMode', () => {
       canSelectAgentMode: false,
       currentMode: 'chat',
       isAgentModeUnavailable: true,
+      isAgentRuntimeMode: false,
       supportToolUse: false,
     });
   });
@@ -26,6 +28,7 @@ describe('resolveEffectiveAgentMode', () => {
       canSelectAgentMode: true,
       currentMode: 'chat',
       isAgentModeUnavailable: false,
+      isAgentRuntimeMode: false,
       supportToolUse: true,
     });
   });

--- a/src/features/ChatInput/hooks/useEffectiveAgentMode.ts
+++ b/src/features/ChatInput/hooks/useEffectiveAgentMode.ts
@@ -14,11 +14,14 @@ export const resolveEffectiveAgentMode = ({
   supportToolUse,
 }: ResolveEffectiveAgentModeParams) => {
   const currentMode: ChatInputMode = enableAgentMode && supportToolUse ? 'agent' : 'chat';
+  // Example: stored Agent mode + a model without tool calling should render chat-only runtime UI.
+  const isAgentRuntimeMode = currentMode === 'agent';
 
   return {
     canSelectAgentMode: supportToolUse,
     currentMode,
     isAgentModeUnavailable: enableAgentMode && !supportToolUse,
+    isAgentRuntimeMode,
     supportToolUse,
   };
 };

--- a/src/features/ChatInput/hooks/useEffectiveAgentMode.ts
+++ b/src/features/ChatInput/hooks/useEffectiveAgentMode.ts
@@ -1,0 +1,35 @@
+import { useModelSupportToolUse } from '@/hooks/useModelSupportToolUse';
+import { useAgentStore } from '@/store/agent';
+import { agentByIdSelectors } from '@/store/agent/selectors';
+
+export type ChatInputMode = 'agent' | 'chat';
+
+interface ResolveEffectiveAgentModeParams {
+  enableAgentMode: boolean;
+  supportToolUse: boolean;
+}
+
+export const resolveEffectiveAgentMode = ({
+  enableAgentMode,
+  supportToolUse,
+}: ResolveEffectiveAgentModeParams) => {
+  const currentMode: ChatInputMode = enableAgentMode && supportToolUse ? 'agent' : 'chat';
+
+  return {
+    canSelectAgentMode: supportToolUse,
+    currentMode,
+    isAgentModeUnavailable: enableAgentMode && !supportToolUse,
+    supportToolUse,
+  };
+};
+
+export const useEffectiveAgentMode = (agentId: string) => {
+  const [enableAgentMode, model, provider] = useAgentStore((s) => [
+    agentByIdSelectors.getAgentEnableModeById(agentId)(s),
+    agentByIdSelectors.getAgentModelById(agentId)(s),
+    agentByIdSelectors.getAgentModelProviderById(agentId)(s),
+  ]);
+  const supportToolUse = useModelSupportToolUse(model, provider);
+
+  return resolveEffectiveAgentMode({ enableAgentMode, supportToolUse });
+};

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
@@ -8,7 +8,10 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';
 import { useUpdateAgentConfig } from '@/features/ChatInput/hooks/useUpdateAgentConfig';
-import { resolveDefaultThinkingLevelForModel } from '@/services/chat/mecha/modelParamsResolver';
+import {
+  resolveDefaultEnableAdaptiveThinkingForModel,
+  resolveDefaultThinkingLevelForModel,
+} from '@/services/chat/mecha/modelParamsResolver';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
@@ -65,6 +68,12 @@ const resolveEnableReasoningInitialValue = (config: LobeAgentChatConfig) => {
   return undefined;
 };
 
+const resolveEnableAdaptiveThinkingInitialValue = (config: LobeAgentChatConfig, model?: string) => {
+  if (Object.hasOwn(config, 'enableAdaptiveThinking')) return config.enableAdaptiveThinking;
+
+  return resolveDefaultEnableAdaptiveThinkingForModel(model);
+};
+
 const ControlsForm = memo<ControlsFormProps>(
   ({ disabled, model: modelProp, onUpdatingChange, provider: providerProp }) => {
     const { t } = useTranslation('chat');
@@ -86,12 +95,17 @@ const ControlsForm = memo<ControlsFormProps>(
     const modelExtendParams = useAiInfraStore(aiModelSelectors.modelExtendParams(model, provider));
     const initialValues = useMemo(() => {
       const enableReasoningInitialValue = resolveEnableReasoningInitialValue(config);
+      const enableAdaptiveThinkingInitialValue = resolveEnableAdaptiveThinkingInitialValue(
+        config,
+        model,
+      );
 
       return {
         ...config,
+        enableAdaptiveThinking: enableAdaptiveThinkingInitialValue,
         enableReasoning: enableReasoningInitialValue,
       };
-    }, [config]);
+    }, [config, model]);
 
     useEffect(() => {
       form.setFieldsValue(initialValues);

--- a/src/features/ModelSwitchPanel/components/ControlsForm/__tests__/ControlsForm.test.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/__tests__/ControlsForm.test.tsx
@@ -118,4 +118,32 @@ describe('ControlsForm', () => {
     });
     expect(testState.updateAgentChatConfig).not.toHaveBeenCalled();
   });
+
+  it('should show model adaptive thinking default without persisting it', () => {
+    testState.aiState.extendParams = ['enableAdaptiveThinking'];
+
+    render(<ControlsForm model="claude-sonnet-5" provider="lobehub" />);
+
+    expect(testState.setFieldsValue).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        enableAdaptiveThinking: true,
+      }),
+    );
+    expect(testState.updateAgentChatConfig).not.toHaveBeenCalled();
+  });
+
+  it('should preserve explicit adaptive thinking override', () => {
+    testState.agentState.config = {
+      enableAdaptiveThinking: false,
+    };
+    testState.aiState.extendParams = ['enableAdaptiveThinking'];
+
+    render(<ControlsForm model="claude-sonnet-5" provider="lobehub" />);
+
+    expect(testState.setFieldsValue).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        enableAdaptiveThinking: false,
+      }),
+    );
+  });
 });

--- a/src/helpers/toolEngineering/index.test.ts
+++ b/src/helpers/toolEngineering/index.test.ts
@@ -113,8 +113,10 @@ vi.mock('@/store/tool/selectors', () => ({
   },
 }));
 
+let mockIsCanUseFC = true;
+
 vi.mock('../isCanUseFC', () => ({
-  isCanUseFC: () => true,
+  isCanUseFC: () => mockIsCanUseFC,
 }));
 
 let mockCurrentAgentPlugins: string[] = [];
@@ -162,6 +164,7 @@ describe('toolEngineering', () => {
     mockInstalledPluginManifestList = () => [];
     mockUseApplicationBuiltinSearchTool = true;
     mockCurrentAgentPlugins = [];
+    mockIsCanUseFC = true;
   });
 
   describe('createToolsEngine', () => {
@@ -281,6 +284,31 @@ describe('toolEngineering', () => {
       });
 
       expect(result.enabledToolIds).toContain('lobe-agent');
+    });
+
+    it('should use chat-mode defaults when the model does not support function calling', () => {
+      mockIsCanUseFC = false;
+
+      const toolsEngine = createAgentToolsEngine({
+        model: 'gemini-3.1-flash-lite-image',
+        provider: 'lobehub',
+      });
+
+      const result = toolsEngine.generateToolsDetailed({
+        model: 'gemini-3.1-flash-lite-image',
+        provider: 'lobehub',
+        toolIds: [],
+      });
+
+      expect(result.enabledToolIds).toEqual([]);
+      expect(result.filteredTools).not.toContainEqual({
+        id: 'lobe-agent',
+        reason: 'incompatible',
+      });
+      expect(result.filteredTools).toContainEqual({
+        id: 'lobe-web-browsing',
+        reason: 'incompatible',
+      });
     });
   });
 

--- a/src/helpers/toolEngineering/index.ts
+++ b/src/helpers/toolEngineering/index.ts
@@ -187,7 +187,8 @@ export const createAgentToolsEngine = (
   const agentState = getAgentStoreState();
   const userPlugins = agentSelectors.currentAgentPlugins(agentState);
   const isChatMode =
-    agentChatConfigSelectors.currentChatConfig(agentState).enableAgentMode === false;
+    agentChatConfigSelectors.currentChatConfig(agentState).enableAgentMode === false ||
+    !isCanUseFC(workingModel.model, workingModel.provider);
 
   // Each entry below still respects its own runtime gate; in chat mode this
   // is the entire whitelist. `allowExplicitActivation` and user plugins /

--- a/src/services/chat/chat.test.ts
+++ b/src/services/chat/chat.test.ts
@@ -9,6 +9,7 @@ import { type EnabledAiModel, ModelProvider } from 'model-bank';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DEFAULT_AGENT_CONFIG } from '@/const/settings';
+import { isCanUseFC } from '@/helpers/isCanUseFC';
 import * as toolEngineeringModule from '@/helpers/toolEngineering';
 import { agentDocumentService } from '@/services/agentDocument';
 import { useAgentStore } from '@/store/agent';
@@ -197,6 +198,34 @@ describe('ChatService', () => {
           messages: expect.anything(),
         }),
         expect.anything(),
+      );
+    });
+
+    it('should pass chat mode to context engineering when the selected model lacks function calling', async () => {
+      const contextEngineeringSpy = vi
+        .spyOn(mechaModule, 'contextEngineering')
+        .mockResolvedValue([]);
+      vi.mocked(isCanUseFC).mockReturnValue(false);
+      const messages = [{ content: 'Hello', role: 'user' }] as UIChatMessage[];
+
+      await chatService.createAssistantMessage({
+        model: 'gemini-3.1-flash-lite-image',
+        messages,
+        provider: ModelProvider.LobeHub,
+        resolvedAgentConfig: createMockResolvedConfig({
+          agentConfig: {
+            model: 'gemini-3.1-flash-lite-image',
+            provider: ModelProvider.LobeHub,
+          },
+          chatConfig: { enableAgentMode: true },
+        }),
+      });
+
+      expect(isCanUseFC).toHaveBeenCalledWith('gemini-3.1-flash-lite-image', ModelProvider.LobeHub);
+      expect(contextEngineeringSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enableAgentMode: false,
+        }),
       );
     });
 

--- a/src/services/chat/index.ts
+++ b/src/services/chat/index.ts
@@ -23,6 +23,7 @@ import { ModelProvider } from 'model-bank';
 
 import { DEFAULT_AGENT_CONFIG } from '@/const/settings';
 import { getSearchConfig } from '@/helpers/getSearchConfig';
+import { isCanUseFC } from '@/helpers/isCanUseFC';
 import { getAgentStoreState } from '@/store/agent';
 import {
   agentByIdSelectors,
@@ -173,6 +174,8 @@ class ChatService {
     const userMemorySettings = settingsSelectors.currentMemorySettings(getUserStoreState());
     const effectiveMemoryEffort =
       chatConfig.memory?.effort ?? userMemorySettings.effort ?? 'medium';
+    const enableAgentMode =
+      chatConfig.enableAgentMode !== false && isCanUseFC(payload.model, payload.provider!);
 
     // =================== 1.2 build agent builder context =================== //
 
@@ -282,6 +285,7 @@ class ChatService {
       agentBuilderContext,
       agentDocuments,
       agentId: targetAgentId,
+      enableAgentMode,
       // Use raw chatConfig values, not selectors with business logic that may force false
       enableHistoryCount: chatConfig.enableHistoryCount,
       enableUserMemories,

--- a/src/services/chat/mecha/contextEngineering.test.ts
+++ b/src/services/chat/mecha/contextEngineering.test.ts
@@ -146,6 +146,36 @@ describe('contextEngineering', () => {
     });
   });
 
+  it('should suppress agent documents when runtime agent mode is disabled', async () => {
+    const output = await contextEngineering({
+      agentDocuments: [
+        {
+          content: 'Project setup steps',
+          filename: 'setup.md',
+          id: 'doc-1',
+          policyLoad: 'always',
+          title: 'Setup',
+        },
+      ],
+      agentId: 'agent-1',
+      enableAgentMode: false,
+      messages: [{ content: 'Summarize the setup', role: 'user' }] as UIChatMessage[],
+      model: 'gpt-4',
+      provider: 'openai',
+    });
+
+    // Example: image-only models force chat mode for this request, so agent
+    // documents must not leak into the prompt while the stored config stays true.
+    const documentsMessage = output.find(
+      (message) =>
+        message.role === 'user' &&
+        typeof message.content === 'string' &&
+        message.content.includes('Project setup steps'),
+    );
+
+    expect(documentsMessage).toBeUndefined();
+  });
+
   it('should use cached available agents without querying during context engineering', async () => {
     useAgentStore.setState({
       availableAgents: [

--- a/src/services/chat/mecha/contextEngineering.test.ts
+++ b/src/services/chat/mecha/contextEngineering.test.ts
@@ -76,6 +76,7 @@ vi.mock('@lobechat/const', async (importOriginal) => {
 beforeEach(() => {
   vi.mocked(agentService.queryAgents).mockResolvedValue([]);
   useAgentStore.setState({
+    activeAgentId: undefined,
     agentMap: {},
     availableAgents: undefined,
   });
@@ -166,6 +167,43 @@ describe('contextEngineering', () => {
 
     // Example: image-only models force chat mode for this request, so agent
     // documents must not leak into the prompt while the stored config stays true.
+    const documentsMessage = output.find(
+      (message) =>
+        message.role === 'user' &&
+        typeof message.content === 'string' &&
+        message.content.includes('Project setup steps'),
+    );
+
+    expect(documentsMessage).toBeUndefined();
+  });
+
+  it('should fall back to stored chat mode when runtime agent mode is omitted', async () => {
+    useAgentStore.setState({
+      activeAgentId: 'agent-1',
+      agentMap: {
+        'agent-1': {
+          chatConfig: { enableAgentMode: false },
+        },
+      },
+    });
+
+    const output = await contextEngineering({
+      agentDocuments: [
+        {
+          content: 'Project setup steps',
+          filename: 'setup.md',
+          id: 'doc-1',
+          policyLoad: 'always',
+          title: 'Setup',
+        },
+      ],
+      messages: [{ content: 'Summarize the setup', role: 'user' }] as UIChatMessage[],
+      model: 'gpt-4',
+      provider: 'openai',
+    });
+
+    // Example: preset-task calls do not pass runtime mode, but explicit stored
+    // Chat mode should still suppress agent-document context.
     const documentsMessage = output.find(
       (message) =>
         message.role === 'user' &&

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -205,6 +205,10 @@ export const contextEngineering = async ({
 
   // Get agent store state (used for both group agent builder context and file/knowledge base)
   const agentStoreState = getAgentStoreState();
+  // Example: preset-task calls omit `enableAgentMode`; preserve explicit chat mode
+  // from stored config instead of letting MessagesEngine treat `undefined` as agent mode.
+  const effectiveEnableAgentMode =
+    enableAgentMode ?? agentChatConfigSelectors.currentChatConfig(agentStoreState).enableAgentMode;
 
   // Build group agent builder context if Group Agent Builder is enabled
   // Note: Uses activeGroupId from chatStore to get the group being edited
@@ -714,7 +718,7 @@ export const contextEngineering = async ({
     // MessagesEngine force-disables skills / agent-document injectors when this
     // is `false` (chat mode). ChatService resolves it from stored user intent
     // plus the selected model's function-call ability.
-    enableAgentMode,
+    enableAgentMode: effectiveEnableAgentMode,
 
     // Skills configuration (resolved above)
     skillsConfig: {

--- a/src/services/chat/mecha/contextEngineering.ts
+++ b/src/services/chat/mecha/contextEngineering.ts
@@ -86,6 +86,11 @@ interface ContextEngineeringContext {
   agentDocuments?: AgentContextDocument[];
   /** The agent ID that will respond (for group context injection) */
   agentId?: string;
+  /**
+   * Runtime-resolved agent mode. Callers may force chat mode for models without
+   * function calling while keeping the stored chatConfig unchanged.
+   */
+  enableAgentMode?: boolean;
   enableHistoryCount?: boolean;
   enableUserMemories?: boolean;
   /** Group ID for multi-agent scenarios */
@@ -135,6 +140,7 @@ export const contextEngineering = async ({
   agentBuilderContext,
   agentDocuments,
   agentId,
+  enableAgentMode,
   groupId,
   initialContext,
   plugins,
@@ -387,14 +393,12 @@ export const contextEngineering = async ({
     try {
       const credsResult = await lambdaClient.market.creds.list.query();
       const userCreds = (credsResult as any)?.data ?? [];
-      credsList = userCreds.map(
-        (cred: any): CredSummary => ({
-          description: cred.description,
-          key: cred.key,
-          name: cred.name,
-          type: cred.type,
-        }),
-      );
+      credsList = userCreds.map((cred: any): CredSummary => ({
+        description: cred.description,
+        key: cred.key,
+        name: cred.name,
+        type: cred.type,
+      }));
       log('Creds context resolved: count=%d', credsList?.length ?? 0);
     } catch (error) {
       // Silently fail - creds context is optional
@@ -707,9 +711,10 @@ export const contextEngineering = async ({
     selectedSkills: initialContext?.selectedSkills,
     selectedTools: initialContext?.selectedTools,
 
-    // Pass enableAgentMode through; MessagesEngine force-disables skills /
-    // agent-document injectors when this is `false` (chat mode).
-    enableAgentMode: agentChatConfigSelectors.currentChatConfig(agentStoreState).enableAgentMode,
+    // MessagesEngine force-disables skills / agent-document injectors when this
+    // is `false` (chat mode). ChatService resolves it from stored user intent
+    // plus the selected model's function-call ability.
+    enableAgentMode,
 
     // Skills configuration (resolved above)
     skillsConfig: {

--- a/src/services/chat/mecha/modelParamsResolver.ts
+++ b/src/services/chat/mecha/modelParamsResolver.ts
@@ -1,6 +1,7 @@
+import type { ModelExtendParams } from '@lobechat/model-runtime';
 import {
   applyModelExtendParams,
-  type ModelExtendParams,
+  resolveDefaultEnableAdaptiveThinkingForModel,
   resolveDefaultThinkingLevelForModel,
 } from '@lobechat/model-runtime';
 import type { LobeAgentChatConfig } from '@lobechat/types';
@@ -8,7 +9,7 @@ import type { LobeAgentChatConfig } from '@lobechat/types';
 import { aiModelSelectors, getAiInfraStoreState } from '@/store/aiInfra';
 
 export type { ModelExtendParams };
-export { resolveDefaultThinkingLevelForModel };
+export { resolveDefaultEnableAdaptiveThinkingForModel, resolveDefaultThinkingLevelForModel };
 
 /**
  * Context for resolving model parameters


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

Reference docs:
- https://ai.google.dev/gemini-api/docs/models/gemini-3.1-flash-lite-image

#### 🔀 Description of Change

This PR gates agent/tool mode by the selected model's function-calling ability.

- Force chat-mode tool resolution when the selected model does not support function calling.
- Pass the runtime-resolved agent mode into context engineering so agent-only context is suppressed for models without tool calls.
- Stop showing the unsupported agentic-tool warning when the model itself is still available.
- Show Chat as the effective mode and disable the Agent option for models without tool calling.
- Add a Google Nano Banana model-id helper and default online model descriptions for Nano Banana 2 Lite.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated tests:

- `cd lobehub && rtk vitest run src/features/ChatInput/hooks/useEffectiveAgentMode.test.ts`
- `cd lobehub && rtk vitest run src/features/ChatInput/CurrentModelNotice/useCurrentModelNotice.test.tsx`
- `cd lobehub && rtk vitest run src/helpers/toolEngineering/index.test.ts`
- `cd lobehub && rtk vitest run src/services/chat/chat.test.ts`
- `cd lobehub && rtk vitest run src/services/chat/mecha/contextEngineering.test.ts`
- `cd lobehub/packages/model-runtime && rtk vitest run src/providers/google/googleModelId.test.ts`
- `bun run scripts/sync-lobehub-model-locales.ts --check`
- `vscode-cli get-diagnostics`

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Key decisions / non-goals:

- `enableAgentMode` remains the stored user intent. This PR does not write back or migrate user config.
- The effective runtime mode is derived from `enableAgentMode !== false && abilities.functionCall`.
- Nano Banana is not special-cased in the agent-mode gating path; it is handled by the same model ability check as any other model.
- Image-size parameters are not added for Nano Banana 2 Lite because the current hosted config only exposes the supported 1K path.
