### PR TITLE
🐛 fix(chat): gate Gateway by model tool ability

### DIFF
--- a/src/features/ChatInput/ActionBar/Plus/index.tsx
+++ b/src/features/ChatInput/ActionBar/Plus/index.tsx
@@ -318,7 +318,7 @@ const PlusAction = memo(() => {
     chatConfigByIdSelectors.getUseModelBuiltinSearchById(agentId)(s),
     chatConfigByIdSelectors.getChatConfigById(agentId)(s).disableGatewayMode,
   ]);
-  const isGatewayModeEnabled = (disableGatewayMode ?? defaultDisableGatewayMode) !== true;
+  const isGatewayModeConfigured = (disableGatewayMode ?? defaultDisableGatewayMode) !== true;
 
   const isMemoryEnabled = useMemoryEnabled(agentId);
   const [showTypoBar, setShowTypoBar] = useChatInputStore((s) => [s.showTypoBar, s.setShowTypoBar]);
@@ -329,6 +329,7 @@ const PlusAction = memo(() => {
     agentId,
   );
   const enableFC = useModelSupportToolUse(model, provider);
+  const isGatewayModeEnabled = isGatewayModeConfigured && enableFC;
   const handleOpenKnowledge = useCallback(() => {
     setDropdownOpen(false);
     openAttachKnowledgeModal();
@@ -386,9 +387,10 @@ const PlusAction = memo(() => {
 
   const handleToggleGatewayMode = useCallback(
     async (checked: boolean) => {
+      if (!enableFC) return;
       await updateAgentChatConfig({ disableGatewayMode: checked ? false : true });
     },
-    [updateAgentChatConfig],
+    [enableFC, updateAgentChatConfig],
   );
 
   const handleToggleParams = useCallback(() => {
@@ -457,7 +459,9 @@ const PlusAction = memo(() => {
         />
         <div className="body">
           <div className="title">{t('gatewayMode.cardTitle')}</div>
-          <div className="desc">{t('gatewayMode.desc')}</div>
+          <div className="desc">
+            {enableFC ? t('gatewayMode.desc') : t('chatMode.agentUnsupported')}
+          </div>
         </div>
       </div>
     );
@@ -608,6 +612,7 @@ const PlusAction = memo(() => {
         ? [
             {
               checked: isGatewayModeEnabled,
+              disabled: !enableFC,
               icon: Cloud,
               key: 'gateway-mode',
               label: (

--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
@@ -325,6 +325,39 @@ describe('ConversationLifecycle actions', () => {
         expect(result.current.executeClientAgent).toHaveBeenCalled();
       });
 
+      it('falls back to client runtime when Gateway mode is unavailable for the model', async () => {
+        const { result } = renderHook(() => useChatStore());
+        const executeGatewayAgentSpy = vi.fn();
+        const executeClientAgentSpy = vi.fn();
+
+        act(() => {
+          useChatStore.setState({
+            executeClientAgent: executeClientAgentSpy,
+            executeGatewayAgent: executeGatewayAgentSpy,
+            isGatewayModeEnabled: () => false,
+          });
+        });
+
+        vi.spyOn(aiChatService, 'sendMessageInServer').mockResolvedValue({
+          messages: [
+            createMockMessage({ id: TEST_IDS.USER_MESSAGE_ID, role: 'user' }),
+            createMockMessage({ id: TEST_IDS.ASSISTANT_MESSAGE_ID, role: 'assistant' }),
+          ],
+          topics: [],
+          assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+        } as any);
+
+        await act(async () => {
+          await result.current.sendMessage({
+            context: createTestContext(),
+            message: TEST_CONTENT.USER_MESSAGE,
+          });
+        });
+
+        expect(executeGatewayAgentSpy).not.toHaveBeenCalled();
+        expect(executeClientAgentSpy).toHaveBeenCalled();
+      });
+
       it('should persist selected slash skills into user message content before sending', async () => {
         const { result } = renderHook(() => useChatStore());
 

--- a/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts
@@ -67,6 +67,7 @@ const mockRuntime = vi.hoisted(() => ({ isChatMode: false, isLocal: false }));
 const mockAgentStore = vi.hoisted(() => ({
   state: { activeAgentId: undefined, agentMap: {} } as any,
 }));
+const mockModelAbility = vi.hoisted(() => ({ supportToolUse: true }));
 
 vi.mock('@/const/version', async (importOriginal) => {
   const actual = await importOriginal<typeof ConstVersion>();
@@ -85,6 +86,12 @@ vi.mock('@/services/electron/gatewayConnection', () => ({
 vi.mock('@/store/agent', () => ({ getAgentStoreState: () => mockAgentStore.state }));
 
 vi.mock('@/store/agent/selectors', () => ({
+  agentByIdSelectors: {
+    getAgentModelById: (agentId: string) => (state: any) =>
+      state.agentMap?.[agentId]?.model ?? 'test-model',
+    getAgentModelProviderById: (agentId: string) => (state: any) =>
+      state.agentMap?.[agentId]?.provider ?? 'test-provider',
+  },
   agentSelectors: { currentAgentWorkingDirectory: () => () => undefined },
   chatConfigByIdSelectors: {
     getChatConfigById: (agentId: string) => (state: any) =>
@@ -92,6 +99,13 @@ vi.mock('@/store/agent/selectors', () => ({
     isChatModeById: () => () => mockRuntime.isChatMode,
     isLocalSystemEnabledById: () => () => mockRuntime.isLocal,
   },
+}));
+
+vi.mock('@/store/aiInfra', () => ({
+  aiModelSelectors: {
+    isModelSupportToolUse: () => () => mockModelAbility.supportToolUse,
+  },
+  getAiInfraStoreState: () => ({}),
 }));
 
 // ─── Mock Client Factory ───
@@ -149,6 +163,7 @@ function createTestAction() {
 describe('GatewayActionImpl', () => {
   beforeEach(() => {
     mockAgentStore.state = { activeAgentId: undefined, agentMap: {} };
+    mockModelAbility.supportToolUse = true;
     mockUserDefaultConfig.disableGatewayMode = undefined;
     mockToolInterventionConfig.approvalMode = 'manual';
     mockToolInterventionConfig.allowList = [];
@@ -199,6 +214,27 @@ describe('GatewayActionImpl', () => {
         enableGatewayMode: true,
       });
       mockUserDefaultConfig.disableGatewayMode = true;
+
+      expect(action.isGatewayModeEnabled('agent-1')).toBe(false);
+    });
+
+    it('returns false when the model does not support tool calling', () => {
+      const { action } = createTestAction();
+      setServerConfig({
+        agentGatewayUrl: 'https://gateway.test.com',
+        enableGatewayMode: true,
+      });
+      mockAgentStore.state = {
+        activeAgentId: 'agent-1',
+        agentMap: {
+          'agent-1': {
+            chatConfig: {},
+            model: 'gemini-3.1-flash-lite-image',
+            provider: 'lobehub',
+          },
+        },
+      };
+      mockModelAbility.supportToolUse = false;
 
       expect(action.isGatewayModeEnabled('agent-1')).toBe(false);
     });

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -12,7 +12,8 @@ import { gatewayConnectionService } from '@/services/electron/gatewayConnection'
 import { messageService } from '@/services/message';
 import { topicService } from '@/services/topic';
 import { getAgentStoreState } from '@/store/agent';
-import { chatConfigByIdSelectors } from '@/store/agent/selectors';
+import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
+import { aiModelSelectors, getAiInfraStoreState } from '@/store/aiInfra';
 import { consumePendingTopicRepos, getPendingTopicRepos } from '@/store/chat/pendingTopicRepos';
 import { topicSelectors } from '@/store/chat/selectors';
 import type { ChatStore } from '@/store/chat/store';
@@ -335,11 +336,24 @@ export class GatewayActionImpl {
     const defaultDisableGatewayMode = settingsSelectors.defaultAgentConfig(useUserStore.getState())
       .chatConfig?.disableGatewayMode;
     const disableGatewayMode = agentDisableGatewayMode ?? defaultDisableGatewayMode;
+    const model = resolvedAgentId
+      ? agentByIdSelectors.getAgentModelById(resolvedAgentId)(agentState)
+      : undefined;
+    const provider = resolvedAgentId
+      ? agentByIdSelectors.getAgentModelProviderById(resolvedAgentId)(agentState)
+      : undefined;
+    // Example: Nano Banana supports image output but not function calling; Gateway would
+    // inject agent/tools context and run the wrong runtime instead of normal image output.
+    const supportToolUse =
+      !!model &&
+      !!provider &&
+      aiModelSelectors.isModelSupportToolUse(model, provider)(getAiInfraStoreState());
 
     return (
       !!serverConfig?.agentGatewayUrl &&
       !!serverConfig.enableGatewayMode &&
-      disableGatewayMode !== true
+      disableGatewayMode !== true &&
+      supportToolUse
     );
   };
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

This PR prevents Agent Gateway mode from being selected for models that do not support tool calling.

- Gate the runtime Gateway switch with `aiModelSelectors.isModelSupportToolUse(model, provider)`.
- Show the chat input Gateway toggle as disabled/off when the current model lacks function calling, without mutating the user's saved Gateway preference.
- Keep unsupported models on the normal client/chat runtime so image-output chat models can continue through their regular path.

#### 🧭 Key Decisions / Non-goals

- The gate is based on model ability, not a model-id special case.
- This does not change user configuration; it only changes the effective runtime/UI state.
- This does not change context compression behavior generally. It prevents unsupported models from entering the Gateway runtime that can inject extra agent/tool context.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated tests:

```bash
cd lobehub && rtk vitest run src/store/chat/slices/agentRun/actions/__tests__/gateway.test.ts src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
vscode-cli get-diagnostics
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Manual scenario: enable Agent Gateway globally, select an image-output chat model without function calling, then send an image generation prompt. The request should use the normal client runtime instead of `executeGatewayAgent`.
