### PR TITLE
⚡️ perf: memoize context provider values to prevent render thrashing

### DIFF
--- a/src/routes/(main)/(create)/features/GenerationLayout/Body/List/index.tsx
+++ b/src/routes/(main)/(create)/features/GenerationLayout/Body/List/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { memo, Suspense } from 'react';
+import { memo, Suspense, useMemo } from 'react';
 
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
 import { useGlobalStore } from '@/store/global';
@@ -23,8 +23,13 @@ const List = memo<
   const useFetchGenerationTopics = useStore((s: any) => s.useFetchGenerationTopics);
   useFetchGenerationTopics(!!isLogin);
 
+  const contextValue = useMemo(
+    () => ({ namespace, useStore: useStore as any }),
+    [namespace, useStore],
+  );
+
   return (
-    <GenerationTopicStoreProvider value={{ namespace, useStore: useStore as any }}>
+    <GenerationTopicStoreProvider value={contextValue}>
       <Suspense fallback={<SkeletonList rows={6} />}>
         <Flexbox gap={4} paddingBlock={1}>
           <TopicList viewMode={viewMode} />

--- a/src/routes/(main)/settings/_layout/index.tsx
+++ b/src/routes/(main)/settings/_layout/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Flexbox } from '@lobehub/ui';
-import { type FC } from 'react';
+import { type FC, useMemo } from 'react';
 import { Outlet } from 'react-router';
 
 import SideBar from '@/routes/(main)/settings/_layout/SideBar';
@@ -10,13 +10,13 @@ import SettingsContextProvider from './ContextProvider';
 import { styles } from './style';
 
 const Layout: FC = () => {
+  const contextValue = useMemo(
+    () => ({ showOpenAIApiKey: true, showOpenAIProxyUrl: true }),
+    [],
+  );
+
   return (
-    <SettingsContextProvider
-      value={{
-        showOpenAIApiKey: true,
-        showOpenAIProxyUrl: true,
-      }}
-    >
+    <SettingsContextProvider value={contextValue}>
       <SideBar />
       <Flexbox className={styles.mainContainer} flex={1} height={'100%'}>
         <Outlet />

--- a/src/routes/(mobile)/settings/_layout/index.tsx
+++ b/src/routes/(mobile)/settings/_layout/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { Outlet } from 'react-router';
 
 import MobileContentLayout from '@/components/server/MobileNavLayout';
@@ -9,13 +9,13 @@ import SettingsContextProvider from '../../../(main)/settings/_layout/ContextPro
 import Header from './Header';
 
 const MobileSettingsWrapper = memo(() => {
+  const contextValue = useMemo(
+    () => ({ showOpenAIApiKey: true, showOpenAIProxyUrl: true }),
+    [],
+  );
+
   return (
-    <SettingsContextProvider
-      value={{
-        showOpenAIApiKey: true,
-        showOpenAIProxyUrl: true,
-      }}
-    >
+    <SettingsContextProvider value={contextValue}>
       <MobileContentLayout header={<Header />}>
         <Outlet />
       </MobileContentLayout>


### PR DESCRIPTION
#### 💻 Change Type

- [x] ⚡️ perf

#### 🔗 Related Issue

Closes #16497

#### 🔀 Description of Change

The three context providers passed a new inline object as their `value` on every render, so the reference changed each time and every consumer in the sub-tree re-rendered past `React.memo`. I wrapped each `value` object in `useMemo` so the reference stays stable. For the settings layouts the value is constant so the deps are empty, and for the generation list the deps are `namespace` and `useStore`. Behavior is unchanged.

#### 🧪 How to Test

- [x] No tests needed

The memoized object is identical to the previous inline one, so there is no behavior change. It is purely a referential-stability fix. No UI changes.