### PR TITLE
🐛 fix(model-runtime): parse Doubao Seed seed:tool_call as tool calls

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -213,7 +213,12 @@ export interface OpenAICompatibleFactoryOptions<T extends Record<string, any> = 
     ) => OpenAI.ChatCompletionCreateParamsStreaming;
     handleStream?: (
       stream: Stream<OpenAI.ChatCompletionChunk> | ReadableStream,
-      options: OpenAIStreamOptions & { inputStartAt?: number },
+      options: {
+        bizErrorTypeTransformer?: OpenAIStreamOptions['bizErrorTypeTransformer'];
+        callbacks?: ChatStreamCallbacks;
+        inputStartAt?: number;
+        payload?: ChatPayloadForTransformStream;
+      },
     ) => ReadableStream;
     handleStreamBizErrorType?: (error: {
       message: string;
@@ -653,7 +658,6 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
             model: payload.model,
             pricing: await getModelPricing(payload.model, this.id, options?.pricingContext),
             provider: this.id,
-            tools: postPayload.tools,
           },
         };
 
@@ -729,8 +733,10 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           return StreamingResponse(
             chatCompletion?.handleStream
               ? chatCompletion.handleStream(prod, {
-                  ...streamOptions,
+                  bizErrorTypeTransformer: streamOptions.bizErrorTypeTransformer,
+                  callbacks: streamOptions.callbacks,
                   inputStartAt,
+                  payload: streamOptions.payload,
                 })
               : OpenAIStream(prod, {
                   ...streamOptions,
@@ -759,9 +765,10 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         return StreamingResponse(
           chatCompletion?.handleStream
             ? chatCompletion.handleStream(stream, {
-                ...streamOptions,
-                enableStreaming: false,
+                bizErrorTypeTransformer: streamOptions.bizErrorTypeTransformer,
+                callbacks: streamOptions.callbacks,
                 inputStartAt,
+                payload: streamOptions.payload,
               })
             : OpenAIStream(stream, { ...streamOptions, enableStreaming: false, inputStartAt }),
           {

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -213,11 +213,7 @@ export interface OpenAICompatibleFactoryOptions<T extends Record<string, any> = 
     ) => OpenAI.ChatCompletionCreateParamsStreaming;
     handleStream?: (
       stream: Stream<OpenAI.ChatCompletionChunk> | ReadableStream,
-      options: {
-        callbacks?: ChatStreamCallbacks;
-        inputStartAt?: number;
-        payload?: ChatPayloadForTransformStream;
-      },
+      options: OpenAIStreamOptions & { inputStartAt?: number },
     ) => ReadableStream;
     handleStreamBizErrorType?: (error: {
       message: string;
@@ -657,6 +653,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
             model: payload.model,
             pricing: await getModelPricing(payload.model, this.id, options?.pricingContext),
             provider: this.id,
+            tools: postPayload.tools,
           },
         };
 
@@ -732,9 +729,8 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           return StreamingResponse(
             chatCompletion?.handleStream
               ? chatCompletion.handleStream(prod, {
-                  callbacks: streamOptions.callbacks,
+                  ...streamOptions,
                   inputStartAt,
-                  payload: streamOptions.payload,
                 })
               : OpenAIStream(prod, {
                   ...streamOptions,
@@ -763,9 +759,9 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
         return StreamingResponse(
           chatCompletion?.handleStream
             ? chatCompletion.handleStream(stream, {
-                callbacks: streamOptions.callbacks,
+                ...streamOptions,
+                enableStreaming: false,
                 inputStartAt,
-                payload: streamOptions.payload,
               })
             : OpenAIStream(stream, { ...streamOptions, enableStreaming: false, inputStartAt }),
           {

--- a/packages/model-runtime/src/core/streams/index.ts
+++ b/packages/model-runtime/src/core/streams/index.ts
@@ -7,3 +7,5 @@ export * from './openai';
 export * from './protocol';
 export * from './qwen';
 export * from './spark';
+export * from './volcengine/parseSeedToolCall';
+export * from './volcengine/seedStream';

--- a/packages/model-runtime/src/core/streams/openai/openai.ts
+++ b/packages/model-runtime/src/core/streams/openai/openai.ts
@@ -70,7 +70,7 @@ const processMarkdownBase64Images = (text: string): { cleanedText: string; urls:
   return { cleanedText, urls };
 };
 
-const transformOpenAIStream = (
+export const transformOpenAIStream = (
   chunk: OpenAI.ChatCompletionChunk,
   streamContext: StreamContext,
   payload?: ChatPayloadForTransformStream,

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -37,6 +37,11 @@ export interface StreamContext {
    */
   returnedCitationArray?: ChatCitationItem[];
   /**
+   * Volcengine Doubao Seed: buffer for in-flight `seed:tool_call` text blocks
+   * that span multiple stream chunks before the closing tag arrives.
+   */
+  seedToolCallBuffer?: string;
+  /**
    * O series models need a condition to separate part
    */
   startReasoning?: boolean;

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -15,6 +15,8 @@ export type ChatPayloadForTransformStream = {
   pricing?: Pricing;
   pricingOptions?: ComputeChatCostOptions;
   provider?: string;
+  /** Original request tools — used by provider-specific stream adapters (e.g. Doubao Seed). */
+  tools?: unknown[];
 };
 
 /**

--- a/packages/model-runtime/src/core/streams/protocol.ts
+++ b/packages/model-runtime/src/core/streams/protocol.ts
@@ -15,8 +15,6 @@ export type ChatPayloadForTransformStream = {
   pricing?: Pricing;
   pricingOptions?: ComputeChatCostOptions;
   provider?: string;
-  /** Original request tools — used by provider-specific stream adapters (e.g. Doubao Seed). */
-  tools?: unknown[];
 };
 
 /**

--- a/packages/model-runtime/src/core/streams/volcengine/parseSeedToolCall.test.ts
+++ b/packages/model-runtime/src/core/streams/volcengine/parseSeedToolCall.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractSeedToolCallsFromText,
+  flushSeedToolCallBuffer,
+  isDoubaoSeedModel,
+  parseSeedToolCallBlock,
+} from './parseSeedToolCall';
+
+const INJECT_CREDS_BLOCK =
+  'seed:tool_call<function name="lobe-creds____injectCredsToSandbox"><parameter name="keys" string="false">["shuyou"]</parameter></function></seed:tool_call>';
+
+describe('isDoubaoSeedModel', () => {
+  it('should match doubao-seed model ids', () => {
+    expect(isDoubaoSeedModel('doubao-seed-2.0-pro')).toBe(true);
+    expect(isDoubaoSeedModel('doubao-seed-2-0-pro-260215')).toBe(true);
+  });
+
+  it('should not match unrelated models', () => {
+    expect(isDoubaoSeedModel('doubao-pro-32k')).toBe(false);
+    expect(isDoubaoSeedModel('deepseek-v4-pro-260425')).toBe(false);
+  });
+});
+
+describe('parseSeedToolCallBlock', () => {
+  it('should parse injectCredsToSandbox tool call', () => {
+    const parsed = parseSeedToolCallBlock(INJECT_CREDS_BLOCK);
+
+    expect(parsed).toEqual({
+      arguments: { keys: ['shuyou'] },
+      name: 'lobe-creds____injectCredsToSandbox',
+    });
+  });
+
+  it('should keep string parameters when string="true"', () => {
+    const block =
+      'seed:tool_call<function name="demo____run"><parameter name="path" string="true">/tmp/a</parameter></function></seed:tool_call>';
+    const parsed = parseSeedToolCallBlock(block);
+
+    expect(parsed).toEqual({
+      arguments: { path: '/tmp/a' },
+      name: 'demo____run',
+    });
+  });
+
+  it('should return null for incomplete blocks', () => {
+    expect(parseSeedToolCallBlock('seed:tool_call<function name="demo____run">')).toBeNull();
+  });
+});
+
+describe('extractSeedToolCallsFromText', () => {
+  it('should convert a complete block into tool_calls chunk', () => {
+    const { chunks, remainingBuffer } = extractSeedToolCallsFromText(
+      `prefix ${INJECT_CREDS_BLOCK} suffix`,
+    );
+
+    expect(remainingBuffer).toBe('');
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toEqual({ data: 'prefix ', type: 'text' });
+    expect(chunks[1]?.type).toBe('tool_calls');
+    expect(chunks[1]?.data[0].function).toEqual({
+      arguments: JSON.stringify({ keys: ['shuyou'] }),
+      name: 'lobe-creds____injectCredsToSandbox',
+    });
+    expect(chunks[2]).toEqual({ data: ' suffix', type: 'text' });
+  });
+
+  it('should buffer incomplete blocks across chunks', () => {
+    const part1 =
+      'seed:tool_call<function name="demo____run"><parameter name="keys" string="false">["a"]';
+    const part2 = '</parameter></function></seed:tool_call>';
+
+    const first = extractSeedToolCallsFromText(part1);
+    expect(first.chunks).toHaveLength(0);
+    expect(first.remainingBuffer).toBe(part1);
+
+    const second = extractSeedToolCallsFromText(part2, first.remainingBuffer);
+    expect(second.remainingBuffer).toBe('');
+    expect(second.chunks).toHaveLength(1);
+    expect(second.chunks[0]?.type).toBe('tool_calls');
+    expect(second.chunks[0]?.data[0].function.name).toBe('demo____run');
+  });
+});
+
+describe('flushSeedToolCallBuffer', () => {
+  it('should flush a complete buffered block on stream end', () => {
+    const flushed = flushSeedToolCallBuffer(INJECT_CREDS_BLOCK);
+
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0]?.type).toBe('tool_calls');
+  });
+
+  it('should emit leftover text when buffer is not a tool call', () => {
+    expect(flushSeedToolCallBuffer('plain tail')).toEqual([{ data: 'plain tail', type: 'text' }]);
+  });
+});

--- a/packages/model-runtime/src/core/streams/volcengine/parseSeedToolCall.ts
+++ b/packages/model-runtime/src/core/streams/volcengine/parseSeedToolCall.ts
@@ -1,0 +1,147 @@
+import type { StreamProtocolChunk, StreamToolCallChunkData } from '../protocol';
+import { generateToolCallId } from '../protocol';
+
+const SEED_TOOL_CALL_START = /seed:tool_call/i;
+const SEED_TOOL_CALL_END = /<\/seed:tool_call>/i;
+
+export interface ParsedSeedToolCall {
+  arguments: Record<string, unknown>;
+  name: string;
+}
+
+export const isDoubaoSeedModel = (model?: string): boolean => {
+  if (!model) return false;
+
+  const normalized = model.toLowerCase();
+
+  return normalized.includes('doubao-seed') || normalized.includes('doubao_seed');
+};
+
+const parseParameterValue = (raw: string, stringAttr?: string): unknown => {
+  const trimmed = raw.trim();
+
+  if (stringAttr === 'true') return trimmed;
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return trimmed;
+  }
+};
+
+/**
+ * Parse a complete Doubao Seed `seed:tool_call` XML block into a tool call payload.
+ *
+ * Example:
+ * seed:tool_call<function name="lobe-creds____injectCredsToSandbox">
+ *   <parameter name="keys" string="false">["shuyou"]</parameter>
+ * </function></seed:tool_call>
+ */
+export const parseSeedToolCallBlock = (block: string): ParsedSeedToolCall | null => {
+  if (!SEED_TOOL_CALL_START.test(block) || !SEED_TOOL_CALL_END.test(block)) return null;
+
+  const nameMatch = block.match(/<function\s+name="([^"]+)"/i);
+  if (!nameMatch?.[1]) return null;
+
+  const args: Record<string, unknown> = {};
+  const paramRegex =
+    /<parameter\s+name="([^"]+)"(?:\s+string="(true|false)")?\s*>([\s\S]*?)<\/parameter>/gi;
+
+  let match: RegExpExecArray | null;
+  while ((match = paramRegex.exec(block)) !== null) {
+    const [, paramName, stringAttr, rawValue] = match;
+    if (!paramName) continue;
+
+    args[paramName] = parseParameterValue(rawValue ?? '', stringAttr);
+  }
+
+  return {
+    arguments: args,
+    name: nameMatch[1],
+  };
+};
+
+const toToolCallsChunk = (
+  parsed: ParsedSeedToolCall,
+  id?: string,
+  index = 0,
+): StreamProtocolChunk => {
+  const toolCall: StreamToolCallChunkData = {
+    function: {
+      arguments: JSON.stringify(parsed.arguments),
+      name: parsed.name,
+    },
+    id: generateToolCallId(index, parsed.name),
+    index,
+    type: 'function',
+  };
+
+  return {
+    data: [toolCall],
+    id,
+    type: 'tool_calls',
+  };
+};
+
+export interface SeedToolCallExtractionResult {
+  chunks: StreamProtocolChunk[];
+  remainingBuffer: string;
+}
+
+/**
+ * Incrementally extract complete `seed:tool_call` blocks from streamed text.
+ * Incomplete blocks are kept in `remainingBuffer` until the closing tag arrives.
+ */
+export const extractSeedToolCallsFromText = (
+  delta: string,
+  buffer = '',
+): SeedToolCallExtractionResult => {
+  let working = `${buffer}${delta}`;
+  const chunks: StreamProtocolChunk[] = [];
+
+  while (working.length > 0) {
+    const startMatch = working.match(SEED_TOOL_CALL_START);
+    const startIdx = startMatch?.index;
+
+    if (startIdx === undefined) {
+      if (working) chunks.push({ data: working, type: 'text' });
+      working = '';
+      break;
+    }
+
+    if (startIdx > 0) {
+      chunks.push({ data: working.slice(0, startIdx), type: 'text' });
+      working = working.slice(startIdx);
+    }
+
+    const endMatch = working.match(SEED_TOOL_CALL_END);
+    if (!endMatch || endMatch.index === undefined) {
+      break;
+    }
+
+    const endIdx = endMatch.index + endMatch[0].length;
+    const block = working.slice(0, endIdx);
+    working = working.slice(endIdx);
+
+    const parsed = parseSeedToolCallBlock(block);
+    if (parsed) {
+      chunks.push(toToolCallsChunk(parsed));
+    } else {
+      chunks.push({ data: block, type: 'text' });
+    }
+  }
+
+  return {
+    chunks,
+    remainingBuffer: working,
+  };
+};
+
+export const flushSeedToolCallBuffer = (buffer: string): StreamProtocolChunk[] => {
+  if (!buffer) return [];
+
+  const parsed = parseSeedToolCallBlock(buffer);
+  if (parsed) return [toToolCallsChunk(parsed)];
+
+  return [{ data: buffer, type: 'text' }];
+};

--- a/packages/model-runtime/src/core/streams/volcengine/seedStream.test.ts
+++ b/packages/model-runtime/src/core/streams/volcengine/seedStream.test.ts
@@ -1,0 +1,101 @@
+import type OpenAI from 'openai';
+import { describe, expect, it } from 'vitest';
+
+import type { StreamContext } from '../protocol';
+import { transformVolcengineSeedStream } from './seedStream';
+
+const INJECT_CREDS_BLOCK =
+  'seed:tool_call<function name="lobe-creds____injectCredsToSandbox"><parameter name="keys" string="false">["shuyou"]</parameter></function></seed:tool_call>';
+
+const seedPayload = {
+  model: 'doubao-seed-2.0-pro',
+  tools: [
+    { function: { name: 'lobe-creds____injectCredsToSandbox', parameters: {} }, type: 'function' },
+  ],
+};
+
+describe('transformVolcengineSeedStream', () => {
+  it('should convert seed:tool_call text into tool_calls for doubao-seed models', () => {
+    const streamContext: StreamContext = { id: 'resp-1' };
+    const chunk = {
+      choices: [{ delta: { content: INJECT_CREDS_BLOCK }, finish_reason: null, index: 0 }],
+      id: 'resp-1',
+      object: 'chat.completion.chunk',
+    } as OpenAI.ChatCompletionChunk;
+
+    const result = transformVolcengineSeedStream(chunk, streamContext, seedPayload);
+    const chunks = Array.isArray(result) ? result : [result];
+    const toolChunk = chunks.find((item) => item.type === 'tool_calls');
+
+    expect(toolChunk?.data[0].function).toEqual({
+      arguments: JSON.stringify({ keys: ['shuyou'] }),
+      name: 'lobe-creds____injectCredsToSandbox',
+    });
+  });
+
+  it('should pass through native tool_calls unchanged', () => {
+    const streamContext: StreamContext = { id: 'resp-2' };
+    const chunk = {
+      choices: [
+        {
+          delta: {
+            tool_calls: [
+              {
+                function: {
+                  arguments: '{"keys":["shuyou"]}',
+                  name: 'lobe-creds____injectCredsToSandbox',
+                },
+                id: 'call_native',
+                index: 0,
+                type: 'function',
+              },
+            ],
+          },
+          finish_reason: null,
+          index: 0,
+        },
+      ],
+      id: 'resp-2',
+      object: 'chat.completion.chunk',
+    } as OpenAI.ChatCompletionChunk;
+
+    const result = transformVolcengineSeedStream(chunk, streamContext, seedPayload);
+    const chunks = Array.isArray(result) ? result : [result];
+
+    expect(chunks[0]?.type).toBe('tool_calls');
+    expect(chunks[0]?.data[0].function.name).toBe('lobe-creds____injectCredsToSandbox');
+  });
+
+  it('should not rewrite text for non-seed models', () => {
+    const streamContext: StreamContext = { id: 'resp-3' };
+    const chunk = {
+      choices: [{ delta: { content: INJECT_CREDS_BLOCK }, finish_reason: null, index: 0 }],
+      id: 'resp-3',
+      object: 'chat.completion.chunk',
+    } as OpenAI.ChatCompletionChunk;
+
+    const result = transformVolcengineSeedStream(chunk, streamContext, {
+      model: 'doubao-pro-32k',
+      tools: seedPayload.tools,
+    });
+    const chunks = Array.isArray(result) ? result : [result];
+
+    expect(chunks[0]).toEqual({ data: INJECT_CREDS_BLOCK, id: 'resp-3', type: 'text' });
+  });
+
+  it('should flush buffered seed tool call on finish_reason', () => {
+    const streamContext: StreamContext = { id: 'resp-4', seedToolCallBuffer: INJECT_CREDS_BLOCK };
+    const chunk = {
+      choices: [{ delta: {}, finish_reason: 'stop', index: 0 }],
+      id: 'resp-4',
+      object: 'chat.completion.chunk',
+    } as OpenAI.ChatCompletionChunk;
+
+    const result = transformVolcengineSeedStream(chunk, streamContext, seedPayload);
+    const chunks = Array.isArray(result) ? result : [result];
+    const toolChunk = chunks.find((item) => item.type === 'tool_calls');
+
+    expect(streamContext.seedToolCallBuffer).toBe('');
+    expect(toolChunk?.data[0].function.name).toBe('lobe-creds____injectCredsToSandbox');
+  });
+});

--- a/packages/model-runtime/src/core/streams/volcengine/seedStream.test.ts
+++ b/packages/model-runtime/src/core/streams/volcengine/seedStream.test.ts
@@ -98,4 +98,30 @@ describe('transformVolcengineSeedStream', () => {
     expect(streamContext.seedToolCallBuffer).toBe('');
     expect(toolChunk?.data[0].function.name).toBe('lobe-creds____injectCredsToSandbox');
   });
+
+  it('should parse closing tag on the terminal content chunk before flushing', () => {
+    const streamContext: StreamContext = {
+      id: 'resp-5',
+      seedToolCallBuffer:
+        'seed:tool_call<function name="lobe-creds____injectCredsToSandbox"><parameter name="keys" string="false">["shuyou"]',
+    };
+    const chunk = {
+      choices: [
+        {
+          delta: { content: '</parameter></function></seed:tool_call>' },
+          finish_reason: 'stop',
+          index: 0,
+        },
+      ],
+      id: 'resp-5',
+      object: 'chat.completion.chunk',
+    } as OpenAI.ChatCompletionChunk;
+
+    const result = transformVolcengineSeedStream(chunk, streamContext, seedPayload);
+    const chunks = Array.isArray(result) ? result : [result];
+    const toolChunk = chunks.find((item) => item.type === 'tool_calls');
+
+    expect(streamContext.seedToolCallBuffer).toBe('');
+    expect(toolChunk?.data[0].function.name).toBe('lobe-creds____injectCredsToSandbox');
+  });
 });

--- a/packages/model-runtime/src/core/streams/volcengine/seedStream.test.ts
+++ b/packages/model-runtime/src/core/streams/volcengine/seedStream.test.ts
@@ -9,9 +9,6 @@ const INJECT_CREDS_BLOCK =
 
 const seedPayload = {
   model: 'doubao-seed-2.0-pro',
-  tools: [
-    { function: { name: 'lobe-creds____injectCredsToSandbox', parameters: {} }, type: 'function' },
-  ],
 };
 
 describe('transformVolcengineSeedStream', () => {
@@ -76,7 +73,6 @@ describe('transformVolcengineSeedStream', () => {
 
     const result = transformVolcengineSeedStream(chunk, streamContext, {
       model: 'doubao-pro-32k',
-      tools: seedPayload.tools,
     });
     const chunks = Array.isArray(result) ? result : [result];
 

--- a/packages/model-runtime/src/core/streams/volcengine/seedStream.ts
+++ b/packages/model-runtime/src/core/streams/volcengine/seedStream.ts
@@ -1,7 +1,7 @@
 import type OpenAI from 'openai';
 import type { Stream } from 'openai/streaming';
 
-import type { ChatStreamCallbacks } from '../../../types';
+import type { OpenAIStreamOptions } from '../openai/openai';
 import { transformOpenAIStream } from '../openai/openai';
 import type {
   ChatPayloadForTransformStream,
@@ -11,6 +11,7 @@ import type {
 import {
   convertIterableToStream,
   createCallbacksTransformer,
+  createFirstErrorHandleTransformer,
   createSSEProtocolTransformer,
   createTokenSpeedCalculator,
 } from '../protocol';
@@ -72,14 +73,14 @@ export const transformVolcengineSeedStream = (
   const item = chunk.choices?.[0];
 
   if (item?.finish_reason) {
+    const processedBase = normalizeSeedStreamChunks(base, streamContext);
     const flushed = flushSeedToolCallBuffer(streamContext.seedToolCallBuffer ?? '');
     streamContext.seedToolCallBuffer = '';
 
     if (flushed.length === 0) {
-      return normalizeSeedStreamChunks(base, streamContext);
+      return processedBase;
     }
 
-    const processedBase = normalizeSeedStreamChunks(base, streamContext);
     const baseChunks = Array.isArray(processedBase) ? processedBase : [processedBase];
 
     return [...baseChunks, ...flushed.map((c) => ({ ...c, id: chunk.id ?? c.id }))];
@@ -92,24 +93,23 @@ export const VolcengineSeedAIStream = (
   stream: Stream<OpenAI.ChatCompletionChunk> | ReadableStream,
   {
     callbacks,
+    bizErrorTypeTransformer,
     payload,
     inputStartAt,
     enableStreaming = true,
-  }: {
-    callbacks?: ChatStreamCallbacks;
-    enableStreaming?: boolean;
-    inputStartAt?: number;
-    payload?: ChatPayloadForTransformStream;
-  } = {},
+  }: OpenAIStreamOptions & { inputStartAt?: number } = {},
 ) => {
   const streamContext: StreamContext = { id: '' };
   const readableStream =
-    stream instanceof ReadableStream ? stream : convertIterableToStream(stream);
+    stream instanceof ReadableStream
+      ? stream
+      : convertIterableToStream(stream, { model: payload?.model, provider: payload?.provider });
 
   const transformWithPayload = (chunk: OpenAI.ChatCompletionChunk, context: StreamContext) =>
     transformVolcengineSeedStream(chunk, context, payload);
 
   return readableStream
+    .pipeThrough(createFirstErrorHandleTransformer(bizErrorTypeTransformer, payload?.provider))
     .pipeThrough(
       createTokenSpeedCalculator(transformWithPayload, {
         enableStreaming,

--- a/packages/model-runtime/src/core/streams/volcengine/seedStream.ts
+++ b/packages/model-runtime/src/core/streams/volcengine/seedStream.ts
@@ -66,7 +66,7 @@ export const transformVolcengineSeedStream = (
 ): StreamProtocolChunk | StreamProtocolChunk[] => {
   const base = transformOpenAIStream(chunk, streamContext, payload);
 
-  if (!isDoubaoSeedModel(payload?.model) || !payload?.tools?.length) {
+  if (!isDoubaoSeedModel(payload?.model)) {
     return base;
   }
 

--- a/packages/model-runtime/src/core/streams/volcengine/seedStream.ts
+++ b/packages/model-runtime/src/core/streams/volcengine/seedStream.ts
@@ -1,0 +1,122 @@
+import type OpenAI from 'openai';
+import type { Stream } from 'openai/streaming';
+
+import type { ChatStreamCallbacks } from '../../../types';
+import { transformOpenAIStream } from '../openai/openai';
+import type {
+  ChatPayloadForTransformStream,
+  StreamContext,
+  StreamProtocolChunk,
+} from '../protocol';
+import {
+  convertIterableToStream,
+  createCallbacksTransformer,
+  createSSEProtocolTransformer,
+  createTokenSpeedCalculator,
+} from '../protocol';
+import {
+  extractSeedToolCallsFromText,
+  flushSeedToolCallBuffer,
+  isDoubaoSeedModel,
+} from './parseSeedToolCall';
+
+const applySeedToolCallExtraction = (
+  chunk: StreamProtocolChunk,
+  streamContext: StreamContext,
+): StreamProtocolChunk | StreamProtocolChunk[] => {
+  if (chunk.type === 'tool_calls') return chunk;
+  if (chunk.type !== 'text' || typeof chunk.data !== 'string') return chunk;
+
+  const { chunks, remainingBuffer } = extractSeedToolCallsFromText(
+    chunk.data,
+    streamContext.seedToolCallBuffer ?? '',
+  );
+  streamContext.seedToolCallBuffer = remainingBuffer;
+
+  if (chunks.length === 0) {
+    return { ...chunk, data: '' };
+  }
+
+  if (chunks.length === 1) {
+    return { ...chunks[0], id: chunk.id ?? chunks[0].id };
+  }
+
+  return chunks.map((item) => ({ ...item, id: chunk.id ?? item.id }));
+};
+
+const normalizeSeedStreamChunks = (
+  result: StreamProtocolChunk | StreamProtocolChunk[],
+  streamContext: StreamContext,
+): StreamProtocolChunk | StreamProtocolChunk[] => {
+  if (Array.isArray(result)) {
+    return result.flatMap((chunk) => {
+      const processed = applySeedToolCallExtraction(chunk, streamContext);
+      return Array.isArray(processed) ? processed : [processed];
+    });
+  }
+
+  return applySeedToolCallExtraction(result, streamContext);
+};
+
+export const transformVolcengineSeedStream = (
+  chunk: OpenAI.ChatCompletionChunk,
+  streamContext: StreamContext,
+  payload?: ChatPayloadForTransformStream,
+): StreamProtocolChunk | StreamProtocolChunk[] => {
+  const base = transformOpenAIStream(chunk, streamContext, payload);
+
+  if (!isDoubaoSeedModel(payload?.model) || !payload?.tools?.length) {
+    return base;
+  }
+
+  const item = chunk.choices?.[0];
+
+  if (item?.finish_reason) {
+    const flushed = flushSeedToolCallBuffer(streamContext.seedToolCallBuffer ?? '');
+    streamContext.seedToolCallBuffer = '';
+
+    if (flushed.length === 0) {
+      return normalizeSeedStreamChunks(base, streamContext);
+    }
+
+    const processedBase = normalizeSeedStreamChunks(base, streamContext);
+    const baseChunks = Array.isArray(processedBase) ? processedBase : [processedBase];
+
+    return [...baseChunks, ...flushed.map((c) => ({ ...c, id: chunk.id ?? c.id }))];
+  }
+
+  return normalizeSeedStreamChunks(base, streamContext);
+};
+
+export const VolcengineSeedAIStream = (
+  stream: Stream<OpenAI.ChatCompletionChunk> | ReadableStream,
+  {
+    callbacks,
+    payload,
+    inputStartAt,
+    enableStreaming = true,
+  }: {
+    callbacks?: ChatStreamCallbacks;
+    enableStreaming?: boolean;
+    inputStartAt?: number;
+    payload?: ChatPayloadForTransformStream;
+  } = {},
+) => {
+  const streamContext: StreamContext = { id: '' };
+  const readableStream =
+    stream instanceof ReadableStream ? stream : convertIterableToStream(stream);
+
+  const transformWithPayload = (chunk: OpenAI.ChatCompletionChunk, context: StreamContext) =>
+    transformVolcengineSeedStream(chunk, context, payload);
+
+  return readableStream
+    .pipeThrough(
+      createTokenSpeedCalculator(transformWithPayload, {
+        enableStreaming,
+        inputStartAt,
+        streamStack: streamContext,
+      }),
+    )
+    .pipeThrough(createSSEProtocolTransformer((c) => c, streamContext))
+    .pipeThrough(createCallbacksTransformer(callbacks, { streamStack: streamContext }));
+};

--- a/packages/model-runtime/src/providers/volcengine/index.test.ts
+++ b/packages/model-runtime/src/providers/volcengine/index.test.ts
@@ -121,5 +121,21 @@ describe('LobeVolcengineAI - custom features', () => {
       expect(calledPayload.thinking).toEqual({ type: 'enabled' });
       expect(calledPayload.reasoning.effort).toBe('high');
     });
+
+    it('should enable parallel_tool_calls for doubao-seed models with tools', async () => {
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'doubao-seed-2.0-pro',
+        tools: [
+          {
+            function: { name: 'lobe-creds____injectCredsToSandbox', parameters: {} },
+            type: 'function',
+          },
+        ],
+      });
+
+      const calledPayload = (instance['client'].chat.completions.create as any).mock.calls[0][0];
+      expect(calledPayload.parallel_tool_calls).toBe(true);
+    });
   });
 });

--- a/packages/model-runtime/src/providers/volcengine/index.ts
+++ b/packages/model-runtime/src/providers/volcengine/index.ts
@@ -3,6 +3,9 @@ import { ModelProvider } from 'model-bank';
 import type { ChatStreamPayload } from '@/types/index';
 
 import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+import { OpenAIStream } from '../../core/streams/openai/openai';
+import { isDoubaoSeedModel } from '../../core/streams/volcengine/parseSeedToolCall';
+import { VolcengineSeedAIStream } from '../../core/streams/volcengine/seedStream';
 import { createVolcengineImage } from './createImage';
 import { createVolcengineVideo } from './video/createVideo';
 import { handleVolcengineVideoWebhook } from './video/handleCreateVideoWebhook';
@@ -61,7 +64,16 @@ export const LobeVolcengineAI = createOpenAICompatibleRuntime({
         ...rest,
         ...(params.thinking?.type && { thinking: { type: params.thinking.type } }),
         ...(params.reasoning_effort && { reasoning_effort: params.reasoning_effort }),
+        ...(payload.tools?.length &&
+          isDoubaoSeedModel(payload.model) && { parallel_tool_calls: true }),
       } as any;
+    },
+    handleStream: (stream, options) => {
+      if (isDoubaoSeedModel(options.payload?.model) && options.payload?.tools?.length) {
+        return VolcengineSeedAIStream(stream, options);
+      }
+
+      return OpenAIStream(stream, options);
     },
   },
   createImage: createVolcengineImage,

--- a/packages/model-runtime/src/providers/volcengine/index.ts
+++ b/packages/model-runtime/src/providers/volcengine/index.ts
@@ -69,7 +69,7 @@ export const LobeVolcengineAI = createOpenAICompatibleRuntime({
       } as any;
     },
     handleStream: (stream, options) => {
-      if (isDoubaoSeedModel(options.payload?.model) && options.payload?.tools?.length) {
+      if (isDoubaoSeedModel(options.payload?.model)) {
         return VolcengineSeedAIStream(stream, options);
       }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

N/A — reported via community reproduction with Doubao Seed 2.0 Pro in cloud sandbox agent runs.

#### 🔀 Description of Change

Doubao Seed models (Volcengine) sometimes emit tool invocations as `seed:tool_call` XML inside streamed **text** instead of OpenAI-compatible `delta.tool_calls`. Agent Runtime then treats the turn as a normal text completion and finishes early, leaving tools (e.g. `lobe-creds____injectCredsToSandbox`) unexecuted.

This PR adds a Volcengine Seed stream adapter that:

- Detects and parses complete `seed:tool_call` blocks from streamed text
- Buffers incomplete blocks across chunks until `</seed:tool_call>` arrives
- Emits standard `tool_calls` protocol chunks for Agent Runtime
- Enables `parallel_tool_calls` for Doubao Seed models when tools are present
- Leaves native `delta.tool_calls` and non-Seed models unchanged

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/model-runtime
bunx vitest run --silent='passed-only' \
  'src/core/streams/volcengine/parseSeedToolCall.test.ts' \
  'src/core/streams/volcengine/seedStream.test.ts' \
  'src/providers/volcengine/index.test.ts'
```

Manual: use **Doubao Seed 2.0 Pro** with cloud sandbox + multi-step agent task that calls `injectCredsToSandbox`; verify the tool executes instead of the run false-completing with raw `seed:tool_call` text in the assistant message.

#### 📸 Screenshots / Videos

N/A — stream/protocol fix, no UI change.

#### 📝 Additional Information

Scope is limited to `packages/model-runtime` (Volcengine provider + stream layer). No server/UI/database changes required.

Made with [Cursor](https://cursor.com)