### PR TITLE
🐛 fix(desktop): show "Topics · <agent>" as the topics tab title

### DIFF
--- a/locales/en-US/electron.json
+++ b/locales/en-US/electron.json
@@ -63,6 +63,7 @@
   "navigation.settings": "Settings",
   "navigation.task": "Task",
   "navigation.tasks": "Tasks",
+  "navigation.topics": "Topics",
   "navigation.unpin": "Unpin",
   "notification.finishChatGeneration": "AI message generation completed",
   "proxy.auth": "Authentication Required",

--- a/locales/zh-CN/electron.json
+++ b/locales/zh-CN/electron.json
@@ -63,6 +63,7 @@
   "navigation.settings": "设置",
   "navigation.task": "任务",
   "navigation.tasks": "任务",
+  "navigation.topics": "话题",
   "navigation.unpin": "取消固定",
   "notification.finishChatGeneration": "AI 消息已生成完毕",
   "proxy.auth": "需要认证",

--- a/packages/locales/src/default/electron.ts
+++ b/packages/locales/src/default/electron.ts
@@ -30,6 +30,7 @@ export default {
   'navigation.settings': 'Settings',
   'navigation.task': 'Task',
   'navigation.tasks': 'Tasks',
+  'navigation.topics': 'Topics',
   'navigation.unpin': 'Unpin',
   'fleet.addColumn': 'Add column',
   'fleet.createTask': 'Create task',

--- a/src/routes/(main)/agent/features/routeMeta.ts
+++ b/src/routes/(main)/agent/features/routeMeta.ts
@@ -1,4 +1,5 @@
-import { MessageSquare } from 'lucide-react';
+import { MessageSquare, MessagesSquareIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 import { usePublishDynamicRouteMeta } from '@/features/RouteMeta/usePublishDynamicRouteMeta';
 import { matchesRouteWorkspace, useRouteWorkspaceId } from '@/features/RouteMeta/workspaceScope';
@@ -53,4 +54,36 @@ export const agentRouteMeta = routeMeta({
   DynamicMeta: AgentDynamicMeta,
   icon: MessageSquare,
   titleKey: 'navigation.chat',
+});
+
+const TopicsDynamicMeta = ({ onResolve, params }: DynamicRouteMetaProps) => {
+  const { t } = useTranslation('electron');
+  const routeWorkspaceId = useRouteWorkspaceId(params);
+  const meta = useAgentStore((s) => {
+    const agentId = params.aid ?? '';
+    const agent = s.agentMap[agentId];
+
+    if (!matchesRouteWorkspace(agent?.workspaceId, routeWorkspaceId)) return {};
+
+    return agentSelectors.getAgentMetaById(agentId)(s);
+  });
+  const hasMeta = Object.keys(meta).length > 0;
+  const agentTitle = hasMeta ? meta.title : undefined;
+
+  usePublishDynamicRouteMeta(
+    {
+      avatar: meta.avatar,
+      backgroundColor: meta.backgroundColor,
+      title: [t('navigation.topics'), agentTitle].filter(Boolean).join(' · ') || undefined,
+    },
+    onResolve,
+  );
+
+  return null;
+};
+
+export const topicsRouteMeta = routeMeta({
+  DynamicMeta: TopicsDynamicMeta,
+  icon: MessagesSquareIcon,
+  titleKey: 'navigation.topics',
 });

--- a/src/spa/router/desktopRouter.config.desktop.tsx
+++ b/src/spa/router/desktopRouter.config.desktop.tsx
@@ -55,7 +55,7 @@ import DesktopAgentChatLayout from '@/routes/(main)/agent/(chat)/_layout';
 import AgentChannelPage from '@/routes/(main)/agent/channel';
 import AgentDocumentLayout from '@/routes/(main)/agent/docs/_layout';
 import AgentDocumentRoute from '@/routes/(main)/agent/docs/[docId]';
-import { agentRouteMeta } from '@/routes/(main)/agent/features/routeMeta';
+import { agentRouteMeta, topicsRouteMeta } from '@/routes/(main)/agent/features/routeMeta';
 import AgentProfilePage from '@/routes/(main)/agent/profile';
 import AgentTaskDetailRoute from '@/routes/(main)/agent/task/[taskId]';
 import AgentScopedTasksRoute from '@/routes/(main)/agent/tasks';
@@ -182,6 +182,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
           },
           {
             element: <AgentTopicsPage />,
+            handle: { meta: topicsRouteMeta },
             path: 'topics',
           },
           {

--- a/src/spa/router/desktopRouter.config.tsx
+++ b/src/spa/router/desktopRouter.config.tsx
@@ -21,7 +21,7 @@ import { fleetRouteMeta } from '@/features/Fleet/routeMeta';
 import { pageRouteMeta } from '@/features/Pages/routeMeta';
 import { verifyRouteMeta } from '@/features/Verify/routeMeta';
 import { workspaceHomeRouteMeta } from '@/features/Workspace/routeMeta';
-import { agentRouteMeta } from '@/routes/(main)/agent/features/routeMeta';
+import { agentRouteMeta, topicsRouteMeta } from '@/routes/(main)/agent/features/routeMeta';
 import { groupRouteMeta } from '@/routes/(main)/group/features/routeMeta';
 import { settingsRouteMeta } from '@/routes/(main)/settings/features/routeMeta';
 import { shareTopicRouteMeta } from '@/routes/share/t/[id]/routeMeta';
@@ -108,6 +108,7 @@ export const sharedMainAreaChildren: RouteObject[] = [
               () => import('@/routes/(main)/agent/topics'),
               'Desktop > Chat > Topics',
             ),
+            handle: { meta: topicsRouteMeta },
             path: 'topics',
           },
           {


### PR DESCRIPTION
## 💡 Summary

The agent **Topics** page tab showed a bare **"LobeHub"** instead of reflecting the page + assistant (e.g. **"话题 · Lobe AI"**).

### Root cause

The Topics route (`/agent/:aid/topics`) was the only sub-route under an agent with **no `handle: { meta }`**. The desktop tab title is derived from the matched route's `routeMeta`; with none present, `useMatchedRouteMeta` found nothing and the tab fell back to `navigation.lobehub` → "LobeHub".

### Fix

- Add `topicsRouteMeta` in `src/routes/(main)/agent/features/routeMeta.ts`, mirroring `agentRouteMeta`'s `DynamicMeta` component pattern (with workspace scoping). It publishes a dynamic title combining the localized **Topics** label with the agent name: `[t('navigation.topics'), agentTitle].join(' · ')`.
- Wire `handle: { meta: topicsRouteMeta }` into **both** desktop router configs (`desktopRouter.config.tsx` and `desktopRouter.config.desktop.tsx`) to satisfy the `desktopRouter.sync` invariant.
- Add the `navigation.topics` i18n key to the `electron` namespace (default source + en-US + zh-CN "话题"). Other locales fill in via the daily i18n CI job.

## 🖼️ Result

The topics tab now renders **"Topics · <agent name>"** (e.g. **"话题 · Lobe AI"**), consistent with the chat tab format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)