### PR TITLE
🐛 fix: avoid Docker canvas tracing panic

### DIFF
--- a/src/libs/next/config/define-config.test.ts
+++ b/src/libs/next/config/define-config.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { defineConfig } from './define-config';
+
+describe('defineConfig', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('keeps Docker canvas tracing away from pnpm symlink directories', () => {
+    vi.stubEnv('DOCKER', 'true');
+    vi.stubEnv('NEXT_BUILD_STANDALONE', '');
+
+    const includes = defineConfig({}).outputFileTracingIncludes?.['*'] ?? [];
+
+    expect(includes).toContain('node_modules/@napi-rs/canvas/**/*');
+    expect(includes).toContain('node_modules/@napi-rs/canvas-*/package.json');
+    expect(includes).toContain('node_modules/@napi-rs/canvas-*/*.node');
+    expect(includes).toContain(
+      'node_modules/.pnpm/@napi-rs+canvas-*/node_modules/@napi-rs/canvas-*/package.json',
+    );
+    expect(includes).toContain(
+      'node_modules/.pnpm/@napi-rs+canvas-*/node_modules/@napi-rs/canvas-*/*.node',
+    );
+    expect(includes).not.toContain('node_modules/@napi-rs/canvas-*/**/*');
+    expect(includes).not.toContain('node_modules/.pnpm/@napi-rs+canvas*/**/*');
+    expect(includes).not.toContain('node_modules/.pnpm/@napi-rs+canvas-*/**/*');
+  });
+});

--- a/src/libs/next/config/define-config.test.ts
+++ b/src/libs/next/config/define-config.test.ts
@@ -1,29 +1,20 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { defineConfig } from './define-config';
+import { dockerCanvasTracingIncludes } from './dockerCanvasTracingIncludes';
 
-describe('defineConfig', () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
+describe('dockerCanvasTracingIncludes', () => {
   it('keeps Docker canvas tracing away from pnpm symlink directories', () => {
-    vi.stubEnv('DOCKER', 'true');
-    vi.stubEnv('NEXT_BUILD_STANDALONE', '');
-
-    const includes = defineConfig({}).outputFileTracingIncludes?.['*'] ?? [];
-
-    expect(includes).toContain('node_modules/@napi-rs/canvas/**/*');
-    expect(includes).toContain('node_modules/@napi-rs/canvas-*/package.json');
-    expect(includes).toContain('node_modules/@napi-rs/canvas-*/*.node');
-    expect(includes).toContain(
+    expect(dockerCanvasTracingIncludes).toContain('node_modules/@napi-rs/canvas/**/*');
+    expect(dockerCanvasTracingIncludes).toContain('node_modules/@napi-rs/canvas-*/package.json');
+    expect(dockerCanvasTracingIncludes).toContain('node_modules/@napi-rs/canvas-*/*.node');
+    expect(dockerCanvasTracingIncludes).toContain(
       'node_modules/.pnpm/@napi-rs+canvas-*/node_modules/@napi-rs/canvas-*/package.json',
     );
-    expect(includes).toContain(
+    expect(dockerCanvasTracingIncludes).toContain(
       'node_modules/.pnpm/@napi-rs+canvas-*/node_modules/@napi-rs/canvas-*/*.node',
     );
-    expect(includes).not.toContain('node_modules/@napi-rs/canvas-*/**/*');
-    expect(includes).not.toContain('node_modules/.pnpm/@napi-rs+canvas*/**/*');
-    expect(includes).not.toContain('node_modules/.pnpm/@napi-rs+canvas-*/**/*');
+    expect(dockerCanvasTracingIncludes).not.toContain('node_modules/@napi-rs/canvas-*/**/*');
+    expect(dockerCanvasTracingIncludes).not.toContain('node_modules/.pnpm/@napi-rs+canvas*/**/*');
+    expect(dockerCanvasTracingIncludes).not.toContain('node_modules/.pnpm/@napi-rs+canvas-*/**/*');
   });
 });

--- a/src/libs/next/config/define-config.ts
+++ b/src/libs/next/config/define-config.ts
@@ -2,6 +2,8 @@ import { codeInspectorPlugin } from 'code-inspector-plugin';
 import { type NextConfig } from 'next';
 import { type Header, type Redirect } from 'next/dist/lib/load-custom-routes';
 
+import { dockerCanvasTracingIncludes } from './dockerCanvasTracingIncludes';
+
 const LANDING_SITEMAP_URL = 'https://lobehub.com/sitemap.xml';
 
 interface CustomNextConfig {
@@ -47,14 +49,7 @@ export function defineConfig(config: CustomNextConfig) {
               // Ensure native bindings are included in standalone output.
               // `@napi-rs/canvas` is loaded via dynamic `require()` (see packages/file-loaders),
               // which may not be picked up by Next.js output tracing.
-              'node_modules/@napi-rs/canvas/**/*',
-              'node_modules/@napi-rs/canvas-*/package.json',
-              'node_modules/@napi-rs/canvas-*/*.node',
-              // Broad pnpm globs also match the symlink directory
-              // `.../@napi-rs/canvas-linux-x64-gnu`; Turbopack 16.3.0-preview.5
-              // tries to hash that directory as a file during Docker output tracing.
-              'node_modules/.pnpm/@napi-rs+canvas-*/node_modules/@napi-rs/canvas-*/package.json',
-              'node_modules/.pnpm/@napi-rs+canvas-*/node_modules/@napi-rs/canvas-*/*.node',
+              ...dockerCanvasTracingIncludes,
             ]
           : []),
       ],

--- a/src/libs/next/config/define-config.ts
+++ b/src/libs/next/config/define-config.ts
@@ -48,10 +48,13 @@ export function defineConfig(config: CustomNextConfig) {
               // `@napi-rs/canvas` is loaded via dynamic `require()` (see packages/file-loaders),
               // which may not be picked up by Next.js output tracing.
               'node_modules/@napi-rs/canvas/**/*',
-              'node_modules/@napi-rs/canvas-*/**/*',
-              // pnpm real package locations (including platform-specific bindings with `.node`)
-              'node_modules/.pnpm/@napi-rs+canvas*/**/*',
-              'node_modules/.pnpm/@napi-rs+canvas-*/**/*',
+              'node_modules/@napi-rs/canvas-*/package.json',
+              'node_modules/@napi-rs/canvas-*/*.node',
+              // Broad pnpm globs also match the symlink directory
+              // `.../@napi-rs/canvas-linux-x64-gnu`; Turbopack 16.3.0-preview.5
+              // tries to hash that directory as a file during Docker output tracing.
+              'node_modules/.pnpm/@napi-rs+canvas-*/node_modules/@napi-rs/canvas-*/package.json',
+              'node_modules/.pnpm/@napi-rs+canvas-*/node_modules/@napi-rs/canvas-*/*.node',
             ]
           : []),
       ],

--- a/src/libs/next/config/dockerCanvasTracingIncludes.ts
+++ b/src/libs/next/config/dockerCanvasTracingIncludes.ts
@@ -1,0 +1,10 @@
+export const dockerCanvasTracingIncludes = [
+  'node_modules/@napi-rs/canvas/**/*',
+  'node_modules/@napi-rs/canvas-*/package.json',
+  'node_modules/@napi-rs/canvas-*/*.node',
+  // Broad pnpm globs also match the symlink directory
+  // `.../@napi-rs/canvas-linux-x64-gnu`; Turbopack 16.3.0-preview.5
+  // tries to hash that directory as a file during Docker output tracing.
+  'node_modules/.pnpm/@napi-rs+canvas-*/node_modules/@napi-rs/canvas-*/package.json',
+  'node_modules/.pnpm/@napi-rs+canvas-*/node_modules/@napi-rs/canvas-*/*.node',
+];


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #16529

#### 🔀 Description of Change

This narrows Docker standalone output tracing for `@napi-rs/canvas` native platform packages.

The previous broad pnpm globs could also match the platform package symlink directory, for example `node_modules/.pnpm/@napi-rs+canvas@0.1.100/node_modules/@napi-rs/canvas-linux-x64-gnu`. With Next.js `16.3.0-preview.5` and Turbopack, Docker production builds may try to hash that directory as a file and fail with `Is a directory (os error 21)`.

The trace list now keeps the main `@napi-rs/canvas` package include, but limits platform packages to the files needed by their package entry points: `package.json` and `*.node` native bindings.

The trace patterns are kept in a small helper so the regression test can cover the Docker glob contract without pulling the full Next config file into app coverage.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated checks:

```bash
cd lobehub && rtk vitest run src/libs/next/config/define-config.test.ts
cd lobehub && rtk vitest run --coverage src/libs/next/config/define-config.test.ts
vscode-cli get-diagnostics
git -C lobehub diff --check -- src/libs/next/config/define-config.ts src/libs/next/config/define-config.test.ts src/libs/next/config/dockerCanvasTracingIncludes.ts
```

Coverage verification:

```bash
rg -n "SF:.*(define-config|dockerCanvasTracingIncludes)" lobehub/coverage/app/lcov.info
# Only src/libs/next/config/dockerCanvasTracingIncludes.ts should appear.
```

Docker verification:

- Clean Docker context reproduced the original Turbopack panic from #16529.
- With the narrowed canvas trace globs applied, the Docker build passed the original Turbopack failure and reached `Compiled successfully`.
- The local builder then failed later during page data collection with `cannot allocate memory`, so the full image was not completed locally.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This PR intentionally keeps Turbopack for Docker builds instead of forcing webpack. The fix is limited to the output tracing include list that exposed the directory-as-file failure.
