### PR TITLE
🐛 fix(conversation): anchor tail loading elapsed time to the last message

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -12,6 +12,7 @@ import Group from './Group';
 
 let mockIsCollapsed = false;
 let mockIsGenerating = false;
+let mockDbMessages: { createdAt?: Date | number | string | null; id: string }[] = [];
 
 vi.mock('@lobehub/ui', () => ({
   Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
@@ -46,7 +47,8 @@ vi.mock('../../../store', () => ({
     isMessageCollapsed: () => () => mockIsCollapsed,
     isMessageGenerating: () => () => mockIsGenerating,
   },
-  useConversationStore: (selector: (state: unknown) => unknown) => selector({}),
+  useConversationStore: (selector: (state: unknown) => unknown) =>
+    selector({ dbMessages: mockDbMessages }),
 }));
 
 vi.mock('./CollapsedMessage', () => ({
@@ -152,7 +154,9 @@ vi.mock('./GroupItem', () => ({
 }));
 
 vi.mock('@/features/Conversation/Messages/components/ContentLoading', () => ({
-  default: ({ id }: { id: string }) => <div data-id={id} data-testid="tail-running" />,
+  default: ({ id, startTime }: { id: string; startTime?: number }) => (
+    <div data-id={id} data-start-time={startTime} data-testid="tail-running" />
+  ),
 }));
 
 const blk = (p: Partial<AssistantContentBlock> & { id: string }): AssistantContentBlock =>
@@ -174,6 +178,7 @@ describe('Group', () => {
     cleanup();
     mockIsCollapsed = false;
     mockIsGenerating = false;
+    mockDbMessages = [];
   });
 
   it('keeps a long mixed single-tool block inline in its natural order', () => {
@@ -476,6 +481,39 @@ describe('Group', () => {
     );
 
     expect(screen.getByTestId('tail-running')).toHaveAttribute('data-id', 'assistant-1');
+  });
+
+  it('anchors the running indicator to the tool RESULT createdAt, not the tool-call block', () => {
+    mockIsGenerating = true;
+    // The tool result lands after the tool-call block; the tail timer must start
+    // from the result row so a long tool runtime is not folded back into elapsed.
+    mockDbMessages = [
+      { createdAt: 1000, id: 'block-1' },
+      { createdAt: 5000, id: 'tool-result-1' },
+    ];
+    render(
+      <Group
+        isLatestItem
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: '',
+            id: 'block-1',
+            tools: [
+              {
+                apiName: 'bash',
+                id: 'tool-1',
+                result: { content: 'done' },
+                result_msg_id: 'tool-result-1',
+              } as any,
+            ],
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId('tail-running')).toHaveAttribute('data-start-time', '5000');
   });
 
   it('hides the running indicator while the inline tool is still executing', () => {

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -84,6 +84,26 @@ const getTurnDurationMs = (
   return max > min ? max - min : 0;
 };
 
+/**
+ * `createdAt` of the turn's last step (its last child block resolved against the
+ * raw `dbMessages`), normalized to epoch ms. Used to anchor the tail running
+ * indicator's elapsed timer to "time since the last step" instead of the whole
+ * run — the operation's own startTime marks the run's beginning.
+ */
+const getLastBlockCreatedAt = (
+  dbMessages: { createdAt?: Date | number | string | null; id: string }[] | undefined,
+  lastBlockId: string | undefined,
+): number | undefined => {
+  if (!Array.isArray(dbMessages) || !lastBlockId) return undefined;
+  const message = dbMessages.find((item) => item.id === lastBlockId);
+  if (message?.createdAt == null) return undefined;
+  const time =
+    message.createdAt instanceof Date
+      ? message.createdAt.getTime()
+      : new Date(message.createdAt).getTime();
+  return Number.isNaN(time) ? undefined : time;
+};
+
 interface PartitionedBlocks {
   /** True while generating if long post-tool answer was moved outside the fold (tool phase UI may show “done”). */
   postToolTailPromoted: boolean;
@@ -416,6 +436,9 @@ const Group = memo<GroupChildrenProps>(
     const turnDurationMs = useConversationStore((s) => getTurnDurationMs(s.dbMessages, blocks));
     const contextValue = useMemo(() => ({ assistantGroupId: id }), [id]);
     const lastBlockId = blocks.at(-1)?.id;
+    const lastBlockCreatedAt = useConversationStore((s) =>
+      getLastBlockCreatedAt(s.dbMessages, lastBlockId),
+    );
 
     const { segments, postToolTailPromoted } = useMemo(
       () => partitionBlocks(blocks, isGenerating),
@@ -550,7 +573,9 @@ const Group = memo<GroupChildrenProps>(
           ) : (
             <>
               {segments.map((segment, index) => renderSegment(segment, index))}
-              {showTailRunningIndicator && <ContentLoading id={id} />}
+              {showTailRunningIndicator && (
+                <ContentLoading id={id} startTime={lastBlockCreatedAt} />
+              )}
             </>
           )}
         </Flexbox>

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -85,23 +85,38 @@ const getTurnDurationMs = (
 };
 
 /**
- * `createdAt` of the turn's last step (its last child block resolved against the
- * raw `dbMessages`), normalized to epoch ms. Used to anchor the tail running
- * indicator's elapsed timer to "time since the last step" instead of the whole
- * run — the operation's own startTime marks the run's beginning.
+ * `createdAt` of the turn's last step, normalized to epoch ms. Used to anchor the
+ * tail running indicator's elapsed timer to "time since the last step" instead of
+ * the whole run — the operation's own startTime marks the run's beginning.
+ *
+ * When the last block ends on tool calls, its freshest message is the tool RESULT
+ * row (`result_msg_id`), created when the tool finished — not the assistant block
+ * that issued the call. Anchoring to the block id alone would fold the tool's
+ * runtime back into the elapsed time, defeating the point. So we take the latest
+ * `createdAt` across the block and its tool-result rows.
  */
 const getLastBlockCreatedAt = (
   dbMessages: { createdAt?: Date | number | string | null; id: string }[] | undefined,
-  lastBlockId: string | undefined,
+  lastBlock: AssistantContentBlock | undefined,
 ): number | undefined => {
-  if (!Array.isArray(dbMessages) || !lastBlockId) return undefined;
-  const message = dbMessages.find((item) => item.id === lastBlockId);
-  if (message?.createdAt == null) return undefined;
-  const time =
-    message.createdAt instanceof Date
-      ? message.createdAt.getTime()
-      : new Date(message.createdAt).getTime();
-  return Number.isNaN(time) ? undefined : time;
+  if (!Array.isArray(dbMessages) || !lastBlock) return undefined;
+
+  const candidateIds = new Set<string>([lastBlock.id]);
+  for (const tool of lastBlock.tools ?? []) {
+    if (tool.result_msg_id) candidateIds.add(tool.result_msg_id);
+  }
+
+  let latest: number | undefined;
+  for (const message of dbMessages) {
+    if (!candidateIds.has(message.id) || message.createdAt == null) continue;
+    const time =
+      message.createdAt instanceof Date
+        ? message.createdAt.getTime()
+        : new Date(message.createdAt).getTime();
+    if (Number.isNaN(time)) continue;
+    if (latest === undefined || time > latest) latest = time;
+  }
+  return latest;
 };
 
 interface PartitionedBlocks {
@@ -435,9 +450,10 @@ const Group = memo<GroupChildrenProps>(
     );
     const turnDurationMs = useConversationStore((s) => getTurnDurationMs(s.dbMessages, blocks));
     const contextValue = useMemo(() => ({ assistantGroupId: id }), [id]);
-    const lastBlockId = blocks.at(-1)?.id;
+    const lastBlock = blocks.at(-1);
+    const lastBlockId = lastBlock?.id;
     const lastBlockCreatedAt = useConversationStore((s) =>
-      getLastBlockCreatedAt(s.dbMessages, lastBlockId),
+      getLastBlockCreatedAt(s.dbMessages, lastBlock),
     );
 
     const { segments, postToolTailPromoted } = useMemo(

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.test.tsx
@@ -9,6 +9,7 @@ import MessageContent from './MessageContent';
 
 let mockStoreContent = 'original full content';
 let mockStoreHasTools = true;
+let mockStoreMessage: { createdAt?: number } | undefined = { createdAt: 1000 };
 
 vi.mock('antd-style', () => ({
   createStaticStyles: () => ({
@@ -33,6 +34,7 @@ vi.mock('../../../store', () => ({
   dataSelectors: {
     getBlockContent: () => () => mockStoreContent,
     getBlockHasTools: () => () => mockStoreHasTools,
+    getDbMessageById: () => () => mockStoreMessage,
   },
   useConversationStore: (selector: (state: unknown) => unknown) => selector({}),
 }));
@@ -51,6 +53,7 @@ describe('MessageContent', () => {
     useMarkdownMock.mockClear();
     mockStoreContent = 'original full content';
     mockStoreHasTools = true;
+    mockStoreMessage = { createdAt: 1000 };
   });
 
   it('renders explicit content override instead of the same-id store content', () => {

--- a/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/MessageContent.tsx
@@ -32,17 +32,27 @@ const MessageContent = memo<MessageContentProps>(
     const content = contentOverride ?? storeContent;
     const hasTools = hasToolsOverride ?? storeHasTools;
 
+    // Anchor the loading timer to this block's own createdAt (the freshest
+    // message) rather than the run-start operation startTime, so an in-flight
+    // block counts "time since this step began" instead of the whole run.
+    const createdAt = useConversationStore((s) => {
+      const value = dataSelectors.getDbMessageById(id)(s)?.createdAt;
+      if (value == null) return undefined;
+      const ms = new Date(value).getTime();
+      return Number.isFinite(ms) ? ms : undefined;
+    });
+
     const message = normalizeThinkTags(processWithArtifact(content ?? ''));
     // Once a tool call exists below this block's text, the text is already
     // finalized — skip the streaming/fade-in animation so settled content above
     // a tool doesn't keep re-animating.
     const { drawer, markdownProps } = useMarkdown(id, disableStreaming || hasTools);
 
-    if (!content && !hasTools) return <ContentLoading id={id} />;
+    if (!content && !hasTools) return <ContentLoading id={id} startTime={createdAt} />;
 
     if (content === LOADING_FLAT) {
       if (hasTools) return null;
-      return <ContentLoading id={id} />;
+      return <ContentLoading id={id} startTime={createdAt} />;
     }
 
     const isSingleLine = (message || '').split('\n').length <= 2;

--- a/src/features/Conversation/Messages/components/ContentLoading.tsx
+++ b/src/features/Conversation/Messages/components/ContentLoading.tsx
@@ -28,13 +28,24 @@ const DEDICATED_OPERATION_LABELS = new Set<OperationType>([
 
 interface ContentLoadingProps {
   id: string;
+  /**
+   * Anchor the elapsed-time counter to this timestamp instead of the operation's
+   * startTime. The operation's startTime marks the whole run's beginning (the run-
+   * start assistant message), so a tail indicator sitting after several completed
+   * steps would count the entire run. Passing the last message's `createdAt` here
+   * makes the counter reflect "time since the last step" instead.
+   */
+  startTime?: number;
 }
 
-const ContentLoading = memo<ContentLoadingProps>(({ id }) => {
+const ContentLoading = memo<ContentLoadingProps>(({ id, startTime: startTimeOverride }) => {
   const { t } = useTranslation('chat');
   const runningOp = useChatStore(operationSelectors.getDeepestRunningOperationByMessage(id));
 
-  const startTime = runningOp?.metadata?.startTime;
+  const startTime =
+    startTimeOverride !== undefined && Number.isFinite(startTimeOverride)
+      ? startTimeOverride
+      : runningOp?.metadata?.startTime;
   const operationType = runningOp?.type as OperationType | undefined;
 
   const [elapsedSeconds, setElapsedSeconds] = useState(() =>


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

The tail running indicator (`ContentLoading`, e.g. "任务正在服务器运行… (Ns)") counted its elapsed time from the running operation's `startTime`. For a server/remote runtime op (`execServerAgentRuntime`) that op spans the **whole run**, and on reconnect its `startTime` is deliberately anchored to the run-start assistant message's `createdAt` (so `OpStatusTray` preserves total elapsed across a page refresh).

As a result, a tail loading indicator sitting **after several completed steps** showed the entire run's elapsed time (e.g. `616s`) instead of "time since the last step".

**Fix** — add an optional `startTime` override to `ContentLoading`, and feed it the last message's `createdAt`:

- `Group.tsx` — the tail running indicator now anchors to the group's **last child block** `createdAt` (resolved against `dbMessages`, reusing the same idiom as the existing `getTurnDurationMs` helper).
- `MessageContent.tsx` — an in-flight empty block anchors to **its own** `createdAt`.
- `ContentLoading.tsx` — new optional `startTime` prop; falls back to the operation `startTime` when not provided (with an `Number.isFinite` guard).

`OpStatusTray` still reads the operation `startTime`, so its total-elapsed-across-refresh behavior is unchanged. `createdAt` is normalized via `new Date(x).getTime()` (post-DB-rehydrate it can be a `Date`/string), falling back to the operation `startTime` when unresolved.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Open a topic where a server/remote agent runs multiple steps (or reopen the page mid-run). The tail loading counter should reflect time since the **last** step/message, not the whole run.

#### 📝 Additional Information

Scoped intentionally to the step-level / tail loading indicators; the input-area `OpStatusTray` total-run timer is unchanged.