### PR TITLE
💄 style(topic): move view-toggle next to sort control in toolbar

### DIFF
--- a/src/features/AgentTopicManager/Header.tsx
+++ b/src/features/AgentTopicManager/Header.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { Flexbox, Icon, Input, Text, Tooltip } from '@lobehub/ui';
-import { Tabs } from '@lobehub/ui/base-ui';
+import { Icon, Input, Text } from '@lobehub/ui';
 import { Breadcrumb as AntBreadcrumb } from 'antd';
-import { ChevronRight, LayoutGrid, List as ListIcon, Search } from 'lucide-react';
+import { ChevronRight, Search } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
@@ -27,8 +26,6 @@ const Header = memo<HeaderProps>(({ agentId }) => {
   const displayTitle = isInbox
     ? agentTitle || t('inbox.title', { ns: 'chat' })
     : agentTitle || t('defaultSession', { ns: 'common' });
-  const viewMode = useTopicsViewStore((s) => s.viewMode);
-  const setViewMode = useTopicsViewStore((s) => s.setViewMode);
   const search = useTopicsViewStore((s) => s.search);
   const setSearch = useTopicsViewStore((s) => s.setSearch);
 
@@ -57,33 +54,6 @@ const Header = memo<HeaderProps>(({ agentId }) => {
             },
           ]}
         />
-      }
-      right={
-        <Flexbox horizontal align={'center'} gap={6}>
-          <Tabs
-            activeKey={viewMode}
-            size={'small'}
-            items={[
-              {
-                key: 'card',
-                label: (
-                  <Tooltip title={t('management.view.card')}>
-                    <Icon icon={LayoutGrid} />
-                  </Tooltip>
-                ),
-              },
-              {
-                key: 'list',
-                label: (
-                  <Tooltip title={t('management.view.list')}>
-                    <Icon icon={ListIcon} />
-                  </Tooltip>
-                ),
-              },
-            ]}
-            onChange={(key) => setViewMode(key as 'card' | 'list')}
-          />
-        </Flexbox>
       }
     >
       <Input

--- a/src/features/AgentTopicManager/Toolbar.tsx
+++ b/src/features/AgentTopicManager/Toolbar.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { ActionIcon, type DropdownItem, DropdownMenu, Flexbox, Icon, Text } from '@lobehub/ui';
+import {
+  ActionIcon,
+  type DropdownItem,
+  DropdownMenu,
+  Flexbox,
+  Icon,
+  Text,
+  Tooltip,
+} from '@lobehub/ui';
 import { confirmModal, Tabs } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
@@ -9,6 +17,8 @@ import {
   CalendarRange,
   ChevronDown,
   FolderClosed,
+  LayoutGrid,
+  List as ListIcon,
   ListFilter,
   ListTodoIcon,
   type LucideIcon,
@@ -220,6 +230,8 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts }) => {
   const setSortBy = useTopicsViewStore((s) => s.setSortBy);
   const groupBy = useTopicsViewStore((s) => s.groupBy);
   const setGroupBy = useTopicsViewStore((s) => s.setGroupBy);
+  const viewMode = useTopicsViewStore((s) => s.viewMode);
+  const setViewMode = useTopicsViewStore((s) => s.setViewMode);
 
   const triggerItems: DropdownItem[] = useMemo(
     () =>
@@ -477,6 +489,33 @@ const Toolbar = memo<ToolbarProps>(({ projects, statusCounts }) => {
       )}
 
       <Flexbox flex={1} />
+
+      <Tabs
+        activeKey={viewMode}
+        size={'small'}
+        style={{ width: 'auto' }}
+        items={[
+          {
+            key: 'card',
+            label: (
+              <Tooltip title={t('management.view.card')}>
+                <Icon icon={LayoutGrid} />
+              </Tooltip>
+            ),
+          },
+          {
+            key: 'list',
+            label: (
+              <Tooltip title={t('management.view.list')}>
+                <Icon icon={ListIcon} />
+              </Tooltip>
+            ),
+          },
+        ]}
+        onChange={(key) => setViewMode(key as 'card' | 'list')}
+      />
+
+      <span className={styles.divider} />
 
       <DropdownMenu items={sortItems}>
         <span className={styles.sortPill}>


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 💄 style

### 🔀 变更说明 | Description of Change

Moves the topic list card/list view-toggle from the top-right corner of the page header into the toolbar, placing it directly next to the sort control (`排序`). The two controls now sit together on the right side of the toolbar, separated by the same thin divider used elsewhere in the toolbar, and the header's top-right corner is now clear.

- `Toolbar.tsx` — renders the view-toggle `Tabs` (card/list) before the sort pill, wired to `viewMode`/`setViewMode` from the topics view store.
- `Header.tsx` — removes the view-toggle and its now-unused imports/state.

No behavior change to the toggle itself — same store state, same options.

### 📝 补充信息 | Additional Information

Purely a UI placement change; view mode continues to be persisted via the existing Zustand store.