### PR TITLE
🐛 fix: correct Codex cached input usage

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/codex.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/codex.test.ts
@@ -839,10 +839,10 @@ describe('CodexAdapter', () => {
     const adapter = new CodexAdapter({
       initialCumulativeUsage: {
         inputCachedTokens: 42_000,
-        inputCacheMissTokens: 52_000,
-        totalInputTokens: 94_000,
+        inputCacheMissTokens: 9_000,
+        totalInputTokens: 51_000,
         totalOutputTokens: 300,
-        totalTokens: 94_300,
+        totalTokens: 51_300,
       },
     });
     const rawEvents = await loadFixture('collab_tool_call.spawn_wait.jsonl');
@@ -898,10 +898,10 @@ describe('CodexAdapter', () => {
       data: {
         usage: {
           inputCachedTokens: 1008,
-          inputCacheMissTokens: 937,
-          totalInputTokens: 1945,
+          inputCacheMissTokens: 929,
+          totalInputTokens: 1937,
           totalOutputTokens: 116,
-          totalTokens: 2061,
+          totalTokens: 2053,
         },
       },
     });
@@ -1075,10 +1075,10 @@ describe('CodexAdapter', () => {
         provider: 'codex',
         usage: {
           inputCachedTokens: 4,
-          inputCacheMissTokens: 10,
-          totalInputTokens: 14,
+          inputCacheMissTokens: 6,
+          totalInputTokens: 10,
           totalOutputTokens: 3,
-          totalTokens: 17,
+          totalTokens: 13,
         },
       },
       type: 'step_complete',
@@ -1089,10 +1089,10 @@ describe('CodexAdapter', () => {
     const adapter = new CodexAdapter({
       initialCumulativeUsage: {
         inputCachedTokens: 4,
-        inputCacheMissTokens: 10,
-        totalInputTokens: 14,
+        inputCacheMissTokens: 6,
+        totalInputTokens: 10,
         totalOutputTokens: 3,
-        totalTokens: 17,
+        totalTokens: 13,
       },
     });
 
@@ -1111,10 +1111,10 @@ describe('CodexAdapter', () => {
         provider: 'codex',
         usage: {
           inputCachedTokens: 5,
-          inputCacheMissTokens: 15,
-          totalInputTokens: 20,
+          inputCacheMissTokens: 10,
+          totalInputTokens: 15,
           totalOutputTokens: 8,
-          totalTokens: 28,
+          totalTokens: 23,
         },
       },
       type: 'step_complete',

--- a/packages/heterogeneous-agents/src/spawn/codexModel.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/codexModel.test.ts
@@ -133,10 +133,10 @@ describe('codex model metadata helpers', () => {
     ).resolves.toMatchObject({
       cumulativeUsage: {
         inputCachedTokens: 5,
-        inputCacheMissTokens: 25,
-        totalInputTokens: 30,
+        inputCacheMissTokens: 20,
+        totalInputTokens: 25,
         totalOutputTokens: 9,
-        totalTokens: 39,
+        totalTokens: 34,
       },
     });
   });

--- a/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/spawnAgent.test.ts
@@ -257,7 +257,7 @@ describe('spawnAgent', () => {
       path.join(sessionDir, `rollout-2026-06-11T01-31-27-${threadId}.jsonl`),
       JSON.stringify({
         type: 'turn.completed',
-        usage: { cached_input_tokens: 42_000, input_tokens: 52_000, output_tokens: 300 },
+        usage: { cached_input_tokens: 42_000, input_tokens: 51_000, output_tokens: 300 },
       }),
     );
 
@@ -288,10 +288,10 @@ describe('spawnAgent', () => {
         phase: 'turn_metadata',
         usage: {
           inputCachedTokens: 1008,
-          inputCacheMissTokens: 937,
-          totalInputTokens: 1945,
+          inputCacheMissTokens: 929,
+          totalInputTokens: 1937,
           totalOutputTokens: 116,
-          totalTokens: 2061,
+          totalTokens: 2053,
         },
       },
       type: 'step_complete',

--- a/packages/heterogeneous-agents/src/utils/codexUsage.ts
+++ b/packages/heterogeneous-agents/src/utils/codexUsage.ts
@@ -11,9 +11,10 @@ export const toCodexUsageData = (
 ): UsageData | undefined => {
   if (!raw) return undefined;
 
-  const inputCacheMissTokens = raw.input_tokens || 0;
   const inputCachedTokens = raw.cached_input_tokens || 0;
-  const totalInputTokens = inputCacheMissTokens + inputCachedTokens;
+  // Codex reports `input_tokens` as total input; cached input is a subset.
+  const totalInputTokens = Math.max(raw.input_tokens || 0, inputCachedTokens);
+  const inputCacheMissTokens = Math.max(0, totalInputTokens - inputCachedTokens);
   const totalOutputTokens = raw.output_tokens || 0;
 
   if (totalInputTokens + totalOutputTokens === 0) return undefined;

--- a/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
@@ -1472,7 +1472,7 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
           codexThreadStarted(),
           codexTurnStarted(),
           codexAgentMessage('item_0', 'Done.'),
-          codexTurnCompleted({ cached_input_tokens: 4, input_tokens: 6, output_tokens: 3 }),
+          codexTurnCompleted({ cached_input_tokens: 4, input_tokens: 10, output_tokens: 3 }),
         ],
         {
           params: {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Correct Codex usage normalization so `input_tokens` is treated as total input tokens.
- Treat `cached_input_tokens` as a subset of input, deriving uncached input as `totalInputTokens - inputCachedTokens`.
- Update Codex adapter, resume, session metadata, and DB persistence test expectations.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
cd packages/heterogeneous-agents && bunx vitest run --silent='passed-only' src/adapters/codex.test.ts src/spawn/codexModel.test.ts src/spawn/spawnAgent.test.ts
bunx vitest run --silent='passed-only' src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This fixes newly persisted Codex usage metadata. Historical rows that were already written with the old double-counted shape are not backfilled by this PR.
