### PR TITLE
🐛 fix(desktop): route hetero intervention submit through its own conversation context

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Detail/Intervention/index.tsx
@@ -4,7 +4,6 @@ import { Flexbox } from '@lobehub/ui';
 import { memo, Suspense, useCallback, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-import { useChatStore } from '@/store/chat';
 import { useUserStore } from '@/store/user';
 import { toolInterventionSelectors } from '@/store/user/selectors';
 
@@ -102,9 +101,11 @@ const Intervention = memo<InterventionProps>(
     const cancelToolInteraction = useConversationStore((s) => s.cancelToolInteraction);
     // Hetero (CC / Codex) interventions ship the answer back through IPC to a
     // running CLI subprocess instead of starting a fresh `executeClientAgent`
-    // turn. Pull the chat-store action lazily so non-hetero interactions stay
-    // on the existing path with no behavior change.
-    const submitHeteroIntervention = useChatStore((s) => s.submitHeteroIntervention);
+    // turn. Route through the conversation store so it carries this card's own
+    // `context` (agent/topic) to the chat store — otherwise the optimistic
+    // writes and topic-status flip fall back to the global `activeTopicId` and
+    // land on whichever topic the user is currently viewing.
+    const submitHeteroIntervention = useConversationStore((s) => s.submitHeteroIntervention);
 
     const handleInteractionAction = useCallback(
       async (

--- a/src/features/Conversation/store/slices/tool/action.test.ts
+++ b/src/features/Conversation/store/slices/tool/action.test.ts
@@ -8,6 +8,7 @@ import { createStore } from '../../index';
 const mockApproveToolCalling = vi.fn();
 const mockRejectToolCalling = vi.fn();
 const mockRejectAndContinueToolCalling = vi.fn();
+const mockSubmitHeteroIntervention = vi.fn();
 
 vi.mock('@/store/chat', () => ({
   useChatStore: {
@@ -17,6 +18,7 @@ vi.mock('@/store/chat', () => ({
       approveToolCalling: mockApproveToolCalling,
       rejectToolCalling: mockRejectToolCalling,
       rejectAndContinueToolCalling: mockRejectAndContinueToolCalling,
+      submitHeteroIntervention: mockSubmitHeteroIntervention,
       cancelOperations: vi.fn(),
       cancelOperation: vi.fn(),
       deleteMessage: vi.fn(),
@@ -157,6 +159,53 @@ describe('Tool Actions', () => {
       });
 
       expect(onToolCallComplete).toHaveBeenCalledWith('tool-call-1', undefined);
+    });
+  });
+
+  describe('submitHeteroIntervention', () => {
+    it('should pass this conversation context to ChatStore, not fall back to global activeTopicId', async () => {
+      // Regression: the hetero path used to call the chat store directly with no
+      // context, so optimistic writes / topic-status flip landed on whatever
+      // topic the user was viewing (global activeTopicId) instead of the card's.
+      const context: ConversationContext = {
+        agentId: 'agent-1',
+        topicId: 'card-topic',
+        threadId: null,
+      };
+
+      const store = createStore({ context });
+
+      await act(async () => {
+        await store.getState().submitHeteroIntervention('tool-msg-1', 'submit', { answer: 'ok' });
+      });
+
+      expect(mockSubmitHeteroIntervention).toHaveBeenCalledWith(
+        'tool-msg-1',
+        'submit',
+        { answer: 'ok' },
+        context,
+      );
+    });
+
+    it('should forward skip / cancel action types with context', async () => {
+      const context: ConversationContext = {
+        agentId: 'agent-2',
+        topicId: 'card-topic-2',
+        threadId: null,
+      };
+
+      const store = createStore({ context });
+
+      await act(async () => {
+        await store.getState().submitHeteroIntervention('tool-msg-2', 'skip');
+      });
+
+      expect(mockSubmitHeteroIntervention).toHaveBeenCalledWith(
+        'tool-msg-2',
+        'skip',
+        undefined,
+        context,
+      );
     });
   });
 

--- a/src/features/Conversation/store/slices/tool/action.ts
+++ b/src/features/Conversation/store/slices/tool/action.ts
@@ -119,6 +119,24 @@ export class ToolActionImpl {
     const chatStore = useChatStore.getState();
     await chatStore.submitToolInteraction(toolMessageId, response, context, options);
   };
+
+  /**
+   * Hetero (CC / Codex) intervention submit/skip/cancel. Unlike the other tool
+   * interactions this ships the answer back to a running CLI subprocess over
+   * IPC, but it still needs this conversation's own `context` so the optimistic
+   * writes and topic-status flip land on the topic that owns the card — not
+   * whatever topic the user happens to be viewing (which is what the chatStore
+   * falls back to via global `activeTopicId`).
+   */
+  submitHeteroIntervention = async (
+    toolMessageId: string,
+    actionType: 'submit' | 'skip' | 'cancel',
+    payload?: Record<string, unknown>,
+  ): Promise<void> => {
+    const { context } = this.#get();
+    const chatStore = useChatStore.getState();
+    await chatStore.submitHeteroIntervention(toolMessageId, actionType, payload, context);
+  };
 }
 
 export type ToolAction = Pick<ToolActionImpl, keyof ToolActionImpl>;

--- a/src/features/GlobalApprovalNotification/styles.ts
+++ b/src/features/GlobalApprovalNotification/styles.ts
@@ -14,6 +14,8 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     }
   `,
   card: css`
+    pointer-events: auto;
+
     overflow: hidden;
     display: flex;
     flex-direction: column;
@@ -24,12 +26,11 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
     background: ${cssVar.colorBgElevated};
     box-shadow: ${cssVar.boxShadowSecondary};
-
-    pointer-events: auto;
   `,
   content: css`
     overflow-y: auto;
     flex: 1;
+
     min-height: 0;
     max-height: 42vh;
     padding-block: 6px 8px;
@@ -51,6 +52,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   headerSubtitle: css`
     overflow: hidden;
+
     font-size: 12px;
     color: ${cssVar.colorTextTertiary};
     text-overflow: ellipsis;
@@ -58,6 +60,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   headerTitle: css`
     overflow: hidden;
+
     font-size: 13px;
     font-weight: 500;
     color: ${cssVar.colorText};
@@ -67,17 +70,18 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   // "+N more pending" hint shown when several conversations are waiting; only
   // the top card is actionable at once.
   moreHint: css`
+    pointer-events: auto;
+
     align-self: center;
 
     padding-block: 2px;
 
     font-size: 12px;
     color: ${cssVar.colorTextTertiary};
-
-    pointer-events: auto;
   `,
   // Collapsed "dynamic island" pill.
   pill: css`
+    pointer-events: auto;
     cursor: pointer;
 
     display: flex;
@@ -94,14 +98,14 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
     background: ${cssVar.colorBgElevated};
     box-shadow: ${cssVar.boxShadowSecondary};
-
-    pointer-events: auto;
   `,
   pillDot: css`
     flex-shrink: 0;
+
     width: 7px;
     height: 7px;
     border-radius: 999px;
+
     background: ${cssVar.colorPrimary};
   `,
   stack: css`
@@ -128,15 +132,14 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorTextTertiary};
   `,
   userRequestText: css`
-    display: -webkit-box;
     overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
 
     font-size: 12px;
     color: ${cssVar.colorTextSecondary};
     text-overflow: ellipsis;
-
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
   `,
   // Top-center fixed wrapper. The wrapper ignores pointer events so it never
   // blocks the page; only the cards / pill re-enable them.
@@ -147,13 +150,12 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     z-index: 1000;
     inset-block-start: var(--global-approval-top, 16px);
     inset-inline-start: 50%;
+    transform: translateX(-50%);
 
     display: flex;
     flex-direction: column;
     align-items: center;
 
-    width: min(420px, 92vw);
-
-    transform: translateX(-50%);
+    width: min(520px, 92vw);
   `,
 }));

--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationControl.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationControl.test.ts
@@ -2013,5 +2013,79 @@ describe('ConversationControl actions', () => {
         }),
       );
     });
+
+    it('flips topic status on the passed context, NOT the active topic, when submitting from a background conversation', async () => {
+      // Regression: submitting a hetero intervention from the global approval
+      // card while the user is viewing a DIFFERENT topic must flip *that card's*
+      // topic back to `running` — not whatever topic is currently active. Before
+      // the fix the chat store fell back to `activeTopicId`, so the unrelated
+      // topic the user was looking at flickered into a loading/running state.
+      const { result } = renderHook(() => useChatStore());
+
+      const agentId = 'hetero-agent';
+      const cardTopicId = 'background-topic';
+      const activeTopicId = 'the-topic-user-is-viewing';
+      const chatKey = messageMapKey({ agentId, topicId: cardTopicId });
+
+      const assistantMessage = createMockMessage({ id: 'assistant-msg-1', role: 'assistant' });
+      const toolMessage = createMockMessage({
+        id: 'tool-msg-1',
+        parentId: assistantMessage.id,
+        plugin: {
+          apiName: 'askUserQuestion',
+          arguments: '{}',
+          identifier: 'lobe-claude-code',
+          type: 'default',
+        },
+        role: 'tool',
+        tool_call_id: 'cc_call_1',
+      } as any);
+
+      let assistantOpId!: string;
+      act(() => {
+        useChatStore.setState({
+          // The user is parked on a completely different topic.
+          activeAgentId: agentId,
+          activeThreadId: undefined,
+          activeTopicId,
+          dbMessagesMap: { [chatKey]: [assistantMessage, toolMessage] },
+          messagesMap: { [chatKey]: [assistantMessage, toolMessage] },
+        });
+
+        assistantOpId = result.current.startOperation({
+          context: { agentId, topicId: cardTopicId, threadId: null },
+          type: 'execHeterogeneousAgent',
+        }).operationId;
+
+        useChatStore.setState((s) => ({
+          messageOperationMap: { ...s.messageOperationMap, [assistantMessage.id]: assistantOpId },
+        }));
+      });
+
+      vi.spyOn(result.current, 'optimisticUpdateMessagePlugin').mockResolvedValue(undefined);
+      vi.spyOn(result.current, 'optimisticUpdateMessageContent').mockResolvedValue(undefined);
+      const updateTopicStatusSpy = vi
+        .spyOn(result.current, 'updateTopicStatus')
+        .mockResolvedValue(undefined as any);
+      vi.spyOn(heterogeneousAgentService, 'submitIntervention').mockResolvedValue(undefined as any);
+
+      await act(async () => {
+        await result.current.submitHeteroIntervention(
+          'tool-msg-1',
+          'submit',
+          { 'Which color?': 'Blue' },
+          { agentId, threadId: undefined, topicId: cardTopicId },
+        );
+      });
+
+      // The card's own topic flips to running...
+      expect(updateTopicStatusSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'running', topicId: cardTopicId }),
+      );
+      // ...and the topic the user is currently viewing is never touched.
+      expect(updateTopicStatusSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ topicId: activeTopicId }),
+      );
+    });
   });
 });


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

The global approval card lets you answer a Claude Code / Codex (hetero) intervention that belongs to a **background** topic while you are viewing a **different** one.

The hetero submit path (`Intervention/index.tsx`) called `chatStore.submitHeteroIntervention` **directly, with no context**, so the optimistic writes and the topic-status flip fell back to the global `activeTopicId`. Result: submitting the card flipped **whatever topic the user was currently looking at** into a loading/running state, instead of the topic that actually owns the card.

Fix — thread the card's own `context` all the way through, matching the other tool-interaction actions:

- `Intervention/index.tsx` now pulls `submitHeteroIntervention` from the **conversation store** (which knows this card's `context`) instead of the global chat store.
- `ToolActionImpl.submitHeteroIntervention` (conversation store) forwards that `context` to `chatStore.submitHeteroIntervention`.
- `conversationControl.ts` already derives `effectiveContext = context ?? global-fallback` and drives `updateTopicStatus` from `effectiveContext.topicId/agentId` — so with a real context passed, the flip now lands on the correct topic.

Also widens the global approval card `min(420px → 520px, 92vw)` so its footer (type-directly link · countdown · Skip · Submit) no longer feels cramped.

> Follow-up (out of scope here): audit the remaining `activeTopicId` fallbacks in the chat store for the same "acts on the active tab, not the target conversation" class of bug.

#### 🧪 How to Test

1. Start a Claude Code / Codex run in topic A that raises an `askUserQuestion` intervention.
2. Switch to topic B (different tab).
3. Answer the intervention from the **global approval card** (without navigating back to A).
4. Expect: topic **A** flips to running; topic **B** (the one you're viewing) is untouched. Before the fix, B incorrectly showed loading.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Regression tests added at both layers:
- `slices/tool/action.test.ts` — asserts the conversation `context` is forwarded to the chat store (not dropped).
- `agentRun/actions/__tests__/conversationControl.test.ts` — asserts `updateTopicStatus` fires for the **passed** context's topic and **never** for the active topic when submitting from a background conversation.