### PR TITLE
🐛 fix(agent-builder): prevent suggestion refresh on autosave

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/arvinxx/CodeProjects/LobeHub/lobehub/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/arvinxx/CodeProjects/LobeHub/lobehub/node_modules

--- a/src/features/AgentBuilder/SuggestionChips/index.tsx
+++ b/src/features/AgentBuilder/SuggestionChips/index.tsx
@@ -104,7 +104,7 @@ interface SuggestionChipsProps {
 const SuggestionChips = memo<SuggestionChipsProps>(
   ({ mode, builderAgentId, count = 3, disabled }) => {
     const { t: tCommon } = useTranslation('common');
-    const { contextSummary, generationMode, locale } = useBuilderContext(mode);
+    const { contextSummary, generationMode, locale, targetId } = useBuilderContext(mode);
 
     const builderConfig = useAgentStore((s) =>
       agentByIdSelectors.getAgentConfigById(builderAgentId)(s),
@@ -120,6 +120,7 @@ const SuggestionChips = memo<SuggestionChipsProps>(
       mode: generationMode,
       model: model ?? '',
       provider: provider ?? '',
+      targetId,
     });
 
     // First load with nothing to show yet — card-shaped skeleton that keeps the

--- a/src/features/AgentBuilder/SuggestionChips/useBuilderContext.ts
+++ b/src/features/AgentBuilder/SuggestionChips/useBuilderContext.ts
@@ -61,6 +61,7 @@ export interface BuilderContext {
   contextSummary: string;
   generationMode: BuilderSuggestionMode;
   locale: string;
+  targetId?: string;
 }
 
 /**
@@ -88,5 +89,10 @@ export const useBuilderContext = (mode: SuggestMode): BuilderContext => {
     [isGroup, agentItem, group],
   );
 
-  return { contextSummary, generationMode: isGroup ? 'group' : 'agent', locale: i18n.language };
+  return {
+    contextSummary,
+    generationMode: isGroup ? 'group' : 'agent',
+    locale: i18n.language,
+    targetId: isGroup ? activeGroupId : activeAgentId,
+  };
 };

--- a/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.test.tsx
+++ b/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.test.tsx
@@ -1,0 +1,140 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { createElement } from 'react';
+import { SWRConfig } from 'swr';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { aiChatService } from '@/services/aiChat';
+
+import { useBuilderSuggestions } from './useBuilderSuggestions';
+
+type GenerateJSONResult = Awaited<ReturnType<typeof aiChatService.generateJSON>>;
+type RecordTracingFeedbackResult = Awaited<ReturnType<typeof aiChatService.recordTracingFeedback>>;
+
+const makeEnvelope = (label: string) =>
+  ({
+    data: {
+      suggestions: [
+        {
+          prompt: `${label} prompt`,
+          title: `${label} title`,
+        },
+      ],
+    },
+    tracingId: `trace-${label}`,
+  }) as GenerateJSONResult;
+
+const baseParams = {
+  builderAgentId: 'builder-agent',
+  contextSummary: 'initial context',
+  enabled: true,
+  locale: 'zh-CN',
+  mode: 'agent',
+  model: 'model-a',
+  provider: 'provider-a',
+  targetId: 'target-agent',
+} satisfies Parameters<typeof useBuilderSuggestions>[0];
+
+const createSWRWrapper = () => {
+  const value = { provider: () => new Map() };
+
+  return function SWRTestWrapper({ children }: PropsWithChildren) {
+    return createElement(SWRConfig, { value }, children);
+  };
+};
+
+const waitForNextTick = async () => {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+};
+
+const getGeneratedUserContent = (callIndex: number) => {
+  const [params] = vi.mocked(aiChatService.generateJSON).mock.calls[callIndex];
+  const userMessage = params.messages.find((message) => message.role === 'user');
+
+  return String(userMessage?.content ?? '');
+};
+
+describe('useBuilderSuggestions', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(aiChatService, 'generateJSON').mockResolvedValue(makeEnvelope('first'));
+    vi.spyOn(aiChatService, 'recordTracingFeedback').mockResolvedValue({
+      ok: true,
+    } as RecordTracingFeedbackResult);
+  });
+
+  it('does not regenerate when autosave updates context for the same target', async () => {
+    const { rerender, result } = renderHook((props) => useBuilderSuggestions(props), {
+      initialProps: baseParams,
+      wrapper: createSWRWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.suggestions[0]?.title).toBe('first title');
+    });
+    expect(aiChatService.generateJSON).toHaveBeenCalledTimes(1);
+
+    rerender({ ...baseParams, contextSummary: 'autosaved updated context' });
+    await waitForNextTick();
+
+    expect(aiChatService.generateJSON).toHaveBeenCalledTimes(1);
+    expect(result.current.suggestions[0]?.title).toBe('first title');
+  });
+
+  it('uses the latest context when the user manually refreshes suggestions', async () => {
+    vi.mocked(aiChatService.generateJSON)
+      .mockResolvedValueOnce(makeEnvelope('first'))
+      .mockResolvedValueOnce(makeEnvelope('second'));
+
+    const { rerender, result } = renderHook((props) => useBuilderSuggestions(props), {
+      initialProps: baseParams,
+      wrapper: createSWRWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.suggestions[0]?.title).toBe('first title');
+    });
+
+    rerender({ ...baseParams, contextSummary: 'manual refresh context' });
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(aiChatService.generateJSON).toHaveBeenCalledTimes(2);
+    });
+
+    expect(getGeneratedUserContent(1)).toContain('manual refresh context');
+    expect(result.current.suggestions[0]?.title).toBe('second title');
+  });
+
+  it('regenerates when the edited target changes', async () => {
+    vi.mocked(aiChatService.generateJSON)
+      .mockResolvedValueOnce(makeEnvelope('first'))
+      .mockResolvedValueOnce(makeEnvelope('second'));
+
+    const { rerender, result } = renderHook((props) => useBuilderSuggestions(props), {
+      initialProps: baseParams,
+      wrapper: createSWRWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.suggestions[0]?.title).toBe('first title');
+    });
+
+    rerender({
+      ...baseParams,
+      contextSummary: 'new target context',
+      targetId: 'target-agent-2',
+    });
+
+    await waitFor(() => {
+      expect(aiChatService.generateJSON).toHaveBeenCalledTimes(2);
+    });
+
+    expect(getGeneratedUserContent(1)).toContain('new target context');
+  });
+});

--- a/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.ts
+++ b/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.ts
@@ -6,7 +6,7 @@ import {
   type BuilderSuggestionMode,
   chainBuilderSuggestion,
 } from '@lobechat/prompts';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import useSWR from 'swr';
 
 import { aiChatService } from '@/services/aiChat';
@@ -54,15 +54,11 @@ export const useBuilderSuggestions = ({
   const [nonce, setNonce] = useState(0);
   const markRegenerated = useBuilderSuggestionFeedbackStore((s) => s.markRegenerated);
 
-  // The context summary is deliberately NOT part of the SWR key: config autosaves
-  // stream in new summaries for the same target and must not trigger a refetch.
-  // We read the latest value from a ref at fetch time so target switches and
-  // manual refreshes (both change the key) always generate from fresh context.
-  const latestContextSummaryRef = useRef(contextSummary);
-  latestContextSummaryRef.current = contextSummary;
-
-  // Key on target identity only — a target switch or a nonce bump regenerates;
-  // autosaves that merely change the summary do not.
+  // Key on target identity only — the context summary is deliberately kept out of
+  // the key so config autosaves (which stream in new summaries for the same target)
+  // don't refetch. Only a target switch or a nonce bump regenerates; the fetcher
+  // closure reads the current summary, which is always the latest value on the
+  // render that changes the key.
   const key =
     enabled && contextSummary && model && provider
       ? (['builder-suggestion', mode, builderAgentId, targetId, nonce] as const)
@@ -72,7 +68,7 @@ export const useBuilderSuggestions = ({
     key,
     async ([, requestMode, requestBuilderAgentId]) => {
       const { messages, schema } = chainBuilderSuggestion({
-        contextSummary: latestContextSummaryRef.current,
+        contextSummary,
         locale,
         mode: requestMode,
       });

--- a/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.ts
+++ b/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.ts
@@ -9,6 +9,7 @@ import {
 import { useCallback, useState } from 'react';
 import useSWR from 'swr';
 
+import { swrKeys } from '@/libs/swr/keys';
 import { aiChatService } from '@/services/aiChat';
 
 import { useBuilderSuggestionFeedbackStore } from './feedbackStore';
@@ -61,17 +62,15 @@ export const useBuilderSuggestions = ({
   // render that changes the key.
   const key =
     enabled && contextSummary && model && provider
-      ? (['builder-suggestion', mode, builderAgentId, targetId, nonce] as const)
+      ? swrKeys.agentBuilder.suggestions(mode, builderAgentId, targetId, nonce)
       : null;
 
   const { data, isLoading, error } = useSWR(
     key,
-    async ([, requestMode, requestBuilderAgentId]) => {
-      const { messages, schema } = chainBuilderSuggestion({
-        contextSummary,
-        locale,
-        mode: requestMode,
-      });
+    async () => {
+      // Read mode/context/agent from the closure: SWR runs the fetcher from the
+      // render that changed the key, so these already hold the latest values.
+      const { messages, schema } = chainBuilderSuggestion({ contextSummary, locale, mode });
       const abortController = new AbortController();
       const envelope = (await aiChatService.generateJSON(
         {
@@ -80,7 +79,7 @@ export const useBuilderSuggestions = ({
           provider,
           schema,
           tracing: {
-            agentId: requestBuilderAgentId,
+            agentId: builderAgentId,
             promptVersion: BUILDER_SUGGESTION_PROMPT_VERSION,
             scenario: TRACING_SCENARIOS.BuilderSuggestion,
             schemaName: BUILDER_SUGGESTION_SCHEMA_NAME,

--- a/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.ts
+++ b/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.ts
@@ -6,7 +6,7 @@ import {
   type BuilderSuggestionMode,
   chainBuilderSuggestion,
 } from '@lobechat/prompts';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import useSWR from 'swr';
 
 import { aiChatService } from '@/services/aiChat';
@@ -40,41 +40,6 @@ type GenerateEnvelope = {
   tracingId?: string;
 } | null;
 
-interface BuilderSuggestionRequest {
-  builderAgentId: string;
-  contextSummary: string;
-  mode: BuilderSuggestionMode;
-  nonce: number;
-  targetId?: string;
-}
-
-type BuilderSuggestionTarget = Pick<
-  BuilderSuggestionRequest,
-  'builderAgentId' | 'mode' | 'targetId'
->;
-
-const createSuggestionRequest = ({
-  builderAgentId,
-  contextSummary,
-  mode,
-  nonce,
-  targetId,
-}: BuilderSuggestionRequest): BuilderSuggestionRequest => ({
-  builderAgentId,
-  contextSummary,
-  mode,
-  nonce,
-  targetId,
-});
-
-const isSameSuggestionTarget = (
-  request: BuilderSuggestionRequest | undefined,
-  { builderAgentId, mode, targetId }: BuilderSuggestionTarget,
-) =>
-  request?.builderAgentId === builderAgentId &&
-  request.mode === mode &&
-  request.targetId === targetId;
-
 export const useBuilderSuggestions = ({
   mode,
   builderAgentId,
@@ -85,45 +50,29 @@ export const useBuilderSuggestions = ({
   enabled,
   targetId,
 }: UseBuilderSuggestionsParams): BuilderSuggestionsResult => {
+  // Bumping the nonce forces a fresh generation (SWR key change) on manual refresh.
+  const [nonce, setNonce] = useState(0);
+  const markRegenerated = useBuilderSuggestionFeedbackStore((s) => s.markRegenerated);
+
+  // The context summary is deliberately NOT part of the SWR key: config autosaves
+  // stream in new summaries for the same target and must not trigger a refetch.
+  // We read the latest value from a ref at fetch time so target switches and
+  // manual refreshes (both change the key) always generate from fresh context.
   const latestContextSummaryRef = useRef(contextSummary);
   latestContextSummaryRef.current = contextSummary;
 
-  const [request, setRequest] = useState<BuilderSuggestionRequest | undefined>(() =>
-    enabled && contextSummary
-      ? createSuggestionRequest({ builderAgentId, contextSummary, mode, nonce: 0, targetId })
-      : undefined,
-  );
-  const markRegenerated = useBuilderSuggestionFeedbackStore((s) => s.markRegenerated);
-
-  useEffect(() => {
-    if (!enabled || !contextSummary) return;
-
-    setRequest((previousRequest) => {
-      if (isSameSuggestionTarget(previousRequest, { builderAgentId, mode, targetId })) {
-        return previousRequest;
-      }
-
-      return createSuggestionRequest({ builderAgentId, contextSummary, mode, nonce: 0, targetId });
-    });
-  }, [builderAgentId, contextSummary, enabled, mode, targetId]);
-
+  // Key on target identity only — a target switch or a nonce bump regenerates;
+  // autosaves that merely change the summary do not.
   const key =
-    enabled && request && model && provider
-      ? ([
-          'builder-suggestion',
-          request.mode,
-          request.builderAgentId,
-          request.targetId,
-          request.contextSummary,
-          request.nonce,
-        ] as const)
+    enabled && contextSummary && model && provider
+      ? (['builder-suggestion', mode, builderAgentId, targetId, nonce] as const)
       : null;
 
   const { data, isLoading, error } = useSWR(
     key,
-    async ([, requestMode, requestBuilderAgentId, , requestContextSummary]) => {
+    async ([, requestMode, requestBuilderAgentId]) => {
       const { messages, schema } = chainBuilderSuggestion({
-        contextSummary: requestContextSummary,
+        contextSummary: latestContextSummaryRef.current,
         locale,
         mode: requestMode,
       });
@@ -160,21 +109,8 @@ export const useBuilderSuggestions = ({
 
   const refresh = useCallback(() => {
     markRegenerated(data?.tracingId);
-    const latestContextSummary = latestContextSummaryRef.current;
-    if (!enabled || !latestContextSummary) return;
-
-    setRequest((previousRequest) =>
-      createSuggestionRequest({
-        builderAgentId,
-        contextSummary: latestContextSummary,
-        mode,
-        nonce: isSameSuggestionTarget(previousRequest, { builderAgentId, mode, targetId })
-          ? previousRequest!.nonce + 1
-          : 1,
-        targetId,
-      }),
-    );
-  }, [builderAgentId, data?.tracingId, enabled, markRegenerated, mode, targetId]);
+    setNonce((n) => n + 1);
+  }, [data?.tracingId, markRegenerated]);
 
   return {
     error,

--- a/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.ts
+++ b/src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.ts
@@ -6,7 +6,7 @@ import {
   type BuilderSuggestionMode,
   chainBuilderSuggestion,
 } from '@lobechat/prompts';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import useSWR from 'swr';
 
 import { aiChatService } from '@/services/aiChat';
@@ -22,6 +22,8 @@ interface UseBuilderSuggestionsParams {
   mode: BuilderSuggestionMode;
   model: string;
   provider: string;
+  /** Agent/group currently being edited. Config autosaves for the same target must not regenerate. */
+  targetId?: string;
 }
 
 interface BuilderSuggestionsResult {
@@ -38,6 +40,41 @@ type GenerateEnvelope = {
   tracingId?: string;
 } | null;
 
+interface BuilderSuggestionRequest {
+  builderAgentId: string;
+  contextSummary: string;
+  mode: BuilderSuggestionMode;
+  nonce: number;
+  targetId?: string;
+}
+
+type BuilderSuggestionTarget = Pick<
+  BuilderSuggestionRequest,
+  'builderAgentId' | 'mode' | 'targetId'
+>;
+
+const createSuggestionRequest = ({
+  builderAgentId,
+  contextSummary,
+  mode,
+  nonce,
+  targetId,
+}: BuilderSuggestionRequest): BuilderSuggestionRequest => ({
+  builderAgentId,
+  contextSummary,
+  mode,
+  nonce,
+  targetId,
+});
+
+const isSameSuggestionTarget = (
+  request: BuilderSuggestionRequest | undefined,
+  { builderAgentId, mode, targetId }: BuilderSuggestionTarget,
+) =>
+  request?.builderAgentId === builderAgentId &&
+  request.mode === mode &&
+  request.targetId === targetId;
+
 export const useBuilderSuggestions = ({
   mode,
   builderAgentId,
@@ -46,20 +83,50 @@ export const useBuilderSuggestions = ({
   provider,
   locale,
   enabled,
+  targetId,
 }: UseBuilderSuggestionsParams): BuilderSuggestionsResult => {
-  // Bumping the nonce forces a fresh generation (SWR key change) on refresh.
-  const [nonce, setNonce] = useState(0);
+  const latestContextSummaryRef = useRef(contextSummary);
+  latestContextSummaryRef.current = contextSummary;
+
+  const [request, setRequest] = useState<BuilderSuggestionRequest | undefined>(() =>
+    enabled && contextSummary
+      ? createSuggestionRequest({ builderAgentId, contextSummary, mode, nonce: 0, targetId })
+      : undefined,
+  );
   const markRegenerated = useBuilderSuggestionFeedbackStore((s) => s.markRegenerated);
 
+  useEffect(() => {
+    if (!enabled || !contextSummary) return;
+
+    setRequest((previousRequest) => {
+      if (isSameSuggestionTarget(previousRequest, { builderAgentId, mode, targetId })) {
+        return previousRequest;
+      }
+
+      return createSuggestionRequest({ builderAgentId, contextSummary, mode, nonce: 0, targetId });
+    });
+  }, [builderAgentId, contextSummary, enabled, mode, targetId]);
+
   const key =
-    enabled && contextSummary && model && provider
-      ? (['builder-suggestion', mode, builderAgentId, contextSummary, nonce] as const)
+    enabled && request && model && provider
+      ? ([
+          'builder-suggestion',
+          request.mode,
+          request.builderAgentId,
+          request.targetId,
+          request.contextSummary,
+          request.nonce,
+        ] as const)
       : null;
 
   const { data, isLoading, error } = useSWR(
     key,
-    async () => {
-      const { messages, schema } = chainBuilderSuggestion({ contextSummary, locale, mode });
+    async ([, requestMode, requestBuilderAgentId, , requestContextSummary]) => {
+      const { messages, schema } = chainBuilderSuggestion({
+        contextSummary: requestContextSummary,
+        locale,
+        mode: requestMode,
+      });
       const abortController = new AbortController();
       const envelope = (await aiChatService.generateJSON(
         {
@@ -68,7 +135,7 @@ export const useBuilderSuggestions = ({
           provider,
           schema,
           tracing: {
-            agentId: builderAgentId,
+            agentId: requestBuilderAgentId,
             promptVersion: BUILDER_SUGGESTION_PROMPT_VERSION,
             scenario: TRACING_SCENARIOS.BuilderSuggestion,
             schemaName: BUILDER_SUGGESTION_SCHEMA_NAME,
@@ -93,8 +160,21 @@ export const useBuilderSuggestions = ({
 
   const refresh = useCallback(() => {
     markRegenerated(data?.tracingId);
-    setNonce((n) => n + 1);
-  }, [data?.tracingId, markRegenerated]);
+    const latestContextSummary = latestContextSummaryRef.current;
+    if (!enabled || !latestContextSummary) return;
+
+    setRequest((previousRequest) =>
+      createSuggestionRequest({
+        builderAgentId,
+        contextSummary: latestContextSummary,
+        mode,
+        nonce: isSameSuggestionTarget(previousRequest, { builderAgentId, mode, targetId })
+          ? previousRequest!.nonce + 1
+          : 1,
+        targetId,
+      }),
+    );
+  }, [builderAgentId, data?.tracingId, enabled, markRegenerated, mode, targetId]);
 
   return {
     error,

--- a/src/libs/swr/keys.ts
+++ b/src/libs/swr/keys.ts
@@ -90,6 +90,23 @@ export const agentKeys = {
   list: def('agent:list', (isLogin: boolean) => ['agent:list', isLogin]),
 };
 
+// ---- agent builder (opening-suggestion chips) ---------------------------
+// Kept off `CACHE_TIERS` on purpose — these are ephemeral LLM-generated chips.
+// `contextSummary` is intentionally NOT part of the key so config autosaves for
+// the same target don't refetch; `nonce` bumps on manual refresh.
+export const agentBuilderKeys = {
+  suggestions: def(
+    'agentBuilder:suggestions',
+    (mode: string, builderAgentId: string, targetId: string | undefined, nonce: number) => [
+      'agentBuilder:suggestions',
+      mode,
+      builderAgentId,
+      targetId,
+      nonce,
+    ],
+  ),
+};
+
 // ---- group --------------------------------------------------------------
 export const groupKeys = {
   detail: def('group:detail', (groupId: string) => ['group:detail', groupId]),
@@ -845,6 +862,7 @@ export const matchDomain =
 export const swrKeys = {
   agent: { ...agentKeys, ...agentConfigKeys },
   agentBot: agentBotKeys,
+  agentBuilder: agentBuilderKeys,
   agentDocument: agentDocumentSWRKeys,
   agentHome: agentHomeKeys,
   agentKnowledge: agentKnowledgeKeys,


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Track the current edited agent/group target for Agent Builder suggestion generation.
- Keep the existing suggestion request stable when autosave updates context for the same target.
- Use the latest context only when the user manually refreshes suggestions or switches targets.
- Add hook coverage for autosave stability, manual refresh, and target switching.

#### 🧪 How to Test

- `bunx vitest run --silent='passed-only' 'src/features/AgentBuilder/SuggestionChips/useBuilderSuggestions.test.tsx'`

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

N/A - behavior-only fix.

#### 📝 Additional Information

N/A
