### PR TITLE
🐛 fix(desktop): scope GC'd hetero optimistic writes to the card's own context

### DIFF
--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationControl.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationControl.test.ts
@@ -1942,12 +1942,12 @@ describe('ConversationControl actions', () => {
       );
     });
 
-    it("CURRENT BEHAVIOR: falls back to global-state optimistic context (empty op) and still submits when the operation is GC'd", async () => {
-      // Characterizes action.ts ~735/~758: when the resolved op has already been
-      // garbage-collected (not present in `operations`), the optimistic context
-      // is the empty object `{}` (global-state fallback) rather than carrying the
-      // stale operationId — but the IPC submit STILL fires with that operationId,
-      // and the call does NOT throw. Locked as-is.
+    it("scopes the optimistic context to the effective context (not a stale opId) and still submits when the operation is GC'd", async () => {
+      // When the resolved op has already been garbage-collected (not present in
+      // `operations`), we don't pass the stale operationId into the optimistic
+      // chain — instead the optimistic context carries the effective conversation
+      // (here the global fallback, since no explicit context is passed), and the
+      // IPC submit STILL fires with that operationId. The call does NOT throw.
       const { result } = renderHook(() => useChatStore());
 
       const agentId = 'hetero-agent';
@@ -1997,11 +1997,12 @@ describe('ConversationControl actions', () => {
         ).resolves.toBeUndefined();
       });
 
-      // Optimistic write uses the empty global-state fallback context.
+      // Optimistic write carries the effective context (global fallback here),
+      // not a stale operationId.
       expect(pluginSpy).toHaveBeenCalledWith(
         'tool-msg-1',
         expect.objectContaining({ intervention: expect.objectContaining({ status: 'rejected' }) }),
-        {},
+        { agentId, groupId: undefined, threadId: undefined, topicId },
       );
 
       // IPC submit still fires with the (stale) resolved operationId + cancel.
@@ -2084,6 +2085,88 @@ describe('ConversationControl actions', () => {
       );
       // ...and the topic the user is currently viewing is never touched.
       expect(updateTopicStatusSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ topicId: activeTopicId }),
+      );
+    });
+
+    it("scopes the optimistic message write to the card's context (not the active topic) when the operation is GC'd", async () => {
+      // Regression: when the run's `execHeterogeneousAgent` op has been
+      // garbage-collected, a global approval card is still mounted from the
+      // bucket's message fields (`reconstructContextFromMessages`). Answering it
+      // must scope the optimistic plugin/content writes to the CARD's bucket, or
+      // the approved tool message never flips in its own bucket (card lingers)
+      // and a no-op write hits whatever topic the user is currently viewing.
+      const { result } = renderHook(() => useChatStore());
+
+      const agentId = 'hetero-agent';
+      const cardTopicId = 'background-topic';
+      const activeTopicId = 'the-topic-user-is-viewing';
+      const chatKey = messageMapKey({ agentId, topicId: cardTopicId });
+
+      const assistantMessage = createMockMessage({ id: 'assistant-msg-1', role: 'assistant' });
+      const toolMessage = createMockMessage({
+        id: 'tool-msg-1',
+        parentId: assistantMessage.id,
+        plugin: {
+          apiName: 'askUserQuestion',
+          arguments: '{}',
+          identifier: 'lobe-claude-code',
+          type: 'default',
+        },
+        role: 'tool',
+        tool_call_id: 'cc_call_1',
+      } as any);
+
+      act(() => {
+        useChatStore.setState({
+          // User is parked elsewhere; the card's run op is already GC'd.
+          activeAgentId: agentId,
+          activeThreadId: undefined,
+          activeTopicId,
+          dbMessagesMap: { [chatKey]: [assistantMessage, toolMessage] },
+          messagesMap: { [chatKey]: [assistantMessage, toolMessage] },
+          messageOperationMap: { [assistantMessage.id]: 'gc-op-id' },
+          operations: {},
+        });
+      });
+
+      const pluginSpy = vi
+        .spyOn(result.current, 'optimisticUpdateMessagePlugin')
+        .mockResolvedValue(undefined);
+      const contentSpy = vi
+        .spyOn(result.current, 'optimisticUpdateMessageContent')
+        .mockResolvedValue(undefined);
+      vi.spyOn(result.current, 'updateTopicStatus').mockResolvedValue(undefined as any);
+      vi.spyOn(heterogeneousAgentService, 'submitIntervention').mockResolvedValue(undefined as any);
+
+      await act(async () => {
+        await result.current.submitHeteroIntervention(
+          'tool-msg-1',
+          'submit',
+          { 'Which color?': 'Blue' },
+          { agentId, threadId: undefined, topicId: cardTopicId },
+        );
+      });
+
+      // Both optimistic writes carry the card's own agent/topic — NOT a stale
+      // operationId and NOT the active topic.
+      const expectedCtx = {
+        agentId,
+        groupId: undefined,
+        threadId: undefined,
+        topicId: cardTopicId,
+      };
+      expect(pluginSpy).toHaveBeenCalledWith('tool-msg-1', expect.anything(), expectedCtx);
+      expect(contentSpy).toHaveBeenCalledWith(
+        'tool-msg-1',
+        expect.any(String),
+        undefined,
+        expectedCtx,
+      );
+      // Never scoped to the topic the user is currently viewing.
+      expect(pluginSpy).not.toHaveBeenCalledWith(
+        'tool-msg-1',
+        expect.anything(),
         expect.objectContaining({ topicId: activeTopicId }),
       );
     });

--- a/src/store/chat/slices/agentRun/actions/entries/conversationControl.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationControl.ts
@@ -811,18 +811,29 @@ export class ConversationControlActionImpl {
     // If the operation has already been garbage-collected (e.g. the bridge
     // timed out earlier and `runtime_end` rolled the op into `completed`
     // 30s+ ago), don't pass the stale opId into the optimistic chain — the
-    // `internal_getConversationContext` fallback uses global state, which
-    // matches the active conversation the user just clicked in. The IPC
-    // submit below stays unchanged: `bridge.resolve()` no-ops on unknown
-    // toolCallIds, so it's safe to fire even when the bridge is gone.
+    // `internal_getConversationContext` fallback would then use global state.
+    // A global approval card can be mounted for exactly this GC'd state (see
+    // `reconstructContextFromMessages`), so scope the optimistic writes with
+    // this card's own `effectiveContext` instead — otherwise they land on
+    // whatever topic the user is currently viewing, leaving the approved tool
+    // message un-flipped in its own bucket (the card lingers). The IPC submit
+    // below stays unchanged: `bridge.resolve()` no-ops on unknown toolCallIds,
+    // so it's safe to fire even when the bridge is gone.
     const operationAlive = !!this.#get().operations[operationId];
     if (!operationAlive) {
       console.warn(
-        '[submitHeteroIntervention] operation already gone, using global-state fallback for optimistic write:',
+        '[submitHeteroIntervention] operation already gone, scoping optimistic write to the card context:',
         operationId,
       );
     }
-    const optimisticContext: OptimisticUpdateContext = operationAlive ? { operationId } : {};
+    const optimisticContext: OptimisticUpdateContext = operationAlive
+      ? { operationId }
+      : {
+          agentId: effectiveContext.agentId,
+          groupId: effectiveContext.groupId,
+          threadId: effectiveContext.threadId,
+          topicId: effectiveContext.topicId,
+        };
 
     if (actionType === 'submit') {
       await this.#get().optimisticUpdateMessagePlugin(

--- a/src/store/chat/slices/message/actions/internals.ts
+++ b/src/store/chat/slices/message/actions/internals.ts
@@ -35,9 +35,16 @@ export class MessageInternalsActionImpl {
 
   internal_dispatchMessage = (
     payload: MessageDispatch,
-    context?: { operationId?: string },
+    context?: {
+      agentId?: string;
+      groupId?: string;
+      operationId?: string;
+      threadId?: string;
+      topicId?: string;
+    },
   ): void => {
-    // Get full conversation context (including scope) from operation or global state
+    // Get full conversation context (including scope) from operation, explicit
+    // context, or global state.
     const ctx = this.#get().internal_getConversationContext(context);
     log(
       '[internal_dispatchMessage] context: agentId=%s, topicId=%s, threadId=%s, scope=%s',

--- a/src/store/chat/slices/message/actions/optimisticUpdate.ts
+++ b/src/store/chat/slices/message/actions/optimisticUpdate.ts
@@ -24,9 +24,17 @@ import { dbMessageSelectors } from '../selectors';
  * Context for optimistic updates to specify session/topic isolation
  */
 export interface OptimisticUpdateContext {
+  // Explicit conversation target, used when no live operation pins the bucket
+  // (e.g. a GC'd hetero submit answered from the global approval card). Takes
+  // precedence over global active-conversation state so the write lands on the
+  // right bucket. See `internal_getConversationContext`.
+  agentId?: string;
+  groupId?: string;
   operationId?: string;
   /** Pre-generated temp message ID (used when ID needs to be known before creation) */
   tempMessageId?: string;
+  threadId?: string;
+  topicId?: string;
 }
 
 /**

--- a/src/store/chat/slices/operation/actions.ts
+++ b/src/store/chat/slices/operation/actions.ts
@@ -47,7 +47,13 @@ export class OperationActionsImpl {
     this.#get = get;
   }
 
-  internal_getConversationContext = (context?: { operationId?: string }): MessageMapKeyInput => {
+  internal_getConversationContext = (context?: {
+    agentId?: string;
+    groupId?: string;
+    operationId?: string;
+    threadId?: string;
+    topicId?: string;
+  }): MessageMapKeyInput => {
     if (context?.operationId) {
       const operation = this.#get().operations[context.operationId];
       if (!operation) {
@@ -84,6 +90,23 @@ export class OperationActionsImpl {
         // subTopicId). Only agentId needs the non-null assertion.
         return { ...operation.context, agentId: agentId! };
       }
+    }
+
+    // Explicit conversation context — used when the caller knows the concrete
+    // conversation but no live operation pins it (e.g. answering a global
+    // approval whose `execHeterogeneousAgent` op was already GC'd). Preferred
+    // over global state so optimistic writes land on the card's own bucket,
+    // not whatever topic the user happens to be viewing. Only agent/topic/
+    // thread scope reaches here — group/page scopes can't be mounted from a
+    // GC'd op (see `reconstructContextFromMessages`), so they still need a live
+    // operation and never fall through to this branch.
+    if (context?.agentId) {
+      return {
+        agentId: context.agentId,
+        groupId: context.groupId,
+        threadId: context.threadId,
+        topicId: context.topicId,
+      };
     }
 
     // Fallback to global state


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up to #16551 (merged). That PR fixed the topic-**status** flip; this one fixes the message-level **optimistic writes** for the same GC'd-operation edge.

#### 🔀 Description of Change

The global approval card can be mounted for a run whose `execHeterogeneousAgent` operation has already been garbage-collected — `collectGlobalApprovals` deliberately reconstructs the context from the bucket's own message fields (`reconstructContextFromMessages`) for exactly that state (a parked run's op is GC'd ~30s after it hits `waiting_for_human`, while the tool message stays `pending`).

When such a card was answered, `submitHeteroIntervention` built `{}` for the optimistic context (no live op to carry), so `optimisticUpdateMessagePlugin` / `optimisticUpdateMessageContent` resolved the bucket via `internal_getConversationContext`'s **global-state fallback**. The topic-status flip was already correct (#16551 routes it through `effectiveContext`), but the message-level optimistic writes landed on **whatever topic the user was viewing**:

- the approved/rejected tool message never flipped in its own bucket → **the approval card lingered** until the real IPC `tool_result` echoed back;
- a no-op write hit the currently-viewed topic's bucket.

Fix — thread the concrete conversation context through the optimistic-update machinery (both optimistic paths — in-memory `internal_dispatchMessage` and post-service `replaceMessages` — converge on `internal_getConversationContext`):

- `internal_getConversationContext` now accepts explicit `{agentId, groupId, threadId, topicId}` and prefers them over global state (a live operation's context still wins). **Purely additive** — existing `{operationId}` / `{}` callers are unchanged.
- `OptimisticUpdateContext` + `internal_dispatchMessage` carry those fields through.
- `submitHeteroIntervention` builds `optimisticContext` from `effectiveContext` (instead of `{}`) when the operation is gone.

Only agent/topic/thread scope reaches this path — group/page scopes can't be mounted from a GC'd op, so they still require a live operation.

#### 🧪 How to Test

1. Start a Claude Code run in topic A that raises an `askUserQuestion`, and leave it parked long enough (~30s+) that its operation is GC'd.
2. Switch to topic B.
3. Answer the intervention from the global approval card.
4. Expect: the card resolves immediately (its own tool message flips to approved/rejected) and topic B is untouched. Before the fix, the card lingered and B got a spurious no-op write.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Regression test: op GC'd + user parked on a different topic → asserts the optimistic plugin/content writes carry the card's own agent/topic and never the active topic.