### PR TITLE
✨ feat(chat): add "restore to input" action for user messages

### DIFF
--- a/locales/en-US/common.json
+++ b/locales/en-US/common.json
@@ -399,6 +399,8 @@
   "rename": "Rename",
   "reset": "Reset",
   "restartToUpdate": "Restart to Update",
+  "restoreToInput": "Restore to input",
+  "restoreToInputSuccess": "Restored to input",
   "retry": "Retry",
   "run": "Run",
   "save": "Save",

--- a/locales/zh-CN/common.json
+++ b/locales/zh-CN/common.json
@@ -399,6 +399,8 @@
   "rename": "重命名",
   "reset": "重置",
   "restartToUpdate": "重启以更新",
+  "restoreToInput": "恢复到输入框",
+  "restoreToInputSuccess": "已恢复到输入框",
   "retry": "重试",
   "run": "运行",
   "save": "保存",

--- a/packages/locales/src/default/common.ts
+++ b/packages/locales/src/default/common.ts
@@ -475,6 +475,8 @@ export default {
   'releaseNotes': 'Version Details',
   'rename': 'Rename',
   'reset': 'Reset',
+  'restoreToInput': 'Restore to input',
+  'restoreToInputSuccess': 'Restored to input',
   'retry': 'Retry',
   'run': 'Run',
   'save': 'Save',

--- a/packages/types/src/files/upload.ts
+++ b/packages/types/src/files/upload.ts
@@ -48,6 +48,13 @@ export interface UploadFileItem {
    * it will use in the file preview before send the message
    */
   previewUrl?: string;
+  /**
+   * marks a draft entry that references an already-persisted file still backing
+   * an existing message (e.g. restored via "restore to input"). Removing such
+   * an entry from the draft must only drop the draft item — it must NOT delete
+   * the underlying file, or the original message would lose its attachment.
+   */
+  skipRemoveFile?: boolean;
   status: FileUploadStatus;
   tasks?: FileParsingTask;
   uploadState?: FileUploadState;

--- a/src/features/Conversation/Messages/User/Actions/index.tsx
+++ b/src/features/Conversation/Messages/User/Actions/index.tsx
@@ -17,6 +17,7 @@ import MessageBranch from '../../components/MessageBranch';
 const DEFAULT_BAR: MessageActionSlot[] = ['regenerate', 'edit', 'copy'];
 const DEFAULT_MENU: MessageActionSlot[] = [
   'edit',
+  'restoreToInput',
   'copy',
   'branching',
   'divider',

--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/restoreToInput.test.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/restoreToInput.test.ts
@@ -1,0 +1,108 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { UIChatMessage } from '@lobechat/types';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MessageActionContext } from '../types';
+import { restoreToInputAction } from './restoreToInput';
+
+const editor = {
+  focus: vi.fn(),
+  setDocument: vi.fn(),
+  setJSONState: vi.fn(),
+};
+const updateInputMessage = vi.fn();
+const clearChatUploadFileList = vi.fn();
+const dispatchChatUploadFileList = vi.fn();
+
+vi.mock('../../../../store', () => ({
+  useConversationStore: (selector: (s: any) => any) => selector({ editor, updateInputMessage }),
+}));
+
+vi.mock('@/store/file', () => ({
+  useFileStore: {
+    getState: () => ({ clearChatUploadFileList, dispatchChatUploadFileList }),
+  },
+}));
+
+const messageSuccess = vi.fn();
+vi.mock('antd', () => ({
+  App: { useApp: () => ({ message: { success: messageSuccess } }) },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const build = (data: Partial<UIChatMessage>, role: MessageActionContext['role'] = 'user') =>
+  renderHook(() => restoreToInputAction.useBuild({ data: data as UIChatMessage, id: 'm1', role }))
+    .result.current;
+
+describe('restoreToInputAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null for non-user messages', () => {
+    expect(build({ content: 'hi' }, 'assistant')).toBeNull();
+  });
+
+  it('restores editorData as JSON when present', () => {
+    const editorData = { root: { children: [] } };
+    build({ content: 'hello', editorData })!.handleClick!();
+
+    expect(editor.setJSONState).toHaveBeenCalledWith(editorData);
+    expect(editor.setDocument).not.toHaveBeenCalled();
+    expect(updateInputMessage).toHaveBeenCalledWith('hello');
+    expect(editor.focus).toHaveBeenCalled();
+    expect(messageSuccess).toHaveBeenCalledWith('restoreToInputSuccess');
+  });
+
+  it('falls back to markdown (with speaker tag stripped) when editorData is empty', () => {
+    build({ content: '<speaker name="Bot" />\nhello', editorData: {} })!.handleClick!();
+
+    expect(editor.setDocument).toHaveBeenCalledWith('markdown', 'hello');
+    expect(editor.setJSONState).not.toHaveBeenCalled();
+    expect(updateInputMessage).toHaveBeenCalledWith('hello');
+  });
+
+  it('rebuilds pending attachments from imageList and fileList', () => {
+    build({
+      content: 'with files',
+      fileList: [{ fileType: 'application/pdf', id: 'f1', name: 'a.pdf', size: 100, url: 'u-f1' }],
+      imageList: [{ alt: 'pic', id: 'i1', url: 'u-i1' }],
+    })!.handleClick!();
+
+    expect(clearChatUploadFileList).toHaveBeenCalled();
+    expect(dispatchChatUploadFileList).toHaveBeenCalledWith({
+      files: [
+        expect.objectContaining({
+          fileUrl: 'u-i1',
+          id: 'i1',
+          previewUrl: 'u-i1',
+          status: 'success',
+        }),
+        expect.objectContaining({
+          fileUrl: 'u-f1',
+          id: 'f1',
+          previewUrl: 'u-f1',
+          status: 'success',
+        }),
+      ],
+      type: 'addFiles',
+    });
+
+    const [{ files }] = dispatchChatUploadFileList.mock.calls[0];
+    expect(files[0].file.type).toBe('image/*');
+    expect(files[1].file).toMatchObject({ name: 'a.pdf', size: 100, type: 'application/pdf' });
+  });
+
+  it('clears the upload list but skips dispatch when there are no attachments', () => {
+    build({ content: 'no files' })!.handleClick!();
+
+    expect(clearChatUploadFileList).toHaveBeenCalled();
+    expect(dispatchChatUploadFileList).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/restoreToInput.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/restoreToInput.ts
@@ -55,6 +55,9 @@ export const restoreToInputAction = defineAction({
           // 2. Rebuild the pending attachments. These files are already uploaded,
           //    so we only need their db id (send reads `f.id`) plus a url for the
           //    thumbnail; the `file` stand-in just feeds the preview UI.
+          //    `skipRemoveFile` marks them as references to already-persisted
+          //    files — removing one from the composer must NOT delete the file
+          //    still backing the original message.
           // `alt`-only items (image/video/audio) carry no size or mime, so the
           // `file` stand-in gets a generic `type` prefix good enough for the
           // preview's `startsWith('image'|'video')` branch.
@@ -67,6 +70,7 @@ export const restoreToInputAction = defineAction({
               fileUrl: item.url,
               id: item.id,
               previewUrl: item.url,
+              skipRemoveFile: true,
               status: 'success' as const,
             }));
 
@@ -79,6 +83,7 @@ export const restoreToInputAction = defineAction({
               fileUrl: f.url,
               id: f.id,
               previewUrl: f.url,
+              skipRemoveFile: true,
               status: 'success' as const,
             })),
           ];

--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/restoreToInput.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/restoreToInput.ts
@@ -1,0 +1,101 @@
+import { App } from 'antd';
+import { Undo2 } from 'lucide-react';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { cleanSpeakerTag } from '@/store/chat/utils/cleanSpeakerTag';
+import { unescapeMarkdown } from '@/store/chat/utils/unescapeMarkdown';
+import { useFileStore } from '@/store/file';
+import { type UploadFileItem } from '@/types/files/upload';
+
+import { useConversationStore } from '../../../../store';
+import { defineAction } from '../defineAction';
+
+/**
+ * Restore a previously sent user message — its text plus every image/file
+ * attachment — back into the ChatInput composer, so the user can resend it.
+ *
+ * Motivated by long agent runs that error out or lose memory: re-attaching a
+ * pile of images by hand is painful, so we rebuild the exact input state from
+ * the persisted message instead.
+ */
+export const restoreToInputAction = defineAction({
+  key: 'restoreToInput',
+  useBuild: (ctx) => {
+    const { t } = useTranslation('common');
+    const { message } = App.useApp();
+    const editor = useConversationStore((s) => s.editor);
+    const updateInputMessage = useConversationStore((s) => s.updateInputMessage);
+
+    return useMemo(() => {
+      // Only user messages carry restorable user input.
+      if (ctx.role !== 'user') return null;
+
+      return {
+        handleClick: () => {
+          if (!editor) return;
+
+          const { content, imageList, fileList, videoList, audioList, editorData } = ctx.data;
+
+          // 1. Restore text. Prefer the persisted editor JSON (round-trips rich
+          //    formatting) and fall back to the markdown content otherwise.
+          const markdown = unescapeMarkdown(cleanSpeakerTag(content ?? ''));
+          const hasEditorData =
+            editorData && typeof editorData === 'object' && Object.keys(editorData).length > 0;
+
+          if (hasEditorData) {
+            editor.setJSONState(editorData);
+          } else {
+            editor.setDocument('markdown', markdown);
+          }
+          // Keep ConversationStore's inputMessage in sync — setDocument does not
+          // fire onMarkdownContentChange, and the send-button gating reads it.
+          updateInputMessage(markdown);
+
+          // 2. Rebuild the pending attachments. These files are already uploaded,
+          //    so we only need their db id (send reads `f.id`) plus a url for the
+          //    thumbnail; the `file` stand-in just feeds the preview UI.
+          // `alt`-only items (image/video/audio) carry no size or mime, so the
+          // `file` stand-in gets a generic `type` prefix good enough for the
+          // preview's `startsWith('image'|'video')` branch.
+          const fromMedia = (
+            list: { alt: string; id: string; url: string }[] | undefined,
+            typePrefix: string,
+          ): UploadFileItem[] =>
+            (list ?? []).map((item) => ({
+              file: { name: item.alt || item.id, size: 0, type: `${typePrefix}/*` } as File,
+              fileUrl: item.url,
+              id: item.id,
+              previewUrl: item.url,
+              status: 'success' as const,
+            }));
+
+          const restored: UploadFileItem[] = [
+            ...fromMedia(imageList, 'image'),
+            ...fromMedia(videoList, 'video'),
+            ...fromMedia(audioList, 'audio'),
+            ...(fileList ?? []).map((f) => ({
+              file: { name: f.name, size: f.size, type: f.fileType } as File,
+              fileUrl: f.url,
+              id: f.id,
+              previewUrl: f.url,
+              status: 'success' as const,
+            })),
+          ];
+
+          const fileStore = useFileStore.getState();
+          fileStore.clearChatUploadFileList();
+          if (restored.length > 0) {
+            fileStore.dispatchChatUploadFileList({ files: restored, type: 'addFiles' });
+          }
+
+          editor.focus();
+          message.success(t('restoreToInputSuccess'));
+        },
+        icon: Undo2,
+        key: 'restoreToInput',
+        label: t('restoreToInput'),
+      };
+    }, [t, message, ctx.role, ctx.data, editor, updateInputMessage]);
+  },
+});

--- a/src/features/Conversation/Messages/components/MessageActionBar/useBuildActions.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/useBuildActions.ts
@@ -7,6 +7,7 @@ import { delAction } from './actions/del';
 import { delAndRegenerateAction } from './actions/delAndRegenerate';
 import { editAction } from './actions/edit';
 import { regenerateAction } from './actions/regenerate';
+import { restoreToInputAction } from './actions/restoreToInput';
 import { selectAction } from './actions/select';
 import { shareAction } from './actions/share';
 import { translateAction } from './actions/translate';
@@ -33,6 +34,7 @@ export const useBuildActions = (
   delAndRegenerate: delAndRegenerateAction.useBuild(ctx),
   edit: editAction.useBuild(ctx),
   regenerate: regenerateAction.useBuild(ctx),
+  restoreToInput: restoreToInputAction.useBuild(ctx),
   select: selectAction.useBuild(ctx),
   share: shareAction.useBuild(ctx),
   translate: translateAction.useBuild(ctx),

--- a/src/store/file/slices/chat/action.test.ts
+++ b/src/store/file/slices/chat/action.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook } from '@testing-library/react';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { notification } from '@/components/AntdStaticMethods';
+import { fileService } from '@/services/file';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 
 import { useFileStore as useStore } from '../../store';
@@ -187,6 +188,44 @@ describe('useFileStore:chat', () => {
     expect(notification.error).toHaveBeenCalledWith({
       description: 'You do not have permission to upload files in this workspace.',
       message: 'File upload failed.',
+    });
+  });
+
+  describe('removeChatUploadFile', () => {
+    it('deletes the underlying file for a normal uploaded item', async () => {
+      const removeFile = vi.spyOn(fileService, 'removeFile').mockResolvedValue(undefined);
+      const { result } = renderHook(() => useStore());
+
+      act(() => {
+        useStore.setState({ chatUploadFileList: [{ id: 'file-1' }] as any });
+      });
+
+      await act(async () => {
+        await result.current.removeChatUploadFile('file-1');
+      });
+
+      expect(result.current.chatUploadFileList).toEqual([]);
+      expect(removeFile).toHaveBeenCalledWith('file-1');
+    });
+
+    it('skips file deletion for a restored item (skipRemoveFile)', async () => {
+      const removeFile = vi.spyOn(fileService, 'removeFile').mockResolvedValue(undefined);
+      const { result } = renderHook(() => useStore());
+
+      act(() => {
+        useStore.setState({
+          chatUploadFileList: [{ id: 'file-1', skipRemoveFile: true }] as any,
+        });
+      });
+
+      await act(async () => {
+        await result.current.removeChatUploadFile('file-1');
+      });
+
+      // draft entry is dropped, but the persisted file backing the original
+      // message must NOT be deleted
+      expect(result.current.chatUploadFileList).toEqual([]);
+      expect(removeFile).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/store/file/slices/chat/action.ts
+++ b/src/store/file/slices/chat/action.ts
@@ -98,9 +98,16 @@ export class FileActionImpl {
   };
 
   removeChatUploadFile = async (id: string): Promise<void> => {
-    const { dispatchChatUploadFileList } = this.#get();
+    const { chatUploadFileList, dispatchChatUploadFileList } = this.#get();
+
+    // Restored entries reference an already-persisted file that still backs the
+    // original message — only drop the draft item, never delete the file itself.
+    const skipRemoveFile = chatUploadFileList.find((item) => item.id === id)?.skipRemoveFile;
 
     dispatchChatUploadFileList({ id, type: 'removeFile' });
+
+    if (skipRemoveFile) return;
+
     await fileService.removeFile(id);
   };
 


### PR DESCRIPTION
## ✨ What & Why

Adds a **「恢复到输入框」(Restore to input)** item to the **user message** overflow (`···`) menu. One click refills the bottom ChatInput composer with that message's **text + all attachments (images / files / videos / audio)**, ready to resend.

Motivation: when a long agent run errors out or loses memory, re-attaching a pile of images by hand is painful. This lets the user recover the exact original input instantly and resend.

## 🧩 How

- **Text** — restored from the persisted editor JSON (`editorData`, round-trips rich formatting) when present; otherwise falls back to the cleaned markdown `content` (`cleanSpeakerTag` + `unescapeMarkdown`). `updateInputMessage` is synced so the send-button gating stays correct.
- **Attachments** — a message's `imageList` / `fileList[].id` **is** the db file id, and the send flow only reads `f.id` (`files?.map(f => f.id)`). So attachments are rebuilt as already-uploaded `UploadFileItem` entries (`status: 'success'` + `id` + `url`) pushed into the global file store's `chatUploadFileList`; a resend re-associates them by id and the backend re-splits them back into image/file lists.
- **Cross-tree access** — the ChatInput editor instance already lives on `ConversationStore` (`setEditor`), which the message action bar already consumes, so no extra event bus is needed.

## 📦 Changes

- `MessageActionBar/actions/restoreToInput.ts` — new action (core logic)
- `MessageActionBar/useBuildActions.ts` — register the action
- `Messages/User/Actions/index.tsx` — add to the user message menu (after `edit`)
- `packages/locales/src/default/common.ts` + `locales/en-US`/`zh-CN` `common.json` — i18n (`restoreToInput` / `restoreToInputSuccess`)
- `MessageActionBar/actions/restoreToInput.test.ts` — 5 unit tests

## ✅ Verification

- **Local end-to-end verify (report)** → https://app.lobehub.com/verify/922eb42d-d63c-414b-9a62-a9799f18472b — **4/4 checks passed**, run on the desktop app directly against this branch's code:
  - `···` menu shows **恢复到输入框** on user messages (after 编辑)
  - one click refills the composer with the message's text **+ image attachment**
  - **P1 fix verified**: removing a restored attachment from the composer does **not** delete the file still backing the original message (image intact after reload)
- Unit tests: **12/12 pass** (`restoreToInput` action ×5 + file-store `removeChatUploadFile` guard ×2, + existing chat-store tests)
- `type-check`: no new errors · ESLint: clean

## 📝 Notes

- Image/video/audio attachments only carry `{alt, id, url}` (no size/mime), so their preview shows `0 B` (thumbnail + name are fine); regular files show the real size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
