### PR TITLE
🐛 fix: remove exhaustive deps suppressions

### DIFF
--- a/src/components/CodeEditorPane/index.tsx
+++ b/src/components/CodeEditorPane/index.tsx
@@ -36,8 +36,15 @@ const CodeEditorPane = memo<CodeEditorPaneProps>(
     const instanceRef = useRef<ICodeMirrorInstance | null>(null);
     const onChangeRef = useRef(onChange);
     const onSaveRef = useRef(onSave);
+    const valueRef = useRef(value);
+    const languageRef = useRef(language);
+    const readOnlyRef = useRef(readOnly);
+
     onChangeRef.current = onChange;
     onSaveRef.current = onSave;
+    valueRef.current = value;
+    languageRef.current = language;
+    readOnlyRef.current = readOnly;
 
     useEffect(() => {
       if (!textareaRef.current) return;
@@ -49,10 +56,10 @@ const CodeEditorPane = memo<CodeEditorPaneProps>(
         const instance = CodeMirror.fromTextArea(dom, {
           lineNumbers: true,
           lineWrapping: true,
-          mode: language,
-          readOnly,
+          mode: languageRef.current,
+          readOnly: readOnlyRef.current,
           theme: 'default',
-          value,
+          value: valueRef.current,
         });
         instance.view.dispatch({
           effects: instance.optionHelper.theme.reconfigure(
@@ -79,7 +86,6 @@ const CodeEditorPane = memo<CodeEditorPaneProps>(
           instanceRef.current = null;
         }
       };
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     useEffect(() => {

--- a/src/features/Conversation/StoreUpdater.tsx
+++ b/src/features/Conversation/StoreUpdater.tsx
@@ -96,7 +96,7 @@ const StoreUpdater = memo<StoreUpdaterProps>(
           storeApi.setState({ messagesInit: true });
         }
       }
-    }, [contextKey]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [contextKey, context, messages, storeApi]);
 
     // Sync external messages into store
     useEffect(() => {

--- a/src/features/ExplorerTree/view/ExplorerTree.tsx
+++ b/src/features/ExplorerTree/view/ExplorerTree.tsx
@@ -65,6 +65,7 @@ function ExplorerTreeInner<TData>(
   ref: ForwardedRef<ExplorerTreeHandle>,
 ) {
   const propsRef = useRef(props);
+  const initialPropsRef = useRef(props);
   propsRef.current = props;
 
   const adapterRef = useRef<NormalizedTree<TData>>(normalizeTree(props.nodes));
@@ -77,13 +78,14 @@ function ExplorerTreeInner<TData>(
   const renamingRef = useRef(false);
 
   const initialOptions = useMemo((): FileTreeOptions => {
+    const initialProps = initialPropsRef.current;
     const initial = adapterRef.current;
     const initialExpandedPaths = remapIdsToPaths(
-      props.defaultExpandedIds ?? props.defaultExpanded,
+      initialProps.defaultExpandedIds ?? initialProps.defaultExpanded,
       initial.pathById,
     );
     const initialSelectedPaths = remapIdsToPaths(
-      props.defaultSelectedIds ?? props.defaultSelected,
+      initialProps.defaultSelectedIds ?? initialProps.defaultSelected,
       initial.pathById,
     );
 
@@ -93,7 +95,7 @@ function ExplorerTreeInner<TData>(
         : (adapterRef.current.nodeById.get(adapterRef.current.idByPath.get(path) ?? '') ?? null);
 
     return {
-      density: props.density,
+      density: initialProps.density,
       dragAndDrop: {
         canDrag: (paths) => {
           const fn = propsRef.current.canDrag;
@@ -157,13 +159,13 @@ function ExplorerTreeInner<TData>(
         },
       },
       icons: {
-        colored: props.iconsColored ?? true,
-        set: props.iconSet ?? 'standard',
+        colored: initialProps.iconsColored ?? true,
+        set: initialProps.iconSet ?? 'standard',
       },
-      gitStatus: props.gitStatus,
+      gitStatus: initialProps.gitStatus,
       initialExpandedPaths,
       initialSelectedPaths,
-      itemHeight: props.itemHeight,
+      itemHeight: initialProps.itemHeight,
       onSelectionChange: (paths) => {
         if (suppressModelEventsRef.current) return;
         const ids = remapPathsToIds(paths, adapterRef.current.idByPath);
@@ -171,7 +173,7 @@ function ExplorerTreeInner<TData>(
         lastEmittedSelectedIds.current = ids;
         propsRef.current.onSelectedChange?.(ids);
       },
-      overscan: props.overscan,
+      overscan: initialProps.overscan,
       paths: initial.paths,
       renaming: {
         canRename: (item) => {
@@ -215,10 +217,9 @@ function ExplorerTreeInner<TData>(
         if (!node) return null;
         return (fn({ node }) as FileTreeRowDecoration | null) ?? null;
       },
-      unsafeCSS: props.unsafeCSS,
+      unsafeCSS: initialProps.unsafeCSS,
     };
     // we build options ONCE; callbacks read propsRef to stay fresh
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const renamingNodeRef = useRef<ExplorerTreeNode<TData> | null>(null);

--- a/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
+++ b/src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
@@ -191,50 +191,53 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
    * Try to refresh the access token using a refresh token
    * This is used during initialization when the access token is expired or invalid
    */
-  const tryRefreshToken = async (refreshTokenValue: string): Promise<boolean> => {
-    try {
-      const clientId = isDesktop ? 'lobehub-desktop' : 'lobechat-com';
+  const tryRefreshToken = useCallback(
+    async (refreshTokenValue: string): Promise<boolean> => {
+      try {
+        const clientId = isDesktop ? 'lobehub-desktop' : 'lobechat-com';
 
-      const response = await lambdaClient.market.oidc.refreshToken.mutate({
-        clientId,
-        refreshToken: refreshTokenValue,
-      });
+        const response = await lambdaClient.market.oidc.refreshToken.mutate({
+          clientId,
+          refreshToken: refreshTokenValue,
+        });
 
-      // Calculate new expiration time (default to 1 hour if not provided)
-      const expiresIn = response.expiresIn ?? 3600;
-      const expiresAt = Date.now() + expiresIn * 1000;
+        // Calculate new expiration time (default to 1 hour if not provided)
+        const expiresIn = response.expiresIn ?? 3600;
+        const expiresAt = Date.now() + expiresIn * 1000;
 
-      // Save new tokens to DB
-      await saveMarketTokensToDB(response.accessToken, response.refreshToken, expiresAt);
+        // Save new tokens to DB
+        await saveMarketTokensToDB(response.accessToken, response.refreshToken, expiresAt);
 
-      // Fetch user info with new token
-      const userInfo = await fetchUserInfo(response.accessToken);
+        // Fetch user info with new token
+        const userInfo = await fetchUserInfo(response.accessToken);
 
-      // Update session state
-      const newSession: MarketAuthSession = {
-        accessToken: response.accessToken,
-        expiresAt,
-        expiresIn,
-        scope: response.scope || 'openid profile email',
-        tokenType: 'Bearer',
-        userInfo: userInfo || undefined,
-      };
+        // Update session state
+        const newSession: MarketAuthSession = {
+          accessToken: response.accessToken,
+          expiresAt,
+          expiresIn,
+          scope: response.scope || 'openid profile email',
+          tokenType: 'Bearer',
+          userInfo: userInfo || undefined,
+        };
 
-      setSession(newSession);
-      setStatus('authenticated');
+        setSession(newSession);
+        setStatus('authenticated');
 
-      console.info('[MarketAuth] Token refreshed successfully during initialization');
-      return true;
-    } catch (error) {
-      console.error('[MarketAuth] Failed to refresh token during initialization:', error);
-      return false;
-    }
-  };
+        console.info('[MarketAuth] Token refreshed successfully during initialization');
+        return true;
+      } catch (error) {
+        console.error('[MarketAuth] Failed to refresh token during initialization:', error);
+        return false;
+      }
+    },
+    [isDesktop],
+  );
 
   /**
    * Initialize: check and restore session, fetch user info
    */
-  const initializeSession = async () => {
+  const initializeSession = useCallback(async () => {
     setStatus('loading');
 
     // If Trusted Client authentication is enabled, fetch user info directly from backend (without token)
@@ -318,7 +321,7 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
 
     setSession(restoredSession);
     setStatus('authenticated');
-  };
+  }, [enableMarketTrustedClient, tryRefreshToken]);
 
   /**
    * The actual sign-in method (internal use)
@@ -672,8 +675,7 @@ export const MarketAuthProvider = ({ children, isDesktop }: MarketAuthProviderPr
     if (isUserStateInit) {
       initializeSession();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isUserStateInit, enableMarketTrustedClient]);
+  }, [initializeSession, isUserStateInit]);
 
   /**
    * Auto-refresh token before expiration


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Closes #16499

#### 🔀 Description of Change

Removes the remaining `react-hooks/exhaustive-deps` suppressions in the current codebase and keeps the existing behavior explicit:

- Updates `CodeEditorPane` to keep one-time CodeMirror initialization while reading latest initialization values through refs.
- Updates `Conversation/StoreUpdater` to include the missing layout effect dependencies.
- Updates `ExplorerTree` to separate initial props from fresh callback props, preserving one-time tree option creation.
- Updates `MarketAuthProvider` to stabilize session initialization callbacks and include them in hook dependencies.

Note: the issue description mentions 8 suppressions, while the current branch contains 4 remaining `exhaustive-deps` suppressions in the listed files.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Suggested checks:

```bash
rg -n "exhaustive-deps" src/components/CodeEditorPane/index.tsx src/features/Conversation/StoreUpdater.tsx src/features/ExplorerTree/view/ExplorerTree.tsx src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
pnpm exec eslint src/components/CodeEditorPane/index.tsx src/features/Conversation/StoreUpdater.tsx src/features/ExplorerTree/view/ExplorerTree.tsx src/layout/AuthProvider/MarketAuth/MarketAuthProvider.tsx
bunx vitest run --silent='passed-only' 'src/features/ExplorerTree/view/ExplorerTree.test.tsx'
pnpm type-check
```

#### 📸 Screenshots / Videos

N/A. No UI changes.

#### 📝 Additional Information

This PR removes hook dependency lint suppressions without adding user-facing behavior changes.
