### PR TITLE
🔒 chore(deps): lock @lobehub/editor to 4.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -291,7 +291,7 @@
     "@lobehub/analytics": "^1.6.2",
     "@lobehub/charts": "^5.0.0",
     "@lobehub/desktop-ipc-typings": "workspace:*",
-    "@lobehub/editor": "4.19.2",
+    "@lobehub/editor": "4.18.0",
     "@lobehub/icons": "^5.0.0",
     "@lobehub/market-sdk": "0.39.1",
     "@lobehub/tts": "^5.1.2",
@@ -564,7 +564,7 @@
       "ffmpeg-static"
     ],
     "overrides": {
-      "@lobehub/editor": "4.19.2",
+      "@lobehub/editor": "4.18.0",
       "@react-pdf/image": "3.0.4",
       "@types/react": "19.2.13",
       "@vitest/coverage-v8": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -291,7 +291,7 @@
     "@lobehub/analytics": "^1.6.2",
     "@lobehub/charts": "^5.0.0",
     "@lobehub/desktop-ipc-typings": "workspace:*",
-    "@lobehub/editor": "^4.17.1",
+    "@lobehub/editor": "4.19.2",
     "@lobehub/icons": "^5.0.0",
     "@lobehub/market-sdk": "0.39.1",
     "@lobehub/tts": "^5.1.2",
@@ -564,6 +564,7 @@
       "ffmpeg-static"
     ],
     "overrides": {
+      "@lobehub/editor": "4.19.2",
       "@react-pdf/image": "3.0.4",
       "@types/react": "19.2.13",
       "@vitest/coverage-v8": "3.2.6",


### PR DESCRIPTION
### 💡 Description

Pin `@lobehub/editor` to an exact version `4.18.0` to lock the dependency.

- Change root direct dependency `@lobehub/editor` from `^4.17.1` to `4.18.0`
- Add `pnpm.overrides["@lobehub/editor"] = "4.18.0"` so all workspace packages (`editor-runtime`, builtin-tools, etc.) resolve to the same exact version

fix：https://github.com/lobehub/lobehub/issues/16568

🤖 Generated with [Claude Code](https://claude.com/claude-code)