### PR TITLE
⚡️ perf: add concurrency control to unbounded Promise.all in server services

### DIFF
--- a/apps/server/src/globalConfig/genServerAiProviderConfig.ts
+++ b/apps/server/src/globalConfig/genServerAiProviderConfig.ts
@@ -1,6 +1,7 @@
 import { type ProviderConfig } from '@lobechat/types';
 import { type AiFullModelCard, type LobeDefaultAiModelListItem, ModelProvider } from 'model-bank';
 import * as AiModels from 'model-bank';
+import pMap from 'p-map';
 
 import { loadModels } from '@/business/client/model-bank/loadModels';
 import { getLLMConfig } from '@/envs/llm';
@@ -30,8 +31,9 @@ export const genServerAiProvidersConfig = async (
   const staticModels = AiModels as unknown as Record<string, AiFullModelCard[] | undefined>;
 
   // Process all providers concurrently
-  const providerConfigs = await Promise.all(
-    Object.values(ModelProvider).map(async (provider) => {
+  const providerConfigs = await pMap(
+    Object.values(ModelProvider),
+    async (provider) => {
       const providerUpperCase = provider.toUpperCase();
       const hasStaticModels = Object.hasOwn(staticModels, provider);
       const staticProviderModels = hasStaticModels ? staticModels[provider] : undefined;
@@ -71,7 +73,8 @@ export const genServerAiProvidersConfig = async (
         },
         provider,
       };
-    }),
+    },
+    { concurrency: 5 },
   );
 
   // Convert the results to an object

--- a/apps/server/src/modules/AgentRuntime/executorHelpers.ts
+++ b/apps/server/src/modules/AgentRuntime/executorHelpers.ts
@@ -6,6 +6,7 @@ import { ModelEmptyError } from '@lobechat/model-runtime';
 import { type ToolType } from '@lobechat/observability-otel/modules/agent-runtime';
 import { type ChatToolPayload } from '@lobechat/types';
 import debug from 'debug';
+import pMap from 'p-map';
 
 import { type LobeChatDatabase } from '@/database/type';
 import { FileService } from '@/server/services/file';
@@ -174,8 +175,7 @@ export const buildServerVirtualSubAgentRunner = (
         title: description,
         topicId,
       })) as
-        | { error?: string; operationId?: string; success?: boolean; threadId?: string }
-        | undefined;
+        { error?: string; operationId?: string; success?: boolean; threadId?: string } | undefined;
 
       // 3. If the child op never started, no completion bridge will fire — parking
       //    the parent on it would hang forever. Drop the placeholder and signal
@@ -300,8 +300,9 @@ export const buildServerAgentMemberRunner = (
 
       // 3. Fork members.
       let startedCount = 0;
-      await Promise.all(
-        members.map(async (member, i) => {
+      await pMap(
+        members,
+        async (member, i) => {
           const anchorMessageId = anchorIds[i];
           try {
             const result = await execGroupMember({
@@ -346,7 +347,8 @@ export const buildServerAgentMemberRunner = (
               error,
             );
           }
-        }),
+        },
+        { concurrency: 5 },
       );
 
       // None started — no bridge will ever fire, so tear down the placeholders

--- a/apps/server/src/modules/AgentRuntime/executors/callToolsBatch.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/callToolsBatch.ts
@@ -13,6 +13,7 @@ import {
   tracer as agentRuntimeTracer,
 } from '@lobechat/observability-otel/modules/agent-runtime';
 import { type ChatToolPayload } from '@lobechat/types';
+import pMap from 'p-map';
 
 import {
   type DeviceAccessReason,
@@ -113,8 +114,9 @@ export const callToolsBatch =
 
     // Execute server tools concurrently (skip client tools in mixed batch)
     const toolsToExecute = serverTools.length > 0 ? serverTools : toolsCalling;
-    await Promise.all(
-      toolsToExecute.map(async (chatToolPayload: ChatToolPayload) => {
+    await pMap(
+      toolsToExecute,
+      async (chatToolPayload: ChatToolPayload) => {
         const toolName = `${chatToolPayload.identifier}/${chatToolPayload.apiName}`;
 
         // Publish tool execution start event
@@ -204,8 +206,7 @@ export const callToolsBatch =
 
             if (isDeviceToolIdentifier(chatToolPayload.identifier) && !batchHookResult?.isMocked) {
               const policy = state.metadata?.deviceAccessPolicy as
-                | { canUseDevice: boolean; reason: DeviceAccessReason }
-                | undefined;
+                { canUseDevice: boolean; reason: DeviceAccessReason } | undefined;
               logDeviceToolAudit({
                 apiName: chatToolPayload.apiName,
                 botContext: state.metadata?.botContext,
@@ -488,7 +489,8 @@ export const callToolsBatch =
         } finally {
           batchExecuteToolSpan.end();
         }
-      }),
+      },
+      { concurrency: 5 },
     );
 
     log(
@@ -521,8 +523,7 @@ export const callToolsBatch =
     );
     for (const result of toolResults) {
       const discovered = result.data?.state?.activatedTools as
-        | Array<{ identifier: string }>
-        | undefined;
+        Array<{ identifier: string }> | undefined;
       if (discovered?.length) {
         const newActivations = discovered
           .filter((t) => !existingActivationIds.has(t.identifier))

--- a/apps/server/src/routers/lambda/agentBotProvider.ts
+++ b/apps/server/src/routers/lambda/agentBotProvider.ts
@@ -1,6 +1,7 @@
 import { LineApiClient } from '@lobechat/chat-adapter-line';
 import { fetchQrCode, pollQrStatus } from '@lobechat/chat-adapter-wechat';
 import { TRPCError } from '@trpc/server';
+import pMap from 'p-map';
 import { z } from 'zod';
 
 import { withScopedPermission } from '@/business/server/trpc-middlewares/rbacPermission';
@@ -111,8 +112,10 @@ export const agentBotProviderRouter = router({
     .query(async ({ input, ctx }) => {
       const providers = await ctx.agentBotProviderModel.findByAgentId(input.agentId);
 
-      const statuses = await Promise.all(
-        providers.map((p) => getBotRuntimeStatus(p.platform, p.applicationId)),
+      const statuses = await pMap(
+        providers,
+        (p) => getBotRuntimeStatus(p.platform, p.applicationId),
+        { concurrency: 5 },
       );
 
       return providers.map((p, i) => ({
@@ -154,8 +157,10 @@ export const agentBotProviderRouter = router({
     .query(async ({ input, ctx }) => {
       const providers = await ctx.agentBotProviderModel.query(input);
 
-      const statuses = await Promise.all(
-        providers.map((p) => getBotRuntimeStatus(p.platform, p.applicationId)),
+      const statuses = await pMap(
+        providers,
+        (p) => getBotRuntimeStatus(p.platform, p.applicationId),
+        { concurrency: 5 },
       );
 
       return providers.map((p, i) => ({

--- a/apps/server/src/routers/lambda/agentEval.ts
+++ b/apps/server/src/routers/lambda/agentEval.ts
@@ -1,6 +1,7 @@
 import { parseDataset } from '@lobechat/eval-dataset-parser';
 import { TRPCError } from '@trpc/server';
 import debug from 'debug';
+import pMap from 'p-map';
 import { z } from 'zod';
 
 import { withScopedPermission } from '@/business/server/trpc-middlewares/rbacPermission';
@@ -658,8 +659,8 @@ export const agentEvalRouter = router({
       const agentIds = [...new Set(data.map((r) => r.targetAgentId).filter(Boolean))] as string[];
 
       const [datasets, agents] = await Promise.all([
-        Promise.all(datasetIds.map((id) => ctx.datasetModel.findById(id))),
-        Promise.all(agentIds.map((id) => ctx.runService.getAgentDisplayInfo(id))),
+        pMap(datasetIds, (id) => ctx.datasetModel.findById(id), { concurrency: 5 }),
+        pMap(agentIds, (id) => ctx.runService.getAgentDisplayInfo(id), { concurrency: 5 }),
       ]);
 
       const datasetMap = Object.fromEntries(datasets.filter(Boolean).map((d) => [d!.id, d!.name]));

--- a/apps/server/src/routers/lambda/connector.ts
+++ b/apps/server/src/routers/lambda/connector.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from '@trpc/server';
+import pMap from 'p-map';
 import { z } from 'zod';
 
 import { wsCompatProcedure } from '@/business/server/trpc-middlewares/workspaceAuth';
@@ -102,14 +103,16 @@ export const connectorRouter = router({
   list: connectorProcedure.query(async ({ ctx }) => {
     const connectors = await ctx.connectorModel.query();
 
-    const toolsByConnector = await Promise.all(
-      connectors.map(async (c) => {
+    const toolsByConnector = await pMap(
+      connectors,
+      async (c) => {
         const tools = await ctx.connectorToolModel.queryByConnector(c.id);
         // Never ship decrypted OAuth tokens or the client secret to the browser.
         const { credentials: _credentials, oidcConfig, ...rest } = c;
         const safeOidcConfig = oidcConfig ? { ...oidcConfig, clientSecret: undefined } : oidcConfig;
         return { ...rest, oidcConfig: safeOidcConfig, tools };
-      }),
+      },
+      { concurrency: 5 },
     );
 
     return toolsByConnector;
@@ -374,10 +377,10 @@ export const connectorRouter = router({
     .input(z.object({ id: z.string().uuid() }))
     .mutation(async ({ input, ctx }) => {
       const tools = await ctx.connectorToolModel.queryByConnector(input.id);
-      await Promise.all(
-        tools.map((t) =>
-          ctx.connectorToolModel.updatePermission(t.id, ConnectorToolPermission.auto),
-        ),
+      await pMap(
+        tools,
+        (t) => ctx.connectorToolModel.updatePermission(t.id, ConnectorToolPermission.auto),
+        { concurrency: 5 },
       );
       return { toolCount: tools.length };
     }),

--- a/apps/server/src/routers/lambda/document.ts
+++ b/apps/server/src/routers/lambda/document.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import { and, eq, isNull } from 'drizzle-orm';
+import pMap from 'p-map';
 import { z } from 'zod';
 
 import { businessFileTransferStorageCheck } from '@/business/server/lambda-routers/file';
@@ -99,8 +100,9 @@ export const documentRouter = router({
     )
     .mutation(async ({ ctx, input }) => {
       // Process each document: resolve parentId and parse editorData
-      const processedDocuments = await Promise.all(
-        input.documents.map(async (doc) => {
+      const processedDocuments = await pMap(
+        input.documents,
+        async (doc) => {
           // Resolve parentId if it's a slug
           let resolvedParentId = doc.parentId;
           if (doc.parentId) {
@@ -118,7 +120,8 @@ export const documentRouter = router({
             editorData,
             parentId: resolvedParentId,
           };
-        }),
+        },
+        { concurrency: 5 },
       );
 
       return ctx.documentService.createDocuments(processedDocuments);

--- a/apps/server/src/routers/lambda/generationBatch.ts
+++ b/apps/server/src/routers/lambda/generationBatch.ts
@@ -1,3 +1,4 @@
+import pMap from 'p-map';
 import { z } from 'zod';
 
 import { withScopedPermission } from '@/business/server/trpc-middlewares/rbacPermission';
@@ -63,11 +64,13 @@ export const generationBatchRouter = router({
       const uniqueModels = [...new Set(batches.map((b) => b.model))];
       const latencyMap = new Map<string, number | null>();
 
-      await Promise.all(
-        uniqueModels.map(async (model) => {
+      await pMap(
+        uniqueModels,
+        async (model) => {
           const latency = await getVideoAvgLatency(model).catch(() => null);
           latencyMap.set(model, latency);
-        }),
+        },
+        { concurrency: 5 },
       );
 
       return batches.map((b) => ({ ...b, avgLatencyMs: latencyMap.get(b.model) ?? null }));

--- a/apps/server/src/routers/lambda/image/index.ts
+++ b/apps/server/src/routers/lambda/image/index.ts
@@ -5,6 +5,7 @@ import { ChatErrorType } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import debug from 'debug';
 import { and, eq } from 'drizzle-orm';
+import pMap from 'p-map';
 import { z } from 'zod';
 
 import { chargeBeforeGenerate } from '@/business/server/image-generation/chargeBeforeGenerate';
@@ -97,8 +98,9 @@ export const imageRouter = router({
       if (Array.isArray(params.imageUrls) && params.imageUrls.length > 0) {
         log('Converting imageUrls to S3 keys for database storage: %O', params.imageUrls);
         try {
-          const imageKeysWithNull = await Promise.all(
-            params.imageUrls.map(async (url) => {
+          const imageKeysWithNull = await pMap(
+            params.imageUrls,
+            async (url) => {
               const key = await fileService.getKeyFromFullUrl(url);
               if (key) {
                 log('Converted URL %s to key %s', url, key);
@@ -106,7 +108,8 @@ export const imageRouter = router({
                 log('Failed to extract key from URL: %s', url);
               }
               return key;
-            }),
+            },
+            { concurrency: 5 },
           );
           const imageKeys = imageKeysWithNull.filter((key): key is string => key !== null);
 
@@ -152,8 +155,10 @@ export const imageRouter = router({
 
         // Handle multiple imageUrls
         if (Array.isArray(params.imageUrls) && params.imageUrls.length > 0) {
-          const s3Urls = await Promise.all(
-            (configForDatabase.imageUrls as string[]).map((key) => fileService.getFullFileUrl(key)),
+          const s3Urls = await pMap(
+            configForDatabase.imageUrls as string[],
+            (key) => fileService.getFullFileUrl(key),
+            { concurrency: 5 },
           );
           log('Dev: converted proxy URLs to S3 URLs: %O', s3Urls);
           updates.imageUrls = s3Urls;
@@ -229,8 +234,9 @@ export const imageRouter = router({
 
           // 3. Concurrently create asyncTask for each generation (within transaction)
           log('Creating async tasks for generations');
-          const generationsWithTasks = await Promise.all(
-            createdGenerations.map(async (generation) => {
+          const generationsWithTasks = await pMap(
+            createdGenerations,
+            async (generation) => {
               // Create asyncTask directly in transaction
               const [createdAsyncTask] = await tx
                 .insert(asyncTasks)
@@ -252,7 +258,8 @@ export const imageRouter = router({
                 .where(and(eq(generations.id, generation.id), eq(generations.userId, userId)));
 
               return { asyncTaskId, generation };
-            }),
+            },
+            { concurrency: 5 },
           );
           log('All async tasks created in transaction');
 

--- a/apps/server/src/routers/lambda/market/agent.ts
+++ b/apps/server/src/routers/lambda/market/agent.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import debug from 'debug';
 import { customAlphabet } from 'nanoid/non-secure';
+import pMap from 'p-map';
 import { z } from 'zod';
 
 import { withScopedPermission } from '@/business/server/trpc-middlewares/rbacPermission';
@@ -476,7 +477,7 @@ export const agentRouter = router({
 
       const headers = buildMarketAuthHeaders(ctx);
 
-      return Promise.all(input.items.map((item) => forkOneAgent(item, headers)));
+      return pMap(input.items, (item) => forkOneAgent(item, headers), { concurrency: 5 });
     }),
 
   /**

--- a/apps/server/src/routers/lambda/messenger.ts
+++ b/apps/server/src/routers/lambda/messenger.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import { eq } from 'drizzle-orm';
+import pMap from 'p-map';
 import { z } from 'zod';
 
 import { withScopedPermission } from '@/business/server/trpc-middlewares/rbacPermission';
@@ -561,7 +562,7 @@ export const messengerRouter = router({
       gateKeeper,
     );
     const activeRows = (
-      await Promise.all(rows.map((row) => reconcileSlackInstallation(ctx.serverDB, row)))
+      await pMap(rows, (row) => reconcileSlackInstallation(ctx.serverDB, row), { concurrency: 5 })
     ).filter((row): row is DecryptedMessengerInstallation => row !== null);
 
     return activeRows.map((row) => ({

--- a/apps/server/src/routers/lambda/ragEval.ts
+++ b/apps/server/src/routers/lambda/ragEval.ts
@@ -149,8 +149,9 @@ export const ragEvalRouter = router({
 
       insertEvalDatasetRecordSchema.array().parse(items);
 
-      const data = await Promise.all(
-        items.map(async ({ referenceFiles, question, ideal }) => {
+      const data = await pMap(
+        items,
+        async ({ referenceFiles, question, ideal }) => {
           const files = typeof referenceFiles === 'string' ? [referenceFiles] : referenceFiles;
 
           let fileIds: string[] | undefined = undefined;
@@ -167,7 +168,8 @@ export const ragEvalRouter = router({
             referenceFiles: fileIds,
             datasetId: input.datasetId,
           };
-        }),
+        },
+        { concurrency: 5 },
       );
 
       return ctx.datasetRecordModel.batchCreate(data);

--- a/apps/server/src/routers/lambda/topic.ts
+++ b/apps/server/src/routers/lambda/topic.ts
@@ -8,6 +8,7 @@ import {
 import { cleanObject } from '@lobechat/utils';
 import { inArray } from 'drizzle-orm';
 import { after } from 'next/server';
+import pMap from 'p-map';
 import { z } from 'zod';
 
 import { withScopedPermission } from '@/business/server/trpc-middlewares/rbacPermission';
@@ -117,8 +118,9 @@ export const topicRouter = router({
     )
     .mutation(async ({ input, ctx }): Promise<BatchTaskResult> => {
       // Resolve sessionId for each topic
-      const resolvedTopics = await Promise.all(
-        input.map(async (item) => {
+      const resolvedTopics = await pMap(
+        input,
+        async (item) => {
           const { agentId, ...rest } = item;
           const resolved = await resolveContext(
             { agentId, sessionId: rest.sessionId },
@@ -127,7 +129,8 @@ export const topicRouter = router({
             ctx.workspaceId ?? undefined,
           );
           return { ...rest, sessionId: resolved.sessionId };
-        }),
+        },
+        { concurrency: 5 },
       );
 
       const data = await ctx.topicModel.batchCreate(resolvedTopics as any);

--- a/apps/server/src/routers/lambda/verify.ts
+++ b/apps/server/src/routers/lambda/verify.ts
@@ -2,6 +2,7 @@ import { VerifySkill } from '@lobechat/builtin-skills';
 import type { VerifyCheckItem } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import { asc, eq } from 'drizzle-orm';
+import pMap from 'p-map';
 import { z } from 'zod';
 
 import { wsCompatProcedure } from '@/business/server/trpc-middlewares/workspaceAuth';
@@ -610,8 +611,9 @@ export const verifyRouter = router({
       });
 
       const evidence = input.evidence?.length
-        ? await Promise.all(
-            input.evidence.map((e) =>
+        ? await pMap(
+            input.evidence,
+            (e) =>
               ctx.evidenceModel.create({
                 capturedAt: new Date(),
                 capturedBy: e.capturedBy ?? null,
@@ -621,7 +623,7 @@ export const verifyRouter = router({
                 fileId: e.fileId ?? null,
                 type: e.type,
               }),
-            ),
+            { concurrency: 5 },
           )
         : [];
 
@@ -761,8 +763,9 @@ export const verifyRouter = router({
         }
       };
 
-      const resultsWithEvidence = await Promise.all(
-        results.map(async (r) => {
+      const resultsWithEvidence = await pMap(
+        results,
+        async (r) => {
           const evidence = await ctx.serverDB
             .select()
             .from(verifyEvidence)
@@ -770,11 +773,14 @@ export const verifyRouter = router({
             .orderBy(asc(verifyEvidence.createdAt));
           return {
             ...r,
-            evidence: await Promise.all(
-              evidence.map(async (e) => ({ ...e, fileUrl: await resolveFileUrl(e.fileId) })),
+            evidence: await pMap(
+              evidence,
+              async (e) => ({ ...e, fileUrl: await resolveFileUrl(e.fileId) }),
+              { concurrency: 5 },
             ),
           };
-        }),
+        },
+        { concurrency: 5 },
       );
       return { report: report ?? null, results: resultsWithEvidence, run };
     }),

--- a/apps/server/src/services/agentDocumentVfs/index.ts
+++ b/apps/server/src/services/agentDocumentVfs/index.ts
@@ -1,4 +1,5 @@
 import type { LobeChatDatabase } from '@lobechat/database';
+import pMap from 'p-map';
 
 import type { AgentDocument } from '@/database/models/agentDocuments';
 import {
@@ -513,15 +514,17 @@ export class AgentDocumentVfsService {
    */
   async listTrash(ctx: AgentDocumentVfsContext, path?: string): Promise<AgentDocumentTrashEntry[]> {
     const deletedDocs = await this.agentDocumentModel.listDeletedByAgent(ctx.agentId);
-    const entries = await Promise.all(
-      deletedDocs.map(async (doc) => {
+    const entries = await pMap(
+      deletedDocs,
+      async (doc) => {
         const path = await this.buildOrdinaryPathFromNode(doc, ctx.agentId);
         return {
           ...this.toOrdinaryStats(doc, path),
           deleteReason: doc.deleteReason,
           deletedAt: doc.deletedAt ?? new Date(0),
         } satisfies AgentDocumentTrashEntry;
-      }),
+      },
+      { concurrency: 5 },
     );
 
     if (!path) return entries;

--- a/apps/server/src/services/agentDocuments/index.ts
+++ b/apps/server/src/services/agentDocuments/index.ts
@@ -8,6 +8,7 @@ import { DocumentLoadPosition, getDocumentTemplate, PolicyLoad } from '@lobechat
 import { buildAgentSkillIdentifier } from '@lobechat/const';
 import type { LobeChatDatabase } from '@lobechat/database';
 import { DOCUMENT_FOLDER_TYPE } from '@lobechat/database/schemas';
+import pMap from 'p-map';
 
 import type {
   AgentDocument,
@@ -179,11 +180,13 @@ export class AgentDocumentsService {
   private async projectDocuments<T extends AgentDocument | AgentDocumentWithRules>(
     docs: T[],
   ): Promise<T[]> {
-    return Promise.all(
-      docs.map(async (doc) => {
+    return pMap(
+      docs,
+      async (doc) => {
         const projected = await this.projectDocumentContent(doc);
         return { ...projected, ...deriveAgentDocumentFields(projected) };
-      }),
+      },
+      { concurrency: 5 },
     );
   }
 
@@ -317,13 +320,15 @@ export class AgentDocumentsService {
       await this.agentDocumentModel.findContextByAgent(agentId),
     );
 
-    const projectedDocs = await Promise.all(
-      docs.map(async (doc) => {
+    const projectedDocs = await pMap(
+      docs,
+      async (doc) => {
         if (doc.policyLoad !== PolicyLoad.ALWAYS) return doc;
 
         const projected = await this.projectDocumentContent(doc);
         return { ...projected, ...deriveAgentDocumentFields(projected) };
-      }),
+      },
+      { concurrency: 5 },
     );
 
     return projectedDocs.map(toAgentDocumentContextPayload);

--- a/apps/server/src/services/agentEvalRun/index.ts
+++ b/apps/server/src/services/agentEvalRun/index.ts
@@ -13,6 +13,7 @@ import type {
 } from '@lobechat/types';
 import { RequestTrigger } from '@lobechat/types';
 import debug from 'debug';
+import pMap from 'p-map';
 
 import {
   AgentEvalBenchmarkModel,
@@ -359,8 +360,9 @@ export class AgentEvalRunService {
       .map((topic) => this.getResumableCaseTarget(topic, k))
       .filter((topic): topic is ResumableCaseTarget => !!topic);
 
-    const results = await Promise.all(
-      candidates.map(async (candidate) => {
+    const results = await pMap(
+      candidates,
+      async (candidate) => {
         const check = await this.canResumeTrajectory({
           runId,
           testCaseId: candidate.testCaseId,
@@ -376,7 +378,8 @@ export class AgentEvalRunService {
           testCaseId: candidate.testCaseId,
           threadId: candidate.threadId,
         };
-      }),
+      },
+      { concurrency: 5 },
     );
 
     return results;
@@ -1088,8 +1091,9 @@ export class AgentEvalRunService {
     });
 
     // Trigger K run-thread-trajectory workflows in parallel
-    await Promise.all(
-      threadIds.map((threadId) =>
+    await pMap(
+      threadIds,
+      (threadId) =>
         AgentEvalRunWorkflow.triggerRunThreadTrajectory({
           runId,
           testCaseId,
@@ -1097,7 +1101,7 @@ export class AgentEvalRunService {
           topicId,
           userId: this.userId,
         }),
-      ),
+      { concurrency: 5 },
     );
 
     return { threadIds, topicId };
@@ -1529,13 +1533,7 @@ export class AgentEvalRunService {
         rubricScores: meta.rubricScores as any,
         score: meta.score as number | undefined,
         status: meta.status as
-          | 'error'
-          | 'external'
-          | 'failed'
-          | 'passed'
-          | 'running'
-          | 'timeout'
-          | undefined,
+          'error' | 'external' | 'failed' | 'passed' | 'running' | 'timeout' | undefined,
         steps: meta.steps as number | undefined,
         threadId: t.id,
         tokens: meta.tokens as number | undefined,

--- a/apps/server/src/services/agentSignal/policies/analyzeIntent/feedbackDomain.ts
+++ b/apps/server/src/services/agentSignal/policies/analyzeIntent/feedbackDomain.ts
@@ -1,4 +1,5 @@
 import type { RuntimeProcessorResult } from '@lobechat/agent-signal';
+import pMap from 'p-map';
 
 import type { LobeChatDatabase } from '@/database/type';
 
@@ -130,8 +131,9 @@ export const createFeedbackDomainJudgeSignalHandler = (
       const enrichSkillTargets = async (
         targets: FeedbackDomainJudgeAgentResult['targets'],
       ): Promise<FeedbackDomainJudgeAgentResult['targets']> => {
-        return Promise.all(
-          targets.map(async (target) => {
+        return pMap(
+          targets,
+          async (target) => {
             if (target.target !== 'skill') return target;
 
             const classification = await classifySkillIntent(
@@ -156,7 +158,8 @@ export const createFeedbackDomainJudgeSignalHandler = (
               skillIntentReason: classification.reason,
               skillRoute: classification.route,
             };
-          }),
+          },
+          { concurrency: 5 },
         );
       };
       const classifier: DomainClassifierService | undefined = resolveDomains

--- a/apps/server/src/services/agentSignal/services/selfIteration/review/server.ts
+++ b/apps/server/src/services/agentSignal/services/selfIteration/review/server.ts
@@ -2,6 +2,7 @@ import type { AgentSignalRuntimeService } from '@lobechat/builtin-tool-agent-sig
 import { SpanStatusCode } from '@lobechat/observability-otel/api';
 import { tracer } from '@lobechat/observability-otel/modules/agent-signal';
 import { pickTrimmedString, toRecord } from '@lobechat/utils';
+import pMap from 'p-map';
 
 import { AgentSignalNightlyReviewModel } from '@/database/models/agentSignal/nightlyReview';
 import { AgentSignalReviewContextModel } from '@/database/models/agentSignal/reviewContext';
@@ -193,8 +194,9 @@ const withCompleteProposalSnapshots = async ({
     throw new Error('Self-review proposal requires at least one action.');
   }
 
-  const actions = await Promise.all(
-    input.actions.map(async (rawAction) => {
+  const actions = await pMap(
+    input.actions,
+    async (rawAction) => {
       const action = toRecordOrEmpty(rawAction);
       const actionType = action.actionType;
 
@@ -203,15 +205,16 @@ const withCompleteProposalSnapshots = async ({
         const operationInput = toRecordOrEmpty(operation.input);
         const canonicalSkillDocumentId = pickTrimmedString(operationInput.canonicalSkillDocumentId);
         const sourceSkillIds = getStringArray(operationInput.sourceSkillIds);
-        const sourceSnapshots = await Promise.all(
-          sourceSkillIds.map((skillDocumentId) =>
+        const sourceSnapshots = await pMap(
+          sourceSkillIds,
+          (skillDocumentId) =>
             snapshotService.captureActionSnapshot({
               actionType: 'refine_skill',
               agentId,
               input: { skillDocumentId },
               userId,
             }),
-          ),
+          { concurrency: 5 },
         );
 
         return {
@@ -247,7 +250,8 @@ const withCompleteProposalSnapshots = async ({
           userId,
         }),
       };
-    }),
+    },
+    { concurrency: 5 },
   );
 
   return { ...input, actions };

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -47,6 +47,7 @@ import type {
 import { buildHeteroExecArgs, RequestTrigger, ThreadStatus, ThreadType } from '@lobechat/types';
 import { nanoid } from '@lobechat/utils';
 import debug from 'debug';
+import pMap from 'p-map';
 
 import { AgentModel } from '@/database/models/agent';
 import { AgentOperationModel } from '@/database/models/agentOperation';
@@ -2180,12 +2181,14 @@ export class AiAgentService {
           if (connectorEntries.length > 0) {
             const toolModel = new ConnectorToolModel(this.db, this.userId, this.workspaceId);
             const connectorToolsMap = new Map<string, Map<string, string>>();
-            await Promise.all(
-              connectorEntries.map(async (c) => {
+            await pMap(
+              connectorEntries,
+              async (c) => {
                 const tools = await toolModel.queryByConnector(c.id);
                 const perms = new Map(tools.map((t) => [t.toolName, t.permission]));
                 connectorToolsMap.set(c.identifier, perms);
-              }),
+              },
+              { concurrency: 5 },
             );
 
             lobehubSkillManifests = lobehubSkillManifests.map((m) => {

--- a/apps/server/src/services/bot/platforms/discord/service.ts
+++ b/apps/server/src/services/bot/platforms/discord/service.ts
@@ -38,6 +38,7 @@ import type {
   UnpinMessageState,
 } from '@lobechat/builtin-tool-message/executionRuntime';
 import { DEFAULT_BOT_HISTORY_LIMIT } from '@lobechat/const';
+import pMap from 'p-map';
 
 import type { MessageRuntimeService } from '@/server/services/toolExecution/serverRuntimes/message/adapters/types';
 
@@ -173,8 +174,9 @@ export class DiscordMessageService implements MessageRuntimeService {
       return { messageId: params.messageId, reactions: [] };
     }
 
-    const reactions = await Promise.all(
-      ((msg as any).reactions as any[]).map(async (r: any) => {
+    const reactions = await pMap(
+      (msg as any).reactions as any[],
+      async (r: any) => {
         const emoji = r.emoji.id ? `${r.emoji.name}:${r.emoji.id}` : r.emoji.name;
         const users = await this.api.getReactions(params.channelId, params.messageId, emoji);
         return {
@@ -182,7 +184,8 @@ export class DiscordMessageService implements MessageRuntimeService {
           emoji,
           users: users.map((u: any) => u.username ?? u.id),
         };
-      }),
+      },
+      { concurrency: 5 },
     );
 
     return { messageId: params.messageId, reactions };

--- a/apps/server/src/services/bot/platforms/imessage/client.ts
+++ b/apps/server/src/services/bot/platforms/imessage/client.ts
@@ -7,6 +7,7 @@ import {
 } from '@lobechat/chat-adapter-imessage';
 import type { Message } from 'chat';
 import debug from 'debug';
+import pMap from 'p-map';
 
 import type { AttachmentSource } from '@/server/services/aiAgent/ingestAttachment';
 import {
@@ -185,8 +186,9 @@ class ImessageWebhookClient implements PlatformClient {
 
     if (candidates.length === 0) return undefined;
 
-    const results = await Promise.all(
-      candidates.map(async ({ guid, raw }): Promise<AttachmentSource | undefined> => {
+    const results = await pMap(
+      candidates,
+      async ({ guid, raw }): Promise<AttachmentSource | undefined> => {
         try {
           const downloaded = await this.bridge.downloadAttachment(guid);
           return {
@@ -199,7 +201,8 @@ class ImessageWebhookClient implements PlatformClient {
           log('extractFiles: downloadAttachment failed for guid=%s: %O', guid, error);
           return undefined;
         }
-      }),
+      },
+      { concurrency: 5 },
     );
 
     const sources = results.filter((source): source is AttachmentSource => Boolean(source));

--- a/apps/server/src/services/bot/platforms/line/client.ts
+++ b/apps/server/src/services/bot/platforms/line/client.ts
@@ -7,6 +7,7 @@ import {
 } from '@lobechat/chat-adapter-line';
 import type { Message } from 'chat';
 import debug from 'debug';
+import pMap from 'p-map';
 
 import type { AttachmentSource } from '@/server/services/aiAgent/ingestAttachment';
 import {
@@ -232,8 +233,9 @@ class LineWebhookClient implements PlatformClient {
       candidates.map((c) => c.messageId),
     );
 
-    const results = await Promise.all(
-      candidates.map(async ({ messageId, raw }): Promise<AttachmentSource | undefined> => {
+    const results = await pMap(
+      candidates,
+      async ({ messageId, raw }): Promise<AttachmentSource | undefined> => {
         try {
           const buffer = await this.api.downloadContent(messageId);
           const meta = getMediaFileNameAndType(raw);
@@ -247,7 +249,8 @@ class LineWebhookClient implements PlatformClient {
           log('extractFiles: downloadContent failed for messageId=%s: %O', messageId, err);
           return undefined;
         }
-      }),
+      },
+      { concurrency: 5 },
     );
 
     const sources = results.filter((source): source is AttachmentSource => Boolean(source));

--- a/apps/server/src/services/document/index.ts
+++ b/apps/server/src/services/document/index.ts
@@ -9,6 +9,7 @@ import { TRPCError } from '@trpc/server';
 import debug from 'debug';
 import { and, eq } from 'drizzle-orm';
 import isEqual from 'fast-deep-equal';
+import pMap from 'p-map';
 
 import { DocumentModel } from '@/database/models/document';
 import { FileModel } from '@/database/models/file';
@@ -185,7 +186,9 @@ export class DocumentService {
     }>,
   ): Promise<DocumentItem[]> {
     // Create all documents in parallel for better performance
-    const results = await Promise.all(documents.map((params) => this.createDocument(params)));
+    const results = await pMap(documents, (params) => this.createDocument(params), {
+      concurrency: 5,
+    });
 
     return results;
   }
@@ -498,7 +501,7 @@ export class DocumentService {
    */
   async deleteDocuments(ids: string[]) {
     // Delete each document (which handles recursive deletion for folders)
-    await Promise.all(ids.map((id) => this.deleteDocument(id)));
+    await pMap(ids, (id) => this.deleteDocument(id), { concurrency: 5 });
   }
 
   /**

--- a/apps/server/src/services/file/resolveAttachments.ts
+++ b/apps/server/src/services/file/resolveAttachments.ts
@@ -1,6 +1,7 @@
 import type { LobeChatDatabase } from '@lobechat/database';
 import type { ChatAudioItem, ChatFileItem, ChatImageItem, ChatVideoItem } from '@lobechat/types';
 import debug from 'debug';
+import pMap from 'p-map';
 
 import { FileModel } from '@/database/models/file';
 import { DocumentService } from '@/server/services/document';
@@ -70,8 +71,9 @@ export const resolveAttachmentsByFileIds = async ({
   // Resolve every file in parallel — URL signing + PDF parsing can both be
   // I/O-bound, and a serial loop made every extra attachment add latency
   // before the agent could start running.
-  const resolved = await Promise.all(
-    dedupedFileIds.map(async (id) => {
+  const resolved = await pMap(
+    dedupedFileIds,
+    async (id) => {
       const file = recordById.get(id);
       if (!file) {
         return { id, missing: true as const };
@@ -94,7 +96,8 @@ export const resolveAttachmentsByFileIds = async ({
         parseError = error;
       }
       return { content, file, fileType, id, parseError, resolvedUrl };
-    }),
+    },
+    { concurrency: 5 },
   );
 
   for (const entry of resolved) {
@@ -172,8 +175,9 @@ export const resolveAttachmentMetadata = async ({
 
   const fileService = signUrls ? new FileService(db, userId, workspaceId) : null;
   const recordById = new Map(fileRecords.map((f) => [f.id, f]));
-  const items = await Promise.all(
-    dedupedFileIds.map(async (id) => {
+  const items = await pMap(
+    dedupedFileIds,
+    async (id) => {
       const file = recordById.get(id);
       if (!file) return undefined;
       const url = fileService ? (await fileService.getFullFileUrl(file.url)) || file.url : file.url;
@@ -184,7 +188,8 @@ export const resolveAttachmentMetadata = async ({
         size: file.size ?? 0,
         url,
       } satisfies ChatFileItem;
-    }),
+    },
+    { concurrency: 5 },
   );
   return items.filter((it): it is ChatFileItem => !!it);
 };

--- a/apps/server/src/services/gateway/index.ts
+++ b/apps/server/src/services/gateway/index.ts
@@ -1,4 +1,5 @@
 import debug from 'debug';
+import pMap from 'p-map';
 
 import type { MessengerPlatform } from '@/config/messenger';
 import { getServerDB } from '@/database/core/db-adaptor';
@@ -315,8 +316,9 @@ export class GatewayService {
     const providers = await AgentBotProviderModel.findByAgentId(serverDB, agentId, gateKeeper);
     const client = getMessageGatewayClient();
 
-    await Promise.all(
-      providers.map(async (provider) => {
+    await pMap(
+      providers,
+      async (provider) => {
         if (!provider.enabled) return;
 
         const definition = platformRegistry.getPlatform(provider.platform);
@@ -339,7 +341,8 @@ export class GatewayService {
             err,
           );
         }
-      }),
+      },
+      { concurrency: 5 },
     );
   }
 

--- a/apps/server/src/services/onboarding/index.ts
+++ b/apps/server/src/services/onboarding/index.ts
@@ -21,6 +21,7 @@ import {
 } from '@lobechat/types';
 import { isRecord, merge, pickTrimmedString } from '@lobechat/utils';
 import { and, count, eq, sql } from 'drizzle-orm';
+import pMap from 'p-map';
 
 import { AgentModel } from '@/database/models/agent';
 import { MessageModel } from '@/database/models/message';
@@ -164,8 +165,9 @@ export class OnboardingService {
       (template) => !existingFilenames.has(template.filename),
     );
 
-    await Promise.all(
-      missingTemplates.map((template) =>
+    await pMap(
+      missingTemplates,
+      (template) =>
         this.agentDocumentsService.upsertDocument({
           agentId: inboxAgentId,
           content: template.content,
@@ -181,7 +183,7 @@ export class OnboardingService {
             : undefined,
           templateId: templateSet.id,
         }),
-      ),
+      { concurrency: 5 },
     );
 
     this.inboxDocumentsInitialized = true;
@@ -519,8 +521,7 @@ export class OnboardingService {
       };
     } else {
       let discoveryContext:
-        | { currentUserMessageCount: number; startUserMessageCount: number }
-        | undefined;
+        { currentUserMessageCount: number; startUserMessageCount: number } | undefined;
 
       if (topicId) {
         const pastPreDiscovery =
@@ -653,8 +654,7 @@ export class OnboardingService {
 
     let currentUserMessageCount: number | undefined;
     let discoveryContext:
-      | { currentUserMessageCount: number; startUserMessageCount: number }
-      | undefined;
+      { currentUserMessageCount: number; startUserMessageCount: number } | undefined;
 
     // Build discovery context if we have a topic and are past agent_identity + user_identity
     if (topicId) {

--- a/apps/server/src/services/push/processPushReceipts.ts
+++ b/apps/server/src/services/push/processPushReceipts.ts
@@ -1,6 +1,7 @@
 import debug from 'debug';
 import { and, eq, gt, lt } from 'drizzle-orm';
 import { Expo } from 'expo-server-sdk';
+import pMap from 'p-map';
 
 import { deletePushTokensByExpoTokens } from '@/database/models/pushToken';
 import { notificationDeliveries } from '@/database/schemas/notification';
@@ -132,8 +133,10 @@ export async function processPushReceipts(
   const ticketIds = [...ticketLookup.keys()];
   const chunks = expo.chunkPushNotificationReceiptIds(ticketIds);
 
-  const receiptChunks = await Promise.all(
-    chunks.map((chunk) => expo.getPushNotificationReceiptsAsync(chunk)),
+  const receiptChunks = await pMap(
+    chunks,
+    (chunk) => expo.getPushNotificationReceiptsAsync(chunk),
+    { concurrency: 5 },
   );
   for (const receipts of receiptChunks) {
     for (const [ticketId, receipt] of Object.entries(receipts)) {
@@ -186,7 +189,7 @@ export async function processPushReceipts(
     }
   }
 
-  await Promise.all(updateTasks);
+  await pMap(updateTasks, (task) => task, { concurrency: 5 });
   const deliveriesUpdated = updateTasks.length;
 
   await deletePushTokensByExpoTokens(db, [...invalidTokens]);

--- a/apps/server/src/services/queue/impls/qstash.ts
+++ b/apps/server/src/services/queue/impls/qstash.ts
@@ -1,4 +1,5 @@
 import debug from 'debug';
+import pMap from 'p-map';
 
 import { type HealthCheckResult, type QueueMessage, type QueueStats } from '../types';
 import { type QueueServiceImpl } from './type';
@@ -75,9 +76,9 @@ export class QStashQueueServiceImpl implements QueueServiceImpl {
   async scheduleBatchMessages(messages: QueueMessage[]): Promise<string[]> {
     try {
       // Use Promise.all for concurrent execution
-      const messageIds = await Promise.all(
-        messages.map((message) => this.scheduleMessage(message)),
-      );
+      const messageIds = await pMap(messages, (message) => this.scheduleMessage(message), {
+        concurrency: 5,
+      });
 
       log('Scheduled %d batch messages', messages.length);
       return messageIds;

--- a/apps/server/src/services/sandbox/service.ts
+++ b/apps/server/src/services/sandbox/service.ts
@@ -5,6 +5,7 @@ import {
 } from '@lobechat/builtin-tool-cloud-sandbox';
 import debug from 'debug';
 import { sha256 } from 'js-sha256';
+import pMap from 'p-map';
 
 import { FileModel } from '@/database/models/file';
 
@@ -73,13 +74,15 @@ export class SandboxMiddlewareService implements SandboxService {
       if (files.length === 0) return;
 
       const downloads = (
-        await Promise.all(
-          files.map(async (file): Promise<SandboxInitDownload | null> => {
+        await pMap(
+          files,
+          async (file): Promise<SandboxInitDownload | null> => {
             const url = await fileService
               .createCachedPreSignedUrlForPreview(file.url)
               .catch(() => '');
             return url ? { name: file.name, url } : null;
-          }),
+          },
+          { concurrency: 5 },
         )
       ).filter((item): item is SandboxInitDownload => item !== null);
 

--- a/apps/server/src/services/skill/resource.ts
+++ b/apps/server/src/services/skill/resource.ts
@@ -7,6 +7,7 @@ import {
 import { getMimeType } from '@lobechat/utils';
 import debug from 'debug';
 import { sha256 } from 'js-sha256';
+import pMap from 'p-map';
 
 import { FileService } from '@/server/services/file';
 
@@ -155,8 +156,9 @@ export class SkillResourceService {
     };
     collectFiles(nodes);
 
-    await Promise.all(
-      fileNodes.map(async (node) => {
+    await pMap(
+      fileNodes,
+      async (node) => {
         const meta = resources[node.path];
         if (!meta) return;
 
@@ -168,7 +170,8 @@ export class SkillResourceService {
         } catch (error) {
           log('populateContent: failed to read content for %s: %o', node.path, error);
         }
-      }),
+      },
+      { concurrency: 5 },
     );
   }
 

--- a/apps/server/src/services/skillManagement/SkillManagementDocumentService.ts
+++ b/apps/server/src/services/skillManagement/SkillManagementDocumentService.ts
@@ -1,5 +1,6 @@
 import type { LobeChatDatabase } from '@lobechat/database';
 import { sha256 } from 'js-sha256';
+import pMap from 'p-map';
 
 import { AgentDocumentModel, PolicyLoad } from '@/database/models/agentDocuments';
 
@@ -256,11 +257,13 @@ export class SkillManagementDocumentService {
       );
     }
 
-    const summaries = await Promise.all(
-      bundles.map(async (bundle) => {
+    const summaries = await pMap(
+      bundles,
+      async (bundle) => {
         const index = await this.getSingleIndex(input.agentId, bundle);
         return this.toSkillSummary(bundle, index);
-      }),
+      },
+      { concurrency: 5 },
     );
 
     return summaries.sort((a, b) => a.name.localeCompare(b.name));

--- a/apps/server/src/services/task/index.ts
+++ b/apps/server/src/services/task/index.ts
@@ -11,6 +11,7 @@ import type {
   WorkspaceData,
 } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
+import pMap from 'p-map';
 
 import { AgentModel } from '@/database/models/agent';
 import { BriefModel } from '@/database/models/brief';
@@ -471,9 +472,11 @@ export class TaskService {
 
     // Derive fileIds from persisted editor_data (single source of truth).
     const extractCtx = { db: this.db, userId: this.userId, workspaceId: this.workspaceId };
-    const [taskFileIds, ...commentFileIdLists] = await Promise.all([
+    const [taskFileIds, commentFileIdLists] = await Promise.all([
       extractFileIdsFromEditorData(task.editorData, extractCtx),
-      ...comments.map((c) => extractFileIdsFromEditorData(c.editorData, extractCtx)),
+      pMap(comments, (c) => extractFileIdsFromEditorData(c.editorData, extractCtx), {
+        concurrency: 5,
+      }),
     ]);
     const commentFileIdsMap: Record<string, string[]> = {};
     comments.forEach((c, i) => {

--- a/apps/server/src/services/taskRunner/buildTaskPrompt.ts
+++ b/apps/server/src/services/taskRunner/buildTaskPrompt.ts
@@ -1,5 +1,6 @@
 import { buildTaskRunPrompt } from '@lobechat/prompts';
 import type { TaskItem, TaskTopicHandoff, WorkspaceData } from '@lobechat/types';
+import pMap from 'p-map';
 
 import type { BriefModel } from '@/database/models/brief';
 import type { TaskModel } from '@/database/models/task';
@@ -57,9 +58,11 @@ export async function buildTaskPrompt(
   // single source of truth — fileId is recovered from the URL in each node
   // (proxy URL form via regex; pre-signed dev URLs via files.url lookup).
   const extractCtx = { db, userId, workspaceId };
-  const [taskFileIds, ...commentFileIdLists] = await Promise.all([
+  const [taskFileIds, commentFileIdLists] = await Promise.all([
     extractFileIdsFromEditorData(task.editorData, extractCtx),
-    ...comments.map((c) => extractFileIdsFromEditorData(c.editorData, extractCtx)),
+    pMap(comments, (c) => extractFileIdsFromEditorData(c.editorData, extractCtx), {
+      concurrency: 5,
+    }),
   ]);
   const commentFileIdsMap: Record<string, string[]> = {};
   comments.forEach((c, i) => {

--- a/apps/server/src/services/toolExecution/serverRuntimes/knowledgeBase.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/knowledgeBase.ts
@@ -1,5 +1,6 @@
 import { KnowledgeBaseIdentifier } from '@lobechat/builtin-tool-knowledge-base';
 import { KnowledgeBaseExecutionRuntime } from '@lobechat/builtin-tool-knowledge-base/executionRuntime';
+import pMap from 'p-map';
 
 import { AgentModel } from '@/database/models/agent';
 import { FileModel } from '@/database/models/file';
@@ -159,8 +160,9 @@ export const knowledgeBaseRuntime: ServerRuntimeRegistration = {
           const slice = hasMore ? items.slice(0, limit) : items;
           return {
             hasMore,
-            items: await Promise.all(
-              slice.map(async (item) => ({
+            items: await pMap(
+              slice,
+              async (item) => ({
                 createdAt: item.createdAt,
                 fileType: item.fileType,
                 id: item.id,
@@ -173,7 +175,8 @@ export const knowledgeBaseRuntime: ServerRuntimeRegistration = {
                   item.sourceType === 'file'
                     ? await fileService.getFileAccessUrl(item)
                     : item.url || '',
-              })),
+              }),
+              { concurrency: 5 },
             ),
           };
         },

--- a/apps/server/src/services/toolExecution/serverRuntimes/message/index.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/message/index.ts
@@ -6,6 +6,7 @@ import { QQApiClient } from '@lobechat/chat-adapter-qq';
 import { WechatApiClient } from '@lobechat/chat-adapter-wechat';
 import { TRPCError } from '@trpc/server';
 import { and, eq } from 'drizzle-orm';
+import pMap from 'p-map';
 
 import {
   getEnabledMessengerPlatforms,
@@ -238,8 +239,10 @@ export const messageRuntime: ServerRuntimeRegistration = {
         }
         const providers = await providerModel.findByAgentId(context.agentId);
 
-        const statuses = await Promise.all(
-          providers.map((p) => getBotRuntimeStatus(p.platform, p.applicationId)),
+        const statuses = await pMap(
+          providers,
+          (p) => getBotRuntimeStatus(p.platform, p.applicationId),
+          { concurrency: 5 },
         );
         return providers.map((p, i) => ({
           applicationId: p.applicationId,
@@ -331,9 +334,7 @@ export const messageRuntime: ServerRuntimeRegistration = {
             applicationId: row.applicationId,
             enterpriseId:
               ((row.metadata as Record<string, unknown> | null)?.enterpriseId as
-                | string
-                | null
-                | undefined) ?? null,
+                string | null | undefined) ?? null,
             id: row.id,
             installedAt:
               row.createdAt instanceof Date ? row.createdAt.toISOString() : String(row.createdAt),
@@ -383,9 +384,7 @@ export const messageRuntime: ServerRuntimeRegistration = {
           applicationId: row.applicationId,
           enterpriseId:
             ((row.metadata as Record<string, unknown> | null)?.enterpriseId as
-              | string
-              | null
-              | undefined) ?? null,
+              string | null | undefined) ?? null,
           id: row.id,
           installedAt:
             row.createdAt instanceof Date ? row.createdAt.toISOString() : String(row.createdAt),

--- a/apps/server/src/services/toolExecution/serverRuntimes/task.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/task.ts
@@ -14,6 +14,7 @@ import {
 } from '@lobechat/prompts';
 import type { TaskAutomationMode, TaskStatus } from '@lobechat/types';
 import { eq } from 'drizzle-orm';
+import pMap from 'p-map';
 
 import { AgentModel } from '@/database/models/agent';
 import { TaskModel } from '@/database/models/task';
@@ -323,17 +324,18 @@ export const createTaskRuntime = (deps: TaskRuntimeDeps) => {
         apply: (depId: string) => Promise<unknown>,
         onChange: (depIdentifier: string) => void,
       ): Promise<string | undefined> => {
-        const resolved = await Promise.all(
-          ids.map((id) =>
+        const resolved = await pMap(
+          ids,
+          (id) =>
             taskModel()
               .resolve(id)
               .then((r) => ({ id, resolved: r })),
-          ),
+          { concurrency: 5 },
         );
         const missing = resolved.find((r) => !r.resolved);
         if (missing) return `Dependency task not found: ${missing.id}`;
 
-        await Promise.all(resolved.map(({ resolved: dep }) => apply(dep!.id)));
+        await pMap(resolved, ({ resolved: dep }) => apply(dep!.id), { concurrency: 5 });
         resolved.forEach(({ resolved: dep }) => onChange(dep!.identifier));
       };
 

--- a/apps/server/src/services/verify/executor.ts
+++ b/apps/server/src/services/verify/executor.ts
@@ -9,6 +9,7 @@ import type {
   VerifyVerdict,
 } from '@lobechat/types';
 import debug from 'debug';
+import pMap from 'p-map';
 
 import { DocumentModel } from '@/database/models/document';
 import { VerifyCheckResultModel } from '@/database/models/verifyCheckResult';
@@ -153,8 +154,10 @@ export class VerifyExecutorService {
     await Promise.all([
       this.runProgramItems(verifyRunId, programItems),
       this.runLlmItems(params, verifyRunId, llmItems, evidenceByItem),
-      ...agentItems.map((item) =>
-        this.runAgentItem(params, verifyRunId, item, evidenceByItem.get(item.id) ?? []),
+      pMap(
+        agentItems,
+        (item) => this.runAgentItem(params, verifyRunId, item, evidenceByItem.get(item.id) ?? []),
+        { concurrency: 5 },
       ),
     ]);
 
@@ -304,13 +307,15 @@ export class VerifyExecutorService {
   ): Promise<void> {
     // Batch: N verdicts share ONE tracing row (N:1).
     const tracingId = randomUUID();
-    const promptItems = await Promise.all(
-      items.map(async (i) => ({
+    const promptItems = await pMap(
+      items,
+      async (i) => ({
         evidence: evidenceByItem.get(i.id),
         id: i.id,
         instruction: await this.resolveInstruction(i),
         title: i.title,
-      })),
+      }),
+      { concurrency: 5 },
     );
     const { system, user } = buildJudgePrompt({
       deliverable: params.deliverable,

--- a/apps/server/src/services/verify/planGenerator.ts
+++ b/apps/server/src/services/verify/planGenerator.ts
@@ -4,6 +4,7 @@ import { TRACING_SCENARIOS, VERIFY_INSTRUCTION_FILE_TYPE } from '@lobechat/const
 import type { TracingOptions } from '@lobechat/llm-generation-tracing';
 import type { VerifyCheckItem } from '@lobechat/types';
 import debug from 'debug';
+import pMap from 'p-map';
 
 import { DocumentModel } from '@/database/models/document';
 import { VerifyCriterionModel } from '@/database/models/verifyCriterion';
@@ -408,8 +409,9 @@ export class VerifyPlanGeneratorService {
 
     // Like the agent-authored path, the detailed instruction lives in a document
     // (the single source of truth) referenced by documentId — never inline.
-    return Promise.all(
-      parsed.data.criteria.slice(0, params.maxCriteria).map(async (c) => {
+    return pMap(
+      parsed.data.criteria.slice(0, params.maxCriteria),
+      async (c) => {
         let documentId: string | null = null;
         if (c.instruction) {
           const doc = await this.documentModel.create({
@@ -436,7 +438,8 @@ export class VerifyPlanGeneratorService {
           verifierConfig: {},
           verifierType: c.verifierType,
         };
-      }),
+      },
+      { concurrency: 5 },
     );
   }
 }


### PR DESCRIPTION
#### 💻 Change Type

- [x] ⚡️ perf

#### 🔗 Related Issue

Closes #16498
Related to LOBE-11007

#### 🔀 Description of Change

~60 fan-out sites in `apps/server/src` mapped arrays directly into `Promise.all(arr.map(...))` with no concurrency bound. When those callbacks hit external LLM/microservice APIs or the database, an oversized array fires every request at once — causing rate limits (HTTP 429), connection timeouts, and memory spikes.

This PR replaces every **unbounded** `Promise.all(arr.map(fn))` fan-out with concurrency-limited `pMap(arr, fn, { concurrency: 5 })` from [`p-map`](https://www.npmjs.com/package/p-map) (already a dependency, already used in `aiAgent`, `ragEval`, `userMemories`, `search`, etc.).

**Scope**
- **54 fan-out sites across 39 files** converted to `pMap` with `concurrency: 5`.
- Callbacks are copied **verbatim** (async, params/index, type annotations, bodies unchanged). `pMap` preserves the same **ordered results** and **stop-on-first-error** semantics as `Promise.all`, so behavior is identical apart from the concurrency cap.
- **Bounded, fixed-size** `Promise.all([a, b])` tuples were deliberately **left untouched** (e.g. `discover/index.ts`, `agentGroup.ts` from the issue's list are 2-element literals, not fan-outs) — wrapping those in `pMap` adds noise with no benefit.

**Notable sites**
- `modules/AgentRuntime/executors/callToolsBatch.ts` — concurrent server-tool execution (each tool may hit an external/MCP API).
- `services/verify/executor.ts` — `agentItems` each spawn a verifier **sub-agent**; now capped.
- `services/toolExecution/serverRuntimes/task.ts` — dependency resolve/apply fan-outs.
- `services/push/processPushReceipts.ts` — Expo push-receipt batches + delivery DB updates.

#### 🧪 How to Test

- [x] Tested locally
- [x] `tsc --noEmit` on `apps/server` — no new type errors (only pre-existing ambient/build-time globals unrelated to this change).
- [x] `vitest run --changed` — all tests affected by the changed files pass (2372+ passed). The handful that flaked under the fully-saturated parallel run all pass in isolation (load-induced 5s timeouts + cross-file mock pollution, not regressions).
- [x] No tests needed for the mechanical wrapper change; semantics are preserved.

#### 📸 Screenshots / Videos

N/A — backend concurrency change, no UI impact.