### PR TITLE
🐛 fix(agent-runtime): reuse seeded assistant placeholder on tool-first resume

### DIFF
--- a/packages/agent-runtime/src/agents/GeneralChatAgent.ts
+++ b/packages/agent-runtime/src/agents/GeneralChatAgent.ts
@@ -758,13 +758,24 @@ export class GeneralChatAgent implements Agent {
         // Context compression completed, continue to call LLM
         const compressionPayload = context.payload as GeneralAgentCompressionResultPayload;
 
-        // If compression was skipped (no messages to compress), just call LLM
-        // Otherwise, messages have been updated with compressed content
-        // Pass parentMessageId and createAssistantMessage=true to force new message creation
+        // A tool-first resume seeds an assistant placeholder that the first
+        // post-tool LLM turn must fill. When that turn is large enough to
+        // compress first, the compress_context step (not a call_llm) leaves the
+        // seed unconsumed, so it reaches here still set — reuse it instead of
+        // forcing a new message, otherwise the placeholder is orphaned for
+        // exactly the high-context cases that trigger compression.
+        //
+        // If compression was skipped (no messages to compress), just call LLM.
+        // Otherwise, messages have been updated with compressed content, and a
+        // normal turn forces a fresh assistant message.
+        const seededAssistantMessageId = state.pendingAssistantMessageId;
+
         return {
           payload: {
-            // Force create new assistant message after compression
-            createAssistantMessage: true,
+            ...(seededAssistantMessageId
+              ? { assistantMessageId: seededAssistantMessageId }
+              : // Force create new assistant message after compression
+                { createAssistantMessage: true }),
             messages: compressionPayload.compressedMessages,
             model: this.config.modelRuntimeConfig?.model,
             parentMessageId: compressionPayload.parentMessageId,

--- a/packages/agent-runtime/src/agents/GeneralChatAgent.ts
+++ b/packages/agent-runtime/src/agents/GeneralChatAgent.ts
@@ -645,9 +645,13 @@ export class GeneralChatAgent implements Agent {
           return { reason: 'queued_message_interrupt', type: 'finish' };
         }
 
-        // No pending tools, continue to call LLM with tool results
+        // No pending tools, continue to call LLM with tool results.
+        // When this operation resumed by executing a tool first (e.g. the tools
+        // activator), reuse the placeholder seeded for that resume so this turn
+        // fills it instead of orphaning it (undefined for normal turns).
         return this.toLLMCall(
           {
+            assistantMessageId: state.pendingAssistantMessageId,
             messages: state.messages,
             model: this.config.modelRuntimeConfig?.model,
             parentMessageId,
@@ -683,9 +687,13 @@ export class GeneralChatAgent implements Agent {
           return { reason: 'queued_message_interrupt', type: 'finish' };
         }
 
-        // No pending tools, continue to call LLM with tool results
+        // No pending tools, continue to call LLM with tool results.
+        // When this operation resumed by executing a tool first (e.g. the tools
+        // activator), reuse the placeholder seeded for that resume so this turn
+        // fills it instead of orphaning it (undefined for normal turns).
         return this.toLLMCall(
           {
+            assistantMessageId: state.pendingAssistantMessageId,
             messages: state.messages,
             model: this.config.modelRuntimeConfig?.model,
             parentMessageId,

--- a/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
+++ b/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
@@ -1915,6 +1915,49 @@ describe('GeneralChatAgent', () => {
         },
       });
     });
+
+    // High-context tool-first resume: when the first post-tool turn compresses
+    // before running, the seeded placeholder must still be reused after
+    // compression rather than orphaned by createAssistantMessage.
+    it('should reuse the seeded assistant placeholder instead of forcing a new message', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        operationId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const compressedMessages = [
+        { content: 'Compressed summary', id: 'group-1', role: 'compressedGroup' },
+        { content: 'Latest user follow-up', role: 'user' },
+      ] as any;
+
+      const state = createMockState({
+        pendingAssistantMessageId: 'msg_seeded_placeholder',
+        tools: [{ name: 'search' }] as any,
+      });
+
+      const context = createMockContext('compression_result', {
+        compressedMessages,
+        parentMessageId: 'tool-msg-1',
+        skipped: false,
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual({
+        type: 'call_llm',
+        payload: {
+          assistantMessageId: 'msg_seeded_placeholder',
+          messages: compressedMessages,
+          model: 'gpt-4o-mini',
+          parentMessageId: 'tool-msg-1',
+          provider: 'openai',
+          tools: state.tools,
+        },
+      });
+      // Must not also force a brand-new message when reusing the placeholder.
+      expect((result as any).payload.createAssistantMessage).toBeUndefined();
+    });
   });
 
   describe('unknown phase', () => {

--- a/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
+++ b/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
@@ -746,6 +746,44 @@ describe('GeneralChatAgent', () => {
       });
     });
 
+    // Resume-seeded placeholder reuse: when an operation resumes by executing a
+    // tool first (e.g. the tools activator auto-approved via human_approved_tool),
+    // the seeded assistant placeholder is stashed on state.pendingAssistantMessageId.
+    // The first call_llm after the tool result must carry it so the LLM turn fills
+    // that placeholder instead of creating a new message and orphaning the seed.
+    it('should reuse the seeded assistant placeholder for the first call_llm after a tool result', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        operationId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const state = createMockState({
+        messages: [
+          { role: 'user', content: 'Hello' },
+          { role: 'assistant', content: '', tools: [] },
+          { role: 'tool', content: 'Successfully activated tools', tool_call_id: 'call-1' },
+        ] as any,
+        pendingAssistantMessageId: 'msg_seeded_placeholder',
+      });
+
+      const context = createMockContext('tool_result', { parentMessageId: 'tool-msg-1' });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual({
+        type: 'call_llm',
+        payload: {
+          assistantMessageId: 'msg_seeded_placeholder',
+          messages: state.messages,
+          model: 'gpt-4o-mini',
+          parentMessageId: 'tool-msg-1',
+          provider: 'openai',
+          tools: undefined,
+        },
+      });
+    });
+
     it('should return compress_context before continuing to LLM when tool results exceed window', async () => {
       const agent = createCompressionAgent();
 

--- a/packages/agent-runtime/src/core/__tests__/runtime.test.ts
+++ b/packages/agent-runtime/src/core/__tests__/runtime.test.ts
@@ -338,6 +338,70 @@ describe('AgentRuntime', () => {
           'Tool not found: unknown_tool',
         );
       });
+
+      // A resume that carries a seeded assistant placeholder must stash it on
+      // state so the follow-up call_llm reuses it — otherwise the placeholder is
+      // orphaned as an empty assistant sibling. See the tools-activator op-split.
+      it('should stash the resume-seeded assistantMessageId as pendingAssistantMessageId', async () => {
+        const agent = new MockAgent();
+        agent.tools = {
+          calculator: vi.fn().mockResolvedValue({ result: 42 }),
+        };
+
+        const runtime = new AgentRuntime(agent);
+        const state = AgentRuntime.createInitialState({ operationId: 'test-session' });
+
+        const result = await runtime.step(state, {
+          operationId: 'test-session',
+          phase: 'human_approved_tool',
+          payload: {
+            approvedToolCall: {
+              id: 'call_123',
+              apiName: 'calculator',
+              identifier: 'calculator',
+              arguments: '{"expression": "2+2"}',
+              type: 'default',
+            },
+            assistantMessageId: 'msg_seeded_placeholder',
+            parentMessageId: 'tool-msg-1',
+            skipCreateToolMessage: true,
+          },
+          session: {
+            sessionId: 'test-session',
+            messageCount: 0,
+            status: 'idle',
+            stepCount: 0,
+          },
+        } as any);
+
+        expect(result.newState.pendingAssistantMessageId).toBe('msg_seeded_placeholder');
+      });
+
+      // Consume-once: once a call_llm step runs it has filled (or replaced) the
+      // seeded placeholder, so the seed must be cleared before the next step —
+      // otherwise a later assistant turn would reuse the id and overwrite it.
+      it('should clear pendingAssistantMessageId after a call_llm step', async () => {
+        const agent = new MockAgent();
+        const callLlmExecutor = vi.fn(async (_instruction: any, state: AgentState) => ({
+          events: [],
+          newState: structuredClone(state),
+        }));
+
+        const runtime = new AgentRuntime(agent, {
+          executors: { call_llm: callLlmExecutor },
+        });
+        const state = AgentRuntime.createInitialState({ operationId: 'test-session' });
+        state.pendingAssistantMessageId = 'msg_seeded_placeholder';
+
+        // MockAgent.runner returns a call_llm instruction for the tool_result phase.
+        const result = await runtime.step(
+          state,
+          createTestContext('tool_result', { parentMessageId: 'tool-msg-1' }),
+        );
+
+        expect(callLlmExecutor).toHaveBeenCalled();
+        expect(result.newState.pendingAssistantMessageId).toBeUndefined();
+      });
     });
 
     describe('human interaction executors', () => {

--- a/packages/agent-runtime/src/core/runtime.ts
+++ b/packages/agent-runtime/src/core/runtime.ts
@@ -111,10 +111,22 @@ export class AgentRuntime {
       if (runtimeContext.phase === 'human_approved_tool') {
         const approvedPayload = runtimeContext.payload as {
           approvedToolCall: ChatToolPayload;
+          assistantMessageId?: string;
           parentMessageId: string;
           skipCreateToolMessage: boolean;
         };
         const toolCalling = approvedPayload.approvedToolCall;
+
+        // The resume seeded an assistant placeholder (assistantMessageId) for
+        // this operation, but the first instruction here is a tool execution —
+        // not an LLM call — so nothing consumes the placeholder and it would be
+        // left as an empty orphan sibling once the follow-up call_llm creates
+        // its own message. Stash the id on state so the first call_llm after
+        // the tool result reuses the placeholder instead (consumed once, then
+        // cleared in the instruction loop below).
+        if (approvedPayload.assistantMessageId) {
+          newState.pendingAssistantMessageId = approvedPayload.assistantMessageId;
+        }
 
         rawInstructions = {
           payload: {
@@ -193,6 +205,14 @@ export class AgentRuntime {
 
         // Update state
         currentState = result.newState;
+
+        // A call_llm consumes any resume-seeded assistant placeholder exactly
+        // once — it has now either reused that message id or created its own —
+        // so clear the seed before the next step. Otherwise a later assistant
+        // turn in the same operation would reuse the id and overwrite this one.
+        if (instruction.type === 'call_llm' && currentState.pendingAssistantMessageId) {
+          currentState.pendingAssistantMessageId = undefined;
+        }
 
         // Keep the last nextContext
         if (result.nextContext) {

--- a/packages/agent-runtime/src/types/generalAgent.ts
+++ b/packages/agent-runtime/src/types/generalAgent.ts
@@ -6,6 +6,12 @@ import {
 } from '@lobechat/types';
 
 export interface GeneralAgentCallLLMInstructionPayload {
+  /**
+   * Reuse an existing assistant message instead of creating a new one. Set when
+   * resuming from a tool-first step (e.g. tools activator) whose seeded
+   * placeholder must be filled by this LLM turn rather than orphaned.
+   */
+  assistantMessageId?: string;
   /** Force create a new assistant message (e.g., after compression) */
   createAssistantMessage?: boolean;
   isFirstMessage?: boolean;

--- a/packages/agent-runtime/src/types/state.ts
+++ b/packages/agent-runtime/src/types/state.ts
@@ -91,15 +91,23 @@ export interface AgentState {
 
   /** Operation-level tool set snapshot (immutable after creation) */
   operationToolSet?: OperationToolSet;
+  // --- HIL ---
+  /**
+   * Assistant placeholder seeded for a resume that starts by executing a tool
+   * (e.g. a human-approved / auto-approved tool such as the tools activator).
+   * The first `call_llm` after that tool consumes this id so its output reuses
+   * the placeholder instead of creating a new message and orphaning the seed.
+   * Cleared once consumed.
+   */
+  pendingAssistantMessageId?: string;
   pendingHumanPrompt?: { metadata?: Record<string, unknown>; prompt: string };
+
   pendingHumanSelect?: {
     metadata?: Record<string, unknown>;
     multi?: boolean;
     options: Array<{ label: string; value: string }>;
     prompt?: string;
   };
-
-  // --- HIL ---
   /**
    * When status is 'waiting_for_human', this stores pending requests
    * for human-in-the-loop operations.


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

When a LobeAI (server-side `GeneralChatAgent`) operation resumes by **executing a tool first** — e.g. the tools activator (`activateTools` / `lobe-activator`) auto-approved via the `human_approved_tool` phase — `execAgent` seeds an assistant placeholder (`content = "..."`) and passes its id to the operation as `payload.assistantMessageId`.

But the operation's first instruction is a `call_tool`, not a `call_llm`, so **nothing consumes the placeholder**. The follow-up `call_llm` (built by the `tool_result` / `tools_batch_result` branch) did not carry `assistantMessageId`, so `callLlm` created a brand-new assistant message and left the seed as an **empty `...` orphan sibling** under the tool result. The normal (`user_input`) flow only reuses the seed because it spreads `...(context.payload)` into the first `call_llm` — the resume path was missing that forwarding.

No user-facing impact (the read path only renders the main-line descendants), but every dynamic tool activation leaves a redundant empty assistant row in the DB.

**Fix** (all in `packages/agent-runtime`, inert for normal flows — the new field is `undefined`):
- Add `AgentState.pendingAssistantMessageId`.
- `core/runtime.ts`: the `human_approved_tool` branch stashes the seeded id onto state; the instruction loop clears it once a `call_llm` has consumed it (client + server).
- `GeneralChatAgent`: `tool_result` / `tools_batch_result` forward `state.pendingAssistantMessageId` to the follow-up `call_llm` so it fills the placeholder in place instead of orphaning it.
- `GeneralAgentCallLLMInstructionPayload`: add `assistantMessageId`.

Sample topic: two ops on one topic (one `waiting_for_human`, one `done`); the empty placeholder only appears at the continuation op's `steps[0].context.payload.assistantMessageId`.

#### 🧪 How to Test

- [x] Added/updated tests
- [x] Tested locally

`packages/agent-runtime` unit tests pass (127), including 3 new regression tests:
- runtime: `human_approved_tool` stashes the seeded id as `pendingAssistantMessageId`
- runtime: `call_llm` clears `pendingAssistantMessageId` (consume-once)
- GeneralChatAgent: the first `call_llm` after a tool result reuses the seeded placeholder

```
pnpm --filter @lobechat/agent-runtime test -- src/core/__tests__/runtime.test.ts src/agents/__tests__/GeneralChatAgent.test.ts
```

#### 📝 Additional Information

Distinct from the heterogeneous-agent anchor-collapse bugs (cold-replica CC write path) — this is a pure server-side LobeAI operation-split issue.

---

**Update (2026-07-04): real-world impact + share-view visibility.**

The "no user-facing impact" caveat above only holds for the live chat read path. In the **share / replay view** (which renders all sibling messages, not just main-line descendants) these empty `...` placeholders **are visible** to users.

The bug is **amplified by the tool-approval flow**: when a conversation requires human approval for every tool call, each approval spawns a fresh tool-first resume op, and each such op leaks one `...` orphan. Observed on a real topic (share `ARvl4Ufv`): 8 consecutive `waiting_for_human` ops in ~10 minutes produced **9 empty `...` orphan assistants — ~12.5% of all assistant rows** in the topic. Each orphan's `created_at` aligns exactly with a resume op's `started_at`; each resume op's steps are `[call_tool lobe-activator] → [call_llm → tool_call] → waiting_for_human`, matching the diagnosis above.