### PR TITLE
🐛 fix(floating-chat-panel): keep sheet background solid at full snap

### DIFF
--- a/src/features/FloatingChatPanel/index.tsx
+++ b/src/features/FloatingChatPanel/index.tsx
@@ -56,7 +56,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   sheetSeamless: css`
     border: none;
     border-radius: 0;
-    background: transparent;
     box-shadow: none;
   `,
   titleSpacer: css`


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- None linked -->

#### 🔀 Description of Change

`FloatingSheet` in `inline` mode grows past its resting height by applying a
negative `marginTop` (e.g. `-380px` at the 800px snap when resting at 420px),
so the sheet paints outside the parent `.panel` box. The panel's
`colorBgContainer` background only covers its own layout box, so the
overflowed top area shows as transparent whenever the user drags to the full
snap point.

The `sheetSeamless` class was overriding the sheet's default background to
`transparent`, relying on the parent to provide the color — which stops
working the moment the sheet extends past the parent. Removing that override
lets the sheet keep its default `${cssVar.colorBgContainer}` background across
its full painted height, including the overflowed region.

When the panel is collapsed the sheet has `visibility: hidden`, so this does
not affect the collapsed appearance.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Open a page that mounts `FloatingChatPanel`.
2. Expand the panel and drag the sheet to the full snap point (800px).
3. Verify the top of the sheet no longer shows through to the underlying
   content — the whole sheet area is solid `colorBgContainer`.
4. Collapse the panel; verify the collapsed appearance is unchanged.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Top of sheet transparent at max snap | Sheet solid across full height |

#### 📝 Additional Information

Existing `FloatingChatPanel` unit tests still pass (they mock `FloatingSheet`,
so this styling-only change is orthogonal to their assertions).