### PR TITLE
💄 style(shared-tool-ui): show empty state for empty Linear list results

### DIFF
--- a/locales/en-US/plugin.json
+++ b/locales/en-US/plugin.json
@@ -32,6 +32,7 @@
   "builtins.github.render.error": "Error",
   "builtins.github.render.rawResult": "Raw result",
   "builtins.github.render.updatedAt": "Updated {{time}}",
+  "builtins.linear.render.empty": "No {{collection}} found",
   "builtins.linear.render.updatedAt": "Updated {{time}}",
   "builtins.lobe-activator.apiName.activateTools": "Activate Tools",
   "builtins.lobe-activator.inspector.activateTools.notFoundCount": "{{count}} not found",

--- a/locales/zh-CN/plugin.json
+++ b/locales/zh-CN/plugin.json
@@ -32,6 +32,7 @@
   "builtins.github.render.error": "错误",
   "builtins.github.render.rawResult": "原始结果",
   "builtins.github.render.updatedAt": "更新于 {{time}}",
+  "builtins.linear.render.empty": "没有找到 {{collection}}",
   "builtins.linear.render.updatedAt": "更新于 {{time}}",
   "builtins.lobe-activator.apiName.activateTools": "激活工具",
   "builtins.lobe-activator.inspector.activateTools.notFoundCount": "{{count}} 个未找到",

--- a/packages/locales/src/default/plugin.ts
+++ b/packages/locales/src/default/plugin.ts
@@ -113,6 +113,7 @@ export default {
   'builtins.github.render.error': 'Error',
   'builtins.github.render.rawResult': 'Raw result',
   'builtins.github.render.updatedAt': 'Updated {{time}}',
+  'builtins.linear.render.empty': 'No {{collection}} found',
   'builtins.linear.render.updatedAt': 'Updated {{time}}',
   'builtins.lobe-cloud-sandbox.apiName.editFile': 'Edit file',
   'builtins.lobe-cloud-sandbox.apiName.executeCode': 'Execute code',

--- a/packages/shared-tool-ui/src/Render/Linear/index.tsx
+++ b/packages/shared-tool-ui/src/Render/Linear/index.tsx
@@ -4,7 +4,7 @@ import type { BuiltinRenderProps } from '@lobechat/types';
 import { fromNow } from '@lobechat/utils/time';
 import { Block, Flexbox, Highlighter, Icon, Markdown, Tag, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import { ExternalLink, Link2 } from 'lucide-react';
+import { ExternalLink, Inbox, Link2 } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -31,6 +31,21 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     padding-inline: 10px;
     border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: 6px;
+
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  empty: css`
+    display: flex;
+    gap: 6px;
+    align-items: center;
+    justify-content: center;
+
+    padding-block: 16px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: 6px;
+
+    font-size: 13px;
+    color: ${cssVar.colorTextTertiary};
 
     background: ${cssVar.colorFillQuaternary};
   `,
@@ -254,12 +269,16 @@ EntityCard.displayName = 'LinearRenderEntityCard';
 
 const LinearRender = memo<BuiltinRenderProps<Record<string, unknown>, unknown, unknown>>(
   ({ apiName, args, content, pluginError }) => {
+    const { t } = useTranslation('plugin');
     const model = useMemo(
       () => buildLinearRenderModel({ apiName, args, content, pluginError }),
       [apiName, args, content, pluginError],
     );
     const hasResult =
-      hasItems(model.resultEntities) || Boolean(model.resultText) || Boolean(model.rawResultJson);
+      hasItems(model.resultEntities) ||
+      Boolean(model.resultText) ||
+      Boolean(model.rawResultJson) ||
+      Boolean(model.emptyCollectionKey);
 
     // Request args are intentionally not rendered here — the Inspector already
     // surfaces the tool inputs, so duplicating them in the render is redundant.
@@ -276,6 +295,14 @@ const LinearRender = memo<BuiltinRenderProps<Record<string, unknown>, unknown, u
               />
             ))}
           </Flexbox>
+        )}
+        {model.emptyCollectionKey && (
+          <div className={styles.empty}>
+            <Icon icon={Inbox} size={14} />
+            <span>
+              {t('builtins.linear.render.empty', { collection: model.emptyCollectionKey })}
+            </span>
+          </div>
         )}
         {model.resultText && (
           <Highlighter

--- a/packages/shared-tool-ui/src/Render/Linear/utils.test.ts
+++ b/packages/shared-tool-ui/src/Render/Linear/utils.test.ts
@@ -195,4 +195,28 @@ describe('buildLinearRenderModel', () => {
 
     expect(model.resultText).toBe('No matching Linear issues found.');
   });
+
+  it('flags an empty list wrapper instead of dumping raw JSON', () => {
+    const model = buildLinearRenderModel({
+      apiName: 'mcp__claude_ai_Linear__list_comments',
+      args: { issueId: 'TEST-123' },
+      content: JSON.stringify({ comments: [], hasNextPage: false }),
+    });
+
+    expect(model.emptyCollectionKey).toBe('comments');
+    expect(model.resultEntities).toHaveLength(0);
+    // The whole point: no raw `{ "comments": [] }` block for an empty list.
+    expect(model.rawResultJson).toBeUndefined();
+  });
+
+  it('does not flag a get_* entity that merely embeds an empty sub-collection', () => {
+    const model = buildLinearRenderModel({
+      apiName: 'mcp__claude_ai_Linear__get_issue',
+      args: { id: 'TEST-456' },
+      content: JSON.stringify({ comments: [], id: 'TEST-456', title: 'Mock issue title' }),
+    });
+
+    expect(model.emptyCollectionKey).toBeUndefined();
+    expect(model.resultEntities).toHaveLength(1);
+  });
 });

--- a/packages/shared-tool-ui/src/Render/Linear/utils.ts
+++ b/packages/shared-tool-ui/src/Render/Linear/utils.ts
@@ -86,6 +86,12 @@ export const isUuidLike = (value: string): boolean => UUID_PATTERN.test(value);
 
 export interface LinearRenderModel {
   actionLabel: string;
+  /**
+   * Collection key (e.g. `comments`) when the result is a list wrapper that
+   * unwrapped to an empty array — drives the "no results" empty state instead of
+   * dumping raw JSON.
+   */
+  emptyCollectionKey?: string;
   errorText?: string;
   rawResultJson?: string;
   requestFields: LinearField[];
@@ -299,9 +305,15 @@ const ENTITY_IDENTITY_KEYS = ['id', 'identifier', 'title', 'name', 'subject'] as
 const looksLikeEntity = (record: Record<PropertyKey, unknown>): boolean =>
   ENTITY_IDENTITY_KEYS.some((key) => Boolean(readDisplayString(record[key])));
 
-const extractResultRecords = (value: unknown): Record<PropertyKey, unknown>[] => {
-  if (Array.isArray(value)) return value.filter(isRecord);
-  if (!isRecord(value)) return [];
+interface LinearResultShape {
+  /** The collection key when the result is a list wrapper (e.g. `comments`). */
+  collectionKey?: string;
+  records: Record<PropertyKey, unknown>[];
+}
+
+const extractResultShape = (value: unknown): LinearResultShape => {
+  if (Array.isArray(value)) return { records: value.filter(isRecord) };
+  if (!isRecord(value)) return { records: [] };
 
   // Wrapper responses (`list_*`, `search`, fetch-collection) carry their payload
   // in a nested collection (`{ issues: [...] }`, `{ results: [...] }`) and have
@@ -316,11 +328,11 @@ const extractResultRecords = (value: unknown): Record<PropertyKey, unknown>[] =>
   if (!looksLikeEntity(value)) {
     for (const key of RESULT_ARRAY_KEYS) {
       const nested = value[key];
-      if (Array.isArray(nested)) return nested.filter(isRecord);
+      if (Array.isArray(nested)) return { collectionKey: key, records: nested.filter(isRecord) };
     }
   }
 
-  return [value];
+  return { records: [value] };
 };
 
 const getErrorText = (error: unknown): string | undefined => {
@@ -348,17 +360,26 @@ export const buildLinearRenderModel = ({
 }): LinearRenderModel => {
   const parsedTool = parseToolName(apiName || '');
   const result = parseResultContent(content);
-  const resultEntities = extractResultRecords(result)
+  const { collectionKey, records } = extractResultShape(result);
+  const resultEntities = records
     .map(buildEntity)
     .filter((entity): entity is LinearEntity => Boolean(entity));
   const resultText = typeof result === 'string' ? result : undefined;
+  // A list wrapper that unwrapped to zero records (e.g. `{ comments: [] }`) is an
+  // intentional empty result — show a "no results" message rather than the raw
+  // JSON payload.
+  const emptyCollectionKey = collectionKey && records.length === 0 ? collectionKey : undefined;
   const rawResultJson =
-    result !== undefined && typeof result !== 'string' && resultEntities.length === 0
+    result !== undefined &&
+    typeof result !== 'string' &&
+    resultEntities.length === 0 &&
+    !emptyCollectionKey
       ? stringifyUnknown(result)
       : undefined;
 
   return {
     actionLabel: staticLabelFor(parsedTool),
+    emptyCollectionKey,
     errorText: getErrorText(pluginError),
     requestFields: getLinearRequestFields(args),
     requestLinks: isRecord(args) ? getLinearLinks(args.links) : [],


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔀 Description of Change

Linear list/search tools whose result unwraps to an empty collection (e.g. `{ comments: [] }`, `{ issues: [] }`) previously fell through to dumping the raw JSON payload in the render.

This adds a dedicated **empty state** — an inbox icon plus a localized `No {{collection}} found` message — driven by a new `emptyCollectionKey` on the render model. `extractResultShape` now returns the collection key alongside the records so the render can distinguish an intentional empty list from an unparseable payload, and the raw-JSON fallback is suppressed when an empty collection is detected.

- `extractResultRecords` → `extractResultShape` (returns `{ collectionKey, records }`)
- new `emptyCollectionKey` field on `LinearRenderModel`
- new i18n key `builtins.linear.render.empty` (en-US + zh-CN)

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Run a Linear `list_comments` / `search` that returns no results — the render shows the empty state instead of raw JSON. Covered by `packages/shared-tool-ui/src/Render/Linear/utils.test.ts` (11 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)