### PR TITLE
🐛 fix(database): scope group-agent removal by ownership (IDOR)

### DIFF
--- a/packages/database/src/repositories/agentGroup/index.test.ts
+++ b/packages/database/src/repositories/agentGroup/index.test.ts
@@ -731,6 +731,32 @@ describe('AgentGroupRepository', () => {
       expect(agent).toBeDefined();
     });
 
+    it('should not remove agents from another user’s group (IDOR)', async () => {
+      // Attacker scoped to a different user targets the victim's group + agents.
+      const attackerRepo = new AgentGroupRepository(serverDB, otherUserId);
+
+      const result = await attackerRepo.removeAgentsFromGroup('remove-group', [
+        'remove-virtual',
+        'remove-regular',
+      ]);
+
+      // Nothing removed: junction rows belong to the victim, not the attacker.
+      expect(result.removedFromGroup).toBe(0);
+      expect(result.deletedVirtualAgentIds).toEqual([]);
+
+      // Victim's group membership is untouched.
+      const groupAgents = await serverDB.query.chatGroupsAgents.findMany({
+        where: (cga, { eq }) => eq(cga.chatGroupId, 'remove-group'),
+      });
+      expect(groupAgents).toHaveLength(3);
+
+      // Victim's virtual agent is not deleted.
+      const virtualAgent = await serverDB.query.agents.findFirst({
+        where: (a, { eq }) => eq(a.id, 'remove-virtual'),
+      });
+      expect(virtualAgent).toBeDefined();
+    });
+
     it('should handle multiple virtual agents', async () => {
       // Add another virtual agent
       await serverDB.insert(agents).values({

--- a/packages/database/src/repositories/agentGroup/index.ts
+++ b/packages/database/src/repositories/agentGroup/index.ts
@@ -92,6 +92,8 @@ export class AgentGroupRepository {
     buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, chatGroups);
   private agentOwnership = () =>
     buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, agents);
+  private groupAgentOwnership = () =>
+    buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, chatGroupsAgents);
   private topicOwnership = () =>
     buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, topics);
   private threadOwnership = () =>
@@ -538,12 +540,19 @@ export class AgentGroupRepository {
     const { virtualAgents } = await this.checkAgentsBeforeRemoval(groupId, agentIds);
     const virtualAgentIds = virtualAgents.map((a) => a.id);
 
-    // 2. Remove all agents from the group (batch delete from junction table)
-    await this.db
+    // 2. Remove all agents from the group (batch delete from junction table).
+    // Scope by the caller's ownership so a client-supplied groupId can only touch
+    // the caller's own junction rows — never another user's group membership (IDOR).
+    const removed = await this.db
       .delete(chatGroupsAgents)
       .where(
-        and(eq(chatGroupsAgents.chatGroupId, groupId), inArray(chatGroupsAgents.agentId, agentIds)),
-      );
+        and(
+          eq(chatGroupsAgents.chatGroupId, groupId),
+          inArray(chatGroupsAgents.agentId, agentIds),
+          this.groupAgentOwnership(),
+        ),
+      )
+      .returning({ agentId: chatGroupsAgents.agentId });
 
     // 3. Delete virtual agents if requested
     // Note: Virtual agents are standalone (no associated sessions), so we can delete them directly
@@ -556,7 +565,7 @@ export class AgentGroupRepository {
 
     return {
       deletedVirtualAgentIds: deleteVirtualAgents ? virtualAgentIds : [],
-      removedFromGroup: agentIds.length,
+      removedFromGroup: removed.length,
     };
   }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- Security fix -->

#### 🔀 Description of Change

fix #16537

`AgentGroupRepository` batch-removed junction rows filtered only by the client-supplied `groupId` and `agentIds`:

```ts
.delete(chatGroupsAgents)
.where(and(eq(chatGroupsAgents.chatGroupId, groupId), inArray(chatGroupsAgents.agentId, agentIds)))
```

Because neither `groupId` nor `agentId` is scoped to the caller, a request supplying another user's group/agent ids could delete that user's group membership rows — an **IDOR**.

This adds a `groupAgentOwnership()` predicate (`userId` + `workspaceId`, matching the existing `agentOwnership` / `chatGroupOwnership` helpers) to the delete's `WHERE`, so it can only ever touch the caller's own junction rows. `removedFromGroup` is now derived from the rows actually deleted (via `.returning()`) rather than the requested `agentIds.length`, so the count reflects reality when some ids are out of scope.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

`packages/database/src/repositories/agentGroup/index.test.ts` (45 passing), including coverage that removal is scoped to the caller's ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)