### PR TITLE
🐛 fix(composio): rename OneDrive slug

### DIFF
--- a/packages/const/src/composio.ts
+++ b/packages/const/src/composio.ts
@@ -175,7 +175,7 @@ export const COMPOSIO_APP_TYPES: ComposioAppType[] = [
       'Integrate with HubSpot to manage contacts, deals, and marketing campaigns. Access CRM data, track pipelines, automate workflows, and streamline your sales and marketing operations.',
   },
   {
-    appSlug: 'ONEDRIVE',
+    appSlug: 'ONE_DRIVE',
     author: 'Composio',
     authorUrl: 'https://composio.dev',
     description:


### PR DESCRIPTION
## Problem
Composio's OneDrive app slug is currently set to `ONEDRIVE`, but the correct slug is `ONE_DRIVE`.

Because of this typo, both Lobehub Cloud and self-hosted Lobehub cannot resolve the OneDrive connection integration correctly.

The official Composio OneDrive toolkit documentation also uses `ONE_DRIVE`:
https://docs.composio.dev/toolkits/one_drive?utm_source=chatgpt.com

## Change
Update the OneDrive app slug in `packages/const/src/composio.ts` from `ONEDRIVE` to `ONE_DRIVE`.

## Impact
This restores OneDrive connectivity for both cloud and self-hosted Lobehub setups.
