### PR TITLE
🐛 fix(verify): surface the real agent-verifier spawn error

### DIFF
--- a/apps/server/src/services/verify/executor.ts
+++ b/apps/server/src/services/verify/executor.ts
@@ -266,10 +266,18 @@ export class VerifyExecutorService {
       });
 
       if (!spawned?.verifierOperationId) {
+        // The runner resolved without an operation id — the spawn never
+        // persisted an operation. Log the returned shape at error level (this
+        // path lands in production runtime logs, unlike the debug-only `log`).
+        console.error(
+          '[verify] agent verifier returned no operation id for item %s: %O',
+          item.id,
+          spawned,
+        );
         await this.resultModel.updateByCheckItem(verifyRunId, item.id, {
           completedAt: new Date(),
           status: 'failed',
-          toulmin: { limitation: 'Agent verifier failed to start.' },
+          toulmin: { limitation: 'Agent verifier failed to start (no operation id returned).' },
           verdict: 'uncertain',
         });
         return;
@@ -286,11 +294,18 @@ export class VerifyExecutorService {
         verifierOperationId: spawned.verifierOperationId,
       });
     } catch (error) {
-      log('agent verifier spawn failed for item %s: %O', item.id, error);
+      // Surface the real cause: the spawn throws during agent startup (before
+      // the verifier operation is persisted), and this catch previously only
+      // emitted a debug-level line + a generic limitation — so in production the
+      // actual error was invisible and the check just read "failed to start".
+      // Log at error level (reaches runtime logs) and thread the message into
+      // the verdict limitation so it is queryable from verify_check_results.
+      const detail = error instanceof Error ? error.message : String(error);
+      console.error('[verify] agent verifier spawn failed for item %s: %O', item.id, error);
       await this.resultModel.updateByCheckItem(verifyRunId, item.id, {
         completedAt: new Date(),
         status: 'failed',
-        toulmin: { limitation: 'Agent verifier failed to start.' },
+        toulmin: { limitation: `Agent verifier failed to start: ${detail}` },
         verdict: 'uncertain',
       });
     }


### PR DESCRIPTION
## Background

Since **2026-06-30**, every `verifierType=agent` delivery-acceptance verifier **fails to start, 100% of the time** (`verify_check_results`: before 06-30 ~10–25 verifier sub-ops were spawned successfully per day with 0 failures; from 06-30 successes dropped to zero and every check records `Agent verifier failed to start.`; 07-01 failure rate 73%, hitting 6 users). It spans all parent providers (lobehub / deepseek / nvidia / opencodezen / claude-code …) — **not hetero-specific**. Any task configured with an agent verifier is falsely marked failed / paused, even when the deliverable was actually completed and a PR opened.

Investigation confirmed: `execAgent` throws during agent startup **before the verifier operation is persisted** (the isolation thread has 0 messages), and the throw propagates up into `runAgentItem`'s catch. But that catch **only logs via `debug()`** (off in production → silently swallowed), and `toulmin.limitation` is a hard-coded generic string with no `error.message`. As a result the real exception is invisible in both Vercel runtime logs and `verify_check_results`, so the exact throw site cannot be located.

See Linear LOBE-11075.

## Changes

`apps/server/src/services/verify/executor.ts` `runAgentItem`:

1. **catch branch**: log the underlying error at error level (`console.error`, which reaches runtime logs) and thread `error.message` into `toulmin.limitation` so it is queryable from the DB.
2. **no-operation-id branch**: log the runner's returned shape separately and set the limitation to `... (no operation id returned).`, distinguishing it from the thrown-error path.

**This is a stop-the-bleed + observability change** (no behavior change): at the current 73% failure rate nearly every task-driven verify triggers it, so once deployed the next failure will expose the real throw site directly in `verify_check_results.toulmin.limitation` / runtime logs. That pinpoints the root cause to fix next (regression-window suspects: #16433, which added a pre-operation `await` inside `execAgent`; #16413, the verify-side changes).

## Testing

- `bunx vitest run apps/server/src/services/verify` → 9 files / 44 tests pass.
- No test asserts the old limitation string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)