### PR TITLE
✨ feat(chat): inline skill tags show description & open SKILL.md on click

### DIFF
--- a/locales/en-US/editor.json
+++ b/locales/en-US/editor.json
@@ -5,6 +5,7 @@
   "actionTag.category.skill": "Skill",
   "actionTag.category.tool": "Tool",
   "actionTag.tooltip.agentSkill": "Loads a skill bundle from this agent's documents for the request.",
+  "actionTag.tooltip.clickToView": "Click to view details",
   "actionTag.tooltip.command": "Runs a client-side slash command before sending.",
   "actionTag.tooltip.projectSkill": "Sent as a slash invocation so the agent's CLI runs the matching project skill.",
   "actionTag.tooltip.skill": "Loads a reusable skill package for this request.",

--- a/locales/zh-CN/editor.json
+++ b/locales/zh-CN/editor.json
@@ -5,6 +5,7 @@
   "actionTag.category.skill": "技能",
   "actionTag.category.tool": "工具",
   "actionTag.tooltip.agentSkill": "为本次请求加载该助理文档库中的技能包。",
+  "actionTag.tooltip.clickToView": "点击查看详情",
   "actionTag.tooltip.command": "发送前会先在客户端执行这条 slash 指令。",
   "actionTag.tooltip.projectSkill": "以 slash 形式发送，由 Agent CLI 自行识别并执行项目内的对应技能。",
   "actionTag.tooltip.skill": "表示这是一条可为本次请求加载的技能包。",

--- a/packages/locales/src/default/editor.ts
+++ b/packages/locales/src/default/editor.ts
@@ -43,6 +43,7 @@ export default {
   'actionTag.category.tool': 'Tool',
   'actionTag.tooltip.agentSkill':
     "Loads a skill bundle from this agent's documents for the request.",
+  'actionTag.tooltip.clickToView': 'Click to view details',
   'actionTag.tooltip.command': 'Runs a client-side slash command before sending.',
   'actionTag.tooltip.projectSkill':
     "Sent as a slash invocation so the agent's CLI runs the matching project skill.",

--- a/src/features/ChatInput/InputEditor/ActionTag/ActionMention.tsx
+++ b/src/features/ChatInput/InputEditor/ActionTag/ActionMention.tsx
@@ -1,8 +1,8 @@
-import { Icon, Tooltip } from '@lobehub/ui';
+import { Flexbox, Icon, Tooltip } from '@lobehub/ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
 import { cx } from 'antd-style';
 import { TerminalIcon, WrenchIcon } from 'lucide-react';
-import type { FC } from 'react';
+import type { FC, MouseEvent } from 'react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -11,7 +11,20 @@ import type { ActionTagCategory } from './types';
 
 export interface ActionMentionProps {
   category: ActionTagCategory;
+  /**
+   * Render the tag as interactive (pointer cursor + hover affordance + a
+   * "click to view" tooltip hint). Defaults to `!!onClick`; pass it explicitly
+   * when the click is handled elsewhere (e.g. the editor's Lexical CLICK_COMMAND
+   * rather than a React `onClick`).
+   */
+  clickable?: boolean;
+  /**
+   * The tag's own description (e.g. a project skill's frontmatter description).
+   * Replaces the generic category description in the tooltip when present.
+   */
+  description?: string;
   label: string;
+  onClick?: () => void;
 }
 
 const CATEGORY_ICON: Record<ActionTagCategory, FC<any>> = {
@@ -49,30 +62,48 @@ const CATEGORY_STYLE_KEY: Record<
   tool: 'toolTag',
 };
 
-export const ActionMention = memo<ActionMentionProps>(({ category, label }) => {
-  const { t } = useTranslation('editor');
+export const ActionMention = memo<ActionMentionProps>(
+  ({ category, label, description, clickable, onClick }) => {
+    const { t } = useTranslation('editor');
 
-  const categoryLabel = t(CATEGORY_I18N_KEY[category] as any);
-  const categoryDescription = t(CATEGORY_TOOLTIP_I18N_KEY[category] as any);
-  const IconComponent = CATEGORY_ICON[category];
-  const styleKey = CATEGORY_STYLE_KEY[category];
+    const categoryLabel = t(CATEGORY_I18N_KEY[category] as any);
+    const categoryDescription = t(CATEGORY_TOOLTIP_I18N_KEY[category] as any);
+    const IconComponent = CATEGORY_ICON[category];
+    const styleKey = CATEGORY_STYLE_KEY[category];
 
-  return (
-    <Tooltip
-      title={
-        <div>
-          <div style={{ fontWeight: 500 }}>{label}</div>
-          <div>{categoryLabel}</div>
-          <div>{categoryDescription}</div>
-        </div>
-      }
-    >
-      <span className={cx(styles.actionTag, styles[styleKey])}>
-        <Icon icon={IconComponent} size={14} />
-        <span className={styles.actionTagLabel}>{label}</span>
-      </span>
-    </Tooltip>
-  );
-});
+    const isClickable = clickable ?? !!onClick;
+    const tooltipDescription = description || categoryDescription;
+
+    const handleClick = onClick
+      ? (event: MouseEvent<HTMLSpanElement>) => {
+          event.stopPropagation();
+          onClick();
+        }
+      : undefined;
+
+    return (
+      <Tooltip
+        title={
+          <Flexbox gap={2}>
+            <div style={{ fontWeight: 500 }}>{label}</div>
+            <div style={{ opacity: 0.65 }}>{categoryLabel}</div>
+            {tooltipDescription && <div>{tooltipDescription}</div>}
+            {isClickable && (
+              <div style={{ opacity: 0.65 }}>{t('actionTag.tooltip.clickToView')}</div>
+            )}
+          </Flexbox>
+        }
+      >
+        <span
+          className={cx(styles.actionTag, styles[styleKey], isClickable && styles.clickable)}
+          onClick={handleClick}
+        >
+          <Icon icon={IconComponent} size={14} />
+          <span className={styles.actionTagLabel}>{label}</span>
+        </span>
+      </Tooltip>
+    );
+  },
+);
 
 ActionMention.displayName = 'ActionMention';

--- a/src/features/ChatInput/InputEditor/ActionTag/ActionTag.tsx
+++ b/src/features/ChatInput/InputEditor/ActionTag/ActionTag.tsx
@@ -1,6 +1,9 @@
 import { CLICK_COMMAND, COMMAND_PRIORITY_LOW, type LexicalEditor } from 'lexical';
 import { memo, useCallback, useEffect, useRef } from 'react';
 
+import { useProjectSkillResolver } from '@/features/SkillsList/useProjectSkillResolver';
+
+import { useAgentId } from '../../hooks/useAgentId';
 import { ActionMention } from './ActionMention';
 import type { ActionTagNode } from './ActionTagNode';
 
@@ -13,12 +16,26 @@ interface ActionTagProps {
 const ActionTag = memo<ActionTagProps>(({ node, editor, label }) => {
   const spanRef = useRef<HTMLSpanElement>(null);
 
-  const onClick = useCallback((payload: MouseEvent) => {
-    if (payload.target === spanRef.current || spanRef.current?.contains(payload.target as Node)) {
-      return true;
-    }
-    return false;
-  }, []);
+  // Project skills carry a filesystem SKILL.md the user can open in the portal;
+  // resolve the tag by its bare name against the active session's skill list.
+  const agentId = useAgentId();
+  const resolveProjectSkill = useProjectSkillResolver(agentId);
+  const skill =
+    node.actionCategory === 'projectSkill' ? resolveProjectSkill(node.actionType) : undefined;
+  const open = skill?.open;
+
+  // The chip lives inside contentEditable, so route clicks through Lexical's
+  // CLICK_COMMAND (not a React onClick) to avoid fighting caret placement.
+  const onClick = useCallback(
+    (payload: MouseEvent) => {
+      if (payload.target === spanRef.current || spanRef.current?.contains(payload.target as Node)) {
+        open?.();
+        return true;
+      }
+      return false;
+    },
+    [open],
+  );
 
   useEffect(() => {
     return editor.registerCommand(CLICK_COMMAND, onClick, COMMAND_PRIORITY_LOW);
@@ -26,7 +43,12 @@ const ActionTag = memo<ActionTagProps>(({ node, editor, label }) => {
 
   return (
     <span ref={spanRef} style={{ verticalAlign: -3 }}>
-      <ActionMention category={node.actionCategory} label={label} />
+      <ActionMention
+        category={node.actionCategory}
+        clickable={!!open}
+        description={skill?.description}
+        label={label}
+      />
     </span>
   );
 });

--- a/src/features/ChatInput/InputEditor/ActionTag/style.ts
+++ b/src/features/ChatInput/InputEditor/ActionTag/style.ts
@@ -30,6 +30,15 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   agentSkillTag: css`
     ${colored(cssVar.colorSuccess, cssVar.borderRadius)}
   `,
+  clickable: css`
+    cursor: pointer;
+    border-radius: ${cssVar.borderRadius};
+    transition: background 0.2s;
+
+    &:hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
   commandTag: css`
     ${colored(cssVar.purple, cssVar.borderRadius)}
   `,

--- a/src/features/Conversation/Markdown/plugins/Skill/Render.tsx
+++ b/src/features/Conversation/Markdown/plugins/Skill/Render.tsx
@@ -4,6 +4,8 @@ import isEqual from 'fast-deep-equal';
 import { memo } from 'react';
 
 import { ActionMention } from '@/features/ChatInput/InputEditor/ActionTag/ActionMention';
+import { useProjectSkillResolver } from '@/features/SkillsList/useProjectSkillResolver';
+import { useAgentStore } from '@/store/agent';
 
 import { type MarkdownElementProps } from '../type';
 
@@ -18,15 +20,30 @@ interface SkillNodeProps {
  * this plugin react-markdown leaves the literal tag text in the bubble, which
  * is what users were seeing before.
  *
- * We don't look up the identifier in any registry — the tag already carries
- * both the `name` (runtime identifier) and the human-readable `label`, so the
- * chip just mirrors what was inserted.
+ * The persisted wire format carries no category, so we resolve the `name`
+ * against the active session's project skills: a match renders as a clickable
+ * "project skill" chip (own description + opens SKILL.md), otherwise it degrades
+ * to a plain, non-clickable skill chip.
  */
 const Render = memo<MarkdownElementProps<SkillNodeProps>>(({ node, children }) => {
   const { label, name } = node?.properties || {};
   const displayLabel = label || name || (typeof children === 'string' ? children : undefined);
+
+  const activeAgentId = useAgentStore((s) => s.activeAgentId);
+  const resolveProjectSkill = useProjectSkillResolver(activeAgentId);
+  // The runtime identifier is the `name`; fall back to the displayed text.
+  const skillName = name || (typeof displayLabel === 'string' ? displayLabel : undefined);
+  const skill = skillName ? resolveProjectSkill(skillName) : undefined;
+
   if (!displayLabel) return null;
-  return <ActionMention category="skill" label={displayLabel} />;
+  return (
+    <ActionMention
+      category={skill ? 'projectSkill' : 'skill'}
+      description={skill?.description}
+      label={displayLabel}
+      onClick={skill?.open}
+    />
+  );
 }, isEqual);
 
 Render.displayName = 'SkillRender';

--- a/src/features/SkillsList/useProjectSkillResolver.ts
+++ b/src/features/SkillsList/useProjectSkillResolver.ts
@@ -1,0 +1,80 @@
+import { isDesktop } from '@lobechat/const';
+import { useCallback } from 'react';
+
+import { resolveExecutionTarget } from '@/helpers/executionTarget';
+import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
+import { useAgentStore } from '@/store/agent';
+import { agentByIdSelectors } from '@/store/agent/selectors';
+
+import { useProjectSkills } from './useProjectSkills';
+
+export interface ResolvedProjectSkill {
+  description?: string;
+  name: string;
+  /**
+   * Opens the skill's `SKILL.md` in the right-hand portal. Only present when the
+   * skill is reachable by the local viewer — a remote device's filesystem can't
+   * be previewed (matches the Files tab / working-sidebar behavior), so those
+   * tags stay non-clickable.
+   */
+  open?: () => void;
+}
+
+/**
+ * Resolve a project-skill tag (by its bare `name`) against the active session's
+ * live project-skill list so an inline tag can show the skill's own description
+ * and open its `SKILL.md`.
+ *
+ * Resolution is name-based on purpose: the persisted `<skill name label />` wire
+ * format carries no path/category, and the same lookup works both in the editor
+ * (composition) and in sent messages. A tag that no longer resolves (skill
+ * removed, or a different working directory) simply degrades to a plain,
+ * non-clickable chip.
+ *
+ * Mirrors `useSlashActionItems`' cwd + device resolution so the tag opens
+ * exactly the skill the slash menu would have inserted.
+ */
+export const useProjectSkillResolver = (
+  agentId?: string,
+): ((name: string) => ResolvedProjectSkill | undefined) => {
+  // Unified cwd: topic > agent's per-device choice > device default > home.
+  const workingDirectory = useEffectiveWorkingDirectory(agentId);
+
+  // Resolve the EFFECTIVE target, then treat it as remote only when it lands on
+  // `device` with a bound device — same coercion the slash menu / sidebar use so
+  // a hetero "This device" run opened on web still resolves.
+  const agencyConfig = useAgentStore((s) =>
+    agentId ? agentByIdSelectors.getAgencyConfigById(agentId)(s) : undefined,
+  );
+  const isHetero = useAgentStore((s) =>
+    agentId ? agentByIdSelectors.isAgentHeterogeneousById(agentId)(s) : false,
+  );
+  const effectiveTarget = resolveExecutionTarget(agencyConfig, {
+    clientExecutionAvailable: isDesktop,
+    isHetero,
+  });
+  const isDeviceMode = effectiveTarget === 'device' && !!agencyConfig?.boundDeviceId;
+  const remoteDeviceId = isDeviceMode ? agencyConfig.boundDeviceId : undefined;
+
+  // Local desktop reads over IPC; a bound device reads over RPC. Shares the SWR
+  // key with the slash menu / sidebar, so this adds no extra fetch.
+  const projectSkillsEnabled = (isDesktop || !!remoteDeviceId) && !!workingDirectory;
+  const { items, onOpenSkill } = useProjectSkills(
+    projectSkillsEnabled ? workingDirectory : undefined,
+    remoteDeviceId,
+  );
+
+  return useCallback(
+    (name: string) => {
+      const item = items.find((skill) => skill.name === name);
+      if (!item) return undefined;
+      return {
+        description: item.description,
+        name: item.name,
+        // A remote device's SKILL.md isn't reachable by the local viewer.
+        open: remoteDeviceId ? undefined : () => onOpenSkill(item),
+      };
+    },
+    [items, onOpenSkill, remoteDeviceId],
+  );
+};


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

Optimizes the inline skill tag (the green `SkillsIcon` + name chip rendered in the chat input and in sent messages).

**Before:** the chip only showed a generic per-category tooltip and had no click behavior.

**After:**

- **Hover** shows the skill's **own description** (from its frontmatter), falling back to the generic category description when none exists.
- **Click** opens the skill's `SKILL.md` in the right-hand portal panel — reusing the same `openLocalFile` flow as the working sidebar's "View".

**How it works (name-based resolution):** the persisted `<skill name label />` wire format carries no path or category, so instead of changing serialization we resolve the tag's bare `name` against the active session's live project-skill list (`useProjectSkills`, shared SWR — no extra fetch):

- **Match** → renders as a clickable `projectSkill` chip (correct "Project skill" label + description + opens `SKILL.md`).
- **No match** (installed/agent skill, different working directory, or removed skill) → degrades gracefully to a plain, non-clickable chip.

One resolver (`useProjectSkillResolver`) powers both surfaces:

- **Input editor** (`ActionTag.tsx`): the chip lives inside `contentEditable`, so the click is routed through Lexical's `CLICK_COMMAND` (not a React `onClick`) to avoid fighting caret placement.
- **Sent messages** (`Skill/Render.tsx`): plain React `onClick`.

Remote-device runs stay non-clickable — a remote filesystem's `SKILL.md` isn't reachable by the local viewer (matches the Files tab behavior).

Files:

- `src/features/SkillsList/useProjectSkillResolver.ts` (new) — name → `{ description, open? }`, mirrors the slash menu's cwd + device resolution.
- `ActionMention.tsx` — new optional `description` / `clickable` / `onClick` props + richer tooltip.
- `ActionTag.tsx`, `Skill/Render.tsx` — wire resolution into both surfaces.
- `style.ts` — clickable affordance (pointer + hover background).
- i18n: `actionTag.tooltip.clickToView` (default + en-US + zh-CN).

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. In a project with `.agents/skills/` or `.claude/skills/`, type `/` in the chat input and pick a project skill.
2. Hover the inserted chip → tooltip shows the skill's description + "Click to view details".
3. Click the chip → `SKILL.md` opens in the right portal.
4. Send the message; repeat 2–3 on the chip in the sent bubble.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Static tooltip, no click | Description on hover, opens SKILL.md on click |