### PR TITLE
✨ feat: stamp CC session id + message id on every hetero message

### DIFF
--- a/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -106,6 +106,15 @@ interface AssistantMessageDbLike {
  */
 interface OperationState {
   agentId: string | null;
+  /**
+   * CC-native session id this run is producing, captured off the stream_start
+   * event stream and stamped on every persisted message's
+   * `metadata.heteroSessionId`. Run-global and stable; a change ACROSS a topic
+   * (visible only because it's copied per-message) means CC forked a new
+   * session — the forensic signal for a lost-`--resume` "session break".
+   * Recovered on a cold replica from the current assistant's stamped metadata.
+   */
+  heteroSessionId: string | undefined;
   lastStepIndex: number;
   main: MainAgentRunState;
   operationId: string;
@@ -387,6 +396,11 @@ export class HeterogeneousPersistenceHandler {
 
     state = {
       agentId: topic?.agentId ?? null,
+      // Left undefined until the run's own stream_start reports it (or a cold
+      // replica recovers it from a stamped message). NOT seeded from
+      // topic.metadata.heteroSessionId: that holds the id we ASKED CC to resume,
+      // which differs from the actual id when a fork/new session occurred.
+      heteroSessionId: undefined,
       lastStepIndex: 0,
       main: createMainAgentRunState(currentAssistantMessageId),
       operationId,
@@ -488,6 +502,13 @@ export class HeterogeneousPersistenceHandler {
     // `currentSubagentMessageId` from `metadata.subagentMessageId`.
     if (typeof snapshot.metadata.mainMessageId === 'string') {
       state.main.currentMainMessageId = snapshot.metadata.mainMessageId;
+    }
+
+    // Recover the run's CC session id from a previously-stamped message so a
+    // cold replica that never saw this run's stream_start still stamps the
+    // right session id on the messages it persists.
+    if (!state.heteroSessionId && typeof snapshot.metadata.heteroSessionId === 'string') {
+      state.heteroSessionId = snapshot.metadata.heteroSessionId;
     }
 
     if (snapshot.textSnapshotSeq > state.main.lastTextSnapshotSeq) {
@@ -732,6 +753,14 @@ export class HeterogeneousPersistenceHandler {
    * replays it against the previous reducer state.
    */
   private async reduceAndApply(state: OperationState, event: AgentStreamEvent) {
+    // Capture the CC-native session id off the stream_start stream so every
+    // message persisted below carries the session it belongs to. Stable per
+    // run; the copy is what makes a mid-topic session fork detectable.
+    if (event.type === 'stream_start') {
+      const sid = (event.data as { sessionId?: string } | undefined)?.sessionId;
+      if (typeof sid === 'string' && sid.length > 0) state.heteroSessionId = sid;
+    }
+
     const { intents, state: next } = reduceMainAgent(state.main, event, this.mainReduceCtx(state));
 
     for (const intent of intents) {
@@ -745,10 +774,31 @@ export class HeterogeneousPersistenceHandler {
     state.main = next;
   }
 
+  /**
+   * Per-message provenance stamped on every hetero-persisted row: the CC
+   * session id the turn ran under (`heteroSessionId`) and, when known, the CC
+   * `message.id` of the turn (`heteroMessageId`). A per-message copy lets a
+   * diff pinpoint the exact row where CC forked to a new session / lost
+   * `--resume` history — something the topic-level single `heteroSessionId`
+   * can never show. Returns `{}` when neither is known, so callers can spread
+   * it without minting empty metadata.
+   */
+  private heteroProvenance(
+    state: OperationState,
+    heteroMessageId?: string,
+  ): { heteroMessageId?: string; heteroSessionId?: string } {
+    const out: { heteroMessageId?: string; heteroSessionId?: string } = {};
+    if (state.heteroSessionId) out.heteroSessionId = state.heteroSessionId;
+    if (heteroMessageId) out.heteroMessageId = heteroMessageId;
+    return out;
+  }
+
   private async applyMainIntent(state: OperationState, intent: MainAgentIntent) {
     switch (intent.kind) {
       case 'createAssistant': {
-        const createMetadata: Record<string, any> = {};
+        const createMetadata: Record<string, any> = {
+          ...this.heteroProvenance(state, intent.mainMessageId),
+        };
         if (intent.signal) createMetadata.signal = intent.signal;
         // Persist the turn's CC message.id so a cold replica can recover
         // `currentMainMessageId` (via refreshMainStateFromDb) and dedupe a
@@ -807,10 +857,12 @@ export class HeterogeneousPersistenceHandler {
         // Phase 2: create new tool rows with reducer-preallocated ids.
         for (const tool of intent.tools) {
           if (!tool.isNew) continue;
+          const toolMetadata = this.heteroProvenance(state, state.main.currentMainMessageId);
           await this.deps.messageModel.create(
             {
               agentId: state.agentId ?? undefined,
               content: '',
+              ...(Object.keys(toolMetadata).length > 0 ? { metadata: toolMetadata } : {}),
               parentId: intent.assistantMessageId,
               plugin: {
                 apiName: tool.payload.apiName,
@@ -841,7 +893,13 @@ export class HeterogeneousPersistenceHandler {
       case 'recordUsage': {
         const update: Record<string, any> = {};
         if (intent.usage !== undefined) {
-          update.metadata = { ...state.main.turnMetadata, usage: intent.usage };
+          // This overwrites the row's metadata wholesale, so re-stamp the
+          // provenance the createAssistant write put there, or usage would wipe it.
+          update.metadata = {
+            ...state.main.turnMetadata,
+            ...this.heteroProvenance(state, state.main.currentMainMessageId),
+            usage: intent.usage,
+          };
         }
         if (intent.model) update.model = intent.model;
         if (intent.provider) update.provider = intent.provider;
@@ -965,17 +1023,19 @@ export class HeterogeneousPersistenceHandler {
       }
 
       case 'createMessage': {
+        const subMetadata: Record<string, any> = {
+          ...this.heteroProvenance(state, intent.subagentMessageId),
+        };
+        // Persist the turn's CC message.id so a cold replica can recover
+        // `currentSubagentMessageId` (via buildSubagentSnapshot) and avoid
+        // a spurious turn boundary that fragments one CC turn into multiple
+        // in-thread assistant rows + empty shells.
+        if (intent.subagentMessageId) subMetadata.subagentMessageId = intent.subagentMessageId;
         await this.deps.messageModel.create(
           {
             agentId: intent.agentId ?? undefined,
             content: intent.content,
-            // Persist the turn's CC message.id so a cold replica can recover
-            // `currentSubagentMessageId` (via buildSubagentSnapshot) and avoid
-            // a spurious turn boundary that fragments one CC turn into multiple
-            // in-thread assistant rows + empty shells.
-            ...(intent.subagentMessageId
-              ? { metadata: { subagentMessageId: intent.subagentMessageId } }
-              : {}),
+            ...(Object.keys(subMetadata).length > 0 ? { metadata: subMetadata } : {}),
             parentId: intent.parentId,
             role: intent.role,
             threadId: intent.threadId,
@@ -1022,10 +1082,12 @@ export class HeterogeneousPersistenceHandler {
         // register them in the global tool-message map for tool_result lookup.
         for (const t of intent.tools) {
           if (!t.isNew) continue;
+          const subToolMetadata = this.heteroProvenance(state);
           await this.deps.messageModel.create(
             {
               agentId: state.agentId ?? undefined,
               content: '',
+              ...(Object.keys(subToolMetadata).length > 0 ? { metadata: subToolMetadata } : {}),
               parentId: intent.assistantMessageId,
               plugin: {
                 apiName: t.payload.apiName,
@@ -1050,7 +1112,9 @@ export class HeterogeneousPersistenceHandler {
 
       case 'recordUsage': {
         await this.deps.messageModel.update(intent.messageId, {
-          metadata: { usage: intent.usage as any },
+          // Wholesale metadata overwrite — re-stamp the session provenance the
+          // createMessage write put there, or usage would wipe it.
+          metadata: { ...this.heteroProvenance(state), usage: intent.usage as any },
           ...(intent.model && { model: intent.model }),
           ...(intent.provider && { provider: intent.provider }),
         });

--- a/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -1082,7 +1082,7 @@ export class HeterogeneousPersistenceHandler {
         // register them in the global tool-message map for tool_result lookup.
         for (const t of intent.tools) {
           if (!t.isNew) continue;
-          const subToolMetadata = this.heteroProvenance(state);
+          const subToolMetadata = this.heteroProvenance(state, intent.subagentMessageId);
           await this.deps.messageModel.create(
             {
               agentId: state.agentId ?? undefined,
@@ -1112,9 +1112,12 @@ export class HeterogeneousPersistenceHandler {
 
       case 'recordUsage': {
         await this.deps.messageModel.update(intent.messageId, {
-          // Wholesale metadata overwrite — re-stamp the session provenance the
-          // createMessage write put there, or usage would wipe it.
-          metadata: { ...this.heteroProvenance(state), usage: intent.usage as any },
+          // Wholesale metadata overwrite — re-stamp the session + message
+          // provenance the createMessage write put there, or usage would wipe it.
+          metadata: {
+            ...this.heteroProvenance(state, intent.subagentMessageId),
+            usage: intent.usage as any,
+          },
           ...(intent.model && { model: intent.model }),
           ...(intent.provider && { provider: intent.provider }),
         });

--- a/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts
@@ -1538,5 +1538,115 @@ describe('HeterogeneousPersistenceHandler', () => {
       expect(sessById.get('cc-1')).toBe('sess-A');
       expect(sessById.get('cc-2')).toBe('sess-B');
     });
+
+    it('stamps heteroMessageId on the FIRST (seeded) turn, not just later newStep turns', async () => {
+      // The first CC assistant follows system:init with NO newStep — it lands on
+      // the pre-seeded assistant. The adapter now carries the turn's message.id on
+      // that non-newStep stream_start so the seed assistant + its first-turn tool
+      // and usage rows get heteroMessageId — the common first turn of a
+      // resumed/forked operation this forensic data exists to diagnose.
+      const h = createHarness({
+        assistantMessageId: 'asst-init',
+        operationId: 'op-1',
+        topicId: 'topic-1',
+      });
+
+      const tool = {
+        apiName: 'Bash',
+        arguments: '{}',
+        id: 'tc-1',
+        identifier: 'bash',
+        type: 'default',
+      };
+
+      await h.handler.ingest({
+        events: [
+          // system:init carries the session id but opens no new assistant.
+          buildEvent('stream_start', 0, { sessionId: 'sess-A' }),
+          // First assistant after init: non-newStep stream_start carrying the
+          // seed turn's CC message.id (what the adapter now emits).
+          buildEvent('stream_start', 1, { messageId: 'cc-seed', sessionId: 'sess-A' }),
+          buildEvent('stream_chunk', 2, { chunkType: 'tools_calling', toolsCalling: [tool] }),
+          buildEvent('step_complete', 3, {
+            phase: 'turn_metadata',
+            usage: { totalInputTokens: 1, totalOutputTokens: 1, totalTokens: 2 },
+          }),
+        ],
+        operationId: 'op-1',
+        topicId: 'topic-1',
+      });
+
+      // The seeded assistant's usage write re-stamps the provenance.
+      const seedUsageWrite = h.messageModel.update.mock.calls.find(
+        ([id, patch]: [string, any]) => id === 'asst-init' && patch?.metadata?.usage,
+      )!;
+      expect(seedUsageWrite[1].metadata).toMatchObject({
+        heteroMessageId: 'cc-seed',
+        heteroSessionId: 'sess-A',
+      });
+
+      const toolRow = [...h.messages.values()].find((m) => m.role === 'tool')!;
+      expect(toolRow.metadata).toMatchObject({
+        heteroMessageId: 'cc-seed',
+        heteroSessionId: 'sess-A',
+      });
+    });
+
+    it('stamps the subagent turn message id on subagent tool + usage rows', async () => {
+      const h = createHarness({
+        assistantMessageId: 'asst-init',
+        operationId: 'op-1',
+        topicId: 'topic-1',
+      });
+
+      const subagentCtx = {
+        parentToolCallId: 'tc-spawn',
+        spawnMetadata: { prompt: 'p', subagentType: 'Explore' },
+        subagentMessageId: 'sub-1',
+      };
+
+      await h.handler.ingest({
+        events: [
+          buildEvent('stream_start', 0, { sessionId: 'sess-A' }),
+          buildEvent('stream_chunk', 1, {
+            chunkType: 'tools_calling',
+            subagent: subagentCtx,
+            toolsCalling: [
+              { apiName: 'Read', arguments: '{}', id: 'inner-tc', identifier: 'read', type: 'default' },
+            ],
+          }),
+          buildEvent('step_complete', 2, {
+            phase: 'turn_metadata',
+            subagent: subagentCtx,
+            usage: { totalInputTokens: 1, totalOutputTokens: 1, totalTokens: 2 },
+          }),
+          buildEvent('agent_runtime_end', 3, { reason: 'success' }),
+        ],
+        operationId: 'op-1',
+        topicId: 'topic-1',
+      });
+
+      const threadId = [...h.threads.keys()][0];
+
+      // The subagent's inner tool row carries the subagent turn's message id.
+      const innerTool = [...h.messages.values()].find(
+        (m) => m.threadId === threadId && m.role === 'tool',
+      )!;
+      expect(innerTool.metadata).toMatchObject({
+        heteroMessageId: 'sub-1',
+        heteroSessionId: 'sess-A',
+      });
+
+      // recordUsage overwrites the subagent assistant's metadata wholesale — the
+      // heteroMessageId createMessage stamped must survive it.
+      const subUsageWrite = h.messageModel.update.mock.calls.find(
+        ([, patch]: [string, any]) => patch?.metadata?.usage,
+      )!;
+      expect(subUsageWrite[1].metadata).toMatchObject({
+        heteroMessageId: 'sub-1',
+        heteroSessionId: 'sess-A',
+        usage: { totalTokens: 2 },
+      });
+    });
   });
 });

--- a/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/HeterogeneousPersistenceHandler.test.ts
@@ -1444,4 +1444,99 @@ describe('HeterogeneousPersistenceHandler', () => {
       expect(h.messages.get('asst-2')?.content).toBe('step2');
     });
   });
+
+  describe('per-message session provenance (heteroSessionId / heteroMessageId)', () => {
+    it('stamps the CC session id + turn message id on the assistant, its tools, and its usage', async () => {
+      const h = createHarness({
+        assistantMessageId: 'asst-init',
+        operationId: 'op-1',
+        topicId: 'topic-1',
+      });
+
+      const tool = {
+        apiName: 'Bash',
+        arguments: '{}',
+        id: 'tc-1',
+        identifier: 'bash',
+        type: 'default',
+      };
+
+      await h.handler.ingest({
+        events: [
+          // system.init: carries the CC session id but opens no new assistant.
+          buildEvent('stream_start', 0, { sessionId: 'sess-A' }),
+          // A real turn boundary: opens a new assistant for CC message cc-1.
+          buildEvent('stream_start', 1, {
+            messageId: 'cc-1',
+            newStep: true,
+            sessionId: 'sess-A',
+          }),
+          buildEvent('stream_chunk', 2, { chunkType: 'tools_calling', toolsCalling: [tool] }),
+          buildEvent('step_complete', 3, {
+            phase: 'turn_metadata',
+            usage: { totalInputTokens: 1, totalOutputTokens: 1, totalTokens: 2 },
+          }),
+        ],
+        operationId: 'op-1',
+        topicId: 'topic-1',
+      });
+
+      const assistant = [...h.messages.values()].find(
+        (m) => m.role === 'assistant' && m.id !== 'asst-init',
+      )!;
+      expect(assistant.metadata).toMatchObject({
+        heteroMessageId: 'cc-1',
+        heteroSessionId: 'sess-A',
+      });
+
+      const toolRow = [...h.messages.values()].find((m) => m.role === 'tool')!;
+      expect(toolRow.metadata).toMatchObject({
+        heteroMessageId: 'cc-1',
+        heteroSessionId: 'sess-A',
+      });
+
+      // recordUsage overwrites the row's metadata wholesale — provenance must survive.
+      const usageWrite = h.messageModel.update.mock.calls.find(
+        ([, patch]: [string, any]) => patch?.metadata?.usage,
+      )!;
+      expect(usageWrite[1].metadata).toMatchObject({
+        heteroMessageId: 'cc-1',
+        heteroSessionId: 'sess-A',
+        usage: { totalTokens: 2 },
+      });
+    });
+
+    it('records a mid-topic session fork per-message so a diff pinpoints the break', async () => {
+      // The tpc_PZAmvtpkfHE1 scenario: `--resume` failed, CC opened a fresh
+      // session mid-conversation, and the topic-level single heteroSessionId
+      // could not show WHERE the history was lost. Per-message stamping does.
+      const h = createHarness({
+        assistantMessageId: 'asst-init',
+        operationId: 'op-1',
+        topicId: 'topic-1',
+      });
+
+      await h.handler.ingest({
+        events: [
+          buildEvent('stream_start', 0, { sessionId: 'sess-A' }),
+          buildEvent('stream_start', 1, { messageId: 'cc-1', newStep: true, sessionId: 'sess-A' }),
+          buildEvent('stream_chunk', 2, { chunkType: 'text', content: 'turn 1' }),
+          // Next turn resumes into a DIFFERENT session — the fork.
+          buildEvent('stream_start', 3, { messageId: 'cc-2', newStep: true, sessionId: 'sess-B' }),
+          buildEvent('stream_chunk', 4, { chunkType: 'text', content: 'turn 2' }),
+        ],
+        operationId: 'op-1',
+        topicId: 'topic-1',
+      });
+
+      const newAssistants = [...h.messages.values()].filter(
+        (m) => m.role === 'assistant' && m.id !== 'asst-init',
+      );
+      const sessById = new Map(
+        newAssistants.map((m) => [m.metadata?.heteroMessageId, m.metadata?.heteroSessionId]),
+      );
+      expect(sessById.get('cc-1')).toBe('sess-A');
+      expect(sessById.get('cc-2')).toBe('sess-B');
+    });
+  });
 });

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -1292,9 +1292,12 @@ describe('ClaudeCodeAdapter', () => {
   describe('multi-step execution (message.id boundary)', () => {
     it('does NOT emit step boundary for the first assistant after init', () => {
       const adapter = new ClaudeCodeAdapter();
-      adapter.adapt({ subtype: 'init', type: 'system' });
+      adapter.adapt({ subtype: 'init', session_id: 'sess-A', type: 'system' });
 
-      // First assistant message after init — should NOT trigger newStep
+      // First assistant message after init — should NOT open a new step
+      // (no stream_end, no newStep), but it DOES emit a non-newStep stream_start
+      // carrying the turn's message.id so the reducer can stamp it as
+      // `currentMainMessageId` (→ heteroMessageId on the seeded assistant).
       const events = adapter.adapt({
         message: { id: 'msg_1', content: [{ text: 'step 1', type: 'text' }] },
         type: 'assistant',
@@ -1302,7 +1305,11 @@ describe('ClaudeCodeAdapter', () => {
 
       const types = events.map((e) => e.type);
       expect(types).not.toContain('stream_end');
-      expect(types).not.toContain('stream_start');
+      const streamStart = events.find((e) => e.type === 'stream_start');
+      expect(streamStart).toBeDefined();
+      expect(streamStart!.data.newStep).toBeUndefined();
+      expect(streamStart!.data.messageId).toBe('msg_1');
+      expect(streamStart!.data.sessionId).toBe('sess-A');
       // Should still emit content
       const chunk = events.find((e) => e.type === 'stream_chunk');
       expect(chunk).toBeDefined();

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -1540,9 +1540,21 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
 
     if (this.currentMessageId === undefined) {
       // First assistant/delta after system init — record without step boundary.
+      // Emit a non-newStep stream_start carrying this turn's CC message.id so
+      // the reducer records `currentMainMessageId` for the SEEDED assistant.
+      // system:init opened the seed with no id, so without this the first turn's
+      // rows (assistant / tools / usage) would carry no `heteroMessageId` — the
+      // exact first turn of a resumed/forked operation this provenance targets.
       this.currentMessageId = messageId;
       this.currentTurnHadToolUse = false;
-      return [];
+      return [
+        this.makeEvent('stream_start', {
+          messageId,
+          model,
+          provider: 'claude-code',
+          sessionId: this.sessionId,
+        }),
+      ];
     }
 
     this.currentMessageId = messageId;

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -738,6 +738,9 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
       this.makeEvent('stream_start', {
         model: raw.model,
         provider: 'claude-code',
+        // The CC session id every message this run produces belongs to. A
+        // change in this value across a topic means CC forked a new session.
+        sessionId: this.sessionId,
       }),
     ];
   }
@@ -1488,7 +1491,13 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
       this.started = true;
       this.currentMessageId = messageId;
       this.currentTurnHadToolUse = false;
-      return [this.makeEvent('stream_start', { model, provider: 'claude-code' })];
+      return [
+        this.makeEvent('stream_start', {
+          model,
+          provider: 'claude-code',
+          sessionId: this.sessionId,
+        }),
+      ];
     }
 
     if (messageId === this.currentMessageId) {
@@ -1524,6 +1533,7 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
           model,
           newStep: true,
           provider: 'claude-code',
+          sessionId: this.sessionId,
         }),
       ];
     }
@@ -1588,6 +1598,7 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
         model,
         newStep: true,
         provider: 'claude-code',
+        sessionId: this.sessionId,
       }),
     ];
   }

--- a/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.ts
+++ b/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.ts
@@ -172,13 +172,28 @@ const streamInit = (state: MainAgentRunState, data: any): ReduceResult => {
   const update: Record<string, any> = {};
   if (data?.model) update.model = data.model;
   if (data?.provider) update.provider = data.provider;
-  if (Object.keys(update).length === 0) return { intents: [], state };
+
+  // The seeded assistant's CC message.id arrives on the first non-newStep
+  // stream_start after system:init (the seed was opened with no id). Record it
+  // as `currentMainMessageId` so the first turn's rows get `heteroMessageId`
+  // provenance; `openTurn` owns it for every later turn. Only seed it once — a
+  // later non-newStep stream_start must not clobber the open turn's id.
+  const seedMainMessageId =
+    typeof data?.messageId === 'string' && !state.currentMainMessageId
+      ? data.messageId
+      : undefined;
+
+  if (Object.keys(update).length === 0 && !seedMainMessageId) return { intents: [], state };
 
   const next = copyState(state);
   if (data.model) next.turnModel = data.model;
   if (data.provider) next.turnProvider = data.provider;
+  if (seedMainMessageId) next.currentMainMessageId = seedMainMessageId;
   return {
-    intents: [{ kind: 'persistAssistant', messageId: state.currentAssistantId, ...update }],
+    intents:
+      Object.keys(update).length > 0
+        ? [{ kind: 'persistAssistant', messageId: state.currentAssistantId, ...update }]
+        : [],
     state: next,
   };
 };

--- a/packages/heterogeneous-agents/src/subagentCoordinator/reducer.test.ts
+++ b/packages/heterogeneous-agents/src/subagentCoordinator/reducer.test.ts
@@ -278,6 +278,9 @@ describe('subagent reducer', () => {
         messageId: 'msg_2',
         model: 'claude',
         provider: 'claude-code',
+        // Carried so recordUsage's wholesale metadata overwrite re-stamps
+        // heteroMessageId instead of wiping it.
+        subagentMessageId: 'm1',
         threadId: 'thd_1',
         usage,
       },

--- a/packages/heterogeneous-agents/src/subagentCoordinator/reducer.ts
+++ b/packages/heterogeneous-agents/src/subagentCoordinator/reducer.ts
@@ -341,6 +341,7 @@ const reduceToolsChunk = (
     content: run.accContent || undefined,
     kind: 'persistToolBatch',
     reasoning: run.accReasoning || undefined,
+    subagentMessageId: run.currentSubagentMessageId || undefined,
     threadId: run.threadId,
     tools: run.toolState.payloads.map((p) => ({
       isNew: newToolMsgIds.includes(run.toolState.toolMsgIdByCallId.get(p.id)!),
@@ -438,6 +439,7 @@ export const reduce = (
           messageId: run.currentAssistantId,
           model: data.model,
           provider: data.provider,
+          subagentMessageId: run.currentSubagentMessageId || undefined,
           threadId: run.threadId,
           usage: data.usage,
         },

--- a/packages/heterogeneous-agents/src/subagentCoordinator/types.ts
+++ b/packages/heterogeneous-agents/src/subagentCoordinator/types.ts
@@ -279,6 +279,12 @@ export interface PersistToolBatchIntent {
   content?: string;
   kind: 'persistToolBatch';
   reasoning?: string;
+  /**
+   * CC `message.id` of the turn these tools belong to, so the interpreter can
+   * stamp `metadata.heteroMessageId` on each new tool row (mirrors the id it
+   * stamps on the turn's assistant via {@link CreateMessageIntent}).
+   */
+  subagentMessageId?: string;
   threadId: string;
   tools: PersistToolBatchEntry[];
 }
@@ -304,6 +310,13 @@ export interface RecordUsageIntent {
   messageId: string;
   model?: string;
   provider?: string;
+  /**
+   * CC `message.id` of the turn whose usage this is. recordUsage overwrites the
+   * assistant row's metadata wholesale, so it must re-stamp `heteroMessageId`
+   * or the value {@link CreateMessageIntent} wrote would be wiped (mirrors the
+   * main-agent recordUsage re-stamp).
+   */
+  subagentMessageId?: string;
   threadId: string;
   usage: unknown;
 }

--- a/packages/heterogeneous-agents/src/types.ts
+++ b/packages/heterogeneous-agents/src/types.ts
@@ -66,6 +66,16 @@ export interface StreamStartData {
   externalSignal?: ExternalSignalContext;
   model?: string;
   provider?: string;
+  /**
+   * CC-native session id (`system:init.session_id`), carried on every
+   * stream_start so the server can stamp it on each persisted message's
+   * `metadata.heteroSessionId`. The topic-level `heteroSessionId` only keeps
+   * the single latest value; a per-message copy lets a diff pinpoint the exact
+   * row where CC forked to a new session (e.g. `--resume` hit a recycled /
+   * empty session and started fresh) — the forensic signal for a lost-history
+   * "session break".
+   */
+  sessionId?: string;
 }
 
 /**

--- a/packages/types/src/message/common/metadata.test.ts
+++ b/packages/types/src/message/common/metadata.test.ts
@@ -12,4 +12,14 @@ describe('MessageMetadataSchema', () => {
 
     expect(parsed).toEqual({ trigger: RequestTrigger.Onboarding });
   });
+
+  it('preserves hetero-agent session provenance so it is not stripped on writes', () => {
+    const parsed = MessageMetadataSchema.parse({
+      heteroMessageId: 'cc-1',
+      heteroSessionId: 'sess-A',
+      unknown: 'stripped',
+    });
+
+    expect(parsed).toEqual({ heteroMessageId: 'cc-1', heteroSessionId: 'sess-A' });
+  });
 });

--- a/packages/types/src/message/common/metadata.ts
+++ b/packages/types/src/message/common/metadata.ts
@@ -180,6 +180,11 @@ export const MessageTaskCallbackSchema = z.object({
 
 export const MessageMetadataSchema = ModelUsageSchema.merge(ModelPerformanceSchema).extend({
   collapsed: z.boolean().optional(),
+  // Hetero-agent (Claude Code) per-message provenance. Listed here so zod does
+  // NOT strip them from writes going through UpdateMessageParamsSchema /
+  // CreateMessageParamsSchema (the renderer executor's `messageService` path).
+  heteroMessageId: z.string().optional(),
+  heteroSessionId: z.string().optional(),
   inspectExpanded: z.boolean().optional(),
   isMultimodal: z.boolean().optional(),
   isSupervisor: z.boolean().optional(),
@@ -262,6 +267,20 @@ export interface MessageMetadata {
   /** @deprecated use `metadata.performance` instead */
   duration?: number;
   finishType?: string;
+  /**
+   * The CC-native `message.id` of the hetero-agent (Claude Code) turn that
+   * produced this message. Forensic provenance stamped by both the server
+   * persistence handler and the renderer executor, so a diff can tie a row
+   * back to its CC turn.
+   */
+  heteroMessageId?: string;
+  /**
+   * The CC-native session id this hetero-agent message was produced under.
+   * `topic.metadata.heteroSessionId` keeps only the single latest value (written
+   * at run end); this per-message copy lets a diff pinpoint the exact row where
+   * CC forked to a new session — the signal for a lost-`--resume` "session break".
+   */
+  heteroSessionId?: string;
   /** @deprecated use the top-level message `usage` field instead */
   inputAudioTokens?: number;
   /** @deprecated use the top-level message `usage` field instead */

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -435,6 +435,32 @@ export const executeHeterogeneousAgent = async (
   let resumeFallbackTriggered = false;
 
   /**
+   * CC-native session id this run is producing, captured off the stream_start
+   * event stream and stamped on every message created below. Mirrors the server
+   * handler's `OperationState.heteroSessionId`: `topic.metadata.heteroSessionId`
+   * only keeps the single latest value (written at run end), so a per-message
+   * copy is what lets a diff pinpoint the exact row where CC forked to a new
+   * session — the forensic signal for a lost-`--resume` "session break".
+   */
+  let heteroSessionId: string | undefined;
+
+  /**
+   * Per-message provenance stamped on every row this run persists: the CC
+   * session id (`heteroSessionId`) and, when known, the turn's CC `message.id`
+   * (`heteroMessageId`). Returns `{}` when neither is known so callers can
+   * spread it without minting empty metadata. Mirrors the server handler's
+   * `heteroProvenance`.
+   */
+  const heteroProvenance = (
+    heteroMessageId?: string,
+  ): { heteroMessageId?: string; heteroSessionId?: string } => {
+    const out: { heteroMessageId?: string; heteroSessionId?: string } = {};
+    if (heteroSessionId) out.heteroSessionId = heteroSessionId;
+    if (heteroMessageId) out.heteroMessageId = heteroMessageId;
+    return out;
+  };
+
+  /**
    * Global `tool_use.id → tool message DB id` lookup, shared across the
    * main agent and every subagent run. `tool_result` events identify
    * the target row by `toolCallId` alone (no scope context needed), so
@@ -668,10 +694,12 @@ export const executeHeterogeneousAgent = async (
 
       case 'createMessage': {
         const t = subagentThreads.get(intent.threadId);
+        const subMetadata = heteroProvenance(intent.subagentMessageId);
         const msg = {
           agentId: intent.agentId ?? undefined,
           content: intent.content,
           id: intent.messageId,
+          ...(Object.keys(subMetadata).length > 0 ? { metadata: subMetadata } : {}),
           parentId: intent.parentId,
           role: intent.role,
           threadId: intent.threadId,
@@ -757,10 +785,12 @@ export const executeHeterogeneousAgent = async (
         // register the global lookup, and seed the thread bucket bubble.
         for (const x of intent.tools) {
           if (!x.isNew) continue;
+          const subToolMetadata = heteroProvenance();
           const toolMsg = {
             agentId: context.agentId,
             content: '',
             id: x.toolMessageId,
+            ...(Object.keys(subToolMetadata).length > 0 ? { metadata: subToolMetadata } : {}),
             parentId: intent.assistantMessageId,
             plugin: {
               apiName: x.payload.apiName,
@@ -822,7 +852,9 @@ export const executeHeterogeneousAgent = async (
       case 'recordUsage': {
         const t = subagentThreads.get(intent.threadId);
         const update = {
-          metadata: { usage: intent.usage as any },
+          // Wholesale metadata overwrite — re-stamp the session provenance the
+          // createMessage write put there, or usage would wipe it.
+          metadata: { ...heteroProvenance(), usage: intent.usage as any },
           ...(intent.model && { model: intent.model }),
           ...(intent.provider && { provider: intent.provider }),
         };
@@ -865,12 +897,14 @@ export const executeHeterogeneousAgent = async (
   const applyMainIntent = async (intent: MainAgentIntent) => {
     switch (intent.kind) {
       case 'createAssistant': {
+        const createMetadata: Record<string, any> = { ...heteroProvenance(intent.mainMessageId) };
+        if (intent.signal) createMetadata.signal = intent.signal;
         try {
           await messageService.createMessage({
             agentId: intent.agentId ?? context.agentId,
             content: '',
             id: intent.messageId,
-            ...(intent.signal ? { metadata: { signal: intent.signal } } : {}),
+            ...(Object.keys(createMetadata).length > 0 ? { metadata: createMetadata } : {}),
             model: intent.model,
             parentId: intent.parentId,
             provider: intent.provider,
@@ -952,11 +986,13 @@ export const executeHeterogeneousAgent = async (
         // register the global lookup so a later tool_result resolves.
         for (const x of intent.tools) {
           if (!x.isNew) continue;
+          const toolMetadata = heteroProvenance(mainState.currentMainMessageId);
           try {
             await messageService.createMessage({
               agentId: context.agentId,
               content: '',
               id: x.toolMessageId,
+              ...(Object.keys(toolMetadata).length > 0 ? { metadata: toolMetadata } : {}),
               parentId: intent.assistantMessageId,
               plugin: {
                 apiName: x.payload.apiName,
@@ -1001,7 +1037,12 @@ export const executeHeterogeneousAgent = async (
 
       case 'recordUsage': {
         const update = {
-          metadata: { usage: intent.usage as any },
+          // Wholesale metadata overwrite — re-stamp the provenance the
+          // createAssistant write put there, or usage would wipe it.
+          metadata: {
+            ...heteroProvenance(mainState.currentMainMessageId),
+            usage: intent.usage as any,
+          },
           ...(intent.model && { model: intent.model }),
           ...(intent.provider && { provider: intent.provider }),
         };
@@ -1038,6 +1079,14 @@ export const executeHeterogeneousAgent = async (
    * matches arrival.
    */
   const reduceAndApplyMain = async (event: AgentStreamEvent) => {
+    // Capture the CC-native session id off the stream_start stream so every
+    // message persisted below carries the session it belongs to (mirrors the
+    // server handler). Stable per run; the copy makes a mid-topic fork visible.
+    if (event.type === 'stream_start') {
+      const sid = (event.data as { sessionId?: string } | undefined)?.sessionId;
+      if (typeof sid === 'string' && sid.length > 0) heteroSessionId = sid;
+    }
+
     const ctx: MainAgentReduceCtx = {
       agentId: context.agentId,
       newId: (kind) => (kind === 'thread' ? generateThreadId() : `msg_${createNanoId(18)()}`),

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -785,7 +785,7 @@ export const executeHeterogeneousAgent = async (
         // register the global lookup, and seed the thread bucket bubble.
         for (const x of intent.tools) {
           if (!x.isNew) continue;
-          const subToolMetadata = heteroProvenance();
+          const subToolMetadata = heteroProvenance(intent.subagentMessageId);
           const toolMsg = {
             agentId: context.agentId,
             content: '',
@@ -852,9 +852,12 @@ export const executeHeterogeneousAgent = async (
       case 'recordUsage': {
         const t = subagentThreads.get(intent.threadId);
         const update = {
-          // Wholesale metadata overwrite — re-stamp the session provenance the
-          // createMessage write put there, or usage would wipe it.
-          metadata: { ...heteroProvenance(), usage: intent.usage as any },
+          // Wholesale metadata overwrite — re-stamp the session + message
+          // provenance the createMessage write put there, or usage would wipe it.
+          metadata: {
+            ...heteroProvenance(intent.subagentMessageId),
+            usage: intent.usage as any,
+          },
           ...(intent.model && { model: intent.model }),
           ...(intent.provider && { provider: intent.provider }),
         };


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

Persist **`heteroSessionId`** and **`heteroMessageId`** on every hetero-agent (Claude Code) message's `metadata` — assistant seeds, tool rows, and usage updates, for both the main agent and subagents — on **both** execution paths.

**Why.** The CC-native session id was only written once, at run finish, onto `topic.metadata.heteroSessionId` (a single latest value). When CC's `--resume` fails and opens a *fresh* session mid-conversation (e.g. the sandbox was recycled and the session files are gone), the model silently loses its history while the DB message tree stays perfectly intact. Nothing recorded **where** the break happened, so a "the agent forgot everything" report was undiagnosable after the fact. A per-message copy makes a mid-topic session fork a one-line diff.

**Both write paths are covered:**

1. **Server / cloud path** (`HeterogeneousPersistenceHandler`) — cloud sandbox runs and device runs that stream back via `heteroIngest`. Captures the session id off the `stream_start` event, keeps it on the operation state, recovers it on cold replicas from a previously-stamped message, and stamps every persisted row. Writes via the DB model directly (no zod validation).
2. **Renderer / desktop-local path** (`executeHeterogeneousAgent`) — desktop-local topics persisted to local pglite via `messageService`. Same shared reducer/intents; now captures the session id off `stream_start` and stamps the same fields on every row. Previously it only stamped `signal`.

**Supporting changes:**
- The adapter (`claudeCode.ts`) now carries `session_id` on every `stream_start` event (it was previously only cached on the adapter and surfaced at `heteroFinish`).
- `heteroSessionId` / `heteroMessageId` are promoted to first-class optional fields on the `MessageMetadata` interface **and** the `MessageMetadataSchema` zod schema. The renderer's `messageService` writes go through tRPC `CreateMessageParamsSchema` / `UpdateMessageParamsSchema`, whose zod validation strips any key not on the schema — without the schema entry the renderer stamping would be silently dropped.

**Design notes.**
- `recordUsage` overwrites a row's metadata wholesale on both paths, so provenance is re-stamped there or usage would wipe it.
- `heteroSessionId` is **not** seeded from `topic.metadata.heteroSessionId` — that holds the id we *asked* CC to resume, which differs from the actual id when a fork occurred. It's only set from the run's own `stream_start` (or recovered from a stamped message).
- Existing load-bearing `mainMessageId` / `subagentMessageId` recovery fields are untouched; `heteroMessageId` is an additive forensic field.
- When no session id is known the provenance helper returns `{}`, so no empty metadata is minted and existing assertions are unaffected (backward compatible).

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- `HeterogeneousPersistenceHandler.test.ts`: session id + turn message id stamped on assistant / tool / usage rows (incl. surviving the `recordUsage` wholesale overwrite); a **mid-topic session fork** recorded per-message so a diff pinpoints the break.
- `metadata.test.ts`: `heteroSessionId` / `heteroMessageId` survive `MessageMetadataSchema.parse` (are not stripped) while unknown keys still are.
- Green: server handler 30 + ingest 7, package adapter/reducer 120, metadata schema 2.

#### 📝 Additional Information

Instrumentation only — makes *future* session breaks diagnosable; it does not recover history already lost on past topics.