### PR TITLE
🔒 fix(rag): scope knowledge-base file resolution to the caller

### DIFF
--- a/apps/server/src/services/knowledgeBase/index.test.ts
+++ b/apps/server/src/services/knowledgeBase/index.test.ts
@@ -5,6 +5,8 @@ import { ChunkModel } from '@/database/models/chunk';
 import { DocumentModel } from '@/database/models/document';
 import { FileModel } from '@/database/models/file';
 import { SearchRepo } from '@/database/repositories/search';
+import { knowledgeBaseFiles } from '@/database/schemas';
+import { buildWorkspaceWhere } from '@/database/utils/workspace';
 import { getServerDefaultFilesConfig } from '@/server/globalConfig';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 
@@ -18,6 +20,9 @@ vi.mock('@/database/repositories/search', () => ({ SearchRepo: vi.fn() }));
 vi.mock('../document', () => ({ DocumentService: vi.fn() }));
 vi.mock('@/server/globalConfig', () => ({ getServerDefaultFilesConfig: vi.fn() }));
 vi.mock('@/server/modules/ModelRuntime', () => ({ initModelRuntimeFromDB: vi.fn() }));
+vi.mock('@/database/utils/workspace', () => ({
+  buildWorkspaceWhere: vi.fn(() => 'WORKSPACE_SCOPE'),
+}));
 
 describe('KnowledgeBaseSearchService', () => {
   const userId = 'user_test';
@@ -238,6 +243,26 @@ describe('KnowledgeBaseSearchService', () => {
           fileIds: ['file_1', 'file_2', 'file_extra'],
         }),
       );
+    });
+
+    it('scopes the knowledgeBaseFiles lookup to the caller (no cross-user KB resolution)', async () => {
+      serverDB.query.knowledgeBaseFiles.findMany.mockResolvedValue([{ fileId: 'file_1' }]);
+      chunkModelMock.semanticSearchForChat.mockResolvedValue([]);
+      searchRepoMock.searchKnowledgeBaseDocuments.mockResolvedValue([]);
+
+      await service.semanticSearchForChat({
+        knowledgeIds: ['kb_victim'],
+        query: 'hi',
+      });
+
+      // ownership predicate must be built for the caller's userId + table
+      expect(buildWorkspaceWhere).toHaveBeenCalledWith(
+        { userId, workspaceId: undefined },
+        knowledgeBaseFiles,
+      );
+      // and it must be combined into the actual findMany WHERE clause
+      const { where } = serverDB.query.knowledgeBaseFiles.findMany.mock.calls[0][0];
+      expect(where).toBeDefined();
     });
 
     it('captures vector path failure in errors + rejections, keeps BM25 documents', async () => {

--- a/apps/server/src/services/knowledgeBase/index.ts
+++ b/apps/server/src/services/knowledgeBase/index.ts
@@ -6,7 +6,7 @@ import {
   RequestTrigger,
   type SemanticSearchSchemaType,
 } from '@lobechat/types';
-import { inArray } from 'drizzle-orm';
+import { and, inArray } from 'drizzle-orm';
 import pMap from 'p-map';
 
 import { ChunkModel } from '@/database/models/chunk';
@@ -14,6 +14,7 @@ import { DocumentModel } from '@/database/models/document';
 import { FileModel } from '@/database/models/file';
 import { type KnowledgeBaseDocumentHit, SearchRepo } from '@/database/repositories/search';
 import { knowledgeBaseFiles } from '@/database/schemas';
+import { buildWorkspaceWhere } from '@/database/utils/workspace';
 import { getServerDefaultFilesConfig } from '@/server/globalConfig';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 import { DocumentService } from '@/server/services/document';
@@ -137,8 +138,16 @@ export class KnowledgeBaseSearchService {
 
       let finalFileIds = input.fileIds ?? [];
       if (knowledgeIds.length > 0) {
+        // Scope the knowledge-base → file resolution to the caller so a user
+        // cannot resolve another user's knowledgeBaseId to the victim's fileIds.
         const knowledgeFiles = await this.serverDB.query.knowledgeBaseFiles.findMany({
-          where: inArray(knowledgeBaseFiles.knowledgeBaseId, knowledgeIds),
+          where: and(
+            inArray(knowledgeBaseFiles.knowledgeBaseId, knowledgeIds),
+            buildWorkspaceWhere(
+              { userId: this.userId, workspaceId: this.workspaceId },
+              knowledgeBaseFiles,
+            ),
+          ),
         });
         finalFileIds = knowledgeFiles.map((f) => f.fileId).concat(finalFileIds);
       }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Closes #16535

#### 🔀 Description of Change

Fixes the remaining cross-user gap reported in the RAG semantic-search IDOR advisory (GHSA-r929-w8h7-f9g6).

**Context — what was already fixed:** The core chunk-level leak is closed. Both `ChunkModel.semanticSearch` and `semanticSearchForChat` now apply `this.ownership()` (`buildWorkspaceWhere` with the caller's `userId`) **unconditionally**, so neither the whole-corpus variant (no `fileIds` → empty WHERE) nor the targeted variant can return another user's chunks. The BM25 path (`SearchRepo.searchKnowledgeBaseDocuments`) is likewise already scoped.

**What this PR fixes:** The `knowledgeBaseFiles` lookup in `KnowledgeBaseSearchService.semanticSearchForChat` resolved `knowledgeIds → fileIds` with only `inArray(knowledgeBaseId, ...)` and no ownership predicate, so a caller could turn another user's `knowledgeBaseId` into the victim's `fileIds`. While the downstream chunk query already rejects those fileIds via ownership, the resolution itself should be scoped too. This applies `buildWorkspaceWhere({ userId, workspaceId }, knowledgeBaseFiles)` — matching the workspace-aware pattern used across the codebase (the table has both `user_id` and `workspace_id` columns + indexes).

#### 🧪 How to Test

- [x] Added/updated tests

`bunx vitest run apps/server/src/services/knowledgeBase/index.test.ts` — 14/14 pass, including a new regression test asserting the KB→file lookup is built for the caller's `userId`.

#### 📝 Additional Information

Server-only change, no schema/migration. Defense-in-depth: even before this, the chunk-layer ownership predicate prevented actual data exfiltration; this closes the KB-resolution layer so a victim's `knowledgeBaseId` can no longer be resolved to their `fileIds` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)