### PR TITLE
🧹 chore: clean LOBE-10949 markers from agent-runtime comments

### DIFF
--- a/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
+++ b/apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
@@ -30,8 +30,8 @@ export const createRuntimeExecutors = (
     compress_context: compressContext(ctx),
     exec_sub_agent: execSubAgent(ctx),
     exec_sub_agents: execSubAgents(ctx),
-    // Migrated into @lobechat/agent-runtime (LOBE-10949 Tier A) — server only
-    // registers the adapters via buildHost.
+    // Migrated into @lobechat/agent-runtime as part of the IO transport port
+    // abstraction — the server now only registers adapters via buildHost.
     finish: createFinishExecutor(host),
     request_human_approve: requestHumanApprove(ctx),
     resolve_aborted_tools: resolveAbortedTools(ctx),

--- a/packages/agent-runtime/src/executors/finish.ts
+++ b/packages/agent-runtime/src/executors/finish.ts
@@ -4,7 +4,8 @@ import type { AgentEvent, AgentInstruction, InstructionExecutor } from '../types
 /**
  * `finish` executor — terminates the operation.
  *
- * First executor hosted in the package (LOBE-10949 Tier A): it depends only on
+ * First executor migrated from the server into this package as part of the
+ * agent-runtime IO transport port abstraction: it depends only on
  * the `StreamSink` + `OperationStore` transports and the operation context, so
  * the server just provides those adapters. Behavior mirrors the previous
  * server-local implementation exactly.

--- a/packages/agent-runtime/src/transport/host.ts
+++ b/packages/agent-runtime/src/transport/host.ts
@@ -37,7 +37,8 @@ export interface RuntimeTransports {
  * Single argument to the (future) package-hosted executor factories. The server
  * builds this once per operation — wiring its adapters + lifecycle dispatcher +
  * operation context — and the package owns the executor logic. This is the seam
- * that lets the same executors run on server and client (LOBE-10949 end-state).
+ * that lets the same executors run on server and client (target end-state of the
+ * agent-runtime IO transport port abstraction).
  */
 export interface AgentRuntimeHost {
   lifecycle?: LifecycleSink;


### PR DESCRIPTION
## Summary

Automated daily scan found 3 `LOBE-XXX` markers in agent-runtime related source files (all referencing LOBE-10949). Replaced them with descriptive comments based on the actual issue context.

## Changes

| File | Change |
|------|--------|
| `packages/agent-runtime/src/transport/host.ts` | Replace `(LOBE-10949 end-state)` with description of the IO transport port abstraction target |
| `packages/agent-runtime/src/executors/finish.ts` | Replace `(LOBE-10949 Tier A)` with context about this being the first executor migrated from server |
| `apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts` | Replace `(LOBE-10949 Tier A)` with explanation of the adapter-registration pattern |

## Files Changed

```
packages/agent-runtime/src/transport/host.ts
packages/agent-runtime/src/executors/finish.ts
apps/server/src/modules/AgentRuntime/RuntimeExecutors.ts
```

## Context

LOBE-10949 is the ongoing refactoring to abstract RuntimeExecutors into `@lobechat/agent-runtime` package capabilities via IO transport ports. The finish executor, human_approve executor, and RuntimeIO transport ports have already been merged. The comments now describe the architectural intent directly rather than referencing an issue number.

Auto-generated by daily marker cleanup on 2026-07-02.