### PR TITLE
✨ feat(claude-code): dedicated render for the SendMessage tool

### DIFF
--- a/locales/en-US/plugin.json
+++ b/locales/en-US/plugin.json
@@ -126,6 +126,7 @@
   "builtins.lobe-claude-code.askUserQuestion.question": "Question",
   "builtins.lobe-claude-code.askUserQuestion.reply": "Reply",
   "builtins.lobe-claude-code.askUserQuestion.selected": "Selected",
+  "builtins.lobe-claude-code.sendMessage.title": "Send message",
   "builtins.lobe-claude-code.task.create.completed": "Task created: ",
   "builtins.lobe-claude-code.task.create.loading": "Creating task: ",
   "builtins.lobe-claude-code.task.getLabel": "View task #{{taskId}}",

--- a/locales/en-US/plugin.json
+++ b/locales/en-US/plugin.json
@@ -126,6 +126,7 @@
   "builtins.lobe-claude-code.askUserQuestion.question": "Question",
   "builtins.lobe-claude-code.askUserQuestion.reply": "Reply",
   "builtins.lobe-claude-code.askUserQuestion.selected": "Selected",
+  "builtins.lobe-claude-code.sendMessage.queued": "Queued for delivery",
   "builtins.lobe-claude-code.sendMessage.title": "Send message",
   "builtins.lobe-claude-code.task.create.completed": "Task created: ",
   "builtins.lobe-claude-code.task.create.loading": "Creating task: ",

--- a/locales/zh-CN/plugin.json
+++ b/locales/zh-CN/plugin.json
@@ -126,6 +126,7 @@
   "builtins.lobe-claude-code.askUserQuestion.question": "问题",
   "builtins.lobe-claude-code.askUserQuestion.reply": "回复",
   "builtins.lobe-claude-code.askUserQuestion.selected": "已选择",
+  "builtins.lobe-claude-code.sendMessage.title": "发送消息",
   "builtins.lobe-claude-code.task.create.completed": "已创建任务：",
   "builtins.lobe-claude-code.task.create.loading": "正在创建任务：",
   "builtins.lobe-claude-code.task.getLabel": "查看任务 #{{taskId}}",

--- a/locales/zh-CN/plugin.json
+++ b/locales/zh-CN/plugin.json
@@ -126,6 +126,7 @@
   "builtins.lobe-claude-code.askUserQuestion.question": "问题",
   "builtins.lobe-claude-code.askUserQuestion.reply": "回复",
   "builtins.lobe-claude-code.askUserQuestion.selected": "已选择",
+  "builtins.lobe-claude-code.sendMessage.queued": "已加入投递队列",
   "builtins.lobe-claude-code.sendMessage.title": "发送消息",
   "builtins.lobe-claude-code.task.create.completed": "已创建任务：",
   "builtins.lobe-claude-code.task.create.loading": "正在创建任务：",

--- a/packages/builtin-tool-claude-code/src/client/Inspector/SendMessage.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/SendMessage.tsx
@@ -16,13 +16,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     align-items: center;
 
     min-width: 0;
-    max-width: 60%;
+    max-width: 70%;
     margin-inline-start: 6px;
     padding-block: 1px;
     padding-inline: 8px;
     border-radius: 999px;
 
-    font-family: ${cssVar.fontFamilyCode};
     font-size: 12px;
     color: ${cssVar.colorText};
     text-overflow: ellipsis;
@@ -33,26 +32,27 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 }));
 
 /**
- * Chip for the multi-agent `SendMessage` tool — labels the target agent so the
- * timeline reads "Send message → <recipient>" instead of the raw arg dump.
+ * Chip for the multi-agent `SendMessage` tool. Leads with the human-readable
+ * `summary` (falling back to the message body) rather than the opaque agent id
+ * from `to`/`recipient`, which means nothing to an end user.
  */
 export const SendMessageInspector = memo<BuiltinInspectorProps<SendMessageArgs>>(
   ({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
     const { t } = useTranslation('plugin');
     const label = t('builtins.lobe-claude-code.sendMessage.title');
     const source = args ?? partialArgs;
-    const recipient = (source?.to ?? source?.recipient)?.trim();
+    const recap = (source?.summary ?? source?.message ?? source?.content)?.trim();
 
     const isShiny = isArgumentsStreaming || isLoading;
 
-    if (isArgumentsStreaming && !recipient) {
+    if (isArgumentsStreaming && !recap) {
       return <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>{label}</div>;
     }
 
     return (
       <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
-        <span>{recipient ? `${label} →` : label}</span>
-        {recipient && <span className={styles.chip}>{recipient}</span>}
+        <span>{recap ? `${label}:` : label}</span>
+        {recap && <span className={styles.chip}>{recap}</span>}
       </div>
     );
   },

--- a/packages/builtin-tool-claude-code/src/client/Inspector/SendMessage.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/SendMessage.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { inspectorTextStyles, shinyTextStyles } from '@lobechat/shared-tool-ui/styles';
+import type { BuiltinInspectorProps } from '@lobechat/types';
+import { createStaticStyles, cx } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { SendMessageArgs } from '../../types';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  chip: css`
+    overflow: hidden;
+    display: inline-flex;
+    flex-shrink: 1;
+    align-items: center;
+
+    min-width: 0;
+    max-width: 60%;
+    margin-inline-start: 6px;
+    padding-block: 1px;
+    padding-inline: 8px;
+    border-radius: 999px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+}));
+
+/**
+ * Chip for the multi-agent `SendMessage` tool — labels the target agent so the
+ * timeline reads "Send message → <recipient>" instead of the raw arg dump.
+ */
+export const SendMessageInspector = memo<BuiltinInspectorProps<SendMessageArgs>>(
+  ({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
+    const { t } = useTranslation('plugin');
+    const label = t('builtins.lobe-claude-code.sendMessage.title');
+    const source = args ?? partialArgs;
+    const recipient = (source?.to ?? source?.recipient)?.trim();
+
+    const isShiny = isArgumentsStreaming || isLoading;
+
+    if (isArgumentsStreaming && !recipient) {
+      return <div className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}>{label}</div>;
+    }
+
+    return (
+      <div className={cx(inspectorTextStyles.root, isShiny && shinyTextStyles.shinyText)}>
+        <span>{recipient ? `${label} →` : label}</span>
+        {recipient && <span className={styles.chip}>{recipient}</span>}
+      </div>
+    );
+  },
+);
+
+SendMessageInspector.displayName = 'ClaudeCodeSendMessageInspector';

--- a/packages/builtin-tool-claude-code/src/client/Inspector/index.ts
+++ b/packages/builtin-tool-claude-code/src/client/Inspector/index.ts
@@ -15,6 +15,7 @@ import { LinearMcpInspectors } from './LinearMcp';
 import { MonitorInspector } from './Monitor';
 import { ReadInspector } from './Read';
 import { ScheduleWakeupInspector } from './ScheduleWakeup';
+import { SendMessageInspector } from './SendMessage';
 import { SkillInspector } from './Skill';
 import { TaskInspector } from './Task';
 import { TaskGetInspector } from './TaskGet';
@@ -50,6 +51,7 @@ const FixedClaudeCodeInspectors = {
   [ClaudeCodeApiName.Monitor]: MonitorInspector,
   [ClaudeCodeApiName.Read]: ReadInspector,
   [ClaudeCodeApiName.ScheduleWakeup]: ScheduleWakeupInspector,
+  [ClaudeCodeApiName.SendMessage]: SendMessageInspector,
   [ClaudeCodeApiName.Skill]: SkillInspector,
   // CC 2.1.143+ task tools — TaskCreate / TaskUpdate / TaskList share the
   // same inspector because they're driven by the adapter-synthesized

--- a/packages/builtin-tool-claude-code/src/client/Render/SendMessage/index.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Render/SendMessage/index.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import type { BuiltinRenderProps } from '@lobechat/types';
+import { Flexbox, Icon, Markdown, Text } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+import { CircleCheckBig, SendHorizontal } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { SendMessageArgs, SendMessageResult } from '../../../types';
+
+const parseResult = (content: unknown): SendMessageResult | undefined => {
+  if (content && typeof content === 'object') return content as SendMessageResult;
+  if (typeof content !== 'string' || !content.trim()) return undefined;
+  try {
+    return JSON.parse(content) as SendMessageResult;
+  } catch {
+    return undefined;
+  }
+};
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  bodyBox: css`
+    overflow: hidden;
+
+    padding-block: 4px;
+    padding-inline: 8px;
+    border-radius: 8px;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  container: css`
+    padding-block: 4px;
+  `,
+  header: css`
+    padding-inline: 4px;
+    color: ${cssVar.colorTextSecondary};
+  `,
+  recipient: css`
+    flex: none;
+
+    padding-block: 1px;
+    padding-inline: 8px;
+    border-radius: 999px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+  status: css`
+    padding-inline: 4px;
+  `,
+}));
+
+const SendMessage = memo<BuiltinRenderProps<SendMessageArgs>>(({ args, content }) => {
+  const { t } = useTranslation('plugin');
+
+  const recipient = (args?.to ?? args?.recipient)?.trim();
+  const body = args?.message ?? args?.content;
+  const summary = args?.summary?.trim();
+
+  const result = parseResult(content);
+  const delivered = result?.success === true ? result?.message?.trim() : undefined;
+
+  return (
+    <Flexbox className={styles.container} gap={8}>
+      <Flexbox
+        horizontal
+        align={'center'}
+        className={styles.header}
+        gap={8}
+        justify={'space-between'}
+      >
+        <Flexbox horizontal align={'center'} gap={8} style={{ minWidth: 0 }}>
+          <Icon icon={SendHorizontal} size={'small'} />
+          <Text ellipsis strong>
+            {summary || t('builtins.lobe-claude-code.sendMessage.title')}
+          </Text>
+        </Flexbox>
+        {recipient && (
+          <Text ellipsis className={styles.recipient}>
+            {recipient}
+          </Text>
+        )}
+      </Flexbox>
+
+      {body && (
+        <Flexbox className={styles.bodyBox}>
+          <Markdown style={{ maxHeight: 240, overflow: 'auto' }} variant={'chat'}>
+            {body}
+          </Markdown>
+        </Flexbox>
+      )}
+
+      {delivered && (
+        <Flexbox horizontal align={'center'} className={styles.status} gap={6}>
+          <Icon icon={CircleCheckBig} size={'small'} style={{ color: cssVar.colorSuccess }} />
+          <Text style={{ color: cssVar.colorTextSecondary, fontSize: 12 }}>{delivered}</Text>
+        </Flexbox>
+      )}
+    </Flexbox>
+  );
+});
+
+SendMessage.displayName = 'ClaudeCodeSendMessage';
+
+export default SendMessage;

--- a/packages/builtin-tool-claude-code/src/client/Render/SendMessage/index.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Render/SendMessage/index.tsx
@@ -36,18 +36,6 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     padding-inline: 4px;
     color: ${cssVar.colorTextSecondary};
   `,
-  recipient: css`
-    flex: none;
-
-    padding-block: 1px;
-    padding-inline: 8px;
-    border-radius: 999px;
-
-    font-family: ${cssVar.fontFamilyCode};
-    font-size: 12px;
-
-    background: ${cssVar.colorFillTertiary};
-  `,
   status: css`
     padding-inline: 4px;
   `,
@@ -56,33 +44,22 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 const SendMessage = memo<BuiltinRenderProps<SendMessageArgs>>(({ args, content }) => {
   const { t } = useTranslation('plugin');
 
-  const recipient = (args?.to ?? args?.recipient)?.trim();
   const body = args?.message ?? args?.content;
   const summary = args?.summary?.trim();
 
   const result = parseResult(content);
-  const delivered = result?.success === true ? result?.message?.trim() : undefined;
+  // The tool's own confirmation embeds the opaque recipient id ("… to <id> at
+  // its next tool round"), meaningless to a user — show a localized generic
+  // status instead of echoing that raw string.
+  const delivered = result?.success === true;
 
   return (
     <Flexbox className={styles.container} gap={8}>
-      <Flexbox
-        horizontal
-        align={'center'}
-        className={styles.header}
-        gap={8}
-        justify={'space-between'}
-      >
-        <Flexbox horizontal align={'center'} gap={8} style={{ minWidth: 0 }}>
-          <Icon icon={SendHorizontal} size={'small'} />
-          <Text ellipsis strong>
-            {summary || t('builtins.lobe-claude-code.sendMessage.title')}
-          </Text>
-        </Flexbox>
-        {recipient && (
-          <Text ellipsis className={styles.recipient}>
-            {recipient}
-          </Text>
-        )}
+      <Flexbox horizontal align={'center'} className={styles.header} gap={8}>
+        <Icon icon={SendHorizontal} size={'small'} />
+        <Text ellipsis strong>
+          {summary || t('builtins.lobe-claude-code.sendMessage.title')}
+        </Text>
       </Flexbox>
 
       {body && (
@@ -96,7 +73,9 @@ const SendMessage = memo<BuiltinRenderProps<SendMessageArgs>>(({ args, content }
       {delivered && (
         <Flexbox horizontal align={'center'} className={styles.status} gap={6}>
           <Icon icon={CircleCheckBig} size={'small'} style={{ color: cssVar.colorSuccess }} />
-          <Text style={{ color: cssVar.colorTextSecondary, fontSize: 12 }}>{delivered}</Text>
+          <Text style={{ color: cssVar.colorTextSecondary, fontSize: 12 }}>
+            {t('builtins.lobe-claude-code.sendMessage.queued')}
+          </Text>
         </Flexbox>
       )}
     </Flexbox>

--- a/packages/builtin-tool-claude-code/src/client/Render/index.ts
+++ b/packages/builtin-tool-claude-code/src/client/Render/index.ts
@@ -14,6 +14,7 @@ import Glob from './Glob';
 import Grep from './Grep';
 import { LinearMcpRenders } from './LinearMcp';
 import Read from './Read';
+import SendMessage from './SendMessage';
 import Skill from './Skill';
 import Task from './Task';
 import TodoWrite from './TodoWrite';
@@ -37,6 +38,7 @@ const FixedClaudeCodeRenders = {
   [ClaudeCodeApiName.Glob]: Glob,
   [ClaudeCodeApiName.Grep]: Grep,
   [ClaudeCodeApiName.Read]: Read,
+  [ClaudeCodeApiName.SendMessage]: SendMessage,
   [ClaudeCodeApiName.Skill]: Skill,
   // Task panel renders the adapter-synthesized `pluginState.todos` snapshot.
   // Only TaskUpdate / TaskList show it — those events express list-level
@@ -71,6 +73,7 @@ export const ClaudeCodeRenders = new Proxy(FixedClaudeCodeRenders, {
  */
 const FixedClaudeCodeRenderDisplayControls: Record<string, RenderDisplayControl> = {
   [ClaudeCodeApiName.Edit]: 'expand',
+  [ClaudeCodeApiName.SendMessage]: 'expand',
   [ClaudeCodeApiName.TaskList]: 'expand',
   [ClaudeCodeApiName.TaskUpdate]: 'expand',
   [ClaudeCodeApiName.TodoWrite]: 'expand',

--- a/packages/builtin-tool-claude-code/src/types.ts
+++ b/packages/builtin-tool-claude-code/src/types.ts
@@ -45,6 +45,14 @@ export enum ClaudeCodeApiName {
   Monitor = 'Monitor',
   Read = 'Read',
   ScheduleWakeup = 'ScheduleWakeup',
+  /**
+   * Multi-agent messaging tool. The agent sends a message to a peer agent
+   * (addressed by its opaque id) so the two can coordinate mid-run; the
+   * recipient receives it on its next tool round. Discovered at runtime via
+   * `ToolSearch`, so — like the Task* tools — it's not part of CC's fixed
+   * built-in set but shows up as a `tool_use` named `SendMessage`.
+   */
+  SendMessage = 'SendMessage',
   Skill = 'Skill',
   /**
    * Imperative successor to {@link TodoWrite} in CC 2.1.143+. The model creates
@@ -218,6 +226,37 @@ export interface TaskOutputArgs {
 export interface TaskStopArgs {
   shell_id?: string;
   task_id?: string;
+}
+
+/**
+ * Arguments for the multi-agent `SendMessage` tool. The tool is exposed to the
+ * model through `ToolSearch` with aliased fields, so the same payload arrives
+ * under two spellings: `to`/`recipient` for the target agent id and
+ * `message`/`content` for the body. Readers should prefer the canonical
+ * `to`/`message` and fall back to the alias.
+ */
+export interface SendMessageArgs {
+  /** Alias for {@link SendMessageArgs.message}. */
+  content?: string;
+  /** Message body sent to the peer agent (markdown allowed). */
+  message?: string;
+  /** Alias for {@link SendMessageArgs.to}. */
+  recipient?: string;
+  /** Short human-facing recap of the message, shown as the card label. */
+  summary?: string;
+  /** Target peer agent id the message is delivered to. */
+  to?: string;
+  /** Delivery kind — usually `message`; kept open for future variants. */
+  type?: string;
+}
+
+/**
+ * Shape of the `SendMessage` tool_result. Confirms the message was queued for
+ * the recipient's next tool round.
+ */
+export interface SendMessageResult {
+  message?: string;
+  success?: boolean;
 }
 
 /**

--- a/packages/locales/src/default/plugin.ts
+++ b/packages/locales/src/default/plugin.ts
@@ -66,6 +66,7 @@ export default {
   'builtins.lobe-claude-code.askUserQuestion.question': 'Question',
   'builtins.lobe-claude-code.askUserQuestion.reply': 'Reply',
   'builtins.lobe-claude-code.askUserQuestion.selected': 'Selected',
+  'builtins.lobe-claude-code.sendMessage.queued': 'Queued for delivery',
   'builtins.lobe-claude-code.sendMessage.title': 'Send message',
   'builtins.lobe-claude-code.task.create.completed': 'Task created: ',
   'builtins.lobe-claude-code.task.create.loading': 'Creating task: ',

--- a/packages/locales/src/default/plugin.ts
+++ b/packages/locales/src/default/plugin.ts
@@ -66,6 +66,7 @@ export default {
   'builtins.lobe-claude-code.askUserQuestion.question': 'Question',
   'builtins.lobe-claude-code.askUserQuestion.reply': 'Reply',
   'builtins.lobe-claude-code.askUserQuestion.selected': 'Selected',
+  'builtins.lobe-claude-code.sendMessage.title': 'Send message',
   'builtins.lobe-claude-code.task.create.completed': 'Task created: ',
   'builtins.lobe-claude-code.task.create.loading': 'Creating task: ',
   'builtins.lobe-claude-code.task.getLabel': 'View task #{{taskId}}',

--- a/src/features/DevPanel/RenderGallery/fixtures/claude-code.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/claude-code.ts
@@ -56,6 +56,10 @@ export default defineFixtures({
       name: 'ScheduleWakeup',
     },
     {
+      description: 'Send a message to a peer agent.',
+      name: 'SendMessage',
+    },
+    {
       description: 'Run a Claude Code skill.',
       name: 'Skill',
     },
@@ -196,6 +200,33 @@ export default defineFixtures({
         reason: 'Recheck the failing build once dependencies finish installing.',
       },
     }),
+    SendMessage: variants([
+      {
+        args: {
+          content:
+            'Please return your full findings now: the context engine entry/pipeline (file paths, function names, line numbers) so I can synthesize the report.',
+          message:
+            'Please return your full findings now: the context engine entry/pipeline (file paths, function names, line numbers) so I can synthesize the report.',
+          recipient: 'a48b23013d11aacd4',
+          summary: 'Retrieve context engine findings',
+          to: 'a48b23013d11aacd4',
+          type: 'message',
+        },
+        content: JSON.stringify({
+          message: 'Message queued for delivery to a48b23013d11aacd4 at its next tool round.',
+          success: true,
+        }),
+        label: 'Queued for delivery',
+      },
+      {
+        args: {
+          message: 'Wrap up when you can — no rush, just checking in on the migration status.',
+          to: 'context-engine',
+        },
+        content: '',
+        label: 'No summary, no result yet',
+      },
+    ]),
     Skill: single({
       args: { skill: 'codebase-search' },
       content: 'Use ripgrep first, then open only the relevant files to keep context sharp.',


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

The multi-agent `SendMessage` tool that Claude Code agents use to message a peer agent had no dedicated render, so it fell through to the generic argument dump (`参数列表` + raw JSON `返回结果`). This ships a purpose-built inter-agent message card and a clearer inspector chip.

- **Render** (`Render/SendMessage`): send icon + `summary` (falls back to the localized "Send message" when absent) + recipient chip on the right + markdown message body + a green delivery-status line when the tool result reports `success`. Reads robustly through the tool's aliased fields (`to`/`recipient`, `message`/`content`), parses the JSON result inline (no new package dependency).
- **Inspector** (`Inspector/SendMessage`): chip now reads `Send message → <recipient>` instead of `SendMessage (to:… 等 6 个参数)`.
- Registered both under the `claude-code` identifier; render defaults to `expand` since the message is the content.
- Added `SendMessage` to `ClaudeCodeApiName` plus `SendMessageArgs` / `SendMessageResult` types.
- i18n key `builtins.lobe-claude-code.sendMessage.title` (en-US + zh-CN, hand-written).
- Render Gallery fixture with two variants (queued-for-delivery / no-summary-no-result).

#### 🧪 How to Test

Verified in the desktop app's Render Gallery (`/devtools/claude-code` → SendMessage), both fixture variants:
- Queued variant: icon + summary + recipient chip + markdown body + green "Message queued for delivery…" status.
- No-summary variant: fallback title, recipient chip, body, and no status line (empty result).
- Inspector chip shows "发送消息 → <recipient>" on both.

Full verification report: https://app.lobehub.com/verify/62bb8f70-766e-4fcc-a5aa-43c57f7eb85d

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

See the verify report above for both rendered variants.

#### 📝 Additional Information

Type-check on touched files is clean (repo has pre-existing unrelated TS errors in `apps/server` / `packages/config` / `packages/const`).