### PR TITLE
🔒 fix(skill): route user-supplied URL fetches through ssrfSafeFetch (SSRF, #16536)

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/integration/agentSkills.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/agentSkills.integration.test.ts
@@ -86,8 +86,16 @@ vi.mock('@/server/services/market', () => ({
   MarketService: vi.fn().mockImplementation(() => mockMarketServiceInstance),
 }));
 
-// Mock global fetch for URL imports
-const mockFetch = vi.fn();
+// User-supplied URLs (importFromUrl / importFromMarket download) must be fetched through
+// ssrfSafeFetch (SSRF guard), never raw global fetch. Configure responses on mockSsrfSafeFetch;
+// the raw global fetch is stubbed to throw so any regression back to raw fetch fails loudly
+// (GHSA-53h9-fmjf-frwr / #16536).
+const { mockSsrfSafeFetch } = vi.hoisted(() => ({ mockSsrfSafeFetch: vi.fn() }));
+vi.mock('@lobechat/ssrf-safe-fetch', () => ({ ssrfSafeFetch: mockSsrfSafeFetch }));
+
+const mockFetch = vi.fn(() => {
+  throw new Error('raw global fetch must not be used for user-supplied URLs; use ssrfSafeFetch');
+});
 vi.stubGlobal('fetch', mockFetch);
 
 describe('Skill Router Integration Tests', () => {
@@ -943,11 +951,11 @@ describe('Skill Router Integration Tests', () => {
 
   describe('importFromUrl', () => {
     beforeEach(() => {
-      mockFetch.mockReset();
+      mockSsrfSafeFetch.mockReset();
     });
 
     it('should import skill from URL', async () => {
-      mockFetch.mockResolvedValue({
+      mockSsrfSafeFetch.mockResolvedValue({
         ok: true,
         status: 200,
         text: async () => `---
@@ -980,7 +988,7 @@ description: A skill from URL
     });
 
     it('should update existing skill when re-importing from same URL', async () => {
-      mockFetch.mockResolvedValue({
+      mockSsrfSafeFetch.mockResolvedValue({
         ok: true,
         status: 200,
         text: async () => 'content',
@@ -1020,7 +1028,7 @@ description: A skill from URL
 
   describe('importFromMarket', () => {
     beforeEach(() => {
-      mockFetch.mockReset();
+      mockSsrfSafeFetch.mockReset();
       mockMarketServiceInstance.getSkillDownloadUrl.mockReset();
     });
 
@@ -1031,7 +1039,7 @@ description: A skill from URL
           'https://market.lobehub.com/api/v1/skills/github.owner.repo/download?version=1.0.0',
         );
 
-      mockFetch.mockResolvedValue({
+      mockSsrfSafeFetch.mockResolvedValue({
         arrayBuffer: async () => new ArrayBuffer(8),
         headers: {
           get: (key: string) => (key === 'content-type' ? 'application/zip' : null),

--- a/apps/server/src/services/generation/index.test.ts
+++ b/apps/server/src/services/generation/index.test.ts
@@ -11,9 +11,16 @@ import { inferFileExtensionFromImageUrl } from '@/utils/url';
 
 import { fetchImageFromUrl, GenerationService } from './index';
 
-// Mock fetch globally
-const mockFetch = vi.fn();
-global.fetch = mockFetch;
+// Image URLs (incl. user-supplied coverUrl) must go through ssrfSafeFetch (SSRF guard), never
+// raw global fetch. Configure image responses on mockSsrfSafeFetch. The raw global fetch is
+// stubbed to throw, so any regression back to `fetch(url)` fails loudly instead of silently
+// re-opening the SSRF hole (GHSA-53h9-fmjf-frwr / #16536).
+const { mockSsrfSafeFetch } = vi.hoisted(() => ({ mockSsrfSafeFetch: vi.fn() }));
+vi.mock('@lobechat/ssrf-safe-fetch', () => ({ ssrfSafeFetch: mockSsrfSafeFetch }));
+
+global.fetch = vi.fn(() => {
+  throw new Error('raw global fetch must not be used for image URLs; use ssrfSafeFetch');
+}) as any;
 
 vi.mock('debug', () => ({
   default: () => vi.fn(),
@@ -119,7 +126,7 @@ describe('GenerationService', () => {
           mockBuffer.byteOffset + mockBuffer.byteLength,
         );
 
-        mockFetch.mockResolvedValueOnce({
+        mockSsrfSafeFetch.mockResolvedValueOnce({
           ok: true,
           status: 200,
           headers: {
@@ -130,7 +137,7 @@ describe('GenerationService', () => {
 
         const result = await fetchImageFromUrl('https://example.com/image.jpg');
 
-        expect(mockFetch).toHaveBeenCalledWith('https://example.com/image.jpg', {
+        expect(mockSsrfSafeFetch).toHaveBeenCalledWith('https://example.com/image.jpg', {
           headers: undefined,
         });
         expect(result.mimeType).toBe('image/jpeg');
@@ -145,7 +152,7 @@ describe('GenerationService', () => {
           mockBuffer.byteOffset + mockBuffer.byteLength,
         );
 
-        mockFetch.mockResolvedValueOnce({
+        mockSsrfSafeFetch.mockResolvedValueOnce({
           ok: true,
           status: 200,
           headers: {
@@ -161,7 +168,7 @@ describe('GenerationService', () => {
 
         const result = await fetchImageFromUrl('https://example.com/image.jpg', customHeaders);
 
-        expect(mockFetch).toHaveBeenCalledWith('https://example.com/image.jpg', {
+        expect(mockSsrfSafeFetch).toHaveBeenCalledWith('https://example.com/image.jpg', {
           headers: customHeaders,
         });
         expect(result.mimeType).toBe('image/jpeg');
@@ -176,7 +183,7 @@ describe('GenerationService', () => {
           mockBuffer.byteOffset + mockBuffer.byteLength,
         );
 
-        mockFetch.mockResolvedValueOnce({
+        mockSsrfSafeFetch.mockResolvedValueOnce({
           ok: true,
           status: 200,
           headers: {
@@ -192,7 +199,7 @@ describe('GenerationService', () => {
       });
 
       it('should throw error when fetch fails', async () => {
-        mockFetch.mockResolvedValueOnce({
+        mockSsrfSafeFetch.mockResolvedValueOnce({
           ok: false,
           status: 404,
           statusText: 'Not Found',
@@ -202,17 +209,49 @@ describe('GenerationService', () => {
           'Failed to fetch image from https://example.com/nonexistent.jpg: 404 Not Found',
         );
 
-        expect(mockFetch).toHaveBeenCalledWith('https://example.com/nonexistent.jpg', {
+        expect(mockSsrfSafeFetch).toHaveBeenCalledWith('https://example.com/nonexistent.jpg', {
           headers: undefined,
         });
       });
 
       it('should throw error when network request fails', async () => {
-        mockFetch.mockRejectedValueOnce(new Error('Network error'));
+        mockSsrfSafeFetch.mockRejectedValueOnce(new Error('Network error'));
 
         await expect(fetchImageFromUrl('https://example.com/image.jpg')).rejects.toThrow(
           'Network error',
         );
+      });
+    });
+
+    // Regression: user-supplied image URLs (e.g. updateTopicCover's coverUrl) must be fetched
+    // through the SSRF guard, never raw global fetch. See GHSA-53h9-fmjf-frwr / #16536.
+    describe('SSRF protection (#16536)', () => {
+      it('should fetch through ssrfSafeFetch, not raw global fetch', async () => {
+        const mockArrayBuffer = Buffer.from('img').buffer;
+        mockSsrfSafeFetch.mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: { get: vi.fn().mockReturnValue('image/png') },
+          arrayBuffer: vi.fn().mockResolvedValue(mockArrayBuffer),
+        });
+
+        await fetchImageFromUrl('http://169.254.169.254/latest/meta-data/');
+
+        // The SSRF guard is the sink; the raw global fetch (stubbed to throw) is never touched.
+        expect(mockSsrfSafeFetch).toHaveBeenCalledWith('http://169.254.169.254/latest/meta-data/', {
+          headers: undefined,
+        });
+        expect(global.fetch).not.toHaveBeenCalled();
+      });
+
+      it('should propagate the SSRF-blocked error for an internal host', async () => {
+        // ssrfSafeFetch rejects when the target resolves to a private/link-local address.
+        mockSsrfSafeFetch.mockRejectedValueOnce(
+          new Error('SSRF blocked: DNS lookup 127.0.0.1 is not allowed.'),
+        );
+
+        await expect(fetchImageFromUrl('http://127.0.0.1:6379/')).rejects.toThrow('SSRF blocked');
+        expect(global.fetch).not.toHaveBeenCalled();
       });
     });
 
@@ -251,7 +290,7 @@ describe('GenerationService', () => {
           mockBuffer.byteOffset + mockBuffer.byteLength,
         );
 
-        mockFetch.mockResolvedValueOnce({
+        mockSsrfSafeFetch.mockResolvedValueOnce({
           ok: true,
           status: 200,
           headers: {
@@ -343,7 +382,7 @@ describe('GenerationService', () => {
         mockOriginalBuffer.byteOffset,
         mockOriginalBuffer.byteOffset + mockOriginalBuffer.byteLength,
       );
-      mockFetch.mockResolvedValueOnce({
+      mockSsrfSafeFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
         headers: {
@@ -447,7 +486,7 @@ describe('GenerationService', () => {
         mockOriginalBuffer.byteOffset,
         mockOriginalBuffer.byteOffset + mockOriginalBuffer.byteLength,
       );
-      mockFetch.mockResolvedValueOnce({
+      mockSsrfSafeFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
         headers: {
@@ -798,7 +837,7 @@ describe('GenerationService', () => {
         mockBuffer.byteOffset,
         mockBuffer.byteOffset + mockBuffer.byteLength,
       );
-      mockFetch.mockResolvedValueOnce({
+      mockSsrfSafeFetch.mockResolvedValueOnce({
         ok: true,
         status: 200,
         headers: {

--- a/apps/server/src/services/generation/index.ts
+++ b/apps/server/src/services/generation/index.ts
@@ -1,5 +1,6 @@
 import { type LobeChatDatabase } from '@lobechat/database';
 import { parseDataUri } from '@lobechat/model-runtime';
+import { ssrfSafeFetch } from '@lobechat/ssrf-safe-fetch';
 import debug from 'debug';
 import { sha256 } from 'js-sha256';
 import mime from 'mime';
@@ -50,7 +51,13 @@ export async function fetchImageFromUrl(
       );
     }
   } else {
-    const response = await fetch(url, { headers: fetchHeaders });
+    // Use ssrfSafeFetch (not raw global fetch): url can be user-supplied (e.g. the
+    // updateTopicCover coverUrl), so a raw fetch would let an authenticated user make the
+    // server request arbitrary internal hosts / cloud metadata (SSRF) — image-typed responses
+    // are read and returned, other responses leak status/statusText for blind probing.
+    // ssrfSafeFetch blocks private/link-local IPs at connect time and on every redirect hop.
+    // See GHSA-53h9-fmjf-frwr / #16536.
+    const response = await ssrfSafeFetch(url, { headers: fetchHeaders });
     if (!response.ok) {
       throw new Error(
         `Failed to fetch image from ${url}: ${response.status} ${response.statusText}`,

--- a/apps/server/src/services/skill/importer.test.ts
+++ b/apps/server/src/services/skill/importer.test.ts
@@ -53,8 +53,16 @@ vi.mock('./parser', () => ({
   SkillParser: vi.fn().mockImplementation(() => mockParserInstance),
 }));
 
-// Mock global fetch for URL imports
-const mockFetch = vi.fn();
+// User-supplied URLs must be fetched through ssrfSafeFetch (SSRF guard), never raw global
+// fetch. Configure URL-import responses on mockSsrfSafeFetch. The raw global fetch is stubbed
+// to throw, so any regression back to `fetch(userUrl)` fails loudly instead of silently
+// re-opening the SSRF hole (GHSA-53h9-fmjf-frwr / #16536).
+const { mockSsrfSafeFetch } = vi.hoisted(() => ({ mockSsrfSafeFetch: vi.fn() }));
+vi.mock('@lobechat/ssrf-safe-fetch', () => ({ ssrfSafeFetch: mockSsrfSafeFetch }));
+
+const mockFetch = vi.fn(() => {
+  throw new Error('raw global fetch must not be used for user-supplied URLs; use ssrfSafeFetch');
+});
 vi.stubGlobal('fetch', mockFetch);
 
 // Mock S3 operations in FileService implementation
@@ -816,11 +824,11 @@ describe('SkillImporter', () => {
 
   describe('importFromUrl', () => {
     beforeEach(() => {
-      mockFetch.mockReset();
+      mockSsrfSafeFetch.mockReset();
     });
 
     it('should import skill from URL', async () => {
-      mockFetch.mockResolvedValue({
+      mockSsrfSafeFetch.mockResolvedValue({
         ok: true,
         status: 200,
         text: async () => `---
@@ -859,7 +867,7 @@ This is the skill content.`,
     });
 
     it('should handle URL with path', async () => {
-      mockFetch.mockResolvedValue({
+      mockSsrfSafeFetch.mockResolvedValue({
         ok: true,
         status: 200,
         text: async () => `---
@@ -883,7 +891,7 @@ description: A nested skill
     });
 
     it('should update existing skill when re-importing from same URL', async () => {
-      mockFetch.mockResolvedValue({
+      mockSsrfSafeFetch.mockResolvedValue({
         ok: true,
         status: 200,
         text: async () => 'content',
@@ -921,7 +929,7 @@ description: A nested skill
     });
 
     it('should return unchanged when content is the same', async () => {
-      mockFetch.mockResolvedValue({
+      mockSsrfSafeFetch.mockResolvedValue({
         ok: true,
         status: 200,
         text: async () => 'content',
@@ -961,7 +969,7 @@ description: A nested skill
     });
 
     it('should throw NOT_FOUND error when URL returns 404', async () => {
-      mockFetch.mockResolvedValue({
+      mockSsrfSafeFetch.mockResolvedValue({
         ok: false,
         status: 404,
         statusText: 'Not Found',
@@ -979,7 +987,7 @@ description: A nested skill
     });
 
     it('should throw DOWNLOAD_FAILED error when fetch fails', async () => {
-      mockFetch.mockResolvedValue({
+      mockSsrfSafeFetch.mockResolvedValue({
         ok: false,
         status: 500,
         statusText: 'Internal Server Error',
@@ -997,7 +1005,7 @@ description: A nested skill
     });
 
     it('should throw DOWNLOAD_FAILED error when network error occurs', async () => {
-      mockFetch.mockRejectedValue(new Error('Network error'));
+      mockSsrfSafeFetch.mockRejectedValue(new Error('Network error'));
 
       await expect(
         importer.importFromUrl({ url: 'https://example.com/network-error.md' }),
@@ -1008,6 +1016,51 @@ description: A nested skill
       } catch (e) {
         expect((e as SkillImportError).code).toBe('DOWNLOAD_FAILED');
       }
+    });
+
+    // Regression: the imported body is stored and returned to the caller, so a raw fetch here
+    // is a full-read SSRF. The fetch must go through the SSRF guard. See GHSA-53h9-fmjf-frwr / #16536.
+    describe('SSRF protection (#16536)', () => {
+      it('should fetch the user URL through ssrfSafeFetch, not raw global fetch', async () => {
+        mockSsrfSafeFetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          headers: { get: () => 'text/markdown' },
+          text: async () => 'internal-response-body',
+        });
+        mockParserInstance.parseSkillMd.mockReturnValue({
+          content: '# x',
+          manifest: { name: 'x', description: 'x' },
+          raw: 'raw',
+        });
+
+        await importer.importFromUrl({ url: 'http://169.254.169.254/latest/meta-data/' });
+
+        // The SSRF guard is the sink; the raw global fetch (stubbed to throw) is never touched.
+        expect(mockSsrfSafeFetch).toHaveBeenCalledWith('http://169.254.169.254/latest/meta-data/', {
+          signal: expect.anything(),
+        });
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
+
+      it('should surface DOWNLOAD_FAILED when ssrfSafeFetch blocks an internal host', async () => {
+        // ssrfSafeFetch rejects when the target resolves to a private/link-local address.
+        mockSsrfSafeFetch.mockRejectedValue(
+          new Error('SSRF blocked: DNS lookup 169.254.169.254 is not allowed.'),
+        );
+
+        await expect(
+          importer.importFromUrl({ url: 'http://169.254.169.254/latest/meta-data/' }),
+        ).rejects.toThrow(SkillImportError);
+
+        try {
+          await importer.importFromUrl({ url: 'http://169.254.169.254/latest/meta-data/' });
+        } catch (e) {
+          expect((e as SkillImportError).code).toBe('DOWNLOAD_FAILED');
+          expect((e as SkillImportError).message).toContain('SSRF blocked');
+        }
+        expect(mockFetch).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/apps/server/src/services/skill/importer.ts
+++ b/apps/server/src/services/skill/importer.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 
 import { type LobeChatDatabase } from '@lobechat/database';
+import { ssrfSafeFetch } from '@lobechat/ssrf-safe-fetch';
 import {
   type CreateSkillInput,
   type ImportGitHubInput,
@@ -322,7 +323,12 @@ export class SkillImporter {
 
       let response: Response;
       try {
-        response = await fetch(input.url, { signal: controller.signal });
+        // Use ssrfSafeFetch (not raw global fetch): input.url is fully user-controlled,
+        // so a raw fetch would let an authenticated user make the server request arbitrary
+        // internal hosts / cloud metadata (SSRF), and the body is stored and returned to the
+        // caller — a full-read SSRF. ssrfSafeFetch blocks private/link-local IPs at connect
+        // time and re-checks every redirect hop. See GHSA-53h9-fmjf-frwr / #16536.
+        response = await ssrfSafeFetch(input.url, { signal: controller.signal });
       } finally {
         clearTimeout(timeoutId);
       }


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 🐛 fix (bug 修复 / 安全修复)

### 🔀 变更说明 | Description of Change

Fixes the authenticated SSRF reported in #16536 (originally private advisory **GHSA-53h9-fmjf-frwr**).

Two authenticated tRPC endpoints fetched a user-controlled URL with the raw global `fetch` instead of the repo's existing `@lobechat/ssrf-safe-fetch` guard, letting any authenticated user make the server request arbitrary internal hosts / cloud metadata:

1. **`agentSkills.importFromUrl` → `SkillImporter.importFromUrl`** (`apps/server/src/services/skill/importer.ts`) — the fetched body is parsed, stored, and returned to the caller, so this is a **full-read SSRF** (e.g. `http://169.254.169.254/latest/meta-data/iam/security-credentials/`).
2. **`generationTopic.updateTopicCover` → `fetchImageFromUrl`** (`apps/server/src/services/generation/index.ts`) — image-typed responses are read/returned (full read of any image-typed internal endpoint); other responses give a blind SSRF with `status`/`statusText` leaked for internal port/path probing.

### 🛠️ Fix

Route both fetches through `ssrfSafeFetch`, which delegates to `request-filtering-agent` to block private/link-local addresses at socket-connect time and re-checks every redirect hop — the same pattern already used by the web crawler (`packages/web-crawler`) and `imageUrlToBase64`. The guard respects `SSRF_ALLOW_PRIVATE_IP_ADDRESS` / `SSRF_ALLOW_IP_ADDRESS_LIST`, so self-hosters who intentionally fetch internal hosts are unaffected.

### ✅ Tests

- Migrated both suites to mock `@lobechat/ssrf-safe-fetch` and **stub the raw global `fetch` to throw**, so any regression back to raw `fetch(userUrl)` fails the suite loudly.
- Added regression cases asserting the SSRF guard is the actual sink (raw fetch never touched) and that an SSRF block surfaces as a proper `DOWNLOAD_FAILED` / thrown error.
- `apps/server` skill + generation suites: **67 tests pass**.

### 📝 Notes

- Scope is the two sinks named in the advisory. The GitHub-import path (`modules/GitHub`) is host-constrained to `github.com` and out of scope here.
- `ingestAttachment` (mentioned in the advisory's "audit for other raw fetches") is not present in this tree; can be followed up separately if it lands.

Refs: GHSA-53h9-fmjf-frwr, closes #16536

🤖 Generated with [Claude Code](https://claude.com/claude-code)