### PR TITLE
🐛 fix: bottom prompt input clipped on image/video topic view

### DIFF
--- a/src/routes/(main)/(create)/features/CreateGenerationPage.tsx
+++ b/src/routes/(main)/(create)/features/CreateGenerationPage.tsx
@@ -12,10 +12,16 @@ import WideScreenContainer from '@/features/WideScreenContainer';
 import WideScreenButton from '@/features/WideScreenContainer/WideScreenButton';
 import { useQueryState } from '@/hooks/useQueryParam';
 
+// The drop zone is a sibling of NavHeader inside a column flex container.
+// `height: 100%` would size it to the FULL container (its content floor keeps
+// flex-shrink from absorbing the nav height), pushing the bottom prompt input
+// below the clipped edge by exactly the nav header height. `flex: 1` +
+// `minHeight: 0` sizes it to the remaining space instead.
 const dropZoneStyle: CSSProperties = {
   display: 'flex',
+  flex: 1,
   flexDirection: 'column',
-  height: '100%',
+  minHeight: 0,
   width: '100%',
 };
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Regression introduced by #16207.

#### 🔀 Description of Change

On the image/video generation page, when a topic has generation records, the bottom prompt input was pushed below the visible area by exactly the nav header height (its lower action row got clipped).

Root cause: #16207 wrapped the page content in `DragUploadZone` with `height: '100%'`. The zone is a sibling of `NavHeader` inside a column flex container, so it got sized to the FULL container height (its content floor prevents flex-shrink from absorbing the nav height) and the whole content was shifted down by the nav header, with the overflow clipped by the layout's `overflow: hidden`.

Fix: size the drop zone with `flex: 1` + `minHeight: 0` instead of `height: '100%'`, so it takes only the remaining space below the nav header. Applies to both `/image` and `/video` (both render through `CreateGenerationPage`).

#### 🧪 How to Test

Open `/image` with an existing topic (has generation records) and check the bottom prompt input: the whole input including its action row should be fully visible and pinned above the bottom edge. Same for `/video`.

Verified with a minimal DOM repro measuring `getBoundingClientRect`: before the fix the input bottom exceeded the container by exactly the nav height (48px); after the fix it aligns with the container bottom.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

`CreateGenerationPage.test.tsx` still passes (4/4).