### PR TITLE
📝 docs(skills): teach ux-audit to check composition, not just behavior

### DIFF
--- a/.agents/skills/ux-audit/SKILL.md
+++ b/.agents/skills/ux-audit/SKILL.md
@@ -141,6 +141,29 @@ So a variant comparison must:
 > backwards, cost footnoted, a winner declared from L1 on what is an L3/analytics metric, and the
 > flag-gated /degrades-to-Classic/desktop-excluded signals explained away.
 
+## Ground rule: a "redundant" control is a composition question before a subtraction one
+
+When L1 spots two controls that seem to do the same thing, the reflex is **subtraction** —
+delete one, hide one, merge them, differentiate the copy. Resist it. Two controls that share
+an _intent_ often differ in **scope**, and the honest fix expresses that scope difference in
+**layout** — promote the wider-scope one to a visible, titled **sibling** — not by removing
+it. Subtraction is a _behavior_-layer move; the better answer usually lives in the
+**composition** layer, which is precisely the half of the benchmark an audit drops when it
+walks the [`ux`](../ux/SKILL.md) checklists but never opens
+[`references/pattern-catalog.md`](references/pattern-catalog.md). The checklists speak states,
+momentum, and draft-safety; they carry no vocabulary for _Titled Sections / Grid of Equals /
+Center Stage_, so a checklist-only read reaches for "dedupe" every time. **Walk the
+pattern-catalog pass (L1 step 2) before writing a remedy for any "redundant / overlapping"
+finding**, and ask: _same intent, different scope?_ → the fix is a sibling, not a delete.
+
+> ❌ The CC AskUserQuestion audit flagged the per-question "write your own" box and the global
+> "Or type directly" escape as redundant and proposed hiding / merging them — a subtraction.
+> They aren't redundant: the per-question box is _question_-scoped, the escape is
+> _whole-form_-scoped. The composition-layer answer is to hide the escape when there's one
+> question and render it as a **visible peer** to the question block when there are several — a
+> _Titled Sections_ move a checklist-only read never surfaced. Skipping the catalog cost the
+> better answer.
+
 ## Ground rule: report the good, not only the gaps
 
 An audit that only lists what's broken has drifted into a bug report. The mandate is
@@ -174,7 +197,11 @@ open-redirect guard, a smart default: these are the **good cases**. Name them, c
 - 🟠 **Dead-ends or misleads** — no forward path, ambiguous state, missing in-progress
   feedback, an empty state that isn't a real page.
 - 🟡 **Friction / inconsistency / missed delight** — predictability, redundant controls,
-  progressive-disclosure gaps, CLS jank.
+  progressive-disclosure gaps, CLS jank. This tier is the **easiest to under-report**: a pass
+  hunting correctness skews 🔴/🟠 and glides past micro-consistency — sibling elements styled
+  differently (options carry a number chip, the free-text row doesn't), an affordance with no
+  label. When the surface is otherwise solid, deliberately switch into the **interface-details**
+  lens for one pass, or these never get written down.
 
 ## Output (shared)
 

--- a/.agents/skills/ux-audit/references/layer-1-static.md
+++ b/.agents/skills/ux-audit/references/layer-1-static.md
@@ -21,6 +21,13 @@ Part of the **ux-audit** skill — see [`../SKILL.md`](../SKILL.md). Benchmark:
   L1 is blind to it. Bring the expected-capability list from the surface-class / competitor
   pass _into_ L1 and check each item as present / missing, or the read only ever grades the
   paths that already exist. ❌ missed once: OAuth consent with **no switch-account** affordance.
+- **Cannot** (a stated intent is not a delivered one): a code comment or a prop _name_ that
+  declares design intent — `// reads as one more choice`, `isPrimary`, `variant="ghost"` — is a
+  **claim, not a verdict**. The mechanism that would realize it may be absent, and L1 can't see
+  the gap between the two. Treat an intent-comment as a thing to **confirm at L2**, never tick
+  it ✅ off the comment. ❌ missed once: the ask-user custom-input comment said it "reads as one
+  more choice", but the row had none of the numbered chips the real options carry — so it
+  didn't; the comment described an intent the render never delivered.
 
 ## Procedure
 

--- a/.agents/skills/ux/SKILL.md
+++ b/.agents/skills/ux/SKILL.md
@@ -134,6 +134,7 @@ The one-screen scan. Each line links back to a module above for the full rule + 
 **Grow — discoverability & progressive disclosure** ([grow.md](references/grow.md))
 
 - [ ] Advanced capability is progressively disclosed / discoverable at the moment of need.
+- [ ] A control that borrows a keyboard/CLI idiom (numbered `1`/`2`/`3` chips, `⌘K` badge, arrow-nav, keycap hint) actually wires those keys — or is restyled so it doesn't imply an absent shortcut; a keycap-looking chip with no handler is a false affordance, worst in a surface ported from a CLI. Confirm the keys fire at L3.
 - [ ] A config surface for a feature with its own data/management area links to it in-context (close the config → manage loop) — not just a promise in copy.
 - [ ] Multi-step flow (>2 steps: wizard/onboarding) shows a step/progress indicator (position + total) and keeps non-essential steps skippable with a visible escape hatch.
 

--- a/.agents/skills/ux/references/grow.md
+++ b/.agents/skills/ux/references/grow.md
@@ -68,3 +68,30 @@ context**, at the moment the user is thinking about the feature.
 
 - [ ] A config surface for a feature with its own data / management area links to it in-context (close the config → manage loop), not just describe it in copy. _(Growth・Meaningful)_
 - [ ] The destination is named as an expected capability up front (cross-surface gap has no `file:line`); a global-nav path elsewhere doesn't excuse the missing near entry point. _(Certainty)_
+
+## 5.4 A borrowed keyboard/CLI idiom must be real, not decorative・Certainty・Natural
+
+When a control **looks like** a known keyboard idiom — numbered `1`/`2`/`3` choice chips, a
+`⌘K` badge, arrow-key list navigation, a keycap-styled shortcut hint — users who know that
+idiom **will press the key**. The look is a promise. So either **wire the key** (the digit
+selects the option, `⌘K` opens the palette, `↑/↓` moves the highlight) or **restyle it so it
+reads as a plain ordinal / label**, never a keycap. A chip that mimics a CLI keycap but has no
+handler is a false affordance — worst of all when the surface is a **port of a CLI flow**
+(Claude Code / Codex), because the user arrives already trained on those keys and the silent
+no-op reads as a bug. This is discoverability's inverse: 5.1 is about revealing a real
+capability; this is about **not advertising one that isn't there**. Whether the keys fire is a
+runtime fact — confirm it at **L3** (press the key), not from the chip's styling.
+
+> ✅ An option row rendered as a keycap (`⌘1`, or a mono `1` chip) responds to that key;
+> a purely ordinal marker is set in body text (not a bordered mono keycap) so it promises
+> nothing. ❌ The CC AskUserQuestion option cards render a mono `1`/`2`/`3` chip in
+> `fontFamilyCode` that reads as a keycap (`OptionCard.tsx` `optionIndex`), mirroring the
+> Claude Code CLI where those digits _are_ the selection keys — but **no keydown handler
+> exists** anywhere in the panel (`builtin-tool-claude-code/.../AskUserQuestion/*`; the
+> Enter/1/2 shortcuts live only in the unrelated `ApprovalActions.tsx`). Pressing 1/2/3 or
+> Enter does nothing — see the global-approval audit. Fix: wire the digit keys to toggle
+> options and Enter to submit (guarded inside the free-text boxes), or drop the keycap styling.
+
+**Checklist**
+
+- [ ] A control that borrows a keyboard/CLI idiom (numbered choices, `⌘K`, arrow-nav, keycap hints) actually wires those keys — or is restyled so it doesn't imply an absent shortcut; especially in a surface ported from a CLI, where the user already knows the keys. Confirm the keys fire at L3. _(Certainty・Natural)_


### PR DESCRIPTION
## 💡 Motivation

Meta-learnings distilled from a real UX audit of the global-approval / CC AskUserQuestion popup. A checklist-only, correctness-hunting audit **systematically missed** two product-owner findings (numbering the free-text row; making the whole-form escape a visible sibling). This PR encodes *why* into the `ux-audit` + `ux` skills so the next audit catches that class.

## 🔧 Changes

**`ux-audit/SKILL.md`**
- New ground rule — **a "redundant" control is a composition question before a subtraction one**: same intent + different scope → promote to a visible sibling, not delete/hide; walk `pattern-catalog.md` before writing the remedy.
- Severity rubric note — the 🟡 craft/consistency tier is the easiest to under-report; switch into the `interface-details` lens for one pass.

**`ux-audit/references/layer-1-static.md`**
- New L1 trap — **a stated-intent comment (`// reads as one more choice`) or prop name is a claim to confirm at L2, never a ✅.**

**`ux/references/grow.md` (+ `ux/SKILL.md` quick-review mirror)**
- New §5.4 — **a borrowed keyboard/CLI idiom (numbered chips, ⌘K) must wire the keys or be restyled**; a keycap with no handler is a false affordance, worst in a CLI-ported surface.

All four cite the audited surface as the ❌ example.

## 📋 Scope

Docs / skills only — **no product code**. Product-side fixes for the popup ship in a follow-up PR.