### PR TITLE
📝 docs(skills): agent profile UX audit

### DIFF
--- a/.agents/skills/ux-audit/references/example/profile.md
+++ b/.agents/skills/ux-audit/references/example/profile.md
@@ -1,0 +1,159 @@
+# Worked example — Agent Profile (助理档案) audit
+
+A real run of this skill against the **agent profile / character editor**
+(`/agent/:aid/profile` → `src/routes/(main)/agent/profile`), 2026-07 (LOBE-11215). Use it
+as a **template for the output shape**, not as current-state truth (the code moves;
+re-verify before citing). Surface = the nav header (breadcrumb + `AutoSaveHint` + status
+tags + More menu) → the profile editor (avatar / name / background, model + tool config, or
+the heterogeneous-agent config panels) → the system-prompt rich-text editor, plus the
+always-mounted edit-lock driver and the right-side Agent Builder copilot.
+
+**Layers run:** L1 (static / code) ✅ — everything below. L2 (visual) / L3 (dynamic + CLS)
+⏳ not yet run — see §5. Verdicts about the render are L1 inferences here, pending L2.
+
+**Surface class & benchmark:** this is a **custom-agent / character editor** (ChatGPT GPT
+editor, Character.ai, Poe bot editor, Dify, Cursor rules). Class norms checked up front:
+live preview / test-the-agent (✓ — the Agent Builder copilot + the sibling chat tab),
+version history / fork (✓ — `AgentVersionReviewTag` / `AgentForkTag`), collaborative edit
+safety (✓ — the edit lock), autosave with a visible save-state (⚠️ — present but can't show
+failure, gap ②), and a config→inspect loop back to the agent's data (✓ — links to stats,
+gap-free, §2). The class norms are largely met — the weakness is **failure handling**, not
+missing capability.
+
+## 1 — Patterns in use
+
+| Pattern (family)               | Where                                                                         | Rating | Note                                               |
+| ------------------------------ | ----------------------------------------------------------------------------- | ------ | -------------------------------------------------- |
+| Visual Framework (layout)      | `NavHeader` + `WideScreenContainer` shell (`index.tsx:46,61`)                 | ✅     | consistent chrome                                  |
+| Breadcrumbs / Deep-linking     | `AgentBreadcrumb`, `/agent/:aid/profile` restores the surface                 | ✅     |                                                    |
+| Center Stage (layout)          | prompt editor dominates the canvas                                            | ✅     |                                                    |
+| Form / Titled Sections (input) | avatar+name header, model/tool panel, prompt editor                           | ✅     |                                                    |
+| Good / Smart Defaults (input)  | inbox → "Lobe AI" name + default avatar (`Content.tsx:77,82`)                 | ✅     |                                                    |
+| Autosave (feedback)            | `AutoSaveHint` saving→saved, debounced writes (`store/action.ts:42`)          | ⚠️     | **no `failed` state** (gap ②)                      |
+| Collaborative lock (feedback)  | `EditLockDriver` peeked before render; read-only for others                   | ✅     | **亮点** — see §2                                  |
+| Streaming-aware editing        | saves suppressed mid-stream, flushed on end (`store/action.ts:76-112`)        | ✅     | **亮点** — see §2                                  |
+| Overview + Detail (data)       | More → Advanced Settings **modal** (`AgentSettings`)                          | ✅     | preserves surface contract (modal, not navigate)   |
+| Cross-surface entry (growth)   | More menu → `/agent/:id/stats`, breadcrumb → chat (`Header/index.tsx:200`)    | ✅     | **亮点** — config→inspect loop closed (§2)         |
+| Rich-text editor + toolbar     | Lexical editor, mention / table / slash plugins (`EditorCanvas`)              | ✅     |                                                    |
+| Loading Skeleton (feedback)    | brand `Loading` while config resolves (`index.tsx:42`)                        | ⚠️     | **success-only gate → permanent on error** (gap ①) |
+| **Failure + Retry** (feedback) | store models it (`agentConfigErrorMap` + selectors + `retryFetchAgentConfig`) | — abs. | **built but wired to nothing** (gap ①)             |
+| Empty / Not-found state        | —                                                                             | — abs. | invalid `:aid` → permanent loading (gap ①)         |
+
+**Read:** layout, deep-linking, collaborative locking, streaming and the config→inspect
+loop are mature — genuinely strong. The weakness clusters entirely in **Feedback (failure
+states)**: an error path that exists in the store but reaches no pixel, and an autosave that
+structurally cannot report failure.
+
+## 2 — Strengths / good cases (don't regress)
+
+This surface is well-built where it counts; these are the ✅ half of the 回灌 loop and the
+"don't regress" baseline for the next refactor:
+
+- **✅ 亮点 — Edit lock is peeked _before_ the editor renders.** `EditLockDriver` is mounted
+  **outside** the config-loading gate (`index.tsx:68-70`, with a comment explaining why), so an
+  agent another workspace member is already editing is read-only from the **first frame** rather
+  than flashing editable then locking. `lockedByOther` / `lockPending` drive a real
+  `EditingIndicator` and hide the Agent Builder (which would fight the lock). Load-bearing
+  collaborative-safety — the model to copy for any shared-resource editor.
+- **✅ 亮点 — Streaming-aware save gating.** While the Agent Builder streams a generated
+  system-prompt into the editor, user-edit detection and debounced saves are **suppressed**, then
+  a single save is flushed when the stream ends (`store/action.ts:76-112`, `EditorCanvas`
+  `finishStreaming`). Generated content never clobbers a save race, and the user's own edits
+  aren't misread as stream output. A subtle correctness win worth protecting.
+- **✅ 亮点 — Config→inspect loop closed from the config context.** The More menu links straight
+  to `/agent/:id/stats` (`Header/index.tsx:200-206`) and the breadcrumb returns to the agent's
+  chat, so configuring the agent and _seeing what it did_ are one click apart — the ✅ contrast to
+  settings-Memory's promise-with-no-door (Grow §5.3).
+- **✅ (worth preserving, but currently inert) — The store already models error ≠ loading
+  correctly.** `agentConfigErrorMap` + `currentAgentConfigError` / `isAgentConfigError` +
+  `retryFetchAgentConfig` (`selectors.ts:235-238`, `action.ts:341-357`) are exactly the right
+  data layer, with a doc comment promising "a retry UI instead of an endless skeleton." The
+  intent is right; gap ① is that **no surface consumes any of it** — so this is a strength to
+  _finish_, not one to admire. (Don't delete it in a cleanup pass — wire it.)
+
+## 3 — Experience gaps (ranked)
+
+**① Config-fetch error → permanent brand-loading; the error+retry machinery is built but
+wired to nothing — ux §4.2 / Read §1.1** 🔴 `ProfileArea` branches only on
+`isAgentConfigLoading` (`index.tsx:42`), whose selector is `!activeAgentId ||
+!agentMap[activeAgentId]` (`selectors.ts:227-228`) — the **data-presence-disguised init flag**
+§4.2 warns about ("loaded = is the data here yet"). On a failed or 404 `getAgentConfigById`,
+`onData` never runs, `agentMap[id]` stays `undefined`, so `isAgentConfigLoading` stays `true`
+**forever** → the full-page `<Loading/>` spins with no reason and no retry. A bad / deleted
+`:aid` is therefore indistinguishable from a slow load (Read §1.1 error-vs-not-found). What
+makes this sharp: `onError` **does** record `agentConfigErrorMap[id]` (`action.ts:341-352`),
+and `currentAgentConfigError` / `isAgentConfigError` (`selectors.ts:235-238`) **and**
+`retryFetchAgentConfig` (`action.ts:357`) all exist — but `rg` finds **zero** consumers
+anywhere in the app. The retry UI the store was built for is dead code. _Remedy:_ branch
+`isAgentConfigError` before the loading gate in `ProfileArea` → a failed state (reason +
+Reload calling `retryFetchAgentConfig`); keep loading only for `!error && no-data`.
+
+**② Autosave cannot represent failure — every save on the surface fails silently — ux §4.4
+/ §4.2** 🔴 `AutoSaveHint`'s save-state enum is `'idle' | 'saving' | 'saved'`
+(`AutoSaveHint.tsx:12`) — **no `failed` variant**, so the machine literally can't _show_ a
+failed write (the exact type-level silent-write trap the page-editor and task-detail examples
+already carry). Downstream, every writer swallows failure: the debounced prompt save and
+`finishStreaming` both `catch → console.error` only (`store/action.ts:48-50, 103-105`); title
+(`AgentHeader.tsx:49`), avatar / background (`:58, 96`), model / tool
+(`ProfileEditor/index.tsx` `updateConfig`), and the Advanced-Settings modal's optimistic
+config/meta writes (`AgentSettings/Content.tsx:59, 65`) surface nothing. A prompt edit that
+failed to persist reads identical to one that saved — config-loss with a "saved" tag over it.
+_Remedy:_ add `failed` to the enum + an inline Retry that keeps the edited value; drive it
+from the writers' `catch`. One convention for the whole surface (bake it into `AutoSaveHint`).
+
+**③ Avatar upload has no `catch` — a failed upload is silent — ux §4.2** 🟠
+`handleAvatarUpload` wraps `uploadWithProgress` in `try { … } finally { setUploading(false) }`
+with **no `catch`** (`AgentHeader.tsx:72-79`); only the client-side size-exceeded case is
+toasted (`:66-68`). A rejected upload (network / server / oversized-after-encode) just flips
+the spinner off — no `message.error`, and the rejection escapes as an unhandled promise.
+_Remedy:_ `catch → message.error` with a retry hint; keep the previous avatar.
+
+**④ Prompt / title drafts aren't backed to durable storage — up to 30s of edits lost on
+reload — ux Edit §2.1** 🟡 The name lives in a `useState` `localTitle` (`AgentHeader.tsx:37`)
+and the prompt is held in the editor until a debounced write (1 s, `maxWait` 30 s —
+`store/action.ts:42-54`) reaches the server; there's **no localStorage draft** like the chat
+composer's `useChatInputDraft`. A reload / crash inside the debounce window vaporizes the last
+edits with no recovery. Milder than a compose box (it does autosave to the server), but the
+30 s `maxWait` plus zero local backup is a real loss window on the surface where users write
+long system prompts. _Remedy:_ mirror `useChatInputDraft` — back the editor draft to
+localStorage keyed by agent id, flush on unmount, clear on confirmed save.
+
+**⑤ Advanced-Settings modal `loading={false}` hardcoded — ux §4.2** 🟡
+`AgentSettings/Content.tsx:93` passes `loading={false}` unconditionally, so if config / meta
+were still resolving the modal would render as ready rather than skeleton. Low impact today
+(the whole surface is gated on `isAgentConfigLoading`, so the store is usually populated before
+the modal can open), but it's a latent success-only assumption. _Remedy:_ derive `loading`
+from the real config-resolved state.
+
+## 4 — Skill feedback
+
+- **New sub-rule landed in `ux` (the generalizable one):** Feedback **§4.2 strengthened** — an
+  error state and retry action that **exist in the store but are consumed by no surface** are
+  still a _missing_ error state; a built-but-unwired failure path is indistinguishable from an
+  absent one, and grepping the error selector's consumers is the check. ❌ example = gap ①
+  (agent profile: `isAgentConfigError` + `retryFetchAgentConfig` built, `rg` → 0 call sites,
+  permanent brand-loading on fetch failure). Mirrored into the Quick review. This was **not**
+  stated before — the prior §4.2 text assumed the error path was simply forgotten, not
+  half-built-and-orphaned.
+- **Validated existing rules** (good ❌ examples to cite, not new): §4.4 (gap ②, the
+  `idle|saving|saved`-no-`failed` enum — a third instance beside the page editor and task
+  detail; added to the §4.4 ❌ list), §4.2 data-presence-disguised init flag (gap ①'s
+  `!agentMap[id]` gate), §4.2 write-side no-`catch` (gap ③), Edit §2.1 (gap ④,
+  autosave-to-server still owes a local draft).
+- **Good cases noted, not landed as new ✅ rules:** the edit-lock-peeked-before-render and
+  streaming-aware-save gating are strong but re-illustrate rules that are already complete
+  (collaborative safety / save-race correctness) rather than revealing a missing distinction —
+  recorded here as the "don't regress" list, not folded into the checklist.
+
+## 5 — Pending: L2 visual + L3 dynamic
+
+- **L2 (visual)** — confirm the prompt editor reads as the dominant Center Stage; check the
+  `AutoSaveHint` tag legibility (saving vs saved vs "latest"); the locked-editor opacity 0.65
+  read; narrow-width layout of the avatar+name row and the heterogeneous-config tabs; dark mode.
+- **L3 (dynamic)** —
+  - Force `getAgentConfigById` to fail / navigate to a bogus `:aid` to **confirm gap ① live**
+    (permanent brand-loading, no retry) and to check nothing else (a route redirect / error
+    boundary) rescues it first.
+  - Force a save write to reject to **confirm gap ②** (the surface shows "saved" / no failure).
+  - Drive an avatar upload failure to **confirm gap ③**.
+  - Reload mid-edit within the debounce window to **confirm gap ④** (lost prompt edits).

--- a/.agents/skills/ux-audit/references/example/stats.md
+++ b/.agents/skills/ux-audit/references/example/stats.md
@@ -1,0 +1,160 @@
+# Worked example — Agent stats / Usage & Cost (统计) audit
+
+A real run of this skill against the per-agent usage & cost dashboard
+(`/agent/:aid/stats` → `src/features/AgentUsage`), 2026-07-02 (LOBE-11218, under the
+Chat / 会话 UX-Audit parent LOBE-11145). Use it as a **template for the output shape**, not as
+current-state truth (the code moves; re-verify before citing).
+
+Surface = a single scrolling column of three `Block` cards: **① summary stat cards**
+(cost / cache savings / token) with a dimension (day/week) + range (7/30/90d) toolbar →
+**② "when this agent spent" stacked bar chart** with a spend/token toggle → **③ per-model
+breakdown table**. Chrome = `NavHeader` + `AgentBreadcrumb`.
+
+**Layers run:** L1 (static / code) ✅ — everything below. L2 (visual) / L3 (dynamic +
+CLS) ⏳ not yet run — see §5. Verdicts about the render (chart sparseness, does $0 read as
+real data) are L1 inferences here, pending L2 confirmation.
+
+**Surface class & its norms (benchmark first).** This is a **usage / cost dashboard** — the
+reference class is Anthropic Console usage, the OpenAI usage dashboard, Vercel/Stripe
+analytics, AWS Cost Explorer. Class norms an L1 code-read is otherwise blind to (each
+checked below): date-range + granularity control ✅; **period-over-period comparison** (▲/▼ %
+vs previous range) ✗; **export / download** (CSV) ✗; **drill-down** from an aggregate to the
+records that produced it ✗; a purpose-built **empty / no-usage** state ✗; **failure ≠ $0** ✗.
+
+## 1 — Patterns in use
+
+| Pattern (family)                      | Where                                                                                                  | Rating | Note                                                                 |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------ | -------------------------------------------------------------------- |
+| Visual Framework (layout)             | `NavHeader` + `WideScreenContainer` centered column (`index.tsx:52`)                                   | ✅     | consistent app chrome                                                |
+| Titled Sections / Card Stack (layout) | three `Block variant="outlined"` cards (`index.tsx:63,101,104`)                                        | ✅     | clean top-to-bottom read                                             |
+| Breadcrumbs (nav)                     | `AgentBreadcrumb` with `usageStats.title` (`index.tsx:56`)                                             | ⚠️     | renders `null` when no active agent (`index.tsx:55`)                 |
+| Sortable Table (data)                 | per-model breakdown `antd Table` (`ModelBreakdown.tsx:65`)                                             | ⚠️     | `pagination={false}`, columns not actually sortable, no row → detail |
+| Dynamic Queries (data)                | day/week + 7/30/90d `Segmented` (`index.tsx:69,83`); spend/token toggle (`UsageTrendChart.tsx:51`)     | ⚠️     | selection is `useState` — not persisted, not in URL (gap ④)          |
+| Datatips / Data Brushing (data)       | `BarChart` stacked series with tooltips (`UsageTrendChart.tsx:63`)                                     | ✅     | interactive read of input/output/cache                               |
+| Number formatting (data)              | `formatUsageValue` / `formatNumber` / `formatTokenNumber` everywhere                                   | ✅     | shared unit-rolling helpers, Read §1.5 (highlight)                   |
+| Skeleton loading (feedback)           | chart `Skeleton.Block height={320}` (`UsageTrendChart.tsx:61`)                                         | ✅     | height matches the loaded chart exactly, 0 CLS (highlight)           |
+| Loading Indicator (feedback)          | `StatisticCard` antd `Spin` (`StatisticCard/index.tsx:166`); table antd spin (`ModelBreakdown.tsx:70`) | ⚠️     | antd `Spin`, not project loader / skeleton (gap ⑥)                   |
+| Failure + Retry (feedback)            | —                                                                                                      | —      | **absent** — no error branch anywhere (gap ①)                        |
+| Empty-state as onboarding (growth)    | —                                                                                                      | —      | **absent** — no "no usage yet" page (gap ②)                          |
+| Overview + Detail / drill-down (data) | —                                                                                                      | —      | **absent** — no aggregate → source-records path (gap ⑤)              |
+| Comparison / trend delta (data)       | —                                                                                                      | —      | **absent** — `TitleWithPercentage` exists but unused (gap ⑤)         |
+
+**Read:** layout, number formatting, and the chart skeleton are mature. The weakness
+clusters hard in **Feedback (no failure state at all)** and **Read §1.1 (failure and empty
+both collapse into a plausible `$0` dashboard)** — the defining flaw of this surface.
+
+## 2 — Strengths / good cases (don't regress)
+
+This surface is thin, but three behaviors are done right and are the "don't regress" list:
+
+- **✅ 亮点 — Chart skeleton matches the loaded chart's exact height (→ candidate ✅ for ux
+  Feedback §4.1).** The loading placeholder is `Skeleton.Block height={320}` and the real
+  `BarChart` is `height={320}` (`UsageTrendChart.tsx:61,64`) — same pixel height, so the
+  loading→content swap causes **zero layout shift**. This is the concrete, numeric form of
+  "skeleton matches the content's height" and worth citing as the ✅ beside §4.1.
+- **✅ 亮点 — Consistent shared number formatting.** Every value routes through
+  `formatUsageValue` / `formatNumber` / `formatTokenNumber` (`StatCards.tsx`,
+  `UsageTrendChart.tsx`, `ModelBreakdown.tsx`) rather than ad-hoc `toLocaleString`, so units
+  roll consistently (Read §1.5) across cards, chart axis, and table.
+- **✅ 亮点 — Model rows are truncation-safe.** Each breakdown row pairs `ModelIcon` + an
+  `ellipsis` model name over a secondary `provider` line (`ModelBreakdown.tsx:24-34`), so a
+  long model id degrades gracefully instead of breaking the row.
+
+## 3 — Experience gaps (ranked)
+
+**① A failed fetch renders as a real-looking `$0` dashboard — ux Read §1.1 / Feedback §4.2**
+🔴 `useAgentUsageStats` returns only `{ data, isLoading }`; **`error` is never read**
+(`index.tsx:46`). On any network / 500 / auth failure SWR resolves to `data === undefined`,
+`isLoading === false`, and the page coerces the failure into **plausible zero data**:
+`summary={data?.summary ?? EMPTY_SUMMARY}` shows **$0.00 cost / 0 tokens** (`index.tsx:98`),
+`buckets={data?.buckets}` → an empty chart, `rows={data?.byModel ?? []}` → an empty table
+(`index.tsx:102,105`). This is worse than the classic `data ?? [] → <Empty>` masquerade:
+the failure doesn't even read as "empty", it reads as **legitimate data — "this agent cost
+you nothing"** — with no reason and **no retry anywhere**. Remedy: read `error`; when
+`error`, render a failed state (reason + Reload/`mutate`) _before_ any aggregate is shown;
+only show data on `!error`.
+
+**② No empty / "no usage yet" state — ux Read §1.1** 🟠 When the agent genuinely has no
+assistant messages in range the server returns zeros + empty arrays
+(`apps/server/.../usage/index.ts:253`, buckets built only from rows), and the client renders
+the same `$0` cards, a blank chart plot, and antd Table's default "No Data"
+(`ModelBreakdown.tsx:65`). There is no purpose-built empty page explaining _what this is,
+why it's empty, and a next action_ (e.g. "This agent hasn't run in the last 30d — start a
+chat"). "No usage yet", "load failed", and "genuinely $0" are three different situations
+rendered identically. Remedy: a real empty page for `!error && !isLoading && totalRequests === 0`, distinct from the error state in ①.
+
+**③ No-active-agent falls through to a silent zero dashboard — ux Read §1.1/§1.6** 🟠 If
+`activeAgentId` is nullish the SWR key is `null` → no fetch, `isLoading === false`, `data === undefined` → the full `$0` dashboard renders under a **`null` breadcrumb**
+(`index.tsx:55-58,46`). No loading, no guidance — just wrong-looking empty content. Remedy:
+gate on a resolved agent id and show a loading/guidance state until it exists.
+
+**④ Range / granularity / chart-type not persisted, not in URL — Certainty (Deep-linking)**
+🟡 `range`, `granularity` (`index.tsx:43-44`) and the chart spend/token toggle
+(`UsageTrendChart.tsx:27`) are all local `useState`. A reload resets to 30d / day / spend,
+and the view is not shareable or bookmarkable — a cost view someone wants to send ("look at
+90d") can't be linked. Remedy: lift the selections to URL search params (Deep-linking).
+
+**⑤ Dashboard dead-ends: no comparison, no export, no drill-down — class norms + Grow §5.3**
+🟡 Three usage/cost-dashboard class norms are absent, and one has a _ready but unused_
+building block:
+
+- **Period-over-period comparison** — `StatCards` uses bare `StatisticCard` with no prior
+  value (`StatCards.tsx:30-67`), yet the design system already ships `TitleWithPercentage` /
+  `growthPercentage` (`components/StatisticCard/…`) precisely for "▲ +12% vs previous
+  period". The capability exists and is simply not wired.
+- **Export / download** — no CSV/export of the breakdown; a cost surface people reconcile
+  against invoices should offer it.
+- **Drill-down (Overview + Detail)** — clicking a model row or a chart bucket leads nowhere;
+  the surface can't answer "what did this $ come from" by linking to the driving
+  conversations. This is the Grow §5.3 closed-loop gap: a metrics pane that doesn't lead
+  onward to the records it summarizes.
+
+**⑥ Loading uses antd `Spin`, inconsistent with the chart skeleton — ux Feedback §4.1** 🟡
+The chart loads with a `Skeleton.Block` (✅) but the stat cards spin via `StatisticCard`'s
+`<Spin percent="auto"/>` (`StatisticCard/index.tsx:166`) and the table uses antd Table's
+built-in spin (`ModelBreakdown.tsx:70`). Feedback §4.1 bans antd `Spin` in favor of
+skeletons / project loaders, and the three blocks loading in three different visual idioms
+reads as unpolished. Remedy: skeleton the cards and table to match the chart.
+
+**⑦ Trend chart is not zero-filled → a sparse, misleading timeline — pending L2** 🟡 The
+server creates a bucket only for days that have messages (`usage/index.ts:253,274-286`), so a
+30-day range with 3 active days renders **3 bars**, not a 30-slot timeline with gaps — the
+"when this agent spent" shape is distorted and the x-axis lies about the range. L1 flags the
+data shape; the visual severity is an **L2** confirm. Remedy: zero-fill buckets across the
+full `[startAt, endAt]` at the requested granularity.
+
+## 4 — Skill feedback (回灌)
+
+- **New generalizable gap → landed in `ux` (mandatory close).** Read §1.1's existing ❌
+  examples are all the _list_ form of the masquerade (`data ?? [] → <Empty>`). This surface
+  reveals a **latent sub-rule**: on a **metrics / aggregate** surface the failure default is
+  a _zero-valued object_ (`?? EMPTY_SUMMARY`, `?? 0`), so the failure renders as **real-looking
+  data ("$0 spent")**, not as "empty" — strictly worse, because nothing signals anything is
+  wrong. Landed by extending Read §1.1 (new paragraph + ❌ **Agent stats** example + a
+  checklist line) and mirroring one line into the SKILL Quick review, citing
+  `AgentUsage/index.tsx:46,98`.
+- **Validated existing rules** (good ❌ instances to cite): Read §1.1 (gaps ①②③), Feedback
+  §4.2 (gap ①, no retry), Feedback §4.1 (gap ⑥, antd `Spin`), Grow §5.3 (gap ⑤, dead-end
+  config/metrics surface).
+- **Good case candidate ✅:** the chart's height-exact skeleton (§2) is the numeric form of
+  Feedback §4.1's "skeleton matches height" — noted as a ✅ example; not yet grafted into the
+  rule text (§4.1 already states the principle).
+- **Noted, not yet landed:** filter state → URL (gap ④) and comparison/export/drill-down
+  class norms (gap ⑤) — captured here; promote to checklist items if a second dashboard
+  surface repeats them.
+
+## 5 — Pending: L2 visual + L3 dynamic
+
+L1-only; verdicts a later pass should confirm or quantify on this surface:
+
+- **L2 (visual)** — confirm gap ⑦ (does a sparse 3-bar chart actually read as a 30-day
+  timeline?); confirm the `$0` cards vs a real value look identical enough to fool a user
+  (gap ①); check the three-idiom loading (skeleton vs two spins, gap ⑥) side by side;
+  narrow-width wrap of the two toolbar `Segmented`s (`index.tsx:64 wrap`).
+- **L3 (dynamic)** —
+  - Force the stats fetch offline to **confirm gap ① live** — that the page settles on `$0`
+    with no error and no retry, not a skeleton.
+  - Drive an agent with **zero** messages to **confirm gap ②** (what the true-empty state
+    actually renders as).
+  - **Measure CLS** across the loading→content swap; the chart skeleton predicts 0 for the
+    chart, but the `Spin`→value swap on the cards and the table are unmeasured.

--- a/.agents/skills/ux/SKILL.md
+++ b/.agents/skills/ux/SKILL.md
@@ -87,7 +87,7 @@ The one-screen scan. Each line links back to a module above for the full rule + 
 **Read — viewing data & lists** ([read.md](references/read.md))
 
 - [ ] Empty / loading / error states are all designed; empty is a real page with a CTA. Always-rendered chrome (toolbar/header) still gets a body empty state. If the `Empty` component ships a `search`/no-match variant, **wire it** — don't render `<Empty/>` bare so a zero-result search shows the first-run onboarding.
-- [ ] Error is checked before the empty branch — a failed fetch never renders as empty (read `error`, don't coerce `data ?? [] → Empty`); a detail page reads `error` before falling to `NotFound` (failed-to-load ≠ deleted/404).
+- [ ] Error is checked before the empty branch — a failed fetch never renders as empty (read `error`, don't coerce `data ?? [] → Empty`); a detail page reads `error` before falling to `NotFound` (failed-to-load ≠ deleted/404). On a **metrics/dashboard** surface the failure default is a zero-valued object (`?? {…:0}`) that renders as a confident `$0` — read `error` before any aggregate, don't fall through to zeros.
 - [ ] List designed across 1 → 10k rows (virtual scroll / pagination / batch as needed).
 - [ ] Search / filter over a paginated list queries the full set server-side, not just the loaded page (no false "no results" for unfetched rows).
 - [ ] Capped/scrollable/virtualized list scrolls the restored active item into view on mount (`block: 'nearest'`, re-run after async rows mount).

--- a/.agents/skills/ux/SKILL.md
+++ b/.agents/skills/ux/SKILL.md
@@ -125,7 +125,7 @@ The one-screen scan. Each line links back to a module above for the full rule + 
 **Feedback — loading & system response** ([feedback.md](references/feedback.md))
 
 - [ ] No antd `Spin`; use `NeuralNetworkLoading` / project loaders.
-- [ ] Every loading state can fail: on error or timeout, show a failed state with a Reload/Retry action — never an infinite spinner. In an auto-dismissing surface (upload dock / progress toast), the countdown clears **success only** — a failed item persists with Retry.
+- [ ] Every loading state can fail: on error or timeout, show a failed state with a Reload/Retry action — never an infinite spinner. In an auto-dismissing surface (upload dock / progress toast), the countdown clears **success only** — a failed item persists with Retry. An error state / retry action that's **modeled in the store but consumed by no surface** (`isXError` selector / `retryX` action with zero `rg` call sites) is still a missing error state — a built-but-orphaned path is a permanent skeleton at the pixel.
 - [ ] A compound gate waiting on a secondary/dependent fetch gates on its **in-flight** flag and releases on settled (data / resolved-`null` / error) — never on the dependency being present in a map, or an absent-by-design dependency hangs it forever.
 - [ ] An awaited write that gates navigation/advance resets its busy flag in `finally` + offers retry — a failed write never permanently disables the forward/Back control.
 - [ ] Autosave surfaces a save-state (saving → saved → failed with retry), never a silent write; the save-state enum actually includes a `failed` variant (a catch that resets to `idle` is a silent write); one save-feedback convention across a multi-field surface, ideally in the shared form wrapper.

--- a/.agents/skills/ux/references/feedback.md
+++ b/.agents/skills/ux/references/feedback.md
@@ -83,6 +83,27 @@ as "is the data here yet". A failed fetch leaves the entry `undefined` → `load
 false → permanent skeleton. Don't read "present in a success-populated map" as "loaded";
 branch the fetch's real `error`.
 
+A subtler shape: the error state and retry action **exist in the store but are wired to
+nothing**. The slice records an `errorMap`, exposes `isXError` / `currentXError` selectors,
+even ships a `retryX` action — the data layer is exactly right — but **no surface consumes
+any of it**: the component still branches only on the success-only loading flag, so a failed
+fetch is a permanent skeleton and the retry the store built is dead code. A built-but-orphaned
+error path is **indistinguishable from a missing one** at the pixel; the store having the
+right shape does not discharge the obligation — a surface must actually read the error and
+render the failed state. When you find an `errorMap` / `isXError` selector, **grep its
+consumers** (`rg isXError`): zero call sites is the tell.
+
+> ❌ **Agent profile** (`/agent/:aid/profile`) branches only on `isAgentConfigLoading =
+!activeAgentId || !agentMap[id]` (`store/agent/selectors/selectors.ts`), the data-presence
+> disguise, and renders a full-page `<Loading/>` — so a failed / 404 `getAgentConfigById` (a bad
+> or deleted `:aid`) spins **forever** with no retry. The kicker: `onError` **does** populate
+> `agentConfigErrorMap`, and `currentAgentConfigError` / `isAgentConfigError` **and**
+> `retryFetchAgentConfig` all exist with a doc comment promising "a retry UI instead of an
+> endless skeleton" — but `rg` finds **zero** consumers anywhere (`ProfileArea` in
+> `routes/(main)/agent/profile/index.tsx` reads none of them). The error+retry machinery is
+> fully built and reaches no pixel. ✅ Branch `isAgentConfigError` before the loading gate → a
+> failed state (reason + Reload calling the existing `retryFetchAgentConfig`).
+
 The mirror-image trap on a **compound** gate — one that holds the skeleton until a **secondary /
 dependent** fetch resolves (a detail that waits on the assignee's config, a row that waits on its
 owner) — is gating on that dependency being **present** in the map. When the dependency
@@ -190,6 +211,7 @@ xSearchLoading || !xInit` flips only on success, so a failed load hangs a **perm
 
 - [ ] Every loading state has a terminal failure path — on error or after a bounded timeout, not an infinite spinner. _(Certainty)_
 - [ ] An init/ready flag isn't gated on success only — the error path resolves the loading state too, no permanent skeleton. _(Certainty)_
+- [ ] The error state is actually **consumed by a surface**, not just modeled in the store — an `errorMap` / `isXError` selector / `retryX` action with **zero call sites** (`rg` the consumers) is a permanent skeleton wearing a built-but-orphaned error path; the store having the right shape doesn't discharge the obligation. _(Certainty)_
 - [ ] A compound gate waiting on a **secondary/dependent** fetch gates on its **in-flight** flag and releases on settled (data / resolved-`null` / error), never on the dependency being **present** in a map — a legitimately absent dependency (deleted / out-of-scope) must not hang the gate. _(Certainty)_
 - [ ] An awaited write that gates navigation resets its in-progress flag in `finally` and offers retry on `catch` — a failed write never permanently disables the advance / Back control. _(Certainty)_
 - [ ] The failed state names the failure and offers a **Reload / Retry** action. _(Meaningful)_
@@ -284,6 +306,12 @@ just moves it onto the button.
 > `PageEditor/store/action.ts`). A network / 500 save failure is then indistinguishable from
 > a success (only a lock `CONFLICT` is surfaced); the state machine literally can't
 > _represent_ failure, so it can never show it — the silent-write trap baked into the type.
+> ❌ **Agent profile** shares the identical type-level trap: `AutoSaveHint`'s enum is
+> `'idle' | 'saving' | 'saved'` (`components/Editor/AutoSaveHint.tsx`) — **no `failed`** — so
+> the header can't show a failed write, and every writer on the surface swallows it: the prompt
+> save and `finishStreaming` `catch → console.error` (`routes/(main)/agent/profile/features/store/action.ts`),
+> while title / avatar / model / tool / advanced-settings saves surface nothing. A prompt edit
+> that failed to persist reads identical to a saved one, with a "saved" tag over it.
 > ❌ **Task detail** config autosave is the same trap twice over: `updateVerifyConfig` /
 > `updateTaskModelConfig` / `updatePeriodicInterval` / `setAutomationMode` / `updateSchedule` all
 > catch-and-`console.error` (`store/task/slices/config/action.ts:121-132,151-167,224-229,279-284`)

--- a/.agents/skills/ux/references/read.md
+++ b/.agents/skills/ux/references/read.md
@@ -31,6 +31,25 @@ gets its own state (reason + Reload). Error is not a kind of empty.
 > ✅ The agent **Documents** tab keeps its new-folder / new-doc toolbar and renders an `Empty` below it when there are no documents.
 > ❌ A bare title over skeleton rows, or a toolbar over dead space.
 > ❌ `Devices` renders a failed device-list fetch as the "Connect your first device" onboarding empty (`DeviceManager.tsx` reads only `{data, isLoading}`), falsely telling the user they own no devices — the same `data ?? [] → empty` trap in `Messenger`, `Creds`, `Skill`, `Stats`, `SystemTools` (7 settings tabs at once); and in **Eval** overview, where a failed benchmark fetch renders the "create your first benchmark" onboarding empty (`eval/index.tsx`).
+
+**On a metrics / aggregate surface the masquerade wears its worst mask: the failure looks
+like _real data_, not "empty".** A dashboard's failure default isn't an empty array — it's a
+**zero-valued object** (`data?.summary ?? { totalCost: 0, … }`, `?? 0`), so an errored fetch
+renders **plausible, legitimate-looking numbers** — "this agent cost you $0.00 / 0 tokens" —
+with nothing on screen signalling anything went wrong. This is strictly worse than the list
+case: an empty list at least invites suspicion ("did this fail?"); a confident `$0`, by
+contrast, reads as the truth. Same fix, higher stakes: always read `error`, then branch to a
+failed state before rendering any aggregate — never fall through to a zero default. Three
+states, not one: failed (reason + Reload), genuinely-zero (a real empty page), and real data
+are different screens.
+
+> ❌ **Agent stats / Usage & Cost** (`/agent/:aid/stats`) reads only `{ data, isLoading }`
+> from `useAgentUsageStats` — **`error` unread** (`AgentUsage/index.tsx:46`) — then coerces a
+> failure into `summary={data?.summary ?? EMPTY_SUMMARY}` (all zeros, `index.tsx:98`),
+> `rows={data?.byModel ?? []}`, and an empty chart. A 500 / offline / auth failure renders a
+> confident **"$0.00 cost, 0 tokens"** dashboard, no reason, no retry — indistinguishable
+> from an agent that genuinely hasn't run. ✅ Branch `error` → a failed card with Reload
+> (`mutate`); show the zero/empty page only on `!error && totalRequests === 0`.
 > ❌ A detail page that `return null`s until its record loads is **not** a loading state — it's a blank flash on the happy path and a **permanent blank** if the fetch fails (no skeleton, no error): **Eval** run / case / dataset detail all `if (!record) return null` (`eval/bench/[benchmarkId]/runs/[runId]/index.tsx`, `.../cases/[caseId]/index.tsx`, `.../datasets/[datasetId]/index.tsx`). Render a skeleton, then an error state.
 > ❌ **Resource** repeats the failure-as-empty trap four times: the Explorer reads only `{ isLoading, isValidating }` (the swr already exposes `error`, unread) so a failed resource fetch renders the "create your first resource" onboarding (`ResourceManager/components/Explorer/index.tsx`, `EmptyPlaceholder.tsx`); the sidebar KB list (`resource/(home)/_layout/Body/LibraryList/index.tsx`), the search overlay (`SearchResultsOverlay.tsx` → false "no results"), and the folder tree (`LibraryHierarchy/index.tsx` → false "add folder") all do the same.
 
@@ -68,6 +87,7 @@ Distinguish `error` (transient → reason + retry, keep the URL) from a resolved
 - [ ] Empty state is a real page with explanation + CTA, not a blank screen. _(Meaningful)_
 - [ ] Empty variants distinguished: "no data yet" vs "no filter match". _(Certainty)_
 - [ ] Error is checked **before** the empty branch — a failed fetch never renders as empty (`!error && length === 0` gates empty); read `error`, don't coerce `data ?? []`. _(Certainty・Meaningful)_
+- [ ] On a **metrics / aggregate** surface (dashboard, stats, cost), a failed fetch never falls through to a **zero-valued default** (`data?.summary ?? {…:0}`, `?? 0`) — a confident `$0` reads as real data, not "empty"; branch `error` before rendering any aggregate. _(Certainty・Meaningful)_
 - [ ] A detail page reads `error` before falling to `NotFound` — a failed fetch shows a reload state, not a "doesn't exist" 404 (deleted vs failed-to-load are different screens). _(Certainty・Meaningful)_
 - [ ] Always-rendered chrome still renders a body empty placeholder. _(Meaningful)_
 - [ ] Loading designed (skeleton / NeuralNetworkLoading), no layout shift — a detail page's "record not loaded yet" is a skeleton, never a bare `return null` / blank. _(Natural)_


### PR DESCRIPTION
## Summary

L1 static UX audits of two agent surfaces, with the generalizable findings fed back into the `ux` skill. **Docs / skills only — no runtime code changes.**

Two surfaces audited in this branch:

1. **Agent profile** (`/agent/:aid/profile`) — LOBE-11215
2. **Agent stats / Usage & Cost** (`/agent/:aid/stats` → `src/features/AgentUsage`) — LOBE-11218

### Profile audit (LOBE-11215)

- New report `.agents/skills/ux-audit/references/example/profile.md` (Patterns in use / Strengths / ranked Gaps / L2·L3 pending).
- `ux` Feedback **§4.2**: added a sub-rule + checklist item — an error state / retry action that is *modeled in the store but consumed by no surface* (`isXError` / `retryX` with zero `rg` hits) is still a **missing error state**; a built-but-orphaned path is a permanent skeleton at the pixel. Agent profile cited as the ❌ example, mirrored into the Quick review.
- `ux` Feedback **§4.4**: added agent profile as the ❌ example of an autosave enum with no `failed` variant (third case beside page-editor / task-detail).

### Stats audit (LOBE-11218)

- New report `.agents/skills/ux-audit/references/example/stats.md` (surface-class benchmark / Patterns / Strengths / 7 ranked gaps / L2·L3 pending).
- `ux` Read **§1.1**: extracted a latent sub-rule — on a **metrics / aggregate** surface the failure default is a *zero-valued object* (`?? EMPTY_SUMMARY`), so an errored fetch renders as a confident `$0`, which is worse than the list `data ?? [] → <Empty>` masquerade because it reads as real data. Agent stats cited as the ❌ example + checklist line, mirrored into the Quick review.

## Findings (filed as sub-issues; this PR fixes no concrete bugs)

**Profile — under LOBE-11215**

| Severity | Finding | Sub-issue |
| -- | -- | -- |
| 🔴 | config fetch failure → permanent Loading; error+retry built but never consumed | LOBE-11246 |
| 🔴 | `AutoSaveHint` has no failed state → all saves fail silently | LOBE-11247 |
| 🟠 | avatar upload has no catch → upload failure is silent | LOBE-11248 |
| 🟡 | prompt/title draft not persisted to localStorage → lost on reload | LOBE-11249 |
| 🟡 | advanced-settings modal hardcodes `loading={false}` | LOBE-11250 |

**Stats — under LOBE-11218**

| Severity | Finding | Sub-issue |
| -- | -- | -- |
| 🔴 | fetch failure masquerades as a real `$0` dashboard (`error` unread, falls back to zeros) | LOBE-11252 |
| 🟠 | no "no usage yet" empty state (indistinguishable from $0 / failure) | LOBE-11253 |
| 🟠 | no active agent → silent $0 dashboard + null breadcrumb | LOBE-11254 |
| 🟡 | filters (range / granularity / chart type) not persisted, not in URL | LOBE-11255 |
| 🟡 | dashboard dead-ends: no period comparison / export / drill-down | LOBE-11256 |
| 🟡 | loading uses antd `Spin`, inconsistent with the chart skeleton | LOBE-11257 |
| 🟡 | trend chart not zero-filled → sparse, misleading timeline (pending L2) | LOBE-11258 |

## Test plan

- No runtime changes; markdown only (skill docs + audit reports). lint-staged prettier/remark formats on commit.

Fixes LOBE-11215
Fixes LOBE-11218

🤖 Generated with [Claude Code](https://claude.com/claude-code)