### PR TITLE
🧰 chore(agent-testing): gate agent-runtime tests on a QStash preflight

### DIFF
--- a/.agents/skills/agent-testing/SKILL.md
+++ b/.agents/skills/agent-testing/SKILL.md
@@ -162,7 +162,29 @@ Useful subcommands:
 ./.agents/skills/agent-testing/scripts/init-dev-env.sh migrate   # migrations only
 ./.agents/skills/agent-testing/scripts/init-dev-env.sh seed-user # seed user + CLI API key
 ./.agents/skills/agent-testing/scripts/init-dev-env.sh qstash    # local QStash for workflow paths
+./.agents/skills/agent-testing/scripts/init-dev-env.sh preflight # gate agent-runtime tests (QStash up in queue mode)
 ./.agents/skills/agent-testing/scripts/init-dev-env.sh clean-db  # remove managed DB container
+```
+
+#### Agent-runtime prerequisite: QStash MUST be up (queue mode)
+
+Any test that runs an **agent** (`lh agent run`, durable ops, `/api/agent/run`,
+the server agent runtime) goes through `AGENT_RUNTIME_MODE=queue` — the default
+here and in production. Creating an agent operation **POSTs to local QStash
+(`127.0.0.1:8080`)**, so if QStash is not running the run dies at operation
+creation with `TypeError: fetch failed` / `ECONNREFUSED 127.0.0.1:8080`
+**before any LLM call** — no trace is recorded and the failure reads as
+unrelated to the env. `FEATURE_FLAGS=-agent_self_iteration` only drops the
+self-iteration workflow; it does **not** remove this dispatch dependency. Treat
+QStash as a hard prerequisite for agent-runtime tests, not an "only when
+workflow" nicety.
+
+So before the first `agent run`, start QStash in a separate terminal and gate on
+the preflight:
+
+```bash
+./.agents/skills/agent-testing/scripts/init-dev-env.sh qstash      # terminal B — keep running
+./.agents/skills/agent-testing/scripts/init-dev-env.sh preflight    # exits non-zero if QStash (or Redis) is down
 ```
 
 Default script env:
@@ -173,10 +195,13 @@ Default script env:
 - `AGENT_RUNTIME_MODE=queue` so backend-only agent runtime checks use the
   same queued execution path as production
 - `REDIS_URL=redis://localhost:6380` for queue-mode agent runtime state
-- `FEATURE_FLAGS=-agent_self_iteration` so local smoke does not require QStash
-- Local QStash defaults (`QSTASH_URL`, `QSTASH_TOKEN`, signing keys) are exported;
-  run `init-dev-env.sh qstash` in a separate terminal when the path under test
-  triggers QStash/Workflow.
+- `FEATURE_FLAGS=-agent_self_iteration` drops the self-iteration workflow (so a
+  simple chat doesn't fan out), but this does **not** remove QStash from the
+  agent-runtime path — queue-mode operation creation still POSTs to QStash.
+- Local QStash defaults (`QSTASH_URL`, `QSTASH_TOKEN`, signing keys) are exported,
+  but the QStash server itself is not auto-started. Run `init-dev-env.sh qstash`
+  in a separate terminal for **any agent-runtime test** (see the agent-runtime
+  prerequisite above), not only workflow paths.
 - `KEY_VAULTS_SECRET`, `AUTH_SECRET`, auth verification off
 - S3 mock vars
 - Managed DB container: `lobehub-agent-testing-postgres`

--- a/.agents/skills/agent-testing/cli/index.md
+++ b/.agents/skills/agent-testing/cli/index.md
@@ -19,6 +19,7 @@ flakiness.
 | CLI source   | `apps/cli/` — runs from source, no rebuild; standalone `node_modules` — run `pnpm install` inside `apps/cli/` (root install does not cover it) |
 | CLI dev mode | `LOBEHUB_CLI_HOME=.lobehub-dev` for isolated settings                                                                                          |
 | Auth         | Seeded API key first; Device Code Flow only as fallback — see [../references/auth.md](../references/auth.md)                                   |
+| QStash       | **Required for `agent run`** (queue mode). Start `init-dev-env.sh qstash` and verify with `init-dev-env.sh preflight` — see below              |
 
 All CLI dev commands run from `apps/cli/`. Subsequent examples use `$CLI`:
 
@@ -101,10 +102,21 @@ $CLI task delete T-1 -y
 
 ### Agent system
 
+`agent run` executes through the **server agent runtime in queue mode**, which
+POSTs the operation to local QStash (`127.0.0.1:8080`). If QStash is not
+running, the run fails at operation creation with `fetch failed` /
+`ECONNREFUSED 127.0.0.1:8080` **before any LLM call** — and no trace is
+recorded. So before running an agent, start QStash and gate on the preflight:
+
+```bash
+./.agents/skills/agent-testing/scripts/init-dev-env.sh qstash      # separate terminal — keep running
+./.agents/skills/agent-testing/scripts/init-dev-env.sh preflight    # non-zero exit if QStash/Redis is down
+```
+
 ```bash
 $CLI agent list
 $CLI agent view <agent-id>
-$CLI agent run <agent-id> -m "Test prompt"
+$CLI agent run <agent-id> -m "Test prompt"   # requires QStash (see preflight above)
 ```
 
 ### Document & knowledge base

--- a/.agents/skills/agent-testing/scripts/init-dev-env.sh
+++ b/.agents/skills/agent-testing/scripts/init-dev-env.sh
@@ -16,6 +16,7 @@
 #   init-dev-env.sh migrate          # run DB migrations against the configured DB
 #   init-dev-env.sh seed-user        # seed the baseline test user + CLI API key
 #   init-dev-env.sh qstash           # run local Upstash QStash dev server
+#   init-dev-env.sh preflight        # check agent-runtime prerequisites (QStash up in queue mode)
 #   init-dev-env.sh dev-next         # exec `pnpm run dev:next` with this env
 #   init-dev-env.sh dev              # exec `bun run dev` with this env
 #   init-dev-env.sh clean-db         # remove the managed Postgres/Redis containers
@@ -104,6 +105,34 @@ QSTASH_LOCAL_NEXT_SIGNING_KEY="${QSTASH_LOCAL_NEXT_SIGNING_KEY:-sig_5ZB6DVzB1wjE
 ok() { printf '  \033[32m✔\033[0m %s\n' "$1"; }
 bad() { printf '  \033[31m✘\033[0m %s\n' "$1"; }
 note() { printf '      %s\n' "$1"; }
+
+# A URL is "reachable" when it answers with any HTTP status. Connection refused
+# / no route yields curl code 000. Used for the dev server, where any listener
+# on the port is the thing we mean.
+_http_reachable() {
+  local url="$1" code
+  command -v curl > /dev/null 2>&1 || return 2
+  code="$(curl -s -o /dev/null -m 3 -w '%{http_code}' "$url" 2>/dev/null || true)"
+  [[ -n "$code" && "$code" != "000" ]]
+}
+
+# QStash-specific probe. 8080 is a common dev port, so "something answers HTTP"
+# is not enough — a foreign listener would make preflight green while `agent
+# run` later publishes to a non-QStash endpoint and fails. Key on QStash's REST
+# contract instead: `/v2/schedules` rejects a tokenless request with 401 and
+# answers the configured bearer with 200. A bare/foreign server fails one leg
+# (catch-all 200 servers don't 401; 404/other servers don't 200), and a wrong
+# token also fails (surfacing auth misconfig). Returns 2 when curl is absent.
+_qstash_reachable() {
+  command -v curl > /dev/null 2>&1 || return 2
+  local base="${QSTASH_URL%/}" unauth auth
+  unauth="$(curl -s -o /dev/null -m 3 -w '%{http_code}' "$base/v2/schedules" 2>/dev/null || true)"
+  [[ "$unauth" == "401" ]] || return 1
+  auth="$(curl -s -o /dev/null -m 3 \
+    -H "Authorization: Bearer ${QSTASH_TOKEN:-}" \
+    -w '%{http_code}' "$base/v2/schedules" 2>/dev/null || true)"
+  [[ "$auth" == "200" ]]
+}
 
 guard_no_root_env() {
   if [[ -f "$ROOT_ENV_FILE" ]]; then
@@ -449,6 +478,55 @@ cmd_status() {
   else
     bad "docker CLI is not available"
   fi
+  if _qstash_reachable; then
+    ok "QStash reachable: $QSTASH_URL"
+  else
+    note "QStash is not answering as QStash at $QSTASH_URL (needed for agent-runtime / queue mode)"
+  fi
+}
+
+# Prerequisite gate for agent-runtime tests. In queue mode (the default here and
+# in production) creating an agent operation POSTs to QStash; if QStash is down
+# the run fails with `ECONNREFUSED 127.0.0.1:8080 / fetch failed` at operation
+# creation — before any LLM call, so no trace is ever recorded. Run this before
+# `lh agent run` (or any durable-op path) and start `qstash` if it fails.
+cmd_preflight() {
+  apply_env
+  local failed=0
+  echo "agent-runtime preflight (AGENT_RUNTIME_MODE=$AGENT_RUNTIME_MODE):"
+
+  if command -v docker > /dev/null 2>&1 &&
+    docker ps --format '{{.Names}}' | grep -Fxq "$REDIS_CONTAINER"; then
+    ok "Redis running: $REDIS_CONTAINER (queue-mode state)"
+  else
+    bad "Redis not running: $REDIS_CONTAINER"
+    note "start it with: $0 setup-db"
+    failed=1
+  fi
+
+  if [[ "$AGENT_RUNTIME_MODE" == "queue" ]]; then
+    if _qstash_reachable; then
+      ok "QStash reachable: $QSTASH_URL (operation dispatch)"
+    else
+      bad "QStash NOT answering as QStash at $QSTASH_URL — agent runs will fail with 'fetch failed' (ECONNREFUSED) or auth errors"
+      note "start it in a separate terminal: $0 qstash"
+      failed=1
+    fi
+  else
+    note "AGENT_RUNTIME_MODE=$AGENT_RUNTIME_MODE (not queue) — QStash not required"
+  fi
+
+  if _http_reachable "$APP_URL"; then
+    ok "dev server reachable: $APP_URL"
+  else
+    note "dev server not reachable at $APP_URL — start it with: $0 dev"
+  fi
+
+  if [[ "$failed" == 1 ]]; then
+    bad "preflight failed — resolve the above before running agent-runtime tests"
+    return 1
+  fi
+  ok "preflight passed — safe to run agent-runtime tests"
 }
 
 cmd_qstash() {
@@ -520,6 +598,7 @@ case "$COMMAND" in
   migrate) migrate_db ;;
   seed-user) seed_user ;;
   qstash) cmd_qstash ;;
+  preflight) cmd_preflight ;;
   dev-next) cmd_dev_next ;;
   dev) cmd_dev ;;
   clean-db) cmd_clean_db ;;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔧 chore

#### 🔀 Description of Change

Running an agent locally (`lh agent run`, durable ops, `/api/agent/run`, the server agent runtime) goes through `AGENT_RUNTIME_MODE=queue` — the default in the agent-testing env and in production. Creating an agent operation **POSTs to local QStash (`127.0.0.1:8080`)**. If QStash isn't running the run dies at operation creation with `TypeError: fetch failed` / `ECONNREFUSED 127.0.0.1:8080` **before any LLM call** — so no trace is recorded and the failure reads as unrelated to the env.

The old skill docs treated QStash as an "only when workflow/QStash path" nicety and even implied `FEATURE_FLAGS=-agent_self_iteration` removed the dependency. That's wrong: the flag only drops the self-iteration workflow; queue-mode operation dispatch still needs QStash. This PR turns that footgun into a checked prerequisite.

**`scripts/init-dev-env.sh`**
- New `preflight` subcommand: hard-checks the agent-runtime prerequisites (Redis running; QStash reachable when `AGENT_RUNTIME_MODE=queue`) and **exits non-zero with the exact fix command** so it can gate before `agent run`.
- **QStash-specific probe** (not "any HTTP listener"): 8080 is a common dev port, so a bare/foreign listener would false-green the check. The probe keys on QStash's REST contract — `/v2/schedules` returns **401** to a tokenless request and **200** to the configured bearer. A catch-all-200 server fails the 401 leg; a 404/other server fails the 200 leg; a wrong token also fails (surfacing auth misconfig).
- `status` now runs the same probe instead of only printing the URL.

**`SKILL.md`**
- New prominent section **"Agent-runtime prerequisite: QStash MUST be up (queue mode)"**.
- Lists the `preflight` subcommand; corrects the misleading `-agent_self_iteration` / "does not require QStash" bullet.

**`cli/index.md`**
- QStash added to the prerequisites table + a preflight callout on the `agent run` pattern.

#### 🧪 How to Test

```bash
S=./.agents/skills/agent-testing/scripts/init-dev-env.sh

# real QStash up → exit 0, "preflight passed"
$S qstash &      # separate terminal
$S preflight

# foreign HTTP listener on the port (the false-green case) → correctly FAILS
( cd /tmp && python3 -m http.server 8085 & )
QSTASH_DEV_PORT=8085 $S preflight   # exit 1 + fix hint

# nothing listening → FAILS
QSTASH_DEV_PORT=8099 $S preflight   # exit 1 + fix hint
```

All three verified locally; `bash -n` clean. Docs-only + a self-contained bash subcommand, no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)