### PR TITLE
💄 style(claude-code): polish the ask-user approval popup

### DIFF
--- a/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion/QuestionPanel.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion/QuestionPanel.tsx
@@ -8,11 +8,34 @@ import { useTranslation } from 'react-i18next';
 import type { AskUserQuestionItem } from '../../../types';
 import OptionCard from './OptionCard';
 
-const styles = createStaticStyles(({ css }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   // Per-question "write your own" input — sits as the last row in the option
-  // stack so it reads as one more choice rather than a separate control.
-  customInput: css`
+  // stack, carrying the next sequential number so it reads as one more choice
+  // rather than a separate control.
+  customRow: css`
     margin-block-start: 2px;
+
+    /* Align the chip under the option number chips (OptionCard padding-inline). */
+    padding-inline: 12px;
+  `,
+  // Mirrors OptionCard's `optionIndex` chip so the free-text row's number reads
+  // identically to the numbered options above it.
+  index: css`
+    flex-shrink: 0;
+
+    box-sizing: border-box;
+    width: 22px;
+    height: 22px;
+    border-radius: 6px;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 22px;
+    color: ${cssVar.colorTextSecondary};
+    text-align: center;
+
+    background: ${cssVar.colorFillTertiary};
   `,
 }));
 
@@ -61,16 +84,20 @@ const QuestionPanel = memo<QuestionPanelProps>(
               onToggle={() => onToggle(question, opt.label)}
             />
           ))}
-          {/* Last item: let the user write their own answer for this question. */}
-          <TextArea
-            autoSize={{ maxRows: 4, minRows: 1 }}
-            className={styles.customInput}
-            disabled={disabled}
-            placeholder={t('claudeCode.askUserQuestion.customOption.placeholder')}
-            value={customValue}
-            variant="filled"
-            onChange={(e) => onCustomChange(question, e.target.value)}
-          />
+          {/* Last item: let the user write their own answer for this question.
+              Numbered as the next option so it reads as one more choice. */}
+          <Flexbox horizontal align="center" className={styles.customRow} gap={12}>
+            <span className={styles.index}>{question.options.length + 1}</span>
+            <TextArea
+              autoSize={{ maxRows: 4, minRows: 1 }}
+              disabled={disabled}
+              placeholder={t('claudeCode.askUserQuestion.customOption.placeholder')}
+              style={{ flex: 1 }}
+              value={customValue}
+              variant="filled"
+              onChange={(e) => onCustomChange(question, e.target.value)}
+            />
+          </Flexbox>
         </Flexbox>
       </Flexbox>
     );

--- a/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion/draft.ts
+++ b/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion/draft.ts
@@ -11,11 +11,14 @@ import type { AskUserQuestionItem } from '../../../types';
 export const FREEFORM_PAYLOAD_KEY = '__freeform__';
 
 /**
- * Server-side bridge timeout (matches `AskUserMcpServer.pendingTimeoutMs`).
- * Not strictly synchronized — server is authoritative — but keeps the on-screen
- * countdown close to reality without plumbing a deadline through every layer.
+ * Server-side bridge timeout — mirrors `DEFAULT_ASK_USER_TIMEOUT_MS` in
+ * `@lobechat/heterogeneous-agents` `askUser/constants.ts` (the authoritative
+ * clock). Kept as a local literal because this package has no dep on that one;
+ * **keep the two in sync**. Not strictly synchronized at runtime — server is
+ * authoritative — but keeps the on-screen countdown close to reality without
+ * plumbing a deadline through every layer.
  */
-export const COUNTDOWN_MS = 5 * 60 * 1000;
+export const COUNTDOWN_MS = 10 * 60 * 1000;
 
 /** Key under tool message `pluginState` where the in-progress draft lives. */
 export const DRAFT_PLUGIN_STATE_KEY = 'askUserDraft';

--- a/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion/index.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion/index.tsx
@@ -3,8 +3,7 @@
 import type { BuiltinInterventionProps } from '@lobechat/types';
 import { Flexbox, Icon, Text, TextArea } from '@lobehub/ui';
 import { Button, Tabs } from '@lobehub/ui/base-ui';
-import { createStaticStyles } from 'antd-style';
-import { ArrowLeft, Check, PenLine, Send, X } from 'lucide-react';
+import { Check, PenLine, Send, X } from 'lucide-react';
 import { memo } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
@@ -13,25 +12,6 @@ import type { AskUserQuestionArgs } from '../../../types';
 import { formatRemaining, isQuestionAnswered } from './draft';
 import QuestionPanel from './QuestionPanel';
 import { useAskUserForm } from './useAskUserForm';
-
-const styles = createStaticStyles(({ css, cssVar }) => ({
-  // "Or type directly" / "Back to options" link — slim secondary text that
-  // sits alongside Skip in the action bar; matches the `lobe-user-interaction`
-  // escape-toggle styling so the two flows feel like the same control.
-  escapeLink: css`
-    cursor: pointer;
-
-    display: inline-flex;
-    gap: 4px;
-    align-items: center;
-
-    transition: color 0.12s ease;
-
-    &:hover {
-      color: ${cssVar.colorText};
-    }
-  `,
-}));
 
 /**
  * CC AskUserQuestion intervention component.
@@ -43,14 +23,19 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
  *
  * Answering a question
  * - Pick one of the numbered options, or
- * - Write your own in the trailing input. Single-select treats the two as
- *   mutually exclusive (typing clears the pick and vice-versa); multi-select
- *   appends the custom text as an extra entry alongside the checked options.
+ * - Write your own in the trailing (numbered) input. Single-select treats the
+ *   two as mutually exclusive (typing clears the pick and vice-versa);
+ *   multi-select appends the custom text as an extra entry alongside the checked
+ *   options.
  *
  * Layout
- * - One question → renders the question + options directly, no tab strip.
- * - Multiple questions → top tab bar (Q1, Q2, …), one panel at a time. Picking
- *   an answer auto-advances to the next unanswered question.
+ * - One question → renders the question + options directly, no tab strip, and
+ *   no whole-form escape (the per-question custom box already is the full
+ *   custom answer).
+ * - Multiple questions → top tab bar (Q1, Q2, …) with a trailing "Or type
+ *   directly" tab as a visible peer: selecting it swaps all questions for one
+ *   freeform box that answers the whole form at once. Picking an answer
+ *   auto-advances to the next unanswered question.
  *
  * State, handlers, and draft persistence all live in `useAskUserForm`; this
  * component is just the view.
@@ -67,7 +52,6 @@ const AskUserQuestionIntervention = memo<BuiltinInterventionProps<AskUserQuestio
     expired,
     handleCustomChange,
     handleEscapeTextChange,
-    handleEscapeToggle,
     handleSkip,
     handleSubmit,
     handleToggle,
@@ -77,41 +61,19 @@ const AskUserQuestionIntervention = memo<BuiltinInterventionProps<AskUserQuestio
     questions,
     remainingMs,
     setActiveTab,
+    setEscapeMode,
     submitting,
   } = useAskUserForm(props);
 
   const footer = (
     <Flexbox horizontal align="center" gap={8} justify="space-between" width={'100%'}>
-      <Flexbox horizontal align="center" gap={12}>
-        {escapeActive ? (
-          <Text
-            className={styles.escapeLink}
-            fontSize={12}
-            type="secondary"
-            onClick={expired || submitting ? undefined : handleEscapeToggle}
-          >
-            <Icon icon={ArrowLeft} size={12} />
-            {t('claudeCode.askUserQuestion.escape.back')}
-          </Text>
-        ) : (
-          <Text
-            className={styles.escapeLink}
-            fontSize={12}
-            type="secondary"
-            onClick={expired || submitting ? undefined : handleEscapeToggle}
-          >
-            {t('claudeCode.askUserQuestion.escape.enter')}
-            <Icon icon={PenLine} size={12} />
-          </Text>
-        )}
-        <Text fontSize={12} type="secondary">
-          {expired
-            ? t('claudeCode.askUserQuestion.timeExpired')
-            : t('claudeCode.askUserQuestion.timeRemaining', {
-                time: formatRemaining(remainingMs),
-              })}
-        </Text>
-      </Flexbox>
+      <Text fontSize={12} type="secondary">
+        {expired
+          ? t('claudeCode.askUserQuestion.timeExpired')
+          : t('claudeCode.askUserQuestion.timeRemaining', {
+              time: formatRemaining(remainingMs),
+            })}
+      </Text>
       <Flexbox horizontal gap={8}>
         <Button disabled={submitting} icon={<Icon icon={X} />} onClick={handleSkip}>
           {t('claudeCode.askUserQuestion.skip')}
@@ -131,23 +93,44 @@ const AskUserQuestionIntervention = memo<BuiltinInterventionProps<AskUserQuestio
 
   return (
     <Flexbox gap={12}>
-      {!escapeActive && isMulti && (
+      {isMulti && (
         <Tabs
-          activeKey={activeTab}
+          activeKey={escapeActive ? 'escape' : activeTab}
           variant="square"
-          items={questions.map((q, idx) => {
-            const done = isQuestionAnswered(q, picks, custom);
-            return {
-              key: String(idx),
+          items={[
+            ...questions.map((q, idx) => {
+              const done = isQuestionAnswered(q, picks, custom);
+              return {
+                key: String(idx),
+                label: (
+                  <Flexbox horizontal align="center" gap={6}>
+                    <Text>Q{idx + 1}</Text>
+                    {done && <Icon icon={Check} size={12} />}
+                  </Flexbox>
+                ),
+              };
+            }),
+            // The whole-form freeform sits as a visible peer to the questions —
+            // it replaces *all* of them, so it reads as a sibling choice, not a
+            // hidden mode toggle.
+            {
+              key: 'escape',
               label: (
                 <Flexbox horizontal align="center" gap={6}>
-                  <Text>Q{idx + 1}</Text>
-                  {done && <Icon icon={Check} size={12} />}
+                  <Icon icon={PenLine} size={12} />
+                  <Text>{t('claudeCode.askUserQuestion.escape.enter')}</Text>
                 </Flexbox>
               ),
-            };
-          })}
-          onChange={(key: string) => setActiveTab(key)}
+            },
+          ]}
+          onChange={(key: string) => {
+            if (key === 'escape') {
+              setEscapeMode(true);
+            } else {
+              setEscapeMode(false);
+              setActiveTab(key);
+            }
+          }}
         />
       )}
 

--- a/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion/useAskUserForm.ts
+++ b/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion/useAskUserForm.ts
@@ -157,23 +157,29 @@ export const useAskUserForm = ({
     [custom, picks, writeDraft],
   );
 
-  const handleEscapeToggle = useCallback(() => {
-    setEscapeActive((prev) => {
-      const next = !prev;
+  const setEscapeMode = useCallback(
+    (next: boolean) => {
+      setEscapeActive(next);
       writeDraft({ custom, escapeActive: next, escapeText, picks });
-      return next;
-    });
-  }, [custom, escapeText, picks, writeDraft]);
+    },
+    [custom, escapeText, picks, writeDraft],
+  );
+
+  // Whole-form freeform only makes sense with more than one question — with a
+  // single question the per-question custom box already IS the full custom
+  // answer, so escape is redundant there and never offered.
+  const escapeAvailable = questions.length > 1;
+  const inEscape = escapeActive && escapeAvailable;
 
   const handleSubmit = useCallback(() => {
-    if (escapeActive) {
+    if (escapeActive && escapeAvailable) {
       // Escape mode is mutually exclusive with picks — send the text alone
       // under `__freeform__`. Bridge formatter forwards it to CC verbatim.
       void submitWith({ [FREEFORM_PAYLOAD_KEY]: escapeText.trim() });
     } else {
       void submitWith(buildSubmitPayload(questions, picks, custom));
     }
-  }, [custom, escapeActive, escapeText, picks, questions, submitWith]);
+  }, [custom, escapeActive, escapeAvailable, escapeText, picks, questions, submitWith]);
 
   const handleSkip = useCallback(async () => {
     if (!onInteractionAction || submitting) return;
@@ -200,7 +206,7 @@ export const useAskUserForm = ({
   // when the clock hits zero, submit that text as-is rather than discarding it.
   useEffect(() => {
     if (!expired || submitting || questions.length === 0) return;
-    if (escapeActive && escapeText.trim().length > 0) {
+    if (escapeActive && escapeAvailable && escapeText.trim().length > 0) {
       void submitWith({ [FREEFORM_PAYLOAD_KEY]: escapeText.trim() });
       return;
     }
@@ -214,10 +220,20 @@ export const useAskUserForm = ({
       }
     }
     void submitWith(fallback);
-  }, [expired, submitting, questions, escapeActive, escapeText, picks, custom, submitWith]);
+  }, [
+    expired,
+    submitting,
+    questions,
+    escapeActive,
+    escapeAvailable,
+    escapeText,
+    picks,
+    custom,
+    submitWith,
+  ]);
 
   const activeQuestion = questions[Number(activeTab)] ?? questions[0];
-  const isSubmitDisabled = escapeActive
+  const isSubmitDisabled = inEscape
     ? !escapeText.trim() || submitting || expired
     : !allAnswered || expired || submitting;
 
@@ -225,21 +241,21 @@ export const useAskUserForm = ({
     activeQuestion,
     activeTab,
     custom,
-    escapeActive,
+    escapeActive: inEscape,
     escapeText,
     expired,
     handleCustomChange,
     handleEscapeTextChange,
-    handleEscapeToggle,
     handleSkip,
     handleSubmit,
     handleToggle,
-    isMulti: questions.length > 1,
+    isMulti: escapeAvailable,
     isSubmitDisabled,
     picks,
     questions,
     remainingMs: deadline - now,
     setActiveTab,
+    setEscapeMode,
     submitting,
   };
 };

--- a/packages/heterogeneous-agents/src/askUser/AskUserBridge.test.ts
+++ b/packages/heterogeneous-agents/src/askUser/AskUserBridge.test.ts
@@ -74,7 +74,7 @@ describe('AskUserBridge', () => {
       bridge.resolve('not-a-real-id', { result: 'x' });
 
       // Promise should still be unresolved — fast-forward past timeout to confirm.
-      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+      vi.advanceTimersByTime(10 * 60 * 1000 + 1);
       const answer = await pending;
       expect(answer.cancelled).toBe(true);
       expect(answer.cancelReason).toBe('timeout');
@@ -109,12 +109,12 @@ describe('AskUserBridge', () => {
       drain.stop();
     });
 
-    it('resolves with cancelled=true on timeout (default 5 min)', async () => {
+    it('resolves with cancelled=true on timeout (default 10 min)', async () => {
       const bridge = new AskUserBridge('op-1');
       const drain = drainEvents(bridge);
       const pending = bridge.pending({ arguments: {} });
 
-      vi.advanceTimersByTime(5 * 60 * 1000 - 1);
+      vi.advanceTimersByTime(10 * 60 * 1000 - 1);
       const stillPending = await Promise.race([pending, Promise.resolve('not-yet')]);
       expect(stillPending).toBe('not-yet');
 

--- a/packages/heterogeneous-agents/src/askUser/AskUserBridge.ts
+++ b/packages/heterogeneous-agents/src/askUser/AskUserBridge.ts
@@ -6,6 +6,8 @@ import type {
   AgentStreamEvent,
 } from '@lobechat/agent-gateway-client';
 
+import { DEFAULT_ASK_USER_TIMEOUT_MS } from './constants';
+
 /**
  * What the MCP handler gets back from `bridge.pending()`.
  *
@@ -138,7 +140,7 @@ export class AskUserBridge {
         new Error(`AskUserBridge: duplicate toolCallId in flight: ${toolCallId}`),
       );
     }
-    const timeoutMs = options.timeoutMs ?? 5 * 60 * 1000;
+    const timeoutMs = options.timeoutMs ?? DEFAULT_ASK_USER_TIMEOUT_MS;
     const progressIntervalMs = options.progressIntervalMs ?? 30_000;
     const startedAt = Date.now();
     const deadline = startedAt + timeoutMs;

--- a/packages/heterogeneous-agents/src/askUser/AskUserMcpServer.ts
+++ b/packages/heterogeneous-agents/src/askUser/AskUserMcpServer.ts
@@ -10,7 +10,11 @@ import { z } from 'zod';
 
 import type { InterventionAnswer } from './AskUserBridge';
 import { AskUserBridge } from './AskUserBridge';
-import { ASK_USER_MCP_SERVER_NAME, ASK_USER_TOOL_NAME } from './constants';
+import {
+  ASK_USER_MCP_SERVER_NAME,
+  ASK_USER_TOOL_NAME,
+  DEFAULT_ASK_USER_TIMEOUT_MS,
+} from './constants';
 
 /**
  * Mirrors CC's built-in `AskUserQuestion` schema. CC's schema:
@@ -142,7 +146,7 @@ export class AskUserMcpServer {
   private readonly progressIntervalMs: number;
 
   constructor(private readonly options: AskUserMcpServerOptions = {}) {
-    this.pendingTimeoutMs = options.pendingTimeoutMs ?? 5 * 60 * 1000;
+    this.pendingTimeoutMs = options.pendingTimeoutMs ?? DEFAULT_ASK_USER_TIMEOUT_MS;
     this.progressIntervalMs = options.progressIntervalMs ?? 30_000;
   }
 

--- a/packages/heterogeneous-agents/src/askUser/constants.ts
+++ b/packages/heterogeneous-agents/src/askUser/constants.ts
@@ -19,3 +19,12 @@ export const ASK_USER_TOOL_FULL_NAME = `mcp__${ASK_USER_MCP_SERVER_NAME}__${ASK_
  * UI / persistence routes on a clean key, not the wire-prefixed MCP name.
  */
 export const ASK_USER_API_NAME = 'askUserQuestion';
+
+/**
+ * How long the server holds a pending ask-user question before it times out
+ * into a `cancelled` answer. This is the **authoritative** clock — the client
+ * countdown (`builtin-tool-claude-code` `draft.ts` `COUNTDOWN_MS`) mirrors this
+ * value and must be kept in sync (that package has no dep on this one, so it
+ * can't import the const directly).
+ */
+export const DEFAULT_ASK_USER_TIMEOUT_MS = 10 * 60 * 1000;

--- a/src/features/GlobalApprovalNotification/ApprovalCard.tsx
+++ b/src/features/GlobalApprovalNotification/ApprovalCard.tsx
@@ -12,6 +12,7 @@ import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspa
 import { ConversationProvider } from '@/features/Conversation';
 import InterventionContent from '@/features/Conversation/InterventionBar/InterventionContent';
 import InterventionTabBar from '@/features/Conversation/InterventionBar/InterventionTabBar';
+import MarkdownMessage from '@/features/Conversation/Markdown';
 import { type ConversationContext } from '@/features/Conversation/types';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { useOperationState } from '@/hooks/useOperationState';
@@ -162,7 +163,9 @@ const ApprovalCard = memo<ApprovalCardProps>(({ group }) => {
         {userRequest && (
           <div className={styles.userRequest}>
             <span className={styles.userRequestLabel}>{t('globalApproval.userRequestLabel')}</span>
-            <span className={styles.userRequestText}>{userRequest}</span>
+            <div className={styles.userRequestBody}>
+              <MarkdownMessage>{userRequest}</MarkdownMessage>
+            </div>
           </div>
         )}
 

--- a/src/features/GlobalApprovalNotification/styles.ts
+++ b/src/features/GlobalApprovalNotification/styles.ts
@@ -115,10 +115,13 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     width: 100%;
   `,
   // The user request that triggered the tool call — context for the approval.
+  // Rendered with the same Markdown component as the User chat bubble, so
+  // formatting / skill tags read consistently. A long request scrolls inside a
+  // capped body rather than hard-truncating, so the full context stays reachable.
   userRequest: css`
     display: flex;
-    gap: 6px;
-    align-items: baseline;
+    flex-direction: column;
+    gap: 4px;
 
     padding-block: 8px;
     padding-inline: 12px;
@@ -126,20 +129,23 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
 
     background: ${cssVar.colorFillQuaternary};
   `,
+  userRequestBody: css`
+    overflow-y: auto;
+    max-height: 120px;
+
+    /* Trim the Markdown block's outer margins so it sits flush in the strip. */
+    p:first-child {
+      margin-block-start: 0;
+    }
+
+    p:last-child {
+      margin-block-end: 0;
+    }
+  `,
   userRequestLabel: css`
     flex-shrink: 0;
     font-size: 12px;
     color: ${cssVar.colorTextTertiary};
-  `,
-  userRequestText: css`
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
-
-    font-size: 12px;
-    color: ${cssVar.colorTextSecondary};
-    text-overflow: ellipsis;
   `,
   // Top-center fixed wrapper. The wrapper ignores pointer events so it never
   // blocks the page; only the cards / pill re-enable them.


### PR DESCRIPTION
## 💡 Motivation

UX polish for the Claude Code **ask-user approval popup** (global-approval island + CC `AskUserQuestion` panel), from a UX audit. Four independent improvements.

> Meta-learnings from the same audit ship separately in #16611 (docs/skills only) — merge that first.

## 🔧 Changes

1. **User-request context uses the chat Markdown renderer.** `ApprovalCard` rendered the triggering user message as plain text (raw `<skill …/>` and markdown leaked through). It now renders via the same `MarkdownMessage` the User bubble uses. The hard 2-line clamp is replaced by a **height-capped scroll**, so a long request stays fully reachable.

2. **Ask-user timeout 5 min → 10 min.** Introduces `DEFAULT_ASK_USER_TIMEOUT_MS` in `heterogeneous-agents` `askUser/constants.ts` as the single **authoritative** value (used by `AskUserMcpServer` + `AskUserBridge`); the client `COUNTDOWN_MS` mirrors it with a keep-in-sync note (that package can't import cross-package). Prevents the server timing out before the on-screen countdown.

3. **Numbered free-text row.** The per-question "write your own" box now carries the next sequential number chip (`options.length + 1`), matching the option chips so it reads as one more choice.

4. **"Or type directly" becomes a peer tab.** The whole-form freeform escape was a footer toggle that silently swapped the entire panel. It's now a **visible trailing tab** beside Q1/Q2 (it replaces *all* questions, so it reads as a sibling, not a hidden mode) — and it's **not shown for single-question asks**, where the per-question box already is the full custom answer.

## ✅ Tests

- `AskUserBridge` 18/18, `AskUserMcpServer` 10/10 (timeout assertions updated to 10 min).
- `bun run type-check`: no new errors in touched files.

## 📝 Notes

- The `claudeCode.askUserQuestion.escape.back` ("Back to options") locale key is now orphaned (the tab replaces it); left in place to avoid churning every locale file.
- Follow-up (not in this PR): the `1`/`2`/`3` chips look like CLI keycaps but no keyboard handler is wired — decide whether to wire digit/Enter keys or de-keycap the chips (see #16611 ux Grow §5.4).