### PR TITLE
🧹 chore(skills): exclude explicit skills from Codex context

### DIFF
--- a/.agents/skills/add-provider-doc/agents/openai.yaml
+++ b/.agents/skills/add-provider-doc/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/add-setting-env/agents/openai.yaml
+++ b/.agents/skills/add-setting-env/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/cli/agents/openai.yaml
+++ b/.agents/skills/cli/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/desktop/agents/openai.yaml
+++ b/.agents/skills/desktop/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/pr/agents/openai.yaml
+++ b/.agents/skills/pr/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/skills-audit/agents/openai.yaml
+++ b/.agents/skills/skills-audit/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/ux-audit/agents/openai.yaml
+++ b/.agents/skills/ux-audit/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/.agents/skills/version-release/agents/openai.yaml
+++ b/.agents/skills/version-release/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

Codex includes available skill names and descriptions in its initial skills list so it can decide which skills to invoke implicitly. This repository has enough local skills that Codex can hit the 2% skills context budget and shorten descriptions, which makes implicit routing less reliable for skills that should remain auto-routable.

Several skills were already intended to be explicit-only through Claude-style `disable-model-invocation: true` frontmatter, but Codex uses `agents/openai.yaml` policy metadata for that behavior. This PR adds `policy.allow_implicit_invocation: false` for those explicit-only skills, including `pr`, so they stay callable via `$skill` without competing for Codex implicit skill context budget.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validation run:

- `git diff --check --cached` before commit

#### 📸 Screenshots / Videos

N/A.

#### 📝 Additional Information

This change only adds Codex skill policy metadata. It does not change the skill instructions themselves.