### PR TITLE
💄 style(claude-code): switch AskUserQuestion question tabs to underline variant

### DIFF
--- a/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion/index.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion/index.tsx
@@ -134,6 +134,7 @@ const AskUserQuestionIntervention = memo<BuiltinInterventionProps<AskUserQuestio
       {!escapeActive && isMulti && (
         <Tabs
           activeKey={activeTab}
+          variant="square"
           items={questions.map((q, idx) => {
             const done = isQuestionAnswered(q, picks, custom);
             return {

--- a/src/features/DevPanel/RenderGallery/fixtures/claude-code.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/claude-code.ts
@@ -113,6 +113,76 @@ export default defineFixtures({
     },
   ],
   fixtures: {
+    askUserQuestion: variants([
+      {
+        args: {
+          questions: [
+            {
+              header: 'Audit level',
+              options: [
+                {
+                  description:
+                    'Fastest, offline, full-coverage baseline. Scans structural issues (missing states / branches / patterns) from code alone.',
+                  label: 'L1 only (read code)',
+                },
+                {
+                  description:
+                    'Also boots the app and screenshots key surfaces to confirm visual hierarchy and rendered states. Medium cost.',
+                  label: 'L1 + L2 (screenshots)',
+                },
+                {
+                  description:
+                    'Adds a real user journey with performance traces (CLS/LCP). Needs a running environment and login. High cost.',
+                  label: 'L1 + L2 + L3',
+                },
+              ],
+              question: 'How deep should this audit round go?',
+            },
+            {
+              header: 'Scope',
+              multiSelect: true,
+              options: [
+                {
+                  description: 'The chat conversation pane and message renders.',
+                  label: 'Chat surface',
+                },
+                {
+                  description: 'Settings pages, providers, and model configuration.',
+                  label: 'Settings',
+                },
+                {
+                  description: 'Onboarding and first-run flows.',
+                  label: 'Onboarding',
+                },
+              ],
+              question: 'Which surfaces should the audit cover?',
+            },
+          ],
+        },
+        label: 'Multi question',
+      },
+      {
+        args: {
+          questions: [
+            {
+              header: 'Approach',
+              options: [
+                {
+                  description: 'Ship the minimal fix now and file a follow-up for the refactor.',
+                  label: 'Minimal fix',
+                },
+                {
+                  description: 'Refactor the module properly before fixing. Slower but cleaner.',
+                  label: 'Refactor first',
+                },
+              ],
+              question: 'How should I handle the legacy module?',
+            },
+          ],
+        },
+        label: 'Single question',
+      },
+    ]),
     Agent: single({
       args: {
         prompt:

--- a/src/features/DevPanel/RenderGallery/toolSurfaces.tsx
+++ b/src/features/DevPanel/RenderGallery/toolSurfaces.tsx
@@ -1,9 +1,13 @@
 'use client';
 
+import type { UIChatMessage } from '@lobechat/types';
 import { Block, Flexbox, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import { Component, memo, type ReactNode } from 'react';
+import { Component, memo, type ReactNode, useMemo } from 'react';
 
+import { type ConversationContext, ConversationProvider } from '@/features/Conversation';
+
+import { DEVTOOLS_AGENT_ID } from './fixtures';
 import {
   bodyKindForMode,
   type DerivedFixtureProps,
@@ -107,6 +111,71 @@ export const ToolInspectorSlot = memo<ToolInspectorSlotProps>(
 
 ToolInspectorSlot.displayName = 'ToolInspectorSlot';
 
+interface InterventionConversationHostProps {
+  api: ApiEntry;
+  children: ReactNode;
+  derived: DerivedFixtureProps;
+  messageId: string;
+  toolCallId: string;
+}
+
+/**
+ * Intervention components run their form logic against the conversation store
+ * (e.g. draft persistence reads the tool message via `getDbMessageById`), so
+ * the standalone By-API preview must seed a `ConversationProvider` with the
+ * matching assistant → tool message pair — without it they crash on mount.
+ */
+const InterventionConversationHost = memo<InterventionConversationHostProps>(
+  ({ api, children, derived, messageId, toolCallId }) => {
+    const context = useMemo<ConversationContext>(
+      () => ({ agentId: DEVTOOLS_AGENT_ID, topicId: `devtools-intervention-${messageId}` }),
+      [messageId],
+    );
+
+    const messages = useMemo<UIChatMessage[]>(() => {
+      const now = Date.now();
+      const assistantId = `${messageId}-assistant`;
+      return [
+        {
+          content: '',
+          createdAt: now,
+          id: assistantId,
+          role: 'assistant',
+          tools: [
+            {
+              apiName: api.apiName,
+              arguments: JSON.stringify(derived.args ?? {}),
+              id: toolCallId,
+              identifier: api.identifier,
+              source: 'builtin',
+              type: 'builtin',
+            },
+          ],
+          updatedAt: now,
+        },
+        {
+          content: '',
+          createdAt: now,
+          id: messageId,
+          parentId: assistantId,
+          pluginIntervention: { status: 'pending' },
+          role: 'tool',
+          tool_call_id: toolCallId,
+          updatedAt: now,
+        },
+      ];
+    }, [api, derived.args, messageId, toolCallId]);
+
+    return (
+      <ConversationProvider hasInitMessages skipFetch context={context} messages={messages}>
+        {children}
+      </ConversationProvider>
+    );
+  },
+);
+
+InterventionConversationHost.displayName = 'InterventionConversationHost';
+
 interface ToolBodySlotProps {
   api: ApiEntry;
   derived: DerivedFixtureProps;
@@ -179,13 +248,20 @@ export const ToolBodySlot = memo<ToolBodySlotProps>(
       case 'intervention': {
         return api.intervention ? (
           <RenderBoundary label={'Intervention'}>
-            <api.intervention
-              apiName={api.apiName}
-              args={derived.args}
-              identifier={api.identifier}
-              interactionMode={'approval'}
+            <InterventionConversationHost
+              api={api}
+              derived={derived}
               messageId={messageId}
-            />
+              toolCallId={toolCallId}
+            >
+              <api.intervention
+                apiName={api.apiName}
+                args={derived.args}
+                identifier={api.identifier}
+                interactionMode={'approval'}
+                messageId={messageId}
+              />
+            </InterventionConversationHost>
           </RenderBoundary>
         ) : (
           missing('intervention')


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

The CC `AskUserQuestion` intervention rendered its Q1/Q2 question strip with the base-ui `Tabs` default `rounded` variant, which reads as a Segmented control — the wrong semantic for sequential question items that carry completion state and auto-advance.

- Switch the question strip to `variant="square"` (underline indicator + hairline list border), so it reads as tab navigation rather than a segmented view toggle.

Two supporting changes to make this previewable in the DevPanel RenderGallery (`/devtools/claude-code`):

- Add `askUserQuestion` fixtures (multi-question and single-question variants) to the Claude Code toolset.
- Fix the By-API × Intervention preview slot, which crashed on mount for any intervention whose form logic reads the conversation store (e.g. `useAskUserForm` resumes drafts via `getDbMessageById`). The slot now hosts interventions in a seeded `ConversationProvider` with a matching assistant → tool message pair, mirroring what the Aggregate view already does.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Run `bun run dev:spa`, open `http://localhost:9876/devtools/claude-code`, select `askUserQuestion` and the **Intervention** lifecycle:

1. The Q1/Q2 strip shows an underline under the active tab (no pill background).
2. Picking an option on Q1 auto-advances to Q2 and Q1 gains a check mark.
3. The intervention no longer crashes with "have not used zustand provider as an ancestor".

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Q1/Q2 rendered as segmented pills | Q1/Q2 rendered as underline tabs with completion check |

#### 📝 Additional Information

The ConversationProvider host fix benefits every intervention preview in the gallery, not just Claude Code's.