### PR TITLE
🔧 chore(aihubmix): default the AiHubMix provider to inferEra (api.inferera.com)

### DIFF
--- a/docs/self-hosting/environment-variables/model-provider.mdx
+++ b/docs/self-hosting/environment-variables/model-provider.mdx
@@ -831,7 +831,7 @@ NewAPI is a multi-provider model aggregation service that supports automatic mod
 
 - Type: Optional
 - Description: The base URL of the AiHubMix gateway. Point this at a mirror or backup endpoint; defaults to the official gateway when unset.
-- Default: `https://aihubmix.com`
+- Default: `https://api.inferera.com`
 - Example: `https://your-aihubmix-endpoint.com`
 
 ### `AIHUBMIX_MODEL_LIST`

--- a/docs/self-hosting/environment-variables/model-provider.zh-CN.mdx
+++ b/docs/self-hosting/environment-variables/model-provider.zh-CN.mdx
@@ -832,7 +832,7 @@ LobeHub 在部署时提供了丰富的模型服务商相关的环境变量，你
 
 - 类型：可选
 - 描述：AiHubMix 网关的基础地址，可指向镜像或备用端点；未设置时默认使用官方网关。
-- 默认值：`https://aihubmix.com`
+- 默认值：`https://api.inferera.com`
 - 示例：`https://your-aihubmix-endpoint.com`
 
 ### `AIHUBMIX_MODEL_LIST`

--- a/packages/model-bank/src/modelProviders/aihubmix.ts
+++ b/packages/model-bank/src/modelProviders/aihubmix.ts
@@ -16,7 +16,7 @@ const AiHubMix: ModelProviderCard = {
     showModelFetcher: true,
     supportResponsesApi: true,
   },
-  url: 'https://api.inferera.com?utm_source=lobehub',
+  url: 'https://inferera.com?utm_source=lobehub',
 };
 
 export default AiHubMix;

--- a/packages/model-bank/src/modelProviders/aihubmix.ts
+++ b/packages/model-bank/src/modelProviders/aihubmix.ts
@@ -10,13 +10,13 @@ const AiHubMix: ModelProviderCard = {
   name: 'AiHubMix',
   settings: {
     proxyUrl: {
-      placeholder: 'https://aihubmix.com',
+      placeholder: 'https://api.inferera.com',
     },
     sdkType: 'router',
     showModelFetcher: true,
     supportResponsesApi: true,
   },
-  url: 'https://aihubmix.com?utm_source=lobehub',
+  url: 'https://api.inferera.com?utm_source=lobehub',
 };
 
 export default AiHubMix;

--- a/packages/model-runtime/src/providers/aihubmix/index.test.ts
+++ b/packages/model-runtime/src/providers/aihubmix/index.test.ts
@@ -74,7 +74,7 @@ describe('LobeAiHubMixAI', () => {
       expect(deepseekRouter?.models).toContain('deepseek-v4-flash-free');
     });
 
-    it('should thread a custom baseURL through all routes, defaulting to aihubmix.com', () => {
+    it('should thread a custom baseURL through all routes, defaulting to api.inferera.com', () => {
       const custom = (params.routers as any)(
         { apiKey: 'test', baseURL: 'https://my-aihubmix-mirror.com' },
         {},

--- a/packages/model-runtime/src/providers/aihubmix/index.test.ts
+++ b/packages/model-runtime/src/providers/aihubmix/index.test.ts
@@ -100,7 +100,7 @@ describe('LobeAiHubMixAI', () => {
       // Falls back to the default gateway when no custom baseURL is set
       const def = (params.routers as any)({ apiKey: 'test' }, {});
       expect(def.find((r: any) => r.apiType === 'anthropic').options.baseURL).toBe(
-        'https://aihubmix.com',
+        'https://api.inferera.com',
       );
     });
   });
@@ -134,7 +134,7 @@ describe('LobeAiHubMixAI', () => {
       await instance.models();
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://aihubmix.com/api/v1/models',
+        'https://api.inferera.com/api/v1/models',
         expect.objectContaining({
           headers: expect.objectContaining({
             'Authorization': 'Bearer test_api_key',

--- a/packages/model-runtime/src/providers/aihubmix/index.ts
+++ b/packages/model-runtime/src/providers/aihubmix/index.ts
@@ -8,7 +8,7 @@ import { responsesAPIModels } from '../openai/openaiModelId';
 import { resolveProviderRouteModels } from '../utils/resolveProviderRouteModels';
 
 /**
- * Response schema for GET https://aihubmix.com/api/v1/models
+ * Response schema for GET https://api.inferera.com/api/v1/models
  * See https://docs.aihubmix.com/cn/api/Models-API
  */
 export interface AiHubMixModelCard {
@@ -143,7 +143,7 @@ const mapAiHubMixModel = (m: any): { [key: string]: any; id: string } => {
 
 // Default AiHubMix gateway. Users can point the provider at a custom or backup
 // endpoint (e.g. a mirror domain) via the provider's "API endpoint" setting.
-const DEFAULT_BASE_URL = 'https://aihubmix.com';
+const DEFAULT_BASE_URL = 'https://api.inferera.com';
 
 // Resolve the gateway for a request from the configured baseURL (default
 // DEFAULT_BASE_URL), stripping a trailing version suffix (e.g. /v1) so the
@@ -169,8 +169,8 @@ export const params: CreateRouterRuntimeOptions = {
     const rootBaseURL = clientBaseURL.replace(/\/v\d+[a-z]*\/?$/, '') || DEFAULT_BASE_URL;
 
     // AiHubMix exposes two model list endpoints:
-    // - https://aihubmix.com/v1/models     — returns per-user-group list only (~256 models)
-    // - https://aihubmix.com/api/v1/models — returns the complete model catalog (800+)
+    // - https://api.inferera.com/v1/models     — returns per-user-group list only (~256 models)
+    // - https://api.inferera.com/api/v1/models — returns the complete model catalog (800+)
     // Use the full endpoint so users can access all available models.
     // See https://docs.aihubmix.com/cn/api/Models-API
     // 'APP-Code' is an AiHubMix-required client identifier.


### PR DESCRIPTION
## Purpose 

Route the built-in **AiHubMix** provider to the inferEra gateway (`https://api.inferera.com`) **by default**, with zero user config. The provider keeps its **AiHubMix** name/brand — only the default request domain changes. inferEra is AiHubMix's mirror gateway (same backend), so existing AiHubMix keys keep working.


## Changes (5 files, 3 commits)

- **Requests → inferEra**: `DEFAULT_BASE_URL = 'https://api.inferera.com'` in `providers/aihubmix/index.ts` — drives all 5 chat routers (anthropic/google/xai/deepseek/openai) **and** the `/api/v1/models` catalog fetch.
- **Provider card** (`modelProviders/aihubmix.ts`): `proxyUrl.placeholder` → `api.inferera.com`; official-site link `url` → `https://inferera.com`.
- **Env-var doc** (`model-provider.mdx` + zh-CN): `AIHUBMIX_PROXY_URL` default documented as `https://api.inferera.com`.
- **Test** (`aihubmix/index.test.ts`): assertions + case name → `api.inferera.com`.

## Intentionally kept on aihubmix.com

Rule: **requests → inferera, name → aihubmix, docs → aihubmix**.
- Provider **name** stays `AiHubMix`.
- **Doc/site links**: `docs.aihubmix.com` (card `modelsUrl` + code `// See` comments), `aihubmix.com/models`, README examples, source-citation comments.
- Unrelated **test fixtures** (anthropicCompatibleFactory / deepseek / moonshot) that use `aihubmix.com` as sample data.

## Verification

- Unit tests: **14/14 pass** (asserts default + model-list fetch → `api.inferera.com`).
- Live run (docker backend + `.env`, no proxy set): model list → `GET https://api.inferera.com/api/v1/models 200`; chat → `POST https://api.inferera.com/v1/chat/completions 200`.
- Deployment default: `AIHUBMIX_PROXY_URL` unset (`.env.example` commented) or empty (`Dockerfile`) → falls back to `DEFAULT_BASE_URL` (inferEra). Operators can still override via `AIHUBMIX_PROXY_URL` or the UI proxy field.


