### PR TITLE
✨ feat(model): add Nano Banana 2 Lite (gemini-3.1-flash-lite-image)

### DIFF
--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -1,5 +1,6 @@
 import {
   nanoBanana2Parameters,
+  nanoBananaLiteParameters,
   nanoBananaParameters,
   nanoBananaProParameters,
 } from '../const/imageParameters';
@@ -168,6 +169,38 @@ const googleChatModels: AIChatModelCard[] = [
       extendParams: ['thinkingLevel', 'urlContext'],
       searchImpl: 'params',
       searchProvider: 'google',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      imageOutput: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 65_536 + 4_096,
+    description:
+      "Gemini 3.1 Flash-Lite Image (Nano Banana 2 Lite) is Google's fastest, most cost-efficient native image generation model for high-volume, low-latency image generation and editing.",
+    displayName: 'Nano Banana 2 Lite',
+    enabled: true,
+    family: 'gemini',
+    generation: 'gemini-3.1',
+    id: 'gemini-3.1-flash-lite-image',
+    knowledgeCutoff: '2025-01',
+    maxOutput: 4_096,
+    pricing: {
+      approximatePricePerImage: 0.034,
+      units: [
+        { name: 'imageOutput', rate: 30, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-06-30',
+    settings: {
+      extendParams: ['imageAspectRatio2', 'thinkingLevel4'],
     },
     type: 'chat',
   },
@@ -806,6 +839,25 @@ export const imagenGenParameters: ModelParamsSchema = {
 };
 
 const googleImageModels: AIImageModelCard[] = [
+  {
+    displayName: 'Nano Banana 2 Lite',
+    id: 'gemini-3.1-flash-lite-image:image',
+    type: 'image',
+    enabled: true,
+    description:
+      "Gemini 3.1 Flash-Lite Image (Nano Banana 2 Lite) is Google's fastest, most cost-efficient native image generation model for high-volume, low-latency image generation and editing.",
+    releasedAt: '2026-06-30',
+    parameters: nanoBananaLiteParameters,
+    pricing: {
+      approximatePricePerImage: 0.034,
+      units: [
+        { name: 'imageOutput', rate: 30, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+  },
   {
     displayName: 'Nano Banana 2',
     id: 'gemini-3.1-flash-image-preview:image',

--- a/packages/model-bank/src/const/imageParameters.ts
+++ b/packages/model-bank/src/const/imageParameters.ts
@@ -85,3 +85,14 @@ export const nanoBanana2Parameters: ModelParamsSchema = {
     enum: ['512', '1K', '2K', '4K'],
   },
 };
+
+export const nanoBananaLiteParameters: ModelParamsSchema = {
+  aspectRatio: {
+    default: 'auto',
+    enum: NANO_BANANA_2_ASPECT_RATIOS,
+  },
+  imageUrls: {
+    default: [],
+  },
+  prompt: { default: '' },
+};


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None — new model support.

#### 🔀 Description of Change

Google released **Nano Banana 2 Lite** (`gemini-3.1-flash-lite-image`, stable/GA) on 2026-06-30 — their fastest, most cost-efficient native image generation model (~4s per image), built for high-volume, low-latency generation and editing.

Interestingly, the locale corpus in this repo already contains translated descriptions for `gemini-3.1-flash-lite-image` / `gemini-3.1-flash-lite-image:image` — only the model cards are missing. This PR fills that gap:

- **Chat card** (same pattern as the Nano Banana 2 family): `imageOutput` + `reasoning` + `vision`; `extendParams: ['imageAspectRatio2', 'thinkingLevel4']`.
- **Image card** (`gemini-3.1-flash-lite-image:image`) with a dedicated `nanoBananaLiteParameters` preset.

Spec sources (official docs, cross-checked against the live API):

| Field | Value | Source |
| --- | --- | --- |
| Context / max output | 65,536 / 4,096 tokens | model docs |
| Thinking | minimal & high only (matches `thinkingLevel4`) | docs + live probe: `LOW`/`MEDIUM` return 400 `"Thinking level X is not supported for this model."` |
| Search grounding | not supported | model docs (hence no `search` ability / `searchImpl`) |
| Resolution | 1K only (2K/4K unsupported) | model docs (hence no `resolution` param in the preset) |
| Aspect ratios | same 14-ratio set as Nano Banana 2 | model docs |
| Pricing | $0.25/M input, $1.50/M text out, $30/M image out (≈ $0.0336 per 1K image) | pricing docs |
| displayName | "Nano Banana 2 Lite" | Models API `displayName` |

Notes:

- The preset intentionally has no `thinkingLevel` param — exposing a thinking-level control in the image workspace is a separate feature and kept out of scope here.
- Verified via the Models API: `supportedGenerationMethods = [generateContent, countTokens, batchGenerateContent]` — the same invocation path as the existing Nano Banana models, so no runtime change is needed.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Running on a self-hosted deployment with these cards since 2026-07-02: the model shows up in the chat model picker and in the image workspace model list, and the config panel renders the expected controls (aspect ratio; thinking level minimal/high via `thinkingLevel4` on the chat side). Model id, display name, supported methods and thinking-level constraints were all verified against the live Gemini API with an API key.

#### 📸 Screenshots / Videos

Data-only change (model bank cards + parameter preset) — no component/UI code touched.
