### PR TITLE
📝 docs: modernize skill description trigger conventions

### DIFF
--- a/.agents/skills/agent-testing/SKILL.md
+++ b/.agents/skills/agent-testing/SKILL.md
@@ -1,15 +1,11 @@
 ---
 name: agent-testing
 description: >
-  Agentic end-to-end testing for LobeHub: backend verification via the CLI,
-  frontend verification via agent-browser (Electron), full-stack verification in
-  the browser, and bot-channel verification via osascript. Local-first today,
-  designed to extend to cloud automation. Triggers on 'cli test', 'test with cli',
-  'verify with cli', 'backend test with cli', 'local test', 'test in electron',
-  'test desktop', 'test bot', 'bot test', 'test in discord', 'test in telegram',
-  'test in slack', 'test in wechat', 'test in weixin', 'test in lark', 'test in feishu',
-  'test in qq', 'manual test', 'osascript', 'test report', or any local
-  end-to-end verification task.
+  Agentic end-to-end testing for LobeHub. Use for any local E2E verification or
+  manual test report: backend checks via the CLI ('cli test', 'backend test with
+  cli'), frontend/desktop checks via agent-browser in Electron ('test in
+  electron', 'test desktop'), full-stack checks in the browser, and bot-channel
+  checks via osascript ('test bot', 'test in discord/telegram/slack/wechat/lark/qq').
 ---
 
 # Agent Testing (Agentic End-to-End Verification)
@@ -183,8 +179,8 @@ So before the first `agent run`, start QStash in a separate terminal and gate on
 the preflight:
 
 ```bash
-./.agents/skills/agent-testing/scripts/init-dev-env.sh qstash      # terminal B — keep running
-./.agents/skills/agent-testing/scripts/init-dev-env.sh preflight    # exits non-zero if QStash (or Redis) is down
+./.agents/skills/agent-testing/scripts/init-dev-env.sh qstash    # terminal B — keep running
+./.agents/skills/agent-testing/scripts/init-dev-env.sh preflight # exits non-zero if QStash (or Redis) is down
 ```
 
 Default script env:

--- a/.agents/skills/review-checklist/SKILL.md
+++ b/.agents/skills/review-checklist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-checklist
-description: 'LobeHub code review checklist. Use when reviewing a PR, diff, or branch for console leftovers, return await, secrets, i18n, desktop router drift, UI imports, migrations, or cloud impact.'
+description: "LobeHub code review checklist. Use whenever reviewing a PR, diff, or branch — even if the user doesn't explicitly ask for a checklist — for console leftovers, return await, secrets, i18n, desktop router drift, UI imports, migrations, or cloud impact."
 user-invocable: false
 ---
 

--- a/.agents/skills/skills-audit/SKILL.md
+++ b/.agents/skills/skills-audit/SKILL.md
@@ -56,16 +56,18 @@ Common false positives (do NOT merge):
 Apply the **standard template**:
 
 ```
-{Topic + key conventions or scope}. Use when {scenarios — verbs + nouns}. Triggers on {`code-symbols`, 'natural phrases', '中文'}.
+{Topic + key conventions or scope}. Use when/for {scenarios — verbs + nouns, weaving the high-signal keywords (`code-symbols`, 'natural phrases', '中文') into the sentence}.
 ```
 
-Skills with `disable-model-invocation: true` (user-invoked only, slash commands) don't need `Triggers on` — they're never auto-routed.
+For skills that chronically undertrigger, an extra "pushy" sentence is fine: `Use whenever {doing X}, even if the user doesn't explicitly ask.`
+
+Skills with `disable-model-invocation: true` (user-invoked only, slash commands) don't need trigger phrasing — they're never auto-routed.
 
 Flag descriptions that:
 
-- ❌ Have NO `Use when` clause (model can't decide when to load it).
-- ❌ Have NO `Triggers on` clause (and aren't `disable-model-invocation`).
-- ❌ Use weird formats (numbered lists `(1)(2)(3)`, `Triggers:` colon instead of `Triggers on`, `MUST use when ...` as opening word).
+- ❌ Have NO `Use when/whenever/for` scenario sentence (model can't decide when to load it).
+- ❌ Still use a standalone `Triggers on {keyword list}` clause — deprecated style; fold the high-signal keywords into the scenario sentence instead.
+- ❌ Use weird formats (numbered lists `(1)(2)(3)`, `Triggers:` keyword dumps, `MUST use when ...` as opening word).
 - ❌ Are dramatically terse for a 200+ line body, or dramatically verbose for a 60-line body.
 - ❌ Reference deleted/renamed skills.
 

--- a/.agents/skills/ux/SKILL.md
+++ b/.agents/skills/ux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ux
-description: 'LobeHub product design values / principles / checklists. Load this skill whenever the work touches user-interface features or implementation — designing or building any user-facing flow — to get better UX results.'
+description: "LobeHub product design values / principles / checklists. Use whenever the work touches user-interface features or implementation — designing or building any user-facing flow, even if the user doesn't mention UX — to get better UX results."
 user-invocable: false
 ---
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Skill descriptions in this repo have converged on scenario-style trigger phrasing ("Use when/for ..." with high-signal keywords woven into the sentence), matching the official skill-creator guidance. This PR aligns the remaining stragglers and the convention doc itself:

- **skills-audit**: update the description template — require a `Use when/whenever/for` scenario sentence, deprecate the standalone `Triggers on {keyword list}` clause (keywords now go inside the sentence), and allow a "pushy" closing sentence for skills that chronically undertrigger.
- **agent-testing**: rewrite the 653-char keyword-dump description into a 389-char scenario sentence that keeps the high-signal keywords.
- **ux**: switch "Load this skill whenever ..." to "Use whenever ..." and add the even-if-not-asked nudge.
- **review-checklist**: switch "Use when" to "Use whenever" with the even-if-not-asked nudge, so reviews load it without an explicit checklist request.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Docs-only change (SKILL.md frontmatter). Verified via the cloud repo's `skill-inventory` script that all 68 skills now pass the `Use when/whenever/for` phrasing check with no legacy `Triggers on` clauses.

#### 📸 Screenshots / Videos

N/A