### PR TITLE
🐛 fix(memory-embedding): show embedding models in Memory Embedding

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/aiProvider.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/aiProvider.test.ts
@@ -58,6 +58,7 @@ describe('aiProviderRouter', () => {
     enabledChatAiProviders: [],
     enabledImageAiProviders: [],
     enabledVideoAiProviders: [],
+    enabledEmbeddingAiProviders: [],
     runtimeConfig: {},
   };
 

--- a/apps/server/src/services/memory/userMemory/__tests__/extract.runtime.test.ts
+++ b/apps/server/src/services/memory/userMemory/__tests__/extract.runtime.test.ts
@@ -13,6 +13,7 @@ const createRuntimeState = (models: EnabledAiModel[], keyVaults: Record<string, 
     enabledChatAiProviders: [],
     enabledImageAiProviders: [],
     enabledVideoAiProviders: [],
+    enabledEmbeddingAiProviders: [],
     runtimeConfig: Object.fromEntries(
       Object.entries(keyVaults).map(([providerId, vault]) => [
         providerId,

--- a/apps/server/src/services/memory/userMemory/persona/__tests__/service.test.ts
+++ b/apps/server/src/services/memory/userMemory/persona/__tests__/service.test.ts
@@ -90,6 +90,7 @@ beforeEach(async () => {
     enabledAiProviders: [],
     enabledChatAiProviders: [],
     enabledImageAiProviders: [],
+    enabledEmbeddingAiProviders: [],
     runtimeConfig: {
       openai: { keyVaults: { apiKey: 'vault-key', baseURL: 'https://vault.example.com' } },
     },
@@ -153,6 +154,7 @@ describe('UserPersonaService', () => {
       ],
       enabledAiProviders: [],
       enabledChatAiProviders: [],
+      enabledEmbeddingAiProviders: [],
       enabledImageAiProviders: [],
       runtimeConfig: {},
     });

--- a/packages/database/src/repositories/aiInfra/__tests__/getAiProviderRuntimeState.test.ts
+++ b/packages/database/src/repositories/aiInfra/__tests__/getAiProviderRuntimeState.test.ts
@@ -91,6 +91,7 @@ describe('AiInfraRepos', () => {
         ],
         enabledImageAiProviders: [],
         enabledVideoAiProviders: [],
+        enabledEmbeddingAiProviders: [],
         runtimeConfig: {
           openai: {
             apiKey: 'test-key',
@@ -175,6 +176,7 @@ describe('AiInfraRepos', () => {
         enabledChatAiProviders: [
           { id: 'openai', logo: 'openai-logo', name: 'OpenAI', source: 'builtin' },
         ],
+        enabledEmbeddingAiProviders: [],
         enabledImageAiProviders: [
           expect.objectContaining({
             id: 'fal',

--- a/packages/database/src/repositories/aiInfra/__tests__/tryMatchingProviderFrom.test.ts
+++ b/packages/database/src/repositories/aiInfra/__tests__/tryMatchingProviderFrom.test.ts
@@ -30,6 +30,7 @@ describe('AiInfraRepos', () => {
       enabledAiModels: models,
       enabledAiProviders: [],
       enabledChatAiProviders: [],
+      enabledEmbeddingAiProviders: [],
       enabledImageAiProviders: [],
       enabledVideoAiProviders: [],
       runtimeConfig: {},

--- a/packages/database/src/repositories/aiInfra/index.ts
+++ b/packages/database/src/repositories/aiInfra/index.ts
@@ -283,6 +283,11 @@ export class AiInfraRepos {
     const enabledVideoAiProviders = enabledAiProviders.filter((provider) => {
       return allModels.some((model) => model.providerId === provider.id && model.type === 'video');
     });
+    const enabledEmbeddingAiProviders = enabledAiProviders.filter((provider) => {
+      return allModels.some(
+        (model) => model.providerId === provider.id && model.type === 'embedding',
+      );
+    });
 
     return {
       enabledAiModels,
@@ -290,6 +295,7 @@ export class AiInfraRepos {
       enabledChatAiProviders,
       enabledImageAiProviders,
       enabledVideoAiProviders,
+      enabledEmbeddingAiProviders,
       runtimeConfig,
     };
   };

--- a/packages/model-bank/src/aiModels/__tests__/index.test.ts
+++ b/packages/model-bank/src/aiModels/__tests__/index.test.ts
@@ -84,6 +84,20 @@ describe('knowledgeCutoff backfill', () => {
     expect(vertexGemini3Pro?.knowledgeCutoff).toBe('2025-01');
   });
 
+  it('keeps builtin embedding models enabled', () => {
+    const openaiEmbeddingModels = LOBE_DEFAULT_MODEL_LIST.filter(
+      (m) => m.providerId === ModelProvider.OpenAI && m.type === 'embedding',
+    );
+    expect(openaiEmbeddingModels.length).toBeGreaterThan(0);
+    expect(openaiEmbeddingModels.every((m) => m.enabled)).toBe(true);
+
+    const vercelEmbeddingModels = LOBE_DEFAULT_MODEL_LIST.filter(
+      (m) => m.providerId === ModelProvider.VercelAIGateway && m.type === 'embedding',
+    );
+    expect(vercelEmbeddingModels.length).toBeGreaterThan(0);
+    expect(vercelEmbeddingModels.every((m) => m.enabled)).toBe(true);
+  });
+
   it('keeps an explicit knowledgeCutoff over the map value', async () => {
     const loader = vi.fn().mockResolvedValue([
       { enabled: true, id: 'gpt-5', knowledgeCutoff: '2020-01', type: 'chat' },

--- a/packages/model-bank/src/aiModels/openai.ts
+++ b/packages/model-bank/src/aiModels/openai.ts
@@ -1494,6 +1494,7 @@ export const openaiEmbeddingModels: AIEmbeddingModelCard[] = [
     contextWindowTokens: 8192,
     description: 'The most capable embedding model for English and non-English tasks.',
     displayName: 'Text Embedding 3 Large',
+    enabled: true,
     id: 'text-embedding-3-large',
     maxDimension: 3072,
     pricing: {
@@ -1508,6 +1509,7 @@ export const openaiEmbeddingModels: AIEmbeddingModelCard[] = [
     description:
       'An efficient, cost-effective next-generation embedding model for retrieval and RAG scenarios.',
     displayName: 'Text Embedding 3 Small',
+    enabled: true,
     id: 'text-embedding-3-small',
     maxDimension: 1536,
     pricing: {

--- a/packages/model-bank/src/aiModels/vercelaigateway.ts
+++ b/packages/model-bank/src/aiModels/vercelaigateway.ts
@@ -1682,6 +1682,7 @@ const vercelAIGatewayEmbeddingModels: AIEmbeddingModelCard[] = [
     description:
       'Amazon Titan Text Embeddings V2 is a lightweight, efficient multilingual embedding model supporting 1024, 512, and 256 dimensions.',
     displayName: 'Titan Text Embeddings V2',
+    enabled: true,
     id: 'amazon/titan-embed-text-v2',
     maxDimension: 1024,
     pricing: {
@@ -1693,6 +1694,7 @@ const vercelAIGatewayEmbeddingModels: AIEmbeddingModelCard[] = [
     description:
       'A state-of-the-art embedding model with strong performance in English, multilingual, and code tasks.',
     displayName: 'Gemini Embedding 001',
+    enabled: true,
     id: 'google/gemini-embedding-001',
     maxDimension: 768,
     pricing: {
@@ -1704,6 +1706,7 @@ const vercelAIGatewayEmbeddingModels: AIEmbeddingModelCard[] = [
     description:
       'An English-focused text embedding model optimized for code and English language tasks.',
     displayName: 'Text Embedding 005',
+    enabled: true,
     id: 'google/text-embedding-005',
     maxDimension: 768,
     pricing: {
@@ -1715,6 +1718,7 @@ const vercelAIGatewayEmbeddingModels: AIEmbeddingModelCard[] = [
     description:
       'A multilingual text embedding model optimized for cross-lingual tasks across many languages.',
     displayName: 'Text Multilingual Embedding 002',
+    enabled: true,
     id: 'google/text-multilingual-embedding-002',
     maxDimension: 768,
     pricing: {
@@ -1726,6 +1730,7 @@ const vercelAIGatewayEmbeddingModels: AIEmbeddingModelCard[] = [
     description:
       'A model that classifies or converts text, images, or mixed content into embeddings.',
     displayName: 'Embed v4.0',
+    enabled: true,
     id: 'cohere/embed-v4.0',
     maxDimension: 1024,
     pricing: {
@@ -1737,6 +1742,7 @@ const vercelAIGatewayEmbeddingModels: AIEmbeddingModelCard[] = [
     description:
       'A code embedding model for embedding codebases and repositories to support coding assistants.',
     displayName: 'Codestral Embed',
+    enabled: true,
     id: 'mistral/codestral-embed',
     maxDimension: 1024,
     pricing: {
@@ -1748,6 +1754,7 @@ const vercelAIGatewayEmbeddingModels: AIEmbeddingModelCard[] = [
     description:
       'A general text embedding model for semantic search, similarity, clustering, and RAG workflows.',
     displayName: 'Mistral Embed',
+    enabled: true,
     id: 'mistral/mistral-embed',
     maxDimension: 1024,
     pricing: {
@@ -1758,6 +1765,7 @@ const vercelAIGatewayEmbeddingModels: AIEmbeddingModelCard[] = [
   {
     description: 'OpenAI’s most capable embedding model for English and non-English tasks.',
     displayName: 'text-embedding-3-large',
+    enabled: true,
     id: 'openai/text-embedding-3-large',
     maxDimension: 3072,
     pricing: {
@@ -1768,6 +1776,7 @@ const vercelAIGatewayEmbeddingModels: AIEmbeddingModelCard[] = [
   {
     description: 'OpenAI’s improved, higher-performance ada embedding model variant.',
     displayName: 'text-embedding-3-small',
+    enabled: true,
     id: 'openai/text-embedding-3-small',
     maxDimension: 1536,
     pricing: {
@@ -1778,6 +1787,7 @@ const vercelAIGatewayEmbeddingModels: AIEmbeddingModelCard[] = [
   {
     description: 'OpenAI’s legacy text embedding model.',
     displayName: 'text-embedding-ada-002',
+    enabled: true,
     id: 'openai/text-embedding-ada-002',
     maxDimension: 1536,
     pricing: {

--- a/packages/types/src/aiProvider.ts
+++ b/packages/types/src/aiProvider.ts
@@ -395,6 +395,7 @@ export interface AiProviderRuntimeState {
   enabledAiModels: EnabledAiModel[];
   enabledAiProviders: EnabledProvider[];
   enabledChatAiProviders: EnabledProvider[];
+  enabledEmbeddingAiProviders: EnabledProvider[];
   enabledImageAiProviders: EnabledProvider[];
   enabledVideoAiProviders: EnabledProvider[];
   runtimeConfig: Record<string, AiProviderRuntimeConfig>;

--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -1,12 +1,13 @@
 import { TooltipGroup } from '@lobehub/ui';
 import { Select, type SelectProps } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
-import { type ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { memo, useMemo } from 'react';
 
 import { ModelItemRender, ProviderItemRender, TAG_CLASSNAME } from '@/components/ModelSelect';
-import { useEnabledChatModels } from '@/hooks/useEnabledChatModels';
-import { type EnabledProviderWithModels } from '@/types/aiProvider';
+import type { EnabledModelListType } from '@/hooks/useEnabledModels';
+import { useEnabledModels } from '@/hooks/useEnabledModels';
+import type { EnabledProviderWithModels } from '@/types/aiProvider';
 
 const prefixCls = 'ant';
 
@@ -41,6 +42,7 @@ interface ModelSelectProps extends Pick<
 > {
   defaultValue?: { model: string; provider?: string };
   initialWidth?: boolean;
+  modelType?: EnabledModelListType;
   onChange?: (props: { model: string; provider: string }) => void;
   popupWidth?: number;
   requiredAbilities?: (keyof EnabledProviderWithModels['children'][number]['abilities'])[];
@@ -60,9 +62,10 @@ const ModelSelect = memo<ModelSelectProps>(
     style,
     variant,
     initialWidth = false,
+    modelType,
     popupWidth,
   }) => {
-    const enabledList = useEnabledChatModels();
+    const enabledList = useEnabledModels(modelType ?? 'chat');
 
     const options = useMemo<SelectProps['options']>(() => {
       const getChatModels = (provider: EnabledProviderWithModels) => {

--- a/src/features/ServiceModel/ModelAssignmentsForm.tsx
+++ b/src/features/ServiceModel/ModelAssignmentsForm.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from 'react-i18next';
 import AsyncError from '@/components/AsyncError';
 import { FORM_STYLE } from '@/const/layoutTokens';
 import ModelSelect from '@/features/ModelSelect';
+import type { EnabledModelListType } from '@/hooks/useEnabledModels';
 import { usePermission } from '@/hooks/usePermission';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors } from '@/store/user/selectors';
@@ -43,6 +44,10 @@ const MEMORY_MODEL_ITEMS: SystemAgentModelItem[] = [
   { contextLimit: true, key: 'userMemoryPersonaWriter' },
   { contextLimit: true, key: 'userMemoryEmbedding' },
 ];
+
+const MEMORY_MODEL_TYPE_MAP: Partial<Record<UserServiceModelConfigKey, EnabledModelListType>> = {
+  userMemoryEmbedding: 'embedding',
+};
 
 const ModelAssignmentsForm = memo(() => {
   const { t } = useTranslation('setting');
@@ -172,6 +177,7 @@ const ModelAssignmentsForm = memo(() => {
       children: (
         <Flexbox direction="vertical" gap={8} style={{ width: 448 }}>
           <ModelSelect
+            modelType={MEMORY_MODEL_TYPE_MAP[key]}
             showAbility={false}
             style={{ minWidth: 0, width: '100%' }}
             value={value}

--- a/src/hooks/useEnabledChatModels.ts
+++ b/src/hooks/useEnabledChatModels.ts
@@ -1,10 +1,7 @@
-import isEqual from 'fast-deep-equal';
+import type { EnabledProviderWithModels } from '@/types/aiProvider';
 
-import { useAiInfraStore } from '@/store/aiInfra';
-import { type EnabledProviderWithModels } from '@/types/aiProvider';
+import { useEnabledModels } from './useEnabledModels';
 
 export const useEnabledChatModels = (): EnabledProviderWithModels[] => {
-  const enabledChatModelList = useAiInfraStore((s) => s.enabledChatModelList, isEqual);
-
-  return enabledChatModelList || [];
+  return useEnabledModels('chat');
 };

--- a/src/hooks/useEnabledModels.ts
+++ b/src/hooks/useEnabledModels.ts
@@ -1,0 +1,21 @@
+import isEqual from 'fast-deep-equal';
+
+import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
+import type { AIProviderStoreState } from '@/store/aiInfra/initialState';
+import type { EnabledProviderWithModels } from '@/types/aiProvider';
+
+export type EnabledModelListType = 'chat' | 'embedding' | 'image' | 'video';
+
+const enabledModelListSelectorMap = {
+  chat: aiProviderSelectors.enabledChatModelList,
+  image: aiProviderSelectors.enabledImageModelList,
+  video: aiProviderSelectors.enabledVideoModelList,
+  embedding: aiProviderSelectors.enabledEmbeddingModelList,
+} satisfies Record<EnabledModelListType, (s: AIProviderStoreState) => EnabledProviderWithModels[]>;
+
+export const useEnabledModels = (modelType: EnabledModelListType): EnabledProviderWithModels[] => {
+  const selector = enabledModelListSelectorMap[modelType];
+  const enabledModelList = useAiInfraStore(selector, isEqual);
+
+  return enabledModelList || [];
+};

--- a/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
+++ b/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
@@ -1,11 +1,19 @@
 import * as runtimeModule from '@lobechat/model-runtime';
-import type { AIImageModelCard, EnabledAiModel, ModelParamsSchema, Pricing } from 'model-bank';
+import type {
+  AIEmbeddingModelCard,
+  AIImageModelCard,
+  EnabledAiModel,
+  ModelParamsSchema,
+  Pricing,
+} from 'model-bank';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   getChatModelList,
+  getEmbeddingModelList,
   getImageModelList,
   normalizeChatModel,
+  normalizeEmbeddingModel,
   normalizeImageModel,
 } from '../action';
 
@@ -30,6 +38,22 @@ const createImageModel = (overrides: Partial<ImageEnabledModel> = {}): ImageEnab
   id: overrides.id ?? 'image-model',
   providerId: overrides.providerId ?? 'openai',
   type: 'image',
+  ...overrides,
+});
+
+type EmbeddingEnabledModel = EnabledAiModel & AIEmbeddingModelCard;
+
+const createEmbeddingModel = (
+  overrides: Partial<EmbeddingEnabledModel> = {},
+): EmbeddingEnabledModel => ({
+  abilities: overrides.abilities ?? {},
+  contextWindowTokens: overrides.contextWindowTokens ?? 8192,
+  displayName: overrides.displayName ?? 'Embedding Model',
+  enabled: overrides.enabled ?? true,
+  id: overrides.id ?? 'embedding-model',
+  maxDimension: overrides.maxDimension ?? 1536,
+  providerId: overrides.providerId ?? 'openai',
+  type: 'embedding',
   ...overrides,
 });
 
@@ -162,6 +186,61 @@ describe('aiProvider action helpers', () => {
     });
   });
 
+  describe('normalizeEmbeddingModel', () => {
+    it('preserves inline metadata without fallback lookup', async () => {
+      const fallbackSpy = vi.spyOn(runtimeModule, 'getModelPropertyWithFallback');
+      const model = createEmbeddingModel({
+        description: 'Inline embedding',
+        knowledgeCutoff: '2024-06',
+        pricing: {
+          units: [{ name: 'textInput', rate: 0.02, strategy: 'fixed', unit: 'millionTokens' }],
+        },
+      });
+
+      const result = await normalizeEmbeddingModel(model);
+
+      expect(result).toMatchObject({
+        description: 'Inline embedding',
+        knowledgeCutoff: '2024-06',
+        pricing: {
+          units: [{ name: 'textInput', rate: 0.02, strategy: 'fixed', unit: 'millionTokens' }],
+        },
+      });
+      expect(fallbackSpy).not.toHaveBeenCalled();
+    });
+
+    it('fetches fallback description/knowledge cutoff/pricing when missing', async () => {
+      const fallbackSpy = vi
+        .mocked(runtimeModule.getModelPropertyWithFallback)
+        .mockImplementation(async (_id, key) => {
+          if (key === 'description') return 'Fallback embedding description';
+          if (key === 'knowledgeCutoff') return '2024-01';
+          if (key === 'pricing')
+            return {
+              units: [{ name: 'textInput', rate: 0.01, strategy: 'fixed', unit: 'millionTokens' }],
+            };
+          return undefined;
+        });
+
+      const result = await normalizeEmbeddingModel(
+        createEmbeddingModel({
+          description: undefined,
+          knowledgeCutoff: undefined,
+          pricing: undefined,
+        }),
+      );
+
+      expect(result.description).toBe('Fallback embedding description');
+      expect(result.knowledgeCutoff).toBe('2024-01');
+      expect(result.pricing).toEqual({
+        units: [{ name: 'textInput', rate: 0.01, strategy: 'fixed', unit: 'millionTokens' }],
+      });
+      expect(fallbackSpy).toHaveBeenCalledWith('embedding-model', 'description', 'openai');
+      expect(fallbackSpy).toHaveBeenCalledWith('embedding-model', 'knowledgeCutoff', 'openai');
+      expect(fallbackSpy).toHaveBeenCalledWith('embedding-model', 'pricing', 'openai');
+    });
+  });
+
   describe('getChatModelList', () => {
     const chatModels = [
       createChatModel({ id: 'gpt-4', providerId: 'openai', displayName: 'GPT-4' }),
@@ -225,6 +304,26 @@ describe('aiProvider action helpers', () => {
 
     it('returns empty array when provider has no image models', async () => {
       const result = await getImageModelList(imageModels, 'unknown');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getEmbeddingModelList', () => {
+    const embeddingModels = [
+      createEmbeddingModel({ id: 'text-embedding-3-small', providerId: 'openai' }),
+      createEmbeddingModel({ id: 'text-embedding-3-large', providerId: 'openai' }),
+      createEmbeddingModel({ id: 'voyage-3', providerId: 'voyage' }),
+    ];
+
+    it('collects normalized embedding models for a provider', async () => {
+      const result = await getEmbeddingModelList(embeddingModels, 'openai');
+
+      expect(result).toHaveLength(2);
+      expect(result.map((m) => m.id)).toEqual(['text-embedding-3-small', 'text-embedding-3-large']);
+    });
+
+    it('returns empty array when provider has no embedding models', async () => {
+      const result = await getEmbeddingModelList(embeddingModels, 'unknown');
       expect(result).toEqual([]);
     });
   });

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -546,7 +546,8 @@ export class AiProviderActionImpl {
             buildImageProviderModelLists(data.enabledImageAiProviders, data.enabledAiModels),
             buildVideoProviderModelLists(data.enabledVideoAiProviders, data.enabledAiModels),
             buildEmbeddingProviderModelLists(
-              data.enabledEmbeddingAiProviders,
+              // Older server/runtime payloads may not include the new embedding provider bucket yet.
+              data.enabledEmbeddingAiProviders ?? [],
               data.enabledAiModels,
             ),
           ]);

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -99,6 +99,27 @@ export const normalizeChatModel = async (model: EnabledAiModel): Promise<Provide
   };
 };
 
+export const normalizeEmbeddingModel = async (
+  model: EnabledAiModel,
+): Promise<ProviderModelListItem> => {
+  const [description, knowledgeCutoff, pricing] = await Promise.all([
+    getModelProperty<string>(model, 'description'),
+    getModelProperty<string>(model, 'knowledgeCutoff'),
+    getModelProperty<Pricing>(model, 'pricing'),
+  ]);
+
+  return {
+    abilities: (model.abilities || {}) as ModelAbilities,
+    contextWindowTokens: model.contextWindowTokens,
+    displayName: model.displayName ?? '',
+    id: model.id,
+    releasedAt: model.releasedAt,
+    ...(description && { description }),
+    ...(knowledgeCutoff && { knowledgeCutoff }),
+    ...(pricing && { pricing }),
+  };
+};
+
 export const normalizeImageModel = async (
   model: EnabledAiModel,
 ): Promise<ProviderModelListItem> => {
@@ -180,6 +201,10 @@ export const getChatModelList = createProviderModelCollector('chat', async (mode
   normalizeChatModel(model),
 );
 
+export const getEmbeddingModelList = createProviderModelCollector('embedding', async (model) =>
+  normalizeEmbeddingModel(model),
+);
+
 export const getImageModelList = createProviderModelCollector('image', normalizeImageModel);
 
 export const getVideoModelList = createProviderModelCollector('video', normalizeVideoModel);
@@ -225,6 +250,14 @@ const buildVideoProviderModelLists = async (
   enabledAiModels: EnabledAiModel[],
 ) => buildProviderModelLists(providers, enabledAiModels, getVideoModelList);
 
+/**
+ * Build embedding provider model lists with proper async handling
+ */
+const buildEmbeddingProviderModelLists = async (
+  providers: EnabledProvider[],
+  enabledAiModels: EnabledAiModel[],
+) => buildProviderModelLists(providers, enabledAiModels, getEmbeddingModelList);
+
 enum AiProviderSwrKey {
   fetchAiProviderItem = 'FETCH_AI_PROVIDER_ITEM',
   fetchAiProviderList = 'FETCH_AI_PROVIDER',
@@ -236,6 +269,7 @@ type AiProviderRuntimeStateWithBuiltinModels = AiProviderRuntimeState & {
   enabledChatModelList?: EnabledProviderWithModels[];
   enabledImageModelList?: EnabledProviderWithModels[];
   enabledVideoModelList?: EnabledProviderWithModels[];
+  enabledEmbeddingModelList?: EnabledProviderWithModels[];
 };
 
 type Setter = StoreSetter<AiInfraStore>;
@@ -502,12 +536,20 @@ export class AiProviderActionImpl {
           const data = await aiProviderService.getAiProviderRuntimeState();
 
           // Build model lists with proper async handling
-          const [enabledChatModelList, enabledImageModelList, enabledVideoModelList] =
-            await Promise.all([
-              buildChatProviderModelLists(data.enabledChatAiProviders, data.enabledAiModels),
-              buildImageProviderModelLists(data.enabledImageAiProviders, data.enabledAiModels),
-              buildVideoProviderModelLists(data.enabledVideoAiProviders, data.enabledAiModels),
-            ]);
+          const [
+            enabledChatModelList,
+            enabledImageModelList,
+            enabledVideoModelList,
+            enabledEmbeddingModelList,
+          ] = await Promise.all([
+            buildChatProviderModelLists(data.enabledChatAiProviders, data.enabledAiModels),
+            buildImageProviderModelLists(data.enabledImageAiProviders, data.enabledAiModels),
+            buildVideoProviderModelLists(data.enabledVideoAiProviders, data.enabledAiModels),
+            buildEmbeddingProviderModelLists(
+              data.enabledEmbeddingAiProviders,
+              data.enabledAiModels,
+            ),
+          ]);
 
           return {
             ...data,
@@ -515,6 +557,7 @@ export class AiProviderActionImpl {
             enabledChatModelList,
             enabledImageModelList,
             enabledVideoModelList,
+            enabledEmbeddingModelList,
           };
         }
 
@@ -544,14 +587,25 @@ export class AiProviderActionImpl {
           })
           .map((item) => ({ id: item.id, name: item.name, source: AiProviderSourceEnum.Builtin }));
 
+        const enabledEmbeddingAiProviders = enabledAiProviders.filter((provider) => {
+          return builtinAiModelList.some(
+            (model) => model.providerId === provider.id && model.type === 'embedding',
+          );
+        });
+
         // Build model lists for non-login state as well
         const enabledAiModels = builtinAiModelList.filter((m) => m.enabled);
-        const [enabledChatModelList, enabledImageModelList, enabledVideoModelList] =
-          await Promise.all([
-            buildChatProviderModelLists(enabledChatAiProviders, enabledAiModels),
-            buildImageProviderModelLists(enabledImageAiProviders, enabledAiModels),
-            buildVideoProviderModelLists(enabledVideoAiProviders, enabledAiModels),
-          ]);
+        const [
+          enabledChatModelList,
+          enabledImageModelList,
+          enabledVideoModelList,
+          enabledEmbeddingModelList,
+        ] = await Promise.all([
+          buildChatProviderModelLists(enabledChatAiProviders, enabledAiModels),
+          buildImageProviderModelLists(enabledImageAiProviders, enabledAiModels),
+          buildVideoProviderModelLists(enabledVideoAiProviders, enabledAiModels),
+          buildEmbeddingProviderModelLists(enabledEmbeddingAiProviders, enabledAiModels),
+        ]);
 
         return {
           builtinAiModelList,
@@ -563,6 +617,8 @@ export class AiProviderActionImpl {
           enabledImageModelList,
           enabledVideoAiProviders,
           enabledVideoModelList,
+          enabledEmbeddingAiProviders,
+          enabledEmbeddingModelList,
           runtimeConfig: {},
         };
       },
@@ -579,6 +635,7 @@ export class AiProviderActionImpl {
               enabledChatModelList: data.enabledChatModelList || [],
               enabledImageModelList: data.enabledImageModelList || [],
               enabledVideoModelList: data.enabledVideoModelList || [],
+              enabledEmbeddingModelList: data.enabledEmbeddingModelList || [],
               isInitAiProviderRuntimeState: true,
             },
             false,

--- a/src/store/aiInfra/slices/aiProvider/initialState.ts
+++ b/src/store/aiInfra/slices/aiProvider/initialState.ts
@@ -24,6 +24,7 @@ export interface AIProviderState {
   enabledAiProviders?: EnabledProvider[];
   // used for select
   enabledChatModelList?: EnabledProviderWithModels[];
+  enabledEmbeddingModelList?: EnabledProviderWithModels[];
   enabledImageModelList?: EnabledProviderWithModels[];
   enabledVideoModelList?: EnabledProviderWithModels[];
   initAiProviderList: boolean;

--- a/src/store/aiInfra/slices/aiProvider/selectors.ts
+++ b/src/store/aiInfra/slices/aiProvider/selectors.ts
@@ -15,9 +15,13 @@ const disabledAiProviderList = (s: AIProviderStoreState) =>
 const disabledCustomAiProviderList = (s: AIProviderStoreState) =>
   s.aiProviderList.filter((item) => !item.enabled && item.source === AiProviderSourceEnum.Custom);
 
+const enabledChatModelList = (s: AIProviderStoreState) => s.enabledChatModelList || [];
+
 const enabledImageModelList = (s: AIProviderStoreState) => s.enabledImageModelList || [];
 
 const enabledVideoModelList = (s: AIProviderStoreState) => s.enabledVideoModelList || [];
+
+const enabledEmbeddingModelList = (s: AIProviderStoreState) => s.enabledEmbeddingModelList || [];
 
 const isProviderEnabled = (id: string) => (s: AIProviderStoreState) =>
   enabledAiProviderList(s).some((i) => i.id === id);
@@ -137,8 +141,10 @@ export const aiProviderSelectors = {
   disabledAiProviderList,
   disabledCustomAiProviderList,
   enabledAiProviderList,
+  enabledChatModelList,
   enabledImageModelList,
   enabledVideoModelList,
+  enabledEmbeddingModelList,
   isActiveProviderApiKeyNotEmpty,
   isActiveProviderEndpointNotEmpty,
   isAiProviderConfigLoading,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #16591 #15520

#### 🔀 Description of Change

This PR makes Memory Embedding use embedding-capable models instead of only chat models.

<img width="1049" height="179" alt="image" src="https://github.com/user-attachments/assets/1751f6b0-6e69-4609-8a8c-9bc617572b95" />

It also exposes embedding provider/model lists through the AI provider runtime state so the selector can render the correct options.

Root cause:
The Memory Embedding selector reused the chat model list, so embedding-only models were filtered out and users could not select proper embedding models.

Fix:
- Add enabledEmbeddingAiProviders to runtime state.
- Make ModelSelect accept a modelType and default to chat for existing usages.
- Set Memory Embedding to use embedding models.
- Keep builtin embedding models enabled.
- Add/update regression tests around runtime state and model-bank behavior.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validated with:
- `bunx eslint` on the touched files
- `bunx vitest run --silent='passed-only'` for the updated server, database, model-bank, and store tests

#### 📝 Additional Information

No screenshots needed. The change is limited to model selection and runtime state wiring.
