### PR TITLE
🐛 fix: use root Popover export for Codex quota menu

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/CodexQuotaMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/CodexQuotaMenu.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import type { CodexQuotaSnapshot, CodexQuotaWindow } from '@lobechat/electron-client-ipc';
-import { ActionIcon, Flexbox, Icon, Skeleton, Text, Tooltip } from '@lobehub/ui';
-import { Popover } from '@lobehub/ui/base-ui';
+import { ActionIcon, Flexbox, Icon, Popover, Skeleton, Text, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { ChevronDownIcon, GaugeIcon, RefreshCwIcon, RotateCcwIcon } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
@@ -30,7 +29,7 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   header: css`
     padding-block-end: 8px;
-    border-bottom: 1px solid ${cssVar.colorBorderSecondary};
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
   `,
   popover: css`
     width: 292px;
@@ -51,7 +50,7 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   resetCredits: css`
     padding-block-start: 8px;
-    border-top: 1px solid ${cssVar.colorBorderSecondary};
+    border-block-start: 1px solid ${cssVar.colorBorderSecondary};
   `,
   trigger: css`
     cursor: pointer;
@@ -73,6 +72,7 @@ const styles = createStaticStyles(({ css }) => ({
 
     appearance: none;
     background: transparent;
+
     transition: all 0.2s;
 
     &:hover {
@@ -273,9 +273,7 @@ const CodexQuotaMenu = memo<CodexQuotaMenuProps>(({ command, env }) => {
           <Skeleton.Button active block size="small" style={{ height: 18 }} />
         </Flexbox>
       ) : quota?.status === 'error' || quota?.status === 'unavailable' ? (
-        <div className={styles.error}>
-          {quota.error || t('heteroAgent.codexQuota.unavailable')}
-        </div>
+        <div className={styles.error}>{quota.error || t('heteroAgent.codexQuota.unavailable')}</div>
       ) : hasQuotaData ? (
         <>
           <Flexbox gap={10}>
@@ -347,11 +345,7 @@ const CodexQuotaMenu = memo<CodexQuotaMenuProps>(({ command, env }) => {
       onOpenChange={handleOpenChange}
     >
       <div>
-        {open ? (
-          trigger
-        ) : (
-          <Tooltip title={t('heteroAgent.codexQuota.tooltip')}>{trigger}</Tooltip>
-        )}
+        {open ? trigger : <Tooltip title={t('heteroAgent.codexQuota.tooltip')}>{trigger}</Tooltip>}
       </div>
     </Popover>
   );


### PR DESCRIPTION
## Summary

- Update the Codex quota menu to import `Popover` from the root `@lobehub/ui` entry.
- Keep the quota menu rendering in local desktop builds where the installed `@lobehub/ui/base-ui` entry does not export the wrapper `Popover` component.

## Root Cause

The local desktop renderer failed with:

```text
The requested module '/node_modules/.vite/deps/@lobehub_ui_base-ui.js' does not provide an export named 'Popover'
```

`@lobehub/ui@5.18.0` exports the high-level `Popover` wrapper from `@lobehub/ui`, while `@lobehub/ui/base-ui` only exposes Popover atoms and related helpers. Importing the wrapper from `base-ui` therefore breaks Vite/Electron module loading.

## Validation

- `bunx eslint 'src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/CodexQuotaMenu.tsx'`
- Verified the Electron desktop app loads locally after the import change.