### PR TITLE
🐛 fix: preserve MCP publishing feedback triage

### DIFF
--- a/.claude/commands/dedupe.md
+++ b/.claude/commands/dedupe.md
@@ -7,7 +7,7 @@ Find up to 3 likely duplicate issues for a given GitHub issue.
 
 To do this, follow these steps precisely:
 
-1. Use an agent to check if the Github issue (a) is closed, (b) does not need to be deduped (eg. because it is broad product feedback without a specific solution, or positive feedback), or (c) already has a duplicates comment that you made earlier. If so, do not proceed.
+1. Use an agent to check if the Github issue (a) is closed, (b) does not need to be deduped (eg. because it is broad product feedback without a specific solution, positive feedback, or a new MCP marketplace listing/submission request handled by the MCP Submission Handler workflow), or (c) already has a duplicates comment that you made earlier. If so, do not proceed.
 2. Use an agent to view a Github issue, and ask the agent to return a summary of the issue
 3. Then, launch 5 parallel agents to search Github for duplicates of this issue, using diverse keywords and search approaches, using the summary from #1
 4. Next, feed the results from #1 and #2 into another agent, so that it can filter out false positives, that are likely not actually duplicates of the original issue. If there are no duplicates remaining, do not proceed.

--- a/.claude/prompts/team-assignment.md
+++ b/.claude/prompts/team-assignment.md
@@ -3,6 +3,7 @@
 ## Quick Reference by Name
 
 - **@arvinxx**: General/uncategorized issues (default assignee), priority:high issues, tool calling, mcp, database
+- **@AmAzing129**: MCP marketplace listing/submission requests and MCP marketplace listing operations
 - **@canisminor1990**: Design, UI components, editor, markdown rendering
 - **@tjx666**: Model providers and configuration, new model additions, image/video generation, vision, cloud version, documentation, TTS, auth, login/register, database
 - **@ONLY-yours**: Performance, streaming, settings, web platform, marketplace, agent builder, schedule task
@@ -121,13 +122,13 @@ Quick reference for assigning issues based on labels.
 
 - Assign to @arvinxx for general issues
 
-**MCP marketplace listing/submission requests — do NOT mention (auto-handled):**
+**MCP marketplace listing/submission requests — @AmAzing129:**
 
-Requests to **add / submit / list a new MCP server** to the marketplace are now processed automatically by the **MCP Submission Handler** workflow (it redirects installable servers to the self-service CLI and closes them, and labels remote-only servers `mcp:remote` for manual review). For these, **do NOT post any @mention comment — apply labels only.**
+Requests to **add / submit / list a new MCP server** to the marketplace belong to @AmAzing129, not @arvinxx. These may also be processed by the **MCP Submission Handler** workflow (it redirects installable servers to the self-service CLI and closes them, and labels remote-only servers `mcp:remote` for manual review), but if a triage mention is posted, mention @AmAzing129.
 
 - Recognize them by: titles like `[Request] Add <name> to the MCP marketplace`, `[MCP] Add/Submit <name>`, `[MCP Submission] …`, `[MCP Plugin] …`; the body asks to list/index a specific MCP server and links its repo or endpoint.
 - This does **NOT** apply to the following — they still get a normal @mention:
-  - Bugs about the marketplace pipeline or an existing listing — e.g. "scoring stuck", "shows outdated version", "rescan/re-index listing", "not syncing". → `@ONLY-yours @arvinxx`
+  - Bugs about the marketplace pipeline or an existing listing — e.g. "scoring stuck", "shows outdated version", "rescan/re-index listing", "not syncing". → `@ONLY-yours @AmAzing129`
   - Feature requests about the marketplace product itself (search, catalog browser, etc.). → `@ONLY-yours`
 
 ## Comment Templates

--- a/.github/scripts/auto-handle-mcp-submission.ts
+++ b/.github/scripts/auto-handle-mcp-submission.ts
@@ -13,6 +13,8 @@
  * Anything that is not a confident match is left untouched for normal triage.
  */
 
+import { classify } from './shared/mcp-submission-classifier';
+
 declare global {
   // @ts-ignore
   var process: {
@@ -69,176 +71,6 @@ async function githubRequest<T>(
   // Some endpoints (e.g. label add) return 200 with a body; others may be empty.
   const text = await response.text();
   return (text ? JSON.parse(text) : undefined) as T;
-}
-
-/**
- * Pull the first plausible "server repo" GitHub URL out of the issue body.
- * Skips links to lobehub's own org and the MCP registry org so we land on the
- * submitter's repository.
- */
-function extractRepoUrl(body: string): string | null {
-  // github.com first-path segments that are NOT repositories (attachments,
-  // pasted screenshots, org pages, etc.). `user-attachments` is the big one —
-  // pasted images land at github.com/user-attachments/assets/... and must never
-  // be mistaken for a server repo.
-  const reserved = new Set([
-    'about',
-    'apps',
-    'collections',
-    'explore',
-    'features',
-    'join',
-    'login',
-    'marketplace',
-    'notifications',
-    'orgs',
-    'pricing',
-    'readme',
-    'search',
-    'settings',
-    'sponsors',
-    'topics',
-    'user-attachments',
-  ]);
-  // Our own org and the upstream registry — skip so we land on the submitter's repo.
-  const ignoredOwners = new Set(['lobehub', 'lobechat', 'modelcontextprotocol']);
-  const regex = /https?:\/\/github\.com\/([\w.-]+)\/([\w.-]+)/gi;
-
-  for (const match of body.matchAll(regex)) {
-    const owner = match[1];
-    let repo = match[2];
-    // Strip trailing junk like ".git", ")", ".", ","
-    repo = repo.replace(/\.git$/i, '').replace(/[).,]+$/, '');
-    if (!owner || !repo) continue;
-    const ownerLc = owner.toLowerCase();
-    if (reserved.has(ownerLc)) continue;
-    if (ignoredOwners.has(ownerLc)) continue;
-    return `https://github.com/${owner}/${repo}`;
-  }
-
-  return null;
-}
-
-interface Classification {
-  // How the server is delivered — only `local` (installable) servers can be
-  // self-published via the CLI; `remote` (URL-only) and `unknown` must go to a human.
-  delivery: 'local' | 'remote' | 'unknown';
-  isSubmission: boolean;
-  reason: string;
-  repoUrl: string | null;
-}
-
-/**
- * Decide whether an issue is a *new MCP server listing request*.
- *
- * High precision on purpose — this drives a hard auto-close. We require an
- * add/submit intent + the word "mcp" + a GitHub repo URL, and explicitly bail
- * out on the two confusable categories observed in real issues:
- *   - marketplace / existing-listing bugs (scoring stuck, outdated version…)
- *   - feedback about the publishing CLI itself (which we actively welcome)
- */
-function classify(title: string, body: string): Classification {
-  const text = `${title}\n${body}`.toLowerCase();
-  const repoUrl = extractRepoUrl(body);
-
-  const hasMcp = /\bmcp\b/.test(text);
-
-  // Explicit "add / submit my server" intent. The `[MCP Submission]` and
-  // `[MCP Plugin]` title prefixes are themselves a declaration of intent.
-  const hasAddVerb =
-    /\b(?:add|submit|submission|submitting|list(?:ing)?|publish|index|register|include)\b/.test(
-      text,
-    ) ||
-    /上架|收录|添加|提交|登记/.test(text) ||
-    /^\s*\[mcp\s*(?:submission|plugin)\]/i.test(title);
-
-  // Marketplace framing — keeps us on listing requests and off random MCP bug
-  // reports that merely mention "mcp" and a verb in passing. A leading `[MCP…`
-  // title tag counts as context.
-  const hasMarketContext =
-    /marketplace|市场|上架|收录|登记/.test(text) || /^\s*\[mcp\b/i.test(title);
-
-  // Problem with the marketplace pipeline or an already-listed server — NOT a
-  // new submission. Leave these for humans.
-  const isMarketplaceBug =
-    /scoring|re-?scan|re-?index|stuck|outdated|out of date|stale|not updating|won'?t update|wrong version|shows? (?:old|outdated|wrong)|disappeared|removed from|missing from|not show(?:ing)?|not syncing|sync(?:ing)? (?:from|issue)|canonical cache/.test(
-      text,
-    );
-
-  // Feedback about the publishing CLI / flow — we explicitly invite these, so
-  // never auto-close them.
-  const isCliFeedback =
-    /market-cli|publish-mcp|publishing skill/.test(text) ||
-    /\bcli\b.+(?:fail|error|issue|problem|bug|not work|can'?t|unable)/.test(text) ||
-    /(?:fail|error|unable|can'?t|cannot).*(?:submit|publish|login|connect|verify ownership)/.test(
-      text,
-    );
-
-  // Delivery method. The CLI can only self-publish *installable* servers
-  // (npm / npx / uvx / pip / docker / stdio). A bare GitHub repo URL does NOT
-  // count — some remote-only servers link a repo yet ship "no install, no npm".
-  // Servers that also offer a remote endpoint but ARE installable stay `local`,
-  // because the CLI can still serve the installable path.
-  // Strong, unambiguous "installable" signals — these prove the CLI can publish it.
-  const hasStrongInstall =
-    /\bnpx\b|\buvx\b|\bpipx\b|\bpip install\b|\bdocker run\b/.test(text) ||
-    /"command"\s*:/.test(text) ||
-    /npmjs\.com\/package\//.test(text);
-  // A bare "stdio" mention is weak — remote submissions often name it in a negation
-  // or comparison ("Transport: SSE, not stdio"), so it must not outrank a remote signal.
-  const hasStdioMention = /\bstdio\b/.test(text);
-  const hasRemoteSignal =
-    /"url"\s*:/.test(text) ||
-    /\bstreamable[- ]?http\b|\bsse\b/.test(text) ||
-    /transport[^a-z]{0,8}(?:sse|http|streamable)/.test(text) ||
-    /\bremote(?:ly)? (?:hosted|mcp|server)\b|\bhosted mcp\b/.test(text) ||
-    // a bare endpoint URL (non-GitHub) labelled "url:" / "endpoint:" is a remote reference
-    /\b(?:endpoint|url)\b[^\n]{1,15}https?:\/\/(?!github\.com)/.test(text);
-  // An explicit "no install / no npm / remote-only" statement is decisive: the server
-  // ships only as a URL, so it overrides any incidental stdio/command mention.
-  const isRemoteOnly =
-    /\bno install\b|\bno npm\b|\bremote[- ]only\b|no local install|installation[- ]free/.test(text);
-  // Precedence: explicit remote-only > strong install > any remote signal > lone stdio mention.
-  const delivery: Classification['delivery'] = isRemoteOnly
-    ? 'remote'
-    : hasStrongInstall
-      ? 'local'
-      : hasRemoteSignal
-        ? 'remote'
-        : hasStdioMention
-          ? 'local'
-          : 'unknown';
-
-  if (!hasMcp) return { delivery, isSubmission: false, reason: 'no "mcp" keyword', repoUrl };
-  if (!hasAddVerb)
-    return { delivery, isSubmission: false, reason: 'no add/submit intent', repoUrl };
-  if (!hasMarketContext)
-    return { delivery, isSubmission: false, reason: 'no marketplace context', repoUrl };
-  // A server reference is required, but for remote submissions the endpoint itself
-  // counts — only the local (CLI) path needs an actual repo URL (for `plugin submit`).
-  if (!repoUrl && delivery !== 'remote')
-    return {
-      delivery,
-      isSubmission: false,
-      reason: 'no server reference (repo URL or endpoint)',
-      repoUrl,
-    };
-  if (isMarketplaceBug)
-    return {
-      delivery,
-      isSubmission: false,
-      reason: 'looks like a marketplace/listing bug',
-      repoUrl,
-    };
-  if (isCliFeedback)
-    return { delivery, isSubmission: false, reason: 'looks like CLI/publishing feedback', repoUrl };
-
-  return {
-    delivery,
-    isSubmission: true,
-    reason: `new MCP server listing request (${delivery})`,
-    repoUrl,
-  };
 }
 
 function buildComment(repoUrl: string | null): string {
@@ -407,4 +239,4 @@ if (import.meta.main) {
   });
 }
 
-export { classify, extractRepoUrl };
+export { classify, extractRepoUrl } from './shared/mcp-submission-classifier';

--- a/.github/scripts/shared/mcp-submission-classifier.ts
+++ b/.github/scripts/shared/mcp-submission-classifier.ts
@@ -1,0 +1,154 @@
+export interface Classification {
+  // How the server is delivered: only local installable servers can be
+  // self-published via the CLI; remote URL-only and unknown delivery go to humans.
+  delivery: 'local' | 'remote' | 'unknown';
+  isSubmission: boolean;
+  reason: string;
+  repoUrl: string | null;
+}
+
+/**
+ * Pull the first plausible "server repo" GitHub URL out of the issue body.
+ * Skips links to LobeHub's own org and the MCP registry org so we land on the
+ * submitter's repository.
+ */
+export function extractRepoUrl(body: string): string | null {
+  // github.com first-path segments that are not repositories: attachments,
+  // pasted screenshots, org pages, etc. `user-attachments` is the big one:
+  // pasted images land at github.com/user-attachments/assets/... and must never
+  // be mistaken for a server repo.
+  const reserved = new Set([
+    'about',
+    'apps',
+    'collections',
+    'explore',
+    'features',
+    'join',
+    'login',
+    'marketplace',
+    'notifications',
+    'orgs',
+    'pricing',
+    'readme',
+    'search',
+    'settings',
+    'sponsors',
+    'topics',
+    'user-attachments',
+  ]);
+  const ignoredOwners = new Set(['lobehub', 'lobechat', 'modelcontextprotocol']);
+  const regex = /https?:\/\/github\.com\/([\w.-]+)\/([\w.-]+)/gi;
+
+  for (const match of body.matchAll(regex)) {
+    const owner = match[1];
+    let repo = match[2];
+    repo = repo.replace(/\.git$/i, '').replace(/[).,]+$/, '');
+    if (!owner || !repo) continue;
+    const ownerLc = owner.toLowerCase();
+    if (reserved.has(ownerLc)) continue;
+    if (ignoredOwners.has(ownerLc)) continue;
+    return `https://github.com/${owner}/${repo}`;
+  }
+
+  return null;
+}
+
+/**
+ * Decide whether an issue is a new MCP server listing request.
+ *
+ * High precision on purpose: the MCP submission handler uses this to drive an
+ * auto-close path. We require add/submit intent + the word "mcp" + a server
+ * reference, and explicitly bail out on marketplace bugs and CLI feedback.
+ */
+export function classify(title: string, body: string): Classification {
+  const text = `${title}\n${body}`.toLowerCase();
+  const repoUrl = extractRepoUrl(body);
+
+  const hasMcp = /\bmcp\b/.test(text);
+
+  // Explicit add / submit intent. The `[MCP Submission]` and `[MCP Plugin]`
+  // title prefixes are themselves a declaration of intent.
+  const hasAddVerb =
+    /\b(?:add|submit|submission|submitting|list(?:ing)?|publish|index|register|include)\b/.test(
+      text,
+    ) ||
+    /上架|收录|添加|提交|登记/.test(text) ||
+    /^\s*\[mcp\s*(?:submission|plugin)\]/i.test(title);
+
+  // Marketplace framing keeps us on listing requests and off random MCP bug
+  // reports that merely mention "mcp" and a verb in passing.
+  const hasMarketContext =
+    /marketplace|市场|上架|收录|登记/.test(text) || /^\s*\[mcp\b/i.test(title);
+
+  const isMarketplaceBug =
+    /scoring|re-?scan|re-?index|stuck|outdated|out of date|stale|not updating|won'?t update|wrong version|shows? (?:old|outdated|wrong)|disappeared|removed from|missing from|not show(?:ing)?|not syncing|sync(?:ing)? (?:from|issue)|canonical cache/.test(
+      text,
+    );
+
+  const isPublishingFlowFeedback =
+    /publish-mcp|publishing skill/.test(text) &&
+    /\b(?:feedback|wrong|confusing?|docs?|instructions?|guide|command sequence|not work|fail|error|bug|issue|problem|can'?t|cannot|unable)\b/.test(
+      text,
+    );
+
+  const isCliFeedback =
+    isPublishingFlowFeedback ||
+    /\bcli\b.+(?:fail|error|issue|problem|bug|not work|can'?t|unable)/.test(text) ||
+    /(?:fail|error|unable|can'?t|cannot).*(?:submit|publish|login|connect|verify ownership)/.test(
+      text,
+    );
+
+  // Strong install signals prove the CLI can publish the server.
+  const hasStrongInstall =
+    /\bnpx\b|\buvx\b|\bpipx\b|\bpip install\b|\bdocker run\b/.test(text) ||
+    /"command"\s*:/.test(text) ||
+    /npmjs\.com\/package\//.test(text);
+  const hasStdioMention = /\bstdio\b/.test(text);
+  const hasRemoteSignal =
+    /"url"\s*:/.test(text) ||
+    /\bstreamable[- ]?http\b|\bsse\b/.test(text) ||
+    /transport[^a-z]{0,8}(?:sse|http|streamable)/.test(text) ||
+    /\bremote(?:ly)? (?:hosted|mcp|server)\b|\bhosted mcp\b/.test(text) ||
+    /\b(?:endpoint|url)\b[^\n]{1,15}https?:\/\/(?!github\.com)/.test(text);
+  const isRemoteOnly =
+    /\bno install\b|\bno npm\b|\bremote[- ]only\b|no local install|installation[- ]free/.test(text);
+
+  const delivery: Classification['delivery'] = isRemoteOnly
+    ? 'remote'
+    : hasStrongInstall
+      ? 'local'
+      : hasRemoteSignal
+        ? 'remote'
+        : hasStdioMention
+          ? 'local'
+          : 'unknown';
+
+  if (!hasMcp) return { delivery, isSubmission: false, reason: 'no "mcp" keyword', repoUrl };
+  if (!hasAddVerb)
+    return { delivery, isSubmission: false, reason: 'no add/submit intent', repoUrl };
+  if (!hasMarketContext)
+    return { delivery, isSubmission: false, reason: 'no marketplace context', repoUrl };
+  if (!repoUrl && delivery !== 'remote')
+    return {
+      delivery,
+      isSubmission: false,
+      reason: 'no server reference (repo URL or endpoint)',
+      repoUrl,
+    };
+  if (isMarketplaceBug)
+    return {
+      delivery,
+      isSubmission: false,
+      reason: 'looks like a marketplace/listing bug',
+      repoUrl,
+    };
+  if (isCliFeedback)
+    return { delivery, isSubmission: false, reason: 'looks like CLI/publishing feedback', repoUrl };
+
+  return {
+    delivery,
+    isSubmission: true,
+    reason: `new MCP server listing request (${delivery})`,
+    repoUrl,
+  };
+}

--- a/.github/scripts/should-run-dedupe.ts
+++ b/.github/scripts/should-run-dedupe.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env bun
+
+import { appendFile } from 'node:fs/promises';
+
+import { classify } from './shared/mcp-submission-classifier';
+
+interface GitHubLabel {
+  name: string;
+}
+
+interface DedupeIssue {
+  body: string | null;
+  labels: GitHubLabel[];
+  state: string;
+  title: string;
+}
+
+interface DedupeDecision {
+  reason: string;
+  shouldDedupe: boolean;
+}
+
+async function githubRequest<T>(endpoint: string, token: string): Promise<T> {
+  const response = await fetch(`https://api.github.com${endpoint}`, {
+    headers: {
+      'Accept': 'application/vnd.github+json',
+      'Authorization': `Bearer ${token}`,
+      'User-Agent': 'should-run-dedupe-script',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API GET ${endpoint} failed: ${response.status} ${response.statusText}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+function hasLabel(issue: DedupeIssue, name: string): boolean {
+  return issue.labels.some((label) => label.name === name);
+}
+
+function githubOutputValue(value: string): string {
+  return value.replaceAll('\n', ' ');
+}
+
+async function setGitHubOutput(name: string, value: string): Promise<void> {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+
+  await appendFile(outputPath, `${name}=${githubOutputValue(value)}\n`);
+}
+
+export function shouldDedupeIssue(issue: DedupeIssue): DedupeDecision {
+  if (issue.state !== 'open') {
+    return {
+      reason: 'Issue is not open',
+      shouldDedupe: false,
+    };
+  }
+
+  if (hasLabel(issue, 'mcp-submission') || hasLabel(issue, 'mcp:remote')) {
+    return {
+      reason: 'MCP marketplace listing request is handled by the MCP submission workflow',
+      shouldDedupe: false,
+    };
+  }
+
+  const classification = classify(issue.title || '', issue.body || '');
+  if (classification.isSubmission) {
+    return {
+      reason: `MCP marketplace listing request (${classification.delivery}) is handled by the MCP submission workflow`,
+      shouldDedupe: false,
+    };
+  }
+
+  return {
+    reason: 'Issue is eligible for duplicate detection',
+    shouldDedupe: true,
+  };
+}
+
+async function main(): Promise<void> {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error('GITHUB_TOKEN environment variable is required');
+
+  const repository = process.env.GITHUB_REPOSITORY;
+  const [repositoryOwner, repositoryName] = repository?.split('/') ?? [];
+  const owner = process.env.GITHUB_REPOSITORY_OWNER || repositoryOwner || 'lobehub';
+  const repo = process.env.GITHUB_REPOSITORY_NAME || repositoryName || 'lobehub';
+  const issueNumber = Number(process.env.ISSUE_NUMBER);
+  if (!issueNumber) throw new Error('ISSUE_NUMBER environment variable is required');
+
+  const issue = await githubRequest<DedupeIssue>(
+    `/repos/${owner}/${repo}/issues/${issueNumber}`,
+    token,
+  );
+  const decision = shouldDedupeIssue(issue);
+
+  console.log(
+    `[INFO] Dedupe preflight for ${owner}/${repo}#${issueNumber}: ${
+      decision.shouldDedupe ? 'run' : 'skip'
+    } - ${decision.reason}`,
+  );
+
+  await setGitHubOutput('should_dedupe', String(decision.shouldDedupe));
+  await setGitHubOutput('reason', decision.reason);
+}
+
+// @ts-ignore - import.meta.main is provided by Bun
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(`[ERROR] ${error}`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/workflows/claude-dedupe-issues.yml
+++ b/.github/workflows/claude-dedupe-issues.yml
@@ -22,12 +22,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+
+      - name: Check whether issue should be deduped
+        id: dedupe-preflight
+        run: bun run .github/scripts/should-run-dedupe.ts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
+          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+
       - name: Copy security prompt
+        if: steps.dedupe-preflight.outputs.should_dedupe == 'true'
         run: |
           mkdir -p /tmp/claude-prompts
           cp .claude/prompts/security-rules.md /tmp/claude-prompts/
 
       - name: Run Claude Code slash command
+        if: steps.dedupe-preflight.outputs.should_dedupe == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -72,7 +72,7 @@ jobs:
             **IMPORTANT**:
             - Follow ALL steps in the issue-triage.md guide
             - Apply labels according to the guide's rules
-            - ${{ steps.check-team.outputs.is_team == 'true' && 'The issue author is a team member. Do NOT post any @mention comment.' || 'Post a mention comment to the appropriate team member(s) based on team-assignment.md. EXCEPTION: if team-assignment.md marks the issue category as auto-handled / no-mention (e.g. MCP marketplace listing/submission requests), do NOT post any @mention comment — apply labels only.' }}
+            - ${{ steps.check-team.outputs.is_team == 'true' && 'The issue author is a team member. Do NOT post any @mention comment.' || 'Post a mention comment to the appropriate team member(s) based on team-assignment.md. EXCEPTION: if team-assignment.md marks the issue category as auto-handled / no-mention, do NOT post any @mention comment — apply labels only.' }}
             - Replace [ISSUE_NUMBER] with: ${{ github.event.issue.number }}
 
             **Start the triage process now.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,9 +140,11 @@ Before reviewing a PR / diff / branch change, read the **review-checklist** skil
 When designing or reviewing user-facing flows (empty/loading/error states, confirmations, async feedback, button hierarchy, lists at scale, pickers), follow LobeHub's design values in [`DESIGN.md`](./DESIGN.md) — Natural / Meaningful / Certainty / Growth (自然 / 意义感 / 确定性 / 成长).
 
 <!-- BEGIN:nextjs-agent-rules -->
+
 # This is NOT the Next.js you know
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 
 **Keep this block, including in commits.** It is part of the project's agent setup, maintained by `next dev` for every agent that works here. If it appears as an uncommitted change, that is intentional — commit it as-is. Do not remove it to clean up a diff; it will be regenerated.
+
 <!-- END:nextjs-agent-rules -->

--- a/tests/github-scripts/claudeDedupeWorkflow.test.ts
+++ b/tests/github-scripts/claudeDedupeWorkflow.test.ts
@@ -1,0 +1,36 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { parse } from 'yaml';
+
+describe('Claude issue dedupe workflow', () => {
+  it('keeps the dedupe preflight independent from the MCP submission handler executor', async () => {
+    const source = await readFile(
+      resolve(process.cwd(), '.github/scripts/should-run-dedupe.ts'),
+      'utf8',
+    );
+
+    expect(source).toContain('./shared/mcp-submission-classifier');
+    expect(source).not.toContain('./auto-handle-mcp-submission');
+  });
+
+  it('runs Claude only after the deterministic dedupe preflight approves the issue', async () => {
+    const workflow = parse(
+      await readFile(resolve(process.cwd(), '.github/workflows/claude-dedupe-issues.yml'), 'utf8'),
+    );
+
+    const steps = workflow.jobs['claude-dedupe-issues'].steps;
+    const preflightStep = steps.find(
+      (step: Record<string, unknown>) => step.name === 'Check whether issue should be deduped',
+    );
+    const claudeStep = steps.find(
+      (step: Record<string, unknown>) => step.name === 'Run Claude Code slash command',
+    );
+
+    expect(preflightStep).toMatchObject({
+      id: 'dedupe-preflight',
+    });
+    expect(preflightStep.run).toContain('bun run .github/scripts/should-run-dedupe.ts');
+    expect(claudeStep.if).toContain("steps.dedupe-preflight.outputs.should_dedupe == 'true'");
+  });
+});

--- a/tests/github-scripts/issueTriageAssignment.test.ts
+++ b/tests/github-scripts/issueTriageAssignment.test.ts
@@ -1,0 +1,23 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+describe('Claude issue triage assignment', () => {
+  it('routes MCP marketplace listing requests to AmAzing129 instead of arvinxx', async () => {
+    const guide = await readFile(
+      resolve(process.cwd(), '.claude/prompts/team-assignment.md'),
+      'utf8',
+    );
+
+    expect(guide).toContain('MCP marketplace listing/submission requests — @AmAzing129');
+    expect(guide).not.toContain('MCP marketplace listing/submission requests — do NOT mention');
+  });
+
+  it('does not keep MCP marketplace submissions as a no-mention example in the workflow', async () => {
+    const workflow = await readFile(
+      resolve(process.cwd(), '.github/workflows/claude-issue-triage.yml'),
+      'utf8',
+    );
+
+    expect(workflow).not.toContain('e.g. MCP marketplace listing/submission requests');
+  });
+});

--- a/tests/github-scripts/mcpSubmissionClassifier.test.ts
+++ b/tests/github-scripts/mcpSubmissionClassifier.test.ts
@@ -1,0 +1,20 @@
+import { classify } from '../../.github/scripts/shared/mcp-submission-classifier';
+
+describe('MCP submission classifier', () => {
+  it('does not classify publishing skill feedback as a new submission', () => {
+    const classification = classify(
+      '[MCP Submission] Feedback about the publishing skill',
+      `I am trying to publish my MCP server with the publishing skill from https://lobehub.com/publish-mcp/skill.md.
+
+- Repo: https://github.com/example/local-mcp-server
+- Install: npx local-mcp-server
+
+The publishing skill points me at the wrong command sequence for this server.`,
+    );
+
+    expect(classification).toMatchObject({
+      isSubmission: false,
+      reason: 'looks like CLI/publishing feedback',
+    });
+  });
+});

--- a/tests/github-scripts/shouldRunDedupe.test.ts
+++ b/tests/github-scripts/shouldRunDedupe.test.ts
@@ -1,0 +1,101 @@
+import { shouldDedupeIssue } from '../../.github/scripts/should-run-dedupe';
+
+describe('shouldDedupeIssue', () => {
+  it('skips closed issues', () => {
+    const decision = shouldDedupeIssue({
+      body: 'Already handled.',
+      labels: [],
+      state: 'closed',
+      title: 'Closed issue',
+    });
+
+    expect(decision).toEqual({
+      reason: 'Issue is not open',
+      shouldDedupe: false,
+    });
+  });
+
+  it.each(['mcp-submission', 'mcp:remote'])('skips issues already marked with %s', (label) => {
+    const decision = shouldDedupeIssue({
+      body: 'Please add this MCP server to the marketplace.',
+      labels: [{ name: label }],
+      state: 'open',
+      title: '[MCP Submission] Add my server',
+    });
+
+    expect(decision).toEqual({
+      reason: 'MCP marketplace listing request is handled by the MCP submission workflow',
+      shouldDedupe: false,
+    });
+  });
+
+  it('skips remote MCP marketplace listing requests before Claude duplicate detection runs', () => {
+    const decision = shouldDedupeIssue({
+      body: `Please add **DC Hub Intelligence** to the LobeHub MCP marketplace - a remote MCP server for real-time data-center & energy intelligence.
+
+- **Endpoint:** \`https://dchub.cloud/mcp\` (streamable-http; \`X-API-Key\` optional for the free tier)
+- **Repo:** https://github.com/azmartone67/dchub-mcp-server
+- **Docs:** https://dchub.cloud/integrations/mcp
+
+{ "mcpServers": { "dchub": { "url": "https://dchub.cloud/mcp", "transport": "http" } } }`,
+      labels: [],
+      state: 'open',
+      title: '[Request] Add DC Hub Intelligence to the MCP marketplace',
+    });
+
+    expect(decision).toMatchObject({
+      shouldDedupe: false,
+    });
+    expect(decision.reason).toContain('MCP marketplace listing request');
+  });
+
+  it('skips local MCP marketplace listing requests before Claude duplicate detection runs', () => {
+    const decision = shouldDedupeIssue({
+      body: `Please submit this MCP server to the marketplace.
+
+- Repo: https://github.com/example/local-mcp-server
+- Install: npx local-mcp-server`,
+      labels: [],
+      state: 'open',
+      title: '[MCP Submission] Local MCP server',
+    });
+
+    expect(decision).toMatchObject({
+      shouldDedupe: false,
+    });
+    expect(decision.reason).toContain('MCP marketplace listing request');
+  });
+
+  it('skips new MCP submissions that mention the market CLI discovery path', () => {
+    const decision = shouldDedupeIssue({
+      body: `Please include Cookiy MCP in the LobeHub MCP marketplace.
+
+- Repository: https://github.com/cookiy-ai/cookiy-skill
+- Install: npx cookiy-mcp
+
+I checked @lobehub/market-cli but could not find the public MCP publish command. If there is a preferred self-service submission path, I can reformat the request.`,
+      labels: [],
+      state: 'open',
+      title: '[Request] Include Cookiy MCP in the LobeHub MCP marketplace',
+    });
+
+    expect(decision).toMatchObject({
+      shouldDedupe: false,
+    });
+    expect(decision.reason).toContain('MCP marketplace listing request');
+  });
+
+  it('allows ordinary open issues to continue to Claude duplicate detection', () => {
+    const decision = shouldDedupeIssue({
+      body: 'The chat input loses focus after uploading a file.',
+      labels: [],
+      state: 'open',
+      title: 'Chat input loses focus after file upload',
+    });
+
+    expect(decision).toEqual({
+      reason: 'Issue is eligible for duplicate detection',
+      shouldDedupe: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extract MCP submission classification into a shared GitHub script helper.
- Add a deterministic dedupe preflight so MCP marketplace listing requests do not invoke Claude duplicate detection.
- Preserve publishing-flow feedback handling so `publish-mcp` / publishing skill feedback is not treated as a new submission.
- Route MCP marketplace listing operations to @AmAzing129 in triage guidance.

## Root Cause

The classifier extraction removed the previous publishing-flow feedback guard, so installable issues that were actually feedback about the publishing skill could be classified as local submissions and auto-handled by the MCP submission workflow.

## Validation

- `bunx vitest run --silent='passed-only' tests/github-scripts/mcpSubmissionClassifier.test.ts tests/github-scripts/shouldRunDedupe.test.ts tests/github-scripts/claudeDedupeWorkflow.test.ts tests/github-scripts/issueTriageAssignment.test.ts`