### PR TITLE
🐛 fix: remove route context production log

### DIFF
--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.test.ts
@@ -255,7 +255,7 @@ describe('createRouterRuntime', () => {
       );
     });
 
-    it('should log missing route attempt context outside development without filtering by model', async () => {
+    it('should not log missing route attempt context outside development', async () => {
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
       const mockChat = vi.fn().mockResolvedValue('chat-response');
 
@@ -284,26 +284,7 @@ describe('createRouterRuntime', () => {
       });
 
       expect(result).toBe('chat-response');
-      expect(consoleError).toHaveBeenCalledWith('[RouteAttemptMissingContext]', expect.any(String));
-
-      const rawDiagnostic = consoleError.mock.calls[0][1] as string;
-      const diagnostic = JSON.parse(rawDiagnostic);
-
-      expect(diagnostic).toEqual(
-        expect.objectContaining({
-          apiType: 'openai',
-          channelId: 'channel-1',
-          metadataKeys: [],
-          missingTrigger: true,
-          missingUser: true,
-          model: 'claude-3-sonnet',
-          optionUserPresent: false,
-          runtimeUserIdPresent: false,
-          toolsCount: 1,
-        }),
-      );
-      expect(rawDiagnostic).not.toContain('do-not-log');
-      expect(rawDiagnostic).not.toContain('secret_tool');
+      expect(consoleError).not.toHaveBeenCalled();
     });
 
     it('should not attach route attempt metadata for non-lobehub runtime', async () => {

--- a/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
+++ b/packages/model-runtime/src/core/RouterRuntime/createRuntime.ts
@@ -247,6 +247,7 @@ export const createRouterRuntime = ({
       const traceId = typeof metadata?.traceId === 'string' ? metadata.traceId : undefined;
 
       if (this._id !== 'lobehub' || (effectiveUserId && trigger)) return effectiveUserId;
+      if (process.env.NODE_ENV !== 'development') return effectiveUserId;
 
       const diagnostic = {
         apiType,
@@ -266,13 +267,7 @@ export const createRouterRuntime = ({
       };
 
       // Example bug: modelRuntime.chat(payload) without metadata would record trigger=null.
-      if (process.env.NODE_ENV === 'development') {
-        throw new Error(`[RouteAttemptMissingContext] ${JSON.stringify(diagnostic)}`);
-      }
-
-      console.error('[RouteAttemptMissingContext]', JSON.stringify(diagnostic));
-
-      return effectiveUserId;
+      throw new Error(`[RouteAttemptMissingContext] ${JSON.stringify(diagnostic)}`);
     }
 
     constructor(options: LobeClientOptions & Record<string, any> = {}) {


### PR DESCRIPTION
# Pull Request

## 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

## 🔗 Related Links

- Linear / GitHub issue: Fixes LOBE-11286
- Related PRs: Cloud PR to follow
- Reference docs / code / articles: N/A

## 🔀 Description of Change

Remove the production `RouteAttemptMissingContext` diagnostic log from `RouterRuntime`.

The runtime still fails fast in development when a LobeHub route attempt misses `user` or `metadata.trigger`, but production requests now proceed without emitting the temporary diagnostic log.

## 🧭 Key Decisions / Non-goals

- Keep the missing-context guard active in development only, so local regressions are still caught early.
- Do not add any cloud-specific business logic or implementation details to the open-source runtime.

## 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

### Automated Tests

- `cd lobehub/packages/model-runtime && bunx vitest run --silent='passed-only' src/core/RouterRuntime/createRuntime.test.ts`

### Manual Verification

- Reviewed the submodule diff to confirm the change is limited to generic `RouterRuntime` behavior and does not expose cloud-only logic.

### Post-Deploy Verification

- Confirm production logs no longer contain temporary `[RouteAttemptMissingContext]` entries from router runtime calls.

## 📸 Screenshots / Videos

N/A

## 🚀 Rollout / Deployment Checklist

- [ ] Environment variables: N/A
- [ ] Redis / Edge Config / feature flags: N/A
- [ ] Database migration or data backfill: N/A
- [ ] Third-party console changes: N/A
- [x] Rollback plan: revert this PR if the development-only guard needs to be restored differently.

## 📝 Additional Information

Cloud-side context propagation and environment-variable model configuration are handled in the follow-up cloud PR.
