### PR TITLE
🐛 fix(skill): surface connect status & gate detail on connected connectors

### DIFF
--- a/src/routes/(main)/settings/skill/features/ComposioSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/ComposioSkillItem.tsx
@@ -11,9 +11,10 @@ import {
   Tooltip,
 } from '@lobehub/ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
-import { Badge, Button } from 'antd';
+import { Button } from 'antd';
 import { cssVar } from 'antd-style';
 import {
+  CircleCheck,
   Loader2,
   MoreHorizontalIcon,
   RotateCcw,
@@ -21,7 +22,7 @@ import {
   Trash2,
   Unplug,
 } from 'lucide-react';
-import { memo, type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import NavItem from '@/features/NavPanel/components/NavItem';
@@ -340,21 +341,54 @@ const ComposioSkillItem = memo<ComposioSkillItemProps>(
     const isPending = server?.status === ComposioServerStatus.PENDING_AUTH;
     const isError = server?.status === ComposioServerStatus.ERROR;
 
-    if (onSelect) {
-      let badge: ReactNode;
-      if (isPending) {
-        badge = (
-          <Center width={18}>
-            <Badge status="warning" />
-          </Center>
-        );
-      } else if (isError) {
-        badge = (
-          <Center width={18}>
-            <Badge status="error" />
-          </Center>
+    // Compact connect/status control for the left-list (NavItem) row. Mirrors the
+    // ChatInput skills dropdown UX: connected → green check; pending/errored →
+    // Re-authorize; not connected → Connect. All open the OAuth flow inline so
+    // users can tell what is connected instead of hitting a blank detail panel.
+    const renderNavExtra = () => {
+      if (isConnecting || isWaitingAuth) {
+        return <Button disabled icon={<Icon spin icon={Loader2} />} size="small" type="text" />;
+      }
+      if (isConnected) {
+        return (
+          <Tooltip title={t('tools.composio.connected')}>
+            <Center width={20}>
+              <Icon icon={CircleCheck} size={16} style={{ color: cssVar.colorSuccess }} />
+            </Center>
+          </Tooltip>
         );
       }
+      if (isPending || isError) {
+        return (
+          <Tooltip title={!canCreate ? createReason : editReason}>
+            <Button
+              disabled={!canCreate || !canEdit}
+              icon={<Icon icon={SquareArrowOutUpRight} />}
+              size="small"
+              type="text"
+              onClick={handleReauthorize}
+            >
+              {t('tools.composio.reauthorize', { defaultValue: 'Re-authorize' })}
+            </Button>
+          </Tooltip>
+        );
+      }
+      return (
+        <Tooltip title={!canCreate ? createReason : editReason}>
+          <Button
+            disabled={!canCreate || !canEdit}
+            icon={<Icon icon={SquareArrowOutUpRight} />}
+            size="small"
+            type="text"
+            onClick={handleConnect}
+          >
+            {t('tools.composio.connect', { defaultValue: 'Connect' })}
+          </Button>
+        </Tooltip>
+      );
+    };
+
+    if (onSelect) {
       const renderNavIcon = () => {
         const { icon, label } = serverType;
         if (typeof icon === 'string') return <Avatar alt={label} avatar={icon} size={18} />;
@@ -363,11 +397,15 @@ const ComposioSkillItem = memo<ComposioSkillItemProps>(
       return (
         <NavItem
           active={isSelected}
-          extra={badge}
+          extra={renderNavExtra()}
           icon={renderNavIcon}
           title={serverType.label}
           titleColor={!isConnected ? cssVar.colorTextDescription : undefined}
-          onClick={onSelect}
+          // Only connected connectors open the detail panel. When not active
+          // (disconnected / pending / error) the row is inert and the only
+          // affordance is the inline Connect / Re-authorize button — otherwise
+          // clicking opens a blank detail panel that reads as a bug.
+          onClick={isConnected ? onSelect : undefined}
         />
       );
     }

--- a/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
@@ -11,9 +11,15 @@ import {
   Tooltip,
 } from '@lobehub/ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
-import { Badge, Button } from 'antd';
+import { Button } from 'antd';
 import { cssVar } from 'antd-style';
-import { Loader2, MoreHorizontalIcon, SquareArrowOutUpRight, Unplug } from 'lucide-react';
+import {
+  CircleCheck,
+  Loader2,
+  MoreHorizontalIcon,
+  SquareArrowOutUpRight,
+  Unplug,
+} from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -284,7 +290,38 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(
     };
 
     const isConnected = server?.status === LobehubSkillStatus.CONNECTED;
-    const isError = server?.status === LobehubSkillStatus.ERROR;
+
+    // Compact connect/status control for the left-list (NavItem) row. Mirrors the
+    // ChatInput skills dropdown UX: connected → green check; otherwise a Connect
+    // button that opens the OAuth flow inline, so users can tell what is connected
+    // and aren't left staring at a blank detail panel wondering if it's a bug.
+    const renderNavExtra = () => {
+      if (isConnecting || isWaitingAuth) {
+        return <Button disabled icon={<Icon spin icon={Loader2} />} size="small" type="text" />;
+      }
+      if (isConnected) {
+        return (
+          <Tooltip title={t('tools.lobehubSkill.connected', { defaultValue: 'Connected' })}>
+            <Center width={20}>
+              <Icon icon={CircleCheck} size={16} style={{ color: cssVar.colorSuccess }} />
+            </Center>
+          </Tooltip>
+        );
+      }
+      return (
+        <Tooltip title={!canCreate ? createReason : editReason}>
+          <Button
+            disabled={!canCreate || !canEdit}
+            icon={<Icon icon={SquareArrowOutUpRight} />}
+            size="small"
+            type="text"
+            onClick={handleConnect}
+          >
+            {t('tools.lobehubSkill.connect')}
+          </Button>
+        </Tooltip>
+      );
+    };
 
     if (onSelect) {
       const renderNavIcon = () => {
@@ -295,17 +332,14 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(
       return (
         <NavItem
           active={isSelected}
+          extra={renderNavExtra()}
           icon={renderNavIcon}
           title={provider.label}
           titleColor={!isConnected ? cssVar.colorTextDescription : undefined}
-          extra={
-            isError ? (
-              <Center width={18}>
-                <Badge status="error" />
-              </Center>
-            ) : undefined
-          }
-          onClick={onSelect}
+          // Only connected connectors open the detail panel. When disconnected,
+          // the row is inert and the only affordance is the inline Connect button —
+          // otherwise clicking opens a blank detail panel that reads as a bug.
+          onClick={isConnected ? onSelect : undefined}
         />
       );
     }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- N/A -->

#### 🔀 Description of Change

On `/settings/skill`, recommended OAuth connectors — LobeHub skills (e.g. **PostHog**) and Composio apps — render in the left list even when the user has never connected them. In the left-list (`NavItem`) layout, the Connect affordance and connection status were **hidden**, so a disconnected row only opened a **blank detail panel**, which reads as a bug.

This PR surfaces the connection state directly in the list, mirroring the ChatInput skills dropdown UX:

- **Inline status/action** in the `NavItem` `extra` slot:
  - Connected → green check (`CircleCheck`)
  - Disconnected → **Connect** button
  - Composio pending / error → **Re-authorize** button
  - All reuse the existing OAuth flow (`handleConnect` / `handleReauthorize`) already present in the components — no new connect logic.
- **Row is inert when not connected**: clicking a disconnected / pending / errored row no longer opens a blank detail panel. Only the inline Connect / Re-authorize button is actionable. Connected rows open the detail panel as before.

Files:
- `src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx`
- `src/routes/(main)/settings/skill/features/ComposioSkillItem.tsx`

#### 🧪 How to Test

Open **Settings → Skills → Connectors** with at least one connected and one never-connected recommended connector (e.g. PostHog):

- Never-connected rows show a **Connect** button; clicking the row body does nothing; clicking **Connect** opens the OAuth window.
- Composio connections in pending/error state show **Re-authorize**.
- Connected rows show a green check and still open the detail panel on click.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Disconnected row → click → blank detail panel | Disconnected row shows inline **Connect**; row body inert |

#### 📝 Additional Information

No breaking changes. Reuses existing store actions (`getLobehubSkillAuthorizeUrl`, `createComposioConnection`, `reauthorizeComposioConnection`) and locale keys (`tools.lobehubSkill.*`, `tools.composio.*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)