### PR TITLE
🐛 fix(agent-runtime): store per-step trace usage

### DIFF
--- a/apps/server/src/services/agentRuntime/OperationTraceRecorder.ts
+++ b/apps/server/src/services/agentRuntime/OperationTraceRecorder.ts
@@ -347,8 +347,8 @@ export class OperationTraceRecorder {
       toolsetBaseline: stepIndex === 0 ? agentState?.operationToolSet : undefined,
       toolsCalling: presentation.toolsCalling,
       toolsResult: presentation.toolsResult,
-      totalCost: presentation.totalCost,
-      totalTokens: presentation.totalTokens,
+      totalCost: presentation.stepCost ?? 0,
+      totalTokens: presentation.stepTotalTokens ?? 0,
     };
   }
 }

--- a/apps/server/src/services/agentRuntime/__tests__/OperationTraceRecorder.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/OperationTraceRecorder.test.ts
@@ -186,6 +186,37 @@ describe('OperationTraceRecorder', () => {
       const step = store.savePartial.mock.calls[0][1].steps[0];
       expect(step.activatedStepToolsDelta).toEqual([{ id: 'b' }, { id: 'c' }]);
     });
+
+    it('stores per-step usage on each step instead of cumulative operation totals', async () => {
+      store.loadPartial.mockResolvedValue({ startedAt: 1, steps: [] });
+
+      await recorder.appendStep('op-usage', {
+        afterStepSignalEvents: [],
+        agentState: { messages: [] },
+        beforeStepSignalEvents: [],
+        currentContext: { phase: 'user_input' },
+        externalRetryCount: 0,
+        presentation: buildPresentation({
+          stepCost: 0.02,
+          stepInputTokens: 30,
+          stepOutputTokens: 20,
+          stepTotalTokens: 50,
+          totalCost: 0.12,
+          totalInputTokens: 300,
+          totalOutputTokens: 200,
+          totalTokens: 500,
+        }),
+        startedAt: 500,
+        stepIndex: 3,
+        stepResult: { events: [], newState: { activatedStepTools: [], messages: [] } },
+      });
+
+      const step = store.savePartial.mock.calls[0][1].steps[0];
+      expect(step.inputTokens).toBe(30);
+      expect(step.outputTokens).toBe(20);
+      expect(step.totalCost).toBe(0.02);
+      expect(step.totalTokens).toBe(50);
+    });
   });
 
   describe('finalize', () => {

--- a/packages/agent-tracing/src/types.ts
+++ b/packages/agent-tracing/src/types.ts
@@ -2,12 +2,7 @@ export interface ExecutionSnapshot {
   agentId?: string;
   completedAt?: number;
   completionReason?:
-    | 'done'
-    | 'error'
-    | 'interrupted'
-    | 'max_steps'
-    | 'cost_limit'
-    | 'waiting_for_human';
+    'done' | 'error' | 'interrupted' | 'max_steps' | 'cost_limit' | 'waiting_for_human';
   error?: { type: string; message: string };
   externalRetryCount?: number;
   model?: string;
@@ -117,9 +112,10 @@ export interface StepSnapshot {
     isSuccess?: boolean;
     output?: string;
   }>;
+  // Cost incurred by this step, not the whole operation.
   totalCost: number;
 
-  // Cumulative
+  // Total tokens consumed by this step, not the whole operation.
   totalTokens: number;
 }
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No linked issue found.

#### 🔀 Description of Change

Persist each trace step's own usage values instead of copying cumulative operation totals into every `StepSnapshot`.

- Store `presentation.stepCost` and `presentation.stepTotalTokens` for step-level totals.
- Keep operation-level totals in the finalized snapshot summary.
- Clarify the `StepSnapshot` type comments for step-level cost and token totals.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bunx vitest run --silent='passed-only' apps/server/src/services/agentRuntime/__tests__/OperationTraceRecorder.test.ts`

#### 📸 Screenshots / Videos

N/A — backend trace persistence fix.

#### 📝 Additional Information

Opened as a standalone fix from `canary`; it does not depend on #16581.