### PR TITLE
📝 docs(skills): normalize skill metadata wording

### DIFF
--- a/.agents/skills/agent-testing/SKILL.md
+++ b/.agents/skills/agent-testing/SKILL.md
@@ -18,7 +18,7 @@ One skill for all agentic end-to-end testing — local-first today, designed to
 also run as full cloud automation. Every test session follows the same
 contract:
 
-```
+```text
 Step -2: Read the two living logs → Step -1: Plan approval → Step 0: Env + Auth → Step 1: Pick surface → Step 2: Run → Step 3: Structured report → Step 4: Publish to LobeHub → Step 5: Teardown
 ```
 
@@ -568,7 +568,7 @@ Skip teardown only when the user explicitly wants the environment left up (e.g.
 
 ## Directory map
 
-```
+```text
 agent-testing/
 ├── SKILL.md            # this router
 ├── cli/index.md        # backend verification via the LobeHub CLI

--- a/.agents/skills/typescript/SKILL.md
+++ b/.agents/skills/typescript/SKILL.md
@@ -47,7 +47,7 @@ user-invocable: false
 - Use consistent, descriptive naming; avoid obscure abbreviations
 - Replace magic numbers/strings with well-named constants
 - Defer formatting to tooling
-- Prefer **named exports** over `export default` — keeps refactor renames and IDE auto-import in sync, and avoids the `default` re-naming drift you get with `import Foo from './foo'`. Reserve `export default` for files where the framework requires it (Next.js page/route/layout, React.lazy targets, config files like `vitest.config.ts`)
+- Prefer **named exports** over `export default` — keeps refactor renames and IDE auto-import in sync, and avoids the `default` re-naming drift you get with `import Foo from './foo'`. Reserve `export default` for files where the framework requires it (Next.js page/route/layout, React.lazy targets, config files like `vitest.config.ts`). The codebase still has many `export default` occurrences — that's historical debt, not a pattern to copy; do not model new code on existing `export default` usage outside the framework-required cases above
 - Before adding local helpers for common guards/parsing/normalization (record checks, string extraction, empty-string handling, timing helpers, JSON-safe utilities, etc.), search `packages/utils` first. If the helper already exists or clearly belongs there, import it from `@lobechat/utils` (or the relevant `@lobechat/utils/*` subpath) instead of duplicating tiny helpers across feature files.
 
 ## UI and Theming

--- a/.agents/skills/ux/SKILL.md
+++ b/.agents/skills/ux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ux
-description: 'LobeHub product design values / principles / checklists. Load this skill whenever the work touches user-interface features or implementation — designing or building any user-facing flow — to get better UX results.'
+description: 'LobeHub product design values / principles / checklists. Use whenever the work touches user-interface features or implementation — designing or building any user-facing flow — to get better UX results.'
 user-invocable: false
 ---
 

--- a/packages/locales/src/default/models.ts
+++ b/packages/locales/src/default/models.ts
@@ -12,31 +12,25 @@ LOBE_DEFAULT_MODEL_LIST.forEach((model) => {
 const lobeHubOnlineModelLocales = {
   'claude-sonnet-5.description':
     "Claude Sonnet 5 is Anthropic's most agentic Sonnet model, built for sustained coding, tool use, and long-context workflows with Sonnet-tier speed and efficiency.",
-  'gemini-3.1-flash-lite-image.description':
-    "Gemini 3.1 Flash Lite Image (Nano Banana 2 Lite) is Google's fastest and most cost-efficient image generation model, built for high-volume generation and editing.",
-  'grok-4.20-beta-0309-reasoning.description':
-    'Intelligent, blazing-fast model that reasons before responding',
-  'grok-4.20-beta-0309-non-reasoning.description': 'A non-reasoning variant for simple use cases',
-  'kimi-k2-0905-preview.description':
-    'kimi-k2 is an MoE foundation model with strong coding and agent capabilities (1T total params, 32B active). Based on kimi-k2-0711-preview, with enhanced agentic coding abilities and better context understanding.',
-  'kimi-k2-turbo-preview.description':
-    'High-speed version of kimi-k2, always aligned with the latest kimi-k2. Same model parameters, output speed up to 60–100 tokens/sec.',
-  'kimi-k2-thinking-turbo.description':
-    'High-speed version of kimi-k2-thinking, suitable for scenarios requiring both deep reasoning and extremely fast responses.',
-  'lobehub-glm-5.2-fast.description':
-    'Fast variant of GLM-5.2 with substantially lower latency. Same capabilities as GLM-5.2 — costs more, but responds much faster.',
-  'gemini-3.1-flash-lite-image:image.description':
-    "Gemini 3.1 Flash Lite Image (Nano Banana 2 Lite) is Google's fastest and most cost-efficient image generation model, built for high-volume generation and editing.",
-  'seedream-5-0-260128.description':
-    'ByteDance-Seedream-5.0-lite by BytePlus features web-retrieval-augmented generation for real-time information, enhanced complex prompt interpretation, and improved reference consistency for professional visual creation.',
-  'fal-ai/bytedance/seedream/v4.5.description':
-    'Seedream 4.5, built by ByteDance Seed team, supports multi-image editing and composition. Features enhanced subject consistency, precise instruction following, spatial logic understanding, aesthetic expression, poster layout and logo design with high-precision text-image rendering.',
   'dreamina-seedance-2-0-260128.description':
     'Seedance 2.0 by ByteDance is the most powerful video generation model, supporting multimodal reference video generation, video editing, video extension, text-to-video, and image-to-video with synchronized audio.',
   'dreamina-seedance-2-0-fast-260128.description':
     'Seedance 2.0 Fast by ByteDance offers the same capabilities as Seedance 2.0 with faster generation speeds at a more competitive price.',
+  'fal-ai/bytedance/seedream/v4.5.description':
+    'Seedream 4.5, built by ByteDance Seed team, supports multi-image editing and composition. Features enhanced subject consistency, precise instruction following, spatial logic understanding, aesthetic expression, poster layout and logo design with high-precision text-image rendering.',
+  'gemini-3.1-flash-lite-image:image.description':
+    "Gemini 3.1 Flash Lite Image (Nano Banana 2 Lite) is Google's fastest and most cost-efficient image generation model, built for high-volume generation and editing.",
+  'gemini-3.1-flash-lite-image.description':
+    "Gemini 3.1 Flash Lite Image (Nano Banana 2 Lite) is Google's fastest and most cost-efficient image generation model, built for high-volume generation and editing.",
+  'grok-4.20-beta-0309-non-reasoning.description': 'A non-reasoning variant for simple use cases',
+  'grok-4.20-beta-0309-reasoning.description':
+    'Intelligent, blazing-fast model that reasons before responding',
+  'lobehub-glm-5.2-fast.description':
+    'Fast variant of GLM-5.2 with substantially lower latency. Same capabilities as GLM-5.2 — costs more, but responds much faster.',
   'seedance-1-5-pro-251215.description':
     'Seedance 1.5 Pro by ByteDance supports text-to-video, image-to-video (first frame, first+last frame), and audio generation synchronized with visuals.',
+  'seedream-5-0-260128.description':
+    'ByteDance-Seedream-5.0-lite by BytePlus features web-retrieval-augmented generation for real-time information, enhanced complex prompt interpretation, and improved reference consistency for professional visual creation.',
 } satisfies Record<`${string}.description`, string>;
 
 Object.assign(locales, lobeHubOnlineModelLocales);


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

Docs-only cleanup of skill metadata wording:

- `ux/SKILL.md`: switch the description from legacy `Load this skill whenever ...` to the standard `Use whenever ...` routing phrasing, matching the repo-wide skill description convention.
- `agent-testing/SKILL.md`: add `text` language tags to bare fenced code blocks and align inline comments in the QStash snippet.

No behavior change — skill routing hints and docs formatting only.

#### 🧪 How to Test

- [ ] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Docs-only change; the cloud repo's `bun run skills:check` inventory check passes against these descriptions.

#### 📸 Screenshots / Videos

N/A — no UI changes.

#### 📝 Additional Information

None.