### PR TITLE
🐛 fix(search): migrate Kagi search from deprecated API v0 to v1

### DIFF
--- a/apps/server/src/services/search/impls/kagi/index.ts
+++ b/apps/server/src/services/search/impls/kagi/index.ts
@@ -22,8 +22,7 @@ export class KagiImpl implements SearchServiceImpl {
   }
 
   private get baseUrl(): string {
-    // Assuming the base URL is consistent with the crawl endpoint
-    return 'https://kagi.com/api/v0';
+    return 'https://kagi.com/api/v1';
   }
 
   async query(query: string, params: SearchParams = {}): Promise<UniformSearchResponse> {
@@ -32,26 +31,23 @@ export class KagiImpl implements SearchServiceImpl {
 
     const body: KagiSearchParameters = {
       limit: 15,
-      q: query,
+      query,
     };
 
     log('Constructed request body: %o', body);
-
-    const searchParams = new URLSearchParams();
-    for (const [key, value] of Object.entries(body)) {
-      searchParams.append(key, String(value));
-    }
 
     let response: Response;
     const startAt = Date.now();
     let costTime: number;
     try {
       log('Sending request to endpoint: %s', endpoint);
-      response = await fetch(`${endpoint}?${searchParams.toString()}`, {
+      response = await fetch(endpoint, {
+        body: JSON.stringify(body),
         headers: {
-          Authorization: this.apiKey ? `Bot ${this.apiKey}` : '',
+          'Authorization': this.apiKey ? `Bearer ${this.apiKey}` : '',
+          'Content-Type': 'application/json',
         },
-        method: 'GET',
+        method: 'POST',
       });
       log('Received response with status: %d', response.status);
       costTime = Date.now() - startAt;
@@ -82,17 +78,19 @@ export class KagiImpl implements SearchServiceImpl {
 
       log('Parsed Kagi response: %o', kagiResponse);
 
-      const mappedResults = (kagiResponse.data || []).map(
-        (result): UniformSearchResult => ({
-          category: 'general', // Default category
-          content: result.snippet || '', // Prioritize content
-          engines: ['kagi'], // Use 'kagi' as the engine name
-          parsedUrl: result.url ? new URL(result.url).hostname : '', // Basic URL parsing
-          score: 1, // Default score to 1
-          title: result.title || '',
-          url: result.url,
-        }),
-      );
+      const mappedResults = (kagiResponse.data?.search || [])
+        .filter((result) => !!result.url)
+        .map(
+          (result): UniformSearchResult => ({
+            category: 'general', // Default category
+            content: result.snippet || '', // Prioritize content
+            engines: ['kagi'], // Use 'kagi' as the engine name
+            parsedUrl: result.url ? new URL(result.url).hostname : '', // Basic URL parsing
+            score: 1, // Default score to 1
+            title: result.title || '',
+            url: result.url,
+          }),
+        );
 
       log('Mapped %d results to SearchResult format', mappedResults.length);
 

--- a/apps/server/src/services/search/impls/kagi/type.ts
+++ b/apps/server/src/services/search/impls/kagi/type.ts
@@ -1,24 +1,28 @@
 export interface KagiSearchParameters {
   limit?: number;
-  q: string;
+  query: string;
 }
 
-interface KagiThumbnail {
+interface KagiSearchImage {
   height?: number | null;
-  url: string;
+  url?: string;
   width?: number | null;
 }
 
-interface KagiData {
-  published?: number;
+interface KagiSearchResult {
+  image?: KagiSearchImage;
+  props?: Record<string, unknown>;
   snippet?: string;
-  t: number;
-  thumbnail?: KagiThumbnail;
+  time?: string;
   title: string;
   url: string;
 }
 
+interface KagiData {
+  infobox?: unknown;
+  search: KagiSearchResult[];
+}
+
 export interface KagiResponse {
-  data: KagiData[];
-  meta?: any;
+  data: KagiData;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lobehub/lobehub",
-  "version": "2.2.13",
+  "version": "2.2.14",
   "description": "LobeHub - an open-source,comprehensive AI Agent framework that supports speech synthesis, multimodal, and extensible Function Call plugin system. Supports one-click free deployment of your private ChatGPT/LLM web application.",
   "keywords": [
     "framework",


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No exact open issue; surfaces as "web search silently fails / returns nothing" on self-hosted deployments using a Kagi key. -->

#### 🔀 Description of Change

The Kagi search provider targets the **deprecated `api/v0`** endpoint using `Authorization: Bot <key>` over `GET`. Kagi has retired v0 for new keys — any key issued through the current Kagi Search API portal only works on **`api/v1`**, so self-hosted deployments get `401 Unauthorized` and web search silently returns no results.

This migrates the provider to `api/v1`:

- **Endpoint**: `https://kagi.com/api/v0` → `https://kagi.com/api/v1`
- **Auth**: `Authorization: Bot <key>` → `Authorization: Bearer <key>`
- **Method / body**: `GET ?q=…` querystring → `POST` with JSON body `{ query, limit }`
- **Response parsing**: v1 nests results under `data.search[]` (v0 returned a flat `data[]`); entries without a `url` (related-search suggestions) are now filtered out
- Types in `type.ts` updated to the v1 response shape (`KagiData.search`, optional `meta`)

No behavior change for the mapped `UniformSearchResult` output.

#### 🧪 How to Test

- [x] Tested locally

Against a live Kagi v1 key on a self-hosted deployment:

- Before: web search → `401 Unauthorized`, no results.
- After: `POST https://kagi.com/api/v1/search` → `200`, results returned and mapped correctly (verified end-to-end with a "Hacker News" query returning 15 results).

Test prompt: ask the assistant to search the web (e.g. *"latest Hacker News headlines"*) with `SEARCH_PROVIDERS=kagi` + a valid `KAGI_API_KEY`.

#### 📸 Screenshots / Videos

N/A — server-side search provider change, no UI.

#### 📝 Additional Information

No breaking changes for users: `KAGI_API_KEY` env var is unchanged. Users must supply a **v1** key (from the Kagi API portal); v0 keys are no longer issued by Kagi.
