### PR TITLE
✨ feat(desktop): background process tracker — Tier 1 UI + IPC

### DIFF
--- a/apps/desktop/src/main/controllers/ShellCommandCtr.ts
+++ b/apps/desktop/src/main/controllers/ShellCommandCtr.ts
@@ -1,10 +1,14 @@
+import os from 'node:os';
+
 import type {
   GetCommandOutputParams,
   GetCommandOutputResult,
   KillCommandParams,
   KillCommandResult,
+  KillProcessParams,
   RunCommandParams,
   RunCommandResult,
+  ShellProcessMeta,
 } from '@lobechat/electron-client-ipc';
 import { runCommand } from '@lobechat/local-file-shell';
 
@@ -17,6 +21,15 @@ const logger = createLogger('controllers:ShellCommandCtr');
 
 /** Prefix for a simple `lh`/`lobe`/`lobehub` invocation (keyword + boundary, args via slice). */
 const SIMPLE_LH_PREFIX = /^\s*(?:lh|lobe|lobehub)(?=\s|$)/;
+
+const MAX_UI_COMMAND_LENGTH = 120;
+
+const redactPath = (text: string) => text.replaceAll(os.homedir(), '~');
+
+const redactCommand = (command: string) =>
+  redactPath(command)
+    .replaceAll(/\b(token|key|secret|password|pwd)\s*[:=]\s*\S+/gi, '$1=***')
+    .slice(0, MAX_UI_COMMAND_LENGTH);
 
 export default class ShellCommandCtr extends ControllerModule {
   static override readonly groupName = 'shellCommand';
@@ -55,5 +68,31 @@ export default class ShellCommandCtr extends ControllerModule {
   @IpcMethod()
   async handleKillCommand({ shell_id }: KillCommandParams): Promise<KillCommandResult> {
     return this.processManager.killTree(shell_id);
+  }
+
+  @IpcMethod()
+  listProcesses(): ShellProcessMeta[] {
+    return this.processManager.list().map((meta) => ({
+      command: redactCommand(meta.command),
+      cwd: meta.cwd ? redactPath(meta.cwd) : undefined,
+      pid: meta.pid,
+      processId: meta.processId,
+      runInBackground: meta.runInBackground,
+      shellId: meta.shellId,
+      startedAt: meta.startedAt,
+    }));
+  }
+
+  @IpcMethod()
+  async killProcess({ force, pid }: KillProcessParams): Promise<KillCommandResult> {
+    return this.processManager.killByPid(pid, force);
+  }
+
+  afterAppReady() {
+    this.processManager.subscribe(() => {
+      this.app.browserManager.broadcastToAllWindows('shellProcessesChanged', {
+        processes: this.listProcesses(),
+      });
+    });
   }
 }

--- a/apps/desktop/src/main/controllers/__tests__/ShellCommandCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/ShellCommandCtr.test.ts
@@ -1,3 +1,5 @@
+import os from 'node:os';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { App } from '@/core/App';
@@ -40,13 +42,34 @@ const mockCliCtr = {
 
 const mockShellProcessManager = {
   getOutput: vi.fn(),
+  killByPid: vi.fn(),
   killTree: vi.fn(),
+  list: vi.fn(() => []),
+  subscribe: vi.fn(),
+};
+
+const mockBrowserManager = {
+  broadcastToAllWindows: vi.fn(),
 };
 
 const mockApp = {
+  browserManager: mockBrowserManager,
   getController: vi.fn((c: unknown) => (c === CliCtr ? mockCliCtr : undefined)),
   shellProcessManager: mockShellProcessManager,
 } as unknown as App;
+
+const makeMeta = (overrides: Record<string, unknown> = {}) => ({
+  command: 'sleep 60',
+  cwd: '/workspace',
+  exitCode: null,
+  pgid: 100,
+  pid: 100,
+  processId: 'uuid-1',
+  runInBackground: true,
+  shellId: 'sh-1',
+  startedAt: 1_000,
+  ...overrides,
+});
 
 describe('ShellCommandCtr (thin wrapper)', () => {
   let ctr: ShellCommandCtr;
@@ -112,5 +135,95 @@ describe('ShellCommandCtr (thin wrapper)', () => {
     expect(mockRunCommand).not.toHaveBeenCalled();
     expect(mockShellProcessManager.getOutput).not.toHaveBeenCalled();
     expect(mockShellProcessManager.killTree).not.toHaveBeenCalled();
+  });
+
+  describe('listProcesses', () => {
+    it('maps manager metas to the IPC shape without pgid/exitCode', () => {
+      mockShellProcessManager.list.mockReturnValue([makeMeta()]);
+
+      expect(ctr.listProcesses()).toEqual([
+        {
+          command: 'sleep 60',
+          cwd: '/workspace',
+          pid: 100,
+          processId: 'uuid-1',
+          runInBackground: true,
+          shellId: 'sh-1',
+          startedAt: 1_000,
+        },
+      ]);
+    });
+
+    it('replaces the home directory with ~ in command and cwd', () => {
+      const home = os.homedir();
+      mockShellProcessManager.list.mockReturnValue([
+        makeMeta({ command: `tail -f ${home}/logs/app.log`, cwd: `${home}/projects` }),
+      ]);
+
+      const [meta] = ctr.listProcesses();
+
+      expect(meta.command).toBe('tail -f ~/logs/app.log');
+      expect(meta.cwd).toBe('~/projects');
+    });
+
+    it('masks secret-looking arguments in the command', () => {
+      mockShellProcessManager.list.mockReturnValue([
+        makeMeta({ command: 'curl --header token=abc123 --data password: hunter2 example.com' }),
+      ]);
+
+      const [meta] = ctr.listProcesses();
+
+      expect(meta.command).toContain('token=***');
+      expect(meta.command).toContain('password=***');
+      expect(meta.command).not.toContain('abc123');
+      expect(meta.command).not.toContain('hunter2');
+    });
+
+    it('caps the command at 120 characters', () => {
+      mockShellProcessManager.list.mockReturnValue([makeMeta({ command: 'x'.repeat(500) })]);
+
+      expect(ctr.listProcesses()[0].command).toHaveLength(120);
+    });
+
+    it('keeps cwd undefined when absent', () => {
+      mockShellProcessManager.list.mockReturnValue([makeMeta({ cwd: undefined })]);
+
+      expect(ctr.listProcesses()[0].cwd).toBeUndefined();
+    });
+  });
+
+  describe('killProcess', () => {
+    it('delegates to app.shellProcessManager.killByPid', async () => {
+      mockShellProcessManager.killByPid.mockResolvedValue({ success: true });
+
+      const result = await ctr.killProcess({ force: true, pid: 4242 });
+
+      expect(mockShellProcessManager.killByPid).toHaveBeenCalledWith(4242, true);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('afterAppReady', () => {
+    it('subscribes to process changes and broadcasts the redacted list', () => {
+      let listener: (() => void) | undefined;
+      mockShellProcessManager.subscribe.mockImplementation((fn: () => void) => {
+        listener = fn;
+        return () => {};
+      });
+      mockShellProcessManager.list.mockReturnValue([makeMeta()]);
+
+      ctr.afterAppReady();
+      expect(mockShellProcessManager.subscribe).toHaveBeenCalledTimes(1);
+      expect(mockBrowserManager.broadcastToAllWindows).not.toHaveBeenCalled();
+
+      listener!();
+
+      expect(mockBrowserManager.broadcastToAllWindows).toHaveBeenCalledWith(
+        'shellProcessesChanged',
+        {
+          processes: [expect.objectContaining({ command: 'sleep 60', pid: 100, shellId: 'sh-1' })],
+        },
+      );
+    });
   });
 });

--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -53,6 +53,8 @@
   "audioPlayer.play": "Play audio",
   "availableAgents": "Available Agents",
   "backToBottom": "Jump to latest",
+  "backgroundProcesses.stop": "End process",
+  "backgroundProcesses.title": "Background processes",
   "beforeUnload.confirmLeave": "A request is still running. Leave anyway?",
   "builtinCopilot": "Built-in Copilot",
   "chatList.expandMessage": "Expand Message",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -53,6 +53,8 @@
   "audioPlayer.play": "播放音频",
   "availableAgents": "可用助理",
   "backToBottom": "跳转到最新",
+  "backgroundProcesses.stop": "结束进程",
+  "backgroundProcesses.title": "后台进程",
   "beforeUnload.confirmLeave": "你有正在生成中的请求，确定要离开吗？",
   "builtinCopilot": "内置 Copilot",
   "chatList.expandMessage": "展开消息",

--- a/packages/electron-client-ipc/src/events/index.ts
+++ b/packages/electron-client-ipc/src/events/index.ts
@@ -4,6 +4,7 @@ import type { NavigationBroadcastEvents } from './navigation';
 import type { ProtocolBroadcastEvents } from './protocol';
 import type { RemoteServerBroadcastEvents } from './remoteServer';
 import type { ScreenCaptureBroadcastEvents } from './screenCapture';
+import type { ShellCommandBroadcastEvents } from './shellCommand';
 import type { SystemBroadcastEvents } from './system';
 import type { TopicPopupBroadcastEvents } from './topicPopup';
 import type { AutoUpdateBroadcastEvents } from './update';
@@ -21,6 +22,7 @@ export interface MainBroadcastEvents
     NavigationBroadcastEvents,
     RemoteServerBroadcastEvents,
     ScreenCaptureBroadcastEvents,
+    ShellCommandBroadcastEvents,
     SystemBroadcastEvents,
     TopicPopupBroadcastEvents,
     ZoomBroadcastEvents,

--- a/packages/electron-client-ipc/src/events/shellCommand.ts
+++ b/packages/electron-client-ipc/src/events/shellCommand.ts
@@ -1,0 +1,5 @@
+import type { ShellProcessMeta } from '../types/shellCommand';
+
+export interface ShellCommandBroadcastEvents {
+  shellProcessesChanged: (params: { processes: ShellProcessMeta[] }) => void;
+}

--- a/packages/electron-client-ipc/src/types/index.ts
+++ b/packages/electron-client-ipc/src/types/index.ts
@@ -10,6 +10,7 @@ export * from './proxy';
 export * from './proxyTRPCRequest';
 export * from './route';
 export * from './screenCapture';
+export * from './shellCommand';
 export * from './shortcut';
 export * from './system';
 export * from './topicPopup';

--- a/packages/electron-client-ipc/src/types/shellCommand.ts
+++ b/packages/electron-client-ipc/src/types/shellCommand.ts
@@ -1,0 +1,14 @@
+export interface ShellProcessMeta {
+  command: string;
+  cwd?: string;
+  pid?: number;
+  processId: string;
+  runInBackground: boolean;
+  shellId: string;
+  startedAt: number;
+}
+
+export interface KillProcessParams {
+  force?: boolean;
+  pid: number;
+}

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -61,6 +61,8 @@ export default {
   'artifact.unknownTitle': 'Untitled Work',
   'availableAgents': 'Available Agents',
   'backToBottom': 'Jump to latest',
+  'backgroundProcesses.stop': 'End process',
+  'backgroundProcesses.title': 'Background processes',
   'beforeUnload.confirmLeave': 'A request is still running. Leave anyway?',
   'builtinCopilot': 'Built-in Copilot',
   'chatList.expandMessage': 'Expand Message',

--- a/src/features/ChatInput/ControlBar/BackgroundProcessesIndicator/index.tsx
+++ b/src/features/ChatInput/ControlBar/BackgroundProcessesIndicator/index.tsx
@@ -1,0 +1,174 @@
+import { type ShellProcessMeta, useWatchBroadcast } from '@lobechat/electron-client-ipc';
+import { ActionIcon, Flexbox, Icon, Tooltip } from '@lobehub/ui';
+import { Button, Popover } from '@lobehub/ui/base-ui';
+import { createStaticStyles } from 'antd-style';
+import { Activity, X } from 'lucide-react';
+import { memo, useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import useSWR from 'swr';
+
+import { shellCommandService } from '@/services/electron/shellCommand';
+
+const SWR_KEY = 'desktop-background-processes';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  command: css`
+    overflow: hidden;
+
+    font-family: ${cssVar.fontFamilyCode};
+    font-size: 12px;
+    color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  list: css`
+    overflow-y: auto;
+    max-height: 320px;
+    padding: 4px;
+  `,
+  row: css`
+    padding-block: 6px;
+    padding-inline: 8px;
+    border-radius: ${cssVar.borderRadius};
+
+    &:hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
+  sub: css`
+    overflow: hidden;
+
+    font-size: 12px;
+    color: ${cssVar.colorTextDescription};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  title: css`
+    padding-block: 10px 6px;
+    padding-inline: 12px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+
+    font-size: 13px;
+    font-weight: 500;
+    color: ${cssVar.colorText};
+  `,
+  trigger: css`
+    font-size: ${cssVar.fontSizeSM};
+    color: ${cssVar.colorTextSecondary};
+  `,
+}));
+
+const formatAge = (startedAt: number) => {
+  const seconds = Math.max(0, Math.floor((Date.now() - startedAt) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+};
+
+interface ProcessRowProps {
+  killing: boolean;
+  onKill: (shellId: string) => void;
+  process: ShellProcessMeta;
+}
+
+const ProcessRow = memo<ProcessRowProps>(({ killing, onKill, process }) => {
+  const { t } = useTranslation('chat');
+
+  return (
+    <Flexbox horizontal align={'center'} className={styles.row} gap={8}>
+      <Flexbox flex={1} style={{ minWidth: 0 }}>
+        <div className={styles.command}>{process.command}</div>
+        <div className={styles.sub}>
+          {[process.cwd, formatAge(process.startedAt)].filter(Boolean).join(' · ')}
+        </div>
+      </Flexbox>
+      <ActionIcon
+        icon={X}
+        loading={killing}
+        size={'small'}
+        title={t('backgroundProcesses.stop')}
+        onClick={() => onKill(process.shellId)}
+      />
+    </Flexbox>
+  );
+});
+
+const BackgroundProcessesIndicator = memo(() => {
+  const { t } = useTranslation('chat');
+  const [open, setOpen] = useState(false);
+  const [killingIds, setKillingIds] = useState<Set<string>>(() => new Set());
+
+  const { data, mutate } = useSWR(SWR_KEY, () => shellCommandService.listProcesses(), {
+    refreshInterval: 10_000,
+    revalidateOnFocus: true,
+  });
+
+  useWatchBroadcast('shellProcessesChanged', ({ processes }) => {
+    void mutate(processes, { revalidate: false });
+  });
+
+  const handleKill = useCallback(
+    async (shellId: string) => {
+      setKillingIds((prev) => new Set(prev).add(shellId));
+      try {
+        await shellCommandService.killShell(shellId);
+        await mutate();
+      } finally {
+        setKillingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(shellId);
+          return next;
+        });
+      }
+    },
+    [mutate],
+  );
+
+  const processes = (data ?? []).filter((process) => process.runInBackground);
+
+  if (processes.length === 0) return null;
+
+  const button = (
+    <Button
+      className={styles.trigger}
+      icon={<Icon icon={Activity} size={'small'} />}
+      size={'small'}
+      type={'text'}
+    >
+      {processes.length}
+    </Button>
+  );
+
+  return (
+    <Popover
+      arrow={false}
+      open={open}
+      placement={'bottomRight'}
+      styles={{ content: { padding: 0, width: 360 } }}
+      trigger={['click']}
+      content={
+        <Flexbox>
+          <div className={styles.title}>{t('backgroundProcesses.title')}</div>
+          <Flexbox className={styles.list}>
+            {processes.map((process) => (
+              <ProcessRow
+                key={process.shellId}
+                killing={killingIds.has(process.shellId)}
+                process={process}
+                onKill={handleKill}
+              />
+            ))}
+          </Flexbox>
+        </Flexbox>
+      }
+      onOpenChange={setOpen}
+    >
+      {open ? button : <Tooltip title={t('backgroundProcesses.title')}>{button}</Tooltip>}
+    </Popover>
+  );
+});
+
+BackgroundProcessesIndicator.displayName = 'BackgroundProcessesIndicator';
+
+export default BackgroundProcessesIndicator;

--- a/src/features/ChatInput/ControlBar/index.tsx
+++ b/src/features/ChatInput/ControlBar/index.tsx
@@ -1,3 +1,4 @@
+import { isDesktop } from '@lobechat/const';
 import { Flexbox, Skeleton } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { memo } from 'react';
@@ -9,6 +10,7 @@ import ContextWindow from '../ActionBar/Token';
 import { useAgentId } from '../hooks/useAgentId';
 import { useChatInputStore } from '../store';
 import ApprovalMode from './ApprovalMode';
+import BackgroundProcessesIndicator from './BackgroundProcessesIndicator';
 import ModeSelector from './ModeSelector';
 import WorkspaceControls from './WorkspaceControls';
 
@@ -68,6 +70,7 @@ const ControlBar = memo(() => {
       </Flexbox>
 
       <Flexbox horizontal align={'center'} className={styles.rightGroup} gap={4}>
+        {isDesktop && <BackgroundProcessesIndicator />}
         {enableAgentMode && <ApprovalMode />}
         {showContextWindow && <ContextWindow />}
       </Flexbox>

--- a/src/services/electron/shellCommand.ts
+++ b/src/services/electron/shellCommand.ts
@@ -1,0 +1,23 @@
+import {
+  type KillCommandResult,
+  type KillProcessParams,
+  type ShellProcessMeta,
+} from '@lobechat/electron-client-ipc';
+
+import { ensureElectronIpc } from '@/utils/electron/ipc';
+
+class ShellCommandService {
+  killProcess = async (params: KillProcessParams): Promise<KillCommandResult> => {
+    return ensureElectronIpc().shellCommand.killProcess(params);
+  };
+
+  killShell = async (shellId: string): Promise<KillCommandResult> => {
+    return ensureElectronIpc().shellCommand.handleKillCommand({ shell_id: shellId });
+  };
+
+  listProcesses = async (): Promise<ShellProcessMeta[]> => {
+    return ensureElectronIpc().shellCommand.listProcesses();
+  };
+}
+
+export const shellCommandService = new ShellCommandService();


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Stacked on #16466 (Tier 1 foundation) — **PR-2 of the background process tracker series** (design: `docs/superpowers/specs/2026-06-30-background-process-tracker-design.md`, §5–§6). Base is `feat/bg-process-tracker-tier1`; retarget to `canary` after #16466 merges (GitHub should auto-retarget).

#### 📝 Description of Change

Renderer-visible surface for the Tier-1 shell process registry:

**IPC (`packages/electron-client-ipc` + `ShellCommandCtr`)**
- New `ShellProcessMeta` / `KillProcessParams` client types and a `shellProcessesChanged` entry in `MainBroadcastEvents`.
- `ShellCommandCtr.listProcesses()` — alive registry entries, redacted at the IPC boundary (homedir → `~` in command and cwd, `token|key|secret|password|pwd`-style args masked to `***`, command capped at 120 chars).
- `ShellCommandCtr.killProcess({ pid, force })` — delegates to `ShellProcessManager.killByPid`; consumed by the orphan UI in PR-3, exposed here per the spec's Tier-1 IPC scope.
- `afterAppReady` subscribes to the manager's `change` event (the subscriber anticipated by PR-1's `emitChange` snapshot fix) and broadcasts the redacted list to all windows, so the UI is push-accurate rather than poll-bound.

**Renderer**
- New `src/services/electron/shellCommand.ts` service (`listProcesses` / `killShell` / `killProcess`).
- `BackgroundProcessesIndicator` in `ChatInput/ControlBar` (desktop-gated with `isDesktop`): Activity chip + count, base-ui Popover listing command (mono, ellipsized) · cwd · age per row, per-row ✕ with in-flight state. SWR 10s poll + `useWatchBroadcast` push mutate. Renders nothing at count 0.
- i18n keys `backgroundProcesses.*` in the `chat` namespace (en-US + zh-CN by hand).

**Deviations from the spec, deliberate**
- Row ✕ kills via `killTree(shellId)` (SIGTERM → SIGKILL escalation + registry cleanup) instead of the spec's `killProcess(pid)` — strictly better semantics for tracked entries; `killProcess` remains for PR-3 orphans.
- The chip counts only `runInBackground` processes (filtered in the renderer): with push updates, counting foreground in-flight commands would make the badge flash on every quick tool call.

#### 🧪 How to Test

- `bunx vitest run apps/desktop/src/main/controllers/__tests__/ShellCommandCtr.test.ts` — 13 tests: redaction (homedir, secrets, 120-cap), `killProcess` delegation, `afterAppReady` subscribe + broadcast round-trip.
- Manual (desktop build): ask the agent to run `sleep 300` with `run_in_background: true` → chip appears with count 1 instantly (push); open popover, ✕ the row → process tree killed, chip disappears. Not yet exercised in a packaged Electron run — covered by unit tests + lint only.