### PR TITLE
🐛 fix: fix codex linear issue render

### DIFF
--- a/packages/builtin-tools/src/codex/mcpToolUtils.test.ts
+++ b/packages/builtin-tools/src/codex/mcpToolUtils.test.ts
@@ -43,6 +43,30 @@ describe('getCodexLinearMcpApiName', () => {
     expect(getCodexLinearMcpApiName({ toolName: 'server_linear_get_issue' })).toBe('get_issue');
   });
 
+  it('normalizes Codex Apps dotted Linear tool names', () => {
+    expect(
+      getCodexLinearMcpApiName({
+        input: { id: 'LOBE-11078' },
+        server: 'codex_apps',
+        toolName: 'linear.get_issue',
+      }),
+    ).toBe('get_issue');
+    expect(
+      getCodexLinearMcpApiName({
+        input: { id: 'issue:TEST-0000' },
+        server: 'codex_apps',
+        toolName: 'linear.fetch',
+      }),
+    ).toBe('get_issue');
+    expect(
+      getCodexLinearMcpApiName({
+        input: { query: 'agent runtime' },
+        server: 'codex_apps',
+        toolName: 'linear.search',
+      }),
+    ).toBe('search');
+  });
+
   it('treats bare issue identifiers as issue fetch calls', () => {
     expect(getCodexLinearMcpApiName({ input: { id: 'TEST-0000' }, toolName: 'linear_fetch' })).toBe(
       'get_issue',

--- a/packages/builtin-tools/src/codex/mcpToolUtils.ts
+++ b/packages/builtin-tools/src/codex/mcpToolUtils.ts
@@ -94,7 +94,11 @@ export const getMcpInputRecord = (
 const normalizeCodexLinearToolName = (toolName: string) => {
   if (!toolName) return { apiName: '', hasLinearPrefix: false };
 
-  let apiName = toolName.trim();
+  let apiName = toolName
+    .trim()
+    .replaceAll(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replaceAll(/[.\-\s]+/g, '_')
+    .toLowerCase();
   let hasLinearPrefix = false;
 
   let changed = true;


### PR DESCRIPTION
## Summary

- Normalize Codex Apps dotted Linear MCP tool names like `linear.get_issue`.
- Route `linear.fetch` and `linear.search` through the existing shared Linear inspector/render path.
- Add focused tests for the `codex_apps > linear.*` shape seen in Codex tool calls.

## Root Cause

Codex Apps can report MCP calls as `server: codex_apps` with dotted tool names such as `linear.get_issue`. The Codex MCP renderer only recognized Linear via Linear server names or underscore-prefixed tool names, so these calls fell back to the generic JSON renderer.

## Validation

```bash
cd packages/builtin-tools
bunx vitest run --config vitest.config.mts --silent='passed-only' src/codex/mcpToolUtils.test.ts
```
