### PR TITLE
🐛 fix(model-runtime): stop retrying provider content filter errors

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/generateObject.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/generateObject.test.ts
@@ -1,4 +1,6 @@
 // @vitest-environment node
+import { AgentRuntimeErrorType } from '@lobechat/types';
+import OpenAI from 'openai';
 import type { Mock } from 'vitest';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -51,6 +53,17 @@ const toolCallResponse = {
 const responseFormatUnsupportedError = Object.assign(
   new Error('400 Error from provider (DeepSeek): This response_format type is unavailable now'),
   { status: 400 },
+);
+
+const providerContentFilterError = new OpenAI.BadRequestError(
+  400,
+  {
+    code: 'content_filter',
+    message: 'The provider blocked this prompt.',
+    type: 'content_filter',
+  },
+  'content filter',
+  new Headers(),
 );
 
 describe('isResponseFormatUnsupportedError', () => {
@@ -140,6 +153,97 @@ describe('generateObject tool-calling fallback', () => {
     await expect(
       instance.generateObject({ ...generateObjectPayload, model: 'big-pickle' }),
     ).rejects.toMatchObject({ message: expect.stringContaining('Insufficient Balance') });
+
+    expect(getCreateMock(instance)).toHaveBeenCalledTimes(1);
+  });
+
+  it('should classify content_filter error codes as provider content policy violations', async () => {
+    const instance = createInstance();
+    vi.spyOn((instance as any).client.chat.completions, 'create').mockRejectedValue(
+      providerContentFilterError,
+    );
+
+    await expect(
+      instance.generateObject({
+        ...generateObjectPayload,
+        model: 'gpt-4o',
+        responseApi: false,
+      }),
+    ).rejects.toMatchObject({
+      error: {
+        code: 'content_filter',
+        type: 'content_filter',
+      },
+      errorType: AgentRuntimeErrorType.ProviderContentPolicyViolation,
+    });
+
+    expect(getCreateMock(instance)).toHaveBeenCalledTimes(1);
+  });
+
+  it('should classify nested content_filter payloads as provider content policy violations', async () => {
+    const instance = createInstance();
+    vi.spyOn((instance as any).client.chat.completions, 'create').mockRejectedValue(
+      new OpenAI.APIError(
+        400,
+        {
+          error: {
+            code: 'content_filter',
+            message: 'The provider blocked this prompt.',
+            type: 'content_filter',
+          },
+          status: 400,
+        },
+        'content filter',
+        new Headers(),
+      ),
+    );
+
+    await expect(
+      instance.generateObject({
+        ...generateObjectPayload,
+        model: 'gpt-4o',
+        responseApi: false,
+      }),
+    ).rejects.toMatchObject({
+      error: {
+        error: expect.objectContaining({
+          code: 'content_filter',
+          type: 'content_filter',
+        }),
+      },
+      errorType: AgentRuntimeErrorType.ProviderContentPolicyViolation,
+    });
+
+    expect(getCreateMock(instance)).toHaveBeenCalledTimes(1);
+  });
+
+  it('should classify content policy finish reasons as provider content policy violations', async () => {
+    const instance = createInstance();
+    vi.spyOn((instance as any).client.chat.completions, 'create').mockRejectedValue(
+      new OpenAI.APIError(
+        400,
+        {
+          choices: [{ finish_reason: 'content_policy_violation' }],
+          message: 'The provider blocked this prompt.',
+          status: 400,
+        },
+        'content filter',
+        new Headers(),
+      ),
+    );
+
+    await expect(
+      instance.generateObject({
+        ...generateObjectPayload,
+        model: 'gpt-4o',
+        responseApi: false,
+      }),
+    ).rejects.toMatchObject({
+      error: {
+        choices: [expect.objectContaining({ finish_reason: 'content_policy_violation' })],
+      },
+      errorType: AgentRuntimeErrorType.ProviderContentPolicyViolation,
+    });
 
     expect(getCreateMock(instance)).toHaveBeenCalledTimes(1);
   });

--- a/packages/model-runtime/src/core/streams/openai/openai.test.ts
+++ b/packages/model-runtime/src/core/streams/openai/openai.test.ts
@@ -130,6 +130,69 @@ describe('OpenAIStream', () => {
     );
   });
 
+  it('should emit a content policy error when finish_reason is content_filter', async () => {
+    const mockOpenAIStream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({
+          choices: [
+            {
+              delta: {},
+              finish_reason: 'content_filter',
+              index: 0,
+            },
+          ],
+          id: 'chatcmpl_content_filter',
+        });
+        controller.close();
+      },
+    });
+    const onError = vi.fn();
+    const onFinal = vi.fn();
+
+    const protocolStream = OpenAIStream(mockOpenAIStream, {
+      callbacks: { onError, onFinal },
+      payload: {
+        model: 'gpt-5.4-mini',
+        provider: 'openai',
+      },
+    });
+
+    const decoder = new TextDecoder();
+    const chunks: string[] = [];
+    // @ts-ignore
+    for await (const chunk of protocolStream) {
+      chunks.push(decoder.decode(chunk, { stream: true }));
+    }
+
+    const expectedError = {
+      body: {
+        chunk: {
+          choices: [
+            {
+              delta: {},
+              finish_reason: 'content_filter',
+              index: 0,
+            },
+          ],
+          id: 'chatcmpl_content_filter',
+        },
+        finishReason: 'content_filter',
+        model: 'gpt-5.4-mini',
+        provider: 'openai',
+      },
+      message: 'Provider blocked the response due to content policy.',
+      type: AgentRuntimeErrorType.ProviderContentPolicyViolation,
+    };
+
+    expect(chunks).toEqual([
+      'id: chatcmpl_content_filter\n',
+      'event: error\n',
+      `data: ${JSON.stringify(expectedError)}\n\n`,
+    ]);
+    expect(onError).toHaveBeenCalledWith(expectedError);
+    expect(onFinal).toHaveBeenCalledWith(expect.objectContaining({ error: expectedError }));
+  });
+
   it('should handle empty stream', async () => {
     const mockStream = new ReadableStream({
       start(controller) {

--- a/packages/model-runtime/src/core/streams/openai/openai.ts
+++ b/packages/model-runtime/src/core/streams/openai/openai.ts
@@ -5,6 +5,7 @@ import type { Stream } from 'openai/streaming';
 import type { ChatStreamCallbacks } from '../../../types';
 import type { ILobeAgentRuntimeErrorType } from '../../../types/error';
 import { AgentRuntimeErrorType } from '../../../types/error';
+import { isErrorCausedByContentFilter } from '../../../utils/isErrorCausedByContentFilter';
 import { convertOpenAIUsage } from '../../usageConverters';
 import type {
   ChatPayloadForTransformStream,
@@ -69,6 +70,21 @@ const processMarkdownBase64Images = (text: string): { cleanedText: string; urls:
 
   return { cleanedText, urls };
 };
+
+const createContentFilterStreamError = (
+  chunk: OpenAI.ChatCompletionChunk,
+  finishReason: string,
+  payload?: ChatPayloadForTransformStream,
+): ChatMessageError => ({
+  body: {
+    chunk,
+    finishReason,
+    model: payload?.model,
+    provider: payload?.provider,
+  },
+  message: 'Provider blocked the response due to content policy.',
+  type: AgentRuntimeErrorType.ProviderContentPolicyViolation,
+});
 
 const transformOpenAIStream = (
   chunk: OpenAI.ChatCompletionChunk,
@@ -276,6 +292,14 @@ const transformOpenAIStream = (
 
     // Handle finish reason
     if (item.finish_reason) {
+      if (isErrorCausedByContentFilter(item)) {
+        return {
+          data: createContentFilterStreamError(chunk, item.finish_reason, payload),
+          id: chunk.id,
+          type: 'error',
+        };
+      }
+
       const usageChunk: StreamProtocolChunk | undefined = chunk.usage
         ? { data: convertOpenAIUsage(chunk.usage, payload), id: chunk.id, type: 'usage' }
         : undefined;

--- a/packages/model-runtime/src/utils/handleOpenAIError.test.ts
+++ b/packages/model-runtime/src/utils/handleOpenAIError.test.ts
@@ -61,6 +61,33 @@ describe('handleOpenAIError', () => {
       expect(result.errorResult).toEqual({ error: errorObject });
       expect(result.message).toBe(apiError.message);
     });
+
+    it('should classify OpenAI content_filter APIError as provider content policy violation', () => {
+      const apiError = new OpenAI.APIError(
+        400,
+        {
+          error: {
+            code: 'content_filter',
+            message: 'The provider blocked this prompt.',
+            type: 'content_filter',
+          },
+        },
+        'content filter',
+        undefined,
+      );
+
+      const result = handleOpenAIError(apiError);
+
+      expect(result.errorResult).toEqual({
+        error: {
+          code: 'content_filter',
+          message: 'The provider blocked this prompt.',
+          type: 'content_filter',
+        },
+      });
+      expect(result.message).toBe(apiError.message);
+      expect(result.RuntimeError).toBe(AgentRuntimeErrorType.ProviderContentPolicyViolation);
+    });
   });
 
   describe('Non-OpenAI error handling', () => {

--- a/packages/model-runtime/src/utils/handleOpenAIError.ts
+++ b/packages/model-runtime/src/utils/handleOpenAIError.ts
@@ -1,10 +1,12 @@
 import OpenAI from 'openai';
 
+import type { ILobeAgentRuntimeErrorType } from '../types/error';
 import { AgentRuntimeErrorType } from '../types/error';
+import { isErrorCausedByContentFilter } from './isErrorCausedByContentFilter';
 
 export const handleOpenAIError = (
   error: any,
-): { RuntimeError?: 'AgentRuntimeError'; errorResult: any; message?: string } => {
+): { RuntimeError?: ILobeAgentRuntimeErrorType; errorResult: any; message?: string } => {
   let errorResult: any;
 
   // Check if the error is an OpenAI APIError
@@ -26,6 +28,9 @@ export const handleOpenAIError = (
     return {
       errorResult,
       message: error.message,
+      RuntimeError: isErrorCausedByContentFilter(errorResult)
+        ? AgentRuntimeErrorType.ProviderContentPolicyViolation
+        : undefined,
     };
   } else {
     const err = error as Error;

--- a/packages/model-runtime/src/utils/isErrorCausedByContentFilter.ts
+++ b/packages/model-runtime/src/utils/isErrorCausedByContentFilter.ts
@@ -1,0 +1,50 @@
+interface ContentFilterErrorPayloadLike {
+  choices?: unknown;
+  code?: unknown;
+  error?: unknown;
+  finish_reason?: unknown;
+  type?: unknown;
+}
+
+const CONTENT_FILTER_SIGNAL_VALUES = new Set(['content_filter', 'content_policy_violation']);
+
+const isContentFilterSignalValue = (value: unknown) =>
+  typeof value === 'string' && CONTENT_FILTER_SIGNAL_VALUES.has(value.toLowerCase());
+
+/**
+ * Detects content-filter failures from structured provider error fields.
+ *
+ * Use when:
+ * - Converting OpenAI-compatible provider errors to runtime error types
+ * - Deciding whether router fallback should stop for a blocked prompt
+ *
+ * Expects:
+ * - Provider payloads may nest structured signals under `error`
+ * - Chat completion payloads may expose `choices[].finish_reason`
+ *
+ * Returns:
+ * - `true` only when `code`, `type`, or `finish_reason` carries a known content-filter signal
+ */
+export const isErrorCausedByContentFilter = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') return false;
+
+  const payload = error as ContentFilterErrorPayloadLike;
+  if (
+    isContentFilterSignalValue(payload.code) ||
+    isContentFilterSignalValue(payload.type) ||
+    isContentFilterSignalValue(payload.finish_reason)
+  )
+    return true;
+
+  if (
+    Array.isArray(payload.choices) &&
+    payload.choices.some((choice) => isErrorCausedByContentFilter(choice))
+  )
+    return true;
+
+  return (
+    Boolean(payload.error) &&
+    typeof payload.error === 'object' &&
+    isErrorCausedByContentFilter(payload.error)
+  );
+};

--- a/packages/model-runtime/src/utils/isNonRetryableRequestError.test.ts
+++ b/packages/model-runtime/src/utils/isNonRetryableRequestError.test.ts
@@ -42,6 +42,44 @@ describe('isNonRetryableRequestError', () => {
     ).toBe(true);
   });
 
+  it('returns true for provider content_filter moderation errors', () => {
+    // ROOT CAUSE:
+    //
+    // OpenAI-compatible providers can return content filter rejections as 400
+    // responses with `code`, `type`, or `finish_reason` set to
+    // "content_filter" instead of a structured runtime error type. If the
+    // router treats that raw provider payload as retryable, one blocked prompt
+    // can fan out across fallback channels.
+    //
+    // Before the fix, this returned false because `content_filter` was not in
+    // the non-retryable code set.
+    //
+    // We fixed this by treating provider moderation signals as terminal request
+    // errors at the model-runtime retry gate.
+    expect(
+      isNonRetryableRequestError({
+        error: {
+          code: 'content_filter',
+          message: 'The provider blocked this prompt.',
+          type: 'content_filter',
+        },
+        errorType: AgentRuntimeErrorType.ProviderBizError,
+        status: 400,
+      }),
+    ).toBe(true);
+
+    expect(
+      isNonRetryableRequestError({
+        error: {
+          choices: [{ finish_reason: 'content_policy_violation' }],
+          message: 'The provider blocked this prompt.',
+        },
+        errorType: AgentRuntimeErrorType.ProviderBizError,
+        status: 400,
+      }),
+    ).toBe(true);
+  });
+
   it('returns true for invalid response_format schema errors', () => {
     expect(
       isNonRetryableRequestError({

--- a/packages/model-runtime/src/utils/isNonRetryableRequestError.ts
+++ b/packages/model-runtime/src/utils/isNonRetryableRequestError.ts
@@ -1,6 +1,7 @@
 import { toRecord } from '@lobechat/utils';
 
 import { AgentRuntimeErrorType } from '../types/error';
+import { isErrorCausedByContentFilter } from './isErrorCausedByContentFilter';
 
 const NON_RETRYABLE_ERROR_TYPES = new Set<string>([
   AgentRuntimeErrorType.ExceededContextWindow,
@@ -165,6 +166,8 @@ export const isNonRetryableRequestError = (error: unknown): boolean => {
     const errorType = (error as { errorType?: unknown }).errorType;
     if (typeof errorType === 'string' && NON_RETRYABLE_ERROR_TYPES.has(errorType)) return true;
   }
+
+  if (isErrorCausedByContentFilter(error)) return true;
 
   if (normalizedStrings.some((value) => RETRYABLE_ERROR_CODES.has(value))) return false;
   if (normalizedStrings.some((value) => NON_RETRYABLE_ERROR_CODES.has(value))) return true;


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-11245

#### 🔀 Description of Change

OpenAI-compatible providers can surface content policy blocks in two different shapes:

- request errors, such as Azure OpenAI returning a 400 payload with `code: "content_filter"`
- successful chat completion stream chunks that terminate with `finish_reason: "content_filter"` or `content_policy_violation`

Previously the request-error path normalized the provider payload as a generic provider business error, so router fallback could treat the blocked prompt as retryable and fan it out across channels. The stream path also treated `content_filter` finish reasons as a normal stop event.

This PR adds structured content-filter detection for OpenAI-compatible payloads without relying on provider message text. It maps provider content-filter request errors to `ProviderContentPolicyViolation`, treats those payloads as non-retryable, and emits an SSE `error` event when a chat completion stream terminates with a content policy finish reason.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validated with:

```bash
pnpm exec vitest run --silent='passed-only' \
  'src/utils/handleOpenAIError.test.ts' \
  'src/core/openaiCompatibleFactory/generateObject.test.ts' \
  'src/core/streams/openai/openai.test.ts' \
  'src/utils/isNonRetryableRequestError.test.ts'

pnpm exec eslint \
  'packages/model-runtime/src/utils/handleOpenAIError.ts' \
  'packages/model-runtime/src/utils/handleOpenAIError.test.ts' \
  'packages/model-runtime/src/core/openaiCompatibleFactory/index.ts' \
  'packages/model-runtime/src/core/openaiCompatibleFactory/generateObject.test.ts' \
  'packages/model-runtime/src/core/streams/openai/openai.ts' \
  'packages/model-runtime/src/core/streams/openai/openai.test.ts' \
  'packages/model-runtime/src/utils/isNonRetryableRequestError.ts' \
  'packages/model-runtime/src/utils/isNonRetryableRequestError.test.ts' \
  'packages/model-runtime/src/utils/isErrorCausedByContentFilter.ts'
```

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

#### 📝 Additional Information

The full repository `pnpm run type-check` currently fails on pre-existing `.next/dev/types/validator.ts` generated route references and cloud alias type resolution issues outside this PR's touched files.
