### PR TITLE
🐛 fix(agent): preserve breadcrumb route prefixes

### DIFF
--- a/src/features/AgentBreadcrumb/index.test.tsx
+++ b/src/features/AgentBreadcrumb/index.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen } from '@testing-library/react';
+import type * as Antd from 'antd';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import AgentBreadcrumb from './index';
+
+const mocks = vi.hoisted(() => ({
+  activeWorkspaceSlug: null as string | null,
+  agentState: {
+    agents: {
+      'agent-1': { title: 'Test Agent' },
+      'inbox': { title: '' },
+    },
+    inboxAgentId: 'inbox',
+  },
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  Icon: () => <span />,
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock('antd', async (importOriginal) => {
+  const actual = await importOriginal<typeof Antd>();
+
+  return {
+    ...actual,
+    Breadcrumb: ({ items }: { items: Array<{ title: ReactNode }> }) => (
+      <nav>
+        {items.map((item, index) => (
+          <span key={index}>{item.title}</span>
+        ))}
+      </nav>
+    ),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => (key === 'inbox.title' ? 'Lobe AI' : key),
+  }),
+}));
+
+vi.mock('@/business/client/hooks/useActiveWorkspaceSlug', () => ({
+  useActiveWorkspaceSlug: () => mocks.activeWorkspaceSlug,
+}));
+
+vi.mock('@/store/agent', () => ({
+  useAgentStore: (selector: (state: typeof mocks.agentState) => unknown) =>
+    selector(mocks.agentState),
+}));
+
+vi.mock('@/store/agent/selectors', () => ({
+  agentSelectors: {
+    getAgentMetaById: (agentId: string) => (state: typeof mocks.agentState) =>
+      state.agents[agentId as keyof typeof state.agents] ?? {},
+  },
+  builtinAgentSelectors: {
+    inboxAgentId: (state: typeof mocks.agentState) => state.inboxAgentId,
+  },
+}));
+
+describe('AgentBreadcrumb', () => {
+  beforeEach(() => {
+    mocks.activeWorkspaceSlug = null;
+  });
+
+  it('links the agent crumb back to the agent chat page', () => {
+    render(
+      <MemoryRouter initialEntries={['/agent/agent-1/profile']}>
+        <AgentBreadcrumb agentId="agent-1" title="Agent Profile" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('link', { name: 'Test Agent' })).toHaveAttribute(
+      'href',
+      '/agent/agent-1',
+    );
+  });
+
+  it('keeps the active workspace route when returning from a workspace profile route', () => {
+    mocks.activeWorkspaceSlug = 'team';
+
+    render(
+      <MemoryRouter initialEntries={['/team/agent/agent-1/profile']}>
+        <AgentBreadcrumb agentId="agent-1" title="Agent Profile" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('link', { name: 'Test Agent' })).toHaveAttribute(
+      'href',
+      '/team/agent/agent-1',
+    );
+  });
+
+  it('lets the router basename restore the debug proxy prefix for workspace links', () => {
+    mocks.activeWorkspaceSlug = 'team';
+
+    render(
+      <MemoryRouter
+        basename="/_dangerous_local_dev_proxy"
+        initialEntries={['/_dangerous_local_dev_proxy/team/agent/agent-1/profile']}
+      >
+        <AgentBreadcrumb agentId="agent-1" title="Agent Profile" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('link', { name: 'Test Agent' })).toHaveAttribute(
+      'href',
+      '/_dangerous_local_dev_proxy/team/agent/agent-1',
+    );
+  });
+});

--- a/src/features/AgentBreadcrumb/index.tsx
+++ b/src/features/AgentBreadcrumb/index.tsx
@@ -3,11 +3,17 @@
 import { Icon, Text } from '@lobehub/ui';
 import { Breadcrumb as AntBreadcrumb } from 'antd';
 import { ChevronRight } from 'lucide-react';
-import { memo, type ReactNode } from 'react';
+import { memo, type ReactNode, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
+import { Link, useLocation } from 'react-router';
 import urlJoin from 'url-join';
 
+import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
+import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
+import {
+  buildPrefixedAgentRoutePath,
+  parseAgentPathname,
+} from '@/routes/(main)/agent/_layout/Sidebar/utils/agentPathname';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors, builtinAgentSelectors } from '@/store/agent/selectors';
 
@@ -25,12 +31,19 @@ interface AgentBreadcrumbProps {
  */
 const AgentBreadcrumb = memo<AgentBreadcrumbProps>(({ agentId, title }) => {
   const { t } = useTranslation(['chat', 'common']);
+  const { pathname } = useLocation();
+  const activeWorkspaceSlug = useActiveWorkspaceSlug();
   const agentTitle = useAgentStore((s) => agentSelectors.getAgentMetaById(agentId)(s).title);
   const inboxAgentId = useAgentStore(builtinAgentSelectors.inboxAgentId);
   const isInbox = !!inboxAgentId && agentId === inboxAgentId;
   const displayTitle = isInbox
     ? agentTitle || t('inbox.title', { ns: 'chat' })
     : agentTitle || t('defaultSession', { ns: 'common' });
+  const agentRoute = useMemo(() => parseAgentPathname(pathname), [pathname]);
+  const agentHomePath = useMemo(() => {
+    const targetPath = buildWorkspaceAwarePath(urlJoin('/agent', agentId), activeWorkspaceSlug);
+    return buildPrefixedAgentRoutePath(targetPath, agentRoute, activeWorkspaceSlug);
+  }, [activeWorkspaceSlug, agentId, agentRoute]);
 
   return (
     <AntBreadcrumb
@@ -38,7 +51,7 @@ const AgentBreadcrumb = memo<AgentBreadcrumbProps>(({ agentId, title }) => {
       items={[
         {
           title: (
-            <Link to={urlJoin('/agent', agentId)}>
+            <Link to={agentHomePath}>
               <Text ellipsis color={'inherit'} style={{ maxWidth: 200 }} weight={500}>
                 {displayTitle}
               </Text>


### PR DESCRIPTION
## Summary

- Preserve workspace/debug-proxy-aware prefixes when the agent breadcrumb links back to the agent chat page.
- Add focused tests for normal, workspace-prefixed, and router-basename-prefixed AgentBreadcrumb routes.

## Root Cause

AgentBreadcrumb built the first crumb with a hard-coded `/agent/:agentId` path. On workspace routes, clicking the agent name could leave the workspace context instead of returning to that workspace's agent chat page.

Debug proxy paths are handled by React Router's `basename` in the real web entry, so the component sees the basename-stripped pathname and `Link` restores the basename when producing the final href. The test suite now models that separately instead of treating the debug proxy segment as part of `useLocation().pathname`.

## Validation

- `bunx vitest run --silent='passed-only' src/features/AgentBreadcrumb/index.test.tsx`
- `bunx vitest run --silent='passed-only' 'src/routes/(main)/agent/_layout/Sidebar/utils/agentPathname.test.ts'`