### PR TITLE
🧹 chore: remove LOBE-XXX markers from source code (2026-07-03)

### DIFF
--- a/apps/server/src/routers/lambda/agentDocument.ts
+++ b/apps/server/src/routers/lambda/agentDocument.ts
@@ -503,7 +503,7 @@ export const agentDocumentRouter = router({
         // user-facing lists stay clean; the agent document-listing tool opts in.
         includeArchivedToolResults: z.boolean().optional().default(false),
         // Restrict the listing to the direct children of this folder so the model
-        // can expand a folder collapsed in the progressive index (LOBE-11072).
+        // can expand a folder collapsed in the progressive index.
         parentId: z.string().optional(),
         scope: z.enum(['agent', 'currentTopic']).optional().default('agent'),
         sourceType: z.enum(['all', 'file', 'web']).optional().default('all'),

--- a/apps/server/src/routers/lambda/task.ts
+++ b/apps/server/src/routers/lambda/task.ts
@@ -1027,8 +1027,9 @@ export const taskRouter = router({
       }
 
       // Reject changing the assignee to a private agent on a public task —
-      // visibility invariant from LOBE-10961. `undefined` means "no change";
-      // `null` clears the assignee and is always safe.
+      // a public task must never be assigned to a private agent.
+      // `undefined` means "no change"; `null` clears the assignee and is
+      // always safe.
       if (data.assigneeAgentId) {
         const agentVisibility = await ctx.agentModel.getAgentVisibility(data.assigneeAgentId);
         ctx.taskService.assertAgentVisibilityCompat(resolved.visibility, agentVisibility);
@@ -1040,9 +1041,10 @@ export const taskRouter = router({
           : await resolveSafeParentTaskId(model, resolved.id, parentTaskId);
 
       // Reparenting a public task under a private one breaks the parent
-      // visibility invariant from LOBE-10962 #3 — workspace members would
-      // still see the child while its new parent is hidden. `undefined`
-      // means "no change"; `null` clears the parent and is always safe.
+      // visibility invariant — a subtask cannot be more public than its
+      // parent (otherwise workspace members would still see the child while
+      // its new parent is hidden). `undefined` means "no change"; `null`
+      // clears the parent and is always safe.
       if (resolvedParentTaskId) {
         const newParent = await model.findById(resolvedParentTaskId);
         ctx.taskService.assertParentVisibilityCompat(resolved.visibility, newParent?.visibility);
@@ -1089,7 +1091,7 @@ export const taskRouter = router({
         // Mirror the edit-lock contract from `update`: reject visibility flips
         // while another workspace member is actively editing this task. Without
         // this check a collaborator could silently retitle a private task to
-        // public (or vice versa) while you're mid-edit. LOBE-10962 #1.
+        // public (or vice versa) while you're mid-edit.
         if (ctx.workspaceId) {
           const blockedBy = await ctx.editLockService.getBlockingHolder('task', resolved.id);
           if (blockedBy) {
@@ -1126,17 +1128,17 @@ export const taskRouter = router({
         }
 
         // Promoting a task to public while a private agent is its assignee
-        // breaks the visibility invariant from LOBE-10961. Reject early —
-        // the user should reassign first, then promote.
+        // breaks the visibility invariant. Reject early — the user should
+        // reassign first, then promote.
         if (input.visibility === 'public' && resolved.assigneeAgentId) {
           const agentVisibility = await ctx.agentModel.getAgentVisibility(resolved.assigneeAgentId);
           ctx.taskService.assertAgentVisibilityCompat(input.visibility, agentVisibility);
         }
 
         // Promoting a subtask to public while its parent is still private
-        // would orphan the child in the workspace view (LOBE-10962 #3). The
-        // user must promote the parent chain first, or keep the subtask
-        // private.
+        // would orphan the child in the workspace view — a subtask cannot
+        // be more public than its parent. The user must promote the parent
+        // chain first, or keep the subtask private.
         if (input.visibility === 'public' && resolved.parentTaskId) {
           const parent = await ctx.taskModel.findById(resolved.parentTaskId);
           ctx.taskService.assertParentVisibilityCompat(input.visibility, parent?.visibility);

--- a/apps/server/src/services/skill/importer.test.ts
+++ b/apps/server/src/services/skill/importer.test.ts
@@ -1166,12 +1166,12 @@ description: A nested skill
     });
   });
 
-  // Regression for LOBE-10893: a skill imported while running inside a workspace
-  // must be written with `workspace_id = <ws>`, not the importer's personal scope
+  // Regression: a skill imported while running inside a workspace must be
+  // written with `workspace_id = <ws>`, not the importer's personal scope
   // (`workspace_id IS NULL`). Otherwise it is invisible to every workspace member
   // — including the creator whenever they operate in workspace mode — and a
   // re-import of a name that already exists personally hits a unique violation.
-  describe('workspace scoping (LOBE-10893)', () => {
+  describe('workspace scoping', () => {
     let workspaceId: string;
     let wsImporter: SkillImporter;
 

--- a/apps/server/src/services/task/index.test.ts
+++ b/apps/server/src/services/task/index.test.ts
@@ -1554,7 +1554,7 @@ describe('TaskService', () => {
     });
   });
 
-  describe('agent ↔ task visibility compat (LOBE-10961)', () => {
+  describe('agent ↔ task visibility compat', () => {
     beforeEach(() => {
       mockTaskModel.create.mockImplementation(async (data: any) => ({
         ...data,
@@ -1628,7 +1628,7 @@ describe('TaskService', () => {
     });
   });
 
-  describe('parent ↔ child visibility compat (LOBE-10962 #3)', () => {
+  describe('parent ↔ child visibility compat', () => {
     beforeEach(() => {
       mockTaskModel.create.mockImplementation(async (data: any) => ({
         ...data,

--- a/apps/server/src/services/task/index.ts
+++ b/apps/server/src/services/task/index.ts
@@ -157,8 +157,8 @@ export class TaskService {
     // we have to assert here even though the inference path can't.
     this.assertAgentVisibilityCompat(createData.visibility, agentVisibility);
 
-    // Invariant: a subtask can never be more public than its parent (LOBE-10962
-    // #3). Otherwise workspace members see an orphaned child whose parent is
+    // Invariant: a subtask can never be more public than its parent.
+    // Otherwise workspace members see an orphaned child whose parent is
     // hidden, leaking the existence of a private task. The inference path
     // already inherits parent visibility, but the explicit-override path can
     // produce a `Private parent + Public child` combo if the caller insists.

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skillStore.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skillStore.test.ts
@@ -62,8 +62,7 @@ describe('skillStoreRuntime', () => {
     mocks.hasAnyPermission.mockResolvedValue(true);
   });
 
-  // Regression guard for LOBE-10893: importing a skill while running inside a
-  // workspace must construct SkillImporter WITH the workspaceId, otherwise the
+  // Regression guard: importing a skill while running inside a workspace must
   // skill row is saved with `workspace_id = NULL` (the importer's personal
   // scope) and becomes invisible to the whole workspace — including the creator
   // whenever they operate in workspace mode.

--- a/packages/agent-runtime/src/executors/humanApprove.ts
+++ b/packages/agent-runtime/src/executors/humanApprove.ts
@@ -3,7 +3,8 @@ import type { AgentEvent, AgentInstruction, AnyHookEvent, InstructionExecutor } 
 
 /**
  * `request_human_approve` executor — pauses the operation for human tool
- * approval (LOBE-10949 Tier A).
+ * approval (Tier A — the most critical executor that requires human
+ * intervention for sensitive operations).
  *
  * Uses the `StreamSink` (event + chunk channels), `LifecycleSink`
  * (`beforeHumanIntervention` hook) and `MessageTransport` (create pending tool

--- a/packages/builtin-tools/src/codex/mcpToolUtils.test.ts
+++ b/packages/builtin-tools/src/codex/mcpToolUtils.test.ts
@@ -46,7 +46,7 @@ describe('getCodexLinearMcpApiName', () => {
   it('normalizes Codex Apps dotted Linear tool names', () => {
     expect(
       getCodexLinearMcpApiName({
-        input: { id: 'LOBE-11078' },
+        input: { id: 'ISSUE-12345' },
         server: 'codex_apps',
         toolName: 'linear.get_issue',
       }),

--- a/packages/database/src/models/__tests__/document.privateVisibility.workspace.test.ts
+++ b/packages/database/src/models/__tests__/document.privateVisibility.workspace.test.ts
@@ -105,7 +105,7 @@ describe('DocumentModel — private/public cross-user isolation', () => {
   });
 
   describe('workspace mode — public agent gate (callerAgentVisibility)', () => {
-    // Closes the LOBE-11055 read-path leak: a workspace-public agent must not
+    // Guards against a read-path leak: a workspace-public agent must not
     // read the caller's own private documents even though it runs under the
     // caller's session. Mirrors the task side's `assertAgentVisibilityCompat`
     // (public task ≠ private agent).

--- a/packages/database/src/models/__tests__/task.test.ts
+++ b/packages/database/src/models/__tests__/task.test.ts
@@ -1972,8 +1972,8 @@ describe('TaskModel', () => {
     });
 
     it('should hide private task comments from other workspace members', async () => {
-      // LOBE-10962 #2: comments inherit task visibility on insert and are
-      // filtered by commentsOwnership on read.
+      // Comments inherit task visibility on insert and are filtered by
+      // commentsOwnership on read.
       const alice = new TaskModel(serverDB, userId, wsId);
       const bob = new TaskModel(serverDB, userId2, wsId);
 
@@ -2006,7 +2006,7 @@ describe('TaskModel', () => {
       expect(await bob.getComments(publicTask.id)).toHaveLength(1);
     });
 
-    it('should NOT cascade updateVisibility into historical task_comments (LOBE-11028)', async () => {
+    it('should NOT cascade updateVisibility into historical task_comments', async () => {
       // Comments are event-shaped historical rows whose visibility is fixed at
       // write time. Promoting the parent task to public must not retroactively
       // expose discussions that took place while the task was private — that
@@ -2051,7 +2051,7 @@ describe('TaskModel', () => {
       expect(await bob.getComments(task.id)).toHaveLength(1);
     });
 
-    it('should NOT cascade updateVisibility into historical task_topics (LOBE-11028)', async () => {
+    it('should NOT cascade updateVisibility into historical task_topics', async () => {
       // Same rationale as comments: a task_topics row records one run of the
       // task. Its visibility is fixed at write time; promoting the task to
       // public must not retroactively expose runs (transcripts, handoffs,

--- a/packages/database/src/models/document.ts
+++ b/packages/database/src/models/document.ts
@@ -305,8 +305,9 @@ export class DocumentModel {
       // No child-table cascade needed here — Pages (`sourceType: 'api'`) hold
       // content inline in `documents.content` / `documents.pages`, and the
       // `document_chunks` junction has no read consumers on the RAG hot path
-      // (that lane goes through `chunks` + `fileChunks` + `files`). See
-      // LOBE-11040 for the deferred RAG-lane analysis.
+      // (that lane goes through `chunks` + `fileChunks` + `files`).
+      // A future `document_chunks` visibility mirror + RAG filter will add
+      // cascade when that lane is built.
 
       return { documentIds: ids };
     });

--- a/packages/database/src/models/task.ts
+++ b/packages/database/src/models/task.ts
@@ -32,8 +32,8 @@ import { buildWorkspaceWhere } from '../utils/workspace';
 
 /**
  * Ownership helpers in this model come in three flavors. Choose by USE CASE,
- * not by table — picking the wrong one is how LOBE-10946's `seq` allocation
- * hotfix got introduced (see git log).
+ * not by table — picking the wrong one led to a `seq` allocation hotfix
+ * (see git log).
  *
  * ┌────────────────────┬──────────────────────────────────────────────┬────────────────────────┐
  * │ Helper             │ Use for                                      │ Visibility-aware?      │
@@ -255,18 +255,18 @@ export class TaskModel {
   }
 
   /**
-   * Promote a task and its full subtree to a new visibility. Combined with the
-   * router-level guard (LOBE-11027), the only legal transition is
-   * `private → public` — there is no `public → private` path.
+   * Promote a task and its full subtree to a new visibility. The only legal
+   * transition is `private → public` — there is no `public → private` path
+   * (one-way commitment; enforced by the router-level guard).
    *
    * Cascades inside a single transaction across structural rows only:
    *   - the root task and every descendant in `tasks`;
    *   - `task_dependencies` and `task_documents` whose `task_id` is in the set.
    *
-   * `task_topics` and `task_comments` are deliberately **not** cascaded
-   * (LOBE-11028). They are event-shaped historical rows whose visibility was
-   * fixed at write time; promoting the task to public must not retroactively
-   * expose runs and discussions that happened while the task was private.
+   * `task_topics` and `task_comments` are deliberately **not** cascaded.
+   * They are event-shaped historical rows whose visibility was fixed at write
+   * time; promoting the task to public must not retroactively expose runs and
+   * discussions that happened while the task was private.
    * Topics / comments created after promotion inherit the task's then-current
    * visibility through their own create paths.
    *

--- a/packages/database/src/schemas/task.ts
+++ b/packages/database/src/schemas/task.ts
@@ -248,8 +248,8 @@ export const taskTopics = pgTable(
 
     // Snapshot of the task's visibility at the time this run was created.
     // Topics inherit `tasks.visibility` on insert but are **not** cascaded by
-    // `TaskModel.updateVisibility` (LOBE-11028): promoting a task to public
-    // must not retroactively expose runs that happened while it was private.
+    // `TaskModel.updateVisibility`: promoting a task to public must not
+    // retroactively expose runs that happened while it was private.
     visibility: text('visibility', { enum: ['private', 'public'] })
       .default('public')
       .notNull(),

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.tsx
@@ -113,8 +113,8 @@ const TaskDetailHeaderActions = memo(() => {
 
     // Publish-to-workspace is the one-way visibility transition. Only surface
     // it on private tasks inside a workspace; public tasks have no inverse
-    // action (intentional — see LOBE-10944 心智模型 #1) and personal mode has
-    // no workspace to publish to.
+    // action (intentional — visibility is a one-way commitment) and personal
+    // mode has no workspace to publish to.
     const publishItem: DropdownItem | null =
       activeWorkspaceId && visibility === 'private'
         ? {

--- a/src/features/AgentTasks/AgentTaskList/CreateTaskInlineEntry.tsx
+++ b/src/features/AgentTasks/AgentTaskList/CreateTaskInlineEntry.tsx
@@ -74,7 +74,7 @@ const CreateTaskInlineEntry = memo<CreateTaskInlineEntryProps>((props) => {
   // In personal mode the chip is hidden and the value is never sent.
   const [visibility, setVisibility] = useState<'private' | 'public'>('private');
 
-  // LOBE-10961: a private agent can only run a private task. Coerce + lock the
+  // A private agent can only run a private task. Coerce + lock the
   // visibility chip when the selected agent is private.
   const assigneeVisibility = useAgentVisibility(assigneeAgentId);
   const isPrivateAgent = assigneeVisibility === 'private';

--- a/src/features/AgentTasks/CreateTaskModal/CreateTaskContent.tsx
+++ b/src/features/AgentTasks/CreateTaskModal/CreateTaskContent.tsx
@@ -61,9 +61,9 @@ const CreateTaskContent = memo<CreateTaskContentProps>(
     // In personal mode the field is irrelevant and the chip is hidden anyway.
     const [visibility, setVisibility] = useState<'private' | 'public'>('private');
 
-    // LOBE-10961: a private agent can only run a private task. When the
-    // selected agent is private we force visibility back to private and lock
-    // the chip so the user can't pick Workspace.
+    // A private agent can only run a private task. When the selected agent
+    // is private we force visibility back to private and lock the chip so
+    // the user can't pick Workspace.
     const assigneeVisibility = useAgentVisibility(assigneeAgentId);
     const isPrivateAgent = assigneeVisibility === 'private';
     useEffect(() => {

--- a/src/features/AgentTasks/features/TaskVisibilityTag.tsx
+++ b/src/features/AgentTasks/features/TaskVisibilityTag.tsx
@@ -48,7 +48,7 @@ interface TaskVisibilityTagProps {
   disableDropdown?: boolean;
   /** When set, treats the chip as locked: dropdown is suppressed and a
    *  tooltip explains why. Used by the create form when the selected agent
-   *  is private (see LOBE-10961). */
+   *  is private (a private agent can only run private tasks). */
   lockedReason?: string;
   /** Controlled mode (e.g. create form): caller owns the state. */
   onChange?: (next: 'private' | 'public') => void;

--- a/src/features/ChatInput/InputEditor/ActionTag/ActionTagPlugin.test.ts
+++ b/src/features/ChatInput/InputEditor/ActionTag/ActionTagPlugin.test.ts
@@ -17,7 +17,7 @@ const makeNode = (opts: { format?: boolean; parent?: any; type?: string }): any 
 
 describe('INLINE_ACTION_TAG_REGEX', () => {
   it('matches the tag a user typed, with trailing text (the regression case)', () => {
-    const text = '<skill name="ux-audit" label="ux-audit" />  搞 LOBE-11218';
+    const text = '<skill name="ux-audit" label="ux-audit" />  do the UX audit';
     const match = INLINE_ACTION_TAG_REGEX.exec(text);
 
     expect(match).not.toBeNull();

--- a/src/store/task/slices/detail/action.ts
+++ b/src/store/task/slices/detail/action.ts
@@ -262,10 +262,10 @@ export class TaskDetailSliceActionImpl {
       await taskService.updateVisibility(id, visibility);
       await Promise.all([this.#get().refreshTaskList(), this.internal_refreshTaskDetail(id)]);
     } catch (error) {
-      // LOBE-10961 surfaces a specific actionable error when the task's assignee
-      // is a private agent. The generic "failed" toast hides what the user must
-      // do next; substitute a targeted one so they know to either reassign or
-      // publish the agent first.
+      // Surfaces a specific actionable error when the task's assignee is a
+      // private agent. The generic "failed" toast hides what the user must
+      // do next; substitute a targeted one so they know to either reassign
+      // or publish the agent first.
       const raw = (error as { message?: string })?.message ?? '';
       const isPrivateAgentBlock = /public task cannot be assigned to a private agent/i.test(raw);
       message.error(

--- a/src/store/task/slices/list/initialState.ts
+++ b/src/store/task/slices/list/initialState.ts
@@ -7,7 +7,7 @@ export type TaskGroupItem = Awaited<ReturnType<typeof taskService.groupList>>['d
 export type TaskViewMode = 'kanban' | 'list';
 
 /**
- * Top-of-list visibility chip selection (LOBE-10973):
+ * Top-of-list visibility chip selection:
  *   - 'all'       → don't narrow further, show every visible task
  *   - 'private'   → only `tasks.visibility = 'private'` (creator-only)
  *   - 'workspace' → only `tasks.visibility = 'public'` (workspace-shared)

--- a/src/utils/__tests__/agentDocumentContextMapping.test.ts
+++ b/src/utils/__tests__/agentDocumentContextMapping.test.ts
@@ -175,8 +175,7 @@ describe('toAgentContextDocuments', () => {
     expect(result.map((d) => d.id)).toEqual(['doc']);
   });
 
-  // LOBE-11072: children inherit their `custom/folder` parent's title so the
-  // progressive index can fold same-folder siblings under a readable name. The
+  // Children inherit their `custom/folder` parent's title so the progressive
   // folder row is still dropped — only its title survives, on the children.
   it('stamps folderTitle on children of a custom/folder and drops the folder row', () => {
     const rows = [

--- a/src/utils/agentDocumentContextMapping.ts
+++ b/src/utils/agentDocumentContextMapping.ts
@@ -69,8 +69,8 @@ export const toAgentContextDocument = (doc: AgentDocumentContextPayload): AgentC
  * child's `parentId` points at the folder's `documentId` (`documents.id`),
  * while the surviving context docs are keyed by their own `agentDocuments.id`
  * — so folder-title resolution has to happen here, not in the injector. The
- * progressive index then folds same-folder siblings into one summary row
- * without ever consuming the folder body's token budget (LOBE-11072).
+ * progressive index folds same-folder siblings into one summary row without
+ * ever consuming the folder body's token budget.
  */
 export const toAgentContextDocuments = (
   docs: AgentDocumentContextPayload[],


### PR DESCRIPTION
## Summary

This PR removes all remaining `LOBE-XXX` marker references from the source code and replaces them with descriptive context based on the resolved Linear issues. These markers were internal tracking notes that should not be exposed in the open-source codebase.

## Changes

22 files were modified across the full stack:

### Database / Schema
- `packages/database/src/models/document.ts` — LOBE-11040 → inline description of deferred RAG-lane work
- `packages/database/src/models/task.ts` — LOBE-10946, LOBE-11027, LOBE-11028 → replaced with descriptive invariant documentation
- `packages/database/src/schemas/task.ts` — LOBE-11028 → replaced with design rationale

### Agent Runtime
- `packages/agent-runtime/src/executors/humanApprove.ts` — LOBE-10949 → replaced with descriptive doc

### Server (TRPC Routers & Services)
- `apps/server/src/routers/lambda/agentDocument.ts` — LOBE-11072
- `apps/server/src/routers/lambda/task.ts` — LOBE-10961 ×2, LOBE-10962 ×3
- `apps/server/src/services/task/index.ts` — LOBE-10962

### Frontend
- `src/features/AgentTasks/` — LOBE-10961 ×3, LOBE-10944
- `src/utils/agentDocumentContextMapping.ts` — LOBE-11072
- `src/store/task/` — LOBE-10961, LOBE-10973

### Tests
- Test files in `packages/database/`, `apps/server/`, `src/` — LOBE-10893, LOBE-10961, LOBE-10962, LOBE-11028, LOBE-11055, LOBE-11072, LOBE-11078, LOBE-11218

## Cleaned markers

LOBE-10893, LOBE-10944, LOBE-10946, LOBE-10949, LOBE-10961, LOBE-10962, LOBE-10973, LOBE-11027, LOBE-11028, LOBE-11040, LOBE-11055, LOBE-11072, LOBE-11078, LOBE-11218

## Verification

```
$ grep -rn 'LOBE-[0-9]' --include='*.ts' --include='*.tsx' \
  --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=docs --exclude-dir=.github \
  src/ apps/ packages/
# No matches — all markers removed.
```

Auto-generated at 2026-07-03.