### PR TITLE
✨ feat(github): unify MCP issue label taxonomy and auto-label rescan requests

### DIFF
--- a/.claude/prompts/team-assignment.md
+++ b/.claude/prompts/team-assignment.md
@@ -124,7 +124,7 @@ Quick reference for assigning issues based on labels.
 
 **MCP marketplace listing/submission requests — @AmAzing129:**
 
-Requests to **add / submit / list a new MCP server** to the marketplace belong to @AmAzing129, not @arvinxx. These may also be processed by the **MCP Submission Handler** workflow (it redirects installable servers to the self-service CLI and closes them, and labels remote-only servers `mcp:remote` for manual review), but if a triage mention is posted, mention @AmAzing129.
+Requests to **add / submit / list a new MCP server** to the marketplace belong to @AmAzing129, not @arvinxx. These may also be processed by the **MCP Submission Handler** workflow (it redirects installable servers to the self-service CLI and closes them, labels non-installable servers `mcp:manual-review`, and labels rescan/refresh requests for existing listings `mcp:rescan`), but if a triage mention is posted, mention @AmAzing129.
 
 - Recognize them by: titles like `[Request] Add <name> to the MCP marketplace`, `[MCP] Add/Submit <name>`, `[MCP Submission] …`, `[MCP Plugin] …`; the body asks to list/index a specific MCP server and links its repo or endpoint.
 - This does **NOT** apply to the following — they still get a normal @mention:

--- a/.github/scripts/auto-handle-mcp-submission.ts
+++ b/.github/scripts/auto-handle-mcp-submission.ts
@@ -5,7 +5,7 @@
  * MCP listing requests are now self-service via the @lobehub/market-cli, so we
  * no longer take them through GitHub issues. This script runs when an issue is
  * opened: if it is a *new-server listing request* (and NOT a marketplace bug or
- * CLI feedback), it labels the issue `mcp-submission`, posts the redirect
+ * CLI feedback), it labels the issue `mcp:submission`, posts the redirect
  * template (pointing at the CLI, with the author's own repo filled in), and
  * closes it as `not_planned`. The comment invites the author to reopen if it
  * was closed by mistake.
@@ -13,6 +13,13 @@
  * Anything that is not a confident match is left untouched for normal triage.
  */
 
+import {
+  MCP_LABEL_COLORS,
+  MCP_LABEL_DESCRIPTIONS,
+  MCP_MANUAL_REVIEW_LABEL,
+  MCP_RESCAN_LABEL,
+  MCP_SUBMISSION_LABEL,
+} from './shared/mcp-labels';
 import { classify } from './shared/mcp-submission-classifier';
 
 declare global {
@@ -24,8 +31,6 @@ declare global {
 }
 
 const MARKER = '<!-- bot:mcp-submission -->';
-const LABEL = 'mcp-submission';
-const LABEL_REMOTE = 'mcp:remote';
 const REPO_PLACEHOLDER = 'https://github.com/<owner>/<repo>';
 
 interface GitHubLabel {
@@ -172,9 +177,31 @@ async function main(): Promise<void> {
   // Idempotency is handled per-step below (label adds are idempotent, the close is a
   // no-op on an already-closed issue, and the redirect comment is guarded by its
   // marker), so a re-run after a partial failure safely completes the missing steps.
-  const { delivery, isSubmission, reason, repoUrl } = classify(issue.title || '', issue.body || '');
-  console.log(`[INFO] Classification: ${isSubmission ? 'SUBMISSION' : 'skip'} — ${reason}`);
+  const { delivery, isSubmission, kind, reason, repoUrl } = classify(
+    issue.title || '',
+    issue.body || '',
+  );
+  console.log(`[INFO] Classification: ${kind} — ${reason}`);
   if (repoUrl) console.log(`[INFO] Extracted repo: ${repoUrl}`);
+
+  // Rescan / refresh requests against an existing listing get their own queue
+  // label and stay open: they need a maintainer (or future automation) to
+  // trigger a rescan, not the "use the CLI" redirect.
+  if (kind === 'listing-ops') {
+    await ensureLabel(
+      owner,
+      repo,
+      token,
+      MCP_RESCAN_LABEL,
+      MCP_LABEL_COLORS.rescan,
+      MCP_LABEL_DESCRIPTIONS.rescan,
+    );
+    await addLabel(owner, repo, token, issueNumber, MCP_RESCAN_LABEL);
+    console.log(
+      '[DONE] Existing-listing rescan request — labeled, left open (no comment, no close)',
+    );
+    return;
+  }
 
   if (!isSubmission) {
     console.log('[DONE] Not a listing request — leaving for normal triage');
@@ -182,24 +209,29 @@ async function main(): Promise<void> {
   }
 
   // Every detected listing request gets the category label.
-  await ensureLabel(owner, repo, token, LABEL, 'c5def5', 'MCP marketplace listing request');
-  await addLabel(owner, repo, token, issueNumber, LABEL);
+  await ensureLabel(
+    owner,
+    repo,
+    token,
+    MCP_SUBMISSION_LABEL,
+    MCP_LABEL_COLORS.submission,
+    MCP_LABEL_DESCRIPTIONS.submission,
+  );
+  await addLabel(owner, repo, token, issueNumber, MCP_SUBMISSION_LABEL);
 
   // Remote-only or unknown-delivery servers cannot be self-published through the
-  // CLI, so we must NOT send the "use the CLI" redirect or close them. Flag for a
-  // maintainer and leave open.
+  // CLI, so we must NOT send the "use the CLI" redirect or close them. Flag for
+  // maintainer review and leave open.
   if (delivery !== 'local') {
-    if (delivery === 'remote') {
-      await ensureLabel(
-        owner,
-        repo,
-        token,
-        LABEL_REMOTE,
-        'fbca04',
-        'Remote-only MCP server — not self-serviceable via the CLI, needs manual handling',
-      );
-      await addLabel(owner, repo, token, issueNumber, LABEL_REMOTE);
-    }
+    await ensureLabel(
+      owner,
+      repo,
+      token,
+      MCP_MANUAL_REVIEW_LABEL,
+      MCP_LABEL_COLORS.manualReview,
+      MCP_LABEL_DESCRIPTIONS.manualReview,
+    );
+    await addLabel(owner, repo, token, issueNumber, MCP_MANUAL_REVIEW_LABEL);
     console.log(
       `[DONE] ${delivery} delivery — left open for manual handling (no comment, no close)`,
     );

--- a/.github/scripts/shared/mcp-labels.ts
+++ b/.github/scripts/shared/mcp-labels.ts
@@ -1,0 +1,27 @@
+export const MCP_FEATURE_LABEL = 'feature:mcp';
+export const MCP_SUBMISSION_LABEL = 'mcp:submission';
+export const MCP_MANUAL_REVIEW_LABEL = 'mcp:manual-review';
+export const MCP_RESCAN_LABEL = 'mcp:rescan';
+export const MCP_TRIGGER_TRIAGE_LABEL = 'trigger:mcp-triage';
+
+export const MCP_LEGACY_SUBMISSION_LABEL = 'mcp-submission';
+export const MCP_LEGACY_REMOTE_LABEL = 'mcp:remote';
+
+export const MCP_LABEL_COLORS = {
+  feature: 'faf9f6',
+  manualReview: 'fbca04',
+  rescan: '1d76db',
+  submission: 'c5def5',
+  triggerTriage: 'ededed',
+} as const;
+
+export const MCP_LABEL_DESCRIPTIONS = {
+  feature:
+    'MCP-related issues across connectors, tools, marketplace, runtime, and desktop integration',
+  manualReview:
+    'MCP submission cannot be resolved by the self-service CLI; maintainer review required',
+  rescan:
+    'Existing MCP marketplace listing needs a rescan/refresh; maintainer or automation action required',
+  submission: 'MCP marketplace listing submission handled by the MCP submission workflow',
+  triggerTriage: 'Manually trigger MCP submission handling',
+} as const;

--- a/.github/scripts/shared/mcp-submission-classifier.ts
+++ b/.github/scripts/shared/mcp-submission-classifier.ts
@@ -3,6 +3,10 @@ export interface Classification {
   // self-published via the CLI; remote URL-only and unknown delivery go to humans.
   delivery: 'local' | 'remote' | 'unknown';
   isSubmission: boolean;
+  // Sub-category the triage bot routes on: a NEW listing submission, an ops
+  // request against an EXISTING listing (rescan / refresh / re-index / stuck
+  // scoring), or neither.
+  kind: 'listing-ops' | 'none' | 'submission';
   reason: string;
   repoUrl: string | null;
 }
@@ -85,6 +89,20 @@ export function classify(title: string, body: string): Classification {
       text,
     );
 
+  // Ops request against an EXISTING listing (rescan / refresh / re-index /
+  // stuck scoring). Kept high-precision like the submission path: an explicit
+  // rescan-style verb or "listing is stale" framing — not just any marketplace
+  // complaint — so product bugs that mention refreshing never match.
+  const isListingOps =
+    hasMcp &&
+    (/\bre-?scan(?:ned|ning)?\b|\bre-?index(?:ed|ing)?\b|refresh (?:the )?(?:existing )?(?:mcp )?(?:server )?(?:listing|metadata)|listing (?:is )?stale|stale (?:listing|scan|canonical)|scoring stuck|stuck scoring|canonical cache|重新扫描|重新索引|刷新.{0,6}(?:列表|收录|索引)/.test(
+      text,
+    ) ||
+      (/\b(?:listing|marketplace)\b|市场/.test(text) &&
+        /\bstale\b|\bscoring\b|\bstuck (?:at|on) v?\d/.test(text)));
+
+  const kind: Classification['kind'] = isListingOps ? 'listing-ops' : 'none';
+
   const isPublishingFlowFeedback =
     /publish-mcp|publishing skill/.test(text) &&
     /\b(?:feedback|wrong|confusing?|docs?|instructions?|guide|command sequence|not work|fail|error|bug|issue|problem|can'?t|cannot|unable)\b/.test(
@@ -123,15 +141,26 @@ export function classify(title: string, body: string): Classification {
           ? 'local'
           : 'unknown';
 
-  if (!hasMcp) return { delivery, isSubmission: false, reason: 'no "mcp" keyword', repoUrl };
+  if (!hasMcp) return { delivery, isSubmission: false, kind, reason: 'no "mcp" keyword', repoUrl };
+  // Listing-ops takes precedence over submission: "add X (rescan existing
+  // listing to v2)" is a rescan of an existing entry, not a new submission.
+  if (isListingOps)
+    return {
+      delivery,
+      isSubmission: false,
+      kind,
+      reason: 'rescan/refresh request for an existing marketplace listing',
+      repoUrl,
+    };
   if (!hasAddVerb)
-    return { delivery, isSubmission: false, reason: 'no add/submit intent', repoUrl };
+    return { delivery, isSubmission: false, kind, reason: 'no add/submit intent', repoUrl };
   if (!hasMarketContext)
-    return { delivery, isSubmission: false, reason: 'no marketplace context', repoUrl };
+    return { delivery, isSubmission: false, kind, reason: 'no marketplace context', repoUrl };
   if (!repoUrl && delivery !== 'remote')
     return {
       delivery,
       isSubmission: false,
+      kind,
       reason: 'no server reference (repo URL or endpoint)',
       repoUrl,
     };
@@ -139,15 +168,23 @@ export function classify(title: string, body: string): Classification {
     return {
       delivery,
       isSubmission: false,
+      kind,
       reason: 'looks like a marketplace/listing bug',
       repoUrl,
     };
   if (isCliFeedback)
-    return { delivery, isSubmission: false, reason: 'looks like CLI/publishing feedback', repoUrl };
+    return {
+      delivery,
+      isSubmission: false,
+      kind,
+      reason: 'looks like CLI/publishing feedback',
+      repoUrl,
+    };
 
   return {
     delivery,
     isSubmission: true,
+    kind: 'submission',
     reason: `new MCP server listing request (${delivery})`,
     repoUrl,
   };

--- a/.github/scripts/should-run-dedupe.ts
+++ b/.github/scripts/should-run-dedupe.ts
@@ -2,6 +2,13 @@
 
 import { appendFile } from 'node:fs/promises';
 
+import {
+  MCP_LEGACY_REMOTE_LABEL,
+  MCP_LEGACY_SUBMISSION_LABEL,
+  MCP_MANUAL_REVIEW_LABEL,
+  MCP_RESCAN_LABEL,
+  MCP_SUBMISSION_LABEL,
+} from './shared/mcp-labels';
 import { classify } from './shared/mcp-submission-classifier';
 
 interface GitHubLabel {
@@ -19,6 +26,14 @@ interface DedupeDecision {
   reason: string;
   shouldDedupe: boolean;
 }
+
+const MCP_DEDUPE_SKIP_LABELS = [
+  MCP_SUBMISSION_LABEL,
+  MCP_MANUAL_REVIEW_LABEL,
+  MCP_RESCAN_LABEL,
+  MCP_LEGACY_SUBMISSION_LABEL,
+  MCP_LEGACY_REMOTE_LABEL,
+] as const;
 
 async function githubRequest<T>(endpoint: string, token: string): Promise<T> {
   const response = await fetch(`https://api.github.com${endpoint}`, {
@@ -59,7 +74,7 @@ export function shouldDedupeIssue(issue: DedupeIssue): DedupeDecision {
     };
   }
 
-  if (hasLabel(issue, 'mcp-submission') || hasLabel(issue, 'mcp:remote')) {
+  if (MCP_DEDUPE_SKIP_LABELS.some((label) => hasLabel(issue, label))) {
     return {
       reason: 'MCP marketplace listing request is handled by the MCP submission workflow',
       shouldDedupe: false,
@@ -70,6 +85,12 @@ export function shouldDedupeIssue(issue: DedupeIssue): DedupeDecision {
   if (classification.isSubmission) {
     return {
       reason: `MCP marketplace listing request (${classification.delivery}) is handled by the MCP submission workflow`,
+      shouldDedupe: false,
+    };
+  }
+  if (classification.kind === 'listing-ops') {
+    return {
+      reason: 'MCP listing rescan request is handled by the MCP submission workflow',
       shouldDedupe: false,
     };
   }

--- a/tests/github-scripts/mcpLabels.test.ts
+++ b/tests/github-scripts/mcpLabels.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MCP_LABEL_DESCRIPTIONS,
+  MCP_MANUAL_REVIEW_LABEL,
+  MCP_RESCAN_LABEL,
+  MCP_SUBMISSION_LABEL,
+  MCP_TRIGGER_TRIAGE_LABEL,
+} from '../../.github/scripts/shared/mcp-labels';
+import { classify } from '../../.github/scripts/shared/mcp-submission-classifier';
+import { shouldDedupeIssue } from '../../.github/scripts/should-run-dedupe';
+
+describe('MCP issue labels', () => {
+  it('uses normalized names and descriptions for the MCP submission workflow', () => {
+    expect(MCP_SUBMISSION_LABEL).toBe('mcp:submission');
+    expect(MCP_MANUAL_REVIEW_LABEL).toBe('mcp:manual-review');
+    expect(MCP_RESCAN_LABEL).toBe('mcp:rescan');
+    expect(MCP_TRIGGER_TRIAGE_LABEL).toBe('trigger:mcp-triage');
+    expect(MCP_LABEL_DESCRIPTIONS.submission).toBe(
+      'MCP marketplace listing submission handled by the MCP submission workflow',
+    );
+    expect(MCP_LABEL_DESCRIPTIONS.manualReview).toBe(
+      'MCP submission cannot be resolved by the self-service CLI; maintainer review required',
+    );
+    expect(MCP_LABEL_DESCRIPTIONS.rescan).toBe(
+      'Existing MCP marketplace listing needs a rescan/refresh; maintainer or automation action required',
+    );
+  });
+
+  it('skips duplicate detection for MCP workflow labels', () => {
+    const baseIssue = {
+      body: '',
+      labels: [],
+      state: 'open',
+      title: 'Regular issue',
+    };
+
+    for (const label of [MCP_SUBMISSION_LABEL, MCP_MANUAL_REVIEW_LABEL, MCP_RESCAN_LABEL]) {
+      expect(
+        shouldDedupeIssue({
+          ...baseIssue,
+          labels: [{ name: label }],
+        }).shouldDedupe,
+      ).toBe(false);
+    }
+  });
+
+  it('skips duplicate detection for unlabeled rescan requests via the classifier', () => {
+    const decision = shouldDedupeIssue({
+      body: 'The marketplace listing is stuck on an old version, please rescan.',
+      labels: [],
+      state: 'open',
+      title: '[Request] Rescan elecz MCP listing to v1.9.6',
+    });
+    expect(decision.shouldDedupe).toBe(false);
+    expect(decision.reason).toContain('rescan');
+  });
+});
+
+describe('classify: listing-ops (rescan of an existing listing)', () => {
+  // Real historical issue titles from lobehub/lobehub.
+  const rescanTitles = [
+    '[MCP Marketplace] Scoring stuck for @apexfdn/copilot-mcp — manual rescan needed',
+    '[Request] Re-index jcdreamjc-wudao-mcp listing stale canonical cache',
+    '[Request] Rescan NodeOps-app/createos-mcp listing (updated website + docs URLs)',
+    '[Request] Refresh existing petropt-petro-mcp listing — stale v0.8.1 scan, now v1.0.0',
+    'Skill listing stale — mlava/scholar-sidekick-mcp not syncing from GitHub',
+    'Refresh stale Hive Intelligence MCP marketplace listings',
+    'Please refresh MCP server listing for repo: https://github.com/ashenud/spira-mcp',
+    '[Request] Refresh metadata for cisco-open-network-sketcher (Local MCP) - version, skills, prompts, resources',
+    '[Request] Refresh existing MeiGen MCP listing — stuck on v1.1.11, current is v1.3.0',
+    'MCP listing stale: @brandsystem/mcp shows v0.3.0, current is v0.4.5',
+    'MCP Server re-index request: degen0root-panchanga_api',
+  ];
+
+  it.each(rescanTitles)('flags "%s" as listing-ops', (title) => {
+    const result = classify(title, '');
+    expect(result.kind).toBe('listing-ops');
+    expect(result.isSubmission).toBe(false);
+  });
+
+  it('prefers listing-ops over submission when both intents appear', () => {
+    const result = classify(
+      '[Request] Add scholar-sidekick-mcp to the MCP marketplace (rescan existing v0.3.0 listing to v0.4.1)',
+      'https://github.com/mlava/scholar-sidekick-mcp — please rescan, npx install works.',
+    );
+    expect(result.kind).toBe('listing-ops');
+    expect(result.isSubmission).toBe(false);
+  });
+
+  it('does not flag MCP product bugs that merely mention refreshing or lists', () => {
+    const productBugTitles = [
+      'Custom MCP tools not auto-refreshing & install button hangs',
+      'Desktop 2.2.9: STDIO MCP tools/list succeeds, but connector.syncTools fails and no tool permissions are registered',
+      '自定义添加的mcp服务器无法自动更新工具列表',
+    ];
+    for (const title of productBugTitles) {
+      expect(classify(title, '').kind).toBe('none');
+    }
+  });
+
+  it('still classifies a plain new-server submission as submission', () => {
+    const result = classify(
+      '[MCP Submission] Add my weather server to the marketplace',
+      'Please add https://github.com/someone/weather-mcp — install with `npx weather-mcp`.',
+    );
+    expect(result.kind).toBe('submission');
+    expect(result.isSubmission).toBe(true);
+  });
+});


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #16059, #16182, #16615, #15330, #15274, #15121 (open rescan requests this label taxonomy is built for — intentionally **no** close keywords; they still need actual rescans).

Follow-up to #16282 (MCP submission handler).

#### 🔀 Description of Change

**1. Centralize the MCP label taxonomy** into `.github/scripts/shared/mcp-labels.ts` and rename to the `mcp:*` scheme:

| Old (hardcoded) | New (shared constant) |
| --------------- | --------------------- |
| `mcp-submission` | `mcp:submission` |
| `mcp:remote` | `mcp:manual-review` (now applied to **all** non-local deliveries, incl. `unknown`, so every submission needing a maintainer is queryable) |
| — | `mcp:rescan` (new) |

The labels were already renamed on GitHub; without this PR the bot recreates the legacy names on its next run (`ensureLabel` sees a 404 and re-creates `mcp-submission`).

**2. Auto-label rescan requests (`mcp:rescan`).** `classify()` now returns `kind: 'submission' | 'listing-ops' | 'none'`. Rescan / refresh / re-index / stuck-scoring requests against an **existing** marketplace listing — historically ~12 closed + 6 open issues, previously left unlabeled for manual triage — are detected with high-precision patterns and labeled `mcp:rescan`, left open, no redirect comment, no close. `listing-ops` takes precedence over `submission` ("add X (rescan existing listing to v2)" is a rescan, not a new submission).

**3. Dedupe preflight** skips `mcp:rescan` + classified listing-ops issues, and keeps skipping the legacy label names for issues labeled before the rename.

Also updates the stale `mcp:remote` reference in `.claude/prompts/team-assignment.md`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bunx vitest run tests/github-scripts/` — 29 tests pass (17 new in `mcpLabels.test.ts`, incl. real historical issue titles as positive/negative fixtures for the rescan detector).
- Dry-ran the new classifier against all 49 currently-open MCP issues: all 6 open rescan requests classified `listing-ops` with zero false positives; the 17 already-labeled submissions + 1 previously missed one (#15660) classified `submission`; all product bugs/feature requests classified `none`.

#### 📸 Screenshots / Videos

No UI changes.

#### 📝 Additional Information

The `mcp:rescan` label has already been created in the repo. Existing open rescan issues can be backfilled with `gh issue edit <n> --add-label "mcp:rescan"`; future ones are labeled automatically by the handler.
