### PR TITLE
🐛 fix(chat): pin client completion notification to the current run's reply

### DIFF
--- a/src/store/chat/slices/agentRun/actions/__tests__/streamingExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/streamingExecutor.test.ts
@@ -2654,7 +2654,12 @@ describe('StreamingExecutor actions', () => {
               ...state.messagesMap,
               [messageMapKey({ agentId: TEST_IDS.SESSION_ID, topicId: TEST_IDS.TOPIC_ID })]: [
                 {
+                  // The completion notification now anchors its body to THIS run's
+                  // assistant (findCompletionAssistantMessageId walks parentMessageId),
+                  // not a positional findLast — so the seeded assistant must descend
+                  // from the run's parentMessageId (TEST_IDS.USER_MESSAGE_ID) to be found.
                   ...createMockMessage({ id: 'assistant-notif', role: 'assistant' }),
+                  parentId: TEST_IDS.USER_MESSAGE_ID,
                   ...overrides,
                 },
               ],

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ChatStore } from '@/store/chat/store';
 
+import { messageMapKey } from '../../../../utils/messageMapKey';
 import type { AgentRuntimeType } from '../dispatch/agentDispatcher';
 import { buildRunLifecycle } from './buildRunLifecycle';
 import type { RunCompleteEvent, RunTerminalStatus, UserMessagePersistedEvent } from './types';
@@ -13,6 +14,22 @@ const agentSignalBridgeMock = vi.hoisted(() => ({
 
 vi.mock('@/store/chat/slices/agentRun/actions/lifecycle/agentSignalBridge', () => ({
   emitClientAgentSignalSourceEvent: agentSignalBridgeMock.emitClientAgentSignalSourceEvent,
+}));
+
+const desktopNotificationMock = vi.hoisted(() => ({
+  notifyDesktopAgentCompleted: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/store/chat/utils/desktopNotification', () => ({
+  notifyDesktopAgentCompleted: desktopNotificationMock.notifyDesktopAgentCompleted,
+}));
+
+// Force the desktop branch of afterRunComplete on (isDesktop is false in the
+// test env). Only afterRunComplete reads isDesktop, and it early-returns for
+// sub_agent runs before the check, so this is inert for every other test.
+vi.mock('@lobechat/const', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@lobechat/const')>()),
+  isDesktop: true,
 }));
 
 const OP = 'op1';
@@ -74,6 +91,7 @@ const completeEvent = (
 
 beforeEach(() => {
   agentSignalBridgeMock.emitClientAgentSignalSourceEvent.mockClear();
+  desktopNotificationMock.notifyDesktopAgentCompleted.mockClear();
 });
 
 describe('buildRunLifecycle.completeRun — transport-driven disposition', () => {
@@ -181,6 +199,70 @@ describe('buildRunLifecycle — sub-agent runs skip top-level effects', () => {
         completeEvent('gateway', { runScope: 'sub_agent', status: 'completed' }),
       ),
     ).resolves.toBeUndefined();
+    expect(desktopNotificationMock.notifyDesktopAgentCompleted).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildRunLifecycle.afterRunComplete — client desktop notification body', () => {
+  const KEY = messageMapKey(CONTEXT);
+  // parentMessageId for the run under test is 'u1' (see `lifecycle` helper), so
+  // the assistant this run produced is the child of 'u1'.
+  const thisTurnAssistant = {
+    content: 'second turn reply',
+    id: 'a-this',
+    parentId: 'u1',
+    role: 'assistant',
+  } as any;
+  const prevTurnAssistant = {
+    content: 'first turn reply',
+    id: 'a-prev',
+    parentId: 'u-prev',
+    role: 'assistant',
+  } as any;
+
+  it('anchors the body to THIS run reply even when messagesMap still ends on the previous turn', async () => {
+    const { get, store } = makeStore();
+    // messagesMap lags: its last assistant is the PREVIOUS turn. The current
+    // run's assistant has only settled into dbMessagesMap so far.
+    store.messagesMap = { [KEY]: [prevTurnAssistant] } as any;
+    store.dbMessagesMap = { [KEY]: [prevTurnAssistant, thisTurnAssistant] } as any;
+
+    await lifecycle('client', get).afterRunComplete(
+      completeEvent('client', { runtimeStatus: 'done' }),
+    );
+
+    expect(desktopNotificationMock.notifyDesktopAgentCompleted).toHaveBeenCalledTimes(1);
+    expect(desktopNotificationMock.notifyDesktopAgentCompleted).toHaveBeenCalledWith(
+      get,
+      expect.objectContaining({ content: 'second turn reply' }),
+    );
+  });
+
+  it('uses this run reply when it is present in messagesMap (linear happy path)', async () => {
+    const { get, store } = makeStore();
+    store.messagesMap = { [KEY]: [prevTurnAssistant, thisTurnAssistant] } as any;
+
+    await lifecycle('client', get).afterRunComplete(
+      completeEvent('client', { runtimeStatus: 'done' }),
+    );
+
+    expect(desktopNotificationMock.notifyDesktopAgentCompleted).toHaveBeenCalledWith(
+      get,
+      expect.objectContaining({ content: 'second turn reply' }),
+    );
+  });
+
+  it('suppresses the notification while this run assistant is still tool-calling', async () => {
+    const { get, store } = makeStore();
+    store.messagesMap = {
+      [KEY]: [{ ...thisTurnAssistant, content: 'partial', tools: [{ id: 'tool-1' }] }],
+    } as any;
+
+    await lifecycle('client', get).afterRunComplete(
+      completeEvent('client', { runtimeStatus: 'done' }),
+    );
+
+    expect(desktopNotificationMock.notifyDesktopAgentCompleted).not.toHaveBeenCalled();
   });
 });
 

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
@@ -27,10 +27,10 @@ vi.mock('@/store/chat/utils/desktopNotification', () => ({
 // Force the desktop branch of afterRunComplete on (isDesktop is false in the
 // test env). Only afterRunComplete reads isDesktop, and it early-returns for
 // sub_agent runs before the check, so this is inert for every other test.
-vi.mock('@lobechat/const', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@lobechat/const')>()),
-  isDesktop: true,
-}));
+vi.mock('@lobechat/const', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, isDesktop: true };
+});
 
 const OP = 'op1';
 const CONTEXT: ConversationContext = { agentId: 'a1', topicId: 't1' } as ConversationContext;

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
@@ -246,8 +246,23 @@ export const buildRunLifecycle = (
       if (adapter.runtimeType === 'client') {
         // CLIENT: notify only OUTSIDE tool-calling mode; content comes from the
         // in-memory store. No badge (preserves the prior client behavior).
+        //
+        // Anchor to the assistant message THIS run produced (walk from
+        // parentMessageId), NOT a positional findLast on the topic. On a later
+        // turn the fresh assistant can still be settling into messagesMap while
+        // the previous turn's assistant is the last populated one — a naive
+        // findLast then surfaces the PRIOR turn's reply as the notification body.
+        // Mirror emitComplete's dual-map (messagesMap → dbMessagesMap) lookup so
+        // the body is pinned to this run's freshest persisted content.
         const finalMessages = get().messagesMap[messageKey] || [];
-        const lastAssistant = finalMessages.findLast((m) => m.role === 'assistant');
+        const dbMessages = get().dbMessagesMap[messageKey] || [];
+        const assistantId =
+          findCompletionAssistantMessageId(finalMessages, parentMessageId, parentMessageType) ??
+          findCompletionAssistantMessageId(dbMessages, parentMessageId, parentMessageType);
+        const lastAssistant = assistantId
+          ? (finalMessages.find((m) => m.id === assistantId) ??
+            dbMessages.find((m) => m.id === assistantId))
+          : undefined;
         if (!lastAssistant?.content || lastAssistant?.tools) return;
 
         await notifyDesktopAgentCompleted(get, {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No tracked issue; reported via user screenshot: on a multi-turn conversation the 2nd completion notification showed the 1st turn's message. -->

#### 🔀 Description of Change

**Symptom:** In a multi-turn conversation, the desktop notification for the **second** turn's completion showed the **first** turn's message text.

**Root cause:** The client-runtime completion notification in `agentRun/actions/lifecycle/buildRunLifecycle.ts` (`afterRunComplete`) resolved its body via a positional lookup:

```ts
const lastAssistant = get().messagesMap[messageKey].findLast((m) => m.role === 'assistant');
```

This is **not anchored to the assistant message the finished run produced**, and it reads only `messagesMap` (the in-memory/UI map). When a later turn completes, its fresh assistant can still be settling into `messagesMap` while only `dbMessagesMap` holds it — so `messagesMap` still ends on the **previous** turn's assistant, and `findLast` returns that prior reply as the notification body.

**Fix:** Anchor the body to *this* run's assistant by walking from `parentMessageId` via `findCompletionAssistantMessageId(...)`, with a `dbMessagesMap` fallback — the exact dual-map pattern `emitComplete` already uses a few lines above in the same file. If the run's own assistant can't be resolved, we show nothing rather than a stale sibling turn's content.

Gateway / hetero paths are **unaffected**: they pass executor-resolved content (hetero's per-run `accContent`), which is already anchored to the current run.

#### 🧪 How to Test

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added regression coverage in `buildRunLifecycle.test.ts`:
- **stale-map case:** `messagesMap` ends on the previous turn's assistant while this run's assistant is only in `dbMessagesMap` → notification body must be **this** turn's reply, not the previous one.
- **linear happy path:** this run's assistant present in `messagesMap` → uses it.
- **tool-calling suppression:** run's assistant still has `tools` → no notification.

> ⚠️ **CI must run the tests.** This working environment is mid dependency-migration (missing `react-router` / an unfetchable `vite` tarball in the local pnpm store), so the vitest suite could not be executed locally. The change is small and mirrors the already-tested `emitComplete` lookup pattern.

#### 📝 Additional Information

Reproduces on the **client** runtime (e.g. a normal DeepSeek chat), which is the path that surfaces the real reply text as the notification body.