### PR TITLE
💄 style: Polish Codex heterogeneous agent profile UI

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/CodexQuotaMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/CodexQuotaMenu.tsx
@@ -76,12 +76,12 @@ const styles = createStaticStyles(({ css }) => ({
     transition: all 0.2s;
 
     &:hover {
-      color: ${cssVar.colorText};
+      color: ${cssVar.colorTextSecondary};
       background: ${cssVar.colorFillSecondary};
     }
   `,
   triggerOpen: css`
-    color: ${cssVar.colorText};
+    color: ${cssVar.colorTextSecondary};
     background: ${cssVar.colorFillSecondary};
   `,
   value: css`
@@ -321,9 +321,7 @@ const CodexQuotaMenu = memo<CodexQuotaMenuProps>(({ command, env }) => {
     >
       <Icon icon={GaugeIcon} size={14} />
       {sessionLeftPercent !== undefined && (
-        <span className={styles.value}>
-          {t('heteroAgent.codexQuota.compactLeft', { percent: sessionLeftPercent })}
-        </span>
+        <span>{t('heteroAgent.codexQuota.compactLeft', { percent: sessionLeftPercent })}</span>
       )}
       <Icon icon={ChevronDownIcon} size={12} />
     </button>

--- a/src/routes/(main)/agent/profile/index.tsx
+++ b/src/routes/(main)/agent/profile/index.tsx
@@ -95,9 +95,10 @@ const ProfileArea = memo(() => {
 // updateAgentConfig, which the server rejects under the lock) and while the lock
 // is still resolving — so it doesn't flash in then vanish once a lock is found.
 const AgentBuilderSlot = memo(() => {
+  const isHeterogeneous = useAgentStore(agentSelectors.isCurrentAgentHeterogeneous);
   const lockedByOther = useProfileStore(profileSelectors.lockedByOther);
   const lockPending = useProfileStore(profileSelectors.lockPending);
-  if (lockedByOther || lockPending) return null;
+  if (isHeterogeneous || lockedByOther || lockPending) return null;
   return <AgentBuilder />;
 });
 


### PR DESCRIPTION
## Summary

- Lighten the Codex quota trigger text so the compact quota chip uses the secondary text ramp instead of visually heavy primary text.
- Hide the right-side Agent Builder panel on heterogeneous Agent profile pages, including when the panel was previously left open in global UI state.

## Why

Heterogeneous agents such as Codex and Claude Code are driven by external runtimes, so the Agent Builder configuration panel is not applicable. The header toggle was already hidden for these agents, but the page-level `AgentBuilderSlot` still mounted the panel when the persisted right-panel state was open.

The quota trigger also forced the compact percentage back to default text color, which made the small control read heavier than adjacent secondary controls.

## Validation

- `git diff --check`
- `bunx eslint --quiet 'src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/CodexQuotaMenu.tsx'`
- `bunx stylelint 'src/routes/(main)/agent/features/Conversation/HeterogeneousChatInput/CodexQuotaMenu.tsx'`
- `bunx eslint --quiet 'src/routes/(main)/agent/profile/index.tsx'`
- `bunx stylelint 'src/routes/(main)/agent/profile/index.tsx'`