### PR TITLE
💄 style(ui): polish interface details across chat, community, and onboarding surfaces

### DIFF
--- a/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
+++ b/src/features/ChatInput/ActionBar/components/ActionDropdown.tsx
@@ -33,7 +33,7 @@ import {
 import DebugNode from '@/components/DebugNode';
 import { useIsMobile } from '@/hooks/useIsMobile';
 
-const styles = createStaticStyles(({ css }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   dropdownMenu: css`
     .ant-avatar {
       margin-inline-end: var(--ant-margin-xs);
@@ -41,6 +41,13 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   trigger: css`
     outline: none;
+
+    /* Keyboard users still need a landmark for where Enter will land. */
+    &:focus-visible {
+      border-radius: ${cssVar.borderRadius};
+      outline: 2px solid ${cssVar.colorPrimary};
+      outline-offset: 2px;
+    }
   `,
 }));
 

--- a/src/features/ChatInput/Desktop/FilePreview/FileList.tsx
+++ b/src/features/ChatInput/Desktop/FilePreview/FileList.tsx
@@ -10,6 +10,9 @@ import FileItem from './FileItem';
 const styles = createStaticStyles(({ css }) => ({
   container: css`
     overflow-x: scroll;
+
+    /* A swipe past the strip's edge must not fire the browser back gesture. */
+    overscroll-behavior-x: none;
     width: 100%;
   `,
 }));

--- a/src/features/Conversation/ChatInput/OpStatusTray.tsx
+++ b/src/features/Conversation/ChatInput/OpStatusTray.tsx
@@ -175,6 +175,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     transform-box: fill-box;
     fill: ${cssVar.colorPrimary};
     animation: op-status-tray-glyph-core 1.5s ease-in-out infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   `,
   glyphOrbit: css`
     transform-origin: center;
@@ -187,6 +191,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     stroke-width: 1.5;
 
     animation: op-status-tray-glyph-spin 2s linear infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   `,
 }));
 

--- a/src/features/Conversation/Messages/Task/ClientTaskDetail/InitializingState.tsx
+++ b/src/features/Conversation/Messages/Task/ClientTaskDetail/InitializingState.tsx
@@ -43,6 +43,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     background: linear-gradient(90deg, transparent, ${cssVar.colorPrimaryBgHover}, transparent);
 
     animation: ${shimmer} 2s infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      display: none;
+    }
   `,
 }));
 

--- a/src/features/Conversation/Messages/Tasks/shared/InitializingState.tsx
+++ b/src/features/Conversation/Messages/Tasks/shared/InitializingState.tsx
@@ -45,6 +45,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     background: linear-gradient(90deg, transparent, ${cssVar.colorPrimaryBgHover}, transparent);
 
     animation: ${shimmer} 2s infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      display: none;
+    }
   `,
 }));
 

--- a/src/features/Conversation/Messages/Tasks/shared/ProcessingState.tsx
+++ b/src/features/Conversation/Messages/Tasks/shared/ProcessingState.tsx
@@ -79,6 +79,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     background: linear-gradient(90deg, transparent, ${cssVar.colorPrimaryBgHover}, transparent);
 
     animation: ${shimmer} 2s infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      display: none;
+    }
   `,
   separator: css`
     width: 3px;

--- a/src/features/Electron/connection/WaitingAnim.tsx
+++ b/src/features/Electron/connection/WaitingAnim.tsx
@@ -31,14 +31,26 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
   pulse1: css`
     animation: ${airdropPulse} 3s ease-out infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   `,
 
   pulse2: css`
     animation: ${airdropPulse} 3s ease-out 1.2s infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   `,
 
   pulse3: css`
     animation: ${airdropPulse} 3s ease-out 1.8s infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   `,
   pulseBase: css`
     pointer-events: none;

--- a/src/routes/(main)/agent/features/Conversation/Header/Tags/ThreadSwitcher.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/Tags/ThreadSwitcher.tsx
@@ -65,10 +65,15 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
       background: ${cssVar.colorFillTertiary};
     }
 
-    &:focus,
-    &:focus-visible {
+    &:focus {
       outline: none;
       box-shadow: none;
+    }
+
+    /* Keep a visible landmark for keyboard focus (mirrors DeviceItem). */
+    &:focus-visible {
+      outline: 2px solid ${cssVar.colorPrimary};
+      outline-offset: -1px;
     }
 
     &[data-popup-open] {

--- a/src/routes/(main)/community/(detail)/agent/features/Details/Nav.tsx
+++ b/src/routes/(main)/community/(detail)/agent/features/Details/Nav.tsx
@@ -4,7 +4,14 @@ import { SOCIAL_URL } from '@lobechat/business-const';
 import { Flexbox, Icon, Tag } from '@lobehub/ui';
 import { Tabs } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
-import { BookOpenIcon, HistoryIcon, LayersIcon, ListIcon, SquareUserIcon } from 'lucide-react';
+import {
+  BookOpenIcon,
+  HistoryIcon,
+  LayersIcon,
+  ListIcon,
+  SquareArrowOutUpRight,
+  SquareUserIcon,
+} from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -15,6 +22,9 @@ import { useDetailContext } from '../DetailProvider';
 const styles = createStaticStyles(({ css, cssVar }) => {
   return {
     link: css`
+      display: inline-flex;
+      gap: 4px;
+      align-items: center;
       color: ${cssVar.colorTextDescription};
 
       &:hover {
@@ -26,8 +36,13 @@ const styles = createStaticStyles(({ css, cssVar }) => {
     `,
     tabsWrapper: css`
       scrollbar-width: none;
+
       overflow-x: auto;
+
+      /* A swipe past the tabs' edge must not fire the browser back gesture. */
+      overscroll-behavior-x: none;
       flex: 1;
+
       min-width: 0;
 
       &::-webkit-scrollbar {
@@ -106,6 +121,7 @@ const Nav = memo<NavProps>(({ mobile, setActiveTab, activeTab = AssistantNavKey.
       <Flexbox horizontal flex="none" gap={12} style={{ marginInlineStart: 12 }}>
         <a className={styles.link} href={SOCIAL_URL.discord} rel="noreferrer" target="_blank">
           {t('mcp.details.nav.needHelp')}
+          <Icon icon={SquareArrowOutUpRight} size={12} />
         </a>
       </Flexbox>
     </Flexbox>

--- a/src/routes/(main)/community/(detail)/provider/features/Details/Nav.tsx
+++ b/src/routes/(main)/community/(detail)/provider/features/Details/Nav.tsx
@@ -4,7 +4,7 @@ import { BRANDING_PROVIDER, SOCIAL_URL } from '@lobechat/business-const';
 import { Flexbox, Icon } from '@lobehub/ui';
 import { Tabs } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
-import { BookOpenIcon, BrainCircuitIcon, ListIcon } from 'lucide-react';
+import { BookOpenIcon, BrainCircuitIcon, ListIcon, SquareArrowOutUpRight } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import urlJoin from 'url-join';
@@ -16,6 +16,9 @@ import { useDetailContext } from '../DetailProvider';
 const styles = createStaticStyles(({ css, cssVar }) => {
   return {
     link: css`
+      display: inline-flex;
+      gap: 4px;
+      align-items: center;
       color: ${cssVar.colorTextDescription};
 
       &:hover {
@@ -85,6 +88,7 @@ const Nav = memo<NavProps>(({ mobile, setActiveTab, activeTab = ProviderNavKey.O
       >
         <a className={styles.link} href={SOCIAL_URL.discord} rel="noreferrer" target="_blank">
           {t('mcp.details.nav.needHelp')}
+          <Icon icon={SquareArrowOutUpRight} size={12} />
         </a>
         {identifier && (
           <a
@@ -97,6 +101,7 @@ const Nav = memo<NavProps>(({ mobile, setActiveTab, activeTab = ProviderNavKey.O
             )}
           >
             {t('mcp.details.nav.viewSourceCode')}
+            <Icon icon={SquareArrowOutUpRight} size={12} />
           </a>
         )}
         <a
@@ -106,6 +111,7 @@ const Nav = memo<NavProps>(({ mobile, setActiveTab, activeTab = ProviderNavKey.O
           target="_blank"
         >
           {t('mcp.details.nav.reportIssue')}
+          <Icon icon={SquareArrowOutUpRight} size={12} />
         </a>
       </Flexbox>
     </Flexbox>

--- a/src/routes/(main)/group/profile/features/Header/index.tsx
+++ b/src/routes/(main)/group/profile/features/Header/index.tsx
@@ -33,8 +33,13 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   tabsWrapper: css`
     scrollbar-width: none;
+
     overflow-x: auto;
+
+    /* A swipe past the tabs' edge must not fire the browser back gesture. */
+    overscroll-behavior-x: none;
     flex: 1;
+
     min-width: 0;
 
     &::-webkit-scrollbar {

--- a/src/routes/onboarding/features/AgentPickerStep/style.ts
+++ b/src/routes/onboarding/features/AgentPickerStep/style.ts
@@ -173,6 +173,10 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     background: ${cssVar.colorFillTertiary};
 
     animation: ${pulse} 1.5s ease-in-out infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   `,
   skeletonCard: css`
     display: flex;
@@ -188,6 +192,10 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     border-radius: ${cssVar.borderRadius};
     background: ${cssVar.colorFillTertiary};
     animation: ${pulse} 1.5s ease-in-out infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   `,
   skeletonPill: css`
     width: 72px;
@@ -197,5 +205,9 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     background: ${cssVar.colorFillTertiary};
 
     animation: ${pulse} 1.5s ease-in-out infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   `,
 }));

--- a/src/styles/loading.ts
+++ b/src/styles/loading.ts
@@ -57,5 +57,9 @@ export const shinyTextStyles = createStaticStyles(({ css, cssVar }) => ({
     background-size: 200% 100%;
 
     animation: ${shine} 1.5s linear infinite;
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
   `,
 }));


### PR DESCRIPTION
#### 🔀 Description of Change

Applies the interface-details checklist to 11 spots across 13 files. All changes are CSS/behavior only — no new locale keys, no API or store changes.

**Keyboard focus visibility restored** (bare `outline: none` stranded keyboard users; ring follows the existing DeviceItem/UpdateNotification `:focus-visible` pattern):

- `ChatInput/ActionBar/components/ActionDropdown` — dropdown trigger
- `agent/.../Header/Tags/ThreadSwitcher` — trigger removed both outline *and* box-shadow on focus

**Decorative animations gated behind `prefers-reduced-motion`** (functional loaders — NeuralNetworkLoading, CircleLoader, DotsLoading, in-flight spinners — intentionally keep animating since they convey state; only ambience is gated, mirroring the existing gates in DeviceManager/FollowUp):

- `Electron/connection/WaitingAnim` — 3 radar pulse rings (static rings + icon still convey waiting)
- Task `ProcessingState` / `InitializingState` ×2 — shimmer overlay hidden; the underlying progress bar remains
- `Conversation/ChatInput/OpStatusTray` — glyph core pulse + orbit spin (textual status + tabular metrics remain)
- `onboarding/AgentPickerStep` — skeleton pulse ×3 (static placeholder remains)
- `styles/loading.ts` `shinyText` — text sheen (static readable text remains)

**Horizontal scrollers no longer trigger the browser back gesture** (`overscroll-behavior-x: none`):

- `ChatInput/Desktop/FilePreview/FileList` — attachment strip in the chat input (an edge swipe here previously risked navigating away mid-draft)
- `group/profile` header tabs and `community/(detail)/agent` detail tabs (both hide their scrollbar, so the gesture hazard was invisible)

**External links marked as external** — community agent/provider detail nav links (Need help → Discord, View source code, Report issue) get the `SquareArrowOutUpRight` icon already used by SkillStore/TaskCallback links; link style becomes inline-flex to align it.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Keyboard focus invisible on chat action-bar dropdown / thread switcher | 2px primary focus-visible ring |
| Edge swipe on attachment strip could navigate back | Scroll contained |
| External community links looked internal | ↗ icon marks them |