### PR TITLE
🐛 fix(chat): expose select/forward action on finished hetero agent turns

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/Actions/index.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/index.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { UIChatMessage } from '@lobechat/types';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GroupActionsBar } from './index';
+
+const storeMock = vi.hoisted(() => ({ isGenerating: false }));
+
+// Flexbox → passthrough so we can read the inner MessageActionBar stub.
+vi.mock('@lobehub/ui', () => ({
+  Flexbox: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// Stub the action bar to expose the resolved `bar` / `menu` slots verbatim.
+vi.mock('../../components/MessageActionBar', () => ({
+  MessageActionBar: ({ bar, menu }: { bar?: string[]; menu?: string[] }) => (
+    <div
+      data-bar={(bar ?? []).join(',')}
+      data-menu={(menu ?? []).join(',')}
+      data-testid="action-bar"
+    />
+  ),
+}));
+
+vi.mock('../../../components/Reaction', () => ({
+  ReactionPicker: () => null,
+}));
+
+// isAssistantGroupItemGenerating(id) is called through useConversationStore; the
+// mocked hook feeds the selector our controllable flag.
+vi.mock('../../../store', () => ({
+  messageStateSelectors: {
+    isAssistantGroupItemGenerating: () => (isGenerating: boolean) => isGenerating,
+  },
+  useConversationStore: (selector: (v: boolean) => unknown) => selector(storeMock.isGenerating),
+}));
+
+const data = { id: 'group-1', role: 'assistantGroup', tools: [] } as unknown as UIChatMessage;
+
+const renderBar = (props: { contentId?: string }) =>
+  render(<GroupActionsBar data={data} id="group-1" {...props} />);
+
+describe('GroupActionsBar — hetero (assistantGroup) forward/select gating', () => {
+  it('still generating with no text block → only delete', () => {
+    storeMock.isGenerating = true;
+    renderBar({ contentId: undefined });
+
+    const bar = screen.getByTestId('action-bar');
+    expect(bar).toHaveAttribute('data-bar', 'del');
+    expect(bar).toHaveAttribute('data-menu', '');
+  });
+
+  it('finished but last block is a tool call → exposes share + select (forward entry) + delete', () => {
+    storeMock.isGenerating = false;
+    renderBar({ contentId: undefined });
+
+    const bar = screen.getByTestId('action-bar');
+    // This is the heterogeneous-agent gap: a completed CC/Codex turn that ends on
+    // a tool block used to fall into the delete-only "in progress" bar, hiding the
+    // forward (`select`) and `share` entries. It must now surface them.
+    const menu = bar.getAttribute('data-menu') ?? '';
+    expect(menu.split(',')).toContain('select');
+    expect(menu.split(',')).toContain('share');
+    expect(menu.split(',')).toContain('del');
+    expect(bar).toHaveAttribute('data-bar', 'delAndRegenerate');
+  });
+
+  it('finished with a trailing text block → full menu (unchanged native behavior)', () => {
+    storeMock.isGenerating = false;
+    renderBar({ contentId: 'block-text' });
+
+    const bar = screen.getByTestId('action-bar');
+    const menu = bar.getAttribute('data-menu') ?? '';
+    expect(menu.split(',')).toContain('select');
+    expect(menu.split(',')).toContain('share');
+    expect(menu.split(',')).toContain('edit');
+  });
+});

--- a/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Actions/index.tsx
@@ -3,6 +3,7 @@ import { Flexbox } from '@lobehub/ui';
 import { memo, useMemo } from 'react';
 
 import { ReactionPicker } from '../../../components/Reaction';
+import { messageStateSelectors, useConversationStore } from '../../../store';
 import type { MessageActionsConfig } from '../../../types';
 import {
   MessageActionBar,
@@ -25,6 +26,12 @@ const DEFAULT_MENU: MessageActionSlot[] = [
   'del',
 ];
 const IN_PROGRESS_BAR: MessageActionSlot[] = ['del'];
+// Finished turn whose last child block is a tool call (typical for heterogeneous
+// CC/Codex turns, which end on a Bash/Read/Edit/Task block with no trailing text).
+// There's no text block to edit/copy, but the turn IS complete — it can still be
+// shared and, crucially, multi-selected/forwarded like a native reply.
+const NO_TEXT_BLOCK_BAR: MessageActionSlot[] = ['delAndRegenerate'];
+const NO_TEXT_BLOCK_MENU: MessageActionSlot[] = ['share', 'select', 'divider', 'del'];
 
 interface GroupActionsProps {
   actionsConfig?: MessageActionsConfig;
@@ -41,10 +48,19 @@ export const GroupActionsBar = memo<GroupActionsProps>(
       [contentBlock, data, id],
     );
 
-    // No finalized text block yet (group is either empty or last child is a
-    // still-running tool call). Only delete is meaningful here.
+    const isGenerating = useConversationStore(
+      messageStateSelectors.isAssistantGroupItemGenerating(id),
+    );
+
+    // No finalized text block (group is empty, or its last child is a tool call).
     if (!contentId) {
-      return <MessageActionBar bar={IN_PROGRESS_BAR} ctx={ctx} />;
+      // Still streaming → only delete is meaningful.
+      if (isGenerating) {
+        return <MessageActionBar bar={IN_PROGRESS_BAR} ctx={ctx} />;
+      }
+      // Finished, but the turn ends on a tool-call block — no text to edit/copy,
+      // yet it's a complete reply that can be shared and multi-selected/forwarded.
+      return <MessageActionBar bar={NO_TEXT_BLOCK_BAR} ctx={ctx} menu={NO_TEXT_BLOCK_MENU} />;
     }
 
     const defaultBar = data.tools ? DEFAULT_BAR_WITH_TOOLS : DEFAULT_BAR;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

The multi-select → **forward** entry (and **share**) never appeared on
heterogeneous agent (Claude Code / Codex) messages, while native agent replies
had it.

Root cause: `GroupActionsBar` (`AssistantGroup/Actions`) gates the full action
menu behind `contentId`, which `getGroupLatestMessageWithoutTools` returns as
`undefined` whenever the group's **last child block is a tool call** or has no
text content. Heterogeneous turns almost always end on a tool-call block
(Bash / Read / Edit / Task), so even after completing they fell into the
delete-only "in progress" bar — hiding `select` (the forward entry) and `share`.

Fix: distinguish a genuinely-generating group from a finished one whose last
block is a tool call, via `isAssistantGroupItemGenerating`. The former keeps the
delete-only bar; the latter now surfaces **share / select / delete**. The
forward pipeline itself was already wired (`assistantGroup` is in
`SELECTABLE_ROLES` and `buildForwardedContent` joins group child blocks) — only
the hover-menu entry was missing.

#### 🧪 How to Test

In the desktop app, open a Claude Code / Codex agent, run a turn that ends on a
tool call (e.g. a single `sleep 20` Bash tool, stopped mid-run). Hover the reply
→ the `…` menu now shows **分享 / 多选 / 删除**; click **多选** → selection mode
opens with the hetero message pre-checked and a **转发** footer.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added a `GroupActionsBar` test covering the three states: generating + no text →
delete only; finished + tool-ending → share/select/del exposed; finished + text
block → full menu.

#### 📸 Screenshots / Videos

Verification report (Electron E2E, with screenshots): https://app.lobehub.com/verify/5a7ad981-ef89-4dba-860e-9b4548aaef60

| Before | After |
| ------ | ----- |
| finished hetero (tool-ending) reply showed a single delete icon, no overflow menu → no way to select/forward | overflow menu shows 分享 / 多选 / 删除; 多选 enters selection mode with a 转发 footer |

#### 📝 Additional Information

Single-layer UI change (`src/features` only). No API/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)