### PR TITLE
🐛 fix(chat): expose select/forward action on finished hetero agent turns

### DIFF
--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -59,7 +59,34 @@ See `probe-mock-patterns.md` for the full working recipes.
 
 ---
 
-## Case 3 — Asserting a capture/tooling root cause from plausibility instead of measuring it
+## Case 3 — Deriving the task from commit messages / branch name instead of the actual ask
+
+**Wrong approach**: on a resumed session with lost prior context, reading the
+branch name (`fix/hetero-callback-signal-metadata`) and top commits (signal
+metadata + Monitor re-enable) and concluding _that_ was the thing to verify —
+then spinning up a whole Monitor E2E — when the user's real task (" 异构 Agent
+消息块转发功能缺失 ") was an entirely different feature (message multi-select /
+forward not exposed on hetero agents). Made the user say "你是丢失上下文了吗？"
+and "你理解错了" twice.
+
+**Why it's wrong**: a branch's committed work is not necessarily the current
+ask. When context was summarized/lost, the commit history is a _hypothesis_, not
+the task. The task lives in the user's words.
+
+**What it breaks**: burned a full Monitor test run + two rounds of clarifying
+questions on the wrong feature before course-correcting.
+
+**Correct approach**: when the user references a task you don't have in context,
+say so plainly and RECOVER it before acting — check `.records/reports/` for
+prior sessions on this branch, read the live conversation's own messages (the
+desktop app persists them; the very first user turn is usually the task), or ask
+for a pointer. Only translate the ask into code/commits after it's grounded.
+Note: the LobeHub desktop app conversation you're driving may BE the host session
+running you — its message list is the source of truth for what was asked.
+
+---
+
+## Case 4 — Asserting a capture/tooling root cause from plausibility instead of measuring it
 
 **Wrong approach**: when a screenshot came out black and CDP capture failed, I
 declared root causes from what "sounded right" and published them: first
@@ -85,7 +112,7 @@ ship a root cause into a report that a one-line probe could have checked.
 
 ---
 
-## Case 4 — (placeholder) append the user's next negative feedback below
+## Case 5 — (placeholder) append the user's next negative feedback below
 
 <!-- New case template:
 ## Case N — one-line summary of the mistake

--- a/.agents/skills/agent-testing/references/probe-mock-patterns.md
+++ b/.agents/skills/agent-testing/references/probe-mock-patterns.md
@@ -210,7 +210,41 @@
   screenshot/query; a click-the-Retry-then-observe flow is timing-flaky — fire it
   via `button.click()` in `eval` right after re-triggering, or extend the toast
   duration.
-- **D6. `agent-browser screenshot` can WEDGE the daemon; `eval`/`get` still work.**
+- **D6. The singleton hover action bar is hard to drive; its icons are
+  `div[role=button]`, NOT `<button>`.** The per-message action bar
+  (`SingletonMessageActionsBar`) is one portal that moves via DOM + a
+  freeze/commit `MutationObserver`, so it appears only while hovering and
+  re-hides on the next commit tick. Gotchas that wasted a run:
+  - `host.querySelectorAll('button')` returns 0 — the ActionIcon items render as
+    `<div role="button">`. Query `[role="button"]` (or the broad
+    `button,[role=button],[class*=ActionIcon]`).
+  - Between two evals the bar can vanish (commit tick). Do hover + inspect + act
+    in as few steps as possible.
+  - ✅ WORKS to open the overflow menu on a message and read its items:
+    ```bash
+    S="--session s9224 --cdp 9224"
+    agent-browser $S hover "#<messageId>" # ChatItem root id = message id
+    sleep 1.5
+    # click the LAST role=button in the host = the "…" overflow trigger
+    agent-browser $S eval '(function(){var h=document.querySelector("[data-singleton-message-action-bar-host]");var b=h&&h.querySelectorAll("[role=button]");if(!b||!b.length)return "no-bar";b[b.length-1].click();return "clicked";})()'
+    sleep 1
+    agent-browser $S screenshot /abs/menu.png
+    agent-browser $S eval '(function(){var t=[];document.querySelectorAll("[role=menuitem],li").forEach(function(i){var s=(i.innerText||"").trim();if(s)t.push(s);});return JSON.stringify(Array.from(new Set(t)));})()'
+    ```
+    A programmatic `.click()` on the ellipsis DOES open the antd dropdown (it sets
+    `data-popup-open`, which also freezes the bar so it won't vanish). The action
+    labels are localized (`分享`/`多选`/`删除` = share/select/del).
+- **D7. To get a _finished_ hetero (CC/Codex) turn that ENDS on a tool block**
+  (last child has tools → `getGroupLatestMessageWithoutTools` returns undefined,
+  the `!contentId` action-bar path): send a single long tool call (e.g.
+  `用 Bash 工具运行 sleep 20`) and, the moment the group's last child is a running
+  tool, call `stopGenerateMessage()` in the SAME eval to avoid the race where CC
+  appends a trailing text summary (which would give it a text last-block and a
+  defined contentId). Poll-then-stop-atomically:
+  ```bash
+  agent-browser $S eval '(function(){var c=window.__LOBE_STORES.chat();var t=c.activeTopicId;var a=c.messagesMap["main_"+c.activeAgentId+"_"+t]||[];var g=a.filter(m=>m.role==="assistantGroup").pop();var lc=g&&g.children&&g.children.at(-1);var running=Object.values(c.operations||{}).some(o=>o.status==="running");if(lc&&(lc.tools||[]).length&&running){c.stopGenerateMessage();return "STOPPED";}return "wait";})()'
+  ```
+- **D8. `agent-browser screenshot` can WEDGE the daemon; `eval`/`get` still work.**
   agent-browser is a daemon (`~/.agent-browser/default.sock`, one serialized
   socket). A screenshot RPC that is interrupted — a mis-invoked flag, a command
   the harness auto-backgrounds then kills, `--full` on a giant page — leaves the
@@ -218,23 +252,23 @@
   `Resource temporarily unavailable (os error 35)` / `CDP response channel closed`
   while `eval`/`get url` keep working. **Not** a display-sleep or permission issue.
   - **Works**: reset with `agent-browser close --all` (respawns the daemon), or
-    skip the daemon entirely (D7).
-- **D7. ✅ WORKS — raw-CDP screenshot, bypasses the daemon.**
+    skip the daemon entirely (D9).
+- **D9. ✅ WORKS — raw-CDP screenshot, bypasses the daemon.**
   `scripts/cdp-screenshot.sh [--port 9222] [--out x.png] [--full] [--check]`
   opens its own ws to the target, does one `Page.captureScreenshot`, closes
-  (\~60ms). Immune to the D6 wedge, and **verified robust when the display is
+  (\~60ms). Immune to the D8 wedge, and **verified robust when the display is
   ASLEEP and when the window is MINIMIZED/occluded** (Chromium forces a compositor
   frame). Use it for Electron evidence and as a preflight (`--check` → exit 0 iff a
   real, non-black frame was captured). Needs repo `node_modules/ws` (resolved via
   NODE\_PATH by the wrapper).
-- **D8. OS `screencapture` is BLACK when the display is asleep/locked/screensaver.**
-  Distinct from D6/D7: `screencapture` (and `capture-app-window.sh`, osascript
+- **D10. OS `screencapture` is BLACK when the display is asleep/locked/screensaver.**
+  Distinct from D8/D9: `screencapture` (and `capture-app-window.sh`, osascript
   grabs) captures the physical framebuffer, so an idle-slept display → a uniformly
   black PNG (mean/max=0; a full-screen black frame has a telltale identical byte
   size). Permission can be fine. Gate with `scripts/check-screen-recording.sh`
   (checks `CGPreflightScreenCaptureAccess` + a real-frame blackness probe) and keep
   the display awake for the whole run: `caffeinate -dimsu &` (or `caffeinate -u`
-  to wake it). CDP capture (D7) does not have this problem.
+  to wake it). CDP capture (D9) does not have this problem.
 
 ---
 

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
@@ -269,7 +269,7 @@ export const buildRunLifecycle = (
 
       await notifyDesktopAgentCompleted(get, {
         badge: true,
-        content: event.notification?.content ?? fallbackContent,
+        content: event.notification?.content || fallbackContent,
         context: notificationContext,
       });
     },


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 🐛 fix
- [x] 📝 docs

### 🔀 变更说明 | Description of Change

The multi-select → forward entry (and share) never appeared on heterogeneous agent (Claude Code / Codex) messages. `GroupActionsBar` gated the full menu behind `contentId`, which `getGroupLatestMessageWithoutTools` returns as `undefined` whenever the group's last child block is a tool call or has no text. Hetero turns almost always end on a tool-call block (Bash/Read/Edit/Task), so they fell into the delete-only "in progress" bar even after completing — hiding `select` (the forward entry) and `share`.

Fix: distinguish a genuinely-generating group from a finished one whose last block is a tool call via `isAssistantGroupItemGenerating`. The former keeps the delete-only bar; the latter now surfaces share / select / delete. The forward pipeline itself was already wired (`assistantGroup` is in `SELECTABLE_ROLES` and `buildForwardedContent` joins group child blocks) — only the entry was missing. Adds a `GroupActionsBar` test asserting all three states.

Also captures the agent-testing lessons from probing this flow (singleton hover action bar is `div[role=button]` not `<button>`; how to force a finished tool-ending hetero turn) into the `agent-testing` skill references.

### 📝 补充信息 | Additional Information

<!-- n/a -->

### ✅ 测试 | How to Test

- [x] Unit test — `GroupActionsBar` asserts delete-only (generating), full menu (finished tool-ending turn), and full menu (text-ending turn)
- Manual: run a Claude Code / Codex turn that ends on a tool call, hover the finished message → the "…" overflow now shows 分享 / 多选 / 删除