### PR TITLE
💄 style(chat): fold only single-sentence status lines into the workflow

### DIFF
--- a/.agents/skills/agent-testing/SKILL.md
+++ b/.agents/skills/agent-testing/SKILL.md
@@ -282,6 +282,32 @@ do not open a login page; verify agent-browser first, then request the Network
 `Cookie:` header only if that verification fails. Full background and failure modes:
 [references/auth.md](./references/auth.md).
 
+### 0.5 — Screen-recording preflight (OS-capture surfaces only)
+
+macOS `screencapture` / osascript / bot-channel captures come out **entirely
+black** when Screen Recording (TCC) permission is missing OR — just as often —
+the **display is asleep / locked / on a screensaver** (permission is fine, but
+there is nothing lit to capture; this bites after a long idle test run). A black
+PNG is easy to mistake for a real capture, so gate BEFORE any OS-capture step:
+
+```bash
+./.agents/skills/agent-testing/scripts/check-screen-recording.sh # exit 0 = OS capture will work
+```
+
+It checks both layers — `CGPreflightScreenCaptureAccess` for permission and a
+real one-frame capture for blackness — and prints the exact fix (which `.app` to
+grant, or wake/unlock the display). `capture-app-window.sh` runs it automatically
+and refuses to write a black artifact (bypass with `SKIP_SCREEN_CHECK=1`).
+
+This gate is **only** for OS-capture surfaces (bot tests, `capture-app-window.sh`,
+osascript screenshots). CDP-based evidence (`agent-browser screenshot`,
+`record-app-screen.sh`) renders from the browser engine and is unaffected. Because
+the display can sleep mid-run, keep it awake for the whole capture session:
+
+```bash
+caffeinate -dimsu & # prevent display/idle sleep for the test run; kill when done
+```
+
 ## Step 1 — Pick the surface by change scope
 
 | Change scope                                            | Default surface                      | Why                                                               | Guide                              |
@@ -362,19 +388,21 @@ Surface guides above carry the detailed workflows. Shared infrastructure:
 
 All under `.agents/skills/agent-testing/scripts/`:
 
-| Script                    | Usage                                                                        |
-| ------------------------- | ---------------------------------------------------------------------------- |
-| `test-env.sh`             | Print/export the resolved local test env and ports                           |
-| `setup-auth.sh`           | One-stop auth setup & status check (`status` / `cli` / `web`)                |
-| `init-dev-env.sh`         | Self-contained local dev env (`setup-db` / `seed-user` / `dev-next` / `dev`) |
-| `app-probe.sh`            | LobeHub app probes: `auth` / `route` / `ops` / `goto <path>` / `errors`      |
-| `record-gif.sh`           | Frame-sequence → GIF for time-based behavior (streaming, timers, animations) |
-| `report-init.sh`          | Scaffold a structured test report (Step 3)                                   |
-| `electron-dev.sh`         | Manage Electron dev env (start/stop/status/restart, CDP 9222)                |
-| `capture-app-window.sh`   | Screenshot a specific app window (general; used by bot tests)                |
-| `record-app-screen.sh`    | Record app screen (video + periodic screenshots)                             |
-| `record-electron-demo.sh` | Record Electron app demo with ffmpeg                                         |
-| `agent-gateway/`          | Gateway probe / dump / analyze tools                                         |
+| Script                      | Usage                                                                                       |
+| --------------------------- | ------------------------------------------------------------------------------------------- |
+| `test-env.sh`               | Print/export the resolved local test env and ports                                          |
+| `setup-auth.sh`             | One-stop auth setup & status check (`status` / `cli` / `web`)                               |
+| `init-dev-env.sh`           | Self-contained local dev env (`setup-db` / `seed-user` / `dev-next` / `dev`)                |
+| `app-probe.sh`              | LobeHub app probes: `auth` / `route` / `ops` / `goto <path>` / `errors`                     |
+| `record-gif.sh`             | Frame-sequence → GIF for time-based behavior (streaming, timers, animations)                |
+| `report-init.sh`            | Scaffold a structured test report (Step 3)                                                  |
+| `check-screen-recording.sh` | Preflight: OS screen-capture works (macOS Screen Recording + display awake)                 |
+| `electron-dev.sh`           | Manage Electron dev env (start/stop/status/restart, CDP 9222)                               |
+| `cdp-screenshot.sh`         | Electron/Chrome screenshot via RAW CDP (bypasses agent-browser daemon); `--check` preflight |
+| `capture-app-window.sh`     | Screenshot a specific app window (general; used by bot tests)                               |
+| `record-app-screen.sh`      | Record app screen (video + periodic screenshots)                                            |
+| `record-electron-demo.sh`   | Record Electron app demo with ffmpeg                                                        |
+| `agent-gateway/`            | Gateway probe / dump / analyze tools                                                        |
 
 `app-probe.sh` is the LobeHub-specific fast path into app state — auth check,
 current route, running operations, and `goto <path>` quick navigation

--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -59,7 +59,33 @@ See `probe-mock-patterns.md` for the full working recipes.
 
 ---
 
-## Case 3 — (placeholder) append the user's next negative feedback below
+## Case 3 — Asserting a capture/tooling root cause from plausibility instead of measuring it
+
+**Wrong approach**: when a screenshot came out black and CDP capture failed, I
+declared root causes from what "sounded right" and published them: first
+"terminal lacks Screen Recording permission" (put it in the shipped report), then
+"CDP is immune to display sleep", then the opposite "headful CDP stalls when the
+display sleeps". Each was stated before running the experiment.
+
+**Why it's wrong**: every one was falsifiable in seconds and most were wrong.
+`CGPreflightScreenCaptureAccess` returned _granted_; a pixel probe showed the black
+frame was **display sleep**, not permission; a raw-CDP A/B (display asleep, window
+minimized) showed CDP capture works fine in both — so the real cause was the
+agent-browser daemon wedging (D5), not sleep at all.
+
+**What it breaks**: a **published report with a wrong root cause**, plus wasted
+round-trips flip-flopping and having to retract each claim.
+
+**Correct approach**: for any capture / permission / timing / "environment"
+failure, **reproduce and measure before asserting or publishing** — pixel
+brightness (mean/max) for blackness, `CGPreflightScreenCaptureAccess` for the TCC
+bit, an A/B with the variable toggled (display asleep vs awake; window normal vs
+minimized) to isolate the cause. State "confirmed by X" vs "suspected", and never
+ship a root cause into a report that a one-line probe could have checked.
+
+---
+
+## Case 4 — (placeholder) append the user's next negative feedback below
 
 <!-- New case template:
 ## Case N — one-line summary of the mistake

--- a/.agents/skills/agent-testing/references/probe-mock-patterns.md
+++ b/.agents/skills/agent-testing/references/probe-mock-patterns.md
@@ -210,6 +210,31 @@
   screenshot/query; a click-the-Retry-then-observe flow is timing-flaky — fire it
   via `button.click()` in `eval` right after re-triggering, or extend the toast
   duration.
+- **D6. `agent-browser screenshot` can WEDGE the daemon; `eval`/`get` still work.**
+  agent-browser is a daemon (`~/.agent-browser/default.sock`, one serialized
+  socket). A screenshot RPC that is interrupted — a mis-invoked flag, a command
+  the harness auto-backgrounds then kills, `--full` on a giant page — leaves the
+  socket half-consumed, and every later `screenshot` fails with
+  `Resource temporarily unavailable (os error 35)` / `CDP response channel closed`
+  while `eval`/`get url` keep working. **Not** a display-sleep or permission issue.
+  - **Works**: reset with `agent-browser close --all` (respawns the daemon), or
+    skip the daemon entirely (D7).
+- **D7. ✅ WORKS — raw-CDP screenshot, bypasses the daemon.**
+  `scripts/cdp-screenshot.sh [--port 9222] [--out x.png] [--full] [--check]`
+  opens its own ws to the target, does one `Page.captureScreenshot`, closes
+  (\~60ms). Immune to the D6 wedge, and **verified robust when the display is
+  ASLEEP and when the window is MINIMIZED/occluded** (Chromium forces a compositor
+  frame). Use it for Electron evidence and as a preflight (`--check` → exit 0 iff a
+  real, non-black frame was captured). Needs repo `node_modules/ws` (resolved via
+  NODE\_PATH by the wrapper).
+- **D8. OS `screencapture` is BLACK when the display is asleep/locked/screensaver.**
+  Distinct from D6/D7: `screencapture` (and `capture-app-window.sh`, osascript
+  grabs) captures the physical framebuffer, so an idle-slept display → a uniformly
+  black PNG (mean/max=0; a full-screen black frame has a telltale identical byte
+  size). Permission can be fine. Gate with `scripts/check-screen-recording.sh`
+  (checks `CGPreflightScreenCaptureAccess` + a real-frame blackness probe) and keep
+  the display awake for the whole run: `caffeinate -dimsu &` (or `caffeinate -u`
+  to wake it). CDP capture (D7) does not have this problem.
 
 ---
 

--- a/.agents/skills/agent-testing/scripts/capture-app-window.sh
+++ b/.agents/skills/agent-testing/scripts/capture-app-window.sh
@@ -24,6 +24,17 @@ set -euo pipefail
 PROCESS="${1:?Usage: capture-app-window.sh <process_name> <output_path>}"
 OUTPUT="${2:?Usage: capture-app-window.sh <process_name> <output_path>}"
 
+# Preflight: OS screen capture returns a fully-black image when Screen Recording
+# permission is missing OR the display is asleep/locked/screensavered. Fail fast with
+# remediation instead of silently writing a black artifact. Set SKIP_SCREEN_CHECK=1 to bypass.
+if [ "${SKIP_SCREEN_CHECK:-0}" != "1" ]; then
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  if ! "$SCRIPT_DIR/check-screen-recording.sh"; then
+    echo "[capture] Aborting: OS screen capture would be black. Fix the above, or wrap the run in 'caffeinate -dimsu' to keep the display awake." >&2
+    exit 1
+  fi
+fi
+
 # Find the CGWindowID for the target process using Swift + CGWindowList
 # Pass process name via environment variable (swift -e doesn't support -- args)
 WINDOW_ID=$(TARGET_PROCESS="$PROCESS" swift -e '

--- a/.agents/skills/agent-testing/scripts/cdp-capture.cjs
+++ b/.agents/skills/agent-testing/scripts/cdp-capture.cjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// cdp-capture.cjs — capture a screenshot from a CDP target via RAW DevTools protocol,
+// bypassing the agent-browser daemon. Proven reliable against headful Electron/Chrome
+// regardless of display sleep or window minimization/occlusion (Page.captureScreenshot
+// forces a compositor frame). Every CDP call is hard-timeout guarded so a stall fails
+// fast instead of wedging anything.
+//
+// Usage: node cdp-capture.cjs --port 9222 --out shot.png [--full] [--target-url <substr>] [--timeout 12000]
+// Prints one line of JSON: {"ok":true,"bytes":N,"ms":N,"targetUrl":"..."} or {"ok":false,"error":"..."}
+// Exit 0 on success, non-zero on failure/timeout.
+
+/* eslint-disable @typescript-eslint/no-require-imports -- standalone CJS tooling script */
+
+const http = require('node:http');
+const fs = require('node:fs');
+const WebSocket = require('ws');
+
+const arg = (k, d) => {
+  const i = process.argv.indexOf(k);
+  return i > -1 ? process.argv[i + 1] : d;
+};
+const has = (k) => process.argv.includes(k);
+const PORT = parseInt(arg('--port', '9222'), 10);
+const OUT = arg('--out', '/tmp/cdp-capture.png');
+const FULL = has('--full');
+const TURL = arg('--target-url', '');
+const TIMEOUT = parseInt(arg('--timeout', '12000'), 10);
+
+const done = (obj, code) => {
+  console.log(JSON.stringify(obj));
+  process.exit(code);
+};
+const httpGet = (path) =>
+  new Promise((res, rej) => {
+    const req = http.get({ host: '127.0.0.1', port: PORT, path }, (r) => {
+      let d = '';
+      r.on('data', (c) => (d += c));
+      r.on('end', () => {
+        try {
+          res(JSON.parse(d));
+        } catch (e) {
+          rej(e);
+        }
+      });
+    });
+    req.on('error', rej);
+    req.setTimeout(4000, () =>
+      req.destroy(
+        new Error(
+          'CDP HTTP timeout — is the app running with --remote-debugging-port=' + PORT + '?',
+        ),
+      ),
+    );
+  });
+
+function client(url) {
+  const ws = new WebSocket(url, { maxPayload: 512 * 1024 * 1024 });
+  const pending = new Map();
+  let id = 0;
+  const ready = new Promise((r, j) => {
+    ws.on('open', r);
+    ws.on('error', j);
+  });
+  ws.on('message', (m) => {
+    const o = JSON.parse(m);
+    if (o.id && pending.has(o.id)) {
+      pending.get(o.id)(o);
+      pending.delete(o.id);
+    }
+  });
+  const send = (method, params = {}, timeout = TIMEOUT) =>
+    new Promise((res, rej) => {
+      const myid = ++id;
+      pending.set(myid, (o) =>
+        o.error ? rej(new Error(method + ': ' + o.error.message)) : res(o.result),
+      );
+      ws.send(JSON.stringify({ id: myid, method, params }));
+      setTimeout(() => {
+        if (pending.has(myid)) {
+          pending.delete(myid);
+          rej(new Error('TIMEOUT ' + method + ' after ' + timeout + 'ms'));
+        }
+      }, timeout);
+    });
+  return { ws, ready, send };
+}
+
+(async () => {
+  const targets = await httpGet('/json');
+  const pages = targets.filter((t) => t.type === 'page' && t.webSocketDebuggerUrl);
+  const page = TURL ? pages.find((t) => (t.url || '').includes(TURL)) : pages[0];
+  if (!page) throw new Error('no page target found' + (TURL ? ' matching "' + TURL + '"' : ''));
+  const pg = client(page.webSocketDebuggerUrl);
+  await pg.ready;
+  let params = { format: 'png' };
+  if (FULL) {
+    const m = await pg.send('Page.getLayoutMetrics', {});
+    const s = m.cssContentSize || m.contentSize;
+    params = {
+      format: 'png',
+      captureBeyondViewport: true,
+      clip: { x: 0, y: 0, width: Math.ceil(s.width), height: Math.ceil(s.height), scale: 1 },
+    };
+  }
+  const t0 = Date.now();
+  const r = await pg.send('Page.captureScreenshot', params);
+  const buf = Buffer.from(r.data, 'base64');
+  fs.writeFileSync(OUT, buf);
+  done({ ok: true, bytes: buf.length, ms: Date.now() - t0, targetUrl: page.url }, 0);
+})().catch((e) => done({ ok: false, error: e.message }, 1));

--- a/.agents/skills/agent-testing/scripts/cdp-screenshot.sh
+++ b/.agents/skills/agent-testing/scripts/cdp-screenshot.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# cdp-screenshot.sh — Reliable Electron/Chrome screenshot via RAW CDP (bypasses the
+# agent-browser daemon) + optional preflight verdict.
+#
+# Why this exists: agent-browser's `screenshot` goes through a long-lived daemon that
+# can wedge ("CDP response channel closed" / "daemon busy") after an interrupted or
+# mis-invoked capture — and once wedged, every later screenshot fails while eval/get
+# still work. Raw `Page.captureScreenshot` is fast (~60ms) and robust: it forces a
+# compositor frame, so it works even when the DISPLAY IS ASLEEP or the WINDOW IS
+# MINIMIZED/OCCLUDED (both verified). Use this instead of `agent-browser screenshot`
+# for Electron evidence, and as a preflight to prove capture works before relying on it.
+#
+# Usage:
+#   ./cdp-screenshot.sh [--port 9222] [--out shot.png] [--full] [--target-url <substr>] [--check]
+#
+#   --check   preflight mode: capture a throwaway frame, verify it is non-black,
+#             print a PASS/FAIL verdict. Exit 0 only if a real frame was captured.
+#
+# Exit codes: 0 ok · 5 capture failed/timeout · 6 captured but BLACK · 7 node/ws missing
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+PORT=9222; OUT=""; CHECK=0; PASS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --port) PORT="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    --check) CHECK=1; shift ;;
+    --full|--target-url) PASS+=("$1"); [ "$1" = "--target-url" ] && { PASS+=("$2"); shift; }; shift ;;
+    *) PASS+=("$1"); shift ;;
+  esac
+done
+[ -z "$OUT" ] && OUT="${TMPDIR:-/tmp}/cdp-shot-$PORT.png"
+
+command -v node >/dev/null 2>&1 || { echo "[cdp-shot] node not found"; exit 7; }
+[ -d "$REPO_DIR/node_modules/ws" ] || { echo "[cdp-shot] node_modules/ws not found under $REPO_DIR (run pnpm install)"; exit 7; }
+
+res="$(NODE_PATH="$REPO_DIR/node_modules" node "$SCRIPT_DIR/cdp-capture.cjs" --port "$PORT" --out "$OUT" --timeout 12000 ${PASS[@]+"${PASS[@]}"} 2>&1)"
+ok="$(printf '%s' "$res" | sed -n 's/.*"ok":\([a-z]*\).*/\1/p')"
+
+if [ "$ok" != "true" ]; then
+  echo "[cdp-shot] CAPTURE FAILED: $res"
+  echo "[cdp-shot] Fix: ensure the app runs with --remote-debugging-port=$PORT and CDP is reachable (curl 127.0.0.1:$PORT/json/version). If agent-browser wedged the session earlier, reset it: 'agent-browser close --all'. Raw CDP here does not use that daemon."
+  exit 5
+fi
+
+# blackness verdict (sips + python3; skip silently if unavailable)
+verdict="unknown"; maxv=""
+if command -v sips >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
+  sips -z 16 16 "$OUT" --out "$OUT.s.png" >/dev/null 2>&1
+  sips -s format bmp "$OUT.s.png" --out "$OUT.bmp" >/dev/null 2>&1
+  maxv="$(python3 - "$OUT.bmp" <<'PY' 2>/dev/null || echo -1
+import sys
+d=open(sys.argv[1],'rb').read();off=int.from_bytes(d[10:14],'little');w=int.from_bytes(d[18:22],'little');h=abs(int.from_bytes(d[22:26],'little',signed=True))
+bpp=int.from_bytes(d[28:30],'little') or 24;B=bpp//8;row=((w*bpp+31)//32)*4;mx=0
+for y in range(h):
+  for x in range(w):
+    q=off+y*row+x*B
+    if q+2<len(d): mx=max(mx,d[q],d[q+1],d[q+2])
+print(mx)
+PY
+)"
+  rm -f "$OUT.s.png" "$OUT.bmp" 2>/dev/null
+  [[ "$maxv" =~ ^[0-9]+$ ]] && { (( maxv < 12 )) && verdict="black" || verdict="live"; }
+fi
+
+if [ "$verdict" = "black" ]; then
+  echo "[cdp-shot] CAPTURED BUT BLACK ($res). Unusual for CDP — check the page actually rendered (not a blank route)."
+  [ "$CHECK" = "1" ] && exit 6
+  exit 6
+fi
+
+echo "[cdp-shot] OK ($res)${maxv:+ maxBrightness=$maxv}"
+[ "$CHECK" = "1" ] && { rm -f "$OUT" 2>/dev/null; echo "[cdp-shot] PREFLIGHT PASS — CDP screenshot works on port $PORT."; }
+exit 0

--- a/.agents/skills/agent-testing/scripts/check-screen-recording.sh
+++ b/.agents/skills/agent-testing/scripts/check-screen-recording.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# check-screen-recording.sh — Preflight gate for OS-level screen capture (macOS).
+#
+# OS screenshots (`screencapture`, osascript, bot-channel captures) come out
+# ENTIRELY BLACK when either:
+#   1. Screen Recording (TCC) permission is not granted to the responsible app, or
+#   2. the display is asleep / locked / running a screensaver (permission is fine
+#      but there is nothing lit to capture — common after a long idle test run).
+# A black artifact is easy to mistake for a real capture, so gate on this BEFORE
+# any OS-capture step. CDP-based evidence (agent-browser screenshot, record-app-screen)
+# renders from the browser engine and is NOT affected — this check is only for the
+# OS-capture surfaces (bot tests, capture-app-window.sh, osascript screenshots).
+#
+# Usage:
+#   ./check-screen-recording.sh            # human-readable; exit 0 if OS capture will work
+#   ./check-screen-recording.sh --json     # machine-readable one-line JSON
+#
+# Exit codes:
+#   0  OS capture works (permission granted AND a live, non-black frame captured)
+#   0  non-macOS (OS capture N/A — use CDP evidence)
+#   3  permission NOT granted        → grant Screen Recording, then restart the app
+#   4  permission ok but frame BLACK → wake/unlock display, quit screensaver, or restart app
+#   2  could not determine (no screencapture/toolchain)
+#
+set -uo pipefail
+
+JSON=0
+for a in "$@"; do case "$a" in --json) JSON=1 ;; esac; done
+
+emit() { # $1=ok(true/false) $2=perm $3=capture $4=exit $5=message [$6=app]
+  if [[ $JSON == 1 ]]; then
+    printf '{"platform":"%s","ok":%s,"permission":"%s","capture":"%s","responsibleApp":"%s","message":"%s"}\n' \
+      "$(uname -s)" "$1" "${2:-unknown}" "${3:-unknown}" "${6:-}" "$5"
+  else
+    echo "[screen-recording] $5"
+  fi
+  exit "$4"
+}
+
+os=$(uname -s)
+if [[ "$os" != "Darwin" ]]; then
+  emit true "n/a" "n/a" 0 "non-macOS ($os): OS screen capture N/A; CDP-based evidence is unaffected. OK."
+fi
+
+# --- responsible app: TCC attributes Screen Recording to the ancestor .app bundle ---
+responsible_app() {
+  local pid=$$ ppid comm
+  for _ in $(seq 1 12); do
+    if ! read -r ppid comm < <(ps -o ppid=,comm= -p "$pid" 2>/dev/null); then break; fi
+    [[ -z "${ppid:-}" ]] && break
+    if [[ "$comm" == *.app/Contents/MacOS/* ]]; then
+      local app="${comm%%.app/*}"; echo "${app##*/}.app"; return 0
+    fi
+    [[ "${ppid:-0}" -le 1 ]] && break
+    pid=$ppid
+  done
+  echo "${TERM_PROGRAM:-your terminal app}"
+}
+APP="$(responsible_app)"
+
+# --- layer 1: TCC permission via CGPreflightScreenCaptureAccess (no prompt, no display) ---
+perm="unknown"
+bin="${TMPDIR:-/tmp}/lobehub-scrcheck"
+if [[ ! -x "$bin" ]] && command -v clang >/dev/null 2>&1; then
+  src="${TMPDIR:-/tmp}/lobehub-scrcheck.c"
+  cat > "$src" <<'EOF'
+#include <CoreGraphics/CoreGraphics.h>
+#include <stdio.h>
+int main(void){ bool ok = CGPreflightScreenCaptureAccess(); printf(ok?"granted\n":"denied\n"); return ok?0:1; }
+EOF
+  clang -framework CoreGraphics -o "$bin" "$src" 2>/dev/null || rm -f "$bin"
+fi
+if [[ -x "$bin" ]]; then
+  perm="$("$bin" 2>/dev/null || echo denied)"
+elif command -v swift >/dev/null 2>&1; then
+  perm="$(swift - <<'EOF' 2>/dev/null || echo denied
+import CoreGraphics
+print(CGPreflightScreenCaptureAccess() ? "granted" : "denied")
+EOF
+)"
+fi
+
+# --- layer 2: liveness — capture one real frame and detect a fully-black image ---
+# Uses the brightest pixel across a downscaled grid: a live desktop always has some
+# lit chrome (menu bar / cursor / window), a blocked/asleep capture is uniformly ~0.
+capture="unknown"; maxv=""
+if command -v screencapture >/dev/null 2>&1; then
+  shot="${TMPDIR:-/tmp}/lobehub-scrlive.png"
+  small="${TMPDIR:-/tmp}/lobehub-scrlive.bmp"
+  rm -f "$shot" "$small"
+  screencapture -x "$shot" 2>/dev/null || true
+  if [[ -s "$shot" ]] && command -v sips >/dev/null 2>&1 && command -v python3 >/dev/null 2>&1; then
+    sips -z 16 16 "$shot" --out "${shot}.s.png" >/dev/null 2>&1
+    sips -s format bmp "${shot}.s.png" --out "$small" >/dev/null 2>&1
+    if [[ -s "$small" ]]; then
+      maxv="$(python3 - "$small" <<'PY' 2>/dev/null || echo -1
+import sys
+d=open(sys.argv[1],'rb').read()
+off=int.from_bytes(d[10:14],'little')
+w=int.from_bytes(d[18:22],'little')
+h=abs(int.from_bytes(d[22:26],'little',signed=True))
+bpp=int.from_bytes(d[28:30],'little') or 24
+Bpp=bpp//8
+row=((w*bpp+31)//32)*4
+mx=0
+for y in range(h):
+    base=off+y*row
+    for x in range(w):
+        p=base+x*Bpp
+        if p+2 < len(d):
+            mx=max(mx, d[p], d[p+1], d[p+2])
+print(mx)
+PY
+)"
+      if [[ "${maxv:-}" =~ ^[0-9]+$ ]]; then
+        # brightest channel < 12/255 across the whole screen ⇒ effectively black
+        if (( maxv < 12 )); then capture="black"; else capture="live"; fi
+      fi
+    fi
+  fi
+  rm -f "$shot" "${shot}.s.png" "$small" 2>/dev/null || true
+fi
+
+# --- decision ---
+if [[ "$capture" == "live" ]]; then
+  emit true "$perm" "$capture" 0 "OK — Screen Recording works (permission granted, display live). OS captures and bot tests will render real frames." "$APP"
+fi
+
+if [[ "$capture" == "black" ]]; then
+  if [[ "$perm" == "denied" ]]; then
+    emit false "$perm" "$capture" 3 "BLOCKED — Screen Recording permission is NOT granted to '$APP'. Enable it in: System Settings ▸ Privacy & Security ▸ Screen Recording ▸ turn ON '$APP', then FULLY QUIT & reopen '$APP' (TCC only takes effect on a fresh launch). Until then every OS screenshot/recording and bot test will be BLACK." "$APP"
+  fi
+  emit false "$perm" "$capture" 4 "BLACK FRAME — permission looks OK but the capture is black. The display is likely asleep / locked / on a screensaver, or '$APP' was just granted permission but not restarted. Wake & unlock the display, disable the screensaver for the test run (caffeinate -d), or restart '$APP', then re-run this check." "$APP"
+fi
+
+# capture couldn't be measured → fall back to the permission verdict
+if [[ "$perm" == "denied" ]]; then
+  emit false "$perm" "$capture" 3 "BLOCKED — Screen Recording permission is NOT granted to '$APP'. Enable it: System Settings ▸ Privacy & Security ▸ Screen Recording ▸ turn ON '$APP', then fully quit & reopen '$APP'." "$APP"
+elif [[ "$perm" == "granted" ]]; then
+  emit true "$perm" "$capture" 0 "Permission granted for '$APP'; could not verify a live frame (no screencapture/sips/python3). Proceeding — if OS captures come out black, wake/unlock the display." "$APP"
+else
+  emit false "$perm" "$capture" 2 "UNDETERMINED — could not check Screen Recording permission or capture a test frame (missing clang/swift/screencapture). Verify manually in System Settings ▸ Privacy & Security ▸ Screen Recording for '$APP'." "$APP"
+fi

--- a/.agents/skills/agent-testing/ui/electron.md
+++ b/.agents/skills/agent-testing/ui/electron.md
@@ -55,26 +55,26 @@ instead of hand-rolling `__LOBE_STORES` eval snippets** for these common needs:
 ```bash
 PROBE=".agents/skills/agent-testing/scripts/app-probe.sh"
 
-$PROBE auth              # login check (Step 0.3) → { isSignedIn, userId }
-$PROBE route             # current SPA route
-$PROBE ops               # running chat operations (type / startTime)
-$PROBE goto /settings    # jump the SPA straight to a route (full reload)
-$PROBE errors-install    # install console.error interceptor
-$PROBE errors            # dump captured errors
+$PROBE auth           # login check (Step 0.3) → { isSignedIn, userId }
+$PROBE route          # current SPA route
+$PROBE ops            # running chat operations (type / startTime)
+$PROBE goto /settings # jump the SPA straight to a route (full reload)
+$PROBE errors-install # install console.error interceptor
+$PROBE errors         # dump captured errors
 ```
 
 `goto` lets a test enter the state under test directly instead of clicking
 through the UI. Common desktop routes:
 
-| Route                         | Where it lands                       |
-| ----------------------------- | ------------------------------------ |
-| `/`                           | Home (has a chat input)              |
-| `/agent/<agentId>`            | Agent conversation (latest topic)    |
-| `/agent/<agentId>/<topicId>`  | Specific topic in a conversation     |
-| `/task` · `/task/<taskId>`    | Task list / task detail              |
-| `/page`                       | Documents (文稿)                     |
-| `/settings`                   | Settings                             |
-| `/community`                  | Discover / community                 |
+| Route                        | Where it lands                    |
+| ---------------------------- | --------------------------------- |
+| `/`                          | Home (has a chat input)           |
+| `/agent/<agentId>`           | Agent conversation (latest topic) |
+| `/agent/<agentId>/<topicId>` | Specific topic in a conversation  |
+| `/task` · `/task/<taskId>`   | Task list / task detail           |
+| `/page`                      | Documents (文稿)                  |
+| `/settings`                  | Settings                          |
+| `/community`                 | Discover / community              |
 
 Targets default to Electron (`--cdp 9222`); set `AB_TARGET="--session <name>"`
 for web sessions. For deeper or one-off state inspection, fall back to raw
@@ -147,16 +147,39 @@ agent-browser --cdp 9222 eval "JSON.stringify(window.__CAPTURED_ERRORS)"
 
 ## Electron Gotchas
 
+- **`agent-browser screenshot` can wedge; prefer raw-CDP capture.** `agent-browser`
+  routes captures through a long-lived daemon. An interrupted or mis-invoked
+  screenshot (a stalled `--full` on a huge page, a killed/backgrounded command, a
+  bad flag) can leave the daemon's CDP session half-open, after which **every**
+  later screenshot fails with `CDP response channel closed` / `daemon busy` — even
+  though `eval` / `get url` still work. This is **not** a display-sleep or
+  permission problem: raw `Page.captureScreenshot` is fast (\~60ms) and works even
+  when the display is asleep or the window is minimized/occluded (verified). Use
+  the raw-CDP helper for Electron evidence and as a preflight:
+
+  ```bash
+  ./.agents/skills/agent-testing/scripts/cdp-screenshot.sh --check               # preflight: PASS ⇒ capture works
+  ./.agents/skills/agent-testing/scripts/cdp-screenshot.sh --out shot.png        # viewport
+  ./.agents/skills/agent-testing/scripts/cdp-screenshot.sh --out full.png --full # full page (captureBeyondViewport)
+  ```
+
+  If agent-browser's own screenshot has already wedged, reset it with
+  `agent-browser close --all` (raw-CDP does not use that daemon and is unaffected).
+
 - **Always use `electron-dev.sh stop` to clean up** — `pkill -f "Electron"` only kills the main process; helper processes (GPU, renderer, network) survive. The script finds and kills all of them via PID matching against the project's electron binary path.
+
 - **`npx electron-vite dev` must run from `apps/desktop/`** — running from project root fails silently. The `electron-dev.sh` script handles this automatically.
+
 - **Dev build auto-opens DevTools, which hijacks the CDP target** — `agent-browser --cdp 9222` may attach to the DevTools page (`devtools://…`) instead of the app (`app://renderer/`). Symptom: `get url` returns a `devtools://` URL. Fix: close the DevTools target and reconnect:
 
   ```bash
   DT_ID=$(curl -s http://localhost:9222/json/list | python3 -c "import json,sys; ts=json.load(sys.stdin); print(next(t['id'] for t in ts if t['type']=='page' and t['url'].startswith('devtools://')))")
   curl -s "http://localhost:9222/json/close/$DT_ID" > /dev/null
-  agent-browser close --all && agent-browser --cdp 9222 get url   # expect app://renderer/
+  agent-browser close --all && agent-browser --cdp 9222 get url # expect app://renderer/
   ```
 
 - **Don't resize the Electron window after load** — resizing triggers full SPA reload
+
 - **Store is at `window.__LOBE_STORES`** not `window.__ZUSTAND_STORES__`
+
 - **Streaming / ticking UI needs GIF evidence** — see `scripts/record-gif.sh`; a static screenshot cannot prove time-based behavior.

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -13,12 +13,11 @@ import type { AssistantContentBlock } from '@/types/index';
 import { messageStateSelectors, useConversationStore } from '../../../store';
 import CouncilList from '../../AgentCouncil/components/CouncilList';
 import { MessageAggregationContext } from '../../Contexts/MessageAggregationContext';
-import { POST_TOOL_FINAL_ANSWER_SCORE_THRESHOLD } from '../constants';
 import {
   areWorkflowToolsComplete,
   formatReasoningDuration,
   getPostToolAnswerSplitIndex,
-  scoreBlockContentAsAnswerLike,
+  isFoldableStatusLine,
 } from '../toolDisplayNames';
 import { CollapsedMessage } from './CollapsedMessage';
 import GroupItem from './GroupItem';
@@ -214,7 +213,8 @@ const appendWorkflowBlock = (
 const shouldPromoteMixedBlockContent = (block: AssistantContentBlock): boolean => {
   if (!hasTools(block) || !hasSubstantiveContent(block)) return false;
 
-  return scoreBlockContentAsAnswerLike(block) >= POST_TOOL_FINAL_ANSWER_SCORE_THRESHOLD;
+  // Only a single short status line stays folded with its tools; everything else is prose.
+  return !isFoldableStatusLine(block);
 };
 
 const appendWorkflowRangeBlock = (

--- a/src/features/Conversation/Messages/AssistantGroup/constants.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/constants.ts
@@ -60,40 +60,6 @@ export const TOOL_HEADLINE_DETAIL_TRUNCATE_LEN = 117;
 /** Suffix when truncating tool strings. */
 export const TOOL_HEADLINE_TRUNCATION_SUFFIX = '...';
 
-// ─── Post-tool “final answer” block promotion (Group partition) ───────────
-
-/** Sum of heuristic scores at or above this promotes visible prose out of workflow chrome. */
-export const POST_TOOL_FINAL_ANSWER_SCORE_THRESHOLD = 3;
-
-/** Add this score when compacted prose length ≥ this (long answer signal). */
-export const POST_TOOL_ANSWER_LENGTH_LONG_SCORE = 2;
-
-/** Lower bound (chars) for POST_TOOL_ANSWER_LENGTH_LONG_SCORE. */
-export const POST_TOOL_ANSWER_LENGTH_LONG_MIN_CHARS = 180;
-
-/** Add this score when length ∈ [medium min, long min). */
-export const POST_TOOL_ANSWER_MEDIUM_TEXT_SCORE = 1;
-
-/** Lower bound (chars) for medium-length contribution. */
-export const POST_TOOL_ANSWER_LENGTH_MEDIUM_MIN_CHARS = 100;
-
-/** Blank-line paragraphing: strong signal for structured deliverable. */
-export const POST_TOOL_ANSWER_DOUBLE_NEWLINE_SCORE = 2;
-
-/** Without \\n\\n, treat many non-empty lines as paragraphing when count ≥ this. */
-export const POST_TOOL_ANSWER_MULTI_LINE_SCORE = 2;
-
-/** Minimum trimmed lines (with at least one non-empty) to count as multi-line body. */
-export const POST_TOOL_ANSWER_MULTI_LINE_MIN_COUNT = 3;
-
-/** Markdown heading or list at line start: structured deliverable. */
-export const POST_TOOL_ANSWER_MARKDOWN_STRUCTURE_SCORE = 2;
-
-/** Add one point when sentence-ending punctuation count ≥ this (compact text). */
-export const POST_TOOL_ANSWER_PUNCT_MIN_COUNT = 3;
-
-export const POST_TOOL_ANSWER_PUNCT_SCORE = 1;
-
 // ─── Time formatting (workflow summary / reasoning suffix) ───────────────
 
 /** Seconds per minute when formatting durations like "2m 30s". */

--- a/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.test.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.test.ts
@@ -2,14 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import { type AssistantContentBlock } from '@/types/index';
 
-import { POST_TOOL_FINAL_ANSWER_SCORE_THRESHOLD } from './constants';
 import {
   getPostToolAnswerSplitIndex,
   getToolDisplayName,
   getWorkflowStreamingHeadlineState,
   getWorkflowSummaryText,
-  scoreBlockContentAsAnswerLike,
-  scorePostToolBlockAsFinalAnswer,
+  isFoldableStatusLine,
   shapeProseForWorkflowHeadline,
 } from './toolDisplayNames';
 
@@ -107,21 +105,32 @@ describe('shapeProseForWorkflowHeadline', () => {
   });
 });
 
-describe('post-tool final answer split', () => {
-  it('scores long structured content as answer-like even when tools share the block', () => {
-    const score = scoreBlockContentAsAnswerLike(
-      blk({
-        id: 'mixed',
-        content:
-          '先总结当前结论。\n\n## 下一步\n\n- 对比方案 A\n- 对比方案 B\n- 给出推荐与风险说明。',
-        tools: [{ apiName: 'search', id: 't1' } as any],
-      }),
-    );
-
-    expect(score).toBeGreaterThanOrEqual(POST_TOOL_FINAL_ANSWER_SCORE_THRESHOLD);
+describe('isFoldableStatusLine', () => {
+  it('keeps a single short status line folded', () => {
+    expect(isFoldableStatusLine(blk({ id: '0', content: '先重建 worktree:' }))).toBe(true);
+    expect(isFoldableStatusLine(blk({ id: '1', content: '现在我来搜索资料。' }))).toBe(true);
   });
 
-  it('returns split index for long structured prose-only block after last tool', () => {
+  it('keeps a single sentence with a dotted token folded', () => {
+    // "src/a.ts" and "Node.js" must not be counted as extra sentence boundaries.
+    expect(isFoldableStatusLine(blk({ id: '0', content: '已更新 src/a.ts 完成。' }))).toBe(true);
+    expect(isFoldableStatusLine(blk({ id: '1', content: '升级到 Node.js 24。' }))).toBe(true);
+  });
+
+  it('treats multi-sentence, multi-line, markdown or long lines as prose', () => {
+    expect(isFoldableStatusLine(blk({ id: '0', content: '第一句话。第二句话。' }))).toBe(false);
+    expect(isFoldableStatusLine(blk({ id: '1', content: '先总结。\n\n## 下一步' }))).toBe(false);
+    expect(isFoldableStatusLine(blk({ id: '2', content: '- 对比方案 A' }))).toBe(false);
+    expect(isFoldableStatusLine(blk({ id: '3', content: 'x'.repeat(120) }))).toBe(false);
+  });
+
+  it('treats empty / loading content as foldable (nothing to lift out)', () => {
+    expect(isFoldableStatusLine(blk({ id: '0', content: '' }))).toBe(true);
+  });
+});
+
+describe('post-tool answer split', () => {
+  it('returns split index for real prose block after last tool', () => {
     const long =
       'Direct summary - Node.js 24 (released May 6, 2025) is a major platform update that upgrades V8 to a newer track, ships notable HTTP and fetch-related changes, and introduces practical migration items for native addons and tooling.\n\n## Checklist\n\n- Rebuild native modules';
     const blocks = [
@@ -132,14 +141,19 @@ describe('post-tool final answer split', () => {
     expect(ix).toBe(1);
   });
 
-  it('does not split short step line after tools', () => {
+  it('splits on a multi-sentence prose block after tools', () => {
+    const blocks = [
+      blk({ id: '0', content: 'x', tools: [{ apiName: 'search', id: 't1' } as any] }),
+      blk({ id: '1', content: '先跑测试。全部通过了。' }),
+    ];
+    expect(getPostToolAnswerSplitIndex(blocks, 0, true, true)).toBe(1);
+  });
+
+  it('does not split a short single-line step after tools', () => {
     const blocks = [
       blk({ id: '0', content: 'x', tools: [{ apiName: 'search', id: 't1' } as any] }),
       blk({ id: '1', content: '现在我来搜索资料。' }),
     ];
-    expect(scorePostToolBlockAsFinalAnswer(blocks[1]!)).toBeLessThan(
-      POST_TOOL_FINAL_ANSWER_SCORE_THRESHOLD,
-    );
     expect(getPostToolAnswerSplitIndex(blocks, 0, true, true)).toBeNull();
   });
 });

--- a/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.ts
+++ b/src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.ts
@@ -7,17 +7,6 @@ import { type AssistantContentBlock } from '@/types/index';
 
 import {
   DURATION_SECONDS_PER_MINUTE,
-  POST_TOOL_ANSWER_DOUBLE_NEWLINE_SCORE,
-  POST_TOOL_ANSWER_LENGTH_LONG_MIN_CHARS,
-  POST_TOOL_ANSWER_LENGTH_LONG_SCORE,
-  POST_TOOL_ANSWER_LENGTH_MEDIUM_MIN_CHARS,
-  POST_TOOL_ANSWER_MARKDOWN_STRUCTURE_SCORE,
-  POST_TOOL_ANSWER_MEDIUM_TEXT_SCORE,
-  POST_TOOL_ANSWER_MULTI_LINE_MIN_COUNT,
-  POST_TOOL_ANSWER_MULTI_LINE_SCORE,
-  POST_TOOL_ANSWER_PUNCT_MIN_COUNT,
-  POST_TOOL_ANSWER_PUNCT_SCORE,
-  POST_TOOL_FINAL_ANSWER_SCORE_THRESHOLD,
   TIME_MS_PER_SECOND,
   TOOL_API_DISPLAY_NAMES,
   TOOL_FIRST_DETAIL_MAX_CHARS,
@@ -38,45 +27,39 @@ export const areWorkflowToolsComplete = (tools: ChatToolPayloadWithResult[]): bo
   return collapsible.every((t) => t.result != null && t.result.content !== LOADING_FLAT);
 };
 
-/** Heuristic: visible content already looks like a deliverable, not a one-line status step. */
-export const scoreBlockContentAsAnswerLike = (block: AssistantContentBlock): number => {
+/**
+ * A mixed / post-tool prose block that is just a single short status line
+ * (e.g. "先重建 worktree:") stays folded together with its tools. Anything richer —
+ * multiple lines, markdown structure, more than one sentence, or a long run-on line —
+ * is treated as real prose and lifted out of the fold so it renders inline in reading order.
+ */
+export const isFoldableStatusLine = (block: AssistantContentBlock): boolean => {
   const raw = (block.content ?? '').trim();
-  if (!raw || raw === LOADING_FLAT) return 0;
+  if (!raw || raw === LOADING_FLAT) return true;
 
-  let score = 0;
-  const compact = raw.replaceAll(/\s+/g, ' ');
-  if (compact.length >= POST_TOOL_ANSWER_LENGTH_LONG_MIN_CHARS)
-    score += POST_TOOL_ANSWER_LENGTH_LONG_SCORE;
-  else if (compact.length >= POST_TOOL_ANSWER_LENGTH_MEDIUM_MIN_CHARS)
-    score += POST_TOOL_ANSWER_MEDIUM_TEXT_SCORE;
+  // A status line is a single line; any newline means paragraphed prose.
+  if (raw.includes('\n')) return false;
 
-  if (raw.includes('\n\n')) score += POST_TOOL_ANSWER_DOUBLE_NEWLINE_SCORE;
-  else if (raw.split('\n').filter((l) => l.trim()).length >= POST_TOOL_ANSWER_MULTI_LINE_MIN_COUNT)
-    score += POST_TOOL_ANSWER_MULTI_LINE_SCORE;
-
+  // Markdown heading or list marker → structured deliverable, not a status line.
   if (
-    new RegExp(`^#{1,${WORKFLOW_MARKDOWN_HEADING_MAX_LEVEL}}\\s`, 'm').test(raw) ||
-    /^\s*[-*]\s+\S/m.test(raw)
+    new RegExp(`^#{1,${WORKFLOW_MARKDOWN_HEADING_MAX_LEVEL}}\\s`).test(raw) ||
+    /^[-*]\s+\S/.test(raw)
   )
-    score += POST_TOOL_ANSWER_MARKDOWN_STRUCTURE_SCORE;
+    return false;
 
-  const punctCount = (compact.match(/[。！？.!?]/g) ?? []).length;
-  if (punctCount >= POST_TOOL_ANSWER_PUNCT_MIN_COUNT) score += POST_TOOL_ANSWER_PUNCT_SCORE;
+  // A long run-on line reads as prose even without a second sentence.
+  if (raw.length > WORKFLOW_PROSE_HEADLINE_MAX_CHARS) return false;
 
-  return score;
-};
-
-/** Heuristic: prose-only block after last tool looks like a long deliverable (not a one-line step). */
-export const scorePostToolBlockAsFinalAnswer = (block: AssistantContentBlock): number => {
-  if (block.tools && block.tools.length > 0) return 0;
-
-  return scoreBlockContentAsAnswerLike(block);
+  // Fold only a single sentence. Latin .!? count only at a real sentence boundary
+  // (end or whitespace) so dotted tokens like "src/a.ts" or "Node.js" don't inflate it.
+  const sentenceCount = (raw.match(/[。！？]|[.!?](?=\s|$)/g) ?? []).length;
+  return sentenceCount <= 1;
 };
 
 /**
- * While generating, first index at or after {@param lastToolIndex} whose prose-only block scores
- * as final-answer-like. Tail from here stays out of the workflow fold. Returns null if tooling
- * reappears or nothing qualifies.
+ * While generating, first index at or after {@param lastToolIndex} whose prose-only block reads as
+ * real prose rather than a one-line status. Tail from here stays out of the workflow fold. Returns
+ * null if tooling reappears or nothing qualifies.
  */
 export const getPostToolAnswerSplitIndex = (
   blocks: AssistantContentBlock[],
@@ -90,7 +73,7 @@ export const getPostToolAnswerSplitIndex = (
   for (let i = lastToolIndex + 1; i < blocks.length; i++) {
     const b = blocks[i]!;
     if (b.tools && b.tools.length > 0) return null;
-    if (scorePostToolBlockAsFinalAnswer(b) >= POST_TOOL_FINAL_ANSWER_SCORE_THRESHOLD) return i;
+    if (!isFoldableStatusLine(b)) return i;
   }
   return null;
 };


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style
- [x] 🔨 chore

#### 🔀 Description of Change

Two related changes:

**1. Chat message folding heuristic (`src/features/Conversation/Messages/AssistantGroup`)**

Replaces the multi-factor "answer-likeness" score (`scoreBlockContentAsAnswerLike`, threshold ≥ 3) that decided whether prose interleaved with tool calls stays folded inside the workflow collapse or is lifted inline. The score was fuzzy and unpredictable — a stray file-path dot or an extra sentence could flip the outcome.

New rule — a single predicate `isFoldableStatusLine`: a mixed / post-tool prose block stays **folded with its tools only when it is a single short status line** (one line, ≤ 1 sentence, no markdown heading/list, ≤ 100 chars). Anything richer — multiple sentences, multiple lines, markdown structure, or a long run-on line — is **promoted inline in reading order** instead of being hidden. Latin `.!?` are counted only at a real sentence boundary (end / whitespace) so dotted tokens like `src/a.ts` or `Node.js` are not miscounted as extra sentences. Removes the now-dead `POST_TOOL_ANSWER_*` scoring constants.

Net effect: only a genuine one-line status step (e.g. `先重建 worktree:`) folds away with its tools; real narration stays visible and in time order.

**2. agent-testing skill: screenshot preflight gates + raw-CDP capture (`.agents/skills/agent-testing`)**

Dev-tooling only, no product impact:

- `check-screen-recording.sh` — preflight that gates OS screen capture (macOS Screen Recording TCC permission **and** a real-frame blackness probe), so a slept / locked / screensavered display fails fast with remediation instead of silently writing an all-black PNG. Wired into `capture-app-window.sh` (bypass with `SKIP_SCREEN_CHECK=1`).
- `cdp-screenshot.sh` + `cdp-capture.cjs` — reliable Electron/Chrome screenshot via **raw CDP**, bypassing the agent-browser daemon (which can wedge into `CDP response channel closed` after an interrupted capture). Verified immune to display sleep and window occlusion; `--check` preflight confirms capture works before a run relies on it.
- Documents both in `SKILL.md` (Step 0.5) + `ui/electron.md`, and records the screenshot failure modes / root causes in the living logs (`common-mistakes.md`, `probe-mock-patterns.md`).

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- Unit: `bunx vitest run src/features/Conversation/Messages/AssistantGroup/toolDisplayNames.test.ts` — 19/19 (folds single sentence, keeps `src/a.ts`/`Node.js` as one sentence, promotes multi-sentence / multi-line / markdown / long lines, treats empty as foldable).
- Real UI (Electron dev): a live agent turn with tool calls + narration renders multi-sentence narration inline between tool segments, a single-sentence step stays attached to its tool, and consecutive tools with no prose between them merge into one `N 次调用` collapse.

#### 📸 Screenshots / Videos

Real-UI evidence and the full verification report: https://app.lobehub.com/verify/52046b24-f750-4644-9081-28b45768c7bb

#### 📝 Additional Information

The two commits are independent in scope (product UI vs. dev tooling) but bundled per request. The agent-testing changes touch only `.agents/skills/**` and have no runtime effect on the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)