### PR TITLE
🐛 fix(resource): delete the underlying file for mirror documents

### DIFF
--- a/apps/server/src/routers/lambda/file.ts
+++ b/apps/server/src/routers/lambda/file.ts
@@ -491,7 +491,10 @@ export const fileRouter = router({
             continue;
           }
 
-          if (item.documentId) {
+          /* PATCHED: a sourceType='file' item that also has a documentId is a file mirror document —
+             deleting only the document leaves the file behind, so delete the file
+             (fileModel.deleteMany also cleans the mirror doc). */
+          if (item.documentId && !item.fileId) {
             documentIds.push(item.documentId);
             continue;
           }

--- a/src/services/resource/index.ts
+++ b/src/services/resource/index.ts
@@ -261,7 +261,15 @@ export class ResourceService {
     if (existing.sourceType === 'file') {
       await fileService.removeFile(id);
     } else {
-      await documentService.deleteDocument(id);
+      /* PATCHED: a file mirror document (a file item whose list id is exposed as docs_ via COALESCE)
+         leaves the files row / S3 object behind if only the document is deleted, so it resurfaces on
+         refresh — delete the underlying file instead (fileModel.delete also cleans the mirror doc). */
+      const doc = await documentService.getDocumentById(id);
+      if (doc?.fileId) {
+        await fileService.removeFile(doc.fileId);
+      } else {
+        await documentService.deleteDocument(id);
+      }
     }
   }
 
@@ -280,7 +288,14 @@ export class ResourceService {
           if (item.sourceType === 'file') {
             fileIds.push(id);
           } else {
-            documentIds.push(id);
+            /* PATCHED: for a file mirror document, delete the underlying file instead
+               (fileModel.deleteMany also cleans the mirror doc) */
+            const doc = await documentService.getDocumentById(id);
+            if (doc?.fileId) {
+              fileIds.push(doc.fileId);
+            } else {
+              documentIds.push(id);
+            }
           }
         }
       }),


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

#12448, #13187 — both are closed, but this deletion path was never fixed and the bug still reproduces on current `canary`. #14662 looks like the same user-visible symptom (object-storage blobs surviving deletion).

#### 🔀 Description of Change

**Bug.** The knowledge list query LEFT JOINs `documents` and exposes `COALESCE(d.id, f.id) AS id`, so a parsed file (a "mirror document" carrying a `fileId`) is listed under its `docs_…` id. The delete paths dispatch on that id / on `documentId`, so they delete only the mirror document row:

- the `files` row and the S3 / object-storage blob are left behind, and
- the item reappears in /files after a refresh (now under its `file_…` id).

**Fix — route mirror documents to file deletion (3 dispatch sites):**

- `src/services/resource/index.ts` — `deleteResource` / `deleteResources`: when the target document carries a `fileId`, delete the underlying file instead. `fileModel.delete` / `deleteMany` already clean up the mirror document and the storage object.
- `apps/server/src/routers/lambda/file.ts` — `deleteKnowledgeItemsByQuery`: push to `documentIds` only when the item has no `fileId`; items carrying both fall through to file deletion.

Pure dispatch fix — no schema, i18n, or UI changes.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

1. Upload a file that gets parsed into a document (docx / pptx / pdf) so a mirror document exists.
2. Delete it from /files — single delete, then again via multi-select / select-all batch delete.
3. Refresh: the item no longer resurfaces, the `files` row is gone, and the object is removed from storage.

Running with this fix on a self-hosted deployment for ~2 weeks, covering the single, batch, and select-all deletion paths.

#### 📸 Screenshots / Videos

Service/server dispatch logic only — no UI change.
