### PR TITLE
🔧 chore(ci): apply codecov project threshold to each flag status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -40,16 +40,19 @@ coverage:
       server:
         flags:
           - server
+        threshold: '0.5%'
       database:
         flags:
           - database
+        threshold: '0.5%'
       builtin-tools:
         flags:
           - builtin-tools
+        threshold: '0.5%'
       app:
         flags:
           - app
-      threshold: '0.5%'
+        threshold: '0.5%'
     patch: off
 
 ignore:


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

Related to #16669 (example of a `codecov/project/*` check failing on a tiny -0.03% drop).

#### 🔀 Description of Change

In `codecov.yml`, `threshold: '0.5%'` was written as a sibling key of the named project statuses (`server` / `database` / `builtin-tools` / `app`) instead of inside each status block. Codecov's config schema only accepts `threshold` inside a status config, so the key was never applied to any flag status — the official validator even rejects the current file:

```
Error at ['coverage', 'status', 'project', 'threshold']:
must be of ['dict', 'boolean'] type
```

The practical effect is that every flag's project status runs with the default threshold of 0, so any tiny coverage fluctuation (e.g. -0.03% in #16669) fails the `codecov/project/*` checks.

This PR moves `threshold: '0.5%'` into each of the four named status blocks, which is the placement the [codecov status docs](https://docs.codecov.com/docs/commit-status#threshold) specify.

#### 🧪 How to Test

Validated with codecov's config validator (`curl --data-binary @codecov.yml https://codecov.io/validate`):

- Old config: rejected with the schema error above.
- New config: `Valid!`, and each project status (`server`, `database`, `builtin-tools`, `app`) parses with `"threshold": 0.5`.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

N/A — CI configuration only.

#### 📝 Additional Information

No behavior change for coverage collection itself; only the pass/fail tolerance of the `codecov/project/*` status checks (0 → 0.5%).