### PR TITLE
🐛 fix(hetero): persist CC resume token on stream_start so it survives watchdog abandon

### DIFF
--- a/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -758,7 +758,18 @@ export class HeterogeneousPersistenceHandler {
     // run; the copy is what makes a mid-topic session fork detectable.
     if (event.type === 'stream_start') {
       const sid = (event.data as { sessionId?: string } | undefined)?.sessionId;
-      if (typeof sid === 'string' && sid.length > 0) state.heteroSessionId = sid;
+      if (typeof sid === 'string' && sid.length > 0 && sid !== state.heteroSessionId) {
+        state.heteroSessionId = sid;
+        // Persist the resume token the moment CC reports it, not only on a clean
+        // `finish()`. A stuck run is abandoned by the inactivity watchdog via
+        // AbandonOperationService, which never calls finish() — so a run that
+        // produced a valid session id but got killed before finishing would
+        // otherwise leave `topic.metadata.heteroSessionId` empty, forcing the
+        // next turn to spawn a fresh CC session and drop all `--resume` history.
+        // Writing it here makes resume survive abandon. finish() still overwrites
+        // with its own sessionId (or clears a stale one on a resume failure).
+        await this.persistSessionId(state.topicId, sid);
+      }
     }
 
     const { intents, state: next } = reduceMainAgent(state.main, event, this.mainReduceCtx(state));

--- a/apps/server/src/services/heterogeneousAgent/__tests__/sessionResume.test.ts
+++ b/apps/server/src/services/heterogeneousAgent/__tests__/sessionResume.test.ts
@@ -358,6 +358,93 @@ describe('HeterogeneousAgentService — phase 2c session id persistence + resume
     });
   });
 
+  describe('eager session-id persistence on stream_start (survives watchdog abandon)', () => {
+    it('persists heteroSessionId as soon as stream_start reports it, without waiting for heteroFinish', async () => {
+      const updateMetadata = vi.fn(async () => undefined);
+      const findById = vi.fn(async () => ({
+        agentId: null,
+        id: 'topic-abandon',
+        metadata: {
+          runningOperation: { assistantMessageId: 'asst-a', operationId: 'op-abandon' },
+        },
+      }));
+
+      const handler = new HeterogeneousPersistenceHandler({
+        messageModel: {
+          findById: vi.fn(async () => null),
+          listMessagePluginsByTopic: vi.fn(async () => []),
+          update: vi.fn(async () => ({ success: true })),
+        } as any,
+        threadModel: {} as any,
+        topicModel: { findById, updateMetadata } as any,
+      });
+
+      // Only a stream_start reporting the CC session id — NO heteroFinish. This
+      // is the inactivity-watchdog path: the run starts, emits its session id,
+      // then gets abandoned by AbandonOperationService (which never calls finish).
+      await handler.ingest({
+        events: [
+          {
+            data: { sessionId: 'cc-live-session' },
+            operationId: 'op-abandon',
+            stepIndex: 0,
+            timestamp: 1,
+            type: 'stream_start',
+          },
+        ],
+        operationId: 'op-abandon',
+        topicId: 'topic-abandon',
+      });
+
+      // The resume token is already on topic.metadata — the next turn can resume.
+      expect(updateMetadata).toHaveBeenCalledWith('topic-abandon', {
+        heteroSessionId: 'cc-live-session',
+      });
+    });
+
+    it('does not re-write when stream_start repeats the same session id', async () => {
+      const updateMetadata = vi.fn(async () => undefined);
+      const findById = vi.fn(async () => ({
+        agentId: null,
+        id: 'topic-dedupe',
+        metadata: { runningOperation: { assistantMessageId: 'asst-d', operationId: 'op-dedupe' } },
+      }));
+
+      const handler = new HeterogeneousPersistenceHandler({
+        messageModel: {
+          findById: vi.fn(async () => null),
+          listMessagePluginsByTopic: vi.fn(async () => []),
+          update: vi.fn(async () => ({ success: true })),
+        } as any,
+        threadModel: {} as any,
+        topicModel: { findById, updateMetadata } as any,
+      });
+
+      await handler.ingest({
+        events: [
+          {
+            data: { sessionId: 'cc-same' },
+            operationId: 'op-dedupe',
+            stepIndex: 0,
+            timestamp: 1,
+            type: 'stream_start',
+          },
+          {
+            data: { sessionId: 'cc-same' },
+            operationId: 'op-dedupe',
+            stepIndex: 1,
+            timestamp: 2,
+            type: 'stream_start',
+          },
+        ],
+        operationId: 'op-dedupe',
+        topicId: 'topic-dedupe',
+      });
+
+      expect(updateMetadata).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('getHeterogeneousResumeSessionId', () => {
     const buildService = (findByIdImpl: (id: string) => Promise<any>) => {
       const findById = vi.fn(findByIdImpl);


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

Remote Claude Code runs lose all context on the *next* turn after being killed by the inactivity watchdog. The CC `--resume` session id is only written to `topic.metadata.heteroSessionId` on a clean `heteroFinish()`. When a stuck run is abandoned, it goes through `AbandonOperationService`, which never calls `finish()` — so a run that already emitted a valid session id (via `stream_start`) but got killed before finishing leaves the topic metadata empty. The next turn then spawns a **fresh** CC session with no `--resume`, silently dropping the previous turn's working context while the message tree stays intact.

**Fix:** persist the session id the moment `stream_start` reports it (deduped against the already-known id), inside `HeterogeneousPersistenceHandler.reduceAndApply`. Resume now survives abandon. `finish()` still overwrites with its own sessionId or clears a stale one on a resume failure, so no behavior change on the clean paths.

#16592 added the per-message session-id stamping that made this session fork *observable*; this PR closes the loop by making it *recoverable*.

**Observed sample** (2026-07-03): a topic where OP1 ran under CC session `e089d68d…`, got abandoned by `inactivity_watchdog` ~10min after going idle, then the user's "继续" spawned OP2 under a brand-new session `c348f320…` — the model only had the replayed DB history (34k tokens) and ended up asking the user what to continue.

#### 🧪 How to Test

- [x] Added/updated tests

Two new cases in `sessionResume.test.ts`:
- ingesting only a `stream_start` with a sessionId (the watchdog-abandon path — **no** `heteroFinish`) persists `heteroSessionId` to topic metadata
- repeated `stream_start` with the same session id writes only once

All 113 heterogeneousAgent tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)