### PR TITLE
✨ feat: add device-scoped filesystem skills

### DIFF
--- a/apps/desktop/src/main/controllers/WorkspaceCtr.ts
+++ b/apps/desktop/src/main/controllers/WorkspaceCtr.ts
@@ -1,9 +1,9 @@
+import type { WorkspaceScanDeps } from '@lobechat/device-control';
 import {
   initWorkspace as runInitWorkspace,
   listProjectSkills as runListProjectSkills,
   statPath as runStatPath,
-  type WorkspaceScanDeps,
-} from '@lobechat/device-control';
+} from '@lobechat/device-control/workspace';
 import {
   type InitWorkspaceParams,
   type InitWorkspaceResult,

--- a/apps/desktop/src/main/controllers/__tests__/WorkspaceCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/WorkspaceCtr.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { type App } from '@/core/App';
 
@@ -28,6 +28,10 @@ vi.mock('node:fs/promises', () => ({
   readdir: vi.fn(),
 }));
 
+vi.mock('@lobechat/local-file-shell', () => ({
+  detectRepoType: vi.fn(async () => undefined),
+}));
+
 const mockLocalFileProtocolManager = {
   approveIndexedProjectRoot: vi.fn(),
 };
@@ -42,8 +46,13 @@ describe('WorkspaceCtr', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    vi.stubEnv('HOME', '/device-home');
     mockFsPromises = await import('node:fs/promises');
     workspaceCtr = new WorkspaceCtr(mockApp);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   const dirent = (name: string, kind: 'dir' | 'file') => ({
@@ -108,6 +117,43 @@ describe('WorkspaceCtr', () => {
         description: 'from agents',
         path: '/proj/.agents/skills/shared/SKILL.md',
       });
+    });
+
+    it('merges execution-device skills and keeps project skills first on duplicate names', async () => {
+      vi.mocked(mockFsPromises.readdir).mockImplementation(async (dir: string) => {
+        if (dir === '/proj/.agents/skills') return [dirent('shared', 'dir')];
+        if (dir === '/proj/.agents/skills/shared') return [dirent('SKILL.md', 'file')];
+        if (dir === '/device-home/.agents/skills')
+          return [dirent('device-writer', 'dir'), dirent('shared', 'dir')];
+        if (dir === '/device-home/.agents/skills/device-writer')
+          return [dirent('SKILL.md', 'file')];
+        if (dir === '/device-home/.agents/skills/shared') return [dirent('SKILL.md', 'file')];
+        throw new Error('ENOENT');
+      });
+      vi.mocked(mockFsPromises.readFile).mockImplementation(async (file: string) => {
+        if (file === '/proj/.agents/skills/shared/SKILL.md')
+          return frontmatter('shared', 'from project');
+        if (file === '/device-home/.agents/skills/device-writer/SKILL.md')
+          return frontmatter('device-writer', 'from device');
+        if (file === '/device-home/.agents/skills/shared/SKILL.md')
+          return frontmatter('shared', 'from device');
+        throw new Error('ENOENT');
+      });
+
+      const result = await workspaceCtr.listProjectSkills({ scope: '/proj' });
+
+      expect(result.skills.map((skill) => `${skill.name}:${skill.scope}`)).toEqual([
+        'device-writer:device',
+        'shared:project',
+      ]);
+      expect(result.skills.find((skill) => skill.name === 'device-writer')).toMatchObject({
+        previewRoot: '/device-home/.agents/skills',
+        scope: 'device',
+      });
+      expect(mockLocalFileProtocolManager.approveIndexedProjectRoot).toHaveBeenCalledWith('/proj');
+      expect(mockLocalFileProtocolManager.approveIndexedProjectRoot).toHaveBeenCalledWith(
+        '/device-home/.agents/skills',
+      );
     });
 
     it('caps instruction file content', async () => {

--- a/apps/desktop/vitest.config.mts
+++ b/apps/desktop/vitest.config.mts
@@ -6,6 +6,11 @@ export default defineConfig({
     alias: {
       '@': resolve(__dirname, './src/main'),
       '~common': resolve(__dirname, './src/common'),
+      '@lobechat/device-control': resolve(__dirname, '../../packages/device-control/src'),
+      '@lobechat/device-control/workspace': resolve(
+        __dirname,
+        '../../packages/device-control/src/workspace',
+      ),
       '@lobechat/local-file-shell': resolve(__dirname, '../../packages/local-file-shell/src'),
     },
     coverage: {

--- a/apps/server/src/modules/AgentRuntime/executors/callTool.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/callTool.ts
@@ -282,11 +282,12 @@ export const callTool =
                 projectSkills: (state.metadata?.operationSkillSet?.skills ?? [])
                   .filter(
                     (skill: { location?: string; source?: string }) =>
-                      skill.source === 'project' && !!skill.location,
+                      (skill.source === 'project' || skill.source === 'device') && !!skill.location,
                   )
-                  .map((skill: { location: string; name: string }) => ({
+                  .map((skill: { location: string; name: string; source?: string }) => ({
                     location: skill.location,
                     name: skill.name,
+                    source: skill.source === 'device' ? 'device' : 'project',
                   })),
                 scope: state.metadata?.scope,
                 serverDB: ctx.serverDB,

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -3121,10 +3121,10 @@ export class AiAgentService {
 
       const projectMetas = workspaceInit.workspace.skills.map((s) => ({
         description: s.description ?? '',
-        identifier: `project:${s.name}`,
+        identifier: `${s.scope === 'device' ? 'device' : 'project'}:${s.name}`,
         location: s.path,
         name: s.name,
-        source: 'project' as const,
+        source: s.scope === 'device' ? ('device' as const) : ('project' as const),
       }));
 
       if (projectMetas.length) {

--- a/apps/server/src/services/deviceGateway/__tests__/index.test.ts
+++ b/apps/server/src/services/deviceGateway/__tests__/index.test.ts
@@ -443,7 +443,7 @@ describe('DeviceGateway', () => {
       mockClient.invokeRpc.mockResolvedValue({
         data: {
           instructions: [{ content: '# Rules', source: 'AGENTS.md' }],
-          // Device returns rich ProjectSkillItems; only name/description/path survive.
+          // Device returns rich ProjectSkillItems; only prompt metadata survives.
           skills: [
             {
               description: 'spa',
@@ -451,7 +451,20 @@ describe('DeviceGateway', () => {
               files: ['SKILL.md'],
               name: 'spa-routes',
               path: '/proj/.agents/skills/spa-routes/SKILL.md',
+              previewRoot: '/proj',
+              scope: 'project',
               skillDir: '/proj/.agents/skills/spa-routes',
+              source: '.agents/skills',
+            },
+            {
+              description: 'device',
+              fileCount: 2,
+              files: ['SKILL.md', 'refs.md'],
+              name: 'device-writer',
+              path: '/home/.agents/skills/device-writer/SKILL.md',
+              previewRoot: '/home/.agents/skills',
+              scope: 'device',
+              skillDir: '/home/.agents/skills/device-writer',
               source: '.agents/skills',
             },
           ],
@@ -473,6 +486,13 @@ describe('DeviceGateway', () => {
             description: 'spa',
             name: 'spa-routes',
             path: '/proj/.agents/skills/spa-routes/SKILL.md',
+            scope: 'project',
+          },
+          {
+            description: 'device',
+            name: 'device-writer',
+            path: '/home/.agents/skills/device-writer/SKILL.md',
+            scope: 'device',
           },
         ],
       });
@@ -588,6 +608,8 @@ describe('DeviceGateway', () => {
             files: ['SKILL.md'],
             name: 'spa-routes',
             path: '/proj/.agents/skills/spa-routes/SKILL.md',
+            previewRoot: '/proj',
+            scope: 'project',
             skillDir: '/proj/.agents/skills/spa-routes',
             source: '.agents/skills',
           },

--- a/apps/server/src/services/deviceGateway/index.ts
+++ b/apps/server/src/services/deviceGateway/index.ts
@@ -171,7 +171,8 @@ export class DeviceGateway {
     try {
       // The device returns rich `ProjectSkillItem`s; narrow to metadata only so
       // the cached `workingDirs` payload stays small (SKILL.md bodies are still
-      // read lazily at activation time).
+      // read lazily at activation time). Keep scope so project/device skills can
+      // be displayed and activated with the correct origin.
       const result = await client.invokeRpc<{
         instructions?: WorkspaceInitResult['instructions'];
         skills?: (ProjectSkillMeta & Record<string, unknown>)[];
@@ -188,10 +189,11 @@ export class DeviceGateway {
       const { instructions, skills } = result.data;
       return {
         instructions: instructions ?? [],
-        skills: (skills ?? []).map(({ description, name, path }) => ({
+        skills: (skills ?? []).map(({ description, name, path, scope }) => ({
           description,
           name,
           path,
+          scope,
         })),
       };
     } catch (error) {

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -329,7 +329,7 @@ export const skillsRuntime: ServerRuntimeRegistration = {
           })
       : [];
 
-    // Project skills live on the device filesystem. Read them through the
+    // Project/device skills live on the execution device filesystem. Read them through the
     // device gateway by reusing the local-system tools — no special
     // file-read primitive, just the existing capabilities over deviceGateway.
     //   - `readFile`  loads SKILL.md and validated reference files.

--- a/apps/server/src/services/toolExecution/types.ts
+++ b/apps/server/src/services/toolExecution/types.ts
@@ -176,11 +176,11 @@ export interface ToolExecutionContext {
   /** Agent runtime operation ID for structured tool outcome identity. */
   operationId?: string;
   /**
-   * Project-level skills (name + absolute SKILL.md path) discovered on the
-   * device filesystem. Used by the Skills runtime to load them on demand via
-   * the device gateway. Derived from the operation's skill set.
+   * Filesystem skills (name + absolute SKILL.md path) discovered on the
+   * execution device. Used by the Skills runtime to load them on demand via the
+   * device gateway. Derived from the operation's skill set.
    */
-  projectSkills?: { location: string; name: string }[];
+  projectSkills?: { location: string; name: string; source?: 'device' | 'project' }[];
   /** Conversation scope captured when the operation was created */
   scope?: string | null;
   /** Server database for LobeHub Skills execution */

--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -1355,6 +1355,7 @@
   "workingPanel.skills.rename.placeholder": "Skill name",
   "workingPanel.skills.rename.title": "Rename skill",
   "workingPanel.skills.section.agent": "Agent skills",
+  "workingPanel.skills.section.device": "Device skills",
   "workingPanel.skills.section.project": "Project skills",
   "workingPanel.skills.section.user": "User skills",
   "workingPanel.skills.title": "Skills",

--- a/locales/en-US/plugin.json
+++ b/locales/en-US/plugin.json
@@ -333,6 +333,7 @@
   "builtins.lobe-skill-store.render.version": "Version",
   "builtins.lobe-skill-store.title": "Skill Store",
   "builtins.lobe-skills.apiName.activateAgentSkill": "Activate Agent Skill",
+  "builtins.lobe-skills.apiName.activateDeviceSkill": "Activate Device Skill",
   "builtins.lobe-skills.apiName.activateProjectSkill": "Activate Project Skill",
   "builtins.lobe-skills.apiName.activateSkill": "Activate Skill",
   "builtins.lobe-skills.apiName.execScript": "Run Script",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -1355,6 +1355,7 @@
   "workingPanel.skills.rename.placeholder": "技能名称",
   "workingPanel.skills.rename.title": "重命名技能",
   "workingPanel.skills.section.agent": "智能体技能",
+  "workingPanel.skills.section.device": "设备技能",
   "workingPanel.skills.section.project": "项目技能",
   "workingPanel.skills.section.user": "用户技能",
   "workingPanel.skills.title": "技能",

--- a/locales/zh-CN/plugin.json
+++ b/locales/zh-CN/plugin.json
@@ -333,6 +333,7 @@
   "builtins.lobe-skill-store.render.version": "版本",
   "builtins.lobe-skill-store.title": "技能商店",
   "builtins.lobe-skills.apiName.activateAgentSkill": "激活 Agent Skill",
+  "builtins.lobe-skills.apiName.activateDeviceSkill": "激活 Device Skill",
   "builtins.lobe-skills.apiName.activateProjectSkill": "激活 Project Skill",
   "builtins.lobe-skills.apiName.activateSkill": "激活技能",
   "builtins.lobe-skills.apiName.execScript": "执行脚本",

--- a/packages/builtin-tool-activator/src/client/Inspector/ActivateSkill/index.tsx
+++ b/packages/builtin-tool-activator/src/client/Inspector/ActivateSkill/index.tsx
@@ -20,6 +20,9 @@ const resolveLabel = (t: TFunction<'plugin'>, source: ActivateSkillSource | unde
     case 'agent': {
       return t('builtins.lobe-skills.apiName.activateAgentSkill');
     }
+    case 'device': {
+      return t('builtins.lobe-skills.apiName.activateDeviceSkill');
+    }
     case 'project': {
       return t('builtins.lobe-skills.apiName.activateProjectSkill');
     }

--- a/packages/builtin-tool-activator/src/types.ts
+++ b/packages/builtin-tool-activator/src/types.ts
@@ -27,7 +27,7 @@ export interface ActivateSkillParams {
   name: string;
 }
 
-export type ActivateSkillSource = 'agent' | 'builtin' | 'project' | 'user';
+export type ActivateSkillSource = 'agent' | 'builtin' | 'device' | 'project' | 'user';
 
 export interface ActivateSkillState {
   description?: string;

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts
@@ -212,6 +212,28 @@ describe('SkillsExecutionRuntime', () => {
       expect(result.state).toMatchObject({ name: 'deploy', source: 'project' });
     });
 
+    it('activateSkill preserves device source for execution-device skills', async () => {
+      const readFile = vi.fn().mockResolvedValue('# Device Writer\nWrite across projects.');
+      const listFiles = vi.fn().mockResolvedValue([]);
+      const runtime = new SkillsExecutionRuntime({
+        deviceFileAccess: { listFiles, readFile },
+        projectSkills: [
+          {
+            location: '/home/.agents/skills/device-writer/SKILL.md',
+            name: 'device-writer',
+            source: 'device',
+          },
+        ],
+        service: createMockService(),
+      });
+
+      const result = await runtime.activateSkill({ name: 'device-writer' });
+
+      expect(readFile).toHaveBeenCalledWith('/home/.agents/skills/device-writer/SKILL.md');
+      expect(result.success).toBe(true);
+      expect(result.state).toMatchObject({ name: 'device-writer', source: 'device' });
+    });
+
     it('activateSkill takes precedence over a same-named DB skill', async () => {
       const readFile = vi.fn().mockResolvedValue('project content');
       const listFiles = vi.fn().mockResolvedValue([]);
@@ -273,7 +295,7 @@ describe('SkillsExecutionRuntime', () => {
       expect(listFiles).toHaveBeenCalledWith('/repo/.agents/skills/deploy');
       expect(readFile).not.toHaveBeenCalled();
       expect(result.success).toBe(false);
-      expect(result.content).toContain('Resource not found in project skill');
+      expect(result.content).toContain('Resource not found in filesystem skill');
     });
 
     it('readReference rejects hidden segments before consulting the device', async () => {

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
@@ -54,16 +54,17 @@ export interface SkillRuntimeService {
 }
 
 /**
- * A project-level skill discovered on the device filesystem
- * (`.agents/skills` / `.claude/skills`). The runtime only needs the name to
- * match an `activateSkill`/`readReference` call and the absolute SKILL.md path
- * to read its content. The directory tree is enumerated lazily on activation
- * via `DeviceFileAccess.listFiles` — keeping it out of the op param payload.
+ * A project- or device-level skill discovered on the execution device
+ * filesystem. The runtime only needs the name to match an
+ * `activateSkill`/`readReference` call and the absolute SKILL.md path to read
+ * its content. The directory tree is enumerated lazily on activation via
+ * `DeviceFileAccess.listFiles` — keeping it out of the op param payload.
  */
 export interface ProjectSkillRuntimeItem {
   /** Absolute path to the skill's SKILL.md on the device. */
   location: string;
   name: string;
+  source?: 'device' | 'project';
 }
 
 /**
@@ -87,7 +88,7 @@ export interface SkillsExecutionRuntimeOptions {
   builtinSkills?: BuiltinSkill[];
   /** Reads project skill files from the device (local-system over the gateway). */
   deviceFileAccess?: DeviceFileAccess;
-  /** Project skills discovered on the device filesystem. */
+  /** Filesystem skills discovered on the execution device. */
   projectSkills?: ProjectSkillRuntimeItem[];
   service: SkillRuntimeService;
 }
@@ -132,7 +133,7 @@ const findByNameCI = <T extends { name: string }>(items: T[], target: string): T
 };
 
 /**
- * Hint appended to activated project-skill content so the model knows how to
+ * Hint appended to activated filesystem-skill content so the model knows how to
  * discover the rest of the skill's directory. We deliberately don't enumerate
  * the tree here — the model has `local-system.globFiles` available and can
  * call it on demand, which keeps the op-param payload small.
@@ -140,7 +141,7 @@ const findByNameCI = <T extends { name: string }>(items: T[], target: string): T
 const buildProjectDirectoryHint = (skillName: string, skillDir: string): string =>
   `## Skill resources
 
-This project skill lives in \`${skillDir}\`. Use \`local-system.globFiles\` with scope="${skillDir}" and pattern="**/*" to discover reference files, then \`readReference\` with skillName="${skillName}" + the relative path to load any of them.`;
+This filesystem skill lives in \`${skillDir}\`. Use \`local-system.globFiles\` with scope="${skillDir}" and pattern="**/*" to discover reference files, then \`readReference\` with skillName="${skillName}" + the relative path to load any of them.`;
 
 export class SkillsExecutionRuntime {
   private builtinSkills: BuiltinSkill[];
@@ -258,13 +259,14 @@ export class SkillsExecutionRuntime {
     const { id, path } = args;
 
     try {
-      // Project skills resolve references relative to the SKILL.md directory,
-      // read through the device file access (local-system over the gateway).
+      // Project/device skills resolve references relative to the SKILL.md
+      // directory, read through device file access (local-system over the
+      // gateway).
       const projectSkill = findByNameCI(this.projectSkills, id);
       if (projectSkill) {
         if (!this.deviceFileAccess) {
           return {
-            content: `Project skill "${id}" cannot be read: no device file access available.`,
+            content: `Filesystem skill "${id}" cannot be read: no device file access available.`,
             success: false,
           };
         }
@@ -291,7 +293,7 @@ export class SkillsExecutionRuntime {
         );
         if (!allowed.has(normalized)) {
           return {
-            content: `Resource not found in project skill "${id}": "${path}"`,
+            content: `Resource not found in filesystem skill "${id}": "${path}"`,
             success: false,
           };
         }
@@ -374,12 +376,12 @@ export class SkillsExecutionRuntime {
   async activateSkill(args: ActivateSkillParams): Promise<BuiltinServerRuntimeOutput> {
     const { name } = args;
 
-    // Project skills (filesystem SKILL.md) take precedence over db/builtin.
+    // Filesystem skills (project/device SKILL.md) take precedence over db/builtin.
     const projectSkill = findByNameCI(this.projectSkills, name);
     if (projectSkill) {
       if (!this.deviceFileAccess) {
         return {
-          content: `Project skill "${name}" cannot be loaded: no device file access available.`,
+          content: `Filesystem skill "${name}" cannot be loaded: no device file access available.`,
           success: false,
         };
       }
@@ -402,13 +404,13 @@ export class SkillsExecutionRuntime {
             hasResources: false,
             location: projectSkill.location,
             name,
-            source: 'project',
+            source: projectSkill.source ?? 'project',
           },
           success: true,
         };
       } catch (e) {
         return {
-          content: `Failed to load project skill "${name}": ${(e as Error).message}`,
+          content: `Failed to load filesystem skill "${name}": ${(e as Error).message}`,
           success: false,
         };
       }

--- a/packages/builtin-tool-skills/src/client/Inspector/RunSkill/index.tsx
+++ b/packages/builtin-tool-skills/src/client/Inspector/RunSkill/index.tsx
@@ -13,6 +13,7 @@ import type { ActivateSkillParams, ActivateSkillSource, ActivateSkillState } fro
 
 type SkillLabelKey =
   | 'builtins.lobe-skills.apiName.activateAgentSkill'
+  | 'builtins.lobe-skills.apiName.activateDeviceSkill'
   | 'builtins.lobe-skills.apiName.activateProjectSkill'
   | 'builtins.lobe-skills.apiName.activateSkill';
 
@@ -20,7 +21,7 @@ type SkillLabelKey =
  * Resolve the inspector label key. State-side `source` is the authority once the
  * tool result has streamed in; while args are still streaming we only have the
  * raw `name` to go on, so detect agent skills via the identifier prefix as a
- * best-effort fallback. Project skills can't be inferred from the bare name
+ * best-effort fallback. Filesystem skills can't be inferred from the bare name
  * (no prefix), so they show "Activate Skill" until the result lands.
  */
 const resolveLabelKey = (
@@ -33,6 +34,9 @@ const resolveLabelKey = (
   switch (effective) {
     case 'agent': {
       return 'builtins.lobe-skills.apiName.activateAgentSkill';
+    }
+    case 'device': {
+      return 'builtins.lobe-skills.apiName.activateDeviceSkill';
     }
     case 'project': {
       return 'builtins.lobe-skills.apiName.activateProjectSkill';

--- a/packages/builtin-tool-skills/src/types.ts
+++ b/packages/builtin-tool-skills/src/types.ts
@@ -12,7 +12,7 @@ export interface ActivateSkillParams {
   name: string;
 }
 
-export type ActivateSkillSource = 'agent' | 'builtin' | 'project' | 'user';
+export type ActivateSkillSource = 'agent' | 'builtin' | 'device' | 'project' | 'user';
 
 export interface ActivateSkillState {
   description?: string;

--- a/packages/device-control/package.json
+++ b/packages/device-control/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "sideEffects": false,
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./workspace": "./src/workspace.ts"
   },
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/packages/device-control/src/__tests__/dispatch.test.ts
+++ b/packages/device-control/src/__tests__/dispatch.test.ts
@@ -8,9 +8,13 @@ import { executeDeviceRpc } from '../dispatch';
 import type { DeviceControlDeps } from '../types';
 
 let root: string;
+let deviceHome: string;
 
 beforeAll(async () => {
   root = await mkdtemp(path.join(tmpdir(), 'device-control-'));
+  deviceHome = await mkdtemp(path.join(tmpdir(), 'device-control-home-'));
+  vi.stubEnv('HOME', deviceHome);
+
   await mkdir(path.join(root, '.agents', 'skills', 'spa-routes'), { recursive: true });
   await writeFile(
     path.join(root, '.agents', 'skills', 'spa-routes', 'SKILL.md'),
@@ -20,7 +24,9 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
+  vi.unstubAllEnvs();
   await rm(root, { force: true, recursive: true });
+  await rm(deviceHome, { force: true, recursive: true });
 });
 
 const makeDeps = (): DeviceControlDeps => ({
@@ -64,6 +70,41 @@ describe('executeDeviceRpc', () => {
       source: string | null;
     };
     expect(result.source).toBe('.agents/skills');
+  });
+
+  it('merges project and device skills with project taking name precedence', async () => {
+    const deviceSkillRoot = path.join(deviceHome, '.agents', 'skills');
+
+    await mkdir(path.join(deviceSkillRoot, 'device-writer'), { recursive: true });
+    await writeFile(
+      path.join(deviceSkillRoot, 'device-writer', 'SKILL.md'),
+      '---\nname: device-writer\ndescription: Device writer\n---\nbody',
+    );
+    await mkdir(path.join(deviceSkillRoot, 'spa-routes'), { recursive: true });
+    await writeFile(
+      path.join(deviceSkillRoot, 'spa-routes', 'SKILL.md'),
+      '---\nname: spa-routes\ndescription: Device duplicate\n---\nbody',
+    );
+
+    try {
+      const deps = makeDeps();
+      const result = (await executeDeviceRpc('listProjectSkills', { scope: root }, deps)) as {
+        skills: { name: string; previewRoot: string; scope: 'device' | 'project' }[];
+      };
+
+      expect(result.skills.map((skill) => `${skill.name}:${skill.scope}`)).toEqual([
+        'device-writer:device',
+        'spa-routes:project',
+      ]);
+      expect(result.skills.find((skill) => skill.name === 'device-writer')?.previewRoot).toBe(
+        deviceSkillRoot,
+      );
+      expect(deps.approveProjectRoot).toHaveBeenCalledWith(root);
+      expect(deps.approveProjectRoot).toHaveBeenCalledWith(deviceSkillRoot);
+    } finally {
+      await rm(path.join(deviceSkillRoot, 'device-writer'), { force: true, recursive: true });
+      await rm(path.join(deviceSkillRoot, 'spa-routes'), { force: true, recursive: true });
+    }
   });
 
   it('parses folded skill descriptions from frontmatter', async () => {

--- a/packages/device-control/src/types.ts
+++ b/packages/device-control/src/types.ts
@@ -8,6 +8,9 @@
 
 // ─── Workspace scan ───
 
+export type ProjectSkillScope = 'device' | 'project';
+export type ProjectSkillSource = '.agents/skills' | '.claude/skills';
+
 export interface ProjectSkillItem {
   description?: string;
   /** Total number of regular files under `skillDir` (recursive, including `SKILL.md`). */
@@ -17,10 +20,14 @@ export interface ProjectSkillItem {
   name: string;
   /** Absolute path to the SKILL.md file. */
   path: string;
+  /** Approved root used by the host preview protocol for this skill. */
+  previewRoot: string;
+  /** Skill filesystem scope: project cwd or execution-device home. */
+  scope: ProjectSkillScope;
   /** Directory containing the SKILL.md. */
   skillDir: string;
   /** Source directory the skill was discovered in. */
-  source: '.agents/skills' | '.claude/skills';
+  source: ProjectSkillSource;
 }
 
 export interface InitWorkspaceParams {
@@ -47,8 +54,8 @@ export interface ListProjectSkillsParams {
 export interface ListProjectSkillsResult {
   root: string;
   skills: ProjectSkillItem[];
-  /** Source directory actually scanned (after fallback resolution). */
-  source: ProjectSkillItem['source'] | null;
+  /** Legacy source hint. Per-skill `scope` / `source` fields are authoritative. */
+  source: ProjectSkillSource | null;
 }
 
 export interface StatPathResult {
@@ -85,9 +92,7 @@ export interface LocalFilePreviewUnsupported {
 }
 
 export type LocalFilePreview =
-  | LocalFilePreviewImage
-  | LocalFilePreviewText
-  | LocalFilePreviewUnsupported;
+  LocalFilePreviewImage | LocalFilePreviewText | LocalFilePreviewUnsupported;
 
 export interface LocalFilePreviewResult {
   error?: string;

--- a/packages/device-control/src/workspace.ts
+++ b/packages/device-control/src/workspace.ts
@@ -1,4 +1,5 @@
 import { readdir, readFile, stat } from 'node:fs/promises';
+import * as os from 'node:os';
 import path from 'node:path';
 
 import { detectRepoType } from '@lobechat/local-file-shell';
@@ -10,6 +11,8 @@ import type {
   ListProjectSkillsParams,
   ListProjectSkillsResult,
   ProjectSkillItem,
+  ProjectSkillScope,
+  ProjectSkillSource,
   StatPathResult,
   WorkspaceInstructionsItem,
   WorkspaceScanDeps,
@@ -18,7 +21,44 @@ import type {
 // Cap recursion to guard against pathological directory trees.
 const MAX_SKILL_FILE_COUNT = 1000;
 
-const SKILL_SOURCES = ['.agents/skills', '.claude/skills'] as const;
+const SKILL_SOURCES = [
+  '.agents/skills',
+  '.claude/skills',
+] as const satisfies readonly ProjectSkillSource[];
+
+interface SkillScanRoot {
+  previewRoot: string;
+  scope: ProjectSkillScope;
+  source: ProjectSkillSource;
+  sourceRoot: string;
+}
+
+const createProjectSkillRoots = (root: string): SkillScanRoot[] =>
+  SKILL_SOURCES.map((source) => ({
+    previewRoot: root,
+    scope: 'project',
+    source,
+    sourceRoot: path.join(root, source),
+  }));
+
+const createDeviceSkillRoots = (): SkillScanRoot[] => {
+  const home = os.homedir();
+
+  return SKILL_SOURCES.map((source) => {
+    const sourceRoot = path.join(home, source);
+    return {
+      previewRoot: sourceRoot,
+      scope: 'device',
+      source,
+      sourceRoot,
+    };
+  });
+};
+
+const createSkillRoots = (root: string): SkillScanRoot[] => [
+  ...createProjectSkillRoots(root),
+  ...createDeviceSkillRoots(),
+];
 
 const toPosixRelativePath = (filePath: string) => filePath.split(path.sep).join('/');
 
@@ -75,18 +115,19 @@ const parseSkillFrontmatter = (raw: string): SkillFrontmatterFields => {
 };
 
 /**
- * Scan one skill source directory (e.g. `.agents/skills`) under `root` and
- * return parsed frontmatter for each `SKILL.md`. Returns `[]` when the source
- * directory is absent or unreadable. Unsorted — callers sort/merge.
+ * Scan one skill source directory and return parsed frontmatter for each
+ * `SKILL.md`. Returns `[]` when the source directory is absent or unreadable.
+ * Unsorted — callers sort/merge.
  */
-const scanSkillsInSource = async (
-  root: string,
-  source: ProjectSkillItem['source'],
-): Promise<ProjectSkillItem[]> => {
-  const dir = path.join(root, source);
+const scanSkillsInSource = async ({
+  previewRoot,
+  scope,
+  source,
+  sourceRoot,
+}: SkillScanRoot): Promise<ProjectSkillItem[]> => {
   let entries;
   try {
-    entries = await readdir(dir, { withFileTypes: true });
+    entries = await readdir(sourceRoot, { withFileTypes: true });
   } catch {
     return [];
   }
@@ -95,7 +136,7 @@ const scanSkillsInSource = async (
     entries
       .filter((entry) => entry.isDirectory() || entry.isSymbolicLink())
       .map(async (entry): Promise<ProjectSkillItem | null> => {
-        const skillDir = path.join(dir, entry.name);
+        const skillDir = path.join(sourceRoot, entry.name);
         const skillFile = path.join(skillDir, 'SKILL.md');
         try {
           const raw = await readFile(skillFile, 'utf8');
@@ -107,6 +148,8 @@ const scanSkillsInSource = async (
             files,
             name: fields.name || entry.name,
             path: skillFile,
+            previewRoot,
+            scope,
             skillDir,
             source,
           };
@@ -117,6 +160,32 @@ const scanSkillsInSource = async (
   );
 
   return skills.filter((skill): skill is ProjectSkillItem => skill !== null);
+};
+
+const collectSkills = async (roots: SkillScanRoot[]): Promise<ProjectSkillItem[]> => {
+  const seen = new Set<string>();
+  const skills: ProjectSkillItem[] = [];
+
+  for (const root of roots) {
+    for (const skill of await scanSkillsInSource(root)) {
+      if (seen.has(skill.name)) continue;
+      seen.add(skill.name);
+      skills.push(skill);
+    }
+  }
+
+  return skills.sort((a, b) => a.name.localeCompare(b.name));
+};
+
+const approvePreviewRoots = async (
+  skills: ProjectSkillItem[],
+  deps: WorkspaceScanDeps,
+  extraRoots: string[] = [],
+): Promise<void> => {
+  if (!deps.approveProjectRoot) return;
+
+  const roots = new Set([...extraRoots, ...skills.map((skill) => skill.previewRoot)]);
+  await Promise.all([...roots].map((root) => deps.approveProjectRoot!(root)));
 };
 
 /**
@@ -145,36 +214,29 @@ const readWorkspaceInstructions = async (root: string): Promise<WorkspaceInstruc
 };
 
 /**
- * Scan agent skill directories under the project root. Returns the first source
- * directory that yields any skills (`.agents/skills` wins). Approves the root
- * for the host preview protocol when any skills are found.
+ * Scan agent skill directories for the project and the execution device.
+ * Project skills win over device skills on name collision. Approves each
+ * discovered skill's preview root for the host preview protocol.
  */
 export const listProjectSkills = async (
   params: ListProjectSkillsParams,
   deps: WorkspaceScanDeps = {},
 ): Promise<ListProjectSkillsResult> => {
   const root = params.scope;
+  const skills = await collectSkills(createSkillRoots(root));
 
-  for (const source of SKILL_SOURCES) {
-    const skills = (await scanSkillsInSource(root, source)).sort((a, b) =>
-      a.name.localeCompare(b.name),
-    );
-
-    if (skills.length > 0) {
-      await deps.approveProjectRoot?.(root);
-      return { root, skills, source };
-    }
+  if (skills.length > 0) {
+    await approvePreviewRoots(skills, deps);
   }
 
-  return { root, skills: [], source: null };
+  return { root, skills, source: skills[0]?.source ?? null };
 };
 
 /**
- * One-call "workspace init" scan: merge project skills from BOTH
- * `.agents/skills` and `.claude/skills` (deduped by name, `.agents/skills`
- * winning) and read the project-root agent instructions. Approves the root for
- * the host preview protocol regardless of what was found, since the run is now
- * bound to this root.
+ * One-call "workspace init" scan: merge project and execution-device skills
+ * (deduped by name, project winning) and read the project-root agent
+ * instructions. Approves the project root regardless of what was found, since
+ * the run is now bound to this root.
  */
 export const initWorkspace = async (
   params: InitWorkspaceParams,
@@ -182,20 +244,10 @@ export const initWorkspace = async (
 ): Promise<InitWorkspaceResult> => {
   const root = params.scope;
 
-  const seen = new Set<string>();
-  const skills: ProjectSkillItem[] = [];
-  for (const source of SKILL_SOURCES) {
-    for (const skill of await scanSkillsInSource(root, source)) {
-      if (seen.has(skill.name)) continue;
-      seen.add(skill.name);
-      skills.push(skill);
-    }
-  }
-  skills.sort((a, b) => a.name.localeCompare(b.name));
-
+  const skills = await collectSkills(createSkillRoots(root));
   const instructions = await readWorkspaceInstructions(root);
 
-  await deps.approveProjectRoot?.(root);
+  await approvePreviewRoots(skills, deps, [root]);
 
   return { instructions, root, skills };
 };

--- a/packages/electron-client-ipc/src/types/localSystem.ts
+++ b/packages/electron-client-ipc/src/types/localSystem.ts
@@ -162,9 +162,7 @@ export interface LocalFilePreviewUnsupported {
 }
 
 export type LocalFilePreview =
-  | LocalFilePreviewImage
-  | LocalFilePreviewText
-  | LocalFilePreviewUnsupported;
+  LocalFilePreviewImage | LocalFilePreviewText | LocalFilePreviewUnsupported;
 
 export interface LocalFilePreviewResult {
   error?: string;
@@ -499,6 +497,9 @@ export interface ResolveSkillResourcePathResult {
   success: boolean;
 }
 
+export type ProjectSkillScope = 'device' | 'project';
+export type ProjectSkillSource = '.agents/skills' | '.claude/skills';
+
 export interface ProjectSkillItem {
   description?: string;
   /** Total number of regular files under `skillDir` (recursive, including `SKILL.md`). */
@@ -511,10 +512,14 @@ export interface ProjectSkillItem {
   name: string;
   /** Absolute path to the SKILL.md file. */
   path: string;
+  /** Approved root used by the host preview protocol for this skill. */
+  previewRoot: string;
+  /** Skill filesystem scope: project cwd or execution-device home. */
+  scope: ProjectSkillScope;
   /** Directory containing the SKILL.md (e.g. `<root>/.agents/skills/spa-routes`). */
   skillDir: string;
   /** Source directory the skill was discovered in. */
-  source: '.agents/skills' | '.claude/skills';
+  source: ProjectSkillSource;
 }
 
 export interface ListProjectSkillsParams {
@@ -525,8 +530,8 @@ export interface ListProjectSkillsParams {
 export interface ListProjectSkillsResult {
   root: string;
   skills: ProjectSkillItem[];
-  /** Source directory actually scanned (after fallback resolution). */
-  source: ProjectSkillItem['source'] | null;
+  /** Legacy source hint. Per-skill `scope` / `source` fields are authoritative. */
+  source: ProjectSkillSource | null;
 }
 
 export interface InitWorkspaceParams {

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -1382,6 +1382,7 @@ export default {
   'workingPanel.skills.rename.placeholder': 'Skill name',
   'workingPanel.skills.rename.title': 'Rename skill',
   'workingPanel.skills.section.agent': 'Agent skills',
+  'workingPanel.skills.section.device': 'Device skills',
   'workingPanel.skills.section.project': 'Project skills',
   'workingPanel.skills.section.user': 'User skills',
   'workingPanel.skills.title': 'Skills',

--- a/packages/locales/src/default/plugin.ts
+++ b/packages/locales/src/default/plugin.ts
@@ -345,6 +345,7 @@ export default {
   'builtins.lobe-skills.apiName.runCommand': 'Run Command',
   'builtins.lobe-skills.apiName.activateSkill': 'Activate Skill',
   'builtins.lobe-skills.apiName.activateAgentSkill': 'Activate Agent Skill',
+  'builtins.lobe-skills.apiName.activateDeviceSkill': 'Activate Device Skill',
   'builtins.lobe-skills.apiName.activateProjectSkill': 'Activate Project Skill',
   'builtins.lobe-skills.apiName.searchSkill': 'Search Skills',
   'builtins.lobe-skills.title': 'Skills',

--- a/packages/prompts/src/prompts/skills/index.ts
+++ b/packages/prompts/src/prompts/skills/index.ts
@@ -1,6 +1,6 @@
 export { buildResourcesTreeText, resourcesTreePrompt } from './resourcesTree';
 
-export type SkillSource = 'builtin' | 'project' | 'user';
+export type SkillSource = 'builtin' | 'device' | 'project' | 'user';
 
 export interface SkillItem {
   description: string;
@@ -8,9 +8,9 @@ export interface SkillItem {
   location?: string;
   name: string;
   /**
-   * Where the skill comes from. `project` skills live on the device filesystem
-   * (e.g. `.agents/skills/<name>/SKILL.md`) and `location` carries their absolute
-   * path so the model can load them via the readFile tool.
+   * Where the skill comes from. `project` and `device` skills live on the
+   * execution device filesystem and `location` carries their absolute path so
+   * the model can load them via the readFile tool.
    */
   source?: SkillSource;
 }
@@ -27,14 +27,16 @@ export const skillsPrompts = (skills: SkillItem[]) => {
 
   const skillTags = skills.map((skill) => skillPrompt(skill)).join('\n');
 
-  const hasProjectSkill = skills.some((skill) => skill.source === 'project');
-  const projectHint = hasProjectSkill
-    ? `\nFor a skill with source="project", load it by calling the readFile tool on its \`location\` path before following its instructions.`
+  const hasFilesystemSkill = skills.some(
+    (skill) => skill.source === 'project' || skill.source === 'device',
+  );
+  const filesystemHint = hasFilesystemSkill
+    ? `\nFor a skill with source="project" or source="device", load it by calling the readFile tool on its \`location\` path before following its instructions.`
     : '';
 
   return `<available_skills>
 ${skillTags}
 </available_skills>
 
-Use the runSkill tool to activate a skill when needed.${projectHint}`;
+Use the runSkill tool to activate a skill when needed.${filesystemHint}`;
 };

--- a/packages/types/src/device.ts
+++ b/packages/types/src/device.ts
@@ -1,6 +1,10 @@
+export type ProjectSkillScope = 'device' | 'project';
+export type ProjectSkillSource = '.agents/skills' | '.claude/skills';
+
 /**
- * A project-level skill discovered on the device filesystem
- * (`.agents/skills` / `.claude/skills`) by the client at request time.
+ * A filesystem skill discovered on the execution device by the client at
+ * request time. Project skills live under the current working directory;
+ * device skills live under the execution device's home directory.
  * Only frontmatter + the absolute SKILL.md path are carried; the SKILL.md
  * body and directory tree are loaded on demand at activation time via the
  * readFile / listFiles tools.
@@ -12,6 +16,8 @@ export interface ProjectSkillMeta {
   name: string;
   /** Absolute path to the skill's SKILL.md on the device filesystem. */
   path: string;
+  /** Skill filesystem scope: project cwd or execution-device home. */
+  scope?: ProjectSkillScope;
 }
 
 /**
@@ -31,8 +37,8 @@ export interface WorkspaceInstructions {
 
 /**
  * Result of scanning a bound project directory ("workspace init"): the agent
- * instructions file plus the project-level skills discovered under
- * `.agents/skills` + `.claude/skills`. Produced in a single device round-trip
+ * instructions file plus filesystem skills discovered under project and
+ * device-level `.agents/skills` + `.claude/skills`. Produced in a single device round-trip
  * (`deviceGateway.initWorkspace`) and cached on `devices.workingDirs[].workspace`
  * so subsequent runs within the TTL — and the web UI — reuse it without
  * re-scanning. Intentionally open to growth (env info, git status, …) as more
@@ -47,7 +53,7 @@ export interface WorkspaceInitResult {
    * when none are present.
    */
   instructions: WorkspaceInstructions[];
-  /** Project-level skills discovered under the project root (metadata only). */
+  /** Filesystem skills discovered on the execution device (metadata only). */
   skills: ProjectSkillMeta[];
 }
 
@@ -431,9 +437,7 @@ export interface DeviceLocalFilePreviewUnsupported {
 }
 
 export type DeviceLocalFilePreview =
-  | DeviceLocalFilePreviewImage
-  | DeviceLocalFilePreviewText
-  | DeviceLocalFilePreviewUnsupported;
+  DeviceLocalFilePreviewImage | DeviceLocalFilePreviewText | DeviceLocalFilePreviewUnsupported;
 
 /**
  * File preview payload for a file on a remote device. Mirrors the desktop local
@@ -492,18 +496,22 @@ export interface DeviceProjectSkillItem {
   name: string;
   /** Absolute path to the SKILL.md file on the device. */
   path: string;
+  /** Approved root used by the host preview protocol for this skill. */
+  previewRoot: string;
+  scope: ProjectSkillScope;
   /** Directory containing the SKILL.md. */
   skillDir: string;
-  source: '.agents/skills' | '.claude/skills';
+  source: ProjectSkillSource;
 }
 
 /**
- * Project skills listing for a directory on a remote device, returned by the
- * `listProjectSkills` device RPC. Powers the Resources tab's skills group in
- * device mode. Mirrors the desktop `ListProjectSkillsResult`.
+ * Project/device skills listing returned by the `listProjectSkills` device RPC.
+ * Powers the Resources tab's skills group in device mode. Mirrors the desktop
+ * `ListProjectSkillsResult`.
  */
 export interface DeviceListProjectSkillsResult {
   root: string;
   skills: DeviceProjectSkillItem[];
-  source: DeviceProjectSkillItem['source'] | null;
+  /** Legacy source hint. Per-skill `scope` / `source` fields are authoritative. */
+  source: ProjectSkillSource | null;
 }

--- a/src/features/ChatInput/InputEditor/ActionTag/types.ts
+++ b/src/features/ChatInput/InputEditor/ActionTag/types.ts
@@ -4,9 +4,9 @@
  * 1. Command      — Built-in, line-start only (slash menu), executed client-side before send
  * 2. Skill        — Skill package, inserted via @ mention, preloaded before execution
  * 3. Tool         — Explicit tool selection, inserted via @ mention, context injected directly
- * 4. ProjectSkill — Hetero-agent project skill (e.g. `.agents/skills/<name>/SKILL.md`),
+ * 4. ProjectSkill — Filesystem skill discovered from the project or execution device,
  *                   inserted via slash menu, serialized as literal `/skill-name` so the
- *                   underlying CLI agent resolves and runs the skill itself.
+ *                   runtime resolves and runs the skill itself.
  * 5. AgentSkill   — Agent-document skill bundle from `agentDocumentService`; the runtime
  *                   resolves the chip's identifier (`agent-document:<filename>`) against
  *                   the agent's document store at preload time.

--- a/src/features/ChatInput/InputEditor/ActionTag/useSlashActionItems.ts
+++ b/src/features/ChatInput/InputEditor/ActionTag/useSlashActionItems.ts
@@ -45,9 +45,9 @@ export const useSlashActionItems = (): SlashOptions['items'] => {
   const editorInstance = useChatInputStore((s) => s.editor);
   const activeTopicId = useChatStore((s) => s.activeTopicId);
 
-  // Resolve the active working directory so we can surface filesystem project
-  // skills. Topic-level override takes precedence over the agent's configured
-  // cwd. Both homogeneous and heterogeneous runtimes accept project skills now
+  // Resolve the active working directory so we can surface filesystem skills.
+  // Topic-level override takes precedence over the agent's configured cwd.
+  // Both homogeneous and heterogeneous runtimes accept filesystem skills now
   // (see commit dd4a4e7595), so we no longer gate on the hetero provider.
   const agentId = useAgentId();
   // Unified cwd: topic > agent's per-device choice > device default > home.
@@ -55,7 +55,7 @@ export const useSlashActionItems = (): SlashOptions['items'] => {
   // set (and for local-device runs), not just an explicit agent/topic pick.
   const workingDirectory = useEffectiveWorkingDirectory(agentId);
 
-  // Device-bound (remote) runs scan project skills on that device over the
+  // Device-bound (remote) runs scan filesystem skills on that device over the
   // `device.listProjectSkills` RPC; the local desktop reads over Electron IPC.
   // Mirror the WorkingSidebar exactly: resolve the EFFECTIVE target first, then
   // treat it as remote only when it lands on `device` with a bound device. The
@@ -77,7 +77,7 @@ export const useSlashActionItems = (): SlashOptions['items'] => {
   const remoteDeviceId = isDeviceMode ? agencyConfig.boundDeviceId : undefined;
 
   // Local desktop reads over IPC; a bound device reads over RPC. Either path
-  // makes project skills reachable even when this client isn't the desktop app
+  // makes filesystem skills reachable even when this client isn't the desktop app
   // (previously gated on `isDesktop` alone, so remote/web runs got nothing).
   const projectSkillsEnabled = (isDesktop || !!remoteDeviceId) && !!workingDirectory;
   const { data: projectSkillsData } = useFetchProjectSkills(
@@ -242,10 +242,9 @@ export const useSlashActionItems = (): SlashOptions['items'] => {
         allItems.push(makeAgentSkillItem(skill) as SlashItem);
       }
 
-      // Filesystem project skills (`.agents/skills/` / `.claude/skills/` under
-      // the working directory). Both homogeneous and heterogeneous runtimes
-      // resolve them — the homogeneous runtime treats them as additional
-      // `<available_skills>` entries.
+      // Filesystem skills from the project and execution device. Both
+      // homogeneous and heterogeneous runtimes resolve them — the homogeneous
+      // runtime treats them as additional `<available_skills>` entries.
       if (projectSkills && projectSkills.length > 0) {
         for (const skill of projectSkills) {
           allItems.push(makeProjectSkillItem(skill) as SlashItem);

--- a/src/features/SkillsList/SkillsList.tsx
+++ b/src/features/SkillsList/SkillsList.tsx
@@ -27,6 +27,8 @@ export interface SkillListItem {
   files?: string[];
   id: string;
   name: string;
+  /** Filesystem skill scope when the row comes from a device scan. */
+  scope?: 'device' | 'project';
 }
 
 /**

--- a/src/features/SkillsList/useProjectSkillResolver.ts
+++ b/src/features/SkillsList/useProjectSkillResolver.ts
@@ -21,8 +21,8 @@ export interface ResolvedProjectSkill {
 }
 
 /**
- * Resolve a project-skill tag (by its bare `name`) against the active session's
- * live project-skill list so an inline tag can show the skill's own description
+ * Resolve a filesystem-skill tag (by its bare `name`) against the active
+ * session's live skill list so an inline tag can show the skill's own description
  * and open its `SKILL.md`.
  *
  * Resolution is name-based on purpose: the persisted `<skill name label />` wire

--- a/src/features/SkillsList/useProjectSkills.ts
+++ b/src/features/SkillsList/useProjectSkills.ts
@@ -1,4 +1,4 @@
-import { type ListProjectSkillsResult, type ProjectSkillItem } from '@lobechat/electron-client-ipc';
+import type { ListProjectSkillsResult, ProjectSkillItem } from '@lobechat/electron-client-ipc';
 import { EyeIcon, PencilIcon, Trash2Icon } from 'lucide-react';
 import path from 'pathe';
 import { useMemo } from 'react';
@@ -10,14 +10,15 @@ import { useChatStore } from '@/store/chat';
 import type { SkillListItem, SkillRowAction } from './SkillsList';
 
 export interface UseProjectSkillsResult {
-  /**
-   * Per-row actions for project skills: "view" opens the SKILL.md (local only —
-   * a remote device's filesystem isn't reachable by the local viewer), while
-   * rename / delete are stubbed (disabled) until the filesystem-mutation IPC
-   * lands.
-   */
+  deviceItems: SkillListItem[];
   /** The thrown error from the SWR scan, if it failed. */
   error: unknown;
+  /**
+   * Per-row actions for filesystem skills: "view" opens the SKILL.md (local
+   * only — a remote device's filesystem isn't reachable by the local viewer),
+   * while rename / delete are stubbed (disabled) until filesystem-mutation IPC
+   * lands.
+   */
   getRowActions: (item: SkillListItem) => SkillRowAction[];
   isLoading: boolean;
   items: SkillListItem[];
@@ -25,13 +26,14 @@ export interface UseProjectSkillsResult {
   mutate: () => void;
   onOpenFile: (item: SkillListItem, relativePath: string) => void;
   onOpenSkill: (item: SkillListItem) => void;
+  projectItems: SkillListItem[];
   raw: ListProjectSkillsResult | undefined;
 }
 
 /**
- * Shared SWR + handlers for filesystem-backed project skills under
- * `.agents/skills/` / `.claude/skills/` in `workingDirectory`. Powers both
- * the hetero `SkillsGroup` and the homogeneous `ProjectLevelSkills` section.
+ * Shared SWR + handlers for filesystem-backed skills. Project skills live
+ * under `.agents/skills` / `.claude/skills` in `workingDirectory`; device
+ * skills live under those directories in the execution device's home.
  *
  * `deviceId` picks the transport: when set, the scan runs on that remote device
  * via the `device.listProjectSkills` RPC; otherwise it goes through local
@@ -51,10 +53,9 @@ export const useProjectSkills = (
 
   const { data, error, isLoading, mutate } = useFetchProjectSkills(workingDirectory, deviceId);
 
-  // listProjectSkills approves `data.root` for preview. Hand that exact value
-  // back to openLocalFile so LocalFileProtocolManager.createPreviewUrl's
-  // approved-root check matches; fall back to the requested workingDirectory
-  // while the SWR fetch is in flight.
+  // listProjectSkills approves per-skill preview roots. Fall back to the
+  // requested workingDirectory while the SWR fetch is in flight or when reading
+  // legacy cached payloads without previewRoot.
   const previewRoot = data?.root || workingDirectory || '';
 
   const items = useMemo<SkillListItem[]>(
@@ -65,9 +66,14 @@ export const useProjectSkills = (
         files: skill.files,
         id: skill.skillDir,
         name: skill.name,
+        scope: skill.scope,
       })),
     [data?.skills],
   );
+
+  const projectItems = useMemo(() => items.filter((item) => item.scope !== 'device'), [items]);
+
+  const deviceItems = useMemo(() => items.filter((item) => item.scope === 'device'), [items]);
 
   const skillByDir = useMemo(() => {
     const map = new Map<string, ProjectSkillItem>();
@@ -83,7 +89,7 @@ export const useProjectSkills = (
     if (!skill) return;
     openLocalFile({
       filePath: path.join(skill.skillDir, relativePath),
-      workingDirectory: previewRoot,
+      workingDirectory: skill.previewRoot || previewRoot,
     });
   };
 
@@ -91,7 +97,7 @@ export const useProjectSkills = (
     if (isRemote) return;
     const skill = skillByDir.get(item.id);
     if (!skill) return;
-    openLocalFile({ filePath: skill.path, workingDirectory: previewRoot });
+    openLocalFile({ filePath: skill.path, workingDirectory: skill.previewRoot || previewRoot });
   };
 
   const getRowActions = (_item: SkillListItem): SkillRowAction[] => {
@@ -127,6 +133,7 @@ export const useProjectSkills = (
   };
 
   return {
+    deviceItems,
     error,
     getRowActions,
     isLoading,
@@ -136,6 +143,7 @@ export const useProjectSkills = (
     },
     onOpenFile,
     onOpenSkill,
+    projectItems,
     raw: data,
   };
 };

--- a/src/hooks/useFetchProjectSkills.ts
+++ b/src/hooks/useFetchProjectSkills.ts
@@ -4,8 +4,7 @@ import { useClientDataSWR } from '@/libs/swr';
 import { projectSkillService } from '@/services/projectSkill';
 
 /**
- * Shared SWR fetch for filesystem-backed project skills under `.agents/skills/`
- * / `.claude/skills/` in a working directory.
+ * Shared SWR fetch for filesystem-backed project and device skills.
  *
  * `deviceId` picks the transport: a bound device scans over the
  * `device.listProjectSkills` RPC, the local desktop reads over Electron IPC. The

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import AgentDocumentsGroup from './AgentDocumentsGroup';
 
 const useClientDataSWR = vi.fn();
+const useProjectSkillsMock = vi.hoisted(() => vi.fn());
 const modalConfirm = vi.hoisted(() => vi.fn());
 const messageError = vi.hoisted(() => vi.fn());
 const messageSuccess = vi.hoisted(() => vi.fn());
@@ -92,6 +93,7 @@ vi.mock('react-i18next', () => ({
           'workingPanel.resources.updatedAt': `Updated ${options?.time}`,
           'workingPanel.skills.empty': 'No skills found',
           'workingPanel.skills.section.agent': 'Agent skills',
+          'workingPanel.skills.section.device': 'Device skills',
           'workingPanel.skills.section.project': 'Project skills',
           'workingPanel.skills.section.user': 'User skills',
         }) as Record<string, string>
@@ -176,13 +178,7 @@ vi.mock('@/features/SkillsList', () => {
       {isEmpty ? <div data-testid="skill-section-empty">{emptyText}</div> : children}
     </div>
   );
-  const useProjectSkills = () => ({
-    isLoading: false,
-    items: [],
-    onOpenFile: () => undefined,
-    onOpenSkill: () => undefined,
-    raw: undefined,
-  });
+  const useProjectSkills = (...args: unknown[]) => useProjectSkillsMock(...args);
   return { SkillSection, SkillsList, useProjectSkills };
 });
 
@@ -303,6 +299,19 @@ const webDocRow = {
 describe('AgentDocumentsGroup', () => {
   beforeEach(() => {
     useClientDataSWR.mockReset();
+    useProjectSkillsMock.mockReset();
+    useProjectSkillsMock.mockReturnValue({
+      deviceItems: [],
+      error: undefined,
+      getRowActions: () => [],
+      isLoading: false,
+      items: [],
+      mutate: vi.fn(),
+      onOpenFile: () => undefined,
+      onOpenSkill: () => undefined,
+      projectItems: [],
+      raw: undefined,
+    });
     modalConfirm.mockReset();
     messageError.mockReset();
     messageSuccess.mockReset();
@@ -331,6 +340,46 @@ describe('AgentDocumentsGroup', () => {
     // file / web docs should not leak into the skills tab
     expect(screen.queryByText('Brief')).not.toBeInTheDocument();
     expect(screen.queryByText('Example')).not.toBeInTheDocument();
+  });
+
+  it('renders project and device filesystem skills as separate sections', () => {
+    const projectItem = {
+      fileCount: 1,
+      id: 'project-skill',
+      name: 'project-writer',
+      scope: 'project' as const,
+    };
+    const deviceItem = {
+      fileCount: 1,
+      id: 'device-skill',
+      name: 'device-writer',
+      scope: 'device' as const,
+    };
+    useProjectSkillsMock.mockReturnValue({
+      deviceItems: [deviceItem],
+      error: undefined,
+      getRowActions: () => [],
+      isLoading: false,
+      items: [projectItem, deviceItem],
+      mutate: vi.fn(),
+      onOpenFile: () => undefined,
+      onOpenSkill: () => undefined,
+      projectItems: [projectItem],
+      raw: undefined,
+    });
+    useClientDataSWR.mockReturnValue({
+      data: [fileDocRow, webDocRow],
+      error: undefined,
+      isLoading: false,
+      mutate: vi.fn(),
+    });
+
+    render(<AgentDocumentsGroup showLocalProjectSkills workingDirectory="/repo" />);
+
+    expect(screen.getByTestId('skill-section-Project skills')).toBeInTheDocument();
+    expect(screen.getByTestId('skill-section-Device skills')).toBeInTheDocument();
+    expect(screen.getByText('project-writer')).toBeInTheDocument();
+    expect(screen.getByText('device-writer')).toBeInTheDocument();
   });
 
   it('opens the SKILL.md document in the portal when clicking a skill bundle row', () => {
@@ -567,7 +616,7 @@ describe('AgentDocumentsGroup', () => {
     render(<AgentDocumentsGroup />);
 
     // No agent bundles, no working dir (no Project section), no user-installed
-    // skills → renderSkills collapses to the global "No skills found"
+    // skills → renderSkills collapses to the shared "No skills found"
     // placeholder rather than rendering an empty section per source.
     expect(screen.getByText('No skills found')).toBeInTheDocument();
     expect(screen.queryByTestId('skills-list')).not.toBeInTheDocument();

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.tsx
@@ -38,6 +38,7 @@ import { chatConfigByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { standardizeIdentifier } from '@/utils/identifier';
 
+import DeviceLevelSkills from './DeviceLevelSkills';
 import ProjectLevelSkills from './ProjectLevelSkills';
 import UserLevelSkills, { useUserSkills } from './UserLevelSkills';
 
@@ -327,10 +328,12 @@ const AgentDocumentsGroup = memo<AgentDocumentsGroupProps>(
     // section layout (flat when a single source has items, sectioned otherwise).
     // Both hooks are SWR-deduped against their respective child fetches.
     const userSkillItems = useUserSkills();
-    const { items: projectSkillItems, isLoading: isProjectSkillsLoading } = useProjectSkills(
-      showProjectSkills ? workingDirectory : undefined,
-      deviceId,
-    );
+    const {
+      deviceItems: deviceSkillItems,
+      error: projectSkillsError,
+      isLoading: isProjectSkillsLoading,
+      projectItems: projectSkillItems,
+    } = useProjectSkills(showProjectSkills ? workingDirectory : undefined, deviceId);
 
     const {
       data = [],
@@ -515,17 +518,27 @@ const AgentDocumentsGroup = memo<AgentDocumentsGroupProps>(
     );
 
     const renderSkills = () => {
-      // Sections render in fixed order — agent → project → user — and each one
+      // Sections render in fixed order — agent → project → device → user — and each one
       // hides itself when it has nothing to show. When exactly one source has
       // items we drop the group header and render the list flat (no redundant
       // "User skills 1" label above a single row). When everything is empty we
       // fall back to a single placeholder.
       const hasAgent = skillItems.length > 0;
       const hasProject = showProjectSkills && projectSkillItems.length > 0;
+      const hasDevice = showProjectSkills && deviceSkillItems.length > 0;
       const hasUser = userSkillItems.length > 0;
-      const activeCount = (hasAgent ? 1 : 0) + (hasProject ? 1 : 0) + (hasUser ? 1 : 0);
+      const activeCount =
+        (hasAgent ? 1 : 0) + (hasProject ? 1 : 0) + (hasDevice ? 1 : 0) + (hasUser ? 1 : 0);
 
       if (activeCount === 0) {
+        if (showProjectSkills && projectSkillsError) {
+          return (
+            <Center flex={1} paddingBlock={24}>
+              <AsyncError error={projectSkillsError} variant={'block'} />
+            </Center>
+          );
+        }
+
         // Project skills refetch on a working-directory switch (new SWR key →
         // empty items while in flight). Show the loader instead of flashing the
         // empty placeholder when there's nothing else to render yet.
@@ -562,6 +575,13 @@ const AgentDocumentsGroup = memo<AgentDocumentsGroupProps>(
             ))}
           {hasProject && (
             <ProjectLevelSkills
+              deviceId={deviceId}
+              hideHeader={flat}
+              workingDirectory={workingDirectory!}
+            />
+          )}
+          {hasDevice && (
+            <DeviceLevelSkills
               deviceId={deviceId}
               hideHeader={flat}
               workingDirectory={workingDirectory!}

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/DeviceLevelSkills.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/DeviceLevelSkills.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { startSkillDrag } from '@/features/ChatInput/InputEditor/ActionTag/skillDragData';
 import { SkillSection, SkillsList, useProjectSkills } from '@/features/SkillsList';
 
-interface ProjectLevelSkillsProps {
+interface DeviceLevelSkillsProps {
   /** Bound remote device id; when set, skills are scanned over RPC. */
   deviceId?: string;
   /**
@@ -15,22 +15,22 @@ interface ProjectLevelSkillsProps {
   workingDirectory: string;
 }
 
-const ProjectLevelSkills = memo<ProjectLevelSkillsProps>(
+const DeviceLevelSkills = memo<DeviceLevelSkillsProps>(
   ({ deviceId, hideHeader, workingDirectory }) => {
     const { t } = useTranslation('chat');
-    const { error, getRowActions, mutate, onOpenFile, onOpenSkill, projectItems } =
-      useProjectSkills(workingDirectory, deviceId);
+    const { deviceItems, error, getRowActions, mutate, onOpenFile, onOpenSkill } = useProjectSkills(
+      workingDirectory,
+      deviceId,
+    );
 
-    // A failed scan must surface an error + Retry, not silently vanish (ux Read
-    // §1.1). Only genuinely-empty (no error) keeps the "hide the section" behavior.
-    if (projectItems.length === 0) {
+    if (deviceItems.length === 0) {
       if (!error) return null;
       if (hideHeader) return <SkillSection isEmpty error={error} onRetry={mutate} />;
       return (
         <SkillSection
           isEmpty
           error={error}
-          sectionHeader={{ title: t('workingPanel.skills.section.project') }}
+          sectionHeader={{ title: t('workingPanel.skills.section.device') }}
           onRetry={mutate}
         />
       );
@@ -39,12 +39,10 @@ const ProjectLevelSkills = memo<ProjectLevelSkillsProps>(
     const list = (
       <SkillsList
         getRowActions={getRowActions}
-        items={projectItems}
+        items={deviceItems}
         onOpenFile={onOpenFile}
         onOpenSkill={onOpenSkill}
         onSkillDragStart={(item, event) => {
-          // Project skills are resolved by the underlying CLI agent itself, so
-          // we serialize them as a literal `/skill-name` (projectSkill chip).
           startSkillDrag(event, {
             category: 'projectSkill',
             label: item.name,
@@ -59,8 +57,8 @@ const ProjectLevelSkills = memo<ProjectLevelSkillsProps>(
     return (
       <SkillSection
         sectionHeader={{
-          count: projectItems.length,
-          title: t('workingPanel.skills.section.project'),
+          count: deviceItems.length,
+          title: t('workingPanel.skills.section.device'),
         }}
       >
         {list}
@@ -69,6 +67,6 @@ const ProjectLevelSkills = memo<ProjectLevelSkillsProps>(
   },
 );
 
-ProjectLevelSkills.displayName = 'ProjectLevelSkills';
+DeviceLevelSkills.displayName = 'DeviceLevelSkills';
 
-export default ProjectLevelSkills;
+export default DeviceLevelSkills;

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/SkillsGroup.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/SkillsGroup.tsx
@@ -16,40 +16,81 @@ const SkillsGroup = memo<SkillsGroupProps>(({ deviceId, workingDirectory }) => {
   // Local desktop reads over IPC; a bound device reads over RPC. Either path
   // makes the skills list reachable even when this client isn't the desktop.
   const enabled = (isDesktop || !!deviceId) && !!workingDirectory;
-  const { getRowActions, isLoading, items, onOpenFile, onOpenSkill } = useProjectSkills(
-    enabled ? workingDirectory : undefined,
-    deviceId,
-  );
+  const {
+    deviceItems,
+    error,
+    getRowActions,
+    isLoading,
+    mutate,
+    onOpenFile,
+    onOpenSkill,
+    projectItems,
+  } = useProjectSkills(enabled ? workingDirectory : undefined, deviceId);
 
   if (!enabled) return null;
 
+  const renderList = (items: typeof projectItems) => (
+    <SkillsList
+      getRowActions={getRowActions}
+      items={items}
+      onOpenFile={onOpenFile}
+      onOpenSkill={onOpenSkill}
+      onSkillDragStart={(item, event) => {
+        // Filesystem skills are resolved by the underlying runtime registry, so
+        // we serialize them as a literal `/skill-name` (projectSkill chip).
+        startSkillDrag(event, {
+          category: 'projectSkill',
+          label: item.name,
+          type: item.name,
+        });
+      }}
+    />
+  );
+
+  const hasProject = projectItems.length > 0;
+  const hasDevice = deviceItems.length > 0;
+
+  if (hasProject || hasDevice) {
+    return (
+      <>
+        {hasProject && (
+          <SkillSection
+            sectionHeader={{
+              collapsible: false,
+              count: projectItems.length,
+              title: t('workingPanel.skills.section.project'),
+            }}
+          >
+            {renderList(projectItems)}
+          </SkillSection>
+        )}
+        {hasDevice && (
+          <SkillSection
+            sectionHeader={{
+              collapsible: false,
+              count: deviceItems.length,
+              title: t('workingPanel.skills.section.device'),
+            }}
+          >
+            {renderList(deviceItems)}
+          </SkillSection>
+        )}
+      </>
+    );
+  }
+
   return (
     <SkillSection
+      isEmpty
       emptyText={t('workingPanel.skills.empty')}
-      isEmpty={items.length === 0}
+      error={error}
       isLoading={isLoading}
       sectionHeader={{
         collapsible: false,
-        count: items.length,
         title: t('workingPanel.skills.title'),
       }}
-    >
-      <SkillsList
-        getRowActions={getRowActions}
-        items={items}
-        onOpenFile={onOpenFile}
-        onOpenSkill={onOpenSkill}
-        onSkillDragStart={(item, event) => {
-          // Project skills are resolved by the underlying CLI agent itself, so
-          // we serialize them as a literal `/skill-name` (projectSkill chip).
-          startSkillDrag(event, {
-            category: 'projectSkill',
-            label: item.name,
-            type: item.name,
-          });
-        }}
-      />
-    </SkillSection>
+      onRetry={mutate}
+    />
   );
 });
 

--- a/src/services/projectSkill.ts
+++ b/src/services/projectSkill.ts
@@ -10,7 +10,7 @@ import { localFileService } from '@/services/electron/localFileService';
  * electron-vs-lambda decision never leaks up. (Parallels `projectFileService`.)
  */
 class ProjectSkillService {
-  /** List `.agents/skills` / `.claude/skills` for a working directory. */
+  /** List project and execution-device `.agents/skills` / `.claude/skills`. */
   async listProjectSkills({
     deviceId,
     scope,


### PR DESCRIPTION
## Summary

- Model filesystem skills with `project` / `device` scope and keep per-skill `source`, `previewRoot`, and `skillDir` metadata across desktop IPC, device RPC, server runtime, and prompt metadata.
- Merge project roots (`.agents/skills`, `.claude/skills`) with device roots (`~/.agents/skills`, `~/.claude/skills`) during workspace scans, with project skills taking precedence on duplicate names.
- Split Resources display into Project skills and Device skills, and surface `Activate Device Skill` in tool inspectors.

Closes #16664.

## Verification

- ✅ `bunx vitest run --config packages/device-control/vitest.config.mts --silent='passed-only' packages/device-control/src/__tests__/dispatch.test.ts`
- ✅ `bunx vitest run --config packages/builtin-tool-skills/vitest.config.mts --silent='passed-only' packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts`
- ✅ `bunx vitest run --silent='passed-only' apps/server/src/services/deviceGateway/__tests__/index.test.ts "src/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup.test.tsx"`
- ✅ `cd apps/desktop && bunx vitest run --config vitest.config.mts --silent='passed-only' src/main/controllers/__tests__/WorkspaceCtr.test.ts`
- ✅ Isolated filesystem smoke for project + device skill merge and `source=device` activation
- ⚠️ `bun run type-check` was attempted and still fails on existing repo/env baseline issues (`local-file-shell` dependency resolution, `@lobechat/types` exports in prompts, hotkey typing). See the report for logs.
- ⚠️ Browser smoke verified web auth and app entry, but Resources panel visual E2E is not covered; grouping is covered by component tests.

Agent-testing report: https://app.lobehub.com/verify/68a8e5a2-c2ca-4935-81dc-845df3c2b494
