### PR TITLE
🐛 fix(chat): surface custom MCP connectors in the @ mention picker

### DIFF
--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -191,6 +191,14 @@ const ExecAgentSchema = z
         toolCallId: z.string(),
       })
       .optional(),
+    /**
+     * Tool identifiers the user @-mentioned in this message. Enabled for this
+     * run in addition to the agent's pinned plugins, so a mentioned tool that
+     * isn't pinned to the agent (e.g. a custom MCP connector picked from the @
+     * list) is callable. Scoped to the caller's own installed tools/connectors
+     * by the user-scoped lookups downstream, so it can't enable others' tools.
+     */
+    selectedToolIds: z.array(z.string()).optional(),
     /** The agent slug to run (either agentId or slug is required) */
     slug: z.string().optional(),
     /**
@@ -680,6 +688,7 @@ export const aiAgentRouter = router({
       fileIds,
       parentMessageId,
       resumeApproval,
+      selectedToolIds,
       trigger,
       userInterventionConfig,
     } = input;
@@ -700,6 +709,7 @@ export const aiAgentRouter = router({
         // human-approval resume — either way, skip user message creation.
         resume: !!parentMessageId,
         resumeApproval,
+        selectedToolIds,
         slug,
         trigger: trigger ?? RequestTrigger.Chat,
         userInterventionConfig,

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -320,6 +320,14 @@ interface InternalExecAgentParams extends ExecAgentParams {
     rejectionReason?: string;
     toolCallId: string;
   };
+  /**
+   * Tool identifiers the user @-mentioned in this message. Merged into the
+   * agent's plugin set for this run (alongside `additionalPluginIds`) so a
+   * mentioned tool that isn't pinned to the agent — e.g. a custom MCP connector
+   * picked from the @ list — is enabled and callable. User-scoped lookups
+   * downstream (connectors, installed plugins) keep it to the caller's own tools.
+   */
+  selectedToolIds?: string[];
   /** Abort startup before the agent runtime operation is created */
   signal?: AbortSignal;
   /**
@@ -912,6 +920,7 @@ export class AiAgentService {
       parentOperationId,
       resume,
       resumeApproval,
+      selectedToolIds,
       suppressUserMessage,
       ephemeralUserMessage,
     } = params;
@@ -2006,7 +2015,17 @@ export class AiAgentService {
     let lobehubSkillManifests: LobeToolManifest[] = [];
     let composioManifests: LobeToolManifest[] = [];
     let connectorManifests: ReturnType<typeof buildConnectorManifests> = [];
-    let agentPlugins: string[] = [...(agentConfig?.plugins ?? []), ...(additionalPluginIds || [])];
+    // `selectedToolIds` are the user's @-mention picks for this turn; merged in
+    // (deduped) alongside the agent's pinned plugins and any internal
+    // `additionalPluginIds` so a mentioned-but-not-pinned tool (e.g. a custom MCP
+    // connector) is both queried for manifests and enabled by the tools engine.
+    let agentPlugins: string[] = [
+      ...new Set([
+        ...(agentConfig?.plugins ?? []),
+        ...(additionalPluginIds || []),
+        ...(selectedToolIds || []),
+      ]),
+    ];
 
     // Model metadata is needed both for tool support checks and agent-management context.
     const { loadModels } = await import('@/business/client/model-bank/loadModels');

--- a/src/features/ChatInput/InputEditor/ActionTag/useInstalledSkillsAndTools.ts
+++ b/src/features/ChatInput/InputEditor/ActionTag/useInstalledSkillsAndTools.ts
@@ -9,6 +9,7 @@ import {
   lobehubSkillStoreSelectors,
   pluginSelectors,
 } from '@/store/tool/selectors';
+import { connectorSelectors } from '@/store/tool/slices/connector';
 
 import type { ActionTagData } from './types';
 
@@ -19,6 +20,7 @@ import type { ActionTagData } from './types';
  */
 export const useInstalledSkillsAndTools = (): ActionTagData[] => {
   const builtinSkills = useToolStore(builtinToolSelectors.installedBuiltinSkills, isEqual);
+  const customConnectors = useToolStore(connectorSelectors.customConnectors, isEqual);
   const installedPlugins = useToolStore(pluginSelectors.installedPluginMetaList, isEqual);
   const composioServers = useToolStore(composioStoreSelectors.getServers, isEqual);
   const lobehubSkillServers = useToolStore(lobehubSkillStoreSelectors.getServers, isEqual);
@@ -63,6 +65,19 @@ export const useInstalledSkillsAndTools = (): ActionTagData[] => {
     // --- Build tool set, excluding identifiers already classified as skills ---
     const toolMap = new Map<string, { icon?: string; label: string }>();
 
+    // Custom connectors (user-added MCP servers) first: they take priority over
+    // a legacy plugin sharing the same identifier, mirroring toolEngineering's
+    // connector-over-plugin rule. Only enabled connectors with synced tools are
+    // in the tools engine (buildClientConnectorManifests), so match that here —
+    // otherwise the picker would offer a mention that resolves to nothing.
+    for (const item of customConnectors) {
+      if (!item.isEnabled || (item.tools?.length ?? 0) === 0) continue;
+      if (skillMap.has(item.identifier)) continue;
+      if (!toolMap.has(item.identifier)) {
+        toolMap.set(item.identifier, { label: item.name || item.identifier });
+      }
+    }
+
     for (const item of installedPlugins) {
       // Skip entries that are actually skills (lobehub skill, agent skill, builtin skill)
       if (skillMap.has(item.identifier)) continue;
@@ -91,6 +106,7 @@ export const useInstalledSkillsAndTools = (): ActionTagData[] => {
     return items;
   }, [
     builtinSkills,
+    customConnectors,
     installedPlugins,
     composioServers,
     lobehubSkillServers,

--- a/src/features/Verify/Workspace/ReportListPanel.tsx
+++ b/src/features/Verify/Workspace/ReportListPanel.tsx
@@ -185,6 +185,7 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   itemTitle: css`
     overflow: hidden;
+    display: block;
 
     font-size: 13px;
     line-height: 1.4;

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/index.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/index.test.tsx
@@ -104,7 +104,13 @@ vi.mock('../TopicListContent/FlatMode', () => ({
   default: () => <div data-testid="flat-mode" />,
 }));
 
-vi.mock('@lobehub/ui', () => ({
+// Partial mock: keep every real export (e.g. `lobeStaticStylish`, which
+// `createStaticStyles` reads at import time in transitively-loaded modules like
+// ShareModal/useContainerStyles) and override only Flexbox. A full mock returning
+// just Flexbox drops those exports and crashes collection whenever the suite's
+// module graph evaluates one of them.
+vi.mock('@lobehub/ui', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
 }));
 

--- a/src/services/aiAgent.ts
+++ b/src/services/aiAgent.ts
@@ -37,6 +37,8 @@ export interface ExecAgentTaskParams {
   prompt: string;
   /** Resume a previous op paused on `human_approve_required` instead of starting from a fresh user prompt. */
   resumeApproval?: ResumeApprovalParam;
+  /** Tool identifiers the user @-mentioned in this message; the server enables them for this run. */
+  selectedToolIds?: string[];
   slug?: string;
   /**
    * Override what initiated this operation. Server defaults to `'chat'` when

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -909,6 +909,11 @@ export class ConversationLifecycleActionImpl {
           metadata: requestMetadata,
           parentOperationId: operationId,
           optimisticTopic,
+          // Forward @-mentioned tool ids so the server runtime enables them for
+          // this run — the gateway/server path otherwise never sees the mention
+          // selection (only the client runtime did). Omit when empty.
+          selectedToolIds:
+            selectedTools.length > 0 ? selectedTools.map((tool) => tool.identifier) : undefined,
           // Pass temp message IDs so the UI doesn't show a blank loading
           // state while waiting for the first step_start event to replace
           // messages with the server's real IDs.

--- a/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
@@ -217,7 +217,13 @@ export class StreamingExecutorActionImpl {
     // When disableTools is true (broadcast mode), skipDefaultTools prevents default tools from being added
     const toolsEngine = createAgentToolsEngine(
       { model: agentConfigData.model, provider: agentConfigData.provider! },
-      effectivePluginIds,
+      // Use `mergedToolIds` (not `effectivePluginIds`) so the enable rules cover
+      // user-selected @-mention ids too — the same id set `generateToolsDetailed`
+      // receives below. Otherwise a mentioned tool that isn't pinned to the agent
+      // (e.g. a custom MCP connector picked from the @ list) would have its
+      // manifest included but be defaulted to disabled by the enable checker, so
+      // no function tools are sent. `platformFilter` still gates availability.
+      mergedToolIds,
       // Context-aware builtin manifests: lobe-agent hides callSubAgent in group /
       // sub-agent runs. Replaces the former dropSubAgentInGroup + applyPluginFilters
       // isSubAgent hard-coding.

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -392,6 +392,14 @@ export class GatewayActionImpl {
      */
     resumeApproval?: ResumeApprovalParam;
     /**
+     * Tool identifiers the user @-mentioned in this message. Forwarded to the
+     * server as `selectedToolIds` so the server runtime enables them for this
+     * run (mirrors the client runtime's mention → callable-tool wiring). Lets a
+     * user invoke a tool that isn't pinned to the agent (e.g. a custom MCP
+     * connector picked from the @ list).
+     */
+    selectedToolIds?: string[];
+    /**
      * Temporary message IDs created during the initial sendMessage phase.
      * These are associated with the new gateway operation so the UI doesn't
      * show a blank loading state while waiting for the first `step_start`
@@ -409,6 +417,7 @@ export class GatewayActionImpl {
       parentMessageId,
       parentOperationId,
       resumeApproval,
+      selectedToolIds,
       tempMessageIds,
     } = params;
 
@@ -477,6 +486,7 @@ export class GatewayActionImpl {
         parentMessageId,
         prompt: message,
         resumeApproval,
+        selectedToolIds,
         trigger: metadata?.trigger,
         userInterventionConfig,
       },


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] 💄 style

#### 🔗 Related Issue

<!-- No exact matching issue; related area: custom MCP connectors. -->

#### 🔀 Description of Change

Make user-added custom MCP connectors usable from the chat `@` mention, plus a small verify-sidebar style fix. Four commits, grouped below.

**1. Custom MCP connectors missing from the `@` mention picker (`fix(chat)`)**

The `@` mention list in `useInstalledSkillsAndTools` was built only from builtin skills, installed plugins, composio servers, lobehub skills, and agent skills — it never read **connectors**, so a user-added custom MCP server (a `custom` connector) could not be `@`-mentioned. Add enabled, tool-synced `customConnectors` to the "tools" group, keyed by `connector.identifier`, ahead of plugins so a connector wins on identifier collision (mirroring `toolEngineering`'s connector-over-plugin priority). The `isEnabled && tools.length > 0` guard matches what actually lands in the tools engine, so the picker never offers a mention that resolves to nothing.

**2. Make `@`-mentioned tools actually callable on the client runtime (`fix(chat)`)**

A mentioned tool that isn't pinned to the agent inserted a chip but its function tools were never sent. In `internal_createAgentState`, `generateToolsDetailed` received `mergedToolIds` (runtime plugins + selected mention ids) so the manifest was included, but `createAgentToolsEngine` was built with `effectivePluginIds` (no selected ids), so the enable checker defaulted the id to disabled. Build the engine with `mergedToolIds` too, so the enable rules cover the same id set. When nothing is mentioned `mergedToolIds === effectivePluginIds` (no behavior change); `platformFilter` still gates availability.

**3. Forward `@`-mentioned tool ids to the server runtime (`fix(chat)`)**

The mention → callable-tool wiring only existed on the client runtime; the gateway/server runtime (`execAgent`) never received the selection, so a mentioned tool wasn't enabled when a turn ran server-side (any tool type, not just connectors). Plumb a dedicated `selectedToolIds` end-to-end: send site → `executeGatewayAgent` → `execAgentTask` → the `aiAgent.execAgent` tRPC input → the `execAgent` service, which merges it (deduped) into `agentPlugins` alongside `additionalPluginIds`. `agentPlugins` already drives the connector-manifest query, the enable rules, and the `generateToolsDetailed` toolIds uniformly, so no server engine change is needed. A dedicated field (not `additionalPluginIds`) keeps user @-mention selections distinct from internal server tool injection, and user-scoped lookups downstream mean a client can only enable its own installed tools.

**4. Long verify-report titles clip instead of ellipsizing (`style(verify)`)**

The verify report sidebar item title had `overflow` / `text-overflow` / `white-space` set, but the title element is an inline `<span>` — `text-overflow: ellipsis` has no effect on inline elements, so long titles overflowed and hard-clipped at the panel edge. Made it `display: block` so the existing ellipsis rules apply.

#### 🧪 How to Test

- [x] Tested locally

Verified the picker + selection + guard and the sidebar truncation end-to-end via agent-browser (Electron/CDP) against a local full-stack dev env with custom connectors seeded into Postgres:

- **A/B (fix off / on):** with the fix, typing `@` shows the custom connector under the **工具 / Tools** group; without it, no Tools group appears.
- **Selection:** picking the connector inserts a tool action-tag whose serialized Lexical state is `{ actionCategory: 'tool', actionType: '<connector-identifier>' }`.
- **Guard:** a disabled connector and a 0-tool connector (both matching the query) are correctly excluded.
- **Sidebar:** long titles now render with a trailing `…` instead of clipping mid-character.

Full run report (picker fix, 4/4): https://app.lobehub.com/verify/6671ba2c-ff49-4dc1-849f-4344c3e3dfd0

Commits 2–3 (callability) were verified by code trace + type-check on both the client and server packages; a live server-runtime A/B (mention → `execAgent: enabled tool ids` includes the connector) is the recommended follow-up check.

#### 📸 Screenshots / Videos

Sidebar title truncation:

| Before | After |
| ------ | ----- |
| long title clips mid-character at the panel edge, no ellipsis | title truncates cleanly with `…` |

#### 📝 Additional Information

No schema or migration changes. Adds one optional tRPC input field (`selectedToolIds`) on `aiAgent.execAgent`; the server contract and its in-repo callers ship together in this PR. No i18n changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)