### PR TITLE
🐛 fix(topic): render byStatus group mode in agent topic sidebar

### DIFF
--- a/src/features/NavPanel/components/NavItem.tsx
+++ b/src/features/NavPanel/components/NavItem.tsx
@@ -129,7 +129,15 @@ const NavItem = memo<NavItemProps>(
         {...rest}
       >
         {icon && (
-          <Center flex={'none'} height={28} width={28}>
+          <Center
+            flex={'none'}
+            // With a description the row is two lines tall; align the leading icon
+            // to the title's first line (match its line-height) instead of letting
+            // it center across both lines, which drops it into the gap.
+            height={description ? 22 : 28}
+            style={description ? { alignSelf: 'flex-start' } : undefined}
+            width={28}
+          >
             {loading ? (
               <NeuralNetworkLoading size={iconSize} />
             ) : (

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -262,8 +262,8 @@ const TopicItem = memo<TopicItemProps>(
     const workingDirectoryNode =
       showWorkingDirectory && workingDirectory ? (
         <Flexbox horizontal align={'center'} gap={4} style={{ overflow: 'hidden' }}>
-          <DirIcon repoType={isDesktop ? undefined : 'github'} size={12} />
-          <Text ellipsis fontSize={11} style={{ color: cssVar.colorTextDescription }}>
+          <DirIcon repoType={isDesktop ? undefined : 'github'} size={13} />
+          <Text ellipsis fontSize={12} style={{ color: cssVar.colorTextDescription }}>
             {getDirName(workingDirectory)}
           </Text>
         </Flexbox>

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/index.tsx
@@ -15,6 +15,7 @@ import { topicSelectors } from '@/store/chat/selectors';
 import AllTopicsDrawer from '../AllTopicsDrawer';
 import { useAgentTopicGroupMode } from '../hooks/useAgentTopicGroupMode';
 import ByProjectMode from '../TopicListContent/ByProjectMode';
+import ByStatusMode from '../TopicListContent/ByStatusMode';
 import ByTimeMode from '../TopicListContent/ByTimeMode';
 import FlatMode from '../TopicListContent/FlatMode';
 
@@ -54,6 +55,8 @@ const TopicList = memo(() => {
         <FlatMode />
       ) : topicGroupMode === 'byProject' ? (
         <ByProjectMode />
+      ) : topicGroupMode === 'byStatus' ? (
+        <ByStatusMode />
       ) : (
         <ByTimeMode />
       )}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] 💄 style

#### 🔗 Related Issue

<!-- N/A -->

#### 🔀 Description of Change

When an agent's topic group mode is `byStatus`, the sidebar silently rendered by-time grouping and never surfaced each topic's project (working directory), which read as a bug.

Root cause: the actually-rendered topic-list dispatcher `Topic/List/index.tsx` only branched on `flat` / `byProject` and fell through to `ByTimeMode` for everything else — so `byStatus` was never handled. (A near-duplicate `TopicListContent/index.tsx` does have the branch, but nothing imports it.)

Changes:

1. **fix**: add the missing `byStatus → <ByStatusMode />` branch to `Topic/List/index.tsx`, so by-status grouping renders and each topic shows its working directory line.
2. **style**: bump the working-directory line from 11px → 12px so it reads as a proper subtitle instead of a glitch.
3. **style**: on two-line `NavItem` rows (with a description), anchor the leading icon to the title's first line instead of centering it across both lines, where it dropped into the gap.

#### 🧪 How to Test

Set an agent's topic grouping to **By Status**, give a topic a working directory, and confirm the topic row shows the project name as a second line, with the leading icon aligned to the title.

- [x] Tested locally (Electron, canary) — verified via agent-testing: by-status now renders `ByStatusMode` and the working-directory line appears; leading icon center aligns with the title.
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

Follow-up candidate (not in this PR): the unused `TopicListContent/index.tsx` duplicates `Topic/List/index.tsx` and could be removed to prevent this divergence recurring.
