### PR TITLE
🐛 fix(chat): render local-file-tag nodes in messages without crashing

### DIFF
--- a/src/features/ChatInput/InputEditor/LocalFileTag/LocalFileTagNode.ts
+++ b/src/features/ChatInput/InputEditor/LocalFileTag/LocalFileTagNode.ts
@@ -1,5 +1,6 @@
 import { addClassNamesToElement } from '@lexical/utils';
 import { getKernelFromEditor } from '@lobehub/editor';
+import type { HeadlessRenderableNode, HeadlessRenderContext } from '@lobehub/editor/renderer';
 import {
   $applyNodeReplacement,
   DecoratorNode,
@@ -11,6 +12,9 @@ import {
   type SerializedLexicalNode,
   type Spread,
 } from 'lexical';
+import { createElement } from 'react';
+
+import { LocalFile } from '@/features/LocalFile';
 
 export type SerializedLocalFileTagNode = Spread<
   {
@@ -28,7 +32,7 @@ export type SerializedLocalFileTagNode = Spread<
  * `@`) and — crucially — own its `<localFile … />` markdown writer via a plugin
  * that is always registered, independent of whether `mentionOption` is enabled.
  */
-export class LocalFileTagNode extends DecoratorNode<any> {
+export class LocalFileTagNode extends DecoratorNode<any> implements HeadlessRenderableNode {
   __name: string;
   __path: string;
   __isDirectory: boolean;
@@ -115,6 +119,15 @@ export class LocalFileTagNode extends DecoratorNode<any> {
       queryDOM: decorator.queryDOM,
       render: decorator.render(this, editor),
     };
+  }
+
+  renderHeadless({ key }: HeadlessRenderContext) {
+    return createElement(LocalFile, {
+      isDirectory: this.__isDirectory,
+      key,
+      name: this.__name,
+      path: this.__path,
+    });
   }
 }
 

--- a/src/features/Conversation/Messages/User/components/RichTextMessage.test.tsx
+++ b/src/features/Conversation/Messages/User/components/RichTextMessage.test.tsx
@@ -34,6 +34,34 @@ const mentionEditorState = {
   },
 };
 
+const localFileEditorState = {
+  root: {
+    children: [
+      {
+        children: [
+          {
+            isDirectory: false,
+            name: 'report.md',
+            path: '/Users/me/project/report.md',
+            type: 'local-file-tag',
+            version: 1,
+          },
+        ],
+        direction: null,
+        format: '',
+        indent: 0,
+        type: 'paragraph',
+        version: 1,
+      },
+    ],
+    direction: null,
+    format: '',
+    indent: 0,
+    type: 'root',
+    version: 1,
+  },
+};
+
 afterEach(() => {
   cleanup();
 });
@@ -47,6 +75,19 @@ describe('RichTextMessage', () => {
     });
 
     expect(container.querySelector('.editor_mention')?.textContent).toBe('@Agent A');
+  });
+
+  // Regression: a local file dragged from the working sidebar serializes to a
+  // `local-file-tag` node. If that node isn't registered on the renderer,
+  // LexicalRenderer throws while parsing the state and the whole message crashes.
+  it('should render local-file-tag nodes without crashing', async () => {
+    const { container } = render(<RichTextMessage editorState={localFileEditorState} />);
+
+    await act(async () => {
+      await moment();
+    });
+
+    expect(container.textContent).toContain('report.md');
   });
 
   it('should render nothing for empty editor state', () => {

--- a/src/features/Conversation/Messages/User/components/RichTextMessage.tsx
+++ b/src/features/Conversation/Messages/User/components/RichTextMessage.tsx
@@ -4,6 +4,7 @@ import type { CSSProperties } from 'react';
 import { memo, useMemo } from 'react';
 
 import { ActionTagNode } from '@/features/ChatInput/InputEditor/ActionTag/ActionTagNode';
+import { LocalFileTagNode } from '@/features/ChatInput/InputEditor/LocalFileTag';
 import { mentionFilledClassName } from '@/features/ChatInput/InputEditor/mentionStyle';
 import { ReferTopicNode } from '@/features/ChatInput/InputEditor/ReferTopic/ReferTopicNode';
 
@@ -13,7 +14,7 @@ interface RichTextMessageProps {
 
 const LINE_HEIGHT = 1.6;
 const style: CSSProperties = { '--common-line-height': LINE_HEIGHT } as CSSProperties;
-const EXTRA_NODES = [ActionTagNode, ReferTopicNode];
+const EXTRA_NODES = [ActionTagNode, ReferTopicNode, LocalFileTagNode];
 
 const RichTextMessage = memo<RichTextMessageProps>(({ editorState }) => {
   const value = useMemo(() => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No matching GitHub issue found -->

#### 🔀 Description of Change

A local file dragged from the working sidebar into the chat input serializes to a `local-file-tag` Lexical node. When such a message was later rendered, the read-only message renderer (`RichTextMessage`) had never registered that node type and the node exposed no headless render path, so `LexicalRenderer` threw while parsing the serialized state — crashing the entire message.

This PR:

- Implements `renderHeadless` on `LocalFileTagNode` (now `implements HeadlessRenderableNode`), rendering the existing `LocalFile` component.
- Registers `LocalFileTagNode` in `RichTextMessage`'s `EXTRA_NODES` alongside `ActionTagNode` and `ReferTopicNode`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added a regression test in `RichTextMessage.test.tsx` that renders a `local-file-tag` editor state and asserts the file name appears instead of crashing. To reproduce manually: drag a local file from the working sidebar into the chat input, send the message, and confirm the message renders the file tag instead of a crash.

#### 📝 Additional Information

No breaking changes. UI-only fix, single layer.