### PR TITLE
⚡️ perf(agent-runtime): stop padding sub-second QStash step delays to a full second

### DIFF
--- a/apps/server/src/services/queue/impls/qstash.ts
+++ b/apps/server/src/services/queue/impls/qstash.ts
@@ -45,7 +45,10 @@ export class QStashQueueServiceImpl implements QueueServiceImpl {
           stepIndex,
           timestamp: Date.now(),
         },
-        delay: Math.ceil(delay / 1000), // Convert milliseconds to seconds
+        // QStash delay granularity is whole seconds, so sub-second step delays
+        // can't be expressed. Ceiling them up padded every step to a full second;
+        // instead dispatch immediately (0) and only delay for >= 1s intents.
+        delay: delay >= 1000 ? Math.round(delay / 1000) : 0,
         headers: {
           'Content-Type': 'application/json',
           'X-Agent-Operation-Id': operationId,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ⚡️ perf

#### 🔀 Description of Change

Durable agent operations re-enqueue every step through QStash (`POST /api/agent/run` → run one step → `scheduleMessage` publishes the next step → QStash calls `/run` again). The intended inter-step delay from `AgentRuntimeService.calculateStepDelay` is **50ms** (100ms after a tool result, ≤1000ms error backoff).

But QStash's `delay` param is **in whole seconds**, and `queue/impls/qstash.ts` converted it with `Math.ceil(delay / 1000)`:

- `Math.ceil(50 / 1000)` → **1**
- `Math.ceil(100 / 1000)` → **1**

So **any sub-second delay was rounded up to a full 1 second**, adding ~1s of dead time to every single step. In production traces this showed up as a rock-steady ~1s floor on the gap between consecutive steps, independent of provider. On a 22-step operation that is ~22s of pure scheduling padding (~13% of wall-clock).

QStash cannot express sub-second delays (`Duration` unit is `s | m | h | d`; no `ms`), so the honest mapping for a sub-second intent is **0 — dispatch immediately** — rather than 1s. Only delays `>= 1s` are still converted to seconds.

```diff
- delay: Math.ceil(delay / 1000), // Convert milliseconds to seconds
+ delay: delay >= 1000 ? Math.round(delay / 1000) : 0,
```

This removes the artificial ~1s per-step gap. The remaining per-step latency (~1.5–1.7s) is QStash queue + endpoint round-trip / function cold start, which this PR does not touch.

Applies to every `scheduleMessage` call: normal step (50ms), post-tool (100ms), startup (50ms), human-intervention resume (100ms), async-tool resume (100ms) — all previously padded to 1s, now immediate.

#### 🧪 How to Test

- [x] No tests needed

Verified via production operation traces: inter-step gap (`steps[].completedAt` → next `steps[].startedAt`) sits at a constant ~2.7s across ops/providers, of which ~1s is this `Math.ceil` floor and ~1.7s is unavoidable QStash platform round-trip. This change eliminates the ~1s component.