### PR TITLE
🐛 fix(group-chat): resolve real parent_id for agent council virtual messages

### DIFF
--- a/src/features/Conversation/store/slices/data/selectors.ts
+++ b/src/features/Conversation/store/slices/data/selectors.ts
@@ -53,7 +53,7 @@ const findLastBlockId = (block: AssistantContentBlock | undefined): string | und
 
 /**
  * Recursively finds the last message ID in a message tree
- * Priority: children > tools > self
+ * Priority: children > tools > virtual group members/tasks/columns > self
  */
 const findLastMessageIdRecursive = (node: UIChatMessage | undefined): string | undefined => {
   if (!node) return undefined;
@@ -70,7 +70,27 @@ const findLastMessageIdRecursive = (node: UIChatMessage | undefined): string | u
     return lastTool?.result_msg_id;
   }
 
-  // Priority 3: Return self ID
+  // Priority 3: Virtual group messages (agentCouncil / groupTasks / tasks / compare)
+  // carry a synthetic composite id (e.g. `agentCouncil-msg_X-msg_Y-msg_Z`) that is
+  // never persisted to the `messages` table. Returning it as a parentId triggers a
+  // PostgreSQL FK violation (23503). Dive into the real member/task/column messages
+  // and resolve the last persisted id instead.
+  const members = (node as any).members as UIChatMessage[] | undefined;
+  if (members && members.length > 0) {
+    return findLastMessageIdRecursive(members.at(-1));
+  }
+
+  const tasks = (node as any).tasks as UIChatMessage[] | undefined;
+  if (tasks && tasks.length > 0) {
+    return findLastMessageIdRecursive(tasks.at(-1));
+  }
+
+  const columns = (node as any).columns as UIChatMessage[][] | undefined;
+  if (columns && columns.length > 0) {
+    return findLastMessageIdRecursive(columns.at(-1)?.at(-1));
+  }
+
+  // Priority 4: Return self ID
   return node.id;
 };
 

--- a/src/store/chat/slices/message/selectors/displayMessage.test.ts
+++ b/src/store/chat/slices/message/selectors/displayMessage.test.ts
@@ -907,5 +907,112 @@ describe('displayMessageSelectors', () => {
       const result = displayMessageSelectors.findLastMessageId('mg_123456')(state as ChatStore);
       expect(result).toBe('msg-999');
     });
+
+    it('should resolve a real member id for an agentCouncil virtual message (not the composite id)', () => {
+      // ROOT CAUSE (issue #15531):
+      //
+      // agentCouncil virtual messages carry a synthetic composite id like
+      // `agentCouncil-msg_X-msg_Y-msg_Z` that is never persisted to the
+      // `messages` table. Returning it as the next turn's parentId triggers a
+      // PostgreSQL FK violation (23503, messages_parent_id_messages_id_fk).
+      const councilMessage = {
+        id: 'agentCouncil-supervisor-1-member-a-member-b',
+        role: 'agentCouncil',
+        content: '',
+        members: [
+          { id: 'member-a', role: 'assistant', content: 'A' },
+          { id: 'member-b', role: 'assistant', content: 'B' },
+        ],
+      } as unknown as UIChatMessage;
+
+      const state: Partial<ChatStore> = {
+        activeAgentId: 'test-id',
+        messagesMap: {
+          [messageMapKey({ agentId: 'test-id' })]: [councilMessage],
+        },
+      };
+
+      const result = displayMessageSelectors.findLastMessageId(
+        'agentCouncil-supervisor-1-member-a-member-b',
+      )(state as ChatStore);
+      expect(result).toBe('member-b');
+    });
+
+    it('should dive into a member assistantGroup to resolve its last real id', () => {
+      const councilMessage = {
+        id: 'agentCouncil-supervisor-1-member-a-member-b',
+        role: 'agentCouncil',
+        content: '',
+        members: [
+          { id: 'member-a', role: 'assistant', content: 'A' },
+          {
+            id: 'member-b-group',
+            role: 'assistantGroup',
+            content: '',
+            children: [
+              { id: 'member-b-block-1', content: 'first' },
+              { id: 'member-b-block-2', content: 'second' },
+            ],
+          },
+        ],
+      } as unknown as UIChatMessage;
+
+      const state: Partial<ChatStore> = {
+        activeAgentId: 'test-id',
+        messagesMap: {
+          [messageMapKey({ agentId: 'test-id' })]: [councilMessage],
+        },
+      };
+
+      const result = displayMessageSelectors.findLastMessageId(
+        'agentCouncil-supervisor-1-member-a-member-b',
+      )(state as ChatStore);
+      expect(result).toBe('member-b-block-2');
+    });
+
+    it('should resolve a real task id for a groupTasks/tasks virtual message (not the composite id)', () => {
+      const groupTasksMessage = {
+        id: 'groupTasks-supervisor-1-task-a-task-b',
+        role: 'groupTasks',
+        content: '',
+        tasks: [
+          { id: 'task-a', role: 'assistant', content: 'A' },
+          { id: 'task-b', role: 'assistant', content: 'B' },
+        ],
+      } as unknown as UIChatMessage;
+
+      const state: Partial<ChatStore> = {
+        activeAgentId: 'test-id',
+        messagesMap: {
+          [messageMapKey({ agentId: 'test-id' })]: [groupTasksMessage],
+        },
+      };
+
+      const result = displayMessageSelectors.findLastMessageId(
+        'groupTasks-supervisor-1-task-a-task-b',
+      )(state as ChatStore);
+      expect(result).toBe('task-b');
+    });
+
+    it('should resolve a real column id for a compare virtual message', () => {
+      const compareMessage = {
+        id: 'compare-group-1',
+        role: 'compare',
+        content: '',
+        columns: [[{ id: 'col-a', content: 'A' }], [{ id: 'col-b', content: 'B' }]],
+      } as unknown as UIChatMessage;
+
+      const state: Partial<ChatStore> = {
+        activeAgentId: 'test-id',
+        messagesMap: {
+          [messageMapKey({ agentId: 'test-id' })]: [compareMessage],
+        },
+      };
+
+      const result = displayMessageSelectors.findLastMessageId('compare-group-1')(
+        state as ChatStore,
+      );
+      expect(result).toBe('col-b');
+    });
   });
 });

--- a/src/store/chat/slices/message/selectors/displayMessage.ts
+++ b/src/store/chat/slices/message/selectors/displayMessage.ts
@@ -240,7 +240,7 @@ const findLastBlockId = (block: AssistantContentBlock | undefined): string | und
 
 /**
  * Recursively finds the last message ID in a message tree
- * Priority: children > tools > compressedGroup.lastMessageId > self
+ * Priority: children > tools > virtual group members/tasks/columns > compressedGroup.lastMessageId > self
  */
 const findLastMessageIdRecursive = (node: UIChatMessage | undefined): string | undefined => {
   if (!node) return undefined;
@@ -257,12 +257,32 @@ const findLastMessageIdRecursive = (node: UIChatMessage | undefined): string | u
     return lastTool?.result_msg_id;
   }
 
-  // Priority 3: For compressedGroup, return lastMessageId instead of group ID
+  // Priority 3: Virtual group messages (agentCouncil / groupTasks / tasks / compare)
+  // carry a synthetic composite id (e.g. `agentCouncil-msg_X-msg_Y-msg_Z`) that is
+  // never persisted to the `messages` table. Returning it as a parentId triggers a
+  // PostgreSQL FK violation (23503). Dive into the real member/task/column messages
+  // and resolve the last persisted id instead.
+  const members = (node as any).members as UIChatMessage[] | undefined;
+  if (members && members.length > 0) {
+    return findLastMessageIdRecursive(members.at(-1));
+  }
+
+  const tasks = (node as any).tasks as UIChatMessage[] | undefined;
+  if (tasks && tasks.length > 0) {
+    return findLastMessageIdRecursive(tasks.at(-1));
+  }
+
+  const columns = (node as any).columns as UIChatMessage[][] | undefined;
+  if (columns && columns.length > 0) {
+    return findLastMessageIdRecursive(columns.at(-1)?.at(-1));
+  }
+
+  // Priority 4: For compressedGroup, return lastMessageId instead of group ID
   if (node.role === 'compressedGroup' && 'lastMessageId' in node) {
     return (node as any).lastMessageId;
   }
 
-  // Priority 4: Return self ID
+  // Priority 5: Return self ID
   return node.id;
 };
 


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 🐛 fix

### 🔀 变更说明 | Description of Change

Fixes the Agent Council (group mode) PostgreSQL foreign-key constraint violation reported in #15531.

**Root cause**

The flat-list / context-tree transformation synthesizes virtual group messages — `agentCouncil`, `groupTasks`, `tasks`, `compare` — whose `id` is a composite string built by concatenating the round's member/task message ids (e.g. `agentCouncil-msg_X-msg_Y-msg_Z`). That composite id is never persisted to the `messages` table.

When the visible last message is one of these virtual nodes, `findLastMessageIdRecursive` only knew how to dive into `children` / `tools`, so it fell through to returning the node's own (composite) id. The store then used it as the next turn's `parentId`, and the insert failed with PostgreSQL error `23503` on `messages_parent_id_messages_id_fk`.

**Fix**

Teach `findLastMessageIdRecursive` (both copies — `store/chat` and `features/Conversation`) to dive into the virtual node's real `members` / `tasks` / `columns` and recursively resolve the last **persisted** message id. This never returns a composite virtual id, so:

- both `agentCouncil-` and `groupTasks-` (plus `tasks-` / `compare`) prefix patterns are fixed,
- server DB mode (Postgres FK) and client mode both get a valid single `parentId`,
- a member that is itself an `assistantGroup` still resolves down to its last real child/tool id.

PR #15408 previously only classified this as `ConversationParentMissing` for error recovery; this addresses the root cause.

### 📝 补充信息 | Additional Information

- Added unit coverage in `displayMessage.test.ts` for the agentCouncil / member-assistantGroup / groupTasks / compare cases.
- Duplicates: #14632, #10088, #12292.

Closes #15531

🤖 Generated with [Claude Code](https://claude.com/claude-code)