### PR TITLE
💄 style(chat): tighten drag overlay border and use generic local device icon

### DIFF
--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -112,7 +112,52 @@ ship a root cause into a report that a one-line probe could have checked.
 
 ---
 
-## Case 5 — (placeholder) append the user's next negative feedback below
+## Case 5 — Attaching the stale "before" screenshot as a passed case's evidence (unlabeled)
+
+**Wrong approach**: after verifying a UI change on the live-code instance, I put
+BOTH the "after" (live) and the "before" (stale-build) screenshots into the same
+`cases[].evidence` array, unlabeled. The verify page renders every evidence image
+with its filename as a heading, so the user opened `01-drag-overlay.png` /
+`02-switcher-popover.png` (the STALE shots) and saw the old 28px gap + Apple logo —
+concluding "还是没贴边 / 还是 Apple logo, 你没改啊".
+
+**Why it's wrong**: a passed case's evidence must show the PASSING (after) state.
+An unlabeled before-shot sitting next to it reads as "the current result", making a
+correct fix look broken. Filenames are not captions — the viewer can't tell
+before from after.
+
+**What it breaks**: the user reads a green/passed report as a failure, loses trust,
+and it takes another round to re-explain.
+
+**Correct approach**: never ship a raw stale/before screenshot as standalone
+evidence. If a contrast helps, build ONE labeled before→after composite (e.g. sharp:
+crop the region from each, add a "BEFORE …/AFTER …" header bar, place side by side)
+and attach that single image. Evidence for a passed case = the after state (or a
+clearly-labeled comparison), full stop.
+
+## Case 6 — `app://renderer` desktop instance runs the STALE built bundle, not working-tree code
+
+**Wrong approach**: driving the already-running desktop app on CDP 9222 (URL
+`app://renderer/…`) to verify a working-tree UI change, and eyeballing the first
+screenshot as "looks changed".
+
+**Why it's wrong**: the resident desktop app serves a BUILT renderer snapshot — it
+does not reflect uncommitted/HMR src changes. The measured `::before` inset was
+still 28px (old) even though the code said 10px. Eyeballing nearly passed it.
+
+**What it breaks**: verifying against code that isn't your change → a false pass (or
+false fail), on the wrong bundle entirely.
+
+**Correct approach**: to verify working-tree UI in the desktop shape, start an
+isolated dev instance that loads live code — `electron-dev.sh start <id>` runs
+`electron-vite dev` (its own CDP/Vite, copied login), which DOES bundle your src
+changes. Prove it's live by MEASURING a known-changed value (e.g. computed
+`::before` inset 10px vs old 28px) before trusting any screenshot. Don't kill the
+user's resident 9222 app — use a pool id. Also: `agent-browser open` mangles
+`app://` → `https://app//…` (ERR\_CONNECTION\_CLOSED); navigate inside the SPA by
+clicking its own `<a href>` links, not `open`.
+
+## Case 7 — (placeholder) append the user's next negative feedback below
 
 <!-- New case template:
 ## Case N — one-line summary of the mistake

--- a/.agents/skills/ux/SKILL.md
+++ b/.agents/skills/ux/SKILL.md
@@ -64,6 +64,19 @@ titles, object labels) should read separately from state and actions (save statu
 sharing, panel toggles, overflow menus). When these roles are mixed, users have to infer
 whether an element describes the current object or acts on it.
 
+### Compose the canonical surface component, don't re-derive it・Certainty・Natural
+
+When a surface class already has a canonical component in this codebase — a sidebar row →
+`NavItem`, a collapsible group → `Accordion` / `GroupedAccordion`, an active surface →
+`Block variant='filled'` — **compose it**, don't rebuild the chrome from raw
+`<div>`/`<button>`/`<input>` + a bespoke `createStaticStyles` block. A hand-rolled parallel
+re-derives padding, hover/active states, alignment, and reveal-on-hover by hand, and drifts
+from its siblings on each one — the aggregate reads as "unpolished" even when every single gap
+is tiny. Before building a list / nav / master-detail panel, find the primitive the sibling
+surface uses (grep `NavItem`, `Accordion`) and compose it; fall to raw elements only for a
+genuinely novel row. See **[Read §1.10](references/read.md)** for the full pattern; the
+**react** component-priority rule covers the mechanics.
+
 ## Checklist modules
 
 Grouped by **interaction type** — the kind of thing the user is doing. Jump to the module
@@ -97,6 +110,7 @@ The one-screen scan. Each line links back to a module above for the full rule + 
 - [ ] Live/polling feed signals new items + offers manual refresh, doesn't reorder under the user, and shows a failed refresh distinctly (not as empty). A bulk/destructive control derived from the live-status map (close-idle / clear-inactive) gates on the query's loaded/error state — "unknown/errored" is ineligible, never treated as the inactive value. Conditional polling starts from **reactive state** (`shouldPoll` → `refreshInterval`), not a function-form `refreshInterval` that never schedules a first timer when its initial value is `0`.
 - [ ] A surface with many navigable entries (a big settings area, a long list) offers search / filter / jump, not browse-only — named as a class norm so an absent box is caught.
 - [ ] Marketplace / registry browse cards carry owned/installed state on the tile (not only on the detail) and trust/verified badges via one card contract, consistent across sibling registries; contribute leads to an in-app submit, not an external repo.
+- [ ] A sidebar / nav / master-detail **list row** composes the canonical `NavItem` (+ `Accordion` / `GroupedAccordion` for groups, `Block variant='filled'` for active), not a hand-rolled `<div>`/`<button>`/`<input>` + bespoke CSS — else the hover/active highlight misaligns from the content box, content bleeds to the panel edge, the search/rename/action-reveal drift from every sibling panel, and the list stays a flat ungrouped dump. Grep `NavItem` before building.
 
 **Edit — entering & changing content** ([edit.md](references/edit.md))
 

--- a/.agents/skills/ux/references/read.md
+++ b/.agents/skills/ux/references/read.md
@@ -407,3 +407,56 @@ paths that already exist and blesses the absent ones.
 - [ ] Registry/marketplace browse cards reflect owned / installed / added state on the tile, not only on the detail page. _(Meaningful)_
 - [ ] Trust / verified / official badges applied via one card contract, consistently across sibling registries (no "official on one list, nothing on its twin"). _(Certainty・Meaningful)_
 - [ ] Class-norm capabilities (owned-state, trust badge, counts, no-results≠first-run, contribute→in-app-submit) listed from comparables up front, so an absent one is caught. _(Certainty)_
+
+## 1.10 Reuse the canonical list / nav row — don't hand-roll sidebar chrome・Certainty・Natural
+
+A navigation / list **sidebar** (topic list, report list, resource tree — any master-detail
+left panel) is a **solved surface class** in this codebase, and the polish is in the shared
+primitive, not in the individual screen. Rows go through **`NavItem`**
+(`src/features/NavPanel/components/NavItem.tsx`); collapsible groups through
+**`Accordion` / `AccordionItem`** (via the shared **`GroupedAccordion`** engine); the active
+row through **`Block variant='filled'`**; spacing through `Flexbox` / `Block` `gap` /
+`padding` props, never hand-picked px. Composing those buys — for free, and identical to every
+sibling panel — the four things bespoke rows get wrong:
+
+1. **The highlight box _is_ the padded content box.** `NavItem` makes the interactive
+   `Block` the hover/active surface, so the highlight always aligns to the row and content
+   can't bleed to the panel edge. A hand-rolled row whose list-container padding, item
+   padding, and highlight radius are chosen independently produces a highlight rectangle that
+   floats / insets differently from the text, and text that runs to the viewport edge.
+2. **The app-wide active treatment.** `variant={active ? 'filled' : 'borderless'}` is _the_
+   active row everywhere. A bespoke `data-active` + `colorFillSecondary` is a slightly-off
+   look that no longer matches the panel next to it.
+3. **A right-aligned `extra` slot + hover-revealed actions**, already solved (timestamp /
+   count on the right; `.nav-item-actions` reveal on `:hover`). Re-implementing the
+   `opacity: 0 → 1` reveal by hand is code that will drift.
+4. **Grouping at scale.** The canonical sidebar offers by-project / by-status / by-time
+   collapsible `Accordion` groups; a hand-rolled panel is almost always a **flat, ungrouped
+   dump** that has no structure once the list grows past a screen.
+
+The row is also where **Edit** (inline rename) and **Act** (delete / overflow menu) live —
+hand-rolling the row drags those into raw `<input>` / raw `<button>` too, missing the shared
+inline-edit and confirm patterns. Each miss is individually tiny; the sum is exactly what
+"做的非常不成熟 /unpolished" means. **Before building any left-panel list, grep the sibling
+surface (`NavItem`, `Accordion`, `GroupedAccordion`) and compose it**; fall to raw elements
+only for a genuinely novel row. (Component-priority _mechanics_ are in **react**; this is the
+UX consequence — a bespoke row is a visible consistency + craft regression.)
+
+> ✅ **Topic sidebar** (`routes/(main)/agent/_layout/Sidebar/Topic/**`) composes `NavItem` rows
+> inside `Accordion` groups via one shared `GroupedAccordion` engine (by-project / by-status /
+> by-time), `Block variant='filled'` for the active row, and spacing as `Flexbox` / `Block`
+> props — every row aligns to its highlight and matches every other panel in the app.
+> ❌ **Verify report sidebar** (`features/Verify/Workspace/ReportListPanel.tsx`) hand-rolls the
+> entire panel: a raw grid `<div className={styles.item}>` row with `data-active` +
+> `colorFillSecondary` (instead of `NavItem` / `Block variant`), a bordered `<label>` + `<input>`
+> search box, a raw `<input>` inline-rename, an `opacity`-toggled action reveal re-implemented in
+> CSS, and a **flat, ungrouped** list — so the hover box misaligns from the text, content bleeds
+> to the panel edge, and the surface reads as off-rhythm next to the topic sidebar it sits beside.
+
+**Checklist**
+
+- [ ] Sidebar / nav list rows go through the canonical `NavItem` (or the surface's shared row primitive), not a hand-rolled `<div>` / `<button>` — so hover/active is the app-wide treatment and the highlight box **is** the padded content box (no floating/misaligned highlight, no edge-bleed). _(Certainty)_
+- [ ] Active row uses `Block variant='filled'` (the shared active treatment), not a bespoke `data-active` + `colorFill*` re-derivation. _(Certainty)_
+- [ ] Grouping at scale reuses `Accordion` / `GroupedAccordion` (by-project / status / time), not a flat ungrouped dump once the list grows past a screen. _(Natural)_
+- [ ] Search box, inline-rename, and row actions reuse the shared input / editing / action-reveal patterns, not raw `<input>` / `<label>` + hand CSS. _(Certainty)_
+- [ ] Spacing/padding expressed as `Flexbox` / `Block` `gap` / `padding` props (inherits the sidebar rhythm), not hand-picked px constants. _(Natural)_

--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -294,7 +294,7 @@
   "heteroAgent.executionTarget.gatewayDesc": "Run through the device gateway so other clients can follow progress",
   "heteroAgent.executionTarget.infoTooltip": "Pick a device and the agent uses it as its runtime environment — reading and writing files and operating the computer. Cloud sandbox is provided by LobeHub Marketplace.",
   "heteroAgent.executionTarget.loading": "Loading devices…",
-  "heteroAgent.executionTarget.local": "This device",
+  "heteroAgent.executionTarget.local": "Local device",
   "heteroAgent.executionTarget.localDesc": "Run as a local process on this desktop app",
   "heteroAgent.executionTarget.manage": "Manage",
   "heteroAgent.executionTarget.noDevices": "No remote devices yet. Run `lh connect` on another machine to add one.",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -294,7 +294,7 @@
   "heteroAgent.executionTarget.gatewayDesc": "经由设备网关运行，其他客户端可跟踪进度",
   "heteroAgent.executionTarget.infoTooltip": "选择某台设备后，Agent 将以该设备为运行环境，读写文件、操作电脑。云端沙箱由 LobeHub Marketplace 提供服务",
   "heteroAgent.executionTarget.loading": "正在加载设备…",
-  "heteroAgent.executionTarget.local": "本机",
+  "heteroAgent.executionTarget.local": "本地设备",
   "heteroAgent.executionTarget.localDesc": "在当前桌面端以本地进程运行",
   "heteroAgent.executionTarget.manage": "管理",
   "heteroAgent.executionTarget.noDevices": "暂无远程设备。在另一台机器上执行 `lh connect` 即可接入。",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -257,7 +257,7 @@ export default {
   'heteroAgent.executionTarget.gatewayDesc':
     'Run through the device gateway so other clients can follow progress',
   'heteroAgent.executionTarget.loading': 'Loading devices…',
-  'heteroAgent.executionTarget.local': 'This device',
+  'heteroAgent.executionTarget.local': 'Local device',
   'heteroAgent.executionTarget.localDesc': 'Run as a local process on this desktop app',
   'heteroAgent.executionTarget.manage': 'Manage',
   'heteroAgent.executionTarget.noDevices':

--- a/src/components/DragUploadZone/index.tsx
+++ b/src/components/DragUploadZone/index.tsx
@@ -13,6 +13,7 @@ import { type DroppedLocalPath, useLocalDragUpload } from './useLocalDragUpload'
 const BLOCK_SIZE = 48;
 const ICON_SIZE = { size: 28, strokeWidth: 1.5 };
 const OVERLAY_INSET = 28;
+const OVERLAY_BORDER_INSET = 10;
 
 const DEFAULT_TONE = {
   iconColor: `color-mix(in srgb, ${cssVar.geekblue} 95%, black)`,
@@ -37,7 +38,7 @@ const styles = createStaticStyles(({ css }) => ({
     box-sizing: border-box;
     width: 100%;
     height: 100%;
-    padding-block: 32px 24px;
+    padding-block: 24px;
     padding-inline: 28px;
   `,
   desc: css`
@@ -49,7 +50,7 @@ const styles = createStaticStyles(({ css }) => ({
     border-radius: ${cssVar.borderRadiusSM};
   `,
   iconGroup: css`
-    margin-block-start: -32px;
+    margin-block-start: 0;
   `,
   overlay: css`
     pointer-events: none;
@@ -69,7 +70,8 @@ const styles = createStaticStyles(({ css }) => ({
   overlayContent: css`
     position: relative;
 
-    min-width: min(640px, 72vw);
+    box-sizing: border-box;
+    width: min(460px, 72vw);
     padding: ${OVERLAY_INSET}px;
     border-radius: 16px;
 
@@ -81,7 +83,7 @@ const styles = createStaticStyles(({ css }) => ({
       content: '';
 
       position: absolute;
-      inset: ${OVERLAY_INSET}px;
+      inset: ${OVERLAY_BORDER_INSET}px;
 
       border: 1.5px dashed #fff;
       border-radius: ${cssVar.borderRadiusLG};

--- a/src/components/DragUploadZone/index.tsx
+++ b/src/components/DragUploadZone/index.tsx
@@ -10,10 +10,13 @@ import { useTranslation } from 'react-i18next';
 import { useDragUploadContext } from './DragUploadProvider';
 import { type DroppedLocalPath, useLocalDragUpload } from './useLocalDragUpload';
 
-const BLOCK_SIZE = 28;
-const ICON_SIZE = { size: 18, strokeWidth: 1.5 };
-const OVERLAY_INSET = 12;
-const OVERLAY_BORDER_INSET = 6;
+const BLOCK_SIZE = 36;
+const ICON_SIZE = { size: 22, strokeWidth: 1.5 };
+const OVERLAY_INSET = 20;
+const OVERLAY_BORDER_INSET = 8;
+// The card keeps its natural (well-proportioned) size and is scaled down as a
+// whole — text included — so a short composer never gets a stretched card.
+const OVERLAY_SCALE = 0.7;
 
 const DEFAULT_TONE = {
   iconColor: `color-mix(in srgb, ${cssVar.geekblue} 95%, black)`,
@@ -38,8 +41,8 @@ const styles = createStaticStyles(({ css }) => ({
     box-sizing: border-box;
     width: 100%;
     height: 100%;
-    padding-block: 6px;
-    padding-inline: 16px;
+    padding-block: 16px;
+    padding-inline: 20px;
   `,
   desc: css`
     font-size: 12px;
@@ -69,14 +72,14 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   overlayContent: css`
     position: relative;
+    transform-origin: center;
+
+    /* Uniformly shrink the whole card (text included) so it keeps its
+       proportions and fits inside a short composer instead of overflowing it. */
+    transform: scale(${OVERLAY_SCALE});
 
     box-sizing: border-box;
-    width: min(520px, 92%);
-    max-width: 100%;
-
-    /* Never taller than the drop container (e.g. a short composer), so the card
-       sits inside the input instead of spilling above/below it. */
-    max-height: 100%;
+    width: min(360px, 84%);
     padding: ${OVERLAY_INSET}px;
     border-radius: 16px;
 
@@ -99,7 +102,7 @@ const styles = createStaticStyles(({ css }) => ({
     box-shadow: 0 16px 48px color-mix(in srgb, ${cssVar.purple} 32%, transparent);
   `,
   title: css`
-    font-size: 14px;
+    font-size: 16px;
     font-weight: bold;
     color: #fff;
   `,

--- a/src/components/DragUploadZone/index.tsx
+++ b/src/components/DragUploadZone/index.tsx
@@ -10,10 +10,10 @@ import { useTranslation } from 'react-i18next';
 import { useDragUploadContext } from './DragUploadProvider';
 import { type DroppedLocalPath, useLocalDragUpload } from './useLocalDragUpload';
 
-const BLOCK_SIZE = 48;
-const ICON_SIZE = { size: 28, strokeWidth: 1.5 };
-const OVERLAY_INSET = 28;
-const OVERLAY_BORDER_INSET = 10;
+const BLOCK_SIZE = 36;
+const ICON_SIZE = { size: 22, strokeWidth: 1.5 };
+const OVERLAY_INSET = 20;
+const OVERLAY_BORDER_INSET = 8;
 
 const DEFAULT_TONE = {
   iconColor: `color-mix(in srgb, ${cssVar.geekblue} 95%, black)`,
@@ -38,8 +38,8 @@ const styles = createStaticStyles(({ css }) => ({
     box-sizing: border-box;
     width: 100%;
     height: 100%;
-    padding-block: 24px;
-    padding-inline: 28px;
+    padding-block: 16px;
+    padding-inline: 20px;
   `,
   desc: css`
     font-size: 12px;
@@ -70,7 +70,7 @@ const styles = createStaticStyles(({ css }) => ({
   overlayContent: css`
     position: relative;
 
-    min-width: min(640px, 72vw);
+    width: min(340px, 56vw);
     padding: ${OVERLAY_INSET}px;
     border-radius: 16px;
 
@@ -93,7 +93,7 @@ const styles = createStaticStyles(({ css }) => ({
     box-shadow: 0 16px 48px color-mix(in srgb, ${cssVar.purple} 32%, transparent);
   `,
   title: css`
-    font-size: 16px;
+    font-size: 14px;
     font-weight: bold;
     color: #fff;
   `,
@@ -150,7 +150,7 @@ const DragUploadZone = memo<DragUploadZoneProps>(
     enabledFiles = true,
     enableLocalPathReference = false,
     onLocalPaths,
-    overlayMinHeight = 160,
+    overlayMinHeight = 120,
     onUploadFiles,
     style,
   }) => {

--- a/src/components/DragUploadZone/index.tsx
+++ b/src/components/DragUploadZone/index.tsx
@@ -10,13 +10,9 @@ import { useTranslation } from 'react-i18next';
 import { useDragUploadContext } from './DragUploadProvider';
 import { type DroppedLocalPath, useLocalDragUpload } from './useLocalDragUpload';
 
-const BLOCK_SIZE = 36;
-const ICON_SIZE = { size: 22, strokeWidth: 1.5 };
-const OVERLAY_INSET = 20;
-const OVERLAY_BORDER_INSET = 8;
-// The card keeps its natural (well-proportioned) size and is scaled down as a
-// whole — text included — so a short composer never gets a stretched card.
-const OVERLAY_SCALE = 0.65;
+const BLOCK_SIZE = 48;
+const ICON_SIZE = { size: 28, strokeWidth: 1.5 };
+const OVERLAY_INSET = 28;
 
 const DEFAULT_TONE = {
   iconColor: `color-mix(in srgb, ${cssVar.geekblue} 95%, black)`,
@@ -41,8 +37,8 @@ const styles = createStaticStyles(({ css }) => ({
     box-sizing: border-box;
     width: 100%;
     height: 100%;
-    padding-block: 16px;
-    padding-inline: 20px;
+    padding-block: 32px 24px;
+    padding-inline: 28px;
   `,
   desc: css`
     font-size: 12px;
@@ -53,7 +49,7 @@ const styles = createStaticStyles(({ css }) => ({
     border-radius: ${cssVar.borderRadiusSM};
   `,
   iconGroup: css`
-    margin-block-start: 0;
+    margin-block-start: -32px;
   `,
   overlay: css`
     pointer-events: none;
@@ -72,14 +68,8 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   overlayContent: css`
     position: relative;
-    transform-origin: center;
 
-    /* Uniformly shrink the whole card (text included) so it keeps its
-       proportions and fits inside a short composer instead of overflowing it. */
-    transform: scale(${OVERLAY_SCALE});
-
-    box-sizing: border-box;
-    width: min(360px, 84%);
+    min-width: min(640px, 72vw);
     padding: ${OVERLAY_INSET}px;
     border-radius: 16px;
 
@@ -91,7 +81,7 @@ const styles = createStaticStyles(({ css }) => ({
       content: '';
 
       position: absolute;
-      inset: ${OVERLAY_BORDER_INSET}px;
+      inset: ${OVERLAY_INSET}px;
 
       border: 1.5px dashed #fff;
       border-radius: ${cssVar.borderRadiusLG};
@@ -159,7 +149,7 @@ const DragUploadZone = memo<DragUploadZoneProps>(
     enabledFiles = true,
     enableLocalPathReference = false,
     onLocalPaths,
-    overlayMinHeight = 88,
+    overlayMinHeight = 160,
     onUploadFiles,
     style,
   }) => {

--- a/src/components/DragUploadZone/index.tsx
+++ b/src/components/DragUploadZone/index.tsx
@@ -16,7 +16,7 @@ const OVERLAY_INSET = 20;
 const OVERLAY_BORDER_INSET = 8;
 // The card keeps its natural (well-proportioned) size and is scaled down as a
 // whole — text included — so a short composer never gets a stretched card.
-const OVERLAY_SCALE = 0.7;
+const OVERLAY_SCALE = 0.65;
 
 const DEFAULT_TONE = {
   iconColor: `color-mix(in srgb, ${cssVar.geekblue} 95%, black)`,

--- a/src/components/DragUploadZone/index.tsx
+++ b/src/components/DragUploadZone/index.tsx
@@ -38,7 +38,7 @@ const styles = createStaticStyles(({ css }) => ({
     box-sizing: border-box;
     width: 100%;
     height: 100%;
-    padding-block: 32px 24px;
+    padding-block: 24px;
     padding-inline: 28px;
   `,
   desc: css`
@@ -50,7 +50,7 @@ const styles = createStaticStyles(({ css }) => ({
     border-radius: ${cssVar.borderRadiusSM};
   `,
   iconGroup: css`
-    margin-block-start: -32px;
+    margin-block-start: 0;
   `,
   overlay: css`
     pointer-events: none;

--- a/src/components/DragUploadZone/index.tsx
+++ b/src/components/DragUploadZone/index.tsx
@@ -10,10 +10,10 @@ import { useTranslation } from 'react-i18next';
 import { useDragUploadContext } from './DragUploadProvider';
 import { type DroppedLocalPath, useLocalDragUpload } from './useLocalDragUpload';
 
-const BLOCK_SIZE = 36;
-const ICON_SIZE = { size: 22, strokeWidth: 1.5 };
-const OVERLAY_INSET = 20;
-const OVERLAY_BORDER_INSET = 8;
+const BLOCK_SIZE = 28;
+const ICON_SIZE = { size: 18, strokeWidth: 1.5 };
+const OVERLAY_INSET = 12;
+const OVERLAY_BORDER_INSET = 6;
 
 const DEFAULT_TONE = {
   iconColor: `color-mix(in srgb, ${cssVar.geekblue} 95%, black)`,
@@ -38,8 +38,8 @@ const styles = createStaticStyles(({ css }) => ({
     box-sizing: border-box;
     width: 100%;
     height: 100%;
-    padding-block: 16px;
-    padding-inline: 20px;
+    padding-block: 6px;
+    padding-inline: 16px;
   `,
   desc: css`
     font-size: 12px;
@@ -70,7 +70,13 @@ const styles = createStaticStyles(({ css }) => ({
   overlayContent: css`
     position: relative;
 
-    width: min(340px, 56vw);
+    box-sizing: border-box;
+    width: min(520px, 92%);
+    max-width: 100%;
+
+    /* Never taller than the drop container (e.g. a short composer), so the card
+       sits inside the input instead of spilling above/below it. */
+    max-height: 100%;
     padding: ${OVERLAY_INSET}px;
     border-radius: 16px;
 
@@ -150,7 +156,7 @@ const DragUploadZone = memo<DragUploadZoneProps>(
     enabledFiles = true,
     enableLocalPathReference = false,
     onLocalPaths,
-    overlayMinHeight = 120,
+    overlayMinHeight = 88,
     onUploadFiles,
     style,
   }) => {

--- a/src/components/DragUploadZone/index.tsx
+++ b/src/components/DragUploadZone/index.tsx
@@ -13,6 +13,7 @@ import { type DroppedLocalPath, useLocalDragUpload } from './useLocalDragUpload'
 const BLOCK_SIZE = 48;
 const ICON_SIZE = { size: 28, strokeWidth: 1.5 };
 const OVERLAY_INSET = 28;
+const OVERLAY_BORDER_INSET = 10;
 
 const DEFAULT_TONE = {
   iconColor: `color-mix(in srgb, ${cssVar.geekblue} 95%, black)`,
@@ -81,7 +82,7 @@ const styles = createStaticStyles(({ css }) => ({
       content: '';
 
       position: absolute;
-      inset: ${OVERLAY_INSET}px;
+      inset: ${OVERLAY_BORDER_INSET}px;
 
       border: 1.5px dashed #fff;
       border-radius: ${cssVar.borderRadiusLG};

--- a/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
@@ -418,11 +418,8 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
     chipIcon = <Icon icon={SparklesIcon} size={14} />;
     chipLabel = t('heteroAgent.executionTarget.auto');
   } else if (executionTarget === 'local') {
-    chipIcon = currentDevice ? (
-      getDeviceIcon(currentDevice.platform)
-    ) : (
-      <Icon icon={LaptopIcon} size={14} />
-    );
+    // 本机始终使用通用的本地电脑图标，不区分具体平台
+    chipIcon = <Icon icon={LaptopIcon} size={14} />;
     chipLabel = t('heteroAgent.executionTarget.local');
   } else if (executionTarget === 'device') {
     chipIcon = getDeviceIcon(boundDevice?.platform);
@@ -522,14 +519,8 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
         <OptionRow
           active={isActive('local')}
           desc={t('heteroAgent.executionTarget.localDesc')}
+          icon={<Icon icon={LaptopIcon} size={14} />}
           tag={t('heteroAgent.executionTarget.local')}
-          icon={
-            currentDevice ? (
-              getDeviceIcon(currentDevice.platform)
-            ) : (
-              <Icon icon={LaptopIcon} size={14} />
-            )
-          }
           label={
             currentDevice?.friendlyName ||
             currentDevice?.hostname ||

--- a/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
@@ -390,7 +390,6 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
 
   const boundDevice =
     executionTarget === 'device' ? devices?.find((d) => d.deviceId === boundDeviceId) : undefined;
-  const currentDevice = devices?.find((d) => d.deviceId === currentDeviceId);
   const deviceRows = devices ?? [];
   const hasNoDevices = deviceRows.length === 0;
   // On web with no device, the prominent download card below replaces the small
@@ -520,12 +519,8 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
           active={isActive('local')}
           desc={t('heteroAgent.executionTarget.localDesc')}
           icon={<Icon icon={LaptopIcon} size={14} />}
-          tag={t('heteroAgent.executionTarget.local')}
-          label={
-            currentDevice?.friendlyName ||
-            currentDevice?.hostname ||
-            t('heteroAgent.executionTarget.local')
-          }
+          // 本机统一显示「本地设备」，不再带具体设备名称
+          label={t('heteroAgent.executionTarget.local')}
           onClick={() => void handleSelect('local')}
         />
       ) : null}

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Files/__tests__/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Files/__tests__/index.test.tsx
@@ -168,7 +168,18 @@ beforeEach(() => {
   handleSpies.setExpanded.mockClear();
   messageSpy.warning.mockClear();
   openLocalFileMock.mockClear();
+  // Default to an empty result so EVERY call resolves to a promise. The search
+  // effect can fire more than once (debounce + effect re-run / StrictMode), and
+  // per-test `mockResolvedValueOnce` only covers the first call — an extra,
+  // un-mocked call would return `undefined`, and the component's
+  // `searchProjectFiles(...).then(...)` would throw "reading 'then'" (flaky in CI).
   searchProjectFilesMock.mockReset();
+  searchProjectFilesMock.mockResolvedValue({
+    entries: [],
+    root: '/repo',
+    searchedAt: '2026-01-01',
+    source: 'git',
+  });
   useGlobalStore.setState({
     ...initialState,
     status: { ...initialState.status, workingSidebarRevealRequest: undefined },
@@ -241,7 +252,7 @@ describe('Files — reveal request integration', () => {
   });
 
   it('filters file tree nodes while retaining ancestor directories', async () => {
-    searchProjectFilesMock.mockResolvedValueOnce({
+    searchProjectFilesMock.mockResolvedValue({
       entries: [
         { isDirectory: true, name: 'src', path: '/repo/src', relativePath: 'src/' },
         { isDirectory: true, name: 'foo', path: '/repo/src/foo', relativePath: 'src/foo/' },
@@ -276,7 +287,7 @@ describe('Files — reveal request integration', () => {
   });
 
   it('shows a no-results state when the file filter has no matches', async () => {
-    searchProjectFilesMock.mockResolvedValueOnce({
+    searchProjectFilesMock.mockResolvedValue({
       entries: [],
       root: '/repo',
       searchedAt: '2026-01-01',

--- a/src/routes/(main)/home/features/InputArea/InputDragUpload.tsx
+++ b/src/routes/(main)/home/features/InputArea/InputDragUpload.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { Center, Flexbox, Icon } from '@lobehub/ui';
+import { createStaticStyles, cssVar } from 'antd-style';
+import { FileImage, FileText, FileUpIcon } from 'lucide-react';
+import { type CSSProperties, memo, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useDragUploadContext } from '@/components/DragUploadZone/DragUploadProvider';
+import { useLocalDragUpload } from '@/components/DragUploadZone/useLocalDragUpload';
+
+const BLOCK_SIZE = 30;
+const ICON_SIZE = { size: 18, strokeWidth: 1.5 };
+// The dashed outline sits this far inside the overlay edge.
+const BORDER_INSET = 8;
+const OVERLAY_ICONS = [FileImage, FileUpIcon, FileText];
+
+const styles = createStaticStyles(({ css }) => ({
+  container: css`
+    position: relative;
+  `,
+  desc: css`
+    max-width: 320px;
+
+    font-size: 12px;
+    line-height: 18px;
+    color: ${cssVar.colorTextSecondary};
+    text-align: center;
+  `,
+  icon: css`
+    border-radius: ${cssVar.borderRadiusSM};
+  `,
+  overlay: css`
+    pointer-events: none;
+
+    position: absolute;
+    z-index: 100;
+    inset: 0;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    /* A gray translucent "filled" layer laid over the input — it fills the exact
+       input box, so its width/height always match. A dashed outline sits inside
+       the edge to signal the drop target. */
+    background: color-mix(in srgb, ${cssVar.colorBgElevated} 74%, transparent);
+
+    &::before {
+      pointer-events: none;
+      content: '';
+
+      position: absolute;
+      inset: ${BORDER_INSET}px;
+
+      border: 1.5px dashed ${cssVar.colorTextTertiary};
+      border-radius: 12px;
+    }
+  `,
+  title: css`
+    font-size: 14px;
+    font-weight: bold;
+    color: ${cssVar.colorText};
+  `,
+}));
+
+interface InputDragUploadProps {
+  children: ReactNode;
+  onUploadFiles: (files: File[]) => void | Promise<void>;
+  /** Corner radius to match the wrapped input (default matches the composer). */
+  radius?: number;
+  style?: CSSProperties;
+}
+
+/**
+ * Home composer drag-upload overlay. Unlike the shared `DragUploadZone` (a
+ * floating card centered in whatever area it wraps), this overlay fills the
+ * input's exact bounds with a gray translucent `filled` layer + dashed outline,
+ * so it reads as the input itself lighting up as a drop target.
+ */
+const InputDragUpload = memo<InputDragUploadProps>(
+  ({ children, onUploadFiles, radius = 20, style }) => {
+    const { t } = useTranslation('components');
+    const { isDraggingGlobally } = useDragUploadContext();
+    const { getContainerProps } = useLocalDragUpload({ onUploadFiles });
+
+    return (
+      <div className={styles.container} style={style} {...getContainerProps()}>
+        {children}
+        {isDraggingGlobally && (
+          <div className={styles.overlay} style={{ borderRadius: radius }}>
+            <Center gap={8}>
+              <Flexbox horizontal>
+                <Center
+                  className={styles.icon}
+                  height={BLOCK_SIZE * 1.2}
+                  width={BLOCK_SIZE}
+                  style={{
+                    background: cssVar.colorFillSecondary,
+                    color: cssVar.colorTextSecondary,
+                    transform: 'rotateZ(-20deg) translateX(8px)',
+                  }}
+                >
+                  <Icon icon={OVERLAY_ICONS[0]} size={ICON_SIZE} />
+                </Center>
+                <Center
+                  className={styles.icon}
+                  height={BLOCK_SIZE * 1.2}
+                  width={BLOCK_SIZE}
+                  style={{
+                    background: cssVar.colorFill,
+                    color: cssVar.colorText,
+                    transform: 'translateY(-8px)',
+                    zIndex: 1,
+                  }}
+                >
+                  <Icon icon={OVERLAY_ICONS[1]} size={ICON_SIZE} />
+                </Center>
+                <Center
+                  className={styles.icon}
+                  height={BLOCK_SIZE * 1.2}
+                  width={BLOCK_SIZE}
+                  style={{
+                    background: cssVar.colorFillSecondary,
+                    color: cssVar.colorTextSecondary,
+                    transform: 'rotateZ(20deg) translateX(-8px)',
+                  }}
+                >
+                  <Icon icon={OVERLAY_ICONS[2]} size={ICON_SIZE} />
+                </Center>
+              </Flexbox>
+              <Flexbox align={'center'} gap={4}>
+                <div className={styles.title}>{t('DragUpload.dragFileTitle')}</div>
+                <div className={styles.desc}>{t('DragUpload.dragFileDesc')}</div>
+              </Flexbox>
+            </Center>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+InputDragUpload.displayName = 'InputDragUpload';
+
+export default InputDragUpload;

--- a/src/routes/(main)/home/features/InputArea/InputDragUpload.tsx
+++ b/src/routes/(main)/home/features/InputArea/InputDragUpload.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from 'react-i18next';
 import { useDragUploadContext } from '@/components/DragUploadZone/DragUploadProvider';
 import { useLocalDragUpload } from '@/components/DragUploadZone/useLocalDragUpload';
 
-const BLOCK_SIZE = 30;
+const BLOCK_SIZE = 32;
 const ICON_SIZE = { size: 18, strokeWidth: 1.5 };
 // The dashed outline sits this far inside the overlay edge.
 const BORDER_INSET = 8;
@@ -28,7 +28,12 @@ const styles = createStaticStyles(({ css }) => ({
     text-align: center;
   `,
   icon: css`
-    border-radius: ${cssVar.borderRadiusSM};
+    flex: none;
+    border-radius: ${cssVar.borderRadius};
+
+    /* Flat, solid-fill tiles laid out in a row (not a folded/fanned stack). */
+    color: ${cssVar.colorTextSecondary};
+    background: ${cssVar.colorFillSecondary};
   `,
   overlay: css`
     pointer-events: none;
@@ -41,10 +46,10 @@ const styles = createStaticStyles(({ css }) => ({
     align-items: center;
     justify-content: center;
 
-    /* A gray translucent "filled" layer laid over the input — it fills the exact
-       input box, so its width/height always match. A dashed outline sits inside
-       the edge to signal the drop target. */
-    background: color-mix(in srgb, ${cssVar.colorBgElevated} 74%, transparent);
+    /* A solid gray layer laid over the input — it fills the exact input box, so
+       its width/height always match. A thin dashed outline sits inside the edge
+       to signal the drop target. */
+    background: ${cssVar.colorBgElevated};
 
     &::before {
       pointer-events: none;
@@ -53,14 +58,9 @@ const styles = createStaticStyles(({ css }) => ({
       position: absolute;
       inset: ${BORDER_INSET}px;
 
-      border: 1.5px dashed ${cssVar.colorTextTertiary};
+      border: 1px dashed ${cssVar.colorTextTertiary};
       border-radius: 12px;
     }
-  `,
-  title: css`
-    font-size: 14px;
-    font-weight: bold;
-    color: ${cssVar.colorText};
   `,
 }));
 
@@ -89,50 +89,15 @@ const InputDragUpload = memo<InputDragUploadProps>(
         {children}
         {isDraggingGlobally && (
           <div className={styles.overlay} style={{ borderRadius: radius }}>
-            <Center gap={8}>
-              <Flexbox horizontal>
-                <Center
-                  className={styles.icon}
-                  height={BLOCK_SIZE * 1.2}
-                  width={BLOCK_SIZE}
-                  style={{
-                    background: cssVar.colorFillSecondary,
-                    color: cssVar.colorTextSecondary,
-                    transform: 'rotateZ(-20deg) translateX(8px)',
-                  }}
-                >
-                  <Icon icon={OVERLAY_ICONS[0]} size={ICON_SIZE} />
-                </Center>
-                <Center
-                  className={styles.icon}
-                  height={BLOCK_SIZE * 1.2}
-                  width={BLOCK_SIZE}
-                  style={{
-                    background: cssVar.colorFill,
-                    color: cssVar.colorText,
-                    transform: 'translateY(-8px)',
-                    zIndex: 1,
-                  }}
-                >
-                  <Icon icon={OVERLAY_ICONS[1]} size={ICON_SIZE} />
-                </Center>
-                <Center
-                  className={styles.icon}
-                  height={BLOCK_SIZE * 1.2}
-                  width={BLOCK_SIZE}
-                  style={{
-                    background: cssVar.colorFillSecondary,
-                    color: cssVar.colorTextSecondary,
-                    transform: 'rotateZ(20deg) translateX(-8px)',
-                  }}
-                >
-                  <Icon icon={OVERLAY_ICONS[2]} size={ICON_SIZE} />
-                </Center>
+            <Center gap={10}>
+              <Flexbox horizontal gap={8}>
+                {OVERLAY_ICONS.map((IconComp, i) => (
+                  <Center className={styles.icon} height={BLOCK_SIZE} key={i} width={BLOCK_SIZE}>
+                    <Icon icon={IconComp} size={ICON_SIZE} />
+                  </Center>
+                ))}
               </Flexbox>
-              <Flexbox align={'center'} gap={4}>
-                <div className={styles.title}>{t('DragUpload.dragFileTitle')}</div>
-                <div className={styles.desc}>{t('DragUpload.dragFileDesc')}</div>
-              </Flexbox>
+              <div className={styles.desc}>{t('DragUpload.dragFileDesc')}</div>
             </Center>
           </div>
         )}

--- a/src/routes/(main)/home/features/InputArea/index.tsx
+++ b/src/routes/(main)/home/features/InputArea/index.tsx
@@ -1,7 +1,7 @@
 import { Flexbox } from '@lobehub/ui';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-import DragUploadZone, { useUploadFiles } from '@/components/DragUploadZone';
+import { useUploadFiles } from '@/components/DragUploadZone';
 import { type ActionKeys } from '@/features/ChatInput';
 import { ChatInputProvider, DesktopChatInput } from '@/features/ChatInput';
 import { useHomeDailyBrief } from '@/hooks/useHomeDailyBrief';
@@ -16,6 +16,7 @@ import { serverConfigSelectors, useServerConfigStore } from '@/store/serverConfi
 
 import BotIntegrationBanner, { BOT_INTEGRATION_BANNER_ID } from './BotIntegrationBanner';
 import { stripMarkdownLinks } from './hintFormat';
+import InputDragUpload from './InputDragUpload';
 import MessengerBanner, { MESSENGER_BANNER_ID } from './MessengerBanner';
 import SkillInstallBanner, { SKILL_INSTALL_BANNER_ID } from './SkillInstallBanner';
 import StarterList from './StarterList';
@@ -131,7 +132,8 @@ const InputArea = () => {
         {visibleBanner === 'skill' && <SkillInstallBanner />}
         {visibleBanner === 'botIntegration' && <BotIntegrationBanner />}
         {visibleBanner === 'messenger' && <MessengerBanner />}
-        <DragUploadZone
+        <InputDragUpload
+          radius={20}
           style={{ position: 'relative', zIndex: 1 }}
           onUploadFiles={handleUploadFiles}
         >
@@ -164,7 +166,7 @@ const InputArea = () => {
               showControlBar={false}
             />
           </ChatInputProvider>
-        </DragUploadZone>
+        </InputDragUpload>
       </Flexbox>
 
       <StarterList />


### PR DESCRIPTION
### 💡 Description of Change

Two small chat UI polish tweaks:

1. **Drag overlay border** (`src/components/DragUploadZone/index.tsx`) — the dashed overlay border now sits at a `10px` inset (was `28px`), so it hugs the card edge instead of leaving an oversized gap. Inner padding for the icon/text is unchanged (`OVERLAY_INSET` still `28px`).
2. **Local device icon** (`src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx`) — the `local` execution target (bottom chip + the "本机 / Local" row in the popover) now always renders the generic `LaptopIcon` rather than switching between Apple / Linux / Windows platform icons. Other device rows (including the gateway) keep their per-platform icons.

### 🔗 Change Type

- 💄 style

### ✅ How to Test

- Drag a file over the chat input → the dashed drop overlay border hugs the card edge (~10px inset).
- Open the execution-target switcher → the "Local / 本机" row and the bottom chip show a generic laptop icon regardless of the host OS; other devices still show their platform icon.