### PR TITLE
✨ feat: use floating panel for task topic chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -295,7 +295,7 @@
     "@lobehub/icons": "^5.10.0",
     "@lobehub/market-sdk": "0.39.1",
     "@lobehub/tts": "^5.1.2",
-    "@lobehub/ui": "^5.18.0",
+    "@lobehub/ui": "^5.19.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/canvas": "^0.1.100",
     "@neondatabase/serverless": "^1.1.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,9 @@ packages:
   - apps/desktop/src/main
   - apps/server
 
+minimumReleaseAgeExclude:
+  - '@lobehub/ui@5.19.0'
+
 onlyBuiltDependencies:
   - '@google/genai'
   - '@lobehub/editor'

--- a/src/features/AgentTasks/AgentTaskDetail/CommentInput.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/CommentInput.tsx
@@ -67,14 +67,21 @@ const CommentInput = memo<{ taskId: string }>(({ taskId }) => {
 
   return (
     <Flexbox className={styles.commentInputCard} gap={6}>
-      <Flexbox horizontal align={'center'} gap={8}>
+      <Flexbox horizontal align={'center'} gap={8} style={{ minWidth: 0, width: '100%' }}>
         <Avatar avatar={userAvatar} size={24} style={{ flexShrink: 0 }} />
-        <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ flex: '1 1 0', minWidth: 0, overflow: 'hidden' }}>
           <EditorCanvas
             editor={editor}
             floatingToolbar={false}
             placeholder={t('taskDetail.commentPlaceholder')}
-            style={{ fontSize: 14, minHeight: 24, paddingBlock: 0 }}
+            style={{
+              fontSize: 14,
+              maxWidth: '100%',
+              minHeight: 24,
+              overflow: 'hidden',
+              paddingBlock: 0,
+              whiteSpace: 'normal',
+            }}
             onContentChange={handleContentChange}
             onPressEnter={({ event }) => {
               if (!canEditTask) return true;

--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx
@@ -81,31 +81,6 @@ vi.mock('@lobehub/ui', () => ({
     </button>
   ),
   copyToClipboard: vi.fn(),
-  Drawer: ({
-    children,
-    closeIconProps,
-    extra,
-    open,
-    styles,
-    title,
-  }: {
-    children?: ReactNode;
-    closeIconProps?: { size?: unknown };
-    extra?: ReactNode;
-    open?: boolean;
-    styles?: { title?: CSSProperties };
-    title?: ReactNode;
-  }) =>
-    open ? (
-      <div data-testid="topic-drawer">
-        <div data-testid="drawer-title-slot" style={styles?.title}>
-          {title}
-        </div>
-        {extra}
-        <button data-size={serializeSize(closeIconProps?.size)} data-testid="drawer-close-icon" />
-        {children}
-      </div>
-    ) : null,
   DropdownMenu: ({ children }: { children?: ReactNode }) => <>{children}</>,
   Flexbox: ({
     children,
@@ -122,10 +97,52 @@ vi.mock('@lobehub/ui', () => ({
   ),
 }));
 
-vi.mock('antd-style', () => ({
-  cssVar: {
-    colorBorderSecondary: '#ddd',
-  },
+vi.mock('@lobehub/ui/base-ui', () => ({
+  FloatingPanel: ({
+    actions,
+    children,
+    height,
+    minHeight,
+    minWidth,
+    open,
+    placement,
+    resizable = true,
+    styles,
+    title,
+    width,
+  }: {
+    actions?: ReactNode;
+    children?: ReactNode;
+    height?: unknown;
+    minHeight?: number;
+    minWidth?: number;
+    open?: boolean;
+    placement?: string;
+    resizable?: boolean;
+    styles?: { body?: CSSProperties; title?: CSSProperties };
+    title?: ReactNode;
+    width?: unknown;
+  }) =>
+    open ? (
+      <div
+        data-height={serializeSize(height)}
+        data-min-height={serializeSize(minHeight)}
+        data-min-width={serializeSize(minWidth)}
+        data-placement={placement}
+        data-resizable={String(resizable)}
+        data-testid="topic-panel"
+        data-width={serializeSize(width)}
+      >
+        <div data-testid="panel-title-slot" style={styles?.title}>
+          {title}
+        </div>
+        <div data-testid="panel-actions-slot">{actions}</div>
+        <button data-testid="panel-close-icon" />
+        <div data-testid="panel-body-slot" style={styles?.body}>
+          {children}
+        </div>
+      </div>
+    ) : null,
 }));
 
 vi.mock('next/dynamic', () => ({
@@ -228,30 +245,44 @@ describe('TopicChatDrawer', () => {
     expect(getByTitle('requires member')).toBeDisabled();
   });
 
-  it('constrains long drawer titles before the header actions', () => {
+  it('constrains long panel titles before the header actions', () => {
     const { getByTestId, getByText } = render(<TopicChatDrawer />);
 
     const title = getByText('Topic 1');
 
     expect(title).toHaveStyle({ flex: '0 1 auto', minWidth: '0' });
     expect(title.parentElement).toHaveStyle({ maxWidth: '100%', overflow: 'hidden' });
-    expect(getByTestId('drawer-title-slot')).toHaveStyle({
+    expect(getByTestId('panel-title-slot')).toHaveStyle({
       boxSizing: 'border-box',
       maxWidth: '100%',
       overflow: 'hidden',
-      paddingInlineEnd: '48px',
     });
   });
 
-  it('keeps the share button box aligned with the default close button', () => {
+  it('renders the share button in the floating panel actions slot', () => {
     const { getAllByTestId, getByTestId } = render(<TopicChatDrawer />);
 
     const icons = getAllByTestId('header-action-icon');
     const moreIcon = icons.find((icon) => !icon.getAttribute('title'));
     const shareIcon = icons.find((icon) => icon.getAttribute('title') === 'share');
 
-    expect(moreIcon).toHaveAttribute('data-size', 'small');
-    expect(shareIcon).toHaveAttribute('data-size', JSON.stringify({ blockSize: 36, size: 18 }));
-    expect(getByTestId('drawer-close-icon')).toHaveAttribute('data-size', '');
+    expect(moreIcon).toBeDefined();
+    expect(shareIcon).toBeDefined();
+    expect(moreIcon!).toHaveAttribute('data-size', 'small');
+    expect(shareIcon!).toHaveAttribute('data-size', JSON.stringify({ blockSize: 32, size: 16 }));
+    expect(getByTestId('panel-actions-slot')).toContainElement(shareIcon!);
+    expect(getByTestId('panel-close-icon')).toBeInTheDocument();
+  });
+
+  it('uses a resizable bottom-right floating panel', () => {
+    const { getByTestId } = render(<TopicChatDrawer />);
+
+    expect(getByTestId('topic-panel')).toHaveAttribute('data-placement', 'bottomRight');
+    expect(getByTestId('topic-panel')).toHaveAttribute('data-resizable', 'true');
+    expect(getByTestId('topic-panel')).toHaveAttribute('data-width', '640');
+    expect(getByTestId('topic-panel')).toHaveAttribute(
+      'data-height',
+      'min(640px, calc(100dvh - 16px))',
+    );
   });
 });

--- a/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx
@@ -5,14 +5,13 @@ import type { DropdownItem } from '@lobehub/ui';
 import {
   ActionIcon,
   copyToClipboard,
-  Drawer,
   DropdownMenu,
   Flexbox,
   Freeze,
   Tag,
   Text,
 } from '@lobehub/ui';
-import { cssVar } from 'antd-style';
+import { FloatingPanel } from '@lobehub/ui/base-ui';
 import { Copy, MoreHorizontal, Share2 } from 'lucide-react';
 import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -37,7 +36,7 @@ import { authSelectors } from '@/store/user/selectors';
 import TopicStatusIcon from '../TopicStatusIcon';
 import FeedbackInput from './FeedbackInput';
 
-const SHARE_ICON_SIZE = { blockSize: 36, size: 18 } as const;
+const SHARE_ICON_SIZE = { blockSize: 32, size: 16 } as const;
 
 interface TopicChatDrawerBodyProps {
   agentId: string;
@@ -205,50 +204,38 @@ const TopicChatDrawer = memo(() => {
     />
   );
 
-  const extra = topicId ? (
-    enableTopicLinkShare && canShare ? (
+  const actions =
+    !topicId ? null : enableTopicLinkShare && canShare ? (
       <SharePopover topicId={topicId} onOpenModal={openShareModal}>
         {shareIcon}
       </SharePopover>
     ) : (
       shareIcon
-    )
-  ) : null;
+    );
 
-  // Freeze title/extra/body during the close animation so the drawer keeps
+  // Freeze title/actions/body during the close animation so the panel keeps
   // its last rendered state instead of flashing to the empty/"untitled" view
   // while topicId/agentId clear.
   return (
-    <Drawer
-      destroyOnHidden
-      containerMaxWidth={'auto'}
-      extra={<Freeze frozen={!open}>{extra}</Freeze>}
+    <FloatingPanel
+      actions={<Freeze frozen={!open}>{actions}</Freeze>}
       getContainer={false}
+      height={'min(640px, calc(100dvh - 16px))'}
       mask={false}
+      minHeight={320}
+      minWidth={360}
       open={open}
-      placement={'right'}
-      push={false}
+      placement={'bottomRight'}
       title={<Freeze frozen={!open}>{title}</Freeze>}
       width={640}
       styles={{
         body: { padding: 0 },
-        bodyContent: { height: '100%' },
+        panel: { maxHeight: 'calc(100dvh - 16px)' },
         title: {
           boxSizing: 'border-box',
           maxWidth: '100%',
           minWidth: 0,
           overflow: 'hidden',
-          paddingInlineEnd: 48,
-        },
-        wrapper: {
-          border: `1px solid ${cssVar.colorBorderSecondary}`,
-          borderRadius: 12,
-          bottom: 8,
-          boxShadow: '0 6px 24px 0 rgba(0, 0, 0, 0.08), 0 2px 6px 0 rgba(0, 0, 0, 0.04)',
-          height: 'auto',
-          overflow: 'hidden',
-          right: 8,
-          top: 8,
         },
       }}
       onClose={closeTopicDrawer}
@@ -256,7 +243,7 @@ const TopicChatDrawer = memo(() => {
       <Freeze frozen={!open}>
         {open && activeTaskId && <TopicChatDrawerBody agentId={agentId!} topicId={topicId!} />}
       </Freeze>
-    </Drawer>
+    </FloatingPanel>
   );
 });
 

--- a/src/features/EditorCanvas/InternalEditor.readonly.test.tsx
+++ b/src/features/EditorCanvas/InternalEditor.readonly.test.tsx
@@ -68,6 +68,16 @@ describe('InternalEditor readonly state', () => {
     expect(editorProps.last?.editable).toBe(false);
   });
 
+  it('constrains the editor wrapper to its parent width', () => {
+    const { container } = render(<InternalEditor editor={editor} />);
+
+    expect(container.firstElementChild).toHaveStyle({
+      maxWidth: '100%',
+      overflow: 'hidden',
+      width: '100%',
+    });
+  });
+
   it('registers the floating toolbar when editable', () => {
     render(<InternalEditor editor={editor} />);
 

--- a/src/features/EditorCanvas/InternalEditor.tsx
+++ b/src/features/EditorCanvas/InternalEditor.tsx
@@ -12,7 +12,8 @@ import {
 import { Editor, useEditorState } from '@lobehub/editor/react';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
-import { memo, type RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
+import type { CSSProperties, RefObject } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { createChatInputRichPlugins } from '@/features/ChatInput/InputEditor/plugins';
@@ -130,6 +131,18 @@ const InternalEditor = memo<InternalEditorProps>(
     }, []);
 
     const finalPlaceholder = placeholder || t('pageEditor.editorPlaceholder');
+    const wrapperStyle = useMemo<CSSProperties>(
+      () => ({
+        cursor: disabled ? 'not-allowed' : undefined,
+        maxWidth: '100%',
+        minWidth: 0,
+        opacity: disabled ? 0.65 : undefined,
+        overflow: 'hidden',
+        pointerEvents: disabled ? 'none' : undefined,
+        width: '100%',
+      }),
+      [disabled],
+    );
 
     // Build plugins array
     const plugins = useMemo(() => {
@@ -290,9 +303,7 @@ const InternalEditor = memo<InternalEditorProps>(
 
     return (
       <div
-        style={
-          disabled ? { cursor: 'not-allowed', opacity: 0.65, pointerEvents: 'none' } : undefined
-        }
+        style={wrapperStyle}
         onClick={(e) => {
           e.stopPropagation();
           e.preventDefault();


### PR DESCRIPTION
## Summary

- Replace the task topic chat drawer with the new `@lobehub/ui/base-ui` `FloatingPanel` from `@lobehub/ui@5.19.0`.
- Keep the panel anchored at bottom-right, resizable, and use a non-full-height initial size.
- Constrain task comment editor placeholder layout so long placeholder text stays inside the input surface.
- Update focused tests for panel sizing/actions and editor wrapper constraints.

## Validation

- `bunx vitest run --silent='passed-only' src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx src/features/EditorCanvas/InternalEditor.test.tsx src/features/EditorCanvas/InternalEditor.readonly.test.tsx`
- `pnpm exec eslint src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.test.tsx src/features/AgentTasks/AgentTaskDetail/CommentInput.tsx src/features/EditorCanvas/InternalEditor.tsx src/features/EditorCanvas/InternalEditor.readonly.test.tsx`
- `git diff --check origin/canary...HEAD`

## Notes

- `@lobehub/ui@5.19.0` was verified as published before updating this repo.
- Local commit hooks could not complete because Prettier failed to resolve `prettier-plugin-sh`; the equivalent focused checks above were run after rebasing onto `origin/canary`.
