### PR TITLE
🐛 fix(message): avoid jsonb arrow IS NULL predicate that crashes serverless PG engine

### DIFF
--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -3189,4 +3189,81 @@ describe('MessageModel Query Tests', () => {
       expect(await messageModel.getLatestSpineMessageId({ topicId: 'nope' })).toBeUndefined();
     });
   });
+
+  // Regression for the signal-tag exclusion predicate. It used to be
+  // `metadata -> 'signal' IS NULL`, which crashes the production serverless
+  // Postgres engine when used as a WHERE qual (rt_fetch out-of-bounds, SQLSTATE
+  // XX000) and made the agent verifier fail to start. It was rewritten to
+  // `NOT COALESCE(jsonb_exists(metadata, 'signal'), false)`; these lock in the
+  // three metadata shapes the rewrite must handle. Server-DB (node-postgres)
+  // only — the client PGlite path is skipped.
+  describe.skipIf(!isServerDB)('getLatestSpineMessageId — signal predicate regression', () => {
+    it('keeps null and signal-free object metadata, excludes only signal-tagged', async () => {
+      await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
+      await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
+      await serverDB.insert(messages).values([
+        {
+          // null metadata — a spine candidate, must not be dropped by the predicate
+          id: 'null-meta',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: 'plain',
+          createdAt: new Date('2023-01-01T00:00:00'),
+        },
+        {
+          // object metadata without a `signal` key — also a spine candidate
+          id: 'obj-meta',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: 'has usage',
+          metadata: { usage: { totalTokens: 10 } } as any,
+          createdAt: new Date('2023-01-01T00:00:01'),
+        },
+        {
+          // newest, but signal-tagged — the only row the predicate must exclude
+          id: 'sig-meta',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: 'callback',
+          metadata: { signal: { type: 'monitor' } } as any,
+          createdAt: new Date('2023-01-01T00:00:02'),
+        },
+      ]);
+
+      // latest non-signal spine row is the signal-free object, not the newer
+      // signal-tagged callback
+      expect(await messageModel.getLatestSpineMessageId({ topicId: 'topic1' })).toBe('obj-meta');
+    });
+
+    it('returns the null-metadata row when it is the only spine candidate', async () => {
+      await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
+      await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
+      await serverDB.insert(messages).values([
+        {
+          id: 'null-only',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: 'plain',
+          createdAt: new Date('2023-01-01T00:00:00'),
+        },
+        {
+          id: 'sig-newer',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: 'callback',
+          metadata: { signal: { type: 'monitor' } } as any,
+          createdAt: new Date('2023-01-01T00:00:01'),
+        },
+      ]);
+
+      // guards the COALESCE: a naive `NOT jsonb_exists(metadata, 'signal')` yields
+      // NULL for null metadata and would wrongly drop this row
+      expect(await messageModel.getLatestSpineMessageId({ topicId: 'topic1' })).toBe('null-only');
+    });
+  });
 });

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -2592,7 +2592,13 @@ export class MessageModel {
           eq(messages.topicId, topicId),
           not(eq(messages.role, 'tool')),
           threadId ? eq(messages.threadId, threadId) : isNull(messages.threadId),
-          sql`${messages.metadata} -> 'signal' IS NULL`,
+          // Exclude signal-tagged assistants by key existence. The equivalent
+          // `metadata -> 'signal' IS NULL` crashes the serverless Postgres engine
+          // when used as a WHERE predicate (rt_fetch out-of-bounds, SQLSTATE
+          // XX000) — the `->` operator only survives in the SELECT/ORDER BY
+          // position, not as a filter qual. `jsonb_exists` is GIN-friendly and
+          // equivalent for real data, since the signal tag is always an object.
+          sql`NOT COALESCE(jsonb_exists(${messages.metadata}, 'signal'), false)`,
           this.ownership(),
         ),
       )


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Related to LOBE-11376

#### 🔀 Description of Change

`MessageModel.getLatestSpineMessageId` filtered out signal-tagged assistants with the predicate `metadata -> 'signal' IS NULL`. On the production serverless Postgres engine, a **jsonb arrow expression null-tested (`IS NULL`) in WHERE-qual position crashes the executor**: `rt_fetch used out-of-bounds`, SQLSTATE `XX000` (`pg_sys.rs:23`). The `->` operator only survives in the SELECT/ORDER BY position; a plain `=` comparison is also fine — it's specifically `<arrow> IS NULL` as a filter qual that dies.

This method seeds the **agent verifier's** context and also computes the **server-authoritative `parentId`** in `sendMessageInServer`, so the crash made task-delivery verification **fail to start** — surfaced to users as a false `Delivery did not pass verification` (and, worse, kicked off auto-repair loops re-doing already-correct deliveries).

**Fix:** filter by key existence instead — `NOT COALESCE(jsonb_exists(metadata, 'signal'), false)`. GIN-friendly, crash-free, and semantically equivalent for real data (the signal tag is always an object, never a JSON null). `NULL` metadata rows are still correctly kept.

Cross-table repro confirmed the crash is a general engine bug (`messages.metadata`, `topics.metadata`, `agents.chat_config` all crash on `<arrow> IS NULL`). The `nightlyReview.ts` / `reviewContext.ts` queries use `COALESCE((...)::boolean, false) = true` (comparison, not `IS NULL`) and are unaffected.

> Follow-up (tracked in LOBE-11376 Part 2): the verify runner currently collapses "verifier failed to start (infra)" into the same `failed` status as a genuine criteria failure. That distinction should be added separately.

#### 🧪 How to Test

- [x] Tested locally

Reproduced the crash and verified the fix against the live cloud DB via `dc query`: `<arrow> IS NULL` in WHERE deterministically returns `XX000`; the `jsonb_exists` form runs clean and selects the identical row set (27/27 rows match the original semantics, incl. NULL-metadata rows).

- [ ] Added/updated tests
- [x] No tests needed