### PR TITLE
✨ feat(review): add Codex-style two-pane diff + file-tree layout to the review panel

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -1320,6 +1320,8 @@
   "workingPanel.review.textDiff.enable": "Enable inline text diff",
   "workingPanel.review.title": "Review",
   "workingPanel.review.tooLarge": "File is too large to diff inline",
+  "workingPanel.review.tree.hide": "Hide file tree",
+  "workingPanel.review.tree.show": "Show file tree",
   "workingPanel.review.unstaged": "Unstaged",
   "workingPanel.review.viewMode.split": "Switch to split view",
   "workingPanel.review.viewMode.unified": "Switch to unified view",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -1320,6 +1320,8 @@
   "workingPanel.review.textDiff.enable": "启用文字差异",
   "workingPanel.review.title": "审查",
   "workingPanel.review.tooLarge": "文件过大，未在面板内展示 diff",
+  "workingPanel.review.tree.hide": "隐藏文件树",
+  "workingPanel.review.tree.show": "显示文件树",
   "workingPanel.review.unstaged": "未暂存",
   "workingPanel.review.viewMode.split": "切换到双栏对比",
   "workingPanel.review.viewMode.unified": "切换到合并视图",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -1428,6 +1428,8 @@ export default {
   'workingPanel.review.textDiff.enable': 'Enable inline text diff',
   'workingPanel.review.title': 'Review',
   'workingPanel.review.tooLarge': 'File is too large to diff inline',
+  'workingPanel.review.tree.hide': 'Hide file tree',
+  'workingPanel.review.tree.show': 'Show file tree',
   'workingPanel.review.unstaged': 'Unstaged',
   'workingPanel.review.viewMode.split': 'Switch to split view',
   'workingPanel.review.viewMode.unified': 'Switch to unified view',

--- a/src/features/RightPanel/index.tsx
+++ b/src/features/RightPanel/index.tsx
@@ -25,6 +25,12 @@ interface RightPanelProps extends Omit<
   expand?: boolean;
   onExpandChange?: (expand: boolean) => void;
   onSizeChange?: (size?: Size) => void;
+  /**
+   * Controlled width. When provided, the parent owns the width (and should keep
+   * it in sync via `onSizeChange` on drag). Omit for the default self-managed
+   * behaviour seeded by `defaultWidth`.
+   */
+  width?: number | string;
 }
 
 const RightPanel = memo<RightPanelProps>(
@@ -36,6 +42,7 @@ const RightPanel = memo<RightPanelProps>(
     expand: expandProp,
     onExpandChange,
     onSizeChange,
+    width: widthProp,
     ...rest
   }) => {
     const [globalExpand, globalToggle] = useGlobalStore((s) => [
@@ -46,7 +53,8 @@ const RightPanel = memo<RightPanelProps>(
     const expand = expandProp ?? globalExpand;
     const handleExpandChange = onExpandChange ?? ((next: boolean) => globalToggle(next));
 
-    const [width, setWidth] = useState<string | number>(defaultWidth);
+    const [internalWidth, setInternalWidth] = useState<string | number>(defaultWidth);
+    const width = widthProp ?? internalWidth;
 
     return (
       <DraggablePanel
@@ -63,7 +71,7 @@ const RightPanel = memo<RightPanelProps>(
         onExpandChange={handleExpandChange}
         onSizeChange={(_, size) => {
           if (size?.width) {
-            setWidth(size.width);
+            setInternalWidth(size.width);
           }
           if (size) onSizeChange?.(size);
         }}

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/FileItem.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/FileItem.tsx
@@ -116,6 +116,10 @@ interface FileItemHeaderProps {
   additions: number;
   deletions: number;
   filePath: string;
+  /** Hide the leading directory portion — used in tree layout where the
+   * containing folders are already shown by the tree, so the row only needs
+   * the bare filename. */
+  hideDir?: boolean;
   /** Called after a successful revert so the parent can refresh the patch list. */
   onReverted?: () => void;
   /** When provided, enables the per-file revert button (unstaged mode only). */
@@ -126,7 +130,7 @@ interface FileItemHeaderProps {
 }
 
 export const FileItemHeader = memo<FileItemHeaderProps>(
-  ({ filePath, additions, deletions, revertContext, onReverted }) => {
+  ({ filePath, additions, deletions, hideDir, revertContext, onReverted }) => {
     const { t } = useTranslation('chat');
     const revealInFilesTab = useGlobalStore((s) => s.revealInFilesTab);
 
@@ -195,7 +199,7 @@ export const FileItemHeader = memo<FileItemHeaderProps>(
     return (
       <div className={styles.header}>
         <span className={styles.pathWrapper} title={filePath}>
-          {dir && (
+          {!hideDir && dir && (
             // bdi keeps the dir's visual order LTR while the span is
             // direction: rtl for head-side truncation of leading segments.
             <span className={styles.dir}>

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/FileRow.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/FileRow.tsx
@@ -56,10 +56,17 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 }));
 
 interface FileRowProps {
+  /** Scroll anchor — the tree-nav rail scrolls to `[data-file-key]` on select. */
+  dataFileKey?: string;
   /** Target device the repo lives on — undefined for local desktop. */
   deviceId?: string;
   entry: GitWorkingTreePatch;
   expanded: boolean;
+  /** Hide the leading directory portion (tree layout shows folders already). */
+  hideDir?: boolean;
+  /** Extra inline-start padding (px) for nested tree rows. Applied to the
+   * clickable header row only — the expanded diff stays full-width. */
+  indent?: number;
   mode: ReviewMode;
   onReverted: () => void;
   onToggle: () => void;
@@ -74,9 +81,12 @@ interface FileRowProps {
 
 const FileRow = memo<FileRowProps>(
   ({
+    dataFileKey,
     deviceId,
     entry,
     expanded,
+    hideDir,
+    indent,
     mode,
     onReverted,
     onToggle,
@@ -95,12 +105,13 @@ const FileRow = memo<FileRowProps>(
       [onToggle],
     );
     return (
-      <div className={styles.item}>
+      <div className={styles.item} data-file-key={dataFileKey}>
         <div
           data-review-row
           aria-expanded={expanded}
           className={styles.row}
           role={'button'}
+          style={indent ? { paddingInlineStart: 10 + indent } : undefined}
           tabIndex={0}
           onClick={onToggle}
           onKeyDown={onKeyDown}
@@ -114,6 +125,7 @@ const FileRow = memo<FileRowProps>(
             additions={entry.additions}
             deletions={entry.deletions}
             filePath={entry.filePath}
+            hideDir={hideDir}
             status={entry.status}
             revertContext={
               mode === 'unstaged' ? { deviceId, workingDirectory: repoAbsolutePath } : undefined

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/FileTreeNav.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/FileTreeNav.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { createStaticStyles } from 'antd-style';
+import { memo, useMemo } from 'react';
+
+import {
+  ExplorerTree,
+  FOLDER_ICON_CSS,
+  getExplorerTreeStyleVars,
+  HIDE_POINTER_FOCUS_RING_CSS,
+} from '@/features/ExplorerTree';
+
+import { buildReviewTreeNodes, type ReviewTreeData, type ReviewTreeGroup } from './reviewTreeNodes';
+
+const FILE_TREE_UNSAFE_CSS = `${FOLDER_ICON_CSS}\n${HIDE_POINTER_FOCUS_RING_CSS}`;
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  tree: css`
+    --trees-bg-override: transparent;
+    --trees-border-color-override: transparent;
+    --trees-selected-bg-override: ${cssVar.colorFillSecondary};
+    --trees-selected-fg-override: ${cssVar.colorText};
+    --trees-bg-muted-override: ${cssVar.colorFillTertiary};
+    --trees-fg-override: ${cssVar.colorTextSecondary};
+    --trees-fg-muted-override: ${cssVar.colorTextSecondary};
+    --trees-accent-override: ${cssVar.colorPrimary};
+    --trees-padding-inline-override: 0px;
+    --trees-font-size-override: 12px;
+    --trees-border-radius-override: 6px;
+
+    flex: 1;
+    min-height: 0;
+  `,
+}));
+
+interface FileTreeNavProps {
+  /** itemKey of the file whose diff is currently focused — highlighted in the tree. */
+  activeFileKey?: string;
+  groups: ReviewTreeGroup[];
+  /** Fired when a file leaf is clicked — the diff list scrolls to & expands it. */
+  onSelectFile: (key: string) => void;
+  showGroupHeaders: boolean;
+}
+
+/**
+ * Navigation-only directory tree for the Review panel's right rail. Reuses the
+ * Files-tab `ExplorerTree` so folder / file-type icons match exactly; clicking a
+ * leaf scrolls the left diff list to that file's patch (no diff embedded here).
+ */
+const FileTreeNav = memo<FileTreeNavProps>(
+  ({ activeFileKey, groups, onSelectFile, showGroupHeaders }) => {
+    const nodes = useMemo(
+      () => buildReviewTreeNodes(groups, showGroupHeaders),
+      [groups, showGroupHeaders],
+    );
+    // Folders start expanded so the full outline shows whenever the rail opens.
+    const defaultExpandedIds = useMemo(
+      () => nodes.filter((node) => node.isFolder).map((node) => node.id),
+      [nodes],
+    );
+    const selectedIds = useMemo(
+      () =>
+        activeFileKey ? nodes.filter((n) => n.data?.key === activeFileKey).map((n) => n.id) : [],
+      [nodes, activeFileKey],
+    );
+    const treeStyleVars = useMemo(
+      () => getExplorerTreeStyleVars({ reserveChevronSlot: nodes.some((node) => node.isFolder) }),
+      [nodes],
+    );
+
+    return (
+      <div className={styles.tree} style={treeStyleVars}>
+        <ExplorerTree<ReviewTreeData>
+          iconsColored
+          defaultExpandedIds={defaultExpandedIds}
+          iconSet="complete"
+          nodes={nodes}
+          selectedIds={selectedIds}
+          style={{ height: '100%' }}
+          unsafeCSS={FILE_TREE_UNSAFE_CSS}
+          onNodeClick={(node) => {
+            if (node.isFolder || !node.data) return;
+            onSelectFile(node.data.key);
+          }}
+        />
+      </div>
+    );
+  },
+);
+
+FileTreeNav.displayName = 'AgentWorkingSidebarReviewFileTreeNav';
+
+export default FileTreeNav;

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/__tests__/reviewTreeNodes.test.ts
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/__tests__/reviewTreeNodes.test.ts
@@ -1,0 +1,57 @@
+import type { GitWorkingTreePatch } from '@lobechat/electron-client-ipc';
+import { describe, expect, it } from 'vitest';
+
+import { buildReviewTreeNodes, itemKey } from '../reviewTreeNodes';
+
+const makePatch = (filePath: string): GitWorkingTreePatch => ({
+  additions: 1,
+  deletions: 0,
+  filePath,
+  isBinary: false,
+  patch: '',
+  status: 'modified',
+  truncated: false,
+});
+
+const group = (absolutePath: string, name: string, paths: string[]) => ({
+  absolutePath,
+  name,
+  patches: paths.map(makePatch),
+});
+
+describe('buildReviewTreeNodes', () => {
+  it('materialises each directory in the chain once and parents files/dirs correctly', () => {
+    const nodes = buildReviewTreeNodes([group('/repo', 'repo', ['src/a/b.ts', 'src/c.ts'])], false);
+
+    const byId = new Map(nodes.map((n) => [n.id, n]));
+    // `src` and `src/a` directories exist exactly once each.
+    expect(nodes.filter((n) => n.isFolder && n.name === 'src')).toHaveLength(1);
+    expect(nodes.filter((n) => n.isFolder && n.name === 'a')).toHaveLength(1);
+    // File nodes carry the diff key and hang off their immediate directory.
+    const leaf = nodes.find((n) => n.name === 'b.ts');
+    expect(leaf?.isFolder).toBe(false);
+    expect(leaf?.data?.key).toBe(itemKey('/repo', makePatch('src/a/b.ts')));
+    expect(byId.get(leaf!.parentId as string)?.name).toBe('a');
+    // Top-level file has a null parent when there are no group headers.
+    expect(nodes.find((n) => n.name === 'c.ts')?.parentId).toBe(byId.get('/repo\u0000src/')?.id);
+  });
+
+  it('adds a group-root folder per repo when group headers are shown', () => {
+    const nodes = buildReviewTreeNodes(
+      [group('/repo', 'repo', ['a.ts']), group('/repo/sub', 'sub', ['x.ts'])],
+      true,
+    );
+
+    const roots = nodes.filter((n) => n.isFolder && n.parentId === null);
+    expect(roots.map((n) => n.name).sort()).toEqual(['repo', 'sub']);
+    // The file in the parent repo hangs off that repo's root node.
+    const aNode = nodes.find((n) => n.name === 'a.ts');
+    const repoRoot = roots.find((n) => n.name === 'repo');
+    expect(aNode?.parentId).toBe(repoRoot?.id);
+  });
+
+  it('skips empty groups', () => {
+    const nodes = buildReviewTreeNodes([group('/repo', 'repo', [])], true);
+    expect(nodes).toHaveLength(0);
+  });
+});

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/index.tsx
@@ -10,6 +10,8 @@ import {
   FoldVerticalIcon,
   GitCompareIcon,
   MoreHorizontalIcon,
+  PanelRightCloseIcon,
+  PanelRightOpenIcon,
   RefreshCwIcon,
   RotateCcwIcon,
   Rows2Icon,
@@ -18,7 +20,7 @@ import {
   WrapTextIcon,
 } from 'lucide-react';
 import path from 'path-browserify-esm';
-import { Fragment, memo, useMemo, useState } from 'react';
+import { Fragment, memo, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import NeuralNetworkLoading from '@/components/NeuralNetworkLoading';
@@ -26,7 +28,9 @@ import { useLocalStorageState } from '@/hooks/useLocalStorageState';
 import { useFetchGitBranch } from '@/store/device';
 
 import FileRow from './FileRow';
+import FileTreeNav from './FileTreeNav';
 import GroupHeader from './GroupHeader';
+import { itemKey } from './reviewTreeNodes';
 import { type ReviewMode, useGitRemoteBranches, useReviewPatches } from './useReviewPatches';
 
 interface RepoGroup {
@@ -50,6 +54,10 @@ interface ReviewProps {
    * set for a remote / web-bound device so git ops route through the device RPCs.
    */
   deviceId?: string;
+  /** Toggle the tree-nav rail. Owned by the sidebar so it can widen the panel. */
+  onToggleTree: () => void;
+  /** Whether the right-hand tree-nav rail is shown (two-pane). */
+  showTree: boolean;
   workingDirectory: string;
 }
 
@@ -57,9 +65,6 @@ interface ReviewProps {
 // either way keeps Shiki tokenization under ~250ms on first paint.
 const DEFAULT_EXPAND_BYTE_BUDGET = 100 * 1024;
 const DEFAULT_EXPAND_MAX_COUNT = 50;
-
-const itemKey = (groupPath: string, entry: { filePath: string; status: string }): string =>
-  `${groupPath}|${entry.status}:${entry.filePath}`;
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   caret: css`
@@ -82,8 +87,14 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     font-size: 12px;
     font-variant-numeric: tabular-nums;
   `,
+  // Two-pane body: diff list (left, flexes) + tree-nav rail (right, fixed).
+  body: css`
+    overflow: hidden;
+    min-height: 0;
+  `,
   list: css`
     position: relative;
+    min-width: 0;
     border-block: 1px solid ${cssVar.colorBorderSecondary};
 
     /* Strip the first visible row's own top border — the list's
@@ -92,6 +103,15 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     & > :first-child {
       border-block-start: none;
     }
+  `,
+  treeRail: css`
+    flex: none;
+
+    width: 240px;
+    min-height: 0;
+    padding-block: 4px;
+    border-block-start: 1px solid ${cssVar.colorBorderSecondary};
+    border-inline-start: 1px solid ${cssVar.colorBorderSecondary};
   `,
   arrow: css`
     flex-shrink: 0;
@@ -198,7 +218,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
 }));
 
-const Review = memo<ReviewProps>(({ deviceId, workingDirectory }) => {
+const Review = memo<ReviewProps>(({ deviceId, onToggleTree, showTree, workingDirectory }) => {
   const { t } = useTranslation('chat');
   const [mode, setMode] = useLocalStorageState<ReviewMode>(REVIEW_MODE_STORAGE_KEY, 'unstaged');
   // Per-repo base-ref override — when set, the branch diff compares against
@@ -330,6 +350,31 @@ const Review = memo<ReviewProps>(({ deviceId, workingDirectory }) => {
     }
     setActiveKeys(initialKeys);
   }
+
+  // The file whose diff the tree-nav last scrolled to — highlighted in the rail.
+  const [activeFileKey, setActiveFileKey] = useState<string | undefined>();
+  // Scroll container for the left diff list; tree-nav clicks scroll it to the
+  // matching `[data-file-key]` row.
+  const listRef = useRef<HTMLDivElement>(null);
+  const toggleFileKey = (key: string) =>
+    setActiveKeys((prev) => (prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key]));
+  // Tree-nav → diff list: reveal the group, expand the file, scroll it into view.
+  const handleSelectFile = (key: string) => {
+    setActiveFileKey(key);
+    const groupPath = key.slice(0, key.indexOf('|'));
+    setCollapsedGroupPaths((prev) => {
+      if (!prev.has(groupPath)) return prev;
+      const next = new Set(prev);
+      next.delete(groupPath);
+      return next;
+    });
+    setActiveKeys((prev) => (prev.includes(key) ? prev : [...prev, key]));
+    // Defer until the row is mounted/uncollapsed, then scroll it to the top.
+    requestAnimationFrame(() => {
+      const el = listRef.current?.querySelector(`[data-file-key="${CSS.escape(key)}"]`);
+      el?.scrollIntoView({ block: 'start' });
+    });
+  };
 
   if (!data && isLoading) {
     return (
@@ -511,6 +556,17 @@ const Review = memo<ReviewProps>(({ deviceId, workingDirectory }) => {
               onClick={handleToggleAll}
             />
           )}
+          {totalEntryCount > 0 && (
+            <ActionIcon
+              active={showTree}
+              icon={showTree ? PanelRightCloseIcon : PanelRightOpenIcon}
+              size={'small'}
+              title={
+                showTree ? t('workingPanel.review.tree.hide') : t('workingPanel.review.tree.show')
+              }
+              onClick={onToggleTree}
+            />
+          )}
           <DropdownMenu items={moreMenuItems} placement={'bottomRight'}>
             <ActionIcon
               icon={MoreHorizontalIcon}
@@ -526,82 +582,92 @@ const Review = memo<ReviewProps>(({ deviceId, workingDirectory }) => {
           <Empty description={emptyText} icon={GitCompareIcon} />
         </Center>
       ) : (
-        <Flexbox className={styles.list} style={{ overflow: 'auto' }} width={'100%'}>
-          {groups.map((group) => {
-            const groupTotals = group.patches.reduce(
-              (acc, p) => {
-                acc.additions += p.additions ?? 0;
-                acc.deletions += p.deletions ?? 0;
-                return acc;
-              },
-              { additions: 0, deletions: 0 },
-            );
-            const groupCollapsed = collapsedGroupPaths.has(group.absolutePath);
-            const groupItemKeys = group.patches.map((p) => itemKey(group.absolutePath, p));
-            const groupAllExpanded =
-              groupItemKeys.length > 0 && groupItemKeys.every((k) => activeKeys.includes(k));
-            const toggleGroupDiffs = () => {
-              setActiveKeys((prev) => {
-                if (groupAllExpanded) {
-                  const set = new Set(groupItemKeys);
-                  return prev.filter((k) => !set.has(k));
-                }
-                const next = new Set(prev);
-                for (const k of groupItemKeys) next.add(k);
-                return Array.from(next);
-              });
-            };
-            return (
-              <Fragment key={group.absolutePath}>
-                {showGroupHeaders && (
-                  <GroupHeader
-                    branch={group.branch}
-                    collapsed={groupCollapsed}
-                    diffsAllExpanded={groupAllExpanded}
-                    hideFoldButton={groupCollapsed || group.patches.length === 0}
-                    name={group.name}
-                    patchCount={group.patches.length}
-                    totalAdditions={groupTotals.additions}
-                    totalDeletions={groupTotals.deletions}
-                    onToggleCollapsed={() => toggleGroupCollapsed(group.absolutePath)}
-                    onToggleDiffs={toggleGroupDiffs}
-                  />
-                )}
-                {showGroupHeaders &&
-                  !groupCollapsed &&
-                  !group.isParent &&
-                  group.patches.length === 0 && (
-                    <div className={styles.groupEmpty}>
-                      {t('workingPanel.review.group.submoduleClean')}
-                    </div>
+        <Flexbox horizontal className={styles.body} flex={1} width={'100%'}>
+          <Flexbox className={styles.list} flex={1} ref={listRef} style={{ overflow: 'auto' }}>
+            {groups.map((group) => {
+              const groupTotals = group.patches.reduce(
+                (acc, p) => {
+                  acc.additions += p.additions ?? 0;
+                  acc.deletions += p.deletions ?? 0;
+                  return acc;
+                },
+                { additions: 0, deletions: 0 },
+              );
+              const groupCollapsed = collapsedGroupPaths.has(group.absolutePath);
+              const groupItemKeys = group.patches.map((p) => itemKey(group.absolutePath, p));
+              const groupAllExpanded =
+                groupItemKeys.length > 0 && groupItemKeys.every((k) => activeKeys.includes(k));
+              const toggleGroupDiffs = () => {
+                setActiveKeys((prev) => {
+                  if (groupAllExpanded) {
+                    const set = new Set(groupItemKeys);
+                    return prev.filter((k) => !set.has(k));
+                  }
+                  const next = new Set(prev);
+                  for (const k of groupItemKeys) next.add(k);
+                  return Array.from(next);
+                });
+              };
+              return (
+                <Fragment key={group.absolutePath}>
+                  {showGroupHeaders && (
+                    <GroupHeader
+                      branch={group.branch}
+                      collapsed={groupCollapsed}
+                      diffsAllExpanded={groupAllExpanded}
+                      hideFoldButton={groupCollapsed || group.patches.length === 0}
+                      name={group.name}
+                      patchCount={group.patches.length}
+                      totalAdditions={groupTotals.additions}
+                      totalDeletions={groupTotals.deletions}
+                      onToggleCollapsed={() => toggleGroupCollapsed(group.absolutePath)}
+                      onToggleDiffs={toggleGroupDiffs}
+                    />
                   )}
-                {!groupCollapsed &&
-                  group.patches.map((entry) => {
-                    const key = itemKey(group.absolutePath, entry);
-                    const expanded = activeKeys.includes(key);
-                    return (
-                      <FileRow
-                        deviceId={deviceId}
-                        entry={entry}
-                        expanded={expanded}
-                        key={key}
-                        mode={mode}
-                        repoAbsolutePath={group.absolutePath}
-                        textDiff={textDiff}
-                        viewMode={viewMode}
-                        wordWrap={wordWrap}
-                        onReverted={() => void mutate()}
-                        onToggle={() =>
-                          setActiveKeys((prev) =>
-                            prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
-                          )
-                        }
-                      />
-                    );
-                  })}
-              </Fragment>
-            );
-          })}
+                  {showGroupHeaders &&
+                    !groupCollapsed &&
+                    !group.isParent &&
+                    group.patches.length === 0 && (
+                      <div className={styles.groupEmpty}>
+                        {t('workingPanel.review.group.submoduleClean')}
+                      </div>
+                    )}
+                  {!groupCollapsed &&
+                    group.patches.length > 0 &&
+                    group.patches.map((entry) => {
+                      const key = itemKey(group.absolutePath, entry);
+                      const expanded = activeKeys.includes(key);
+                      return (
+                        <FileRow
+                          dataFileKey={key}
+                          deviceId={deviceId}
+                          entry={entry}
+                          expanded={expanded}
+                          key={key}
+                          mode={mode}
+                          repoAbsolutePath={group.absolutePath}
+                          textDiff={textDiff}
+                          viewMode={viewMode}
+                          wordWrap={wordWrap}
+                          onReverted={() => void mutate()}
+                          onToggle={() => toggleFileKey(key)}
+                        />
+                      );
+                    })}
+                </Fragment>
+              );
+            })}
+          </Flexbox>
+          {showTree && (
+            <Flexbox className={styles.treeRail}>
+              <FileTreeNav
+                activeFileKey={activeFileKey}
+                groups={groups}
+                showGroupHeaders={showGroupHeaders}
+                onSelectFile={handleSelectFile}
+              />
+            </Flexbox>
+          )}
         </Flexbox>
       )}
     </Flexbox>

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/reviewTreeNodes.ts
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/reviewTreeNodes.ts
@@ -1,0 +1,66 @@
+import type { GitWorkingTreePatch } from '@lobechat/electron-client-ipc';
+
+import type { ExplorerTreeNode } from '@/features/ExplorerTree';
+
+/** Stable per-file diff key — shared by the diff list (scroll anchor) and the
+ * tree-nav selection so clicking a tree leaf maps back to its patch. */
+export const itemKey = (groupPath: string, entry: { filePath: string; status: string }): string =>
+  `${groupPath}|${entry.status}:${entry.filePath}`;
+
+export interface ReviewTreeData {
+  /** itemKey of the owning patch — what the diff list scrolls to. */
+  key: string;
+}
+
+export interface ReviewTreeGroup {
+  absolutePath: string;
+  name: string;
+  patches: GitWorkingTreePatch[];
+}
+
+// Node ids are prefixed with the owning repo path so file paths that repeat
+// across submodule groups never collide. NUL can't appear in a real path.
+const SEP = '\u0000';
+
+/**
+ * Fold the flat per-repo patch lists into `ExplorerTree` nodes (files + the
+ * chain of containing directories), so the Review nav rail renders with the
+ * exact same folder / colored file-type icons as the Files tab. When there are
+ * submodule groups, each group gets a top-level folder holding its files.
+ */
+export const buildReviewTreeNodes = (
+  groups: ReviewTreeGroup[],
+  showGroupHeaders: boolean,
+): ExplorerTreeNode<ReviewTreeData>[] => {
+  const nodes: ExplorerTreeNode<ReviewTreeData>[] = [];
+  for (const group of groups) {
+    if (group.patches.length === 0) continue;
+    const gp = group.absolutePath;
+    const rootId = showGroupHeaders ? `${gp}${SEP}` : null;
+    if (rootId) nodes.push({ id: rootId, isFolder: true, name: group.name, parentId: null });
+
+    const seenDir = new Set<string>();
+    for (const patch of group.patches) {
+      const segments = patch.filePath.split('/');
+      // Materialise the directory chain once per unique dir.
+      for (let i = 1; i < segments.length; i++) {
+        const dirRel = `${segments.slice(0, i).join('/')}/`;
+        const dirId = `${gp}${SEP}${dirRel}`;
+        if (seenDir.has(dirId)) continue;
+        seenDir.add(dirId);
+        const parentId = i > 1 ? `${gp}${SEP}${segments.slice(0, i - 1).join('/')}/` : rootId;
+        nodes.push({ id: dirId, isFolder: true, name: segments[i - 1], parentId });
+      }
+      const fileParent =
+        segments.length > 1 ? `${gp}${SEP}${segments.slice(0, -1).join('/')}/` : rootId;
+      nodes.push({
+        data: { key: itemKey(gp, patch) },
+        id: `${gp}${SEP}${patch.filePath}`,
+        isFolder: false,
+        name: segments.at(-1) ?? patch.filePath,
+        parentId: fileParent,
+      });
+    }
+  }
+  return nodes;
+};

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
@@ -1,7 +1,7 @@
 import { ActionIcon, Flexbox } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { PanelRightCloseIcon } from 'lucide-react';
-import { lazy, memo } from 'react';
+import { lazy, memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
@@ -11,6 +11,7 @@ import RightPanel from '@/features/RightPanel';
 import { resolveTargetDeviceId } from '@/helpers/agentWorkingDirectory';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
+import { useLocalStorageState } from '@/hooks/useLocalStorageState';
 import { useAgentStore } from '@/store/agent';
 import {
   agentByIdSelectors,
@@ -78,6 +79,11 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 
 type Tab = 'files' | 'params' | 'review' | 'resources';
 
+const REVIEW_TREE_STORAGE_KEY = 'lobechat-review-tree';
+const DEFAULT_PANEL_WIDTH = 360;
+// Two-pane Review (diff list + file-tree rail) is cramped below this.
+const TWO_PANE_MIN_WIDTH = 560;
+
 const AgentWorkingSidebar = memo(() => {
   const { t } = useTranslation(['chat', 'setting']);
   const toggleRightPanel = useGlobalStore((s) => s.toggleRightPanel);
@@ -137,8 +143,34 @@ const AgentWorkingSidebar = memo(() => {
   };
   const activeTab: Tab = resolveActiveTab();
 
+  // Review's tree-nav rail lives here (not inside Review) so the panel can widen
+  // when the two-pane layout is on. Hidden by default — the panel shows only the
+  // diff list until the user opens the tree from the toolbar. Persisted so it
+  // survives reloads.
+  const [showReviewTree, setShowReviewTree] = useLocalStorageState<boolean>(
+    REVIEW_TREE_STORAGE_KEY,
+    false,
+  );
+  const [panelWidth, setPanelWidth] = useState<number | string>(DEFAULT_PANEL_WIDTH);
+  const reviewTwoPane = activeTab === 'review' && reviewAvailable && showReviewTree;
+  useEffect(() => {
+    if (!reviewTwoPane) return;
+    setPanelWidth((w) =>
+      typeof w === 'number' && w < TWO_PANE_MIN_WIDTH ? TWO_PANE_MIN_WIDTH : w,
+    );
+  }, [reviewTwoPane]);
+
   return (
-    <RightPanel stableLayout defaultWidth={360} maxWidth={720} minWidth={300}>
+    <RightPanel
+      stableLayout
+      defaultWidth={DEFAULT_PANEL_WIDTH}
+      maxWidth={720}
+      minWidth={300}
+      width={panelWidth}
+      onSizeChange={(size) => {
+        if (typeof size?.width === 'number') setPanelWidth(size.width);
+      }}
+    >
       <Flexbox height={'100%'} width={'100%'}>
         <Flexbox
           horizontal
@@ -198,7 +230,12 @@ const AgentWorkingSidebar = memo(() => {
           )}
           {reviewAvailable && (
             <Flexbox className={activeTab === 'review' ? styles.pane : styles.paneHidden}>
-              <Review deviceId={remoteDeviceId} workingDirectory={workingDirectory} />
+              <Review
+                deviceId={remoteDeviceId}
+                showTree={showReviewTree}
+                workingDirectory={workingDirectory}
+                onToggleTree={() => setShowReviewTree((v) => !v)}
+              />
             </Flexbox>
           )}
           {filesAvailable && (


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔀 Description of Change

The agent working-sidebar **Review** panel now renders a **two-pane layout inspired by Codex**:

- **Left** — the list-style **diff detail** (changed files with their inline `PatchDiff`, full-width).
- **Right** — a **directory tree** for navigation. Clicking a file in the tree scrolls the diff list to that file and expands it; the selected file is highlighted in the tree.

Details:
- The tree rail **reuses the Files-tab `ExplorerTree`**, so folder / colored file-type icons match the Files tab exactly. No per-file `+/-` stats in the tree — it stays a clean outline.
- A **file-tree toggle** is a toolbar `ActionIcon` next to the ⋯ menu (persisted to `localStorage`, two-pane by default). Hiding the tree gives full-width diffs.
- The panel **widens to a comfortable width** (`RightPanel` gains an optional controlled `width`) when the two-pane layout is on, and never shrinks the user's own wider drag.

Implementation:
- New `Review/reviewTreeNodes.ts` folds the flat per-repo patch list into `ExplorerTreeNode`s (files + directory chain, submodule groups get a root folder).
- New `Review/FileTreeNav.tsx` renders the nav rail via `ExplorerTree` (`iconSet="complete"`, controlled selection, click → scroll/expand).
- `Review/index.tsx` becomes the two-pane container (left diff list with `data-file-key` scroll anchors, right nav rail); the tree-visibility state is lifted to `WorkingSidebar` so it can drive the panel width.

#### 🧪 How to Test

- [x] Tested locally (agent-testing, Electron)
- [x] Added/updated tests (`Review/__tests__/reviewTreeNodes.test.ts`)

Open a Claude Code / Codex agent with a local git working directory that has uncommitted changes across nested folders → open the **Review** tab. The diff list renders on the left with a directory tree on the right; click a tree file to jump to its diff; toggle the tree via the toolbar icon next to ⋯.

#### 📸 Screenshots / Videos

_UI evidence captured via agent-testing (two-pane, file-type icons, toggle, click-to-navigate)._
