### PR TITLE
✨ feat(verify): distinguish verifier infra failure from a rejected delivery (errored state)

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/verify.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/verify.test.ts
@@ -96,6 +96,29 @@ describe('verifyRouter', () => {
       expect(modelMocks.findRunById).toHaveBeenCalledWith('other-user-run');
       expect(modelMocks.upsertByCheckItem).not.toHaveBeenCalled();
     });
+
+    it('records an infra failure as status `errored` with no verdict', async () => {
+      modelMocks.findRunById.mockResolvedValueOnce({ id: 'run-1' });
+      modelMocks.upsertByCheckItem.mockResolvedValueOnce({ id: 'result-err' });
+
+      await createCaller().ingestResult({
+        checkItemId: 'check-1',
+        status: 'errored',
+        toulmin: { limitation: 'Agent verifier failed to start.' },
+        verifyRunId: 'run-1',
+      });
+
+      const written = modelMocks.upsertByCheckItem.mock.calls[0][0];
+      expect(written).toMatchObject({ status: 'errored', verifyRunId: 'run-1' });
+      expect(written.verdict).toBeUndefined();
+    });
+
+    it('rejects a result with neither a verdict nor an explicit status', async () => {
+      await expect(
+        createCaller().ingestResult({ checkItemId: 'check-1', verifyRunId: 'run-1' } as any),
+      ).rejects.toThrow();
+      expect(modelMocks.upsertByCheckItem).not.toHaveBeenCalled();
+    });
   });
 
   describe('deleteRun', () => {

--- a/apps/server/src/routers/lambda/verify.ts
+++ b/apps/server/src/routers/lambda/verify.ts
@@ -47,7 +47,15 @@ const onFailSchema = z.enum(['manual', 'auto_repair']);
 const decisionSchema = z.enum(['accepted', 'rejected', 'overridden']);
 const modelConfigSchema = z.object({ model: z.string(), provider: z.string() });
 const verdictSchema = z.enum(['passed', 'failed', 'uncertain']);
-const checkStatusSchema = z.enum(['pending', 'running', 'passed', 'failed', 'skipped']);
+const checkStatusSchema = z.enum([
+  'pending',
+  'running',
+  'passed',
+  'failed',
+  // Verifier could not run (infra failure) — carries no verdict.
+  'errored',
+  'skipped',
+]);
 const runSourceSchema = z.enum(['agent', 'agent-testing']);
 const evidenceTypeSchema = z.enum([
   'screenshot',
@@ -538,23 +546,32 @@ export const verifyRouter = router({
 
   ingestResult: verifyProcedure
     .input(
-      z.object({
-        checkItemId: z.string(),
-        checkItemIndex: z.number().optional(),
-        checkItemTitle: z.string().optional(),
-        confidence: z.number().min(0).max(1).optional(),
-        required: z.boolean().optional(),
-        status: checkStatusSchema.optional(),
-        // `.nullish()` (not `.optional()`) so a re-ingest can pass an explicit
-        // `null` to CLEAR a prior suggestion/observation — `undefined` would be
-        // dropped from the conflict UPDATE and leave the stale value on the row,
-        // breaking the full-replace guarantee. See the ingest-report caller.
-        suggestion: z.string().nullish(),
-        toulmin: toulminSchema.nullish(),
-        verdict: verdictSchema,
-        verifierType: verifierTypeSchema.optional(),
-        verifyRunId: z.string(),
-      }),
+      z
+        .object({
+          checkItemId: z.string(),
+          checkItemIndex: z.number().optional(),
+          checkItemTitle: z.string().optional(),
+          confidence: z.number().min(0).max(1).optional(),
+          required: z.boolean().optional(),
+          status: checkStatusSchema.optional(),
+          // `.nullish()` (not `.optional()`) so a re-ingest can pass an explicit
+          // `null` to CLEAR a prior suggestion/observation — `undefined` would be
+          // dropped from the conflict UPDATE and leave the stale value on the row,
+          // breaking the full-replace guarantee. See the ingest-report caller.
+          suggestion: z.string().nullish(),
+          toulmin: toulminSchema.nullish(),
+          // Optional so an infra failure can be recorded as `status: 'errored'`
+          // with no verdict (the verifier never produced a judgment).
+          verdict: verdictSchema.optional(),
+          verifierType: verifierTypeSchema.optional(),
+          verifyRunId: z.string(),
+        })
+        // A row needs either a verdict (→ derives status) or an explicit status
+        // (e.g. `errored`); otherwise there's nothing to record.
+        .refine((v) => v.verdict !== undefined || v.status !== undefined, {
+          message: 'Either a verdict or an explicit status is required.',
+          path: ['verdict'],
+        }),
     )
     .mutation(async ({ ctx, input }) => {
       const run = await resolveVerifyRun(ctx, input.verifyRunId);
@@ -566,7 +583,9 @@ export const verifyRouter = router({
         completedAt: new Date(),
         confidence: input.confidence,
         required: input.required ?? true,
-        status: input.status ?? statusForVerdict(input.verdict),
+        // Prefer an explicit status; else derive from the verdict (the refine
+        // guarantees at least one is present).
+        status: input.status ?? (input.verdict ? statusForVerdict(input.verdict) : 'errored'),
         suggestion: input.suggestion,
         toulmin: input.toulmin,
         verdict: input.verdict,

--- a/apps/server/src/services/verify/__tests__/driveTaskFromVerify.test.ts
+++ b/apps/server/src/services/verify/__tests__/driveTaskFromVerify.test.ts
@@ -96,6 +96,27 @@ describe('driveTaskFromVerify', () => {
     expect(deliverMock.mock.calls[0][0]).toMatchObject({ reason: 'error', taskId: 'task-1' });
   });
 
+  it('errored → pauses with a non-accusatory brief; never claims the delivery "did not pass"', async () => {
+    runFindByOperation.mockResolvedValue({ id: 'run-1', metadata: null, status: 'errored' });
+    await driveTaskFromVerify(db, 'u1', 'op-1');
+
+    // Paused for a human, but NOT completed — the delivery was never evaluated.
+    expect(taskUpdateStatus).toHaveBeenCalledWith('task-1', 'paused', { error: null });
+    expect(serviceUpdateStatus).not.toHaveBeenCalled();
+
+    // The brief frames it as an internal verification error, not a rejected delivery.
+    const briefArg = briefCreate.mock.calls[0][0];
+    expect(briefArg.summary).not.toContain('did not pass');
+    expect(briefArg.summary.toLowerCase()).toContain('could not run');
+
+    // The creator callback is an error, but the message must NOT accuse the
+    // delivery of failing verification.
+    const deliverArg = deliverMock.mock.calls[0][0];
+    expect(deliverArg.reason).toBe('error');
+    expect(deliverArg.errorMessage).not.toBe('Delivery did not pass verification.');
+    expect(deliverArg.errorMessage.toLowerCase()).toContain('internal error');
+  });
+
   it('skips when the run has not terminally settled (verifying/repairing)', async () => {
     runFindByOperation.mockResolvedValue({ id: 'run-1', metadata: null, status: 'verifying' });
     await driveTaskFromVerify(db, 'u1', 'op-1');

--- a/apps/server/src/services/verify/__tests__/statusService.recompute.test.ts
+++ b/apps/server/src/services/verify/__tests__/statusService.recompute.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { VerifyStatusService } from '../statusService';
+
+const { runFindByOperation, runUpdateStatus, resultListByRun } = vi.hoisted(() => ({
+  resultListByRun: vi.fn(),
+  runFindByOperation: vi.fn(),
+  runUpdateStatus: vi.fn(),
+}));
+
+vi.mock('@/database/models/verifyRun', () => ({
+  VerifyRunModel: vi.fn(() => ({
+    findByOperation: runFindByOperation,
+    updateStatus: runUpdateStatus,
+  })),
+}));
+vi.mock('@/database/models/verifyCheckResult', () => ({
+  VerifyCheckResultModel: vi.fn(() => ({ listByRun: resultListByRun })),
+}));
+
+const db = {} as any;
+
+// One confirmed run whose plan is the given required check items.
+const runWith = (items: { id: string }[]) => ({
+  id: 'run-1',
+  plan: items.map((i) => ({ ...i, required: true })),
+  planConfirmedAt: new Date(),
+  status: 'verifying',
+});
+
+describe('VerifyStatusService.recompute — errored rollup', () => {
+  beforeEach(() => {
+    [runFindByOperation, runUpdateStatus, resultListByRun].forEach((m) => m.mockReset());
+  });
+
+  it('an errored required check (none failed) rolls up to `errored`, not `failed`', async () => {
+    runFindByOperation.mockResolvedValue(runWith([{ id: 'c1' }]));
+    resultListByRun.mockResolvedValue([{ checkItemId: 'c1', status: 'errored', verdict: null }]);
+
+    const status = await new VerifyStatusService(db, 'u1').recompute('op-1');
+
+    expect(status).toBe('errored');
+    expect(runUpdateStatus).toHaveBeenCalledWith('run-1', 'errored');
+  });
+
+  it('a genuine failure dominates an errored check (delivery still gates)', async () => {
+    runFindByOperation.mockResolvedValue(runWith([{ id: 'c1' }, { id: 'c2' }]));
+    resultListByRun.mockResolvedValue([
+      { checkItemId: 'c1', status: 'errored', verdict: null },
+      { checkItemId: 'c2', status: 'failed', verdict: 'failed' },
+    ]);
+
+    const status = await new VerifyStatusService(db, 'u1').recompute('op-1');
+
+    expect(status).toBe('failed');
+  });
+
+  it('a still-running check keeps the run `verifying` even with an errored sibling', async () => {
+    runFindByOperation.mockResolvedValue(runWith([{ id: 'c1' }, { id: 'c2' }]));
+    resultListByRun.mockResolvedValue([
+      { checkItemId: 'c1', status: 'errored', verdict: null },
+      { checkItemId: 'c2', status: 'running', verdict: null },
+    ]);
+
+    const status = await new VerifyStatusService(db, 'u1').recompute('op-1');
+
+    expect(status).toBe('verifying');
+  });
+
+  it('all passing required checks still roll up to `passed`', async () => {
+    runFindByOperation.mockResolvedValue(runWith([{ id: 'c1' }]));
+    resultListByRun.mockResolvedValue([{ checkItemId: 'c1', status: 'passed', verdict: 'passed' }]);
+
+    const status = await new VerifyStatusService(db, 'u1').recompute('op-1');
+
+    expect(status).toBe('passed');
+  });
+});

--- a/apps/server/src/services/verify/__tests__/verifierTerminal.test.ts
+++ b/apps/server/src/services/verify/__tests__/verifierTerminal.test.ts
@@ -48,7 +48,7 @@ describe('settleVerifierCheckFromTerminal', () => {
     ]);
   });
 
-  it('marks a still-running verifier result failed/uncertain and finalizes the parent run', async () => {
+  it('marks a still-running verifier result `errored` (no verdict) and finalizes the parent run', async () => {
     await settleVerifierCheckFromTerminal(
       db,
       'u',
@@ -62,18 +62,18 @@ describe('settleVerifierCheckFromTerminal', () => {
       'ws',
     );
 
-    expect(updateByCheckItemMock).toHaveBeenCalledWith(
-      'run-1',
-      'check-1',
-      expect.objectContaining({
-        status: 'failed',
-        toulmin: {
-          limitation: 'Verifier failed before submitting a verdict: InvalidProviderAPIKey',
-        },
-        verdict: 'uncertain',
-        verifierOperationId: 'verifier-op',
-      }),
-    );
+    // A verifier that terminated without a verdict is an infra failure, not a
+    // delivery judgment — recorded as `errored` with no verdict so it never gates
+    // delivery or seeds a repair round.
+    const written = updateByCheckItemMock.mock.calls[0][2];
+    expect(written).toMatchObject({
+      status: 'errored',
+      toulmin: {
+        limitation: 'Verifier failed before submitting a verdict: InvalidProviderAPIKey',
+      },
+      verifierOperationId: 'verifier-op',
+    });
+    expect(written.verdict).toBeUndefined();
     expect(recomputeMock).toHaveBeenCalledWith('parent-op');
     expect(finalizeVerifyRunMock).toHaveBeenCalledWith(db, 'u', 'parent-op', {}, 'ws');
   });

--- a/apps/server/src/services/verify/executor.ts
+++ b/apps/server/src/services/verify/executor.ts
@@ -62,7 +62,12 @@ export interface ExecuteVerifyParams {
 
 const verdictToStatus = (verdict: VerifyVerdict): VerifyCheckResultStatus =>
   verdict === 'passed' ? 'passed' : 'failed';
-const terminalResultStatuses = new Set<VerifyCheckResultStatus>(['passed', 'failed', 'skipped']);
+const terminalResultStatuses = new Set<VerifyCheckResultStatus>([
+  'passed',
+  'failed',
+  'errored',
+  'skipped',
+]);
 
 /** Group a run's evidence rows by the plan item they back, for judge injection. */
 type EvidenceByItem = Map<string, JudgeEvidence[]>;
@@ -276,9 +281,11 @@ export class VerifyExecutorService {
         );
         await this.resultModel.updateByCheckItem(verifyRunId, item.id, {
           completedAt: new Date(),
-          status: 'failed',
+          // Infra failure, not a delivery verdict: the verifier never started, so
+          // there is nothing to judge. `errored` (no verdict) keeps this out of
+          // the delivery gate and the auto-repair set.
+          status: 'errored',
           toulmin: { limitation: 'Agent verifier failed to start (no operation id returned).' },
-          verdict: 'uncertain',
         });
         return;
       }
@@ -304,9 +311,11 @@ export class VerifyExecutorService {
       console.error('[verify] agent verifier spawn failed for item %s: %O', item.id, error);
       await this.resultModel.updateByCheckItem(verifyRunId, item.id, {
         completedAt: new Date(),
-        status: 'failed',
+        // Infra failure (spawn threw before the verifier op was persisted), not a
+        // delivery verdict — mark `errored` so it neither gates delivery nor seeds
+        // a repair round.
+        status: 'errored',
         toulmin: { limitation: `Agent verifier failed to start: ${detail}` },
-        verdict: 'uncertain',
       });
     }
   }

--- a/apps/server/src/services/verify/repairService.ts
+++ b/apps/server/src/services/verify/repairService.ts
@@ -192,8 +192,12 @@ export const maybeAutoRepair = async (
   await new VerifyRepairService(db, userId, workspaceId).triggerAutoRepair(operationId, spawner);
 };
 
+// `errored` = the verifier couldn't run (infra), so there's no delivery fault to
+// repair — exclude it even though it carries no verdict.
 const isFailed = (r: VerifyCheckResultItem | undefined): boolean =>
-  !!r && (r.status === 'failed' || r.verdict === 'failed' || r.verdict === 'uncertain');
+  !!r &&
+  r.status !== 'errored' &&
+  (r.status === 'failed' || r.verdict === 'failed' || r.verdict === 'uncertain');
 
 const buildInstruction = (
   failures: { item: VerifyCheckItem; result: VerifyCheckResultItem | undefined }[],

--- a/apps/server/src/services/verify/settle.ts
+++ b/apps/server/src/services/verify/settle.ts
@@ -42,7 +42,7 @@ export const driveTaskFromVerify = async (
     const runModel = new VerifyRunModel(db, userId, workspaceId);
     const run = await runModel.findByOperation(operationId);
     // Only act on a terminally settled run (skip pending / verifying / repairing).
-    if (run?.status !== 'passed' && run?.status !== 'failed') return;
+    if (run?.status !== 'passed' && run?.status !== 'failed' && run?.status !== 'errored') return;
     if ((run.metadata as { taskDrivenAt?: string } | null)?.taskDrivenAt) return; // already drove
 
     const op = await new AgentOperationModel(db, userId, workspaceId).findById(operationId);
@@ -62,19 +62,33 @@ export const driveTaskFromVerify = async (
       });
       log('verify passed → task %s completed', op.taskId);
     } else {
-      // Failed acceptance → surface for the user (urgent brief) + pause the task.
+      // Two non-pass outcomes, kept distinct so an infra error never reads as a
+      // rejected delivery:
+      // - failed:  the verifier ran and judged the delivery short of the criteria.
+      // - errored: the verifier could not run (infra) — the delivery was NOT
+      //   evaluated, so we must not claim it "did not pass".
+      const isErrored = run.status === 'errored';
       await new BriefModel(db, userId, workspaceId).create({
         actions: DEFAULT_BRIEF_ACTIONS['error'],
         agentId: task.assigneeAgentId || undefined,
         priority: 'urgent',
-        summary: 'Delivery did not pass verification.',
+        summary: isErrored
+          ? 'Verification could not run (internal error); the delivery was not evaluated.'
+          : 'Delivery did not pass verification.',
         taskId: op.taskId,
-        title: `${task.identifier} failed verification`,
+        title: isErrored
+          ? `${task.identifier} verification errored`
+          : `${task.identifier} failed verification`,
         trigger: 'task',
         type: 'error',
       });
       await taskModel.updateStatus(op.taskId, 'paused', { error: null });
-      log('verify failed → task %s paused + brief', op.taskId);
+      log(
+        isErrored
+          ? 'verify errored → task %s paused + brief'
+          : 'verify failed → task %s paused + brief',
+        op.taskId,
+      );
     }
 
     // Deferred creator callback: verify-bound runs defer
@@ -83,13 +97,19 @@ export const driveTaskFromVerify = async (
     // never an unaccepted output it might act on before a later verify failure.
     // Best-effort; must not block the idempotency marker below.
     try {
+      const errorMessage =
+        run.status === 'failed'
+          ? 'Delivery did not pass verification.'
+          : run.status === 'errored'
+            ? 'Verification could not be completed due to an internal error; the delivery was not evaluated. Please retry or review it manually.'
+            : undefined;
       await new TaskResultBridgeService(db, userId, workspaceId).deliver({
         operationId,
         reason: run.status === 'passed' ? 'done' : 'error',
         taskId: op.taskId,
         taskIdentifier: task.identifier,
         topicId: op.topicId ?? undefined,
-        ...(run.status === 'failed' && { errorMessage: 'Delivery did not pass verification.' }),
+        ...(errorMessage && { errorMessage }),
       });
     } catch (error) {
       log('verify-settle creator callback failed for task %s (non-fatal): %O', op.taskId, error);
@@ -121,11 +141,13 @@ export const finalizeVerifyRun = async (
   await maybeAutoRepair(db, userId, operationId, workspaceId);
 
   const settled = await new VerifyRunModel(db, userId, workspaceId).findByOperation(operationId);
-  if (settled?.status !== 'passed' && settled?.status !== 'failed') return;
+  if (settled?.status !== 'passed' && settled?.status !== 'failed' && settled?.status !== 'errored')
+    return;
 
   // Report only on terminal settle (a single card on the final delivery, not one
-  // per repair round). Skipped when the caller lacks the deliverable (agent path).
-  if (opts.report) {
+  // per repair round). Skipped when the caller lacks the deliverable (agent path)
+  // and for `errored` runs, which carry no criteria judgment to report.
+  if (opts.report && settled.status !== 'errored') {
     await new VerifyReporterService(db, userId, workspaceId).generateReport({
       ...opts.report,
       verifyRunId: settled.id,

--- a/apps/server/src/services/verify/statusService.ts
+++ b/apps/server/src/services/verify/statusService.ts
@@ -27,8 +27,11 @@ export class VerifyStatusService {
    * Returns the computed status. Gate logic only considers `required` items:
    * - any required result still pending/running → `verifying`
    * - any required result failed → `failed`
+   * - else any required result errored (verifier couldn't run) → `errored`
    * - otherwise → `passed`
-   * `skipped` results (e.g. v1 program placeholders) are pass-through.
+   * A genuine `failed` dominates an `errored` (the delivery has a real problem to
+   * fix, so it should still gate + repair). `skipped` results (e.g. v1 program
+   * placeholders) are pass-through.
    */
   async recompute(operationId: string): Promise<VerifyRunStatus | null> {
     const run = await this.runModel.findByOperation(operationId);
@@ -48,6 +51,7 @@ export class VerifyStatusService {
 
     let anyPending = false;
     let anyFailed = false;
+    let anyErrored = false;
     for (const item of requiredItems) {
       const result = byItem.get(item.id);
       // A required item without a result yet is still pending.
@@ -56,9 +60,16 @@ export class VerifyStatusService {
         continue;
       }
       if (result.status === 'failed' || result.verdict === 'failed') anyFailed = true;
+      else if (result.status === 'errored') anyErrored = true;
     }
 
-    const status: VerifyRunStatus = anyPending ? 'verifying' : anyFailed ? 'failed' : 'passed';
+    const status: VerifyRunStatus = anyPending
+      ? 'verifying'
+      : anyFailed
+        ? 'failed'
+        : anyErrored
+          ? 'errored'
+          : 'passed';
 
     if (status !== run.status) {
       await this.runModel.updateStatus(run.id, status);

--- a/apps/server/src/services/verify/verifierTerminal.ts
+++ b/apps/server/src/services/verify/verifierTerminal.ts
@@ -9,7 +9,7 @@ import { VerifyStatusService } from './statusService';
 
 const log = debug('lobe-server:verify-verifier-terminal');
 
-const TERMINAL_RESULT_STATUSES = new Set(['passed', 'failed', 'skipped']);
+const TERMINAL_RESULT_STATUSES = new Set(['passed', 'failed', 'errored', 'skipped']);
 
 export interface SettleVerifierCheckFromTerminalParams {
   checkItemId: string;
@@ -52,10 +52,12 @@ export const settleVerifierCheckFromTerminal = async (
 
     await resultModel.updateByCheckItem(run.id, checkItemId, {
       completedAt: new Date(),
-      status: 'failed',
+      // The verifier terminated without producing a verdict — an infra/verifier
+      // malfunction, not a delivery judgment. `errored` (no verdict) keeps it out
+      // of the delivery gate and the auto-repair set.
+      status: 'errored',
       suggestion: 'Review the verifier configuration and rerun verification.',
       toulmin: { limitation },
-      verdict: 'uncertain',
       verifierOperationId,
     });
 

--- a/packages/database/src/models/agentOperation.ts
+++ b/packages/database/src/models/agentOperation.ts
@@ -1,3 +1,4 @@
+import type { VerifyRunStatus } from '@lobechat/types';
 import { and, eq, gte, isNotNull, sql } from 'drizzle-orm';
 
 import { today } from '@/utils/time';
@@ -12,17 +13,12 @@ import { agentOperations } from '../schemas/agentOperations';
 import type { LobeChatDatabase } from '../type';
 import { buildWorkspaceWhere } from '../utils/workspace';
 
-/** Verify rollup states, mirrors the `verify_status` enum column. */
-export type VerifyStatus =
-  | 'unverified'
-  | 'planned'
-  | 'verifying'
-  | 'passed'
-  | 'failed'
-  // Verifier could not run (infra error) — terminal, but not a delivery failure.
-  | 'errored'
-  | 'repairing'
-  | 'delivered';
+/**
+ * Verify rollup states. Aliases the single `VerifyRunStatus` source of truth in
+ * `@lobechat/types` (which also backs the `verify_status` column enum and
+ * `verify_runs.status`) so the three never drift.
+ */
+export type VerifyStatus = VerifyRunStatus;
 
 export interface RecordOperationStartParams {
   agentId?: string | null;

--- a/packages/database/src/models/agentOperation.ts
+++ b/packages/database/src/models/agentOperation.ts
@@ -19,6 +19,8 @@ export type VerifyStatus =
   | 'verifying'
   | 'passed'
   | 'failed'
+  // Verifier could not run (infra error) — terminal, but not a delivery failure.
+  | 'errored'
   | 'repairing'
   | 'delivered';
 
@@ -67,12 +69,7 @@ export interface RecordOperationCompletionParams {
   /** Backfill the executed provider — see {@link RecordOperationCompletionParams.model}. */
   provider?: string | null;
   status:
-    | 'running'
-    | 'waiting_for_human'
-    | 'waiting_for_async_tool'
-    | 'done'
-    | 'error'
-    | 'interrupted';
+    'running' | 'waiting_for_human' | 'waiting_for_async_tool' | 'done' | 'error' | 'interrupted';
   stepCount?: number | null;
   toolCalls?: number | null;
   totalCost?: number | null;

--- a/packages/database/src/schemas/agentOperations.ts
+++ b/packages/database/src/schemas/agentOperations.ts
@@ -1,4 +1,5 @@
 import type { VerifyCheckItem } from '@lobechat/types';
+import { verifyRunStatuses } from '@lobechat/types';
 import { boolean, index, integer, jsonb, pgTable, text } from 'drizzle-orm/pg-core';
 
 import { amountNumeric, timestamps, timestamptz } from './_helpers';
@@ -26,24 +27,6 @@ const completionReasons = [
   'cost_limit',
   'waiting_for_human',
   'waiting_for_async_tool',
-] as const;
-
-/**
- * Denormalized rollup of the operation's verify (delivery checker) state.
- * Lets the operation list page render badges / filter without joining the
- * verify_* tables. It is a rollup of plan.status + result aggregation and MUST
- * be updated through the service layer (on plan confirm / each result / repair)
- * to avoid drift.
- */
-const verifyStatuses = [
-  'unverified',
-  'planned',
-  'verifying',
-  'passed',
-  'failed',
-  'errored',
-  'repairing',
-  'delivered',
 ] as const;
 
 export interface AgentOperationInterruption {
@@ -100,8 +83,11 @@ export const agentOperations = pgTable(
     // are retained only to avoid an ALTER on this analytics table; they are no
     // longer read or written by the verify pipeline and are dropped in a later
     // cleanup migration.
+    // Denormalized rollup of the verify (delivery checker) state. Shares the
+    // single `verifyRunStatuses` set from `@lobechat/types` so it can't drift
+    // from `verify_runs.status`.
     /** @deprecated read from verify_runs.status */
-    verifyStatus: text('verify_status', { enum: verifyStatuses }),
+    verifyStatus: text('verify_status', { enum: verifyRunStatuses }),
     /** @deprecated read from verify_runs.plan */
     verifyPlan: jsonb('verify_plan').$type<VerifyCheckItem[]>(),
     /** @deprecated read from verify_runs.plan_confirmed_at */

--- a/packages/database/src/schemas/agentOperations.ts
+++ b/packages/database/src/schemas/agentOperations.ts
@@ -41,6 +41,7 @@ const verifyStatuses = [
   'verifying',
   'passed',
   'failed',
+  'errored',
   'repairing',
   'delivered',
 ] as const;

--- a/packages/locales/src/default/verify.ts
+++ b/packages/locales/src/default/verify.ts
@@ -1,4 +1,5 @@
 export default {
+  'badge.errored': 'Check could not run',
   'badge.failed': 'Check failed',
   'badge.passed': 'Check passed',
   'badge.pending': 'Awaiting check',
@@ -125,6 +126,9 @@ export default {
   'reports.verdict.pending': 'No report',
   'reports.verdict.uncertain': 'Uncertain',
 
+  'result.errored.sub':
+    'The delivery checker could not run because of an internal error, so this result was not evaluated. Retry the verification or review it manually.',
+  'result.errored.title': 'Draft result',
   'result.failed.sub':
     'This result is held back. The delivery checker found verification insufficient and triggered a repair.',
   'result.failed.title': 'Draft result',
@@ -142,6 +146,7 @@ export default {
 
   'status.checking': 'Delivery Checker: checking {{passed}}/{{total}}',
   'status.draft': 'Delivery Checker: awaiting confirmation · {{total}} checks',
+  'status.errored': 'Delivery Checker: could not run',
   'status.failed': 'Delivery Checker: failed · repair triggered',
   'status.idle': 'Delivery Checker: not generated',
   'status.passed': 'Delivery Checker: passed {{passed}}/{{total}}',

--- a/packages/types/src/verify.ts
+++ b/packages/types/src/verify.ts
@@ -18,12 +18,18 @@ export type VerifierType = (typeof verifierTypes)[number];
 export const verifyOnFailStrategies = ['manual', 'auto_repair'] as const;
 export type VerifyOnFailStrategy = (typeof verifyOnFailStrategies)[number];
 
-/** Lifecycle of a single check result. */
+/**
+ * Lifecycle of a single check result.
+ * - errored: the verifier could not run (infra / startup failure) — NOT a
+ *   delivery judgment. Kept distinct from `failed` so a broken verifier never
+ *   reads as a rejected delivery and never seeds an auto-repair round.
+ */
 export const verifyCheckResultStatuses = [
   'pending',
   'running',
   'passed',
   'failed',
+  'errored',
   'skipped',
 ] as const;
 export type VerifyCheckResultStatus = (typeof verifyCheckResultStatuses)[number];
@@ -47,6 +53,9 @@ export const verifyRunStatuses = [
   'verifying',
   'passed',
   'failed',
+  // At least one required check errored (verifier couldn't run) and none
+  // genuinely failed — verification is inconclusive, not a rejected delivery.
+  'errored',
   'repairing',
   'delivered',
 ] as const;

--- a/src/features/Verify/CheckerDock.tsx
+++ b/src/features/Verify/CheckerDock.tsx
@@ -197,6 +197,7 @@ const CheckerDock = memo<CheckerDockProps>(({ operationId, embedded }) => {
   const subText = (() => {
     const map: Record<string, string> = {
       draft: t('status.draft', { total: plan.length }),
+      errored: t('status.errored'),
       failed: t('status.failed'),
       passed: t('status.passed', { passed: counts.passed, total: counts.total }),
       repairing: t('status.repairing'),
@@ -367,7 +368,12 @@ const CheckerDock = memo<CheckerDockProps>(({ operationId, embedded }) => {
   // Merged verify card: just the checker body (items + actions), no dock chrome.
   if (embedded) return body;
 
-  const headIcon = phase === 'passed' ? Check : phase === 'failed' ? ShieldAlert : ShieldCheck;
+  const headIcon =
+    phase === 'passed'
+      ? Check
+      : phase === 'failed' || phase === 'errored'
+        ? ShieldAlert
+        : ShieldCheck;
 
   return (
     <div className={styles.dock}>

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -470,7 +470,9 @@ const VERDICT_META: Record<
 const imageEvidenceTypes = new Set(['gif', 'screenshot']);
 const isInlineImageEvidence = (evidence: VerifyEvidenceWithUrl) =>
   Boolean(evidence.fileUrl && imageEvidenceTypes.has(evidence.type));
-const terminalRunStatuses = new Set(['delivered', 'failed', 'passed']);
+// `errored` is terminal too (the verifier couldn't run) — stop polling and don't
+// treat it as a live/in-progress status.
+const terminalRunStatuses = new Set(['delivered', 'errored', 'failed', 'passed']);
 const liveStatusLabelKey = {
   planned: 'report.status.planned',
   repairing: 'report.status.repairing',

--- a/src/features/Verify/RunResult.tsx
+++ b/src/features/Verify/RunResult.tsx
@@ -76,13 +76,19 @@ const useStyles = createStyles(({ css, token }) => ({
 interface BadgeMeta {
   color: 'default' | 'success' | 'error' | 'warning';
   icon: typeof Check;
-  key: 'pending' | 'failed' | 'repairing' | 'passed';
+  key: 'pending' | 'failed' | 'errored' | 'repairing' | 'passed';
 }
 
 const phaseToResult: Record<DockPhase, { badge: BadgeMeta; subKey: string } | null> = {
   draft: {
     badge: { color: 'default', icon: Shield, key: 'pending' },
     subKey: 'result.pending.sub',
+  },
+  errored: {
+    // Warning, not error: the verifier couldn't run, so the delivery was never
+    // judged — never render it as a failed check.
+    badge: { color: 'warning', icon: Info, key: 'errored' },
+    subKey: 'result.errored.sub',
   },
   failed: {
     badge: { color: 'error', icon: X, key: 'failed' },

--- a/src/features/Verify/utils.test.ts
+++ b/src/features/Verify/utils.test.ts
@@ -7,6 +7,9 @@ describe('phaseFromStatus', () => {
     expect(phaseFromStatus('planned')).toBe('draft');
     expect(phaseFromStatus('verifying')).toBe('verifying');
     expect(phaseFromStatus('failed')).toBe('failed');
+    // `errored` is a terminal, non-pass phase of its own — never `idle` (which
+    // would drop the checker body and read as still-pending).
+    expect(phaseFromStatus('errored')).toBe('errored');
     expect(phaseFromStatus('repairing')).toBe('repairing');
     expect(phaseFromStatus('passed')).toBe('passed');
     expect(phaseFromStatus('delivered')).toBe('passed');

--- a/src/features/Verify/utils.ts
+++ b/src/features/Verify/utils.ts
@@ -3,7 +3,16 @@ import type { VerifyCheckItem } from '@lobechat/types';
 import type { VerifyStatus } from '@/database/models/agentOperation';
 import type { VerifyCheckResultItem } from '@/database/schemas/verify';
 
-export type DockPhase = 'idle' | 'draft' | 'verifying' | 'failed' | 'repairing' | 'passed';
+export type DockPhase =
+  | 'idle'
+  | 'draft'
+  | 'verifying'
+  | 'failed'
+  // The verifier could not run (infra error) — a terminal, non-pass state that
+  // is NOT a delivery failure. Rendered distinctly so it never reads as "failed".
+  | 'errored'
+  | 'repairing'
+  | 'passed';
 
 /** Map the persisted rollup status to the dock's phase state machine. */
 export const phaseFromStatus = (status: VerifyStatus | null | undefined): DockPhase => {
@@ -19,6 +28,9 @@ export const phaseFromStatus = (status: VerifyStatus | null | undefined): DockPh
     }
     case 'repairing': {
       return 'repairing';
+    }
+    case 'errored': {
+      return 'errored';
     }
     case 'passed':
     case 'delivered': {
@@ -84,6 +96,7 @@ export const phaseCardBackground = (
     }
     case 'draft':
     case 'verifying':
+    case 'errored':
     case 'repairing': {
       return glow(theme.colorWarning);
     }


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Related to LOBE-11376 (Part 2). Part 1 (the crash root-cause) is #16693.

#### 🔀 Description of Change

Adds an `errored` state so a verifier that **could not run** is never reported as a delivery that **failed verification**.

**Problem.** Any agent-verifier startup failure (no operation id, spawn throw, or terminating without a verdict) was written as `status: 'failed' + verdict: 'uncertain'`. The rollup treats that as a genuine failure, so the task creator gets `Delivery did not pass verification` and an **auto-repair round re-runs an already-correct delivery** — even though the delivery was never actually evaluated. (In the reported case the verifier crashed on a jsonb query before it ever started; over the last window, 49 runs were false-failed and 38 kicked off wasteful repair loops.)

**Fix.** Infra/verifier failures are now recorded as `status: 'errored'` (no verdict):

- `recompute` rolls up to run status `errored` only when no required check genuinely failed; a real `failed` still dominates (delivery gates + repairs as before).
- `errored` checks are excluded from the auto-repair set.
- `driveTaskFromVerify` pauses the task with a **non-accusatory** brief and a creator callback that says verification could not run — never that the delivery failed. No report card is generated for an errored run.
- The existing LLM-judge and structural-evidence gates are unchanged: a verifier that *ran* and judged the delivery short still `failed`s and gates/repairs.

`errored` is added to both the check-result and run-status enums (and the twin `agent_operations.verify_status` set, kept in sync to avoid drift). All three are `text` columns with a TS-level enum — **no migration needed**.

> Follow-up (noted on LOBE-11376): bounded auto-retry of the verifier on `errored` before pausing for a human. This PR delivers the classification + correct routing; retry is additive on top.

#### 🧪 How to Test

- [x] Tested locally

`bun run type-check` clean across the monorepo. Verify service suite green (10 files / 49 tests), including new coverage:
- `statusService.recompute.test.ts` — errored rolls up to `errored`; a genuine `failed` dominates; a running sibling keeps `verifying`; all-pass → `passed`.
- `driveTaskFromVerify.test.ts` — `errored` pauses with a non-accusatory brief and a creator message that never says the delivery "did not pass".
- `verifierTerminal.test.ts` — updated: a verifier terminating without a verdict is recorded `errored` (no verdict).

- [x] Added/updated tests