### PR TITLE
🐛 Fix floating chat panel expand offset

### DIFF
--- a/src/features/FloatingChatPanel/HoverExpandBar.tsx
+++ b/src/features/FloatingChatPanel/HoverExpandBar.tsx
@@ -69,11 +69,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 }));
 
 export interface HoverExpandBarProps {
+  bottomOffset?: number;
   onExpand: () => void;
   visible: boolean;
 }
 
-const HoverExpandBar = memo<HoverExpandBarProps>(({ visible, onExpand }) => {
+const HoverExpandBar = memo<HoverExpandBarProps>(({ bottomOffset = 0, visible, onExpand }) => {
   const { t } = useTranslation('chat');
   const s = styles;
 
@@ -82,6 +83,7 @@ const HoverExpandBar = memo<HoverExpandBarProps>(({ visible, onExpand }) => {
       aria-hidden={!visible}
       className={`${s.bar} ${visible ? s.visible : s.hidden}`}
       data-testid="floating-chat-panel-hover-bar"
+      style={bottomOffset > 0 ? { insetBlockEnd: `calc(100% + ${bottomOffset}px)` } : undefined}
     >
       <button
         className={s.trigger}

--- a/src/features/FloatingChatPanel/InputRow.test.tsx
+++ b/src/features/FloatingChatPanel/InputRow.test.tsx
@@ -2,9 +2,15 @@
  * @vitest-environment happy-dom
  */
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import InputRow from './InputRow';
+
+const mockConversationState = vi.hoisted(() => ({
+  current: {
+    chatInputOverlayHeight: 0,
+  },
+}));
 
 vi.mock('@/features/Conversation', () => ({
   ChatInput: ({
@@ -31,11 +37,23 @@ vi.mock('@/features/Conversation', () => ({
   ),
 }));
 
+vi.mock('@/features/Conversation/store', () => ({
+  inputSelectors: {
+    chatInputOverlayHeight: (s: { chatInputOverlayHeight: number }) => s.chatInputOverlayHeight,
+  },
+  useConversationStore: (selector: (s: { chatInputOverlayHeight: number }) => unknown) =>
+    selector(mockConversationState.current),
+}));
+
 vi.mock('@lobehub/ui', () => ({
   Icon: ({ icon }: { icon: () => void }) => <span data-testid="icon">{icon.name}</span>,
 }));
 
 describe('FloatingChatPanel InputRow', () => {
+  beforeEach(() => {
+    mockConversationState.current.chatInputOverlayHeight = 0;
+  });
+
   it('renders ChatInput in compact mode with empty actions and no control bar while collapsed', () => {
     render(<InputRow isCollapsed onExpand={() => {}} />);
     const input = screen.getByTestId('chat-input');
@@ -84,6 +102,24 @@ describe('FloatingChatPanel InputRow', () => {
 
     fireEvent.blur(row, { relatedTarget: screen.getByTestId('outside') });
     expect(bar.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('offsets the expand bar above the measured chat input overlay', () => {
+    mockConversationState.current.chatInputOverlayHeight = 44;
+    render(<InputRow isCollapsed onExpand={() => {}} />);
+
+    const row = screen.getByTestId('floating-chat-panel-input-row');
+    fireEvent.focus(row);
+
+    expect(screen.getByTestId('floating-chat-panel-hover-bar').style.insetBlockEnd).toBe(
+      'calc(100% + 44px)',
+    );
+  });
+
+  it('keeps the default expand bar position when no chat input overlay is present', () => {
+    render(<InputRow isCollapsed onExpand={() => {}} />);
+
+    expect(screen.getByTestId('floating-chat-panel-hover-bar').style.insetBlockEnd).toBe('');
   });
 
   it('keeps the expand bar hidden while the panel is already expanded', () => {

--- a/src/features/FloatingChatPanel/InputRow.tsx
+++ b/src/features/FloatingChatPanel/InputRow.tsx
@@ -5,6 +5,7 @@ import { type FocusEvent, memo, useCallback, useEffect, useRef, useState } from 
 import { flushSync } from 'react-dom';
 
 import { ChatInput } from '@/features/Conversation';
+import { inputSelectors, useConversationStore } from '@/features/Conversation/store';
 
 import HoverExpandBar from './HoverExpandBar';
 
@@ -78,6 +79,7 @@ const InputRow = memo<InputRowProps>(({ isCollapsed, onExpand }) => {
   const [renderedCollapsed, setRenderedCollapsed] = useState(isCollapsed);
   const [focused, setFocused] = useState(false);
   const focusedRef = useRef(false);
+  const overlayHeight = useConversationStore(inputSelectors.chatInputOverlayHeight);
 
   useEffect(() => {
     if (renderedCollapsed === isCollapsed) return;
@@ -113,7 +115,11 @@ const InputRow = memo<InputRowProps>(({ isCollapsed, onExpand }) => {
         onBlur={handleBlur}
         onFocus={handleFocus}
       >
-        <HoverExpandBar visible={isCollapsed && focused} onExpand={onExpand} />
+        <HoverExpandBar
+          bottomOffset={overlayHeight}
+          visible={isCollapsed && focused}
+          onExpand={onExpand}
+        />
         <div className={s.surface}>
           <ChatInput
             allowExpand={false}

--- a/src/features/FloatingChatPanel/index.test.tsx
+++ b/src/features/FloatingChatPanel/index.test.tsx
@@ -132,6 +132,20 @@ vi.mock('@/features/Conversation', () => ({
   },
 }));
 
+const mockConversationState = vi.hoisted(() => ({
+  current: {
+    chatInputOverlayHeight: 0,
+  },
+}));
+
+vi.mock('@/features/Conversation/store', () => ({
+  inputSelectors: {
+    chatInputOverlayHeight: (s: { chatInputOverlayHeight: number }) => s.chatInputOverlayHeight,
+  },
+  useConversationStore: (selector: (s: { chatInputOverlayHeight: number }) => unknown) =>
+    selector(mockConversationState.current),
+}));
+
 vi.mock('@/routes/(main)/agent/features/Conversation/useActionsBarConfig', () => ({
   useActionsBarConfig: () => ({ assistant: {}, user: {} }),
 }));


### PR DESCRIPTION
## Summary

- Offset the floating chat panel expand affordance by the measured chat input overlay height.
- Reuse `chatInputOverlayHeight` so `OpStatusTray`, todo progress, and queue trays all reserve space through the same geometry signal.
- Add regression coverage for both overlay-present and overlay-absent positions.

## Root Cause

The floating panel expand affordance sat at the input row top edge, while `OpStatusTray` renders as a measured floating overlay above the same chat input. Raising z-index only changed hit testing; it did not prevent the two surfaces from occupying the same position.

## Validation

- `bunx vitest run --silent='passed-only' src/features/FloatingChatPanel/InputRow.test.tsx src/features/FloatingChatPanel/index.test.tsx`\n- `bunx eslint src/features/FloatingChatPanel/HoverExpandBar.tsx src/features/FloatingChatPanel/InputRow.tsx src/features/FloatingChatPanel/InputRow.test.tsx src/features/FloatingChatPanel/index.test.tsx`