### PR TITLE
💄 style(chat): fold a non-latest finished turn whole under the 已处理 header

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -380,6 +380,62 @@ describe('Group', () => {
     expect(screen.queryByTestId('answer-segment')).not.toBeInTheDocument();
   });
 
+  it('folds a non-latest finished turn whole — final answer collapses into the fold too', () => {
+    render(
+      <Group
+        enableProcessFold
+        id="assistant-1"
+        isLatestItem={false}
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: 'Running the checks.',
+            id: 'block-1',
+            tools: [
+              { apiName: 'bash', id: 'tool-1', result: { content: 'ok' } } as any,
+              { apiName: 'bash', id: 'tool-2', result: { content: 'ok' } } as any,
+            ],
+          }),
+          blk({ content: 'Here is the final answer.', id: 'block-2' }),
+        ]}
+      />,
+    );
+
+    const fold = screen.getByTestId('process-fold');
+    const answer = screen.getByTestId('answer-segment');
+    // The final answer renders INSIDE the fold, not as a visible sibling.
+    expect(fold.contains(answer)).toBe(true);
+    expect(fold.contains(screen.getByTestId('workflow-segment'))).toBe(true);
+  });
+
+  it('keeps the latest finished turn’s final answer visible outside the fold', () => {
+    render(
+      <Group
+        enableProcessFold
+        isLatestItem
+        id="assistant-1"
+        messageIndex={0}
+        blocks={[
+          blk({
+            content: 'Running the checks.',
+            id: 'block-1',
+            tools: [
+              { apiName: 'bash', id: 'tool-1', result: { content: 'ok' } } as any,
+              { apiName: 'bash', id: 'tool-2', result: { content: 'ok' } } as any,
+            ],
+          }),
+          blk({ content: 'Here is the final answer.', id: 'block-2' }),
+        ]}
+      />,
+    );
+
+    const fold = screen.getByTestId('process-fold');
+    const answer = screen.getByTestId('answer-segment');
+    // Latest turn: the answer stays out of the fold so it reads without expanding.
+    expect(fold.contains(answer)).toBe(false);
+    expect(fold.contains(screen.getByTestId('workflow-segment'))).toBe(true);
+  });
+
   it('keeps assistant runtime errors outside the workflow collapse', () => {
     const { container } = render(
       <Group

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -553,13 +553,13 @@ const Group = memo<GroupChildrenProps>(
       );
     };
 
-    // Codex-style turn folding: once the turn's op has ended, fold its whole
-    // process (reasoning + tools + intermediate prose) under a single "已处理
-    // {duration}" header, leaving the final answer always visible. The latest
-    // turn folds only after a final answer exists; still-generating turns render
-    // in full.
+    // Codex-style turn folding: once the turn's op has ended, fold it under a
+    // single "已处理 {duration}" header. A non-latest turn folds *whole* — its
+    // final answer collapses in too, so scrolled-past turns read as one compact
+    // row. The latest turn only folds its process and keeps the final answer
+    // visible (so a just-finished reply stays readable); still-generating turns
+    // render in full.
     const { processSegments, finalSegments } = splitFinalAnswer(segments);
-    const processStepCount = countFoldedProcessSteps(processSegments);
     const foldProcess = shouldFoldProcess({
       enabled: enableProcessFold,
       hasFinalAnswer: hasRenderableFinalAnswer(finalSegments),
@@ -568,6 +568,12 @@ const Group = memo<GroupChildrenProps>(
       operationEnded: !hasActiveOperation,
       processSegments,
     });
+
+    // Non-latest turns collapse everything; the latest turn keeps its final
+    // answer out of the fold.
+    const foldedSegments = isLatestItem ? processSegments : segments;
+    const visibleSegments = isLatestItem ? finalSegments : [];
+    const processStepCount = countFoldedProcessSteps(foldedSegments);
 
     const durationText =
       turnDurationMs >= 1000 ? formatReasoningDuration(turnDurationMs) : undefined;
@@ -579,12 +585,12 @@ const Group = memo<GroupChildrenProps>(
             <>
               <ProcessFold durationText={durationText} stepCount={processStepCount}>
                 <Flexbox gap={8}>
-                  {processSegments.map((segment) =>
+                  {foldedSegments.map((segment) =>
                     renderSegment(segment, segments.indexOf(segment)),
                   )}
                 </Flexbox>
               </ProcessFold>
-              {finalSegments.map((segment) => renderSegment(segment, segments.indexOf(segment)))}
+              {visibleSegments.map((segment) => renderSegment(segment, segments.indexOf(segment)))}
             </>
           ) : (
             <>


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

With the **fold finished turn** lab flag (`enableFoldFinishedTurn`) on, `splitFinalAnswer` always carved the final answer out of the fold — so a scrolled-past (non-latest) agent turn still rendered its full final answer inline, and the "fold everything except the last turn" effect read as broken.

This folds a **non-latest** finished turn **whole**: its final answer collapses into the `已处理 / 共运行 N 步` header too, so past turns read as one compact row. The **latest** turn is unchanged — it still folds only its process and keeps the final answer visible so a just-finished reply stays readable.

Scoped to the fold render layer in `Group.tsx` (`foldedSegments` / `visibleSegments` gated on `isLatestItem`); no change to block partitioning or workflow segmentation.

Edge: a pure-text non-latest turn (no tools/reasoning) still does **not** fold — `shouldFoldProcess` requires a workflow segment, so there is no "process" to hide behind a `共运行 N 步` header.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Unit: `Group.test.tsx` adds two cases — a non-latest finished turn folds its final answer *inside* the fold; the latest turn keeps it *outside*. 16/16 pass.
- E2E (Electron, real Claude Code multi-turn topic): non-latest turn collapses to a single `共运行 65 步 ▶` header (answer hidden), latest turn keeps `共运行 162 步` answer visible; expanding restores the full hidden process; an HMR A/B reverting the two lines reproduces the old inline-answer behavior.
- Verify report: https://app.lobehub.com/verify/30ec376b-092d-4852-83fd-4d15f1a9ff3b

#### 📸 Screenshots / Videos

| Before (answer of non-latest turn stays inline) | After (non-latest turn folds whole) |
| --- | --- |
| non-latest turn's final answer rendered above the next user bubble | non-latest turn = one `共运行 N 步` header, latest turn keeps its answer |

See the verify report above for the rendered before/after evidence.

#### 📝 Additional Information

Behavior only applies when the `enableFoldFinishedTurn` lab flag is enabled (Settings → Advanced → Labs); default off.