### PR TITLE
⚡️ perf(workflow): limit memory extraction concurrency

### DIFF
--- a/apps/server/src/services/memory/userMemory/extract.ts
+++ b/apps/server/src/services/memory/userMemory/extract.ts
@@ -2712,6 +2712,20 @@ const WORKFLOW_PATHS = {
   users: '/api/workflows/memory-user-memory/pipelines/chat-topic/process-users',
 } as const;
 
+const PROCESS_USERS_FLOW_CONTROL = {
+  key: 'memory-user-memory.pipelines.chat-topic.process-users',
+  parallelism: 1,
+  ratePerSecond: 1,
+} satisfies FlowControl;
+
+// NOTICE: Trigger-side flow control is required for initial workflow delivery.
+// A serve() flowControl setting alone is applied after the run starts, so it cannot prevent
+// many process-user-topics runs from entering execution at the same time.
+const PROCESS_USER_TOPICS_FLOW_CONTROL = {
+  key: 'memory-user-memory.pipelines.chat-topic.process-user-topics',
+  parallelism: 25,
+} satisfies FlowControl;
+
 const getWorkflowUrl = (path: string, baseUrl: string) => {
   const url = new URL(path, baseUrl);
 
@@ -2751,7 +2765,12 @@ export class MemoryExtractionWorkflowService {
     }
 
     const url = getWorkflowUrl(WORKFLOW_PATHS.users, payload.baseUrl);
-    return this.getClient().trigger({ body: payload, headers: options?.extraHeaders, url });
+    return this.getClient().trigger({
+      body: payload,
+      flowControl: PROCESS_USERS_FLOW_CONTROL,
+      headers: options?.extraHeaders,
+      url,
+    });
   }
 
   static triggerHourly(
@@ -2777,6 +2796,7 @@ export class MemoryExtractionWorkflowService {
     const url = getWorkflowUrl(WORKFLOW_PATHS.userTopics, payload.baseUrl);
     return this.getClient().trigger({
       body: payload,
+      flowControl: PROCESS_USER_TOPICS_FLOW_CONTROL,
       headers: options?.extraHeaders,
       url,
     });
@@ -2796,13 +2816,11 @@ export class MemoryExtractionWorkflowService {
       body: payload,
       flowControl: {
         key: `memory-user-memory.pipelines.chat-topic.process-topics.user.${userId}`,
-        // NOTICE: if modified the parallelism of
-        // src/server/workflows-hono/memory-user-memory/workflows/processTopics.ts
-        // or added new memory layer, make sure to update the number below.
-        //
-        // Currently, CEPA (context, experience, preference, activity) + identity = 5 layers.
-        // and since identity requires sequential processing, we set parallelism to 5.
-        parallelism: 5,
+        // NOTICE: Each process-topics workflow currently invokes topic workflows sequentially.
+        // Parallelism 20 therefore bounds each user's active topic extraction workflows to 20.
+        // If process-topics changes back to parallel per-topic invoke, divide this number by
+        // the per-batch topic concurrency to preserve the same per-user topic budget.
+        parallelism: 20,
       },
       headers: options?.extraHeaders,
       url,

--- a/src/server/workflows-hono/memory-user-memory/index.ts
+++ b/src/server/workflows-hono/memory-user-memory/index.ts
@@ -6,8 +6,11 @@ import { hourlyWorkflowHandler, hourlyWorkflowOptions } from './workflows/hourly
 import { personaUpdateHandler } from './workflows/personaUpdate';
 import { processTopicWorkflow } from './workflows/processTopic';
 import { processTopicsHandler } from './workflows/processTopics';
-import { processUsersHandler } from './workflows/processUsers';
-import { processUserTopicsHandler } from './workflows/processUserTopics';
+import { processUsersHandler, processUsersWorkflowOptions } from './workflows/processUsers';
+import {
+  processUserTopicsHandler,
+  processUserTopicsWorkflowOptions,
+} from './workflows/processUserTopics';
 
 const app = new Hono();
 
@@ -26,12 +29,18 @@ app.post(
 
 app.post(
   '/pipelines/chat-topic/process-users',
-  serve(processUsersHandler, { qstashClient: createWorkflowQstashClient() }),
+  serve(processUsersHandler, {
+    ...processUsersWorkflowOptions,
+    qstashClient: createWorkflowQstashClient(),
+  }),
 );
 
 app.post(
   '/pipelines/chat-topic/process-user-topics',
-  serve(processUserTopicsHandler, { qstashClient: createWorkflowQstashClient() }),
+  serve(processUserTopicsHandler, {
+    ...processUserTopicsWorkflowOptions,
+    qstashClient: createWorkflowQstashClient(),
+  }),
 );
 
 app.post(

--- a/src/server/workflows-hono/memory-user-memory/workflows/processUserTopics.ts
+++ b/src/server/workflows-hono/memory-user-memory/workflows/processUserTopics.ts
@@ -19,6 +19,8 @@ import { assertMemoryWorkflowContextAllowed } from './runGuard';
 const TOPIC_PAGE_SIZE = 50;
 const TOPIC_BATCH_SIZE = 4;
 const WORKFLOW_PATH = 'api/workflows/memory-user-memory/pipelines/chat-topic/process-user-topics';
+const PROCESS_USER_TOPICS_FLOW_CONTROL_KEY =
+  'memory-user-memory.pipelines.chat-topic.process-user-topics';
 
 const { upstashWorkflowExtraHeaders } = parseMemoryExtractionConfig();
 
@@ -168,4 +170,27 @@ export const processUserTopicsHandler = async (
   }
 
   return { processedUsers: params.userIds.length };
+};
+
+/**
+ * Shared flow-control settings for active user-topic workers.
+ *
+ * Use when:
+ * - Serving process-user-topics workflow runs through Upstash Workflow
+ * - Keeping memory extraction bounded to 25 concurrently active users
+ *
+ * Expects:
+ * - Trigger-side calls use the same key to throttle initial workflow delivery
+ *
+ * Returns:
+ * - Upstash Workflow serve options that limit process-user-topics executions
+ */
+export const processUserTopicsWorkflowOptions = {
+  // NOTICE: This key intentionally omits userId. Adding userId would create one independent
+  // bucket per user and would not cap total database pressure; the global key keeps at most
+  // 25 user-topic workers active across all users.
+  flowControl: {
+    key: PROCESS_USER_TOPICS_FLOW_CONTROL_KEY,
+    parallelism: 25,
+  },
 };

--- a/src/server/workflows-hono/memory-user-memory/workflows/processUsers.ts
+++ b/src/server/workflows-hono/memory-user-memory/workflows/processUsers.ts
@@ -18,6 +18,7 @@ import { serializeWorkflowCursor } from './utils';
 const USER_PAGE_SIZE = 50;
 const USER_BATCH_SIZE = 10;
 const WORKFLOW_PATH = 'api/workflows/memory-user-memory/pipelines/chat-topic/process-users';
+const PROCESS_USERS_FLOW_CONTROL_KEY = 'memory-user-memory.pipelines.chat-topic.process-users';
 
 const { upstashWorkflowExtraHeaders } = parseMemoryExtractionConfig();
 
@@ -117,4 +118,28 @@ export const processUsersHandler = async (
     nextCursor: cursor ? cursor.id : null,
     processedUsers: ids.length,
   };
+};
+
+/**
+ * Shared flow-control settings for the process-users workflow.
+ *
+ * Use when:
+ * - Serving process-users workflow runs through Upstash Workflow
+ * - Keeping hourly/user-triggered process-users runs from executing unbounded work concurrently
+ *
+ * Expects:
+ * - Trigger-side workflow calls use the same key to throttle initial workflow delivery
+ *
+ * Returns:
+ * - Upstash Workflow serve options that limit follow-up workflow steps
+ */
+export const processUsersWorkflowOptions = {
+  // NOTICE: Serve-side flow control only applies after a workflow run has entered Upstash
+  // Workflow execution. triggerProcessUsers must pass the same key so initial deliveries
+  // are throttled before many process-users runs can start at once.
+  flowControl: {
+    key: PROCESS_USERS_FLOW_CONTROL_KEY,
+    parallelism: 1,
+    ratePerSecond: 1,
+  },
 };


### PR DESCRIPTION
# Pull Request

## 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

## 🔗 Related Links

- Linear / GitHub issue: N/A
- Related PRs: N/A
- Reference docs / code / articles: Upstash Workflow flowControl behavior verified locally with QStash dev server.

## 🔀 Description of Change

Limit memory user-memory extraction fan-out with Upstash Workflow flow control:

- throttle `process-users` root scheduling with a shared global key
- cap active `process-user-topics` workers globally at 25
- raise per-user `process-topics` flow control to 20 active topic workflows
- apply flow control on both `WorkflowClient.trigger()` and `serve()` paths where initial delivery throttling matters

## 🧭 Key Decisions / Non-goals

- The `process-user-topics` flow-control key intentionally does not include `userId`. A user-scoped key creates one independent bucket per user and does not cap total database pressure.
- The per-user topic limit remains user-scoped on `process-topics.user.${userId}`, so each user's topic extraction budget is bounded separately.
- This PR does not migrate the existing `WorkflowClient.trigger()` fan-out to `context.invoke(...)`; it uses queue-level flow control as the lower-risk operational guard.

## 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

### Automated Tests

- `pnpm --dir lobehub exec eslint src/server/workflows-hono/memory-user-memory/index.ts src/server/workflows-hono/memory-user-memory/workflows/processUsers.ts src/server/workflows-hono/memory-user-memory/workflows/processUserTopics.ts apps/server/src/services/memory/userMemory/extract.ts --no-warn-ignored`

### Manual Verification

- Ran `pnpm qstash` with the local QStash dev server.
- Verified `serve(..., { flowControl })` alone does not throttle initial workflow deliveries.
- Verified `WorkflowClient.trigger({ flowControl })` with the same key throttles concurrent workflow delivery.
- Verified user-scoped `process-user-topics.user.${userId}` keys allow every distinct user bucket to run concurrently, so a global key is required for total user-worker pressure.

### Post-Deploy Verification

- Watch Upstash Workflow/QStash delivery for `memory-user-memory.pipelines.chat-topic.process-user-topics` and confirm active workers stay near or below 25.
- Watch database active connections, CPU, lock waits, and memory extraction latency during hourly runs.

## 📸 Screenshots / Videos

N/A

## 🚀 Rollout / Deployment Checklist

- [ ] Environment variables: N/A
- [ ] Redis / Edge Config / feature flags: N/A
- [ ] Database migration or data backfill: N/A
- [ ] Third-party console changes: N/A
- [ ] Rollback plan: revert this PR or lower the flow-control parallelism values in a follow-up patch.

## 📝 Additional Information

N/A
