### PR TITLE
🐛 fix(worktree): never offer to remove the source worktree

### DIFF
--- a/src/features/ChatInput/ControlBar/WorktreeSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/WorktreeSwitcher.tsx
@@ -336,8 +336,15 @@ const getWorktreeBranch = (
 const isDisabled = (worktree: DeviceGitWorktreeListItem): boolean =>
   !!worktree.bare || !!worktree.prunable;
 
-const canRemoveWorktree = (worktree: DeviceGitWorktreeListItem): boolean =>
-  !worktree.current && !worktree.locked && !isDisabled(worktree);
+// The main/source worktree can never be removed (`git worktree remove <main>`
+// fails with "is a main working tree"), and when the agent runs on a linked
+// worktree it is listed with `current: false` — so exclude it by path too, not
+// just via the `current` flag, to avoid offering a delete that always errors.
+const canRemoveWorktree = (worktree: DeviceGitWorktreeListItem, sourcePath: string): boolean =>
+  !worktree.current &&
+  !worktree.locked &&
+  !isDisabled(worktree) &&
+  normalizeDisplayPath(worktree.path) !== normalizeDisplayPath(sourcePath);
 
 interface DirtyStatProps {
   status?: DeviceGitWorktreeListItem['status'];
@@ -494,7 +501,7 @@ const WorktreeSwitcher = memo<WorktreeSwitcherProps>(
                       );
                       const displayPath = getRelativeDisplayPath(worktree.path, sourcePath);
                       const disabled = isDisabled(worktree);
-                      const removable = canRemoveWorktree(worktree);
+                      const removable = canRemoveWorktree(worktree, sourcePath);
 
                       return (
                         <DropdownMenuItem

--- a/src/features/ChatInput/ControlBar/__tests__/WorktreeSwitcher.test.tsx
+++ b/src/features/ChatInput/ControlBar/__tests__/WorktreeSwitcher.test.tsx
@@ -230,6 +230,45 @@ describe('WorktreeSwitcher', () => {
     expect(messageErrorMock).not.toHaveBeenCalled();
   });
 
+  it('never offers to remove the source worktree even when it is not current', () => {
+    render(
+      <WorktreeSwitcher
+        isGithub
+        agentId="agent-1"
+        currentBranch="feat/current"
+        deviceId="device-1"
+        path="/repo-canary"
+        sourcePath="/repo"
+        worktrees={[
+          {
+            // The main/source worktree — listed as non-current because the agent
+            // runs on a linked worktree. `git worktree remove` would always fail.
+            branch: 'main',
+            current: false,
+            path: '/repo',
+            status: { added: 0, clean: true, deleted: 0, modified: 0, total: 0 },
+          },
+          {
+            branch: 'canary',
+            current: true,
+            path: '/repo-canary',
+            status: { added: 0, clean: true, deleted: 0, modified: 0, total: 0 },
+          },
+          {
+            branch: 'feature',
+            current: false,
+            path: '/repo-feature',
+            status: { added: 0, clean: true, deleted: 0, modified: 0, total: 0 },
+          },
+        ]}
+      />,
+    );
+
+    // Only the linked branch worktree is removable; the source and the current
+    // worktree are both excluded.
+    expect(screen.getAllByLabelText('workingDirectory.removeWorktreeAction')).toHaveLength(1);
+  });
+
   it('commits the selected worktree path as the working directory', () => {
     render(
       <WorktreeSwitcher


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up to #16704 (review finding). That PR relaxed the worktree-switcher delete guard to allow removing branch worktrees, which unintentionally exposed a delete action for the source/main worktree.

#### 🔀 Description of Change

When the agent runs on a linked worktree (`path=/repo-canary`, `sourcePath=/repo`), the repository's source/main worktree row is listed with `current: false` and is non-bare, so the relaxed `canRemoveWorktree` predicate now enables its trash button. But `git worktree remove <main>` always fails (`fatal: '<main>' is a main working tree`), so the menu offered a delete action that could only ever error for the source checkout.

Fix: exclude the source worktree by path (comparing normalized `sourcePath`) in `canRemoveWorktree`, in addition to the existing `current` flag — linked branch worktrees stay removable.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- With the agent on a linked worktree, open the switcher → the source/main worktree row no longer shows a delete action; other linked branch worktrees still do.
- Added `WorktreeSwitcher.test.tsx` case: source worktree listed as non-current is not offered for removal (only the linked branch worktree is).