### PR TITLE
💄 CC AskUserQuestion: fix selected-option color + bounce dock on approval

### DIFF
--- a/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion/OptionCard.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Intervention/AskUserQuestion/OptionCard.tsx
@@ -8,7 +8,10 @@ import { memo } from 'react';
 const styles = createStaticStyles(({ css, cssVar }) => ({
   // Card sits inline with the chat — no surrounding panel chrome. Hover
   // tints the row so the stack reads as clickable; selection swaps to a
-  // filled `colorPrimaryBg` so the pick is visually weighty.
+  // neutral filled row so the pick is visually weighty. We use `colorFill*`
+  // rather than `colorPrimaryBg` because LobeHub's default primary is a
+  // near-black neutral, which makes `colorPrimaryBg` render as a muddy black
+  // block; the selection signal instead rides the filled row + the checkmark.
   option: css`
     cursor: pointer;
 
@@ -54,10 +57,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     font-weight: 500;
   `,
   optionSelected: css`
-    background: ${cssVar.colorPrimaryBg};
+    background: ${cssVar.colorFillSecondary};
 
     &:hover {
-      background: ${cssVar.colorPrimaryBgHover};
+      background: ${cssVar.colorFill};
     }
   `,
 }));

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -44,6 +44,7 @@ import {
   reconstructUploadFilesFromQueue,
 } from '@/store/chat/slices/operation/types';
 import { type ChatStore, useChatStore } from '@/store/chat/store';
+import { notifyDesktopHumanApprovalRequired } from '@/store/chat/utils/desktopNotification';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 
 import { buildRunLifecycle } from '../../lifecycle/buildRunLifecycle';
@@ -1186,6 +1187,12 @@ export const executeHeterogeneousAgent = async (
             // so it's obvious from the topic list that this conversation is
             // blocked on the user, not still streaming.
             writeTopicStatus('waitingForHuman');
+            // Parity with the homogeneous approval paths (client / gateway /
+            // aiAgent): a CC AskUserQuestion now also bumps the dock badge and
+            // bounces the macOS dock. The helper is desktop-guarded and only
+            // requests attention while the window is hidden/unfocused, so it's
+            // a no-op when the user is already looking at the approval.
+            void notifyDesktopHumanApprovalRequired(get, context);
           } catch (err) {
             console.error('[HeterogeneousAgent] persist intervention pending failed:', err);
           }


### PR DESCRIPTION
## Summary

Two small UX fixes for the Claude Code **AskUserQuestion** approval card, split from the working-directory-metadata branch into their own PR.

### 1. Selected option looked like a black block
The selected option row used `colorPrimaryBg` / `colorPrimaryBgHover`. LobeHub's default primary is a near-black neutral, so those tokens resolve to a muddy black block rather than a readable highlight. Switched to neutral `colorFillSecondary` (hover `colorFill`), so the pick reads as a proper filled row while the primary-colored checkmark carries the selection accent.

- `packages/builtin-tool-claude-code/.../AskUserQuestion/OptionCard.tsx`

### 2. CC approval didn't bounce the macOS dock
The homogeneous approval paths (client / gateway / aiAgent) already call `notifyDesktopHumanApprovalRequired` to bump the dock badge and bounce the dock when a human approval becomes pending. The heterogeneous Claude Code path (`agent_intervention_request`) was the **only** one missing it, so a CC AskUserQuestion waited silently with no desktop attention cue. Now fires the same shared helper right after the intervention is stamped pending.

- `src/store/chat/.../hetero/heterogeneousAgentExecutor.ts`

The helper is desktop-guarded and only requests attention while the window is hidden/unfocused, so it's a no-op when the user is already looking at the card.

## Test plan
- [ ] Trigger a CC AskUserQuestion; confirm the selected option is a neutral filled row (not black) in dark + light themes.
- [ ] With the window unfocused, trigger a CC approval; confirm the macOS dock bounces + shows the badge; confirm no bounce when the window is focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)