### PR TITLE
🐛 fix(chat): keep every finished turn's final answer visible outside the fold

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx
@@ -380,7 +380,7 @@ describe('Group', () => {
     expect(screen.queryByTestId('answer-segment')).not.toBeInTheDocument();
   });
 
-  it('folds a non-latest finished turn whole — final answer collapses into the fold too', () => {
+  it('keeps a non-latest finished turn’s final answer visible outside the fold', () => {
     render(
       <Group
         enableProcessFold
@@ -403,8 +403,9 @@ describe('Group', () => {
 
     const fold = screen.getByTestId('process-fold');
     const answer = screen.getByTestId('answer-segment');
-    // The final answer renders INSIDE the fold, not as a visible sibling.
-    expect(fold.contains(answer)).toBe(true);
+    // Folding only ever collapses the process; the final answer stays a visible
+    // sibling for every turn, latest or not — never swallowed into the fold.
+    expect(fold.contains(answer)).toBe(false);
     expect(fold.contains(screen.getByTestId('workflow-segment'))).toBe(true);
   });
 

--- a/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/components/Group.tsx
@@ -553,13 +553,16 @@ const Group = memo<GroupChildrenProps>(
       );
     };
 
-    // Codex-style turn folding: once the turn's op has ended, fold it under a
-    // single "已处理 {duration}" header. A non-latest turn folds *whole* — its
-    // final answer collapses in too, so scrolled-past turns read as one compact
-    // row. The latest turn only folds its process and keeps the final answer
-    // visible (so a just-finished reply stays readable); still-generating turns
-    // render in full.
+    // Codex-style turn folding: once the turn's op has ended, fold its whole
+    // process (reasoning + tools + intermediate prose) under a single "已处理
+    // {duration}" header, leaving the final answer always visible — for every
+    // turn, latest or not. Folding must never swallow the final answer, since
+    // that is the turn's payload; only the process collapses. The latest turn
+    // is eligible only once its final answer exists (so a tool-only latest turn
+    // does not collapse into a lone header); still-generating turns render in
+    // full.
     const { processSegments, finalSegments } = splitFinalAnswer(segments);
+    const processStepCount = countFoldedProcessSteps(processSegments);
     const foldProcess = shouldFoldProcess({
       enabled: enableProcessFold,
       hasFinalAnswer: hasRenderableFinalAnswer(finalSegments),
@@ -568,12 +571,6 @@ const Group = memo<GroupChildrenProps>(
       operationEnded: !hasActiveOperation,
       processSegments,
     });
-
-    // Non-latest turns collapse everything; the latest turn keeps its final
-    // answer out of the fold.
-    const foldedSegments = isLatestItem ? processSegments : segments;
-    const visibleSegments = isLatestItem ? finalSegments : [];
-    const processStepCount = countFoldedProcessSteps(foldedSegments);
 
     const durationText =
       turnDurationMs >= 1000 ? formatReasoningDuration(turnDurationMs) : undefined;
@@ -585,12 +582,12 @@ const Group = memo<GroupChildrenProps>(
             <>
               <ProcessFold durationText={durationText} stepCount={processStepCount}>
                 <Flexbox gap={8}>
-                  {foldedSegments.map((segment) =>
+                  {processSegments.map((segment) =>
                     renderSegment(segment, segments.indexOf(segment)),
                   )}
                 </Flexbox>
               </ProcessFold>
-              {visibleSegments.map((segment) => renderSegment(segment, segments.indexOf(segment)))}
+              {finalSegments.map((segment) => renderSegment(segment, segments.indexOf(segment)))}
             </>
           ) : (
             <>


### PR DESCRIPTION
### 💡 Problem

With the *fold finished turn* lab feature on, `#16700` made a **non-latest** finished turn fold *whole* — its **final answer** (the turn's actual payload, e.g. a report) collapsed into the `已处理 / 共运行 N 步` header along with the process. Only the **latest** turn kept its answer visible.

Result: scrolling back through history shows rows of bare `共运行 N 步 ▶` headers with **no answer** — every past reply's content is hidden until you expand it one by one. The step count even included the answer block (e.g. `共运行 5 步` = 3 assistants + 2 tools, the report block counted in).

### 🔨 Fix

Folding is meant to hide the **process** (reasoning + tool calls), never the final answer. Drop the `isLatestItem ? … : segments` branching in `Group.tsx` so **every** turn — latest or not — folds only `processSegments` and always renders `finalSegments` as a visible sibling.

- `Group.tsx`: unify the fold render path; `processStepCount` now counts only the folded process.
- `Group.test.tsx`: rewrite the non-latest test to assert the final answer stays **outside** the fold (was asserting the old whole-fold behavior).

Behavior after: any finished turn shows `共运行 N 步 ▶` (process collapsed) with its report always visible below.

### ✅ Test

`bunx vitest run src/features/Conversation/Messages/AssistantGroup/components/Group.test.tsx` — 16 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)