### PR TITLE
⚡️ perf(workflow): configure memory topic parallelism

### DIFF
--- a/apps/server/src/globalConfig/parseMemoryExtractionConfig.test.ts
+++ b/apps/server/src/globalConfig/parseMemoryExtractionConfig.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { parseMemoryExtractionConfig } from './parseMemoryExtractionConfig';
+
+const WORKFLOW_PARALLELISM_ENV = 'MEMORY_USER_MEMORY_WORKFLOW_PROCESS_USER_TOPICS_PARALLELISM';
+
+const originalWorkflowParallelism = process.env[WORKFLOW_PARALLELISM_ENV];
+
+describe('parseMemoryExtractionConfig', () => {
+  afterEach(() => {
+    if (originalWorkflowParallelism === undefined) {
+      delete process.env[WORKFLOW_PARALLELISM_ENV];
+      return;
+    }
+
+    process.env[WORKFLOW_PARALLELISM_ENV] = originalWorkflowParallelism;
+  });
+
+  it('defaults process-user-topics workflow parallelism to 25', () => {
+    delete process.env[WORKFLOW_PARALLELISM_ENV];
+
+    expect(parseMemoryExtractionConfig().workflow?.processUserTopicsParallelism).toBe(25);
+  });
+
+  it('parses process-user-topics workflow parallelism from env', () => {
+    process.env[WORKFLOW_PARALLELISM_ENV] = '17';
+
+    expect(parseMemoryExtractionConfig().workflow?.processUserTopicsParallelism).toBe(17);
+  });
+
+  it('falls back to 25 when process-user-topics workflow parallelism env is invalid', () => {
+    process.env[WORKFLOW_PARALLELISM_ENV] = '0';
+
+    expect(parseMemoryExtractionConfig().workflow?.processUserTopicsParallelism).toBe(25);
+
+    process.env[WORKFLOW_PARALLELISM_ENV] = 'abc';
+
+    expect(parseMemoryExtractionConfig().workflow?.processUserTopicsParallelism).toBe(25);
+  });
+});

--- a/apps/server/src/globalConfig/parseMemoryExtractionConfig.ts
+++ b/apps/server/src/globalConfig/parseMemoryExtractionConfig.ts
@@ -16,6 +16,8 @@ const MEMORY_LAYERS: GlobalMemoryLayer[] = [
   'preference',
 ];
 
+const DEFAULT_WORKFLOW_PROCESS_USER_TOPICS_PARALLELISM = 25;
+
 const parseTokenLimitEnv = (value?: string) => {
   if (value === undefined) return undefined;
   const parsed = Number(value);
@@ -23,6 +25,15 @@ const parseTokenLimitEnv = (value?: string) => {
   if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
 
   return Math.floor(parsed);
+};
+
+const parsePositiveIntegerEnv = (value: string | undefined, fallback: number) => {
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed <= 0) return fallback;
+
+  return parsed;
 };
 
 // NOTICE:
@@ -77,6 +88,10 @@ export interface MemoryExtractionPrivateConfig {
     headers?: Record<string, string>;
   };
   whitelistUsers?: string[];
+  workflow?: {
+    /** Maximum active process-user-topics workflow workers across all users. */
+    processUserTopicsParallelism: number;
+  };
 }
 
 const parseGateKeeperAgent = (): MemoryAgentConfig => {
@@ -250,6 +265,10 @@ export const parseMemoryExtractionConfig = (): MemoryExtractionPrivateConfig => 
         ? Number(concurrencyRaw)
         : undefined
       : undefined;
+  const processUserTopicsParallelism = parsePositiveIntegerEnv(
+    process.env.MEMORY_USER_MEMORY_WORKFLOW_PROCESS_USER_TOPICS_PARALLELISM,
+    DEFAULT_WORKFLOW_PROCESS_USER_TOPICS_PARALLELISM,
+  );
 
   const whitelistUsers = process.env.MEMORY_USER_MEMORY_WHITELIST_USERS?.split(',')
     .filter(Boolean)
@@ -317,6 +336,9 @@ export const parseMemoryExtractionConfig = (): MemoryExtractionPrivateConfig => 
       headers: webhookHeaders,
     },
     whitelistUsers,
+    workflow: {
+      processUserTopicsParallelism,
+    },
   };
 };
 

--- a/apps/server/src/services/memory/userMemory/extract.ts
+++ b/apps/server/src/services/memory/userMemory/extract.ts
@@ -2718,13 +2718,17 @@ const PROCESS_USERS_FLOW_CONTROL = {
   ratePerSecond: 1,
 } satisfies FlowControl;
 
-// NOTICE: Trigger-side flow control is required for initial workflow delivery.
-// A serve() flowControl setting alone is applied after the run starts, so it cannot prevent
-// many process-user-topics runs from entering execution at the same time.
-const PROCESS_USER_TOPICS_FLOW_CONTROL = {
-  key: 'memory-user-memory.pipelines.chat-topic.process-user-topics',
-  parallelism: 25,
-} satisfies FlowControl;
+const getProcessUserTopicsFlowControl = (): FlowControl => {
+  const { workflow } = parseMemoryExtractionConfig();
+
+  return {
+    key: 'memory-user-memory.pipelines.chat-topic.process-user-topics',
+    // NOTICE: Trigger-side flow control is required for initial workflow delivery.
+    // A serve() flowControl setting alone is applied after the run starts, so it cannot prevent
+    // many process-user-topics runs from entering execution at the same time.
+    parallelism: workflow?.processUserTopicsParallelism ?? 25,
+  };
+};
 
 const getWorkflowUrl = (path: string, baseUrl: string) => {
   const url = new URL(path, baseUrl);
@@ -2796,7 +2800,7 @@ export class MemoryExtractionWorkflowService {
     const url = getWorkflowUrl(WORKFLOW_PATHS.userTopics, payload.baseUrl);
     return this.getClient().trigger({
       body: payload,
-      flowControl: PROCESS_USER_TOPICS_FLOW_CONTROL,
+      flowControl: getProcessUserTopicsFlowControl(),
       headers: options?.extraHeaders,
       url,
     });

--- a/src/server/workflows-hono/memory-user-memory/workflows/processUserTopics.ts
+++ b/src/server/workflows-hono/memory-user-memory/workflows/processUserTopics.ts
@@ -22,7 +22,7 @@ const WORKFLOW_PATH = 'api/workflows/memory-user-memory/pipelines/chat-topic/pro
 const PROCESS_USER_TOPICS_FLOW_CONTROL_KEY =
   'memory-user-memory.pipelines.chat-topic.process-user-topics';
 
-const { upstashWorkflowExtraHeaders } = parseMemoryExtractionConfig();
+const { upstashWorkflowExtraHeaders, workflow } = parseMemoryExtractionConfig();
 
 export const processUserTopicsHandler = async (
   context: WorkflowContext<MemoryExtractionPayloadInput>,
@@ -177,7 +177,7 @@ export const processUserTopicsHandler = async (
  *
  * Use when:
  * - Serving process-user-topics workflow runs through Upstash Workflow
- * - Keeping memory extraction bounded to 25 concurrently active users
+ * - Keeping memory extraction bounded to the configured active user worker limit
  *
  * Expects:
  * - Trigger-side calls use the same key to throttle initial workflow delivery
@@ -188,9 +188,9 @@ export const processUserTopicsHandler = async (
 export const processUserTopicsWorkflowOptions = {
   // NOTICE: This key intentionally omits userId. Adding userId would create one independent
   // bucket per user and would not cap total database pressure; the global key keeps at most
-  // 25 user-topic workers active across all users.
+  // the configured number of user-topic workers active across all users.
   flowControl: {
     key: PROCESS_USER_TOPICS_FLOW_CONTROL_KEY,
-    parallelism: 25,
+    parallelism: workflow?.processUserTopicsParallelism ?? 25,
   },
 };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #16498

#### 🔀 Description of Change

- Reads process-user-topics workflow parallelism from `MEMORY_USER_MEMORY_WORKFLOW_PROCESS_USER_TOPICS_PARALLELISM`.
- Keeps the default at `25` and falls back to `25` for invalid values.
- Applies the configured limit on both trigger-side and serve-side flow control using the same global key.
- Keeps the flow-control key user-agnostic so the limit caps total active user-topic workers instead of creating one bucket per user.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
pnpm --dir lobehub exec vitest run --silent='passed-only' 'apps/server/src/globalConfig/parseMemoryExtractionConfig.test.ts'\npnpm --dir lobehub exec eslint apps/server/src/globalConfig/parseMemoryExtractionConfig.ts apps/server/src/globalConfig/parseMemoryExtractionConfig.test.ts apps/server/src/services/memory/userMemory/extract.ts src/server/workflows-hono/memory-user-memory/workflows/processUserTopics.ts --no-warn-ignored\n```\n\n#### 📸 Screenshots / Videos\n\nN/A\n\n#### 📝 Additional Information\n\nThe global `process-user-topics` key is intentional. Adding userId to this key would create an independent flow-control bucket per user and would not protect shared database capacity during large fan-out runs.