### PR TITLE
📝 docs(ux): land tasks-list L2 audit findings into ux checklists

### DIFF
--- a/.agents/skills/ux-audit/references/example/tasks.md
+++ b/.agents/skills/ux-audit/references/example/tasks.md
@@ -20,7 +20,8 @@ citing).
 
 **Surface class:** agent task board / issue-tracker list — benchmark against Linear / Asana /
 GitHub Issues (list · kanban · grouping · priority · assignee · **live status** · bulk ops).
-**Layers run:** L1 (static / code) ✅ — everything below. L2 (visual) / L3 (dynamic + CLS)
+**Layers run:** L1 (static / code) ✅ — §1–§4 below. L2 (visual) ✅ — a **re-verify pass on a later
+branch** (user-supplied screenshot of the populated list), see the **§6 addendum**. L3 (dynamic + CLS)
 ⏳ not yet run — see §5.
 
 **Load-bearing files:** `features/AgentTasks/AgentTaskList/{AgentTasksPage,TaskList,KanbanBoard,
@@ -175,3 +176,40 @@ create/clear-filters affordance. _Remedy:_ refresh the list-level status on the 
   - Let a running task complete while the list is open → **confirm gap L⑥** (stale status, no indicator).
   - Fail a context-menu status change / kanban drag / create → **confirm gap L④** (silent revert).
   - **Measure list CLS/LCP** across skeleton→content and the up-to-50 per-row detail fetches (gap L②).
+
+## 6 — L2 visual addendum (2026-07, later branch)
+
+A **re-verify pass** on a later branch, anchored on a user-supplied screenshot of the **populated**
+list (a persistent create composer holding a long draft, above a "进行中 1" status group with a single
+cron task). Two things it establishes that the original L1-only run could not:
+
+**First, the original 🔴 L① is fixed.** `TaskList` now wraps its content in `AsyncBoundary` with
+`error` / `isLoading` / `onRetry`, and `AgentTasksPage.tsx:67-72` keeps the SWR handle and threads
+`error`/`mutate` into it (`TaskList.tsx:300-316`), gating error **ahead of** empty. A failed list
+fetch now shows Retry instead of a permanent skeleton — exactly the remedy L① asked for. **Don't
+regress the call-site read.**
+
+**Second, two gaps only the render exposes** (both landed as new `ux` rules — Read **§1.11** and
+**§1.12**):
+
+- **V1 🟠 — the persistent composer buries the list (Read §1.11, Center Stage).** `AgentTasksPage.tsx:165`
+  renders `CreateTaskInlineEntry` whenever `!inlineCollapsed`, and its Lexical editor grows to content
+  height with **no `max-height` / scroll** (`CreateTaskInlineEntry.tsx:213-231`). A long instruction draft
+  fills \~half the viewport and pushes the "进行中" group + every task **below the fold** — on a populated
+  board the composer out-weighs the records. _Remedy:_ cap the editor height; default to collapsed once
+  `!isEmptyHero`.
+- **V2 🟠 — a scheduled task is mislabeled "进行中 / In Progress" (Read §1.12, consistency-is-semantic).**
+  `listViewOptions.ts:107` folds `scheduled → running` and the group header renders
+  `taskDetail.status.running` (`:232,237`), so a daily-cron task idle until 06:00 sits under "In Progress"
+  though its own row reads "每天 06:00 运行". The group label asserts a state the task isn't in. _Remedy:_
+  a distinct "Scheduled" group ranked above running.
+- **V3 🟡 — the latest-activity sub-line duplicates the task name.** `AgentTaskItem.tsx:209` →
+  `TaskLatestActivity` renders " 主题 #5: <title>" (`TaskLatestActivity.tsx:13-24`); for a recurring task the
+  topic title equals `task.name`, so the row prints the name twice. _Remedy:_ suppress the sub-line when it
+  equals `task.name`, or show last-run time / result instead. (Instance of interface-details duplication —
+  ❌ example, not a new rule.)
+
+Still open from §3 at re-verify (unchanged): L② (client-side sort/group over the 50-cap + per-row detail
+fan-out), L④ (silent create failure — `handleSubmit`'s `if (result)` has no error toast,
+`CreateTaskInlineEntry.tsx:148-170`), L⑤ (create draft in local `useState`, not persisted), L⑥ (in-list
+`Empty` has no CTA / no no-match variant; list-level status not refreshed by the per-row poll).

--- a/.agents/skills/ux/SKILL.md
+++ b/.agents/skills/ux/SKILL.md
@@ -111,6 +111,8 @@ The one-screen scan. Each line links back to a module above for the full rule + 
 - [ ] A surface with many navigable entries (a big settings area, a long list) offers search / filter / jump, not browse-only — named as a class norm so an absent box is caught.
 - [ ] Marketplace / registry browse cards carry owned/installed state on the tile (not only on the detail) and trust/verified badges via one card contract, consistent across sibling registries; contribute leads to an in-app submit, not an external repo.
 - [ ] A sidebar / nav / master-detail **list row** composes the canonical `NavItem` (+ `Accordion` / `GroupedAccordion` for groups, `Block variant='filled'` for active), not a hand-rolled `<div>`/`<button>`/`<input>` + bespoke CSS — else the hover/active highlight misaligns from the content box, content bleeds to the panel edge, the search/rename/action-reveal drift from every sibling panel, and the list stays a flat ungrouped dump. Grep `NavItem` before building.
+- [ ] A persistent create/compose affordance above a list is the hero only while the list is **empty**; once populated it doesn't bury the records — cap the editor height (max-height + internal scroll) and/or default it to collapsed when the list has data, so the records keep Center Stage.
+- [ ] A status group/label is true for **every** member — don't fold a distinct lifecycle state (scheduled/queued/snoozed) under a label that asserts another (running/in-progress); give it its own group or a neutral label.
 
 **Edit — entering & changing content** ([edit.md](references/edit.md))
 

--- a/.agents/skills/ux/references/read.md
+++ b/.agents/skills/ux/references/read.md
@@ -460,3 +460,62 @@ UX consequence — a bespoke row is a visible consistency + craft regression.)
 - [ ] Grouping at scale reuses `Accordion` / `GroupedAccordion` (by-project / status / time), not a flat ungrouped dump once the list grows past a screen. _(Natural)_
 - [ ] Search box, inline-rename, and row actions reuse the shared input / editing / action-reveal patterns, not raw `<input>` / `<label>` + hand CSS. _(Certainty)_
 - [ ] Spacing/padding expressed as `Flexbox` / `Block` `gap` / `padding` props (inherits the sidebar rhythm), not hand-picked px constants. _(Natural)_
+## 1.11 A persistent composer above a list must not bury the records・Meaningful・Natural
+
+A list surface with an **always-visible create / compose affordance above the records** (an
+inline "new task" editor, a "what's on your mind" post box, a reply composer over a thread)
+is the _hero_ of the **empty** state — there, teaching + one big input is exactly right
+(§1.1, Grow onboarding). But the moment the list is **populated**, the primary content is
+the **records**, and the composer becomes secondary; it must not out-weigh them. The common
+break: an **auto-growing editor with no `max-height`** whose height tracks its content, so a
+long draft (or a pre-filled template) inflates the box until it fills the viewport and pushes
+the **entire list below the fold** — Center Stage inverted, the user scrolls past their own
+compose draft to reach the records they came to see. Fix it two ways, ideally both: **cap the
+input's height** (a `max-height` + internal scroll so a long draft scrolls _inside_ the box,
+not the page), and **default the composer to collapsed once the list is non-empty** (a
+one-click / focus expand back to the hero size), so the records keep the top of the fold. The
+empty-state hero and the populated-list composer are the **same component in two roles** —
+let the surface pick the role from whether it has data, don't render one size for both.
+
+> ✅ On an empty list the create composer is a tall autofocused hero; once records exist it
+> collapses to a single-line entry (one click / focus re-expands it), and even expanded its
+> editor caps at a few rows with internal scroll — the list stays above the fold.
+> ❌ **全部任务** (`/tasks`) renders `CreateTaskInlineEntry` persistently whenever
+> `!inlineCollapsed` (`AgentTasksPage.tsx:165`), and its Lexical editor grows to content
+> height with **no `max-height` / scroll** (`CreateTaskInlineEntry.tsx:213-231`). A long
+> instruction draft fills \~half the viewport and pushes the "进行中" group and every task
+> **below the fold** — on a populated board the composer dominates the list it sits over. The
+> collapse flag (`taskCreateInlineCollapsed`) exists but defaults to _expanded_ and the editor
+> is uncapped. ✅ Cap the editor height; default to collapsed once `!isEmptyHero`.
+
+**Checklist**
+
+- [ ] A persistent create/compose affordance above a list is the hero only while the list is **empty**; once populated it doesn't push the records below the fold. _(Meaningful)_
+- [ ] An auto-growing editor above a list has a `max-height` + internal scroll — a long draft scrolls inside the box, not the page. _(Natural)_
+- [ ] The composer defaults to collapsed / compact once the list has data (one-click / focus re-expand), so the records keep Center Stage. _(Meaningful・Natural)_
+
+## 1.12 A status group's label must be true for every member・Certainty・Meaningful
+
+When a list **groups or labels by status**, the group header _asserts a state_ — every row
+under "In Progress" claims to be actively running. So don't **fold a distinct lifecycle state
+into another** whose label then lies about it: a **scheduled-but-idle** item (a cron task
+waiting for its next fire, a queued job, a snoozed item) collapsed into a "running" / "In
+Progress" group tells the user it's executing _now_ when it's merely _waiting_. This is
+"consistency is semantic" at the label level — the header must be **true for every member**.
+The tell is a status→group map that points two different lifecycle states at one label; the
+row often already shows the real state (a schedule tag, a "next run" pill), which makes the
+group header's contradiction all the more visible. Give the distinct state its **own group /
+label** (ranked where it belongs), or relabel the shared group so it's true for both.
+
+> ✅ A "Scheduled" group (ranked above "Running") holds cron/queued tasks; "In Progress" holds
+> only what's actually executing — each header is true for every row under it.
+> ❌ **全部任务** folds `scheduled → running` in the group map (`listViewOptions.ts:107`) and
+> renders the header as `taskDetail.status.running` = "进行中 / In Progress" (`:232,237`), so a
+> daily-cron task that is **idle until 06:00** sits under "In Progress" — even though its own
+> row reads "每天 06:00 运行". The label claims a state the task isn't in. ✅ A distinct
+> "Scheduled" group; keep "In Progress" for genuinely-running tasks.
+
+**Checklist**
+
+- [ ] A status group/label is true for **every** member — no folding a distinct lifecycle state (scheduled/queued/snoozed) under a label that asserts a different one (running/in-progress). _(Certainty)_
+- [ ] The distinct state gets its own group/label (ranked appropriately), or the shared label is neutral enough to be true for both. _(Meaningful)_


### PR DESCRIPTION
## Summary

Runs the **ux-audit** skill against the populated **全部任务 / Tasks list** surface and feeds the findings back into the `ux` checklists (回灌). This is the **visual (L2) re-verify pass** the prior L1-only audit (LOBE-11219) could not do — anchored on a screenshot of the populated list (a persistent create composer over a "进行中" status group).

Docs / skill files only — **no product code changes**.

## What lands

Two genuinely-new, generalizable rules (neither was previously stated):

- **Read §1.10** — *A persistent composer above a list must not bury the records.* An inline create/compose affordance is the hero only while the list is **empty**; once populated the records are the primary content. An **auto-growing editor with no `max-height`** pushes the whole list below the fold when the draft is long — cap the height (+ internal scroll) and/or default to collapsed once the list has data.
- **Read §1.11** — *A status group's label must be true for every member.* Don't fold a distinct lifecycle state (scheduled/queued/snoozed) into another whose label then lies (a cron task idle until 06:00 shown under "In Progress"). Give it its own group or a neutral label.

Both are mirrored into the **SKILL.md Quick review**, and a **§6 L2 addendum** is appended to the tasks-list worked example — which also records that the prior 🔴 **L① permanent-skeleton-on-error** gap is now **fixed** via `AsyncBoundary` (don't-regress note).

## Findings (from the screenshot, cited to code)

| # | Sev | Finding | Evidence |
| - | --- | ------- | -------- |
| V1 | 🟠 | Persistent composer's uncapped editor buries the list below the fold | `AgentTasksPage.tsx:165`, `CreateTaskInlineEntry.tsx:213-231` |
| V2 | 🟠 | Scheduled task mislabeled "进行中 / In Progress" | `listViewOptions.ts:107`, `:232,237` |
| V3 | 🟡 | Latest-activity sub-line duplicates the task name | `AgentTaskItem.tsx:209`, `TaskLatestActivity.tsx:13-24` |

V1/V2 are the actionable product fixes (follow-ups, not in this PR); V3 and the carried L②/L④/L⑤/L⑥ are validated-existing instances.

## Files
- `.agents/skills/ux/references/read.md` — new §1.10, §1.11
- `.agents/skills/ux/SKILL.md` — two Quick-review mirror lines
- `.agents/skills/ux-audit/references/example/tasks.md` — §6 L2 addendum

🤖 Generated with [Claude Code](https://claude.com/claude-code)