### PR TITLE
🙈 refactor(task): stop returning brief activities in task detail

### DIFF
--- a/apps/server/src/services/task/index.test.ts
+++ b/apps/server/src/services/task/index.test.ts
@@ -7,7 +7,6 @@ import { TaskModel } from '@/database/models/task';
 import { TaskTopicModel } from '@/database/models/taskTopic';
 import { UserModel } from '@/database/models/user';
 import type { LobeChatDatabase } from '@/database/type';
-import { BriefService } from '@/server/services/brief';
 
 import { TaskService } from './index';
 
@@ -558,7 +557,7 @@ describe('TaskService', () => {
       ]);
     });
 
-    it('should build activities sorted by time ascending', async () => {
+    it('should build activities sorted by time ascending and exclude briefs (LOBE-11393)', async () => {
       const task = {
         assigneeAgentId: null,
         assigneeUserId: null,
@@ -623,11 +622,12 @@ describe('TaskService', () => {
       const service = new TaskService(db, userId);
       const result = await service.getTaskDetail('TASK-1');
 
-      expect(result?.activities).toHaveLength(3);
-      // sorted ascending: brief (Jan 1) < comment (Jan 2) < topic (Jan 3)
-      expect(result?.activities?.[0].type).toBe('brief');
-      expect(result?.activities?.[1].type).toBe('comment');
-      expect(result?.activities?.[2].type).toBe('topic');
+      // Brief (Jan 1) is intentionally excluded from the feed (LOBE-11393), even
+      // though one exists for the task; only comment (Jan 2) + topic (Jan 3) remain.
+      expect(result?.activities).toHaveLength(2);
+      expect(result?.activities?.some((a) => a.type === 'brief')).toBe(false);
+      expect(result?.activities?.[0].type).toBe('comment');
+      expect(result?.activities?.[1].type).toBe('topic');
     });
 
     it('should resolve author info for activities', async () => {
@@ -1155,204 +1155,6 @@ describe('TaskService', () => {
       expect(result?.workspace).toBeUndefined();
     });
 
-    it('should build brief activities with full BriefItem fields', async () => {
-      const task = {
-        assigneeAgentId: null,
-        assigneeUserId: null,
-        createdAt: null,
-        description: null,
-        error: null,
-        heartbeatInterval: null,
-        heartbeatTimeout: null,
-        id: 'task_001',
-        identifier: 'TASK-1',
-        instruction: null,
-        lastHeartbeatAt: null,
-        name: 'Task 1',
-        parentTaskId: null,
-        priority: 'normal',
-        status: 'todo',
-        totalTopics: 0,
-      };
-
-      const briefs = [
-        {
-          actions: [{ key: 'approve', label: '✅', type: 'resolve' }],
-          agentId: 'agent-1',
-          artifacts: ['doc_1'],
-          createdAt: new Date('2024-01-01T00:00:00Z'),
-          cronJobId: null,
-          id: 'brief-1',
-          priority: 'urgent',
-          readAt: new Date('2024-01-01T01:00:00Z'),
-          resolvedAction: 'approved',
-          resolvedAt: new Date('2024-01-01T02:00:00Z'),
-          resolvedComment: 'looks good',
-          summary: 'Review brief',
-          taskId: 'task_001',
-          title: 'Approval',
-          topicId: null,
-          type: 'decision',
-          userId: 'user-1',
-        },
-      ];
-
-      mockTaskModel.resolve.mockResolvedValue(task);
-      mockTaskModel.findAllDescendants.mockResolvedValue([]);
-      mockTaskModel.getDependencies.mockResolvedValue([]);
-      mockTaskTopicModel.findWithHandoff.mockResolvedValue([]);
-      mockBriefModel.findByTaskId.mockResolvedValue(briefs);
-      mockTaskModel.getComments.mockResolvedValue([]);
-      mockTaskModel.getTreePinnedDocuments.mockResolvedValue({ nodeMap: {}, tree: [] });
-      mockTaskModel.findByIds.mockResolvedValue([]);
-      mockTaskModel.getCheckpointConfig.mockReturnValue({});
-      mockTaskModel.getVerifyConfig.mockReturnValue(undefined);
-      mockAgentModel.getAgentAvatarsByIds.mockResolvedValue([
-        { avatar: 'avatar.png', backgroundColor: '#fff', id: 'agent-1', title: 'Agent One' },
-      ]);
-
-      const service = new TaskService(db, userId);
-      const result = await service.getTaskDetail('TASK-1');
-
-      expect(result?.activities?.[0]).toMatchObject({
-        actions: [{ key: 'approve', label: '✅', type: 'resolve' }],
-        agent: { avatar: 'avatar.png', backgroundColor: '#fff', id: 'agent-1', title: 'Agent One' },
-        agentId: 'agent-1',
-        artifacts: ['doc_1'],
-        briefType: 'decision',
-        createdAt: '2024-01-01T00:00:00.000Z',
-        id: 'brief-1',
-        priority: 'urgent',
-        readAt: '2024-01-01T01:00:00.000Z',
-        resolvedAction: 'approved',
-        resolvedAt: '2024-01-01T02:00:00.000Z',
-        resolvedComment: 'looks good',
-        summary: 'Review brief',
-        taskId: 'task_001',
-        title: 'Approval',
-        type: 'brief',
-        userId: 'user-1',
-      });
-    });
-
-    it('should keep resolvedAction and resolvedComment as separate fields', async () => {
-      const task = {
-        assigneeAgentId: null,
-        assigneeUserId: null,
-        createdAt: null,
-        description: null,
-        error: null,
-        heartbeatInterval: null,
-        heartbeatTimeout: null,
-        id: 'task_001',
-        identifier: 'TASK-1',
-        instruction: null,
-        lastHeartbeatAt: null,
-        name: 'Task 1',
-        parentTaskId: null,
-        priority: 'normal',
-        status: 'todo',
-        totalTopics: 0,
-      };
-
-      const briefs = [
-        {
-          createdAt: new Date('2024-01-01T00:00:00Z'),
-          id: 'brief-1',
-          priority: 'normal',
-          resolvedAction: 'retry',
-          resolvedComment: null,
-          summary: 'Retry brief',
-          title: 'Retry',
-          type: 'insight',
-        },
-      ];
-
-      mockTaskModel.resolve.mockResolvedValue(task);
-      mockTaskModel.findAllDescendants.mockResolvedValue([]);
-      mockTaskModel.getDependencies.mockResolvedValue([]);
-      mockTaskTopicModel.findWithHandoff.mockResolvedValue([]);
-      mockBriefModel.findByTaskId.mockResolvedValue(briefs);
-      mockTaskModel.getComments.mockResolvedValue([]);
-      mockTaskModel.getTreePinnedDocuments.mockResolvedValue({ nodeMap: {}, tree: [] });
-      mockTaskModel.findByIds.mockResolvedValue([]);
-      mockTaskModel.getCheckpointConfig.mockReturnValue({});
-      mockTaskModel.getVerifyConfig.mockReturnValue(undefined);
-
-      const service = new TaskService(db, userId);
-      const result = await service.getTaskDetail('TASK-1');
-
-      expect(result?.activities?.[0]).toMatchObject({
-        resolvedAction: 'retry',
-        resolvedComment: null,
-        type: 'brief',
-      });
-    });
-
-    it('should still return task detail when brief agent enrichment fails', async () => {
-      const task = {
-        assigneeAgentId: null,
-        assigneeUserId: null,
-        createdAt: null,
-        description: null,
-        error: null,
-        heartbeatInterval: null,
-        heartbeatTimeout: null,
-        id: 'task_001',
-        identifier: 'TASK-1',
-        instruction: null,
-        lastHeartbeatAt: null,
-        name: 'Task 1',
-        parentTaskId: null,
-        priority: 'normal',
-        status: 'todo',
-        totalTopics: 0,
-      };
-
-      const briefs = [
-        {
-          agentId: 'agent-1',
-          createdAt: new Date('2024-01-01T00:00:00Z'),
-          id: 'brief-1',
-          priority: 'normal',
-          resolvedAction: null,
-          resolvedComment: null,
-          summary: 'Brief',
-          taskId: 'task_001',
-          title: 'Brief A',
-          type: 'insight',
-        },
-      ];
-
-      mockTaskModel.resolve.mockResolvedValue(task);
-      mockTaskModel.findAllDescendants.mockResolvedValue([]);
-      mockTaskModel.getDependencies.mockResolvedValue([]);
-      mockTaskTopicModel.findWithHandoff.mockResolvedValue([]);
-      mockBriefModel.findByTaskId.mockResolvedValue(briefs);
-      mockTaskModel.getComments.mockResolvedValue([]);
-      mockTaskModel.getTreePinnedDocuments.mockResolvedValue({ nodeMap: {}, tree: [] });
-      mockTaskModel.findByIds.mockResolvedValue([]);
-      mockTaskModel.getCheckpointConfig.mockReturnValue({});
-      mockTaskModel.getVerifyConfig.mockReturnValue(undefined);
-      // Force the brief enrichment path to reject without breaking the
-      // sibling resolveAuthors call (which shares the agent model mock).
-      const enrichSpy = vi
-        .spyOn(BriefService.prototype, 'enrichBriefAgentOnly')
-        .mockRejectedValueOnce(new Error('DB error'));
-
-      const service = new TaskService(db, userId);
-      const result = await service.getTaskDetail('TASK-1');
-
-      expect(result).not.toBeNull();
-      expect(result?.activities).toHaveLength(1);
-      expect(result?.activities?.[0]).toMatchObject({
-        agent: null,
-        id: 'brief-1',
-        type: 'brief',
-      });
-      enrichSpy.mockRestore();
-    });
-
     it('should use topic handoff title with fallback to Untitled', async () => {
       const task = {
         assigneeAgentId: null,
@@ -1429,16 +1231,14 @@ describe('TaskService', () => {
         totalTopics: 0,
       };
 
-      const briefs = [
+      // A topic without a createdAt should sort to the end (time-less items last).
+      const topics = [
         {
           createdAt: null,
-          id: 'brief-1',
-          priority: 'normal',
-          resolvedAction: null,
-          resolvedComment: null,
-          summary: 'No time brief',
-          title: 'No Time',
-          type: 'insight',
+          handoff: { title: 'No Time' },
+          seq: 1,
+          status: 'completed',
+          topicId: 'topic-1',
         },
       ];
 
@@ -1453,8 +1253,8 @@ describe('TaskService', () => {
       mockTaskModel.resolve.mockResolvedValue(task);
       mockTaskModel.findAllDescendants.mockResolvedValue([]);
       mockTaskModel.getDependencies.mockResolvedValue([]);
-      mockTaskTopicModel.findWithHandoff.mockResolvedValue([]);
-      mockBriefModel.findByTaskId.mockResolvedValue(briefs);
+      mockTaskTopicModel.findWithHandoff.mockResolvedValue(topics);
+      mockBriefModel.findByTaskId.mockResolvedValue([]);
       mockTaskModel.getComments.mockResolvedValue(comments);
       mockTaskModel.getTreePinnedDocuments.mockResolvedValue({ nodeMap: {}, tree: [] });
       mockTaskModel.findByIds.mockResolvedValue([]);
@@ -1465,9 +1265,9 @@ describe('TaskService', () => {
       const result = await service.getTaskDetail('TASK-1');
 
       expect(result?.activities).toHaveLength(2);
-      // comment with time should come first, brief without time at end
+      // comment with time should come first, topic without time at end
       expect(result?.activities?.[0].type).toBe('comment');
-      expect(result?.activities?.[1].type).toBe('brief');
+      expect(result?.activities?.[1].type).toBe('topic');
     });
   });
 

--- a/apps/server/src/services/task/index.ts
+++ b/apps/server/src/services/task/index.ts
@@ -13,7 +13,6 @@ import type {
 import { TRPCError } from '@trpc/server';
 
 import { AgentModel } from '@/database/models/agent';
-import { BriefModel } from '@/database/models/brief';
 import { TaskModel } from '@/database/models/task';
 import { TaskTopicModel } from '@/database/models/taskTopic';
 import { TopicModel } from '@/database/models/topic';
@@ -21,7 +20,6 @@ import { UserModel } from '@/database/models/user';
 import type { LobeChatDatabase } from '@/database/type';
 
 import { AiAgentService } from '../aiAgent';
-import { BriefService } from '../brief';
 import { extractFileIdsFromEditorData } from '../file/extractFileIdsFromEditorData';
 import { resolveAttachmentMetadata } from '../file/resolveAttachments';
 import { type SubtaskGraphPlan, TaskGraphService } from '../taskGraph';
@@ -88,8 +86,6 @@ export interface RunReadySubtasksResult {
 
 export class TaskService {
   private agentModel: AgentModel;
-  private briefModel: BriefModel;
-  private briefService: BriefService;
   private db: LobeChatDatabase;
   private taskModel: TaskModel;
   private taskTopicModel: TaskTopicModel;
@@ -106,8 +102,6 @@ export class TaskService {
     this.taskModel = new TaskModel(db, userId, workspaceId);
     this.taskTopicModel = new TaskTopicModel(db, userId, workspaceId);
     this.topicModel = new TopicModel(db, userId, workspaceId);
-    this.briefModel = new BriefModel(db, userId, workspaceId);
-    this.briefService = new BriefService(db, userId, workspaceId);
   }
 
   /**
@@ -516,17 +510,17 @@ export class TaskService {
       task = { ...task, error: null };
     }
 
-    const [allDescendants, dependencies, directTopics, briefs, comments, workspace] =
-      await Promise.all([
-        this.taskModel.findAllDescendants(task.id),
-        this.taskModel.getDependencies(task.id),
-        this.taskTopicModel
-          .findWithHandoff(task.id, TASK_DETAIL_DIRECT_TOPIC_LIMIT)
-          .catch(() => []),
-        this.briefModel.findByTaskId(task.id).catch(() => []),
-        this.taskModel.getComments(task.id).catch(() => []),
-        this.taskModel.getTreePinnedDocuments(task.id).catch(() => emptyWorkspace),
-      ]);
+    // Brief hidden (LOBE-11393): the task detail activity feed no longer carries
+    // brief-type activities — the UI converges on Task Run. Briefs are therefore
+    // not fetched/enriched here (see the omitted brief spread below). The brief
+    // lifecycle, model and data are untouched; revert this to bring them back.
+    const [allDescendants, dependencies, directTopics, comments, workspace] = await Promise.all([
+      this.taskModel.findAllDescendants(task.id),
+      this.taskModel.getDependencies(task.id),
+      this.taskTopicModel.findWithHandoff(task.id, TASK_DETAIL_DIRECT_TOPIC_LIMIT).catch(() => []),
+      this.taskModel.getComments(task.id).catch(() => []),
+      this.taskModel.getTreePinnedDocuments(task.id).catch(() => emptyWorkspace),
+    ]);
 
     const allDescendantIds = allDescendants.map((s) => s.id);
     const descendantTaskMap = new Map(allDescendants.map((s) => [s.id, s]));
@@ -713,10 +707,6 @@ export class TaskService {
       const topicAgentId = t.agentId ?? t.sourceTaskAssigneeAgentId ?? task.assigneeAgentId;
       if (topicAgentId) agentIds.add(topicAgentId);
     }
-    // Briefs may have an agentId
-    for (const b of briefs) {
-      if (b.agentId) agentIds.add(b.agentId);
-    }
     // Comments have authorAgentId or authorUserId
     for (const c of comments) {
       if (c.authorAgentId) agentIds.add(c.authorAgentId);
@@ -726,12 +716,7 @@ export class TaskService {
     if (task.createdByAgentId) agentIds.add(task.createdByAgentId);
     else if (task.createdByUserId) userIds.add(task.createdByUserId);
 
-    const [authorMap, enrichedBriefs] = await Promise.all([
-      this.resolveAuthors(agentIds, userIds),
-      this.briefService
-        .enrichBriefAgentOnly(briefs)
-        .catch(() => briefs.map((b) => ({ ...b, agent: null }))),
-    ]);
+    const authorMap = await this.resolveAuthors(agentIds, userIds);
 
     const creatorId = task.createdByAgentId ?? task.createdByUserId;
     const createdActivity: TaskDetailActivity | null =
@@ -765,29 +750,7 @@ export class TaskService {
           type: 'topic' as const,
         };
       }),
-      ...enrichedBriefs.map((b) => ({
-        actions: b.actions ?? undefined,
-        agent: b.agent,
-        agentId: b.agentId,
-        artifacts: b.artifacts ?? undefined,
-        author: b.agentId ? authorMap.get(b.agentId) : undefined,
-        briefType: b.type,
-        createdAt: toISO(b.createdAt),
-        cronJobId: b.cronJobId,
-        id: b.id,
-        priority: b.priority,
-        readAt: toISO(b.readAt),
-        resolvedAction: b.resolvedAction,
-        resolvedAt: toISO(b.resolvedAt),
-        resolvedComment: b.resolvedComment,
-        summary: b.summary,
-        taskId: b.taskId,
-        time: toISO(b.createdAt),
-        title: b.title,
-        topicId: b.topicId,
-        type: 'brief' as const,
-        userId: b.userId,
-      })),
+      // Brief activities intentionally omitted (LOBE-11393) — see the fetch note above.
       ...comments.map((c) => {
         const ids = commentFileIdsMap[c.id] ?? [];
         const files = ids.map((id) => fileById.get(id)).filter((f) => !!f);


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

Part of LOBE-11393 (Brief 下线, 以 Task Run 为中心呈现) — first step: hide brief from the **Task Detail** activity feed. Done on the **backend** (data source), so no client-side filtering is involved. The Home Brief feed, the brief lifecycle and all brief data are intentionally left untouched.

#### 🔀 Description of Change

`TaskService.getTaskDetail` no longer includes brief-type activities in its `activities` list:

- It stops fetching briefs (`briefModel.findByTaskId`) and stops enriching them (`briefService.enrichBriefAgentOnly`).
- The brief spread into `activities` is removed, so the feed carries only Task Run (topics) and comments.
- The now-unused `briefModel` / `briefService` members and their imports are dropped.

Because the server simply no longer emits brief activities, the client renders the trimmed feed as-is — **no frontend change needed**.

Scope & safety:

- **Home Brief section is unchanged** — the Home `DailyBrief` feed still shows briefs.
- The brief model, service, lifecycle (`synthesizeTopicBrief` / `briefModel.create`) and stored rows are all untouched — reverting this commit restores the brief activities.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- Task detail → Activities: only runs (topics) and comments show; no brief cards.
- Server unit tests (`apps/server/src/services/task/index.test.ts`): a task whose brief model returns a brief still yields an `activities` list with **no** `type: 'brief'` entry; obsolete brief-activity tests removed; the "no-time sorts last" case re-anchored on a topic. All 35 pass.

#### 📝 Additional Information

Reversible by design — revert this commit to bring brief activities back in task detail while the full LOBE-11393 retirement is designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)