### PR TITLE
fix(remote-device): mark gateway devices online in serverDB-less fallback

### DIFF
--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/remoteDevice.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/remoteDevice.test.ts
@@ -284,5 +284,36 @@ describe('remoteDeviceRuntime', () => {
         expect.objectContaining({ deviceId: 'd-ws', online: true, scope: 'workspace' }),
       ]);
     });
+
+    it('tags gateway-only devices online in the serverDB-less fallback so they survive the online filter', async () => {
+      // Regression guard: the raw gateway pool has no `online` field, but the
+      // gateway only returns live-connected devices. The serverDB-less fallback
+      // must add `online: true`, otherwise the runtime's `.filter(d => d.online)`
+      // drops every device and the agent reports "no online device".
+      const context: ToolExecutionContext = {
+        toolManifestMap: {},
+        userId: 'user-1',
+      };
+
+      // Mirror the real gateway payload: NO `online` field.
+      mockQueryDeviceList.mockResolvedValue([
+        {
+          deviceId: 'd-gateway',
+          hostname: 'laptop',
+          lastSeen: '2024-01-01',
+          platform: 'darwin',
+        },
+      ]);
+
+      const runtime = remoteDeviceRuntime.factory(context) as RemoteDeviceExecutionRuntime;
+      const result = await runtime.listOnlineDevices();
+
+      expect(mockQueryDeviceList).toHaveBeenCalledWith('user-1', undefined);
+      expect(result.success).toBe(true);
+      const parsed = JSON.parse(result.content);
+      expect(parsed).toEqual([
+        expect.objectContaining({ deviceId: 'd-gateway', online: true, scope: 'personal' }),
+      ]);
+    });
   });
 });

--- a/apps/server/src/services/toolExecution/serverRuntimes/remoteDevice.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/remoteDevice.ts
@@ -39,11 +39,14 @@ export const remoteDeviceRuntime: ServerRuntimeRegistration = {
 
         // Without a DB handle we cannot merge aliases / DB rows; fall back to the
         // raw gateway pool for the active scope (workspace runs never include
-        // personal devices), still tagged with scope.
+        // personal devices), still tagged with scope. The gateway only returns
+        // live-connected devices, so they are online by definition — without this
+        // flag the runtime's `.filter(d => d.online)` drops every device and the
+        // agent reports no online device even with a live, connected one.
         if (!serverDB) {
           const scope = workspaceId ? ('workspace' as const) : ('personal' as const);
           const online = await deviceGateway.queryDeviceList(userId, workspaceId);
-          return online.map((d) => ({ ...d, scope }));
+          return online.map((d) => ({ ...d, online: true, scope }));
         }
 
         const devices = await getScopedOnlineDevices(serverDB, userId, workspaceId);


### PR DESCRIPTION
## Problem

`listOnlineDevices` (Remote Device tool) has a `serverDB`-less fallback that
returns the raw gateway device pool but never sets `online` on those entries:

```ts
if (!serverDB) {
  const scope = workspaceId ? 'workspace' : 'personal';
  const online = await deviceGateway.queryDeviceList(userId, workspaceId);
  return online.map((d) => ({ ...d, scope })); // <- no `online`
}
```

`RemoteDeviceExecutionRuntime` then filters with `.filter(d => d.online)` (and
`activateDevice` with `.find(d => ... && d.online)`), so **every device is
dropped** whenever the tool execution context has no `serverDB` handle. The
agent reports "no online device" and tells the user to install the desktop app,
even though a device is live and connected through the gateway.

Observed with a self-hosted CLI device: the device is online in the gateway
hub and shows online in the device selector, but the agent's `listOnlineDevices`
returns empty.

## Fix

Tag the gateway pool entries `online: true` in the fallback. `deviceGateway.queryDeviceList`
only returns live-connected devices, so they are online by definition — the
non-fallback branch (`getScopedOnlineDevices`) already surfaces them as online.

One line, no behavior change when `serverDB` is present.
