### PR TITLE
🐛 fix(agent): restore right working-sidebar drag-resize

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -1,0 +1,113 @@
+import { act, render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import AgentWorkingSidebar from '../index';
+
+// ─── captured RightPanel props ────────────────────────────────────────────────
+// The real RightPanel is a controlled DraggablePanel; here we stub it so the test
+// can read back the `width` it receives and drive its `onSizeChange` directly.
+
+interface CapturedRightPanelProps {
+  children?: ReactNode;
+  onSizeChange?: (size?: { height?: number | string; width?: number | string }) => void;
+  width?: number | string;
+}
+
+const rightPanel = vi.hoisted(() => ({
+  current: undefined as CapturedRightPanelProps | undefined,
+}));
+
+vi.mock('@/features/RightPanel', () => ({
+  default: (props: CapturedRightPanelProps) => {
+    rightPanel.current = props;
+    return <div data-testid="right-panel">{props.children}</div>;
+  },
+}));
+
+// ─── stub every downstream dependency so the sidebar renders deterministically ──
+
+vi.mock('../Files', () => ({ default: () => <div /> }));
+vi.mock('../Review', () => ({ default: () => <div /> }));
+vi.mock('../ProgressSection', () => ({ default: () => <div /> }));
+vi.mock('../ResourcesSection', () => ({ default: () => <div /> }));
+vi.mock('../ParamsSection', () => ({ default: () => <div /> }));
+
+vi.mock('@/store/agent', () => ({ useAgentStore: () => undefined }));
+vi.mock('@/store/agent/selectors', () => ({
+  agentByIdSelectors: {},
+  agentSelectors: { isCurrentAgentHeterogeneous: () => false },
+  chatConfigByIdSelectors: {},
+}));
+vi.mock('@/store/global', () => ({ useGlobalStore: () => undefined }));
+vi.mock('@/store/electron', () => ({ useElectronStore: () => undefined }));
+
+vi.mock('@/features/ChatInput/ControlBar/useRepoType', () => ({ useRepoType: () => undefined }));
+vi.mock('@/hooks/useEffectiveWorkingDirectory', () => ({
+  useEffectiveWorkingDirectory: () => undefined,
+}));
+vi.mock('@/hooks/useLocalStorageState', () => ({
+  useLocalStorageState: () => [false, vi.fn()],
+}));
+vi.mock('@/helpers/agentWorkingDirectory', () => ({ resolveTargetDeviceId: () => undefined }));
+vi.mock('@/helpers/executionTarget', () => ({ resolveExecutionTarget: () => 'local' }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  ActionIcon: () => <button type="button" />,
+  Flexbox: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('antd-style', () => ({
+  createStaticStyles: () => () => ({}),
+}));
+
+afterEach(() => {
+  rightPanel.current = undefined;
+  vi.clearAllMocks();
+});
+
+describe('AgentWorkingSidebar — controlled panel width', () => {
+  it('seeds the RightPanel with the default width', () => {
+    render(<AgentWorkingSidebar />);
+
+    expect(rightPanel.current?.width).toBe(360);
+  });
+
+  // Regression: DraggablePanel reports the dragged width as a `"480px"` string on
+  // drag-stop. A `typeof width === 'number'` guard silently dropped it, so the
+  // controlled width never updated and the panel snapped back — appearing
+  // impossible to resize. The handler must parse the px string.
+  it('applies a "480px" string width from a drag so the panel actually resizes', () => {
+    render(<AgentWorkingSidebar />);
+
+    act(() => {
+      rightPanel.current?.onSizeChange?.({ width: '480px' });
+    });
+
+    expect(rightPanel.current?.width).toBe(480);
+  });
+
+  it('applies a numeric drag width unchanged', () => {
+    render(<AgentWorkingSidebar />);
+
+    act(() => {
+      rightPanel.current?.onSizeChange?.({ width: 500 });
+    });
+
+    expect(rightPanel.current?.width).toBe(500);
+  });
+
+  it('ignores a size update with no width', () => {
+    render(<AgentWorkingSidebar />);
+
+    act(() => {
+      rightPanel.current?.onSizeChange?.({ height: '100%' });
+    });
+
+    expect(rightPanel.current?.width).toBe(360);
+  });
+});

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
@@ -168,7 +168,11 @@ const AgentWorkingSidebar = memo(() => {
       minWidth={300}
       width={panelWidth}
       onSizeChange={(size) => {
-        if (typeof size?.width === 'number') setPanelWidth(size.width);
+        if (!size?.width) return;
+        // DraggablePanel emits width as a `"420px"` string on drag-stop; parse it so
+        // the controlled width actually updates (otherwise the panel snaps back).
+        const w = typeof size.width === 'string' ? Number.parseInt(size.width) : size.width;
+        if (Number.isFinite(w)) setPanelWidth(w);
       }}
     >
       <Flexbox height={'100%'} width={'100%'}>


### PR DESCRIPTION
## What

The agent working-sidebar right panel could no longer be resized by dragging — the handle appeared dead, snapping back to the default width on release.

## Root cause

Introduced by #16695 (Codex two-pane review layout), which made `RightPanel` **controlled** via `width={panelWidth}` in `WorkingSidebar`. On drag-stop, `DraggablePanel`'s `onSizeChange` reports the width as a **string** (`"480px"`, from `${clampedMainSize}px`). The handler guarded on:

```ts
if (typeof size?.width === 'number') setPanelWidth(size.width);
```

`typeof "480px" === 'number'` is `false`, so `setPanelWidth` never fired. Since the width is controlled, the panel re-rendered back to its fixed `panelWidth` → looked impossible to drag.

The three other controlled `RightPanel` consumers (`AgentBuilder`, `PageEditor/Copilot`, `PageEditor/RightPanel`) already parse the px string correctly; only this new call site diverged.

## Fix

Parse the px string to a number before updating the controlled width, matching the existing convention.

## Test

Adds `WorkingSidebar/__tests__/index.test.tsx` — stubs `RightPanel`, drives `onSizeChange` with a `"480px"` string, and asserts the controlled width updates to `480`. Verified it fails on the pre-fix code and passes after. Also covers numeric pass-through and the no-width no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)