### PR TITLE
🚨 fix(memory): add kill switch to disable hourly memory extraction cron

### DIFF
--- a/apps/server/src/globalConfig/parseMemoryExtractionConfig.ts
+++ b/apps/server/src/globalConfig/parseMemoryExtractionConfig.ts
@@ -61,6 +61,17 @@ export interface MemoryExtractionPrivateConfig {
   featureFlags: {
     enableBenchmarkLoCoMo: boolean;
   };
+  /**
+   * Kill switch for the hourly all-user memory extraction cron.
+   *
+   * NOTICE:
+   * Defaults to ON to preserve behavior for self-hosted deployments. As an operational
+   * kill switch, set `MEMORY_USER_MEMORY_HOURLY_DISABLED=true` to stop the hourly cron
+   * from fanning out across the whole user base (e.g. when the workflow is re-running
+   * gatekeeper + layer LLM calls every hour without idempotency). Does not affect
+   * user-initiated extraction.
+   */
+  hourlyEnabled: boolean;
   observabilityS3?: {
     accessKeyId?: string;
     bucketName?: string;
@@ -243,6 +254,9 @@ export const parseMemoryExtractionConfig = (): MemoryExtractionPrivateConfig => 
   const featureFlags = {
     enableBenchmarkLoCoMo: process.env.MEMORY_USER_MEMORY_FEATURE_FLAG_BENCHMARK_LOCOMO === 'true',
   };
+  // Kill switch: the hourly all-user cron is ON by default (self-host friendly);
+  // set MEMORY_USER_MEMORY_HOURLY_DISABLED=true to stop the fan-out.
+  const hourlyEnabled = process.env.MEMORY_USER_MEMORY_HOURLY_DISABLED !== 'true';
   const concurrencyRaw = process.env.MEMORY_USER_MEMORY_CONCURRENCY;
   const concurrency =
     concurrencyRaw !== undefined
@@ -310,6 +324,7 @@ export const parseMemoryExtractionConfig = (): MemoryExtractionPrivateConfig => 
     embeddingPreferredModels,
     embeddingPreferredProviders,
     featureFlags,
+    hourlyEnabled,
     observabilityS3: extractorObservabilityS3,
     upstashWorkflowExtraHeaders,
     webhook: {

--- a/src/server/workflows-hono/memory-user-memory/workflows/__tests__/hourly.test.ts
+++ b/src/server/workflows-hono/memory-user-memory/workflows/__tests__/hourly.test.ts
@@ -5,6 +5,7 @@ import { hourlyWorkflowHandler } from '../hourly';
 const mocks = vi.hoisted(() => ({
   createExecutor: vi.fn(),
   getUsersForHourlyExtraction: vi.fn(),
+  hourlyEnabled: true,
   triggerHourly: vi.fn(),
   triggerProcessUsers: vi.fn(),
 }));
@@ -18,6 +19,7 @@ vi.mock('@/envs/app', () => ({
 
 vi.mock('@/server/globalConfig/parseMemoryExtractionConfig', () => ({
   parseMemoryExtractionConfig: () => ({
+    hourlyEnabled: mocks.hourlyEnabled,
     upstashWorkflowExtraHeaders: {},
     webhook: { baseUrl: 'https://app.example.com' },
   }),
@@ -42,11 +44,31 @@ vi.mock('../runGuard', () => ({
 describe('hourlyWorkflowHandler', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.hourlyEnabled = true;
     mocks.createExecutor.mockResolvedValue({
       getUsersForHourlyExtraction: mocks.getUsersForHourlyExtraction,
     });
     mocks.triggerHourly.mockResolvedValue({ workflowRunId: 'next-page-run' });
     mocks.triggerProcessUsers.mockResolvedValue({ workflowRunId: 'process-users-run' });
+  });
+
+  it('bails out before any fan-out when the hourly kill switch is disabled', async () => {
+    mocks.hourlyEnabled = false;
+
+    const context = {
+      requestPayload: { dryRun: false },
+      run: vi.fn((_name: string, callback: () => unknown) => callback()),
+    };
+
+    await expect(hourlyWorkflowHandler(context as never)).resolves.toMatchObject({
+      processedUsers: 0,
+    });
+    // No user listing, no per-user fan-out, no next-page scheduling.
+    expect(context.run).not.toHaveBeenCalled();
+    expect(mocks.createExecutor).not.toHaveBeenCalled();
+    expect(mocks.getUsersForHourlyExtraction).not.toHaveBeenCalled();
+    expect(mocks.triggerProcessUsers).not.toHaveBeenCalled();
+    expect(mocks.triggerHourly).not.toHaveBeenCalled();
   });
 
   it('continues pagination when Upstash restores the user batch cursor as JSON', async () => {

--- a/src/server/workflows-hono/memory-user-memory/workflows/hourly.ts
+++ b/src/server/workflows-hono/memory-user-memory/workflows/hourly.ts
@@ -27,6 +27,19 @@ export const hourlyWorkflowHandler = async (
   context: WorkflowContext<MemoryExtractionHourlyWorkflowPayload>,
 ) => {
   const { cursor, dryRun } = context.requestPayload || {};
+
+  // NOTICE: Kill switch (止血). On by default; set MEMORY_USER_MEMORY_HOURLY_DISABLED=true to
+  // stop the hourly cron from fanning out across the whole user base (it otherwise re-runs the
+  // gatekeeper + layer LLM calls every hour without idempotency). Read per invocation so
+  // flipping the env takes effect on the next cron run without waiting for a cold start. Does
+  // not affect user-initiated extraction.
+  if (!parseMemoryExtractionConfig().hourlyEnabled) {
+    return {
+      message: 'Hourly memory extraction is disabled (MEMORY_USER_MEMORY_HOURLY_DISABLED=true).',
+      processedUsers: 0,
+    };
+  }
+
   await assertMemoryWorkflowContextAllowed(context, WORKFLOW_PATH);
 
   const baseUrl = resolveBaseUrl();


### PR DESCRIPTION
## 💡 Background / 背景

The hourly user-memory extraction cron (`memory-user-memory:call-cron-hourly-analysis`) fans out across the **whole eligible user base** every hour. On upstream failures it re-runs the gatekeeper + layer LLM calls with **no idempotency**, driving a runaway spend spike:

- Vercel `/api/workflows/*`: **~7.4M invocations / 48h**, with a `process-topics` retry storm (`Error while parsing output of Invoke step. Expected a string, but got: undefined`).
- Model spend (`gpt-5-mini` gatekeeper/layers) jumped from ~$160/day (07-02) to **$781 (07-03) → $2451 (07-04)**.

This PR is the **immediate bleeding-stop (止血)** — an operational kill switch. Root-cause fixes (Upstash invoke return-value must be a string; `failed` topics must be idempotent instead of re-run every hour) will follow in separate PRs.

## 🔨 Changes

- Add `hourlyEnabled` to the memory extraction config, **ON by default** (self-host friendly).
- Set `MEMORY_USER_MEMORY_HOURLY_DISABLED=true` to make `hourlyWorkflowHandler` bail out **before any fan-out** (no user listing, no per-user trigger, no next-page scheduling).
- Flag is read **per invocation**, so flipping the env takes effect on the next cron run without waiting for a cold start.
- **Does not affect user-initiated extraction** — only the all-user hourly cron.

## ✅ Test

- `hourly.test.ts`: existing pagination test + new "bails out before any fan-out when disabled" test — both pass.
- Changed files type-check clean.

## 📝 Ops note

To stop the bleeding in production, set in Vercel (`lobehub-cloud-next` / `lobehub-pro`):

```
MEMORY_USER_MEMORY_HOURLY_DISABLED=true
```

> ⚠️ Stops **new** fan-out only. Already-queued Upstash retries continue until exhausted; use the Redis run guard for in-flight kills if needed.