### PR TITLE
💄 style(verify): full-width report TLDR with normal body text

### DIFF
--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -84,8 +84,8 @@ const styles = createStaticStyles(({ css }) => ({
     line-height: 1;
   `,
   summary: css`
-    max-width: 64ch;
-    color: ${cssVar.colorTextSecondary};
+    max-width: 100%;
+    color: ${cssVar.colorText};
   `,
   meta: css`
     display: flex;


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 💄 style

### 🔀 变更说明 | Description of Change

The verify report TL;DR (`summary`) was capped at `64ch` and rendered in a muted secondary color, making it read as a de-emphasized caption. This makes it full-width and uses the normal body text color so the summary reads as primary content.

- `max-width: 64ch` → `100%`
- `color: colorTextSecondary` → `colorText`

### 📝 补充信息 | Additional Information

Single CSS change in `src/features/Verify/ReportViewer.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)