### PR TITLE
♻️ refactor(workflow): expose run guard webhook route

### DIFF
--- a/apps/server/src/globalConfig/parseWorkflowRunGuardConfig.ts
+++ b/apps/server/src/globalConfig/parseWorkflowRunGuardConfig.ts
@@ -1,0 +1,23 @@
+const parseHeaders = (value?: string) =>
+  value
+    ?.split(',')
+    .filter(Boolean)
+    .reduce<Record<string, string>>((acc, pair) => {
+      const [key, headerValue] = pair.split('=').map((s) => s.trim());
+      if (key && headerValue) {
+        acc[key] = headerValue;
+      }
+      return acc;
+    }, {});
+
+/** Parses workflow run guard webhook headers and app URL settings. */
+export const parseWorkflowRunGuardConfig = () => ({
+  appUrl:
+    process.env.WORKFLOW_RUN_GUARD_WEBHOOK_BASE_URL ||
+    process.env.MEMORY_USER_MEMORY_WEBHOOK_BASE_URL ||
+    process.env.INTERNAL_APP_URL ||
+    process.env.APP_URL,
+  webhook: {
+    headers: parseHeaders(process.env.WORKFLOW_RUN_GUARD_WEBHOOK_HEADERS),
+  },
+});

--- a/src/app/(backend)/api/webhooks/workflows/run-guard/route.test.ts
+++ b/src/app/(backend)/api/webhooks/workflows/run-guard/route.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetRedisConfig, redis, redisLib, workflowClient } = vi.hoisted(() => ({
+  mockGetRedisConfig: vi.fn(),
+  redis: {
+    set: vi.fn(),
+  },
+  redisLib: {
+    initializeRedis: vi.fn(),
+    isRedisEnabled: vi.fn(),
+  },
+  workflowClient: {
+    cancel: vi.fn(),
+    logs: vi.fn(),
+  },
+}));
+
+vi.mock('@/envs/redis', () => ({
+  getRedisConfig: mockGetRedisConfig,
+}));
+
+vi.mock('@/libs/redis', () => ({
+  initializeRedis: redisLib.initializeRedis,
+  isRedisEnabled: redisLib.isRedisEnabled,
+}));
+
+vi.mock('@/libs/qstash', () => ({
+  workflowClient,
+}));
+
+const { POST } = await import('./route');
+
+const originalEnv = {
+  APP_URL: process.env.APP_URL,
+  INTERNAL_APP_URL: process.env.INTERNAL_APP_URL,
+  MEMORY_USER_MEMORY_WEBHOOK_BASE_URL: process.env.MEMORY_USER_MEMORY_WEBHOOK_BASE_URL,
+  WORKFLOW_RUN_GUARD_WEBHOOK_HEADERS: process.env.WORKFLOW_RUN_GUARD_WEBHOOK_HEADERS,
+};
+
+const restoreEnv = () => {
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+};
+
+describe('workflow run guard webhook route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRedisConfig.mockReturnValue({ enabled: true, url: 'redis://test' });
+    redisLib.isRedisEnabled.mockReturnValue(true);
+    redisLib.initializeRedis.mockReturnValue(redis);
+    process.env.APP_URL = 'https://app.lobehub.com';
+    process.env.INTERNAL_APP_URL = '';
+    process.env.MEMORY_USER_MEMORY_WEBHOOK_BASE_URL = '';
+    process.env.WORKFLOW_RUN_GUARD_WEBHOOK_HEADERS = 'Authorization=Bearer webhook-secret';
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  /**
+   * @example
+   * POST(requestWithWrongAuthorizationHeader) returns 401 and does not read Redis.
+   */
+  it('rejects invalid webhook headers', async () => {
+    const response = await POST(
+      new Request('https://app.lobehub.com/api/webhooks/workflows/run-guard', {
+        body: JSON.stringify({ scope: { type: 'global' } }),
+        headers: { Authorization: 'Bearer wrong-secret' },
+        method: 'POST',
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+    expect(redisLib.initializeRedis).not.toHaveBeenCalled();
+  });
+
+  /**
+   * @example
+   * POST(requestWhenEnvHeadersMissing) returns 401 and leaves guard state untouched.
+   */
+  it('rejects when webhook header env is missing', async () => {
+    delete process.env.WORKFLOW_RUN_GUARD_WEBHOOK_HEADERS;
+
+    const response = await POST(
+      new Request('https://app.lobehub.com/api/webhooks/workflows/run-guard', {
+        body: JSON.stringify({ scope: { type: 'global' } }),
+        headers: { Authorization: 'Bearer webhook-secret' },
+        method: 'POST',
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    expect(redisLib.initializeRedis).not.toHaveBeenCalled();
+  });
+
+  /**
+   * @example
+   * POST({ scope: { type: 'global' }, ttlSeconds: 60 }) with Authorization header stores a global guard.
+   */
+  it('sets a guard from webhook payload', async () => {
+    redis.set.mockResolvedValue('OK');
+
+    const response = await POST(
+      new Request('https://app.lobehub.com/api/webhooks/workflows/run-guard', {
+        body: JSON.stringify({
+          reason: 'external stop',
+          scope: { type: 'global' },
+          ttlSeconds: 60,
+        }),
+        headers: { Authorization: 'Bearer webhook-secret' },
+        method: 'POST',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      guard: {
+        key: 'workflow:run-guard:global',
+        ttlSeconds: 60,
+        value: { reason: 'external stop' },
+      },
+      success: true,
+    });
+    expect(redis.set).toHaveBeenCalledWith(
+      'workflow:run-guard:global',
+      expect.stringContaining('external stop'),
+      { ex: 60 },
+    );
+  });
+
+  /**
+   * @example
+   * POST(validPayloadWithAllConfiguredHeaders) accepts every configured header pair.
+   */
+  it('accepts multiple configured webhook headers', async () => {
+    process.env.WORKFLOW_RUN_GUARD_WEBHOOK_HEADERS =
+      'Authorization=Bearer webhook-secret,x-workflow-source=ops-console';
+    redis.set.mockResolvedValue('OK');
+
+    const response = await POST(
+      new Request('https://app.lobehub.com/api/webhooks/workflows/run-guard', {
+        body: JSON.stringify({ scope: { type: 'global' } }),
+        headers: {
+          'Authorization': 'Bearer webhook-secret',
+          'x-workflow-source': 'ops-console',
+        },
+        method: 'POST',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ success: true });
+  });
+
+  /**
+   * @example
+   * POST(validPayloadWithBase64LikeHeaderValue) keeps text after the first equals sign.
+   */
+  it('accepts configured header values that contain equals signs', async () => {
+    process.env.WORKFLOW_RUN_GUARD_WEBHOOK_HEADERS = 'x-run-guard-token=abc=def==';
+    redis.set.mockResolvedValue('OK');
+
+    const response = await POST(
+      new Request('https://app.lobehub.com/api/webhooks/workflows/run-guard', {
+        body: JSON.stringify({ scope: { type: 'global' } }),
+        headers: { 'x-run-guard-token': 'abc=def==' },
+        method: 'POST',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ success: true });
+  });
+
+  /**
+   * @example
+   * POST(pathGuardWithCancelPolicy) stores the guard and cancels matching workflow runs.
+   */
+  it('cancels qstash runs for path guards when policy requests it', async () => {
+    process.env.MEMORY_USER_MEMORY_WEBHOOK_BASE_URL = 'https://internal.lobehub.com';
+    redis.set.mockResolvedValue('OK');
+    workflowClient.cancel.mockResolvedValue({ cancelled: 1 });
+
+    const response = await POST(
+      new Request('https://app.lobehub.com/api/webhooks/workflows/run-guard', {
+        body: JSON.stringify({
+          policy: { cancelQstash: true },
+          scope: { type: 'path', workflowPath: 'api/workflows/memory-user-memory' },
+        }),
+        headers: { Authorization: 'Bearer webhook-secret' },
+        method: 'POST',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      guard: {
+        key: 'workflow:run-guard:path:api/workflows/memory-user-memory',
+        value: { policy: { cancelQstash: true } },
+      },
+      qstash: {
+        cancelled: 1,
+        workflowUrlPrefix: 'https://internal.lobehub.com/api/workflows/memory-user-memory',
+      },
+      success: true,
+    });
+    expect(workflowClient.logs).not.toHaveBeenCalled();
+    expect(workflowClient.cancel).toHaveBeenCalledWith({
+      urlStartingWith: 'https://internal.lobehub.com/api/workflows/memory-user-memory',
+    });
+  });
+
+  /**
+   * @example
+   * POST({ scope: { type: 'path' } }) returns 400 because workflowPath is required.
+   */
+  it('rejects invalid bodies before reading redis', async () => {
+    const response = await POST(
+      new Request('https://app.lobehub.com/api/webhooks/workflows/run-guard', {
+        body: JSON.stringify({ scope: { type: 'path' } }),
+        headers: { Authorization: 'Bearer webhook-secret' },
+        method: 'POST',
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(redisLib.initializeRedis).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({ error: 'Invalid request' });
+  });
+
+  /**
+   * @example
+   * POST('{broken') returns an explicit invalid JSON response.
+   */
+  it('rejects malformed json bodies', async () => {
+    const response = await POST(
+      new Request('https://app.lobehub.com/api/webhooks/workflows/run-guard', {
+        body: '{broken',
+        headers: { Authorization: 'Bearer webhook-secret' },
+        method: 'POST',
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(redisLib.initializeRedis).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid JSON' });
+  });
+
+  /**
+   * @example
+   * POST(validPayload) returns 500 when Redis is unavailable.
+   */
+  it('fails closed when redis is not configured', async () => {
+    redisLib.isRedisEnabled.mockReturnValue(false);
+
+    const response = await POST(
+      new Request('https://app.lobehub.com/api/webhooks/workflows/run-guard', {
+        body: JSON.stringify({ scope: { type: 'global' } }),
+        headers: { Authorization: 'Bearer webhook-secret' },
+        method: 'POST',
+      }),
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({ error: 'Redis is not configured' });
+  });
+});

--- a/src/app/(backend)/api/webhooks/workflows/run-guard/route.test.ts
+++ b/src/app/(backend)/api/webhooks/workflows/run-guard/route.test.ts
@@ -161,26 +161,6 @@ describe('workflow run guard webhook route', () => {
 
   /**
    * @example
-   * POST(validPayloadWithBase64LikeHeaderValue) keeps text after the first equals sign.
-   */
-  it('accepts configured header values that contain equals signs', async () => {
-    process.env.WORKFLOW_RUN_GUARD_WEBHOOK_HEADERS = 'x-run-guard-token=abc=def==';
-    redis.set.mockResolvedValue('OK');
-
-    const response = await POST(
-      new Request('https://app.lobehub.com/api/webhooks/workflows/run-guard', {
-        body: JSON.stringify({ scope: { type: 'global' } }),
-        headers: { 'x-run-guard-token': 'abc=def==' },
-        method: 'POST',
-      }),
-    );
-
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toMatchObject({ success: true });
-  });
-
-  /**
-   * @example
    * POST(pathGuardWithCancelPolicy) stores the guard and cancels matching workflow runs.
    */
   it('cancels qstash runs for path guards when policy requests it', async () => {

--- a/src/app/(backend)/api/webhooks/workflows/run-guard/route.ts
+++ b/src/app/(backend)/api/webhooks/workflows/run-guard/route.ts
@@ -7,6 +7,10 @@ import { initializeRedis, isRedisEnabled } from '@/libs/redis';
 import { parseWorkflowRunGuardConfig } from '@/server/globalConfig/parseWorkflowRunGuardConfig';
 import { cancelWorkflowRunsByGuardPolicy, setWorkflowRunGuard } from '@/server/workflows/runGuard';
 
+// NOTICE:
+// Next.js route segment config is required here because this operational webhook reads
+// runtime env, Redis, and QStash clients. Keep it on Node.js and force dynamic handling so
+// the route is evaluated per request instead of being statically optimized.
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 

--- a/src/app/(backend)/api/webhooks/workflows/run-guard/route.ts
+++ b/src/app/(backend)/api/webhooks/workflows/run-guard/route.ts
@@ -1,0 +1,189 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getRedisConfig } from '@/envs/redis';
+import { workflowClient } from '@/libs/qstash';
+import { initializeRedis, isRedisEnabled } from '@/libs/redis';
+import type { BaseRedisProvider } from '@/libs/redis/types';
+import { cancelWorkflowRunsByGuardPolicy, setWorkflowRunGuard } from '@/server/workflows/runGuard';
+
+/**
+ * Forces this operational webhook to run on Node.js for Redis and QStash clients.
+ */
+export const runtime = 'nodejs';
+
+/**
+ * Disables static optimization for an operational webhook that reads runtime env and Redis.
+ */
+export const dynamic = 'force-dynamic';
+
+const guardScopeSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('global') }),
+  z.object({ type: z.literal('path'), workflowPath: z.string().trim().min(1) }),
+  z.object({ type: z.literal('user'), userId: z.string().trim().min(1) }),
+  z.object({ type: z.literal('run'), workflowRunId: z.string().trim().min(1) }),
+  z.object({
+    stepName: z.string().trim().min(1),
+    type: z.literal('step'),
+    workflowRunId: z.string().trim().min(1),
+  }),
+]);
+
+const guardPolicySchema = z
+  .object({
+    cancelQstash: z.boolean().optional(),
+  })
+  .strict();
+
+const setGuardBodySchema = z
+  .object({
+    policy: guardPolicySchema.optional(),
+    reason: z.string().trim().min(1).optional(),
+    scope: guardScopeSchema,
+    ttlSeconds: z.number().int().positive().optional(),
+  })
+  .strict();
+
+/**
+ * Parses required run-guard webhook headers from environment configuration.
+ *
+ * Use when:
+ * - Matching the memory webhook `Header=Value,Header2=Value2` configuration shape.
+ * - Keeping run-guard webhook authorization configurable by deployment.
+ *
+ * Expects:
+ * - Header pairs are comma-separated.
+ * - Each pair contains the first `=` between the header name and value.
+ *
+ * Returns:
+ * - A header map used for exact request header checks.
+ */
+const parseWebhookHeaders = () =>
+  process.env.WORKFLOW_RUN_GUARD_WEBHOOK_HEADERS?.split(',')
+    .filter(Boolean)
+    .reduce<Record<string, string>>((acc, pair) => {
+      const separatorIndex = pair.indexOf('=');
+      if (separatorIndex <= 0) return acc;
+
+      const key = pair.slice(0, separatorIndex).trim();
+      const value = pair.slice(separatorIndex + 1).trim();
+      if (key && value) {
+        acc[key] = value;
+      }
+      return acc;
+    }, {}) ?? {};
+
+/**
+ * Verifies the workflow run guard webhook header before mutating guard state.
+ *
+ * Use when:
+ * - Protecting the external workflow run guard webhook.
+ * - Missing configuration should deny access instead of opening the route.
+ *
+ * Expects:
+ * - `WORKFLOW_RUN_GUARD_WEBHOOK_HEADERS` is set in operational environments.
+ *
+ * Returns:
+ * - An unauthorized response when the request cannot be authenticated.
+ */
+const requireWebhookAuth = (request: Request): NextResponse | undefined => {
+  const headers = parseWebhookHeaders();
+
+  if (Object.keys(headers).length === 0) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (request.headers.get(key) !== value) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+  }
+};
+
+/**
+ * Reads the shared Redis client and fails closed for webhook guard mutations.
+ *
+ * Use when:
+ * - Setting workflow run guards from the webhook route.
+ *
+ * Expects:
+ * - Redis is configured when this webhook is enabled.
+ *
+ * Returns:
+ * - A non-null Redis provider compatible with the shared guard store.
+ */
+const getRedisOrThrow = async (): Promise<BaseRedisProvider> => {
+  const config = getRedisConfig();
+  if (!isRedisEnabled(config)) throw new Error('Redis is not configured');
+
+  return initializeRedis(config);
+};
+
+const invalidRequest = (issues: z.ZodIssue[]) =>
+  NextResponse.json({ error: 'Invalid request', issues }, { status: 400 });
+
+const invalidJson = () => NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+
+const resolveAppUrl = () =>
+  process.env.MEMORY_USER_MEMORY_WEBHOOK_BASE_URL ||
+  process.env.INTERNAL_APP_URL ||
+  process.env.APP_URL;
+
+/**
+ * Creates or replaces one workflow run guard from an authenticated webhook.
+ *
+ * Use when:
+ * - External automation needs to stop workflow work by global, path, user, run, or step scope.
+ * - Path-scoped guards may also cancel matching active QStash workflow runs.
+ *
+ * Expects:
+ * - The configured webhook headers match the request headers.
+ * - Body matches the mutation schema.
+ * - Redis is configured.
+ *
+ * Returns:
+ * - JSON containing `success: true`, the stored guard, and optional QStash cancellation result.
+ */
+export const POST = async (request: Request) => {
+  const unauthorized = requireWebhookAuth(request);
+  if (unauthorized) return unauthorized;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return invalidJson();
+  }
+
+  const parsed = setGuardBodySchema.safeParse(body);
+  if (!parsed.success) return invalidRequest(parsed.error.issues);
+
+  try {
+    const redis = await getRedisOrThrow();
+    const { policy, reason, scope, ttlSeconds } = parsed.data;
+    const guard = await setWorkflowRunGuard(redis, {
+      scope,
+      ttlSeconds,
+      value: {
+        policy,
+        reason,
+      },
+    });
+
+    let qstash;
+
+    if (policy?.cancelQstash && scope.type === 'path') {
+      const appUrl = resolveAppUrl();
+      if (!appUrl) throw new Error('App URL is not configured');
+
+      qstash = await cancelWorkflowRunsByGuardPolicy(workflowClient, {
+        appUrl,
+        workflowPath: scope.workflowPath,
+      });
+    }
+
+    return NextResponse.json({ guard, qstash, success: true });
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+};

--- a/src/app/(backend)/api/webhooks/workflows/run-guard/route.ts
+++ b/src/app/(backend)/api/webhooks/workflows/run-guard/route.ts
@@ -4,17 +4,10 @@ import { z } from 'zod';
 import { getRedisConfig } from '@/envs/redis';
 import { workflowClient } from '@/libs/qstash';
 import { initializeRedis, isRedisEnabled } from '@/libs/redis';
-import type { BaseRedisProvider } from '@/libs/redis/types';
+import { parseWorkflowRunGuardConfig } from '@/server/globalConfig/parseWorkflowRunGuardConfig';
 import { cancelWorkflowRunsByGuardPolicy, setWorkflowRunGuard } from '@/server/workflows/runGuard';
 
-/**
- * Forces this operational webhook to run on Node.js for Redis and QStash clients.
- */
 export const runtime = 'nodejs';
-
-/**
- * Disables static optimization for an operational webhook that reads runtime env and Redis.
- */
 export const dynamic = 'force-dynamic';
 
 const guardScopeSchema = z.discriminatedUnion('type', [
@@ -45,91 +38,6 @@ const setGuardBodySchema = z
   .strict();
 
 /**
- * Parses required run-guard webhook headers from environment configuration.
- *
- * Use when:
- * - Matching the memory webhook `Header=Value,Header2=Value2` configuration shape.
- * - Keeping run-guard webhook authorization configurable by deployment.
- *
- * Expects:
- * - Header pairs are comma-separated.
- * - Each pair contains the first `=` between the header name and value.
- *
- * Returns:
- * - A header map used for exact request header checks.
- */
-const parseWebhookHeaders = () =>
-  process.env.WORKFLOW_RUN_GUARD_WEBHOOK_HEADERS?.split(',')
-    .filter(Boolean)
-    .reduce<Record<string, string>>((acc, pair) => {
-      const separatorIndex = pair.indexOf('=');
-      if (separatorIndex <= 0) return acc;
-
-      const key = pair.slice(0, separatorIndex).trim();
-      const value = pair.slice(separatorIndex + 1).trim();
-      if (key && value) {
-        acc[key] = value;
-      }
-      return acc;
-    }, {}) ?? {};
-
-/**
- * Verifies the workflow run guard webhook header before mutating guard state.
- *
- * Use when:
- * - Protecting the external workflow run guard webhook.
- * - Missing configuration should deny access instead of opening the route.
- *
- * Expects:
- * - `WORKFLOW_RUN_GUARD_WEBHOOK_HEADERS` is set in operational environments.
- *
- * Returns:
- * - An unauthorized response when the request cannot be authenticated.
- */
-const requireWebhookAuth = (request: Request): NextResponse | undefined => {
-  const headers = parseWebhookHeaders();
-
-  if (Object.keys(headers).length === 0) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
-  for (const [key, value] of Object.entries(headers)) {
-    if (request.headers.get(key) !== value) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-  }
-};
-
-/**
- * Reads the shared Redis client and fails closed for webhook guard mutations.
- *
- * Use when:
- * - Setting workflow run guards from the webhook route.
- *
- * Expects:
- * - Redis is configured when this webhook is enabled.
- *
- * Returns:
- * - A non-null Redis provider compatible with the shared guard store.
- */
-const getRedisOrThrow = async (): Promise<BaseRedisProvider> => {
-  const config = getRedisConfig();
-  if (!isRedisEnabled(config)) throw new Error('Redis is not configured');
-
-  return initializeRedis(config);
-};
-
-const invalidRequest = (issues: z.ZodIssue[]) =>
-  NextResponse.json({ error: 'Invalid request', issues }, { status: 400 });
-
-const invalidJson = () => NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
-
-const resolveAppUrl = () =>
-  process.env.MEMORY_USER_MEMORY_WEBHOOK_BASE_URL ||
-  process.env.INTERNAL_APP_URL ||
-  process.env.APP_URL;
-
-/**
  * Creates or replaces one workflow run guard from an authenticated webhook.
  *
  * Use when:
@@ -145,21 +53,39 @@ const resolveAppUrl = () =>
  * - JSON containing `success: true`, the stored guard, and optional QStash cancellation result.
  */
 export const POST = async (request: Request) => {
-  const unauthorized = requireWebhookAuth(request);
-  if (unauthorized) return unauthorized;
+  const { appUrl, webhook } = parseWorkflowRunGuardConfig();
+  const headers = webhook.headers ?? {};
+
+  if (Object.keys(headers).length === 0) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (request.headers.get(key) !== value) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+  }
 
   let body: unknown;
   try {
     body = await request.json();
   } catch {
-    return invalidJson();
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
   }
 
   const parsed = setGuardBodySchema.safeParse(body);
-  if (!parsed.success) return invalidRequest(parsed.error.issues);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid request', issues: parsed.error.issues },
+      { status: 400 },
+    );
+  }
 
   try {
-    const redis = await getRedisOrThrow();
+    const redisConfig = getRedisConfig();
+    if (!isRedisEnabled(redisConfig)) throw new Error('Redis is not configured');
+
+    const redis = initializeRedis(redisConfig);
     const { policy, reason, scope, ttlSeconds } = parsed.data;
     const guard = await setWorkflowRunGuard(redis, {
       scope,
@@ -173,7 +99,6 @@ export const POST = async (request: Request) => {
     let qstash;
 
     if (policy?.cancelQstash && scope.type === 'path') {
-      const appUrl = resolveAppUrl();
       if (!appUrl) throw new Error('App URL is not configured');
 
       qstash = await cancelWorkflowRunsByGuardPolicy(workflowClient, {

--- a/src/app/(backend)/api/webhooks/workflows/run-guard/route.ts
+++ b/src/app/(backend)/api/webhooks/workflows/run-guard/route.ts
@@ -11,6 +11,8 @@ import { cancelWorkflowRunsByGuardPolicy, setWorkflowRunGuard } from '@/server/w
 // Next.js route segment config is required here because this operational webhook reads
 // runtime env, Redis, and QStash clients. Keep it on Node.js and force dynamic handling so
 // the route is evaluated per request instead of being statically optimized.
+// Source/context: `https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config`
+// and `node_modules/next/dist/docs/01-app/03-api-reference/03-file-conventions/02-route-segment-config/runtime.md`.
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
@@ -89,7 +91,9 @@ export const POST = async (request: Request) => {
     const redisConfig = getRedisConfig();
     if (!isRedisEnabled(redisConfig)) throw new Error('Redis is not configured');
 
-    const redis = initializeRedis(redisConfig);
+    const redis = await initializeRedis(redisConfig);
+    if (!redis) throw new Error('Redis is not configured');
+
     const { policy, reason, scope, ttlSeconds } = parsed.data;
     const guard = await setWorkflowRunGuard(redis, {
       scope,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to lobehub/lobehub#16721

#### 🔀 Description of Change

Adds the workflow run guard webhook route to the open-source app router so deployments can set run guards through the same generic workflow capability that already lives in `src/server/workflows/runGuard`.

The route is protected by configurable webhook headers through `WORKFLOW_RUN_GUARD_WEBHOOK_HEADERS`, using the same `Header=Value,Header2=Value2` shape as the memory webhook routes. Missing or empty header configuration fails closed with `401`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated:

- `pnpm --dir lobehub exec vitest run --silent='passed-only' 'src/app/(backend)/api/webhooks/workflows/run-guard/route.test.ts'`

Manual via cloud route re-export:

- With `WORKFLOW_RUN_GUARD_WEBHOOK_HEADERS="Authorization=Bearer e2e-secret"`, wrong Authorization returned `401`.
- With the same env and correct Authorization, an invalid body returned `400`, confirming auth passed and payload validation ran.
- With `WORKFLOW_RUN_GUARD_WEBHOOK_HEADERS=` empty, the request returned `401`, confirming fail-closed behavior.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

Cloud can re-export this route instead of carrying a cloud-only implementation.
