### PR TITLE
✨ feat(workflow): add Upstash workflow metrics

### DIFF
--- a/apps/server/src/services/agentRuntime/hooks/HookDispatcher.ts
+++ b/apps/server/src/services/agentRuntime/hooks/HookDispatcher.ts
@@ -1,6 +1,7 @@
 import debug from 'debug';
 import urlJoin from 'url-join';
 
+import { OtelQstashClient } from '@/libs/qstash';
 import { isQueueAgentRuntimeEnabled } from '@/server/services/queue/impls';
 
 import type {
@@ -31,7 +32,6 @@ export async function deliverWebhook(
 
   if (delivery === 'qstash') {
     try {
-      const { Client } = await import('@upstash/qstash');
       const qstashToken = process.env.QSTASH_TOKEN;
       if (!qstashToken) {
         if (fallback === 'none') {
@@ -41,7 +41,7 @@ export async function deliverWebhook(
         await fetchDeliver(resolvedUrl, payload);
         return;
       }
-      const client = new Client({ token: qstashToken });
+      const client = new OtelQstashClient({ token: qstashToken });
       await client.publishJSON({
         body: payload,
         headers: {

--- a/apps/server/src/services/memory/userMemory/extract.ts
+++ b/apps/server/src/services/memory/userMemory/extract.ts
@@ -49,7 +49,7 @@ import type {
 } from '@lobechat/types';
 import { RequestTrigger } from '@lobechat/types';
 import { type FlowControl } from '@upstash/qstash';
-import { Client } from '@upstash/workflow';
+import type { Client } from '@upstash/workflow';
 import debug from 'debug';
 import { and, asc, eq, inArray } from 'drizzle-orm';
 import { join } from 'pathe';
@@ -67,6 +67,7 @@ import { UserMemorySourceBenchmarkLoCoMoModel } from '@/database/models/userMemo
 import { AiInfraRepos } from '@/database/repositories/aiInfra';
 import { getServerDB } from '@/database/server';
 import { buildWorkspaceWhere } from '@/database/utils/workspace';
+import { OtelWorkflowClient } from '@/libs/qstash';
 import { getServerGlobalConfig } from '@/server/globalConfig';
 import { type MemoryAgentConfig } from '@/server/globalConfig/parseMemoryExtractionConfig';
 import { parseMemoryExtractionConfig } from '@/server/globalConfig/parseMemoryExtractionConfig';
@@ -2746,7 +2747,7 @@ const getWorkflowClient = () => {
     (config as Record<string, unknown>).url = process.env.QSTASH_URL;
   }
 
-  return new Client(config);
+  return new OtelWorkflowClient(config);
 };
 
 export class MemoryExtractionWorkflowService {

--- a/apps/server/src/services/queue/impls/qstash.ts
+++ b/apps/server/src/services/queue/impls/qstash.ts
@@ -1,5 +1,7 @@
 import debug from 'debug';
 
+import { OtelQstashClient } from '@/libs/qstash';
+
 import { type HealthCheckResult, type QueueMessage, type QueueStats } from '../types';
 import { type QueueServiceImpl } from './type';
 
@@ -33,10 +35,9 @@ export class QStashQueueServiceImpl implements QueueServiceImpl {
     } = message;
 
     try {
-      const { Client } = await import('@upstash/qstash');
       log('Initialized QStash queue service');
-      const qstashClient = new Client({ token: this.config.qstashToken });
-      const response = await qstashClient.publishJSON({
+      const qstashClient = new OtelQstashClient({ token: this.config.qstashToken });
+      const request = {
         body: {
           context,
           operationId,
@@ -58,7 +59,8 @@ export class QStashQueueServiceImpl implements QueueServiceImpl {
         retryDelay,
         retries,
         url: endpoint,
-      });
+      };
+      const response = await qstashClient.publishJSON(request);
 
       log(
         `[${operationId}] Scheduled step %d to %s with %dms delay (messageId: %s)`,

--- a/packages/observability-otel/package.json
+++ b/packages/observability-otel/package.json
@@ -13,6 +13,7 @@
     "./modules/upstash-workflow": "./src/modules/upstash-workflow/index.ts"
   },
   "dependencies": {
+    "@lobechat/utils": "workspace:*",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.76.0",
     "@opentelemetry/exporter-metrics-otlp-http": "^0.208.0",

--- a/packages/observability-otel/src/modules/upstash-workflow/index.ts
+++ b/packages/observability-otel/src/modules/upstash-workflow/index.ts
@@ -168,7 +168,9 @@ export const withOtelMetricsForUpstashWorkflowContext = <
     stepFunction: () => TResult | Promise<TResult>,
   ): Promise<TResult | Promise<TResult>> => {
     try {
-      const result = await originalRun.call(context, stepName, stepFunction);
+      const result = await (originalRun.call(context, stepName, stepFunction) as Promise<
+        TResult | Promise<TResult>
+      >);
       recordUpstashWorkflowEvent({
         ...baseAttributes,
         ...context,
@@ -200,7 +202,7 @@ export const withOtelMetricsForUpstashWorkflowContext = <
       settings: unknown,
     ): Promise<TResult> => {
       try {
-        const result = await originalInvoke.call(context, stepName, settings);
+        const result = await (originalInvoke.call(context, stepName, settings) as Promise<TResult>);
         recordUpstashWorkflowEvent({
           ...baseAttributes,
           ...context,

--- a/packages/observability-otel/src/modules/upstash-workflow/index.ts
+++ b/packages/observability-otel/src/modules/upstash-workflow/index.ts
@@ -34,7 +34,9 @@ export const workflowEventCounter = meter.createCounter('upstash_workflow_events
 
 export type UpstashWorkflowOperation = 'invoke' | 'serve' | 'step' | 'trigger';
 export type UpstashWorkflowInterface = 'qstash' | 'workflow';
-export type UpstashWorkflowStatus = 'error' | 'success';
+export type UpstashWorkflowStatus = 'abort' | 'error' | 'success';
+
+const UPSTASH_WORKFLOW_ABORT_ERROR_TYPES = new Set(['WorkflowAbort', 'WorkflowRetryAfterError']);
 
 export interface UpstashWorkflowContextAttributes {
   failureUrl?: string;
@@ -83,6 +85,9 @@ export const normalizeUpstashWorkflowPath = (url?: string): string | undefined =
     return url.startsWith('/') ? url : undefined;
   }
 };
+
+const statusFromUpstashWorkflowError = (error: unknown): UpstashWorkflowStatus =>
+  UPSTASH_WORKFLOW_ABORT_ERROR_TYPES.has(errorNameFrom(error) ?? '') ? 'abort' : 'error';
 
 /**
  * Builds metric attributes for Upstash Workflow and QStash events.
@@ -180,7 +185,7 @@ export const withOtelMetricsForUpstashWorkflowContext = <
         ...context,
         errorType: errorNameFrom(error) ?? typeof error,
         operation: 'step',
-        status: 'error',
+        status: statusFromUpstashWorkflowError(error),
         stepName,
       });
 
@@ -212,7 +217,7 @@ export const withOtelMetricsForUpstashWorkflowContext = <
           ...context,
           errorType: errorNameFrom(error) ?? typeof error,
           operation: 'invoke',
-          status: 'error',
+          status: statusFromUpstashWorkflowError(error),
           stepName,
         });
 
@@ -263,7 +268,7 @@ export const withOtelMetricsForUpstashWorkflows = <TContext, TResult>(
         ...(context as UpstashWorkflowContextAttributes),
         errorType: errorNameFrom(error) ?? typeof error,
         operation: 'serve',
-        status: 'error',
+        status: statusFromUpstashWorkflowError(error),
       });
 
       throw error;

--- a/packages/observability-otel/src/modules/upstash-workflow/index.ts
+++ b/packages/observability-otel/src/modules/upstash-workflow/index.ts
@@ -1,13 +1,44 @@
-import { trace } from '@opentelemetry/api';
+import { errorNameFrom } from '@lobechat/utils';
+import { metrics, trace } from '@opentelemetry/api';
 
+const meter = metrics.getMeter('server-services-upstash-workflow');
 export const tracer = trace.getTracer('@lobechat/upstash-workflow', '0.0.1');
 
-export const ATTR_UPSTASH_WORKFLOW_RUN_ID = 'upstash.workflow.run_id' as const;
-export const ATTR_UPSTASH_WORKFLOW_URL = 'upstash.workflow.url' as const;
-export const ATTR_UPSTASH_WORKFLOW_FAILURE_URL = 'upstash.workflow.failure_url' as const;
-export const ATTR_UPSTASH_WORKFLOW_LABEL = 'upstash.workflow.label' as const;
-export const ATTR_UPSTASH_WORKFLOW_RETRY_COUNT = 'upstash.workflow.retries' as const;
-export const ATTR_UPSTASH_WORKFLOW_RETRY_DELAY = 'upstash.workflow.retry_delay' as const;
+export const ATTR_UPSTASH_WORKFLOW_OPERATION = 'upstash_workflow_operation' as const;
+export const ATTR_UPSTASH_WORKFLOW_STATUS = 'upstash_workflow_status' as const;
+export const ATTR_UPSTASH_WORKFLOW_INTERFACE = 'upstash_workflow_interface' as const;
+export const ATTR_UPSTASH_WORKFLOW_RUN_ID = 'upstash_workflow_run_id' as const;
+export const ATTR_UPSTASH_WORKFLOW_URL = 'upstash_workflow_url' as const;
+export const ATTR_UPSTASH_WORKFLOW_PATH = 'upstash_workflow_path' as const;
+export const ATTR_UPSTASH_WORKFLOW_FAILURE_URL = 'upstash_workflow_failure_url' as const;
+export const ATTR_UPSTASH_WORKFLOW_LABEL = 'upstash_workflow_label' as const;
+export const ATTR_UPSTASH_WORKFLOW_RETRY_COUNT = 'upstash_workflow_retries' as const;
+export const ATTR_UPSTASH_WORKFLOW_RETRY_DELAY = 'upstash_workflow_retry_delay' as const;
+export const ATTR_UPSTASH_WORKFLOW_STEP_NAME = 'upstash_workflow_step_name' as const;
+export const ATTR_UPSTASH_WORKFLOW_ERROR_TYPE = 'upstash_workflow_error_type' as const;
+
+/**
+ * Count Upstash Workflow and QStash lifecycle events.
+ *
+ * Use when:
+ * - Tracking workflow trigger, step, invoke, and serve volumes
+ * - Comparing outbound QStash/Workflow calls with inbound workflow deliveries
+ *
+ * Expects:
+ * - Low-cardinality labels such as operation, status, interface, and route path
+ *
+ * Returns:
+ * - Monotonic event counts exported through the configured OTEL metric reader
+ */
+export const workflowEventCounter = meter.createCounter('upstash_workflow_events_total', {
+  description:
+    'Count of Upstash Workflow and QStash lifecycle events grouped by operation and status.',
+  unit: '{event}',
+});
+
+export type UpstashWorkflowOperation = 'invoke' | 'serve' | 'step' | 'trigger';
+export type UpstashWorkflowInterface = 'qstash' | 'workflow';
+export type UpstashWorkflowStatus = 'error' | 'success';
 
 export interface UpstashWorkflowContextAttributes {
   failureUrl?: string;
@@ -18,13 +49,228 @@ export interface UpstashWorkflowContextAttributes {
   workflowRunId?: string;
 }
 
-export const buildUpstashWorkflowAttributes = (
-  context: UpstashWorkflowContextAttributes,
-): Record<string, number | string | undefined> => ({
-  [ATTR_UPSTASH_WORKFLOW_FAILURE_URL]: context.failureUrl,
-  [ATTR_UPSTASH_WORKFLOW_LABEL]: context.label,
-  [ATTR_UPSTASH_WORKFLOW_RETRY_COUNT]: context.retries,
-  [ATTR_UPSTASH_WORKFLOW_RETRY_DELAY]: context.retryDelay,
-  [ATTR_UPSTASH_WORKFLOW_RUN_ID]: context.workflowRunId,
-  [ATTR_UPSTASH_WORKFLOW_URL]: context.url,
+export interface UpstashWorkflowMetricAttributes extends UpstashWorkflowContextAttributes {
+  errorType?: string;
+  interface?: UpstashWorkflowInterface;
+  operation: UpstashWorkflowOperation;
+  path?: string;
+  status: UpstashWorkflowStatus;
+  stepName?: string;
+}
+
+export interface UpstashWorkflowContextLike<
+  TInitialPayload = unknown,
+> extends UpstashWorkflowContextAttributes {
+  invoke?: <TResult = unknown>(stepName: string, settings: unknown) => Promise<TResult>;
+  requestPayload: TInitialPayload;
+  run: <TResult>(
+    stepName: string,
+    stepFunction: () => TResult | Promise<TResult>,
+  ) => Promise<TResult | Promise<TResult>>;
+}
+
+/**
+ * Normalizes workflow URLs into route paths.
+ *
+ * Before:
+ * - "https://app.example.com/api/workflows/task/watchdog"
+ *
+ * After:
+ * - "/api/workflows/task/watchdog"
+ */
+export const normalizeUpstashWorkflowPath = (url?: string): string | undefined => {
+  if (!url) return undefined;
+
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url.startsWith('/') ? url : undefined;
+  }
+};
+
+/**
+ * Builds metric attributes for Upstash Workflow and QStash events.
+ *
+ * Use when:
+ * - Recording a workflow lifecycle counter from shared wrappers
+ * - Normalizing route URLs into low-cardinality path labels
+ *
+ * Expects:
+ * - `operation` and `status` are present for metric counter events
+ * - `url` may be absolute or an already-normalized route path
+ *
+ * Returns:
+ * - Attribute map accepted by OpenTelemetry metrics APIs
+ */
+export const buildUpstashWorkflowMetricAttributes = (
+  attributes: UpstashWorkflowContextAttributes &
+    Partial<Omit<UpstashWorkflowMetricAttributes, keyof UpstashWorkflowContextAttributes>>,
+): Record<string, boolean | number | string | undefined> => ({
+  [ATTR_UPSTASH_WORKFLOW_ERROR_TYPE]: attributes.errorType,
+  [ATTR_UPSTASH_WORKFLOW_FAILURE_URL]: attributes.failureUrl,
+  [ATTR_UPSTASH_WORKFLOW_INTERFACE]: attributes.interface,
+  [ATTR_UPSTASH_WORKFLOW_LABEL]: attributes.label,
+  [ATTR_UPSTASH_WORKFLOW_OPERATION]: attributes.operation,
+  [ATTR_UPSTASH_WORKFLOW_PATH]: attributes.path ?? normalizeUpstashWorkflowPath(attributes.url),
+  [ATTR_UPSTASH_WORKFLOW_RETRY_COUNT]: attributes.retries,
+  [ATTR_UPSTASH_WORKFLOW_RETRY_DELAY]: attributes.retryDelay,
+  [ATTR_UPSTASH_WORKFLOW_RUN_ID]: attributes.workflowRunId,
+  [ATTR_UPSTASH_WORKFLOW_STATUS]: attributes.status,
+  [ATTR_UPSTASH_WORKFLOW_STEP_NAME]: attributes.stepName,
+  [ATTR_UPSTASH_WORKFLOW_URL]: attributes.url,
 });
+
+/**
+ * Records one or more Upstash Workflow lifecycle events.
+ *
+ * Use when:
+ * - A QStash publish or Workflow trigger is attempted
+ * - A workflow route is served by Upstash
+ * - A workflow step or invoke call is submitted from a context
+ *
+ * Expects:
+ * - `count` is the number of events represented by this observation
+ *
+ * Returns:
+ * - Nothing; the observation is emitted to the active OTEL meter provider
+ */
+export const recordUpstashWorkflowEvent = (
+  attributes: UpstashWorkflowMetricAttributes,
+  count = 1,
+): void => {
+  workflowEventCounter.add(count, buildUpstashWorkflowMetricAttributes(attributes));
+};
+
+/**
+ * Wraps a WorkflowContext with step and invoke counters.
+ *
+ * Use when:
+ * - Wrapping an Upstash Workflow route function before passing it to `serve`
+ * - Counting `context.run(...)` and `context.invoke(...)` calls without editing each step
+ *
+ * Expects:
+ * - Upstash context methods keep their original `this` binding
+ *
+ * Returns:
+ * - The same context instance with wrapped methods
+ */
+export const withOtelMetricsForUpstashWorkflowContext = <
+  TInitialPayload,
+  TContext extends UpstashWorkflowContextLike<TInitialPayload>,
+>(
+  context: TContext,
+  baseAttributes?: Partial<UpstashWorkflowContextAttributes>,
+): TContext => {
+  const originalRun = context.run;
+
+  context.run = (async <TResult>(
+    stepName: string,
+    stepFunction: () => TResult | Promise<TResult>,
+  ): Promise<TResult | Promise<TResult>> => {
+    try {
+      const result = await originalRun.call(context, stepName, stepFunction);
+      recordUpstashWorkflowEvent({
+        ...baseAttributes,
+        ...context,
+        operation: 'step',
+        status: 'success',
+        stepName,
+      });
+
+      return result;
+    } catch (error) {
+      recordUpstashWorkflowEvent({
+        ...baseAttributes,
+        ...context,
+        errorType: errorNameFrom(error) ?? typeof error,
+        operation: 'step',
+        status: 'error',
+        stepName,
+      });
+
+      throw error;
+    }
+  }) as TContext['run'];
+
+  if (context.invoke) {
+    const originalInvoke = context.invoke;
+
+    context.invoke = (async <TResult = unknown>(
+      stepName: string,
+      settings: unknown,
+    ): Promise<TResult> => {
+      try {
+        const result = await originalInvoke.call(context, stepName, settings);
+        recordUpstashWorkflowEvent({
+          ...baseAttributes,
+          ...context,
+          operation: 'invoke',
+          status: 'success',
+          stepName,
+        });
+
+        return result;
+      } catch (error) {
+        recordUpstashWorkflowEvent({
+          ...baseAttributes,
+          ...context,
+          errorType: errorNameFrom(error) ?? typeof error,
+          operation: 'invoke',
+          status: 'error',
+          stepName,
+        });
+
+        throw error;
+      }
+    }) as TContext['invoke'];
+  }
+
+  return context;
+};
+
+/**
+ * Wraps an Upstash Workflow route function with serve, step, and invoke metrics.
+ *
+ * Use when:
+ * - Passing a handler to `@upstash/workflow/hono` or `@upstash/workflow/nextjs` `serve`
+ * - Counting inbound workflow deliveries and the steps they submit
+ *
+ * Expects:
+ * - The wrapped function receives a standard WorkflowContext-like object
+ *
+ * Returns:
+ * - A route function with the same result contract as the original handler
+ */
+export const withOtelMetricsForUpstashWorkflows = <TContext, TResult>(
+  routeFunction: (context: TContext) => Promise<TResult>,
+  baseAttributes?: Partial<UpstashWorkflowContextAttributes>,
+) => {
+  return async (context: TContext): Promise<TResult> => {
+    const instrumentedContext = withOtelMetricsForUpstashWorkflowContext(
+      context as TContext & UpstashWorkflowContextLike,
+      baseAttributes,
+    ) as TContext;
+
+    try {
+      const result = await routeFunction(instrumentedContext);
+      recordUpstashWorkflowEvent({
+        ...baseAttributes,
+        ...(context as UpstashWorkflowContextAttributes),
+        operation: 'serve',
+        status: 'success',
+      });
+
+      return result;
+    } catch (error) {
+      recordUpstashWorkflowEvent({
+        ...baseAttributes,
+        ...(context as UpstashWorkflowContextAttributes),
+        errorType: errorNameFrom(error) ?? typeof error,
+        operation: 'serve',
+        status: 'error',
+      });
+
+      throw error;
+    }
+  };
+};

--- a/packages/observability-otel/src/modules/upstash-workflow/index.ts
+++ b/packages/observability-otel/src/modules/upstash-workflow/index.ts
@@ -7,6 +7,7 @@ export const tracer = trace.getTracer('@lobechat/upstash-workflow', '0.0.1');
 export const ATTR_UPSTASH_WORKFLOW_OPERATION = 'upstash_workflow_operation' as const;
 export const ATTR_UPSTASH_WORKFLOW_STATUS = 'upstash_workflow_status' as const;
 export const ATTR_UPSTASH_WORKFLOW_INTERFACE = 'upstash_workflow_interface' as const;
+export const ATTR_UPSTASH_WORKFLOW_URL = 'upstash_workflow_url' as const;
 export const ATTR_UPSTASH_WORKFLOW_PATH = 'upstash_workflow_path' as const;
 export const ATTR_UPSTASH_WORKFLOW_RETRY_COUNT = 'upstash_workflow_retries' as const;
 export const ATTR_UPSTASH_WORKFLOW_RETRY_DELAY = 'upstash_workflow_retry_delay' as const;
@@ -94,6 +95,7 @@ export const normalizeUpstashWorkflowPath = (url?: string): string | undefined =
  * - `operation` and `status` are present for metric counter events
  * - `url` may be absolute or an already-normalized route path
  * - Per-run identifiers are excluded from metric labels to avoid high-cardinality series
+ * - `upstash_workflow_url` stores the normalized route path, not the absolute URL
  *
  * Returns:
  * - Attribute map accepted by OpenTelemetry metrics APIs
@@ -109,6 +111,7 @@ export const buildUpstashWorkflowMetricAttributes = (
   [ATTR_UPSTASH_WORKFLOW_RETRY_COUNT]: attributes.retries,
   [ATTR_UPSTASH_WORKFLOW_RETRY_DELAY]: attributes.retryDelay,
   [ATTR_UPSTASH_WORKFLOW_STATUS]: attributes.status,
+  [ATTR_UPSTASH_WORKFLOW_URL]: attributes.path ?? normalizeUpstashWorkflowPath(attributes.url),
 });
 
 /**

--- a/packages/observability-otel/src/modules/upstash-workflow/index.ts
+++ b/packages/observability-otel/src/modules/upstash-workflow/index.ts
@@ -7,14 +7,9 @@ export const tracer = trace.getTracer('@lobechat/upstash-workflow', '0.0.1');
 export const ATTR_UPSTASH_WORKFLOW_OPERATION = 'upstash_workflow_operation' as const;
 export const ATTR_UPSTASH_WORKFLOW_STATUS = 'upstash_workflow_status' as const;
 export const ATTR_UPSTASH_WORKFLOW_INTERFACE = 'upstash_workflow_interface' as const;
-export const ATTR_UPSTASH_WORKFLOW_RUN_ID = 'upstash_workflow_run_id' as const;
-export const ATTR_UPSTASH_WORKFLOW_URL = 'upstash_workflow_url' as const;
 export const ATTR_UPSTASH_WORKFLOW_PATH = 'upstash_workflow_path' as const;
-export const ATTR_UPSTASH_WORKFLOW_FAILURE_URL = 'upstash_workflow_failure_url' as const;
-export const ATTR_UPSTASH_WORKFLOW_LABEL = 'upstash_workflow_label' as const;
 export const ATTR_UPSTASH_WORKFLOW_RETRY_COUNT = 'upstash_workflow_retries' as const;
 export const ATTR_UPSTASH_WORKFLOW_RETRY_DELAY = 'upstash_workflow_retry_delay' as const;
-export const ATTR_UPSTASH_WORKFLOW_STEP_NAME = 'upstash_workflow_step_name' as const;
 export const ATTR_UPSTASH_WORKFLOW_ERROR_TYPE = 'upstash_workflow_error_type' as const;
 
 /**
@@ -98,6 +93,7 @@ export const normalizeUpstashWorkflowPath = (url?: string): string | undefined =
  * Expects:
  * - `operation` and `status` are present for metric counter events
  * - `url` may be absolute or an already-normalized route path
+ * - Per-run identifiers are excluded from metric labels to avoid high-cardinality series
  *
  * Returns:
  * - Attribute map accepted by OpenTelemetry metrics APIs
@@ -107,17 +103,12 @@ export const buildUpstashWorkflowMetricAttributes = (
     Partial<Omit<UpstashWorkflowMetricAttributes, keyof UpstashWorkflowContextAttributes>>,
 ): Record<string, boolean | number | string | undefined> => ({
   [ATTR_UPSTASH_WORKFLOW_ERROR_TYPE]: attributes.errorType,
-  [ATTR_UPSTASH_WORKFLOW_FAILURE_URL]: attributes.failureUrl,
   [ATTR_UPSTASH_WORKFLOW_INTERFACE]: attributes.interface,
-  [ATTR_UPSTASH_WORKFLOW_LABEL]: attributes.label,
   [ATTR_UPSTASH_WORKFLOW_OPERATION]: attributes.operation,
   [ATTR_UPSTASH_WORKFLOW_PATH]: attributes.path ?? normalizeUpstashWorkflowPath(attributes.url),
   [ATTR_UPSTASH_WORKFLOW_RETRY_COUNT]: attributes.retries,
   [ATTR_UPSTASH_WORKFLOW_RETRY_DELAY]: attributes.retryDelay,
-  [ATTR_UPSTASH_WORKFLOW_RUN_ID]: attributes.workflowRunId,
   [ATTR_UPSTASH_WORKFLOW_STATUS]: attributes.status,
-  [ATTR_UPSTASH_WORKFLOW_STEP_NAME]: attributes.stepName,
-  [ATTR_UPSTASH_WORKFLOW_URL]: attributes.url,
 });
 
 /**

--- a/src/app/(backend)/api/workflows/agent-eval-run/execute-test-case/route.ts
+++ b/src/app/(backend)/api/workflows/agent-eval-run/execute-test-case/route.ts
@@ -1,3 +1,4 @@
+import { withOtelMetricsForUpstashWorkflows } from '@lobechat/observability-otel/modules/upstash-workflow';
 import { serve } from '@upstash/workflow/nextjs';
 import debug from 'debug';
 
@@ -16,7 +17,7 @@ const log = debug('lobe-server:workflows:execute-test-case');
  * 3. Each trajectory executes the agent once and stores results
  */
 export const { POST } = serve<ExecuteTestCasePayload>(
-  async (context) => {
+  withOtelMetricsForUpstashWorkflows(async (context) => {
     const { runId, testCaseId, userId } = context.requestPayload ?? {};
 
     log('Starting: runId=%s testCaseId=%s', runId, testCaseId);
@@ -57,7 +58,7 @@ export const { POST } = serve<ExecuteTestCasePayload>(
     log('Completed: runId=%s testCaseId=%s k=%d', runId, testCaseId, k);
 
     return { k, success: true, testCaseId };
-  },
+  }),
   {
     flowControl: {
       key: 'agent-eval-run.execute-test-case',

--- a/src/app/(backend)/api/workflows/agent-eval-run/finalize-run/route.ts
+++ b/src/app/(backend)/api/workflows/agent-eval-run/finalize-run/route.ts
@@ -1,3 +1,4 @@
+import { withOtelMetricsForUpstashWorkflows } from '@lobechat/observability-otel/modules/upstash-workflow';
 import { serve } from '@upstash/workflow/nextjs';
 import debug from 'debug';
 
@@ -22,7 +23,7 @@ const log = debug('lobe-server:workflows:finalize-run');
  * 4. Update run status to 'completed'
  */
 export const { POST } = serve<FinalizeRunPayload>(
-  async (context) => {
+  withOtelMetricsForUpstashWorkflows(async (context) => {
     const { runId, userId } = context.requestPayload ?? {};
 
     log('Starting: runId=%s', runId);
@@ -95,7 +96,7 @@ export const { POST } = serve<FinalizeRunPayload>(
       runId,
       success: true,
     };
-  },
+  }),
   {
     flowControl: { key: 'agent-eval-run.finalize-run', parallelism: 10, rate: 1 },
     qstashClient,

--- a/src/app/(backend)/api/workflows/agent-eval-run/paginate-test-cases/route.ts
+++ b/src/app/(backend)/api/workflows/agent-eval-run/paginate-test-cases/route.ts
@@ -1,3 +1,4 @@
+import { withOtelMetricsForUpstashWorkflows } from '@lobechat/observability-otel/modules/upstash-workflow';
 import { serve } from '@upstash/workflow/nextjs';
 import debug from 'debug';
 import { chunk } from 'es-toolkit/compat';
@@ -20,7 +21,7 @@ const log = debug('lobe-server:workflows:paginate-test-cases');
  * Paginate test cases workflow - handles pagination, filtering, and fanout
  */
 export const { POST } = serve<PaginateTestCasesPayload>(
-  async (context) => {
+  withOtelMetricsForUpstashWorkflows(async (context) => {
     const { runId, cursor, testCaseIds: payloadTestCaseIds, userId } = context.requestPayload ?? {};
 
     log(
@@ -164,7 +165,7 @@ export const { POST } = serve<PaginateTestCasesPayload>(
       skippedTestCases: batchTestCaseIds.length - testCaseIds.length,
       success: true,
     };
-  },
+  }),
   {
     flowControl: { key: 'agent-eval-run.paginate-test-cases', parallelism: 200, rate: 5 },
     qstashClient,

--- a/src/app/(backend)/api/workflows/agent-eval-run/resume-agent-trajectory/route.ts
+++ b/src/app/(backend)/api/workflows/agent-eval-run/resume-agent-trajectory/route.ts
@@ -1,3 +1,4 @@
+import { withOtelMetricsForUpstashWorkflows } from '@lobechat/observability-otel/modules/upstash-workflow';
 import { serve } from '@upstash/workflow/nextjs';
 import debug from 'debug';
 
@@ -10,7 +11,7 @@ import { resolveAgentEvalRunWorkspace } from '@/server/workflows/agentEvalRun/ut
 const log = debug('lobe-server:workflows:resume-agent-trajectory');
 
 export const { POST } = serve<ResumeAgentTrajectoryPayload>(
-  async (context) => {
+  withOtelMetricsForUpstashWorkflows(async (context) => {
     const payload = context.requestPayload ?? {};
     const { runId, testCaseId, topicId, userId } = payload;
 
@@ -43,7 +44,7 @@ export const { POST } = serve<ResumeAgentTrajectoryPayload>(
     );
 
     return { success: true, testCaseId, topicId };
-  },
+  }),
   {
     flowControl: {
       key: 'agent-eval-run.resume-agent-trajectory',

--- a/src/app/(backend)/api/workflows/agent-eval-run/resume-thread-trajectory/route.ts
+++ b/src/app/(backend)/api/workflows/agent-eval-run/resume-thread-trajectory/route.ts
@@ -1,3 +1,4 @@
+import { withOtelMetricsForUpstashWorkflows } from '@lobechat/observability-otel/modules/upstash-workflow';
 import { serve } from '@upstash/workflow/nextjs';
 import debug from 'debug';
 
@@ -10,7 +11,7 @@ import { resolveAgentEvalRunWorkspace } from '@/server/workflows/agentEvalRun/ut
 const log = debug('lobe-server:workflows:resume-thread-trajectory');
 
 export const { POST } = serve<ResumeThreadTrajectoryPayload>(
-  async (context) => {
+  withOtelMetricsForUpstashWorkflows(async (context) => {
     const payload = context.requestPayload ?? {};
     const { runId, testCaseId, threadId, topicId, userId } = payload;
 
@@ -45,7 +46,7 @@ export const { POST } = serve<ResumeThreadTrajectoryPayload>(
     );
 
     return { success: true, testCaseId, threadId, topicId };
-  },
+  }),
   {
     flowControl: {
       key: 'agent-eval-run.resume-thread-trajectory',

--- a/src/app/(backend)/api/workflows/agent-eval-run/run-agent-trajectory/route.ts
+++ b/src/app/(backend)/api/workflows/agent-eval-run/run-agent-trajectory/route.ts
@@ -1,3 +1,4 @@
+import { withOtelMetricsForUpstashWorkflows } from '@lobechat/observability-otel/modules/upstash-workflow';
 import { serve } from '@upstash/workflow/nextjs';
 import debug from 'debug';
 
@@ -18,7 +19,7 @@ const log = debug('lobe-server:workflows:run-agent-trajectory');
  * For k>1: creates K threads and triggers K run-thread-trajectory sub-workflows
  */
 export const { POST } = serve<RunAgentTrajectoryPayload>(
-  async (context) => {
+  withOtelMetricsForUpstashWorkflows(async (context) => {
     const { runId, testCaseId, userId } = context.requestPayload ?? {};
 
     log('Starting: runId=%s testCaseId=%s', runId, testCaseId);
@@ -109,7 +110,7 @@ export const { POST } = serve<RunAgentTrajectoryPayload>(
       testCaseId,
       topicId: result.topicId,
     };
-  },
+  }),
   {
     flowControl: {
       key: 'agent-eval-run.run-agent-trajectory',

--- a/src/app/(backend)/api/workflows/agent-eval-run/run-benchmark/route.ts
+++ b/src/app/(backend)/api/workflows/agent-eval-run/run-benchmark/route.ts
@@ -1,3 +1,4 @@
+import { withOtelMetricsForUpstashWorkflows } from '@lobechat/observability-otel/modules/upstash-workflow';
 import { serve } from '@upstash/workflow/nextjs';
 import debug from 'debug';
 
@@ -19,7 +20,7 @@ const log = debug('lobe-server:workflows:run-benchmark');
  * 6. Trigger paginate-test-cases workflow
  */
 export const { POST } = serve<RunBenchmarkPayload>(
-  async (context) => {
+  withOtelMetricsForUpstashWorkflows(async (context) => {
     const { runId, dryRun, force, userId } = context.requestPayload ?? {};
 
     log('Starting: runId=%s dryRun=%s force=%s', runId, dryRun, force);
@@ -126,7 +127,7 @@ export const { POST } = serve<RunBenchmarkPayload>(
       ...result,
       message: `Triggered pagination for ${testCaseIds.length} test cases`,
     };
-  },
+  }),
   {
     flowControl: { key: 'agent-eval-run.process-run', parallelism: 100, rate: 1 },
     qstashClient,

--- a/src/app/(backend)/api/workflows/agent-eval-run/run-thread-trajectory/route.ts
+++ b/src/app/(backend)/api/workflows/agent-eval-run/run-thread-trajectory/route.ts
@@ -1,3 +1,4 @@
+import { withOtelMetricsForUpstashWorkflows } from '@lobechat/observability-otel/modules/upstash-workflow';
 import { serve } from '@upstash/workflow/nextjs';
 import debug from 'debug';
 
@@ -17,7 +18,7 @@ const log = debug('lobe-server:workflows:run-thread-trajectory');
  * Each thread is an independent execution of the same test case.
  */
 export const { POST } = serve<RunThreadTrajectoryPayload>(
-  async (context) => {
+  withOtelMetricsForUpstashWorkflows(async (context) => {
     const { runId, testCaseId, threadId, topicId, userId } = context.requestPayload ?? {};
 
     log('Starting: runId=%s testCaseId=%s threadId=%s', runId, testCaseId, threadId);
@@ -95,7 +96,7 @@ export const { POST } = serve<RunThreadTrajectoryPayload>(
     log('Thread agent started: runId=%s testCaseId=%s threadId=%s', runId, testCaseId, threadId);
 
     return { success: true, testCaseId, threadId, topicId };
-  },
+  }),
   {
     flowControl: {
       key: 'agent-eval-run.run-thread-trajectory',

--- a/src/libs/qstash/index.ts
+++ b/src/libs/qstash/index.ts
@@ -1,5 +1,7 @@
-import { Client, Receiver } from '@upstash/qstash';
-import { Client as WorkflowClient } from '@upstash/workflow';
+import { recordUpstashWorkflowEvent } from '@lobechat/observability-otel/modules/upstash-workflow';
+import { errorNameFrom } from '@lobechat/utils';
+import { Client, type PublishRequest, type PublishResponse, Receiver } from '@upstash/qstash';
+import { Client as WorkflowClient, type TriggerOptions } from '@upstash/workflow';
 import debug from 'debug';
 
 const log = debug('lobe-server:qstash');
@@ -10,13 +12,131 @@ const headers = {
   }),
 };
 
+const normalizeLabel = (label?: string | string[]): string | undefined =>
+  Array.isArray(label) ? label.join(',') : label;
+
+type WorkflowTriggerResponse = { workflowRunId: string };
+
+/**
+ * QStash client that records OTEL metrics for outbound JSON publishes.
+ *
+ * Use when:
+ * - Publishing QStash JSON messages from server code
+ * - Passing a QStash client into Upstash Workflow `serve()` options
+ *
+ * Expects:
+ * - The base `Client` handles authentication and request serialization
+ *
+ * Returns:
+ * - The same publish response as `@upstash/qstash` `Client.publishJSON`
+ */
+export class OtelQstashClient extends Client {
+  override async publishJSON<
+    TBody = unknown,
+    TRequest extends PublishRequest<TBody> = PublishRequest<TBody>,
+  >(request: TRequest): Promise<PublishResponse<TRequest>> {
+    try {
+      const response = await super.publishJSON(request);
+      recordUpstashWorkflowEvent({
+        interface: 'qstash',
+        label: normalizeLabel(request.label),
+        operation: 'trigger',
+        retries: request.retries,
+        retryDelay: request.retryDelay,
+        status: 'success',
+        url: request.url,
+      });
+
+      return response;
+    } catch (error) {
+      recordUpstashWorkflowEvent({
+        errorType: errorNameFrom(error) ?? typeof error,
+        interface: 'qstash',
+        label: normalizeLabel(request.label),
+        operation: 'trigger',
+        retries: request.retries,
+        retryDelay: request.retryDelay,
+        status: 'error',
+        url: request.url,
+      });
+
+      throw error;
+    }
+  }
+}
+
+/**
+ * Upstash Workflow client that records OTEL metrics for outbound triggers.
+ *
+ * Use when:
+ * - Triggering Upstash Workflow runs from app code
+ * - Preserving the native workflow client API while adding metrics
+ *
+ * Expects:
+ * - Trigger params are either one workflow trigger or a batch of triggers
+ *
+ * Returns:
+ * - The same trigger response shape as `@upstash/workflow` `Client.trigger`
+ */
+export class OtelWorkflowClient extends WorkflowClient {
+  override trigger(params: TriggerOptions): Promise<WorkflowTriggerResponse>;
+  override trigger(params: TriggerOptions[]): Promise<WorkflowTriggerResponse[]>;
+  override async trigger(
+    params: TriggerOptions | TriggerOptions[],
+  ): Promise<WorkflowTriggerResponse | WorkflowTriggerResponse[]> {
+    const first = Array.isArray(params) ? params[0] : params;
+    const count = Array.isArray(params) ? params.length : 1;
+
+    try {
+      const response = Array.isArray(params)
+        ? await super.trigger(params)
+        : await super.trigger(params);
+
+      recordUpstashWorkflowEvent(
+        {
+          interface: 'workflow',
+          label: first?.label,
+          operation: 'trigger',
+          retries: first?.retries,
+          retryDelay: first?.retryDelay,
+          status: 'success',
+          url: first?.url,
+          workflowRunId: Array.isArray(response)
+            ? response[0]?.workflowRunId
+            : response.workflowRunId,
+        },
+        count,
+      );
+
+      return response;
+    } catch (error) {
+      recordUpstashWorkflowEvent(
+        {
+          errorType: errorNameFrom(error) ?? typeof error,
+          interface: 'workflow',
+          label: first?.label,
+          operation: 'trigger',
+          retries: first?.retries,
+          retryDelay: first?.retryDelay,
+          status: 'error',
+          url: first?.url,
+          workflowRunId: first?.workflowRunId,
+        },
+        count,
+      );
+
+      throw error;
+    }
+  }
+}
+
 /**
  * QStash client with Vercel Deployment Protection bypass headers.
  * Use as `qstashClient` option in Upstash Workflow `serve()`.
  *
  * @see https://upstash.com/docs/workflow/troubleshooting/vercel
  */
-export const qstashClient = new Client({
+export const qstashClient = new OtelQstashClient({
   headers,
   token: process.env.QSTASH_TOKEN!,
 });
@@ -25,7 +145,7 @@ export const qstashClient = new Client({
  * Workflow client with Vercel Deployment Protection bypass headers.
  * Use for triggering workflows via `workflowClient.trigger()`.
  */
-export const workflowClient = new WorkflowClient({
+export const workflowClient = new OtelWorkflowClient({
   headers,
   token: process.env.QSTASH_TOKEN!,
 });

--- a/src/server/agent-hono/middlewares/qstashAuth.ts
+++ b/src/server/agent-hono/middlewares/qstashAuth.ts
@@ -1,3 +1,5 @@
+import { recordUpstashWorkflowEvent } from '@lobechat/observability-otel/modules/upstash-workflow';
+import { errorNameFrom } from '@lobechat/utils';
 import debug from 'debug';
 import type { MiddlewareHandler } from 'hono';
 
@@ -18,8 +20,33 @@ export const qstashAuth = (): MiddlewareHandler => async (c, next) => {
 
   if (!isValid) {
     log('Rejected: invalid QStash signature on %s', c.req.path);
+    recordUpstashWorkflowEvent({
+      errorType: 'InvalidSignature',
+      interface: 'qstash',
+      operation: 'serve',
+      path: c.req.path,
+      status: 'error',
+    });
+
     return c.json({ error: 'Invalid signature' }, 401);
   }
 
-  await next();
+  try {
+    await next();
+    recordUpstashWorkflowEvent({
+      interface: 'qstash',
+      operation: 'serve',
+      path: c.req.path,
+      status: 'success',
+    });
+  } catch (error) {
+    recordUpstashWorkflowEvent({
+      errorType: errorNameFrom(error) ?? typeof error,
+      interface: 'qstash',
+      operation: 'serve',
+      path: c.req.path,
+      status: 'error',
+    });
+    throw error;
+  }
 };

--- a/src/server/agent-hono/middlewares/qstashOrApiKeyAuth.ts
+++ b/src/server/agent-hono/middlewares/qstashOrApiKeyAuth.ts
@@ -1,3 +1,5 @@
+import { recordUpstashWorkflowEvent } from '@lobechat/observability-otel/modules/upstash-workflow';
+import { errorNameFrom } from '@lobechat/utils';
 import debug from 'debug';
 import type { MiddlewareHandler } from 'hono';
 
@@ -32,8 +34,38 @@ export const qstashOrApiKeyAuth = (): MiddlewareHandler => async (c, next) => {
 
   if (!isValidQStash && !isValidApiKey) {
     log('Rejected: neither QStash sig nor API key matched on %s', c.req.path);
+    recordUpstashWorkflowEvent({
+      errorType: 'Unauthorized',
+      interface: 'qstash',
+      operation: 'serve',
+      path: c.req.path,
+      status: 'error',
+    });
+
     return c.json({ error: 'Unauthorized - Valid QStash signature or API key required' }, 401);
   }
 
-  await next();
+  try {
+    await next();
+    if (isValidQStash) {
+      recordUpstashWorkflowEvent({
+        interface: 'qstash',
+        operation: 'serve',
+        path: c.req.path,
+        status: 'success',
+      });
+    }
+  } catch (error) {
+    if (isValidQStash) {
+      recordUpstashWorkflowEvent({
+        errorType: errorNameFrom(error) ?? typeof error,
+        interface: 'qstash',
+        operation: 'serve',
+        path: c.req.path,
+        status: 'error',
+      });
+    }
+
+    throw error;
+  }
 };

--- a/src/server/workflows-hono/agent-signal/index.ts
+++ b/src/server/workflows-hono/agent-signal/index.ts
@@ -1,3 +1,4 @@
+import { withOtelMetricsForUpstashWorkflows } from '@lobechat/observability-otel/modules/upstash-workflow';
 import { serve } from '@upstash/workflow/hono';
 import { Hono } from 'hono';
 
@@ -14,9 +15,14 @@ app.post('/cron-hourly-nightly-self-review', qstashAuth(), scheduleNightlyReview
 
 app.post(
   '/run',
-  serve<AgentSignalWorkflowRunPayload>((context) => runAgentSignalWorkflow(context), {
-    qstashClient: createWorkflowQstashClient(),
-  }),
+  serve<AgentSignalWorkflowRunPayload>(
+    withOtelMetricsForUpstashWorkflows((context) => runAgentSignalWorkflow(context), {
+      url: '/api/workflows/agent-signal/run',
+    }),
+    {
+      qstashClient: createWorkflowQstashClient(),
+    },
+  ),
 );
 
 export default app;

--- a/src/server/workflows-hono/memory-user-memory/index.ts
+++ b/src/server/workflows-hono/memory-user-memory/index.ts
@@ -1,3 +1,4 @@
+import { withOtelMetricsForUpstashWorkflows } from '@lobechat/observability-otel/modules/upstash-workflow';
 import { serve, serveMany } from '@upstash/workflow/hono';
 import { Hono } from 'hono';
 
@@ -16,36 +17,61 @@ const app = new Hono();
 
 app.post(
   '/call-cron-hourly-analysis',
-  serve(hourlyWorkflowHandler, {
-    ...hourlyWorkflowOptions,
-    qstashClient: createWorkflowQstashClient(),
-  }),
+  serve(
+    withOtelMetricsForUpstashWorkflows(hourlyWorkflowHandler, {
+      url: '/api/workflows/memory-user-memory/call-cron-hourly-analysis',
+    }),
+    {
+      ...hourlyWorkflowOptions,
+      qstashClient: createWorkflowQstashClient(),
+    },
+  ),
 );
 
 app.post(
   '/pipelines/persona/update-writing',
-  serve(personaUpdateHandler, { qstashClient: createWorkflowQstashClient() }),
+  serve(
+    withOtelMetricsForUpstashWorkflows(personaUpdateHandler, {
+      url: '/api/workflows/memory-user-memory/pipelines/persona/update-writing',
+    }),
+    { qstashClient: createWorkflowQstashClient() },
+  ),
 );
 
 app.post(
   '/pipelines/chat-topic/process-users',
-  serve(processUsersHandler, {
-    ...processUsersWorkflowOptions,
-    qstashClient: createWorkflowQstashClient(),
-  }),
+  serve(
+    withOtelMetricsForUpstashWorkflows(processUsersHandler, {
+      url: '/api/workflows/memory-user-memory/pipelines/chat-topic/process-users',
+    }),
+    {
+      ...processUsersWorkflowOptions,
+      qstashClient: createWorkflowQstashClient(),
+    },
+  ),
 );
 
 app.post(
   '/pipelines/chat-topic/process-user-topics',
-  serve(processUserTopicsHandler, {
-    ...processUserTopicsWorkflowOptions,
-    qstashClient: createWorkflowQstashClient(),
-  }),
+  serve(
+    withOtelMetricsForUpstashWorkflows(processUserTopicsHandler, {
+      url: '/api/workflows/memory-user-memory/pipelines/chat-topic/process-user-topics',
+    }),
+    {
+      ...processUserTopicsWorkflowOptions,
+      qstashClient: createWorkflowQstashClient(),
+    },
+  ),
 );
 
 app.post(
   '/pipelines/chat-topic/process-topics',
-  serve(processTopicsHandler, { qstashClient: createWorkflowQstashClient() }),
+  serve(
+    withOtelMetricsForUpstashWorkflows(processTopicsHandler, {
+      url: '/api/workflows/memory-user-memory/pipelines/chat-topic/process-topics',
+    }),
+    { qstashClient: createWorkflowQstashClient() },
+  ),
 );
 
 // NOTICE: Must use serveMany here. The `context.invoke(processTopicWorkflow)` call in

--- a/src/server/workflows-hono/memory-user-memory/workflows/processTopic.ts
+++ b/src/server/workflows-hono/memory-user-memory/workflows/processTopic.ts
@@ -1,7 +1,8 @@
 import { SpanStatusCode } from '@lobechat/observability-otel/api';
 import {
-  buildUpstashWorkflowAttributes,
+  buildUpstashWorkflowMetricAttributes,
   tracer as upstashWorkflowTracer,
+  withOtelMetricsForUpstashWorkflows,
 } from '@lobechat/observability-otel/modules/upstash-workflow';
 import { LayersEnum, MemorySourceType } from '@lobechat/types';
 import { errorMessageFrom } from '@lobechat/utils';
@@ -38,7 +39,7 @@ const processTopicRoute = async (context: WorkflowContext<MemoryExtractionPayloa
       const payload = normalizeMemoryExtractionPayload(context.requestPayload || {});
 
       span.setAttributes({
-        ...buildUpstashWorkflowAttributes(context),
+        ...buildUpstashWorkflowMetricAttributes(context),
         'workflow.memory_user_memory.layers': payload.layers.join(','),
         'workflow.memory_user_memory.source': payload.sources.join(','),
         'workflow.memory_user_memory.topic_id': payload.topicIds[0],
@@ -200,7 +201,9 @@ const processTopicRoute = async (context: WorkflowContext<MemoryExtractionPayloa
   );
 
 export const processTopicWorkflow = createWorkflow<MemoryExtractionPayloadInput, unknown>(
-  processTopicRoute,
+  withOtelMetricsForUpstashWorkflows(processTopicRoute, {
+    url: '/api/workflows/memory-user-memory/pipelines/chat-topic/process-topic',
+  }),
   {
     failureFunction: async ({ context, failStatus, failResponse }) => {
       try {

--- a/src/server/workflows-hono/memory-user-memory/workflows/processTopics.ts
+++ b/src/server/workflows-hono/memory-user-memory/workflows/processTopics.ts
@@ -1,6 +1,6 @@
 import { SpanStatusCode } from '@lobechat/observability-otel/api';
 import {
-  buildUpstashWorkflowAttributes,
+  buildUpstashWorkflowMetricAttributes,
   tracer as upstashWorkflowTracer,
 } from '@lobechat/observability-otel/modules/upstash-workflow';
 import { LayersEnum, MemorySourceType } from '@lobechat/types';
@@ -37,7 +37,7 @@ export const processTopicsHandler = (context: WorkflowContext<MemoryExtractionPa
       const payload = normalizeMemoryExtractionPayload(context.requestPayload || {});
 
       span.setAttributes({
-        ...buildUpstashWorkflowAttributes(context),
+        ...buildUpstashWorkflowMetricAttributes(context),
         'workflow.memory_user_memory.force_all': payload.forceAll,
         'workflow.memory_user_memory.force_topics': payload.forceTopics,
         'workflow.memory_user_memory.layers': payload.layers.join(','),

--- a/src/server/workflows-hono/middlewares/qstashAuth.ts
+++ b/src/server/workflows-hono/middlewares/qstashAuth.ts
@@ -1,3 +1,5 @@
+import { recordUpstashWorkflowEvent } from '@lobechat/observability-otel/modules/upstash-workflow';
+import { errorNameFrom } from '@lobechat/utils';
 import debug from 'debug';
 import type { MiddlewareHandler } from 'hono';
 
@@ -24,11 +26,39 @@ const log = debug('lobe-server:workflows:qstash-auth');
 export const qstashAuth = (): MiddlewareHandler => async (c, next) => {
   if (process.env.QSTASH_CURRENT_SIGNING_KEY) {
     const rawBody = await c.req.text();
+
     const ok = await verifyQStashSignature(c.req.raw, rawBody);
     if (!ok) {
       log('Rejected: invalid QStash signature on %s', c.req.path);
+      recordUpstashWorkflowEvent({
+        errorType: 'InvalidSignature',
+        interface: 'qstash',
+        operation: 'serve',
+        path: c.req.path,
+        status: 'error',
+      });
+
       return c.json({ error: 'Invalid signature' }, 401);
     }
   }
-  await next();
+  try {
+    await next();
+
+    recordUpstashWorkflowEvent({
+      interface: 'qstash',
+      operation: 'serve',
+      path: c.req.path,
+      status: 'success',
+    });
+  } catch (error) {
+    recordUpstashWorkflowEvent({
+      errorType: errorNameFrom(error) ?? typeof error,
+      interface: 'qstash',
+      operation: 'serve',
+      path: c.req.path,
+      status: 'error',
+    });
+
+    throw error;
+  }
 };

--- a/src/server/workflows-hono/qstashClient.ts
+++ b/src/server/workflows-hono/qstashClient.ts
@@ -1,5 +1,4 @@
-import { Client } from '@upstash/qstash';
-
+import { OtelQstashClient } from '@/libs/qstash';
 import { parseMemoryExtractionConfig } from '@/server/globalConfig/parseMemoryExtractionConfig';
 
 const { upstashWorkflowExtraHeaders } = parseMemoryExtractionConfig();
@@ -9,7 +8,7 @@ const { upstashWorkflowExtraHeaders } = parseMemoryExtractionConfig();
 // a shared QStash client. See:
 // https://upstash.com/docs/workflow/troubleshooting/vercel#step-2-pass-header-when-triggering
 export const createWorkflowQstashClient = () =>
-  new Client({
+  new OtelQstashClient({
     headers: { ...upstashWorkflowExtraHeaders },
     token: process.env.QSTASH_TOKEN!,
   });


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Adds shared OpenTelemetry metrics for Upstash Workflow and QStash lifecycle events.

- Add `upstash_workflow_events_total` with Prometheus-friendly labels.
- Count workflow trigger, step, invoke, and serve events with success/error status.
- Add OTEL wrappers for Upstash Workflow route/context handling.
- Add OTEL-aware QStash and Workflow client subclasses instead of monkey-patching methods with `.bind`.
- Wire metrics into existing workflow, QStash, and agent-eval-run routes.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Automated / local checks:

- `pnpm --dir lobehub exec eslint packages/observability-otel/src/modules/upstash-workflow/index.ts --concurrency=auto`
- `pnpm --dir lobehub exec eslint packages/observability-otel/src/modules/upstash-workflow/index.ts src/libs/qstash/index.ts src/server/workflows-hono/qstashClient.ts src/server/workflows-hono/agent-signal/index.ts src/server/workflows-hono/memory-user-memory/index.ts src/server/workflows-hono/memory-user-memory/workflows/processTopic.ts src/server/workflows-hono/memory-user-memory/workflows/processTopics.ts src/server/workflows-hono/middlewares/qstashAuth.ts src/server/agent-hono/middlewares/qstashAuth.ts src/server/agent-hono/middlewares/qstashOrApiKeyAuth.ts apps/server/src/services/memory/userMemory/extract.ts apps/server/src/services/queue/impls/qstash.ts apps/server/src/services/agentRuntime/hooks/HookDispatcher.ts 'src/app/(backend)/api/workflows/agent-eval-run/run-benchmark/route.ts' 'src/app/(backend)/api/workflows/agent-eval-run/paginate-test-cases/route.ts' 'src/app/(backend)/api/workflows/agent-eval-run/execute-test-case/route.ts' 'src/app/(backend)/api/workflows/agent-eval-run/run-agent-trajectory/route.ts' 'src/app/(backend)/api/workflows/agent-eval-run/run-thread-trajectory/route.ts' 'src/app/(backend)/api/workflows/agent-eval-run/resume-agent-trajectory/route.ts' 'src/app/(backend)/api/workflows/agent-eval-run/resume-thread-trajectory/route.ts' 'src/app/(backend)/api/workflows/agent-eval-run/finalize-run/route.ts' --concurrency=auto`
- Local OTEL SDK check with `InMemoryMetricExporter`: verified step, invoke, and serve points are collected.
- Backend observability check via `./.agents/skills/backend-dev/scripts/hack-local/prometheus`: verified `upstash_workflow_events_total` series appears in Prometheus with expected labels.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

The metric and label names intentionally use underscore naming to match existing Prometheus-facing metrics and avoid dotted label-name translation issues in the collector pipeline.
