### PR TITLE
🐛 fix(mobile): stabilize topic modal navigation

### DIFF
--- a/src/routes/(mobile)/chat/features/Topic/features/TopicModal.tsx
+++ b/src/routes/(mobile)/chat/features/Topic/features/TopicModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { PropsWithChildren } from 'react';
-import { memo, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import ImperativeModal from '@/components/ImperativeModal';
@@ -21,6 +21,12 @@ const Topics = memo(({ children }: PropsWithChildren) => {
   const [overlayContainer, setOverlayContainer] = useState<HTMLDivElement | null>(null);
 
   useFetchTopics();
+
+  useEffect(() => {
+    return () => {
+      toggleConfig(false);
+    };
+  }, [toggleConfig]);
 
   return (
     <OverlayContainerContext value={overlayContainer}>

--- a/src/spa/router/mobileRouter.config.tsx
+++ b/src/spa/router/mobileRouter.config.tsx
@@ -12,6 +12,8 @@ import { agentRouteMeta } from '@/routes/(main)/agent/features/routeMeta';
 import { shareTopicRouteMeta } from '@/routes/share/t/[id]/routeMeta';
 import { dynamicElement, dynamicLayout, ErrorBoundary, redirectElement } from '@/utils/router';
 
+const mobileChatElement = dynamicElement(() => import('@/routes/(mobile)/chat'), 'Mobile > Chat');
+
 /**
  * Children shared between `/` and `/:workspaceSlug` for mobile. Mobile only
  * mirrors the subset of routes it actually supports — settings / me / default
@@ -28,15 +30,12 @@ export const sharedMainAreaChildren: RouteObject[] = [
       {
         children: [
           {
-            element: dynamicElement(() => import('@/routes/(mobile)/chat'), 'Mobile > Chat'),
+            element: mobileChatElement,
             handle: { meta: agentRouteMeta },
             index: true,
           },
           {
-            element: dynamicElement(
-              () => import('@/routes/(mobile)/chat'),
-              'Mobile > Chat > Topic',
-            ),
+            element: mobileChatElement,
             handle: { meta: agentRouteMeta },
             path: ':topicId',
           },

--- a/src/spa/router/mobileRouter.test.tsx
+++ b/src/spa/router/mobileRouter.test.tsx
@@ -3,12 +3,12 @@ import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+const readMobileRouterSource = () =>
+  readFile(path.join(process.cwd(), 'src/spa/router/mobileRouter.config.tsx'), 'utf8');
+
 describe('mobileRouter task routes', () => {
   it('registers task list and detail routes under the shared workspace layout', async () => {
-    const source = await readFile(
-      path.join(process.cwd(), 'src/spa/router/mobileRouter.config.tsx'),
-      'utf8',
-    );
+    const source = await readMobileRouterSource();
 
     expect(source).toContain("import('@/routes/(main)/(task-workspace)/_layout')");
     expect(source).toContain("import('@/routes/(main)/tasks')");
@@ -19,5 +19,15 @@ describe('mobileRouter task routes', () => {
     expect(source).toContain("path: ':taskId'");
     expect(source).toContain("path: ':aid/task/:taskId'");
     expect(source).not.toContain("import('@/routes/(main)/tasks/_layout')");
+  });
+
+  it('reuses one chat element for agent index and topic routes', async () => {
+    const source = await readMobileRouterSource();
+
+    expect(source).toContain(
+      "const mobileChatElement = dynamicElement(() => import('@/routes/(mobile)/chat'), 'Mobile > Chat');",
+    );
+    expect(source.match(/element:\s*mobileChatElement/g)).toHaveLength(2);
+    expect(source.match(/import\('@\/routes\/\(mobile\)\/chat'\)/g)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #16732

#### 🔀 Description of Change

This PR stabilizes the mobile topic selector navigation path described in #16732.

- Reuse the same mobile chat route element for both the agent index route and topic route, so selecting a topic from the mobile selector follows the same chat route instance instead of swapping between separate dynamic elements.
- Reset the mobile topic modal config state when the topic modal unmounts, preventing leftover modal/overlay state from blocking later interactions after leaving the chat page.
- Add coverage that keeps the mobile router using a single shared chat element for the index and topic routes.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx eslint 'src/spa/router/mobileRouter.config.tsx' 'src/spa/router/mobileRouter.test.tsx' 'src/routes/(mobile)/chat/features/Topic/features/TopicModal.tsx'
bunx vitest run --silent='passed-only' 'src/spa/router/mobileRouter.test.tsx'
bunx vitest run --silent='passed-only' 'src/routes/(main)/agent/_layout/Sidebar/Topic/hooks/useTopicNavigation.test.tsx'
```

Verified the mobile topic selector flow for switching into an existing topic and leaving the chat page while the topic modal is open.

#### 📸 Screenshots / Videos

N/A, behavior fix without visual changes.

#### 📝 Additional Information

The issue is isolated to the mobile topic selector/modal navigation path. Direct mobile URL access and desktop topic navigation already load the updated topic state correctly.
