### PR TITLE
🐛 fix(workflow): await run guard cancellation after redis

### DIFF
--- a/src/app/(backend)/api/webhooks/workflows/run-guard/route.test.ts
+++ b/src/app/(backend)/api/webhooks/workflows/run-guard/route.test.ts
@@ -167,10 +167,17 @@ describe('workflow run guard webhook route', () => {
    */
   it('cancels qstash runs for path guards when policy requests it', async () => {
     process.env.MEMORY_USER_MEMORY_WEBHOOK_BASE_URL = 'https://internal.lobehub.com';
-    redis.set.mockResolvedValue('OK');
-    mockCancelWorkflowRunsByGuardPolicy.mockResolvedValue({
-      cancelled: 1,
-      workflowUrlPrefix: 'https://internal.lobehub.com/api/workflows/memory-user-memory',
+    const calls: string[] = [];
+    redis.set.mockImplementation(async () => {
+      calls.push('redis:set');
+      return 'OK';
+    });
+    mockCancelWorkflowRunsByGuardPolicy.mockImplementation(async () => {
+      calls.push('qstash:cancel');
+      return {
+        cancelled: 1,
+        workflowUrlPrefix: 'https://internal.lobehub.com/api/workflows/memory-user-memory',
+      };
     });
 
     const response = await POST(
@@ -200,6 +207,7 @@ describe('workflow run guard webhook route', () => {
       appUrl: 'https://internal.lobehub.com',
       workflowPath: 'api/workflows/memory-user-memory',
     });
+    expect(calls).toEqual(['redis:set', 'qstash:cancel']);
   });
 
   /**

--- a/src/app/(backend)/api/webhooks/workflows/run-guard/route.ts
+++ b/src/app/(backend)/api/webhooks/workflows/run-guard/route.ts
@@ -103,16 +103,18 @@ export const POST = async (request: Request) => {
       },
     });
 
-    let qstash;
+    let qstashPromise: ReturnType<typeof cancelWorkflowRunsByGuardPolicy> | undefined;
 
     if (policy?.cancelQstash && scope.type === 'path') {
       if (!appUrl) throw new Error('App URL is not configured');
 
-      qstash = await cancelWorkflowRunsByGuardPolicy({
+      qstashPromise = cancelWorkflowRunsByGuardPolicy({
         appUrl,
         workflowPath: scope.workflowPath,
       });
     }
+
+    const qstash = await qstashPromise;
 
     return NextResponse.json({ guard, qstash, success: true });
   } catch (error) {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #16731
Related to LOBE-11422

#### 🔀 Description of Change

This follow-up makes the run-guard webhook cancellation order explicit:

- Write the Redis run guard first.
- Start QStash cancellation only after the Redis guard has been stored.
- Await the cancellation promise before returning the webhook response so callers still receive the QStash result/error.
- Add regression coverage that records the call order as `redis:set` before `qstash:cancel`.

The previous implementation already awaited Redis before cancellation. This PR keeps that behavior while making the promise lifecycle harder to accidentally reorder in future edits.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
pnpm --dir lobehub exec vitest run --silent='passed-only' 
  'src/app/(backend)/api/webhooks/workflows/run-guard/route.test.ts'

pnpm --dir lobehub exec eslint 
  'src/app/(backend)/api/webhooks/workflows/run-guard/route.ts' 
  'src/app/(backend)/api/webhooks/workflows/run-guard/route.test.ts' 
  --concurrency=auto

git -C lobehub diff --check
```

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

This does not change the fail-closed behavior: if QStash cancellation fails, the route still returns the cancellation error after Redis has already stored the guard.