### PR TITLE
✨ feat(task): show run last message on run card & unify topic/task status icons

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -165,6 +165,33 @@ Default control height is 36px (`controlHeight`); use `controlHeightSM` 28px and
 
 Style components with lobe-ui's styling layer: prefer `createStaticStyles` with `cssVar.*` (zero-runtime) and fall back to `createStyles` + `token` only when styles need runtime computation.
 
+## Status Icons
+
+Topic and task surfaces speak **one status-icon language**. There is a single source of truth — `STATUS_META` in `src/components/StatusIcon` — and every surface (sidebar group headers, list rows, kanban, tags, detail) maps its own status enum onto a canonical `StatusKind` and reads icon + color from there. Never redefine a local status→icon map.
+
+The vocabulary is built on the lucide `Circle-*` family so all states read as one set:
+
+| Kind             | Icon           | Color token            | Meaning                                                                           |
+| ---------------- | -------------- | ---------------------- | --------------------------------------------------------------------------------- |
+| `running`        | `CircleDot`    | `colorWarning`         | actively executing (static glyph)                                                 |
+| `scheduled`      | `Clock`        | `colorWarning`         | queued for a future run                                                           |
+| `needsAttention` | `Hand`         | `colorInfo`            | a human is needed (topic `pending`/`waitingForHuman`, task `paused`/`needsInput`) |
+| `paused`         | `PauseCircle`  | `colorTextDescription` | genuinely suspended                                                               |
+| `completed`      | `CircleCheck`  | `colorSuccess`         | finished successfully                                                             |
+| `failed`         | `CircleX`      | `colorError`           | errored                                                                           |
+| `backlog`        | `CircleDashed` | `colorTextQuaternary`  | not started / idle                                                                |
+| `active`         | `CircleDot`    | `colorTextTertiary`    | open topic, not running                                                           |
+| `canceled`       | `CircleSlash`  | `colorTextSecondary`   | canceled                                                                          |
+| `archived`       | `Archive`      | `colorTextDescription` | archived                                                                          |
+| `timeout`        | `CircleAlert`  | `colorWarning`         | timed out                                                                         |
+
+Two rules the map encodes:
+
+- **`running` is two-tier.** Group headers / summaries / count-badges show the **static** `CircleDot`. A row that is executing **right now** shows the **animated** `RingLoadingIcon` (the same CircleDot, spinning) — the one canonical live spinner; don't hand-roll another.
+- **`Hand` means "needs you", never "paused".** `needsAttention` (blue hand) and `paused` (grey pause) are distinct concepts and must not be merged, even though task-land historically labeled the attention state `paused`.
+
+> Migration note: a few topic surfaces still render legacy grey `CheckCircle2` (`completed`) / `TriangleAlert` (`failed`) locally instead of the canonical green-check / red-cross. Converging those two is a deferred follow-up — new code should use `STATUS_META`.
+
 ## Voice & Content
 
 Copy is part of the design — precise, calm, and free of filler. The voice is youthful, friendly, and modern on the surface; professional, reliable, and control-first underneath (reference points: Notion, Figma, Apple, Discord, OpenAI).

--- a/apps/server/src/services/task/index.test.ts
+++ b/apps/server/src/services/task/index.test.ts
@@ -630,6 +630,61 @@ describe('TaskService', () => {
       expect(result?.activities?.[1].type).toBe('topic');
     });
 
+    it('exposes the run last message (handoff.content) alongside the summary (LOBE-11396)', async () => {
+      const task = {
+        assigneeAgentId: null,
+        assigneeUserId: null,
+        createdAt: null,
+        description: null,
+        error: null,
+        heartbeatInterval: null,
+        heartbeatTimeout: null,
+        id: 'task_001',
+        identifier: 'TASK-1',
+        instruction: null,
+        lastHeartbeatAt: null,
+        name: 'Task 1',
+        parentTaskId: null,
+        priority: 'normal',
+        status: 'todo',
+        totalTopics: 0,
+      };
+
+      const topics = [
+        {
+          createdAt: new Date('2024-01-03T00:00:00Z'),
+          handoff: {
+            content: 'The raw last assistant message shown as the run result.',
+            summary: 'A short synthesized summary.',
+            title: 'Topic A',
+          },
+          seq: 1,
+          status: 'completed',
+          topicId: 'topic-1',
+        },
+      ];
+
+      mockTaskModel.resolve.mockResolvedValue(task);
+      mockTaskModel.findAllDescendants.mockResolvedValue([]);
+      mockTaskModel.getDependencies.mockResolvedValue([]);
+      mockTaskTopicModel.findWithHandoff.mockResolvedValue(topics);
+      mockBriefModel.findByTaskId.mockResolvedValue([]);
+      mockTaskModel.getComments.mockResolvedValue([]);
+      mockTaskModel.getTreePinnedDocuments.mockResolvedValue({ nodeMap: {}, tree: [] });
+      mockTaskModel.findByIds.mockResolvedValue([]);
+      mockTaskModel.getCheckpointConfig.mockReturnValue({});
+      mockTaskModel.getVerifyConfig.mockReturnValue(undefined);
+
+      const service = new TaskService(db, userId);
+      const result = await service.getTaskDetail('TASK-1');
+
+      const topicActivity = result?.activities?.find((a) => a.type === 'topic');
+      expect(topicActivity?.summary).toBe('A short synthesized summary.');
+      expect(topicActivity?.content).toBe(
+        'The raw last assistant message shown as the run result.',
+      );
+    });
+
     it('should resolve author info for activities', async () => {
       const task = {
         assigneeAgentId: 'agt_assignee',

--- a/apps/server/src/services/task/index.ts
+++ b/apps/server/src/services/task/index.ts
@@ -736,6 +736,9 @@ export class TaskService {
         return {
           author: topicAgentId ? authorMap.get(topicAgentId) : undefined,
           completedAt: toISO(t.completedAt),
+          // Raw last assistant message of the run (LOBE-11396), shown alongside
+          // the synthesized summary on the run card.
+          content: handoff?.content,
           id: t.topicId ?? undefined,
           operationId: t.operationId ?? null,
           runningOperation: t.metadata?.runningOperation ?? null,

--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -125,7 +125,7 @@ export class TaskLifecycleService {
       // 1. Update topic status
       if (topicId) await this.taskTopicModel.updateStatus(taskId, topicId, 'completed');
 
-      // 2. Generate handoff summary + topic title
+      // 2. Generate handoff summary + topic title (best-effort LLM synthesis).
       if (topicId && lastAssistantContent) {
         await this.generateHandoff(
           taskId,
@@ -134,6 +134,18 @@ export class TaskLifecycleService {
           lastAssistantContent,
           currentTask,
         );
+      }
+
+      // 2b. Persist the raw last message as the run card's result (LOBE-11396).
+      //     Done independently of (and after) generateHandoff via a jsonb_set
+      //     patch, so `handoff.content` is written even when the summary LLM in
+      //     step 2 throws — otherwise a completed run would show no result.
+      if (topicId && lastAssistantContent) {
+        try {
+          await this.taskTopicModel.updateHandoffContent(taskId, topicId, lastAssistantContent);
+        } catch (e) {
+          console.warn('[TaskLifecycle] persisting run last message failed:', e);
+        }
       }
 
       // 3. Delivery acceptance now runs through Verify: the verify
@@ -440,13 +452,10 @@ export class TaskLifecycleService {
         await this.topicModel.update(topicId, { title: handoff.title });
       }
 
-      // Store handoff in task_topics dedicated fields. `content` carries the raw
-      // last assistant message (LOBE-11396) so the run card can show the actual
-      // output alongside the LLM-synthesized summary.
-      await this.taskTopicModel.updateHandoff(taskId, topicId, {
-        ...handoff,
-        content: lastAssistantContent,
-      });
+      // Store handoff in task_topics dedicated fields. `handoff.content` (the raw
+      // last message) is persisted separately in onTopicComplete so it survives
+      // even when this LLM synthesis throws.
+      await this.taskTopicModel.updateHandoff(taskId, topicId, handoff);
 
       log('handoff generated for topic %s: title=%s', topicId, handoff.title);
     } catch (e) {

--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -440,8 +440,13 @@ export class TaskLifecycleService {
         await this.topicModel.update(topicId, { title: handoff.title });
       }
 
-      // Store handoff in task_topics dedicated fields
-      await this.taskTopicModel.updateHandoff(taskId, topicId, handoff);
+      // Store handoff in task_topics dedicated fields. `content` carries the raw
+      // last assistant message (LOBE-11396) so the run card can show the actual
+      // output alongside the LLM-synthesized summary.
+      await this.taskTopicModel.updateHandoff(taskId, topicId, {
+        ...handoff,
+        content: lastAssistantContent,
+      });
 
       log('handoff generated for topic %s: title=%s', topicId, handoff.title);
     } catch (e) {

--- a/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
+++ b/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
@@ -67,6 +67,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
     taskModel.shouldPauseOnTopicComplete = vi.fn().mockReturnValue(true);
     // Avoid generateHandoff side effects by skipping when lastAssistantContent is undefined
     (service as any).taskTopicModel.updateStatus = updateTopicStatus;
+    (service as any).taskTopicModel.updateHandoffContent = vi.fn().mockResolvedValue(undefined);
     (service as any).briefModel.create = createBrief;
     (service as any).briefModel.hasUnresolvedUrgentByTask = vi.fn().mockResolvedValue(false);
   });
@@ -90,6 +91,30 @@ describe('TaskLifecycleService.onTopicComplete', () => {
 
       expect(updateStatus).toHaveBeenCalledWith('task-1', 'scheduled', { error: null });
       expect(updateStatus).not.toHaveBeenCalledWith('task-1', 'paused', expect.anything());
+    });
+
+    it('persists the run last message independently of handoff summary (LOBE-11396)', async () => {
+      const task = baseTask({ automationMode: 'heartbeat' });
+      findById.mockResolvedValue(task);
+      // Model the summary path as a no-op (e.g. its LLM call failed and was
+      // swallowed) — the raw last message must still be persisted for the card.
+      vi.spyOn(service as any, 'generateHandoff').mockResolvedValue(undefined);
+      const updateHandoffContent = (service as any).taskTopicModel.updateHandoffContent;
+
+      await service.onTopicComplete({
+        lastAssistantContent: 'the raw last assistant message',
+        operationId: 'op-1',
+        reason: 'done',
+        taskId: 'task-1',
+        taskIdentifier: 'TASK-1',
+        topicId: 'topic-1',
+      });
+
+      expect(updateHandoffContent).toHaveBeenCalledWith(
+        'task-1',
+        'topic-1',
+        'the raw last assistant message',
+      );
     });
 
     it('schedule-mode task → status="scheduled"', async () => {

--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -854,6 +854,8 @@
   "taskDetail.runAll.skipped.blockedExternally": "{{count}} task(s) waiting on a blocker outside this batch — will run automatically when unblocked",
   "taskDetail.runAll.skipped.ineligible": "{{count}} task(s) running or scheduled — skipped",
   "taskDetail.runAll.title": "Run subtasks in dependency order",
+  "taskDetail.runFollowUp": "Ask a follow-up",
+  "taskDetail.runFollowUpPlaceholder": "Ask a follow-up about this run...",
   "taskDetail.runNow": "Run now",
   "taskDetail.runTask": "Run",
   "taskDetail.saveModelConfig": "Save",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -854,6 +854,8 @@
   "taskDetail.runAll.skipped.blockedExternally": "{{count}} 个任务被本批次外的依赖阻塞 —— 解除阻塞后将自动运行",
   "taskDetail.runAll.skipped.ineligible": "{{count}} 个任务正在运行或已排期 —— 已跳过",
   "taskDetail.runAll.title": "按依赖顺序运行子任务",
+  "taskDetail.runFollowUp": "追问",
+  "taskDetail.runFollowUpPlaceholder": "对这次运行追问...",
   "taskDetail.runNow": "立即运行",
   "taskDetail.runTask": "运行",
   "taskDetail.saveModelConfig": "保存",

--- a/packages/database/src/models/taskTopic.ts
+++ b/packages/database/src/models/taskTopic.ts
@@ -147,6 +147,22 @@ export class TaskTopicModel {
       .where(and(eq(taskTopics.taskId, taskId), eq(taskTopics.topicId, topicId), this.ownership()));
   }
 
+  /**
+   * Patch the raw run output into `handoff.content` (LOBE-11396) without
+   * disturbing other handoff keys. Uses `jsonb_set` so it is order-independent
+   * with respect to `updateHandoff` — critically, this lets the caller persist
+   * the last message even when the (separate) handoff-summary LLM call fails, so
+   * the run card always has a result to show.
+   */
+  async updateHandoffContent(taskId: string, topicId: string, content: string): Promise<void> {
+    await this.db
+      .update(taskTopics)
+      .set({
+        handoff: sql`jsonb_set(COALESCE(${taskTopics.handoff}, '{}'::jsonb), '{content}', ${JSON.stringify(content)}::jsonb)`,
+      })
+      .where(and(eq(taskTopics.taskId, taskId), eq(taskTopics.topicId, topicId), this.ownership()));
+  }
+
   async updateReview(
     taskId: string,
     topicId: string,

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -928,6 +928,8 @@ export default {
   'taskDetail.comment.save': 'Save',
   'taskDetail.commentPlaceholder':
     'Leave feedback to guide the agent — your comments shape the next run...',
+  'taskDetail.runFollowUp': 'Ask a follow-up',
+  'taskDetail.runFollowUpPlaceholder': 'Ask a follow-up about this run...',
   'taskDetail.collapseReply': 'Collapse',
   'taskDetail.replyInThread': 'Reply in this thread',
   'taskDetail.replyPlaceholder': 'Reply in this thread...',

--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -111,6 +111,12 @@ export interface TaskTopicHandoff {
    * about the brief delivery itself, written by the lifecycle service.
    */
   briefDecision?: BriefDecision;
+  /**
+   * Raw last assistant message of the run, captured on completion (LOBE-11396).
+   * Shown on the run card alongside the LLM-synthesized `summary` so the feed
+   * surfaces the actual run output, not only the summary.
+   */
+  content?: string;
   keyFindings?: string[];
   nextAction?: string;
   summary?: string;

--- a/src/components/StatusIcon/const.ts
+++ b/src/components/StatusIcon/const.ts
@@ -1,0 +1,87 @@
+import type { TaskStatus } from '@lobechat/types';
+import { cssVar } from 'antd-style';
+import {
+  Archive,
+  CircleAlert,
+  CircleCheck,
+  CircleDashed,
+  CircleDot,
+  CircleSlash,
+  CircleX,
+  Clock,
+  Hand,
+  type LucideIcon,
+  PauseCircle,
+} from 'lucide-react';
+
+/**
+ * Canonical status vocabulary shared by BOTH topic and task surfaces. Each
+ * concrete status enum (ChatTopicStatus, TaskStatus, topic status-buckets, …)
+ * maps onto one of these kinds so the whole app speaks one visual language.
+ */
+export type StatusKind =
+  | 'running'
+  | 'scheduled'
+  | 'needsAttention'
+  | 'paused'
+  | 'completed'
+  | 'failed'
+  | 'backlog'
+  | 'active'
+  | 'canceled'
+  | 'archived'
+  | 'timeout';
+
+export interface StatusMeta {
+  color: string;
+  icon: LucideIcon;
+}
+
+/**
+ * THE single source of truth for status → icon + color across topic & task.
+ *
+ * Built on the `Circle-*` family so every status reads as one coherent set.
+ * `running` is the STATIC glyph used by group headers / summaries / badges; a
+ * row that is *actively executing right now* renders the animated
+ * {@link RingLoadingIcon} instead — the live variant of this same `CircleDot`.
+ *
+ * `needsAttention` is the "a human is needed" state (topic `pending` /
+ * `waitingForHuman`, task `paused` / `needsInput`); `paused` is a genuinely
+ * suspended item. They are different concepts and must not be merged.
+ *
+ * NOTE: `completed` and `failed` are the canonical target (green check / red
+ * cross). Task surfaces already match; a few TOPIC surfaces still render their
+ * legacy grey `CheckCircle2` / `TriangleAlert` locally and are intentionally
+ * NOT yet wired here — that convergence is deferred to a follow-up.
+ */
+export const STATUS_META: Record<StatusKind, StatusMeta> = {
+  active: { color: cssVar.colorTextTertiary, icon: CircleDot },
+  archived: { color: cssVar.colorTextDescription, icon: Archive },
+  backlog: { color: cssVar.colorTextQuaternary, icon: CircleDashed },
+  canceled: { color: cssVar.colorTextSecondary, icon: CircleSlash },
+  completed: { color: cssVar.colorSuccess, icon: CircleCheck },
+  failed: { color: cssVar.colorError, icon: CircleX },
+  needsAttention: { color: cssVar.colorInfo, icon: Hand },
+  paused: { color: cssVar.colorTextDescription, icon: PauseCircle },
+  running: { color: cssVar.colorWarning, icon: CircleDot },
+  scheduled: { color: cssVar.colorWarning, icon: Clock },
+  timeout: { color: cssVar.colorWarning, icon: CircleAlert },
+};
+
+const TASK_STATUS_KIND: Record<TaskStatus, StatusKind> = {
+  backlog: 'backlog',
+  canceled: 'canceled',
+  completed: 'completed',
+  failed: 'failed',
+  paused: 'needsAttention',
+  running: 'running',
+  scheduled: 'scheduled',
+};
+
+/** Map a `TaskStatus` onto the canonical status kind. */
+export const getTaskStatusKind = (status: TaskStatus): StatusKind =>
+  TASK_STATUS_KIND[status] ?? 'backlog';
+
+/** Convenience: canonical meta for a task status. */
+export const getTaskStatusMeta = (status: TaskStatus): StatusMeta =>
+  STATUS_META[getTaskStatusKind(status)];

--- a/src/components/StatusIcon/index.ts
+++ b/src/components/StatusIcon/index.ts
@@ -1,0 +1,8 @@
+export {
+  getTaskStatusKind,
+  getTaskStatusMeta,
+  STATUS_META,
+  type StatusKind,
+  type StatusMeta,
+} from './const';
+export { default as RingLoadingIcon } from '@/components/RingLoading';

--- a/src/features/AgentTasks/AgentTaskDetail/CommentInput.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/CommentInput.tsx
@@ -17,7 +17,16 @@ import { useTaskStore } from '@/store/task';
 
 import { styles } from '../shared/style';
 
-const CommentInput = memo<{ taskId: string }>(({ taskId }) => {
+interface CommentInputProps {
+  /** Called after a comment is successfully submitted (e.g. to collapse an inline input). */
+  onSent?: () => void;
+  placeholder?: string;
+  taskId: string;
+  /** Scope the comment to a specific run (topic) — e.g. a follow-up on a run card. */
+  topicId?: string;
+}
+
+const CommentInput = memo<CommentInputProps>(({ taskId, topicId, placeholder, onSent }) => {
   const { t } = useTranslation('chat');
   const { allowed: canEditTask } = usePermission('create_content');
   const editor = useEditor();
@@ -56,14 +65,15 @@ const CommentInput = memo<{ taskId: string }>(({ taskId }) => {
 
     setSubmitting(true);
     try {
-      await addComment(taskId, markdown, { editorData: json });
+      await addComment(taskId, markdown, { editorData: json, topicId });
       editor?.cleanDocument?.();
       setHasContent(false);
       setHasAttachments(false);
+      onSent?.();
     } finally {
       setSubmitting(false);
     }
-  }, [canEditTask, taskId, editor, addComment, submitting]);
+  }, [canEditTask, taskId, topicId, editor, addComment, submitting, onSent]);
 
   return (
     <Flexbox className={styles.commentInputCard} gap={6}>
@@ -73,7 +83,7 @@ const CommentInput = memo<{ taskId: string }>(({ taskId }) => {
           <EditorCanvas
             editor={editor}
             floatingToolbar={false}
-            placeholder={t('taskDetail.commentPlaceholder')}
+            placeholder={placeholder ?? t('taskDetail.commentPlaceholder')}
             style={{
               fontSize: 14,
               maxWidth: '100%',

--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
@@ -15,15 +15,17 @@ import {
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { useSize } from 'ahooks';
 import { cssVar } from 'antd-style';
-import { CircleDot, CircleStop, Copy, ExternalLink, MoreHorizontal } from 'lucide-react';
+import { CircleDot, CircleStop, Copy, ExternalLink, MoreHorizontal, SquarePen } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AgentProfilePopup from '@/features/AgentProfileCard/AgentProfilePopup';
 import { useActivityTime } from '@/hooks/useActivityTime';
 import { useTaskStore } from '@/store/task';
+import { taskDetailSelectors } from '@/store/task/selectors';
 
 import { styles } from '../shared/style';
+import CommentInput from './CommentInput';
 import TopicStatusIcon from './TopicStatusIcon';
 
 const formatDuration = (ms: number): string => {
@@ -70,6 +72,8 @@ const TopicCard = memo<TopicCardProps>(({ activity }) => {
   const { t } = useTranslation('chat');
   const openTopicDrawer = useTaskStore((s) => s.openTopicDrawer);
   const cancelTopic = useTaskStore((s) => s.cancelTopic);
+  const activeTaskId = useTaskStore(taskDetailSelectors.activeTaskId);
+  const [commenting, setCommenting] = useState(false);
   const isRunning = activity.status === 'running';
 
   const finalDuration =
@@ -233,11 +237,32 @@ const TopicCard = memo<TopicCardProps>(({ activity }) => {
       </Flexbox>
 
       {activity.summary && (
-        <Text fontSize={13} style={{ color: cssVar.colorTextSecondary, whiteSpace: 'pre-wrap' }}>
+        <Text fontSize={13} style={{ color: cssVar.colorTextDescription, whiteSpace: 'pre-wrap' }}>
           {activity.summary}
         </Text>
       )}
       {activity.content && <RunContent content={activity.content} />}
+      {activeTaskId && (
+        <Flexbox horizontal justify={'flex-end'} onClick={stopPropagation}>
+          {commenting ? (
+            <Flexbox style={{ width: '100%' }}>
+              <CommentInput
+                placeholder={t('taskDetail.runFollowUpPlaceholder')}
+                taskId={activeTaskId}
+                topicId={activity.id}
+                onSent={() => setCommenting(false)}
+              />
+            </Flexbox>
+          ) : (
+            <ActionIcon
+              icon={SquarePen}
+              size={'small'}
+              title={t('taskDetail.runFollowUp')}
+              onClick={() => setCommenting(true)}
+            />
+          )}
+        </Flexbox>
+      )}
     </Block>
   );
 });

--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
@@ -178,8 +178,8 @@ const TopicCard = memo<TopicCardProps>(({ activity }) => {
     <Block
       clickable={!!activity.id}
       gap={8}
-      paddingBlock={8}
-      paddingInline={8}
+      paddingBlock={12}
+      paddingInline={12}
       style={{ borderRadius: cssVar.borderRadiusLG }}
       variant={'outlined'}
       onClick={activity.id ? handleOpen : undefined}

--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
@@ -207,6 +207,11 @@ const TopicCard = memo<TopicCardProps>(({ activity }) => {
           {activity.summary}
         </Text>
       )}
+      {activity.content && (
+        <Text fontSize={13} style={{ color: cssVar.colorTextTertiary, whiteSpace: 'pre-wrap' }}>
+          {activity.content}
+        </Text>
+      )}
     </Block>
   );
 });

--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
@@ -6,14 +6,17 @@ import {
   type DropdownItem,
   DropdownMenu,
   Flexbox,
+  Markdown,
+  MaskShadow,
   stopPropagation,
   Tag,
   Text,
 } from '@lobehub/ui';
 import { confirmModal } from '@lobehub/ui/base-ui';
+import { useSize } from 'ahooks';
 import { cssVar } from 'antd-style';
 import { CircleDot, CircleStop, Copy, ExternalLink, MoreHorizontal } from 'lucide-react';
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import AgentProfilePopup from '@/features/AgentProfileCard/AgentProfilePopup';
@@ -31,6 +34,33 @@ const formatDuration = (ms: number): string => {
   const hours = Math.floor(minutes / 60);
   return `${hours}h ${minutes % 60}m`;
 };
+
+// The run's last message (`content`) is the raw assistant output — markdown, and
+// often long. Render it as rich text, but keep it a bounded preview in the feed:
+// clamp overflow with a fade and let the whole card open the run drawer for the
+// full message (progressive disclosure). `pointerEvents: none` keeps every click
+// — including on links/code inside the markdown — falling through to the card.
+const RUN_CONTENT_MAX_HEIGHT = 160;
+
+const RunContent = memo<{ content: string }>(({ content }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const size = useSize(ref);
+  const isOverflow = !!size && size.height > RUN_CONTENT_MAX_HEIGHT;
+
+  const markdown = (
+    <Markdown ref={ref} style={{ overflow: 'unset', pointerEvents: 'none' }} variant={'chat'}>
+      {content}
+    </Markdown>
+  );
+
+  return isOverflow ? (
+    <MaskShadow size={32} style={{ maxHeight: RUN_CONTENT_MAX_HEIGHT }}>
+      {markdown}
+    </MaskShadow>
+  ) : (
+    markdown
+  );
+});
 
 interface TopicCardProps {
   activity: TaskDetailActivity;
@@ -207,11 +237,7 @@ const TopicCard = memo<TopicCardProps>(({ activity }) => {
           {activity.summary}
         </Text>
       )}
-      {activity.content && (
-        <Text fontSize={13} style={{ color: cssVar.colorTextTertiary, whiteSpace: 'pre-wrap' }}>
-          {activity.content}
-        </Text>
-      )}
+      {activity.content && <RunContent content={activity.content} />}
     </Block>
   );
 });

--- a/src/features/AgentTasks/AgentTaskDetail/TopicStatusIcon.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicStatusIcon.tsx
@@ -1,54 +1,21 @@
 import { Icon } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
-import {
-  CircleAlert,
-  CircleCheck,
-  CircleDashed,
-  CircleSlash,
-  CircleX,
-  type LucideIcon,
-} from 'lucide-react';
 import { memo } from 'react';
+
+import { RingLoadingIcon, STATUS_META, type StatusKind } from '@/components/StatusIcon';
 
 type TopicRunStatus = 'canceled' | 'completed' | 'failed' | 'pending' | 'running' | 'timeout';
 
-const STATIC_META: Record<
-  Exclude<TopicRunStatus, 'running'>,
-  { color: string; icon: LucideIcon }
-> = {
-  canceled: { color: cssVar.colorTextSecondary, icon: CircleSlash },
-  completed: { color: cssVar.colorSuccess, icon: CircleCheck },
-  failed: { color: cssVar.colorError, icon: CircleX },
-  pending: { color: cssVar.colorTextQuaternary, icon: CircleDashed },
-  timeout: { color: cssVar.colorWarning, icon: CircleAlert },
+// A subtask topic's run status → canonical status kind. `pending` (not yet
+// started) reads as `backlog`; `running` is handled separately by the live
+// spinner below.
+const RUN_STATUS_KIND: Record<Exclude<TopicRunStatus, 'running'>, StatusKind> = {
+  canceled: 'canceled',
+  completed: 'completed',
+  failed: 'failed',
+  pending: 'backlog',
+  timeout: 'timeout',
 };
-
-const RunningIcon = memo<{ size: number }>(({ size }) => {
-  const mainColor = cssVar.colorWarning;
-  const ringColor = `color-mix(in srgb, ${cssVar.colorWarning} 35%, transparent)`;
-  return (
-    <svg aria-hidden fill="none" height={size} viewBox="0 0 16 16" width={size}>
-      <circle cx="8" cy="8" r="6.5" stroke={ringColor} strokeWidth="1.5" />
-      <path
-        d="M14.5 8 A 6.5 6.5 0 0 1 8 14.5"
-        fill="none"
-        stroke={mainColor}
-        strokeLinecap="round"
-        strokeWidth="1.5"
-      >
-        <animateTransform
-          attributeName="transform"
-          dur="1s"
-          from="0 8 8"
-          repeatCount="indefinite"
-          to="360 8 8"
-          type="rotate"
-        />
-      </path>
-      <circle cx="8" cy="8" fill={mainColor} r="2.5" stroke={ringColor} strokeWidth="1" />
-    </svg>
-  );
-});
 
 interface TopicStatusIconProps {
   size?: number;
@@ -56,9 +23,15 @@ interface TopicStatusIconProps {
 }
 
 const TopicStatusIcon = memo<TopicStatusIconProps>(({ size = 16, status }) => {
-  if (status === 'running') return <RunningIcon size={size} />;
-  const key = (status ?? 'pending') as keyof typeof STATIC_META;
-  const meta = STATIC_META[key] ?? STATIC_META.pending;
+  // Live variant of the canonical `running` CircleDot: the animated ring.
+  if (status === 'running') {
+    const ringColor = `color-mix(in srgb, ${cssVar.colorWarning} 35%, transparent)`;
+    return (
+      <RingLoadingIcon ringColor={ringColor} size={size} style={{ color: cssVar.colorWarning }} />
+    );
+  }
+  const kind = RUN_STATUS_KIND[(status ?? 'pending') as keyof typeof RUN_STATUS_KIND] ?? 'backlog';
+  const meta = STATUS_META[kind];
   return <Icon color={meta.color} icon={meta.icon} size={size} />;
 });
 

--- a/src/features/AgentTasks/features/TaskStatusIcon.tsx
+++ b/src/features/AgentTasks/features/TaskStatusIcon.tsx
@@ -1,34 +1,9 @@
 import type { TaskStatus } from '@lobechat/types';
 import { ActionIcon } from '@lobehub/ui';
-import { cssVar } from 'antd-style';
-import type { LucideIcon } from 'lucide-react';
-import {
-  CircleCheck,
-  CircleDashed,
-  CircleDot,
-  CircleSlash,
-  CircleX,
-  Clock,
-  HandIcon,
-} from 'lucide-react';
 import { memo } from 'react';
 
+import { getTaskStatusMeta } from '@/components/StatusIcon';
 import { taskListSelectors } from '@/store/task/selectors';
-
-interface StatusMeta {
-  color: string;
-  icon: LucideIcon;
-}
-
-const STATUS_META: Record<TaskStatus, StatusMeta> = {
-  backlog: { color: cssVar.colorTextQuaternary, icon: CircleDashed },
-  canceled: { color: cssVar.colorTextSecondary, icon: CircleSlash },
-  completed: { color: cssVar.colorSuccess, icon: CircleCheck },
-  failed: { color: cssVar.colorError, icon: CircleX },
-  paused: { color: cssVar.colorInfo, icon: HandIcon },
-  running: { color: cssVar.colorWarning, icon: CircleDot },
-  scheduled: { color: cssVar.colorWarning, icon: Clock },
-};
 
 interface TaskStatusIconProps {
   size?: number;
@@ -37,7 +12,7 @@ interface TaskStatusIconProps {
 
 const TaskStatusIcon = memo<TaskStatusIconProps>(({ size = 16, status }) => {
   const displayStatus = taskListSelectors.getDisplayStatus(status);
-  const meta = STATUS_META[status as TaskStatus] ?? STATUS_META.backlog;
+  const meta = getTaskStatusMeta(status);
 
   return (
     <ActionIcon

--- a/src/features/AgentTasks/features/TaskStatusTag.tsx
+++ b/src/features/AgentTasks/features/TaskStatusTag.tsx
@@ -2,20 +2,12 @@ import type { TaskStatus } from '@lobechat/types';
 import { type DropdownItem, DropdownMenu, Icon, type MenuInfo, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import type { LucideIcon } from 'lucide-react';
-import {
-  CircleCheck,
-  CircleDashed,
-  CircleDot,
-  CircleSlash,
-  CircleX,
-  Clock,
-  HandIcon,
-  Loader2Icon,
-} from 'lucide-react';
+import { Loader2Icon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { getTaskStatusMeta } from '@/components/StatusIcon';
 import { usePermission } from '@/hooks/usePermission';
 import { useTaskStore } from '@/store/task';
 
@@ -28,50 +20,24 @@ interface StatusMeta {
   labelKey: string;
 }
 
-export const STATUS_META: Record<TaskStatus, StatusMeta> = {
-  backlog: {
-    color: cssVar.colorTextQuaternary,
-    icon: CircleDashed,
-    label: 'Backlog',
-    labelKey: 'status.backlog',
-  },
-  canceled: {
-    color: cssVar.colorTextSecondary,
-    icon: CircleSlash,
-    label: 'Canceled',
-    labelKey: 'status.canceled',
-  },
-  completed: {
-    color: cssVar.colorSuccess,
-    icon: CircleCheck,
-    label: 'Completed',
-    labelKey: 'status.completed',
-  },
-  failed: {
-    color: cssVar.colorError,
-    icon: CircleX,
-    label: 'Failed',
-    labelKey: 'status.failed',
-  },
-  paused: {
-    color: cssVar.colorInfo,
-    icon: HandIcon,
-    label: 'Pending review',
-    labelKey: 'status.paused',
-  },
-  running: {
-    color: cssVar.colorWarning,
-    icon: CircleDot,
-    label: 'Running',
-    labelKey: 'status.running',
-  },
-  scheduled: {
-    color: cssVar.colorWarning,
-    icon: Clock,
-    label: 'Scheduled',
-    labelKey: 'status.scheduled',
-  },
+// Labels stay local; icon + color come from the shared canonical status map so
+// the tag can never drift from the sidebar / kanban glyphs.
+const STATUS_LABELS: Record<TaskStatus, { label: string; labelKey: string }> = {
+  backlog: { label: 'Backlog', labelKey: 'status.backlog' },
+  canceled: { label: 'Canceled', labelKey: 'status.canceled' },
+  completed: { label: 'Completed', labelKey: 'status.completed' },
+  failed: { label: 'Failed', labelKey: 'status.failed' },
+  paused: { label: 'Pending review', labelKey: 'status.paused' },
+  running: { label: 'Running', labelKey: 'status.running' },
+  scheduled: { label: 'Scheduled', labelKey: 'status.scheduled' },
 };
+
+export const STATUS_META: Record<TaskStatus, StatusMeta> = Object.fromEntries(
+  (Object.keys(STATUS_LABELS) as TaskStatus[]).map((status) => [
+    status,
+    { ...getTaskStatusMeta(status), ...STATUS_LABELS[status] },
+  ]),
+) as Record<TaskStatus, StatusMeta>;
 
 export const USER_SELECTABLE_STATUSES: TaskStatus[] = [
   'backlog',

--- a/src/routes/(main)/agent/_layout/Sidebar/Task/StatusGroup.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Task/StatusGroup.tsx
@@ -2,31 +2,21 @@
 
 import { AccordionItem, Center, Flexbox, Icon, Text } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
-import { CircleDashed, CircleDot, HandIcon, type LucideIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
+import { STATUS_META as STATUS_ICON, type StatusKind } from '@/components/StatusIcon';
 import type { TaskGroupItem } from '@/store/task/slices/list/initialState';
 
 import TaskItem from './TaskItem';
 
-const STATUS_META: Record<string, { color: string; icon: LucideIcon; titleKey: string }> = {
-  backlog: {
-    color: cssVar.colorTextQuaternary,
-    icon: CircleDashed,
-    titleKey: 'taskList.kanban.backlog',
-  },
-  needsInput: {
-    color: cssVar.colorInfo,
-    icon: HandIcon,
-    titleKey: 'taskList.kanban.needsInput',
-  },
-  running: {
-    color: cssVar.colorWarning,
-    icon: CircleDot,
-    titleKey: 'taskList.kanban.running',
-  },
+// Task sidebar group keys → canonical status kind + i18n title. `needsInput`
+// (paused + failed tasks awaiting a human) is the `needsAttention` kind.
+const GROUP_META: Record<string, { kind: StatusKind; titleKey: string }> = {
+  backlog: { kind: 'backlog', titleKey: 'taskList.kanban.backlog' },
+  needsInput: { kind: 'needsAttention', titleKey: 'taskList.kanban.needsInput' },
+  running: { kind: 'running', titleKey: 'taskList.kanban.running' },
 };
 
 interface StatusGroupProps {
@@ -36,8 +26,9 @@ interface StatusGroupProps {
 const StatusGroup = memo<StatusGroupProps>(({ group }) => {
   const { t } = useTranslation('chat');
   const { taskId } = useParams<{ taskId?: string }>();
-  const meta = STATUS_META[group.key];
-  if (!meta) return null;
+  const groupMeta = GROUP_META[group.key];
+  if (!groupMeta) return null;
+  const meta = STATUS_ICON[groupMeta.kind];
 
   return (
     <AccordionItem
@@ -50,7 +41,7 @@ const StatusGroup = memo<StatusGroupProps>(({ group }) => {
             <Icon color={meta.color} icon={meta.icon} size={{ size: 14, strokeWidth: 1.75 }} />
           </Center>
           <Text ellipsis fontSize={13} style={{ color: cssVar.colorTextSecondary, flex: 1 }}>
-            {t(meta.titleKey as 'taskList.kanban.backlog')}
+            {t(groupMeta.titleKey as 'taskList.kanban.backlog')}
           </Text>
           <Text fontSize={11} type="secondary">
             {group.tasks.length}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -3,13 +3,14 @@ import type { ChatTopicMetadata, ChatTopicStatus } from '@lobechat/types';
 import { formatElapsedClockTime } from '@lobechat/utils';
 import { Flexbox, Icon, Skeleton, Tag, Text, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cssVar, keyframes, useTheme } from 'antd-style';
-import { CheckCircle2, Hand, HashIcon, MessageSquareDashed, TriangleAlert } from 'lucide-react';
+import { CheckCircle2, HashIcon, MessageSquareDashed, TriangleAlert } from 'lucide-react';
 import { memo, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import DotsLoading from '@/components/DotsLoading';
 import RingLoadingIcon from '@/components/RingLoading';
+import { STATUS_META } from '@/components/StatusIcon';
 import { isDesktop } from '@/const/version';
 import DirIcon from '@/features/ChatInput/ControlBar/DirIcon';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';
@@ -344,7 +345,13 @@ const TopicItem = memo<TopicItemProps>(
           titleColor={cssVar.colorText}
           icon={(() => {
             if (isWaitingForHuman) {
-              return <Icon icon={Hand} size={'small'} style={{ color: cssVar.colorInfo }} />;
+              return (
+                <Icon
+                  icon={STATUS_META.needsAttention.icon}
+                  size={'small'}
+                  style={{ color: STATUS_META.needsAttention.color }}
+                />
+              );
             }
             if (shouldShowRunningIcon) {
               return (

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
@@ -4,7 +4,6 @@ import { createStaticStyles, cssVar, cx, keyframes } from 'antd-style';
 import {
   FolderClosedIcon,
   FolderOpenIcon,
-  HandIcon,
   type LucideIcon,
   PlusIcon,
   TriangleAlertIcon,
@@ -15,6 +14,7 @@ import { useParams } from 'react-router';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import RingLoadingIcon from '@/components/RingLoading';
+import { STATUS_META } from '@/components/StatusIcon';
 import { isDesktop } from '@/const/version';
 import { useCommitWorkingDirectory } from '@/features/ChatInput/ControlBar/useCommitWorkingDirectory';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
@@ -153,7 +153,7 @@ const CollapsedStatusBadges = memo<{ counts: ProjectTopicStatusCounts }>(({ coun
     {
       className: styles.statusBadgeWaiting,
       count: counts.waitingForHuman,
-      icon: HandIcon,
+      icon: STATUS_META.needsAttention.icon,
       label: t('projectStatus.waitingForHuman', { count: counts.waitingForHuman }),
     },
     {

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByStatusMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByStatusMode/GroupItem.tsx
@@ -1,33 +1,31 @@
 import { AccordionItem, Center, Flexbox, Icon, Text } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
-import {
-  Archive,
-  CheckCircle2,
-  CircleDot,
-  Hand,
-  Loader,
-  type LucideIcon,
-  PauseCircle,
-  Star,
-} from 'lucide-react';
+import { CheckCircle2, Star } from 'lucide-react';
 import { memo } from 'react';
+
+import { STATUS_META, type StatusMeta } from '@/components/StatusIcon';
 
 import TopicItem from '../../List/Item';
 import { type GroupItemComponentProps } from '../GroupedAccordion';
 
-// Map each status-group id to its icon + color, mirroring the per-topic status
-// glyphs in `List/Item`. `pending` collapses the attention-needing states
-// (awaiting input / failed / unread completion) into one group, so it reuses the
-// `waitingForHuman` hand glyph in info-blue; `favorite` is the synthetic group
-// split out by `buildGroupedTopics`, so it gets a neutral-grey star.
-const STATUS_ICON: Record<string, { color: string; icon: LucideIcon }> = {
-  active: { color: cssVar.colorTextTertiary, icon: CircleDot },
-  archived: { color: cssVar.colorTextDescription, icon: Archive },
+// Topic status-group id → icon + color, drawn from the shared canonical status
+// map so headers stay in lockstep with task glyphs and per-topic rows. The
+// `pending` bucket (awaiting input / failed / unread completion) is the
+// `needsAttention` kind (blue hand). Two entries stay local: `favorite` is a
+// marker, not a status; `completed` still renders its legacy grey check until
+// the deferred completed/failed convergence lands.
+const LOCAL: Record<string, StatusMeta> = {
   completed: { color: cssVar.colorTextDescription, icon: CheckCircle2 },
   favorite: { color: cssVar.colorTextTertiary, icon: Star },
-  paused: { color: cssVar.colorTextDescription, icon: PauseCircle },
-  pending: { color: cssVar.colorInfo, icon: Hand },
-  running: { color: cssVar.colorWarning, icon: Loader },
+};
+
+const STATUS_ICON: Record<string, StatusMeta> = {
+  active: STATUS_META.active,
+  archived: STATUS_META.archived,
+  paused: STATUS_META.paused,
+  pending: STATUS_META.needsAttention,
+  running: STATUS_META.running,
+  ...LOCAL,
 };
 
 const GroupItem = memo<GroupItemComponentProps>(({ group, activeTopicId, activeThreadId }) => {

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByStatusMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByStatusMode/GroupItem.tsx
@@ -3,8 +3,8 @@ import { cssVar } from 'antd-style';
 import {
   Archive,
   CheckCircle2,
-  CircleAlert,
   CircleDot,
+  Hand,
   Loader,
   type LucideIcon,
   PauseCircle,
@@ -17,15 +17,16 @@ import { type GroupItemComponentProps } from '../GroupedAccordion';
 
 // Map each status-group id to its icon + color, mirroring the per-topic status
 // glyphs in `List/Item`. `pending` collapses the attention-needing states
-// (awaiting input / failed / unread completion) into one group; `favorite` is
-// the synthetic group split out by `buildGroupedTopics`, so it gets a star.
+// (awaiting input / failed / unread completion) into one group, so it reuses the
+// `waitingForHuman` hand glyph in info-blue; `favorite` is the synthetic group
+// split out by `buildGroupedTopics`, so it gets a neutral-grey star.
 const STATUS_ICON: Record<string, { color: string; icon: LucideIcon }> = {
   active: { color: cssVar.colorTextTertiary, icon: CircleDot },
   archived: { color: cssVar.colorTextDescription, icon: Archive },
   completed: { color: cssVar.colorTextDescription, icon: CheckCircle2 },
-  favorite: { color: cssVar.colorWarning, icon: Star },
+  favorite: { color: cssVar.colorTextTertiary, icon: Star },
   paused: { color: cssVar.colorTextDescription, icon: PauseCircle },
-  pending: { color: cssVar.colorWarning, icon: CircleAlert },
+  pending: { color: cssVar.colorInfo, icon: Hand },
   running: { color: cssVar.colorWarning, icon: Loader },
 };
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] ♻️ refactor
- [x] 💄 style

#### 🔗 Related Issue

Closes LOBE-11396

#### 🔀 Description of Change

This branch bundles two related threads on the task/topic run surfaces:

**1. Run card — last message (LOBE-11396)**
- Show the run's last message on the run card; render it as rich text and persist it when summary generation fails.
- Run-card polish: swap run summary/content colors, add a per-run follow-up, increase inner padding, and wire up per-topic comment input.
- Backend: task service / `taskLifecycle` / `taskTopic` model + `packages/types` support for surfacing the last message, with tests and `chat` i18n keys (en-US + zh-CN).

**2. Unified topic/task status-icon language (refactor)**
- Add `src/components/StatusIcon` — a single canonical `STATUS_META` (`StatusKind` → icon + color, built on the lucide `Circle-*` family) that every topic and task surface now consumes, replacing ~4 drifting local status maps and 2 duplicate ring spinners.
- Topic **Running** group header now uses the task `CircleDot` glyph (was `Loader`); the pending group uses a blue `Hand`, favorite a neutral-grey `Star`.
- `running` is two-tier: static `CircleDot` for headers/summaries, animated `RingLoadingIcon` for a row executing right now (the hand-rolled `RunningIcon` is merged into `RingLoadingIcon`).
- `needsAttention` (blue `Hand`) unifies topic `pending`/`waitingForHuman` with task `paused`/`needsInput`, kept distinct from `paused`.
- Values map 1:1 to each surface's current glyphs (task side unchanged). Topic `completed`/`failed` convergence to the canonical green-check / red-cross is intentionally deferred. Language documented in `DESIGN.md` § Status Icons.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Status-icon rendering verified end-to-end in an isolated Electron dev instance (live working-tree code), confirming the topic Running group renders `CircleDot`/warning and the topic + task sidebars now share one icon vocabulary. Verify reports:
- Status-icon convergence: https://app.lobehub.com/verify/9bd3a63d-c46a-4381-8b9a-0e585a1fe878
- Pending/favorite icons: https://app.lobehub.com/verify/186aaa6a-591e-4f76-a146-033244dee108

Component tests updated/passing (`AgentTaskItem`, `taskCardListDisplay`, topic `List/Item`, `useTaskItemContextMenu`, `TaskSubtaskProgressTag`, `onTopicComplete`, task service); `type-check` clean for the touched files.

#### 📝 Additional Information

Follow-ups (agreed, out of scope here): converge topic `completed`/`failed` to the canonical green-check / red-cross, migrate `AgentTopicManager/StatusDot` (dot idiom) into the icon language, and unify the `paused` label copy (Paused / Pending review / Needs input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)