### PR TITLE
🐛 fix(hetero): stop the topic spinner sticking after a local CC run finishes

### DIFF
--- a/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { messageService } from '@/services/message';
 import { emitClientAgentSignalSourceEvent } from '@/store/chat/slices/agentRun/actions/lifecycle/agentSignalBridge';
 import { notifyDesktopHumanApprovalRequired } from '@/store/chat/utils/desktopNotification';
-import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 
 import { buildRunLifecycle } from '../lifecycle/buildRunLifecycle';
 import { createGatewayEventHandler } from '../transports/gateway/gatewayEventHandler';
@@ -514,7 +513,7 @@ describe('createGatewayEventHandler', () => {
   });
 
   describe('visible_output_end', () => {
-    it('clears visible loading without completing the operation', async () => {
+    it('marks visible loading done without completing the operation or clearing topic loading', async () => {
       const store = createMockStore();
       const handler = createHandler(store);
 
@@ -530,25 +529,11 @@ describe('createGatewayEventHandler', () => {
         visibleLoadingDone: true,
       });
       expect(store.completeOperation).not.toHaveBeenCalledWith('op-1');
-      expect(store.internal_updateTopicLoading).toHaveBeenCalledWith('topic-1', false);
-    });
-
-    it('keeps topic loading when another message is queued in the same context', async () => {
-      const store = createMockStore();
-      (store as any).queuedMessages = {
-        [messageMapKey({ agentId: 'agent-1', scope: 'session', topicId: 'topic-1' } as any)]: [
-          { content: 'next' },
-        ],
-      };
-      const handler = createHandler(store);
-
-      handler(makeEvent('visible_output_end'));
-      await flush();
-
-      expect(store.updateOperationMetadata).toHaveBeenCalledWith('op-1', {
-        visibleLoadingDone: true,
-      });
-      expect(store.internal_updateTopicLoading).not.toHaveBeenCalledWith('topic-1', false);
+      // Sidebar "running" spinner is driven off `topic.status === 'running'`
+      // (persisted, reset at the terminal) for gateway/hetero runs — not the
+      // client-only `topicLoadingIds` overlay — so visible_output_end no longer
+      // clears it early.
+      expect(store.internal_updateTopicLoading).not.toHaveBeenCalled();
     });
   });
 

--- a/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
@@ -71,6 +71,10 @@ vi.mock('@/services/electron/heterogeneousAgent', () => ({
 // Gateway event handler — we spy on it but let it run (it calls getMessages)
 vi.mock('../transports/gateway/gatewayEventHandler', () => ({
   createGatewayEventHandler: vi.fn(() => vi.fn()),
+  // Faithful re-impl (the real one is unmocked to keep the import cycle out of
+  // this test): only 'interrupted' / 'waiting_for_async_tool' are non-clean.
+  isCompletedRuntimeEnd: (reason?: string | null) =>
+    reason !== 'interrupted' && reason !== 'waiting_for_async_tool',
 }));
 
 // isDesktop — defaults to `false` (matching the real test env / __ELECTRON__
@@ -4082,6 +4086,58 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
           topicId: 'topic-1',
         }),
       );
+    });
+
+    // ── 5. stuck-spinner regression: status reset must not wait on the drain ──
+    it('resets topic status even when the persist queue never drains', async () => {
+      // A DB write that never settles — mirrors a dropped desktop-IPC reply. It
+      // strands the executor's persistQueue, which onComplete used to `await`
+      // unbounded BEFORE resetting topic status, leaving the sidebar spinning
+      // forever after the CLI had already exited (the bug this guards against).
+      let releaseWrite!: () => void;
+      const hangingWrite = new Promise<void>((r) => {
+        releaseWrite = r;
+      });
+      mockUpdateMessage.mockReturnValue(hangingWrite);
+
+      const updateTopicStatus = vi.fn();
+      const store = createMockStore({
+        activeTopicId: 'topic-1', // viewing → a clean end writes 'active'
+        updateTopicStatus,
+      });
+      const get = vi.fn(() => store);
+
+      let resolveSendPrompt!: () => void;
+      mockSendPrompt.mockReturnValue(
+        new Promise<void>((r) => {
+          resolveSendPrompt = r;
+        }),
+      );
+
+      const executorPromise = executeHeterogeneousAgent(get, defaultParams);
+      await flush();
+
+      // A tool batch enqueues an awaited `updateMessage` onto persistQueue — the
+      // hanging write above stalls the queue before the terminal drain.
+      ipc.emitRawLine('ipc-sess-1', ccInit());
+      ipc.emitRawLine('ipc-sess-1', ccToolUse('msg_01', 'toolu_1', 'Read', { file_path: '/a' }));
+      ipc.emitRawLine('ipc-sess-1', ccToolResult('toolu_1', 'file content'));
+      ipc.emitRawLine('ipc-sess-1', ccResult());
+      ipc.emitComplete('ipc-sess-1');
+      await flush();
+
+      // The fix: status is reset synchronously at the top of onComplete, BEFORE
+      // the (now stalled + bounded) drain — so the spinner clears to 'active'
+      // even though the persist queue is still pending on the hanging write.
+      expect(updateTopicStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'active', topicId: 'topic-1' }),
+      );
+
+      // Release so the queue drains and the executor settles cleanly.
+      releaseWrite();
+      resolveSendPrompt();
+      await executorPromise;
+      await flush();
     });
   });
 });

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -830,9 +830,12 @@ export class ConversationLifecycleActionImpl {
       // branch returns early (line 498) and never reaches that clear.
       this.#get().updateOperationMetadata(operationId, { inputEditorTempState: null });
 
-      if (heteroData.topicId && !optimisticTopicResolved) {
-        this.#get().internal_updateTopicLoading(heteroData.topicId, true);
-      }
+      // Sidebar "running" spinner for hetero runs is driven off the persisted
+      // `topic.status === 'running'` (written by the executor's writeTopicStatus,
+      // and bucketed by resolveStatusBucket) — no separate client-only
+      // `topicLoadingIds` overlay, which used to desync: it cleared on the
+      // linear sendPrompt path (below) while `status` stayed 'running' when the
+      // executor's onComplete stalled, leaving the topic spinning after finish.
 
       // Start heterogeneous agent execution
       const { operationId: heteroOpId } = this.#get().startOperation({
@@ -885,8 +888,6 @@ export class ConversationLifecycleActionImpl {
           type: 'HeterogeneousAgentError',
         });
       }
-
-      if (heteroData.topicId) this.#get().internal_updateTopicLoading(heteroData.topicId, false);
 
       return {
         assistantMessageId: heteroData.assistantMessageId,

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -554,7 +554,6 @@ export class GatewayActionImpl {
     this.#get().moveQueuedMessages(messageMapKey(context), messageMapKey(execContext));
 
     if (result.topicId) {
-      if (!optimisticTopic) this.#get().internal_updateTopicLoading(result.topicId, true);
       void this.#get().updateTopicStatus?.({
         agentId: context.agentId,
         groupId: context.groupId,
@@ -667,7 +666,6 @@ export class GatewayActionImpl {
         // terminal-missing fallback so the op never sticks `running`.
         if (!terminalReceived) this.#get().completeOperation(gatewayOpId);
         if (result.topicId) {
-          this.#get().internal_updateTopicLoading(result.topicId, false);
           // A clean completion the user isn't watching is owned by
           // `markTopicUnread` (status: 'unread'); skip the 'active' write so
           // the two never race over the status field. Every other case (viewing,
@@ -819,8 +817,6 @@ export class GatewayActionImpl {
       gatewayUrl: agentGatewayUrl,
       onEvent: eventRouter,
       onSessionComplete: ({ succeeded, terminalReceived, authFailed }) => {
-        this.#get().internal_updateTopicLoading(topicId, false);
-
         // A reconnect is a passive re-subscribe — it must not END a run it merely
         // re-subscribed to. Only finalize when the close PROVES the op is over:
         //   - terminalReceived: a real agent_runtime_end / error streamed in, or

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -24,7 +24,6 @@ import type {
 } from '@/store/chat/slices/agentRun/actions/lifecycle/types';
 import type { ChatStore } from '@/store/chat/store';
 import { notifyDesktopHumanApprovalRequired } from '@/store/chat/utils/desktopNotification';
-import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 
 // `agent_runtime_end` reasons that are NOT a clean completion: a mid-stream
 // cancel and a deferred-tool park. These must NOT mark the topic unread, and
@@ -585,10 +584,11 @@ export const createGatewayEventHandler = (
           // means visible output is done; the operation still waits for
           // agent_runtime_end to preserve terminal side-effect ordering.
           get().updateOperationMetadata(operationId, { visibleLoadingDone: true });
-          const hasQueuedMessage =
-            (get().queuedMessages?.[messageMapKey(context)]?.length ?? 0) > 0;
-          if (context.topicId && !hasQueuedMessage)
-            get().internal_updateTopicLoading(context.topicId, false);
+          // The sidebar "running" spinner is driven off `topic.status === 'running'`
+          // (persisted, reset at the terminal) for gateway/hetero runs — no
+          // client-only `topicLoadingIds` early-clear here, so the topic keeps
+          // spinning through the post-visible-output terminal side-effects until
+          // the run actually completes.
         });
         break;
       }

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -39,6 +39,7 @@ import { message as antdMessage } from '@/components/AntdStaticMethods';
 import { heterogeneousAgentService } from '@/services/electron/heterogeneousAgent';
 import { messageService } from '@/services/message';
 import { threadService } from '@/services/thread';
+import { topicSelectors } from '@/store/chat/selectors';
 import {
   mergeQueuedMessages,
   reconstructUploadFilesFromQueue,
@@ -49,7 +50,7 @@ import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 
 import { buildRunLifecycle } from '../../lifecycle/buildRunLifecycle';
 import type { RunScope } from '../../lifecycle/types';
-import { createGatewayEventHandler } from '../gateway/gatewayEventHandler';
+import { createGatewayEventHandler, isCompletedRuntimeEnd } from '../gateway/gatewayEventHandler';
 
 /** Mirrors `idGenerator('threads', 16)` on the server so sync-allocated ids have the same shape. */
 const generateThreadId = () => `thd_${createNanoId(16)()}`;
@@ -105,8 +106,7 @@ const maybeClassifyCliAuthRequiredError = (
 
 const shouldSuppressTerminalErrorEcho = (content: string, error: ChatMessageError): boolean => {
   const errorBody = error.body as
-    | (HeterogeneousAgentSessionError & { clearEchoedContent?: boolean })
-    | undefined;
+    (HeterogeneousAgentSessionError & { clearEchoedContent?: boolean }) | undefined;
   if (
     !errorBody?.clearEchoedContent &&
     errorBody?.code !== HeterogeneousAgentSessionErrorCode.AuthRequired
@@ -189,6 +189,28 @@ const isRecoverableResumeError = (
     error.code === HeterogeneousAgentSessionErrorCode.ResumeThreadNotFound
   );
 };
+
+/**
+ * How long the terminal callbacks wait for the persist queue to drain before
+ * proceeding regardless. Bounds the one place a completed run could otherwise
+ * hang forever — a queued DB write whose desktop-IPC reply never arrives — so op
+ * completion, the terminal forward, and the desktop notification still run.
+ * Topic status is reset ahead of this wait, so the sidebar spinner never depends
+ * on it at all.
+ */
+const PERSIST_DRAIN_TIMEOUT = 10_000;
+
+/** Await `queue`, but give up after `ms`; pending work is abandoned, not cancelled. */
+const drainWithTimeout = (queue: Promise<unknown>, ms: number): Promise<void> =>
+  new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    void Promise.resolve(queue)
+      .catch(() => {})
+      .finally(() => {
+        clearTimeout(timer);
+        resolve();
+      });
+  });
 
 export interface HeterogeneousAgentExecutorParams {
   assistantMessageId: string;
@@ -1367,10 +1389,38 @@ export const executeHeterogeneousAgent = async (
         if (completed) return;
         completed = true;
 
-        // Wait for all tool persistence to finish before writing final state
-        await persistQueue.catch(console.error);
-
         const isErrorTerminal = deferredTerminalEvent?.type === 'error';
+
+        // Reset the sidebar "running" status BEFORE draining the persist queue.
+        // Topic status is independent of message persistence, so a stalled queue
+        // (e.g. a subagent-heavy run whose final DB write never settles) must not
+        // strand the topic spinning after the CLI has exited — the stuck-spinner
+        // this guards against. Content persistence + the terminal forward still
+        // wait for the (now bounded) drain below.
+        {
+          const reason = (deferredTerminalEvent?.data as { reason?: string } | undefined)?.reason;
+          if (isErrorTerminal) {
+            writeTopicStatus('failed');
+          } else if (!isAborted() && isCompletedRuntimeEnd(reason)) {
+            // Clean completion: the viewer sees 'active'; a background topic gets
+            // the unread badge (markTopicUnread self-guards on activeTopicId).
+            if (get().activeTopicId === context.topicId) writeTopicStatus('active');
+            else
+              get().markTopicUnread?.({
+                agentId: context.agentId,
+                groupId: context.groupId,
+                topicId: context.topicId,
+              });
+          } else {
+            // Cancel / deferred-tool park — back to a neutral 'active'.
+            writeTopicStatus('active');
+          }
+        }
+
+        // Bounded: a persist that never settles must not block op completion,
+        // the terminal forward, or the completion notification below.
+        await drainWithTimeout(persistQueue, PERSIST_DRAIN_TIMEOUT);
+
         // Snapshot the final content BEFORE the terminal reduce resets the
         // accumulator — used for the completion notification body below.
         const finalContent = mainState.accContent;
@@ -1413,12 +1463,10 @@ export const executeHeterogeneousAgent = async (
         pendingSubagentFlush.clear();
 
         if (!isErrorTerminal) {
-          // A clean completion the user isn't watching is owned by the gateway
-          // handler's markTopicUnread (status: 'unread'); only clear back to
-          // 'active' when the user is viewing so the two writes don't race.
-          if (get().activeTopicId === context.topicId) writeTopicStatus('active');
-          // NOW forward the deferred terminal event — handler will
-          // fetchAndReplaceMessages and pick up the final persisted state.
+          // Topic status was already reset ahead of the drain (top of
+          // onComplete); forward the deferred terminal only so the handler runs
+          // the final fetchAndReplaceMessages + completeOperation against the
+          // now-persisted state.
           eventHandler(terminalEvent);
         }
 
@@ -1445,7 +1493,12 @@ export const executeHeterogeneousAgent = async (
         if (retryWithoutResume(error)) return;
         completed = true;
 
-        await persistQueue.catch(console.error);
+        // Reset status ahead of the drain (see onComplete) so a stalled queue
+        // can't strand the spinner; persistTerminalError below re-asserts 'failed'
+        // with the full error UI.
+        writeTopicStatus(isAborted() ? 'active' : 'failed');
+
+        await drainWithTimeout(persistQueue, PERSIST_DRAIN_TIMEOUT);
 
         const deferredMessageError =
           deferredTerminalEvent?.type === 'error'
@@ -1594,6 +1647,32 @@ export const executeHeterogeneousAgent = async (
     unsubscribe?.();
     // Don't stopSession here — keep it alive for multi-turn resume.
     // Session cleanup happens on topic deletion or Electron quit.
+
+    // Backstop: if neither onComplete nor onError ever ran (e.g. the
+    // heteroAgentSessionComplete IPC was missed, or its listener was torn down
+    // before it landed), the status reset above never happened. The CLI has
+    // exited by the time this linear path resolves, so a topic still persisted
+    // as 'running' would spin forever — reconcile it. Both terminal callbacks
+    // reset status ahead of their drain, so reaching here still 'running' means
+    // neither ran. Skipped on the resume-retry path, whose recursive run owns
+    // the lifecycle.
+    if (!resumeFallbackTriggered && context.topicId) {
+      // Best-effort: a finally must never throw (it would mask the real flow),
+      // and the topic map may be absent in edge/test states.
+      try {
+        const stuckRunning =
+          topicSelectors.getTopicById(context.topicId)(get())?.status === 'running';
+        if (stuckRunning) {
+          // Cast: TS narrows the closure-mutated `deferredTerminalEvent` back to
+          // `null` in this linear-flow scope (it can't see the async IPC writes).
+          const terminal = deferredTerminalEvent as AgentStreamEvent | null;
+          writeTopicStatus(terminal?.type === 'error' ? 'failed' : 'active');
+          get().completeOperation(operationId);
+        }
+      } catch (err) {
+        console.error('[HeterogeneousAgent] status reconcile backstop failed:', err);
+      }
+    }
   }
 
   if (fallbackPromise) {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

The sidebar topic "running" spinner is driven by `topicLoadingIds.includes(id) || topic.status === 'running'`. For agent runs these are **two independent drivers that desync**: the hetero transport clears `topicLoadingIds` on the linear `sendPrompt` path, while `topic.status` stays `'running'` when the executor's `onComplete` stalls — so a local Claude Code run finishes but the topic keeps spinning (and it's persisted, so it survives reload).

**Part 1 — converge the agent-run spinner onto the persisted `topic.status`.**
Drop the redundant `topicLoadingIds` set/clear from the hetero + gateway transports (both already write `status='running'` and reset it), plus the `visible_output_end` early-clear in the shared gateway handler. `topicLoadingIds` is kept for **client mode** (which has no `status='running'` — it's the only driver there) and for non-agent topic ops (inline rename / title summary / metadata / create). Grouping already buckets by `status === 'running'` (`resolveStatusBucket`), so the sidebar status groups are unaffected.

**Part 2 — fix the stuck `status='running'`.**
The hetero executor's `onComplete`/`onError` reset topic status only **after** `await persistQueue`, which never settles if a queued DB write hangs (most likely on subagent-heavy runs, where the queue accumulates the heaviest persists). That stalls the whole terminal lifecycle. The fix:

- **Hoist the status reset ahead of the drain** — status is independent of message persistence, so the spinner clears the instant the CLI exits regardless of the queue.
- **Bound the drain** (`drainWithTimeout`, 10s) so op completion, the terminal forward, and the desktop notification can't hang forever on a never-settling persist.
- **`finally` backstop** that reconciles a still-`running` topic (and completes the op) if the IPC terminal callbacks never fired at all.

#### 🧪 How to Test

Run a local Claude Code agent (especially one that spawns subagents) and confirm the sidebar topic spinner clears once the run finishes — including under a slow/stalled DB persist.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

New regression test **"resets topic status even when the persist queue never drains"** — mocks a `updateMessage` that never resolves to stall `persistQueue`, then asserts the topic status is still reset. It fails on the old code (which `await`ed the queue before resetting). Full affected suites (`heterogeneousAgentExecutor`, `gatewayEventHandler`, `gateway`, `conversationLifecycle`) pass; type-check clean on the touched files.

#### 📝 Additional Information

Behavior note: gateway/hetero spinners now clear at the run's true terminal (status reset) rather than at `visible_output_end`, matching `status='running'` as the single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)