### PR TITLE
📝 docs(agent-testing): default to isolated full run for screenshot requests

### DIFF
--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -179,3 +179,32 @@ The published `https://app.lobehub.com/verify/<id>` page already renders every
 screenshot inline — that URL is the only visual deliverable. Describe key visual
 outcomes in prose; mention the local report dir as a plain string (not a
 markdown link) if a reference is useful.
+
+## Case 8 — Asking the user "how should I run this?" instead of defaulting to an isolated full run
+
+**Wrong approach**: when a visual/screenshot request needs an isolated env (app
+must run the feature branch, not the working dir's current branch; a background
+process owns the shared checkout; the surface needs fixture data like a git repo
+with 2 worktrees), stopping to ask the user which approach to take — full
+isolated run vs a lighter HMR shot vs a static prototype — via a plan-approval
+question.
+
+**Why it's wrong**: the user's standing preference is that **agent-testing
+DEFAULTS to a full isolated-environment screenshot/recording run that ends in a
+published verify report** — "time is not a concern; solve the env problems
+yourself." Presenting environment difficulty as a menu of shortcuts pushes setup
+decisions back onto the user that the skill is supposed to own.
+
+**What it breaks**: wastes a round on a question the user doesn't want, and
+signals the agent will cut corners on fidelity when the env is inconvenient.
+
+**Correct approach**: for any "run it and show me" request, go straight to the
+**isolated full run** by default — spin up a dedicated worktree + dev instance on
+the feature branch (never disturb the user's running app or the branch a
+background process holds), build whatever fixture data the surface needs (create a
+throwaway git repo, `git worktree add` a second tree, point a fresh conversation's
+working directory at it, etc.), capture the real rendered screenshot/GIF, verify
+it by opening the PNG, and publish the `/verify` report. Only surface a
+plan-approval question when the *product decision* is ambiguous (what to test),
+never for *environment mechanics* (how to render it). Env obstacles are the
+skill's job to solve and then iterate back into these logs.


### PR DESCRIPTION
#### 💻 Change Type

- [x] 📝 docs

#### 🔀 Description of Change

Adds **Case 8** to the agent-testing skill's `common-mistakes.md` living log.

Standing preference captured: for any "run it and show me / screenshot it" request routed through the agent-testing skill, **default to a full isolated-environment screenshot/recording run that ends in a published verify report** — rather than pausing to ask the user how to render it (full isolated run vs a lighter HMR shot vs a static prototype).

The skill owns the environment mechanics: spin up a dedicated worktree + dev instance on the feature branch (never disturbing the user's running app or the branch a background process holds), build whatever fixture data the surface needs (throwaway git repo, `git worktree add` a second tree, point a fresh conversation's working directory at it), capture and verify the real screenshot, and publish. Only surface a plan-approval question when the *product decision* (what to test) is ambiguous — never for *environment mechanics* (how to render it).

Split out from the worktree-switcher work (#16725) per request, since this is a skill-behavior change unrelated to that feature.

#### 🧪 How to Test

- [x] No tests needed

Docs-only change to an agent skill reference file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)