### PR TITLE
🐛 fix(task): stop flashing empty state during task list refetch

### DIFF
--- a/src/features/AgentTasks/AgentTaskList/AgentTasksPage.tsx
+++ b/src/features/AgentTasks/AgentTaskList/AgentTasksPage.tsx
@@ -61,12 +61,20 @@ const AgentTasksPage = memo<AgentTasksPageProps>(({ agentId }) => {
   const { allowed: canCreateTask, reason } = usePermission('create_content');
   const viewMode = useTaskStore(taskListSelectors.viewMode);
   const useFetchTaskList = useTaskStore((s) => s.useFetchTaskList);
-  // Keep the SWR handle so a failed list fetch surfaces error + Retry instead of
-  // a permanent skeleton (the store only flips `isTaskListInit` on success — see
-  // LOBE-11181). `data` (undefined until first success) is the settled signal.
-  const { data, error, isLoading, mutate } = useFetchTaskList(
+  // Keep the SWR handle only for `error` + `mutate` (the error/Retry state).
+  const { error, isLoading, mutate } = useFetchTaskList(
     agentId ? { agentId } : { allAgents: true },
   );
+  // Drive the loading/empty boundary off the store's own init flag, NOT SWR's
+  // per-key `data`. On a scope (agent ↔ all) or visibility switch the store
+  // resets `tasks` + `isTaskListInit` together (`scopeChangeResetState`), but
+  // SWR still holds cached `data` for the target key — so keying `hasSettled`
+  // off SWR `data` made it `true` while `tasks` was empty and flashed the "no
+  // tasks" empty during the refetch. `isTaskListInit` flips true only on the
+  // current scope's success and resets in lockstep with `tasks`, so the settled
+  // signal never disagrees with the emptiness signal. Still resets to false on a
+  // failed first load, so we surface loading only while there's no error (below).
+  const isTaskListInit = useTaskStore(taskListSelectors.isTaskListInit);
   const isEmptyHero = useTaskStore(taskListSelectors.isListEmpty);
   const rawViewOptions = useGlobalStore(systemStatusSelectors.taskListViewOptions);
   const viewOptions = useMemo(() => normalizeTaskListViewOptions(rawViewOptions), [rawViewOptions]);
@@ -164,9 +172,9 @@ const AgentTasksPage = memo<AgentTasksPageProps>(({ agentId }) => {
         >
           {!inlineCollapsed && <CreateTaskInlineEntry agentId={agentId} lockAssignee={!!agentId} />}
           <TaskList
-            data={data}
+            data={isTaskListInit || undefined}
             error={error}
-            isLoading={isLoading}
+            isLoading={isLoading || (!isTaskListInit && !error)}
             options={viewOptions}
             routeScope={routeScope}
             onRetry={() => mutate()}

--- a/src/features/AgentTasks/AgentTaskList/KanbanBoard.tsx
+++ b/src/features/AgentTasks/AgentTaskList/KanbanBoard.tsx
@@ -88,12 +88,18 @@ const KanbanBoard = memo<KanbanBoardProps>(({ agentId, routeScope }) => {
   const { allowed: canEditTask } = usePermission('create_content');
 
   const useFetchTaskGroupList = useTaskStore((s) => s.useFetchTaskGroupList);
-  // Surface a failed group fetch as error + Retry instead of a permanent
-  // skeleton board (LOBE-11181). `data` (undefined until first success) is the
-  // settled signal.
-  const { data, error, isLoading, mutate } = useFetchTaskGroupList(
+  // Keep the SWR handle only for `error` + `mutate` (the error/Retry state).
+  const { error, isLoading, mutate } = useFetchTaskGroupList(
     agentId ? { agentId } : { allAgents: true },
   );
+  // Drive the loading/empty boundary off the store's own init flag, NOT SWR's
+  // per-key `data`. On a scope or visibility switch the store resets
+  // `taskGroups` + `isTaskGroupListInit` together (`scopeChangeResetState`)
+  // while SWR still holds cached `data` for the target key — keying `hasSettled`
+  // off SWR `data` flashed the "no tasks" empty board during the refetch.
+  // `isTaskGroupListInit` resets in lockstep with `taskGroups`, so the settled
+  // signal never disagrees with the emptiness signal.
+  const isTaskGroupListInit = useTaskStore(taskListSelectors.isTaskGroupListInit);
 
   const taskGroups = useTaskStore(taskListSelectors.taskGroups);
   const updateTaskStatus = useTaskStore((s) => s.updateTaskStatus);
@@ -283,12 +289,12 @@ const KanbanBoard = memo<KanbanBoardProps>(({ agentId, routeScope }) => {
   // undefined until the first fetch settles.
   return (
     <AsyncBoundary
-      data={data}
+      data={isTaskGroupListInit || undefined}
       empty={emptyState}
       error={error}
       errorVariant={'block'}
       isEmpty={totalTasks === 0}
-      isLoading={isLoading}
+      isLoading={isLoading || (!isTaskGroupListInit && !error)}
       loading={skeletonBoard}
       onRetry={() => mutate()}
     >

--- a/src/features/AgentTasks/AgentTaskList/TaskList.tsx
+++ b/src/features/AgentTasks/AgentTaskList/TaskList.tsx
@@ -29,7 +29,12 @@ import {
 import TaskItemSkeleton from './TaskItemSkeleton';
 
 interface TaskListProps {
-  /** The list SWR result — `undefined` until the first fetch settles (the settled signal). */
+  /**
+   * Settled signal — truthy once the current scope's list has loaded into the
+   * store, `undefined` while unsettled. Derived from the store's
+   * `isTaskListInit` (not raw SWR `data`) so it resets in lockstep with `tasks`
+   * on a scope/visibility switch and never disagrees with the empty signal.
+   */
   data?: unknown;
   /** Thrown error from the list SWR — surfaced as a failure state, not a skeleton. */
   error?: unknown;
@@ -298,8 +303,8 @@ const TaskList = memo<TaskListProps>((props) => {
     );
 
   // Error is gated ahead of empty by AsyncBoundary, so a failed fetch shows a
-  // Retry block instead of the "no tasks" empty (LOBE-11181). `data` is the SWR
-  // result — undefined until the first fetch settles.
+  // Retry block instead of the "no tasks" empty (LOBE-11181). `data` is the
+  // store-derived settled signal — see the `data` prop doc above.
   return (
     <AsyncBoundary
       data={data}


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No tracked issue -->

#### 🔀 Description of Change

The task **list** and **kanban** loading gate read its two signals from sources that fall out of sync:

- `hasSettled` came from SWR's **per-key** `data` (`AsyncBoundary`: `data !== undefined`)
- `isEmpty` came from the **store** (`tasks.length === 0` / `totalTasks === 0`)

On a **scope switch** (agent ↔ 全部任务 / all-agents) or a **visibility toggle** (the "显示已完成与已取消" chip), `setListVisibility` / `useFetchTaskList/syncAgentId` apply `scopeChangeResetState`, clearing `tasks` + `isTaskListInit` (and `taskGroups` + `isTaskGroupListInit`) together. But SWR still holds **cached `data`** for the target key, so `hasSettled` was `true` while the store was empty → `AsyncBoundary` skipped the loading branch and rendered the **"暂无任务" empty state during the refetch** instead of the skeleton.

**Fix:** drive the boundary off the store's own init flag (`isTaskListInit` / `isTaskGroupListInit`), which resets in **lockstep** with `tasks` / `taskGroups`, so the settled signal can never disagree with the emptiness signal:

```tsx
data={isTaskListInit || undefined}                    // settled signal, in sync with tasks
isLoading={isLoading || (!isTaskListInit && !error)}  // unsettled scope → skeleton
```

SWR `error` / `mutate` are retained, so a failed first load still surfaces the error + Retry block (loading is only shown while `!error`). This matches how the page-level `isEmptyHero` (`isListEmpty = isTaskListInit && tasks.length === 0`) already gates.

#### 🧪 How to Test

Reproduce the flash on `canary`: open 全部任务, then toggle the "显示已完成与已取消" switch (or switch between an agent-scoped task list and the all-agents list) after the target scope has been cached once — the empty "暂无任务" placeholder flashes before the list re-renders. With this change the skeleton is shown instead.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

Applies to both the list view (`AgentTasksPage` → `TaskList`) and the kanban board (`KanbanBoard`); both shared the same decoupled-signal bug.