### PR TITLE
🐛 fix(workflow): reduce run guard Redis reads

### DIFF
--- a/src/server/workflows/runGuard/__tests__/store.test.ts
+++ b/src/server/workflows/runGuard/__tests__/store.test.ts
@@ -10,6 +10,7 @@ import {
 const redis = {
   del: vi.fn(),
   get: vi.fn(),
+  mget: vi.fn(),
   scan: vi.fn(),
   set: vi.fn(),
   ttl: vi.fn(),
@@ -63,12 +64,15 @@ describe('workflow run guard store', () => {
     });
   });
 
-  it('throws WorkflowRunGuardError on the first matching key', async () => {
-    redis.get.mockImplementation(async (key: string) =>
-      key === 'workflow:run-guard:path:api/workflows/memory-user-memory'
-        ? JSON.stringify({ reason: 'blocked' })
-        : null,
-    );
+  it('checks all guard candidates with one mget and throws on the first matching key', async () => {
+    redis.mget.mockResolvedValue([
+      null,
+      null,
+      null,
+      JSON.stringify({ reason: 'blocked' }),
+      JSON.stringify({ reason: 'later match' }),
+      null,
+    ]);
 
     await expect(
       assertWorkflowRunAllowed(redis as unknown as Parameters<typeof assertWorkflowRunAllowed>[0], {
@@ -79,10 +83,21 @@ describe('workflow run guard store', () => {
       name: 'WorkflowRunGuardError',
       reason: 'blocked',
     });
+    expect(redis.mget).toHaveBeenCalledTimes(1);
+    expect(redis.mget).toHaveBeenCalledWith(
+      'workflow:run-guard:global',
+      'workflow:run-guard:path:api',
+      'workflow:run-guard:path:api/workflows',
+      'workflow:run-guard:path:api/workflows/memory-user-memory',
+      'workflow:run-guard:path:api/workflows/memory-user-memory/pipelines',
+      'workflow:run-guard:path:api/workflows/memory-user-memory/pipelines/chat-topic',
+      'workflow:run-guard:path:api/workflows/memory-user-memory/pipelines/chat-topic/process-topic',
+    );
+    expect(redis.get).not.toHaveBeenCalled();
   });
 
   it('ignores malformed guard values during execution checks', async () => {
-    redis.get.mockResolvedValue('{broken');
+    redis.mget.mockResolvedValue(['{broken']);
 
     await expect(
       assertWorkflowRunAllowed(redis as unknown as Parameters<typeof assertWorkflowRunAllowed>[0], {
@@ -92,7 +107,7 @@ describe('workflow run guard store', () => {
   });
 
   it('ignores array guard values during execution checks', async () => {
-    redis.get.mockResolvedValue('[]');
+    redis.mget.mockResolvedValue(['[]']);
 
     await expect(
       assertWorkflowRunAllowed(redis as unknown as Parameters<typeof assertWorkflowRunAllowed>[0], {
@@ -101,8 +116,8 @@ describe('workflow run guard store', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('fails open when Redis get throws during execution checks', async () => {
-    redis.get.mockRejectedValue(new Error('redis unavailable'));
+  it('fails open when Redis mget throws during execution checks', async () => {
+    redis.mget.mockRejectedValue(new Error('redis unavailable'));
 
     await expect(
       assertWorkflowRunAllowed(redis as unknown as Parameters<typeof assertWorkflowRunAllowed>[0], {

--- a/src/server/workflows/runGuard/store.ts
+++ b/src/server/workflows/runGuard/store.ts
@@ -70,14 +70,17 @@ const parseGuardValue = (raw: string | null): WorkflowRunGuardValue | undefined 
  * - Rejects with {@link WorkflowRunGuardError} when the first matching guard blocks execution.
  */
 export const assertWorkflowRunAllowed = async (
-  redis: Pick<BaseRedisProvider, 'get'> | null,
+  redis: Pick<BaseRedisProvider, 'mget'> | null,
   scope: WorkflowRunGuardCheckScope,
 ): Promise<void> => {
   if (!redis) return;
 
   try {
-    for (const candidate of buildWorkflowRunGuardKeys(scope)) {
-      const value = parseGuardValue(await redis.get(candidate.key));
+    const candidates = buildWorkflowRunGuardKeys(scope);
+    const values = await redis.mget(...candidates.map((candidate) => candidate.key));
+
+    for (const [index, candidate] of candidates.entries()) {
+      const value = parseGuardValue(values[index] ?? null);
       if (!value) continue;
 
       const match: WorkflowRunGuardMatch = {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Replace workflow run guard candidate checks from sequential Redis GET calls with a single MGET call.
- Preserve candidate ordering so the first matching guard still determines the thrown WorkflowRunGuardError.
- Update store tests to cover single-call MGET behavior, malformed values, and fail-open Redis errors.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated tests:

```bash
bunx vitest run --silent='passed-only' 'src/server/workflows/runGuard/__tests__'
```

Manual verification:

- Verified the configured Redis provider supports MGET against `.env.development` REDIS_URL.
- Verified a no-guard check performs one MGET and a temporary path guard still blocks execution.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This reduces Redis command fan-out during workflow replay without changing guard key construction or matching semantics.
