### PR TITLE
🐛 fix(chat): handle stream network failures

### DIFF
--- a/src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts
+++ b/src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts
@@ -1,7 +1,7 @@
 import { type GeneralAgentCallLLMResultPayload } from '@lobechat/agent-runtime';
 import { LOADING_FLAT } from '@lobechat/const';
 import type { MessageToolCall } from '@lobechat/types';
-import { RequestTrigger } from '@lobechat/types';
+import { ChatErrorType, RequestTrigger } from '@lobechat/types';
 import { describe, expect, it, vi } from 'vitest';
 
 import { chatService } from '@/services/chat';
@@ -1702,6 +1702,57 @@ describe('call_llm executor', () => {
   });
 
   describe('Google blocked stream errors', () => {
+    it('should mark the assistant message as failed and refresh messages when the stream rejects', async () => {
+      // Given
+      const mockStore = createMockStore();
+      const context = createTestContext();
+      const instruction = createCallLLMInstruction();
+      const state = createInitialState();
+
+      mockStore.dbMessagesMap[context.messageKey] = [];
+
+      vi.mocked(chatService.createAssistantMessageStream).mockRejectedValueOnce(
+        new TypeError('Failed to fetch'),
+      );
+
+      // When
+      const result = await executeWithMockContext({
+        executor: 'call_llm',
+        instruction,
+        state,
+        mockStore,
+        context,
+      });
+
+      // Then
+      expect(mockStore.optimisticUpdateMessageError).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          message: 'Failed to fetch',
+          type: ChatErrorType.UnknownChatFetchError,
+        }),
+        { operationId: context.operationId },
+      );
+      expect(mockStore.refreshMessages).toHaveBeenCalledWith({
+        agentId: context.agentId,
+        groupId: undefined,
+        threadId: undefined,
+        topicId: context.topicId,
+      });
+      expect(result).toEqual(
+        expect.objectContaining({
+          events: [
+            expect.objectContaining({
+              type: 'error',
+            }),
+          ],
+          newState: expect.objectContaining({
+            status: 'error',
+          }),
+        }),
+      );
+    });
+
     it('should keep normal content and update message error state', async () => {
       // Given
       const mockStore = createMockStore();

--- a/src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts
+++ b/src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts
@@ -1753,6 +1753,65 @@ describe('call_llm executor', () => {
       );
     });
 
+    it('should stop with an error state when the stream reports an error without rejecting', async () => {
+      // Given
+      const mockStore = createMockStore();
+      const context = createTestContext();
+      const instruction = createCallLLMInstruction();
+      const state = createInitialState();
+
+      mockStore.dbMessagesMap[context.messageKey] = [];
+
+      vi.mocked(chatService.createAssistantMessageStream).mockImplementation(
+        async (params: any) => {
+          await params.onErrorHandle?.({
+            body: {
+              provider: 'openai',
+            },
+            message: 'Network connection lost',
+            type: ChatErrorType.UnknownChatFetchError,
+          });
+        },
+      );
+
+      // When
+      const result = await executeWithMockContext({
+        executor: 'call_llm',
+        instruction,
+        state,
+        mockStore,
+        context,
+      });
+
+      // Then
+      expect(mockStore.optimisticUpdateMessageError).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          message: 'Network connection lost',
+          type: ChatErrorType.UnknownChatFetchError,
+        }),
+        { operationId: context.operationId },
+      );
+      expect(mockStore.refreshMessages).toHaveBeenCalledWith({
+        agentId: context.agentId,
+        groupId: undefined,
+        threadId: undefined,
+        topicId: context.topicId,
+      });
+      expect(result).toEqual(
+        expect.objectContaining({
+          events: [
+            expect.objectContaining({
+              type: 'error',
+            }),
+          ],
+          newState: expect.objectContaining({
+            status: 'error',
+          }),
+        }),
+      );
+    });
+
     it('should keep normal content and update message error state', async () => {
       // Given
       const mockStore = createMockStore();

--- a/src/store/chat/agents/__tests__/createAgentExecutors/fixtures/mockStore.ts
+++ b/src/store/chat/agents/__tests__/createAgentExecutors/fixtures/mockStore.ts
@@ -106,6 +106,8 @@ export const createMockStore = (overrides: Partial<ChatStore> = {}): ChatStore =
 
     optimisticUpdatePluginState: vi.fn().mockResolvedValue(undefined),
 
+    refreshMessages: vi.fn().mockResolvedValue(undefined),
+
     // Operation management methods
     startOperation: vi.fn().mockImplementation((config) => {
       const operationId = `op_${nanoid()}`;

--- a/src/store/chat/agents/createAgentExecutors.ts
+++ b/src/store/chat/agents/createAgentExecutors.ts
@@ -459,6 +459,34 @@ export const createAgentExecutors = (context: {
       );
 
       const messages = llmPayload.messages.filter((message) => message.id !== assistantMessageId);
+      let streamError: ChatMessageError | undefined;
+
+      const handleStreamError = async (error: ChatMessageError) => {
+        streamError = error;
+
+        await context.get().optimisticUpdateMessageError(assistantMessageId, error, {
+          operationId: context.operationId,
+        });
+      };
+
+      const toUnknownChatFetchError = (error: unknown): ChatMessageError => {
+        const message = error instanceof Error ? error.message : String(error);
+
+        return {
+          body: { message, traceId },
+          message,
+          type: ChatErrorType.UnknownChatFetchError,
+        };
+      };
+
+      const returnStreamErrorState = async (error: ChatMessageError) => {
+        await context.get().refreshMessages({ agentId, groupId, threadId, topicId });
+
+        return {
+          events: [{ error, type: 'error' as const }],
+          newState: { ...state, status: 'error' as const },
+        };
+      };
 
       try {
         await chatService.createAssistantMessageStream({
@@ -491,9 +519,7 @@ export const createAgentExecutors = (context: {
             };
             const localizedError = localizeError(enrichedError);
 
-            await context.get().optimisticUpdateMessageError(assistantMessageId, localizedError, {
-              operationId: context.operationId,
-            });
+            await handleStreamError(localizedError);
           },
           onFinish: async (
             _content,
@@ -550,22 +576,15 @@ export const createAgentExecutors = (context: {
       } catch (error) {
         if (isAbortError(error, abortController)) throw error;
 
-        const message = error instanceof Error ? error.message : String(error);
-        const streamError: ChatMessageError = {
-          body: { message, traceId },
-          message,
-          type: ChatErrorType.UnknownChatFetchError,
-        };
+        const streamError = toUnknownChatFetchError(error);
 
-        await context.get().optimisticUpdateMessageError(assistantMessageId, streamError, {
-          operationId: context.operationId,
-        });
-        await context.get().refreshMessages({ agentId, groupId, threadId, topicId });
+        await handleStreamError(streamError);
 
-        return {
-          events: [{ error: streamError, type: 'error' as const }],
-          newState: { ...state, status: 'error' as const },
-        };
+        return returnStreamErrorState(streamError);
+      }
+
+      if (streamError) {
+        return returnStreamErrorState(streamError);
       }
 
       const isFunctionCall = handler.getIsFunctionCall();

--- a/src/store/chat/agents/createAgentExecutors.ts
+++ b/src/store/chat/agents/createAgentExecutors.ts
@@ -20,6 +20,7 @@ import { UsageCounter } from '@lobechat/agent-runtime';
 import { countContextTokens, type ToolsEngine } from '@lobechat/context-engine';
 import { chainCompressContext } from '@lobechat/prompts';
 import {
+  ChatErrorType,
   type ChatMessageError,
   type ChatToolPayload,
   type CreateMessageParams,
@@ -297,7 +298,7 @@ export const createAgentExecutors = (context: {
       if (!operation) {
         throw new Error(`Operation not found: ${context.operationId}`);
       }
-      const { subAgentId, groupId, topicId } = operation.context;
+      const { subAgentId, groupId, threadId, topicId } = operation.context;
       const abortController = operation.abortController;
 
       // In group orchestration, subAgentId is the actual responding agent
@@ -459,92 +460,113 @@ export const createAgentExecutors = (context: {
 
       const messages = llmPayload.messages.filter((message) => message.id !== assistantMessageId);
 
-      await chatService.createAssistantMessageStream({
-        abortController,
-        params: {
-          agentId: agentId || undefined,
-          groupId,
-          messages,
-          model: llmPayload.model,
-          provider: llmPayload.provider,
-          resolvedAgentConfig,
-          topicId: topicId ?? undefined,
-          ...agentConfigData.params,
-        },
-        initialContext: runtimeContext?.initialContext,
-        metadata: context.metadata,
-        stepContext: runtimeContext?.stepContext,
-        trace: {
-          traceId,
-          topicId: topicId ?? undefined,
-          traceName: TraceNameMap.Conversation,
-        },
-        onErrorHandle: async (error) => {
-          const enrichedError = {
-            ...error,
-            body: {
-              ...error.body,
-              traceId: traceId ?? error.body?.traceId,
-            },
-          };
-          const localizedError = localizeError(enrichedError);
-
-          await context.get().optimisticUpdateMessageError(assistantMessageId, localizedError, {
-            operationId: context.operationId,
-          });
-        },
-        onFinish: async (
-          _content,
-          { traceId, observationId, toolCalls, reasoning, grounding, usage, speed, type },
-        ) => {
-          void _content;
-
-          if (traceId) {
-            messageService.updateMessage(
-              assistantMessageId,
-              { traceId, observationId: observationId ?? undefined },
-              { agentId, groupId, topicId },
-            );
-          }
-
-          const result = await handler.handleFinish({
+      try {
+        await chatService.createAssistantMessageStream({
+          abortController,
+          params: {
+            agentId: agentId || undefined,
+            groupId,
+            messages,
+            model: llmPayload.model,
+            provider: llmPayload.provider,
+            resolvedAgentConfig,
+            topicId: topicId ?? undefined,
+            ...agentConfigData.params,
+          },
+          initialContext: runtimeContext?.initialContext,
+          metadata: context.metadata,
+          stepContext: runtimeContext?.stepContext,
+          trace: {
             traceId,
-            observationId,
-            toolCalls,
-            reasoning,
-            grounding,
-            usage,
-            speed,
-            type,
-          });
-
-          finalUsage = result.usage;
-          finalToolCalls = result.toolCalls;
-
-          await optimisticUpdateMessageContent(
-            assistantMessageId,
-            result.content,
-            {
-              tools: result.tools,
-              reasoning: result.metadata.reasoning,
-              search: result.metadata.search,
-              imageList: result.metadata.imageList,
-              metadata: {
-                ...result.metadata.usage,
-                ...result.metadata.performance,
-                performance: result.metadata.performance,
-                usage: result.metadata.usage,
-                finishType: result.metadata.finishType,
-                ...(result.metadata.isMultimodal && { isMultimodal: true }),
+            topicId: topicId ?? undefined,
+            traceName: TraceNameMap.Conversation,
+          },
+          onErrorHandle: async (error) => {
+            const enrichedError = {
+              ...error,
+              body: {
+                ...error.body,
+                traceId: traceId ?? error.body?.traceId,
               },
-            },
-            { operationId: context.operationId },
-          );
-        },
-        onMessageHandle: async (chunk) => {
-          handler.handleChunk(chunk as StreamChunk);
-        },
-      });
+            };
+            const localizedError = localizeError(enrichedError);
+
+            await context.get().optimisticUpdateMessageError(assistantMessageId, localizedError, {
+              operationId: context.operationId,
+            });
+          },
+          onFinish: async (
+            _content,
+            { traceId, observationId, toolCalls, reasoning, grounding, usage, speed, type },
+          ) => {
+            void _content;
+
+            if (traceId) {
+              messageService.updateMessage(
+                assistantMessageId,
+                { traceId, observationId: observationId ?? undefined },
+                { agentId, groupId, topicId },
+              );
+            }
+
+            const result = await handler.handleFinish({
+              traceId,
+              observationId,
+              toolCalls,
+              reasoning,
+              grounding,
+              usage,
+              speed,
+              type,
+            });
+
+            finalUsage = result.usage;
+            finalToolCalls = result.toolCalls;
+
+            await optimisticUpdateMessageContent(
+              assistantMessageId,
+              result.content,
+              {
+                tools: result.tools,
+                reasoning: result.metadata.reasoning,
+                search: result.metadata.search,
+                imageList: result.metadata.imageList,
+                metadata: {
+                  ...result.metadata.usage,
+                  ...result.metadata.performance,
+                  performance: result.metadata.performance,
+                  usage: result.metadata.usage,
+                  finishType: result.metadata.finishType,
+                  ...(result.metadata.isMultimodal && { isMultimodal: true }),
+                },
+              },
+              { operationId: context.operationId },
+            );
+          },
+          onMessageHandle: async (chunk) => {
+            handler.handleChunk(chunk as StreamChunk);
+          },
+        });
+      } catch (error) {
+        if (isAbortError(error, abortController)) throw error;
+
+        const message = error instanceof Error ? error.message : String(error);
+        const streamError: ChatMessageError = {
+          body: { message, traceId },
+          message,
+          type: ChatErrorType.UnknownChatFetchError,
+        };
+
+        await context.get().optimisticUpdateMessageError(assistantMessageId, streamError, {
+          operationId: context.operationId,
+        });
+        await context.get().refreshMessages({ agentId, groupId, threadId, topicId });
+
+        return {
+          events: [{ error: streamError, type: 'error' as const }],
+          newState: { ...state, status: 'error' as const },
+        };
+      }
 
       const isFunctionCall = handler.getIsFunctionCall();
       const content = handler.getOutput();


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #16762

#### 🔀 Description of Change

- Handles rejected chat assistant streams by marking the assistant message with `UnknownChatFetchError`.
- Refreshes the active conversation messages after stream failure so restored network state can recover from the latest server data.
- Adds regression coverage for rejected assistant streams in the `call_llm` executor.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run --silent='passed-only' src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts
bun run type-check
bunx eslint src/store/chat/agents/createAgentExecutors.ts src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts src/store/chat/agents/__tests__/createAgentExecutors/fixtures/mockStore.ts
```

#### 📝 Additional Information

This is scoped to stream rejection handling and does not auto-resubmit user prompts.
