### PR TITLE
🐛 fix(memory-user-memory): isolate per-topic invoke failures so one bad topic can't retry-storm

### DIFF
--- a/src/server/workflows-hono/memory-user-memory/workflows/processTopics.ts
+++ b/src/server/workflows-hono/memory-user-memory/workflows/processTopics.ts
@@ -5,7 +5,7 @@ import {
 } from '@lobechat/observability-otel/modules/upstash-workflow';
 import { LayersEnum, MemorySourceType } from '@lobechat/types';
 import { type WorkflowContext } from '@upstash/workflow';
-import { WorkflowAbort } from '@upstash/workflow';
+import { WorkflowAbort, WorkflowNonRetryableError } from '@upstash/workflow';
 
 import { AsyncTaskModel } from '@/database/models/asyncTask';
 import { getServerDB } from '@/database/server';
@@ -116,28 +116,45 @@ export const processTopicsHandler = (context: WorkflowContext<MemoryExtractionPa
         // Delegate per-topic extraction to dedicated workflow for better isolation.
         for (const [index, topicId] of payload.topicIds.entries()) {
           const stepName = `memory:user-memory:extract:users:${userId}:topics:${topicId}:invoke:${index}`;
-          await context.invoke(stepName, {
-            body: {
-              ...payload,
-              layers: payload.layers.length ? payload.layers : [...CEPA_LAYERS, ...IDENTITY_LAYERS],
-              topicIds: [topicId],
-              userId,
-              userIds: [userId],
-            },
-            // CEPA: run in parallel across the batch
-            //
-            // NOTICE: if modified the parallelism of CEPA_LAYERS
-            // or added new memory layer, make sure to update the number below.
-            //
-            // Currently, CEPA (context, experience, preference, activity) + identity = 5 layers.
-            // and since identity requires sequential processing, we set parallelism to 5.
-            flowControl: {
-              key: `memory-user-memory.pipelines.chat-topic.process-topic.user.${userId}.topic.${topicId}`,
-              parallelism: 5,
-            },
-            headers: upstashWorkflowExtraHeaders,
-            workflow: processTopicWorkflow,
-          });
+          try {
+            await context.invoke(stepName, {
+              body: {
+                ...payload,
+                layers: payload.layers.length
+                  ? payload.layers
+                  : [...CEPA_LAYERS, ...IDENTITY_LAYERS],
+                topicIds: [topicId],
+                userId,
+                userIds: [userId],
+              },
+              // CEPA: run in parallel across the batch
+              //
+              // NOTICE: if modified the parallelism of CEPA_LAYERS
+              // or added new memory layer, make sure to update the number below.
+              //
+              // Currently, CEPA (context, experience, preference, activity) + identity = 5 layers.
+              // and since identity requires sequential processing, we set parallelism to 5.
+              flowControl: {
+                key: `memory-user-memory.pipelines.chat-topic.process-topic.user.${userId}.topic.${topicId}`,
+                parallelism: 5,
+              },
+              headers: upstashWorkflowExtraHeaders,
+              workflow: processTopicWorkflow,
+            });
+          } catch (error) {
+            // NOTICE: Upstash throws WorkflowAbort after a step executes to persist state — it must
+            // bubble up, never be swallowed here.
+            if (error instanceof WorkflowAbort) throw error;
+            // A child process-topic that FAILED (e.g. a bad model config makes extraction always
+            // fail) must NOT fail this batch. If it propagated, this whole process-topics run would
+            // become retryable and, on every retry replay, re-invoke the same topic forever —
+            // piling up hundreds of thousands of flow-control messages on a single (user, topic).
+            // Record it and move on to the next topic (per-topic isolation).
+            console.error(
+              `[process-topics] invoke failed for user ${userId} topic ${topicId}; skipping topic`,
+              error instanceof Error ? error.message : error,
+            );
+          }
         }
 
         // Trigger user persona update after topic processing using the workflow client.
@@ -167,7 +184,12 @@ export const processTopicsHandler = (context: WorkflowContext<MemoryExtractionPa
           message: error instanceof Error ? error.message : 'process-topics workflow failed',
         });
 
-        throw error;
+        // NOTICE: Make process-topics non-retryable (aligning with process-topic). A retryable
+        // failure here re-runs the whole run — including its context.invoke steps — which is exactly
+        // how one bad topic snowballed into a retry storm. Fail fast instead of looping.
+        throw new WorkflowNonRetryableError(
+          error instanceof Error ? error.message : 'process-topics workflow failed',
+        );
       } finally {
         span.end();
       }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Root-cause fix for LOBE-11454 (memory retry storm). Complements #16758 (which fixed the run-guard *throw* side but NOT this invoke retry loop).

#### 🔀 Description of Change

**Root cause of the 2026-07-05 memory retry storm.** `processTopics` treated a failed `context.invoke` (a child `process-topic` that always fails — e.g. the affected user's memory model was configured to a non-existent `gpt-10-mini`) as a **retryable** error:

- Each `context.invoke` had no per-invoke isolation; a failed child made it throw.
- The outer catch did `throw error` (retryable), not `WorkflowNonRetryableError`.

So QStash retried the whole run, and every retry replayed the for-loop's `context.invoke` for the failing topic again — re-pushing a message onto that `(user, topic)`'s flow-control key each time. **One topic snowballed to ~650k queued invokes** (`...process-topic.user.<id>.topic.<id>` waitListSize = 652620) and the run re-enqueued itself forever (the `process-topics` disabled/invoke flood, ~1200/min, that wouldn't converge).

**Fix:**
- Wrap each `context.invoke` in try/catch: **re-throw `WorkflowAbort`** (Upstash's normal post-step persist signal must bubble up), but on a genuine child failure **log and skip that topic** — per-topic isolation, one bad topic no longer fails the batch.
- Outer catch throws **`WorkflowNonRetryableError`** instead of the raw error, aligning with `process-topic.ts`. A retryable failure here re-runs the whole run (incl. its invoke steps) — exactly how the storm compounded.

`gpt-10-mini` (the unavailable model) is a runtime config issue tracked separately; this change makes the pipeline resilient to **any** always-failing topic regardless of trigger.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Note: repo-wide `type-check` has pre-existing failures from a duplicate `drizzle-orm` install (unrelated files: `ragEval`, `aiAgent` tests) that reproduce on canary without this change. This diff only adds a try/catch + swaps the throw type (`WorkflowNonRetryableError` is already used by the sibling `process-topic.ts`).