### PR TITLE
🐛 fix(memory-user-memory): apply run guard in persona update-writing handler

### DIFF
--- a/src/server/workflows-hono/memory-user-memory/workflows/personaUpdate.ts
+++ b/src/server/workflows-hono/memory-user-memory/workflows/personaUpdate.ts
@@ -7,11 +7,26 @@ import {
   UserPersonaService,
 } from '@/server/services/memory/userMemory/persona/service';
 
+import { resolveMemoryWorkflowRunGuard } from './runGuard';
+
+const WORKFLOW_PATH = 'api/workflows/memory-user-memory/pipelines/persona/update-writing';
+
 const workflowPayloadSchema = z.object({
   userIds: z.array(z.string()).optional(),
 });
 
 export const personaUpdateHandler = async (context: WorkflowContext) => {
+  // NOTICE: Return (never throw) on a guard match — a throw before the first step makes Upstash
+  // re-enqueue the run, turning a "disable" guard into an infinite retry storm.
+  const guardBlock = await resolveMemoryWorkflowRunGuard(context, WORKFLOW_PATH);
+  if (guardBlock) {
+    return {
+      message: `Memory workflow disabled by run guard (${guardBlock.reason ?? guardBlock.scope}); skipping.`,
+      processedUsers: 0,
+      skipped: true,
+    };
+  }
+
   const payload = await context.run('memory:pipelines:persona:update-writing:parse-payload', () =>
     workflowPayloadSchema.parse(context.requestPayload || {}),
   );


### PR DESCRIPTION
## What & why

The persona `update-writing` handler (`/pipelines/persona/update-writing`) was the only `memory-user-memory` workflow handler with **no run-guard check**. Every other handler (`hourly`, `processUsers`, `processUserTopics`, `processTopics`, `processTopic`) calls `resolveMemoryWorkflowRunGuard` at entry, so a user- or path-scoped run guard can gracefully disable them.

Because `personaUpdate.ts` skipped this check, a run guard set to contain a memory storm could **not** stop the persona pipeline — it stayed an unguarded producer, still doing persona composition work after the guard was applied.

## Change

Add `resolveMemoryWorkflowRunGuard(context, WORKFLOW_PATH)` at handler entry, returning a skip result on a guard match (never throwing — a throw before the first step makes Upstash re-enqueue the run into a retry storm). Mirrors the existing handlers exactly.

## Test

- `bun run check .../personaUpdate.ts --lint` → clean
- Guard payload user extraction already covered by the shared `runGuard` (reads `payload.userId` / `userIds[0]`), which the persona payload (`{ userIds }`) satisfies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)