### PR TITLE
🐛 fix(hetero): derive spine promotion from currentAssistantId (cold-replica safe)

### DIFF
--- a/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.test.ts
+++ b/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.test.ts
@@ -235,6 +235,33 @@ describe('main agent reducer', () => {
     expect(state.lastSpineMessageId).toBe('msg_4');
   });
 
+  // ─── The promotion must survive a cold / non-sticky serverless replica ───
+  // `refreshMainStateFromDb` rehydrates `currentAssistantId` + `lastSpineMessageId`
+  // but NOT any per-turn "opened as signal" bookkeeping. A replica that resumes
+  // mid-signal-turn (SIG open, still toolless in the DB so the recovered spine is
+  // the PRE-signal assistant) then receives SIG's `tools_calling` + the next
+  // `newStep` in one batch. Promotion must still fire, or the same-batch normal
+  // turn forks off the stale spine again — recreating the tail-drop for
+  // non-sticky ingestion. Deriving the promotion from `currentAssistantId`
+  // (not an in-memory flag) is what makes this hold.
+  it('promotes on a rehydrated cold replica with no in-memory signal flag', () => {
+    // State as projected by refreshMainStateFromDb: SIG is the open turn, the
+    // recovered spine is the pre-signal assistant (they differ).
+    const rehydrated: MainAgentRunState = {
+      ...createMainAgentRunState('SEED'),
+      currentAssistantId: 'SIG',
+      lastSpineMessageId: 'SPINE0',
+      lastToolMsgIdEver: 'toolPre',
+    };
+    const ctx = makeCtx();
+
+    let r = reduceMainAgent(rehydrated, toolsEvent([tool('t1')]), ctx); // SIG's tool_use
+    expect(r.state.lastSpineMessageId).toBe('SIG'); // promoted despite no flag
+
+    r = reduceMainAgent(r.state, newStepEvent(), ctx); // the next normal turn
+    expect(ofKind(r.intents, 'createAssistant')[0]).toMatchObject({ parentId: 'SIG' });
+  });
+
   it('falls back to the current assistant only before any tool exists', () => {
     const { steps } = run([textEvent('hi'), newStepEvent()]); // no tool ever seen
     expect(ofKind(steps[1], 'createAssistant')[0]).toMatchObject({

--- a/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.ts
+++ b/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.ts
@@ -156,11 +156,11 @@ const openTurn = (state: MainAgentRunState, data: any, ctx: MainAgentReduceCtx):
   next.currentAssistantId = messageId;
   // The spine only advances on NORMAL turns — a signal/reactive turn is a
   // tool-child callback, so the next normal turn re-mounts on the pre-callback
-  // spine assistant, not on the callback. But a signal turn that goes on to
-  // emit a tool_use is really back on the main chain: `reduceToolsChunk`
-  // promotes it onto the spine, gated on this flag.
+  // spine assistant, not on the callback. A signal turn that then emits a
+  // tool_use is really back on the main chain; `reduceToolsChunk` advances the
+  // spine onto it at that point (derived from `currentAssistantId`, so it holds
+  // on a cold replica too — see there).
   if (!isSignalTurn) next.lastSpineMessageId = messageId;
-  next.currentTurnIsSignal = isSignalTurn;
   next.currentMainMessageId = mainMessageId;
   next.accContent = '';
   next.accReasoning = '';
@@ -277,15 +277,21 @@ const reduceToolsChunk = (
   const lastToolMsgId = newToolMsgIds.at(-1);
   if (lastToolMsgId) next.lastToolMsgIdEver = lastToolMsgId;
 
-  // A signal/reactive turn that emits a tool_use is back on the main chain (the
-  // reactive-push phase is over — mirrors the adapter dropping its pending
-  // signal on the next tool_use). Promote it onto the spine so the NEXT normal
-  // turn chains off THIS turn, not the pre-signal spine assistant. Otherwise the
-  // wire forks and the read side drops everything after the fork. Consume once.
-  if (next.currentTurnIsSignal) {
-    next.lastSpineMessageId = next.currentAssistantId;
-    next.currentTurnIsSignal = false;
-  }
+  // Any assistant that emits a tool_use is on the main chain, so it is a spine
+  // message — advance the spine onto it. For a normal turn this is a no-op
+  // (`openTurn` already pointed the spine here). For a turn OPENED as a
+  // signal/reactive callback that then called a tool, this promotes it so the
+  // NEXT normal turn chains off THIS turn instead of the pre-signal assistant —
+  // otherwise the wire forks and the read side drops everything after the fork.
+  //
+  // Deriving the promotion from `currentAssistantId` (not a per-turn "opened as
+  // signal" flag) is what keeps it correct on a cold / non-sticky serverless
+  // replica: an in-memory flag is NOT rehydrated by `refreshMainStateFromDb`,
+  // but `currentAssistantId` and `lastSpineMessageId` ARE — and a mid-flight
+  // signal turn is still toolless in the DB, so the recovered spine is the
+  // pre-signal assistant (≠ currentAssistantId) and this batch's `tools_calling`
+  // promotes it exactly as a warm replica would.
+  next.lastSpineMessageId = next.currentAssistantId;
 
   return { intents, state: next };
 };

--- a/packages/heterogeneous-agents/src/mainAgentCoordinator/types.ts
+++ b/packages/heterogeneous-agents/src/mainAgentCoordinator/types.ts
@@ -79,20 +79,6 @@ export interface MainAgentRunState {
    * host-seeded first turn (which never opens via `newStep`, so can't fork).
    */
   currentMainMessageId: string | undefined;
-  /**
-   * True while the CURRENT turn was opened as a signal/reactive turn (parented
-   * off a tool via `lastToolMsgIdEver`, spine deliberately NOT advanced). The
-   * writer tags a turn `signal` at `stream_start`, BEFORE it knows the turn will
-   * use tools. A signal turn that then emits a `tool_use` is really back on the
-   * main chain — `reduceToolsChunk` advances the spine onto it so the NEXT
-   * normal turn chains off THIS turn instead of re-mounting on the pre-signal
-   * spine. Without this, the wire forks (`spine → {signal-turn-with-tools,
-   * next-normal-turn}`) and the read side, which picks the earliest continuation
-   * at a fork, walks into the signal branch and drops the post-fork tail — the
-   * "trace 和回复对不上 + 中间截断" render bug. Consumed on the first tool batch;
-   * reset per turn in `openTurn`.
-   */
-  currentTurnIsSignal: boolean;
   /** Set once a terminal event has been reduced (idempotent finalize). */
   ended: boolean;
   /**
@@ -138,7 +124,6 @@ export const createMainAgentRunState = (seedAssistantId: string): MainAgentRunSt
   accReasoning: '',
   currentAssistantId: seedAssistantId,
   currentMainMessageId: undefined,
-  currentTurnIsSignal: false,
   ended: false,
   lastSpineMessageId: seedAssistantId,
   lastTextSnapshotSeq: 0,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Follow-up hardening for #16750 (hetero signal-turn spine promotion). Addresses a P1 review finding on the non-sticky serverless ingestion path.

#### 🔀 Description of Change

#16750 gated the spine promotion on an in-memory `currentTurnIsSignal` flag set in `openTurn`. On a **cold / non-sticky serverless replica**, `refreshMainStateFromDb` rehydrates `currentAssistantId` and `lastSpineMessageId` from the DB but **not** that flag. So a replica resuming mid-signal-turn (the signal assistant is open and still toolless in the DB) that receives the signal turn's `tools_calling` + the following `stream_start { newStep }` in one batch would skip the promotion — the same-batch normal turn forks off the stale pre-signal spine and the tail drops again for non-sticky ingestion, recreating the exact bug #16750 fixed. (The renderer / warm-replica paths were unaffected, so this never bit `tpc_aGIggi9N8DpK`, which is client-run.)

**Fix:** drop the flag and derive the promotion from `currentAssistantId`. In `reduceToolsChunk`, unconditionally advance `lastSpineMessageId` onto the current assistant:

- a normal turn already points the spine at itself → no-op;
- a turn opened as a signal callback that then emits a `tool_use` → promoted.

Because a mid-flight signal turn is toolless in the DB, the recovered spine on a cold replica is the pre-signal assistant (≠ `currentAssistantId`), so the batch's `tools_calling` promotes it exactly as a warm replica would — nothing to rehydrate.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

```bash
cd packages/heterogeneous-agents && bunx vitest run src/mainAgentCoordinator/reducer.test.ts   # 23 passed
bunx tsgo --noEmit   # 0 errors
```

New test `promotes on a rehydrated cold replica with no in-memory signal flag` builds the state `refreshMainStateFromDb` would project (open signal assistant, spine recovered to the pre-signal assistant) and asserts the next turn still chains off the promoted turn.

#### 📝 Additional Information

Removes the `currentTurnIsSignal` state field entirely (no writer / reader references remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
