### PR TITLE
fix: remove unused param lint suppressions

### DIFF
--- a/packages/business-server/src/image-generation/chargeAfterGenerate.ts
+++ b/packages/business-server/src/image-generation/chargeAfterGenerate.ts
@@ -17,5 +17,4 @@ interface ChargeParams {
   workspaceId?: string;
 }
 
-// eslint-disable-next-line unused-imports/no-unused-vars
-export async function chargeAfterGenerate(params: ChargeParams): Promise<void> {}
+export async function chargeAfterGenerate(_params: ChargeParams): Promise<void> {}

--- a/packages/business-server/src/video-generation/chargeAfterGenerate.ts
+++ b/packages/business-server/src/video-generation/chargeAfterGenerate.ts
@@ -17,5 +17,4 @@ interface ChargeParams {
   workspaceId?: string;
 }
 
-// eslint-disable-next-line unused-imports/no-unused-vars
-export async function chargeAfterGenerate(params: ChargeParams): Promise<void> {}
+export async function chargeAfterGenerate(_params: ChargeParams): Promise<void> {}


### PR DESCRIPTION
## Summary
- remove two `unused-imports/no-unused-vars` eslint suppressions from business-server generation charge stubs
- mark the currently unused params with the existing underscore convention

Part of #16482

## Verification
- `git diff --check`
- confirmed the removed suppression text is no longer present in the changed files
- `pnpm exec eslint packages/business-server/src/image-generation/chargeAfterGenerate.ts packages/business-server/src/video-generation/chargeAfterGenerate.ts` could not run because eslint is not installed in this sparse checkout (`Command "eslint" not found`)
