### PR TITLE
🐛 fix(desktop): open device-scope skill previews (local IPC + bound-device RPC)

### DIFF
--- a/src/features/SkillsList/useProjectSkillResolver.ts
+++ b/src/features/SkillsList/useProjectSkillResolver.ts
@@ -12,10 +12,9 @@ export interface ResolvedProjectSkill {
   description?: string;
   name: string;
   /**
-   * Opens the skill's `SKILL.md` in the right-hand portal. Only present when the
-   * skill is reachable by the local viewer — a remote device's filesystem can't
-   * be previewed (matches the Files tab / working-sidebar behavior), so those
-   * tags stay non-clickable.
+   * Opens the skill's `SKILL.md` in the right-hand portal. Present whenever the
+   * skill resolves — local reads go over IPC, a bound device over RPC (matches
+   * the Files tab / working-sidebar behavior).
    */
   open?: () => void;
 }
@@ -71,10 +70,11 @@ export const useProjectSkillResolver = (
       return {
         description: item.description,
         name: item.name,
-        // A remote device's SKILL.md isn't reachable by the local viewer.
-        open: remoteDeviceId ? undefined : () => onOpenSkill(item),
+        // Preview opens in every mode now — onOpenSkill reads over IPC locally
+        // and over RPC for a bound device (like the Files tab).
+        open: () => onOpenSkill(item),
       };
     },
-    [items, onOpenSkill, remoteDeviceId],
+    [items, onOpenSkill],
   );
 };

--- a/src/features/SkillsList/useProjectSkills.ts
+++ b/src/features/SkillsList/useProjectSkills.ts
@@ -14,10 +14,9 @@ export interface UseProjectSkillsResult {
   /** The thrown error from the SWR scan, if it failed. */
   error: unknown;
   /**
-   * Per-row actions for filesystem skills: "view" opens the SKILL.md (local
-   * only — a remote device's filesystem isn't reachable by the local viewer),
-   * while rename / delete are stubbed (disabled) until filesystem-mutation IPC
-   * lands.
+   * Per-row actions for filesystem skills: "view" opens the SKILL.md (locally
+   * via IPC, or on a bound device over RPC — same as the Files tab), while
+   * rename / delete are stubbed (disabled) until filesystem-mutation IPC lands.
    */
   getRowActions: (item: SkillListItem) => SkillRowAction[];
   isLoading: boolean;
@@ -35,10 +34,11 @@ export interface UseProjectSkillsResult {
  * under `.agents/skills` / `.claude/skills` in `workingDirectory`; device
  * skills live under those directories in the execution device's home.
  *
- * `deviceId` picks the transport: when set, the scan runs on that remote device
- * via the `device.listProjectSkills` RPC; otherwise it goes through local
- * Electron IPC. Like the Files tab, remote mode lists skills but does not open
- * previews (the device's filesystem isn't reachable by the local viewer).
+ * `deviceId` picks the transport for both listing and preview: when set, the
+ * scan and file reads run on that bound device via RPC (`device.listProjectSkills`
+ * / `device.getLocalFilePreview`); otherwise they go through local Electron IPC.
+ * Mirrors the Files tab — a bound device (remote or this machine) previews over
+ * RPC rather than being non-openable.
  *
  * Pass `undefined` workingDirectory to keep the hook inert (no fetch fires) —
  * useful when the caller hasn't decided whether to render the section yet.
@@ -49,7 +49,6 @@ export const useProjectSkills = (
 ): UseProjectSkillsResult => {
   const { t } = useTranslation('chat');
   const openLocalFile = useChatStore((s) => s.openLocalFile);
-  const isRemote = !!deviceId;
 
   const { data, error, isLoading, mutate } = useFetchProjectSkills(workingDirectory, deviceId);
 
@@ -81,31 +80,42 @@ export const useProjectSkills = (
     return map;
   }, [data?.skills]);
 
-  const onOpenFile = (item: SkillListItem, relativePath: string) => {
-    // A remote device has no filesystem the local viewer can open (matches the
-    // Files tab); device mode lists skills but does not preview them.
-    if (isRemote) return;
-    const skill = skillByDir.get(item.id);
-    if (!skill) return;
+  // Device-scope skills live under the execution device's home
+  // (`~/.agents/skills` / `~/.claude/skills`), outside the topic's project
+  // scope. Marking them external both keeps the portal scope filter
+  // (isLocalFileInCurrentScope) from dropping the tab and clears the desktop
+  // preview protocol's approved-root / symlink-containment check
+  // (resolveApprovedPreviewPath), so previews open instead of showing blank.
+  const openSkillFile = (skill: ProjectSkillItem, filePath: string) => {
     openLocalFile({
-      filePath: path.join(skill.skillDir, relativePath),
+      allowExternalFilePreview: skill.scope === 'device',
+      // A bound device (remote, or this machine as a device) reads the preview
+      // over RPC, exactly like the Files tab; an undefined deviceId falls back to
+      // local Electron IPC. The old `isRemote` no-op predated remote preview.
+      deviceId,
+      filePath,
       workingDirectory: skill.previewRoot || previewRoot,
     });
   };
 
-  const onOpenSkill = (item: SkillListItem) => {
-    if (isRemote) return;
+  const onOpenFile = (item: SkillListItem, relativePath: string) => {
     const skill = skillByDir.get(item.id);
     if (!skill) return;
-    openLocalFile({ filePath: skill.path, workingDirectory: skill.previewRoot || previewRoot });
+    openSkillFile(skill, path.join(skill.skillDir, relativePath));
+  };
+
+  const onOpenSkill = (item: SkillListItem) => {
+    const skill = skillByDir.get(item.id);
+    if (!skill) return;
+    openSkillFile(skill, skill.path);
   };
 
   const getRowActions = (_item: SkillListItem): SkillRowAction[] => {
     const comingSoon = t('workingPanel.skills.actions.comingSoon');
     return [
       {
-        // Remote devices list skills but can't preview them (matches Files tab).
-        disabled: isRemote,
+        // Preview works in every mode: local via IPC, bound device via RPC
+        // (matches the Files tab, which reads remote files over RPC).
         icon: EyeIcon,
         key: 'view',
         label: t('workingPanel.skills.actions.view'),


### PR DESCRIPTION
## Summary

Device-scope skills (listed under **设备技能 / Device skills** in the working-sidebar Skills group, backed by the execution device's home `~/.agents/skills` / `~/.claude/skills`) could not be opened for preview, while **项目技能 / Project skills** worked. Clicking a device skill (or its "view" action / file tree) did nothing or showed a blank panel.

Three gates blocked device-scope previews:

1. **Stale `isRemote` no-op** — `useProjectSkills`' `onOpenSkill`/`onOpenFile` early-returned whenever a device was bound. That guard predated remote preview support; the Files tab has since been upgraded to read/write remote files over the `device.getLocalFilePreview` RPC.
2. **Portal scope filter** — device skills live under the device home, *outside* the topic's project working directory, so `isLocalFileInCurrentScope` (`store/chat/slices/portal/selectors.ts`) filtered the tab out → blank panel.
3. **Desktop preview-protocol containment** — `resolveApprovedPreviewPath` (`LocalFileProtocolManager.ts`) runs a `realpath` approved-root/containment check that rejects home-dir skills, which are commonly **symlinks** (e.g. `~/.claude/skills/foo -> ../../.agents/skills/foo`).

Project skills always worked because their preview root equals the project root, which equals the topic scope directory — passing all three gates.

## Fix

Mirror the already-working Files tab in `src/features/SkillsList/`:

- Drop the `isRemote` early-return; pass `deviceId` to `openLocalFile` so a bound device (remote or this machine) reads the preview over RPC, and an undefined `deviceId` falls back to local Electron IPC.
- Set `allowExternalFilePreview: skill.scope === 'device'`. This single flag clears **both** remaining gates: `isLocalFileInCurrentScope` short-circuits to `true`, and `resolveApprovedPreviewPath` approves the file via `approveExternalPreviewFile` (bypassing the approved-root + symlink containment check).
- Un-gate the "view" row action and the inline-tag resolver's `open` (`useProjectSkillResolver`), which were also disabled whenever a device was bound.

## Testing

- `bun run check` lint clean on both changed files.
- Type-check: no new errors in the touched files (pre-existing repo-wide duplicate-package noise unrelated to this change).
- Manual: open a device-scope skill from the Skills group and confirm the `SKILL.md` / tree files render in the right-hand portal, in both local and bound-device modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)