### PR TITLE
✅ test(memory-user-memory): mock workflow start helper

### DIFF
--- a/src/server/workflows-hono/memory-user-memory/workflows/__tests__/processUserTopics.test.ts
+++ b/src/server/workflows-hono/memory-user-memory/workflows/__tests__/processUserTopics.test.ts
@@ -44,6 +44,7 @@ vi.mock('@/database/server', () => ({ getServerDB: vi.fn() }));
 
 vi.mock('../runGuard', () => ({
   checkGuard: vi.fn().mockResolvedValue({ result: true }),
+  ensureWorkflowStarted: vi.fn().mockResolvedValue({ started: true }),
 }));
 
 const createContext = () => ({


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up to https://github.com/lobehub/lobehub/pull/16775.

#### 🔀 Description of Change

Adds the missing `ensureWorkflowStarted` export to the `../runGuard` mock in `processUserTopics.test.ts`.

`processUserTopicsHandler` now calls the workflow-start helper at entry, so tests that fully mock `../runGuard` must provide the new export.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
pnpm --dir lobehub exec vitest run --silent='passed-only' src/server/workflows-hono/memory-user-memory/workflows/__tests__/processUserTopics.test.ts
pnpm --dir lobehub exec vitest run --silent='passed-only' src/server/workflows-hono/memory-user-memory/workflows/__tests__/runGuard.test.ts src/server/workflows-hono/memory-user-memory/workflows/__tests__/hourly.test.ts src/server/workflows-hono/memory-user-memory/workflows/__tests__/personaUpdate.test.ts src/server/workflows-hono/memory-user-memory/workflows/__tests__/processUserTopics.test.ts
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Test-only change.