### PR TITLE
🧹 chore: remove LOBE-XXX internal marker references from source comments

### DIFF
--- a/apps/server/src/services/task/index.test.ts
+++ b/apps/server/src/services/task/index.test.ts
@@ -557,7 +557,7 @@ describe('TaskService', () => {
       ]);
     });
 
-    it('should build activities sorted by time ascending and exclude briefs (LOBE-11393)', async () => {
+    it('should build activities sorted by time ascending and exclude briefs', async () => {
       const task = {
         assigneeAgentId: null,
         assigneeUserId: null,
@@ -622,7 +622,7 @@ describe('TaskService', () => {
       const service = new TaskService(db, userId);
       const result = await service.getTaskDetail('TASK-1');
 
-      // Brief (Jan 1) is intentionally excluded from the feed (LOBE-11393), even
+      // Brief (Jan 1) is intentionally excluded from the feed, even
       // though one exists for the task; only comment (Jan 2) + topic (Jan 3) remain.
       expect(result?.activities).toHaveLength(2);
       expect(result?.activities?.some((a) => a.type === 'brief')).toBe(false);
@@ -630,7 +630,7 @@ describe('TaskService', () => {
       expect(result?.activities?.[1].type).toBe('topic');
     });
 
-    it('exposes the run last message (handoff.content) alongside the summary (LOBE-11396)', async () => {
+    it('exposes the run last message (handoff.content) alongside the summary', async () => {
       const task = {
         assigneeAgentId: null,
         assigneeUserId: null,

--- a/apps/server/src/services/task/index.ts
+++ b/apps/server/src/services/task/index.ts
@@ -510,7 +510,7 @@ export class TaskService {
       task = { ...task, error: null };
     }
 
-    // Brief hidden (LOBE-11393): the task detail activity feed no longer carries
+    // Brief hidden: the task detail activity feed no longer carries
     // brief-type activities — the UI converges on Task Run. Briefs are therefore
     // not fetched/enriched here (see the omitted brief spread below). The brief
     // lifecycle, model and data are untouched; revert this to bring them back.
@@ -736,7 +736,7 @@ export class TaskService {
         return {
           author: topicAgentId ? authorMap.get(topicAgentId) : undefined,
           completedAt: toISO(t.completedAt),
-          // Raw last assistant message of the run (LOBE-11396), shown alongside
+          // Raw last assistant message of the run, shown alongside
           // the synthesized summary on the run card.
           content: handoff?.content,
           id: t.topicId ?? undefined,
@@ -753,7 +753,7 @@ export class TaskService {
           type: 'topic' as const,
         };
       }),
-      // Brief activities intentionally omitted (LOBE-11393) — see the fetch note above.
+      // Brief activities intentionally omitted — see the fetch note above.
       ...comments.map((c) => {
         const ids = commentFileIdsMap[c.id] ?? [];
         const files = ids.map((id) => fileById.get(id)).filter((f) => !!f);

--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -136,7 +136,7 @@ export class TaskLifecycleService {
         );
       }
 
-      // 2b. Persist the raw last message as the run card's result (LOBE-11396).
+      // 2b. Persist the raw last message as the run card's result.
       //     Done independently of (and after) generateHandoff via a jsonb_set
       //     patch, so `handoff.content` is written even when the summary LLM in
       //     step 2 throws — otherwise a completed run would show no result.

--- a/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
+++ b/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
@@ -93,7 +93,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
       expect(updateStatus).not.toHaveBeenCalledWith('task-1', 'paused', expect.anything());
     });
 
-    it('persists the run last message independently of handoff summary (LOBE-11396)', async () => {
+    it('persists the run last message independently of handoff summary', async () => {
       const task = baseTask({ automationMode: 'heartbeat' });
       findById.mockResolvedValue(task);
       // Model the summary path as a no-op (e.g. its LLM call failed and was

--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -429,7 +429,7 @@ describe('AgentModel', () => {
     it('nulls out a mounted KB / file that the caller can no longer read', async () => {
       // Workspace: A owns a public KB + public file and mounts them onto a
       // public agent. B (another member) sees both mounts in the editor.
-      // After A flips both back to `private` via LOBE-11270, the mount rows
+      // After A flips both back to `private`, the mount rows
       // should stay (so the UI can render an "unavailable" placeholder), but
       // the joined entity fields must be nulled so no name / description
       // leaks and the runtime skips the KB via its `k.id` filter.

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -484,7 +484,7 @@ export class AgentModel {
     //
     // The joined `knowledgeBases` / `files` rows also need a visibility guard
     // in the `leftJoin` ON clause: without it, a KB or file that was later
-    // flipped back to `private` via `setVisibility` (LOBE-11270) would keep
+    // flipped back to `private` via `setVisibility` would keep
     // leaking its name / description into every mounted-agent view across the
     // workspace. Enforcing the guard on the ON clause (rather than WHERE)
     // keeps the mount row in the result but nulls out the referenced entity —

--- a/packages/database/src/models/document.ts
+++ b/packages/database/src/models/document.ts
@@ -291,8 +291,7 @@ export class DocumentModel {
    *
    * Unpublishing is safe by design — after the flip, `buildWorkspaceWhere`
    * hides those rows from other members immediately; already-loaded content in
-   * their client stays until they refresh. See LOBE-11270 for the collect
-   * decision.
+   * their client stays until they refresh.
    */
   setVisibility = async (
     rootId: string,

--- a/packages/database/src/models/knowledgeBase.ts
+++ b/packages/database/src/models/knowledgeBase.ts
@@ -239,7 +239,7 @@ export class KnowledgeBaseModel {
    *
    * Unpublishing is safe by design — this column only gates KB list
    * enumeration; other members lose the sidebar entry immediately, while
-   * downstream RAG paths handle a missing/unreachable KB per LOBE-11270.
+   * downstream RAG paths handle a missing/unreachable KB.
    */
   setVisibility = async (id: string, visibility: 'private' | 'public') => {
     const fromVisibility = visibility === 'public' ? 'private' : 'public';

--- a/packages/database/src/models/taskTopic.ts
+++ b/packages/database/src/models/taskTopic.ts
@@ -148,7 +148,7 @@ export class TaskTopicModel {
   }
 
   /**
-   * Patch the raw run output into `handoff.content` (LOBE-11396) without
+   * Patch the raw run output into `handoff.content` without
    * disturbing other handoff keys. Uses `jsonb_set` so it is order-independent
    * with respect to `updateHandoff` — critically, this lets the caller persist
    * the last message even when the (separate) handoff-summary LLM call fails, so

--- a/packages/database/src/models/topicDocument.ts
+++ b/packages/database/src/models/topicDocument.ts
@@ -65,7 +65,7 @@ export class TopicDocumentModel {
    * visibility guard on the joined `documents` row, a private document
    * previously shared into a workspace-visible topic would leak back to
    * every workspace member after its creator flipped it to `private` via
-   * `setVisibility` (LOBE-11270). Apply `buildWorkspaceWhere` on `documents`
+   * `setVisibility`. Apply `buildWorkspaceWhere` on `documents`
    * so the join drops rows the current viewer can no longer read — they
    * simply disappear from the sidebar list.
    */

--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -112,7 +112,7 @@ export interface TaskTopicHandoff {
    */
   briefDecision?: BriefDecision;
   /**
-   * Raw last assistant message of the run, captured on completion (LOBE-11396).
+   * Raw last assistant message of the run, captured on completion.
    * Shown on the run card alongside the LLM-synthesized `summary` so the feed
    * surfaces the actual run output, not only the summary.
    */

--- a/src/components/Editor/AutoSaveHint.tsx
+++ b/src/components/Editor/AutoSaveHint.tsx
@@ -21,7 +21,7 @@ interface AutoSaveHintProps {
  * AutoSaveHint - Unified save status indicator for editors
  *
  * Displays real-time save status for document/config changes. The `failed`
- * state (LOBE-11078 write-side) renders an error tag with an inline Retry so a
+ * state renders an error tag with an inline Retry so a
  * silent save failure can never masquerade as "Latest version loaded".
  */
 const AutoSaveHint = memo<AutoSaveHintProps>(({ style, saveStatus, lastUpdatedTime, onRetry }) => {

--- a/src/features/AgentTasks/AgentTaskList/KanbanBoard.tsx
+++ b/src/features/AgentTasks/AgentTaskList/KanbanBoard.tsx
@@ -285,7 +285,7 @@ const KanbanBoard = memo<KanbanBoardProps>(({ agentId, routeScope }) => {
   );
 
   // Error gated ahead of empty by AsyncBoundary so a failed fetch shows Retry
-  // instead of the "no tasks" empty (LOBE-11181). `data` is the SWR result —
+  // instead of the "no tasks" empty. `data` is the SWR result —
   // undefined until the first fetch settles.
   return (
     <AsyncBoundary

--- a/src/features/AgentTasks/AgentTaskList/TaskList.tsx
+++ b/src/features/AgentTasks/AgentTaskList/TaskList.tsx
@@ -303,7 +303,7 @@ const TaskList = memo<TaskListProps>((props) => {
     );
 
   // Error is gated ahead of empty by AsyncBoundary, so a failed fetch shows a
-  // Retry block instead of the "no tasks" empty (LOBE-11181). `data` is the
+  // Retry block instead of the "no tasks" empty. `data` is the
   // store-derived settled signal — see the `data` prop doc above.
   return (
     <AsyncBoundary

--- a/src/features/Fleet/RunningTaskSidebar.tsx
+++ b/src/features/Fleet/RunningTaskSidebar.tsx
@@ -284,7 +284,7 @@ const RunningTaskSidebar = memo<RunningTaskSidebarProps>(
         </Button>
         {error && columns.length === 0 ? (
           // A failed poll must read as a failure with Reload, never as the fake
-          // "no running tasks" empty (LOBE-11167).
+          // "no running tasks" empty.
           <AsyncError error={error} variant={'inline'} onRetry={onReload} />
         ) : isLoading && columns.length === 0 ? (
           Array.from({ length: 3 }).map((_, index) => <SidebarTaskSkeleton key={index} />)

--- a/src/features/Fleet/useRunningTopics.ts
+++ b/src/features/Fleet/useRunningTopics.ts
@@ -44,7 +44,7 @@ export const useRunningTopics = () => {
 
   // Only a first-load failure (no data yet) is a hard error worth a failed
   // state; a background poll error while we still hold columns keeps the stale
-  // list instead of flapping to "no running tasks" (LOBE-11167).
+  // list instead of flapping to "no running tasks".
   const hasHardError = Boolean(error) && data === undefined;
 
   const running = useMemo(() => (data ?? []) as RunningTopic[], [data]);

--- a/src/features/Pages/PageLayout/Body/index.tsx
+++ b/src/features/Pages/PageLayout/Body/index.tsx
@@ -53,7 +53,7 @@ const Body = memo(() => {
   // first fetch succeeds, so a failed load surfaces error + Retry instead of a
   // permanent skeleton. The store's `documents` field can't be the signal — it
   // initializes to `[]` (a settled-looking empty), so a failed fetch would fall
-  // through to the "no pages" empty rather than the error (LOBE-11127).
+  // through to the "no pages" empty rather than the error.
   const { data, error, isLoading, isValidating, mutate } = useFetchDocuments();
 
   const filteredDocumentsCount = usePageStore(pageSelectors.filteredDocumentsCount);

--- a/src/features/ResourceUnavailable/index.tsx
+++ b/src/features/ResourceUnavailable/index.tsx
@@ -69,7 +69,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
  *
  * Uniform placeholder rendered wherever a cross-user reference resolves to a
  * resource the current viewer no longer has access to — typically because the
- * creator flipped it back to `private` via `setVisibility` (LOBE-11270). Kept
+ * creator flipped it back to `private` via `setVisibility`. Kept
  * intentionally low-emphasis so message threads don't scream at readers who
  * didn't do anything wrong.
  */

--- a/src/features/ServiceModel/ModelAssignmentsForm.tsx
+++ b/src/features/ServiceModel/ModelAssignmentsForm.tsx
@@ -72,7 +72,6 @@ const ModelAssignmentsForm = memo(() => {
 
   if (!isUserStateInit) {
     // A failed user-state init must show error + Retry, not a permanent skeleton
-    // (LOBE-11118).
     if (isUserStateInitError)
       return (
         <AsyncError

--- a/src/features/VisibilityConfirmContent/index.tsx
+++ b/src/features/VisibilityConfirmContent/index.tsx
@@ -138,7 +138,7 @@ const rowIconClass = (tone: Tone) => {
  * `VisibilityConfirmContent`
  *
  * Shared body for the two mirrored confirm dialogs that guard workspace
- * visibility transitions (LOBE-11270):
+ * visibility transitions:
  * - `makePrivate` — destructive, public → private
  * - `publish` — constructive, private → public (bidirectional counterpart)
  *

--- a/src/hooks/useSaveState.ts
+++ b/src/hooks/useSaveState.ts
@@ -22,7 +22,7 @@ export interface SaveStateHandle {
  * <AutoSaveHint saveStatus={status} lastUpdatedTime={lastSavedAt} onRetry={retry} />
  * ```
  *
- * The whole point (LOBE-11078 write-side): a failed save resolves to `failed`,
+ * The whole point: a failed save resolves to `failed`,
  * never `idle`, so it can't render as a clean "Latest version loaded". Errors
  * are swallowed after being surfaced via `status` so fire-and-forget autosave
  * callers don't produce unhandled rejections; use the store-level `runMutation`

--- a/src/routes/(main)/(create)/features/GenerationWorkspace/Content.tsx
+++ b/src/routes/(main)/(create)/features/GenerationWorkspace/Content.tsx
@@ -36,7 +36,7 @@ const Content = ({
   const isCurrentGenerationTopicLoaded = useStore(selectors.isCurrentGenerationTopicLoaded);
   // Keep `error` / `mutate`: the topic's "loaded" flag is `Array.isArray(map[topicId])`,
   // written only on success, so a failed batch fetch would otherwise stick on the
-  // skeleton forever with no retry (LOBE-11208).
+  // skeleton forever with no retry.
   const { error, mutate } = useFetchGenerationBatches(activeTopicId);
   const currentBatches = useStore(selectors.currentGenerationBatches);
   const hasGenerations = currentBatches && currentBatches.length > 0;

--- a/src/routes/(main)/community/(detail)/workspace/index.tsx
+++ b/src/routes/(main)/community/(detail)/workspace/index.tsx
@@ -155,7 +155,7 @@ const WorkspaceDetailPage = memo<WorkspaceDetailPageProps>(({ mobile }) => {
   if (!contextConfig) {
     // A transient profile fetch failure must not masquerade as "workspace not
     // found" — offer Reload. Only a resolved-empty profile is a real 404
-    // (LOBE-11223). `fallbackProfile` would have yielded a contextConfig, so
+    // `fallbackProfile` would have yielded a contextConfig, so
     // reaching here with an error means we have nothing to show.
     if (userProfileError)
       return (

--- a/src/routes/(main)/community/(list)/(home)/index.tsx
+++ b/src/routes/(main)/community/(list)/(home)/index.tsx
@@ -42,7 +42,7 @@ const HomePage = memo(() => {
 
   // Gate each section independently so a failure in one featured list surfaces a
   // Retry there instead of leaving the whole page on a permanent skeleton
-  // (LOBE-11223).
+  //
   return (
     <>
       <CreatorRewardBanner />

--- a/src/routes/(main)/home/features/AgentSelect/AgentList.tsx
+++ b/src/routes/(main)/home/features/AgentSelect/AgentList.tsx
@@ -92,7 +92,7 @@ const AgentList = memo<AgentListProps>(({ activeAgentId, error, onRetry, onSelec
   }, [inboxAgentId, inboxMeta, allAgents, t]);
 
   // Error gated ahead of the skeleton so a failed list fetch shows Retry instead
-  // of a permanent skeleton (`isAgentListInit` only flips on success — LOBE-11079).
+  // of a permanent skeleton (`isAgentListInit` only flips on success).
   return (
     <AsyncBoundary
       data={isInit ? allAgents : undefined}

--- a/src/routes/(main)/home/features/AgentSelect/index.tsx
+++ b/src/routes/(main)/home/features/AgentSelect/index.tsx
@@ -41,7 +41,7 @@ const AgentSelect = memo(() => {
 
   // Trigger fetching the home agent list so the popover content is ready when
   // opened. Keep `error` / `mutate` so a failed list fetch shows a Retry state
-  // in the popover instead of a permanent skeleton (LOBE-11079).
+  // in the popover instead of a permanent skeleton.
   const { error: agentListError, mutate: refetchAgentList } = useFetchAgentList();
 
   const isLoading = useAgentStore(agentSelectors.isAgentConfigLoading);

--- a/src/routes/(main)/home/features/Recents/List.tsx
+++ b/src/routes/(main)/home/features/Recents/List.tsx
@@ -46,7 +46,7 @@ const RecentsList = memo<RecentsListProps>(({ error, onRetry }) => {
 
   // Error gated ahead of the skeleton so a failed recents fetch shows Retry
   // instead of a permanent skeleton (`isRecentsInit` only flips on success —
-  // LOBE-11079).
+  //
   return (
     <AsyncBoundary
       data={isInit ? recents : undefined}

--- a/src/routes/(main)/home/features/Recents/index.tsx
+++ b/src/routes/(main)/home/features/Recents/index.tsx
@@ -45,7 +45,7 @@ const Recents = memo<RecentsProps>(({ itemKey }) => {
   const isInit = useHomeStore(homeRecentSelectors.isRecentsInit);
   const isLogin = useUserStore(authSelectors.isLogin);
   // Keep `error` / `mutate` so a failed recents fetch surfaces a Retry state
-  // instead of a permanent skeleton (LOBE-11079).
+  // instead of a permanent skeleton.
   const { error, isRevalidating, mutate } = useInitRecents();
 
   const activeWorkspaceId = useActiveWorkspaceId();

--- a/src/routes/(main)/settings/advanced/index.tsx
+++ b/src/routes/(main)/settings/advanced/index.tsx
@@ -97,7 +97,7 @@ const Page = memo(() => {
 
   if (!isUserStateInit) {
     // A failed user-state init must show error + Retry, not a permanent skeleton
-    // (LOBE-11139).
+    //
     if (isUserStateInitError)
       return (
         <AsyncError

--- a/src/routes/(main)/settings/provider/(list)/ProviderGrid/index.tsx
+++ b/src/routes/(main)/settings/provider/(list)/ProviderGrid/index.tsx
@@ -30,7 +30,7 @@ const List = memo((props: ListProps) => {
   const [initAiProviderList] = useAiInfraStore((s) => [s.initAiProviderList]);
   // Own the same list fetch (SWR-deduped with ProviderMenu) so a failed load
   // shows error + Retry here too, instead of a permanent skeleton grid
-  // (`initAiProviderList` only flips on success — LOBE-11117).
+  // (`initAiProviderList` only flips on success).
   const useFetchAiProviderList = useAiInfraStore((s) => s.useFetchAiProviderList);
   const { error, mutate } = useFetchAiProviderList();
 

--- a/src/routes/(main)/settings/provider/ProviderMenu/index.tsx
+++ b/src/routes/(main)/settings/provider/ProviderMenu/index.tsx
@@ -96,7 +96,7 @@ const ProviderMenu = ({
 
   // Own the provider-list fetch here so a failed load surfaces error + Retry
   // instead of a permanent skeleton — `initAiProviderList` only flips on success
-  // (LOBE-11117).
+  //
   const { error, mutate } = useFetchAiProviderList();
 
   // Search overrides everything (matches prior behavior); otherwise gate the

--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -125,7 +125,7 @@ const SkillList = memo<SkillListProps>(
     useFetchInstalledPlugins();
     // Keep each SWR handle so a failed skill fetch surfaces error + Retry instead
     // of a fake-empty list (each hook syncs into the store only on success —
-    // LOBE-11124).
+    //
     const lobehubSkillsSWR = useFetchLobehubSkillConnections(isLobehubSkillEnabled);
     const composioSWR = useFetchUserComposioConnections(isComposioEnabled);
     const agentSkillsSWR = useFetchAgentSkills(true);
@@ -342,7 +342,7 @@ const SkillList = memo<SkillListProps>(
       customMCPs.length > 0;
 
     // A failed fetch must read as a failure with Retry, never as the "no skills"
-    // empty (error gated ahead of empty — LOBE-11124).
+    // empty (error gated ahead of empty).
     if (skillsError && !hasAnySkills) {
       return (
         <Center className={styles.container} paddingBlock={48}>

--- a/src/routes/onboarding/features/ResponseLanguageStep.tsx
+++ b/src/routes/onboarding/features/ResponseLanguageStep.tsx
@@ -45,7 +45,7 @@ const ResponseLanguageStep = memo<ResponseLanguageStepProps>(({ onBack, onNext }
       // (`commonStepsCompleted` keys off `responseLanguage`), so it must be able
       // to fail: on error reset the navigating lock so the user can retry
       // instead of being stuck with both buttons permanently disabled
-      // (LOBE-11154).
+      //
       await setSettings({ general: { responseLanguage: value } });
       await onNext();
     } catch {

--- a/src/store/user/slices/common/action.ts
+++ b/src/store/user/slices/common/action.ts
@@ -108,7 +108,7 @@ export class CommonActionImpl {
       {
         onError: (error) => {
           // Record the init failure so gated tabs (Advanced / ServiceModel) can
-          // render error + Retry instead of a permanent skeleton (LOBE-11118/11139).
+          // render error + Retry instead of a permanent skeleton.
           this.#set({ isUserStateInitError: error }, false, n('initUserState/error'));
           options?.onError?.(error);
         },

--- a/src/store/utils/runMutation.ts
+++ b/src/store/utils/runMutation.ts
@@ -36,7 +36,7 @@ export interface RunMutationConfig<TStore extends object, T> {
  * counterpart to the read-side `AsyncBoundary`. It wraps the recurring
  * saving → optimistic → mutate → (saved | rollback + failed + toast) dance so no
  * action can forget the failure branch, which is the exact bug (`catch → 'idle'`,
- * a lost edit rendering as a clean state) the LOBE-11078 audit found duplicated
+ * a lost edit rendering as a clean state) the UX audit found duplicated
  * across the write surfaces.
  *
  * Kept deliberately lightweight vs. the queued `OptimisticEngine` — no cross-action


### PR DESCRIPTION
## Summary

This PR removes all remaining LOBE-XXX internal marker references from source code comments across the codebase.

## What changed

- Removed 32 (LOBE-XXXXX) parenthetical references from source comments
- Preserved the descriptive intent of every comment — only the issue-number markers were removed
- No logic or behavior changes

## Files changed

35 files across src/, packages/, and apps/:
- src/components/, src/features/, src/hooks/, src/routes/, src/store/
- packages/database/src/models/, packages/types/src/
- apps/server/src/services/

## Rationale

As an open-source project, internal Linear issue references (LOBE-XXX) should not persist in the public source. The descriptive comments already capture the *why*, so removing the numeric markers preserves readability without leaking internal tracking references.

Auto-generated at 2026-07-06 10:13:29