### PR TITLE
✨ feat(mobile-router): expose composio router

### DIFF
--- a/apps/server/src/routers/mobile/index.ts
+++ b/apps/server/src/routers/mobile/index.ts
@@ -13,6 +13,7 @@ import { aiModelRouter } from '../lambda/aiModel';
 import { aiProviderRouter } from '../lambda/aiProvider';
 import { briefRouter } from '../lambda/brief';
 import { chunkRouter } from '../lambda/chunk';
+import { composioRouter } from '../lambda/composio';
 import { configRouter } from '../lambda/config';
 import { deviceRouter } from '../lambda/device';
 import { documentRouter } from '../lambda/document';
@@ -40,6 +41,7 @@ export const mobileRouter = router({
   aiModel: aiModelRouter,
   aiProvider: aiProviderRouter,
   chunk: chunkRouter,
+  composio: composioRouter,
   config: configRouter,
   device: deviceRouter,
   document: documentRouter,


### PR DESCRIPTION
## Summary
- expose the existing Composio lambda router through the mobile tRPC router
- allow mobile clients to call composio create/status/update/delete procedures via /trpc/mobile

## Verification
- git diff --check

Note: local prettier/pre-commit could not run because this submodule checkout does not have lint-staged/prettier installed.