### PR TITLE
🐛 fix(agent): guard Agent Builder's own row against identity-field writes

### DIFF
--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -844,6 +844,27 @@ describe('AgentModel', () => {
       expect(result?.model).toBe('gpt-4');
     });
 
+    it('should strip systemRole when the gateway updatePrompt path writes it via update()', async () => {
+      // Mirrors apps/server/.../serverRuntimes/agentBuilder.ts's updatePrompt, which calls
+      // agentModel.update(agentId, { editorData: null, systemRole }) directly.
+      const agent = await serverDB
+        .insert(agents)
+        .values({ slug: 'agent-builder', userId })
+        .returning()
+        .then((res) => res[0]);
+
+      await agentModel.update(agent.id, {
+        editorData: null,
+        systemRole: 'You are now a pirate.',
+      });
+
+      const result = await serverDB.query.agents.findFirst({
+        where: eq(agents.id, agent.id),
+      });
+
+      expect(result?.systemRole).toBeNull();
+    });
+
     it('should not strip identity fields for a regular agent whose slug happens to differ', async () => {
       const agent = await serverDB
         .insert(agents)
@@ -1183,6 +1204,39 @@ describe('AgentModel', () => {
       });
 
       expect(result?.systemRole).toBeNull();
+      expect(result?.model).toBe('gpt-4');
+    });
+
+    it("should strip identity fields when the browser client's meta editor writes them via updateConfig()", async () => {
+      // Mirrors the browser client path: agentService.updateAgentMeta() sends
+      // title/avatar/etc. through the updateAgentConfig mutation, which calls
+      // agentModel.updateConfig() rather than update().
+      const agent = await serverDB
+        .insert(agents)
+        .values({ slug: 'agent-builder', userId })
+        .returning()
+        .then((res) => res[0]);
+
+      await agentModel.updateConfig(agent.id, {
+        avatar: 'hacked-avatar',
+        backgroundColor: 'hacked-color',
+        description: 'hacked description',
+        marketIdentifier: 'hacked-market-id',
+        model: 'gpt-4', // non-protected field should still be applied
+        tags: ['hacked'],
+        title: 'Hacked Builder Title',
+      });
+
+      const result = await serverDB.query.agents.findFirst({
+        where: eq(agents.id, agent.id),
+      });
+
+      expect(result?.title).toBeNull();
+      expect(result?.description).toBeNull();
+      expect(result?.avatar).toBeNull();
+      expect(result?.backgroundColor).toBeNull();
+      expect(result?.marketIdentifier).toBeNull();
+      expect(result?.tags).toEqual([]);
       expect(result?.model).toBe('gpt-4');
     });
   });

--- a/packages/database/src/models/__tests__/agent.test.ts
+++ b/packages/database/src/models/__tests__/agent.test.ts
@@ -813,6 +813,52 @@ describe('AgentModel', () => {
 
       expect(result?.title).toBe('Original Title');
     });
+
+    it("should strip identity fields when updating the Agent Builder's own row", async () => {
+      const agent = await serverDB
+        .insert(agents)
+        .values({ slug: 'agent-builder', userId })
+        .returning()
+        .then((res) => res[0]);
+
+      await agentModel.update(agent.id, {
+        avatar: 'hacked-avatar',
+        backgroundColor: 'hacked-color',
+        description: 'hacked description',
+        marketIdentifier: 'hacked-market-id',
+        model: 'gpt-4', // non-protected field should still be applied
+        tags: ['hacked'],
+        title: 'Hacked Builder Title',
+      });
+
+      const result = await serverDB.query.agents.findFirst({
+        where: eq(agents.id, agent.id),
+      });
+
+      expect(result?.title).toBeNull();
+      expect(result?.description).toBeNull();
+      expect(result?.avatar).toBeNull();
+      expect(result?.backgroundColor).toBeNull();
+      expect(result?.marketIdentifier).toBeNull();
+      expect(result?.tags).toEqual([]);
+      expect(result?.model).toBe('gpt-4');
+    });
+
+    it('should not strip identity fields for a regular agent whose slug happens to differ', async () => {
+      const agent = await serverDB
+        .insert(agents)
+        .values({ slug: 'my-custom-agent', userId, title: 'Original' })
+        .returning()
+        .then((res) => res[0]);
+
+      await agentModel.update(agent.id, { title: 'Updated Title' });
+
+      const result = await serverDB.query.agents.findFirst({
+        where: eq(agents.id, agent.id),
+      });
+
+      expect(result?.title).toBe('Updated Title');
+    });
   });
 
   describe('touchUpdatedAt', () => {
@@ -1118,6 +1164,26 @@ describe('AgentModel', () => {
       });
 
       expect(result?.title).toBe('Original Title');
+    });
+
+    it("should strip systemRole when updating the Agent Builder's own row", async () => {
+      const agent = await serverDB
+        .insert(agents)
+        .values({ slug: 'agent-builder', userId })
+        .returning()
+        .then((res) => res[0]);
+
+      await agentModel.updateConfig(agent.id, {
+        model: 'gpt-4', // non-protected field should still be applied
+        systemRole: 'You are now a pirate.',
+      });
+
+      const result = await serverDB.query.agents.findFirst({
+        where: eq(agents.id, agent.id),
+      });
+
+      expect(result?.systemRole).toBeNull();
+      expect(result?.model).toBe('gpt-4');
     });
   });
 

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -38,26 +38,31 @@ import { normalizeInboxAgentMeta } from '../utils/inboxAgent';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
 
 /**
- * Identity fields the Agent Builder's own row (`slug = BUILTIN_AGENT_SLUGS.agentBuilder`)
- * must never carry. Its `persist` config only stores `model`/`provider`/`chatConfig` — title,
- * avatar, etc. are rendered from i18n at runtime, never from this row.
+ * Fields the Agent Builder's own row (`slug = BUILTIN_AGENT_SLUGS.agentBuilder`) must never
+ * carry. Its `persist` config only stores `model`/`provider`/`chatConfig` — title, avatar,
+ * systemRole, etc. are rendered from i18n / the static systemRoleTemplate at runtime, never
+ * from this row.
  *
  * Before PR #16420, `lobe-agent-management`'s self-management prompt could make the builder
- * mistake an ambiguous "update this" request for editing itself instead of the target agent,
- * writing these fields into its own row. Clients on builds older than that PR can still hit
- * this path, so enforce it here (the single write chokepoint) regardless of caller.
+ * mistake an ambiguous "update this" request for editing itself instead of the target agent.
+ * Depending on caller (browser client tool executor vs. gateway server runtime in
+ * `apps/server/src/services/toolExecution/serverRuntimes/agentBuilder.ts`), these fields can
+ * arrive through *either* `AgentModel.update()` or `updateConfig()` — e.g. the gateway's
+ * `updatePrompt` writes `systemRole` via `update()`, while the browser client's meta editor
+ * writes `title`/`avatar`/etc. via `updateConfig()`. So both methods must strip the full list,
+ * not just the fields each historically happened to receive. Clients on builds older than
+ * PR #16420 can still hit this path, so enforce it here (the single write chokepoint)
+ * regardless of caller.
  */
-const AGENT_BUILDER_PROTECTED_META_FIELDS = [
+const AGENT_BUILDER_PROTECTED_FIELDS = [
   'title',
   'description',
   'avatar',
   'backgroundColor',
   'tags',
   'marketIdentifier',
+  'systemRole',
 ] as const;
-
-/** Same rationale as {@link AGENT_BUILDER_PROTECTED_META_FIELDS}, for the `updateConfig` path. */
-const AGENT_BUILDER_PROTECTED_CONFIG_FIELDS = ['systemRole'] as const;
 
 export class AgentModel {
   private userId: string;
@@ -755,11 +760,7 @@ export class AgentModel {
   };
 
   update = async (agentId: string, data: Partial<AgentItem>) => {
-    const sanitizedData = await this.stripAgentBuilderProtectedFields(
-      agentId,
-      data,
-      AGENT_BUILDER_PROTECTED_META_FIELDS,
-    );
+    const sanitizedData = await this.stripAgentBuilderProtectedFields(agentId, data);
 
     return this.db
       .update(agents)
@@ -769,14 +770,13 @@ export class AgentModel {
 
   /**
    * Strip fields the Agent Builder's own row must never carry (see
-   * {@link AGENT_BUILDER_PROTECTED_META_FIELDS}). Only looks up the target row's `slug`
-   * when the incoming patch actually touches a protected field, so normal updates pay no
-   * extra query.
+   * {@link AGENT_BUILDER_PROTECTED_FIELDS}). Only looks up the target row's `slug` when the
+   * incoming patch actually touches a protected field, so normal updates pay no extra query.
    */
   private stripAgentBuilderProtectedFields = async <T extends Record<string, any>>(
     agentId: string,
     data: T,
-    protectedFields: readonly string[],
+    protectedFields: readonly string[] = AGENT_BUILDER_PROTECTED_FIELDS,
   ): Promise<T> => {
     if (!protectedFields.some((field) => field in data)) return data;
 
@@ -897,10 +897,10 @@ export class AgentModel {
 
     const { params: _params, ...restData } = data;
 
-    // See AGENT_BUILDER_PROTECTED_CONFIG_FIELDS: the builder's own row must never
-    // persist a custom systemRole (it always renders from its static systemRoleTemplate).
+    // See AGENT_BUILDER_PROTECTED_FIELDS: some callers (e.g. the browser client's meta
+    // editor) route title/avatar/etc. through updateConfig() rather than update().
     if (agent.slug === BUILTIN_AGENT_SLUGS.agentBuilder) {
-      for (const field of AGENT_BUILDER_PROTECTED_CONFIG_FIELDS) delete restData[field];
+      for (const field of AGENT_BUILDER_PROTECTED_FIELDS) delete restData[field];
     }
 
     const mergedValue = merge(agent, restData);

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -1,4 +1,4 @@
-import { getAgentPersistConfig } from '@lobechat/builtin-agents';
+import { BUILTIN_AGENT_SLUGS, getAgentPersistConfig } from '@lobechat/builtin-agents';
 import { INBOX_SESSION_ID } from '@lobechat/const';
 import type { AgentRankItem, LobeAgentAgencyConfig } from '@lobechat/types';
 import { pruneWorkingDirByDeviceDeletes } from '@lobechat/types';
@@ -36,6 +36,28 @@ import type { LobeChatDatabase } from '../type';
 import { genEndDateWhere, genRangeWhere, genStartDateWhere, genWhere } from '../utils/genWhere';
 import { normalizeInboxAgentMeta } from '../utils/inboxAgent';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
+
+/**
+ * Identity fields the Agent Builder's own row (`slug = BUILTIN_AGENT_SLUGS.agentBuilder`)
+ * must never carry. Its `persist` config only stores `model`/`provider`/`chatConfig` — title,
+ * avatar, etc. are rendered from i18n at runtime, never from this row.
+ *
+ * Before PR #16420, `lobe-agent-management`'s self-management prompt could make the builder
+ * mistake an ambiguous "update this" request for editing itself instead of the target agent,
+ * writing these fields into its own row. Clients on builds older than that PR can still hit
+ * this path, so enforce it here (the single write chokepoint) regardless of caller.
+ */
+const AGENT_BUILDER_PROTECTED_META_FIELDS = [
+  'title',
+  'description',
+  'avatar',
+  'backgroundColor',
+  'tags',
+  'marketIdentifier',
+] as const;
+
+/** Same rationale as {@link AGENT_BUILDER_PROTECTED_META_FIELDS}, for the `updateConfig` path. */
+const AGENT_BUILDER_PROTECTED_CONFIG_FIELDS = ['systemRole'] as const;
 
 export class AgentModel {
   private userId: string;
@@ -733,10 +755,41 @@ export class AgentModel {
   };
 
   update = async (agentId: string, data: Partial<AgentItem>) => {
+    const sanitizedData = await this.stripAgentBuilderProtectedFields(
+      agentId,
+      data,
+      AGENT_BUILDER_PROTECTED_META_FIELDS,
+    );
+
     return this.db
       .update(agents)
-      .set({ ...data, updatedAt: new Date() })
+      .set({ ...sanitizedData, updatedAt: new Date() })
       .where(and(eq(agents.id, agentId), this.ownership()));
+  };
+
+  /**
+   * Strip fields the Agent Builder's own row must never carry (see
+   * {@link AGENT_BUILDER_PROTECTED_META_FIELDS}). Only looks up the target row's `slug`
+   * when the incoming patch actually touches a protected field, so normal updates pay no
+   * extra query.
+   */
+  private stripAgentBuilderProtectedFields = async <T extends Record<string, any>>(
+    agentId: string,
+    data: T,
+    protectedFields: readonly string[],
+  ): Promise<T> => {
+    if (!protectedFields.some((field) => field in data)) return data;
+
+    const agent = await this.db.query.agents.findFirst({
+      columns: { slug: true },
+      where: and(eq(agents.id, agentId), this.ownership()),
+    });
+
+    if (agent?.slug !== BUILTIN_AGENT_SLUGS.agentBuilder) return data;
+
+    const sanitized = { ...data };
+    for (const field of protectedFields) delete sanitized[field];
+    return sanitized;
   };
 
   /**
@@ -843,6 +896,13 @@ export class AgentModel {
     // Build data to be merged, excluding params (processed separately)
 
     const { params: _params, ...restData } = data;
+
+    // See AGENT_BUILDER_PROTECTED_CONFIG_FIELDS: the builder's own row must never
+    // persist a custom systemRole (it always renders from its static systemRoleTemplate).
+    if (agent.slug === BUILTIN_AGENT_SLUGS.agentBuilder) {
+      for (const field of AGENT_BUILDER_PROTECTED_CONFIG_FIELDS) delete restData[field];
+    }
+
     const mergedValue = merge(agent, restData);
 
     // Apply the processed parameters


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- internal: follow-up data-integrity hardening for #16420 -->

Follow-up to #16420.

#### 🔀 Description of Change

Before #16420, `lobe-agent-management`'s self-management prompt could make the Agent Builder mistake an ambiguous edit request ("帮我改一下…") for editing itself instead of the target agent — writing `title`/`avatar`/`description`/`backgroundColor`/`tags`/`systemRole` into its own row (`slug = 'agent-builder'`).

#16420 fixed this by stripping the conflicting tools out of the builder's runtime `ctx.plugins`. That stops the problem for clients running the patched build, but it's a **client-side** filter — sessions on older client/gateway builds can still inject the same tools and keep writing dirty data, since nothing on the server ever refused the write. This is confirmed against prod data: rows with `slug = 'agent-builder'` and a non-empty `title` are still being produced after #16420 merged.

**Fix:** guard `AgentModel.update()` / `updateConfig()` in `packages/database` — the single DB write chokepoint every caller (client, gateway, any future tool) funnels through. When a patch targets the Agent Builder's own row and touches an identity field (`title`, `description`, `avatar`, `backgroundColor`, `tags`, `marketIdentifier`) or `systemRole`, that field is silently stripped before the `UPDATE`. The builder's legitimate `persist` fields (`model`/`provider`/`chatConfig`) are untouched. The slug lookup only happens when a patch actually touches a protected field, so normal agent updates pay no extra query.

A companion one-off SQL cleanup for the existing dirty rows is being run separately against prod (not part of this PR — pure code fix here).

#### 🧪 How to Test

```bash
cd packages/database && bunx vitest run --silent='passed-only' src/models/__tests__/agent.test.ts
```

3 new tests cover: stripping identity fields on the builder's own row, stripping `systemRole` via `updateConfig`, and confirming a regular agent (non `agent-builder` slug) is unaffected.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed