### PR TITLE
🐛 fix(lobe-agent): guard todo defaultItems against non-array tool-call args

### DIFF
--- a/packages/builtin-tool-lobe-agent/src/client/Intervention/AddTodo.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/Intervention/AddTodo.tsx
@@ -16,14 +16,18 @@ const AddTodoIntervention = memo<BuiltinInterventionProps<CreateTodosParams>>(
     // Handle both formats:
     // - Initial AI input: { adds: string[] } (from AI)
     // - After user edit: { items: TodoItem[] } (saved format)
-    const defaultItems: TodoItem[] =
-      args?.items || args?.adds?.map((text) => ({ status: 'todo', text })) || [];
+    // `args` originates from model tool-call output (and may be a partial parse
+    // while streaming), so guard on Array.isArray rather than truthiness — a
+    // truthy non-array value would otherwise flow through and crash `.map`.
+    const defaultItems: TodoItem[] = Array.isArray(args?.items)
+      ? args.items
+      : Array.isArray(args?.adds)
+        ? args.adds.map((text) => ({ status: 'todo', text }))
+        : [];
 
     const handleSave = useCallback(
       async (items: TodoItem[]) => {
-        console.info('[AddTodoIntervention] handleSave called with', items.length, 'items');
         await onArgsChange?.({ items });
-        console.info('[AddTodoIntervention] onArgsChange completed');
       },
       [onArgsChange],
     );

--- a/packages/builtin-tool-lobe-agent/src/client/components/SortableTodoList/index.tsx
+++ b/packages/builtin-tool-lobe-agent/src/client/components/SortableTodoList/index.tsx
@@ -42,9 +42,7 @@ const SortableTodoList = memo<SortableTodoListProps>(
     useEffect(() => {
       if (registerBeforeApprove) {
         const unregister = registerBeforeApprove('sortable-todo-list', async () => {
-          console.info('trigger save');
           await store.getState().saveNow();
-          console.info('trigger save successful');
         });
         // Cleanup: unregister on unmount
         return unregister;

--- a/packages/builtin-tool-lobe-agent/src/client/components/SortableTodoList/store/actions.ts
+++ b/packages/builtin-tool-lobe-agent/src/client/components/SortableTodoList/store/actions.ts
@@ -27,11 +27,9 @@ export const createActions = (
 ): TodoListStore => {
   // Save implementation (used by both debounced and immediate save)
   const performSave = async () => {
-    console.info('[performSave] called, onSave:', !!internals.onSave);
     if (!internals.onSave) return;
 
     const { items, isDirty } = get();
-    console.info('[performSave] isDirty:', isDirty, 'items:', items.length);
     if (!isDirty) return;
 
     set({ saveStatus: 'saving' });
@@ -39,9 +37,7 @@ export const createActions = (
     try {
       // Convert TodoListItem[] to TodoItem[] (remove id)
       const todoItems: TodoItem[] = items.map(({ status, text }) => ({ status, text }));
-      console.info('[performSave] calling onSave with', todoItems.length, 'items');
       await internals.onSave(todoItems);
-      console.info('[performSave] onSave completed');
       set({ isDirty: false, saveStatus: 'saved' });
 
       // Match saveNow: ease the indicator back to `idle` so the UI doesn't
@@ -68,7 +64,13 @@ export const createActions = (
 
   return {
     ...initialState,
-    items: defaultItems.map((item) => ({ ...item, id: generateId() })),
+    // Defensive: `defaultItems` ultimately derives from untrusted model tool-call
+    // args, so fall back to an empty list rather than throwing during store init
+    // (which would crash the whole Conversation render tree).
+    items: (Array.isArray(defaultItems) ? defaultItems : []).map((item) => ({
+      ...item,
+      id: generateId(),
+    })),
 
     addItem: () => {
       const { items, newItemText } = get();
@@ -104,9 +106,7 @@ export const createActions = (
 
       try {
         const todoItems: TodoItem[] = items.map(({ status, text }) => ({ status, text }));
-        console.info('[saveNow] force saving', todoItems.length, 'items');
         await internals.onSave(todoItems);
-        console.info('[saveNow] save completed');
         set({ isDirty: false, saveStatus: 'saved' });
 
         setTimeout(() => {

--- a/packages/builtin-tool-lobe-agent/src/client/components/SortableTodoList/store/store.test.ts
+++ b/packages/builtin-tool-lobe-agent/src/client/components/SortableTodoList/store/store.test.ts
@@ -49,6 +49,15 @@ describe('TodoListStore', () => {
 
       expect(state.items[0].id).not.toBe(state.items[1].id);
     });
+
+    it('should fall back to empty items when defaultItems is not an array', () => {
+      // `defaultItems` ultimately derives from untrusted model tool-call args
+      // (and may be a partial parse while streaming), so a non-array value must
+      // not crash store init.
+      const store = createTodoListStore({ foo: 'bar' } as unknown as TodoItem[]);
+
+      expect(store.getState().items).toEqual([]);
+    });
   });
 
   describe('addItem', () => {


### PR DESCRIPTION
## 💻 Changes

Fixes a session-crashing `TypeError: defaultItems.map is not a function`.

### Root cause

`SortableTodoList` builds `defaultItems` from AI tool-call output (`CreateTodosParams`), which is untrusted at runtime and may be a **truthy non-array** value — malformed model output, or a partial parse while the tool args are still streaming. In `AddTodoIntervention`:

```ts
const defaultItems = args?.items || args?.adds?.map(...) || [];
```

The `||` chain only checks truthiness, so a non-array `args.items` bypassed the `[]` fallback and flowed straight into the store. `createActions` then threw at `defaultItems.map(...)` during `createStore` init — which runs in render — collapsing the entire Conversation render tree.

### Fix

- Guard on `Array.isArray` in `AddTodoIntervention` for both `items` and `adds`.
- Add a defensive `Array.isArray` fallback in the store's `createActions` so no caller can crash store init.
- Remove leftover debug `console.info` logs.
- Add a regression test covering the non-array `defaultItems` case.

## 🧪 Testing

- `store.test.ts` — 36 tests pass (incl. new non-array regression case).
- Lint clean (one pre-existing `exhaustive-deps` warning on the intentional create-once `useMemo`, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)