### PR TITLE
✨ feat(topic): make the linked PR in the meta hover card clickable

### DIFF
--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.tsx
@@ -84,6 +84,21 @@ const styles = createStaticStyles(({ css }) => ({
     line-height: 18px;
     white-space: normal;
   `,
+  prLink: css`
+    cursor: pointer;
+
+    margin-inline: -6px;
+    padding-block: 2px;
+    padding-inline: 6px;
+    border-radius: 6px;
+
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
 }));
 
 interface CiVisual {
@@ -188,8 +203,8 @@ const MetaHoverCard = memo<MetaHoverCardProps>(({ metadata, title, time }) => {
         (() => {
           const prState = getPullRequestState(pullRequest);
           const prVisual = PR_STATE_VISUAL[prState];
-          return (
-            <div className={styles.row}>
+          const prInner = (
+            <>
               <Icon
                 className={styles.rowIcon}
                 icon={prVisual.icon}
@@ -203,7 +218,21 @@ const MetaHoverCard = memo<MetaHoverCardProps>(({ metadata, title, time }) => {
                 {pullRequest.title ? ` · ${pullRequest.title}` : ''}
                 <span style={{ color: cssVar.colorTextTertiary }}>{` #${pullRequest.number}`}</span>
               </span>
-            </div>
+            </>
+          );
+          // Clickable when a url is persisted — opens the PR on GitHub in the
+          // system browser; older snapshots without a url stay a plain row.
+          return pullRequest.url ? (
+            <a
+              className={`${styles.row} ${styles.prLink}`}
+              href={pullRequest.url}
+              rel={'noreferrer'}
+              target={'_blank'}
+            >
+              {prInner}
+            </a>
+          ) : (
+            <div className={styles.row}>{prInner}</div>
           );
         })()}
 


### PR DESCRIPTION
## 💡 Description

The topic meta hover card (agent sidebar) surfaces the linked PR as **state · title · #number**, but the row was static — you couldn't click through to it.

This wires the existing `DeviceGitLinkedPullRequest.url` (already carried in the metadata, just unused by the card) onto the PR row so clicking opens the PR on GitHub in the system browser, using the same `target="_blank" rel="noreferrer"` idiom the rest of the app uses. A subtle hover background signals it's interactive. Rows from older snapshots without a persisted `url` fall back to a plain, non-interactive row.

No new data, no i18n, no migration — purely wiring an existing field into a link.

## 🔗 Related

N/A

## 📝 Change Type

- [x] ✨ feat: New feature

## ✅ How to Test

- Hover a topic row whose session has a linked PR → the PR row now shows a hover highlight and is clickable → opens the PR on GitHub.
- A topic whose snapshot predates the `url` field → the PR row still renders, just not clickable (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)