### PR TITLE
✨ feat(hetero): auto-detect `git worktree add` and flip topic into the worktree

### DIFF
--- a/src/store/chat/slices/agentRun/actions/transports/hetero/__tests__/worktreeDetection.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/__tests__/worktreeDetection.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { applyWorktreeAddToTopic, parseWorktreeAddPath } from '../worktreeDetection';
+
+const topicMocks = vi.hoisted(() => ({ getTopicById: vi.fn() }));
+
+vi.mock('@/store/chat/selectors', () => ({
+  topicSelectors: {
+    getTopicById: (id: string) => (state: unknown) => topicMocks.getTopicById(id, state),
+  },
+}));
+
+describe('parseWorktreeAddPath', () => {
+  it('resolves a relative path against the source cwd', () => {
+    expect(parseWorktreeAddPath('git worktree add ../wt', '/repo')).toBe('/wt');
+    expect(parseWorktreeAddPath('git worktree add wt', '/repo')).toBe('/repo/wt');
+  });
+
+  it('keeps an absolute path as-is', () => {
+    expect(parseWorktreeAddPath('git worktree add /tmp/wt', '/repo')).toBe('/tmp/wt');
+  });
+
+  it('skips flags and their values', () => {
+    expect(parseWorktreeAddPath('git worktree add -b feature ../feat', '/repo')).toBe('/feat');
+    expect(parseWorktreeAddPath('git worktree add --detach /tmp/wt', '/repo')).toBe('/tmp/wt');
+    expect(parseWorktreeAddPath('git worktree add -f --lock /tmp/wt', '/repo')).toBe('/tmp/wt');
+  });
+
+  it('parses a JSON `arguments` blob (CC Bash tool shape)', () => {
+    expect(parseWorktreeAddPath('{"command":"git worktree add ../wt"}', '/repo')).toBe('/wt');
+  });
+
+  it('handles a quoted path with spaces', () => {
+    expect(parseWorktreeAddPath('git worktree add "../my wt"', '/repo')).toBe('/my wt');
+  });
+
+  it('stops at a shell separator (does not slurp the chained command)', () => {
+    expect(parseWorktreeAddPath('cd /repo && git worktree add wt && cd wt', '/repo')).toBe(
+      '/repo/wt',
+    );
+  });
+
+  it('returns undefined for non-worktree-add commands', () => {
+    expect(parseWorktreeAddPath('git status', '/repo')).toBeUndefined();
+    expect(parseWorktreeAddPath('git worktree list', '/repo')).toBeUndefined();
+    expect(parseWorktreeAddPath('{"command":"ls -la"}', '/repo')).toBeUndefined();
+    expect(parseWorktreeAddPath(undefined, '/repo')).toBeUndefined();
+  });
+});
+
+const makeGet = () => {
+  const updateTopicMetadata = vi.fn().mockResolvedValue(undefined);
+  const get = () => ({ updateTopicMetadata }) as any;
+  return { get, updateTopicMetadata };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('applyWorktreeAddToTopic', () => {
+  it('records the new worktree as the topic active one', async () => {
+    topicMocks.getTopicById.mockReturnValue({
+      metadata: { workingDirectoryConfig: { path: '/repo', repoType: 'github' } },
+    });
+    const { get, updateTopicMetadata } = makeGet();
+
+    await applyWorktreeAddToTopic(get, { topicId: 't1', worktreePath: '/wt' });
+
+    expect(updateTopicMetadata).toHaveBeenCalledWith('t1', {
+      workingDirectoryConfig: {
+        git: { activeWorktree: '/wt', isWorktree: true },
+        path: '/repo',
+        repoType: 'github',
+      },
+    });
+  });
+
+  it('falls back to the passed sourcePath when the topic has no config', async () => {
+    topicMocks.getTopicById.mockReturnValue({ metadata: { workingDirectory: '/repo' } });
+    const { get, updateTopicMetadata } = makeGet();
+
+    await applyWorktreeAddToTopic(get, { sourcePath: '/repo', topicId: 't1', worktreePath: '/wt' });
+
+    expect(updateTopicMetadata).toHaveBeenCalledWith('t1', {
+      workingDirectoryConfig: {
+        git: { activeWorktree: '/wt', isWorktree: true },
+        path: '/repo',
+      },
+    });
+  });
+
+  it('does nothing when the worktree resolves to the source path', async () => {
+    topicMocks.getTopicById.mockReturnValue({
+      metadata: { workingDirectoryConfig: { path: '/repo' } },
+    });
+    const { get, updateTopicMetadata } = makeGet();
+
+    await applyWorktreeAddToTopic(get, { topicId: 't1', worktreePath: '/repo' });
+
+    expect(updateTopicMetadata).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent when the active worktree is already set', async () => {
+    topicMocks.getTopicById.mockReturnValue({
+      metadata: {
+        workingDirectoryConfig: {
+          git: { activeWorktree: '/wt', isWorktree: true },
+          path: '/repo',
+        },
+      },
+    });
+    const { get, updateTopicMetadata } = makeGet();
+
+    await applyWorktreeAddToTopic(get, { topicId: 't1', worktreePath: '/wt' });
+
+    expect(updateTopicMetadata).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the topic is gone', async () => {
+    topicMocks.getTopicById.mockReturnValue(undefined);
+    const { get, updateTopicMetadata } = makeGet();
+
+    await applyWorktreeAddToTopic(get, { topicId: 't1', worktreePath: '/wt' });
+
+    expect(updateTopicMetadata).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -57,6 +57,7 @@ import { messageMapKey } from '@/store/chat/utils/messageMapKey';
 import { buildRunLifecycle } from '../../lifecycle/buildRunLifecycle';
 import type { RunScope } from '../../lifecycle/types';
 import { createGatewayEventHandler, isCompletedRuntimeEnd } from '../gateway/gatewayEventHandler';
+import { applyWorktreeAddToTopic, parseWorktreeAddPath } from './worktreeDetection';
 
 /** Mirrors `idGenerator('threads', 16)` on the server so sync-allocated ids have the same shape. */
 const generateThreadId = () => `thd_${createNanoId(16)()}`;
@@ -513,6 +514,13 @@ export const executeHeterogeneousAgent = async (
    * `persistToolResult` and the intervention handlers.
    */
   const toolMsgIdByCallId: Map<string, string> = new Map();
+  /**
+   * `tool_use.id → resolved worktree path` for MAIN-agent shell calls that ran
+   * `git worktree add <path>`. Captured when the tool row is created, consumed
+   * once its result lands SUCCESSFULLY (`resolveToolResult`, `!isError`) to flip
+   * the topic into the new worktree — so a failed add never moves the state.
+   */
+  const worktreeAddByCallId: Map<string, string> = new Map();
   /**
    * Shared main-agent run coordinator state — the pure reducer in
    * `@lobechat/heterogeneous-agents`. Owns the main turn/step state machine
@@ -1049,6 +1057,10 @@ export const executeHeterogeneousAgent = async (
         // register the global lookup so a later tool_result resolves.
         for (const x of intent.tools) {
           if (!x.isNew) continue;
+          // Sniff `git worktree add <path>` so a successful result can flip the
+          // topic into the new worktree (see `resolveToolResult` below).
+          const worktreePath = parseWorktreeAddPath(x.payload.arguments, workingDirectory);
+          if (worktreePath) worktreeAddByCallId.set(x.payload.id, worktreePath);
           const toolMetadata = heteroProvenance(mainState.currentMainMessageId);
           try {
             await messageService.createMessage({
@@ -1095,6 +1107,17 @@ export const executeHeterogeneousAgent = async (
           context,
           intent.pluginState,
         );
+        // A `git worktree add` that succeeded → record the new worktree as the
+        // topic's active one. Fire-and-forget: it only patches topic metadata.
+        const worktreePath = worktreeAddByCallId.get(intent.toolCallId);
+        worktreeAddByCallId.delete(intent.toolCallId);
+        if (worktreePath && !intent.isError && context.topicId) {
+          void applyWorktreeAddToTopic(get, {
+            sourcePath: workingDirectory,
+            topicId: context.topicId,
+            worktreePath,
+          }).catch((e) => console.error('[HeterogeneousAgent] worktree state update failed:', e));
+        }
         return;
       }
 

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/worktreeDetection.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/worktreeDetection.ts
@@ -1,0 +1,141 @@
+import type { WorkingDirConfig } from '@lobechat/types';
+import isEqual from 'fast-deep-equal';
+
+import { topicSelectors } from '@/store/chat/selectors';
+import type { ChatStore } from '@/store/chat/store';
+
+/**
+ * Detect `git worktree add <path>` in a heterogeneous agent's shell tool call and
+ * flip the topic's working-directory state into that worktree.
+ *
+ * Heterogeneous CLI agents (Claude Code / Codex) run their own shell tool — their
+ * calls never pass through our runtime executors, so the server `afterToolCall`
+ * hook never fires for them. We instead sniff the command at the tool-ingest seam
+ * (`heterogeneousAgentExecutor`) and, once the command SUCCEEDS, record the new
+ * worktree as the topic's active one. Mirrors what `WorktreeSwitcher` writes on a
+ * manual selection: only `git.activeWorktree` changes; the CLI session cwd stays
+ * anchored to the source repo (hetero anchors cwd to source, worktree is a record).
+ */
+
+/** Flags on `git worktree add` that consume the following token as their value. */
+const VALUE_FLAGS = new Set(['-b', '-B', '--reason']);
+
+const stripQuotes = (token: string): string => {
+  if (token.length >= 2) {
+    const first = token[0];
+    const last = token.at(-1);
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return token.slice(1, -1);
+    }
+  }
+  return token;
+};
+
+const isAbsolute = (p: string): boolean =>
+  p.startsWith('/') || p.startsWith('~') || /^[A-Z]:[\\/]/i.test(p) || p.startsWith('\\\\');
+
+/** Collapse `.`/`..` segments in a POSIX path without touching the filesystem. */
+const normalizePosix = (p: string): string => {
+  const isAbs = p.startsWith('/');
+  const out: string[] = [];
+  for (const part of p.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') {
+      if (out.length > 0 && out.at(-1) !== '..') out.pop();
+      else if (!isAbs) out.push('..');
+    } else {
+      out.push(part);
+    }
+  }
+  return (isAbs ? '/' : '') + out.join('/');
+};
+
+const resolveWorktreePath = (p: string, cwd?: string): string => {
+  // Windows / home-relative paths: can't resolve without the device fs, keep as-is.
+  if (isAbsolute(p)) return p.startsWith('/') ? normalizePosix(p) : p;
+  if (!cwd) return p;
+  return normalizePosix(`${cwd}/${p}`);
+};
+
+/**
+ * Pull the shell command out of a tool call's raw `arguments` (a JSON string for
+ * CC's `Bash`, but tolerate an already-parsed object or a bare string too).
+ */
+const extractCommand = (rawArgs: unknown): string | undefined => {
+  const fromObject = (obj: any): string | undefined =>
+    obj?.command ?? obj?.cmd ?? obj?.script ?? obj?.content;
+
+  if (rawArgs && typeof rawArgs === 'object') return fromObject(rawArgs);
+  if (typeof rawArgs !== 'string') return undefined;
+
+  const trimmed = rawArgs.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.startsWith('{')) {
+    try {
+      return fromObject(JSON.parse(trimmed)) ?? trimmed;
+    } catch {
+      return trimmed;
+    }
+  }
+  return trimmed;
+};
+
+/**
+ * Parse a shell tool call for `git worktree add <path>` and return the target
+ * worktree path (resolved to absolute against `cwd` when relative). Returns
+ * `undefined` when the call isn't a worktree-add.
+ */
+export const parseWorktreeAddPath = (rawArgs: unknown, cwd?: string): string | undefined => {
+  const command = extractCommand(rawArgs);
+  if (!command || !/\bworktree\s+add\b/.test(command)) return undefined;
+
+  const after = /\bworktree\s+add\b([\s\S]*)/.exec(command)?.[1] ?? '';
+  // Only look at the `worktree add` invocation itself — stop at a shell separator
+  // so a chained `&& cd ...` never gets mistaken for the path argument.
+  const segment = after.split(/[\n;|&]/)[0] ?? '';
+  const tokens = segment.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (VALUE_FLAGS.has(token)) {
+      i += 1; // skip this flag's value
+      continue;
+    }
+    if (token.startsWith('-')) continue; // other flags
+    const path = stripQuotes(token);
+    if (path) return resolveWorktreePath(path, cwd);
+  }
+  return undefined;
+};
+
+/**
+ * Record a newly-created worktree as the topic's active one. No-op when the
+ * worktree resolves to the source path itself, or when nothing would change.
+ */
+export const applyWorktreeAddToTopic = async (
+  get: () => ChatStore,
+  params: { sourcePath?: string; topicId: string; worktreePath: string },
+): Promise<void> => {
+  const { topicId, sourcePath, worktreePath } = params;
+  const topic = topicSelectors.getTopicById(topicId)(get());
+  if (!topic) return;
+
+  const currentConfig = topic.metadata?.workingDirectoryConfig;
+  const source = currentConfig?.path ?? sourcePath ?? topic.metadata?.workingDirectory;
+  if (!source || worktreePath === source) return;
+
+  const git: NonNullable<WorkingDirConfig['git']> = {
+    ...currentConfig?.git,
+    activeWorktree: worktreePath,
+    isWorktree: true,
+  };
+  const nextConfig: WorkingDirConfig = {
+    ...currentConfig,
+    git,
+    path: source,
+    ...(currentConfig?.repoType ? { repoType: currentConfig.repoType } : {}),
+  };
+
+  if (isEqual(currentConfig, nextConfig)) return;
+  await get().updateTopicMetadata(topicId, { workingDirectoryConfig: nextConfig });
+};


### PR DESCRIPTION
## What

When a heterogeneous CLI agent (Claude Code / Codex) runs `git worktree add <path>` during a run, automatically record that worktree as the topic's active working directory — so the sidebar / status bar reflect "now in the worktree" without a manual switch.

## Why the `afterToolCall` hook can't do this

`afterToolCall` is a server-only hook dispatched exclusively from our two runtime tool executors (`callTool.ts`, `callToolsBatch.ts`). Heterogeneous agents run their **own** shell tool — their calls are ingested from the CLI stream (`heteroIngest`) and never pass through those executors, so the hook never fires for them (the hetero branch in `execAgent` returns before `AgentRuntimeService`, registering only `onComplete`/`onError`). So the interception has to happen at the hetero tool-ingest seam instead.

## How

In `heterogeneousAgentExecutor` (client-side, where the topic store is reachable):

1. **Capture** — when a MAIN-agent tool row is created (`persistToolBatch`), sniff `git worktree add <path>` out of the shell call's `arguments` and stash `tool_use.id → resolved worktree path`.
2. **Apply on success** — when that call's result lands (`resolveToolResult`) with `!isError`, write `workingDirectoryConfig.git.activeWorktree` (+ `isWorktree`) onto the topic. A failed add never moves the state.

This mirrors exactly what `WorktreeSwitcher` writes on a manual selection: **only** `git.activeWorktree` changes — the CLI session cwd stays anchored to the source repo (hetero anchors cwd to source; the worktree is a record, not a cwd move). Idempotent, fire-and-forget.

### `parseWorktreeAddPath`
Tolerates the CC `Bash` JSON `arguments` shape (and bare strings / objects), skips flags + their values (`-b`/`-B`/`--reason`), stops at shell separators so a chained `&& cd ...` isn't mistaken for the path, and resolves relative paths against the run's source cwd (POSIX; Windows/`~` paths kept as-is).

## Scope / follow-ups

- **Main agent only.** Subagent worktree adds are ambiguous scratch context and are intentionally not flipped.
- **Detection = command sniff** (`git worktree add`), the clearest intent signal. `cd` into a pre-existing worktree is intentionally not inferred.
- Homogeneous local `runCommand` and gateway-dispatched tools are out of scope here (their interception points differ — client executor tool_result and the real `afterToolCall` respectively).

## Tests

New `worktreeDetection.test.ts` (12 cases): path parsing (relative/absolute/flags/quoted/JSON/compound/negatives) + the topic-apply logic (write / source-path fallback / no-op when equal to source / idempotent / missing topic). `bun run check` clean; the executor's own suite (75 tests) still passes; type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)