### PR TITLE
🐛 fix: render markdown footnotes without citations

### DIFF
--- a/src/features/Conversation/Messages/useChatMarkdown.test.tsx
+++ b/src/features/Conversation/Messages/useChatMarkdown.test.tsx
@@ -45,4 +45,10 @@ describe('useChatMarkdown (assistant / grouped message pipeline)', () => {
     expect(assistantScoped).toBeTruthy();
     expect(remarkPlugins).toContain(assistantScoped!.remarkPlugin);
   });
+
+  it('keeps markdown footnotes visible when structured citations are absent', () => {
+    const { result } = renderHook(() => useChatMarkdown({ id: 'a3', isGenerating: false }));
+
+    expect(result.current.markdownProps.showFootnotes).toBe(true);
+  });
 });

--- a/src/features/Conversation/Messages/useChatMarkdown.tsx
+++ b/src/features/Conversation/Messages/useChatMarkdown.tsx
@@ -71,19 +71,22 @@ export const useChatMarkdown = ({
         enableStream,
         rehypePlugins,
         remarkPlugins,
-        showFootnotes:
-          !!citations && citations.length > 0 && citations.every((item) => item.title !== item.url),
+        showFootnotes: !citations?.length || citations.every((item) => item.title !== item.url),
       }) satisfies Partial<MarkdownProps>,
     [animated, citations, components, enableStream],
   );
 
-  const drawer = drawerContent ? (
-    <HtmlPreviewDrawer
-      content={drawerContent}
-      open={!!drawerContent}
-      onClose={() => setDrawerContent(null)}
-    />
-  ) : null;
+  const drawer = useMemo(
+    () =>
+      drawerContent ? (
+        <HtmlPreviewDrawer
+          content={drawerContent}
+          open={!!drawerContent}
+          onClose={() => setDrawerContent(null)}
+        />
+      ) : null,
+    [drawerContent],
+  );
 
   return useMemo(() => ({ drawer, markdownProps }), [drawer, markdownProps]);
 };


### PR DESCRIPTION
## Summary

- Render Markdown footnotes when a message has no structured citation payload.
- Add a regression test for assistant Markdown props without `search.citations`.
- Memoize the HTML preview drawer to keep the hook return value stable after lint autofix.

## Root Cause

Some assistant messages can contain reference links as standard Markdown footnote definitions instead of structured citation metadata. In that shape, the message body includes the reference content, but `search.citations` is absent.

The Markdown parser consumes GFM footnote definitions and renders them through the footnotes UI only when `showFootnotes` is enabled. `useChatMarkdown` previously enabled footnotes only when structured `citations` existed. As a result, Markdown-native footnote definitions were removed from the body by parsing but never rendered by the footnotes UI, leaving an empty reference heading in the visible answer.

This is a frontend Markdown rendering condition issue. The source links are present in the Markdown content; they are just hidden when no structured citations accompany the message.

## Changes

- Change `showFootnotes` so Markdown-native footnotes remain visible when structured citations are absent.
- Preserve the existing behavior for structured citations whose title equals URL.
- Add test coverage for the no-citations Markdown footnote path.

## Verification

- `bunx vitest run --silent='passed-only' 'src/features/Conversation/Messages/useChatMarkdown.test.tsx'`
- `bun run check src/features/Conversation/Messages/useChatMarkdown.tsx src/features/Conversation/Messages/useChatMarkdown.test.tsx --lint --test`
- Verified locally with `bun run dev:spa` and the debug proxy that a previously empty reference section now renders its Markdown footnote source links.
