### PR TITLE
🐛 fix(skill): show full connector catalog, not just recommended set

### DIFF
--- a/src/routes/(main)/settings/skill/features/SkillList.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillList.tsx
@@ -218,32 +218,27 @@ const SkillList = memo<SkillListProps>(
           }
         }
 
-        // Also add connected Lobehub skills that are not in RECOMMENDED_SKILLS
+        // Also add every other Lobehub skill provider so users can discover and
+        // connect integrations beyond the curated RECOMMENDED_SKILLS set —
+        // otherwise a provider like Vercel or Linear never appears until it's
+        // already connected, and a disconnected one has no way to be found.
         if (isLobehubSkillEnabled) {
-          for (const server of allLobehubSkillServers) {
-            if (
-              server.status === LobehubSkillStatus.CONNECTED &&
-              !addedLobehubIds.has(server.identifier)
-            ) {
-              const provider = getLobehubSkillProviderById(server.identifier);
-              if (provider) {
-                integrationItems.push({ provider, type: 'lobehub' });
-              }
+          for (const provider of LOBEHUB_SKILL_PROVIDERS) {
+            if (!addedLobehubIds.has(provider.id)) {
+              integrationItems.push({ provider, type: 'lobehub' });
+              addedLobehubIds.add(provider.id);
             }
           }
         }
 
-        // Also add connected Composio skills that are not in RECOMMENDED_SKILLS
+        // Also add every other Composio app so users can discover and connect
+        // integrations beyond the curated RECOMMENDED_SKILLS set — otherwise an
+        // app like Jira never appears until it's already connected.
         if (isComposioEnabled) {
-          for (const server of allComposioServers) {
-            if (
-              server.status === ComposioServerStatus.ACTIVE &&
-              !addedComposioIds.has(server.identifier)
-            ) {
-              const serverType = getComposioAppByIdentifier(server.identifier);
-              if (serverType) {
-                integrationItems.push({ serverType, type: 'composio' });
-              }
+          for (const serverType of COMPOSIO_APP_TYPES) {
+            if (!addedComposioIds.has(serverType.identifier)) {
+              integrationItems.push({ serverType, type: 'composio' });
+              addedComposioIds.add(serverType.identifier);
             }
           }
         }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- N/A -->

#### 🔀 Description of Change

Follow-up to #16633. On `/settings/skill` (Connectors tab), the left list only rendered LobeHub skill providers / Composio apps that were either curated in `RECOMMENDED_SKILLS` or already connected. Anything outside that curated set — e.g. Vercel, Linear, GitHub, Microsoft (LobeHub skills), or Jira, Confluence, Salesforce, Figma, etc. (Composio apps) — never appeared in the list at all until it had somehow already been connected, so users had no way to discover or connect them from this page.

- `LOBEHUB_SKILL_PROVIDERS` and `COMPOSIO_APP_TYPES` are now fully added to the integrations list (previously only the recommended subset + already-connected extras were added).
- Recommended items are still added first, so they continue to lead the list; the rest of the catalog now also renders with the inline Connect button (from #16633) when not yet connected.

Files:
- `src/routes/(main)/settings/skill/features/SkillList.tsx`

#### 🧪 How to Test

Open **Settings → Skills → Connectors**:

- Providers/apps outside the curated recommended set (e.g. Vercel, Jira, Confluence) now appear in the list with an inline **Connect** button when not connected.
- Recommended items (PostHog, Gmail, etc.) still appear at the top of the list, same as before.
- Already-connected items still show the green check and open the detail panel on click.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Non-recommended connectors (Vercel, Jira, ...) never appear until connected | All connectors appear, with Connect button when disconnected |

#### 📝 Additional Information

No breaking changes. Pure client-side list construction change; reuses existing connect/reauthorize UX from #16633.