### PR TITLE
✨ feat(hetero): auto-detect `git worktree add` via builtin executor onAfterCall

### DIFF
--- a/src/store/tool/slices/builtin/executors/__tests__/heteroCli.test.ts
+++ b/src/store/tool/slices/builtin/executors/__tests__/heteroCli.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { claudeCodeExecutor, codexExecutor } from '../heteroCli';
+
+const detectMocks = vi.hoisted(() => ({ applyWorktreeAddFromToolCall: vi.fn() }));
+
+vi.mock('../worktreeDetection', () => ({
+  applyWorktreeAddFromToolCall: detectMocks.applyWorktreeAddFromToolCall,
+}));
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('heteroCli executors', () => {
+  it('registers the CLI adapter identifiers and exposes no invokable APIs', () => {
+    expect(claudeCodeExecutor.identifier).toBe('claude-code');
+    expect(codexExecutor.identifier).toBe('codex');
+    // Empty apiEnum → never treated as an invokable client tool.
+    expect(claudeCodeExecutor.hasApi('Bash')).toBe(false);
+    expect(claudeCodeExecutor.getApiNames()).toEqual([]);
+  });
+
+  it('runs worktree detection on a successful tool call', async () => {
+    const params = { command: 'git worktree add /wt' };
+    await claudeCodeExecutor.onAfterCall!({
+      apiName: 'Bash',
+      identifier: 'claude-code',
+      params,
+      result: { content: '', success: true },
+    });
+    expect(detectMocks.applyWorktreeAddFromToolCall).toHaveBeenCalledWith(params);
+  });
+
+  it('skips detection when the tool call failed', async () => {
+    await claudeCodeExecutor.onAfterCall!({
+      apiName: 'Bash',
+      identifier: 'claude-code',
+      params: { command: 'git worktree add /wt' },
+      result: { content: 'fatal: ...', success: false },
+    });
+    expect(detectMocks.applyWorktreeAddFromToolCall).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/tool/slices/builtin/executors/__tests__/worktreeDetection.test.ts
+++ b/src/store/tool/slices/builtin/executors/__tests__/worktreeDetection.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { applyWorktreeAddFromToolCall, parseWorktreeAddPath } from '../worktreeDetection';
+
+const chatMocks = vi.hoisted(() => ({
+  activeTopicId: undefined as string | undefined,
+  topics: {} as Record<string, { metadata?: Record<string, any> }>,
+  updateTopicMetadata: vi.fn(),
+}));
+
+vi.mock('@/store/chat/store', () => ({
+  getChatStoreState: () => chatMocks,
+}));
+
+vi.mock('@/store/chat/selectors', () => ({
+  topicSelectors: {
+    getTopicById: (id: string) => (state: typeof chatMocks) => state.topics[id],
+  },
+}));
+
+describe('parseWorktreeAddPath', () => {
+  const cmd = (command: unknown) => ({ command });
+
+  it('resolves a relative path against the source cwd', () => {
+    expect(parseWorktreeAddPath(cmd('git worktree add ../wt'), '/repo')).toBe('/wt');
+    expect(parseWorktreeAddPath(cmd('git worktree add wt'), '/repo')).toBe('/repo/wt');
+  });
+
+  it('keeps an absolute path as-is', () => {
+    expect(parseWorktreeAddPath(cmd('git worktree add /tmp/wt'), '/repo')).toBe('/tmp/wt');
+  });
+
+  it('skips flags and their values', () => {
+    expect(parseWorktreeAddPath(cmd('git worktree add -b feature ../feat'), '/repo')).toBe('/feat');
+    expect(parseWorktreeAddPath(cmd('git worktree add --detach /tmp/wt'), '/repo')).toBe('/tmp/wt');
+  });
+
+  it('stops at a shell separator', () => {
+    expect(parseWorktreeAddPath(cmd('cd /repo && git worktree add wt && cd wt'), '/repo')).toBe(
+      '/repo/wt',
+    );
+  });
+
+  it('joins an argv-array command (Codex shell shape)', () => {
+    expect(parseWorktreeAddPath(cmd(['git', 'worktree', 'add', '/tmp/wt']), '/repo')).toBe(
+      '/tmp/wt',
+    );
+  });
+
+  it('reads only `command`, never `content` (writeFile is safe)', () => {
+    expect(
+      parseWorktreeAddPath({ content: 'run: git worktree add /wt', file_path: 'a.md' }, '/repo'),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for non-worktree-add calls', () => {
+    expect(parseWorktreeAddPath(cmd('git status'), '/repo')).toBeUndefined();
+    expect(parseWorktreeAddPath(cmd('git worktree list'), '/repo')).toBeUndefined();
+    expect(parseWorktreeAddPath({ file_path: '/x' }, '/repo')).toBeUndefined();
+    expect(parseWorktreeAddPath(undefined, '/repo')).toBeUndefined();
+  });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  chatMocks.activeTopicId = undefined;
+  chatMocks.topics = {};
+});
+
+describe('applyWorktreeAddFromToolCall', () => {
+  it('records the new worktree onto the active topic', async () => {
+    chatMocks.activeTopicId = 't1';
+    chatMocks.topics = {
+      t1: { metadata: { workingDirectoryConfig: { path: '/repo', repoType: 'github' } } },
+    };
+
+    await applyWorktreeAddFromToolCall({ command: 'git worktree add ../wt' });
+
+    expect(chatMocks.updateTopicMetadata).toHaveBeenCalledWith('t1', {
+      workingDirectoryConfig: {
+        git: { activeWorktree: '/wt', isWorktree: true },
+        path: '/repo',
+        repoType: 'github',
+      },
+    });
+  });
+
+  it('does nothing when there is no active topic', async () => {
+    chatMocks.activeTopicId = undefined;
+    await applyWorktreeAddFromToolCall({ command: 'git worktree add /wt' });
+    expect(chatMocks.updateTopicMetadata).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the worktree resolves to the source path', async () => {
+    chatMocks.activeTopicId = 't1';
+    chatMocks.topics = { t1: { metadata: { workingDirectoryConfig: { path: '/repo' } } } };
+    await applyWorktreeAddFromToolCall({ command: 'git worktree add /repo' });
+    expect(chatMocks.updateTopicMetadata).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent when the active worktree is already set', async () => {
+    chatMocks.activeTopicId = 't1';
+    chatMocks.topics = {
+      t1: {
+        metadata: {
+          workingDirectoryConfig: {
+            git: { activeWorktree: '/wt', isWorktree: true },
+            path: '/repo',
+          },
+        },
+      },
+    };
+    await applyWorktreeAddFromToolCall({ command: 'git worktree add /wt' });
+    expect(chatMocks.updateTopicMetadata).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for a non-worktree command', async () => {
+    chatMocks.activeTopicId = 't1';
+    chatMocks.topics = { t1: { metadata: { workingDirectoryConfig: { path: '/repo' } } } };
+    await applyWorktreeAddFromToolCall({ command: 'ls -la' });
+    expect(chatMocks.updateTopicMetadata).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/tool/slices/builtin/executors/heteroCli.ts
+++ b/src/store/tool/slices/builtin/executors/heteroCli.ts
@@ -1,0 +1,38 @@
+import type { ToolAfterCallContext } from '@lobechat/types';
+import { BaseExecutor } from '@lobechat/types';
+
+import { applyWorktreeAddFromToolCall } from './worktreeDetection';
+
+/**
+ * Hook-only executor for a heterogeneous CLI agent's tool identifier
+ * (`claude-code` / `codex` — set by the adapters in
+ * `packages/heterogeneous-agents/src/adapters/*`). These agents run their OWN
+ * tools, so this executor is NEVER invoked: `apiEnum` is empty → `hasApi()` is
+ * always false → the client-tool dispatch (`hasExecutor`) never routes to
+ * `invoke`, and no phantom tool is exposed to the model.
+ *
+ * It exists solely so the `tool_end` dispatcher
+ * (`gatewayEventHandler.dispatchOnAfterCall`, which resolves the executor by the
+ * tool's `identifier`) can reach `onAfterCall` and observe the CLI's shell tool
+ * results renderer-side — the same seam idiomatic builtin tools use to react to
+ * their own mutations.
+ */
+const EMPTY_API_ENUM = {} as Record<string, string>;
+
+class HeteroCliExecutor extends BaseExecutor<typeof EMPTY_API_ENUM> {
+  protected readonly apiEnum = EMPTY_API_ENUM;
+
+  constructor(readonly identifier: string) {
+    super();
+  }
+
+  onAfterCall = async ({ params, result }: ToolAfterCallContext): Promise<void> => {
+    if (!result.success) return;
+    // Only a successful `git worktree add` matches; every other tool call (and
+    // non-shell tool) falls through cheaply inside the detector.
+    await applyWorktreeAddFromToolCall(params);
+  };
+}
+
+export const claudeCodeExecutor = new HeteroCliExecutor('claude-code');
+export const codexExecutor = new HeteroCliExecutor('codex');

--- a/src/store/tool/slices/builtin/executors/index.ts
+++ b/src/store/tool/slices/builtin/executors/index.ts
@@ -20,6 +20,7 @@ import { memoryExecutor } from '@lobechat/builtin-tool-memory/executor';
 import { taskExecutor } from '@lobechat/builtin-tool-task/client/executor';
 
 import type { BuiltinToolContext, BuiltinToolResult, IBuiltinToolExecutor } from '../types';
+import { claudeCodeExecutor, codexExecutor } from './heteroCli';
 import { activatorExecutor } from './lobe-activator';
 import { agentDocumentsExecutor } from './lobe-agent-documents';
 import { messageExecutor } from './lobe-message';
@@ -137,6 +138,10 @@ export const registerBuiltinToolExecutors = (): void => {
   if (executorsRegistered) return;
 
   registerExecutors([
+    // Hook-only executors for heterogeneous CLI agents (Claude Code / Codex) —
+    // observe their shell tool results via `onAfterCall` (never invoked).
+    claudeCodeExecutor,
+    codexExecutor,
     agentBuilderExecutor,
     agentDocumentsExecutor,
     agentManagementExecutor,

--- a/src/store/tool/slices/builtin/executors/worktreeDetection.ts
+++ b/src/store/tool/slices/builtin/executors/worktreeDetection.ts
@@ -1,0 +1,133 @@
+import type { WorkingDirConfig } from '@lobechat/types';
+import { getWorkingDirSourcePath } from '@lobechat/types';
+import isEqual from 'fast-deep-equal';
+
+import { topicSelectors } from '@/store/chat/selectors';
+import { getChatStoreState } from '@/store/chat/store';
+
+/**
+ * Detect `git worktree add <path>` in a heterogeneous CLI agent's shell tool call
+ * and flip the active topic's working-directory state into that worktree.
+ *
+ * Runs from the `claude-code` / `codex` executor's `onAfterCall` hook (renderer-side,
+ * fired on `tool_end`). Mirrors what `WorktreeSwitcher` writes on a manual selection:
+ * only `git.activeWorktree` / `isWorktree` change — the CLI session cwd stays anchored
+ * to the source repo (hetero anchors cwd to source; the worktree is a record).
+ */
+
+/** Flags on `git worktree add` that consume the following token as their value. */
+const VALUE_FLAGS = new Set(['-b', '-B', '--reason']);
+
+const stripQuotes = (token: string): string => {
+  if (token.length >= 2) {
+    const first = token[0];
+    const last = token.at(-1);
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return token.slice(1, -1);
+    }
+  }
+  return token;
+};
+
+const isAbsolute = (p: string): boolean =>
+  p.startsWith('/') || p.startsWith('~') || /^[A-Z]:[\\/]/i.test(p) || p.startsWith('\\\\');
+
+/** Collapse `.`/`..` segments in a POSIX path without touching the filesystem. */
+const normalizePosix = (p: string): string => {
+  const isAbs = p.startsWith('/');
+  const out: string[] = [];
+  for (const part of p.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') {
+      if (out.length > 0 && out.at(-1) !== '..') out.pop();
+      else if (!isAbs) out.push('..');
+    } else {
+      out.push(part);
+    }
+  }
+  return (isAbs ? '/' : '') + out.join('/');
+};
+
+const resolveWorktreePath = (p: string, cwd?: string): string => {
+  // Windows / home-relative paths: can't resolve without the device fs, keep as-is.
+  if (isAbsolute(p)) return p.startsWith('/') ? normalizePosix(p) : p;
+  if (!cwd) return p;
+  return normalizePosix(`${cwd}/${p}`);
+};
+
+/**
+ * Pull the shell command out of a tool call's parsed `params`. Only reads the
+ * `command`/`cmd` field (CC `Bash`, Codex shell) — deliberately NOT `content`, so
+ * a `writeFile` whose body happens to contain "git worktree add" never misfires.
+ * Codex may send the command as an argv array; join it.
+ */
+const extractCommand = (params: unknown): string | undefined => {
+  if (!params || typeof params !== 'object') return undefined;
+  const raw = (params as any).command ?? (params as any).cmd;
+  if (Array.isArray(raw))
+    return raw.every((x) => typeof x === 'string') ? raw.join(' ') : undefined;
+  return typeof raw === 'string' ? raw : undefined;
+};
+
+/**
+ * Parse a shell tool call's `params` for `git worktree add <path>` and return the
+ * target worktree path (resolved to absolute against `cwd` when relative). Returns
+ * `undefined` when the call isn't a worktree-add.
+ */
+export const parseWorktreeAddPath = (params: unknown, cwd?: string): string | undefined => {
+  const command = extractCommand(params);
+  if (!command || !/\bworktree\s+add\b/.test(command)) return undefined;
+
+  const after = /\bworktree\s+add\b([\s\S]*)/.exec(command)?.[1] ?? '';
+  // Only look at the `worktree add` invocation itself — stop at a shell separator
+  // so a chained `&& cd ...` never gets mistaken for the path argument.
+  const segment = after.split(/[\n;|&]/)[0] ?? '';
+  const tokens = segment.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
+
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (VALUE_FLAGS.has(token)) {
+      i += 1; // skip this flag's value
+      continue;
+    }
+    if (token.startsWith('-')) continue; // other flags
+    const path = stripQuotes(token);
+    if (path) return resolveWorktreePath(path, cwd);
+  }
+  return undefined;
+};
+
+/**
+ * If the tool call was a successful `git worktree add`, record the new worktree as
+ * the ACTIVE topic's active one. `onAfterCall` carries no run topicId, so this
+ * targets `activeTopicId` — during a CLI run that IS the run's topic (mirrors how
+ * other executors, e.g. Task, key off active store state). No-op when the worktree
+ * resolves to the source path itself or nothing would change.
+ */
+export const applyWorktreeAddFromToolCall = async (params: unknown): Promise<void> => {
+  const state = getChatStoreState();
+  const topicId = state.activeTopicId;
+  if (!topicId) return;
+
+  const topic = topicSelectors.getTopicById(topicId)(state);
+  const currentConfig = topic?.metadata?.workingDirectoryConfig;
+  const source = getWorkingDirSourcePath(currentConfig) ?? topic?.metadata?.workingDirectory;
+
+  const worktreePath = parseWorktreeAddPath(params, source);
+  if (!worktreePath || !source || worktreePath === source) return;
+
+  const git: NonNullable<WorkingDirConfig['git']> = {
+    ...currentConfig?.git,
+    activeWorktree: worktreePath,
+    isWorktree: true,
+  };
+  const nextConfig: WorkingDirConfig = {
+    ...currentConfig,
+    git,
+    path: source,
+    ...(currentConfig?.repoType ? { repoType: currentConfig.repoType } : {}),
+  };
+
+  if (isEqual(currentConfig, nextConfig)) return;
+  await state.updateTopicMetadata(topicId, { workingDirectoryConfig: nextConfig });
+};


### PR DESCRIPTION
> Supersedes #16787 (which patched the hetero reducer). This uses the idiomatic builtin executor `onAfterCall` hook instead.

## What

When a heterogeneous CLI agent (Claude Code / Codex) runs `git worktree add <path>` during a run, automatically record that worktree as the active topic's working directory — so the sidebar / status bar reflect "now in the worktree" without a manual switch.

## Mechanism — the builtin executor `onAfterCall` hook

`IBuiltinToolExecutor.onAfterCall` (`packages/types/src/tool/builtin.ts:888`) is a **renderer-side** hook dispatched from the `tool_end` event (`gatewayEventHandler.dispatchOnAfterCall`, line 152), **regardless of whether the tool ran client- or server-side** — and the hetero path routes its `tool_end` events through the very same `eventHandler`. Idiomatic builtin tools (task, skill-store, agent-documents…) already use it to react to their own mutations.

The one catch: `dispatchOnAfterCall` resolves the executor by the tool's `identifier`, and CC/Codex tool calls carry `identifier: 'claude-code'` / `'codex'` (set by the adapters), for which **no executor was registered** — so `onAfterCall` never reached them.

### Fix
Register a **hook-only** executor per CLI identifier (`heteroCli.ts`):
- Empty `apiEnum` → `hasApi()` is always `false` → the client-tool dispatch (`hasExecutor`) never routes to `invoke`, and no phantom tool is exposed to the model. It exists **solely** so the `tool_end` dispatcher can reach `onAfterCall`.
- `onAfterCall`: on a **successful** call, run worktree detection.

### Detection + apply (`worktreeDetection.ts`)
- `parseWorktreeAddPath(params, cwd)` — reads only the `command`/`cmd` field (never `content`, so a `writeFile` body containing "git worktree add" can't misfire), supports Codex's argv-array form, skips flags + their values (`-b`/`-B`/`--reason`), stops at shell separators, resolves relative paths against the source cwd.
- `applyWorktreeAddFromToolCall` — writes `git.activeWorktree` / `isWorktree` onto the topic, mirroring a manual `WorktreeSwitcher` selection (only the worktree record changes; the CLI session cwd stays anchored to the source repo).

## Known limitation — active topic binding

`onAfterCall` carries no run `topicId`, so the write targets `activeTopicId`. During a live CLI run that IS the run's topic (same pattern other executors use, e.g. Task keying off `activeTaskId`). If the user navigates to another topic mid-run, a worktree add would stamp the wrong topic — acceptable for this signal, and noted here.

## Scope

- CC/Codex only. Homogeneous `runCommand` (identifier `lobe-local-system`, already registered) could get the same behavior by adding `onAfterCall` to `LocalSystemExecutor` in a follow-up.
- Detection = command sniff of `git worktree add` (clearest intent). `cd` into a pre-existing worktree is not inferred.

## Tests

`worktreeDetection.test.ts` (13) — path parsing (relative/absolute/flags/argv-array/`content`-safety/negatives) + topic apply (write / no active topic / equals-source no-op / idempotent / non-worktree). `heteroCli.test.ts` (3) — identifiers, no invokable APIs, success-gating. `bun run check` clean; registry test + type-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)