### PR TITLE
🐛 fix(memory): guard memory render against non-array tool-call args

### DIFF
--- a/packages/builtin-tool-memory/src/client/Inspector/SearchUserMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Inspector/SearchUserMemory/index.tsx
@@ -15,7 +15,10 @@ export const SearchUserMemoryInspector = memo<
 >(({ args, partialArgs, isArgumentsStreaming, isLoading, pluginState }) => {
   const { t } = useTranslation('plugin');
 
-  const query = args?.queries?.join(', ') || partialArgs?.queries?.join(', ');
+  // `queries` comes from raw model tool-call args; a model may emit a scalar where
+  // `string[]` is expected, so `.join` guards against a non-array crashing render.
+  const joinQueries = (queries: unknown) => (Array.isArray(queries) ? queries.join(', ') : '');
+  const query = joinQueries(args?.queries) || joinQueries(partialArgs?.queries);
 
   // Initial streaming state
   if (isArgumentsStreaming && !query) {

--- a/packages/builtin-tool-memory/src/client/Render/SearchUserMemory/index.tsx
+++ b/packages/builtin-tool-memory/src/client/Render/SearchUserMemory/index.tsx
@@ -59,6 +59,8 @@ interface MemoryItemProps {
 }
 
 const MemoryItem = memo<MemoryItemProps>(({ title, content, subContent, tags }) => {
+  // Guard against non-array `tags` (dirty data) so a bad row can't crash the list.
+  const safeTags = Array.isArray(tags) ? tags : [];
   return (
     <Flexbox className={styles.item} gap={4}>
       {title && <div className={styles.itemTitle}>{title}</div>}
@@ -68,9 +70,9 @@ const MemoryItem = memo<MemoryItemProps>(({ title, content, subContent, tags }) 
           {subContent}
         </Text>
       )}
-      {tags && tags.length > 0 && (
+      {safeTags.length > 0 && (
         <Flexbox horizontal className={styles.tags} gap={4} wrap={'wrap'}>
-          {tags.map((tag, index) => (
+          {safeTags.map((tag, index) => (
             <Tag key={index} size={'small'}>
               {tag}
             </Tag>

--- a/packages/builtin-tool-memory/src/client/components/ExperienceMemoryCard.tsx
+++ b/packages/builtin-tool-memory/src/client/components/ExperienceMemoryCard.tsx
@@ -89,9 +89,14 @@ export const ExperienceMemoryCard = memo<ExperienceMemoryCardProps>(({ data, loa
   const { summary, details, tags, title, withExperience } = data || {};
   const { situation, reasoning, action, possibleOutcome, keyLearning } = withExperience || {};
 
+  // `tags` comes from raw model tool-call args without zod coercion, so a model may
+  // emit a scalar where `string[]` is expected. Normalize to an array to keep this
+  // card from crashing on dirty input (`.map` on a non-array).
+  const safeTags = Array.isArray(tags) ? tags : [];
+
   const hasStarContent = situation || reasoning || action || possibleOutcome;
 
-  if (!summary && !details && !tags?.length && !title && !hasStarContent && !keyLearning)
+  if (!summary && !details && !safeTags.length && !title && !hasStarContent && !keyLearning)
     return null;
 
   const starItems = [
@@ -115,7 +120,7 @@ export const ExperienceMemoryCard = memo<ExperienceMemoryCardProps>(({ data, loa
       {hasStarContent ? (
         <>
           {/* Collapsed Summary */}
-          {(summary || tags?.length) && (
+          {(summary || safeTags.length > 0) && (
             <Accordion gap={0}>
               <AccordionItem
                 itemKey="summary"
@@ -133,9 +138,9 @@ export const ExperienceMemoryCard = memo<ExperienceMemoryCardProps>(({ data, loa
                 <Flexbox gap={8} paddingBlock={'8px 12px'} paddingInline={8}>
                   {summary && <div className={styles.summary}>{summary}</div>}
                   {details && <div className={styles.detail}>{details}</div>}
-                  {tags && tags.length > 0 && (
+                  {safeTags.length > 0 && (
                     <Flexbox horizontal className={styles.tags} gap={8} wrap={'wrap'}>
-                      {tags.map((tag, index) => (
+                      {safeTags.map((tag, index) => (
                         <Tag key={index}>{tag}</Tag>
                       ))}
                     </Flexbox>
@@ -211,9 +216,9 @@ export const ExperienceMemoryCard = memo<ExperienceMemoryCardProps>(({ data, loa
             <>
               {summary && <div className={styles.summary}>{summary}</div>}
               {details && <StreamingMarkdown>{details}</StreamingMarkdown>}
-              {tags && tags.length > 0 && (
+              {safeTags.length > 0 && (
                 <Flexbox horizontal className={styles.tags} gap={8} wrap={'wrap'}>
-                  {tags.map((tag, index) => (
+                  {safeTags.map((tag, index) => (
                     <Tag key={index}>{tag}</Tag>
                   ))}
                 </Flexbox>

--- a/packages/builtin-tool-memory/src/client/components/PreferenceMemoryCard.tsx
+++ b/packages/builtin-tool-memory/src/client/components/PreferenceMemoryCard.tsx
@@ -101,6 +101,12 @@ export const PreferenceMemoryCard = memo<PreferenceMemoryCardProps>(({ data, loa
   const { conclusionDirectives, originContext, appContext, suggestions, type } =
     withPreference || {};
 
+  // `tags`/`suggestions` come from raw model tool-call args without zod coercion,
+  // so a model may emit a scalar where `string[]` is expected. Normalize to arrays
+  // to keep this card from crashing on dirty input (`.map` on a non-array).
+  const safeTags = Array.isArray(tags) ? tags : [];
+  const safeSuggestions = Array.isArray(suggestions) ? suggestions : [];
+
   const hasContextContent =
     originContext?.actor ||
     originContext?.scenario ||
@@ -110,12 +116,12 @@ export const PreferenceMemoryCard = memo<PreferenceMemoryCardProps>(({ data, loa
 
   const hasAppContext = appContext?.app || appContext?.feature || appContext?.surface;
 
-  const hasSuggestions = suggestions && suggestions.length > 0;
+  const hasSuggestions = safeSuggestions.length > 0;
 
   if (
     !summary &&
     !details &&
-    !tags?.length &&
+    !safeTags.length &&
     !title &&
     !conclusionDirectives &&
     !hasContextContent &&
@@ -152,7 +158,7 @@ export const PreferenceMemoryCard = memo<PreferenceMemoryCardProps>(({ data, loa
       {hasContextContent || hasAppContext ? (
         <>
           {/* Collapsed Summary */}
-          {(summary || tags?.length) && (
+          {(summary || safeTags.length > 0) && (
             <Accordion gap={0}>
               <AccordionItem
                 itemKey="summary"
@@ -170,9 +176,9 @@ export const PreferenceMemoryCard = memo<PreferenceMemoryCardProps>(({ data, loa
                 <Flexbox gap={8} paddingBlock={'8px 12px'} paddingInline={8}>
                   {summary && <div className={styles.summary}>{summary}</div>}
                   {details && <div className={styles.detail}>{details}</div>}
-                  {tags && tags.length > 0 && (
+                  {safeTags.length > 0 && (
                     <Flexbox horizontal className={styles.tags} gap={8} wrap={'wrap'}>
-                      {tags.map((tag, index) => (
+                      {safeTags.map((tag, index) => (
                         <Tag key={index}>{tag}</Tag>
                       ))}
                     </Flexbox>
@@ -297,7 +303,7 @@ export const PreferenceMemoryCard = memo<PreferenceMemoryCardProps>(({ data, loa
                 <span className={highlightTextStyles.info}>Suggestions</span>
               </Text>
               <Flexbox gap={8}>
-                {suggestions.map((suggestion, index) => (
+                {safeSuggestions.map((suggestion, index) => (
                   <div className={styles.suggestion} key={index}>
                     {suggestion}
                   </div>
@@ -329,7 +335,7 @@ export const PreferenceMemoryCard = memo<PreferenceMemoryCardProps>(({ data, loa
                     <span className={highlightTextStyles.info}>Suggestions</span>
                   </Text>
                   <Flexbox gap={8}>
-                    {suggestions.map((suggestion, index) => (
+                    {safeSuggestions.map((suggestion, index) => (
                       <div className={styles.suggestion} key={index}>
                         {suggestion}
                       </div>
@@ -337,9 +343,9 @@ export const PreferenceMemoryCard = memo<PreferenceMemoryCardProps>(({ data, loa
                   </Flexbox>
                 </Flexbox>
               )}
-              {tags && tags.length > 0 && (
+              {safeTags.length > 0 && (
                 <Flexbox horizontal className={styles.tags} gap={8} wrap={'wrap'}>
-                  {tags.map((tag, index) => (
+                  {safeTags.map((tag, index) => (
                     <Tag key={index}>{tag}</Tag>
                   ))}
                 </Flexbox>


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- No matching GitHub/Linear issue found. -->

#### 🔀 Description of Change

The Preference/Experience memory cards and the `SearchUserMemory` inspector/render read `tags`, `suggestions`, and `queries` **directly from raw model tool-call args**, which are never zod-coerced before hitting the render layer.

When a model emits a scalar where a `string[]` is expected (e.g. `"tags": "communication"` instead of `["communication"]`):

- `suggestions.length > 0` reads truthy on a string, so the guard passes
- `suggestions.map(...)` / `tags.map(...)` / `queries.join(...)` then throw a synchronous `TypeError: x.map is not a function` **during render**, crashing the whole card (and the surrounding React subtree)

This is dirty-input hardening — `partial-json` streaming always keeps array fields as arrays, so the trigger is genuinely malformed model output, not a streaming intermediate state.

**Fix:** normalize each field with `Array.isArray` guards so a non-array value simply renders nothing instead of taking down the card.

| File | Change |
| ---- | ------ |
| `components/PreferenceMemoryCard.tsx` | `tags`/`suggestions` → `safeTags`/`safeSuggestions`; all `.length` guards and `.map` call sites use the normalized arrays |
| `components/ExperienceMemoryCard.tsx` | same `tags` → `safeTags` pattern |
| `Render/SearchUserMemory/index.tsx` | one guard in the shared `MemoryItem` covers activities/contexts/experiences/identities/preferences |
| `Inspector/SearchUserMemory/index.tsx` | `queries.join(', ')` guarded via `Array.isArray` (same failure class on scalar args) |

`QueryTaxonomyOptions` was intentionally left alone: it reads structured `pluginState` (execution result) and only does `.length`, so it is not exposed to scalar-vs-array model output.

#### 🧪 How to Test

`tags`/`suggestions`/`queries` are normalized with `Array.isArray` before any `.map`/`.join`/`.length`, so a scalar value falls back to `[]`/`''` and the branch is skipped rather than throwing. Verified `bun run check --lint` is clean on all four files and the touched files produce no type errors.

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

A more thorough alternative is a single `schema.safeParse`/normalize pass at the executor or render entry point; the `Array.isArray` guards here are the minimal fix scoped to the render-crash symptom.