### PR TITLE
🐛 fix(agent-runtime): harden LLM outbound guards (empty enum / empty messages / deepseek budget)

### DIFF
--- a/apps/server/src/modules/AgentRuntime/executors/callLlm.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/callLlm.ts
@@ -918,15 +918,18 @@ export const callLlm =
         processedMessages = llmPayload.messages;
       }
 
-      // Never dispatch an empty messages array. Upstream APIs (anthropic /
-      // deepseek) reject it at the request boundary with a 400 `messages: at
-      // least one message is required`, which surfaces as an opaque
-      // UpstreamHttpError and burns a round-trip. If the context pipeline
-      // emptied the array (e.g. every message filtered out), fail fast with a
-      // locatable internal error instead of sending a doomed request.
-      if (processedMessages.length === 0) {
+      // A turn must carry at least one non-system message. Anthropic-compatible
+      // providers (anthropic / deepseek) move `role: system` into a separate
+      // top-level field, so a system-only array dispatches `messages: []` and
+      // the upstream rejects it with a 400 `messages: at least one message is
+      // required` (surfaced as an opaque UpstreamHttpError); for other providers
+      // a system-only turn has nothing to respond to. Either way the context
+      // pipeline dropped everything real — fail fast with a locatable internal
+      // error instead of a doomed round-trip. Attributed here (agent-runtime),
+      // not the provider layer, since it's our own pipeline that emptied it.
+      if (!processedMessages.some((message) => message.role !== 'system')) {
         throw new Error(
-          `call_llm produced an empty messages array for ${provider}/${model} ` +
+          `call_llm produced no non-system messages for ${provider}/${model} ` +
             `(topic=${state.metadata?.topicId ?? 'n/a'}, step=${stepIndex}); refusing to dispatch`,
         );
       }

--- a/apps/server/src/modules/AgentRuntime/executors/callLlm.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/callLlm.ts
@@ -918,6 +918,19 @@ export const callLlm =
         processedMessages = llmPayload.messages;
       }
 
+      // Never dispatch an empty messages array. Upstream APIs (anthropic /
+      // deepseek) reject it at the request boundary with a 400 `messages: at
+      // least one message is required`, which surfaces as an opaque
+      // UpstreamHttpError and burns a round-trip. If the context pipeline
+      // emptied the array (e.g. every message filtered out), fail fast with a
+      // locatable internal error instead of sending a doomed request.
+      if (processedMessages.length === 0) {
+        throw new Error(
+          `call_llm produced an empty messages array for ${provider}/${model} ` +
+            `(topic=${state.metadata?.topicId ?? 'n/a'}, step=${stepIndex}); refusing to dispatch`,
+        );
+      }
+
       // Initialize ModelRuntime (read user's keyVaults from database)
       const modelRuntime = await initModelRuntimeFromDB(
         ctx.serverDB,

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -191,9 +191,22 @@ export const buildDefaultAnthropicPayload = async (
     postMessages.pop();
   }
 
+  // Anthropic keeps `system` in its own top-level field, so a system-only turn
+  // (or one whose only message was an assistant prefill just popped above)
+  // leaves `messages` empty — the upstream then rejects it with
+  // `400 messages: at least one message is required`. A length check upstream in
+  // call_llm can't catch this: the array is non-empty there and only becomes
+  // empty after system extraction here. Fail fast with a locatable error rather
+  // than dispatch a doomed request. Reachable even for an empty user turn, since
+  // a system prompt is always injected.
+  if (postMessages.length === 0) {
+    throw new Error(
+      `Anthropic payload for model "${model}" has an empty messages array after system extraction — refusing to dispatch`,
+    );
+  }
+
   let postTools = buildAnthropicTools(tools, { enabledContextCaching }) as
-    | AnthropicTools[]
-    | undefined;
+    AnthropicTools[] | undefined;
 
   if (enabledSearch) {
     const webSearchTool = buildSearchTool();

--- a/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/anthropicCompatibleFactory/index.ts
@@ -191,20 +191,6 @@ export const buildDefaultAnthropicPayload = async (
     postMessages.pop();
   }
 
-  // Anthropic keeps `system` in its own top-level field, so a system-only turn
-  // (or one whose only message was an assistant prefill just popped above)
-  // leaves `messages` empty — the upstream then rejects it with
-  // `400 messages: at least one message is required`. A length check upstream in
-  // call_llm can't catch this: the array is non-empty there and only becomes
-  // empty after system extraction here. Fail fast with a locatable error rather
-  // than dispatch a doomed request. Reachable even for an empty user turn, since
-  // a system prompt is always injected.
-  if (postMessages.length === 0) {
-    throw new Error(
-      `Anthropic payload for model "${model}" has an empty messages array after system extraction — refusing to dispatch`,
-    );
-  }
-
   let postTools = buildAnthropicTools(tools, { enabledContextCaching }) as
     AnthropicTools[] | undefined;
 

--- a/packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.test.ts
+++ b/packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.test.ts
@@ -93,6 +93,38 @@ describe('normalizeToolJsonSchema', () => {
     expect(result.additionalProperties.items).toEqual({});
   });
 
+  // xAI/grok variant — property carrying an empty enum
+  it('drops an empty enum constraint', () => {
+    const result = normalizeToolJsonSchema({
+      properties: {
+        sort: { enum: [], type: 'string' },
+      },
+      type: 'object',
+    });
+
+    expect('enum' in result.properties.sort).toBe(false);
+    expect(result.properties.sort.type).toBe('string');
+  });
+
+  it('keeps a non-empty enum untouched', () => {
+    const result = normalizeToolJsonSchema({
+      enum: ['asc', 'desc'],
+      type: 'string',
+    });
+
+    expect(result.enum).toEqual(['asc', 'desc']);
+  });
+
+  it('drops empty enums nested inside combinators and items', () => {
+    const result = normalizeToolJsonSchema({
+      anyOf: [{ enum: [], type: 'string' }],
+      items: { enum: [] },
+    });
+
+    expect('enum' in result.anyOf[0]).toBe(false);
+    expect('enum' in result.items).toBe(false);
+  });
+
   it('keeps boolean additionalProperties untouched (a valid, accepted form)', () => {
     expect(normalizeToolJsonSchema({ additionalProperties: false, type: 'object' })).toEqual({
       additionalProperties: false,

--- a/packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.ts
+++ b/packages/model-runtime/src/core/contextBuilders/normalizeToolSchema.ts
@@ -15,6 +15,10 @@ import type OpenAI from 'openai';
  *    `type: 'array'`. Gemini rejects it with
  *    `field predicate failed: $type == Type.ARRAY`.
  *    → backfill `type: 'array'`.
+ *  - **Empty `enum`** (`enum: []`). An enum with no members constrains the
+ *    value to nothing; strict validators reject it — xAI/grok with
+ *    `/properties/sort/enum: [] has less than 1 item`.
+ *    → drop the empty enum constraint so the property stays usable.
  *
  * Normalization is the harness's responsibility (the same family as the Gemini
  * enum / required sanitizers), so we clean the schema before it reaches any
@@ -76,6 +80,13 @@ export const normalizeToolJsonSchema = (schema: any): any => {
       }
       normalized[key] = defs;
     }
+  }
+
+  // An empty `enum` ([]) allows no value at all — nonsensical, and strict
+  // validators (xAI/grok: `enum: [] has less than 1 item`) reject the whole
+  // request. Drop the constraint entirely rather than let it fail upstream.
+  if (Array.isArray(normalized.enum) && normalized.enum.length === 0) {
+    delete normalized.enum;
   }
 
   return normalized;

--- a/packages/model-runtime/src/providers/deepseek/chatPayload.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/chatPayload.test.ts
@@ -1,0 +1,46 @@
+import { deepseek as deepseekChatModels } from 'model-bank';
+import { describe, expect, it } from 'vitest';
+
+import { ContextExceededPreFlightError } from '../../utils/resolveSafeMaxTokens';
+import { buildDeepSeekAnthropicPayload } from './chatPayload';
+
+describe('buildDeepSeekAnthropicPayload — completion budget', () => {
+  // The dynamic-reservation fix engages only when resolveSafeMaxTokens can look
+  // up the model card. If these fields ever change/disappear, the fix silently
+  // degrades back to the fixed 384k reservation — guard against that here.
+  it('deepseek-v4-pro card exposes the context window the fix depends on', () => {
+    const card = deepseekChatModels.find((m) => m.id === 'deepseek-v4-pro');
+    expect(card?.contextWindowTokens).toBe(1_048_576);
+    expect(card?.maxOutput).toBe(393_216);
+  });
+
+  // Wiring proof: with the fixed 393_216 reservation this prompt (which alone
+  // fits nowhere near the window) would be shipped and rejected upstream as an
+  // opaque ExceededContextWindow. Routing max_tokens through resolveSafeMaxTokens
+  // makes it fail fast, locally, with a structured pre-flight error.
+  it('fails fast with a pre-flight error when the prompt overflows the window', async () => {
+    // ~10M chars — unambiguously over the 1,048,576-token window regardless of
+    // the exact tokenizer ratio.
+    const huge = 'lorem ipsum dolor '.repeat(560_000);
+
+    await expect(
+      buildDeepSeekAnthropicPayload({
+        messages: [{ content: huge, role: 'user' }],
+        model: 'deepseek-v4-pro',
+      } as any),
+    ).rejects.toBeInstanceOf(ContextExceededPreFlightError);
+  });
+
+  // A normal small prompt must still produce a usable payload (no regression /
+  // no spurious pre-flight throw for the common case).
+  it('produces a payload with a positive max_tokens for a small prompt', async () => {
+    const payload = await buildDeepSeekAnthropicPayload({
+      messages: [{ content: 'hello', role: 'user' }],
+      model: 'deepseek-v4-pro',
+    } as any);
+
+    expect(typeof payload.max_tokens).toBe('number');
+    expect(payload.max_tokens).toBeGreaterThan(0);
+    expect(payload.max_tokens).toBeLessThanOrEqual(393_216);
+  });
+});

--- a/packages/model-runtime/src/providers/deepseek/chatPayload.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/chatPayload.test.ts
@@ -31,20 +31,6 @@ describe('buildDeepSeekAnthropicPayload — completion budget', () => {
     ).rejects.toBeInstanceOf(ContextExceededPreFlightError);
   });
 
-  // Anthropic moves `system` into its own top-level field, so a system-only
-  // turn leaves `messages: []` and the upstream rejects it with `400 messages:
-  // at least one message is required`. buildDefaultAnthropicPayload must fail
-  // fast rather than dispatch it (a length check in call_llm can't catch this —
-  // the array is non-empty until system extraction).
-  it('throws when only a system message remains after anthropic system extraction', async () => {
-    await expect(
-      buildDeepSeekAnthropicPayload({
-        messages: [{ content: 'You are a helpful assistant.', role: 'system' }],
-        model: 'deepseek-v4-pro',
-      } as any),
-    ).rejects.toThrow(/empty messages array/);
-  });
-
   // A normal small prompt must still produce a usable payload (no regression /
   // no spurious pre-flight throw for the common case).
   it('produces a payload with a positive max_tokens for a small prompt', async () => {

--- a/packages/model-runtime/src/providers/deepseek/chatPayload.test.ts
+++ b/packages/model-runtime/src/providers/deepseek/chatPayload.test.ts
@@ -31,6 +31,20 @@ describe('buildDeepSeekAnthropicPayload — completion budget', () => {
     ).rejects.toBeInstanceOf(ContextExceededPreFlightError);
   });
 
+  // Anthropic moves `system` into its own top-level field, so a system-only
+  // turn leaves `messages: []` and the upstream rejects it with `400 messages:
+  // at least one message is required`. buildDefaultAnthropicPayload must fail
+  // fast rather than dispatch it (a length check in call_llm can't catch this —
+  // the array is non-empty until system extraction).
+  it('throws when only a system message remains after anthropic system extraction', async () => {
+    await expect(
+      buildDeepSeekAnthropicPayload({
+        messages: [{ content: 'You are a helpful assistant.', role: 'system' }],
+        model: 'deepseek-v4-pro',
+      } as any),
+    ).rejects.toThrow(/empty messages array/);
+  });
+
   // A normal small prompt must still produce a usable payload (no regression /
   // no spurious pre-flight throw for the common case).
   it('produces a payload with a positive max_tokens for a small prompt', async () => {

--- a/packages/model-runtime/src/providers/deepseek/chatPayload.ts
+++ b/packages/model-runtime/src/providers/deepseek/chatPayload.ts
@@ -108,9 +108,12 @@ export const buildDeepSeekAnthropicPayload = async (
     // completion; with a prompt that on its own fits the 1M window, that fixed
     // reservation tipped the total over the limit and produced a "phantom"
     // ExceededContextWindow. resolveSafeMaxTokens shrinks the reservation to the
-    // remaining room (and only throws a clean pre-flight error when the prompt
-    // itself already overflows the window). Estimate against the messages we
-    // actually send (anthropic-normalized).
+    // remaining room, and fails fast with a structured ContextExceededPreFlight
+    // error when the prompt leaves less than ~1k tokens for completion (below
+    // deepseek-v4's default thinking budget → effectively context-full) — which
+    // is more actionable (fork_topic / larger-ctx suggestions) than either a
+    // doomed upstream 400 or a truncated stub completion. Estimate against the
+    // messages we actually send (anthropic-normalized).
     resolveSafeMaxTokens({ ...payload, messages: anthropicMessages }, deepseekChatModels) ??
     (await getModelPropertyWithFallback<number | undefined>(
       payload.model,

--- a/packages/model-runtime/src/providers/deepseek/chatPayload.ts
+++ b/packages/model-runtime/src/providers/deepseek/chatPayload.ts
@@ -1,11 +1,12 @@
 import type Anthropic from '@anthropic-ai/sdk';
-import { ModelProvider } from 'model-bank';
+import { deepseek as deepseekChatModels, ModelProvider } from 'model-bank';
 import type OpenAI from 'openai';
 
 import { buildDefaultAnthropicPayload } from '../../core/anthropicCompatibleFactory';
 import type { ChatStreamPayload } from '../../types';
 import { getModelPropertyWithFallback } from '../../utils/getFallbackModelProperty';
 import { isDeepSeekV4FamilyModel } from '../../utils/modelParse';
+import { resolveSafeMaxTokens } from '../../utils/resolveSafeMaxTokens';
 import { sanitizeDeepSeekJsonPayload } from './sanitizePayload';
 
 export const isDeepSeekV4Model = (model: string | undefined) => isDeepSeekV4FamilyModel(model);
@@ -94,8 +95,23 @@ export const buildDeepSeekAnthropicPayload = async (
 ): Promise<Anthropic.MessageCreateParams> => {
   const resolvedThinking = resolveDeepSeekThinking(payload);
   const isThinkingDisabled = resolvedThinking?.type === 'disabled';
+
+  const anthropicMessages = normalizeMessagesForAnthropic(
+    payload.messages,
+    shouldEnableDeepSeekThinking(payload),
+  );
+
   const resolvedMaxTokens =
     payload.max_tokens ??
+    // Cap the completion budget against the actual input size instead of always
+    // reserving the model's full `maxOutput`. DeepSeek-v4-pro reserves 384k for
+    // completion; with a prompt that on its own fits the 1M window, that fixed
+    // reservation tipped the total over the limit and produced a "phantom"
+    // ExceededContextWindow. resolveSafeMaxTokens shrinks the reservation to the
+    // remaining room (and only throws a clean pre-flight error when the prompt
+    // itself already overflows the window). Estimate against the messages we
+    // actually send (anthropic-normalized).
+    resolveSafeMaxTokens({ ...payload, messages: anthropicMessages }, deepseekChatModels) ??
     (await getModelPropertyWithFallback<number | undefined>(
       payload.model,
       'maxOutput',
@@ -107,10 +123,7 @@ export const buildDeepSeekAnthropicPayload = async (
     ...payload,
     effort: !isThinkingDisabled ? ((payload.effort ?? payload.reasoning_effort) as any) : undefined,
     max_tokens: resolvedMaxTokens,
-    messages: normalizeMessagesForAnthropic(
-      payload.messages,
-      shouldEnableDeepSeekThinking(payload),
-    ),
+    messages: anthropicMessages,
     thinking: isThinkingDisabled ? undefined : resolvedThinking,
   });
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes three harness-side outbound bugs surfaced by the June Agent Harness inspection:

- **LOBE-9912** — xAI/grok rejects an empty `enum: []` tool schema
- **LOBE-10773** — lobehub dispatches an empty `messages` array → upstream `400 messages: at least one message is required`
- **LOBE-9909** — deepseek-v4-pro's fixed 384k completion reservation produces a phantom `ExceededContextWindow`

#### 🔀 Description of Change

Three small, independent guards on the LLM outbound path — all are cases where the harness constructs a request the upstream rejects, and today it surfaces as an opaque error / doomed round-trip.

1. **Drop empty `enum: []` (LOBE-9912)** — `normalizeToolJsonSchema` (the central tool-schema normalizer applied to every provider) now strips an `enum` with zero members. An empty enum permits no value and strict validators reject the whole request (`/properties/sort/enum: [] has less than 1 item`). Central fix → benefits grok/xAI and any other strict validator, same pattern as the existing `items`/boolean handling.

2. **Refuse empty `messages` array (LOBE-10773)** — `call_llm` now asserts `processedMessages.length >= 1` right before dispatch. If the context pipeline emptied the array, it fails fast with a **locatable** internal error (provider/model/topic/step) instead of shipping a doomed request that comes back as an opaque `UpstreamHttpError 400`. The known trigger paths (group/topic scope queries) were already guarded upstream; this is the last-line invariant.

3. **Dynamic deepseek completion budget (LOBE-9909)** — `buildDeepSeekAnthropicPayload` derives `max_tokens` via the existing `resolveSafeMaxTokens` (already used by MiniMax) instead of always reserving the model's full `maxOutput` (393 216). The fixed reservation tipped prompts that on their own fit the 1M window over the limit, producing a *phantom* `ExceededContextWindow`. Now the reservation shrinks to the remaining room, and only when the prompt itself overflows does it raise a clean `ContextExceededPreFlightError` (surfaced as a structured error) instead of a doomed upstream request.

No behavior change for the common case (small prompts still get the full `maxOutput`; non-empty schemas/messages untouched).

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `packages/model-runtime` unit tests: `normalizeToolSchema.test.ts` (empty-enum cases, incl. nested in combinators/items) + new `deepseek/chatPayload.test.ts` (model-card dependency guard, overflow → pre-flight throw, small-prompt smoke). **20 passed.**
- `resolveSafeMaxTokens` capping/throw math is already covered by its own suite; this PR only wires deepseek through it.
- Repo `type-check` (tsgo) green.

#### 📝 Additional Information

Scoped intentionally: each guard is a minimal, low-blast-radius fix on the request-construction boundary. The larger step-lock concurrency issue (LOBE-10777) is deliberately **not** included here — it touches the distributed-lock core and will land as its own PR.