### PR TITLE
⚡️ perf(memory): skip unchanged persona upserts

### DIFF
--- a/packages/database/src/models/userMemory/__tests__/persona.test.ts
+++ b/packages/database/src/models/userMemory/__tests__/persona.test.ts
@@ -67,6 +67,36 @@ describe('UserPersonaModel', () => {
     expect(persisted).toHaveLength(1);
   });
 
+  it('returns the existing document without updating unchanged persona content', async () => {
+    const { document: created } = await personaModel.upsertPersona({
+      memoryIds: ['mem-1'],
+      persona: '# stable persona',
+      sourceIds: ['src-1'],
+      tagline: 'Stable',
+    });
+    const existingDiffs = await serverDB.query.userPersonaDocumentHistories.findMany({
+      where: (t, { eq }) => eq(t.userId, userId),
+    });
+
+    const { diff, document } = await personaModel.upsertPersona({
+      memoryIds: ['mem-1'],
+      persona: '# stable persona',
+      sourceIds: ['src-1'],
+      tagline: 'Stable',
+    });
+
+    expect(diff).toBeUndefined();
+    expect(document.id).toBe(created.id);
+    expect(document.version).toBe(1);
+    expect(document.updatedAt).toEqual(created.updatedAt);
+    expect(document.accessedAt).toEqual(created.accessedAt);
+
+    const persisted = await serverDB.query.userPersonaDocumentHistories.findMany({
+      where: (t, { eq }) => eq(t.userId, userId),
+    });
+    expect(persisted).toHaveLength(existingDiffs.length);
+  });
+
   it('skips diff insert when no diff content supplied', async () => {
     const { diff } = await personaModel.upsertPersona({
       persona: '# only persona',

--- a/packages/database/src/models/userMemory/persona.ts
+++ b/packages/database/src/models/userMemory/persona.ts
@@ -1,4 +1,5 @@
 import { and, desc, eq } from 'drizzle-orm';
+import isEqual from 'fast-deep-equal';
 
 import type {
   NewUserPersonaDocument,
@@ -93,22 +94,36 @@ export class UserPersonaModel {
         ),
       });
       const nextVersion = (existing?.version ?? 0) + 1;
+      const nextMemoryIds = params.memoryIds ?? existing?.memoryIds ?? undefined;
+      const nextMetadata = params.metadata ?? existing?.metadata ?? undefined;
+      const nextProfile = params.profile ?? 'default';
+      const nextSourceIds = params.sourceIds ?? existing?.sourceIds ?? undefined;
+      const nextTagline = params.tagline ?? existing?.tagline ?? undefined;
 
       const baseDocument: Omit<NewUserPersonaDocument, 'id' | 'userId'> = {
         capturedAt: params.capturedAt,
-        memoryIds: params.memoryIds ?? undefined,
-        metadata: params.metadata ?? undefined,
+        memoryIds: nextMemoryIds,
+        metadata: nextMetadata,
         persona: params.persona,
-        profile: params.profile ?? 'default',
-        sourceIds: params.sourceIds ?? undefined,
-        tagline: params.tagline ?? undefined,
+        profile: nextProfile,
+        sourceIds: nextSourceIds,
+        tagline: nextTagline,
         version: nextVersion,
       };
 
       let document: UserPersonaDocument;
 
       if (existing) {
-        [document] = await tx
+        const hasDocumentChanges =
+          existing.persona !== params.persona ||
+          existing.tagline !== (nextTagline ?? null) ||
+          !isEqual(existing.memoryIds, nextMemoryIds ?? null) ||
+          !isEqual(existing.sourceIds, nextSourceIds ?? null) ||
+          !isEqual(existing.metadata, nextMetadata ?? null);
+
+        if (!hasDocumentChanges) return { document: existing };
+
+        const [updated] = await tx
           .update(userPersonaDocuments)
           .set({ ...baseDocument, updatedAt: new Date() })
           .where(
@@ -117,7 +132,30 @@ export class UserPersonaModel {
               eq(userPersonaDocuments.userId, this.userId),
             ),
           )
-          .returning();
+          .returning({
+            accessedAt: userPersonaDocuments.accessedAt,
+            capturedAt: userPersonaDocuments.capturedAt,
+            createdAt: userPersonaDocuments.createdAt,
+            id: userPersonaDocuments.id,
+            updatedAt: userPersonaDocuments.updatedAt,
+            version: userPersonaDocuments.version,
+          });
+
+        document = {
+          ...existing,
+          accessedAt: updated.accessedAt,
+          capturedAt: updated.capturedAt,
+          createdAt: updated.createdAt,
+          id: updated.id,
+          memoryIds: nextMemoryIds ?? null,
+          metadata: nextMetadata ?? null,
+          persona: params.persona,
+          profile: nextProfile,
+          sourceIds: nextSourceIds ?? null,
+          tagline: nextTagline ?? null,
+          updatedAt: updated.updatedAt,
+          version: updated.version,
+        };
       } else {
         [document] = await tx
           .insert(userPersonaDocuments)


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No linked issue.

#### 🔀 Description of Change

- Skip persona document UPDATEs when the requested persona content, tagline, memory IDs, source IDs, and metadata are unchanged.
- Narrow UPDATE RETURNING for changed persona documents to small metadata fields, then compose the returned model from existing data plus the requested payload.
- Add a regression test proving unchanged persona upserts keep version and timestamps stable and do not create additional history rows.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands:

```bash
pnpm exec vitest run --silent='passed-only' 'src/models/userMemory/__tests__/persona.test.ts'
pnpm exec eslint lobehub/packages/database/src/models/userMemory/persona.ts lobehub/packages/database/src/models/userMemory/__tests__/persona.test.ts
```

Note: the clean worktree used for the PR did not have dependencies installed, so final verification reused the main workspace. A root `pnpm run type-check` is currently blocked by an unrelated existing `FloatingPanel` export error in `lobehub/src/features/AgentTasks/AgentTaskDetail/TopicChatDrawer/index.tsx`.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This PR intentionally keeps the schema unchanged. It targets the low-risk query hot path first: avoid no-op writes and avoid returning large persona text from UPDATE statements when a write is necessary.