### PR TITLE
🐛 fix(skills): teach agent-browser skill to diagnose anti-bot blocks

### DIFF
--- a/packages/builtin-skills/src/agent-browser/content.ts
+++ b/packages/builtin-skills/src/agent-browser/content.ts
@@ -31,7 +31,7 @@ When scraping dynamic or anti-bot pages, escalate from cheap to heavy and stop a
 Rung transitions are diagnoses, not retries — recognize "blocked" instead of re-trying the same rung:
 
 - **Blocked looks exactly like "not loaded"**: after ONE \`wait --load networkidle\`, an empty/near-empty body (\`agent-browser eval "document.body.innerText.length"\` returns ~0) means you are fingerprinted, not slow. Extra waits, longer timeouts, or re-screenshots cannot fix a fingerprint — go straight to rung 3.
-- **Other block signals**: a JS-challenge cookie (\`cf_clearance\`, \`*_jsl_clearance*\`, \`acw_tc\`, …) or a response that is mostly obfuscated JS. Seeing one of these at any point = already blocked, escalate immediately.
+- **Other block signals**: a response that is mostly obfuscated challenge JS, or a JS-challenge cookie (\`cf_clearance\`, \`*_jsl_clearance*\`, \`acw_tc\`, …) alongside an empty or challenge-page body. A clearance cookie next to real content means the challenge already passed — keep the session and read the page.
 - **\`--headed\` is NOT an escalation rung**: it only opens a window on the same automation-launched browser, so the fingerprint is unchanged. The real escalation is attaching to the user's own Chrome via \`--cdp\`.
 - When a rung fails, come back to this ladder — don't improvise ad-hoc diagnostics (curl retry loops, one-off python scripts, killing processes).
 

--- a/packages/builtin-skills/src/agent-browser/content.ts
+++ b/packages/builtin-skills/src/agent-browser/content.ts
@@ -16,6 +16,8 @@ agent-browser snapshot -i    # 4. re-snapshot after any page change
 
 Refs become **stale on every page change** (click that navigates, form submit, dynamic re-render, dialog open). Always re-snapshot before the next ref interaction.
 
+If a page opens to an empty body or a verification/challenge screen, treat it as anti-bot fingerprinting — jump to the escalation ladder below instead of waiting longer or retrying.
+
 When the task is done, run \`agent-browser close\` and quit any Chrome you launched for CDP — browsers opened for the task otherwise stay on the user's machine.
 
 ## Dynamic pages & anti-bot escalation
@@ -26,9 +28,16 @@ When scraping dynamic or anti-bot pages, escalate from cheap to heavy and stop a
 2. **Empty body, verification page, or obfuscated JS** → the page needs a real JS run: \`agent-browser open <url>\`, \`agent-browser wait --load networkidle\`, then \`agent-browser read\` (or \`snapshot\`).
 3. **Still blocked** (anti-bot that fingerprints headless Chrome) → connect to a real browser: launch Chrome with \`--remote-debugging-port=9222\` (Chrome 136+ also requires a separate \`--user-data-dir\`), then drive it with \`agent-browser --cdp 9222 <command>\` — a real browser fingerprint usually passes in one go.
 
-Discipline: the crux of anti-bot checks is "did a real browser execute the JS", so the closer to a human environment, the easier it passes. Verify you actually got content with \`agent-browser eval "document.body.innerText.length"\` (0 means blocked). Dump large output to a file first, then \`grep\`/\`head\` it.
+Rung transitions are diagnoses, not retries — recognize "blocked" instead of re-trying the same rung:
+
+- **Blocked looks exactly like "not loaded"**: after ONE \`wait --load networkidle\`, an empty/near-empty body (\`agent-browser eval "document.body.innerText.length"\` returns ~0) means you are fingerprinted, not slow. Extra waits, longer timeouts, or re-screenshots cannot fix a fingerprint — go straight to rung 3.
+- **Other block signals**: a JS-challenge cookie (\`cf_clearance\`, \`*_jsl_clearance*\`, \`acw_tc\`, …) or a response that is mostly obfuscated JS. Seeing one of these at any point = already blocked, escalate immediately.
+- **\`--headed\` is NOT an escalation rung**: it only opens a window on the same automation-launched browser, so the fingerprint is unchanged. The real escalation is attaching to the user's own Chrome via \`--cdp\`.
+- When a rung fails, come back to this ladder — don't improvise ad-hoc diagnostics (curl retry loops, one-off python scripts, killing processes).
+
+Discipline: the crux of anti-bot checks is "did a real browser execute the JS", so the closer to a human environment, the easier it passes. Always verify you actually got content with \`agent-browser eval "document.body.innerText.length"\` before declaring success. Dump large output to a file first, then \`grep\`/\`head\` it.
 
 ## Discovering everything else
 
-Run \`agent-browser --help\` for the full command list, then \`agent-browser <subcommand> --help\` for any subcommand whose flags you're unsure about. The CLI also ships specialized skills (\`agent-browser skills list\`, \`agent-browser skills get <name>\`) covering Electron apps, Slack, dogfooding, Vercel Sandbox, and AWS Bedrock AgentCore — load one only when the task falls outside ordinary web pages.
+Run \`agent-browser --help\` for the full command list, then \`agent-browser <subcommand> --help\` for any subcommand whose flags you're unsure about. The CLI also ships specialized skills (\`agent-browser skills list\`, \`agent-browser skills get <name>\`) covering Electron apps, Slack, dogfooding, Vercel Sandbox, and AWS Bedrock AgentCore — load one only when the task falls outside ordinary web pages. Those docs are command references; the anti-bot escalation ladder above still governs how you respond to blocked pages.
 </agent_browser_guides>`;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Related to #16722, #16759

#### 🔀 Description of Change

Follow-up to #16722 / #16759. The anti-bot escalation ladder is in the agent-browser skill prompt, but a real session (Sonnet 5) still fumbled: it treated an empty headless body as a slow-loading page (looping `wait networkidle` / longer timeouts / re-screenshots), invented `--headed` as an intermediate escalation rung, and ignored a `_jsl_clearance`-style challenge cookie it had already seen. Root cause: the ladder said *how to escalate* but never *how to recognize you are blocked*.

This PR adds the missing diagnosis rules to the skill prompt:

- **Early tripwire in the core loop**: empty body / verification page on open → jump to the escalation ladder, don't wait or retry.
- **"Blocked looks exactly like not-loaded"**: after ONE `wait --load networkidle`, a near-empty body means fingerprinted, not slow — extra waits/timeouts/screenshots can't fix a fingerprint; go straight to CDP.
- **Block signals list**: JS-challenge cookies (`cf_clearance`, `*_jsl_clearance*`, `acw_tc`, …) or mostly-obfuscated-JS responses = already blocked, escalate immediately.
- **`--headed` explicitly called out as NOT an escalation rung** — same automation fingerprint; the only real escalation is attaching to the user's own Chrome via `--cdp`.
- When a rung fails, return to the ladder instead of improvising ad-hoc diagnostics (curl retry loops, one-off scripts, killing processes).
- CLI-served skill docs (`skills get core`) are command references; the ladder still governs blocked-page handling.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Prompt-only change (`packages/builtin-skills/src/agent-browser/content.ts`); lint clean via `bun run check`.

#### 📝 Additional Information

Key decisions:

- Kept rung 2's single `wait --load networkidle` (legitimate for genuinely dynamic pages) but bounded it to one attempt before diagnosing as blocked.
- Cookie names are examples, not an exhaustive list — the operative rule is "challenge cookie or obfuscated JS = blocked", so new vendors still match.