### PR TITLE
🐛 fix(oidc): define explicit artifact TTLs

### DIFF
--- a/src/libs/oidc-provider/provider.test.ts
+++ b/src/libs/oidc-provider/provider.test.ts
@@ -72,6 +72,38 @@ describe('OIDC Provider - Market Client Integration', () => {
       vi.doUnmock('@/envs/app');
     }, 10000);
 
+    it('should define numeric TTLs for all OIDC provider artifacts', async () => {
+      vi.doMock('@/envs/app', () => ({
+        appEnv: {
+          APP_URL: 'https://example.com',
+          MARKET_BASE_URL: undefined,
+        },
+      }));
+
+      const module = await import('./provider');
+
+      expect(module.oidcArtifactTTL).toEqual({
+        AccessToken: 7 * 24 * 60 * 60,
+        AuthorizationCode: 600,
+        BackchannelAuthenticationRequest: 600,
+        ClientCredentials: 600,
+        DeviceCode: 600,
+        Grant: 14 * 24 * 60 * 60,
+        IdToken: 3600,
+        Interaction: 3600,
+        RefreshToken: 30 * 24 * 60 * 60,
+        Session: 30 * 24 * 60 * 60,
+      });
+
+      for (const ttl of Object.values(module.oidcArtifactTTL)) {
+        expect(typeof ttl).toBe('number');
+        expect(Number.isSafeInteger(ttl)).toBe(true);
+        expect(ttl).toBeGreaterThan(0);
+      }
+
+      vi.doUnmock('@/envs/app');
+    }, 10000);
+
     it('should have createOIDCProvider function', async () => {
       vi.doMock('@/envs/app', () => ({
         appEnv: {

--- a/src/libs/oidc-provider/provider.ts
+++ b/src/libs/oidc-provider/provider.ts
@@ -1,6 +1,6 @@
-import { type LobeChatDatabase } from '@lobechat/database';
+import type { LobeChatDatabase } from '@lobechat/database';
 import debug from 'debug';
-import { type Configuration, type KoaContextWithOIDC } from 'oidc-provider';
+import type { Configuration, KoaContextWithOIDC } from 'oidc-provider';
 import Provider, { errors } from 'oidc-provider';
 import urlJoin from 'url-join';
 
@@ -18,6 +18,24 @@ import { createInteractionPolicy } from './interaction-policy';
 const logProvider = debug('lobe-oidc:provider');
 
 export const API_AUDIENCE = 'urn:lobehub:chat';
+
+const MINUTE_SECONDS = 60;
+const HOUR_SECONDS = 60 * MINUTE_SECONDS;
+const DAY_SECONDS = 24 * HOUR_SECONDS;
+
+// Keep all artifact TTLs explicit; oidc-provider validates its default TTL functions at runtime.
+export const oidcArtifactTTL = {
+  AccessToken: 7 * DAY_SECONDS,
+  AuthorizationCode: 10 * MINUTE_SECONDS,
+  BackchannelAuthenticationRequest: 10 * MINUTE_SECONDS,
+  ClientCredentials: 10 * MINUTE_SECONDS,
+  DeviceCode: 10 * MINUTE_SECONDS,
+  Grant: 14 * DAY_SECONDS,
+  IdToken: HOUR_SECONDS,
+  Interaction: HOUR_SECONDS,
+  RefreshToken: 30 * DAY_SECONDS,
+  Session: 30 * DAY_SECONDS,
+} satisfies NonNullable<Configuration['ttl']>;
 
 /**
  * Get cookie keys using KEY_VAULTS_SECRET
@@ -243,8 +261,7 @@ export const createOIDCProvider = async (db: LobeChatDatabase): Promise<Provider
         // Read the ui_locales parameter from the OIDC request (space-separated language priorities)
         // https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
         const uiLocalesRaw = (interaction.params?.ui_locales || ctx.oidc?.params?.ui_locales) as
-          | string
-          | undefined;
+          string | undefined;
 
         let query = '';
         if (uiLocalesRaw) {
@@ -303,17 +320,7 @@ export const createOIDCProvider = async (db: LobeChatDatabase): Promise<Provider
     scopes: defaultScopes,
 
     // 8. Token TTL
-    ttl: {
-      AccessToken: 7 * 24 * 3600, // 7 days
-      AuthorizationCode: 600, // 10 minutes
-      DeviceCode: 600, // 10 minutes (if enabled)
-
-      IdToken: 3600, // 1 hour
-      Interaction: 3600, // 1 hour
-
-      RefreshToken: 30 * 24 * 60 * 60, // 30 days
-      Session: 30 * 24 * 60 * 60, // 30 days
-    },
+    ttl: oidcArtifactTTL,
   };
 
   // Create provider instance


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching GitHub issue found.

#### 🔀 Description of Change

`lh login` failed when the CLI started the device authorization flow against `POST /oidc/device/auth`. The server returned `500 Internal Server Error` with this message:

```text
ttl.BackchannelAuthenticationRequest must be a positive integer or a regular function returning one
```

The OIDC provider configuration only set numeric TTLs for part of the artifact set. The remaining artifacts, including `BackchannelAuthenticationRequest`, fell back to `oidc-provider` default TTL functions. In the production route runtime, `oidc-provider` rejected that default function during TTL validation before the device authorization request could start.

This PR makes all OIDC artifact TTLs explicit positive integers and reuses one typed `oidcArtifactTTL` object in the provider configuration. It also adds a regression test that asserts every configured TTL is numeric, safe, and positive.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check src/libs/oidc-provider/provider.ts src/libs/oidc-provider/provider.test.ts --lint --test --type
```

Result:

```text
✓ 2 files · lint clean · tests 17 passed · types clean
```

#### 📸 Screenshots / Videos

N/A. Backend/OIDC configuration fix.

#### 📝 Additional Information

After deployment, `lh login` should be able to start the device authorization flow instead of failing before returning the device code.
