### PR TITLE
🐛 fix(agent-runtime): reuse placeholder on tool result resume

### DIFF
--- a/apps/server/src/services/aiAgent/__tests__/execAgent.resumeToolResult.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.resumeToolResult.test.ts
@@ -212,7 +212,10 @@ describe('AiAgentService.execAgent - resumeToolResult', () => {
     expect(mockCreateOperation).toHaveBeenCalledWith(
       expect.objectContaining({
         initialContext: expect.objectContaining({
-          payload: expect.objectContaining({ parentMessageId: 'tool-msg-1' }),
+          payload: expect.objectContaining({
+            assistantMessageId: 'assistant-msg-new',
+            parentMessageId: 'tool-msg-1',
+          }),
           phase: 'tool_result',
         }),
       }),

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -3240,7 +3240,10 @@ export class AiAgentService {
     if (resumeToolResult) {
       initialContext = {
         initialContext: initialContext.initialContext,
-        payload: { parentMessageId: resumeToolResult.parentMessageId } as any,
+        payload: {
+          assistantMessageId: assistantMessageRecord.id,
+          parentMessageId: resumeToolResult.parentMessageId,
+        } as any,
         phase: 'tool_result' as const,
         session: {
           messageCount: allMessages.length,

--- a/packages/agent-runtime/src/core/__tests__/runtime.test.ts
+++ b/packages/agent-runtime/src/core/__tests__/runtime.test.ts
@@ -377,6 +377,28 @@ describe('AgentRuntime', () => {
         expect(result.newState.pendingAssistantMessageId).toBe('msg_seeded_placeholder');
       });
 
+      it('should stash a tool_result-seeded assistantMessageId as pendingAssistantMessageId', async () => {
+        const agent = new MockAgent();
+        agent.runner = vi.fn(async (_context: AgentRuntimeContext, state: AgentState) => {
+          expect(state.pendingAssistantMessageId).toBe('msg_seeded_placeholder');
+          return { type: 'finish' as const, reason: 'completed' as const, reasonDetail: 'Done' };
+        });
+
+        const runtime = new AgentRuntime(agent);
+        const state = AgentRuntime.createInitialState({ operationId: 'test-session' });
+
+        const result = await runtime.step(
+          state,
+          createTestContext('tool_result', {
+            assistantMessageId: 'msg_seeded_placeholder',
+            parentMessageId: 'tool-msg-1',
+          }),
+        );
+
+        expect(agent.runner).toHaveBeenCalled();
+        expect(result.newState.pendingAssistantMessageId).toBe('msg_seeded_placeholder');
+      });
+
       // Consume-once: once a call_llm step runs it has filled (or replaced) the
       // seeded placeholder, so the seed must be cleared before the next step —
       // otherwise a later assistant turn would reuse the id and overwrite it.

--- a/packages/agent-runtime/src/core/__tests__/runtime.test.ts
+++ b/packages/agent-runtime/src/core/__tests__/runtime.test.ts
@@ -399,6 +399,21 @@ describe('AgentRuntime', () => {
         expect(result.newState.pendingAssistantMessageId).toBe('msg_seeded_placeholder');
       });
 
+      it('should allow payload-less tool_result contexts to reach the agent runner', async () => {
+        const agent = new MockAgent();
+        agent.runner = vi.fn(async () => ({
+          type: 'finish' as const,
+          reason: 'completed' as const,
+          reasonDetail: 'Done',
+        }));
+
+        const runtime = new AgentRuntime(agent);
+        const state = AgentRuntime.createInitialState({ operationId: 'test-session' });
+
+        await expect(runtime.step(state, createTestContext('tool_result'))).resolves.toBeDefined();
+        expect(agent.runner).toHaveBeenCalled();
+      });
+
       // Consume-once: once a call_llm step runs it has filled (or replaced) the
       // seeded placeholder, so the seed must be cleared before the next step —
       // otherwise a later assistant turn would reuse the id and overwrite it.

--- a/packages/agent-runtime/src/core/runtime.ts
+++ b/packages/agent-runtime/src/core/runtime.ts
@@ -138,10 +138,12 @@ export class AgentRuntime {
         };
       } else {
         if (runtimeContext.phase === 'tool_result') {
-          const toolResultPayload = runtimeContext.payload as {
-            assistantMessageId?: string;
-          };
-          if (toolResultPayload.assistantMessageId) {
+          const toolResultPayload = runtimeContext.payload as
+            | {
+                assistantMessageId?: string;
+              }
+            | undefined;
+          if (toolResultPayload?.assistantMessageId) {
             newState.pendingAssistantMessageId = toolResultPayload.assistantMessageId;
           }
         }

--- a/packages/agent-runtime/src/core/runtime.ts
+++ b/packages/agent-runtime/src/core/runtime.ts
@@ -137,6 +137,15 @@ export class AgentRuntime {
           type: 'call_tool',
         };
       } else {
+        if (runtimeContext.phase === 'tool_result') {
+          const toolResultPayload = runtimeContext.payload as {
+            assistantMessageId?: string;
+          };
+          if (toolResultPayload.assistantMessageId) {
+            newState.pendingAssistantMessageId = toolResultPayload.assistantMessageId;
+          }
+        }
+
         // Standard flow: Plan -> Execute
         rawInstructions = await this.agent.runner(runtimeContext, newState);
       }


### PR DESCRIPTION
## Summary

- Pass the seeded assistant message id through `resumeToolResult` initial context.
- Stash that id during `tool_result` resume so the next LLM call reuses the existing placeholder.
- Add regression coverage for both server payload wiring and runtime state handling.

## Root Cause

`askUserQuestion` resume creates an assistant placeholder before starting the Gateway operation, but the `resumeToolResult` path only passed `parentMessageId` to the runtime. The runtime therefore created a new assistant message for the resumed LLM turn, leaving the seeded placeholder as an orphan bubble that rendered as the agent avatar/title at the answer tail.

## Validation

- `bunx vitest run --silent='passed-only' src/core/__tests__/runtime.test.ts` from `packages/agent-runtime`
- `bunx vitest run --silent='passed-only' apps/server/src/services/aiAgent/__tests__/execAgent.resumeToolResult.test.ts`
- `bun run check packages/agent-runtime/src/core/runtime.ts packages/agent-runtime/src/core/__tests__/runtime.test.ts apps/server/src/services/aiAgent/index.ts apps/server/src/services/aiAgent/__tests__/execAgent.resumeToolResult.test.ts --lint --test`

Note: `bun run check` reports existing unused-vars warnings in `packages/agent-runtime/src/core/__tests__/runtime.test.ts`, with tests passing.