### PR TITLE
🔨 chore(skills): flatten agent-browser block handling into a single real-Chrome decision

### DIFF
--- a/packages/builtin-skills/src/agent-browser/content.ts
+++ b/packages/builtin-skills/src/agent-browser/content.ts
@@ -31,6 +31,7 @@ An empty body, a verification/challenge screen, or a page that is mostly obfusca
    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \\
      --remote-debugging-port=9222 --user-data-dir="$HOME/.agent-browser-cdp" &
    agent-browser --cdp 9222 open <url>                              # drive THAT browser
+   agent-browser --cdp 9222 wait --load networkidle                 # let the challenge run + reload settle
    agent-browser --cdp 9222 eval "document.body.innerText.length"   # re-verify you got content
    \`\`\`
 

--- a/packages/builtin-skills/src/agent-browser/content.ts
+++ b/packages/builtin-skills/src/agent-browser/content.ts
@@ -16,28 +16,29 @@ agent-browser snapshot -i    # 4. re-snapshot after any page change
 
 Refs become **stale on every page change** (click that navigates, form submit, dynamic re-render, dialog open). Always re-snapshot before the next ref interaction.
 
-If a page opens to an empty body or a verification/challenge screen, treat it as anti-bot fingerprinting — jump to the escalation ladder below instead of waiting longer or retrying.
+If a page opens to an empty body or a verification/challenge screen, treat it as a block, not a slow load — go straight to the real-Chrome step below.
 
 When the task is done, run \`agent-browser close\` and quit any Chrome you launched for CDP — browsers opened for the task otherwise stay on the user's machine.
 
-## Dynamic pages & anti-bot escalation
+## Blocked or dynamic pages — go straight to real Chrome
 
-When scraping dynamic or anti-bot pages, escalate from cheap to heavy and stop at the first rung that yields real content:
+An empty body, a verification/challenge screen, or a page that is mostly obfuscated JS is **blocked, not still loading** — and no amount of waiting, reloading, or re-screenshotting changes a fingerprint. So this is one decision, not a ladder: did you get real text back? If not, drive the user's own Chrome over CDP and commit to it.
 
-1. **Lightweight first**: builtin web search/crawl tools (or \`curl\`) — if the main text comes back, done.
-2. **Empty body, verification page, or obfuscated JS** → the page needs a real JS run: \`agent-browser open <url>\`, \`agent-browser wait --load networkidle\`, then \`agent-browser read\` (or \`snapshot\`).
-3. **Still blocked** (anti-bot that fingerprints headless Chrome) → connect to a real browser: launch Chrome with \`--remote-debugging-port=9222\` (Chrome 136+ also requires a separate \`--user-data-dir\`), then drive it with \`agent-browser --cdp 9222 <command>\` — a real browser fingerprint usually passes in one go.
+1. **One headless check** — \`agent-browser open <url>\`, one \`agent-browser wait --load networkidle\`, then \`agent-browser eval "document.body.innerText.length"\`. Real text → done.
+2. **Zero / near-zero → real Chrome over CDP now.** Its human fingerprint clears the JS challenge in one pass:
+   \`\`\`bash
+   # macOS (Linux: use \`google-chrome\`) — launch the user's real Chrome with a debug port, in the background
+   "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \\
+     --remote-debugging-port=9222 --user-data-dir="$HOME/.agent-browser-cdp" &
+   agent-browser --cdp 9222 open <url>                              # drive THAT browser
+   agent-browser --cdp 9222 eval "document.body.innerText.length"   # re-verify you got content
+   \`\`\`
 
-Rung transitions are diagnoses, not retries — recognize "blocked" instead of re-trying the same rung:
+**Commit to real Chrome; don't thrash.** Once step 1 comes back empty, do not sleep, reload, re-screenshot, switch to \`--headed\` (same automation browser — not an escalation), or reopen the session. And do NOT hand-roll the bypass yourself — no reversing the challenge JS, no computing clearance cookies with curl/python/node. Those are slow, per-site, and break on the next algorithm change; real Chrome is the general answer, so go there and see it through.
 
-- **Blocked looks exactly like "not loaded"**: after ONE \`wait --load networkidle\`, an empty/near-empty body (\`agent-browser eval "document.body.innerText.length"\` returns ~0) means you are fingerprinted, not slow. Extra waits, longer timeouts, or re-screenshots cannot fix a fingerprint — go straight to rung 3.
-- **Other block signals**: a response that is mostly obfuscated challenge JS, or a JS-challenge cookie (\`cf_clearance\`, \`*_jsl_clearance*\`, \`acw_tc\`, …) alongside an empty or challenge-page body. A clearance cookie next to real content means the challenge already passed — keep the session and read the page.
-- **\`--headed\` is NOT an escalation rung**: it only opens a window on the same automation-launched browser, so the fingerprint is unchanged. The real escalation is attaching to the user's own Chrome via \`--cdp\`.
-- When a rung fails, come back to this ladder — don't improvise ad-hoc diagnostics (curl retry loops, one-off python scripts, killing processes).
-
-Discipline: the crux of anti-bot checks is "did a real browser execute the JS", so the closer to a human environment, the easier it passes. Always verify you actually got content with \`agent-browser eval "document.body.innerText.length"\` before declaring success. Dump large output to a file first, then \`grep\`/\`head\` it.
+A JS-challenge cookie (\`cf_clearance\`, \`*_jsl_clearance*\`, \`acw_tc\`, …) next to an empty/challenge body confirms the block. The same cookie next to real content means the challenge already passed — keep the session and read the page. Dump large page output to a file first, then \`grep\`/\`head\` it.
 
 ## Discovering everything else
 
-Run \`agent-browser --help\` for the full command list, then \`agent-browser <subcommand> --help\` for any subcommand whose flags you're unsure about. The CLI also ships specialized skills (\`agent-browser skills list\`, \`agent-browser skills get <name>\`) covering Electron apps, Slack, dogfooding, Vercel Sandbox, and AWS Bedrock AgentCore — load one only when the task falls outside ordinary web pages. Those docs are command references; the anti-bot escalation ladder above still governs how you respond to blocked pages.
+Run \`agent-browser --help\` for the full command list, then \`agent-browser <subcommand> --help\` for any subcommand whose flags you're unsure about. The CLI also ships specialized skills (\`agent-browser skills list\`, \`agent-browser skills get <name>\`) covering Electron apps, Slack, dogfooding, Vercel Sandbox, and AWS Bedrock AgentCore — load one only when the task falls outside ordinary web pages. Those docs are command references; the real-Chrome rule above still governs how you respond to blocked pages.
 </agent_browser_guides>`;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔗 Related Issue

Related to #16799 (added block-diagnosis rules), #16759, #16722.

#### 🔀 Description of Change

Follow-up to #16799. That PR taught the `agent-browser` skill to *recognize* an anti-bot block (empty body / challenge screen = blocked, not a slow load), but it still framed the response as a cheap-to-heavy **escalation ladder**. In practice a strong model (Sonnet 5) reads a ladder as "climb one rung at a time" and burns turns re-waiting, reloading, re-screenshotting, or hand-rolling a per-site bypass before finally attaching to a real Chrome — the one step that actually clears a JS challenge.

The fix is to stop presenting alternatives and make it a single decision:

- Retitle the section **"Blocked or dynamic pages — go straight to real Chrome"** and collapse the ladder into one binary check: run one headless probe; if `document.body.innerText.length` is zero / near-zero, drive the user's own Chrome over CDP **now** and commit to it.
- Add an explicit **do-not-hand-roll** rule: no reversing the challenge JS, no computing clearance cookies with curl/python/node — those are slow, per-site, and break on the next algorithm change; real Chrome is the general answer.
- Keep the block-signal reference (`cf_clearance` / `*_jsl_clearance*` / `acw_tc` next to an empty body = blocked; next to real content = already passed) and the "don't thrash" list (`--headed` is the same automation browser, not an escalation).

Net effect: the model reaches the strongest tool (real Chrome fingerprint) on the first failed probe instead of after several wasted attempts.

Pure prompt-text change in one file — no i18n, no schema, no API surface.

#### 🧪 How to Test

- [x] Tested locally

Manual: in LobeHub desktop, ask a model to scrape a page behind a JS challenge (Cloudflare / 加速乐 `__jsl_clearance` / 阿里云 WAF). Expected: after one empty headless probe it launches the user's real Chrome with `--remote-debugging-port` and drives it via `agent-browser --cdp`, rather than re-waiting / reloading / hand-cracking the cookie. Verified in one pass on a real challenge page.

#### 📝 Additional Information

`builtin-skills` is consumed from source; the change ships to clients on the next build. No migration or rollout steps.
