### PR TITLE
🐛 fix(skills): restore device execution branch for execScript in gateway mode

### DIFF
--- a/.agents/skills/agent-tracing/SKILL.md
+++ b/.agents/skills/agent-tracing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-tracing
-description: 'Agent tracing CLI for execution snapshots. Use for agent-tracing, traces, snapshots, LLM call inspection, context engine data, agent step analysis, execution debugging, or pulling remote/production traces ("拉线上 tracing") by operation id.'
+description: 'Agent tracing CLI for execution snapshots. Use for agent-tracing, traces, snapshots, LLM call inspection, context engine data, agent step analysis, execution debugging, or pulling remote/production traces ("拉线上 tracing") by operation id. Also the first stop for debugging agent tool calls — wrong or missing tool_calls, unexpected tool arguments or results, which tools were available at a step, or why a tool ran where it did.'
 user-invocable: false
 ---
 

--- a/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
+++ b/apps/desktop/src/main/controllers/GatewayConnectionCtr.ts
@@ -384,6 +384,9 @@ export default class GatewayConnectionCtr extends ControllerModule {
       getLocalFilePreview: (params) => this.localFileCtr.getLocalFilePreview(params),
       getProjectFileIndex: (params) => this.localFileCtr.getProjectFileIndex(params),
       searchProjectFiles: (params) => this.localFileCtr.searchProjectFiles(params),
+      // Skill-archive cache (`prepareSkillDirectory` RPC): reuse LocalFileCtr's
+      // deps so gateway-prepared skills share one cache with the renderer-IPC path.
+      ...this.localFileCtr.getSkillDirectoryDeps(),
     };
   }
 

--- a/apps/desktop/src/main/controllers/LocalFileCtr.ts
+++ b/apps/desktop/src/main/controllers/LocalFileCtr.ts
@@ -1,8 +1,12 @@
 import { constants } from 'node:fs';
-import { access, mkdir, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
+import { access, readFile, realpath, stat } from 'node:fs/promises';
 import path from 'node:path';
 
-import { defaultSearchProjectFiles } from '@lobechat/device-control';
+import {
+  defaultSearchProjectFiles,
+  prepareSkillDirectory,
+  type SkillDirectoryDeps,
+} from '@lobechat/device-control';
 import {
   type AuditSafePathsParams,
   type AuditSafePathsResult,
@@ -55,7 +59,6 @@ import {
 } from '@lobechat/local-file-shell';
 import { dialog, shell } from 'electron';
 import { execa } from 'execa';
-import { unzipSync } from 'fflate';
 
 import ContentSearchService from '@/services/contentSearchSrv';
 import FileSearchService from '@/services/fileSearchSrv';
@@ -494,66 +497,25 @@ export default class LocalFileCtr extends ControllerModule {
     }
   }
 
+  /**
+   * Host deps for the shared skill-archive cache: this keeps the renderer-IPC
+   * path (here) and the gateway RPC path (`GatewayConnectionCtr` →
+   * `@lobechat/device-control`) on ONE cache directory and one proxy-aware
+   * fetch, so a skill prepared by either entry point is a cache hit for the
+   * other.
+   */
+  getSkillDirectoryDeps(): SkillDirectoryDeps {
+    return {
+      fetchSkillArchive: netFetch,
+      skillCacheRoot: path.join(this.app.appStoragePath, 'file-storage', 'skills'),
+    };
+  }
+
   @IpcMethod()
-  async handlePrepareSkillDirectory({
-    forceRefresh,
-    url,
-    zipHash,
-  }: PrepareSkillDirectoryParams): Promise<PrepareSkillDirectoryResult> {
-    const cacheRoot = path.join(this.app.appStoragePath, 'file-storage', 'skills');
-    const extractedDir = path.join(cacheRoot, 'extracted', zipHash);
-    const markerPath = path.join(extractedDir, '.prepared');
-    const zipPath = path.join(cacheRoot, 'archives', `${zipHash}.zip`);
-
-    try {
-      if (!forceRefresh) {
-        await access(markerPath, constants.F_OK);
-        return { extractedDir, success: true, zipPath };
-      }
-    } catch {
-      // Cache miss, continue preparing the local copy.
-    }
-
-    try {
-      const response = await netFetch(url);
-      if (!response.ok) {
-        throw new Error(
-          `Failed to download skill package: ${response.status} ${response.statusText}`,
-        );
-      }
-
-      const buffer = Buffer.from(await response.arrayBuffer());
-      const extractedFiles = unzipSync(new Uint8Array(buffer));
-
-      await rm(extractedDir, { force: true, recursive: true });
-      await mkdir(path.dirname(zipPath), { recursive: true });
-      await mkdir(extractedDir, { recursive: true });
-      await writeFile(zipPath, buffer);
-
-      for (const [relativePath, fileContent] of Object.entries(extractedFiles)) {
-        if (relativePath.endsWith('/')) continue;
-
-        const targetPath = path.resolve(extractedDir, relativePath);
-        const normalizedRoot = `${path.resolve(extractedDir)}${path.sep}`;
-        if (targetPath !== path.resolve(extractedDir) && !targetPath.startsWith(normalizedRoot)) {
-          throw new Error(`Unsafe file path in skill archive: ${relativePath}`);
-        }
-
-        await mkdir(path.dirname(targetPath), { recursive: true });
-        await writeFile(targetPath, Buffer.from(fileContent as Uint8Array));
-      }
-
-      await writeFile(markerPath, JSON.stringify({ preparedAt: Date.now(), url, zipHash }), 'utf8');
-
-      return { extractedDir, success: true, zipPath };
-    } catch (error) {
-      return {
-        error: (error as Error).message,
-        extractedDir,
-        success: false,
-        zipPath,
-      };
-    }
+  async handlePrepareSkillDirectory(
+    params: PrepareSkillDirectoryParams,
+  ): Promise<PrepareSkillDirectoryResult> {
+    return prepareSkillDirectory(params, this.getSkillDirectoryDeps());
   }
 
   @IpcMethod()

--- a/apps/desktop/src/main/controllers/__tests__/LocalFileCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/LocalFileCtr.test.ts
@@ -520,13 +520,19 @@ describe('LocalFileCtr', () => {
         '/mock/app/storage/file-storage/skills/archives/zip-hash-123.zip',
         expect.any(Buffer),
       );
+      // Extraction goes into a staging dir that is swapped in via rename so
+      // the live cache path never exposes a partially written tree.
       expect(mockFsPromises.writeFile).toHaveBeenCalledWith(
-        '/mock/app/storage/file-storage/skills/extracted/zip-hash-123/SKILL.md',
+        '/mock/app/storage/file-storage/skills/extracted/.staging-zip-hash-123/SKILL.md',
         expect.any(Buffer),
       );
       expect(mockFsPromises.writeFile).toHaveBeenCalledWith(
-        '/mock/app/storage/file-storage/skills/extracted/zip-hash-123/docs/reference.txt',
+        '/mock/app/storage/file-storage/skills/extracted/.staging-zip-hash-123/docs/reference.txt',
         expect.any(Buffer),
+      );
+      expect(mockFsPromises.rename).toHaveBeenCalledWith(
+        '/mock/app/storage/file-storage/skills/extracted/.staging-zip-hash-123',
+        '/mock/app/storage/file-storage/skills/extracted/zip-hash-123',
       );
     });
 

--- a/apps/desktop/vitest.config.mts
+++ b/apps/desktop/vitest.config.mts
@@ -1,4 +1,5 @@
 import { resolve } from 'node:path';
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
@@ -11,6 +12,9 @@ export default defineConfig({
         __dirname,
         '../../packages/device-control/src/workspace',
       ),
+      // Not hoisted to the (super)project root node_modules, so resolve it to
+      // workspace source like the packages above.
+      '@lobechat/device-identity': resolve(__dirname, '../../packages/device-identity/src'),
       '@lobechat/local-file-shell': resolve(__dirname, '../../packages/local-file-shell/src'),
     },
     coverage: {

--- a/apps/server/src/modules/AgentRuntime/executors/__tests__/resolveRunActiveDeviceId.test.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/__tests__/resolveRunActiveDeviceId.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveRunActiveDeviceId } from '../resolveRunActiveDeviceId';
+
+describe('resolveRunActiveDeviceId', () => {
+  it('passes the id through when the plan routed a device', () => {
+    expect(
+      resolveRunActiveDeviceId({
+        activeDeviceId: 'device-1',
+        executionPlan: { deviceId: 'device-1', kind: 'device' },
+      }),
+    ).toBe('device-1');
+  });
+
+  it('swallows a preset/stale id when the plan is not device-capable', () => {
+    for (const kind of ['sandbox', 'none']) {
+      expect(
+        resolveRunActiveDeviceId({
+          activeDeviceId: 'device-1',
+          executionPlan: { kind },
+        }),
+      ).toBeUndefined();
+    }
+  });
+
+  it('swallows the id when the device access policy denies the sender', () => {
+    expect(
+      resolveRunActiveDeviceId({
+        activeDeviceId: 'device-1',
+        deviceAccessPolicy: { canUseDevice: false, reason: 'external-bot' },
+        executionPlan: { deviceId: 'device-1', kind: 'device' },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('falls back to the policy-only gate when no plan exists (old/resumed operations)', () => {
+    expect(resolveRunActiveDeviceId({ activeDeviceId: 'device-1' })).toBe('device-1');
+    expect(resolveRunActiveDeviceId(undefined)).toBeUndefined();
+  });
+});

--- a/apps/server/src/modules/AgentRuntime/executors/__tests__/resolveRunActiveDeviceId.test.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/__tests__/resolveRunActiveDeviceId.test.ts
@@ -12,6 +12,18 @@ describe('resolveRunActiveDeviceId', () => {
     ).toBe('device-1');
   });
 
+  // Mid-run device activation: the model selects a device via the
+  // lobe-remote-device tool while the run-start plan still says unrouted —
+  // the folded-back id must survive the gate.
+  it('passes a mid-run activated id through under a device-unrouted plan', () => {
+    expect(
+      resolveRunActiveDeviceId({
+        activeDeviceId: 'device-1',
+        executionPlan: { kind: 'device-unrouted', reason: 'no-bound-device' },
+      }),
+    ).toBe('device-1');
+  });
+
   it('swallows a preset/stale id when the plan is not device-capable', () => {
     for (const kind of ['sandbox', 'none']) {
       expect(

--- a/apps/server/src/modules/AgentRuntime/executors/callLlm.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/callLlm.ts
@@ -72,11 +72,9 @@ import { TopicModel } from '@/database/models/topic';
 import { UserModel } from '@/database/models/user';
 import { UserPersonaModel } from '@/database/models/userMemory/persona';
 import { fileEnv } from '@/envs/file';
-import { type ExecutionPlan, isDeviceCapablePlan } from '@/helpers/executionTarget';
 import { serverMessagesEngine } from '@/server/modules/Mecha/ContextEngineering';
 import { initModelRuntimeFromDB } from '@/server/modules/ModelRuntime';
 import { AgentDocumentsService } from '@/server/services/agentDocuments';
-import { type DeviceAccessReason } from '@/server/services/aiAgent/deviceToolAudit';
 import { FileService } from '@/server/services/file';
 import { MarketService } from '@/server/services/market';
 import { OnboardingService } from '@/server/services/onboarding';
@@ -101,6 +99,7 @@ import { formatErrorEventData } from '../formatErrorEventData';
 import { classifyLLMError } from '../llmErrorClassification';
 import { createConversationParentMissingError } from '../messagePersistErrors';
 import { VISIBLE_OUTPUT_END_PUBLISHED_STEP_INDEX_METADATA_KEY } from '../visibleOutputEnd';
+import { resolveRunActiveDeviceId } from './resolveRunActiveDeviceId';
 
 export const callLlm =
   (ctx: RuntimeExecutorContext): InstructionExecutor =>
@@ -118,20 +117,10 @@ export const callLlm =
     //
     // Single-track device gate: `buildStepToolDelta` treats activeDeviceId as
     // an independent activation signal (it only dedupes against already-
-    // enabled tools), so any id that reaches it WILL inject local-system. The
-    // execution plan is the only authority on whether this session may touch
-    // a device — swallow the id for non-device-capable plans (`none`,
-    // `sandbox`) and for denied senders, even if `state.metadata.activeDeviceId`
-    // was populated by a bug or a mid-run side effect. Plans absent on old /
-    // resumed operations fall back to the policy-only gate.
-    const devicePolicy = state.metadata?.deviceAccessPolicy as
-      { canUseDevice: boolean; reason: DeviceAccessReason } | undefined;
-    const executionPlan = state.metadata?.executionPlan as ExecutionPlan | undefined;
-    const planAllowsDevice = !executionPlan || isDeviceCapablePlan(executionPlan);
-    const activeDeviceId =
-      devicePolicy?.canUseDevice === false || !planAllowsDevice
-        ? undefined
-        : state.metadata?.activeDeviceId;
+    // enabled tools), so any id that reaches it WILL inject local-system.
+    // `resolveRunActiveDeviceId` swallows the id whenever the plan/policy
+    // forbids devices — the same filter the tool executors apply.
+    const activeDeviceId = resolveRunActiveDeviceId(state.metadata);
     const operationToolSet: OperationToolSet = state.operationToolSet ?? {
       enabledToolIds: [],
       executorMap: state.toolExecutorMap ?? {},

--- a/apps/server/src/modules/AgentRuntime/executors/callTool.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/callTool.ts
@@ -1,6 +1,7 @@
 import {
   type AgentEvent,
   type AgentInstruction,
+  extractActivatedSkillsFromMessages,
   type InstructionExecutor,
   UsageCounter,
 } from '@lobechat/agent-runtime';
@@ -262,6 +263,12 @@ export const callTool =
           execution = await executeToolWithRetry(
             () =>
               toolExecutionService.executeTool(chatToolPayload, {
+                // Server-side equivalent of the client transport's
+                // computeStepContext: state.messages carries the DB rows
+                // (pluginState included), so skills execScript can resolve the
+                // activated skill archives. Without this the device/sandbox
+                // skill preparation silently runs with zero skills.
+                activatedSkills: extractActivatedSkillsFromMessages(state.messages),
                 // Plan/policy-filtered: a preset or stale metadata id must not route
                 // tool execution (e.g. skills execScript) onto a device the resolved
                 // plan didn't authorize.
@@ -469,8 +476,14 @@ export const callTool =
 
         const newState = structuredClone(state);
 
+        // Keep plugin/pluginState on the in-state copy: the batch executor
+        // refreshes state.messages from full DB rows, but this single-tool path
+        // never does — without these fields a later step could not extract the
+        // skill activation this call just produced (activatedSkills above).
         newState.messages.push({
           content: executionResult.content,
+          plugin: chatToolPayload,
+          pluginState: executionResult.state,
           role: 'tool',
           tool_call_id: chatToolPayload.id,
         });

--- a/apps/server/src/modules/AgentRuntime/executors/callTool.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/callTool.ts
@@ -43,6 +43,7 @@ import {
   markPersistFatal,
 } from '../messagePersistErrors';
 import { resolveToolTimeoutMs } from '../resolveToolTimeout';
+import { resolveRunActiveDeviceId } from './resolveRunActiveDeviceId';
 
 export const callTool =
   (ctx: RuntimeExecutorContext): InstructionExecutor =>
@@ -260,7 +261,10 @@ export const callTool =
           execution = await executeToolWithRetry(
             () =>
               toolExecutionService.executeTool(chatToolPayload, {
-                activeDeviceId: state.metadata?.activeDeviceId,
+                // Plan/policy-filtered: a preset or stale metadata id must not route
+                // tool execution (e.g. skills execScript) onto a device the resolved
+                // plan didn't authorize.
+                activeDeviceId: resolveRunActiveDeviceId(state.metadata),
                 agentId: toolCallAgentId,
                 agentMember: buildServerAgentMemberRunner(
                   ctx,

--- a/apps/server/src/modules/AgentRuntime/executors/callTool.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/callTool.ts
@@ -44,6 +44,7 @@ import {
 } from '../messagePersistErrors';
 import { resolveToolTimeoutMs } from '../resolveToolTimeout';
 import { resolveRunActiveDeviceId } from './resolveRunActiveDeviceId';
+import { resolveRunProjectSkills } from './resolveRunProjectSkills';
 
 export const callTool =
   (ctx: RuntimeExecutorContext): InstructionExecutor =>
@@ -287,16 +288,7 @@ export const callTool =
                 memoryToolPermission: agentConfig?.chatConfig?.memory?.toolPermission,
                 messageId: state.metadata?.sourceMessageId,
                 operationId,
-                projectSkills: (state.metadata?.operationSkillSet?.skills ?? [])
-                  .filter(
-                    (skill: { location?: string; source?: string }) =>
-                      (skill.source === 'project' || skill.source === 'device') && !!skill.location,
-                  )
-                  .map((skill: { location: string; name: string; source?: string }) => ({
-                    location: skill.location,
-                    name: skill.name,
-                    source: skill.source === 'device' ? 'device' : 'project',
-                  })),
+                projectSkills: resolveRunProjectSkills(state.metadata),
                 scope: state.metadata?.scope,
                 serverDB: ctx.serverDB,
                 skipResultTruncation: true,

--- a/apps/server/src/modules/AgentRuntime/executors/callToolsBatch.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/callToolsBatch.ts
@@ -45,6 +45,7 @@ import {
 } from '../messagePersistErrors';
 import { resolveToolTimeoutMs } from '../resolveToolTimeout';
 import { resolveRunActiveDeviceId } from './resolveRunActiveDeviceId';
+import { resolveRunProjectSkills } from './resolveRunProjectSkills';
 
 export const callToolsBatch =
   (ctx: RuntimeExecutorContext): InstructionExecutor =>
@@ -284,6 +285,10 @@ export const callToolsBatch =
                     memoryToolPermission: batchAgentConfig?.chatConfig?.memory?.toolPermission,
                     messageId: state.metadata?.sourceMessageId,
                     operationId,
+                    // Mirrors the single-tool `callTool` context: without these
+                    // a batched device execScript loses the SKILL.md / selected
+                    // working directory and runs from the daemon's default cwd.
+                    projectSkills: resolveRunProjectSkills(state.metadata),
                     scope: state.metadata?.scope,
                     serverDB: ctx.serverDB,
                     skipResultTruncation: true,
@@ -300,6 +305,10 @@ export const callToolsBatch =
                     toolResultMaxLength: batchAgentConfig?.chatConfig?.toolResultMaxLength,
                     topicId: ctx.topicId,
                     userId: ctx.userId,
+                    // Device-bound cwd folded into deviceSystemInfo at operation
+                    // creation; resume-safe via computeDeviceContext (recovers it
+                    // from the prior tool message's pluginState.metadata).
+                    workingDirectory: state.metadata?.deviceSystemInfo?.workingDirectory,
                     workspaceId: state.metadata?.workspaceId ?? ctx.workspaceId,
                   }),
                 {

--- a/apps/server/src/modules/AgentRuntime/executors/callToolsBatch.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/callToolsBatch.ts
@@ -44,6 +44,7 @@ import {
   markPersistFatal,
 } from '../messagePersistErrors';
 import { resolveToolTimeoutMs } from '../resolveToolTimeout';
+import { resolveRunActiveDeviceId } from './resolveRunActiveDeviceId';
 
 export const callToolsBatch =
   (ctx: RuntimeExecutorContext): InstructionExecutor =>
@@ -259,7 +260,10 @@ export const callToolsBatch =
               execution = await executeToolWithRetry(
                 () =>
                   toolExecutionService.executeTool(chatToolPayload, {
-                    activeDeviceId: state.metadata?.activeDeviceId,
+                    // Plan/policy-filtered: a preset or stale metadata id must not route
+                    // tool execution (e.g. skills execScript) onto a device the resolved
+                    // plan didn't authorize.
+                    activeDeviceId: resolveRunActiveDeviceId(state.metadata),
                     agentId: state.metadata?.agentId,
                     agentMember: buildServerAgentMemberRunner(
                       ctx,

--- a/apps/server/src/modules/AgentRuntime/executors/callToolsBatch.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/callToolsBatch.ts
@@ -1,6 +1,7 @@
 import {
   type AgentEvent,
   type AgentInstruction,
+  extractActivatedSkillsFromMessages,
   type InstructionExecutor,
   UsageCounter,
 } from '@lobechat/agent-runtime';
@@ -116,6 +117,11 @@ export const callToolsBatch =
 
     // Execute server tools concurrently (skip client tools in mixed batch)
     const toolsToExecute = serverTools.length > 0 ? serverTools : toolsCalling;
+    // Server-side equivalent of the client transport's computeStepContext
+    // (mirrors the single-tool `callTool` context): skills execScript resolves
+    // activated skill archives from the message history, which the raw LLM
+    // args never carry. Computed once — identical for every tool in the batch.
+    const runActivatedSkills = extractActivatedSkillsFromMessages(state.messages);
     await Promise.all(
       toolsToExecute.map(async (chatToolPayload: ChatToolPayload) => {
         const toolName = `${chatToolPayload.identifier}/${chatToolPayload.apiName}`;
@@ -261,6 +267,7 @@ export const callToolsBatch =
               execution = await executeToolWithRetry(
                 () =>
                   toolExecutionService.executeTool(chatToolPayload, {
+                    activatedSkills: runActivatedSkills,
                     // Plan/policy-filtered: a preset or stale metadata id must not route
                     // tool execution (e.g. skills execScript) onto a device the resolved
                     // plan didn't authorize.

--- a/apps/server/src/modules/AgentRuntime/executors/resolveRunActiveDeviceId.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/resolveRunActiveDeviceId.ts
@@ -1,0 +1,27 @@
+import { type ExecutionPlan, isDeviceCapablePlan } from '@/helpers/executionTarget';
+import { type DeviceAccessReason } from '@/server/services/aiAgent/deviceToolAudit';
+
+/**
+ * Single-track device gate shared by the run executors: the execution plan
+ * (and the device access policy) is the only authority on whether this run
+ * may touch a device. `metadata.activeDeviceId` alone is NOT sufficient — the
+ * desktop client can preset it on the run request, and a mid-run side effect
+ * can leave it stale — so every consumer (LLM tool injection in `callLlm`,
+ * tool execution contexts in `callTool` / `callToolsBatch`) must read the id
+ * through this filter. Plans absent on old / resumed operations fall back to
+ * the policy-only gate.
+ */
+export const resolveRunActiveDeviceId = (metadata?: {
+  activeDeviceId?: string;
+  deviceAccessPolicy?: unknown;
+  executionPlan?: unknown;
+}): string | undefined => {
+  const devicePolicy = metadata?.deviceAccessPolicy as
+    { canUseDevice: boolean; reason: DeviceAccessReason } | undefined;
+  const executionPlan = metadata?.executionPlan as ExecutionPlan | undefined;
+  const planAllowsDevice = !executionPlan || isDeviceCapablePlan(executionPlan);
+
+  if (devicePolicy?.canUseDevice === false || !planAllowsDevice) return undefined;
+
+  return metadata?.activeDeviceId;
+};

--- a/apps/server/src/modules/AgentRuntime/executors/resolveRunActiveDeviceId.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/resolveRunActiveDeviceId.ts
@@ -4,12 +4,20 @@ import { type DeviceAccessReason } from '@/server/services/aiAgent/deviceToolAud
 /**
  * Single-track device gate shared by the run executors: the execution plan
  * (and the device access policy) is the only authority on whether this run
- * may touch a device. `metadata.activeDeviceId` alone is NOT sufficient — the
- * desktop client can preset it on the run request, and a mid-run side effect
- * can leave it stale — so every consumer (LLM tool injection in `callLlm`,
- * tool execution contexts in `callTool` / `callToolsBatch`) must read the id
- * through this filter. Plans absent on old / resumed operations fall back to
- * the policy-only gate.
+ * may touch a device. `metadata.activeDeviceId` alone is NOT sufficient — a
+ * mid-run side effect can leave it stale — so every consumer (LLM tool
+ * injection in `callLlm`, tool execution contexts in `callTool` /
+ * `callToolsBatch`) must read the id through this filter. Plans absent on
+ * old / resumed operations fall back to the policy-only gate.
+ *
+ * `device-unrouted` deliberately passes the id through (via
+ * `isDeviceCapablePlan`): the run-start id is derived strictly from the plan
+ * (`aiAgent` sets it only for `kind === 'device'`), so an id appearing under
+ * a `device-unrouted` plan can only come from a legitimate mid-run activation
+ * — the model selecting a device with the `lobe-remote-device` tool, whose
+ * pluginState `computeDeviceContext` folds back into the metadata at the next
+ * step boundary while the plan still says unrouted. Tightening the gate to
+ * `kind === 'device'` would swallow exactly that flow.
  */
 export const resolveRunActiveDeviceId = (metadata?: {
   activeDeviceId?: string;

--- a/apps/server/src/modules/AgentRuntime/executors/resolveRunProjectSkills.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/resolveRunProjectSkills.ts
@@ -1,0 +1,19 @@
+/**
+ * Project/device filesystem skills (SKILL.md on the execution device) from the
+ * operation's skill set, shaped for the tool-execution context. Shared by
+ * `callTool` and `callToolsBatch` so batched device `execScript` calls resolve
+ * the same SKILL.md cwd as single calls — an unshared copy is exactly how the
+ * batch path silently dropped these fields once already.
+ */
+export const resolveRunProjectSkills = (metadata?: {
+  operationSkillSet?: { skills?: { location?: string; name: string; source?: string }[] };
+}): { location: string; name: string; source: 'device' | 'project' }[] =>
+  (metadata?.operationSkillSet?.skills ?? [])
+    .filter(
+      (skill) => (skill.source === 'project' || skill.source === 'device') && !!skill.location,
+    )
+    .map((skill) => ({
+      location: skill.location as string,
+      name: skill.name,
+      source: skill.source === 'device' ? ('device' as const) : ('project' as const),
+    }));

--- a/apps/server/src/services/deviceGateway/index.ts
+++ b/apps/server/src/services/deviceGateway/index.ts
@@ -204,6 +204,50 @@ export class DeviceGateway {
   }
 
   /**
+   * Prepare a skill archive on the device: download the presigned zip and
+   * extract it into the device-local cache (idempotent by `zipHash`). Runs on
+   * the generic device RPC relay like `initWorkspace`, but unlike the
+   * read-oriented helpers, failures are RETURNED with their reason instead of
+   * collapsing to `undefined` — the skills exec path must tell the model why
+   * the device can't run the skill (offline, outdated client, download
+   * failure) rather than silently degrading to the sandbox.
+   */
+  async prepareSkillDirectory(params: {
+    deviceId: string;
+    forceRefresh?: boolean;
+    timeout?: number;
+    url: string;
+    userId: string;
+    workspaceId?: string;
+    zipHash: string;
+  }): Promise<{ error?: string; extractedDir?: string; success: boolean }> {
+    const { deviceId, forceRefresh, timeout = 60_000, url, userId, workspaceId, zipHash } = params;
+    const client = this.getClient();
+    if (!client) return { error: 'Device Gateway is not configured', success: false };
+
+    try {
+      const result = await client.invokeRpc<{
+        error?: string;
+        extractedDir: string;
+        success: boolean;
+      }>(
+        { deviceId, timeout, userId, workspaceId },
+        { method: 'prepareSkillDirectory', params: { forceRefresh, url, zipHash } },
+      );
+
+      if (!result.success || !result.data) {
+        return { error: result.error || 'prepareSkillDirectory failed', success: false };
+      }
+
+      return result.data;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      log('prepareSkillDirectory: error for deviceId=%s — %s', deviceId, message);
+      return { error: message, success: false };
+    }
+  }
+
+  /**
    * Generic helper for the granular git read RPCs (branch / PR / working-tree /
    * ahead-behind). Returns `undefined` when the gateway is unconfigured, the
    * device is offline, or the call fails — callers treat that as "unknown".

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
@@ -513,6 +513,87 @@ describe('skillsRuntime', () => {
         300_000,
       );
     });
+
+    // Large streams are truncated to a preview device-side with the full
+    // output saved to disk — dropping state.outputFiles would lose the only
+    // retrieval path for the truncated output.
+    it('carries saved-output file paths through for truncated device output', async () => {
+      mocks.executeToolCall.mockResolvedValue({
+        content: 'preview…',
+        state: {
+          exitCode: 0,
+          outputFiles: {
+            stdout: {
+              path: '/tmp/lobe-shell/shell-1.stdout.log',
+              size: 5_242_880,
+              truncated: true,
+            },
+          },
+          stdout: 'preview…',
+          success: true,
+        },
+        success: true,
+      });
+
+      const { skillsRuntime } = await import('../skills');
+      const runtime = await skillsRuntime.factory({
+        activeDeviceId: 'device-1',
+        serverDB: {} as never,
+        toolManifestMap: {},
+        topicId: 'topic-1',
+        userId: 'user-1',
+      });
+
+      const result = await runtime.execScript({
+        activatedSkills: [],
+        command: 'cat big.log',
+        description: 'noisy script',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.content).toContain('/tmp/lobe-shell/shell-1.stdout.log');
+      expect(result.state).toMatchObject({
+        outputFiles: { stdout: expect.objectContaining({ truncated: true }) },
+      });
+    });
+
+    // The device manifest hides the sandbox-only APIs, but the builtin
+    // executor dispatches any method on the runtime regardless of the
+    // manifest — a prompt-following or hallucinated call must be refused at
+    // execution time, not silently run in the sandbox.
+    it('refuses the sandbox runCommand while a device is routed', async () => {
+      const { skillsRuntime } = await import('../skills');
+      const runtime = await skillsRuntime.factory({
+        activeDeviceId: 'device-1',
+        serverDB: {} as never,
+        toolManifestMap: {},
+        topicId: 'topic-1',
+        userId: 'user-1',
+      });
+
+      const result = await runtime.runCommand({ command: 'ls' });
+
+      expect(result.success).toBe(false);
+      expect(result.content).toContain('lobe-local-system');
+      expect(mocks.createSandboxService).not.toHaveBeenCalled();
+    });
+
+    it('refuses the sandbox exportFile while a device is routed', async () => {
+      const { skillsRuntime } = await import('../skills');
+      const runtime = await skillsRuntime.factory({
+        activeDeviceId: 'device-1',
+        serverDB: {} as never,
+        toolManifestMap: {},
+        topicId: 'topic-1',
+        userId: 'user-1',
+      });
+
+      const result = await runtime.exportFile({ filename: 'out.csv', path: '/tmp/out.csv' });
+
+      expect(result.success).toBe(false);
+      expect(result.content).toContain("already on the user's machine");
+      expect(mocks.sandboxService.exportAndUploadFile).not.toHaveBeenCalled();
+    });
   });
 
   // Regression guard for the device-gating fix: builtin skills must be filtered

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
@@ -389,6 +389,119 @@ describe('skillsRuntime', () => {
       );
     });
 
+    // Archive prepares are full device-gateway round-trips and activatedSkills
+    // accumulates over the conversation — they must fire concurrently, while
+    // the activation-order semantics (last resolvable wins the cwd) stay
+    // intact.
+    it('fires archive prepares concurrently and the last resolvable skill wins the cwd', async () => {
+      mocks.findByName.mockImplementation(async (name: string) => {
+        if (name === 'skill-a') return { id: 'a-id', name: 'skill-a', zipFileHash: 'hash-a' };
+        if (name === 'skill-b') return { id: 'b-id', name: 'skill-b', zipFileHash: 'hash-b' };
+        return undefined;
+      });
+      mocks.checkHash.mockImplementation(async (hash: string) => ({
+        isExist: true,
+        url: `skills/${hash}.zip`,
+      }));
+      mocks.fileService.getFullFileUrl.mockImplementation(
+        async (url: string) => `https://files.example.com/${url}`,
+      );
+
+      // Hold both prepares pending to prove the second RPC fires before the
+      // first resolves (a sequential await chain would deadlock this test).
+      const resolvers: ((value: { extractedDir: string; success: boolean }) => void)[] = [];
+      mocks.prepareSkillDirectory.mockImplementation(
+        () => new Promise((resolve) => resolvers.push(resolve)),
+      );
+      mocks.executeToolCall.mockResolvedValue({
+        content: 'ok',
+        state: { exitCode: 0, stdout: 'ok', success: true },
+        success: true,
+      });
+
+      const { skillsRuntime } = await import('../skills');
+      const runtime = await skillsRuntime.factory({
+        activeDeviceId: 'device-1',
+        serverDB: {} as never,
+        toolManifestMap: {},
+        topicId: 'topic-1',
+        userId: 'user-1',
+      });
+
+      const pending = runtime.execScript({
+        activatedSkills: [
+          { id: 'a-id', name: 'skill-a' },
+          { id: 'b-id', name: 'skill-b' },
+        ],
+        command: 'python scripts/run.py',
+        description: 'multi skill',
+      });
+
+      await vi.waitFor(() => expect(mocks.prepareSkillDirectory).toHaveBeenCalledTimes(2));
+      resolvers[0]({ extractedDir: '/dev/extracted/hash-a', success: true });
+      resolvers[1]({ extractedDir: '/dev/extracted/hash-b', success: true });
+
+      const result = await pending;
+      expect(result.success).toBe(true);
+      expect(mocks.executeToolCall).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          arguments: JSON.stringify({
+            command: 'python scripts/run.py',
+            cwd: '/dev/extracted/hash-b',
+          }),
+        }),
+        undefined,
+      );
+    });
+
+    // With concurrent prepares, error reporting must still follow activation
+    // order: the FIRST failing skill is the one surfaced, regardless of which
+    // RPC settles first.
+    it('reports the first failing skill in activation order despite concurrent prepares', async () => {
+      mocks.findByName.mockImplementation(async (name: string) => {
+        if (name === 'skill-a') return { id: 'a-id', name: 'skill-a', zipFileHash: 'hash-a' };
+        if (name === 'skill-b') return { id: 'b-id', name: 'skill-b', zipFileHash: 'hash-b' };
+        return undefined;
+      });
+      mocks.checkHash.mockImplementation(async (hash: string) => ({
+        isExist: true,
+        url: `skills/${hash}.zip`,
+      }));
+      mocks.fileService.getFullFileUrl.mockImplementation(
+        async (url: string) => `https://files.example.com/${url}`,
+      );
+      mocks.prepareSkillDirectory.mockImplementation(async ({ zipHash }: { zipHash: string }) =>
+        zipHash === 'hash-a'
+          ? { error: 'Failed to download skill archive: 404 Not Found', success: false }
+          : { extractedDir: '/dev/extracted/hash-b', success: true },
+      );
+
+      const { skillsRuntime } = await import('../skills');
+      const runtime = await skillsRuntime.factory({
+        activeDeviceId: 'device-1',
+        serverDB: {} as never,
+        toolManifestMap: {},
+        topicId: 'topic-1',
+        userId: 'user-1',
+      });
+
+      const result = await runtime.execScript({
+        activatedSkills: [
+          { id: 'a-id', name: 'skill-a' },
+          { id: 'b-id', name: 'skill-b' },
+        ],
+        command: 'python scripts/run.py',
+        description: 'multi skill',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.content).toContain('skill-a');
+      expect(result.content).toContain('404 Not Found');
+      expect(mocks.executeToolCall).not.toHaveBeenCalled();
+      expect(mocks.sandboxService.callTool).not.toHaveBeenCalled();
+    });
+
     // A command that outlives the shell observation window comes back with no
     // exitCode — it must surface as still running (with a pollable shell_id),
     // not as a successful completion.

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
@@ -422,6 +422,37 @@ describe('skillsRuntime', () => {
       expect(result.content).not.toContain('completed successfully');
     });
 
+    // The device ComputerRuntime reports service failures (spawn error, shell
+    // lost) with a delivered envelope: `success: true`, `state.success:
+    // false`, and no exitCode — they must surface as failures, not as a
+    // still-running command.
+    it('reports failure when the device service fails without an exit code', async () => {
+      mocks.executeToolCall.mockResolvedValue({
+        content: 'spawn ENOENT',
+        state: { error: 'spawn ENOENT', isBackground: false, success: false },
+        success: true,
+      });
+
+      const { skillsRuntime } = await import('../skills');
+      const runtime = await skillsRuntime.factory({
+        activeDeviceId: 'device-1',
+        serverDB: {} as never,
+        toolManifestMap: {},
+        topicId: 'topic-1',
+        userId: 'user-1',
+      });
+
+      const result = await runtime.execScript({
+        activatedSkills: [],
+        command: 'python scripts/run.py',
+        description: 'spawn failure',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.content).toContain('spawn ENOENT');
+      expect(result.content).not.toContain('still running');
+    });
+
     // The device shell observation reports success: true for any delivered
     // observation — the actual exit status only lives in exitCode.
     it('reports failure when the script exits non-zero despite a successful observation', async () => {

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
@@ -245,7 +245,7 @@ describe('skillsRuntime', () => {
 
     it('fails explicitly (no sandbox fallback) when the device cannot prepare a skill', async () => {
       mocks.prepareSkillDirectory.mockResolvedValue({
-        error: 'Unknown device RPC method: prepareSkillDirectory',
+        error: 'Failed to download skill archive: 404 Not Found',
         success: false,
       });
 
@@ -265,9 +265,43 @@ describe('skillsRuntime', () => {
       });
 
       expect(result.success).toBe(false);
-      expect(result.content).toContain('Unknown device RPC method');
+      expect(result.content).toContain('404 Not Found');
       expect(mocks.executeToolCall).not.toHaveBeenCalled();
       expect(mocks.sandboxService.callTool).not.toHaveBeenCalled();
+    });
+
+    // Version-skew window: an old client build replies with the dispatcher's
+    // deterministic unknown-method error — the ONE prepare failure that falls
+    // back to the sandbox, with an explicit disclosure note for the model.
+    it('falls back to the sandbox (with a disclosure note) when the client predates the RPC', async () => {
+      mocks.prepareSkillDirectory.mockResolvedValue({
+        error: 'Unknown device RPC method: prepareSkillDirectory',
+        success: false,
+      });
+
+      const { skillsRuntime } = await import('../skills');
+      const runtime = await skillsRuntime.factory({
+        activeDeviceId: 'device-1',
+        serverDB: {} as never,
+        toolManifestMap: {},
+        topicId: 'topic-1',
+        userId: 'user-1',
+      });
+
+      const result = await runtime.execScript({
+        activatedSkills: [{ id: 'user-skill-id', name: 'user-skill' }],
+        command: 'python scripts/run.py',
+        description: 'Run skill script',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.state).toMatchObject({ executionEnv: 'sandbox' });
+      expect(result.content).toContain('update their LobeHub app');
+      expect(mocks.executeToolCall).not.toHaveBeenCalled();
+      expect(mocks.sandboxService.callTool).toHaveBeenCalledWith(
+        'execScript',
+        expect.objectContaining({ command: 'python scripts/run.py' }),
+      );
     });
 
     it('runs without a skill dir (workingDirectory cwd) when no archive exists', async () => {

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
@@ -338,6 +338,90 @@ describe('skillsRuntime', () => {
       );
     });
 
+    // Filesystem (project/device) skills have no DB archive — their SKILL.md
+    // directory on the device is the cwd, and the last activated skill wins
+    // over earlier archive-backed ones.
+    it('uses the project skill directory as cwd, winning over earlier archives', async () => {
+      mocks.prepareSkillDirectory.mockResolvedValue({
+        extractedDir: '/home/user/.lobehub/skills/extracted/zip-hash-1',
+        success: true,
+      });
+      mocks.executeToolCall.mockResolvedValue({
+        content: 'ok',
+        state: { exitCode: 0, stdout: 'ok', success: true },
+        success: true,
+      });
+
+      const { skillsRuntime } = await import('../skills');
+      const runtime = await skillsRuntime.factory({
+        activeDeviceId: 'device-1',
+        projectSkills: [
+          { location: '/ws/.agents/skills/foo/SKILL.md', name: 'foo', source: 'project' },
+        ],
+        serverDB: {} as never,
+        toolManifestMap: {},
+        topicId: 'topic-1',
+        userId: 'user-1',
+      });
+
+      const result = await runtime.execScript({
+        activatedSkills: [
+          { id: 'user-skill-id', name: 'user-skill' },
+          { id: 'foo-id', name: 'foo' },
+        ],
+        command: 'python scripts/run.py',
+        description: 'Run project skill script',
+      });
+
+      expect(result.success).toBe(true);
+      // The archive-backed skill is still prepared (activated earlier)...
+      expect(mocks.prepareSkillDirectory).toHaveBeenCalledTimes(1);
+      // ...but the project skill activated last wins the cwd.
+      expect(mocks.executeToolCall).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          arguments: JSON.stringify({
+            command: 'python scripts/run.py',
+            cwd: '/ws/.agents/skills/foo',
+          }),
+        }),
+        undefined,
+      );
+    });
+
+    // A command that outlives the shell observation window comes back with no
+    // exitCode — it must surface as still running (with a pollable shell_id),
+    // not as a successful completion.
+    it('reports a still-running command instead of pretending completion', async () => {
+      mocks.executeToolCall.mockResolvedValue({
+        content: 'Command is still running after the wait window.',
+        state: { commandId: 'shell-9', stdout: '', success: true },
+        success: true,
+      });
+
+      const { skillsRuntime } = await import('../skills');
+      const runtime = await skillsRuntime.factory({
+        activeDeviceId: 'device-1',
+        serverDB: {} as never,
+        toolManifestMap: {},
+        topicId: 'topic-1',
+        userId: 'user-1',
+      });
+
+      const result = await runtime.execScript({
+        activatedSkills: [],
+        command: 'sleep 600',
+        description: 'long script',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.state).toMatchObject({ executionEnv: 'device', shellId: 'shell-9' });
+      expect(result.state).not.toHaveProperty('exitCode', 0);
+      expect(result.content).toContain('still running');
+      expect(result.content).toContain('shell-9');
+      expect(result.content).not.toContain('completed successfully');
+    });
+
     // The device shell observation reports success: true for any delivered
     // observation — the actual exit status only lives in exitCode.
     it('reports failure when the script exits non-zero despite a successful observation', async () => {

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => {
   return {
     checkHash: vi.fn(),
     createSandboxService: vi.fn(() => sandboxService),
+    executeToolCall: vi.fn(),
     fileService: {
       getFullFileUrl: vi.fn(),
     },
@@ -28,6 +29,7 @@ const mocks = vi.hoisted(() => {
     getAgentSkills: vi.fn(),
     getUserSettings: vi.fn(),
     marketService: {},
+    prepareSkillDirectory: vi.fn(),
     readResource: vi.fn(),
     sandboxService,
   };
@@ -88,6 +90,17 @@ vi.mock('@/server/services/skill/resource', () => ({
   SkillResourceService: vi.fn(() => ({
     readResource: mocks.readResource,
   })),
+}));
+
+vi.mock('@/server/services/deviceGateway', () => ({
+  deviceGateway: {
+    executeToolCall: mocks.executeToolCall,
+    prepareSkillDirectory: mocks.prepareSkillDirectory,
+  },
+}));
+
+vi.mock('../resolveWorkspaceScope', () => ({
+  resolveRunWorkspaceId: vi.fn(async () => undefined),
 }));
 
 describe('skillsRuntime', () => {
@@ -154,6 +167,142 @@ describe('skillsRuntime', () => {
         },
       }),
     );
+  });
+
+  it('tags sandbox exec results with executionEnv for plugin-state observability', async () => {
+    const { skillsRuntime } = await import('../skills');
+    const runtime = await skillsRuntime.factory({
+      serverDB: {} as never,
+      toolManifestMap: {},
+      topicId: 'topic-1',
+      userId: 'user-1',
+    });
+
+    const result = await runtime.execScript({
+      activatedSkills: [],
+      command: 'echo hi',
+      description: 'plain command',
+    });
+
+    expect(result.state).toMatchObject({ executionEnv: 'sandbox' });
+  });
+
+  // Regression guard for the server/gateway migration: when the execution plan
+  // routed a device (activeDeviceId present), execScript must run ON the device
+  // — prepare the skill archives via the prepareSkillDirectory RPC and execute
+  // through local-system over the gateway — never in the cloud sandbox.
+  describe('device execution branch', () => {
+    it('prepares archives on the device and runs the command with cwd = extracted dir', async () => {
+      mocks.prepareSkillDirectory.mockResolvedValue({
+        extractedDir: '/home/user/.lobehub/skills/extracted/zip-hash-1',
+        success: true,
+      });
+      mocks.executeToolCall.mockResolvedValue({
+        content: 'ok',
+        state: { exitCode: 0, stdout: 'ok', success: true },
+        success: true,
+      });
+
+      const { skillsRuntime } = await import('../skills');
+      const runtime = await skillsRuntime.factory({
+        activeDeviceId: 'device-1',
+        serverDB: {} as never,
+        toolManifestMap: {},
+        topicId: 'topic-1',
+        userId: 'user-1',
+      });
+
+      const result = await runtime.execScript({
+        activatedSkills: [{ id: 'user-skill-id', name: 'user-skill' }],
+        command: 'python scripts/run.py',
+        description: 'Run skill script',
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.state).toMatchObject({ executionEnv: 'device' });
+      expect(mocks.prepareSkillDirectory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deviceId: 'device-1',
+          url: 'https://files.example.com/user-skill.zip',
+          userId: 'user-1',
+          zipHash: 'zip-hash-1',
+        }),
+      );
+      expect(mocks.executeToolCall).toHaveBeenCalledWith(
+        expect.objectContaining({ deviceId: 'device-1', userId: 'user-1' }),
+        expect.objectContaining({
+          apiName: 'runCommand',
+          arguments: JSON.stringify({
+            command: 'python scripts/run.py',
+            cwd: '/home/user/.lobehub/skills/extracted/zip-hash-1',
+          }),
+          identifier: 'lobe-local-system',
+        }),
+        undefined,
+      );
+      expect(mocks.sandboxService.callTool).not.toHaveBeenCalled();
+    });
+
+    it('fails explicitly (no sandbox fallback) when the device cannot prepare a skill', async () => {
+      mocks.prepareSkillDirectory.mockResolvedValue({
+        error: 'Unknown device RPC method: prepareSkillDirectory',
+        success: false,
+      });
+
+      const { skillsRuntime } = await import('../skills');
+      const runtime = await skillsRuntime.factory({
+        activeDeviceId: 'device-1',
+        serverDB: {} as never,
+        toolManifestMap: {},
+        topicId: 'topic-1',
+        userId: 'user-1',
+      });
+
+      const result = await runtime.execScript({
+        activatedSkills: [{ id: 'user-skill-id', name: 'user-skill' }],
+        command: 'python scripts/run.py',
+        description: 'Run skill script',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.content).toContain('Unknown device RPC method');
+      expect(mocks.executeToolCall).not.toHaveBeenCalled();
+      expect(mocks.sandboxService.callTool).not.toHaveBeenCalled();
+    });
+
+    it('runs without a skill dir (workingDirectory cwd) when no archive exists', async () => {
+      mocks.executeToolCall.mockResolvedValue({
+        content: 'ok',
+        state: { exitCode: 0, stdout: 'ok', success: true },
+        success: true,
+      });
+
+      const { skillsRuntime } = await import('../skills');
+      const runtime = await skillsRuntime.factory({
+        activeDeviceId: 'device-1',
+        serverDB: {} as never,
+        toolManifestMap: {},
+        topicId: 'topic-1',
+        userId: 'user-1',
+        workingDirectory: '/Users/me/project',
+      });
+
+      const result = await runtime.execScript({
+        activatedSkills: [{ id: 'builtin-skill-id', name: 'builtin-skill' }],
+        command: 'echo hi',
+        description: 'no archive',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mocks.prepareSkillDirectory).not.toHaveBeenCalled();
+      expect(mocks.executeToolCall).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          arguments: JSON.stringify({ command: 'echo hi', cwd: '/Users/me/project' }),
+        }),
+        undefined,
+      );
+    });
   });
 
   // Regression guard for the device-gating fix: builtin skills must be filtered

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
@@ -303,6 +303,67 @@ describe('skillsRuntime', () => {
         undefined,
       );
     });
+
+    // The device shell observation reports success: true for any delivered
+    // observation — the actual exit status only lives in exitCode.
+    it('reports failure when the script exits non-zero despite a successful observation', async () => {
+      mocks.executeToolCall.mockResolvedValue({
+        content: '',
+        state: { exitCode: 2, stderr: 'boom', stdout: '', success: true },
+        success: true,
+      });
+
+      const { skillsRuntime } = await import('../skills');
+      const runtime = await skillsRuntime.factory({
+        activeDeviceId: 'device-1',
+        serverDB: {} as never,
+        toolManifestMap: {},
+        topicId: 'topic-1',
+        userId: 'user-1',
+      });
+
+      const result = await runtime.execScript({
+        activatedSkills: [],
+        command: 'exit 2',
+        description: 'failing script',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.state).toMatchObject({ executionEnv: 'device', exitCode: 2 });
+      expect(result.content).toContain('boom');
+    });
+
+    it('forwards executionTimeoutMs as the shell observation timeout in the runCommand args', async () => {
+      mocks.executeToolCall.mockResolvedValue({
+        content: 'ok',
+        state: { exitCode: 0, stdout: 'ok', success: true },
+        success: true,
+      });
+
+      const { skillsRuntime } = await import('../skills');
+      const runtime = await skillsRuntime.factory({
+        activeDeviceId: 'device-1',
+        executionTimeoutMs: 300_000,
+        serverDB: {} as never,
+        toolManifestMap: {},
+        topicId: 'topic-1',
+        userId: 'user-1',
+      });
+
+      await runtime.execScript({
+        activatedSkills: [],
+        command: 'sleep 60',
+        description: 'long script',
+      });
+
+      expect(mocks.executeToolCall).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          arguments: JSON.stringify({ command: 'sleep 60', timeout: 300_000 }),
+        }),
+        300_000,
+      );
+    });
   });
 
   // Regression guard for the device-gating fix: builtin skills must be filtered

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/skills.test.ts
@@ -367,7 +367,8 @@ describe('skillsRuntime', () => {
       const result = await runtime.execScript({
         activatedSkills: [
           { id: 'user-skill-id', name: 'user-skill' },
-          { id: 'foo-id', name: 'foo' },
+          // Filesystem activations carry no DB id — matching is by name only.
+          { name: 'foo' },
         ],
         command: 'python scripts/run.py',
         description: 'Run project skill script',

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -64,6 +64,23 @@ interface ActivatedSkillArchive {
   zipHash: string;
 }
 
+/**
+ * Sentinel returned by `execScriptOnDevice` when the routed device runs a
+ * client build that predates the `prepareSkillDirectory` RPC (shipped with
+ * this feature). The device dispatcher replies deterministically with an
+ * unknown-method error, so this is a reliable capability probe — distinct
+ * from network failures/timeouts, which must NOT trigger a fallback.
+ */
+const LEGACY_DEVICE_CLIENT = Symbol('legacy-device-client');
+
+/**
+ * Appended to the sandbox result on a legacy-client fallback so the model
+ * discloses the degradation — the manifest already told it the command would
+ * run on the user's device.
+ */
+const LEGACY_FALLBACK_NOTE =
+  "Note: the user's device client is outdated and does not support on-device skill execution, so this command ran in the cloud sandbox instead. Tell the user to update their LobeHub app to run skills on their device.";
+
 class SkillServerRuntimeService implements SkillRuntimeService {
   private resourceService: SkillResourceService;
   private skillModel: AgentSkillModel;
@@ -213,13 +230,15 @@ class SkillServerRuntimeService implements SkillRuntimeService {
    *
    * Failures return an explicit error and NEVER fall back to the sandbox — a
    * silent sandbox run against a user who chose their device is exactly the
-   * regression this path fixes. Typical failure: an older desktop build that
-   * doesn't know the `prepareSkillDirectory` RPC yet.
+   * regression this path fixes. Single exception: an older client build that
+   * doesn't know the `prepareSkillDirectory` RPC yet (version-skew window)
+   * returns the `LEGACY_DEVICE_CLIENT` sentinel, and the caller runs the
+   * sandbox path with an explicit disclosure note instead.
    */
   private execScriptOnDevice = async (
     command: string,
     activatedSkills?: ExecScriptActivatedSkill[],
-  ): Promise<CommandResult> => {
+  ): Promise<CommandResult | typeof LEGACY_DEVICE_CLIENT> => {
     const device = this.device!;
     const fail = (stderr: string): CommandResult => ({
       executionEnv: 'device',
@@ -246,6 +265,14 @@ class SkillServerRuntimeService implements SkillRuntimeService {
         });
 
         if (!prepared.success || !prepared.extractedDir) {
+          // The device dispatcher's deterministic reply for a method it does
+          // not know — the client predates this RPC, hand back to the caller
+          // for the sandbox fallback.
+          if (prepared.error?.includes('Unknown device RPC method')) {
+            log('Device %s predates prepareSkillDirectory, falling back', device.deviceId);
+            return LEGACY_DEVICE_CLIENT;
+          }
+
           return fail(
             `Failed to prepare skill "${archive.name}" on the user's device: ${prepared.error ?? 'unknown error'}. ` +
               'Do not retry elsewhere — report this to the user (their LobeHub app may need an update).',
@@ -321,13 +348,32 @@ class SkillServerRuntimeService implements SkillRuntimeService {
       description: string;
     },
   ): Promise<CommandResult> => {
-    const { activatedSkills, description } = options;
-
     // Execution target follows the run's plan: a routed device wins over the
     // sandbox (restores the pre-gateway desktop behavior).
     if (this.device) {
-      return this.execScriptOnDevice(command, activatedSkills);
+      const deviceResult = await this.execScriptOnDevice(command, options.activatedSkills);
+      if (deviceResult !== LEGACY_DEVICE_CLIENT) return deviceResult;
+
+      // Version-skew fallback: the client predates the RPC. Run the sandbox
+      // path but disclose the degradation in stderr so the model relays it.
+      const sandboxResult = await this.execScriptInSandbox(command, options);
+      return {
+        ...sandboxResult,
+        stderr: [sandboxResult.stderr, LEGACY_FALLBACK_NOTE].filter(Boolean).join('\n'),
+      };
     }
+
+    return this.execScriptInSandbox(command, options);
+  };
+
+  private execScriptInSandbox = async (
+    command: string,
+    options: {
+      activatedSkills?: ExecScriptActivatedSkill[];
+      description: string;
+    },
+  ): Promise<CommandResult> => {
+    const { activatedSkills, description } = options;
 
     if (!this.topicId) {
       throw new Error('topicId is required for execScript');

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -52,11 +52,27 @@ interface SkillDeviceExecution {
   deviceId: string;
   executionTimeoutMs?: number;
   operationId?: string;
+  /**
+   * Filesystem skills already living on the device (project/device SKILL.md).
+   * execScript resolves their SKILL.md directory as cwd, mirroring the
+   * prepared-archive skills.
+   */
+  projectSkills?: { location: string; name: string }[];
   /** Lazily resolved workspace principal — see `resolveRunWorkspaceId`. */
   resolveWorkspaceId: () => Promise<string | undefined>;
-  /** cwd fallback when no activated skill ships an archive. */
+  /** cwd fallback when no activated skill resolves to a directory. */
   workingDirectory?: string;
 }
+
+/**
+ * Cross-platform dirname for device paths, which may use either separator
+ * depending on the device OS (mirrors `getDirname` in the builtin-tool-skills
+ * ExecutionRuntime — server-side `path.dirname` would mishandle `\`).
+ */
+const deviceDirname = (filePath: string): string => {
+  const idx = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+  return idx === -1 ? '' : filePath.slice(0, idx);
+};
 
 interface ActivatedSkillArchive {
   name: string;
@@ -250,12 +266,31 @@ class SkillServerRuntimeService implements SkillRuntimeService {
 
     try {
       const archives = await this.resolveActivatedSkillArchives(activatedSkills);
+      const archiveByName = new Map(archives.map((a) => [a.name.toLowerCase(), a]));
       const workspaceId = await device.resolveWorkspaceId();
 
-      // Prepare all activated archives; the LAST one (most recently activated)
-      // wins as cwd — mirrors the sandbox provider's resolveExecScriptSkillName.
+      // Resolve each activated skill to a device directory in activation
+      // order; the LAST resolvable one wins as cwd — mirrors the sandbox
+      // provider's resolveExecScriptSkillName. Filesystem (project/device)
+      // skills already live on the device, so their SKILL.md directory is the
+      // cwd directly; archive-backed skills are prepared device-side first
+      // (idempotent by zipHash).
       let runDir: string | undefined;
-      for (const archive of archives) {
+      for (const activated of activatedSkills ?? []) {
+        if (!activated.name) continue;
+        const lowerName = activated.name.toLowerCase();
+
+        // Filesystem skills take precedence on name collision, matching
+        // `activateSkill` in the ExecutionRuntime.
+        const projectSkill = device.projectSkills?.find((s) => s.name.toLowerCase() === lowerName);
+        if (projectSkill) {
+          runDir = deviceDirname(projectSkill.location) || runDir;
+          continue;
+        }
+
+        const archive = archiveByName.get(lowerName);
+        if (!archive) continue;
+
         const prepared = await deviceGateway.prepareSkillDirectory({
           deviceId: device.deviceId,
           url: archive.url,
@@ -307,6 +342,7 @@ class SkillServerRuntimeService implements SkillRuntimeService {
       log('execScript device response: %O', response);
 
       const state = (response.state ?? {}) as {
+        commandId?: string;
         exitCode?: number;
         stderr?: string;
         stdout?: string;
@@ -323,17 +359,19 @@ class SkillServerRuntimeService implements SkillRuntimeService {
 
       // The device shell reports success for any delivered observation, even
       // when the command exited non-zero (the exit status only lives in
-      // exitCode) — derive success from the exit status instead. A missing
+      // exitCode) — derive success from the exit status instead. An undefined
       // exitCode means the command is still running past the observation
-      // window; keep that non-failing (the script keeps running on the
-      // device), matching the legacy desktop behavior.
-      const exitCode = state.exitCode ?? 0;
+      // window: pass it through with the shell handle so the formatter
+      // reports a running command (pollable via local-system.getCommandOutput)
+      // instead of pretending completion.
+      const exitCode = state.exitCode;
       return {
         executionEnv: 'device',
         exitCode,
         output: state.stdout ?? response.content ?? '',
+        shellId: state.commandId,
         stderr: state.stderr,
-        success: exitCode === 0,
+        success: exitCode === undefined || exitCode === 0,
       };
     } catch (error) {
       log('Error executing script on device: %O', error);
@@ -514,6 +552,7 @@ export const skillsRuntime: ServerRuntimeRegistration = {
           deviceId: context.activeDeviceId,
           executionTimeoutMs: context.executionTimeoutMs,
           operationId: context.operationId,
+          projectSkills: context.projectSkills,
           // Same lazy workspace-principal recovery as the local-system runtime,
           // so workspace devices are addressed under the right gateway pool.
           resolveWorkspaceId: () => (workspaceIdPromise ??= resolveRunWorkspaceId(context)),

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -549,11 +549,13 @@ export const skillsRuntime: ServerRuntimeRegistration = {
     const fileService = new FileService(context.serverDB, context.userId, context.workspaceId);
     const fileModel = new FileModel(context.serverDB, context.userId, context.workspaceId);
 
-    // `activeDeviceId` is set by the aiAgent ONLY when the execution plan
-    // routed a device (`plan.kind === 'device'`), so its presence is the
-    // device-branch switch: execScript then runs on the device instead of the
-    // cloud sandbox. `device-unrouted` runs carry no activeDeviceId and keep
-    // the sandbox path (with the unrouted disclosure in the manifest).
+    // `activeDeviceId` presence is the device-branch switch: execScript then
+    // runs on the device instead of the cloud sandbox. The executors filter
+    // the raw metadata id through `resolveRunActiveDeviceId` (plan/policy
+    // gate) before it reaches this context, so a preset or stale id cannot
+    // route execution onto a device the resolved plan didn't authorize;
+    // `device-unrouted` runs keep the sandbox path (with the unrouted
+    // disclosure in the manifest).
     let workspaceIdPromise: Promise<string | undefined> | undefined;
     const device: SkillDeviceExecution | undefined = context.activeDeviceId
       ? {

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -150,6 +150,21 @@ class SkillServerRuntimeService implements SkillRuntimeService {
   };
 
   runCommand = async (options: { command: string }): Promise<CommandResult> => {
+    // The device manifest hides this sandbox API (`DEVICE_HIDDEN_API_NAMES` in
+    // `resolveManifest`), but the builtin executor dispatches any method that
+    // exists on this runtime regardless of the manifest — enforce the same
+    // decision at execution time so a prompt-following or hallucinated call
+    // can't silently run in the sandbox while the user expects their device.
+    if (this.device) {
+      return {
+        exitCode: 1,
+        output: '',
+        stderr:
+          'runCommand targets the cloud sandbox and is unavailable while a local device is routed. Use execScript for skill scripts, or lobe-local-system runCommand for other shell commands on the device.',
+        success: false,
+      };
+    }
+
     if (!this.topicId) {
       throw new Error('topicId is required for runCommand');
     }
@@ -345,6 +360,7 @@ class SkillServerRuntimeService implements SkillRuntimeService {
         commandId?: string;
         error?: string;
         exitCode?: number;
+        outputFiles?: CommandResult['outputFiles'];
         stderr?: string;
         stdout?: string;
         success?: boolean;
@@ -377,6 +393,9 @@ class SkillServerRuntimeService implements SkillRuntimeService {
         executionEnv: 'device',
         exitCode,
         output: state.stdout ?? response.content ?? '',
+        // Large streams are truncated to a preview device-side with the full
+        // output saved to disk — the paths are the only retrieval handle.
+        outputFiles: state.outputFiles,
         shellId: state.commandId,
         stderr: state.stderr,
         success: exitCode === undefined || exitCode === 0,
@@ -476,6 +495,14 @@ class SkillServerRuntimeService implements SkillRuntimeService {
   };
 
   exportFile = async (path: string, filename: string): Promise<ExportFileResult> => {
+    // Same manifest-hidden guard as `runCommand`: the message reaches the
+    // model through the ExecutionRuntime catch ("Failed to export file: ...").
+    if (this.device) {
+      throw new Error(
+        "exportFile pulls artifacts out of the cloud sandbox and is unavailable while a local device is routed — files created on the device are already on the user's machine.",
+      );
+    }
+
     if (!this.topicId) {
       throw new Error('topicId is required for exportFile');
     }

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -264,7 +264,14 @@ class SkillServerRuntimeService implements SkillRuntimeService {
         },
         {
           apiName: LocalSystemApiName.runCommand,
-          arguments: JSON.stringify({ command, ...(cwd && { cwd }) }),
+          // `timeout` is the device-side shell observation window (default
+          // 30s, clamped at the device's MAX_OBSERVATION_TIMEOUT_MS) — without
+          // it a long script returns early while still running.
+          arguments: JSON.stringify({
+            command,
+            ...(cwd && { cwd }),
+            ...(device.executionTimeoutMs && { timeout: device.executionTimeoutMs }),
+          }),
           identifier: LocalSystemIdentifier,
         },
         device.executionTimeoutMs,
@@ -287,12 +294,19 @@ class SkillServerRuntimeService implements SkillRuntimeService {
         );
       }
 
+      // The device shell reports success for any delivered observation, even
+      // when the command exited non-zero (the exit status only lives in
+      // exitCode) — derive success from the exit status instead. A missing
+      // exitCode means the command is still running past the observation
+      // window; keep that non-failing (the script keeps running on the
+      // device), matching the legacy desktop behavior.
+      const exitCode = state.exitCode ?? 0;
       return {
         executionEnv: 'device',
-        exitCode: state.exitCode ?? 0,
+        exitCode,
         output: state.stdout ?? response.content ?? '',
         stderr: state.stderr,
-        success: true,
+        success: exitCode === 0,
       };
     } catch (error) {
       log('Error executing script on device: %O', error);

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -10,6 +10,7 @@ import {
 import {
   type DeviceFileAccess,
   type ExportFileResult,
+  getDirname,
   type SkillRuntimeService,
   SkillsExecutionRuntime,
 } from '@lobechat/builtin-tool-skills/executionRuntime';
@@ -63,16 +64,6 @@ interface SkillDeviceExecution {
   /** cwd fallback when no activated skill resolves to a directory. */
   workingDirectory?: string;
 }
-
-/**
- * Cross-platform dirname for device paths, which may use either separator
- * depending on the device OS (mirrors `getDirname` in the builtin-tool-skills
- * ExecutionRuntime — server-side `path.dirname` would mishandle `\`).
- */
-const deviceDirname = (filePath: string): string => {
-  const idx = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
-  return idx === -1 ? '' : filePath.slice(0, idx);
-};
 
 interface ActivatedSkillArchive {
   name: string;
@@ -290,6 +281,43 @@ class SkillServerRuntimeService implements SkillRuntimeService {
       // skills already live on the device, so their SKILL.md directory is the
       // cwd directly; archive-backed skills are prepared device-side first
       // (idempotent by zipHash).
+      //
+      // Prepares fire concurrently (deduped by zipHash — concurrent extraction
+      // of the same archive would also race device-side): each call is a full
+      // device-gateway round-trip and activatedSkills accumulates over the
+      // conversation, so awaiting one by one scales exec latency linearly with
+      // skill count. The walk below consumes the settled results in activation
+      // order, preserving the sequential semantics: last resolvable wins, and
+      // the FIRST failure in activation order is the one reported (including
+      // the legacy-client sentinel).
+      const isProjectSkill = (lowerName: string) =>
+        device.projectSkills?.some((s) => s.name.toLowerCase() === lowerName);
+      const prepareByHash = new Map<
+        string,
+        ReturnType<typeof deviceGateway.prepareSkillDirectory>
+      >();
+      for (const activated of activatedSkills ?? []) {
+        const lowerName = activated.name?.toLowerCase();
+        if (!lowerName || isProjectSkill(lowerName)) continue;
+        const archive = archiveByName.get(lowerName);
+        if (!archive || prepareByHash.has(archive.zipHash)) continue;
+        prepareByHash.set(
+          archive.zipHash,
+          deviceGateway.prepareSkillDirectory({
+            deviceId: device.deviceId,
+            url: archive.url,
+            userId: this.userId,
+            workspaceId,
+            zipHash: archive.zipHash,
+          }),
+        );
+      }
+      // Settle everything up front so the early return on a first failure
+      // below can't leave a later rejection unhandled (prepareSkillDirectory
+      // reports failures as `success: false` rather than throwing, so this is
+      // belt-and-braces; re-awaiting a settled entry in the walk is free).
+      await Promise.allSettled(prepareByHash.values());
+
       let runDir: string | undefined;
       for (const activated of activatedSkills ?? []) {
         if (!activated.name) continue;
@@ -299,20 +327,14 @@ class SkillServerRuntimeService implements SkillRuntimeService {
         // `activateSkill` in the ExecutionRuntime.
         const projectSkill = device.projectSkills?.find((s) => s.name.toLowerCase() === lowerName);
         if (projectSkill) {
-          runDir = deviceDirname(projectSkill.location) || runDir;
+          runDir = getDirname(projectSkill.location) || runDir;
           continue;
         }
 
         const archive = archiveByName.get(lowerName);
         if (!archive) continue;
 
-        const prepared = await deviceGateway.prepareSkillDirectory({
-          deviceId: device.deviceId,
-          url: archive.url,
-          userId: this.userId,
-          workspaceId,
-          zipHash: archive.zipHash,
-        });
+        const prepared = await prepareByHash.get(archive.zipHash)!;
 
         if (!prepared.success || !prepared.extractedDir) {
           // The device dispatcher's deterministic reply for a method it does

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -699,6 +699,10 @@ export const skillsRuntime: ServerRuntimeRegistration = {
     }
 
     return new SkillsExecutionRuntime({
+      // Resolved by the runtime executors from the operation's message
+      // history (the server-side stepContext equivalent); execScript falls
+      // back to these because the raw LLM args never carry activatedSkills.
+      activatedSkills: context.activatedSkills,
       builtinSkills: [
         // Device-only skills resolve in device-capable runs — mirrors the
         // SkillEngine gate in aiAgent that builds <available_skills>, so a

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -29,6 +29,7 @@ import { createSandboxService, normalizeSandboxCommandResult } from '@/server/se
 import { SkillResourceService } from '@/server/services/skill/resource';
 import { preprocessLhCommand } from '@/server/services/toolExecution/preprocessLhCommand';
 
+import { resolveRunWorkspaceId } from './resolveWorkspaceScope';
 import { type ServerRuntimeRegistration } from './types';
 
 const log = debug('lobe-server:skills-runtime');
@@ -37,6 +38,30 @@ interface UserSettingsWithMarketToken {
   market?: {
     accessToken?: string;
   };
+}
+
+/**
+ * Device-execution wiring for the exec APIs, present only when the run's
+ * execution plan routed a device (`plan.kind === 'device'` — the aiAgent sets
+ * `context.activeDeviceId` from exactly that condition). When present,
+ * `execScript` runs ON the device instead of the cloud sandbox: skill archives
+ * are prepared device-side via the `prepareSkillDirectory` RPC and the command
+ * executes through the local-system tool over the device gateway.
+ */
+interface SkillDeviceExecution {
+  deviceId: string;
+  executionTimeoutMs?: number;
+  operationId?: string;
+  /** Lazily resolved workspace principal — see `resolveRunWorkspaceId`. */
+  resolveWorkspaceId: () => Promise<string | undefined>;
+  /** cwd fallback when no activated skill ships an archive. */
+  workingDirectory?: string;
+}
+
+interface ActivatedSkillArchive {
+  name: string;
+  url: string;
+  zipHash: string;
 }
 
 class SkillServerRuntimeService implements SkillRuntimeService {
@@ -48,8 +73,10 @@ class SkillServerRuntimeService implements SkillRuntimeService {
   private serverDB: LobeChatDatabase;
   private topicId?: string;
   private userId: string;
+  private device?: SkillDeviceExecution;
 
   constructor(options: {
+    device?: SkillDeviceExecution;
     fileModel: FileModel;
     fileService: FileService;
     marketService: MarketService;
@@ -67,6 +94,7 @@ class SkillServerRuntimeService implements SkillRuntimeService {
     this.serverDB = options.serverDB;
     this.topicId = options.topicId;
     this.userId = options.userId;
+    this.device = options.device;
   }
 
   findAll = (): Promise<{ data: SkillListItem[]; total: number }> => {
@@ -96,7 +124,13 @@ class SkillServerRuntimeService implements SkillRuntimeService {
     // Preprocess lh commands: rewrite to npx @lobehub/cli + inject auth env vars
     const lhResult = await preprocessLhCommand(options.command, this.userId);
     if (lhResult.error) {
-      return { exitCode: 1, output: '', stderr: lhResult.error, success: false };
+      return {
+        executionEnv: 'sandbox',
+        exitCode: 1,
+        output: '',
+        stderr: lhResult.error,
+        success: false,
+      };
     }
 
     try {
@@ -113,6 +147,7 @@ class SkillServerRuntimeService implements SkillRuntimeService {
 
       if (!response.success) {
         return {
+          executionEnv: 'sandbox',
           exitCode: 1,
           output: '',
           stderr: response.error?.message || 'Command execution failed',
@@ -120,15 +155,148 @@ class SkillServerRuntimeService implements SkillRuntimeService {
         };
       }
 
-      return normalizeSandboxCommandResult(response);
+      return { ...normalizeSandboxCommandResult(response), executionEnv: 'sandbox' };
     } catch (error) {
       log('Error running command: %O', error);
       return {
+        executionEnv: 'sandbox',
         exitCode: 1,
         output: '',
         stderr: (error as Error).message || 'Command execution failed',
         success: false,
       };
+    }
+  };
+
+  /**
+   * Resolve the presigned zip URLs (+ content hashes) of the activated skills
+   * that have a persisted archive, preserving activation order. Shared by the
+   * sandbox path (needs name → url) and the device path (needs the zipHash as
+   * the device-cache idempotency key).
+   */
+  private resolveActivatedSkillArchives = async (
+    activatedSkills?: ExecScriptActivatedSkill[],
+  ): Promise<ActivatedSkillArchive[]> => {
+    const archives: ActivatedSkillArchive[] = [];
+    if (!activatedSkills?.length) return archives;
+
+    for (const activatedSkill of activatedSkills) {
+      if (!activatedSkill.name) continue;
+
+      const skill = await this.skillModel.findByName(activatedSkill.name);
+
+      if (!skill) {
+        log('No persisted skill bundle found for activated skill: %s', activatedSkill.name);
+        continue;
+      }
+
+      if (!skill.zipFileHash) continue;
+
+      const fileInfo = await this.fileModel.checkHash(skill.zipFileHash);
+      if (!fileInfo.isExist || !fileInfo.url) continue;
+
+      const fullUrl = await this.fileService.getFullFileUrl(fileInfo.url);
+      if (fullUrl) {
+        archives.push({ name: skill.name, url: fullUrl, zipHash: skill.zipFileHash });
+        log('Resolved zipUrl for skill %s', skill.name);
+      }
+    }
+
+    return archives;
+  };
+
+  /**
+   * Run execScript ON the routed device: prepare every activated skill archive
+   * device-side (idempotent by zipHash), then execute the command through the
+   * local-system tool over the device gateway with cwd = the extracted skill
+   * directory.
+   *
+   * Failures return an explicit error and NEVER fall back to the sandbox — a
+   * silent sandbox run against a user who chose their device is exactly the
+   * regression this path fixes. Typical failure: an older desktop build that
+   * doesn't know the `prepareSkillDirectory` RPC yet.
+   */
+  private execScriptOnDevice = async (
+    command: string,
+    activatedSkills?: ExecScriptActivatedSkill[],
+  ): Promise<CommandResult> => {
+    const device = this.device!;
+    const fail = (stderr: string): CommandResult => ({
+      executionEnv: 'device',
+      exitCode: 1,
+      output: '',
+      stderr,
+      success: false,
+    });
+
+    try {
+      const archives = await this.resolveActivatedSkillArchives(activatedSkills);
+      const workspaceId = await device.resolveWorkspaceId();
+
+      // Prepare all activated archives; the LAST one (most recently activated)
+      // wins as cwd — mirrors the sandbox provider's resolveExecScriptSkillName.
+      let runDir: string | undefined;
+      for (const archive of archives) {
+        const prepared = await deviceGateway.prepareSkillDirectory({
+          deviceId: device.deviceId,
+          url: archive.url,
+          userId: this.userId,
+          workspaceId,
+          zipHash: archive.zipHash,
+        });
+
+        if (!prepared.success || !prepared.extractedDir) {
+          return fail(
+            `Failed to prepare skill "${archive.name}" on the user's device: ${prepared.error ?? 'unknown error'}. ` +
+              'Do not retry elsewhere — report this to the user (their LobeHub app may need an update).',
+          );
+        }
+        runDir = prepared.extractedDir;
+      }
+
+      const cwd = runDir ?? device.workingDirectory;
+      const response = await deviceGateway.executeToolCall(
+        {
+          deviceId: device.deviceId,
+          operationId: device.operationId,
+          userId: this.userId,
+          workspaceId,
+        },
+        {
+          apiName: LocalSystemApiName.runCommand,
+          arguments: JSON.stringify({ command, ...(cwd && { cwd }) }),
+          identifier: LocalSystemIdentifier,
+        },
+        device.executionTimeoutMs,
+      );
+
+      log('execScript device response: %O', response);
+
+      const state = (response.state ?? {}) as {
+        exitCode?: number;
+        stderr?: string;
+        stdout?: string;
+      };
+
+      if (!response.success) {
+        return fail(
+          state.stderr ||
+            response.error ||
+            response.content ||
+            'Command execution failed on the device',
+        );
+      }
+
+      return {
+        executionEnv: 'device',
+        exitCode: state.exitCode ?? 0,
+        output: state.stdout ?? response.content ?? '',
+        stderr: state.stderr,
+        success: true,
+      };
+    } catch (error) {
+      log('Error executing script on device: %O', error);
+      return fail((error as Error).message || 'Command execution failed on the device');
     }
   };
 
@@ -141,6 +309,12 @@ class SkillServerRuntimeService implements SkillRuntimeService {
   ): Promise<CommandResult> => {
     const { activatedSkills, description } = options;
 
+    // Execution target follows the run's plan: a routed device wins over the
+    // sandbox (restores the pre-gateway desktop behavior).
+    if (this.device) {
+      return this.execScriptOnDevice(command, activatedSkills);
+    }
+
     if (!this.topicId) {
       throw new Error('topicId is required for execScript');
     }
@@ -152,35 +326,13 @@ class SkillServerRuntimeService implements SkillRuntimeService {
         description,
       };
 
-      if (activatedSkills?.length) {
-        const skillZipUrls: Record<string, string> = {};
-
-        for (const activatedSkill of activatedSkills) {
-          if (!activatedSkill.name) continue;
-
-          const skill = await this.skillModel.findByName(activatedSkill.name);
-
-          if (!skill) {
-            log('No persisted skill bundle found for activated skill: %s', activatedSkill.name);
-            continue;
-          }
-
-          if (!skill.zipFileHash) continue;
-
-          const fileInfo = await this.fileModel.checkHash(skill.zipFileHash);
-          if (!fileInfo.isExist || !fileInfo.url) continue;
-
-          const fullUrl = await this.fileService.getFullFileUrl(fileInfo.url);
-          if (fullUrl) {
-            skillZipUrls[skill.name] = fullUrl;
-            log('Resolved zipUrl for skill %s', skill.name);
-          }
-        }
-
-        if (Object.keys(skillZipUrls).length > 0) {
-          enhancedParams.skillZipUrls = skillZipUrls;
-          log('Added skillZipUrls to execScript params: %O', Object.keys(skillZipUrls));
-        }
+      const archives = await this.resolveActivatedSkillArchives(activatedSkills);
+      if (archives.length > 0) {
+        enhancedParams.skillZipUrls = Object.fromEntries(archives.map((a) => [a.name, a.url]));
+        log(
+          'Added skillZipUrls to execScript params: %O',
+          archives.map((a) => a.name),
+        );
       }
 
       const sandboxService = createSandboxService({
@@ -196,6 +348,7 @@ class SkillServerRuntimeService implements SkillRuntimeService {
 
       if (!response.success) {
         return {
+          executionEnv: 'sandbox',
           exitCode: 1,
           output: '',
           stderr: response.error?.message || 'Command execution failed',
@@ -203,10 +356,11 @@ class SkillServerRuntimeService implements SkillRuntimeService {
         };
       }
 
-      return normalizeSandboxCommandResult(response);
+      return { ...normalizeSandboxCommandResult(response), executionEnv: 'sandbox' };
     } catch (error) {
       log('Error executing script: %O', error);
       return {
+        executionEnv: 'sandbox',
         exitCode: 1,
         output: '',
         stderr: (error as Error).message || 'Command execution failed',
@@ -289,7 +443,26 @@ export const skillsRuntime: ServerRuntimeRegistration = {
     const fileService = new FileService(context.serverDB, context.userId, context.workspaceId);
     const fileModel = new FileModel(context.serverDB, context.userId, context.workspaceId);
 
+    // `activeDeviceId` is set by the aiAgent ONLY when the execution plan
+    // routed a device (`plan.kind === 'device'`), so its presence is the
+    // device-branch switch: execScript then runs on the device instead of the
+    // cloud sandbox. `device-unrouted` runs carry no activeDeviceId and keep
+    // the sandbox path (with the unrouted disclosure in the manifest).
+    let workspaceIdPromise: Promise<string | undefined> | undefined;
+    const device: SkillDeviceExecution | undefined = context.activeDeviceId
+      ? {
+          deviceId: context.activeDeviceId,
+          executionTimeoutMs: context.executionTimeoutMs,
+          operationId: context.operationId,
+          // Same lazy workspace-principal recovery as the local-system runtime,
+          // so workspace devices are addressed under the right gateway pool.
+          resolveWorkspaceId: () => (workspaceIdPromise ??= resolveRunWorkspaceId(context)),
+          workingDirectory: context.workingDirectory,
+        }
+      : undefined;
+
     const service = new SkillServerRuntimeService({
+      device,
       fileModel,
       fileService,
       marketService,

--- a/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/skills.ts
@@ -343,14 +343,22 @@ class SkillServerRuntimeService implements SkillRuntimeService {
 
       const state = (response.state ?? {}) as {
         commandId?: string;
+        error?: string;
         exitCode?: number;
         stderr?: string;
         stdout?: string;
+        success?: boolean;
       };
 
-      if (!response.success) {
+      // `response.success` is the delivery envelope only: the device-side
+      // ComputerRuntime reports service failures (spawn error, shell lost,
+      // missing params) as `success: true` with `state.success: false` and no
+      // exitCode (`errorOutput`) — without this check they'd fall through to
+      // the still-running branch below and read as a successful run.
+      if (!response.success || state.success === false) {
         return fail(
           state.stderr ||
+            state.error ||
             response.error ||
             response.content ||
             'Command execution failed on the device',

--- a/apps/server/src/services/toolExecution/types.ts
+++ b/apps/server/src/services/toolExecution/types.ts
@@ -4,6 +4,7 @@ import {
   type ChatToolPayload,
   type ClientSecretPayload,
   type ExecSubAgentParams,
+  type StepActivatedSkill,
 } from '@lobechat/types';
 
 export interface ToolExecutionMemoryEmbeddingRuntime {
@@ -115,6 +116,15 @@ export interface ServerAgentMemberRunner {
 }
 
 export interface ToolExecutionContext {
+  /**
+   * Skills activated so far in the conversation (activateSkill /
+   * activateTools tool results), extracted by the runtime executors from the
+   * operation's message history — the server-side equivalent of the client
+   * transport's stepContext. The skills runtime uses this to resolve skill
+   * archives for `execScript` (device `prepareSkillDirectory` + sandbox
+   * `skillZipUrls`); the raw LLM args never carry it.
+   */
+  activatedSkills?: StepActivatedSkill[];
   /** Target device ID for device proxy tool calls */
   activeDeviceId?: string;
   /** Agent ID executing the tool call */

--- a/packages/agent-runtime/src/utils/messageSelectors.test.ts
+++ b/packages/agent-runtime/src/utils/messageSelectors.test.ts
@@ -1,7 +1,11 @@
 import type { UIChatMessage } from '@lobechat/types';
 import { describe, expect, it } from 'vitest';
 
-import { collectFromMessages, findInMessages } from './messageSelectors';
+import {
+  collectFromMessages,
+  extractActivatedSkillsFromMessages,
+  findInMessages,
+} from './messageSelectors';
 
 const createMessage = (overrides: Partial<UIChatMessage> = {}): UIChatMessage =>
   ({
@@ -93,5 +97,226 @@ describe('collectFromMessages', () => {
     });
 
     expect(result).toEqual(['tool']);
+  });
+});
+
+describe('extractActivatedSkillsFromMessages', () => {
+  it('should return undefined when no skill activations exist', () => {
+    const messages = [
+      createMessage({ content: 'hi', role: 'user' } as any),
+      createToolMessage({ plugin: { apiName: 'execScript', identifier: 'lobe-skills' } } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toBeUndefined();
+  });
+
+  it('should extract skills from direct activateSkill results', () => {
+    const messages = [
+      createToolMessage({
+        plugin: { apiName: 'activateSkill', identifier: 'lobe-skills' },
+        pluginState: { description: 'PDF tools', id: 'skl_1', name: 'pdf' },
+      } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toEqual([
+      { description: 'PDF tools', id: 'skl_1', name: 'pdf' },
+    ]);
+  });
+
+  it('should extract skills from activator activateSkill and activateTools results', () => {
+    const messages = [
+      createToolMessage({
+        plugin: { apiName: 'activateSkill', identifier: 'lobe-activator' },
+        pluginState: { id: 'skl_1', name: 'pdf' },
+      } as any),
+      createToolMessage({
+        plugin: { apiName: 'activateTools', identifier: 'lobe-activator' },
+        pluginState: {
+          activatedSkills: [
+            { description: 'sheets', id: 'skl_2', name: 'xlsx' },
+            { id: 'missing-name-dropped' },
+          ],
+        },
+      } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toEqual([
+      { description: undefined, id: 'skl_1', name: 'pdf' },
+      { description: 'sheets', id: 'skl_2', name: 'xlsx' },
+    ]);
+  });
+
+  it('should deduplicate by skill id with later activations winning', () => {
+    const messages = [
+      createToolMessage({
+        plugin: { apiName: 'activateSkill', identifier: 'lobe-skills' },
+        pluginState: { description: 'old', id: 'skl_1', name: 'pdf' },
+      } as any),
+      createToolMessage({
+        plugin: { apiName: 'activateSkill', identifier: 'lobe-skills' },
+        pluginState: { description: 'new', id: 'skl_1', name: 'pdf' },
+      } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toEqual([
+      { description: 'new', id: 'skl_1', name: 'pdf' },
+    ]);
+  });
+
+  it('should ignore non-tool roles and other tool identifiers', () => {
+    const messages = [
+      createMessage({
+        plugin: { apiName: 'activateSkill', identifier: 'lobe-skills' },
+        pluginState: { id: 'skl_1', name: 'pdf' },
+        role: 'assistant',
+      } as any),
+      createToolMessage({
+        plugin: { apiName: 'activateSkill', identifier: 'lobe-web-browsing' },
+        pluginState: { id: 'skl_2', name: 'web' },
+      } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toBeUndefined();
+  });
+
+  // The server runtime rehydrates state.messages from the DB at every step
+  // (rehydrateStateMessagesFromDB), which runs conversation-flow parse():
+  // completed turns are folded into assistantGroup virtual nodes where tool
+  // rows live on children[].tools[] with pluginState as result.state.
+  it('should extract skills folded into assistantGroup nodes (cross-turn rehydrated state)', () => {
+    const messages = [
+      createMessage({ content: 'activate xlsx', role: 'user' } as any),
+      createMessage({
+        children: [
+          {
+            content: '',
+            id: 'msg-asst-1',
+            tools: [
+              {
+                apiName: 'activateSkill',
+                arguments: '{"name":"xlsx"}',
+                id: 'call_1',
+                identifier: 'lobe-skills',
+                result: {
+                  content: 'activated',
+                  id: 'msg-tool-1',
+                  state: { description: 'sheets', id: 'skl_1', name: 'xlsx' },
+                },
+              },
+            ],
+          },
+          {
+            content: 'done',
+            id: 'msg-asst-2',
+            tools: [
+              {
+                apiName: 'execScript',
+                id: 'call_2',
+                identifier: 'lobe-skills',
+                result: { content: 'ok', id: 'msg-tool-2', state: { executionEnv: 'device' } },
+              },
+            ],
+          },
+        ],
+        role: 'assistantGroup',
+      } as any),
+      createMessage({ content: 'run it again', role: 'user' } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toEqual([
+      { description: 'sheets', id: 'skl_1', name: 'xlsx' },
+    ]);
+  });
+
+  it('should extract activateTools skills from assistantGroup nodes', () => {
+    const messages = [
+      createMessage({
+        children: [
+          {
+            content: '',
+            id: 'msg-asst-1',
+            tools: [
+              {
+                apiName: 'activateTools',
+                id: 'call_1',
+                identifier: 'lobe-activator',
+                result: {
+                  content: 'activated',
+                  id: 'msg-tool-1',
+                  state: { activatedSkills: [{ id: 'skl_2', name: 'pdf' }] },
+                },
+              },
+            ],
+          },
+        ],
+        role: 'assistantGroup',
+      } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toEqual([
+      { description: undefined, id: 'skl_2', name: 'pdf' },
+    ]);
+  });
+
+  it('should recurse into compressedGroup compressedMessages', () => {
+    const messages = [
+      createMessage({
+        compressedMessages: [
+          createMessage({
+            children: [
+              {
+                content: '',
+                id: 'msg-asst-1',
+                tools: [
+                  {
+                    apiName: 'activateSkill',
+                    id: 'call_1',
+                    identifier: 'lobe-skills',
+                    result: {
+                      content: 'ok',
+                      id: 'msg-tool-1',
+                      state: { id: 'skl_3', name: 'docx' },
+                    },
+                  },
+                ],
+              },
+            ],
+            role: 'assistantGroup',
+          } as any),
+        ],
+        role: 'compressedGroup',
+      } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toEqual([
+      { description: undefined, id: 'skl_3', name: 'docx' },
+    ]);
+  });
+
+  it('should ignore assistantGroup tools without activation state or with other identifiers', () => {
+    const messages = [
+      createMessage({
+        children: [
+          {
+            content: '',
+            id: 'msg-asst-1',
+            tools: [
+              // Tool without a captured result (still pending)
+              { apiName: 'activateSkill', id: 'call_1', identifier: 'lobe-skills' },
+              // Non-skill identifier
+              {
+                apiName: 'activateSkill',
+                id: 'call_2',
+                identifier: 'lobe-web-browsing',
+                result: { content: 'ok', id: 'msg-tool-2', state: { id: 'skl_9', name: 'web' } },
+              },
+            ],
+          },
+        ],
+        role: 'assistantGroup',
+      } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toBeUndefined();
   });
 });

--- a/packages/agent-runtime/src/utils/messageSelectors.test.ts
+++ b/packages/agent-runtime/src/utils/messageSelectors.test.ts
@@ -163,6 +163,27 @@ describe('extractActivatedSkillsFromMessages', () => {
     ]);
   });
 
+  // Exec paths pick the LAST entry as the most recent activation for the
+  // script cwd, so a reactivation must move the skill to the end.
+  it('should move a reactivated skill to the end of the activation order', () => {
+    const activate = (id: string, name: string) =>
+      createToolMessage({
+        plugin: { apiName: 'activateSkill', identifier: 'lobe-skills' },
+        pluginState: { id, name },
+      } as any);
+
+    const messages = [
+      activate('skl_a', 'alpha'),
+      activate('skl_b', 'beta'),
+      activate('skl_a', 'alpha'),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toEqual([
+      { description: undefined, id: 'skl_b', name: 'beta' },
+      { description: undefined, id: 'skl_a', name: 'alpha' },
+    ]);
+  });
+
   // Filesystem (project/device) and builtin skill activations persist no DB
   // id — dropping them broke device-exec cwd resolution, which matches
   // activated skills against device.projectSkills by name.

--- a/packages/agent-runtime/src/utils/messageSelectors.test.ts
+++ b/packages/agent-runtime/src/utils/messageSelectors.test.ts
@@ -163,6 +163,49 @@ describe('extractActivatedSkillsFromMessages', () => {
     ]);
   });
 
+  // Filesystem (project/device) and builtin skill activations persist no DB
+  // id — dropping them broke device-exec cwd resolution, which matches
+  // activated skills against device.projectSkills by name.
+  it('should keep activateSkill states without an id (filesystem/builtin skills)', () => {
+    const messages = [
+      createToolMessage({
+        plugin: { apiName: 'activateSkill', identifier: 'lobe-skills' },
+        pluginState: {
+          hasResources: false,
+          location: '/repo/.agents/skills/foo/SKILL.md',
+          name: 'foo',
+          source: 'project',
+        },
+      } as any),
+      createToolMessage({
+        plugin: { apiName: 'activateTools', identifier: 'lobe-activator' },
+        pluginState: { activatedSkills: [{ description: 'builtin', name: 'bar' }] },
+      } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toEqual([
+      { description: undefined, name: 'foo' },
+      { description: 'builtin', name: 'bar' },
+    ]);
+  });
+
+  it('should deduplicate id-less activations by name with later activations winning', () => {
+    const messages = [
+      createToolMessage({
+        plugin: { apiName: 'activateSkill', identifier: 'lobe-skills' },
+        pluginState: { name: 'foo', source: 'project' },
+      } as any),
+      createToolMessage({
+        plugin: { apiName: 'activateSkill', identifier: 'lobe-skills' },
+        pluginState: { description: 'reactivated', name: 'foo', source: 'project' },
+      } as any),
+    ];
+
+    expect(extractActivatedSkillsFromMessages(messages)).toEqual([
+      { description: 'reactivated', name: 'foo' },
+    ]);
+  });
+
   it('should ignore non-tool roles and other tool identifiers', () => {
     const messages = [
       createMessage({

--- a/packages/agent-runtime/src/utils/messageSelectors.ts
+++ b/packages/agent-runtime/src/utils/messageSelectors.ts
@@ -1,4 +1,15 @@
-import type { UIChatMessage } from '@lobechat/types';
+import type { StepActivatedSkill, UIChatMessage } from '@lobechat/types';
+
+/**
+ * Wire-format tool identifiers that carry skill activations in their
+ * pluginState. Literal copies of `SkillsIdentifier`
+ * (@lobechat/builtin-tool-skills) and `LobeActivatorIdentifier`
+ * (@lobechat/builtin-tool-activator) — both are frozen, persisted in DB
+ * message rows, and not importable here without adding tool-package deps to
+ * the runtime core.
+ */
+const SKILLS_IDENTIFIER = 'lobe-skills';
+const ACTIVATOR_IDENTIFIER = 'lobe-activator';
 
 /**
  * Options for message visitor traversal
@@ -79,4 +90,129 @@ export const collectFromMessages = <T>(
   }
 
   return results;
+};
+
+/**
+ * A single tool invocation observed in the conversation, normalized across the
+ * two message shapes activations can arrive in (see
+ * `collectToolInvocations`).
+ */
+interface ToolInvocation {
+  apiName?: string;
+  identifier?: string;
+  state?: any;
+}
+
+/**
+ * Normalize one message into the tool invocations it carries.
+ *
+ * Two shapes must be handled:
+ * 1. Flat DB rows — `role='tool'` messages with `plugin` / `pluginState`
+ *    (client store, `execAgent` initialMessages, same-run pushed results).
+ * 2. Virtual grouped nodes produced by conversation-flow `parse()` — the
+ *    server runtime rehydrates `state.messages` from the DB at every step
+ *    (`rehydrateStateMessagesFromDB`), which folds completed turns into
+ *    `assistantGroup` / `supervisor` nodes: tool rows disappear as standalone
+ *    entries and live on `children[].tools[]` instead, with the original
+ *    `pluginState` re-attached as `result.state` (see
+ *    FlatListBuilder.createAssistantGroupMessage). Without this branch,
+ *    cross-turn skill activations are invisible to later runs.
+ *    `compressedGroup` nodes keep their members on `compressedMessages` in
+ *    the same flat-list shape, so recurse into them.
+ */
+const collectToolInvocations = (msg: UIChatMessage): ToolInvocation[] => {
+  if (msg.role === 'tool') {
+    return [
+      { apiName: msg.plugin?.apiName, identifier: msg.plugin?.identifier, state: msg.pluginState },
+    ];
+  }
+
+  const invocations: ToolInvocation[] = [];
+
+  const children = (msg as any).children;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      if (!Array.isArray(child?.tools)) continue;
+      for (const tool of child.tools) {
+        invocations.push({
+          apiName: tool?.apiName,
+          identifier: tool?.identifier,
+          state: tool?.result?.state,
+        });
+      }
+    }
+  }
+
+  const compressedMessages = (msg as any).compressedMessages;
+  if (Array.isArray(compressedMessages)) {
+    for (const compressed of compressedMessages) {
+      invocations.push(...collectToolInvocations(compressed));
+    }
+  }
+
+  return invocations;
+};
+
+/**
+ * Accumulate activated skills from all activateSkill / activateTools tool
+ * messages. Skills once activated remain active for the rest of the
+ * conversation; the skill id deduplicates (later activations update the entry).
+ *
+ * Shared by the client transport (chat store dbMessage selector feeding
+ * `computeStepContext`) and the server runtime executors (`callTool` /
+ * `callToolsBatch`), so both execution paths resolve the same activation set
+ * for skills `execScript`. Handles both flat `role='tool'` rows and the
+ * conversation-flow grouped shape (`assistantGroup` etc.) — see
+ * `collectToolInvocations`.
+ */
+export const extractActivatedSkillsFromMessages = (
+  messages: UIChatMessage[],
+): StepActivatedSkill[] | undefined => {
+  const skillsMap = new Map<string, StepActivatedSkill>();
+
+  for (const msg of messages) {
+    for (const invocation of collectToolInvocations(msg)) {
+      if (!(
+        invocation.identifier === SKILLS_IDENTIFIER ||
+        invocation.identifier === ACTIVATOR_IDENTIFIER
+      ))
+        continue;
+
+      // Direct activateSkill calls — state has top-level id/name
+      if (
+        invocation.apiName === 'activateSkill' &&
+        invocation.state?.id &&
+        invocation.state?.name
+      ) {
+        const id = invocation.state.id as string;
+        skillsMap.set(id, {
+          description: invocation.state.description as string | undefined,
+          id,
+          name: invocation.state.name as string,
+        });
+      }
+
+      // activateTools fallback — skills nested in pluginState.activatedSkills[]
+      if (
+        invocation.apiName === 'activateTools' &&
+        Array.isArray(invocation.state?.activatedSkills)
+      ) {
+        for (const skill of invocation.state.activatedSkills as Array<{
+          description?: string;
+          id?: string;
+          name?: string;
+        }>) {
+          if (skill.id && skill.name) {
+            skillsMap.set(skill.id, {
+              description: skill.description,
+              id: skill.id,
+              name: skill.name,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return skillsMap.size > 0 ? [...skillsMap.values()] : undefined;
 };

--- a/packages/agent-runtime/src/utils/messageSelectors.ts
+++ b/packages/agent-runtime/src/utils/messageSelectors.ts
@@ -157,7 +157,9 @@ const collectToolInvocations = (msg: UIChatMessage): ToolInvocation[] => {
  * Accumulate activated skills from all activateSkill / activateTools tool
  * messages. Skills once activated remain active for the rest of the
  * conversation; the skill id (or name, for filesystem/builtin activations that
- * persist no id) deduplicates — later activations update the entry.
+ * persist no id) deduplicates — a reactivation updates the entry AND moves it
+ * to the end, since exec paths treat the last entry as the most recent
+ * activation when picking the script cwd.
  *
  * Shared by the client transport (chat store dbMessage selector feeding
  * `computeStepContext`) and the server runtime executors (`callTool` /
@@ -185,7 +187,13 @@ export const extractActivatedSkillsFromMessages = (
       if (invocation.apiName === 'activateSkill' && invocation.state?.name) {
         const id = invocation.state.id as string | undefined;
         const name = invocation.state.name as string;
-        skillsMap.set(id ?? name, {
+        const key = id ?? name;
+        // Delete before set so reactivation moves the skill to the end —
+        // downstream exec paths pick the LAST resolvable skill as cwd, so
+        // insertion order must reflect activation recency (A → B → A must
+        // yield [B, A], not Map#set's kept-in-place [A, B]).
+        skillsMap.delete(key);
+        skillsMap.set(key, {
           description: invocation.state.description as string | undefined,
           ...(id && { id }),
           name,
@@ -203,7 +211,10 @@ export const extractActivatedSkillsFromMessages = (
           name?: string;
         }>) {
           if (skill.name) {
-            skillsMap.set(skill.id ?? skill.name, {
+            const key = skill.id ?? skill.name;
+            // Same delete-before-set as above: keep activation recency.
+            skillsMap.delete(key);
+            skillsMap.set(key, {
               description: skill.description,
               ...(skill.id && { id: skill.id }),
               name: skill.name,

--- a/packages/agent-runtime/src/utils/messageSelectors.ts
+++ b/packages/agent-runtime/src/utils/messageSelectors.ts
@@ -129,7 +129,7 @@ const collectToolInvocations = (msg: UIChatMessage): ToolInvocation[] => {
 
   const invocations: ToolInvocation[] = [];
 
-  const children = (msg as any).children;
+  const { children } = msg;
   if (Array.isArray(children)) {
     for (const child of children) {
       if (!Array.isArray(child?.tools)) continue;
@@ -143,7 +143,7 @@ const collectToolInvocations = (msg: UIChatMessage): ToolInvocation[] => {
     }
   }
 
-  const compressedMessages = (msg as any).compressedMessages;
+  const { compressedMessages } = msg;
   if (Array.isArray(compressedMessages)) {
     for (const compressed of compressedMessages) {
       invocations.push(...collectToolInvocations(compressed));

--- a/packages/agent-runtime/src/utils/messageSelectors.ts
+++ b/packages/agent-runtime/src/utils/messageSelectors.ts
@@ -156,7 +156,8 @@ const collectToolInvocations = (msg: UIChatMessage): ToolInvocation[] => {
 /**
  * Accumulate activated skills from all activateSkill / activateTools tool
  * messages. Skills once activated remain active for the rest of the
- * conversation; the skill id deduplicates (later activations update the entry).
+ * conversation; the skill id (or name, for filesystem/builtin activations that
+ * persist no id) deduplicates — later activations update the entry.
  *
  * Shared by the client transport (chat store dbMessage selector feeding
  * `computeStepContext`) and the server runtime executors (`callTool` /
@@ -178,17 +179,16 @@ export const extractActivatedSkillsFromMessages = (
       ))
         continue;
 
-      // Direct activateSkill calls — state has top-level id/name
-      if (
-        invocation.apiName === 'activateSkill' &&
-        invocation.state?.id &&
-        invocation.state?.name
-      ) {
-        const id = invocation.state.id as string;
-        skillsMap.set(id, {
+      // Direct activateSkill calls — state has top-level name (id only for DB
+      // skills; filesystem/builtin activations persist no id, so `name` alone
+      // must be enough to keep them — server exec paths match by name anyway).
+      if (invocation.apiName === 'activateSkill' && invocation.state?.name) {
+        const id = invocation.state.id as string | undefined;
+        const name = invocation.state.name as string;
+        skillsMap.set(id ?? name, {
           description: invocation.state.description as string | undefined,
-          id,
-          name: invocation.state.name as string,
+          ...(id && { id }),
+          name,
         });
       }
 
@@ -202,10 +202,10 @@ export const extractActivatedSkillsFromMessages = (
           id?: string;
           name?: string;
         }>) {
-          if (skill.id && skill.name) {
-            skillsMap.set(skill.id, {
+          if (skill.name) {
+            skillsMap.set(skill.id ?? skill.name, {
               description: skill.description,
-              id: skill.id,
+              ...(skill.id && { id: skill.id }),
               name: skill.name,
             });
           }

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.test.ts
@@ -96,6 +96,46 @@ describe('SkillsExecutionRuntime', () => {
         expect(result.success).toBe(false);
         expect(result.content).toBe('Failed to execute command: sandbox timeout');
       });
+
+      it('should fall back to constructor activatedSkills when args carry none', async () => {
+        const execScript = vi.fn().mockResolvedValue({
+          exitCode: 0,
+          output: 'ok',
+          success: true,
+        } satisfies CommandResult);
+        const contextSkills = [{ description: 'PDF tools', id: 'skl_1', name: 'pdf' }];
+        const runtime = new SkillsExecutionRuntime({
+          activatedSkills: contextSkills,
+          service: createMockService({ execScript }),
+        });
+
+        await runtime.execScript(args);
+
+        expect(execScript).toHaveBeenCalledWith('echo hello', {
+          activatedSkills: contextSkills,
+          description: 'test command',
+        });
+      });
+
+      it('should prefer args activatedSkills over the constructor fallback', async () => {
+        const execScript = vi.fn().mockResolvedValue({
+          exitCode: 0,
+          output: 'ok',
+          success: true,
+        } satisfies CommandResult);
+        const argsSkills = [{ id: 'skl_2', name: 'xlsx' }];
+        const runtime = new SkillsExecutionRuntime({
+          activatedSkills: [{ id: 'skl_1', name: 'pdf' }],
+          service: createMockService({ execScript }),
+        });
+
+        await runtime.execScript({ ...args, activatedSkills: argsSkills });
+
+        expect(execScript).toHaveBeenCalledWith('echo hello', {
+          activatedSkills: argsSkills,
+          description: 'test command',
+        });
+      });
     });
 
     describe('via runCommand fallback', () => {

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
@@ -42,7 +42,7 @@ export interface SkillRuntimeService {
   execScript?: (
     command: string,
     options: {
-      activatedSkills?: Array<{ description?: string; id: string; name: string }>;
+      activatedSkills?: Array<{ description?: string; id?: string; name: string }>;
       description: string;
     },
   ) => Promise<CommandResult>;

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
@@ -498,6 +498,9 @@ export class SkillsExecutionRuntime {
       stdout: result.output,
       success: result.success,
       exitCode: result.exitCode,
+      // Renders the saved-output paths when the shell truncated the inline
+      // stream — without them the full output is unreachable.
+      outputFiles: result.outputFiles,
       // Surfaces the still-running message with a pollable handle when the
       // command outlived the observation window (exitCode undefined).
       shellId: result.shellId,
@@ -509,6 +512,7 @@ export class SkillsExecutionRuntime {
         command,
         ...(result.executionEnv && { executionEnv: result.executionEnv }),
         exitCode: result.exitCode,
+        ...(result.outputFiles && { outputFiles: result.outputFiles }),
         ...(result.shellId && { shellId: result.shellId }),
         success: result.success,
       },

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
@@ -498,6 +498,9 @@ export class SkillsExecutionRuntime {
       stdout: result.output,
       success: result.success,
       exitCode: result.exitCode,
+      // Surfaces the still-running message with a pollable handle when the
+      // command outlived the observation window (exitCode undefined).
+      shellId: result.shellId,
     });
 
     return {
@@ -506,6 +509,7 @@ export class SkillsExecutionRuntime {
         command,
         ...(result.executionEnv && { executionEnv: result.executionEnv }),
         exitCode: result.exitCode,
+        ...(result.shellId && { shellId: result.shellId }),
         success: result.success,
       },
       success: result.success,

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
@@ -102,8 +102,12 @@ export interface SkillsExecutionRuntimeOptions {
   service: SkillRuntimeService;
 }
 
-/** Cross-platform dirname for absolute paths (POSIX or Windows separators). */
-const getDirname = (filePath: string): string => {
+/**
+ * Cross-platform dirname for absolute paths (POSIX or Windows separators).
+ * Exported for the server skills runtime, which resolves device paths that may
+ * use either separator — server-side `path.dirname` would mishandle `\`.
+ */
+export const getDirname = (filePath: string): string => {
   const idx = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
   return idx === -1 ? '' : filePath.slice(0, idx);
 };

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
@@ -11,6 +11,7 @@ import type {
 import type {
   ActivateSkillParams,
   CommandResult,
+  ExecScriptActivatedSkill,
   ExecScriptParams,
   ExportFileParams,
   ReadReferenceParams,
@@ -85,6 +86,14 @@ export interface DeviceFileAccess {
 }
 
 export interface SkillsExecutionRuntimeOptions {
+  /**
+   * Activated skills resolved by the caller from the conversation history.
+   * Fallback for `execScript` when the args carry none: the client executor
+   * injects stepContext.activatedSkills into the args, but the server runtime
+   * registry passes the raw LLM args, so the server factory threads them here
+   * instead.
+   */
+  activatedSkills?: ExecScriptActivatedSkill[];
   builtinSkills?: BuiltinSkill[];
   /** Reads project skill files from the device (local-system over the gateway). */
   deviceFileAccess?: DeviceFileAccess;
@@ -144,6 +153,7 @@ const buildProjectDirectoryHint = (skillName: string, skillDir: string): string 
 This filesystem skill lives in \`${skillDir}\`. Use \`local-system.globFiles\` with scope="${skillDir}" and pattern="**/*" to discover reference files, then \`readReference\` with skillName="${skillName}" + the relative path to load any of them.`;
 
 export class SkillsExecutionRuntime {
+  private activatedSkills?: ExecScriptActivatedSkill[];
   private builtinSkills: BuiltinSkill[];
   private projectSkills: ProjectSkillRuntimeItem[];
   private deviceFileAccess?: DeviceFileAccess;
@@ -151,13 +161,17 @@ export class SkillsExecutionRuntime {
 
   constructor(options: SkillsExecutionRuntimeOptions) {
     this.service = options.service;
+    this.activatedSkills = options.activatedSkills;
     this.builtinSkills = options.builtinSkills || [];
     this.projectSkills = options.projectSkills || [];
     this.deviceFileAccess = options.deviceFileAccess;
   }
 
   async execScript(args: ExecScriptParams): Promise<BuiltinServerRuntimeOutput> {
-    const { activatedSkills, command, description } = args;
+    const { command, description } = args;
+    // Args win when the caller (client executor) already injected stepContext;
+    // the constructor option covers the server path where args are raw LLM output.
+    const activatedSkills = args.activatedSkills ?? this.activatedSkills;
 
     // Try new execScript method first (with cloud sandbox support)
     if (this.service.execScript) {

--- a/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
+++ b/packages/builtin-tool-skills/src/ExecutionRuntime/index.ts
@@ -504,6 +504,7 @@ export class SkillsExecutionRuntime {
       content,
       state: {
         command,
+        ...(result.executionEnv && { executionEnv: result.executionEnv }),
         exitCode: result.exitCode,
         success: result.success,
       },

--- a/packages/builtin-tool-skills/src/client/Inspector/ExecScript/index.tsx
+++ b/packages/builtin-tool-skills/src/client/Inspector/ExecScript/index.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { type BuiltinInspectorProps } from '@lobechat/types';
+import { Icon } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
-import { Check, X } from 'lucide-react';
+import { Check, LoaderCircle, X } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -41,13 +42,20 @@ export const ExecScriptInspector = memo<BuiltinInspectorProps<ExecScriptParams, 
     }
 
     const isSuccess = pluginState?.success;
+    // A command that outlived the shell's observation window has no exitCode
+    // yet and reports `success: true` for the model loop (still running ≠
+    // failed) — but the UI must not show a completed checkmark while the
+    // command is in fact still executing (pollable via shellId).
+    const isStillRunning = pluginState?.exitCode === undefined && !!pluginState?.shellId;
 
     return (
       <div className={cx(inspectorTextStyles.root, isLoading && shinyTextStyles.shinyText)}>
         <span style={{ marginInlineStart: 2 }}>
           <span>{t('builtins.lobe-skills.apiName.execScript')}: </span>
           {description && <span className={highlightTextStyles.primary}>{description}</span>}
-          {isLoading ? null : pluginState?.success !== undefined ? (
+          {isLoading ? null : isStillRunning ? (
+            <Icon spin className={styles.statusIcon} icon={LoaderCircle} size={14} />
+          ) : pluginState?.success !== undefined ? (
             isSuccess ? (
               <Check className={styles.statusIcon} color={cssVar.colorSuccess} size={14} />
             ) : (

--- a/packages/builtin-tool-skills/src/resolveManifest.test.ts
+++ b/packages/builtin-tool-skills/src/resolveManifest.test.ts
@@ -26,21 +26,29 @@ describe('resolveSkillsManifest', () => {
     },
   );
 
-  it('prefixes exec APIs with the fallback framing when a device is online', () => {
+  // Device runs execute execScript ON the device (serverRuntimes/skills.ts
+  // device branch) — the description must say so, and the sandbox-only APIs
+  // (runCommand / exportFile) are dropped, restoring the original desktop
+  // manifest shape.
+  it('declares device execution and hides sandbox-only APIs when a device is routed', () => {
     const result = resolveSkillsManifest({ executionEnv: 'device' })!;
 
-    for (const name of EXEC_APIS) {
-      const description = apiByName(result, name).description;
-      expect(description).toMatch(/^Fallback execution environment: an isolated cloud sandbox/);
-      expect(description).toContain('GITHUB_TOKEN');
-      // the original mechanics stay after the preamble
-      expect(description).toContain(apiByName(SkillsManifest, name).description);
-    }
+    const description = apiByName(result, SkillsApiName.execScript).description;
+    expect(description).toMatch(/^Execution environment: the user's selected device/);
+    expect(description).toContain('NOT injected');
+    // the original mechanics stay after the preamble
+    expect(description).toContain(apiByName(SkillsManifest, SkillsApiName.execScript).description);
+
+    const apiNames = result.api.map((a) => a.name);
+    expect(apiNames).not.toContain(SkillsApiName.runCommand);
+    expect(apiNames).not.toContain(SkillsApiName.exportFile);
+    expect(apiNames).toContain(SkillsApiName.activateSkill);
+    expect(apiNames).toContain(SkillsApiName.readReference);
+
     // cross-tool arbitration rides the tool systemRole, not the descriptions
     expect(result.systemRole).toContain(systemPrompt);
-    expect(result.systemRole).toContain(
-      'Default shell execution to `lobe-local-system` runCommand',
-    );
+    expect(result.systemRole).toContain('`execScript` runs skill scripts on the device');
+    expect(result.systemRole).toContain('`lobe-local-system` runCommand');
   });
 
   it.each(['bound-device-offline', 'no-online-device'] as const)(
@@ -109,7 +117,7 @@ describe('resolveSkillsManifest', () => {
     expect(result.systemRole).toBe(systemPrompt);
   });
 
-  it.each(['device', 'device-unrouted', 'sandbox'] as const)(
+  it.each(['device-unrouted', 'sandbox'] as const)(
     'keeps non-exec APIs, api shape, and humanIntervention intact for %s',
     (executionEnv) => {
       const result = resolveSkillsManifest({ executionEnv })!;
@@ -124,6 +132,16 @@ describe('resolveSkillsManifest', () => {
       expect(result.identifier).toBe(SkillsManifest.identifier);
     },
   );
+
+  it('keeps non-exec APIs and humanIntervention intact for device', () => {
+    const result = resolveSkillsManifest({ executionEnv: 'device' })!;
+
+    for (const name of NON_EXEC_APIS) {
+      expect(apiByName(result, name)).toBe(apiByName(SkillsManifest, name));
+    }
+    expect(apiByName(result, SkillsApiName.execScript).humanIntervention).toBe('required');
+    expect(result.identifier).toBe(SkillsManifest.identifier);
+  });
 
   it('does not mutate the static manifest', () => {
     const staticDescriptions = SkillsManifest.api.map((a) => a.description);

--- a/packages/builtin-tool-skills/src/resolveManifest.ts
+++ b/packages/builtin-tool-skills/src/resolveManifest.ts
@@ -4,15 +4,27 @@ import { SkillsManifest } from './manifest';
 import { SkillsApiName } from './types';
 
 /**
- * The exec-class APIs whose runtime is the server-side cloud sandbox
- * (`apps/server/.../serverRuntimes/skills.ts`), regardless of the run's
- * execution target. Their static descriptions never say where they run, so a
- * desktop user who picked "local device" can have commands silently land in
- * the sandbox — most damagingly when the bound device is judged offline and
- * `lobe-local-system` is not injected at all (plan kind `device-unrouted`).
+ * The exec-class APIs. Their runtime target follows the run's execution plan
+ * (`apps/server/.../serverRuntimes/skills.ts`): a routed device
+ * (`executionEnv: 'device'`) runs `execScript` ON the device; every other
+ * environment runs in the server-side cloud sandbox. Descriptions are resolved
+ * per plan below so the model is never told a location the runtime won't honor.
  */
 const EXEC_API_NAMES = new Set<string>([
   SkillsApiName.execScript,
+  SkillsApiName.exportFile,
+  SkillsApiName.runCommand,
+]);
+
+/**
+ * APIs hidden when a device is routed — the sandbox-oriented surface makes no
+ * sense there. `runCommand` duplicates `lobe-local-system` runCommand on the
+ * device, and `exportFile` exists to pull artifacts OUT of the sandbox; device
+ * runs leave artifacts on the user's machine, where they already are. This
+ * also restores the original desktop manifest shape, which only ever exposed
+ * `execScript` (see `manifest.desktop.ts`).
+ */
+const DEVICE_HIDDEN_API_NAMES = new Set<string>([
   SkillsApiName.exportFile,
   SkillsApiName.runCommand,
 ]);
@@ -22,9 +34,10 @@ const EXEC_API_NAMES = new Set<string>([
  * carry tool semantics only (where it runs, what credentials it has);
  * cross-tool arbitration lives in `EXEC_ENV_FACTS`.
  *
- * - `device`: a local device is online — the sandbox is the FALLBACK.
- *   Credential fact: `injectCredsToSandbox` only injects into the sandbox;
- *   devices deliberately get nothing.
+ * - `device`: a device is routed — `execScript` runs ON it: the skill archive
+ *   is downloaded/extracted device-side and the command runs in the skill
+ *   directory. LobeHub-managed credentials are deliberately NOT injected into
+ *   devices (`injectCredsToSandbox` only targets the sandbox).
  * - `device-unrouted`: the user chose local-device execution but no device is
  *   routed this run — the model must disclose that instead of silently
  *   running machine-specific commands in the sandbox. Wording varies by
@@ -38,7 +51,7 @@ const EXEC_ENV_PREAMBLES: Partial<
   Record<NonNullable<BuiltinToolResolveContext['executionEnv']>, string>
 > = {
   'device':
-    "Fallback execution environment: an isolated cloud sandbox, not the user's machine (LobeHub-managed credentials injected, e.g. `GITHUB_TOKEN`).",
+    "Execution environment: the user's selected device, not a cloud sandbox. The skill archive is auto-extracted on the device and the command runs in the skill directory. LobeHub-managed credentials (e.g. `GITHUB_TOKEN`) are NOT injected.",
   'device-unrouted':
     'Fallback execution environment: an isolated cloud sandbox. The user chose local-device execution but no device is routed this run — say so before running commands that assume their machine.',
   'sandbox': "Execution environment: an isolated cloud sandbox, not the user's machine.",
@@ -55,7 +68,7 @@ const EXEC_ENV_FACTS: Partial<
   Record<NonNullable<BuiltinToolResolveContext['executionEnv']>, string>
 > = {
   'device':
-    'A local device is online. Default shell execution to `lobe-local-system` runCommand; use the skills exec APIs only when the local run lacks a required tool, the task needs LobeHub-managed credentials, or the task needs isolation.',
+    'A local device is routed: `execScript` runs skill scripts on the device (archive auto-extracted, cwd = skill directory); use `lobe-local-system` runCommand for other shell commands. LobeHub-managed credentials are not available on the device.',
   'device-unrouted':
     'No local device is routed; shell commands execute in the cloud sandbox this run.',
 };
@@ -98,12 +111,14 @@ const resolveUnroutedTexts = (
 /**
  * Context-aware manifest for the lobe-skills tool: prefixes the exec-class API
  * descriptions with where they actually run, derived from the resolved
- * execution plan (see `BuiltinToolResolveContext.executionEnv`).
+ * execution plan (see `BuiltinToolResolveContext.executionEnv`). Device runs
+ * additionally drop the sandbox-only APIs (`runCommand` / `exportFile`).
  */
 export const resolveSkillsManifest: BuiltinManifestResolver = (context) => {
   const basePreamble = context.executionEnv && EXEC_ENV_PREAMBLES[context.executionEnv];
   if (!basePreamble) return SkillsManifest;
 
+  const isDeviceRun = context.executionEnv === 'device';
   const unrouted =
     context.executionEnv === 'device-unrouted'
       ? resolveUnroutedTexts(context.executionEnvUnroutedReason)
@@ -113,11 +128,13 @@ export const resolveSkillsManifest: BuiltinManifestResolver = (context) => {
 
   return {
     ...SkillsManifest,
-    api: SkillsManifest.api.map((api) =>
-      EXEC_API_NAMES.has(api.name)
-        ? { ...api, description: `${preamble} ${api.description}` }
-        : api,
-    ),
+    api: SkillsManifest.api
+      .filter((api) => !isDeviceRun || !DEVICE_HIDDEN_API_NAMES.has(api.name))
+      .map((api) =>
+        EXEC_API_NAMES.has(api.name)
+          ? { ...api, description: `${preamble} ${api.description}` }
+          : api,
+      ),
     ...(fact && {
       systemRole: `${SkillsManifest.systemRole}\n<execution_environment>\n${fact}\n</execution_environment>\n`,
     }),

--- a/packages/builtin-tool-skills/src/types.ts
+++ b/packages/builtin-tool-skills/src/types.ts
@@ -46,7 +46,18 @@ export interface ExecScriptParams {
 
 export interface ExecScriptState {
   command: string;
-  exitCode: number;
+  executionEnv?: 'device' | 'sandbox';
+  /**
+   * Undefined means the command was still running when the observation window
+   * elapsed — mirrors `CommandResult.exitCode`.
+   */
+  exitCode?: number;
+  outputFiles?: CommandResult['outputFiles'];
+  /**
+   * Shell handle for a still-running command, pollable via
+   * `local-system.getCommandOutput`.
+   */
+  shellId?: string;
   success: boolean;
 }
 

--- a/packages/builtin-tool-skills/src/types.ts
+++ b/packages/builtin-tool-skills/src/types.ts
@@ -61,8 +61,17 @@ export interface CommandResult {
    * execution-target degradation is observable in the product UI.
    */
   executionEnv?: 'device' | 'sandbox';
-  exitCode: number;
+  /**
+   * Undefined means the command was still running when the observation window
+   * elapsed — the formatter reports it as still running instead of completed.
+   */
+  exitCode?: number;
   output: string;
+  /**
+   * Shell handle for a still-running command, pollable via
+   * `local-system.getCommandOutput`.
+   */
+  shellId?: string;
   stderr?: string;
   success: boolean;
 }

--- a/packages/builtin-tool-skills/src/types.ts
+++ b/packages/builtin-tool-skills/src/types.ts
@@ -56,6 +56,11 @@ export interface RunCommandOptions {
 }
 
 export interface CommandResult {
+  /**
+   * Where the command actually ran. Flows into the tool call's plugin state so
+   * execution-target degradation is observable in the product UI.
+   */
+  executionEnv?: 'device' | 'sandbox';
   exitCode: number;
   output: string;
   stderr?: string;

--- a/packages/builtin-tool-skills/src/types.ts
+++ b/packages/builtin-tool-skills/src/types.ts
@@ -68,6 +68,15 @@ export interface CommandResult {
   exitCode?: number;
   output: string;
   /**
+   * Saved-output file handles reported by the shell when stdout/stderr exceed
+   * the inline preview (device runs save the full stream to disk) — the only
+   * retrieval path for output the preview truncated.
+   */
+  outputFiles?: {
+    stderr?: { path: string; size?: number; truncated?: boolean };
+    stdout?: { path: string; size?: number; truncated?: boolean };
+  };
+  /**
    * Shell handle for a still-running command, pollable via
    * `local-system.getCommandOutput`.
    */

--- a/packages/builtin-tool-skills/src/types.ts
+++ b/packages/builtin-tool-skills/src/types.ts
@@ -30,7 +30,8 @@ export interface ActivateSkillState {
  */
 export interface ExecScriptActivatedSkill {
   description?: string;
-  id: string;
+  /** DB skill id; absent for filesystem/builtin activations — match by `name`. */
+  id?: string;
   name: string;
 }
 

--- a/packages/device-control/package.json
+++ b/packages/device-control/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@lobechat/local-file-shell": "workspace:*",
     "fast-glob": "^3.3.3",
+    "fflate": "^0.8.3",
     "gray-matter": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/device-control/src/__tests__/skillDirectory.test.ts
+++ b/packages/device-control/src/__tests__/skillDirectory.test.ts
@@ -81,6 +81,20 @@ describe('prepareSkillDirectory', () => {
     expect(fetchSkillArchive).toHaveBeenCalledTimes(2);
   });
 
+  it('rejects zipHash values that are not plain content-hash tokens', async () => {
+    const fetchSkillArchive = vi.fn();
+
+    const result = await prepareSkillDirectory(
+      { url: 'https://example.com/a.zip', zipHash: '../../../etc' },
+      { fetchSkillArchive, skillCacheRoot: cacheRoot },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid zipHash');
+    expect(result.extractedDir).toBe('');
+    expect(fetchSkillArchive).not.toHaveBeenCalled();
+  });
+
   it('rejects archives with path traversal entries', async () => {
     const zip = buildZip({ '../evil.txt': 'pwned' });
 

--- a/packages/device-control/src/__tests__/skillDirectory.test.ts
+++ b/packages/device-control/src/__tests__/skillDirectory.test.ts
@@ -1,0 +1,109 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { zipSync } from 'fflate';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { prepareSkillDirectory } from '../skillDirectory';
+
+let cacheRoot: string;
+
+const buildZip = (entries: Record<string, string>) =>
+  zipSync(
+    Object.fromEntries(
+      Object.entries(entries).map(([name, content]) => [name, new TextEncoder().encode(content)]),
+    ),
+  );
+
+const okResponse = (zip: Uint8Array) =>
+  ({
+    arrayBuffer: async () => zip.buffer.slice(zip.byteOffset, zip.byteOffset + zip.byteLength),
+    ok: true,
+  }) as Response;
+
+beforeEach(async () => {
+  cacheRoot = await mkdtemp(path.join(tmpdir(), 'skill-dir-'));
+});
+
+afterEach(async () => {
+  await rm(cacheRoot, { force: true, recursive: true });
+});
+
+describe('prepareSkillDirectory', () => {
+  it('downloads, extracts and marks the directory prepared', async () => {
+    const zip = buildZip({ 'SKILL.md': '# skill', 'scripts/run.sh': 'echo hi' });
+    const fetchSkillArchive = vi.fn(async () => okResponse(zip));
+
+    const result = await prepareSkillDirectory(
+      { url: 'https://example.com/skill.zip', zipHash: 'hash-1' },
+      { fetchSkillArchive, skillCacheRoot: cacheRoot },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.extractedDir).toBe(path.join(cacheRoot, 'extracted', 'hash-1'));
+    await expect(readFile(path.join(result.extractedDir, 'SKILL.md'), 'utf8')).resolves.toBe(
+      '# skill',
+    );
+    await expect(
+      readFile(path.join(result.extractedDir, 'scripts', 'run.sh'), 'utf8'),
+    ).resolves.toBe('echo hi');
+    const marker = JSON.parse(await readFile(path.join(result.extractedDir, '.prepared'), 'utf8'));
+    expect(marker.zipHash).toBe('hash-1');
+  });
+
+  it('is idempotent on zipHash: second call skips the download', async () => {
+    const zip = buildZip({ 'SKILL.md': '# skill' });
+    const fetchSkillArchive = vi.fn(async () => okResponse(zip));
+    const deps = { fetchSkillArchive, skillCacheRoot: cacheRoot };
+
+    await prepareSkillDirectory({ url: 'https://example.com/a.zip', zipHash: 'hash-1' }, deps);
+    const second = await prepareSkillDirectory(
+      { url: 'https://example.com/a.zip', zipHash: 'hash-1' },
+      deps,
+    );
+
+    expect(second.success).toBe(true);
+    expect(fetchSkillArchive).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-downloads when forceRefresh is set', async () => {
+    const zip = buildZip({ 'SKILL.md': '# skill' });
+    const fetchSkillArchive = vi.fn(async () => okResponse(zip));
+    const deps = { fetchSkillArchive, skillCacheRoot: cacheRoot };
+
+    await prepareSkillDirectory({ url: 'https://example.com/a.zip', zipHash: 'hash-1' }, deps);
+    await prepareSkillDirectory(
+      { forceRefresh: true, url: 'https://example.com/a.zip', zipHash: 'hash-1' },
+      deps,
+    );
+
+    expect(fetchSkillArchive).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects archives with path traversal entries', async () => {
+    const zip = buildZip({ '../evil.txt': 'pwned' });
+
+    const result = await prepareSkillDirectory(
+      { url: 'https://example.com/evil.zip', zipHash: 'hash-evil' },
+      { fetchSkillArchive: async () => okResponse(zip), skillCacheRoot: cacheRoot },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Unsafe file path');
+  });
+
+  it('returns a failure result when the download fails', async () => {
+    const result = await prepareSkillDirectory(
+      { url: 'https://example.com/missing.zip', zipHash: 'hash-404' },
+      {
+        fetchSkillArchive: async () =>
+          ({ ok: false, status: 404, statusText: 'Not Found' }) as Response,
+        skillCacheRoot: cacheRoot,
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('404');
+  });
+});

--- a/packages/device-control/src/__tests__/skillDirectory.test.ts
+++ b/packages/device-control/src/__tests__/skillDirectory.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -79,6 +79,38 @@ describe('prepareSkillDirectory', () => {
     );
 
     expect(fetchSkillArchive).toHaveBeenCalledTimes(2);
+  });
+
+  // Two concurrent cache-missed prepares of the same zipHash used to both
+  // pass the marker check and interleave rm/extract on the live directory.
+  it('serializes concurrent prepares of the same zipHash so the follower reuses the cache', async () => {
+    const zip = buildZip({ 'SKILL.md': '# skill' });
+    let releaseFetch!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    const fetchSkillArchive = vi.fn(async () => {
+      await gate;
+      return okResponse(zip);
+    });
+    const deps = { fetchSkillArchive, skillCacheRoot: cacheRoot };
+
+    const first = prepareSkillDirectory(
+      { url: 'https://example.com/a.zip', zipHash: 'hash-1' },
+      deps,
+    );
+    const second = prepareSkillDirectory(
+      { url: 'https://example.com/a.zip', zipHash: 'hash-1' },
+      deps,
+    );
+    releaseFetch();
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(firstResult.success).toBe(true);
+    expect(secondResult.success).toBe(true);
+    expect(fetchSkillArchive).toHaveBeenCalledTimes(1);
+    // The staging dir is swapped in via rename, never left behind.
+    await expect(readdir(path.join(cacheRoot, 'extracted'))).resolves.toEqual(['hash-1']);
   });
 
   it('rejects zipHash values that are not plain content-hash tokens', async () => {

--- a/packages/device-control/src/dispatch.ts
+++ b/packages/device-control/src/dispatch.ts
@@ -22,11 +22,13 @@ import {
   writeLocalFile,
 } from '@lobechat/local-file-shell';
 
+import { prepareSkillDirectory } from './skillDirectory';
 import type {
   DeviceControlDeps,
   InitWorkspaceParams,
   ListProjectSkillsParams,
   LocalFilePreviewUrlParams,
+  PrepareSkillDirectoryParams,
   ProjectFileIndexParams,
   ProjectFileSearchParams,
 } from './types';
@@ -41,6 +43,7 @@ import { initWorkspace, listProjectSkills, statPath } from './workspace';
 export const DEVICE_RPC_METHODS = [
   'initWorkspace',
   'listProjectSkills',
+  'prepareSkillDirectory',
   'statPath',
   'getProjectFileIndex',
   'searchProjectFiles',
@@ -93,6 +96,10 @@ export const executeDeviceRpc = async (
 
     case 'listProjectSkills': {
       return listProjectSkills(params as ListProjectSkillsParams, deps);
+    }
+
+    case 'prepareSkillDirectory': {
+      return prepareSkillDirectory(params as PrepareSkillDirectoryParams, deps);
     }
 
     case 'statPath': {

--- a/packages/device-control/src/index.ts
+++ b/packages/device-control/src/index.ts
@@ -1,5 +1,6 @@
 export { DEVICE_RPC_METHODS, type DeviceRpcMethod, executeDeviceRpc } from './dispatch';
 export { defaultGetLocalFilePreview } from './filePreview';
 export { defaultGetProjectFileIndex, defaultSearchProjectFiles } from './projectFileIndex';
+export { defaultSkillCacheRoot, prepareSkillDirectory } from './skillDirectory';
 export * from './types';
 export { initWorkspace, listProjectSkills, statPath } from './workspace';

--- a/packages/device-control/src/skillDirectory.ts
+++ b/packages/device-control/src/skillDirectory.ts
@@ -1,5 +1,5 @@
 import { constants } from 'node:fs';
-import { access, mkdir, rm, writeFile } from 'node:fs/promises';
+import { access, mkdir, rename, rm, writeFile } from 'node:fs/promises';
 import * as os from 'node:os';
 import path from 'node:path';
 
@@ -18,6 +18,18 @@ import type {
  * shares one cache with the renderer-IPC path (`LocalFileCtr`).
  */
 export const defaultSkillCacheRoot = () => path.join(os.homedir(), '.lobehub', 'skills');
+
+/**
+ * In-flight preparations keyed by extraction dir. Concurrent same-hash calls
+ * (e.g. two execScript tool calls batched in one step, or a forceRefresh
+ * racing a cache miss) would otherwise both miss the `.prepared` marker and
+ * interleave rm/extract on the live cache path — deleting files out from
+ * under a command that already received that directory as its cwd. Chaining
+ * serializes them per key; the follower then hits the marker fast-path.
+ * In-process is enough: the desktop main process and the CLI daemon use
+ * separate cache roots, so a key is never contended across processes.
+ */
+const inflightPrepares = new Map<string, Promise<PrepareSkillDirectoryResult>>();
 
 /**
  * Download and extract a skill archive into the device-local cache, keyed by
@@ -52,54 +64,81 @@ export const prepareSkillDirectory = async (
   const markerPath = path.join(extractedDir, '.prepared');
   const zipPath = path.join(cacheRoot, 'archives', `${zipHash}.zip`);
 
-  try {
-    if (!forceRefresh) {
-      await access(markerPath, constants.F_OK);
-      return { extractedDir, success: true, zipPath };
-    }
-  } catch {
-    // Cache miss, continue preparing the local copy.
-  }
-
-  try {
-    const fetchImpl = deps.fetchSkillArchive ?? fetch;
-    const response = await fetchImpl(url);
-    if (!response.ok) {
-      throw new Error(
-        `Failed to download skill package: ${response.status} ${response.statusText}`,
-      );
+  const run = async (): Promise<PrepareSkillDirectoryResult> => {
+    try {
+      if (!forceRefresh) {
+        await access(markerPath, constants.F_OK);
+        return { extractedDir, success: true, zipPath };
+      }
+    } catch {
+      // Cache miss, continue preparing the local copy.
     }
 
-    const buffer = Buffer.from(await response.arrayBuffer());
-    const extractedFiles = unzipSync(new Uint8Array(buffer));
-
-    await rm(extractedDir, { force: true, recursive: true });
-    await mkdir(path.dirname(zipPath), { recursive: true });
-    await mkdir(extractedDir, { recursive: true });
-    await writeFile(zipPath, buffer);
-
-    for (const [relativePath, fileContent] of Object.entries(extractedFiles)) {
-      if (relativePath.endsWith('/')) continue;
-
-      const targetPath = path.resolve(extractedDir, relativePath);
-      const normalizedRoot = `${path.resolve(extractedDir)}${path.sep}`;
-      if (targetPath !== path.resolve(extractedDir) && !targetPath.startsWith(normalizedRoot)) {
-        throw new Error(`Unsafe file path in skill archive: ${relativePath}`);
+    try {
+      const fetchImpl = deps.fetchSkillArchive ?? fetch;
+      const response = await fetchImpl(url);
+      if (!response.ok) {
+        throw new Error(
+          `Failed to download skill package: ${response.status} ${response.statusText}`,
+        );
       }
 
-      await mkdir(path.dirname(targetPath), { recursive: true });
-      await writeFile(targetPath, Buffer.from(fileContent as Uint8Array));
+      const buffer = Buffer.from(await response.arrayBuffer());
+      const extractedFiles = unzipSync(new Uint8Array(buffer));
+
+      // Extract into a staging dir and swap it in with a rename: the live
+      // cache path never exposes a partially written tree, and the window
+      // where a running command's cwd is replaced shrinks from the whole
+      // download+extract to two metadata ops. The zipHash validation above
+      // (no leading dot allowed) guarantees staging dirs can't collide with
+      // real hash dirs.
+      const stagingDir = path.join(cacheRoot, 'extracted', `.staging-${zipHash}`);
+      await rm(stagingDir, { force: true, recursive: true });
+      await mkdir(path.dirname(zipPath), { recursive: true });
+      await mkdir(stagingDir, { recursive: true });
+      await writeFile(zipPath, buffer);
+
+      for (const [relativePath, fileContent] of Object.entries(extractedFiles)) {
+        if (relativePath.endsWith('/')) continue;
+
+        const targetPath = path.resolve(stagingDir, relativePath);
+        const normalizedRoot = `${path.resolve(stagingDir)}${path.sep}`;
+        if (targetPath !== path.resolve(stagingDir) && !targetPath.startsWith(normalizedRoot)) {
+          throw new Error(`Unsafe file path in skill archive: ${relativePath}`);
+        }
+
+        await mkdir(path.dirname(targetPath), { recursive: true });
+        await writeFile(targetPath, Buffer.from(fileContent as Uint8Array));
+      }
+
+      await writeFile(
+        path.join(stagingDir, '.prepared'),
+        JSON.stringify({ preparedAt: Date.now(), url, zipHash }),
+        'utf8',
+      );
+
+      await rm(extractedDir, { force: true, recursive: true });
+      await rename(stagingDir, extractedDir);
+
+      return { extractedDir, success: true, zipPath };
+    } catch (error) {
+      return {
+        error: (error as Error).message,
+        extractedDir,
+        success: false,
+        zipPath,
+      };
     }
+  };
 
-    await writeFile(markerPath, JSON.stringify({ preparedAt: Date.now(), url, zipHash }), 'utf8');
-
-    return { extractedDir, success: true, zipPath };
-  } catch (error) {
-    return {
-      error: (error as Error).message,
-      extractedDir,
-      success: false,
-      zipPath,
-    };
+  // Serialize per extraction dir (see inflightPrepares). `run` never rejects,
+  // so chaining with `.then(run)` is safe.
+  const previous = inflightPrepares.get(extractedDir);
+  const task = previous ? previous.then(run) : run();
+  inflightPrepares.set(extractedDir, task);
+  try {
+    return await task;
+  } finally {
+    if (inflightPrepares.get(extractedDir) === task) inflightPrepares.delete(extractedDir);
   }
 };

--- a/packages/device-control/src/skillDirectory.ts
+++ b/packages/device-control/src/skillDirectory.ts
@@ -34,6 +34,19 @@ export const prepareSkillDirectory = async (
 ): Promise<PrepareSkillDirectoryResult> => {
   const { forceRefresh, url, zipHash } = params;
 
+  // `zipHash` arrives over the device RPC channel and keys filesystem paths —
+  // including a recursive rm of the extraction dir on refresh — so reject
+  // anything that isn't a plain content-hash-like token before deriving any
+  // path (defense in depth alongside the zip-slip guard below).
+  if (!/^[\w-]+$/.test(zipHash)) {
+    return {
+      error: `Invalid zipHash: expected a content hash, got "${zipHash}"`,
+      extractedDir: '',
+      success: false,
+      zipPath: '',
+    };
+  }
+
   const cacheRoot = deps.skillCacheRoot ?? defaultSkillCacheRoot();
   const extractedDir = path.join(cacheRoot, 'extracted', zipHash);
   const markerPath = path.join(extractedDir, '.prepared');

--- a/packages/device-control/src/skillDirectory.ts
+++ b/packages/device-control/src/skillDirectory.ts
@@ -1,0 +1,92 @@
+import { constants } from 'node:fs';
+import { access, mkdir, rm, writeFile } from 'node:fs/promises';
+import * as os from 'node:os';
+import path from 'node:path';
+
+import { unzipSync } from 'fflate';
+
+import type {
+  PrepareSkillDirectoryParams,
+  PrepareSkillDirectoryResult,
+  SkillDirectoryDeps,
+} from './types';
+
+/**
+ * Portable default cache root, following the CLI's `~/.lobehub` convention
+ * (see `apps/cli/src/settings`). The desktop injects its
+ * `<appStoragePath>/file-storage/skills` dir instead so the gateway RPC path
+ * shares one cache with the renderer-IPC path (`LocalFileCtr`).
+ */
+export const defaultSkillCacheRoot = () => path.join(os.homedir(), '.lobehub', 'skills');
+
+/**
+ * Download and extract a skill archive into the device-local cache, keyed by
+ * `zipHash` with a `.prepared` marker for idempotency. Shared by the desktop
+ * main process (renderer IPC + gateway RPC) and the CLI daemon so both hosts
+ * expose the same skill-execution surface.
+ *
+ * Layout mirrors the original desktop implementation (`LocalFileCtr`):
+ * `<cacheRoot>/extracted/<zipHash>/` + `<cacheRoot>/archives/<zipHash>.zip`.
+ */
+export const prepareSkillDirectory = async (
+  params: PrepareSkillDirectoryParams,
+  deps: SkillDirectoryDeps = {},
+): Promise<PrepareSkillDirectoryResult> => {
+  const { forceRefresh, url, zipHash } = params;
+
+  const cacheRoot = deps.skillCacheRoot ?? defaultSkillCacheRoot();
+  const extractedDir = path.join(cacheRoot, 'extracted', zipHash);
+  const markerPath = path.join(extractedDir, '.prepared');
+  const zipPath = path.join(cacheRoot, 'archives', `${zipHash}.zip`);
+
+  try {
+    if (!forceRefresh) {
+      await access(markerPath, constants.F_OK);
+      return { extractedDir, success: true, zipPath };
+    }
+  } catch {
+    // Cache miss, continue preparing the local copy.
+  }
+
+  try {
+    const fetchImpl = deps.fetchSkillArchive ?? fetch;
+    const response = await fetchImpl(url);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to download skill package: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    const extractedFiles = unzipSync(new Uint8Array(buffer));
+
+    await rm(extractedDir, { force: true, recursive: true });
+    await mkdir(path.dirname(zipPath), { recursive: true });
+    await mkdir(extractedDir, { recursive: true });
+    await writeFile(zipPath, buffer);
+
+    for (const [relativePath, fileContent] of Object.entries(extractedFiles)) {
+      if (relativePath.endsWith('/')) continue;
+
+      const targetPath = path.resolve(extractedDir, relativePath);
+      const normalizedRoot = `${path.resolve(extractedDir)}${path.sep}`;
+      if (targetPath !== path.resolve(extractedDir) && !targetPath.startsWith(normalizedRoot)) {
+        throw new Error(`Unsafe file path in skill archive: ${relativePath}`);
+      }
+
+      await mkdir(path.dirname(targetPath), { recursive: true });
+      await writeFile(targetPath, Buffer.from(fileContent as Uint8Array));
+    }
+
+    await writeFile(markerPath, JSON.stringify({ preparedAt: Date.now(), url, zipHash }), 'utf8');
+
+    return { extractedDir, success: true, zipPath };
+  } catch (error) {
+    return {
+      error: (error as Error).message,
+      extractedDir,
+      success: false,
+      zipPath,
+    };
+  }
+};

--- a/packages/device-control/src/types.ts
+++ b/packages/device-control/src/types.ts
@@ -133,6 +133,36 @@ export interface ProjectFileSearchResult {
   source: 'git' | 'glob';
 }
 
+// ─── Skill directory ───
+
+export interface PrepareSkillDirectoryParams {
+  forceRefresh?: boolean;
+  /** Presigned download URL of the skill zip archive. */
+  url: string;
+  /** Content hash of the archive — the idempotency key for the local cache. */
+  zipHash: string;
+}
+
+export interface PrepareSkillDirectoryResult {
+  error?: string;
+  /** Device-local directory the archive was extracted into. */
+  extractedDir: string;
+  success: boolean;
+  zipPath: string;
+}
+
+/**
+ * Host hooks for the skill-archive cache. Both are optional: the CLI daemon
+ * runs on the portable defaults; the desktop injects both so the gateway RPC
+ * path shares the cache (and proxy-aware fetch) with its renderer-IPC path.
+ */
+export interface SkillDirectoryDeps {
+  /** Fetch used to download skill archives. Desktop injects Electron's `net` fetch (proxy-aware); defaults to global `fetch`. */
+  fetchSkillArchive?: (url: string) => Promise<Response>;
+  /** Skill zip cache root. Desktop: `<appStoragePath>/file-storage/skills`; defaults to `~/.lobehub/skills`. */
+  skillCacheRoot?: string;
+}
+
 /**
  * The subset of platform hooks the workspace-scan helpers need. Kept narrow so
  * the desktop's local-IPC `WorkspaceCtr` can reuse `initWorkspace` /
@@ -156,7 +186,7 @@ export interface WorkspaceScanDeps {
  * - The CLI uses the portable defaults exported from this package
  *   (`defaultGetLocalFilePreview`, `defaultGetProjectFileIndex`).
  */
-export interface DeviceControlDeps extends WorkspaceScanDeps {
+export interface DeviceControlDeps extends SkillDirectoryDeps, WorkspaceScanDeps {
   /** Read a local file preview (host-gated on desktop; disk read on CLI). */
   getLocalFilePreview: (params: LocalFilePreviewUrlParams) => Promise<LocalFilePreviewResult>;
   /** Build the project file index. */

--- a/packages/types/src/stepContext.ts
+++ b/packages/types/src/stepContext.ts
@@ -35,7 +35,12 @@ export interface StepContextTodos {
  */
 export interface StepActivatedSkill {
   description?: string;
-  id: string;
+  /**
+   * DB skill id. Absent for filesystem (project/device) and builtin skill
+   * activations, whose persisted state carries no id — consumers match by
+   * `name` (the server exec paths resolve archives/project skills by name).
+   */
+  id?: string;
   name: string;
 }
 

--- a/src/services/electron/__tests__/desktopSkillRuntime.test.ts
+++ b/src/services/electron/__tests__/desktopSkillRuntime.test.ts
@@ -92,6 +92,64 @@ describe('desktopSkillRuntimeService', () => {
     expect(result).toBe('/tmp/demo-skill');
   });
 
+  // id-less builtin/filesystem activations reach the desktop runtime since the
+  // shared extractor keeps them — they never resolve to a packaged skill and
+  // must not shadow one activated before/after them (last resolvable wins).
+  it('should skip id-less unresolvable activations and use the last packaged skill', async () => {
+    getByIdMock.mockResolvedValue({
+      id: 'skill-1',
+      name: 'demo-skill',
+      zipFileHash: 'zip-hash-1',
+    });
+    getByNameMock.mockResolvedValue(undefined);
+    getZipUrlMock.mockResolvedValue({
+      name: 'demo-skill',
+      url: 'https://example.com/demo-skill.zip',
+    });
+    prepareSkillDirectoryMock.mockResolvedValue({
+      extractedDir: '/tmp/demo-skill',
+      success: true,
+      zipPath: '/tmp/demo-skill.zip',
+    });
+
+    const result = await desktopSkillRuntimeService.resolveExecutionDirectory([
+      { name: 'builtin-skill' },
+      { id: 'skill-1', name: 'demo-skill' },
+      { name: 'project-skill' },
+    ]);
+
+    expect(getByNameMock).toHaveBeenCalledWith('project-skill');
+    expect(getByIdMock).toHaveBeenCalledWith('skill-1');
+    expect(result).toBe('/tmp/demo-skill');
+    // The walk stops at the packaged skill — earlier activations are not resolved.
+    expect(getByNameMock).not.toHaveBeenCalledWith('builtin-skill');
+  });
+
+  it('should prepare the most recently activated packaged skill when several resolve', async () => {
+    getByIdMock.mockImplementation(async (id: string) =>
+      id === 'skill-1'
+        ? { id: 'skill-1', name: 'first-skill', zipFileHash: 'zip-hash-1' }
+        : { id: 'skill-2', name: 'second-skill', zipFileHash: 'zip-hash-2' },
+    );
+    getZipUrlMock.mockResolvedValue({
+      name: 'second-skill',
+      url: 'https://example.com/second-skill.zip',
+    });
+    prepareSkillDirectoryMock.mockResolvedValue({
+      extractedDir: '/tmp/second-skill',
+      success: true,
+      zipPath: '/tmp/second-skill.zip',
+    });
+
+    const result = await desktopSkillRuntimeService.resolveExecutionDirectory([
+      { id: 'skill-1', name: 'first-skill' },
+      { id: 'skill-2', name: 'second-skill' },
+    ]);
+
+    expect(getZipUrlMock).toHaveBeenCalledWith('skill-2');
+    expect(result).toBe('/tmp/second-skill');
+  });
+
   it('should return undefined when the skill has no packaged zip', async () => {
     getByIdMock.mockResolvedValue({
       id: 'skill-1',

--- a/src/services/electron/desktopSkillRuntime.ts
+++ b/src/services/electron/desktopSkillRuntime.ts
@@ -35,12 +35,21 @@ class DesktopSkillRuntimeService {
   async resolveExecutionDirectory(
     activatedSkills?: ExecScriptActivatedSkill[],
   ): Promise<string | undefined> {
-    // Use the first activated skill to resolve the execution directory
-    const firstSkill = activatedSkills?.[0];
-    if (!firstSkill) return undefined;
+    if (!activatedSkills?.length) return undefined;
 
-    const skill = await this.resolveSkill({ id: firstSkill.id, name: firstSkill.name });
-    return this.prepareSkillDirectoryForSkill(skill);
+    // Walk from the most recent activation and use the first one that
+    // resolves to a packaged (zip-backed) DB skill — id-less filesystem/
+    // builtin activations never resolve here and must not shadow a packaged
+    // skill activated before/after them. Mirrors the server exec paths'
+    // "last resolvable skill wins the cwd" semantics.
+    for (const activated of [...activatedSkills].reverse()) {
+      const skill = await this.resolveSkill({ id: activated.id, name: activated.name });
+      if (!skill?.zipFileHash) continue;
+
+      return this.prepareSkillDirectoryForSkill(skill);
+    }
+
+    return undefined;
   }
 
   async resolveReferenceFullPath(params: {

--- a/src/store/chat/slices/message/selectors/dbMessage.ts
+++ b/src/store/chat/slices/message/selectors/dbMessage.ts
@@ -1,5 +1,5 @@
+import { extractActivatedSkillsFromMessages } from '@lobechat/agent-runtime';
 import { LobeActivatorIdentifier } from '@lobechat/builtin-tool-activator';
-import { SkillsIdentifier } from '@lobechat/builtin-tool-skills';
 import {
   type StepActivatedSkill,
   type StepContextTodos,
@@ -202,52 +202,7 @@ export const selectActivatedToolIdsFromMessages = (
  */
 export const selectActivatedSkillsFromMessages = (
   messages: UIChatMessage[],
-): StepActivatedSkill[] | undefined => {
-  const skillsMap = new Map<string, StepActivatedSkill>();
-
-  for (const msg of messages) {
-    if (
-      msg.role !== 'tool' ||
-      !(
-        msg.plugin?.identifier === SkillsIdentifier ||
-        msg.plugin?.identifier === LobeActivatorIdentifier
-      )
-    )
-      continue;
-
-    // Direct activateSkill calls — state has top-level id/name
-    if (msg.plugin?.apiName === 'activateSkill' && msg.pluginState?.id && msg.pluginState?.name) {
-      const id = msg.pluginState.id as string;
-      skillsMap.set(id, {
-        description: msg.pluginState.description as string | undefined,
-        id,
-        name: msg.pluginState.name as string,
-      });
-    }
-
-    // activateTools fallback — skills nested in pluginState.activatedSkills[]
-    if (
-      msg.plugin?.apiName === 'activateTools' &&
-      Array.isArray(msg.pluginState?.activatedSkills)
-    ) {
-      for (const skill of msg.pluginState.activatedSkills as Array<{
-        description?: string;
-        id?: string;
-        name?: string;
-      }>) {
-        if (skill.id && skill.name) {
-          skillsMap.set(skill.id, {
-            description: skill.description,
-            id: skill.id,
-            name: skill.name,
-          });
-        }
-      }
-    }
-  }
-
-  return skillsMap.size > 0 ? [...skillsMap.values()] : undefined;
-};
+): StepActivatedSkill[] | undefined => extractActivatedSkillsFromMessages(messages);
 
 // ============= Todos Selectors ========== //
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-11500. Related to LOBE-11479, LOBE-11444, LOBE-11457; follows up #16759.

#### 🔀 Description of Change

In the client-runtime era, desktop `lobe-skills.execScript` had a full local-device path: the skill zip was downloaded and extracted **on the device** (idempotent by zipHash) and the command ran locally with cwd = the extracted skill directory. The server/gateway migration lost that branch — skills exec always landed in the cloud sandbox, even when the user explicitly selected their local device. This PR restores it, with the execution target following the resolved ExecutionPlan:

- **`@lobechat/device-control`**: new `prepareSkillDirectory` device RPC — the desktop `LocalFileCtr` download/extract logic (fetch + fflate + zip-slip guard + `.prepared` idempotency marker) moved into the shared package, so the desktop main process and the CLI daemon expose the same capability. No gateway relay changes (`rpc_request` is routed by method device-side).
- **Hosts**: desktop `LocalFileCtr` now delegates to the shared implementation; `GatewayConnectionCtr` injects the same cache root + proxy-aware fetch, so the renderer-IPC path and the gateway RPC path share one cache. The CLI daemon picks up the portable defaults (`~/.lobehub/skills`) with zero changes.
- **Server** (`serverRuntimes/skills.ts`): `execScript` branches on the plan — when a device is routed (`activeDeviceId` present ⇔ `plan.kind === 'device'`), skill archives are prepared device-side via the RPC and the command executes through local-system over the device gateway (cwd = extracted dir, most-recently-activated skill wins, mirroring the sandbox provider). Failures return an explicit error and **never silently fall back to the sandbox**. Every exec result now records `executionEnv` (`device` / `sandbox`) in plugin state for execution-target observability.
- **`resolveManifest.ts`**: on device runs the API surface drops `runCommand` / `exportFile` (restoring the original desktop manifest shape — `runCommand` duplicates `lobe-local-system` and `exportFile` only makes sense for pulling artifacts out of the sandbox), and `execScript`'s description declares device execution with no LobeHub-managed credentials. `sandbox` / `device-unrouted` wording is unchanged.

Also fixes the desktop vitest config missing an alias for `@lobechat/device-identity` (not hoisted in the superproject context), which prevented `GatewayConnectionCtr.test.ts` from running at all.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- `device-control`: unit tests for extraction, zipHash idempotency, forceRefresh, zip-slip rejection, download failure.
- `serverRuntimes/skills.ts`: device branch (prepare → run with cwd), explicit failure with no sandbox fallback, no-archive cwd fallback, sandbox executionEnv tagging.
- `resolveManifest`: device runs hide `runCommand`/`exportFile` and declare device execution; sandbox / device-unrouted assertions unchanged.

#### 📝 Additional Information

Key decisions / non-goals:

- **Explicit failure over silent fallback**: device execution failures surface a clear error to the model — silent sandbox degradation is exactly the regression this fixes. Single exception (version-skew window): a client build that predates the `prepareSkillDirectory` RPC replies with a deterministic unknown-method error; that one case falls back to the sandbox **with an explicit disclosure note** telling the model to ask the user to update their app. Network failures/timeouts never fall back. Server can ship before the desktop release.
- **`exportFile` intentionally not device-ported**: device runs leave artifacts on the user's machine, where they already are; there is no readback flow by design.
- **`lh` auth on devices is user-managed** (`lh login`): devices are persistent environments, unlike per-run sandboxes, so no JWT injection is added for device runs.
- Non-goal: consolidating bare `runCommand` / the injection matrix (tracked separately in LOBE-11479).
- Non-goal: mid-run manifest re-resolution. A run that starts `device-unrouted` keeps its run-start skills manifest snapshot even after the model activates a device mid-run, so exec-API wording can go stale (sandbox phrasing while `execScript` correctly runs on the just-activated device). Harmless in execution — the runtime refuses the manifest-hidden sandbox APIs whenever a device is routed and redirects to `execScript`/`lobe-local-system` — but the wording refresh needs a step-delta manifest mechanism that belongs to the LOBE-11479 follow-up.



---

#### 🐛 Follow-up in this PR: activated skills were invisible to the server runtime (cross-turn)

E2E acceptance surfaced a second regression in the same migration, fixed here in `d06aeb0b`:

1. **Server executors never passed `activatedSkills`.** Only the legacy client transport computed the activation set (`computeStepContext`); the server `callTool` / `callToolsBatch` executors handed the raw LLM args to the tool runtime, so `execScriptOnDevice`'s prepare loop ran with zero skills and cwd silently fell back. Fixed by a shared pure extractor `extractActivatedSkillsFromMessages` (`@lobechat/agent-runtime`), used by both the client selector and the server executors, threaded through `ToolExecutionContext.activatedSkills` → `serverRuntimes/skills.ts` → the ExecutionRuntime `args` fallback.
2. **Cross-turn activations were still lost after fix 1.** The server runtime rehydrates `state.messages` from the DB at every step (`rehydrateStateMessagesFromDB`), which runs conversation-flow `parse()`: completed turns are folded into `assistantGroup` virtual nodes, so `role='tool'` rows (and their `pluginState`) vanish as standalone entries — a skill activated in a previous turn was invisible to any later run in the same topic. The extractor now also walks the grouped shape (`children[].tools[].result.state`, plus `compressedGroup.compressedMessages` recursively).

Verified end-to-end on a real device (CLI `lh connect` daemon + device gateway): cross-turn `execScript` now emits `prepareSkillDirectory`, runs with cwd = the extracted skill dir (`~/.lobehub/skills/extracted/<zipHash>`), reuses the `.prepared` cache on re-run, and records `executionEnv: 'device'`.

---

#### 🔍 Review follow-up (`3ad180cf26`)

Deep-review findings addressed in one commit:

- **Still-running UI signal**: a device command outliving the shell observation window kept `success: true` (correct for the model loop — still running ≠ failed) but `ExecScriptInspector` rendered a completed green check while the model text said "still running". The inspector now shows a spinning loader when `exitCode` is undefined and a `shellId` is present; `ExecScriptState` typing aligned with the actually-persisted state (`exitCode?`, `shellId`, `executionEnv`, `outputFiles`).
- **Concurrent skill prepares**: `execScriptOnDevice` awaited `prepareSkillDirectory` per archive sequentially — latency scaled linearly with activated-skill count (which accumulates over the conversation). Prepares now fire concurrently (deduped by zipHash), and results are consumed in activation order to preserve the sequential semantics (last resolvable wins the cwd; first failure in activation order is reported, legacy-client sentinel included). Pinned by two new tests.
- **Type/reuse cleanups**: dropped the `(msg as any)` casts in `extractActivatedSkillsFromMessages` (fields are already typed on `UIChatMessage`); `deviceDirname` replaced by exporting the existing `getDirname` from the ExecutionRuntime.

