### PR TITLE
✨ feat(hetero): align tool_end payload+result so onAfterCall works for CLI agents

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -1725,6 +1725,10 @@ describe('ClaudeCodeAdapter', () => {
       expect(events).toHaveLength(1);
       expect(events[0].type).toBe('tool_end');
       expect(events[0].data.toolCallId).toBe('t1');
+      // A pending tool that never produced a result must NOT report success —
+      // otherwise side-effect hooks would treat an unfinished tool as completed.
+      expect(events[0].data.isSuccess).toBe(false);
+      expect(events[0].data.result).toMatchObject({ success: false });
     });
 
     it('returns empty array when no pending tools', () => {

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -445,6 +445,47 @@ describe('ClaudeCodeAdapter', () => {
       expect(end!.data.toolCallId).toBe('t1');
     });
 
+    it('aligns tool_end with the server shape — carries payload + result', () => {
+      const adapter = new ClaudeCodeAdapter();
+      adapter.adapt({ subtype: 'init', type: 'system' });
+      adapter.adapt({
+        message: {
+          id: 'msg_1',
+          content: [
+            {
+              id: 't1',
+              input: { command: 'git worktree add ../wt' },
+              name: 'Bash',
+              type: 'tool_use',
+            },
+          ],
+        },
+        type: 'assistant',
+      });
+
+      const events = adapter.adapt({
+        message: {
+          content: [{ content: 'Preparing worktree', tool_use_id: 't1', type: 'tool_result' }],
+          role: 'user',
+        },
+        type: 'user',
+      });
+
+      const end = events.find((e) => e.type === 'tool_end');
+      // Payload mirrors tool_start's `{ toolCalling }` so `onAfterCall` can resolve
+      // the executor by identifier and read the command args; result gives success.
+      expect(end!.data.payload).toEqual({
+        toolCalling: {
+          apiName: 'Bash',
+          arguments: JSON.stringify({ command: 'git worktree add ../wt' }),
+          id: 't1',
+          identifier: 'claude-code',
+          type: 'default',
+        },
+      });
+      expect(end!.data.result).toMatchObject({ content: 'Preparing worktree', success: true });
+    });
+
     it('handles array-shaped tool_result content', () => {
       const adapter = new ClaudeCodeAdapter();
       adapter.adapt({ subtype: 'init', type: 'system' });

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -556,6 +556,13 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
    */
   private mainToolInputsById = new Map<string, Record<string, any>>();
   /**
+   * `tool_use.id → ToolCallPayload`, so `tool_end` can re-attach the same
+   * `{ toolCalling }` payload the server ships — aligning the hetero event
+   * stream with the gateway/server one so renderer `onAfterCall` hooks fire
+   * identically regardless of runtime.
+   */
+  private toolPayloadById = new Map<string, ToolCallPayload>();
+  /**
    * Set of parent tool_use ids whose spawn metadata has already been
    * announced on a subagent event. Guarantees `spawnMetadata` appears
    * exactly once per subagent run — on the first subagent event for that
@@ -676,7 +683,7 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
   flush(): HeterogeneousAgentEvent[] {
     // Close any still-open tools (shouldn't happen in normal flow, but be safe)
     const events = [...this.pendingToolCalls].map((id) =>
-      this.makeEvent('tool_end', { isSuccess: true, toolCallId: id }),
+      this.makeEvent('tool_end', this.buildToolEndData(id, true)),
     );
     this.pendingToolCalls.clear();
     return events;
@@ -814,14 +821,19 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
           // domain-named) instead of the wire-prefixed MCP form. Identifier
           // stays `claude-code` because this remains a CC-side tool.
           const apiName = block.name === ASK_USER_MCP_TOOL_NAME ? ASK_USER_API_NAME : block.name;
-          newToolCalls.push({
+          const toolPayload: ToolCallPayload = {
             apiName,
             arguments: JSON.stringify(block.input || {}),
             id: block.id,
             identifier: 'claude-code',
             type: 'default',
-          });
+          };
+          newToolCalls.push(toolPayload);
           this.pendingToolCalls.add(block.id);
+          // Cache the payload by id so `tool_end` can carry the same
+          // `{ toolCalling }` the server emits — keeps the event stream aligned
+          // so renderer `onAfterCall` hooks fire identically across runtimes.
+          this.toolPayloadById.set(block.id, toolPayload);
           // Cache EVERY main-agent tool_use input so the subagent-spawn
           // handler (`emitToolChunk`) can look up the parent's args on
           // first subagent event regardless of which spawn-tool name CC
@@ -1015,14 +1027,19 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
           // domain-named) instead of the wire-prefixed MCP form. Identifier
           // stays `claude-code` because this remains a CC-side tool.
           const apiName = block.name === ASK_USER_MCP_TOOL_NAME ? ASK_USER_API_NAME : block.name;
-          newToolCalls.push({
+          const toolPayload: ToolCallPayload = {
             apiName,
             arguments: JSON.stringify(block.input || {}),
             id: block.id,
             identifier: 'claude-code',
             type: 'default',
-          });
+          };
+          newToolCalls.push(toolPayload);
           this.pendingToolCalls.add(block.id);
+          // Cache the payload by id so `tool_end` can carry the same
+          // `{ toolCalling }` the server emits — keeps the event stream aligned
+          // so renderer `onAfterCall` hooks fire identically across runtimes.
+          this.toolPayloadById.set(block.id, toolPayload);
           if (block.name === CC_TODO_WRITE_TOOL_NAME && block.input) {
             this.todoWriteInputs.set(block.id, block.input as TodoWriteArgs);
           }
@@ -1133,6 +1150,33 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
   }
 
   /**
+   * Build `tool_end` event data aligned with the server/gateway shape: alongside
+   * `{ isSuccess, toolCallId }`, re-attach the tool's `{ toolCalling }` payload
+   * (from `toolPayloadById`) and a `result` mirroring a `BuiltinToolResult`. This
+   * is what lets the renderer's `onAfterCall` dispatch resolve the executor (by
+   * `identifier`) and observe the result — otherwise hetero tool_end carried no
+   * payload/result and `onAfterCall` was a silent no-op for CLI runs.
+   */
+  private buildToolEndData(
+    toolCallId: string,
+    isSuccess: boolean,
+    opts?: { content?: string; state?: unknown; subagent?: SubagentEventContext },
+  ): Record<string, any> {
+    const data: Record<string, any> = { isSuccess, toolCallId };
+    if (opts?.subagent) data.subagent = opts.subagent;
+
+    const toolCalling = this.toolPayloadById.get(toolCallId);
+    if (toolCalling) data.payload = { toolCalling };
+
+    data.result = {
+      content: opts?.content ?? '',
+      success: isSuccess,
+      ...(opts?.state ? { state: opts.state } : {}),
+    };
+    return data;
+  }
+
+  /**
    * Handle user events — these contain tool_result blocks.
    * NOTE: In Claude Code, tool results are emitted as `type: 'user'` events
    * (representing the synthetic user turn that feeds results back to the LLM).
@@ -1239,11 +1283,14 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
       if (this.pendingToolCalls.has(toolCallId)) {
         this.pendingToolCalls.delete(toolCallId);
         events.push(
-          this.makeEvent('tool_end', {
-            isSuccess: !block.is_error,
-            subagent: subagentCtx,
-            toolCallId,
-          }),
+          this.makeEvent(
+            'tool_end',
+            this.buildToolEndData(toolCallId, !block.is_error, {
+              content: resultContent,
+              state: pluginState,
+              subagent: subagentCtx,
+            }),
+          ),
         );
       }
     }

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -681,9 +681,12 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
   }
 
   flush(): HeterogeneousAgentEvent[] {
-    // Close any still-open tools (shouldn't happen in normal flow, but be safe)
+    // A still-pending tool never produced a result (the CLI ended / was cancelled
+    // mid-tool), so mark it UNSUCCESSFUL — mirrors Codex's drain and stops a
+    // side-effect hook (e.g. worktree detection) from treating an unfinished
+    // `git worktree add` as a success.
     const events = [...this.pendingToolCalls].map((id) =>
-      this.makeEvent('tool_end', this.buildToolEndData(id, true)),
+      this.makeEvent('tool_end', this.buildToolEndData(id, false)),
     );
     this.pendingToolCalls.clear();
     return events;

--- a/packages/heterogeneous-agents/src/adapters/codex.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/codex.test.ts
@@ -427,6 +427,36 @@ describe('CodexAdapter', () => {
     });
   });
 
+  it('aligns tool_end with the server shape — carries payload + result', () => {
+    const adapter = new CodexAdapter();
+    adapter.adapt({
+      item: {
+        command: 'git worktree add /wt',
+        id: 'item_1',
+        status: 'in_progress',
+        type: 'command_execution',
+      },
+      type: 'item.started',
+    });
+    const completed = adapter.adapt({
+      item: {
+        aggregated_output: 'Preparing worktree',
+        command: 'git worktree add /wt',
+        exit_code: 0,
+        id: 'item_1',
+        status: 'completed',
+        type: 'command_execution',
+      },
+      type: 'item.completed',
+    });
+
+    const end = completed.find((e) => e.type === 'tool_end');
+    expect(end!.data.payload).toMatchObject({
+      toolCalling: { apiName: 'command_execution', id: 'item_1', identifier: 'codex' },
+    });
+    expect(end!.data.result).toMatchObject({ success: true });
+  });
+
   it('maps command execution items into tool lifecycle events', () => {
     const adapter = new CodexAdapter();
 

--- a/packages/heterogeneous-agents/src/adapters/codex.ts
+++ b/packages/heterogeneous-agents/src/adapters/codex.ts
@@ -996,19 +996,30 @@ export class CodexAdapter implements AgentEventAdapter {
     const belongsToCurrentStep =
       pendingStepIndex === undefined || pendingStepIndex === this.stepIndex;
 
+    const toolPayload = toToolPayload(item);
     if (!this.pendingToolCalls.has(item.id)) {
-      const tool = toToolPayload(item);
-      this.pendingToolCallStepIndex.set(tool.id, this.stepIndex);
-      events.push(...this.emitToolChunk(tool));
+      this.pendingToolCallStepIndex.set(toolPayload.id, this.stepIndex);
+      events.push(...this.emitToolChunk(toolPayload));
     }
 
     this.pendingToolCalls.delete(item.id);
     this.pendingToolCallStepIndex.delete(item.id);
     if (belongsToCurrentStep) this.hasToolActivitySinceAgentMessage = true;
-    events.push(this.makeEvent('tool_result', getToolResultData(item as CodexToolItem)));
+    const resultData = getToolResultData(item as CodexToolItem);
+    const isSuccess = isSuccessfulToolCompletion(item as CodexToolItem);
+    events.push(this.makeEvent('tool_result', resultData));
+    // Align tool_end with the server/gateway shape — carry the `{ toolCalling }`
+    // payload + a `BuiltinToolResult`-shaped `result` so renderer `onAfterCall`
+    // hooks resolve the executor and observe the result, identically to server runs.
     events.push(
       this.makeEvent('tool_end', {
-        isSuccess: isSuccessfulToolCompletion(item as CodexToolItem),
+        isSuccess,
+        payload: { toolCalling: toolPayload },
+        result: {
+          content: resultData.content,
+          success: isSuccess,
+          ...(resultData.pluginState ? { state: resultData.pluginState } : {}),
+        },
         toolCallId: item.id,
       }),
     );

--- a/packages/types/src/tool/builtin.ts
+++ b/packages/types/src/tool/builtin.ts
@@ -934,6 +934,14 @@ export interface ToolHookContext {
    * Useful for correlating before/after hooks against the same call.
    */
   toolCallId?: string;
+  /**
+   * Topic id of the run this tool call belongs to (the bound operation's topic),
+   * threaded from the event handler's conversation context. Prefer this over the
+   * globally-active topic so a hook's side effects land on the run's own topic
+   * even if the user has navigated away mid-run. Undefined when the run has no
+   * topic yet.
+   */
+  topicId?: string;
 }
 
 export interface ToolBeforeCallContext extends ToolHookContext {}

--- a/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
@@ -680,6 +680,7 @@ describe('createGatewayEventHandler', () => {
         params: { identifier: 'T-3' },
         result: { content: 'Task deleted', success: true },
         toolCallId: 'tc-1',
+        topicId: 'topic-1',
       });
     });
 
@@ -750,6 +751,7 @@ describe('createGatewayEventHandler', () => {
         identifier: 'lobe-task',
         params: { identifier: 'T-5', name: 'renamed' },
         toolCallId: 'tc-3',
+        topicId: 'topic-1',
       });
     });
   });

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -106,7 +106,10 @@ const readToolPayload = (
  * tool packages can react before their own mutations dispatch (e.g.
  * optimistic UI). Fires for both client- and server-runtime tools.
  */
-const dispatchOnBeforeCall = async (data: ToolStartData | undefined): Promise<void> => {
+const dispatchOnBeforeCall = async (
+  data: ToolStartData | undefined,
+  topicId?: string,
+): Promise<void> => {
   const payload = data?.toolCalling as ChatToolPayloadLike | undefined;
   const identity = readToolPayload(payload);
   if (!identity) return;
@@ -115,7 +118,7 @@ const dispatchOnBeforeCall = async (data: ToolStartData | undefined): Promise<vo
   const executor = getExecutor(identity.identifier);
   if (!executor?.onBeforeCall) return;
 
-  await executor.onBeforeCall(identity);
+  await executor.onBeforeCall({ ...identity, topicId });
 };
 
 /**
@@ -140,7 +143,10 @@ const unwrapToolPayload = (raw: unknown): ChatToolPayloadLike | undefined => {
  * tool packages can react to their own mutations (e.g. invalidate store
  * caches) regardless of whether the tool ran client- or server-side.
  */
-const dispatchOnAfterCall = async (data: ToolEndData | undefined): Promise<void> => {
+const dispatchOnAfterCall = async (
+  data: ToolEndData | undefined,
+  topicId?: string,
+): Promise<void> => {
   const identity = readToolPayload(unwrapToolPayload(data?.payload));
   if (!identity) return;
 
@@ -151,6 +157,7 @@ const dispatchOnAfterCall = async (data: ToolEndData | undefined): Promise<void>
   await executor.onAfterCall({
     ...identity,
     result: (data?.result ?? {}) as BuiltinToolResult,
+    topicId,
   });
 };
 
@@ -598,7 +605,7 @@ export const createGatewayEventHandler = (
         // Loading is already active from stream_start (not cleared by stream_end).
         const data = event.data as ToolStartData | undefined;
         enqueue(async () => {
-          await dispatchOnBeforeCall(data).catch(console.error);
+          await dispatchOnBeforeCall(data, context.topicId ?? undefined).catch(console.error);
         });
         break;
       }
@@ -664,7 +671,7 @@ export const createGatewayEventHandler = (
         enqueue(async () => {
           await Promise.all([
             fetchAndReplaceMessages(get, context).catch(console.error),
-            dispatchOnAfterCall(data).catch(console.error),
+            dispatchOnAfterCall(data, context.topicId ?? undefined).catch(console.error),
           ]);
         });
         break;

--- a/src/store/tool/slices/builtin/executors/__tests__/heteroCli.test.ts
+++ b/src/store/tool/slices/builtin/executors/__tests__/heteroCli.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { claudeCodeExecutor, codexExecutor } from '../heteroCli';
+
+const detectMocks = vi.hoisted(() => ({ applyWorktreeAddFromToolCall: vi.fn() }));
+
+vi.mock('../worktreeDetection', () => ({
+  applyWorktreeAddFromToolCall: detectMocks.applyWorktreeAddFromToolCall,
+}));
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('heteroCli executors', () => {
+  it('registers the CLI adapter identifiers and exposes no invokable APIs', () => {
+    expect(claudeCodeExecutor.identifier).toBe('claude-code');
+    expect(codexExecutor.identifier).toBe('codex');
+    // Empty apiEnum → never treated as an invokable client tool.
+    expect(claudeCodeExecutor.hasApi('Bash')).toBe(false);
+    expect(claudeCodeExecutor.getApiNames()).toEqual([]);
+  });
+
+  it('runs worktree detection on a successful tool call', async () => {
+    const params = { command: 'git worktree add /wt' };
+    await claudeCodeExecutor.onAfterCall!({
+      apiName: 'Bash',
+      identifier: 'claude-code',
+      params,
+      result: { content: '', success: true },
+    });
+    expect(detectMocks.applyWorktreeAddFromToolCall).toHaveBeenCalledWith(params);
+  });
+
+  it('skips detection when the tool call failed', async () => {
+    await claudeCodeExecutor.onAfterCall!({
+      apiName: 'Bash',
+      identifier: 'claude-code',
+      params: { command: 'git worktree add /wt' },
+      result: { content: 'fatal: ...', success: false },
+    });
+    expect(detectMocks.applyWorktreeAddFromToolCall).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/tool/slices/builtin/executors/__tests__/heteroCli.test.ts
+++ b/src/store/tool/slices/builtin/executors/__tests__/heteroCli.test.ts
@@ -2,11 +2,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { claudeCodeExecutor, codexExecutor } from '../heteroCli';
 
-const detectMocks = vi.hoisted(() => ({ applyWorktreeAddFromToolCall: vi.fn() }));
+const detectMocks = vi.hoisted(() => ({ recordWorktreeAdd: vi.fn() }));
 
 vi.mock('../worktreeDetection', () => ({
-  applyWorktreeAddFromToolCall: detectMocks.applyWorktreeAddFromToolCall,
+  recordWorktreeAdd: detectMocks.recordWorktreeAdd,
 }));
+
+const call = (over: Record<string, any> = {}) => ({
+  apiName: 'Bash',
+  identifier: 'claude-code',
+  params: { command: 'git worktree add /wt' },
+  result: { content: '', success: true },
+  topicId: 't1',
+  ...over,
+});
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -19,24 +28,50 @@ describe('heteroCli executors', () => {
     expect(claudeCodeExecutor.getApiNames()).toEqual([]);
   });
 
-  it('runs worktree detection on a successful tool call', async () => {
-    const params = { command: 'git worktree add /wt' };
-    await claudeCodeExecutor.onAfterCall!({
-      apiName: 'Bash',
-      identifier: 'claude-code',
-      params,
-      result: { content: '', success: true },
+  it('records the worktree for a successful shell call, keyed by the run topic', async () => {
+    await claudeCodeExecutor.onAfterCall!(call());
+    expect(detectMocks.recordWorktreeAdd).toHaveBeenCalledWith({
+      command: 'git worktree add /wt',
+      topicId: 't1',
     });
-    expect(detectMocks.applyWorktreeAddFromToolCall).toHaveBeenCalledWith(params);
   });
 
-  it('skips detection when the tool call failed', async () => {
-    await claudeCodeExecutor.onAfterCall!({
-      apiName: 'Bash',
-      identifier: 'claude-code',
-      params: { command: 'git worktree add /wt' },
-      result: { content: 'fatal: ...', success: false },
+  it('passes an argv-array command through verbatim (boundaries preserved)', async () => {
+    await codexExecutor.onAfterCall!(
+      call({
+        apiName: 'command_execution',
+        identifier: 'codex',
+        params: { command: ['git', 'worktree', 'add', '/tmp/my wt'] },
+      }),
+    );
+    expect(detectMocks.recordWorktreeAdd).toHaveBeenCalledWith({
+      command: ['git', 'worktree', 'add', '/tmp/my wt'],
+      topicId: 't1',
     });
-    expect(detectMocks.applyWorktreeAddFromToolCall).not.toHaveBeenCalled();
+  });
+
+  it('skips a failed call', async () => {
+    await claudeCodeExecutor.onAfterCall!(call({ result: { content: 'fatal', success: false } }));
+    expect(detectMocks.recordWorktreeAdd).not.toHaveBeenCalled();
+  });
+
+  it('skips when there is no run topic', async () => {
+    await claudeCodeExecutor.onAfterCall!(call({ topicId: undefined }));
+    expect(detectMocks.recordWorktreeAdd).not.toHaveBeenCalled();
+  });
+
+  it('is constrained to the shell tool — ignores other tools', async () => {
+    // A non-shell tool (e.g. Write) whose params happen to carry `content`.
+    await claudeCodeExecutor.onAfterCall!(
+      call({ apiName: 'Write', params: { command: 'git worktree add /wt' } }),
+    );
+    expect(detectMocks.recordWorktreeAdd).not.toHaveBeenCalled();
+  });
+
+  it('reads only command/cmd, never content', async () => {
+    await claudeCodeExecutor.onAfterCall!(
+      call({ params: { content: 'git worktree add /wt', file_path: 'a.md' } }),
+    );
+    expect(detectMocks.recordWorktreeAdd).not.toHaveBeenCalled();
   });
 });

--- a/src/store/tool/slices/builtin/executors/__tests__/worktreeDetection.test.ts
+++ b/src/store/tool/slices/builtin/executors/__tests__/worktreeDetection.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { applyWorktreeAddFromToolCall, parseWorktreeAddPath } from '../worktreeDetection';
+
+const chatMocks = vi.hoisted(() => ({
+  activeTopicId: undefined as string | undefined,
+  topics: {} as Record<string, { metadata?: Record<string, any> }>,
+  updateTopicMetadata: vi.fn(),
+}));
+
+vi.mock('@/store/chat/store', () => ({
+  getChatStoreState: () => chatMocks,
+}));
+
+vi.mock('@/store/chat/selectors', () => ({
+  topicSelectors: {
+    getTopicById: (id: string) => (state: typeof chatMocks) => state.topics[id],
+  },
+}));
+
+describe('parseWorktreeAddPath', () => {
+  const cmd = (command: unknown) => ({ command });
+
+  it('resolves a relative path against the source cwd', () => {
+    expect(parseWorktreeAddPath(cmd('git worktree add ../wt'), '/repo')).toBe('/wt');
+    expect(parseWorktreeAddPath(cmd('git worktree add wt'), '/repo')).toBe('/repo/wt');
+  });
+
+  it('keeps an absolute path as-is', () => {
+    expect(parseWorktreeAddPath(cmd('git worktree add /tmp/wt'), '/repo')).toBe('/tmp/wt');
+  });
+
+  it('skips flags and their values', () => {
+    expect(parseWorktreeAddPath(cmd('git worktree add -b feature ../feat'), '/repo')).toBe('/feat');
+    expect(parseWorktreeAddPath(cmd('git worktree add --detach /tmp/wt'), '/repo')).toBe('/tmp/wt');
+  });
+
+  it('stops at a shell separator', () => {
+    expect(parseWorktreeAddPath(cmd('cd /repo && git worktree add wt && cd wt'), '/repo')).toBe(
+      '/repo/wt',
+    );
+  });
+
+  it('joins an argv-array command (Codex shell shape)', () => {
+    expect(parseWorktreeAddPath(cmd(['git', 'worktree', 'add', '/tmp/wt']), '/repo')).toBe(
+      '/tmp/wt',
+    );
+  });
+
+  it('reads only `command`, never `content` (writeFile is safe)', () => {
+    expect(
+      parseWorktreeAddPath({ content: 'run: git worktree add /wt', file_path: 'a.md' }, '/repo'),
+    ).toBeUndefined();
+  });
+
+  it('requires an actual git invocation — not the words in another command (P2)', () => {
+    expect(parseWorktreeAddPath(cmd('echo git worktree add ../wt'), '/repo')).toBeUndefined();
+    expect(parseWorktreeAddPath(cmd('rg "git worktree add" .'), '/repo')).toBeUndefined();
+    expect(parseWorktreeAddPath(cmd('grep -r "worktree add" src'), '/repo')).toBeUndefined();
+  });
+
+  it('accepts wrappers and git global options', () => {
+    expect(parseWorktreeAddPath(cmd('sudo git worktree add /wt'), '/repo')).toBe('/wt');
+    expect(parseWorktreeAddPath(cmd('git -C /elsewhere worktree add wt'), '/repo')).toBe(
+      '/elsewhere/wt',
+    );
+    expect(parseWorktreeAddPath(cmd('git -c core.hooksPath=/x worktree add /wt'), '/repo')).toBe(
+      '/wt',
+    );
+  });
+
+  it('returns undefined for non-worktree-add calls', () => {
+    expect(parseWorktreeAddPath(cmd('git status'), '/repo')).toBeUndefined();
+    expect(parseWorktreeAddPath(cmd('git worktree list'), '/repo')).toBeUndefined();
+    expect(parseWorktreeAddPath({ file_path: '/x' }, '/repo')).toBeUndefined();
+    expect(parseWorktreeAddPath(undefined, '/repo')).toBeUndefined();
+  });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  chatMocks.activeTopicId = undefined;
+  chatMocks.topics = {};
+});
+
+describe('applyWorktreeAddFromToolCall', () => {
+  it('records the new worktree onto the active topic', async () => {
+    chatMocks.activeTopicId = 't1';
+    chatMocks.topics = {
+      t1: { metadata: { workingDirectoryConfig: { path: '/repo', repoType: 'github' } } },
+    };
+
+    await applyWorktreeAddFromToolCall({ command: 'git worktree add ../wt' });
+
+    expect(chatMocks.updateTopicMetadata).toHaveBeenCalledWith('t1', {
+      workingDirectoryConfig: {
+        git: { activeWorktree: '/wt', isWorktree: true },
+        path: '/repo',
+        repoType: 'github',
+      },
+    });
+  });
+
+  it('does nothing when there is no active topic', async () => {
+    chatMocks.activeTopicId = undefined;
+    await applyWorktreeAddFromToolCall({ command: 'git worktree add /wt' });
+    expect(chatMocks.updateTopicMetadata).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the worktree resolves to the source path', async () => {
+    chatMocks.activeTopicId = 't1';
+    chatMocks.topics = { t1: { metadata: { workingDirectoryConfig: { path: '/repo' } } } };
+    await applyWorktreeAddFromToolCall({ command: 'git worktree add /repo' });
+    expect(chatMocks.updateTopicMetadata).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent when the active worktree is already set', async () => {
+    chatMocks.activeTopicId = 't1';
+    chatMocks.topics = {
+      t1: {
+        metadata: {
+          workingDirectoryConfig: {
+            git: { activeWorktree: '/wt', isWorktree: true },
+            path: '/repo',
+          },
+        },
+      },
+    };
+    await applyWorktreeAddFromToolCall({ command: 'git worktree add /wt' });
+    expect(chatMocks.updateTopicMetadata).not.toHaveBeenCalled();
+  });
+
+  it('does nothing for a non-worktree command', async () => {
+    chatMocks.activeTopicId = 't1';
+    chatMocks.topics = { t1: { metadata: { workingDirectoryConfig: { path: '/repo' } } } };
+    await applyWorktreeAddFromToolCall({ command: 'ls -la' });
+    expect(chatMocks.updateTopicMetadata).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/tool/slices/builtin/executors/__tests__/worktreeDetection.test.ts
+++ b/src/store/tool/slices/builtin/executors/__tests__/worktreeDetection.test.ts
@@ -1,9 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { applyWorktreeAddFromToolCall, parseWorktreeAddPath } from '../worktreeDetection';
+import { parseWorktreeAddPath, recordWorktreeAdd } from '../worktreeDetection';
 
 const chatMocks = vi.hoisted(() => ({
-  activeTopicId: undefined as string | undefined,
   topics: {} as Record<string, { metadata?: Record<string, any> }>,
   updateTopicMetadata: vi.fn(),
 }));
@@ -19,78 +18,67 @@ vi.mock('@/store/chat/selectors', () => ({
 }));
 
 describe('parseWorktreeAddPath', () => {
-  const cmd = (command: unknown) => ({ command });
-
   it('resolves a relative path against the source cwd', () => {
-    expect(parseWorktreeAddPath(cmd('git worktree add ../wt'), '/repo')).toBe('/wt');
-    expect(parseWorktreeAddPath(cmd('git worktree add wt'), '/repo')).toBe('/repo/wt');
+    expect(parseWorktreeAddPath('git worktree add ../wt', '/repo')).toBe('/wt');
+    expect(parseWorktreeAddPath('git worktree add wt', '/repo')).toBe('/repo/wt');
   });
 
   it('keeps an absolute path as-is', () => {
-    expect(parseWorktreeAddPath(cmd('git worktree add /tmp/wt'), '/repo')).toBe('/tmp/wt');
+    expect(parseWorktreeAddPath('git worktree add /tmp/wt', '/repo')).toBe('/tmp/wt');
   });
 
   it('skips flags and their values', () => {
-    expect(parseWorktreeAddPath(cmd('git worktree add -b feature ../feat'), '/repo')).toBe('/feat');
-    expect(parseWorktreeAddPath(cmd('git worktree add --detach /tmp/wt'), '/repo')).toBe('/tmp/wt');
+    expect(parseWorktreeAddPath('git worktree add -b feature ../feat', '/repo')).toBe('/feat');
+    expect(parseWorktreeAddPath('git worktree add --detach /tmp/wt', '/repo')).toBe('/tmp/wt');
   });
 
   it('stops at a shell separator', () => {
-    expect(parseWorktreeAddPath(cmd('cd /repo && git worktree add wt && cd wt'), '/repo')).toBe(
+    expect(parseWorktreeAddPath('cd /repo && git worktree add wt && cd wt', '/repo')).toBe(
       '/repo/wt',
     );
   });
 
-  it('joins an argv-array command (Codex shell shape)', () => {
-    expect(parseWorktreeAddPath(cmd(['git', 'worktree', 'add', '/tmp/wt']), '/repo')).toBe(
-      '/tmp/wt',
+  it('preserves argv boundaries for the array form — a path with spaces stays intact', () => {
+    expect(parseWorktreeAddPath(['git', 'worktree', 'add', '/tmp/my wt'], '/repo')).toBe(
+      '/tmp/my wt',
     );
+    expect(parseWorktreeAddPath(['git', 'worktree', 'add', 'my wt'], '/repo')).toBe('/repo/my wt');
   });
 
-  it('reads only `command`, never `content` (writeFile is safe)', () => {
-    expect(
-      parseWorktreeAddPath({ content: 'run: git worktree add /wt', file_path: 'a.md' }, '/repo'),
-    ).toBeUndefined();
-  });
-
-  it('requires an actual git invocation — not the words in another command (P2)', () => {
-    expect(parseWorktreeAddPath(cmd('echo git worktree add ../wt'), '/repo')).toBeUndefined();
-    expect(parseWorktreeAddPath(cmd('rg "git worktree add" .'), '/repo')).toBeUndefined();
-    expect(parseWorktreeAddPath(cmd('grep -r "worktree add" src'), '/repo')).toBeUndefined();
+  it('requires an actual git invocation — not the words in another command', () => {
+    expect(parseWorktreeAddPath('echo git worktree add ../wt', '/repo')).toBeUndefined();
+    expect(parseWorktreeAddPath('rg "git worktree add" .', '/repo')).toBeUndefined();
+    expect(parseWorktreeAddPath('grep -r "worktree add" src', '/repo')).toBeUndefined();
   });
 
   it('accepts wrappers and git global options', () => {
-    expect(parseWorktreeAddPath(cmd('sudo git worktree add /wt'), '/repo')).toBe('/wt');
-    expect(parseWorktreeAddPath(cmd('git -C /elsewhere worktree add wt'), '/repo')).toBe(
+    expect(parseWorktreeAddPath('sudo git worktree add /wt', '/repo')).toBe('/wt');
+    expect(parseWorktreeAddPath('git -C /elsewhere worktree add wt', '/repo')).toBe(
       '/elsewhere/wt',
     );
-    expect(parseWorktreeAddPath(cmd('git -c core.hooksPath=/x worktree add /wt'), '/repo')).toBe(
-      '/wt',
-    );
+    expect(parseWorktreeAddPath('git -c core.hooksPath=/x worktree add /wt', '/repo')).toBe('/wt');
   });
 
   it('returns undefined for non-worktree-add calls', () => {
-    expect(parseWorktreeAddPath(cmd('git status'), '/repo')).toBeUndefined();
-    expect(parseWorktreeAddPath(cmd('git worktree list'), '/repo')).toBeUndefined();
-    expect(parseWorktreeAddPath({ file_path: '/x' }, '/repo')).toBeUndefined();
-    expect(parseWorktreeAddPath(undefined, '/repo')).toBeUndefined();
+    expect(parseWorktreeAddPath('git status', '/repo')).toBeUndefined();
+    expect(parseWorktreeAddPath('git worktree list', '/repo')).toBeUndefined();
   });
 });
 
+const PR_TOPIC = {
+  metadata: { workingDirectoryConfig: { path: '/repo', repoType: 'github' } },
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
-  chatMocks.activeTopicId = undefined;
   chatMocks.topics = {};
 });
 
-describe('applyWorktreeAddFromToolCall', () => {
-  it('records the new worktree onto the active topic', async () => {
-    chatMocks.activeTopicId = 't1';
-    chatMocks.topics = {
-      t1: { metadata: { workingDirectoryConfig: { path: '/repo', repoType: 'github' } } },
-    };
+describe('recordWorktreeAdd', () => {
+  it('records the new worktree onto the given (run) topic', async () => {
+    chatMocks.topics = { t1: PR_TOPIC };
 
-    await applyWorktreeAddFromToolCall({ command: 'git worktree add ../wt' });
+    await recordWorktreeAdd({ command: 'git worktree add ../wt', topicId: 't1' });
 
     expect(chatMocks.updateTopicMetadata).toHaveBeenCalledWith('t1', {
       workingDirectoryConfig: {
@@ -101,21 +89,21 @@ describe('applyWorktreeAddFromToolCall', () => {
     });
   });
 
-  it('does nothing when there is no active topic', async () => {
-    chatMocks.activeTopicId = undefined;
-    await applyWorktreeAddFromToolCall({ command: 'git worktree add /wt' });
-    expect(chatMocks.updateTopicMetadata).not.toHaveBeenCalled();
+  it('targets the passed topicId, not the active one', async () => {
+    chatMocks.topics = { other: PR_TOPIC, t1: PR_TOPIC };
+
+    await recordWorktreeAdd({ command: 'git worktree add /wt', topicId: 'other' });
+
+    expect(chatMocks.updateTopicMetadata).toHaveBeenCalledWith('other', expect.anything());
   });
 
   it('does nothing when the worktree resolves to the source path', async () => {
-    chatMocks.activeTopicId = 't1';
     chatMocks.topics = { t1: { metadata: { workingDirectoryConfig: { path: '/repo' } } } };
-    await applyWorktreeAddFromToolCall({ command: 'git worktree add /repo' });
+    await recordWorktreeAdd({ command: 'git worktree add /repo', topicId: 't1' });
     expect(chatMocks.updateTopicMetadata).not.toHaveBeenCalled();
   });
 
   it('is idempotent when the active worktree is already set', async () => {
-    chatMocks.activeTopicId = 't1';
     chatMocks.topics = {
       t1: {
         metadata: {
@@ -126,14 +114,13 @@ describe('applyWorktreeAddFromToolCall', () => {
         },
       },
     };
-    await applyWorktreeAddFromToolCall({ command: 'git worktree add /wt' });
+    await recordWorktreeAdd({ command: 'git worktree add /wt', topicId: 't1' });
     expect(chatMocks.updateTopicMetadata).not.toHaveBeenCalled();
   });
 
   it('does nothing for a non-worktree command', async () => {
-    chatMocks.activeTopicId = 't1';
-    chatMocks.topics = { t1: { metadata: { workingDirectoryConfig: { path: '/repo' } } } };
-    await applyWorktreeAddFromToolCall({ command: 'ls -la' });
+    chatMocks.topics = { t1: PR_TOPIC };
+    await recordWorktreeAdd({ command: 'ls -la', topicId: 't1' });
     expect(chatMocks.updateTopicMetadata).not.toHaveBeenCalled();
   });
 });

--- a/src/store/tool/slices/builtin/executors/heteroCli.ts
+++ b/src/store/tool/slices/builtin/executors/heteroCli.ts
@@ -1,0 +1,38 @@
+import type { ToolAfterCallContext } from '@lobechat/types';
+import { BaseExecutor } from '@lobechat/types';
+
+import { applyWorktreeAddFromToolCall } from './worktreeDetection';
+
+/**
+ * Hook-only executor for a heterogeneous CLI agent's tool identifier
+ * (`claude-code` / `codex` — set by the adapters in
+ * `packages/heterogeneous-agents/src/adapters/*`). These agents run their OWN
+ * tools, so this executor is NEVER invoked: `apiEnum` is empty → `hasApi()` is
+ * always false → the client-tool dispatch (`hasExecutor`) never routes to
+ * `invoke`, and no phantom tool is exposed to the model.
+ *
+ * It exists solely so the `tool_end` dispatcher
+ * (`gatewayEventHandler.dispatchOnAfterCall`, which resolves the executor by the
+ * tool's `identifier`) can reach `onAfterCall` and observe the CLI's shell tool
+ * results renderer-side — the same seam idiomatic builtin tools use to react to
+ * their own mutations.
+ */
+const EMPTY_API_ENUM = {} as Record<string, string>;
+
+class HeteroCliExecutor extends BaseExecutor<typeof EMPTY_API_ENUM> {
+  protected readonly apiEnum = EMPTY_API_ENUM;
+
+  constructor(readonly identifier: string) {
+    super();
+  }
+
+  onAfterCall = async ({ params, result }: ToolAfterCallContext): Promise<void> => {
+    if (!result.success) return;
+    // Only a successful `git worktree add` matches; every other tool call (and
+    // non-shell tool) falls through cheaply inside the detector.
+    await applyWorktreeAddFromToolCall(params);
+  };
+}
+
+export const claudeCodeExecutor = new HeteroCliExecutor('claude-code');
+export const codexExecutor = new HeteroCliExecutor('codex');

--- a/src/store/tool/slices/builtin/executors/heteroCli.ts
+++ b/src/store/tool/slices/builtin/executors/heteroCli.ts
@@ -1,7 +1,7 @@
 import type { ToolAfterCallContext } from '@lobechat/types';
 import { BaseExecutor } from '@lobechat/types';
 
-import { applyWorktreeAddFromToolCall } from './worktreeDetection';
+import { recordWorktreeAdd } from './worktreeDetection';
 
 /**
  * Hook-only executor for a heterogeneous CLI agent's tool identifier
@@ -19,20 +19,52 @@ import { applyWorktreeAddFromToolCall } from './worktreeDetection';
  */
 const EMPTY_API_ENUM = {} as Record<string, string>;
 
+/**
+ * Pull the command out of a shell tool's parsed params. Only reads `command`/`cmd`
+ * — never `content` — so a file-write tool can't be mistaken for a shell command.
+ * Returns the raw value (string OR the argv-array form) so the detector can keep
+ * argument boundaries.
+ */
+const readShellCommand = (params: unknown): string | string[] | undefined => {
+  if (!params || typeof params !== 'object') return undefined;
+  const raw = (params as { cmd?: unknown; command?: unknown }).command ?? (params as any).cmd;
+  if (typeof raw === 'string') return raw;
+  if (Array.isArray(raw) && raw.every((t) => typeof t === 'string')) return raw as string[];
+  return undefined;
+};
+
 class HeteroCliExecutor extends BaseExecutor<typeof EMPTY_API_ENUM> {
   protected readonly apiEnum = EMPTY_API_ENUM;
 
-  constructor(readonly identifier: string) {
+  /**
+   * @param identifier   The CLI adapter's tool identifier (`claude-code` / `codex`).
+   * @param shellApiNames The adapter's shell / run-command tool api name(s). Side
+   *   effects are constrained to THIS tool first, then handled uniformly — we don't
+   *   sniff every tool call's params.
+   */
+  constructor(
+    readonly identifier: string,
+    private readonly shellApiNames: ReadonlySet<string>,
+  ) {
     super();
   }
 
-  onAfterCall = async ({ params, result }: ToolAfterCallContext): Promise<void> => {
-    if (!result.success) return;
-    // Only a successful `git worktree add` matches; every other tool call (and
-    // non-shell tool) falls through cheaply inside the detector.
-    await applyWorktreeAddFromToolCall(params);
+  onAfterCall = async ({
+    apiName,
+    params,
+    result,
+    topicId,
+  }: ToolAfterCallContext): Promise<void> => {
+    // Constrain to a SUCCESSFUL run of the shell tool bound to a run topic.
+    if (!result.success || !topicId || !this.shellApiNames.has(apiName)) return;
+
+    const command = readShellCommand(params);
+    if (command === undefined) return;
+
+    await recordWorktreeAdd({ command, topicId });
   };
 }
 
-export const claudeCodeExecutor = new HeteroCliExecutor('claude-code');
-export const codexExecutor = new HeteroCliExecutor('codex');
+// CC's shell tool is `Bash`; Codex's is `command_execution`.
+export const claudeCodeExecutor = new HeteroCliExecutor('claude-code', new Set(['Bash']));
+export const codexExecutor = new HeteroCliExecutor('codex', new Set(['command_execution']));

--- a/src/store/tool/slices/builtin/executors/index.ts
+++ b/src/store/tool/slices/builtin/executors/index.ts
@@ -20,6 +20,7 @@ import { memoryExecutor } from '@lobechat/builtin-tool-memory/executor';
 import { taskExecutor } from '@lobechat/builtin-tool-task/client/executor';
 
 import type { BuiltinToolContext, BuiltinToolResult, IBuiltinToolExecutor } from '../types';
+import { claudeCodeExecutor, codexExecutor } from './heteroCli';
 import { activatorExecutor } from './lobe-activator';
 import { agentDocumentsExecutor } from './lobe-agent-documents';
 import { messageExecutor } from './lobe-message';
@@ -137,6 +138,10 @@ export const registerBuiltinToolExecutors = (): void => {
   if (executorsRegistered) return;
 
   registerExecutors([
+    // Hook-only executors for heterogeneous CLI agents (Claude Code / Codex) —
+    // observe their shell tool results via `onAfterCall` (never invoked).
+    claudeCodeExecutor,
+    codexExecutor,
     agentBuilderExecutor,
     agentDocumentsExecutor,
     agentManagementExecutor,

--- a/src/store/tool/slices/builtin/executors/worktreeDetection.ts
+++ b/src/store/tool/slices/builtin/executors/worktreeDetection.ts
@@ -55,20 +55,6 @@ const resolveWorktreePath = (p: string, cwd?: string): string => {
   return normalizePosix(`${cwd}/${p}`);
 };
 
-/**
- * Pull the shell command out of a tool call's parsed `params`. Only reads the
- * `command`/`cmd` field (CC `Bash`, Codex shell) — deliberately NOT `content`, so
- * a `writeFile` whose body happens to contain "git worktree add" never misfires.
- * Codex may send the command as an argv array; join it.
- */
-const extractCommand = (params: unknown): string | undefined => {
-  if (!params || typeof params !== 'object') return undefined;
-  const raw = (params as any).command ?? (params as any).cmd;
-  if (Array.isArray(raw))
-    return raw.every((x) => typeof x === 'string') ? raw.join(' ') : undefined;
-  return typeof raw === 'string' ? raw : undefined;
-};
-
 const tokenize = (s: string): string[] => s.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
 
 /** `git` global options that consume the following token as their value. */
@@ -86,13 +72,12 @@ const WRAPPERS = new Set(['sudo', 'env', 'command', 'nice', 'nohup', 'time']);
 const isAssignment = (t: string) => /^[A-Z_]\w*=/i.test(t);
 
 /**
- * If ONE shell segment is a real `git … worktree add <path>` invocation, return the
- * path (resolved against the source cwd, honoring a `-C <dir>` override). Requires
- * the executable to actually be `git` — so `echo git worktree add …` or
- * `rg "git worktree add"` (P2) never match.
+ * If ONE command's tokens are a real `git … worktree add <path>` invocation, return
+ * the path (resolved against the source cwd, honoring a `-C <dir>` override).
+ * Requires the executable to actually be `git` — so `echo git worktree add …` or
+ * `rg "git worktree add"` never match.
  */
-const parseGitWorktreeAddSegment = (segment: string, cwd?: string): string | undefined => {
-  const tokens = tokenize(segment);
+const parseGitWorktreeAddTokens = (tokens: string[], cwd?: string): string | undefined => {
   let i = 0;
 
   // Strip leading `VAR=val` assignments and command wrappers (sudo/env/…).
@@ -136,38 +121,51 @@ const parseGitWorktreeAddSegment = (segment: string, cwd?: string): string | und
 };
 
 /**
- * Parse a shell tool call's `params` for a real `git worktree add <path>` invocation
- * and return the target worktree path (resolved to absolute against `cwd` when
- * relative). Returns `undefined` when the call isn't an actual worktree-add.
+ * Parse a shell command for a real `git worktree add <path>` invocation and return
+ * the target worktree path (resolved to absolute against `cwd` when relative).
+ *
+ * `command` is a raw string (tokenized, split on shell separators) OR the argv
+ * array form some CLIs use (Codex) — for the array we DON'T re-join+re-tokenize, so
+ * a path token containing spaces (`['git','worktree','add','/tmp/my wt']`) keeps its
+ * boundary. Returns `undefined` when the call isn't an actual worktree-add.
  */
-export const parseWorktreeAddPath = (params: unknown, cwd?: string): string | undefined => {
-  const command = extractCommand(params);
-  // Cheap pre-filter, then verify each shell segment is truly a `git` invocation.
-  if (!command || !/\bworktree\s+add\b/.test(command)) return undefined;
+export const parseWorktreeAddPath = (
+  command: string | string[],
+  cwd?: string,
+): string | undefined => {
+  if (Array.isArray(command)) {
+    // Already-tokenized argv → a single command, boundaries preserved.
+    return command.every((t) => typeof t === 'string')
+      ? parseGitWorktreeAddTokens(command, cwd)
+      : undefined;
+  }
+  if (typeof command !== 'string' || !/\bworktree\s+add\b/.test(command)) return undefined;
   for (const segment of command.split(/[\n;|&]/)) {
-    const path = parseGitWorktreeAddSegment(segment, cwd);
+    const path = parseGitWorktreeAddTokens(tokenize(segment), cwd);
     if (path) return path;
   }
   return undefined;
 };
 
 /**
- * If the tool call was a successful `git worktree add`, record the new worktree as
- * the ACTIVE topic's active one. `onAfterCall` carries no run topicId, so this
- * targets `activeTopicId` — during a CLI run that IS the run's topic (mirrors how
- * other executors, e.g. Task, key off active store state). No-op when the worktree
- * resolves to the source path itself or nothing would change.
+ * Record a successful `git worktree add` as the run topic's active worktree. Writes
+ * to the passed `topicId` (the bound operation's topic — from the `onAfterCall`
+ * context), NOT the globally-active topic, so a run whose topic the user has
+ * navigated away from still updates its own state. No-op when the worktree resolves
+ * to the source path itself or nothing would change.
  */
-export const applyWorktreeAddFromToolCall = async (params: unknown): Promise<void> => {
+export const recordWorktreeAdd = async (params: {
+  command: string | string[];
+  topicId: string;
+}): Promise<void> => {
+  const { command, topicId } = params;
   const state = getChatStoreState();
-  const topicId = state.activeTopicId;
-  if (!topicId) return;
 
   const topic = topicSelectors.getTopicById(topicId)(state);
   const currentConfig = topic?.metadata?.workingDirectoryConfig;
   const source = getWorkingDirSourcePath(currentConfig) ?? topic?.metadata?.workingDirectory;
 
-  const worktreePath = parseWorktreeAddPath(params, source);
+  const worktreePath = parseWorktreeAddPath(command, source);
   if (!worktreePath || !source || worktreePath === source) return;
 
   const git: NonNullable<WorkingDirConfig['git']> = {

--- a/src/store/tool/slices/builtin/executors/worktreeDetection.ts
+++ b/src/store/tool/slices/builtin/executors/worktreeDetection.ts
@@ -1,0 +1,187 @@
+import type { WorkingDirConfig } from '@lobechat/types';
+import { getWorkingDirSourcePath } from '@lobechat/types';
+import isEqual from 'fast-deep-equal';
+
+import { topicSelectors } from '@/store/chat/selectors';
+import { getChatStoreState } from '@/store/chat/store';
+
+/**
+ * Detect `git worktree add <path>` in a heterogeneous CLI agent's shell tool call
+ * and flip the active topic's working-directory state into that worktree.
+ *
+ * Runs from the `claude-code` / `codex` executor's `onAfterCall` hook (renderer-side,
+ * fired on `tool_end`). Mirrors what `WorktreeSwitcher` writes on a manual selection:
+ * only `git.activeWorktree` / `isWorktree` change — the CLI session cwd stays anchored
+ * to the source repo (hetero anchors cwd to source; the worktree is a record).
+ */
+
+/** Flags on `git worktree add` that consume the following token as their value. */
+const VALUE_FLAGS = new Set(['-b', '-B', '--reason']);
+
+const stripQuotes = (token: string): string => {
+  if (token.length >= 2) {
+    const first = token[0];
+    const last = token.at(-1);
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return token.slice(1, -1);
+    }
+  }
+  return token;
+};
+
+const isAbsolute = (p: string): boolean =>
+  p.startsWith('/') || p.startsWith('~') || /^[A-Z]:[\\/]/i.test(p) || p.startsWith('\\\\');
+
+/** Collapse `.`/`..` segments in a POSIX path without touching the filesystem. */
+const normalizePosix = (p: string): string => {
+  const isAbs = p.startsWith('/');
+  const out: string[] = [];
+  for (const part of p.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') {
+      if (out.length > 0 && out.at(-1) !== '..') out.pop();
+      else if (!isAbs) out.push('..');
+    } else {
+      out.push(part);
+    }
+  }
+  return (isAbs ? '/' : '') + out.join('/');
+};
+
+const resolveWorktreePath = (p: string, cwd?: string): string => {
+  // Windows / home-relative paths: can't resolve without the device fs, keep as-is.
+  if (isAbsolute(p)) return p.startsWith('/') ? normalizePosix(p) : p;
+  if (!cwd) return p;
+  return normalizePosix(`${cwd}/${p}`);
+};
+
+/**
+ * Pull the shell command out of a tool call's parsed `params`. Only reads the
+ * `command`/`cmd` field (CC `Bash`, Codex shell) — deliberately NOT `content`, so
+ * a `writeFile` whose body happens to contain "git worktree add" never misfires.
+ * Codex may send the command as an argv array; join it.
+ */
+const extractCommand = (params: unknown): string | undefined => {
+  if (!params || typeof params !== 'object') return undefined;
+  const raw = (params as any).command ?? (params as any).cmd;
+  if (Array.isArray(raw))
+    return raw.every((x) => typeof x === 'string') ? raw.join(' ') : undefined;
+  return typeof raw === 'string' ? raw : undefined;
+};
+
+const tokenize = (s: string): string[] => s.match(/"[^"]*"|'[^']*'|\S+/g) ?? [];
+
+/** `git` global options that consume the following token as their value. */
+const GIT_VALUE_OPTS = new Set([
+  '-C',
+  '-c',
+  '--git-dir',
+  '--work-tree',
+  '--namespace',
+  '--super-prefix',
+  '--config-env',
+]);
+/** Command wrappers that may precede the real `git` executable. */
+const WRAPPERS = new Set(['sudo', 'env', 'command', 'nice', 'nohup', 'time']);
+const isAssignment = (t: string) => /^[A-Z_]\w*=/i.test(t);
+
+/**
+ * If ONE shell segment is a real `git … worktree add <path>` invocation, return the
+ * path (resolved against the source cwd, honoring a `-C <dir>` override). Requires
+ * the executable to actually be `git` — so `echo git worktree add …` or
+ * `rg "git worktree add"` (P2) never match.
+ */
+const parseGitWorktreeAddSegment = (segment: string, cwd?: string): string | undefined => {
+  const tokens = tokenize(segment);
+  let i = 0;
+
+  // Strip leading `VAR=val` assignments and command wrappers (sudo/env/…).
+  while (i < tokens.length && (isAssignment(tokens[i]) || WRAPPERS.has(stripQuotes(tokens[i])))) {
+    i += 1;
+  }
+  if (stripQuotes(tokens[i] ?? '') !== 'git') return undefined;
+  i += 1;
+
+  // git global options; `-C <dir>` rebases relative worktree paths.
+  let baseCwd = cwd;
+  while (i < tokens.length && tokens[i].startsWith('-')) {
+    if (tokens[i] === '-C') {
+      const dir = stripQuotes(tokens[i + 1] ?? '');
+      if (dir) baseCwd = resolveWorktreePath(dir, baseCwd);
+      i += 2;
+    } else if (GIT_VALUE_OPTS.has(tokens[i])) {
+      i += 2;
+    } else {
+      i += 1; // valueless flag or `--opt=val`
+    }
+  }
+
+  // Subcommand must be exactly `worktree add`.
+  if (stripQuotes(tokens[i] ?? '') !== 'worktree') return undefined;
+  i += 1;
+  if (stripQuotes(tokens[i] ?? '') !== 'add') return undefined;
+  i += 1;
+
+  // First positional after `add` is the worktree path.
+  for (; i < tokens.length; i += 1) {
+    if (VALUE_FLAGS.has(tokens[i])) {
+      i += 1; // skip this flag's value
+      continue;
+    }
+    if (tokens[i].startsWith('-')) continue; // other flags
+    const path = stripQuotes(tokens[i]);
+    if (path) return resolveWorktreePath(path, baseCwd);
+  }
+  return undefined;
+};
+
+/**
+ * Parse a shell tool call's `params` for a real `git worktree add <path>` invocation
+ * and return the target worktree path (resolved to absolute against `cwd` when
+ * relative). Returns `undefined` when the call isn't an actual worktree-add.
+ */
+export const parseWorktreeAddPath = (params: unknown, cwd?: string): string | undefined => {
+  const command = extractCommand(params);
+  // Cheap pre-filter, then verify each shell segment is truly a `git` invocation.
+  if (!command || !/\bworktree\s+add\b/.test(command)) return undefined;
+  for (const segment of command.split(/[\n;|&]/)) {
+    const path = parseGitWorktreeAddSegment(segment, cwd);
+    if (path) return path;
+  }
+  return undefined;
+};
+
+/**
+ * If the tool call was a successful `git worktree add`, record the new worktree as
+ * the ACTIVE topic's active one. `onAfterCall` carries no run topicId, so this
+ * targets `activeTopicId` — during a CLI run that IS the run's topic (mirrors how
+ * other executors, e.g. Task, key off active store state). No-op when the worktree
+ * resolves to the source path itself or nothing would change.
+ */
+export const applyWorktreeAddFromToolCall = async (params: unknown): Promise<void> => {
+  const state = getChatStoreState();
+  const topicId = state.activeTopicId;
+  if (!topicId) return;
+
+  const topic = topicSelectors.getTopicById(topicId)(state);
+  const currentConfig = topic?.metadata?.workingDirectoryConfig;
+  const source = getWorkingDirSourcePath(currentConfig) ?? topic?.metadata?.workingDirectory;
+
+  const worktreePath = parseWorktreeAddPath(params, source);
+  if (!worktreePath || !source || worktreePath === source) return;
+
+  const git: NonNullable<WorkingDirConfig['git']> = {
+    ...currentConfig?.git,
+    activeWorktree: worktreePath,
+    isWorktree: true,
+  };
+  const nextConfig: WorkingDirConfig = {
+    ...currentConfig,
+    git,
+    path: source,
+    ...(currentConfig?.repoType ? { repoType: currentConfig.repoType } : {}),
+  };
+
+  if (isEqual(currentConfig, nextConfig)) return;
+  await state.updateTopicMetadata(topicId, { workingDirectoryConfig: nextConfig });
+};


### PR DESCRIPTION
> Supersedes #16787 (hetero reducer patch) and #16791 (onAfterCall that never fired). This fixes the two review findings by aligning the event stream at its source.

## The two bugs (both real)

**P1 — onAfterCall never received hetero tool payloads.** `gatewayEventHandler.dispatchOnAfterCall` resolves the executor from `data.payload` and passes `data.result`, but the CC/Codex adapters emitted `tool_end` as `{ isSuccess, toolCallId }` (`claudeCode.ts` / `codex.ts`) — no payload, no result. So after a successful `git worktree add` there was nothing to resolve the executor or gate on `result.success`: the detector was a silent no-op and `activeWorktree` was never updated. This made #16791 dead for real CLI runs.

**P2 — the detector matched the words, not a git invocation.** `/\bworktree\s+add\b/` matched any successful command containing "worktree add" — `echo git worktree add ../wt`, `rg "git worktree add" .` — writing a bogus `activeWorktree`.

## Fix — unify the event stream (align at the source)

`ToolEndData` already declares optional `payload` / `result` (the server fills them). Fill the same on hetero `tool_end`, so `onAfterCall` fires identically across runtimes — for **every** builtin tool's hook, not just this feature:

- **`claudeCode.ts`** — cache each tool_use `ToolCallPayload` by id; a `buildToolEndData` helper re-attaches `{ toolCalling }` (the same payload `tool_start` ships) + a `BuiltinToolResult`-shaped `result` (content + success + state) at both tool_end sites.
- **`codex.ts`** — attach `{ toolCalling: toToolPayload(item) }` + `result` on completion.

## Feature — auto-detect `git worktree add` (CC/Codex)

Hook-only `claude-code` / `codex` executors (empty `apiEnum` → never invoked, never exposed as a tool). On a **successful** shell call, `onAfterCall` records a real `git … worktree add <path>` as the active topic's active worktree (`git.activeWorktree` / `isWorktree`), mirroring a manual `WorktreeSwitcher` selection; the CLI session cwd stays anchored to the source repo.

**P2 fix:** detection now requires the executable to actually be `git` — after stripping `VAR=val` / `sudo`/`env` wrappers and honoring `-C <dir>` — with `worktree add` as its subcommand. Reads only `command`/`cmd` (never `content`), supports Codex's argv-array form.

## Known limitation
`onAfterCall` carries no run `topicId`, so the write targets `activeTopicId` (the run's topic during a live CLI run, as other executors do). If the user navigates away mid-run, a worktree add would stamp the wrong topic.

## Tests
- Adapter tests assert `tool_end` now carries `payload` + `result` (CC + Codex); all 132 existing adapter tests still pass (partial `toMatchObject` absorbed the additive fields).
- Detector tests: git-invocation gate (P2 false-positives + wrappers/`-C`), argv-array, `content`-safety, apply logic. Executor tests: identifiers / no invokable APIs / success-gating.
- `bun run check` clean; type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)