### PR TITLE
🐛 fix: limit connect service systemd env import to allowlisted variables

### DIFF
--- a/apps/cli/src/service/connect.test.ts
+++ b/apps/cli/src/service/connect.test.ts
@@ -131,8 +131,11 @@ describe('connect service', () => {
     ]);
   });
 
-  it('imports the current environment by name and clears stale service env', () => {
+  it('imports only allowlisted service env and clears stale service env', () => {
     process.env.LOBEHUB_CLI_API_KEY = 'test-key';
+    // Unrelated shell secrets must never reach the systemd user manager —
+    // import-environment makes them inheritable by every other user service.
+    process.env.AWS_SECRET_ACCESS_KEY = 'shell-secret';
     delete process.env.LOBEHUB_CLI_HOME;
 
     installConnectService();
@@ -142,6 +145,9 @@ describe('connect service', () => {
     );
     expect(systemctlCalls).toContainEqual(
       expect.arrayContaining(['--user', 'import-environment', 'LOBEHUB_CLI_API_KEY']),
+    );
+    expect(systemctlCalls).not.toContainEqual(
+      expect.arrayContaining(['import-environment', 'AWS_SECRET_ACCESS_KEY']),
     );
     expect(systemctlCalls).not.toContainEqual(['--user', 'import-environment']);
   });

--- a/apps/cli/src/service/connect.ts
+++ b/apps/cli/src/service/connect.ts
@@ -8,7 +8,6 @@ import { CLI_API_KEY_ENV } from '../constants/auth';
 import { getRunningDaemonPid } from '../daemon/manager';
 
 const SERVICE_NAME = 'lobehub-connect.service';
-const ENV_NAME_PATTERN = /^[A-Z_]\w*$/i;
 const SERVICE_ENV_NAMES = [
   'AGENT_GATEWAY_URL',
   'DEBUG',
@@ -127,7 +126,11 @@ function importServiceEnvironment(): void {
     systemctl(['unset-environment', ...staleServiceEnvNames], 'inherit');
   }
 
-  const environmentNames = Object.keys(process.env).filter((name) => ENV_NAME_PATTERN.test(name));
+  // Only the allowlisted service vars: `import-environment` writes into the
+  // systemd user manager's environment, which every user service started
+  // afterwards inherits — importing all of process.env would leak unrelated
+  // shell secrets (AWS_*, GITHUB_TOKEN, ...) manager-wide.
+  const environmentNames = SERVICE_ENV_NAMES.filter((name) => process.env[name] !== undefined);
   if (environmentNames.length > 0) {
     systemctl(['import-environment', ...environmentNames], 'inherit');
   }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Related to #16629. Flagged by Codex review: https://github.com/lobehub-biz/lobehub-cloud/pull/988#pullrequestreview-4637702518

#### 🔀 Description of Change

`lh connect service install` / `start` / `restart` previously ran `systemctl --user import-environment` with (almost) every variable from `process.env`. `import-environment` writes into the **systemd user manager's** environment, which every user service started afterwards inherits — so unrelated shell secrets (`AWS_SECRET_ACCESS_KEY`, `GITHUB_TOKEN`, ...) leaked manager-wide and became readable by any other user service.

This PR limits the import to the existing `SERVICE_ENV_NAMES` allowlist (the same list already used by the `unset-environment` stale-cleanup path), and removes the now-unused `ENV_NAME_PATTERN`.

#### 🧪 How to Test

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Extended the env-import test to assert `AWS_SECRET_ACCESS_KEY` is never passed to `import-environment`. Note: `connect.test.ts` currently only runs on Linux (`requireLinuxSystemd` throws on darwin without a platform mock), so CI (ubuntu) is the verification path — local macOS failures are pre-existing.

#### 📝 Additional Information

No behavior change for the service itself: the allowlist covers all variables the connect service actually reads (`LOBEHUB_SERVER`, `LOBEHUB_JWT`, `LOBEHUB_CLI_API_KEY`, gateway URLs, `DEBUG`, ...).