### PR TITLE
🐛 fix(oidc): surface route 500 stack to production logs

### DIFF
--- a/src/app/(backend)/oidc/[...oidc]/route.ts
+++ b/src/app/(backend)/oidc/[...oidc]/route.ts
@@ -85,7 +85,10 @@ const handler = async (req: NextRequest) => {
       status: finalStatus,
     });
   } catch (error) {
-    log(`Error handling OIDC ${req.method} request: %O`, error); // Log method in error
+    // Surface the real stack to production logs. A debug `log()` only writes to the
+    // `lobe-oidc:route` namespace, which is disabled in production, so 500s otherwise
+    // land with no application-layer error signature (monitoring blind spot).
+    console.error(`[OIDC Route] Error handling ${req.method} ${requestUrl.pathname}:`, error);
     return new NextResponse(`Internal Server Error: ${(error as Error).message}`, { status: 500 });
   }
 };


### PR DESCRIPTION
## 💻 Change Type

- [x] 🐛 fix

## 🔀 Description of Change

The `/oidc/[...oidc]` route's `catch` block logged errors **only** via the `lobe-oidc:route` `debug()` namespace, which is disabled in production. So when `/oidc/token` (and other OIDC endpoints) returned `500`, the real error/stack never reached Vercel function logs — the response body carried a generic message and the log line had an empty signature.

This is the monitoring blind spot flagged in **LOBE-11497**: during the 07-06 backend/DB anomaly, `/oidc/token` threw hundreds of 500s with no application-layer error to root-cause against.

This PR replaces the debug-only log with a `console.error` that carries the request method + pathname, so the underlying error reaches production logs.

```ts
} catch (error) {
  console.error(`[OIDC Route] Error handling ${req.method} ${requestUrl.pathname}:`, error);
  return new NextResponse(`Internal Server Error: ${(error as Error).message}`, { status: 500 });
}
```

> Note: this is an **observability** fix only — it does not change the 500 behavior itself. The LOBE-11497 incident's likely root cause is a shared-backend (Neon/DB) blip (correlated 5xx across unrelated endpoints, same deployment); this change makes the next occurrence diagnosable.

## 📝 Related Issue

Refs LOBE-11497

## ✅ How to Test

- [x] Trigger an error inside the OIDC handler (e.g. DB unreachable during a token exchange) and confirm the stack now appears in server/function logs via `console.error`, tagged with method + pathname.