### PR TITLE
✨ feat(task): expand long run content inline

### DIFF
--- a/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx
@@ -12,10 +12,19 @@ import {
   Tag,
   Text,
 } from '@lobehub/ui';
-import { confirmModal } from '@lobehub/ui/base-ui';
+import { Button, confirmModal } from '@lobehub/ui/base-ui';
 import { useSize } from 'ahooks';
-import { cssVar } from 'antd-style';
-import { CircleDot, CircleStop, Copy, ExternalLink, MoreHorizontal, SquarePen } from 'lucide-react';
+import { createStaticStyles, cssVar } from 'antd-style';
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  CircleDot,
+  CircleStop,
+  Copy,
+  ExternalLink,
+  MoreHorizontal,
+  SquarePen,
+} from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -29,6 +38,50 @@ import { styles } from '../shared/style';
 import RunReplyEditor from './RunReplyEditor';
 import TopicStatusIcon from './TopicStatusIcon';
 
+const runContentStyles = createStaticStyles(({ css, cssVar }) => ({
+  clipInner: css`
+    padding-block-end: 36px;
+  `,
+  container: css`
+    position: relative;
+    width: 100%;
+  `,
+  toggleButton: css`
+    pointer-events: auto;
+
+    height: 28px;
+    padding-inline: 10px;
+    border-color: transparent;
+    border-radius: 999px;
+
+    color: ${cssVar.colorTextSecondary};
+
+    background: ${cssVar.colorFillQuaternary};
+
+    &:focus-visible,
+    &:hover:not(:disabled, [aria-disabled='true']) {
+      color: ${cssVar.colorText};
+      background: ${cssVar.colorFillTertiary};
+    }
+  `,
+  toggleFloating: css`
+    pointer-events: none;
+
+    position: absolute;
+    z-index: 1;
+    inset-block-end: 4px;
+    inset-inline: 0;
+
+    display: flex;
+    justify-content: center;
+  `,
+  toggleInline: css`
+    display: flex;
+    justify-content: center;
+    margin-block-start: 4px;
+  `,
+}));
+
 const formatDuration = (ms: number): string => {
   const seconds = Math.floor(ms / 1000);
   if (seconds < 60) return `${seconds}s`;
@@ -40,15 +93,21 @@ const formatDuration = (ms: number): string => {
 
 // The run's last message (`content`) is the raw assistant output — markdown, and
 // often long. Render it as rich text, but keep it a bounded preview in the feed:
-// clamp overflow with a fade and let the whole card open the run drawer for the
-// full message (progressive disclosure). `pointerEvents: none` keeps every click
-// — including on links/code inside the markdown — falling through to the card.
+// clamp overflow with a fade, offer an inline expand affordance, and still let
+// the whole card open the run drawer for deeper reading. `pointerEvents: none`
+// keeps every click inside markdown falling through to the card.
 const RUN_CONTENT_MAX_HEIGHT = 160;
 
 const RunContent = memo<{ content: string }>(({ content }) => {
+  const { t } = useTranslation('chat');
   const ref = useRef<HTMLDivElement>(null);
   const size = useSize(ref);
+  const [expanded, setExpanded] = useState(false);
   const isOverflow = !!size && size.height > RUN_CONTENT_MAX_HEIGHT;
+
+  useEffect(() => {
+    setExpanded(false);
+  }, [content]);
 
   const markdown = (
     <Markdown ref={ref} style={{ overflow: 'unset', pointerEvents: 'none' }} variant={'chat'}>
@@ -56,12 +115,42 @@ const RunContent = memo<{ content: string }>(({ content }) => {
     </Markdown>
   );
 
-  return isOverflow ? (
-    <MaskShadow size={32} style={{ maxHeight: RUN_CONTENT_MAX_HEIGHT }}>
-      {markdown}
-    </MaskShadow>
-  ) : (
-    markdown
+  if (!isOverflow) return markdown;
+
+  const toggleButton = (
+    <Button
+      aria-expanded={expanded}
+      className={runContentStyles.toggleButton}
+      icon={expanded ? <ChevronUpIcon size={14} /> : <ChevronDownIcon size={14} />}
+      shape={'round'}
+      size={'small'}
+      type={'fill'}
+      onClick={() => setExpanded((value) => !value)}
+    >
+      {expanded ? t('messageLongCollapse.collapse') : t('messageLongCollapse.expand')}
+    </Button>
+  );
+
+  if (expanded) {
+    return (
+      <div className={runContentStyles.container}>
+        {markdown}
+        <div className={runContentStyles.toggleInline} onClick={stopPropagation}>
+          {toggleButton}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={runContentStyles.container}>
+      <MaskShadow size={40} style={{ maxHeight: RUN_CONTENT_MAX_HEIGHT }}>
+        <div className={runContentStyles.clipInner}>{markdown}</div>
+      </MaskShadow>
+      <div className={runContentStyles.toggleFloating} onClick={stopPropagation}>
+        {toggleButton}
+      </div>
+    </div>
   );
 });
 


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No exact matching GitHub issue found.

Searched:

- `task detail expand run content`
- `Task 详情 展开全部`
- `long task run content`

#### 🔀 Description of Change

Add an inline expand/collapse interaction for long rendered run content in the Task detail page.

When a topic run's markdown output exceeds the preview height, the card now keeps the existing clipped preview with a fade and shows a centered `Expand all` affordance. Clicking it expands the full rendered markdown in place and changes the affordance to `Collapse`. The expand/collapse button stops event propagation so it does not open the run detail drawer; the rest of the card keeps the existing drawer-opening behavior.

This is a UI-only change in `TopicCard.tsx`; no backend, schema, or cross-layer contract changes are involved, so no stacked PR split is needed.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Validation performed:

- `bun run check src/features/AgentTasks/AgentTaskDetail/TopicCard.tsx --lint`
- Agent-testing report: https://app.lobehub.com/verify/9dd7ff64-a1ed-4796-bb8d-62348fd1f800

Manual scenario covered in the report:

1. Open Task detail page with a long markdown topic run.
2. Confirm the run content is rendered as markdown and clipped with an `Expand all` button.
3. Click `Expand all` and confirm the full rendered content appears inline.
4. Confirm the click does not open the topic drawer.
5. Click `Collapse` and confirm the card returns to the clipped preview state.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| See the collapsed preview evidence in the agent-testing report. | See the expanded full-render and collapsed-again evidence in the agent-testing report. |

#### 📝 Additional Information

Full `--type` was attempted during verification, but this checkout is currently blocked by existing repository-wide type conflicts across Drizzle, antd, dayjs, and `@types/react` versions. The captured output did not include `TopicCard.tsx` or `AgentTaskDetail` errors.

The Electron isolated surface was also attempted and recorded as blocked because the dev instance did not stably enter the target Task detail page.