### PR TITLE
🐛 fix(agent): guard working directory path rendering

### DIFF
--- a/src/features/ChatInput/ControlBar/WorkingDirectoryPicker.tsx
+++ b/src/features/ChatInput/ControlBar/WorkingDirectoryPicker.tsx
@@ -3,6 +3,7 @@
 import { isDesktop } from '@lobechat/const';
 import type { WorkingDirEntry } from '@lobechat/types';
 import { getWorkingDirEffectivePath } from '@lobechat/types';
+import { isRecord } from '@lobechat/utils';
 import { Flexbox, Icon, Input, Popover, Tooltip } from '@lobehub/ui';
 import { toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
@@ -24,6 +25,10 @@ import {
   resolveAgentWorkingDirectory,
   resolveTargetDeviceId,
 } from '@/helpers/agentWorkingDirectory';
+import {
+  getWorkingDirectoryName,
+  getWorkingDirectoryPathString,
+} from '@/helpers/workingDirectoryPath';
 import { deviceService } from '@/services/device';
 import { electronSystemService } from '@/services/electron/system';
 import { useAgentStore } from '@/store/agent';
@@ -209,7 +214,8 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-const getDirName = (path: string) => path.split('/').findLast(Boolean) || path;
+const isValidWorkingDirEntry = (entry: unknown): entry is WorkingDirEntry =>
+  isRecord(entry) && !!getWorkingDirectoryPathString(entry.path);
 
 type FolderEntry = { path: string; repoType?: 'git' | 'github' };
 
@@ -317,19 +323,23 @@ const WorkingDirectoryPicker = memo<WorkingDirectoryPickerProps>(({ agentId }) =
   // The local machine's filesystem is browsable; a remote device's is not.
   const isLocalDevice = isDesktop && !!targetDeviceId && targetDeviceId === currentDeviceId;
 
-  const recents = useDeviceStore(deviceSelectors.getDeviceWorkingDirs(targetDeviceId));
-  const deviceDefaultCwd = useDeviceStore(deviceSelectors.getDeviceDefaultCwd(targetDeviceId));
-  const topicWorkingDirectory = useChatStore(topicSelectors.currentTopicWorkingDirectory);
+  const rawRecents = useDeviceStore(deviceSelectors.getDeviceWorkingDirs(targetDeviceId));
+  const recents = useMemo(() => rawRecents.filter(isValidWorkingDirEntry), [rawRecents]);
+  const rawDeviceDefaultCwd = useDeviceStore(deviceSelectors.getDeviceDefaultCwd(targetDeviceId));
+  const deviceDefaultCwd = getWorkingDirectoryPathString(rawDeviceDefaultCwd);
+  const rawTopicWorkingDirectory = useChatStore(topicSelectors.currentTopicWorkingDirectory);
+  const topicWorkingDirectory = getWorkingDirectoryPathString(rawTopicWorkingDirectory);
   const topicWorkingDirectoryConfig = useChatStore(
     (s) => topicSelectors.currentTopicMetadata(s)?.workingDirectoryConfig,
   );
-  const legacyAgentWorkingDirectory = useAgentStore(
+  const rawLegacyAgentWorkingDirectory = useAgentStore(
     (s) => s.localAgentWorkingDirectoryMap[agentId],
   );
+  const legacyAgentWorkingDirectory = getWorkingDirectoryPathString(rawLegacyAgentWorkingDirectory);
 
   // The explicitly-selected cwd (no home fallback) — drives the active check and
   // the Reset affordance.
-  const selectedDir = resolveAgentWorkingDirectory({
+  const resolvedSelectedDir = resolveAgentWorkingDirectory({
     agencyConfig,
     currentDeviceId,
     deviceDefaultCwd,
@@ -337,6 +347,7 @@ const WorkingDirectoryPicker = memo<WorkingDirectoryPickerProps>(({ agentId }) =
     topicWorkingDirectory,
     topicWorkingDirectoryConfig,
   });
+  const selectedDir = getWorkingDirectoryPathString(resolvedSelectedDir);
 
   // Reset only makes sense when an agent-level override exists. The device-wide
   // `deviceDefaultCwd` isn't clearable from here (it's the fallback itself), so
@@ -359,7 +370,7 @@ const WorkingDirectoryPicker = memo<WorkingDirectoryPickerProps>(({ agentId }) =
     if (!query) return recents;
     return recents.filter(
       (entry) =>
-        getDirName(entry.path).toLowerCase().includes(query) ||
+        getWorkingDirectoryName(entry.path)?.toLowerCase().includes(query) ||
         entry.path.toLowerCase().includes(query),
     );
   }, [recents, search]);
@@ -405,7 +416,9 @@ const WorkingDirectoryPicker = memo<WorkingDirectoryPickerProps>(({ agentId }) =
           variant: 'text',
         },
       ],
-      title: t('workingDirectory.removed', { name: getDirName(entry.path) }),
+      title: t('workingDirectory.removed', {
+        name: getWorkingDirectoryName(entry.path) ?? entry.path,
+      }),
     });
   };
 
@@ -431,7 +444,9 @@ const WorkingDirectoryPicker = memo<WorkingDirectoryPickerProps>(({ agentId }) =
         <DirIcon repoType={entry.repoType} />
         <Flexbox flex={1} style={{ minWidth: 0 }}>
           <Flexbox horizontal align={'center'} gap={6}>
-            <div className={styles.dirName}>{getDirName(entry.path)}</div>
+            <div className={styles.dirName}>
+              {getWorkingDirectoryName(entry.path) ?? entry.path}
+            </div>
             {isDefault && (
               <span className={styles.badge}>{t('workingDirectory.defaultBadge')}</span>
             )}
@@ -517,7 +532,9 @@ const WorkingDirectoryPicker = memo<WorkingDirectoryPickerProps>(({ agentId }) =
     </Flexbox>
   );
 
-  const displayName = selectedDir ? getDirName(selectedDir) : t('workingDirectory.notSet');
+  const displayName = selectedDir
+    ? (getWorkingDirectoryName(selectedDir) ?? selectedDir)
+    : t('workingDirectory.notSet');
 
   const trigger = (
     <div className={styles.button}>

--- a/src/features/ChatInput/ControlBar/WorkingDirectorySection.tsx
+++ b/src/features/ChatInput/ControlBar/WorkingDirectorySection.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { isDesktop } from '@lobechat/const';
-import { getWorkingDirEffectivePath } from '@lobechat/types';
+import { isRecord } from '@lobechat/utils';
 import { memo } from 'react';
 
+import SafeBoundary from '@/components/ErrorBoundary';
 import { resolveTargetDeviceId } from '@/helpers/agentWorkingDirectory';
+import { getWorkingDirectoryPathString } from '@/helpers/workingDirectoryPath';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
@@ -19,31 +21,43 @@ interface WorkingDirectorySectionProps {
   agentId: string;
 }
 
+const getEntryEffectivePath = (entry: unknown) => {
+  if (!isRecord(entry)) return;
+
+  const sourcePath = getWorkingDirectoryPathString(entry.path);
+  const git = isRecord(entry.git) ? entry.git : undefined;
+  return getWorkingDirectoryPathString(git?.activeWorktree) ?? sourcePath;
+};
+
 /**
  * Working directory + git status, shared by the agent runtime bars. The unified
  * picker handles local and remote targets alike; git status shows for both — the
  * local machine probes its own filesystem, a remote device answers over RPC
  * (read-only) via GitStatus's `deviceId`.
  */
-const WorkingDirectorySection = memo<WorkingDirectorySectionProps>(({ agentId }) => {
+const WorkingDirectorySectionInner = memo<WorkingDirectorySectionProps>(({ agentId }) => {
   const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));
   const currentDeviceId = useElectronStore((s) => s.gatewayDeviceInfo?.deviceId);
   const targetDeviceId = resolveTargetDeviceId(agencyConfig, currentDeviceId);
   const isLocalDevice = isDesktop && !!targetDeviceId && targetDeviceId === currentDeviceId;
 
-  const effectiveWorkingDirectory = useEffectiveWorkingDirectory(agentId);
+  const rawEffectiveWorkingDirectory = useEffectiveWorkingDirectory(agentId);
+  const effectiveWorkingDirectory = getWorkingDirectoryPathString(rawEffectiveWorkingDirectory);
 
   // Local machine probes the filesystem for repoType; a remote device's repoType
   // comes from the cached `workingDirs` entry (we can't probe a remote fs here).
   const localRepoType = useRepoType(isLocalDevice ? effectiveWorkingDirectory : undefined);
   const deviceDirs = useDeviceStore(deviceSelectors.getDeviceWorkingDirs(targetDeviceId));
-  const currentEntry = deviceDirs.find(
-    (d) =>
-      d.path === effectiveWorkingDirectory ||
-      getWorkingDirEffectivePath(d) === effectiveWorkingDirectory,
-  );
-  const sourceWorkingDirectory = currentEntry?.path ?? effectiveWorkingDirectory;
-  const remoteRepoType = currentEntry?.repoType;
+  const currentEntry = effectiveWorkingDirectory
+    ? deviceDirs.find((entry) => getEntryEffectivePath(entry) === effectiveWorkingDirectory)
+    : undefined;
+  const sourceWorkingDirectory =
+    (isRecord(currentEntry) ? getWorkingDirectoryPathString(currentEntry.path) : undefined) ??
+    effectiveWorkingDirectory;
+  const remoteRepoType =
+    currentEntry?.repoType === 'git' || currentEntry?.repoType === 'github'
+      ? currentEntry.repoType
+      : undefined;
   const repoType = isLocalDevice ? localRepoType : remoteRepoType;
 
   return (
@@ -61,6 +75,14 @@ const WorkingDirectorySection = memo<WorkingDirectorySectionProps>(({ agentId })
     </>
   );
 });
+
+WorkingDirectorySectionInner.displayName = 'WorkingDirectorySectionInner';
+
+const WorkingDirectorySection = memo<WorkingDirectorySectionProps>(({ agentId }) => (
+  <SafeBoundary minHeight={22} resetKeys={[agentId]}>
+    <WorkingDirectorySectionInner agentId={agentId} />
+  </SafeBoundary>
+));
 
 WorkingDirectorySection.displayName = 'WorkingDirectorySection';
 

--- a/src/helpers/workingDirectoryPath.ts
+++ b/src/helpers/workingDirectoryPath.ts
@@ -1,0 +1,15 @@
+import { pickString } from '@lobechat/utils';
+
+export const getWorkingDirectoryPathString = (path: unknown) => {
+  const value = pickString(path)?.trim();
+  return value || undefined;
+};
+
+// Last non-empty path segment — the folder name. Also yields the repo name for
+// a web github URL (".../owner/repo" -> "repo").
+export const getWorkingDirectoryName = (path: unknown) => {
+  const value = getWorkingDirectoryPathString(path);
+  if (!value) return;
+
+  return value.replaceAll('\\', '/').split('/').findLast(Boolean) || value;
+};

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -20,6 +20,7 @@ import DirIcon from '@/features/ChatInput/ControlBar/DirIcon';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';
 import NavItem from '@/features/NavPanel/components/NavItem';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
+import { getWorkingDirectoryName } from '@/helpers/workingDirectoryPath';
 import { getPlatformIcon } from '@/routes/(main)/agent/channel/const';
 import { useAgentStore } from '@/store/agent';
 import { agentSelectors } from '@/store/agent/selectors';
@@ -120,20 +121,18 @@ const cancelPendingSingleClick = () => {
   }
 };
 
-// Last non-empty path segment — the folder name. Also yields the repo name for
-// a web github URL (".../owner/repo" → "repo").
-const getDirName = (path: string) => path.split('/').findLast(Boolean) || path;
-
 const getWorkingDirectoryDisplay = (metadata: ChatTopicMetadata | undefined) => {
   const config = metadata?.workingDirectoryConfig;
   const workingDirectory = getTopicMetadataWorkingDirectoryEffectivePath(metadata);
   if (!workingDirectory) return;
 
   const branch = config?.git?.branch;
-  const dirName = getDirName(workingDirectory);
+  const dirName = getWorkingDirectoryName(workingDirectory);
+  if (!dirName) return;
+
   const sourcePath = getTopicMetadataWorkingDirectorySourcePath(metadata);
   const sourceName =
-    sourcePath && sourcePath !== workingDirectory ? getDirName(sourcePath) : undefined;
+    sourcePath && sourcePath !== workingDirectory ? getWorkingDirectoryName(sourcePath) : undefined;
   const pathLabel = sourceName && sourceName !== dirName ? `${sourceName}/${dirName}` : dirName;
 
   return {

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/metaCardData.ts
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/metaCardData.ts
@@ -8,9 +8,7 @@ import type { LucideIcon } from 'lucide-react';
 import { GitMerge, GitPullRequestArrow, GitPullRequestClosed } from 'lucide-react';
 
 import { isDesktop } from '@/const/version';
-
-const getDirName = (path: string) =>
-  path.replaceAll('\\', '/').split('/').findLast(Boolean) || path;
+import { getWorkingDirectoryName } from '@/helpers/workingDirectoryPath';
 
 export type PullRequestState = 'open' | 'merged' | 'closed';
 
@@ -59,8 +57,8 @@ export const getTopicMetaCard = (metadata: ChatTopicMetadata | undefined) => {
     branch: git.branch,
     detached: git.detached,
     pullRequest: git.github?.pullRequest ?? undefined,
-    repoName: sourcePath ? getDirName(sourcePath) : undefined,
+    repoName: sourcePath ? getWorkingDirectoryName(sourcePath) : undefined,
     repoType: config.repoType ?? (isDesktop ? undefined : ('github' as const)),
-    worktreeName: isWorktree && effectivePath ? getDirName(effectivePath) : undefined,
+    worktreeName: isWorktree && effectivePath ? getWorkingDirectoryName(effectivePath) : undefined,
   };
 };


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- Link to the issue that is fixed by this PR -->

No matching GitHub issue found.

Related runtime report: `TypeError: path.split is not a function` in working directory rendering.

#### 🔀 Description of Change

This PR prevents dirty working-directory data from crashing the agent page.

- Safely narrows working directory values from device, topic, and agent metadata before reading path segments.
- Filters invalid recent working directory entries before rendering the picker list.
- Adds a local `SafeBoundary` around `WorkingDirectorySection` so failures in the working directory module degrade in place instead of triggering the full-page Oops fallback.

Root cause: some persisted or device-synced working directory entries can contain a non-string `path`, while several render helpers assumed `path` was always a string and called `path.split(...)` directly.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Validation:

- Agent-testing report: https://app.lobehub.com/verify/45a7422f-2f83-4844-8d2d-3481dd073a3a
- `bun run check src/features/ChatInput/ControlBar/WorkingDirectoryPicker.tsx src/features/ChatInput/ControlBar/WorkingDirectorySection.tsx 'src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx' 'src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/metaCardData.ts' --lint`
- Electron validation covered:
  - normal working directory control rendering
  - injected dirty `workingDirs` entry with object `path`
  - local ErrorBoundary fallback for `WorkingDirectorySection`

Note: `bun run check ... --type` currently triggers the repository-level type check and is blocked by existing cross-package/dependency-resolution issues. This is recorded as blocked in the agent-testing report.

#### 📸 Screenshots / Videos

Evidence is included in the agent-testing report:

| Before | After |
| ------ | ----- |
| Full-page Oops from `path.split is not a function` when dirty cwd data reaches rendering. | Working directory picker renders normally with dirty cwd data filtered; module-level fault injection only shows local `Render Error`. |

#### 📝 Additional Information

The fix is intentionally defensive at render boundaries. It does not migrate existing persisted data; invalid entries are ignored for display so the rest of the page remains usable.
