### PR TITLE
Fix Codex file change diff rendering

### DIFF
--- a/packages/heterogeneous-agents/src/spawn/codexFileChangeTracker.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/codexFileChangeTracker.test.ts
@@ -76,6 +76,44 @@ describe('CodexFileChangeTracker', () => {
     expect((enriched.item as any).diffText).toContain(`diff --git a${addPath} b${addPath}`);
   });
 
+  it('does not synthesize a whole-file diff when an update starts without a path snapshot', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'codex-file-change-tracker-'));
+    tempDirs.push(dir);
+
+    const updatePath = path.join(dir, 'existing.ts');
+    await writeFile(updatePath, 'line one\nline two\nline three\n', 'utf8');
+
+    const tracker = new CodexFileChangeTracker();
+
+    await tracker.track({
+      item: {
+        changes: [],
+        id: 'item_missing_snapshot',
+        type: 'file_change',
+      },
+      type: 'item.started',
+    });
+
+    await writeFile(updatePath, 'line one\nline two updated\nline three\n', 'utf8');
+
+    const enriched = await tracker.track({
+      item: {
+        changes: [{ kind: 'update', path: updatePath }],
+        id: 'item_missing_snapshot',
+        type: 'file_change',
+      },
+      type: 'item.completed',
+    });
+
+    expect(enriched.item).toMatchObject({
+      changes: [{ kind: 'update', linesAdded: 0, linesDeleted: 0, path: updatePath }],
+      linesAdded: 0,
+      linesDeleted: 0,
+    });
+    expect(enriched.item).not.toHaveProperty('diffText');
+    expect(enriched.item.changes?.[0]).not.toHaveProperty('diffText');
+  });
+
   it('treats rename changes as metadata-only and keeps line stats at zero', async () => {
     const dir = await mkdtemp(path.join(tmpdir(), 'codex-file-change-tracker-'));
     tempDirs.push(dir);

--- a/packages/heterogeneous-agents/src/spawn/codexFileChangeTracker.ts
+++ b/packages/heterogeneous-agents/src/spawn/codexFileChangeTracker.ts
@@ -6,6 +6,8 @@ import { createPatch } from 'diff';
 interface CodexFileChangeEntry {
   diffText?: string;
   kind?: string;
+  linesAdded?: number;
+  linesDeleted?: number;
   path?: string;
 }
 
@@ -145,6 +147,13 @@ const computeFileChangeDiff = async (
     if (!snapshot?.exists) return { linesAdded: 0, linesDeleted: 0 };
     if (snapshot.content === undefined) return { linesAdded: 0, linesDeleted: 0 };
     return buildFileChangeDiff(filePath, previousContent, '');
+  }
+
+  if (!snapshot) {
+    return {
+      linesAdded: change.linesAdded ?? 0,
+      linesDeleted: change.linesDeleted ?? 0,
+    };
   }
 
   if (!snapshot?.exists && !current.exists) return { linesAdded: 0, linesDeleted: 0 };

--- a/packages/heterogeneous-agents/src/spawn/codexFileChangeTracker.ts
+++ b/packages/heterogeneous-agents/src/spawn/codexFileChangeTracker.ts
@@ -40,7 +40,7 @@ interface CodexFileChangeDiff extends CodexFileChangeLineStats {
   diffText?: string;
 }
 
-interface CodexTrackedFileChangeEntry extends CodexFileChangeEntry, CodexFileChangeDiff {}
+type CodexTrackedFileChangeEntry = CodexFileChangeEntry & CodexFileChangeDiff;
 
 interface CodexTrackedFileChangeItem extends CodexFileChangeItem, CodexFileChangeLineStats {
   changes?: CodexTrackedFileChangeEntry[];


### PR DESCRIPTION
## Summary
- Avoid synthesizing a diff for Codex `file_change` updates when the start event did not include a path snapshot.
- Preserve Codex-provided line stats in that missing-snapshot case instead of treating the existing file as a brand-new addition.
- Add a regression test for update events whose `item.started` payload lacks `changes`.

## Root Cause
Codex can stream `file_change` with no file paths on `item.started`, then include update paths only on `item.completed`. The tracker previously used an empty previous-content fallback for updates without a snapshot, so the UI rendered the whole current file as newly added.

## Validation
- `bun run check packages/heterogeneous-agents/src/spawn/codexFileChangeTracker.ts packages/heterogeneous-agents/src/spawn/codexFileChangeTracker.test.ts --lint --test`
- `git diff --check`
