### PR TITLE
🐛 fix: route codex new topic streams to persisted key

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/integration/aiAgent/multiRoundTools.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/aiAgent/multiRoundTools.integration.test.ts
@@ -43,6 +43,8 @@ let serverDB: LobeChatDatabase;
 let userId: string;
 let testAgentWithToolsId: string;
 
+const MULTI_ROUND_AGENT_TEST_TIMEOUT = 15_000;
+
 const createTestContext = () => ({
   jwtPayload: { userId },
   userId,
@@ -334,7 +336,7 @@ describe('Multi-Round Tool Execution', () => {
     expect(mockResponsesCreate).toHaveBeenCalledTimes(3);
 
     mockExecuteTool.mockRestore();
-  });
+  }, MULTI_ROUND_AGENT_TEST_TIMEOUT);
 
   it('should maintain correct state.messages structure in AgentState across tool rounds', async () => {
     let callCount = 0;
@@ -405,5 +407,5 @@ describe('Multi-Round Tool Execution', () => {
     expect(totalToolCalls).toBe(4);
 
     mockExecuteTool.mockRestore();
-  });
+  }, MULTI_ROUND_AGENT_TEST_TIMEOUT);
 });

--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
@@ -1649,6 +1649,129 @@ describe('ConversationLifecycle actions', () => {
         );
       });
 
+      it('should route new-topic heterogeneous streaming updates to the persisted topic key', async () => {
+        mockConstEnv.isDesktop = true;
+        setupMockSelectors({
+          agentConfig: {
+            agencyConfig: {
+              heterogeneousProvider: { command: 'codex', type: 'codex' },
+            },
+          },
+        });
+
+        const createdTopicId = 'created-topic-id';
+        const { result } = renderHook(() => useChatStore());
+
+        vi.spyOn(aiChatService, 'sendMessageInServer').mockResolvedValue({
+          assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+          isCreateNewTopic: true,
+          messages: [
+            createMockMessage({
+              id: TEST_IDS.USER_MESSAGE_ID,
+              role: 'user',
+              topicId: createdTopicId,
+            }),
+            createMockMessage({
+              id: TEST_IDS.ASSISTANT_MESSAGE_ID,
+              role: 'assistant',
+              topicId: createdTopicId,
+            }),
+          ],
+          topicId: createdTopicId,
+          userMessageId: TEST_IDS.USER_MESSAGE_ID,
+        } as any);
+        executeHeterogeneousAgentMock.mockResolvedValue(undefined);
+
+        await act(async () => {
+          await result.current.sendMessage({
+            message: TEST_CONTENT.USER_MESSAGE,
+            context: { ...createTestContext(), isNew: true, scope: 'main' },
+          });
+        });
+
+        const executorParams = executeHeterogeneousAgentMock.mock.calls[0]?.[1];
+        expect(executorParams?.context).toEqual(
+          expect.objectContaining({
+            agentId: TEST_IDS.SESSION_ID,
+            isNew: false,
+            scope: 'main',
+            topicId: createdTopicId,
+          }),
+        );
+
+        const heteroOperation = Object.values(useChatStore.getState().operations).find(
+          (operation) => operation.type === 'execHeterogeneousAgent',
+        );
+        expect(heteroOperation?.context).toEqual(
+          expect.objectContaining({
+            isNew: false,
+            topicId: createdTopicId,
+          }),
+        );
+
+        const persistedTopicKey = messageMapKey({
+          agentId: TEST_IDS.SESSION_ID,
+          scope: 'main',
+          topicId: createdTopicId,
+        });
+        const leakedNewTopicKey = messageMapKey({
+          agentId: TEST_IDS.SESSION_ID,
+          isNew: true,
+          scope: 'main',
+          topicId: createdTopicId,
+        });
+
+        expect(useChatStore.getState().messagesMap[persistedTopicKey]).toHaveLength(2);
+        expect(useChatStore.getState().messagesMap[leakedNewTopicKey] ?? []).toHaveLength(0);
+      });
+
+      it('should preserve the isNew marker for heterogeneous new-thread contexts', async () => {
+        mockConstEnv.isDesktop = true;
+        setupMockSelectors({
+          agentConfig: {
+            agencyConfig: {
+              heterogeneousProvider: { command: 'codex', type: 'codex' },
+            },
+          },
+        });
+
+        const { result } = renderHook(() => useChatStore());
+
+        vi.spyOn(aiChatService, 'sendMessageInServer').mockResolvedValue({
+          assistantMessageId: TEST_IDS.ASSISTANT_MESSAGE_ID,
+          messages: [
+            createMockMessage({ id: TEST_IDS.USER_MESSAGE_ID, role: 'user' }),
+            createMockMessage({ id: TEST_IDS.ASSISTANT_MESSAGE_ID, role: 'assistant' }),
+          ],
+          topicId: TEST_IDS.TOPIC_ID,
+          userMessageId: TEST_IDS.USER_MESSAGE_ID,
+        } as any);
+        executeHeterogeneousAgentMock.mockResolvedValue(undefined);
+
+        await act(async () => {
+          await result.current.sendMessage({
+            message: TEST_CONTENT.USER_MESSAGE,
+            context: {
+              ...createTestContext(),
+              isNew: true,
+              scope: 'thread',
+              sourceMessageId: 'source-message-id',
+              threadType: 'continuation',
+              topicId: TEST_IDS.TOPIC_ID,
+            },
+          });
+        });
+
+        const executorParams = executeHeterogeneousAgentMock.mock.calls[0]?.[1];
+        expect(executorParams?.context).toEqual(
+          expect.objectContaining({
+            isNew: true,
+            scope: 'thread',
+            topicId: TEST_IDS.TOPIC_ID,
+          }),
+        );
+      });
+
       it('should recover heterogeneous context selections from the persisted user message metadata', async () => {
         mockConstEnv.isDesktop = true;
         setupMockSelectors({

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -802,10 +802,17 @@ export class ConversationLifecycleActionImpl {
         return;
       }
 
-      // Update context with server-created topicId
+      // Update context with server-created topicId. Once the server has returned a
+      // persisted topic, the hetero stream must target the real topic bucket; keeping
+      // `isNew` would route chunks to `main_<agent>_<topic>_new`.
+      const heteroTopicId = heteroData.topicId ?? operationContext.topicId;
+      const shouldResolveNewTopicKey = !!heteroTopicId && operationContext.scope !== 'thread';
       const heteroContext = {
         ...operationContext,
-        topicId: heteroData.topicId ?? operationContext.topicId,
+        // startOperation inherits from the parent op before merging this context.
+        // Use an explicit false so the child exec op does not inherit `isNew: true`.
+        ...(shouldResolveNewTopicKey ? { isNew: false } : {}),
+        topicId: heteroTopicId,
       };
       const heteroResponseMeta = heteroData as SendMessageServerResponseMeta;
       const heteroMessageKey = messageMapKey(heteroContext);


### PR DESCRIPTION
## What changed

- Route persisted heterogeneous/Codex new-topic runs to the real topic message bucket by resolving the child execution context with `isNew: false` once a persisted topic id exists.
- Preserve `isNew` for `scope: thread` new-thread contexts.
- Add regression coverage for both the new-topic Codex path and the thread-context boundary.

## Why

Codex stream events were arriving in the renderer trace, but the UI could stay empty because `execHeterogeneousAgent` inherited `isNew: true` from the parent send operation. `internal_dispatchMessage` resolves its message bucket from the operation context, so chunks were routed to `main_<agent>_<topic>_new` while the visible conversation reads `main_<agent>_<topic>`.

## Validation

- `bun run check src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts --test`
  - 51 tests passed
- `bun run check src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts --lint`
  - 2 files lint clean

Verify report: https://app.lobehub.com/verify/d944f438-683b-4f9f-905e-5547a417617c

## Notes

A separate worktree was used for this PR so unrelated local verify/report-viewer changes in the original checkout are not included.
