### PR TITLE
🐛 fix(cli): scope connect service env to unit

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -48,6 +48,7 @@
     "picocolors": "^1.1.1",
     "semver": "^7.8.5",
     "superjson": "^2.2.6",
+    "tree-kill": "^1.2.2",
     "tsdown": "^0.21.10",
     "typescript": "^6.0.3",
     "ws": "^8.21.0"

--- a/apps/cli/src/service/connect.test.ts
+++ b/apps/cli/src/service/connect.test.ts
@@ -59,6 +59,8 @@ describe('connect service', () => {
     delete process.env.LOBEHUB_CLI_HOME;
     delete process.env.LOBEHUB_CLI_API_KEY;
     delete process.env.LOBEHUB_JWT;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
 
     getRunningDaemonPidMock.mockReturnValue(null);
     loadCredentialsMock.mockReturnValue({ accessToken: 'jwt' });
@@ -99,6 +101,9 @@ describe('connect service', () => {
     expect(fs.readFileSync(unitPath, 'utf8')).toContain(
       `"${process.execPath}" "${entryPath}" "connect" "--service-child"`,
     );
+    expect(fs.readFileSync(unitPath, 'utf8')).toContain(
+      `EnvironmentFile=${path.join(tmpDir, '.lobehub', 'connect-service.env')}`,
+    );
     expect(systemctlCalls).toContainEqual(['--user', 'daemon-reload']);
     expect(systemctlCalls).toContainEqual(['--user', 'enable', '--now', 'lobehub-connect.service']);
   });
@@ -131,18 +136,23 @@ describe('connect service', () => {
     ]);
   });
 
-  it('imports the current environment by name and clears stale service env', () => {
+  it('writes the current environment to a service-scoped env file', () => {
+    process.env.ANTHROPIC_API_KEY = 'anthropic-key';
+    process.env.AWS_SECRET_ACCESS_KEY = 'aws-secret';
     process.env.LOBEHUB_CLI_API_KEY = 'test-key';
-    delete process.env.LOBEHUB_CLI_HOME;
+    process.env.QUOTED_ENV = 'value with "quotes", \\slashes, and $dollars';
 
     installConnectService();
 
-    expect(systemctlCalls).toContainEqual(
-      expect.arrayContaining(['--user', 'unset-environment', 'LOBEHUB_CLI_HOME']),
-    );
-    expect(systemctlCalls).toContainEqual(
-      expect.arrayContaining(['--user', 'import-environment', 'LOBEHUB_CLI_API_KEY']),
-    );
+    const envFilePath = path.join(tmpDir, '.lobehub', 'connect-service.env');
+    const envFile = fs.readFileSync(envFilePath, 'utf8');
+    expect(fs.statSync(envFilePath).mode & 0o777).toBe(0o600);
+    expect(envFile).toContain('ANTHROPIC_API_KEY="anthropic-key"');
+    expect(envFile).toContain('AWS_SECRET_ACCESS_KEY="aws-secret"');
+    expect(envFile).toContain('LOBEHUB_CLI_API_KEY="test-key"');
+    expect(envFile).toContain('QUOTED_ENV="value with \\"quotes\\", \\\\slashes, and \\$dollars"');
+    expect(systemctlCalls.some((call) => call.includes('import-environment'))).toBe(false);
+    expect(systemctlCalls.some((call) => call.includes('unset-environment'))).toBe(false);
     expect(systemctlCalls).not.toContainEqual(['--user', 'import-environment']);
   });
 
@@ -153,9 +163,13 @@ describe('connect service', () => {
   it('starts an installed service after preflight checks pass', () => {
     installConnectService();
     systemctlCalls = [];
+    process.env.LOBEHUB_CLI_API_KEY = 'rotated-key';
 
     expect(startConnectService()).toBe(true);
 
+    expect(fs.readFileSync(path.join(tmpDir, '.lobehub', 'connect-service.env'), 'utf8')).toContain(
+      'LOBEHUB_CLI_API_KEY="rotated-key"',
+    );
     expect(systemctlCalls).toContainEqual(['--user', 'start', 'lobehub-connect.service']);
   });
 });

--- a/apps/cli/src/service/connect.ts
+++ b/apps/cli/src/service/connect.ts
@@ -9,16 +9,7 @@ import { getRunningDaemonPid } from '../daemon/manager';
 
 const SERVICE_NAME = 'lobehub-connect.service';
 const ENV_NAME_PATTERN = /^[A-Z_]\w*$/i;
-const SERVICE_ENV_NAMES = [
-  'AGENT_GATEWAY_URL',
-  'DEBUG',
-  'LH_GATEWAY_URL',
-  'LOBEHUB_CLI_CHANNEL',
-  'LOBEHUB_CLI_HOME',
-  CLI_API_KEY_ENV,
-  'LOBEHUB_JWT',
-  'LOBEHUB_SERVER',
-];
+const SERVICE_ENV_FILE_NAME = 'connect-service.env';
 
 export interface ConnectServiceStatus {
   active: boolean;
@@ -46,6 +37,14 @@ function getUserServiceDir(): string {
   );
 }
 
+function getCliHomeDir(): string {
+  return path.join(os.homedir(), process.env.LOBEHUB_CLI_HOME || '.lobehub');
+}
+
+function getServiceEnvFilePath(): string {
+  return path.join(getCliHomeDir(), SERVICE_ENV_FILE_NAME);
+}
+
 function getExecErrorMessage(error: unknown): string {
   const stderr =
     error && typeof error === 'object' && 'stderr' in error
@@ -61,8 +60,9 @@ function renderUnit(): string {
   const escapeSystemdEnvValue = (value: string): string =>
     value.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
   const homeDir = os.homedir();
-  const cliHomeDir = path.join(homeDir, process.env.LOBEHUB_CLI_HOME || '.lobehub');
+  const cliHomeDir = getCliHomeDir();
   const logPath = path.join(cliHomeDir, 'daemon.log');
+  const envFilePath = getServiceEnvFilePath();
   const scriptPath = fs.realpathSync(process.argv[1]!);
   const execStart = [process.execPath, scriptPath, 'connect', '--service-child']
     .map(quoteSystemdValue)
@@ -79,6 +79,7 @@ function renderUnit(): string {
     '[Service]',
     'Type=simple',
     `WorkingDirectory=${homeDir}`,
+    `EnvironmentFile=${envFilePath}`,
     `Environment=HOME=${escapeSystemdEnvValue(homeDir)}`,
     'Environment=LOBEHUB_CONNECT_SERVICE=1',
     `ExecStart=${execStart}`,
@@ -121,16 +122,27 @@ function requireLinuxSystemd() {
   }
 }
 
-function importServiceEnvironment(): void {
-  const staleServiceEnvNames = SERVICE_ENV_NAMES.filter((name) => process.env[name] === undefined);
-  if (staleServiceEnvNames.length > 0) {
-    systemctl(['unset-environment', ...staleServiceEnvNames], 'inherit');
-  }
+function writeServiceEnvironmentFile(): void {
+  const quoteEnvironmentFileValue = (value: string): string =>
+    `"${value
+      .replaceAll('\\', '\\\\')
+      .replaceAll('"', '\\"')
+      .replaceAll('`', '\\`')
+      .replaceAll('$', '\\$')}"`;
 
-  const environmentNames = Object.keys(process.env).filter((name) => ENV_NAME_PATTERN.test(name));
-  if (environmentNames.length > 0) {
-    systemctl(['import-environment', ...environmentNames], 'inherit');
-  }
+  const lines = Object.entries(process.env)
+    .filter((entry): entry is [string, string] => {
+      const [name, value] = entry;
+      return ENV_NAME_PATTERN.test(name) && value !== undefined;
+    })
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, value]) => `${name}=${quoteEnvironmentFileValue(value)}`);
+
+  const envFilePath = getServiceEnvFilePath();
+  fs.mkdirSync(path.dirname(envFilePath), { mode: 0o700, recursive: true });
+  // The captured shell environment can include provider API keys; keep it owner-only.
+  fs.writeFileSync(envFilePath, `${lines.join('\n')}\n`, { mode: 0o600 });
+  fs.chmodSync(envFilePath, 0o600);
 }
 
 function assertNoConnectDaemonRunning(): void {
@@ -159,14 +171,10 @@ export function installConnectService(): void {
   assertNoConnectDaemonRunning();
   assertConnectServiceAuthAvailable();
 
-  fs.mkdirSync(path.join(os.homedir(), process.env.LOBEHUB_CLI_HOME || '.lobehub'), {
-    mode: 0o700,
-    recursive: true,
-  });
+  writeServiceEnvironmentFile();
   fs.mkdirSync(getUserServiceDir(), { mode: 0o700, recursive: true });
   fs.writeFileSync(path.join(getUserServiceDir(), SERVICE_NAME), renderUnit(), { mode: 0o644 });
 
-  importServiceEnvironment();
   systemctl(['daemon-reload'], 'inherit');
   systemctl(['enable', '--now', SERVICE_NAME], 'inherit');
 }
@@ -184,6 +192,7 @@ export function uninstallConnectService(): boolean {
   }
 
   fs.unlinkSync(unitPath);
+  fs.rmSync(getServiceEnvFilePath(), { force: true });
   systemctl(['daemon-reload'], 'inherit');
 
   return true;
@@ -194,7 +203,7 @@ export function startConnectService(): boolean {
   requireLinuxSystemd();
   assertNoConnectDaemonRunning();
   assertConnectServiceAuthAvailable();
-  importServiceEnvironment();
+  writeServiceEnvironmentFile();
   systemctl(['start', SERVICE_NAME], 'inherit');
   return true;
 }
@@ -211,7 +220,7 @@ export function restartConnectService(): boolean {
   requireLinuxSystemd();
   assertNoConnectDaemonRunning();
   assertConnectServiceAuthAvailable();
-  importServiceEnvironment();
+  writeServiceEnvironmentFile();
   systemctl(['restart', SERVICE_NAME], 'inherit');
   return true;
 }


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #16629.

#### 🔀 Description of Change

`lh connect service install/start/restart` no longer imports the caller environment into the systemd user manager via `systemctl --user import-environment`.

Instead, the CLI captures the caller environment into a service-scoped env file:

- writes `~/.lobehub/connect-service.env`
- keeps the file owner-only with `0600`
- references it from `lobehub-connect.service` via unquoted `EnvironmentFile=/path/to/connect-service.env`
- removes the env file on service uninstall

This preserves compatibility for tools launched by the connect service that rely on arbitrary user env vars, such as provider API keys, while avoiding manager-wide env pollution for later user services.

Also declares `tree-kill` as a CLI runtime dependency because the bundled CLI can resolve it at runtime through the local shell process manager path.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Unit/lint checks:

```bash
cd apps/cli
bunx vitest run --silent='passed-only' src/service/connect.test.ts
```

```bash
bunx eslint apps/cli/src/service/connect.ts apps/cli/src/service/connect.test.ts
git diff --check
```

Build/runtime checks:

```bash
cd apps/cli
bun run build
```

Verified a production-install style runtime by copying `dist + package.json`, installing production dependencies only, and running:

```bash
node dist/index.js --version
```

Manual systemd container verification:

- installed `lobehub-connect.service`
- confirmed unit uses unquoted `EnvironmentFile=/root/.lobehub/connect-service.env`
- confirmed `systemd-analyze verify` does not reject the directive
- confirmed env file mode is `600`
- confirmed the service process environment contains env vars from `connect-service.env`
- confirmed the systemd user manager process environment does not contain those env vars

#### 📸 Screenshots / Videos

N/A. CLI/systemd behavior only.

#### 📝 Additional Information

The env file may contain provider API keys and other shell secrets, so it is intentionally written as owner-only. This does not create a hard isolation boundary against same-UID processes, but it avoids leaking the captured env into the systemd user manager’s global environment.