### PR TITLE
✨ feat: inline short verify text evidence

### DIFF
--- a/apps/cli/src/commands/verify.ts
+++ b/apps/cli/src/commands/verify.ts
@@ -39,6 +39,9 @@ function assertEnum<T extends string>(value: T | undefined, allowed: T[], flag: 
 type Verdict = 'failed' | 'passed' | 'uncertain';
 type EvidenceType = 'dom_snapshot' | 'gif' | 'screenshot' | 'text' | 'transcript' | 'video';
 
+const INLINE_TEXT_EVIDENCE_LIMIT = 5000;
+const INLINE_TEXT_EVIDENCE_TYPES = new Set<EvidenceType>(['dom_snapshot', 'text', 'transcript']);
+
 /** Map a free-form case/summary result token onto the verify verdict vocabulary. */
 function toVerdict(raw: unknown): Verdict {
   const s = String(raw ?? '').toLowerCase();
@@ -57,6 +60,20 @@ function evidenceTypeForFile(file: string): EvidenceType {
   return 'text';
 }
 
+function inlineTextEvidenceForFile(file: string, type: EvidenceType | string): string | undefined {
+  if (!INLINE_TEXT_EVIDENCE_TYPES.has(type as EvidenceType)) return undefined;
+
+  try {
+    const buffer = readFileSync(file);
+    if (buffer.includes(0)) return undefined;
+
+    const content = buffer.toString('utf8');
+    return content.length > 0 && content.length < INLINE_TEXT_EVIDENCE_LIMIT ? content : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Normalize a case's `evidence` field (string | string[] | {path}[]) to path strings. */
 function evidencePaths(evidence: unknown): string[] {
   if (!evidence) return [];
@@ -64,6 +81,40 @@ function evidencePaths(evidence: unknown): string[] {
   return arr
     .map((e) => (typeof e === 'string' ? e : (e?.path ?? e?.file)))
     .filter((p): p is string => typeof p === 'string' && p.length > 0);
+}
+
+function firstString(...values: unknown[]): string | undefined {
+  return values.find((v): v is string => typeof v === 'string' && v.length > 0);
+}
+
+function firstStringOrNumber(...values: unknown[]): string | number | undefined {
+  return values.find(
+    (v): v is string | number => (typeof v === 'string' && v.length > 0) || typeof v === 'number',
+  );
+}
+
+function objectValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/** Normalize common agent-testing PR shapes into the verify coding scope. */
+function pullRequestFromResult(result: Record<string, unknown>) {
+  const pr = objectValue(result.pullRequest) ?? objectValue(result.pr);
+  const url = firstString(
+    pr?.url,
+    pr?.htmlUrl,
+    pr?.html_url,
+    result.pullRequestUrl,
+    result.prUrl,
+    typeof result.pr === 'string' ? result.pr : undefined,
+  );
+  const number = firstStringOrNumber(pr?.number, result.pullRequestNumber, result.prNumber);
+  const title = firstString(pr?.title, result.pullRequestTitle, result.prTitle);
+  const entries = Object.entries({ number, title, url }).filter(([, v]) => v !== undefined);
+
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
 }
 
 /**
@@ -743,15 +794,19 @@ export function registerVerifyCommand(program: Command) {
         }
         const client = await getTrpcClient();
         let fileId: string | undefined;
+        let inlineContent = options.content;
         if (options.file) {
-          const uploaded = await uploadLocalFile(client, options.file);
-          fileId = uploaded.id;
+          inlineContent = inlineTextEvidenceForFile(options.file, options.type!);
+          if (inlineContent === undefined) {
+            const uploaded = await uploadLocalFile(client, options.file);
+            fileId = uploaded.id;
+          }
         }
         const evidence = hasEvidence
           ? [
               {
                 capturedBy: options.by as any,
-                content: options.content,
+                content: inlineContent,
                 description: options.desc,
                 fileId,
                 type: options.type as any,
@@ -807,14 +862,18 @@ export function registerVerifyCommand(program: Command) {
         }
         const client = await getTrpcClient();
         let fileId: string | undefined;
+        let inlineContent = options.content;
         if (options.file) {
-          const uploaded = await uploadLocalFile(client, options.file);
-          fileId = uploaded.id;
+          inlineContent = inlineTextEvidenceForFile(options.file, options.type);
+          if (inlineContent === undefined) {
+            const uploaded = await uploadLocalFile(client, options.file);
+            fileId = uploaded.id;
+          }
         }
         const ev = await client.verify.uploadEvidence.mutate({
           capturedBy: options.by as any,
           checkResultId: options.check,
-          content: options.content,
+          content: inlineContent,
           description: options.desc,
           fileId,
           type: options.type as any,
@@ -993,11 +1052,13 @@ export function registerVerifyCommand(program: Command) {
         const surfaces = Array.isArray(result.surfaces)
           ? result.surfaces.filter((s: unknown) => typeof s === 'string')
           : undefined;
+        const pullRequest = pullRequestFromResult(result);
         const contextEntries = Object.entries({
           branch: typeof result.branch === 'string' ? result.branch : undefined,
           commit: typeof result.commit === 'string' ? result.commit : undefined,
           entry: typeof result.entry === 'string' ? result.entry : undefined,
           focus: typeof result.focus === 'string' ? result.focus : options.goal,
+          pullRequest,
           surfaces: surfaces && surfaces.length > 0 ? surfaces : undefined,
           testedAt: typeof result.createdAt === 'string' ? result.createdAt : undefined,
         }).filter(([, v]) => v !== undefined);
@@ -1059,7 +1120,8 @@ export function registerVerifyCommand(program: Command) {
         //    rather than duplicating it. Track the ids we touch to prune dropped
         //    cases afterwards, keeping a re-run a full replace.
         const seenCheckItemIds = new Set<string>();
-        let uploaded = 0;
+        let evidenceCount = 0;
+        let inlined = 0;
         for (const [index, c] of cases.entries()) {
           const checkItemId = String(c.id ?? c.checkItemId ?? `case-${index + 1}`);
           seenCheckItemIds.add(checkItemId);
@@ -1101,17 +1163,21 @@ export function registerVerifyCommand(program: Command) {
               continue;
             }
             try {
-              const file = await uploadLocalFile(client, abs);
+              const type = evidenceTypeForFile(abs);
+              const content = inlineTextEvidenceForFile(abs, type);
+              const file = content === undefined ? await uploadLocalFile(client, abs) : undefined;
               await client.verify.uploadEvidence.mutate({
                 capturedBy: 'cli',
                 checkResultId: checkResult.id,
                 // The filename, not the case title — the title already heads the
                 // check card, so reusing it here just triples the same text.
+                content,
                 description: path.basename(abs),
-                fileId: file.id,
-                type: evidenceTypeForFile(abs),
+                fileId: file?.id,
+                type,
               });
-              uploaded += 1;
+              evidenceCount += 1;
+              if (content !== undefined) inlined += 1;
             } catch (e) {
               // A stub/unreachable storage bucket (common in local dev) fails the
               // file PUT — don't abort the whole ingest over one artifact; the
@@ -1169,7 +1235,14 @@ export function registerVerifyCommand(program: Command) {
 
         if (options.json !== undefined) {
           outputJson(
-            { cases: cases.length, evidence: uploaded, pruned, reused, verifyRunId: runId },
+            {
+              cases: cases.length,
+              evidence: evidenceCount,
+              inlined,
+              pruned,
+              reused,
+              verifyRunId: runId,
+            },
             typeof options.json === 'string' ? options.json : undefined,
           );
           return;
@@ -1177,10 +1250,13 @@ export function registerVerifyCommand(program: Command) {
 
         const verb = reused ? 'Updated' : 'Ingested';
         console.log(
-          `${pc.green('✓')} ${verb} ${pc.bold(String(cases.length))} case(s), ${pc.bold(String(uploaded))} evidence file(s)` +
+          `${pc.green('✓')} ${verb} ${pc.bold(String(cases.length))} case(s), ${pc.bold(String(evidenceCount))} evidence artifact(s)` +
+            `${inlined > 0 ? `, ${pc.bold(String(inlined))} inline` : ''}` +
             `${pruned > 0 ? `, pruned ${pc.bold(String(pruned))} stale case(s)` : ''}`,
         );
-        console.log(`${pc.bold('verifyRunId')}: ${runId}${reused ? pc.dim(' (updated in place)') : ''}`);
+        console.log(
+          `${pc.bold('verifyRunId')}: ${runId}${reused ? pc.dim(' (updated in place)') : ''}`,
+        );
         if (options.open) {
           console.log(`${pc.bold('open')}: /verify/${runId}`);
         }

--- a/apps/cli/src/commands/verify.ts
+++ b/apps/cli/src/commands/verify.ts
@@ -99,16 +99,29 @@ function objectValue(value: unknown): Record<string, unknown> | undefined {
     : undefined;
 }
 
+function safeWebUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Normalize common agent-testing PR shapes into the verify coding scope. */
 function pullRequestFromResult(result: Record<string, unknown>) {
   const pr = objectValue(result.pullRequest) ?? objectValue(result.pr);
-  const url = firstString(
-    pr?.url,
-    pr?.htmlUrl,
-    pr?.html_url,
-    result.pullRequestUrl,
-    result.prUrl,
-    typeof result.pr === 'string' ? result.pr : undefined,
+  const url = safeWebUrl(
+    firstString(
+      pr?.url,
+      pr?.htmlUrl,
+      pr?.html_url,
+      result.pullRequestUrl,
+      result.prUrl,
+      typeof result.pr === 'string' ? result.pr : undefined,
+    ),
   );
   const number = firstStringOrNumber(pr?.number, result.pullRequestNumber, result.prNumber);
   const title = firstString(pr?.title, result.pullRequestTitle, result.prTitle);

--- a/apps/server/src/routers/lambda/__tests__/verify.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/verify.test.ts
@@ -178,12 +178,31 @@ describe('verifyRouter', () => {
       modelMocks.updateRun.mockResolvedValueOnce(updatedRun);
 
       await createCaller().updateRun({
-        value: { context: { branch: 'feat/x', commit: 'abc123' }, goal: 'ship x' },
+        value: {
+          context: {
+            branch: 'feat/x',
+            commit: 'abc123',
+            pullRequest: {
+              number: 42,
+              title: 'Ship x',
+              url: 'https://github.com/lobehub/lobehub/pull/42',
+            },
+          },
+          goal: 'ship x',
+        },
         verifyRunId: 'run-1',
       });
 
       expect(modelMocks.updateRun).toHaveBeenCalledWith('run-1', {
-        context: { branch: 'feat/x', commit: 'abc123' },
+        context: {
+          branch: 'feat/x',
+          commit: 'abc123',
+          pullRequest: {
+            number: 42,
+            title: 'Ship x',
+            url: 'https://github.com/lobehub/lobehub/pull/42',
+          },
+        },
         goal: 'ship x',
       });
     });

--- a/apps/server/src/routers/lambda/__tests__/verify.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/verify.test.ts
@@ -206,6 +206,26 @@ describe('verifyRouter', () => {
         goal: 'ship x',
       });
     });
+
+    it('rejects non-web pull request URLs before storing report context', async () => {
+      await expect(
+        createCaller().updateRun({
+          value: {
+            context: {
+              pullRequest: {
+                number: 42,
+                title: 'Unsafe PR',
+                url: 'javascript:alert(1)',
+              },
+            },
+          },
+          verifyRunId: 'run-1',
+        }),
+      ).rejects.toThrow();
+
+      expect(modelMocks.findRunById).not.toHaveBeenCalled();
+      expect(modelMocks.updateRun).not.toHaveBeenCalled();
+    });
   });
 
   describe('deleteResult', () => {

--- a/apps/server/src/routers/lambda/verify.ts
+++ b/apps/server/src/routers/lambda/verify.ts
@@ -98,11 +98,18 @@ const verifyRunIdInputSchema = z.object({ verifyRunId: z.string() });
 
 // The scenario's context (coding scope), rendered as the report's scope header.
 // Shared by createRun and updateRun so a re-ingest can refresh the scope in place.
+const pullRequestContextSchema = z.object({
+  number: z.union([z.number(), z.string()]).optional(),
+  title: z.string().optional(),
+  url: z.string().optional(),
+});
+
 const runContextSchema = z.object({
   branch: z.string().optional(),
   commit: z.string().optional(),
   entry: z.string().optional(),
   focus: z.string().optional(),
+  pullRequest: pullRequestContextSchema.optional(),
   surfaces: z.array(z.string()).optional(),
   testedAt: z.string().optional(),
 });

--- a/apps/server/src/routers/lambda/verify.ts
+++ b/apps/server/src/routers/lambda/verify.ts
@@ -98,10 +98,18 @@ const verifyRunIdInputSchema = z.object({ verifyRunId: z.string() });
 
 // The scenario's context (coding scope), rendered as the report's scope header.
 // Shared by createRun and updateRun so a re-ingest can refresh the scope in place.
+const webUrlSchema = z
+  .string()
+  .url()
+  .refine((value) => {
+    const protocol = new URL(value).protocol;
+    return protocol === 'http:' || protocol === 'https:';
+  });
+
 const pullRequestContextSchema = z.object({
   number: z.union([z.number(), z.string()]).optional(),
   title: z.string().optional(),
-  url: z.string().optional(),
+  url: webUrlSchema.optional(),
 });
 
 const runContextSchema = z.object({

--- a/locales/en-US/verify.json
+++ b/locales/en-US/verify.json
@@ -70,6 +70,8 @@
   "report.scope.date": "Date",
   "report.scope.entry": "Entry",
   "report.scope.focus": "Focus",
+  "report.scope.pullRequest": "Pull request",
+  "report.scope.pullRequestNumber": "PR #{{number}}",
   "report.scope.surface": "Surface",
   "report.sections.checks": "Checks",
   "report.sections.details": "Details",

--- a/locales/zh-CN/verify.json
+++ b/locales/zh-CN/verify.json
@@ -70,6 +70,8 @@
   "report.scope.date": "日期",
   "report.scope.entry": "入口",
   "report.scope.focus": "重点",
+  "report.scope.pullRequest": "关联 PR",
+  "report.scope.pullRequestNumber": "PR #{{number}}",
   "report.scope.surface": "范围",
   "report.sections.checks": "检查项",
   "report.sections.details": "详情",

--- a/packages/locales/src/default/verify.ts
+++ b/packages/locales/src/default/verify.ts
@@ -81,6 +81,8 @@ export default {
   'report.scope.date': 'Date',
   'report.scope.entry': 'Entry',
   'report.scope.focus': 'Focus',
+  'report.scope.pullRequest': 'Pull request',
+  'report.scope.pullRequestNumber': 'PR #{{number}}',
   'report.scope.surface': 'Surface',
   'report.sections.checks': 'Checks',
   'report.sections.details': 'Details',

--- a/packages/types/src/verify.ts
+++ b/packages/types/src/verify.ts
@@ -85,6 +85,15 @@ export type VerifyRunScenario = (typeof verifyRunScenarios)[number];
  * Rendered as the report's scope header so the verify page reads as the final
  * report.
  */
+export interface VerifyCodingPullRequest {
+  /** Pull request number, e.g. 123. */
+  number?: number | string;
+  /** Pull request title. */
+  title?: string;
+  /** Web URL for opening the PR. */
+  url?: string;
+}
+
 export interface VerifyCodingScope {
   /** Git branch the report was produced against. */
   branch?: string;
@@ -94,6 +103,8 @@ export interface VerifyCodingScope {
   entry?: string;
   /** The focus / key risk of this round (free text). */
   focus?: string;
+  /** Associated pull request, when the verification run has one. */
+  pullRequest?: VerifyCodingPullRequest;
   /** Test surfaces exercised, e.g. ["cli", "web"]. */
   surfaces?: string[];
   /** When the report was authored (ISO 8601) — distinct from the row's createdAt (ingest time). */

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -1009,7 +1009,7 @@ const CodingScopeCard = memo<{ context: VerifyCodingScope | null | undefined }>(
                 href={pullRequestUrl}
                 rel="noreferrer"
                 target="_blank"
-                title={pullRequest.title ?? pullRequestUrl}
+                title={pullRequest?.title ?? pullRequestUrl}
               >
                 {pullRequestContent}
               </a>

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -137,31 +137,31 @@ const styles = createStaticStyles(({ css }) => ({
   codingScope: css`
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
 
-    margin-block-start: 4px;
-    padding-block: 12px;
-    padding-inline: 14px;
-    border: 1px solid ${cssVar.colorBorderSecondary};
-    border-radius: ${cssVar.borderRadius};
-
-    background: ${cssVar.colorFillQuaternary};
+    max-width: 100%;
+    margin-block-start: 8px;
   `,
   codingScopeMain: css`
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: 8px;
     align-items: center;
 
     min-width: 0;
+
+    @media (width <= 720px) {
+      flex-wrap: wrap;
+    }
   `,
   branchChip: css`
     display: inline-flex;
+    flex: 1 1 220px;
     gap: 8px;
     align-items: center;
 
     min-width: 0;
-    max-width: 100%;
+    max-width: 320px;
     height: 32px;
     padding-inline: 10px;
     border: 1px solid ${cssVar.colorBorderSecondary};
@@ -183,82 +183,20 @@ const styles = createStaticStyles(({ css }) => ({
       white-space: nowrap;
     }
   `,
-  prChip: css`
-    cursor: default;
-
+  commitChip: css`
     display: inline-flex;
+    flex: 0 0 auto;
     gap: 7px;
     align-items: center;
 
-    min-width: 0;
-    max-width: 100%;
     height: 32px;
     padding-inline: 10px;
-    border: 1px solid color-mix(in srgb, ${cssVar.colorLink} 32%, ${cssVar.colorBorder});
+    border: 1px solid ${cssVar.colorBorderSecondary};
     border-radius: ${cssVar.borderRadiusSM};
 
-    font-size: 13px;
-    color: ${cssVar.colorLink};
-    text-decoration: none;
-
-    background: color-mix(in srgb, ${cssVar.colorLink} 8%, ${cssVar.colorBgContainer});
-
-    &[data-link='true'] {
-      cursor: pointer;
-    }
-
-    &[data-link='true']:hover {
-      border-color: ${cssVar.colorLink};
-      color: ${cssVar.colorLinkHover};
-    }
-  `,
-  prTitle: css`
-    overflow: hidden;
-
-    min-width: 0;
-
     color: ${cssVar.colorTextSecondary};
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  `,
-  scopeGrid: css`
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-    gap: 9px 14px;
-  `,
-  scopeGridItem: css`
-    display: grid;
-    grid-template-columns: 16px minmax(0, 1fr);
-    gap: 7px;
-    align-items: start;
 
-    min-width: 0;
-
-    &[data-wide='true'] {
-      grid-column: 1 / -1;
-    }
-  `,
-  scopeGridIcon: css`
-    display: flex;
-    padding-block-start: 2px;
-    color: ${cssVar.colorTextQuaternary};
-  `,
-  scopeGridBody: css`
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    min-width: 0;
-  `,
-  scopeGridLabel: css`
-    font-size: 11px;
-    line-height: 1.3;
-    color: ${cssVar.colorTextTertiary};
-  `,
-  scopeGridValue: css`
-    font-size: 13px;
-    line-height: 1.45;
-    color: ${cssVar.colorTextSecondary};
-    overflow-wrap: anywhere;
+    background: ${cssVar.colorBgContainer};
 
     code {
       font-family: ${cssVar.fontFamilyCode};
@@ -266,14 +204,106 @@ const styles = createStaticStyles(({ css }) => ({
       color: ${cssVar.colorText};
     }
   `,
+  prChip: css`
+    cursor: default;
+
+    display: inline-flex;
+    flex: 1 1 280px;
+    gap: 7px;
+    align-items: center;
+
+    min-width: 0;
+    max-width: 100%;
+    height: 32px;
+    padding-inline: 10px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusSM};
+
+    font-size: 13px;
+    color: ${cssVar.colorText};
+    text-decoration: none;
+
+    background: ${cssVar.colorBgContainer};
+
+    &[data-link='true'] {
+      cursor: pointer;
+    }
+
+    &[data-link='true']:hover {
+      border-color: ${cssVar.colorLink};
+      color: ${cssVar.colorText};
+    }
+
+    > svg:first-child {
+      flex: 0 0 auto;
+      color: ${cssVar.colorLink};
+    }
+  `,
+  prNumber: css`
+    flex: 0 0 auto;
+    color: ${cssVar.colorLink};
+  `,
+  prTitle: css`
+    overflow: hidden;
+    flex: 1 1 auto;
+
+    min-width: 0;
+
+    color: ${cssVar.colorTextSecondary};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  scopeMetaRow: css`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 14px;
+    align-items: center;
+
+    min-width: 0;
+  `,
+  scopeMetaItem: css`
+    display: inline-flex;
+    gap: 6px;
+    align-items: center;
+
+    min-width: 0;
+    max-width: 100%;
+
+    font-size: 12px;
+    line-height: 1.45;
+    color: ${cssVar.colorTextTertiary};
+
+    code {
+      overflow: hidden;
+
+      min-width: 0;
+
+      font-family: ${cssVar.fontFamilyCode};
+      font-size: 12px;
+      color: ${cssVar.colorTextSecondary};
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  `,
+  scopeFocus: css`
+    display: inline-flex;
+    gap: 6px;
+    align-items: flex-start;
+
+    max-width: 72ch;
+
+    font-size: 13px;
+    line-height: 1.45;
+    color: ${cssVar.colorTextSecondary};
+  `,
   surfaceList: css`
     display: flex;
     flex-wrap: wrap;
-    gap: 5px;
+    gap: 4px;
   `,
   surfaceChip: css`
     padding-block: 1px;
-    padding-inline: 7px;
+    padding-inline: 6px;
     border-radius: ${cssVar.borderRadiusSM};
 
     font-size: 12px;
@@ -938,14 +968,6 @@ const pullRequestLabel = (
   });
 };
 
-interface CodingScopeGridItem {
-  icon: typeof FileText;
-  key: string;
-  label: string;
-  value: ReactNode;
-  wide?: boolean;
-}
-
 const CodingScopeCard = memo<{ context: VerifyCodingScope | null | undefined }>(({ context }) => {
   const { t } = useTranslation('verify');
   if (!context) return null;
@@ -966,78 +988,21 @@ const CodingScopeCard = memo<{ context: VerifyCodingScope | null | undefined }>(
 
   if (!hasScope) return null;
 
-  const candidateItems: (CodingScopeGridItem | null)[] = [
-    commit
-      ? {
-          icon: GitCommit,
-          key: 'commit',
-          label: t('report.scope.commit'),
-          value: <code>{commit}</code>,
-        }
-      : null,
-    surfaces && surfaces.length > 0
-      ? {
-          icon: Layers,
-          key: 'surfaces',
-          label: t('report.scope.surface'),
-          value: (
-            <span className={styles.surfaceList}>
-              {surfaces.map((surface) => (
-                <span className={styles.surfaceChip} key={surface}>
-                  {surface}
-                </span>
-              ))}
-            </span>
-          ),
-        }
-      : null,
-    entry
-      ? {
-          icon: Terminal,
-          key: 'entry',
-          label: t('report.scope.entry'),
-          value: <code>{entry}</code>,
-        }
-      : null,
-    date
-      ? {
-          icon: CalendarClock,
-          key: 'date',
-          label: t('report.scope.date'),
-          value: date,
-        }
-      : null,
-    focus
-      ? {
-          icon: Target,
-          key: 'focus',
-          label: t('report.scope.focus'),
-          value: focus,
-          wide: true,
-        }
-      : null,
-  ];
-  const items = candidateItems.filter((item): item is CodingScopeGridItem => Boolean(item));
   const pullRequestContent =
     hasPullRequest && pullRequest ? (
       <>
         <Icon icon={GitPullRequest} size={15} />
-        <span>{pullRequestLabel(pullRequest, t)}</span>
+        <span className={styles.prNumber}>{pullRequestLabel(pullRequest, t)}</span>
         {pullRequest.title && <span className={styles.prTitle}>{pullRequest.title}</span>}
         {pullRequest.url && <Icon icon={ExternalLink} size={13} />}
       </>
     ) : null;
+  const shortCommit = commit && commit.length > 12 ? commit.slice(0, 10) : commit;
 
   return (
     <div className={styles.codingScope}>
-      {(branch || hasPullRequest) && (
+      {(hasPullRequest || branch || commit) && (
         <div className={styles.codingScopeMain}>
-          {branch && (
-            <span className={styles.branchChip} title={branch}>
-              <Icon icon={GitBranch} size={15} />
-              <code>{branch}</code>
-            </span>
-          )}
           {pullRequestContent &&
             (pullRequest?.url ? (
               <a
@@ -1055,22 +1020,54 @@ const CodingScopeCard = memo<{ context: VerifyCodingScope | null | undefined }>(
                 {pullRequestContent}
               </span>
             ))}
+          {branch && (
+            <span className={styles.branchChip} title={branch}>
+              <Icon icon={GitBranch} size={15} />
+              <code>{branch}</code>
+            </span>
+          )}
+          {commit && (
+            <span className={styles.commitChip} title={commit}>
+              <Icon icon={GitCommit} size={14} />
+              <code>{shortCommit}</code>
+            </span>
+          )}
         </div>
       )}
 
-      {items.length > 0 && (
-        <div className={styles.scopeGrid}>
-          {items.map((item) => (
-            <div className={styles.scopeGridItem} data-wide={item.wide} key={item.key}>
-              <span className={styles.scopeGridIcon}>
-                <Icon icon={item.icon} size={14} />
+      {(surfaces?.length || entry || date) && (
+        <div className={styles.scopeMetaRow}>
+          {surfaces && surfaces.length > 0 && (
+            <span className={styles.scopeMetaItem}>
+              <Icon icon={Layers} size={13} />
+              <span className={styles.surfaceList}>
+                {surfaces.map((surface) => (
+                  <span className={styles.surfaceChip} key={surface}>
+                    {surface}
+                  </span>
+                ))}
               </span>
-              <span className={styles.scopeGridBody}>
-                <span className={styles.scopeGridLabel}>{item.label}</span>
-                <span className={styles.scopeGridValue}>{item.value}</span>
-              </span>
-            </div>
-          ))}
+            </span>
+          )}
+          {entry && (
+            <span className={styles.scopeMetaItem} title={entry}>
+              <Icon icon={Terminal} size={13} />
+              <code>{entry}</code>
+            </span>
+          )}
+          {date && (
+            <span className={styles.scopeMetaItem}>
+              <Icon icon={CalendarClock} size={13} />
+              <span>{date}</span>
+            </span>
+          )}
+        </div>
+      )}
+
+      {focus && (
+        <div className={styles.scopeFocus}>
+          <Icon icon={Target} size={13} />
+          <span>{focus}</span>
         </div>
       )}
     </div>

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -942,6 +942,17 @@ const formatScopeDate = (value: string | undefined): string | undefined => {
   return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
 };
 
+const safeWebUrl = (value: string | null | undefined): string | undefined => {
+  if (!value) return undefined;
+
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
 const pullRequestLabel = (
   pullRequest: NonNullable<VerifyCodingScope['pullRequest']>,
   t: TFunction<'verify'>,
@@ -974,13 +985,14 @@ const CodingScopeCard = memo<{ context: VerifyCodingScope | null | undefined }>(
 
   if (!hasScope) return null;
 
+  const pullRequestUrl = safeWebUrl(pullRequest?.url);
   const pullRequestContent =
     hasPullRequest && pullRequest ? (
       <>
         <Icon icon={GitPullRequest} size={15} />
         <span className={styles.prNumber}>{pullRequestLabel(pullRequest, t)}</span>
         {pullRequest.title && <span className={styles.prTitle}>{pullRequest.title}</span>}
-        {pullRequest.url && <Icon icon={ExternalLink} size={13} />}
+        {pullRequestUrl && <Icon icon={ExternalLink} size={13} />}
       </>
     ) : null;
   const shortCommit = commit && commit.length > 12 ? commit.slice(0, 10) : commit;
@@ -990,14 +1002,14 @@ const CodingScopeCard = memo<{ context: VerifyCodingScope | null | undefined }>(
       {(hasPullRequest || branch || commit || date) && (
         <div className={styles.codingScopeMain}>
           {pullRequestContent &&
-            (pullRequest?.url ? (
+            (pullRequestUrl ? (
               <a
                 className={styles.prChip}
                 data-link={true}
-                href={pullRequest.url}
+                href={pullRequestUrl}
                 rel="noreferrer"
                 target="_blank"
-                title={pullRequest.title ?? pullRequest.url}
+                title={pullRequest.title ?? pullRequestUrl}
               >
                 {pullRequestContent}
               </a>

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { VerifyEvidenceType, VerifyRunContext } from '@lobechat/types';
+import type { VerifyCodingScope, VerifyEvidenceType } from '@lobechat/types';
 import {
   Block,
   Center,
@@ -17,13 +17,21 @@ import { createStaticStyles, cssVar } from 'antd-style';
 import type { TFunction } from 'i18next';
 import {
   AlertTriangle,
+  CalendarClock,
   Check,
   ChevronRight,
   CircleHelp,
   Clock3,
+  ExternalLink,
   FileText,
+  GitBranch,
+  GitCommit,
+  GitPullRequest,
   Image as ImageIcon,
+  Layers,
   RefreshCw,
+  Target,
+  Terminal,
   Video,
   X,
 } from 'lucide-react';
@@ -125,6 +133,153 @@ const styles = createStaticStyles(({ css }) => ({
     color: ${cssVar.colorInfoText};
 
     background: ${cssVar.colorInfoBg};
+  `,
+  codingScope: css`
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+
+    margin-block-start: 4px;
+    padding-block: 12px;
+    padding-inline: 14px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadius};
+
+    background: ${cssVar.colorFillQuaternary};
+  `,
+  codingScopeMain: css`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+
+    min-width: 0;
+  `,
+  branchChip: css`
+    display: inline-flex;
+    gap: 8px;
+    align-items: center;
+
+    min-width: 0;
+    max-width: 100%;
+    height: 32px;
+    padding-inline: 10px;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadiusSM};
+
+    color: ${cssVar.colorTextSecondary};
+
+    background: ${cssVar.colorBgContainer};
+
+    code {
+      overflow: hidden;
+
+      min-width: 0;
+
+      font-family: ${cssVar.fontFamilyCode};
+      font-size: 13px;
+      color: ${cssVar.colorText};
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  `,
+  prChip: css`
+    cursor: default;
+
+    display: inline-flex;
+    gap: 7px;
+    align-items: center;
+
+    min-width: 0;
+    max-width: 100%;
+    height: 32px;
+    padding-inline: 10px;
+    border: 1px solid color-mix(in srgb, ${cssVar.colorLink} 32%, ${cssVar.colorBorder});
+    border-radius: ${cssVar.borderRadiusSM};
+
+    font-size: 13px;
+    color: ${cssVar.colorLink};
+    text-decoration: none;
+
+    background: color-mix(in srgb, ${cssVar.colorLink} 8%, ${cssVar.colorBgContainer});
+
+    &[data-link='true'] {
+      cursor: pointer;
+    }
+
+    &[data-link='true']:hover {
+      border-color: ${cssVar.colorLink};
+      color: ${cssVar.colorLinkHover};
+    }
+  `,
+  prTitle: css`
+    overflow: hidden;
+
+    min-width: 0;
+
+    color: ${cssVar.colorTextSecondary};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  scopeGrid: css`
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 9px 14px;
+  `,
+  scopeGridItem: css`
+    display: grid;
+    grid-template-columns: 16px minmax(0, 1fr);
+    gap: 7px;
+    align-items: start;
+
+    min-width: 0;
+
+    &[data-wide='true'] {
+      grid-column: 1 / -1;
+    }
+  `,
+  scopeGridIcon: css`
+    display: flex;
+    padding-block-start: 2px;
+    color: ${cssVar.colorTextQuaternary};
+  `,
+  scopeGridBody: css`
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  `,
+  scopeGridLabel: css`
+    font-size: 11px;
+    line-height: 1.3;
+    color: ${cssVar.colorTextTertiary};
+  `,
+  scopeGridValue: css`
+    font-size: 13px;
+    line-height: 1.45;
+    color: ${cssVar.colorTextSecondary};
+    overflow-wrap: anywhere;
+
+    code {
+      font-family: ${cssVar.fontFamilyCode};
+      font-size: 12px;
+      color: ${cssVar.colorText};
+    }
+  `,
+  surfaceList: css`
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+  `,
+  surfaceChip: css`
+    padding-block: 1px;
+    padding-inline: 7px;
+    border-radius: ${cssVar.borderRadiusSM};
+
+    font-size: 12px;
+    color: ${cssVar.colorTextSecondary};
+
+    background: ${cssVar.colorFillTertiary};
   `,
 
   /* sticky filter chips */
@@ -467,9 +622,13 @@ const VERDICT_META: Record<
 };
 
 const imageEvidenceTypes = new Set(['gif', 'screenshot']);
-/** Media that renders/plays inline in the check body (image + video), no click-to-open. */
-const isInlineEvidence = (evidence: VerifyEvidenceWithUrl) =>
+/** Visual media that renders/plays inline in the check body, no click-to-open. */
+const isInlineVisualEvidence = (evidence: VerifyEvidenceWithUrl) =>
   Boolean(evidence.fileUrl && (imageEvidenceTypes.has(evidence.type) || evidence.type === 'video'));
+
+/** Evidence with a directly renderable payload in the check body, no click-to-open. */
+const isInlineEvidence = (evidence: VerifyEvidenceWithUrl) =>
+  Boolean(evidence.content) || isInlineVisualEvidence(evidence);
 
 /** Coarse attachment bucket for the type marker: image / video / everything else. */
 type EvidenceCategory = 'file' | 'image' | 'video';
@@ -554,7 +713,7 @@ const EvidenceItem = memo<{ evidence: VerifyEvidenceWithUrl; index: number }>(
     const description = e.description && e.description !== label ? e.description : null;
     // Inline media (image/gif/video) speaks for itself — the raw filename header
     // is visual noise, so only keep a meaningful caption (description) for it.
-    const isMedia = isInlineEvidence(e);
+    const isMedia = isInlineVisualEvidence(e);
 
     return (
       <Flexbox gap={6}>
@@ -761,27 +920,164 @@ const ReportPageState = memo<{
   </Center>
 ));
 
-/** Build the meta row (branch / commit / surface / verified) from the run scope. */
-const scopeToMeta = (
-  context: VerifyRunContext | null | undefined,
-  scenario: string | null | undefined,
-  t: TFunction<'verify'>,
-): { label: string; value: string }[] => {
-  if (scenario !== 'coding' || !context) return [];
-  const { branch, commit, surfaces, entry, focus, testedAt } = context;
-  const surface = surfaces && surfaces.length > 0 ? surfaces.join(' / ') : undefined;
-  const date = testedAt ? new Date(testedAt).toLocaleString() : undefined;
-  return (
-    [
-      { label: t('report.scope.focus'), value: focus },
-      { label: t('report.scope.branch'), value: branch },
-      { label: t('report.scope.surface'), value: surface },
-      { label: t('report.scope.entry'), value: entry },
-      { label: t('report.scope.commit'), value: commit },
-      { label: t('report.scope.date'), value: date },
-    ] as { label: string; value?: string | null }[]
-  ).filter((m): m is { label: string; value: string } => Boolean(m.value));
+const formatScopeDate = (value: string | undefined): string | undefined => {
+  if (!value) return undefined;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
 };
+
+const pullRequestLabel = (
+  pullRequest: NonNullable<VerifyCodingScope['pullRequest']>,
+  t: TFunction<'verify'>,
+) => {
+  if (pullRequest.number === undefined || pullRequest.number === null)
+    return t('report.scope.pullRequest');
+
+  return t('report.scope.pullRequestNumber', {
+    number: String(pullRequest.number).replace(/^#/, ''),
+  });
+};
+
+interface CodingScopeGridItem {
+  icon: typeof FileText;
+  key: string;
+  label: string;
+  value: ReactNode;
+  wide?: boolean;
+}
+
+const CodingScopeCard = memo<{ context: VerifyCodingScope | null | undefined }>(({ context }) => {
+  const { t } = useTranslation('verify');
+  if (!context) return null;
+
+  const { branch, commit, entry, focus, pullRequest, surfaces, testedAt } = context;
+  const hasPullRequest = Boolean(
+    pullRequest && (pullRequest.number !== undefined || pullRequest.title || pullRequest.url),
+  );
+  const date = formatScopeDate(testedAt);
+  const hasScope =
+    Boolean(branch) ||
+    Boolean(commit) ||
+    Boolean(entry) ||
+    Boolean(focus) ||
+    hasPullRequest ||
+    Boolean(surfaces?.length) ||
+    Boolean(date);
+
+  if (!hasScope) return null;
+
+  const candidateItems: (CodingScopeGridItem | null)[] = [
+    commit
+      ? {
+          icon: GitCommit,
+          key: 'commit',
+          label: t('report.scope.commit'),
+          value: <code>{commit}</code>,
+        }
+      : null,
+    surfaces && surfaces.length > 0
+      ? {
+          icon: Layers,
+          key: 'surfaces',
+          label: t('report.scope.surface'),
+          value: (
+            <span className={styles.surfaceList}>
+              {surfaces.map((surface) => (
+                <span className={styles.surfaceChip} key={surface}>
+                  {surface}
+                </span>
+              ))}
+            </span>
+          ),
+        }
+      : null,
+    entry
+      ? {
+          icon: Terminal,
+          key: 'entry',
+          label: t('report.scope.entry'),
+          value: <code>{entry}</code>,
+        }
+      : null,
+    date
+      ? {
+          icon: CalendarClock,
+          key: 'date',
+          label: t('report.scope.date'),
+          value: date,
+        }
+      : null,
+    focus
+      ? {
+          icon: Target,
+          key: 'focus',
+          label: t('report.scope.focus'),
+          value: focus,
+          wide: true,
+        }
+      : null,
+  ];
+  const items = candidateItems.filter((item): item is CodingScopeGridItem => Boolean(item));
+  const pullRequestContent =
+    hasPullRequest && pullRequest ? (
+      <>
+        <Icon icon={GitPullRequest} size={15} />
+        <span>{pullRequestLabel(pullRequest, t)}</span>
+        {pullRequest.title && <span className={styles.prTitle}>{pullRequest.title}</span>}
+        {pullRequest.url && <Icon icon={ExternalLink} size={13} />}
+      </>
+    ) : null;
+
+  return (
+    <div className={styles.codingScope}>
+      {(branch || hasPullRequest) && (
+        <div className={styles.codingScopeMain}>
+          {branch && (
+            <span className={styles.branchChip} title={branch}>
+              <Icon icon={GitBranch} size={15} />
+              <code>{branch}</code>
+            </span>
+          )}
+          {pullRequestContent &&
+            (pullRequest?.url ? (
+              <a
+                className={styles.prChip}
+                data-link={true}
+                href={pullRequest.url}
+                rel="noreferrer"
+                target="_blank"
+                title={pullRequest.title ?? pullRequest.url}
+              >
+                {pullRequestContent}
+              </a>
+            ) : (
+              <span className={styles.prChip} title={pullRequest?.title}>
+                {pullRequestContent}
+              </span>
+            ))}
+        </div>
+      )}
+
+      {items.length > 0 && (
+        <div className={styles.scopeGrid}>
+          {items.map((item) => (
+            <div className={styles.scopeGridItem} data-wide={item.wide} key={item.key}>
+              <span className={styles.scopeGridIcon}>
+                <Icon icon={item.icon} size={14} />
+              </span>
+              <span className={styles.scopeGridBody}>
+                <span className={styles.scopeGridLabel}>{item.label}</span>
+                <span className={styles.scopeGridValue}>{item.value}</span>
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+});
+
+CodingScopeCard.displayName = 'CodingScopeCard';
 
 /**
  * The report detail pane. Renders the verdict hero, a sticky verdict-filter bar,
@@ -863,7 +1159,7 @@ const ReportViewer = memo(() => {
   const uncertain = report?.uncertainChecks ?? counts.uncertain;
   const verdict = (report?.verdict as Verdict | null) ?? null;
   const visible = filter === 'all' ? ordered : ordered.filter((r) => checkVerdict(r) === filter);
-  const meta = scopeToMeta(run.context, run.scenario, t);
+  const isCodingReport = run.scenario === 'coding';
 
   const chips: { count: number; dot?: string; key: Filter; label: string }[] = [
     { count: total, key: 'all', label: t('report.filter.all') },
@@ -896,20 +1192,10 @@ const ReportViewer = memo(() => {
             </Text>
           </div>
 
-          {run.scenario !== 'coding' && run.goal && (
-            <Text className={styles.summary}>{run.goal}</Text>
-          )}
+          {!isCodingReport && run.goal && <Text className={styles.summary}>{run.goal}</Text>}
           {report?.summary && <Text className={styles.summary}>{report.summary}</Text>}
 
-          {meta.length > 0 && (
-            <div className={styles.meta}>
-              {meta.map((m) => (
-                <span className={styles.metaItem} key={m.label}>
-                  {m.label} <code>{m.value}</code>
-                </span>
-              ))}
-            </div>
-          )}
+          {isCodingReport && <CodingScopeCard context={run.context} />}
 
           {liveStatus && (
             <div className={styles.liveBanner}>

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -1226,9 +1226,11 @@ const ReportViewer = memo(() => {
           <div className={styles.checks}>
             {visible.map((r) => (
               <CheckRow
-                defaultOpen={checkVerdict(r) === 'failed' || r.evidence.some(isInlineEvidence)}
                 key={r.id}
                 result={r}
+                defaultOpen={
+                  checkVerdict(r) === 'failed' || r.evidence.some(isInlineVisualEvidence)
+                }
               />
             ))}
           </div>

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -137,39 +137,29 @@ const styles = createStaticStyles(({ css }) => ({
   codingScope: css`
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 6px;
 
     max-width: 100%;
     margin-block-start: 8px;
   `,
   codingScopeMain: css`
     display: flex;
-    flex-wrap: nowrap;
-    gap: 8px;
+    flex-wrap: wrap;
+    gap: 6px 14px;
     align-items: center;
 
     min-width: 0;
-
-    @media (width <= 720px) {
-      flex-wrap: wrap;
-    }
   `,
   branchChip: css`
     display: inline-flex;
-    flex: 1 1 220px;
-    gap: 8px;
+    flex: 0 1 auto;
+    gap: 6px;
     align-items: center;
 
     min-width: 0;
-    max-width: 320px;
-    height: 32px;
-    padding-inline: 10px;
-    border: 1px solid ${cssVar.colorBorderSecondary};
-    border-radius: ${cssVar.borderRadiusSM};
+    max-width: 360px;
 
-    color: ${cssVar.colorTextSecondary};
-
-    background: ${cssVar.colorBgContainer};
+    color: ${cssVar.colorTextTertiary};
 
     code {
       overflow: hidden;
@@ -177,71 +167,67 @@ const styles = createStaticStyles(({ css }) => ({
       min-width: 0;
 
       font-family: ${cssVar.fontFamilyCode};
-      font-size: 13px;
-      color: ${cssVar.colorText};
+      font-size: 12px;
+      color: ${cssVar.colorTextSecondary};
       text-overflow: ellipsis;
       white-space: nowrap;
+    }
+
+    svg {
+      flex: 0 0 auto;
+      color: ${cssVar.colorTextQuaternary};
     }
   `,
   commitChip: css`
     display: inline-flex;
     flex: 0 0 auto;
-    gap: 7px;
+    gap: 6px;
     align-items: center;
 
-    height: 32px;
-    padding-inline: 10px;
-    border: 1px solid ${cssVar.colorBorderSecondary};
-    border-radius: ${cssVar.borderRadiusSM};
-
-    color: ${cssVar.colorTextSecondary};
-
-    background: ${cssVar.colorBgContainer};
+    color: ${cssVar.colorTextTertiary};
 
     code {
       font-family: ${cssVar.fontFamilyCode};
       font-size: 12px;
-      color: ${cssVar.colorText};
+      color: ${cssVar.colorTextTertiary};
+    }
+
+    svg {
+      flex: 0 0 auto;
+      color: ${cssVar.colorTextQuaternary};
     }
   `,
   prChip: css`
     cursor: default;
 
     display: inline-flex;
-    flex: 1 1 280px;
-    gap: 7px;
+    flex: 0 1 auto;
+    gap: 6px;
     align-items: center;
 
     min-width: 0;
-    max-width: 100%;
-    height: 32px;
-    padding-inline: 10px;
-    border: 1px solid ${cssVar.colorBorderSecondary};
-    border-radius: ${cssVar.borderRadiusSM};
+    max-width: 420px;
 
-    font-size: 13px;
-    color: ${cssVar.colorText};
+    font-size: 12px;
+    color: ${cssVar.colorTextSecondary};
     text-decoration: none;
-
-    background: ${cssVar.colorBgContainer};
 
     &[data-link='true'] {
       cursor: pointer;
     }
 
     &[data-link='true']:hover {
-      border-color: ${cssVar.colorLink};
-      color: ${cssVar.colorText};
+      color: ${cssVar.colorLink};
     }
 
     > svg:first-child {
       flex: 0 0 auto;
-      color: ${cssVar.colorLink};
+      color: ${cssVar.colorTextQuaternary};
     }
   `,
   prNumber: css`
     flex: 0 0 auto;
-    color: ${cssVar.colorLink};
+    color: ${cssVar.colorTextSecondary};
   `,
   prTitle: css`
     overflow: hidden;
@@ -249,7 +235,7 @@ const styles = createStaticStyles(({ css }) => ({
 
     min-width: 0;
 
-    color: ${cssVar.colorTextSecondary};
+    color: ${cssVar.colorTextTertiary};
     text-overflow: ellipsis;
     white-space: nowrap;
   `,
@@ -1001,7 +987,7 @@ const CodingScopeCard = memo<{ context: VerifyCodingScope | null | undefined }>(
 
   return (
     <div className={styles.codingScope}>
-      {(hasPullRequest || branch || commit) && (
+      {(hasPullRequest || branch || commit || date) && (
         <div className={styles.codingScopeMain}>
           {pullRequestContent &&
             (pullRequest?.url ? (
@@ -1032,10 +1018,16 @@ const CodingScopeCard = memo<{ context: VerifyCodingScope | null | undefined }>(
               <code>{shortCommit}</code>
             </span>
           )}
+          {date && (
+            <span className={styles.scopeMetaItem}>
+              <Icon icon={CalendarClock} size={13} />
+              <span>{date}</span>
+            </span>
+          )}
         </div>
       )}
 
-      {(surfaces?.length || entry || date) && (
+      {(surfaces?.length || entry) && (
         <div className={styles.scopeMetaRow}>
           {surfaces && surfaces.length > 0 && (
             <span className={styles.scopeMetaItem}>
@@ -1053,12 +1045,6 @@ const CodingScopeCard = memo<{ context: VerifyCodingScope | null | undefined }>(
             <span className={styles.scopeMetaItem} title={entry}>
               <Icon icon={Terminal} size={13} />
               <code>{entry}</code>
-            </span>
-          )}
-          {date && (
-            <span className={styles.scopeMetaItem}>
-              <Icon icon={CalendarClock} size={13} />
-              <span>{date}</span>
             </span>
           )}
         </div>


### PR DESCRIPTION
## Summary
- add coding report scope metadata for branch, commit, surfaces, entry, date, focus, and pull request links
- inline short text/dom/transcript evidence under 5000 characters from verify CLI upload paths
- render inline content evidence directly in verify report rows instead of forcing file-button/modal flow

## Verification
- bun run check apps/cli/src/commands/verify.ts apps/server/src/routers/lambda/verify.ts apps/server/src/routers/lambda/__tests__/verify.test.ts packages/types/src/verify.ts packages/locales/src/default/verify.ts src/features/Verify/ReportViewer.tsx locales/en-US/verify.json locales/zh-CN/verify.json --lint --test
- agent-testing report: https://app.lobehub.com/verify/d007d1cc-23ea-4b2d-8872-fa88ad219434

## Notes
- Full --type remains blocked by existing repo-wide Next generated route, Drizzle duplicate-package, and dayjs version type conflicts; no new ReportViewer type errors surfaced in the target check.