### PR TITLE
🐛 fix(agent-runtime): retry non-stale lock conflicts

### DIFF
--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -744,6 +744,34 @@ export class AgentRuntimeService {
       stepLockOwner,
     );
     if (!claimed) {
+      let currentState: AgentState | null | undefined = null;
+      try {
+        currentState = await this.coordinator.loadAgentState(operationId);
+      } catch (error) {
+        log(
+          '[%s][%d] Failed to load state while handling step lock conflict: %O',
+          operationId,
+          stepIndex,
+          error,
+        );
+      }
+
+      const currentStepCount = currentState?.stepCount;
+      if (currentState && typeof currentStepCount === 'number' && currentStepCount > stepIndex) {
+        log(
+          '[%s][%d] Step lock conflict is stale (stepCount=%d), skipping',
+          operationId,
+          stepIndex,
+          currentStepCount,
+        );
+        return {
+          nextStepScheduled: false,
+          state: currentState,
+          stepResult: null,
+          success: true,
+        };
+      }
+
       log(
         '[%s][%d] Step lock conflict — another instance is executing this step, returning locked',
         operationId,
@@ -753,7 +781,7 @@ export class AgentRuntimeService {
         locked: true,
         nextStepScheduled: false,
         state: {},
-        success: true,
+        success: false,
       };
     }
 

--- a/apps/server/src/services/agentRuntime/__tests__/executeStep.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/executeStep.test.ts
@@ -247,10 +247,15 @@ describe('AgentRuntimeService.executeStep - step idempotency (distributed lock)'
     return service;
   };
 
-  it('should return locked=true when tryClaimStep returns false', async () => {
+  it('should return locked=true for a non-stale lock conflict', async () => {
     const service = createService();
     const coordinator = (service as any).coordinator;
     coordinator.tryClaimStep = vi.fn().mockResolvedValue(false);
+    coordinator.loadAgentState = vi.fn().mockResolvedValue({
+      status: 'running',
+      stepCount: 5,
+      lastModified: new Date().toISOString(),
+    });
 
     const result = await service.executeStep({
       operationId: 'op-locked',
@@ -258,10 +263,32 @@ describe('AgentRuntimeService.executeStep - step idempotency (distributed lock)'
     });
 
     expect(result.locked).toBe(true);
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
     expect(result.nextStepScheduled).toBe(false);
-    // Should NOT call loadAgentState since lock was not acquired
-    expect(coordinator.loadAgentState).not.toHaveBeenCalled();
+    expect(coordinator.loadAgentState).toHaveBeenCalledWith('op-locked');
+    expect(coordinator.releaseStepLock).not.toHaveBeenCalled();
+  });
+
+  it('should ack stale duplicate deliveries even when the stale step lock is held', async () => {
+    const service = createService();
+    const coordinator = (service as any).coordinator;
+    coordinator.tryClaimStep = vi.fn().mockResolvedValue(false);
+    coordinator.loadAgentState = vi.fn().mockResolvedValue({
+      status: 'running',
+      stepCount: 10,
+      lastModified: new Date().toISOString(),
+    });
+
+    const result = await service.executeStep({
+      operationId: 'op-stale-locked',
+      stepIndex: 8,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.locked).toBeUndefined();
+    expect(result.stepResult).toBeNull();
+    expect(result.nextStepScheduled).toBe(false);
+    expect(coordinator.releaseStepLock).not.toHaveBeenCalled();
   });
 
   it('should skip execution when stepCount > stepIndex (delayed retry after lock TTL)', async () => {

--- a/apps/server/src/services/agentRuntime/types.ts
+++ b/apps/server/src/services/agentRuntime/types.ts
@@ -181,7 +181,8 @@ export interface AgentExecutionParams {
 export interface AgentExecutionResult {
   /**
    * When true, the step was already being executed by another instance (lock conflict).
-   * The caller should ACK duplicate queue deliveries as a no-op.
+   * Stale duplicates are handled before returning this; callers should keep
+   * this response retryable so fresh deliveries can run after the lock clears.
    */
   locked?: boolean;
   nextStepScheduled: boolean;

--- a/src/server/agent-hono/handlers/__tests__/runStep.test.ts
+++ b/src/server/agent-hono/handlers/__tests__/runStep.test.ts
@@ -191,28 +191,26 @@ describe('runStep handler', () => {
     );
   });
 
-  it('returns a no-op ACK when the step is locked', async () => {
+  it('returns 429 with Retry-After header when the step is locked', async () => {
     mockGetOperationMetadata.mockResolvedValue({ userId: 'user-1' });
     mockExecuteStep.mockResolvedValue({
       locked: true,
       nextStepScheduled: false,
       state: {},
-      success: true,
+      success: false,
     });
 
     const { ctx, getCaptures } = buildContext({ body: validBody });
     const res = await runStep(ctx);
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(429);
     const captured = getCaptures()[0];
-    expect(captured.body).toEqual({
-      locked: true,
-      nextStepScheduled: false,
+    expect(captured.body).toMatchObject({
+      error: 'Step is currently being executed, retry later',
       operationId: 'op-1',
       stepIndex: 2,
-      success: true,
     });
-    expect(captured.headers).toBeUndefined();
+    expect(captured.headers).toEqual({ 'Retry-After': '37' });
   });
 
   it('forwards the upstash-retried header to executeStep as externalRetryCount', async () => {

--- a/src/server/agent-hono/handlers/runStep.ts
+++ b/src/server/agent-hono/handlers/runStep.ts
@@ -150,17 +150,15 @@ export async function runStep(c: Context): Promise<Response> {
       verifyAsyncToolBarrier,
     });
 
-    // Step is currently being executed by another instance. ACK duplicate
-    // at-least-once deliveries so QStash does not amplify them into retries.
+    // A non-stale lock conflict means another delivery is still executing this
+    // operation. Keep the response retryable so QStash redelivers this step.
     if (result.locked) {
-      log(`[${operationId}] Step ${stepIndex} locked by another instance, returning no-op ACK`);
-      return c.json({
-        locked: true,
-        nextStepScheduled: false,
-        operationId,
-        stepIndex,
-        success: true,
-      });
+      log(`[${operationId}] Step ${stepIndex} locked by another instance, returning 429`);
+      return c.json(
+        { error: 'Step is currently being executed, retry later', operationId, stepIndex },
+        429,
+        { 'Retry-After': '37' },
+      );
     }
 
     const executionTime = Date.now() - startTime;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up to #16821 and #16829.

#### 🔀 Description of Change

Rebases #16832 on top of #16821's operation-scoped lock design. Lock conflicts now split into two cases:

- stale duplicate delivery: if persisted `stepCount > stepIndex`, `executeStep` ACKs it as already completed;
- non-stale/fresh conflict: `executeStep` returns `locked=true` with `success=false`, and `runStep` responds `429` with `Retry-After` so QStash retries after the operation lock clears.

This keeps #16821's owner-token heartbeat/release behavior while avoiding ACKing legitimate successor deliveries.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run apps/server/src/services/agentRuntime/AgentRuntimeService.test.ts apps/server/src/services/agentRuntime/__tests__/executeStep.test.ts src/server/agent-hono/handlers/__tests__/runStep.test.ts
bun run type-check
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This replaces the earlier #16832 approach with a smaller patch layered directly on #16821.
