### PR TITLE
🐛 fix(chat): surface waiting-for-human topic status

### DIFF
--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationControl.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationControl.test.ts
@@ -46,6 +46,9 @@ vi.mock('@/utils/localStorage', () => {
 
 beforeEach(() => {
   resetTestEnvironment();
+  useChatStore.setState({
+    updateTopicStatus: vi.fn().mockResolvedValue(undefined),
+  });
 });
 
 afterEach(() => {
@@ -495,6 +498,9 @@ describe('ConversationControl actions', () => {
 
       // Mock internal methods
       vi.spyOn(result.current, 'optimisticUpdateMessagePlugin').mockResolvedValue(undefined);
+      const updateTopicStatusSpy = vi
+        .spyOn(result.current, 'updateTopicStatus')
+        .mockResolvedValue(undefined as any);
       const internal_createAgentStateSpy = vi
         .spyOn(result.current, 'internal_createAgentState')
         .mockReturnValue({
@@ -533,6 +539,13 @@ describe('ConversationControl actions', () => {
             topicId: builderTopicId,
             scope: 'agent_builder',
           }),
+        }),
+      );
+      expect(updateTopicStatusSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: builderAgentId,
+          status: 'active',
+          topicId: builderTopicId,
         }),
       );
     });

--- a/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
@@ -59,6 +59,7 @@ function createMockStore() {
       };
     }),
     updateOperationMetadata: vi.fn(),
+    updateTopicStatus: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -567,6 +568,13 @@ describe('createGatewayEventHandler', () => {
         expect.any(Function),
         expect.objectContaining({
           agentId: 'agent-1',
+          topicId: 'topic-1',
+        }),
+      );
+      expect(store.updateTopicStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: 'agent-1',
+          status: 'waitingForHuman',
           topicId: 'topic-1',
         }),
       );

--- a/src/store/chat/slices/agentRun/actions/__tests__/streamingExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/streamingExecutor.test.ts
@@ -2184,6 +2184,9 @@ describe('StreamingExecutor actions', () => {
         });
         operationId = res.operationId;
       });
+      const updateTopicStatusSpy = vi
+        .spyOn(result.current, 'updateTopicStatus')
+        .mockResolvedValue(undefined as any);
 
       // Mock internal_createAgentState to return waiting_for_human status
       mockInternalCreateAgentState({
@@ -2201,7 +2204,13 @@ describe('StreamingExecutor actions', () => {
         agentConfig: createMockResolvedAgentConfig(),
       });
       vi.spyOn(agentRuntime.AgentRuntime.prototype, 'step').mockResolvedValue({
-        events: [],
+        events: [
+          {
+            operationId,
+            pendingToolsCalling: [],
+            type: 'human_approve_required',
+          },
+        ],
         newState: createMockRuntimeState(operationId!, 'waiting_for_human'),
         nextContext: undefined,
       });
@@ -2224,6 +2233,13 @@ describe('StreamingExecutor actions', () => {
       // 1. User can see the tool intervention UI without loading indicator
       // 2. A new operation will be created when user approves/rejects
       expect(result.current.operations[operationId!].status).toBe('completed');
+      expect(updateTopicStatusSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: TEST_IDS.SESSION_ID,
+          status: 'waitingForHuman',
+          topicId: TEST_IDS.TOPIC_ID,
+        }),
+      );
       // Parked ≠ terminal: NO `client.runtime.complete` is emitted — the run has
       // not ended, it is waiting for human approval — parked states do not emit
       // mis-emitted a terminal `cancelled` complete signal.

--- a/src/store/chat/slices/agentRun/actions/entries/conversationControl.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationControl.ts
@@ -2,6 +2,7 @@
 import { type AgentRuntimeContext } from '@lobechat/agent-runtime';
 import { MESSAGE_CANCEL_FLAT } from '@lobechat/const';
 import {
+  type ChatTopicStatus,
   type ConversationContext,
   type MessageMetadata,
   type UIChatMessage,
@@ -153,6 +154,25 @@ export class ConversationControlActionImpl {
     for (const id of opIds) completeOperation(id);
   };
 
+  #writeTopicStatus = (context: ConversationContext, status: ChatTopicStatus): void => {
+    if (!context.topicId) return;
+
+    const topicScope =
+      context.scope === 'group' || context.scope === 'group_agent' ? context.scope : undefined;
+
+    const statusWrite = this.#get().updateTopicStatus?.({
+      agentId: context.agentId,
+      groupId: context.groupId,
+      ...(topicScope ? { scope: topicScope } : {}),
+      status,
+      topicId: context.topicId,
+    });
+
+    void statusWrite?.catch((error) => {
+      console.error('[conversationControl] updateTopicStatus failed:', error);
+    });
+  };
+
   stopGenerateMessage = (): void => {
     const { activeAgentId, activeTopicId, cancelOperations } = this.#get();
 
@@ -295,6 +315,8 @@ export class ConversationControlActionImpl {
     });
 
     const optimisticContext = { operationId };
+
+    this.#writeTopicStatus(effectiveContext, 'active');
 
     // Park → resume: a new op continues the run paused on this tool's approval.
     this.#emitRunResumed(effectiveContext, {
@@ -445,6 +467,8 @@ export class ConversationControlActionImpl {
 
     const optimisticContext: OptimisticUpdateContext = { operationId };
     const shouldCreateUserMessage = options?.createUserMessage !== false;
+
+    this.#writeTopicStatus(effectiveContext, 'active');
 
     // Park → resume: a new op continues the run paused on this tool interaction.
     this.#emitRunResumed(effectiveContext, {
@@ -671,6 +695,8 @@ export class ConversationControlActionImpl {
 
     const optimisticContext: OptimisticUpdateContext = { operationId };
 
+    this.#writeTopicStatus(effectiveContext, 'active');
+
     // Park → resume: a new op continues the run paused on this tool interaction.
     this.#emitRunResumed(effectiveContext, {
       operationId,
@@ -782,6 +808,8 @@ export class ConversationControlActionImpl {
     });
 
     const optimisticContext = { operationId };
+
+    this.#writeTopicStatus(effectiveContext, 'active');
 
     await this.#get().optimisticUpdateMessagePlugin(
       toolMessageId,
@@ -1050,6 +1078,8 @@ export class ConversationControlActionImpl {
 
     const optimisticContext = { operationId };
 
+    this.#writeTopicStatus(effectiveContext, 'active');
+
     // Optimistic update - update status to rejected and save reason
     const intervention = {
       rejectedReason: reason,
@@ -1164,6 +1194,7 @@ export class ConversationControlActionImpl {
       });
 
       const optimisticContext = { operationId };
+      this.#writeTopicStatus(effectiveContext, 'active');
       // Park → resume: the new gateway op continues the run paused on this tool.
       this.#emitRunResumed(effectiveContext, {
         operationId,

--- a/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
@@ -710,11 +710,21 @@ export class StreamingExecutorActionImpl {
           }
 
           case 'human_approve_required': {
-            await notifyDesktopHumanApprovalRequired(this.#get, {
-              agentId,
-              groupId,
-              topicId,
-            });
+            await notifyDesktopHumanApprovalRequired(this.#get, context);
+            if (topicId) {
+              const statusWrite = this.#get().updateTopicStatus?.({
+                agentId,
+                groupId,
+                ...(context.scope === 'group' || context.scope === 'group_agent'
+                  ? { scope: context.scope }
+                  : {}),
+                status: 'waitingForHuman',
+                topicId,
+              });
+              void statusWrite?.catch((error) => {
+                console.error('[streamingExecutor] updateTopicStatus failed:', error);
+              });
+            }
             break;
           }
 

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -636,16 +636,22 @@ export const createGatewayEventHandler = (
 
         if (data?.phase === 'human_approval' && data.requiresApproval && data.pendingToolsCalling) {
           void notifyDesktopHumanApprovalRequired(get, context);
-          // Persist a paused marker so the sidebar reflects "waiting on user" across reload.
-          // Resume back to 'running' is free: approve / reject both spawn a new op via the
-          // executor entries, which already write 'running'.
-          if (context.topicId)
-            void get().updateTopicStatus?.({
+          // Persist the explicit "needs user input" marker so the sidebar swaps
+          // the running spinner for the hand icon across reloads.
+          if (context.topicId) {
+            const statusWrite = get().updateTopicStatus?.({
               agentId: context.agentId,
               groupId: context.groupId,
-              status: 'paused',
+              ...(context.scope === 'group' || context.scope === 'group_agent'
+                ? { scope: context.scope }
+                : {}),
+              status: 'waitingForHuman',
               topicId: context.topicId,
             });
+            void statusWrite?.catch((error) => {
+              console.error('[gatewayEventHandler] updateTopicStatus failed:', error);
+            });
+          }
         }
 
         break;

--- a/src/store/chat/slices/aiAgent/actions/__tests__/runAgent.test.ts
+++ b/src/store/chat/slices/aiAgent/actions/__tests__/runAgent.test.ts
@@ -348,6 +348,9 @@ describe('runAgent actions', () => {
         const context = createStreamingContext({
           assistantId: TEST_IDS.ASSISTANT_MESSAGE_ID,
         });
+        const updateTopicStatusSpy = vi
+          .spyOn(result.current, 'updateTopicStatus')
+          .mockResolvedValue(undefined as any);
 
         const event: StreamEvent = {
           type: 'step_start',
@@ -377,6 +380,14 @@ describe('runAgent actions', () => {
           expect.objectContaining({
             agentId: 'agent-1',
             groupId: 'group-1',
+            topicId: 'topic-1',
+          }),
+        );
+        expect(updateTopicStatusSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            agentId: 'agent-1',
+            groupId: 'group-1',
+            status: 'waitingForHuman',
             topicId: 'topic-1',
           }),
         );

--- a/src/store/chat/slices/aiAgent/actions/runAgent.ts
+++ b/src/store/chat/slices/aiAgent/actions/runAgent.ts
@@ -301,6 +301,20 @@ export class AgentActionImpl {
           });
 
           await notifyDesktopHumanApprovalRequired(this.#get, operation.context);
+          if (operation.context.topicId) {
+            const statusWrite = this.#get().updateTopicStatus?.({
+              agentId: operation.context.agentId,
+              groupId: operation.context.groupId,
+              ...(operation.context.scope === 'group' || operation.context.scope === 'group_agent'
+                ? { scope: operation.context.scope }
+                : {}),
+              status: 'waitingForHuman',
+              topicId: operation.context.topicId,
+            });
+            void statusWrite?.catch((error) => {
+              console.error('[runAgent] updateTopicStatus failed:', error);
+            });
+          }
 
           // Stop loading state, waiting for human intervention
           log(`Stopping loading for human approval: ${assistantId}`);


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

Supersedes #14889 on the current `agentRun` architecture.

Built-in tool approvals and Gateway `human_approval` parks now persist topic status as `waitingForHuman`, so the sidebar and topic grouping show the existing awaiting-input affordance instead of falling back to `paused` / default topic icons.

Resolvers for approve / submit / skip / cancel / reject / reject-and-continue now clear the topic back to `active` immediately after the user acts, so the hand icon does not linger while the resumed run starts.

This also keeps the legacy `aiAgent` stream handler aligned for group/server stream paths that still call `internal_handleAgentStreamEvent`.

#### 🧪 How to Test

- `bun run check src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts src/store/chat/slices/agentRun/actions/entries/conversationControl.ts src/store/chat/slices/aiAgent/actions/runAgent.ts src/store/chat/slices/agentRun/actions/__tests__/streamingExecutor.test.ts src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts src/store/chat/slices/agentRun/actions/__tests__/conversationControl.test.ts src/store/chat/slices/aiAgent/actions/__tests__/runAgent.test.ts --lint --test`

#### 📝 Notes

- Full `--type` currently fails on existing repository-wide issues unrelated to this change (`.next/dev` generated route types, duplicated Drizzle/Dayjs type instances).
