### PR TITLE
🐛 fix: preserve desktop notification deep links

### DIFF
--- a/packages/electron-client-ipc/src/events/navigation.ts
+++ b/packages/electron-client-ipc/src/events/navigation.ts
@@ -50,5 +50,5 @@ export interface NavigationBroadcastEvents {
   /**
    * Ask renderer to navigate within the SPA without reloading the whole page.
    */
-  navigate: (data: { path: string; replace?: boolean }) => void;
+  navigate: (data: { escape?: boolean; path: string; replace?: boolean }) => void;
 }

--- a/packages/electron-client-ipc/src/types/notification.ts
+++ b/packages/electron-client-ipc/src/types/notification.ts
@@ -5,8 +5,11 @@ export interface ShowDesktopNotificationParams {
    * SPA path to navigate to when the user clicks the notification.
    * Reuses the existing `navigate` main-broadcast pipeline, so it requires
    * `DesktopNavigationBridge` to be mounted on the renderer side.
+   *
+   * `escape` tells the renderer to use this path literally instead of applying
+   * the currently active workspace prefix.
    */
-  navigate?: { path: string; replace?: boolean };
+  navigate?: { escape?: boolean; path: string; replace?: boolean };
   requestAttention?: boolean;
   silent?: boolean;
   title: string;

--- a/packages/types/src/conversation.ts
+++ b/packages/types/src/conversation.ts
@@ -233,4 +233,11 @@ export interface ConversationContext {
    * builds `RuntimeInitialContext.taskManager` from the task store.
    */
   viewedTask?: { type: 'list' } | { taskId: string; type: 'detail' };
+  /**
+   * Workspace slug captured at the conversation entry point. Desktop
+   * notifications and other out-of-band navigations use this to return to the
+   * same workspace instead of reinterpreting the target under the currently
+   * active tab.
+   */
+  workspaceSlug?: string;
 }

--- a/src/features/DesktopNavigationBridge/index.test.tsx
+++ b/src/features/DesktopNavigationBridge/index.test.tsx
@@ -1,0 +1,72 @@
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import DesktopNavigationBridge from './index';
+
+type NavigatePayload = { escape?: boolean; path: string; replace?: boolean };
+type NavigateHandler = (payload: NavigatePayload) => void;
+
+let registeredHandler: NavigateHandler | null = null;
+
+const navigateMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@lobechat/electron-client-ipc', () => ({
+  useWatchBroadcast: (event: string, handler: NavigateHandler) => {
+    if (event === 'navigate') registeredHandler = handler;
+  },
+}));
+
+vi.mock('@/features/Workspace/useWorkspaceAwareNavigate', () => ({
+  useWorkspaceAwareNavigate: () => navigateMock,
+}));
+
+const emitNavigate = (payload: NavigatePayload) => {
+  act(() => {
+    registeredHandler?.(payload);
+  });
+};
+
+describe('DesktopNavigationBridge', () => {
+  beforeEach(() => {
+    registeredHandler = null;
+    navigateMock.mockReset();
+  });
+
+  it('uses escaped navigation for literal desktop notification paths', () => {
+    render(<DesktopNavigationBridge />);
+
+    emitNavigate({ escape: true, path: '/team/agent/a1/t1' });
+
+    expect(navigateMock).toHaveBeenCalledWith('/team/agent/a1/t1', {
+      escape: true,
+      replace: false,
+    });
+  });
+
+  it('preserves replace navigation options from desktop broadcasts', () => {
+    render(<DesktopNavigationBridge />);
+
+    emitNavigate({ path: '/agent/a1', replace: true });
+
+    expect(navigateMock).toHaveBeenCalledWith('/agent/a1', {
+      escape: false,
+      replace: true,
+    });
+  });
+
+  it('keeps legacy broadcasts as plain workspace-aware navigation', () => {
+    render(<DesktopNavigationBridge />);
+
+    emitNavigate({ path: '/agent/a1/t1' });
+
+    expect(navigateMock).toHaveBeenCalledWith('/agent/a1/t1');
+  });
+
+  it('ignores empty navigation paths', () => {
+    render(<DesktopNavigationBridge />);
+
+    emitNavigate({ path: '' });
+
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/DesktopNavigationBridge/index.tsx
+++ b/src/features/DesktopNavigationBridge/index.tsx
@@ -9,9 +9,13 @@ const DesktopNavigationBridge = memo(() => {
   const navigate = useWorkspaceAwareNavigate();
 
   const handleNavigate = useCallback(
-    ({ path, replace }: { path: string; replace?: boolean }) => {
+    ({ escape, path, replace }: { escape?: boolean; path: string; replace?: boolean }) => {
       if (!path) return;
-      navigate(path, { replace: !!replace });
+      if (escape || replace !== undefined) {
+        navigate(path, { escape: !!escape, replace: !!replace });
+        return;
+      }
+      navigate(path);
     },
     [navigate],
   );

--- a/src/features/GlobalApprovalNotification/ApprovalCard.tsx
+++ b/src/features/GlobalApprovalNotification/ApprovalCard.tsx
@@ -6,7 +6,6 @@ import { ActionIcon, Avatar } from '@lobehub/ui';
 import { ArrowUpRight } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { ConversationProvider } from '@/features/Conversation';
@@ -14,6 +13,7 @@ import InterventionContent from '@/features/Conversation/InterventionBar/Interve
 import InterventionTabBar from '@/features/Conversation/InterventionBar/InterventionTabBar';
 import MarkdownMessage from '@/features/Conversation/Markdown';
 import { type ConversationContext } from '@/features/Conversation/types';
+import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
 import { useOperationState } from '@/hooks/useOperationState';
 import { useAgentStore } from '@/store/agent';
@@ -39,8 +39,8 @@ interface ApprovalCardProps {
 const ApprovalCard = memo<ApprovalCardProps>(({ group }) => {
   const { context, interventions } = group;
   const { t } = useTranslation('chat');
-  const navigate = useNavigate();
-  const workspaceSlug = useActiveWorkspaceSlug();
+  const navigate = useWorkspaceAwareNavigate();
+  const activeWorkspaceSlug = useActiveWorkspaceSlug();
 
   const chatKey = useMemo(() => messageMapKey(context), [context]);
   const messages = useChatStore((s) => s.dbMessagesMap[chatKey]);
@@ -98,8 +98,17 @@ const ApprovalCard = memo<ApprovalCardProps>(({ group }) => {
       path = AGENT_CHAT_TOPIC_URL(context.agentId, context.topicId);
     }
     if (!path) return;
-    navigate(buildWorkspaceAwarePath(path, workspaceSlug));
-  }, [context.agentId, context.groupId, context.topicId, navigate, workspaceSlug]);
+    navigate(buildWorkspaceAwarePath(path, context.workspaceSlug ?? activeWorkspaceSlug), {
+      escape: true,
+    });
+  }, [
+    activeWorkspaceSlug,
+    context.agentId,
+    context.groupId,
+    context.topicId,
+    context.workspaceSlug,
+    navigate,
+  ]);
 
   const canOpenConversation = !!(context.groupId || context.topicId);
 

--- a/src/routes/(main)/agent/features/Conversation/useAgentContext.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/useAgentContext.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment happy-dom
  */
 import { renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { initialState as initialChatState } from '@/store/chat/initialState';
 import { useChatStore } from '@/store/chat/store';
@@ -11,8 +11,15 @@ import { initialEditorState } from '@/store/document/slices/editor';
 
 import { useAgentContext } from './useAgentContext';
 
+const activeWorkspaceSlugMock = vi.hoisted(() => ({ value: null as string | null }));
+
+vi.mock('@/business/client/hooks/useActiveWorkspaceSlug', () => ({
+  useActiveWorkspaceSlug: () => activeWorkspaceSlugMock.value,
+}));
+
 describe('useAgentContext', () => {
   beforeEach(() => {
+    activeWorkspaceSlugMock.value = null;
     useChatStore.setState(
       {
         ...initialChatState,
@@ -97,5 +104,13 @@ describe('useAgentContext', () => {
     const { result } = renderHook(() => useAgentContext());
 
     expect(result.current.documentId).toBeUndefined();
+  });
+
+  it('captures the active workspace slug for out-of-band navigation', () => {
+    activeWorkspaceSlugMock.value = 'team';
+
+    const { result } = renderHook(() => useAgentContext());
+
+    expect(result.current.workspaceSlug).toBe('team');
   });
 });

--- a/src/routes/(main)/agent/features/Conversation/useAgentContext.ts
+++ b/src/routes/(main)/agent/features/Conversation/useAgentContext.ts
@@ -2,6 +2,7 @@
 
 import { type ConversationContext } from '@lobechat/types';
 
+import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { useChatStore } from '@/store/chat';
 import { useDocumentStore } from '@/store/document';
 
@@ -12,6 +13,7 @@ import { useDocumentStore } from '@/store/document';
  * Returns context for regular agent conversations.
  */
 export function useAgentContext(): ConversationContext {
+  const workspaceSlug = useActiveWorkspaceSlug();
   const [agentId, topicId, threadId] = useChatStore((s) => [
     s.activeAgentId,
     s.activeTopicId ?? null,
@@ -40,5 +42,6 @@ export function useAgentContext(): ConversationContext {
     scope: threadId ? 'thread' : 'main',
     threadId,
     topicId,
+    ...(workspaceSlug ? { workspaceSlug } : {}),
   };
 }

--- a/src/routes/(main)/group/features/Conversation/useGroupContext.ts
+++ b/src/routes/(main)/group/features/Conversation/useGroupContext.ts
@@ -2,6 +2,7 @@
 
 import { type ConversationContext } from '@lobechat/types';
 
+import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { useAgentGroupStore } from '@/store/agentGroup';
 import { agentGroupSelectors } from '@/store/agentGroup/selectors';
 import { useChatStore } from '@/store/chat';
@@ -13,6 +14,7 @@ import { useChatStore } from '@/store/chat';
  * Used for group chat pages where multiple agents participate.
  */
 export function useGroupContext(): ConversationContext {
+  const workspaceSlug = useActiveWorkspaceSlug();
   const [topicId, threadId] = useChatStore((s) => [
     s.activeTopicId ?? null,
     s.activeThreadId ?? null,
@@ -38,5 +40,6 @@ export function useGroupContext(): ConversationContext {
     scope: threadId ? 'group_agent' : 'group',
     threadId,
     topicId,
+    ...(workspaceSlug ? { workspaceSlug } : {}),
   };
 }

--- a/src/routes/(main)/home/features/InputArea/useSend.test.ts
+++ b/src/routes/(main)/home/features/InputArea/useSend.test.ts
@@ -71,6 +71,14 @@ const homeDailyBriefState = vi.hoisted(() => ({
   pairs: [] as { hint: string; welcome: string }[],
 }));
 
+const activeWorkspaceSlugMock = vi.hoisted(() => ({
+  value: null as string | null,
+}));
+
+vi.mock('@/business/client/hooks/useActiveWorkspaceSlug', () => ({
+  useActiveWorkspaceSlug: () => activeWorkspaceSlugMock.value,
+}));
+
 vi.mock('@/hooks/useQueryRoute', () => ({
   useQueryRoute: () => routerMock,
 }));
@@ -145,6 +153,7 @@ describe('Home InputArea useSend', () => {
     fileState.chatContextSelections = [];
     fileState.chatUploadFileList = [];
     homeState.inputActiveMode = null;
+    activeWorkspaceSlugMock.value = null;
   });
 
   it('routes cold homepage sends to the created topic instead of relying on ChatHydration timing', async () => {
@@ -178,6 +187,27 @@ describe('Home InputArea useSend', () => {
     expect(routerMock.replace).toHaveBeenCalledWith('/agent/agt_inbox/tpc_created');
   });
 
+  it('captures the active workspace slug in default homepage sends', async () => {
+    activeWorkspaceSlugMock.value = 'team';
+    const { result } = renderHook(() => useSend());
+    const params: Parameters<SendButtonHandler>[0] = {
+      clearContent: vi.fn(),
+      editor: {} as Parameters<SendButtonHandler>[0]['editor'],
+      getEditorData: () => undefined,
+      getMarkdownContent: () => 'hello',
+    };
+
+    await act(async () => {
+      await result.current.send(params);
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: { agentId: 'agt_inbox', isolatedTopic: true, workspaceSlug: 'team' },
+      }),
+    );
+  });
+
   it('drops editorData when sending the placeholder hint so the user message renders the markdown content', async () => {
     homeDailyBriefState.currentPair = {
       hint: '看下 Bug #14153 + #14112 Agent 手机端不同步/不显示...',
@@ -209,6 +239,7 @@ describe('Home InputArea useSend', () => {
 
   it('passes context selections through starter agent mode sends', async () => {
     homeState.inputActiveMode = 'agent';
+    activeWorkspaceSlugMock.value = 'team';
     fileState.chatContextSelections = [
       {
         content: 'const selected = true;',
@@ -245,6 +276,7 @@ describe('Home InputArea useSend', () => {
           }),
         ],
         message: 'use this selection',
+        workspaceSlug: 'team',
       }),
     );
     expect(clearChatContextSelectionsMock).toHaveBeenCalledTimes(1);

--- a/src/routes/(main)/home/features/InputArea/useSend.ts
+++ b/src/routes/(main)/home/features/InputArea/useSend.ts
@@ -1,6 +1,7 @@
 import { AGENT_CHAT_TOPIC_URL, AGENT_CHAT_URL } from '@lobechat/const';
 import { useCallback } from 'react';
 
+import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import type { SendButtonHandler } from '@/features/ChatInput/store/initialState';
 import { buildMessageContextSelections } from '@/features/ChatInput/utils/contextSelections';
 import { useHomeDailyBrief } from '@/hooks/useHomeDailyBrief';
@@ -37,6 +38,7 @@ const ensureAgentConfigLoaded = async (agentId: string): Promise<void> => {
 
 export const useSend = () => {
   const router = useQueryRoute();
+  const activeWorkspaceSlug = useActiveWorkspaceSlug();
   const sendMessage = useChatStore((s) => s.sendMessage);
   const clearChatUploadFileList = useFileStore((s) => s.clearChatUploadFileList);
   const clearChatContextSelections = useFileStore((s) => s.clearChatContextSelections);
@@ -95,17 +97,35 @@ export const useSend = () => {
 
         switch (inputActiveMode) {
           case 'agent': {
-            await sendAsAgent({ contextSelections, editorData, message, pageSelections });
+            await sendAsAgent({
+              contextSelections,
+              editorData,
+              message,
+              pageSelections,
+              workspaceSlug: activeWorkspaceSlug,
+            });
             break;
           }
 
           case 'group': {
-            await sendAsGroup({ contextSelections, editorData, message, pageSelections });
+            await sendAsGroup({
+              contextSelections,
+              editorData,
+              message,
+              pageSelections,
+              workspaceSlug: activeWorkspaceSlug,
+            });
             break;
           }
 
           case 'write': {
-            await sendAsWrite({ contextSelections, editorData, message, pageSelections });
+            await sendAsWrite({
+              contextSelections,
+              editorData,
+              message,
+              pageSelections,
+              workspaceSlug: activeWorkspaceSlug,
+            });
             break;
           }
 
@@ -124,7 +144,11 @@ export const useSend = () => {
             await ensureAgentConfigLoaded(activeAgentId);
 
             sendMessage({
-              context: { agentId: activeAgentId, isolatedTopic: true },
+              context: {
+                agentId: activeAgentId,
+                isolatedTopic: true,
+                ...(activeWorkspaceSlug ? { workspaceSlug: activeWorkspaceSlug } : {}),
+              },
               contextSelections,
               contexts: contextList,
               editorData,
@@ -148,6 +172,7 @@ export const useSend = () => {
     },
     [
       activeAgentId,
+      activeWorkspaceSlug,
       sendMessage,
       clearChatContextSelections,
       clearChatUploadFileList,

--- a/src/store/chat/agents/GroupOrchestration/createGroupOrchestrationExecutors.ts
+++ b/src/store/chat/agents/GroupOrchestration/createGroupOrchestrationExecutors.ts
@@ -697,6 +697,7 @@ export const createGroupOrchestrationExecutors = (
           topicId,
           threadId,
           scope: 'thread',
+          workspaceSlug: messageContext.workspaceSlug,
         };
 
         // 4. Create a child operation for task execution (now with threadId)

--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationControl.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationControl.test.ts
@@ -46,6 +46,9 @@ vi.mock('@/utils/localStorage', () => {
 
 beforeEach(() => {
   resetTestEnvironment();
+  useChatStore.setState({
+    updateTopicStatus: vi.fn().mockResolvedValue(undefined),
+  });
 });
 
 afterEach(() => {
@@ -495,6 +498,9 @@ describe('ConversationControl actions', () => {
 
       // Mock internal methods
       vi.spyOn(result.current, 'optimisticUpdateMessagePlugin').mockResolvedValue(undefined);
+      const updateTopicStatusSpy = vi
+        .spyOn(result.current, 'updateTopicStatus')
+        .mockResolvedValue(undefined as any);
       const internal_createAgentStateSpy = vi
         .spyOn(result.current, 'internal_createAgentState')
         .mockReturnValue({
@@ -533,6 +539,13 @@ describe('ConversationControl actions', () => {
             topicId: builderTopicId,
             scope: 'agent_builder',
           }),
+        }),
+      );
+      expect(updateTopicStatusSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: builderAgentId,
+          status: 'active',
+          topicId: builderTopicId,
         }),
       );
     });

--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationControl.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationControl.test.ts
@@ -702,6 +702,8 @@ describe('ConversationControl actions', () => {
         const executeClientAgentSpy = vi
           .spyOn(result.current, 'executeClientAgent')
           .mockResolvedValue(undefined);
+        const updateTopicStatusMock = vi.mocked(result.current.updateTopicStatus);
+        updateTopicStatusMock.mockClear();
 
         await act(async () => {
           await result.current.approveToolCalling('tool-msg-1', 'group-1');
@@ -720,6 +722,9 @@ describe('ConversationControl actions', () => {
           }),
         );
         expect(executeClientAgentSpy).not.toHaveBeenCalled();
+        expect(updateTopicStatusMock).toHaveBeenCalledWith(
+          expect.objectContaining({ agentId, status: 'active', topicId }),
+        );
 
         // Fallback guard: the paused `execServerAgentRuntime` op in this
         // context must be completed so the loading state doesn't bleed
@@ -845,6 +850,8 @@ describe('ConversationControl actions', () => {
         const executeGatewayAgentSpy = vi
           .spyOn(result.current, 'executeGatewayAgent')
           .mockRejectedValue(new Error('network error'));
+        const updateTopicStatusMock = vi.mocked(result.current.updateTopicStatus);
+        updateTopicStatusMock.mockClear();
 
         await act(async () => {
           await result.current.approveToolCalling('tool-msg-1', 'group-1');
@@ -860,6 +867,9 @@ describe('ConversationControl actions', () => {
         );
         expect(serverOps).toHaveLength(1);
         expect(serverOps[0]!.status).toBe('running');
+        expect(
+          updateTopicStatusMock.mock.calls.some(([payload]) => payload.status === 'active'),
+        ).toBe(false);
 
         executeGatewayAgentSpy.mockRestore();
       });

--- a/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
@@ -59,6 +59,7 @@ function createMockStore() {
       };
     }),
     updateOperationMetadata: vi.fn(),
+    updateTopicStatus: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -567,6 +568,13 @@ describe('createGatewayEventHandler', () => {
         expect.any(Function),
         expect.objectContaining({
           agentId: 'agent-1',
+          topicId: 'topic-1',
+        }),
+      );
+      expect(store.updateTopicStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: 'agent-1',
+          status: 'waitingForHuman',
           topicId: 'topic-1',
         }),
       );

--- a/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
@@ -3993,7 +3993,7 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
           // body = markdownToTxt(finalContent)
           body: expect.stringContaining('All done with the task'),
           // navigate path resolved from agentId + topicId
-          navigate: { path: expect.any(String) },
+          navigate: expect.objectContaining({ escape: true, path: expect.any(String) }),
           title: expect.any(String),
         }),
       );

--- a/src/store/chat/slices/agentRun/actions/__tests__/streamingExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/streamingExecutor.test.ts
@@ -2184,6 +2184,9 @@ describe('StreamingExecutor actions', () => {
         });
         operationId = res.operationId;
       });
+      const updateTopicStatusSpy = vi
+        .spyOn(result.current, 'updateTopicStatus')
+        .mockResolvedValue(undefined as any);
 
       // Mock internal_createAgentState to return waiting_for_human status
       mockInternalCreateAgentState({
@@ -2201,7 +2204,13 @@ describe('StreamingExecutor actions', () => {
         agentConfig: createMockResolvedAgentConfig(),
       });
       vi.spyOn(agentRuntime.AgentRuntime.prototype, 'step').mockResolvedValue({
-        events: [],
+        events: [
+          {
+            operationId,
+            pendingToolsCalling: [],
+            type: 'human_approve_required',
+          },
+        ],
         newState: createMockRuntimeState(operationId!, 'waiting_for_human'),
         nextContext: undefined,
       });
@@ -2224,6 +2233,13 @@ describe('StreamingExecutor actions', () => {
       // 1. User can see the tool intervention UI without loading indicator
       // 2. A new operation will be created when user approves/rejects
       expect(result.current.operations[operationId!].status).toBe('completed');
+      expect(updateTopicStatusSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentId: TEST_IDS.SESSION_ID,
+          status: 'waitingForHuman',
+          topicId: TEST_IDS.TOPIC_ID,
+        }),
+      );
       // Parked ≠ terminal: NO `client.runtime.complete` is emitted — the run has
       // not ended, it is waiting for human approval — parked states do not emit
       // mis-emitted a terminal `cancelled` complete signal.

--- a/src/store/chat/slices/agentRun/actions/entries/conversationControl.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationControl.ts
@@ -2,6 +2,7 @@
 import { type AgentRuntimeContext } from '@lobechat/agent-runtime';
 import { MESSAGE_CANCEL_FLAT } from '@lobechat/const';
 import {
+  type ChatTopicStatus,
   type ConversationContext,
   type MessageMetadata,
   type UIChatMessage,
@@ -153,6 +154,25 @@ export class ConversationControlActionImpl {
     for (const id of opIds) completeOperation(id);
   };
 
+  #writeTopicStatus = (context: ConversationContext, status: ChatTopicStatus): void => {
+    if (!context.topicId) return;
+
+    const topicScope =
+      context.scope === 'group' || context.scope === 'group_agent' ? context.scope : undefined;
+
+    const statusWrite = this.#get().updateTopicStatus?.({
+      agentId: context.agentId,
+      groupId: context.groupId,
+      ...(topicScope ? { scope: topicScope } : {}),
+      status,
+      topicId: context.topicId,
+    });
+
+    void statusWrite?.catch((error) => {
+      console.error('[conversationControl] updateTopicStatus failed:', error);
+    });
+  };
+
   stopGenerateMessage = (): void => {
     const { activeAgentId, activeTopicId, cancelOperations } = this.#get();
 
@@ -295,6 +315,8 @@ export class ConversationControlActionImpl {
     });
 
     const optimisticContext = { operationId };
+
+    this.#writeTopicStatus(effectiveContext, 'active');
 
     // Park → resume: a new op continues the run paused on this tool's approval.
     this.#emitRunResumed(effectiveContext, {
@@ -445,6 +467,8 @@ export class ConversationControlActionImpl {
 
     const optimisticContext: OptimisticUpdateContext = { operationId };
     const shouldCreateUserMessage = options?.createUserMessage !== false;
+
+    this.#writeTopicStatus(effectiveContext, 'active');
 
     // Park → resume: a new op continues the run paused on this tool interaction.
     this.#emitRunResumed(effectiveContext, {
@@ -671,6 +695,8 @@ export class ConversationControlActionImpl {
 
     const optimisticContext: OptimisticUpdateContext = { operationId };
 
+    this.#writeTopicStatus(effectiveContext, 'active');
+
     // Park → resume: a new op continues the run paused on this tool interaction.
     this.#emitRunResumed(effectiveContext, {
       operationId,
@@ -782,6 +808,8 @@ export class ConversationControlActionImpl {
     });
 
     const optimisticContext = { operationId };
+
+    this.#writeTopicStatus(effectiveContext, 'active');
 
     await this.#get().optimisticUpdateMessagePlugin(
       toolMessageId,
@@ -1050,6 +1078,8 @@ export class ConversationControlActionImpl {
 
     const optimisticContext = { operationId };
 
+    this.#writeTopicStatus(effectiveContext, 'active');
+
     // Optimistic update - update status to rejected and save reason
     const intervention = {
       rejectedReason: reason,
@@ -1164,6 +1194,7 @@ export class ConversationControlActionImpl {
       });
 
       const optimisticContext = { operationId };
+      this.#writeTopicStatus(effectiveContext, 'active');
       // Park → resume: the new gateway op continues the run paused on this tool.
       this.#emitRunResumed(effectiveContext, {
         operationId,

--- a/src/store/chat/slices/agentRun/actions/entries/conversationControl.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationControl.ts
@@ -315,14 +315,15 @@ export class ConversationControlActionImpl {
     });
 
     const optimisticContext = { operationId };
+    const shouldUseGatewayResume = this.#shouldUseGatewayResume(effectiveContext);
 
-    this.#writeTopicStatus(effectiveContext, 'active');
+    if (!shouldUseGatewayResume) this.#writeTopicStatus(effectiveContext, 'active');
 
     // Park → resume: a new op continues the run paused on this tool's approval.
     this.#emitRunResumed(effectiveContext, {
       operationId,
       parentMessageId: toolMessageId,
-      runtimeType: this.#shouldUseGatewayResume(effectiveContext) ? 'gateway' : 'client',
+      runtimeType: shouldUseGatewayResume ? 'gateway' : 'client',
     });
 
     // 2. Update intervention status to approved
@@ -338,7 +339,7 @@ export class ConversationControlActionImpl {
     // message, persists `intervention=approved`, dispatches the approved
     // tool, and streams results back on the new op. No in-place resume of
     // the paused op — simpler state + avoids stepIndex races.
-    if (this.#shouldUseGatewayResume(effectiveContext)) {
+    if (shouldUseGatewayResume) {
       const toolCallId = toolMessage.tool_call_id;
       if (!toolCallId) {
         console.warn(
@@ -364,6 +365,7 @@ export class ConversationControlActionImpl {
             toolCallId,
           },
         });
+        this.#writeTopicStatus(effectiveContext, 'active');
         this.#completeOpsById(pausedOpIds);
         completeOperation(operationId);
       } catch (error) {
@@ -467,14 +469,15 @@ export class ConversationControlActionImpl {
 
     const optimisticContext: OptimisticUpdateContext = { operationId };
     const shouldCreateUserMessage = options?.createUserMessage !== false;
+    const shouldUseGatewayResume = this.#shouldUseGatewayResume(effectiveContext);
 
-    this.#writeTopicStatus(effectiveContext, 'active');
+    if (!shouldUseGatewayResume) this.#writeTopicStatus(effectiveContext, 'active');
 
     // Park → resume: a new op continues the run paused on this tool interaction.
     this.#emitRunResumed(effectiveContext, {
       operationId,
       parentMessageId: toolMessageId,
-      runtimeType: this.#shouldUseGatewayResume(effectiveContext) ? 'gateway' : 'client',
+      runtimeType: shouldUseGatewayResume ? 'gateway' : 'client',
     });
 
     // 1. Mark intervention as approved and set tool result to user's response
@@ -506,7 +509,7 @@ export class ConversationControlActionImpl {
     // resumes from `phase: 'tool_result'` (NO re-execution). The synthetic user
     // message (2b) is not needed — the server continues from the answered tool
     // call. Mirrors approveToolCalling's gateway branch.
-    if (this.#shouldUseGatewayResume(effectiveContext)) {
+    if (shouldUseGatewayResume) {
       const toolCallId = toolMessage.tool_call_id;
       if (!toolCallId) {
         console.warn(
@@ -533,6 +536,7 @@ export class ConversationControlActionImpl {
             ...(options?.pluginState ? { pluginState: options.pluginState } : {}),
           },
         });
+        this.#writeTopicStatus(effectiveContext, 'active');
         this.#completeOpsById(pausedOpIds);
         completeOperation(operationId);
       } catch (error) {
@@ -1077,8 +1081,9 @@ export class ConversationControlActionImpl {
     });
 
     const optimisticContext = { operationId };
+    const shouldUseGatewayResume = this.#shouldUseGatewayResume(effectiveContext);
 
-    this.#writeTopicStatus(effectiveContext, 'active');
+    if (!shouldUseGatewayResume) this.#writeTopicStatus(effectiveContext, 'active');
 
     // Optimistic update - update status to rejected and save reason
     const intervention = {
@@ -1108,7 +1113,7 @@ export class ConversationControlActionImpl {
     // `rejected_continue` share the same code path (both surface the
     // rejection to the LLM as user feedback), so a separate `rejected`
     // decision adds complexity without behavioural difference.
-    if (this.#shouldUseGatewayResume(effectiveContext)) {
+    if (shouldUseGatewayResume) {
       const toolCallId = toolMessage.tool_call_id;
       if (!toolCallId) {
         console.warn(
@@ -1137,6 +1142,7 @@ export class ConversationControlActionImpl {
             toolCallId,
           },
         });
+        this.#writeTopicStatus(effectiveContext, 'active');
         this.#completeOpsById(pausedOpIds);
       } catch (error) {
         console.error('[rejectToolCalling][server] Gateway resume failed:', error);
@@ -1194,7 +1200,6 @@ export class ConversationControlActionImpl {
       });
 
       const optimisticContext = { operationId };
-      this.#writeTopicStatus(effectiveContext, 'active');
       // Park → resume: the new gateway op continues the run paused on this tool.
       this.#emitRunResumed(effectiveContext, {
         operationId,
@@ -1229,6 +1234,7 @@ export class ConversationControlActionImpl {
             toolCallId,
           },
         });
+        this.#writeTopicStatus(effectiveContext, 'active');
         this.#completeOpsById(pausedOpIds);
         completeOperation(operationId);
       } catch (error) {

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.test.ts
@@ -33,7 +33,11 @@ vi.mock('@lobechat/const', async (importOriginal) => {
 });
 
 const OP = 'op1';
-const CONTEXT: ConversationContext = { agentId: 'a1', topicId: 't1' } as ConversationContext;
+const CONTEXT: ConversationContext = {
+  agentId: 'a1',
+  topicId: 't1',
+  workspaceSlug: 'team',
+} as ConversationContext;
 
 const makeStore = (afterCompletionCallbacks?: Array<() => void>) => {
   const store = {
@@ -50,7 +54,7 @@ const makeStore = (afterCompletionCallbacks?: Array<() => void>) => {
     messagesMap: {},
     operations: {
       [OP]: {
-        context: { agentId: 'a1', topicId: 't1' },
+        context: CONTEXT,
         metadata: afterCompletionCallbacks ? { runtimeHooks: { afterCompletionCallbacks } } : {},
         status: 'running',
       },
@@ -234,7 +238,10 @@ describe('buildRunLifecycle.afterRunComplete — client desktop notification bod
     expect(desktopNotificationMock.notifyDesktopAgentCompleted).toHaveBeenCalledTimes(1);
     expect(desktopNotificationMock.notifyDesktopAgentCompleted).toHaveBeenCalledWith(
       get,
-      expect.objectContaining({ content: 'second turn reply' }),
+      expect.objectContaining({
+        content: 'second turn reply',
+        context: expect.objectContaining({ workspaceSlug: 'team' }),
+      }),
     );
   });
 

--- a/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/lifecycle/buildRunLifecycle.ts
@@ -137,7 +137,7 @@ export const buildRunLifecycle = (
   adapter: RunAdapterContext,
 ): AgentRunLifecycle => {
   const { context, parentMessageId, parentMessageType } = adapter;
-  const { agentId, topicId, threadId, groupId } = context;
+  const { agentId, topicId, threadId, groupId, workspaceSlug } = context;
   const messageKey = messageMapKey(context);
   const contextKey = messageKey;
 
@@ -248,7 +248,7 @@ export const buildRunLifecycle = (
       if (adapter.runScope === 'sub_agent') return;
       if (!isDesktop) return;
 
-      const notificationContext = { agentId, groupId, topicId };
+      const notificationContext = { agentId, groupId, topicId, workspaceSlug };
 
       if (adapter.runtimeType === 'client') {
         // CLIENT: notify only OUTSIDE tool-calling mode; content comes from the

--- a/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
@@ -710,11 +710,21 @@ export class StreamingExecutorActionImpl {
           }
 
           case 'human_approve_required': {
-            await notifyDesktopHumanApprovalRequired(this.#get, {
-              agentId,
-              groupId,
-              topicId,
-            });
+            await notifyDesktopHumanApprovalRequired(this.#get, context);
+            if (topicId) {
+              const statusWrite = this.#get().updateTopicStatus?.({
+                agentId,
+                groupId,
+                ...(context.scope === 'group' || context.scope === 'group_agent'
+                  ? { scope: context.scope }
+                  : {}),
+                status: 'waitingForHuman',
+                topicId,
+              });
+              void statusWrite?.catch((error) => {
+                console.error('[streamingExecutor] updateTopicStatus failed:', error);
+              });
+            }
             break;
           }
 
@@ -881,12 +891,16 @@ export class StreamingExecutorActionImpl {
       void this.#get().refreshThreads();
 
       // 2. Build the sub-agent ConversationContext (threadId provides isolation)
+      const workspaceSlug = parentOperationId
+        ? this.#get().operations[parentOperationId]?.context.workspaceSlug
+        : undefined;
       const subContext: ConversationContext = {
         agentId,
         isSubAgent: true,
         scope: 'thread',
         threadId,
         topicId,
+        ...(workspaceSlug ? { workspaceSlug } : {}),
       };
 
       // 3. Create a child operation chained to the parent runtime operation

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -636,16 +636,22 @@ export const createGatewayEventHandler = (
 
         if (data?.phase === 'human_approval' && data.requiresApproval && data.pendingToolsCalling) {
           void notifyDesktopHumanApprovalRequired(get, context);
-          // Persist a paused marker so the sidebar reflects "waiting on user" across reload.
-          // Resume back to 'running' is free: approve / reject both spawn a new op via the
-          // executor entries, which already write 'running'.
-          if (context.topicId)
-            void get().updateTopicStatus?.({
+          // Persist the explicit "needs user input" marker so the sidebar swaps
+          // the running spinner for the hand icon across reloads.
+          if (context.topicId) {
+            const statusWrite = get().updateTopicStatus?.({
               agentId: context.agentId,
               groupId: context.groupId,
-              status: 'paused',
+              ...(context.scope === 'group' || context.scope === 'group_agent'
+                ? { scope: context.scope }
+                : {}),
+              status: 'waitingForHuman',
               topicId: context.topicId,
             });
+            void statusWrite?.catch((error) => {
+              console.error('[gatewayEventHandler] updateTopicStatus failed:', error);
+            });
+          }
         }
 
         break;

--- a/src/store/chat/slices/aiAgent/actions/__tests__/runAgent.test.ts
+++ b/src/store/chat/slices/aiAgent/actions/__tests__/runAgent.test.ts
@@ -348,6 +348,9 @@ describe('runAgent actions', () => {
         const context = createStreamingContext({
           assistantId: TEST_IDS.ASSISTANT_MESSAGE_ID,
         });
+        const updateTopicStatusSpy = vi
+          .spyOn(result.current, 'updateTopicStatus')
+          .mockResolvedValue(undefined as any);
 
         const event: StreamEvent = {
           type: 'step_start',
@@ -377,6 +380,14 @@ describe('runAgent actions', () => {
           expect.objectContaining({
             agentId: 'agent-1',
             groupId: 'group-1',
+            topicId: 'topic-1',
+          }),
+        );
+        expect(updateTopicStatusSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            agentId: 'agent-1',
+            groupId: 'group-1',
+            status: 'waitingForHuman',
             topicId: 'topic-1',
           }),
         );

--- a/src/store/chat/slices/aiAgent/actions/runAgent.ts
+++ b/src/store/chat/slices/aiAgent/actions/runAgent.ts
@@ -301,6 +301,20 @@ export class AgentActionImpl {
           });
 
           await notifyDesktopHumanApprovalRequired(this.#get, operation.context);
+          if (operation.context.topicId) {
+            const statusWrite = this.#get().updateTopicStatus?.({
+              agentId: operation.context.agentId,
+              groupId: operation.context.groupId,
+              ...(operation.context.scope === 'group' || operation.context.scope === 'group_agent'
+                ? { scope: operation.context.scope }
+                : {}),
+              status: 'waitingForHuman',
+              topicId: operation.context.topicId,
+            });
+            void statusWrite?.catch((error) => {
+              console.error('[runAgent] updateTopicStatus failed:', error);
+            });
+          }
 
           // Stop loading state, waiting for human intervention
           log(`Stopping loading for human approval: ${assistantId}`);

--- a/src/store/chat/utils/desktopNotification.test.ts
+++ b/src/store/chat/utils/desktopNotification.test.ts
@@ -76,6 +76,15 @@ describe('resolveNotificationNavigatePath', () => {
       path: AGENT_CHAT_TOPIC_URL('a1', 't1'),
     });
   });
+
+  it('marks workspace notification navigation as escaped after prefixing the path', () => {
+    expect(
+      resolveNotificationNavigate({ agentId: 'a1', topicId: 't1', workspaceSlug: 'team' }),
+    ).toEqual({
+      escape: true,
+      path: '/team/agent/a1/t1',
+    });
+  });
 });
 
 describe('resolveNotificationTitle', () => {

--- a/src/store/chat/utils/desktopNotification.test.ts
+++ b/src/store/chat/utils/desktopNotification.test.ts
@@ -1,10 +1,16 @@
-import { AGENT_CHAT_TOPIC_URL, AGENT_CHAT_URL, GROUP_CHAT_URL } from '@lobechat/const';
+import {
+  AGENT_CHAT_TOPIC_URL,
+  AGENT_CHAT_URL,
+  GROUP_CHAT_TOPIC_URL,
+  GROUP_CHAT_URL,
+} from '@lobechat/const';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { ChatStore } from '@/store/chat/store';
 
 import {
   buildNotificationBody,
+  resolveNotificationNavigate,
   resolveNotificationNavigatePath,
   resolveNotificationTitle,
 } from './desktopNotification';
@@ -27,24 +33,56 @@ describe('resolveNotificationNavigatePath', () => {
     );
   });
 
+  it('preserves the originating workspace for agent topics', () => {
+    expect(
+      resolveNotificationNavigatePath({ agentId: 'a1', topicId: 't1', workspaceSlug: 'team' }),
+    ).toBe('/team/agent/a1/t1');
+  });
+
   it('falls back to the agent root when there is no topic', () => {
     expect(resolveNotificationNavigatePath({ agentId: 'a1' })).toBe(AGENT_CHAT_URL('a1'));
   });
 
-  it('lands a group chat on the group root, taking precedence over agent/topic', () => {
+  it('deep-links a group chat to the specific topic, taking precedence over agent/topic', () => {
+    expect(resolveNotificationNavigatePath({ agentId: 'a1', groupId: 'g1', topicId: 't1' })).toBe(
+      GROUP_CHAT_TOPIC_URL('g1', 't1'),
+    );
+  });
+
+  it('preserves the originating workspace for group topics', () => {
     expect(
-      resolveNotificationNavigatePath({ agentId: 'a1', groupId: 'g1', topicId: 't1' }),
-    ).toBe(GROUP_CHAT_URL('g1'));
+      resolveNotificationNavigatePath({
+        agentId: 'a1',
+        groupId: 'g1',
+        topicId: 't1',
+        workspaceSlug: 'team',
+      }),
+    ).toBe('/team/group/g1/t1');
+  });
+
+  it('falls back to the group root when there is no topic', () => {
+    expect(resolveNotificationNavigatePath({ agentId: 'a1', groupId: 'g1' })).toBe(
+      GROUP_CHAT_URL('g1'),
+    );
   });
 
   it('returns undefined when there is no routable context', () => {
     expect(resolveNotificationNavigatePath({})).toBeUndefined();
   });
+
+  it('marks notification navigation as escaped so renderer uses the path literally', () => {
+    expect(resolveNotificationNavigate({ agentId: 'a1', topicId: 't1' })).toEqual({
+      escape: true,
+      path: AGENT_CHAT_TOPIC_URL('a1', 't1'),
+    });
+  });
 });
 
 describe('resolveNotificationTitle', () => {
-  const makeGet = (topicDataMap: unknown): (() => ChatStore) =>
-    (() => ({ topicDataMap }) as unknown as ChatStore);
+  const makeGet =
+    (topicDataMap: unknown): (() => ChatStore) =>
+    () =>
+      ({ topicDataMap }) as unknown as ChatStore;
 
   it('prefers the topic title', () => {
     const key = topicMapKey({ agentId: 'agent-named' });

--- a/src/store/chat/utils/desktopNotification.ts
+++ b/src/store/chat/utils/desktopNotification.ts
@@ -1,4 +1,10 @@
-import { AGENT_CHAT_TOPIC_URL, AGENT_CHAT_URL, GROUP_CHAT_URL, isDesktop } from '@lobechat/const';
+import {
+  AGENT_CHAT_TOPIC_URL,
+  AGENT_CHAT_URL,
+  GROUP_CHAT_TOPIC_URL,
+  GROUP_CHAT_URL,
+  isDesktop,
+} from '@lobechat/const';
 import type { ConversationContext } from '@lobechat/types';
 import { t } from 'i18next';
 
@@ -13,26 +19,46 @@ export interface DesktopNotificationContext {
   agentId?: ConversationContext['agentId'];
   groupId?: ConversationContext['groupId'];
   topicId?: ConversationContext['topicId'];
+  workspaceSlug?: ConversationContext['workspaceSlug'];
 }
 
 /** Cap the notification body so a long reply doesn't overflow the OS banner. */
 const NOTIFICATION_BODY_MAX_LENGTH = 256;
 
+const applyWorkspaceSlug = (path: string, workspaceSlug?: string): string =>
+  workspaceSlug ? `/${workspaceSlug}${path}` : path;
+
 /**
  * Resolve the SPA path that should be opened when the user clicks a desktop
- * notification, based on the conversation context. Group chats land on the
- * group root (topic is selected from store), 1:1 chats deep-link to the
- * specific topic.
+ * notification, based on the conversation context. Topic-aware contexts
+ * deep-link to the specific topic so clicking from another tab/topic still
+ * lands on the completed run.
  */
 export const resolveNotificationNavigatePath = (
   context: DesktopNotificationContext,
 ): string | undefined => {
-  if (context.groupId) return GROUP_CHAT_URL(context.groupId);
+  if (context.groupId && context.topicId)
+    return applyWorkspaceSlug(
+      GROUP_CHAT_TOPIC_URL(context.groupId, context.topicId),
+      context.workspaceSlug,
+    );
+  if (context.groupId)
+    return applyWorkspaceSlug(GROUP_CHAT_URL(context.groupId), context.workspaceSlug);
   if (context.agentId && context.topicId) {
-    return AGENT_CHAT_TOPIC_URL(context.agentId, context.topicId);
+    return applyWorkspaceSlug(
+      AGENT_CHAT_TOPIC_URL(context.agentId, context.topicId),
+      context.workspaceSlug,
+    );
   }
-  if (context.agentId) return AGENT_CHAT_URL(context.agentId);
+  if (context.agentId)
+    return applyWorkspaceSlug(AGENT_CHAT_URL(context.agentId), context.workspaceSlug);
   return undefined;
+};
+
+export const resolveNotificationNavigate = (context: DesktopNotificationContext) => {
+  const path = resolveNotificationNavigatePath(context);
+
+  return path ? { escape: true, path } : undefined;
 };
 
 /**
@@ -87,14 +113,14 @@ export const notifyDesktopHumanApprovalRequired = async (
       t('desktopNotification.humanApprovalRequired.title', { ns: 'chat' }),
     );
 
-    const navigatePath = resolveNotificationNavigatePath(context);
+    const navigate = resolveNotificationNavigate(context);
 
     await Promise.allSettled([
       desktopNotificationService.setBadgeCount(1),
       desktopNotificationService.showNotification({
         body: t('desktopNotification.humanApprovalRequired.body', { ns: 'chat' }),
         force: true,
-        navigate: navigatePath ? { path: navigatePath } : undefined,
+        navigate,
         requestAttention: true,
         title,
       }),
@@ -133,12 +159,12 @@ export const notifyDesktopAgentCompleted = async (
   try {
     const { desktopNotificationService } = await import('@/services/electron/desktopNotification');
     const fallback = t('notification.finishChatGeneration', { ns: 'electron' });
-    const navigatePath = resolveNotificationNavigatePath(context);
+    const navigate = resolveNotificationNavigate(context);
 
     const tasks: Promise<unknown>[] = [
       desktopNotificationService.showNotification({
         body: buildNotificationBody(content, fallback),
-        navigate: navigatePath ? { path: navigatePath } : undefined,
+        navigate,
         title: resolveNotificationTitle(get, context, fallback),
       }),
     ];

--- a/src/store/home/slices/homeInput/action.test.ts
+++ b/src/store/home/slices/homeInput/action.test.ts
@@ -179,6 +179,18 @@ describe('HomeInputActionImpl', () => {
         }),
       );
     });
+
+    it('passes the workspace slug to the agent builder message context', async () => {
+      const action = createAction();
+
+      await action.sendAsAgent({ message: 'build a support agent', workspaceSlug: 'team' });
+
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: { agentId: 'agentBuilder', scope: 'agent_builder', workspaceSlug: 'team' },
+        }),
+      );
+    });
   });
 
   describe('sendAsGroup', () => {
@@ -193,6 +205,22 @@ describe('HomeInputActionImpl', () => {
         expect.objectContaining({
           context: { agentId: 'groupAgentBuilder', scope: 'group_agent_builder' },
           message: 'build a research group',
+        }),
+      );
+    });
+
+    it('passes the workspace slug to the group builder message context', async () => {
+      const action = createAction();
+
+      await action.sendAsGroup({ message: 'build a research group', workspaceSlug: 'team' });
+
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: {
+            agentId: 'groupAgentBuilder',
+            scope: 'group_agent_builder',
+            workspaceSlug: 'team',
+          },
         }),
       );
     });
@@ -212,6 +240,23 @@ describe('HomeInputActionImpl', () => {
         expect.objectContaining({
           context: { agentId: 'pageAgent', documentId: 'doc-new', scope: 'page' },
           message: 'write me a doc',
+        }),
+      );
+    });
+
+    it('passes the workspace slug to the page agent message context', async () => {
+      const action = createAction();
+
+      await action.sendAsWrite({ message: 'write me a doc', workspaceSlug: 'team' });
+
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: {
+            agentId: 'pageAgent',
+            documentId: 'doc-new',
+            scope: 'page',
+            workspaceSlug: 'team',
+          },
         }),
       );
     });

--- a/src/store/home/slices/homeInput/action.ts
+++ b/src/store/home/slices/homeInput/action.ts
@@ -26,6 +26,7 @@ interface SendMessageWithEditorParams {
   groupId?: string;
   message: string;
   pageSelections?: PageSelection[];
+  workspaceSlug?: string | null;
 }
 
 /**
@@ -70,6 +71,7 @@ export class HomeInputActionImpl {
     groupId,
     message,
     pageSelections,
+    workspaceSlug,
   }: SendMessageWithEditorParams): Promise<string> => {
     this.#set({ homeInputLoading: true }, false, n('sendAsAgent/start'));
 
@@ -135,7 +137,11 @@ export class HomeInputActionImpl {
 
         if (agentBuilderId) {
           await sendMessage({
-            context: { agentId: agentBuilderId, scope: 'agent_builder' },
+            context: {
+              agentId: agentBuilderId,
+              scope: 'agent_builder',
+              ...(workspaceSlug ? { workspaceSlug } : {}),
+            },
             contextSelections,
             editorData,
             message,
@@ -159,6 +165,7 @@ export class HomeInputActionImpl {
     groupId,
     message,
     pageSelections,
+    workspaceSlug,
   }: SendMessageWithEditorParams): Promise<string> => {
     this.#set({ homeInputLoading: true }, false, n('sendAsGroup/start'));
 
@@ -210,7 +217,11 @@ export class HomeInputActionImpl {
 
         const { sendMessage } = useChatStore.getState();
         await sendMessage({
-          context: { agentId: groupAgentBuilderId, scope: 'group_agent_builder' },
+          context: {
+            agentId: groupAgentBuilderId,
+            scope: 'group_agent_builder',
+            ...(workspaceSlug ? { workspaceSlug } : {}),
+          },
           contextSelections,
           editorData,
           message,
@@ -240,6 +251,7 @@ export class HomeInputActionImpl {
     editorData,
     message,
     pageSelections,
+    workspaceSlug,
   }: SendMessageWithEditorParams): Promise<string> => {
     this.#set({ homeInputLoading: true }, false, n('sendAsWrite/start'));
 
@@ -280,7 +292,12 @@ export class HomeInputActionImpl {
           // has not mounted yet, so the page editor runtime singleton may still
           // be bound to the previously open document — relying on its fallback
           // here would scope server-side PageAgent tools to the wrong document.
-          context: { agentId: pageAgentId, documentId: newDoc.id, scope: 'page' },
+          context: {
+            agentId: pageAgentId,
+            documentId: newDoc.id,
+            scope: 'page',
+            ...(workspaceSlug ? { workspaceSlug } : {}),
+          },
           contextSelections,
           editorData,
           message,


### PR DESCRIPTION
## Summary

- Capture `workspaceSlug` in conversation contexts and carry it through agent/group/sub-agent run contexts.
- Resolve desktop notification clicks to literal topic deep links for agent and group chats, then pass `escape: true` through the Electron navigation broadcast so the renderer does not reinterpret the path under the currently active workspace/tab.
- Keep human-approval notification topics in `waitingForHuman`, and restore topic status to `active` when approval/reject/input resumes the run.

## Root cause

Desktop notification navigation was not carrying the full out-of-band routing context. Group notifications landed on the group root instead of the concrete topic, and workspace-aware renderer navigation could prefix/reinterpret paths using the currently active workspace. That made notification clicks unreliable when the user was in another tab, another workspace, or another topic.

## Validation

- `bun run check ... --lint --test` on the scoped notification/approval files: 23 files lint clean, 281 tests passed.
- `git diff --check` passed.
- Electron live-code rendered-surface: started an isolated desktop dev instance, invoked real `notification.showDesktopNotification` from `/`, auto-triggered the same main-process `Notification.on("click")` handler with a test probe, verified `broadcast("navigate")` -> `DesktopNavigationBridge` -> `/agent/agt_nPlJokZw3epa/tpc_F19mtmdtssQ9`, and captured the final real topic screenshot.
- `bun run check --type` is currently blocked by existing Drizzle/dayjs multi-version type conflicts outside this change; touched-path filtering of the saved type log returned 0 matching errors.
- Verification report: https://app.lobehub.com/verify/14bc3c7e-f71f-437c-84e1-daa340270899

Refs LOBE-10457
