### PR TITLE
Fix home cache sync before paint

### DIFF
--- a/src/libs/swr/useClientDataSWRWithSync.test.tsx
+++ b/src/libs/swr/useClientDataSWRWithSync.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { render } from '@testing-library/react';
+import { useLayoutEffect } from 'react';
+import type { SWRResponse } from 'swr';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useClientDataSWR } from './index';
+import { useClientDataSWRWithSync } from './useClientDataSWRWithSync';
+
+vi.mock('./index', () => ({
+  useClientDataSWR: vi.fn(),
+}));
+
+const swrResponse = <T,>(data: T): SWRResponse<T> =>
+  ({
+    data,
+    error: undefined,
+    isLoading: false,
+    isValidating: false,
+    mutate: vi.fn(),
+  }) as unknown as SWRResponse<T>;
+
+interface ProbeProps {
+  cacheKey: string | readonly unknown[];
+  onData: (data: unknown) => void;
+  onLayoutRead?: () => void;
+}
+
+const Probe = ({ cacheKey, onData, onLayoutRead }: ProbeProps) => {
+  useClientDataSWRWithSync(cacheKey, null, { onData });
+
+  useLayoutEffect(() => {
+    onLayoutRead?.();
+  });
+
+  return null;
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useClientDataSWRWithSync', () => {
+  it('syncs cached data before consumer layout effects run', () => {
+    const cached = { items: ['cached'] };
+    let mirrored: unknown;
+    let observedDuringLayout: unknown;
+
+    vi.mocked(useClientDataSWR).mockReturnValue(swrResponse(cached));
+
+    render(
+      <Probe
+        cacheKey={['agent:list', true]}
+        onData={(data) => {
+          mirrored = data;
+        }}
+        onLayoutRead={() => {
+          observedDuringLayout = mirrored;
+        }}
+      />,
+    );
+
+    expect(observedDuringLayout).toBe(cached);
+  });
+
+  it('syncs the same cached data again when the SWR key changes', () => {
+    const cached = { items: ['same-reference'] };
+    const onData = vi.fn();
+
+    vi.mocked(useClientDataSWR).mockReturnValue(swrResponse(cached));
+
+    const { rerender } = render(<Probe cacheKey={['agent:list', true]} onData={onData} />);
+
+    expect(onData).toHaveBeenCalledTimes(1);
+
+    rerender(<Probe cacheKey={['agent:list', true, 'workspace-a']} onData={onData} />);
+
+    expect(onData).toHaveBeenCalledTimes(2);
+    expect(onData).toHaveBeenLastCalledWith(cached);
+  });
+
+  it('syncs null as settled cached data', () => {
+    const onData = vi.fn();
+
+    vi.mocked(useClientDataSWR).mockReturnValue(swrResponse(null));
+
+    render(<Probe cacheKey="nullable:key" onData={onData} />);
+
+    expect(onData).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/libs/swr/useClientDataSWRWithSync.ts
+++ b/src/libs/swr/useClientDataSWRWithSync.ts
@@ -9,12 +9,20 @@
  * SWR key — consumers never need to opt in per call.
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useLayoutEffect, useRef } from 'react';
 import { type SWRConfiguration, type SWRResponse } from 'swr';
 
 import { useClientDataSWR } from './index';
 
 type Key = string | readonly unknown[] | null | undefined;
+
+const useBrowserLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+const serializeSyncKey = (key: Key): string => {
+  if (key == null) return '';
+  if (Array.isArray(key)) return JSON.stringify(key);
+  return String(key);
+};
 
 interface UseClientDataSWRWithSyncOptions<T> extends SWRConfiguration<T> {
   /**
@@ -52,7 +60,8 @@ export function useClientDataSWRWithSync<T>(
   options?: UseClientDataSWRWithSyncOptions<T>,
 ): SWRResponse<T> {
   const { onData, skipSync, onSuccess, ...swrOptions } = options || {};
-  const hasSyncedRef = useRef(false);
+  const keySignature = serializeSyncKey(key);
+  const lastSyncedRef = useRef<{ data: T; key: string } | null>(null);
 
   const response = useClientDataSWR<T>(key, fetcher, {
     ...swrOptions,
@@ -62,25 +71,25 @@ export function useClientDataSWRWithSync<T>(
       // Also sync via onData
       if (onData && !skipSync) {
         onData(data);
-        hasSyncedRef.current = true;
+        lastSyncedRef.current = { data, key: keySignature };
       }
     },
   });
 
   const { data } = response;
 
-  // When cached data is available, sync to store immediately
-  useEffect(() => {
-    if (data && onData && !skipSync && !hasSyncedRef.current) {
-      onData(data);
-      hasSyncedRef.current = true;
-    }
-  }, [data, onData, skipSync]);
+  // When cached data is available, sync to store before the browser paints.
+  useBrowserLayoutEffect(() => {
+    if (data === undefined || !onData || skipSync) return;
 
-  // Reset sync state when key changes
-  useEffect(() => {
-    hasSyncedRef.current = false;
-  }, [key?.toString()]);
+    const lastSynced = lastSyncedRef.current;
+    if (lastSynced?.key === keySignature && lastSynced.data === data) {
+      return;
+    }
+
+    onData(data);
+    lastSyncedRef.current = { data, key: keySignature };
+  }, [data, keySignature, onData, skipSync]);
 
   return response;
 }


### PR DESCRIPTION
## Summary

- Sync persisted SWR data back into Zustand before the browser paints on the client.
- Track the last synced cache key together with the data reference so key changes re-sync correctly.
- Add regression coverage for pre-paint sync, key-change re-sync, and null cached payloads.

## Root Cause

Home reads mirrored Zustand state while SWR owns the persisted cache. `useClientDataSWRWithSync` previously mirrored cached SWR data in a normal effect, so the first paint could still see an uninitialized store and show skeleton/default UI, making the persisted cache look ineffective.

## Validation

- `bunx vitest run --silent='passed-only' src/libs/swr/useClientDataSWRWithSync.test.tsx`
- `bunx vitest run --silent='passed-only' src/libs/swr/localStorageProvider.test.ts src/libs/swr/cacheProvider.integration.test.tsx src/layout/GlobalProvider/CacheHydrationGate.test.tsx`
- `bun run check src/libs/swr/useClientDataSWRWithSync.ts src/libs/swr/useClientDataSWRWithSync.test.tsx --lint --test`

Note: `bun run check ... --type` was attempted from the main worktree and is currently blocked by existing repo-wide duplicate dependency type conflicts (Drizzle/React/antd/dayjs) plus an existing chat test type error, unrelated to this change.
