### PR TITLE
🐛 fix: hide agent signal threads from topic lists

### DIFF
--- a/packages/database/src/models/__tests__/thread.test.ts
+++ b/packages/database/src/models/__tests__/thread.test.ts
@@ -1,9 +1,9 @@
-import { ThreadStatus, ThreadType } from '@lobechat/types';
+import { RequestTrigger, ThreadStatus, ThreadType } from '@lobechat/types';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
-import { messages, sessions, threads, topics, users } from '../../schemas';
+import { agentOperations, messages, sessions, threads, topics, users } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
 import { ThreadModel } from '../thread';
 
@@ -243,6 +243,41 @@ describe('ThreadModel', () => {
       expect(thread.metadata?.totalTokens).toBeUndefined();
       expect(thread.metadata?.totalToolCalls).toBeUndefined();
       expect(thread.metadata?.model).toBeUndefined();
+    });
+
+    it('hides agent-signal isolation threads from topic thread lists', async () => {
+      await serverDB.transaction(async (tx) => {
+        await tx.insert(threads).values([
+          {
+            id: 'visible-subagent-thread',
+            status: ThreadStatus.Active,
+            title: 'Visible subagent',
+            topicId,
+            type: ThreadType.Isolation,
+            userId,
+          },
+          {
+            id: 'agent-signal-thread',
+            status: ThreadStatus.Active,
+            title: 'Agent Signal Skill',
+            topicId,
+            type: ThreadType.Isolation,
+            userId,
+          },
+        ]);
+        await tx.insert(agentOperations).values({
+          id: 'agent-signal-operation',
+          status: 'done',
+          threadId: 'agent-signal-thread',
+          topicId,
+          trigger: RequestTrigger.AgentSignal,
+          userId,
+        });
+      });
+
+      const result = await threadModel.queryByTopicId(topicId);
+
+      expect(result.map((thread) => thread.id)).toEqual(['visible-subagent-thread']);
     });
   });
 

--- a/packages/database/src/models/thread.ts
+++ b/packages/database/src/models/thread.ts
@@ -1,9 +1,9 @@
 import type { CreateThreadParams } from '@lobechat/types';
-import { ThreadStatus } from '@lobechat/types';
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { RequestTrigger, ThreadStatus } from '@lobechat/types';
+import { and, desc, eq, notExists, sql } from 'drizzle-orm';
 
 import type { ThreadItem } from '../schemas';
-import { messages, threads } from '../schemas';
+import { agentOperations, messages, threads } from '../schemas';
 import type { LobeChatDatabase } from '../type';
 import { buildWorkspacePayload, buildWorkspaceWhere } from '../utils/workspace';
 
@@ -121,7 +121,29 @@ export class ThreadModel {
       .select({ ...queryColumns, ...subagentMetricColumns })
       .from(threads)
       .leftJoin(messages, eq(messages.threadId, threads.id))
-      .where(and(eq(threads.topicId, topicId), this.ownership()))
+      .where(
+        and(
+          eq(threads.topicId, topicId),
+          this.ownership(),
+          // NOTICE:
+          // Agent Signal self-iteration runs create isolation threads to keep
+          // internal memory/skill traces out of the main chat transcript.
+          // Those traces are persisted for audit/debugging through
+          // `agent_operations.trigger = agent_signal`, but should not appear as
+          // user-facing sub-agent attachments in the topic thread list.
+          notExists(
+            this.db
+              .select({ id: agentOperations.id })
+              .from(agentOperations)
+              .where(
+                and(
+                  eq(agentOperations.threadId, threads.id),
+                  eq(agentOperations.trigger, RequestTrigger.AgentSignal),
+                ),
+              ),
+          ),
+        ),
+      )
       .groupBy(threads.id)
       .orderBy(desc(threads.updatedAt));
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Hide Agent Signal self-iteration isolation threads from topic thread lists.
- Keep normal isolation/sub-agent threads visible.
- Preserve Agent Signal thread rows and operation records for audit/debugging.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Automated:

- `pnpm -C lobehub/packages/database exec vitest run --silent='passed-only' 'src/models/__tests__/thread.test.ts'`
- `pnpm run type-check`
- `pnpm --dir lobehub exec eslint packages/database/src/models/thread.ts packages/database/src/models/__tests__/thread.test.ts --concurrency=auto`

Notes:

- `pnpm lint` in the cloud repo could not run because `bun` is unavailable in this local shell.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Agent Signal background memory/skill runs create isolation threads so their internal traces do not flatten into the main chat transcript. This PR keeps those persisted traces available through `agent_operations.trigger = agent_signal`, but excludes them from user-facing topic thread lists.
