### PR TITLE
🐛 fix(ProviderConfig): reset form fields to prevent leaking old values on provider switch

### DIFF
--- a/src/routes/(main)/settings/provider/features/ProviderConfig/index.tsx
+++ b/src/routes/(main)/settings/provider/features/ProviderConfig/index.tsx
@@ -236,6 +236,9 @@ const ProviderConfig = memo<ProviderConfigProps>(
         ...(providerRuntimeConfig?.config && { config: providerRuntimeConfig.config }),
       };
 
+      // Clear the previous provider's field state first so omitted keys do not
+      // leak old values when the next provider has empty credentials.
+      form.resetFields();
       // Set form values and mark as initialized
       form.setFieldsValue(mergedData);
       lastInitializedIdRef.current = id;


### PR DESCRIPTION

#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #16833

<!-- Link to the issue that is fixed by this PR -->

<!-- Example: Fixes #xxx, Closes #xxx, Related to #xxx -->

#### 🔀 Description of Change

explicitly reset the form `form.resetFields()` before `setFieldsValue`.

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 🧪 How to Test

<!-- Please describe how you tested your changes -->

<!-- For AI features, please include test prompts or scenarios -->

- [ ] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

<!-- If this PR includes UI changes, please provide screenshots or videos -->

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
