### PR TITLE
🐛 fix(agent-runtime): honor auto-run for dynamic approvals

### DIFF
--- a/packages/agent-runtime/src/agents/GeneralChatAgent.ts
+++ b/packages/agent-runtime/src/agents/GeneralChatAgent.ts
@@ -187,7 +187,10 @@ export class GeneralChatAgent implements Agent {
       if (dynamicPolicy !== undefined) {
         if (dynamicPolicy === 'never') {
           toolsToExecute.push(toolCalling);
-        } else if (approvalMode === 'headless' && dynamicPolicy !== 'always') {
+        } else if (
+          (approvalMode === 'auto-run' || approvalMode === 'headless') &&
+          dynamicPolicy !== 'always'
+        ) {
           toolsToExecute.push(toolCalling);
         } else {
           toolsNeedingIntervention.push(toolCalling);

--- a/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
+++ b/packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts
@@ -2043,6 +2043,73 @@ describe('GeneralChatAgent', () => {
       ]);
     });
 
+    it('should execute dynamic required tools when user approvalMode is auto-run', async () => {
+      const agent = new GeneralChatAgent({
+        agentConfig: { maxSteps: 100 },
+        dynamicInterventionAudits: {
+          pathScopeAudit: async (toolArgs, metadata) => {
+            const workingDirectory = metadata?.workingDirectory as string | undefined;
+            if (!workingDirectory) return false;
+            const path = toolArgs.path as string;
+            return !path.startsWith(workingDirectory);
+          },
+        },
+        operationId: 'test-session',
+        modelRuntimeConfig: mockModelRuntimeConfig,
+      });
+
+      const toolCall: ChatToolPayload = {
+        id: 'call-1',
+        identifier: 'local-system',
+        apiName: 'readLocalFile',
+        arguments: '{"path":"/etc/passwd"}',
+        type: 'builtin',
+      };
+
+      const state = createMockState({
+        metadata: { workingDirectory: '/workspace' },
+        toolManifestMap: {
+          'local-system': {
+            identifier: 'local-system',
+            api: [
+              {
+                name: 'readLocalFile',
+                humanIntervention: {
+                  dynamic: {
+                    default: 'never',
+                    policy: 'required',
+                    type: 'pathScopeAudit',
+                  },
+                },
+              },
+            ],
+          },
+        },
+        userInterventionConfig: {
+          approvalMode: 'auto-run',
+          allowList: [],
+        },
+      });
+
+      const context = createMockContext('llm_result', {
+        hasToolsCalling: true,
+        toolsCalling: [toolCall],
+        parentMessageId: 'msg-1',
+      });
+
+      const result = await agent.runner(context, state);
+
+      expect(result).toEqual([
+        {
+          type: 'call_tool',
+          payload: {
+            parentMessageId: 'msg-1',
+            toolCalling: toolCall,
+          },
+        },
+      ]);
+    });
+
     it('should execute tool when dynamic policy resolves to never', async () => {
       const agent = new GeneralChatAgent({
         agentConfig: { maxSteps: 100 },


### PR DESCRIPTION
## Summary

- Honor `auto-run` for dynamic intervention policies that resolve to `required`, matching static `required` behavior.
- Keep `always` intervention policies non-bypassable.
- Add regression coverage for dynamic `pathScopeAudit` in auto-run mode.

## Root Cause

Dynamic intervention handling only let `headless` bypass non-`always` policies. The `auto-run` bypass happened later in the static-policy path, so tools like local-system `readFile` with dynamic `pathScopeAudit` still parked for approval.

## Validation

- `bunx vitest run --silent='passed-only' src/agents/__tests__/GeneralChatAgent.test.ts`
- `bun run check packages/agent-runtime/src/agents/GeneralChatAgent.ts packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts --lint`
- `bun run check packages/agent-runtime/src/agents/GeneralChatAgent.ts packages/agent-runtime/src/agents/__tests__/GeneralChatAgent.test.ts --lint --type` fails on existing repo-wide duplicate dependency type conflicts (`drizzle`, `antd`/React, `dayjs`), unrelated to this patch.
