### PR TITLE
🔧 chore: gate react-scan behind REACT_SCAN env flag

### DIFF
--- a/plugins/vite/sharedRendererConfig.ts
+++ b/plugins/vite/sharedRendererConfig.ts
@@ -242,6 +242,7 @@ export function sharedRendererDefine(options: { isElectron: boolean; isMobile: b
     '__DEV__': process.env.NODE_ENV !== 'production' ? 'true' : 'false',
     '__ELECTRON__': JSON.stringify(options.isElectron),
     '__MOBILE__': JSON.stringify(options.isMobile),
+    '__REACT_SCAN__': process.env.REACT_SCAN === 'true' ? 'true' : 'false',
     '__TEST__': 'false',
     ...nextPublicDefine,
     // Keep a safe fallback so generic `process.env` access won't crash in browser runtime.

--- a/src/initialize.ts
+++ b/src/initialize.ts
@@ -33,8 +33,8 @@ if (typeof window !== 'undefined') {
   });
 }
 
-if (__DEV__) {
+if (__DEV__ && __REACT_SCAN__) {
   void import('react-scan').then(({ scan }) => {
-    scan({ enabled: false, showToolbar: true });
+    scan({ enabled: true, showToolbar: true });
   });
 }


### PR DESCRIPTION
## What

Make the react-scan diagnostic runtime **opt-in** instead of loading on every dev session.

Previously `src/initialize.ts` loaded react-scan whenever `__DEV__` was true, so the react-scan toolbar was always shown in dev. It is now gated behind a `__REACT_SCAN__` compile-time flag, injected from the `REACT_SCAN` env var in `sharedRendererDefine`. The `__REACT_SCAN__` global was already declared in `global.d.ts` ("enable react-scan diagnostic runtime") but never assigned — this wires it up.

## How to enable

```bash
REACT_SCAN=true bun run dev:spa
```

When enabled it now actually scans (`enabled: true`) rather than only rendering the toolbar.

## Notes

- Applies to both web (`vite.config.ts`) and desktop (`electron.vite.config.ts`), since both go through `sharedRendererDefine`.
- No behavior change when `REACT_SCAN` is unset: react-scan is not imported at all — no toolbar, no runtime cost.
