### PR TITLE
🐛 fix(web-crawler): make crawl failures traceable per impl

### DIFF
--- a/packages/web-crawler/src/crawImpl/__tests__/jina.test.ts
+++ b/packages/web-crawler/src/crawImpl/__tests__/jina.test.ts
@@ -186,17 +186,17 @@ describe('jina crawler', () => {
     });
   });
 
-  it('should return undefined if response is not ok', async () => {
+  it('should throw HTTP status error if response is not ok', async () => {
     mockFetch.mockResolvedValue(
-      createMockResponse(null, { ok: false, status: 500, statusText: 'Internal Server Error' }),
+      createMockResponse(null, { ok: false, status: 429, statusText: 'Too Many Requests' }),
     );
 
-    const result = await jina('https://example.com', { filterOptions: {} });
-
-    expect(result).toBeUndefined();
+    await expect(jina('https://example.com', { filterOptions: {} })).rejects.toThrow(
+      'Jina request failed with status 429: Too Many Requests',
+    );
   });
 
-  it('should return undefined if response code is not 200', async () => {
+  it('should throw error if response code is not 200', async () => {
     const mockResponse = createMockResponse(
       {
         code: 400,
@@ -207,9 +207,9 @@ describe('jina crawler', () => {
 
     mockFetch.mockResolvedValue(mockResponse);
 
-    const result = await jina('https://example.com', { filterOptions: {} });
-
-    expect(result).toBeUndefined();
+    await expect(jina('https://example.com', { filterOptions: {} })).rejects.toThrow(
+      'Jina request failed with code 400: Bad Request',
+    );
   });
 
   it('should throw error if fetch throws non-fetch-failed error', async () => {

--- a/packages/web-crawler/src/crawImpl/jina.ts
+++ b/packages/web-crawler/src/crawImpl/jina.ts
@@ -2,7 +2,7 @@ import { getJinaReaderBaseUrl } from '@lobechat/utils';
 
 import type { CrawlImpl } from '../type';
 import { toFetchError } from '../utils/errorType';
-import { parseJSONResponse } from '../utils/response';
+import { createHTTPStatusError, parseJSONResponse } from '../utils/response';
 import { withTimeout } from '../utils/withTimeout';
 
 const JINA_TIMEOUT = 15_000;
@@ -29,7 +29,7 @@ export const jina: CrawlImpl<{ apiKey?: string }> = async (url, params) => {
   }
 
   if (!res.ok) {
-    return;
+    throw await createHTTPStatusError(res, 'Jina');
   }
 
   const json = await parseJSONResponse<{
@@ -40,10 +40,15 @@ export const jina: CrawlImpl<{ apiKey?: string }> = async (url, params) => {
       siteName?: string;
       title?: string;
     };
+    message?: string;
   }>(res, 'Jina');
 
   if (json.code !== 200) {
-    return;
+    throw new Error(
+      json.message
+        ? `Jina request failed with code ${json.code}: ${json.message}`
+        : `Jina request failed with code ${json.code}`,
+    );
   }
 
   const result = json.data;

--- a/packages/web-crawler/src/crawImpl/naive.ts
+++ b/packages/web-crawler/src/crawImpl/naive.ts
@@ -109,7 +109,7 @@ export const naive: CrawlImpl = async (url, { filterOptions }) => {
       url,
     } satisfies CrawlSuccessResult;
   } catch (error) {
-    console.error(error);
+    console.error('[naive]', error);
   }
 
   return;

--- a/packages/web-crawler/src/crawler.ts
+++ b/packages/web-crawler/src/crawler.ts
@@ -51,7 +51,9 @@ export class Crawler {
     const filteredRuleImpls = ruleImpls
       ? (ruleImpls.filter((impl) => this.impls.includes(impl as CrawlImplType)) as CrawlImplType[])
       : undefined;
-    const systemImpls = (filteredRuleImpls?.length ? filteredRuleImpls : this.impls) as CrawlImplType[];
+    const systemImpls = (
+      filteredRuleImpls?.length ? filteredRuleImpls : this.impls
+    ) as CrawlImplType[];
 
     const finalImpls = userImpls
       ? (userImpls.filter((impl) => Object.keys(crawlImpls).includes(impl)) as CrawlImplType[])
@@ -71,11 +73,14 @@ export class Crawler {
           };
         }
 
+        console.error(
+          `[${impl}] returned empty or short content (length: ${res?.content?.length ?? 0})`,
+        );
         finalError = new Error(`${impl} returned empty or short content`);
         finalError.name = 'EmptyCrawlResultError';
         finalCrawler = impl;
       } catch (error) {
-        console.error(error);
+        console.error(`[${impl}]`, error);
         finalError = error as Error;
         finalCrawler = impl;
       }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-11549

#### 🔀 Description of Change

When debugging crawl failures in production, jina's errors were untraceable: its timeout errors carried no impl name (only recognizable by the jina-specific 15s timeout value), and its non-2xx / `code !== 200` failures returned `undefined` silently with no log at all (e.g. a 429 rate limit left zero trace).

Changes:

1. **`crawler.ts`** — unified logging with impl name, one change covering all 7 impls:
   - catch branch now logs `console.error(`[${impl}]`, error)`, so timeout/network errors are attributable
   - the empty/short-content branch now logs `[${impl}] returned empty or short content (length: N)`, making the non-exception fallback path visible mid-flight
2. **`jina.ts`** — silent failures now throw, aligned with all other impls:
   - `!res.ok` → `throw await createHTTPStatusError(res, 'Jina')` (jina was the only impl silently swallowing non-2xx; the other 6 all throw)
   - `json.code !== 200` → throws `Jina request failed with code ${code}: ${message}`
   - short content (<100 chars) still returns `undefined`, consistent with the shared convention across impls
3. **`naive.ts`** — the bare `console.error(error)` in its internal catch now carries a `[naive]` prefix

Fallback behavior is unchanged: a failing impl is caught by the crawl loop and the next impl is tried.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- `packages/web-crawler`: full suite passes (159 tests)
- `jina.test.ts`: the two "return undefined" cases for non-2xx / `code !== 200` are now assertions that the error is thrown (non-2xx case uses 429 to mirror the production rate-limit scenario)

#### 📝 Additional Information

Deliberately **not** adding a label param to `withTimeout` and not touching other impls' silent returns — the crawl-loop logging covers all of them in one place. `debug()`-level logging was rejected because it is invisible in production logs by default, which was the original pain point.