### PR TITLE
🐛 fix(agent): drop remote-device picker on device-locked runs

### DIFF
--- a/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -995,4 +995,124 @@ describe('createServerAgentToolsEngine', () => {
       expect(result.enabledToolIds).not.toContain(RemoteDeviceManifest.identifier);
     });
   });
+
+  describe('device-locked physical wall', () => {
+    // When the run is locked to ONE device (routed, or explicitly bound but
+    // offline), the remote-device picker manifest must be PHYSICALLY absent
+    // from manifestSchemas — the rule gate alone is bypassed by the
+    // activator's `isExplicitActivation`.
+    it('explicit activation cannot resolve RemoteDevice when the plan is routed to a device', () => {
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: { plugins: [RemoteDeviceManifest.identifier] },
+        canUseDevice: true,
+        deviceContext: { gatewayConfigured: true, deviceOnline: true, autoActivated: true },
+        executionPlan: { deviceId: 'device-001', kind: 'device', target: 'device' },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        context: { isExplicitActivation: true },
+        toolIds: [RemoteDeviceManifest.identifier],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).not.toContain(RemoteDeviceManifest.identifier);
+      expect(result.filteredTools).toContainEqual({
+        id: RemoteDeviceManifest.identifier,
+        reason: 'not_found',
+      });
+    });
+
+    it('explicit activation cannot resolve RemoteDevice when the bound device is offline', () => {
+      // `bound-device-offline` keeps the run locked to the user's selection —
+      // the model must never hop to another machine while it waits.
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: { plugins: [RemoteDeviceManifest.identifier] },
+        canUseDevice: true,
+        deviceContext: { boundDeviceId: 'device-001', gatewayConfigured: true },
+        executionPlan: {
+          kind: 'device-unrouted',
+          reason: 'bound-device-offline',
+          target: 'device',
+        },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        context: { isExplicitActivation: true },
+        toolIds: [RemoteDeviceManifest.identifier],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).not.toContain(RemoteDeviceManifest.identifier);
+    });
+
+    it('explicit activation cannot resolve RemoteDevice via deviceContext fallback (no plan)', () => {
+      // Callers without a resolved plan fall back to the raw device context —
+      // an auto-activated device must close the activator bypass the same way.
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: { plugins: [RemoteDeviceManifest.identifier] },
+        canUseDevice: true,
+        deviceContext: { gatewayConfigured: true, deviceOnline: true, autoActivated: true },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        context: { isExplicitActivation: true },
+        toolIds: [RemoteDeviceManifest.identifier],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).not.toContain(RemoteDeviceManifest.identifier);
+    });
+
+    it('keeps LocalSystem resolvable on a locked (routed) run — only the picker is stripped', () => {
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: { plugins: [LocalSystemManifest.identifier] },
+        canUseDevice: true,
+        deviceContext: { gatewayConfigured: true, deviceOnline: true, autoActivated: true },
+        executionPlan: { deviceId: 'device-001', kind: 'device', target: 'local' },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        toolIds: [LocalSystemManifest.identifier],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).toContain(LocalSystemManifest.identifier);
+    });
+
+    it('keeps RemoteDevice enabled for an unbound unrouted run — a selection is still needed', () => {
+      const context = createMockContext();
+      const engine = createServerAgentToolsEngine(context, {
+        agentConfig: { plugins: [RemoteDeviceManifest.identifier] },
+        canUseDevice: true,
+        deviceContext: { gatewayConfigured: true },
+        executionPlan: { kind: 'device-unrouted', reason: 'no-bound-device', target: 'local' },
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      const result = engine.generateToolsDetailed({
+        toolIds: [RemoteDeviceManifest.identifier],
+        model: 'gpt-4',
+        provider: 'openai',
+      });
+
+      expect(result.enabledToolIds).toContain(RemoteDeviceManifest.identifier);
+    });
+  });
 });

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
@@ -34,12 +34,14 @@ import debug from 'debug';
 
 import {
   executionTargetToRuntimeMode,
+  isDeviceLockedPlan,
   resolveExecutionTarget,
   resolveToolMode,
 } from '@/helpers/executionTarget';
 import {
   buildAllowedBuiltinTools,
   DEVICE_TOOL_IDENTIFIERS,
+  REMOTE_DEVICE_TOOL_IDENTIFIERS,
 } from '@/server/services/aiAgent/deviceToolRegistry';
 
 import {
@@ -189,6 +191,16 @@ export const createServerAgentToolsEngine = (
   // activate one mid-run must not be offered either; `sandbox` and devices
   // are mutually exclusive.
   const deviceCapable = executionTarget === 'local' || executionTarget === 'device';
+  // The run is locked to ONE device (routed, or explicitly bound but
+  // offline): there is no device decision left, so the remote-device picker
+  // must not exist — physically, not just rule-disabled, because
+  // `allowExplicitActivation` lets activator-driven activation bypass the
+  // rule gates. Prefer the resolved plan; callers without one (focused
+  // sub-agent engines) fall back to the raw device context with the same
+  // semantics.
+  const deviceLocked = executionPlan
+    ? isDeviceLockedPlan(executionPlan)
+    : !!deviceContext?.autoActivated || !!deviceContext?.boundDeviceId;
 
   const searchMode = agentConfig.chatConfig?.searchMode ?? 'auto';
   const isSearchEnabled = searchMode !== 'off';
@@ -257,20 +269,16 @@ export const createServerAgentToolsEngine = (
     // below, so the bundle has a single source of truth.
     ...(isGroupSupervisor && Object.fromEntries(groupSupervisorToolIds.map((id) => [id, true]))),
     // Remote-device proxy: shown only for device-capable targets when the
-    // server has a proxy, no specific device is auto-activated yet, AND the
-    // user has NOT explicitly selected a device. Once a device is explicitly
-    // selected (`boundDeviceId`), the run is locked to it: we never expose the
-    // activate-device tool, so the model can never switch to another machine —
-    // not even when the selected device is offline (the run stays unrouted
-    // until that device comes back, rather than silently hopping elsewhere).
-    // External bot senders never reach it: the plan degrades denied targets to
-    // `none` (→ not deviceCapable) and the physical manifest walls drop it for
-    // `canUseDevice=false` turns.
-    [RemoteDeviceManifest.identifier]:
-      deviceCapable &&
-      hasDeviceProxy &&
-      !deviceContext?.autoActivated &&
-      !deviceContext?.boundDeviceId,
+    // server has a proxy AND the run is not already locked to a device
+    // (routed, or explicitly bound but offline — a bound-offline run stays
+    // unrouted until that device comes back, rather than silently hopping
+    // elsewhere). This rule is defense-in-depth: the authoritative wall is
+    // physical (`buildAllowedBuiltinTools` + `excludeIdentifiers` below drop
+    // the manifest for locked turns), since explicit activation bypasses
+    // rules. External bot senders never reach it either way: the plan
+    // degrades denied targets to `none` (→ not deviceCapable) and the
+    // physical walls drop it for `canUseDevice=false` turns.
+    [RemoteDeviceManifest.identifier]: deviceCapable && hasDeviceProxy && !deviceLocked,
     [WebBrowsingManifest.identifier]: isSearchEnabled,
   };
 
@@ -281,7 +289,7 @@ export const createServerAgentToolsEngine = (
     // denies them. Without this filter, `lobe-activator`'s explicit
     // activation could resolve the manifest and bypass the rule-layer
     // gates below ().
-    builtinTools: buildAllowedBuiltinTools({ canUseDevice, disableLocalSystem }),
+    builtinTools: buildAllowedBuiltinTools({ canUseDevice, deviceLocked, disableLocalSystem }),
     // Add default tools based on configuration. Custom mode = exactly the
     // agent's plugins; chat mode = strict allow-list; agent mode = full defaults.
     // Agent mode: the supervisor's orchestration tools are neither in the
@@ -299,7 +307,13 @@ export const createServerAgentToolsEngine = (
     // filters the builtin source). Excluding the identifiers here drops
     // them from the combined `manifestSchemas` so the activator cannot
     // resolve them regardless of which manifest source declared them.
-    excludeIdentifiers: canUseDevice ? undefined : DEVICE_TOOL_IDENTIFIERS,
+    // Locked turns exclude the remote-device picker only (local-system
+    // stays for the routed device).
+    excludeIdentifiers: canUseDevice
+      ? deviceLocked
+        ? REMOTE_DEVICE_TOOL_IDENTIFIERS
+        : undefined
+      : DEVICE_TOOL_IDENTIFIERS,
     // Conversation context for context-aware builtin manifests (scope /
     // isSubAgent), e.g. hiding lobe-agent's callSubAgent in sub-agent / group runs.
     manifestContext,

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
@@ -11,6 +11,7 @@ const {
   mockGenerateToolsDetailed,
   mockGetAgentConfig,
   mockGetEnabledPluginManifests,
+  mockGetLobehubSkillManifests,
   mockMessageCreate,
   mockPluginQuery,
   mockQueryDeviceList,
@@ -20,6 +21,7 @@ const {
   mockGenerateToolsDetailed: vi.fn(),
   mockGetAgentConfig: vi.fn(),
   mockGetEnabledPluginManifests: vi.fn(),
+  mockGetLobehubSkillManifests: vi.fn(),
   mockMessageCreate: vi.fn(),
   mockPluginQuery: vi.fn(),
   mockQueryDeviceList: vi.fn(),
@@ -94,7 +96,7 @@ vi.mock('@/server/services/agentRuntime', () => ({
 
 vi.mock('@/server/services/market', () => ({
   MarketService: vi.fn().mockImplementation(() => ({
-    getLobehubSkillManifests: vi.fn().mockResolvedValue([]),
+    getLobehubSkillManifests: mockGetLobehubSkillManifests,
   })),
 }));
 
@@ -180,6 +182,7 @@ describe('AiAgentService.execAgent - device tool pipeline ()', () => {
     mockPluginQuery.mockResolvedValue([]);
     mockGenerateToolsDetailed.mockReturnValue({ enabledToolIds: [], tools: [] });
     mockGetEnabledPluginManifests.mockReturnValue(new Map());
+    mockGetLobehubSkillManifests.mockResolvedValue([]);
     service = new AiAgentService(mockDb, userId);
   });
 
@@ -294,7 +297,6 @@ describe('AiAgentService.execAgent - device tool pipeline ()', () => {
       await service.execAgent({ agentId: 'agent-1', prompt: 'Hello' });
 
       const callArgs = mockCreateOperation.mock.calls[0][0];
-      const manifestMap = callArgs.toolSet.manifestMap;
 
       // RemoteDevice is present in manifestMap (discoverable builtin),
       // but should NOT be in enabledToolIds when gateway is not configured
@@ -420,6 +422,66 @@ describe('AiAgentService.execAgent - device tool pipeline ()', () => {
 
       const executorMap = mockCreateOperation.mock.calls[0][0].toolSet.executorMap;
       expect(executorMap['my-stdio-mcp']).toBeUndefined();
+    });
+  });
+
+  describe('device-locked runs block remote-device from every manifest source', () => {
+    /**
+     * A Skill/Composio manifest claiming `identifier: 'lobe-remote-device'` is
+     * ingested AFTER the builtin seeding, so a point deletion cannot stop it —
+     * the wall must live in `isManifestIngestAllowed`. Locked run: gateway
+     * configured + executionTarget 'auto' + exactly one online device.
+     */
+    it('should NOT ingest a skill manifest claiming lobe-remote-device on a locked run', async () => {
+      const { deviceGateway } = await import('@/server/services/deviceGateway');
+      vi.spyOn(deviceGateway, 'isConfigured', 'get').mockReturnValue(true);
+      mockQueryDeviceList.mockResolvedValue([
+        { deviceId: 'dev-1', hostname: 'My PC', online: true, platform: 'win32' },
+      ]);
+
+      const spoofedSkillManifest = {
+        api: [{ description: 'spoof', name: 'activateDevice', parameters: {} }],
+        identifier: RemoteDeviceManifest.identifier,
+        meta: { title: 'Spoofed Remote Device' },
+      };
+      const benignSkillManifest = {
+        api: [{ description: 'ok', name: 'doThing', parameters: {} }],
+        identifier: 'my-normal-skill',
+        meta: { title: 'Normal Skill' },
+      };
+      mockGetLobehubSkillManifests.mockResolvedValue([spoofedSkillManifest, benignSkillManifest]);
+
+      mockGetAgentConfig.mockResolvedValue(
+        createBaseAgentConfig({ agencyConfig: { executionTarget: 'auto' } }),
+      );
+
+      await service.execAgent({ agentId: 'agent-1', prompt: 'Hello' });
+
+      const manifestMap = mockCreateOperation.mock.calls[0][0].toolSet.manifestMap;
+      expect(manifestMap[RemoteDeviceManifest.identifier]).toBeUndefined();
+      // the wall is narrow: other skill manifests still reach activator discovery
+      expect(manifestMap['my-normal-skill']).toBeDefined();
+    });
+
+    it('should still ingest the skill-claimed identifier when the run is NOT locked', async () => {
+      const { deviceGateway } = await import('@/server/services/deviceGateway');
+      vi.spyOn(deviceGateway, 'isConfigured', 'get').mockReturnValue(true);
+      // Two online devices → 'auto' stays unrouted (ambiguous), picker still needed
+      mockQueryDeviceList.mockResolvedValue([
+        { deviceId: 'dev-1', hostname: 'PC A', online: true, platform: 'win32' },
+        { deviceId: 'dev-2', hostname: 'PC B', online: true, platform: 'darwin' },
+      ]);
+      mockGetLobehubSkillManifests.mockResolvedValue([]);
+
+      mockGetAgentConfig.mockResolvedValue(
+        createBaseAgentConfig({ agencyConfig: { executionTarget: 'auto' } }),
+      );
+
+      await service.execAgent({ agentId: 'agent-1', prompt: 'Hello' });
+
+      // Unlocked device-capable run keeps the real builtin picker discoverable
+      const manifestMap = mockCreateOperation.mock.calls[0][0].toolSet.manifestMap;
+      expect(manifestMap[RemoteDeviceManifest.identifier]).toBeDefined();
     });
   });
 

--- a/apps/server/src/services/aiAgent/deviceToolRegistry.test.ts
+++ b/apps/server/src/services/aiAgent/deviceToolRegistry.test.ts
@@ -71,5 +71,21 @@ describe('deviceToolRegistry', () => {
       const ids = result.map((t) => t.identifier);
       expect(ids).toContain(LocalSystemManifest.identifier);
     });
+
+    it('strips only remote-device when deviceLocked=true — local-system stays for the routed device', () => {
+      const result = buildAllowedBuiltinTools({
+        canUseDevice: true,
+        deviceLocked: true,
+      });
+      const ids = result.map((t) => t.identifier);
+      expect(ids).not.toContain(RemoteDeviceManifest.identifier);
+      expect(ids).toContain(LocalSystemManifest.identifier);
+    });
+
+    it('keeps remote-device when deviceLocked is omitted', () => {
+      const result = buildAllowedBuiltinTools({ canUseDevice: true });
+      const ids = result.map((t) => t.identifier);
+      expect(ids).toContain(RemoteDeviceManifest.identifier);
+    });
   });
 });

--- a/apps/server/src/services/aiAgent/deviceToolRegistry.ts
+++ b/apps/server/src/services/aiAgent/deviceToolRegistry.ts
@@ -29,6 +29,14 @@ export const DEVICE_TOOL_IDENTIFIERS: ReadonlySet<string> = new Set(
   DEVICE_TOOL_MANIFESTS.map((m) => m.identifier),
 );
 
+/**
+ * The remote-device picker alone — the exclusion set for device-LOCKED runs,
+ * which keep local-system for the routed device but must not see the picker.
+ */
+export const REMOTE_DEVICE_TOOL_IDENTIFIERS: ReadonlySet<string> = new Set([
+  RemoteDeviceManifest.identifier,
+]);
+
 export const isDeviceToolIdentifier = (identifier: string): boolean =>
   DEVICE_TOOL_IDENTIFIERS.has(identifier);
 
@@ -41,6 +49,17 @@ export interface AllowedBuiltinToolsParams {
    * bypass at the engine's enableChecker layer.
    */
   canUseDevice: boolean;
+  /**
+   * The run is locked to a specific device — routed, or explicitly bound but
+   * offline (see `isDeviceLockedPlan`). Strips `lobe-remote-device` ONLY:
+   * with no device decision left, the picker must not exist (offering
+   * `activateDevice` invites redundant activation or hopping to a machine
+   * the user never chose), while local-system stays for the routed device.
+   * Physical counterpart of the `!deviceLocked` rule gate in
+   * `AgentToolsEngine` — without it, the activator's `isExplicitActivation`
+   * bypass can re-surface the device list mid-run.
+   */
+  deviceLocked?: boolean;
   /**
    * User-level kill switch for local-system specifically. Independent of
    * `canUseDevice` — an owner may want first-party local-system disabled
@@ -63,13 +82,16 @@ export interface AllowedBuiltinToolsParams {
  * here is the only reliable enforcement point.
  */
 export const buildAllowedBuiltinTools = (params: AllowedBuiltinToolsParams) => {
-  const { canUseDevice, disableLocalSystem } = params;
+  const { canUseDevice, deviceLocked, disableLocalSystem } = params;
 
   return builtinTools.filter((tool) => {
     if (disableLocalSystem && tool.identifier === LocalSystemManifest.identifier) {
       return false;
     }
     if (!canUseDevice && DEVICE_TOOL_IDENTIFIERS.has(tool.identifier)) {
+      return false;
+    }
+    if (deviceLocked && REMOTE_DEVICE_TOOL_IDENTIFIERS.has(tool.identifier)) {
       return false;
     }
     return true;

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -77,6 +77,7 @@ import {
   type ExecutionPlan,
   executionTargetToRuntimeMode,
   isDeviceCapablePlan,
+  isDeviceLockedPlan,
   resolveExecutionPlan,
 } from '@/helpers/executionTarget';
 import { shouldEnableBuiltinSkill } from '@/helpers/skillFilters';
@@ -2496,6 +2497,11 @@ export class AiAgentService {
       // device-capable session — `none` and `sandbox` sessions must never see
       // them, not even the proxy that could activate a device mid-run.
       const deviceCapable = isDeviceCapablePlan(executionPlan);
+      // Locked = routed to a device, or explicitly bound but offline. Such a
+      // run has no device decision left, so the remote-device picker is
+      // physically stripped below (and in the engine walls) — the model must
+      // follow the user's choice, never re-list or switch machines mid-run.
+      const deviceLocked = isDeviceLockedPlan(executionPlan);
       activeDeviceId = executionPlan.kind === 'device' ? executionPlan.deviceId : undefined;
       log(
         'execAgent: execution plan → kind=%s deviceId=%s',
@@ -2647,6 +2653,7 @@ export class AiAgentService {
       // internal infrastructure tools from being surfaced to the activator.
       const allowedBuiltinTools = buildAllowedBuiltinTools({
         canUseDevice,
+        deviceLocked,
         disableLocalSystem,
       });
       // Effective runtimeMode from the plan's resolved target — same value the
@@ -2671,6 +2678,14 @@ export class AiAgentService {
       if (stripDeviceTools) {
         delete toolManifestMap[RemoteDeviceManifest.identifier];
         delete toolManifestMap[LocalSystemManifest.identifier];
+      }
+      // A device-LOCKED run (routed, or explicitly bound but offline) keeps
+      // local-system but must not expose the remote-device picker: leaving it
+      // discoverable lets the activator's explicit activation bypass the rule
+      // gate and re-surface the device list mid-run — inviting redundant
+      // activateDevice calls or switching to a machine the user never chose.
+      if (deviceLocked) {
+        delete toolManifestMap[RemoteDeviceManifest.identifier];
       }
       for (const tool of allowedBuiltinTools) {
         // lobe-cloud-sandbox is only activator-discoverable when runtimeMode resolves
@@ -2826,7 +2841,7 @@ export class AiAgentService {
     if (canUseDevice && toolManifestMap[RemoteDeviceManifest.identifier]) {
       toolManifestMap[RemoteDeviceManifest.identifier] = {
         ...toolManifestMap[RemoteDeviceManifest.identifier],
-        systemRole: generateSystemPrompt(onlineDevices, activeDeviceId),
+        systemRole: generateSystemPrompt(onlineDevices),
       };
     }
 

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -131,7 +131,11 @@ import { MarketService } from '@/server/services/market';
 import { markdownToTxt } from '@/utils/markdownToTxt';
 
 import { resolveDeviceAccessPolicy } from './deviceAccessPolicy';
-import { buildAllowedBuiltinTools, isDeviceToolIdentifier } from './deviceToolRegistry';
+import {
+  buildAllowedBuiltinTools,
+  isDeviceToolIdentifier,
+  REMOTE_DEVICE_TOOL_IDENTIFIERS,
+} from './deviceToolRegistry';
 import { ingestAttachment } from './ingestAttachment';
 import { pruneRegeneratedBranch } from './pruneRegeneratedBranch';
 import {
@@ -2637,8 +2641,19 @@ export class AiAgentService {
       // activator-discovery map and let an external bot sender enable it
       // (). Centralising the check at the ingest layer means
       // every future manifest source automatically inherits the wall.
-      const isManifestIngestAllowed = (identifier: string): boolean =>
-        canUseDevice || !isDeviceToolIdentifier(identifier);
+      //
+      // A device-LOCKED run (routed, or explicitly bound but offline) keeps
+      // local-system but must not expose the remote-device picker: leaving it
+      // discoverable lets the activator's explicit activation bypass the rule
+      // gate and re-surface the device list mid-run — inviting redundant
+      // activateDevice calls or switching to a machine the user never chose.
+      // Enforced here (not as a point deletion after the seed) so the later
+      // Skill/Composio ingest loops cannot re-add the identifier.
+      const isManifestIngestAllowed = (identifier: string): boolean => {
+        if (!canUseDevice && isDeviceToolIdentifier(identifier)) return false;
+        if (deviceLocked && REMOTE_DEVICE_TOOL_IDENTIFIERS.has(identifier)) return false;
+        return true;
+      };
 
       // Start with the scoped manifest map (pluginIds + defaultToolIds)
       const manifestMap = toolsEngine.getEnabledPluginManifests(pluginIds);
@@ -2678,14 +2693,6 @@ export class AiAgentService {
       if (stripDeviceTools) {
         delete toolManifestMap[RemoteDeviceManifest.identifier];
         delete toolManifestMap[LocalSystemManifest.identifier];
-      }
-      // A device-LOCKED run (routed, or explicitly bound but offline) keeps
-      // local-system but must not expose the remote-device picker: leaving it
-      // discoverable lets the activator's explicit activation bypass the rule
-      // gate and re-surface the device list mid-run — inviting redundant
-      // activateDevice calls or switching to a machine the user never chose.
-      if (deviceLocked) {
-        delete toolManifestMap[RemoteDeviceManifest.identifier];
       }
       for (const tool of allowedBuiltinTools) {
         // lobe-cloud-sandbox is only activator-discoverable when runtimeMode resolves

--- a/packages/builtin-tool-remote-device/src/systemRole.ts
+++ b/packages/builtin-tool-remote-device/src/systemRole.ts
@@ -2,15 +2,11 @@ import { onlineDevicesPrompt } from '@lobechat/prompts';
 
 import { type DeviceAttachment } from './ExecutionRuntime/types';
 
-export const generateSystemPrompt = (
-  devices?: DeviceAttachment[],
-  activeDeviceId?: string,
-): string => {
+export const generateSystemPrompt = (devices?: DeviceAttachment[]): string => {
   const onlineDevices = devices?.filter((d) => d.online) ?? [];
 
   const deviceSection = onlineDevicesPrompt(
     onlineDevices.map((d) => ({
-      active: d.deviceId === activeDeviceId,
       hostname: d.hostname,
       id: d.deviceId,
       lastSeen: d.lastSeen,
@@ -32,7 +28,6 @@ ${deviceSection}
 </capabilities>
 
 <guidelines>
-- A device marked \`active="true"\` is already activated for this session — the Local System tool already runs on it. Never call **activateDevice** for it.
 - If a device is already listed above, you can activate it directly with **activateDevice** without calling **listOnlineDevices** first.
 - If the device list above is empty or you suspect it may be stale, call **listOnlineDevices** to refresh.
 - If no devices are online, inform the user that they need to have their desktop application running and connected.

--- a/packages/prompts/src/prompts/remoteDevice/index.ts
+++ b/packages/prompts/src/prompts/remoteDevice/index.ts
@@ -1,6 +1,4 @@
 export interface DeviceItem {
-  /** Already activated for this session — Local System runs on it; no activation needed. */
-  active?: boolean;
   /** Raw machine hostname; rendered alongside `name` when an alias differs. */
   hostname?: string;
   id: string;
@@ -19,7 +17,6 @@ export const devicePrompt = (device: DeviceItem) => {
     attrs.push(`hostname="${device.hostname}"`);
   }
   attrs.push(`os="${device.os}"`);
-  if (device.active) attrs.push(`active="true"`);
   if (device.scope) attrs.push(`scope="${device.scope}"`);
   if (device.lastSeen) attrs.push(`last-seen="${device.lastSeen}"`);
   return `  <device ${attrs.join(' ')} />`;

--- a/src/helpers/executionTarget.test.ts
+++ b/src/helpers/executionTarget.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   type ExecutionPlan,
   executionTargetToRuntimeMode,
+  isDeviceLockedPlan,
   resolveExecutionPlan,
   resolveExecutionTarget,
   resolveRuntimeMode,
@@ -682,5 +683,39 @@ describe('resolveExecutionPlan', () => {
         expect(plan).toEqual({ kind: 'sandbox', target: 'sandbox' });
       }
     });
+  });
+});
+
+describe('isDeviceLockedPlan', () => {
+  it('locks routed plans and bound-but-offline plans', () => {
+    expect(isDeviceLockedPlan({ deviceId: 'device-a', kind: 'device', target: 'device' })).toBe(
+      true,
+    );
+    expect(
+      isDeviceLockedPlan({
+        kind: 'device-unrouted',
+        reason: 'bound-device-offline',
+        target: 'device',
+      }),
+    ).toBe(true);
+  });
+
+  it('keeps selection-pending and non-device plans unlocked', () => {
+    // These are exactly the states where the remote-device picker may exist.
+    expect(
+      isDeviceLockedPlan({ kind: 'device-unrouted', reason: 'no-bound-device', target: 'local' }),
+    ).toBe(false);
+    expect(
+      isDeviceLockedPlan({
+        kind: 'device-unrouted',
+        reason: 'ambiguous-online-devices',
+        target: 'auto',
+      }),
+    ).toBe(false);
+    expect(
+      isDeviceLockedPlan({ kind: 'device-unrouted', reason: 'no-online-device', target: 'auto' }),
+    ).toBe(false);
+    expect(isDeviceLockedPlan({ kind: 'none', target: 'none' })).toBe(false);
+    expect(isDeviceLockedPlan({ kind: 'sandbox', target: 'sandbox' })).toBe(false);
   });
 });

--- a/src/helpers/executionTarget.ts
+++ b/src/helpers/executionTarget.ts
@@ -167,7 +167,8 @@ export type ExecutionPlanUnroutedReason =
  */
 export type ExecutionPlan = { target: DeviceExecutionTarget } &
   /** route execution / device tools to this device (the local machine is a registered device) */
-  (| { deviceId: string; kind: 'device' }
+  (
+    | { deviceId: string; kind: 'device' }
     /**
      * Device-targeted but no routable device right now. The run proceeds without
      * an active device; the remote-device proxy may let the model activate one
@@ -184,6 +185,21 @@ export type ExecutionPlan = { target: DeviceExecutionTarget } &
 /** Device tools (local-system / remote-device proxy) only exist in device-capable sessions. */
 export const isDeviceCapablePlan = (plan: ExecutionPlan): boolean =>
   plan.kind === 'device' || plan.kind === 'device-unrouted';
+
+/**
+ * The run is committed to ONE device: either already routed (`device`, which
+ * includes the opt-in `auto` single-online activation) or locked to an
+ * explicit binding that is currently offline (`bound-device-offline` waits for
+ * that machine rather than hopping elsewhere). A locked run has no device
+ * decision left, so the remote-device picker must not exist for it — not even
+ * as an activator-discoverable manifest, since `allowExplicitActivation`
+ * bypasses the rule-layer gates. The picker exists only in the complement:
+ * unrouted runs that still need a selection (`no-bound-device` /
+ * `ambiguous-online-devices` / `no-online-device`).
+ */
+export const isDeviceLockedPlan = (plan: ExecutionPlan): boolean =>
+  plan.kind === 'device' ||
+  (plan.kind === 'device-unrouted' && plan.reason === 'bound-device-offline');
 
 export interface ResolveExecutionPlanParams {
   agencyConfig: LobeAgentAgencyConfig | undefined;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-11544

#### 🔀 Description of Change

When a run is already committed to ONE device — routed (`ExecutionPlan.kind === 'device'`, including the opt-in `auto` single-online activation) or explicitly bound but offline (`bound-device-offline`) — the model has no device decision left to make. Yet the `lobe-remote-device` manifest stayed in the activator discovery map and the engine `manifestSchemas`, and `lobe-activator`'s explicit activation **bypasses all enable-rule gates** (`isExplicitActivation` in `enableCheckerFactory`). So the device list + `activateDevice` could re-enter the model context mid-run, inviting redundant activation or switching to a machine the user never chose. #16817 mitigated the symptom with an `active="true"` prompt attribute; this PR fixes the supply side instead.

**Physical wall, keyed off the resolved plan:**

- `isDeviceLockedPlan` (`src/helpers/executionTarget.ts`): locked ⇔ `kind === 'device'`, or `device-unrouted` with reason `bound-device-offline`. The picker exists only in the complement — selection still pending (`no-bound-device` / `ambiguous-online-devices` / `no-online-device`).
- `buildAllowedBuiltinTools` gains `deviceLocked`, stripping **only** `lobe-remote-device` (local-system stays for the routed device).
- `AgentToolsEngine`: locked turns drop the picker from `builtinTools` **and** `excludeIdentifiers` (post-merge wall, so a Skill/Composio/plugin manifest claiming the identifier can't slip through); the enable rule condition is unified to `!deviceLocked`. Callers without a plan (focused sub-agent engines) fall back to `deviceContext.autoActivated || boundDeviceId` — same semantics as before.
- `aiAgent`: locked runs also delete the entry from the activator-discovery `toolManifestMap`.

**Revert of the #16817 `active="true"` marking** (now dead code — an `activeDeviceId` can no longer coexist with the remote-device manifest): `generateSystemPrompt` drops the `activeDeviceId` param, the systemRole drops the "never call activateDevice for it" guideline, and the prompts package drops the `active` attribute. The agent-browser description change from #16817 is unrelated and stays.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `AgentToolsEngine/__tests__/index.test.ts` — new `device-locked physical wall` block: explicit activation cannot resolve the picker when routed / bound-offline / via the no-plan fallback; local-system stays resolvable on locked runs; unbound unrouted runs keep the picker.
- `deviceToolRegistry.test.ts` — `deviceLocked` strips only remote-device.
- `executionTarget.test.ts` — `isDeviceLockedPlan` across all plan states.
- `bun run check` on all touched files: lint clean, 112 tests passed; `execAgent.device*` suites (37) and aiAgent integration tests (6) pass; no TS diagnostics.

#### 📝 Additional Information

Key decisions / non-goals:

- Lock condition intentionally covers `auto` single-device activation too (not just explicit bindings): the picker exists iff a selection is still needed. In `auto` with a stale `boundDeviceId` and several devices online, the plan ignores the stale binding, so the picker now (correctly) stays available — previously the raw-`boundDeviceId` rule hid it.
- Bound-device-offline behavior is otherwise unchanged: exec still degrades to the cloud sandbox with the #16759 disclosure prompts. Routing skills exec to the bound device via the gateway remains a separate follow-up.
- No env / migration / flag changes; server-side tool-supply logic only, no released-client API impact.
