### PR TITLE
🐛 fix(home): exclude system topics from unread badges

### DIFF
--- a/packages/database/src/repositories/home/__tests__/index.test.ts
+++ b/packages/database/src/repositories/home/__tests__/index.test.ts
@@ -310,6 +310,43 @@ describe('HomeRepository', () => {
       expect(result.ungrouped).toHaveLength(0);
     });
 
+    it('should not count system-triggered unread topics in agent sidebar badges', async () => {
+      const agentId = 'agent-with-system-unread';
+
+      await clientDB.transaction(async (tx) => {
+        await tx.insert(Schema.agents).values({
+          id: agentId,
+          pinned: false,
+          title: 'Agent With System Unread',
+          userId,
+          virtual: false,
+        });
+        await tx.insert(Schema.topics).values([
+          {
+            agentId,
+            id: 'regular-unread-topic',
+            status: 'unread',
+            title: 'Regular unread topic',
+            userId,
+          },
+          {
+            agentId,
+            id: 'document-unread-topic',
+            status: 'unread',
+            title: 'Document unread topic',
+            trigger: 'document',
+            userId,
+          },
+        ]);
+      });
+
+      const result = await homeRepo.getSidebarAgentList();
+
+      expect(result.ungrouped).toHaveLength(1);
+      expect(result.ungrouped[0].id).toBe(agentId);
+      expect(result.ungrouped[0].unreadCount).toBe(1);
+    });
+
     describe('backward compatibility - fallback to sessions.pinned', () => {
       it('should fallback to sessions.pinned when agents.pinned is undefined (legacy data)', async () => {
         // Simulate legacy data: agents.pinned is null, but sessions.pinned is true

--- a/packages/database/src/repositories/home/index.ts
+++ b/packages/database/src/repositories/home/index.ts
@@ -4,7 +4,7 @@ import {
   type SidebarGroup,
 } from '@lobechat/types';
 import { cleanObject } from '@lobechat/utils';
-import { and, count, desc, eq, not, sql } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, isNull, not, or, sql } from 'drizzle-orm';
 
 import { ChatGroupModel } from '../../models/chatGroup';
 import {
@@ -19,6 +19,11 @@ import { type LobeChatDatabase } from '../../type';
 import { sanitizeBm25Query } from '../../utils/bm25';
 import { normalizeInboxAgentMeta } from '../../utils/inboxAgent';
 import { buildWorkspaceWhere } from '../../utils/workspace';
+
+// Mirrors the main chat sidebar's system-topic exclusions, plus the legacy
+// task_manager trigger. These topics are surfaced in their own product surfaces,
+// so counting them here can leave a badge the regular agent topic list cannot clear.
+const HOME_UNREAD_EXCLUDE_TRIGGERS = ['cron', 'eval', 'task_manager', 'task', 'document'];
 
 // Re-export types for backward compatibility
 export type {
@@ -159,6 +164,10 @@ export class HomeRepository {
     groupUnread: Map<string, number>;
   }> {
     const isUnread = eq(topics.status, 'unread');
+    const isMainSidebarTopic = or(
+      isNull(topics.trigger),
+      not(inArray(topics.trigger, HOME_UNREAD_EXCLUDE_TRIGGERS)),
+    );
 
     const [byAgent, byGroup] = await Promise.all([
       this.db
@@ -168,6 +177,7 @@ export class HomeRepository {
           and(
             buildWorkspaceWhere(this.scope, topics),
             isUnread,
+            isMainSidebarTopic,
             sql`${topics.agentId} is not null`,
           ),
         )
@@ -179,6 +189,7 @@ export class HomeRepository {
           and(
             buildWorkspaceWhere(this.scope, topics),
             isUnread,
+            isMainSidebarTopic,
             sql`${topics.groupId} is not null`,
           ),
         )
@@ -267,25 +278,23 @@ export class HomeRepository {
           visibility: a.visibility,
         };
       }),
-      ...chatGroupItems.map(
-        (g): EnrichedItem => ({
-          // If group has custom avatar, use it (string); otherwise fallback to member avatars (array)
-          avatar: g.avatar ? g.avatar : (memberAvatarsMap.get(g.id) ?? null),
-          backgroundColor: g.backgroundColor,
-          description: g.description,
-          groupAvatar: g.avatar,
-          groupId: g.groupId,
-          id: g.id,
-          isPrivate: g.visibility === 'private',
-          pinned: g.pinned ?? false,
-          sessionId: null,
-          title: g.title,
-          type: 'group' as const,
-          unreadCount: groupUnread.get(g.id) ?? 0,
-          updatedAt: g.updatedAt,
-          visibility: g.visibility,
-        }),
-      ),
+      ...chatGroupItems.map((g): EnrichedItem => ({
+        // If group has custom avatar, use it (string); otherwise fallback to member avatars (array)
+        avatar: g.avatar ? g.avatar : (memberAvatarsMap.get(g.id) ?? null),
+        backgroundColor: g.backgroundColor,
+        description: g.description,
+        groupAvatar: g.avatar,
+        groupId: g.groupId,
+        id: g.id,
+        isPrivate: g.visibility === 'private',
+        pinned: g.pinned ?? false,
+        sessionId: null,
+        title: g.title,
+        type: 'group' as const,
+        unreadCount: groupUnread.get(g.id) ?? 0,
+        updatedAt: g.updatedAt,
+        visibility: g.visibility,
+      })),
     ];
 
     // Sort all items by updatedAt descending


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No related issue found.

#### 🔀 Description of Change

- Exclude system-triggered topics (`cron`, `eval`, `task_manager`, `task`, `document`) from home sidebar unread badge counts.
- Apply the exclusion to both agent and group unread count aggregation so home badges match the main chat sidebar behavior.
- Add a regression test covering document-triggered unread topics.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check packages/database/src/repositories/home/index.ts packages/database/src/repositories/home/__tests__/index.test.ts --lint --test`

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A | N/A |

#### 📝 Additional Information

No breaking changes.