### PR TITLE
🐛 fix(hetero): persist resume session id at stream_start so errors don't lose it

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/codex.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/codex.test.ts
@@ -25,6 +25,30 @@ describe('CodexAdapter', () => {
     expect(adapter.sessionId).toBe('thread-123');
   });
 
+  it('stamps the thread id on stream_start so the resume token persists early (ratelimit regression)', () => {
+    // Regression: codex used to emit stream_start WITHOUT a sessionId, so the
+    // resume token could only be persisted in `finish()` — a rate-limit error
+    // (no finish / error branch) lost the session. After thread.started sets
+    // it, every stream_start must carry it (matching claudeCode) so BOTH the
+    // server (HeterogeneousPersistenceHandler) and the desktop renderer persist
+    // it at stream_start time, before any error can short-circuit the run.
+
+    // Before thread.started reports an id, stream_start omits sessionId.
+    const withoutThread = new CodexAdapter();
+    const [startBefore] = withoutThread.adapt({ type: 'turn.started' });
+    expect(startBefore).toMatchObject({ data: { provider: 'codex' }, type: 'stream_start' });
+    expect((startBefore.data as { sessionId?: string }).sessionId).toBeUndefined();
+
+    // After thread.started, the stream_start carries the thread id.
+    const withThread = new CodexAdapter();
+    withThread.adapt({ thread_id: 'thread-xyz', type: 'thread.started' });
+    const [startAfter] = withThread.adapt({ type: 'turn.started' });
+    expect(startAfter).toMatchObject({
+      data: { provider: 'codex', sessionId: 'thread-xyz' },
+      type: 'stream_start',
+    });
+  });
+
   it('emits stream start and text chunks for turn + agent messages', () => {
     const adapter = new CodexAdapter();
 

--- a/packages/heterogeneous-agents/src/adapters/codex.ts
+++ b/packages/heterogeneous-agents/src/adapters/codex.ts
@@ -1066,6 +1066,13 @@ export class CodexAdapter implements AgentEventAdapter {
     return {
       ...(this.currentModel ? { model: this.currentModel } : {}),
       provider: CODEX_IDENTIFIER,
+      // Stamp the codex thread id on every stream_start (set from
+      // `thread.started`, which fires before `turn.started` emits this), so
+      // the resume token persists at stream_start on BOTH the server
+      // (HeterogeneousPersistenceHandler) and desktop renderer paths — matching
+      // claudeCode. Without it codex relied solely on `finish()`, so a
+      // rate-limit error (no finish / error branch) lost the session.
+      ...(this.sessionId ? { sessionId: this.sessionId } : {}),
       ...extra,
     };
   }

--- a/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
@@ -912,6 +912,47 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
       expect(contentWrite).toBeDefined();
     });
 
+    it('persists the resume session id from stream_start even when sendPrompt rejects (ratelimit regression)', async () => {
+      // Regression for tpc_k9pUn1yf151P: a rate-limit makes the CLI exit
+      // non-zero, so `sendPrompt` REJECTS and control jumps to `catch` —
+      // skipping the success-path metadata write. The session id used to be
+      // lost, so the next turn started a FRESH session and dropped ~41k of
+      // context. The stream_start early-write must land the resume token before
+      // the rejection, regardless of how the run ends.
+      const store = createMockStore();
+      const get = vi.fn(() => store);
+
+      // sendPrompt rejects (non-zero CLI exit) — drives the catch-block path,
+      // so the success-path getSessionInfo write never runs.
+      let rejectSendPrompt!: (e: unknown) => void;
+      mockSendPrompt.mockReturnValue(
+        new Promise<void>((_, rej) => {
+          rejectSendPrompt = rej;
+        }),
+      );
+
+      const executorPromise = executeHeterogeneousAgent(get, defaultParams);
+      await flush();
+
+      // CC reports its session id via system:init → stream_start (the early
+      // resume-token write fires here), streams a little, then the run fails.
+      ipc.emitRawLine('ipc-sess-1', ccInit('cc-sess-ratelimit'));
+      ipc.emitRawLine('ipc-sess-1', ccText('msg_01', 'partial content'));
+      await flush();
+
+      // Reject sendPrompt → catch block (success path skipped entirely).
+      rejectSendPrompt(new Error('rate limit exceeded'));
+      await executorPromise.catch(() => {});
+      await flush();
+
+      // The resume token was persisted at stream_start, BEFORE the catch block
+      // ran — so the next turn resumes this session instead of starting fresh.
+      expect(store.updateTopicMetadata).toHaveBeenCalledWith(
+        'topic-1',
+        expect.objectContaining({ heteroSessionId: 'cc-sess-ratelimit' }),
+      );
+    });
+
     it('should not persist streamed auth error echoes as assistant content when the session errors', async () => {
       const rawAuthError =
         'Failed to authenticate. API Error: 401 {"type":"error","error":{"type":"authentication_error","message":"Invalid authentication credentials"}}';

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -1190,7 +1190,32 @@ export const executeHeterogeneousAgent = async (
     // server handler). Stable per run; the copy makes a mid-topic fork visible.
     if (event.type === 'stream_start') {
       const sid = (event.data as { sessionId?: string } | undefined)?.sessionId;
-      if (typeof sid === 'string' && sid.length > 0) heteroSessionId = sid;
+      if (typeof sid === 'string' && sid.length > 0 && sid !== heteroSessionId) {
+        heteroSessionId = sid;
+        // Persist the resume token the MOMENT the CLI reports it — but only on
+        // a FRESH run. The success-path write below only runs when `sendPrompt`
+        // resolves; a rate-limit / API error rejects it and jumps straight to
+        // `catch`, so without this early write the token is lost and the next
+        // turn starts a fresh session (the `tpc_k9pUn1yf151P` regression). On a
+        // `--resume` run the id is already in metadata (it's where
+        // `resumeSessionId` came from), so skip — a failed resume is cleaned up
+        // by the retry/clear path, not re-stamped here. Fire-and-forget +
+        // guarded so it never throws past the persistQueue chain nor delays
+        // event processing; the success path re-writes it on completion.
+        if (!resumeSessionId && context.topicId && updateTopicMetadata) {
+          const topicMetadata = getTopicMetadataById(get(), context.topicId);
+          updateTopicMetadata(context.topicId, {
+            heteroSessionId: sid,
+            heteroSessionIdByWorkingDirectory: setHeteroSessionIdForWorkingDirectory(
+              topicMetadata,
+              workingDirectory,
+              sid,
+            ),
+          }).catch((err) =>
+            console.error('[HeterogeneousAgent] Failed to early-persist resume session id:', err),
+          );
+        }
+      }
     }
 
     const ctx: MainAgentReduceCtx = {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] ✅ test

#### 🔗 Related Issue

No tracking issue. Root caused from topic `tpc_k9pUn1yf151P`, where a `ratelimit` error caused the next turn to start a fresh heterogeneous-agent session and drop ~41k of accumulated context.

#### 🔀 Description of Change

A rate-limit / API error makes the CLI exit non-zero, so `sendPrompt` rejects and the desktop renderer jumps straight to `catch` — skipping the success-path `updateTopicMetadata` that writes the resume token. The token was therefore never persisted, and the next turn started a **fresh** session, losing context.

The **cloud/server** path already persists the session id at `stream_start` (`HeterogeneousPersistenceHandler`), but the **desktop renderer** only captured it into a local variable — the `topic.metadata` write was `finish`/success-only. So a run that errored before completing lost its resume token.

Two fixes:

1. **`heterogeneousAgentExecutor`** — on a **fresh** run (no `resumeSessionId`), persist `heteroSessionId` + the per-cwd map to `topic.metadata` the moment `stream_start` reports it (mirrors the server handler). Resume runs are skipped — the id is already in metadata, and a failed resume is cleaned up by the existing retry/clear path. Fire-and-forget + guarded so it never throws past the `persistQueue` chain nor delays event processing; the success path still re-writes it on completion.
2. **codex adapter** — stamp `sessionId` into `stream_start` (set from `thread.started`, which precedes `turn.started`), matching `claudeCode`. Without it codex emitted `stream_start` with no `sessionId`, so neither the server nor the renderer `stream_start` persistence could capture a codex session — codex relied solely on `finish()`.

No server-contract change (`updateTopicMetadata` already accepts `heteroSessionId`), so this ships as a single PR.

#### 🧪 How to Test

- [x] Added/updated tests
- [x] Tested locally

Two regression tests, each verified to **fail without** its fix and pass with it:

- `heterogeneousAgentExecutor.test.ts` — a rejecting `sendPrompt` (non-zero CLI exit) still leaves the resume token in `topic.metadata`, because the early `stream_start` write landed before the `catch` block ran.
- `codex.test.ts` — `stream_start` carries the thread id once `thread.started` has fired (and omits it before).

Full suite for both files: 110 passing (`bun run check --test ...`).

#### 📝 Additional Information

The `!resumeSessionId` guard is deliberate: it targets the actual regression (a fresh run whose session id was never persisted) without disturbing the resume-error path (`retryWithoutResume` / `clearStaleResumeMetadata`), whose existing test (`does NOT retry resume once partial output streamed`) still passes.

Co-Authored-By: Claude <noreply@anthropic.com>