### PR TITLE
🐛 fix(chat): worktree directory label shows source repo + removal toast

### DIFF
--- a/locales/en-US/device.json
+++ b/locales/en-US/device.json
@@ -69,6 +69,7 @@
   "workingDirectory.removeWorktreeAction": "Delete worktree",
   "workingDirectory.removeWorktreeConfirm": "Delete worktree “{{name}}”? This removes the worktree directory but keeps its branch. Git will refuse if it has uncommitted changes.",
   "workingDirectory.removeWorktreeFailed": "Delete worktree failed",
+  "workingDirectory.removeWorktreePending": "Deleting worktree “{{name}}”…",
   "workingDirectory.removeWorktreeSuccess": "Worktree deleted",
   "workingDirectory.removeWorktreeTitle": "Delete worktree",
   "workingDirectory.removed": "Removed “{{name}}”",

--- a/locales/zh-CN/device.json
+++ b/locales/zh-CN/device.json
@@ -69,6 +69,7 @@
   "workingDirectory.removeWorktreeAction": "删除 Worktree",
   "workingDirectory.removeWorktreeConfirm": "删除 Worktree“{{name}}”？这会移除该 worktree 目录，但保留其分支；如果仍有未提交更改，Git 会拒绝删除。",
   "workingDirectory.removeWorktreeFailed": "删除 Worktree 失败",
+  "workingDirectory.removeWorktreePending": "正在删除 Worktree“{{name}}”…",
   "workingDirectory.removeWorktreeSuccess": "Worktree 已删除",
   "workingDirectory.removeWorktreeTitle": "删除 Worktree",
   "workingDirectory.removed": "已移除「{{name}}」",

--- a/packages/locales/src/default/device.ts
+++ b/packages/locales/src/default/device.ts
@@ -90,6 +90,7 @@ export default {
   'workingDirectory.removeWorktreeConfirm':
     'Delete worktree “{{name}}”? This removes the worktree directory but keeps its branch. Git will refuse if it has uncommitted changes.',
   'workingDirectory.removeWorktreeFailed': 'Delete worktree failed',
+  'workingDirectory.removeWorktreePending': 'Deleting worktree “{{name}}”…',
   'workingDirectory.removeWorktreeSuccess': 'Worktree deleted',
   'workingDirectory.removeWorktreeTitle': 'Delete worktree',
   'workingDirectory.worktreeSearchPlaceholder': 'Search worktrees',

--- a/src/features/ChatInput/ControlBar/WorkingDirectoryPicker.tsx
+++ b/src/features/ChatInput/ControlBar/WorkingDirectoryPicker.tsx
@@ -2,7 +2,7 @@
 
 import { isDesktop } from '@lobechat/const';
 import type { WorkingDirEntry } from '@lobechat/types';
-import { getWorkingDirEffectivePath } from '@lobechat/types';
+import { getWorkingDirSourcePath } from '@lobechat/types';
 import { isRecord } from '@lobechat/utils';
 import { Flexbox, Icon, Input, Popover, Tooltip } from '@lobehub/ui';
 import { toast } from '@lobehub/ui/base-ui';
@@ -22,7 +22,7 @@ import { useTranslation } from 'react-i18next';
 
 import { openAddWorkingDirModal } from '@/features/WorkingDirectory';
 import {
-  resolveAgentWorkingDirectory,
+  resolveAgentWorkingDirectorySource,
   resolveTargetDeviceId,
 } from '@/helpers/agentWorkingDirectory';
 import {
@@ -337,9 +337,12 @@ const WorkingDirectoryPicker = memo<WorkingDirectoryPickerProps>(({ agentId }) =
   );
   const legacyAgentWorkingDirectory = getWorkingDirectoryPathString(rawLegacyAgentWorkingDirectory);
 
-  // The explicitly-selected cwd (no home fallback) — drives the active check and
-  // the Reset affordance.
-  const resolvedSelectedDir = resolveAgentWorkingDirectory({
+  // The explicitly-selected REPO (no home fallback) — drives the directory label,
+  // the active check, and the Reset affordance. Resolves to the SOURCE path
+  // (repo root), never the active worktree: the label shows the repo the agent is
+  // bound to, while the worktree switcher in git status tracks the active
+  // worktree separately.
+  const resolvedSelectedDir = resolveAgentWorkingDirectorySource({
     agencyConfig,
     currentDeviceId,
     deviceDefaultCwd,
@@ -428,9 +431,9 @@ const WorkingDirectoryPicker = memo<WorkingDirectoryPickerProps>(({ agentId }) =
   };
 
   const renderRow = (entry: WorkingDirEntry) => {
-    const effectivePath = getWorkingDirEffectivePath(entry);
-    const isActive = effectivePath === selectedDir;
-    const isDefault = !!deviceDefaultCwd && effectivePath === deviceDefaultCwd;
+    const sourcePath = getWorkingDirSourcePath(entry);
+    const isActive = sourcePath === selectedDir;
+    const isDefault = !!deviceDefaultCwd && sourcePath === deviceDefaultCwd;
     return (
       <Flexbox
         horizontal

--- a/src/features/ChatInput/ControlBar/WorktreeSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/WorktreeSwitcher.tsx
@@ -556,12 +556,21 @@ const WorktreeSwitcher = memo<WorktreeSwitcherProps>(
           // reconciles on the next `onWorktreesChange` revalidate.
           onOk: () => {
             setRemovingPaths((prev) => new Set(prev).add(worktree.path));
+            // The dropdown is already closed, so a persistent loading toast is the
+            // only signal that a (potentially slow) removal is in progress. It gets
+            // swapped for the success/failure toast once the background op settles.
+            const pendingToast = toast.loading(
+              t('workingDirectory.removeWorktreePending', {
+                name: getPathName(worktree.path),
+              }),
+            );
             void (async () => {
               const result = await gitService.removeGitWorktree({
                 deviceId,
                 path,
                 worktreePath: worktree.path,
               });
+              pendingToast.close();
               if (result.success) {
                 // The list is hidden behind the closed dropdown, so this toast
                 // is the only signal that the background removal finished.

--- a/src/features/ChatInput/ControlBar/__tests__/WorktreeSwitcher.test.tsx
+++ b/src/features/ChatInput/ControlBar/__tests__/WorktreeSwitcher.test.tsx
@@ -9,6 +9,10 @@ const confirmModalMock = vi.hoisted(() => vi.fn());
 const messageErrorMock = vi.hoisted(() => vi.fn());
 const messageSuccessMock = vi.hoisted(() => vi.fn());
 const removeGitWorktreeMock = vi.hoisted(() => vi.fn());
+const toastLoadingCloseMock = vi.hoisted(() => vi.fn());
+const toastLoadingMock = vi.hoisted(() =>
+  vi.fn(() => ({ close: toastLoadingCloseMock, id: 'pending', update: vi.fn() })),
+);
 
 vi.mock('../useCommitWorkingDirectory', () => ({
   useCommitWorkingDirectory: () => ({ commit: commitMock }),
@@ -51,7 +55,12 @@ vi.mock('@lobehub/ui/base-ui', () => ({
       {children}
     </div>
   ),
-  toast: { error: messageErrorMock, info: vi.fn(), success: messageSuccessMock },
+  toast: {
+    error: messageErrorMock,
+    info: vi.fn(),
+    loading: toastLoadingMock,
+    success: messageSuccessMock,
+  },
 }));
 
 vi.mock('antd-style', () => ({
@@ -72,6 +81,8 @@ beforeEach(() => {
   confirmModalMock.mockReset();
   messageErrorMock.mockReset();
   messageSuccessMock.mockReset();
+  toastLoadingMock.mockClear();
+  toastLoadingCloseMock.mockReset();
   removeGitWorktreeMock.mockReset();
   removeGitWorktreeMock.mockResolvedValue({ success: true });
 });
@@ -227,6 +238,11 @@ describe('WorktreeSwitcher', () => {
     // resolved value.
     confirmModalMock.mock.calls[0][0].onOk();
 
+    // a pending toast surfaces immediately since the closed dropdown hides the row
+    expect(toastLoadingMock).toHaveBeenCalledWith(
+      'workingDirectory.removeWorktreePending:{"name":"repo-detached"}',
+    );
+
     expect(removeGitWorktreeMock).toHaveBeenCalledWith({
       deviceId: 'device-1',
       path: '/repo',
@@ -235,6 +251,8 @@ describe('WorktreeSwitcher', () => {
     await waitFor(() => {
       expect(onWorktreesChange).toHaveBeenCalled();
     });
+    // the pending toast is dismissed before the terminal toast is shown
+    expect(toastLoadingCloseMock).toHaveBeenCalledTimes(1);
     expect(messageSuccessMock).toHaveBeenCalledWith('workingDirectory.removeWorktreeSuccess');
     expect(messageErrorMock).not.toHaveBeenCalled();
   });
@@ -279,6 +297,8 @@ describe('WorktreeSwitcher', () => {
         'fatal: worktree contains modified or untracked files',
       );
     });
+    // the pending toast is dismissed even when the removal fails
+    expect(toastLoadingCloseMock).toHaveBeenCalledTimes(1);
     expect(messageSuccessMock).not.toHaveBeenCalled();
     expect(onWorktreesChange).not.toHaveBeenCalled();
   });

--- a/src/helpers/agentWorkingDirectory.test.ts
+++ b/src/helpers/agentWorkingDirectory.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 import {
   resolveAgentWorkingDirectory,
   resolveAgentWorkingDirectoryConfig,
+  resolveAgentWorkingDirectorySource,
   resolveTargetDeviceId,
 } from './agentWorkingDirectory';
 
@@ -121,6 +122,44 @@ describe('resolveAgentWorkingDirectory', () => {
 
   it('returns undefined when nothing is configured', () => {
     expect(resolveAgentWorkingDirectory({})).toBeUndefined();
+  });
+});
+
+describe('resolveAgentWorkingDirectorySource', () => {
+  it('resolves to the SOURCE repo path, ignoring the active worktree', () => {
+    // A worktree switch records `activeWorktree` but the directory label must
+    // keep showing the repo root (where hetero CLI sessions actually anchor).
+    const agencyConfig = cfg({
+      executionTarget: 'local',
+      workingDirByDevice: {
+        cur: {
+          git: { activeWorktree: '/repo-fix', branch: 'fix', isWorktree: true },
+          path: '/repo',
+          repoType: 'git',
+        },
+      },
+    });
+
+    expect(resolveAgentWorkingDirectorySource({ agencyConfig, currentDeviceId: 'cur' })).toBe(
+      '/repo',
+    );
+    // the effective resolver still yields the worktree — the two intentionally
+    // diverge, and git status (not the directory label) is what consumes it.
+    expect(resolveAgentWorkingDirectory({ agencyConfig, currentDeviceId: 'cur' })).toBe(
+      '/repo-fix',
+    );
+  });
+
+  it('resolves the topic-level config to its source path', () => {
+    expect(
+      resolveAgentWorkingDirectorySource({
+        topicWorkingDirectory: '/topic-effective',
+        topicWorkingDirectoryConfig: {
+          git: { activeWorktree: '/repo-fix', isWorktree: true },
+          path: '/repo',
+        },
+      }),
+    ).toBe('/repo');
   });
 });
 

--- a/src/helpers/agentWorkingDirectory.ts
+++ b/src/helpers/agentWorkingDirectory.ts
@@ -3,7 +3,7 @@ import type {
   WorkingDirConfig,
   WorkingDirConfigValue,
 } from '@lobechat/types';
-import { getWorkingDirEffectivePath } from '@lobechat/types';
+import { getWorkingDirEffectivePath, getWorkingDirSourcePath } from '@lobechat/types';
 
 /**
  * The device a run targets: an explicitly bound remote device, this machine,
@@ -76,4 +76,22 @@ export const resolveAgentWorkingDirectory = (
 ): string | undefined => {
   const config = resolveAgentWorkingDirectoryConfig(params);
   return getWorkingDirEffectivePath(config);
+};
+
+/**
+ * Same precedence as {@link resolveAgentWorkingDirectory}, but resolves to the
+ * SOURCE repo path (`config.path`) — the repo root, ignoring any active
+ * worktree recorded in `config.git.activeWorktree`.
+ *
+ * Use this for the directory-picker DISPLAY, which shows the repo the agent is
+ * bound to. The effective (worktree) path belongs to git status / the worktree
+ * switcher, not the directory label: heterogeneous CLI agents anchor their
+ * session cwd to the source repo (see `conversationLifecycle`), so showing the
+ * worktree here would misrepresent where the run actually executes.
+ */
+export const resolveAgentWorkingDirectorySource = (
+  params: Parameters<typeof resolveAgentWorkingDirectoryConfig>[0],
+): string | undefined => {
+  const config = resolveAgentWorkingDirectoryConfig(params);
+  return getWorkingDirSourcePath(config);
 };


### PR DESCRIPTION
Two related fixes in the worktree / working-directory control strip.

**1. Directory label shows the source repo, not the worktree path**

The directory picker resolved the *active worktree* path for its label (`resolveAgentWorkingDirectory` -> `getWorkingDirEffectivePath`). But heterogeneous CLI agents (Claude Code / Codex) anchor their session cwd to the **source repo** (see `conversationLifecycle`: `runtimeType === 'hetero' ? getWorkingDirSourcePath : getWorkingDirEffectivePath`). So after a worktree switch the directory label flipped to the worktree folder, mismatching where the run actually executes and duplicating the worktree name already shown by the worktree switcher.

- Add `resolveAgentWorkingDirectorySource` (same precedence as `resolveAgentWorkingDirectory`, but returns `config.path` = repo root, ignoring `git.activeWorktree`).
- `WorkingDirectoryPicker` uses it for the label and the recents active/default check.
- `GitStatus` / the worktree switcher stay on the effective (worktree) path. Split: directory label = repo, worktree switcher = active worktree.

**2. Loading toast while deleting a worktree**

Worktree removal runs in the background after the confirm dialog closes (the dropdown is already hidden), so a slow `git worktree remove` had no "in progress" signal. Surface a persistent `toast.loading` on confirm and dismiss it for the terminal success/failure toast (mirrors the lib's own `toast.promise` pattern).

**How to Test**

- `agentWorkingDirectory.test.ts`: new `resolveAgentWorkingDirectorySource` cases (returns source with `activeWorktree` set; contrasts with the effective resolver still yielding the worktree).
- `WorktreeSwitcher.test.tsx`: asserts the pending toast fires on confirm and is dismissed on both success and failure.
- End-to-end (agent-testing, isolated Electron, in-memory `activeWorktree` injection against a real Codex agent bound to this repo): with `activeWorktree` set to a different worktree, the picker resolves `selectedDir` = source (`lobehub-desktop`) and the rendered strip shows the source label next to the worktree switcher. Verify report: https://app.lobehub.com/verify/229a5502-00cc-4c23-b4ea-2de30fb3ce0c
- helper (14) + ControlBar (8) tests green; lint clean.

**Notes**

- `WorkingDirectoryPicker.tsx` on `canary` uses the `@/helpers/workingDirectoryPath` helpers; this PR keeps those and only swaps the path resolution to the source variant.
- Pure renderer + shared helper; no DB / migration / server-contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)