### PR TITLE
🐛 fix(app): list embedding models in service selector

### DIFF
--- a/src/features/ModelSelect/index.tsx
+++ b/src/features/ModelSelect/index.tsx
@@ -5,7 +5,7 @@ import { type ReactNode } from 'react';
 import { memo, useMemo } from 'react';
 
 import { ModelItemRender, ProviderItemRender, TAG_CLASSNAME } from '@/components/ModelSelect';
-import { useEnabledChatModels } from '@/hooks/useEnabledChatModels';
+import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { type EnabledProviderWithModels } from '@/types/aiProvider';
 
 const prefixCls = 'ant';
@@ -41,6 +41,7 @@ interface ModelSelectProps extends Pick<
 > {
   defaultValue?: { model: string; provider?: string };
   initialWidth?: boolean;
+  modelType?: 'chat' | 'embedding';
   onChange?: (props: { model: string; provider: string }) => void;
   popupWidth?: number;
   requiredAbilities?: (keyof EnabledProviderWithModels['children'][number]['abilities'])[];
@@ -52,7 +53,7 @@ const ModelSelect = memo<ModelSelectProps>(
   ({
     value,
     onChange,
-    showAbility = true,
+    showAbility: _showAbility = true,
     requiredAbilities,
     loading,
     disabled,
@@ -61,8 +62,13 @@ const ModelSelect = memo<ModelSelectProps>(
     variant,
     initialWidth = false,
     popupWidth,
+    modelType = 'chat',
   }) => {
-    const enabledList = useEnabledChatModels();
+    const enabledList = useAiInfraStore((s) =>
+      modelType === 'embedding'
+        ? aiProviderSelectors.enabledEmbeddingModelList(s)
+        : s.enabledChatModelList || [],
+    );
 
     const options = useMemo<SelectProps['options']>(() => {
       const getChatModels = (provider: EnabledProviderWithModels) => {
@@ -105,7 +111,7 @@ const ModelSelect = memo<ModelSelectProps>(
           };
         })
         .filter(Boolean) as SelectProps['options'];
-    }, [enabledList, requiredAbilities, showAbility]);
+    }, [enabledList, requiredAbilities]);
 
     return (
       <TooltipGroup>

--- a/src/features/ServiceModel/ModelAssignmentsForm.tsx
+++ b/src/features/ServiceModel/ModelAssignmentsForm.tsx
@@ -21,6 +21,7 @@ import type { SystemAgentItem, UserServiceModelConfigKey } from '@/types/user/se
 interface SystemAgentModelItem {
   contextLimit?: boolean;
   key: UserServiceModelConfigKey;
+  modelType?: 'chat' | 'embedding';
 }
 
 type LoadingKey = 'defaultAgent' | UserServiceModelConfigKey;
@@ -44,7 +45,7 @@ const OPTIONAL_FEATURE_ITEMS: SystemAgentModelItem[] = [
 const MEMORY_MODEL_ITEMS: SystemAgentModelItem[] = [
   { contextLimit: true, key: 'memoryAnalysisAgentConfig' },
   { contextLimit: true, key: 'userMemoryPersonaWriter' },
-  { contextLimit: true, key: 'userMemoryEmbedding' },
+  { contextLimit: true, key: 'userMemoryEmbedding', modelType: 'embedding' },
 ];
 
 const ModelAssignmentsForm = memo(() => {
@@ -179,39 +180,42 @@ const ModelAssignmentsForm = memo(() => {
     } satisfies FormItemProps;
   });
 
-  const memoryModelItems: FormItemProps[] = MEMORY_MODEL_ITEMS.map(({ contextLimit, key }) => {
-    const value = systemAgentSettings[key];
+  const memoryModelItems: FormItemProps[] = MEMORY_MODEL_ITEMS.map(
+    ({ contextLimit, key, modelType }) => {
+      const value = systemAgentSettings[key];
 
-    return {
-      children: (
-        <Flexbox direction="vertical" gap={8} style={{ width: 448 }}>
-          <ModelSelect
-            showAbility={false}
-            style={{ minWidth: 0, width: '100%' }}
-            value={value}
-            onChange={(props) => updateSystemAgentModel(key, props)}
-          />
-          {contextLimit && (
-            <ConfigProvider theme={{ token: { controlHeight: 32 } }}>
-              <InputNumber
-                min={1}
-                placeholder={t('serviceModel.contextLimit.placeholder')}
-                style={{ alignSelf: 'flex-end', width: 180 }}
-                value={value.contextLimit}
-                onChange={(contextLimit) =>
-                  updateSystemAgentModel(key, {
-                    contextLimit: typeof contextLimit === 'number' ? contextLimit : undefined,
-                  })
-                }
-              />
-            </ConfigProvider>
-          )}
-        </Flexbox>
-      ),
-      desc: t(`systemAgent.${key}.modelDesc`),
-      label: t(`systemAgent.${key}.title`),
-    } satisfies FormItemProps;
-  });
+      return {
+        children: (
+          <Flexbox direction="vertical" gap={8} style={{ width: 448 }}>
+            <ModelSelect
+              modelType={modelType}
+              showAbility={false}
+              style={{ minWidth: 0, width: '100%' }}
+              value={value}
+              onChange={(props) => updateSystemAgentModel(key, props)}
+            />
+            {contextLimit && (
+              <ConfigProvider theme={{ token: { controlHeight: 32 } }}>
+                <InputNumber
+                  min={1}
+                  placeholder={t('serviceModel.contextLimit.placeholder')}
+                  style={{ alignSelf: 'flex-end', width: 180 }}
+                  value={value.contextLimit}
+                  onChange={(contextLimit) =>
+                    updateSystemAgentModel(key, {
+                      contextLimit: typeof contextLimit === 'number' ? contextLimit : undefined,
+                    })
+                  }
+                />
+              </ConfigProvider>
+            )}
+          </Flexbox>
+        ),
+        desc: t(`systemAgent.${key}.modelDesc`),
+        label: t(`systemAgent.${key}.title`),
+      } satisfies FormItemProps;
+    },
+  );
 
   const optionalFeatureItems: FormItemProps[] = OPTIONAL_FEATURE_ITEMS.map(({ key }) => {
     const value = systemAgentSettings[key];

--- a/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
+++ b/src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts
@@ -4,8 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   getChatModelList,
+  getEmbeddingModelList,
   getImageModelList,
   normalizeChatModel,
+  normalizeEmbeddingModel,
   normalizeImageModel,
 } from '../action';
 
@@ -17,6 +19,17 @@ const createChatModel = (overrides: Partial<EnabledAiModel> = {}): EnabledAiMode
   id: overrides.id ?? 'chat-model',
   providerId: overrides.providerId ?? 'openai',
   type: 'chat',
+  ...overrides,
+});
+
+const createEmbeddingModel = (overrides: Partial<EnabledAiModel> = {}): EnabledAiModel => ({
+  abilities: overrides.abilities ?? {},
+  contextWindowTokens: overrides.contextWindowTokens,
+  displayName: overrides.displayName ?? 'Embedding Model',
+  enabled: overrides.enabled ?? true,
+  id: overrides.id ?? 'embedding-model',
+  providerId: overrides.providerId ?? 'openai',
+  type: 'embedding',
   ...overrides,
 });
 
@@ -162,6 +175,28 @@ describe('aiProvider action helpers', () => {
     });
   });
 
+  describe('normalizeEmbeddingModel', () => {
+    it('preserves inline embedding metadata without loading fallback model config', async () => {
+      const fallbackSpy = vi.spyOn(runtimeModule, 'getModelPropertyWithFallback');
+      const pricing: Pricing = {
+        units: [{ name: 'textInput', rate: 0.02, strategy: 'fixed', unit: 'millionTokens' }],
+      };
+      const model = {
+        ...createEmbeddingModel({ id: 'text-embedding-3-small', providerId: 'openai' }),
+        description: 'Inline embedding description',
+        knowledgeCutoff: '2024-01',
+        pricing,
+      };
+
+      const result = await normalizeEmbeddingModel(model);
+
+      expect(result.description).toBe('Inline embedding description');
+      expect(result.knowledgeCutoff).toBe('2024-01');
+      expect(result.pricing).toBe(pricing);
+      expect(fallbackSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getChatModelList', () => {
     const chatModels = [
       createChatModel({ id: 'gpt-4', providerId: 'openai', displayName: 'GPT-4' }),
@@ -206,6 +241,39 @@ describe('aiProvider action helpers', () => {
       );
 
       expect(result.map((model) => model.id)).toEqual(['visible-model']);
+    });
+  });
+
+  describe('getEmbeddingModelList', () => {
+    it('collects only visible embedding models for a provider', async () => {
+      // ROOT CAUSE:
+      //
+      // Memory embedding settings used the chat-only model list, so embedding
+      // models existed in runtime state but were never offered by the selector.
+      //
+      // We fixed this by building an embedding-specific provider model list and
+      // wiring the memory embedding dropdown to that list.
+      const result = await getEmbeddingModelList(
+        [
+          createChatModel({ id: 'gpt-4o', providerId: 'openai' }),
+          createEmbeddingModel({
+            displayName: 'Text Embedding 3 Small',
+            id: 'text-embedding-3-small',
+            providerId: 'openai',
+          }),
+          createEmbeddingModel({
+            displayName: 'Hidden Embedding Alias',
+            id: 'hidden-embedding-alias',
+            providerId: 'openai',
+            visible: false,
+          }),
+          createEmbeddingModel({ id: 'cohere-embed', providerId: 'cohere' }),
+        ],
+        'openai',
+      );
+
+      expect(result.map((model) => model.id)).toEqual(['text-embedding-3-small']);
+      expect(result[0].displayName).toBe('Text Embedding 3 Small');
     });
   });
 

--- a/src/store/aiInfra/slices/aiProvider/action.ts
+++ b/src/store/aiInfra/slices/aiProvider/action.ts
@@ -99,6 +99,39 @@ export const normalizeChatModel = async (model: EnabledAiModel): Promise<Provide
   };
 };
 
+/**
+ * Normalizes an enabled embedding model for provider model selectors.
+ *
+ * Use when:
+ * - Building model assignment dropdown options for embedding-specific tasks
+ *
+ * Expects:
+ * - A visible enabled model with `type: "embedding"` from model-bank/runtime state
+ *
+ * Returns:
+ * - A provider-list item compatible with {@link EnabledProviderWithModels}
+ */
+export const normalizeEmbeddingModel = async (
+  model: EnabledAiModel,
+): Promise<ProviderModelListItem> => {
+  const [description, knowledgeCutoff, pricing] = await Promise.all([
+    getModelProperty<string>(model, 'description'),
+    getModelProperty<string>(model, 'knowledgeCutoff'),
+    getModelProperty<Pricing>(model, 'pricing'),
+  ]);
+
+  return {
+    abilities: (model.abilities || {}) as ModelAbilities,
+    contextWindowTokens: model.contextWindowTokens,
+    displayName: model.displayName ?? '',
+    id: model.id,
+    releasedAt: model.releasedAt,
+    ...(description && { description }),
+    ...(knowledgeCutoff && { knowledgeCutoff }),
+    ...(pricing && { pricing }),
+  };
+};
+
 export const normalizeImageModel = async (
   model: EnabledAiModel,
 ): Promise<ProviderModelListItem> => {
@@ -180,6 +213,11 @@ export const getChatModelList = createProviderModelCollector('chat', async (mode
   normalizeChatModel(model),
 );
 
+export const getEmbeddingModelList = createProviderModelCollector(
+  'embedding',
+  normalizeEmbeddingModel,
+);
+
 export const getImageModelList = createProviderModelCollector('image', normalizeImageModel);
 
 export const getVideoModelList = createProviderModelCollector('video', normalizeVideoModel);
@@ -218,6 +256,14 @@ const buildChatProviderModelLists = async (
 ) => buildProviderModelLists(providers, enabledAiModels, getChatModelList);
 
 /**
+ * Build embedding provider model lists with proper async handling
+ */
+const buildEmbeddingProviderModelLists = async (
+  providers: EnabledProvider[],
+  enabledAiModels: EnabledAiModel[],
+) => buildProviderModelLists(providers, enabledAiModels, getEmbeddingModelList);
+
+/**
  * Build video provider model lists with proper async handling
  */
 const buildVideoProviderModelLists = async (
@@ -234,6 +280,7 @@ enum AiProviderSwrKey {
 type AiProviderRuntimeStateWithBuiltinModels = AiProviderRuntimeState & {
   builtinAiModelList: LobeDefaultAiModelListItem[];
   enabledChatModelList?: EnabledProviderWithModels[];
+  enabledEmbeddingModelList?: EnabledProviderWithModels[];
   enabledImageModelList?: EnabledProviderWithModels[];
   enabledVideoModelList?: EnabledProviderWithModels[];
 };
@@ -501,18 +548,30 @@ export class AiProviderActionImpl {
         if (isLogin) {
           const data = await aiProviderService.getAiProviderRuntimeState();
 
+          const enabledEmbeddingAiProviders = data.enabledAiProviders.filter((provider) => {
+            return data.enabledAiModels.some(
+              (model) => model.providerId === provider.id && model.type === 'embedding',
+            );
+          });
+
           // Build model lists with proper async handling
-          const [enabledChatModelList, enabledImageModelList, enabledVideoModelList] =
-            await Promise.all([
-              buildChatProviderModelLists(data.enabledChatAiProviders, data.enabledAiModels),
-              buildImageProviderModelLists(data.enabledImageAiProviders, data.enabledAiModels),
-              buildVideoProviderModelLists(data.enabledVideoAiProviders, data.enabledAiModels),
-            ]);
+          const [
+            enabledChatModelList,
+            enabledEmbeddingModelList,
+            enabledImageModelList,
+            enabledVideoModelList,
+          ] = await Promise.all([
+            buildChatProviderModelLists(data.enabledChatAiProviders, data.enabledAiModels),
+            buildEmbeddingProviderModelLists(enabledEmbeddingAiProviders, data.enabledAiModels),
+            buildImageProviderModelLists(data.enabledImageAiProviders, data.enabledAiModels),
+            buildVideoProviderModelLists(data.enabledVideoAiProviders, data.enabledAiModels),
+          ]);
 
           return {
             ...data,
             builtinAiModelList,
             enabledChatModelList,
+            enabledEmbeddingModelList,
             enabledImageModelList,
             enabledVideoModelList,
           };
@@ -544,14 +603,27 @@ export class AiProviderActionImpl {
           })
           .map((item) => ({ id: item.id, name: item.name, source: AiProviderSourceEnum.Builtin }));
 
+        const enabledEmbeddingAiProviders = enabledAiProviders
+          .filter((provider) => {
+            return builtinAiModelList.some(
+              (model) => model.providerId === provider.id && model.type === 'embedding',
+            );
+          })
+          .map((item) => ({ id: item.id, name: item.name, source: AiProviderSourceEnum.Builtin }));
+
         // Build model lists for non-login state as well
         const enabledAiModels = builtinAiModelList.filter((m) => m.enabled);
-        const [enabledChatModelList, enabledImageModelList, enabledVideoModelList] =
-          await Promise.all([
-            buildChatProviderModelLists(enabledChatAiProviders, enabledAiModels),
-            buildImageProviderModelLists(enabledImageAiProviders, enabledAiModels),
-            buildVideoProviderModelLists(enabledVideoAiProviders, enabledAiModels),
-          ]);
+        const [
+          enabledChatModelList,
+          enabledEmbeddingModelList,
+          enabledImageModelList,
+          enabledVideoModelList,
+        ] = await Promise.all([
+          buildChatProviderModelLists(enabledChatAiProviders, enabledAiModels),
+          buildEmbeddingProviderModelLists(enabledEmbeddingAiProviders, enabledAiModels),
+          buildImageProviderModelLists(enabledImageAiProviders, enabledAiModels),
+          buildVideoProviderModelLists(enabledVideoAiProviders, enabledAiModels),
+        ]);
 
         return {
           builtinAiModelList,
@@ -559,6 +631,7 @@ export class AiProviderActionImpl {
           enabledAiProviders,
           enabledChatAiProviders,
           enabledChatModelList,
+          enabledEmbeddingModelList,
           enabledImageAiProviders,
           enabledImageModelList,
           enabledVideoAiProviders,
@@ -577,6 +650,7 @@ export class AiProviderActionImpl {
               enabledAiModels: data.enabledAiModels,
               enabledAiProviders: data.enabledAiProviders,
               enabledChatModelList: data.enabledChatModelList || [],
+              enabledEmbeddingModelList: data.enabledEmbeddingModelList || [],
               enabledImageModelList: data.enabledImageModelList || [],
               enabledVideoModelList: data.enabledVideoModelList || [],
               isInitAiProviderRuntimeState: true,

--- a/src/store/aiInfra/slices/aiProvider/initialState.ts
+++ b/src/store/aiInfra/slices/aiProvider/initialState.ts
@@ -24,6 +24,7 @@ export interface AIProviderState {
   enabledAiProviders?: EnabledProvider[];
   // used for select
   enabledChatModelList?: EnabledProviderWithModels[];
+  enabledEmbeddingModelList?: EnabledProviderWithModels[];
   enabledImageModelList?: EnabledProviderWithModels[];
   enabledVideoModelList?: EnabledProviderWithModels[];
   initAiProviderList: boolean;

--- a/src/store/aiInfra/slices/aiProvider/selectors.ts
+++ b/src/store/aiInfra/slices/aiProvider/selectors.ts
@@ -15,6 +15,8 @@ const disabledAiProviderList = (s: AIProviderStoreState) =>
 const disabledCustomAiProviderList = (s: AIProviderStoreState) =>
   s.aiProviderList.filter((item) => !item.enabled && item.source === AiProviderSourceEnum.Custom);
 
+const enabledEmbeddingModelList = (s: AIProviderStoreState) => s.enabledEmbeddingModelList || [];
+
 const enabledImageModelList = (s: AIProviderStoreState) => s.enabledImageModelList || [];
 
 const enabledVideoModelList = (s: AIProviderStoreState) => s.enabledVideoModelList || [];
@@ -137,6 +139,7 @@ export const aiProviderSelectors = {
   disabledAiProviderList,
   disabledCustomAiProviderList,
   enabledAiProviderList,
+  enabledEmbeddingModelList,
   enabledImageModelList,
   enabledVideoModelList,
   isActiveProviderApiKeyNotEmpty,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #15520

#### 🔀 Description of Change

- Add an embedding-specific enabled model list to aiProvider runtime state.
- Let the Service Model memory embedding selector read embedding models instead of the chat-only model list.
- Keep the generic ModelSelect defaulting to chat models so existing selectors are unchanged.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
pnpm exec prettier --check 'src/store/aiInfra/slices/aiProvider/action.ts' 'src/store/aiInfra/slices/aiProvider/initialState.ts' 'src/store/aiInfra/slices/aiProvider/selectors.ts' 'src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts' 'src/features/ModelSelect/index.tsx' 'src/features/ServiceModel/ModelAssignmentsForm.tsx'
pnpm exec eslint 'src/store/aiInfra/slices/aiProvider/action.ts' 'src/store/aiInfra/slices/aiProvider/initialState.ts' 'src/store/aiInfra/slices/aiProvider/selectors.ts' 'src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts' 'src/features/ModelSelect/index.tsx' 'src/features/ServiceModel/ModelAssignmentsForm.tsx'
pnpm exec vitest run --silent='passed-only' 'src/store/aiInfra/slices/aiProvider/__tests__/action.test.ts'
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

Non-goal: this PR does not change provider configuration or model enablement rules; it only exposes already-enabled embedding models to the memory embedding selector.
