### PR TITLE
🐛 fix(topic): sort sidebar by activity time to stop list jumping

### DIFF
--- a/packages/database/src/models/__tests__/topics/topic.query.test.ts
+++ b/packages/database/src/models/__tests__/topics/topic.query.test.ts
@@ -196,11 +196,11 @@ describe('TopicModel - Query', () => {
       expect(result.items.map((t) => t.id)).toEqual(['waiting', 'active']);
     });
 
-    it('returns the latest message activity as `updatedAt`, falling back to the row updatedAt', async () => {
-      // The client sorts the sidebar by the returned `updatedAt`, so it must
-      // carry the same activity time the server ORDER BY uses (topicActivityAt),
-      // not the raw topics.updatedAt column — otherwise the two sorts disagree
-      // and the list jumps. (LOBE-11543)
+    it('returns the latest message activity as `sortUpdatedAt` while `updatedAt` stays the row value', async () => {
+      // The client sorts the sidebar by `sortUpdatedAt`, so it must carry the same
+      // activity time the server ORDER BY uses (topicActivityAt) — otherwise the two
+      // sorts disagree and the list jumps. `updatedAt` stays the raw row value so
+      // rename/favorite edits still show a real edit time. (LOBE-11543)
       await serverDB.insert(topics).values([
         { id: 'has-msg', sessionId, updatedAt: new Date('2023-01-01'), userId },
         { id: 'no-msg', sessionId, updatedAt: new Date('2023-03-01'), userId },
@@ -219,11 +219,17 @@ describe('TopicModel - Query', () => {
       const result = await topicModel.query({ containerId: sessionId });
 
       const byId = Object.fromEntries(result.items.map((t) => [t.id, t]));
-      // has-msg reflects the message time (2023-06), NOT its row updatedAt (2023-01).
-      expect(byId['has-msg'].updatedAt.toISOString()).toBe(new Date('2023-06-01').toISOString());
-      // no-msg has no messages → COALESCE falls back to the row updatedAt.
-      expect(byId['no-msg'].updatedAt.toISOString()).toBe(new Date('2023-03-01').toISOString());
-      // And the order follows the returned activity time (2023-06 before 2023-03).
+      // sortUpdatedAt reflects the message time (2023-06), NOT its row updatedAt (2023-01).
+      expect(byId['has-msg'].sortUpdatedAt?.toISOString()).toBe(
+        new Date('2023-06-01').toISOString(),
+      );
+      // updatedAt still carries the raw row value (2023-01), untouched by message activity.
+      expect(byId['has-msg'].updatedAt.toISOString()).toBe(new Date('2023-01-01').toISOString());
+      // no-msg has no messages → sortUpdatedAt COALESCE falls back to the row updatedAt.
+      expect(byId['no-msg'].sortUpdatedAt?.toISOString()).toBe(
+        new Date('2023-03-01').toISOString(),
+      );
+      // And the order follows the activity time (2023-06 before 2023-03).
       expect(result.items.map((t) => t.id)).toEqual(['has-msg', 'no-msg']);
     });
 

--- a/packages/database/src/models/__tests__/topics/topic.query.test.ts
+++ b/packages/database/src/models/__tests__/topics/topic.query.test.ts
@@ -196,6 +196,37 @@ describe('TopicModel - Query', () => {
       expect(result.items.map((t) => t.id)).toEqual(['waiting', 'active']);
     });
 
+    it('returns the latest message activity as `updatedAt`, falling back to the row updatedAt', async () => {
+      // The client sorts the sidebar by the returned `updatedAt`, so it must
+      // carry the same activity time the server ORDER BY uses (topicActivityAt),
+      // not the raw topics.updatedAt column — otherwise the two sorts disagree
+      // and the list jumps. (LOBE-11543)
+      await serverDB.insert(topics).values([
+        { id: 'has-msg', sessionId, updatedAt: new Date('2023-01-01'), userId },
+        { id: 'no-msg', sessionId, updatedAt: new Date('2023-03-01'), userId },
+      ]);
+      // An assistant message (any role counts) that is newer than the row.
+      await serverDB.insert(messages).values([
+        {
+          id: 'has-msg-latest',
+          role: 'assistant',
+          topicId: 'has-msg',
+          updatedAt: new Date('2023-06-01'),
+          userId,
+        },
+      ]);
+
+      const result = await topicModel.query({ containerId: sessionId });
+
+      const byId = Object.fromEntries(result.items.map((t) => [t.id, t]));
+      // has-msg reflects the message time (2023-06), NOT its row updatedAt (2023-01).
+      expect(byId['has-msg'].updatedAt.toISOString()).toBe(new Date('2023-06-01').toISOString());
+      // no-msg has no messages → COALESCE falls back to the row updatedAt.
+      expect(byId['no-msg'].updatedAt.toISOString()).toBe(new Date('2023-03-01').toISOString());
+      // And the order follows the returned activity time (2023-06 before 2023-03).
+      expect(result.items.map((t) => t.id)).toEqual(['has-msg', 'no-msg']);
+    });
+
     it('should query topics with pagination', async () => {
       await serverDB.insert(topics).values([
         { id: '1', userId, updatedAt: new Date('2023-01-01') },

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -297,7 +297,13 @@ export class TopicModel {
                 metadata: topics.metadata,
                 status: topics.status,
                 title: topics.title,
-                updatedAt: topics.updatedAt,
+                // Sidebar sorts topics client-side by this `updatedAt`. Return the same
+                // `topicActivityAt` the ORDER BY uses (latest message time, COALESCE
+                // fallback to the row's own updatedAt) so the client-side sort key
+                // matches the server order — otherwise returning the raw
+                // `topics.updatedAt` column makes the two sorts disagree and the list
+                // visibly jumps. See rankTopics for the same pattern. (LOBE-11543)
+                updatedAt: topicActivityAt,
                 ...detailColumns,
               } as any)
               .from(topics)
@@ -359,7 +365,13 @@ export class TopicModel {
                 metadata: topics.metadata,
                 status: topics.status,
                 title: topics.title,
-                updatedAt: topics.updatedAt,
+                // Sidebar sorts topics client-side by this `updatedAt`. Return the same
+                // `topicActivityAt` the ORDER BY uses (latest message time, COALESCE
+                // fallback to the row's own updatedAt) so the client-side sort key
+                // matches the server order — otherwise returning the raw
+                // `topics.updatedAt` column makes the two sorts disagree and the list
+                // visibly jumps. See rankTopics for the same pattern. (LOBE-11543)
+                updatedAt: topicActivityAt,
                 ...detailColumns,
               } as any)
               .from(topics)
@@ -417,7 +429,13 @@ export class TopicModel {
               sessionId: topics.sessionId,
               status: topics.status,
               title: topics.title,
-              updatedAt: topics.updatedAt,
+              // Sidebar sorts topics client-side by this `updatedAt`. Return the same
+              // `topicActivityAt` the ORDER BY uses (latest message time, COALESCE
+              // fallback to the row's own updatedAt) so the client-side sort key
+              // matches the server order — otherwise returning the raw
+              // `topics.updatedAt` column makes the two sorts disagree and the list
+              // visibly jumps. See rankTopics for the same pattern. (LOBE-11543)
+              updatedAt: topicActivityAt,
               ...detailColumns,
             } as any)
             .from(topics)

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -297,13 +297,15 @@ export class TopicModel {
                 metadata: topics.metadata,
                 status: topics.status,
                 title: topics.title,
-                // Sidebar sorts topics client-side by this `updatedAt`. Return the same
-                // `topicActivityAt` the ORDER BY uses (latest message time, COALESCE
-                // fallback to the row's own updatedAt) so the client-side sort key
-                // matches the server order — otherwise returning the raw
-                // `topics.updatedAt` column makes the two sorts disagree and the list
-                // visibly jumps. See rankTopics for the same pattern. (LOBE-11543)
-                updatedAt: topicActivityAt,
+                updatedAt: topics.updatedAt,
+                // Sidebar sorts/groups topics client-side by this `sortUpdatedAt` — the
+                // same `topicActivityAt` the ORDER BY uses (latest message time, COALESCE
+                // fallback to the row's own updatedAt). Keeping it separate from the
+                // display `updatedAt` above matches the client-side sort key to the server
+                // order (otherwise the two disagree and the list visibly jumps) while a
+                // rename/favorite edit still shows its real edit time. See rankTopics for
+                // the same activity-time pattern. (LOBE-11543)
+                sortUpdatedAt: topicActivityAt,
                 ...detailColumns,
               } as any)
               .from(topics)
@@ -365,13 +367,15 @@ export class TopicModel {
                 metadata: topics.metadata,
                 status: topics.status,
                 title: topics.title,
-                // Sidebar sorts topics client-side by this `updatedAt`. Return the same
-                // `topicActivityAt` the ORDER BY uses (latest message time, COALESCE
-                // fallback to the row's own updatedAt) so the client-side sort key
-                // matches the server order — otherwise returning the raw
-                // `topics.updatedAt` column makes the two sorts disagree and the list
-                // visibly jumps. See rankTopics for the same pattern. (LOBE-11543)
-                updatedAt: topicActivityAt,
+                updatedAt: topics.updatedAt,
+                // Sidebar sorts/groups topics client-side by this `sortUpdatedAt` — the
+                // same `topicActivityAt` the ORDER BY uses (latest message time, COALESCE
+                // fallback to the row's own updatedAt). Keeping it separate from the
+                // display `updatedAt` above matches the client-side sort key to the server
+                // order (otherwise the two disagree and the list visibly jumps) while a
+                // rename/favorite edit still shows its real edit time. See rankTopics for
+                // the same activity-time pattern. (LOBE-11543)
+                sortUpdatedAt: topicActivityAt,
                 ...detailColumns,
               } as any)
               .from(topics)
@@ -429,13 +433,15 @@ export class TopicModel {
               sessionId: topics.sessionId,
               status: topics.status,
               title: topics.title,
-              // Sidebar sorts topics client-side by this `updatedAt`. Return the same
-              // `topicActivityAt` the ORDER BY uses (latest message time, COALESCE
-              // fallback to the row's own updatedAt) so the client-side sort key
-              // matches the server order — otherwise returning the raw
-              // `topics.updatedAt` column makes the two sorts disagree and the list
-              // visibly jumps. See rankTopics for the same pattern. (LOBE-11543)
-              updatedAt: topicActivityAt,
+              updatedAt: topics.updatedAt,
+              // Sidebar sorts/groups topics client-side by this `sortUpdatedAt` — the
+              // same `topicActivityAt` the ORDER BY uses (latest message time, COALESCE
+              // fallback to the row's own updatedAt). Keeping it separate from the
+              // display `updatedAt` above matches the client-side sort key to the server
+              // order (otherwise the two disagree and the list visibly jumps) while a
+              // rename/favorite edit still shows its real edit time. See rankTopics for
+              // the same activity-time pattern. (LOBE-11543)
+              sortUpdatedAt: topicActivityAt,
               ...detailColumns,
             } as any)
             .from(topics)

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -250,6 +250,14 @@ export interface ChatTopic extends Omit<BaseDataModel, 'meta'> {
   messageCount?: number | null;
   metadata?: ChatTopicMetadata;
   sessionId?: string;
+  /**
+   * Sort key for the sidebar list: the topic's latest message-activity time
+   * (server `topicActivityAt`), falling back to `updatedAt`. Kept separate from
+   * `updatedAt` so the client sort matches the server ORDER BY (no list jumping)
+   * while `updatedAt` still reflects real row edits like rename/favorite.
+   * (LOBE-11543)
+   */
+  sortUpdatedAt?: number;
   status?: ChatTopicStatus | null;
   title: string;
   /** Server-side mock until real token aggregation lands. */

--- a/packages/utils/src/client/topic.test.ts
+++ b/packages/utils/src/client/topic.test.ts
@@ -220,6 +220,49 @@ describe('groupTopicsByUpdatedTime', () => {
     // By updatedAt: grouped under yesterday
     expect(byUpdated[0].id).toBe('yesterday');
   });
+
+  it('should group and sort by sortUpdatedAt (activity time) when present, ignoring updatedAt', () => {
+    const lastYear = dayjs().subtract(1, 'year').valueOf();
+    const today = dayjs().valueOf();
+
+    // Row was edited last year (updatedAt) but had message activity today
+    // (sortUpdatedAt) — the sidebar must group it under "today". (LOBE-11543)
+    const topic: ChatTopic = {
+      id: 'active',
+      title: 'Recently active',
+      createdAt: lastYear,
+      updatedAt: lastYear,
+      sortUpdatedAt: today,
+    };
+
+    const result = groupTopicsByUpdatedTime([topic]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('today');
+  });
+
+  it('should order rows by sortUpdatedAt (activity) over updatedAt (row edit time)', () => {
+    const base = dayjs().subtract(1, 'month').valueOf();
+    // `a` has an older row edit time but newer activity → must sort first.
+    const a: ChatTopic = {
+      id: 'a',
+      title: 'Older edit, newer activity',
+      createdAt: base,
+      updatedAt: dayjs().hour(9).valueOf(),
+      sortUpdatedAt: dayjs().hour(11).valueOf(),
+    };
+    const b: ChatTopic = {
+      id: 'b',
+      title: 'Newer edit, older activity',
+      createdAt: base,
+      updatedAt: dayjs().hour(10).valueOf(),
+      sortUpdatedAt: dayjs().hour(10).valueOf(),
+    };
+
+    const result = groupTopicsByUpdatedTime([b, a]);
+
+    expect(result[0].children.map((t) => t.id)).toEqual(['a', 'b']);
+  });
 });
 
 describe('working directory topic helpers', () => {

--- a/packages/utils/src/client/topic.ts
+++ b/packages/utils/src/client/topic.ts
@@ -71,6 +71,15 @@ const sortGroups = (groups: GroupedTopic[]): GroupedTopic[] => {
   });
 };
 
+/**
+ * Resolve the timestamp a topic sorts/groups by for the given field. For
+ * `updatedAt` this is the server-provided `sortUpdatedAt` (latest message
+ * activity), falling back to the raw `updatedAt` when absent — so the sidebar
+ * order matches the server ORDER BY and doesn't jump. (LOBE-11543)
+ */
+export const getTopicSortTime = (topic: ChatTopic, field: 'createdAt' | 'updatedAt'): number =>
+  field === 'updatedAt' ? (topic.sortUpdatedAt ?? topic.updatedAt) : topic.createdAt;
+
 // Generic time-based grouping parameterized by field
 const groupTopicsByField = (
   topics: ChatTopic[],
@@ -78,11 +87,13 @@ const groupTopicsByField = (
 ): GroupedTopic[] => {
   if (!topics.length) return [];
 
-  const sortedTopics = [...topics].sort((a, b) => b[field] - a[field]);
+  const sortedTopics = [...topics].sort(
+    (a, b) => getTopicSortTime(b, field) - getTopicSortTime(a, field),
+  );
   const groupsMap = new Map<TimeGroupId, ChatTopic[]>();
 
   for (const topic of sortedTopics) {
-    const groupId = getTopicGroupId(topic[field]);
+    const groupId = getTopicGroupId(getTopicSortTime(topic, field));
     const existing = groupsMap.get(groupId);
     if (existing) {
       existing.push(topic);
@@ -162,7 +173,7 @@ export const groupTopicsByProject = (
 
   // Sort topics inside each group by chosen field desc
   for (const group of groupsMap.values()) {
-    group.children.sort((a, b) => b[field] - a[field]);
+    group.children.sort((a, b) => getTopicSortTime(b, field) - getTopicSortTime(a, field));
   }
 
   const groups: GroupedTopic[] = Array.from(groupsMap.entries()).map(
@@ -177,8 +188,8 @@ export const groupTopicsByProject = (
   return groups.sort((a, b) => {
     if (a.id === NO_PROJECT_GROUP_ID) return 1;
     if (b.id === NO_PROJECT_GROUP_ID) return -1;
-    const aTime = a.children[0]?.[field] ?? 0;
-    const bTime = b.children[0]?.[field] ?? 0;
+    const aTime = a.children[0] ? getTopicSortTime(a.children[0], field) : 0;
+    const bTime = b.children[0] ? getTopicSortTime(b.children[0], field) : 0;
     return bTime - aTime;
   });
 };
@@ -251,7 +262,7 @@ export const groupTopicsByStatus = (
 
   // Sort topics inside each group by chosen field desc
   for (const children of groupsMap.values()) {
-    children.sort((a, b) => b[field] - a[field]);
+    children.sort((a, b) => getTopicSortTime(b, field) - getTopicSortTime(a, field));
   }
 
   // Emit only non-empty groups, in the fixed priority order

--- a/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/conversationLifecycle.test.ts
@@ -1855,8 +1855,8 @@ describe('ConversationLifecycle actions', () => {
       });
     });
 
-    describe('optimistic topic updatedAt', () => {
-      it('should optimistically update topic updatedAt when sending message to existing topic', async () => {
+    describe('optimistic topic sortUpdatedAt', () => {
+      it('should optimistically bump topic sortUpdatedAt when sending message to existing topic', async () => {
         const { result } = renderHook(() => useChatStore());
         const topicId = TEST_IDS.TOPIC_ID;
 
@@ -1878,17 +1878,17 @@ describe('ConversationLifecycle actions', () => {
           });
         });
 
-        // Should call internal_dispatchTopic with updateTopic to touch updatedAt
+        // Should call internal_dispatchTopic with updateTopic to bump the sidebar sort key
         expect(dispatchTopicSpy).toHaveBeenCalledWith(
           expect.objectContaining({
             type: 'updateTopic',
             id: topicId,
-            value: { updatedAt: expect.any(Number) },
+            value: { sortUpdatedAt: expect.any(Number) },
           }),
         );
       });
 
-      it('should NOT optimistically update topic updatedAt when server returns topics (new topic)', async () => {
+      it('should NOT optimistically bump topic sortUpdatedAt when server returns topics (new topic)', async () => {
         const { result } = renderHook(() => useChatStore());
 
         const dispatchTopicSpy = vi.spyOn(result.current, 'internal_dispatchTopic');
@@ -1912,9 +1912,9 @@ describe('ConversationLifecycle actions', () => {
           });
         });
 
-        // Should NOT call internal_dispatchTopic with updateTopic for updatedAt
+        // Should NOT call internal_dispatchTopic with updateTopic for sortUpdatedAt
         const updateTopicCalls = dispatchTopicSpy.mock.calls.filter(
-          ([payload]) => payload.type === 'updateTopic' && 'updatedAt' in (payload.value || {}),
+          ([payload]) => payload.type === 'updateTopic' && 'sortUpdatedAt' in (payload.value || {}),
         );
         expect(updateTopicCalls).toHaveLength(0);
       });

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -1189,11 +1189,14 @@ export class ConversationLifecycleActionImpl {
         this.#get().updateOperationMetadata(operationId, { createdTopicId: data.topicId });
         void Promise.resolve(this.#get().refreshTopic()).catch(console.error);
       } else if (operationContext.topicId) {
-        // Optimistically update topic's updatedAt so sidebar re-groups immediately
+        // Optimistically bump the sort key (`sortUpdatedAt`, the sidebar's activity-time
+        // sort/group key) so the topic jumps to the top immediately, before the SWR
+        // refetch returns the server's fresh `topicActivityAt`. Bumping `updatedAt` here
+        // would no longer reorder anything — the sidebar sorts by `sortUpdatedAt`. (LOBE-11543)
         this.#get().internal_dispatchTopic({
           type: 'updateTopic',
           id: operationContext.topicId,
-          value: { updatedAt: Date.now() },
+          value: { sortUpdatedAt: Date.now() },
         });
       }
 

--- a/src/store/chat/slices/topic/reducer.ts
+++ b/src/store/chat/slices/topic/reducer.ts
@@ -53,6 +53,10 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
           favorite: false,
           id: payload.value.id ?? Date.now().toString(),
           sessionId: payload.value.sessionId || undefined,
+          // A brand-new topic is fresh activity: seed the sidebar sort key so it
+          // lands at the top immediately, matching the server's `topicActivityAt`
+          // once the real row is fetched. (LOBE-11543)
+          sortUpdatedAt: Date.now(),
           updatedAt: Date.now(),
         });
 
@@ -72,19 +76,13 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
           // Only update if the merged value is different from current (excluding updatedAt).
           // Compare against a plain snapshot, not the raw draft proxy — see message/reducer.ts.
           if (!isEqual(current(currentTopic), mergedTopic)) {
-            // Status flips (running/unread/read bookkeeping) are not user activity —
-            // bumping updatedAt here reorders the updatedAt-sorted sidebar on every
-            // run end / topic read, and the bump reverts on the next refetch (the
-            // server orders by latest-message time), so rows visibly jump around.
-            const isStatusOnlyWrite = Object.keys(value).every((key) => key === 'status');
-
-            if (isStatusOnlyWrite) {
-              draftState[topicIndex] = mergedTopic;
-            } else {
-              // TODO: updatedAt type needs to be changed to Date later
-              // @ts-ignore
-              draftState[topicIndex] = { ...mergedTopic, updatedAt: new Date() };
-            }
+            // Bump `updatedAt` (display/edit time) on every real write. The sidebar
+            // no longer sorts by `updatedAt` — it sorts by `sortUpdatedAt` (activity
+            // time) — so a status flip bumping `updatedAt` here can't reorder the
+            // list; only an explicit `sortUpdatedAt` in `value` moves a row. (LOBE-11543)
+            // TODO: updatedAt type needs to be changed to Date later
+            // @ts-ignore
+            draftState[topicIndex] = { ...mergedTopic, updatedAt: new Date() };
           }
         }
       });
@@ -105,6 +103,10 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
           ...nextTopic,
           ...value,
           id: nextId,
+          // Resolving a first-send optimistic topic to its real id is fresh activity:
+          // keep it pinned to the top via the sidebar sort key (`sortUpdatedAt`), not
+          // just `updatedAt` which the sidebar no longer sorts by. (LOBE-11543)
+          sortUpdatedAt: Date.now(),
           updatedAt: Date.now(),
         };
 

--- a/src/store/chat/slices/topic/selectors.ts
+++ b/src/store/chat/slices/topic/selectors.ts
@@ -10,6 +10,7 @@ import {
   type TopicSortBy,
 } from '@/types/topic';
 import {
+  getTopicSortTime,
   groupTopicsByProject,
   groupTopicsByStatus,
   groupTopicsByTime,
@@ -130,7 +131,7 @@ const isSearchingTopic = (s: ChatStoreState) => s.isSearchingTopic;
 
 const sortTopics = (topics: ChatTopic[], sortBy: TopicSortBy): ChatTopic[] => {
   const field = sortBy === 'createdAt' ? 'createdAt' : 'updatedAt';
-  return [...topics].sort((a, b) => b[field] - a[field]);
+  return [...topics].sort((a, b) => getTopicSortTime(b, field) - getTopicSortTime(a, field));
 };
 
 // Limit topics for sidebar display based on user's page size preference


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Related to LOBE-11543.

#### 🔀 Description of Change

The topic sidebar sorts client-side by the returned `updatedAt`, but the server ORDER BY uses `topicActivityAt` — the latest message's `updatedAt`, with a COALESCE fallback to the row's own `updatedAt` — while the SELECT returned the raw `topics.updatedAt` column. **The two sort keys disagree**, so:

- A topic that just got a new message rises on the server but not on the client (its row `updatedAt` didn't change), so it fails to move to the top until a refetch.
- A pure `status` flip (run-end `unread` / mark-read) bumps the row `updatedAt`, yanking that row to the top client-side; the next refetch orders by message time and snaps it back — the list visibly jumps.

**Fix:** the server returns the activity time as a dedicated **`sortUpdatedAt`** field (the same `topicActivityAt` the ORDER BY uses), keeping `updatedAt` as the raw row-modification time. The client sorts and groups by `sortUpdatedAt ?? updatedAt`, so the client sort key always equals the server order and the two can no longer disagree. Because sorting no longer keys on `updatedAt`, a rename / favorite / status write can bump the display `updatedAt` without ever reordering the list.

#### 🧭 Key Decisions

- **Dedicated `sortUpdatedAt` field instead of overwriting `updatedAt`.** An earlier revision overwrote `updatedAt` with the activity time; this splits the concern so `updatedAt` still reflects real row edits (rename/favorite show a true edit time) while `sortUpdatedAt` drives ordering. Added as optional `ChatTopic.sortUpdatedAt?: number`; all sort/group paths route through a single `getTopicSortTime()` helper.
- **`topicActivityAt` keeps its current semantics: latest message `updatedAt`, any role — not restricted to `role = 'user'`.** Manual regeneration must keep a topic on top, and regeneration only touches the assistant message (no user message); a `role = 'user'` filter would drop regenerated topics from the top. So the literal "sort by user message" idea was intentionally not taken.
- **Optimistic top-placement preserved.** Send/regenerate on an existing topic and first-send tmp-topic resolution now bump `sortUpdatedAt` (not `updatedAt`) so the row jumps to the top immediately, before the SWR refetch returns the server's fresh activity time.
- **Retired the `isStatusOnlyWrite` guard** in the topic reducer — it existed only to stop status flips from reordering the `updatedAt`-sorted sidebar; with sorting keyed on `sortUpdatedAt` that can't happen, so the special case is gone.
- **Non-goal:** the translation/TTS noise (acting on an old message bumps `messages.updatedAt` and lifts an old topic) is out of scope here; it needs those passive-enrich writes to stop touching `updatedAt` and will be handled separately.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- DB model (`topic.query.test.ts`): a topic whose row `updatedAt` is old (2023-01) but has a newer message (2023-06) returns `sortUpdatedAt` = the message time while `updatedAt` stays the raw row value; a topic with no messages falls back; ordering follows `sortUpdatedAt`.
- Client utils (`topic.test.ts`): grouping/ordering keys on `sortUpdatedAt` (activity) over `updatedAt` (row edit) when present.
- Store (`conversationLifecycle.test.ts`): existing-topic send optimistically bumps `sortUpdatedAt`; new-topic path does not.

#### 📝 Additional Information

Query field addition + client sort-key change — no migration, no env, no feature flag.