### PR TITLE
🐛 fix(agent): web execution-target display + workingDirectory leak

### DIFF
--- a/apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts
@@ -70,6 +70,35 @@ describe('serverMessagesEngine', () => {
       expect(result[0].content).toBe(systemRole + '\n\n' + getCurrentDateContent());
     });
 
+    it('renders {{workingDirectory}} to a fallback instead of leaking the literal (LOBE-11473)', async () => {
+      const messages = createBasicMessages();
+      const systemRole = '<working-directory>{{workingDirectory}}</working-directory>';
+
+      // No additionalVariables — e.g. a web-originated device run whose bound cwd
+      // could not be resolved. The literal must never survive into the prompt.
+      const fallback = await serverMessagesEngine({
+        messages,
+        model: 'gpt-4',
+        provider: 'openai',
+        systemRole,
+      });
+      expect(fallback[0].content).not.toContain('{{workingDirectory}}');
+      expect(fallback[0].content).toContain('(not specified, use user Home directory as default)');
+
+      // A resolved cwd (deviceSystemInfo.workingDirectory) overrides the fallback.
+      const resolved = await serverMessagesEngine({
+        additionalVariables: { workingDirectory: '/Users/tj/project' },
+        messages,
+        model: 'gpt-4',
+        provider: 'openai',
+        systemRole,
+      });
+      expect(resolved[0].content).toContain(
+        '<working-directory>/Users/tj/project</working-directory>',
+      );
+      expect(resolved[0].content).not.toContain('(not specified');
+    });
+
     it('should inject model knowledge cutoff when provided', async () => {
       const messages = createBasicMessages();
 

--- a/apps/server/src/modules/Mecha/ContextEngineering/index.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/index.ts
@@ -24,6 +24,14 @@ const createServerVariableGenerators = (params: {
     // Model-related variables
     model: () => model ?? '',
     provider: () => provider ?? '',
+    // Working directory fallback. Unlike the client generator, the server has no
+    // store to resolve cwd from — the real value arrives via `additionalVariables`
+    // (`deviceSystemInfo.workingDirectory`, only set when a device-run's bound cwd
+    // resolves) and overrides this through the spread order below. Without this
+    // fallback, a device-run whose cwd can't be resolved (e.g. a web-originated
+    // session with no bound directory) leaves `{{workingDirectory}}` unmatched and
+    // leaks the literal into the local-system system prompt (LOBE-11473).
+    workingDirectory: () => '(not specified, use user Home directory as default)',
   };
 };
 

--- a/src/features/AgentDocumentPage/RightPanel/index.tsx
+++ b/src/features/AgentDocumentPage/RightPanel/index.tsx
@@ -12,6 +12,7 @@ import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { isDesktop } from '@/const/version';
 import RightPanel from '@/features/RightPanel';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
+import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
 import { useClientDataSWR } from '@/libs/swr';
 import AgentDocumentsGroup from '@/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup';
@@ -19,7 +20,6 @@ import { agentDocumentService, agentDocumentSWRKeys } from '@/services/agentDocu
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, agentSelectors } from '@/store/agent/selectors';
 import { useGlobalStore } from '@/store/global';
-import { getServerConfigStoreState } from '@/store/serverConfig';
 import { standardizeIdentifier } from '@/utils/identifier';
 
 type AgentDocumentPanelTab = 'documents' | 'skills';
@@ -82,7 +82,7 @@ const AgentDocumentRightPanel = memo(() => {
   const agencyConfig = useAgentStore((s) =>
     activeAgentId ? agentByIdSelectors.getAgencyConfigById(activeAgentId)(s) : undefined,
   );
-  const deviceRoutingAvailable = !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl;
+  const deviceRoutingAvailable = isGatewayModeEnabled(activeAgentId);
   const effectiveTarget = resolveExecutionTarget(agencyConfig, {
     clientExecutionAvailable: isDesktop,
     deviceRoutingAvailable,

--- a/src/features/AgentDocumentPage/RightPanel/index.tsx
+++ b/src/features/AgentDocumentPage/RightPanel/index.tsx
@@ -12,7 +12,7 @@ import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import { isDesktop } from '@/const/version';
 import RightPanel from '@/features/RightPanel';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
-import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
+import { useIsGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
 import { useClientDataSWR } from '@/libs/swr';
 import AgentDocumentsGroup from '@/routes/(main)/agent/features/Conversation/WorkingSidebar/ResourcesSection/AgentDocumentsGroup';
@@ -82,7 +82,7 @@ const AgentDocumentRightPanel = memo(() => {
   const agencyConfig = useAgentStore((s) =>
     activeAgentId ? agentByIdSelectors.getAgencyConfigById(activeAgentId)(s) : undefined,
   );
-  const deviceRoutingAvailable = isGatewayModeEnabled(activeAgentId);
+  const deviceRoutingAvailable = useIsGatewayModeEnabled(activeAgentId);
   const effectiveTarget = resolveExecutionTarget(agencyConfig, {
     clientExecutionAvailable: isDesktop,
     deviceRoutingAvailable,

--- a/src/features/AgentDocumentPage/RightPanel/index.tsx
+++ b/src/features/AgentDocumentPage/RightPanel/index.tsx
@@ -19,6 +19,7 @@ import { agentDocumentService, agentDocumentSWRKeys } from '@/services/agentDocu
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, agentSelectors } from '@/store/agent/selectors';
 import { useGlobalStore } from '@/store/global';
+import { getServerConfigStoreState } from '@/store/serverConfig';
 import { standardizeIdentifier } from '@/utils/identifier';
 
 type AgentDocumentPanelTab = 'documents' | 'skills';
@@ -81,9 +82,11 @@ const AgentDocumentRightPanel = memo(() => {
   const agencyConfig = useAgentStore((s) =>
     activeAgentId ? agentByIdSelectors.getAgencyConfigById(activeAgentId)(s) : undefined,
   );
+  const deviceRoutingAvailable = !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl;
   const effectiveTarget = resolveExecutionTarget(agencyConfig, {
-    isHetero,
     clientExecutionAvailable: isDesktop,
+    deviceRoutingAvailable,
+    isHetero,
   });
   const remoteDeviceId =
     effectiveTarget === 'device' && agencyConfig?.boundDeviceId

--- a/src/features/AgentTaskManager/AgentSelectorAction.test.tsx
+++ b/src/features/AgentTaskManager/AgentSelectorAction.test.tsx
@@ -71,6 +71,7 @@ vi.mock('antd-style', () => ({
 
 vi.mock('lucide-react', () => ({
   ChevronsUpDownIcon: () => <span data-testid="chevron" />,
+  Circle: () => <span data-testid="circle" />,
 }));
 
 vi.mock('react-i18next', () => ({

--- a/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
@@ -26,7 +26,7 @@ import { useTranslation } from 'react-i18next';
 import { useSelectExecutionTarget } from '@/features/ChatInput/hooks/useSelectExecutionTarget';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
-import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
+import { useIsGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { lambdaQuery } from '@/libs/trpc/client';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
@@ -372,7 +372,7 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
   // Effective target: shared with server dispatch. In particular, a hetero
   // desktop "local" selection that carries this desktop's boundDeviceId becomes
   // a device target when the same agent is opened from web.
-  const deviceRoutingAvailable = isGatewayModeEnabled(agentId);
+  const deviceRoutingAvailable = useIsGatewayModeEnabled(agentId);
   const executionTarget = resolveExecutionTarget(agencyConfig, {
     clientExecutionAvailable: isDesktop,
     deviceRoutingAvailable,

--- a/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
@@ -30,6 +30,7 @@ import { lambdaQuery } from '@/libs/trpc/client';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useElectronStore } from '@/store/electron';
+import { getServerConfigStoreState } from '@/store/serverConfig';
 
 const styles = createStaticStyles(({ css }) => ({
   button: css`
@@ -371,9 +372,11 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
   // Effective target: shared with server dispatch. In particular, a hetero
   // desktop "local" selection that carries this desktop's boundDeviceId becomes
   // a device target when the same agent is opened from web.
+  const deviceRoutingAvailable = !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl;
   const executionTarget = resolveExecutionTarget(agencyConfig, {
-    isHetero,
     clientExecutionAvailable: isDesktop,
+    deviceRoutingAvailable,
+    isHetero,
   });
 
   const selectExecutionTarget = useSelectExecutionTarget(agentId);

--- a/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
@@ -26,11 +26,11 @@ import { useTranslation } from 'react-i18next';
 import { useSelectExecutionTarget } from '@/features/ChatInput/hooks/useSelectExecutionTarget';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
+import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { lambdaQuery } from '@/libs/trpc/client';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useElectronStore } from '@/store/electron';
-import { getServerConfigStoreState } from '@/store/serverConfig';
 
 const styles = createStaticStyles(({ css }) => ({
   button: css`
@@ -372,7 +372,7 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
   // Effective target: shared with server dispatch. In particular, a hetero
   // desktop "local" selection that carries this desktop's boundDeviceId becomes
   // a device target when the same agent is opened from web.
-  const deviceRoutingAvailable = !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl;
+  const deviceRoutingAvailable = isGatewayModeEnabled(agentId);
   const executionTarget = resolveExecutionTarget(agencyConfig, {
     clientExecutionAvailable: isDesktop,
     deviceRoutingAvailable,

--- a/src/features/ChatInput/ControlBar/WorkspaceControls.tsx
+++ b/src/features/ChatInput/ControlBar/WorkspaceControls.tsx
@@ -4,7 +4,7 @@ import { isDesktop } from '@lobechat/const';
 import { memo } from 'react';
 
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
-import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
+import { useIsGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
 
@@ -37,7 +37,7 @@ const WorkspaceControls = memo<WorkspaceControlsProps>(
     const runtimeMode = useAgentStore(chatConfigByIdSelectors.getRuntimeModeById(agentId));
     const isHeterogeneous = useAgentStore(agentByIdSelectors.isAgentHeterogeneousById(agentId));
     const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));
-    const deviceRoutingAvailable = isGatewayModeEnabled(agentId);
+    const deviceRoutingAvailable = useIsGatewayModeEnabled(agentId);
     const effectiveTarget = resolveExecutionTarget(agencyConfig, {
       clientExecutionAvailable: isDesktop,
       deviceRoutingAvailable,

--- a/src/features/ChatInput/ControlBar/WorkspaceControls.tsx
+++ b/src/features/ChatInput/ControlBar/WorkspaceControls.tsx
@@ -4,9 +4,9 @@ import { isDesktop } from '@lobechat/const';
 import { memo } from 'react';
 
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
+import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
-import { getServerConfigStoreState } from '@/store/serverConfig';
 
 import CloudRepoSwitcher from './CloudRepoSwitcher';
 import HeteroDeviceSwitcher from './HeteroDeviceSwitcher';
@@ -37,7 +37,7 @@ const WorkspaceControls = memo<WorkspaceControlsProps>(
     const runtimeMode = useAgentStore(chatConfigByIdSelectors.getRuntimeModeById(agentId));
     const isHeterogeneous = useAgentStore(agentByIdSelectors.isAgentHeterogeneousById(agentId));
     const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));
-    const deviceRoutingAvailable = !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl;
+    const deviceRoutingAvailable = isGatewayModeEnabled(agentId);
     const effectiveTarget = resolveExecutionTarget(agencyConfig, {
       clientExecutionAvailable: isDesktop,
       deviceRoutingAvailable,

--- a/src/features/ChatInput/ControlBar/WorkspaceControls.tsx
+++ b/src/features/ChatInput/ControlBar/WorkspaceControls.tsx
@@ -6,6 +6,7 @@ import { memo } from 'react';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, chatConfigByIdSelectors } from '@/store/agent/selectors';
+import { getServerConfigStoreState } from '@/store/serverConfig';
 
 import CloudRepoSwitcher from './CloudRepoSwitcher';
 import HeteroDeviceSwitcher from './HeteroDeviceSwitcher';
@@ -36,9 +37,11 @@ const WorkspaceControls = memo<WorkspaceControlsProps>(
     const runtimeMode = useAgentStore(chatConfigByIdSelectors.getRuntimeModeById(agentId));
     const isHeterogeneous = useAgentStore(agentByIdSelectors.isAgentHeterogeneousById(agentId));
     const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));
+    const deviceRoutingAvailable = !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl;
     const effectiveTarget = resolveExecutionTarget(agencyConfig, {
-      isHetero: isHeterogeneous,
       clientExecutionAvailable: isDesktop,
+      deviceRoutingAvailable,
+      isHetero: isHeterogeneous,
     });
     const isDeviceMode = effectiveTarget === 'device' && !!agencyConfig?.boundDeviceId;
 

--- a/src/features/ChatInput/InputEditor/ActionTag/useSlashActionItems.ts
+++ b/src/features/ChatInput/InputEditor/ActionTag/useSlashActionItems.ts
@@ -15,6 +15,7 @@ import { useFetchProjectSkills } from '@/hooks/useFetchProjectSkills';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
+import { getServerConfigStoreState } from '@/store/serverConfig';
 import { useToolStore } from '@/store/tool';
 import { agentDocumentSkillsSelectors } from '@/store/tool/selectors';
 import type { AgentDocumentSkillItem } from '@/store/tool/slices/agentDocumentSkills/initialState';
@@ -69,9 +70,11 @@ export const useSlashActionItems = (): SlashOptions['items'] => {
   const isHetero = useAgentStore((s) =>
     agentId ? agentByIdSelectors.isAgentHeterogeneousById(agentId)(s) : false,
   );
+  const deviceRoutingAvailable = !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl;
   const effectiveTarget = resolveExecutionTarget(agencyConfig, {
-    isHetero,
     clientExecutionAvailable: isDesktop,
+    deviceRoutingAvailable,
+    isHetero,
   });
   const isDeviceMode = effectiveTarget === 'device' && !!agencyConfig?.boundDeviceId;
   const remoteDeviceId = isDeviceMode ? agencyConfig.boundDeviceId : undefined;

--- a/src/features/ChatInput/InputEditor/ActionTag/useSlashActionItems.ts
+++ b/src/features/ChatInput/InputEditor/ActionTag/useSlashActionItems.ts
@@ -10,12 +10,12 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
+import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
 import { useFetchProjectSkills } from '@/hooks/useFetchProjectSkills';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
-import { getServerConfigStoreState } from '@/store/serverConfig';
 import { useToolStore } from '@/store/tool';
 import { agentDocumentSkillsSelectors } from '@/store/tool/selectors';
 import type { AgentDocumentSkillItem } from '@/store/tool/slices/agentDocumentSkills/initialState';
@@ -70,7 +70,7 @@ export const useSlashActionItems = (): SlashOptions['items'] => {
   const isHetero = useAgentStore((s) =>
     agentId ? agentByIdSelectors.isAgentHeterogeneousById(agentId)(s) : false,
   );
-  const deviceRoutingAvailable = !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl;
+  const deviceRoutingAvailable = isGatewayModeEnabled(agentId);
   const effectiveTarget = resolveExecutionTarget(agencyConfig, {
     clientExecutionAvailable: isDesktop,
     deviceRoutingAvailable,

--- a/src/features/ChatInput/InputEditor/ActionTag/useSlashActionItems.ts
+++ b/src/features/ChatInput/InputEditor/ActionTag/useSlashActionItems.ts
@@ -10,7 +10,7 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
-import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
+import { useIsGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
 import { useFetchProjectSkills } from '@/hooks/useFetchProjectSkills';
 import { useAgentStore } from '@/store/agent';
@@ -70,7 +70,7 @@ export const useSlashActionItems = (): SlashOptions['items'] => {
   const isHetero = useAgentStore((s) =>
     agentId ? agentByIdSelectors.isAgentHeterogeneousById(agentId)(s) : false,
   );
-  const deviceRoutingAvailable = isGatewayModeEnabled(agentId);
+  const deviceRoutingAvailable = useIsGatewayModeEnabled(agentId);
   const effectiveTarget = resolveExecutionTarget(agencyConfig, {
     clientExecutionAvailable: isDesktop,
     deviceRoutingAvailable,

--- a/src/features/SkillsList/useProjectSkillResolver.ts
+++ b/src/features/SkillsList/useProjectSkillResolver.ts
@@ -5,6 +5,7 @@ import { resolveExecutionTarget } from '@/helpers/executionTarget';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
+import { getServerConfigStoreState } from '@/store/serverConfig';
 
 import { useProjectSkills } from './useProjectSkills';
 
@@ -48,8 +49,10 @@ export const useProjectSkillResolver = (
   const isHetero = useAgentStore((s) =>
     agentId ? agentByIdSelectors.isAgentHeterogeneousById(agentId)(s) : false,
   );
+  const deviceRoutingAvailable = !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl;
   const effectiveTarget = resolveExecutionTarget(agencyConfig, {
     clientExecutionAvailable: isDesktop,
+    deviceRoutingAvailable,
     isHetero,
   });
   const isDeviceMode = effectiveTarget === 'device' && !!agencyConfig?.boundDeviceId;

--- a/src/features/SkillsList/useProjectSkillResolver.ts
+++ b/src/features/SkillsList/useProjectSkillResolver.ts
@@ -2,10 +2,10 @@ import { isDesktop } from '@lobechat/const';
 import { useCallback } from 'react';
 
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
+import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
-import { getServerConfigStoreState } from '@/store/serverConfig';
 
 import { useProjectSkills } from './useProjectSkills';
 
@@ -49,7 +49,7 @@ export const useProjectSkillResolver = (
   const isHetero = useAgentStore((s) =>
     agentId ? agentByIdSelectors.isAgentHeterogeneousById(agentId)(s) : false,
   );
-  const deviceRoutingAvailable = !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl;
+  const deviceRoutingAvailable = isGatewayModeEnabled(agentId);
   const effectiveTarget = resolveExecutionTarget(agencyConfig, {
     clientExecutionAvailable: isDesktop,
     deviceRoutingAvailable,

--- a/src/features/SkillsList/useProjectSkillResolver.ts
+++ b/src/features/SkillsList/useProjectSkillResolver.ts
@@ -2,7 +2,7 @@ import { isDesktop } from '@lobechat/const';
 import { useCallback } from 'react';
 
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
-import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
+import { useIsGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
@@ -49,7 +49,7 @@ export const useProjectSkillResolver = (
   const isHetero = useAgentStore((s) =>
     agentId ? agentByIdSelectors.isAgentHeterogeneousById(agentId)(s) : false,
   );
-  const deviceRoutingAvailable = isGatewayModeEnabled(agentId);
+  const deviceRoutingAvailable = useIsGatewayModeEnabled(agentId);
   const effectiveTarget = resolveExecutionTarget(agencyConfig, {
     clientExecutionAvailable: isDesktop,
     deviceRoutingAvailable,

--- a/src/helpers/executionTarget.test.ts
+++ b/src/helpers/executionTarget.test.ts
@@ -45,7 +45,11 @@ describe('resolveExecutionTarget', () => {
     ).toBe('local');
   });
 
-  it('routes hetero desktop-local bindings to the bound device on web', () => {
+  it('routes a bound desktop-local selection to the bound device on web (plain and hetero)', () => {
+    // LOBE-11473: a `local` pick pins this desktop's own deviceId as
+    // `boundDeviceId`; on web that config still runs on the bound device
+    // server-side, so surface it honestly as `device` instead of masquerading
+    // as `sandbox`. This applies to plain agents too, not just hetero.
     expect(
       resolveExecutionTarget(cfg({ boundDeviceId: 'device-a', executionTarget: 'local' }), {
         clientExecutionAvailable: false,
@@ -57,7 +61,7 @@ describe('resolveExecutionTarget', () => {
       resolveExecutionTarget(cfg({ boundDeviceId: 'device-a', executionTarget: 'local' }), {
         clientExecutionAvailable: false,
       }),
-    ).toBe('sandbox');
+    ).toBe('device');
   });
 
   it('keeps `device` on web (a bound device is reachable from anywhere)', () => {

--- a/src/helpers/executionTarget.test.ts
+++ b/src/helpers/executionTarget.test.ts
@@ -45,11 +45,12 @@ describe('resolveExecutionTarget', () => {
     ).toBe('local');
   });
 
-  it('routes a bound desktop-local selection to the bound device on web (plain and hetero)', () => {
+  it('routes a bound desktop-local selection to the bound device on web when device routing is available (plain and hetero)', () => {
     // LOBE-11473: a `local` pick pins this desktop's own deviceId as
     // `boundDeviceId`; on web that config still runs on the bound device
     // server-side, so surface it honestly as `device` instead of masquerading
-    // as `sandbox`. This applies to plain agents too, not just hetero.
+    // as `sandbox`. Hetero agents always route here; plain agents need a
+    // device-gateway (`deviceRoutingAvailable`) to actually reach the machine.
     expect(
       resolveExecutionTarget(cfg({ boundDeviceId: 'device-a', executionTarget: 'local' }), {
         clientExecutionAvailable: false,
@@ -60,8 +61,22 @@ describe('resolveExecutionTarget', () => {
     expect(
       resolveExecutionTarget(cfg({ boundDeviceId: 'device-a', executionTarget: 'local' }), {
         clientExecutionAvailable: false,
+        deviceRoutingAvailable: true,
       }),
     ).toBe('device');
+  });
+
+  it('keeps a bound `local` as `sandbox` when no device routing is available (LOBE-11473 regression)', () => {
+    // A plain agent with a bound `local` target but no device-gateway to route
+    // it (self-host without DEVICE_GATEWAY_URL, or any server call that leaves
+    // `deviceRoutingAvailable` unset) must fall back to the cloud sandbox — it
+    // cannot reach the bound device. Guards against resolving to
+    // `device`/`device-unrouted` and stripping sandbox tools server-side.
+    expect(
+      resolveExecutionTarget(cfg({ boundDeviceId: 'device-a', executionTarget: 'local' }), {
+        clientExecutionAvailable: false,
+      }),
+    ).toBe('sandbox');
   });
 
   it('keeps `device` on web (a bound device is reachable from anywhere)', () => {
@@ -195,6 +210,14 @@ describe('resolveRuntimeMode', () => {
     // executionTarget=local synced from desktop, resolved on web → sandbox → cloud
     expect(resolveRuntimeMode(cfg({ executionTarget: 'local' }), false)).toBe('cloud');
   });
+
+  it('routes a bound web `local` to device (runtimeMode none) only when device routing is available', () => {
+    const boundLocal = cfg({ boundDeviceId: 'device-a', executionTarget: 'local' });
+    // with a device-gateway → device → runtimeMode none (routed via the plan)
+    expect(resolveRuntimeMode(boundLocal, false, true)).toBe('none');
+    // without one → sandbox → cloud (LOBE-11473 regression guard)
+    expect(resolveRuntimeMode(boundLocal, false)).toBe('cloud');
+  });
 });
 
 describe('resolveExecutionPlan', () => {
@@ -229,6 +252,20 @@ describe('resolveExecutionPlan', () => {
           agencyConfig: cfg({ boundDeviceId: 'device-a', executionTarget: 'sandbox' }),
           clientExecutionAvailable: true,
           onlineDeviceIds: ONLINE_A,
+        }),
+      ).toEqual({ kind: 'sandbox', target: 'sandbox' });
+    });
+
+    it('keeps a bound `local` as sandbox on a no-gateway backend (LOBE-11473 regression)', () => {
+      // No device-gateway: `clientExecutionAvailable` is false and the plan
+      // never passes `deviceRoutingAvailable`, so a bound `local` target must
+      // resolve to the sandbox — not `device`/`device-unrouted`, which would
+      // strip cloud-sandbox tools on a self-host without device routing.
+      expect(
+        resolveExecutionPlan({
+          agencyConfig: cfg({ boundDeviceId: 'device-a', executionTarget: 'local' }),
+          clientExecutionAvailable: false,
+          onlineDeviceIds: [],
         }),
       ).toEqual({ kind: 'sandbox', target: 'sandbox' });
     });

--- a/src/helpers/executionTarget.ts
+++ b/src/helpers/executionTarget.ts
@@ -41,6 +41,26 @@ export interface ResolveExecutionTargetOptions {
    */
   clientExecutionAvailable: boolean;
   /**
+   * Whether a device-gateway can route the run to a registered device in this
+   * environment. Orthogonal to {@link clientExecutionAvailable} (in-process
+   * `local` capability): the two coincide on a server (both equal
+   * `gatewayConfigured`), but split on the web client — the browser can't run
+   * `local` in-process (`clientExecutionAvailable` false) yet its backend may
+   * still have a device-gateway that routes to a `lh connect`-ed machine
+   * (`deviceRoutingAvailable` true).
+   *
+   * Gates ONLY the web-display upgrade of a bound `local` target to `device`
+   * (see `resolveExecutionTarget`). Server execution never relies on it: with a
+   * gateway `clientExecutionAvailable` is already true (branch skipped, `local`
+   * routes to a device via `resolveExecutionPlan`); without one the target must
+   * stay `sandbox`. So server callers leave it `undefined` (false) and the
+   * branch is a no-op there — only web display sites pass
+   * `!!serverConfig.agentGatewayUrl` to keep the honest device display
+   * (LOBE-11473). `isHetero` also satisfies the gate: a hetero agent's bound
+   * `local` was always surfaced as `device` on web regardless of gateway state.
+   */
+  deviceRoutingAvailable?: boolean;
+  /**
    * Heterogeneous agents (Claude Code / Codex) bring their own toolchain and
    * must execute somewhere, so `'none'` is not a valid target for them: it
    * coerces to `'local'` on desktop and `'sandbox'` on web.
@@ -80,10 +100,18 @@ export interface ResolveExecutionTargetOptions {
  * `deviceId` as `boundDeviceId` (see `useSelectExecutionTarget`), and the
  * server routes such a config to that bound device — so on web we resolve it
  * to `device`, surfacing honestly that it runs on the user's machine (via
- * `lh connect`) instead of masquerading as `sandbox`. Only an UNBOUND `local`
- * (no `boundDeviceId`) falls back to `sandbox` on web. This applies to plain
+ * `lh connect`) instead of masquerading as `sandbox`. This applies to plain
  * agents too, not just heterogeneous CLI agents (LOBE-11473: plain agents used
  * to leak here, showing "cloud sandbox" while the server ran on the device).
+ *
+ * This upgrade is gated on `deviceRoutingAvailable` (or `isHetero`): the run
+ * can only reach the bound device if a device-gateway exists to route it. Web
+ * display sites pass `!!serverConfig.agentGatewayUrl` (cloud always has one);
+ * a no-gateway self-host has no route, so its bound `local` stays `sandbox`.
+ * An UNBOUND `local` (no `boundDeviceId`) always falls back to `sandbox` on web.
+ * Server callers leave `deviceRoutingAvailable` unset — with a gateway they
+ * already pass `clientExecutionAvailable: true` and skip this branch, so it is
+ * inert server-side and never diverts a no-gateway run away from `sandbox`.
  *
  * Bot triggers (`trigger === bot`) upgrade a `local` target (a bot has no UI
  * to pick a device and `local` in-process IPC is unreachable from the cloud
@@ -93,11 +121,21 @@ export interface ResolveExecutionTargetOptions {
  */
 export const resolveExecutionTarget = (
   agencyConfig: LobeAgentAgencyConfig | undefined,
-  { clientExecutionAvailable, isHetero, trigger }: ResolveExecutionTargetOptions,
+  {
+    clientExecutionAvailable,
+    deviceRoutingAvailable,
+    isHetero,
+    trigger,
+  }: ResolveExecutionTargetOptions,
 ): DeviceExecutionTarget => {
   const stored = agencyConfig?.executionTarget;
   let effective = stored ?? (clientExecutionAvailable ? 'local' : 'none');
-  if (!clientExecutionAvailable && stored === 'local' && agencyConfig?.boundDeviceId) {
+  if (
+    !clientExecutionAvailable &&
+    (isHetero || deviceRoutingAvailable) &&
+    stored === 'local' &&
+    agencyConfig?.boundDeviceId
+  ) {
     return 'device';
   }
   if (isHetero && effective === 'none') effective = clientExecutionAvailable ? 'local' : 'sandbox';
@@ -144,8 +182,11 @@ export const executionTargetToRuntimeMode = (target: DeviceExecutionTarget): Run
 export const resolveRuntimeMode = (
   agencyConfig: LobeAgentAgencyConfig | undefined,
   clientExecutionAvailable: boolean,
+  deviceRoutingAvailable?: boolean,
 ): RuntimeEnvMode =>
-  executionTargetToRuntimeMode(resolveExecutionTarget(agencyConfig, { clientExecutionAvailable }));
+  executionTargetToRuntimeMode(
+    resolveExecutionTarget(agencyConfig, { clientExecutionAvailable, deviceRoutingAvailable }),
+  );
 
 export type ExecutionPlanUnroutedReason =
   /** `auto` mode with more than one device online — the model must pick one */

--- a/src/helpers/executionTarget.ts
+++ b/src/helpers/executionTarget.ts
@@ -76,10 +76,14 @@ export interface ResolveExecutionTargetOptions {
  * `device(currentDeviceId)` into the in-process path.
  *
  * Defaults: desktop → `local`, web → `none`. On web `local` isn't available
- * (no local filesystem), so a stored `local` (synced from desktop) usually
- * resolves to `sandbox`. For heterogeneous CLI agents, a desktop `local`
- * selection that has already been bound to that desktop's `deviceId` resolves
- * to `device` on web, so the same machine can execute through `lh connect`.
+ * (no local filesystem). A desktop `local` pick pins that desktop's own
+ * `deviceId` as `boundDeviceId` (see `useSelectExecutionTarget`), and the
+ * server routes such a config to that bound device — so on web we resolve it
+ * to `device`, surfacing honestly that it runs on the user's machine (via
+ * `lh connect`) instead of masquerading as `sandbox`. Only an UNBOUND `local`
+ * (no `boundDeviceId`) falls back to `sandbox` on web. This applies to plain
+ * agents too, not just heterogeneous CLI agents (LOBE-11473: plain agents used
+ * to leak here, showing "cloud sandbox" while the server ran on the device).
  *
  * Bot triggers (`trigger === bot`) upgrade a `local` target (a bot has no UI
  * to pick a device and `local` in-process IPC is unreachable from the cloud
@@ -93,7 +97,7 @@ export const resolveExecutionTarget = (
 ): DeviceExecutionTarget => {
   const stored = agencyConfig?.executionTarget;
   let effective = stored ?? (clientExecutionAvailable ? 'local' : 'none');
-  if (isHetero && !clientExecutionAvailable && stored === 'local' && agencyConfig?.boundDeviceId) {
+  if (!clientExecutionAvailable && stored === 'local' && agencyConfig?.boundDeviceId) {
     return 'device';
   }
   if (isHetero && effective === 'none') effective = clientExecutionAvailable ? 'local' : 'sandbox';
@@ -167,7 +171,8 @@ export type ExecutionPlanUnroutedReason =
  */
 export type ExecutionPlan = { target: DeviceExecutionTarget } &
   /** route execution / device tools to this device (the local machine is a registered device) */
-  (| { deviceId: string; kind: 'device' }
+  (
+    | { deviceId: string; kind: 'device' }
     /**
      * Device-targeted but no routable device right now. The run proceeds without
      * an active device; the remote-device proxy may let the model activate one

--- a/src/helpers/gatewayMode.test.ts
+++ b/src/helpers/gatewayMode.test.ts
@@ -1,0 +1,77 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useAgentStore } from '@/store/agent';
+import { type AgentStoreState } from '@/store/agent/initialState';
+import * as serverConfigStore from '@/store/serverConfig';
+
+import { resolveGatewayModeEnabled, useIsGatewayModeEnabled } from './gatewayMode';
+
+const mockServerConfig = (serverConfig?: {
+  agentGatewayUrl?: string;
+  enableGatewayMode?: boolean;
+}) =>
+  vi
+    .spyOn(serverConfigStore, 'getServerConfigStoreState')
+    .mockReturnValue({ serverConfig } as ReturnType<
+      typeof serverConfigStore.getServerConfigStoreState
+    >);
+
+const stateWith = (disableGatewayMode?: boolean): AgentStoreState =>
+  ({
+    activeAgentId: 'agent-1',
+    agentMap: { 'agent-1': { chatConfig: { disableGatewayMode } } },
+  }) as unknown as AgentStoreState;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('resolveGatewayModeEnabled', () => {
+  it('is enabled when the gateway URL + enableGatewayMode are set and the agent has not opted out', () => {
+    mockServerConfig({ agentGatewayUrl: 'wss://gw', enableGatewayMode: true });
+
+    expect(resolveGatewayModeEnabled(stateWith(false), 'agent-1')).toBe(true);
+    // `disableGatewayMode: undefined` counts as enabled.
+    expect(resolveGatewayModeEnabled(stateWith(undefined), 'agent-1')).toBe(true);
+  });
+
+  it('is disabled when the deployment has no gateway URL', () => {
+    mockServerConfig(undefined);
+
+    expect(resolveGatewayModeEnabled(stateWith(false), 'agent-1')).toBe(false);
+  });
+
+  it('is disabled when Gateway mode is off even with a gateway URL', () => {
+    mockServerConfig({ agentGatewayUrl: 'wss://gw', enableGatewayMode: false });
+
+    expect(resolveGatewayModeEnabled(stateWith(false), 'agent-1')).toBe(false);
+  });
+
+  it('is disabled when the agent opts out via disableGatewayMode', () => {
+    mockServerConfig({ agentGatewayUrl: 'wss://gw', enableGatewayMode: true });
+
+    expect(resolveGatewayModeEnabled(stateWith(true), 'agent-1')).toBe(false);
+  });
+});
+
+describe('useIsGatewayModeEnabled', () => {
+  it('re-computes when the agent toggles disableGatewayMode (reactivity, LOBE-11473)', () => {
+    mockServerConfig({ agentGatewayUrl: 'wss://gw', enableGatewayMode: true });
+    useAgentStore.setState(stateWith(false));
+
+    const { result } = renderHook(() => useIsGatewayModeEnabled('agent-1'));
+    expect(result.current).toBe(true);
+
+    // Toggling Gateway Mode from the chat ActionBar mutates chatConfig only; the
+    // hook must still re-render off its own subscription (the display sites
+    // subscribe to agencyConfig, a sibling slice, so they would otherwise stay
+    // stale after sends fall back to sandbox).
+    act(() => {
+      useAgentStore.setState({
+        agentMap: { 'agent-1': { chatConfig: { disableGatewayMode: true } } },
+      } as Partial<AgentStoreState>);
+    });
+    expect(result.current).toBe(false);
+  });
+});

--- a/src/helpers/gatewayMode.ts
+++ b/src/helpers/gatewayMode.ts
@@ -1,0 +1,46 @@
+import { getAgentStoreState } from '@/store/agent';
+import { agentSelectors } from '@/store/agent/selectors';
+import { getServerConfigStoreState } from '@/store/serverConfig';
+import { useUserStore } from '@/store/user';
+import { settingsSelectors } from '@/store/user/selectors';
+
+/**
+ * Whether Gateway mode is EFFECTIVELY enabled for a run — the predicate every
+ * execution-target DISPLAY site shares so the picker/sidebar never surface a
+ * `device` target the runtime can't actually reach.
+ *
+ * A configured `agentGatewayUrl` alone is NOT enough: the deployment must also
+ * turn Gateway mode on (`enableGatewayMode`) and the agent (or the user's
+ * default agent config) must not opt out via `disableGatewayMode`. When any of
+ * these is false, sends fall back to the non-gateway client path, so a bound
+ * `local` target cannot actually reach the device — the display must keep it as
+ * `sandbox` rather than surfacing `device` (LOBE-11473 follow-up).
+ *
+ * This intentionally mirrors dispatch's own gate,
+ * `GatewayActionImpl.isGatewayModeEnabled` in the gateway transport
+ * (`store/chat/.../gateway/gateway.ts`) — keep the two in sync. It is kept
+ * separate because dispatch reads `window.global_serverConfigStore` directly
+ * (its tests mock that global), while display sites read the module singleton
+ * via `getServerConfigStoreState()`. `disableGatewayMode: undefined` = enabled.
+ *
+ * Reads stores non-reactively via `getState()` — safe for callers that already
+ * re-render on the underlying agent/server config, and for selectors that
+ * cannot subscribe to a second store.
+ */
+export const isGatewayModeEnabled = (agentId?: string): boolean => {
+  const serverConfig = getServerConfigStoreState()?.serverConfig;
+  const agentState = getAgentStoreState();
+  const resolvedAgentId = agentId ?? agentState.activeAgentId;
+  const agentDisableGatewayMode = resolvedAgentId
+    ? agentSelectors.getAgentConfigById(resolvedAgentId)(agentState)?.chatConfig?.disableGatewayMode
+    : undefined;
+  const defaultDisableGatewayMode = settingsSelectors.defaultAgentConfig(useUserStore.getState())
+    .chatConfig?.disableGatewayMode;
+  const disableGatewayMode = agentDisableGatewayMode ?? defaultDisableGatewayMode;
+
+  return (
+    !!serverConfig?.agentGatewayUrl &&
+    !!serverConfig.enableGatewayMode &&
+    disableGatewayMode !== true
+  );
+};

--- a/src/helpers/gatewayMode.ts
+++ b/src/helpers/gatewayMode.ts
@@ -1,4 +1,5 @@
-import { getAgentStoreState } from '@/store/agent';
+import { useAgentStore } from '@/store/agent';
+import { type AgentStoreState } from '@/store/agent/initialState';
 import { agentSelectors } from '@/store/agent/selectors';
 import { getServerConfigStoreState } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
@@ -18,29 +19,80 @@ import { settingsSelectors } from '@/store/user/selectors';
  *
  * This intentionally mirrors dispatch's own gate,
  * `GatewayActionImpl.isGatewayModeEnabled` in the gateway transport
- * (`store/chat/.../gateway/gateway.ts`) — keep the two in sync. It is kept
- * separate because dispatch reads `window.global_serverConfigStore` directly
- * (its tests mock that global), while display sites read the module singleton
- * via `getServerConfigStoreState()`. `disableGatewayMode: undefined` = enabled.
+ * (`store/chat/.../gateway/gateway.ts`) — keep the two in sync.
  *
- * Reads stores non-reactively via `getState()` — safe for callers that already
- * re-render on the underlying agent/server config, and for selectors that
- * cannot subscribe to a second store.
+ * `serverConfig` is read non-reactively: `agentGatewayUrl` / `enableGatewayMode`
+ * are deployment-static app config, loaded once at hydration and never mutated
+ * at runtime, so no store subscribes to them (and the display sites'
+ * component tests deliberately run without the serverConfig context Provider).
+ * `disableGatewayMode`, by contrast, is user-toggleable at runtime (the chat
+ * ActionBar / advanced settings), so the reactive `useIsGatewayModeEnabled`
+ * hook subscribes to it — see that hook's note.
  */
-export const isGatewayModeEnabled = (agentId?: string): boolean => {
+const evaluateGatewayModeEnabled = (disableGatewayMode: boolean | undefined): boolean => {
   const serverConfig = getServerConfigStoreState()?.serverConfig;
-  const agentState = getAgentStoreState();
-  const resolvedAgentId = agentId ?? agentState.activeAgentId;
-  const agentDisableGatewayMode = resolvedAgentId
-    ? agentSelectors.getAgentConfigById(resolvedAgentId)(agentState)?.chatConfig?.disableGatewayMode
-    : undefined;
-  const defaultDisableGatewayMode = settingsSelectors.defaultAgentConfig(useUserStore.getState())
-    .chatConfig?.disableGatewayMode;
-  const disableGatewayMode = agentDisableGatewayMode ?? defaultDisableGatewayMode;
 
   return (
     !!serverConfig?.agentGatewayUrl &&
     !!serverConfig.enableGatewayMode &&
     disableGatewayMode !== true
   );
+};
+
+/**
+ * Resolve the effective `disableGatewayMode` opt-out from an agent state: the
+ * agent's own `chatConfig.disableGatewayMode`, falling back to the user's
+ * default agent config. `disableGatewayMode: undefined` = enabled.
+ */
+const resolveDisableGatewayMode = (
+  agentState: AgentStoreState,
+  resolvedAgentId: string | undefined,
+): boolean | undefined => {
+  const agentDisableGatewayMode = resolvedAgentId
+    ? agentSelectors.getAgentConfigById(resolvedAgentId)(agentState)?.chatConfig?.disableGatewayMode
+    : undefined;
+  const defaultDisableGatewayMode = settingsSelectors.defaultAgentConfig(useUserStore.getState())
+    .chatConfig?.disableGatewayMode;
+
+  return agentDisableGatewayMode ?? defaultDisableGatewayMode;
+};
+
+/**
+ * Selector-friendly, non-reactive variant: derives the gate from an agent store
+ * state the caller already holds (e.g. a zustand selector's `s`). It re-runs
+ * whenever the enclosing `useAgentStore(selector)` re-evaluates on an agent
+ * store change, so it stays reactive to `disableGatewayMode` without a second
+ * global read.
+ */
+export const resolveGatewayModeEnabled = (
+  agentState: AgentStoreState,
+  agentId?: string,
+): boolean => {
+  const resolvedAgentId = agentId ?? agentState.activeAgentId;
+
+  return evaluateGatewayModeEnabled(resolveDisableGatewayMode(agentState, resolvedAgentId));
+};
+
+/**
+ * Reactive hook for render call sites (device switcher, workspace sidebar,
+ * resource/skill panels). Subscribes to the live-mutable `disableGatewayMode`
+ * (agent chatConfig + user default) so toggling Gateway Mode from the chat
+ * ActionBar re-renders the display and it stops surfacing a `device` target
+ * once sends have fallen back to sandbox (LOBE-11473 follow-up). `serverConfig`
+ * stays a non-reactive read — see `resolveGatewayModeEnabled`'s note.
+ */
+export const useIsGatewayModeEnabled = (agentId?: string): boolean => {
+  const activeAgentId = useAgentStore((s) => s.activeAgentId);
+  const resolvedAgentId = agentId ?? activeAgentId;
+  const agentDisableGatewayMode = useAgentStore((s) =>
+    resolvedAgentId
+      ? agentSelectors.getAgentConfigById(resolvedAgentId)(s)?.chatConfig?.disableGatewayMode
+      : undefined,
+  );
+  const defaultDisableGatewayMode = useUserStore(
+    (s) => settingsSelectors.defaultAgentConfig(s).chatConfig?.disableGatewayMode,
+  );
+  const disableGatewayMode = agentDisableGatewayMode ?? defaultDisableGatewayMode;
+
+  return evaluateGatewayModeEnabled(disableGatewayMode);
 };

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.test.tsx
@@ -116,6 +116,7 @@ vi.mock('@/libs/router/navigation', () => ({
 }));
 
 vi.mock('@/store/agent', () => ({
+  getAgentStoreState: () => agentStoreStateMock,
   useAgentStore: (selector: (state: { activeAgentId?: string }) => unknown) =>
     selector(agentStoreStateMock),
 }));
@@ -124,6 +125,9 @@ vi.mock('@/store/agent/selectors', () => ({
   agentByIdSelectors: {
     getAgencyConfigById: () => () => ({ boundDeviceId: 'device-1' }),
     isAgentHeterogeneousById: () => () => true,
+  },
+  agentSelectors: {
+    getAgentConfigById: () => () => undefined,
   },
 }));
 

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
@@ -18,7 +18,7 @@ import RingLoadingIcon from '@/components/RingLoading';
 import { isDesktop } from '@/const/version';
 import { useCommitWorkingDirectory } from '@/features/ChatInput/ControlBar/useCommitWorkingDirectory';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
-import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
+import { useIsGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { usePathname } from '@/libs/router/navigation';
 import { useAgentStore } from '@/store/agent';
@@ -256,7 +256,7 @@ const GroupItem = memo<GroupItemComponentProps>(
 
     // Web can add a topic in a directory too when the agent targets a bound
     // device — the write goes to `workingDirByDevice`, no Electron dependency.
-    const deviceRoutingAvailable = isGatewayModeEnabled(currentAgentId);
+    const deviceRoutingAvailable = useIsGatewayModeEnabled(currentAgentId);
     const effectiveTarget = resolveExecutionTarget(agencyConfig, {
       clientExecutionAvailable: isDesktop,
       deviceRoutingAvailable,

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
@@ -18,13 +18,13 @@ import RingLoadingIcon from '@/components/RingLoading';
 import { isDesktop } from '@/const/version';
 import { useCommitWorkingDirectory } from '@/features/ChatInput/ControlBar/useCommitWorkingDirectory';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
+import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { useQueryRoute } from '@/hooks/useQueryRoute';
 import { usePathname } from '@/libs/router/navigation';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { operationSelectors } from '@/store/chat/selectors';
-import { getServerConfigStoreState } from '@/store/serverConfig';
 
 import { buildPrefixedAgentRoutePath, parseAgentPathname } from '../../../utils/agentPathname';
 import TopicItem from '../../List/Item';
@@ -256,7 +256,7 @@ const GroupItem = memo<GroupItemComponentProps>(
 
     // Web can add a topic in a directory too when the agent targets a bound
     // device — the write goes to `workingDirByDevice`, no Electron dependency.
-    const deviceRoutingAvailable = !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl;
+    const deviceRoutingAvailable = isGatewayModeEnabled(currentAgentId);
     const effectiveTarget = resolveExecutionTarget(agencyConfig, {
       clientExecutionAvailable: isDesktop,
       deviceRoutingAvailable,

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
@@ -24,6 +24,7 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
 import { operationSelectors } from '@/store/chat/selectors';
+import { getServerConfigStoreState } from '@/store/serverConfig';
 
 import { buildPrefixedAgentRoutePath, parseAgentPathname } from '../../../utils/agentPathname';
 import TopicItem from '../../List/Item';
@@ -255,9 +256,11 @@ const GroupItem = memo<GroupItemComponentProps>(
 
     // Web can add a topic in a directory too when the agent targets a bound
     // device — the write goes to `workingDirByDevice`, no Electron dependency.
+    const deviceRoutingAvailable = !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl;
     const effectiveTarget = resolveExecutionTarget(agencyConfig, {
-      isHetero: isHeterogeneous,
       clientExecutionAvailable: isDesktop,
+      deviceRoutingAvailable,
+      isHetero: isHeterogeneous,
     });
     const isDeviceMode = effectiveTarget === 'device' && !!agencyConfig?.boundDeviceId;
     const canAddTopic = (isDesktop || isDeviceMode) && !!workingDirectory;

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -33,10 +33,16 @@ vi.mock('../ProgressSection', () => ({ default: () => <div /> }));
 vi.mock('../ResourcesSection', () => ({ default: () => <div /> }));
 vi.mock('../ParamsSection', () => ({ default: () => <div /> }));
 
-vi.mock('@/store/agent', () => ({ useAgentStore: () => undefined }));
+vi.mock('@/store/agent', () => ({
+  getAgentStoreState: () => ({ activeAgentId: undefined }),
+  useAgentStore: () => undefined,
+}));
 vi.mock('@/store/agent/selectors', () => ({
   agentByIdSelectors: {},
-  agentSelectors: { isCurrentAgentHeterogeneous: () => false },
+  agentSelectors: {
+    getAgentConfigById: () => () => undefined,
+    isCurrentAgentHeterogeneous: () => false,
+  },
   chatConfigByIdSelectors: {},
 }));
 vi.mock('@/store/global', () => ({ useGlobalStore: () => undefined }));

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/store/agent/selectors';
 import { useElectronStore } from '@/store/electron';
 import { useGlobalStore } from '@/store/global';
+import { getServerConfigStoreState } from '@/store/serverConfig';
 
 import Files from './Files';
 import ProgressSection from './ProgressSection';
@@ -114,9 +115,11 @@ const AgentWorkingSidebar = memo(() => {
   const currentDeviceId = useElectronStore((s) => s.gatewayDeviceInfo?.deviceId);
   const targetDeviceId = resolveTargetDeviceId(agencyConfig, currentDeviceId);
   const repoType = useRepoType(workingDirectory, targetDeviceId);
+  const deviceRoutingAvailable = !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl;
   const effectiveTarget = resolveExecutionTarget(agencyConfig, {
-    isHetero,
     clientExecutionAvailable: isDesktop,
+    deviceRoutingAvailable,
+    isHetero,
   });
 
   // Running against a bound device (remote, or this machine as a device): file

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
@@ -10,7 +10,7 @@ import { useRepoType } from '@/features/ChatInput/ControlBar/useRepoType';
 import RightPanel from '@/features/RightPanel';
 import { resolveTargetDeviceId } from '@/helpers/agentWorkingDirectory';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
-import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
+import { useIsGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
 import { useLocalStorageState } from '@/hooks/useLocalStorageState';
 import { useAgentStore } from '@/store/agent';
@@ -115,7 +115,7 @@ const AgentWorkingSidebar = memo(() => {
   const currentDeviceId = useElectronStore((s) => s.gatewayDeviceInfo?.deviceId);
   const targetDeviceId = resolveTargetDeviceId(agencyConfig, currentDeviceId);
   const repoType = useRepoType(workingDirectory, targetDeviceId);
-  const deviceRoutingAvailable = isGatewayModeEnabled(activeAgentId);
+  const deviceRoutingAvailable = useIsGatewayModeEnabled(activeAgentId);
   const effectiveTarget = resolveExecutionTarget(agencyConfig, {
     clientExecutionAvailable: isDesktop,
     deviceRoutingAvailable,

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
@@ -10,6 +10,7 @@ import { useRepoType } from '@/features/ChatInput/ControlBar/useRepoType';
 import RightPanel from '@/features/RightPanel';
 import { resolveTargetDeviceId } from '@/helpers/agentWorkingDirectory';
 import { resolveExecutionTarget } from '@/helpers/executionTarget';
+import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
 import { useLocalStorageState } from '@/hooks/useLocalStorageState';
 import { useAgentStore } from '@/store/agent';
@@ -20,7 +21,6 @@ import {
 } from '@/store/agent/selectors';
 import { useElectronStore } from '@/store/electron';
 import { useGlobalStore } from '@/store/global';
-import { getServerConfigStoreState } from '@/store/serverConfig';
 
 import Files from './Files';
 import ProgressSection from './ProgressSection';
@@ -115,7 +115,7 @@ const AgentWorkingSidebar = memo(() => {
   const currentDeviceId = useElectronStore((s) => s.gatewayDeviceInfo?.deviceId);
   const targetDeviceId = resolveTargetDeviceId(agencyConfig, currentDeviceId);
   const repoType = useRepoType(workingDirectory, targetDeviceId);
-  const deviceRoutingAvailable = !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl;
+  const deviceRoutingAvailable = isGatewayModeEnabled(activeAgentId);
   const effectiveTarget = resolveExecutionTarget(agencyConfig, {
     clientExecutionAvailable: isDesktop,
     deviceRoutingAvailable,

--- a/src/store/agent/selectors/chatConfigByIdSelectors.ts
+++ b/src/store/agent/selectors/chatConfigByIdSelectors.ts
@@ -7,6 +7,7 @@ import { type LobeAgentChatConfig, type RuntimeEnvMode } from '@lobechat/types';
 
 import { resolveRuntimeMode, resolveToolMode } from '@/helpers/executionTarget';
 import { type AgentStoreState } from '@/store/agent/initialState';
+import { getServerConfigStoreState } from '@/store/serverConfig';
 
 import { agentSelectors } from './selectors';
 
@@ -73,7 +74,15 @@ const getRuntimeModeById =
   (s: AgentStoreState): RuntimeEnvMode => {
     const config = agentSelectors.getAgentConfigById(agentId)(s);
 
-    return resolveRuntimeMode(config?.agencyConfig, isDesktop);
+    // `serverConfig` is a static app-config snapshot (loaded once at startup),
+    // so a non-reactive `getState()` read is safe here — it never changes after
+    // hydration. On web a bound `local` target only surfaces as `device` (not
+    // `sandbox`) when the backend has a device-gateway to route it (LOBE-11473).
+    return resolveRuntimeMode(
+      config?.agencyConfig,
+      isDesktop,
+      !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl,
+    );
   };
 
 const getSkillActivateModeById =

--- a/src/store/agent/selectors/chatConfigByIdSelectors.ts
+++ b/src/store/agent/selectors/chatConfigByIdSelectors.ts
@@ -6,7 +6,7 @@ import {
 import { type LobeAgentChatConfig, type RuntimeEnvMode } from '@lobechat/types';
 
 import { resolveRuntimeMode, resolveToolMode } from '@/helpers/executionTarget';
-import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
+import { resolveGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { type AgentStoreState } from '@/store/agent/initialState';
 
 import { agentSelectors } from './selectors';
@@ -76,8 +76,13 @@ const getRuntimeModeById =
 
     // On web a bound `local` target only surfaces as `device` (not `sandbox`)
     // when Gateway mode is effectively enabled and can route to the device
-    // (LOBE-11473).
-    return resolveRuntimeMode(config?.agencyConfig, isDesktop, isGatewayModeEnabled(agentId));
+    // (LOBE-11473). Derive the gate from this selector's own state `s` so it
+    // re-evaluates on `disableGatewayMode` changes without a second global read.
+    return resolveRuntimeMode(
+      config?.agencyConfig,
+      isDesktop,
+      resolveGatewayModeEnabled(s, agentId),
+    );
   };
 
 const getSkillActivateModeById =

--- a/src/store/agent/selectors/chatConfigByIdSelectors.ts
+++ b/src/store/agent/selectors/chatConfigByIdSelectors.ts
@@ -6,8 +6,8 @@ import {
 import { type LobeAgentChatConfig, type RuntimeEnvMode } from '@lobechat/types';
 
 import { resolveRuntimeMode, resolveToolMode } from '@/helpers/executionTarget';
+import { isGatewayModeEnabled } from '@/helpers/gatewayMode';
 import { type AgentStoreState } from '@/store/agent/initialState';
-import { getServerConfigStoreState } from '@/store/serverConfig';
 
 import { agentSelectors } from './selectors';
 
@@ -74,15 +74,10 @@ const getRuntimeModeById =
   (s: AgentStoreState): RuntimeEnvMode => {
     const config = agentSelectors.getAgentConfigById(agentId)(s);
 
-    // `serverConfig` is a static app-config snapshot (loaded once at startup),
-    // so a non-reactive `getState()` read is safe here — it never changes after
-    // hydration. On web a bound `local` target only surfaces as `device` (not
-    // `sandbox`) when the backend has a device-gateway to route it (LOBE-11473).
-    return resolveRuntimeMode(
-      config?.agencyConfig,
-      isDesktop,
-      !!getServerConfigStoreState()?.serverConfig?.agentGatewayUrl,
-    );
+    // On web a bound `local` target only surfaces as `device` (not `sandbox`)
+    // when Gateway mode is effectively enabled and can route to the device
+    // (LOBE-11473).
+    return resolveRuntimeMode(config?.agencyConfig, isDesktop, isGatewayModeEnabled(agentId));
   };
 
 const getSkillActivateModeById =


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-11473 · part of the execution-environment convergence (LOBE-11479)

#### 🔀 Description of Change

Two web-path bugs from the same production trace (web-originated session whose agent is pinned to a `local` device):

**1. Execution-target display split-brain** — `resolveExecutionTarget`
A desktop `local` pick pins that desktop's own `deviceId` as `boundDeviceId`. On web the server routes such a config to that bound device, but the display coerced `local → sandbox`, so the selector showed **"Cloud Sandbox"** while commands ran on the user's machine. The honest `local + boundDeviceId → device` branch was gated to hetero agents only; plain agents fell through to the `sandbox` coercion. Removed the `isHetero` gate so plain agents surface the bound device honestly too. Execution is unchanged — server (`gatewayConfigured=true`) and desktop (`clientExecutionAvailable=true`) never enter this web-only branch. This also makes the client `runtimeMode` (`device → none`) agree with the server's derivation instead of diverging (`cloud` vs `none`).

**2. `{{workingDirectory}}` prompt leak** — `createServerVariableGenerators`
On a device run whose cwd cannot be resolved (all four bound-cwd sources empty — typical for a web-originated session), the server variable table had no `workingDirectory` key, so the placeholder renderer preserved the literal `{{workingDirectory}}` and leaked it into the local-system system prompt (the model then passed off the home path as the cwd). Added a server-side `workingDirectory` fallback generator mirroring the client one; a resolved cwd from `deviceSystemInfo.workingDirectory` still overrides it via `additionalVariables`.

#### 🧭 Key Decisions / Non-goals

- **Display, not execution (bug 1)**: the user's stored intent is `local` (never `sandbox`); the display lied. Making the label honest is the minimal fix. Whether a web `local` *should* route to the pinned device at all (send-time resolution, no stale pin) is deliberately **out of scope** → LOBE-11458.
- **Offline degradation still out of scope**: `:96` is optimistic (checks `boundDeviceId` presence, not online). "Shows device, runs in sandbox because offline" disclosure belongs to LOBE-11457.
- **Fallback generator, not template-strip (bug 2)**: mirrors the existing per-variable "always return a string" pattern (and Mustache/Handlebars: missing → empty). A generic "strip unresolved `{{}}`" net was rejected — it would break recursive rendering and legitimate `{{}}` in user content. A CI guard for unrendered leaks is tracked separately (LOBE-11479 ④).
- **Field split-brain already fixed**: the original `chatConfig.runtimeEnv.runtimeMode` field is gone from canary; the selector already reads/writes `agencyConfig.executionTarget`. No field/migration work here.

#### 🧪 How to Test

- [x] Added/updated tests

##### Automated Tests

`bun run check` on the 4 changed files — lint clean, 81 tests passed.

- `executionTarget.test.ts`: bound web `local` (plain **and** hetero) → `device`; unbound web `local` → `sandbox`.
- `serverMessagesEngine.test.ts`: unresolved cwd renders the fallback hint (no `{{workingDirectory}}` literal); a provided cwd renders the real path.

#### 📝 Additional Information

No env / migration / feature flag.