### PR TITLE
🐛 fix: classify residue errors and surface PG causes

### DIFF
--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
@@ -168,6 +168,35 @@ describe('formatErrorForState', () => {
       expect(result.numericId).toBe(7004);
       expect(result.attribution).toBe('harness');
     });
+
+    it('unwraps PG diagnostics from a Drizzle "Failed query" cause for final state errors', () => {
+      const error = new Error('Failed query: begin \nparams: ');
+      (error as any).cause = {
+        code: 'XX000',
+        message:
+          'Failed to acquire permit to connect to the database. Too many database connection attempts are currently ongoing.',
+        severity: 'ERROR',
+      };
+
+      const result = formatErrorForState(error);
+
+      expect(result.type).toBe('pg_XX000');
+      expect(result.message).toBe(
+        'PG XX000 · ERROR · Failed to acquire permit to connect to the database. Too many database connection attempts are currently ongoing.',
+      );
+      expect(result.attribution).toBe('harness');
+      expect(result.category).toBe('stream');
+      expect(result.countAsFailure).toBe(true);
+      expect(result.body).toMatchObject({
+        pg: {
+          code: 'XX000',
+          message:
+            'Failed to acquire permit to connect to the database. Too many database connection attempts are currently ongoing.',
+          severity: 'ERROR',
+        },
+        wrappedMessage: 'Failed query: begin \nparams: ',
+      });
+    });
   });
 
   describe('ProviderBizError refinement', () => {

--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.ts
@@ -2,6 +2,8 @@ import { getErrorCodeSpec, refineErrorCode } from '@lobechat/model-runtime';
 import { AgentRuntimeErrorType, ChatErrorType, type ChatMessageError } from '@lobechat/types';
 import { isRecord } from '@lobechat/utils';
 
+import { formatPgError, pgErrorType, unwrapPgError } from './pgError';
+
 /** Pull a usable HTTP status out of the nested upstream error object. */
 const extractHttpStatus = (body: unknown): number | undefined => {
   if (!body || typeof body !== 'object') return undefined;
@@ -187,6 +189,25 @@ export const formatErrorForState = (error: unknown): ChatMessageError => {
   }
 
   if (error instanceof Error) {
+    const pg = unwrapPgError(error);
+    if (pg) {
+      return {
+        attribution: 'harness',
+        body: {
+          name: error.name,
+          pg,
+          wrappedMessage: error.message,
+        },
+        category: 'stream',
+        countAsFailure: true,
+        httpStatus: 500,
+        message: formatPgError(pg),
+        retryable: false,
+        severity: 'error',
+        type: pgErrorType(pg) as ChatMessageError['type'],
+      };
+    }
+
     return enrichWithSpec({
       body: { name: error.name },
       message: error.message,

--- a/packages/model-runtime/src/errors/match.test.ts
+++ b/packages/model-runtime/src/errors/match.test.ts
@@ -392,8 +392,11 @@ describe('matchErrorPattern — gateway user/upstream residues by category', () 
     {
       cases: [
         ['no channel available for model', AgentRuntimeErrorType.NoAvailableChannel],
+        ['All available accounts exhausted', AgentRuntimeErrorType.NoAvailableChannel],
         ['"code":"NOT_FOUND","msg":"route not found"', AgentRuntimeErrorType.NoAvailableChannel],
         ['Unknown Model, please check the model code', AgentRuntimeErrorType.ModelNotFound],
+        ['Requested model is not valid', AgentRuntimeErrorType.ModelNotFound],
+        ['invalid params, unknown model', AgentRuntimeErrorType.ModelNotFound],
         ['404 page not found', AgentRuntimeErrorType.UserConfigError],
         ['OpenAIException - {"detail":"Not Found"}', AgentRuntimeErrorType.UserConfigError],
       ],
@@ -407,7 +410,11 @@ describe('matchErrorPattern — gateway user/upstream residues by category', () 
           'vertexai',
         ],
         ['No active credentials for provider', AgentRuntimeErrorType.InvalidProviderAPIKey],
+        ['API key is disabled.', AgentRuntimeErrorType.InvalidProviderAPIKey],
+        ['This API key has been suspended.', AgentRuntimeErrorType.InvalidProviderAPIKey],
         ['<h1>403 Forbidden</h1>', AgentRuntimeErrorType.PermissionDenied],
+        ['403 | Forbidden', AgentRuntimeErrorType.PermissionDenied],
+        ['You have no permission to access this resource', AgentRuntimeErrorType.PermissionDenied],
       ],
       name: 'credentials and access',
     },
@@ -436,6 +443,14 @@ describe('matchErrorPattern — gateway user/upstream residues by category', () 
           'error getting file type: failed to download file, status code: 404',
           AgentRuntimeErrorType.InvalidRequestFormat,
         ],
+        [
+          'Unable to download the file. Please verify the URL and try again.',
+          AgentRuntimeErrorType.InvalidRequestFormat,
+        ],
+        [
+          'The request is invalid for this endpoint. Check your model name, messages, tools, and parameters.',
+          AgentRuntimeErrorType.InvalidRequestFormat,
+        ],
         ['422 status code (no body)', AgentRuntimeErrorType.InvalidRequestFormat],
       ],
       name: 'request format and file retrieval',
@@ -444,6 +459,10 @@ describe('matchErrorPattern — gateway user/upstream residues by category', () 
       cases: [
         ['503 "Service Unavailable"', AgentRuntimeErrorType.ProviderServiceUnavailable],
         ['Hệ thống đang bận', AgentRuntimeErrorType.ProviderServiceUnavailable],
+        [
+          'Vision is temporarily unavailable. Send text-only requests for now.',
+          AgentRuntimeErrorType.ProviderServiceUnavailable,
+        ],
       ],
       name: 'service unavailable',
     },

--- a/packages/model-runtime/src/errors/patterns.ts
+++ b/packages/model-runtime/src/errors/patterns.ts
@@ -549,6 +549,10 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     match: sub('Hệ thống đang bận'),
     note: 'Vietnamese proxy: system busy, retry shortly',
   },
+  {
+    code: AgentRuntimeErrorType.ProviderServiceUnavailable,
+    match: sub('Vision is temporarily unavailable. Send text-only requests for now.'),
+  },
   { code: AgentRuntimeErrorType.ProviderServiceUnavailable, match: sub('服务器问题调试中') },
   { code: AgentRuntimeErrorType.ProviderServiceUnavailable, match: sub('undergoing an upgrade') },
 
@@ -615,6 +619,10 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   // NoAvailableChannel — router / proxy has no upstream
   // ─────────────────────────────────────────────────────────────────────────
   { code: AgentRuntimeErrorType.NoAvailableChannel, match: sub('No available accounts') },
+  {
+    code: AgentRuntimeErrorType.NoAvailableChannel,
+    match: sub('All available accounts exhausted'),
+  },
   { code: AgentRuntimeErrorType.NoAvailableChannel, match: sub('No endpoints found') },
   {
     code: AgentRuntimeErrorType.NoAvailableChannel,
@@ -708,6 +716,8 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   { code: AgentRuntimeErrorType.ModelNotFound, match: sub('not available for integrator') },
   { code: AgentRuntimeErrorType.ModelNotFound, match: sub('is not available. Please use') },
   { code: AgentRuntimeErrorType.ModelNotFound, match: sub('The requested model is not available') },
+  { code: AgentRuntimeErrorType.ModelNotFound, match: sub('Requested model is not valid') },
+  { code: AgentRuntimeErrorType.ModelNotFound, match: sub('invalid params, unknown model') },
   {
     code: AgentRuntimeErrorType.ModelNotFound,
     match: sub('Unknown Model, please check the model code'),
@@ -744,6 +754,11 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   {
     code: AgentRuntimeErrorType.InvalidProviderAPIKey,
     match: sub('API key expired. Please renew the API key'),
+  },
+  { code: AgentRuntimeErrorType.InvalidProviderAPIKey, match: sub('API key is disabled.') },
+  {
+    code: AgentRuntimeErrorType.InvalidProviderAPIKey,
+    match: sub('This API key has been suspended.'),
   },
   {
     code: AgentRuntimeErrorType.InvalidProviderAPIKey,
@@ -802,6 +817,11 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   },
   { code: AgentRuntimeErrorType.PermissionDenied, match: sub('not available for trial users') },
   { code: AgentRuntimeErrorType.PermissionDenied, match: sub('403 Forbidden') },
+  { code: AgentRuntimeErrorType.PermissionDenied, match: sub('403 | Forbidden') },
+  {
+    code: AgentRuntimeErrorType.PermissionDenied,
+    match: sub('You have no permission to access this resource'),
+  },
   {
     code: AgentRuntimeErrorType.PermissionDenied,
     match: sub('Access denied due to Virtual Network'),
@@ -1078,6 +1098,16 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
   {
     code: AgentRuntimeErrorType.InvalidRequestFormat,
     match: sub('error getting file type: failed to download file'),
+  },
+  {
+    code: AgentRuntimeErrorType.InvalidRequestFormat,
+    match: sub('Unable to download the file. Please verify the URL and try again.'),
+  },
+  {
+    code: AgentRuntimeErrorType.InvalidRequestFormat,
+    match: sub(
+      'The request is invalid for this endpoint. Check your model name, messages, tools, and parameters.',
+    ),
   },
   { code: AgentRuntimeErrorType.InvalidRequestFormat, match: sub('422 status code (no body)') },
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to [LOBE-11571](https://linear.app/lobehub/issue/LOBE-11571)
Related to [LOBE-11570](https://linear.app/lobehub/issue/LOBE-11570)

#### 🔀 Description of Change

- Add 10 missing model-runtime error patterns from the July user/upstream residue review bucket.
- Cover account-pool exhaustion, invalid/unknown models, disabled/suspended API keys, permission denial, request/download validation, and Anthropic vision temporary unavailability.
- Surface nested PostgreSQL/persist causes in `formatErrorForState` so DB write failures keep their actionable cause instead of collapsing into opaque state errors.
- The audited cleanup plan matched 378 safe non-lobehub rows: 286 already-covered rows plus 92 rows covered by this follow-up PR.
- Keep broad/provider-ambiguous residues out of this PR: `PROHIBITED_CONTENT`, `Provider blocked the response due to content policy`, `finishReason: SAFETY`, URL download timeout, `messages parameter is illegal`, and generic backend 400 patterns remain review-only because bare substrings either hit `provider=lobehub` or are too broad.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
node_modules/.bin/vitest run --config packages/model-runtime/vitest.config.mts packages/model-runtime/src/errors/match.test.ts
# 97 tests passed

bunx vitest run apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
# 24 tests passed

git diff --check origin/canary...HEAD
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

- Folded in the change from #16872 so the July residue classification and DB formatter follow-up can land as one PR.
- Snapshot: `/tmp/gw-errors.json`, total 12,766 rows fetched via paginated DC CLI.
- Audit report: `/tmp/error-pattern-audit.json`; `safeMatchedRows=378`, every safe pattern has `lobehubRows=0`.
- Gateway historical cleanup completed: deleted 378 rows with `dc agent-gateway delete-errors`.
- After-cleanup audit: `/tmp/error-pattern-audit-after-cleanup.json`; `safeMatchedRows=0`, total rows 12,389.
