### PR TITLE
🐛 fix(agent-runtime): surface PG causes in state errors

### DIFF
--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
@@ -168,6 +168,35 @@ describe('formatErrorForState', () => {
       expect(result.numericId).toBe(7004);
       expect(result.attribution).toBe('harness');
     });
+
+    it('unwraps PG diagnostics from a Drizzle "Failed query" cause for final state errors', () => {
+      const error = new Error('Failed query: begin \nparams: ');
+      (error as any).cause = {
+        code: 'XX000',
+        message:
+          'Failed to acquire permit to connect to the database. Too many database connection attempts are currently ongoing.',
+        severity: 'ERROR',
+      };
+
+      const result = formatErrorForState(error);
+
+      expect(result.type).toBe('pg_XX000');
+      expect(result.message).toBe(
+        'PG XX000 · ERROR · Failed to acquire permit to connect to the database. Too many database connection attempts are currently ongoing.',
+      );
+      expect(result.attribution).toBe('harness');
+      expect(result.category).toBe('stream');
+      expect(result.countAsFailure).toBe(true);
+      expect(result.body).toMatchObject({
+        pg: {
+          code: 'XX000',
+          message:
+            'Failed to acquire permit to connect to the database. Too many database connection attempts are currently ongoing.',
+          severity: 'ERROR',
+        },
+        wrappedMessage: 'Failed query: begin \nparams: ',
+      });
+    });
   });
 
   describe('ProviderBizError refinement', () => {

--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.ts
@@ -2,6 +2,8 @@ import { getErrorCodeSpec, refineErrorCode } from '@lobechat/model-runtime';
 import { AgentRuntimeErrorType, ChatErrorType, type ChatMessageError } from '@lobechat/types';
 import { isRecord } from '@lobechat/utils';
 
+import { formatPgError, pgErrorType, unwrapPgError } from './pgError';
+
 /** Pull a usable HTTP status out of the nested upstream error object. */
 const extractHttpStatus = (body: unknown): number | undefined => {
   if (!body || typeof body !== 'object') return undefined;
@@ -187,6 +189,25 @@ export const formatErrorForState = (error: unknown): ChatMessageError => {
   }
 
   if (error instanceof Error) {
+    const pg = unwrapPgError(error);
+    if (pg) {
+      return {
+        attribution: 'harness',
+        body: {
+          name: error.name,
+          pg,
+          wrappedMessage: error.message,
+        },
+        category: 'stream',
+        countAsFailure: true,
+        httpStatus: 500,
+        message: formatPgError(pg),
+        retryable: false,
+        severity: 'error',
+        type: pgErrorType(pg) as ChatMessageError['type'],
+      };
+    }
+
     return enrichWithSpec({
       body: { name: error.name },
       message: error.message,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-11570

#### 🔀 Description of Change

- Unwrap PostgreSQL diagnostics from Drizzle `Failed query` errors before the generic Error fallback.
- Preserve the PG code, severity, and message in final agent state errors so DB persist/query failures expose the real Neon/Postgres cause.
- Add coverage for `begin` failures whose `cause` carries Neon permit saturation diagnostics.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Passed:

`bunx vitest run apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts apps/server/src/modules/AgentRuntime/__tests__/formatErrorEventData.test.ts apps/server/src/modules/AgentRuntime/__tests__/pgError.test.ts`

Also ran:

`bun run check lobehub/apps/server/src/modules/AgentRuntime/formatErrorForState.ts lobehub/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts --lint --test --type`

Result: target tests passed, but local check exited non-zero because this checkout cannot resolve `prettier-plugin-sh` for the lint hook and existing generated `.next/dev/types/validator.ts` references missing route modules.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

#### 📝 Additional Information

This improves diagnostics for residual DB persist/query failures observed in LOBE-11570, especially `Failed query: begin/rollback` records that otherwise hide the underlying PG error in the wrapper message.
