### PR TITLE
🐛 fix(model-runtime): strip thinking from chat completion payloads

### DIFF
--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
@@ -133,6 +133,35 @@ describe('LobeOpenAICompatibleFactory', () => {
       expect(result).toBeInstanceOf(Response);
     });
 
+    it('should not leak internal thinking param to generic OpenAI-compatible chat payloads', async () => {
+      const mockStream = new ReadableStream();
+
+      (instance['client'].chat.completions.create as Mock).mockResolvedValue(
+        Promise.resolve(mockStream),
+      );
+
+      await instance.chat({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model: 'mistralai/mistral-7b-instruct:free',
+        reasoning_effort: 'high',
+        temperature: 0.7,
+        thinking: { budget_tokens: 1024, type: 'enabled' },
+      } as any);
+
+      expect(instance['client'].chat.completions.create).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          thinking: expect.anything(),
+        }),
+        expect.anything(),
+      );
+      expect(instance['client'].chat.completions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reasoning_effort: 'high',
+        }),
+        expect.anything(),
+      );
+    });
+
     // MCP tool schemas with `items: true` or array props missing
     // `type` must be normalized before reaching the upstream validator.
     it('should normalize tool parameter schemas before sending to upstream', async () => {
@@ -1485,6 +1514,40 @@ describe('LobeOpenAICompatibleFactory', () => {
         },
         { timeout: 10000 },
       );
+
+      it('should preserve thinking for Responses API payloads', async () => {
+        const LobeMockProviderUseResponses = createOpenAICompatibleRuntime({
+          baseURL: 'https://api.test.com/v1',
+          chatCompletion: {
+            useResponse: true,
+          },
+          provider: ModelProvider.OpenAI,
+        });
+
+        const inst = new LobeMockProviderUseResponses({ apiKey: 'test' });
+        const mockResponsesCreate = vi
+          .spyOn(inst['client'].responses, 'create')
+          .mockResolvedValue({
+            output_text: 'ok',
+          } as any);
+
+        await inst.chat({
+          messages: [{ content: 'hi', role: 'user' }],
+          model: 'any-model',
+          reasoning_effort: 'high',
+          stream: false,
+          temperature: 0,
+          thinking: { budget_tokens: 1024, type: 'enabled' },
+        } as any);
+
+        expect(mockResponsesCreate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            reasoning: { effort: 'high' },
+            thinking: { budget_tokens: 1024, type: 'enabled' },
+          }),
+          expect.anything(),
+        );
+      });
 
       it('should enable strictToolPairing when building Responses API input', async () => {
         const LobeMockProviderUseResponses = createOpenAICompatibleRuntime({

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -669,6 +669,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           const {
             apiMode: _apiMode,
             preserveThinking: _preserveThinking,
+            thinking: _thinking,
             ...cleanProcessedPayload
           } = processedPayload as any;
           const customRequestPayload = {
@@ -686,9 +687,16 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           ) as any;
         } else {
           // Remove LobeHub-internal fields before sending to downstream API.
+          // `thinking` is a runtime abstraction consumed by provider-specific
+          // handlePayload implementations; generic OpenAI-compatible APIs reject it.
           // `preserveThinking` is only consumed by Qwen/Zhipu handlePayload (which runs above)
           // and must not leak to other providers' APIs as an unknown parameter.
-          const { apiMode: _, preserveThinking: _pt, ...cleanedPayload } = postPayload as any;
+          const {
+            apiMode: _,
+            preserveThinking: _pt,
+            thinking: _thinking,
+            ...cleanedPayload
+          } = postPayload as any;
           const finalPayload = {
             ...cleanedPayload,
             messages,

--- a/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
+++ b/packages/model-runtime/src/core/openaiCompatibleFactory/index.ts
@@ -121,8 +121,7 @@ type ChatCompletionCreateParamsWithPromptCacheKey = Omit<
   Pick<GenerateObjectPayload, 'reasoning_effort'>;
 type GenerateObjectReasoningParams = Pick<GenerateObjectPayload, 'reasoning_effort' | 'thinking'>;
 type ResponseCreateParamsWithPromptCacheKey = (
-  | OpenAI.Responses.ResponseCreateParamsStreaming
-  | OpenAI.Responses.ResponseCreateParams
+  OpenAI.Responses.ResponseCreateParamsStreaming | OpenAI.Responses.ResponseCreateParams
 ) &
   OpenAIExtraParams;
 // Exclude openai's own `provider` (added in openai SDK 6.45.0 as `provider?: Provider`
@@ -694,9 +693,12 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
           const {
             apiMode: _,
             preserveThinking: _pt,
-            thinking: _thinking,
-            ...cleanedPayload
+            ...payloadWithoutInternalFields
           } = postPayload as any;
+          const { thinking: _thinking, ...payloadWithoutThinking } = payloadWithoutInternalFields;
+          const cleanedPayload = chatCompletion?.handlePayload
+            ? payloadWithoutInternalFields
+            : payloadWithoutThinking;
           const finalPayload = {
             ...cleanedPayload,
             messages,
@@ -979,8 +981,7 @@ export const createOpenAICompatibleRuntime = <T extends Record<string, any> = an
       // Structural type keeps this compatible across openai SDK majors (v6
       // widened tool_calls to a function/custom union).
       const toolCalls = res.choices[0].message.tool_calls as
-        | { function?: { arguments: string; name: string } }[]
-        | undefined;
+        { function?: { arguments: string; name: string } }[] | undefined;
       const toolCall =
         toolCalls?.find((item) => item.function?.name === tool.function.name) ?? toolCalls?.[0];
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-11568 and LOBE-11572.

#### 🔀 Description of Change

- Strip the LobeHub `thinking` runtime option before generic OpenAI-compatible chat completion requests are sent upstream.
- Strip `thinking` from custom OpenAI-compatible chat completion client payloads as well.
- Keep Responses API payloads preserving `thinking`, because Responses mode needs to pass internal thinking/reasoning state through for continuation.
- Preserve the existing `reasoning_effort` -> `reasoning.effort` conversion for Responses API.
- Add regressions for both paths: chat completions must not receive `thinking`, while Responses API must retain it.

This targets the July residue where first-party `lobehub` routing can fall through to generic OpenAI-compatible chat completion channels and send both `thinking` and `reasoning_effort`. Responses API is intentionally excluded from the stripping behavior. Other LOBE-11568 schema residues, such as Gemini thought signatures and tool response names, remain separate provider-specific follow-ups.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Passed:

```bash
node_modules/.bin/vitest run --config packages/model-runtime/vitest.config.mts packages/model-runtime/src/core/openaiCompatibleFactory/index.test.ts
# 101 tests passed

git diff --check
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No error-message patterns were added. This is a request-shape guard for model-runtime payload construction.
