### PR TITLE
🐛 fix(agent-runtime): persist empty completion retry diagnostics

### DIFF
--- a/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts
@@ -915,13 +915,27 @@ describe('RuntimeExecutors', () => {
           state,
         );
         // Drive the retry backoff sleeps to completion.
-        const settled = expect(promise).rejects.toBeInstanceOf(ModelEmptyError);
+        const rejection = promise.catch((error) => error);
         await vi.runAllTimersAsync();
         // Must throw (so the harness records a readable error state) instead of
         // silently finalizing to a completion with a blank assistant message.
-        await settled;
+        const error = await rejection;
+        expect(error).toBeInstanceOf(ModelEmptyError);
         // EMPTY_COMPLETION_MAX_RETRIES (2) retries → 3 total attempts.
         expect(mockChat).toHaveBeenCalledTimes(3);
+        expect(error.diagnostics).toMatchObject({
+          attempt: 3,
+          maxAttempts: 3,
+          model: 'deepseek-v4-pro',
+          outputTokens: 1,
+          provider: 'lobehub',
+          retryBudget: 2,
+          retryEvents: [
+            expect.objectContaining({ attempt: 2, delayMs: 1000, maxAttempts: 3 }),
+            expect.objectContaining({ attempt: 3, delayMs: 2000, maxAttempts: 3 }),
+          ],
+          toolCallCount: 0,
+        });
       } finally {
         vi.useRealTimers();
       }
@@ -4738,7 +4752,7 @@ describe('RuntimeExecutors', () => {
           'op-123',
           expect.objectContaining({
             type: 'stream_retry',
-            data: { attempt: 2, delayMs: 1000, maxAttempts: 6 },
+            data: expect.objectContaining({ attempt: 2, delayMs: 1000, maxAttempts: 6 }),
           }),
         );
       } finally {
@@ -4869,21 +4883,21 @@ describe('RuntimeExecutors', () => {
           'op-123',
           expect.objectContaining({
             type: 'stream_retry',
-            data: { attempt: 2, delayMs: 1000, maxAttempts: 6 },
+            data: expect.objectContaining({ attempt: 2, delayMs: 1000, maxAttempts: 6 }),
           }),
         );
         expect(mockStreamManager.publishStreamEvent).toHaveBeenCalledWith(
           'op-123',
           expect.objectContaining({
             type: 'stream_retry',
-            data: { attempt: 3, delayMs: 2000, maxAttempts: 6 },
+            data: expect.objectContaining({ attempt: 3, delayMs: 2000, maxAttempts: 6 }),
           }),
         );
         expect(mockStreamManager.publishStreamEvent).toHaveBeenCalledWith(
           'op-123',
           expect.objectContaining({
             type: 'stream_retry',
-            data: { attempt: 4, delayMs: 4000, maxAttempts: 6 },
+            data: expect.objectContaining({ attempt: 4, delayMs: 4000, maxAttempts: 6 }),
           }),
         );
       } finally {

--- a/apps/server/src/modules/AgentRuntime/executors/callLlm.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/callLlm.ts
@@ -1414,7 +1414,19 @@ export const callLlm =
                   attempt,
                   maxAttempts,
                 );
-                throw new ModelEmptyError();
+                throw new ModelEmptyError(undefined, {
+                  attempt,
+                  contentLength: content.length,
+                  finishReason: currentStepFinishReason,
+                  imageCount: imageList.length,
+                  maxAttempts,
+                  model,
+                  outputTokens:
+                    typeof reportedOutputTokens === 'number' ? reportedOutputTokens : undefined,
+                  provider,
+                  reasoningLength: thinkingContent.length,
+                  toolCallCount: toolsCalling.length + tool_calls.length,
+                });
               }
 
               // Answer-in-thinking salvage: some thinking-mode models — notably
@@ -1708,8 +1720,20 @@ export const callLlm =
                   delayMs,
                 );
 
+                const retryEvent: AgentEvent = {
+                  data: {
+                    attempt: attempt + 1,
+                    delayMs,
+                    errorType: classified.code,
+                    kind: classified.kind,
+                    maxAttempts,
+                  },
+                  type: 'stream_retry',
+                };
+                events.push(retryEvent);
+
                 await streamManager.publishStreamEvent(operationId, {
-                  data: { attempt: attempt + 1, delayMs, maxAttempts },
+                  data: retryEvent.data,
                   stepIndex,
                   type: 'stream_retry',
                 });
@@ -1721,6 +1745,13 @@ export const callLlm =
                 }
 
                 continue;
+              }
+
+              if (error instanceof ModelEmptyError && error.diagnostics) {
+                error.diagnostics.retryBudget = retryBudget;
+                error.diagnostics.retryEvents = events
+                  .filter((event) => event.type === 'stream_retry')
+                  .map((event) => event.data);
               }
 
               // Cancel/interrupt path: when the user stops mid-stream, the model-runtime

--- a/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
+++ b/apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts
@@ -83,7 +83,14 @@ describe('formatErrorForState', () => {
     });
 
     it('enriches a thrown ModelEmptyError into a readable retryable terminal error', () => {
-      const result = formatErrorForState(new ModelEmptyError());
+      const result = formatErrorForState(
+        new ModelEmptyError(undefined, {
+          attempt: 3,
+          maxAttempts: 3,
+          outputTokens: 1,
+          retryEvents: [{ attempt: 2, delayMs: 1000, maxAttempts: 3 }],
+        }),
+      );
 
       // The `errorType` field must win over the generic Error → InternalServerError
       // path so the terminal state is classified and dashboard-visible instead of
@@ -95,6 +102,14 @@ describe('formatErrorForState', () => {
       expect(result.countAsFailure).toBe(true);
       expect(result.numericId).toBe(8014);
       expect(result.message).toContain('empty completion');
+      expect(result.body).toMatchObject({
+        diagnostics: {
+          attempt: 3,
+          maxAttempts: 3,
+          outputTokens: 1,
+          retryEvents: [expect.objectContaining({ attempt: 2 })],
+        },
+      });
     });
 
     it('marks provider-side rate limits as retryable with provider attribution', () => {

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -1331,6 +1331,7 @@ export class AgentRuntimeService {
             error: newStateError
               ? {
                   attribution: newStateError.attribution,
+                  body: newStateError.body,
                   category: newStateError.category,
                   countAsFailure: newStateError.countAsFailure,
                   httpStatus: newStateError.httpStatus,
@@ -1441,6 +1442,7 @@ export class AgentRuntimeService {
         completionReason: 'error',
         error: {
           attribution: formattedError.attribution,
+          body: formattedError.body,
           category: formattedError.category,
           countAsFailure: formattedError.countAsFailure,
           httpStatus: formattedError.httpStatus,
@@ -1450,7 +1452,11 @@ export class AgentRuntimeService {
           severity: formattedError.severity,
           type: String(formattedError.type),
         },
-        failedStep: { startedAt: stepStartAt, stepIndex },
+        failedStep: {
+          startedAt: stepStartAt,
+          stepIndex,
+          stepType: formattedError.category === 'provider' ? 'call_llm' : 'call_tool',
+        },
         state: finalStateWithError,
       });
 

--- a/apps/server/src/services/agentRuntime/OperationTraceRecorder.ts
+++ b/apps/server/src/services/agentRuntime/OperationTraceRecorder.ts
@@ -55,6 +55,7 @@ export interface FinalizeParams {
    */
   error?: {
     attribution?: ChatMessageErrorAttribution;
+    body?: unknown;
     category?: string;
     countAsFailure?: boolean;
     httpStatus?: number;
@@ -70,7 +71,7 @@ export interface FinalizeParams {
    * so the catch caller passes this to keep step counts aligned with the
    * assistant message that triggered the call. See .
    */
-  failedStep?: { startedAt: number; stepIndex: number };
+  failedStep?: { startedAt: number; stepIndex: number; stepType?: 'call_llm' | 'call_tool' };
   state: any;
 }
 
@@ -151,12 +152,7 @@ export class OperationTraceRecorder {
             executionTimeMs: now - params.failedStep.startedAt,
             startedAt: params.failedStep.startedAt,
             stepIndex: params.failedStep.stepIndex,
-            // StepSnapshot.stepType is strictly 'call_llm' | 'call_tool';
-            // persist-fatal originates in the tool path so 'call_tool' is the
-            // truthful label. LLM-side failures still map here — the
-            // surrounding `events: [{type: 'error'}]` is the discriminant
-            // consumers read.
-            stepType: 'call_tool',
+            stepType: params.failedStep.stepType ?? 'call_tool',
             totalCost: params.state?.cost?.total ?? 0,
             totalTokens: params.state?.usage?.llm?.tokens?.total ?? 0,
           });

--- a/apps/server/src/services/agentRuntime/__tests__/OperationTraceRecorder.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/OperationTraceRecorder.test.ts
@@ -296,6 +296,55 @@ describe('OperationTraceRecorder', () => {
       expect(saved.completionReason).toBe('error');
     });
 
+    it('preserves failed LLM step type and structured error body diagnostics', async () => {
+      store.loadPartial.mockResolvedValue({
+        startedAt: 1000,
+        steps: [{ stepIndex: 0, stepType: 'call_tool' }],
+      });
+
+      await recorder.finalize('op-empty-completion', {
+        completionReason: 'error',
+        error: {
+          body: {
+            diagnostics: {
+              attempt: 3,
+              maxAttempts: 3,
+              outputTokens: 1,
+              retryEvents: [
+                { attempt: 2, delayMs: 1000, maxAttempts: 3, type: 'stream_retry' },
+                { attempt: 3, delayMs: 2000, maxAttempts: 3, type: 'stream_retry' },
+              ],
+            },
+          },
+          message: 'Model returned an empty completion',
+          retryable: true,
+          type: 'ModelEmptyCompletion',
+        },
+        failedStep: { startedAt: 5000, stepIndex: 1, stepType: 'call_llm' },
+        state: { metadata: {}, stepCount: 1 },
+      });
+
+      const saved = store.save.mock.calls[0][0];
+      const failed = saved.steps.find((s: any) => s.stepIndex === 1);
+      expect(failed.stepType).toBe('call_llm');
+      expect(failed.events?.[0]).toMatchObject({
+        error: {
+          body: {
+            diagnostics: {
+              attempt: 3,
+              retryEvents: [
+                expect.objectContaining({ attempt: 2 }),
+                expect.objectContaining({ attempt: 3 }),
+              ],
+            },
+          },
+          type: 'ModelEmptyCompletion',
+        },
+        type: 'error',
+      });
+      expect(saved.error.body.diagnostics).toMatchObject({ attempt: 3, maxAttempts: 3 });
+    });
+
     it('merges the error event into an existing step when stepIndex collides (success-path append landed before later failure)', async () => {
       // The success path may have already pushed step 1 to the partial before
       // a later failure (e.g. saveAgentState throws post-append). The recorder

--- a/packages/agent-runtime/src/types/event.ts
+++ b/packages/agent-runtime/src/types/event.ts
@@ -21,6 +21,17 @@ export interface AgentEventLlmResult {
   type: 'llm_result';
 }
 
+export interface AgentEventStreamRetry {
+  data: {
+    attempt: number;
+    delayMs: number;
+    errorType?: string;
+    kind?: string;
+    maxAttempts: number;
+  };
+  type: 'stream_retry';
+}
+
 export interface AgentEventToolPending {
   toolCalls: ToolsCalling[];
   type: 'tool_pending';
@@ -120,6 +131,7 @@ export type AgentEvent =
   | AgentEventLlmStart
   | AgentEventLlmStream
   | AgentEventLlmResult
+  | AgentEventStreamRetry
   // Tool invocation
   | AgentEventToolPending
   | AgentEventToolResult

--- a/packages/model-runtime/src/errors/modelEmptyCompletion.ts
+++ b/packages/model-runtime/src/errors/modelEmptyCompletion.ts
@@ -1,5 +1,20 @@
 import { AgentRuntimeErrorType } from '@lobechat/types';
 
+export interface ModelEmptyCompletionDiagnostics {
+  attempt?: number;
+  contentLength?: number;
+  finishReason?: string;
+  imageCount?: number;
+  maxAttempts?: number;
+  model?: string;
+  outputTokens?: number;
+  provider?: string;
+  reasoningLength?: number;
+  retryBudget?: number;
+  retryEvents?: Array<Record<string, unknown>>;
+  toolCallCount?: number;
+}
+
 /**
  * Thrown when the model returns an empty completion — no text content, no
  * reasoning, no tool calls, no images, and ~0 output tokens. This is the "empty
@@ -19,12 +34,15 @@ import { AgentRuntimeErrorType } from '@lobechat/types';
  */
 export class ModelEmptyError extends Error {
   readonly errorType = AgentRuntimeErrorType.ModelEmptyCompletion;
+  readonly diagnostics?: ModelEmptyCompletionDiagnostics;
 
   constructor(
     message = 'Model returned an empty completion (no content, no tool calls, no output tokens).',
+    diagnostics?: ModelEmptyCompletionDiagnostics,
   ) {
     super(message);
     this.name = 'ModelEmptyError';
+    this.diagnostics = diagnostics;
   }
 }
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-11562 and LOBE-11565.

#### 🔀 Description of Change

- Add structured diagnostics to `ModelEmptyError`, including attempt/maxAttempts/provider/model/output token counts and retry history.
- Persist runtime `stream_retry` events during empty-completion retries so traces can prove whether retry happened and how many attempts were used.
- Preserve structured error `body` in agent-runtime trace snapshots and mark provider-side synthetic failed steps as `call_llm` instead of defaulting to `call_tool`.
- Keep the existing bounded retry strategy unchanged: this PR improves observability and post-deploy triage for MEC rather than hiding it with an error pattern.

This addresses the LOBE-11565 gap where snapshots showed terminal `ModelEmptyCompletion` but did not preserve retry attempt history, making it hard to tell whether the final error represented retry exhaustion or a single empty response.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bunx vitest run apps/server/src/modules/AgentRuntime/formatErrorForState.test.ts apps/server/src/modules/AgentRuntime/__tests__/RuntimeExecutors.test.ts apps/server/src/services/agentRuntime/__tests__/OperationTraceRecorder.test.ts apps/server/src/modules/AgentRuntime/__tests__/llmErrorClassification.test.ts packages/agent-runtime/src/utils/runtimeRetry.test.ts
bun run type-check
git diff --check
```

Result: 4 test files passed, 208 tests passed; type-check passed; diff check passed.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

No model-runtime error patterns were added. Follow-up decision after deployment: if diagnostics show repeated HTTP-200-empty from a single branded provider channel, evaluate channel failover separately.
