### PR TITLE
🐛 fix(agent-runtime): reconcile abandoned terminal operations

### DIFF
--- a/apps/server/src/agent-hono/handlers/__tests__/finalizeAbandoned.test.ts
+++ b/apps/server/src/agent-hono/handlers/__tests__/finalizeAbandoned.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { finalizeAbandoned } from '../finalizeAbandoned';
+
+const { mockFinalizeAbandoned, mockGetServerDB } = vi.hoisted(() => ({
+  mockFinalizeAbandoned: vi.fn(),
+  mockGetServerDB: vi.fn(),
+}));
+
+vi.mock('@/database/core/db-adaptor', () => ({
+  getServerDB: mockGetServerDB,
+}));
+
+vi.mock('@/server/services/agentRuntime', () => ({
+  AbandonOperationService: vi.fn().mockImplementation(() => ({
+    finalizeAbandoned: mockFinalizeAbandoned,
+  })),
+}));
+
+vi.mock('@/server/services/agentRuntime/hooks/HookDispatcher', () => ({
+  deliverWebhook: vi.fn(),
+}));
+
+vi.mock('@/server/services/aiAgent', () => ({
+  AiAgentService: vi.fn(),
+}));
+
+function buildContext(body: unknown) {
+  let captured: { body: any; status: number } | undefined;
+  const ctx = {
+    json: (b: any, status = 200) => {
+      captured = { body: b, status };
+      return Response.json(b, { status });
+    },
+    req: {
+      json: async () => body,
+    },
+  } as any;
+
+  return { ctx, getCaptured: () => captured };
+}
+
+describe('finalizeAbandoned handler', () => {
+  beforeEach(() => {
+    mockGetServerDB.mockResolvedValue({ db: true });
+    mockFinalizeAbandoned.mockResolvedValue({
+      assistantMessageUpdated: false,
+      completionReason: 'done',
+      finalized: false,
+      found: true,
+      reconciledStatus: 'completed',
+      terminal: true,
+      terminalStatus: 'completed',
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns gateway-readable terminal reconciliation fields from the service result', async () => {
+    const { ctx, getCaptured } = buildContext({
+      operationId: 'op_done',
+      reason: 'inactivity_watchdog',
+    });
+
+    const res = await finalizeAbandoned(ctx);
+
+    expect(res.status).toBe(200);
+    expect(mockFinalizeAbandoned).toHaveBeenCalledWith('op_done', 'inactivity_watchdog');
+    expect(getCaptured()?.body).toMatchObject({
+      completionReason: 'done',
+      operationId: 'op_done',
+      reason: 'inactivity_watchdog',
+      reconciledStatus: 'completed',
+      terminal: true,
+      terminalStatus: 'completed',
+    });
+    expect(getCaptured()?.body.executionTime).toEqual(expect.any(Number));
+  });
+
+  it('returns 400 when operationId is missing', async () => {
+    const { ctx } = buildContext({ reason: 'inactivity_watchdog' });
+
+    const res = await finalizeAbandoned(ctx);
+
+    expect(res.status).toBe(400);
+    expect(mockFinalizeAbandoned).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/modules/AgentRuntime/GatewayStreamNotifier.ts
+++ b/apps/server/src/modules/AgentRuntime/GatewayStreamNotifier.ts
@@ -17,7 +17,7 @@ const MAX_INFLIGHT = 20; // bounded concurrency
 
 /**
  * Decorator that wraps an IStreamEventManager and additionally
- * pushes events to the Agent Gateway via HTTP (fire-and-forget).
+ * pushes events to the Agent Gateway via HTTP.
  *
  * Redis SSE remains the primary event storage / subscription mechanism.
  * The Gateway is an additional push channel for WebSocket delivery.
@@ -133,7 +133,7 @@ export class GatewayStreamNotifier implements IStreamEventManager {
     const effectiveReasonDetail = reasonDetail || getDefaultReasonDetail(finalState, reason);
     const errorType = finalState?.error?.type || finalState?.error?.errorType;
 
-    void this.pushEvent(operationId, {
+    await this.pushEvent(operationId, {
       // Forward `uiMessages` to the gateway push channel so terminal-state
       // clients consuming /push-event get the canonical UIChatMessage[]
       // snapshot — the final step has no later step_start to carry a fresh

--- a/apps/server/src/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
+++ b/apps/server/src/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
@@ -42,6 +42,8 @@ describe('GatewayStreamNotifier', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue({ ok: true, text: () => Promise.resolve('') });
     inner = createMockInner();
     notifier = new GatewayStreamNotifier(inner, gatewayUrl, serviceToken);
   });
@@ -193,6 +195,82 @@ describe('GatewayStreamNotifier', () => {
       expect(urls).toContain(`${gatewayUrl}/api/operations/push-event`);
       // Gateway handles session completion directly in pushEvent on agent_runtime_end
       expect(urls).not.toContain(`${gatewayUrl}/api/operations/update-status`);
+    });
+
+    it('awaits the terminal gateway push before resolving', async () => {
+      let resolveFetch!: () => void;
+      mockFetch.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFetch = () => resolve({ ok: true, text: () => Promise.resolve('') });
+          }),
+      );
+
+      const result = notifier.publishAgentRuntimeEnd({
+        finalState: { status: 'done' },
+        operationId: 'op-1',
+        reason: 'completed',
+        stepIndex: 2,
+      });
+      let resolved = false;
+      void result.then(() => {
+        resolved = true;
+      });
+
+      await Promise.resolve();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${gatewayUrl}/api/operations/push-event`,
+        expect.objectContaining({ method: 'POST' }),
+      );
+      expect(resolved).toBe(false);
+
+      resolveFetch();
+
+      await expect(result).resolves.toBe('publishAgentRuntimeEnd-result');
+      expect(resolved).toBe(true);
+    });
+
+    it('awaits both primary and mirror terminal pushes before resolving', async () => {
+      await notifier.publishAgentRuntimeInit('op-member', { mirrorToOperationId: 'op-supervisor' });
+      await new Promise((r) => setTimeout(r, 0));
+      mockFetch.mockClear();
+
+      const resolvers: Array<() => void> = [];
+      mockFetch.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolvers.push(() => resolve({ ok: true, text: () => Promise.resolve('') }));
+          }),
+      );
+
+      const result = notifier.publishAgentRuntimeEnd({
+        finalState: { status: 'done' },
+        operationId: 'op-member',
+        reason: 'completed',
+        stepIndex: 2,
+      });
+      let resolved = false;
+      void result.then(() => {
+        resolved = true;
+      });
+
+      await Promise.resolve();
+
+      const pushCalls = mockFetch.mock.calls.filter((c: any[]) =>
+        String(c[0]).includes('/api/operations/push-event'),
+      );
+      expect(pushCalls).toHaveLength(2);
+      expect(resolved).toBe(false);
+
+      resolvers[0]();
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+
+      resolvers[1]();
+
+      await expect(result).resolves.toBe('publishAgentRuntimeEnd-result');
+      expect(resolved).toBe(true);
     });
 
     it('computes effectiveReasonDetail when reasonDetail is omitted', async () => {

--- a/apps/server/src/services/agentRuntime/AbandonOperationService.ts
+++ b/apps/server/src/services/agentRuntime/AbandonOperationService.ts
@@ -21,6 +21,20 @@ import { createDefaultSnapshotStore } from './snapshotStore';
 
 const log = debug('lobe-server:abandon-operation');
 
+type TerminalCompletionReason = 'done' | 'error' | 'interrupted';
+type GatewayTerminalStatus = 'completed' | 'error' | 'interrupted';
+
+const TERMINAL_COMPLETION_REASONS = new Set<string>(['done', 'error', 'interrupted']);
+
+const toTerminalCompletionReason = (value: unknown): TerminalCompletionReason | undefined => {
+  return typeof value === 'string' && TERMINAL_COMPLETION_REASONS.has(value)
+    ? (value as TerminalCompletionReason)
+    : undefined;
+};
+
+const toGatewayTerminalStatus = (reason: TerminalCompletionReason): GatewayTerminalStatus =>
+  reason === 'done' ? 'completed' : reason;
+
 interface AbandonOperationOptions {
   coordinator?: AgentRuntimeCoordinator;
   snapshotStore?: ISnapshotStore | null;
@@ -50,15 +64,23 @@ export interface FinalizeAbandonedResult {
   abandoned?: boolean;
   /** Whether the assistant message was successfully marked as errored. */
   assistantMessageUpdated: boolean;
+  /** Existing terminal completion reason when the op already finished before watchdog finalize. */
+  completionReason?: TerminalCompletionReason;
   /** Whether the operation was finalized into a snapshot (false if no partial existed). */
   finalized: boolean;
   /** Whether agent state was found in Redis. */
   found: boolean;
+  /** Gateway-readable terminal status used to reconcile phantom inactivity timeouts. */
+  reconciledStatus?: GatewayTerminalStatus;
   /**
    * Set when the abandoned op was a sub-agent parked under a parent's
    * `callSubAgent`. The caller MUST bridge this to resume the parent.
    */
   subAgentResume?: AbandonedSubAgentResume;
+  /** True when finalize-abandoned discovered the operation had already reached a terminal state. */
+  terminal?: boolean;
+  /** Alias for gateway watchdogs that key off terminalStatus instead of reconciledStatus. */
+  terminalStatus?: GatewayTerminalStatus;
 }
 
 /**
@@ -117,6 +139,25 @@ export class AbandonOperationService {
       state.status === 'running' ||
       state.status === 'waiting_for_human' ||
       state.status === 'waiting_for_async_tool';
+
+    const partial = this.snapshotStore
+      ? await this.snapshotStore.loadPartial(operationId).catch(() => null)
+      : null;
+    const terminalReason =
+      this.inferTerminalFromState(state) ??
+      this.inferTerminalFromPartial(partial) ??
+      (await this.inferTerminalFromAssistantMessage(metadata));
+    if (terminalReason) {
+      this.markTerminal(result, terminalReason);
+      await this.cleanupCoordinator(operationId);
+      log(
+        '[%s] watchdog saw already-terminal op (reason=%s): %O',
+        operationId,
+        terminalReason,
+        result,
+      );
+      return result;
+    }
     const message = `Operation abandoned: ${reason}`;
     const error: ChatMessageError = {
       body: { message },
@@ -126,9 +167,6 @@ export class AbandonOperationService {
 
     // Synthesize a failed-step record at index = lastCompleted + 1 so consumers
     // see the operation ended at a step that never produced data.
-    const partial = this.snapshotStore
-      ? await this.snapshotStore.loadPartial(operationId).catch(() => null)
-      : null;
     const lastStepIndex = partial?.steps?.length
       ? Math.max(...partial.steps.map((s) => s.stepIndex))
       : -1;
@@ -245,11 +283,7 @@ export class AbandonOperationService {
     // the coordinator metadata, so deleting it now would 401 every redelivery
     // and strand the parent. The lingering state expires on its own Redis TTL.
     if (!result.subAgentResume) {
-      try {
-        await this.coordinator.deleteAgentOperation(operationId);
-      } catch (e) {
-        log('[%s] coordinator cleanup failed (non-fatal): %O', operationId, e);
-      }
+      await this.cleanupCoordinator(operationId);
     }
 
     log('[%s] abandoned op finalized (reason=%s): %O', operationId, reason, result);
@@ -262,6 +296,12 @@ export class AbandonOperationService {
     result: FinalizeAbandonedResult,
   ): Promise<void> {
     const op = await this.findOperationRow(operationId);
+    const terminalReason = this.inferTerminalFromOperationRow(op);
+    if (terminalReason) {
+      this.markTerminal(result, terminalReason);
+      return;
+    }
+
     if (!op || !['running', 'waiting_for_human', 'waiting_for_async_tool'].includes(op.status)) {
       return;
     }
@@ -315,6 +355,59 @@ export class AbandonOperationService {
     } catch (e) {
       log('[%s] no-state abandon: operation lookup failed (non-fatal): %O', operationId, e);
       return null;
+    }
+  }
+
+  private markTerminal(
+    result: FinalizeAbandonedResult,
+    completionReason: TerminalCompletionReason,
+  ): void {
+    const gatewayStatus = toGatewayTerminalStatus(completionReason);
+    result.completionReason = completionReason;
+    result.reconciledStatus = gatewayStatus;
+    result.terminal = true;
+    result.terminalStatus = gatewayStatus;
+  }
+
+  private inferTerminalFromState(state: any): TerminalCompletionReason | undefined {
+    return toTerminalCompletionReason(state?.status) ?? toTerminalCompletionReason(state?.reason);
+  }
+
+  private inferTerminalFromPartial(partial: any): TerminalCompletionReason | undefined {
+    return toTerminalCompletionReason(partial?.completionReason);
+  }
+
+  private inferTerminalFromOperationRow(
+    op: typeof agentOperations.$inferSelect | null | undefined,
+  ): TerminalCompletionReason | undefined {
+    if (!op) return undefined;
+    return toTerminalCompletionReason(op.completionReason) ?? toTerminalCompletionReason(op.status);
+  }
+
+  private async inferTerminalFromAssistantMessage(metadata: {
+    assistantMessageId?: string;
+    userId?: string;
+    workspaceId?: string;
+  }): Promise<TerminalCompletionReason | undefined> {
+    if (!metadata.userId || !metadata.assistantMessageId) return undefined;
+
+    try {
+      const messageModel = new MessageModel(this.db, metadata.userId, metadata.workspaceId);
+      const assistant = await messageModel.findById(metadata.assistantMessageId);
+      if (!assistant) return undefined;
+      if ((assistant as any).error) return 'error';
+    } catch (e) {
+      log('[%s] terminal assistant lookup failed (non-fatal): %O', metadata.assistantMessageId, e);
+    }
+
+    return undefined;
+  }
+
+  private async cleanupCoordinator(operationId: string): Promise<void> {
+    try {
+      await this.coordinator.deleteAgentOperation(operationId);
+    } catch (e) {
+      log('[%s] coordinator cleanup failed (non-fatal): %O', operationId, e);
     }
   }
 

--- a/apps/server/src/services/agentRuntime/__tests__/AbandonOperationService.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/AbandonOperationService.test.ts
@@ -26,8 +26,12 @@ const buildCoordinator = (
 });
 
 const messageUpdateMock = vi.fn().mockResolvedValue({ success: true });
+const messageFindByIdMock = vi.fn().mockResolvedValue(null);
 vi.mock('@/database/models/message', () => ({
-  MessageModel: vi.fn().mockImplementation(() => ({ update: messageUpdateMock })),
+  MessageModel: vi.fn().mockImplementation(() => ({
+    findById: messageFindByIdMock,
+    update: messageUpdateMock,
+  })),
 }));
 
 const findOperationMock = vi.fn().mockResolvedValue(null);
@@ -88,8 +92,8 @@ const buildDb = (overrides: { assistantRow?: any; operationRow?: any } = {}) =>
 
 describe('AbandonOperationService', () => {
   beforeEach(() => {
-    messageUpdateMock.mockClear();
-    dispatchHooksMock.mockClear();
+    messageFindByIdMock.mockReset().mockResolvedValue(null);
+    messageUpdateMock.mockReset().mockResolvedValue({ success: true });
     findOperationMock.mockReset().mockResolvedValue(null);
     recordCompletionMock.mockClear();
     findThreadMock.mockReset().mockResolvedValue(null);
@@ -172,11 +176,12 @@ describe('AbandonOperationService', () => {
     });
   });
 
-  it('keeps no-state terminal operations classified as completed phantom timeouts', async () => {
+  it('returns terminal reconciliation fields for no-state terminal operations', async () => {
     const coord = buildCoordinator({ loadAgentState: vi.fn().mockResolvedValue(null) });
     const store = buildStore();
     const db = buildDb({
       operationRow: {
+        completionReason: 'done',
         id: 'op_done',
         status: 'done',
         userId: 'user_x',
@@ -190,6 +195,12 @@ describe('AbandonOperationService', () => {
 
     const result = await svc.finalizeAbandoned('op_done', 'inactivity_watchdog');
 
+    expect(result).toMatchObject({
+      completionReason: 'done',
+      reconciledStatus: 'completed',
+      terminal: true,
+      terminalStatus: 'completed',
+    });
     expect(result.abandoned).toBeUndefined();
     expect(recordCompletionMock).not.toHaveBeenCalled();
     expect(messageUpdateMock).not.toHaveBeenCalled();
@@ -307,35 +318,95 @@ describe('AbandonOperationService', () => {
     expect(coord.deleteAgentOperation).toHaveBeenCalledWith('op_x');
   });
 
-  it.each(['done', 'error', 'interrupted'])(
-    'skips abandoned lifecycle dispatch for terminal coordinator state %s',
-    async (status) => {
-      const coord = buildCoordinator({
-        loadAgentState: vi.fn().mockResolvedValue(stateWith({ status })),
-      });
-      const store = buildStore();
-      store.loadPartial.mockResolvedValue(null);
-      topicFindByIdMock.mockResolvedValue({
-        metadata: {
-          runningOperation: {
-            assistantMessageId: 'msg_assist_1',
-            operationId: 'op_x',
-          },
-        },
-      });
+  it('returns terminal reconciliation fields when live state is already terminal', async () => {
+    const coord = buildCoordinator({
+      loadAgentState: vi.fn().mockResolvedValue(stateWith({ status: 'done' })),
+    });
+    const store = buildStore();
+    store.loadPartial.mockResolvedValue({ steps: [{ stepIndex: 0 }], startedAt: 1 });
 
-      const svc = new AbandonOperationService({} as any, {
-        coordinator: coord as any,
-        snapshotStore: store as any,
-      });
+    const svc = new AbandonOperationService({} as any, {
+      coordinator: coord as any,
+      snapshotStore: store as any,
+    });
 
-      const result = await svc.finalizeAbandoned('op_x', 'inactivity_5m');
+    const result = await svc.finalizeAbandoned('op_done', 'inactivity_watchdog');
 
-      expect(result.found).toBe(true);
-      expect(topicUpdateMetadataMock).toHaveBeenCalledWith('tpc_x', { runningOperation: null });
-      expect(dispatchHooksMock).not.toHaveBeenCalled();
-    },
-  );
+    expect(result).toMatchObject({
+      completionReason: 'done',
+      finalized: false,
+      found: true,
+      reconciledStatus: 'completed',
+      terminal: true,
+      terminalStatus: 'completed',
+    });
+    expect(store.save).not.toHaveBeenCalled();
+    expect(messageUpdateMock).not.toHaveBeenCalled();
+    expect(coord.deleteAgentOperation).toHaveBeenCalledWith('op_done');
+  });
+
+  it('returns terminal reconciliation fields when partial snapshot already has completionReason', async () => {
+    const coord = buildCoordinator({
+      loadAgentState: vi.fn().mockResolvedValue(stateWith()),
+    });
+    const store = buildStore();
+    store.loadPartial.mockResolvedValue({
+      completionReason: 'interrupted',
+      startedAt: 1,
+      steps: [{ stepIndex: 0 }],
+    });
+
+    const svc = new AbandonOperationService({} as any, {
+      coordinator: coord as any,
+      snapshotStore: store as any,
+    });
+
+    const result = await svc.finalizeAbandoned('op_interrupted', 'inactivity_watchdog');
+
+    expect(result).toMatchObject({
+      completionReason: 'interrupted',
+      found: true,
+      reconciledStatus: 'interrupted',
+      terminal: true,
+      terminalStatus: 'interrupted',
+    });
+    expect(store.save).not.toHaveBeenCalled();
+    expect(messageUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('does not infer terminal completion from non-placeholder assistant content alone', async () => {
+    const coord = buildCoordinator({
+      loadAgentState: vi.fn().mockResolvedValue(stateWith()),
+    });
+    const store = buildStore();
+    store.loadPartial.mockResolvedValue({ startedAt: 1, steps: [{ stepIndex: 0 }] });
+    messageFindByIdMock.mockResolvedValue({
+      content: 'final answer already persisted',
+      id: 'msg_assist_1',
+      role: 'assistant',
+    });
+
+    const svc = new AbandonOperationService({} as any, {
+      coordinator: coord as any,
+      snapshotStore: store as any,
+    });
+
+    const result = await svc.finalizeAbandoned('op_answered', 'inactivity_watchdog');
+
+    expect(result).toMatchObject({
+      assistantMessageUpdated: true,
+      finalized: true,
+      found: true,
+    });
+    expect(result.terminal).toBeUndefined();
+    expect(store.save).toHaveBeenCalled();
+    expect(messageUpdateMock).toHaveBeenCalledWith('msg_assist_1', {
+      error: expect.objectContaining({
+        message: expect.stringContaining('inactivity_watchdog'),
+        type: 'AgentRuntimeError',
+      }),
+    });
+  });
 
   it('skips snapshot finalize when no partial exists but still updates message', async () => {
     const coord = buildCoordinator({


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to LOBE-11561, LOBE-11564.

#### 🔀 Description of Change

- Await terminal `/push-event` delivery in `GatewayStreamNotifier.publishAgentRuntimeEnd` so the gateway can see the final runtime event before the server invocation resolves.
- Teach `AbandonOperationService.finalizeAbandoned` to return gateway-readable terminal reconciliation fields when live state, partial snapshot, or the operation row already proves the op is terminal.
- Keep the reconciliation narrow: non-placeholder assistant content alone is not treated as `done`, so partial streaming output still remains eligible for a real inactivity timeout.
- Add handler coverage proving `finalize-abandoned` returns the reconciliation fields the gateway watchdog needs.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
bunx vitest run apps/server/src/services/agentRuntime/__tests__/AbandonOperationService.test.ts src/server/agent-hono/handlers/__tests__/finalizeAbandoned.test.ts apps/server/src/modules/AgentRuntime/__tests__/GatewayStreamNotifier.test.ts
# 3 files passed, 56 tests passed

git diff --check
```

`bun run type-check` and file-scoped `bun run check ... --lint --type` were attempted, but this isolated worktree only had a symlinked dependency tree for test execution. The commands failed on missing workspace dependencies / `prettier-plugin-sh` resolution outside this change rather than on these touched files.

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This is the lobehub-side half of the OIT remediation.