### PR TITLE
🐛 fix: reduce home refresh load

### DIFF
--- a/packages/database/src/models/__tests__/recent.test.ts
+++ b/packages/database/src/models/__tests__/recent.test.ts
@@ -113,13 +113,13 @@ describe('RecentModel', () => {
         });
       });
 
-      it('orders topic rows by latest message activity', async () => {
+      it('orders topic rows by topic updatedAt even when messages are newer', async () => {
         await serverDB.insert(agents).values({ id: 'agent-activity', userId, virtual: false });
         await serverDB.insert(topics).values([
           {
             agentId: 'agent-activity',
             id: 'topic-old-row-latest-message',
-            title: 'latest message wins',
+            title: 'latest message is ignored',
             updatedAt: minutesAgo(30),
             userId,
           },
@@ -142,8 +142,8 @@ describe('RecentModel', () => {
         const result = await recentModel.queryRecent();
 
         expect(result.map((row) => row.id)).toEqual([
-          'topic-old-row-latest-message',
           'topic-new-row-old-message',
+          'topic-old-row-latest-message',
         ]);
         expect(result[0].updatedAt.getTime()).toBeGreaterThan(result[1].updatedAt.getTime());
       });

--- a/packages/database/src/models/recent.ts
+++ b/packages/database/src/models/recent.ts
@@ -2,7 +2,7 @@ import type { TaskStatus } from '@lobechat/types';
 import { and, desc, eq, inArray, isNotNull, isNull, ne, not, or, sql } from 'drizzle-orm';
 import { unionAll } from 'drizzle-orm/pg-core';
 
-import { agents, DOCUMENT_FOLDER_TYPE, documents, messages, tasks, topics } from '../schemas';
+import { agents, DOCUMENT_FOLDER_TYPE, documents, tasks, topics } from '../schemas';
 import type { LobeChatDatabase } from '../type';
 import { buildWorkspaceWhere } from '../utils/workspace';
 
@@ -48,17 +48,6 @@ export class RecentModel {
     const taskScopeWhere = this.workspaceId
       ? eq(tasks.workspaceId, this.workspaceId)
       : and(eq(tasks.createdByUserId, this.userId), isNull(tasks.workspaceId));
-    const latestTopicMessageAtSubquery = this.db
-      .select({ value: messages.updatedAt })
-      .from(messages)
-      .where(and(eq(messages.topicId, topics.id), buildWorkspaceWhere(scope, messages)))
-      .orderBy(desc(messages.updatedAt))
-      .limit(1);
-
-    const topicActivityAt =
-      sql<Date>`COALESCE((${latestTopicMessageAtSubquery}), ${topics.updatedAt})`.mapWith(
-        topics.updatedAt,
-      );
 
     const topicArm = this.db
       .select({
@@ -69,7 +58,7 @@ export class RecentModel {
         status: sql<TaskStatus | null>`NULL`.as('status'),
         title: sql<string>`COALESCE(${topics.title}, 'Untitled Topic')`.as('title'),
         type: sql<RecentDbItem['type']>`'topic'`.as('type'),
-        updatedAt: topicActivityAt.as('updated_at'),
+        updatedAt: topics.updatedAt,
       })
       .from(topics)
       .leftJoin(agents, eq(topics.agentId, agents.id))

--- a/src/routes/(main)/home/_layout/Header/components/useInboxUnreadCount.test.ts
+++ b/src/routes/(main)/home/_layout/Header/components/useInboxUnreadCount.test.ts
@@ -82,11 +82,11 @@ describe('useInboxUnreadCount', () => {
     );
   });
 
-  it('keeps the 10 second polling timer while deduping repeated requests', () => {
-    expect(INBOX_UNREAD_COUNT_REFRESH_INTERVAL).toBe(10_000);
+  it('polls unread count once per minute while deduping repeated requests', () => {
+    expect(INBOX_UNREAD_COUNT_REFRESH_INTERVAL).toBe(60_000);
     expect(INBOX_UNREAD_COUNT_DEDUPING_INTERVAL).toBe(30_000);
-    expect(INBOX_UNREAD_COUNT_DEDUPING_INTERVAL).toBeGreaterThan(
-      INBOX_UNREAD_COUNT_REFRESH_INTERVAL,
+    expect(INBOX_UNREAD_COUNT_REFRESH_INTERVAL).toBeGreaterThan(
+      INBOX_UNREAD_COUNT_DEDUPING_INTERVAL,
     );
   });
 });

--- a/src/routes/(main)/home/_layout/Header/components/useInboxUnreadCount.ts
+++ b/src/routes/(main)/home/_layout/Header/components/useInboxUnreadCount.ts
@@ -6,7 +6,7 @@ import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/selectors';
 
 export const INBOX_UNREAD_COUNT_DEDUPING_INTERVAL = 30_000;
-export const INBOX_UNREAD_COUNT_REFRESH_INTERVAL = 10_000;
+export const INBOX_UNREAD_COUNT_REFRESH_INTERVAL = 60_000;
 
 export const useInboxUnreadCount = () => {
   const enableBusinessFeatures = useServerConfigStore(serverConfigSelectors.enableBusinessFeatures);

--- a/src/store/home/slices/recent/action.test.ts
+++ b/src/store/home/slices/recent/action.test.ts
@@ -39,6 +39,20 @@ afterEach(() => {
 
 describe('RecentActionImpl', () => {
   describe('useFetchRecents onData scope guard', () => {
+    it('does not poll recents periodically', () => {
+      const swrSpy = vi.spyOn(swr, 'useClientDataSWRWithSync').mockReturnValue({
+        data: undefined,
+        isValidating: false,
+        mutate: vi.fn(),
+      } as any);
+
+      renderHook(() => useHomeStore.getState().useFetchRecents(true, 10, 'user-1:ws-A'));
+
+      expect(swrSpy).toHaveBeenCalledWith(expect.any(Array), expect.any(Function), {
+        onData: expect.any(Function),
+      });
+    });
+
     it('applies data for the matching scope and tags recentsScope', () => {
       vi.spyOn(cacheScope, 'getCacheScope').mockReturnValue('user-1:ws-A');
       const getOnData = captureOnData('user-1:ws-A');

--- a/src/store/home/slices/recent/action.ts
+++ b/src/store/home/slices/recent/action.ts
@@ -12,12 +12,6 @@ import { setNamespace } from '@/utils/storeDebug';
 
 const n = setNamespace('recent');
 
-// Mirror the home Daily Brief / task detail polling cadence so users see new
-// items, status transitions (incl. backlog/paused → running which the per-item
-// task.detail poll never caught) without manual refresh. SWR pauses when the
-// tab is backgrounded.
-const RECENTS_REFRESH_INTERVAL = 10_000;
-
 const updateRecentTitleInList = (id: string, title: string) => (items?: RecentItem[]) =>
   items?.map((item) => (item.id === id ? { ...item, title } : item));
 
@@ -91,7 +85,6 @@ export class RecentActionImpl {
             n('useFetchRecents/onData'),
           );
         },
-        refreshInterval: RECENTS_REFRESH_INTERVAL,
       },
     );
   };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Reduces load from home refresh paths:

- `recent.getAll` now orders topic rows by the topic row `updatedAt` instead of deriving activity from the latest message.
- `useFetchRecents` no longer polls every 10 seconds. Recents still revalidate via the existing SWR key and explicit `refreshRecents()` paths.
- Notification unread count polling now runs once per minute instead of every 10 seconds.

The broader topic list activity ordering remains unchanged in this PR.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands run:

```bash
cd lobehub/packages/database && bunx vitest run --silent=passed-only src/models/__tests__/recent.test.ts
bunx vitest run --silent=passed-only src/store/home/slices/recent/action.test.ts
bunx vitest run --silent=passed-only src/routes/(main)/home/_layout/Header/components/useInboxUnreadCount.test.ts
```

Results:

- RecentModel: 23 tests passed
- RecentActionImpl: 9 tests passed
- useInboxUnreadCount: 3 tests passed

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This PR intentionally does not change broader topic activity sorting. It only removes the `messages` lookup and periodic recents polling from home recents, and lowers notification unread count polling frequency, as a production performance stopgap.
