### PR TITLE
🐛 fix(chat): gate text selection lab and release task verify

### DIFF
--- a/locales/en-US/labs.json
+++ b/locales/en-US/labs.json
@@ -15,6 +15,8 @@
   "features.imessage.title": "iMessage Channel",
   "features.inputMarkdown.desc": "Render Markdown in the input area in real time (bold text, code blocks, tables, etc.).",
   "features.inputMarkdown.title": "Input Markdown Rendering",
+  "features.messageTextSelectionActions.desc": "Show a quick action when selecting text in chat messages so the selected text can be added to the next conversation context.",
+  "features.messageTextSelectionActions.title": "Message Text Selection Actions",
   "features.platformAgent.desc": "Show the \"Connect Agent\" entry in the create menu. Connected agents (e.g. OpenClaw, Hermes) run on your own devices and communicate back via lh connect.",
   "features.platformAgent.title": "Connect Agent",
   "features.taskVerify.desc": "Add a delivery-acceptance section to the task detail: describe acceptance in one sentence and let AI generate editable verify criteria.",

--- a/locales/zh-CN/labs.json
+++ b/locales/zh-CN/labs.json
@@ -15,6 +15,8 @@
   "features.imessage.title": "iMessage 渠道",
   "features.inputMarkdown.desc": "在输入区域实时渲染 Markdown（粗体、代码块、表格等）",
   "features.inputMarkdown.title": "输入框 Markdown 渲染",
+  "features.messageTextSelectionActions.desc": "在聊天消息中选中文本时显示快捷操作，可将选中的文本加入下一次对话上下文。",
+  "features.messageTextSelectionActions.title": "消息文本选择操作",
   "features.platformAgent.desc": "在创建菜单中显示「接入助理」入口。接入的助理（如 OpenClaw、Hermes）运行在你自己的设备上，通过 lh connect 与 LobeHub 通信。",
   "features.platformAgent.title": "接入助理",
   "features.taskVerify.desc": "在任务详情里增加「交付验收」模块：一句话描述验收要求，AI 自动生成可编辑的验收项。",

--- a/packages/const/src/user.ts
+++ b/packages/const/src/user.ts
@@ -17,6 +17,7 @@ export const DEFAULT_PREFERENCE: UserPreference = {
     enableAgentSelfIteration: false,
     enableFleet: false,
     enableInputMarkdown: true,
+    enableMessageTextSelectionActions: false,
     enablePlatformAgent: false,
   },
   topicGroupMode: 'byTime',

--- a/packages/locales/src/default/labs.ts
+++ b/packages/locales/src/default/labs.ts
@@ -22,6 +22,9 @@ export default {
   'features.inputMarkdown.desc':
     'Render Markdown in the input area in real time (bold text, code blocks, tables, etc.).',
   'features.inputMarkdown.title': 'Input Markdown Rendering',
+  'features.messageTextSelectionActions.desc':
+    'Show a quick action when selecting text in chat messages so the selected text can be added to the next conversation context.',
+  'features.messageTextSelectionActions.title': 'Message Text Selection Actions',
   'features.platformAgent.desc':
     'Show the "Connect Agent" entry in the create menu. Connected agents (e.g. OpenClaw, Hermes) run on your own devices and communicate back via lh connect.',
   'features.platformAgent.title': 'Connect Agent',

--- a/packages/types/src/user/preference.ts
+++ b/packages/types/src/user/preference.ts
@@ -67,6 +67,10 @@ export const UserLabSchema = z.object({
    */
   enableInputMarkdown: z.boolean().optional(),
   /**
+   * enable selecting message text and adding it to the next conversation context
+   */
+  enableMessageTextSelectionActions: z.boolean().optional(),
+  /**
    * show the "Add Platform Agent" entry in the create menu
    */
   enablePlatformAgent: z.boolean().optional(),
@@ -115,11 +119,7 @@ export interface UserPreference {
 }
 
 export type ReferralStatusString =
-  | 'pending_reward'
-  | 'registered'
-  | 'suspected'
-  | 'rewarded'
-  | 'revoked';
+  'pending_reward' | 'registered' | 'suspected' | 'rewarded' | 'revoked';
 
 export interface UserInitializationState {
   agentOnboarding?: UserAgentOnboarding;

--- a/src/features/AgentTasks/AgentTaskDetail/TaskVerifyConfig.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskVerifyConfig.tsx
@@ -39,8 +39,6 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors, agentSelectors } from '@/store/agent/selectors';
 import { useTaskStore } from '@/store/task';
 import { taskDetailSelectors } from '@/store/task/selectors';
-import { useUserStore } from '@/store/user';
-import { labPreferSelectors } from '@/store/user/selectors';
 
 const SAVE_DEBOUNCE_MS = 600;
 
@@ -85,7 +83,6 @@ const TaskVerifyConfig = memo(() => {
   const { t } = useTranslation('chat');
   const { message } = App.useApp();
   const { allowed: canEditTask } = usePermission('create_content');
-  const enableTaskVerify = useUserStore(labPreferSelectors.enableTaskVerify);
 
   const taskId = useTaskStore(taskDetailSelectors.activeTaskId);
   const verify = useTaskStore(taskDetailSelectors.activeTaskVerifyConfig);
@@ -351,8 +348,6 @@ const TaskVerifyConfig = memo(() => {
   );
 
   if (!taskId) return null;
-  // Gated behind the Labs "task verify" experimental toggle (off by default).
-  if (!enableTaskVerify) return null;
   // The whole section is an editor surface; hide it when the user can't edit.
   if (!canEditTask) return null;
 

--- a/src/features/Conversation/Messages/index.tsx
+++ b/src/features/Conversation/Messages/index.tsx
@@ -9,6 +9,8 @@ import { memo, Suspense, useCallback } from 'react';
 
 import BubblesLoading from '@/components/BubblesLoading';
 import SafeBoundary from '@/components/ErrorBoundary';
+import { useUserStore } from '@/store/user';
+import { labPreferSelectors } from '@/store/user/selectors';
 
 import History from '../components/History';
 import { useChatItemContextMenu } from '../hooks/useChatItemContextMenu';
@@ -70,6 +72,9 @@ const MessageItem = memo<MessageItemProps>(
     isLatestItem,
   }) => {
     const topic = useConversationStore((s) => s.context.topicId);
+    const enableMessageTextSelectionActions = useUserStore(
+      labPreferSelectors.enableMessageTextSelectionActions,
+    );
 
     // Get message from ConversationStore
     const message = useConversationStore(dataSelectors.getDisplayMessageById(id), isEqual);
@@ -222,11 +227,12 @@ const MessageItem = memo<MessageItemProps>(
       </SafeBoundary>
     );
 
-    const selectableContent = supportsTextSelectionActions ? (
-      <TextSelectionActionLayer>{content}</TextSelectionActionLayer>
-    ) : (
-      content
-    );
+    const selectableContent =
+      enableMessageTextSelectionActions && supportsTextSelectionActions ? (
+        <TextSelectionActionLayer>{content}</TextSelectionActionLayer>
+      ) : (
+        content
+      );
 
     return (
       <>

--- a/src/routes/(main)/settings/advanced/index.test.tsx
+++ b/src/routes/(main)/settings/advanced/index.test.tsx
@@ -117,4 +117,28 @@ describe('Advanced settings page', () => {
 
     expect(screen.getByText('features.agentDocumentFloatingChatPanel.title')).toBeDefined();
   });
+
+  it('renders the message text selection actions lab toggle', () => {
+    useUserStore.setState({
+      isUserStateInit: true,
+      setSettings: vi.fn(),
+      updateLab: vi.fn(),
+    });
+
+    render(<Page />, { wrapper: createWrapper() });
+
+    expect(screen.getByText('features.messageTextSelectionActions.title')).toBeDefined();
+  });
+
+  it('does not render released task verify as a lab toggle', () => {
+    useUserStore.setState({
+      isUserStateInit: true,
+      setSettings: vi.fn(),
+      updateLab: vi.fn(),
+    });
+
+    render(<Page />, { wrapper: createWrapper() });
+
+    expect(screen.queryByText('features.taskVerify.title')).toBeNull();
+  });
 });

--- a/src/routes/(main)/settings/advanced/index.tsx
+++ b/src/routes/(main)/settings/advanced/index.tsx
@@ -53,8 +53,8 @@ const Page = memo(() => {
     enablePlatformAgent,
     enableImessage,
     enableFleet,
-    enableTaskVerify,
     enableFoldFinishedTurn,
+    enableMessageTextSelectionActions,
     updateLab,
   ] = useUserStore((s) => [
     preferenceSelectors.isPreferenceInit(s),
@@ -63,8 +63,8 @@ const Page = memo(() => {
     labPreferSelectors.enablePlatformAgent(s),
     labPreferSelectors.enableImessage(s),
     labPreferSelectors.enableFleet(s),
-    labPreferSelectors.enableTaskVerify(s),
     labPreferSelectors.enableFoldFinishedTurn(s),
+    labPreferSelectors.enableMessageTextSelectionActions(s),
     s.updateLab,
   ]);
 
@@ -188,19 +188,6 @@ const Page = memo(() => {
     {
       children: (
         <Switch
-          checked={enableTaskVerify}
-          loading={!isPreferenceInit}
-          onChange={(checked) => updateLab({ enableTaskVerify: checked })}
-        />
-      ),
-      className: styles.labItem,
-      desc: tLabs('features.taskVerify.desc'),
-      label: tLabs('features.taskVerify.title'),
-      minWidth: undefined,
-    },
-    {
-      children: (
-        <Switch
           checked={enableFoldFinishedTurn}
           loading={!isPreferenceInit}
           onChange={(checked) => updateLab({ enableFoldFinishedTurn: checked })}
@@ -209,6 +196,19 @@ const Page = memo(() => {
       className: styles.labItem,
       desc: tLabs('features.foldFinishedTurn.desc'),
       label: tLabs('features.foldFinishedTurn.title'),
+      minWidth: undefined,
+    },
+    {
+      children: (
+        <Switch
+          checked={enableMessageTextSelectionActions}
+          loading={!isPreferenceInit}
+          onChange={(checked) => updateLab({ enableMessageTextSelectionActions: checked })}
+        />
+      ),
+      className: styles.labItem,
+      desc: tLabs('features.messageTextSelectionActions.desc'),
+      label: tLabs('features.messageTextSelectionActions.title'),
       minWidth: undefined,
     },
     ...(isDesktop

--- a/src/store/user/slices/preference/selectors.test.ts
+++ b/src/store/user/slices/preference/selectors.test.ts
@@ -79,5 +79,17 @@ describe('preferenceSelectors', () => {
 
       expect(labPreferSelectors.enableAgentDocumentFloatingChatPanel(store)).toBe(true);
     });
+
+    it('returns false for message text selection actions by default', () => {
+      store.preference.lab = undefined;
+
+      expect(labPreferSelectors.enableMessageTextSelectionActions(store)).toBe(false);
+    });
+
+    it('returns the configured message text selection actions preference', () => {
+      store.preference.lab = { enableMessageTextSelectionActions: true };
+
+      expect(labPreferSelectors.enableMessageTextSelectionActions(store)).toBe(true);
+    });
   });
 });

--- a/src/store/user/slices/preference/selectors/labPrefer.ts
+++ b/src/store/user/slices/preference/selectors/labPrefer.ts
@@ -15,6 +15,10 @@ export const labPreferSelectors = {
   enableImessage: (s: UserState): boolean => s.preference.lab?.enableImessage ?? false,
   enableInputMarkdown: (s: UserState): boolean =>
     s.preference.lab?.enableInputMarkdown ?? DEFAULT_PREFERENCE.lab?.enableInputMarkdown ?? true,
+  enableMessageTextSelectionActions: (s: UserState): boolean =>
+    s.preference.lab?.enableMessageTextSelectionActions ??
+    DEFAULT_PREFERENCE.lab?.enableMessageTextSelectionActions ??
+    false,
   enablePlatformAgent: (s: UserState): boolean => s.preference.lab?.enablePlatformAgent ?? false,
   enableTaskVerify: (s: UserState): boolean => s.preference.lab?.enableTaskVerify ?? false,
 };


### PR DESCRIPTION
## Summary

- Add a Labs preference for message text selection actions, defaulting to off.
- Gate `TextSelectionActionLayer` behind that Lab switch so chat messages no longer mount the text-selection interaction layer by default.
- Release Task Delivery Acceptance from Labs: the task verify section now shows directly for editable task details, and the Labs settings toggle is removed.
- Add Labs copy for default/en-US/zh-CN and cover the selector/settings behavior with focused tests.

## Why

Today's chat interaction slowdown may be related to the newly mounted message text selection layer. Keeping it behind a Lab option lets us preserve the feature for testing while restoring the default chat rendering path.

Task Delivery Acceptance is ready to be available by default, so it no longer needs an experimental Lab gate.

## Validation

- `bun run check src/features/Conversation/Messages/index.tsx 'src/routes/(main)/settings/advanced/index.tsx' 'src/routes/(main)/settings/advanced/index.test.tsx' src/store/user/slices/preference/selectors/labPrefer.ts src/store/user/slices/preference/selectors.test.ts packages/types/src/user/preference.ts packages/const/src/user.ts packages/locales/src/default/labs.ts locales/en-US/labs.json locales/zh-CN/labs.json --lint --test`
  - lint clean
  - tests 13 passed
- `bun run check src/features/AgentTasks/AgentTaskDetail/TaskVerifyConfig.tsx 'src/routes/(main)/settings/advanced/index.tsx' 'src/routes/(main)/settings/advanced/index.test.tsx' --lint --test`
  - lint clean
  - tests 4 passed

Note: `--type` was attempted in the auxiliary worktree, but that worktree had no independent install and reusing the main worktree's `node_modules` makes workspace symlinks resolve against the older checkout, producing unrelated canary/main type export mismatches.
