### PR TITLE
🐛 fix(desktop): unblock onboarding startup

### DIFF
--- a/src/layout/GlobalProvider/CacheHydrationGate.test.tsx
+++ b/src/layout/GlobalProvider/CacheHydrationGate.test.tsx
@@ -67,6 +67,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  window.history.replaceState(null, '', '/');
   resetHydration();
   document.getElementById('loading-screen')?.remove();
   vi.useRealTimers();
@@ -174,6 +175,22 @@ describe('CacheHydrationGate', () => {
       cacheHydration.markReady('anon:personal');
     });
     expect(screen.queryByTestId('app')).not.toBeNull();
+  });
+
+  it('releases desktop onboarding without waiting for userId', () => {
+    vi.useFakeTimers();
+    window.history.replaceState(null, '', '/desktop-onboarding');
+    mockIsDesktop = true;
+    mockIsSignedIn = false;
+    mockUserId = undefined;
+    renderGate();
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(screen.queryByTestId('app')).not.toBeNull();
+    expect(document.getElementById('loading-screen')).toBeNull();
   });
 
   it('REGRESSION: signed-in web stays blocked past the timeout when userId is unresolved', () => {

--- a/src/layout/GlobalProvider/CacheHydrationGate.tsx
+++ b/src/layout/GlobalProvider/CacheHydrationGate.tsx
@@ -28,8 +28,8 @@ const HYDRATION_TIMEOUT = 1500;
  * full-screen white flash on login.
  *
  * The first paint additionally waits for a real `userId` — but only where one
- * is expected, i.e. where the identity round-trip actually runs: desktop
- * (always resolves a `DESKTOP_USER` id) or a signed-in web session. The
+ * is expected, i.e. where the identity round-trip actually runs: normal desktop
+ * app paths (which resolve a `DESKTOP_USER` id) or a signed-in web session. The
  * anonymous scope is only ever a transient pre-identity boot state, so painting
  * under it would persist fetched data into the `anon` partition and orphan it
  * the moment the real scope resolves (the stale-loading cache-miss bug).
@@ -44,6 +44,8 @@ const CacheHydrationGate = ({ children }: PropsWithChildren) => {
   const isAuthLoaded = Boolean(useUserStore(authSelectors.isLoaded));
   const isSignedIn = useUserStore(authSelectors.isLogin);
   const userId = useUserStore(userProfileSelectors.userId);
+  const isDesktopOnboarding =
+    typeof window !== 'undefined' && window.location.pathname.startsWith('/desktop-onboarding');
 
   const ready = useSyncExternalStore(
     cacheHydration.subscribe,
@@ -68,7 +70,7 @@ const CacheHydrationGate = ({ children }: PropsWithChildren) => {
     // signed-in web session — the same condition that triggers `useInitUserState`).
     // No-auth / logged-out web never produces one, so it must not be blocked here.
     // Guard on `isAuthLoaded` so we don't act on a stale `isSignedIn` mid-load.
-    if (isAuthLoaded && (isDesktop || isSignedIn) && !userId) return;
+    if (isAuthLoaded && ((isDesktop && !isDesktopOnboarding) || isSignedIn) && !userId) return;
 
     // Block until the session check resolves (it always does — success, failure,
     // or no-auth — so this isn't an infinite hang). Preceding the timeout means a
@@ -84,7 +86,7 @@ const CacheHydrationGate = ({ children }: PropsWithChildren) => {
     if (!ready) return;
 
     setReleased(true);
-  }, [isAuthLoaded, isSignedIn, userId, ready, released, timedOut]);
+  }, [isAuthLoaded, isDesktopOnboarding, isSignedIn, userId, ready, released, timedOut]);
 
   useLayoutEffect(() => {
     if (!released) return;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Allow the initial cache hydration gate to release on the desktop onboarding route without waiting for a desktop user id.
- Keep the existing desktop-specific route ownership intact: Electron dev resolves desktopRouter.config to desktopRouter.config.desktop.tsx through the Vite platform resolver.
- Add regression coverage for desktop onboarding loading-screen release behavior.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands:

- bunx vitest run --silent='passed-only' src/layout/GlobalProvider/CacheHydrationGate.test.tsx
- bun run check src/layout/GlobalProvider/CacheHydrationGate.tsx src/layout/GlobalProvider/CacheHydrationGate.test.tsx --lint --test
- git diff --check

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Desktop onboarding stayed on the static loading screen before user identity initialized. | Desktop onboarding route mounts after the hydration timeout without requiring a user id. |

#### 📝 Additional Information

Desktop cold start can still intentionally load app://renderer/desktop-onboarding when the remote server is not configured. The fix is limited to the first-paint gate for that route.