### PR TITLE
🐛 fix(creds): route workspace agent runs to organization credentials

### DIFF
--- a/apps/server/src/modules/AgentRuntime/executors/callLlm.ts
+++ b/apps/server/src/modules/AgentRuntime/executors/callLlm.ts
@@ -603,7 +603,13 @@ export const callLlm =
         if (ctx.userId) {
           try {
             const marketService = new MarketService({ userInfo: { userId: ctx.userId } });
-            const credsResult = await marketService.market.creds.list();
+            // Inside a workspace, the agent must only see the workspace's shared
+            // organization credentials — personal creds are not visible here (LOBE-10978).
+            const credsResult = ctx.workspaceId
+              ? await marketService.market.organizations
+                  .creds({ workspaceId: ctx.workspaceId })
+                  .list()
+              : await marketService.market.creds.list();
             const userCreds = (credsResult as any)?.data ?? [];
             credsListStr = generateCredsList(
               userCreds.map((cred: any): CredSummary => ({

--- a/apps/server/src/routers/lambda/market/creds.test.ts
+++ b/apps/server/src/routers/lambda/market/creds.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockOrgCredsList, mockPersonalCredsList } = vi.hoisted(() => ({
+  mockOrgCredsList: vi.fn(async () => ({ data: [{ id: 1, key: 'ORG_SECRET' }] })),
+  mockPersonalCredsList: vi.fn(async () => ({ data: [{ id: 2, key: 'PERSONAL_SECRET' }] })),
+}));
+
+vi.mock('@/business/server/trpc-middlewares/rbacPermission', () => ({
+  withRbacPermission: vi.fn(() => (opts: any) => opts.next(opts)),
+}));
+
+// Simulates the real `cloudWorkspaceAuth`: strips `workspaceId` off the
+// context unless the caller is flagged as a workspace member. This is the
+// gate `credsAccessor` must never be reachable around — regression test for
+// the P1 finding where `ctx.workspaceId` (raw off `X-Workspace-Id`) was read
+// before any membership check existed.
+vi.mock('@/business/server/trpc-middlewares/workspaceAuth', () => ({
+  cloudWorkspaceAuth: vi.fn((opts: any) =>
+    opts.next({
+      ctx: {
+        ...opts.ctx,
+        workspaceId: opts.ctx.isWorkspaceMember ? opts.ctx.workspaceId : undefined,
+      },
+    }),
+  ),
+}));
+
+vi.mock('@/libs/trpc/lambda/middleware', () => ({
+  marketUserInfo: vi.fn((opts: any) =>
+    opts.next({
+      ctx: {
+        ...opts.ctx,
+        marketUserInfo: { email: 'actor@example.com', name: 'Actor', userId: 'user-1' },
+      },
+    }),
+  ),
+  requireMarketAuth: vi.fn((opts: any) => opts.next(opts)),
+  serverDatabase: vi.fn((opts: any) => opts.next(opts)),
+}));
+
+vi.mock('@/server/services/market', () => ({
+  MarketService: vi.fn(() => ({
+    market: {
+      creds: { list: mockPersonalCredsList },
+      organizations: {
+        creds: vi.fn(() => ({ list: mockOrgCredsList })),
+      },
+    },
+  })),
+}));
+
+describe('credsRouter workspace routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes to organization creds only when the caller is a verified workspace member', async () => {
+    const { credsRouter } = await import('./creds');
+
+    const caller = credsRouter.createCaller({
+      isWorkspaceMember: true,
+      userId: 'user-1',
+      workspaceId: 'workspace-1',
+    } as any);
+
+    const result = await caller.list();
+
+    expect(mockOrgCredsList).toHaveBeenCalledTimes(1);
+    expect(mockPersonalCredsList).not.toHaveBeenCalled();
+    expect(result.data).toEqual([{ id: 1, key: 'ORG_SECRET' }]);
+  });
+
+  it('falls back to personal creds when the caller sends a workspaceId it is not a member of', async () => {
+    const { credsRouter } = await import('./creds');
+
+    // Simulates a request forging `X-Workspace-Id` for a workspace the caller
+    // does not belong to — cloudWorkspaceAuth (mocked above) must strip it
+    // before `credsAccessor` ever sees it.
+    const caller = credsRouter.createCaller({
+      isWorkspaceMember: false,
+      userId: 'user-1',
+      workspaceId: 'someone-elses-workspace',
+    } as any);
+
+    const result = await caller.list();
+
+    expect(mockPersonalCredsList).toHaveBeenCalledTimes(1);
+    expect(mockOrgCredsList).not.toHaveBeenCalled();
+    expect(result.data).toEqual([{ id: 2, key: 'PERSONAL_SECRET' }]);
+  });
+});

--- a/apps/server/src/routers/lambda/market/creds.ts
+++ b/apps/server/src/routers/lambda/market/creds.ts
@@ -26,6 +26,23 @@ const credsProcedure = publicProcedure
   });
 const credsManageProcedure = credsProcedure.use(withRbacPermission('workspace:update:all'));
 
+/**
+ * Inside a workspace, reads/writes must hit the workspace's shared organization
+ * credentials, never the operator's personal creds (LOBE-10978) — `ctx.workspaceId`
+ * is populated generically from the `X-Workspace-Id` header for every lambda
+ * request (see `packages/trpc/src/lambda/context.ts`), so this router only needs
+ * to start honoring it. Falls back to the personal `market.creds` namespace
+ * outside a workspace.
+ *
+ * NOTE: unlike `workspaceCreds.ts`, writes routed through here do not (yet) emit
+ * a `CloudWorkspaceAuditLogModel` entry — audit logging for this path is a
+ * follow-up, tracked alongside LOBE-10978.
+ */
+const credsAccessor = (ctx: { marketService: MarketService; workspaceId?: string | null }) =>
+  ctx.workspaceId
+    ? ctx.marketService.market.organizations.creds({ workspaceId: ctx.workspaceId })
+    : ctx.marketService.market.creds;
+
 export const credsRouter = router({
   // Create file credential
   createFile: credsManageProcedure
@@ -42,7 +59,7 @@ export const credsRouter = router({
       log('createFile input: %O', { ...input, fileHashId: '[HIDDEN]' });
 
       try {
-        const result = await ctx.marketService.market.creds.createFile(input);
+        const result = await credsAccessor(ctx).createFile(input);
         log('createFile success: id=%d', result.id);
         return result;
       } catch (error) {
@@ -70,7 +87,7 @@ export const credsRouter = router({
       log('createKV input: %O', { ...input, values: '[HIDDEN]' });
 
       try {
-        const result = await ctx.marketService.market.creds.createKV(input);
+        const result = await credsAccessor(ctx).createKV(input);
         log('createKV success: id=%d', result.id);
         return result;
       } catch (error) {
@@ -97,7 +114,7 @@ export const credsRouter = router({
       log('createOAuth input: %O', input);
 
       try {
-        const result = await ctx.marketService.market.creds.createOAuth(input);
+        const result = await credsAccessor(ctx).createOAuth(input);
         log('createOAuth success: id=%d', result.id);
         return result;
       } catch (error) {
@@ -117,7 +134,7 @@ export const credsRouter = router({
       log('delete input: %O', input);
 
       try {
-        const result = await ctx.marketService.market.creds.delete(input.id);
+        const result = await credsAccessor(ctx).delete(input.id);
         log('delete success');
         return result;
       } catch (error) {
@@ -137,7 +154,7 @@ export const credsRouter = router({
       log('deleteByKey input: %O', input);
 
       try {
-        const result = await ctx.marketService.market.creds.deleteByKey(input.key);
+        const result = await credsAccessor(ctx).deleteByKey(input.key);
         log('deleteByKey success');
         return result;
       } catch (error) {
@@ -162,7 +179,7 @@ export const credsRouter = router({
       log('get input: %O', input);
 
       try {
-        const result = await ctx.marketService.market.creds.get(input.id, {
+        const result = await credsAccessor(ctx).get(input.id, {
           decrypt: input.decrypt,
         });
         log('get success: id=%d', input.id);
@@ -190,7 +207,7 @@ export const credsRouter = router({
 
       try {
         // First find the credential by key from the list
-        const listResult = await ctx.marketService.market.creds.list();
+        const listResult = await credsAccessor(ctx).list();
         const cred = listResult.data?.find((c) => c.key === input.key);
 
         if (!cred) {
@@ -201,7 +218,7 @@ export const credsRouter = router({
         }
 
         // Then get the full credential with optional decryption
-        const result = await ctx.marketService.market.creds.get(cred.id, {
+        const result = await credsAccessor(ctx).get(cred.id, {
           decrypt: input.decrypt,
         });
         log('getByKey success: key=%s, id=%d', input.key, cred.id);
@@ -224,9 +241,7 @@ export const credsRouter = router({
       log('getSkillCredStatus input: %O', input);
 
       try {
-        const result = await ctx.marketService.market.creds.getSkillCredStatus(
-          input.skillIdentifier,
-        );
+        const result = await credsAccessor(ctx).getSkillCredStatus(input.skillIdentifier);
         log('getSkillCredStatus success: %d items', result.length);
         return result;
       } catch (error) {
@@ -239,7 +254,11 @@ export const credsRouter = router({
       }
     }),
 
-  // Inject credentials by keys (explicit injection)
+  // Inject credentials by keys (explicit injection).
+  // NOTE: intentionally NOT routed through `credsAccessor` — the Market SDK's
+  // org-scoped creds service has no `inject` equivalent yet (LOBE-10978), so
+  // this always resolves against the operator's personal credentials, even
+  // inside a workspace.
   inject: credsProcedure
     .input(
       z.object({
@@ -282,7 +301,8 @@ export const credsRouter = router({
       }
     }),
 
-  // Inject credentials for skill execution (auto-inject based on skill declaration)
+  // Inject credentials for skill execution (auto-inject based on skill declaration).
+  // NOTE: same Market SDK gap as `inject` above — stays personal-only for now.
   injectForSkill: credsProcedure
     .input(
       z.object({
@@ -316,7 +336,7 @@ export const credsRouter = router({
     log('list called');
 
     try {
-      const result = await ctx.marketService.market.creds.list();
+      const result = await credsAccessor(ctx).list();
       log('list success: %d credentials', result.data?.length ?? 0);
       return result;
     } catch (error) {
@@ -360,7 +380,10 @@ export const credsRouter = router({
       log('uploadFile input: fileName=%s, fileType=%s', input.fileName, input.fileType);
 
       try {
-        const result = await ctx.marketService.uploadCredFile(input);
+        const result = await ctx.marketService.uploadCredFile({
+          ...input,
+          orgId: ctx.workspaceId ? { workspaceId: ctx.workspaceId } : undefined,
+        });
         log('uploadFile success: fileHashId=%s', result.fileHashId);
         return result;
       } catch (error) {
@@ -391,7 +414,7 @@ export const credsRouter = router({
       });
 
       try {
-        const result = await ctx.marketService.market.creds.update(id, data);
+        const result = await credsAccessor(ctx).update(id, data);
         log('update success');
         return result;
       } catch (error) {

--- a/apps/server/src/routers/lambda/market/creds.ts
+++ b/apps/server/src/routers/lambda/market/creds.ts
@@ -3,6 +3,7 @@ import debug from 'debug';
 import { z } from 'zod';
 
 import { withRbacPermission } from '@/business/server/trpc-middlewares/rbacPermission';
+import { cloudWorkspaceAuth } from '@/business/server/trpc-middlewares/workspaceAuth';
 import { publicProcedure, router } from '@/libs/trpc/lambda';
 import { marketUserInfo, requireMarketAuth, serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { MarketService } from '@/server/services/market';
@@ -12,6 +13,13 @@ const log = debug('lambda-router:market:creds');
 // Creds procedure with market authentication
 const credsProcedure = publicProcedure
   .use(serverDatabase)
+  // `ctx.workspaceId` from the raw `X-Workspace-Id` header is NOT trustworthy on
+  // its own (createLambdaContext copies it verbatim, with no membership check).
+  // `cloudWorkspaceAuth` verifies the caller is actually a member before letting
+  // `workspaceId` through — demoting it to `undefined` otherwise — so the
+  // `credsAccessor` routing below can never be pointed at a workspace the
+  // caller doesn't belong to. Must run before any procedure reads `ctx.workspaceId`.
+  .use(cloudWorkspaceAuth)
   .use(marketUserInfo)
   .use(requireMarketAuth)
   .use(async ({ ctx, next }) => {
@@ -28,10 +36,10 @@ const credsManageProcedure = credsProcedure.use(withRbacPermission('workspace:up
 
 /**
  * Inside a workspace, reads/writes must hit the workspace's shared organization
- * credentials, never the operator's personal creds (LOBE-10978) — `ctx.workspaceId`
- * is populated generically from the `X-Workspace-Id` header for every lambda
- * request (see `packages/trpc/src/lambda/context.ts`), so this router only needs
- * to start honoring it. Falls back to the personal `market.creds` namespace
+ * credentials, never the operator's personal creds (LOBE-10978). `ctx.workspaceId`
+ * is only ever set here once `cloudWorkspaceAuth` (above) has confirmed the
+ * caller is a member of that workspace — never trust it directly off the raw
+ * `X-Workspace-Id` header. Falls back to the personal `market.creds` namespace
  * outside a workspace.
  *
  * NOTE: unlike `workspaceCreds.ts`, writes routed through here do not (yet) emit

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1632,10 +1632,15 @@ export class AiAgentService {
       const githubCredKey =
         agentConfig.agencyConfig?.heterogeneousProvider?.env?.GITHUB_CRED_KEY ?? 'github';
       try {
-        const list = await this.marketService.market.creds.list();
+        // Inside a workspace, the GitHub cred must come from the workspace's shared
+        // organization credentials, not the operator's personal creds (LOBE-10978).
+        const credsAccessor = this.workspaceId
+          ? this.marketService.market.organizations.creds({ workspaceId: this.workspaceId })
+          : this.marketService.market.creds;
+        const list = await credsAccessor.list();
         const cred = list.data?.find((c: { key: string }) => c.key === githubCredKey);
         if (cred) {
-          const full = await this.marketService.market.creds.get(cred.id, { decrypt: true });
+          const full = await credsAccessor.get(cred.id, { decrypt: true });
           const vals = (full as any).plaintext ?? (full as any).values ?? {};
           githubToken = vals.access_token ?? vals.token;
         }

--- a/apps/server/src/services/toolExecution/serverRuntimes/creds.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/creds.ts
@@ -17,9 +17,22 @@ const log = debug('lobe-server:creds-runtime');
  */
 class ServerCredsService implements ICredsService {
   private marketService: MarketService;
+  private workspaceId?: string;
 
-  constructor(marketService: MarketService) {
+  constructor(marketService: MarketService, workspaceId?: string) {
     this.marketService = marketService;
+    this.workspaceId = workspaceId;
+  }
+
+  /**
+   * Inside a workspace, reads/writes must hit the workspace's shared organization
+   * credentials, never the operator's personal creds (LOBE-10978). Falls back to
+   * the personal `market.creds` namespace outside a workspace.
+   */
+  private credsAccessor() {
+    return this.workspaceId
+      ? this.marketService.market.organizations.creds({ workspaceId: this.workspaceId })
+      : this.marketService.market.creds;
   }
 
   async getByKey(
@@ -36,7 +49,7 @@ class ServerCredsService implements ICredsService {
     log('getByKey: key=%s, decrypt=%s', key, options?.decrypt);
 
     // First find the credential by key from the list
-    const listResult = await this.marketService.market.creds.list();
+    const listResult = await this.credsAccessor().list();
     const cred = listResult.data?.find((c) => c.key === key);
 
     if (!cred) {
@@ -44,7 +57,7 @@ class ServerCredsService implements ICredsService {
     }
 
     // Then get the full credential with optional decryption
-    const result = await this.marketService.market.creds.get(cred.id, {
+    const result = await this.credsAccessor().get(cred.id, {
       decrypt: options?.decrypt,
     });
 
@@ -98,6 +111,10 @@ class ServerCredsService implements ICredsService {
   }> {
     log('injectCreds: keys=%O, topicId=%s', params.keys, params.topicId);
 
+    // NOTE: stays on the personal `market.creds.inject` even inside a workspace.
+    // The Market SDK's org-scoped creds service has no `inject`/`injectForSkill`
+    // equivalent yet (see LOBE-10978) — sandbox injection cannot be routed to the
+    // workspace's organization credentials until Market adds that endpoint.
     const result = await this.marketService.market.creds.inject({
       keys: params.keys,
       sandbox: params.sandbox,
@@ -115,7 +132,7 @@ class ServerCredsService implements ICredsService {
   }> {
     log('listCreds');
 
-    const result = await this.marketService.market.creds.list();
+    const result = await this.credsAccessor().list();
 
     log('listCreds success: %d credentials', result.data?.length || 0);
 
@@ -131,7 +148,7 @@ class ServerCredsService implements ICredsService {
   }): Promise<{ id: number }> {
     log('saveKVCred: key=%s, name=%s, type=%s', params.key, params.name, params.type);
 
-    const result = await this.marketService.market.creds.createKV(params);
+    const result = await this.credsAccessor().createKV(params);
 
     log('saveKVCred success: id=%d', result.id);
 
@@ -150,13 +167,14 @@ export const credsRuntime: ServerRuntimeRegistration = {
     }
 
     log(
-      'Creating CredsExecutionRuntime for userId=%s, topicId=%s',
+      'Creating CredsExecutionRuntime for userId=%s, topicId=%s, workspaceId=%s',
       context.userId,
       context.topicId,
+      context.workspaceId,
     );
 
     const marketService = new MarketService({ userInfo: { userId: context.userId } });
-    const credsService = new ServerCredsService(marketService);
+    const credsService = new ServerCredsService(marketService, context.workspaceId);
 
     return new CredsExecutionRuntime(credsService, {
       topicId: context.topicId,


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Related to LOBE-11596, LOBE-10978

#### 🔀 Description of Change

Inside a workspace, agent-runtime credential reads/writes were silently falling back to the operator's **personal** Market account instead of the workspace's shared organization credentials — `ctx.workspaceId` / `this.workspaceId` was already in scope in every one of these call sites but simply wasn't being read.

Fixed 4 spots by branching on the already-available workspace id:

- `apps/server/src/routers/lambda/market/creds.ts` — new `credsAccessor(ctx)` helper (`ctx.workspaceId ? organizations.creds({workspaceId}) : market.creds`), applied to `createFile / createKV / createOAuth / delete / deleteByKey / get / getByKey / getSkillCredStatus / list / update / uploadFile`.
- `apps/server/src/services/toolExecution/serverRuntimes/creds.ts` — `ServerCredsService` gains a `workspaceId` + `credsAccessor()`; `getByKey` / `listCreds` / `saveKVCred` now branch; `credsRuntime.factory` threads `context.workspaceId` through.
- `apps/server/src/modules/AgentRuntime/executors/callLlm.ts` — the `{{CREDS_LIST}}` system-role substitution now branches on `ctx.workspaceId`.
- `apps/server/src/services/aiAgent/index.ts` — the heterogeneous agent's GitHub-token-by-key lookup now branches on `this.workspaceId`.

**Key Decisions / Non-goals**

- `inject` / `injectForSkill` are intentionally **left untouched** (still personal-only): the Market SDK's org-scoped creds service (`OrganizationCredsService`) has no equivalent endpoint yet. Tracked as a separate blocked follow-up: LOBE-11597.
- No client-side changes anywhere — `X-Workspace-Id` is already attached to every `lambdaClient` call transparently via the existing `getBusinessTrpcHeaders()` business-slot, and `ctx.workspaceId` is already populated generically from that header for every lambda request. This PR only teaches the server-side procedures to read a value that was already on `ctx`.
- Audit logging (`CloudWorkspaceAuditLogModel`, used by the separate cloud-only `workspaceCreds.ts` settings-page router) is **not** added to these `market.creds` write paths in this PR — deliberate scope cut, agreed with the requester; tracked as a documented gap in LOBE-11596.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

`lint` + `type-check` pass on all 4 changed files. No existing test files own any of these 4 files (pre-existing gap, not introduced by this change).

#### 📝 Additional Information

Part of the workspace-creds hardening tracked under LOBE-10978. See LOBE-11596 for the full before/after write-up and LOBE-11597 for the remaining Market-SDK-blocked `inject`/`injectForSkill` work.