### PR TITLE
💄 style(agent): align review gutter button

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/FileItem.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/FileItem.tsx
@@ -143,25 +143,29 @@ const reviewDiffUnsafeCSS = `
     backdrop-filter: blur(16px) !important;
   }
 
-  [data-utility-button] {
-    width: 16px !important;
-    min-width: 16px !important;
-    height: 16px !important;
+  [data-gutter-utility-slot] [data-utility-button] {
+    width: 18px !important;
+    min-width: 18px !important;
+    height: 18px !important;
     margin-right: calc(1ch - 8px) !important;
-    border: 1px solid ${themeCssVar.colorBorderSecondary} !important;
-    border-radius: 50% !important;
-    background: ${themeCssVar.colorBgContainer} !important;
-    color: ${themeCssVar.colorTextSecondary} !important;
-    box-shadow: 0 2px 8px ${themeCssVar.colorFillSecondary} !important;
+    border: 1px solid #0969da !important;
+    border-radius: 4px !important;
+    background: #0969da !important;
+    background-color: #0969da !important;
+    color: #fff !important;
+    fill: currentColor !important;
+    box-shadow: 0 1px 3px ${themeCssVar.colorFillSecondary} !important;
   }
 
-  [data-utility-button]:hover {
-    border-color: ${themeCssVar.colorPrimary} !important;
-    background: ${themeCssVar.colorPrimaryBg} !important;
-    color: ${themeCssVar.colorPrimary} !important;
+  [data-gutter-utility-slot] [data-utility-button]:is(:hover, :focus-visible, :active) {
+    border-color: #0860ca !important;
+    background: #0860ca !important;
+    background-color: #0860ca !important;
+    color: #fff !important;
+    fill: currentColor !important;
   }
 
-  [data-utility-button] [data-icon] {
+  [data-gutter-utility-slot] [data-utility-button] [data-icon] {
     width: 10px !important;
     height: 10px !important;
   }
@@ -375,6 +379,7 @@ const FileItemBody = memo<FileItemBodyProps>(
         language={language}
         patch={patch}
         showHeader={false}
+        style={{ borderRadius: 0 }}
         variant={'borderless'}
         viewMode={viewMode}
       />


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Align the review gutter utility button with the GitHub review button style.

- Remove the large circular gutter button treatment.
- Use a GitHub-like blue filled button with a darker interactive state.
- Remove the rounded outer PatchDiff container in the working sidebar review diff.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validated with:

- bun run check src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/FileItem.tsx --lint
- git diff --check -- src/routes/(main)/agent/features/Conversation/WorkingSidebar/Review/FileItem.tsx

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

UI-only styling adjustment for the working sidebar review diff.