### PR TITLE
🐛 fix: show multi-select for hetero messages

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/useActionsBarConfig.ts
+++ b/src/routes/(main)/agent/features/Conversation/useActionsBarConfig.ts
@@ -10,6 +10,8 @@ import { agentSelectors } from '@/store/agent/selectors';
  * Hetero-agent (Claude Code / Codex) sessions keep the menu minimal — copy +
  * delete — because the external runtime owns the assistant message lifecycle
  * (edit / regenerate / branching / translate / tts / share don't apply).
+ * `select` remains available because forwarding / batch deletion is handled by
+ * the local conversation UI and does not depend on the external runtime.
  *
  * The one user-message action that DOES belong here is `restoreToInput`: a long
  * CLI run that errors out or loses context is exactly when you want to pull the
@@ -18,12 +20,12 @@ import { agentSelectors } from '@/store/agent/selectors';
  */
 const HETERO_USER: { bar: MessageActionSlot[]; menu: MessageActionSlot[] } = {
   bar: ['copy'],
-  menu: ['restoreToInput', 'copy', 'divider', 'del'],
+  menu: ['restoreToInput', 'copy', 'divider', 'select', 'divider', 'del'],
 };
 
 const HETERO_ASSISTANT: { bar: MessageActionSlot[]; menu: MessageActionSlot[] } = {
   bar: ['copy'],
-  menu: ['copy', 'divider', 'del'],
+  menu: ['copy', 'divider', 'select', 'divider', 'del'],
 };
 
 export const useActionsBarConfig = (): ActionsBarConfig => {


### PR DESCRIPTION
## Summary
- add the `select` action back to hetero-agent user, assistant, and assistantGroup overflow menus
- keep the menu otherwise minimal: restore/copy/delete for user messages and copy/delete for assistant turns

## Root Cause
The hetero-agent action bar override intentionally trimmed unsupported lifecycle actions, but also removed `select`. Multi-select is handled by the local conversation UI for forwarding and batch deletion, so it should stay available even when the external runtime owns edit/regenerate behavior.

## Validation
- `bun run check src/routes/'(main)'/agent/features/Conversation/useActionsBarConfig.ts --lint`