### PR TITLE
🐛 fix: preflight OpenAI context limit errors

### DIFF
--- a/packages/model-runtime/src/errors/classifier.test.ts
+++ b/packages/model-runtime/src/errors/classifier.test.ts
@@ -15,6 +15,7 @@ describe('ErrorClassifier', () => {
     ['prompt is too long: 231426 tokens > 200000 maximum', true],
     ['context_length_exceeded', true],
     ['MAXIMUM CONTEXT LENGTH exceeded', true],
+    ['Free plan effective context limit reached, please reduce input.', true],
     ['Invalid API key', false],
     ['Rate limit exceeded', false],
     ['Internal server error', false],

--- a/packages/model-runtime/src/errors/match.test.ts
+++ b/packages/model-runtime/src/errors/match.test.ts
@@ -30,6 +30,11 @@ describe('matchErrorPattern', () => {
     ).toBe(AgentRuntimeErrorType.ExceededContextWindow);
   });
 
+  it('classifies free-plan context limit residues as ExceededContextWindow', () => {
+    const message = 'Free plan effective context limit reached. Please reduce the conversation.';
+    expect(matchErrorPattern({ message })?.code).toBe(AgentRuntimeErrorType.ExceededContextWindow);
+  });
+
   it('disambiguates 429-class rate limit from balance-class quota', () => {
     expect(matchErrorPattern({ message: 'rate_limit_exceeded' })?.code).toBe(
       AgentRuntimeErrorType.RateLimitExceeded,

--- a/packages/model-runtime/src/errors/patterns.ts
+++ b/packages/model-runtime/src/errors/patterns.ts
@@ -107,6 +107,10 @@ export const ERROR_PATTERNS: ErrorPattern[] = [
     code: AgentRuntimeErrorType.ExceededContextWindow,
     match: sub('request too large for model', { caseInsensitive: true }),
   },
+  {
+    code: AgentRuntimeErrorType.ExceededContextWindow,
+    match: sub('free plan effective context limit reached', { caseInsensitive: true }),
+  },
   { code: AgentRuntimeErrorType.ExceededContextWindow, match: sub('exceeded max context length') },
   {
     code: AgentRuntimeErrorType.ExceededContextWindow,

--- a/packages/model-runtime/src/providers/openai/index.test.ts
+++ b/packages/model-runtime/src/providers/openai/index.test.ts
@@ -3,6 +3,7 @@ import OpenAI from 'openai';
 import type { Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { AgentRuntimeErrorType } from '../../types/error';
 import * as debugStreamModule from '../../utils/debugStream';
 import * as getModelPricingModule from '../../utils/getModelPricing';
 import officalOpenAIModels from './fixtures/openai-models.json';
@@ -57,6 +58,27 @@ describe('LobeOpenAI', () => {
 
       // Assert
       expect(result).toBeInstanceOf(Response);
+    });
+
+    it('should abort locally when the prompt exceeds the OpenAI model context window', async () => {
+      const mockCreateMethod = vi.spyOn(instance['client'].chat.completions, 'create');
+      const hugeContent = 'lorem ipsum dolor '.repeat(150_000);
+
+      try {
+        await instance.chat({
+          messages: [{ content: hugeContent, role: 'user' }],
+          model: 'gpt-4o',
+          temperature: 0,
+        });
+        expect.fail('expected chat to reject');
+      } catch (error) {
+        expect((error as any).errorType).toBe(AgentRuntimeErrorType.ExceededContextWindow);
+        expect((error as any).error.type).toBe('context_exceeded_pre_flight');
+        expect((error as any).error.model).toBe('gpt-4o');
+        expect((error as any).error.ctx).toBe(128_000);
+      }
+
+      expect(mockCreateMethod).not.toHaveBeenCalled();
     });
 
     describe('Error', () => {

--- a/packages/model-runtime/src/providers/openai/index.ts
+++ b/packages/model-runtime/src/providers/openai/index.ts
@@ -1,4 +1,4 @@
-import { ModelProvider } from 'model-bank';
+import { ModelProvider, openaiChatModels } from 'model-bank';
 
 import { pruneReasoningPayload } from '../../core/contextBuilders/openai';
 import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
@@ -23,6 +23,7 @@ const enableServiceTierFlex = process.env.OPENAI_SERVICE_TIER_FLEX === '1';
 export const params = {
   baseURL: 'https://api.openai.com/v1',
   chatCompletion: {
+    contextPreFlight: { models: openaiChatModels },
     handlePayload: (payload) => {
       const { enabledSearch, model, ...rest } = payload;
 

--- a/packages/model-runtime/src/utils/isNonRetryableRequestError.test.ts
+++ b/packages/model-runtime/src/utils/isNonRetryableRequestError.test.ts
@@ -42,6 +42,19 @@ describe('isNonRetryableRequestError', () => {
     ).toBe(true);
   });
 
+  it('returns true for provider request-body-too-large context errors', () => {
+    expect(
+      isNonRetryableRequestError({
+        error: {
+          message: 'Request body too large for gpt-4o model',
+          type: 'invalid_request_error',
+        },
+        errorType: AgentRuntimeErrorType.ProviderBizError,
+        status: 400,
+      }),
+    ).toBe(true);
+  });
+
   it('returns true for provider content_filter moderation errors', () => {
     // ROOT CAUSE:
     //

--- a/packages/model-runtime/src/utils/isNonRetryableRequestError.ts
+++ b/packages/model-runtime/src/utils/isNonRetryableRequestError.ts
@@ -72,6 +72,7 @@ const NON_RETRYABLE_MESSAGE_PATTERNS = [
   'messages with role',
   'missing required parameter',
   'prompt is too long',
+  'request body too large',
   'request too large for model',
   'response_format',
   'schema validation error',

--- a/packages/model-runtime/src/utils/resolveSafeMaxTokens.test.ts
+++ b/packages/model-runtime/src/utils/resolveSafeMaxTokens.test.ts
@@ -209,6 +209,33 @@ describe('assertContextWithinWindow', () => {
     ).toThrow(ContextExceededPreFlightError);
   });
 
+  it('does not count base64 image data as text tokens', () => {
+    const base64Data = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'.repeat(
+      2000,
+    );
+
+    expect(() =>
+      assertContextWithinWindow(
+        {
+          messages: [
+            {
+              content: [
+                { text: 'Describe this image', type: 'text' },
+                {
+                  image_url: { url: `data:image/png;base64,${base64Data}` },
+                  type: 'image_url',
+                },
+              ],
+              role: 'user',
+            },
+          ],
+          model: 'vision-model',
+        } as any,
+        [baseModel({ contextWindowTokens: 2000, id: 'vision-model' })],
+      ),
+    ).not.toThrow();
+  });
+
   it('attaches structured payload via toPayload', () => {
     const longContent = 'a'.repeat(20_000);
     try {

--- a/packages/model-runtime/src/utils/resolveSafeMaxTokens.ts
+++ b/packages/model-runtime/src/utils/resolveSafeMaxTokens.ts
@@ -1,6 +1,6 @@
-import { type AiFullModelCard } from 'model-bank';
-import { estimateTokenCount } from 'tokenx';
+import type { AiFullModelCard } from 'model-bank';
 
+import { estimateOpenAIChatInputTokens } from '../core/usageConverters';
 import type { ChatStreamPayload } from '../types/chat';
 
 /**
@@ -91,9 +91,7 @@ export class ContextExceededPreFlightError extends Error {
 
 const estimatePayloadInputTokens = (payload: Pick<ChatStreamPayload, 'messages' | 'tools'>) => {
   const { messages = [], tools } = payload;
-  const messagesText = JSON.stringify(messages);
-  const toolsText = tools && tools.length > 0 ? JSON.stringify(tools) : '';
-  return estimateTokenCount(messagesText) + (toolsText ? estimateTokenCount(toolsText) : 0);
+  return estimateOpenAIChatInputTokens(messages, { tools }).totalTokens;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Add OpenAI model context preflight so oversized prompts fail before sending the provider request.
- Classify free-plan context-limit messages as `ExceededContextWindow`.
- Treat provider "request body too large" errors as non-retryable request errors.

## Why

LOBE-11569 tracks residual context-window and request-too-large failures from gateway snapshots. These cases should produce clearer context-limit handling instead of retrying as operational failures.

Fixes LOBE-11569

## Validation

- `bun run check packages/model-runtime/src/errors/classifier.test.ts packages/model-runtime/src/errors/match.test.ts packages/model-runtime/src/errors/patterns.ts packages/model-runtime/src/providers/openai/index.test.ts packages/model-runtime/src/providers/openai/index.ts packages/model-runtime/src/utils/isNonRetryableRequestError.test.ts packages/model-runtime/src/utils/isNonRetryableRequestError.ts --lint --test --type`
