### PR TITLE
🐛 fix: prevent ChatInput warning collapsing actions

### DIFF
--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -324,3 +324,47 @@ attach the static shot of the asserted state as the primary evidence. If the
 expected-failure terminal state is worth showing, say so explicitly in the
 case's `observation` ("ends in the error page because the test session id is
 fake — expected, not the assertion") so the viewer is told before they see it.
+
+---
+
+## Case 14 — Verifying only the entry compose surface when a shared component also appears in deeper pages
+
+**Wrong approach**: after changing a shared chat input component, publishing a
+passing UI report from the home compose surface only, even though the same
+component also renders after entering an agent/conversation page.
+
+**Why it's wrong**: shared components can be composed with different wrappers,
+slots, and responsive containers across surfaces. A fix that looks correct on the
+home input can still be misplaced on an inner conversation page.
+
+**What it breaks**: the verify report goes green while a deeper product path
+still shows the old or awkward warning placement, and the user has to point out
+that the page after entry was never checked.
+
+**Correct approach**: enumerate all product surfaces where the changed shared UI
+renders before publishing. For ChatInput placement changes, verify both the home
+input and an inner agent/conversation page, attach separate screenshot evidence
+for each, and mark any skipped surface explicitly blocked or untested.
+
+---
+
+## Case 15 — Verifying action-bar placement without covering collapsed toolbar state
+
+**Wrong approach**: after moving a warning into a chat input action bar, checking
+only the normal expanded toolbar state and publishing the layout as passed,
+without forcing the toolbar into its persisted collapsed / auto-collapsed state.
+
+**Why it's wrong**: action bars often have their own overflow behavior and saved
+user preference. Adding a warning beside the toolbar can shrink the measured
+available width enough to trigger a popup collapse, or a previously saved
+collapsed preference can hide the exact action the change is supposed to sit
+beside.
+
+**What it breaks**: the screenshot can look acceptable for a fresh profile while
+real users who have collapsed the toolbar, or narrower input containers, see the
+primary left action replaced by a chevron/popup icon.
+
+**Correct approach**: for any UI change inside an action/toolbar row, verify both
+the default state and the collapsed/overflow state. If the design requires a
+specific action to stay visible, disable or bypass the toolbar collapse logic for
+that surface and include evidence that no collapse chevron is rendered.

--- a/src/features/ChatInput/ActionBar/index.tsx
+++ b/src/features/ChatInput/ActionBar/index.tsx
@@ -7,14 +7,27 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 import { useUserStore } from '@/store/user';
 import { labPreferSelectors } from '@/store/user/slices/preference/selectors';
 
-import { type ActionKeys } from '../ActionBar/config';
+import { type ActionKey, type ActionKeys } from '../ActionBar/config';
 import { actionMap } from '../ActionBar/config';
 import { useChatInputStore } from '../store';
 import { type DropdownPlacement } from './context';
 import { ActionBarContext } from './context';
 
-const mapActionsToItems = (keys: ActionKeys[]): ChatInputActionsProps['items'] =>
-  keys.map((actionKey, index) => {
+const mapActionToItem = (actionKey: ActionKey) => {
+  const Render = actionMap[actionKey];
+
+  return {
+    alwaysDisplay: actionKey === 'contextWindow',
+    children: <Render key={actionKey} />,
+    key: actionKey,
+  };
+};
+
+const mapActionsToItems = (
+  keys: ActionKeys[],
+  { disableCollapse = false }: { disableCollapse?: boolean } = {},
+): ChatInputActionsProps['items'] =>
+  keys.flatMap((actionKey, index) => {
     if (typeof actionKey === 'string') {
       if (actionKey === '---') {
         return {
@@ -22,35 +35,28 @@ const mapActionsToItems = (keys: ActionKeys[]): ChatInputActionsProps['items'] =
           type: 'divider',
         };
       }
-      const Render = actionMap[actionKey];
-      return {
-        alwaysDisplay: actionKey === 'contextWindow',
-        children: <Render key={actionKey} />,
-        key: actionKey,
-      };
-    } else {
-      return {
-        children: actionKey.map((groupActionKey) => {
-          const Render = actionMap[groupActionKey];
-          return {
-            children: <Render key={groupActionKey} />,
-            key: groupActionKey,
-          };
-        }),
-        key: `group-${index}`,
-        type: 'collapse',
-      };
+
+      return mapActionToItem(actionKey);
     }
+
+    if (disableCollapse) return actionKey.map(mapActionToItem);
+
+    return {
+      children: actionKey.map((groupActionKey) => mapActionToItem(groupActionKey)),
+      key: `group-${index}`,
+      type: 'collapse',
+    };
   });
 
 export interface ActionToolbarProps {
   borderRadius?: number;
+  disableCollapse?: boolean;
   dropdownPlacement?: DropdownPlacement;
   extraActionItems?: ChatInputActionsProps['items'];
 }
 
 const ActionToolbar = memo<ActionToolbarProps>(
-  ({ borderRadius, dropdownPlacement, extraActionItems = [] }) => {
+  ({ borderRadius, disableCollapse = false, dropdownPlacement, extraActionItems = [] }) => {
     const [expandInputActionbar, toggleExpandInputActionbar] = useGlobalStore((s) => [
       systemStatusSelectors.expandInputActionbar(s),
       s.toggleExpandInputActionbar,
@@ -64,8 +70,8 @@ const ActionToolbar = memo<ActionToolbarProps>(
     const mobile = useChatInputStore((s) => s.mobile);
 
     const items = useMemo(
-      () => (mapActionsToItems(leftActions) ?? []).concat(extraActionItems),
-      [extraActionItems, leftActions],
+      () => (mapActionsToItems(leftActions, { disableCollapse }) ?? []).concat(extraActionItems),
+      [disableCollapse, extraActionItems, leftActions],
     );
 
     const contextValue = useMemo(
@@ -76,14 +82,19 @@ const ActionToolbar = memo<ActionToolbarProps>(
     return (
       <ActionBarContext value={contextValue}>
         <ChatInputActions
+          autoCollapse={!disableCollapse}
           collapseOffset={mobile ? 48 : 80}
-          defaultGroupCollapse={true}
-          groupCollapse={!expandInputActionbar}
+          defaultGroupCollapse={!disableCollapse}
+          groupCollapse={disableCollapse ? false : !expandInputActionbar}
           items={items}
           style={{ paddingLeft: 6 }}
-          onGroupCollapseChange={(v) => {
-            toggleExpandInputActionbar(!v);
-          }}
+          onGroupCollapseChange={
+            disableCollapse
+              ? undefined
+              : (v) => {
+                  toggleExpandInputActionbar(!v);
+                }
+          }
         />
       </ActionBarContext>
     );

--- a/src/features/ChatInput/ChatInputNotice/index.tsx
+++ b/src/features/ChatInput/ChatInputNotice/index.tsx
@@ -7,18 +7,41 @@ import { useTranslation } from 'react-i18next';
 
 import { useChatInputNotice } from './useChatInputNotice';
 
-const styles = createStaticStyles(({ css }) => ({
+const styles = createStaticStyles(({ css, cssVar }) => ({
   alert: css`
     /* Keep the icon centered against the single-line title. */
     align-items: center !important;
 
+    flex: 0 1 auto;
+
+    min-width: 0;
+    max-width: min(560px, 52vw);
+    padding-block: 4px !important;
+    padding-inline: 8px 10px !important;
+    border-radius: ${cssVar.borderRadius};
+
+    .ant-alert-content {
+      min-width: 0;
+    }
+
+    .ant-alert-message,
     .ant-alert-title {
+      overflow: hidden;
+
       font-size: 12px;
       line-height: 18px !important;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     .ant-alert-icon {
+      flex: none;
       height: 18px !important;
+      margin-inline-end: 6px !important;
+    }
+
+    @media (max-width: 768px) {
+      max-width: 100%;
     }
   `,
 }));

--- a/src/features/ChatInput/Desktop/index.tsx
+++ b/src/features/ChatInput/Desktop/index.tsx
@@ -59,6 +59,19 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     border: none;
     border-radius: 0 !important;
   `,
+  leftActions: css`
+    flex: none;
+    min-width: 0;
+
+    > * {
+      flex: none !important;
+    }
+  `,
+  leftSlot: css`
+    overflow: hidden;
+    flex: 1;
+    min-width: 0;
+  `,
 }));
 
 interface DesktopChatInputProps extends ActionToolbarProps {
@@ -169,6 +182,27 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
         style={{ height: 32, minWidth: 64, width: 64 }}
       />
     ) : null;
+    const noticeNode = !isConfigLoading && <ChatInputNotice />;
+    const leftSlotContent = (
+      <Flexbox horizontal align={'center'} className={styles.leftActions}>
+        {leftContent ?? (
+          <ActionBar
+            disableCollapse
+            borderRadius={borderRadius}
+            dropdownPlacement={dropdownPlacement}
+            extraActionItems={extraActionItems}
+          />
+        )}
+      </Flexbox>
+    );
+    const leftSlot = noticeNode ? (
+      <Flexbox horizontal align={'center'} className={styles.leftSlot} gap={4}>
+        {leftSlotContent}
+        {noticeNode}
+      </Flexbox>
+    ) : (
+      leftSlotContent
+    );
 
     const content = (
       <Flexbox
@@ -179,7 +213,6 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
         onDragOver={handleDragOver}
         onDrop={handleDrop}
       >
-        {!isConfigLoading && <ChatInputNotice />}
         <ChatInput
           data-testid="chat-input"
           defaultHeight={chatInputHeight || 32}
@@ -191,17 +224,8 @@ const DesktopChatInput = memo<DesktopChatInputProps>(
           footer={
             compact ? undefined : (
               <ChatInputActionBar
+                left={loadingLeftSlot ?? leftSlot}
                 style={actionBarStyle ?? { paddingRight: 8 }}
-                left={
-                  loadingLeftSlot ??
-                  leftContent ?? (
-                    <ActionBar
-                      borderRadius={borderRadius}
-                      dropdownPlacement={dropdownPlacement}
-                      extraActionItems={extraActionItems}
-                    />
-                  )
-                }
                 right={
                   loadingRightSlot ??
                   rightContent ??

--- a/src/features/ChatInput/Mobile/index.tsx
+++ b/src/features/ChatInput/Mobile/index.tsx
@@ -28,6 +28,19 @@ const styles = createStaticStyles(({ css }) => ({
 
     background: ${cssVar.colorBgLayout};
   `,
+  leftActions: css`
+    flex: none;
+    min-width: 0;
+
+    > * {
+      flex: none !important;
+    }
+  `,
+  leftSlot: css`
+    overflow: hidden;
+    flex: 1;
+    min-width: 0;
+  `,
 }));
 
 const DesktopChatInput = memo(() => {
@@ -45,10 +58,8 @@ const DesktopChatInput = memo(() => {
         paddingBlock={'0 12px'}
         paddingInline={12}
       >
-        <ChatInputNotice />
         <ChatInput
           fullscreen={expand}
-          header={<ChatInputActionBar left={<ActionBar />} />}
           slashMenuRef={slashMenuRef}
           footer={
             <ChatInputActionBar
@@ -57,6 +68,18 @@ const DesktopChatInput = memo(() => {
               style={{
                 paddingRight: 8,
               }}
+            />
+          }
+          header={
+            <ChatInputActionBar
+              left={
+                <Flexbox horizontal align={'center'} className={styles.leftSlot} gap={4}>
+                  <Flexbox horizontal align={'center'} className={styles.leftActions}>
+                    <ActionBar disableCollapse />
+                  </Flexbox>
+                  <ChatInputNotice />
+                </Flexbox>
+              }
             />
           }
         >


### PR DESCRIPTION
## Summary

- Move the model-unavailable warning into the ChatInput action row so it sits after the left-side tools instead of floating above the editor.
- Add `disableCollapse` to the ChatInput `ActionBar` so the warning does not cause `+` / left actions to collapse into a chevron popup.
- Apply the non-collapsing action row to desktop and mobile ChatInput surfaces.
- Apply truncation to Ant Alert's actual `.ant-alert-message` node so long warning copy stays one-line in narrow inputs.
- Record agent-testing lessons for inner-page coverage and collapsed-toolbar state coverage.

## Root Cause

The warning was placed beside `ChatInputActions`, but the editor action component still had two collapse paths enabled: width-based `autoCollapse` and group-level collapse. In narrow conversation inputs, or when a collapsed actionbar state was present, the primary left action could be replaced by an up-chevron before the warning.

This PR intentionally disables collapse for the ChatInput left action row in this warning placement so the left-side entry stays stable next to the warning.

## Validation

- `bunx eslint src/features/ChatInput/ActionBar/index.tsx src/features/ChatInput/ChatInputNotice/index.tsx src/features/ChatInput/Desktop/index.tsx src/features/ChatInput/Mobile/index.tsx`
- `bun run check src/features/ChatInput/ActionBar/index.tsx src/features/ChatInput/ChatInputNotice/index.tsx src/features/ChatInput/Desktop/index.tsx src/features/ChatInput/Mobile/index.tsx --test`
- `git diff --check`
- Visual Verify report: https://app.lobehub.com/verify/dcedd2e1-7055-4e37-91ae-5a7ab23a4af4

Notes:
- `bun run check ... --lint` is still blocked locally by missing `stylelint-config-standard`; direct ESLint passed.
- `bun run check ... --type` was previously blocked by unrelated workspace/local dependency issues and was not used as a signal for this UI-only change.
