### PR TITLE
[codex] Polish verify preview and topic metadata UI

### DIFF
--- a/locales/en-US/topic.json
+++ b/locales/en-US/topic.json
@@ -151,7 +151,6 @@
   "management.title": "Topics",
   "management.view.card": "Card",
   "management.view.list": "List",
-  "metaCard.branchNote": "The chat branch reflects the active branch from your last session; sending a message updates it.",
   "metaCard.ci.failure": "CI failed",
   "metaCard.ci.none": "No CI checks",
   "metaCard.ci.pending": "CI running",

--- a/locales/zh-CN/topic.json
+++ b/locales/zh-CN/topic.json
@@ -151,7 +151,6 @@
   "management.title": "话题",
   "management.view.card": "卡片",
   "management.view.list": "列表",
-  "metaCard.branchNote": "聊天分支反映上次使用时的活动分支；发送消息将更新聊天分支",
   "metaCard.ci.failure": "CI 未通过",
   "metaCard.ci.none": "无 CI 检查",
   "metaCard.ci.pending": "CI 进行中",

--- a/packages/locales/src/default/topic.ts
+++ b/packages/locales/src/default/topic.ts
@@ -31,8 +31,6 @@ export default {
   'duplicateSuccess': 'Topic Copied Successfully',
   'failedStatusTip': 'This run hit an error — open it to take a look.',
   'favorite': 'Favorite',
-  'metaCard.branchNote':
-    'The chat branch reflects the active branch from your last session; sending a message updates it.',
   'metaCard.ci.failure': 'CI failed',
   'metaCard.ci.none': 'No CI checks',
   'metaCard.ci.pending': 'CI running',

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -11,6 +11,7 @@ import { toRecord } from '@lobechat/utils/object';
 import {
   Block,
   Center,
+  Drawer,
   Empty,
   Flexbox,
   Highlighter,
@@ -19,7 +20,7 @@ import {
   Markdown,
   Text,
 } from '@lobehub/ui';
-import { Button, Modal } from '@lobehub/ui/base-ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import type { TFunction } from 'i18next';
 import {
@@ -1230,31 +1231,50 @@ const EvidenceFileButton = memo<{
 
 EvidenceFileButton.displayName = 'EvidenceFileButton';
 
-/** Modal gallery of one check's evidence — one section per artifact, by type. */
-const EvidenceModal = memo<{
+/** Right-side evidence gallery — one section per artifact, by type. */
+const EvidenceDrawer = memo<{
   evidence: VerifyEvidenceWithUrl[];
   onClose: () => void;
   open: boolean;
   title: string;
 }>(({ evidence, onClose, open, title }) => (
-  <Modal
-    footer={null}
+  <Drawer
+    destroyOnHidden
+    containerMaxWidth={'100%'}
     open={open}
+    placement={'right'}
     title={title}
-    width={'min(760px, 92vw)'}
-    onCancel={() => onClose()}
+    width={'min(1120px, calc(100vw - 48px))'}
+    styles={{
+      body: {
+        height: '100%',
+        padding: 0,
+      },
+      bodyContent: {
+        height: '100%',
+        minHeight: 0,
+        overflow: 'hidden',
+      },
+    }}
+    onClose={onClose}
   >
-    <Flexbox gap={20} style={{ maxHeight: '68vh', overflow: 'auto', paddingBlock: 4 }}>
+    <Flexbox
+      gap={20}
+      height={'100%'}
+      paddingBlock={12}
+      paddingInline={16}
+      style={{ overflow: 'auto' }}
+    >
       {evidence.map((e, index) => (
         <EvidenceItem evidence={e} index={index + 1} key={e.id} />
       ))}
     </Flexbox>
-  </Modal>
+  </Drawer>
 ));
 
 EvidenceItem.displayName = 'EvidenceItem';
 
-EvidenceModal.displayName = 'EvidenceModal';
+EvidenceDrawer.displayName = 'EvidenceDrawer';
 
 /** One check — an expandable row; evidence opens one artifact at a time. */
 const CheckRow = memo<{ defaultOpen: boolean; result: VerifyResultWithEvidence }>(
@@ -1337,7 +1357,7 @@ const CheckRow = memo<{ defaultOpen: boolean; result: VerifyResultWithEvidence }
                   )}
                 </div>
                 {selectedEvidence && (
-                  <EvidenceModal
+                  <EvidenceDrawer
                     evidence={[selectedEvidence]}
                     open={Boolean(selectedEvidence)}
                     title={evidenceDisplayName(selectedEvidence, t, selectedEvidenceIndex + 1)}

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { ChatTopicMetadata } from '@lobechat/types';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import MetaHoverCard from './MetaHoverCard';
+
+vi.mock('@lobehub/ui', () => ({
+  Icon: () => <span data-testid="meta-card-icon" />,
+}));
+
+vi.mock('antd-style', () => ({
+  createStaticStyles: () => ({
+    card: 'card',
+    header: 'header',
+    headerTime: 'headerTime',
+    headerTitle: 'headerTitle',
+    prLink: 'prLink',
+    row: 'row',
+    rowIcon: 'rowIcon',
+    rowText: 'rowText',
+  }),
+  cssVar: {
+    colorError: '#f00',
+    colorSuccess: '#0f0',
+    colorTextTertiary: '#999',
+    colorWarning: '#fa0',
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, string>) =>
+      values?.sha ? `${key}:${values.sha}` : key,
+  }),
+}));
+
+vi.mock('@/const/version', () => ({ isDesktop: false }));
+
+vi.mock('@/features/ChatInput/ControlBar/DirIcon', () => ({
+  default: ({ size }: { size?: number }) => <span data-size={size} data-testid="dir-icon" />,
+}));
+
+describe('MetaHoverCard', () => {
+  it('shows persisted git context without the branch explanation note', () => {
+    const metadata: ChatTopicMetadata = {
+      workingDirectory: '/repo-fix',
+      workingDirectoryConfig: {
+        git: { activeWorktree: '/repo-fix', branch: 'fix', isWorktree: true },
+        path: '/repo',
+        repoType: 'git',
+      },
+    };
+
+    render(<MetaHoverCard metadata={metadata} time={<span>00:33</span>} title="Topic" />);
+
+    expect(screen.getByText('Topic')).toBeInTheDocument();
+    expect(screen.getByText('00:33')).toBeInTheDocument();
+    expect(screen.getByText('repo')).toBeInTheDocument();
+    expect(screen.getByText('fix')).toBeInTheDocument();
+    expect(screen.getByText('repo-fix')).toBeInTheDocument();
+    expect(screen.queryByText('metaCard.branchNote')).not.toBeInTheDocument();
+  });
+});

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.tsx
@@ -3,7 +3,6 @@ import { Icon } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import type { Clock } from 'lucide-react';
 import {
-  CircleAlert,
   CircleCheck,
   CircleSlash,
   CircleX,
@@ -69,20 +68,6 @@ const styles = createStaticStyles(({ css }) => ({
     min-width: 0;
     text-overflow: ellipsis;
     white-space: nowrap;
-  `,
-  warnRow: css`
-    align-items: flex-start;
-    color: ${cssVar.colorWarning};
-  `,
-  warnIcon: css`
-    flex: none;
-    margin-block-start: 1px;
-    color: ${cssVar.colorWarning};
-  `,
-  warnText: css`
-    min-width: 0;
-    line-height: 18px;
-    white-space: normal;
   `,
   prLink: css`
     cursor: pointer;
@@ -193,11 +178,6 @@ const MetaHoverCard = memo<MetaHoverCardProps>(({ metadata, title, time }) => {
           {worktreeName}
         </DetailRow>
       )}
-
-      <div className={`${styles.row} ${styles.warnRow}`}>
-        <Icon className={styles.warnIcon} icon={CircleAlert} size={15} />
-        <span className={styles.warnText}>{t('metaCard.branchNote')}</span>
-      </div>
 
       {pullRequest &&
         (() => {


### PR DESCRIPTION
## Summary

- Replace the Verify report evidence file preview modal with a right-side Drawer and a larger full-height scrollable preview area.
- Remove the redundant branch explanation warning row from the topic meta hover card.
- Add a focused component test for the topic meta hover card and clean the default/en-US/zh-CN topic locale key.

## Validation

- `bun run check src/features/Verify/ReportViewer.tsx src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.tsx src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.test.tsx packages/locales/src/default/topic.ts locales/en-US/topic.json locales/zh-CN/topic.json --lint --test`
