### PR TITLE
♻️ refactor: Split worktree and branch controls

### DIFF
--- a/src/features/ChatInput/ControlBar/GitStatus.tsx
+++ b/src/features/ChatInput/ControlBar/GitStatus.tsx
@@ -1,7 +1,7 @@
 import { Icon, Tooltip } from '@lobehub/ui';
 import { toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
-import { ArrowDownIcon, ArrowUpIcon, GitBranchIcon, GitPullRequest } from 'lucide-react';
+import { ArrowDownIcon, ArrowUpIcon, GitPullRequest } from 'lucide-react';
 import { memo, useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -308,14 +308,13 @@ const GitStatus = memo<GitStatusProps>(({ agentId, path, sourcePath, isGithub, d
 
   const branchTrigger = (
     <div className={styles.trigger}>
-      <Icon icon={GitBranchIcon} size={12} />
       <span className={styles.branchLabel}>{branch}</span>
     </div>
   );
 
-  const hasMultipleWorktrees = worktrees.length > 1;
+  const hasWorktreeMenu = worktrees.length > 0;
 
-  const branchNode = hasMultipleWorktrees ? (
+  const worktreeNode = hasWorktreeMenu ? (
     <WorktreeSwitcher
       agentId={agentId}
       currentBranch={branch}
@@ -327,7 +326,9 @@ const GitStatus = memo<GitStatusProps>(({ agentId, path, sourcePath, isGithub, d
       worktrees={worktrees}
       onWorktreesChange={mutateWorktrees}
     />
-  ) : detached ? (
+  ) : null;
+
+  const branchNode = detached ? (
     // Detached HEAD → plain branch label (nothing to switch to).
     <Tooltip title={branchTooltip}>{branchTrigger}</Tooltip>
   ) : (
@@ -423,6 +424,7 @@ const GitStatus = memo<GitStatusProps>(({ agentId, path, sourcePath, isGithub, d
   return (
     <>
       <div className={styles.separator} />
+      {worktreeNode}
       {branchNode}
       {pullNode}
       {pushNode}

--- a/src/features/ChatInput/ControlBar/WorktreeSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/WorktreeSwitcher.tsx
@@ -18,6 +18,7 @@ import { createStaticStyles, cssVar, cx } from 'antd-style';
 import {
   CheckIcon,
   FolderPlusIcon,
+  GitBranchIcon,
   GitForkIcon,
   LoaderCircleIcon,
   RefreshCwIcon,
@@ -59,16 +60,6 @@ const styles = createStaticStyles(({ css }) => ({
     text-overflow: ellipsis;
     white-space: nowrap;
   `,
-  branchInline: css`
-    overflow: hidden;
-
-    min-width: 28px;
-    max-width: 220px;
-
-    color: ${cssVar.colorText};
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  `,
   check: css`
     display: flex;
     flex: none;
@@ -97,18 +88,6 @@ const styles = createStaticStyles(({ css }) => ({
 
     /* Cancel DropdownMenuPopup's default 4px padding so our sections align edge-to-edge */
     margin: -4px;
-  `,
-  count: css`
-    flex: none;
-
-    padding-inline: 5px;
-    border-radius: 999px;
-
-    font-size: 11px;
-    line-height: 16px;
-    color: ${cssVar.colorTextTertiary};
-
-    background: ${cssVar.colorFillSecondary};
   `,
   diffStat: css`
     display: inline-flex;
@@ -324,12 +303,11 @@ const styles = createStaticStyles(({ css }) => ({
 
     display: inline-flex;
     flex: none;
-    gap: 5px;
     align-items: center;
+    justify-content: center;
 
-    max-width: 420px;
-    padding-block: 2px;
-    padding-inline: 4px;
+    width: 24px;
+    height: 22px;
     border-radius: 4px;
 
     font-size: 12px;
@@ -345,12 +323,6 @@ const styles = createStaticStyles(({ css }) => ({
   triggerAnchor: css`
     display: inline-flex;
     flex: none;
-  `,
-  worktreeName: css`
-    overflow: hidden;
-    max-width: 140px;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   `,
 }));
 
@@ -473,7 +445,7 @@ const WorktreeSwitcher = memo<WorktreeSwitcherProps>(
     // slow (up to a 30s timeout + device round-trip), so removal runs detached
     // from the confirm dialog — this tracks in-flight rows to guard against a
     // duplicate delete if the dropdown is reopened mid-removal.
-    const [removingPaths, setRemovingPaths] = useState<Set<string>>(new Set());
+    const [removingPaths, setRemovingPaths] = useState<Set<string>>(() => new Set());
     const currentRowRef = useRef<HTMLDivElement>(null);
     const { commit } = useCommitWorkingDirectory(agentId);
 
@@ -637,13 +609,16 @@ const WorktreeSwitcher = memo<WorktreeSwitcherProps>(
     const triggerTitle = detached
       ? t('workingDirectory.detachedHead', { sha: currentBranch })
       : `${currentName} · ${branchLabel}`;
+    const isSourceWorktree = normalizeDisplayPath(currentPath) === normalizeDisplayPath(sourcePath);
+    const triggerIcon = isSourceWorktree ? GitBranchIcon : GitForkIcon;
 
     const trigger = (
-      <div className={styles.trigger}>
-        <Icon icon={GitForkIcon} size={12} />
-        <span className={styles.worktreeName}>{currentName}</span>
-        <span className={styles.branchInline}>{branchLabel}</span>
-        <span className={styles.count}>{worktrees.length}</span>
+      <div
+        aria-label={t('workingDirectory.worktreesHeading')}
+        className={styles.trigger}
+        role="button"
+      >
+        <Icon icon={triggerIcon} size={13} />
       </div>
     );
 

--- a/src/features/ChatInput/ControlBar/__tests__/GitStatus.test.tsx
+++ b/src/features/ChatInput/ControlBar/__tests__/GitStatus.test.tsx
@@ -179,4 +179,19 @@ describe('GitStatus', () => {
       expect(screen.getByText('#123')).toBeInTheDocument();
     });
   });
+
+  it('keeps branch switching visible when worktrees are available', () => {
+    gitHookMocks.useFetchGitWorktrees.mockReturnValue({
+      data: [
+        { branch: 'fix/remote-review', current: true, path: '/repo' },
+        { branch: 'canary', current: false, path: '/repo-canary' },
+      ],
+      mutate: gitHookMocks.mutateWorktrees,
+    });
+
+    render(<GitStatus isGithub agentId="agent-1" path="/repo" sourcePath="/repo" />);
+
+    expect(screen.getByTestId('worktree-switcher')).toBeInTheDocument();
+    expect(screen.getByText('fix/remote-review')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

- Split the bottom Git control into a dedicated worktree/main switcher and an independent branch switcher.
- Make `WorktreeSwitcher` render as an icon-only working-copy control, using a branch icon for the source worktree and a fork icon for linked worktrees.
- Keep branch checkout available even when multiple worktrees exist.

## Impact

This keeps the source selector, worktree/main selector, and branch selector semantically separate while preserving the compact bottom-bar layout.

## Verification

- `bun run check src/features/ChatInput/ControlBar/GitStatus.tsx src/features/ChatInput/ControlBar/WorktreeSwitcher.tsx src/features/ChatInput/ControlBar/__tests__/GitStatus.test.tsx src/features/ChatInput/ControlBar/__tests__/WorktreeSwitcher.test.tsx --lint --test`
- Agent-testing report: https://app.lobehub.com/verify/82724b24-f8c1-48bb-8d3c-dfbf3fec0b3e

Note: the agent-testing report is partial because the isolated Electron dev instance reached Renderer ready but then dropped CDP before visual screenshot capture; the Web Debug Proxy could open the local SPA but did not expose the local-device working-directory context needed for this Git control.
