### PR TITLE
🐛 fix: pass streamed report text as gateway completion notification body

### DIFF
--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
@@ -302,6 +302,65 @@ describe('createGatewayEventHandler', () => {
     );
   });
 
+  it('prefers the terminal snapshot final assistant text over the streamed accumulator', async () => {
+    vi.spyOn(messageService, 'getMessages').mockResolvedValue([] as unknown as UIChatMessage[]);
+    const lifecycle = createLifecycle();
+    const store = createStore();
+    const handler = createGatewayEventHandler(() => store, {
+      assistantMessageId: 'answer-msg',
+      context,
+      operationId: 'op-1',
+      runLifecycle: lifecycle as any,
+      runtimeType: 'gateway',
+    });
+
+    // The stream dropped the tail; the server-finalized snapshot has the whole
+    // report, and the chat is reconciled to it — so must the notification be.
+    handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'The final rep' }));
+    handler(
+      makeEvent('agent_runtime_end', {
+        reason: 'completed',
+        uiMessages: [
+          { content: 'run it', id: 'user-msg', role: 'user' },
+          { content: 'The final report.', id: 'answer-msg', role: 'assistant' },
+        ] as unknown as UIChatMessage[],
+      }),
+    );
+    await flush();
+
+    expect(lifecycle.afterRunComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ notification: { content: 'The final report.' } }),
+    );
+  });
+
+  it('falls back to the streamed accumulator when the terminal snapshot carries no assistant text', async () => {
+    vi.spyOn(messageService, 'getMessages').mockResolvedValue([] as unknown as UIChatMessage[]);
+    const lifecycle = createLifecycle();
+    const store = createStore();
+    const handler = createGatewayEventHandler(() => store, {
+      assistantMessageId: 'answer-msg',
+      context,
+      operationId: 'op-1',
+      runLifecycle: lifecycle as any,
+      runtimeType: 'gateway',
+    });
+
+    handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'The final report.' }));
+    handler(
+      makeEvent('agent_runtime_end', {
+        reason: 'completed',
+        uiMessages: [
+          { content: '', id: 'answer-msg', role: 'assistant' },
+        ] as unknown as UIChatMessage[],
+      }),
+    );
+    await flush();
+
+    expect(lifecycle.afterRunComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ notification: { content: 'The final report.' } }),
+    );
+  });
+
   it('passes empty notification content when nothing streamed so afterRunComplete can fall back to the store', async () => {
     vi.spyOn(messageService, 'getMessages').mockResolvedValue([] as unknown as UIChatMessage[]);
     const lifecycle = createLifecycle();

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
@@ -263,4 +263,81 @@ describe('createGatewayEventHandler', () => {
       visibleLoadingDone: true,
     });
   });
+
+  // ────────────────────────────────────────────────────
+  // Gateway completion notification body
+  // ────────────────────────────────────────────────────
+
+  const createLifecycle = () => ({
+    afterRunComplete: vi.fn().mockResolvedValue(undefined),
+    completeRun: vi.fn().mockResolvedValue({ requeued: false }),
+  });
+
+  it('passes the streamed report text as the gateway completion notification body', async () => {
+    vi.spyOn(messageService, 'getMessages').mockResolvedValue([] as unknown as UIChatMessage[]);
+    const lifecycle = createLifecycle();
+    const store = createStore();
+    const handler = createGatewayEventHandler(() => store, {
+      assistantMessageId: 'answer-msg',
+      context,
+      operationId: 'op-1',
+      runLifecycle: lifecycle as any,
+      runtimeType: 'gateway',
+    });
+
+    // Stream the report text so `accumulatedContent` (the optimistic in-memory
+    // source) holds it, then end the run with no terminal uiMessages snapshot.
+    handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'The final report.' }));
+    handler(makeEvent('agent_runtime_end', { reason: 'completed' }));
+    await flush();
+
+    expect(lifecycle.completeRun).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'completed' }),
+    );
+    expect(lifecycle.afterRunComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        notification: { content: 'The final report.' },
+        status: 'completed',
+      }),
+    );
+  });
+
+  it('passes empty notification content when nothing streamed so afterRunComplete can fall back to the store', async () => {
+    vi.spyOn(messageService, 'getMessages').mockResolvedValue([] as unknown as UIChatMessage[]);
+    const lifecycle = createLifecycle();
+    const store = createStore();
+    const handler = createGatewayEventHandler(() => store, {
+      assistantMessageId: 'answer-msg',
+      context,
+      operationId: 'op-1',
+      runLifecycle: lifecycle as any,
+      runtimeType: 'gateway',
+    });
+
+    handler(makeEvent('agent_runtime_end', { reason: 'completed' }));
+    await flush();
+
+    expect(lifecycle.afterRunComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ notification: { content: '' } }),
+    );
+  });
+
+  it('does not fire afterRunComplete on a cancelled (non-completed) gateway run', async () => {
+    vi.spyOn(messageService, 'getMessages').mockResolvedValue([] as unknown as UIChatMessage[]);
+    const lifecycle = createLifecycle();
+    const store = createStore();
+    const handler = createGatewayEventHandler(() => store, {
+      assistantMessageId: 'answer-msg',
+      context,
+      operationId: 'op-1',
+      runLifecycle: lifecycle as any,
+      runtimeType: 'gateway',
+    });
+
+    handler(makeEvent('stream_chunk', { chunkType: 'text', content: 'partial' }));
+    handler(makeEvent('agent_runtime_end', { reason: 'interrupted' }));
+    await flush();
+
+    expect(lifecycle.afterRunComplete).not.toHaveBeenCalled();
+  });
 });

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -879,7 +879,21 @@ export const createGatewayEventHandler = (
               status,
             });
             if (!requeued && status === 'completed') {
-              await runLifecycle.afterRunComplete({ ...lifecycleEventBase, status });
+              await runLifecycle.afterRunComplete({
+                ...lifecycleEventBase,
+                // Pass the in-memory streamed report text so the desktop
+                // notification body isn't left on the generic "generation
+                // finished" fallback. The terminal `uiMessages` snapshot (or a
+                // racing DB fetch in `fetchAndReplaceMessages`) may not have the
+                // assistant content committed yet at this instant, so the store
+                // read in `afterRunComplete` would resolve empty and the banner
+                // would show the fallback. `accumulatedContent` is the
+                // optimistic stream (closure, untouched by `replaceMessages`),
+                // so it is the durable source — mirroring the hetero executor,
+                // which passes its `accContent` as `notification.content`.
+                notification: { content: accumulatedContent },
+                status,
+              });
             }
           } else {
             // hetero reuses this handler only for message reconciliation; its

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -826,6 +826,10 @@ export const createGatewayEventHandler = (
           get().internal_toggleToolCallingStreaming(currentAssistantMessageId, undefined);
           endReasoningIfNeeded();
 
+          // The terminal snapshot, when the server pushed one — the reconciled
+          // Source of Truth for this run's final assistant text.
+          let terminalMessages: UIChatMessage[] | undefined;
+
           // Reconcile messages FIRST so the terminal run lifecycle's notification
           // (afterRunComplete) can read the final assistant content from the store.
           //
@@ -834,6 +838,7 @@ export const createGatewayEventHandler = (
           // to a DB refetch only if the snapshot is absent (older server
           // builds, or push-event delivery edge cases).
           if (Array.isArray(data?.uiMessages)) {
+            terminalMessages = data.uiMessages;
             get().replaceMessages(data.uiMessages, {
               action: 'gateway/agent_runtime_end',
               context,
@@ -879,19 +884,26 @@ export const createGatewayEventHandler = (
               status,
             });
             if (!requeued && status === 'completed') {
+              // Notification body, resolved most-authoritative first:
+              //
+              // 1. the terminal snapshot's final assistant text — server-
+              //    finalized, so it wins over the optimistic stream even when
+              //    the two disagree (dropped chunks, server-side rewrites);
+              // 2. `accumulatedContent`, the in-memory stream (a closure
+              //    untouched by `replaceMessages`), for the no-snapshot path
+              //    where `fetchAndReplaceMessages` races the executor's DB
+              //    write and would otherwise leave the body empty. Its stale
+              //    predecessor is NOT read back from that refetch: a not-yet-
+              //    written assistant row would surface the PRIOR turn's reply;
+              // 3. nothing (`''`), letting `afterRunComplete` fall back to its
+              //    store read and then to the generic "generation finished".
+              const finalAssistantContent = terminalMessages?.findLast(
+                (message) => message.role === 'assistant',
+              )?.content;
+
               await runLifecycle.afterRunComplete({
                 ...lifecycleEventBase,
-                // Pass the in-memory streamed report text so the desktop
-                // notification body isn't left on the generic "generation
-                // finished" fallback. The terminal `uiMessages` snapshot (or a
-                // racing DB fetch in `fetchAndReplaceMessages`) may not have the
-                // assistant content committed yet at this instant, so the store
-                // read in `afterRunComplete` would resolve empty and the banner
-                // would show the fallback. `accumulatedContent` is the
-                // optimistic stream (closure, untouched by `replaceMessages`),
-                // so it is the durable source — mirroring the hetero executor,
-                // which passes its `accContent` as `notification.content`.
-                notification: { content: accumulatedContent },
+                notification: { content: finalAssistantContent || accumulatedContent },
                 status,
               });
             }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

None — desktop notification for gateway (native agent runtime) runs showed the generic "generation finished" fallback instead of the report preview.

#### 🔀 Description of Change

When a gateway-runtime run finishes in the background, the desktop notification body fell back to the generic `notification.finishChatGeneration` ("AI 消息已生成完毕") instead of previewing the actual reply.

**Root cause:** the gateway transport's `afterRunComplete` call never supplied `notification.content`, so `buildRunLifecycle.afterRunComplete` resolved the body from the store (`findLast(assistant).content`). At the instant `agent_runtime_end` fires, the terminal `uiMessages` snapshot (or the racing `fetchAndReplaceMessages` DB fetch) often hasn't committed the assistant content yet — so the store read resolves empty and `buildNotificationBody` returns the fallback. The report text *is* rendered in the chat (a later refetch lands it), but the notification already fired with empty content.

The hetero executor avoids this by passing its in-memory `accContent` as `notification.content`.

**Fix:** mirror hetero — pass the gateway handler's in-memory `accumulatedContent` (the optimistic stream, a closure untouched by `replaceMessages`) as `notification.content` at the `agent_runtime_end` call site. When nothing streamed, an empty string is passed and `afterRunComplete` still falls back to its store read, so tool-only / empty answers keep prior behavior.

Files:
- `src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts` — pass `notification: { content: accumulatedContent }`.
- `…/gatewayEventHandler.test.ts` — cover the streamed-text, empty-stream, and cancelled-run cases.

#### 🧪 How to Test

- [x] Added/updated tests
- [ ] Tested locally

New unit tests in `gatewayEventHandler.test.ts`:
- passes the streamed report text as the gateway completion notification body
- passes empty notification content when nothing streamed (lets `afterRunComplete` fall back to the store)
- does not fire `afterRunComplete` on a cancelled (non-completed) gateway run

`bunx vitest run gatewayEventHandler.test.ts` → 8 passed.

Manual repro (desktop, backgrounded window so the OS banner fires): trigger a native gateway agent run, wait for completion — the notification body should now preview the report instead of "AI 消息已生成完毕".

#### 📝 Additional Information

No behavior change for the hetero path (it already passed `notification.content`) or for cancelled/failed/requeued runs (`afterRunComplete` isn't called).