### PR TITLE
✨ feat: add Grok 4.5 reasoning effort extend param

### DIFF
--- a/packages/locales/src/default/modelProvider.ts
+++ b/packages/locales/src/default/modelProvider.ts
@@ -279,6 +279,8 @@ export default {
     'For Grok 4.20 series; controls reasoning intensity. Low/Medium uses 4 agents, High/XHigh uses 16 agents.',
   'providerModels.item.modelConfig.extendParams.options.grok4_3ReasoningEffort.hint':
     'For Grok 4.3 series; controls reasoning intensity.',
+  'providerModels.item.modelConfig.extendParams.options.grok4_5ReasoningEffort.hint':
+    'For Grok 4.5 series; controls reasoning intensity (low/medium/high, default high).',
   'providerModels.item.modelConfig.extendParams.options.hy3ReasoningEffort.hint':
     'For Hy3 models; controls reasoning intensity. no_think (ultra-fast response), low (quick reasoning), and high (deep reasoning)—to accommodate varying latency and depth requirements, from high-frequency interactions to complex engineering tasks.',
   'providerModels.item.modelConfig.extendParams.options.ring2_6ReasoningEffort.hint':

--- a/packages/locales/src/default/models.ts
+++ b/packages/locales/src/default/models.ts
@@ -25,6 +25,8 @@ const lobeHubOnlineModelLocales = {
   'grok-4.20-beta-0309-non-reasoning.description': 'A non-reasoning variant for simple use cases',
   'grok-4.20-beta-0309-reasoning.description':
     'Intelligent, blazing-fast model that reasons before responding',
+  'grok-4.5.description':
+    "SpaceXAI's flagship model for coding, agentic tasks, and knowledge work — configurable reasoning (low/medium/high, always on).",
   'lobehub-glm-5.2-fast.description':
     'Fast variant of GLM-5.2 with substantially lower latency. Same capabilities as GLM-5.2 — costs more, but responds much faster.',
   'seedance-1-5-pro-251215.description':

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -308,6 +308,7 @@ export type ExtendParamsType =
   | 'glm5_2ReasoningEffort'
   | 'grok4_20ReasoningEffort'
   | 'grok4_3ReasoningEffort'
+  | 'grok4_5ReasoningEffort'
   | 'hy3ReasoningEffort'
   | 'ring2_6ReasoningEffort'
   | 'codexMaxReasoningEffort'
@@ -361,6 +362,7 @@ export const ExtendParamsTypeSchema = z.enum([
   'glm5_2ReasoningEffort',
   'grok4_20ReasoningEffort',
   'grok4_3ReasoningEffort',
+  'grok4_5ReasoningEffort',
   'hy3ReasoningEffort',
   'ring2_6ReasoningEffort',
   'codexMaxReasoningEffort',

--- a/packages/model-runtime/src/utils/modelExtendParams.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.ts
@@ -235,6 +235,10 @@ export const applyModelExtendParams = (ctx: ApplyModelExtendParamsContext): Mode
     extendParams.reasoning_effort = chatConfig.grok4_3ReasoningEffort;
   }
 
+  if (modelExtendParams.includes('grok4_5ReasoningEffort') && chatConfig.grok4_5ReasoningEffort) {
+    extendParams.reasoning_effort = chatConfig.grok4_5ReasoningEffort;
+  }
+
   if (modelExtendParams.includes('hy3ReasoningEffort') && chatConfig.hy3ReasoningEffort) {
     extendParams.reasoning_effort = chatConfig.hy3ReasoningEffort;
   }

--- a/packages/types/src/agent/chatConfig.ts
+++ b/packages/types/src/agent/chatConfig.ts
@@ -92,6 +92,7 @@ export interface LobeAgentChatConfig extends AgentMemoryChatConfig, AgentSelfIte
   gpt5_2ReasoningEffort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh';
   gpt5ReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
   grok4_3ReasoningEffort?: 'none' | 'low' | 'medium' | 'high';
+  grok4_5ReasoningEffort?: 'low' | 'medium' | 'high';
   grok4_20ReasoningEffort?: 'low' | 'medium' | 'high' | 'xhigh';
   /**
    * Number of historical messages
@@ -242,6 +243,7 @@ export const AgentChatConfigSchema = z
     glm5_2ReasoningEffort: z.enum(['high', 'max']).optional(),
     grok4_20ReasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh']).optional(),
     grok4_3ReasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
+    grok4_5ReasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
     hy3ReasoningEffort: z.enum(['no_think', 'low', 'high']).optional(),
     ring2_6ReasoningEffort: z.enum(['high', 'xhigh']).optional(),
     historyCount: z.number().optional(),

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
@@ -26,6 +26,7 @@ import GPT51ReasoningEffortSlider from './GPT51ReasoningEffortSlider';
 import GPT52ProReasoningEffortSlider from './GPT52ProReasoningEffortSlider';
 import GPT52ReasoningEffortSlider from './GPT52ReasoningEffortSlider';
 import Grok43ReasoningEffortSlider from './Grok43ReasoningEffortSlider';
+import Grok45ReasoningEffortSlider from './Grok45ReasoningEffortSlider';
 import Grok420ReasoningEffortSlider from './Grok420ReasoningEffortSlider';
 import Hy3ReasoningEffortSlider from './Hy3ReasoningEffortSlider';
 import ImageAspectRatio2Select from './ImageAspectRatio2Select';
@@ -341,6 +342,17 @@ const ControlsForm = memo<ControlsFormProps>(
         layout: 'vertical',
         minWidth: undefined,
         name: 'grok4_3ReasoningEffort',
+        style: {
+          paddingBottom: 0,
+        },
+      },
+      {
+        children: <Grok45ReasoningEffortSlider />,
+        desc: 'reasoning_effort',
+        label: t('extendParams.reasoningEffort.title'),
+        layout: 'vertical',
+        minWidth: undefined,
+        name: 'grok4_5ReasoningEffort',
         style: {
           paddingBottom: 0,
         },

--- a/src/features/ModelSwitchPanel/components/ControlsForm/Grok45ReasoningEffortSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/Grok45ReasoningEffortSlider.tsx
@@ -1,0 +1,17 @@
+import { type CreatedLevelSliderProps } from './createLevelSlider';
+import { createLevelSliderComponent } from './createLevelSlider';
+
+// Grok 4.5 reasoning is always on: low/medium/high (no 'none'), default high.
+const GROK4_5_REASONING_EFFORT_LEVELS = ['low', 'medium', 'high'] as const;
+type Grok45ReasoningEffort = (typeof GROK4_5_REASONING_EFFORT_LEVELS)[number];
+
+export type Grok45ReasoningEffortSliderProps = CreatedLevelSliderProps<Grok45ReasoningEffort>;
+
+const Grok45ReasoningEffortSlider = createLevelSliderComponent<Grok45ReasoningEffort>({
+  configKey: 'grok4_5ReasoningEffort',
+  defaultValue: 'high',
+  levels: GROK4_5_REASONING_EFFORT_LEVELS,
+  style: { minWidth: 200 },
+});
+
+export default Grok45ReasoningEffortSlider;

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -14,6 +14,7 @@ import GPT51ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/C
 import GPT52ProReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/GPT52ProReasoningEffortSlider';
 import GPT52ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/GPT52ReasoningEffortSlider';
 import Grok43ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/Grok43ReasoningEffortSlider';
+import Grok45ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/Grok45ReasoningEffortSlider';
 import Grok420ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/Grok420ReasoningEffortSlider';
 import Hy3ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/Hy3ReasoningEffortSlider';
 import ImageAspectRatio2Select from '@/features/ModelSwitchPanel/components/ControlsForm/ImageAspectRatio2Select';
@@ -114,6 +115,10 @@ const EXTEND_PARAMS_OPTIONS: ExtendParamsOption[] = [
     key: 'grok4_3ReasoningEffort',
   },
   {
+    hintKey: 'providerModels.item.modelConfig.extendParams.options.grok4_5ReasoningEffort.hint',
+    key: 'grok4_5ReasoningEffort',
+  },
+  {
     hintKey: 'providerModels.item.modelConfig.extendParams.options.hy3ReasoningEffort.hint',
     key: 'hy3ReasoningEffort',
   },
@@ -191,6 +196,7 @@ const TITLE_KEY_ALIASES: Partial<Record<ExtendParamsType, ExtendParamsType>> = {
   glm5_2ReasoningEffort: 'reasoningEffort',
   grok4_20ReasoningEffort: 'reasoningEffort',
   grok4_3ReasoningEffort: 'reasoningEffort',
+  grok4_5ReasoningEffort: 'reasoningEffort',
   hy3ReasoningEffort: 'reasoningEffort',
   ring2_6ReasoningEffort: 'reasoningEffort',
   imageAspectRatio2: 'imageAspectRatio',
@@ -246,6 +252,11 @@ const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
   },
   grok4_3ReasoningEffort: {
     labelSuffix: ' (Grok 4.3)',
+    previewWidth: 300,
+    tag: 'reasoning_effort',
+  },
+  grok4_5ReasoningEffort: {
+    labelSuffix: ' (Grok 4.5)',
     previewWidth: 300,
     tag: 'reasoning_effort',
   },
@@ -419,6 +430,7 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
       glm5_2ReasoningEffort: <GLM52ReasoningEffortSlider value="max" />,
       grok4_20ReasoningEffort: <Grok420ReasoningEffortSlider value="medium" />,
       grok4_3ReasoningEffort: <Grok43ReasoningEffortSlider value="low" />,
+      grok4_5ReasoningEffort: <Grok45ReasoningEffortSlider value="high" />,
       hy3ReasoningEffort: <Hy3ReasoningEffortSlider value="high" />,
       ring2_6ReasoningEffort: <Ring26ReasoningEffortSlider value="high" />,
       imageAspectRatio: <ImageAspectRatioSelect value="1:1" />,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Adds a dedicated `grok4_5ReasoningEffort` extend param so the Grok 4.5 model family can expose a reasoning-effort control in the UI, wired end-to-end:

- **Types**: add `grok4_5ReasoningEffort` to `ExtendParamsType` union + zod schema (`aiModel.ts`), and to `LobeAgentChatConfig` field + zod enum (`chatConfig.ts`).
- **Runtime resolver**: map `grok4_5ReasoningEffort` → `reasoning_effort` in `modelExtendParams.ts` (only when the user explicitly sets it; otherwise the API default `high` applies).
- **UI**: new `Grok45ReasoningEffortSlider` (levels `low/medium/high`, default `high`, always on — no `none`), registered in `ControlsForm` and `ExtendParamsSelect`.
- **i18n**: hint copy in `modelProvider.ts`; `grok-4.5.description` synced into `models.ts` for the online-only model.

Grok 4.5 reasoning is always on with `low/medium/high` (default `high`), which differs from Grok 4.3 (`none/low/medium/high`, default `low`) — hence a separate param rather than reusing `grok4_3ReasoningEffort`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check --type` → types clean
- `bun run check --lint` (changed files) → lint clean
- `bun run check --test modelExtendParams` → 12 passed

#### 📝 Additional Information

No breaking changes — purely additive. The new param maps to the standard `reasoning_effort` API field; unset = provider default (`high`).
