### PR TITLE
🐛 fix(chat): keep creating user messages opaque

### DIFF
--- a/src/features/Conversation/Messages/index.tsx
+++ b/src/features/Conversation/Messages/index.tsx
@@ -98,6 +98,7 @@ const MessageItem = memo<MessageItemProps>(
       role === 'assistant' || role === 'assistantGroup' || role === 'supervisor';
     const supportsTextSelectionActions =
       role === 'user' || role === 'assistant' || role === 'assistantGroup';
+    const shouldDimCreatingMessage = isMessageCreating && role !== 'user';
 
     const onContextMenu = useCallback(
       async (event: MouseEvent<HTMLDivElement>) => {
@@ -238,7 +239,7 @@ const MessageItem = memo<MessageItemProps>(
       <>
         {enableHistoryDivider && <History />}
         <Flexbox
-          className={cx(styles.message, className, isMessageCreating && styles.loading)}
+          className={cx(styles.message, className, shouldDimCreatingMessage && styles.loading)}
           data-index={index}
           onContextMenu={onContextMenu}
         >


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No matching issue found.

#### 🔀 Description of Change

Creating user messages should keep their normal visual weight while the send operation is still creating the message record. This PR limits the existing loading opacity to non-user messages, so assistant and assistant-group creation states still appear dimmed.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

Validated with:

```bash
bun run check src/features/Conversation/Messages/index.tsx
```

Agent-testing verification report: https://app.lobehub.com/verify/81097de9-9d40-48ad-9ab9-cbf7e6f16710

#### 📸 Screenshots / Videos

Visual evidence is attached in the verification report: https://app.lobehub.com/verify/81097de9-9d40-48ad-9ab9-cbf7e6f16710

#### 📝 Additional Information

The change is scoped to `MessageItem` class selection and does not alter message creation or operation state handling.
