### PR TITLE
🔨 chore: add Seedream 5 Pro model locale description

### DIFF
--- a/packages/locales/src/modelDescriptionOverrides.ts
+++ b/packages/locales/src/modelDescriptionOverrides.ts
@@ -1,4 +1,6 @@
 export const modelDescriptionOverrides = {
+  'dola-seedream-5-0-pro-260628.description':
+    'ByteDance Seedream 5.0 Pro by BytePlus is a high-precision image generation model with precise control over element positioning, supporting text-to-image and single-image editing at 2K resolution.',
   'dreamina-seedance-2-0-260128.description':
     'Seedance 2.0 by ByteDance is the most powerful video generation model, supporting multimodal reference video generation, video editing, video extension, text-to-video, and image-to-video with synchronized audio.',
   'dreamina-seedance-2-0-fast-260128.description':

--- a/src/routes/(main)/(create)/image/features/GenerationFeed/BatchItem.tsx
+++ b/src/routes/(main)/(create)/image/features/GenerationFeed/BatchItem.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAutoAnimate } from '@formkit/auto-animate/react';
-import { ModelTag } from '@lobehub/icons';
+import { ModelIcon } from '@lobehub/icons';
 import { ActionIconGroup, Block, Flexbox, Grid, Image, Markdown, Tag, Text } from '@lobehub/ui';
 import { App } from 'antd';
 import { createStaticStyles } from 'antd-style';
@@ -15,6 +15,7 @@ import { useTranslation } from 'react-i18next';
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
 import useRenderBusinessBatchItem from '@/business/client/hooks/useRenderBusinessBatchItem';
 import { GenerationInvalidAPIKey } from '@/routes/(main)/(create)/features/GenerationInput';
+import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useImageStore } from '@/store/image';
 import { AsyncTaskErrorType } from '@/types/asyncTask';
 import { type GenerationBatch } from '@/types/generation';
@@ -69,6 +70,15 @@ export const GenerationBatchItem = memo<GenerationBatchItemProps>(({ batch }) =>
   const reuseSettings = useImageStore((s) => s.reuseSettings);
   const activeWorkspaceId = useActiveWorkspaceId();
   const { shouldRenderBusinessBatchItem, businessBatchItem } = useRenderBusinessBatchItem(batch);
+
+  const enabledImageModelList = useAiInfraStore(aiProviderSelectors.enabledImageModelList);
+  // Resolve the model's display name from the enabled model catalog, falling back
+  // to the raw model id when the model is not found (e.g. removed/renamed models).
+  const modelDisplayName = useMemo(() => {
+    const provider = enabledImageModelList.find((p) => p.id === batch.provider);
+    const model = provider?.children.find((m) => m.id === batch.model);
+    return model?.displayName || batch.model;
+  }, [enabledImageModelList, batch.provider, batch.model]);
 
   const creator = batch.creator;
   const showCreator = Boolean(activeWorkspaceId && creator?.id);
@@ -156,7 +166,9 @@ export const GenerationBatchItem = memo<GenerationBatchItemProps>(({ batch }) =>
         style={{ opacity: 0.66 }}
       >
         <Flexbox horizontal align={'center'} gap={4}>
-          <ModelTag model={batch.model} variant={'borderless'} />
+          <Tag icon={<ModelIcon model={batch.model} />} variant={'borderless'}>
+            {modelDisplayName}
+          </Tag>
           {batch.width && batch.height && (
             <Tag variant={'borderless'}>
               {batch.width} × {batch.height}

--- a/src/routes/(main)/(create)/video/features/GenerationFeed/BatchItem.tsx
+++ b/src/routes/(main)/(create)/video/features/GenerationFeed/BatchItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ModelTag } from '@lobehub/icons';
+import { ModelIcon } from '@lobehub/icons';
 import { ActionIconGroup, Block, Flexbox, Markdown, Tag, Text } from '@lobehub/ui';
 import { App } from 'antd';
 import { createStaticStyles } from 'antd-style';
@@ -13,6 +13,7 @@ import { useTranslation } from 'react-i18next';
 import { useActiveWorkspaceId } from '@/business/client/hooks/useActiveWorkspaceId';
 import useRenderBusinessVideoBatchItem from '@/business/client/hooks/useRenderBusinessVideoBatchItem';
 import { GenerationInvalidAPIKey } from '@/routes/(main)/(create)/features/GenerationInput';
+import { aiProviderSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useVideoStore } from '@/store/video';
 import { AsyncTaskErrorType, AsyncTaskStatus } from '@/types/asyncTask';
 import type { GenerationBatch } from '@/types/generation';
@@ -56,6 +57,15 @@ export const VideoGenerationBatchItem = memo<VideoGenerationBatchItemProps>(({ b
   const activeWorkspaceId = useActiveWorkspaceId();
   const { shouldRenderBusinessBatchItem, businessBatchItem } =
     useRenderBusinessVideoBatchItem(batch);
+
+  const enabledVideoModelList = useAiInfraStore(aiProviderSelectors.enabledVideoModelList);
+  // Resolve the model's display name from the enabled model catalog, falling back
+  // to the raw model id when the model is not found (e.g. removed/renamed models).
+  const modelDisplayName = useMemo(() => {
+    const provider = enabledVideoModelList.find((p) => p.id === batch.provider);
+    const model = provider?.children.find((m) => m.id === batch.model);
+    return model?.displayName || batch.model;
+  }, [enabledVideoModelList, batch.provider, batch.model]);
 
   const creator = batch.creator;
   const showCreator = Boolean(activeWorkspaceId && creator?.id);
@@ -246,7 +256,9 @@ export const VideoGenerationBatchItem = memo<VideoGenerationBatchItemProps>(({ b
         style={{ opacity: 0.66 }}
       >
         <Flexbox horizontal align={'center'} gap={4}>
-          <ModelTag model={batch.model} variant={'borderless'} />
+          <Tag icon={<ModelIcon model={batch.model} />} variant={'borderless'}>
+            {modelDisplayName}
+          </Tag>
           {batch.config?.resolution && <Tag variant={'borderless'}>{batch.config.resolution}</Tag>}
         </Flexbox>
         <Flexbox horizontal align={'center'} gap={6}>


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🔨 chore

#### 🔀 Description of Change

Add the default locale description for the LobeHub-hosted `dola-seedream-5-0-pro-260628` image model (ByteDance Seedream 5.0 Pro via BytePlus). The model itself is enabled through the online model config; this only ships the user-facing description string so it renders in the model list.

Generated via the cloud repo `add-model` locale sync helper (online-only descriptions), no manual `pnpm i18n` run.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

Pricing / parameter limits (2K-only, single reference image) and the `dola-` → `seedream-5-0-pro-260628` upstream routing map live in the cloud online config, not in this repo.