### PR TITLE
🐛 fix: enforce qstash minimum settling delay

### DIFF
--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -368,3 +368,29 @@ primary left action replaced by a chevron/popup icon.
 the default state and the collapsed/overflow state. If the design requires a
 specific action to stay visible, disable or bypass the toolbar collapse logic for
 that surface and include evidence that no collapse chevron is rendered.
+
+---
+
+## Case 16 — Publishing a component harness when the user asked for full product verification
+
+**Wrong approach**: when the isolated Electron instance failed once and local Docker
+was unavailable, declaring the product-surface verification blocked and publishing a
+component harness report as the main answer, even though another live Electron dev
+pool / CDP route was already running and previous runs had used it successfully.
+
+**Why it's wrong**: a component harness proves a narrow render contract, but it does
+not prove the full product composition, message list layout, app theme tokens,
+store plumbing, or that the evidence is inspectable in the actual desktop surface.
+Environment friction is the agent-testing job to solve, not a reason to downgrade
+without exhausting known running surfaces.
+
+**What it breaks**: the user opens a report expecting complete product evidence and
+gets a partial proof instead, then has to push back that the full verification used
+to run normally.
+
+**Correct approach**: before marking Electron/Web blocked, inventory existing dev
+instances and CDP ports, check whether a sibling worktree already runs the needed
+live branch, measure the target URL/bundle, and use that path if it renders current
+code. Only keep a harness as supporting evidence; the primary UI evidence must come
+from the product surface, or the report must clearly fail/block after every known
+path is measured.

--- a/apps/server/src/services/queue/__tests__/QueueService.test.ts
+++ b/apps/server/src/services/queue/__tests__/QueueService.test.ts
@@ -169,14 +169,14 @@ describe('QueueService', () => {
       const impl = new QStashQueueServiceImpl({ qstashToken: 'test-qstash-token' });
       const result = impl.scheduleMessage({
         context: { phase: 'user_input' } as any,
-        delay: 50,
+        delay: 500,
         endpoint: 'https://example.com/api/agent/run',
         operationId: 'op-test',
         priority: 'high',
         stepIndex: 0,
       });
 
-      await vi.advanceTimersByTimeAsync(49);
+      await vi.advanceTimersByTimeAsync(499);
       expect(qstashMocks.publishJSON).not.toHaveBeenCalled();
 
       await vi.advanceTimersByTimeAsync(1);
@@ -185,6 +185,33 @@ describe('QueueService', () => {
       const request = qstashMocks.publishJSON.mock.calls[0][0];
       expect(request).not.toHaveProperty('delay');
       expect(request.body.timestamp).toEqual(expect.any(Number));
+    });
+
+    it('should floor zero delay at the 300ms minimum settling window', async () => {
+      vi.useFakeTimers();
+      qstashMocks.publishJSON.mockResolvedValue({ messageId: 'msg-test' });
+
+      const { QStashQueueServiceImpl } = await import('../impls/qstash');
+      const impl = new QStashQueueServiceImpl({ qstashToken: 'test-qstash-token' });
+      const result = impl.scheduleMessage({
+        context: { phase: 'user_input' } as any,
+        delay: 0,
+        endpoint: 'https://example.com/api/agent/run',
+        operationId: 'op-test',
+        priority: 'high',
+        stepIndex: 0,
+      });
+
+      // 300ms minimum — not yet published at 299ms
+      await vi.advanceTimersByTimeAsync(299);
+      expect(qstashMocks.publishJSON).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(result).resolves.toBe('msg-test');
+
+      // Zero delay is sub-second, so it is not forwarded to QStash
+      const request = qstashMocks.publishJSON.mock.calls[0][0];
+      expect(request).not.toHaveProperty('delay');
     });
 
     it('should pass second-granularity delays through to QStash', async () => {

--- a/apps/server/src/services/queue/impls/qstash.ts
+++ b/apps/server/src/services/queue/impls/qstash.ts
@@ -9,6 +9,17 @@ const log = debug('lobe-server:service:queue:qstash');
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+/**
+ * Minimum settling delay (ms) applied before publishing a QStash message.
+ *
+ * QStash's `delay` option is second-granularity — the `Duration` string form
+ * (`10s`, `1m`, `2h`, `1d`) has no millisecond unit, and a bare number is
+ * treated as seconds (so `100` would mean 100s, not 100ms). Sub-second settling
+ * windows therefore cannot be delegated to QStash and must be honored locally;
+ * this floors small or zero delays so a step always gets a brief settle.
+ */
+const MIN_SETTLING_DELAY_MS = 300;
+
 const toQStashDelaySeconds = (delayMs: number): number | undefined => {
   if (delayMs <= 0) return undefined;
   if (delayMs < 1000) return undefined;
@@ -45,11 +56,12 @@ export class QStashQueueServiceImpl implements QueueServiceImpl {
 
     try {
       // QStash publish delays are second-granularity (`10s`, `1m`, or numeric
-      // seconds). Preserve the runtime's small settling windows, such as the
-      // initial 50ms, by waiting before publishing instead of collapsing them to
-      // immediate delivery.
-      if (delay > 0 && delay < 1000) {
-        await sleep(delay);
+      // seconds) and cannot express sub-second settling, so honor small windows
+      // locally. Floor at MIN_SETTLING_DELAY_MS so even a zero/near-zero delay
+      // still settles before publishing instead of collapsing to immediate
+      // delivery.
+      if (delay < 1000) {
+        await sleep(Math.max(delay, MIN_SETTLING_DELAY_MS));
       }
 
       log('Initialized QStash queue service');


### PR DESCRIPTION
## Summary

- floor sub-second QStash queue dispatches at a 300ms local settling window
- keep second-granularity delays delegated to QStash, e.g. 1500ms -> `delay: 2`
- expand queue service tests for the 0ms floor and sub-second local wait behavior
- record an agent-testing lesson about not replacing full product verification with a component harness when the user asked for complete verification

## Why

QStash delay values are second-granularity. Very small runtime settle windows, including zero or near-zero delays, cannot be represented safely as QStash delay values, so they need to be honored locally before publishing. Without that floor, retry/step dispatch can collapse to immediate delivery.

## Verification

Published verification report: https://app.lobehub.com/verify/a76dcc52-33f7-41e6-b459-9ae061fd8d3d

- `bunx vitest run --silent='passed-only' apps/server/src/services/queue/__tests__/QueueService.test.ts` -> 33 tests passed
- `bun run check apps/server/src/services/queue/impls/qstash.ts apps/server/src/services/queue/__tests__/QueueService.test.ts` -> lint clean, tests 33 passed
- runtime probe: `delay=0` published after ~302ms, `delay=500` after ~502ms, `delay=1500` immediately with QStash `delay: 2`
- `git diff --check` -> passed
- `bun run check --type` -> types clean
