### PR TITLE
🐛 fix(lint): migrate restricted UI imports

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1249,11 +1249,6 @@
       "count": 1
     }
   },
-  "src/routes/(main)/settings/creds/features/CreateCredModal/OAuthCredForm.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/routes/(main)/settings/creds/features/CredItem.tsx": {
     "no-restricted-imports": {
       "count": 1
@@ -1359,17 +1354,7 @@
       "count": 1
     }
   },
-  "src/routes/(main)/settings/skill/features/ComposioSkillItem.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/routes/(main)/settings/skill/features/LeftPanel.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx": {
     "no-restricted-imports": {
       "count": 1
     }

--- a/src/components/DragUpload/useDragUpload.test.tsx
+++ b/src/components/DragUpload/useDragUpload.test.tsx
@@ -1,5 +1,4 @@
 import { act, renderHook } from '@testing-library/react';
-import type * as AntdModule from 'antd';
 import { App } from 'antd';
 import { type Mock } from 'vitest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -10,11 +9,15 @@ import { agentSelectors } from '@/store/agent/selectors';
 
 import { getContainer, useDragUpload } from './useDragUpload';
 
+interface AntdMockModule {
+  App: typeof App;
+}
+
 // Mock the hooks and components
 vi.mock('@/hooks/useVisualMediaUploadAbility');
 vi.mock('@/store/agent');
 vi.mock('antd', async () => {
-  const actual = await vi.importActual<typeof AntdModule>('antd');
+  const actual = await vi.importActual<AntdMockModule>('antd');
   const mockWarning = vi.fn();
 
   return {

--- a/src/components/InvalidAPIKey/__tests__/ComfyUIForm.test.tsx
+++ b/src/components/InvalidAPIKey/__tests__/ComfyUIForm.test.tsx
@@ -28,6 +28,7 @@ vi.mock('antd-style', async (importOriginal) => {
       fn({
         css: () => '',
         cssVar: {},
+        cx: (...args: any[]) => args.filter(Boolean).join(' '),
       }),
     ),
     useTheme: () => ({

--- a/src/features/AgentBreadcrumb/index.test.tsx
+++ b/src/features/AgentBreadcrumb/index.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import type * as Antd from 'antd';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -22,8 +21,12 @@ vi.mock('@lobehub/ui', () => ({
   Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
 }));
 
+interface AntdMockModule {
+  Breadcrumb: (props: { items: Array<{ title: ReactNode }> }) => ReactNode;
+}
+
 vi.mock('antd', async (importOriginal) => {
-  const actual = await importOriginal<typeof Antd>();
+  const actual = await importOriginal<AntdMockModule>();
 
   return {
     ...actual,

--- a/src/features/AgentSetting/AgentDocuments/index.tsx
+++ b/src/features/AgentSetting/AgentDocuments/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { confirmModal, Select } from '@lobehub/ui/base-ui';
+import { Button, confirmModal, Select } from '@lobehub/ui/base-ui';
 import type { TableColumnsType } from 'antd';
-import { App, Button, Popconfirm, Space, Table, Tag, Typography } from 'antd';
+import { App, Popconfirm, Space, Table, Tag, Typography } from 'antd';
 import { memo, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/features/AgentTasks/AgentTaskList/CreateTaskInlineEntry.test.tsx
+++ b/src/features/AgentTasks/AgentTaskList/CreateTaskInlineEntry.test.tsx
@@ -36,7 +36,7 @@ vi.mock('@lobehub/ui/base-ui', () => ({
     disabled?: boolean;
     onClick?: () => void;
   }) => (
-    <button disabled={disabled} onClick={onClick}>
+    <button disabled={disabled} type="button" onClick={onClick}>
       {children}
     </button>
   ),

--- a/src/features/AgentTasks/AgentTaskList/CreateTaskInlineEntry.test.tsx
+++ b/src/features/AgentTasks/AgentTaskList/CreateTaskInlineEntry.test.tsx
@@ -24,6 +24,24 @@ vi.mock('@lobehub/editor/react', () => ({
   }),
 }));
 
+// Stub the base-ui Button (submit) to a native button — it needs a
+// MotionProvider the app sets up globally but the unit env doesn't.
+vi.mock('@lobehub/ui/base-ui', () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+  }: {
+    children?: ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
 vi.mock('@/features/EditorCanvas', () => ({
   EditorCanvas: ({ disabled }: { disabled?: boolean }) => (
     <div data-disabled={String(!!disabled)} data-testid="task-editor" />

--- a/src/features/AgentTasks/AgentTaskList/CreateTaskInlineEntry.tsx
+++ b/src/features/AgentTasks/AgentTaskList/CreateTaskInlineEntry.tsx
@@ -2,7 +2,7 @@
 
 import { useEditor } from '@lobehub/editor/react';
 import { ActionIcon, Block, Flexbox, Icon, Text } from '@lobehub/ui';
-import { Button } from 'antd';
+import { Button } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { $getRoot } from 'lexical';
 import { ChevronUp, Paperclip, UserCircle2 } from 'lucide-react';

--- a/src/features/AgentTasks/CreateTaskModal/CreateTaskContent.tsx
+++ b/src/features/AgentTasks/CreateTaskModal/CreateTaskContent.tsx
@@ -2,8 +2,7 @@
 
 import { useEditor } from '@lobehub/editor/react';
 import { ActionIcon, Block, Flexbox, Icon, Text } from '@lobehub/ui';
-import { useModalContext } from '@lobehub/ui/base-ui';
-import { Button } from 'antd';
+import { Button, useModalContext } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { Minimize2, Paperclip, UserCircle2, X } from 'lucide-react';
 import { type KeyboardEvent, memo, useCallback, useEffect, useRef, useState } from 'react';

--- a/src/features/Connectors/ConnectorDetail/ToolPermissionGroup.tsx
+++ b/src/features/Connectors/ConnectorDetail/ToolPermissionGroup.tsx
@@ -1,5 +1,4 @@
-import { DropdownMenu } from '@lobehub/ui/base-ui';
-import { Button } from 'antd';
+import { Button, DropdownMenu } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import { ChevronDownIcon, ChevronRightIcon, MoreHorizontalIcon } from 'lucide-react';
 import { memo, useState } from 'react';

--- a/src/features/Connectors/ConnectorDetail/index.test.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.test.tsx
@@ -51,7 +51,9 @@ vi.mock('@lobechat/const', () => ({
   getLobehubSkillProviderById: () => undefined,
 }));
 
-vi.mock('antd', () => ({
+// Stub the base-ui Button to a native button — it needs a MotionProvider the
+// app sets up globally but the unit env doesn't.
+vi.mock('@lobehub/ui/base-ui', () => ({
   Button: ({
     children,
     disabled,
@@ -65,6 +67,7 @@ vi.mock('antd', () => ({
       {children}
     </button>
   ),
+  confirmModal: vi.fn(),
 }));
 
 vi.mock('@/store/tool', () => ({

--- a/src/features/Connectors/ConnectorDetail/index.test.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.test.tsx
@@ -63,7 +63,7 @@ vi.mock('@lobehub/ui/base-ui', () => ({
     disabled?: boolean;
     onClick?: () => void;
   }) => (
-    <button disabled={disabled} onClick={onClick}>
+    <button disabled={disabled} type="button" onClick={onClick}>
       {children}
     </button>
   ),

--- a/src/features/Connectors/ConnectorDetail/index.tsx
+++ b/src/features/Connectors/ConnectorDetail/index.tsx
@@ -1,6 +1,5 @@
 import { getComposioAppByIdentifier, getLobehubSkillProviderById } from '@lobechat/const';
-import { confirmModal } from '@lobehub/ui/base-ui';
-import { Button } from 'antd';
+import { Button, confirmModal } from '@lobehub/ui/base-ui';
 import { PencilIcon, RefreshCwIcon, Trash2 } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { memo, useCallback, useState } from 'react';

--- a/src/features/Conversation/ChatItem/components/ErrorContent.tsx
+++ b/src/features/Conversation/ChatItem/components/ErrorContent.tsx
@@ -1,5 +1,5 @@
 import { Alert, Skeleton } from '@lobehub/ui';
-import { Button } from 'antd';
+import { Button } from '@lobehub/ui/base-ui';
 import { RotateCcw } from 'lucide-react';
 import { memo, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -47,7 +47,7 @@ const ErrorContent = memo<ErrorContentProps>(({ customErrorRender, error, id, on
             color="default"
             icon={<RotateCcw size={14} />}
             size="small"
-            variant="filled"
+            type="fill"
             onClick={onRegenerate}
           >
             {t('regenerate')}

--- a/src/features/Conversation/Error/ExceededContextWindowError.tsx
+++ b/src/features/Conversation/Error/ExceededContextWindowError.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@lobehub/ui';
-import { Button } from 'antd';
+import { Button } from '@lobehub/ui/base-ui';
 import { Minimize2 } from 'lucide-react';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/Conversation/Error/QuotaLimitError.tsx
+++ b/src/features/Conversation/Error/QuotaLimitError.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@lobehub/ui';
-import { Button } from 'antd';
+import { Button } from '@lobehub/ui/base-ui';
 import { AlertTriangle, RotateCw } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/features/Conversation/Error/TraceIdError.tsx
+++ b/src/features/Conversation/Error/TraceIdError.tsx
@@ -1,7 +1,8 @@
 import { SOCIAL_URL } from '@lobechat/business-const';
 import { copyToClipboard, Icon } from '@lobehub/ui';
+import { Button } from '@lobehub/ui/base-ui';
 import { DiscordIcon } from '@lobehub/ui/icons';
-import { Button, message } from 'antd';
+import { message } from 'antd';
 import { cssVar } from 'antd-style';
 import { AlertTriangle, Copy, RotateCw } from 'lucide-react';
 import { memo, useCallback } from 'react';

--- a/src/features/EditorCanvas/DiffAllToolbar.tsx
+++ b/src/features/EditorCanvas/DiffAllToolbar.tsx
@@ -3,7 +3,8 @@
 import type { IEditor } from '@lobehub/editor';
 import { DiffAction, LITEXML_DIFFNODE_ALL_COMMAND } from '@lobehub/editor';
 import { Block, Icon } from '@lobehub/ui';
-import { Button, Space } from 'antd';
+import { Button } from '@lobehub/ui/base-ui';
+import { Space } from 'antd';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
 import { Check, X } from 'lucide-react';
 import { memo, useEffect, useState } from 'react';
@@ -149,7 +150,7 @@ const DiffAllToolbar = memo<DiffAllToolbarProps>(({ documentId, editor }) => {
           <Button
             color={'default'}
             size={'small'}
-            variant="filled"
+            type="fill"
             onClick={async () => {
               editor.dispatchCommand(LITEXML_DIFFNODE_ALL_COMMAND, {
                 action: DiffAction.Accept,

--- a/src/features/SkillStore/SkillDetail/Header.tsx
+++ b/src/features/SkillStore/SkillDetail/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Avatar, Flexbox, Icon, Text, Tooltip, useModalContext } from '@lobehub/ui';
-import { Button } from 'antd';
+import { Button } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import { Loader2, Plus, SquareArrowOutUpRight } from 'lucide-react';
 import { memo, useEffect, useRef } from 'react';

--- a/src/features/SkillStore/SkillList/Community/Item.tsx
+++ b/src/features/SkillStore/SkillList/Community/Item.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { ActionIcon, Block, DropdownMenu, Flexbox, Icon, stopPropagation } from '@lobehub/ui';
-import { confirmModal } from '@lobehub/ui/base-ui';
-import { Button } from 'antd';
+import { Button, confirmModal } from '@lobehub/ui/base-ui';
 import isEqual from 'fast-deep-equal';
 import { MoreVerticalIcon, Plus, Trash2 } from 'lucide-react';
 import React, { memo, Suspense, useState } from 'react';
@@ -111,7 +110,7 @@ const Item = memo<DiscoverMcpItem>(({ name, description, icon, identifier }) => 
 
     if (installing) {
       return (
-        <Button size="small" variant={'filled'} onClick={handleCancel}>
+        <Button size="small" type="fill" onClick={handleCancel}>
           {t('store.actions.cancel')}
         </Button>
       );

--- a/src/layout/AuthProvider/MarketAuth/SocialConnectButton.tsx
+++ b/src/layout/AuthProvider/MarketAuth/SocialConnectButton.tsx
@@ -2,7 +2,8 @@
 
 import { SiGithub, SiX } from '@icons-pack/react-simple-icons';
 import { ActionIcon, Flexbox, Text, Tooltip } from '@lobehub/ui';
-import { Button, Spin } from 'antd';
+import { Button } from '@lobehub/ui/base-ui';
+import { Spin } from 'antd';
 import { cssVar } from 'antd-style';
 import { ArrowRight, Link2Off, Loader2 } from 'lucide-react';
 import { memo } from 'react';

--- a/src/routes/(main)/agent/channel/detail/Body.tsx
+++ b/src/routes/(main)/agent/channel/detail/Body.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { Flexbox, Form, FormGroup, FormItem, Tag, Text } from '@lobehub/ui';
-import { Button, Switch } from '@lobehub/ui/base-ui';
-import { Form as AntdForm, type FormInstance, InputNumber, Popconfirm, Select } from 'antd';
+import type { SelectOption } from '@lobehub/ui/base-ui';
+import { Button, Select, Switch } from '@lobehub/ui/base-ui';
+import { Form as AntdForm, type FormInstance, InputNumber, Popconfirm } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { Plus, RotateCcw, Trash2 } from 'lucide-react';
 import { Fragment, memo, useCallback, useMemo, useState } from 'react';
@@ -143,29 +144,35 @@ const SchemaField = memo<SchemaFieldProps>(({ field, parentKey, divider, disable
     case 'string': {
       if (field.enum) {
         const hasDescriptions = field.enumDescriptions?.some(Boolean);
+        const options = field.enum.map((value, i) => ({
+          description: field.enumDescriptions?.[i] ? t(field.enumDescriptions[i]) : undefined,
+          label: field.enumLabels?.[i] ? t(field.enumLabels[i]) : value,
+          value,
+        })) satisfies Array<SelectOption<string> & { description?: string }>;
+
         children = (
           <Select
             disabled={disabled}
+            options={options}
             placeholder={field.placeholder ? t(field.placeholder) : undefined}
             optionRender={
               hasDescriptions
-                ? (item) => (
-                    <Flexbox horizontal align="center" gap={12} justify="space-between">
-                      <span>{item.label}</span>
-                      {item.data.description ? (
-                        <Text fontSize={12} type="secondary">
-                          {item.data.description}
-                        </Text>
-                      ) : null}
-                    </Flexbox>
-                  )
+                ? (item) => {
+                    const option = item as SelectOption<string> & { description?: string };
+
+                    return (
+                      <Flexbox horizontal align="center" gap={12} justify="space-between">
+                        <span>{option.label}</span>
+                        {option.description && (
+                          <Text fontSize={12} type="secondary">
+                            {option.description}
+                          </Text>
+                        )}
+                      </Flexbox>
+                    );
+                  }
                 : undefined
             }
-            options={field.enum.map((value, i) => ({
-              description: field.enumDescriptions?.[i] ? t(field.enumDescriptions[i]) : undefined,
-              label: field.enumLabels?.[i] ? t(field.enumLabels[i]) : value,
-              value,
-            }))}
           />
         );
       } else {

--- a/src/routes/(main)/agent/channel/detail/permission.test.tsx
+++ b/src/routes/(main)/agent/channel/detail/permission.test.tsx
@@ -2,7 +2,6 @@
  * @vitest-environment happy-dom
  */
 import { render, screen, within } from '@testing-library/react';
-import type * as AntdModule from 'antd';
 import { Form } from 'antd';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -19,6 +18,10 @@ const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
 }));
 
+interface AntdMockModule {
+  App: Record<PropertyKey, unknown>;
+}
+
 vi.mock('react-i18next', () => ({
   Trans: ({ i18nKey }: { i18nKey: string }) => <span>{i18nKey}</span>,
   useTranslation: () => ({
@@ -28,7 +31,7 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('antd', async (importOriginal) => {
-  const actual = await importOriginal<typeof AntdModule>();
+  const actual = await importOriginal<AntdMockModule>();
 
   return {
     ...actual,

--- a/src/routes/(main)/agent/channel/platform/imessage/CredentialExtras.tsx
+++ b/src/routes/(main)/agent/channel/platform/imessage/CredentialExtras.tsx
@@ -3,7 +3,8 @@
 import { isDesktop } from '@lobechat/const';
 import type { ImessageBridgeConfig, ImessageBridgeStatus } from '@lobechat/electron-client-ipc';
 import { Flexbox, FormItem, Tag, Text } from '@lobehub/ui';
-import { App, Button, Form as AntdForm, Switch } from 'antd';
+import { Button } from '@lobehub/ui/base-ui';
+import { App, Form as AntdForm, Switch } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { Info, Wrench } from 'lucide-react';
 import { memo, use, useCallback, useEffect, useState } from 'react';

--- a/src/routes/(main)/agent/channel/platform/line/CredentialExtras.tsx
+++ b/src/routes/(main)/agent/channel/platform/line/CredentialExtras.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { App, Button, Form as AntdForm } from 'antd';
+import { Button } from '@lobehub/ui/base-ui';
+import { App, Form as AntdForm } from 'antd';
 import { Download } from 'lucide-react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -15,8 +16,7 @@ const CredentialExtras = memo<PlatformCredentialExtrasProps>(({ disabled }) => {
   const { message } = App.useApp();
   const form = AntdForm.useFormInstance();
   const channelAccessToken = AntdForm.useWatch(['credentials', 'channelAccessToken'], form) as
-    | string
-    | undefined;
+    string | undefined;
   const [loading, setLoading] = useState(false);
 
   const lineFetchBotInfo = useAgentStore((s) => s.lineFetchBotInfo);

--- a/src/routes/(main)/agent/channel/platform/wechat/QrCodeAuth.tsx
+++ b/src/routes/(main)/agent/channel/platform/wechat/QrCodeAuth.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { InfoCircleOutlined } from '@ant-design/icons';
-import { createModal, useModalContext } from '@lobehub/ui/base-ui';
-import { Alert, Button, type ButtonProps, QRCode, Spin, Typography } from 'antd';
+import { Button, type ButtonProps, createModal, useModalContext } from '@lobehub/ui/base-ui';
+import { Alert, QRCode, Spin, Typography } from 'antd';
 import { t as i18nT } from 'i18next';
 import { QrCode, RefreshCw } from 'lucide-react';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';

--- a/src/routes/(main)/agent/profile/features/Header/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.test.tsx
@@ -1,6 +1,5 @@
 import type * as LobeChatConst from '@lobechat/const';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type * as Antd from 'antd';
 import type * as LucideReact from 'lucide-react';
 import type { PropsWithChildren, ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -86,8 +85,13 @@ vi.mock('@lobehub/ui/base-ui', () => ({
   confirmModal: vi.fn(),
 }));
 
+interface AntdMockModule {
+  App: Record<PropertyKey, unknown>;
+  Modal: Record<PropertyKey, unknown>;
+}
+
 vi.mock('antd', async (importOriginal) => {
-  const actual = await importOriginal<typeof Antd>();
+  const actual = await importOriginal<AntdMockModule>();
 
   return {
     ...actual,

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/CloudHeterogeneousConfig.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/CloudHeterogeneousConfig.tsx
@@ -3,7 +3,8 @@
 import { type HeterogeneousProviderConfig, type UserCredSummary } from '@lobechat/types';
 import { Github } from '@lobehub/icons';
 import { Flexbox } from '@lobehub/ui';
-import { Avatar, Button, Input, Select, Spin, Tag, Typography } from 'antd';
+import { Button, Select } from '@lobehub/ui/base-ui';
+import { Avatar, Input, Spin, Tag, Typography } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { CheckCircle2, KeyRound, X } from 'lucide-react';
 import { memo, useState } from 'react';
@@ -313,6 +314,21 @@ const CloudHeterogeneousConfig = memo<CloudHeterogeneousConfigProps>(
     const githubCreds = allCreds.filter(
       (c) => c.type === 'oauth' && c.oauthProvider?.toLowerCase().includes('github'),
     );
+    const githubCredOptions = githubCreds.map((cred) => ({
+      label: (
+        <span className={styles.credOption}>
+          {cred.oauthAvatar ? <Avatar size={16} src={cred.oauthAvatar} /> : <Github size={14} />}
+          <span>{cred.name}</span>
+          {cred.oauthUsername && (
+            <Typography.Text style={{ fontSize: 12 }} type="secondary">
+              @{cred.oauthUsername}
+            </Typography.Text>
+          )}
+        </span>
+      ),
+      title: [cred.name, cred.oauthUsername].filter(Boolean).join(' '),
+      value: cred.key,
+    }));
 
     const saveEnv = (patch: Record<string, string>) => {
       if (!canEdit) return;
@@ -361,35 +377,16 @@ const CloudHeterogeneousConfig = memo<CloudHeterogeneousConfigProps>(
             <Select
               allowClear
               disabled={!canEdit}
-              placeholder={t('heterogeneousStatus.cloud.githubPlaceholder')}
+              options={githubCredOptions}
               style={{ width: '100%' }}
-              value={storedGithubCredKey || undefined}
-              notFoundContent={
-                <Flexbox style={{ padding: '8px 0', fontSize: 12 }}>
-                  {t('heterogeneousStatus.cloud.githubNoCreds')}
-                </Flexbox>
+              value={storedGithubCredKey || null}
+              placeholder={
+                githubCredOptions.length > 0
+                  ? t('heterogeneousStatus.cloud.githubPlaceholder')
+                  : t('heterogeneousStatus.cloud.githubNoCreds')
               }
-              onChange={(key: string) => saveEnv({ GITHUB_CRED_KEY: key })}
-              onClear={() => saveEnv({ GITHUB_CRED_KEY: '' })}
-            >
-              {githubCreds.map((cred) => (
-                <Select.Option key={cred.key} value={cred.key}>
-                  <span className={styles.credOption}>
-                    {cred.oauthAvatar ? (
-                      <Avatar size={16} src={cred.oauthAvatar} />
-                    ) : (
-                      <Github size={14} />
-                    )}
-                    <span>{cred.name}</span>
-                    {cred.oauthUsername && (
-                      <Typography.Text style={{ fontSize: 12 }} type="secondary">
-                        @{cred.oauthUsername}
-                      </Typography.Text>
-                    )}
-                  </span>
-                </Select.Option>
-              ))}
-            </Select>
+              onChange={(key) => saveEnv({ GITHUB_CRED_KEY: typeof key === 'string' ? key : '' })}
+            />
 
             <span className={styles.sectionDesc}>{t('heterogeneousStatus.cloud.githubDesc')}</span>
           </Flexbox>

--- a/src/routes/(main)/agent/profile/features/ProfileEditor/RemoteAgentConfigCard.tsx
+++ b/src/routes/(main)/agent/profile/features/ProfileEditor/RemoteAgentConfigCard.tsx
@@ -6,8 +6,8 @@ import {
 } from '@lobechat/heterogeneous-agents';
 import type { HeterogeneousProviderConfig } from '@lobechat/types';
 import { ActionIcon, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
-import { Button as BaseButton, createModal, Select, useModalContext } from '@lobehub/ui/base-ui';
-import { Button, Tag } from 'antd';
+import { Button, createModal, Select, useModalContext } from '@lobehub/ui/base-ui';
+import { Tag } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { t as i18nT } from 'i18next';
 import { BotIcon, CheckCircle2, MonitorSmartphone, RefreshCw, XCircle } from 'lucide-react';
@@ -198,17 +198,17 @@ const ChangeDeviceContent = memo<ChangeDeviceContentProps>(
           )}
         </Flexbox>
         <Flexbox horizontal gap={8} justify={'flex-end'}>
-          <BaseButton disabled={saving} onClick={close}>
+          <Button disabled={saving} onClick={close}>
             {t('cancel', { ns: 'common' })}
-          </BaseButton>
-          <BaseButton
+          </Button>
+          <Button
             disabled={!selectedDeviceId || checkingCapability || capabilityBad}
             loading={saving}
             type={'primary'}
             onClick={handleSave}
           >
             {t('platformAgentConfig.changeDevice')}
-          </BaseButton>
+          </Button>
         </Flexbox>
       </Flexbox>
     );

--- a/src/routes/(main)/community/(detail)/user/features/UserSkillList.tsx
+++ b/src/routes/(main)/community/(detail)/user/features/UserSkillList.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { Flexbox, Grid, Tag, Text } from '@lobehub/ui';
-import { Button, Input, Pagination } from 'antd';
+import { Button } from '@lobehub/ui/base-ui';
+import { Input, Pagination } from 'antd';
 import { Plus } from 'lucide-react';
 import { memo, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/routes/(main)/community/(detail)/workspace/features/WorkspaceStatusFilter.tsx
+++ b/src/routes/(main)/community/(detail)/workspace/features/WorkspaceStatusFilter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Select } from 'antd';
+import { Select } from '@lobehub/ui/base-ui';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/routes/(main)/eval/bench/[benchmarkId]/features/RunCreateModal/Content.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/features/RunCreateModal/Content.tsx
@@ -2,8 +2,8 @@
 
 import { AGENT_PROFILE_URL, DEFAULT_INBOX_AVATAR, INBOX_SESSION_ID } from '@lobechat/const';
 import { Accordion, AccordionItem, ActionIcon, Avatar, Flexbox, Text } from '@lobehub/ui';
-import { useModalContext } from '@lobehub/ui/base-ui';
-import { Form, Input, InputNumber, Select, Space } from 'antd';
+import { Select, useModalContext } from '@lobehub/ui/base-ui';
+import { Form, Input, InputNumber, Space } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { SquareArrowOutUpRight } from 'lucide-react';
 import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
@@ -127,7 +127,7 @@ const RunCreateContent: FC<RunCreateContentProps> = ({
             <span>{agent.title}</span>
           </span>
         ),
-        searchLabel: agent.title || '',
+        title: agent.title || '',
         value: agent.id,
       })),
     [allAgents],
@@ -226,9 +226,6 @@ const RunCreateContent: FC<RunCreateContentProps> = ({
           options={agentOptions}
           placeholder={t('run.create.agent.placeholder')}
           variant="filled"
-          filterOption={(input, option) =>
-            (option?.searchLabel as string)?.toLowerCase().includes(input.toLowerCase())
-          }
           optionRender={(option) => (
             <span
               style={{

--- a/src/routes/(main)/eval/bench/[benchmarkId]/features/RunCreateModal/Content.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/features/RunCreateModal/Content.tsx
@@ -113,24 +113,35 @@ const RunCreateContent: FC<RunCreateContentProps> = ({
 
   const allAgents = useMemo(() => [inboxAgent, ...agents], [inboxAgent, agents]);
 
+  const agentMap = useMemo(() => new Map(allAgents.map((agent) => [agent.id, agent])), [allAgents]);
+
   const agentOptions = useMemo(
     () =>
       allAgents.map((agent) => ({
-        label: (
-          <span style={{ alignItems: 'center', display: 'inline-flex', gap: 8 }}>
-            <Avatar
-              avatar={agent.avatar || undefined}
-              background={agent.backgroundColor || undefined}
-              size={20}
-              title={agent.title || ''}
-            />
-            <span>{agent.title}</span>
-          </span>
-        ),
+        label: agent.title || agent.id,
         title: agent.title || '',
         value: agent.id,
       })),
     [allAgents],
+  );
+
+  const renderAgentLabel = useCallback(
+    (agentId: string, fallback: React.ReactNode) => {
+      const agent = agentMap.get(agentId);
+
+      return (
+        <span style={{ alignItems: 'center', display: 'inline-flex', gap: 8 }}>
+          <Avatar
+            avatar={agent?.avatar || undefined}
+            background={agent?.backgroundColor || undefined}
+            size={20}
+            title={agent?.title || String(fallback)}
+          />
+          <span>{agent?.title || fallback}</span>
+        </span>
+      );
+    },
+    [agentMap],
   );
 
   const handleOpenAgent = useCallback((agentId: string, e: React.MouseEvent) => {
@@ -222,6 +233,7 @@ const RunCreateContent: FC<RunCreateContentProps> = ({
           allowClear
           showSearch
           className={styles.agentSelect}
+          labelRender={(option) => renderAgentLabel(String(option.value), option.label)}
           loading={loadingAgents}
           options={agentOptions}
           placeholder={t('run.create.agent.placeholder')}
@@ -235,7 +247,7 @@ const RunCreateContent: FC<RunCreateContentProps> = ({
                 justifyContent: 'space-between',
               }}
             >
-              {option.label}
+              {renderAgentLabel(String(option.value), option.label)}
               <ActionIcon
                 icon={SquareArrowOutUpRight}
                 size="small"

--- a/src/routes/(main)/eval/bench/[benchmarkId]/features/RunEditModal/Content.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/features/RunEditModal/Content.tsx
@@ -3,8 +3,8 @@
 import { AGENT_PROFILE_URL, DEFAULT_INBOX_AVATAR, INBOX_SESSION_ID } from '@lobechat/const';
 import type { AgentEvalRunStatus, EvalRunInputConfig } from '@lobechat/types';
 import { Accordion, AccordionItem, ActionIcon, Avatar, Flexbox } from '@lobehub/ui';
-import { useModalContext } from '@lobehub/ui/base-ui';
-import { App, Form, Input, InputNumber, Select, Space } from 'antd';
+import { Select, useModalContext } from '@lobehub/ui/base-ui';
+import { App, Form, Input, InputNumber, Space } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { SquareArrowOutUpRight } from 'lucide-react';
 import { type FC, useCallback, useEffect, useMemo, useState } from 'react';
@@ -121,7 +121,7 @@ const RunEditContent: FC<RunEditContentProps> = ({ formId, onLoadingChange, run 
             <span>{agent.title}</span>
           </span>
         ),
-        searchLabel: agent.title || '',
+        title: agent.title || '',
         value: agent.id,
       })),
     [allAgents],
@@ -197,9 +197,6 @@ const RunEditContent: FC<RunEditContentProps> = ({ formId, onLoadingChange, run 
             options={agentOptions}
             placeholder={t('run.create.agent.placeholder')}
             variant="filled"
-            filterOption={(input, option) =>
-              (option?.searchLabel as string)?.toLowerCase().includes(input.toLowerCase())
-            }
             optionRender={(option) => (
               <span
                 style={{

--- a/src/routes/(main)/eval/bench/[benchmarkId]/features/RunEditModal/Content.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/features/RunEditModal/Content.tsx
@@ -107,24 +107,35 @@ const RunEditContent: FC<RunEditContentProps> = ({ formId, onLoadingChange, run 
 
   const allAgents = useMemo(() => [inboxAgent, ...agents], [inboxAgent, agents]);
 
+  const agentMap = useMemo(() => new Map(allAgents.map((agent) => [agent.id, agent])), [allAgents]);
+
   const agentOptions = useMemo(
     () =>
       allAgents.map((agent) => ({
-        label: (
-          <span style={{ alignItems: 'center', display: 'inline-flex', gap: 8 }}>
-            <Avatar
-              avatar={agent.avatar || undefined}
-              background={agent.backgroundColor || undefined}
-              size={20}
-              title={agent.title || ''}
-            />
-            <span>{agent.title}</span>
-          </span>
-        ),
+        label: agent.title || agent.id,
         title: agent.title || '',
         value: agent.id,
       })),
     [allAgents],
+  );
+
+  const renderAgentLabel = useCallback(
+    (agentId: string, fallback: React.ReactNode) => {
+      const agent = agentMap.get(agentId);
+
+      return (
+        <span style={{ alignItems: 'center', display: 'inline-flex', gap: 8 }}>
+          <Avatar
+            avatar={agent?.avatar || undefined}
+            background={agent?.backgroundColor || undefined}
+            size={20}
+            title={agent?.title || String(fallback)}
+          />
+          <span>{agent?.title || fallback}</span>
+        </span>
+      );
+    },
+    [agentMap],
   );
 
   const handleOpenAgent = useCallback((agentId: string, e: React.MouseEvent) => {
@@ -193,6 +204,7 @@ const RunEditContent: FC<RunEditContentProps> = ({ formId, onLoadingChange, run 
             allowClear
             showSearch
             className={styles.agentSelect}
+            labelRender={(option) => renderAgentLabel(String(option.value), option.label)}
             loading={loadingAgents}
             options={agentOptions}
             placeholder={t('run.create.agent.placeholder')}
@@ -206,7 +218,7 @@ const RunEditContent: FC<RunEditContentProps> = ({ formId, onLoadingChange, run 
                   justifyContent: 'space-between',
                 }}
               >
-                {option.label}
+                {renderAgentLabel(String(option.value), option.label)}
                 <ActionIcon
                   icon={SquareArrowOutUpRight}
                   size="small"

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/RunHeader/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/features/RunHeader/index.tsx
@@ -3,8 +3,8 @@
 import { AGENT_PROFILE_URL } from '@lobechat/const';
 import type { AgentEvalRunDetail } from '@lobechat/types';
 import { ActionIcon, Avatar, copyToClipboard, Flexbox, Highlighter, Markdown } from '@lobehub/ui';
-import { confirmModal } from '@lobehub/ui/base-ui';
-import { App, Button, Tag } from 'antd';
+import { Button, confirmModal } from '@lobehub/ui/base-ui';
+import { App, Tag } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import {
   ArrowLeft,
@@ -105,9 +105,7 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   agentLink: css`
     cursor: pointer;
-
     border-radius: ${cssVar.borderRadiusSM};
-
     transition: color 0.15s ease;
 
     &:hover {
@@ -134,7 +132,6 @@ const styles = createStaticStyles(({ css }) => ({
   headerBand: css`
     padding: 20px;
     border-radius: ${cssVar.borderRadiusLG};
-
     background: ${cssVar.colorFillQuaternary};
   `,
   metaItem: css`
@@ -165,6 +162,7 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   runName: css`
     margin: 0;
+
     font-size: ${cssVar.fontSizeHeading3};
     font-weight: 600;
     line-height: 1.2;

--- a/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/index.tsx
+++ b/src/routes/(main)/eval/bench/[benchmarkId]/runs/[runId]/index.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { Flexbox, Text } from '@lobehub/ui';
-import { confirmModal } from '@lobehub/ui/base-ui';
-import { Button, Progress } from 'antd';
+import { Button, confirmModal } from '@lobehub/ui/base-ui';
+import { Progress } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { Play, RotateCcw } from 'lucide-react';
 import { memo, useState } from 'react';

--- a/src/routes/(main)/settings/creds/features/CreateCredModal/OAuthCredForm.tsx
+++ b/src/routes/(main)/settings/creds/features/CreateCredModal/OAuthCredForm.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Button, Flexbox } from '@lobehub/ui';
+import { Flexbox } from '@lobehub/ui';
+import { Button, Select } from '@lobehub/ui/base-ui';
 import { useMutation } from '@tanstack/react-query';
-import { Avatar, Empty, Form, Input, Select, Spin } from 'antd';
+import { Avatar, Empty, Form, Input, Spin } from 'antd';
 import { createStaticStyles } from 'antd-style';
 import { type FC } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -50,6 +51,24 @@ const OAuthCredForm: FC<OAuthCredFormProps> = ({ credsApi, disabled, onBack, onS
   const { data: connectionsData, isLoading } = credsApi.query.listOAuthConnections.useQuery();
 
   const connections = connectionsData?.connections ?? [];
+  const connectionOptions = connections.map((conn: any) => {
+    const provider = conn.providerId || 'OAuth';
+    const displayName = conn.providerName || conn.providerUserName || conn.email || conn.name;
+
+    return {
+      label: (
+        <span className={styles.connectionOption}>
+          {conn.avatar && <Avatar size="small" src={conn.avatar} />}
+          <span>
+            <span className={styles.provider}>{provider}</span>
+            {displayName && <span className={styles.username}> - {displayName}</span>}
+          </span>
+        </span>
+      ),
+      title: [provider, displayName].filter(Boolean).join(' '),
+      value: conn.id,
+    };
+  });
 
   const createMutation = useMutation({
     mutationFn: async (values: FormValues) => {
@@ -99,24 +118,11 @@ const OAuthCredForm: FC<OAuthCredFormProps> = ({ credsApi, disabled, onBack, onS
         name="oauthConnectionId"
         rules={[{ required: true, message: t('creds.form.connectionRequired') }]}
       >
-        <Select disabled={disabled} placeholder={t('creds.form.selectConnectionPlaceholder')}>
-          {connections.map((conn: any) => {
-            const provider = conn.providerId || 'OAuth';
-            const displayName =
-              conn.providerName || conn.providerUserName || conn.email || conn.name;
-            return (
-              <Select.Option key={conn.id} value={conn.id}>
-                <span className={styles.connectionOption}>
-                  {conn.avatar && <Avatar size="small" src={conn.avatar} />}
-                  <span>
-                    <span className={styles.provider}>{provider}</span>
-                    {displayName && <span className={styles.username}> - {displayName}</span>}
-                  </span>
-                </span>
-              </Select.Option>
-            );
-          })}
-        </Select>
+        <Select
+          disabled={disabled}
+          options={connectionOptions}
+          placeholder={t('creds.form.selectConnectionPlaceholder')}
+        />
       </Form.Item>
 
       <Form.Item

--- a/src/routes/(main)/settings/provider/features/ProviderConfig/OAuthDeviceFlowAuth/index.tsx
+++ b/src/routes/(main)/settings/provider/features/ProviderConfig/OAuthDeviceFlowAuth/index.tsx
@@ -3,8 +3,8 @@
 import { CheckCircleFilled } from '@ant-design/icons';
 import { ProviderIcon } from '@lobehub/icons';
 import { CopyButton, Flexbox, Icon } from '@lobehub/ui';
-import { confirmModal } from '@lobehub/ui/base-ui';
-import { Avatar, Button, Typography } from 'antd';
+import { Button, confirmModal } from '@lobehub/ui/base-ui';
+import { Avatar, Typography } from 'antd';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { ExternalLinkIcon, Loader2Icon, LogOutIcon, UnplugIcon } from 'lucide-react';
 import { type ReactNode } from 'react';

--- a/src/routes/(main)/settings/proxy/features/ProxyForm.test.tsx
+++ b/src/routes/(main)/settings/proxy/features/ProxyForm.test.tsx
@@ -74,6 +74,26 @@ vi.mock('./SaveBar', () => ({
     ) : null,
 }));
 
+// Stub the base-ui Button (test-connection) to a native button — it needs a
+// MotionProvider the app sets up globally but the unit env doesn't. Keep
+// type="button" to match the real Button's default htmlType and avoid
+// implicitly submitting the surrounding form.
+vi.mock('@lobehub/ui/base-ui', () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+  }: {
+    children?: ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button disabled={disabled} type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
 vi.mock('@lobehub/ui', async () => {
   const { Form: AntdForm } = await import('antd');
 

--- a/src/routes/(main)/settings/proxy/features/ProxyForm.tsx
+++ b/src/routes/(main)/settings/proxy/features/ProxyForm.tsx
@@ -3,7 +3,8 @@
 import { type NetworkProxySettings } from '@lobechat/electron-client-ipc';
 import { type FormGroupItemType } from '@lobehub/ui';
 import { Form, Skeleton, toast } from '@lobehub/ui';
-import { Button, Form as AntdForm, Input, Radio, Space, Switch } from 'antd';
+import { Button } from '@lobehub/ui/base-ui';
+import { Form as AntdForm, Input, Radio, Space, Switch } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 

--- a/src/routes/(main)/settings/proxy/features/SaveBar.tsx
+++ b/src/routes/(main)/settings/proxy/features/SaveBar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button } from 'antd';
+import { Button } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import { AnimatePresence, m } from 'motion/react';
 import { memo } from 'react';

--- a/src/routes/(main)/settings/skill/features/ComposioSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/ComposioSkillItem.tsx
@@ -1,17 +1,8 @@
 'use client';
 
 import { type ComposioAppType } from '@lobechat/const';
-import {
-  Avatar,
-  Button as LobeButton,
-  Center,
-  DropdownMenu,
-  Flexbox,
-  Icon,
-  Tooltip,
-} from '@lobehub/ui';
-import { confirmModal } from '@lobehub/ui/base-ui';
-import { Button } from 'antd';
+import { Avatar, Center, DropdownMenu, Flexbox, Icon, Tooltip } from '@lobehub/ui';
+import { Button, confirmModal } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import {
   CircleCheck,
@@ -306,7 +297,7 @@ const ComposioSkillItem = memo<ComposioSkillItemProps>(
             ]}
           >
             <Tooltip title={editReason}>
-              <LobeButton disabled={!canEdit} icon={MoreHorizontalIcon} />
+              <Button disabled={!canEdit} icon={MoreHorizontalIcon} />
             </Tooltip>
           </DropdownMenu>
         );
@@ -328,7 +319,7 @@ const ComposioSkillItem = memo<ComposioSkillItemProps>(
             ]}
           >
             <Tooltip title={editReason}>
-              <LobeButton disabled={!canEdit} icon={MoreHorizontalIcon} />
+              <Button disabled={!canEdit} icon={MoreHorizontalIcon} />
             </Tooltip>
           </DropdownMenu>
         );

--- a/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
+++ b/src/routes/(main)/settings/skill/features/LobehubSkillItem.tsx
@@ -1,17 +1,8 @@
 'use client';
 
 import { type LobehubSkillProviderType } from '@lobechat/const';
-import {
-  Avatar,
-  Button as LobeButton,
-  Center,
-  DropdownMenu,
-  Flexbox,
-  Icon,
-  Tooltip,
-} from '@lobehub/ui';
-import { confirmModal } from '@lobehub/ui/base-ui';
-import { Button } from 'antd';
+import { Avatar, Center, DropdownMenu, Flexbox, Icon, Tooltip } from '@lobehub/ui';
+import { Button, confirmModal } from '@lobehub/ui/base-ui';
 import { cssVar } from 'antd-style';
 import {
   CircleCheck,
@@ -283,7 +274,7 @@ const LobehubSkillItem = memo<LobehubSkillItemProps>(
           ]}
         >
           <Tooltip title={editReason}>
-            <LobeButton disabled={!canEdit} icon={MoreHorizontalIcon} />
+            <Button disabled={!canEdit} icon={MoreHorizontalIcon} />
           </Tooltip>
         </DropdownMenu>
       );

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.test.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.test.tsx
@@ -78,11 +78,9 @@ vi.mock('@lobehub/ui', () => ({
   Skeleton: () => <div data-testid="skeleton" />,
 }));
 
+// Stub the base-ui Button to a native button — it needs a MotionProvider the
+// app sets up globally but the unit env doesn't.
 vi.mock('@lobehub/ui/base-ui', () => ({
-  confirmModal: mocks.confirmModal,
-}));
-
-vi.mock('antd', () => ({
   Button: ({
     children,
     disabled,
@@ -92,10 +90,11 @@ vi.mock('antd', () => ({
     disabled?: boolean;
     onClick?: () => void;
   }) => (
-    <button disabled={disabled} onClick={onClick}>
+    <button disabled={disabled} type="button" onClick={onClick}>
       {children}
     </button>
   ),
+  confirmModal: mocks.confirmModal,
 }));
 
 vi.mock('antd-style', () => ({

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
@@ -2,8 +2,7 @@
 
 import { getLobehubSkillProviderById } from '@lobechat/const';
 import { Avatar, Markdown, Skeleton } from '@lobehub/ui';
-import { confirmModal } from '@lobehub/ui/base-ui';
-import { Button } from 'antd';
+import { Button, confirmModal } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { Plus, SquareArrowOutUpRight, Trash2, Unplug } from 'lucide-react';
@@ -22,12 +21,7 @@ import { getLocalizedBuiltinSkillDetail, getNoPermissionsTitle } from './localiz
 const AgentSkillDetail = lazy(() => import('@/features/AgentSkillDetail'));
 
 export type ToolDetailType =
-  | 'agent-skill'
-  | 'builtin'
-  | 'builtin-skill'
-  | 'lobehub-connector'
-  | 'mcp-connector'
-  | 'plugin';
+  'agent-skill' | 'builtin' | 'builtin-skill' | 'lobehub-connector' | 'mcp-connector' | 'plugin';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   description: css`


### PR DESCRIPTION
#### 💻 Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Migrate newly failing restricted `Button` and `Select` imports to `@lobehub/ui/base-ui`.
- Adapt affected base-ui `Select` usages from `Select.Option` children to the `options` API.
- Replace test-only `antd` type imports with local mock interfaces.
- Prune now-unused eslint suppression entries after the import migration.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Commands run:

```bash
npm run lint:ts
bun run check --type
git diff --check
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

This fixes the CI lint failure introduced by the stricter `@lobehub/ui` restricted import rule surfaced by newer UI package resolution.
