### PR TITLE
feat(provider): add Eden AI provider

### DIFF
--- a/docs/usage/providers/edenai.mdx
+++ b/docs/usage/providers/edenai.mdx
@@ -1,0 +1,38 @@
+---
+title: Using Eden AI API Key in LobeHub
+description: >-
+  Learn how to configure and use Eden AI in LobeHub, obtain your API key, and
+  start chatting with 100+ OpenAI-compatible models through one EU-hosted API.
+tags:
+  - LobeHub
+  - Eden AI
+  - OpenAI Compatible
+  - API Key
+  - Web UI
+---
+
+# Using Eden AI in LobeHub
+
+[Eden AI](https://www.edenai.co) provides unified, OpenAI-compatible access to 100+ models from many providers (OpenAI, Anthropic, Google, Mistral, DeepSeek, and more) through a single EU-hosted endpoint and API key. Models use the `provider/model` naming scheme (e.g. `anthropic/claude-sonnet-4-5`, `mistral/codestral-latest`).
+
+This guide will walk you through how to use Eden AI in LobeHub:
+
+<Steps>
+  ### Step 1: Get Your Eden AI API Key
+
+  - Sign up and log in to the [Eden AI platform](https://app.edenai.run).
+  - Open your account settings and create an API key.
+
+  ### Step 2: Configure Eden AI in LobeHub
+
+  - Go to `Settings` -> `AI Service Provider` and find `Eden AI`.
+  - Paste your API key into the input.
+  - Pick an Eden AI model and start chatting.
+
+  <Callout type={'info'}>
+    The default endpoint is `https://api.edenai.run/v3`. For EU-only data
+    residency you can point the proxy URL to `https://api.eu.edenai.run/v3`.
+  </Callout>
+</Steps>
+
+You can now use the models provided by Eden AI in LobeHub.

--- a/packages/env/src/llm.ts
+++ b/packages/env/src/llm.ts
@@ -24,6 +24,9 @@ export const getLLMConfig = () => {
       ENABLED_DEEPSEEK: z.boolean(),
       DEEPSEEK_API_KEY: z.string().optional(),
 
+      ENABLED_EDENAI: z.boolean(),
+      EDENAI_API_KEY: z.string().optional(),
+
       ENABLED_GOOGLE: z.boolean(),
       GOOGLE_API_KEY: z.string().optional(),
 
@@ -276,6 +279,9 @@ export const getLLMConfig = () => {
 
       ENABLED_DEEPSEEK: !!process.env.DEEPSEEK_API_KEY,
       DEEPSEEK_API_KEY: process.env.DEEPSEEK_API_KEY,
+
+      ENABLED_EDENAI: !!process.env.EDENAI_API_KEY,
+      EDENAI_API_KEY: process.env.EDENAI_API_KEY,
 
       ENABLED_GOOGLE: process.env.ENABLED_GOOGLE !== '0',
       GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,

--- a/packages/model-bank/package.json
+++ b/packages/model-bank/package.json
@@ -25,6 +25,7 @@
     "./cometapi": "./src/aiModels/cometapi.ts",
     "./comfyui": "./src/aiModels/comfyui.ts",
     "./deepseek": "./src/aiModels/deepseek.ts",
+    "./edenai": "./src/aiModels/edenai.ts",
     "./fal": "./src/aiModels/fal.ts",
     "./fireworksai": "./src/aiModels/fireworksai.ts",
     "./giteeai": "./src/aiModels/giteeai.ts",

--- a/packages/model-bank/src/aiModels/edenai.ts
+++ b/packages/model-bank/src/aiModels/edenai.ts
@@ -1,0 +1,132 @@
+import type { AIChatModelCard } from '../types/aiModel';
+
+// Eden AI is an OpenAI-compatible aggregator. Models use the `provider/model`
+// naming scheme and can also be discovered live via the model fetcher.
+// https://www.edenai.co/product/models
+const edenaiChatModels: AIChatModelCard[] = [
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      structuredOutput: true,
+    },
+    contextWindowTokens: 200_000,
+    description:
+      'Anthropic Claude Sonnet 4.5, a strong general-purpose and coding model, served through Eden AI.',
+    displayName: 'Claude Sonnet 4.5',
+    enabled: true,
+    id: 'anthropic/claude-sonnet-4-5',
+    maxOutput: 64_000,
+    pricing: {
+      currency: 'USD',
+      units: [
+        { name: 'textInput', rate: 3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 15, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      structuredOutput: true,
+    },
+    contextWindowTokens: 200_000,
+    description: 'Anthropic Claude Haiku 4.5, a fast and cost-effective model, served through Eden AI.',
+    displayName: 'Claude Haiku 4.5',
+    enabled: true,
+    id: 'anthropic/claude-haiku-4-5',
+    maxOutput: 64_000,
+    pricing: {
+      currency: 'USD',
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      structuredOutput: true,
+    },
+    contextWindowTokens: 400_000,
+    description: 'OpenAI GPT-5.1, served through Eden AI.',
+    displayName: 'GPT-5.1',
+    enabled: true,
+    id: 'openai/gpt-5.1',
+    maxOutput: 128_000,
+    pricing: {
+      currency: 'USD',
+      units: [
+        { name: 'textInput', rate: 1.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 10, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      structuredOutput: true,
+    },
+    contextWindowTokens: 400_000,
+    description: 'OpenAI GPT-5.1 Codex, optimized for coding, served through Eden AI.',
+    displayName: 'GPT-5.1 Codex',
+    id: 'openai/gpt-5.1-codex',
+    maxOutput: 128_000,
+    pricing: {
+      currency: 'USD',
+      units: [
+        { name: 'textInput', rate: 1.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 10, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+    },
+    contextWindowTokens: 256_000,
+    description: 'Mistral Codestral, optimized for code generation, served through Eden AI.',
+    displayName: 'Codestral',
+    id: 'mistral/codestral-latest',
+    maxOutput: 8192,
+    pricing: {
+      currency: 'USD',
+      units: [
+        { name: 'textInput', rate: 0.3, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.9, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      structuredOutput: true,
+    },
+    contextWindowTokens: 128_000,
+    description: 'DeepSeek V4 Pro, served through Eden AI.',
+    displayName: 'DeepSeek V4 Pro',
+    id: 'deepseek/deepseek-v4-pro',
+    maxOutput: 32_768,
+    pricing: {
+      currency: 'USD',
+      units: [
+        { name: 'textInput', rate: 0.28, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 0.42, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    type: 'chat',
+  },
+];
+
+export const allModels = [...edenaiChatModels];
+
+export default allModels;

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -20,6 +20,7 @@ import { default as cohere } from './cohere';
 import { default as cometapi } from './cometapi';
 import { default as comfyui } from './comfyui';
 import { default as deepseek } from './deepseek';
+import { default as edenai } from './edenai';
 import { default as fal } from './fal';
 import { default as fireworksai } from './fireworksai';
 import { default as giteeai } from './giteeai';
@@ -128,6 +129,7 @@ const staticModelMap: ModelsMap = {
   cometapi,
   comfyui,
   deepseek,
+  edenai,
   fal,
   fireworksai,
   giteeai,
@@ -242,6 +244,7 @@ export { default as cohere } from './cohere';
 export { default as cometapi } from './cometapi';
 export { default as comfyui } from './comfyui';
 export { default as deepseek } from './deepseek';
+export { default as edenai } from './edenai';
 export { default as fal, fluxSchnellParamsSchema } from './fal';
 export { default as fireworksai } from './fireworksai';
 export { default as giteeai } from './giteeai';

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -18,6 +18,7 @@ export enum ModelProvider {
   CometAPI = 'cometapi',
   ComfyUI = 'comfyui',
   DeepSeek = 'deepseek',
+  EdenAI = 'edenai',
   Fal = 'fal',
   FireworksAI = 'fireworksai',
   GiteeAI = 'giteeai',

--- a/packages/model-bank/src/modelProviders/edenai.ts
+++ b/packages/model-bank/src/modelProviders/edenai.ts
@@ -1,0 +1,23 @@
+import type { ModelProviderCard } from '@/types/llm';
+
+// ref: https://docs.edenai.co
+const EdenAI: ModelProviderCard = {
+  chatModels: [],
+  checkModel: 'mistral/mistral-small-latest',
+  description:
+    'Eden AI provides unified, OpenAI-compatible access to 100+ models from many providers (OpenAI, Anthropic, Google, Mistral, DeepSeek, and more) through a single EU-hosted endpoint and API key.',
+  id: 'edenai',
+  modelList: { showModelFetcher: true },
+  modelsUrl: 'https://www.edenai.co/product/models',
+  name: 'Eden AI',
+  settings: {
+    proxyUrl: {
+      placeholder: 'https://api.edenai.run/v3',
+    },
+    sdkType: 'openai',
+    showModelFetcher: true,
+  },
+  url: 'https://www.edenai.co',
+};
+
+export default EdenAI;

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -21,6 +21,7 @@ import CohereProvider from './cohere';
 import CometAPIProvider from './cometapi';
 import ComfyUIProvider from './comfyui';
 import DeepSeekProvider from './deepseek';
+import EdenAIProvider from './edenai';
 import FalProvider from './fal';
 import FireworksAIProvider from './fireworksai';
 import GiteeAIProvider from './giteeai';
@@ -94,6 +95,7 @@ export const LOBE_DEFAULT_MODEL_LIST: ChatModelCard[] = [
   ZhiPuProvider.chatModels,
   BedrockProvider.chatModels,
   DeepSeekProvider.chatModels,
+  EdenAIProvider.chatModels,
   GoogleProvider.chatModels,
   GroqProvider.chatModels,
   GithubProvider.chatModels,
@@ -149,6 +151,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   KimiCodingPlanProvider,
   OpenAIProvider,
   DeepSeekProvider,
+  EdenAIProvider,
   XinferenceProvider,
   MoonshotProvider,
   BedrockProvider,
@@ -256,6 +259,7 @@ export { default as CohereProviderCard } from './cohere';
 export { default as CometAPIProviderCard } from './cometapi';
 export { default as ComfyUIProviderCard } from './comfyui';
 export { default as DeepSeekProviderCard } from './deepseek';
+export { default as EdenAIProviderCard } from './edenai';
 export { default as FalProviderCard } from './fal';
 export { default as FireworksAIProviderCard } from './fireworksai';
 export { default as GiteeAIProviderCard } from './giteeai';

--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -46,6 +46,7 @@ export { LobeCerebrasAI } from './providers/cerebras';
 export { LobeCometAPIAI } from './providers/cometapi';
 export { LobeComfyUI } from './providers/comfyui';
 export { LobeDeepSeekAI } from './providers/deepseek';
+export { LobeEdenAIAI } from './providers/edenai';
 export { LobeGLMCodingPlanAI } from './providers/glmCodingPlan';
 export { LobeGoogleAI } from './providers/google';
 export * from './providers/google/googleModelId';

--- a/packages/model-runtime/src/providers/edenai/index.ts
+++ b/packages/model-runtime/src/providers/edenai/index.ts
@@ -1,0 +1,16 @@
+import { ModelProvider } from 'model-bank';
+
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+
+/**
+ * Eden AI (https://www.edenai.co) is an OpenAI-compatible aggregator that
+ * exposes 100+ models from many providers through a single EU-hosted endpoint
+ * and API key. Models use the `provider/model` naming scheme.
+ */
+export const LobeEdenAIAI = createOpenAICompatibleRuntime({
+  baseURL: 'https://api.edenai.run/v3',
+  debug: {
+    chatCompletion: () => process.env.DEBUG_EDENAI_CHAT_COMPLETION === '1',
+  },
+  provider: ModelProvider.EdenAI,
+});

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -17,6 +17,7 @@ import { LobeCohereAI } from './providers/cohere';
 import { LobeCometAPIAI } from './providers/cometapi';
 import { LobeComfyUI } from './providers/comfyui';
 import { LobeDeepSeekAI } from './providers/deepseek';
+import { LobeEdenAIAI } from './providers/edenai';
 import { LobeFalAI } from './providers/fal';
 import { LobeFireworksAI } from './providers/fireworksai';
 import { LobeGiteeAI } from './providers/giteeai';
@@ -100,6 +101,7 @@ export const providerRuntimeMap = {
   cometapi: LobeCometAPIAI,
   comfyui: LobeComfyUI,
   deepseek: LobeDeepSeekAI,
+  edenai: LobeEdenAIAI,
   fal: LobeFalAI,
   fireworksai: LobeFireworksAI,
   giteeai: LobeGiteeAI,


### PR DESCRIPTION
## 💻 Changes

Adds **Eden AI** (https://www.edenai.co) as a built-in provider. Eden AI is an OpenAI-compatible aggregator that exposes 100+ models from many providers (OpenAI, Anthropic, Google, Mistral, DeepSeek, xAI, …) through a single EU-hosted endpoint and one API key. Models use the `provider/model` naming scheme.

Follows the existing OpenAI-compatible provider pattern (OpenRouter/DeepSeek):

- `ModelProvider.EdenAI` enum entry
- `modelProviders/edenai.ts` provider card (`sdkType: 'openai'`, proxy URL `https://api.edenai.run/v3`, model fetcher enabled)
- `aiModels/edenai.ts` curated model list + `package.json` `exports` entry
- `model-runtime` provider (`createOpenAICompatibleRuntime`) + `runtimeMap` wiring + export
- `EDENAI_API_KEY` env wiring (`packages/env`)
- docs page (`docs/usage/providers/edenai.mdx`)

## 📝 Additional Info

- Eden AI is fully OpenAI-compatible, so the runtime reuses the standard OpenAI-compatible factory — no bespoke request handling.
- API key is read from `EDENAI_API_KEY` (or entered in the UI); never hardcoded.
- Base URL defaults to `https://api.edenai.run/v3`; an EU-only endpoint is available at `https://api.eu.edenai.run/v3`.

Verified locally: `model-bank` type-checks clean, `exports.test.ts` + `modelProviders/index.test.ts` pass, and the enum/runtime/`providerRuntimeMap` wiring is covered by a smoke check. The Eden AI endpoint was verified live (`/v3/chat/completions` and `/v3/models` both 200).
