### PR TITLE
🐛 fix(test): avoid optional builder context access

### DIFF
--- a/src/store/agent/selectors/agentByIdSelectors.test.ts
+++ b/src/store/agent/selectors/agentByIdSelectors.test.ts
@@ -79,7 +79,7 @@ describe('agentByIdSelectors', () => {
 
       const context = agentByIdSelectors.getAgentBuilderContextById('agent-1')(state);
 
-      expect(context.config.plugins).toEqual(['search']);
+      expect(context.config).toMatchObject({ plugins: ['search'] });
     });
   });
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up for CI failure after #16936.

#### 🔀 Description of Change

- Update the `agentByIdSelectors` regression test to assert `context.config` with `toMatchObject` instead of directly dereferencing `context.config.plugins`.
- Fixes `TS18048: 'context.config' is possibly 'undefined'` during `tsgo --noEmit` while preserving the disabled-plugin filtering assertion.

#### 🧪 How to Test

```bash
bun run check --type src/store/agent/selectors/agentByIdSelectors.test.ts
bun run check src/store/agent/selectors/agentByIdSelectors.test.ts
```

#### 📝 Additional Information

Root cause: `AgentBuilderContext.config` is typed as optional, so direct property access in the test failed type-check even though the selector currently returns a config object.