### PR TITLE
⚡️ perf(swr): persist activeScopeKey for parallel cache hydration (instant-open gate)

### DIFF
--- a/src/layout/GlobalProvider/CacheHydrationGate.test.tsx
+++ b/src/layout/GlobalProvider/CacheHydrationGate.test.tsx
@@ -8,37 +8,13 @@ import CacheHydrationGate from './CacheHydrationGate';
 
 // --- controllable inputs -----------------------------------------------------
 let mockScope = 'anon:personal';
-let mockIsAuthLoaded = true;
-let mockIsSignedIn = true;
-let mockUserId: string | undefined = 'u1';
-let mockIsDesktop = false;
 
 vi.mock('@/libs/swr/useCacheScope', () => ({
   useCacheScope: () => mockScope,
 }));
 
-vi.mock('@/store/user', () => ({
-  useUserStore: (selector: (s: any) => unknown) =>
-    selector({
-      isLoaded: mockIsAuthLoaded,
-      isSignedIn: mockIsSignedIn,
-      user: { id: mockUserId },
-    }),
-}));
-
-vi.mock('@/store/user/selectors', () => ({
-  authSelectors: { isLoaded: (s: any) => s.isLoaded, isLogin: (s: any) => s.isSignedIn },
-  userProfileSelectors: { userId: (s: any) => s.user?.id },
-}));
-
 vi.mock('@/libs/bootTiming', () => ({
   bootTiming: { mark: vi.fn() },
-}));
-
-vi.mock('@lobechat/const', () => ({
-  get isDesktop() {
-    return mockIsDesktop;
-  },
 }));
 
 const ALL_SCOPES = ['anon:personal', 'u1:personal', 'u2:personal'];
@@ -55,10 +31,6 @@ const renderGate = () =>
 
 beforeEach(() => {
   mockScope = 'anon:personal';
-  mockIsAuthLoaded = true;
-  mockIsSignedIn = true;
-  mockUserId = 'u1';
-  mockIsDesktop = false;
   resetHydration();
   // A loading-screen node so the gate's removal side-effect has a target.
   const el = document.createElement('div');
@@ -74,7 +46,7 @@ afterEach(() => {
 });
 
 describe('CacheHydrationGate', () => {
-  it('blocks first paint (renders nothing) until the initial scope is ready', () => {
+  it('blocks first paint (renders nothing) until the active scope is hydrated', () => {
     renderGate();
     // not ready yet → blocked
     expect(screen.queryByTestId('app')).toBeNull();
@@ -96,173 +68,42 @@ describe('CacheHydrationGate', () => {
     });
     expect(screen.queryByTestId('app')).not.toBeNull();
 
-    // Simulate login: scope flips to the signed-in user, whose cache is NOT yet
-    // hydrated (markPending / never marked ready). The old key={scope} remount
-    // would blank the whole tree here.
+    // Simulate the session resolving a different scope whose cache is NOT yet
+    // hydrated. The old key={scope} remount would blank the whole tree here.
     act(() => {
       mockScope = 'u1:personal';
       cacheHydration.markPending('u1:personal'); // new scope not ready
-      // force a re-render through the hydration store subscription
-      cacheHydration.markReady('anon:personal');
+      cacheHydration.markReady('anon:personal'); // force a re-render via the store
     });
 
-    // App stays mounted throughout the scope change — this is the invariant that
-    // prevents the reported full-screen white flash on login.
+    // App stays mounted throughout the scope change.
     expect(screen.queryByTestId('app')).not.toBeNull();
 
-    // Even after the new scope finishes hydrating, still mounted (never blanked).
     act(() => {
       cacheHydration.markReady('u1:personal');
     });
     expect(screen.queryByTestId('app')).not.toBeNull();
   });
 
-  it('first paint waits for userId to resolve (signed-in) even when cache is ready', () => {
-    mockUserId = undefined;
-    renderGate();
-
-    act(() => {
-      cacheHydration.markReady('anon:personal');
-    });
-    // cache ready + auth loaded + signed in, but identity round-trip not done → blocked
-    expect(screen.queryByTestId('app')).toBeNull();
-
-    // Resolve identity and drive a genuine hydration snapshot change so the gate
-    // re-renders and re-evaluates the release condition.
-    act(() => {
-      mockUserId = 'u1';
-      cacheHydration.markPending('anon:personal'); // ready: true → false (re-render, still !ready)
-    });
-    expect(screen.queryByTestId('app')).toBeNull();
-
-    act(() => {
-      cacheHydration.markReady('anon:personal'); // ready: false → true → release
-    });
-    expect(screen.queryByTestId('app')).not.toBeNull();
-  });
-
-  it('timeout backstop releases the app once identity is resolved even if cache never hydrates', () => {
-    vi.useFakeTimers();
-    mockUserId = 'u1';
-    // cache scope is never marked ready
+  it('releases the moment the active scope is ready — no identity round-trip wait', () => {
+    // The persisted activeScopeKey means the hydrated scope is already the real
+    // user partition, so the gate must not wait for auth/userId — only `ready`.
     renderGate();
     expect(screen.queryByTestId('app')).toBeNull();
 
-    act(() => {
-      vi.advanceTimersByTime(1500);
-    });
-    expect(screen.queryByTestId('app')).not.toBeNull();
-  });
-
-  it('REGRESSION: signed-in desktop stays blocked past the timeout when userId is unresolved', () => {
-    vi.useFakeTimers();
-    mockIsDesktop = true;
-    mockUserId = undefined;
-    renderGate();
-    expect(screen.queryByTestId('app')).toBeNull();
-
-    // The old behavior released into the anonymous scope here — orphaning any
-    // data fetched under it. The userId guard now precedes the timeout backstop.
-    act(() => {
-      vi.advanceTimersByTime(1500);
-    });
-    expect(screen.queryByTestId('app')).toBeNull();
-    expect(document.getElementById('loading-screen')).not.toBeNull();
-
-    // Identity resolves later (incl. via SWR focus/reconnect revalidation) → release.
-    act(() => {
-      mockUserId = 'u1';
-      cacheHydration.markReady('anon:personal');
-    });
-    expect(screen.queryByTestId('app')).not.toBeNull();
-  });
-
-  it('releases desktop onboarding without waiting for userId', () => {
-    vi.useFakeTimers();
-    window.history.replaceState(null, '', '/desktop-onboarding');
-    mockIsDesktop = true;
-    mockIsSignedIn = false;
-    mockUserId = undefined;
-    renderGate();
-
-    act(() => {
-      vi.advanceTimersByTime(1500);
-    });
-
-    expect(screen.queryByTestId('app')).not.toBeNull();
-    expect(document.getElementById('loading-screen')).toBeNull();
-  });
-
-  it('REGRESSION: signed-in web stays blocked past the timeout when userId is unresolved', () => {
-    vi.useFakeTimers();
-    mockIsSignedIn = true;
-    mockUserId = undefined;
-    renderGate();
-
-    act(() => {
-      vi.advanceTimersByTime(1500);
-    });
-    expect(screen.queryByTestId('app')).toBeNull();
-
-    act(() => {
-      mockUserId = 'u1';
-      cacheHydration.markReady('anon:personal');
-    });
-    expect(screen.queryByTestId('app')).not.toBeNull();
-  });
-
-  it('P1 FIX: no-auth / logged-out web is NOT blocked on userId — releases once ready', () => {
-    mockIsSignedIn = false; // no session (no-auth deployment, or logged out)
-    mockUserId = undefined; // and no userId will ever arrive
-    renderGate();
-
-    // No userId gate applies → only the cache-ready condition remains.
     act(() => {
       cacheHydration.markReady('anon:personal');
     });
     expect(screen.queryByTestId('app')).not.toBeNull();
   });
 
-  it('P1 FIX: no-auth / logged-out web releases via the timeout even if cache never hydrates', () => {
+  it('timeout backstop releases the app even if hydration never becomes ready', () => {
     vi.useFakeTimers();
-    mockIsSignedIn = false;
-    mockUserId = undefined;
     renderGate();
     expect(screen.queryByTestId('app')).toBeNull();
 
     act(() => {
       vi.advanceTimersByTime(1500);
-    });
-    expect(screen.queryByTestId('app')).not.toBeNull();
-  });
-
-  it('does not treat a stale isSignedIn as final while auth is still loading', () => {
-    // Auth mid-load: isSignedIn is not yet trustworthy. Must not release into
-    // anon via timeout before the session resolves.
-    vi.useFakeTimers();
-    mockIsAuthLoaded = false;
-    mockIsSignedIn = false;
-    mockUserId = undefined;
-    renderGate();
-
-    act(() => {
-      vi.advanceTimersByTime(1500);
-    });
-    expect(screen.queryByTestId('app')).toBeNull();
-
-    // Session resolves to signed-in → now a userId is expected → keep blocking until it lands.
-    act(() => {
-      mockIsAuthLoaded = true;
-      mockIsSignedIn = true;
-      cacheHydration.markReady('anon:personal'); // false→true snapshot change → re-render
-    });
-    expect(screen.queryByTestId('app')).toBeNull();
-
-    // userId resolves → release. (markPending forces a re-render that reads the
-    // updated mockUserId; the mock store itself doesn't notify.)
-    act(() => {
-      mockUserId = 'u1';
-      cacheHydration.markPending('anon:personal'); // true→false snapshot change → re-render
     });
     expect(screen.queryByTestId('app')).not.toBeNull();
   });

--- a/src/layout/GlobalProvider/CacheHydrationGate.tsx
+++ b/src/layout/GlobalProvider/CacheHydrationGate.tsx
@@ -1,14 +1,11 @@
 'use client';
 
-import { isDesktop } from '@lobechat/const';
 import type { PropsWithChildren } from 'react';
 import { useEffect, useLayoutEffect, useState, useSyncExternalStore } from 'react';
 
 import { bootTiming } from '@/libs/bootTiming';
 import { cacheHydration } from '@/libs/swr/cacheHydration';
 import { useCacheScope } from '@/libs/swr/useCacheScope';
-import { useUserStore } from '@/store/user';
-import { authSelectors, userProfileSelectors } from '@/store/user/selectors';
 
 // first-write-wins: only the very first paint records the boot timing mark.
 let firstPaintMarked = false;
@@ -16,36 +13,26 @@ let firstPaintMarked = false;
 const HYDRATION_TIMEOUT = 1500;
 
 /**
- * Blocks the first paint until the initial identity scope's IndexedDB cache has
- * hydrated, so the app never flashes empty on cold boot — the static
- * `loading-screen` overlay covers exactly this window.
+ * Blocks the first paint until the active scope's IndexedDB cache has hydrated,
+ * so the app never flashes empty on cold boot — the static `loading-screen`
+ * overlay covers exactly this window.
  *
  * This is a one-way latch: once released it never blanks again. A later scope
  * change (anonymous → signed-in, or workspace switch) re-hydrates the SWR cache
  * *in place* via `Query.tsx`'s `reloadScope()`, keeping the current tree mounted
- * while the new scope's data swaps in underneath. Re-blocking here (as the old
- * `key={scope}` remount did) would unmount the whole app and expose a
- * full-screen white flash on login.
+ * while the new scope's data swaps in underneath.
  *
- * The first paint additionally waits for a real `userId` — but only where one
- * is expected, i.e. where the identity round-trip actually runs: normal desktop
- * app paths (which resolve a `DESKTOP_USER` id) or a signed-in web session. The
- * anonymous scope is only ever a transient pre-identity boot state, so painting
- * under it would persist fetched data into the `anon` partition and orphan it
- * the moment the real scope resolves (the stale-loading cache-miss bug).
- * Blocking until `userId` lands closes that leak at the root: no data UI ever
- * mounts under the anonymous scope. A no-auth / logged-out web deployment has
- * no `userId` to wait for, so it is exempt and falls through to the
- * timeout/ready backstop. `initState` revalidates on focus/reconnect, so a
- * transient network failure self-heals into a release.
+ * The active scope is known synchronously at boot from the persisted
+ * `activeScopeKey` (the last-known `${userId}:${workspace}`), so the provider
+ * hydrates the *real* user partition in parallel with the session check — the
+ * gate only waits for that hydration (`ready`), not for the identity
+ * round-trip. That parallelism is what restores instant-from-cache first paint.
+ * Writes made before the session confirms the scope are quarantined by the
+ * cache provider (`isEphemeralScope`), so the optimistic window can't orphan or
+ * pollute a partition. The 1500ms timeout is a pure hung-hydration backstop.
  */
 const CacheHydrationGate = ({ children }: PropsWithChildren) => {
   const scope = useCacheScope();
-  const isAuthLoaded = Boolean(useUserStore(authSelectors.isLoaded));
-  const isSignedIn = useUserStore(authSelectors.isLogin);
-  const userId = useUserStore(userProfileSelectors.userId);
-  const isDesktopOnboarding =
-    typeof window !== 'undefined' && window.location.pathname.startsWith('/desktop-onboarding');
 
   const ready = useSyncExternalStore(
     cacheHydration.subscribe,
@@ -65,28 +52,11 @@ const CacheHydrationGate = ({ children }: PropsWithChildren) => {
 
   useEffect(() => {
     if (released) return;
-
-    // A userId is expected only where the identity round-trip runs (desktop or a
-    // signed-in web session — the same condition that triggers `useInitUserState`).
-    // No-auth / logged-out web never produces one, so it must not be blocked here.
-    // Guard on `isAuthLoaded` so we don't act on a stale `isSignedIn` mid-load.
-    if (isAuthLoaded && ((isDesktop && !isDesktopOnboarding) || isSignedIn) && !userId) return;
-
-    // Block until the session check resolves (it always does — success, failure,
-    // or no-auth — so this isn't an infinite hang). Preceding the timeout means a
-    // slow session can't release into the anonymous scope.
-    if (!isAuthLoaded) return;
-
-    // Backstop: identity resolved, but cache hydration is hung — release rather
-    // than hang. Safe because a userId is either present or not expected here.
-    if (timedOut) {
-      setReleased(true);
-      return;
-    }
-    if (!ready) return;
-
-    setReleased(true);
-  }, [isAuthLoaded, isDesktopOnboarding, isSignedIn, userId, ready, released, timedOut]);
+    // Release the moment the active scope's cache has hydrated — the persisted
+    // activeScopeKey means that's already the real user partition, so this paints
+    // straight from cache. The timeout backstop guards a hung hydration only.
+    if (ready || timedOut) setReleased(true);
+  }, [ready, timedOut, released]);
 
   useLayoutEffect(() => {
     if (!released) return;

--- a/src/libs/swr/localStorageProvider.ts
+++ b/src/libs/swr/localStorageProvider.ts
@@ -26,7 +26,7 @@
 import { bootTiming } from '@/libs/bootTiming';
 
 import { buildLocalDataKey, localDataCache } from './localDataCache';
-import { isAnonymousScope } from './useCacheScope';
+import { isScopeTrusted } from './useCacheScope';
 
 interface CacheEntry<T = unknown> {
   /** Cached data */
@@ -510,16 +510,15 @@ export const swrCacheProvider = (
   return createCacheProvider({
     getScope,
     idbPatterns: [...CACHE_TIERS.idb],
-    // Desktop's anonymous scope is a transient pre-identity boot state (a
-    // successful `getUserState` always resolves a real `userId`), so quarantine
-    // its writes from persistence — otherwise a slow identity round-trip lets
-    // real data land in the `anon` partition and get orphaned on the scope flip.
-    // The anonymous scope is only ever a transient pre-identity boot state —
-    // quarantine its writes from persistence so a slow identity round-trip
-    // can't land real data in the `anon` partition and orphan it on the scope
-    // flip. (The CacheHydrationGate now blocks paint until `userId` resolves, so
-    // this is defense-in-depth for any fetcher that mounts outside the gate.)
-    isEphemeralScope: isAnonymousScope,
+    // Quarantine writes until the session check resolves (`isScopeTrusted`).
+    // The active scope is optimistic (persisted last-known user) before the
+    // session confirms it, so a write made then could land in the wrong
+    // partition on an account switch / first-ever boot and get orphaned. Once the
+    // session resolves the scope is definitive and writes persist — including
+    // no-auth, where the check completes to "not signed in" and the anonymous
+    // scope is a legitimate durable context. `reloadScope` clears the dirty set
+    // on a real scope flip, so quarantined writes never survive a switch.
+    isEphemeralScope: () => !isScopeTrusted(),
     localPatterns: [...CACHE_TIERS.local],
     onScopeHydrated,
     // Governs the localStorage tier only (recents-style shells); the IndexedDB

--- a/src/libs/swr/useCacheScope.test.ts
+++ b/src/libs/swr/useCacheScope.test.ts
@@ -10,10 +10,21 @@ import {
 
 let mockUserId: string | null | undefined = undefined;
 let mockIsAuthLoaded = false;
+let mockIsUserStateInit = false;
 let mockWorkspaceId: string | null = null;
+let mockIsDesktop = false;
 
+vi.mock('@lobechat/const', () => ({
+  get isDesktop() {
+    return mockIsDesktop;
+  },
+}));
 vi.mock('@/store/user', () => ({
-  getUserStoreState: () => ({ user: { id: mockUserId }, isLoaded: mockIsAuthLoaded }),
+  getUserStoreState: () => ({
+    isLoaded: mockIsAuthLoaded,
+    isUserStateInit: mockIsUserStateInit,
+    user: { id: mockUserId },
+  }),
 }));
 vi.mock('@/store/user/selectors', () => ({
   authSelectors: { isLoaded: (s: any) => s.isLoaded },
@@ -53,7 +64,9 @@ describe('activeScopeKey + optimistic scope', () => {
     localStorage.clear();
     mockUserId = undefined;
     mockIsAuthLoaded = false;
+    mockIsUserStateInit = false;
     mockWorkspaceId = null;
+    mockIsDesktop = false;
   });
 
   afterEach(() => {
@@ -77,6 +90,22 @@ describe('activeScopeKey + optimistic scope', () => {
     expect(getCacheScope()).toBe('user_real:w2');
   });
 
+  it('getCacheScope ignores the persisted scope once the session resolves signed-out', () => {
+    // expired cookie / sign-out in another tab: session settled, but no user
+    localStorage.setItem('lobehub:active-scope', 'user_abc:w1');
+    mockIsAuthLoaded = true;
+    expect(getCacheScope()).toBe('anon:personal');
+  });
+
+  it('getCacheScope keeps the persisted scope on desktop until user state initializes', () => {
+    // desktop hardcodes isLoaded=true on mount; userId lands with useInitUserState
+    localStorage.setItem('lobehub:active-scope', 'user_abc:w1');
+    mockIsDesktop = true;
+    mockIsAuthLoaded = true;
+    mockIsUserStateInit = false;
+    expect(getCacheScope()).toBe('user_abc:w1');
+  });
+
   it('clearActiveScopeKey removes the persisted scope (logout)', () => {
     localStorage.setItem('lobehub:active-scope', 'user_abc:personal');
     clearActiveScopeKey();
@@ -89,6 +118,8 @@ describe('activeScopeKey + optimistic scope', () => {
 describe('isScopeTrusted', () => {
   beforeEach(() => {
     mockIsAuthLoaded = false;
+    mockIsUserStateInit = false;
+    mockIsDesktop = false;
   });
 
   it('is untrusted while the session check is in flight', () => {
@@ -98,6 +129,20 @@ describe('isScopeTrusted', () => {
 
   it('is trusted once the session check resolves (covers both signed-in and no-auth)', () => {
     mockIsAuthLoaded = true;
+    expect(isScopeTrusted()).toBe(true);
+  });
+
+  it('on desktop, is untrusted until user state initializes even though isLoaded is true', () => {
+    mockIsDesktop = true;
+    mockIsAuthLoaded = true;
+    mockIsUserStateInit = false;
+    expect(isScopeTrusted()).toBe(false);
+  });
+
+  it('on desktop, is trusted once user state initializes', () => {
+    mockIsDesktop = true;
+    mockIsAuthLoaded = true;
+    mockIsUserStateInit = true;
     expect(isScopeTrusted()).toBe(true);
   });
 });

--- a/src/libs/swr/useCacheScope.test.ts
+++ b/src/libs/swr/useCacheScope.test.ts
@@ -1,6 +1,28 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { buildCacheScope } from './useCacheScope';
+import {
+  buildCacheScope,
+  clearActiveScopeKey,
+  getCacheScope,
+  isAnonymousScope,
+  isScopeTrusted,
+} from './useCacheScope';
+
+let mockUserId: string | null | undefined = undefined;
+let mockIsAuthLoaded = false;
+let mockWorkspaceId: string | null = null;
+
+vi.mock('@/store/user', () => ({
+  getUserStoreState: () => ({ user: { id: mockUserId }, isLoaded: mockIsAuthLoaded }),
+}));
+vi.mock('@/store/user/selectors', () => ({
+  authSelectors: { isLoaded: (s: any) => s.isLoaded },
+  userProfileSelectors: { userId: (s: any) => s.user?.id },
+}));
+vi.mock('@/business/client/hooks/useActiveWorkspaceId', () => ({
+  getActiveWorkspaceId: () => mockWorkspaceId,
+  useActiveWorkspaceId: () => mockWorkspaceId,
+}));
 
 describe('buildCacheScope', () => {
   it('falls back to anon/personal', () => {
@@ -16,5 +38,66 @@ describe('buildCacheScope', () => {
   it('isolates different users and workspaces', () => {
     expect(buildCacheScope('u1', 'w1')).not.toBe(buildCacheScope('u2', 'w1'));
     expect(buildCacheScope('u1', 'w1')).not.toBe(buildCacheScope('u1', 'w2'));
+  });
+});
+
+describe('isAnonymousScope', () => {
+  it('matches the anon partition only', () => {
+    expect(isAnonymousScope('anon:personal')).toBe(true);
+    expect(isAnonymousScope('u1:personal')).toBe(false);
+  });
+});
+
+describe('activeScopeKey + optimistic scope', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockUserId = undefined;
+    mockIsAuthLoaded = false;
+    mockWorkspaceId = null;
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('getCacheScope falls back to anon when no userId and no persisted scope (first-ever boot)', () => {
+    expect(getCacheScope()).toBe('anon:personal');
+  });
+
+  it('getCacheScope returns the persisted activeScopeKey optimistically when userId is unresolved', () => {
+    localStorage.setItem('lobehub:active-scope', 'user_abc:w1');
+    // userId still unresolved — but we hydrate the last-known user partition
+    expect(getCacheScope()).toBe('user_abc:w1');
+  });
+
+  it('getCacheScope prefers the real resolved scope over the persisted one', () => {
+    localStorage.setItem('lobehub:active-scope', 'user_abc:w1');
+    mockUserId = 'user_real';
+    mockWorkspaceId = 'w2';
+    expect(getCacheScope()).toBe('user_real:w2');
+  });
+
+  it('clearActiveScopeKey removes the persisted scope (logout)', () => {
+    localStorage.setItem('lobehub:active-scope', 'user_abc:personal');
+    clearActiveScopeKey();
+    expect(localStorage.getItem('lobehub:active-scope')).toBeNull();
+    // → next getCacheScope (userId unresolved) falls back to anon
+    expect(getCacheScope()).toBe('anon:personal');
+  });
+});
+
+describe('isScopeTrusted', () => {
+  beforeEach(() => {
+    mockIsAuthLoaded = false;
+  });
+
+  it('is untrusted while the session check is in flight', () => {
+    mockIsAuthLoaded = false;
+    expect(isScopeTrusted()).toBe(false);
+  });
+
+  it('is trusted once the session check resolves (covers both signed-in and no-auth)', () => {
+    mockIsAuthLoaded = true;
+    expect(isScopeTrusted()).toBe(true);
   });
 });

--- a/src/libs/swr/useCacheScope.ts
+++ b/src/libs/swr/useCacheScope.ts
@@ -1,12 +1,59 @@
+import { useEffect, useState } from 'react';
+
 import {
   getActiveWorkspaceId,
   useActiveWorkspaceId,
 } from '@/business/client/hooks/useActiveWorkspaceId';
 import { getUserStoreState, useUserStore } from '@/store/user';
-import { userProfileSelectors } from '@/store/user/selectors';
+import { authSelectors, userProfileSelectors } from '@/store/user/selectors';
 
 const ANON = 'anon';
 const PERSONAL = 'personal';
+
+/**
+ * localStorage key holding the last-known resolved cache scope
+ * (`${userId}:${workspaceId}`). On a cold boot the identity round-trip hasn't
+ * resolved yet, so we can't know which user partition to hydrate — reading this
+ * synchronously lets us hydrate the *real* user's IndexedDB cache in parallel
+ * with the session check, instead of the empty anonymous partition and only
+ * re-hydrating after the session resolves. That parallelism is what restores
+ * instant-from-cache first paint (the #10884 synchronous-cache behavior the
+ * async IndexedDB tier in #15844 lost).
+ */
+const ACTIVE_SCOPE_STORAGE_KEY = 'lobehub:active-scope';
+
+const isBrowser = () => typeof localStorage !== 'undefined';
+
+const readActiveScope = (): string | null => {
+  if (!isBrowser()) return null;
+  try {
+    return localStorage.getItem(ACTIVE_SCOPE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+const writeActiveScope = (scope: string): void => {
+  if (!isBrowser()) return;
+  try {
+    localStorage.setItem(ACTIVE_SCOPE_STORAGE_KEY, scope);
+  } catch {
+    // best-effort
+  }
+};
+
+/**
+ * Drop the persisted active scope. Call on logout / sign-out so the next boot
+ * doesn't hydrate a since-logged-out user's cache.
+ */
+export const clearActiveScopeKey = (): void => {
+  if (!isBrowser()) return;
+  try {
+    localStorage.removeItem(ACTIVE_SCOPE_STORAGE_KEY);
+  } catch {
+    // best-effort
+  }
+};
 
 /**
  * Build a cache scope string from the current identity.
@@ -17,7 +64,7 @@ const PERSONAL = 'personal';
  * never collides or overwrites each other.
  *
  * Personal mode (no active workspace) collapses to `${userId}:personal`;
- * logged-out / SSR collapses to `anon:personal`.
+ * logged-out / SSR / first-ever boot collapses to `anon:personal`.
  */
 export const buildCacheScope = (
   userId: string | null | undefined,
@@ -26,27 +73,66 @@ export const buildCacheScope = (
 
 /**
  * Whether a scope belongs to the anonymous (identity-unresolved) partition.
- *
- * The anonymous scope is only ever a transient pre-identity boot state — once
- * auth resolves, every signed-in user has a real `userId` — so it is never a
- * durable identity and its writes must not be persisted (see the cache
- * provider's `isEphemeralScope`).
  */
 export const isAnonymousScope = (scope: string): boolean => scope.startsWith(`${ANON}:`);
 
 /**
+ * The effective cache scope for the *current* moment.
+ *
+ * - Identity resolved (`userId` known): the real scope `${userId}:${workspace}`.
+ * - Identity unresolved (cold boot, session check in flight): the persisted
+ *   `activeScopeKey` (last-known user) so the cache provider hydrates the right
+ *   partition up front — falling back to `anon:personal` only on a first-ever
+ *   boot with no persisted scope.
+ */
+const resolveScope = (
+  userId: string | null | undefined,
+  workspaceId: string | null | undefined,
+  persisted: string | null,
+): string => {
+  if (userId) return buildCacheScope(userId, workspaceId);
+  return persisted ?? buildCacheScope(undefined, undefined);
+};
+
+/**
  * React hook returning the current cache scope. Recomputes when the signed-in
- * user or the active workspace changes.
+ * user or the active workspace changes. Persists every resolved real (non-anon)
+ * scope so the next cold boot can hydrate it in parallel with the session check.
  */
 export const useCacheScope = (): string => {
   const userId = useUserStore(userProfileSelectors.userId);
   const workspaceId = useActiveWorkspaceId();
-  return buildCacheScope(userId, workspaceId);
+  // Read once on mount — the persisted key only matters before identity resolves.
+  const [persisted] = useState(readActiveScope);
+
+  const scope = resolveScope(userId, workspaceId, persisted);
+
+  useEffect(() => {
+    if (userId && !isAnonymousScope(scope)) writeActiveScope(scope);
+  }, [scope, userId]);
+
+  return scope;
 };
 
 /**
  * Non-React getter for the current cache scope (for use inside services /
- * imperative code paths).
+ * imperative code paths, and the SWR cache provider's `getScope`).
  */
 export const getCacheScope = (): string =>
-  buildCacheScope(userProfileSelectors.userId(getUserStoreState()), getActiveWorkspaceId());
+  resolveScope(
+    userProfileSelectors.userId(getUserStoreState()),
+    getActiveWorkspaceId(),
+    readActiveScope(),
+  );
+
+/**
+ * Whether the current scope has been confirmed by a resolved session.
+ *
+ * Until the auth/session check completes, the scope is the optimistic persisted
+ * one (or anon) — writes made then are quarantined (see the cache provider's
+ * `isEphemeralScope`) so an account switch / first-ever boot can't pollute or
+ * orphan a partition. Once the session resolves, writes persist normally (this
+ * also covers no-auth: the session check completes to "not signed in", and the
+ * anonymous scope is a legitimate durable context there).
+ */
+export const isScopeTrusted = (): boolean => Boolean(authSelectors.isLoaded(getUserStoreState()));

--- a/src/libs/swr/useCacheScope.ts
+++ b/src/libs/swr/useCacheScope.ts
@@ -1,10 +1,11 @@
+import { isDesktop } from '@lobechat/const';
 import { useEffect, useState } from 'react';
 
 import {
   getActiveWorkspaceId,
   useActiveWorkspaceId,
 } from '@/business/client/hooks/useActiveWorkspaceId';
-import { getUserStoreState, useUserStore } from '@/store/user';
+import { getUserStoreState, type UserStore, useUserStore } from '@/store/user';
 import { authSelectors, userProfileSelectors } from '@/store/user/selectors';
 
 const ANON = 'anon';
@@ -77,20 +78,45 @@ export const buildCacheScope = (
 export const isAnonymousScope = (scope: string): boolean => scope.startsWith(`${ANON}:`);
 
 /**
+ * Whether the identity round-trip has landed, i.e. `userId` is now known to be
+ * either a real id or genuinely absent.
+ *
+ * The signal differs per deployment, and `isLoaded` alone is *not* it:
+ *
+ * - Web (Better-Auth): `isLoaded` flips when the session request settles, at
+ *   which point `user` is populated (or confirmed empty). It is the signal.
+ * - Desktop: `DesktopAuthProvider` hardcodes `isLoaded` to `true` on mount
+ *   because the server trusts `DESKTOP_USER_ID`, but `userId` only lands when
+ *   the async `useInitUserState` fetch resolves. `isUserStateInit` is the
+ *   signal there; using `isLoaded` would declare the anonymous boot scope
+ *   trustworthy and let that window's writes orphan into the `anon` partition.
+ * - No-auth self-host: `isLoaded` is `true` on mount and `useInitUserState`
+ *   never runs, so `userId` stays undefined forever and `anon` is the real,
+ *   durable scope. `isDesktop` is false there, so `isLoaded` applies.
+ */
+const isIdentityResolved = (s: UserStore): boolean =>
+  isDesktop ? s.isUserStateInit : Boolean(authSelectors.isLoaded(s));
+
+/**
  * The effective cache scope for the *current* moment.
  *
- * - Identity resolved (`userId` known): the real scope `${userId}:${workspace}`.
- * - Identity unresolved (cold boot, session check in flight): the persisted
- *   `activeScopeKey` (last-known user) so the cache provider hydrates the right
- *   partition up front — falling back to `anon:personal` only on a first-ever
- *   boot with no persisted scope.
+ * - Identity resolved, `userId` known: the real scope `${userId}:${workspace}`.
+ * - Identity unresolved (cold boot, identity round-trip in flight): the
+ *   persisted `activeScopeKey` (last-known user) so the cache provider hydrates
+ *   the right partition up front — falling back to `anon:personal` only on a
+ *   first-ever boot with no persisted scope.
+ * - Identity resolved, no `userId` (expired cookie, sign-out in another tab,
+ *   no-auth): `anon:personal`. The persisted scope must be ignored here or a
+ *   logged-out visitor keeps reading and writing the previous user's partition.
  */
 const resolveScope = (
   userId: string | null | undefined,
   workspaceId: string | null | undefined,
   persisted: string | null,
+  identityResolved: boolean,
 ): string => {
   if (userId) return buildCacheScope(userId, workspaceId);
+  if (identityResolved) return buildCacheScope(undefined, undefined);
   return persisted ?? buildCacheScope(undefined, undefined);
 };
 
@@ -101,15 +127,20 @@ const resolveScope = (
  */
 export const useCacheScope = (): string => {
   const userId = useUserStore(userProfileSelectors.userId);
+  const identityResolved = useUserStore(isIdentityResolved);
   const workspaceId = useActiveWorkspaceId();
   // Read once on mount — the persisted key only matters before identity resolves.
   const [persisted] = useState(readActiveScope);
 
-  const scope = resolveScope(userId, workspaceId, persisted);
+  const scope = resolveScope(userId, workspaceId, persisted, identityResolved);
 
   useEffect(() => {
     if (userId && !isAnonymousScope(scope)) writeActiveScope(scope);
-  }, [scope, userId]);
+    // The identity round-trip landed on "nobody": the persisted scope belongs to
+    // a session that is no longer valid, so drop it rather than let the next
+    // boot optimistically hydrate it again.
+    else if (identityResolved && !userId) clearActiveScopeKey();
+  }, [scope, userId, identityResolved]);
 
   return scope;
 };
@@ -118,21 +149,25 @@ export const useCacheScope = (): string => {
  * Non-React getter for the current cache scope (for use inside services /
  * imperative code paths, and the SWR cache provider's `getScope`).
  */
-export const getCacheScope = (): string =>
-  resolveScope(
-    userProfileSelectors.userId(getUserStoreState()),
+export const getCacheScope = (): string => {
+  const state = getUserStoreState();
+
+  return resolveScope(
+    userProfileSelectors.userId(state),
     getActiveWorkspaceId(),
     readActiveScope(),
+    isIdentityResolved(state),
   );
+};
 
 /**
- * Whether the current scope has been confirmed by a resolved session.
+ * Whether the current scope has been confirmed by a resolved identity.
  *
- * Until the auth/session check completes, the scope is the optimistic persisted
+ * Until the identity round-trip lands, the scope is the optimistic persisted
  * one (or anon) — writes made then are quarantined (see the cache provider's
  * `isEphemeralScope`) so an account switch / first-ever boot can't pollute or
- * orphan a partition. Once the session resolves, writes persist normally (this
+ * orphan a partition. Once identity resolves, writes persist normally (this
  * also covers no-auth: the session check completes to "not signed in", and the
  * anonymous scope is a legitimate durable context there).
  */
-export const isScopeTrusted = (): boolean => Boolean(authSelectors.isLoaded(getUserStoreState()));
+export const isScopeTrusted = (): boolean => isIdentityResolved(getUserStoreState());

--- a/src/store/user/slices/auth/action.ts
+++ b/src/store/user/slices/auth/action.ts
@@ -1,5 +1,6 @@
 import { type SSOProvider } from '@lobechat/types';
 
+import { clearActiveScopeKey } from '@/libs/swr/useCacheScope';
 import { type StoreSetter } from '@/store/types';
 
 import { type UserStore } from '../../store';
@@ -74,6 +75,9 @@ export class UserAuthActionImpl {
     await signOut({
       fetchOptions: {
         onSuccess: () => {
+          // Drop the persisted active scope so the next boot doesn't hydrate the
+          // signed-out user's cache (localStorage survives the reload below).
+          clearActiveScopeKey();
           // Use window.location.href to trigger a full page reload
           // This ensures all client-side state (React, Zustand, cache) is cleared
           window.location.href = '/signin';


### PR DESCRIPTION
## Summary

Cold boot could only hydrate the cache scope once the identity round-trip resolved `userId`, so the provider hydrated the empty anonymous partition first and only re-hydrated the real user partition **after** the session resolved — sequentially. First paint waited for the session RTT + the real hydration. This is the root of the "home opens slow even though I visited yesterday" path that #16850 only half-addressed (it fixed the anon-scope orphan but still waited for `userId`).

Persist the last-known `${userId}:${workspace}` as `activeScopeKey` (localStorage, sync-readable). At boot the provider hydrates that real user partition **in parallel** with the session check, so the gate only waits for `ready` (the local IndexedDB read), not the network RTT. This is the same "cache is synchronously available" property the #10884 localStorage tier had and the #15844 async IndexedDB tier lost.

## Change

- **`useCacheScope`** — optimistic persisted scope (hydrate the last-known user partition before the session resolves) + `isScopeTrusted` (session check done) + `clearActiveScopeKey`.
- **`localStorageProvider`** — `isEphemeralScope = () => !isScopeTrusted()`: quarantine writes until the session confirms the scope, so an account switch / first-ever boot can't orphan or pollute a partition. `reloadScope` clears the dirty set on a real flip, so quarantined writes never survive a switch. No-auth is unaffected (the session check completes to "not signed in" and the anonymous scope becomes a legitimate durable context).
- **`CacheHydrationGate`** — release on `ready` (drop the `userId`-RTT wait; the persisted scope means `ready` is already the real partition).
- **`auth`** — `clearActiveScopeKey()` on logout.

## Verification

- Unit: `useCacheScope` (10) + `localStorageProvider` (22) + `CacheHydrationGate` (4) = **36/36 pass** after rebase; tsc clean on changed files.
- Live (Electron built app, real account / warm cache, backend = production): on renderer reload the **gate releases at ~641ms** and the home renders from cache; `activeScopeKey` is persisted and reused. Report: https://app.lobehub.com/verify/2d417acf-c344-4e67-876c-4be9715d4989

## Honest limitations of the live measurement

- The Electron app proxies all data through the **main process** (`BackendProxy`), so the renderer-side `performance` API can't see the data calls — I could **not** cleanly confirm cache-hit vs network from the renderer.
- From the test machine the network to `app.lobehub.com` was flaky (85 connection failures → SWR retries), which inflated the post-gate content-render time. So the "~1–2s to full content" number is **not** representative of production and could not be cleanly attributed to either the network or the SWR→store→render chain. A clean measurement (local backend, or main-proxy timing) is the right follow-up — tracked separately, not blocking this gate/boot fix.

## Notes

- This PR targets the **boot / loading-screen layer** (gate releases fast, home opens from cache, no anon orphan). The remaining "content renders ~instantly after the gate" depends on the separate SWR→onData→store→render chain and is out of scope here.
- Replaces the `isAnonymousScope` quarantine from #16850 with the session-gated `!isScopeTrusted()` quarantine (covers no-auth correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)