### PR TITLE
🐛 fix: detect Codex CLI bundled with ChatGPT.app

### DIFF
--- a/apps/cli/src/commands/hetero.test.ts
+++ b/apps/cli/src/commands/hetero.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readdir, readFile } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { PassThrough } from 'node:stream';
@@ -8,7 +8,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { registerHeteroCommand } from './hetero';
 
-const { mockSpawnAgent } = vi.hoisted(() => ({
+const { mockResolveHeteroSpawnCommand, mockSpawnAgent } = vi.hoisted(() => ({
+  mockResolveHeteroSpawnCommand: vi.fn(),
   mockSpawnAgent: vi.fn(),
 }));
 const { mockGetTrpcClient, mockHeteroFinishMutate, mockHeteroIngestMutate } = vi.hoisted(() => ({
@@ -19,6 +20,10 @@ const { mockGetTrpcClient, mockHeteroFinishMutate, mockHeteroIngestMutate } = vi
 
 vi.mock('@lobechat/heterogeneous-agents/spawn', () => ({
   spawnAgent: mockSpawnAgent,
+}));
+
+vi.mock('@lobechat/heterogeneous-agents/resolveCliCommand', () => ({
+  resolveHeteroSpawnCommand: mockResolveHeteroSpawnCommand,
 }));
 
 vi.mock('../api/client', () => ({
@@ -91,6 +96,12 @@ describe('hetero exec command', () => {
       throw new Error(`__exit__${code}`);
     }) as any);
     stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    mockResolveHeteroSpawnCommand.mockReset();
+    mockResolveHeteroSpawnCommand.mockImplementation(
+      async (agentType: 'claude-code' | 'codex', command?: string) => ({
+        command: command ?? (agentType === 'codex' ? 'codex' : 'claude'),
+      }),
+    );
     mockSpawnAgent.mockReset();
     mockHeteroIngestMutate.mockReset();
     mockHeteroFinishMutate.mockReset();
@@ -301,7 +312,7 @@ describe('hetero exec command', () => {
 
     expect(mockSpawnAgent).toHaveBeenCalledTimes(1);
     expect(mockSpawnAgent.mock.calls[0][0]).toMatchObject({
-      command: undefined,
+      command: 'codex',
       extraArgs: ['-c', 'model = "gpt-5.4"', '-c', 'model_reasoning_effort="xhigh"'],
     });
   });
@@ -414,9 +425,6 @@ describe('hetero exec command', () => {
   });
 
   it('reads multimodal content from --input-json <file>', async () => {
-    const { mkdtemp, writeFile, rm } = await import('node:fs/promises');
-    const { tmpdir } = await import('node:os');
-    const path = await import('node:path');
     const dir = await mkdtemp(`${tmpdir()}/hetero-input-json-`);
     const file = path.join(dir, 'input.json');
     await writeFile(
@@ -446,8 +454,8 @@ describe('hetero exec command', () => {
     // missing local --image paths, fetch failures, etc. The CLI must catch
     // these and exit with a friendly message instead of crashing on an
     // unhandled rejection.
-    mockSpawnAgent.mockReturnValue(
-      Promise.reject(new Error('ENOENT: no such file or directory, open /missing.png')),
+    mockSpawnAgent.mockRejectedValue(
+      new Error('ENOENT: no such file or directory, open /missing.png'),
     );
 
     await runCmd([
@@ -465,7 +473,7 @@ describe('hetero exec command', () => {
   });
 
   it('finishes server-ingest runs with error when spawnAgent rejects before streaming', async () => {
-    mockSpawnAgent.mockReturnValue(Promise.reject(new Error('spawn claude ENOENT')));
+    mockSpawnAgent.mockRejectedValue(new Error('spawn claude ENOENT'));
 
     await runCmd([
       'hetero',

--- a/apps/cli/src/commands/hetero.ts
+++ b/apps/cli/src/commands/hetero.ts
@@ -816,7 +816,7 @@ const exec = async (options: ExecOptions): Promise<void> => {
   ];
   // Resolve the CLI binary once, up front, and reuse it for both the initial
   // run and the resume-retry. For the default bare command (`codex`/`claude`)
-  // this finds the validated binary — including the Codex.app bundled CLI when
+  // this finds the validated binary — including an app-bundled Codex CLI when
   // a broken `codex` shim shadows PATH — so sandbox/terminal runs no longer
   // ENOENT on a stale global install. Custom commands are used verbatim.
   const resolvedCommand = await resolveHeteroSpawnCommand(agentType, options.command);

--- a/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
+++ b/apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts
@@ -214,8 +214,8 @@ interface AgentSession {
   /**
    * Absolute CLI path resolved by spawn preflight detection. Used for spawn()
    * when the configured command is bare: detection can find the CLI through
-   * the login-shell PATH or a well-known install location (e.g. the Codex.app
-   * bundled CLI) that plain spawn() with the inherited env can't resolve.
+   * the login-shell PATH or a well-known install location (e.g. an app-bundled
+   * Codex CLI) that plain spawn() with the inherited env can't resolve.
    */
   resolvedCommandPath?: string;
   /**
@@ -513,7 +513,7 @@ export default class HeterogeneousAgentCtr extends ControllerModule {
     if (!status || status.available) {
       // Spawn through the detector-resolved absolute path when the configured
       // command is bare — detection may have located the CLI somewhere plain
-      // spawn() can't (login-shell PATH, Codex.app bundled CLI, …).
+      // spawn() can't (login-shell PATH, app-bundled Codex CLI, …).
       const useResolvedPath = Boolean(status?.path) && !command.includes(path.sep);
       session.resolvedCommandPath = useResolvedPath ? status!.path : undefined;
       // Carry the login-shell PATH the detector resolved through, so a

--- a/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
+++ b/apps/desktop/src/main/controllers/__tests__/HeterogeneousAgentCtr.test.ts
@@ -681,9 +681,9 @@ describe('HeterogeneousAgentCtr', () => {
 
     it('spawns through the detector-resolved absolute path when the bare command is off PATH', async () => {
       // Codex desktop app case: `codex` is not on PATH, but the preflight
-      // detector finds the CLI bundled inside Codex.app. Spawning the bare
+      // detector finds the CLI bundled inside ChatGPT.app. Spawning the bare
       // command would ENOENT — spawn must use the resolved absolute path.
-      const resolvedPath = '/Applications/Codex.app/Contents/Resources/codex';
+      const resolvedPath = '/Applications/ChatGPT.app/Contents/Resources/codex';
       const detect = vi.fn().mockResolvedValue({ available: true, path: resolvedPath });
       const { proc } = createFakeProc();
       nextFakeProc = proc;

--- a/apps/desktop/src/main/modules/binaries/__tests__/cliAgentBinaries.test.ts
+++ b/apps/desktop/src/main/modules/binaries/__tests__/cliAgentBinaries.test.ts
@@ -239,7 +239,7 @@ describe('cliAgentBinaries', () => {
       }
     });
 
-    it('falls back to the Codex.app bundled CLI when `codex` is not on any PATH', async () => {
+    it('falls back to the ChatGPT.app bundled CLI when `codex` is not on any PATH', async () => {
       const originalPath = process.env.PATH;
       const originalShell = process.env.SHELL;
       // Deterministic env: no SHELL → no login-shell lookup, merged PATH
@@ -255,13 +255,13 @@ describe('cliAgentBinaries', () => {
         const status = await codexBinary.detect();
 
         expect(status.available).toBe(true);
-        expect(status.path).toBe('/Applications/Codex.app/Contents/Resources/codex');
+        expect(status.path).toBe('/Applications/ChatGPT.app/Contents/Resources/codex');
         expect(status.version).toBe('codex-cli 0.138.0');
 
         expect(execFileMock).toHaveBeenCalledTimes(2);
         expect(execFileMock.mock.calls[0]![0]).toBe('which');
         expect(execFileMock.mock.calls[1]![0]).toBe(
-          '/Applications/Codex.app/Contents/Resources/codex',
+          '/Applications/ChatGPT.app/Contents/Resources/codex',
         );
       } finally {
         process.env.PATH = originalPath;
@@ -278,15 +278,17 @@ describe('cliAgentBinaries', () => {
 
       try {
         callExecFileError(new Error('not found')); // which codex
-        callExecFileError(new Error('ENOENT')); // /Applications candidate
-        callExecFileError(new Error('ENOENT')); // ~/Applications candidate
+        callExecFileError(new Error('ENOENT')); // /Applications/ChatGPT.app
+        callExecFileError(new Error('ENOENT')); // ~/Applications/ChatGPT.app
+        callExecFileError(new Error('ENOENT')); // /Applications/Codex.app
+        callExecFileError(new Error('ENOENT')); // ~/Applications/Codex.app
 
         const { codexBinary } = await import('../cliAgentBinaries');
         const status = await codexBinary.detect();
 
         expect(status.available).toBe(false);
-        expect(execFileMock).toHaveBeenCalledTimes(3);
-        expect(execFileMock.mock.calls[2]![0]).toBe(
+        expect(execFileMock).toHaveBeenCalledTimes(5);
+        expect(execFileMock.mock.calls[4]![0]).toBe(
           path.join(os.homedir(), 'Applications', 'Codex.app', 'Contents', 'Resources', 'codex'),
         );
       } finally {

--- a/apps/desktop/src/main/modules/binaries/cliAgentBinaries.ts
+++ b/apps/desktop/src/main/modules/binaries/cliAgentBinaries.ts
@@ -7,7 +7,7 @@ import type { BinarySpec, BinaryStatus } from '@/core/infrastructure/BinaryManag
 import { defineCommandBinary } from '@/core/infrastructure/BinaryManager';
 
 // The command-resolution + validation logic (which/where lookup, login-shell
-// PATH retry, well-known install fallbacks incl. the Codex.app bundled CLI,
+// PATH retry, well-known install fallbacks incl. app-bundled Codex CLIs,
 // `--version` keyword validation) lives in the shared `@lobechat/heterogeneous-
 // agents` package so the desktop manager path and the `lh hetero exec` CLI /
 // sandbox path resolve binaries identically. This module only adapts it into
@@ -65,7 +65,7 @@ export const claudeCodeBinary: BinarySpec = {
  * OpenAI Codex CLI
  * @see https://github.com/openai/codex
  *
- * Goes through `detectHeterogeneousCliCommand` so the Codex.app bundled-CLI
+ * Goes through `detectHeterogeneousCliCommand` so the app-bundled CLI
  * fallback applies here too, keeping the manager path and the custom-command
  * path in sync.
  */

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.test.ts
@@ -75,7 +75,7 @@ describe('resolveCliCommand', () => {
       expect(execMock).not.toHaveBeenCalled();
     });
 
-    it('falls through a PATH `codex` that fails validation to the Codex.app bundled CLI', async () => {
+    it('falls through a PATH `codex` that fails validation to the ChatGPT.app bundled CLI', async () => {
       const originalPath = process.env.PATH;
       const originalShell = process.env.SHELL;
       // Deterministic env: no SHELL → no login-shell lookup.
@@ -87,15 +87,42 @@ describe('resolveCliCommand', () => {
         callExecFile('/Users/x/Library/pnpm/codex\n');
         // ...but its `--version` errors (ENOENT-style broken wrapper).
         callExecFileError(new Error('spawn ENOENT'));
-        // Fallback: the Codex.app bundled CLI validates.
+        // Fallback: the ChatGPT.app bundled CLI validates.
         callExecFile('codex-cli 0.142.5');
 
         const { detectHeterogeneousCliCommand } = await importModule();
         const status = await detectHeterogeneousCliCommand('codex', 'codex');
 
         expect(status.available).toBe(true);
-        expect(status.path).toBe('/Applications/Codex.app/Contents/Resources/codex');
+        expect(status.path).toBe('/Applications/ChatGPT.app/Contents/Resources/codex');
         expect(execFileMock.mock.calls[2]![0]).toBe(
+          '/Applications/ChatGPT.app/Contents/Resources/codex',
+        );
+      } finally {
+        process.env.PATH = originalPath;
+        if (originalShell === undefined) delete process.env.SHELL;
+        else process.env.SHELL = originalShell;
+      }
+    });
+
+    it('falls back to the legacy Codex.app bundle when ChatGPT.app is unavailable', async () => {
+      const originalPath = process.env.PATH;
+      const originalShell = process.env.SHELL;
+      process.env.PATH = '/usr/bin:/bin';
+      delete process.env.SHELL;
+
+      try {
+        callExecFileError(new Error('not found')); // which codex
+        callExecFileError(new Error('ENOENT')); // /Applications/ChatGPT.app
+        callExecFileError(new Error('ENOENT')); // ~/Applications/ChatGPT.app
+        callExecFile('codex-cli 0.142.5'); // /Applications/Codex.app
+
+        const { detectHeterogeneousCliCommand } = await importModule();
+        const status = await detectHeterogeneousCliCommand('codex', 'codex');
+
+        expect(status.available).toBe(true);
+        expect(status.path).toBe('/Applications/Codex.app/Contents/Resources/codex');
+        expect(execFileMock.mock.calls[3]![0]).toBe(
           '/Applications/Codex.app/Contents/Resources/codex',
         );
       } finally {
@@ -118,7 +145,7 @@ describe('resolveCliCommand', () => {
         const status = await detectHeterogeneousCliCommand('codex', 'codex-beta');
 
         expect(status.available).toBe(false);
-        // Only the custom command's own `which` runs — no Codex.app fallback.
+        // Only the custom command's own `which` runs — no app-bundle fallback.
         expect(execFileMock).toHaveBeenCalledTimes(1);
         expect(execFileMock.mock.calls[0]![0]).toBe('which');
       } finally {
@@ -252,8 +279,10 @@ describe('resolveCliCommand', () => {
 
       try {
         callExecFileError(new Error('not found')); // which codex
-        callExecFileError(new Error('ENOENT')); // /Applications candidate
-        callExecFileError(new Error('ENOENT')); // ~/Applications candidate
+        callExecFileError(new Error('ENOENT')); // /Applications/ChatGPT.app
+        callExecFileError(new Error('ENOENT')); // ~/Applications/ChatGPT.app
+        callExecFileError(new Error('ENOENT')); // /Applications/Codex.app
+        callExecFileError(new Error('ENOENT')); // ~/Applications/Codex.app
 
         const { resolveHeteroSpawnCommand } = await importModule();
         const resolved = await resolveHeteroSpawnCommand('codex', 'codex');

--- a/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
+++ b/packages/heterogeneous-agents/src/spawn/resolveCliCommand.ts
@@ -254,7 +254,7 @@ export const DEFAULT_HETERO_COMMAND: Record<HeterogeneousCliAgentType, string> =
 // Well-known absolute install locations probed when a bare command isn't on
 // PATH. This covers GUI-launched apps with a lean launchd PATH: Claude's
 // official installer can put `claude` under ~/.local/bin, while the Codex
-// desktop app bundles a functional CLI inside Codex.app without symlinking it.
+// desktop app bundles a functional CLI inside its app bundle without symlinking it.
 const getWellKnownCommandPaths = (agentType: HeterogeneousCliAgentType): string[] => {
   switch (agentType) {
     case 'claude-code': {
@@ -270,11 +270,16 @@ const getWellKnownCommandPaths = (agentType: HeterogeneousCliAgentType): string[
     case 'codex': {
       if (platform() !== 'darwin') return [];
 
-      const bundledCli = path.join('Codex.app', 'Contents', 'Resources', 'codex');
-      return [
-        path.join('/Applications', bundledCli),
-        path.join(homedir(), 'Applications', bundledCli),
-      ];
+      // Codex.app was renamed to ChatGPT.app. Prefer the current bundle name,
+      // while keeping Codex.app as a fallback for older installations.
+      return ['ChatGPT.app', 'Codex.app'].flatMap((appBundleName) => {
+        const bundledCli = path.join(appBundleName, 'Contents', 'Resources', 'codex');
+
+        return [
+          path.join('/Applications', bundledCli),
+          path.join(homedir(), 'Applications', bundledCli),
+        ];
+      });
     }
     default: {
       return [];
@@ -330,8 +335,8 @@ export interface ResolvedHeteroCommand {
  * to the requested command, preserving the prior PATH-trusting behavior.
  *
  * Resolution only kicks in for the DEFAULT bare command (`codex` / `claude`) —
- * the case that benefits from the well-known-path fallback (e.g. the Codex.app
- * bundled CLI when a broken `codex` shim shadows PATH). A custom command or an
+ * the case that benefits from the well-known-path fallback (e.g. an app-bundled
+ * Codex CLI when a broken `codex` shim shadows PATH). A custom command or an
  * explicit path is used verbatim, unchanged from before. This mirrors the
  * desktop controller, which resolves the default via the binary manager and
  * leaves custom commands to the caller.


### PR DESCRIPTION
## Summary

- detect the Codex CLI bundled in `ChatGPT.app` on macOS
- keep the legacy `Codex.app` locations as fallbacks for older installations
- update desktop resolver coverage for the new bundle name and all missing-candidate cases
- isolate CLI command tests from host-installed app bundles and defer rejected mocks until invocation

## Root cause

The Codex desktop app was renamed to `ChatGPT.app`, but the shared CLI resolver only probed `Codex.app/Contents/Resources/codex`. Finder-launched desktop processes often have a lean `PATH`, so users with only the renamed app installed were incorrectly shown `cli_not_found` before an agent operation could start.

## Impact

Local Codex agents can now launch from either the current `ChatGPT.app` bundle or the legacy `Codex.app` bundle. Existing PATH resolution and explicit custom commands keep their current precedence.

## Validation

- `bun run check <changed files>` — lint clean, 104 related tests passed
- `bun run check --type` — full type-check clean
- lean-PATH smoke test resolved `/Applications/ChatGPT.app/Contents/Resources/codex` and validated `codex-cli 0.144.0-alpha.4`
