### PR TITLE
✨ feat(model): add GPT-5.6 support

### DIFF
--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -199,6 +199,8 @@
   "extendParams.preserveThinking.title": "传递历史思考过程",
   "extendParams.reasoningBudgetToken.title": "思考 Token 预算",
   "extendParams.reasoningEffort.title": "推理强度",
+  "extendParams.reasoningMode.desc": "标准模式平衡速度与成本；Pro 模式会为困难任务投入更多计算，可能消耗更多 Token。",
+  "extendParams.reasoningMode.title": "推理模式",
   "extendParams.textVerbosity.title": "输出详细程度",
   "extendParams.thinking.title": "深度思考开关",
   "extendParams.thinkingBudget.title": "思考预算",

--- a/locales/zh-CN/modelProvider.json
+++ b/locales/zh-CN/modelProvider.json
@@ -247,6 +247,7 @@
   "providerModels.item.modelConfig.extendParams.options.reasoningBudgetToken32k.hint": "适用于GLM-5和GLM-4.7；控制推理的令牌预算（最大32k）。",
   "providerModels.item.modelConfig.extendParams.options.reasoningBudgetToken80k.hint": "适用于Qwen3系列；控制推理的令牌预算（最大80k）。",
   "providerModels.item.modelConfig.extendParams.options.reasoningEffort.hint": "适用于 OpenAI 及其他具备推理能力的模型；控制推理力度。",
+  "providerModels.item.modelConfig.extendParams.options.reasoningMode.hint": "适用于 GPT-5.6 Responses API；可在 Standard 与 Pro 推理模式之间切换。",
   "providerModels.item.modelConfig.extendParams.options.ring2_6ReasoningEffort.hint": "适用于 Ring 2.6 系列；控制推理强度。",
   "providerModels.item.modelConfig.extendParams.options.step3_5ReasoningEffort.hint": "适用于 Step 3.5 系列；控制推理强度。",
   "providerModels.item.modelConfig.extendParams.options.textVerbosity.hint": "适用于 GPT-5+ 系列；控制输出内容的详尽程度。",

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -123,6 +123,9 @@ export default {
   'extendParams.imageResolution.title': 'Image Resolution',
   'extendParams.reasoningBudgetToken.title': 'Thinking Consumption Token',
   'extendParams.reasoningEffort.title': 'Reasoning Intensity',
+  'extendParams.reasoningMode.desc':
+    'Standard balances speed and cost. Pro performs more model work for difficult tasks and may use more tokens.',
+  'extendParams.reasoningMode.title': 'Reasoning Mode',
   'extendParams.textVerbosity.title': 'Output Text Detail Level',
   'extendParams.thinking.title': 'Deep Thinking Switch',
   'extendParams.thinkingBudget.title': 'Thinking Budget',

--- a/packages/locales/src/default/modelProvider.ts
+++ b/packages/locales/src/default/modelProvider.ts
@@ -273,6 +273,8 @@ export default {
     'For GPT-5.2 Pro series; controls reasoning intensity.',
   'providerModels.item.modelConfig.extendParams.options.gpt5_2ReasoningEffort.hint':
     'For GPT-5.2 series; controls reasoning intensity.',
+  'providerModels.item.modelConfig.extendParams.options.gpt5_6ReasoningEffort.hint':
+    'For GPT-5.6 series; controls reasoning intensity from None through Max.',
   'providerModels.item.modelConfig.extendParams.options.glm5_2ReasoningEffort.hint':
     'For GLM-5.2; controls reasoning effort with High and Max levels.',
   'providerModels.item.modelConfig.extendParams.options.grok4_20ReasoningEffort.hint':
@@ -307,6 +309,8 @@ export default {
     'For Qwen3 series; controls token budget for reasoning (max 80k).',
   'providerModels.item.modelConfig.extendParams.options.reasoningEffort.hint':
     'For OpenAI and other reasoning-capable models; controls reasoning effort.',
+  'providerModels.item.modelConfig.extendParams.options.reasoningMode.hint':
+    'For GPT-5.6 Responses API; switches between Standard and Pro reasoning modes.',
   'providerModels.item.modelConfig.extendParams.options.step3_5ReasoningEffort.hint':
     'For Step 3.5 series; controls reasoning intensity.',
   'providerModels.item.modelConfig.extendParams.options.textVerbosity.hint':

--- a/packages/locales/src/default/models.ts
+++ b/packages/locales/src/default/models.ts
@@ -12,6 +12,8 @@ LOBE_DEFAULT_MODEL_LIST.forEach((model) => {
 const lobeHubOnlineModelLocales = {
   'claude-sonnet-5.description':
     "Claude Sonnet 5 is Anthropic's most agentic Sonnet model, built for sustained coding, tool use, and long-context workflows with Sonnet-tier speed and efficiency.",
+  'dola-seedream-5-0-pro-260628.description':
+    'ByteDance Seedream 5.0 Pro by BytePlus is a high-precision image generation model with precise control over element positioning, supporting text-to-image and single-image editing at 2K resolution.',
   'dreamina-seedance-2-0-260128.description':
     'Seedance 2.0 by ByteDance is the most powerful video generation model, supporting multimodal reference video generation, video editing, video extension, text-to-video, and image-to-video with synchronized audio.',
   'dreamina-seedance-2-0-fast-260128.description':
@@ -22,6 +24,12 @@ const lobeHubOnlineModelLocales = {
     "Gemini 3.1 Flash Lite Image (Nano Banana 2 Lite) is Google's fastest and most cost-efficient image generation model, built for high-volume generation and editing.",
   'gemini-3.1-flash-lite-image.description':
     "Gemini 3.1 Flash Lite Image (Nano Banana 2 Lite) is Google's fastest and most cost-efficient image generation model, built for high-volume generation and editing.",
+  'gpt-5.6-luna.description':
+    'GPT-5.6 Luna is optimized for cost-sensitive, high-volume workloads with the lowest price in the GPT-5.6 family.',
+  'gpt-5.6-sol.description':
+    "GPT-5.6 Sol is OpenAI's frontier model for complex reasoning, coding, and long-horizon agentic work. The gpt-5.6 alias routes to Sol.",
+  'gpt-5.6-terra.description':
+    'GPT-5.6 Terra balances intelligence and cost for everyday professional work, competitive with GPT-5.5 at about half the price.',
   'grok-4.20-beta-0309-non-reasoning.description': 'A non-reasoning variant for simple use cases',
   'grok-4.20-beta-0309-reasoning.description':
     'Intelligent, blazing-fast model that reasons before responding',

--- a/packages/model-bank/src/types/aiModel.ts
+++ b/packages/model-bank/src/types/aiModel.ts
@@ -301,10 +301,12 @@ export type ExtendParamsType =
   | 'effort'
   | 'deepseekV4ReasoningEffort'
   | 'reasoningEffort'
+  | 'reasoningMode'
   | 'gpt5ReasoningEffort'
   | 'gpt5_1ReasoningEffort'
   | 'gpt5_2ReasoningEffort'
   | 'gpt5_2ProReasoningEffort'
+  | 'gpt5_6ReasoningEffort'
   | 'glm5_2ReasoningEffort'
   | 'grok4_20ReasoningEffort'
   | 'grok4_3ReasoningEffort'
@@ -355,10 +357,12 @@ export const ExtendParamsTypeSchema = z.enum([
   'effort',
   'deepseekV4ReasoningEffort',
   'reasoningEffort',
+  'reasoningMode',
   'gpt5ReasoningEffort',
   'gpt5_1ReasoningEffort',
   'gpt5_2ReasoningEffort',
   'gpt5_2ProReasoningEffort',
+  'gpt5_6ReasoningEffort',
   'glm5_2ReasoningEffort',
   'grok4_20ReasoningEffort',
   'grok4_3ReasoningEffort',

--- a/packages/model-runtime/src/core/usageConverters/openai.test.ts
+++ b/packages/model-runtime/src/core/usageConverters/openai.test.ts
@@ -100,6 +100,101 @@ describe('convertUsage', () => {
     });
   });
 
+  it('should map GPT-5.6+ cache_write_tokens and exclude them from uncached miss', () => {
+    // Official Chat Completions shape from OpenAI prompt-caching docs (GPT-5.6+):
+    // cache_write_tokens is a subset of prompt_tokens billed at 1.25× uncached input.
+    const usageWithCacheWrite = {
+      prompt_tokens: 2000,
+      prompt_tokens_details: {
+        cached_tokens: 0,
+        cache_write_tokens: 1500,
+      },
+      completion_tokens: 100,
+      total_tokens: 2100,
+    } as OpenAI.Completions.CompletionUsage;
+
+    const result = convertOpenAIUsage(usageWithCacheWrite);
+
+    expect(result).toEqual({
+      inputTextTokens: 2000,
+      inputWriteCacheTokens: 1500,
+      // uncached 1× bucket must not include writes (2000 - 0 - 1500)
+      inputCacheMissTokens: 500,
+      totalInputTokens: 2000,
+      totalOutputTokens: 100,
+      outputTextTokens: 100,
+      totalTokens: 2100,
+    });
+    expect(result).not.toHaveProperty('inputCachedTokens');
+  });
+
+  it('should split miss / read / write when both cache hit and write are present', () => {
+    const usage = {
+      prompt_tokens: 3000,
+      prompt_tokens_details: {
+        cached_tokens: 1000,
+        cache_write_tokens: 800,
+      },
+      completion_tokens: 50,
+      total_tokens: 3050,
+    } as OpenAI.Completions.CompletionUsage;
+
+    const result = convertOpenAIUsage(usage);
+
+    expect(result).toMatchObject({
+      inputCachedTokens: 1000,
+      inputWriteCacheTokens: 800,
+      inputCacheMissTokens: 1200, // 3000 - 1000 - 800
+      totalInputTokens: 3000,
+    });
+  });
+
+  it('should bill textInput_cacheWrite at 1.25x without double-charging textInput', () => {
+    const pricing: Pricing = {
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 1.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    };
+
+    // 1M write-only input + 0 output → cost should be 1.25, not 1 + 1.25
+    const writeOnly = {
+      prompt_tokens: 1_000_000,
+      prompt_tokens_details: {
+        cached_tokens: 0,
+        cache_write_tokens: 1_000_000,
+      },
+      completion_tokens: 0,
+      total_tokens: 1_000_000,
+    } as OpenAI.Completions.CompletionUsage;
+
+    const writeOnlyResult = convertOpenAIUsage(writeOnly, { pricing });
+    expect(writeOnlyResult.inputWriteCacheTokens).toBe(1_000_000);
+    expect(writeOnlyResult.inputCacheMissTokens).toBe(0);
+    expect(writeOnlyResult.cost).toBeCloseTo(1.25, 10);
+
+    // Mixed: 500k miss @1 + 300k read @0.1 + 200k write @1.25 = 0.5 + 0.03 + 0.25 = 0.78
+    const mixed = {
+      prompt_tokens: 1_000_000,
+      prompt_tokens_details: {
+        cached_tokens: 300_000,
+        cache_write_tokens: 200_000,
+      },
+      completion_tokens: 0,
+      total_tokens: 1_000_000,
+    } as OpenAI.Completions.CompletionUsage;
+
+    const mixedResult = convertOpenAIUsage(mixed, { pricing });
+    expect(mixedResult).toMatchObject({
+      inputCacheMissTokens: 500_000,
+      inputCachedTokens: 300_000,
+      inputWriteCacheTokens: 200_000,
+    });
+    expect(mixedResult.cost).toBeCloseTo(0.78, 10);
+  });
+
   it('should preserve zero cache miss tokens for fully cached completion usage', () => {
     const pricing: Pricing = {
       units: [
@@ -436,6 +531,39 @@ describe('convertUsage', () => {
       totalTokens: 4796,
     });
     expect(result.cost).toBeGreaterThan(0);
+  });
+
+  it('should map GPT-5.6+ cache_write_tokens for ResponseUsage and bill cache write', () => {
+    const pricing: Pricing = {
+      units: [
+        { name: 'textInput', rate: 1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheRead', rate: 0.1, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 1.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    };
+
+    const responseUsage = {
+      input_tokens: 1_000_000,
+      input_tokens_details: {
+        cached_tokens: 100_000,
+        cache_write_tokens: 400_000,
+      },
+      output_tokens: 0,
+      total_tokens: 1_000_000,
+    } as OpenAI.Responses.ResponseUsage;
+
+    const result = convertOpenAIResponseUsage(responseUsage, { pricing });
+
+    // miss = 1_000_000 - 100_000 - 400_000 = 500_000
+    // cost = 0.5 + 0.01 + 0.5 = 1.01
+    expect(result).toMatchObject({
+      inputCacheMissTokens: 500_000,
+      inputCachedTokens: 100_000,
+      inputWriteCacheTokens: 400_000,
+      totalInputTokens: 1_000_000,
+    });
+    expect(result.cost).toBeCloseTo(1.01, 10);
   });
 
   it('should enrich completion usage with pricing cost when pricing is provided', () => {

--- a/packages/model-runtime/src/core/usageConverters/openai.ts
+++ b/packages/model-runtime/src/core/usageConverters/openai.ts
@@ -1,4 +1,5 @@
 import type { ModelTokensUsage, ModelUsage } from '@lobechat/types';
+import { isRecord } from '@lobechat/utils/object';
 import debug from 'debug';
 import type { Pricing } from 'model-bank';
 import type OpenAI from 'openai';
@@ -21,6 +22,41 @@ const shouldKeepUsageValue = (key: string, value: unknown) => {
   return key === 'inputCacheMissTokens';
 };
 
+/**
+ * OpenAI GPT-5.6+ reports cache writes as `cache_write_tokens` under usage details.
+ * The field is not yet in all openai SDK type snapshots, so read it defensively.
+ *
+ * Billing note: write tokens are a subset of total input tokens and are charged at
+ * 1.25× uncached input. They must be excluded from the uncached (1×) miss bucket so
+ * computeChatCost does not double-charge textInput + textInput_cacheWrite.
+ */
+const readCacheWriteTokens = (details: unknown): number | undefined => {
+  if (!isRecord(details)) return undefined;
+
+  const value = details.cache_write_tokens;
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+};
+
+const resolveOpenAIInputCacheMissTokens = (params: {
+  explicitMissTokens?: number;
+  inputCachedTokens?: number;
+  inputWriteCacheTokens?: number;
+  totalInputTokens: number;
+}): number | undefined => {
+  if (typeof params.explicitMissTokens === 'number') return params.explicitMissTokens;
+
+  const hasCacheBreakdown =
+    typeof params.inputCachedTokens === 'number' ||
+    typeof params.inputWriteCacheTokens === 'number';
+
+  if (!hasCacheBreakdown) return undefined;
+
+  return Math.max(
+    0,
+    params.totalInputTokens - (params.inputCachedTokens ?? 0) - (params.inputWriteCacheTokens ?? 0),
+  );
+};
+
 export const convertOpenAIUsage = (
   usage: OpenAI.Completions.CompletionUsage,
   payload?: ChatPayloadForTransformStream,
@@ -32,10 +68,14 @@ export const convertOpenAIUsage = (
 
   const cachedTokens =
     (usage as any).prompt_cache_hit_tokens || usage.prompt_tokens_details?.cached_tokens;
+  const inputWriteCacheTokens = readCacheWriteTokens(usage.prompt_tokens_details);
 
-  const inputCacheMissTokens =
-    (usage as any).prompt_cache_miss_tokens ??
-    (typeof cachedTokens === 'number' ? totalInputTokens - cachedTokens : undefined);
+  const inputCacheMissTokens = resolveOpenAIInputCacheMissTokens({
+    explicitMissTokens: (usage as any).prompt_cache_miss_tokens,
+    inputCachedTokens: typeof cachedTokens === 'number' ? cachedTokens : undefined,
+    inputWriteCacheTokens,
+    totalInputTokens,
+  });
 
   const totalOutputTokens = usage.completion_tokens;
   const outputReasoning = usage.completion_tokens_details?.reasoning_tokens || 0;
@@ -59,6 +99,7 @@ export const convertOpenAIUsage = (
     inputCachedTokens: cachedTokens,
     inputCitationTokens,
     inputTextTokens,
+    inputWriteCacheTokens,
     outputAudioTokens,
     outputImageTokens,
     outputReasoningTokens: outputReasoning,
@@ -90,14 +131,21 @@ export const convertOpenAIResponseUsage = (
   // 1. Extract and default primary values
   const totalInputTokens = usage.input_tokens || 0;
   const inputCachedTokens = usage.input_tokens_details?.cached_tokens || 0;
+  const inputWriteCacheTokens = readCacheWriteTokens(usage.input_tokens_details);
 
   const totalOutputTokens = usage.output_tokens || 0;
   const outputReasoningTokens = usage.output_tokens_details?.reasoning_tokens || 0;
 
   const overallTotalTokens = usage.total_tokens || 0;
 
-  // 2. Calculate derived values
-  const inputCacheMissTokens = totalInputTokens - inputCachedTokens;
+  // 2. Calculate derived values.
+  // Exclude cache writes from the uncached bucket so textInput (1×) and
+  // textInput_cacheWrite (1.25×) do not both bill the same tokens.
+  const inputCacheMissTokens = resolveOpenAIInputCacheMissTokens({
+    inputCachedTokens,
+    inputWriteCacheTokens,
+    totalInputTokens,
+  })!;
 
   // For ResponseUsage, inputTextTokens is effectively totalInputTokens as no further breakdown is given.
   const inputTextTokens = totalInputTokens;
@@ -116,6 +164,7 @@ export const convertOpenAIResponseUsage = (
     inputCachedTokens,
     inputCitationTokens: undefined, // Not in ResponseUsage
     inputTextTokens,
+    inputWriteCacheTokens,
     outputAudioTokens: undefined, // Not in ResponseUsage
     outputImageTokens,
     outputReasoningTokens,

--- a/packages/model-runtime/src/providers/azureOpenai/index.test.ts
+++ b/packages/model-runtime/src/providers/azureOpenai/index.test.ts
@@ -135,6 +135,33 @@ describe('LobeAzureOpenAI', () => {
         );
       });
 
+      it('should preserve GPT-5.6 Pro mode and Max effort in Responses payloads', async () => {
+        const mockProdStream = new ReadableStream() as any;
+        const mockDebugStream = new ReadableStream() as any;
+
+        vi.spyOn(instance['client'].responses, 'create').mockResolvedValue({
+          tee: () => [mockProdStream, mockDebugStream],
+        } as any);
+        vi.spyOn(getModelPricingModule, 'getModelPricing').mockResolvedValue(undefined);
+        vi.spyOn(streamsModule, 'OpenAIResponsesStream').mockReturnValue(new ReadableStream());
+
+        await instance.chat({
+          messages: [{ content: 'Review this migration.', role: 'user' }],
+          model: 'gpt-5.6-sol',
+          reasoning: { mode: 'pro' },
+          reasoning_effort: 'max',
+          stream: true,
+        });
+
+        const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
+
+        expect(createCall.reasoning).toEqual({
+          effort: 'max',
+          mode: 'pro',
+          summary: 'auto',
+        });
+      });
+
       it('should use deploymentName for Azure Responses API requests while keeping logical model for pricing', async () => {
         const mockProdStream = new ReadableStream() as any;
         const mockDebugStream = new ReadableStream() as any;

--- a/packages/model-runtime/src/providers/openai/index.test.ts
+++ b/packages/model-runtime/src/providers/openai/index.test.ts
@@ -278,10 +278,10 @@ describe('LobeOpenAI', () => {
       expect(createCall.model).toBe('o1-pro');
     });
 
-    it('should use responses API for future GPT-5 minor models', async () => {
+    it('should use responses API for GPT-5.6 family models', async () => {
       const payload = {
         messages: [{ content: 'Hello', role: 'user' as const }],
-        model: 'gpt-5.6',
+        model: 'gpt-5.6-sol',
         temperature: 0.7,
       };
 
@@ -289,7 +289,7 @@ describe('LobeOpenAI', () => {
 
       expect(instance['client'].responses.create).toHaveBeenCalled();
       const createCall = (instance['client'].responses.create as Mock).mock.calls[0][0];
-      expect(createCall.model).toBe('gpt-5.6');
+      expect(createCall.model).toBe('gpt-5.6-sol');
     });
 
     it('should use responses API when enabledSearch is true', async () => {
@@ -350,13 +350,17 @@ describe('LobeOpenAI', () => {
   });
 
   describe('responses.handlePayload', () => {
-    it('should add web_search tool when enabledSearch is true', async () => {
+    it('should add web_search and prune legacy sampling params for GPT-5.6', async () => {
       const payload = {
         enabledSearch: true,
+        frequency_penalty: 0.5,
         messages: [{ content: 'Hello', role: 'user' as const }],
-        model: 'gpt-4o',
-        // 使用常规模型，通过 enabledSearch 触发 responses API
+        model: 'gpt-5.6-sol',
+        presence_penalty: 0.3,
+        reasoning: { mode: 'pro' as const },
+        reasoning_effort: 'max' as const,
         temperature: 0.7,
+        top_p: 0.9,
         tools: [{ function: { description: 'test', name: 'test' }, type: 'function' as const }],
       };
 
@@ -367,6 +371,14 @@ describe('LobeOpenAI', () => {
         { description: 'test', name: 'test', type: 'function' },
         { type: 'web_search' },
       ]);
+      expect(createCall).toMatchObject({
+        model: 'gpt-5.6-sol',
+        reasoning: { effort: 'max', mode: 'pro', summary: 'auto' },
+      });
+      expect(createCall.frequency_penalty).toBeUndefined();
+      expect(createCall.presence_penalty).toBeUndefined();
+      expect(createCall.temperature).toBeUndefined();
+      expect(createCall.top_p).toBeUndefined();
     });
 
     it('should add search_context_size to web_search tool when OPENAI_SEARCH_CONTEXT_SIZE is set', async () => {
@@ -443,10 +455,10 @@ describe('LobeOpenAI', () => {
       expect(createCall.reasoning).toEqual({ effort: 'high', summary: 'auto' });
     });
 
-    it('should set reasoning.effort to high for future gpt-5.x-pro models', async () => {
+    it('should set reasoning.effort to high for gpt-5.5-pro', async () => {
       const payload = {
         messages: [{ content: 'Hello', role: 'user' as const }],
-        model: 'gpt-5.6-pro',
+        model: 'gpt-5.5-pro',
         temperature: 0.7,
       };
 

--- a/packages/model-runtime/src/providers/openai/openaiModelId.test.ts
+++ b/packages/model-runtime/src/providers/openai/openaiModelId.test.ts
@@ -13,12 +13,12 @@ import {
 
 describe('parseOpenAIModelId', () => {
   it('should parse native GPT model ids', () => {
-    expect(parseOpenAIModelId('gpt-5.6-pro-2026-06-25')).toEqual({
+    expect(parseOpenAIModelId('gpt-5.6-sol')).toEqual({
       family: 'gpt',
       majorVersion: 5,
       minorVersion: 6,
-      modifiers: ['pro'],
-      normalizedModelId: 'gpt-5.6-pro-2026-06-25',
+      modifiers: ['sol'],
+      normalizedModelId: 'gpt-5.6-sol',
       source: 'openai',
     });
   });
@@ -35,12 +35,12 @@ describe('parseOpenAIModelId', () => {
   });
 
   it('should parse OpenRouter OpenAI ids', () => {
-    expect(parseOpenAIModelId('openai/gpt-5.6-mini')).toEqual({
+    expect(parseOpenAIModelId('openai/gpt-5.6-terra')).toEqual({
       family: 'gpt',
       majorVersion: 5,
       minorVersion: 6,
-      modifiers: ['mini'],
-      normalizedModelId: 'gpt-5.6-mini',
+      modifiers: ['terra'],
+      normalizedModelId: 'gpt-5.6-terra',
       source: 'openRouter',
     });
   });
@@ -81,15 +81,16 @@ describe('isGPT5ResponsesModel', () => {
     expect(isGPT5ResponsesModel('gpt-5.5-pro')).toBe(true);
   });
 
-  it('should match future GPT-5 minor versions without allowlist entries', () => {
+  it('should match the GPT-5.6 family without allowlist entries', () => {
     expect(isGPT5ResponsesModel('gpt-5.6')).toBe(true);
-    expect(isGPT5ResponsesModel('gpt-5.6-mini')).toBe(true);
-    expect(isGPT5ResponsesModel('gpt-5.6-pro')).toBe(true);
+    expect(isGPT5ResponsesModel('gpt-5.6-sol')).toBe(true);
+    expect(isGPT5ResponsesModel('gpt-5.6-terra')).toBe(true);
+    expect(isGPT5ResponsesModel('gpt-5.6-luna')).toBe(true);
   });
 
   it('should not force OpenRouter GPT slugs into the built-in Responses API rules', () => {
-    expect(isGPT5ResponsesModel('openai/gpt-5.6-pro')).toBe(false);
-    expect(isResponsesAPIModel('openai/gpt-5.6-pro')).toBe(false);
+    expect(isGPT5ResponsesModel('openai/gpt-5.6-terra')).toBe(false);
+    expect(isResponsesAPIModel('openai/gpt-5.6-terra')).toBe(false);
   });
 
   it('should not match non-GPT-5 ids', () => {
@@ -100,27 +101,31 @@ describe('isGPT5ResponsesModel', () => {
 });
 
 describe('isGPT5ProResponsesModel', () => {
-  it('should match future GPT-5 pro variants', () => {
-    expect(isGPT5ProResponsesModel('gpt-5.6-pro')).toBe(true);
-    expect(isGPT5ProResponsesModel('gpt-5.6-pro-2026-06-25')).toBe(true);
+  it('should match GPT-5 pro variants', () => {
+    expect(isGPT5ProResponsesModel('gpt-5-pro')).toBe(true);
+    expect(isGPT5ProResponsesModel('gpt-5.5-pro')).toBe(true);
   });
 
   it('should not match non-pro GPT-5 variants', () => {
     expect(isGPT5ProResponsesModel('gpt-5.6')).toBe(false);
-    expect(isGPT5ProResponsesModel('gpt-5.6-mini')).toBe(false);
-    expect(isGPT5ProResponsesModel('openai/gpt-5.6-pro-2026-06-25')).toBe(false);
+    expect(isGPT5ProResponsesModel('gpt-5.6-sol')).toBe(false);
+    expect(isGPT5ProResponsesModel('gpt-5.6-terra')).toBe(false);
+    expect(isGPT5ProResponsesModel('gpt-5.6-luna')).toBe(false);
+    expect(isGPT5ProResponsesModel('openai/gpt-5.5-pro')).toBe(false);
   });
 });
 
 describe('supportsGPT5ResponsesReasoningEffortNone', () => {
   it('should support none reasoning effort for non-pro GPT-5 minor models', () => {
     expect(supportsGPT5ResponsesReasoningEffortNone('gpt-5.6')).toBe(true);
-    expect(supportsGPT5ResponsesReasoningEffortNone('gpt-5.6-mini')).toBe(true);
+    expect(supportsGPT5ResponsesReasoningEffortNone('gpt-5.6-sol')).toBe(true);
+    expect(supportsGPT5ResponsesReasoningEffortNone('gpt-5.6-terra')).toBe(true);
+    expect(supportsGPT5ResponsesReasoningEffortNone('gpt-5.6-luna')).toBe(true);
   });
 
   it('should preserve unsupported cases', () => {
     expect(supportsGPT5ResponsesReasoningEffortNone('gpt-5')).toBe(false);
-    expect(supportsGPT5ResponsesReasoningEffortNone('gpt-5.6-pro')).toBe(false);
+    expect(supportsGPT5ResponsesReasoningEffortNone('gpt-5.5-pro')).toBe(false);
     expect(supportsGPT5ResponsesReasoningEffortNone('openai/gpt-5.6')).toBe(false);
     expect(supportsGPT5ResponsesReasoningEffortNone('gpt-4o')).toBe(false);
   });
@@ -133,8 +138,8 @@ describe('isOpenAIReasoningPayloadModel', () => {
     expect(isOpenAIReasoningPayloadModel('o4-mini')).toBe(true);
     expect(isOpenAIReasoningPayloadModel('codex-mini-latest')).toBe(true);
     expect(isOpenAIReasoningPayloadModel('computer-use-preview')).toBe(true);
-    expect(isOpenAIReasoningPayloadModel('gpt-5.6-mini')).toBe(true);
-    expect(isOpenAIReasoningPayloadModel('openai/gpt-5.6')).toBe(true);
+    expect(isOpenAIReasoningPayloadModel('gpt-5.6-luna')).toBe(true);
+    expect(isOpenAIReasoningPayloadModel('openai/gpt-5.6-sol')).toBe(true);
   });
 
   it('should preserve unsupported cases', () => {
@@ -150,14 +155,14 @@ describe('isOpenAIComputerUseModel', () => {
   });
 
   it('should not match unrelated models', () => {
-    expect(isOpenAIComputerUseModel('gpt-5.6')).toBe(false);
+    expect(isOpenAIComputerUseModel('gpt-5.6-sol')).toBe(false);
   });
 });
 
 describe('supportsOpenAIServiceTierFlex', () => {
   it('should support flex tier model families', () => {
-    expect(supportsOpenAIServiceTierFlex('gpt-5.6')).toBe(true);
-    expect(supportsOpenAIServiceTierFlex('openai/gpt-5.6-mini')).toBe(true);
+    expect(supportsOpenAIServiceTierFlex('gpt-5.6-sol')).toBe(true);
+    expect(supportsOpenAIServiceTierFlex('openai/gpt-5.6-terra')).toBe(true);
     expect(supportsOpenAIServiceTierFlex('o3-pro')).toBe(true);
     expect(supportsOpenAIServiceTierFlex('o4-mini')).toBe(true);
   });

--- a/packages/model-runtime/src/providers/openai/openaiPayload.test.ts
+++ b/packages/model-runtime/src/providers/openai/openaiPayload.test.ts
@@ -3,18 +3,21 @@ import { describe, expect, it } from 'vitest';
 import { params } from './index';
 
 describe('OpenAI payload handlers', () => {
-  it('should force future GPT-5 minor models to use Responses API', () => {
-    const result = params.chatCompletion.handlePayload({
-      messages: [{ content: 'Hello', role: 'user' }],
-      model: 'gpt-5.6',
-      temperature: 0.7,
-    });
+  it.each(['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'])(
+    'should route %s through the Responses API',
+    (model) => {
+      const result = params.chatCompletion.handlePayload({
+        messages: [{ content: 'Hello', role: 'user' }],
+        model,
+        temperature: 0.7,
+      });
 
-    expect(result).toMatchObject({
-      apiMode: 'responses',
-      model: 'gpt-5.6',
-    });
-  });
+      expect(result).toMatchObject({
+        apiMode: 'responses',
+        model,
+      });
+    },
+  );
 
   it('should keep GPT-5 chat-latest variants on Chat Completions', () => {
     const result = params.chatCompletion.handlePayload({
@@ -29,16 +32,16 @@ describe('OpenAI payload handlers', () => {
     expect(result.apiMode).toBeUndefined();
   });
 
-  it('should normalize future GPT-5 pro reasoning effort to high in Responses payloads', () => {
+  it('should normalize GPT-5 Pro reasoning effort to high in Responses payloads', () => {
     const result = params.responses.handlePayload({
       messages: [{ content: 'Hello', role: 'user' }],
-      model: 'gpt-5.6-pro',
+      model: 'gpt-5.5-pro',
       reasoning: { effort: 'medium' },
       temperature: 0.7,
     });
 
     expect(result).toMatchObject({
-      model: 'gpt-5.6-pro',
+      model: 'gpt-5.5-pro',
       reasoning: { effort: 'high', summary: 'auto' },
     });
   });

--- a/packages/model-runtime/src/types/chat.ts
+++ b/packages/model-runtime/src/types/chat.ts
@@ -134,6 +134,7 @@ export interface ChatStreamPayload {
   provider?: string;
   reasoning?: {
     effort?: string;
+    mode?: 'standard' | 'pro';
     summary?: string;
   };
   reasoning_effort?: 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
@@ -261,10 +262,7 @@ export interface UsageMissingDiagnostics {
   provider?: string;
   responseId?: string;
   source:
-    | 'anthropic_messages'
-    | 'google_generative_ai'
-    | 'openai_chat_completions'
-    | 'openai_responses';
+    'anthropic_messages' | 'google_generative_ai' | 'openai_chat_completions' | 'openai_responses';
   terminalEventType: string;
   terminalStatus?: string;
 }

--- a/packages/model-runtime/src/utils/modelExtendParams.test.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.test.ts
@@ -81,6 +81,52 @@ describe('applyModelExtendParams', () => {
     ).toBe('high');
   });
 
+  it('resolves GPT-5.6 max reasoning effort', () => {
+    const result = applyModelExtendParams({
+      chatConfig: chatConfig({ gpt5_6ReasoningEffort: 'max' }),
+      extendParams: ['gpt5_6ReasoningEffort'],
+      model: 'gpt-5.6-sol',
+    });
+
+    expect(result.reasoning_effort).toBe('max');
+  });
+
+  it('resolves GPT-5.6 Pro mode independently from reasoning effort', () => {
+    const result = applyModelExtendParams({
+      chatConfig: chatConfig({
+        gpt5_6ReasoningEffort: 'max',
+        reasoningMode: 'pro',
+      }),
+      extendParams: ['reasoningMode', 'gpt5_6ReasoningEffort'],
+      model: 'gpt-5.6-sol',
+    });
+
+    expect(result).toMatchObject({
+      reasoning: { mode: 'pro' },
+      reasoning_effort: 'max',
+    });
+  });
+
+  it('omits the default Standard reasoning mode', () => {
+    const result = applyModelExtendParams({
+      chatConfig: chatConfig({ reasoningMode: 'standard' }),
+      extendParams: ['reasoningMode'],
+      model: 'gpt-5.6-sol',
+    });
+
+    expect(result.reasoning).toBeUndefined();
+  });
+
+  it('omits Pro mode when the model card does not declare reasoningMode', () => {
+    const result = applyModelExtendParams({
+      chatConfig: chatConfig({ reasoningMode: 'pro' }),
+      extendParams: ['gpt5_6ReasoningEffort'],
+      model: 'gpt-5.6-sol',
+    });
+
+    expect(result.reasoning).toBeUndefined();
+  });
+
   it('resolves GLM-5.2 reasoning effort', () => {
     const result = applyModelExtendParams({
       chatConfig: chatConfig({ glm5_2ReasoningEffort: 'max' }),

--- a/packages/model-runtime/src/utils/modelExtendParams.ts
+++ b/packages/model-runtime/src/utils/modelExtendParams.ts
@@ -11,6 +11,9 @@ export interface ModelExtendParams {
   imageAspectRatio?: string;
   imageResolution?: string;
   preserveThinking?: boolean;
+  reasoning?: {
+    mode?: 'standard' | 'pro';
+  };
   reasoning_effort?: string;
   thinking?: {
     budget_tokens?: number;
@@ -214,6 +217,14 @@ export const applyModelExtendParams = (ctx: ApplyModelExtendParamsContext): Mode
 
   if (modelExtendParams.includes('gpt5_2ReasoningEffort') && chatConfig.gpt5_2ReasoningEffort) {
     extendParams.reasoning_effort = chatConfig.gpt5_2ReasoningEffort;
+  }
+
+  if (modelExtendParams.includes('gpt5_6ReasoningEffort') && chatConfig.gpt5_6ReasoningEffort) {
+    extendParams.reasoning_effort = chatConfig.gpt5_6ReasoningEffort;
+  }
+
+  if (modelExtendParams.includes('reasoningMode') && chatConfig.reasoningMode === 'pro') {
+    extendParams.reasoning = { ...extendParams.reasoning, mode: 'pro' };
   }
 
   if (

--- a/packages/types/src/agent/chatConfig.ts
+++ b/packages/types/src/agent/chatConfig.ts
@@ -90,6 +90,7 @@ export interface LobeAgentChatConfig extends AgentMemoryChatConfig, AgentSelfIte
   gpt5_1ReasoningEffort?: 'none' | 'low' | 'medium' | 'high';
   gpt5_2ProReasoningEffort?: 'medium' | 'high' | 'xhigh';
   gpt5_2ReasoningEffort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh';
+  gpt5_6ReasoningEffort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
   gpt5ReasoningEffort?: 'minimal' | 'low' | 'medium' | 'high';
   grok4_3ReasoningEffort?: 'none' | 'low' | 'medium' | 'high';
   grok4_5ReasoningEffort?: 'low' | 'medium' | 'high';
@@ -136,6 +137,10 @@ export interface LobeAgentChatConfig extends AgentMemoryChatConfig, AgentSelfIte
    */
   reasoningBudgetToken80k?: number;
   reasoningEffort?: 'low' | 'medium' | 'high';
+  /**
+   * Selects the Responses API reasoning execution mode.
+   */
+  reasoningMode?: 'standard' | 'pro';
   ring2_6ReasoningEffort?: 'high' | 'xhigh';
   /**
    * Runtime environment configuration (desktop only)
@@ -240,6 +245,7 @@ export const AgentChatConfigSchema = z
     gpt5_1ReasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
     gpt5_2ProReasoningEffort: z.enum(['medium', 'high', 'xhigh']).optional(),
     gpt5_2ReasoningEffort: z.enum(['none', 'low', 'medium', 'high', 'xhigh']).optional(),
+    gpt5_6ReasoningEffort: z.enum(['none', 'low', 'medium', 'high', 'xhigh', 'max']).optional(),
     glm5_2ReasoningEffort: z.enum(['high', 'max']).optional(),
     grok4_20ReasoningEffort: z.enum(['low', 'medium', 'high', 'xhigh']).optional(),
     grok4_3ReasoningEffort: z.enum(['none', 'low', 'medium', 'high']).optional(),
@@ -258,6 +264,7 @@ export const AgentChatConfigSchema = z
     reasoningBudgetToken32k: z.number().optional(),
     reasoningBudgetToken80k: z.number().optional(),
     reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+    reasoningMode: z.enum(['standard', 'pro']).optional(),
     searchFCModel: z
       .object({
         model: z.string(),

--- a/packages/types/src/openai/chat.ts
+++ b/packages/types/src/openai/chat.ts
@@ -117,6 +117,14 @@ export interface ChatStreamPayload {
    * @default openai
    */
   provider?: string;
+  /**
+   * Responses API reasoning configuration.
+   */
+  reasoning?: {
+    effort?: string;
+    mode?: 'standard' | 'pro';
+    summary?: string;
+  };
   response_format?: ChatResponseFormat;
   responseMode?: 'stream' | 'json';
   /**

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ControlsForm.tsx
@@ -25,6 +25,7 @@ import GPT5ReasoningEffortSlider from './GPT5ReasoningEffortSlider';
 import GPT51ReasoningEffortSlider from './GPT51ReasoningEffortSlider';
 import GPT52ProReasoningEffortSlider from './GPT52ProReasoningEffortSlider';
 import GPT52ReasoningEffortSlider from './GPT52ReasoningEffortSlider';
+import { GPT56ReasoningEffortSlider } from './GPT56ReasoningEffortSlider';
 import Grok43ReasoningEffortSlider from './Grok43ReasoningEffortSlider';
 import Grok45ReasoningEffortSlider from './Grok45ReasoningEffortSlider';
 import Grok420ReasoningEffortSlider from './Grok420ReasoningEffortSlider';
@@ -35,6 +36,7 @@ import ImageResolution2Slider from './ImageResolution2Slider';
 import ImageResolutionSlider from './ImageResolutionSlider';
 import Opus47EffortSlider from './Opus47EffortSlider';
 import ReasoningEffortSlider from './ReasoningEffortSlider';
+import ReasoningModeSegmented from './ReasoningModeSegmented';
 import ReasoningTokenSlider from './ReasoningTokenSlider';
 import ReasoningTokenSlider32k from './ReasoningTokenSlider32k';
 import ReasoningTokenSlider80k from './ReasoningTokenSlider80k';
@@ -240,6 +242,21 @@ const ControlsForm = memo<ControlsFormProps>(
         },
       },
       {
+        children: <ReasoningModeSegmented />,
+        desc: isNarrow ? (
+          <span style={descNarrow}>{t('extendParams.reasoningMode.desc')}</span>
+        ) : (
+          t('extendParams.reasoningMode.desc')
+        ),
+        label: t('extendParams.reasoningMode.title'),
+        layout: 'vertical',
+        minWidth: undefined,
+        name: 'reasoningMode',
+        style: {
+          paddingBottom: 0,
+        },
+      },
+      {
         children: <EffortSlider />,
         desc: isNarrow ? (
           <span style={descNarrow}>{t('extendParams.effort.desc')}</span>
@@ -298,6 +315,17 @@ const ControlsForm = memo<ControlsFormProps>(
         layout: 'vertical',
         minWidth: undefined,
         name: 'gpt5_2ReasoningEffort',
+        style: {
+          paddingBottom: 0,
+        },
+      },
+      {
+        children: <GPT56ReasoningEffortSlider />,
+        desc: 'reasoning_effort',
+        label: t('extendParams.reasoningEffort.title'),
+        layout: 'vertical',
+        minWidth: undefined,
+        name: 'gpt5_6ReasoningEffort',
         style: {
           paddingBottom: 0,
         },

--- a/src/features/ModelSwitchPanel/components/ControlsForm/GPT56ReasoningEffortSlider.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/GPT56ReasoningEffortSlider.tsx
@@ -1,0 +1,14 @@
+import type { CreatedLevelSliderProps } from './createLevelSlider';
+import { createLevelSliderComponent } from './createLevelSlider';
+
+const GPT56_REASONING_EFFORT_LEVELS = ['none', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
+type GPT56ReasoningEffort = (typeof GPT56_REASONING_EFFORT_LEVELS)[number];
+
+export type GPT56ReasoningEffortSliderProps = CreatedLevelSliderProps<GPT56ReasoningEffort>;
+
+export const GPT56ReasoningEffortSlider = createLevelSliderComponent<GPT56ReasoningEffort>({
+  configKey: 'gpt5_6ReasoningEffort',
+  defaultValue: 'medium',
+  levels: GPT56_REASONING_EFFORT_LEVELS,
+  style: { minWidth: 270 },
+});

--- a/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningModeSegmented.tsx
+++ b/src/features/ModelSwitchPanel/components/ControlsForm/ReasoningModeSegmented.tsx
@@ -1,0 +1,88 @@
+import type { SegmentedOptions } from '@lobehub/ui/base-ui';
+import { Segmented } from '@lobehub/ui/base-ui';
+import { memo } from 'react';
+
+import { useAgentId } from '@/features/ChatInput/hooks/useAgentId';
+import { useUpdateAgentConfig } from '@/features/ChatInput/hooks/useUpdateAgentConfig';
+import { useAgentStore } from '@/store/agent';
+import { chatConfigByIdSelectors } from '@/store/agent/selectors';
+
+const REASONING_MODES = ['standard', 'pro'] as const;
+type ReasoningMode = (typeof REASONING_MODES)[number];
+
+const REASONING_MODE_OPTIONS = [
+  { label: 'Standard', value: 'standard' },
+  { label: 'Pro', value: 'pro' },
+] satisfies SegmentedOptions<ReasoningMode>;
+
+export interface ReasoningModeSegmentedProps {
+  defaultValue?: ReasoningMode;
+  disabled?: boolean;
+  id?: string;
+  onChange?: (value: ReasoningMode) => void;
+  value?: ReasoningMode;
+}
+
+const ReasoningModeSegmentedInner = memo<{
+  disabled?: boolean;
+  id?: string;
+  onChange: (value: ReasoningMode) => void;
+  value: ReasoningMode;
+}>(({ disabled, id, onChange, value }) => (
+  <Segmented<ReasoningMode>
+    block
+    disabled={disabled}
+    id={id}
+    options={REASONING_MODE_OPTIONS}
+    size={'small'}
+    style={{ maxWidth: 240 }}
+    value={value}
+    onChange={onChange}
+  />
+));
+
+const ReasoningModeSegmentedWithStore = memo<{
+  defaultValue: ReasoningMode;
+  disabled?: boolean;
+  id?: string;
+}>(({ defaultValue, disabled, id }) => {
+  const agentId = useAgentId();
+  const { updateAgentChatConfig } = useUpdateAgentConfig();
+  const config = useAgentStore((s) => chatConfigByIdSelectors.getChatConfigById(agentId)(s));
+
+  const value = REASONING_MODES.includes(config.reasoningMode as ReasoningMode)
+    ? (config.reasoningMode as ReasoningMode)
+    : defaultValue;
+
+  return (
+    <ReasoningModeSegmentedInner
+      disabled={disabled}
+      id={id}
+      value={value}
+      onChange={(reasoningMode) => updateAgentChatConfig({ reasoningMode })}
+    />
+  );
+});
+
+const ReasoningModeSegmented = memo<ReasoningModeSegmentedProps>(
+  ({ defaultValue = 'standard', disabled, id, onChange, value }) => {
+    const isControlled = value !== undefined || onChange !== undefined;
+
+    if (isControlled) {
+      return (
+        <ReasoningModeSegmentedInner
+          disabled={disabled}
+          id={id}
+          value={value ?? defaultValue}
+          onChange={onChange ?? (() => {})}
+        />
+      );
+    }
+
+    return (
+      <ReasoningModeSegmentedWithStore defaultValue={defaultValue} disabled={disabled} id={id} />
+    );
+  },
+);
+
+export default ReasoningModeSegmented;

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/ExtendParamsSelect.tsx
@@ -13,6 +13,7 @@ import GPT5ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/Co
 import GPT51ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/GPT51ReasoningEffortSlider';
 import GPT52ProReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/GPT52ProReasoningEffortSlider';
 import GPT52ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/GPT52ReasoningEffortSlider';
+import { GPT56ReasoningEffortSlider } from '@/features/ModelSwitchPanel/components/ControlsForm/GPT56ReasoningEffortSlider';
 import Grok43ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/Grok43ReasoningEffortSlider';
 import Grok45ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/Grok45ReasoningEffortSlider';
 import Grok420ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/Grok420ReasoningEffortSlider';
@@ -23,6 +24,7 @@ import ImageResolution2Slider from '@/features/ModelSwitchPanel/components/Contr
 import ImageResolutionSlider from '@/features/ModelSwitchPanel/components/ControlsForm/ImageResolutionSlider';
 import Opus47EffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/Opus47EffortSlider';
 import ReasoningEffortSlider from '@/features/ModelSwitchPanel/components/ControlsForm/ReasoningEffortSlider';
+import ReasoningModeSegmented from '@/features/ModelSwitchPanel/components/ControlsForm/ReasoningModeSegmented';
 import ReasoningTokenSlider from '@/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider';
 import ReasoningTokenSlider32k from '@/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider32k';
 import ReasoningTokenSlider80k from '@/features/ModelSwitchPanel/components/ControlsForm/ReasoningTokenSlider80k';
@@ -87,6 +89,10 @@ const EXTEND_PARAMS_OPTIONS: ExtendParamsOption[] = [
     key: 'reasoningEffort',
   },
   {
+    hintKey: 'providerModels.item.modelConfig.extendParams.options.reasoningMode.hint',
+    key: 'reasoningMode',
+  },
+  {
     hintKey: 'providerModels.item.modelConfig.extendParams.options.gpt5ReasoningEffort.hint',
     key: 'gpt5ReasoningEffort',
   },
@@ -97,6 +103,10 @@ const EXTEND_PARAMS_OPTIONS: ExtendParamsOption[] = [
   {
     hintKey: 'providerModels.item.modelConfig.extendParams.options.gpt5_2ReasoningEffort.hint',
     key: 'gpt5_2ReasoningEffort',
+  },
+  {
+    hintKey: 'providerModels.item.modelConfig.extendParams.options.gpt5_6ReasoningEffort.hint',
+    key: 'gpt5_6ReasoningEffort',
   },
   {
     hintKey: 'providerModels.item.modelConfig.extendParams.options.gpt5_2ProReasoningEffort.hint',
@@ -193,6 +203,7 @@ const TITLE_KEY_ALIASES: Partial<Record<ExtendParamsType, ExtendParamsType>> = {
   gpt5_1ReasoningEffort: 'reasoningEffort',
   gpt5_2ProReasoningEffort: 'reasoningEffort',
   gpt5_2ReasoningEffort: 'reasoningEffort',
+  gpt5_6ReasoningEffort: 'reasoningEffort',
   glm5_2ReasoningEffort: 'reasoningEffort',
   grok4_20ReasoningEffort: 'reasoningEffort',
   grok4_3ReasoningEffort: 'reasoningEffort',
@@ -244,6 +255,7 @@ const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
     tag: 'reasoning_effort',
   },
   gpt5_2ReasoningEffort: { labelSuffix: ' (GPT-5.2)', previewWidth: 300, tag: 'reasoning_effort' },
+  gpt5_6ReasoningEffort: { labelSuffix: ' (GPT-5.6)', previewWidth: 340, tag: 'reasoning_effort' },
   glm5_2ReasoningEffort: { labelSuffix: ' (GLM-5.2)', previewWidth: 240, tag: 'reasoning_effort' },
   grok4_20ReasoningEffort: {
     labelSuffix: ' (Grok 4.20)',
@@ -280,6 +292,7 @@ const PREVIEW_META: Partial<Record<ExtendParamsType, PreviewMeta>> = {
     previewWidth: 460,
     tag: 'preserve_thinking',
   },
+  reasoningMode: { labelSuffix: ' (GPT-5.6)', previewWidth: 280, tag: 'reasoning.mode' },
   reasoningBudgetToken: { previewWidth: 350, tag: 'thinking.budget_tokens' },
   reasoningBudgetToken32k: {
     labelSuffix: ' (32k)',
@@ -427,6 +440,7 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
       gpt5_1ReasoningEffort: <GPT51ReasoningEffortSlider value="none" />,
       gpt5_2ProReasoningEffort: <GPT52ProReasoningEffortSlider value="medium" />,
       gpt5_2ReasoningEffort: <GPT52ReasoningEffortSlider value="none" />,
+      gpt5_6ReasoningEffort: <GPT56ReasoningEffortSlider value="medium" />,
       glm5_2ReasoningEffort: <GLM52ReasoningEffortSlider value="max" />,
       grok4_20ReasoningEffort: <Grok420ReasoningEffortSlider value="medium" />,
       grok4_3ReasoningEffort: <Grok43ReasoningEffortSlider value="low" />,
@@ -442,6 +456,7 @@ const ExtendParamsSelect = memo<ExtendParamsSelectProps>(({ value, onChange }) =
       reasoningBudgetToken32k: <ReasoningTokenSlider32k defaultValue={1 * 1024} />,
       reasoningBudgetToken80k: <ReasoningTokenSlider80k defaultValue={1 * 1024} />,
       reasoningEffort: <ReasoningEffortSlider value="medium" />,
+      reasoningMode: <ReasoningModeSegmented value="standard" />,
       step3_5ReasoningEffort: <Step3_5ReasoningEffortSlider value="low" />,
       textVerbosity: <TextVerbositySlider value="medium" />,
       thinking: <ThinkingSlider value="auto" />,

--- a/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/__tests__/ExtendParamsSelect.test.tsx
+++ b/src/routes/(main)/settings/provider/features/ModelList/CreateNewModelModal/__tests__/ExtendParamsSelect.test.tsx
@@ -9,6 +9,7 @@ describe('ExtendParamsSelect', () => {
   describe('normalizeExtendParamsValue', () => {
     const definitionMap = new Map([
       ['enableReasoning', { key: 'enableReasoning' }],
+      ['reasoningMode', { key: 'reasoningMode' }],
       ['reasoningBudgetToken', { key: 'reasoningBudgetToken' }],
     ]) as any;
 
@@ -20,10 +21,10 @@ describe('ExtendParamsSelect', () => {
     it('should filter unsupported extend params while keeping valid values', () => {
       expect(
         normalizeExtendParamsValue(
-          ['enableReasoning', 'unsupportedParam', 'reasoningBudgetToken'] as any,
+          ['enableReasoning', 'unsupportedParam', 'reasoningMode', 'reasoningBudgetToken'] as any,
           definitionMap,
         ),
-      ).toEqual(['enableReasoning', 'reasoningBudgetToken']);
+      ).toEqual(['enableReasoning', 'reasoningMode', 'reasoningBudgetToken']);
     });
   });
 
@@ -34,6 +35,7 @@ describe('ExtendParamsSelect', () => {
       gpt5_1ReasoningEffort: 'reasoningEffort',
       gpt5_2ProReasoningEffort: 'reasoningEffort',
       gpt5_2ReasoningEffort: 'reasoningEffort',
+      gpt5_6ReasoningEffort: 'reasoningEffort',
       glm5_2ReasoningEffort: 'reasoningEffort',
       thinkingLevel2: 'thinkingLevel',
     };
@@ -43,6 +45,7 @@ describe('ExtendParamsSelect', () => {
       expect(TITLE_KEY_ALIASES['gpt5_1ReasoningEffort']).toBe('reasoningEffort');
       expect(TITLE_KEY_ALIASES['gpt5_2ReasoningEffort']).toBe('reasoningEffort');
       expect(TITLE_KEY_ALIASES['gpt5_2ProReasoningEffort']).toBe('reasoningEffort');
+      expect(TITLE_KEY_ALIASES['gpt5_6ReasoningEffort']).toBe('reasoningEffort');
     });
 
     it('should map GLM-5.2 variant to reasoningEffort', () => {
@@ -66,6 +69,7 @@ describe('ExtendParamsSelect', () => {
       gpt5_1ReasoningEffort: 'reasoningEffort',
       gpt5_2ProReasoningEffort: 'reasoningEffort',
       gpt5_2ReasoningEffort: 'reasoningEffort',
+      gpt5_6ReasoningEffort: 'reasoningEffort',
       glm5_2ReasoningEffort: 'reasoningEffort',
       thinkingLevel2: 'thinkingLevel',
     };

--- a/src/services/chat/mecha/modelParamsResolver.test.ts
+++ b/src/services/chat/mecha/modelParamsResolver.test.ts
@@ -435,6 +435,60 @@ describe('resolveModelExtendParams', () => {
       });
     });
 
+    describe('gpt5_6ReasoningEffort param', () => {
+      beforeEach(() => {
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'isModelHasExtendParams').mockReturnValue(
+          () => true,
+        );
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParams').mockReturnValue(() => [
+          'gpt5_6ReasoningEffort',
+        ]);
+      });
+
+      it('should set max reasoning_effort for GPT-5.6', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: {
+            gpt5_6ReasoningEffort: 'max',
+          } as any,
+          model: 'gpt-5.6-sol',
+          provider: 'openai',
+        });
+
+        expect(result.reasoning_effort).toBe('max');
+      });
+    });
+
+    describe('reasoningMode param', () => {
+      beforeEach(() => {
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'isModelHasExtendParams').mockReturnValue(
+          () => true,
+        );
+        vi.spyOn(aiModelSelectors.aiModelSelectors, 'modelExtendParams').mockReturnValue(() => [
+          'reasoningMode',
+        ]);
+      });
+
+      it('should set Pro mode for GPT-5.6', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: { reasoningMode: 'pro' },
+          model: 'gpt-5.6-sol',
+          provider: 'openai',
+        });
+
+        expect(result.reasoning).toEqual({ mode: 'pro' });
+      });
+
+      it('should omit the default Standard mode', () => {
+        const result = resolveModelExtendParams({
+          chatConfig: { reasoningMode: 'standard' },
+          model: 'gpt-5.6-sol',
+          provider: 'openai',
+        });
+
+        expect(result.reasoning).toBeUndefined();
+      });
+    });
+
     describe('gpt5_2ProReasoningEffort param', () => {
       beforeEach(() => {
         vi.spyOn(aiModelSelectors.aiModelSelectors, 'isModelHasExtendParams').mockReturnValue(


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

- N/A — new OpenAI model capability
- [OpenAI reasoning mode documentation](https://developers.openai.com/api/docs/guides/reasoning#reasoning-mode)
- [OpenAI prompt caching documentation](https://developers.openai.com/api/docs/guides/prompt-caching)

#### 🔀 Description of Change

- Recognize the GPT-5.6 alias and Sol, Terra, and Luna family model IDs as Responses API models.
- Add the GPT-5.6 reasoning effort range from `none` through `max`.
- Add an independent `standard` / `pro` reasoning mode setting and a compact segmented control.
- Preserve the upstream default by omitting `reasoning.mode` for Standard and sending it only for Pro.
- Forward Pro mode and reasoning effort together in OpenAI and Azure OpenAI Responses payloads.
- Account for `cache_write_tokens` in Chat Completions and Responses usage without double-charging uncached input.
- Add shared types, locales, model descriptions, and regression coverage.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check --lint --test --type
```

Result: 23 changed files linted, 206 related tests passed, and type checks passed.

Manual verification:

1. Configure a GPT-5.6 model card with `reasoningMode` and `gpt5_6ReasoningEffort` extend params.
2. Confirm the model controls show a compact `Standard | Pro` segmented selector and the six effort levels.
3. Select Pro + Max and verify the Responses request contains `reasoning: { mode: 'pro', effort: 'max' }`.
4. Switch back to Standard and verify `reasoning.mode` is omitted.

Live upstream smoke testing remains pending until GPT-5.6 access is available to the test account.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Reasoning mode rendered as a full-width two-step slider | Reasoning mode rendered as a compact `Standard | Pro` segmented control |

#### 📝 Additional Information

- Reasoning mode and reasoning effort remain independent, matching the OpenAI Responses API contract.
- Existing GPT Pro model IDs retain their current fixed-effort behavior.
- Standard mode intentionally sends no new field, minimizing compatibility risk for OpenAI-compatible endpoints.
- No breaking changes or migration are required.
