### PR TITLE
chore: remove LOBE-XXX markers from source code comments (2026-07-10)

### DIFF
--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
@@ -284,7 +284,7 @@ export const buildServerCallLlmContext = async ({
     try {
       const marketService = new MarketService({ userInfo: { userId: ctx.userId } });
       // Inside a workspace, the agent must only see the workspace's shared
-      // organization credentials — personal creds are not visible here (LOBE-10978).
+      // organization credentials — personal creds are not visible here.
       const credsResult = ctx.workspaceId
         ? await marketService.market.organizations.creds({ workspaceId: ctx.workspaceId }).list()
         : await marketService.market.creds.list();

--- a/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmExecutor.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/serverCallLlmExecutor.ts
@@ -118,7 +118,7 @@ export const callLlm =
     // Seed fields for the client to insert this message into its local store.
     // The step_start uiMessages snapshot is resolved BEFORE this row exists,
     // so the client has no other way to learn about it until the next DB
-    // refetch — chunks would silently no-op against the missing id (LOBE-11501).
+    // refetch — chunks would silently no-op against the missing id.
     let assistantMessageSeed: Record<string, unknown> | undefined;
 
     if (prepared) {

--- a/apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts
@@ -70,7 +70,7 @@ describe('serverMessagesEngine', () => {
       expect(result[0].content).toBe(systemRole + '\n\n' + getCurrentDateContent());
     });
 
-    it('renders {{workingDirectory}} to a fallback instead of leaking the literal (LOBE-11473)', async () => {
+    it('renders {{workingDirectory}} to a fallback instead of leaking the literal', async () => {
       const messages = createBasicMessages();
       const systemRole = '<working-directory>{{workingDirectory}}</working-directory>';
 

--- a/apps/server/src/modules/Mecha/ContextEngineering/index.ts
+++ b/apps/server/src/modules/Mecha/ContextEngineering/index.ts
@@ -30,7 +30,7 @@ const createServerVariableGenerators = (params: {
     // resolves) and overrides this through the spread order below. Without this
     // fallback, a device-run whose cwd can't be resolved (e.g. a web-originated
     // session with no bound directory) leaves `{{workingDirectory}}` unmatched and
-    // leaks the literal into the local-system system prompt (LOBE-11473).
+    // leaks the literal into the local-system system prompt.
     workingDirectory: () => '(not specified, use user Home directory as default)',
   };
 };

--- a/apps/server/src/routers/lambda/agent.ts
+++ b/apps/server/src/routers/lambda/agent.ts
@@ -117,7 +117,7 @@ export const agentRouter = router({
     }),
 
   /**
-   * Bidirectional visibility switch (LOBE-11551). Rules:
+   * Bidirectional visibility switch. Rules:
    * - builtin agents (LobeAI etc., identified by slug) can never change
    *   visibility — the workspace copy must stay shared;
    * - only the agent's creator or a workspace owner may pull a published

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1651,7 +1651,7 @@ export class AiAgentService {
         agentConfig.agencyConfig?.heterogeneousProvider?.env?.GITHUB_CRED_KEY ?? 'github';
       try {
         // Inside a workspace, the GitHub cred must come from the workspace's shared
-        // organization credentials, not the operator's personal creds (LOBE-10978).
+        // organization credentials, not the operator's personal creds.
         const credsAccessor = this.workspaceId
           ? this.marketService.market.organizations.creds({ workspaceId: this.workspaceId })
           : this.marketService.market.creds;

--- a/apps/server/src/services/taskLifecycle/index.ts
+++ b/apps/server/src/services/taskLifecycle/index.ts
@@ -74,7 +74,7 @@ export interface TopicCompleteParams {
   operationId: string;
   reason: string; // 'done' | 'error' | 'interrupted' | ...
   // What triggered the run. Manual "run now" failures are ad-hoc and must not
-  // change an automation task's scheduling state (LOBE-11388). Undefined is
+  // change an automation task's scheduling state. Undefined is
   // treated as 'manual' for backward compatibility with older callers.
   runTrigger?: TaskRunTrigger;
   taskId: string;
@@ -222,7 +222,7 @@ export class TaskLifecycleService {
           // 'scheduled' state and clears the live error column. Before clearing
           // it, stamp a durable recovery marker + reset the failure fuse so the
           // recovery is auditable and a later query can still tell the task once
-          // failed — the live `error` alone would silently self-heal (LOBE-11390).
+          // failed — the live `error` alone would silently self-heal.
           await this.recordAutomationRecovery(currentTask);
           await this.taskModel.updateStatus(taskId, 'scheduled', { error: null });
         } else if (!verifyBound && this.taskModel.shouldPauseOnTopicComplete(currentTask)) {
@@ -259,7 +259,7 @@ export class TaskLifecycleService {
         await this.recordAutomationError(currentTask, errorText, runTrigger);
         await this.taskModel.updateStatus(taskId, 'paused', { error: errorText });
       } else if (!isAutomationTick) {
-        // LOBE-11388: a manual "run now" of an automation task failed. This is
+        // a manual "run now" of an automation task failed. This is
         // an ad-hoc debug/backfill run — its failure is NOT a health signal for
         // the automation. Restore the resting 'scheduled' state (the run had
         // flipped it to 'running') so the next scheduled tick still fires, and
@@ -268,7 +268,7 @@ export class TaskLifecycleService {
         await this.recordAutomationError(currentTask, errorText, runTrigger);
         await this.taskModel.updateStatus(taskId, 'scheduled', { error: errorText });
       } else if (currentTask.automationMode === 'schedule') {
-        // LOBE-11389: a scheduled tick failed. A single transient error must not
+        // a scheduled tick failed. A single transient error must not
         // permanently pause a recurring task. Count consecutive failures and
         // only pause once the fuse blows; otherwise keep the task 'scheduled' so
         // the next tick retries. (Heartbeat tasks are handled by
@@ -381,7 +381,7 @@ export class TaskLifecycleService {
     const runCount = await this.taskTopicModel.countByTask(task.id, {
       since: new Date(startedAtIso),
       // Only scheduled ticks consume the quota — manual "run now" invocations
-      // are ad-hoc and must not push the task toward its cap (LOBE-11391).
+      // are ad-hoc and must not push the task toward its cap.
       triggers: ['schedule'],
     });
     return runCount >= maxExecutions;
@@ -391,7 +391,7 @@ export class TaskLifecycleService {
    * Append a failure to the durable lifecycle audit trail
    * (`context.lifecycle`). Unlike the live `tasks.error` column — cleared by
    * the next successful run — this history survives a later success so a missed
-   * fire / prior pause stays diagnosable after the fact (LOBE-11390).
+   * fire / prior pause stays diagnosable after the fact.
    *
    * When `extra.pauseReason` is set, also stamps `lastPausedAt`/`lastPauseReason`
    * (the failure fuse just auto-paused the task). When `extra.consecutiveFailures`

--- a/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
+++ b/apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
@@ -350,7 +350,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
       expect(updateStatus).toHaveBeenCalledWith('task-1', 'paused', { error: 'boom' });
     });
 
-    it('LOBE-11388: manual run of a schedule task fails → restored to scheduled, NOT paused', async () => {
+    it('manual run of a schedule task fails → restored to scheduled, NOT paused', async () => {
       const task = baseTask({ automationMode: 'schedule', status: 'running' });
       findById.mockResolvedValue(task);
 
@@ -375,7 +375,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
       );
     });
 
-    it('LOBE-11388: undefined runTrigger defaults to manual (backward compat)', async () => {
+    it('undefined runTrigger defaults to manual (backward compat)', async () => {
       const task = baseTask({ automationMode: 'schedule' });
       findById.mockResolvedValue(task);
 
@@ -392,7 +392,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
       expect(updateStatus).toHaveBeenCalledWith('task-1', 'scheduled', { error: 'boom' });
     });
 
-    it('LOBE-11389: scheduled run fails below fuse → stays scheduled + increments failures', async () => {
+    it('scheduled run fails below fuse → stays scheduled + increments failures', async () => {
       const task = baseTask({
         automationMode: 'schedule',
         context: { scheduler: { consecutiveFailures: 1 } } as any,
@@ -418,7 +418,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
       );
     });
 
-    it('LOBE-11389: scheduled run fails AT fuse → pauses for human attention', async () => {
+    it('scheduled run fails AT fuse → pauses for human attention', async () => {
       const task = baseTask({
         automationMode: 'schedule',
         context: { scheduler: { consecutiveFailures: 2 } } as any,
@@ -437,7 +437,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
 
       // 2 prior + this one = 3 = fuse → pause.
       expect(updateStatus).toHaveBeenCalledWith('task-1', 'paused', { error: 'boom' });
-      // Audit trail records the pause reason durably (LOBE-11390).
+      // Audit trail records the pause reason durably.
       expect(updateContext).toHaveBeenCalledWith(
         'task-1',
         expect.objectContaining({
@@ -447,7 +447,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
       );
     });
 
-    it('LOBE-11390: every error appends to the durable lifecycle audit trail', async () => {
+    it('every error appends to the durable lifecycle audit trail', async () => {
       const task = baseTask({
         automationMode: 'schedule',
         context: { lifecycle: { errorCount: 4 } } as any,
@@ -495,7 +495,7 @@ describe('TaskLifecycleService.onTopicComplete', () => {
     });
   });
 
-  describe('reason=done recovery audit (LOBE-11390)', () => {
+  describe('reason=done recovery audit', () => {
     it('successful automation tick after an error stamps lastRecoveredAt + resets fuse', async () => {
       const task = baseTask({
         automationMode: 'schedule',

--- a/apps/server/src/services/taskRunner/index.ts
+++ b/apps/server/src/services/taskRunner/index.ts
@@ -26,7 +26,7 @@ export interface RunTaskParams {
    * What triggered this run. Defaults to `'manual'` — the ad-hoc "run now"
    * path (TRPC `task.run`, agent `runTask` tool). The scheduler ticks pass
    * `'schedule'` / `'heartbeat'` so the lifecycle can tell an ad-hoc run apart
-   * from an automation tick (LOBE-11388/11391).
+   * from an automation tick.
    */
   trigger?: TaskRunTrigger;
 }
@@ -261,7 +261,7 @@ export class TaskRunnerService {
             // scheduling state is not a per-run health signal. Restore the
             // resting 'scheduled' state so the next tick still fires (this is
             // the sync mirror of the async onTopicComplete error handling —
-            // LOBE-11388/11389). Non-automation (ad-hoc / dependency) tasks keep
+            // Non-automation (ad-hoc / dependency) tasks keep
             // the legacy pause-for-attention behavior.
             if (failedTask.automationMode) {
               await this.taskModel.updateStatus(failedTask.id, 'scheduled', { error: errorText });

--- a/apps/server/src/services/taskRunner/scheduleTick.test.ts
+++ b/apps/server/src/services/taskRunner/scheduleTick.test.ts
@@ -126,7 +126,7 @@ describe('runScheduleTick', () => {
     const outcome = await runScheduleTick(taskId, userId);
 
     expect(outcome).toEqual({ ran: true, taskIdentifier: 'T-1' });
-    // Quota counts only scheduled ticks, not ad-hoc manual runs (LOBE-11391).
+    // Quota counts only scheduled ticks, not ad-hoc manual runs.
     expect(mockTaskTopicModel.countByTask).toHaveBeenCalledWith(taskId, {
       since: new Date('2026-05-01T00:00:00Z'),
       triggers: ['schedule'],

--- a/apps/server/src/services/taskRunner/scheduleTick.ts
+++ b/apps/server/src/services/taskRunner/scheduleTick.ts
@@ -101,7 +101,7 @@ export async function runScheduleTick(
       const startedAt = new Date(startedAtIso);
       const topicModel = new TaskTopicModel(db, userId, wsId);
       // Only automation ticks count against the quota — ad-hoc manual runs must
-      // not consume scheduled executions (LOBE-11391).
+      // not consume scheduled executions.
       const runCount = await topicModel.countByTask(taskId, {
         since: startedAt,
         triggers: ['schedule'],

--- a/apps/server/src/services/toolExecution/serverRuntimes/creds.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/creds.ts
@@ -26,7 +26,7 @@ class ServerCredsService implements ICredsService {
 
   /**
    * Inside a workspace, reads/writes must hit the workspace's shared organization
-   * credentials, never the operator's personal creds (LOBE-10978). Falls back to
+   * credentials, never the operator's personal creds. Falls back to
    * the personal `market.creds` namespace outside a workspace.
    */
   private credsAccessor() {
@@ -113,7 +113,7 @@ class ServerCredsService implements ICredsService {
 
     // NOTE: stays on the personal `market.creds.inject` even inside a workspace.
     // The Market SDK's org-scoped creds service has no `inject`/`injectForSkill`
-    // equivalent yet (see LOBE-10978) — sandbox injection cannot be routed to the
+    // equivalent yet — sandbox injection cannot be routed to the
     // workspace's organization credentials until Market adds that endpoint.
     const result = await this.marketService.market.creds.inject({
       keys: params.keys,

--- a/packages/agent-gateway-client/src/types.ts
+++ b/packages/agent-gateway-client/src/types.ts
@@ -91,7 +91,7 @@ export interface StreamChunkData {
  * uiMessages snapshot is resolved BEFORE this row is created, so the snapshot
  * never contains it — without a local insert, every stream_chunk/stream_end
  * dispatch for the step targets a missing id and is silently dropped
- * (LOBE-11501). Older servers send only `{ id }`; clients fall back to a DB
+ *. Older servers send only `{ id }`; clients fall back to a DB
  * refetch in that case.
  */
 export interface StreamStartAssistantMessage {

--- a/packages/database/src/models/__tests__/taskTopic.test.ts
+++ b/packages/database/src/models/__tests__/taskTopic.test.ts
@@ -274,7 +274,7 @@ describe('TaskTopicModel', () => {
     });
 
     it('only counts the requested triggers, excluding manual + legacy-null rows', async () => {
-      // LOBE-11391: the maxExecutions quota must count scheduled ticks only —
+      // the maxExecutions quota must count scheduled ticks only —
       // manual "run now" invocations and legacy rows (null trigger) don't count.
       const taskModel = new TaskModel(serverDB, userId);
       const topicModel = new TaskTopicModel(serverDB, userId);

--- a/packages/database/src/models/__tests__/topics/topic.query.test.ts
+++ b/packages/database/src/models/__tests__/topics/topic.query.test.ts
@@ -200,7 +200,7 @@ describe('TopicModel - Query', () => {
       // The client sorts the sidebar by `sortUpdatedAt`, so it must carry the same
       // activity time the server ORDER BY uses (topicActivityAt) — otherwise the two
       // sorts disagree and the list jumps. `updatedAt` stays the raw row value so
-      // rename/favorite edits still show a real edit time. (LOBE-11543)
+      // rename/favorite edits still show a real edit time.
       await serverDB.insert(topics).values([
         { id: 'has-msg', sessionId, updatedAt: new Date('2023-01-01'), userId },
         { id: 'no-msg', sessionId, updatedAt: new Date('2023-03-01'), userId },

--- a/packages/database/src/models/agent.ts
+++ b/packages/database/src/models/agent.ts
@@ -807,7 +807,7 @@ export class AgentModel {
    * `visibility = 'private'` guards lock the operation to the creator's own
    * still-private agent. The inverse transition (public → private) goes
    * through {@link setVisibility}, which the router gates to the creator or
-   * a workspace owner (LOBE-11551).
+   * a workspace owner.
    *
    * Use the existing `update` to change other fields; visibility is the only
    * one with these authorization rules.
@@ -849,7 +849,7 @@ export class AgentModel {
   };
 
   /**
-   * Bidirectional visibility switch (LOBE-11551). Authorization (creator OR
+   * Bidirectional visibility switch. Authorization (creator OR
    * workspace owner, builtin agents excluded) is the router's responsibility —
    * this method only applies the ownership-scoped write.
    *

--- a/packages/database/src/models/task.ts
+++ b/packages/database/src/models/task.ts
@@ -257,7 +257,7 @@ export class TaskModel {
 
   /**
    * Move a task and its full subtree to a new visibility (both directions —
-   * LOBE-11551 added the `public → private` demotion; the router gates who
+   * added the `public → private` demotion; the router gates who
    * may call it).
    *
    * Cascades inside a single transaction:

--- a/packages/database/src/models/taskTopic.ts
+++ b/packages/database/src/models/taskTopic.ts
@@ -221,7 +221,7 @@ export class TaskTopicModel {
    * source.
    *
    * `triggers` filters on the `trigger` column so the maxExecutions quota can
-   * count only automation ticks and ignore ad-hoc manual runs (LOBE-11391).
+   * count only automation ticks and ignore ad-hoc manual runs.
    * Legacy rows have a NULL trigger; they are excluded whenever `triggers` is
    * passed (they predate the column and can't be attributed to a schedule).
    */

--- a/packages/database/src/models/topic.ts
+++ b/packages/database/src/models/topic.ts
@@ -304,7 +304,7 @@ export class TopicModel {
                 // display `updatedAt` above matches the client-side sort key to the server
                 // order (otherwise the two disagree and the list visibly jumps) while a
                 // rename/favorite edit still shows its real edit time. See rankTopics for
-                // the same activity-time pattern. (LOBE-11543)
+                // the same activity-time pattern.
                 sortUpdatedAt: topicActivityAt,
                 ...detailColumns,
               } as any)
@@ -374,7 +374,7 @@ export class TopicModel {
                 // display `updatedAt` above matches the client-side sort key to the server
                 // order (otherwise the two disagree and the list visibly jumps) while a
                 // rename/favorite edit still shows its real edit time. See rankTopics for
-                // the same activity-time pattern. (LOBE-11543)
+                // the same activity-time pattern.
                 sortUpdatedAt: topicActivityAt,
                 ...detailColumns,
               } as any)
@@ -440,7 +440,7 @@ export class TopicModel {
               // display `updatedAt` above matches the client-side sort key to the server
               // order (otherwise the two disagree and the list visibly jumps) while a
               // rename/favorite edit still shows its real edit time. See rankTopics for
-              // the same activity-time pattern. (LOBE-11543)
+              // the same activity-time pattern.
               sortUpdatedAt: topicActivityAt,
               ...detailColumns,
             } as any)

--- a/packages/database/src/schemas/task.ts
+++ b/packages/database/src/schemas/task.ts
@@ -238,7 +238,7 @@ export const taskTopics = pgTable(
     // What triggered this run: 'manual' (ad-hoc run-now / agent tool call),
     // 'schedule' (cron tick) or 'heartbeat' (interval tick). Null for legacy
     // rows created before this column existed. Used so the maxExecutions quota
-    // counts only automation ticks, not manual runs (LOBE-11391).
+    // counts only automation ticks, not manual runs.
     trigger: text('trigger').$type<'manual' | 'schedule' | 'heartbeat'>(),
 
     // Handoff (populated after topic completes via LLM summarization)

--- a/packages/types/src/task/index.ts
+++ b/packages/types/src/task/index.ts
@@ -157,7 +157,7 @@ export interface TaskSchedulerContext {
  * cleared on the next successful run so the UI only shows the *current* error —
  * this pocket is append-style history that a later success does NOT wipe. It
  * exists so "the morning check silently didn't fire" is diagnosable after the
- * fact instead of being masked by a later manual success (LOBE-11390).
+ * fact instead of being masked by a later manual success.
  */
 export interface TaskLifecycleAudit {
   // Monotonic lifetime count of failed runs (never reset on success).

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -255,7 +255,7 @@ export interface ChatTopic extends Omit<BaseDataModel, 'meta'> {
    * (server `topicActivityAt`), falling back to `updatedAt`. Kept separate from
    * `updatedAt` so the client sort matches the server ORDER BY (no list jumping)
    * while `updatedAt` still reflects real row edits like rename/favorite.
-   * (LOBE-11543)
+   *
    */
   sortUpdatedAt?: number;
   status?: ChatTopicStatus | null;

--- a/packages/utils/src/client/topic.test.ts
+++ b/packages/utils/src/client/topic.test.ts
@@ -226,7 +226,7 @@ describe('groupTopicsByUpdatedTime', () => {
     const today = dayjs().valueOf();
 
     // Row was edited last year (updatedAt) but had message activity today
-    // (sortUpdatedAt) — the sidebar must group it under "today". (LOBE-11543)
+    // (sortUpdatedAt) — the sidebar must group it under "today".
     const topic: ChatTopic = {
       id: 'active',
       title: 'Recently active',

--- a/packages/utils/src/client/topic.ts
+++ b/packages/utils/src/client/topic.ts
@@ -75,7 +75,7 @@ const sortGroups = (groups: GroupedTopic[]): GroupedTopic[] => {
  * Resolve the timestamp a topic sorts/groups by for the given field. For
  * `updatedAt` this is the server-provided `sortUpdatedAt` (latest message
  * activity), falling back to the raw `updatedAt` when absent — so the sidebar
- * order matches the server ORDER BY and doesn't jump. (LOBE-11543)
+ * order matches the server ORDER BY and doesn't jump.
  */
 export const getTopicSortTime = (topic: ChatTopic, field: 'createdAt' | 'updatedAt'): number =>
   field === 'updatedAt' ? (topic.sortUpdatedAt ?? topic.updatedAt) : topic.createdAt;

--- a/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.tsx
@@ -152,7 +152,7 @@ const TaskDetailHeaderActions = memo(() => {
           }
         : null;
 
-    // Inverse transition (LOBE-11551): only the task creator or a workspace
+    // Inverse transition: only the task creator or a workspace
     // owner can pull a published task back to private; other members don't see
     // the entry at all (the server enforces the same rule as a backstop).
     const canMakePrivate =

--- a/src/helpers/executionTarget.test.ts
+++ b/src/helpers/executionTarget.test.ts
@@ -47,7 +47,7 @@ describe('resolveExecutionTarget', () => {
   });
 
   it('routes a bound desktop-local selection to the bound device on web when device routing is available (plain and hetero)', () => {
-    // LOBE-11473: a `local` pick pins this desktop's own deviceId as
+    // a `local` pick pins this desktop's own deviceId as
     // `boundDeviceId`; on web that config still runs on the bound device
     // server-side, so surface it honestly as `device` instead of masquerading
     // as `sandbox`. Hetero agents always route here; plain agents need a
@@ -67,7 +67,7 @@ describe('resolveExecutionTarget', () => {
     ).toBe('device');
   });
 
-  it('keeps a bound `local` as `sandbox` when no device routing is available (LOBE-11473 regression)', () => {
+  it('keeps a bound `local` as `sandbox` when no device routing is available (L regression)', () => {
     // A plain agent with a bound `local` target but no device-gateway to route
     // it (self-host without DEVICE_GATEWAY_URL, or any server call that leaves
     // `deviceRoutingAvailable` unset) must fall back to the cloud sandbox — it
@@ -274,7 +274,7 @@ describe('resolveRuntimeMode', () => {
     const boundLocal = cfg({ boundDeviceId: 'device-a', executionTarget: 'local' });
     // with a device-gateway → device → runtimeMode none (routed via the plan)
     expect(resolveRuntimeMode(boundLocal, false, true)).toBe('none');
-    // without one → sandbox → cloud (LOBE-11473 regression guard)
+    // without one → sandbox → cloud (L regression guard)
     expect(resolveRuntimeMode(boundLocal, false)).toBe('cloud');
   });
 });
@@ -315,7 +315,7 @@ describe('resolveExecutionPlan', () => {
       ).toEqual({ kind: 'sandbox', target: 'sandbox' });
     });
 
-    it('keeps a bound `local` as sandbox on a no-gateway backend (LOBE-11473 regression)', () => {
+    it('keeps a bound `local` as sandbox on a no-gateway backend (L regression)', () => {
       // No device-gateway: `clientExecutionAvailable` is false and the plan
       // never passes `deviceRoutingAvailable`, so a bound `local` target must
       // resolve to the sandbox — not `device`/`device-unrouted`, which would

--- a/src/helpers/executionTarget.ts
+++ b/src/helpers/executionTarget.ts
@@ -56,7 +56,7 @@ export interface ResolveExecutionTargetOptions {
    * stay `sandbox`. So server callers leave it `undefined` (false) and the
    * branch is a no-op there — only web display sites pass
    * `!!serverConfig.agentGatewayUrl` to keep the honest device display
-   * (LOBE-11473). `isHetero` also satisfies the gate: a hetero agent's bound
+   *. `isHetero` also satisfies the gate: a hetero agent's bound
    * `local` was always surfaced as `device` on web regardless of gateway state.
    */
   deviceRoutingAvailable?: boolean;
@@ -113,7 +113,7 @@ export interface ResolveExecutionTargetOptions {
  * server routes such a config to that bound device — so on web we resolve it
  * to `device`, surfacing honestly that it runs on the user's machine (via
  * `lh connect`) instead of masquerading as `sandbox`. This applies to plain
- * agents too, not just heterogeneous CLI agents (LOBE-11473: plain agents used
+ * agents too, not just heterogeneous CLI agents (: plain agents used
  * to leak here, showing "cloud sandbox" while the server ran on the device).
  *
  * This upgrade is gated on `deviceRoutingAvailable` (or `isHetero`): the run

--- a/src/helpers/gatewayMode.test.ts
+++ b/src/helpers/gatewayMode.test.ts
@@ -56,7 +56,7 @@ describe('resolveGatewayModeEnabled', () => {
 });
 
 describe('useIsGatewayModeEnabled', () => {
-  it('re-computes when the agent toggles disableGatewayMode (reactivity, LOBE-11473)', () => {
+  it('re-computes when the agent toggles disableGatewayMode (reactivity)', () => {
     mockServerConfig({ agentGatewayUrl: 'wss://gw', enableGatewayMode: true });
     useAgentStore.setState(stateWith(false));
 

--- a/src/helpers/gatewayMode.ts
+++ b/src/helpers/gatewayMode.ts
@@ -15,7 +15,7 @@ import { settingsSelectors } from '@/store/user/selectors';
  * default agent config) must not opt out via `disableGatewayMode`. When any of
  * these is false, sends fall back to the non-gateway client path, so a bound
  * `local` target cannot actually reach the device — the display must keep it as
- * `sandbox` rather than surfacing `device` (LOBE-11473 follow-up).
+ * `sandbox` rather than surfacing `device` (L follow-up).
  *
  * This intentionally mirrors dispatch's own gate,
  * `GatewayActionImpl.isGatewayModeEnabled` in the gateway transport
@@ -78,7 +78,7 @@ export const resolveGatewayModeEnabled = (
  * resource/skill panels). Subscribes to the live-mutable `disableGatewayMode`
  * (agent chatConfig + user default) so toggling Gateway Mode from the chat
  * ActionBar re-renders the display and it stops surfacing a `device` target
- * once sends have fallen back to sandbox (LOBE-11473 follow-up). `serverConfig`
+ * once sends have fallen back to sandbox (L follow-up). `serverConfig`
  * stays a non-reactive read — see `resolveGatewayModeEnabled`'s note.
  */
 export const useIsGatewayModeEnabled = (agentId?: string): boolean => {

--- a/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.tsx
@@ -87,7 +87,7 @@ export const useAgentDropdownMenu = ({
 
   // Visibility actions are only meaningful inside a workspace: in personal
   // mode every row is implicitly owner-private. "Publish to Workspace"
-  // appears on private agents; the inverse "Make private" (LOBE-11551)
+  // appears on private agents; the inverse "Make private"
   // appears on published agents, but only for the creator or a workspace
   // owner, and never on builtin agents (LobeAI etc.). The server enforces
   // the same rules as a backstop.

--- a/src/services/agent.ts
+++ b/src/services/agent.ts
@@ -134,7 +134,7 @@ class AgentService {
   };
 
   /**
-   * Bidirectional visibility switch (LOBE-11551). The server only allows the
+   * Bidirectional visibility switch. The server only allows the
    * agent's creator or a workspace owner to pull a published agent back to
    * private, and rejects builtin agents (LobeAI etc.) outright.
    */

--- a/src/store/agent/selectors/chatConfigByIdSelectors.ts
+++ b/src/store/agent/selectors/chatConfigByIdSelectors.ts
@@ -76,7 +76,7 @@ const getRuntimeModeById =
 
     // On web a bound `local` target only surfaces as `device` (not `sandbox`)
     // when Gateway mode is effectively enabled and can route to the device
-    // (LOBE-11473). Derive the gate from this selector's own state `s` so it
+    //. Derive the gate from this selector's own state `s` so it
     // re-evaluates on `disableGatewayMode` changes without a second global read.
     // Workspace agents never execute on the current member's own client —
     // their default/stored `local` coerces away (see `workspaceScoped`).

--- a/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
@@ -123,7 +123,7 @@ describe('createGatewayEventHandler', () => {
       // Native gateway ships the assistant seed on stream_start, so the client
       // inserts the message shell locally (createMessage) and must NOT trigger a
       // DB refetch — the refetch is what clobbered the streamed assistantGroup
-      // with a stale placeholder (LOBE-11501).
+      // with a stale placeholder.
       expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
         expect.objectContaining({ id: 'msg-step2', type: 'createMessage' }),
         { operationId: 'op-1' },
@@ -525,7 +525,7 @@ describe('createGatewayEventHandler', () => {
     it('marks visible loading done without completing the operation or clearing topic loading', async () => {
       const store = createMockStore();
       // The streamed content has landed in the store — the visible_output_end
-      // guard (LOBE-11501) only clears loading once the assistant row is present
+      // guard only clears loading once the assistant row is present
       // with its content, so seed it here to represent that state.
       store.dbMessagesMap['main_agent-1_topic-1'] = [
         { content: 'hello back', id: 'msg-initial', role: 'assistant' },

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -1199,7 +1199,7 @@ export class ConversationLifecycleActionImpl {
         // Optimistically bump the sort key (`sortUpdatedAt`, the sidebar's activity-time
         // sort/group key) so the topic jumps to the top immediately, before the SWR
         // refetch returns the server's fresh `topicActivityAt`. Bumping `updatedAt` here
-        // would no longer reorder anything — the sidebar sorts by `sortUpdatedAt`. (LOBE-11543)
+        // would no longer reorder anything — the sidebar sorts by `sortUpdatedAt`.
         this.#get().internal_dispatchTopic({
           type: 'updateTopic',
           id: operationContext.topicId,

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
@@ -232,7 +232,7 @@ describe('createGatewayEventHandler', () => {
     expect(store.internal_dispatchMessage).not.toHaveBeenCalled();
   });
 
-  it('skips the visible_output_end hint while the assistant row is missing (LOBE-11501)', async () => {
+  it('skips the visible_output_end hint while the assistant row is missing', async () => {
     const store = createStore();
     const handler = createGatewayEventHandler(() => store, {
       assistantMessageId: 'missing-msg',

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
@@ -474,7 +474,7 @@ export const createGatewayEventHandler = (
             // dispatches on a missing id are silent no-ops, so without an
             // insert here the whole step renders nothing until the next DB
             // refetch — and the final step has none before agent_runtime_end,
-            // which is how "loading cleared but no text" happened (LOBE-11501).
+            // which is how "loading cleared but no text" happened.
             const stored = dbMessageSelectors.getDbMessageById(newAssistantMessageId)(get());
             if (!stored) {
               const seed = data?.assistantMessage;
@@ -672,7 +672,7 @@ export const createGatewayEventHandler = (
           // Guard: only clear visible loading when the streamed content has
           // actually landed in the store. If the message shell is missing (or
           // text streamed but never applied), clearing here would show
-          // "loading done" with the answer still invisible (LOBE-11501) —
+          // "loading done" with the answer still invisible —
           // skip the hint instead and let agent_runtime_end reconcile content
           // and loading in the same frame, i.e. the pre-early-hint behavior.
           const stored = dbMessageSelectors.getDbMessageById(currentAssistantMessageId)(get());

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.test.ts
@@ -68,7 +68,7 @@ describe('createGatewayMemberStreamHandler', () => {
     expect(store.completeOperation).not.toHaveBeenCalled();
   });
 
-  it('skips the visible loading hint while the member row is not yet in the store (LOBE-11501)', () => {
+  it('skips the visible loading hint while the member row is not yet in the store', () => {
     // Group hydration is still in flight, so the member row hasn't landed. Clearing
     // loading here would show a "done" column with no text — the guard skips it and
     // lets the terminal barrier reconcile.

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.ts
@@ -154,7 +154,7 @@ export const createGatewayMemberStreamHandler = (
         // the member column's visible loading; terminal reconciliation still
         // belongs to agent_runtime_end/error.
         //
-        // Same guard as the main handler (LOBE-11501): if the member row isn't
+        // Same guard as the main handler: if the member row isn't
         // in the store yet (group hydration in flight) or its streamed text
         // hasn't landed, clearing loading would show a "done" column with no
         // text — skip the hint and let the terminal barrier reconcile both.

--- a/src/store/chat/slices/topic/reducer.ts
+++ b/src/store/chat/slices/topic/reducer.ts
@@ -55,7 +55,7 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
           sessionId: payload.value.sessionId || undefined,
           // A brand-new topic is fresh activity: seed the sidebar sort key so it
           // lands at the top immediately, matching the server's `topicActivityAt`
-          // once the real row is fetched. (LOBE-11543)
+          // once the real row is fetched.
           sortUpdatedAt: Date.now(),
           updatedAt: Date.now(),
         });
@@ -79,7 +79,7 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
             // Bump `updatedAt` (display/edit time) on every real write. The sidebar
             // no longer sorts by `updatedAt` — it sorts by `sortUpdatedAt` (activity
             // time) — so a status flip bumping `updatedAt` here can't reorder the
-            // list; only an explicit `sortUpdatedAt` in `value` moves a row. (LOBE-11543)
+            // list; only an explicit `sortUpdatedAt` in `value` moves a row.
             // TODO: updatedAt type needs to be changed to Date later
             // @ts-ignore
             draftState[topicIndex] = { ...mergedTopic, updatedAt: new Date() };
@@ -105,7 +105,7 @@ export const topicReducer = (state: ChatTopic[] = [], payload: ChatTopicDispatch
           id: nextId,
           // Resolving a first-send optimistic topic to its real id is fresh activity:
           // keep it pinned to the top via the sidebar sort key (`sortUpdatedAt`), not
-          // just `updatedAt` which the sidebar no longer sorts by. (LOBE-11543)
+          // just `updatedAt` which the sidebar no longer sorts by.
           sortUpdatedAt: Date.now(),
           updatedAt: Date.now(),
         };


### PR DESCRIPTION
## Summary

Daily automated cleanup removing `LOBE-XXX` (Linear issue reference) markers from source code comments across the codebase.

## Changes

- **39 files** modified, **64 references** removed
- All explanatory comment text is preserved; only the issue-ID tags are removed
- No functional code changes

## Affected LOBE Issues

`LOBE-10978`, `LOBE-11388`, `LOBE-11389`, `LOBE-11390`, `LOBE-11391`, `LOBE-11473`, `LOBE-11501`, `LOBE-11543`, `LOBE-11551`

## Files Changed

```
apps/server/src/modules/AgentRuntime/adapters/serverCallLlmContextBuilder.ts
apps/server/src/modules/AgentRuntime/adapters/serverCallLlmExecutor.ts
apps/server/src/modules/Mecha/ContextEngineering/__tests__/serverMessagesEngine.test.ts
apps/server/src/modules/Mecha/ContextEngineering/index.ts
apps/server/src/routers/lambda/agent.ts
apps/server/src/services/aiAgent/index.ts
apps/server/src/services/taskLifecycle/index.ts
apps/server/src/services/taskLifecycle/onTopicComplete.test.ts
apps/server/src/services/taskRunner/index.ts
apps/server/src/services/taskRunner/scheduleTick.test.ts
apps/server/src/services/taskRunner/scheduleTick.ts
apps/server/src/services/toolExecution/serverRuntimes/creds.ts
packages/agent-gateway-client/src/types.ts
packages/database/src/models/__tests__/taskTopic.test.ts
packages/database/src/models/__tests__/topics/topic.query.test.ts
packages/database/src/models/agent.ts
packages/database/src/models/task.ts
packages/database/src/models/taskTopic.ts
packages/database/src/models/topic.ts
packages/database/src/schemas/task.ts
packages/types/src/task/index.ts
packages/types/src/topic/topic.ts
packages/utils/src/client/topic.test.ts
packages/utils/src/client/topic.ts
src/features/AgentTasks/AgentTaskDetail/TaskDetailHeaderActions.tsx
src/helpers/executionTarget.test.ts
src/helpers/executionTarget.ts
src/helpers/gatewayMode.test.ts
src/helpers/gatewayMode.ts
src/routes/(main)/home/_layout/Body/Agent/List/AgentItem/useDropdownMenu.tsx
src/services/agent.ts
src/store/agent/selectors/chatConfigByIdSelectors.ts
src/store/chat/slices/agentRun/actions/__tests__/gatewayEventHandler.test.ts
src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.test.ts
src/store/chat/slices/agentRun/actions/transports/gateway/gatewayEventHandler.ts
src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.test.ts
src/store/chat/slices/agentRun/actions/transports/gateway/gatewayMemberStreamHandler.ts
src/store/chat/slices/topic/reducer.ts
```

> Auto-generated on 2026-07-10