### PR TITLE
💄 style(home): hide model shortcuts

### DIFF
--- a/src/features/Workspace/__tests__/workspaceAwarePath.test.ts
+++ b/src/features/Workspace/__tests__/workspaceAwarePath.test.ts
@@ -11,6 +11,12 @@ describe('buildWorkspaceAwarePath', () => {
   it('prefixes absolute paths with the active workspace slug', () => {
     expect(buildWorkspaceAwarePath('/memory', 'acme')).toBe('/acme/memory');
     expect(buildWorkspaceAwarePath('/agent/inbox', 'acme')).toBe('/acme/agent/inbox');
+    expect(buildWorkspaceAwarePath('/image?model=image-model', 'acme')).toBe(
+      '/acme/image?model=image-model',
+    );
+    expect(buildWorkspaceAwarePath('/video?model=video-model', 'acme')).toBe(
+      '/acme/video?model=video-model',
+    );
     expect(buildWorkspaceAwarePath('/community/agent/jailbreak', 'acme')).toBe(
       '/acme/community/agent/jailbreak',
     );

--- a/src/routes/(main)/home/features/InputArea/index.tsx
+++ b/src/routes/(main)/home/features/InputArea/index.tsx
@@ -15,7 +15,6 @@ import { systemStatusSelectors } from '@/store/global/selectors';
 import { stripMarkdownLinks } from './hintFormat';
 import InputDragUpload from './InputDragUpload';
 import MessengerBanner, { MESSENGER_BANNER_ID } from './MessengerBanner';
-import StarterList from './StarterList';
 import { useSend } from './useSend';
 
 const leftActions: ActionKeys[] = ['agentMode', 'plus'];
@@ -118,7 +117,8 @@ const InputArea = () => {
         </InputDragUpload>
       </Flexbox>
 
-      <StarterList />
+      {/* TODO: Remove the deprecated StarterList implementation after the home model shortcuts
+          have been retired permanently. */}
     </Flexbox>
   );
 };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Stop rendering the deprecated home model shortcut list.
- Keep the implementation in place with a TODO for later cleanup.
- Cover workspace-aware image and video paths in the existing route helper tests.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check "lobehub/src/routes/(main)/home/features/InputArea/index.tsx" lobehub/src/features/Workspace/__tests__/workspaceAwarePath.test.ts --lint --test`

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

The shortcut implementation is intentionally retained but no longer mounted. Removing its implementation and related model-default plumbing is a follow-up cleanup.