### PR TITLE
🐛 fix(hetero): show the CLI model and usage while streaming

### DIFF
--- a/.agents/skills/agent-testing/references/probe-mock-patterns.md
+++ b/.agents/skills/agent-testing/references/probe-mock-patterns.md
@@ -543,10 +543,27 @@
   the shell env). This authenticates BOTH the renderer (BackendProxyProtocolManager injects the
   same token) and any main-process fetch, so the whole app comes up signed in. Revert with
   `git checkout --` + `grep -rn AGENT-TEST` afterwards, and never echo the token.
+- **Works — alternative, no source edit, when you can approve a browser prompt**: seed a
+  PRISTINE profile so the app takes the signed-out path and renders the real login screen
+  instead of hanging:
+  ```bash
+  mkdir -p /tmp/empty-golden
+  LOBE_GOLDEN_PROFILE=/tmp/empty-golden ./electron-dev.sh start <id>
+  ```
+  Drive onboarding (`开始` → `下一步` ×2 → `登录 LobeHub Cloud`). The device-code flow opens the
+  browser and auto-approves against an existing app.lobehub.com session, giving the instance its
+  OWN token — so it never rotates the one the user's resident app holds.
+- **Why the blank shell has no login button**: the failed refresh leaves `isUserStateInit:false`
+  (with `isLoaded:true, user:null`), and the desktop first-frame gate waits on it forever. Every
+  route — `/`, `/desktop-onboarding` — renders empty. Reloading, soft-navving, and waiting all
+  fail to resolve it, so it reads exactly like a Case-1 blank page.
 - **Gotcha**: a worktree installed with `pnpm install --ignore-scripts` has NO electron binary
   (`node_modules/.pnpm/electron@*/node_modules/electron/dist` missing). Fix with
   `cd apps/desktop && pnpm rebuild electron`. Also remember `apps/desktop` and `apps/cli` are
   NOT in the root pnpm workspace — install inside each.
+- **Gotcha**: `electron-dev.sh restart <id>` keeps the userData dir, but a device-code session
+  did NOT survive it — budget for one more login after any restart (e.g. when a main-process
+  change forces one, see E9).
 
 ### C5. ✅ WORKS — main-process `logger.info` is invisible unless `DEBUG` is set
 
@@ -561,3 +578,15 @@ session:')` line. In development `createLogger().info` routes to the `debug` pac
   `grep -oE "controllers:HeterogeneousAgentCtr INFO: [^']*" /tmp/lobe-electron-pool/instance-<id>.log`.
   Don't trust the hetero tracing dir for this — it is gated and the copied golden profile ships
   STALE trace sessions from months earlier that look like a fresh run.
+### E9. Main-process code changes need a restart; Vite HMR only covers the renderer
+
+- Adapters under `packages/heterogeneous-agents` run in the **main** process
+  (JSONL framing + adapter + `toStreamEvent`). Editing one and reloading the
+  renderer verifies nothing — the old adapter is still running.
+- Prove which code each process has before trusting a run:
+  ```bash
+  # renderer: vite serves working-tree src (VITE_BASE + id)
+  curl -s --noproxy '*' "http://127.0.0.1:<vitePort>/src/<path>.ts" | grep -c '<marker>'
+  # main: rebuilt on start into the desktop dist bundle
+  grep -c '<marker>' apps/desktop/dist/main/index.js
+  ```

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -18,6 +18,19 @@ describe('ClaudeCodeAdapter', () => {
       expect(adapter.sessionId).toBe('sess_123');
     });
 
+    // `system init` beta-tags the id; every later event reports it clean. The
+    // renderer stamps the assistant from this event, so the tag must not leak.
+    it('strips the beta marker from the init model id', () => {
+      const adapter = new ClaudeCodeAdapter();
+      const events = adapter.adapt({
+        model: 'claude-opus-4-8[1m]',
+        session_id: 'sess_123',
+        subtype: 'init',
+        type: 'system',
+      });
+      expect(events[0].data.model).toBe('claude-opus-4-8');
+    });
+
     it('emits visible_output_end before agent_runtime_end on success result', () => {
       const adapter = new ClaudeCodeAdapter();
       adapter.adapt({ subtype: 'init', type: 'system' });

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -31,6 +31,19 @@ describe('ClaudeCodeAdapter', () => {
       expect(events[0].data.model).toBe('claude-opus-4-8');
     });
 
+    // Only a TRAILING marker is a beta tag — a bracket anywhere else is part of
+    // the id and must survive.
+    it('leaves an id without a trailing marker untouched', () => {
+      const adapter = new ClaudeCodeAdapter();
+      const events = adapter.adapt({
+        model: 'claude-opus[4]-8',
+        session_id: 'sess_123',
+        subtype: 'init',
+        type: 'system',
+      });
+      expect(events[0].data.model).toBe('claude-opus[4]-8');
+    });
+
     it('emits visible_output_end before agent_runtime_end on success result', () => {
       const adapter = new ClaudeCodeAdapter();
       adapter.adapt({ subtype: 'init', type: 'system' });

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -112,8 +112,15 @@ const TASK_LIST_LINE_PATTERN = /^#(\d+) \[(pending|in_progress|completed)\] (.+)
  * that no other event — and no model-bank entry — uses. Strip it so the id the
  * run opens with is the same canonical one `turn_metadata` later confirms;
  * otherwise the assistant renders the tagged id until the first turn ends.
+ *
+ * Sliced rather than matched: an unanchored `/\[[^\]]*\]$/` rescans from every
+ * start offset, which is quadratic on a `[[[[…` input (CodeQL flags it).
  */
-const stripModelBetaMarker = (model?: string) => model?.replace(/\[[^\]]*\]$/, '');
+const stripModelBetaMarker = (model?: string) => {
+  if (!model?.endsWith(']')) return model;
+  const markerStart = model.lastIndexOf('[');
+  return markerStart === -1 ? model : model.slice(0, markerStart);
+};
 
 /**
  * Tool name CC sees for the LobeHub-hosted MCP `ask_user_question` server.

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -108,6 +108,14 @@ const TASK_UPDATE_RESULT_PATTERN = /^Updated task #\d+/;
 const TASK_LIST_LINE_PATTERN = /^#(\d+) \[(pending|in_progress|completed)\] (.+)$/;
 
 /**
+ * `system init` tags the model id with a beta marker (`claude-opus-4-8[1m]`)
+ * that no other event — and no model-bank entry — uses. Strip it so the id the
+ * run opens with is the same canonical one `turn_metadata` later confirms;
+ * otherwise the assistant renders the tagged id until the first turn ends.
+ */
+const stripModelBetaMarker = (model?: string) => model?.replace(/\[[^\]]*\]$/, '');
+
+/**
  * Tool name CC sees for the LobeHub-hosted MCP `ask_user_question` server.
  * Source of truth lives in `../askUser/constants.ts`; replicated here as a
  * literal so the adapter compiles in browser bundles without dragging in
@@ -782,7 +790,7 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
     this.started = true;
     return [
       this.makeEvent('stream_start', {
-        model: raw.model,
+        model: stripModelBetaMarker(raw.model),
         provider: 'claude-code',
         // The CC session id every message this run produces belongs to. A
         // change in this value across a topic means CC forked a new session.

--- a/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
@@ -927,6 +927,64 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
       expect(finalWrite![1].provider).toBe('claude-code');
     });
 
+    // The run's first assistant already exists in `dbMessagesMap` before the
+    // executor starts, so the gateway handler's stream_start seed-insert (its
+    // only model/provider → store path) is skipped for it. The executor must
+    // therefore mirror the flush into the store itself, or the row renders
+    // without a model until the next refetch.
+    it('should dispatch model + provider into the store for the initial assistant', async () => {
+      const seeded = [
+        {
+          agentId: 'agent-1',
+          content: '',
+          id: 'ast-initial',
+          role: 'assistant',
+          topicId: 'topic-1',
+        },
+      ];
+      const store = createMockStore({
+        dbMessagesMap: { 'main_agent-1_topic-1': seeded },
+        messagesMap: { 'main_agent-1_topic-1': seeded },
+      });
+
+      await runWithEvents([ccInit(), ccText('msg_01', 'hi'), ccResult()], { store });
+
+      const dispatched = store.internal_dispatchMessage.mock.calls.find(
+        ([payload]: any) =>
+          payload.type === 'updateMessage' &&
+          payload.id === 'ast-initial' &&
+          payload.value?.provider === 'claude-code',
+      );
+      expect(dispatched).toBeDefined();
+      expect(dispatched![0].value.model).toBe('claude-sonnet-4-6');
+    });
+
+    // `recordUsage` is the main-agent twin of the subagent interpreter's
+    // `recordUsage`, which updates its thread bucket via `stream.update`.
+    // Without the store dispatch, per-turn usage never renders live.
+    it('should dispatch turn usage into the store', async () => {
+      const store = createMockStore();
+
+      await runWithEvents(
+        [
+          ccInit(),
+          ccMessageStart('msg_01', 'claude-opus-4-6'),
+          ccAssistant('msg_01', [{ text: 'Hello', type: 'text' }], { model: 'claude-opus-4-6' }),
+          ccMessageDelta({ input_tokens: 100, output_tokens: 20 }),
+          ccResult(),
+        ],
+        { store },
+      );
+
+      const dispatched = store.internal_dispatchMessage.mock.calls.find(
+        ([payload]: any) =>
+          payload.type === 'updateMessage' && payload.value?.metadata?.usage !== undefined,
+      );
+      expect(dispatched).toBeDefined();
+      expect(dispatched![0].value.model).toBe('claude-opus-4-6');
+      expect(dispatched![0].value.provider).toBe('claude-code');
+    });
+
     it('should write accumulated reasoning', async () => {
       await runWithEvents([
         ccInit(),

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -1478,6 +1478,22 @@ export const executeHeterogeneousAgent = async (
             });
           },
         );
+        // Mirror ONLY model/provider into the store: content/reasoning already
+        // stream live via the gateway handler's raw stream_chunk forward. The
+        // CLI's model has no live path at all — the run's FIRST assistant is
+        // already in `dbMessagesMap` when the run starts, so the gateway's
+        // stream_start seed insert (its one model→store hop) is skipped for it
+        // and the flush above is DB-only. `provider` is already seeded from the
+        // agent config; re-stamping it keeps the store and the row identical.
+        const liveUpdate: Record<string, any> = {};
+        if (intent.model) liveUpdate.model = intent.model;
+        if (intent.provider) liveUpdate.provider = intent.provider;
+        if (Object.keys(liveUpdate).length > 0) {
+          get().internal_dispatchMessage(
+            { id: intent.messageId, type: 'updateMessage', value: liveUpdate },
+            { operationId },
+          );
+        }
         return;
       }
 
@@ -1604,6 +1620,14 @@ export const executeHeterogeneousAgent = async (
         };
         messageWriteBatcher.enqueueUpdateMessage(intent.messageId, update, messageWriteCtx, (err) =>
           console.error('[HeterogeneousAgent] Failed to record main usage:', err),
+        );
+        // Same payload into the store so usage + model/provider render live —
+        // the subagent interpreter's `recordUsage` already does this via
+        // `stream.update`. Dispatching `update` verbatim keeps the store's
+        // metadata identical to the row the batcher writes.
+        get().internal_dispatchMessage(
+          { id: intent.messageId, type: 'updateMessage', value: update as any },
+          { operationId },
         );
         return;
       }


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none found -->

#### 🔀 Description of Change

A heterogeneous run's **first** assistant message rendered without a model id (and without token usage) for the whole run — the value only appeared after the next refetch.

**Root cause.** The main-agent coordinator's `persistAssistant` and `recordUsage` intents only enqueued DB writes via the message batcher. Content and reasoning still stream live because the gateway handler forwards raw `stream_chunk` events, but `model` and `usage` have no such path. The gateway's `stream_start` seed insert is the one place a model reaches the store, and it is guarded by `if (!stored)` — which never fires for a run's first assistant, because that row is already in `dbMessagesMap` before the run starts. So the DB row was correct while the store was not. The subagent interpreter's `recordUsage` already mirrors into its thread bucket via `stream.update`; the main-agent twin did not.

Both intents now dispatch into the store alongside the DB write.

**A follow-on fix in the same PR.** Claude Code's `system init` beta-tags the model id (`claude-opus-4-8[1m]`) while every later event reports it clean — the adapter already documents this. That tagged id used to live only in a transient DB write nobody could see; once the executor dispatches it, the UI renders `claude-opus-4-8[1m]` until the first turn ends and `turn_metadata` corrects it. The marker matches no model-bank entry either. `ClaudeCodeAdapter` now strips it at the init emit, so the id the run opens with is the canonical one, and the DB no longer holds the tagged value even transiently.

Scope note: `provider` was never actually missing — it is seeded from the agent config when the assistant row is created. It is re-stamped here only to keep the store and the row identical.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

**Tests.** Three new cases: two in `heterogeneousAgentExecutor.test.ts` (the seed assistant gets `model` + `provider` dispatched; turn usage is dispatched), one in `claudeCode.test.ts` (the init model id is stripped of its beta marker). Both executor cases were confirmed to fail against the unpatched executor before the fix landed. Full runs: executor 90/90, `heterogeneous-agents` adapter + coordinator 127/127, lint and type-check clean.

**End-to-end.** Verified in an isolated Electron dev instance running the working tree (confirmed live: the Vite-served renderer module and `apps/desktop/dist/main/index.js` both carry the change), driving a real Claude Code conversation through the chat input.

Sampling `dbMessagesMap` every 150ms while the operation was `running`:

| | first assistant, mid-stream |
| --- | --- |
| Before (fix reverted) | `model: null` across all 54 running samples — and still `null` after the run completed |
| After | `model: "claude-opus-4-8"`, `provider: "claude-code"`, `usage: true` while content was still streaming |

Probed a second, multi-step turn with a `Bash` tool call (3 assistant messages): the step-2 assistant created by `openTurn → createAssistant` also carries model/provider/usage live. No `[1m]`-tagged id appeared in any of the 52 running samples after the adapter fix.

#### 📸 Screenshots / Videos

The assistant footer now shows `✳ claude-opus-4-8` and the token count while the message is still streaming; previously that row was empty for the run's first message.

#### 📝 Additional Information

Also appends two entries to `agent-testing`'s probe log, both hit while verifying this:

- A **stale** golden profile wedges the desktop first frame — a failed token refresh leaves `isUserStateInit: false` forever, so the renderer hangs on the splash with no login UI to click. Seeding a pristine profile takes the signed-out path and renders normally. This is a pre-existing product behaviour, not touched here.
- Adapters run in the Electron **main** process, so Vite HMR does not pick them up; a main-process change needs an instance restart, and each process's code should be proven before trusting a run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)