### PR TITLE
🐛 fix(agent): support GPT-5.6 Codex models and usage

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -336,6 +336,7 @@
   "heteroAgent.modelSelector.reasoning.low": "Low",
   "heteroAgent.modelSelector.reasoning.max": "Max",
   "heteroAgent.modelSelector.reasoning.medium": "Medium",
+  "heteroAgent.modelSelector.reasoning.ultra": "Ultra",
   "heteroAgent.modelSelector.reasoning.xhigh": "Extra High",
   "heteroAgent.modelSelector.speed": "Speed",
   "heteroAgent.modelSelector.speed.fast": "Fast",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -338,6 +338,7 @@
   "heteroAgent.modelSelector.reasoning.low": "低",
   "heteroAgent.modelSelector.reasoning.max": "最高",
   "heteroAgent.modelSelector.reasoning.medium": "中",
+  "heteroAgent.modelSelector.reasoning.ultra": "极致",
   "heteroAgent.modelSelector.reasoning.xhigh": "超高",
   "heteroAgent.modelSelector.speed": "速度",
   "heteroAgent.modelSelector.speed.fast": "快速",

--- a/packages/heterogeneous-agents/src/adapters/codex.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/codex.test.ts
@@ -1249,6 +1249,7 @@ describe('CodexAdapter', () => {
         cached_input_tokens: 4,
         input_tokens: 10,
         output_tokens: 3,
+        reasoning_output_tokens: 2,
       },
     });
 
@@ -1259,6 +1260,8 @@ describe('CodexAdapter', () => {
         usage: {
           inputCachedTokens: 4,
           inputCacheMissTokens: 6,
+          outputReasoningTokens: 2,
+          outputTextTokens: 1,
           totalInputTokens: 10,
           totalOutputTokens: 3,
           totalTokens: 13,
@@ -1273,6 +1276,8 @@ describe('CodexAdapter', () => {
       initialCumulativeUsage: {
         inputCachedTokens: 4,
         inputCacheMissTokens: 6,
+        outputReasoningTokens: 1,
+        outputTextTokens: 2,
         totalInputTokens: 10,
         totalOutputTokens: 3,
         totalTokens: 13,
@@ -1285,6 +1290,7 @@ describe('CodexAdapter', () => {
         cached_input_tokens: 9,
         input_tokens: 25,
         output_tokens: 11,
+        reasoning_output_tokens: 5,
       },
     });
 
@@ -1295,6 +1301,8 @@ describe('CodexAdapter', () => {
         usage: {
           inputCachedTokens: 5,
           inputCacheMissTokens: 10,
+          outputReasoningTokens: 4,
+          outputTextTokens: 4,
           totalInputTokens: 15,
           totalOutputTokens: 8,
           totalTokens: 23,

--- a/packages/heterogeneous-agents/src/spawn/codexModel.test.ts
+++ b/packages/heterogeneous-agents/src/spawn/codexModel.test.ts
@@ -110,12 +110,53 @@ describe('codex model metadata helpers', () => {
     });
   });
 
-  it('reads the latest cumulative usage from a Codex rollout session file', async () => {
+  it('prefers real rollout cumulative usage over legacy usage fields', async () => {
     const codexHome = await makeTempCodexHome();
     const sessionDir = path.join(codexHome, 'sessions', '2026', '06', '11');
     await mkdir(sessionDir, { recursive: true });
     await writeFile(
       path.join(sessionDir, 'rollout-2026-06-11T01-31-27-thread-usage.jsonl'),
+      [
+        JSON.stringify({
+          payload: {
+            info: {
+              total_token_usage: {
+                cached_input_tokens: 5,
+                input_tokens: 25,
+                output_tokens: 9,
+                reasoning_output_tokens: 4,
+              },
+            },
+            type: 'token_count',
+            usage: { input_tokens: 100, output_tokens: 100 },
+          },
+          type: 'event_msg',
+          usage: { input_tokens: 200, output_tokens: 200 },
+        }),
+      ].join('\n'),
+    );
+
+    await expect(
+      readCodexSessionModel('thread-usage', { env: { CODEX_HOME: codexHome } }),
+    ).resolves.toMatchObject({
+      cumulativeUsage: {
+        inputCachedTokens: 5,
+        inputCacheMissTokens: 20,
+        outputReasoningTokens: 4,
+        outputTextTokens: 5,
+        totalInputTokens: 25,
+        totalOutputTokens: 9,
+        totalTokens: 34,
+      },
+    });
+  });
+
+  it('keeps legacy rollout usage fields as a fallback', async () => {
+    const codexHome = await makeTempCodexHome();
+    const sessionDir = path.join(codexHome, 'sessions', '2026', '06', '11');
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      path.join(sessionDir, 'rollout-2026-06-11T01-31-27-thread-legacy-usage.jsonl'),
       [
         JSON.stringify({
           payload: { usage: { input_tokens: 10, output_tokens: 2 } },
@@ -129,7 +170,7 @@ describe('codex model metadata helpers', () => {
     );
 
     await expect(
-      readCodexSessionModel('thread-usage', { env: { CODEX_HOME: codexHome } }),
+      readCodexSessionModel('thread-legacy-usage', { env: { CODEX_HOME: codexHome } }),
     ).resolves.toMatchObject({
       cumulativeUsage: {
         inputCachedTokens: 5,

--- a/packages/heterogeneous-agents/src/spawn/codexModel.ts
+++ b/packages/heterogeneous-agents/src/spawn/codexModel.ts
@@ -283,7 +283,10 @@ export const readCodexSessionModel = async (
     try {
       const record = JSON.parse(line);
       const payload = record?.payload;
-      const usage = toCodexUsageData(record?.usage) || toCodexUsageData(payload?.usage);
+      const usage =
+        toCodexUsageData(payload?.info?.total_token_usage) ||
+        toCodexUsageData(record?.usage) ||
+        toCodexUsageData(payload?.usage);
       if (usage) cumulativeUsage = usage;
 
       const payloadModel =

--- a/packages/heterogeneous-agents/src/types.ts
+++ b/packages/heterogeneous-agents/src/types.ts
@@ -275,6 +275,10 @@ export interface UsageData {
   inputCacheMissTokens: number;
   /** Input tokens written into the prompt cache (cache creation). */
   inputWriteCacheTokens?: number;
+  /** Output tokens used for model reasoning. */
+  outputReasoningTokens?: number;
+  /** Non-reasoning output tokens. */
+  outputTextTokens?: number;
   totalInputTokens: number;
   totalOutputTokens: number;
   totalTokens: number;

--- a/packages/heterogeneous-agents/src/utils/codexUsage.test.ts
+++ b/packages/heterogeneous-agents/src/utils/codexUsage.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import { toCodexUsageData, toTurnUsageFromCumulative } from './codexUsage';
+
+describe('Codex usage helpers', () => {
+  it('maps reasoning and text output token breakdowns', () => {
+    expect(
+      toCodexUsageData({
+        cached_input_tokens: 40,
+        input_tokens: 100,
+        output_tokens: 30,
+        reasoning_output_tokens: 12,
+      }),
+    ).toEqual({
+      inputCachedTokens: 40,
+      inputCacheMissTokens: 60,
+      outputReasoningTokens: 12,
+      outputTextTokens: 18,
+      totalInputTokens: 100,
+      totalOutputTokens: 30,
+      totalTokens: 130,
+    });
+  });
+
+  it('omits output breakdowns when reasoning usage is missing or invalid', () => {
+    for (const reasoningOutputTokens of [undefined, -1, 31, Number.NaN]) {
+      const usage = toCodexUsageData({
+        input_tokens: 100,
+        output_tokens: 30,
+        reasoning_output_tokens: reasoningOutputTokens,
+      });
+
+      expect(usage).not.toHaveProperty('outputReasoningTokens');
+      expect(usage).not.toHaveProperty('outputTextTokens');
+    }
+  });
+
+  it('subtracts reliable cumulative output breakdowns', () => {
+    expect(
+      toTurnUsageFromCumulative(
+        {
+          inputCachedTokens: 9,
+          inputCacheMissTokens: 16,
+          outputReasoningTokens: 12,
+          outputTextTokens: 18,
+          totalInputTokens: 25,
+          totalOutputTokens: 30,
+          totalTokens: 55,
+        },
+        {
+          inputCachedTokens: 4,
+          inputCacheMissTokens: 6,
+          outputReasoningTokens: 4,
+          outputTextTokens: 6,
+          totalInputTokens: 10,
+          totalOutputTokens: 10,
+          totalTokens: 20,
+        },
+      ),
+    ).toEqual({
+      inputCachedTokens: 5,
+      inputCacheMissTokens: 10,
+      outputReasoningTokens: 8,
+      outputTextTokens: 12,
+      totalInputTokens: 15,
+      totalOutputTokens: 20,
+      totalTokens: 35,
+    });
+  });
+
+  it('omits cumulative output breakdowns when the previous snapshot has none', () => {
+    const usage = toTurnUsageFromCumulative(
+      {
+        inputCacheMissTokens: 20,
+        outputReasoningTokens: 8,
+        outputTextTokens: 12,
+        totalInputTokens: 20,
+        totalOutputTokens: 20,
+        totalTokens: 40,
+      },
+      {
+        inputCacheMissTokens: 10,
+        totalInputTokens: 10,
+        totalOutputTokens: 5,
+        totalTokens: 15,
+      },
+    );
+
+    expect(usage).toMatchObject({
+      inputCacheMissTokens: 10,
+      totalInputTokens: 10,
+      totalOutputTokens: 15,
+      totalTokens: 25,
+    });
+    expect(usage).not.toHaveProperty('outputReasoningTokens');
+    expect(usage).not.toHaveProperty('outputTextTokens');
+  });
+
+  it('omits non-monotonic cumulative output breakdowns', () => {
+    const usage = toTurnUsageFromCumulative(
+      {
+        inputCacheMissTokens: 20,
+        outputReasoningTokens: 6,
+        outputTextTokens: 14,
+        totalInputTokens: 20,
+        totalOutputTokens: 20,
+        totalTokens: 40,
+      },
+      {
+        inputCacheMissTokens: 10,
+        outputReasoningTokens: 7,
+        outputTextTokens: 3,
+        totalInputTokens: 10,
+        totalOutputTokens: 10,
+        totalTokens: 20,
+      },
+    );
+
+    expect(usage).toMatchObject({
+      inputCacheMissTokens: 10,
+      totalInputTokens: 10,
+      totalOutputTokens: 10,
+      totalTokens: 20,
+    });
+    expect(usage).not.toHaveProperty('outputReasoningTokens');
+    expect(usage).not.toHaveProperty('outputTextTokens');
+  });
+});

--- a/packages/heterogeneous-agents/src/utils/codexUsage.ts
+++ b/packages/heterogeneous-agents/src/utils/codexUsage.ts
@@ -4,7 +4,16 @@ export interface CodexUsagePayload {
   cached_input_tokens?: number;
   input_tokens?: number;
   output_tokens?: number;
+  reasoning_output_tokens?: number;
 }
+
+const getValidReasoningOutputTokens = (
+  value: unknown,
+  totalOutputTokens: number,
+): number | undefined =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0 && value <= totalOutputTokens
+    ? value
+    : undefined;
 
 export const toCodexUsageData = (
   raw: CodexUsagePayload | null | undefined,
@@ -16,12 +25,22 @@ export const toCodexUsageData = (
   const totalInputTokens = Math.max(raw.input_tokens || 0, inputCachedTokens);
   const inputCacheMissTokens = Math.max(0, totalInputTokens - inputCachedTokens);
   const totalOutputTokens = raw.output_tokens || 0;
+  const outputReasoningTokens = getValidReasoningOutputTokens(
+    raw.reasoning_output_tokens,
+    totalOutputTokens,
+  );
 
   if (totalInputTokens + totalOutputTokens === 0) return undefined;
 
   return {
     inputCachedTokens: inputCachedTokens || undefined,
     inputCacheMissTokens,
+    ...(outputReasoningTokens === undefined
+      ? {}
+      : {
+          outputReasoningTokens,
+          outputTextTokens: totalOutputTokens - outputReasoningTokens,
+        }),
     totalInputTokens,
     totalOutputTokens,
     totalTokens: totalInputTokens + totalOutputTokens,
@@ -35,6 +54,45 @@ const isMonotonicUsage = (current: UsageData, previous: UsageData) =>
   current.totalOutputTokens >= previous.totalOutputTokens &&
   current.totalTokens >= previous.totalTokens;
 
+const getTurnOutputBreakdown = (
+  current: UsageData,
+  previous: UsageData,
+  totalOutputTokens: number,
+): Pick<UsageData, 'outputReasoningTokens' | 'outputTextTokens'> | undefined => {
+  const currentReasoning = current.outputReasoningTokens;
+  const currentText = current.outputTextTokens;
+  const previousReasoning = previous.outputReasoningTokens;
+  const previousText = previous.outputTextTokens;
+
+  if (
+    currentReasoning === undefined ||
+    currentText === undefined ||
+    previousReasoning === undefined ||
+    previousText === undefined ||
+    !Number.isFinite(currentReasoning) ||
+    !Number.isFinite(currentText) ||
+    !Number.isFinite(previousReasoning) ||
+    !Number.isFinite(previousText) ||
+    currentReasoning < 0 ||
+    currentText < 0 ||
+    previousReasoning < 0 ||
+    previousText < 0 ||
+    currentReasoning + currentText !== current.totalOutputTokens ||
+    previousReasoning + previousText !== previous.totalOutputTokens ||
+    currentReasoning < previousReasoning ||
+    currentText < previousText
+  ) {
+    return undefined;
+  }
+
+  const outputReasoningTokens = currentReasoning - previousReasoning;
+  const outputTextTokens = currentText - previousText;
+
+  if (outputReasoningTokens + outputTextTokens !== totalOutputTokens) return undefined;
+
+  return { outputReasoningTokens, outputTextTokens };
+};
+
 export const toTurnUsageFromCumulative = (
   current: UsageData | undefined,
   previous: UsageData | undefined,
@@ -47,12 +105,14 @@ export const toTurnUsageFromCumulative = (
   const totalInputTokens = current.totalInputTokens - previous.totalInputTokens;
   const totalOutputTokens = current.totalOutputTokens - previous.totalOutputTokens;
   const totalTokens = totalInputTokens + totalOutputTokens;
+  const outputBreakdown = getTurnOutputBreakdown(current, previous, totalOutputTokens);
 
   if (totalTokens === 0) return undefined;
 
   return {
     inputCachedTokens: inputCachedTokens || undefined,
     inputCacheMissTokens,
+    ...outputBreakdown,
     totalInputTokens,
     totalOutputTokens,
     totalTokens,

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -245,6 +245,7 @@ export default {
   'heteroAgent.modelSelector.reasoning.low': 'Low',
   'heteroAgent.modelSelector.reasoning.max': 'Max',
   'heteroAgent.modelSelector.reasoning.medium': 'Medium',
+  'heteroAgent.modelSelector.reasoning.ultra': 'Ultra',
   'heteroAgent.modelSelector.reasoning.xhigh': 'Extra High',
   'heteroAgent.modelSelector.speed': 'Speed',
   'heteroAgent.modelSelector.speed.fast': 'Fast',

--- a/packages/types/src/agent/agencyConfig.test.ts
+++ b/packages/types/src/agent/agencyConfig.test.ts
@@ -4,6 +4,8 @@ import {
   buildHeteroExecArgs,
   buildHeteroSpawnArgs,
   codexModelSupportsFastSpeed,
+  codexModelSupportsReasoningEffort,
+  getCodexReasoningEffortLevels,
   HETEROGENEOUS_AGENT_DEFAULT_SELECTION,
   pruneWorkingDirByDeviceDeletes,
   resolveClaudeCodeModel,
@@ -163,6 +165,10 @@ describe('buildHeteroSpawnArgs', () => {
         effort: 'low',
       }),
     ).toBe('xhigh');
+    expect(resolveCodexReasoningEffort({ effort: 'max' })).toBe('max');
+    expect(resolveCodexReasoningEffort({ args: ['-c', 'model_reasoning_effort="ultra"'] })).toBe(
+      'ultra',
+    );
   });
 
   it('appends --model and model_reasoning_effort config for Codex', () => {
@@ -171,6 +177,21 @@ describe('buildHeteroSpawnArgs', () => {
       'gpt-5.5',
       '-c',
       'model_reasoning_effort="high"',
+    ]);
+  });
+
+  it('passes extended Codex reasoning efforts through spawn and exec args', () => {
+    expect(buildHeteroSpawnArgs({ effort: 'ultra', model: 'gpt-5.6-sol', type: 'codex' })).toEqual([
+      '--model',
+      'gpt-5.6-sol',
+      '-c',
+      'model_reasoning_effort="ultra"',
+    ]);
+    expect(buildHeteroExecArgs({ effort: 'max', model: 'gpt-5.6-luna', type: 'codex' })).toEqual([
+      '--model',
+      'gpt-5.6-luna',
+      '--effort',
+      'max',
     ]);
   });
 
@@ -247,6 +268,36 @@ describe('buildHeteroSpawnArgs', () => {
   });
 });
 
+describe('codex reasoning effort capabilities', () => {
+  const commonLevels = ['low', 'medium', 'high', 'xhigh'];
+  const maxLevels = [...commonLevels, 'max'];
+  const ultraLevels = [...maxLevels, 'ultra'];
+
+  it('returns the extended levels supported by each GPT-5.6 model', () => {
+    expect(getCodexReasoningEffortLevels('gpt-5.6')).toEqual(ultraLevels);
+    expect(getCodexReasoningEffortLevels('gpt-5.6-sol')).toEqual(ultraLevels);
+    expect(getCodexReasoningEffortLevels('gpt-5.6-terra')).toEqual(ultraLevels);
+    expect(getCodexReasoningEffortLevels('gpt-5.6-luna')).toEqual(maxLevels);
+  });
+
+  it('reports model-specific Max and Ultra support', () => {
+    expect(codexModelSupportsReasoningEffort('gpt-5.6', 'ultra')).toBe(true);
+    expect(codexModelSupportsReasoningEffort('gpt-5.6-sol', 'ultra')).toBe(true);
+    expect(codexModelSupportsReasoningEffort('gpt-5.6-terra', 'ultra')).toBe(true);
+    expect(codexModelSupportsReasoningEffort('gpt-5.6-luna', 'max')).toBe(true);
+    expect(codexModelSupportsReasoningEffort('gpt-5.6-luna', 'ultra')).toBe(false);
+  });
+
+  it('uses conservative common levels for old, unknown, and default models', () => {
+    expect(getCodexReasoningEffortLevels('gpt-5.5')).toEqual(commonLevels);
+    expect(getCodexReasoningEffortLevels('gpt-5.4-mini')).toEqual(commonLevels);
+    expect(getCodexReasoningEffortLevels('custom-codex-model')).toEqual(commonLevels);
+    expect(getCodexReasoningEffortLevels(HETEROGENEOUS_AGENT_DEFAULT_SELECTION)).toEqual(
+      commonLevels,
+    );
+  });
+});
+
 describe('codex speed mode', () => {
   it('resolves missing / default selections to Default', () => {
     expect(resolveCodexSpeedMode(undefined)).toBe(HETEROGENEOUS_AGENT_DEFAULT_SELECTION);
@@ -271,6 +322,10 @@ describe('codex speed mode', () => {
 
   it('reports fast support for catalog models and the default selection', () => {
     expect(codexModelSupportsFastSpeed(HETEROGENEOUS_AGENT_DEFAULT_SELECTION)).toBe(true);
+    expect(codexModelSupportsFastSpeed('gpt-5.6')).toBe(true);
+    expect(codexModelSupportsFastSpeed('gpt-5.6-sol')).toBe(true);
+    expect(codexModelSupportsFastSpeed('gpt-5.6-terra')).toBe(true);
+    expect(codexModelSupportsFastSpeed('gpt-5.6-luna')).toBe(true);
     expect(codexModelSupportsFastSpeed('gpt-5.5')).toBe(true);
     expect(codexModelSupportsFastSpeed('gpt-5.4')).toBe(true);
     expect(codexModelSupportsFastSpeed('gpt-5.4-mini')).toBe(false);

--- a/packages/types/src/agent/agencyConfig.ts
+++ b/packages/types/src/agent/agencyConfig.ts
@@ -31,13 +31,27 @@ export const CLAUDE_CODE_DEFAULT_REASONING_EFFORT = 'high' satisfies ClaudeCodeR
  * Codex reasoning-effort levels, mirrored to the CLI config key
  * `model_reasoning_effort`.
  */
-export const CODEX_REASONING_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh'] as const;
+export const CODEX_COMMON_REASONING_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh'] as const;
+
+export const CODEX_REASONING_EFFORT_LEVELS = [
+  ...CODEX_COMMON_REASONING_EFFORT_LEVELS,
+  'max',
+  'ultra',
+] as const;
 
 export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORT_LEVELS)[number];
 
-export const CODEX_DEFAULT_MODEL = 'gpt-5.5';
+export const CODEX_DEFAULT_MODEL = 'gpt-5.6-sol';
 export const CODEX_DEFAULT_REASONING_EFFORT = 'medium' satisfies CodexReasoningEffort;
 export const CODEX_REASONING_EFFORT_CONFIG_KEY = 'model_reasoning_effort';
+
+const CODEX_MAX_REASONING_EFFORT_LEVELS = [
+  ...CODEX_COMMON_REASONING_EFFORT_LEVELS,
+  'max',
+] as const satisfies readonly CodexReasoningEffort[];
+
+const CODEX_ULTRA_REASONING_MODELS = ['gpt-5.6', 'gpt-5.6-sol', 'gpt-5.6-terra'] as const;
+const CODEX_MAX_REASONING_MODELS = ['gpt-5.6-luna'] as const;
 
 export type HeterogeneousReasoningEffort =
   ClaudeCodeReasoningEffort | CodexReasoningEffort | HeterogeneousAgentDefaultSelection;
@@ -60,9 +74,16 @@ export const CODEX_SERVICE_TIER_CONFIG_KEY = 'service_tier';
 
 /**
  * Codex models whose catalog exposes the Fast (`priority`) service tier.
- * Sourced from the model catalog embedded in codex-cli (>= 0.142).
+ * Sourced from the model catalog embedded in codex-cli.
  */
-export const CODEX_FAST_SPEED_MODELS = ['gpt-5.5', 'gpt-5.4'] as const;
+export const CODEX_FAST_SPEED_MODELS = [
+  'gpt-5.6',
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5.6-luna',
+  'gpt-5.5',
+  'gpt-5.4',
+] as const;
 
 /**
  * `service_tier` values the Codex CLI resolves to the Fast tier
@@ -239,6 +260,30 @@ const isClaudeCodeReasoningEffort = (
 const isCodexReasoningEffort = (value: string | undefined): value is CodexReasoningEffort =>
   !!value && CODEX_REASONING_EFFORT_LEVELS.includes(value as CodexReasoningEffort);
 
+/**
+ * Reasoning-effort levels exposed by a Codex model. Unknown and default model
+ * selections use the conservative common set because their actual capability
+ * cannot be known until the CLI resolves the model.
+ */
+export const getCodexReasoningEffortLevels = (model: string): readonly CodexReasoningEffort[] => {
+  if (
+    CODEX_ULTRA_REASONING_MODELS.includes(model as (typeof CODEX_ULTRA_REASONING_MODELS)[number])
+  ) {
+    return CODEX_REASONING_EFFORT_LEVELS;
+  }
+
+  if (CODEX_MAX_REASONING_MODELS.includes(model as (typeof CODEX_MAX_REASONING_MODELS)[number])) {
+    return CODEX_MAX_REASONING_EFFORT_LEVELS;
+  }
+
+  return CODEX_COMMON_REASONING_EFFORT_LEVELS;
+};
+
+export const codexModelSupportsReasoningEffort = (
+  model: string,
+  effort: CodexReasoningEffort,
+): boolean => getCodexReasoningEffortLevels(model).includes(effort);
+
 export const resolveClaudeCodeModel = (
   source: ClaudeCodeSelectionSource | null | undefined,
 ): string => {
@@ -328,8 +373,8 @@ const getExplicitCodexSpeedMode = (
 
 /**
  * Whether the Fast speed toggle applies to a selector model value. `default`
- * counts as supported: the CLI's own default model (currently gpt-5.5)
- * supports Fast, and unsupported models simply ignore the tier.
+ * counts as supported so the CLI remains free to resolve its own model; an
+ * unsupported resolved model simply ignores the tier.
  */
 export const codexModelSupportsFastSpeed = (model: string): boolean =>
   model === HETEROGENEOUS_AGENT_DEFAULT_SELECTION ||

--- a/src/features/ChatInput/ControlBar/HeteroModel.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroModel.tsx
@@ -10,9 +10,10 @@ import type {
 import {
   CLAUDE_CODE_REASONING_EFFORT_LEVELS,
   CODEX_REASONING_EFFORT_CONFIG_KEY,
-  CODEX_REASONING_EFFORT_LEVELS,
   CODEX_SERVICE_TIER_CONFIG_KEY,
   codexModelSupportsFastSpeed,
+  codexModelSupportsReasoningEffort,
+  getCodexReasoningEffortLevels,
   HETEROGENEOUS_AGENT_DEFAULT_SELECTION,
   resolveClaudeCodeModel,
   resolveClaudeCodeReasoningEffort,
@@ -57,18 +58,24 @@ const CLAUDE_CODE_MODEL_OPTIONS = [
 ] as const;
 
 const CODEX_MODEL_OPTIONS = [
+  { label: 'GPT-5.6 Sol', value: 'gpt-5.6-sol' },
+  { label: 'GPT-5.6 Terra', value: 'gpt-5.6-terra' },
+  { label: 'GPT-5.6 Luna', value: 'gpt-5.6-luna' },
   { label: 'GPT-5.5', value: 'gpt-5.5' },
   { label: 'GPT-5.4', value: 'gpt-5.4' },
   { label: 'GPT-5.4 Mini', value: 'gpt-5.4-mini' },
   { label: 'GPT-5.3 Codex Spark', value: 'gpt-5.3-codex-spark' },
 ] as const;
 
-const MODEL_LABELS: Record<string, string> = Object.fromEntries(
-  [...CLAUDE_CODE_MODEL_OPTIONS, ...CODEX_MODEL_OPTIONS].map((option) => [
-    option.value,
-    option.label,
-  ]),
-);
+const MODEL_LABELS: Record<string, string> = {
+  'gpt-5.6': 'GPT-5.6',
+  ...Object.fromEntries(
+    [...CLAUDE_CODE_MODEL_OPTIONS, ...CODEX_MODEL_OPTIONS].map((option) => [
+      option.value,
+      option.label,
+    ]),
+  ),
+};
 
 const EFFORT_LABEL_KEYS = {
   [HETEROGENEOUS_AGENT_DEFAULT_SELECTION]: 'heteroAgent.modelSelector.default',
@@ -76,6 +83,7 @@ const EFFORT_LABEL_KEYS = {
   low: 'heteroAgent.modelSelector.reasoning.low',
   max: 'heteroAgent.modelSelector.reasoning.max',
   medium: 'heteroAgent.modelSelector.reasoning.medium',
+  ultra: 'heteroAgent.modelSelector.reasoning.ultra',
   xhigh: 'heteroAgent.modelSelector.reasoning.xhigh',
 } as const satisfies Record<HeteroReasoningEffort, string>;
 
@@ -425,8 +433,15 @@ const HeteroModel = memo(() => {
         provider?.type === 'codex' &&
         resolveCodexSpeedMode(provider) === 'fast' &&
         !codexModelSupportsFastSpeed(value);
+      const currentEffort =
+        provider?.type === 'codex' ? resolveCodexReasoningEffort(provider) : undefined;
+      const resetEffort =
+        currentEffort !== undefined &&
+        currentEffort !== HETEROGENEOUS_AGENT_DEFAULT_SELECTION &&
+        !codexModelSupportsReasoningEffort(value, currentEffort);
 
       void patchProvider({
+        ...(resetEffort ? { effort: HETEROGENEOUS_AGENT_DEFAULT_SELECTION } : {}),
         model: value,
         ...(resetSpeed ? { speed: HETEROGENEOUS_AGENT_DEFAULT_SELECTION } : {}),
       });
@@ -471,7 +486,9 @@ const HeteroModel = memo(() => {
   const effortLabelKeys = providerType === 'codex' ? CODEX_EFFORT_LABEL_KEYS : EFFORT_LABEL_KEYS;
   const effortLabel = t(effortLabelKeys[effort]);
   const reasoningLevels =
-    providerType === 'codex' ? CODEX_REASONING_EFFORT_LEVELS : CLAUDE_CODE_REASONING_EFFORT_LEVELS;
+    providerType === 'codex'
+      ? getCodexReasoningEffortLevels(model)
+      : CLAUDE_CODE_REASONING_EFFORT_LEVELS;
   const providerModelOptions =
     providerType === 'codex' ? CODEX_MODEL_OPTIONS : CLAUDE_CODE_MODEL_OPTIONS;
   const effortOptions: { label: string; value: HeteroReasoningEffort }[] = [


### PR DESCRIPTION
## Summary

- add GPT-5.6 Sol, Terra, and Luna to the heterogeneous Codex model selector
- expose model-specific reasoning efforts (including Max and Ultra) and Fast support
- reset incompatible effort or speed selections when switching models while preserving Codex CLI defaults
- map Codex `reasoning_output_tokens` into reasoning/text usage details
- restore resume usage baselines from rollout `payload.info.total_token_usage`, with legacy fallbacks
- add focused capability, usage, adapter, rollout, and locale coverage

## Why

The Codex catalog now exposes GPT-5.6 model variants with different reasoning-effort limits, but LobeHub still used an older global capability list. In addition, current Codex rollout files store cumulative usage under `payload.info.total_token_usage`; reading only legacy usage fields caused resumed turns to lose their baseline, and reasoning tokens were not surfaced separately.

## Impact

Users can select the current GPT-5.6 Codex variants with only the efforts and speed modes each model supports. Token usage now separates reasoning from visible output, and resumed Codex sessions calculate per-turn usage from the correct cumulative baseline.

## Validation

- `bun run check <changed files>`: lint clean, 76 related tests passed
- `bun run check packages/heterogeneous-agents/src/spawn/codexModel.test.ts`: lint clean, 6 tests passed
- pre-commit Prettier, Stylelint, and ESLint hooks passed
- `bun run check --type` currently stops on an unrelated existing fixture error at `packages/model-runtime/src/core/usageConverters/openai.test.ts:546` (`ResponseUsage.output_tokens_details` is missing)