### PR TITLE
🐛 fix(chat-input): resolve the worktree switcher against the main worktree

### DIFF
--- a/.agents/skills/agent-testing/references/auth.md
+++ b/.agents/skills/agent-testing/references/auth.md
@@ -188,18 +188,22 @@ EOF
 $EDEV save-login <id>
 ```
 
-Two traps behind a signed-out instance:
+Three traps behind a signed-out instance:
 
-- **The refresh token rotates on every boot and expires \~7 days after the last
-  refresh.** Only the instance that booted last holds a valid one, so a `stop` is
-  what keeps the snapshot alive. If an instance is _killed_ instead (crash, command
-  timeout) its rotated token dies with it — `save-login <id>` before anything risky.
-  `login-status` reads `lobehub-settings.json → encryptedTokens.expiresAt`.
-- **An expired token does not always mean signed out.** A better-auth cookie can
+- **The refresh token rotates on every boot.** Only the instance that booted last
+  holds a usable one, so a `stop` is what keeps the snapshot alive. If an instance is
+  _killed_ instead (crash, command timeout) its rotated token dies with it —
+  `save-login <id>` before anything risky.
+- **`encryptedTokens.expiresAt` is the ACCESS token's expiry, not the refresh
+  token's.** It is `Date.now() + data.expires_in * 1000` in
+  `RemoteServerConfigCtr.saveTokens`, so it goes stale on a perfectly refreshable
+  login and must never gate whether a profile is kept. The signal that _does_ mean
+  signed out is a **missing `refreshToken`**: the app calls `clearTokens()` (deleting
+  the whole `encryptedTokens` key) when a refresh fails non-retryably
+  (`invalid_grant` \&co), and preserves it on transient failures.
+- **Even a missing token does not always mean signed out.** A better-auth cookie can
   outlive it. `stop` / `save-login` probe the _running renderer_ for a user id, so a
   live cookie-only session is captured too; the on-disk token alone would miss it.
-  Conversely a failed refresh makes the app **erase** `encryptedTokens`, so a
-  signed-out instance leaves no token behind at all.
 
 ## Scope
 

--- a/.agents/skills/agent-testing/references/auth.md
+++ b/.agents/skills/agent-testing/references/auth.md
@@ -35,7 +35,7 @@ not `127.0.0.1`.
 | -------- | ---------------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------- |
 | CLI      | Seeded API key or OIDC Device Code Flow  | `.records/env/agent-testing-cli.env` + `$HOME/.lobehub-dev`       | No for seed path; yes for device-code fallback |
 | Web      | Seeded better-auth login or cookie copy  | `~/.lobehub-agent-testing/web-state.json` + agent-browser session | No for seed path; copy cookie only as fallback |
-| Electron | App's own login state                    | Electron user-data dir                                            | Log in once manually in the app                |
+| Electron | App's own login state                    | `~/.lobehub/agent-testing/electron-login` (snapshot on `stop`)    | No — the agent drives the sign-in itself       |
 | Bot      | Native apps (Discord/WeChat/…) logged in | Each app's own session                                            | Once per app                                   |
 
 ## CLI — Seeded API key
@@ -147,10 +147,19 @@ agent-browser --session lobehub-dev snapshot -i | head -20
 
 ## Electron
 
-The desktop app keeps its own persistent login state in its user-data
-directory — log in once manually inside the app and it survives restarts of
-`electron-dev.sh`. No injection needed. The standard check (do NOT hand-roll a
-store eval) once Electron is up with CDP:
+The desktop app keeps its login in its user-data directory. Pool instances get a
+throwaway userData, so `electron-dev.sh` persists the login **for you**: `stop`
+snapshots it into `~/.lobehub/agent-testing/electron-login` before wiping the dir,
+and `start` seeds every new instance from that snapshot. Sign in once, not once
+per run.
+
+```bash
+EDEV=./.agents/skills/agent-testing/scripts/electron-dev.sh
+$EDEV login-status        # which source seeds the next instance, and its expiry
+$EDEV save-login <id>     # snapshot a live instance without stopping it
+```
+
+The standard check (do NOT hand-roll a store eval) once Electron is up with CDP:
 
 ```bash
 ./.agents/skills/agent-testing/scripts/app-probe.sh auth
@@ -159,6 +168,38 @@ store eval) once Electron is up with CDP:
 
 `setup-auth.sh status` runs this probe automatically when CDP 9222 is
 reachable.
+
+### When the instance comes up signed out
+
+Sign it in **yourself** — never hand this step to the user. The desktop flow is
+OAuth+PKCE against `/oidc/auth`, and the redirect target is a **server page the app
+then polls** (`/oidc/callback/desktop`), not a `lobehub://` deep link — so no other
+app can steal the callback, and no click is needed when the default browser already
+has a LobeHub session:
+
+```bash
+agent-browser --session s<port> --cdp <port> eval --stdin << 'EOF'
+(async () => {
+  const m = await import('/src/services/electron/remoteServer.ts');
+  return JSON.stringify(await (m.remoteServerService || m.default).requestAuthorization({ storageMode: 'cloud' }));
+})()
+EOF
+# poll until user().user.id appears, then capture it:
+$EDEV save-login <id>
+```
+
+Two traps behind a signed-out instance:
+
+- **The refresh token rotates on every boot and expires \~7 days after the last
+  refresh.** Only the instance that booted last holds a valid one, so a `stop` is
+  what keeps the snapshot alive. If an instance is _killed_ instead (crash, command
+  timeout) its rotated token dies with it — `save-login <id>` before anything risky.
+  `login-status` reads `lobehub-settings.json → encryptedTokens.expiresAt`.
+- **An expired token does not always mean signed out.** A better-auth cookie can
+  outlive it. `stop` / `save-login` probe the _running renderer_ for a user id, so a
+  live cookie-only session is captured too; the on-disk token alone would miss it.
+  Conversely a failed refresh makes the app **erase** `encryptedTokens`, so a
+  signed-out instance leaves no token behind at all.
 
 ## Scope
 

--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -211,6 +211,39 @@ skill's job to solve and then iterate back into these logs.
 
 ---
 
+## Case 8b — Handing the user the sign-in click when the app under test is signed out
+
+**Wrong approach**: an isolated Electron instance came up signed out (its userData had been wiped by an
+earlier `electron-dev.sh stop`, and the golden profile's refresh token was expired → `invalid_grant`), so
+the run stopped and offered the user a choice: "I click Sign in and you authorize in the browser" vs
+"skip the screenshot".
+
+**Why it's wrong**: this is Case 8 wearing a different hat. `auth.md` says "Electron: log in once manually
+in the app" — that line is addressed to the **agent**, not the user. Auth is environment mechanics, and the
+standing rule is that the skill owns those end to end. The user's words: " 你以后都自己点 sign in 授权，不应
+该让我操作 ".
+
+**What it breaks**: burns a round on a question the user doesn't want, and stalls a UI-touching change
+(Case 9 / Case 10) one click short of its screenshot.
+
+**Correct approach**: drive the sign-in yourself — click the app's own "Sign in" entry, follow the OAuth
+flow in the browser it opens, and get back into the app. Only escalate when a step genuinely needs
+something you cannot supply (a 2FA push on their phone), and then name the exact blocking step instead of
+offering to drop the evidence.
+
+**What this run changed**: `electron-dev.sh stop <id>` used to delete the instance's userData and its login
+with it, so every run re-entered the sign-in flow. It now snapshots the login into
+`~/.lobehub/agent-testing/electron-login` first, and `start` seeds new instances from that snapshot
+(`login-status` shows the source + expiry; `save-login <id>` captures a live instance before anything
+risky, since a _killed_ instance loses its rotated refresh token).
+
+**Corollary**: never assume a profile is signed in because it exists — probe for a real signed-in state
+(`user().user?.id`, or a cheap authed mutation) before building a fixture on top of it. A rendered sidebar
+is not proof: the signed-out onboarding screen has text too, so `innerText.length > 50` passes while
+`createAgent` returns `UNAUTHORIZED`.
+
+---
+
 ## Case 9 — Self-judging a screenshot as "too costly" and asking the user to picture the result
 
 **Wrong approach**: after a small user-facing UI change (a padding tweak), skipping

--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -214,7 +214,7 @@ skill's job to solve and then iterate back into these logs.
 ## Case 8b — Handing the user the sign-in click when the app under test is signed out
 
 **Wrong approach**: an isolated Electron instance came up signed out (its userData had been wiped by an
-earlier `electron-dev.sh stop`, and the golden profile's refresh token was expired → `invalid_grant`), so
+earlier `electron-dev.sh stop`, and the golden profile's refresh token was rejected → `invalid_grant`), so
 the run stopped and offered the user a choice: "I click Sign in and you authorize in the browser" vs
 "skip the screenshot".
 

--- a/.agents/skills/agent-testing/references/probe-mock-patterns.md
+++ b/.agents/skills/agent-testing/references/probe-mock-patterns.md
@@ -485,6 +485,78 @@
     server's `S3_ACCESS_KEY_ID/S3_SECRET_ACCESS_KEY=S3RVER`, `S3_ENABLE_PATH_STYLE=1`,
     `S3_PUBLIC_DOMAIN=http://127.0.0.1:29000/<bucket>`.
 
+### E8. ✅ WORKS — a git-worktree checkout needs its OWN `pnpm install`, not a symlinked `node_modules`
+
+- **Situation**: verifying a UI change from a `git worktree` (e.g. `.claude/worktrees/<name>`), which
+  starts with no `node_modules`.
+- **Doesn't work**: symlinking the main checkout's `node_modules` (root and/or `apps/desktop`) into the
+  worktree. The workspace links inside it point `@lobechat/*` at the MAIN checkout's `packages/`, which
+  sits on a different branch — the Electron main build then dies with
+  `[MISSING_EXPORT] "X" is not exported by "../../packages/<pkg>/src/..."`. Renderer source resolves from
+  the worktree while packages resolve from the main repo, so the two disagree.
+- **Works**: run `pnpm install` at the worktree root AND `cd apps/desktop && pnpm install` (standalone,
+  not in the workspace). \~5 min total, mostly hardlinked from the store.
+- **Also**: a Vite dev server left over from an earlier failed `electron-dev.sh start <id>` is REUSED by
+  the retry (`CDP already reachable … Skipping start`) and can keep serving pre-edit module text. If the
+  DOM shows markup that contradicts the source, curl the dev server for the file and grep for a token you
+  just added (`curl -s 127.0.0.1:<vitePort>/src/path/File.tsx | grep -c myNewSymbol`) before blaming the
+  code. `electron-dev.sh stop <id>` then start again to get a clean server.
+
+### E9. Electron dev's FIRST cold boot sits on the splash with an empty `#root` for 1–3 minutes
+
+- **Situation**: after `electron-dev.sh start <id>`, `app-probe.sh auth` returns `isSignedIn:false`,
+  `#root` has providers but `innerText.length === 0`, and the screenshot is just the LobeHub splash. The
+  main log shows `Proactive token refresh failed` / `invalid_grant`.
+- **Doesn't work**: concluding the copied login state expired. That refresh error is a red herring — the
+  app recovers, and `RENDERER_WAIT_S` (60s) can expire while Vite is still on
+  `[optimizer] bundling dependencies`, which ends in `optimized dependencies changed. reloading`.
+- **Works**: poll until the DOM actually has content instead of sleeping a fixed amount:
+  ```bash
+  until [ "$(agent-browser --session s \
+    '(function(){return String(document.getElementById("root").innerText.trim().length>50)})()' < port > --cdp < port > eval \
+    | tr -d '"')" = "true" ]; do sleep 5; done
+  ```
+  Also note `zsh does NOT word-split unquoted vars` — `S="--session x --cdp 9226"; agent-browser $S eval`
+  fails with `Unknown command`. Inline the flags or use an array.
+
+### E10. ✅ WORKS — stop the main process from yanking the renderer back to its last tab
+
+- **Situation**: driving the SPA to a specific route for a screenshot. `history.pushState` + `popstate`
+  lands correctly, then \~15–20s later `location.pathname` snaps back to whatever tab the main process
+  has stored (e.g. `/devtools/claude-code`). A hard `location.href` nav is reverted the same way.
+- **Cause**: the main process broadcasts `navigate`, and `src/features/DesktopNavigationBridge` obeys it.
+- **Works**: HMR-neutralize the bridge for the run, then revert:
+  ```tsx
+  // src/features/DesktopNavigationBridge/index.tsx — [AGENT-TEST] REMOVE
+  useWatchBroadcast('navigate', () => {
+    void handleNavigate;
+  });
+  ```
+  `git checkout -- src/features/DesktopNavigationBridge/index.tsx` afterwards; `grep -rn AGENT-TEST src/`
+  must come back empty.
+
+### E11. ✅ WORKS — drive the working-directory / git-status ControlBar without the native dir picker
+
+- The picker opens a native dialog, but the same write path is reachable from the store. With no active
+  topic, `commit()` persists to `agencyConfig.workingDirByDevice[deviceId]`:
+  ```js
+  const a = window.__LOBE_STORES.agent(),
+    d = window.__LOBE_STORES.device();
+  const did = window.__LOBE_STORES.electron().gatewayDeviceInfo.deviceId;
+  const entry = { path: '/abs/repo', repoType: 'git' };
+  await a.updateAgentConfigById(agentId, {
+    agencyConfig: { workingDirByDevice: { [did]: entry } },
+  });
+  await d.updateDeviceCwd(did, entry, { setDefault: false }); // so the entry exists → sourcePath resolves
+  ```
+  Create a throwaway agent with `agent().createAgent({ title })` and delete it afterwards with
+  `session().removeSession(agentId)` (there is no `deleteAgent` on the agent store) plus
+  `device().removeDeviceWorkingDir(did, path)` — otherwise the fixture cwd lingers in the real account.
+- **Identify icons precisely**: lucide renders `svg.lucide.lucide-git-fork`. Several git icons live in the
+  same bar (the dir picker's `DirIcon` is `git-branch`, the review toggle is `git-compare`), so scope the
+  assertion to the trigger: `document.querySelector('[role=button][aria-label="Worktrees"]') svg`, and
+  still open the PNG to confirm (Case 1).
+
 ### E6. code-inspector-plugin breaks Turbopack compile of Next-served authed pages
 
 - **Situation**: the first AUTHENTICATED render of a Next-served (non-SPA) page whose client

--- a/.agents/skills/agent-testing/scripts/electron-dev.sh
+++ b/.agents/skills/agent-testing/scripts/electron-dev.sh
@@ -26,10 +26,10 @@
 # Login persistence (so you sign in ONCE, not once per run):
 #   `stop` snapshots the instance's login state into $LOGIN_STATE_DIR before it
 #   wipes the userData, and `start` seeds new instances from that snapshot. The
-#   app's OAuth refresh token ROTATES on every boot and expires after ~7 days, so
-#   the snapshot must be re-taken each run — that is exactly what `stop` does.
-#   The golden profile is only a fallback for the very first run, and is never
-#   written to (it belongs to the user's own dev app).
+#   app's OAuth refresh token ROTATES on every boot, so only the instance that
+#   booted last holds a usable one — the snapshot must be re-taken each run, which
+#   is exactly what `stop` does. The golden profile is only a fallback for the very
+#   first run, and is never written to (it belongs to the user's own dev app).
 #     ./electron-dev.sh login-status      # where the login comes from + expiry
 #     ./electron-dev.sh save-login <id>   # snapshot a live instance without stopping
 #   If an instance is killed instead of stopped (crash, command timeout), its
@@ -223,49 +223,68 @@ copy_login_items() {
   done
 }
 
-# Milliseconds until the profile's OAuth refresh token expires. Prints nothing
-# when the profile carries no token at all; a negative number means expired.
-refresh_token_expiry_ms() {
-  python3 - "$1/lobehub-settings.json" 2>/dev/null <<'PY' || true
+# Reads lobehub-settings.json → encryptedTokens and prints
+#   "<hasRefreshToken:0|1> <msUntilAccessTokenExpiry|?>"
+#
+# `expiresAt` is `Date.now() + data.expires_in * 1000` (RemoteServerConfigCtr.saveTokens),
+# i.e. the ACCESS token's lifetime — NOT the refresh token's. It is routinely in the
+# past on a perfectly refreshable login, so it must never gate whether we keep a
+# profile. What does gate it: the app deletes the whole `encryptedTokens` key
+# (clearTokens) the moment a refresh fails non-retryably (`invalid_grant` &co), and
+# keeps it on transient failures. So a present refreshToken means "can still re-auth".
+read_token_state() {
+  python3 - "$1/lobehub-settings.json" 2>/dev/null <<'PY' || echo "0 ?"
 import json, pathlib, sys, time
 
 path = pathlib.Path(sys.argv[1])
 if not path.is_file():
+    print("0 ?")
     sys.exit(0)
 try:
     tokens = (json.loads(path.read_text()) or {}).get('encryptedTokens') or {}
 except Exception:
+    print("0 ?")
     sys.exit(0)
+
+has_refresh = 1 if tokens.get('refreshToken') else 0
 expires_at = tokens.get('expiresAt')
-if not tokens.get('refreshToken') or not expires_at:
+if not expires_at:
+    print(f"{has_refresh} ?")
     sys.exit(0)
 # The field has been seen in both seconds and milliseconds.
 if expires_at < 1e11:
     expires_at *= 1000
-print(int(expires_at - time.time() * 1000))
+print(f"{has_refresh} {int(expires_at - time.time() * 1000)}")
 PY
 }
 
-# True when the profile can still refresh its session on the next boot.
-profile_has_live_login() {
-  local ms
-  ms=$(refresh_token_expiry_ms "$1")
-  [[ "$ms" =~ ^-?[0-9]+$ ]] && [ "$ms" -gt 0 ]
+# True when the profile still carries a refresh token, i.e. the app can mint a new
+# session from it on the next boot. An expired ACCESS token says nothing here.
+profile_can_reauth() {
+  local state
+  state=$(read_token_state "$1")
+  [ "${state%% *}" = "1" ]
 }
 
 describe_login() {
-  local label="$1" profile="$2" ms
+  local label="$1" profile="$2" state ms access
   if [ ! -d "$profile" ]; then
     echo "  $label: (absent) — $profile"
     return
   fi
-  ms=$(refresh_token_expiry_ms "$profile")
-  if [[ ! "$ms" =~ ^-?[0-9]+$ ]]; then
-    echo "  $label: no token — $profile"
-  elif [ "$ms" -gt 0 ]; then
-    echo "  $label: valid, expires in $((ms / 3600000))h — $profile"
+  state=$(read_token_state "$profile")
+  ms="${state##* }"
+  if [[ "$ms" =~ ^-?[0-9]+$ ]]; then
+    [ "$ms" -gt 0 ] &&
+      access="access token fresh for $((ms / 3600000))h" ||
+      access="access token stale $(( -ms / 3600000 ))h (harmless — it gets refreshed)"
   else
-    echo "  $label: EXPIRED $(( -ms / 3600000 ))h ago — $profile"
+    access="no access-token expiry recorded"
+  fi
+  if [ "${state%% *}" = "1" ]; then
+    echo "  $label: refresh token PRESENT — $access — $profile"
+  else
+    echo "  $label: refresh token GONE (app cleared it after a failed refresh) — $profile"
   fi
 }
 
@@ -295,8 +314,8 @@ probe_renderer_authed() {
 save_login_state() {
   local src="$1" authed_hint="${2:-0}"
   [ -d "$src" ] || return 0
-  if [ "$authed_hint" != "1" ] && ! profile_has_live_login "$src"; then
-    echo "[electron-dev] Not saving login state: $src is signed out / has no valid refresh token (kept the previous snapshot)."
+  if [ "$authed_hint" != "1" ] && ! profile_can_reauth "$src"; then
+    echo "[electron-dev] Not saving login state: $src is signed out (the app cleared its refresh token) — kept the previous snapshot."
     return 0
   fi
   local staging="${LOGIN_STATE_DIR}.staging.$$"
@@ -305,12 +324,10 @@ save_login_state() {
   copy_login_items "$src" "$staging"
   rm -rf "$LOGIN_STATE_DIR"
   mv "$staging" "$LOGIN_STATE_DIR"
-  local ms
-  ms=$(refresh_token_expiry_ms "$LOGIN_STATE_DIR")
-  if [[ "$ms" =~ ^-?[0-9]+$ ]] && [ "$ms" -gt 0 ]; then
-    echo "[electron-dev] Saved login state → $LOGIN_STATE_DIR (refresh token valid for $((ms / 3600000))h)"
+  if profile_can_reauth "$LOGIN_STATE_DIR"; then
+    echo "[electron-dev] Saved login state → $LOGIN_STATE_DIR (refresh token captured)"
   else
-    echo "[electron-dev] Saved login state → $LOGIN_STATE_DIR (cookie session; refresh token already expired)"
+    echo "[electron-dev] Saved login state → $LOGIN_STATE_DIR (cookie session only — no refresh token on disk)"
   fi
 }
 
@@ -337,8 +354,8 @@ seed_userdata() {
   fi
 
   echo "[electron-dev] Seeding userData from $label → $dst"
-  profile_has_live_login "$src" ||
-    echo "[electron-dev]   note: its refresh token is expired — a cookie session may still carry it; otherwise sign in once and 'stop' will capture it."
+  profile_can_reauth "$src" ||
+    echo "[electron-dev]   note: no refresh token on disk — a cookie session may still carry it; otherwise sign in once and 'stop' will capture it."
   copy_login_items "$src" "$dst"
 }
 
@@ -499,7 +516,9 @@ do_start() {
 
   if ! wait_for_cdp; then
     echo "[electron-dev] Failed to bring up CDP. Cleaning up..."
-    do_stop
+    # The app never came up, so its userData is just the seed copy — snapshotting it
+    # would overwrite a good snapshot with an unverified (possibly rejected) token.
+    SKIP_LOGIN_SAVE=1 do_stop
     return 1
   fi
   wait_for_renderer || true
@@ -553,9 +572,10 @@ do_login_status() {
     echo "[electron-dev] Nothing to seed from: sign in once inside the app, then 'save-login <id>' (or just 'stop <id>')."
     return 2
   fi
-  echo "[electron-dev] Note: an expired refresh token does not always mean signed out —"
-  echo "[electron-dev] the app may still hold a cookie session. 'stop'/'save-login' probe the"
-  echo "[electron-dev] running renderer, so a live login is captured either way."
+  echo "[electron-dev] Note: 'expiresAt' in the profile is the ACCESS token's lifetime, not the"
+  echo "[electron-dev] refresh token's — a stale one is normal and gets refreshed on boot. Only a"
+  echo "[electron-dev] missing refresh token means signed out. 'stop'/'save-login' also probe the"
+  echo "[electron-dev] running renderer, so a cookie-only session is captured too."
 }
 
 do_stop_all() {

--- a/.agents/skills/agent-testing/scripts/electron-dev.sh
+++ b/.agents/skills/agent-testing/scripts/electron-dev.sh
@@ -18,10 +18,22 @@
 # Each pool instance <id> gets, all env-driven so instances never collide:
 #   CDP port   = CDP_BASE + id   (9222 + id)
 #   Vite port  = VITE_BASE + id  (5173 + id)   → needs LOBE_DESKTOP_VITE_PORT support
-#   userData   = $POOL_DIR/ud-<id> (login state copied from the golden profile)
+#   userData   = $POOL_DIR/ud-<id> (login state seeded from the saved snapshot)
 #   IPC id     = lobehub-desktop-dev-<id>       → needs LOBE_IPC_ID support
 # Drive each with a DISTINCT agent-browser session, else the daemon reuses one
 # connection across ports:  agent-browser --session s<port> --cdp <port> ...
+#
+# Login persistence (so you sign in ONCE, not once per run):
+#   `stop` snapshots the instance's login state into $LOGIN_STATE_DIR before it
+#   wipes the userData, and `start` seeds new instances from that snapshot. The
+#   app's OAuth refresh token ROTATES on every boot and expires after ~7 days, so
+#   the snapshot must be re-taken each run — that is exactly what `stop` does.
+#   The golden profile is only a fallback for the very first run, and is never
+#   written to (it belongs to the user's own dev app).
+#     ./electron-dev.sh login-status      # where the login comes from + expiry
+#     ./electron-dev.sh save-login <id>   # snapshot a live instance without stopping
+#   If an instance is killed instead of stopped (crash, command timeout), its
+#   rotated token dies with it — run `save-login` before anything risky.
 #
 # Environment variables:
 #   CDP_PORT          — (legacy only) CDP port (default: 9222)
@@ -29,9 +41,12 @@
 #   CDP_BASE          — pool CDP base (default: 9222 → instance id adds on top)
 #   VITE_BASE         — pool Vite base (default: 5173)
 #   POOL_DIR          — pool state dir (default: /tmp/lobe-electron-pool)
-#   LOBE_GOLDEN_PROFILE — userData to copy login state from
+#   LOBE_LOGIN_STATE_DIR — persistent login snapshot, survives /tmp cleanup
+#                       (default: ~/.lobehub/agent-testing/electron-login)
+#   LOBE_GOLDEN_PROFILE — userData to seed from when no snapshot exists yet
 #                       (default: ~/Library/Application Support/lobehub-desktop-dev)
 #   KEEP_DATA=1       — on `stop <id>`, keep the instance's userData dir
+#   SKIP_LOGIN_SAVE=1 — on `stop <id>`, do not snapshot the login state
 #   ELECTRON_WAIT_S   — max seconds to wait for CDP (default: 90)
 #   RENDERER_WAIT_S   — max seconds to wait for the SPA (default: 60)
 #
@@ -52,6 +67,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 POOL_DIR="${POOL_DIR:-/tmp/lobe-electron-pool}"
 GOLDEN_PROFILE="${LOBE_GOLDEN_PROFILE:-$HOME/Library/Application Support/lobehub-desktop-dev}"
+# Persistent across runs AND across /tmp cleanup — the pool dir is not.
+LOGIN_STATE_DIR="${LOBE_LOGIN_STATE_DIR:-$HOME/.lobehub/agent-testing/electron-login}"
 
 # Project-scoped electron path prefix used for pgrep matching in LEGACY mode only
 # (pool mode never uses it — it would cross instances). Any Electron binary from
@@ -188,27 +205,141 @@ wait_for_renderer() {
   return 0
 }
 
-# Copy the login-bearing items from the golden profile into a fresh userData dir
-# (skips the multi-GB caches). No-op if the dir already exists.
+# ── Login state ──────────────────────────────────────────────────────
+#
+# The login-bearing subset of a userData dir (skips the multi-GB caches). The
+# OAuth tokens themselves live in lobehub-settings.json → encryptedTokens.
+LOGIN_ITEMS=(
+  "lobehub-settings.json" "Local State" "Preferences"
+  "Cookies" "Cookies-journal" "Local Storage" "IndexedDB"
+  "Session Storage" "Network Persistent State" "lobehub-storage"
+)
+
+copy_login_items() {
+  local src="$1" dst="$2" f
+  mkdir -p "$dst"
+  for f in "${LOGIN_ITEMS[@]}"; do
+    [ -e "$src/$f" ] && cp -R "$src/$f" "$dst/" 2>/dev/null || true
+  done
+}
+
+# Milliseconds until the profile's OAuth refresh token expires. Prints nothing
+# when the profile carries no token at all; a negative number means expired.
+refresh_token_expiry_ms() {
+  python3 - "$1/lobehub-settings.json" 2>/dev/null <<'PY' || true
+import json, pathlib, sys, time
+
+path = pathlib.Path(sys.argv[1])
+if not path.is_file():
+    sys.exit(0)
+try:
+    tokens = (json.loads(path.read_text()) or {}).get('encryptedTokens') or {}
+except Exception:
+    sys.exit(0)
+expires_at = tokens.get('expiresAt')
+if not tokens.get('refreshToken') or not expires_at:
+    sys.exit(0)
+# The field has been seen in both seconds and milliseconds.
+if expires_at < 1e11:
+    expires_at *= 1000
+print(int(expires_at - time.time() * 1000))
+PY
+}
+
+# True when the profile can still refresh its session on the next boot.
+profile_has_live_login() {
+  local ms
+  ms=$(refresh_token_expiry_ms "$1")
+  [[ "$ms" =~ ^-?[0-9]+$ ]] && [ "$ms" -gt 0 ]
+}
+
+describe_login() {
+  local label="$1" profile="$2" ms
+  if [ ! -d "$profile" ]; then
+    echo "  $label: (absent) — $profile"
+    return
+  fi
+  ms=$(refresh_token_expiry_ms "$profile")
+  if [[ ! "$ms" =~ ^-?[0-9]+$ ]]; then
+    echo "  $label: no token — $profile"
+  elif [ "$ms" -gt 0 ]; then
+    echo "  $label: valid, expires in $((ms / 3600000))h — $profile"
+  else
+    echo "  $label: EXPIRED $(( -ms / 3600000 ))h ago — $profile"
+  fi
+}
+
+# 1 when the running renderer reports a signed-in user. The OAuth refresh token
+# is not the only way the app holds a session (a better-auth cookie outlives it),
+# so an expired token does NOT mean the instance is signed out — ask the app.
+probe_renderer_authed() {
+  if ! curl -sf --max-time 2 "http://localhost:${CDP_PORT}/json/version" >/dev/null 2>&1; then
+    echo 0
+    return
+  fi
+  local out
+  out=$(agent-browser --session "edev$CDP_PORT" --cdp "$CDP_PORT" eval \
+    '(function(){try{var u=window.__LOBE_STORES.user();return (u.user&&u.user.id)?"AUTHED":"ANON";}catch(e){return "ERR";}})()' \
+    2>/dev/null | tail -1 || true)
+  case "$out" in
+    *AUTHED*) echo 1 ;;
+    *) echo 0 ;;
+  esac
+}
+
+# Persist an instance's login into the snapshot so the NEXT run starts signed in.
+# The refresh token rotates on every boot, so the instance's copy is the only
+# valid one by the time it stops — capture it before the userData is wiped.
+# `authed_hint=1` (from probe_renderer_authed, taken while the app was alive)
+# overrides the token check, which cannot see a cookie-only session.
+save_login_state() {
+  local src="$1" authed_hint="${2:-0}"
+  [ -d "$src" ] || return 0
+  if [ "$authed_hint" != "1" ] && ! profile_has_live_login "$src"; then
+    echo "[electron-dev] Not saving login state: $src is signed out / has no valid refresh token (kept the previous snapshot)."
+    return 0
+  fi
+  local staging="${LOGIN_STATE_DIR}.staging.$$"
+  rm -rf "$staging"
+  mkdir -p "$(dirname "$LOGIN_STATE_DIR")"
+  copy_login_items "$src" "$staging"
+  rm -rf "$LOGIN_STATE_DIR"
+  mv "$staging" "$LOGIN_STATE_DIR"
+  local ms
+  ms=$(refresh_token_expiry_ms "$LOGIN_STATE_DIR")
+  if [[ "$ms" =~ ^-?[0-9]+$ ]] && [ "$ms" -gt 0 ]; then
+    echo "[electron-dev] Saved login state → $LOGIN_STATE_DIR (refresh token valid for $((ms / 3600000))h)"
+  else
+    echo "[electron-dev] Saved login state → $LOGIN_STATE_DIR (cookie session; refresh token already expired)"
+  fi
+}
+
+# Seed a fresh userData dir: prefer the snapshot we saved on the last stop, and
+# fall back to the user's own dev profile for the very first run. No-op if the
+# dir already exists.
 seed_userdata() {
   local dst="$1"
   [ -d "$dst" ] && return 0
-  if [ ! -d "$GOLDEN_PROFILE" ]; then
-    echo "[electron-dev] WARNING: golden profile not found at $GOLDEN_PROFILE — instance will start signed out."
+
+  # The snapshot only exists because a `stop`/`save-login` found that instance
+  # signed in, so prefer it unconditionally over the golden profile.
+  local src="" label=""
+  if [ -d "$LOGIN_STATE_DIR" ]; then
+    src="$LOGIN_STATE_DIR"
+    label="saved login state"
+  elif [ -d "$GOLDEN_PROFILE" ]; then
+    src="$GOLDEN_PROFILE"
+    label="golden profile (first run)"
+  else
+    echo "[electron-dev] WARNING: no login state at $LOGIN_STATE_DIR or $GOLDEN_PROFILE — instance will start signed out."
     mkdir -p "$dst"
     return 0
   fi
-  echo "[electron-dev] Seeding login state from golden profile → $dst"
-  mkdir -p "$dst"
-  local items=(
-    "lobehub-settings.json" "Local State" "Preferences"
-    "Cookies" "Cookies-journal" "Local Storage" "IndexedDB"
-    "Session Storage" "Network Persistent State" "lobehub-storage"
-  )
-  local f
-  for f in "${items[@]}"; do
-    [ -e "$GOLDEN_PROFILE/$f" ] && cp -R "$GOLDEN_PROFILE/$f" "$dst/" 2>/dev/null || true
-  done
+
+  echo "[electron-dev] Seeding userData from $label → $dst"
+  profile_has_live_login "$src" ||
+    echo "[electron-dev]   note: its refresh token is expired — a cookie session may still carry it; otherwise sign in once and 'stop' will capture it."
+  copy_login_items "$src" "$dst"
 }
 
 # ── Commands ─────────────────────────────────────────────────────────
@@ -217,6 +348,13 @@ do_stop() {
   local label="legacy"
   [ "$POOL_MODE" = "1" ] && label="instance $INSTANCE (cdp $CDP_PORT)"
   echo "[electron-dev] Stopping Electron dev ($label)..."
+
+  # Ask the still-running app whether it is signed in — after the kill there is
+  # nothing left to ask, and the on-disk token alone can't see a cookie session.
+  local authed=0
+  if [ "$POOL_MODE" = "1" ] && [ "${SKIP_LOGIN_SAVE:-0}" != "1" ]; then
+    authed=$(probe_renderer_authed)
+  fi
 
   local seed_pids
   seed_pids=$(find_instance_pids)
@@ -280,8 +418,10 @@ do_stop() {
   agent-browser --session "edev$CDP_PORT" --cdp "$CDP_PORT" close --all 2>/dev/null || true
   rm -f "$PIDFILE"
 
-  # Pool mode: wipe the instance's userData unless asked to keep it.
+  # Pool mode: capture the (freshly rotated) login before touching the userData,
+  # then wipe it unless asked to keep it.
   if [ "$POOL_MODE" = "1" ] && [ -n "$USER_DATA_DIR" ]; then
+    [ "${SKIP_LOGIN_SAVE:-0}" = "1" ] || save_login_state "$USER_DATA_DIR" "$authed"
     if [ "${KEEP_DATA:-0}" = "1" ]; then
       echo "[electron-dev] Keeping userData: $USER_DATA_DIR"
     else
@@ -371,9 +511,11 @@ do_start() {
   fi
 }
 
-# Quiet stop used at the head of start — never wipes userData.
+# Quiet stop used at the head of start — never wipes userData, and never
+# snapshots: a leftover userData can carry a token that a LATER run has already
+# rotated away, which still looks unexpired but would overwrite a good snapshot.
 do_stop_quiet_for_start() {
-  KEEP_DATA=1 do_stop >/dev/null 2>&1 || true
+  KEEP_DATA=1 SKIP_LOGIN_SAVE=1 do_stop >/dev/null 2>&1 || true
 }
 
 do_restart() {
@@ -401,6 +543,19 @@ do_list() {
     done
   fi
   [ "$found" = "0" ] && echo "  (none)"
+}
+
+do_login_status() {
+  echo "[electron-dev] Login sources (the snapshot wins when present):"
+  describe_login "saved snapshot" "$LOGIN_STATE_DIR"
+  describe_login "golden profile" "$GOLDEN_PROFILE"
+  if [ ! -d "$LOGIN_STATE_DIR" ] && [ ! -d "$GOLDEN_PROFILE" ]; then
+    echo "[electron-dev] Nothing to seed from: sign in once inside the app, then 'save-login <id>' (or just 'stop <id>')."
+    return 2
+  fi
+  echo "[electron-dev] Note: an expired refresh token does not always mean signed out —"
+  echo "[electron-dev] the app may still hold a cookie session. 'stop'/'save-login' probe the"
+  echo "[electron-dev] running renderer, so a live login is captured either way."
 }
 
 do_stop_all() {
@@ -445,18 +600,33 @@ case "$CMD" in
   list)
     do_list
     ;;
+  save-login)
+    derive_instance "$INSTANCE"
+    if [ "$POOL_MODE" != "1" ]; then
+      echo "[electron-dev] save-login needs a pool instance id (its userData dir)."
+      exit 1
+    fi
+    save_login_state "$USER_DATA_DIR" "$(probe_renderer_authed)"
+    ;;
+  login-status)
+    do_login_status
+    ;;
   *)
     echo "Usage: $0 {start|stop|status|restart} [<id>]   |   $0 stop --all   |   $0 list"
+    echo "       $0 save-login <id>   |   $0 login-status"
     echo ""
-    echo "  start [<id>]   — Start an instance. No id = legacy single instance (CDP 9222)."
-    echo "                   <id> = pool member: CDP 9222+id, Vite 5173+id, own userData"
-    echo "                   (login copied from the golden profile) + IPC id."
-    echo "  stop [<id>]    — Stop an instance. Pool stop is sibling-safe. KEEP_DATA=1 to"
-    echo "                   preserve the instance's userData."
-    echo "  stop --all     — Stop every pool instance."
-    echo "  status [<id>]  — Check whether the instance's CDP is reachable."
-    echo "  restart [<id>] — Stop then start."
-    echo "  list           — List pool instances and their CDP reachability."
+    echo "  start [<id>]      — Start an instance. No id = legacy single instance (CDP 9222)."
+    echo "                      <id> = pool member: CDP 9222+id, Vite 5173+id, own userData"
+    echo "                      (login seeded from the saved snapshot) + IPC id."
+    echo "  stop [<id>]       — Stop an instance. Pool stop is sibling-safe, and snapshots the"
+    echo "                      instance's login first. KEEP_DATA=1 preserves the userData;"
+    echo "                      SKIP_LOGIN_SAVE=1 skips the snapshot."
+    echo "  stop --all        — Stop every pool instance."
+    echo "  status [<id>]     — Check whether the instance's CDP is reachable."
+    echo "  restart [<id>]    — Stop then start."
+    echo "  list              — List pool instances and their CDP reachability."
+    echo "  save-login <id>   — Snapshot a live instance's login without stopping it."
+    echo "  login-status      — Show which source will seed the next instance, and its expiry."
     exit 1
     ;;
 esac

--- a/.agents/skills/agent-testing/ui/electron.md
+++ b/.agents/skills/agent-testing/ui/electron.md
@@ -2,7 +2,7 @@
 
 Default surface for verifying **pure frontend changes** (components, store logic, styles, interactions) in the primary product shape. Drives the Electron renderer over CDP with `agent-browser` — see [../references/agent-browser.md](../references/agent-browser.md) for the full command reference.
 
-**Auth**: the Electron app keeps its own persistent login state — log in once manually in the app; sessions survive restarts. Run `../scripts/setup-auth.sh status` before testing (see [../references/auth.md](../references/auth.md)).
+**Auth**: `electron-dev.sh` persists the login across runs — `stop` snapshots it to `~/.lobehub/agent-testing/electron-login`, `start` seeds each new instance from there (`login-status` inspects it, `save-login <id>` captures a live instance). Sign in once, not once per run — and if an instance still comes up signed out, **drive the sign-in yourself**; never ask the user to click it. Run `../scripts/setup-auth.sh status` before testing (see [../references/auth.md](../references/auth.md)).
 
 **Linux / headless (cloud)**: Electron itself runs on Linux, but it has no true headless mode — it needs a display server. In a headless environment wrap the launch with `xvfb-run` (virtual framebuffer). Everything CDP-based keeps working under Xvfb: the `agent-browser --cdp 9222` connection, snapshots, eval, and `agent-browser screenshot` (captured from the renderer via CDP, not the OS screen). What does NOT work on Linux: `capture-app-window.sh` (macOS `screencapture`), osascript, and the ffmpeg recording scripts in their current form.
 
@@ -40,12 +40,15 @@ After `start` succeeds, connect with: `agent-browser --cdp 9222 snapshot -i`
 
 #### Environment Variables
 
-| Variable          | Default                 | Description                              |
-| ----------------- | ----------------------- | ---------------------------------------- |
-| `CDP_PORT`        | `9222`                  | Chrome DevTools Protocol port            |
-| `ELECTRON_LOG`    | `/tmp/electron-dev.log` | Electron process log                     |
-| `ELECTRON_WAIT_S` | `60`                    | Max seconds to wait for Electron process |
-| `RENDERER_WAIT_S` | `60`                    | Max seconds to wait for SPA to load      |
+| Variable               | Default                                   | Description                                       |
+| ---------------------- | ----------------------------------------- | ------------------------------------------------- |
+| `CDP_PORT`             | `9222`                                    | Chrome DevTools Protocol port                     |
+| `ELECTRON_LOG`         | `/tmp/electron-dev.log`                   | Electron process log                              |
+| `ELECTRON_WAIT_S`      | `60`                                      | Max seconds to wait for Electron process          |
+| `RENDERER_WAIT_S`      | `60`                                      | Max seconds to wait for SPA to load               |
+| `LOBE_LOGIN_STATE_DIR` | `~/.lobehub/agent-testing/electron-login` | Persistent login snapshot (survives `/tmp` wipes) |
+| `KEEP_DATA`            | `0`                                       | `1` = `stop <id>` keeps the instance's userData   |
+| `SKIP_LOGIN_SAVE`      | `0`                                       | `1` = `stop <id>` does not snapshot the login     |
 
 ### LobeHub Probes & Quick Navigation
 

--- a/src/features/ChatInput/ControlBar/WorktreeSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/WorktreeSwitcher.tsx
@@ -384,15 +384,24 @@ const getWorktreeBranch = (
 const isDisabled = (worktree: DeviceGitWorktreeListItem): boolean =>
   !!worktree.bare || !!worktree.prunable;
 
-// The main/source worktree can never be removed (`git worktree remove <main>`
-// fails with "is a main working tree"), and when the agent runs on a linked
-// worktree it is listed with `current: false` — so exclude it by path too, not
-// just via the `current` flag, to avoid offering a delete that always errors.
-const canRemoveWorktree = (worktree: DeviceGitWorktreeListItem, sourcePath: string): boolean =>
+// The main worktree can never be removed (`git worktree remove <main>` fails with
+// "is a main working tree"), and when the agent runs on a linked worktree it is
+// listed with `current: false` — so exclude it by path too, not just via the
+// `current` flag, to avoid offering a delete that always errors. `sourcePath` is
+// NOT the main worktree whenever the user picks a linked worktree directly as the
+// working directory, so it is excluded separately (removing the conversation's own
+// source repo would strand it), not used as a stand-in for the main worktree.
+const canRemoveWorktree = (
+  worktree: DeviceGitWorktreeListItem,
+  sourcePath: string,
+  mainWorktreePath?: string,
+): boolean =>
   !worktree.current &&
   !worktree.locked &&
   !isDisabled(worktree) &&
-  normalizeDisplayPath(worktree.path) !== normalizeDisplayPath(sourcePath);
+  normalizeDisplayPath(worktree.path) !== normalizeDisplayPath(sourcePath) &&
+  (!mainWorktreePath ||
+    normalizeDisplayPath(worktree.path) !== normalizeDisplayPath(mainWorktreePath));
 
 interface DirtyStatProps {
   status?: DeviceGitWorktreeListItem['status'];
@@ -609,8 +618,17 @@ const WorktreeSwitcher = memo<WorktreeSwitcherProps>(
     const triggerTitle = detached
       ? t('workingDirectory.detachedHead', { sha: currentBranch })
       : `${currentName} · ${branchLabel}`;
-    const isSourceWorktree = normalizeDisplayPath(currentPath) === normalizeDisplayPath(sourcePath);
-    const triggerIcon = isSourceWorktree ? GitBranchIcon : GitForkIcon;
+    // `git worktree list` always emits the main worktree first (a bare repo has
+    // none, so every checkout is linked). Compare against it rather than
+    // `sourcePath`, which is itself a linked worktree whenever the user picks one
+    // directly as the working directory — that would show a branch icon while
+    // standing inside a worktree.
+    const [mainWorktree] = worktrees;
+    const isLinkedWorktree =
+      !!mainWorktree &&
+      (!!mainWorktree.bare ||
+        normalizeDisplayPath(currentPath) !== normalizeDisplayPath(mainWorktree.path));
+    const triggerIcon = isLinkedWorktree ? GitForkIcon : GitBranchIcon;
 
     const trigger = (
       <div
@@ -670,7 +688,8 @@ const WorktreeSwitcher = memo<WorktreeSwitcherProps>(
                       const displayPath = getRelativeDisplayPath(worktree.path, sourcePath);
                       const disabled = isDisabled(worktree);
                       const removing = removingPaths.has(worktree.path);
-                      const removable = canRemoveWorktree(worktree, sourcePath) && !removing;
+                      const removable =
+                        canRemoveWorktree(worktree, sourcePath, mainWorktree?.path) && !removing;
 
                       return (
                         <DropdownMenuItem

--- a/src/features/ChatInput/ControlBar/__tests__/WorktreeSwitcher.test.tsx
+++ b/src/features/ChatInput/ControlBar/__tests__/WorktreeSwitcher.test.tsx
@@ -32,7 +32,7 @@ vi.mock('@/services/git', () => ({
 }));
 
 vi.mock('@lobehub/ui', () => ({
-  Icon: () => <span data-testid="icon" />,
+  Icon: ({ icon }: any) => <span data-icon={icon?.displayName ?? icon?.name} data-testid="icon" />,
   Input: ({ value, onChange, placeholder }: any) => (
     <input placeholder={placeholder} value={value} onChange={onChange} />
   ),
@@ -87,6 +87,14 @@ beforeEach(() => {
   removeGitWorktreeMock.mockResolvedValue({ success: true });
 });
 
+const triggerIconName = () =>
+  within(screen.getByTestId('worktree-dropdown-trigger'))
+    .getAllByTestId('icon')[0]
+    .getAttribute('data-icon');
+
+/** Text of the worktree row owning `el` — rows render as `<button>` (mocked DropdownMenuItem). */
+const rowTextOf = (el: HTMLElement) => el.closest('button')?.textContent ?? '';
+
 describe('WorktreeSwitcher', () => {
   it('keeps the dropdown trigger anchored to a stable DOM wrapper', () => {
     render(
@@ -116,6 +124,62 @@ describe('WorktreeSwitcher', () => {
     const trigger = screen.getByTestId('worktree-dropdown-trigger');
     expect(trigger.firstElementChild?.tagName).toBe('DIV');
     expect(within(trigger).getByTestId('worktree-tooltip')).toBeTruthy();
+  });
+
+  it('shows a branch icon on the main worktree and a fork icon on a linked one', () => {
+    const cleanStatus = { added: 0, clean: true, deleted: 0, modified: 0, total: 0 };
+    const worktrees = [
+      { branch: 'canary', current: true, path: '/repo', status: cleanStatus },
+      { branch: 'feat/x', current: false, path: '/repo-feat', status: cleanStatus },
+    ];
+
+    const { rerender } = render(
+      <WorktreeSwitcher
+        isGithub
+        agentId="agent-1"
+        currentBranch="canary"
+        path="/repo"
+        sourcePath="/repo"
+        worktrees={worktrees}
+      />,
+    );
+    expect(triggerIconName()).toBe('GitBranch');
+
+    // The user picked the linked worktree directly as the working directory, so
+    // `sourcePath` is the worktree itself — the icon must still read "worktree".
+    rerender(
+      <WorktreeSwitcher
+        isGithub
+        agentId="agent-1"
+        currentBranch="feat/x"
+        path="/repo-feat"
+        sourcePath="/repo-feat"
+        worktrees={[
+          { ...worktrees[0], current: false },
+          { ...worktrees[1], current: true },
+        ]}
+      />,
+    );
+    expect(triggerIconName()).toBe('GitFork');
+  });
+
+  it('treats every checkout of a bare repository as a linked worktree', () => {
+    const cleanStatus = { added: 0, clean: true, deleted: 0, modified: 0, total: 0 };
+    render(
+      <WorktreeSwitcher
+        isGithub
+        agentId="agent-1"
+        currentBranch="canary"
+        path="/repo/canary"
+        sourcePath="/repo/canary"
+        worktrees={[
+          { bare: true, current: false, path: '/repo' },
+          { branch: 'canary', current: true, path: '/repo/canary', status: cleanStatus },
+        ]}
+      />,
+    );
+
+    expect(triggerIconName()).toBe('GitFork');
   });
 
   it('renders dirty stats and omits clean labels in the worktree list', () => {
@@ -187,6 +251,32 @@ describe('WorktreeSwitcher', () => {
     expect(screen.getByText('/Users/me/projects/project')).toBeTruthy();
     expect(screen.getByText('../project-fix')).toBeTruthy();
     expect(screen.getByText('/tmp/project-scratch')).toBeTruthy();
+  });
+
+  it('never offers to remove the main worktree, even when it is not the source path', () => {
+    const cleanStatus = { added: 0, clean: true, deleted: 0, modified: 0, total: 0 };
+    render(
+      <WorktreeSwitcher
+        isGithub
+        agentId="agent-1"
+        currentBranch="feat/x"
+        path="/repo-feat"
+        sourcePath="/repo-feat"
+        worktrees={[
+          // main worktree — listed first, and `current: false` because the
+          // conversation runs on a linked one. `git worktree remove` would error.
+          { branch: 'canary', current: false, path: '/repo', status: cleanStatus },
+          { branch: 'feat/x', current: true, path: '/repo-feat', status: cleanStatus },
+          { branch: 'feat/y', current: false, path: '/repo-other', status: cleanStatus },
+        ]}
+      />,
+    );
+
+    // Only `/repo-other` is removable: `/repo` is the main worktree and
+    // `/repo-feat` is both the current worktree and the conversation's source.
+    const removeButtons = screen.getAllByLabelText('workingDirectory.removeWorktreeAction');
+    expect(removeButtons).toHaveLength(1);
+    expect(rowTextOf(removeButtons[0])).toContain('feat/y');
   });
 
   it('confirms and removes a non-current worktree', async () => {


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [x] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

**1. `WorktreeSwitcher` mistook `sourcePath` for the main worktree**

`sourcePath` is whatever directory the user picked in the working-directory picker. It is a *linked* worktree whenever a conversation is pointed straight at one, instead of being switched into it from the source repo. Two places treated it as a stand-in for the main worktree:

- **Trigger icon** — `isSourceWorktree = currentPath === sourcePath` held, so the control rendered a **branch** glyph while standing inside a worktree. (Tell-tale symptom in the popover: the current row prints an absolute path, because `getRelativeDisplayPath` returns early when `target === sourcePath`.)
- **Delete affordance** — `canRemoveWorktree` excluded `sourcePath` rather than the main worktree, so the row for the *real* main worktree offered a delete action that `git worktree remove <main>` always rejects with `is a main working tree`.

`git worktree list --porcelain` emits the main worktree first (a bare repo has none, so every checkout is linked), and `listGitWorktrees` preserves that order across both the IPC and device-RPC paths. Both call sites now compare against that entry. `sourcePath` is kept as a *separate* delete guard — removing the conversation's own source repo would strand it.

**2. `agent-testing`: the Electron login now survives across runs**

`electron-dev.sh stop <id>` wipes the instance's userData, so every verification run re-seeded from the golden profile — whose OAuth refresh token rotates on each boot and expires ~7 days after the last refresh. Once it lapsed, every run hit the sign-in wall.

`stop` now snapshots the login into `~/.lobehub/agent-testing/electron-login` before wiping, and `start` seeds new instances from that snapshot. Two new commands: `login-status` (which source seeds the next instance + its expiry) and `save-login <id>` (capture a live instance — a *killed* one loses its rotated token). The save decision probes the running renderer rather than the on-disk token, because a better-auth cookie session can outlive the token, and a failed refresh makes the app erase `encryptedTokens` entirely.

The skill's living logs also gained this run's findings: a worktree checkout needs its own `pnpm install` (a symlinked `node_modules` resolves `@lobechat/*` back to the main checkout's branch and breaks the main-process build), the first cold boot leaves `#root` empty for minutes, the main process yanks the renderer back to its last tab, and how to drive the working-directory ControlBar without the native picker.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Three new cases in `WorktreeSwitcher.test.tsx`. Two of them were each run against the old logic to confirm they fail there, so they are genuine regression tests:

1. main worktree → `GitBranch`; then, with `sourcePath` equal to the linked worktree → `GitFork` (old logic: `GitBranch`)
2. a bare repository's first entry means every checkout is linked → `GitFork`
3. a main worktree with `current: false` and `path !== sourcePath` offers no delete button (old logic: it did)

End-to-end in an isolated Electron dev instance loading the branch, against a throwaway repo with a main worktree plus two linked ones, pointing a scratch agent's working directory at each in turn:

| working directory | trigger icon | delete affordance |
| --- | --- | --- |
| `repo-main` (main worktree) | branch | — |
| `repo-feat` (linked, and the picked source) | **worktree / fork** | — (current) |
| `repo-other` (linked, removable) | — | trash icon on hover |

The login-persistence change was verified end to end: sign in once → `save-login 5` → `stop 5` → `start 6` printed `Seeding userData from saved login state` and instance 6 came up already authenticated, with no interaction.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Standing inside a linked worktree, the switcher showed a branch icon — indistinguishable from the directory picker's own `git-branch` glyph right next to it. | The switcher shows the fork/worktree icon, and reverts to the branch icon only on the main worktree. |
| The main worktree's row offered a delete action that always errored. | Delete is offered only on removable linked worktrees. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)