### PR TITLE
✨ feat(analytics): add conversation business hook

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/user.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/user.test.ts
@@ -59,6 +59,26 @@ describe('userRouter', () => {
     vi.mocked(onUserActivityForBusiness).mockResolvedValue(undefined);
   });
 
+  describe('getUserActivitySummary', () => {
+    it('returns the user-level activity summary', async () => {
+      const summary = {
+        lastUserMessageAt: new Date('2026-06-01T00:00:00.000Z'),
+        userCreatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      };
+      vi.mocked(UserModel).mockImplementation(
+        () =>
+          ({
+            getUserActivitySummary: vi.fn().mockResolvedValue(summary),
+          }) as any,
+      );
+
+      const result = await userRouter.createCaller({ ...mockCtx }).getUserActivitySummary();
+
+      expect(result).toEqual(summary);
+      expect(UserModel).toHaveBeenCalledWith(serverDB, mockUserId);
+    });
+  });
+
   describe('getUserRegistrationDuration', () => {
     it('should return registration duration', async () => {
       const mockDuration = { duration: 100, createdAt: '2023-01-01', updatedAt: '2023-01-02' };

--- a/apps/server/src/routers/lambda/user.ts
+++ b/apps/server/src/routers/lambda/user.ts
@@ -97,6 +97,10 @@ const userProcedure = authedProcedure.use(serverDatabase).use(async ({ ctx, next
 });
 
 export const userRouter = router({
+  getUserActivitySummary: userProcedure.query(async ({ ctx }) => {
+    return ctx.userModel.getUserActivitySummary();
+  }),
+
   getUserRegistrationDuration: userProcedure.query(async ({ ctx }) => {
     return ctx.userModel.getUserRegistrationDuration();
   }),

--- a/packages/database/src/models/__tests__/user.test.ts
+++ b/packages/database/src/models/__tests__/user.test.ts
@@ -31,6 +31,56 @@ describe('UserModel', () => {
     vi.clearAllMocks();
   });
 
+  describe('getUserActivitySummary', () => {
+    it('returns the user creation time and latest user-authored message', async () => {
+      const userCreatedAt = new Date('2026-01-01T00:00:00.000Z');
+      const latestUserMessageAt = new Date('2026-03-01T00:00:00.000Z');
+      await serverDB.update(users).set({ createdAt: userCreatedAt }).where(eq(users.id, userId));
+      await serverDB.insert(messages).values([
+        {
+          content: 'older',
+          createdAt: new Date('2026-02-01T00:00:00.000Z'),
+          id: 'activity-user-old',
+          role: 'user',
+          userId,
+        },
+        {
+          content: 'ignored assistant',
+          createdAt: new Date('2026-04-01T00:00:00.000Z'),
+          id: 'activity-assistant',
+          role: 'assistant',
+          userId,
+        },
+        {
+          content: 'latest',
+          createdAt: latestUserMessageAt,
+          id: 'activity-user-latest',
+          role: 'user',
+          userId,
+        },
+        {
+          content: 'other user',
+          createdAt: new Date('2026-05-01T00:00:00.000Z'),
+          id: 'activity-other-user',
+          role: 'user',
+          userId: otherUserId,
+        },
+      ]);
+
+      await expect(userModel.getUserActivitySummary()).resolves.toEqual({
+        lastUserMessageAt: latestUserMessageAt,
+        userCreatedAt,
+      });
+    });
+
+    it('returns a null message time when the user has never sent a message', async () => {
+      const result = await userModel.getUserActivitySummary();
+
+      expect(result.lastUserMessageAt).toBeNull();
+      expect(result.userCreatedAt).toBeInstanceOf(Date);
+    });
+  });
+
   describe('getUserRegistrationDuration', () => {
     it('should return registration duration for existing user', async () => {
       const thirtyDaysAgo = new Date();

--- a/packages/database/src/models/user.ts
+++ b/packages/database/src/models/user.ts
@@ -8,7 +8,7 @@ import type {
 } from '@lobechat/types';
 import { TRPCError } from '@trpc/server';
 import dayjs from 'dayjs';
-import { and, asc, eq, gt, inArray, or, sql } from 'drizzle-orm';
+import { and, asc, eq, gt, inArray, max, or, sql } from 'drizzle-orm';
 import type { PartialDeep } from 'type-fest';
 
 import { merge } from '@/utils/merge';
@@ -60,6 +60,26 @@ export class UserModel {
     this.userId = userId;
     this.db = db;
   }
+
+  getUserActivitySummary = async (): Promise<{
+    lastUserMessageAt: Date | null;
+    userCreatedAt: Date | null;
+  }> => {
+    const [summary] = await this.db
+      .select({
+        lastUserMessageAt: max(messages.createdAt),
+        userCreatedAt: users.createdAt,
+      })
+      .from(users)
+      .leftJoin(messages, and(eq(messages.userId, users.id), eq(messages.role, 'user')))
+      .where(eq(users.id, this.userId))
+      .groupBy(users.createdAt);
+
+    return {
+      lastUserMessageAt: summary?.lastUserMessageAt ?? null,
+      userCreatedAt: summary?.userCreatedAt ?? null,
+    };
+  };
 
   getUserRegistrationDuration = async (): Promise<{
     createdAt: string;
@@ -232,8 +252,7 @@ export class UserModel {
     `);
 
     const row = result.rows[0] as
-      | { previousLastActiveAt: Date | string; userCreatedAt: Date | string }
-      | undefined;
+      { previousLastActiveAt: Date | string; userCreatedAt: Date | string } | undefined;
     if (!row) return;
 
     return {

--- a/src/business/client/hooks/useBusinessConversationAnalytics.ts
+++ b/src/business/client/hooks/useBusinessConversationAnalytics.ts
@@ -1,0 +1,5 @@
+import type { ConversationContext, ConversationHooks } from '@/features/Conversation/types';
+
+export const useBusinessConversationAnalytics = (
+  _context: ConversationContext,
+): ConversationHooks => ({});

--- a/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
@@ -89,7 +89,7 @@ const Conversation = memo(() => {
   const businessAnalyticsHooks = useBusinessConversationAnalytics(context);
 
   const hooks = useMemo(
-    () => mergeConversationHooks(chatFollowUpHooks, businessAnalyticsHooks),
+    () => mergeConversationHooks(businessAnalyticsHooks, chatFollowUpHooks),
     [businessAnalyticsHooks, chatFollowUpHooks],
   );
 

--- a/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
+++ b/src/routes/(main)/agent/features/Conversation/ConversationArea.tsx
@@ -6,6 +6,7 @@ import debug from 'debug';
 import { memo, Suspense, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useBusinessConversationAnalytics } from '@/business/client/hooks/useBusinessConversationAnalytics';
 import AgentHome from '@/features/AgentHome';
 import ChatMiniMap from '@/features/ChatMiniMap';
 import { ChatList, ConversationProvider } from '@/features/Conversation';
@@ -85,8 +86,12 @@ const Conversation = memo(() => {
     threadId: context.threadId ?? undefined,
     topicId: context.topicId ?? undefined,
   });
+  const businessAnalyticsHooks = useBusinessConversationAnalytics(context);
 
-  const hooks = useMemo(() => mergeConversationHooks(chatFollowUpHooks), [chatFollowUpHooks]);
+  const hooks = useMemo(
+    () => mergeConversationHooks(chatFollowUpHooks, businessAnalyticsHooks),
+    [businessAnalyticsHooks, chatFollowUpHooks],
+  );
 
   return (
     <ConversationProvider

--- a/src/services/user/index.ts
+++ b/src/services/user/index.ts
@@ -16,6 +16,13 @@ import {
 import { type UserSettings } from '@/types/user/settings';
 
 export class UserService {
+  getUserActivitySummary = async (): Promise<{
+    lastUserMessageAt: Date | null;
+    userCreatedAt: Date | null;
+  }> => {
+    return lambdaClient.user.getUserActivitySummary.query();
+  };
+
   getUserRegistrationDuration = async (): Promise<{
     createdAt: string;
     duration: number;


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Add a generic conversation analytics business hook with a no-op default implementation.
- Merge business analytics hooks into the main agent conversation lifecycle.
- Add an authenticated user activity summary that returns account creation time and the latest user-authored message time across the account.
- Cover the activity summary with model and router tests.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check --lint --test`

Result: 88 related tests passed.

#### 📸 Screenshots / Videos

N/A — no visual changes.

#### 📝 Additional Information

The default business hook is intentionally a no-op. This PR adds extension points and read-only activity data only; it does not change message sending, generation, follow-up, or other conversation behavior.