### PR TITLE
💄 style: lead the topic meta PR row with its number

### DIFF
--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.test.tsx
@@ -63,4 +63,34 @@ describe('MetaHoverCard', () => {
     expect(screen.getByText('repo-fix')).toBeInTheDocument();
     expect(screen.queryByText('metaCard.branchNote')).not.toBeInTheDocument();
   });
+
+  it('renders the PR number ahead of the title so the ellipsis never eats it', () => {
+    const metadata: ChatTopicMetadata = {
+      workingDirectory: '/repo',
+      workingDirectoryConfig: {
+        git: {
+          branch: 'perf/active-scope-key',
+          github: {
+            pullRequest: {
+              ciStatus: 'success',
+              mergedAt: '2026-07-09T00:00:00.000Z',
+              number: 16_951,
+              state: 'closed',
+              title: 'perf(swr): persist activeScopeKey',
+              url: 'https://github.com/lobehub/lobehub/pull/16951',
+            },
+          },
+        },
+        path: '/repo',
+        repoType: 'git',
+      },
+    };
+
+    render(<MetaHoverCard metadata={metadata} title="Topic" />);
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', 'https://github.com/lobehub/lobehub/pull/16951');
+    expect(link).toHaveTextContent('metaCard.pr.merged · #16951 perf(swr): persist activeScopeKey');
+    expect(screen.getByTitle('#16951 perf(swr): persist activeScopeKey')).toBeInTheDocument();
+  });
 });

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/MetaHoverCard.tsx
@@ -80,7 +80,10 @@ const styles = createStaticStyles(({ css }) => ({
     color: inherit;
     text-decoration: none;
 
+    /* antd's global a:hover outranks the color:inherit above, so without this the
+       row would turn link-blue; hovering should read as emphasis instead. */
     &:hover {
+      color: ${cssVar.colorText};
       background: ${cssVar.colorFillTertiary};
     }
   `,
@@ -183,6 +186,9 @@ const MetaHoverCard = memo<MetaHoverCardProps>(({ metadata, title, time }) => {
         (() => {
           const prState = getPullRequestState(pullRequest);
           const prVisual = PR_STATE_VISUAL[prState];
+          const prTitleAttr = pullRequest.title
+            ? `#${pullRequest.number} ${pullRequest.title}`
+            : `#${pullRequest.number}`;
           const prInner = (
             <>
               <Icon
@@ -191,12 +197,16 @@ const MetaHoverCard = memo<MetaHoverCardProps>(({ metadata, title, time }) => {
                 size={15}
                 style={{ color: prVisual.color }}
               />
-              <span className={styles.rowText} title={pullRequest.title}>
+              <span className={styles.rowText} title={prTitleAttr}>
                 <span style={{ color: prVisual.color, fontWeight: 500 }}>
                   {t(prVisual.labelKey)}
                 </span>
-                {pullRequest.title ? ` · ${pullRequest.title}` : ''}
-                <span style={{ color: cssVar.colorTextTertiary }}>{` #${pullRequest.number}`}</span>
+                {/* The number leads the title: it is the stable identifier, and a
+                    long title would otherwise push it past the ellipsis. */}
+                <span
+                  style={{ color: cssVar.colorTextTertiary }}
+                >{` · #${pullRequest.number}`}</span>
+                {pullRequest.title ? ` ${pullRequest.title}` : ''}
               </span>
             </>
           );


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 💄 style

### 🔀 变更说明 | Description of Change

Two small fixes to the linked-PR row in the topic sidebar hover card (`MetaHoverCard`).

**1. The PR number now leads the title.**

The row rendered `<state> · <title> #<number>`. Because PR titles are long and the row is `text-overflow: ellipsis`, the number — the stable identifier you actually want to read — was almost always truncated away. It now sits between the state and the title:

```diff
- 已合并 · perf(swr): persist activeScopeKey across cold …
+ 已合并 · #16951 perf(swr): persist activeScopeKey acros…
```

The `title` attribute (native tooltip) carries `#<number> <title>` to match.

**2. Hover no longer turns the row link-blue.**

The row is an `<a>`, and antd's global `a:hover { color: colorLinkHover }` (specificity `0,1,1`) outranks the `color: inherit` on `.prLink` (`0,1,0`), so hovering tinted the whole row blue. Hover now explicitly steps the text up one level of emphasis (`colorTextSecondary` → `colorText`), which reads as "this is interactive" without the link-blue.

### 📝 补充信息 | Additional Information

Covered by a new case in `MetaHoverCard.test.tsx` asserting the rendered order, the `href`, and the tooltip text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)