### PR TITLE
✨ feat(setting): split Skills and Connectors into separate settings pages

### DIFF
--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -1006,6 +1006,7 @@
   "tab.appearance": "Appearance",
   "tab.chatAppearance": "Chat Appearance",
   "tab.common": "Appearance",
+  "tab.connector": "Connectors",
   "tab.creds": "Credentials",
   "tab.devices": "Devices",
   "tab.experiment": "Experiment",
@@ -2488,6 +2489,7 @@
   "workspaceSetting.storage.telemetry.desc": "Help us improve {{appName}} with anonymous workspace usage data",
   "workspaceSetting.storage.telemetry.title": "Send Anonymous Workspace Usage Data",
   "workspaceSetting.tab.auditLog": "Audit logs",
+  "workspaceSetting.tab.connector": "Connectors",
   "workspaceSetting.tab.general": "General",
   "workspaceSetting.tab.members": "Members",
   "workspaceSetting.tab.skill": "Skills"

--- a/packages/locales/src/default/setting.ts
+++ b/packages/locales/src/default/setting.ts
@@ -1163,6 +1163,7 @@ When I am ___, I need ___
   'tab.appearance': 'Appearance',
   'tab.chatAppearance': 'Chat Appearance',
   'tab.common': 'Appearance',
+  'tab.connector': 'Connectors',
   'tab.creds': 'Credentials',
   'tab.devices': 'Devices',
   'tab.experiment': 'Experiment',
@@ -2688,6 +2689,7 @@ When I am ___, I need ___
   'workspaceSetting.storage.telemetry.desc':
     'Help us improve {{appName}} with anonymous workspace usage data',
   'workspaceSetting.storage.telemetry.title': 'Send Anonymous Workspace Usage Data',
+  'workspaceSetting.tab.connector': 'Connectors',
   'workspaceSetting.tab.skill': 'Skills',
   'tools.add': 'Add Skill',
   'tools.addSkillOrConnector': 'Add Skills / Connectors',

--- a/src/features/ChatInput/ActionBar/Tools/PopoverContent.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/PopoverContent.tsx
@@ -185,7 +185,7 @@ const PopoverContent = memo<PopoverContentProps>(
               type="button"
               onClick={() => {
                 closePopover();
-                navigate('/settings/skill');
+                navigate('/settings/connector');
               }}
             >
               <Icon icon={Settings} size={14} />

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -1620,7 +1620,7 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
           onClick={(event) => {
             event.stopPropagation();
             closeDropdown?.();
-            navigate('/settings/skill');
+            navigate('/settings/connector');
           }}
         >
           <Icon icon={Settings} size={SKILL_ICON_SIZE} />

--- a/src/features/ProfileEditor/PopoverContent.tsx
+++ b/src/features/ProfileEditor/PopoverContent.tsx
@@ -106,7 +106,7 @@ const PopoverContent = memo<PopoverContentProps>(({ items, onOpenStore, onClose 
           tabIndex={0}
           onClick={() => {
             onClose?.();
-            navigate('/settings/skill');
+            navigate('/settings/connector');
           }}
         >
           <div className={toolsListStyles.itemIcon}>

--- a/src/features/Workspace/__tests__/workspaceAwarePath.test.ts
+++ b/src/features/Workspace/__tests__/workspaceAwarePath.test.ts
@@ -71,6 +71,7 @@ describe('buildWorkspaceAwarePath', () => {
     expect(buildWorkspaceAwarePath('/settings/credits', 'acme')).toBe('/acme/settings/credits');
     expect(buildWorkspaceAwarePath('/settings/usage', 'acme')).toBe('/acme/settings/usage');
     expect(buildWorkspaceAwarePath('/settings/skill', 'acme')).toBe('/acme/settings/skill');
+    expect(buildWorkspaceAwarePath('/settings/connector', 'acme')).toBe('/acme/settings/connector');
     expect(buildWorkspaceAwarePath('/settings/messenger', 'acme')).toBe('/acme/settings/messenger');
     expect(buildWorkspaceAwarePath('/settings/creds', 'acme')).toBe('/acme/settings/creds');
     expect(buildWorkspaceAwarePath('/settings/provider/openai', 'acme')).toBe(

--- a/src/features/Workspace/workspaceAwarePath.ts
+++ b/src/features/Workspace/workspaceAwarePath.ts
@@ -32,6 +32,7 @@ const isPersonalPath = (to: string): boolean => PERSONAL_PATH_REGEX.test(to);
 export const WORKSPACE_SETTINGS_TABS: ReadonlySet<string> = new Set([
   'apikey',
   'billing',
+  'connector',
   'creds',
   'credits',
   'general',

--- a/src/features/WorkspaceSetting/hooks/useCategory.tsx
+++ b/src/features/WorkspaceSetting/hooks/useCategory.tsx
@@ -1,5 +1,6 @@
 import { SkillsIcon } from '@lobehub/ui/icons';
 import {
+  Blocks,
   Brain,
   Building2,
   ChartColumnBigIcon,
@@ -118,6 +119,11 @@ export const useWorkspaceSettingCategory = (): WorkspaceSettingCategoryGroup[] =
               icon: SkillsIcon,
               key: WorkspaceSettingsTabs.Skill,
               label: t('workspaceSetting.tab.skill'),
+            },
+            {
+              icon: Blocks,
+              key: WorkspaceSettingsTabs.Connector,
+              label: t('workspaceSetting.tab.connector'),
             },
             {
               icon: KeyRound,

--- a/src/routes/(main)/[workspaceSlug]/settings/connector/index.tsx
+++ b/src/routes/(main)/[workspaceSlug]/settings/connector/index.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import { ToolSettings } from '@/routes/(main)/settings/skill';
+
+const WorkspaceConnectorSetting = () => <ToolSettings viewMode="connector" />;
+
+WorkspaceConnectorSetting.displayName = 'WorkspaceConnectorSetting';
+
+export default WorkspaceConnectorSetting;

--- a/src/routes/(main)/home/_layout/Body/Agent/ModalProvider.test.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/ModalProvider.test.tsx
@@ -153,7 +153,7 @@ describe('AgentModalProvider', () => {
     fireEvent.click(screen.getByText('View in Skills'));
 
     expect(mocks.navigate).toHaveBeenCalledWith(
-      '/settings/skill?tab=skill&skill=product-requirements-writer',
+      '/settings/skill?skill=product-requirements-writer',
     );
   });
 });

--- a/src/routes/(main)/home/_layout/Body/Agent/ModalProvider.tsx
+++ b/src/routes/(main)/home/_layout/Body/Agent/ModalProvider.tsx
@@ -112,7 +112,7 @@ const CreateModalRenderer = memo<CreateModalRendererProps>(
     const handleOpenSkills = useCallback(
       (identifier: string) => {
         onClose();
-        navigate(`/settings/skill?tab=skill&skill=${encodeURIComponent(identifier)}`);
+        navigate(`/settings/skill?skill=${encodeURIComponent(identifier)}`);
       },
       [navigate, onClose],
     );

--- a/src/routes/(main)/settings/connector/index.tsx
+++ b/src/routes/(main)/settings/connector/index.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { memo } from 'react';
+
+import { ToolSettings } from '@/routes/(main)/settings/skill';
+
+const Page = memo(() => <ToolSettings viewMode="connector" />);
+
+Page.displayName = 'ConnectorSettings';
+
+export default Page;

--- a/src/routes/(main)/settings/features/SettingsContent.tsx
+++ b/src/routes/(main)/settings/features/SettingsContent.tsx
@@ -70,7 +70,10 @@ const SettingsContent = ({ mobile, activeTab }: SettingsContentProps) => {
   return (
     <>
       {Object.keys(componentMap).map((tabKey) => {
-        const isFullWidth = tabKey === SettingsTabs.Provider || tabKey === SettingsTabs.Skill;
+        const isFullWidth =
+          tabKey === SettingsTabs.Provider ||
+          tabKey === SettingsTabs.Skill ||
+          tabKey === SettingsTabs.Connector;
         if (activeTab !== tabKey) return null;
         const content = renderComponent(tabKey);
         if (isFullWidth) return <Fragment key={tabKey}>{content}</Fragment>;

--- a/src/routes/(main)/settings/features/componentMap.desktop.ts
+++ b/src/routes/(main)/settings/features/componentMap.desktop.ts
@@ -10,6 +10,7 @@ import About from '../about';
 import Advanced from '../advanced';
 import APIKey from '../apikey';
 import Appearance from '../appearance';
+import Connector from '../connector';
 import Creds from '../creds';
 import Devices from '../devices';
 import Hotkey from '../hotkey';
@@ -47,6 +48,7 @@ export const componentMap = {
   [SettingsTabs.Creds]: Creds,
   [SettingsTabs.Security]: Security,
   [SettingsTabs.Skill]: Skill,
+  [SettingsTabs.Connector]: Connector,
 
   [SettingsTabs.Plans]: Plans,
   [SettingsTabs.Credits]: Credits,

--- a/src/routes/(main)/settings/features/componentMap.ts
+++ b/src/routes/(main)/settings/features/componentMap.ts
@@ -71,6 +71,9 @@ export const componentMap = {
   [SettingsTabs.Skill]: dynamic(() => import('../skill'), {
     loading: loading('Settings > Skill'),
   }),
+  [SettingsTabs.Connector]: dynamic(() => import('../connector'), {
+    loading: loading('Settings > Connector'),
+  }),
 
   [SettingsTabs.Plans]: dynamic(() => import('@/business/client/BusinessSettingPages/Plans'), {
     loading: loading('Settings > Plans'),

--- a/src/routes/(main)/settings/hooks/useCategory.tsx
+++ b/src/routes/(main)/settings/hooks/useCategory.tsx
@@ -3,6 +3,7 @@ import { Avatar } from '@lobehub/ui';
 import { SkillsIcon } from '@lobehub/ui/icons';
 import {
   BellIcon,
+  Blocks,
   Brain,
   BrainCircuit,
   ChartColumnBigIcon,
@@ -160,6 +161,11 @@ export const useCategory = () => {
         icon: SkillsIcon,
         key: SettingsTabs.Skill,
         label: t('tab.skill'),
+      },
+      {
+        icon: Blocks,
+        key: SettingsTabs.Connector,
+        label: t('tab.connector'),
       },
       {
         icon: BrainCircuit,

--- a/src/routes/(main)/settings/skill/features/LeftPanel.tsx
+++ b/src/routes/(main)/settings/skill/features/LeftPanel.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Button, DropdownMenu, Flexbox, Icon, Text } from '@lobehub/ui';
-import { Tabs } from '@lobehub/ui/base-ui';
 import { GithubIcon } from '@lobehub/ui/icons';
 import { createStaticStyles } from 'antd-style';
 import { FileArchive, Grid2x2Plus, Link, Store } from 'lucide-react';
@@ -49,13 +48,12 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 interface LeftPanelProps {
   onDeleteSelected: () => void;
   onSelect: (identifier: string, type: ToolDetailType) => void;
-  onViewModeChange: (mode: SkillViewMode) => void;
   selectedIdentifier?: string;
   viewMode: SkillViewMode;
 }
 
 const LeftPanel = memo<LeftPanelProps>(
-  ({ onDeleteSelected, onSelect, onViewModeChange, selectedIdentifier, viewMode }) => {
+  ({ onDeleteSelected, onSelect, selectedIdentifier, viewMode }) => {
     const { t } = useTranslation('setting');
     const [showAddConnector, setShowAddConnector] = useState(false);
 
@@ -63,85 +61,80 @@ const LeftPanel = memo<LeftPanelProps>(
       createSkillStoreModal();
     }, []);
 
+    const isConnectorView = viewMode === 'connector';
+
     return (
       <>
         <div className={styles.root}>
           <div className={styles.header}>
-            <Tabs
-              activeKey={viewMode}
-              size="small"
-              style={{ width: 'auto' }}
-              items={[
-                { key: 'connector', label: t('skillView.connectors', 'Connectors') },
-                { key: 'skill', label: t('skillView.skills', 'Skills') },
-              ]}
-              onChange={(key) => onViewModeChange(key as SkillViewMode)}
-            />
+            <Text strong style={{ fontSize: 14 }}>
+              {isConnectorView
+                ? t('skillView.connectors', 'Connectors')
+                : t('skillView.skills', 'Skills')}
+            </Text>
 
             <div style={{ display: 'flex', gap: 6 }} onClick={(e) => e.stopPropagation()}>
-              <DropdownMenu
-                nativeButton={false}
-                placement="bottomRight"
-                items={[
-                  {
-                    icon: <Icon icon={Link} />,
-                    key: 'importUrl',
-                    label: (
-                      <Flexbox gap={2}>
-                        <span>{t('tab.importFromUrl')}</span>
-                        <Text style={{ fontSize: 12 }} type="secondary">
-                          {t('tab.importFromUrl.desc')}
-                        </Text>
-                      </Flexbox>
-                    ),
-                    onClick: () => openImportFromUrlModal(),
-                  },
-                  {
-                    icon: <Icon icon={GithubIcon} />,
-                    key: 'importGithub',
-                    label: (
-                      <Flexbox gap={2}>
-                        <span>{t('tab.importFromGithub')}</span>
-                        <Text style={{ fontSize: 12 }} type="secondary">
-                          {t('tab.importFromGithub.desc')}
-                        </Text>
-                      </Flexbox>
-                    ),
-                    onClick: () => openImportFromGithubModal(),
-                  },
-                  {
-                    icon: <Icon icon={FileArchive} />,
-                    key: 'uploadZip',
-                    label: (
-                      <Flexbox gap={2}>
-                        <span>{t('tab.uploadZip')}</span>
-                        <Text style={{ fontSize: 12 }} type="secondary">
-                          {t('tab.uploadZip.desc')}
-                        </Text>
-                      </Flexbox>
-                    ),
-                    onClick: () => openUploadSkillModal(),
-                  },
-                  { type: 'divider' as const },
-                  {
-                    icon: <Icon icon={Grid2x2Plus} />,
-                    key: 'addConnector',
-                    label: (
-                      <Flexbox gap={2}>
-                        <span>
-                          {t('connector.add.title', {
-                            defaultValue: 'Add Custom Connector',
-                            ns: 'tool',
-                          })}
-                        </span>
-                      </Flexbox>
-                    ),
-                    onClick: () => setShowAddConnector(true),
-                  },
-                ]}
-              >
-                <Button icon={Grid2x2Plus} size="small" />
-              </DropdownMenu>
+              {isConnectorView ? (
+                // Connector view: single action to add a custom OAuth connector.
+                <Button
+                  icon={Grid2x2Plus}
+                  size="small"
+                  title={t('connector.add.title', {
+                    defaultValue: 'Add Custom Connector',
+                    ns: 'tool',
+                  })}
+                  onClick={() => setShowAddConnector(true)}
+                />
+              ) : (
+                // Skill view: import a skill from a URL, GitHub, or a zip upload.
+                <DropdownMenu
+                  nativeButton={false}
+                  placement="bottomRight"
+                  items={[
+                    {
+                      icon: <Icon icon={Link} />,
+                      key: 'importUrl',
+                      label: (
+                        <Flexbox gap={2}>
+                          <span>{t('tab.importFromUrl')}</span>
+                          <Text style={{ fontSize: 12 }} type="secondary">
+                            {t('tab.importFromUrl.desc')}
+                          </Text>
+                        </Flexbox>
+                      ),
+                      onClick: () => openImportFromUrlModal(),
+                    },
+                    {
+                      icon: <Icon icon={GithubIcon} />,
+                      key: 'importGithub',
+                      label: (
+                        <Flexbox gap={2}>
+                          <span>{t('tab.importFromGithub')}</span>
+                          <Text style={{ fontSize: 12 }} type="secondary">
+                            {t('tab.importFromGithub.desc')}
+                          </Text>
+                        </Flexbox>
+                      ),
+                      onClick: () => openImportFromGithubModal(),
+                    },
+                    {
+                      icon: <Icon icon={FileArchive} />,
+                      key: 'uploadZip',
+                      label: (
+                        <Flexbox gap={2}>
+                          <span>{t('tab.uploadZip')}</span>
+                          <Text style={{ fontSize: 12 }} type="secondary">
+                            {t('tab.uploadZip.desc')}
+                          </Text>
+                        </Flexbox>
+                      ),
+                      onClick: () => openUploadSkillModal(),
+                    },
+                  ]}
+                >
+                  <Button icon={Grid2x2Plus} size="small" />
+                </DropdownMenu>
+              )}
               <Button icon={<Icon icon={Store} />} size="small" onClick={handleOpenStore} />
             </div>
           </div>

--- a/src/routes/(main)/settings/skill/index.tsx
+++ b/src/routes/(main)/settings/skill/index.tsx
@@ -31,15 +31,19 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-const Page = memo(() => {
+interface ToolSettingsProps {
+  /**
+   * Which surface to manage. Fixed per-route now that skills and connectors
+   * each own a dedicated settings page (`/settings/skill` and
+   * `/settings/connector`) instead of sharing one tab-switched page.
+   */
+  viewMode: SkillViewMode;
+}
+
+export const ToolSettings = memo<ToolSettingsProps>(({ viewMode }) => {
   const [searchParams] = useSearchParams();
-  const queryViewMode: SkillViewMode =
-    searchParams.get('tab') === 'skill' || searchParams.get('view') === 'skill'
-      ? 'skill'
-      : 'connector';
   const querySkillIdentifier = searchParams.get('skill');
   const [selected, setSelected] = useState<SelectedTool | null>(null);
-  const [viewMode, setViewMode] = useState<SkillViewMode>(queryViewMode);
 
   const builtinTools = useToolStore((s) => s.builtinTools, isEqual);
   const builtinSkills = useToolStore((s) => s.builtinSkills, isEqual);
@@ -49,14 +53,6 @@ const Page = memo(() => {
     (s) => builtinToolSelectors.installedAllMetaList(s).map((tool) => tool.identifier),
     isEqual,
   );
-
-  useEffect(() => {
-    setSelected(null);
-  }, [viewMode]);
-
-  useEffect(() => {
-    setViewMode(queryViewMode);
-  }, [queryViewMode]);
 
   useEffect(() => {
     if (selected) return;
@@ -98,7 +94,6 @@ const Page = memo(() => {
           viewMode={viewMode}
           onDeleteSelected={() => setSelected(null)}
           onSelect={handleSelect}
-          onViewModeChange={setViewMode}
         />
 
         {selected && (
@@ -114,6 +109,10 @@ const Page = memo(() => {
     </>
   );
 });
+
+ToolSettings.displayName = 'ToolSettings';
+
+const Page = memo(() => <ToolSettings viewMode="skill" />);
 
 Page.displayName = 'SkillSettings';
 

--- a/src/routes/(mobile)/me/settings/features/useCategory.tsx
+++ b/src/routes/(mobile)/me/settings/features/useCategory.tsx
@@ -1,5 +1,6 @@
 import { SkillsIcon } from '@lobehub/ui/icons';
 import {
+  Blocks,
   Brain,
   BrainCircuit,
   ChartColumnBigIcon,
@@ -110,6 +111,7 @@ export const useCategory = (): CategoryGroup[] => {
         label: t('setting:tab.serviceModel'),
       }),
       makeItem({ icon: SkillsIcon, key: SettingsTabs.Skill, label: t('setting:tab.skill') }),
+      makeItem({ icon: Blocks, key: SettingsTabs.Connector, label: t('setting:tab.connector') }),
       makeItem({ icon: BrainCircuit, key: SettingsTabs.Memory, label: t('setting:tab.memory') }),
       makeItem({ icon: KeyRound, key: SettingsTabs.Creds, label: t('setting:tab.creds') }),
       showApiKeyManage &&

--- a/src/spa/router/desktopRouter.config.desktop.tsx
+++ b/src/spa/router/desktopRouter.config.desktop.tsx
@@ -36,6 +36,7 @@ import WorkspaceSlugSettingsLayout from '@/routes/(main)/[workspaceSlug]/setting
 import WorkspaceSlugSettingsApiKeyPage from '@/routes/(main)/[workspaceSlug]/settings/apikey';
 import WorkspaceSlugSettingsAuditLogPage from '@/routes/(main)/[workspaceSlug]/settings/audit-log';
 import WorkspaceSlugSettingsBillingPage from '@/routes/(main)/[workspaceSlug]/settings/billing';
+import WorkspaceSlugSettingsConnectorPage from '@/routes/(main)/[workspaceSlug]/settings/connector';
 import WorkspaceSlugSettingsCreditsPage from '@/routes/(main)/[workspaceSlug]/settings/credits';
 import WorkspaceSlugSettingsCredsPage from '@/routes/(main)/[workspaceSlug]/settings/creds';
 import WorkspaceSlugSettingsDevicesPage from '@/routes/(main)/[workspaceSlug]/settings/devices';
@@ -685,6 +686,7 @@ export const desktopRoutes: RouteObject[] = [
               // shell (sidebar + outlet) — they own their internal layout.
               { element: <WorkspaceSlugSettingsProviderPage />, path: 'provider' },
               { element: <WorkspaceSlugSettingsSkillPage />, path: 'skill' },
+              { element: <WorkspaceSlugSettingsConnectorPage />, path: 'connector' },
               // Padded tabs share a centered, max-width container layout.
               {
                 children: [

--- a/src/spa/router/desktopRouter.config.tsx
+++ b/src/spa/router/desktopRouter.config.tsx
@@ -814,6 +814,13 @@ export const desktopRoutes: RouteObject[] = [
                 ),
                 path: 'skill',
               },
+              {
+                element: dynamicElement(
+                  () => import('@/routes/(main)/[workspaceSlug]/settings/connector'),
+                  'Desktop > Workspace > Settings > Connector',
+                ),
+                path: 'connector',
+              },
               // Padded tabs share a centered, max-width container layout.
               {
                 children: [

--- a/src/spa/router/desktopRouter.sync.test.tsx
+++ b/src/spa/router/desktopRouter.sync.test.tsx
@@ -117,6 +117,7 @@ describe('desktopRouter config sync', () => {
       '@/routes/(main)/[workspaceSlug]/settings/credits',
       '@/routes/(main)/[workspaceSlug]/settings/usage',
       '@/routes/(main)/[workspaceSlug]/settings/skill',
+      '@/routes/(main)/[workspaceSlug]/settings/connector',
       '@/routes/(main)/[workspaceSlug]/settings/audit-log',
     ];
 

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -56,6 +56,7 @@ export enum SettingsTabs {
   ChatAppearance = 'chat-appearance',
   /** @deprecated Use Appearance instead */
   Common = 'common',
+  Connector = 'connector',
   Credits = 'credits',
   Creds = 'creds',
   Devices = 'devices',

--- a/src/types/workspaceSettings.ts
+++ b/src/types/workspaceSettings.ts
@@ -9,6 +9,7 @@ export enum WorkspaceSettingsTabs {
   APIKey = 'apikey',
   AuditLog = 'audit-log',
   Billing = 'billing',
+  Connector = 'connector',
   Credits = 'credits',
   Creds = 'creds',
   Devices = 'devices',


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] ♻️ refactor / ✨ feat

### 🔀 变更说明 | Description of Change

The `/settings/skill` page previously hosted **both** Skills and Connectors behind a top-left tab switcher. This splits them into two dedicated pages so each surface is managed on its own, and removes the tab switcher:

- `/settings/skill` → **Skills** management
- `/settings/connector` → **Connectors** management

This makes it immediately clear which page manages what, instead of hiding one behind a tab.

### 📝 What changed

- Extract a shared `ToolSettings` component driven by a fixed `viewMode` prop instead of internal tab state; the skill page renders `skill`, the new connector page renders `connector`.
- Remove the `Connectors / Skills` tabs from the panel header, replacing them with a section title + a context-appropriate add action (skill imports on the Skills page, "Add Custom Connector" on the Connectors page).
- Add a `Connector` entry to personal, workspace, and mobile settings navigation, the settings component map (web + desktop), and both desktop router configs (personal `:tab` catch-all + explicit workspace routes).
- Point the generic tools "management" links at `/settings/connector` (preserving the prior default view, which was the connector list) and simplify the skill deep-link (`?skill=` instead of `?tab=skill&skill=`).
- Add `tab.connector` / `workspaceSetting.tab.connector` i18n keys.

### ✅ Verification

- `pnpm run type-check` passes.
- ESLint clean on all changed files.
- Affected tests pass: `componentMap.sync`, `desktopRouter.sync`, `ModalProvider` (8 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)