### PR TITLE
🐛 fix(agent): anchor execAgent user turns instead of forking a new root

### DIFF
--- a/apps/server/src/services/aiAgent/__tests__/execAgent.builtinRuntime.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.builtinRuntime.test.ts
@@ -48,6 +48,8 @@ vi.mock('@/libs/trusted-client', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     query: mockMessageQuery,
     update: vi.fn().mockResolvedValue({}),
   })),

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.connectorOverlap.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.connectorOverlap.test.ts
@@ -39,6 +39,8 @@ vi.mock('@/server/modules/KeyVaultsEncrypt', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     query: vi.fn().mockResolvedValue([]),
     update: vi.fn().mockResolvedValue({}),
   })),

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.device.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.device.test.ts
@@ -30,6 +30,8 @@ vi.mock('@/libs/trusted-client', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     query: vi.fn().mockResolvedValue([]),
     update: vi.fn().mockResolvedValue({}),
   })),

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.deviceToolPipeline.test.ts
@@ -36,6 +36,8 @@ vi.mock('@/libs/trusted-client', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     query: vi.fn().mockResolvedValue([]),
     update: vi.fn().mockResolvedValue({}),
   })),

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.disableTools.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.disableTools.test.ts
@@ -33,6 +33,8 @@ vi.mock('@/libs/trusted-client', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     query: vi.fn().mockResolvedValue([]),
     update: vi.fn().mockResolvedValue({}),
   })),

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.files.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.files.test.ts
@@ -26,6 +26,8 @@ vi.mock('@/libs/trusted-client', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     query: vi.fn().mockResolvedValue([]),
     update: vi.fn().mockResolvedValue({}),
   })),

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.headlessDefault.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.headlessDefault.test.ts
@@ -18,6 +18,8 @@ vi.mock('@/libs/trusted-client', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     query: vi.fn().mockResolvedValue([]),
     update: vi.fn().mockResolvedValue({}),
   })),

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.heteroFiles.test.ts
@@ -67,6 +67,8 @@ vi.mock('@/libs/trpc/utils/internalJwt', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     query: vi.fn().mockResolvedValue([]),
     update: vi.fn().mockResolvedValue({}),
   })),

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.modelOverride.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.modelOverride.test.ts
@@ -18,6 +18,8 @@ vi.mock('@/libs/trusted-client', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     query: vi.fn().mockResolvedValue([]),
     update: vi.fn().mockResolvedValue({}),
   })),

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.pluginTriState.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.pluginTriState.test.ts
@@ -43,6 +43,8 @@ vi.mock('@/server/modules/KeyVaultsEncrypt', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     query: vi.fn().mockResolvedValue([]),
     update: vi.fn().mockResolvedValue({}),
   })),

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.resume.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.resume.test.ts
@@ -21,6 +21,8 @@ vi.mock('@/libs/trusted-client', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     findById: mockFindById,
     query: mockMessageQuery,
     queryTopicMessageTree: mockQueryTree,

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.resumeApproval.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.resumeApproval.test.ts
@@ -31,6 +31,8 @@ vi.mock('@/libs/trusted-client', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     findById: mockFindById,
     findMessagePlugin: mockFindMessagePlugin,
     query: mockMessageQuery,

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.resumeToolResult.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.resumeToolResult.test.ts
@@ -33,6 +33,8 @@ vi.mock('@/libs/trusted-client', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     findById: mockFindById,
     findMessagePlugin: mockFindMessagePlugin,
     query: mockMessageQuery,

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.spineAnchor.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.spineAnchor.test.ts
@@ -1,0 +1,252 @@
+import type * as ModelBankModule from 'model-bank';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AiAgentService } from '../index';
+
+const { mockGetLatestNonToolMessageId, mockGetLatestSpineMessageId, mockMessageCreate } =
+  vi.hoisted(() => ({
+    mockGetLatestNonToolMessageId: vi.fn(),
+    mockGetLatestSpineMessageId: vi.fn(),
+    mockMessageCreate: vi.fn(),
+  }));
+
+vi.mock('@/libs/trusted-client', () => ({
+  generateTrustedClientToken: vi.fn().mockReturnValue(undefined),
+  getTrustedClientTokenForSession: vi.fn().mockResolvedValue(undefined),
+  isTrustedClientEnabled: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/database/models/message', () => ({
+  MessageModel: vi.fn().mockImplementation(() => ({
+    create: mockMessageCreate,
+    getLatestNonToolMessageId: mockGetLatestNonToolMessageId,
+    getLatestSpineMessageId: mockGetLatestSpineMessageId,
+    query: vi.fn().mockResolvedValue([]),
+    update: vi.fn().mockResolvedValue({}),
+  })),
+}));
+
+vi.mock('@/database/models/agent', () => ({
+  AgentModel: vi.fn().mockImplementation(() => ({
+    getAgentConfig: vi.fn().mockResolvedValue({
+      chatConfig: {},
+      files: [],
+      id: 'agent-1',
+      knowledgeBases: [],
+      model: 'gpt-4',
+      plugins: [],
+      provider: 'openai',
+      systemRole: 'You are a helpful assistant',
+    }),
+    queryAgents: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+vi.mock('@/server/services/agent', () => ({
+  AgentService: vi.fn().mockImplementation(() => ({
+    getAgentConfig: vi.fn().mockResolvedValue({
+      chatConfig: {},
+      files: [],
+      id: 'agent-1',
+      knowledgeBases: [],
+      model: 'gpt-4',
+      plugins: [],
+      provider: 'openai',
+      systemRole: 'You are a helpful assistant',
+    }),
+  })),
+}));
+
+vi.mock('@/database/models/plugin', () => ({
+  PluginModel: vi.fn().mockImplementation(() => ({
+    query: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+vi.mock('@/database/models/topic', () => ({
+  TopicModel: vi.fn().mockImplementation(() => ({
+    create: vi.fn().mockResolvedValue({ id: 'topic-1' }),
+    findById: vi.fn().mockResolvedValue(undefined),
+    updateMetadata: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+vi.mock('@/database/models/thread', () => ({
+  ThreadModel: vi.fn().mockImplementation(() => ({
+    create: vi.fn(),
+    findById: vi.fn(),
+    update: vi.fn(),
+  })),
+}));
+
+vi.mock('@/database/models/chatGroup', () => ({
+  ChatGroupModel: vi.fn().mockImplementation(() => ({
+    findById: vi.fn().mockResolvedValue(undefined),
+    getGroupAgentsWithMeta: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+vi.mock('@/server/services/agentRuntime', () => ({
+  AgentRuntimeService: vi.fn().mockImplementation(() => ({
+    createOperation: vi.fn().mockResolvedValue({
+      autoStarted: true,
+      messageId: 'queue-msg-1',
+      operationId: 'op-123',
+      success: true,
+    }),
+  })),
+}));
+
+vi.mock('@/server/services/market', () => ({
+  MarketService: vi.fn().mockImplementation(() => ({
+    getLobehubSkillManifests: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+vi.mock('@/server/services/composio', () => ({
+  ComposioService: vi.fn().mockImplementation(() => ({
+    getComposioManifests: vi.fn().mockResolvedValue([]),
+  })),
+}));
+
+vi.mock('@/server/services/file', () => ({
+  FileService: vi.fn().mockImplementation(() => ({
+    uploadFromUrl: vi.fn(),
+  })),
+}));
+
+vi.mock('@/server/modules/Mecha', () => ({
+  createServerAgentToolsEngine: vi.fn().mockReturnValue({
+    generateToolsDetailed: vi.fn().mockReturnValue({ enabledToolIds: [], tools: [] }),
+    getEnabledPluginManifests: vi.fn().mockReturnValue(new Map()),
+  }),
+  serverMessagesEngine: vi.fn().mockResolvedValue([{ content: 'test', role: 'user' }]),
+}));
+
+vi.mock('@/server/services/deviceGateway', () => ({
+  deviceGateway: {
+    isConfigured: false,
+    queryDeviceList: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+vi.mock('@/server/modules/ModelRuntime', () => ({
+  initModelRuntimeFromDB: vi.fn(),
+}));
+
+vi.mock('model-bank', async (importOriginal) => {
+  const actual = await importOriginal<typeof ModelBankModule>();
+  return {
+    ...actual,
+    LOBE_DEFAULT_MODEL_LIST: [
+      {
+        abilities: { functionCall: true, video: false, vision: true },
+        id: 'gpt-4',
+        providerId: 'openai',
+      },
+    ],
+  };
+});
+
+const userMessageCall = () => mockMessageCreate.mock.calls.find((call) => call[0].role === 'user');
+const assistantMessageCall = () =>
+  mockMessageCreate.mock.calls.find((call) => call[0].role === 'assistant');
+
+/**
+ * Regression coverage for LOBE-11489: a user turn persisted with
+ * `parentId: undefined` into a non-empty topic becomes a second ROOT. The
+ * renderer walks the parentId forest depth-first, so an earlier root's
+ * still-growing subtree is emitted before a later root and the newest reply
+ * renders ABOVE older messages.
+ */
+describe('AiAgentService.execAgent - user turn spine anchoring', () => {
+  let service: AiAgentService;
+  const mockDb = {} as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMessageCreate.mockImplementation(async (payload: { role: string }) => ({
+      id: payload.role === 'user' ? 'user-msg-1' : 'assistant-msg-1',
+    }));
+    mockGetLatestSpineMessageId.mockResolvedValue(undefined);
+    mockGetLatestNonToolMessageId.mockResolvedValue(undefined);
+
+    service = new AiAgentService(mockDb, 'test-user-id');
+  });
+
+  it('anchors the user turn on the spine head of an existing topic', async () => {
+    mockGetLatestSpineMessageId.mockResolvedValue('spine-head-1');
+
+    await service.execAgent({
+      agentId: 'agent-1',
+      appContext: { topicId: 'topic-1' },
+      prompt: 'Test prompt',
+    });
+
+    expect(mockGetLatestSpineMessageId).toHaveBeenCalledWith({
+      threadId: null,
+      topicId: 'topic-1',
+    });
+    expect(userMessageCall()![0]).toMatchObject({ parentId: 'spine-head-1', role: 'user' });
+    // No spine candidate is missing, so the fallback must not be queried.
+    expect(mockGetLatestNonToolMessageId).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the latest non-tool message when the topic has no spine candidate', async () => {
+    mockGetLatestSpineMessageId.mockResolvedValue(undefined);
+    mockGetLatestNonToolMessageId.mockResolvedValue('signal-turn-1');
+
+    await service.execAgent({
+      agentId: 'agent-1',
+      appContext: { topicId: 'topic-1' },
+      prompt: 'Test prompt',
+    });
+
+    expect(mockGetLatestNonToolMessageId).toHaveBeenCalledWith({
+      threadId: null,
+      topicId: 'topic-1',
+    });
+    expect(userMessageCall()![0]).toMatchObject({ parentId: 'signal-turn-1', role: 'user' });
+  });
+
+  it('leaves the first turn of an empty topic as the single root', async () => {
+    await service.execAgent({
+      agentId: 'agent-1',
+      appContext: { topicId: 'topic-1' },
+      prompt: 'Test prompt',
+    });
+
+    expect(userMessageCall()![0].parentId).toBeUndefined();
+  });
+
+  it('chains the assistant placeholder onto the user turn it just created', async () => {
+    mockGetLatestSpineMessageId.mockResolvedValue('spine-head-1');
+
+    await service.execAgent({
+      agentId: 'agent-1',
+      appContext: { topicId: 'topic-1' },
+      prompt: 'Test prompt',
+    });
+
+    expect(assistantMessageCall()![0]).toMatchObject({
+      parentId: 'user-msg-1',
+      role: 'assistant',
+    });
+  });
+
+  it('scopes the anchor lookup to the thread when one is active', async () => {
+    mockGetLatestSpineMessageId.mockResolvedValue('thread-spine-1');
+
+    await service.execAgent({
+      agentId: 'agent-1',
+      appContext: { threadId: 'thread-123', topicId: 'topic-1' },
+      prompt: 'Test prompt',
+    });
+
+    expect(mockGetLatestSpineMessageId).toHaveBeenCalledWith({
+      threadId: 'thread-123',
+      topicId: 'topic-1',
+    });
+    expect(userMessageCall()![0]).toMatchObject({ parentId: 'thread-spine-1' });
+  });
+});

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.threadId.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.threadId.test.ts
@@ -18,6 +18,8 @@ vi.mock('@/libs/trusted-client', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     query: vi.fn().mockResolvedValue([]),
     update: vi.fn().mockResolvedValue({}),
   })),

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.topicHistory.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.topicHistory.test.ts
@@ -20,6 +20,8 @@ vi.mock('@/libs/trusted-client', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: mockMessageCreate,
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     query: mockMessageQuery,
     update: vi.fn().mockResolvedValue({}),
   })),

--- a/apps/server/src/services/aiAgent/__tests__/execSubAgent.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execSubAgent.test.ts
@@ -38,6 +38,8 @@ vi.mock('@/database/models/agent', () => ({
 vi.mock('@/database/models/message', () => ({
   MessageModel: vi.fn().mockImplementation(() => ({
     create: vi.fn().mockResolvedValue({ id: 'msg-1' }),
+    getLatestNonToolMessageId: vi.fn().mockResolvedValue(undefined),
+    getLatestSpineMessageId: vi.fn().mockResolvedValue(undefined),
     query: vi.fn().mockResolvedValue([]),
     update: vi.fn().mockResolvedValue({}),
   })),

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -1517,13 +1517,34 @@ export class AiAgentService {
     // exclude this freshly-created turn — history must be the PRIOR turns only,
     // otherwise the new prompt is double-counted in the LLM context.
     const selfMessageIds = new Set<string>();
-    const userMessageParentId =
-      runFromHistory || parentMessageId
-        ? undefined
-        : await this.messageModel.getLatestSpineMessageId?.({
-            threadId: appContext?.threadId ?? null,
-            topicId,
-          });
+    // Anchor the new user turn on the conversation tail. Never leave it
+    // undefined for a topic that already has messages: `parentId: undefined`
+    // persists a second ROOT, and the renderer walks the parentId forest
+    // depth-first — an earlier root's still-growing subtree is emitted before a
+    // later root, so the newest reply lands ABOVE older messages (LOBE-11489).
+    //
+    // `getLatestSpineMessageId` skips tool rows and toolless signal turns, so it
+    // can come back empty on a topic built entirely from signal callbacks; fall
+    // back to the latest non-tool row rather than orphaning the turn.
+    const resolveUserMessageParentId = async () => {
+      if (runFromHistory) return undefined;
+      if (parentMessageId) return parentMessageId;
+
+      const threadId = appContext?.threadId ?? null;
+      const spineId = await this.messageModel.getLatestSpineMessageId({ threadId, topicId });
+      if (spineId) return spineId;
+
+      const fallbackId = await this.messageModel.getLatestNonToolMessageId({ threadId, topicId });
+      if (fallbackId) {
+        log(
+          'execAgent: no spine head for topic %s, anchoring user turn on latest non-tool message %s',
+          topicId,
+          fallbackId,
+        );
+      }
+      return fallbackId;
+    };
+    const userMessageParentId = await resolveUserMessageParentId();
     const userMessageRecord = runFromHistory
       ? undefined
       : await this.messageModel.create({
@@ -1571,7 +1592,9 @@ export class AiAgentService {
       groupId: appContext?.groupId ?? undefined,
       metadata: orchestrationMetadata,
       model: isHeteroAgent ? undefined : model,
-      parentId: parentMessageId ?? userMessageRecord?.id,
+      // Chain onto the user turn we just persisted; `parentMessageId` is the
+      // anchor only on a resume, where no user message is created.
+      parentId: userMessageRecord?.id ?? parentMessageId,
       provider: isHeteroAgent ? heteroType : provider,
       role: 'assistant',
       threadId: appContext?.threadId ?? undefined,

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -3135,9 +3135,11 @@ describe('MessageModel Query Tests', () => {
     it('scopes the main thread to threadId IS NULL (ignores thread messages)', async () => {
       await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
       await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
-      await serverDB.insert(threads).values([
-        { id: 'thread1', userId, topicId: 'topic1', sourceMessageId: 'm1', type: 'standalone' },
-      ]);
+      await serverDB
+        .insert(threads)
+        .values([
+          { id: 'thread1', userId, topicId: 'topic1', sourceMessageId: 'm1', type: 'standalone' },
+        ]);
       await serverDB.insert(messages).values([
         {
           id: 'm1',
@@ -3187,6 +3189,97 @@ describe('MessageModel Query Tests', () => {
       expect(await otherModel.getLatestSpineMessageId({ topicId: 'topic1' })).toBeUndefined();
       // unknown topic yields undefined
       expect(await messageModel.getLatestSpineMessageId({ topicId: 'nope' })).toBeUndefined();
+    });
+  });
+
+  // Fallback anchor used when `getLatestSpineMessageId` comes back empty. Without
+  // it a new user turn is persisted as a second root and the renderer emits the
+  // newest reply above older messages (LOBE-11489).
+  describe('getLatestNonToolMessageId', () => {
+    it('returns a toolless signal turn that the spine query skips', async () => {
+      await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
+      await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
+      await serverDB.insert(messages).values([
+        {
+          id: 'sig-1',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: 'monitor callback',
+          metadata: { signal: { type: 'monitor' } } as any,
+          createdAt: new Date('2023-01-01T00:00:00'),
+        },
+      ]);
+
+      // the spine query finds nothing to anchor on...
+      expect(await messageModel.getLatestSpineMessageId({ topicId: 'topic1' })).toBeUndefined();
+      // ...so the fallback keeps the next turn off a second root
+      expect(await messageModel.getLatestNonToolMessageId({ topicId: 'topic1' })).toBe('sig-1');
+    });
+
+    it('never anchors on a tool result, even when it is the newest row', async () => {
+      await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
+      await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
+      await serverDB.insert(messages).values([
+        {
+          id: 'sig-1',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: 'callback',
+          metadata: { signal: { type: 'monitor' } } as any,
+          createdAt: new Date('2023-01-01T00:00:00'),
+        },
+        {
+          id: 'tool-1',
+          userId,
+          topicId: 'topic1',
+          role: 'tool',
+          parentId: 'sig-1',
+          content: 'result',
+          createdAt: new Date('2023-01-01T00:00:01'),
+        },
+      ]);
+
+      expect(await messageModel.getLatestNonToolMessageId({ topicId: 'topic1' })).toBe('sig-1');
+    });
+
+    it('scopes to thread, user, and returns undefined for an empty topic', async () => {
+      const otherModel = new MessageModel(serverDB, otherUserId);
+      await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
+      await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
+      await serverDB
+        .insert(threads)
+        .values([
+          { id: 'thread1', userId, topicId: 'topic1', sourceMessageId: 'm1', type: 'standalone' },
+        ]);
+      await serverDB.insert(messages).values([
+        {
+          id: 'm1',
+          userId,
+          topicId: 'topic1',
+          role: 'user',
+          threadId: null,
+          content: 'main tail',
+          createdAt: new Date('2023-01-01T00:00:00'),
+        },
+        {
+          id: 't1',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          threadId: 'thread1',
+          content: 'thread tail',
+          createdAt: new Date('2023-01-01T00:00:01'),
+        },
+      ]);
+
+      expect(await messageModel.getLatestNonToolMessageId({ topicId: 'topic1' })).toBe('m1');
+      expect(
+        await messageModel.getLatestNonToolMessageId({ topicId: 'topic1', threadId: 'thread1' }),
+      ).toBe('t1');
+      expect(await otherModel.getLatestNonToolMessageId({ topicId: 'topic1' })).toBeUndefined();
+      expect(await messageModel.getLatestNonToolMessageId({ topicId: 'nope' })).toBeUndefined();
     });
   });
 

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -2645,6 +2645,45 @@ export class MessageModel {
     return row?.id;
   };
 
+  /**
+   * Fallback anchor for {@link getLatestSpineMessageId}: the latest non-tool
+   * message in a topic/thread, WITHOUT the toolless-signal exclusion.
+   *
+   * A topic whose main thread holds nothing but toolless signal turns has no
+   * spine candidate, so the spine lookup returns undefined and the caller would
+   * persist the new turn with `parentId: undefined` — a second root that forks
+   * the conversation tree. The renderer walks that forest depth-first, so an
+   * earlier root's long-running subtree gets emitted before a later root and the
+   * newest reply surfaces ABOVE older messages (LOBE-11489).
+   *
+   * `role:'tool'` stays excluded: tool results are inline children of their
+   * assistant turn, and anchoring a normal turn onto one orphans it under the
+   * read side's tool-only signal collection.
+   */
+  getLatestNonToolMessageId = async ({
+    topicId,
+    threadId,
+  }: {
+    threadId?: string | null;
+    topicId: string;
+  }): Promise<string | undefined> => {
+    const [row] = await this.db
+      .select({ id: messages.id })
+      .from(messages)
+      .where(
+        and(
+          eq(messages.topicId, topicId),
+          not(eq(messages.role, 'tool')),
+          threadId ? eq(messages.threadId, threadId) : isNull(messages.threadId),
+          this.ownership(),
+        ),
+      )
+      .orderBy(desc(messages.createdAt))
+      .limit(1);
+
+    return row?.id;
+  };
+
   updateTranslate = async (id: string, translate: Partial<ChatTranslate>) => {
     const result = await this.db.query.messageTranslates.findFirst({
       where: and(eq(messageTranslates.id, id), this.translatesOwnership()),


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-11489

#### 🔀 Description of Change

Chat messages could render in reversed order — the AI's newest reply appearing *above* older messages.

**Root cause.** `execAgent` resolved the new user turn's `parentId` through `getLatestSpineMessageId`, which deliberately skips `role:'tool'` rows and toolless signal turns. On a topic whose main thread holds nothing but signal callbacks the lookup returns `undefined`, so the turn was persisted with `parentId: undefined` — a **second root**.

The renderer (`FlatListBuilder`) walks the `parentId` forest depth-first, emitting an earlier root's *entire* subtree before moving to the next root. Once a long-running turn's subtree outlives the next root, the newest assistant reply gets painted above older messages. Slow generation widens that window, which is why the reversal clustered during the load incident rather than showing up uniformly.

**The fix.**

- New `MessageModel.getLatestNonToolMessageId` — a fallback anchor that relaxes the signal exclusion but still refuses `role:'tool'`, preserving the invariant from #16362 that a user turn never parents off a tool result.
- `execAgent` now resolves the anchor explicitly: `parentMessageId` → spine head → latest non-tool row. A topic that already has messages can no longer produce an orphan root.
- Log when the fallback fires, so an empty spine on a non-empty topic is visible instead of silent.
- Dropped the `?.` on `getLatestSpineMessageId`. `messageModel` is a concrete `MessageModel` in production, so the optional call could only mask incomplete test doubles — and it did: 16 suites mocked the model without the method.
- The assistant placeholder now chains onto the user turn we just created (`userMessageRecord?.id ?? parentMessageId`) rather than preferring `parentMessageId`, which is the anchor only on a resume, where no user turn is created.

**Scope note.** The bulk of this fork class was already closed by #16433 (2026-06-30); production extra-root counts dropped from ~13.7k/day to ~31/day. This PR closes the remaining path. It does **not** repair conversations that forked before that fix — roughly 9% of topics still carry multiple main-thread roots and will keep rendering out of order until a separate backfill re-parents them. That backfill is tracked separately.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

New `execAgent.spineAnchor.test.ts` covers: anchoring on the spine head, falling back to the latest non-tool row when no spine candidate exists, leaving a genuinely-empty topic's first turn as the single root, chaining the assistant onto the new user turn, and thread-scoped lookup.

New `getLatestNonToolMessageId` cases in `message.query.test.ts` (real DB) cover: returning a toolless signal turn the spine query skips, never anchoring on a tool result even when it is the newest row, and thread/user scoping.

Verified locally against the equivalent pre-rebase tree: 18 execAgent suites (162 tests), 9 adjacent suites that mock `MessageModel` (221 tests), and `message.query.test.ts` (70 tests) all pass; lint clean. The canary-rebased branch could not run vitest locally (fresh worktree without an install), so CI is the authority on this exact commit.

#### 📸 Screenshots / Videos

n/a — server-side persistence change.

#### 📝 Additional Information

No migration. `getLatestNonToolMessageId` is additive; the extra query only runs when the spine lookup comes back empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)