### PR TITLE
💄 style(chat-input): tighten the worktree-icon to branch-name gap

### DIFF
--- a/src/features/ChatInput/ControlBar/GitStatus.tsx
+++ b/src/features/ChatInput/ControlBar/GitStatus.tsx
@@ -39,6 +39,12 @@ const styles = createStaticStyles(({ css }) => {
     behindStat: css`
       color: ${cssVar.colorError};
     `,
+    branchGroup: css`
+      display: flex;
+      flex: none;
+      gap: 2px;
+      align-items: center;
+    `,
     branchLabel: css`
       overflow: hidden;
       max-width: 160px;
@@ -424,8 +430,12 @@ const GitStatus = memo<GitStatusProps>(({ agentId, path, sourcePath, isGithub, d
   return (
     <>
       <div className={styles.separator} />
-      {worktreeNode}
-      {branchNode}
+      {/* The worktree icon and the branch name name one thing — which checkout
+       * you're on — so they sit closer to each other than to their neighbours. */}
+      <div className={styles.branchGroup}>
+        {worktreeNode}
+        {branchNode}
+      </div>
       {pullNode}
       {pushNode}
       {diffNode}

--- a/src/features/ChatInput/ControlBar/WorktreeSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/WorktreeSwitcher.tsx
@@ -306,7 +306,7 @@ const styles = createStaticStyles(({ css }) => ({
     align-items: center;
     justify-content: center;
 
-    width: 24px;
+    width: 20px;
     height: 22px;
     border-radius: 4px;
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

In the git-status row of the chat input's ControlBar, the gap between the worktree icon and the branch-name pill was visibly the widest seam in the row. It measured **13.5px**, and no single CSS rule said so — three paddings stacked:

| contributor | px |
| --- | --- |
| slack inside the 24px icon box around its 13px glyph | 5.5 |
| `leftGroup` flex `gap={4}` | 4 |
| branch pill's `padding-inline` | 4 |

Two changes, both narrow:

1. **`WorktreeSwitcher`** — the trigger box goes `24px → 20px` so its hover background hugs the glyph instead of floating around it.
2. **`GitStatus`** — the worktree icon and the branch pill move into a `branchGroup` container with `gap: 2px`. They name one thing (which checkout you're on), so proximity now groups them tighter than the separators, sync chips, and PR chip around them.

Net seam: **9.5px**, in line with the ~9–10px rhythm of the neighbouring elements. The two hover backgrounds still clear each other by 2px, so hovering either one doesn't visually merge them.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

`bun run check` on the two files: lint clean, 14 tests pass. No behaviour change, so no new tests.

Verified in the real desktop app rather than by reading CSS — an isolated Electron dev instance pointed at a scratch git repo (long branch name to force the ellipsis, `↑14 ↓6 +8`), measuring `getBoundingClientRect` on the rendered nodes before and after, toggling the code via HMR:

| | icon box | icon → text | hover-box seam |
| --- | --- | --- | --- |
| before | 24px | 13.5px | 4px |
| after | 20px | **9.5px** | 2px |

Full report with screenshots: https://app.lobehub.com/verify/eab87280-b9d1-485d-bd55-d1520733aa9a

#### 📸 Screenshots / Videos

Before/after crops of the same row (labelled composite) are attached to the verify report linked above.

#### 📝 Additional Information

Unrelated pre-existing issue found while verifying, **not addressed here**: `leftGroup` is an `overflow-x: auto` strip. At the default 1180px window with the right panel open it has `clientWidth 318` vs `scrollWidth 645`, so the entire git-status row (worktree icon, branch, ahead/behind, diff, PR) is clipped out of view with no scroll affordance. Worth a separate fix.