### PR TITLE
🐛 fix(chat-input): stop the dir icon from reusing the branch glyph

### DIFF
--- a/src/features/ChatInput/ControlBar/DirIcon.tsx
+++ b/src/features/ChatInput/ControlBar/DirIcon.tsx
@@ -1,23 +1,28 @@
 import { Github } from '@lobehub/icons';
 import { Icon } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
-import { FolderIcon, GitBranchIcon } from 'lucide-react';
+import { FolderGit2Icon, FolderIcon } from 'lucide-react';
 import { memo } from 'react';
 
 interface DirIconProps {
-  /** Detected repo type — drives the glyph: GitHub mark, git branch, or a plain
-   * folder when the type is unknown. */
+  /** Detected repo type — drives the glyph: GitHub mark, a git-tracked folder, or
+   * a plain folder when the type is unknown. */
   repoType?: 'git' | 'github';
   size?: number;
 }
 
 /** Directory icon shared by every cwd surface (local / device / settings pickers,
- * topic rows) so a `github` dir looks the same everywhere. */
+ * topic rows) so a `github` dir looks the same everywhere.
+ *
+ * A plain-git dir renders a *folder* glyph, not `GitBranchIcon`: this icon names a
+ * directory, and in the ControlBar it sits immediately left of the worktree switcher,
+ * which owns the branch glyph. Two identical branch icons side by side read as one
+ * control repeated rather than "repo" followed by "branch". */
 const DirIcon = memo<DirIconProps>(({ repoType, size = 16 }) => {
   const iconStyle = { color: cssVar.colorTextTertiary, flex: 'none' as const };
   if (repoType === 'github') return <Github size={size} style={iconStyle} />;
   return (
-    <Icon icon={repoType === 'git' ? GitBranchIcon : FolderIcon} size={size} style={iconStyle} />
+    <Icon icon={repoType === 'git' ? FolderGit2Icon : FolderIcon} size={size} style={iconStyle} />
   );
 });
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

`detectRepoType` (`packages/local-file-shell/src/git/repoType.ts`) reads `.git/config` and returns `'github'` only when a `github.com` remote matches — every other repo gets `'git'`, and a non-repo gets `undefined`. `DirIcon` mapped that `'git'` case onto lucide's `GitBranchIcon`.

In the chat input's ControlBar, the working-directory picker sits immediately left of the worktree switcher, which draws **the same** `git-branch` glyph. So on a GitLab / self-hosted / remote-less checkout the bar rendered two identical branch icons about 30px apart:

- the left one meaning *"this directory is a git repo"*
- the right one meaning *"switch worktree"*

They read as one control repeated, not as two different things. GitHub users never hit it — `repoType === 'github'` renders the GitHub mark.

This renders a git-tracked directory as `FolderGit2Icon`. It still reads as a *directory* (consistent with the plain `FolderIcon` used when the type is unknown), and it gives the branch glyph back to the controls that actually deal with branches.

`DirIcon` is shared, so the same glyph change lands on `DeviceManager/DeviceDetailPanel` and the topic sidebar rows — which is the component's stated intent ("shared by every cwd surface so a `github` dir looks the same everywhere").

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

`bun run check` on the file: lint clean. The two topic tests that touch `DirIcon` `vi.mock` it wholesale and don't assert the glyph, so nothing there needed updating.

Verified by rendering, not by reading CSS — an isolated Electron dev instance with its working directory pointed at a scratch repo whose remote is a local bare repo (so `detectRepoType` genuinely returns `'git'`). Enumerating every lucide glyph in the ControlBar strip, before and after, toggled via HMR:

| | glyphs in the strip | `git-branch` count |
| --- | --- | --- |
| before | …, `git-branch`, chevron, `git-branch` | **2** |
| after | …, `folder-git2`, chevron, `git-branch` | **1** |

`detectRepoType` was also run directly against three directories to confirm the precondition: local-remote fixture → `git`, this repo → `github`, `/tmp` → `undefined`.

Full report with before/after screenshots: https://app.lobehub.com/verify/4e0e9f06-27df-430a-8be3-48381d6025bf

#### 📸 Screenshots / Videos

Labelled before/after composite of the same bar region is attached to the verify report linked above.

#### 📝 Additional Information

Related pre-existing issue found while verifying, **not addressed here**: `WorkingDirectoryPicker.tsx` derives the trigger's icon from `recents.find((r) => r.path === selectedDir)?.repoType`, i.e. from whether the current directory happens to be in the recents list rather than from what the directory actually is. Before `recents` resolves, the icon is a plain folder; a GitHub repo missing from recents stays a plain folder. Calling the existing `GitController.detectRepoType` IPC for `selectedDir` would be more honest. Worth a separate fix.