### PR TITLE
🐛 fix(analytics): stabilize conversation hook identity

### DIFF
--- a/src/business/client/hooks/useBusinessConversationAnalytics.test.ts
+++ b/src/business/client/hooks/useBusinessConversationAnalytics.test.ts
@@ -1,0 +1,18 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useBusinessConversationAnalytics } from './useBusinessConversationAnalytics';
+
+describe('useBusinessConversationAnalytics', () => {
+  it('returns stable empty hooks across rerenders', () => {
+    const { result, rerender } = renderHook(() =>
+      useBusinessConversationAnalytics({ agentId: 'agent-1' }),
+    );
+    const initialHooks = result.current;
+
+    rerender();
+
+    expect(result.current).toBe(initialHooks);
+    expect(result.current).toEqual({});
+  });
+});

--- a/src/business/client/hooks/useBusinessConversationAnalytics.ts
+++ b/src/business/client/hooks/useBusinessConversationAnalytics.ts
@@ -1,5 +1,7 @@
 import type { ConversationContext, ConversationHooks } from '@/features/Conversation/types';
 
+const EMPTY_HOOKS: ConversationHooks = {};
+
 export const useBusinessConversationAnalytics = (
   _context: ConversationContext,
-): ConversationHooks => ({});
+): ConversationHooks => EMPTY_HOOKS;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Follow-up to #16968 and its review feedback.

#### 🔀 Description of Change

- Return a module-level empty `ConversationHooks` object from the default business analytics hook.
- Preserve hook identity across conversation rerenders so `mergeConversationHooks` does not rebuild wrapper callbacks unnecessarily.
- Add a regression test covering referential stability across rerenders.

The previous no-op implementation returned a fresh object on every render. When follow-up hooks were enabled, that invalidated the merge memo and caused redundant ConversationStore hook updates during message and operation rerenders.

#### 🧪 How to Test

- `bun run check src/business/client/hooks/useBusinessConversationAnalytics.ts src/business/client/hooks/useBusinessConversationAnalytics.test.ts`
  - lint clean
  - 1 related test passed
- `bun run check --type`
  - blocked by unrelated existing/generated workspace errors, including stale `.next/types` route references and duplicate Drizzle/Dayjs dependency types
  - no errors referenced the changed files

#### 📸 Screenshots / Videos

N/A — no visual changes.