### PR TITLE
⚡️ perf(queue): drop the local 300ms settling sleep before QStash publish

### DIFF
--- a/apps/server/src/services/queue/__tests__/QueueService.test.ts
+++ b/apps/server/src/services/queue/__tests__/QueueService.test.ts
@@ -161,8 +161,7 @@ describe('QueueService', () => {
       delete process.env.QSTASH_TOKEN;
     });
 
-    it('should wait locally for sub-second QStash delays before publishing', async () => {
-      vi.useFakeTimers();
+    it('should round sub-second delays up to 1s for QStash', async () => {
       qstashMocks.publishJSON.mockResolvedValue({ messageId: 'msg-test' });
 
       const { QStashQueueServiceImpl } = await import('../impls/qstash');
@@ -176,19 +175,14 @@ describe('QueueService', () => {
         stepIndex: 0,
       });
 
-      await vi.advanceTimersByTimeAsync(499);
-      expect(qstashMocks.publishJSON).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
       await expect(result).resolves.toBe('msg-test');
 
       const request = qstashMocks.publishJSON.mock.calls[0][0];
-      expect(request).not.toHaveProperty('delay');
+      expect(request).toMatchObject({ delay: 1 });
       expect(request.body.timestamp).toEqual(expect.any(Number));
     });
 
-    it('should floor zero delay at the 300ms minimum settling window', async () => {
-      vi.useFakeTimers();
+    it('should publish zero delay immediately without a QStash delay', async () => {
       qstashMocks.publishJSON.mockResolvedValue({ messageId: 'msg-test' });
 
       const { QStashQueueServiceImpl } = await import('../impls/qstash');
@@ -202,14 +196,8 @@ describe('QueueService', () => {
         stepIndex: 0,
       });
 
-      // 300ms minimum — not yet published at 299ms
-      await vi.advanceTimersByTimeAsync(299);
-      expect(qstashMocks.publishJSON).not.toHaveBeenCalled();
-
-      await vi.advanceTimersByTimeAsync(1);
       await expect(result).resolves.toBe('msg-test');
 
-      // Zero delay is sub-second, so it is not forwarded to QStash
       const request = qstashMocks.publishJSON.mock.calls[0][0];
       expect(request).not.toHaveProperty('delay');
     });

--- a/apps/server/src/services/queue/impls/qstash.ts
+++ b/apps/server/src/services/queue/impls/qstash.ts
@@ -7,24 +7,16 @@ import { type QueueServiceImpl } from './type';
 
 const log = debug('lobe-server:service:queue:qstash');
 
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
 /**
- * Minimum settling delay (ms) applied before publishing a QStash message.
- *
  * QStash's `delay` option is second-granularity — the `Duration` string form
  * (`10s`, `1m`, `2h`, `1d`) has no millisecond unit, and a bare number is
- * treated as seconds (so `100` would mean 100s, not 100ms). Sub-second settling
- * windows therefore cannot be delegated to QStash and must be honored locally;
- * this floors small or zero delays so a step always gets a brief settle.
+ * treated as seconds (so `100` would mean 100s, not 100ms). Positive
+ * sub-second delays are rounded up to 1s.
  */
-const MIN_SETTLING_DELAY_MS = 300;
-
 const toQStashDelaySeconds = (delayMs: number): number | undefined => {
   if (delayMs <= 0) return undefined;
-  if (delayMs < 1000) return undefined;
 
-  return Math.round(delayMs / 1000);
+  return Math.max(1, Math.round(delayMs / 1000));
 };
 
 /**
@@ -55,15 +47,6 @@ export class QStashQueueServiceImpl implements QueueServiceImpl {
     } = message;
 
     try {
-      // QStash publish delays are second-granularity (`10s`, `1m`, or numeric
-      // seconds) and cannot express sub-second settling, so honor small windows
-      // locally. Floor at MIN_SETTLING_DELAY_MS so even a zero/near-zero delay
-      // still settles before publishing instead of collapsing to immediate
-      // delivery.
-      if (delay < 1000) {
-        await sleep(Math.max(delay, MIN_SETTLING_DELAY_MS));
-      }
-
       log('Initialized QStash queue service');
       const qstashClient = new OtelQstashClient({ token: this.config.qstashToken });
       const qstashDelay = toQStashDelaySeconds(delay);


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [x] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

The QStash queue impl used to handle sub-second scheduling delays by sleeping in-process (floored at a 300ms minimum settling window) before publishing, because QStash's `delay` option is second-granularity.

This PR removes that local sleep entirely:

- Positive sub-second delays are now rounded up to a `1s` QStash delay (`Math.max(1, Math.round(delayMs / 1000))`) and delegated to QStash instead of blocking the publishing request.
- Zero/negative delays publish immediately with no `delay` option, instead of being floored to a 300ms local wait.
- Delays ≥ 1s behave as before.

Behavior note: the default step delay (50ms) previously meant a ~300ms local wait; it now becomes a 1s QStash-side delay, so per-step scheduling intervals grow slightly — in exchange, `scheduleMessage` no longer holds the server request open to settle.

#### 🧪 How to Test

Updated the QStash impl tests: 500ms delay asserts `delay: 1` is forwarded to QStash, and zero delay asserts immediate publish with no `delay` property. `bun run check` passes (lint clean, 33 tests passed).

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

None — server-side only.

#### 📝 Additional Information

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)