### PR TITLE
🐛 fix(message): report a zero-row update as a failed write

### DIFF
--- a/packages/database/src/models/__tests__/messages/message.update.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.update.test.ts
@@ -101,6 +101,32 @@ describe('MessageModel Update Tests', () => {
       expect(result[0].content).toBe('message 1');
     });
 
+    it('should report success when a row was actually updated', async () => {
+      await serverDB
+        .insert(messages)
+        .values([{ id: '1', userId, role: 'user', content: 'message 1' }]);
+
+      const result = await messageModel.update('1', { content: 'updated message' });
+
+      expect(result).toEqual({ success: true });
+    });
+
+    it('should report failure when no message matches the id', async () => {
+      const result = await messageModel.update('does-not-exist', { content: 'updated message' });
+
+      expect(result).toEqual({ success: false });
+    });
+
+    it('should report failure when the message belongs to another user', async () => {
+      await serverDB
+        .insert(messages)
+        .values([{ id: '1', userId: otherUserId, role: 'user', content: 'message 1' }]);
+
+      const result = await messageModel.update('1', { content: 'updated message' });
+
+      expect(result).toEqual({ success: false });
+    });
+
     it('should update message tools', async () => {
       // Create test data
       await serverDB.insert(messages).values([
@@ -560,6 +586,22 @@ describe('MessageModel Update Tests', () => {
       expect(dbResult[0].content).toBe('updated content');
     });
 
+    it('should report failure when no tool message matches the id', async () => {
+      const result = await messageModel.updateToolMessage('tool-msg-missing', {
+        content: 'updated content',
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it('should report failure when a plugin-only patch matches no plugin row', async () => {
+      const result = await messageModel.updateToolMessage('tool-msg-missing', {
+        pluginState: { key: 'value' },
+      });
+
+      expect(result.success).toBe(false);
+    });
+
     it('should update metadata only and merge with existing', async () => {
       await serverDB.insert(messages).values({
         id: 'tool-msg-2',
@@ -745,7 +787,8 @@ describe('MessageModel Update Tests', () => {
         content: 'hacked content',
       });
 
-      expect(result.success).toBe(true);
+      // Ownership filters the row out, so the patch lands nowhere — a lost write.
+      expect(result.success).toBe(false);
 
       // Verify content was NOT updated
       const dbResult = await serverDB
@@ -780,15 +823,13 @@ describe('MessageModel Update Tests', () => {
     });
 
     it('should return success false on error', async () => {
-      // Don't create any message - this should cause the transaction to succeed
-      // but not update anything (which is still success)
+      // The transaction itself succeeds, but the update matches no row. Batched
+      // writers key their retry ledger off `success`, so this must not be true.
       const result = await messageModel.updateToolMessage('non-existent-id', {
         content: 'content',
       });
 
-      // The method returns success: true even for non-existent messages
-      // because the update query doesn't fail, it just doesn't match any rows
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     });
 
     it('should handle empty params gracefully', async () => {

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -2213,6 +2213,10 @@ export class MessageModel {
       metadata || usageToWrite
         ? { ...metadata, ...(usageToWrite && { usage: usageToWrite }) }
         : undefined;
+    // A patch that matches no row is a lost write, not a no-op: the caller asked
+    // to persist content onto `id` and it went nowhere. Batched writers key their
+    // retry ledger off this flag, so reporting success here silently drops data.
+    let matchedRow = false;
     try {
       await runTimedStage(
         timing,
@@ -2269,6 +2273,8 @@ export class MessageModel {
               { hasMetadata: !!metadataPatch, valueKeys: Object.keys(message) },
             );
 
+            matchedRow = !!updated;
+
             if (
               updated?.topicId && // When this write carries token usage (assistant finalize / hetero
               // step), recompute the topic's denormalized usage rollup from its
@@ -2290,6 +2296,11 @@ export class MessageModel {
           valueKeys: Object.keys(message),
         },
       );
+
+      if (!matchedRow) {
+        console.error(`Update message error: no message matched id ${id}`);
+        return { success: false };
+      }
 
       return { success: true };
     } catch (error) {
@@ -2427,6 +2438,10 @@ export class MessageModel {
   ): Promise<{ success: boolean }> => {
     const { content, metadata, pluginState, pluginError } = params;
 
+    // `undefined` while no branch has looked for the row yet; see `update` above
+    // for why a write that matches nothing must not report success.
+    let matchedRow: boolean | undefined;
+
     try {
       await this.db.transaction(async (trx) => {
         // Update messages table (content, metadata)
@@ -2446,10 +2461,13 @@ export class MessageModel {
           }
 
           if (Object.keys(messageUpdateData).length > 0) {
-            await trx
+            const [updated] = await trx
               .update(messages)
               .set(messageUpdateData)
-              .where(and(eq(messages.id, id), this.ownership()));
+              .where(and(eq(messages.id, id), this.ownership()))
+              .returning({ id: messages.id });
+
+            matchedRow = !!updated;
           }
         }
 
@@ -2458,6 +2476,10 @@ export class MessageModel {
           const pluginItem = await trx.query.messagePlugins.findFirst({
             where: and(eq(messagePlugins.id, id), this.pluginsOwnership()),
           });
+
+          // A plugin-only patch never touches `messages`, so the plugin row is
+          // the only evidence the tool message exists.
+          if (matchedRow === undefined) matchedRow = !!pluginItem;
 
           if (pluginItem) {
             const pluginUpdateData: Record<string, any> = {};
@@ -2479,6 +2501,11 @@ export class MessageModel {
           }
         }
       });
+
+      if (matchedRow === false) {
+        console.error(`Update tool message error: no tool message matched id ${id}`);
+        return { success: false };
+      }
 
       return { success: true };
     } catch (error) {

--- a/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
@@ -4409,6 +4409,55 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
       });
     });
 
+    it('replays a tool-parented signal assistant only after its tool row lands', async () => {
+      // A signal turn parents off the run's last TOOL row, not the spine. So a
+      // create ledger that drains every assistant before any tool row retries
+      // the signal assistant while its parent is still missing, burns its only
+      // retry on a guaranteed FK violation, and drops the turn.
+      const persisted = new Set<string>(['ast-initial']);
+      let toolCreateBlips = 1;
+      mockCreateMessage.mockImplementation(async (params: any) => {
+        // One transient failure on the tool row — the seed of the cascade.
+        if (params.role === 'tool' && toolCreateBlips > 0) {
+          toolCreateBlips -= 1;
+          throw new Error('transient write failure');
+        }
+        // Everything else obeys `messages.parent_id`, like the real table does.
+        if (params.parentId && !persisted.has(params.parentId)) {
+          throw new Error(`FK violation: parent ${params.parentId} is not present`);
+        }
+        persisted.add(params.id);
+        return { id: params.id };
+      });
+
+      await runWithEvents([
+        ccInit(),
+        ccMessageStart('msg_01'),
+        ccToolUse('msg_01', 'toolu_mon_0', 'Monitor', { shell: 'every 1s' }),
+        ccTaskStarted('task_a', 'toolu_mon_0'),
+        ccToolResult('toolu_mon_0', 'Monitor started'),
+        // Natural confirmation turn — parents off the spine.
+        ccMessageStart('msg_02'),
+        ccText('msg_02', 'Monitor started.'),
+        // Monitor pushed stdout → signal callback, parents off the tool row.
+        ccMessageStart('msg_03'),
+        ccText('msg_03', 'tick 1'),
+        ccResult(),
+      ]);
+
+      const toolCreate = mockCreateMessage.mock.calls.find(([p]: any) => p.role === 'tool');
+      const signalCreate = mockCreateMessage.mock.calls.find(
+        ([p]: any) => p.role === 'assistant' && p.metadata?.signal,
+      );
+      expect(toolCreate).toBeDefined();
+      expect(signalCreate).toBeDefined();
+      expect(signalCreate![0].parentId).toBe(toolCreate![0].id);
+
+      // Both rows must exist once the run settles, or the signal turn is lost.
+      expect(persisted.has(toolCreate![0].id)).toBe(true);
+      expect(persisted.has(signalCreate![0].id)).toBe(true);
+    });
+
     it('does NOT stamp metadata.signal on turns following a tool_result (main-chain follow-up)', async () => {
       const idCounter = { tool: 0, assistant: 0 };
       mockCreateMessage.mockImplementation(async (params: any) => {

--- a/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/heterogeneousAgentExecutor.test.ts
@@ -1123,6 +1123,96 @@ describe('heterogeneousAgentExecutor DB persistence', () => {
   });
 
   // ────────────────────────────────────────────────────
+  // Lost-write recovery — the tpc_mMYve6mAIT4J incident
+  // ────────────────────────────────────────────────────
+
+  describe('lost-write recovery (FK cascade)', () => {
+    /**
+     * End-to-end replay of the original incident against a fake table that
+     * enforces the two invariants the real `messages` table does:
+     *   - `parent_id` is a FK: a create whose parent row is absent throws 23503.
+     *   - an update whose id matches no row reports `success: false` (a lost
+     *     write, not a no-op) — the semantic this PR restored.
+     *
+     * A single transient `createMessage` failure orphans the seed of a spine
+     * chain (`asst → asst → asst …`); every later assistant then fails the FK,
+     * and every content flush in between lands on a row that does not exist.
+     * The fix must recover ALL of it: replay the creates in dependency order,
+     * then replay the content the zero-row updates stashed.
+     */
+    const makeFakeTable = (seedId: string) => {
+      const rows = new Map<string, any>([[seedId, { content: '', id: seedId, role: 'assistant' }]]);
+      let firstAssistantBlipped = false;
+
+      const create = async (params: any) => {
+        // Seed the cascade: the first fresh assistant create fails once, exactly
+        // like the single dropped write that started the real incident.
+        if (params.role === 'assistant' && !firstAssistantBlipped) {
+          firstAssistantBlipped = true;
+          throw new Error('transient write failure');
+        }
+        if (params.parentId && !rows.has(params.parentId)) {
+          throw new Error(`FK violation: parent ${params.parentId} is absent`);
+        }
+        rows.set(params.id, { ...params, content: params.content ?? '' });
+        return { id: params.id };
+      };
+
+      const update = async (id: string, value: any) => {
+        const row = rows.get(id);
+        if (!row) return { success: false };
+        Object.assign(row, value);
+        return { success: true };
+      };
+
+      return { create, rows, update };
+    };
+
+    it('recovers every assistant + its content after a create failure cascades down the spine', async () => {
+      const store = createMockStore({
+        dbMessagesMap: {
+          'main_agent-1_topic-1': [
+            { content: '', id: 'ast-initial', role: 'assistant', topicId: 'topic-1' },
+          ],
+        },
+      });
+      const table = makeFakeTable('ast-initial');
+      mockCreateMessage.mockImplementation(table.create);
+      mockUpdateMessage.mockImplementation(table.update);
+
+      // msg_01 reuses the seed; msg_02..04 are fresh spine assistants, each
+      // parented off the previous one — so orphaning msg_02 takes 03 and 04 too.
+      const texts = {
+        msg_01: 'seed turn answer',
+        msg_02: 'first fresh turn',
+        msg_03: 'second fresh turn',
+        msg_04: 'final answer that must survive',
+      };
+      await runWithEvents(
+        [
+          ccInit(),
+          ccText('msg_01', texts.msg_01),
+          ccText('msg_02', texts.msg_02),
+          ccText('msg_03', texts.msg_03),
+          ccText('msg_04', texts.msg_04),
+          ccResult(),
+        ],
+        { store },
+      );
+
+      // Every assistant turn is present AND carries its text — no empty shells,
+      // nothing dropped. This is the exact assertion that fails pre-fix: the
+      // content updates "succeeded" against absent rows, so the ledger that
+      // would have replayed them stayed empty.
+      const persistedContent = [...table.rows.values()]
+        .filter((r) => r.role === 'assistant')
+        .map((r) => r.content)
+        .sort();
+      expect(persistedContent).toEqual(Object.values(texts).sort());
+    });
+  });
+
+  // ────────────────────────────────────────────────────
   // Error handling
   // ────────────────────────────────────────────────────
 

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -791,6 +791,22 @@ export const executeHeterogeneousAgent = async (
     string,
     Extract<MessageBatchOperation, { type: 'createMessage' }>['message']
   >();
+  /**
+   * Tool rows hang off an assistant row, so a failed `createAssistant` takes
+   * every tool row of that step down with it (FK on `messages.parent_id`).
+   * Replayed after `pendingMainCreates` so the parents exist again.
+   */
+  const pendingToolCreates = new Map<
+    string,
+    Extract<MessageBatchOperation, { type: 'createMessage' }>['message']
+  >();
+  /** Retry ledger for tool result content / plugin state. */
+  const pendingToolFlush = new Map<string, ToolMessageUpdateOperation['value']>();
+
+  /** Later intents carry a superset of the payload, so a shallow merge wins. */
+  const stashMainFlush = (messageId: string, update: Record<string, any>) => {
+    pendingMainFlush.set(messageId, { ...pendingMainFlush.get(messageId), ...update });
+  };
   /** Serializes async persist operations so ordering is stable. */
   let persistQueue: Promise<void> = Promise.resolve();
   /**
@@ -1004,16 +1020,15 @@ export const executeHeterogeneousAgent = async (
       return;
     }
 
-    messageWriteBatcher.enqueueToolMessageUpdate(
-      toolMsgId,
-      {
-        content,
-        pluginError: isError ? { message: content } : undefined,
-        pluginState,
-      },
-      messageWriteCtx,
-      (err) => console.error('[HeterogeneousAgent] Failed to update tool message content:', err),
-    );
+    const toolUpdate = {
+      content,
+      pluginError: isError ? { message: content } : undefined,
+      pluginState,
+    };
+    messageWriteBatcher.enqueueToolMessageUpdate(toolMsgId, toolUpdate, messageWriteCtx, (err) => {
+      console.error('[HeterogeneousAgent] Failed to update tool message content:', err);
+      pendingToolFlush.set(toolMsgId, { ...pendingToolFlush.get(toolMsgId), ...toolUpdate });
+    });
   };
   const applyInterventionRequest = async (data: AgentInterventionRequestData): Promise<boolean> => {
     const toolMsgId = toolMsgIdByCallId.get(data.toolCallId);
@@ -1472,10 +1487,7 @@ export const executeHeterogeneousAgent = async (
           messageWriteCtx,
           (err) => {
             console.error('[HeterogeneousAgent] Failed to flush main assistant:', err);
-            pendingMainFlush.set(intent.messageId, {
-              ...pendingMainFlush.get(intent.messageId),
-              ...update,
-            });
+            stashMainFlush(intent.messageId, update);
           },
         );
         // Mirror ONLY model/provider into the store: content/reasoning already
@@ -1542,13 +1554,21 @@ export const executeHeterogeneousAgent = async (
           } as any;
         };
 
+        // The ledger always carries the phase-3 shape: by the time it replays,
+        // the tool rows exist, and stashing the phase-1 shape would let a stale
+        // `tools[]` (no `result_msg_id`) clobber a phase-3 write that landed.
+        const finalAssistantUpdate = buildUpdate(true);
+
         // Phase 1: pre-register assistant.tools[] (no result_msg_id yet) so the
         // conversation-flow parser finds matching ids the moment tool rows land.
         messageWriteBatcher.enqueueUpdateMessage(
           intent.assistantMessageId,
           buildUpdate(false),
           messageWriteCtx,
-          (err) => console.error('[HeterogeneousAgent] Failed to pre-register main tools:', err),
+          (err) => {
+            console.error('[HeterogeneousAgent] Failed to pre-register main tools:', err);
+            stashMainFlush(intent.assistantMessageId, finalAssistantUpdate);
+          },
         );
 
         // Phase 2: create rows for new tools with their pre-allocated ids and
@@ -1556,7 +1576,10 @@ export const executeHeterogeneousAgent = async (
         for (const x of intent.tools) {
           if (!x.isNew) continue;
           const toolMsg = buildToolMessage(x);
-          messageWriteBatcher.enqueueCreateMessage(toolMsg);
+          messageWriteBatcher.enqueueCreateMessage(toolMsg, (err) => {
+            console.error('[HeterogeneousAgent] Failed to create tool message:', err);
+            pendingToolCreates.set(x.toolMessageId, toolMsg);
+          });
           toolMsgIdByCallId.set(x.payload.id, x.toolMessageId);
           mainToolCallIds.add(x.payload.id);
           get().internal_dispatchMessage(
@@ -1566,12 +1589,14 @@ export const executeHeterogeneousAgent = async (
         }
 
         // Phase 3: backfill result_msg_id on assistant.tools[].
-        const finalAssistantUpdate = buildUpdate(true);
         messageWriteBatcher.enqueueUpdateMessage(
           intent.assistantMessageId,
           finalAssistantUpdate,
           messageWriteCtx,
-          (err) => console.error('[HeterogeneousAgent] Failed to finalize main tools:', err),
+          (err) => {
+            console.error('[HeterogeneousAgent] Failed to finalize main tools:', err);
+            stashMainFlush(intent.assistantMessageId, finalAssistantUpdate);
+          },
         );
         get().internal_dispatchMessage(
           {
@@ -1618,8 +1643,14 @@ export const executeHeterogeneousAgent = async (
           ...(intent.model && { model: intent.model }),
           ...(intent.provider && { provider: intent.provider }),
         };
-        messageWriteBatcher.enqueueUpdateMessage(intent.messageId, update, messageWriteCtx, (err) =>
-          console.error('[HeterogeneousAgent] Failed to record main usage:', err),
+        messageWriteBatcher.enqueueUpdateMessage(
+          intent.messageId,
+          update,
+          messageWriteCtx,
+          (err) => {
+            console.error('[HeterogeneousAgent] Failed to record main usage:', err);
+            stashMainFlush(intent.messageId, update);
+          },
         );
         // Same payload into the store so usage + model/provider render live —
         // the subagent interpreter's `recordUsage` already does this via
@@ -1975,6 +2006,11 @@ export const executeHeterogeneousAgent = async (
           const queueDrained = await waitForPersistQueue(persistQueue, 'terminal');
 
           if (queueDrained) {
+            // Order is load-bearing: `messages.parent_id` is a real FK, so a row
+            // can only be replayed once its parent is back. Assistants chain to
+            // the previous assistant (Map insertion order == ancestor order),
+            // tool rows chain to their assistant, and every content flush needs
+            // its row to already exist or it silently matches zero rows.
             for (const [messageId, messageToCreate] of pendingMainCreates) {
               try {
                 await messageService.createMessage(messageToCreate);
@@ -1984,12 +2020,36 @@ export const executeHeterogeneousAgent = async (
               }
             }
 
+            for (const [messageId, messageToCreate] of pendingToolCreates) {
+              try {
+                await messageService.createMessage(messageToCreate);
+                pendingToolCreates.delete(messageId);
+              } catch (err) {
+                console.error('[HeterogeneousAgent] Failed to replay tool create:', err);
+              }
+            }
+
             for (const [messageId, update] of pendingMainFlush) {
               try {
                 await updateMessageOrThrow(messageId, update);
                 pendingMainFlush.delete(messageId);
               } catch (err) {
                 console.error('[HeterogeneousAgent] Failed to replay main assistant flush:', err);
+              }
+            }
+
+            for (const [messageId, update] of pendingToolFlush) {
+              try {
+                const result = await messageService.updateToolMessage(messageId, update, {
+                  agentId: context.agentId,
+                  topicId: context.topicId,
+                });
+                if (result?.success === false) {
+                  throw new Error(`updateToolMessage returned success=false for ${messageId}`);
+                }
+                pendingToolFlush.delete(messageId);
+              } catch (err) {
+                console.error('[HeterogeneousAgent] Failed to replay tool flush:', err);
               }
             }
 

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -787,16 +787,18 @@ export const executeHeterogeneousAgent = async (
    * be lost once the reducer clears `accContent` on terminal.
    */
   const pendingMainFlush = new Map<string, Record<string, any>>();
-  const pendingMainCreates = new Map<
-    string,
-    Extract<MessageBatchOperation, { type: 'createMessage' }>['message']
-  >();
   /**
-   * Tool rows hang off an assistant row, so a failed `createAssistant` takes
-   * every tool row of that step down with it (FK on `messages.parent_id`).
-   * Replayed after `pendingMainCreates` so the parents exist again.
+   * Retry ledger for every failed row create — assistants AND tool rows, in one
+   * Map on purpose. `messages.parent_id` is a real FK and the parent graph is
+   * not layered: a tool row hangs off its assistant, but a signal/reactive
+   * assistant hangs off the run's last TOOL row (see `computeTurnParentId`).
+   * Splitting the ledger by role would replay a tool-parented assistant before
+   * its parent tool row and lose the turn. Enqueue order IS dependency order —
+   * the reducer can only name a parent it has already emitted a create for —
+   * and `Map` preserves insertion order, so one in-order drain is correct with
+   * no knowledge of which parent kind any given row uses.
    */
-  const pendingToolCreates = new Map<
+  const pendingCreates = new Map<
     string,
     Extract<MessageBatchOperation, { type: 'createMessage' }>['message']
   >();
@@ -1461,7 +1463,7 @@ export const executeHeterogeneousAgent = async (
         } as any;
         messageWriteBatcher.enqueueCreateMessage(messageToCreate, (err) => {
           console.error('[HeterogeneousAgent] Failed to create step assistant:', err);
-          pendingMainCreates.set(intent.messageId, messageToCreate);
+          pendingCreates.set(intent.messageId, messageToCreate);
         });
         get().internal_dispatchMessage(
           { id: intent.messageId, type: 'createMessage', value: messageToCreate },
@@ -1578,7 +1580,7 @@ export const executeHeterogeneousAgent = async (
           const toolMsg = buildToolMessage(x);
           messageWriteBatcher.enqueueCreateMessage(toolMsg, (err) => {
             console.error('[HeterogeneousAgent] Failed to create tool message:', err);
-            pendingToolCreates.set(x.toolMessageId, toolMsg);
+            pendingCreates.set(x.toolMessageId, toolMsg);
           });
           toolMsgIdByCallId.set(x.payload.id, x.toolMessageId);
           mainToolCallIds.add(x.payload.id);
@@ -2006,26 +2008,15 @@ export const executeHeterogeneousAgent = async (
           const queueDrained = await waitForPersistQueue(persistQueue, 'terminal');
 
           if (queueDrained) {
-            // Order is load-bearing: `messages.parent_id` is a real FK, so a row
-            // can only be replayed once its parent is back. Assistants chain to
-            // the previous assistant (Map insertion order == ancestor order),
-            // tool rows chain to their assistant, and every content flush needs
-            // its row to already exist or it silently matches zero rows.
-            for (const [messageId, messageToCreate] of pendingMainCreates) {
+            // Order is load-bearing: rows first, in the order they were enqueued
+            // (that is their FK dependency order), then the content patches —
+            // an update against a row that does not exist yet matches zero rows.
+            for (const [messageId, messageToCreate] of pendingCreates) {
               try {
                 await messageService.createMessage(messageToCreate);
-                pendingMainCreates.delete(messageId);
+                pendingCreates.delete(messageId);
               } catch (err) {
-                console.error('[HeterogeneousAgent] Failed to replay main assistant create:', err);
-              }
-            }
-
-            for (const [messageId, messageToCreate] of pendingToolCreates) {
-              try {
-                await messageService.createMessage(messageToCreate);
-                pendingToolCreates.delete(messageId);
-              } catch (err) {
-                console.error('[HeterogeneousAgent] Failed to replay tool create:', err);
+                console.error('[HeterogeneousAgent] Failed to replay message create:', err);
               }
             }
 


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none yet -->

#### 🔀 Description of Change

`MessageModel.update` / `updateToolMessage` returned `{ success: true }` when the patch matched **no row**. `MessageService.batchMutate` derives its per-op result from that flag, and the hetero executor derives its retry ledger from the per-op result — so a content write aimed at a row that had failed to be created was reported as landed, and dropped on the floor.

**The failure mode this unblocks.** `messages.parent_id` is a real FK, and each hetero `createAssistant` uses the previous assistant as its parent. So a single lost `createMessage` orphans every later assistant of the run:

```
[cause]: error: insert or update on table "messages"
         violates foreign key constraint "messages_parent_id_messages_id_fk"
  code: '23503'
  detail: 'Key (parent_id)=(msg_k2uSEboqxlD2G0KN0Y) is not present in table "messages".'
```

The creates landed in `pendingMainCreates` and were replayed at terminal — but every `persistAssistant` update in between "succeeded" against a row that did not exist, so `pendingMainFlush` stayed empty and the text was never queued for replay. The run ended as a chain of empty assistant rows: the CLI had finished normally, the final answer's row existed, its `content` was `''`.

Observed on a local Claude Code run (`tpc_mMYve6mAIT4J`): 49 empty assistant rows created in a 34s burst right after the CLI exited, mapping 1:1 (via `metadata.heteroMessageId`) to the 49 turns of the preceding 20 minutes. 25 topics in the last 7 days show the same signature.

Changes:

- report `success: false` when the update matches no row — a missing id, or a row filtered out by ownership. The evidence was already there: `update` destructures `[updated]` from `.returning()` and never checks it.
- give the hetero executor the two ledgers it was missing — tool row creates and tool result flushes — plus `persistToolBatch` phase 1/3 and `recordUsage`, which previously only reached `console.error`.
- replay in FK order at terminal: assistant creates → tool creates → content flushes.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

`pnpm --filter @lobechat/database exec vitest run src/models/__tests__/messages/` → 271 passed, 4 skipped.
`vitest run apps/server/src/services/message/__tests__/index.test.ts` → 28 passed.
`pnpm type-check` clean.

New cases: `update` on a missing id, `update` on another user's row, `updateToolMessage` on a missing id, and a plugin-only patch matching no plugin row.

#### 📝 Additional Information

**Two existing tests asserted the old behaviour verbatim** and are flipped here. One carried the comment *"The method returns success: true even for non-existent messages because the update query doesn't fail, it just doesn't match any rows"* — it was recorded as known behaviour, not overlooked. That is the line worth a second opinion during review.

**Blast radius is smaller than it looks.** Server-side `MessageService.updateMessage` discards the model's result (`return this.queryWithSuccess(options)`), so the tRPC single-update path and the client's optimistic-update flows never observe this flag. Only `batchMutate` reads it — which is exactly the writer that needs it.

Deliberately **not** in this PR:

- re-enqueueing failed ops at the head of the *next* flush instead of waiting for terminal. That needs `create` to be idempotent first (`onConflictDoNothing`), or replaying an id that actually landed turns into a `23505`.
- `updateMessageOrThrow` can never actually throw today, for the same reason the blast radius is zero — the server swallows the model result. The terminal replay's "confirmed persisted" check is therefore cosmetic.
- a real transcript ↔ DB reconciliation on resume. The in-memory ledger dies with the renderer; the CLI transcript on disk is the only durable source of truth, and rows already carry `metadata.heteroMessageId` to align against.

None of these lose data on their own — they only govern how wide the window is between a blip and its repair.
