### PR TITLE
🔀 merge: sync main into weekly release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lobehub/lobehub",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "LobeHub - an open-source,comprehensive AI Agent framework that supports speech synthesis, multimodal, and extensible Function Call plugin system. Supports one-click free deployment of your private ChatGPT/LLM web application.",
   "keywords": [
     "framework",

--- a/package.json
+++ b/package.json
@@ -291,7 +291,7 @@
     "@lobehub/analytics": "^1.6.2",
     "@lobehub/charts": "^5.0.0",
     "@lobehub/desktop-ipc-typings": "workspace:*",
-    "@lobehub/editor": "4.19.2",
+    "@lobehub/editor": "4.18.0",
     "@lobehub/icons": "^5.0.0",
     "@lobehub/market-sdk": "0.39.1",
     "@lobehub/tts": "^5.1.2",
@@ -564,7 +564,7 @@
       "ffmpeg-static"
     ],
     "overrides": {
-      "@lobehub/editor": "4.19.2",
+      "@lobehub/editor": "4.18.0",
       "@react-pdf/image": "3.0.4",
       "@types/react": "19.2.13",
       "@vitest/coverage-v8": "3.2.6",

--- a/package.json
+++ b/package.json
@@ -291,7 +291,7 @@
     "@lobehub/analytics": "^1.6.2",
     "@lobehub/charts": "^5.0.0",
     "@lobehub/desktop-ipc-typings": "workspace:*",
-    "@lobehub/editor": "^4.17.1",
+    "@lobehub/editor": "4.19.2",
     "@lobehub/icons": "^5.0.0",
     "@lobehub/market-sdk": "0.39.1",
     "@lobehub/tts": "^5.1.2",
@@ -564,6 +564,7 @@
       "ffmpeg-static"
     ],
     "overrides": {
+      "@lobehub/editor": "4.19.2",
       "@react-pdf/image": "3.0.4",
       "@types/react": "19.2.13",
       "@vitest/coverage-v8": "3.2.6",


### PR DESCRIPTION
Resolve the weekly release conflict with `main` while preserving the current canary dependency set. This carries the published `2.2.9` baseline into the release branch; the next patch version remains CI-managed.