### PR TITLE
💄 style: add user interaction and Codex error inspectors

### DIFF
--- a/locales/en-US/plugin.json
+++ b/locales/en-US/plugin.json
@@ -22,6 +22,7 @@
   "builtins.codex.commandExecution.readFile": "Read file",
   "builtins.codex.commandExecution.runNode": "Run node script",
   "builtins.codex.commandExecution.runPython": "Run python script",
+  "builtins.codex.error.fallback": "Codex reported a warning",
   "builtins.codex.fileChange.editedFiles_one": "Edited {{count}} file",
   "builtins.codex.fileChange.editedFiles_other": "Edited {{count}} files",
   "builtins.codex.fileChange.editing": "Editing files",

--- a/locales/zh-CN/plugin.json
+++ b/locales/zh-CN/plugin.json
@@ -22,6 +22,7 @@
   "builtins.codex.commandExecution.readFile": "读取文件",
   "builtins.codex.commandExecution.runNode": "运行 node 脚本",
   "builtins.codex.commandExecution.runPython": "运行 python 脚本",
+  "builtins.codex.error.fallback": "Codex 发出了一条警告",
   "builtins.codex.fileChange.editedFiles_one": "已编辑 {{count}} 个文件",
   "builtins.codex.fileChange.editedFiles_other": "已编辑 {{count}} 个文件",
   "builtins.codex.fileChange.editing": "编辑文件中",

--- a/packages/builtin-tool-user-interaction/src/client/Inspector/AskUserQuestion/index.test.tsx
+++ b/packages/builtin-tool-user-interaction/src/client/Inspector/AskUserQuestion/index.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AskUserQuestionInspector } from './index';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: () => 'Ask user question',
+  }),
+}));
+
+vi.mock('@lobechat/shared-tool-ui/styles', () => ({
+  inspectorTextStyles: { root: 'inspector-root' },
+  shinyTextStyles: { shinyText: 'shiny-text' },
+}));
+
+vi.mock('@lobehub/ui', () => ({}));
+
+vi.mock('antd-style', () => ({
+  createStaticStyles: () => new Proxy({}, { get: (_target, property) => String(property) }),
+  cx: (...classNames: Array<string | false | undefined>) => classNames.filter(Boolean).join(' '),
+}));
+
+describe('AskUserQuestionInspector', () => {
+  afterEach(cleanup);
+
+  it('renders the API label and the first question header as a chip', () => {
+    render(
+      <AskUserQuestionInspector
+        apiName="askUserQuestion"
+        identifier="lobe-user-interaction"
+        args={{
+          questions: [
+            {
+              header: 'Direction',
+              multiSelect: true,
+              options: [{ description: 'Start here', label: 'Evidence pages' }],
+              question: 'Which area should we explore first?',
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Ask user question')).toBeTruthy();
+    expect(screen.getByText('Direction')).toBeTruthy();
+    expect(screen.queryByText(/questions:/)).toBeNull();
+  });
+
+  it('uses partial questions and the active animation while arguments stream', () => {
+    render(
+      <AskUserQuestionInspector
+        isArgumentsStreaming
+        apiName="askUserQuestion"
+        args={{ questions: [] }}
+        identifier="lobe-user-interaction"
+        partialArgs={{
+          questions: [
+            {
+              header: 'Next step',
+              options: [],
+              question: 'What should happen next?',
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId('ask-user-question-inspector').classList).toContain('shiny-text');
+    expect(screen.getByText('Next step')).toBeTruthy();
+  });
+
+  it('keeps the title stable before any useful arguments arrive', () => {
+    render(
+      <AskUserQuestionInspector
+        isArgumentsStreaming
+        apiName="askUserQuestion"
+        args={{ questions: [] }}
+        identifier="lobe-user-interaction"
+        partialArgs={{ questions: [] }}
+      />,
+    );
+
+    expect(screen.getByText('Ask user question')).toBeTruthy();
+    expect(screen.queryByText(/questions:/)).toBeNull();
+  });
+
+  it('summarizes multiple questions with the remaining count', () => {
+    render(
+      <AskUserQuestionInspector
+        apiName="askUserQuestion"
+        identifier="lobe-user-interaction"
+        args={{
+          questions: [
+            { header: 'Scope', options: [], question: 'How broad should this pass be?' },
+            { header: 'Tone', options: [], question: 'Which tone should we use?' },
+            { header: 'Format', options: [], question: 'Which format should we use?' },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Scope +2')).toBeTruthy();
+    expect(screen.queryByText('Tone')).toBeNull();
+  });
+});

--- a/packages/builtin-tool-user-interaction/src/client/Inspector/AskUserQuestion/index.tsx
+++ b/packages/builtin-tool-user-interaction/src/client/Inspector/AskUserQuestion/index.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { normalizeAskUserQuestions } from '@lobechat/shared-tool-ui/ask-user';
+import { inspectorTextStyles, shinyTextStyles } from '@lobechat/shared-tool-ui/styles';
+import type { BuiltinInspectorProps } from '@lobechat/types';
+import { createStaticStyles, cx } from 'antd-style';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { AskUserQuestionArgs } from '../../../types';
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  chip: css`
+    overflow: hidden;
+
+    min-width: 0;
+    margin-inline-start: 6px;
+    padding-block: 2px;
+    padding-inline: 10px;
+    border-radius: 999px;
+
+    font-size: 12px;
+    color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+
+    background: ${cssVar.colorFillTertiary};
+  `,
+}));
+
+export const AskUserQuestionInspector = memo<BuiltinInspectorProps<AskUserQuestionArgs>>(
+  ({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
+    const { t } = useTranslation('plugin');
+    const label = t('builtins.lobe-user-interaction.apiName.askUserQuestion');
+    const argsQuestions = normalizeAskUserQuestions(args);
+    const questions = argsQuestions.length ? argsQuestions : normalizeAskUserQuestions(partialArgs);
+    const firstQuestion = questions[0];
+    const firstSummary = firstQuestion?.header || firstQuestion?.question;
+    const summary =
+      questions.length > 1 && firstSummary
+        ? `${firstSummary} +${questions.length - 1}`
+        : firstSummary;
+
+    if (isArgumentsStreaming && !summary) {
+      return (
+        <div
+          className={cx(inspectorTextStyles.root, shinyTextStyles.shinyText)}
+          data-testid="ask-user-question-inspector"
+        >
+          {label}
+        </div>
+      );
+    }
+
+    return (
+      <div
+        data-testid="ask-user-question-inspector"
+        className={cx(
+          inspectorTextStyles.root,
+          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
+        )}
+      >
+        <span>{label}</span>
+        {summary && <span className={styles.chip}>{summary}</span>}
+      </div>
+    );
+  },
+);
+
+AskUserQuestionInspector.displayName = 'AskUserQuestionInspector';
+
+export default AskUserQuestionInspector;

--- a/packages/builtin-tool-user-interaction/src/client/Inspector/index.ts
+++ b/packages/builtin-tool-user-interaction/src/client/Inspector/index.ts
@@ -1,0 +1,10 @@
+import type { BuiltinInspector } from '@lobechat/types';
+
+import { UserInteractionApiName } from '../../types';
+import { AskUserQuestionInspector } from './AskUserQuestion';
+
+export const UserInteractionInspectors: Record<string, BuiltinInspector> = {
+  [UserInteractionApiName.askUserQuestion]: AskUserQuestionInspector as BuiltinInspector,
+};
+
+export { AskUserQuestionInspector } from './AskUserQuestion';

--- a/packages/builtin-tool-user-interaction/src/client/index.ts
+++ b/packages/builtin-tool-user-interaction/src/client/index.ts
@@ -1,4 +1,6 @@
 export { UserInteractionManifest } from '../manifest';
 export * from '../types';
+export { UserInteractionInspectors } from './Inspector';
+export { default as AskUserQuestionInspector } from './Inspector/AskUserQuestion';
 export { UserInteractionInterventions } from './Intervention';
 export { default as AskUserQuestionIntervention } from './Intervention/AskUserQuestion';

--- a/packages/builtin-tools/src/codex/ErrorInspector.test.tsx
+++ b/packages/builtin-tools/src/codex/ErrorInspector.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ErrorInspector from './ErrorInspector';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: () => 'Codex reported a warning',
+  }),
+}));
+
+vi.mock('@lobechat/shared-tool-ui/styles', () => ({
+  inspectorTextStyles: { root: 'inspector-root' },
+  shinyTextStyles: { shinyText: 'shiny-text' },
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  Icon: ({ className }: { className?: string }) => (
+    <span className={className} data-testid="icon" />
+  ),
+}));
+
+vi.mock('antd-style', () => ({
+  createStaticStyles: () => new Proxy({}, { get: (_target, property) => String(property) }),
+  cx: (...classNames: Array<string | false | undefined>) => classNames.filter(Boolean).join(' '),
+}));
+
+describe('Codex ErrorInspector', () => {
+  afterEach(cleanup);
+
+  it('renders the warning icon and error message', () => {
+    render(
+      <ErrorInspector
+        apiName="error"
+        args={{ id: 'item_0', message: 'The session model changed.', type: 'error' }}
+        identifier="codex"
+      />,
+    );
+
+    expect(screen.getByTestId('icon')).toBeTruthy();
+    expect(screen.getByText('The session model changed.')).toBeTruthy();
+  });
+
+  it('reads partial message content while arguments stream', () => {
+    render(
+      <ErrorInspector
+        isArgumentsStreaming
+        apiName="error"
+        args={{}}
+        identifier="codex"
+        partialArgs={{ message: 'Session compatibility warning' }}
+      />,
+    );
+
+    expect(screen.getByText('Session compatibility warning')).toBeTruthy();
+    expect(screen.getByTestId('codex-error-inspector').classList).toContain('shiny-text');
+  });
+
+  it('uses localized fallback copy when no message is available', () => {
+    render(<ErrorInspector apiName="error" args={{}} identifier="codex" />);
+
+    expect(screen.getByText('Codex reported a warning')).toBeTruthy();
+  });
+});

--- a/packages/builtin-tools/src/codex/ErrorInspector.tsx
+++ b/packages/builtin-tools/src/codex/ErrorInspector.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { inspectorTextStyles, shinyTextStyles } from '@lobechat/shared-tool-ui/styles';
+import type { BuiltinInspectorProps } from '@lobechat/types';
+import { Icon } from '@lobehub/ui';
+import { createStaticStyles, cx } from 'antd-style';
+import { AlertTriangle } from 'lucide-react';
+import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export interface CodexErrorArgs {
+  id?: string;
+  message?: string;
+  type?: string;
+}
+
+const styles = createStaticStyles(({ css, cssVar }) => ({
+  icon: css`
+    flex: none;
+    color: ${cssVar.colorWarning};
+  `,
+  message: css`
+    overflow: hidden;
+
+    min-width: 0;
+
+    color: ${cssVar.colorWarningText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  root: css`
+    gap: 6px;
+    align-items: center;
+  `,
+}));
+
+const ErrorInspector = memo<BuiltinInspectorProps<CodexErrorArgs>>(
+  ({ args, partialArgs, isArgumentsStreaming, isLoading }) => {
+    const { t } = useTranslation('plugin');
+    const message = args?.message?.trim() || partialArgs?.message?.trim();
+    const fallback = t('builtins.codex.error.fallback', {
+      defaultValue: 'Codex reported a warning',
+    });
+
+    return (
+      <div
+        data-testid="codex-error-inspector"
+        className={cx(
+          inspectorTextStyles.root,
+          styles.root,
+          (isArgumentsStreaming || isLoading) && shinyTextStyles.shinyText,
+        )}
+      >
+        <Icon className={styles.icon} icon={AlertTriangle} size={14} />
+        <span className={styles.message}>{message || fallback}</span>
+      </div>
+    );
+  },
+);
+
+ErrorInspector.displayName = 'CodexErrorInspector';
+
+export default ErrorInspector;

--- a/packages/builtin-tools/src/codex/index.ts
+++ b/packages/builtin-tools/src/codex/index.ts
@@ -4,6 +4,7 @@ import CollabToolInspector from './CollabToolInspector';
 import CollabToolRender from './CollabToolRender';
 import CommandExecutionInspector from './CommandExecutionInspector';
 import { CodexRenderDisplayControls } from './displayControls';
+import ErrorInspector from './ErrorInspector';
 import FileChangeInspector from './FileChangeInspector';
 import FileChangeRender from './FileChangeRender';
 import McpToolInspector from './McpToolInspector';
@@ -16,6 +17,7 @@ import WebSearchRender from './WebSearchRender';
 export const CodexInspectors: Record<string, BuiltinInspector> = {
   collab_tool_call: CollabToolInspector as BuiltinInspector,
   command_execution: CommandExecutionInspector as BuiltinInspector,
+  error: ErrorInspector as BuiltinInspector,
   file_change: FileChangeInspector as BuiltinInspector,
   mcp_tool_call: McpToolInspector as BuiltinInspector,
   todo_list: TodoListInspector as BuiltinInspector,

--- a/packages/builtin-tools/src/register.ts
+++ b/packages/builtin-tools/src/register.ts
@@ -121,6 +121,7 @@ import {
 import { TaskInspectors, TaskManifest, TaskRenders } from '@lobechat/builtin-tool-task/client';
 import {
   UserInteractionIdentifier,
+  UserInteractionInspectors,
   UserInteractionInterventions,
 } from '@lobechat/builtin-tool-user-interaction/client';
 import {
@@ -240,6 +241,7 @@ export const registerBuiltinToolSurfaces = (): void => {
     [SkillStoreManifest.identifier]: SkillStoreInspectors as Record<string, BuiltinInspector>,
     [SkillsManifest.identifier]: SkillsInspectors as Record<string, BuiltinInspector>,
     [TaskManifest.identifier]: TaskInspectors as Record<string, BuiltinInspector>,
+    [UserInteractionIdentifier]: UserInteractionInspectors as Record<string, BuiltinInspector>,
     [WebBrowsingManifest.identifier]: WebBrowsingInspectors as Record<string, BuiltinInspector>,
     [WebOnboardingManifest.identifier]: WebOnboardingInspectors as Record<string, BuiltinInspector>,
     codex: CodexInspectors,

--- a/packages/locales/src/default/plugin.ts
+++ b/packages/locales/src/default/plugin.ts
@@ -122,6 +122,7 @@ export default {
   'builtins.codex.commandExecution.readFile': 'Read file',
   'builtins.codex.commandExecution.runNode': 'Run node script',
   'builtins.codex.commandExecution.runPython': 'Run python script',
+  'builtins.codex.error.fallback': 'Codex reported a warning',
   'builtins.codex.fileChange.editedFiles_one': 'Edited {{count}} file',
   'builtins.codex.fileChange.editedFiles_other': 'Edited {{count}} files',
   'builtins.codex.fileChange.editing': 'Editing files',

--- a/src/features/DevPanel/RenderGallery/fixtures/codex.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/codex.ts
@@ -69,6 +69,10 @@ export default defineFixtures({
   },
   apiList: [
     {
+      description: 'Show a warning emitted by the Codex runtime.',
+      name: 'error',
+    },
+    {
       description: 'Run a shell command in Codex.',
       name: 'command_execution',
     },
@@ -90,6 +94,15 @@ export default defineFixtures({
     },
   ],
   fixtures: {
+    error: single({
+      args: {
+        id: 'item_0',
+        message:
+          'This session was recorded with model `gpt-5.5` but is resuming with `gpt-5.6-sol`. Consider switching back to the original model.',
+        type: 'error',
+      },
+      content: 'Completed error.',
+    }),
     command_execution: single({
       args: { command: "/bin/zsh -lc 'bun run type-check'" },
       content: 'Checked 1247 files in 2.3s\nNo type errors found.',

--- a/src/features/DevPanel/RenderGallery/fixtures/lobe-user-interaction.ts
+++ b/src/features/DevPanel/RenderGallery/fixtures/lobe-user-interaction.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { defineFixtures, single } from './_helpers';
+import { defineFixtures, variants } from './_helpers';
 
 export default defineFixtures({
   identifier: 'lobe-user-interaction',
@@ -15,37 +15,40 @@ export default defineFixtures({
     },
   ],
   fixtures: {
-    askUserQuestion: single({
-      args: {
-        question: {
-          description:
-            'Help us tailor the next reply. Pick the rendering surface you want previewed.',
-          fields: [
+    askUserQuestion: variants([
+      {
+        args: {
+          questions: [
             {
-              key: 'surface',
-              kind: 'select',
-              label: 'Preview surface',
+              header: 'Direction',
+              multiSelect: true,
               options: [
-                { label: 'Render', value: 'render' },
-                { label: 'Streaming', value: 'streaming' },
-                { label: 'Placeholder', value: 'placeholder' },
-                { label: 'Intervention', value: 'intervention' },
+                { description: 'Focus on the core story', label: 'Evidence pages' },
+                { description: 'Polish the visual system', label: 'Visual direction' },
               ],
-              placeholder: 'Choose one',
-              required: true,
-            },
-            {
-              key: 'note',
-              kind: 'textarea',
-              label: 'Optional note',
-              placeholder: 'Anything to call out about the preview?',
+              question: 'Which area should we explore first?',
             },
           ],
-          id: 'devtools-preview-question',
-          mode: 'form',
-          prompt: 'Which builtin tool surface should we focus the next preview iteration on?',
         },
+        label: 'Single question',
       },
-    }),
+      {
+        args: {
+          questions: [
+            {
+              header: 'Scope',
+              options: [{ description: 'Start with the smallest useful slice', label: 'Focused' }],
+              question: 'How broad should this pass be?',
+            },
+            {
+              header: 'Tone',
+              options: [{ description: 'Keep the interface calm', label: 'Neutral' }],
+              question: 'Which visual tone should we use?',
+            },
+          ],
+        },
+        label: 'Multiple questions',
+      },
+    ]),
   },
 });

--- a/src/store/tool/builtinToolRegistry.test.ts
+++ b/src/store/tool/builtinToolRegistry.test.ts
@@ -7,7 +7,10 @@ import {
 import { GroupAgentBuilderInspectors } from '@lobechat/builtin-tool-group-agent-builder/client';
 import { SkillStoreApiName, SkillStoreIdentifier } from '@lobechat/builtin-tool-skill-store';
 import { SkillStoreInspectors, SkillStoreRenders } from '@lobechat/builtin-tool-skill-store/client';
-import { UserInteractionIdentifier } from '@lobechat/builtin-tool-user-interaction';
+import {
+  UserInteractionApiName,
+  UserInteractionIdentifier,
+} from '@lobechat/builtin-tool-user-interaction';
 import {
   WebOnboardingApiName,
   WebOnboardingIdentifier,
@@ -53,6 +56,10 @@ describe('builtin tool registry', () => {
     expect(getBuiltinRenderDisplayControl(ClaudeCodeToolIdentifier, apiName)).toBe('expand');
   });
 
+  it('registers the Codex error inspector', () => {
+    expect(getBuiltinInspector('codex', 'error')).toBeDefined();
+  });
+
   it('includes user interaction and web onboarding in web onboarding runtime plugins', () => {
     const runtime =
       typeof WEB_ONBOARDING.runtime === 'function'
@@ -62,6 +69,12 @@ describe('builtin tool registry', () => {
     expect(runtime.plugins).toContain(UserInteractionIdentifier);
     expect(runtime.plugins).toContain(WebOnboardingIdentifier);
     expect(runtime.agencyConfig?.executionTarget).toBe('none');
+  });
+
+  it('registers the ask user question inspector', () => {
+    expect(
+      getBuiltinInspector(UserInteractionIdentifier, UserInteractionApiName.askUserQuestion),
+    ).toBeDefined();
   });
 
   it('exposes the marketplace APIs under the web onboarding manifest', () => {


### PR DESCRIPTION
## Summary

- add a dedicated `askUserQuestion` inspector matching the Claude Code summary-chip pattern
- add a Codex `error` inspector with a warning icon and concise message
- register both inspectors and refresh Render Gallery fixtures
- add component and registry coverage plus localized fallback copy

## Verification

- `packages/builtin-tool-user-interaction`: AskUserQuestion Inspector tests (4 passed)
- `packages/builtin-tools`: Codex Error Inspector tests (3 passed)
- builtin tool registry tests (9 passed)
- lint and `git diff --check` passed
- agent-testing report: https://app.lobehub.com/verify/d665616d-cfba-4eaf-a6eb-714062924b89

## Notes

- full type-check remains blocked by the pre-existing `packages/model-runtime/src/core/usageConverters/openai.test.ts` missing `cache_write_tokens` fixture field