### PR TITLE
💄 style(model-bank): add GPT-5.6, Grok 4.5, Sonnet 5, Nano Banana 2 Lite

### DIFF
--- a/packages/locales/src/default/models.ts
+++ b/packages/locales/src/default/models.ts
@@ -10,31 +10,15 @@ LOBE_DEFAULT_MODEL_LIST.forEach((model) => {
 
 // #region LobeHub online model descriptions
 const lobeHubOnlineModelLocales = {
-  'claude-sonnet-5.description':
-    "Claude Sonnet 5 is Anthropic's most agentic Sonnet model, built for sustained coding, tool use, and long-context workflows with Sonnet-tier speed and efficiency.",
-  'dola-seedream-5-0-pro-260628.description':
-    'ByteDance Seedream 5.0 Pro by BytePlus is a high-precision image generation model with precise control over element positioning, supporting text-to-image and single-image editing at 2K resolution.',
   'dreamina-seedance-2-0-260128.description':
     'Seedance 2.0 by ByteDance is the most powerful video generation model, supporting multimodal reference video generation, video editing, video extension, text-to-video, and image-to-video with synchronized audio.',
   'dreamina-seedance-2-0-fast-260128.description':
     'Seedance 2.0 Fast by ByteDance offers the same capabilities as Seedance 2.0 with faster generation speeds at a more competitive price.',
   'fal-ai/bytedance/seedream/v4.5.description':
     'Seedream 4.5, built by ByteDance Seed team, supports multi-image editing and composition. Features enhanced subject consistency, precise instruction following, spatial logic understanding, aesthetic expression, poster layout and logo design with high-precision text-image rendering.',
-  'gemini-3.1-flash-lite-image:image.description':
-    "Gemini 3.1 Flash Lite Image (Nano Banana 2 Lite) is Google's fastest and most cost-efficient image generation model, built for high-volume generation and editing.",
-  'gemini-3.1-flash-lite-image.description':
-    "Gemini 3.1 Flash Lite Image (Nano Banana 2 Lite) is Google's fastest and most cost-efficient image generation model, built for high-volume generation and editing.",
-  'gpt-5.6-luna.description':
-    'GPT-5.6 Luna is optimized for cost-sensitive, high-volume workloads with the lowest price in the GPT-5.6 family.',
-  'gpt-5.6-sol.description':
-    "GPT-5.6 Sol is OpenAI's frontier model for complex reasoning, coding, and long-horizon agentic work. The gpt-5.6 alias routes to Sol.",
-  'gpt-5.6-terra.description':
-    'GPT-5.6 Terra balances intelligence and cost for everyday professional work, competitive with GPT-5.5 at about half the price.',
   'grok-4.20-beta-0309-non-reasoning.description': 'A non-reasoning variant for simple use cases',
   'grok-4.20-beta-0309-reasoning.description':
     'Intelligent, blazing-fast model that reasons before responding',
-  'grok-4.5.description':
-    "SpaceXAI's flagship model for coding, agentic tasks, and knowledge work — configurable reasoning (low/medium/high, always on).",
   'lobehub-glm-5.2-fast.description':
     'Fast variant of GLM-5.2 with substantially lower latency. Same capabilities as GLM-5.2 — costs more, but responds much faster.',
   'seedance-1-5-pro-251215.description':

--- a/packages/model-bank/src/aiModels/anthropic.ts
+++ b/packages/model-bank/src/aiModels/anthropic.ts
@@ -53,6 +53,9 @@ const anthropicChatModels: AIChatModelCard[] = [
     id: 'claude-sonnet-5',
     knowledgeCutoff: '2026-01',
     maxOutput: 128_000,
+    // Introductory pricing, in effect through 2026-08-31. From 2026-09-01 standard rates apply:
+    // input 3 / output 15 / cacheRead 0.3 / cacheWrite 3.75 (per million tokens).
+    // See https://platform.claude.com/docs/en/about-claude/pricing
     pricing: {
       units: [
         { name: 'textInput_cacheRead', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },

--- a/packages/model-bank/src/aiModels/anthropic.ts
+++ b/packages/model-bank/src/aiModels/anthropic.ts
@@ -45,6 +45,40 @@ const anthropicChatModels: AIChatModelCard[] = [
     },
     contextWindowTokens: 1_000_000,
     description:
+      "Claude Sonnet 5 is Anthropic's most agentic Sonnet model, built for sustained coding, tool use, and long-context workflows with Sonnet-tier speed and efficiency.",
+    displayName: 'Claude Sonnet 5',
+    enabled: true,
+    family: 'claude-sonnet',
+    generation: 'claude-5',
+    id: 'claude-sonnet-5',
+    knowledgeCutoff: '2026-01',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 10, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput_cacheWrite', rate: 2.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-06-30',
+    settings: {
+      disabledParams: ['temperature', 'top_p'],
+      extendParams: ['disableContextCaching', 'enableAdaptiveThinking', 'opus47Effort'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_000_000,
+    description:
       "Claude Opus 4.8 is Anthropic's most capable model, building on Opus 4.7 with improvements across reasoning, agentic coding, and tool use.",
     displayName: 'Claude Opus 4.8',
     enabled: true,

--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -208,6 +208,7 @@ const googleChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
+      functionCall: true,
       imageOutput: true,
       reasoning: true,
       vision: true,

--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -1,4 +1,5 @@
 import {
+  nanoBanana2LiteParameters,
   nanoBanana2Parameters,
   nanoBananaParameters,
   nanoBananaProParameters,
@@ -203,6 +204,33 @@ const googleChatModels: AIChatModelCard[] = [
       searchImpl: 'params',
       searchProvider: 'google',
     },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      imageOutput: true,
+      reasoning: true,
+      vision: true,
+    },
+    contextWindowTokens: 65_536 + 4_096,
+    description:
+      "Gemini 3.1 Flash Lite Image (Nano Banana 2 Lite) is Google's fastest and most cost-efficient image generation model, built for high-volume generation and editing.",
+    displayName: 'Nano Banana 2 Lite',
+    enabled: true,
+    family: 'gemini',
+    generation: 'gemini-3.1',
+    id: 'gemini-3.1-flash-lite-image',
+    maxOutput: 4_096,
+    pricing: {
+      approximatePricePerImage: 0.034,
+      units: [
+        { name: 'imageOutput', rate: 30, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-06-30',
     type: 'chat',
   },
   {
@@ -820,6 +848,25 @@ const googleImageModels: AIImageModelCard[] = [
       units: [
         { name: 'imageOutput', rate: 60, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+  },
+  {
+    displayName: 'Nano Banana 2 Lite',
+    id: 'gemini-3.1-flash-lite-image:image',
+    type: 'image',
+    enabled: true,
+    description:
+      "Gemini 3.1 Flash Lite Image (Nano Banana 2 Lite) is Google's fastest and most cost-efficient image generation model, built for high-volume generation and editing.",
+    releasedAt: '2026-06-30',
+    parameters: nanoBanana2LiteParameters,
+    pricing: {
+      approximatePricePerImage: 0.034,
+      units: [
+        { name: 'imageOutput', rate: 30, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'imageInput', rate: 0.25, strategy: 'fixed', unit: 'millionTokens' },
         { name: 'textOutput', rate: 1.5, strategy: 'fixed', unit: 'millionTokens' },
       ],
     },

--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -208,7 +208,8 @@ const googleChatModels: AIChatModelCard[] = [
   },
   {
     abilities: {
-      functionCall: true,
+      // no functionCall: the runtime always requests ['Text', 'Image'] modalities for
+      // nano-banana models, and Vertex AI rejects function declarations in that mode
       imageOutput: true,
       reasoning: true,
       vision: true,

--- a/packages/model-bank/src/aiModels/google.ts
+++ b/packages/model-bank/src/aiModels/google.ts
@@ -220,6 +220,7 @@ const googleChatModels: AIChatModelCard[] = [
     family: 'gemini',
     generation: 'gemini-3.1',
     id: 'gemini-3.1-flash-lite-image',
+    knowledgeCutoff: '2025-01',
     maxOutput: 4_096,
     pricing: {
       approximatePricePerImage: 0.034,
@@ -231,6 +232,10 @@ const googleChatModels: AIChatModelCard[] = [
       ],
     },
     releasedAt: '2026-06-30',
+    settings: {
+      // no imageResolution2: output resolution is fixed at 1K for the Lite model
+      extendParams: ['imageAspectRatio2'],
+    },
     type: 'chat',
   },
   {

--- a/packages/model-bank/src/aiModels/openai.ts
+++ b/packages/model-bank/src/aiModels/openai.ts
@@ -45,6 +45,201 @@ export const openaiChatModels: AIChatModelCard[] = [
       vision: true,
     },
     contextWindowTokens: 1_050_000,
+    description:
+      "GPT-5.6 Sol is OpenAI's frontier model for complex reasoning, coding, and long-horizon agentic work. The gpt-5.6 alias routes to Sol.",
+    displayName: 'GPT-5.6 Sol',
+    enabled: true,
+    family: 'gpt',
+    generation: 'gpt-5.6',
+    id: 'gpt-5.6-sol',
+    knowledgeCutoff: '2026-02',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        {
+          name: 'textInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 5, upTo: 272_000 },
+            { rate: 10, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.5, upTo: 272_000 },
+            { rate: 1, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput_cacheWrite',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 6.25, upTo: 272_000 },
+            { rate: 12.5, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textOutput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 30, upTo: 272_000 },
+            { rate: 45, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-07-09',
+    settings: {
+      extendParams: ['reasoningMode', 'gpt5_6ReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_050_000,
+    description:
+      'GPT-5.6 Terra balances intelligence and cost for everyday professional work, competitive with GPT-5.5 at about half the price.',
+    displayName: 'GPT-5.6 Terra',
+    enabled: true,
+    family: 'gpt',
+    generation: 'gpt-5.6',
+    id: 'gpt-5.6-terra',
+    knowledgeCutoff: '2026-02',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        {
+          name: 'textInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 2.5, upTo: 272_000 },
+            { rate: 5, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.25, upTo: 272_000 },
+            { rate: 0.5, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput_cacheWrite',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 3.125, upTo: 272_000 },
+            { rate: 6.25, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textOutput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 15, upTo: 272_000 },
+            { rate: 22.5, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-07-09',
+    settings: {
+      extendParams: ['reasoningMode', 'gpt5_6ReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_050_000,
+    description:
+      'GPT-5.6 Luna is optimized for cost-sensitive, high-volume workloads with the lowest price in the GPT-5.6 family.',
+    displayName: 'GPT-5.6 Luna',
+    enabled: true,
+    family: 'gpt',
+    generation: 'gpt-5.6',
+    id: 'gpt-5.6-luna',
+    knowledgeCutoff: '2026-02',
+    maxOutput: 128_000,
+    pricing: {
+      units: [
+        {
+          name: 'textInput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 1, upTo: 272_000 },
+            { rate: 2, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput_cacheRead',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 0.1, upTo: 272_000 },
+            { rate: 0.2, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textInput_cacheWrite',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 1.25, upTo: 272_000 },
+            { rate: 2.5, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+        {
+          name: 'textOutput',
+          strategy: 'tiered',
+          tiers: [
+            { rate: 6, upTo: 272_000 },
+            { rate: 9, upTo: 'infinity' },
+          ],
+          unit: 'millionTokens',
+        },
+      ],
+    },
+    releasedAt: '2026-07-09',
+    settings: {
+      extendParams: ['reasoningMode', 'gpt5_6ReasoningEffort', 'textVerbosity'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
+      reasoning: true,
+      search: true,
+      structuredOutput: true,
+      vision: true,
+    },
+    contextWindowTokens: 1_050_000,
     description: 'GPT-5.5 is our newest frontier model for the most complex professional work.',
     displayName: 'GPT-5.5',
     enabled: true,

--- a/packages/model-bank/src/aiModels/xai.ts
+++ b/packages/model-bank/src/aiModels/xai.ts
@@ -5,6 +5,35 @@ const xaiChatModels: AIChatModelCard[] = [
   {
     abilities: {
       functionCall: true,
+      reasoning: true,
+      search: true,
+      vision: true,
+    },
+    contextWindowTokens: 500_000,
+    description:
+      "SpaceXAI's flagship model for coding, agentic tasks, and knowledge work — configurable reasoning (low/medium/high, always on).",
+    displayName: 'Grok 4.5',
+    enabled: true,
+    family: 'grok',
+    generation: 'grok-4.5',
+    id: 'grok-4.5',
+    pricing: {
+      units: [
+        { name: 'textInput_cacheRead', rate: 0.5, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textInput', rate: 2, strategy: 'fixed', unit: 'millionTokens' },
+        { name: 'textOutput', rate: 6, strategy: 'fixed', unit: 'millionTokens' },
+      ],
+    },
+    releasedAt: '2026-07-08',
+    settings: {
+      extendParams: ['grok4_5ReasoningEffort'],
+      searchImpl: 'params',
+    },
+    type: 'chat',
+  },
+  {
+    abilities: {
+      functionCall: true,
       search: true,
       structuredOutput: true,
       vision: true,

--- a/packages/model-bank/src/aiModels/xai.ts
+++ b/packages/model-bank/src/aiModels/xai.ts
@@ -7,6 +7,7 @@ const xaiChatModels: AIChatModelCard[] = [
       functionCall: true,
       reasoning: true,
       search: true,
+      structuredOutput: true,
       vision: true,
     },
     contextWindowTokens: 500_000,

--- a/packages/model-bank/src/aiModels/xai.ts
+++ b/packages/model-bank/src/aiModels/xai.ts
@@ -52,7 +52,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput_cacheRead',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.2, upTo: 0.2 },
+            { rate: 0.2, upTo: 200_000 },
             { rate: 0.4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -61,7 +61,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput',
           strategy: 'tiered',
           tiers: [
-            { rate: 1.25, upTo: 0.2 },
+            { rate: 1.25, upTo: 200_000 },
             { rate: 2.5, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -70,7 +70,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textOutput',
           strategy: 'tiered',
           tiers: [
-            { rate: 2.5, upTo: 0.2 },
+            { rate: 2.5, upTo: 200_000 },
             { rate: 5, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -104,7 +104,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput_cacheRead',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.2, upTo: 0.2 },
+            { rate: 0.2, upTo: 200_000 },
             { rate: 0.4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -113,7 +113,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput',
           strategy: 'tiered',
           tiers: [
-            { rate: 1.25, upTo: 0.2 },
+            { rate: 1.25, upTo: 200_000 },
             { rate: 2.5, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -122,7 +122,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textOutput',
           strategy: 'tiered',
           tiers: [
-            { rate: 2.5, upTo: 0.2 },
+            { rate: 2.5, upTo: 200_000 },
             { rate: 5, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -156,7 +156,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput_cacheRead',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.2, upTo: 0.2 },
+            { rate: 0.2, upTo: 200_000 },
             { rate: 0.4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -165,7 +165,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput',
           strategy: 'tiered',
           tiers: [
-            { rate: 1.25, upTo: 0.2 },
+            { rate: 1.25, upTo: 200_000 },
             { rate: 2.5, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -174,7 +174,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textOutput',
           strategy: 'tiered',
           tiers: [
-            { rate: 2.5, upTo: 0.2 },
+            { rate: 2.5, upTo: 200_000 },
             { rate: 5, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -208,7 +208,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput_cacheRead',
           strategy: 'tiered',
           tiers: [
-            { rate: 0.2, upTo: 0.2 },
+            { rate: 0.2, upTo: 200_000 },
             { rate: 0.4, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -217,7 +217,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textInput',
           strategy: 'tiered',
           tiers: [
-            { rate: 1.25, upTo: 0.2 },
+            { rate: 1.25, upTo: 200_000 },
             { rate: 2.5, upTo: 'infinity' },
           ],
           unit: 'millionTokens',
@@ -226,7 +226,7 @@ const xaiChatModels: AIChatModelCard[] = [
           name: 'textOutput',
           strategy: 'tiered',
           tiers: [
-            { rate: 2.5, upTo: 0.2 },
+            { rate: 2.5, upTo: 200_000 },
             { rate: 5, upTo: 'infinity' },
           ],
           unit: 'millionTokens',

--- a/packages/model-bank/src/const/imageParameters.ts
+++ b/packages/model-bank/src/const/imageParameters.ts
@@ -69,6 +69,18 @@ export const nanoBananaProParameters: ModelParamsSchema = {
   },
 };
 
+// Nano Banana 2 Lite has no resolution control (fixed 1K output)
+export const nanoBanana2LiteParameters: ModelParamsSchema = {
+  aspectRatio: {
+    default: 'auto',
+    enum: NANO_BANANA_2_ASPECT_RATIOS,
+  },
+  imageUrls: {
+    default: [],
+  },
+  prompt: { default: '' },
+};
+
 export const nanoBanana2Parameters: ModelParamsSchema = {
   aspectRatio: {
     default: 'auto',


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔗 Related Issue

Related to #16957 (GPT-5.6 runtime support), #16921 (Grok 4.5 reasoning effort extend param)

#### 🔀 Description of Change

Add recently launched models to their self-hosted provider cards in `model-bank`:

- **OpenAI**: `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` — tiered pricing with the 272k threshold, including the new `textInput_cacheWrite` unit (runtime support landed in #16957)
- **xAI**: `grok-4.5` — always-on reasoning with `grok4_5ReasoningEffort` (extend param landed in #16921)
- **Anthropic**: `claude-sonnet-5` (Claude Fable 5 already exists)
- **Google**: `gemini-3.1-flash-lite-image` (Nano Banana 2 Lite) as both a chat card and a `:image` generation card, with a new `nanoBanana2LiteParameters` schema (no resolution control, fixed 1K output)

Also fixes a pre-existing bug in `xai.ts`: the grok-4.3 / grok-4.20 tiered pricing used `upTo: 0.2` where the runtime (`computeChatCost`) compares `upTo` against raw input token counts, so every request was priced at the higher tier. Now `upTo: 200_000`, matching the convention in `azure.ts` / `google.ts` and the production billing config.

Also cleans up `packages/locales/src/default/models.ts`: descriptions for these models move out of the LobeHub online-only block since they are now auto-generated from `LOBE_DEFAULT_MODEL_LIST`, and drops a stale entry for a delisted model (`dola-seedream-5-0-pro-260628`).

#### 🧪 How to Test

- [x] Tested locally
- [x] No tests needed

- `bunx vitest run src/aiModels/__tests__/index.test.ts src/const/__tests__/knowledgeCutoff.test.ts src/exports.test.ts` in `packages/model-bank` — 33 passed
- `tsc --noEmit` in `packages/model-bank` — clean

#### 📝 Additional Information

- Claude Sonnet 5's direct-API card includes `search` / `structuredOutput` / `searchImpl: 'params'` to match sibling Anthropic cards, even though some hosted routing channels don't expose built-in search.
- Ability flags were verified against the official model pages AND the provider runtime: Grok 4.5 sets `structuredOutput` (xAI docs list it). Nano Banana 2 Lite omits `functionCall` even though Google docs list it — the runtime always requests `['Text', 'Image']` modalities for nano-banana models and Vertex AI rejects function declarations in that mode (matching the sibling Nano Banana cards). It also omits search grounding / structured outputs / resolution extend params (Not supported, fixed 1K output).
- Existing models' `enabled` flags are untouched — additions only.


