### PR TITLE
✨ feat: support disabling builtin tools

### DIFF
--- a/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/__tests__/index.test.ts
@@ -296,6 +296,27 @@ describe('createServerAgentToolsEngine', () => {
     expect(lobeAgent?.api.map((a) => a.name)).toContain(LobeAgentApiName.callSubAgent);
   });
 
+  it('should honor an explicit disabled policy for an always-on builtin tool', () => {
+    const context = createMockContext();
+    const engine = createServerAgentToolsEngine(context, {
+      agentConfig: { plugins: [] },
+      disabledPluginIds: [LobeAgentManifest.identifier],
+      model: 'deepseek-chat',
+      provider: 'deepseek',
+    });
+
+    const result = engine.generateToolsDetailed({
+      model: 'deepseek-chat',
+      provider: 'deepseek',
+      toolIds: [],
+    });
+
+    expect(result.enabledToolIds).not.toContain(LobeAgentManifest.identifier);
+    expect(result.enabledManifests).not.toContainEqual(
+      expect.objectContaining({ identifier: LobeAgentManifest.identifier }),
+    );
+  });
+
   it('hides lobe-agent callSubAgent when manifestContext.isSubAgent is true', () => {
     const context = createMockContext();
     const engine = createServerAgentToolsEngine(context, {

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/index.ts
@@ -154,6 +154,7 @@ export const createServerAgentToolsEngine = (
     canUseDevice = false,
     deviceContext,
     disableLocalSystem = false,
+    disabledPluginIds = [],
     executionPlan,
     globalMemoryEnabled = false,
     hasEnabledKnowledgeBases = false,
@@ -282,6 +283,13 @@ export const createServerAgentToolsEngine = (
     [WebBrowsingManifest.identifier]: isSearchEnabled,
   };
 
+  const excludedIdentifiers = new Set(disabledPluginIds);
+  if (!canUseDevice) {
+    for (const identifier of DEVICE_TOOL_IDENTIFIERS) excludedIdentifiers.add(identifier);
+  } else if (deviceLocked) {
+    for (const identifier of REMOTE_DEVICE_TOOL_IDENTIFIERS) excludedIdentifiers.add(identifier);
+  }
+
   return createServerToolsEngine(context, {
     // Pass additional manifests (e.g., LobeHub Skills)
     additionalManifests,
@@ -309,11 +317,7 @@ export const createServerAgentToolsEngine = (
     // resolve them regardless of which manifest source declared them.
     // Locked turns exclude the remote-device picker only (local-system
     // stays for the routed device).
-    excludeIdentifiers: canUseDevice
-      ? deviceLocked
-        ? REMOTE_DEVICE_TOOL_IDENTIFIERS
-        : undefined
-      : DEVICE_TOOL_IDENTIFIERS,
+    excludeIdentifiers: excludedIdentifiers.size > 0 ? excludedIdentifiers : undefined,
     // Conversation context for context-aware builtin manifests (scope /
     // isSubAgent), e.g. hiding lobe-agent's callSubAgent in sub-agent / group runs.
     manifestContext,

--- a/apps/server/src/modules/Mecha/AgentToolsEngine/types.ts
+++ b/apps/server/src/modules/Mecha/AgentToolsEngine/types.ts
@@ -104,6 +104,8 @@ export interface ServerCreateAgentToolsEngineParams {
     deviceOnline?: boolean;
     gatewayConfigured: boolean;
   };
+  /** Plugin and builtin identifiers explicitly disabled in the agent configuration. */
+  disabledPluginIds?: string[];
   /** Whether to suppress the local-system builtin while preserving other tools. */
   disableLocalSystem?: boolean;
   /**

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.pluginTriState.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.pluginTriState.test.ts
@@ -152,6 +152,9 @@ const installedPluginsArg = () =>
 const agentConfigPluginsArg = () =>
   mockCreateServerAgentToolsEngine.mock.calls[0][1].agentConfig.plugins as string[];
 
+const disabledPluginIdsArg = () =>
+  mockCreateServerAgentToolsEngine.mock.calls[0][1].disabledPluginIds as string[];
+
 const toolManifestMapArg = () =>
   mockCreateOperation.mock.calls[0][0].toolSet.manifestMap as Record<string, unknown>;
 
@@ -210,6 +213,7 @@ describe('AiAgentService.execAgent - three-state plugin config (pinned/auto/disa
     await service.execAgent({ agentId: 'agent-1', prompt: 'Hello' } as any);
 
     expect(agentConfigPluginsArg()).toEqual(['plugin-a']);
+    expect(disabledPluginIdsArg()).toEqual(['plugin-b']);
   });
 
   it('behaves identically to a pure string array when no entry is disabled', async () => {

--- a/apps/server/src/services/aiAgent/__tests__/execAgent.pluginTriState.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execAgent.pluginTriState.test.ts
@@ -257,4 +257,19 @@ describe('AiAgentService.execAgent - three-state plugin config (pinned/auto/disa
     expect(toolManifestMapArg()).not.toHaveProperty('composio-disabled');
     expect(toolManifestMapArg()).not.toHaveProperty('skill-disabled');
   });
+
+  it('excludes a disabled builtin from the activator-discovery toolManifestMap', async () => {
+    mockGetAgentConfig.mockResolvedValue({
+      chatConfig: {},
+      id: 'agent-1',
+      model: 'gpt-4',
+      plugins: [{ identifier: 'lobe-agent', mode: 'disabled' }],
+      provider: 'openai',
+      systemRole: 'You are a helper',
+    });
+
+    await service.execAgent({ agentId: 'agent-1', prompt: 'Hello' } as any);
+
+    expect(toolManifestMapArg()).not.toHaveProperty('lobe-agent');
+  });
 });

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -2690,6 +2690,7 @@ export class AiAgentService {
             }
           : undefined,
         disableLocalSystem,
+        disabledPluginIds,
         executionPlan,
         globalMemoryEnabled,
         hasEnabledKnowledgeBases,

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -2758,6 +2758,7 @@ export class AiAgentService {
       // Enforced here (not as a point deletion after the seed) so the later
       // Skill/Composio ingest loops cannot re-add the identifier.
       const isManifestIngestAllowed = (identifier: string): boolean => {
+        if (disabledPluginIdSet.has(identifier)) return false;
         if (!canUseDevice && isDeviceToolIdentifier(identifier)) return false;
         if (deviceLocked && REMOTE_DEVICE_TOOL_IDENTIFIERS.has(identifier)) return false;
         return true;
@@ -2803,6 +2804,7 @@ export class AiAgentService {
         delete toolManifestMap[LocalSystemManifest.identifier];
       }
       for (const tool of allowedBuiltinTools) {
+        if (!isManifestIngestAllowed(tool.identifier)) continue;
         // lobe-cloud-sandbox is only activator-discoverable when runtimeMode resolves
         // to 'cloud' (i.e. executionTarget='sandbox').
         if (tool.identifier === CloudSandboxManifest.identifier && agentRuntimeMode !== 'cloud')
@@ -2823,6 +2825,7 @@ export class AiAgentService {
       // separate `canUseDevice` check is needed here.)
       if (
         !disableLocalSystem &&
+        isManifestIngestAllowed(LocalSystemManifest.identifier) &&
         gatewayConfigured &&
         agentRuntimeMode === 'local' &&
         !toolManifestMap[LocalSystemManifest.identifier]

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -1064,7 +1064,7 @@
   "tab.usage": "用量",
   "tools.activation.auto": "自动",
   "tools.activation.auto.desc": "智能调用",
-  "tools.activation.disabled": "已禁用",
+  "tools.activation.disabled": "禁用",
   "tools.activation.disabled.desc": "不会启用",
   "tools.activation.fixed.hint": "由应用强制开启，始终可用，无法关闭",
   "tools.activation.pinned": "固定启用",

--- a/packages/builtin-tools/src/index.ts
+++ b/packages/builtin-tools/src/index.ts
@@ -65,9 +65,9 @@ export const defaultToolIds = [
  * skill-activate mode the discovery tools in `manualModeExcludeToolIds` are still removed
  * from the defaults before the enable checker runs, so they end up disabled there.
  *
- * This list is also the source for the chat-input Tools popover's read-only "Pinned"
- * section (`builtinToolSelectors.fixedDisplayMetaList`), so users can see what the app
- * keeps active — that selector applies the same manual-mode exclusion to stay truthful.
+ * This list is also the source for builtin entries in the chat-input Tools popover.
+ * They default to pinned but can be explicitly disabled per agent; entries represented by
+ * the activation mode control itself are excluded from that menu.
  */
 export const alwaysOnToolIds = [
   LobeAgentManifest.identifier,
@@ -75,6 +75,12 @@ export const alwaysOnToolIds = [
   SkillsManifest.identifier,
   SkillStoreManifest.identifier,
 ];
+
+/**
+ * Runtime tools represented by the skill activation mode control itself. They remain part
+ * of the engine defaults but should not appear as independently configurable tool rows.
+ */
+export const activationModeControlledToolIds = [LobeActivatorManifest.identifier];
 
 /**
  * Tool IDs to exclude from defaults when in manual skill-activate mode.

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -332,12 +332,33 @@ const styles = createStaticStyles(({ css }) => ({
 
     width: 100%;
     min-width: 0;
+
+    &:hover [data-tool-trailing],
+    &:focus-within [data-tool-trailing] {
+      pointer-events: auto;
+      opacity: 1;
+    }
   `,
   toolTrailing: css`
+    pointer-events: none;
+
     display: inline-flex;
     flex: none;
     gap: 8px;
     align-items: center;
+
+    opacity: 0;
+
+    transition: opacity 150ms ${cssVar.motionEaseOut};
+
+    @media (hover: none) {
+      pointer-events: auto;
+      opacity: 1;
+    }
+  `,
+  toolTrailingVisible: css`
+    pointer-events: auto;
+    opacity: 1;
   `,
   typeTag: css`
     display: inline-flex;
@@ -694,13 +715,16 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
           <span className={cx(styles.toolLabelText)}>{label}</span>
           {extraTag}
         </span>
-        <span className={cx(styles.toolTrailing)}>
+        <span
+          data-tool-trailing
+          className={cx(styles.toolTrailing, policyOpenId === id && styles.toolTrailingVisible)}
+        >
           {badge && <span className={cx(styles.typeTag)}>{badge}</span>}
           {action}
         </span>
       </span>
     ),
-    [openSkillPolicyMenu],
+    [openSkillPolicyMenu, policyOpenId],
   );
 
   const createManagedSkillItem = useCallback(

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -1621,7 +1621,7 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
             key: 'auto',
             label: renderActivationGroupLabel({
               autoSwitch: true,
-              count: fixedDisabledItems.length + allAutoItems.length,
+              count: allAutoItems.length,
               icon: <Icon icon={Zap} size={14} />,
               open: autoOpen,
               title: t('tools.activation.auto'),
@@ -2015,7 +2015,7 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
   );
 
   return {
-    autoCount: allAutoItems.length + fixedDisabledItems.length,
+    autoCount: allAutoItems.length,
     editPluginDrawer,
     installedPluginItems,
     marketFooter,

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -1093,7 +1093,6 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
 
         return createManagedSkillItem({
           badge: <Icon icon={Wrench} size={12} />,
-          defaultMode: 'pinned',
           deleteConfig: {
             displayName: title,
             onDelete: () => uninstallBuiltinTool(item.identifier),

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -1093,6 +1093,7 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
 
         return createManagedSkillItem({
           badge: <Icon icon={Wrench} size={12} />,
+          defaultMode: 'pinned',
           deleteConfig: {
             displayName: title,
             onDelete: () => uninstallBuiltinTool(item.identifier),
@@ -1620,7 +1621,7 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
             key: 'auto',
             label: renderActivationGroupLabel({
               autoSwitch: true,
-              count: allAutoItems.length,
+              count: fixedDisabledItems.length + allAutoItems.length,
               icon: <Icon icon={Zap} size={14} />,
               open: autoOpen,
               title: t('tools.activation.auto'),
@@ -2014,7 +2015,7 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
   );
 
   return {
-    autoCount: allAutoItems.length,
+    autoCount: allAutoItems.length + fixedDisabledItems.length,
     editPluginDrawer,
     installedPluginItems,
     marketFooter,

--- a/src/helpers/toolEngineering/index.test.ts
+++ b/src/helpers/toolEngineering/index.test.ts
@@ -289,6 +289,23 @@ describe('toolEngineering', () => {
       expect(result.enabledToolIds).toContain('lobe-agent');
     });
 
+    it('should honor an explicit disabled policy for an always-on builtin tool', () => {
+      mockCurrentAgentDisabledPlugins = ['lobe-agent'];
+
+      const toolsEngine = createAgentToolsEngine({
+        model: 'deepseek-chat',
+        provider: 'deepseek',
+      });
+
+      const result = toolsEngine.generateToolsDetailed({
+        model: 'deepseek-chat',
+        provider: 'deepseek',
+        toolIds: [],
+      });
+
+      expect(result.enabledToolIds).not.toContain('lobe-agent');
+    });
+
     it('should use chat-mode defaults when the model does not support function calling', () => {
       mockIsCanUseFC = false;
 

--- a/src/store/tool/slices/builtin/selectors.test.ts
+++ b/src/store/tool/slices/builtin/selectors.test.ts
@@ -153,6 +153,7 @@ describe('builtinToolSelectors', () => {
 
       // Only fixed-display ids are returned; lobe-agent leads the list, unrelated tools excluded.
       expect(result.map((item) => item.identifier)).toContain('lobe-agent');
+      expect(result.map((item) => item.identifier)).not.toContain('lobe-activator');
       expect(result.map((item) => item.identifier)).not.toContain('tool-1');
       expect(result[0].identifier).toBe('lobe-agent');
     });

--- a/src/store/tool/slices/builtin/selectors.ts
+++ b/src/store/tool/slices/builtin/selectors.ts
@@ -1,4 +1,5 @@
 import {
+  activationModeControlledToolIds,
   alwaysOnToolIds,
   manualModeExcludeToolIds,
   runtimeManagedToolIds,
@@ -179,7 +180,12 @@ const allMetaList = (s: ToolStoreState): LobeToolMetaWithAvailability[] => {
     .agentSkillMetaList(s)
     .map((meta) => ({ ...meta, availableInWeb: true }));
 
-  return [...skillMetas, ...agentSkillMetas, ...builtinMetas, ...getComposioMetasWithAvailability(s)];
+  return [
+    ...skillMetas,
+    ...agentSkillMetas,
+    ...builtinMetas,
+    ...getComposioMetasWithAvailability(s),
+  ];
 };
 
 /**
@@ -232,10 +238,11 @@ const installedAllMetaList = (s: ToolStoreState): LobeToolMetaWithAvailability[]
 };
 
 const MANUAL_MODE_EXCLUDE_TOOL_IDS = new Set(manualModeExcludeToolIds);
+const ACTIVATION_MODE_CONTROLLED_TOOL_IDS = new Set(activationModeControlledToolIds);
 
 /**
- * Get meta for the application-fixed tools (always-on, not user-controllable) that should
- * be shown read-only in the chat-input Tools popover's "Pinned" section.
+ * Get meta for builtin runtime tools that default to pinned and should be shown in the
+ * chat-input Tools popover. Their per-agent policy supports pinned or disabled.
  *
  * These tools are normally `hidden` (and some are `discoverable: false`), so they never
  * appear in `metaList` / `metaListIncludingHidden`. Here we read them directly from
@@ -251,6 +258,7 @@ const fixedDisplayMetaList =
   ({ isManualMode }: { isManualMode: boolean } = { isManualMode: false }) =>
   (s: ToolStoreState): LobeToolMeta[] =>
     alwaysOnToolIds
+      .filter((id) => !ACTIVATION_MODE_CONTROLLED_TOOL_IDS.has(id))
       .filter((id) => !(isManualMode && MANUAL_MODE_EXCLUDE_TOOL_IDS.has(id)))
       .map((id) => s.builtinTools.find((tool) => tool.identifier === id))
       .filter((tool): tool is ToolStoreState['builtinTools'][number] => !!tool)


### PR DESCRIPTION
## Summary

- allow builtin runtime tools and skills to switch between pinned and disabled
- keep the auto activation option unavailable for builtin entries
- hide the tool/skill activator from the pinned list because it is controlled by the Auto switch
- update the Chinese disabled action label from “已禁用” to “禁用”

## Test plan

- `bun run check packages/builtin-tools/src/index.ts src/store/tool/slices/builtin/selectors.ts src/store/tool/slices/builtin/selectors.test.ts`
- `bun run check src/features/ChatInput/ActionBar/Tools/useControls.tsx src/helpers/toolEngineering/index.test.ts`