### PR TITLE
🌐 (i18n): remove Chinese Trans fallback children

### DIFF
--- a/src/features/DataImporter/Error.tsx
+++ b/src/features/DataImporter/Error.tsx
@@ -39,22 +39,24 @@ const Error = memo<ErrorProps>(({ error, onClick }) => {
       }
       subTitle={
         <Balancer>
-          <Trans i18nKey="importModal.error.desc" ns={'common'}>
-            非常抱歉，数据库升级过程发生异常。请重试升级，或
-            <a
-              aria-label={'issue'}
-              href={GITHUB_ISSUES}
-              rel="noreferrer"
-              target="_blank"
-              onClick={(e) => {
-                e.preventDefault();
-                githubService.submitImportError(error!);
-              }}
-            >
-              提交问题
-            </a>
-            我们将会第一时间帮你排查问题。
-          </Trans>
+          <Trans
+            i18nKey="importModal.error.desc"
+            ns={'common'}
+            components={[
+              <span key="0" />,
+              <a
+                aria-label={'issue'}
+                href={GITHUB_ISSUES}
+                key="1"
+                rel="noreferrer"
+                target="_blank"
+                onClick={(e) => {
+                  e.preventDefault();
+                  githubService.submitImportError(error!);
+                }}
+              />,
+            ]}
+          />
         </Balancer>
       }
     />

--- a/src/features/FileViewer/NotSupport/index.tsx
+++ b/src/features/FileViewer/NotSupport/index.tsx
@@ -35,17 +35,20 @@ const NotSupport: ComponentType<NotSupportProps> = ({ fileName, url, style }) =>
         <Flexbox align={'center'} gap={12}>
           <FluentEmoji emoji={'👀'} size={64} />
           <Flexbox style={{ textAlign: 'center' }}>
-            <Trans i18nKey="preview.unsupportedFileAndContact" ns={'file'}>
-              此文件格式暂不支持在线预览，如有预览诉求，欢迎
-              <a
-                aria-label={'todo'}
-                href={MORE_FILE_PREVIEW_REQUEST_URL}
-                rel="noreferrer"
-                target="_blank"
-              >
-                反馈给我们
-              </a>
-            </Trans>
+            <Trans
+              i18nKey="preview.unsupportedFileAndContact"
+              ns={'file'}
+              components={[
+                <span key="0" />,
+                <a
+                  aria-label={'todo'}
+                  href={MORE_FILE_PREVIEW_REQUEST_URL}
+                  key="1"
+                  rel="noreferrer"
+                  target="_blank"
+                />,
+              ]}
+            />
           </Flexbox>
           {url && (
             <Button


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #16485

#### 🔀 Description of Change

Removes inline Chinese fallback text from the data-import error and unsupported-file views. Both Trans components now use the existing locale keys with indexed components, preserving their links and click behavior. The other two files named in the issue contain Chinese comments only and already render localized UI.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validation:
- bun run check on both changed files
- bun run check --type
- verified en-US and zh-CN interpolation for both existing locale keys

#### 📸 Screenshots / Videos

No visual layout change; rendered translations remain the same.

#### 📝 Additional Information

No locale keys or generated translation files were added because the required en-US and zh-CN entries already exist.