### PR TITLE
🐛 fix(chat): prevent mobile input auto-zoom

### DIFF
--- a/src/features/ChatInput/InputEditor/index.test.tsx
+++ b/src/features/ChatInput/InputEditor/index.test.tsx
@@ -7,6 +7,10 @@ const permission = vi.hoisted(() => ({
   allowed: false,
 }));
 
+const platform = vi.hoisted(() => ({
+  isMobile: false,
+}));
+
 const mocks = vi.hoisted(() => {
   const chatInputState = {
     clearInputCompletionError: vi.fn(() => {
@@ -60,6 +64,16 @@ const getAutoCompleteProps = async (): Promise<AutoCompleteProps> => {
   expect(autoCompleteProps).toBeDefined();
 
   return autoCompleteProps!;
+};
+
+const getEditorStyle = async () => {
+  const { Editor } = await import('@lobehub/editor/react');
+  const props = vi.mocked(Editor).mock.lastCall?.[0] as
+    { style?: { fontSize?: number } } | undefined;
+
+  expect(props).toBeDefined();
+
+  return props!.style;
 };
 
 vi.mock('@lobechat/const', () => ({
@@ -148,6 +162,10 @@ vi.mock('@/store/chat', () => ({
     getState: () => ({ activeTopicId: undefined }),
   }),
 }));
+vi.mock('@/store/serverConfig', () => ({
+  useServerConfigStore: <T,>(selector: StoreSelector<T>) =>
+    selector({ isMobile: platform.isMobile }),
+}));
 vi.mock('../hooks/useChatInputDraft', () => ({
   useChatInputDraft: () => ({ restoreDraft: vi.fn(), saveDraftDebounced: vi.fn() }),
 }));
@@ -229,6 +247,7 @@ describe('ChatInput InputEditor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     permission.allowed = false;
+    platform.isMobile = false;
     mocks.inputCompletionConfig.enabled = false;
     mocks.inputCompletionConfig.model = 'gpt-4o-mini';
     mocks.inputCompletionConfig.provider = 'openai';
@@ -247,6 +266,23 @@ describe('ChatInput InputEditor', () => {
     render(<InputEditor />);
 
     expect(screen.getByTestId('mock-editor')).toHaveAttribute('data-editable', 'false');
+  });
+
+  it('renders the editor at 16px on mobile', async () => {
+    permission.allowed = true;
+    platform.isMobile = true;
+
+    render(<InputEditor />);
+
+    expect((await getEditorStyle())?.fontSize).toBe(16);
+  });
+
+  it('keeps the editor font size unchanged on desktop', async () => {
+    permission.allowed = true;
+
+    render(<InputEditor />);
+
+    expect((await getEditorStyle())?.fontSize).toBeUndefined();
   });
 
   it('pauses autocomplete after a non-abort generation error', async () => {

--- a/src/features/ChatInput/InputEditor/index.tsx
+++ b/src/features/ChatInput/InputEditor/index.tsx
@@ -26,6 +26,7 @@ import { aiChatService } from '@/services/aiChat';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useChatStore } from '@/store/chat';
+import { useServerConfigStore } from '@/store/serverConfig';
 import { useUserStore } from '@/store/user';
 import {
   labPreferSelectors,
@@ -79,6 +80,7 @@ const InputEditor = memo<{
   placeholderVariant?: PlaceholderVariant;
 }>(({ defaultRows = 2, placeholder, placeholderVariant }) => {
   const { t } = useTranslation('chat');
+  const mobile = useServerConfigStore((s) => s.isMobile);
   const [
     editor,
     slashMenuRef,
@@ -560,6 +562,7 @@ const InputEditor = memo<{
           )
         }
         style={{
+          fontSize: mobile ? 16 : undefined,
           minHeight: defaultRows > 1 ? defaultRows * 23 : undefined,
         }}
         onCompositionEnd={({ event }) => compositionProps.onCompositionEnd(event)}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Closes #16340

#### 🔀 Description of Change

The chat variant of `@lobehub/editor` defaults to `14px`. On iOS, focusing that contenteditable can trigger viewport auto-zoom and make the chat input margins appear to disappear.

This sets the shared chat editor root to `16px` when the server-provided mobile flag is active. That flag is stable across portrait and landscape rotation. Desktop keeps the existing editor font size, and user pinch-zoom remains enabled.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- `bun run check src/features/ChatInput/InputEditor/index.tsx src/features/ChatInput/InputEditor/index.test.tsx`
- `bun run type-check`
- Verified the real editor DOM computes to `16px` at an iPhone viewport and remains `14px` on desktop

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| Focusable editor inherits `14px`; iOS may auto-zoom | Mobile editor uses `16px`; desktop remains unchanged |

#### 📝 Additional Information

No restrictive viewport settings were added. A physical iOS smoke test is still recommended for the keyboard and visual viewport behavior.
