### PR TITLE
💄 style: unify task/topic execution status icons into a shared visual source

### DIFF
--- a/src/components/ExecutionStatus.ts
+++ b/src/components/ExecutionStatus.ts
@@ -1,0 +1,81 @@
+import type { ChatTopicStatus, TaskStatus } from '@lobechat/types';
+import { cssVar } from 'antd-style';
+import type { LucideIcon } from 'lucide-react';
+import {
+  Archive,
+  Circle,
+  CircleCheck,
+  CircleDashed,
+  CircleDot,
+  CirclePause,
+  CircleSlash,
+  CircleX,
+  Clock,
+  HandIcon,
+  StarIcon,
+} from 'lucide-react';
+
+export interface ExecutionStatusVisual {
+  color: string;
+  icon: LucideIcon;
+}
+
+/**
+ * Canonical glyph + color per execution-status semantic, shared by tasks and
+ * topics (sidebar rows, group headers, kanban columns, management table, fleet
+ * sidebar). One semantic → one visual, so the same state never renders with
+ * different icons across surfaces. Live "running" rows may still swap the
+ * static glyph for the animated `RingLoadingIcon` — same circle family and
+ * warning color, animation just signals liveness.
+ */
+const VISUALS = {
+  archived: { color: cssVar.colorTextDescription, icon: Archive },
+  backlog: { color: cssVar.colorTextQuaternary, icon: CircleDashed },
+  canceled: { color: cssVar.colorTextSecondary, icon: CircleSlash },
+  completed: { color: cssVar.colorSuccess, icon: CircleCheck },
+  failed: { color: cssVar.colorError, icon: CircleX },
+  idle: { color: cssVar.colorTextTertiary, icon: Circle },
+  paused: { color: cssVar.colorTextDescription, icon: CirclePause },
+  running: { color: cssVar.colorWarning, icon: CircleDot },
+  scheduled: { color: cssVar.colorWarning, icon: Clock },
+  waitingForHuman: { color: cssVar.colorInfo, icon: HandIcon },
+} satisfies Record<string, ExecutionStatusVisual>;
+
+export const TASK_STATUS_VISUALS: Record<TaskStatus, ExecutionStatusVisual> = {
+  backlog: VISUALS.backlog,
+  canceled: VISUALS.canceled,
+  completed: VISUALS.completed,
+  failed: VISUALS.failed,
+  // Task `paused` is surfaced as "Pending review" — same semantic as a topic
+  // waiting for human input, so it shares the hand glyph.
+  paused: VISUALS.waitingForHuman,
+  running: VISUALS.running,
+  scheduled: VISUALS.scheduled,
+};
+
+export const TOPIC_STATUS_VISUALS: Record<ChatTopicStatus, ExecutionStatusVisual> = {
+  active: VISUALS.idle,
+  archived: VISUALS.archived,
+  // Topic lists are mostly history: mute completed to keep long lists quiet,
+  // unlike task boards where a green check marks an achievement.
+  completed: { ...VISUALS.completed, color: cssVar.colorTextDescription },
+  failed: VISUALS.failed,
+  paused: VISUALS.paused,
+  running: VISUALS.running,
+  // `unread` rows render a custom ripple dot; this is the fallback glyph.
+  unread: { color: cssVar.colorInfo, icon: CircleDot },
+  waitingForHuman: VISUALS.waitingForHuman,
+};
+
+/**
+ * Synthetic sidebar group buckets that don't map 1:1 to a persisted status:
+ * `favorite` is split out by `buildGroupedTopics`; `pending` collapses the
+ * attention-needing states (waiting for human / failed / unread) and borrows
+ * the waiting-for-human glyph since "needs your attention" is its semantic.
+ */
+export const TOPIC_GROUP_VISUALS = {
+  favorite: { color: cssVar.colorTextTertiary, icon: StarIcon },
+  pending: VISUALS.waitingForHuman,
+} satisfies Record<string, ExecutionStatusVisual>;
+
+export const EXECUTION_STATUS_VISUALS = VISUALS;

--- a/src/features/AgentTasks/AgentTaskDetail/TopicStatusIcon.tsx
+++ b/src/features/AgentTasks/AgentTaskDetail/TopicStatusIcon.tsx
@@ -1,25 +1,18 @@
 import { Icon } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
-import {
-  CircleAlert,
-  CircleCheck,
-  CircleDashed,
-  CircleSlash,
-  CircleX,
-  type LucideIcon,
-} from 'lucide-react';
+import { CircleAlert } from 'lucide-react';
 import { memo } from 'react';
+
+import { EXECUTION_STATUS_VISUALS, type ExecutionStatusVisual } from '@/components/ExecutionStatus';
 
 type TopicRunStatus = 'canceled' | 'completed' | 'failed' | 'pending' | 'running' | 'timeout';
 
-const STATIC_META: Record<
-  Exclude<TopicRunStatus, 'running'>,
-  { color: string; icon: LucideIcon }
-> = {
-  canceled: { color: cssVar.colorTextSecondary, icon: CircleSlash },
-  completed: { color: cssVar.colorSuccess, icon: CircleCheck },
-  failed: { color: cssVar.colorError, icon: CircleX },
-  pending: { color: cssVar.colorTextQuaternary, icon: CircleDashed },
+const STATIC_META: Record<Exclude<TopicRunStatus, 'running'>, ExecutionStatusVisual> = {
+  canceled: EXECUTION_STATUS_VISUALS.canceled,
+  completed: EXECUTION_STATUS_VISUALS.completed,
+  failed: EXECUTION_STATUS_VISUALS.failed,
+  // Not-yet-started run: same glyph as a backlog task.
+  pending: EXECUTION_STATUS_VISUALS.backlog,
   timeout: { color: cssVar.colorWarning, icon: CircleAlert },
 };
 

--- a/src/features/AgentTasks/features/TaskStatusIcon.tsx
+++ b/src/features/AgentTasks/features/TaskStatusIcon.tsx
@@ -1,34 +1,9 @@
 import type { TaskStatus } from '@lobechat/types';
 import { ActionIcon } from '@lobehub/ui';
-import { cssVar } from 'antd-style';
-import type { LucideIcon } from 'lucide-react';
-import {
-  CircleCheck,
-  CircleDashed,
-  CircleDot,
-  CircleSlash,
-  CircleX,
-  Clock,
-  HandIcon,
-} from 'lucide-react';
 import { memo } from 'react';
 
+import { TASK_STATUS_VISUALS } from '@/components/ExecutionStatus';
 import { taskListSelectors } from '@/store/task/selectors';
-
-interface StatusMeta {
-  color: string;
-  icon: LucideIcon;
-}
-
-const STATUS_META: Record<TaskStatus, StatusMeta> = {
-  backlog: { color: cssVar.colorTextQuaternary, icon: CircleDashed },
-  canceled: { color: cssVar.colorTextSecondary, icon: CircleSlash },
-  completed: { color: cssVar.colorSuccess, icon: CircleCheck },
-  failed: { color: cssVar.colorError, icon: CircleX },
-  paused: { color: cssVar.colorInfo, icon: HandIcon },
-  running: { color: cssVar.colorWarning, icon: CircleDot },
-  scheduled: { color: cssVar.colorWarning, icon: Clock },
-};
 
 interface TaskStatusIconProps {
   size?: number;
@@ -37,7 +12,7 @@ interface TaskStatusIconProps {
 
 const TaskStatusIcon = memo<TaskStatusIconProps>(({ size = 16, status }) => {
   const displayStatus = taskListSelectors.getDisplayStatus(status);
-  const meta = STATUS_META[status as TaskStatus] ?? STATUS_META.backlog;
+  const meta = TASK_STATUS_VISUALS[status as TaskStatus] ?? TASK_STATUS_VISUALS.backlog;
 
   return (
     <ActionIcon

--- a/src/features/AgentTasks/features/TaskStatusTag.tsx
+++ b/src/features/AgentTasks/features/TaskStatusTag.tsx
@@ -2,20 +2,12 @@ import type { TaskStatus } from '@lobechat/types';
 import { type DropdownItem, DropdownMenu, Icon, type MenuInfo, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import type { LucideIcon } from 'lucide-react';
-import {
-  CircleCheck,
-  CircleDashed,
-  CircleDot,
-  CircleSlash,
-  CircleX,
-  Clock,
-  HandIcon,
-  Loader2Icon,
-} from 'lucide-react';
+import { Loader2Icon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { TASK_STATUS_VISUALS } from '@/components/ExecutionStatus';
 import { usePermission } from '@/hooks/usePermission';
 import { useTaskStore } from '@/store/task';
 
@@ -28,49 +20,16 @@ interface StatusMeta {
   labelKey: string;
 }
 
+// Icons/colors come from the shared execution-status visuals; this map only
+// adds the task-specific labels.
 export const STATUS_META: Record<TaskStatus, StatusMeta> = {
-  backlog: {
-    color: cssVar.colorTextQuaternary,
-    icon: CircleDashed,
-    label: 'Backlog',
-    labelKey: 'status.backlog',
-  },
-  canceled: {
-    color: cssVar.colorTextSecondary,
-    icon: CircleSlash,
-    label: 'Canceled',
-    labelKey: 'status.canceled',
-  },
-  completed: {
-    color: cssVar.colorSuccess,
-    icon: CircleCheck,
-    label: 'Completed',
-    labelKey: 'status.completed',
-  },
-  failed: {
-    color: cssVar.colorError,
-    icon: CircleX,
-    label: 'Failed',
-    labelKey: 'status.failed',
-  },
-  paused: {
-    color: cssVar.colorInfo,
-    icon: HandIcon,
-    label: 'Pending review',
-    labelKey: 'status.paused',
-  },
-  running: {
-    color: cssVar.colorWarning,
-    icon: CircleDot,
-    label: 'Running',
-    labelKey: 'status.running',
-  },
-  scheduled: {
-    color: cssVar.colorWarning,
-    icon: Clock,
-    label: 'Scheduled',
-    labelKey: 'status.scheduled',
-  },
+  backlog: { ...TASK_STATUS_VISUALS.backlog, label: 'Backlog', labelKey: 'status.backlog' },
+  canceled: { ...TASK_STATUS_VISUALS.canceled, label: 'Canceled', labelKey: 'status.canceled' },
+  completed: { ...TASK_STATUS_VISUALS.completed, label: 'Completed', labelKey: 'status.completed' },
+  failed: { ...TASK_STATUS_VISUALS.failed, label: 'Failed', labelKey: 'status.failed' },
+  paused: { ...TASK_STATUS_VISUALS.paused, label: 'Pending review', labelKey: 'status.paused' },
+  running: { ...TASK_STATUS_VISUALS.running, label: 'Running', labelKey: 'status.running' },
+  scheduled: { ...TASK_STATUS_VISUALS.scheduled, label: 'Scheduled', labelKey: 'status.scheduled' },
 };
 
 export const USER_SELECTABLE_STATUSES: TaskStatus[] = [

--- a/src/features/AgentTopicManager/StatusDot.tsx
+++ b/src/features/AgentTopicManager/StatusDot.tsx
@@ -5,17 +5,17 @@ import { cssVar, useTheme } from 'antd-style';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { TOPIC_STATUS_VISUALS } from '@/components/ExecutionStatus';
 import RingLoadingIcon from '@/components/RingLoading';
 
+// Dot colors come from the shared execution-status visuals so the management
+// table reads the same as the sidebar topic lists; `idle` is a synthetic
+// fallback for topics that dropped out of the running set.
 const STATUS_COLOR: Record<string, string> = {
-  active: cssVar.colorSuccess,
-  archived: cssVar.colorWarning,
-  completed: cssVar.colorTextQuaternary,
-  failed: cssVar.colorError,
+  ...Object.fromEntries(
+    Object.entries(TOPIC_STATUS_VISUALS).map(([status, visual]) => [status, visual.color]),
+  ),
   idle: cssVar.colorTextQuaternary,
-  paused: cssVar.colorInfo,
-  running: cssVar.colorWarning,
-  waitingForHuman: cssVar.colorInfo,
 };
 
 interface StatusDotProps {

--- a/src/routes/(main)/agent/_layout/Sidebar/Task/StatusGroup.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Task/StatusGroup.tsx
@@ -2,31 +2,22 @@
 
 import { AccordionItem, Center, Flexbox, Icon, Text } from '@lobehub/ui';
 import { cssVar } from 'antd-style';
-import { CircleDashed, CircleDot, HandIcon, type LucideIcon } from 'lucide-react';
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
+import { EXECUTION_STATUS_VISUALS, type ExecutionStatusVisual } from '@/components/ExecutionStatus';
 import type { TaskGroupItem } from '@/store/task/slices/list/initialState';
 
 import TaskItem from './TaskItem';
 
-const STATUS_META: Record<string, { color: string; icon: LucideIcon; titleKey: string }> = {
-  backlog: {
-    color: cssVar.colorTextQuaternary,
-    icon: CircleDashed,
-    titleKey: 'taskList.kanban.backlog',
-  },
+const STATUS_META: Record<string, ExecutionStatusVisual & { titleKey: string }> = {
+  backlog: { ...EXECUTION_STATUS_VISUALS.backlog, titleKey: 'taskList.kanban.backlog' },
   needsInput: {
-    color: cssVar.colorInfo,
-    icon: HandIcon,
+    ...EXECUTION_STATUS_VISUALS.waitingForHuman,
     titleKey: 'taskList.kanban.needsInput',
   },
-  running: {
-    color: cssVar.colorWarning,
-    icon: CircleDot,
-    titleKey: 'taskList.kanban.running',
-  },
+  running: { ...EXECUTION_STATUS_VISUALS.running, titleKey: 'taskList.kanban.running' },
 };
 
 interface StatusGroupProps {

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -7,13 +7,14 @@ import {
 } from '@lobechat/utils/client/topic';
 import { Flexbox, Icon, Popover, Skeleton, Tag, Text, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cssVar, keyframes, useTheme } from 'antd-style';
-import { CheckCircle2, Hand, HashIcon, MessageSquareDashed, TriangleAlert } from 'lucide-react';
+import { HashIcon, MessageSquareDashed } from 'lucide-react';
 import type { CSSProperties } from 'react';
 import { memo, Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import DotsLoading from '@/components/DotsLoading';
+import { TOPIC_STATUS_VISUALS } from '@/components/ExecutionStatus';
 import RingLoadingIcon from '@/components/RingLoading';
 import { isDesktop } from '@/const/version';
 import DirIcon from '@/features/ChatInput/ControlBar/DirIcon';
@@ -400,7 +401,8 @@ const TopicItem = memo<TopicItemProps>(
         titleColor={cssVar.colorText}
         icon={(() => {
           if (isWaitingForHuman) {
-            return <Icon icon={Hand} size={'small'} style={{ color: cssVar.colorInfo }} />;
+            const visual = TOPIC_STATUS_VISUALS.waitingForHuman;
+            return <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
           }
           if (shouldShowRunningIcon) {
             return (
@@ -412,9 +414,10 @@ const TopicItem = memo<TopicItemProps>(
             );
           }
           if (isFailed) {
+            const visual = TOPIC_STATUS_VISUALS.failed;
             return (
               <Tooltip title={t('failedStatusTip')}>
-                <Icon icon={TriangleAlert} size={'small'} style={{ color: cssVar.colorError }} />
+                <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />
               </Tooltip>
             );
           }
@@ -434,13 +437,8 @@ const TopicItem = memo<TopicItemProps>(
             );
           }
           if (isCompleted) {
-            return (
-              <Icon
-                icon={CheckCircle2}
-                size={'small'}
-                style={{ color: cssVar.colorTextDescription }}
-              />
-            );
+            const visual = TOPIC_STATUS_VISUALS.completed;
+            return <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
           }
           if (metadata?.bot?.platform) {
             const ProviderIcon = getPlatformIcon(metadata.bot!.platform);

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByProjectMode/GroupItem.tsx
@@ -1,19 +1,13 @@
 import { AGENT_CHAT_URL } from '@lobechat/const';
 import { AccordionItem, ActionIcon, Center, Flexbox, Icon, Text, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx, keyframes } from 'antd-style';
-import {
-  FolderClosedIcon,
-  FolderOpenIcon,
-  HandIcon,
-  type LucideIcon,
-  PlusIcon,
-  TriangleAlertIcon,
-} from 'lucide-react';
+import { FolderClosedIcon, FolderOpenIcon, type LucideIcon, PlusIcon } from 'lucide-react';
 import { memo, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
+import { TOPIC_STATUS_VISUALS } from '@/components/ExecutionStatus';
 import RingLoadingIcon from '@/components/RingLoading';
 import { isDesktop } from '@/const/version';
 import { useCommitWorkingDirectory } from '@/features/ChatInput/ControlBar/useCommitWorkingDirectory';
@@ -154,13 +148,13 @@ const CollapsedStatusBadges = memo<{ counts: ProjectTopicStatusCounts }>(({ coun
     {
       className: styles.statusBadgeWaiting,
       count: counts.waitingForHuman,
-      icon: HandIcon,
+      icon: TOPIC_STATUS_VISUALS.waitingForHuman.icon,
       label: t('projectStatus.waitingForHuman', { count: counts.waitingForHuman }),
     },
     {
       className: styles.statusBadgeError,
       count: counts.failed,
-      icon: TriangleAlertIcon,
+      icon: TOPIC_STATUS_VISUALS.failed.icon,
       label: t('projectStatus.failed', { count: counts.failed }),
     },
   ].filter((item) => item.count > 0);

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByStatusMode/GroupItem.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/ByStatusMode/GroupItem.tsx
@@ -1,32 +1,21 @@
 import { AccordionItem, Center, Flexbox, Icon, Text } from '@lobehub/ui';
-import { cssVar } from 'antd-style';
-import {
-  Archive,
-  CheckCircle2,
-  CircleAlert,
-  CircleDot,
-  Loader,
-  type LucideIcon,
-  PauseCircle,
-  Star,
-} from 'lucide-react';
 import { memo } from 'react';
+
+import {
+  type ExecutionStatusVisual,
+  TOPIC_GROUP_VISUALS,
+  TOPIC_STATUS_VISUALS,
+} from '@/components/ExecutionStatus';
 
 import TopicItem from '../../List/Item';
 import { type GroupItemComponentProps } from '../GroupedAccordion';
 
-// Map each status-group id to its icon + color, mirroring the per-topic status
-// glyphs in `List/Item`. `pending` collapses the attention-needing states
-// (awaiting input / failed / unread completion) into one group; `favorite` is
-// the synthetic group split out by `buildGroupedTopics`, so it gets a star.
-const STATUS_ICON: Record<string, { color: string; icon: LucideIcon }> = {
-  active: { color: cssVar.colorTextTertiary, icon: CircleDot },
-  archived: { color: cssVar.colorTextDescription, icon: Archive },
-  completed: { color: cssVar.colorTextDescription, icon: CheckCircle2 },
-  favorite: { color: cssVar.colorWarning, icon: Star },
-  paused: { color: cssVar.colorTextDescription, icon: PauseCircle },
-  pending: { color: cssVar.colorWarning, icon: CircleAlert },
-  running: { color: cssVar.colorWarning, icon: Loader },
+// Status-group ids map 1:1 to a topic status except the synthetic `favorite`
+// and `pending` buckets — all visuals come from the shared execution-status
+// set so group headers, topic rows and task surfaces stay consistent.
+const STATUS_ICON: Record<string, ExecutionStatusVisual> = {
+  ...TOPIC_STATUS_VISUALS,
+  ...TOPIC_GROUP_VISUALS,
 };
 
 const GroupItem = memo<GroupItemComponentProps>(({ group, activeTopicId, activeThreadId }) => {

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -1,21 +1,16 @@
 import { GROUP_CHAT_TOPIC_URL } from '@lobechat/const';
 import type { ChatTopicStatus } from '@lobechat/types';
 import { Flexbox, Icon, Skeleton, Tag, Text, Tooltip } from '@lobehub/ui';
-import { createStaticStyles, cssVar } from 'antd-style';
-import {
-  CheckCircle2,
-  Hand,
-  HashIcon,
-  Loader2Icon,
-  MessageSquareDashed,
-  TriangleAlert,
-} from 'lucide-react';
+import { createStaticStyles, cssVar, useTheme } from 'antd-style';
+import { HashIcon, MessageSquareDashed } from 'lucide-react';
 import { AnimatePresence, m } from 'motion/react';
 import { memo, Suspense, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import DotsLoading from '@/components/DotsLoading';
+import { TOPIC_STATUS_VISUALS } from '@/components/ExecutionStatus';
+import RingLoadingIcon from '@/components/RingLoading';
 import { isDesktop } from '@/const/version';
 import { useHasDraft } from '@/features/ChatInput/draftStorage';
 import NavItem from '@/features/NavPanel/components/NavItem';
@@ -92,6 +87,11 @@ interface TopicItemProps {
 
 const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, status }) => {
   const { t } = useTranslation('topic');
+  const { isDarkMode } = useTheme();
+  // Same live-running ring as the agent sidebar topic rows (see List/Item there).
+  const loadingRingColor = isDarkMode
+    ? cssVar.colorWarningBorder
+    : `color-mix(in srgb, ${cssVar.colorWarning} 45%, transparent)`;
   const toggleMobileTopic = useGlobalStore((s) => s.toggleMobileTopic);
   const [activeGroupId, switchTopic] = useAgentGroupStore((s) => [s.activeGroupId, s.switchTopic]);
   const addTab = useElectronStore((s) => s.addTab);
@@ -241,7 +241,11 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
         titleColor={cssVar.colorText}
         icon={
           isLoading ? (
-            <Icon spin color={cssVar.colorWarning} icon={Loader2Icon} size={'small'} />
+            <RingLoadingIcon
+              ringColor={loadingRingColor}
+              size={14}
+              style={{ color: cssVar.colorWarning }}
+            />
           ) : (
             <Icon color={cssVar.colorTextDescription} icon={MessageSquareDashed} size={'small'} />
           )
@@ -277,28 +281,29 @@ const TopicItem = memo<TopicItemProps>(({ id, title, fav, active, threadId, stat
         titleColor={cssVar.colorText}
         icon={(() => {
           if (isWaitingForHuman) {
-            return <Icon icon={Hand} size={'small'} style={{ color: cssVar.colorInfo }} />;
+            const visual = TOPIC_STATUS_VISUALS.waitingForHuman;
+            return <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
           }
           if (isLoading || isRunning) {
             return (
-              <Icon spin icon={Loader2Icon} size={'small'} style={{ color: cssVar.colorWarning }} />
+              <RingLoadingIcon
+                ringColor={loadingRingColor}
+                size={14}
+                style={{ color: cssVar.colorWarning }}
+              />
             );
           }
           if (isFailed) {
+            const visual = TOPIC_STATUS_VISUALS.failed;
             return (
               <Tooltip title={t('failedStatusTip')}>
-                <Icon icon={TriangleAlert} size={'small'} style={{ color: cssVar.colorError }} />
+                <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />
               </Tooltip>
             );
           }
           if (isCompleted) {
-            return (
-              <Icon
-                icon={CheckCircle2}
-                size={'small'}
-                style={{ color: cssVar.colorTextDescription }}
-              />
-            );
+            const visual = TOPIC_STATUS_VISUALS.completed;
+            return <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
           }
           return (
             <Icon icon={HashIcon} size={'small'} style={{ color: cssVar.colorTextDescription }} />


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style
- [x] ♻️ refactor

#### 🔀 Description of Change

Status glyphs for tasks and topics were duplicated and had drifted apart across many surfaces (sidebar rows, group headers, kanban columns, the management table, the fleet sidebar). This PR introduces `src/components/ExecutionStatus.ts` as the single source of truth for status icon + color, and points every surface at it — one semantic, one visual.

Per-request tweaks to the by-status **topic group headers**:

- **Favorite** — gray outline star instead of the yellow filled star.
- **Running (进行中)** — `CircleDot`, matching the task status icon, instead of the static `Loader` glyph.
- **Pending (待处理)** — the waitForHuman `Hand` icon instead of a warning `CircleAlert`.

Consumers migrated to the shared set: `TaskStatusTag`, `TaskStatusIcon`, sidebar task `StatusGroup`, task-detail `TopicStatusIcon`, `AgentTopicManager/StatusDot`, the agent and group sidebar topic rows (`List/Item`), and the by-project / by-status group headers. Two intentional differences are documented in the shared module: topic lists keep `completed` muted (history, not achievement), and live-running rows keep the animated `RingLoading` ring rather than the static `CircleDot` (same color/family; the animation signals liveness).

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Verified in an isolated Electron dev instance (live working-tree code) by rendering the by-status grouped topic sidebar and visually confirming the three header icons (gray star / CircleDot / Hand) plus the unified per-row glyphs. Task-side consumers are covered by existing unit tests (10 related cases passing).

Verify report: https://app.lobehub.com/verify/826742ae-63c6-4cde-b55e-7db56738fd2b

#### 📸 Screenshots / Videos

See the verify report above — the by-status grouped sidebar renders 收藏 (gray star), 进行中 (CircleDot), 待处理 (Hand), plus unified per-row status glyphs.