### PR TITLE
✨ feat(model-provider): add DaoXE support

### DIFF
--- a/locales/en-US/providers.json
+++ b/locales/en-US/providers.json
@@ -17,6 +17,7 @@
   "cohere.description": "Cohere delivers cutting-edge multilingual models, advanced retrieval, and AI workspaces for modern enterprises—all in one secure platform.",
   "cometapi.description": "CometAPI provides access to frontier models from OpenAI, Anthropic, Google, and more, letting users choose the best model and pricing for diverse use cases.",
   "comfyui.description": "A powerful open-source workflow engine for image, video, and audio generation, supporting models like SD, FLUX, Qwen, Hunyuan, and WAN with node-based editing and private deployment.",
+  "daoxe.description": "DaoXE provides access to models from OpenAI, Anthropic, Google, xAI, DeepSeek, and more through a unified OpenAI-compatible API.",
   "deepseek.description": "DeepSeek focuses on AI research and applications. Its latest DeepSeek V4 family ships in Flash and Pro variants with a 1M context window and hybrid thinking — competitive with leading closed frontier models on reasoning and agent benchmarks.",
   "fal.description": "A generative media platform built for developers.",
   "fireworksai.description": "Fireworks AI provides advanced language model services with function calling and multimodal processing. Firefunction V2 (based on Llama-3) is optimized for function calls, chat, and instruction following, while FireLLaVA-13B supports mixed image-text inputs. Other notable models include the Llama and Mixtral families.",

--- a/locales/zh-CN/providers.json
+++ b/locales/zh-CN/providers.json
@@ -17,6 +17,7 @@
   "cohere.description": "Cohere 提供前沿的多语言模型、先进的检索能力和 AI 工作空间，为现代企业提供一体化、安全的平台。",
   "cometapi.description": "CometAPI 提供对 OpenAI、Anthropic、Google 等前沿模型的访问，用户可根据不同需求选择最优模型与价格。",
   "comfyui.description": "一个强大的开源工作流引擎，支持图像、视频和音频生成，兼容 SD、FLUX、Qwen、混元、WAN 等模型，支持节点式编辑与私有部署。",
+  "daoxe.description": "DaoXE 通过统一且兼容 OpenAI 的 API，提供对 OpenAI、Anthropic、Google、xAI、DeepSeek 等多家模型的访问。",
   "deepseek.description": "DeepSeek 专注于人工智能研究与应用。其最新的 DeepSeek V4 系列包含 Flash 和 Pro 两个版本，具备 100 万上下文窗口和混合式思维能力，在推理与智能体基准测试中可与领先的闭源前沿模型竞争。",
   "fal.description": "一个为开发者打造的生成式媒体平台。",
   "fireworksai.description": "Fireworks AI 提供先进的语言模型服务，支持函数调用与多模态处理。Firefunction V2（基于 Llama-3）优化了函数调用、对话与指令执行，FireLLaVA-13B 支持图文混合输入，另有 Llama 与 Mixtral 系列模型。",

--- a/packages/env/src/llm.ts
+++ b/packages/env/src/llm.ts
@@ -219,6 +219,9 @@ export const getLLMConfig = () => {
       ENABLED_COMETAPI: z.boolean(),
       COMETAPI_KEY: z.string().optional(),
 
+      ENABLED_DAOXE: z.boolean(),
+      DAOXE_API_KEY: z.string().optional(),
+
       ENABLED_AIHUBMIX: z.boolean(),
       AIHUBMIX_API_KEY: z.string().optional(),
       AIHUBMIX_PROXY_URL: z.string().optional(),
@@ -469,6 +472,9 @@ export const getLLMConfig = () => {
 
       ENABLED_COMETAPI: !!process.env.COMETAPI_KEY,
       COMETAPI_KEY: process.env.COMETAPI_KEY,
+
+      ENABLED_DAOXE: !!process.env.DAOXE_API_KEY,
+      DAOXE_API_KEY: process.env.DAOXE_API_KEY,
 
       ENABLED_AIHUBMIX: !!process.env.AIHUBMIX_API_KEY,
       AIHUBMIX_API_KEY: process.env.AIHUBMIX_API_KEY,

--- a/packages/model-bank/package.json
+++ b/packages/model-bank/package.json
@@ -24,6 +24,7 @@
     "./cohere": "./src/aiModels/cohere.ts",
     "./cometapi": "./src/aiModels/cometapi.ts",
     "./comfyui": "./src/aiModels/comfyui.ts",
+    "./daoxe": "./src/aiModels/daoxe.ts",
     "./deepseek": "./src/aiModels/deepseek.ts",
     "./fal": "./src/aiModels/fal.ts",
     "./fireworksai": "./src/aiModels/fireworksai.ts",

--- a/packages/model-bank/src/aiModels/daoxe.ts
+++ b/packages/model-bank/src/aiModels/daoxe.ts
@@ -1,0 +1,8 @@
+import type { AIChatModelCard } from '../types/aiModel';
+
+// DaoXE exposes the models available to each API key dynamically via /v1/models.
+const daoxeModels: AIChatModelCard[] = [];
+
+export const allModels = [...daoxeModels];
+
+export default allModels;

--- a/packages/model-bank/src/aiModels/index.ts
+++ b/packages/model-bank/src/aiModels/index.ts
@@ -19,6 +19,7 @@ import { default as cloudflare } from './cloudflare';
 import { default as cohere } from './cohere';
 import { default as cometapi } from './cometapi';
 import { default as comfyui } from './comfyui';
+import { default as daoxe } from './daoxe';
 import { default as deepseek } from './deepseek';
 import { default as fal } from './fal';
 import { default as fireworksai } from './fireworksai';
@@ -127,6 +128,7 @@ const staticModelMap: ModelsMap = {
   cohere,
   cometapi,
   comfyui,
+  daoxe,
   deepseek,
   fal,
   fireworksai,
@@ -241,6 +243,7 @@ export { default as cloudflare } from './cloudflare';
 export { default as cohere } from './cohere';
 export { default as cometapi } from './cometapi';
 export { default as comfyui } from './comfyui';
+export { default as daoxe } from './daoxe';
 export { default as deepseek } from './deepseek';
 export { default as fal, fluxSchnellParamsSchema } from './fal';
 export { default as fireworksai } from './fireworksai';

--- a/packages/model-bank/src/const/modelProvider.ts
+++ b/packages/model-bank/src/const/modelProvider.ts
@@ -17,6 +17,7 @@ export enum ModelProvider {
   Cohere = 'cohere',
   CometAPI = 'cometapi',
   ComfyUI = 'comfyui',
+  DaoXE = 'daoxe',
   DeepSeek = 'deepseek',
   Fal = 'fal',
   FireworksAI = 'fireworksai',

--- a/packages/model-bank/src/modelProviders/daoxe.ts
+++ b/packages/model-bank/src/modelProviders/daoxe.ts
@@ -1,0 +1,24 @@
+import type { ModelProviderCard } from '@/types/llm';
+
+const DaoXE: ModelProviderCard = {
+  apiKeyUrl: 'https://daoxe.com/keys',
+  chatModels: [],
+  checkModel: 'gemini-2.5-flash',
+  description:
+    'DaoXE provides access to models from OpenAI, Anthropic, Google, xAI, DeepSeek, and more through a unified OpenAI-compatible API.',
+  id: 'daoxe',
+  modelList: { showModelFetcher: true },
+  modelsUrl: 'https://daoxe.com/pricing',
+  name: 'DaoXE',
+  settings: {
+    proxyUrl: {
+      placeholder: 'https://daoxe.com/v1',
+    },
+    sdkType: 'openai',
+    showModelFetcher: true,
+    supportResponsesApi: true,
+  },
+  url: 'https://daoxe.com',
+};
+
+export default DaoXE;

--- a/packages/model-bank/src/modelProviders/index.ts
+++ b/packages/model-bank/src/modelProviders/index.ts
@@ -20,6 +20,7 @@ import CloudflareProvider from './cloudflare';
 import CohereProvider from './cohere';
 import CometAPIProvider from './cometapi';
 import ComfyUIProvider from './comfyui';
+import DaoXEProvider from './daoxe';
 import DeepSeekProvider from './deepseek';
 import FalProvider from './fal';
 import FireworksAIProvider from './fireworksai';
@@ -214,6 +215,7 @@ export const DEFAULT_MODEL_PROVIDER_LIST = [
   ReplicateProvider,
   NebiusProvider,
   CometAPIProvider,
+  DaoXEProvider,
   VercelAIGatewayProvider,
   CerebrasProvider,
   ZenMuxProvider,
@@ -255,6 +257,7 @@ export { default as CloudflareProviderCard } from './cloudflare';
 export { default as CohereProviderCard } from './cohere';
 export { default as CometAPIProviderCard } from './cometapi';
 export { default as ComfyUIProviderCard } from './comfyui';
+export { default as DaoXEProviderCard } from './daoxe';
 export { default as DeepSeekProviderCard } from './deepseek';
 export { default as FalProviderCard } from './fal';
 export { default as FireworksAIProviderCard } from './fireworksai';

--- a/packages/model-runtime/src/index.ts
+++ b/packages/model-runtime/src/index.ts
@@ -45,6 +45,7 @@ export { LobeBflAI } from './providers/bfl';
 export { LobeCerebrasAI } from './providers/cerebras';
 export { LobeCometAPIAI } from './providers/cometapi';
 export { LobeComfyUI } from './providers/comfyui';
+export { LobeDaoXEAI } from './providers/daoxe';
 export { LobeDeepSeekAI } from './providers/deepseek';
 export { LobeGLMCodingPlanAI } from './providers/glmCodingPlan';
 export { LobeGoogleAI } from './providers/google';

--- a/packages/model-runtime/src/providers/daoxe/index.test.ts
+++ b/packages/model-runtime/src/providers/daoxe/index.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import { ModelProvider } from 'model-bank';
+import { describe, expect, it, vi } from 'vitest';
+
+import { testProvider } from '../../providerTestUtils';
+import { LobeDaoXEAI, params } from './index';
+
+vi.mock('@lobechat/business-model-bank/model-config', () => ({
+  loadModels: vi.fn().mockResolvedValue([]),
+}));
+
+testProvider({
+  Runtime: LobeDaoXEAI,
+  chatDebugEnv: 'DEBUG_DAOXE_CHAT_COMPLETION',
+  chatModel: 'gemini-2.5-flash',
+  defaultBaseURL: 'https://daoxe.com/v1',
+  provider: ModelProvider.DaoXE,
+  test: {
+    skipAPICall: true,
+  },
+});
+
+describe('LobeDaoXEAI models', () => {
+  it('fetches and normalizes the models available to the API key', async () => {
+    const list = vi.fn().mockResolvedValue({
+      data: [{ id: 'gemini-2.5-flash' }, { id: 'claude-sonnet-4-6' }],
+    });
+
+    const models = await params.models!({
+      client: { models: { list } } as any,
+    });
+
+    expect(list).toHaveBeenCalledOnce();
+    expect(models.map((model) => model.id)).toEqual(['gemini-2.5-flash', 'claude-sonnet-4-6']);
+  });
+
+  it('handles an empty model response', async () => {
+    const models = await params.models!({
+      client: { models: { list: vi.fn().mockResolvedValue({}) } } as any,
+    });
+
+    expect(models).toEqual([]);
+  });
+});

--- a/packages/model-runtime/src/providers/daoxe/index.ts
+++ b/packages/model-runtime/src/providers/daoxe/index.ts
@@ -1,0 +1,25 @@
+import { ModelProvider } from 'model-bank';
+
+import type { OpenAICompatibleFactoryOptions } from '../../core/openaiCompatibleFactory';
+import { createOpenAICompatibleRuntime } from '../../core/openaiCompatibleFactory';
+import { processMultiProviderModelList } from '../../utils/modelParse';
+
+export interface DaoXEModelCard {
+  id: string;
+}
+
+export const params = {
+  baseURL: 'https://daoxe.com/v1',
+  debug: {
+    chatCompletion: () => process.env.DEBUG_DAOXE_CHAT_COMPLETION === '1',
+  },
+  models: async ({ client }) => {
+    const modelsPage = (await client.models.list()) as any;
+    const modelList: DaoXEModelCard[] = modelsPage.data || [];
+
+    return processMultiProviderModelList(modelList, ModelProvider.DaoXE);
+  },
+  provider: ModelProvider.DaoXE,
+} satisfies OpenAICompatibleFactoryOptions;
+
+export const LobeDaoXEAI = createOpenAICompatibleRuntime(params);

--- a/packages/model-runtime/src/runtimeMap.ts
+++ b/packages/model-runtime/src/runtimeMap.ts
@@ -16,6 +16,7 @@ import { LobeCloudflareAI } from './providers/cloudflare';
 import { LobeCohereAI } from './providers/cohere';
 import { LobeCometAPIAI } from './providers/cometapi';
 import { LobeComfyUI } from './providers/comfyui';
+import { LobeDaoXEAI } from './providers/daoxe';
 import { LobeDeepSeekAI } from './providers/deepseek';
 import { LobeFalAI } from './providers/fal';
 import { LobeFireworksAI } from './providers/fireworksai';
@@ -99,6 +100,7 @@ export const providerRuntimeMap = {
   cohere: LobeCohereAI,
   cometapi: LobeCometAPIAI,
   comfyui: LobeComfyUI,
+  daoxe: LobeDaoXEAI,
   deepseek: LobeDeepSeekAI,
   fal: LobeFalAI,
   fireworksai: LobeFireworksAI,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

No related issue found.

#### 🔀 Description of Change

Adds DaoXE as a built-in AI provider.

- Registers the provider card with the default OpenAI-compatible endpoint at https://daoxe.com/v1.
- Supports dynamic model discovery through /v1/models and exposes Responses API capability.
- Adds the DaoXE runtime to the provider runtime map.
- Adds DAOXE_API_KEY server configuration.
- Adds English and Simplified Chinese provider descriptions.
- Uses gemini-2.5-flash as the connectivity-check model because it is available in the public default model group.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation performed:

- bun run check: lint clean, 21 related tests passed.
- bun run check --type: types clean.
- DaoXE runtime test: 11 tests passed.
- Live unauthenticated endpoint checks confirmed structured 401 responses for /v1/models and /v1/chat/completions.
- CORS preflight allows browser requests from arbitrary HTTPS origins.

No authenticated inference request was made because no DaoXE API key was available in the test environment.

#### 📸 Screenshots / Videos

Not applicable; this is a provider registry and runtime integration with no layout changes.

#### 📝 Additional Information

DaoXE publishes its current model catalog and endpoint capabilities at https://daoxe.com/pricing.