### PR TITLE
🐛 fix: serve desktop bundle for /verify on mobile UA

### DIFF
--- a/src/libs/next/proxy/define-config.ts
+++ b/src/libs/next/proxy/define-config.ts
@@ -89,15 +89,18 @@ export function defineConfig() {
       locale,
     });
 
-    // Share pages are responsive on their own; always serve the desktop bundle
+    // These pages are responsive on their own; always serve the desktop bundle
     // so mobile UA does not land on mobile-specific routes.
-    const isSharePath = url.pathname === '/share' || url.pathname.startsWith('/share/');
+    const desktopOnlyPaths = ['/share', '/verify'];
+    const isDesktopOnlyPath = desktopOnlyPaths.some(
+      (path) => url.pathname === path || url.pathname.startsWith(`${path}/`),
+    );
 
     const safeLocale = toSafeLocale(locale);
 
     // 2. Create normalized preference values
     const route = RouteVariants.serializeVariants({
-      isMobile: !isSharePath && device.type === 'mobile',
+      isMobile: !isDesktopOnlyPath && device.type === 'mobile',
       locale: safeLocale,
     });
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

The proxy already always serves the desktop SPA bundle for `/share` paths so mobile user-agents do not land on mobile-specific routes (share pages are responsive on their own).

This change generalizes that exception into a `desktopOnlyPaths` list and includes `/verify` (and nested `/verify/*` paths), matching the same behavior for verification pages.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

1. Open a `/verify` URL with a mobile user-agent (or DevTools device mode).
2. Confirm the request is routed to the desktop SPA bundle rather than mobile-specific routes.
3. Regression: `/share` paths still force the desktop bundle; other mobile paths still receive the mobile bundle.

#### 📸 Screenshots / Videos

N/A — routing/proxy behavior only.

#### 📝 Additional Information

Single-file change in `src/libs/next/proxy/define-config.ts`.