### PR TITLE
🐛 fix(connector): sync and run Desktop STDIO tools locally

### DIFF
--- a/apps/server/src/routers/lambda/__tests__/connector.syncTools.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/connector.syncTools.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentModel } from '@/database/models/agent';
+import { ConnectorModel } from '@/database/models/connector';
+import { ConnectorToolModel } from '@/database/models/connectorTool';
+import { PluginModel } from '@/database/models/plugin';
+import { syncConnectorToolsById } from '@/server/services/connector/sync';
+
+import { connectorRouter } from '../connector';
+
+vi.mock('@/database/models/agent', () => ({ AgentModel: vi.fn() }));
+vi.mock('@/database/models/connector', () => ({ ConnectorModel: vi.fn() }));
+vi.mock('@/database/models/connectorTool', () => ({ ConnectorToolModel: vi.fn() }));
+vi.mock('@/database/models/plugin', () => ({ PluginModel: vi.fn() }));
+vi.mock('@/server/services/connector/sync', () => ({ syncConnectorToolsById: vi.fn() }));
+vi.mock('@/server/modules/KeyVaultsEncrypt', () => ({
+  KeyVaultsGateKeeper: { initWithEnvKey: async () => ({}) },
+}));
+vi.mock('@/business/server/trpc-middlewares/workspaceAuth', async () => {
+  const mod = await vi.importActual<{ trpc: any }>('@/libs/trpc/lambda/init');
+  return {
+    requireWorkspaceRoleWhenScoped: () => mod.trpc.middleware(async (opts: any) => opts.next()),
+    wsCompatProcedure: mod.trpc.procedure,
+  };
+});
+vi.mock('@/libs/trpc/lambda/middleware', () => ({
+  serverDatabase: async (opts: any) =>
+    opts.next({ ctx: { ...opts.ctx, serverDB: opts.ctx.serverDB ?? {} } }),
+}));
+
+describe('connectorRouter.syncTools', () => {
+  const connectorId = '11111111-1111-4111-8111-111111111111';
+  let connectorModelMock: any;
+  let connectorToolModelMock: any;
+
+  const caller = () =>
+    connectorRouter.createCaller({
+      serverDB: {},
+      userId: 'user_test',
+      workspaceId: null,
+    } as any);
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    connectorModelMock = {
+      findById: vi.fn().mockResolvedValue({ id: connectorId, userId: 'user_test' }),
+    };
+    connectorToolModelMock = {};
+    vi.mocked(AgentModel).mockImplementation(() => ({}) as any);
+    vi.mocked(ConnectorModel).mockImplementation(() => connectorModelMock);
+    vi.mocked(ConnectorToolModel).mockImplementation(() => connectorToolModelMock);
+    vi.mocked(PluginModel).mockImplementation(() => ({}) as any);
+    vi.mocked(syncConnectorToolsById).mockResolvedValue({ toolCount: 1 });
+  });
+
+  it('forwards normalized client tools with the scoped UUID context', async () => {
+    const tools = [
+      {
+        description: 'Read a local file',
+        inputSchema: { properties: { path: { type: 'string' } }, type: 'object' },
+        toolName: 'read_file',
+      },
+    ];
+
+    const result = await caller().syncTools({ id: connectorId, tools });
+
+    expect(result).toEqual({ toolCount: 1 });
+    expect(syncConnectorToolsById).toHaveBeenCalledWith(
+      connectorId,
+      expect.objectContaining({
+        connectorModel: connectorModelMock,
+        connectorToolModel: connectorToolModelMock,
+      }),
+      tools,
+    );
+  });
+
+  it('keeps ID-only calls on the existing service path', async () => {
+    await caller().syncTools({ id: connectorId });
+
+    expect(syncConnectorToolsById).toHaveBeenCalledWith(
+      connectorId,
+      expect.objectContaining({
+        connectorModel: connectorModelMock,
+        connectorToolModel: connectorToolModelMock,
+      }),
+    );
+  });
+
+  it('reports client-tool persistence failures as sync failures', async () => {
+    vi.mocked(syncConnectorToolsById).mockRejectedValue(new Error('database unavailable'));
+
+    await expect(caller().syncTools({ id: connectorId, tools: [] })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Failed to sync connector tools: database unavailable',
+    });
+  });
+
+  it('preserves the existing ID-only fetch failure message', async () => {
+    vi.mocked(syncConnectorToolsById).mockRejectedValue(new Error('MCP unavailable'));
+
+    await expect(caller().syncTools({ id: connectorId })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Failed to fetch tools from MCP server: MCP unavailable',
+    });
+  });
+
+  it('rejects client tool payloads beyond the bounded schema', async () => {
+    await expect(
+      caller().syncTools({
+        id: connectorId,
+        tools: Array.from({ length: 257 }, (_, index) => ({ toolName: `tool_${index}` })),
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    expect(syncConnectorToolsById).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate client tool names', async () => {
+    await expect(
+      caller().syncTools({
+        id: connectorId,
+        tools: [{ toolName: 'duplicate' }, { toolName: 'duplicate' }],
+      }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    expect(syncConnectorToolsById).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/routers/lambda/connector.ts
+++ b/apps/server/src/routers/lambda/connector.ts
@@ -83,6 +83,50 @@ const connectorCredentialsInputSchema = z.discriminatedUnion('type', [
   z.object({ headers: z.record(z.string(), z.string()), type: z.literal('header') }),
 ]);
 
+const MAX_SYNC_TOOL_COUNT = 256;
+const MAX_SYNC_TOOL_DESCRIPTION_LENGTH = 4096;
+const MAX_SYNC_TOOL_PAYLOAD_SIZE = 2 * 1024 * 1024;
+const MAX_SYNC_TOOL_SCHEMA_SIZE = 64 * 1024;
+
+const syncConnectorToolSchema = z.object({
+  description: z.string().max(MAX_SYNC_TOOL_DESCRIPTION_LENGTH).optional(),
+  inputSchema: z
+    .record(z.string(), z.unknown())
+    .refine(
+      (value) =>
+        new TextEncoder().encode(JSON.stringify(value)).length <= MAX_SYNC_TOOL_SCHEMA_SIZE,
+      {
+        message: `inputSchema must be ${MAX_SYNC_TOOL_SCHEMA_SIZE} bytes or smaller`,
+      },
+    )
+    .optional(),
+  toolName: z.string().min(1).max(255),
+});
+
+const syncConnectorToolsSchema = z
+  .array(syncConnectorToolSchema)
+  .max(MAX_SYNC_TOOL_COUNT)
+  .superRefine((tools, ctx) => {
+    const names = new Set<string>();
+    for (const [index, tool] of tools.entries()) {
+      if (names.has(tool.toolName)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate tool name: ${tool.toolName}`,
+          path: [index, 'toolName'],
+        });
+      }
+      names.add(tool.toolName);
+    }
+
+    if (new TextEncoder().encode(JSON.stringify(tools)).length > MAX_SYNC_TOOL_PAYLOAD_SIZE) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Tool payload must be ${MAX_SYNC_TOOL_PAYLOAD_SIZE} bytes or smaller`,
+      });
+    }
+  });
+
 const createConnectorSchema = z.object({
   /**
    * Bind this connector to a specific agent (Agent > Workspace/Personal). When
@@ -638,12 +682,17 @@ export const connectorRouter = router({
     }),
 
   /**
-   * Fetch the tool list from the remote MCP server and sync it into
-   * `user_connector_tools`. Manifest-derived fields are overwritten;
-   * user permission settings are preserved.
+   * Sync tools into `user_connector_tools`, either by fetching from the remote
+   * MCP server or by accepting a normalized list for an owned stdio connector.
+   * Manifest-derived fields are overwritten; user permissions are preserved.
    */
   syncTools: connectorWriteProcedure
-    .input(z.object({ id: z.string().uuid() }))
+    .input(
+      z.object({
+        id: z.string().uuid(),
+        tools: syncConnectorToolsSchema.optional(),
+      }),
+    )
     .mutation(async ({ input, ctx }) => {
       const target = await ctx.connectorModel.findById(input.id);
       if (!target) throw new TRPCError({ code: 'NOT_FOUND', message: 'Connector not found' });
@@ -652,12 +701,18 @@ export const connectorRouter = router({
       // update/delete/reset.
       assertWorkspaceRowManageable(ctx, target.userId, 'connector');
       try {
-        return await syncConnectorToolsById(input.id, ctx);
+        return input.tools === undefined
+          ? await syncConnectorToolsById(input.id, ctx)
+          : await syncConnectorToolsById(input.id, ctx, input.tools);
       } catch (err: any) {
+        const messagePrefix =
+          input.tools === undefined
+            ? 'Failed to fetch tools from MCP server'
+            : 'Failed to sync connector tools';
         throw new TRPCError({
           cause: err,
           code: 'INTERNAL_SERVER_ERROR',
-          message: `Failed to fetch tools from MCP server: ${err?.message ?? 'unknown error'}`,
+          message: `${messagePrefix}: ${err?.message ?? 'unknown error'}`,
         });
       }
     }),

--- a/apps/server/src/services/connector/sync.test.ts
+++ b/apps/server/src/services/connector/sync.test.ts
@@ -1,9 +1,19 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { DecryptedConnector } from '@/database/models/connector';
 import type { ConnectorCredentials } from '@/database/schemas';
+import { ConnectorMcpConnectionType, ConnectorStatus } from '@/database/schemas';
+import { mcpService } from '@/server/services/mcp';
 
-import { buildConnectorMcpParams, buildHttpAuthFromCredentials } from './sync';
+import {
+  buildConnectorMcpParams,
+  buildHttpAuthFromCredentials,
+  syncConnectorToolsById,
+} from './sync';
+import { ensureFreshConnectorToken } from './tokens';
+
+vi.mock('@/server/services/mcp', () => ({ mcpService: { listRawTools: vi.fn() } }));
+vi.mock('./tokens', () => ({ ensureFreshConnectorToken: vi.fn() }));
 
 const httpConnector = (
   credentials: ConnectorCredentials | null,
@@ -100,10 +110,7 @@ describe('buildConnectorMcpParams', () => {
   it('merges metadata.customHeaders alongside bearer auth', () => {
     expect(
       buildConnectorMcpParams(
-        httpConnector(
-          { token: 'tok', type: 'bearer' },
-          { customHeaders: { 'X-Tenant': 't1' } },
-        ),
+        httpConnector({ token: 'tok', type: 'bearer' }, { customHeaders: { 'X-Tenant': 't1' } }),
       ),
     ).toEqual({
       auth: { token: 'tok', type: 'bearer' },
@@ -116,9 +123,7 @@ describe('buildConnectorMcpParams', () => {
 
   it('applies metadata.customHeaders with no auth credential', () => {
     expect(
-      buildConnectorMcpParams(
-        httpConnector(null, { customHeaders: { 'X-Api-Key': 'abc' } }),
-      ),
+      buildConnectorMcpParams(httpConnector(null, { customHeaders: { 'X-Api-Key': 'abc' } })),
     ).toEqual({
       auth: undefined,
       headers: { 'X-Api-Key': 'abc' },
@@ -172,5 +177,196 @@ describe('buildConnectorMcpParams', () => {
       name: 'Local Connector',
       type: 'stdio',
     });
+  });
+});
+
+describe('syncConnectorToolsById', () => {
+  const connectorId = '11111111-1111-4111-8111-111111111111';
+
+  const stdioConnector = {
+    credentials: {
+      accessToken: 'must-not-refresh',
+      expiresAt: 0,
+      refreshToken: 'refresh-token',
+      type: 'oauth2',
+    },
+    id: connectorId,
+    identifier: 'local-connector',
+    isEnabled: true,
+    mcpConnectionType: ConnectorMcpConnectionType.stdio,
+    mcpServerUrl: null,
+    mcpStdioConfig: {
+      args: ['--serve'],
+      command: '/usr/bin/local-mcp',
+      env: { API_KEY: 'secret' },
+    },
+    metadata: { custom: 'preserved' },
+    name: 'Local Connector',
+    oidcConfig: {
+      clientId: 'client-id',
+      issuer: 'https://auth.example.com',
+      scheme: 'pre_registration',
+    },
+    sourceType: 'custom',
+    status: ConnectorStatus.disconnected,
+  } as unknown as DecryptedConnector;
+
+  const createContext = (connector: DecryptedConnector | null = stdioConnector) => {
+    const connectorModel = {
+      findById: vi.fn().mockResolvedValue(connector),
+      update: vi.fn(),
+      updateStatus: vi.fn().mockResolvedValue(undefined),
+    };
+    const connectorToolModel = {
+      upsertMany: vi.fn().mockResolvedValue(undefined),
+    };
+
+    return {
+      connectorModel,
+      connectorToolModel,
+      ctx: { connectorModel, connectorToolModel } as any,
+    };
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(ensureFreshConnectorToken).mockImplementation(async (connector) => connector);
+  });
+
+  it('persists supplied stdio tools against the exact UUID without fetching or refreshing', async () => {
+    const { connectorModel, connectorToolModel, ctx } = createContext();
+    const tools = [
+      {
+        description: 'Read the current weather',
+        inputSchema: { properties: { city: { type: 'string' } }, type: 'object' },
+        toolName: 'get_weather',
+      },
+      { toolName: 'create_note' },
+    ];
+
+    const result = await syncConnectorToolsById(connectorId, ctx, tools);
+
+    expect(result).toEqual({ toolCount: 2 });
+    expect(connectorModel.findById).toHaveBeenCalledWith(connectorId);
+    expect(ensureFreshConnectorToken).not.toHaveBeenCalled();
+    expect(mcpService.listRawTools).not.toHaveBeenCalled();
+    expect(connectorToolModel.upsertMany).toHaveBeenCalledWith(connectorId, [
+      {
+        crudType: 'read',
+        description: 'Read the current weather',
+        inputSchema: { properties: { city: { type: 'string' } }, type: 'object' },
+        toolName: 'get_weather',
+      },
+      {
+        crudType: 'write',
+        description: undefined,
+        inputSchema: undefined,
+        toolName: 'create_note',
+      },
+    ]);
+    expect(connectorModel.updateStatus).toHaveBeenCalledWith(
+      connectorId,
+      ConnectorStatus.connected,
+    );
+    expect(connectorModel.update).not.toHaveBeenCalled();
+  });
+
+  it('keeps an empty supplied stdio tool list on the client persistence path', async () => {
+    const { connectorModel, connectorToolModel, ctx } = createContext();
+
+    const result = await syncConnectorToolsById(connectorId, ctx, []);
+
+    expect(result).toEqual({ toolCount: 0 });
+    expect(ensureFreshConnectorToken).not.toHaveBeenCalled();
+    expect(mcpService.listRawTools).not.toHaveBeenCalled();
+    expect(connectorToolModel.upsertMany).toHaveBeenCalledWith(connectorId, []);
+    expect(connectorModel.updateStatus).toHaveBeenCalledWith(
+      connectorId,
+      ConnectorStatus.connected,
+    );
+    expect(connectorModel.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects supplied tools for an HTTP connector before any sync side effects', async () => {
+    const connector = httpConnector(null) as DecryptedConnector;
+    connector.id = connectorId;
+    const { connectorModel, connectorToolModel, ctx } = createContext(connector);
+
+    await expect(
+      syncConnectorToolsById(connectorId, ctx, [{ toolName: 'get_weather' }]),
+    ).rejects.toThrow('Client-supplied tools are only supported for stdio connectors');
+
+    expect(ensureFreshConnectorToken).not.toHaveBeenCalled();
+    expect(mcpService.listRawTools).not.toHaveBeenCalled();
+    expect(connectorToolModel.upsertMany).not.toHaveBeenCalled();
+    expect(connectorModel.updateStatus).not.toHaveBeenCalled();
+    expect(connectorModel.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects supplied tools for a STDIO connector without a command', async () => {
+    const connector = {
+      ...stdioConnector,
+      mcpStdioConfig: { args: [] },
+    } as unknown as DecryptedConnector;
+    const { connectorModel, connectorToolModel, ctx } = createContext(connector);
+
+    await expect(
+      syncConnectorToolsById(connectorId, ctx, [{ toolName: 'get_weather' }]),
+    ).rejects.toThrow('Connector has no valid STDIO configuration');
+
+    expect(ensureFreshConnectorToken).not.toHaveBeenCalled();
+    expect(mcpService.listRawTools).not.toHaveBeenCalled();
+    expect(connectorToolModel.upsertMany).not.toHaveBeenCalled();
+    expect(connectorModel.updateStatus).not.toHaveBeenCalled();
+  });
+
+  it('keeps the ID-only path fetching and normalizing tools from MCP', async () => {
+    const connector = httpConnector(null) as DecryptedConnector;
+    connector.id = connectorId;
+    const { connectorModel, connectorToolModel, ctx } = createContext(connector);
+    vi.mocked(mcpService.listRawTools).mockResolvedValue([
+      {
+        description: 'Search remotely',
+        inputSchema: { properties: { query: { type: 'string' } }, type: 'object' },
+        name: 'search_remote',
+      },
+    ] as any);
+
+    const result = await syncConnectorToolsById(connectorId, ctx);
+
+    expect(result).toEqual({ toolCount: 1 });
+    expect(ensureFreshConnectorToken).toHaveBeenCalledWith(connector, connectorModel);
+    expect(mcpService.listRawTools).toHaveBeenCalledWith({
+      auth: undefined,
+      headers: undefined,
+      name: 'My Connector',
+      type: 'http',
+      url: 'https://mcp.example.com',
+    });
+    expect(connectorToolModel.upsertMany).toHaveBeenCalledWith(connectorId, [
+      {
+        crudType: 'read',
+        description: 'Search remotely',
+        inputSchema: { properties: { query: { type: 'string' } }, type: 'object' },
+        toolName: 'search_remote',
+      },
+    ]);
+    expect(connectorModel.updateStatus).toHaveBeenCalledWith(
+      connectorId,
+      ConnectorStatus.connected,
+    );
+  });
+
+  it('keeps the ID-only MCP fetch failure status behavior', async () => {
+    const connector = httpConnector(null) as DecryptedConnector;
+    connector.id = connectorId;
+    const { connectorModel, connectorToolModel, ctx } = createContext(connector);
+    const fetchError = new Error('MCP unavailable');
+    vi.mocked(mcpService.listRawTools).mockRejectedValue(fetchError);
+
+    await expect(syncConnectorToolsById(connectorId, ctx)).rejects.toBe(fetchError);
+
+    expect(connectorModel.updateStatus).toHaveBeenCalledWith(connectorId, ConnectorStatus.error);
+    expect(connectorToolModel.upsertMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/services/connector/sync.ts
+++ b/apps/server/src/services/connector/sync.ts
@@ -13,6 +13,12 @@ export interface ConnectorToolSyncContext {
   connectorToolModel: ConnectorToolModel;
 }
 
+export interface ClientConnectorTool {
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+  toolName: string;
+}
+
 /** Build the MCP client connection params (with auth) from a connector row. */
 export const buildConnectorMcpParams = (
   connector: DecryptedConnector,
@@ -34,8 +40,7 @@ export const buildConnectorMcpParams = (
   // type. Merge them on top of any header-type credential headers (older rows
   // stored custom headers as a 'header' credential before this split).
   const customHeaders = connector.metadata?.customHeaders as Record<string, string> | undefined;
-  const mergedHeaders =
-    headers || customHeaders ? { ...headers, ...customHeaders } : undefined;
+  const mergedHeaders = headers || customHeaders ? { ...headers, ...customHeaders } : undefined;
   return {
     auth,
     headers: mergedHeaders,
@@ -87,9 +92,10 @@ export const buildHttpAuthFromCredentials = (
 };
 
 /**
- * Connect to a connector's MCP server, fetch its tool list, and sync it into
- * `user_connector_tools`. Refreshes the OAuth token first when needed, and
- * updates the connector status (`connected` on success, `error` on failure).
+ * Sync a connector's tools into `user_connector_tools`. A supplied list is
+ * accepted only for stdio connectors; otherwise tools are fetched from the MCP
+ * server after refreshing OAuth when needed. Updates status to `connected` on
+ * successful persistence and keeps the existing remote-fetch error handling.
  *
  * Shared by the `syncTools` tRPC mutation and the OAuth callback so a connector
  * has its tools immediately after authorization — no client round-trip needed.
@@ -97,32 +103,54 @@ export const buildHttpAuthFromCredentials = (
 export const syncConnectorToolsById = async (
   connectorId: string,
   ctx: ConnectorToolSyncContext,
+  clientTools?: ClientConnectorTool[],
 ): Promise<{ toolCount: number }> => {
   let connector = await ctx.connectorModel.findById(connectorId);
   if (!connector) throw new Error('Connector not found');
 
-  if (!connector.mcpServerUrl && connector.mcpConnectionType !== ConnectorMcpConnectionType.stdio) {
-    throw new Error('Connector has no MCP server URL configured');
+  let toolsToSync: ClientConnectorTool[];
+
+  if (clientTools !== undefined) {
+    if (connector.mcpConnectionType !== ConnectorMcpConnectionType.stdio) {
+      throw new Error('Client-supplied tools are only supported for stdio connectors');
+    }
+    if (!connector.mcpStdioConfig?.command?.trim()) {
+      throw new Error('Connector has no valid STDIO configuration');
+    }
+    toolsToSync = clientTools;
+  } else {
+    if (
+      !connector.mcpServerUrl &&
+      connector.mcpConnectionType !== ConnectorMcpConnectionType.stdio
+    ) {
+      throw new Error('Connector has no MCP server URL configured');
+    }
+
+    // Refresh the OAuth access token if it has expired before connecting.
+    connector = await ensureFreshConnectorToken(connector, ctx.connectorModel);
+
+    const mcpParams = buildConnectorMcpParams(connector);
+
+    let rawTools: Awaited<ReturnType<typeof mcpService.listRawTools>>;
+    try {
+      rawTools = await mcpService.listRawTools(mcpParams);
+    } catch (err) {
+      await ctx.connectorModel.updateStatus(connectorId, ConnectorStatus.error);
+      throw err;
+    }
+
+    toolsToSync = rawTools.map((tool) => ({
+      description: tool.description,
+      inputSchema: tool.inputSchema as Record<string, unknown>,
+      toolName: tool.name,
+    }));
   }
 
-  // Refresh the OAuth access token if it has expired before connecting.
-  connector = await ensureFreshConnectorToken(connector, ctx.connectorModel);
-
-  const mcpParams = buildConnectorMcpParams(connector);
-
-  let rawTools: Awaited<ReturnType<typeof mcpService.listRawTools>>;
-  try {
-    rawTools = await mcpService.listRawTools(mcpParams);
-  } catch (err) {
-    await ctx.connectorModel.updateStatus(connectorId, ConnectorStatus.error);
-    throw err;
-  }
-
-  const syncInputs = rawTools.map((t) => ({
-    crudType: inferCrudType(t.name),
-    description: t.description,
-    inputSchema: t.inputSchema as Record<string, unknown>,
-    toolName: t.name,
+  const syncInputs = toolsToSync.map((tool) => ({
+    crudType: inferCrudType(tool.toolName),
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+    toolName: tool.toolName,
   }));
 
   await ctx.connectorToolModel.upsertMany(connectorId, syncInputs);

--- a/src/helpers/toolEngineering/buildClientConnectorManifests.ts
+++ b/src/helpers/toolEngineering/buildClientConnectorManifests.ts
@@ -6,9 +6,9 @@ import type { ConnectorWithTools } from '@/store/tool/slices/connector/types';
 /**
  * Convert connector store rows into ToolManifest entries for the classic
  * (client-orchestrated) chat path, mirroring the server-side
- * `buildConnectorManifests`. The manifest carries no `mcpParams`/auth — the
- * client has no token; connector tool calls are executed server-side via
- * `connector.callTool`, which decrypts the stored credentials.
+ * `buildConnectorManifests`. The manifest carries no `mcpParams`/auth. HTTP
+ * connector calls execute server-side with stored credentials, while Desktop
+ * STDIO connectors resolve their stored process config from the connector store.
  *
  * Permission mapping:
  * - 'auto'           → humanIntervention undefined (AI calls freely)

--- a/src/helpers/toolEngineering/index.ts
+++ b/src/helpers/toolEngineering/index.ts
@@ -117,7 +117,7 @@ export const createToolsEngine = (config: ToolsEngineConfig = {}): ToolsEngine =
 
   // Get custom connector manifests (user-added MCP servers). Connectors take
   // priority over plugins: any plugin sharing a connector identifier is dropped
-  // so the connector (server-side execution with its stored token) wins.
+  // so the connector's transport-aware execution path wins.
   const connectorManifests = buildClientConnectorManifests(
     connectorSelectors.customConnectors(toolStoreState),
   );

--- a/src/services/mcp.test.ts
+++ b/src/services/mcp.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { mcpService } from './mcp';
 
+const mockConstEnv = vi.hoisted(() => ({ isDesktop: false }));
+
 const mockElectronIpc = {
   mcp: {
     callTool: vi.fn(),
@@ -16,7 +18,9 @@ const mockElectronIpc = {
 // Mock dependencies
 vi.mock('@lobechat/const', () => ({
   CURRENT_VERSION: '1.0.0',
-  isDesktop: false,
+  get isDesktop() {
+    return mockConstEnv.isDesktop;
+  },
 }));
 
 vi.mock('@lobechat/utils', () => ({
@@ -33,6 +37,13 @@ vi.mock('@lobechat/utils', () => ({
 }));
 
 vi.mock('@/libs/trpc/client', () => ({
+  lambdaClient: {
+    connector: {
+      callTool: {
+        mutate: vi.fn(),
+      },
+    },
+  },
   toolsClient: {
     market: {
       callCloudMcpEndpoint: {
@@ -76,14 +87,266 @@ vi.mock('@/store/tool/selectors', () => ({
   pluginSelectors: mockPluginSelectors,
 }));
 
+const createConnector = (overrides: Record<string, unknown> = {}) => ({
+  credentials: null,
+  id: 'connector-1',
+  identifier: 'persisted-stdio',
+  isEnabled: true,
+  mcpConnectionType: 'stdio',
+  mcpServerUrl: null,
+  mcpStdioConfig: {
+    args: ['-y', 'test-mcp-server'],
+    command: 'npx',
+    env: { API_KEY: 'local-key' },
+  },
+  metadata: null,
+  name: 'Persisted STDIO',
+  sourceType: 'custom',
+  status: 'connected',
+  tools: [
+    {
+      crudType: 'read',
+      description: 'Search locally',
+      displayName: null,
+      id: 'connector-tool-1',
+      inputSchema: { type: 'object' },
+      permission: 'auto',
+      toolName: 'search',
+      userConnectorId: 'connector-1',
+    },
+  ],
+  ...overrides,
+});
+
+const createConnectorStoreState = (connectors: ReturnType<typeof createConnector>[]) => ({
+  connectors,
+  fetchConnectors: vi.fn().mockResolvedValue(undefined),
+});
+
+const createToolPayload = (overrides: Partial<ChatToolPayload> = {}): ChatToolPayload => ({
+  id: 'connector-tool-call',
+  identifier: 'persisted-stdio',
+  apiName: 'search',
+  arguments: '{"query":"local"}',
+  type: 'standalone',
+  ...overrides,
+});
+
 describe('MCPService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+    mockConstEnv.isDesktop = false;
     mockGetToolStoreState.mockReturnValue({});
   });
 
   describe('invokeMcpToolCall', () => {
+    it('should route a persisted STDIO connector through Desktop IPC only', async () => {
+      const { lambdaClient } = await import('@/libs/trpc/client');
+      mockConstEnv.isDesktop = true;
+      const state = createConnectorStoreState([createConnector()]);
+      mockGetToolStoreState.mockReturnValue(state);
+
+      const mockResult = {
+        content: 'local result',
+        state: { content: [{ text: 'local result', type: 'text' }] },
+        success: true,
+      };
+      vi.mocked(mockElectronIpc.mcp.callTool).mockResolvedValue(
+        superjson.serialize(mockResult) as any,
+      );
+
+      const result = await mcpService.invokeMcpToolCall(createToolPayload(), {});
+
+      expect(result).toEqual(mockResult);
+      expect(state.fetchConnectors).toHaveBeenCalledOnce();
+      expect(mockElectronIpc.mcp.callTool).toHaveBeenCalledOnce();
+      expect(lambdaClient.connector.callTool.mutate).not.toHaveBeenCalled();
+    });
+
+    it('should keep a persisted STDIO connector on the server path on Web', async () => {
+      const { lambdaClient } = await import('@/libs/trpc/client');
+      mockGetToolStoreState.mockReturnValue({ connectors: [createConnector()] });
+      vi.mocked(lambdaClient.connector.callTool.mutate).mockResolvedValue('server result');
+
+      const payload = createToolPayload();
+      const result = await mcpService.invokeMcpToolCall(payload, {});
+
+      expect(result).toBe('server result');
+      expect(lambdaClient.connector.callTool.mutate).toHaveBeenCalledWith(
+        {
+          args: payload.arguments,
+          identifier: payload.identifier,
+          toolName: payload.apiName,
+        },
+        { signal: undefined },
+      );
+      expect(mockElectronIpc.mcp.callTool).not.toHaveBeenCalled();
+    });
+
+    it('should keep a persisted HTTP connector on the server path on Desktop', async () => {
+      const { lambdaClient } = await import('@/libs/trpc/client');
+      mockConstEnv.isDesktop = true;
+      mockGetToolStoreState.mockReturnValue({
+        connectors: [
+          createConnector({
+            identifier: 'persisted-http',
+            mcpConnectionType: 'http',
+            mcpServerUrl: 'http://127.0.0.1:3000/mcp',
+            mcpStdioConfig: null,
+          }),
+        ],
+      });
+      vi.mocked(lambdaClient.connector.callTool.mutate).mockResolvedValue('http result');
+
+      const payload = createToolPayload({ identifier: 'persisted-http' });
+      const result = await mcpService.invokeMcpToolCall(payload, {});
+
+      expect(result).toBe('http result');
+      expect(lambdaClient.connector.callTool.mutate).toHaveBeenCalledWith(
+        {
+          args: payload.arguments,
+          identifier: payload.identifier,
+          toolName: payload.apiName,
+        },
+        { signal: undefined },
+      );
+      expect(mockElectronIpc.mcp.callTool).not.toHaveBeenCalled();
+    });
+
+    it('should reject a Desktop STDIO connector without stored config', async () => {
+      const { lambdaClient } = await import('@/libs/trpc/client');
+      mockConstEnv.isDesktop = true;
+      mockGetToolStoreState.mockReturnValue(
+        createConnectorStoreState([createConnector({ mcpStdioConfig: null })]),
+      );
+
+      await expect(mcpService.invokeMcpToolCall(createToolPayload(), {})).rejects.toThrow(
+        'Desktop STDIO connector "persisted-stdio" is missing required mcpStdioConfig.command',
+      );
+      expect(mockElectronIpc.mcp.callTool).not.toHaveBeenCalled();
+      expect(lambdaClient.connector.callTool.mutate).not.toHaveBeenCalled();
+    });
+
+    it('should reject an unsynced Desktop STDIO tool before IPC', async () => {
+      const { lambdaClient } = await import('@/libs/trpc/client');
+      mockConstEnv.isDesktop = true;
+      mockGetToolStoreState.mockReturnValue(createConnectorStoreState([createConnector()]));
+
+      await expect(
+        mcpService.invokeMcpToolCall(createToolPayload({ apiName: 'unknown_tool' }), {}),
+      ).rejects.toThrow("Tool 'unknown_tool' is not available on this connector");
+      expect(mockElectronIpc.mcp.callTool).not.toHaveBeenCalled();
+      expect(lambdaClient.connector.callTool.mutate).not.toHaveBeenCalled();
+    });
+
+    it('should reject a disabled Desktop STDIO tool before IPC', async () => {
+      const { lambdaClient } = await import('@/libs/trpc/client');
+      mockConstEnv.isDesktop = true;
+      mockGetToolStoreState.mockReturnValue(
+        createConnectorStoreState([
+          createConnector({
+            tools: [
+              {
+                crudType: 'read',
+                description: 'Search locally',
+                displayName: null,
+                id: 'connector-tool-1',
+                inputSchema: { type: 'object' },
+                permission: 'disabled',
+                toolName: 'search',
+                userConnectorId: 'connector-1',
+              },
+            ],
+          }),
+        ]),
+      );
+
+      await expect(mcpService.invokeMcpToolCall(createToolPayload(), {})).rejects.toThrow(
+        "Tool 'search' is disabled for this connector",
+      );
+      expect(mockElectronIpc.mcp.callTool).not.toHaveBeenCalled();
+      expect(lambdaClient.connector.callTool.mutate).not.toHaveBeenCalled();
+    });
+
+    it('should parse Desktop connector args and deserialize the IPC result', async () => {
+      mockConstEnv.isDesktop = true;
+      mockGetToolStoreState.mockReturnValue(
+        createConnectorStoreState([
+          createConnector({
+            mcpStdioConfig: {
+              args: ['server.js', '--stdio'],
+              command: 'node',
+              env: { NODE_ENV: 'test' },
+            },
+          }),
+        ]),
+      );
+
+      const mockResult = {
+        content: 'parsed result',
+        state: { content: [{ text: 'parsed result', type: 'text' }] },
+        success: true,
+      };
+      vi.mocked(mockElectronIpc.mcp.callTool).mockResolvedValue(
+        superjson.serialize(mockResult) as any,
+      );
+
+      const result = await mcpService.invokeMcpToolCall(
+        createToolPayload({ arguments: '{"query":"parsed","limit":2}' }),
+        {},
+      );
+
+      const serializedInput = vi.mocked(mockElectronIpc.mcp.callTool).mock.calls[0][0];
+      expect(superjson.deserialize(serializedInput as any)).toEqual({
+        args: { limit: 2, query: 'parsed' },
+        env: { NODE_ENV: 'test' },
+        params: {
+          args: ['server.js', '--stdio'],
+          command: 'node',
+          env: { NODE_ENV: 'test' },
+          name: 'persisted-stdio',
+          type: 'stdio',
+        },
+        toolName: 'search',
+      });
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should re-read Desktop STDIO permission state before IPC', async () => {
+      const { lambdaClient } = await import('@/libs/trpc/client');
+      mockConstEnv.isDesktop = true;
+      const stale = createConnectorStoreState([createConnector()]);
+      const fresh = createConnectorStoreState([
+        createConnector({
+          tools: [
+            {
+              crudType: 'read',
+              description: 'Search locally',
+              displayName: null,
+              id: 'connector-tool-1',
+              inputSchema: { type: 'object' },
+              permission: 'disabled',
+              toolName: 'search',
+              userConnectorId: 'connector-1',
+            },
+          ],
+        }),
+      ]);
+      stale.fetchConnectors.mockImplementation(async () => {
+        mockGetToolStoreState.mockReturnValue(fresh);
+      });
+      mockGetToolStoreState.mockReturnValue(stale);
+
+      await expect(mcpService.invokeMcpToolCall(createToolPayload(), {})).rejects.toThrow(
+        "Tool 'search' is disabled for this connector",
+      );
+
+      expect(stale.fetchConnectors).toHaveBeenCalledOnce();
+      expect(mockElectronIpc.mcp.callTool).not.toHaveBeenCalled();
+      expect(lambdaClient.connector.callTool.mutate).not.toHaveBeenCalled();
+    });
+
     it('should invoke tool call with installed plugin', async () => {
       const { toolsClient } = await import('@/libs/trpc/client');
       const { discoverService } = await import('./discover');

--- a/src/services/mcp.ts
+++ b/src/services/mcp.ts
@@ -9,6 +9,7 @@ import { type PluginManifest } from '@lobehub/market-sdk';
 import { type CallReportRequest } from '@lobehub/market-types';
 import superjson from 'superjson';
 
+import { ConnectorToolPermission } from '@/database/schemas';
 import { type MCPToolCallResult } from '@/libs/mcp';
 import { toolsClient } from '@/libs/trpc/client';
 import { ensureElectronIpc } from '@/utils/electron/ipc';
@@ -30,6 +31,13 @@ function calculateObjectSizeBytes(obj: any): number {
   }
 }
 
+async function callDesktopStdioTool(data: unknown): Promise<MCPToolCallResult> {
+  const serialized = superjson.serialize(data);
+  const serializedResult = await ensureElectronIpc().mcp.callTool(serialized as any);
+
+  return superjson.deserialize(serializedResult as any) as MCPToolCallResult;
+}
+
 class MCPService {
   async invokeMcpToolCall(
     payload: ChatToolPayload,
@@ -40,22 +48,69 @@ class MCPService {
     const { pluginSelectors } = await import('@/store/tool/selectors');
     const { getToolStoreState } = await import('@/store/tool/store');
 
-    const s = getToolStoreState();
+    let s = getToolStoreState();
     const { identifier, arguments: args, apiName } = payload;
 
-    // Connector-first: custom connectors execute server-side with their stored
-    // (encrypted) OAuth token, so route them before the plugin path. The client
-    // has no credentials, hence the dedicated `connector.callTool` endpoint.
-    // Only connectors with a real MCP endpoint are routed here — Lobehub/Composio
-    // skills synced into the connector store have no mcpServerUrl and keep their
-    // original executor path.
+    // Connector-first: Desktop STDIO connectors execute through Electron IPC;
+    // HTTP connectors execute server-side with their stored credentials. Only
+    // connectors with a real MCP endpoint are routed here — Lobehub/Composio
+    // skills synced into the connector store keep their original executor path.
     const { connectorSelectors } = await import('@/store/tool/slices/connector');
-    const connector = connectorSelectors.connectorByIdentifier(identifier)(s);
+    let connector = connectorSelectors.connectorByIdentifier(identifier)(s);
+
+    if (isDesktop && connector?.mcpConnectionType === 'stdio') {
+      const connectorId = connector.id;
+      await s.fetchConnectors();
+      s = getToolStoreState();
+      connector = connectorSelectors.connectorById(connectorId)(s);
+
+      if (!connector || connector.identifier !== identifier) {
+        throw new Error(`Desktop STDIO connector "${identifier}" is no longer available`);
+      }
+      if (!connector.isEnabled) {
+        throw new Error(`Connector "${identifier}" is disabled`);
+      }
+      if (connector.mcpConnectionType !== 'stdio') {
+        throw new Error(`Connector "${identifier}" is no longer configured for STDIO`);
+      }
+    }
+
     if (
       connector &&
       connector.isEnabled &&
       (connector.mcpServerUrl || connector.mcpConnectionType === 'stdio')
     ) {
+      if (isDesktop && connector.mcpConnectionType === 'stdio') {
+        const { mcpStdioConfig } = connector;
+        const tool = connector.tools.find((item) => item.toolName === apiName);
+
+        if (!tool) {
+          throw new Error(`Tool '${apiName}' is not available on this connector`);
+        }
+        if (tool.permission === ConnectorToolPermission.disabled) {
+          throw new Error(`Tool '${apiName}' is disabled for this connector`);
+        }
+
+        if (!mcpStdioConfig?.command) {
+          throw new Error(
+            `Desktop STDIO connector "${identifier}" is missing required mcpStdioConfig.command`,
+          );
+        }
+
+        return callDesktopStdioTool({
+          args: safeParseJSON(args) ?? {},
+          env: mcpStdioConfig.env,
+          params: {
+            args: mcpStdioConfig.args ?? [],
+            command: mcpStdioConfig.command,
+            env: mcpStdioConfig.env,
+            name: identifier,
+            type: 'stdio',
+          },
+          toolName: apiName,
+        });
+      }
+
       const { lambdaClient } = await import('@/libs/trpc/client');
       return (await lambdaClient.connector.callTool.mutate(
         { args, identifier, toolName: apiName },
@@ -158,9 +213,7 @@ class MCPService {
       } else if (isDesktop && isStdio) {
         // For desktop and stdio, use IPC (main process)
         // Note: IPC doesn't support AbortSignal yet
-        const serialized = superjson.serialize(data);
-        const serializedResult = await ensureElectronIpc().mcp.callTool(serialized as any);
-        result = superjson.deserialize(serializedResult as any) as any;
+        result = await callDesktopStdioTool(data);
       } else {
         // For other types, use the toolsClient
         result = await toolsClient.mcp.callTool.mutate(data, { signal });

--- a/src/store/tool/slices/connector/action.test.ts
+++ b/src/store/tool/slices/connector/action.test.ts
@@ -1,0 +1,265 @@
+import type * as LobechatConstModule from '@lobechat/const';
+import type { ToolManifest } from '@lobechat/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { StoreSetter } from '@/store/types';
+
+import type { ToolStore } from '../../store';
+import { ConnectorActionImpl } from './action';
+import type { ConnectorWithTools } from './types';
+
+const desktopEnv = vi.hoisted(() => ({ isDesktop: true }));
+
+vi.mock('@lobechat/const', async (importOriginal) => {
+  const actual = await importOriginal<typeof LobechatConstModule>();
+  return {
+    ...actual,
+    get isDesktop() {
+      return desktopEnv.isDesktop;
+    },
+  };
+});
+
+const clientMocks = vi.hoisted(() => ({
+  listAgentBoundConnectors: vi.fn(),
+  listConnectors: vi.fn(),
+  syncTools: vi.fn(),
+}));
+
+vi.mock('@/libs/trpc/client', () => ({
+  lambdaClient: {
+    connector: {
+      list: { query: clientMocks.listConnectors },
+      listAgentBound: { query: clientMocks.listAgentBoundConnectors },
+      syncTools: { mutate: clientMocks.syncTools },
+    },
+  },
+}));
+
+const mcpMocks = vi.hoisted(() => ({
+  getStdioMcpServerManifest: vi.fn(),
+}));
+
+vi.mock('@/services/mcp', () => ({
+  mcpService: {
+    getStdioMcpServerManifest: mcpMocks.getStdioMcpServerManifest,
+  },
+}));
+
+const createConnector = (
+  id: string,
+  mcpConnectionType: string,
+  overrides: Partial<ConnectorWithTools> = {},
+): ConnectorWithTools => ({
+  credentials: null,
+  id,
+  identifier: `${id}-identifier`,
+  isEnabled: true,
+  mcpConnectionType,
+  mcpServerUrl: mcpConnectionType === 'http' ? 'https://mcp.example.com' : null,
+  mcpStdioConfig: null,
+  metadata: null,
+  name: `${id} name`,
+  sourceType: 'custom',
+  status: 'connected',
+  tools: [],
+  ...overrides,
+});
+
+const createAction = (
+  connectors: ConnectorWithTools[],
+  agentBoundConnectors: ConnectorWithTools[] = [],
+) => {
+  const state = {
+    agentBoundConnectors,
+    connectorCreating: false,
+    connectors,
+    connectorSyncing: {},
+    isAgentBoundInit: agentBoundConnectors.length > 0,
+    isConnectorsInit: true,
+  } as ToolStore;
+  const set = ((partial: Parameters<StoreSetter<ToolStore>>[0]) => {
+    const next = typeof partial === 'function' ? partial(state) : partial;
+    Object.assign(state, next);
+  }) as StoreSetter<ToolStore>;
+
+  return { action: new ConnectorActionImpl(set, () => state), state };
+};
+
+const manifest: ToolManifest = {
+  api: [
+    {
+      description: 'Find matching items',
+      name: 'find_items',
+      parameters: {
+        properties: { query: { type: 'string' } },
+        required: ['query'],
+        type: 'object',
+      },
+    },
+  ],
+  identifier: 'target-connector',
+  meta: { title: 'Target connector' },
+  type: 'mcp',
+};
+
+beforeEach(() => {
+  desktopEnv.isDesktop = true;
+  clientMocks.listAgentBoundConnectors.mockReset().mockResolvedValue([]);
+  clientMocks.listConnectors.mockReset().mockResolvedValue([]);
+  clientMocks.syncTools.mockReset().mockResolvedValue({ toolCount: 1 });
+  mcpMocks.getStdioMcpServerManifest.mockReset().mockResolvedValue(manifest);
+});
+
+describe('ConnectorActionImpl.syncConnectorTools', () => {
+  it('fetches a Desktop STDIO manifest locally and syncs mapped tools by exact ID', async () => {
+    const id = 'target-id';
+    const decoy = createConnector('other-id', 'http', { identifier: id });
+    const target = createConnector(id, 'stdio', {
+      mcpStdioConfig: {
+        args: ['server.js', '--stdio'],
+        command: 'node',
+        env: { MCP_TOKEN: 'local-only' },
+      },
+      name: 'Target connector',
+    });
+    const { action, state } = createAction([decoy, target]);
+
+    await action.syncConnectorTools(id);
+
+    expect(mcpMocks.getStdioMcpServerManifest).toHaveBeenCalledWith({
+      args: ['server.js', '--stdio'],
+      command: 'node',
+      env: { MCP_TOKEN: 'local-only' },
+      name: 'Target connector',
+    });
+    expect(clientMocks.syncTools).toHaveBeenCalledOnce();
+    expect(clientMocks.syncTools).toHaveBeenCalledWith({
+      id,
+      tools: [
+        {
+          description: 'Find matching items',
+          inputSchema: {
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+            type: 'object',
+          },
+          toolName: 'find_items',
+        },
+      ],
+    });
+    expect(clientMocks.listConnectors).toHaveBeenCalledOnce();
+    expect(state.connectorSyncing[id]).toBe(false);
+  });
+
+  it('propagates a local fetch error, clears syncing state, and does not fall back remotely', async () => {
+    const id = 'stdio-id';
+    const error = new Error('STDIO process failed');
+    const connector = createConnector(id, 'stdio', {
+      mcpStdioConfig: { command: 'broken-command' },
+    });
+    const { action, state } = createAction([connector]);
+    mcpMocks.getStdioMcpServerManifest.mockRejectedValueOnce(error);
+
+    await expect(action.syncConnectorTools(id)).rejects.toBe(error);
+
+    expect(clientMocks.syncTools).not.toHaveBeenCalled();
+    expect(clientMocks.listConnectors).not.toHaveBeenCalled();
+    expect(state.connectorSyncing[id]).toBe(false);
+  });
+
+  it('uses the ID-only sync path for Web STDIO', async () => {
+    desktopEnv.isDesktop = false;
+    const id = 'web-stdio-id';
+    const connector = createConnector(id, 'stdio', {
+      mcpStdioConfig: { command: 'node' },
+    });
+    const { action, state } = createAction([connector]);
+
+    await action.syncConnectorTools(id);
+
+    expect(mcpMocks.getStdioMcpServerManifest).not.toHaveBeenCalled();
+    expect(clientMocks.syncTools).toHaveBeenCalledWith({ id });
+    expect(state.connectorSyncing[id]).toBe(false);
+  });
+
+  it('uses the ID-only sync path for Desktop HTTP', async () => {
+    const id = 'desktop-http-id';
+    const { action, state } = createAction([createConnector(id, 'http')]);
+
+    await action.syncConnectorTools(id);
+
+    expect(mcpMocks.getStdioMcpServerManifest).not.toHaveBeenCalled();
+    expect(clientMocks.syncTools).toHaveBeenCalledWith({ id });
+    expect(state.connectorSyncing[id]).toBe(false);
+  });
+
+  it('syncs an agent-bound Desktop STDIO connector and refreshes its connector pool', async () => {
+    const id = 'agent-stdio-id';
+    const connector = createConnector(id, 'stdio', {
+      agentId: 'agent-id',
+      mcpStdioConfig: { command: 'node' },
+    });
+    const { action, state } = createAction([], [connector]);
+    clientMocks.listAgentBoundConnectors.mockResolvedValue([connector]);
+
+    await action.syncConnectorTools(id);
+
+    expect(mcpMocks.getStdioMcpServerManifest).toHaveBeenCalledOnce();
+    expect(clientMocks.syncTools).toHaveBeenCalledWith({
+      id,
+      tools: [
+        expect.objectContaining({
+          inputSchema: expect.objectContaining({ type: 'object' }),
+          toolName: 'find_items',
+        }),
+      ],
+    });
+    expect(clientMocks.listAgentBoundConnectors).toHaveBeenCalledOnce();
+    expect(state.connectorSyncing[id]).toBe(false);
+  });
+
+  it('refreshes a cold Desktop store before choosing the STDIO path', async () => {
+    const id = 'missing-id';
+    const connector = createConnector(id, 'stdio', {
+      mcpStdioConfig: { command: 'node' },
+    });
+    const { action, state } = createAction([]);
+    clientMocks.listConnectors.mockResolvedValue([connector]);
+
+    await action.syncConnectorTools(id);
+
+    expect(mcpMocks.getStdioMcpServerManifest).toHaveBeenCalledOnce();
+    expect(clientMocks.syncTools).toHaveBeenCalledWith({
+      id,
+      tools: [
+        {
+          description: 'Find matching items',
+          inputSchema: {
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+            type: 'object',
+          },
+          toolName: 'find_items',
+        },
+      ],
+    });
+    expect(clientMocks.listConnectors).toHaveBeenCalledTimes(2);
+    expect(state.connectorSyncing[id]).toBe(false);
+  });
+
+  it('fails closed when a missing Desktop connector is still absent after refresh', async () => {
+    const id = 'missing-id';
+    const { action, state } = createAction([]);
+
+    await expect(action.syncConnectorTools(id)).rejects.toThrow(
+      `Connector ${id} was not found after refresh`,
+    );
+
+    expect(mcpMocks.getStdioMcpServerManifest).not.toHaveBeenCalled();
+    expect(clientMocks.syncTools).not.toHaveBeenCalled();
+    expect(clientMocks.listConnectors).toHaveBeenCalledOnce();
+    expect(clientMocks.listAgentBoundConnectors).toHaveBeenCalledOnce();
+    expect(state.connectorSyncing[id]).toBe(false);
+  });
+});

--- a/src/store/tool/slices/connector/action.ts
+++ b/src/store/tool/slices/connector/action.ts
@@ -1,8 +1,13 @@
+import { isDesktop } from '@lobechat/const';
+import type { ToolManifest } from '@lobechat/types';
+
 import type { ConnectorToolPermission } from '@/database/schemas';
 import { lambdaClient } from '@/libs/trpc/client';
+import { mcpService } from '@/services/mcp';
 import type { StoreSetter } from '@/store/types';
 
 import type { ToolStore } from '../../store';
+import { connectorSelectors } from './selectors';
 
 type Setter = StoreSetter<ToolStore>;
 
@@ -10,13 +15,13 @@ export const createConnectorSlice = (set: Setter, get: () => ToolStore, _api?: u
   new ConnectorActionImpl(set, get, _api);
 
 export class ConnectorActionImpl {
-  readonly #set: Setter;
   readonly #get: () => ToolStore;
+  readonly #set: Setter;
 
   constructor(set: Setter, get: () => ToolStore, _api?: unknown) {
     void _api;
-    this.#set = set;
     this.#get = get;
+    this.#set = set;
   }
 
   fetchConnectors = async (): Promise<void> => {
@@ -161,7 +166,42 @@ export class ConnectorActionImpl {
       'syncConnectorTools/start',
     );
     try {
-      await lambdaClient.connector.syncTools.mutate({ id });
+      let connector = connectorSelectors.connectorById(id)(this.#get());
+
+      // A cold Desktop store cannot safely decide whether the connector is
+      // local STDIO. Check both current connector pools before falling back.
+      if (isDesktop && !connector) {
+        await this.fetchConnectors();
+        connector = connectorSelectors.connectorById(id)(this.#get());
+        if (!connector) {
+          await this.fetchAgentBoundConnectors();
+          connector = connectorSelectors.connectorById(id)(this.#get());
+        }
+        if (!connector) throw new Error(`Connector ${id} was not found after refresh`);
+      }
+
+      if (isDesktop && connector?.mcpConnectionType === 'stdio') {
+        const config = connector.mcpStdioConfig;
+        if (!config) throw new Error(`Connector ${id} is missing its STDIO configuration`);
+        if (!config.command?.trim())
+          throw new Error(`Connector ${id} is missing its STDIO command`);
+
+        const manifest: ToolManifest = await mcpService.getStdioMcpServerManifest({
+          args: config.args,
+          command: config.command,
+          env: config.env,
+          name: connector.name,
+        });
+        const tools = manifest.api.map(({ description, name, parameters }) => ({
+          description,
+          inputSchema: parameters,
+          toolName: name,
+        }));
+
+        await lambdaClient.connector.syncTools.mutate({ id, tools });
+      } else {
+        await lambdaClient.connector.syncTools.mutate({ id });
+      }
       await this.#refreshConnectorLists();
     } finally {
       this.#set(

--- a/src/store/tool/slices/connector/types.ts
+++ b/src/store/tool/slices/connector/types.ts
@@ -1,4 +1,4 @@
-import type { ConnectorToolPermission } from '@/database/schemas';
+import type { ConnectorToolPermission, UserConnectorItem } from '@/database/schemas';
 
 export interface ConnectorTool {
   crudType: string;
@@ -20,6 +20,7 @@ export interface ConnectorWithTools {
   isEnabled: boolean;
   mcpConnectionType: string | null;
   mcpServerUrl: string | null;
+  mcpStdioConfig: UserConnectorItem['mcpStdioConfig'];
   metadata: Record<string, unknown> | null;
   name: string;
   sourceType: string;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Related to #16533

#### 🔀 Description of Change

Desktop already discovers STDIO tools through Electron IPC, but connector sync previously asked the remote backend to spawn the device-local process. Persisted connector calls followed the remote path as well.

This change keeps the Desktop STDIO lifecycle local while preserving server-owned persistence and permissions:

- fetch the STDIO manifest through IPC and persist normalized tools against the existing connector UUID;
- accept bounded client-supplied tools only for an owned STDIO connector with valid stored configuration;
- run persisted Desktop STDIO connector calls through IPC after refreshing connector state and rejecting unknown or disabled tools;
- keep Web STDIO and Desktop HTTP on their existing server paths.

Private/LAN Streamable HTTP is intentionally out of scope. HTTP sync and execution can depend on server-held credentials and OAuth refresh, while the Desktop connector list excludes those secrets. Persisting previewed tools alone would not fix execution, so local HTTP needs a separate secure credential and routing design.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Repository changed-file check: 11 files, 79 tests passed.
- Connector and migration regression suite: 8 files, 104 tests passed.
- Real Desktop `MCPClient` STDIO smoke: listed `echo`, `debug`, and `add`, then successfully invoked `echo` through a spawned MCP process.

#### 📸 Screenshots / Videos

N/A — no UI change.

#### 📝 Additional Information

- No database migration.
- No credentials, command, environment variables, or STDIO configuration are sent in the tool-persistence payload.
