### PR TITLE
♻️ refactor: store message usage in top-level column

### DIFF
--- a/packages/conversation-flow/src/transformation/MessageTransformer.ts
+++ b/packages/conversation-flow/src/transformation/MessageTransformer.ts
@@ -15,7 +15,7 @@ export class MessageTransformer {
    * Convert a Message to AssistantContentBlock
    */
   messageToContentBlock(message: Message): AssistantContentBlock {
-    const { usage, performance } = this.splitMetadata(message.metadata);
+    const { usage, performance } = this.splitMetadata(message.metadata, message.usage);
 
     return {
       content: message.content || '',
@@ -39,16 +39,20 @@ export class MessageTransformer {
    * - **Flat** (legacy): `metadata.totalTokens`, `metadata.ttft`, etc — older write paths
    *   that splatted token fields directly onto metadata.
    *
-   * Nested takes priority; flat fields fill in any missing keys (transition state).
+   * Top-level usage takes priority. Nested and flat metadata fields only fill in
+   * missing keys for legacy rows during the migration period.
    */
-  splitMetadata(metadata?: any): {
+  splitMetadata(
+    metadata?: any,
+    topLevelUsage?: ModelUsage,
+  ): {
     performance?: ModelPerformance;
     usage?: ModelUsage;
   } {
-    if (!metadata) return {};
+    if (!metadata && !topLevelUsage) return {};
 
-    const usage: ModelUsage = { ...metadata.usage };
-    const performance: ModelPerformance = { ...metadata.performance };
+    const usage: ModelUsage = { ...metadata?.usage, ...topLevelUsage };
+    const performance: ModelPerformance = { ...metadata?.performance };
     let hasUsage = Object.keys(usage).length > 0;
     let hasPerformance = Object.keys(performance).length > 0;
 
@@ -75,7 +79,7 @@ export class MessageTransformer {
     ] as const;
 
     usageFields.forEach((field) => {
-      if (metadata[field] !== undefined && (usage as any)[field] === undefined) {
+      if (metadata?.[field] !== undefined && (usage as any)[field] === undefined) {
         (usage as any)[field] = metadata[field];
         hasUsage = true;
       }
@@ -83,7 +87,7 @@ export class MessageTransformer {
 
     const performanceFields = ['duration', 'latency', 'tps', 'ttft'] as const;
     performanceFields.forEach((field) => {
-      if (metadata[field] !== undefined && (performance as any)[field] === undefined) {
+      if (metadata?.[field] !== undefined && (performance as any)[field] === undefined) {
         (performance as any)[field] = metadata[field];
         hasPerformance = true;
       }

--- a/packages/conversation-flow/src/transformation/__tests__/MessageTransformer.test.ts
+++ b/packages/conversation-flow/src/transformation/__tests__/MessageTransformer.test.ts
@@ -61,6 +61,22 @@ describe('MessageTransformer', () => {
       expect(result.usage).toBeUndefined();
       expect(result.performance).toBeUndefined();
     });
+
+    it('should prefer top-level usage over metadata.usage', () => {
+      const message: Message = {
+        content: 'Hello',
+        createdAt: 0,
+        id: 'msg-1',
+        metadata: { usage: { cost: 0.001, totalTokens: 100 } },
+        role: 'assistant',
+        updatedAt: 0,
+        usage: { cost: 0.002, totalTokens: 200 },
+      };
+
+      const result = transformer.messageToContentBlock(message);
+
+      expect(result.usage).toEqual({ cost: 0.002, totalTokens: 200 });
+    });
   });
 
   describe('splitMetadata', () => {
@@ -120,6 +136,19 @@ describe('MessageTransformer', () => {
 
       expect(result.performance).toEqual({
         duration: 1000,
+      });
+    });
+
+    it('should use metadata.usage only as a fallback for missing top-level fields', () => {
+      const result = transformer.splitMetadata(
+        { usage: { cost: 0.001, totalInputTokens: 10, totalTokens: 100 } },
+        { cost: 0.002, totalTokens: 200 },
+      );
+
+      expect(result.usage).toEqual({
+        cost: 0.002,
+        totalInputTokens: 10,
+        totalTokens: 200,
       });
     });
   });

--- a/packages/database/src/models/__tests__/messages/message.create.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.create.test.ts
@@ -104,8 +104,7 @@ describe('MessageModel Create Tests', () => {
       });
 
       expect(result.usage).toEqual(usage);
-      // metadata.usage stays written for backward-compatible reads
-      expect((result.metadata as any).usage).toEqual(usage);
+      expect((result.metadata as any).usage).toBeUndefined();
     });
 
     it('prefers a top-level usage over metadata.usage on create', async () => {
@@ -119,6 +118,7 @@ describe('MessageModel Create Tests', () => {
       });
 
       expect(result.usage).toEqual(topLevel);
+      expect((result.metadata as any).usage).toBeUndefined();
     });
 
     it('should generate message ID automatically', async () => {

--- a/packages/database/src/models/__tests__/messages/message.update.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.update.test.ts
@@ -1635,8 +1635,7 @@ describe('MessageModel Update Tests', () => {
 
       const [row] = await serverDB.select().from(messages).where(eq(messages.id, 'promote-msg'));
       expect(row.usage).toEqual(usage);
-      // metadata.usage stays written for backward-compatible reads
-      expect((row.metadata as any).usage).toEqual(usage);
+      expect((row.metadata as any).usage).toBeUndefined();
     });
 
     it('prefers a top-level usage over metadata.usage', async () => {
@@ -1654,11 +1653,10 @@ describe('MessageModel Update Tests', () => {
 
       const [row] = await serverDB.select().from(messages).where(eq(messages.id, 'prefer-msg'));
       expect(row.usage).toEqual(topLevel);
-      // metadata.usage is kept consistent with the column
-      expect((row.metadata as any).usage).toEqual(topLevel);
+      expect((row.metadata as any).usage).toBeUndefined();
     });
 
-    it('dual-writes metadata.usage when usage arrives as a top-level param only', async () => {
+    it('writes top-level usage without duplicating it into metadata', async () => {
       await serverDB.insert(messages).values({
         id: 'top-only-msg',
         metadata: { tps: 1 }, // pre-existing non-usage metadata must be preserved
@@ -1672,8 +1670,7 @@ describe('MessageModel Update Tests', () => {
 
       const [row] = await serverDB.select().from(messages).where(eq(messages.id, 'top-only-msg'));
       expect(row.usage).toEqual(usage);
-      // legacy readers / rollback paths still see metadata.usage
-      expect((row.metadata as any).usage).toEqual(usage);
+      expect((row.metadata as any).usage).toBeUndefined();
       expect((row.metadata as any).tps).toBe(1);
     });
 
@@ -1685,7 +1682,7 @@ describe('MessageModel Update Tests', () => {
 
       const [row] = await serverDB.select().from(messages).where(eq(messages.id, 'meta-msg'));
       expect(row.usage).toEqual(usage);
-      expect((row.metadata as any).usage).toEqual(usage);
+      expect((row.metadata as any).usage).toBeUndefined();
     });
   });
 });

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -2248,7 +2248,7 @@ export class MessageModel {
                     .where(and(eq(messages.id, id), this.ownership())),
               );
               mergedMetadata = merge(existingMessage?.metadata || {}, metadataPatch);
-              if (usageToWrite) delete mergedMetadata.usage;
+              if (usageToWrite && mergedMetadata) delete mergedMetadata.usage;
             }
             const metadataToWrite = mergedMetadata;
 

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -1939,6 +1939,8 @@ export class MessageModel {
   ) => {
     // Ensure group message does not populate sessionId
     const normalizedMessage = message.groupId ? { ...message, sessionId: null } : message;
+    const { usage: legacyUsage, ...metadata } =
+      (normalizedMessage.metadata as Record<string, any> | undefined) || {};
 
     return buildWorkspacePayload(
       { userId: this.userId, workspaceId: this.workspaceId },
@@ -1949,14 +1951,13 @@ export class MessageModel {
         // TODO: remove this when the client is updated
         createdAt: createdAt ? new Date(createdAt) : undefined,
         id,
+        metadata: normalizedMessage.metadata ? metadata : undefined,
         model: fromModel,
         provider: fromProvider,
         updatedAt: updatedAt ? new Date(updatedAt) : undefined,
         // Promote token usage into the dedicated `usage` column, preferring a
         // top-level `usage` over the legacy `metadata.usage`.
-        usage:
-          normalizedMessage.usage ??
-          (normalizedMessage.metadata as { usage?: ModelUsage } | undefined)?.usage,
+        usage: normalizedMessage.usage ?? (legacyUsage as ModelUsage | undefined),
       },
     );
   };
@@ -2200,19 +2201,11 @@ export class MessageModel {
     { imageList, metadata, usage, ...message }: Partial<UpdateMessageParams>,
     timing?: ModelTimingContext,
   ): Promise<{ success: boolean }> => {
-    // Promote token usage into the dedicated `usage` column. Prefer a top-level
-    // `usage` payload, falling back to `metadata.usage` so existing writers
-    // (Gateway / hetero-agent executors) keep populating the column without
-    // changes. `metadata.usage` is still written for backward-compatible reads.
-    const usageToWrite = usage ?? (metadata as { usage?: ModelUsage } | undefined)?.usage;
-    // Keep `metadata.usage` dual-written even when usage arrives as a top-level
-    // param (with no metadata payload) — legacy readers / rollback paths still
-    // consume it during the transition. Folding the resolved usage into the
-    // patch also keeps it consistent with the column when both are sent.
-    const metadataPatch =
-      metadata || usageToWrite
-        ? { ...metadata, ...(usageToWrite && { usage: usageToWrite }) }
-        : undefined;
+    // Accept legacy callers that still send `metadata.usage`, but persist usage
+    // exclusively in the dedicated top-level column.
+    const { usage: legacyUsage, ...metadataPatch } = (metadata as Record<string, any>) || {};
+    const usageToWrite = usage ?? (legacyUsage as ModelUsage | undefined);
+    const shouldUpdateMetadata = !!metadata || !!usageToWrite;
     // A patch that matches no row is a lost write, not a no-op: the caller asked
     // to persist content onto `id` and it went nowhere. Batched writers key their
     // retry ledger off this flag, so reporting success here silently drops data.
@@ -2241,10 +2234,10 @@ export class MessageModel {
               );
             }
 
-            // 2. Handle metadata merge if there's a metadata payload or a
-            // top-level usage to fold back into `metadata.usage`.
+            // 2. Merge non-usage metadata. A usage-bearing update also removes
+            // any legacy `metadata.usage` left on the existing row.
             let mergedMetadata: Record<string, any> | undefined;
-            if (metadataPatch) {
+            if (shouldUpdateMetadata) {
               const [existingMessage] = await runTimedStage(
                 timing,
                 'db.message.update.metadata.select',
@@ -2255,6 +2248,7 @@ export class MessageModel {
                     .where(and(eq(messages.id, id), this.ownership())),
               );
               mergedMetadata = merge(existingMessage?.metadata || {}, metadataPatch);
+              if (usageToWrite) delete mergedMetadata.usage;
             }
             const metadataToWrite = mergedMetadata;
 
@@ -2293,7 +2287,7 @@ export class MessageModel {
           }),
         {
           hasImageList: !!imageList?.length,
-          hasMetadata: !!metadataPatch,
+          hasMetadata: shouldUpdateMetadata,
           valueKeys: Object.keys(message),
         },
       );
@@ -2317,10 +2311,9 @@ export class MessageModel {
 
     if (!item) return;
 
-    const mergedMetadata = merge(item.metadata || {}, metadata);
-    // Keep the dedicated `usage` column in sync when the merged metadata carries
-    // token usage, preferring it over the existing column value.
-    const usageToWrite = (metadata as { usage?: ModelUsage } | undefined)?.usage;
+    const { usage: usageToWrite, ...metadataPatch } = metadata as Record<string, any>;
+    const mergedMetadata = merge(item.metadata || {}, metadataPatch);
+    if (usageToWrite) delete mergedMetadata.usage;
 
     return this.db
       .update(messages)

--- a/packages/database/src/schemas/message.ts
+++ b/packages/database/src/schemas/message.ts
@@ -108,8 +108,8 @@ export const messages = pgTable(
     metadata: jsonb('metadata'),
     /**
      * Token usage + cost for this message, promoted out of `metadata.usage`
-     * into a dedicated column. `metadata.usage` stays the source of truth during
-     * the dual-write transition; new reads/aggregations should target this column.
+     * into a dedicated column. New writes target this column exclusively;
+     * readers may temporarily fall back to `metadata.usage` for legacy rows.
      */
     usage: jsonb('usage').$type<ModelUsage>(),
 

--- a/src/utils/subagentMetrics.test.ts
+++ b/src/utils/subagentMetrics.test.ts
@@ -28,6 +28,18 @@ describe('aggregateSubagentMetrics', () => {
     expect(result.totalTokens).toBe(1000);
   });
 
+  it('prefers top-level usage when both storage shapes are present', () => {
+    const result = aggregateSubagentMetrics([
+      {
+        metadata: { usage: { totalTokens: 700 } },
+        role: 'assistant',
+        usage: { totalTokens: 300 },
+      },
+    ]);
+
+    expect(result.totalTokens).toBe(300);
+  });
+
   it('returns zeros / undefined model for an empty or usage-less set', () => {
     expect(aggregateSubagentMetrics([])).toEqual({
       model: undefined,

--- a/src/utils/subagentMetrics.ts
+++ b/src/utils/subagentMetrics.ts
@@ -43,7 +43,7 @@ export const aggregateSubagentMetrics = (messages: MetricMessage[]): SubagentMet
       // dbMessagesMap holds the raw DB shape (`metadata.usage`); the
       // display-bound UIChatMessage promotes it to a top-level `usage` — accept
       // either so the same helper serves both call sites.
-      totalTokens += m.metadata?.usage?.totalTokens ?? m.usage?.totalTokens ?? 0;
+      totalTokens += m.usage?.totalTokens ?? m.metadata?.usage?.totalTokens ?? 0;
       if (!model && m.model) model = m.model;
     }
   }


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Stop dual-writing message usage into `metadata.usage` in the database model layer.
- Keep accepting legacy `metadata.usage` inputs, promote them into the dedicated top-level `usage` column, and remove the legacy metadata key on usage-bearing writes.
- Preserve all non-usage metadata during create/update/updateMetadata flows.
- Prefer top-level `usage` in MessageTransformer and subagent metrics while retaining `metadata.usage` as a legacy read fallback.
- Update schema documentation and regression tests.

Heterogeneous-agent callers that still submit `metadata.usage` are intentionally left unchanged for a follow-up change. The model layer nevertheless normalizes those writes into the top-level column.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation performed:

- Conversation-flow and subagent metrics focused tests: 19 passed.
- Lint passed for all 8 changed files.
- `git diff --check` passed.
- Database test suites could not load with the existing local dependency tree because the latest canary database tests require `@electric-sql/pglite`, which is not installed in the reused workspace dependencies.

#### 📸 Screenshots / Videos

Not applicable; no visual changes.

#### 📝 Additional Information

`metadata.usage` read fallbacks remain in place for historical rows and can be removed in a later cleanup after the compatibility window.