### PR TITLE
🧪 test: add local S3 storage for agent testing

### DIFF
--- a/.agents/skills/agent-testing/SKILL.md
+++ b/.agents/skills/agent-testing/SKILL.md
@@ -171,6 +171,7 @@ Bootstrap flow when no `.env` exists:
 ```bash
 # From repo root. Managed Postgres/Redis flow requires Docker Desktop.
 ./.agents/skills/agent-testing/scripts/init-dev-env.sh setup-db
+./.agents/skills/agent-testing/scripts/init-dev-env.sh s3 # terminal B — keep running
 ./.agents/skills/agent-testing/scripts/init-dev-env.sh seed-user
 ./.agents/skills/agent-testing/scripts/init-dev-env.sh dev
 ```
@@ -199,9 +200,32 @@ Useful subcommands:
 ./.agents/skills/agent-testing/scripts/init-dev-env.sh migrate   # migrations only
 ./.agents/skills/agent-testing/scripts/init-dev-env.sh seed-user # seed user + CLI API key
 ./.agents/skills/agent-testing/scripts/init-dev-env.sh qstash    # local QStash for workflow paths
-./.agents/skills/agent-testing/scripts/init-dev-env.sh preflight # gate agent-runtime tests (QStash up in queue mode)
+./.agents/skills/agent-testing/scripts/init-dev-env.sh s3        # local S3-compatible file storage
+./.agents/skills/agent-testing/scripts/init-dev-env.sh preflight # gate agent-runtime tests (QStash + S3)
 ./.agents/skills/agent-testing/scripts/init-dev-env.sh clean-db  # remove managed DB container
+./.agents/skills/agent-testing/scripts/init-dev-env.sh clean-s3  # remove persisted local S3 objects
 ```
+
+#### Local file storage: s3rver MUST be up
+
+The no-`.env` bootstrap points the app at a local `s3rver` instance so browser
+uploads, presigned URLs, attachments, and generated files exercise a real S3
+HTTP round trip instead of a placeholder endpoint. Start it in a separate
+terminal before the dev server:
+
+```bash
+./.agents/skills/agent-testing/scripts/init-dev-env.sh s3
+```
+
+The command creates `agent-testing-bucket`, configures CORS for the allocated
+local app/SPA origins, and persists objects under
+`.records/data/agent-testing-s3`. The fixed `S3RVER` credentials are required by
+the emulator's presigned-URL validation. `preflight` performs HeadBucket plus a
+real Put/Get/Delete round trip; a listening port alone is not considered ready.
+
+Keep this storage local to the product-under-test. Step 4 report publishing
+still runs in a clean production CLI environment and uploads evidence to
+production storage.
 
 #### Agent-runtime prerequisite: QStash MUST be up (queue mode)
 
@@ -240,7 +264,7 @@ Default script env:
   in a separate terminal for **any agent-runtime test** (see the agent-runtime
   prerequisite above), not only workflow paths.
 - `KEY_VAULTS_SECRET`, `AUTH_SECRET`, auth verification off
-- S3 mock vars
+- Local S3-compatible storage vars (`s3rver`; start with the `s3` subcommand)
 - Managed DB container: `lobehub-agent-testing-postgres`
 - Managed Redis container: `lobehub-agent-testing-redis`
 
@@ -422,7 +446,7 @@ All under `.agents/skills/agent-testing/scripts/`:
 | ------------------------------- | ------------------------------------------------------------------------------------------- |
 | `test-env.sh`                   | Print/export the resolved local test env and ports                                          |
 | `setup-auth.sh`                 | One-stop auth setup & status check (`status` / `cli` / `web`)                               |
-| `init-dev-env.sh`               | Self-contained local dev env (`setup-db` / `seed-user` / `dev-next` / `dev`)                |
+| `init-dev-env.sh`               | Self-contained local dev env (`setup-db` / `s3` / `seed-user` / `dev-next` / `dev`)         |
 | `app-probe.sh`                  | LobeHub app probes: `auth` / `route` / `ops` / `goto <path>` / `errors`                     |
 | `agent-browser-klm.mjs`         | Wrap `agent-browser`, run the real action, and append a GOMS-KLM interaction atom JSONL     |
 | `agent-browser-klm-analyze.mjs` | Summarize interaction JSONL into `result.json.interactionCost` / markdown cost output       |

--- a/.agents/skills/agent-testing/references/probe-mock-patterns.md
+++ b/.agents/skills/agent-testing/references/probe-mock-patterns.md
@@ -414,6 +414,30 @@ Re-tested end-to-end against the running dev server. The previous claim ("blocks
     text stays short, then read its `button`s (`[Close, 重试]`).
     Pick fixture names that do NOT contain any state keyword you'll assert on.
 
+### C6. ✅ WORKS — read a topic's metadata (workingDirectoryConfig etc.) from the chat store, and reset to a fresh topic
+
+- **Doesn't work**: `chat().topicsMap[topicId]` / `chat().topicDataMap[topicId]` — there is
+  no per-topic-id map. `topicDataMap` is keyed by **view key** (`agent_<agentId>`), and each
+  value is a paginated view object (`{ items, total, hasMore, … }`), not a topic.
+- **Works** (verified while E2E-testing `git worktree add` side-effect recording):
+  ```js
+  var c = window.__LOBE_STORES.chat();
+  var view = c.topicDataMap['agent_' + agentId];
+  var topic = (view.items || []).find(function (x) {
+    return x.id === c.activeTopicId;
+  });
+  topic.metadata.workingDirectoryConfig; // ← e.g. git.activeWorktree written by recordGitCommandEffects
+  ```
+- **Fresh topic without touching the UI**: `await c.openNewTopicOrSaveTopic()` — with an
+  active topic it saves/exits to the agent's no-topic compose state (activeTopicId → null),
+  so the next send creates a new topic. Chain per-case fixtures this way instead of clicking
+  "Start New Topic". The contenteditable ref changes after the switch — re-run
+  `snapshot -i -C` before typing.
+- Full E2E loop this enabled: E11 fixture agent (`heterogeneousProvider: { type: 'claude-code' },
+executionTarget: 'local'` in `agencyConfig`) + one message per case asking CC to run a
+  specific shell command → poll `chat().operations` for `running === 0` → assert the
+  topic's metadata via the probe above. A real CC one-command turn completes in \~10–20s.
+
 ---
 
 ## D. agent-browser / CDP mechanics

--- a/.agents/skills/agent-testing/scripts/check-s3.mjs
+++ b/.agents/skills/agent-testing/scripts/check-s3.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadBucketCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+
+const endpoint = process.env.S3_ENDPOINT;
+const bucket = process.env.S3_BUCKET;
+
+if (!endpoint || !bucket) {
+  console.error('S3_ENDPOINT and S3_BUCKET are required.');
+  process.exit(1);
+}
+
+const client = new S3Client({
+  credentials: {
+    accessKeyId: process.env.S3_ACCESS_KEY_ID || 'S3RVER',
+    secretAccessKey: process.env.S3_SECRET_ACCESS_KEY || 'S3RVER',
+  },
+  endpoint,
+  forcePathStyle: process.env.S3_ENABLE_PATH_STYLE !== '0',
+  region: process.env.S3_REGION || 'us-east-1',
+});
+
+const key = `.agent-testing/preflight-${process.pid}-${Date.now()}.txt`;
+const expected = `agent-testing-s3-${Date.now()}`;
+
+try {
+  await client.send(new HeadBucketCommand({ Bucket: bucket }));
+  await client.send(new PutObjectCommand({ Body: expected, Bucket: bucket, Key: key }));
+  const result = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+  const actual = await result.Body?.transformToString();
+  if (actual !== expected) {
+    throw new Error(`round-trip content mismatch: expected ${expected}, received ${actual}`);
+  }
+  await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
+  console.log(`S3 read/write/delete passed: ${endpoint}/${bucket}`);
+} catch (error) {
+  console.error(`S3 preflight failed for ${endpoint}/${bucket}:`, error);
+  process.exit(1);
+} finally {
+  client.destroy();
+}

--- a/.agents/skills/agent-testing/scripts/init-dev-env.sh
+++ b/.agents/skills/agent-testing/scripts/init-dev-env.sh
@@ -16,15 +16,17 @@
 #   init-dev-env.sh migrate          # run DB migrations against the configured DB
 #   init-dev-env.sh seed-user        # seed the baseline test user + CLI API key
 #   init-dev-env.sh qstash           # run local Upstash QStash dev server
-#   init-dev-env.sh preflight        # check agent-runtime prerequisites (QStash up in queue mode)
+#   init-dev-env.sh s3               # run local s3rver object storage
+#   init-dev-env.sh preflight        # check agent-runtime prerequisites (QStash + S3)
 #   init-dev-env.sh dev-next         # exec `pnpm run dev:next` with this env
 #   init-dev-env.sh dev              # exec `bun run dev` with this env
 #   init-dev-env.sh stop-dev         # stop the dev server (Next + Vite) started by `dev`
-#   init-dev-env.sh clean            # teardown: stop dev server (DB/Redis containers kept)
+#   init-dev-env.sh clean            # teardown: stop dev server (DB/Redis/S3 data kept)
+#   init-dev-env.sh clean-s3         # remove local S3 test data
 #   init-dev-env.sh clean-db         # remove the managed Postgres/Redis containers
 #
 # Overrides:
-#   SERVER_PORT=3010 DB_PORT=5433 DB_CONTAINER=lobehub-agent-testing-postgres REDIS_PORT=6380 REDIS_CONTAINER=lobehub-agent-testing-redis QSTASH_DEV_PORT=8080
+#   SERVER_PORT=3010 DB_PORT=5433 DB_CONTAINER=lobehub-agent-testing-postgres REDIS_PORT=6380 REDIS_CONTAINER=lobehub-agent-testing-redis QSTASH_DEV_PORT=8080 S3_DEV_PORT=29000
 #   AGENT_TESTING_DEV_STATE_FILE=.records/runtime/agent-testing-dev.state
 
 set -euo pipefail
@@ -105,6 +107,8 @@ QSTASH_DEV_PORT="${QSTASH_DEV_PORT:-8080}"
 QSTASH_LOCAL_TOKEN="${QSTASH_LOCAL_TOKEN:-eyJVc2VySUQiOiJkZWZhdWx0VXNlciIsIlBhc3N3b3JkIjoiZGVmYXVsdFBhc3N3b3JkIn0=}"
 QSTASH_LOCAL_CURRENT_SIGNING_KEY="${QSTASH_LOCAL_CURRENT_SIGNING_KEY:-sig_7kYjw48mhY7kAjqNGcy6cr29RJ6r}"
 QSTASH_LOCAL_NEXT_SIGNING_KEY="${QSTASH_LOCAL_NEXT_SIGNING_KEY:-sig_5ZB6DVzB1wjE8S6rZ7eenA8Pdnhs}"
+S3_DEV_PORT="${S3_DEV_PORT:-29000}"
+S3_DATA_DIR="${S3_DATA_DIR:-$WORKSPACE_ROOT/.records/data/agent-testing-s3}"
 
 ok() { printf '  \033[32m✔\033[0m %s\n' "$1"; }
 bad() { printf '  \033[31m✘\033[0m %s\n' "$1"; }
@@ -165,10 +169,16 @@ apply_env() {
   export QSTASH_TOKEN="${QSTASH_TOKEN:-$QSTASH_LOCAL_TOKEN}"
   export QSTASH_URL="${QSTASH_URL:-http://127.0.0.1:${QSTASH_DEV_PORT}}"
   export REDIS_URL
-  export S3_ACCESS_KEY_ID="${S3_ACCESS_KEY_ID:-agent-testing-access-key}"
+  export S3_ACCESS_KEY_ID="${S3_ACCESS_KEY_ID:-S3RVER}"
   export S3_BUCKET="${S3_BUCKET:-agent-testing-bucket}"
-  export S3_ENDPOINT="${S3_ENDPOINT:-https://agent-testing-s3.localhost}"
-  export S3_SECRET_ACCESS_KEY="${S3_SECRET_ACCESS_KEY:-agent-testing-secret-key}"
+  export S3_DATA_DIR
+  export S3_DEV_PORT
+  export S3_ENABLE_PATH_STYLE="${S3_ENABLE_PATH_STYLE:-1}"
+  export S3_ENDPOINT="${S3_ENDPOINT:-http://127.0.0.1:${S3_DEV_PORT}}"
+  export S3_PUBLIC_DOMAIN="${S3_PUBLIC_DOMAIN:-${S3_ENDPOINT}/${S3_BUCKET}}"
+  export S3_REGION="${S3_REGION:-us-east-1}"
+  export S3_SECRET_ACCESS_KEY="${S3_SECRET_ACCESS_KEY:-S3RVER}"
+  export S3_SET_ACL="${S3_SET_ACL:-0}"
   export SPA_PORT
   export VITE_DEV_PORT="${VITE_DEV_PORT:-$SPA_PORT}"
   # Bypass cloud chat-security UA/headless fingerprint checks for local e2e only.
@@ -198,8 +208,14 @@ env_keys() {
     REDIS_URL \
     S3_ACCESS_KEY_ID \
     S3_BUCKET \
+    S3_DATA_DIR \
+    S3_DEV_PORT \
+    S3_ENABLE_PATH_STYLE \
     S3_ENDPOINT \
+    S3_PUBLIC_DOMAIN \
+    S3_REGION \
     S3_SECRET_ACCESS_KEY \
+    S3_SET_ACL \
     SPA_PORT \
     VITE_DEV_PORT \
     AGENT_TESTING_DISABLE_CHAT_SECURITY
@@ -487,6 +503,11 @@ cmd_status() {
   else
     note "QStash is not answering as QStash at $QSTASH_URL (needed for agent-runtime / queue mode)"
   fi
+  if node "$REPO_ROOT/.agents/skills/agent-testing/scripts/check-s3.mjs" > /dev/null 2>&1; then
+    ok "S3 reachable and writable: $S3_ENDPOINT/$S3_BUCKET"
+  else
+    note "S3 is not ready at $S3_ENDPOINT (start it with: $0 s3)"
+  fi
 }
 
 # Prerequisite gate for agent-runtime tests. In queue mode (the default here and
@@ -518,6 +539,14 @@ cmd_preflight() {
     fi
   else
     note "AGENT_RUNTIME_MODE=$AGENT_RUNTIME_MODE (not queue) — QStash not required"
+  fi
+
+  if node "$REPO_ROOT/.agents/skills/agent-testing/scripts/check-s3.mjs" > /dev/null 2>&1; then
+    ok "S3 read/write/delete passed: $S3_ENDPOINT/$S3_BUCKET"
+  else
+    bad "S3 preflight failed at $S3_ENDPOINT/$S3_BUCKET"
+    note "start it in a separate terminal: $0 s3"
+    failed=1
   fi
 
   if _http_reachable "$APP_URL"; then
@@ -620,6 +649,15 @@ stop_owned_process_tree() {
   kill -KILL "$root_pid" 2>/dev/null || true
 }
 
+cmd_s3() {
+  apply_env
+  cd "$REPO_ROOT"
+  note "starting local S3 server at $S3_ENDPOINT"
+  note "bucket=$S3_BUCKET; data=$S3_DATA_DIR"
+  note "keep this process running while testing file uploads"
+  exec node .agents/skills/agent-testing/scripts/start-s3.mjs
+}
+
 cmd_dev_next() {
   apply_env
   cd "$REPO_ROOT"
@@ -687,7 +725,18 @@ cmd_clean() {
   # Postgres/Redis containers are intentionally reused across runs (setup-db is
   # idempotent), so they are left running — remove them explicitly with clean-db.
   cmd_stop_dev
-  note "managed DB/Redis containers left running (reused across runs); remove with: $0 clean-db"
+  note "managed DB/Redis containers and S3 data left in place for reuse"
+  note "remove DB/Redis with: $0 clean-db; remove S3 data with: $0 clean-s3"
+}
+
+cmd_clean_s3() {
+  apply_env
+  if [[ -d "$S3_DATA_DIR" ]]; then
+    rm -rf "$S3_DATA_DIR"
+    ok "removed local S3 data: $S3_DATA_DIR"
+  else
+    note "local S3 data not found: $S3_DATA_DIR"
+  fi
 }
 
 usage() {
@@ -712,12 +761,14 @@ case "$COMMAND" in
   migrate) migrate_db ;;
   seed-user) seed_user ;;
   qstash) cmd_qstash ;;
+  s3) cmd_s3 ;;
   preflight) cmd_preflight ;;
   dev-next) cmd_dev_next ;;
   dev) cmd_dev ;;
   stop-dev | stop) cmd_stop_dev ;;
   clean) cmd_clean ;;
   clean-db) cmd_clean_db ;;
+  clean-s3) cmd_clean_s3 ;;
   status) cmd_status ;;
   *)
     usage

--- a/.agents/skills/agent-testing/scripts/start-s3.mjs
+++ b/.agents/skills/agent-testing/scripts/start-s3.mjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import S3rver from 's3rver';
+
+const port = Number(process.env.S3_DEV_PORT || 29_000);
+const address = process.env.S3_DEV_ADDRESS || '127.0.0.1';
+const bucket = process.env.S3_BUCKET || 'agent-testing-bucket';
+const directory = path.resolve(process.env.S3_DATA_DIR || '.records/data/agent-testing-s3');
+
+const origins = new Set();
+for (const candidate of [process.env.APP_URL, process.env.S3_ALLOWED_ORIGIN]) {
+  if (!candidate) continue;
+  try {
+    origins.add(new URL(candidate).origin);
+  } catch {
+    console.error(`Invalid S3 CORS origin: ${candidate}`);
+    process.exit(1);
+  }
+}
+for (const candidatePort of [process.env.PORT, process.env.SPA_PORT, process.env.VITE_DEV_PORT]) {
+  if (!candidatePort) continue;
+  origins.add(`http://localhost:${candidatePort}`);
+  origins.add(`http://127.0.0.1:${candidatePort}`);
+}
+
+const corsRules = [...origins]
+  .map(
+    (origin) => `
+  <CORSRule>
+    <AllowedOrigin>${origin}</AllowedOrigin>
+    <AllowedMethod>GET</AllowedMethod>
+    <AllowedMethod>HEAD</AllowedMethod>
+    <AllowedMethod>PUT</AllowedMethod>
+    <AllowedMethod>POST</AllowedMethod>
+    <AllowedMethod>DELETE</AllowedMethod>
+    <AllowedHeader>*</AllowedHeader>
+    <ExposeHeader>ETag</ExposeHeader>
+    <MaxAgeSeconds>3000</MaxAgeSeconds>
+  </CORSRule>`,
+  )
+  .join('');
+const corsConfig = `<CORSConfiguration>${corsRules}\n</CORSConfiguration>`;
+
+fs.mkdirSync(directory, { recursive: true });
+
+const server = new S3rver({
+  address,
+  configureBuckets: [{ configs: [corsConfig], name: bucket }],
+  directory,
+  port,
+  silent: false,
+});
+
+const close = async (signal) => {
+  console.log(`\nReceived ${signal}; stopping local S3 server...`);
+  await server.close();
+  process.exit(0);
+};
+
+process.once('SIGINT', () => void close('SIGINT'));
+process.once('SIGTERM', () => void close('SIGTERM'));
+
+try {
+  await server.run();
+  console.log('Agent-testing S3 server is ready:');
+  console.log(`  endpoint: http://${address}:${port}`);
+  console.log(`  bucket:   ${bucket}`);
+  console.log(`  data:     ${directory}`);
+} catch (error) {
+  console.error('Failed to start agent-testing S3 server:', error);
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -541,6 +541,7 @@
     "remark-mdx": "^3.1.1",
     "remark-parse": "^11.0.0",
     "require-in-the-middle": "^8.0.1",
+    "s3rver": "3.7.1",
     "semantic-release": "^21.1.2",
     "stylelint": "^16.26.1",
     "tsx": "^4.22.4",
@@ -576,6 +577,7 @@
       "pdfjs-dist": "5.4.530",
       "react": "19.2.7",
       "react-dom": "19.2.7",
+      "s3rver>fast-xml-parser": "3.21.1",
       "stylelint-config-clean-order": "7.0.0",
       "typescript": "6.0.3",
       "vitest": "3.2.6"


### PR DESCRIPTION
## Summary

- add an explicit local `s3rver` service to the agent-testing bootstrap
- provision the test bucket and browser upload CORS automatically
- validate S3 with a real Head/Put/Get/Delete preflight round trip
- document startup, persistence, cleanup, and production publishing boundaries

## Verification

- `bun run check .agents/skills/agent-testing/scripts/init-dev-env.sh .agents/skills/agent-testing/scripts/start-s3.mjs .agents/skills/agent-testing/scripts/check-s3.mjs`
- verified SDK Put/Get/Delete against the local bucket
- verified CORS preflight for browser PUT
- verified presigned PUT returns HTTP 200 and uploaded content can be read back
- verified `clean-s3` removes persisted test data

## Notes

- pins `s3rver` to `3.7.1`
- scopes `fast-xml-parser` to `3.21.1` for `s3rver`, avoiding the repository-wide v5 override incompatibility