### PR TITLE
🐛 fix(worktree): unwrap Codex login-shell wrapper before git command detection

### DIFF
--- a/packages/builtin-tools/src/codex/commandExecutionUtils.ts
+++ b/packages/builtin-tools/src/codex/commandExecutionUtils.ts
@@ -1,3 +1,5 @@
+// The parse-side unwrap in src/store/tool/slices/builtin/executors/worktreeDetection.ts
+// mirrors this wrapper shape — keep the accepted forms in sync.
 const SHELL_WRAPPER_PATTERN =
   /^(?:\/usr\/bin\/env\s+)?(?:\/\S+\/)?(?:bash|sh|zsh)\s+(?:-lc|-c|-l\s+-c)\s+(\S[\s\S]*)$/;
 

--- a/src/store/tool/slices/builtin/executors/__tests__/worktreeDetection.test.ts
+++ b/src/store/tool/slices/builtin/executors/__tests__/worktreeDetection.test.ts
@@ -126,6 +126,42 @@ describe('parseWorktreeAddPath', () => {
     expect(parseWorktreeAddPath('git worktree add $(mktemp -d) feat/x', '/repo')).toBeUndefined();
     expect(parseWorktreeAddPath('git worktree add ~/wt feat/x', '/repo')).toBeUndefined();
   });
+
+  it('unwraps the Codex login-shell wrapper', () => {
+    expect(parseWorktreeAddPath('/bin/zsh -lc "git worktree add -b feat/x ../wt"', '/repo')).toBe(
+      '/wt',
+    );
+    expect(parseWorktreeAddPath("bash -lc 'git worktree add /tmp/wt'", '/repo')).toBe('/tmp/wt');
+    expect(parseWorktreeAddPath('sh -c "git worktree add wt"', '/repo')).toBe('/repo/wt');
+    expect(parseWorktreeAddPath('/usr/bin/env bash -l -c "git worktree add /wt"', '/repo')).toBe(
+      '/wt',
+    );
+  });
+
+  it('unwraps the argv form of the shell wrapper', () => {
+    expect(
+      parseWorktreeAddPath(['/bin/zsh', '-lc', 'git worktree add -b feat/x /tmp/wt'], '/repo'),
+    ).toBe('/tmp/wt');
+    expect(parseWorktreeAddPath(['bash', '-l', '-c', 'git worktree add ../wt'], '/repo')).toBe(
+      '/wt',
+    );
+  });
+
+  it('handles separators, escaped quotes, and nesting inside the wrapper payload', () => {
+    expect(
+      parseWorktreeAddPath('/bin/zsh -lc "cd /repo && git worktree add \\"/tmp/my wt\\""', '/repo'),
+    ).toBe('/tmp/my wt');
+    expect(parseWorktreeAddPath(`zsh -lc 'bash -c "git worktree add /tmp/wt"'`, '/repo')).toBe(
+      '/tmp/wt',
+    );
+  });
+
+  it('still rejects non-git payloads inside a wrapper', () => {
+    expect(
+      parseWorktreeAddPath('/bin/zsh -lc "echo git worktree add /wt"', '/repo'),
+    ).toBeUndefined();
+    expect(parseWorktreeAddPath(`/bin/zsh -lc "rg 'git worktree add' ."`, '/repo')).toBeUndefined();
+  });
 });
 
 const PR_TOPIC = {
@@ -332,6 +368,72 @@ describe('recordGitCommandEffects', () => {
           github: {
             pullRequest: {
               isDraft: true,
+              number: 456,
+              state: 'OPEN',
+              title: 'Fix topic',
+              url: 'https://github.com/lobehub/lobehub/pull/456',
+            },
+            pullRequestStatus: 'ok',
+          },
+        },
+        path: '/repo',
+        repoType: 'github',
+      },
+    });
+  });
+
+  it('records a worktree add shipped through the Codex zsh wrapper', async () => {
+    chatMocks.topics = { t1: PR_TOPIC };
+
+    await recordGitCommandEffects({
+      command: '/bin/zsh -lc "git worktree add -b feat/agent-testing-s3rver /Users/me/wt canary"',
+      topicId: 't1',
+    });
+
+    expect(chatMocks.updateTopicMetadata).toHaveBeenCalledWith('t1', {
+      workingDirectoryConfig: {
+        git: {
+          activeWorktree: '/Users/me/wt',
+          branch: 'feat/agent-testing-s3rver',
+          isWorktree: true,
+        },
+        path: '/repo',
+        repoType: 'github',
+      },
+    });
+  });
+
+  it('updates the branch from a wrapped git switch', async () => {
+    chatMocks.topics = { t1: PR_TOPIC };
+
+    await recordGitCommandEffects({
+      command: 'bash -lc "git switch fix/topic"',
+      topicId: 't1',
+    });
+
+    expect(chatMocks.updateTopicMetadata).toHaveBeenCalledWith('t1', {
+      workingDirectoryConfig: {
+        git: { branch: 'fix/topic' },
+        path: '/repo',
+        repoType: 'github',
+      },
+    });
+  });
+
+  it('binds a created PR from a wrapped gh pr create', async () => {
+    chatMocks.topics = { t1: PR_TOPIC };
+
+    await recordGitCommandEffects({
+      command: `/bin/zsh -lc "gh pr create --title 'Fix topic'"`,
+      resultContent: 'https://github.com/lobehub/lobehub/pull/456',
+      topicId: 't1',
+    });
+
+    expect(chatMocks.updateTopicMetadata).toHaveBeenCalledWith('t1', {
+      workingDirectoryConfig: {
+        git: {
+          github: {
+            pullRequest: {
               number: 456,
               state: 'OPEN',
               title: 'Fix topic',

--- a/src/store/tool/slices/builtin/executors/worktreeDetection.ts
+++ b/src/store/tool/slices/builtin/executors/worktreeDetection.ts
@@ -16,7 +16,8 @@ import { getElectronStoreState } from '@/store/electron';
  * (renderer-side, fired on `tool_end`). The CLI session cwd stays anchored to
  * the source repo; selected worktree / branch / linked PR are topic metadata.
  *
- * Command parsing is a trigger + hint, not the source of truth: `$VAR`
+ * Command parsing is a trigger + hint, not the source of truth: a Codex-style
+ * login-shell wrapper (`/bin/zsh -lc "…"`) is peeled off first, `$VAR`
  * references are expanded from assignments earlier in the same command, and a
  * path that still carries shell syntax after that is never recorded literally —
  * the real path is read back from the device's `git worktree list` (matched by
@@ -207,12 +208,17 @@ const findInCommand = <T>(
   parser: (tokens: string[], env?: ShellEnv) => T | undefined,
 ): T | undefined => {
   if (Array.isArray(command)) {
-    return command.every((t) => typeof t === 'string') ? parser(command) : undefined;
+    if (!command.every((t) => typeof t === 'string')) return undefined;
+    // A shell-wrapped argv carries a raw shell string as its payload — recurse so
+    // it gets the same separator splitting and `$VAR` expansion as the string form.
+    const wrapped = unwrapShellArgv(command);
+    if (wrapped !== undefined) return findInCommand(wrapped, parser);
+    return parser(command);
   }
   if (typeof command !== 'string') return undefined;
 
   const env: ShellEnv = {};
-  for (const segment of command.split(/[\n;|&]/)) {
+  for (const segment of unwrapShellCommand(command).split(/[\n;|&]/)) {
     const tokens = tokenize(segment);
     const result = parser(tokens, env);
     if (result) return result;
@@ -563,6 +569,63 @@ const GIT_VALUE_OPTS = new Set([
 const WRAPPERS = new Set(['sudo', 'env', 'command', 'nice', 'nohup', 'time']);
 
 /**
+ * Codex ships every shell tool call wrapped in a login shell — the wire command is
+ * `/bin/zsh -lc "git worktree add …"` (or the argv form `['bash', '-lc', 'git …']`)
+ * — so the head token is the shell, never `git`/`gh`, and the real command hides
+ * inside a single quoted token. The display layer strips this wrapper
+ * (`stripShellWrapper` in `packages/builtin-tools/src/codex/commandExecutionUtils.ts`
+ * — keep the accepted shapes in sync), so parsing must strip it too, or the UI shows
+ * a bare git command that this module silently rejected.
+ */
+const SHELL_WRAPPER_PATTERN =
+  /^(?:\/usr\/bin\/env\s+)?(?:\/\S+\/)?(?:bash|sh|zsh)\s+(?:-lc|-c|-l\s+-c)\s+(\S[\s\S]*)$/;
+const SHELL_EXECUTABLES = new Set(['bash', 'sh', 'zsh']);
+
+/** Undo the shell's own quoting of the wrapper payload (`-lc "git \"…\""` → `git "…"`). */
+const stripOuterShellQuotes = (value: string): string => {
+  const trimmed = value.trim();
+  if (trimmed.length < 2) return trimmed;
+
+  const quote = trimmed[0];
+  if ((quote !== '"' && quote !== "'") || trimmed.at(-1) !== quote) return trimmed;
+
+  const body = trimmed.slice(1, -1);
+  if (quote === "'") return body.replaceAll("'\\''", "'");
+
+  return body
+    .replaceAll('\\"', '"')
+    .replaceAll('\\`', '`')
+    .replaceAll('\\$', '$')
+    .replaceAll('\\\\', '\\');
+};
+
+/** `['/bin/zsh', '-lc', 'git …']` → `git …`; undefined when argv is not a shell wrapper. */
+const unwrapShellArgv = (tokens: string[]): string | undefined => {
+  let i = getExecutableName(tokens[0] ?? '') === 'env' ? 1 : 0;
+  if (!SHELL_EXECUTABLES.has(getExecutableName(tokens[i] ?? '') ?? '')) return undefined;
+  i += 1;
+  if (stripQuotes(tokens[i] ?? '') === '-l') i += 1;
+  const flag = stripQuotes(tokens[i] ?? '');
+  if (flag !== '-c' && flag !== '-lc') return undefined;
+  return tokens[i + 1];
+};
+
+/** Peel `bash|sh|zsh -lc "…"` layers off a raw command string until none remain. */
+const unwrapShellCommand = (command: string): string => {
+  let current = command;
+  // Wrappers can nest (`zsh -lc 'bash -c "git …"'`) but only shallowly; each peel
+  // strictly shortens the string, so the depth cap is a formality.
+  for (let depth = 0; depth < 4; depth += 1) {
+    const match = SHELL_WRAPPER_PATTERN.exec(current.trim());
+    if (!match) break;
+    const inner = stripOuterShellQuotes(match[1]);
+    if (!inner) break;
+    current = inner;
+  }
+  return current;
+};
+
+/**
  * If ONE command's tokens are a real `git … worktree add <path>` invocation, return
  * the path (resolved against the source cwd, honoring a `-C <dir>` override).
  * Requires the executable to actually be `git` — so `echo git worktree add …` or
@@ -643,16 +706,22 @@ const parseWorktreeAddInfo = (
   cwd?: string,
 ): WorktreeAddParseResult | undefined => {
   if (Array.isArray(command)) {
+    if (!command.every((t) => typeof t === 'string')) return undefined;
+    // A shell-wrapped argv carries a raw shell string as its payload — recurse so
+    // it gets the same separator splitting and `$VAR` expansion as the string form.
+    const wrapped = unwrapShellArgv(command);
+    if (wrapped !== undefined) return parseWorktreeAddInfo(wrapped, cwd);
     // Already-tokenized argv → a single command, boundaries preserved. No shell
     // ran, so tokens are literal — no assignments to collect or vars to expand.
-    return command.every((t) => typeof t === 'string')
-      ? parseGitWorktreeAddTokens(command, cwd)
-      : undefined;
+    return parseGitWorktreeAddTokens(command, cwd);
   }
-  if (typeof command !== 'string' || !/\bworktree\s+add\b/.test(command)) return undefined;
+  if (typeof command !== 'string') return undefined;
+
+  const unwrapped = unwrapShellCommand(command);
+  if (!/\bworktree\s+add\b/.test(unwrapped)) return undefined;
 
   const env: ShellEnv = {};
-  for (const segment of command.split(/[\n;|&]/)) {
+  for (const segment of unwrapped.split(/[\n;|&]/)) {
     const tokens = tokenize(segment);
     const info = parseGitWorktreeAddTokens(tokens, cwd, env);
     if (info) return info;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

<!-- none found -->

#### 🔀 Description of Change

Codex ships every shell tool call wrapped in a login shell — the wire `command` is `/bin/zsh -lc "git worktree add …"` (confirmed from a local heterogeneous trace) — so `worktreeDetection.ts` tokenized `/bin/zsh` as the executable, failed the `isGitExecutable` check, and gave up. Meanwhile the display layer (`stripShellWrapper` in codex `commandExecutionUtils.ts`) strips that wrapper before rendering, so the UI showed a clean `git worktree add …` bubble — creating the illusion that a correct command was inexplicably not recognized.

Since `recordGitCommandEffects` is the single sniffing entry, this silently broke **all** git side-effect recording for Codex runs:

- `git worktree add` — active worktree never recorded; the bottom bar kept showing the source repo's branch
- `git switch` / confirmed `git checkout` — branch sync never updated
- `gh pr create` — PR binding never attached

**Fix:** peel the shell wrapper at both parse entry points (`findInCommand` and `parseWorktreeAddInfo`) before separator splitting / tokenizing:

- String form: regex aligned with the display-side `stripShellWrapper` (`bash|sh|zsh` + `-lc`/`-c`/`-l -c`, optional `/usr/bin/env` prefix and absolute shell path), plus outer-quote stripping with shell unescaping; handles nested wrappers
- Argv form: `['/bin/zsh', '-lc', 'git …']` recurses into the string path so the payload gets the same splitting and `$VAR` expansion
- Cross-reference comments added on both sides so the two wrapper shapes stay in sync

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Added cases covering: wrapped `git worktree add` (string + argv forms, `-lc` / `-c` / `-l -c`, `/usr/bin/env` prefix), separators and escaped quotes inside the payload, nested wrappers, non-git payloads inside a wrapper (still rejected), and `recordGitCommandEffects` end-to-end for wrapped `git worktree add` / `git switch` / `gh pr create`. `bun run check` (lint + 73 tests) and full type-check pass.

#### 📝 Additional Information

Claude Code was unaffected because its `Bash` tool passes bare commands (and `EnterWorktree` has dedicated sentence parsing) — this sniffing path had only ever been validated against CC's shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)