### PR TITLE
🐛 fix: preserve workspace device settings navigation

### DIFF
--- a/src/features/Workspace/__tests__/workspaceAwarePath.test.ts
+++ b/src/features/Workspace/__tests__/workspaceAwarePath.test.ts
@@ -72,6 +72,9 @@ describe('buildWorkspaceAwarePath', () => {
     expect(buildWorkspaceAwarePath('/settings/usage', 'acme')).toBe('/acme/settings/usage');
     expect(buildWorkspaceAwarePath('/settings/skill', 'acme')).toBe('/acme/settings/skill');
     expect(buildWorkspaceAwarePath('/settings/connector', 'acme')).toBe('/acme/settings/connector');
+    expect(buildWorkspaceAwarePath('/settings/devices', 'acme')).toBe('/acme/settings/devices');
+    expect(buildWorkspaceAwarePath('/settings/audit-log', 'acme')).toBe('/acme/settings/audit-log');
+    expect(buildWorkspaceAwarePath('/settings/storage', 'acme')).toBe('/acme/settings/storage');
     expect(buildWorkspaceAwarePath('/settings/messenger', 'acme')).toBe('/acme/settings/messenger');
     expect(buildWorkspaceAwarePath('/settings/creds', 'acme')).toBe('/acme/settings/creds');
     expect(buildWorkspaceAwarePath('/settings/provider/openai', 'acme')).toBe(

--- a/src/features/Workspace/workspaceAwarePath.ts
+++ b/src/features/Workspace/workspaceAwarePath.ts
@@ -31,10 +31,12 @@ const isPersonalPath = (to: string): boolean => PERSONAL_PATH_REGEX.test(to);
  */
 export const WORKSPACE_SETTINGS_TABS: ReadonlySet<string> = new Set([
   'apikey',
+  'audit-log',
   'billing',
   'connector',
   'creds',
   'credits',
+  'devices',
   'general',
   'members',
   'messenger',
@@ -43,6 +45,7 @@ export const WORKSPACE_SETTINGS_TABS: ReadonlySet<string> = new Set([
   'service-model',
   'skill',
   'stats',
+  'storage',
   'usage',
 ]);
 

--- a/src/spa/router/desktopRouter.sync.test.tsx
+++ b/src/spa/router/desktopRouter.sync.test.tsx
@@ -1,8 +1,11 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import type { RouteObject } from 'react-router';
 import { matchRoutes } from 'react-router';
 import { describe, expect, it } from 'vitest';
+
+import { WORKSPACE_SETTINGS_TABS } from '@/features/Workspace/workspaceAwarePath';
 
 import { desktopRoutes } from './desktopRouter.config';
 
@@ -159,6 +162,28 @@ describe('desktopRouter config sync', () => {
     // `path: 'billing'` block under `:workspaceSlug` is preserved as redirects)
     expect(asyncSource).toContain("redirectElement('../settings/plans')");
     expect(syncSource).toContain("redirectElement('../settings/plans')");
+  });
+
+  it('workspace-aware navigation recognizes every registered workspace settings tab', () => {
+    const rootRoute = desktopRoutes.find((route) => route.path === '/');
+    const workspaceRoute = rootRoute?.children?.find((route) => route.path === ':workspaceSlug');
+    const settingsRoute = workspaceRoute?.children?.find((route) => route.path === 'settings');
+
+    expect(settingsRoute, 'Workspace settings route must exist').toBeDefined();
+
+    const collectPaths = (routes: RouteObject[]): string[] =>
+      routes.flatMap((route) =>
+        route.path
+          ? [route.path, ...collectPaths(route.children ?? [])]
+          : collectPaths(route.children ?? []),
+      );
+    const registeredTabs = collectPaths(settingsRoute?.children ?? []);
+    const missingTabs = registeredTabs.filter((tab) => !WORKSPACE_SETTINGS_TABS.has(tab));
+
+    expect(
+      missingTabs,
+      `Add workspace settings tabs to WORKSPACE_SETTINGS_TABS: ${missingTabs.join(', ')}`,
+    ).toEqual([]);
   });
 
   it('task list and detail desktop routes share one workspace layout', async () => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

- N/A — reported from the execution-device picker

#### 🔀 Description of Change

- Route the execution-device Manage action to the active workspace device settings page.
- Register the previously omitted workspace settings tabs (`devices`, `storage`, and `audit-log`) in workspace-aware navigation.
- Add regression coverage for direct path rewriting and a router-to-navigation catalog sync check.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bun run check lobehub/src/features/Workspace/workspaceAwarePath.ts lobehub/src/features/Workspace/__tests__/workspaceAwarePath.test.ts lobehub/src/spa/router/desktopRouter.sync.test.tsx --lint --test`

Result: 16 tests passed and lint is clean. The full repository type-check still reports pre-existing errors outside the changed files; no changed-file type errors remain.

#### 📸 Screenshots / Videos

N/A — navigation-only change.

#### 📝 Additional Information

The sync test derives desktop workspace settings tabs from the registered route tree so future route additions fail clearly when workspace-aware navigation is not updated.

Non-goal: this PR does not add new mobile workspace settings pages; `devices` and `storage` remain desktop-only surfaces.