### PR TITLE
🐛 fix(ci): copy existing E2E prompt

### DIFF
--- a/.github/workflows/claude-auto-e2e-testing.yml
+++ b/.github/workflows/claude-auto-e2e-testing.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Copy prompts
         run: |
           mkdir -p /tmp/claude-prompts
-          cp .claude/prompts/auto-e2e-testing.md /tmp/claude-prompts/
+          cp .claude/prompts/e2e-coverage.md /tmp/claude-prompts/auto-e2e-testing.md
           cp .claude/prompts/security-rules.md /tmp/claude-prompts/
           cp e2e/CLAUDE.md /tmp/claude-prompts/e2e-guide.md
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #17030

#### 🔀 Description of Change

The auto E2E workflow copied `.claude/prompts/auto-e2e-testing.md`, but that source file has never existed. The E2E coverage prompt is stored as `.claude/prompts/e2e-coverage.md`, while the Claude step still reads the fixed temporary name `auto-e2e-testing.md`.

Copy the existing prompt under the downstream filename so both paths remain valid.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [ ] No tests needed

- `bun run check .github/workflows/claude-auto-e2e-testing.yml --lint`
- Copied the prompt into a disposable directory, then verified the destination name and content with `cmp`.

#### 📸 Screenshots / Videos

N/A — workflow-only change.

#### 📝 Additional Information

This removes the confirmed `Copy prompts` blocker. The latest workflow run also fails earlier during dependency installation, which is unrelated to this path fix.
