### PR TITLE
✨ feat(server): expose agent documents to mobile

### DIFF
--- a/apps/server/src/routers/mobile/index.ts
+++ b/apps/server/src/routers/mobile/index.ts
@@ -6,6 +6,7 @@ import { mobileSubscriptionRouter } from '@/business/server/mobile-routers/mobil
 import { publicProcedure, router } from '@/libs/trpc/lambda';
 
 import { agentRouter } from '../lambda/agent';
+import { agentDocumentRouter } from '../lambda/agentDocument';
 import { agentSkillsRouter } from '../lambda/agentSkills';
 import { aiAgentRouter } from '../lambda/aiAgent';
 import { aiChatRouter } from '../lambda/aiChat';
@@ -34,6 +35,7 @@ import { userRouter } from '../lambda/user';
 
 export const mobileRouter = router({
   agent: agentRouter,
+  agentDocument: agentDocumentRouter,
   agentSkills: agentSkillsRouter,
   aiAgent: aiAgentRouter,
   aiChat: aiChatRouter,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Expose the existing `agentDocumentRouter` through the mobile tRPC router.
- Allow the mobile client to call `agentDocument.listDocuments` while preserving the same server data path used by web.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Validation:

- `git diff --check`
- Downstream `lobehub-mobile` targeted ESLint
- Downstream `lobehub-mobile` type-check, including `trpcClient.agentDocument.listDocuments`

The cloud wrapper checkout has dependencies from an older submodule pin, so its wrapper-wide type-check and ESLint cannot resolve current canary packages locally. GitHub CI provides the clean canary validation.

#### 📸 Screenshots / Videos

N/A — server router registration only.

#### 📝 Additional Information

After merge, `biz-lobehub-cloud` must update its `lobehub` submodule pointer before the mobile repository updates its `lobehub-cloud` pointer.