### PR TITLE
💄 style(claude-code): render Read image preview at natural aspect ratio

### DIFF
--- a/packages/builtin-tool-claude-code/src/client/Render/Read/index.tsx
+++ b/packages/builtin-tool-claude-code/src/client/Render/Read/index.tsx
@@ -64,8 +64,9 @@ const Read = memo<BuiltinRenderProps<ReadArgs, ReadPluginState>>(
               <Image
                 alt={filePath || image.mediaType || ''}
                 key={image.fileId || image.url || index}
+                maxHeight={600}
                 src={image.url}
-                style={{ borderRadius: 8, maxHeight: 240, objectFit: 'contain' }}
+                style={{ borderRadius: 8 }}
               />
             ))}
           </Flexbox>


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None

#### 🔀 Description of Change

The Claude Code `Read` render passed `maxHeight` / `objectFit` via the `style` prop of `@lobehub/ui`'s `Image`, but `style` only applies to the outer wrapper — the inner `img` was left unconstrained and got stretched to the full container width, cropping/zooming the preview.

Pass `maxHeight={600}` as a component prop instead, which lands on the `img` itself. Since the `img` is `width/height: auto` with `max-width: 100%`, the image now renders at its natural aspect ratio — small images at intrinsic size, large ones scaled down proportionally, capped at 600px tall. No `objectFit` needed: nothing forces the box off-ratio, so there is no cropping or letterboxing in any case.

#### 🧪 How to Test

Verified end-to-end via agent-testing on an isolated Electron dev instance (live working-tree code), against a real conversation containing CC `Read`-on-image results:

- Large image (1999×1608) renders 746×600 — capped at 600px tall, aspect-ratio delta 0.00%, no crop/letterbox; the `img` carries inline `max-height: 600px` (proves the prop lands on the img, not the wrapper).
- Small image (300×150 probe) renders at intrinsic size, no longer stretched to container width.

Published report with screenshots: https://app.lobehub.com/verify/c9e2bc55-0b3d-44a3-bb22-dbe2a15e03eb

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

#### 📝 Additional Information

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
