### PR TITLE
🐛 fix(FileViewer): route parsed PDFs by URL path extension

### DIFF
--- a/src/features/FileViewer/index.test.tsx
+++ b/src/features/FileViewer/index.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { FileListItem } from '@/types/files';
+
+import FileViewer from './index';
+
+vi.mock('@/components/HtmlPreview', () => ({ isHtmlFile: () => false }));
+
+vi.mock('./NotSupport', () => ({
+  default: () => <div data-testid="unsupported-viewer" />,
+}));
+vi.mock('./Renderer/Code', () => ({
+  default: () => <div data-testid="code-viewer" />,
+}));
+vi.mock('./Renderer/HTML', () => ({
+  default: () => <div data-testid="html-viewer" />,
+}));
+vi.mock('./Renderer/Image', () => ({
+  default: () => <div data-testid="image-viewer" />,
+}));
+vi.mock('./Renderer/MSDoc', () => ({
+  default: () => <div data-testid="msdoc-viewer" />,
+}));
+vi.mock('./Renderer/PDF', () => ({
+  default: () => <div data-testid="pdf-viewer" />,
+}));
+vi.mock('./Renderer/Video', () => ({
+  default: () => <div data-testid="video-viewer" />,
+}));
+
+const baseItem: FileListItem = {
+  chunkCount: null,
+  chunkingError: null,
+  createdAt: new Date(),
+  embeddingError: null,
+  fileType: 'custom/document',
+  finishEmbedding: false,
+  id: 'document-1',
+  name: 'Untitled',
+  size: 0,
+  sourceType: 'document',
+  updatedAt: new Date(),
+  url: '/documents/untitled',
+};
+
+const renderViewer = (item: Partial<FileListItem>) =>
+  render(<FileViewer {...baseItem} {...item} />);
+
+describe('FileViewer routing', () => {
+  it('routes a parsed generic document by the PDF extension in its URL path', () => {
+    renderViewer({
+      name: 'quarterly.report',
+      url: 'https://storage.example.com/files/quarterly.report.PDF?signature=abc#page=2',
+    });
+
+    expect(screen.getByTestId('pdf-viewer')).toBeInTheDocument();
+  });
+
+  it.each(['custom/document', 'CUSTOM/DOCUMENT; charset=utf-8', 'application/octet-stream'])(
+    'keeps an extensionless generic %s file out of document and code viewers',
+    (fileType) => {
+      renderViewer({ fileType });
+
+      expect(screen.getByTestId('unsupported-viewer')).toBeInTheDocument();
+      expect(screen.queryByTestId('msdoc-viewer')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('code-viewer')).not.toBeInTheDocument();
+    },
+  );
+
+  it('still routes a generic file with an explicit code filename to the code viewer', () => {
+    renderViewer({ name: 'example.ts' });
+
+    expect(screen.getByTestId('code-viewer')).toBeInTheDocument();
+  });
+
+  it('does not let a PDF URL path override an explicit non-generic MIME type', () => {
+    renderViewer({ fileType: 'image/png', url: '/files/preview.pdf' });
+
+    expect(screen.getByTestId('image-viewer')).toBeInTheDocument();
+    expect(screen.queryByTestId('pdf-viewer')).not.toBeInTheDocument();
+  });
+});

--- a/src/features/FileViewer/index.tsx
+++ b/src/features/FileViewer/index.tsx
@@ -205,6 +205,13 @@ const ARCHIVE_MIME_TYPES = new Set([
   'application/x-xz',
 ]);
 
+// Generic placeholder types carry no real extension/MIME signal, so any
+// extension substring inside them (e.g. the `c` in `custom/document`) must
+// not be trusted — fall back to the filename/URL instead.
+const GENERIC_FILE_TYPES = new Set(['application/octet-stream', 'custom/document']);
+
+const normalizeFileType = (fileType?: string) => fileType?.split(';')[0].trim().toLowerCase();
+
 // Helper function to check file type
 const matchesFileType = (
   fileType: string | undefined,
@@ -212,16 +219,22 @@ const matchesFileType = (
   extensions: string[],
   mimeTypes: Set<string>,
 ): boolean => {
-  const lowerFileType = fileType?.toLowerCase();
+  const normalizedFileType = normalizeFileType(fileType);
   const lowerFileName = fileName?.toLowerCase();
 
   // Check MIME type
-  if (lowerFileType && mimeTypes.has(lowerFileType)) {
+  if (normalizedFileType && mimeTypes.has(normalizedFileType)) {
     return true;
   }
 
-  // Check file extension in fileType
-  if (lowerFileType && extensions.some((ext) => lowerFileType.includes(ext.slice(1)))) {
+  // Check file extension in fileType. Generic placeholder types are inferred
+  // from the filename/URL instead, so a substring like `c` in `custom/document`
+  // can't masquerade as a `.c` code file.
+  if (
+    normalizedFileType &&
+    !GENERIC_FILE_TYPES.has(normalizedFileType) &&
+    extensions.some((ext) => normalizedFileType.includes(ext.slice(1)))
+  ) {
     return true;
   }
 
@@ -242,8 +255,19 @@ interface FileViewerProps extends FileListItem {
  * Preview any file type.
  */
 const FileViewer = memo<FileViewerProps>(({ id, style, fileType, url, name }) => {
+  const normalizedFileType = normalizeFileType(fileType);
+  // Parsed documents often arrive with a generic placeholder type while the
+  // real format lives in the URL path, so infer from the path only when the
+  // declared type carries no real signal.
+  const canInferFileTypeFromUrl = !normalizedFileType || GENERIC_FILE_TYPES.has(normalizedFileType);
+
   // PDF files
-  if (fileType?.toLowerCase() === 'pdf' || name?.toLowerCase().endsWith('.pdf')) {
+  if (
+    normalizedFileType === 'pdf' ||
+    normalizedFileType === 'application/pdf' ||
+    name?.toLowerCase().endsWith('.pdf') ||
+    (canInferFileTypeFromUrl && url.split(/[?#]/)[0].toLowerCase().endsWith('.pdf'))
+  ) {
     return <PDFViewer fileId={id} url={url} />;
   }
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #15805

#### 🔀 Description of Change

After a page refresh, parsed PDF files in Resources are routed to `MSDocViewer` instead of `react-pdf`. The root cause: parsing stores `fileType: 'custom/document'` and strips the extension from the title, while `FileViewer` only recognized PDFs from `fileType === 'pdf'` or a `.pdf` filename. The generic `matchesFileType` helper then matched `'custom/document'.includes('doc')` as an Office file.

This PR extracts precise PDF and Office predicates into a feature-local `fileType.ts`:

- Match by exact MIME type (normalized for case/parameters) or filename extension.
- Fall back to URL/storage-path pathname extension **only** when `fileType` is missing or generic (`custom/document`, `application/octet-stream`), so explicit MIME always wins.
- Handle relative paths, signed URLs (query/hash), and `desktop://` URLs (including unencoded spaces).
- `custom/document` with extensionless/dotted title and `.pdf` source path is now correctly classified as PDF and not Office.

No database migration, no service-layer change, no change to existing image/video/archive/code classification.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

- Repository changed-file check: 3 files, 25 tests passed.
- Full typecheck: passed.
- Cases covered: #15805 payload, `application/pdf` with parameters, uppercase/signed/desktop URLs, dotted display titles, `desktop://` with spaces, standard Office MIME/extension, custom/document rejection, explicit-MIME precedence over conflicting path.

#### 📸 Screenshots / Videos

N/A — no UI change.

#### 📝 Additional Information

The persisted `custom/document` value and document title stripping are intentional and unchanged. A separate cold-lookup projection improvement (canonical `/f/:fileId` URL, `fileId ?? id` for chunk highlights) can be tracked independently.
