### PR TITLE
🐛 fix(chat): show ControlBar git status for worktree topics & add Fable 5 model

### DIFF
--- a/src/features/ChatInput/ControlBar/HeteroModel.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroModel.tsx
@@ -52,6 +52,7 @@ type HeteroReasoningEffort =
 type SelectableHeteroProviderType = 'claude-code' | 'codex';
 
 const CLAUDE_CODE_MODEL_OPTIONS = [
+  { label: 'Fable 5', value: 'fable' },
   { label: 'Opus 4.8', value: 'opus' },
   { label: 'Sonnet 4.6', value: 'sonnet' },
   { label: 'Haiku 4.5', value: 'haiku' },

--- a/src/features/ChatInput/ControlBar/WorkingDirectorySection.tsx
+++ b/src/features/ChatInput/ControlBar/WorkingDirectorySection.tsx
@@ -6,10 +6,12 @@ import { memo } from 'react';
 
 import SafeBoundary from '@/components/ErrorBoundary';
 import { resolveTargetDeviceId } from '@/helpers/agentWorkingDirectory';
-import { getWorkingDirectoryPathString } from '@/helpers/workingDirectoryPath';
+import { getConfigRepoType, getWorkingDirectoryPathString } from '@/helpers/workingDirectoryPath';
 import { useEffectiveWorkingDirectory } from '@/hooks/useEffectiveWorkingDirectory';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
+import { useChatStore } from '@/store/chat';
+import { topicSelectors } from '@/store/chat/selectors';
 import { deviceSelectors, useDeviceStore } from '@/store/device';
 import { useElectronStore } from '@/store/electron';
 
@@ -58,7 +60,18 @@ const WorkingDirectorySectionInner = memo<WorkingDirectorySectionProps>(({ agent
     currentEntry?.repoType === 'git' || currentEntry?.repoType === 'github'
       ? currentEntry.repoType
       : undefined;
-  const repoType = isLocalDevice ? localRepoType : remoteRepoType;
+
+  // Live probes (fs / cached device dirs) can't resolve repoType for a worktree
+  // path that was never registered as a device working dir — so fall back to the
+  // repoType persisted on the topic (the same snapshot the meta hover card reads).
+  // Without this the whole GitStatus is gated out and branch/worktree/PR chips
+  // vanish even though the topic clearly carries git context.
+  const topicWorkingDirectoryConfig = useChatStore(
+    (s) => topicSelectors.currentTopicMetadata(s)?.workingDirectoryConfig,
+  );
+  const repoType =
+    (isLocalDevice ? localRepoType : remoteRepoType) ??
+    getConfigRepoType(topicWorkingDirectoryConfig);
 
   return (
     <>

--- a/src/features/ChatInput/ControlBar/WorkingDirectorySection.tsx
+++ b/src/features/ChatInput/ControlBar/WorkingDirectorySection.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { isDesktop } from '@lobechat/const';
+import { getWorkingDirEffectivePath } from '@lobechat/types';
 import { isRecord } from '@lobechat/utils';
 import { memo } from 'react';
 
@@ -46,21 +47,6 @@ const WorkingDirectorySectionInner = memo<WorkingDirectorySectionProps>(({ agent
   const rawEffectiveWorkingDirectory = useEffectiveWorkingDirectory(agentId);
   const effectiveWorkingDirectory = getWorkingDirectoryPathString(rawEffectiveWorkingDirectory);
 
-  // Local machine probes the filesystem for repoType; a remote device's repoType
-  // comes from the cached `workingDirs` entry (we can't probe a remote fs here).
-  const localRepoType = useRepoType(isLocalDevice ? effectiveWorkingDirectory : undefined);
-  const deviceDirs = useDeviceStore(deviceSelectors.getDeviceWorkingDirs(targetDeviceId));
-  const currentEntry = effectiveWorkingDirectory
-    ? deviceDirs.find((entry) => getEntryEffectivePath(entry) === effectiveWorkingDirectory)
-    : undefined;
-  const sourceWorkingDirectory =
-    (isRecord(currentEntry) ? getWorkingDirectoryPathString(currentEntry.path) : undefined) ??
-    effectiveWorkingDirectory;
-  const remoteRepoType =
-    currentEntry?.repoType === 'git' || currentEntry?.repoType === 'github'
-      ? currentEntry.repoType
-      : undefined;
-
   // Live probes (fs / cached device dirs) can't resolve repoType for a worktree
   // path that was never registered as a device working dir — so fall back to the
   // repoType persisted on the topic (the same snapshot the meta hover card reads).
@@ -69,9 +55,38 @@ const WorkingDirectorySectionInner = memo<WorkingDirectorySectionProps>(({ agent
   const topicWorkingDirectoryConfig = useChatStore(
     (s) => topicSelectors.currentTopicMetadata(s)?.workingDirectoryConfig,
   );
+  // Only trust the persisted config when it actually describes the directory we
+  // resolved — the topic override wins in `useEffectiveWorkingDirectory`, so this
+  // holds whenever the config is what produced `effectiveWorkingDirectory`.
+  const topicConfigMatchesEffective =
+    !!effectiveWorkingDirectory &&
+    getWorkingDirEffectivePath(topicWorkingDirectoryConfig) === effectiveWorkingDirectory;
+  const persistedConfig = topicConfigMatchesEffective ? topicWorkingDirectoryConfig : undefined;
+
+  // Local machine probes the filesystem for repoType; a remote device's repoType
+  // comes from the cached `workingDirs` entry (we can't probe a remote fs here).
+  const localRepoType = useRepoType(isLocalDevice ? effectiveWorkingDirectory : undefined);
+  const deviceDirs = useDeviceStore(deviceSelectors.getDeviceWorkingDirs(targetDeviceId));
+  const currentEntry = effectiveWorkingDirectory
+    ? deviceDirs.find((entry) => getEntryEffectivePath(entry) === effectiveWorkingDirectory)
+    : undefined;
+  const remoteRepoType =
+    currentEntry?.repoType === 'git' || currentEntry?.repoType === 'github'
+      ? currentEntry.repoType
+      : undefined;
+
+  // The SOURCE repo, not the checkout. A persisted-worktree topic has no matching
+  // `workingDirs` entry (that's exactly why the repoType probe misses), so without
+  // the persisted `config.path` this would collapse to the worktree path — and
+  // WorktreeSwitcher commits `sourcePath` as the WorkingDirEntry.path, rewriting
+  // the topic's repo source to the linked worktree and breaking later switches.
+  const sourceWorkingDirectory =
+    (isRecord(currentEntry) ? getWorkingDirectoryPathString(currentEntry.path) : undefined) ??
+    getWorkingDirectoryPathString(persistedConfig?.path) ??
+    effectiveWorkingDirectory;
+
   const repoType =
-    (isLocalDevice ? localRepoType : remoteRepoType) ??
-    getConfigRepoType(topicWorkingDirectoryConfig);
+    (isLocalDevice ? localRepoType : remoteRepoType) ?? getConfigRepoType(persistedConfig);
 
   return (
     <>

--- a/src/helpers/workingDirectoryPath.ts
+++ b/src/helpers/workingDirectoryPath.ts
@@ -1,4 +1,19 @@
+import type { WorkingDirConfig, WorkingDirRepoType } from '@lobechat/types';
 import { pickString } from '@lobechat/utils';
+
+import { isDesktop } from '@/const/version';
+
+/**
+ * The persisted repo type for a working-dir config, applying the web default:
+ * on web there is no local filesystem to probe, so an unset type is treated as
+ * `github` (the only web-supported repo source); on desktop it stays `undefined`
+ * so callers fall back to a live probe.
+ *
+ * Shared by the topic meta hover card and the ControlBar git status so both read
+ * repoType from the same source instead of diverging.
+ */
+export const getConfigRepoType = (config?: WorkingDirConfig): WorkingDirRepoType | undefined =>
+  config?.repoType ?? (isDesktop ? undefined : 'github');
 
 export const getWorkingDirectoryPathString = (path: unknown) => {
   const value = pickString(path)?.trim();

--- a/src/helpers/workingDirectoryPath.ts
+++ b/src/helpers/workingDirectoryPath.ts
@@ -5,15 +5,23 @@ import { isDesktop } from '@/const/version';
 
 /**
  * The persisted repo type for a working-dir config, applying the web default:
- * on web there is no local filesystem to probe, so an unset type is treated as
- * `github` (the only web-supported repo source); on desktop it stays `undefined`
- * so callers fall back to a live probe.
+ * on web there is no local filesystem to probe, so an unset type on an EXISTING
+ * config is treated as `github` (the only web-supported repo source); on desktop
+ * it stays `undefined` so callers fall back to a live probe.
+ *
+ * No config at all means "nothing was ever persisted" — that must stay
+ * `undefined` on every platform, otherwise a web caller would treat any bare
+ * device cwd as a GitHub repo and fire git/PR probes at directories that were
+ * never identified as one.
  *
  * Shared by the topic meta hover card and the ControlBar git status so both read
  * repoType from the same source instead of diverging.
  */
-export const getConfigRepoType = (config?: WorkingDirConfig): WorkingDirRepoType | undefined =>
-  config?.repoType ?? (isDesktop ? undefined : 'github');
+export const getConfigRepoType = (config?: WorkingDirConfig): WorkingDirRepoType | undefined => {
+  if (!config) return undefined;
+
+  return config.repoType ?? (isDesktop ? undefined : 'github');
+};
 
 export const getWorkingDirectoryPathString = (path: unknown) => {
   const value = pickString(path)?.trim();

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/metaCardData.ts
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/metaCardData.ts
@@ -7,8 +7,7 @@ import { cssVar } from 'antd-style';
 import type { LucideIcon } from 'lucide-react';
 import { GitMerge, GitPullRequestArrow, GitPullRequestClosed } from 'lucide-react';
 
-import { isDesktop } from '@/const/version';
-import { getWorkingDirectoryName } from '@/helpers/workingDirectoryPath';
+import { getConfigRepoType, getWorkingDirectoryName } from '@/helpers/workingDirectoryPath';
 
 export type PullRequestState = 'open' | 'merged' | 'closed';
 
@@ -58,7 +57,7 @@ export const getTopicMetaCard = (metadata: ChatTopicMetadata | undefined) => {
     detached: git.detached,
     pullRequest: git.github?.pullRequest ?? undefined,
     repoName: sourcePath ? getWorkingDirectoryName(sourcePath) : undefined,
-    repoType: config.repoType ?? (isDesktop ? undefined : ('github' as const)),
+    repoType: getConfigRepoType(config),
     worktreeName: isWorktree && effectivePath ? getWorkingDirectoryName(effectivePath) : undefined,
   };
 };


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix
- [x] ✨ feat

#### 🔀 Description of Change

Two changes in the agent chat ControlBar:

**1. ControlBar git status vanished for worktree topics (fix)**

The topic meta hover card renders repo / branch / worktree / PR from the topic's persisted `workingDirectoryConfig.git`. But the bottom ControlBar's `GitStatus` (the branch / worktree / PR chips) was gated on a **live-resolved** `repoType` derived from the device's `workingDirs` cache + a filesystem probe. A worktree effective path is usually **not** registered as a device working dir, so that live lookup returned `undefined`, the `effectiveWorkingDirectory && repoType` gate in `WorkingDirectorySection` failed, and the whole `GitStatus` — branch, worktree switcher, PR chip — silently disappeared, even though the topic clearly carried git context.

The two surfaces read `repoType` from different sources and diverged. This PR:

- Extracts a shared `getConfigRepoType(config)` helper (persisted repoType + the web `github` default) into `helpers/workingDirectoryPath.ts`, and routes the meta hover card through it (behavior-preserving).
- Makes `WorkingDirectorySection` fall back to the topic's persisted `workingDirectoryConfig.repoType` when the live probe yields nothing, so `GitStatus` mounts for worktree topics.

**2. Add Fable 5 to the Claude Code model selector (feat)**

Adds `{ label: 'Fable 5', value: 'fable' }` to `CLAUDE_CODE_MODEL_OPTIONS`. The value flows through verbatim as `--model fable` to the Claude Code CLI; the model value is a free-form string with no backend enum/schema to sync, and `MODEL_LABELS` picks up the label automatically.

#### 🧪 How to Test

- [x] Tested locally

1. Open a Claude Code agent topic whose run used a git **worktree**.
2. Confirm the bottom ControlBar now shows the branch / worktree / PR chips (previously blank), matching the topic hover card.
3. Open the model selector and confirm **Fable 5** appears at the top of the Claude Code model list.

#### 📝 Additional Information

No backend / schema changes. `getConfigRepoType` is now the single source for persisted repoType across the hover card and the ControlBar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)