### PR TITLE
🐛 fix(bot): recover empty completion replies from DB and notify thread members

### DIFF
--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -476,13 +476,37 @@ export class CompletionLifecycle {
     const isAsyncToolPark = reason === 'waiting_for_async_tool';
 
     try {
-      const { event, metadata } = this.buildLifecycleEvent(operationId, state, reason);
+      const { assistantMessageId, event, metadata } = this.buildLifecycleEvent(
+        operationId,
+        state,
+        reason,
+      );
 
       // Finalize the agent_operations row before user hooks fire so
       // downstream consumers see the row in its terminal shape.
       await this.persistCompletion(operationId, state, reason);
 
       if (isAsyncToolPark) return;
+
+      // `lastAssistantContent` comes off the Redis-backed `state.messages`,
+      // while the assistant message row is persisted through a separate
+      // `messageModel.update` path. When the two diverge (state entry empty
+      // but the DB row holds the full reply — LOBE-11632: bot completions
+      // arrived with no content while the app showed the reply), consumers
+      // like the IM bot callback silently drop the reply. Recover from the DB
+      // row — the same source of truth the app UI renders — before dispatch.
+      if (
+        (reason === 'done' || reason === 'max_steps' || reason === 'cost_limit') &&
+        !event.lastAssistantContent?.trim() &&
+        !event.attachments?.length
+      ) {
+        const recovered = await this.recoverLastAssistantContent(
+          operationId,
+          assistantMessageId,
+          metadata?.userId || this.userId,
+        );
+        if (recovered) event.lastAssistantContent = recovered;
+      }
 
       await hookDispatcher.dispatch(operationId, 'onComplete', event, metadata._hooks);
 
@@ -565,6 +589,41 @@ export class CompletionLifecycle {
         // Kept across an async-tool park: the op resumes under the same id.
         this.verifyPlanInstantiations.delete(operationId);
       }
+    }
+  }
+
+  /**
+   * Load the final assistant message row from the DB and return its text
+   * content, for completions whose Redis-side state carried no assistant
+   * text (see the LOBE-11632 note in {@link dispatchHooks}). Non-fatal: any
+   * failure just leaves the event as-built.
+   */
+  private async recoverLastAssistantContent(
+    operationId: string,
+    assistantMessageId: string | undefined,
+    userId: string,
+  ): Promise<string | undefined> {
+    if (!assistantMessageId) return undefined;
+
+    try {
+      const messageModel =
+        userId === this.userId
+          ? this.messageModel
+          : new MessageModel(this.serverDB, userId, this.workspaceId);
+      const row = await messageModel.findById(assistantMessageId);
+      const content = typeof row?.content === 'string' ? row.content : undefined;
+      if (!content?.trim()) return undefined;
+
+      // console (not debug) so state/DB divergence stays visible in
+      // production logs — the silent variant of this is what made
+      // LOBE-11632 hard to diagnose.
+      console.warn(
+        `[CompletionLifecycle][${operationId}] completion event had no assistant text; recovered ${content.length} chars from message ${assistantMessageId}`,
+      );
+      return content;
+    } catch (error) {
+      log('[%s] recoverLastAssistantContent failed (non-fatal): %O', operationId, error);
+      return undefined;
     }
   }
 

--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -1,4 +1,6 @@
 import { isParkedStatus } from '@lobechat/agent-runtime';
+import type { MessageContentPart } from '@lobechat/types';
+import { deserializeParts } from '@lobechat/utils';
 import debug from 'debug';
 
 import {
@@ -611,8 +613,21 @@ export class CompletionLifecycle {
           ? this.messageModel
           : new MessageModel(this.serverDB, userId, this.workspaceId);
       const row = await messageModel.findById(assistantMessageId);
-      const content = typeof row?.content === 'string' ? row.content : undefined;
-      if (!content?.trim()) return undefined;
+      const raw = typeof row?.content === 'string' ? row.content : undefined;
+      if (!raw?.trim()) return undefined;
+
+      // Multimodal rows store `content` as serialized MessageContentPart[]
+      // (see serverCallLlmFinalizer / serializePartsForStorage) — sending
+      // that verbatim would deliver raw JSON to the bot channel. Extract
+      // only the text parts; an image-only row yields no recoverable text.
+      const parts = deserializeParts(raw);
+      const content = parts
+        ? parts
+            .filter((p): p is Extract<MessageContentPart, { type: 'text' }> => p.type === 'text')
+            .map((p) => p.text)
+            .join('')
+        : raw;
+      if (!content.trim()) return undefined;
 
       // console (not debug) so state/DB divergence stays visible in
       // production logs — the silent variant of this is what made

--- a/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
+++ b/apps/server/src/services/agentRuntime/CompletionLifecycle.ts
@@ -618,9 +618,14 @@ export class CompletionLifecycle {
 
       // Multimodal rows store `content` as serialized MessageContentPart[]
       // (see serverCallLlmFinalizer / serializePartsForStorage) — sending
-      // that verbatim would deliver raw JSON to the bot channel. Extract
-      // only the text parts; an image-only row yields no recoverable text.
-      const parts = deserializeParts(raw);
+      // that verbatim would deliver raw JSON to the bot channel. Gate on the
+      // row's `metadata.isMultimodal` flag (the same signal the app UI uses
+      // in DisplayContent) rather than sniffing the string, so a legitimate
+      // plain-text reply that happens to be a JSON array is preserved as-is.
+      // Extract only the text parts; an image-only row recovers nothing.
+      const isMultimodal =
+        (row?.metadata as { isMultimodal?: boolean } | null | undefined)?.isMultimodal === true;
+      const parts = isMultimodal ? deserializeParts(raw) : null;
       const content = parts
         ? parts
             .filter((p): p is Extract<MessageContentPart, { type: 'text' }> => p.type === 'text')

--- a/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
@@ -412,6 +412,111 @@ describe('CompletionLifecycle.dispatchHooks — async-tool park', () => {
   });
 });
 
+describe('CompletionLifecycle.dispatchHooks — lastAssistantContent DB recovery (LOBE-11632)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const buildDoneState = (assistantContent: string | undefined) => ({
+    messages: [
+      { content: 'user prompt', id: 'msg-user', role: 'user' },
+      { content: assistantContent, id: 'msg-assistant', role: 'assistant' },
+    ],
+    metadata: { _hooks: [], agentId: 'agent-1', topicId: 'tpc-1', userId: 'user-1' },
+    status: 'done',
+  });
+
+  const setupSpies = (lifecycle: CompletionLifecycle) => {
+    vi.spyOn(lifecycle as any, 'persistCompletion').mockResolvedValue(undefined);
+    vi.spyOn(lifecycle as any, 'createVerifyMessage').mockResolvedValue(undefined);
+    vi.spyOn(verifyServices, 'runVerifyOnCompletion').mockResolvedValue(undefined);
+    vi.spyOn(hookDispatcher, 'unregister').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    return vi.spyOn(hookDispatcher, 'dispatch').mockResolvedValue(undefined as any);
+  };
+
+  it('recovers the reply text from the DB row when the state carries no assistant text', async () => {
+    const lifecycle = buildLifecycle();
+    const dispatchSpy = setupSpies(lifecycle);
+    const findById = vi.fn().mockResolvedValue({ content: 'the real reply', id: 'msg-assistant' });
+    (lifecycle as any).messageModel = { findById };
+
+    await lifecycle.dispatchHooks('op-1', buildDoneState(''), 'done');
+
+    expect(findById).toHaveBeenCalledWith('msg-assistant');
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'op-1',
+      'onComplete',
+      expect.objectContaining({ lastAssistantContent: 'the real reply' }),
+      [],
+    );
+  });
+
+  it('does not hit the DB when the state already carries assistant text', async () => {
+    const lifecycle = buildLifecycle();
+    const dispatchSpy = setupSpies(lifecycle);
+    const findById = vi.fn();
+    (lifecycle as any).messageModel = { findById };
+
+    await lifecycle.dispatchHooks('op-1', buildDoneState('state reply'), 'done');
+
+    expect(findById).not.toHaveBeenCalled();
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'op-1',
+      'onComplete',
+      expect.objectContaining({ lastAssistantContent: 'state reply' }),
+      [],
+    );
+  });
+
+  it('leaves the event untouched when the DB row is empty too', async () => {
+    const lifecycle = buildLifecycle();
+    const dispatchSpy = setupSpies(lifecycle);
+    const findById = vi.fn().mockResolvedValue({ content: '', id: 'msg-assistant' });
+    (lifecycle as any).messageModel = { findById };
+
+    await lifecycle.dispatchHooks('op-1', buildDoneState(''), 'done');
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'op-1',
+      'onComplete',
+      expect.objectContaining({ lastAssistantContent: undefined }),
+      [],
+    );
+  });
+
+  it('still dispatches the original event when the DB lookup throws', async () => {
+    const lifecycle = buildLifecycle();
+    const dispatchSpy = setupSpies(lifecycle);
+    const findById = vi.fn().mockRejectedValue(new Error('db down'));
+    (lifecycle as any).messageModel = { findById };
+
+    await lifecycle.dispatchHooks('op-1', buildDoneState(''), 'done');
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'op-1',
+      'onComplete',
+      expect.objectContaining({ lastAssistantContent: undefined }),
+      [],
+    );
+  });
+
+  it('skips recovery on the error path', async () => {
+    const lifecycle = buildLifecycle();
+    setupSpies(lifecycle);
+    const findById = vi.fn();
+    (lifecycle as any).messageModel = { findById, update: vi.fn().mockResolvedValue(undefined) };
+
+    await lifecycle.dispatchHooks(
+      'op-1',
+      { ...buildDoneState(''), error: { message: 'boom' }, status: 'error' },
+      'error',
+    );
+
+    expect(findById).not.toHaveBeenCalled();
+  });
+});
+
 describe('CompletionLifecycle.emitSignalEvents — assistant anchor', () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
@@ -476,7 +476,11 @@ describe('CompletionLifecycle.dispatchHooks — lastAssistantContent DB recovery
       { text: '图里是一只猫', type: 'text' },
       { image: 'data:image/png;base64,xxx', type: 'image' },
     ]);
-    const findById = vi.fn().mockResolvedValue({ content: serialized, id: 'msg-assistant' });
+    const findById = vi.fn().mockResolvedValue({
+      content: serialized,
+      id: 'msg-assistant',
+      metadata: { isMultimodal: true },
+    });
     (lifecycle as any).messageModel = { findById };
 
     await lifecycle.dispatchHooks('op-1', buildDoneState(''), 'done');
@@ -489,11 +493,34 @@ describe('CompletionLifecycle.dispatchHooks — lastAssistantContent DB recovery
     );
   });
 
+  it('returns a plain-text reply verbatim even when it looks like a parts array', async () => {
+    const lifecycle = buildLifecycle();
+    const dispatchSpy = setupSpies(lifecycle);
+    // A legitimate text answer that happens to be a JSON array with `type`
+    // fields — without metadata.isMultimodal it must NOT be parsed as parts.
+    const jsonLookalike = '[{"type":"custom","value":1}]';
+    const findById = vi.fn().mockResolvedValue({ content: jsonLookalike, id: 'msg-assistant' });
+    (lifecycle as any).messageModel = { findById };
+
+    await lifecycle.dispatchHooks('op-1', buildDoneState(''), 'done');
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'op-1',
+      'onComplete',
+      expect.objectContaining({ lastAssistantContent: jsonLookalike }),
+      [],
+    );
+  });
+
   it('does not recover raw JSON from an image-only multimodal DB row', async () => {
     const lifecycle = buildLifecycle();
     const dispatchSpy = setupSpies(lifecycle);
     const serialized = JSON.stringify([{ image: 'data:image/png;base64,xxx', type: 'image' }]);
-    const findById = vi.fn().mockResolvedValue({ content: serialized, id: 'msg-assistant' });
+    const findById = vi.fn().mockResolvedValue({
+      content: serialized,
+      id: 'msg-assistant',
+      metadata: { isMultimodal: true },
+    });
     (lifecycle as any).messageModel = { findById };
 
     await lifecycle.dispatchHooks('op-1', buildDoneState(''), 'done');

--- a/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
+++ b/apps/server/src/services/agentRuntime/__tests__/CompletionLifecycle.test.ts
@@ -469,6 +469,43 @@ describe('CompletionLifecycle.dispatchHooks — lastAssistantContent DB recovery
     );
   });
 
+  it('extracts only text parts when the DB row stores serialized multimodal content', async () => {
+    const lifecycle = buildLifecycle();
+    const dispatchSpy = setupSpies(lifecycle);
+    const serialized = JSON.stringify([
+      { text: '图里是一只猫', type: 'text' },
+      { image: 'data:image/png;base64,xxx', type: 'image' },
+    ]);
+    const findById = vi.fn().mockResolvedValue({ content: serialized, id: 'msg-assistant' });
+    (lifecycle as any).messageModel = { findById };
+
+    await lifecycle.dispatchHooks('op-1', buildDoneState(''), 'done');
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'op-1',
+      'onComplete',
+      expect.objectContaining({ lastAssistantContent: '图里是一只猫' }),
+      [],
+    );
+  });
+
+  it('does not recover raw JSON from an image-only multimodal DB row', async () => {
+    const lifecycle = buildLifecycle();
+    const dispatchSpy = setupSpies(lifecycle);
+    const serialized = JSON.stringify([{ image: 'data:image/png;base64,xxx', type: 'image' }]);
+    const findById = vi.fn().mockResolvedValue({ content: serialized, id: 'msg-assistant' });
+    (lifecycle as any).messageModel = { findById };
+
+    await lifecycle.dispatchHooks('op-1', buildDoneState(''), 'done');
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      'op-1',
+      'onComplete',
+      expect.objectContaining({ lastAssistantContent: undefined }),
+      [],
+    );
+  });
+
   it('leaves the event untouched when the DB row is empty too', async () => {
     const lifecycle = buildLifecycle();
     const dispatchSpy = setupSpies(lifecycle);

--- a/apps/server/src/services/bot/AgentBridgeService.ts
+++ b/apps/server/src/services/bot/AgentBridgeService.ts
@@ -703,13 +703,13 @@ export class AgentBridgeService {
       ? platformRegistry.getPlatform(opts.botContext.platform)
       : undefined;
     const botPlatformContext:
-      | { platformName: string; supportsMarkdown: boolean; warnings?: string[] }
-      | undefined = platformDef
-      ? {
-          platformName: platformDef.name,
-          supportsMarkdown: platformDef.supportsMarkdown !== false,
-        }
-      : undefined;
+      { platformName: string; supportsMarkdown: boolean; warnings?: string[] } | undefined =
+      platformDef
+        ? {
+            platformName: platformDef.name,
+            supportsMarkdown: platformDef.supportsMarkdown !== false,
+          }
+        : undefined;
     // Whether we can edit a previously-posted message in place. When false
     // (QQ/WeChat today), the chat-adapter falls editMessage back to postMessage,
     // so each step/completion edit surfaces as a NEW message — leaving the
@@ -736,6 +736,19 @@ export class AgentBridgeService {
       workspaceId: this.workspaceId,
     });
     const timezone = await this.loadTimezone();
+
+    // Make sure the person who triggered the run is a member of the reply
+    // thread, so the platform notifies them when the reply lands (LOBE-11632:
+    // Discord's auto-created mention threads never add the mentioning user,
+    // and pill rendering on the origin message proved unreliable — replies
+    // were delivered but nobody was told). Fire-and-forget; never blocks.
+    const senderPlatformId = userMessage.author?.userId;
+    if (client?.ensureThreadMember && botContext?.platformThreadId && senderPlatformId) {
+      void safeSideEffect(
+        () => client.ensureThreadMember!(botContext.platformThreadId!, senderPlatformId),
+        'ensureThreadMember (executeWithCallback)',
+      );
+    }
 
     // When the message-gateway is configured AND the platform supports typing
     // indicators, skip the ack/progress message and rely on the gateway's
@@ -1613,8 +1626,7 @@ export class AgentBridgeService {
       const userModel = new UserModel(this.db, this.userId);
       const settings = await userModel.getUserSettings();
       this.timezone = (settings?.general as Record<string, unknown>)?.timezone as
-        | string
-        | undefined;
+        string | undefined;
     } catch {
       // Fall back to server time if settings can't be loaded
     }

--- a/apps/server/src/services/bot/BotCallbackService.ts
+++ b/apps/server/src/services/bot/BotCallbackService.ts
@@ -437,7 +437,12 @@ export class BotCallbackService {
     const hasText = !!lastAssistantContent?.trim();
     const hasAttachments = !!attachments?.length;
     if (!hasText && !hasAttachments) {
-      log('handleCompletion: no lastAssistantContent and no attachments, skipping');
+      // console (not debug) — every one of these is a user-facing "bot went
+      // silent" (LOBE-11632): the run completed but the completion event
+      // carried nothing to deliver. Must stay visible in production logs.
+      console.error(
+        `[BotCallbackService] completion had no lastAssistantContent and no attachments, skipping reply (operationId=${operationId}, topicId=${body.topicId}, thread=${body.platformThreadId})`,
+      );
       return;
     }
 
@@ -488,7 +493,10 @@ export class BotCallbackService {
           isLast && attachments?.length ? { attachments, content: chunks[i] } : chunks[i],
         );
       } catch (error) {
-        log('handleCompletion: failed to send chunk %d: %O', i, error);
+        console.error(
+          `[BotCallbackService] failed to send reply chunk ${i}/${lastIndex} (thread=${body.platformThreadId}):`,
+          error,
+        );
       }
     }
   }
@@ -511,6 +519,14 @@ export class BotCallbackService {
     if (canEdit && progressMessageId) {
       try {
         await messenger.editMessage(progressMessageId, payload);
+        // Positive delivery record (console, not debug): "we sent it and the
+        // platform accepted it" must be provable from production logs alone —
+        // LOBE-11632 burned days on inferring delivery from the absence of
+        // error logs while the target thread had been deleted out from under
+        // the bot.
+        console.info(
+          `[BotCallbackService] completion reply delivered via editMessage (message=${progressMessageId})`,
+        );
         return;
       } catch (error) {
         log('handleCompletion: editMessage failed, falling back to createMessage: %O', error);
@@ -518,8 +534,12 @@ export class BotCallbackService {
     }
     try {
       await messenger.createMessage(payload);
+      console.info('[BotCallbackService] completion reply delivered via createMessage');
     } catch (error) {
-      log('handleCompletion: createMessage fallback failed: %O', error);
+      // Last resort failed — the reply is lost. console (not debug) so the
+      // "agent ran but no reply appeared" class of failures (LOBE-11632)
+      // is visible in production logs instead of an HTTP 200 with nothing.
+      console.error('[BotCallbackService] createMessage fallback failed, reply lost:', error);
     }
   }
 

--- a/apps/server/src/services/bot/BotCallbackService.ts
+++ b/apps/server/src/services/bot/BotCallbackService.ts
@@ -39,6 +39,28 @@ import {
 
 const log = debug('lobe-server:bot:callback');
 
+/**
+ * Render a platform delivery error for production logging WITHOUT dumping
+ * the raw error object — platform SDK errors (e.g. `@discordjs/rest`
+ * DiscordAPIError) carry the full `requestBody`, i.e. the user/assistant
+ * message content, which must not be persisted in logs. Status/code live on
+ * well-known fields; the message string from these SDKs is the API error
+ * summary (e.g. "Unknown Channel"), not the payload.
+ */
+const describePlatformError = (error: unknown): string => {
+  if (error instanceof Error) {
+    const status = (error as { status?: unknown }).status;
+    const code = (error as { code?: unknown }).code;
+    const parts = [
+      `${error.name}: ${error.message}`,
+      status === undefined ? undefined : `status=${status}`,
+      code === undefined ? undefined : `code=${code}`,
+    ].filter(Boolean);
+    return parts.join(' ');
+  }
+  return String(error);
+};
+
 // --------------- Callback body types ---------------
 
 export interface BotCallbackBody {
@@ -494,8 +516,7 @@ export class BotCallbackService {
         );
       } catch (error) {
         console.error(
-          `[BotCallbackService] failed to send reply chunk ${i}/${lastIndex} (thread=${body.platformThreadId}):`,
-          error,
+          `[BotCallbackService] failed to send reply chunk ${i}/${lastIndex} (thread=${body.platformThreadId}): ${describePlatformError(error)}`,
         );
       }
     }
@@ -539,7 +560,9 @@ export class BotCallbackService {
       // Last resort failed — the reply is lost. console (not debug) so the
       // "agent ran but no reply appeared" class of failures (LOBE-11632)
       // is visible in production logs instead of an HTTP 200 with nothing.
-      console.error('[BotCallbackService] createMessage fallback failed, reply lost:', error);
+      console.error(
+        `[BotCallbackService] createMessage fallback failed, reply lost: ${describePlatformError(error)}`,
+      );
     }
   }
 

--- a/apps/server/src/services/bot/platforms/discord/api.ts
+++ b/apps/server/src/services/bot/platforms/discord/api.ts
@@ -224,6 +224,16 @@ export class DiscordApi {
     });
   }
 
+  /**
+   * Add a user to a thread. Members receive a notification and see the
+   * thread in their client regardless of whether the origin message's
+   * thread pill rendered (see LOBE-11632).
+   */
+  async addThreadMember(threadId: string, userId: string): Promise<void> {
+    log('addThreadMember: thread=%s, user=%s', threadId, userId);
+    await this.rest.put(Routes.threadMembers(threadId, userId));
+  }
+
   // ==================== Message Operations ====================
 
   async getMessages(

--- a/apps/server/src/services/bot/platforms/discord/client.ts
+++ b/apps/server/src/services/bot/platforms/discord/client.ts
@@ -224,6 +224,26 @@ class DiscordGatewayClient implements PlatformClient {
     };
   }
 
+  /**
+   * Add the triggering user to the auto-created reply thread so Discord
+   * notifies them and the thread shows up in their client. Only applies to
+   * guild threads (4-segment composite); DMs and top-level channels deliver
+   * in place. Best-effort: a failure (missing permission, user left the
+   * guild) must never affect the reply flow.
+   */
+  async ensureThreadMember(platformThreadId: string, platformUserId: string): Promise<void> {
+    const parts = platformThreadId.split(':');
+    // Format: discord:guildId:channelId:discordThreadId
+    if (parts.length !== 4 || parts[1] === '@me' || !parts[3] || !platformUserId) return;
+
+    try {
+      await this.discord.addThreadMember(parts[3], platformUserId);
+      log('ensureThreadMember: added user %s to thread %s', platformUserId, parts[3]);
+    } catch (error) {
+      log('ensureThreadMember: failed (non-fatal): %O', error);
+    }
+  }
+
   getMessenger(platformThreadId: string): PlatformMessenger {
     const channelId = extractChannelId(platformThreadId);
     const threadId = platformThreadId.split(':')[3];
@@ -302,8 +322,7 @@ class DiscordGatewayClient implements PlatformClient {
     const directAttachments = (message as any).attachments as DirectAttachment[] | undefined;
     const raw = (message as any).raw as Record<string, any> | undefined;
     const refAttachments = raw?.referenced_message?.attachments as
-      | DiscordRefAttachment[]
-      | undefined;
+      DiscordRefAttachment[] | undefined;
 
     log(
       'extractFiles: msgId=%s, direct=%d, referenced=%d',

--- a/apps/server/src/services/bot/platforms/types.ts
+++ b/apps/server/src/services/bot/platforms/types.ts
@@ -194,6 +194,23 @@ export interface PlatformClient {
   createAdapter: () => Record<string, any>;
 
   /**
+   * Ensure the triggering user is a member of the platform thread the bot
+   * replies in, so the platform pushes them a notification and surfaces the
+   * thread in their client.
+   *
+   * Discord: the auto-created per-mention reply thread never adds the
+   * mentioning user as a member — the reply lands in a thread the user is
+   * not notified about, and thread-pill rendering on the origin message has
+   * proven unreliable (LOBE-11632: two separate clients showed no pill for
+   * hours while the API said `HAS_THREAD`). Explicit membership bypasses
+   * both gaps. Best-effort — implementations must swallow failures.
+   *
+   * Platforms whose replies land directly in the conversation (Telegram,
+   * Slack channel replies, DMs) can omit this method.
+   */
+  ensureThreadMember?: (platformThreadId: string, platformUserId: string) => Promise<void>;
+
+  /**
    * Read the inbound message author's preferred language from the platform
    * payload (e.g. Telegram's `from.language_code`, Discord's `user.locale`).
    * Returns the raw platform string — caller is responsible for normalizing

--- a/src/server/agent-hono/handlers/botCallback.ts
+++ b/src/server/agent-hono/handlers/botCallback.ts
@@ -39,6 +39,15 @@ export async function botCallback(c: Context): Promise<Response> {
     return c.json({ error: `Unknown callback type: ${type}` }, 400);
   }
 
+  // console (not debug) for completions only: arrival of the final-reply
+  // callback must be provable from production logs (LOBE-11632) — the debug
+  // namespace above is not enabled in production, and steps are too chatty.
+  if (type === 'completion') {
+    console.info(
+      `[botCallback] completion received (operationId=${body.operationId}, thread=${platformThreadId}, reason=${body.reason}, contentLen=${typeof body.lastAssistantContent === 'string' ? body.lastAssistantContent.length : 0})`,
+    );
+  }
+
   try {
     const serverDB = await getServerDB();
     const service = new BotCallbackService(serverDB);


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Fixes LOBE-11632

#### 🔀 Description of Change

Three fixes for the "bot went silent on IM channels" class of incidents, where an agent run completed and the reply was visible in the app, but the bot channel (Discord etc.) showed nothing:

1. **CompletionLifecycle — recover empty completion replies from the DB.** The lifecycle event pulls `lastAssistantContent` off the Redis-backed `state.messages`, while the assistant message row is persisted through a separate `messageModel.update` path. When the two diverge (state entry empty, DB row complete), consumers like the IM bot callback silently dropped the reply. On a done-ish completion (`done` / `max_steps` / `cost_limit`) with no assistant text and no attachments, the dispatcher now falls back to the persisted assistant message row — the same source of truth the app UI renders — before firing `onComplete` hooks. Recovery logs a `console.warn` with operationId so state/DB divergence stays measurable in production.

2. **BotCallbackService / botCallback — production-visible delivery logging.** Completion arrival, delivery success (edit/create), delivery failure, and the empty-payload skip were all `debug()`-only, i.e. invisible in production. Diagnosing this incident required inferring delivery from the *absence* of error logs. All four points now log at console level (info/error) with operationId / topicId / thread context.

3. **AgentBridgeService / Discord — add the triggering user to the reply thread.** Discord mention-created reply threads never added the mentioning user as a member, and thread-pill rendering on the origin message proved unreliable across clients (hours of no pill while the API reported `HAS_THREAD`) — replies were delivered but nobody was notified. The bridge now fire-and-forgets a new optional platform capability `PlatformClient.ensureThreadMember` (Discord: `PUT /channels/<thread>/thread-members/<user>`), so the platform pushes a notification and surfaces the thread in the user's client. Best-effort; guarded to 4-segment guild threads only.

#### Key Decisions / Non-goals

- DB recovery is scoped to done-ish reasons; `error` / `interrupted` / async-tool parks keep their existing semantics.
- When the DB row is also empty (e.g. a model `refusal` finishing with zero content), the event stays empty — surfacing that class to the user is a separate runtime-layer fix (tracked in LOBE-11731); this PR makes it observable via the skip `console.error`.
- `ensureThreadMember` is deliberately optional per platform: platforms whose replies land directly in the conversation (Telegram, Slack, DMs) omit it.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- `bun run check --test` on the touched services: 126 tests pass (5 new cases covering recovery hit, pass-through, DB-empty, DB-error, error-path skip).
- Integration-verified the incident scenario against a real SQL layer + queue-mode webhook HTTP delivery: an empty-state completion recovers the DB reply and the webhook consumer receives the full content, while a normal completion passes through unchanged. Verify report: https://app.lobehub.com/verify/9594ccf3-1e27-4c22-b292-c13dfa0899fe

#### 📝 Additional Information

Production forensics (timeline, trace evidence, and the Discord-side reproduction) are documented on LOBE-11632 / LOBE-11731.

🤖 Generated with [Claude Code](https://claude.com/claude-code)