### PR TITLE
🐛 fix(agent): persist working sidebar width

### DIFF
--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
 import { act, render } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import AgentWorkingSidebar from '../index';
 
@@ -10,6 +10,7 @@ import AgentWorkingSidebar from '../index';
 
 interface CapturedRightPanelProps {
   children?: ReactNode;
+  defaultWidth?: number | string;
   maxWidth?: number | string;
   onSizeChange?: (size?: { height?: number | string; width?: number | string }) => void;
   width?: number | string;
@@ -17,6 +18,28 @@ interface CapturedRightPanelProps {
 
 const rightPanel = vi.hoisted(() => ({
   current: undefined as CapturedRightPanelProps | undefined,
+}));
+
+const agentStore = vi.hoisted(() => ({
+  activeAgentId: undefined as string | undefined,
+  isLocalSystemEnabled: false,
+}));
+
+const reviewState = vi.hoisted(() => ({
+  repoType: undefined as string | undefined,
+  showTree: false,
+  workingDirectory: undefined as string | undefined,
+}));
+
+const globalStore = vi.hoisted(() => ({
+  updateSystemStatus: vi.fn(),
+  toggleRightPanel: vi.fn(),
+  setWorkingSidebarTab: vi.fn(),
+  status: {
+    showRightPanel: true,
+    workingSidebarTab: 'params' as string | undefined,
+    workingSidebarWidth: 360 as number | undefined,
+  },
 }));
 
 vi.mock('@/features/RightPanel', () => ({
@@ -35,29 +58,44 @@ vi.mock('../ResourcesSection', () => ({ default: () => <div /> }));
 vi.mock('../ParamsSection', () => ({ default: () => <div /> }));
 
 vi.mock('@/store/agent', () => ({
-  getAgentStoreState: () => ({ activeAgentId: undefined }),
-  useAgentStore: () => undefined,
+  getAgentStoreState: () => agentStore,
+  useAgentStore: (selector: (s: typeof agentStore) => unknown) => selector(agentStore),
 }));
 vi.mock('@/store/agent/selectors', () => ({
-  agentByIdSelectors: {},
+  agentByIdSelectors: {
+    getAgencyConfigById: () => () => undefined,
+    isWorkspaceAgentById: () => () => false,
+  },
   agentSelectors: {
-    getAgentConfigById: () => () => undefined,
     isCurrentAgentHeterogeneous: () => false,
   },
-  chatConfigByIdSelectors: {},
+  chatConfigByIdSelectors: {
+    isChatModeById: () => () => false,
+    isLocalSystemEnabledById: () => () => agentStore.isLocalSystemEnabled,
+  },
 }));
-vi.mock('@/store/global', () => ({ useGlobalStore: () => undefined }));
+vi.mock('@/store/global', () => ({
+  useGlobalStore: (selector: (s: typeof globalStore) => unknown) => selector(globalStore),
+}));
+vi.mock('@/store/global/selectors', () => ({
+  systemStatusSelectors: {
+    workingSidebarWidth: (s: typeof globalStore) => s.status.workingSidebarWidth || 360,
+  },
+}));
 vi.mock('@/store/electron', () => ({ useElectronStore: () => undefined }));
 
-vi.mock('@/features/ChatInput/ControlBar/useRepoType', () => ({ useRepoType: () => undefined }));
+vi.mock('@/features/ChatInput/ControlBar/useRepoType', () => ({
+  useRepoType: () => reviewState.repoType,
+}));
 vi.mock('@/hooks/useEffectiveWorkingDirectory', () => ({
-  useEffectiveWorkingDirectory: () => undefined,
+  useEffectiveWorkingDirectory: () => reviewState.workingDirectory,
 }));
 vi.mock('@/hooks/useLocalStorageState', () => ({
-  useLocalStorageState: () => [false, vi.fn()],
+  useLocalStorageState: () => [reviewState.showTree, vi.fn()],
 }));
 vi.mock('@/helpers/agentWorkingDirectory', () => ({ resolveTargetDeviceId: () => undefined }));
 vi.mock('@/helpers/executionTarget', () => ({ resolveExecutionTarget: () => 'local' }));
+vi.mock('@/helpers/gatewayMode', () => ({ useIsGatewayModeEnabled: () => false }));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
@@ -71,6 +109,20 @@ vi.mock('@lobehub/ui', () => ({
 vi.mock('antd-style', () => ({
   createStaticStyles: () => () => ({}),
 }));
+
+beforeEach(() => {
+  agentStore.activeAgentId = undefined;
+  agentStore.isLocalSystemEnabled = false;
+  reviewState.repoType = undefined;
+  reviewState.showTree = false;
+  reviewState.workingDirectory = undefined;
+  globalStore.status.workingSidebarWidth = 360;
+  globalStore.status.showRightPanel = true;
+  globalStore.status.workingSidebarTab = 'params';
+  globalStore.updateSystemStatus.mockReset();
+  globalStore.toggleRightPanel.mockReset();
+  globalStore.setWorkingSidebarTab.mockReset();
+});
 
 afterEach(() => {
   rightPanel.current = undefined;
@@ -90,27 +142,65 @@ describe('AgentWorkingSidebar — controlled panel width', () => {
     expect(rightPanel.current?.maxWidth).toBe(1200);
   });
 
+  it('restores a previously persisted width from systemStatus', () => {
+    globalStore.status.workingSidebarWidth = 520;
+
+    render(<AgentWorkingSidebar />);
+
+    expect(rightPanel.current?.width).toBe(520);
+  });
+
+  it('clamps two-pane Review width without overwriting the persisted preference', () => {
+    agentStore.activeAgentId = 'agent';
+    agentStore.isLocalSystemEnabled = true;
+    reviewState.repoType = 'git';
+    reviewState.showTree = true;
+    reviewState.workingDirectory = 'C:\\repo';
+    globalStore.status.workingSidebarTab = 'review';
+
+    const { unmount } = render(<AgentWorkingSidebar />);
+
+    expect(rightPanel.current?.defaultWidth).toBe(560);
+    expect(rightPanel.current?.width).toBe(560);
+    expect(globalStore.updateSystemStatus).not.toHaveBeenCalled();
+
+    unmount();
+    globalStore.status.workingSidebarTab = 'params';
+    render(<AgentWorkingSidebar />);
+    expect(rightPanel.current?.width).toBe(360);
+  });
+
   // Regression: DraggablePanel reports the dragged width as a `"480px"` string on
   // drag-stop. A `typeof width === 'number'` guard silently dropped it, so the
   // controlled width never updated and the panel snapped back — appearing
   // impossible to resize. The handler must parse the px string.
   it('applies a "480px" string width from a drag so the panel actually resizes', () => {
-    render(<AgentWorkingSidebar />);
+    const { unmount } = render(<AgentWorkingSidebar />);
 
     act(() => {
       rightPanel.current?.onSizeChange?.({ width: '480px' });
     });
 
+    expect(globalStore.updateSystemStatus).toHaveBeenCalledWith({ workingSidebarWidth: 480 });
+
+    globalStore.status.workingSidebarWidth = 480;
+    unmount();
+    render(<AgentWorkingSidebar />);
     expect(rightPanel.current?.width).toBe(480);
   });
 
   it('applies a numeric drag width unchanged', () => {
-    render(<AgentWorkingSidebar />);
+    const { unmount } = render(<AgentWorkingSidebar />);
 
     act(() => {
       rightPanel.current?.onSizeChange?.({ width: 500 });
     });
 
+    expect(globalStore.updateSystemStatus).toHaveBeenCalledWith({ workingSidebarWidth: 500 });
+
+    globalStore.status.workingSidebarWidth = 500;
+    unmount();
+    render(<AgentWorkingSidebar />);
     expect(rightPanel.current?.width).toBe(500);
   });
 
@@ -122,5 +212,6 @@ describe('AgentWorkingSidebar — controlled panel width', () => {
     });
 
     expect(rightPanel.current?.width).toBe(360);
+    expect(globalStore.updateSystemStatus).not.toHaveBeenCalled();
   });
 });

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/index.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/store/agent/selectors';
 import { useElectronStore } from '@/store/electron';
 import { useGlobalStore } from '@/store/global';
+import { systemStatusSelectors } from '@/store/global/selectors';
 import { useUserStore } from '@/store/user';
 import { labPreferSelectors } from '@/store/user/selectors';
 
@@ -84,20 +85,24 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
 type Tab = 'browser' | 'files' | 'params' | 'review' | 'resources';
 
 const REVIEW_TREE_STORAGE_KEY = 'lobechat-review-tree';
-const DEFAULT_PANEL_WIDTH = 360;
 const MAX_PANEL_WIDTH = 1200;
 // Two-pane Review (diff list + file-tree rail) is cramped below this.
 const TWO_PANE_MIN_WIDTH = 560;
 
 const AgentWorkingSidebar = memo(() => {
   const { t } = useTranslation(['chat', 'setting']);
-  const toggleRightPanel = useGlobalStore((s) => s.toggleRightPanel);
-  // Panel open/collapsed state (drives the `<RightPanel>` expand). Used to gate
-  // the resources pane's document fetch so a collapsed sidebar doesn't pull the
-  // full agent-document list into the conversation's initial batch.
-  const showRightPanel = useGlobalStore((s) => s.status.showRightPanel);
-  const setWorkingSidebarTab = useGlobalStore((s) => s.setWorkingSidebarTab);
-  const storedTab = useGlobalStore((s) => s.status.workingSidebarTab);
+  const [storedWidth, updateSystemStatus, toggleRightPanel, setWorkingSidebarTab, showRightPanel, storedTab] =
+    useGlobalStore((s) => [
+      systemStatusSelectors.workingSidebarWidth(s),
+      s.updateSystemStatus,
+      s.toggleRightPanel,
+      s.setWorkingSidebarTab,
+      // Panel open/collapsed state (drives the `<RightPanel>` expand). Used to gate
+      // the resources pane's document fetch so a collapsed sidebar doesn't pull the
+      // full agent-document list into the conversation's initial batch.
+      s.status.showRightPanel,
+      s.status.workingSidebarTab,
+    ]);
   const activeAgentId = useAgentStore((s) => s.activeAgentId);
   const isLocalSystemEnabled = useAgentStore((s) =>
     activeAgentId ? chatConfigByIdSelectors.isLocalSystemEnabledById(activeAgentId)(s) : false,
@@ -172,7 +177,6 @@ const AgentWorkingSidebar = memo(() => {
     REVIEW_TREE_STORAGE_KEY,
     false,
   );
-  const [panelWidth, setPanelWidth] = useState<number | string>(DEFAULT_PANEL_WIDTH);
   // Mount the browser pane on first activation only (no eager page load), then
   // keep it mounted-but-hidden so the page survives tab switches.
   const [browserActivated, setBrowserActivated] = useState(false);
@@ -180,26 +184,22 @@ const AgentWorkingSidebar = memo(() => {
     if (activeTab === 'browser') setBrowserActivated(true);
   }, [activeTab]);
   const reviewTwoPane = activeTab === 'review' && reviewAvailable && showReviewTree;
-  useEffect(() => {
-    if (!reviewTwoPane) return;
-    setPanelWidth((w) =>
-      typeof w === 'number' && w < TWO_PANE_MIN_WIDTH ? TWO_PANE_MIN_WIDTH : w,
-    );
-  }, [reviewTwoPane]);
+  const displayWidth = reviewTwoPane ? Math.max(storedWidth, TWO_PANE_MIN_WIDTH) : storedWidth;
 
   return (
     <RightPanel
       stableLayout
-      defaultWidth={DEFAULT_PANEL_WIDTH}
+      defaultWidth={displayWidth}
       maxWidth={MAX_PANEL_WIDTH}
       minWidth={300}
-      width={panelWidth}
+      width={displayWidth}
       onSizeChange={(size) => {
         if (!size?.width) return;
         // DraggablePanel emits width as a `"420px"` string on drag-stop; parse it so
         // the controlled width actually updates (otherwise the panel snaps back).
         const w = typeof size.width === 'string' ? Number.parseInt(size.width) : size.width;
-        if (Number.isFinite(w)) setPanelWidth(w);
+        if (!Number.isFinite(w) || w === storedWidth) return;
+        updateSystemStatus({ workingSidebarWidth: w });
       }}
     >
       <Flexbox height={'100%'} width={'100%'}>

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -333,6 +333,11 @@ export interface SystemStatus {
    */
   workingSidebarTab?: WorkingSidebarTab;
   /**
+   * Width of the agent chat right-side WorkingSidebar (space / params / files / …).
+   * Persisted so resizing survives remounts when navigating away and back.
+   */
+  workingSidebarWidth?: number;
+  /**
    * Workspace-mode overlay for sidebar layout/visibility preferences.
    * When the user is inside a workspace (see `useActiveWorkspaceId`), reads
    * fall back to these values instead of the top-level fields, and writes
@@ -466,6 +471,7 @@ export const INITIAL_STATUS = {
   videoPanelWidth: 320,
   videoTopicViewMode: 'grid' as const,
   videoTopicPanelWidth: 80,
+  workingSidebarWidth: 360,
 } satisfies SystemStatus;
 
 export const initialState: GlobalState = {

--- a/src/store/global/selectors/systemStatus.test.ts
+++ b/src/store/global/selectors/systemStatus.test.ts
@@ -90,6 +90,24 @@ describe('systemStatusSelectors', () => {
       expect(systemStatusSelectors.portalWidth(noPortalWidth)).toBe(400);
     });
 
+    it('should return workingSidebarWidth from status, defaulting to 360', () => {
+      expect(
+        systemStatusSelectors.workingSidebarWidth(
+          merge(initialState, {
+            status: { workingSidebarWidth: 520 },
+          }),
+        ),
+      ).toBe(520);
+
+      expect(
+        systemStatusSelectors.workingSidebarWidth(
+          merge(initialState, {
+            status: { workingSidebarWidth: undefined },
+          }),
+        ),
+      ).toBe(360);
+    });
+
     it('should clamp persisted left panel width to the draggable panel bounds', () => {
       expect(
         systemStatusSelectors.leftPanelWidth(

--- a/src/store/global/selectors/systemStatus.ts
+++ b/src/store/global/selectors/systemStatus.ts
@@ -384,6 +384,7 @@ const modelSwitchPanelGroupMode = (s: GlobalState) =>
   s.status.modelSwitchPanelGroupMode || 'byProvider';
 const modelSwitchPanelWidth = (s: GlobalState) => s.status.modelSwitchPanelWidth || 460;
 const pageAgentPanelWidth = (s: GlobalState) => s.status.pageAgentPanelWidth || 360;
+const workingSidebarWidth = (s: GlobalState) => s.status.workingSidebarWidth || 360;
 
 const leftPanelWidth = (s: GlobalState): number => {
   return normalizeNavPanelWidth(s.status.leftPanelWidth);
@@ -495,4 +496,5 @@ export const systemStatusSelectors = {
   videoTopicViewMode,
   videoTopicPanelWidth,
   wideScreen,
+  workingSidebarWidth,
 };


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Persist the Agent conversation WorkingSidebar width in the global system status.

Previously, the width was stored only in component-local state. Navigating away from an Agent conversation (for example, creating or opening a Page) unmounted the sidebar, so returning to the conversation reset it to the default width.

This change:

- adds a persisted `workingSidebarWidth` system status field
- restores the saved width when the WorkingSidebar remounts
- saves drag-resize changes through `updateSystemStatus`
- keeps the Review two-pane minimum-width adjustment persisted
- adds regression coverage for restoring the width after remount

#### 🧪 How to Test

1. Open an Agent conversation and show the right WorkingSidebar.
2. Resize the sidebar.
3. Navigate to a Page or another route that unmounts the Agent conversation layout.
4. Return to the Agent conversation.
5. Confirm the sidebar keeps the resized width.

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Validation:

- `vitest`: 48 tests passed across the WorkingSidebar and system status selector suites
- ESLint passed for all changed files
- full TypeScript type-check passed
- Windows Electron unpacked build completed successfully

#### 📸 Screenshots / Videos

Not included; this fixes persisted layout state without changing the panel's visual design.

#### 📝 Additional Information

The width preference uses the existing `SystemStatus` local persistence path, consistent with other resizable panels such as `portalWidth` and `pageAgentPanelWidth`.