### PR TITLE
🐛 fix(database): repair Zod 4 + drizzle-zod insert schema type inference

### DIFF
--- a/apps/server/src/routers/lambda/thread.ts
+++ b/apps/server/src/routers/lambda/thread.ts
@@ -5,7 +5,7 @@ import { withScopedPermission } from '@/business/server/trpc-middlewares/rbacPer
 import { wsCompatProcedure } from '@/business/server/trpc-middlewares/workspaceAuth';
 import { MessageModel } from '@/database/models/message';
 import { ThreadModel } from '@/database/models/thread';
-import { insertThreadSchema } from '@/database/schemas';
+import { updateThreadSchema } from '@/database/schemas';
 import { router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { type ThreadItem } from '@/types/topic/thread';
@@ -120,7 +120,7 @@ export const threadRouter = router({
     .input(
       z.object({
         id: z.string(),
-        value: insertThreadSchema.partial(),
+        value: updateThreadSchema,
       }),
     )
     .mutation(async ({ input, ctx }) => {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -34,7 +34,7 @@
   "peerDependencies": {
     "dayjs": "*",
     "drizzle-orm": "*",
-    "drizzle-zod": "*",
+    "drizzle-zod": "^0.8.3",
     "nanoid": "*",
     "pg": "*",
     "zod": "^4.4.3"

--- a/packages/database/src/schemas/agent.ts
+++ b/packages/database/src/schemas/agent.ts
@@ -29,6 +29,9 @@ import { workspaces } from './workspace';
 // agent is a model that represents the assistant that is created by the user
 // agent can have its own knowledge base and files
 
+/** Agent visibility — shared by column def and insert schema. */
+export const AGENT_VISIBILITY = ['private', 'public'] as const;
+
 export const agents = pgTable(
   'agents',
   {
@@ -80,9 +83,7 @@ export const agents = pgTable(
      * the creator (`user_id`). Ignored in personal mode where the row is
      * implicitly private to its owner.
      */
-    visibility: text('visibility', { enum: ['private', 'public'] })
-      .default('public')
-      .notNull(),
+    visibility: text('visibility', { enum: AGENT_VISIBILITY }).default('public').notNull(),
 
     ...timestamps,
   },
@@ -108,7 +109,8 @@ export const insertAgentSchema = createInsertSchema(agents, {
   chatConfig: AgentChatConfigSchema.nullish(),
   // See insertSessionGroupSchema: Zod 4 + drizzle-zod text-enum inference pollution.
   // `.optional()` preserves defaulted-column omit semantics at runtime.
-  visibility: z.enum(['private', 'public']).optional(),
+  // Enum values from AGENT_VISIBILITY so column def and schema stay in sync.
+  visibility: z.enum(AGENT_VISIBILITY).optional(),
 });
 
 export type NewAgent = typeof agents.$inferInsert;

--- a/packages/database/src/schemas/agent.ts
+++ b/packages/database/src/schemas/agent.ts
@@ -106,8 +106,9 @@ export const insertAgentSchema = createInsertSchema(agents, {
   agencyConfig: z.custom<LobeAgentAgencyConfig>().nullish(),
   // Override chatConfig type to use the proper schema
   chatConfig: AgentChatConfigSchema.nullish(),
-  // See insertSessionGroupSchema: Zod 4 + drizzle-zod text-enum inference pollution
-  visibility: z.enum(['private', 'public']),
+  // See insertSessionGroupSchema: Zod 4 + drizzle-zod text-enum inference pollution.
+  // `.optional()` preserves defaulted-column omit semantics at runtime.
+  visibility: z.enum(['private', 'public']).optional(),
 });
 
 export type NewAgent = typeof agents.$inferInsert;

--- a/packages/database/src/schemas/agent.ts
+++ b/packages/database/src/schemas/agent.ts
@@ -106,6 +106,8 @@ export const insertAgentSchema = createInsertSchema(agents, {
   agencyConfig: z.custom<LobeAgentAgencyConfig>().nullish(),
   // Override chatConfig type to use the proper schema
   chatConfig: AgentChatConfigSchema.nullish(),
+  // See insertSessionGroupSchema: Zod 4 + drizzle-zod text-enum inference pollution
+  visibility: z.enum(['private', 'public']),
 });
 
 export type NewAgent = typeof agents.$inferInsert;

--- a/packages/database/src/schemas/file.ts
+++ b/packages/database/src/schemas/file.ts
@@ -293,9 +293,10 @@ export const knowledgeBases = pgTable(
   ],
 );
 
-// See insertSessionGroupSchema: Zod 4 + drizzle-zod text-enum inference pollution
+// See insertSessionGroupSchema: Zod 4 + drizzle-zod text-enum inference pollution.
+// `.optional()` preserves defaulted-column omit semantics at runtime.
 export const insertKnowledgeBasesSchema = createInsertSchema(knowledgeBases, {
-  visibility: z.enum(['private', 'public']),
+  visibility: z.enum(['private', 'public']).optional(),
 });
 
 export type NewKnowledgeBase = typeof knowledgeBases.$inferInsert;

--- a/packages/database/src/schemas/file.ts
+++ b/packages/database/src/schemas/file.ts
@@ -244,6 +244,9 @@ export const files = pgTable(
 export type NewFile = typeof files.$inferInsert;
 export type FileItem = typeof files.$inferSelect;
 
+/** Knowledge-base visibility — shared by column def and insert schema. */
+export const KNOWLEDGE_BASE_VISIBILITY = ['private', 'public'] as const;
+
 export const knowledgeBases = pgTable(
   'knowledge_bases',
   {
@@ -279,9 +282,7 @@ export const knowledgeBases = pgTable(
      * (file-level workspace visibility). This column only gates *KB list*
      * enumeration; retrieval via a known KB id still goes through `ownership()`.
      */
-    visibility: text('visibility', { enum: ['private', 'public'] })
-      .default('public')
-      .notNull(),
+    visibility: text('visibility', { enum: KNOWLEDGE_BASE_VISIBILITY }).default('public').notNull(),
 
     ...timestamps,
   },
@@ -295,8 +296,9 @@ export const knowledgeBases = pgTable(
 
 // See insertSessionGroupSchema: Zod 4 + drizzle-zod text-enum inference pollution.
 // `.optional()` preserves defaulted-column omit semantics at runtime.
+// Enum values from KNOWLEDGE_BASE_VISIBILITY so column def and schema stay in sync.
 export const insertKnowledgeBasesSchema = createInsertSchema(knowledgeBases, {
-  visibility: z.enum(['private', 'public']).optional(),
+  visibility: z.enum(KNOWLEDGE_BASE_VISIBILITY).optional(),
 });
 
 export type NewKnowledgeBase = typeof knowledgeBases.$inferInsert;

--- a/packages/database/src/schemas/file.ts
+++ b/packages/database/src/schemas/file.ts
@@ -13,6 +13,7 @@ import {
   varchar,
 } from 'drizzle-orm/pg-core';
 import { createInsertSchema } from 'drizzle-zod';
+import { z } from 'zod';
 
 import type { LobeDocumentPage } from '@/types/document';
 import type { FileSource } from '@/types/files';
@@ -292,7 +293,10 @@ export const knowledgeBases = pgTable(
   ],
 );
 
-export const insertKnowledgeBasesSchema = createInsertSchema(knowledgeBases);
+// See insertSessionGroupSchema: Zod 4 + drizzle-zod text-enum inference pollution
+export const insertKnowledgeBasesSchema = createInsertSchema(knowledgeBases, {
+  visibility: z.enum(['private', 'public']),
+});
 
 export type NewKnowledgeBase = typeof knowledgeBases.$inferInsert;
 export type KnowledgeBaseItem = typeof knowledgeBases.$inferSelect;

--- a/packages/database/src/schemas/session.ts
+++ b/packages/database/src/schemas/session.ts
@@ -1,6 +1,7 @@
 import { isNotNull, isNull } from 'drizzle-orm';
 import { boolean, index, integer, pgTable, text, uniqueIndex, varchar } from 'drizzle-orm/pg-core';
 import { createInsertSchema } from 'drizzle-zod';
+import { z } from 'zod';
 
 import { idGenerator, randomSlug } from '../utils/idGenerator';
 import { timestamps } from './_helpers';
@@ -51,7 +52,13 @@ export const sessionGroups = pgTable(
   }),
 );
 
-export const insertSessionGroupSchema = createInsertSchema(sessionGroups);
+// Explicit z.enum overrides: drizzle-zod + Zod 4 maps text(..., { enum }) to a
+// ZodEnum whose inferred output pollutes with String prototype members
+// (e.g. `"private" | "public" | 2 | (() => string) | ...`), which breaks
+// assignability to Drizzle `$inferSelect` partials used by model.update.
+export const insertSessionGroupSchema = createInsertSchema(sessionGroups, {
+  visibility: z.enum(['private', 'public']),
+});
 
 export type NewSessionGroup = typeof sessionGroups.$inferInsert;
 export type SessionGroupItem = typeof sessionGroups.$inferSelect;
@@ -99,7 +106,9 @@ export const sessions = pgTable(
   ],
 );
 
-export const insertSessionSchema = createInsertSchema(sessions);
+export const insertSessionSchema = createInsertSchema(sessions, {
+  type: z.enum(['agent', 'group']),
+});
 // export const selectSessionSchema = createSelectSchema(sessions);
 
 export type NewSession = typeof sessions.$inferInsert;

--- a/packages/database/src/schemas/session.ts
+++ b/packages/database/src/schemas/session.ts
@@ -8,6 +8,12 @@ import { timestamps } from './_helpers';
 import { users } from './user';
 import { workspaces } from './workspace';
 
+/** Session-group visibility — shared by column def and insert schema. */
+export const SESSION_GROUP_VISIBILITY = ['private', 'public'] as const;
+
+/** Session type — shared by column def and insert schema. */
+export const SESSION_TYPE = ['agent', 'group'] as const;
+
 //  ======= sessionGroups ======= //
 
 export const sessionGroups = pgTable(
@@ -31,9 +37,7 @@ export const sessionGroups = pgTable(
      * workspace member can see the folder; `private` constrains it to the
      * creator (`user_id`). Ignored in personal mode.
      */
-    visibility: text('visibility', { enum: ['private', 'public'] })
-      .default('public')
-      .notNull(),
+    visibility: text('visibility', { enum: SESSION_GROUP_VISIBILITY }).default('public').notNull(),
 
     ...timestamps,
   },
@@ -58,8 +62,9 @@ export const sessionGroups = pgTable(
 // assignability to Drizzle `$inferSelect` partials used by model.update.
 // Keep `.optional()` so defaulted columns stay omit-able (bare z.enum would
 // make them required and change runtime insert validation).
+// Enum values from SESSION_GROUP_VISIBILITY so column def and schema stay in sync.
 export const insertSessionGroupSchema = createInsertSchema(sessionGroups, {
-  visibility: z.enum(['private', 'public']).optional(),
+  visibility: z.enum(SESSION_GROUP_VISIBILITY).optional(),
 });
 
 export type NewSessionGroup = typeof sessionGroups.$inferInsert;
@@ -81,7 +86,7 @@ export const sessions = pgTable(
     avatar: text('avatar'),
     backgroundColor: text('background_color'),
 
-    type: text('type', { enum: ['agent', 'group'] }).default('agent'),
+    type: text('type', { enum: SESSION_TYPE }).default('agent'),
 
     userId: text('user_id')
       .references(() => users.id, { onDelete: 'cascade' })
@@ -110,7 +115,7 @@ export const sessions = pgTable(
 
 export const insertSessionSchema = createInsertSchema(sessions, {
   // column is nullable + default — match drizzle-zod insert optionality
-  type: z.enum(['agent', 'group']).nullish(),
+  type: z.enum(SESSION_TYPE).nullish(),
 });
 // export const selectSessionSchema = createSelectSchema(sessions);
 

--- a/packages/database/src/schemas/session.ts
+++ b/packages/database/src/schemas/session.ts
@@ -56,8 +56,10 @@ export const sessionGroups = pgTable(
 // ZodEnum whose inferred output pollutes with String prototype members
 // (e.g. `"private" | "public" | 2 | (() => string) | ...`), which breaks
 // assignability to Drizzle `$inferSelect` partials used by model.update.
+// Keep `.optional()` so defaulted columns stay omit-able (bare z.enum would
+// make them required and change runtime insert validation).
 export const insertSessionGroupSchema = createInsertSchema(sessionGroups, {
-  visibility: z.enum(['private', 'public']),
+  visibility: z.enum(['private', 'public']).optional(),
 });
 
 export type NewSessionGroup = typeof sessionGroups.$inferInsert;
@@ -107,7 +109,8 @@ export const sessions = pgTable(
 );
 
 export const insertSessionSchema = createInsertSchema(sessions, {
-  type: z.enum(['agent', 'group']),
+  // column is nullable + default — match drizzle-zod insert optionality
+  type: z.enum(['agent', 'group']).nullish(),
 });
 // export const selectSessionSchema = createSelectSchema(sessions);
 

--- a/packages/database/src/schemas/topic.ts
+++ b/packages/database/src/schemas/topic.ts
@@ -10,7 +10,8 @@ import {
   text,
   uniqueIndex,
 } from 'drizzle-orm/pg-core';
-import { createInsertSchema } from 'drizzle-zod';
+import { createInsertSchema, createUpdateSchema } from 'drizzle-zod';
+import { z } from 'zod';
 
 import { createNanoId, idGenerator } from '../utils/idGenerator';
 import { amountNumeric, createdAt, timestamps, timestamptz } from './_helpers';
@@ -165,7 +166,29 @@ export const threads = pgTable(
 
 export type NewThread = typeof threads.$inferInsert;
 export type ThreadItem = typeof threads.$inferSelect;
-export const insertThreadSchema = createInsertSchema(threads);
+const threadSchemaRefine = {
+  metadata: z.custom<ThreadMetadata>().optional(),
+  status: z.enum([
+    'active',
+    'processing',
+    'pending',
+    'inReview',
+    'todo',
+    'cancel',
+    'completed',
+    'failed',
+  ]),
+  type: z.enum(['continuation', 'standalone', 'isolation', 'eval']),
+} as const;
+
+// Explicit enum/jsonb overrides: plain createInsertSchema(threads) hits TS2589
+// (excessively deep instantiation) under Zod 4 because of self-ref parentThreadId
+// plus multi-value text enums; overrides keep inference shallow and correct.
+export const insertThreadSchema = createInsertSchema(threads, threadSchemaRefine);
+
+// Prefer createUpdateSchema over insertThreadSchema.partial() — .partial() on the
+// insert schema still blows the instantiation depth limit (TS2589) under Zod 4.
+export const updateThreadSchema = createUpdateSchema(threads, threadSchemaRefine);
 
 /**
  * Document-Topic association table - Implements many-to-many relationship between documents and topics

--- a/packages/database/src/schemas/topic.ts
+++ b/packages/database/src/schemas/topic.ts
@@ -107,6 +107,21 @@ export const topics = pgTable(
 export type NewTopic = typeof topics.$inferInsert;
 export type TopicItem = typeof topics.$inferSelect;
 
+/** Single source of truth for thread `type` — column def + zod schemas share this. */
+export const THREAD_TYPE = ['continuation', 'standalone', 'isolation', 'eval'] as const;
+
+/** Single source of truth for thread `status` — column def + zod schemas share this. */
+export const THREAD_STATUS = [
+  'active',
+  'processing',
+  'pending',
+  'inReview',
+  'todo',
+  'cancel',
+  'completed',
+  'failed',
+] as const;
+
 // @ts-ignore
 export const threads = pgTable(
   'threads',
@@ -118,19 +133,8 @@ export const threads = pgTable(
     title: text('title'),
     content: text('content'),
     editor_data: jsonb('editor_data'),
-    type: text('type', { enum: ['continuation', 'standalone', 'isolation', 'eval'] }).notNull(),
-    status: text('status', {
-      enum: [
-        'active',
-        'processing',
-        'pending',
-        'inReview',
-        'todo',
-        'cancel',
-        'completed',
-        'failed',
-      ],
-    }),
+    type: text('type', { enum: THREAD_TYPE }).notNull(),
+    status: text('status', { enum: THREAD_STATUS }),
 
     topicId: text('topic_id')
       .references(() => topics.id, { onDelete: 'cascade' })
@@ -170,12 +174,11 @@ export type ThreadItem = typeof threads.$inferSelect;
 // (excessively deep instantiation) under Zod 4 because of self-ref parentThreadId
 // plus multi-value text enums; overrides keep inference shallow and correct.
 // Preserve insert nullability: `type` is notNull (required), `status` is nullable.
+// Enum values come from THREAD_TYPE / THREAD_STATUS so column def and schema can't drift.
 export const insertThreadSchema = createInsertSchema(threads, {
   metadata: z.custom<ThreadMetadata>().optional(),
-  status: z
-    .enum(['active', 'processing', 'pending', 'inReview', 'todo', 'cancel', 'completed', 'failed'])
-    .nullish(),
-  type: z.enum(['continuation', 'standalone', 'isolation', 'eval']),
+  status: z.enum(THREAD_STATUS).nullish(),
+  type: z.enum(THREAD_TYPE),
 });
 
 // Prefer createUpdateSchema over insertThreadSchema.partial() — .partial() on the
@@ -184,10 +187,8 @@ export const insertThreadSchema = createInsertSchema(threads, {
 // by createUpdateSchema and would require type/status on every partial update.
 export const updateThreadSchema = createUpdateSchema(threads, {
   metadata: z.custom<ThreadMetadata>().optional(),
-  status: z
-    .enum(['active', 'processing', 'pending', 'inReview', 'todo', 'cancel', 'completed', 'failed'])
-    .nullish(),
-  type: z.enum(['continuation', 'standalone', 'isolation', 'eval']).optional(),
+  status: z.enum(THREAD_STATUS).nullish(),
+  type: z.enum(THREAD_TYPE).optional(),
 });
 
 /**

--- a/packages/database/src/schemas/topic.ts
+++ b/packages/database/src/schemas/topic.ts
@@ -166,29 +166,29 @@ export const threads = pgTable(
 
 export type NewThread = typeof threads.$inferInsert;
 export type ThreadItem = typeof threads.$inferSelect;
-const threadSchemaRefine = {
-  metadata: z.custom<ThreadMetadata>().optional(),
-  status: z.enum([
-    'active',
-    'processing',
-    'pending',
-    'inReview',
-    'todo',
-    'cancel',
-    'completed',
-    'failed',
-  ]),
-  type: z.enum(['continuation', 'standalone', 'isolation', 'eval']),
-} as const;
-
 // Explicit enum/jsonb overrides: plain createInsertSchema(threads) hits TS2589
 // (excessively deep instantiation) under Zod 4 because of self-ref parentThreadId
 // plus multi-value text enums; overrides keep inference shallow and correct.
-export const insertThreadSchema = createInsertSchema(threads, threadSchemaRefine);
+// Preserve insert nullability: `type` is notNull (required), `status` is nullable.
+export const insertThreadSchema = createInsertSchema(threads, {
+  metadata: z.custom<ThreadMetadata>().optional(),
+  status: z
+    .enum(['active', 'processing', 'pending', 'inReview', 'todo', 'cancel', 'completed', 'failed'])
+    .nullish(),
+  type: z.enum(['continuation', 'standalone', 'isolation', 'eval']),
+});
 
 // Prefer createUpdateSchema over insertThreadSchema.partial() — .partial() on the
 // insert schema still blows the instantiation depth limit (TS2589) under Zod 4.
-export const updateThreadSchema = createUpdateSchema(threads, threadSchemaRefine);
+// All refined fields must be optional: bare z.enum refinements are NOT auto-wrapped
+// by createUpdateSchema and would require type/status on every partial update.
+export const updateThreadSchema = createUpdateSchema(threads, {
+  metadata: z.custom<ThreadMetadata>().optional(),
+  status: z
+    .enum(['active', 'processing', 'pending', 'inReview', 'todo', 'cancel', 'completed', 'failed'])
+    .nullish(),
+  type: z.enum(['continuation', 'standalone', 'isolation', 'eval']).optional(),
+});
 
 /**
  * Document-Topic association table - Implements many-to-many relationship between documents and topics


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A — found while running `bun run check --type` on latest `canary` after the Zod v4 upgrade (#16998).

#### 🔀 Description of Change

### Phenomenon

`bun run check --type` failed on clean `canary` with **6 TypeScript errors**, all in lambda routers that pass `createInsertSchema(...).partial()` into model `update` / `create` methods:

| File | Error |
|------|--------|
| `sessionGroup.ts` / `_template.ts` | `visibility` not assignable |
| `knowledgeBase.ts` | `visibility` not assignable |
| `session.ts` (create + update) | `config.visibility` / `type` not assignable |
| `thread.ts` | **TS2589** Type instantiation is excessively deep |

The assignability errors looked like this (abbreviated):

```ts
// Inferred from insertXSchema.partial()
visibility?: "private" | "public" | 2 | (() => string) | { (): string; ... } | ...

// Expected by Partial<SessionGroupItem> / model.update
visibility?: "private" | "public"
```

### Root cause (two layers)

1. **Dependency mismatch** — Root used `drizzle-zod@^0.8.3` for Zod 4, but `@lobechat/database` peer was `drizzle-zod: "*"`, which resolved to **0.5.1** (Zod 3-era).
2. **Type-inference gap** — For `text('col', { enum: [...] })`, `createInsertSchema` maps to a `ZodEnum` whose **inferred TypeScript output** is polluted under Zod 4. Runtime enum validation was fine; only types broke assignability to Drizzle `$inferSelect` partials. Self-referential `threads` + `.partial()` also hits **TS2589**.

### Solution

| Change | Why |
|--------|-----|
| Pin `@lobechat/database` peer `drizzle-zod` to `^0.8.3` | Align package with the Zod 4 stack |
| Override text-enum fields with explicit `z.enum([...])` **and** preserve column optionality (`.optional()` / `.nullish()`) | Fix inferred types **without** changing insert omit/null semantics |
| Export `updateThreadSchema` via `createUpdateSchema` (refined fields all optional/nullish) | Avoid TS2589; keep partial-update payloads valid (e.g. `{ title }` only) |

### Runtime impact (important)

This is **not** a DB migration / SQL schema change. It touches Zod schemas in `packages/database` (used as TRPC input validators) + one router import.

- **No table/column/SQL changes**
- **Enum allowed values unchanged** (`private`/`public`, `agent`/`group`, thread type/status, …)
- **Insert optionality preserved** — bare `z.enum(...)` would strip drizzle-zod’s optional wrappers and make defaulted fields required; overrides use `.optional()` / `.nullish()` to match pre-fix behavior
- **Thread update optionality preserved** — first revision briefly required `type`/`status` on every update; follow-up commit makes refined fields optional/nullish so `{}` / `{ title }` still pass (same as `insertThreadSchema.partial()`)

Verified with side-by-side `safeParse` samples (plain `createInsertSchema` vs fixed overrides; `insert.partial()` vs fixed `createUpdateSchema`).

### Why not cast at call sites

Casting would silence check without repairing the shared schema contract and would reappear on every new update route.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

```bash
bun run check --type
# Expected: ✓ types clean
```

#### 📸 Screenshots / Videos

N/A

#### 📝 Additional Information

**Files**

- `packages/database/package.json` — peer `drizzle-zod`
- `packages/database/src/schemas/{session,agent,file,topic}.ts`
- `apps/server/src/routers/lambda/thread.ts`

**Follow-up (optional)**

- Shared helper that auto-applies `z.enum` + correct optional/nullish from column metadata
- Upstream issue if enum output pollution is treated as a library bug