### PR TITLE
🐛 fix(test): add required visibility field to device test factory

### DIFF
--- a/src/store/device/action.test.ts
+++ b/src/store/device/action.test.ts
@@ -26,6 +26,7 @@ const buildDevice = (overrides: Partial<DeviceListItem> = {}): DeviceListItem =>
   platform: null,
   registered: true,
   scope: 'personal',
+  visibility: null,
   workingDirs: [],
   ...overrides,
 });


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Related to #17037 (which introduced the required `visibility` field)

#### 🔀 Description of Change

The `buildDevice` test factory in `src/store/device/action.test.ts` never set the `visibility` field. #17037 made `visibility: DeviceVisibility | null` a **required** field on `DeviceListItem`, so with the value only coming from the `...overrides` (`Partial<DeviceListItem>`) spread, `tsgo --noEmit` inferred it as `DeviceVisibility | null | undefined` and failed type-check:

```
src/store/device/action.test.ts(16,83): error TS2322:
  Type '{ …; visibility?: DeviceVisibility | null | undefined; … }' is not assignable to type 'DeviceListItem'.
    Type 'undefined' is not assignable to type 'DeviceVisibility | null'.
```

Because `type-check` is part of the `lint` script, this broke the **Release Desktop Canary** workflow at its Code quality check stage on **every** push to `canary` since #17037 merged. It slipped through review because Release Desktop Canary only runs on push to `canary` (not on PRs), and canary's regular Test CI runs kept getting cancelled by rapid successive pushes.

Fix: add `visibility: null` to the factory's base object — the correct personal-scope default per the field's documented semantics (`null` for personal and ghost rows).

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

- `bun run check --type` → `✓ types clean` (was failing before this change)
- `bun run check src/store/device/action.test.ts` → `lint clean · tests 3 passed`

#### 📝 Additional Information

Separately, run [29164723766](https://github.com/lobehub/lobehub/actions/runs/29164723766) (#17064) failed at **Build Desktop App (macos-15-intel)** — an unrelated macOS Intel packaging failure, not addressed by this PR.
