### PR TITLE
🐛 fix: rescue legacy custom MCP migration & connector config panel

### DIFF
--- a/locales/en-US/setting.json
+++ b/locales/en-US/setting.json
@@ -1255,6 +1255,8 @@
   "tools.composio.tools": "tools",
   "tools.composio.verifyAuth": "I have completed authentication",
   "tools.disabled": "The current model does not support function calls and cannot use the skill",
+  "tools.legacyConnector.configure": "Configure",
+  "tools.legacyConnector.upgradeDesc": "This connector still uses the legacy plugin format. Configure it to finish upgrading, then manage its tool permissions here.",
   "tools.lobehubSkill.authorize": "Authorize",
   "tools.lobehubSkill.connect": "Connect",
   "tools.lobehubSkill.connected": "Connected",

--- a/locales/zh-CN/setting.json
+++ b/locales/zh-CN/setting.json
@@ -1255,6 +1255,8 @@
   "tools.composio.tools": "个工具",
   "tools.composio.verifyAuth": "我已完成认证",
   "tools.disabled": "当前模型不支持函数调用，无法使用技能",
+  "tools.legacyConnector.configure": "配置",
+  "tools.legacyConnector.upgradeDesc": "此连接器仍在使用旧的插件格式。点击「配置」完成升级后，即可在此管理它的工具权限。",
   "tools.lobehubSkill.authorize": "授权",
   "tools.lobehubSkill.connect": "连接",
   "tools.lobehubSkill.connected": "已连接",

--- a/packages/locales/src/default/setting.ts
+++ b/packages/locales/src/default/setting.ts
@@ -2759,6 +2759,9 @@ When I am ___, I need ___
   'tools.add': 'Add Skill',
   'tools.addSkillOrConnector': 'Add Skills / Connectors',
   'tools.noConfigurablePermissions': 'This skill does not expose configurable tool permissions.',
+  'tools.legacyConnector.configure': 'Configure',
+  'tools.legacyConnector.upgradeDesc':
+    'This connector still uses the legacy plugin format. Configure it to finish upgrading, then manage its tool permissions here.',
   'tools.builtins.groupName': 'Built-ins',
   'tools.builtins.install': 'Install',
   'tools.builtins.installed': 'Installed',

--- a/src/features/Connectors/CustomConnectorModal/index.tsx
+++ b/src/features/Connectors/CustomConnectorModal/index.tsx
@@ -224,6 +224,10 @@ const CustomConnectorModal = memo<CustomConnectorModalProps>(
         const result = await executeLegacyMigrationSave(legacyPlugin, value, {
           createConnector,
           deleteConnector,
+          // Read fresh so the rollback only deletes a connector this migration
+          // created, never one the idempotent upsert merely updated.
+          hasExistingConnector: (id) =>
+            Boolean(connectorSelectors.connectorByIdentifier(id)(useToolStore.getState())),
           syncConnectorTools,
           uninstallCustomPlugin,
         });

--- a/src/features/Connectors/CustomConnectorModal/index.tsx
+++ b/src/features/Connectors/CustomConnectorModal/index.tsx
@@ -97,6 +97,7 @@ const cleanRecord = (record?: Record<string, string>): Record<string, string> | 
 const CustomConnectorModal = memo<CustomConnectorModalProps>(
   ({ open, onClose, connectorId, legacyPlugin, onEditSuccess }) => {
     const createConnector = useToolStore((s) => s.createConnector);
+    const deleteConnector = useToolStore((s) => s.deleteConnector);
     const updateConnector = useToolStore((s) => s.updateConnector);
     const getConnectorForEdit = useToolStore((s) => s.getConnectorForEdit);
     const startConnectorOAuth = useToolStore((s) => s.startConnectorOAuth);
@@ -200,7 +201,10 @@ const CustomConnectorModal = memo<CustomConnectorModalProps>(
       };
     }, [isEditMode, isMigrationMode, legacyPlugin, connector, editFetchedData]);
 
-    const handleSave = async (value: LobeToolCustomPlugin, ctx?: { oauthPopup?: Window | null }) => {
+    const handleSave = async (
+      value: LobeToolCustomPlugin,
+      ctx?: { oauthPopup?: Window | null },
+    ) => {
       // ── Migration mode ────────────────────────────────────────────────────
       // Promote a legacy `user_installed_plugins.type='customPlugin'` row into
       // a `user_connectors` row. Server `connector.create` is idempotent on
@@ -219,6 +223,7 @@ const CustomConnectorModal = memo<CustomConnectorModalProps>(
         // alone) is already inside `value`. Hand it to the orchestrator.
         const result = await executeLegacyMigrationSave(legacyPlugin, value, {
           createConnector,
+          deleteConnector,
           syncConnectorTools,
           uninstallCustomPlugin,
         });
@@ -269,7 +274,7 @@ const CustomConnectorModal = memo<CustomConnectorModalProps>(
         // submitted before `connector` resolves, but this keeps it safe.
         const headers = cleanRecord(mcp.headers);
         if (connector) {
-          const nextMetadata: Record<string, unknown> = { ...(connector.metadata ?? {}) };
+          const nextMetadata: Record<string, unknown> = { ...connector.metadata };
           if (headers) nextMetadata.customHeaders = headers;
           else delete nextMetadata.customHeaders;
           patch.metadata = nextMetadata;
@@ -325,7 +330,11 @@ const CustomConnectorModal = memo<CustomConnectorModalProps>(
         mcpServerUrl: isHttp ? mcp.url?.trim() : undefined,
         mcpStdioConfig: isHttp
           ? undefined
-          : { args: mcp.args ?? [], command: (mcp.command ?? '').trim(), env: cleanRecord(mcp.env) },
+          : {
+              args: mcp.args ?? [],
+              command: (mcp.command ?? '').trim(),
+              env: cleanRecord(mcp.env),
+            },
         name: identifier,
         sourceType: ConnectorSourceType.custom,
       };

--- a/src/features/Connectors/CustomConnectorModal/legacyPluginMigration.test.ts
+++ b/src/features/Connectors/CustomConnectorModal/legacyPluginMigration.test.ts
@@ -388,6 +388,7 @@ describe('executeLegacyMigrationSave', () => {
 
   let createConnector: ReturnType<typeof vi.fn>;
   let deleteConnector: ReturnType<typeof vi.fn>;
+  let hasExistingConnector: ReturnType<typeof vi.fn>;
   let syncConnectorTools: ReturnType<typeof vi.fn>;
   let uninstallCustomPlugin: ReturnType<typeof vi.fn>;
   let calls: string[];
@@ -402,6 +403,8 @@ describe('executeLegacyMigrationSave', () => {
     deleteConnector = vi.fn(async () => {
       calls.push('deleteConnector');
     });
+    // Default: no pre-existing connector (the common fresh-migration case).
+    hasExistingConnector = vi.fn(() => false);
     syncConnectorTools = vi.fn(async () => {
       calls.push('syncConnectorTools');
     });
@@ -419,6 +422,7 @@ describe('executeLegacyMigrationSave', () => {
     const result = await executeLegacyMigrationSave(legacy(), legacy(), {
       createConnector,
       deleteConnector,
+      hasExistingConnector,
       syncConnectorTools,
       uninstallCustomPlugin,
     });
@@ -438,6 +442,7 @@ describe('executeLegacyMigrationSave', () => {
     await executeLegacyMigrationSave(legacy('agent-x'), value, {
       createConnector,
       deleteConnector,
+      hasExistingConnector,
       syncConnectorTools,
       uninstallCustomPlugin,
     });
@@ -459,6 +464,7 @@ describe('executeLegacyMigrationSave', () => {
     await executeLegacyMigrationSave(legacy('legacy-id'), legacy('renamed-in-form'), {
       createConnector,
       deleteConnector,
+      hasExistingConnector,
       syncConnectorTools,
       uninstallCustomPlugin,
     });
@@ -478,6 +484,7 @@ describe('executeLegacyMigrationSave', () => {
     const result = await executeLegacyMigrationSave(broken, broken, {
       createConnector,
       deleteConnector,
+      hasExistingConnector,
       syncConnectorTools,
       uninstallCustomPlugin,
     });
@@ -495,6 +502,7 @@ describe('executeLegacyMigrationSave', () => {
       executeLegacyMigrationSave(legacy(), legacy(), {
         createConnector,
         deleteConnector,
+        hasExistingConnector,
         syncConnectorTools,
         uninstallCustomPlugin,
       }),
@@ -515,6 +523,7 @@ describe('executeLegacyMigrationSave', () => {
       executeLegacyMigrationSave(legacy(), legacy(), {
         createConnector,
         deleteConnector,
+        hasExistingConnector,
         syncConnectorTools,
         uninstallCustomPlugin,
       }),
@@ -527,6 +536,26 @@ describe('executeLegacyMigrationSave', () => {
     expect(uninstallCustomPlugin).not.toHaveBeenCalled();
   });
 
+  it('does NOT roll back on sync failure when a connector already existed (idempotent update)', async () => {
+    // `createConnector` is an upsert: a pre-existing row for this identifier is
+    // UPDATED, not created. A transient sync failure must not delete it —
+    // that would destroy a working connector's synced tools/credentials (e.g. a
+    // prior successful migration whose best-effort legacy uninstall had failed).
+    hasExistingConnector.mockReturnValue(true);
+    syncConnectorTools.mockRejectedValueOnce(new Error('mcp tools/list timeout'));
+    await expect(
+      executeLegacyMigrationSave(legacy(), legacy(), {
+        createConnector,
+        deleteConnector,
+        hasExistingConnector,
+        syncConnectorTools,
+        uninstallCustomPlugin,
+      }),
+    ).rejects.toThrow('mcp tools/list timeout');
+    expect(deleteConnector).not.toHaveBeenCalled();
+    expect(uninstallCustomPlugin).not.toHaveBeenCalled();
+  });
+
   it('still rethrows the sync error even if the rollback delete also fails', async () => {
     syncConnectorTools.mockRejectedValueOnce(new Error('mcp tools/list timeout'));
     deleteConnector.mockRejectedValueOnce(new Error('rollback network error'));
@@ -534,6 +563,7 @@ describe('executeLegacyMigrationSave', () => {
       executeLegacyMigrationSave(legacy(), legacy(), {
         createConnector,
         deleteConnector,
+        hasExistingConnector,
         syncConnectorTools,
         uninstallCustomPlugin,
       }),
@@ -550,6 +580,7 @@ describe('executeLegacyMigrationSave', () => {
     const result = await executeLegacyMigrationSave(legacy(), legacy(), {
       createConnector,
       deleteConnector,
+      hasExistingConnector,
       syncConnectorTools,
       uninstallCustomPlugin,
     });
@@ -571,6 +602,7 @@ describe('executeLegacyMigrationSave', () => {
       executeLegacyMigrationSave(legacy(), legacy(), {
         createConnector,
         deleteConnector,
+        hasExistingConnector,
         syncConnectorTools,
         uninstallCustomPlugin,
       }),
@@ -583,6 +615,7 @@ describe('executeLegacyMigrationSave', () => {
     const result = await executeLegacyMigrationSave(legacy(), legacy(), {
       createConnector,
       deleteConnector,
+      hasExistingConnector,
       syncConnectorTools,
       uninstallCustomPlugin,
     });

--- a/src/features/Connectors/CustomConnectorModal/legacyPluginMigration.test.ts
+++ b/src/features/Connectors/CustomConnectorModal/legacyPluginMigration.test.ts
@@ -199,7 +199,7 @@ describe('buildConnectorPayloadFromLegacy', () => {
       if (!r.ok) throw new Error('expected ok');
       expect(r.payload.credentials).toEqual({
         headers: {
-          Authorization: 'Bearer sk-xyz',
+          'Authorization': 'Bearer sk-xyz',
           'X-Tenant': 'acme',
           'X-Trace': 'on',
         },
@@ -387,6 +387,7 @@ describe('executeLegacyMigrationSave', () => {
     }) as LobeToolCustomPlugin;
 
   let createConnector: ReturnType<typeof vi.fn>;
+  let deleteConnector: ReturnType<typeof vi.fn>;
   let syncConnectorTools: ReturnType<typeof vi.fn>;
   let uninstallCustomPlugin: ReturnType<typeof vi.fn>;
   let calls: string[];
@@ -397,6 +398,9 @@ describe('executeLegacyMigrationSave', () => {
     createConnector = vi.fn(async () => {
       calls.push('createConnector');
       return 'new-conn-id';
+    });
+    deleteConnector = vi.fn(async () => {
+      calls.push('deleteConnector');
     });
     syncConnectorTools = vi.fn(async () => {
       calls.push('syncConnectorTools');
@@ -414,6 +418,7 @@ describe('executeLegacyMigrationSave', () => {
   it('runs create → sync → uninstall in exact order on the happy path', async () => {
     const result = await executeLegacyMigrationSave(legacy(), legacy(), {
       createConnector,
+      deleteConnector,
       syncConnectorTools,
       uninstallCustomPlugin,
     });
@@ -432,6 +437,7 @@ describe('executeLegacyMigrationSave', () => {
 
     await executeLegacyMigrationSave(legacy('agent-x'), value, {
       createConnector,
+      deleteConnector,
       syncConnectorTools,
       uninstallCustomPlugin,
     });
@@ -452,6 +458,7 @@ describe('executeLegacyMigrationSave', () => {
     // identifier regardless of what the form ended up with.
     await executeLegacyMigrationSave(legacy('legacy-id'), legacy('renamed-in-form'), {
       createConnector,
+      deleteConnector,
       syncConnectorTools,
       uninstallCustomPlugin,
     });
@@ -470,6 +477,7 @@ describe('executeLegacyMigrationSave', () => {
     } as LobeToolCustomPlugin;
     const result = await executeLegacyMigrationSave(broken, broken, {
       createConnector,
+      deleteConnector,
       syncConnectorTools,
       uninstallCustomPlugin,
     });
@@ -486,27 +494,54 @@ describe('executeLegacyMigrationSave', () => {
     await expect(
       executeLegacyMigrationSave(legacy(), legacy(), {
         createConnector,
+        deleteConnector,
         syncConnectorTools,
         uninstallCustomPlugin,
       }),
     ).rejects.toThrow('boom: bad network');
     expect(syncConnectorTools).not.toHaveBeenCalled();
     expect(uninstallCustomPlugin).not.toHaveBeenCalled();
+    // Nothing was created, so there is nothing to roll back.
+    expect(deleteConnector).not.toHaveBeenCalled();
   });
 
-  it('rethrows syncConnectorTools failure and leaves legacy plugin in place', async () => {
+  it('rolls back the created connector when tool sync fails, leaving legacy plugin in place', async () => {
     // Most likely failure in practice — MCP server unreachable at sync time.
-    // The user keeps a working legacy plugin and can retry the save later.
+    // The half-created connector must be deleted so it does not linger as a
+    // tool-less duplicate; the legacy plugin row is left untouched so the user
+    // can retry the save once the endpoint is healthy.
     syncConnectorTools.mockRejectedValueOnce(new Error('mcp tools/list timeout'));
     await expect(
       executeLegacyMigrationSave(legacy(), legacy(), {
         createConnector,
+        deleteConnector,
         syncConnectorTools,
         uninstallCustomPlugin,
       }),
     ).rejects.toThrow('mcp tools/list timeout');
-    expect(createConnector).toHaveBeenCalledTimes(1);
+    // `syncConnectorTools` is invoked but its mock rejects without recording a
+    // call, so `calls` shows create → rollback delete.
     expect(syncConnectorTools).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['createConnector', 'deleteConnector']);
+    expect(deleteConnector).toHaveBeenCalledWith('new-conn-id');
+    expect(uninstallCustomPlugin).not.toHaveBeenCalled();
+  });
+
+  it('still rethrows the sync error even if the rollback delete also fails', async () => {
+    syncConnectorTools.mockRejectedValueOnce(new Error('mcp tools/list timeout'));
+    deleteConnector.mockRejectedValueOnce(new Error('rollback network error'));
+    await expect(
+      executeLegacyMigrationSave(legacy(), legacy(), {
+        createConnector,
+        deleteConnector,
+        syncConnectorTools,
+        uninstallCustomPlugin,
+      }),
+    ).rejects.toThrow('mcp tools/list timeout');
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      '[connector-migration] rollback after failed sync failed',
+      expect.any(Error),
+    );
     expect(uninstallCustomPlugin).not.toHaveBeenCalled();
   });
 
@@ -514,34 +549,40 @@ describe('executeLegacyMigrationSave', () => {
     uninstallCustomPlugin.mockRejectedValueOnce(new Error('legacy delete failed'));
     const result = await executeLegacyMigrationSave(legacy(), legacy(), {
       createConnector,
+      deleteConnector,
       syncConnectorTools,
       uninstallCustomPlugin,
     });
     // Migration is still considered SUCCESSFUL — the runtime dedupes by
     // identifier and the connector wins, so the leaked legacy row is harmless.
+    // Sync succeeded, so the connector is NOT rolled back.
     expect(result).toEqual({ connectorId: 'new-conn-id', ok: true });
+    expect(deleteConnector).not.toHaveBeenCalled();
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       '[connector-migration] uninstall legacy plugin failed',
       expect.any(Error),
     );
   });
 
-  it('idempotent retry: re-running after a failed sync repeats all steps cleanly', async () => {
-    // First attempt: sync fails.
+  it('idempotent retry: re-running after a rolled-back sync repeats all steps cleanly', async () => {
+    // First attempt: sync fails → the created connector is rolled back.
     syncConnectorTools.mockRejectedValueOnce(new Error('first attempt fails'));
     await expect(
       executeLegacyMigrationSave(legacy(), legacy(), {
         createConnector,
+        deleteConnector,
         syncConnectorTools,
         uninstallCustomPlugin,
       }),
     ).rejects.toThrow('first attempt fails');
+    expect(calls).toEqual(['createConnector', 'deleteConnector']);
 
     // Reset call log; retry. Server-side `connector.create` is idempotent on
     // (user_id, identifier), so the second create is an UPDATE.
     calls.length = 0;
     const result = await executeLegacyMigrationSave(legacy(), legacy(), {
       createConnector,
+      deleteConnector,
       syncConnectorTools,
       uninstallCustomPlugin,
     });

--- a/src/features/Connectors/CustomConnectorModal/legacyPluginMigration.ts
+++ b/src/features/Connectors/CustomConnectorModal/legacyPluginMigration.ts
@@ -8,8 +8,7 @@ import { ConnectorSourceType } from '@/database/schemas';
  */
 export interface MigrationCreatePayload {
   credentials?:
-    | { token: string; type: 'bearer' }
-    | { headers: Record<string, string>; type: 'header' };
+    { token: string; type: 'bearer' } | { headers: Record<string, string>; type: 'header' };
   identifier: string;
   isEnabled: true;
   mcpConnectionType: 'http' | 'stdio' | 'cloud';
@@ -45,9 +44,7 @@ const cleanRecord = (record?: Record<string, string>): Record<string, string> | 
  * the legacy form lets users set both independently, and dropping either side
  * silently would break tool calls for the 38 rows in that combo.
  */
-export const buildConnectorPayloadFromLegacy = (
-  legacy: LobeToolCustomPlugin,
-): MigrationResult => {
+export const buildConnectorPayloadFromLegacy = (legacy: LobeToolCustomPlugin): MigrationResult => {
   const mcp = legacy.customParams?.mcp;
   if (!mcp) return { ok: false, reason: 'no-mcp' };
 
@@ -60,9 +57,7 @@ export const buildConnectorPayloadFromLegacy = (
 
   const identifier = legacy.identifier;
   const displayName =
-    legacy.manifest?.meta?.title ||
-    legacy.customParams?.description ||
-    identifier;
+    legacy.manifest?.meta?.title || legacy.customParams?.description || identifier;
 
   const metadata: Record<string, unknown> = {};
   if (legacy.customParams?.description) metadata.description = legacy.customParams.description;
@@ -142,9 +137,15 @@ export const buildConnectorPayloadFromLegacy = (
  *   2. `createConnector` — server is idempotent on `(user_id, identifier)` so
  *      a half-baked marketplace connector from the old `syncPluginTools` path
  *      becomes an UPDATE, no client-side collision branch needed.
- *   3. `syncConnectorTools` — fail-loud. A throw here BAILS BEFORE step 4, so
- *      the legacy plugin row survives and the user keeps a working agent.
- *      Re-opening "Configure" later re-runs the same steps (all idempotent).
+ *   3. `syncConnectorTools` — fail-loud. On failure (the MCP endpoint is
+ *      unreachable / 500s), ROLL BACK the connector created in step 2 before
+ *      rethrowing. Leaving it behind would strand the user: the tool-less
+ *      connector now shadows the legacy row, so it renders as a duplicate in
+ *      the connector list AND `connectorByIdentifier` starts resolving it,
+ *      which removes the "Configure to migrate" entry point (that only shows
+ *      when no connector exists). Rolling back returns us atomically to the
+ *      pre-migration state — legacy row only — so the user can retry once the
+ *      endpoint is healthy (create is rebuilt from the untouched legacy shape).
  *   4. `uninstallCustomPlugin` — best-effort. A throw is logged but swallowed;
  *      the runtime's `connectorIdentifierSet` filter in
  *      `aiAgent/index.ts:1717` dedupes by identifier (connector wins), so a
@@ -155,6 +156,7 @@ export const buildConnectorPayloadFromLegacy = (
  */
 export interface MigrationSaveDeps {
   createConnector: (payload: MigrationCreatePayload) => Promise<string>;
+  deleteConnector: (id: string) => Promise<void>;
   syncConnectorTools: (id: string) => Promise<void>;
   uninstallCustomPlugin: (id: string) => Promise<void>;
 }
@@ -184,7 +186,21 @@ export const executeLegacyMigrationSave = async (
   };
 
   const newConnectorId = await deps.createConnector(payload);
-  await deps.syncConnectorTools(newConnectorId);
+
+  try {
+    await deps.syncConnectorTools(newConnectorId);
+  } catch (syncError) {
+    // Endpoint unreachable / manifest fetch failed. Roll the just-created
+    // connector back so we don't leave a tool-less duplicate alongside the
+    // surviving legacy plugin (see step 3 above), then rethrow so the modal
+    // surfaces the failure and the legacy row stays as the single source.
+    try {
+      await deps.deleteConnector(newConnectorId);
+    } catch (rollbackError) {
+      console.error('[connector-migration] rollback after failed sync failed', rollbackError);
+    }
+    throw syncError;
+  }
 
   try {
     await deps.uninstallCustomPlugin(legacyPlugin.identifier);

--- a/src/features/Connectors/CustomConnectorModal/legacyPluginMigration.ts
+++ b/src/features/Connectors/CustomConnectorModal/legacyPluginMigration.ts
@@ -138,8 +138,10 @@ export const buildConnectorPayloadFromLegacy = (legacy: LobeToolCustomPlugin): M
  *      a half-baked marketplace connector from the old `syncPluginTools` path
  *      becomes an UPDATE, no client-side collision branch needed.
  *   3. `syncConnectorTools` — fail-loud. On failure (the MCP endpoint is
- *      unreachable / 500s), ROLL BACK the connector created in step 2 before
- *      rethrowing. Leaving it behind would strand the user: the tool-less
+ *      unreachable / 500s), ROLL BACK the connector — but only when step 2
+ *      actually CREATED it (see `hasExistingConnector`), never when it merely
+ *      updated a pre-existing row. Leaving a freshly-created one behind would
+ *      strand the user: the tool-less
  *      connector now shadows the legacy row, so it renders as a duplicate in
  *      the connector list AND `connectorByIdentifier` starts resolving it,
  *      which removes the "Configure to migrate" entry point (that only shows
@@ -157,6 +159,12 @@ export const buildConnectorPayloadFromLegacy = (legacy: LobeToolCustomPlugin): M
 export interface MigrationSaveDeps {
   createConnector: (payload: MigrationCreatePayload) => Promise<string>;
   deleteConnector: (id: string) => Promise<void>;
+  /**
+   * Whether a `user_connectors` row already exists for this identifier BEFORE
+   * the create call. `createConnector` is an idempotent upsert, so on the sync
+   * failure path we must NOT delete a row we merely updated — only one we created.
+   */
+  hasExistingConnector: (identifier: string) => boolean;
   syncConnectorTools: (id: string) => Promise<void>;
   uninstallCustomPlugin: (id: string) => Promise<void>;
 }
@@ -185,6 +193,10 @@ export const executeLegacyMigrationSave = async (
     identifier: legacyPlugin.identifier,
   };
 
+  // Capture pre-existence BEFORE the upsert so the rollback below only ever
+  // deletes a connector THIS migration created (see MigrationSaveDeps).
+  const connectorAlreadyExisted = deps.hasExistingConnector(payload.identifier);
+
   const newConnectorId = await deps.createConnector(payload);
 
   try {
@@ -194,10 +206,17 @@ export const executeLegacyMigrationSave = async (
     // connector back so we don't leave a tool-less duplicate alongside the
     // surviving legacy plugin (see step 3 above), then rethrow so the modal
     // surfaces the failure and the legacy row stays as the single source.
-    try {
-      await deps.deleteConnector(newConnectorId);
-    } catch (rollbackError) {
-      console.error('[connector-migration] rollback after failed sync failed', rollbackError);
+    //
+    // Skip rollback when a connector already existed for this identifier: the
+    // upsert UPDATED that row (it did not create one), so deleting it would
+    // destroy a working connector's synced tools/credentials — e.g. a prior
+    // successful migration whose best-effort legacy uninstall had failed.
+    if (!connectorAlreadyExisted) {
+      try {
+        await deps.deleteConnector(newConnectorId);
+      } catch (rollbackError) {
+        console.error('[connector-migration] rollback after failed sync failed', rollbackError);
+      }
     }
     throw syncError;
   }

--- a/src/features/PluginDevModal/index.tsx
+++ b/src/features/PluginDevModal/index.tsx
@@ -169,6 +169,11 @@ const DevModal = memo<DevModalProps>(
           push={false}
           title={t(isEditMode ? 'dev.title.skillSettings' : 'dev.title.create')}
           width={mobile ? '100%' : 800}
+          // Sit above @lobehub/ui's base-ui floating layer (Popover/Dropdown/Tooltip = 1100).
+          // antd Drawer defaults to ~1000, so a config panel opened from the Tools skill
+          // popover would otherwise mount *behind* the still-open popover and look like it
+          // "didn't open". 1200 = the base-ui modal tier.
+          zIndex={1200}
           styles={{
             body: {
               padding: 0,

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.test.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.test.tsx
@@ -22,6 +22,11 @@ const mocks = vi.hoisted(() => {
     getLobehubSkillAuthorizeUrl: vi.fn(),
     installBuiltinTool: vi.fn(),
     installedBuiltinIds: [] as string[],
+    installedPlugins: [] as Array<{
+      customParams?: { mcp?: Record<string, unknown> };
+      identifier: string;
+      type: string;
+    }>,
     lobehubSkillServers: [] as Array<{
       identifier: string;
       isConnected: boolean;
@@ -123,6 +128,9 @@ vi.mock('react-i18next', () => ({
         'tools.lobehubSkill.disconnect': 'Disconnect',
         'tools.lobehubSkill.disconnectConfirm.desc': `Disconnect ${(options as { name?: string })?.name}?`,
         'tools.lobehubSkill.disconnectConfirm.title': `Disconnect ${(options as { name?: string })?.name}`,
+        'tools.legacyConnector.configure': 'Configure',
+        'tools.legacyConnector.upgradeDesc':
+          'This connector still uses the legacy plugin format. Configure it to finish upgrading, then manage its tool permissions here.',
         'tools.noConfigurablePermissions':
           'This skill does not expose configurable tool permissions.',
       };
@@ -152,6 +160,8 @@ vi.mock('@/features/Connectors', () => ({
       {lifecycleActions}
     </div>
   ),
+  CustomConnectorModal: ({ open }: { open?: boolean }) =>
+    open ? <div data-testid="migration-modal" /> : null,
 }));
 
 vi.mock('@/hooks/usePermission', () => ({
@@ -199,6 +209,22 @@ vi.mock('@/store/tool/slices/connector', () => ({
   },
 }));
 
+// Mock the real selector to avoid pulling its `toolAvailability` → `skillFilters`
+// → `@lobechat/const` (isDesktop) transitive imports into the unit env; mirror
+// the real `getCustomPluginById` behaviour against the mocked tool state.
+vi.mock('@/store/tool/slices/plugin/selectors', () => ({
+  pluginSelectors: {
+    getCustomPluginById:
+      (identifier: string) =>
+      (
+        state: typeof mocks.toolState,
+      ): (typeof mocks.toolState.installedPlugins)[number] | undefined =>
+        state.installedPlugins.find(
+          (plugin) => plugin.identifier === identifier && plugin.type === 'customPlugin',
+        ),
+  },
+}));
+
 vi.mock('@/store/user', () => ({
   useUserStore<T>(selector: (state: typeof mocks.userState) => T): T {
     return selector(mocks.userState);
@@ -226,7 +252,33 @@ describe('SkillDetail', () => {
     mocks.toolState.composioServers = [];
     mocks.toolState.connectors = [];
     mocks.toolState.installedBuiltinIds = [];
+    mocks.toolState.installedPlugins = [];
     mocks.toolState.lobehubSkillServers = [];
+  });
+
+  it('offers a Configure migration action for an un-migrated legacy custom MCP', async () => {
+    // Legacy `user_installed_plugins` custom MCP with an mcp config but no
+    // matching `user_connectors` row → the panel should surface the migration
+    // entry instead of the dead-end "no configurable permissions" copy.
+    mocks.toolState.installedPlugins = [
+      {
+        customParams: { mcp: { type: 'http', url: 'https://mcp.example.com' } },
+        identifier: 'my-mcp',
+        type: 'customPlugin',
+      },
+    ];
+
+    render(<SkillDetail identifier="my-mcp" type="mcp-connector" />);
+
+    expect(await screen.findByRole('button', { name: 'Configure' })).toBeEnabled();
+    expect(
+      screen.getByText(
+        'This connector still uses the legacy plugin format. Configure it to finish upgrading, then manage its tool permissions here.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('This skill does not expose configurable tool permissions.'),
+    ).not.toBeInTheDocument();
   });
 
   it('shows a disconnect action for a connected LobeHub connector without configurable tools', async () => {

--- a/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
+++ b/src/routes/(main)/settings/skill/features/SkillDetail/index.tsx
@@ -5,16 +5,17 @@ import { Avatar, Markdown, Skeleton } from '@lobehub/ui';
 import { Button, confirmModal } from '@lobehub/ui/base-ui';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
-import { Plus, SquareArrowOutUpRight, Trash2, Unplug } from 'lucide-react';
+import { Plus, SquareArrowOutUpRight, Trash2, Unplug, Wrench } from 'lucide-react';
 import { lazy, memo, Suspense, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import { ConnectorDetail } from '@/features/Connectors';
+import { ConnectorDetail, CustomConnectorModal } from '@/features/Connectors';
 import { useSkillConnect } from '@/features/SkillStore/SkillList/LobeHub/useSkillConnect';
 import { usePermission } from '@/hooks/usePermission';
 import { useToolStore } from '@/store/tool';
 import { builtinToolSelectors, lobehubSkillStoreSelectors } from '@/store/tool/selectors';
 import { connectorSelectors } from '@/store/tool/slices/connector';
+import { pluginSelectors } from '@/store/tool/slices/plugin/selectors';
 
 import { getLocalizedBuiltinSkillDetail, getNoPermissionsTitle } from './localization';
 
@@ -149,6 +150,7 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type, onDelete }) => {
   const { t: ts } = useTranslation('setting');
   const [syncing, setSyncing] = useState(false);
   const [noManifest, setNoManifest] = useState(false);
+  const [migrateOpen, setMigrateOpen] = useState(false);
 
   const { allowed: canCreate } = usePermission('create_content');
   const { allowed: canEdit } = usePermission('edit_own_content');
@@ -161,6 +163,14 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type, onDelete }) => {
   const uninstallBuiltinTool = useToolStore((s) => s.uninstallBuiltinTool);
   const deleteAgentSkill = useToolStore((s) => s.deleteAgentSkill);
   const connector = useToolStore(connectorSelectors.connectorByIdentifier(identifier));
+
+  // Legacy `user_installed_plugins` custom MCP that was never migrated to a
+  // connector. Such a row has no `user_connectors` entry, so the panel falls
+  // into the "no configurable permissions" empty state. We offer to upgrade it
+  // in place via the connector migration flow instead of leaving a dead end.
+  const legacyPlugin = useToolStore(pluginSelectors.getCustomPluginById(identifier), isEqual);
+  const canMigrateLegacy =
+    (type === 'mcp-connector' || type === 'plugin') && Boolean(legacyPlugin?.customParams?.mcp);
 
   // For lobehub-connector: get the server's tool list from the store
   const lobehubServer = useToolStore(lobehubSkillStoreSelectors.getServerByIdentifier(identifier));
@@ -367,9 +377,41 @@ const SkillDetail = memo<SkillDetailProps>(({ identifier, type, onDelete }) => {
           <div className={styles.noPermissionsTitle}>
             {type === 'lobehub-connector' ? lobehubLabel : noPermissionsTitle}
           </div>
-          {renderLobehubConnectorAction()}
+          {canMigrateLegacy ? (
+            <Button
+              disabled={!canCreate || !canEdit}
+              icon={<Wrench size={14} />}
+              size="small"
+              type="primary"
+              onClick={() => {
+                if (!canCreate || !canEdit) return;
+                setMigrateOpen(true);
+              }}
+            >
+              {ts('tools.legacyConnector.configure')}
+            </Button>
+          ) : (
+            renderLobehubConnectorAction()
+          )}
         </div>
-        {ts('tools.noConfigurablePermissions')}
+        {canMigrateLegacy
+          ? ts('tools.legacyConnector.upgradeDesc')
+          : ts('tools.noConfigurablePermissions')}
+        {canMigrateLegacy && legacyPlugin && (
+          <CustomConnectorModal
+            legacyPlugin={legacyPlugin}
+            open={migrateOpen}
+            onClose={() => setMigrateOpen(false)}
+            onEditSuccess={async () => {
+              setMigrateOpen(false);
+              setNoManifest(false);
+              // The migration created a `user_connectors` row keyed by the same
+              // identifier; refresh so this panel resolves it and swaps to the
+              // permission editor.
+              await fetchConnectors();
+            }}
+          />
+        )}
       </div>
     );
   }

--- a/src/store/discover/slices/skill/action.ts
+++ b/src/store/discover/slices/skill/action.ts
@@ -35,8 +35,15 @@ export class SkillActionImpl {
   }): SWRResponse<DiscoverSkillDetail> => {
     const locale = globalHelpers.getCurrentLanguage();
 
+    // Skills imported from a raw URL get a synthetic `url.<host>.<path>`
+    // identifier (see server skill importer `url.${host}.${pathPart}`), not a
+    // marketplace slug — the market detail lookup can only 404 for them and
+    // would otherwise spam the console with 500s + SWR retries. Skip the request
+    // and let callers fall back to the locally stored name/description/icon.
+    const isMarketIdentifier = !!identifier && !identifier.startsWith('url.');
+
     return useClientDataSWR(
-      !identifier ? null : discoverKeys.skillDetail(locale, identifier, version),
+      !isMarketIdentifier ? null : discoverKeys.skillDetail(locale, identifier, version),
       async () => discoverService.getSkillDetail({ identifier: identifier!, version }),
     );
   };


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

Related to #15674 (legacy custom MCP → connector migration).

#### 🔀 Description of Change

Three fixes around the custom-connector / legacy-plugin configuration flow, found while testing on cloud:

**1. `fix(discover)` — market skill-detail 500 storm**
Skills imported from a raw URL carry a synthetic `url.<host>.<path>` identifier (server skill importer), not a marketplace slug, so `market.skill.getSkillDetail` can only 404 — the server maps that to a 500 and SWR retries, spamming the console. `useFetchSkillDetail` now skips the request for `url.`-prefixed identifiers; `MarketSkillIcon` / the popover already fall back to the locally stored name/icon.

**2. `fix(connector)` — legacy custom MCP migration: entry point + atomic rollback**
- Settings › Connectors showed a dead-end empty state ("no configurable tool permissions") for legacy `user_installed_plugins` custom MCPs that were never migrated to `user_connectors`. It now detects a legacy plugin carrying an `mcp` config and surfaces a **Configure** button that opens the existing `CustomConnectorModal` migration flow, refreshing into the tool-permission editor on success.
- When tool sync failed (endpoint unreachable / 500) the flow left **both** a tool-less connector **and** the surviving legacy row — a visible duplicate that also stranded the user (the lingering connector shadowed the legacy row, so the migrate entry disappeared). `executeLegacyMigrationSave` now **rolls the created connector back** on sync failure, returning atomically to the pre-migration state so the user can retry once the endpoint is healthy.

**3. `fix(plugin)` — config Drawer z-index**
The DevModal Drawer (antd, z ≈ 1000) opened from the Tools skill popover mounted *behind* it: `@lobehub/ui`'s base-ui floating layer (Popover/Dropdown) is 1100, and the Configure button's `stopPropagation` keeps that popover open. The panel was in the DOM but invisible ("click does nothing / twice to show"). Pinned the Drawer to the base-ui modal tier (1200).

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- **Migration entry**: with an un-migrated legacy custom MCP (`user_installed_plugins.type='customPlugin'` + `customParams.mcp`), open Settings › Connectors and select it → a **Configure** button appears; clicking it migrates to a connector and shows the tool-permission editor.
- **Rollback**: point the legacy MCP at an unreachable endpoint and migrate → the save fails with a toast and **no** duplicate / half-baked connector is left behind (legacy row preserved for retry). Covered by `legacyPluginMigration.test.ts` (32 tests).
- **z-index**: agent Tools popover → `…` → Configure on a custom connector → the config panel opens on top on the **first** click.
- **skill 500**: with a `url.`-imported skill installed, open the Tools popover → no `getSkillDetail` 500 in the console; the skill icon/name still render.

#### 📝 Additional Information

**Key decisions / non-goals**
- On migration sync failure we **roll the connector back** (atomic) rather than leaving it and deduping the list in the UI. UI-dedup was intentionally rejected: hiding the legacy row while a (broken) connector exists would also hide the migrate entry, stranding the user with a tool-less connector and no retry path.
- The "uninstall legacy row" step stays best-effort/swallowed. A rare local-delete failure leaves a temporary duplicate that the runtime dedupes by identifier (connector wins) and the next successful retry cleans up — deliberately not hardened here to avoid the above trade-off.
- No DB schema changes → targets `canary`.
