### PR TITLE
🐛 fix(agent): keep profile breadcrumb left-aligned

### DIFF
--- a/src/routes/(main)/agent/profile/features/Header/index.test.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.test.tsx
@@ -139,7 +139,6 @@ vi.mock('@/components/AntdStaticMethods', () => ({
 }));
 
 vi.mock('@/const/layoutTokens', () => ({
-  CONVERSATION_MIN_WIDTH: 960,
   DESKTOP_HEADER_ICON_SMALL_SIZE: 24,
 }));
 
@@ -231,16 +230,20 @@ describe('Agent profile Header', () => {
     mocks.agentState.isCurrentAgentHeterogeneous = false;
     mocks.agentState.systemRole = 'You are helpful.';
     mocks.agentState.config.plugins = ['lobe-web-browsing'];
+    mocks.globalState.showAgentBuilderPanel = false;
     mocks.profileState.editor = undefined;
   });
 
-  it('aligns the breadcrumb with the responsive profile content column', () => {
-    render(<Header />);
+  it.each([false, true])(
+    'keeps the breadcrumb aligned with the left content inset when builder expanded is %s',
+    (showAgentBuilderPanel) => {
+      mocks.globalState.showAgentBuilderPanel = showAgentBuilderPanel;
 
-    expect(screen.getByTestId('nav-header-left').style.paddingInlineStart).toBe(
-      'max(8px, calc((100% - 960px) / 2 + 16px))',
-    );
-  });
+      render(<Header />);
+
+      expect(screen.getByTestId('nav-header-left').style.paddingInlineStart).toBe('8px');
+    },
+  );
 
   it('should show the markdown export action', () => {
     render(<Header />);

--- a/src/routes/(main)/agent/profile/features/Header/index.tsx
+++ b/src/routes/(main)/agent/profile/features/Header/index.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from 'react-i18next';
 import { useAgentTransferMenuItem } from '@/business/client/hooks/useAgentTransferMenuItem';
 import { useBusinessAgentImportMenuItem } from '@/business/client/hooks/useBusinessAgentImportMenuItem';
 import { message } from '@/components/AntdStaticMethods';
-import { CONVERSATION_MIN_WIDTH, DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
+import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
 import AgentBreadcrumb from '@/features/AgentBreadcrumb';
 import NavHeader from '@/features/NavHeader';
 import ToggleRightPanelButton from '@/features/RightPanel/ToggleRightPanelButton';
@@ -273,7 +273,7 @@ const Header = memo(() => {
       }
       styles={{
         left: {
-          paddingInlineStart: `max(8px, calc((100% - ${CONVERSATION_MIN_WIDTH}px) / 2 + 16px))`,
+          paddingInlineStart: 8,
         },
       }}
     />


### PR DESCRIPTION
## Summary

- Keep the Agent Profile breadcrumb pinned to the left content inset.
- Preserve the same breadcrumb position whether Agent Builder is expanded or collapsed.
- Cover both panel states with a regression test.

## Root cause

The profile header used the responsive centered content-column offset introduced in #17071, which moved the breadcrumb toward the center when the available profile area widened.

## Validation

- `bun run check src/routes/(main)/agent/profile/features/Header/index.tsx src/routes/(main)/agent/profile/features/Header/index.test.tsx`
- Verified locally in SPA with Agent Builder expanded and collapsed.
