### PR TITLE
🐛 fix(topic): stop cross-mode key pollution collapsing topic groups

### DIFF
--- a/src/hooks/useTopicGroupCollapse.test.ts
+++ b/src/hooks/useTopicGroupCollapse.test.ts
@@ -16,8 +16,8 @@ const setCollapsed = (byMode: Record<string, string[]>) => {
 };
 
 beforeEach(() => {
-  vi.spyOn(useGlobalStore.getState().statusStorage, 'saveToLocalStorage').mockImplementation(
-    () => {},
+  vi.spyOn(useGlobalStore.getState().statusStorage, 'saveToLocalStorage').mockResolvedValue(
+    undefined,
   );
   setCollapsed({});
 });

--- a/src/hooks/useTopicGroupCollapse.test.ts
+++ b/src/hooks/useTopicGroupCollapse.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useGlobalStore } from '@/store/global';
+
+import { useTopicGroupCollapse } from './useTopicGroupCollapse';
+
+const TIME_GROUPS = ['favorite', 'today', 'yesterday', 'week'];
+const PROJECT_GROUPS = ['favorite', 'project:/repo/a', 'project:/repo/b'];
+
+const setCollapsed = (byMode: Record<string, string[]>) => {
+  useGlobalStore.setState({
+    isStatusInit: true,
+    status: { ...useGlobalStore.getState().status, collapsedTopicGroupKeysByMode: byMode },
+  });
+};
+
+beforeEach(() => {
+  vi.spyOn(useGlobalStore.getState().statusStorage, 'saveToLocalStorage').mockImplementation(
+    () => {},
+  );
+  setCollapsed({});
+});
+
+describe('useTopicGroupCollapse', () => {
+  it('expands every group when nothing has been collapsed yet', () => {
+    const { result } = renderHook(() => useTopicGroupCollapse('byTime', TIME_GROUPS));
+
+    expect(result.current.expandedKeys).toEqual(TIME_GROUPS);
+  });
+
+  it('keeps byProject keys from collapsing the byTime groups', () => {
+    setCollapsed({ byProject: ['project:/repo/a'] });
+
+    const { result } = renderHook(() => useTopicGroupCollapse('byTime', TIME_GROUPS));
+
+    expect(result.current.expandedKeys).toEqual(TIME_GROUPS);
+  });
+
+  it('writes collapsed keys into the current mode bucket only', () => {
+    setCollapsed({ byTime: ['week'] });
+
+    const { result } = renderHook(() => useTopicGroupCollapse('byProject', PROJECT_GROUPS));
+
+    act(() => {
+      result.current.setExpandedKeys(['favorite', 'project:/repo/b']);
+    });
+
+    expect(useGlobalStore.getState().status.collapsedTopicGroupKeysByMode).toEqual({
+      byProject: ['project:/repo/a'],
+      byTime: ['week'],
+    });
+  });
+
+  it('expands a group that appears after the collapsed list was persisted', () => {
+    setCollapsed({ byProject: ['project:/repo/a'] });
+
+    const { result } = renderHook(() =>
+      useTopicGroupCollapse('byProject', [...PROJECT_GROUPS, 'project:/repo/new']),
+    );
+
+    expect(result.current.expandedKeys).toEqual([
+      'favorite',
+      'project:/repo/b',
+      'project:/repo/new',
+    ]);
+  });
+
+  it('preserves the collapsed state of groups that are not currently rendered', () => {
+    setCollapsed({ byProject: ['project:/repo/paged-out'] });
+
+    const { result } = renderHook(() => useTopicGroupCollapse('byProject', PROJECT_GROUPS));
+
+    act(() => {
+      result.current.setExpandedKeys(['favorite', 'project:/repo/a']);
+    });
+
+    expect(useGlobalStore.getState().status.collapsedTopicGroupKeysByMode?.byProject).toEqual([
+      'project:/repo/paged-out',
+      'project:/repo/b',
+    ]);
+  });
+});

--- a/src/hooks/useTopicGroupCollapse.ts
+++ b/src/hooks/useTopicGroupCollapse.ts
@@ -1,0 +1,41 @@
+import { useCallback, useMemo } from 'react';
+
+import { useGlobalStore } from '@/store/global';
+import { systemStatusSelectors } from '@/store/global/selectors';
+import { type TopicGroupMode } from '@/types/topic';
+
+const EMPTY_KEYS: string[] = [];
+
+/**
+ * Accordion state for the topic sidebar groups, expanded by default.
+ *
+ * The persisted list holds the *collapsed* keys, bucketed per group mode: a group
+ * that only shows up later (a new project directory, a new month bucket) is absent
+ * from the list and therefore starts expanded, and `project:*` keys can never bleed
+ * into byTime, where they would match nothing and collapse every group.
+ */
+export const useTopicGroupCollapse = (mode: TopicGroupMode, groupIds: string[]) => {
+  const collapsedKeys =
+    useGlobalStore(systemStatusSelectors.collapsedTopicGroupKeys(mode)) ?? EMPTY_KEYS;
+  const updateSystemStatus = useGlobalStore((s) => s.updateSystemStatus);
+
+  const expandedKeys = useMemo(
+    () => groupIds.filter((id) => !collapsedKeys.includes(id)),
+    [groupIds, collapsedKeys],
+  );
+
+  const setExpandedKeys = useCallback(
+    (keys: string[]) => {
+      const nextCollapsed = [
+        // groups that aren't rendered right now (paged out, or emptied) keep their state
+        ...collapsedKeys.filter((id) => !groupIds.includes(id)),
+        ...groupIds.filter((id) => !keys.includes(id)),
+      ];
+
+      updateSystemStatus({ collapsedTopicGroupKeysByMode: { [mode]: nextCollapsed } });
+    },
+    [collapsedKeys, groupIds, mode, updateSystemStatus],
+  );
+
+  return { expandedKeys, setExpandedKeys };
+};

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/ToggleGroups.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/ToggleGroups.tsx
@@ -4,6 +4,7 @@ import { Maximize2, Minimize2 } from 'lucide-react';
 import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useTopicGroupCollapse } from '@/hooks/useTopicGroupCollapse';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
@@ -25,14 +26,8 @@ const ToggleGroups = memo(() => {
   );
   const groupTopics = useChatStore(groupSelector, isEqual);
 
-  const [topicGroupKeys, updateSystemStatus] = useGlobalStore((s) => [
-    systemStatusSelectors.topicGroupKeys(s),
-    s.updateSystemStatus,
-  ]);
-
   const groupIds = useMemo(() => groupTopics.map((group) => group.id), [groupTopics]);
-  // undefined means "default all expanded", so treat it as fully expanded
-  const expandedKeys = topicGroupKeys ?? groupIds;
+  const { expandedKeys, setExpandedKeys } = useTopicGroupCollapse(topicGroupMode, groupIds);
   const isAllCollapsed = expandedKeys.length === 0;
 
   // flat mode renders FlatMode (no accordion), so the toggle has nothing to affect;
@@ -44,7 +39,7 @@ const ToggleGroups = memo(() => {
       icon={isAllCollapsed ? Maximize2 : Minimize2}
       size={'small'}
       title={isAllCollapsed ? t('sidebar.expandAll') : t('sidebar.collapseAll')}
-      onClick={() => updateSystemStatus({ expandTopicGroupKeys: isAllCollapsed ? groupIds : [] })}
+      onClick={() => setExpandedKeys(isAllCollapsed ? groupIds : [])}
     />
   );
 });

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/GroupedAccordion.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/TopicListContent/GroupedAccordion.tsx
@@ -3,13 +3,14 @@
 import { Accordion, Flexbox } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
 import { MoreHorizontal } from 'lucide-react';
-import { type ComponentType, memo, useEffect, useMemo } from 'react';
+import { type ComponentType, memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import urlJoin from 'url-join';
 
 import NavItem from '@/features/NavPanel/components/NavItem';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
+import { useTopicGroupCollapse } from '@/hooks/useTopicGroupCollapse';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
@@ -51,26 +52,15 @@ const GroupedAccordion = memo<GroupedAccordionProps>(({ GroupItem }) => {
   );
   const groupTopics = useChatStore(groupSelector, isEqual);
 
-  const [topicGroupKeys, updateSystemStatus] = useGlobalStore((s) => [
-    systemStatusSelectors.topicGroupKeys(s),
-    s.updateSystemStatus,
-  ]);
-
-  useEffect(() => {
-    updateSystemStatus({ expandTopicGroupKeys: undefined });
-  }, [topicSortBy, topicGroupMode, updateSystemStatus]);
-
-  const expandedKeys = useMemo(
-    () => topicGroupKeys || groupTopics.map((group) => group.id),
-    [topicGroupKeys, groupTopics],
-  );
+  const groupIds = useMemo(() => groupTopics.map((group) => group.id), [groupTopics]);
+  const { expandedKeys, setExpandedKeys } = useTopicGroupCollapse(topicGroupMode, groupIds);
 
   return (
     <Flexbox gap={2}>
       <Accordion
         expandedKeys={expandedKeys}
         gap={2}
-        onExpandedChange={(keys) => updateSystemStatus({ expandTopicGroupKeys: keys as any })}
+        onExpandedChange={(keys) => setExpandedKeys(keys as string[])}
       >
         {groupTopics.map((group) => (
           <GroupItem

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/index.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/TopicListContent/ByTimeMode/index.tsx
@@ -3,11 +3,12 @@
 import { Accordion, Flexbox } from '@lobehub/ui';
 import isEqual from 'fast-deep-equal';
 import { MoreHorizontal } from 'lucide-react';
-import { memo, useEffect, useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import NavItem from '@/features/NavPanel/components/NavItem';
 import SkeletonList from '@/features/NavPanel/components/SkeletonList';
+import { useTopicGroupCollapse } from '@/hooks/useTopicGroupCollapse';
 import { useChatStore } from '@/store/chat';
 import { topicSelectors } from '@/store/chat/selectors';
 import { useGlobalStore } from '@/store/global';
@@ -36,19 +37,8 @@ const ByTimeMode = memo(() => {
   );
   const groupTopics = useChatStore(groupSelector, isEqual);
 
-  const [topicGroupKeys, updateSystemStatus] = useGlobalStore((s) => [
-    systemStatusSelectors.topicGroupKeys(s),
-    s.updateSystemStatus,
-  ]);
-
-  // Reset expanded keys when grouping changes so all groups start expanded
-  useEffect(() => {
-    updateSystemStatus({ expandTopicGroupKeys: undefined });
-  }, [topicSortBy, topicGroupMode, updateSystemStatus]);
-
-  const expandedKeys = useMemo(() => {
-    return topicGroupKeys || groupTopics.map((group) => group.id);
-  }, [topicGroupKeys, groupTopics]);
+  const groupIds = useMemo(() => groupTopics.map((group) => group.id), [groupTopics]);
+  const { expandedKeys, setExpandedKeys } = useTopicGroupCollapse(topicGroupMode, groupIds);
 
   return (
     <Flexbox gap={2}>
@@ -56,7 +46,7 @@ const ByTimeMode = memo(() => {
       <Accordion
         expandedKeys={expandedKeys}
         gap={2}
-        onExpandedChange={(keys) => updateSystemStatus({ expandTopicGroupKeys: keys as any })}
+        onExpandedChange={(keys) => setExpandedKeys(keys as string[])}
       >
         {groupTopics.map((group) => (
           <GroupItem

--- a/src/store/global/initialState.ts
+++ b/src/store/global/initialState.ts
@@ -4,6 +4,7 @@ import { type MigrationSQL, type MigrationTableItem } from '@/types/clientDB';
 import { DatabaseLoadingState } from '@/types/clientDB';
 import { type LocaleMode } from '@/types/locale';
 import { SessionDefaultGroup } from '@/types/session';
+import { type TopicGroupMode } from '@/types/topic';
 import { AsyncLocalStorage } from '@/utils/localStorage';
 
 export enum SidebarTabKey {
@@ -127,6 +128,14 @@ export interface SystemStatus {
    */
   agentPageSize?: number;
   chatInputHeight?: number;
+  /**
+   * Which topicGroups are collapsed, bucketed by group mode. We persist the
+   * collapsed keys rather than the expanded ones so a group that shows up later
+   * (a new project directory, a new month bucket) starts expanded; and bucketing
+   * per mode keeps `project:*` keys from leaking into byTime, where nothing would
+   * match and every group would render collapsed.
+   */
+  collapsedTopicGroupKeysByMode?: Partial<Record<TopicGroupMode, string[]>>;
   disabledModelProvidersSortType?: string;
   disabledModelsSortType?: string;
   /**
@@ -145,8 +154,6 @@ export interface SystemStatus {
   expandInputActionbar?: boolean;
   // which sessionGroup should expand
   expandSessionGroupKeys: string[];
-  // which topicGroup should expand
-  expandTopicGroupKeys?: string[];
   fileManagerViewMode?: 'list' | 'masonry';
   filePanelWidth: number;
   /**

--- a/src/store/global/selectors/systemStatus.ts
+++ b/src/store/global/selectors/systemStatus.ts
@@ -1,3 +1,5 @@
+import { type TopicGroupMode } from '@/types/topic';
+
 import type {
   GlobalState,
   ModelDetailPanelExpandedKey,
@@ -83,7 +85,10 @@ const sessionGroupKeys =
     return value || INITIAL_STATUS.expandSessionGroupKeys;
   };
 
-const topicGroupKeys = (s: GlobalState): string[] | undefined => s.status.expandTopicGroupKeys;
+const collapsedTopicGroupKeys =
+  (mode: TopicGroupMode) =>
+  (s: GlobalState): string[] | undefined =>
+    s.status.collapsedTopicGroupKeysByMode?.[mode];
 
 const agentSidebarSections =
   (agentId: string | undefined) =>
@@ -484,7 +489,7 @@ export const systemStatusSelectors = {
   systemStatus,
   verifyReportPanelWidth,
   tokenDisplayFormatShort,
-  topicGroupKeys,
+  collapsedTopicGroupKeys,
   topicPageSize,
   videoPanelWidth,
   videoTopicViewMode,


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None — reported directly.

#### 🔀 Description of Change

With the topic sidebar grouped **by project**, every group renders expanded; switch to **by time** and every group (收藏 / 今天 / 昨天 / 本周 / 本月 / …) renders **collapsed**.

**Root cause.** The group accordion persisted a single global list of *expanded* keys (`status.expandTopicGroupKeys`), shared across all grouping modes. The group ids of the modes live in different namespaces — `project:/abs/path` vs `favorite` / `today` / `week` / `2026-06` vs `pending` / `active`. Once the user expanded or collapsed anything in byProject, that list held `project:*` ids; switching to byTime matched none of them, so `expandedKeys.includes(group.id)` was false for every group.

The code already anticipated this and tried to reset the list on a mode change:

```ts
useEffect(() => {
  updateSystemStatus({ expandTopicGroupKeys: undefined });
}, [topicSortBy, topicGroupMode, updateSystemStatus]);
```

**but that reset is a no-op.** `updateSystemStatus` merges through `packages/utils/src/merge.ts` (es-toolkit `compat/mergeWith`), which follows lodash semantics and **skips `undefined` source values**. Verified:

```
merge({ expandTopicGroupKeys: ['project:/a'] }, { expandTopicGroupKeys: undefined })
  → { expandTopicGroupKeys: ['project:/a'] }   // unchanged
```

So the stale cross-mode keys survived every mode switch. The grouping mode is also per-agent (`claude-code` / `codex` agents default to `byProject`), while this state was one global value — so touching the groups on a single Claude Code agent made time groups default-collapsed on **every** agent.

**Fix.** Persist the **collapsed** keys instead of the expanded ones, **bucketed per group mode**:

```ts
collapsedTopicGroupKeysByMode?: Partial<Record<TopicGroupMode, string[]>>;
```

- **Bucketing** keeps `project:*` keys out of byTime — the pollution is structurally impossible now.
- **Inverting the semantics** (collapsed-list, not expanded-allowlist) means a group that only shows up *later* — a newly created project directory, a new month bucket — is absent from the list and therefore starts **expanded**. Under the old expanded-allowlist it could never be in the list, so it always started collapsed.
- An empty bucket now naturally means "nothing collapsed", which also sidesteps the truthy-`[]` trap in the old `topicGroupKeys || allIds` fallback.
- The dead `useEffect` reset is removed, so nothing depends on `merge` accepting `undefined` any more.

The expanded/collapsed math and the per-mode write are centralized in a new `useTopicGroupCollapse` hook, shared by the agent sidebar, the collapse-all/expand-all toggle, and the group sidebar's copy of the same logic (which had the identical bug).

**Migration:** the old `expandTopicGroupKeys` field is dropped from the type and is no longer read by any code path, so existing polluted profiles recover on first load — no cache clearing needed. The stale value simply sits unread in `LOBE_SYSTEM_STATUS`.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Verified end-to-end in the Electron desktop app against a **real account whose persisted profile actually carried the polluted key list** (17 keys: a mix of `project:*`, `pending`/`active`, and a stray `today` / `2026-02`).

A **code-level A/B on the same persisted data** proves the fix rather than asserting it — reverting the changed files to `HEAD` reproduces the bug (all 6 time groups `expanded: false`, pixel-identical to the report), and restoring them expands all 6:

📋 **Full verification report with screenshots:** https://app.lobehub.com/verify/b463a3e6-6d21-40ac-82e4-c56ec3b39637

| Case | Result |
| --- | --- |
| byTime — time groups default expanded (the bug) | ✅ 6/6 expanded |
| byProject — project groups default expanded (incl. 收藏) | ✅ 9/9 expanded |
| Collapse in byProject → byTime unaffected → back to byProject remembers | ✅ two independent buckets, zero cross-talk |
| Collapse-all / expand-all toggle round-trip, current mode only | ✅ |
| Unit tests (`useTopicGroupCollapse`) | ✅ 5 passed |

Unit tests cover: default-all-expanded; `byProject` keys not collapsing `byTime`; writes landing only in the current mode's bucket; a group appearing after persistence starting expanded; and not dropping the collapsed state of groups that aren't currently rendered.

#### 📸 Screenshots / Videos

Before → after (same account, same persisted state, only the code differs) is rendered in the verification report linked above.