### PR TITLE
🐛 fix(agent): refresh branch after CLI checkout

### DIFF
--- a/src/store/tool/slices/builtin/executors/__tests__/worktreeDetection.test.ts
+++ b/src/store/tool/slices/builtin/executors/__tests__/worktreeDetection.test.ts
@@ -252,6 +252,25 @@ describe('recordWorktreeAdd', () => {
 });
 
 describe('recordGitCommandEffects', () => {
+  it('refreshes the local branch cache when the run is bound to this device', async () => {
+    chatMocks.topics = {
+      t1: {
+        metadata: {
+          boundDeviceId: 'device-1',
+          workingDirectoryConfig: {
+            git: { branch: 'canary' },
+            path: '/repo',
+            repoType: 'github',
+          },
+        },
+      },
+    };
+
+    await recordGitCommandEffects({ command: 'git switch fix/topic', topicId: 't1' });
+
+    expect(swrMocks.mutate).toHaveBeenCalledWith(['device:gitBranch', 'local', '/repo']);
+  });
+
   it('refreshes the remote-device branch cache after a branch switch', async () => {
     chatMocks.topics = {
       t1: {

--- a/src/store/tool/slices/builtin/executors/__tests__/worktreeDetection.test.ts
+++ b/src/store/tool/slices/builtin/executors/__tests__/worktreeDetection.test.ts
@@ -19,6 +19,12 @@ const gitServiceMocks = vi.hoisted(() => ({
   listGitWorktrees: vi.fn(),
 }));
 
+const swrMocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+}));
+
+vi.mock('@/libs/swr', () => swrMocks);
+
 vi.mock('@/store/chat/store', () => ({
   getChatStoreState: () => chatMocks,
 }));
@@ -246,6 +252,25 @@ describe('recordWorktreeAdd', () => {
 });
 
 describe('recordGitCommandEffects', () => {
+  it('refreshes the remote-device branch cache after a branch switch', async () => {
+    chatMocks.topics = {
+      t1: {
+        metadata: {
+          boundDeviceId: 'remote-device',
+          workingDirectoryConfig: {
+            git: { branch: 'canary' },
+            path: '/repo',
+            repoType: 'github',
+          },
+        },
+      },
+    };
+
+    await recordGitCommandEffects({ command: 'git switch fix/topic', topicId: 't1' });
+
+    expect(swrMocks.mutate).toHaveBeenCalledWith(['device:gitBranch', 'remote-device', '/repo']);
+  });
+
   it('updates the topic branch when the agent switches branch with git switch', async () => {
     chatMocks.topics = {
       t1: {

--- a/src/store/tool/slices/builtin/executors/worktreeDetection.ts
+++ b/src/store/tool/slices/builtin/executors/worktreeDetection.ts
@@ -886,7 +886,11 @@ export const recordGitCommandEffects = async (params: {
   // shared branch key so the control bar (and its branch-keyed PR lookup) follows
   // the repository's actual HEAD immediately after the tool call completes.
   if (branchSwitch) {
-    await mutate(deviceKeys.gitBranch(topic?.metadata?.boundDeviceId ?? 'local', source));
+    const boundDeviceId = topic?.metadata?.boundDeviceId;
+    const currentDeviceId = getElectronStoreState().gatewayDeviceInfo?.deviceId;
+    const cacheDeviceId =
+      currentDeviceId && boundDeviceId === currentDeviceId ? 'local' : boundDeviceId;
+    await mutate(deviceKeys.gitBranch(cacheDeviceId ?? 'local', source));
   }
 };
 

--- a/src/store/tool/slices/builtin/executors/worktreeDetection.ts
+++ b/src/store/tool/slices/builtin/executors/worktreeDetection.ts
@@ -3,6 +3,8 @@ import type { DeviceGitLinkedPullRequest, WorkingDirConfig } from '@lobechat/typ
 import { getWorkingDirSourcePath } from '@lobechat/types';
 import isEqual from 'fast-deep-equal';
 
+import { mutate } from '@/libs/swr';
+import { deviceKeys } from '@/libs/swr/keys';
 import { gitService } from '@/services/git';
 import { topicSelectors } from '@/store/chat/selectors';
 import { getChatStoreState } from '@/store/chat/store';
@@ -875,8 +877,17 @@ export const recordGitCommandEffects = async (params: {
     nextConfig = applyPullRequestToConfig(nextConfig, source, prCreate);
   }
 
-  if (isEqual(currentConfig, nextConfig)) return;
-  await state.updateTopicMetadata(topicId, { workingDirectoryConfig: nextConfig });
+  if (!isEqual(currentConfig, nextConfig)) {
+    await state.updateTopicMetadata(topicId, { workingDirectoryConfig: nextConfig });
+  }
+
+  // A checkout performed inside the heterogeneous CLI bypasses ChatInput's
+  // BranchSwitcher, which normally refreshes this cache itself. Revalidate the
+  // shared branch key so the control bar (and its branch-keyed PR lookup) follows
+  // the repository's actual HEAD immediately after the tool call completes.
+  if (branchSwitch) {
+    await mutate(deviceKeys.gitBranch(topic?.metadata?.boundDeviceId ?? 'local', source));
+  }
 };
 
 /**


### PR DESCRIPTION
## Summary

- revalidate the shared Git branch cache after heterogeneous CLI checkout commands
- keep the ChatInput branch and linked PR state synchronized with the repository HEAD
- cover remote-device cache invalidation with a regression test

## Testing

- `bun run check src/store/tool/slices/builtin/executors/worktreeDetection.ts src/store/tool/slices/builtin/executors/__tests__/worktreeDetection.test.ts` (59 tests passed)
- `git diff --check`