### PR TITLE
🐛 fix(chat): stabilize skill policy menu actions

### DIFF
--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -445,3 +445,21 @@ live branch, measure the target URL/bundle, and use that path if it renders curr
 code. Only keep a harness as supporting evidence; the primary UI evidence must come
 from the product surface, or the report must clearly fail/block after every known
 path is measured.
+
+---
+
+## Case 17 — Using a fixed timeout to arbitrate competing nested popovers
+
+**Wrong approach**: when a row-level hover popover competes with a nested action
+popover, closing the hover surface and suppressing it for an arbitrary number of
+milliseconds.
+
+**Why it's wrong**: pointer travel time varies. After the timeout expires, the hover
+surface can reopen while the action menu is still active and consume the interaction.
+
+**What it breaks**: menu actions become intermittently unclickable; destructive
+actions can disappear before their confirmation surface opens.
+
+**Correct approach**: coordinate both surfaces through explicit shared state. Keep
+the hover surface disabled for the complete lifetime of the nested action popover,
+then restore it only after that popover closes.

--- a/src/features/ChatInput/ActionBar/Tools/PopoverContent.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/PopoverContent.tsx
@@ -117,13 +117,14 @@ const filterItems = (items: ItemType[], keyword: string): ItemType[] => {
 
 interface PopoverContentProps {
   autoCount: number;
+  detailPopoverDisabled?: boolean;
   items: ItemType[];
   onOpenStore: () => void;
   pinnedCount: number;
 }
 
 const PopoverContent = memo<PopoverContentProps>(
-  ({ autoCount, items, onOpenStore, pinnedCount }) => {
+  ({ autoCount, detailPopoverDisabled, items, onOpenStore, pinnedCount }) => {
     const { t } = useTranslation('setting');
     const navigate = useWorkspaceAwareNavigate();
     const [searchKeyword, setSearchKeyword] = useState('');
@@ -156,7 +157,7 @@ const PopoverContent = memo<PopoverContentProps>(
             overflowY: 'auto',
           }}
         >
-          <ToolsList items={filteredItems} />
+          <ToolsList detailPopoverDisabled={detailPopoverDisabled} items={filteredItems} />
         </ScrollSignalProvider>
         <div className={styles.footer}>
           <span className={styles.statsItem}>

--- a/src/features/ChatInput/ActionBar/Tools/ToolsList.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/ToolsList.tsx
@@ -63,6 +63,7 @@ interface ToolItemData {
 }
 
 interface ToolsListProps {
+  detailPopoverDisabled?: boolean;
   items: ItemType[];
 }
 
@@ -70,7 +71,11 @@ const DividerItem = memo<{ index: number }>(({ index }) => (
   <Divider key={`divider-${index}`} style={{ margin: '4px 0' }} />
 ));
 
-const RegularItem = memo<{ index: number; item: ToolItemData }>(({ item, index }) => {
+const RegularItem = memo<{
+  detailPopoverDisabled?: boolean;
+  index: number;
+  item: ToolItemData;
+}>(({ detailPopoverDisabled, item, index }) => {
   const [open, setOpen] = useState(false);
   const suppressUntilRef = useRef(0);
 
@@ -93,10 +98,17 @@ const RegularItem = memo<{ index: number; item: ToolItemData }>(({ item, index }
     return () => window.removeEventListener(CLOSE_TOOL_DETAIL_POPOVER_EVENT, close);
   }, []);
 
-  const handleOpenChange = useCallback((nextOpen: boolean) => {
-    if (nextOpen && Date.now() < suppressUntilRef.current) return;
-    setOpen(nextOpen);
-  }, []);
+  useEffect(() => {
+    if (detailPopoverDisabled) setOpen(false);
+  }, [detailPopoverDisabled]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen && (detailPopoverDisabled || Date.now() < suppressUntilRef.current)) return;
+      setOpen(nextOpen);
+    },
+    [detailPopoverDisabled],
+  );
 
   const iconNode = item.icon ? (
     isValidElement(item.icon) ? (
@@ -126,6 +138,7 @@ const RegularItem = memo<{ index: number; item: ToolItemData }>(({ item, index }
     <Popover
       arrow={false}
       content={item.popoverContent}
+      disabled={detailPopoverDisabled}
       mouseEnterDelay={0.3}
       open={open}
       placement={'rightTop'}
@@ -138,29 +151,44 @@ const RegularItem = memo<{ index: number; item: ToolItemData }>(({ item, index }
   );
 });
 
-const GroupItem = memo<{ index: number; item: ToolItemData }>(({ item, index }) => (
+const GroupItem = memo<{
+  detailPopoverDisabled?: boolean;
+  index: number;
+  item: ToolItemData;
+}>(({ detailPopoverDisabled, item, index }) => (
   <Fragment key={item.key || `group-${index}`}>
     <Text className={toolsListStyles.groupLabel} fontSize={12} type="secondary">
       {item.label}
     </Text>
     {item.children?.map((child, childIndex) => (
-      <ToolListItem index={childIndex} item={child} key={child.key || `item-${childIndex}`} />
+      <ToolListItem
+        detailPopoverDisabled={detailPopoverDisabled}
+        index={childIndex}
+        item={child}
+        key={child.key || `item-${childIndex}`}
+      />
     ))}
   </Fragment>
 ));
 
-const ToolListItem = memo<{ index: number; item: ToolItemData | null }>(({ item, index }) => {
+const ToolListItem = memo<{
+  detailPopoverDisabled?: boolean;
+  index: number;
+  item: ToolItemData | null;
+}>(({ detailPopoverDisabled, item, index }) => {
   if (!item) return null;
   if (item.type === 'divider') return <DividerItem index={index} />;
-  if (item.type === 'group') return <GroupItem index={index} item={item} />;
-  return <RegularItem index={index} item={item} />;
+  if (item.type === 'group')
+    return <GroupItem detailPopoverDisabled={detailPopoverDisabled} index={index} item={item} />;
+  return <RegularItem detailPopoverDisabled={detailPopoverDisabled} index={index} item={item} />;
 });
 
-const ToolsList = memo<ToolsListProps>(({ items }) => {
+const ToolsList = memo<ToolsListProps>(({ detailPopoverDisabled, items }) => {
   return (
     <Flexbox gap={0} padding={4}>
       {items.map((item, index) => (
         <ToolListItem
+          detailPopoverDisabled={detailPopoverDisabled}
           index={index}
           item={item as ToolItemData | null}
           key={item?.key || `item-${index}`}

--- a/src/features/ChatInput/ActionBar/Tools/index.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/index.tsx
@@ -14,7 +14,7 @@ import { useControls } from './useControls';
 
 const Tools = memo(() => {
   const { t } = useTranslation('setting');
-  const { marketItems, editPluginDrawer, pinnedCount, autoCount } = useControls();
+  const { marketItems, editPluginDrawer, pinnedCount, autoCount, isPolicyMenuOpen } = useControls();
 
   const agentId = useAgentId();
   const model = useAgentStore((s) => agentByIdSelectors.getAgentModelById(agentId)(s));
@@ -39,6 +39,7 @@ const Tools = memo(() => {
           content: (
             <PopoverContent
               autoCount={autoCount}
+              detailPopoverDisabled={isPolicyMenuOpen}
               items={marketItems}
               pinnedCount={pinnedCount}
               onOpenStore={handleOpenStore}

--- a/src/features/ChatInput/ActionBar/Tools/useControls.tsx
+++ b/src/features/ChatInput/ActionBar/Tools/useControls.tsx
@@ -2041,6 +2041,7 @@ export const useControls = ({ closeDropdown }: { closeDropdown?: () => void } = 
     autoCount: allAutoItems.length,
     editPluginDrawer,
     installedPluginItems,
+    isPolicyMenuOpen: policyOpenId !== null,
     marketFooter,
     marketHeader,
     marketItems,


### PR DESCRIPTION
## Summary

- coordinate the skill policy menu with row-level detail popovers through explicit open state
- keep hover detail popovers disabled for the complete lifetime of a policy menu
- document the nested-popover timeout failure pattern in the agent-testing guidance

## Root cause

The tool list previously closed its row detail popover and suppressed reopening for 600 ms when a policy menu opened. Pointer travel can exceed that fixed window, allowing the hover detail popover to reopen while the policy menu remains active and consume the intended action click.

## User impact

MCP policy actions, including Uninstall, remain reliably clickable. Selecting Uninstall now consistently opens its confirmation dialog instead of allowing the action menu to disappear first.

## Validation

- `bun run check src/features/ChatInput/ActionBar/Tools/useControls.tsx src/features/ChatInput/ActionBar/Tools/index.tsx src/features/ChatInput/ActionBar/Tools/PopoverContent.tsx src/features/ChatInput/ActionBar/Tools/ToolsList.tsx`
- isolated Electron dev verification on the rebased branch: opened Context7 MCP policy menu, waited 1.5 seconds, clicked Uninstall, and confirmed the uninstall dialog appeared; cancelled without mutating installation state
- verification report: https://app.lobehub.com/verify/d71e07ce-768d-4720-9c87-7e0e7aa27d26

Full workspace type-check remains blocked by pre-existing generated TTS route errors and workspace dependency/type duplication; none of the changed component files appears in the reported failures.
