### PR TITLE
💄 style(connector): use theme code font for connector tool names

### DIFF
--- a/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
+++ b/src/features/Connectors/ConnectorDetail/ToolPermissionRow.tsx
@@ -72,7 +72,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   toolName: css`
     overflow: hidden;
 
-    font-family: var(--font-mono, monospace);
+    font-family: ${cssVar.fontFamilyCode};
     font-size: 13px;
     color: ${cssVar.colorText};
     text-overflow: ellipsis;


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔀 Description of Change

The connector tool-detail rows (Settings › Connectors → right panel, `ToolPermissionRow`) styled tool names with `font-family: var(--font-mono, monospace)`.

`--font-mono` is only injected by Next.js `next/font` on **web**. The **desktop** Electron SPA (Vite) build never defines it, so the `var()` resolved to an unavailable value and the tool identifiers fell back to the default **proportional** font instead of a monospace one (see screenshots — desktop vs web).

Switch to the antd theme token `cssVar.fontFamilyCode`, which is guaranteed present on both web and desktop (via the ThemeProvider) and already ships a proper monospace fallback stack. This also aligns the row with every other code-font call site in the app (`ModelSelect`, `ReportViewer`, `KeyValueEditor`, builtin-tool renderers) — `ToolPermissionRow` was the lone outlier using the raw CSS var.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Open **Settings › Connectors**, select a connector that exposes tools (e.g. Documents / a custom MCP). The tool identifiers in the right panel now render in a monospace/code font on **both** web and the desktop app.

#### 📸 Screenshots / Videos

| Before (desktop) | After |
| ---------------- | ----- |
| proportional font — `--font-mono` undefined on desktop | monospace via `cssVar.fontFamilyCode` |
