### PR TITLE
✨ feat: per-topic model and per-source-device execution target overrides

### DIFF
--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -171,8 +171,12 @@ const ExecAgentSchema = z
     existingMessageIds: z.array(z.string()).optional().default([]),
     /** File IDs of already-uploaded attachments to attach to the new user message */
     fileIds: z.array(z.string()).optional(),
+    /** Topic-level model override; forwarded to the agent run so the topic's pinned model wins. */
+    model: z.string().optional(),
     /** Parent message ID for regeneration/continue (skip user message creation, branch from this message) */
     parentMessageId: z.string().optional(),
+    /** Topic-level provider override; forwarded alongside `model`. */
+    provider: z.string().optional(),
     /** The user input/prompt */
     prompt: z.string(),
     /**
@@ -717,7 +721,9 @@ export const aiAgentRouter = router({
       existingMessageIds = [],
       fileIds,
       mentionedAgents,
+      model,
       parentMessageId,
+      provider,
       resumeApproval,
       resumeToolResult,
       selectedToolIds,
@@ -736,8 +742,10 @@ export const aiAgentRouter = router({
         existingMessageIds,
         fileIds,
         mentionedAgents,
+        model,
         parentMessageId,
         prompt,
+        provider,
         // When parentMessageId is provided, this is a regeneration/continue or a
         // human-approval resume — either way, skip user message creation.
         resume: !!parentMessageId,

--- a/apps/server/src/routers/lambda/aiAgent.ts
+++ b/apps/server/src/routers/lambda/aiAgent.ts
@@ -167,6 +167,8 @@ const ExecAgentSchema = z
     autoStart: z.boolean().optional().default(true),
     /** Explicit device ID to bind to the topic and activate for this run */
     deviceId: z.string().optional(),
+    /** Source device id of the requesting machine, for per-source override resolution. */
+    sourceDeviceId: z.string().optional(),
     /** Optional existing message IDs to include in context */
     existingMessageIds: z.array(z.string()).optional().default([]),
     /** File IDs of already-uploaded attachments to attach to the new user message */
@@ -719,6 +721,7 @@ export const aiAgentRouter = router({
       autoStart = true,
       deviceId,
       existingMessageIds = [],
+      sourceDeviceId,
       fileIds,
       mentionedAgents,
       model,
@@ -740,6 +743,7 @@ export const aiAgentRouter = router({
         autoStart,
         deviceId,
         existingMessageIds,
+        sourceDeviceId,
         fileIds,
         mentionedAgents,
         model,

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -64,6 +64,7 @@ import {
   ReasoningGraphSchema,
   RequestTrigger,
   resolveAgencyConfig,
+  resolveOverrideBySource,
   ThreadStatus,
   ThreadType,
 } from '@lobechat/types';
@@ -1109,8 +1110,11 @@ export class AiAgentService {
           this.workspaceId,
         );
         const preference = await workspaceUserSettings.getPreference();
-        const override = preference.agentDeviceOverrides?.[resolvedAgentId];
-        agentConfig.agencyConfig = resolveAgencyConfig(agentConfig.agencyConfig, override);
+        const bySource = preference.agentDeviceOverrides?.[resolvedAgentId];
+        // Server doesn't know the sourceDeviceId (which machine the request came from),
+        // so use '*' as fallback — the user's last-set generic override.
+        const override = resolveOverrideBySource(bySource, '*');
+        agentConfig.agencyConfig = resolveAgencyConfig(agentConfig.agencyConfig, override ?? null);
       } catch (error) {
         // Losing the override is non-fatal: dispatch falls back to the shared
         // agencyConfig, which is exactly the pre-LOBE-11689 behaviour.

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -30,10 +30,11 @@ import type {
   AgentManagementContext,
   BotPlatformContext,
   LobeToolManifest,
+  SkillEngine,
   ToolExecutor,
+  type ToolsEngine,
   ToolSource,
 } from '@lobechat/context-engine';
-import { SkillEngine, type ToolsEngine } from '@lobechat/context-engine';
 import type { LobeChatDatabase } from '@lobechat/database';
 import { isRemoteHeterogeneousType } from '@lobechat/heterogeneous-agents';
 import { buildTaskManagerDefaultsPrompt } from '@lobechat/prompts';
@@ -980,6 +981,34 @@ export class AiAgentService {
    *   → ServerMechaModule.ContextEngineering(input, config, messages)
    *   → AgentRuntimeService.createOperation(...)
    */
+  /**
+   * Resolve the caller's per-source-device execution override for `agentId`,
+   * mirroring the client resolver. Workspace agents read
+   * `workspace_user_settings.agentDeviceOverrides`; personal agents read
+   * `users.preference.personalDeviceOverrides`. Returns `undefined` when no
+   * override is set, so the shared `agencyConfig` is used as-is.
+   */
+  private async resolveCallerDeviceOverride(
+    agentId: string,
+    sourceDeviceId?: string,
+  ): Promise<{ boundDeviceId?: string; executionTarget?: string } | undefined> {
+    if (this.workspaceId) {
+      const workspaceUserSettings = new WorkspaceUserSettingsModel(
+        this.db,
+        this.userId,
+        this.workspaceId,
+      );
+      const preference = await workspaceUserSettings.getPreference();
+      const bySource = preference.agentDeviceOverrides?.[agentId];
+      return resolveOverrideBySource(bySource, sourceDeviceId ?? '*');
+    }
+
+    const userModel = new UserModel(this.db, this.userId);
+    const preference = await userModel.getUserPreference();
+    const bySource = preference?.personalDeviceOverrides?.[agentId];
+    return resolveOverrideBySource(bySource, sourceDeviceId ?? '*');
+  }
+
   async execAgent(params: InternalExecAgentParams): Promise<ExecAgentResult> {
     const {
       additionalPluginIds,
@@ -990,6 +1019,7 @@ export class AiAgentService {
       autoStart = true,
       botContext,
       deviceId: requestedDeviceId,
+      sourceDeviceId,
       botPlatformContext,
       discordContext,
       existingMessageIds = [],
@@ -1092,34 +1122,40 @@ export class AiAgentService {
     // Use actual agent ID from config for subsequent operations
     const resolvedAgentId = agentConfig.id;
 
-    // Layer this caller's per-user device override (LOBE-11689) over the shared
-    // agencyConfig so THIS user's Cloud Sandbox / workspace-device / local pick
-    // drives dispatch instead of whichever choice landed on the shared row.
-    // Only applied for workspace agents — personal agents already have a single
-    // owner whose choice IS the shared config. The override lives in the
-    // dedicated `workspace_user_settings` table (per-(workspace, user)) so it
-    // stays orthogonal to member-list queries and cascades on either identity
-    // delete. `resolveAgencyConfig` is a no-op when no override exists, so a
-    // first-open (or a member who hasn't touched the switcher) transparently
-    // sees the shared default.
-    if (this.workspaceId) {
-      try {
-        const workspaceUserSettings = new WorkspaceUserSettingsModel(
-          this.db,
-          this.userId,
-          this.workspaceId,
-        );
-        const preference = await workspaceUserSettings.getPreference();
-        const bySource = preference.agentDeviceOverrides?.[resolvedAgentId];
-        // Server doesn't know the sourceDeviceId (which machine the request came from),
-        // so use '*' as fallback — the user's last-set generic override.
-        const override = resolveOverrideBySource(bySource, '*');
-        agentConfig.agencyConfig = resolveAgencyConfig(agentConfig.agencyConfig, override ?? null);
-      } catch (error) {
-        // Losing the override is non-fatal: dispatch falls back to the shared
-        // agencyConfig, which is exactly the pre-LOBE-11689 behaviour.
-        log('execAgent: failed to load caller workspace_user_settings override: %O', error);
+    // Layer this caller's per-user device override over the shared agencyConfig
+    // so THIS user's Cloud Sandbox / workspace-device / local pick drives
+    // dispatch instead of whichever choice landed on the shared row. Mirrors the
+    // client resolver (agentConfigResolver.withDeviceOverride):
+    //   topic override → source-device override → shared agencyConfig
+    // - Workspace agents read `workspace_user_settings.agentDeviceOverrides`.
+    // - Personal agents read `users.preference.personalDeviceOverrides` (their
+    //   choice is no longer written to the shared config).
+    // `resolveOverrideBySource`/`resolveAgencyConfig` are no-ops when no override
+    // exists, so a first-open (or a member who hasn't touched the switcher)
+    // transparently sees the shared default.
+    try {
+      const sourceOverride = await this.resolveCallerDeviceOverride(
+        resolvedAgentId,
+        sourceDeviceId,
+      );
+
+      agentConfig.agencyConfig = resolveAgencyConfig(
+        agentConfig.agencyConfig,
+        sourceOverride ?? null,
+      );
+
+      // Topic-level device override wins over the source-device override.
+      if (appContext?.topicId) {
+        const topic = await this.topicModel.findById(appContext.topicId);
+        const topicOverride = topic?.metadata?.deviceOverride;
+        if (topicOverride) {
+          agentConfig.agencyConfig = resolveAgencyConfig(agentConfig.agencyConfig, topicOverride);
+        }
       }
+    } catch (error) {
+      // Losing the override is non-fatal: dispatch falls back to the shared
+      // agencyConfig, which is exactly the pre-LOBE-11689 behaviour.
+      log('execAgent: failed to resolve caller device override: %O', error);
     }
 
     // Persistence-attribution agent id. Background Agent Signal runs (memory /
@@ -3316,15 +3352,16 @@ export class AiAgentService {
     // gates. manifestMap is intentionally broader for discovery and must not
     // by itself authorize a tool in chat/custom mode or without function calls.
     const historicalActivatedToolIds = extractActivatedToolIdsFromMessages(allMessages) ?? [];
-    const activatableToolIds = toolsEngine && historicalActivatedToolIds.length > 0
-      ? toolsEngine.generateToolsDetailed({
-          context: { isExplicitActivation: true },
-          model,
-          provider,
-          skipDefaultTools: true,
-          toolIds: historicalActivatedToolIds,
-        }).enabledToolIds
-      : [];
+    const activatableToolIds =
+      toolsEngine && historicalActivatedToolIds.length > 0
+        ? toolsEngine.generateToolsDetailed({
+            context: { isExplicitActivation: true },
+            model,
+            provider,
+            skipDefaultTools: true,
+            toolIds: historicalActivatedToolIds,
+          }).enabledToolIds
+        : [];
 
     log('execAgent: prepared evalContext for executor');
 

--- a/packages/database/src/models/__tests__/workspaceUserSettings.test.ts
+++ b/packages/database/src/models/__tests__/workspaceUserSettings.test.ts
@@ -39,7 +39,7 @@ describe('WorkspaceUserSettingsModel', () => {
     const model = new WorkspaceUserSettingsModel(serverDB, userA, workspaceId);
     await model.updatePreference({
       agentDeviceOverrides: {
-        agentX: { boundDeviceId: 'device-1', executionTarget: 'device' },
+        agentX: { '*': { boundDeviceId: 'device-1', executionTarget: 'device' } },
       },
     });
 
@@ -47,7 +47,7 @@ describe('WorkspaceUserSettingsModel', () => {
     expect(row).toBeDefined();
     expect(row?.preference).toEqual({
       agentDeviceOverrides: {
-        agentX: { boundDeviceId: 'device-1', executionTarget: 'device' },
+        agentX: { '*': { boundDeviceId: 'device-1', executionTarget: 'device' } },
       },
     });
   });
@@ -55,41 +55,40 @@ describe('WorkspaceUserSettingsModel', () => {
   it('merges subsequent patches into the same row instead of replacing (UPSERT update branch)', async () => {
     const model = new WorkspaceUserSettingsModel(serverDB, userA, workspaceId);
     await model.updatePreference({
-      agentDeviceOverrides: { agentX: { executionTarget: 'sandbox' } },
+      agentDeviceOverrides: { agentX: { '*': { executionTarget: 'sandbox' } } },
     });
-    // Patch adds a second agent — the first agent's override must survive.
     await model.updatePreference({
       agentDeviceOverrides: {
-        agentX: { executionTarget: 'sandbox' },
-        agentY: { boundDeviceId: 'device-Y', executionTarget: 'device' },
+        agentX: { '*': { executionTarget: 'sandbox' } },
+        agentY: { '*': { boundDeviceId: 'device-Y', executionTarget: 'device' } },
       },
     });
 
     const preference = await model.getPreference();
     expect(preference.agentDeviceOverrides).toEqual({
-      agentX: { executionTarget: 'sandbox' },
-      agentY: { boundDeviceId: 'device-Y', executionTarget: 'device' },
+      agentX: { '*': { executionTarget: 'sandbox' } },
+      agentY: { '*': { boundDeviceId: 'device-Y', executionTarget: 'device' } },
     });
   });
 
   it('deep-merges agentDeviceOverrides so a single-agent patch never drops other agents', async () => {
     const model = new WorkspaceUserSettingsModel(serverDB, userA, workspaceId);
     await model.updatePreference({
-      agentDeviceOverrides: { agentX: { executionTarget: 'sandbox' } },
+      agentDeviceOverrides: { agentX: { '*': { executionTarget: 'sandbox' } } },
     });
 
     // A client with a stale/empty local copy patches ONLY agentY — agentX's
     // saved choice must survive the write.
     await model.updatePreference({
       agentDeviceOverrides: {
-        agentY: { boundDeviceId: 'device-Y', executionTarget: 'device' },
+        agentY: { '*': { boundDeviceId: 'device-Y', executionTarget: 'device' } },
       },
     });
 
     const preference = await model.getPreference();
     expect(preference.agentDeviceOverrides).toEqual({
-      agentX: { executionTarget: 'sandbox' },
-      agentY: { boundDeviceId: 'device-Y', executionTarget: 'device' },
+      agentX: { '*': { executionTarget: 'sandbox' } },
+      agentY: { '*': { boundDeviceId: 'device-Y', executionTarget: 'device' } },
     });
   });
 
@@ -98,21 +97,25 @@ describe('WorkspaceUserSettingsModel', () => {
     const modelB = new WorkspaceUserSettingsModel(serverDB, userB, workspaceId);
 
     await modelA.updatePreference({
-      agentDeviceOverrides: { shared: { boundDeviceId: 'A-device', executionTarget: 'device' } },
+      agentDeviceOverrides: {
+        shared: { '*': { boundDeviceId: 'A-device', executionTarget: 'device' } },
+      },
     });
     await modelB.updatePreference({
-      agentDeviceOverrides: { shared: { boundDeviceId: 'B-device', executionTarget: 'device' } },
+      agentDeviceOverrides: {
+        shared: { '*': { boundDeviceId: 'B-device', executionTarget: 'device' } },
+      },
     });
 
     const [prefA, prefB] = await Promise.all([modelA.getPreference(), modelB.getPreference()]);
-    expect(prefA.agentDeviceOverrides?.shared?.boundDeviceId).toBe('A-device');
-    expect(prefB.agentDeviceOverrides?.shared?.boundDeviceId).toBe('B-device');
+    expect(prefA.agentDeviceOverrides?.shared?.['*']?.boundDeviceId).toBe('A-device');
+    expect(prefB.agentDeviceOverrides?.shared?.['*']?.boundDeviceId).toBe('B-device');
   });
 
   it('cascades on workspace delete — FK removes every row for that workspace', async () => {
     const model = new WorkspaceUserSettingsModel(serverDB, userA, workspaceId);
     await model.updatePreference({
-      agentDeviceOverrides: { a: { executionTarget: 'sandbox' } },
+      agentDeviceOverrides: { a: { '*': { executionTarget: 'sandbox' } } },
     });
     expect(await model.get()).toBeDefined();
 
@@ -123,7 +126,7 @@ describe('WorkspaceUserSettingsModel', () => {
   it('cascades on user delete — FK removes every row for that user', async () => {
     const model = new WorkspaceUserSettingsModel(serverDB, userA, workspaceId);
     await model.updatePreference({
-      agentDeviceOverrides: { a: { executionTarget: 'sandbox' } },
+      agentDeviceOverrides: { a: { '*': { executionTarget: 'sandbox' } } },
     });
     expect(await model.get()).toBeDefined();
 

--- a/packages/database/src/models/__tests__/workspaceUserSettings.test.ts
+++ b/packages/database/src/models/__tests__/workspaceUserSettings.test.ts
@@ -133,4 +133,32 @@ describe('WorkspaceUserSettingsModel', () => {
     await serverDB.delete(users);
     expect(await model.get()).toBeUndefined();
   });
+
+  it('merges per source device so a single-source patch never drops other devices', async () => {
+    const model = new WorkspaceUserSettingsModel(serverDB, userA, workspaceId);
+    await model.updatePreference({
+      agentDeviceOverrides: {
+        agentX: {
+          deviceA: { boundDeviceId: 'device-A', executionTarget: 'device' },
+          deviceB: { boundDeviceId: 'device-B', executionTarget: 'device' },
+        },
+      },
+    });
+
+    // A client with a stale/partial local copy patches ONLY deviceB for agentX —
+    // deviceA's saved choice must survive the write.
+    await model.updatePreference({
+      agentDeviceOverrides: {
+        agentX: { deviceB: { executionTarget: 'sandbox' } },
+      },
+    });
+
+    const preference = await model.getPreference();
+    expect(preference.agentDeviceOverrides).toEqual({
+      agentX: {
+        deviceA: { boundDeviceId: 'device-A', executionTarget: 'device' },
+        deviceB: { boundDeviceId: 'device-B', executionTarget: 'sandbox' },
+      },
+    });
+  });
 });

--- a/packages/database/src/models/workspaceUserSettings.ts
+++ b/packages/database/src/models/workspaceUserSettings.ts
@@ -68,11 +68,14 @@ export class WorkspaceUserSettingsModel {
    */
   updatePreference = async (patch: Partial<WorkspaceUserPreference>) => {
     const current = (await this.getPreference()) ?? {};
-    // `agentDeviceOverrides` merges one level deeper: clients patch a single
-    // agent's override built from their LOCAL copy of the map, which may be
-    // stale or empty (picker used before the preference fetch settled), and a
-    // top-level replace would silently drop this user's saved choices for
-    // every other agent. Individual per-agent entries still replace wholesale.
+    // `agentDeviceOverrides` merges per source device, not per agent. Clients
+    // patch a single agent's override built from their LOCAL copy of the
+    // per-source map, which may be stale or partial (e.g. the picker was opened
+    // before the preference fetch settled, or another tab saved a different
+    // source device). A shallow per-agent replace would silently drop this
+    // user's saved choices for *other* source devices, breaking the per-source
+    // isolation. So merge one level deeper: each agent's source map is combined
+    // key-by-key with what's already persisted.
     const next: WorkspaceUserPreference = {
       ...current,
       ...patch,
@@ -80,7 +83,12 @@ export class WorkspaceUserSettingsModel {
         ? {
             agentDeviceOverrides: {
               ...current.agentDeviceOverrides,
-              ...patch.agentDeviceOverrides,
+              ...Object.fromEntries(
+                Object.entries(patch.agentDeviceOverrides).map(([agentId, bySource]) => [
+                  agentId,
+                  { ...current.agentDeviceOverrides?.[agentId], ...bySource },
+                ]),
+              ),
             },
           }
         : {}),

--- a/packages/database/src/models/workspaceUserSettings.ts
+++ b/packages/database/src/models/workspaceUserSettings.ts
@@ -84,10 +84,20 @@ export class WorkspaceUserSettingsModel {
             agentDeviceOverrides: {
               ...current.agentDeviceOverrides,
               ...Object.fromEntries(
-                Object.entries(patch.agentDeviceOverrides).map(([agentId, bySource]) => [
-                  agentId,
-                  { ...current.agentDeviceOverrides?.[agentId], ...bySource },
-                ]),
+                Object.entries(patch.agentDeviceOverrides).map(([agentId, bySource]) => {
+                  // Normalize a legacy flat override (`{ executionTarget,
+                  // boundDeviceId }`) into the per-source map shape before
+                  // merging, so it doesn't shadow the new keyed entry — the
+                  // resolver treats any object with top-level executionTarget /
+                  // boundDeviceId as legacy flat and returns it as-is, skipping
+                  // source keys.
+                  const existing = current.agentDeviceOverrides?.[agentId];
+                  const normalizedExisting =
+                    existing && ('executionTarget' in existing || 'boundDeviceId' in existing)
+                      ? { '*': existing }
+                      : existing;
+                  return [agentId, { ...normalizedExisting, ...bySource }];
+                }),
               ),
             },
           }

--- a/packages/types/src/agent/agencyConfig.test.ts
+++ b/packages/types/src/agent/agencyConfig.test.ts
@@ -14,6 +14,7 @@ import {
   resolveCodexModel,
   resolveCodexReasoningEffort,
   resolveCodexSpeedMode,
+  resolveOverrideBySource,
 } from './agencyConfig';
 
 describe('pruneWorkingDirByDeviceDeletes', () => {
@@ -454,5 +455,31 @@ describe('resolveAgencyConfig', () => {
     expect(resolveAgencyConfig(shared, { executionTarget: 'none' })).toEqual({
       executionTarget: 'none',
     });
+  });
+});
+
+describe('resolveOverrideBySource', () => {
+  it('returns undefined when bySource is nullish', () => {
+    expect(resolveOverrideBySource(undefined, 'd1')).toBeUndefined();
+    expect(resolveOverrideBySource(null, 'd1')).toBeUndefined();
+  });
+
+  it('matches the exact sourceDeviceId', () => {
+    const bySource = {
+      'd1': { executionTarget: 'device' as const },
+      '*': { executionTarget: 'none' as const },
+    };
+    expect(resolveOverrideBySource(bySource, 'd1')).toEqual({ executionTarget: 'device' });
+  });
+
+  it('falls back to the wildcard key', () => {
+    const bySource = { '*': { executionTarget: 'local' as const } };
+    expect(resolveOverrideBySource(bySource, 'd1')).toEqual({ executionTarget: 'local' });
+  });
+
+  it('honors the legacy flat override format', () => {
+    // Pre-per-source map shape stored the override directly on the agent key.
+    const flat = { executionTarget: 'sandbox' as const, boundDeviceId: 'dev-1' };
+    expect(resolveOverrideBySource(flat as any, 'd1')).toEqual(flat);
   });
 });

--- a/packages/types/src/agent/agencyConfig.ts
+++ b/packages/types/src/agent/agencyConfig.ts
@@ -614,6 +614,11 @@ export const resolveOverrideBySource = (
   sourceDeviceId?: string | null,
 ): Pick<LobeAgentAgencyConfig, 'boundDeviceId' | 'executionTarget'> | undefined => {
   if (!bySource) return undefined;
+  // Backward-compat: the pre-per-source map format stored the override
+  // directly (a flat AgentDeviceOverride), not a per-sourceDeviceId map.
+  if ('executionTarget' in bySource || 'boundDeviceId' in bySource) {
+    return bySource as Pick<LobeAgentAgencyConfig, 'boundDeviceId' | 'executionTarget'>;
+  }
   if (sourceDeviceId && bySource[sourceDeviceId]) return bySource[sourceDeviceId];
   if (bySource['*']) return bySource['*'];
   return undefined;

--- a/packages/types/src/agent/agencyConfig.ts
+++ b/packages/types/src/agent/agencyConfig.ts
@@ -567,9 +567,13 @@ export interface LobeAgentAgencyConfig {
  * inherently a *single* execution decision for the whole workspace. Real users
  * want each member to pick their own machine independently (see
  * `UserPreference.agentDeviceOverrides`). This helper merges the shared
- * baseline with the caller's per-agent override so every code path — client
- * device switcher, server dispatch, workingDir resolution — sees one
- * consistent "effective" config.
+ * baseline with the caller's per-agent per-platform override so every code
+ * path — client device switcher, server dispatch, workingDir resolution —
+ * sees one consistent "effective" config.
+ *
+ * When `overridesByPlatform` is provided, the correct override for `platform`
+ * is looked up first; if not found, falls back to the `'*'` key (if any).
+ * If neither exists, only `agencyConfig` is returned.
  *
  * Rules:
  * - `override.executionTarget` wins when set; falls back to shared
@@ -595,6 +599,24 @@ export const resolveAgencyConfig = (
     ...(hasTarget ? { executionTarget: override.executionTarget } : {}),
     ...(hasDevice ? { boundDeviceId: override.boundDeviceId } : {}),
   };
+};
+
+/**
+ * Resolve the best override for a given sourceDeviceId from a
+ * `AgentDeviceOverridesBySource` map. Falls back to `'*'` if no exact
+ * match. Returns `undefined` when nothing is set.
+ */
+export const resolveOverrideBySource = (
+  bySource:
+    | Record<string, Pick<LobeAgentAgencyConfig, 'boundDeviceId' | 'executionTarget'>>
+    | null
+    | undefined,
+  sourceDeviceId?: string | null,
+): Pick<LobeAgentAgencyConfig, 'boundDeviceId' | 'executionTarget'> | undefined => {
+  if (!bySource) return undefined;
+  if (sourceDeviceId && bySource[sourceDeviceId]) return bySource[sourceDeviceId];
+  if (bySource['*']) return bySource['*'];
+  return undefined;
 };
 
 /**

--- a/packages/types/src/agentExecution/index.ts
+++ b/packages/types/src/agentExecution/index.ts
@@ -161,6 +161,12 @@ export interface ExecAgentParams {
   provider?: string;
   /** The agent slug to run (either agentId or slug is required) */
   slug?: string;
+  /**
+   * Source device id of the machine making this request, used to resolve the
+   * caller's per-source-device execution override. Mirrors the key the UI
+   * switcher writes; falls back to `'*'` on the server when omitted.
+   */
+  sourceDeviceId?: string;
 }
 
 /**

--- a/packages/types/src/topic/topic.test.ts
+++ b/packages/types/src/topic/topic.test.ts
@@ -45,4 +45,12 @@ describe('chatTopicMetadataUpdateSchema', () => {
       chatTopicMetadataUpdateSchema.parse({ deviceOverride: { executionTarget: 'local' } }),
     ).toEqual({ deviceOverride: { executionTarget: 'local' } });
   });
+
+  it('accepts a topic-level modelOverride patch', () => {
+    const metadata = {
+      modelOverride: { model: 'gpt-5', provider: 'openai' },
+    };
+
+    expect(chatTopicMetadataUpdateSchema.parse(metadata)).toEqual(metadata);
+  });
 });

--- a/packages/types/src/topic/topic.test.ts
+++ b/packages/types/src/topic/topic.test.ts
@@ -34,4 +34,15 @@ describe('chatTopicMetadataUpdateSchema', () => {
 
     expect(result.success).toBe(false);
   });
+
+  it('accepts a topic-level deviceOverride patch', () => {
+    const metadata = {
+      deviceOverride: { boundDeviceId: 'dev-1', executionTarget: 'device' },
+    };
+
+    expect(chatTopicMetadataUpdateSchema.parse(metadata)).toEqual(metadata);
+    expect(
+      chatTopicMetadataUpdateSchema.parse({ deviceOverride: { executionTarget: 'local' } }),
+    ).toEqual({ deviceOverride: { executionTarget: 'local' } });
+  });
 });

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -161,6 +161,18 @@ export interface ChatTopicMetadata {
   importedFrom?: string;
   model?: string;
   /**
+   * Topic-level model override. When set, the chat-input model selector and
+   * the client/server exec paths use this model+provider instead of the
+   * agent's default for every message in this topic.
+   *
+   * Kept separate from the top-level `model`/`provider` because history
+   * compression (`internal_summaryHistory`) also writes `metadata.model` /
+   * `metadata.provider` with the *summarizer* agent — reusing those would make
+   * subsequent sends silently switch to the summarizer model. This dedicated
+   * field is the only thing the model-override path reads.
+   */
+  modelOverride?: { model: string; provider: string };
+  /**
    * Free-form feedback collected after agent onboarding completion.
    * Comment text is stored only here (not analytics) and is length-capped server-side.
    */
@@ -241,6 +253,7 @@ export const chatTopicMetadataUpdateSchema = z.object({
   heteroSessionId: z.string().optional(),
   heteroSessionIdByWorkingDirectory: z.record(z.string(), z.string()).optional(),
   model: z.string().optional(),
+  modelOverride: z.object({ model: z.string(), provider: z.string() }).optional(),
   onboardingFeedback: z
     .object({
       comment: z.string().max(500).optional(),

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -232,6 +232,12 @@ export interface ChatTopicMetadata {
 /** Metadata patch accepted by the topic update API. */
 export const chatTopicMetadataUpdateSchema = z.object({
   boundDeviceId: z.string().optional(),
+  deviceOverride: z
+    .object({
+      boundDeviceId: z.string().optional(),
+      executionTarget: z.enum(['auto', 'device', 'local', 'none', 'sandbox']).optional(),
+    })
+    .optional(),
   heteroSessionId: z.string().optional(),
   heteroSessionIdByWorkingDirectory: z.record(z.string(), z.string()).optional(),
   model: z.string().optional(),

--- a/packages/types/src/topic/topic.ts
+++ b/packages/types/src/topic/topic.ts
@@ -111,6 +111,12 @@ export interface ChatTopicMetadata {
   boundDeviceId?: string;
   cronJobId?: string;
   /**
+   * Topic-level device override. When set, wins over platform-level overrides
+   * and the agent's `agencyConfig`. Allows each topic to pin a specific
+   * execution target and/or device.
+   */
+  deviceOverride?: { executionTarget?: string; boundDeviceId?: string };
+  /**
    * Scoped pointer to the currently active assistant message for a running
    * heterogeneous agent operation. Includes `operationId` so cold-start
    * replicas only use the value when it belongs to the current operation —

--- a/packages/types/src/user/preference.ts
+++ b/packages/types/src/user/preference.ts
@@ -9,13 +9,7 @@ import type { UserOnboarding } from './onboarding';
 import type { UserSettings } from './settings';
 
 /**
- * Per-agent override for the device execution decision. Stored on
- * `workspace_user_settings.preference.agentDeviceOverrides` (see
- * {@link WorkspaceUserPreference}) and merged over `agents.agencyConfig` at
- * read time so each workspace member's Cloud Sandbox / workspace-device /
- * local-machine choice is independent — one member's pick never traps
- * another. See `resolveAgencyConfig` in
- * `packages/types/src/agent/agencyConfig.ts` for the merge implementation.
+ * Per-agent override for the device execution decision.
  *
  * Two fields only, deliberately: `executionTarget` + `boundDeviceId`.
  * `heterogeneousProvider`, `verifyRubricId`, and `workingDirByDevice` remain
@@ -28,24 +22,22 @@ export interface AgentDeviceOverride {
 }
 
 /**
+ * Per-source-device device overrides for a single agent.
+ * Key = sourceDeviceId of the physical machine the user is on
+ * (gateway deviceId on desktop, localStorage anonymous ID on web).
+ * `'*'` = fallback when no source-device-specific override exists.
+ */
+export type AgentDeviceOverridesBySource = Record<string, AgentDeviceOverride>;
+
+/**
  * Per-user preferences that only make sense inside a specific workspace.
  *
  * Stored in its own DB table (`workspace_user_settings`, PK
  * `(workspace_id, user_id)`) — the workspace-scoped counterpart to
- * `user_settings`. The dedicated table lets:
- *   - workspace / user delete cascade take out every trace in one shot;
- *   - member-list queries stay leak-free (they hit `workspace_members`, not
- *     this table);
- *   - the "workspace-scoped user preference" boundary be obvious at the
- *     schema layer.
- *
- * A single jsonb `preference` column holds this shape today (matches how
- * `users.preference` scales); if a future family grows large enough to
- * deserve its own column (à la `user_settings.hotkey` / `user_settings.tts`),
- * split it out at that point.
+ * `user_settings`.
  */
 export interface WorkspaceUserPreference {
-  agentDeviceOverrides?: Record<string /* agentId */, AgentDeviceOverride>;
+  agentDeviceOverrides?: Record<string /* agentId */, AgentDeviceOverridesBySource>;
 }
 
 export interface LobeUser {
@@ -60,110 +52,49 @@ export interface LobeUser {
 }
 
 export const UserGuideSchema = z.object({
-  /**
-   * Move the settings button to the avatar dropdown
-   */
   moveSettingsToAvatar: z.boolean().optional(),
-
-  /**
-   * Topic Guide
-   */
   topic: z.boolean().optional(),
-
-  /**
-   * tell user that uploaded files can be found in knowledge base
-   */
   uploadFileInKnowledgeBase: z.boolean().optional(),
 });
 
 export type UserGuide = z.infer<typeof UserGuideSchema>;
 
 export const UserLabSchema = z.object({
-  /**
-   * enable graph runtime configuration for agents
-   */
   enableAgentGraphConfig: z.boolean().optional(),
-  /**
-   * enable agent self-iteration feedback capture and policy execution
-   */
   enableAgentSelfIteration: z.boolean().optional(),
-  /**
-   * run Claude Code hetero sessions through the Claude Agent SDK instead of CLI spawn
-   */
   enableClaudeCodeSdk: z.boolean().optional(),
-  /**
-   * enable the Fleet view (side-by-side running-task dashboard)
-   */
   enableFleet: z.boolean().optional(),
-  /**
-   * fold a finished agent turn's process under a "已处理" header when its final answer is visible
-   */
   enableFoldFinishedTurn: z.boolean().optional(),
-  /**
-   * enable multi-agent group chat mode
-   */
   enableGroupChat: z.boolean().optional(),
-  /**
-   * enable the iMessage channel (BlueBubbles Desktop bridge)
-   */
   enableImessage: z.boolean().optional(),
-  /**
-   * show the in-app Browser tab in the conversation WorkingSidebar (desktop only)
-   */
   enableInAppBrowser: z.boolean().optional(),
-  /**
-   * enable markdown rendering in chat input editor
-   */
   enableInputMarkdown: z.boolean().optional(),
-  /**
-   * enable selecting message text and adding it to the next conversation context
-   */
   enableMessageTextSelectionActions: z.boolean().optional(),
-  /**
-   * show the "Add Platform Agent" entry in the create menu
-   */
   enablePlatformAgent: z.boolean().optional(),
-  /**
-   * enable the task delivery-acceptance (verify) config UI on the task detail
-   */
   enableTaskVerify: z.boolean().optional(),
 });
 
 export type UserLab = z.infer<typeof UserLabSchema>;
 
 export interface UserPreference {
-  /** Last-used app for "Open working directory in…" split button. Empty/unknown values fall back to platform default. */
   defaultOpenInApp?: string;
-  /**
-   * disable markdown rendering in chat input editor
-   * @deprecated Use lab.enableInputMarkdown instead
-   */
+
   disableInputMarkdownRender?: boolean;
+
   guide?: UserGuide;
   hideSyncAlert?: boolean;
-  /**
-   * lab experimental features
-   */
   lab?: UserLab;
-  /**
-   * Last active workspace id. Used on cloud to land the user back in the
-   * workspace they last used when they open `/` — `null` means personal
-   * context. Stored as id (not slug) so workspace renames don't invalidate it.
-   */
   lastWorkspaceId?: string | null;
   /**
-   * @deprecated Use settings.general.telemetry instead
+   * Per-agent per-source-device device overrides for personal agents.
+   * Same structure as WorkspaceUserPreference.agentDeviceOverrides.
+   * Persisted to `users.preference` JSONB column.
    */
+  personalDeviceOverrides?: Record<string /* agentId */, AgentDeviceOverridesBySource>;
   telemetry?: boolean | null;
   topicGroupMode?: TopicGroupMode;
-  /**
-   * whether to include completed topics in the topic list
-   */
   topicIncludeCompleted?: boolean;
   topicSortBy?: TopicSortBy;
-  /**
-   * whether to use cmd + enter to send message
-   */
   useCmdEnterToSend?: boolean;
 }
 
@@ -181,14 +112,10 @@ export interface UserInitializationState {
   hasConversation?: boolean;
   interests?: string[];
   isFreePlan?: boolean;
-  /** @deprecated Use onboarding field instead */
   isOnboard?: boolean;
   lastName?: string;
   onboarding?: UserOnboarding;
   preference: UserPreference;
-  /**
-   * Referral lifecycle status for the current user (invitee side).
-   */
   referralStatus?: ReferralStatusString;
   settings: PartialDeep<UserSettings>;
   subscriptionPlan?: Plans;
@@ -201,12 +128,8 @@ export const OAuthAccountSchema = z.object({
   providerAccountId: z.string(),
 });
 
-/**
- * SSO Provider info displayed in profile page
- */
 export interface SSOProvider {
   email?: string;
-  /** Expiration time - Date for better-auth */
   expiresAt?: Date | number | null;
   provider: string;
   providerAccountId: string;

--- a/packages/types/src/user/preference.ts
+++ b/packages/types/src/user/preference.ts
@@ -135,6 +135,13 @@ export interface SSOProvider {
   providerAccountId: string;
 }
 
+const agentDeviceOverrideSchema = z.object({
+  boundDeviceId: z.string().optional(),
+  executionTarget: z.enum(['auto', 'device', 'local', 'none', 'sandbox']).optional(),
+});
+
+const agentDeviceOverridesBySourceSchema = z.record(z.string(), agentDeviceOverrideSchema);
+
 export const UserPreferenceSchema = z
   .object({
     defaultOpenInApp: z.string().optional(),
@@ -142,6 +149,7 @@ export const UserPreferenceSchema = z
     hideSyncAlert: z.boolean().optional(),
     lab: UserLabSchema.optional(),
     lastWorkspaceId: z.string().nullish(),
+    personalDeviceOverrides: z.record(z.string(), agentDeviceOverridesBySourceSchema).optional(),
     telemetry: z.boolean().nullable(),
     topicGroupMode: z.enum(['byTime', 'byProject', 'flat', 'byStatus']).optional(),
     topicIncludeCompleted: z.boolean().optional(),

--- a/src/features/ChatInput/ActionBar/Model/index.tsx
+++ b/src/features/ChatInput/ActionBar/Model/index.tsx
@@ -67,8 +67,8 @@ const ModelSwitch = memo(() => {
   const topicModelOverride = useChatStore((s) => {
     if (!activeTopicId) return undefined;
     const topic = topicSelectors.getTopicById(activeTopicId)(s);
-    if (!topic?.metadata?.model) return undefined;
-    return { model: topic.metadata.model, provider: topic.metadata.provider || '' };
+    if (!topic?.metadata?.modelOverride) return undefined;
+    return topic.metadata.modelOverride;
   });
 
   const model = topicModelOverride?.model || agentModel;
@@ -82,8 +82,7 @@ const ModelSwitch = memo(() => {
 
       if (activeTopicId) {
         await updateTopicMetadata(activeTopicId, {
-          model: config.model,
-          provider: config.provider,
+          modelOverride: { model: config.model, provider: config.provider },
         });
       } else {
         await updateAgentConfigById(agentId, config);

--- a/src/features/ChatInput/ActionBar/Model/index.tsx
+++ b/src/features/ChatInput/ActionBar/Model/index.tsx
@@ -8,6 +8,8 @@ import ModelSwitchPanel from '@/features/ModelSwitchPanel';
 import { usePermission } from '@/hooks/usePermission';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
+import { useChatStore } from '@/store/chat';
+import { topicSelectors } from '@/store/chat/selectors';
 
 import { useAgentId } from '../../hooks/useAgentId';
 import { useActionBarContext } from '../context';
@@ -53,20 +55,48 @@ const ModelSwitch = memo(() => {
   const { allowed: canCreateContent, reason } = usePermission('create_content');
 
   const agentId = useAgentId();
-  const [model, provider, updateAgentConfigById] = useAgentStore((s) => [
-    agentByIdSelectors.getAgentModelById(agentId)(s),
-    agentByIdSelectors.getAgentModelProviderById(agentId)(s),
-    s.updateAgentConfigById,
-  ]);
+  const agentModel = useAgentStore(agentByIdSelectors.getAgentModelById(agentId));
+  const agentProvider = useAgentStore(agentByIdSelectors.getAgentModelProviderById(agentId));
+  const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
   const applyBusinessModelModeConfig = useBusinessModelModeConfig();
+
+  const [activeTopicId, updateTopicMetadata] = useChatStore((s) => [
+    s.activeTopicId,
+    s.updateTopicMetadata,
+  ]);
+  const topicModelOverride = useChatStore((s) => {
+    if (!activeTopicId) return undefined;
+    const topic = topicSelectors.getTopicById(activeTopicId)(s);
+    if (!topic?.metadata?.model) return undefined;
+    return { model: topic.metadata.model, provider: topic.metadata.provider || '' };
+  });
+
+  const model = topicModelOverride?.model || agentModel;
+  const provider = topicModelOverride?.provider || agentProvider;
 
   const handleModelChange = useCallback(
     async (params: { model: string; provider: string }) => {
       if (!canCreateContent) return;
 
-      await updateAgentConfigById(agentId, applyBusinessModelModeConfig(params));
+      const config = applyBusinessModelModeConfig(params);
+
+      if (activeTopicId) {
+        await updateTopicMetadata(activeTopicId, {
+          model: config.model,
+          provider: config.provider,
+        });
+      } else {
+        await updateAgentConfigById(agentId, config);
+      }
     },
-    [agentId, applyBusinessModelModeConfig, canCreateContent, updateAgentConfigById],
+    [
+      activeTopicId,
+      agentId,
+      applyBusinessModelModeConfig,
+      canCreateContent,
+      updateAgentConfigById,
+      updateTopicMetadata,
+    ],
   );
 
   const trigger = (

--- a/src/features/ChatInput/ActionBar/ModelLabel/index.tsx
+++ b/src/features/ChatInput/ActionBar/ModelLabel/index.tsx
@@ -64,8 +64,8 @@ const ModelLabel = memo(() => {
   const topicModelOverride = useChatStore((s) => {
     if (!activeTopicId) return undefined;
     const topic = topicSelectors.getTopicById(activeTopicId)(s);
-    if (!topic?.metadata?.model) return undefined;
-    return { model: topic.metadata.model, provider: topic.metadata.provider || '' };
+    if (!topic?.metadata?.modelOverride) return undefined;
+    return topic.metadata.modelOverride;
   });
 
   const model = topicModelOverride?.model || agentModel;
@@ -82,8 +82,7 @@ const ModelLabel = memo(() => {
 
       if (activeTopicId) {
         await updateTopicMetadata(activeTopicId, {
-          model: config.model,
-          provider: config.provider,
+          modelOverride: { model: config.model, provider: config.provider },
         });
       } else {
         await updateAgentConfigById(agentId, config);

--- a/src/features/ChatInput/ActionBar/ModelLabel/index.tsx
+++ b/src/features/ChatInput/ActionBar/ModelLabel/index.tsx
@@ -9,6 +9,8 @@ import { usePermission } from '@/hooks/usePermission';
 import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
+import { useChatStore } from '@/store/chat';
+import { topicSelectors } from '@/store/chat/selectors';
 
 import { useAgentId } from '../../hooks/useAgentId';
 import { useActionBarContext } from '../context';
@@ -50,12 +52,24 @@ const ModelLabel = memo(() => {
   const { allowed: canCreateContent, reason } = usePermission('create_content');
 
   const agentId = useAgentId();
-  const [model, provider, updateAgentConfigById] = useAgentStore((s) => [
-    agentByIdSelectors.getAgentModelById(agentId)(s),
-    agentByIdSelectors.getAgentModelProviderById(agentId)(s),
-    s.updateAgentConfigById,
-  ]);
+  const agentModel = useAgentStore(agentByIdSelectors.getAgentModelById(agentId));
+  const agentProvider = useAgentStore(agentByIdSelectors.getAgentModelProviderById(agentId));
+  const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
   const applyBusinessModelModeConfig = useBusinessModelModeConfig();
+
+  const [activeTopicId, updateTopicMetadata] = useChatStore((s) => [
+    s.activeTopicId,
+    s.updateTopicMetadata,
+  ]);
+  const topicModelOverride = useChatStore((s) => {
+    if (!activeTopicId) return undefined;
+    const topic = topicSelectors.getTopicById(activeTopicId)(s);
+    if (!topic?.metadata?.model) return undefined;
+    return { model: topic.metadata.model, provider: topic.metadata.provider || '' };
+  });
+
+  const model = topicModelOverride?.model || agentModel;
+  const provider = topicModelOverride?.provider || agentProvider;
 
   const enabledModel = useAiInfraStore(aiModelSelectors.getEnabledModelById(model, provider));
   const displayName = enabledModel?.displayName || model;
@@ -64,9 +78,25 @@ const ModelLabel = memo(() => {
     async (params: { model: string; provider: string }) => {
       if (!canCreateContent) return;
 
-      await updateAgentConfigById(agentId, applyBusinessModelModeConfig(params));
+      const config = applyBusinessModelModeConfig(params);
+
+      if (activeTopicId) {
+        await updateTopicMetadata(activeTopicId, {
+          model: config.model,
+          provider: config.provider,
+        });
+      } else {
+        await updateAgentConfigById(agentId, config);
+      }
     },
-    [agentId, applyBusinessModelModeConfig, canCreateContent, updateAgentConfigById],
+    [
+      activeTopicId,
+      agentId,
+      applyBusinessModelModeConfig,
+      canCreateContent,
+      updateAgentConfigById,
+      updateTopicMetadata,
+    ],
   );
 
   const trigger = (

--- a/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
+++ b/src/features/ChatInput/ControlBar/HeteroDeviceSwitcher.tsx
@@ -4,7 +4,7 @@ import { SiApple, SiLinux } from '@icons-pack/react-simple-icons';
 import { isDesktop } from '@lobechat/const';
 import { isRemoteHeterogeneousType } from '@lobechat/heterogeneous-agents';
 import type { DeviceExecutionTarget } from '@lobechat/types';
-import { resolveAgencyConfig } from '@lobechat/types';
+import { resolveAgencyConfig, resolveOverrideBySource } from '@lobechat/types';
 import { Microsoft } from '@lobehub/icons';
 import { Flexbox, Icon, Popover, Tooltip } from '@lobehub/ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
@@ -34,6 +34,7 @@ import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useElectronStore } from '@/store/electron';
 import { useUserStore } from '@/store/user';
 import { workspaceUserSettingsSelectors } from '@/store/user/selectors';
+import { getSourceDeviceId } from '@/utils/sourceDevice';
 
 const styles = createStaticStyles(({ css }) => ({
   button: css`
@@ -359,7 +360,27 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
   const { isLoading: isWorkspacePreferenceLoading } = useUserStore(
     (s) => s.useFetchWorkspaceUserPreference,
   )();
-  const override = useUserStore(workspaceUserSettingsSelectors.agentDeviceOverrideById(agentId));
+
+  const { data: devices, isLoading } = lambdaQuery.device.listDevices.useQuery(undefined, {
+    staleTime: 30_000,
+  });
+
+  // The current machine's own gateway deviceId (desktop only)
+  useElectronStore((s) => s.useFetchGatewayDeviceInfo)();
+  const gatewayDeviceInfo = useElectronStore((s) => s.gatewayDeviceInfo);
+  const currentDeviceId = isDesktop ? gatewayDeviceInfo?.deviceId : undefined;
+
+  // Per-source-device override resolution
+  const sourceDeviceId = isDesktop ? currentDeviceId : getSourceDeviceId();
+  const workspaceOverride = useUserStore(
+    workspaceUserSettingsSelectors.agentDeviceOverrideById(agentId, sourceDeviceId),
+  );
+  const personalOverride = useUserStore((s) => {
+    if (isWorkspaceAgent) return undefined;
+    const bySource = s.preference?.personalDeviceOverrides?.[agentId];
+    return resolveOverrideBySource(bySource, sourceDeviceId);
+  });
+  const override = isWorkspaceAgent ? workspaceOverride : personalOverride;
   const agencyConfig = resolveAgencyConfig(sharedAgencyConfig, override);
 
   const heteroType = agencyConfig?.heterogeneousProvider?.type;
@@ -370,17 +391,6 @@ const HeteroDeviceSwitcher = memo<HeteroDeviceSwitcherProps>(({ agentId }) => {
   // (plain chat, no execution environment) isn't a valid target for them: hide
   // the option and never fall back to / honour a stale stored `'none'`.
   const isHetero = !!heteroType;
-
-  const { data: devices, isLoading } = lambdaQuery.device.listDevices.useQuery(undefined, {
-    staleTime: 30_000,
-  });
-
-  // The current machine's own gateway deviceId (desktop only), used to badge the
-  // matching device row with a "This device" tag and show the local-process
-  // description instead of the generic online/offline status.
-  useElectronStore((s) => s.useFetchGatewayDeviceInfo)();
-  const gatewayDeviceInfo = useElectronStore((s) => s.gatewayDeviceInfo);
-  const currentDeviceId = isDesktop ? gatewayDeviceInfo?.deviceId : undefined;
 
   // Effective target: `resolveExecutionTarget` runs over the *merged*
   // `agencyConfig` (shared + this user's LOBE-11689 override), so what the

--- a/src/features/ChatInput/hooks/useSelectExecutionTarget.test.ts
+++ b/src/features/ChatInput/hooks/useSelectExecutionTarget.test.ts
@@ -22,11 +22,21 @@ const testState = vi.hoisted(() => ({
   getDeviceInfo: vi.fn(),
   isDesktop: false,
   user: {
+    preference: {
+      personalDeviceOverrides: undefined as
+        | Record<string, Record<string, { boundDeviceId?: string; executionTarget?: string }>>
+        | undefined,
+    },
+    updatePreference: vi.fn(),
     updateWorkspaceUserPreference: vi.fn(),
     workspaceUserPreference: {} as {
       agentDeviceOverrides?: Record<string, { boundDeviceId?: string; executionTarget?: string }>;
     },
   },
+}));
+
+vi.mock('@/utils/sourceDevice', () => ({
+  getSourceDeviceId: () => 'web-device-1',
 }));
 
 vi.mock('@lobechat/const', () => ({
@@ -70,20 +80,25 @@ describe('useSelectExecutionTarget', () => {
     testState.electron.gatewayDeviceInfo = undefined;
     testState.getDeviceInfo = vi.fn();
     testState.isDesktop = false;
+    testState.user.preference = { personalDeviceOverrides: undefined };
+    testState.user.updatePreference = vi.fn();
     testState.user.workspaceUserPreference = {};
     testState.user.updateWorkspaceUserPreference = vi.fn();
   });
 
-  describe('personal agent — writes to the shared agencyConfig', () => {
+  describe('personal agent — writes to users.preference.personalDeviceOverrides (per source device)', () => {
     it('persists the target as-is when switching to sandbox, keeping any existing boundDeviceId', async () => {
       testState.agent.agencyConfig = { boundDeviceId: 'device-1', executionTarget: 'local' };
       const { result } = renderHook(() => useSelectExecutionTarget('agent-id'));
 
       await result.current('sandbox');
 
-      expect(testState.agent.updateAgentConfigById).toHaveBeenCalledWith('agent-id', {
-        agencyConfig: { boundDeviceId: 'device-1', executionTarget: 'sandbox' },
+      expect(testState.user.updatePreference).toHaveBeenCalledWith({
+        personalDeviceOverrides: {
+          'agent-id': { 'web-device-1': { boundDeviceId: 'device-1', executionTarget: 'sandbox' } },
+        },
       });
+      expect(testState.agent.updateAgentConfigById).not.toHaveBeenCalled();
       expect(testState.user.updateWorkspaceUserPreference).not.toHaveBeenCalled();
     });
 
@@ -92,9 +107,12 @@ describe('useSelectExecutionTarget', () => {
 
       await result.current('device', 'device-2');
 
-      expect(testState.agent.updateAgentConfigById).toHaveBeenCalledWith('agent-id', {
-        agencyConfig: { boundDeviceId: 'device-2', executionTarget: 'device' },
+      expect(testState.user.updatePreference).toHaveBeenCalledWith({
+        personalDeviceOverrides: {
+          'agent-id': { 'web-device-1': { boundDeviceId: 'device-2', executionTarget: 'device' } },
+        },
       });
+      expect(testState.agent.updateAgentConfigById).not.toHaveBeenCalled();
     });
 
     it("stores 'local' verbatim (not pre-resolved to 'device') to preserve the in-process IPC path", async () => {
@@ -105,8 +123,12 @@ describe('useSelectExecutionTarget', () => {
       await result.current('local');
 
       expect(testState.getDeviceInfo).not.toHaveBeenCalled();
-      expect(testState.agent.updateAgentConfigById).toHaveBeenCalledWith('agent-id', {
-        agencyConfig: { boundDeviceId: 'this-machine', executionTarget: 'local' },
+      expect(testState.user.updatePreference).toHaveBeenCalledWith({
+        personalDeviceOverrides: {
+          'agent-id': {
+            'this-machine': { boundDeviceId: 'this-machine', executionTarget: 'local' },
+          },
+        },
       });
     });
 
@@ -118,8 +140,10 @@ describe('useSelectExecutionTarget', () => {
       await result.current('local');
 
       expect(testState.getDeviceInfo).toHaveBeenCalled();
-      expect(testState.agent.updateAgentConfigById).toHaveBeenCalledWith('agent-id', {
-        agencyConfig: { boundDeviceId: 'resolved-device', executionTarget: 'local' },
+      expect(testState.user.updatePreference).toHaveBeenCalledWith({
+        personalDeviceOverrides: {
+          'agent-id': { '*': { boundDeviceId: 'resolved-device', executionTarget: 'local' } },
+        },
       });
     });
 
@@ -130,8 +154,10 @@ describe('useSelectExecutionTarget', () => {
 
       await result.current('local');
 
-      expect(testState.agent.updateAgentConfigById).toHaveBeenCalledWith('agent-id', {
-        agencyConfig: { boundDeviceId: 'stale-device', executionTarget: 'local' },
+      expect(testState.user.updatePreference).toHaveBeenCalledWith({
+        personalDeviceOverrides: {
+          'agent-id': { 'web-device-1': { executionTarget: 'local' } },
+        },
       });
     });
 
@@ -142,8 +168,24 @@ describe('useSelectExecutionTarget', () => {
 
       await result.current('local');
 
-      expect(testState.agent.updateAgentConfigById).not.toHaveBeenCalled();
+      expect(testState.user.updatePreference).not.toHaveBeenCalled();
       expect(testState.user.updateWorkspaceUserPreference).not.toHaveBeenCalled();
+    });
+
+    it('merges into an existing personalDeviceOverrides without dropping other agents', async () => {
+      testState.user.preference.personalDeviceOverrides = {
+        'other-agent': { '*': { executionTarget: 'sandbox' } },
+      };
+      const { result } = renderHook(() => useSelectExecutionTarget('agent-id'));
+
+      await result.current('device', 'device-3');
+
+      expect(testState.user.updatePreference).toHaveBeenCalledWith({
+        personalDeviceOverrides: {
+          'other-agent': { '*': { executionTarget: 'sandbox' } },
+          'agent-id': { 'web-device-1': { boundDeviceId: 'device-3', executionTarget: 'device' } },
+        },
+      });
     });
   });
 
@@ -159,7 +201,9 @@ describe('useSelectExecutionTarget', () => {
 
       expect(testState.user.updateWorkspaceUserPreference).toHaveBeenCalledWith({
         agentDeviceOverrides: {
-          'agent-id': { boundDeviceId: 'ws-device-1', executionTarget: 'device' },
+          'agent-id': {
+            'web-device-1': { boundDeviceId: 'ws-device-1', executionTarget: 'device' },
+          },
         },
       });
       expect(testState.agent.updateAgentConfigById).not.toHaveBeenCalled();
@@ -174,7 +218,9 @@ describe('useSelectExecutionTarget', () => {
 
       expect(testState.user.updateWorkspaceUserPreference).toHaveBeenCalledWith({
         agentDeviceOverrides: {
-          'agent-id': { boundDeviceId: 'this-machine', executionTarget: 'local' },
+          'agent-id': {
+            'this-machine': { boundDeviceId: 'this-machine', executionTarget: 'local' },
+          },
         },
       });
       expect(testState.agent.updateAgentConfigById).not.toHaveBeenCalled();
@@ -193,7 +239,7 @@ describe('useSelectExecutionTarget', () => {
       expect(testState.user.updateWorkspaceUserPreference).toHaveBeenCalledWith({
         agentDeviceOverrides: {
           'other-agent': { boundDeviceId: 'other-device', executionTarget: 'device' },
-          'agent-id': { executionTarget: 'sandbox' },
+          'agent-id': { 'web-device-1': { executionTarget: 'sandbox' } },
         },
       });
     });
@@ -205,7 +251,7 @@ describe('useSelectExecutionTarget', () => {
       await result.current('sandbox');
 
       expect(testState.user.updateWorkspaceUserPreference).toHaveBeenCalledWith({
-        agentDeviceOverrides: { 'agent-id': { executionTarget: 'sandbox' } },
+        agentDeviceOverrides: { 'agent-id': { 'web-device-1': { executionTarget: 'sandbox' } } },
       });
     });
   });

--- a/src/features/ChatInput/hooks/useSelectExecutionTarget.ts
+++ b/src/features/ChatInput/hooks/useSelectExecutionTarget.ts
@@ -9,49 +9,30 @@ import { useAgentStore } from '@/store/agent';
 import { agentByIdSelectors } from '@/store/agent/selectors';
 import { useElectronStore } from '@/store/electron';
 import { useUserStore } from '@/store/user';
+import { getSourceDeviceId } from '@/utils/sourceDevice';
 
 /**
- * Persist an execution-target selection for an agent. Shared by the device
- * switcher and the sandbox notice so the `local` device-id resolution (which
- * has to find this machine's gateway `deviceId`) lives in one place.
+ * Persist an execution-target selection for an agent.
  *
- * `executionTarget` is the single source of truth — the server tool gate +
- * client `getRuntimeModeById` derive `runtimeMode` from it.
- *
- * Storage split (LOBE-11689):
- * - **Personal agent** — writes go straight into the shared
- *   `agents.agencyConfig` (there's only ever one owner, so there's nothing to
- *   isolate).
- * - **Workspace agent** — writes go into
- *   `workspace_user_settings.preference.agentDeviceOverrides[agentId]`
- *   (per-user per-workspace) so each member's Cloud Sandbox / workspace-device
- *   / this-machine choice stays independent. The shared `agents.agencyConfig`
- *   is left as-is, becoming the group-wide fallback for members who haven't
- *   chosen anything yet. Reads / writes are cached through the
- *   `workspaceUserSettings` slice of the user store, keyed on the active
- *   workspaceId.
- *
- * `local` is stored verbatim (`{ executionTarget: 'local', boundDeviceId: <me> }`)
- * so both desktop dispatch (in-process IPC — the fast path) and web dispatch
- * (server-side coercion to `device` via the existing gateway rule) keep their
- * respective semantics. That's why the old
- * `if (target === 'local' && isWorkspaceAgent) return;` guard is gone: with
- * per-user overrides my choice can't hurt other members.
+ * Storage:
+ * - **Personal agent** — writes to
+ *   `users.preference.personalDeviceOverrides[agentId][sourceDeviceId]`
+ *   so each machine's choice is independent. `agents.agencyConfig` is left
+ *   untouched (old data remains as fallback; new agents stay null → platform default).
+ * - **Workspace agent** — writes to
+ *   `workspace_user_settings.preference.agentDeviceOverrides[agentId][sourceDeviceId]`
+ *   (per-user per-workspace per-device).
  */
 export const useSelectExecutionTarget = (agentId: string) => {
   const agencyConfig = useAgentStore(agentByIdSelectors.getAgencyConfigById(agentId));
   const isHetero = useAgentStore(agentByIdSelectors.isAgentHeterogeneousById(agentId));
   const isWorkspaceAgent = useAgentStore((s) => Boolean(s.agentMap[agentId]?.workspaceId));
-  const updateAgentConfigById = useAgentStore((s) => s.updateAgentConfigById);
 
   const updateWorkspaceUserPreference = useUserStore((s) => s.updateWorkspaceUserPreference);
-  // Latest known bucket so the write below can splice a single agentId leaf
-  // without stomping any of the caller's other agent overrides in this
-  // workspace. Optimistic merge inside the action keeps this in sync.
+  const updatePreference = useUserStore((s) => s.updatePreference);
   const workspaceUserPreference = useUserStore((s) => s.workspaceUserPreference);
+  const userPreference = useUserStore((s) => s.preference);
 
-  // The current machine's own gateway deviceId (desktop only); used to pin a
-  // `local` selection to this device.
   const gatewayDeviceInfo = useElectronStore((s) => s.gatewayDeviceInfo);
   const currentDeviceId = isDesktop ? gatewayDeviceInfo?.deviceId : undefined;
 
@@ -68,44 +49,35 @@ export const useSelectExecutionTarget = (agentId: string) => {
             nextBoundDeviceId = undefined;
           }
         }
-        // Hetero agents must execute somewhere; without a resolvable local
-        // device there is nothing to pin `local` to, so don't switch.
         if (isHetero && !nextBoundDeviceId) return;
       }
 
-      // Store the intent verbatim (`local` stays `local`), not a
-      // pre-resolved `device`. Two reasons:
-      //
-      // 1. Semantic parity with personal agents. `local` and `device` are
-      //    distinct at dispatch time — `local` runs in-process on the
-      //    desktop, `device` tunnels through the gateway (even when the
-      //    bound device *is* this desktop). Persisting `device` would rob a
-      //    workspace-mode `local` pick of the faster in-process path when
-      //    the run happens on this desktop, and change personal-agent
-      //    behaviour (which used to store `local` verbatim).
-      // 2. On surfaces without a client (web / server dispatch),
-      //    `resolveExecutionTarget` already coerces a stored `local` +
-      //    `boundDeviceId` to `device` when a gateway is available, so the
-      //    server-side dispatch path Just Works — no need to pre-coerce here.
+      const override = {
+        executionTarget: target,
+        ...(nextBoundDeviceId ? { boundDeviceId: nextBoundDeviceId } : {}),
+      };
+      const sourceDeviceId = isDesktop ? currentDeviceId : getSourceDeviceId();
+      const sourceKey = sourceDeviceId || '*';
+
       if (isWorkspaceAgent) {
+        const bySource = workspaceUserPreference.agentDeviceOverrides?.[agentId] as
+          Record<string, any> | undefined;
         const nextOverrides = {
           ...workspaceUserPreference.agentDeviceOverrides,
-          [agentId]: {
-            executionTarget: target,
-            ...(nextBoundDeviceId ? { boundDeviceId: nextBoundDeviceId } : {}),
-          },
+          [agentId]: { ...bySource, [sourceKey]: override },
         };
         await updateWorkspaceUserPreference({ agentDeviceOverrides: nextOverrides });
         return;
       }
 
-      await updateAgentConfigById(agentId, {
-        agencyConfig: {
-          ...agencyConfig,
-          executionTarget: target,
-          ...(nextBoundDeviceId ? { boundDeviceId: nextBoundDeviceId } : {}),
-        },
-      });
+      // Personal agent
+      const bySource = userPreference.personalDeviceOverrides?.[agentId] as
+        Record<string, any> | undefined;
+      const nextOverrides = {
+        ...userPreference.personalDeviceOverrides,
+        [agentId]: { ...bySource, [sourceKey]: override },
+      };
+      await updatePreference({ personalDeviceOverrides: nextOverrides });
     },
     [
       agentId,
@@ -113,9 +85,10 @@ export const useSelectExecutionTarget = (agentId: string) => {
       currentDeviceId,
       isHetero,
       isWorkspaceAgent,
-      updateAgentConfigById,
       updateWorkspaceUserPreference,
+      updatePreference,
       workspaceUserPreference,
+      userPreference,
     ],
   );
 };

--- a/src/features/ChatInput/hooks/useSelectExecutionTarget.ts
+++ b/src/features/ChatInput/hooks/useSelectExecutionTarget.ts
@@ -59,9 +59,19 @@ export const useSelectExecutionTarget = (agentId: string) => {
       const sourceDeviceId = isDesktop ? currentDeviceId : getSourceDeviceId();
       const sourceKey = sourceDeviceId || '*';
 
+      // A legacy flat override (`{ executionTarget, boundDeviceId }`) reads as a
+      // whole-object override in `resolveOverrideBySource`, so it would shadow
+      // the new per-source entry. Normalize it to a `'*'` source key first.
+      const normalizeBySource = (
+        raw: Record<string, any> | undefined,
+      ): Record<string, any> | undefined =>
+        raw && ('executionTarget' in raw || 'boundDeviceId' in raw) ? { '*': raw } : raw;
+
       if (isWorkspaceAgent) {
-        const bySource = workspaceUserPreference.agentDeviceOverrides?.[agentId] as
-          Record<string, any> | undefined;
+        const bySource = normalizeBySource(
+          workspaceUserPreference.agentDeviceOverrides?.[agentId] as
+            Record<string, any> | undefined,
+        );
         const nextOverrides = {
           ...workspaceUserPreference.agentDeviceOverrides,
           [agentId]: { ...bySource, [sourceKey]: override },
@@ -71,8 +81,9 @@ export const useSelectExecutionTarget = (agentId: string) => {
       }
 
       // Personal agent
-      const bySource = userPreference.personalDeviceOverrides?.[agentId] as
-        Record<string, any> | undefined;
+      const bySource = normalizeBySource(
+        userPreference.personalDeviceOverrides?.[agentId] as Record<string, any> | undefined,
+      );
       const nextOverrides = {
         ...userPreference.personalDeviceOverrides,
         [agentId]: { ...bySource, [sourceKey]: override },

--- a/src/features/Conversation/store/slices/generation/action.ts
+++ b/src/features/Conversation/store/slices/generation/action.ts
@@ -5,6 +5,7 @@ import type {
   ConversationContext,
   HeterogeneousProviderConfig,
 } from '@lobechat/types';
+import { resolveAgencyConfig } from '@lobechat/types';
 import { t } from 'i18next';
 import { type StateCreator } from 'zustand';
 
@@ -22,6 +23,7 @@ import {
   parseSelectedSkillsFromEditorData,
   parseSelectedToolsFromEditorData,
 } from '@/store/chat/slices/agentRun/actions/entries/commandBus';
+import { resolveDeviceOverrideForAgent } from '@/store/chat/slices/agentRun/actions/entries/conversationLifecycle';
 import { resolveHeteroResume } from '@/store/chat/slices/agentRun/actions/transports/hetero/heteroResume';
 import { operationSelectors } from '@/store/chat/slices/operation/selectors';
 import { INPUT_LOADING_OPERATION_TYPES } from '@/store/chat/slices/operation/types';
@@ -442,9 +444,15 @@ export const generationSlice: StateCreator<
     }
 
     const agentConfig = agentSelectors.getAgentConfigById(context.agentId)(getAgentStoreState());
+    // Mirror `conversationLifecycle` runtime selection: honor a personal/workspace
+    // per-source-device override even though `agentConfig.agencyConfig` is untouched.
+    const effectiveAgencyConfig = resolveAgencyConfig(
+      agentConfig?.agencyConfig,
+      resolveDeviceOverrideForAgent(context.agentId) ?? null,
+    );
     const runtimeType = selectRuntimeType({
-      boundDeviceId: agentConfig?.agencyConfig?.boundDeviceId,
-      executionTarget: agentConfig?.agencyConfig?.executionTarget,
+      boundDeviceId: effectiveAgencyConfig?.boundDeviceId,
+      executionTarget: effectiveAgencyConfig?.executionTarget,
       heterogeneousProvider: agentConfig?.agencyConfig?.heterogeneousProvider,
       isGatewayMode: chatStore.isGatewayModeEnabled(context.agentId),
       isWorkspaceAgent: agentByIdSelectors.isWorkspaceAgentById(context.agentId)(
@@ -896,9 +904,14 @@ export const generationSlice: StateCreator<
 
       const agentConfig = agentSelectors.getAgentConfigById(context.agentId)(getAgentStoreState());
       const heterogeneousProvider = agentConfig?.agencyConfig?.heterogeneousProvider;
+      // Honor a personal/workspace per-source-device override here too.
+      const effectiveAgencyConfig = resolveAgencyConfig(
+        agentConfig?.agencyConfig,
+        resolveDeviceOverrideForAgent(context.agentId) ?? null,
+      );
       const runtimeType = selectRuntimeType({
-        boundDeviceId: agentConfig?.agencyConfig?.boundDeviceId,
-        executionTarget: agentConfig?.agencyConfig?.executionTarget,
+        boundDeviceId: effectiveAgencyConfig?.boundDeviceId,
+        executionTarget: effectiveAgencyConfig?.executionTarget,
         heterogeneousProvider,
         isGatewayMode: chatStore.isGatewayModeEnabled(context.agentId),
         isWorkspaceAgent: agentByIdSelectors.isWorkspaceAgentById(context.agentId)(

--- a/src/services/aiAgent.ts
+++ b/src/services/aiAgent.ts
@@ -65,9 +65,13 @@ export interface ExecAgentTaskParams {
    * context so the supervisor run delegates to them instead of answering itself.
    */
   mentionedAgents?: RuntimeMentionedAgent[];
+  /** Topic-level model override, forwarded so the server run uses the topic's pinned model. */
+  model?: string;
   /** Parent message ID for regeneration/continue (skip user message creation, branch from this message) */
   parentMessageId?: string;
   prompt: string;
+  /** Topic-level provider override, forwarded alongside `model`. */
+  provider?: string;
   /** Resume a previous op paused on `human_approve_required` instead of starting from a fresh user prompt. */
   resumeApproval?: ResumeApprovalParam;
   /** Resume a previous op paused on a human-intervention tool by carrying the human answer as the tool result. */

--- a/src/services/aiAgent.ts
+++ b/src/services/aiAgent.ts
@@ -79,6 +79,8 @@ export interface ExecAgentTaskParams {
   /** Tool identifiers the user @-mentioned in this message; the server enables them for this run. */
   selectedToolIds?: string[];
   slug?: string;
+  /** Source device id of the requesting machine, forwarded for per-source override resolution. */
+  sourceDeviceId?: string;
   /**
    * Override what initiated this operation. Server defaults to `'chat'` when
    * omitted. Pass a more specific value (`'cli'`, `'openapi'`, …) so the

--- a/src/services/chat/mecha/agentConfigResolver.ts
+++ b/src/services/chat/mecha/agentConfigResolver.ts
@@ -127,7 +127,9 @@ export interface AgentConfigResolverContext {
    * Topic-level model/provider override.
    * When set, overrides the agent's model/provider so each topic can use a
    * different model. The caller (streamingExecutor) reads this from
-   * `topic.metadata.model` / `topic.metadata.provider`.
+   * `topic.metadata.modelOverride` — a dedicated field, kept separate from the
+   * top-level `metadata.model`/`provider` that history compression writes with
+   * the *summarizer* model.
    */
   topicModelOverride?: { model: string; provider: string };
 }

--- a/src/services/chat/mecha/agentConfigResolver.ts
+++ b/src/services/chat/mecha/agentConfigResolver.ts
@@ -6,9 +6,11 @@ import { type LobeToolManifest } from '@lobechat/context-engine';
 import {
   type ChatCompletionTool,
   getActivePluginIds,
+  type LobeAgentAgencyConfig,
   type LobeAgentChatConfig,
   type LobeAgentConfig,
   type MessageMapScope,
+  resolveOverrideBySource,
 } from '@lobechat/types';
 import debug from 'debug';
 import { produce } from 'immer';
@@ -104,8 +106,22 @@ export interface AgentConfigResolverContext {
 
   /** Message map scope (e.g., 'page', 'main', 'thread') */
   scope?: MessageMapScope;
+  /**
+   * Source deviceId identifying the physical machine the user is currently on.
+   * On desktop this is the local gateway deviceId; on web it's undefined or
+   * a synthetic key. Used to look up per-source-device overrides in
+   * `users.preference.agentDeviceOverrides[agentId][sourceDeviceId]`.
+   */
+  sourceDeviceId?: string;
+
   /** Target agent config for agent-builder */
   targetAgentConfig?: LobeAgentConfig;
+
+  /**
+   * Topic-level device override. When set, wins over source-device overrides
+   * and the agent's agencyConfig.
+   */
+  topicDeviceOverride?: { executionTarget?: string; boundDeviceId?: string };
 
   /**
    * Topic-level model/provider override.
@@ -162,6 +178,73 @@ const withTopicModelOverride = (
 ): LobeAgentConfig => {
   if (!override) return config;
   return { ...config, model: override.model, provider: override.provider };
+};
+
+/**
+ * Apply topic-level + source-device-level device overrides onto the resolved
+ * agency config. Resolution order: topic override → source-device override →
+ * existing agencyConfig.
+ *
+ * Reads from `useUserStore.getState()` and `getAgentStoreState()` — safe to
+ * call outside React since they are plain zustand getters.
+ */
+const withDeviceOverride = (
+  config: LobeAgentConfig,
+  ctx: {
+    agentId?: string;
+    sourceDeviceId?: string;
+    topicDeviceOverride?: { executionTarget?: string; boundDeviceId?: string };
+  },
+): LobeAgentConfig => {
+  const topicOverride = ctx.topicDeviceOverride;
+
+  // Read source-device-level override from user preference
+  let sourceOverride: { executionTarget?: string; boundDeviceId?: string } | undefined;
+  if (ctx.agentId) {
+    try {
+      const userStore = useUserStore.getState();
+      const agentStore = getAgentStoreState();
+      const isWorkspace = Boolean(agentStore.agentMap[ctx.agentId]?.workspaceId);
+
+      const bySource = isWorkspace
+        ? userStore.workspaceUserPreference.agentDeviceOverrides?.[ctx.agentId]
+        : userStore.preference?.personalDeviceOverrides?.[ctx.agentId];
+
+      sourceOverride = resolveOverrideBySource(
+        bySource as
+          | Record<string, Pick<LobeAgentAgencyConfig, 'boundDeviceId' | 'executionTarget'>>
+          | undefined,
+        ctx.sourceDeviceId,
+      );
+    } catch {
+      // Non-fatal — fall through to agencyConfig
+    }
+  }
+
+  if (!topicOverride && !sourceOverride) return config;
+
+  const existingAgencyConfig = config.agencyConfig;
+  const merged: Record<string, string | undefined> = {
+    executionTarget: existingAgencyConfig?.executionTarget,
+    boundDeviceId: existingAgencyConfig?.boundDeviceId,
+  };
+
+  // Source-device override (medium priority)
+  if (sourceOverride?.executionTarget !== undefined)
+    merged.executionTarget = sourceOverride.executionTarget;
+  if (sourceOverride?.boundDeviceId !== undefined)
+    merged.boundDeviceId = sourceOverride.boundDeviceId;
+
+  // Topic override (highest priority)
+  if (topicOverride?.executionTarget !== undefined)
+    merged.executionTarget = topicOverride.executionTarget;
+  if (topicOverride?.boundDeviceId !== undefined)
+    merged.boundDeviceId = topicOverride.boundDeviceId;
+
+  return {
+    ...config,
+    agencyConfig: { ...existingAgencyConfig, ...merged },
+  };
 };
 
 export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAgentConfig => {
@@ -317,7 +400,14 @@ export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAge
       };
 
       return {
-        agentConfig: withTopicModelOverride(finalAgentConfig, ctx.topicModelOverride),
+        agentConfig: withDeviceOverride(
+          withTopicModelOverride(finalAgentConfig, ctx.topicModelOverride),
+          {
+            agentId: ctx.agentId,
+            sourceDeviceId: ctx.sourceDeviceId,
+            topicDeviceOverride: ctx.topicDeviceOverride,
+          },
+        ),
         chatConfig: finalChatConfig,
         isBuiltinAgent: false,
         plugins: applyPluginFilters(pageAgentPlugins),
@@ -342,7 +432,14 @@ export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAge
       };
 
       return {
-        agentConfig: withTopicModelOverride(finalAgentConfig, ctx.topicModelOverride),
+        agentConfig: withDeviceOverride(
+          withTopicModelOverride(finalAgentConfig, ctx.topicModelOverride),
+          {
+            agentId: ctx.agentId,
+            sourceDeviceId: ctx.sourceDeviceId,
+            topicDeviceOverride: ctx.topicDeviceOverride,
+          },
+        ),
         chatConfig: finalChatConfig,
         isBuiltinAgent: false,
         plugins: applyPluginFilters(taskAgentPlugins),
@@ -351,7 +448,14 @@ export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAge
 
     // Not in page scope - return standard config
     return {
-      agentConfig: withTopicModelOverride(finalAgentConfig, ctx.topicModelOverride),
+      agentConfig: withDeviceOverride(
+        withTopicModelOverride(finalAgentConfig, ctx.topicModelOverride),
+        {
+          agentId: ctx.agentId,
+          sourceDeviceId: ctx.sourceDeviceId,
+          topicDeviceOverride: ctx.topicDeviceOverride,
+        },
+      ),
       chatConfig: finalChatConfig,
       isBuiltinAgent: false,
       plugins: applyPluginFilters(finalPlugins),
@@ -498,7 +602,14 @@ export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAge
   });
 
   return {
-    agentConfig: withTopicModelOverride(finalAgentConfig, ctx.topicModelOverride),
+    agentConfig: withDeviceOverride(
+      withTopicModelOverride(finalAgentConfig, ctx.topicModelOverride),
+      {
+        agentId: ctx.agentId,
+        sourceDeviceId: ctx.sourceDeviceId,
+        topicDeviceOverride: ctx.topicDeviceOverride,
+      },
+    ),
     chatConfig: resolvedChatConfig,
     isBuiltinAgent: true,
     plugins: applyPluginFilters(finalPlugins),

--- a/src/services/chat/mecha/agentConfigResolver.ts
+++ b/src/services/chat/mecha/agentConfigResolver.ts
@@ -106,6 +106,14 @@ export interface AgentConfigResolverContext {
   scope?: MessageMapScope;
   /** Target agent config for agent-builder */
   targetAgentConfig?: LobeAgentConfig;
+
+  /**
+   * Topic-level model/provider override.
+   * When set, overrides the agent's model/provider so each topic can use a
+   * different model. The caller (streamingExecutor) reads this from
+   * `topic.metadata.model` / `topic.metadata.provider`.
+   */
+  topicModelOverride?: { model: string; provider: string };
 }
 
 /**
@@ -144,6 +152,18 @@ export interface ResolvedAgentConfig {
  *
  * For regular agents, this simply returns the config from the store.
  */
+/**
+ * Apply topic-level model override onto the resolved agent config.
+ * Returns a new object when the override is present, otherwise the input.
+ */
+const withTopicModelOverride = (
+  config: LobeAgentConfig,
+  override: { model: string; provider: string } | undefined,
+): LobeAgentConfig => {
+  if (!override) return config;
+  return { ...config, model: override.model, provider: override.provider };
+};
+
 export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAgentConfig => {
   const { agentId, model, documentContent, plugins, targetAgentConfig, isSubAgent, disableTools } =
     ctx;
@@ -297,7 +317,7 @@ export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAge
       };
 
       return {
-        agentConfig: finalAgentConfig,
+        agentConfig: withTopicModelOverride(finalAgentConfig, ctx.topicModelOverride),
         chatConfig: finalChatConfig,
         isBuiltinAgent: false,
         plugins: applyPluginFilters(pageAgentPlugins),
@@ -322,7 +342,7 @@ export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAge
       };
 
       return {
-        agentConfig: finalAgentConfig,
+        agentConfig: withTopicModelOverride(finalAgentConfig, ctx.topicModelOverride),
         chatConfig: finalChatConfig,
         isBuiltinAgent: false,
         plugins: applyPluginFilters(taskAgentPlugins),
@@ -331,7 +351,7 @@ export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAge
 
     // Not in page scope - return standard config
     return {
-      agentConfig: finalAgentConfig,
+      agentConfig: withTopicModelOverride(finalAgentConfig, ctx.topicModelOverride),
       chatConfig: finalChatConfig,
       isBuiltinAgent: false,
       plugins: applyPluginFilters(finalPlugins),
@@ -478,7 +498,7 @@ export const resolveAgentConfig = (ctx: AgentConfigResolverContext): ResolvedAge
   });
 
   return {
-    agentConfig: finalAgentConfig,
+    agentConfig: withTopicModelOverride(finalAgentConfig, ctx.topicModelOverride),
     chatConfig: resolvedChatConfig,
     isBuiltinAgent: true,
     plugins: applyPluginFilters(finalPlugins),

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -20,7 +20,12 @@ import type {
   SendMessageServerResponse,
   UIChatMessage,
 } from '@lobechat/types';
-import { getWorkingDirEffectivePath, getWorkingDirSourcePath } from '@lobechat/types';
+import {
+  getWorkingDirEffectivePath,
+  getWorkingDirSourcePath,
+  resolveAgencyConfig,
+  resolveOverrideBySource,
+} from '@lobechat/types';
 import { nanoid } from '@lobechat/utils';
 import { TRPCClientError } from '@trpc/client';
 import { t } from 'i18next';
@@ -72,8 +77,10 @@ import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { pageAgentRuntime } from '@/store/tool/slices/builtin/executors/lobe-page-agent';
 import { type StoreSetter } from '@/store/types';
+import { useUserStore } from '@/store/user';
 import { useUserMemoryStore } from '@/store/userMemory';
 import { markdownToTxt } from '@/utils/markdownToTxt';
+import { getSourceDeviceId } from '@/utils/sourceDevice';
 
 import { materializeLocalSystemToolSnapshots } from '../transports/client/localSystemToolSnapshots';
 import type { CommandSendOverrides, SingleAgentMentionDirectRoute } from './commandBus';
@@ -140,6 +147,30 @@ interface OptimisticTopicPlaceholder {
 type Setter = StoreSetter<ChatStore>;
 export const conversationLifecycle = (set: Setter, get: () => ChatStore, _api?: unknown) =>
   new ConversationLifecycleActionImpl(set, get, _api);
+
+/**
+ * Resolve the effective per-source-device execution override for an agent from
+ * the current user's preference (personal or workspace), matching the key the
+ * switcher wrote. Used by runtime selection so a device picker change takes
+ * effect on the next send even though `agentConfig.agencyConfig` is untouched.
+ */
+const resolveDeviceOverrideForAgent = (
+  agentId: string,
+): { boundDeviceId?: string; executionTarget?: string } | undefined => {
+  const userStore = useUserStore.getState();
+  const agentState = getAgentStoreState();
+  const isWorkspace = Boolean(agentState.agentMap[agentId]?.workspaceId);
+  const bySource = isWorkspace
+    ? userStore.workspaceUserPreference.agentDeviceOverrides?.[agentId]
+    : userStore.preference?.personalDeviceOverrides?.[agentId];
+  const sourceDeviceId = isDesktop
+    ? getElectronStoreState()?.gatewayDeviceInfo?.deviceId
+    : getSourceDeviceId();
+  return resolveOverrideBySource(
+    bySource as Record<string, { boundDeviceId?: string; executionTarget?: string }> | undefined,
+    sourceDeviceId,
+  );
+};
 
 const isAbortError = (error: unknown, abortController?: AbortController) =>
   !!abortController?.signal.aborted ||
@@ -267,10 +298,19 @@ export class ConversationLifecycleActionImpl {
     if (!agentId) return;
 
     const agentConfig = agentSelectors.getAgentConfigById(agentId)(getAgentStoreState());
+    // Runtime selection must honour the user's per-source-device execution
+    // override (personal or workspace), not just the shared `agencyConfig` —
+    // the switcher writes those overrides out-of-band, so reading only
+    // `agencyConfig` would route the next send to the stale local/cloud target.
+    const deviceOverride = resolveDeviceOverrideForAgent(agentId);
+    const effectiveAgencyConfig = resolveAgencyConfig(
+      agentConfig?.agencyConfig,
+      deviceOverride ?? null,
+    );
     const heterogeneousProvider = agentConfig?.agencyConfig?.heterogeneousProvider;
     const runtimeType = selectRuntimeType({
-      boundDeviceId: agentConfig?.agencyConfig?.boundDeviceId,
-      executionTarget: agentConfig?.agencyConfig?.executionTarget,
+      boundDeviceId: effectiveAgencyConfig?.boundDeviceId,
+      executionTarget: effectiveAgencyConfig?.executionTarget,
       heterogeneousProvider,
       isGatewayMode: this.#get().isGatewayModeEnabled(agentId),
       isWorkspaceAgent: agentByIdSelectors.isWorkspaceAgentById(agentId)(getAgentStoreState()),

--- a/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
+++ b/src/store/chat/slices/agentRun/actions/entries/conversationLifecycle.ts
@@ -154,7 +154,7 @@ export const conversationLifecycle = (set: Setter, get: () => ChatStore, _api?: 
  * switcher wrote. Used by runtime selection so a device picker change takes
  * effect on the next send even though `agentConfig.agencyConfig` is untouched.
  */
-const resolveDeviceOverrideForAgent = (
+export const resolveDeviceOverrideForAgent = (
   agentId: string,
 ): { boundDeviceId?: string; executionTarget?: string } | undefined => {
   const userStore = useUserStore.getState();
@@ -1126,7 +1126,16 @@ export class ConversationLifecycleActionImpl {
       );
 
     try {
-      const { model, provider } = agentSelectors.getAgentConfigById(agentId)(getAgentStoreState());
+      const agentConfigForMsg = agentSelectors.getAgentConfigById(agentId)(getAgentStoreState());
+      // In client mode the local run resolves the topic `modelOverride` (see
+      // `streamingExecutor`/withTopicModelOverride), so the persisted assistant
+      // message must carry that override too, not just the agent's base model.
+      const topicModelOverride = operationContext.topicId
+        ? topicSelectors.getTopicById(operationContext.topicId)(this.#get())?.metadata
+            ?.modelOverride
+        : undefined;
+      const model = topicModelOverride?.model ?? agentConfigForMsg?.model;
+      const provider = topicModelOverride?.provider ?? agentConfigForMsg?.provider;
 
       const topicId = operationContext.topicId;
 

--- a/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
@@ -56,6 +56,7 @@ import { pageAgentRuntime } from '@/store/tool/slices/builtin/executors/lobe-pag
 import { type StoreSetter } from '@/store/types';
 import { toolInterventionSelectors } from '@/store/user/selectors';
 import { getUserStoreState } from '@/store/user/store';
+import { getSourceDeviceId } from '@/utils/sourceDevice';
 
 import { buildRunLifecycle } from '../../lifecycle/buildRunLifecycle';
 import type { RunParkedReason, RunScope } from '../../lifecycle/types';
@@ -159,6 +160,7 @@ export class StreamingExecutorActionImpl {
 
     // Read topic-level model/provider override from active topic metadata
     let topicModelOverride: { model: string; provider: string } | undefined;
+    let topicDeviceOverride: { executionTarget?: string; boundDeviceId?: string } | undefined;
     if (topicId) {
       const topic = topicSelectors.getTopicById(topicId)(this.#get());
       if (topic?.metadata?.model) {
@@ -167,7 +169,17 @@ export class StreamingExecutorActionImpl {
           provider: topic.metadata.provider || '',
         };
       }
+      if (topic?.metadata?.deviceOverride) {
+        topicDeviceOverride = topic.metadata.deviceOverride;
+      }
     }
+
+    // Determine source deviceId for per-source-device override resolution
+    // On desktop this is the local machine's gateway deviceId; on web/mobile
+    // it's a localStorage-based anonymous device ID unique per machine.
+    const sourceDeviceId: string | undefined = isDesktop
+      ? getElectronStoreState()?.gatewayDeviceInfo?.deviceId
+      : getSourceDeviceId();
 
     // Resolve agent config with builtin agent runtime config merged
     // This ensures runtime plugins (e.g., 'lobe-agent-builder' for Agent Builder) are included
@@ -180,6 +192,8 @@ export class StreamingExecutorActionImpl {
       isSubAgent, // Filter out lobe-agent in sub-agent context
       scope, // Pass scope from operation context
       topicModelOverride, // Pass topic-level model override
+      topicDeviceOverride, // Pass topic-level device override
+      sourceDeviceId, // Pass current source deviceId for per-device override
     });
 
     const { agentConfig: agentConfigData, plugins: pluginIds } = agentConfig;

--- a/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
@@ -157,6 +157,18 @@ export class StreamingExecutorActionImpl {
     const scope = operation?.context.scope;
     const groupId = operation?.context.groupId;
 
+    // Read topic-level model/provider override from active topic metadata
+    let topicModelOverride: { model: string; provider: string } | undefined;
+    if (topicId) {
+      const topic = topicSelectors.getTopicById(topicId)(this.#get());
+      if (topic?.metadata?.model) {
+        topicModelOverride = {
+          model: topic.metadata.model,
+          provider: topic.metadata.provider || '',
+        };
+      }
+    }
+
     // Resolve agent config with builtin agent runtime config merged
     // This ensures runtime plugins (e.g., 'lobe-agent-builder' for Agent Builder) are included
     // - isSubAgent: filters out lobe-agent tool to prevent nested sub-agent creation
@@ -167,6 +179,7 @@ export class StreamingExecutorActionImpl {
       groupId, // Pass groupId for supervisor detection
       isSubAgent, // Filter out lobe-agent in sub-agent context
       scope, // Pass scope from operation context
+      topicModelOverride, // Pass topic-level model override
     });
 
     const { agentConfig: agentConfigData, plugins: pluginIds } = agentConfig;

--- a/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
@@ -163,11 +163,8 @@ export class StreamingExecutorActionImpl {
     let topicDeviceOverride: { executionTarget?: string; boundDeviceId?: string } | undefined;
     if (topicId) {
       const topic = topicSelectors.getTopicById(topicId)(this.#get());
-      if (topic?.metadata?.model) {
-        topicModelOverride = {
-          model: topic.metadata.model,
-          provider: topic.metadata.provider || '',
-        };
+      if (topic?.metadata?.modelOverride) {
+        topicModelOverride = topic.metadata.modelOverride;
       }
       if (topic?.metadata?.deviceOverride) {
         topicDeviceOverride = topic.metadata.deviceOverride;

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -27,9 +27,11 @@ import { consumePendingTopicRepos, getPendingTopicRepos } from '@/store/chat/pen
 import { topicSelectors } from '@/store/chat/selectors';
 import type { ChatStore } from '@/store/chat/store';
 import { messageMapKey } from '@/store/chat/utils/messageMapKey';
+import { getElectronStoreState } from '@/store/electron';
 import type { StoreSetter } from '@/store/types';
 import { useUserStore } from '@/store/user';
 import { settingsSelectors, toolInterventionSelectors } from '@/store/user/selectors';
+import { getSourceDeviceId } from '@/utils/sourceDevice';
 
 import { buildRunLifecycle } from '../../lifecycle/buildRunLifecycle';
 import type { RunScope } from '../../lifecycle/types';
@@ -488,6 +490,12 @@ export class GatewayActionImpl {
       ? topicSelectors.getTopicById(context.topicId)(this.#get())?.metadata?.modelOverride
       : undefined;
 
+    // Source device id of this machine, so the server resolves the caller's
+    // per-source-device execution override (matches the key the switcher wrote).
+    const sourceDeviceId = isDesktop
+      ? getElectronStoreState()?.gatewayDeviceInfo?.deviceId
+      : getSourceDeviceId();
+
     const result = await aiAgentService.execAgentTask(
       {
         agentId: context.agentId,
@@ -524,6 +532,7 @@ export class GatewayActionImpl {
         resumeApproval,
         resumeToolResult,
         selectedToolIds,
+        ...(sourceDeviceId ? { sourceDeviceId } : {}),
         trigger: metadata?.trigger,
         userInterventionConfig,
       },

--- a/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/gateway/gateway.ts
@@ -482,6 +482,12 @@ export class GatewayActionImpl {
       allowList: toolInterventionSelectors.allowList(useUserStore.getState()),
     };
 
+    // Forward the active topic's model override so the server run uses the
+    // topic's pinned model/provider instead of the agent default.
+    const topicModelOverride = context.topicId
+      ? topicSelectors.getTopicById(context.topicId)(this.#get())?.metadata?.modelOverride
+      : undefined;
+
     const result = await aiAgentService.execAgentTask(
       {
         agentId: context.agentId,
@@ -511,7 +517,9 @@ export class GatewayActionImpl {
         deviceId: localDeviceId,
         fileIds,
         mentionedAgents,
+        ...(topicModelOverride ? { model: topicModelOverride.model } : {}),
         parentMessageId,
+        ...(topicModelOverride ? { provider: topicModelOverride.provider } : {}),
         prompt: message,
         resumeApproval,
         resumeToolResult,

--- a/src/store/user/slices/workspaceUserSettings/selectors.ts
+++ b/src/store/user/slices/workspaceUserSettings/selectors.ts
@@ -1,17 +1,28 @@
 import type { AgentDeviceOverride } from '@lobechat/types';
+import { resolveOverrideBySource } from '@lobechat/types';
 
 import { type UserStore } from '@/store/user';
 
 /**
- * The caller's override for a specific agent in the currently-active
- * workspace, or `undefined` when nothing is pinned yet. Merged over
- * `agents.agencyConfig` by `resolveAgencyConfig` at read time so pickers and
- * dispatch always agree.
+ * The caller's per-source-device override for a specific workspace agent.
+ * Returns the override matching `sourceDeviceId`, falling back to `'*'`.
+ *
+ * Backward-compat: if the stored value has `executionTarget` at the top level
+ * (old flat format), returns it directly.
  */
 const agentDeviceOverrideById =
-  (agentId: string) =>
-  (s: UserStore): AgentDeviceOverride | undefined =>
-    s.workspaceUserPreference.agentDeviceOverrides?.[agentId];
+  (agentId: string, sourceDeviceId?: string) =>
+  (s: UserStore): AgentDeviceOverride | undefined => {
+    const raw = s.workspaceUserPreference.agentDeviceOverrides?.[agentId];
+    if (!raw) return undefined;
+
+    // Old format: a flat AgentDeviceOverride with executionTarget at top level
+    if ('executionTarget' in raw || 'boundDeviceId' in raw) {
+      return raw as unknown as AgentDeviceOverride;
+    }
+
+    return resolveOverrideBySource(raw as Record<string, AgentDeviceOverride>, sourceDeviceId);
+  };
 
 export const workspaceUserSettingsSelectors = {
   agentDeviceOverrideById,

--- a/src/utils/sourceDevice.ts
+++ b/src/utils/sourceDevice.ts
@@ -1,0 +1,34 @@
+import { isDesktop } from '@lobechat/const';
+
+export const LOBE_DEVICE_ID_KEY = 'lobe_device_id';
+
+/**
+ * Get or create a stable anonymous device ID for the current machine.
+ *
+ * - On desktop (Electron): returns the local gateway deviceId from the store.
+ * - On web / mobile: creates a random UUID on first visit and persists it in
+ *   `localStorage.lobe_device_id`. Subsequent visits return the same ID,
+ *   so different browsers on the same machine get different IDs (correct),
+ *   but the same browser on the same machine always gets the same ID.
+ * - If localStorage is unavailable (SSR, private mode storage disabled):
+ *   returns `'anonymous'` as a fallback.
+ */
+export const getSourceDeviceId = (): string | undefined => {
+  if (isDesktop) {
+    // Desktop gets its deviceId from the Electron gateway store — handled by
+    // the caller. This path is only reached from non-desktop contexts.
+    return undefined;
+  }
+
+  try {
+    const stored = localStorage.getItem(LOBE_DEVICE_ID_KEY);
+    if (stored) return stored;
+
+    const id = crypto.randomUUID();
+    localStorage.setItem(LOBE_DEVICE_ID_KEY, id);
+    return id;
+  } catch {
+    // localStorage unavailable (SSR, private mode, etc.)
+    return 'anonymous';
+  }
+};


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

#### 🔀 Description of Change

Two independent but related improvements to per-context settings:

**1. Per-topic model override**

Model selection in the chat input bar now writes to the active topic metadata when a topic is open, instead of globally changing the agent model. When no topic is active, it falls back to writing to the agent config (existing behavior).

New resolution chain: `topic.metadata.model/provider` → `agent.config.model/provider` → `DEFAULT_MODEL`.

**2. Per-source-device execution target override**

Device selection (execution target + bound device) is now scoped to the physical machine the user is on, so different machines remember their own device choice independently.

- Desktop uses `gatewayDeviceInfo.deviceId` as the source identifier.
- Web/Mobile uses a per-browser anonymous ID stored in `localStorage.lobe_device_id`.
- New resolution chain: `topic.metadata.deviceOverride` → per-source-device override → `agents.agencyConfig` → platform default.
- Old data in `agents.agencyConfig` is preserved as a read-only fallback; new writes go to the per-source-device override.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| ...    | ...   |

#### 📝 Additional Information

<!-- Add any other context about the Pull Request here. -->

<!-- Breaking changes? Migration guide? Performance impact? -->
