### PR TITLE
✨ feat: support comparison evidence in verify reports

### DIFF
--- a/.agents/skills/agent-testing/references/report.md
+++ b/.agents/skills/agent-testing/references/report.md
@@ -61,6 +61,22 @@ the page. It carries only the non-duplicate narrative (仍需跟进 / 本轮验�
      Embed it like an image: `![case 2](assets/case2-streaming.gif)`. Verify
      at least the first/last frames visually (Read the GIF) before citing.
 
+   - UI (before/after comparison): capture and visually verify both original
+     screenshots. Do not ask the agent to compose them into a new image. In the
+     case's `evidence` array, pair them with a shared comparison id:
+
+     ```json
+     "evidence": [
+       { "path": "assets/before.png", "comparison": { "id": "layout", "role": "before" } },
+       { "path": "assets/after.png", "comparison": { "id": "layout", "role": "after" } }
+     ]
+     ```
+
+     The verify page renders a complete pair side by side with Before / After
+     headings. `comparison.label` may override either heading. A group contains
+     exactly one `before` and one `after`; incomplete groups render as ordinary
+     evidence.
+
    - CLI: exact command + trimmed output (`$CLI task list | tee "$DIR/assets/task-list.txt"`).
 
    - Network: `agent-browser network requests` dumps or HAR files.

--- a/apps/cli/src/commands/verify.ts
+++ b/apps/cli/src/commands/verify.ts
@@ -75,12 +75,37 @@ function inlineTextEvidenceForFile(file: string, type: EvidenceType | string): s
 }
 
 /** Normalize a case's `evidence` field (string | string[] | {path}[]) to path strings. */
-function evidencePaths(evidence: unknown): string[] {
+interface ReportEvidenceInput {
+  comparison?: { id?: string; label?: string; role?: 'after' | 'before' };
+  description?: string;
+  path: string;
+}
+
+function reportEvidence(evidence: unknown): ReportEvidenceInput[] {
   if (!evidence) return [];
   const arr = Array.isArray(evidence) ? evidence : [evidence];
   return arr
-    .map((e) => (typeof e === 'string' ? e : (e?.path ?? e?.file)))
-    .filter((p): p is string => typeof p === 'string' && p.length > 0);
+    .map((e): ReportEvidenceInput | null => {
+      if (typeof e === 'string') return { path: e };
+      const value = objectValue(e);
+      const evidencePath = value && firstString(value.path, value.file);
+      if (!evidencePath) return null;
+      const comparison = objectValue(value.comparison);
+      const role = comparison?.role;
+      return {
+        comparison:
+          comparison && (role === 'before' || role === 'after')
+            ? {
+                id: firstString(comparison.id),
+                label: firstString(comparison.label),
+                role,
+              }
+            : undefined,
+        description: firstString(value.description, value.desc),
+        path: evidencePath,
+      };
+    })
+    .filter((item): item is ReportEvidenceInput => item !== null);
 }
 
 function firstString(...values: unknown[]): string | undefined {
@@ -1190,7 +1215,8 @@ export function registerVerifyCommand(program: Command) {
             }
           }
 
-          for (const rel of evidencePaths(c.evidence)) {
+          for (const evidenceInput of reportEvidence(c.evidence)) {
+            const rel = evidenceInput.path;
             const abs = path.isAbsolute(rel) ? rel : path.join(dir, rel);
             if (!existsSync(abs)) {
               log.warn(`evidence not found, skipping: ${rel}`);
@@ -1206,8 +1232,11 @@ export function registerVerifyCommand(program: Command) {
                 // The filename, not the case title — the title already heads the
                 // check card, so reusing it here just triples the same text.
                 content,
-                description: path.basename(abs),
+                description: evidenceInput.description ?? path.basename(abs),
                 fileId: file?.id,
+                metadata: evidenceInput.comparison
+                  ? { comparison: evidenceInput.comparison }
+                  : undefined,
                 type,
               });
               evidenceCount += 1;

--- a/apps/server/src/routers/lambda/verify.ts
+++ b/apps/server/src/routers/lambda/verify.ts
@@ -159,6 +159,7 @@ const uploadEvidenceInputSchema = z
     content: z.string().min(1).optional(),
     description: z.string().optional(),
     fileId: z.string().min(1).optional(),
+    metadata: z.unknown().optional(),
     type: evidenceTypeSchema,
   })
   .refine((data) => Boolean(data.content) !== Boolean(data.fileId), {
@@ -666,6 +667,7 @@ export const verifyRouter = router({
         content: input.content ?? null,
         description: input.description ?? null,
         fileId: input.fileId ?? null,
+        metadata: input.metadata ?? null,
         type: input.type,
       });
     }),

--- a/locales/en-US/verify.json
+++ b/locales/en-US/verify.json
@@ -52,6 +52,8 @@
   "report.evidence.category.file": "File",
   "report.evidence.category.image": "Image",
   "report.evidence.category.video": "Video",
+  "report.evidence.comparison.after": "After",
+  "report.evidence.comparison.before": "Before",
   "report.evidence.count": "{{count}} evidence",
   "report.evidence.inlineFallback": "Inline evidence {{index}}",
   "report.evidence.openDetail": "Open {{name}}",

--- a/locales/zh-CN/verify.json
+++ b/locales/zh-CN/verify.json
@@ -52,6 +52,8 @@
   "report.evidence.category.file": "文件",
   "report.evidence.category.image": "图片",
   "report.evidence.category.video": "视频",
+  "report.evidence.comparison.after": "优化后",
+  "report.evidence.comparison.before": "优化前",
   "report.evidence.count": "{{count}} 条证据",
   "report.evidence.inlineFallback": "内联证据 {{index}}",
   "report.evidence.openDetail": "打开 {{name}}",

--- a/packages/locales/src/default/verify.ts
+++ b/packages/locales/src/default/verify.ts
@@ -64,6 +64,8 @@ export default {
   'report.evidence.category.video': 'Video',
   'report.evidence.count': '{{count}} evidence',
   'report.evidence.inlineFallback': 'Inline evidence {{index}}',
+  'report.evidence.comparison.after': 'After',
+  'report.evidence.comparison.before': 'Before',
   'report.evidence.openDetail': 'Open {{name}}',
   'report.evidence.view': 'View evidence ({{count}})',
   'report.filter.all': 'All',

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -74,7 +74,7 @@ const styles = createStaticStyles(({ css }) => ({
   `,
   page: css`
     width: 100%;
-    max-width: 1180px;
+    max-width: 880px;
     margin-inline: auto;
     padding-block: 32px 64px;
     padding-inline: 32px;
@@ -700,6 +700,36 @@ const styles = createStaticStyles(({ css }) => ({
 
     max-width: 70ch;
   `,
+  comparison: css`
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+    width: 100%;
+
+    @media (width <= 640px) {
+      grid-template-columns: 1fr;
+    }
+  `,
+  comparisonItem: css`
+    overflow: hidden;
+
+    min-width: 0;
+    border: 1px solid ${cssVar.colorBorderSecondary};
+    border-radius: ${cssVar.borderRadius};
+
+    background: ${cssVar.colorBgContainer};
+  `,
+  comparisonLabel: css`
+    display: block;
+
+    padding-block: 7px;
+    padding-inline: 10px;
+    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
+
+    font-size: 12px;
+    font-weight: 600;
+    color: ${cssVar.colorTextSecondary};
+  `,
   evidenceFile: css`
     cursor: pointer;
 
@@ -1014,6 +1044,34 @@ const evidenceDisplayName = (
   evidence.description ||
   t('report.evidence.inlineFallback', { index });
 
+interface EvidenceComparison {
+  id: string;
+  label?: string;
+  role: 'after' | 'before';
+}
+
+const evidenceComparison = (evidence: VerifyEvidenceWithUrl): EvidenceComparison | null => {
+  const metadata = toRecord(evidence.metadata);
+  if (!metadata) return null;
+
+  const comparison = toRecord(metadata.comparison);
+  if (!comparison) return null;
+
+  const role = comparison.role;
+  if (
+    typeof comparison.id !== 'string' ||
+    (role !== 'before' && role !== 'after') ||
+    !isInlineVisualEvidence(evidence)
+  )
+    return null;
+
+  return {
+    id: comparison.id,
+    label: typeof comparison.label === 'string' ? comparison.label : undefined,
+    role,
+  };
+};
+
 /** A file-backed text evidence, decoded + syntax highlighted (avoids mojibake). */
 const DocumentViewer = memo<{ fileName?: string | null; url: string }>(({ fileName, url }) => {
   const { t } = useTranslation('verify');
@@ -1274,6 +1332,31 @@ const EvidenceDrawer = memo<{
 
 EvidenceItem.displayName = 'EvidenceItem';
 
+const EvidenceComparisonView = memo<{
+  after: VerifyEvidenceWithUrl;
+  before: VerifyEvidenceWithUrl;
+}>(({ after, before }) => {
+  const { t } = useTranslation('verify');
+
+  return (
+    <div className={styles.comparison}>
+      {[before, after].map((evidence, index) => {
+        const comparison = evidenceComparison(evidence)!;
+        return (
+          <div className={styles.comparisonItem} key={evidence.id}>
+            <span className={styles.comparisonLabel}>
+              {comparison.label ?? t(`report.evidence.comparison.${comparison.role}`)}
+            </span>
+            <EvidenceItem evidence={evidence} index={index + 1} />
+          </div>
+        );
+      })}
+    </div>
+  );
+});
+
+EvidenceComparisonView.displayName = 'EvidenceComparisonView';
+
 EvidenceDrawer.displayName = 'EvidenceDrawer';
 
 /** One check — an expandable row; evidence opens one artifact at a time. */
@@ -1299,6 +1382,22 @@ const CheckRow = memo<{ defaultOpen: boolean; result: VerifyResultWithEvidence }
       : -1;
     const selectedEvidence =
       selectedEvidenceIndex >= 0 ? result.evidence[selectedEvidenceIndex] : null;
+    const comparisonGroups = new Map<
+      string,
+      Partial<Record<'after' | 'before', VerifyEvidenceWithUrl>>
+    >();
+    for (const evidence of result.evidence) {
+      const comparison = evidenceComparison(evidence);
+      if (!comparison) continue;
+      const group = comparisonGroups.get(comparison.id) ?? {};
+      group[comparison.role] = evidence;
+      comparisonGroups.set(comparison.id, group);
+    }
+    const pairedEvidenceIds = new Set(
+      [...comparisonGroups.values()]
+        .filter((group) => group.before && group.after)
+        .flatMap((group) => [group.before!.id, group.after!.id]),
+    );
 
     return (
       <div className={styles.row}>
@@ -1343,8 +1442,13 @@ const CheckRow = memo<{ defaultOpen: boolean; result: VerifyResultWithEvidence }
             {evidenceCount > 0 && (
               <>
                 <div className={styles.evidenceList}>
+                  {[...comparisonGroups.entries()].map(([id, group]) =>
+                    group.before && group.after ? (
+                      <EvidenceComparisonView after={group.after} before={group.before} key={id} />
+                    ) : null,
+                  )}
                   {result.evidence.map((e, index) =>
-                    isInlineEvidence(e) ? (
+                    pairedEvidenceIds.has(e.id) ? null : isInlineEvidence(e) ? (
                       <EvidenceItem evidence={e} index={index + 1} key={e.id} />
                     ) : (
                       <EvidenceFileButton
@@ -1630,6 +1734,9 @@ const ReportViewer = memo<ReportViewerProps>(({ runId: explicitRunId }) => {
         <main>
           <Flexbox gap={12}>
             <div className={styles.heroLine}>
+              <Text as={'h1'} style={{ fontSize: 24, lineHeight: 1.3, margin: 0 }}>
+                {run.title || t('report.titleFallback')}
+              </Text>
               {verdict && (
                 <span
                   className={styles.pill}
@@ -1642,9 +1749,6 @@ const ReportViewer = memo<ReportViewerProps>(({ runId: explicitRunId }) => {
                   {t(`report.verdict.${verdict}`)}
                 </span>
               )}
-              <Text as={'h1'} style={{ fontSize: 24, lineHeight: 1.3, margin: 0 }}>
-                {run.title || t('report.titleFallback')}
-              </Text>
             </div>
 
             {!isCodingReport && run.goal && <Text className={styles.summary}>{run.goal}</Text>}


### PR DESCRIPTION
## Summary

- preserve comparison metadata while uploading verification evidence from CLI reports
- persist evidence metadata through the verify API
- render complete before/after visual evidence pairs side by side with localized labels
- document the comparison evidence format for agent testing reports
- refine the verification report width and title/verdict hierarchy

## Test plan

- `bun run check .agents/skills/agent-testing/references/report.md apps/cli/src/commands/verify.ts apps/server/src/routers/lambda/verify.ts locales/en-US/verify.json locales/zh-CN/verify.json packages/locales/src/default/verify.ts src/features/Verify/ReportViewer.tsx`
- 32 related tests passed; lint clean
- pre-commit Markdown, Prettier, Stylelint, and ESLint hooks passed