### PR TITLE
✨ feat(mobile): expose ASR router

### DIFF
--- a/apps/server/src/routers/mobile/index.test.ts
+++ b/apps/server/src/routers/mobile/index.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { mobileRouter } from './index';
+
+describe('mobileRouter', () => {
+  it('exposes speech transcription', () => {
+    const caller = mobileRouter.createCaller({} as never);
+
+    expect(caller.asr.transcribe).toBeTypeOf('function');
+  });
+});

--- a/apps/server/src/routers/mobile/index.ts
+++ b/apps/server/src/routers/mobile/index.ts
@@ -12,6 +12,7 @@ import { aiAgentRouter } from '../lambda/aiAgent';
 import { aiChatRouter } from '../lambda/aiChat';
 import { aiModelRouter } from '../lambda/aiModel';
 import { aiProviderRouter } from '../lambda/aiProvider';
+import { asrRouter } from '../lambda/asr';
 import { briefRouter } from '../lambda/brief';
 import { chunkRouter } from '../lambda/chunk';
 import { composioRouter } from '../lambda/composio';
@@ -42,6 +43,7 @@ export const mobileRouter = router({
   brief: briefRouter,
   aiModel: aiModelRouter,
   aiProvider: aiProviderRouter,
+  asr: asrRouter,
   chunk: chunkRouter,
   composio: composioRouter,
   config: configRouter,


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Supports mobile voice-input transcription through the existing ASR backend.

#### 🔀 Description of Change

- expose the existing `asrRouter` from the mobile tRPC router
- add a router contract test for `asr.transcribe`

This lets mobile clients call the authenticated ASR mutation through `/trpc/mobile` while keeping provider credentials and transcription runtime configuration on the server.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

`bunx vitest run --silent=passed-only apps/server/src/routers/mobile/index.test.ts`

#### 📸 Screenshots / Videos

Not applicable; backend router-only change.

#### 📝 Additional Information

No schema or migration changes.