### PR TITLE
🐛 fix(chat): stop retry from deleting the user turn it anchors on

### DIFF
--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/regenerate.test.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/regenerate.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import type { UIChatMessage } from '@lobechat/types';
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { MessageActionContext } from '../types';
+import { regenerateAction } from './regenerate';
+
+const regenerateUserMessage = vi.fn();
+const regenerateAssistantMessage = vi.fn();
+const deleteMessage = vi.fn();
+
+vi.mock('../../../../store', () => ({
+  messageStateSelectors: { isMessageRegenerating: () => () => false },
+  useConversationStore: (selector: (s: any) => any) =>
+    selector({ deleteMessage, regenerateAssistantMessage, regenerateUserMessage }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const build = (data: Partial<UIChatMessage>, role: MessageActionContext['role'], id = 'msg-1') =>
+  renderHook(() => regenerateAction.useBuild({ data: data as UIChatMessage, id, role })).result
+    .current!;
+
+const error = { body: { message: 'boom' }, type: 'ProviderBizError' };
+
+describe('regenerateAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('never deletes an errored USER turn — the retry anchors the new assistant on it', () => {
+    // The regenerate is fired without await and persists the new assistant with
+    // `parent_id = <this user message>`. Deleting the anchor races that insert: the
+    // assistant violates the FK, silently never lands, and the whole turn is lost.
+    build({ error, id: 'user-1' } as unknown as UIChatMessage, 'user', 'user-1').handleClick!();
+
+    expect(regenerateUserMessage).toHaveBeenCalledWith('user-1');
+    expect(deleteMessage).not.toHaveBeenCalled();
+  });
+
+  it('drops an errored ASSISTANT turn — the retry re-anchors on its parent, not on itself', () => {
+    build({ error, id: 'asst-1' } as unknown as UIChatMessage, 'assistant', 'asst-1')
+      .handleClick!();
+
+    expect(regenerateAssistantMessage).toHaveBeenCalledWith('asst-1');
+    expect(deleteMessage).toHaveBeenCalledWith('asst-1');
+  });
+
+  it('keeps a healthy assistant turn when regenerating', () => {
+    build({ content: 'hi', id: 'asst-1' } as unknown as UIChatMessage, 'assistant', 'asst-1')
+      .handleClick!();
+
+    expect(regenerateAssistantMessage).toHaveBeenCalledWith('asst-1');
+    expect(deleteMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/Conversation/Messages/components/MessageActionBar/actions/regenerate.ts
+++ b/src/features/Conversation/Messages/components/MessageActionBar/actions/regenerate.ts
@@ -21,9 +21,15 @@ export const regenerateAction = defineAction({
         disabled: isRegenerating,
         handleClick: () => {
           if (ctx.role === 'user') {
+            // Never delete a user turn on retry. The regenerate we just fired is not
+            // awaited, and it anchors the new assistant message on this very id via the
+            // `messages.parent_id` FK. Deleting it races that insert: the assistant then
+            // violates the FK, silently never lands, and the whole turn — prompt included
+            // — is gone for good.
             regenerateUserMessage(ctx.id);
-            if (ctx.data.error) deleteMessage(ctx.id);
           } else {
+            // Safe: the retry re-anchors on this message's PARENT user turn, not on the
+            // assistant itself, so dropping the errored assistant cannot orphan the insert.
             regenerateAssistantMessage(ctx.id);
             if (ctx.data.error) deleteMessage(ctx.id);
           }

--- a/src/features/Conversation/hooks/useChatItemContextMenu.tsx
+++ b/src/features/Conversation/hooks/useChatItemContextMenu.tsx
@@ -293,11 +293,15 @@ export const useChatItemContextMenu = ({
             resendThreadMessage(id);
           } else if (role === 'assistant') {
             regenerateAssistantMessage(id);
+            // Only an errored ASSISTANT may be dropped here: the retry re-anchors on its
+            // parent user turn, so the pending insert keeps a live `parent_id`. Deleting a
+            // USER turn instead would race the regenerate that anchors on it — the new
+            // assistant fails its FK, never lands, and the entire turn disappears.
+            if (item.error) deleteMessage(id);
           } else {
             regenerateUserMessage(id);
           }
 
-          if (item.error) deleteMessage(id);
           break;
         }
         case 'delAndRegenerate': {


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 🐛 fix

### 🔀 变更说明 | Description of Change

线上「消息凭空消失」的根因。客户 topic 里 op 正常跑完并计费（`status=done`），但那一轮的 **user + assistant 两条消息在库里完全不存在**。

**机制**：点重试时，`regenerateUserMessage(id)` 是**不 await** 就发出去的，它会把新的 assistant 消息以 `parent_id = <这条 user 消息>` 持久化。而紧接着的 `if (error) deleteMessage(id)` 把这条 user 消息删了 —— 删除与插入竞态：

1. user 消息被删
2. 在飞的 regenerate 插入 assistant，`parent_id` 已悬空 → 违反 `messages_parent_id_messages_id_fk`
3. 插入失败，行从没落库；op 手里握着内存里的 id 照跑不误，全程写入命中 0 行、静默成功
4. 结果：**提问和回复一起消失，且不可恢复**

`MessageModel.deleteMessage` 删除时会把子消息 re-parent 到父节点，所以单删 user 消息不会带走一条**已存在**的 assistant —— assistant 消失只可能是它压根没 INSERT 进去，这也印证了上面的时序。

**修法**：重试时只允许删除**出错的 assistant** —— 那条路径重新锚定在它的**父 user 消息**上，待插入的行 `parent_id` 始终有效。user 消息（以及 portal thread 里 `resendThreadMessage` 重发的锚点）**永不删除**。

action bar 和 context menu 两处是同一个模式，一并修掉。

### 📝 补充信息 | Additional Information

- 这行代码很老（最早见于 2023-10 `#340`），不是新回归 —— 与线上丢失率一个月稳定在 ~2% 的观测吻合。后来 agent runtime 把 assistant 改成服务端带 FK 硬锚在 `parent_id` 上持久化，才让它从"无害"变成"整轮消失"。
- 新增 `regenerate.test.ts` 锁死该回归。

🤖 Generated with [Claude Code](https://claude.com/claude-code)