### PR TITLE
💄 style(topic): use alert triangle for failed topic status

### DIFF
--- a/src/components/ExecutionStatus.ts
+++ b/src/components/ExecutionStatus.ts
@@ -13,6 +13,7 @@ import {
   Clock,
   HandIcon,
   StarIcon,
+  TriangleAlert,
 } from 'lucide-react';
 
 export interface ExecutionStatusVisual {
@@ -59,7 +60,10 @@ export const TOPIC_STATUS_VISUALS: Record<ChatTopicStatus, ExecutionStatusVisual
   // Topic lists are mostly history: mute completed to keep long lists quiet,
   // unlike task boards where a green check marks an achievement.
   completed: { ...VISUALS.completed, color: cssVar.colorTextDescription },
-  failed: VISUALS.failed,
+  // A failed topic is an alert the user should act on, not a terminal outcome
+  // like a failed task run — the warning triangle reads that way, the circled X
+  // reads as "closed/rejected".
+  failed: { ...VISUALS.failed, icon: TriangleAlert },
   paused: VISUALS.paused,
   running: VISUALS.running,
   scheduled: VISUALS.scheduled,


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 💄 style

### 🔀 变更说明 | Description of Change

The topic list previously marked a failed topic with `TriangleAlert`. #17016 unified task/topic status glyphs into a shared visual source, which swapped it to `CircleX` — but the two states aren't the same semantic:

- A **failed task** is a terminal outcome on a board; the circled X reads as "closed / rejected".
- A **failed topic** is an alert the user is expected to act on (retry, inspect the error); the warning triangle reads that way.

This overrides `failed` in `TOPIC_STATUS_VISUALS` only, so topic surfaces (sidebar rows in both the agent and group sidebars, and the by-project / by-status group-header failed badges) go back to the alert triangle in `colorError`. `TASK_STATUS_VISUALS.failed` keeps `CircleX`.

### 📝 补充信息 | Additional Information

`AgentTaskDetail/TopicStatusIcon` reads the base `EXECUTION_STATUS_VISUALS.failed` and intentionally stays on `CircleX` — it renders topic *runs* inside a task detail, which belongs to the task visual language.

Icon-only change, no behavior or type changes; verified with `bun run check`.