### PR TITLE
🐛 fix: workspace topic share

### DIFF
--- a/.agents/skills/agent-testing/references/probe-mock-patterns.md
+++ b/.agents/skills/agent-testing/references/probe-mock-patterns.md
@@ -1009,3 +1009,16 @@ nodeintegration, plugins, disablewebsecurity, allowpopups, preload, …`). The h
 - **Works**: set `agent_id` on every seeded message row (matching the topic's `agent_id`).
   Probe the endpoint directly before blaming the UI:
   `/trpc/lambda/message.getMessages?input={"json":{"topicId":..,"topicShareId":..,"agentId":..}}`.
+
+### F2. Seeded share topics also need `topics.agent_id`, or the client never fires the message fetch
+
+- **Situation**: same setup as F1, but the failure is one layer earlier — metadata (title)
+  renders while `message.getMessages` never even appears in network requests.
+- **Doesn't work**: assuming the fetch failed — it was never fired. `useFetchMessages`
+  gates on `!!context.agentId && !!context.topicId`
+  (`src/store/chat/slices/message/actions/query.ts:268`), and the share page passes
+  `agentId: data.agentId ?? ''` — a topic seeded without `agent_id` yields `''` → SWR key
+  is null → no request, silent skeleton (a Case-1 lookalike with no error anywhere).
+- **Works**: seed an `agents` row and set `topics.agent_id` (and `messages.agent_id`)
+  before opening the share page. Verify the fetch actually fired via
+  `agent-browser network requests | grep getMessages`, not by waiting on the UI.

--- a/apps/server/src/routers/lambda/__tests__/integration/message.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/message.integration.test.ts
@@ -629,6 +629,132 @@ describe('Message Router Integration Tests', () => {
       }
     });
 
+    it('should return workspace topic messages via topicShareId for a link share', async () => {
+      const { topicShares, workspaces } = await import('@/database/schemas');
+
+      const [workspace] = await serverDB
+        .insert(workspaces)
+        .values({
+          name: 'Share Test Workspace',
+          primaryOwnerId: userId,
+          slug: `share-test-ws-${userId.slice(0, 8)}`,
+        })
+        .returning();
+
+      const [wsTopic] = await serverDB
+        .insert(topics)
+        .values({ title: 'Workspace Topic', userId, workspaceId: workspace.id })
+        .returning();
+
+      await serverDB.insert(messages).values([
+        {
+          content: 'workspace message 1',
+          id: 'ws-share-msg-1',
+          role: 'user',
+          topicId: wsTopic.id,
+          userId,
+          workspaceId: workspace.id,
+        },
+        {
+          content: 'workspace message 2',
+          id: 'ws-share-msg-2',
+          role: 'assistant',
+          topicId: wsTopic.id,
+          userId,
+          workspaceId: workspace.id,
+        },
+      ]);
+
+      const [share] = await serverDB
+        .insert(topicShares)
+        .values({
+          topicId: wsTopic.id,
+          userId,
+          visibility: 'link',
+          workspaceId: workspace.id,
+        })
+        .returning();
+
+      // Visitor (not the owner, not a workspace member) opens the share link
+      const visitorId = await createTestUser(serverDB);
+      const caller = messageRouter.createCaller(createTestContext(visitorId));
+
+      const result = await caller.getMessages({ topicShareId: share.id });
+
+      expect(result).toHaveLength(2);
+      expect(result.map((m) => m.id)).toEqual(
+        expect.arrayContaining(['ws-share-msg-1', 'ws-share-msg-2']),
+      );
+
+      await cleanupTestUser(serverDB, visitorId);
+    });
+
+    it('rejects everyone but the creator for a PRIVATE share, even workspace members', async () => {
+      const { WORKSPACE_SYSTEM_ROLES } = await import('@lobechat/const/rbac');
+      const { RbacModel } = await import('@/database/models/rbac');
+      const { seedWorkspaceRoles } = await import('@/database/utils/seedWorkspaceRoles');
+      const { topicShares, workspaces } = await import('@/database/schemas');
+
+      const [workspace] = await serverDB
+        .insert(workspaces)
+        .values({
+          name: 'Private Share WS',
+          primaryOwnerId: userId,
+          slug: `priv-share-ws-${userId.slice(0, 8)}`,
+        })
+        .returning();
+      await seedWorkspaceRoles(serverDB, workspace.id);
+
+      const [wsTopic] = await serverDB
+        .insert(topics)
+        .values({ title: 'Private Share Topic', userId, workspaceId: workspace.id })
+        .returning();
+      await serverDB.insert(messages).values({
+        content: 'member-visible message',
+        id: 'ws-priv-share-msg-1',
+        role: 'user',
+        topicId: wsTopic.id,
+        userId,
+        workspaceId: workspace.id,
+      });
+      const [share] = await serverDB
+        .insert(topicShares)
+        .values({
+          topicId: wsTopic.id,
+          userId,
+          visibility: 'private',
+          workspaceId: workspace.id,
+        })
+        .returning();
+
+      // The creator can read messages through their own private share link
+      const creatorCaller = messageRouter.createCaller(createTestContext(userId));
+      const creatorResult = await creatorCaller.getMessages({ topicShareId: share.id });
+      expect(creatorResult.map((m) => m.id)).toEqual(['ws-priv-share-msg-1']);
+
+      // A workspace member (viewer role) is rejected — private is creator-only
+      const memberId = await createTestUser(serverDB);
+      await new RbacModel(serverDB, memberId).assignWorkspaceRole({
+        roleName: WORKSPACE_SYSTEM_ROLES.VIEWER,
+        userId: memberId,
+        workspaceId: workspace.id,
+      });
+      const memberCaller = messageRouter.createCaller(createTestContext(memberId));
+      await expect(memberCaller.getMessages({ topicShareId: share.id })).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+      });
+
+      // A non-member stays FORBIDDEN as well
+      const outsiderId = await createTestUser(serverDB);
+      const outsiderCaller = messageRouter.createCaller(createTestContext(outsiderId));
+      await expect(outsiderCaller.getMessages({ topicShareId: share.id })).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+      });
+
+      await cleanupTestUser(serverDB, memberId);
+      await cleanupTestUser(serverDB, outsiderId);
+    });
+
     it('should return messages filtered by groupId', async () => {
       const caller = messageRouter.createCaller(createTestContext(userId));
 

--- a/apps/server/src/routers/lambda/__tests__/integration/topicShare.integration.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/integration/topicShare.integration.test.ts
@@ -1,0 +1,186 @@
+// @vitest-environment node
+import { WORKSPACE_SYSTEM_ROLES } from '@lobechat/const/rbac';
+import { type LobeChatDatabase } from '@lobechat/database';
+import { topics, workspaceAuditLogs, workspaces } from '@lobechat/database/schemas';
+import { getTestDB } from '@lobechat/database/test-utils';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RbacModel } from '@/database/models/rbac';
+import { seedWorkspaceRoles } from '@/database/utils/seedWorkspaceRoles';
+
+import { topicRouter } from '../../topic';
+import { cleanupTestUser, createTestUser } from './setup';
+
+// Mock FileService to avoid S3 initialization issues in tests
+vi.mock('@/server/services/file', () => ({
+  FileService: vi.fn().mockImplementation(() => ({
+    getFullFileUrl: vi.fn().mockResolvedValue('mock-url'),
+    deleteFile: vi.fn().mockResolvedValue(undefined),
+    deleteFiles: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+let testDB: LobeChatDatabase;
+vi.mock('@/database/core/db-adaptor', () => ({
+  getServerDB: vi.fn(() => testDB),
+}));
+
+const createWorkspaceContext = (userId: string, workspaceId?: string) => ({
+  jwtPayload: { userId },
+  userId,
+  workspaceId,
+});
+
+describe('Topic Share Router Integration Tests (workspace permission matrix)', () => {
+  let serverDB: LobeChatDatabase;
+  let creatorId: string;
+  let memberId: string;
+  let ownerId: string;
+  let workspaceId: string;
+  let topicId: string;
+
+  beforeEach(async () => {
+    serverDB = await getTestDB();
+    testDB = serverDB;
+
+    creatorId = await createTestUser(serverDB);
+    memberId = await createTestUser(serverDB);
+    ownerId = await createTestUser(serverDB);
+
+    const [workspace] = await serverDB
+      .insert(workspaces)
+      .values({
+        name: 'Share Perm WS',
+        primaryOwnerId: ownerId,
+        slug: `share-perm-ws-${creatorId.slice(0, 8)}`,
+      })
+      .returning();
+    workspaceId = workspace.id;
+
+    await seedWorkspaceRoles(serverDB, workspaceId);
+    const rbac = new RbacModel(serverDB, creatorId);
+    await rbac.assignWorkspaceRole({
+      roleName: WORKSPACE_SYSTEM_ROLES.MEMBER,
+      userId: creatorId,
+      workspaceId,
+    });
+    await rbac.assignWorkspaceRole({
+      roleName: WORKSPACE_SYSTEM_ROLES.MEMBER,
+      userId: memberId,
+      workspaceId,
+    });
+    await rbac.assignWorkspaceRole({
+      roleName: WORKSPACE_SYSTEM_ROLES.OWNER,
+      userId: ownerId,
+      workspaceId,
+    });
+
+    const [topic] = await serverDB
+      .insert(topics)
+      .values({ title: 'WS Perm Topic', userId: creatorId, workspaceId })
+      .returning();
+    topicId = topic.id;
+  });
+
+  afterEach(async () => {
+    await serverDB
+      .delete(workspaceAuditLogs)
+      .where(eq(workspaceAuditLogs.workspaceId, workspaceId));
+    await serverDB.delete(workspaces).where(eq(workspaces.id, workspaceId));
+    await cleanupTestUser(serverDB, creatorId);
+    await cleanupTestUser(serverDB, memberId);
+    await cleanupTestUser(serverDB, ownerId);
+  });
+
+  const auditRows = () =>
+    serverDB.query.workspaceAuditLogs.findMany({
+      where: eq(workspaceAuditLogs.workspaceId, workspaceId),
+    });
+
+  describe('management permission: creator + workspace owner only', () => {
+    it('creator can enable and switch their own share', async () => {
+      const caller = topicRouter.createCaller(createWorkspaceContext(creatorId, workspaceId));
+
+      const created = await caller.enableSharing({ topicId, visibility: 'private' });
+      expect(created?.topicId).toBe(topicId);
+
+      const updated = await caller.updateShareVisibility({ topicId, visibility: 'link' });
+      expect(updated?.visibility).toBe('link');
+    });
+
+    it("another member cannot manage the creator's share", async () => {
+      const creatorCaller = topicRouter.createCaller(
+        createWorkspaceContext(creatorId, workspaceId),
+      );
+      await creatorCaller.enableSharing({ topicId, visibility: 'private' });
+
+      const memberCaller = topicRouter.createCaller(createWorkspaceContext(memberId, workspaceId));
+
+      await expect(
+        memberCaller.updateShareVisibility({ topicId, visibility: 'link' }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      await expect(memberCaller.disableSharing({ topicId })).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+      });
+      await expect(
+        memberCaller.enableSharing({ topicId, visibility: 'link' }),
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+
+    it("workspace owner can manage a member's share", async () => {
+      const creatorCaller = topicRouter.createCaller(
+        createWorkspaceContext(creatorId, workspaceId),
+      );
+      await creatorCaller.enableSharing({ topicId, visibility: 'link' });
+
+      const ownerCaller = topicRouter.createCaller(createWorkspaceContext(ownerId, workspaceId));
+
+      const updated = await ownerCaller.updateShareVisibility({ topicId, visibility: 'private' });
+      expect(updated?.visibility).toBe('private');
+    });
+  });
+
+  describe('audit trail', () => {
+    it('records resource.shared when visibility becomes link, and resource.unshared when it leaves', async () => {
+      const caller = topicRouter.createCaller(createWorkspaceContext(creatorId, workspaceId));
+
+      // private placeholder — no audit
+      await caller.enableSharing({ topicId, visibility: 'private' });
+      expect(await auditRows()).toHaveLength(0);
+
+      // private -> link — resource.shared
+      await caller.updateShareVisibility({ topicId, visibility: 'link' });
+      let rows = await auditRows();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        action: 'resource.shared',
+        resourceId: topicId,
+        resourceType: 'topic',
+        userId: creatorId,
+      });
+
+      // link -> disabled — resource.unshared
+      await caller.disableSharing({ topicId });
+      rows = await auditRows();
+      expect(rows).toHaveLength(2);
+      expect(rows.map((r) => r.action).sort()).toEqual(['resource.shared', 'resource.unshared']);
+    });
+
+    it('personal mode is not audited and stays creator-managed', async () => {
+      const [personalTopic] = await serverDB
+        .insert(topics)
+        .values({ title: 'Personal Topic', userId: creatorId })
+        .returning();
+
+      const caller = topicRouter.createCaller(createWorkspaceContext(creatorId, undefined));
+      const created = await caller.enableSharing({
+        topicId: personalTopic.id,
+        visibility: 'link',
+      });
+      expect(created?.visibility).toBe('link');
+
+      expect(await auditRows()).toHaveLength(0);
+    });
+  });
+});

--- a/apps/server/src/routers/lambda/__tests__/share.test.ts
+++ b/apps/server/src/routers/lambda/__tests__/share.test.ts
@@ -37,6 +37,7 @@ describe('shareRouter', () => {
         title: 'Test Topic',
         topicId: 'topic-1',
         visibility: 'link',
+        workspaceId: null,
       };
 
       vi.mocked(TopicShareModel.findByShareIdWithAccessCheck).mockResolvedValue(mockShare);
@@ -88,6 +89,7 @@ describe('shareRouter', () => {
         title: 'Topic with Agent',
         topicId: 'topic-1',
         visibility: 'link',
+        workspaceId: null,
       };
 
       vi.mocked(TopicShareModel.findByShareIdWithAccessCheck).mockResolvedValue(mockShare);
@@ -134,6 +136,7 @@ describe('shareRouter', () => {
         title: 'Group Topic',
         topicId: 'topic-2',
         visibility: 'link',
+        workspaceId: null,
       };
 
       vi.mocked(TopicShareModel.findByShareIdWithAccessCheck).mockResolvedValue(mockShare);
@@ -216,6 +219,7 @@ describe('shareRouter', () => {
         title: 'Private Topic',
         topicId: 'topic-private',
         visibility: 'private',
+        workspaceId: null,
       };
 
       vi.mocked(TopicShareModel.findByShareIdWithAccessCheck).mockResolvedValue(mockShare);

--- a/apps/server/src/routers/lambda/message.ts
+++ b/apps/server/src/routers/lambda/message.ts
@@ -305,8 +305,12 @@ export const messageRouter = router({
           ctx.userId ?? undefined,
         );
 
-        const messageModel = new MessageModel(ctx.serverDB, share.ownerId);
-        const fileService = new FileService(ctx.serverDB, share.ownerId);
+        // Workspace shares store their workspaceId on the share record; without
+        // it the ownership filter degrades to `workspace_id IS NULL` and returns
+        // no messages for workspace topics.
+        const shareWorkspaceId = share.workspaceId ?? undefined;
+        const messageModel = new MessageModel(ctx.serverDB, share.ownerId, shareWorkspaceId);
+        const fileService = new FileService(ctx.serverDB, share.ownerId, shareWorkspaceId);
 
         return messageModel.query(
           { ...queryParams, topicId: share.topicId },

--- a/apps/server/src/routers/lambda/topic.ts
+++ b/apps/server/src/routers/lambda/topic.ts
@@ -1,3 +1,4 @@
+import { PERMISSION_ACTIONS } from '@lobechat/const/rbac';
 import {
   chatTopicMetadataUpdateSchema,
   chatTopicStatusSchema,
@@ -8,6 +9,7 @@ import {
   type RecentTopicGroupMember,
 } from '@lobechat/types';
 import { cleanObject } from '@lobechat/utils';
+import { TRPCError } from '@trpc/server';
 import { inArray } from 'drizzle-orm';
 import { after } from 'next/server';
 import { z } from 'zod';
@@ -20,12 +22,15 @@ import { AgentOperationModel } from '@/database/models/agentOperation';
 import { ChatGroupModel } from '@/database/models/chatGroup';
 import { FileModel } from '@/database/models/file';
 import { MessageModel } from '@/database/models/message';
+import { RbacModel } from '@/database/models/rbac';
 import { TopicModel } from '@/database/models/topic';
 import { TopicShareModel } from '@/database/models/topicShare';
+import { WorkspaceAuditLogModel } from '@/database/models/workspaceAuditLog';
 import { AgentMigrationRepo } from '@/database/repositories/agentMigration';
 import { HeteroSessionImporterRepo } from '@/database/repositories/heteroSessionImporter';
 import { TopicImporterRepo } from '@/database/repositories/topicImporter';
 import { chatGroups } from '@/database/schemas';
+import type { LobeChatDatabase } from '@/database/type';
 import { router } from '@/libs/trpc/lambda';
 import { serverDatabase } from '@/libs/trpc/lambda/middleware';
 import { FileService } from '@/server/services/file';
@@ -55,6 +60,65 @@ const topicProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) =>
     },
   });
 });
+
+interface TopicShareCtx {
+  serverDB: LobeChatDatabase;
+  topicModel: TopicModel;
+  userId: string;
+  workspaceId?: string | null;
+}
+
+/**
+ * Workspace share management is creator + workspace-owner only: a member may
+ * manage shares of their own topics; managing someone else's requires the
+ * `:all` scope (workspace owner). Personal mode needs no extra check — the
+ * model's ownership filter already scopes mutations to the caller.
+ */
+const assertCanManageTopicShare = async (ctx: TopicShareCtx, topicId: string) => {
+  if (!ctx.workspaceId) return;
+
+  const topic = await ctx.topicModel.findById(topicId);
+  if (!topic) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Topic not found' });
+  }
+  if (topic.userId === ctx.userId) return;
+
+  const isWorkspaceAdmin = await new RbacModel(ctx.serverDB, ctx.userId).hasPermission(
+    `${PERMISSION_ACTIONS.TOPIC_UPDATE}:all`,
+    { workspaceId: ctx.workspaceId },
+  );
+  if (!isWorkspaceAdmin) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'Only the topic creator or a workspace owner can manage this share',
+    });
+  }
+};
+
+/**
+ * Audit trail for workspace share state changes, mirroring the page-share
+ * `resource.shared` / `resource.unshared` events. Personal mode is not
+ * audited. A share record with 'private' visibility is an unshared
+ * placeholder, so only transitions in/out of 'link' are recorded.
+ */
+const recordTopicShareAudit = async (
+  ctx: TopicShareCtx,
+  params: { currentVisibility: string; previousVisibility: string; topicId: string },
+) => {
+  if (!ctx.workspaceId) return;
+  const { currentVisibility, previousVisibility, topicId } = params;
+  if (currentVisibility === previousVisibility) return;
+  if (currentVisibility !== 'link' && previousVisibility !== 'link') return;
+
+  await new WorkspaceAuditLogModel(ctx.serverDB).create({
+    action: currentVisibility === 'link' ? 'resource.shared' : 'resource.unshared',
+    metadata: { currentVisibility, previousVisibility },
+    resourceId: topicId,
+    resourceType: 'topic',
+    userId: ctx.userId,
+    workspaceId: ctx.workspaceId,
+  });
+};
 
 export const topicRouter = router({
   getTopicDetail: topicProcedure
@@ -246,7 +310,20 @@ export const topicRouter = router({
     .use(withScopedPermission('topic:update'))
     .input(z.object({ topicId: z.string() }))
     .mutation(async ({ input, ctx }) => {
-      return ctx.topicShareModel.deleteByTopicId(input.topicId);
+      await assertCanManageTopicShare(ctx, input.topicId);
+
+      const previous = await ctx.topicShareModel.getByTopicId(input.topicId);
+      const result = await ctx.topicShareModel.deleteByTopicId(input.topicId);
+
+      if (previous) {
+        await recordTopicShareAudit(ctx, {
+          currentVisibility: 'private',
+          previousVisibility: previous.visibility,
+          topicId: input.topicId,
+        });
+      }
+
+      return result;
     }),
 
   /**
@@ -261,7 +338,20 @@ export const topicRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      return ctx.topicShareModel.create(input.topicId, input.visibility);
+      await assertCanManageTopicShare(ctx, input.topicId);
+
+      const previous = await ctx.topicShareModel.getByTopicId(input.topicId);
+      const result = await ctx.topicShareModel.create(input.topicId, input.visibility);
+
+      if (result) {
+        await recordTopicShareAudit(ctx, {
+          currentVisibility: result.visibility,
+          previousVisibility: previous?.visibility ?? 'private',
+          topicId: input.topicId,
+        });
+      }
+
+      return result;
     }),
 
   queryTopics: topicProcedure
@@ -651,7 +741,20 @@ export const topicRouter = router({
       }),
     )
     .mutation(async ({ input, ctx }) => {
-      return ctx.topicShareModel.updateVisibility(input.topicId, input.visibility);
+      await assertCanManageTopicShare(ctx, input.topicId);
+
+      const previous = await ctx.topicShareModel.getByTopicId(input.topicId);
+      const result = await ctx.topicShareModel.updateVisibility(input.topicId, input.visibility);
+
+      if (result && previous) {
+        await recordTopicShareAudit(ctx, {
+          currentVisibility: result.visibility,
+          previousVisibility: previous.visibility,
+          topicId: input.topicId,
+        });
+      }
+
+      return result;
     }),
 
   updateTopic: topicProcedure

--- a/packages/database/src/models/__tests__/documentShare.test.ts
+++ b/packages/database/src/models/__tests__/documentShare.test.ts
@@ -1,11 +1,14 @@
 // @vitest-environment node
+import { WORKSPACE_SYSTEM_ROLES } from '@lobechat/const/rbac';
 import { TRPCError } from '@trpc/server';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { getTestDB } from '../../core/getTestDB';
-import { documents, documentShares, users } from '../../schemas';
+import { documents, documentShares, users, workspaces } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
+import { seedWorkspaceRoles } from '../../utils/seedWorkspaceRoles';
 import { DocumentShareModel } from '../documentShare';
+import { RbacModel } from '../rbac';
 
 const serverDB: LobeChatDatabase = await getTestDB();
 
@@ -234,6 +237,144 @@ describe('DocumentShareModel', () => {
 
       const after = await shareModel.getByDocumentId(docId);
       expect(after!.pageViewCount).toBe(2);
+    });
+  });
+
+  describe('workspace mode ownership', () => {
+    const workspaceId = 'doc-share-ws-ownership';
+    const wsDocId = 'doc-share-ws-ownership-doc';
+    let wsShareModel: DocumentShareModel;
+
+    beforeEach(async () => {
+      await serverDB.insert(workspaces).values({
+        id: workspaceId,
+        name: 'Ownership WS',
+        primaryOwnerId: userId,
+        slug: 'doc-share-ws-ownership',
+      });
+      await serverDB
+        .insert(documents)
+        .values({ id: wsDocId, title: 'WS Doc', userId, workspaceId, ...baseDocFields });
+      wsShareModel = new DocumentShareModel(serverDB, userId, workspaceId);
+    });
+
+    it('getByDocumentId should still find the share after switching visibility to link', async () => {
+      await wsShareModel.create(wsDocId, { visibility: 'private' });
+
+      const updated = await wsShareModel.updateVisibility(wsDocId, 'link');
+      expect(updated).not.toBeNull();
+
+      // Regression: document_shares.visibility is 'private' | 'link' (share
+      // semantics) and must not be fed into the workspace row-visibility filter.
+      const info = await wsShareModel.getByDocumentId(wsDocId);
+      expect(info).not.toBeNull();
+      expect(info!.visibility).toBe('link');
+    });
+
+    it('updatePermission works on a link share in workspace mode', async () => {
+      await wsShareModel.create(wsDocId, { visibility: 'link' });
+
+      const updated = await wsShareModel.updatePermission(wsDocId, 'edit');
+      expect(updated).not.toBeNull();
+      expect(updated!.permission).toBe('edit');
+    });
+
+    it('deleteByDocumentId removes a link share in workspace mode', async () => {
+      await wsShareModel.create(wsDocId, { visibility: 'link' });
+
+      await wsShareModel.deleteByDocumentId(wsDocId);
+
+      const info = await wsShareModel.getByDocumentId(wsDocId);
+      expect(info).toBeNull();
+    });
+
+    describe('findByDocumentIdWithAccessCheck — private is creator-only, even in a workspace', () => {
+      beforeEach(async () => {
+        await seedWorkspaceRoles(serverDB, workspaceId);
+        await new RbacModel(serverDB, userId2).assignWorkspaceRole({
+          roleName: WORKSPACE_SYSTEM_ROLES.VIEWER,
+          userId: userId2,
+          workspaceId,
+        });
+      });
+
+      it('rejects a workspace member (viewer role) for a private share', async () => {
+        await wsShareModel.create(wsDocId, { visibility: 'private' });
+
+        try {
+          await DocumentShareModel.findByDocumentIdWithAccessCheck(serverDB, wsDocId, userId2);
+          throw new Error('should not reach');
+        } catch (error) {
+          expect((error as TRPCError).code).toBe('FORBIDDEN');
+        }
+      });
+
+      it('rejects a workspace member for a doc with NO share record', async () => {
+        try {
+          await DocumentShareModel.findByDocumentIdWithAccessCheck(serverDB, wsDocId, userId2);
+          throw new Error('should not reach');
+        } catch (error) {
+          expect((error as TRPCError).code).toBe('FORBIDDEN');
+        }
+      });
+
+      it('allows the creator to view their own private share', async () => {
+        await wsShareModel.create(wsDocId, { visibility: 'private' });
+
+        const result = await DocumentShareModel.findByDocumentIdWithAccessCheck(
+          serverDB,
+          wsDocId,
+          userId,
+        );
+
+        expect(result.document.id).toBe(wsDocId);
+        expect(result.isOwner).toBe(true);
+      });
+
+      it('rejects a member for a workspace-PRIVATE doc private share (row visibility wins)', async () => {
+        const privDocId = 'doc-share-ws-priv-doc';
+        await serverDB.insert(documents).values({
+          id: privDocId,
+          title: 'WS Private Doc',
+          userId,
+          visibility: 'private',
+          workspaceId,
+          ...baseDocFields,
+        });
+        const privShareModel = new DocumentShareModel(serverDB, userId, workspaceId);
+        await privShareModel.create(privDocId, { visibility: 'private' });
+
+        try {
+          await DocumentShareModel.findByDocumentIdWithAccessCheck(serverDB, privDocId, userId2);
+          throw new Error('should not reach');
+        } catch (error) {
+          expect((error as TRPCError).code).toBe('FORBIDDEN');
+        }
+      });
+
+      it('rejects anonymous access for a private workspace share', async () => {
+        await wsShareModel.create(wsDocId, { visibility: 'private' });
+
+        try {
+          await DocumentShareModel.findByDocumentIdWithAccessCheck(serverDB, wsDocId, undefined);
+          throw new Error('should not reach');
+        } catch (error) {
+          expect((error as TRPCError).code).toBe('FORBIDDEN');
+        }
+      });
+
+      it('rejects a non-member for a private workspace share', async () => {
+        const outsiderId = 'doc-share-outsider';
+        await serverDB.insert(users).values({ id: outsiderId });
+        await wsShareModel.create(wsDocId, { visibility: 'private' });
+
+        try {
+          await DocumentShareModel.findByDocumentIdWithAccessCheck(serverDB, wsDocId, outsiderId);
+          throw new Error('should not reach');
+        } catch (error) {
+          expect((error as TRPCError).code).toBe('FORBIDDEN');
+        }
+      });
     });
   });
 });

--- a/packages/database/src/models/__tests__/topicShare.test.ts
+++ b/packages/database/src/models/__tests__/topicShare.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { WORKSPACE_SYSTEM_ROLES } from '@lobechat/const/rbac';
 import { TRPCError } from '@trpc/server';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -11,8 +12,11 @@ import {
   topics,
   topicShares,
   users,
+  workspaces,
 } from '../../schemas';
 import type { LobeChatDatabase } from '../../type';
+import { seedWorkspaceRoles } from '../../utils/seedWorkspaceRoles';
+import { RbacModel } from '../rbac';
 import { TopicShareModel } from '../topicShare';
 
 const serverDB: LobeChatDatabase = await getTestDB();
@@ -202,6 +206,155 @@ describe('TopicShareModel', () => {
 
       expect(result).toBeDefined();
       expect(result!.agentId).toBeNull();
+    });
+
+    it('should return workspaceId for a workspace topic share', async () => {
+      const workspaceId = 'topic-share-test-workspace';
+      const wsTopicId = 'topic-share-test-ws-topic';
+
+      await serverDB.insert(workspaces).values({
+        id: workspaceId,
+        name: 'Test Workspace',
+        primaryOwnerId: userId,
+        slug: 'topic-share-test-ws',
+      });
+      await serverDB
+        .insert(topics)
+        .values({ id: wsTopicId, title: 'Workspace Topic', userId, workspaceId });
+
+      const wsShareModel = new TopicShareModel(serverDB, userId, workspaceId);
+      const created = await wsShareModel.create(wsTopicId, 'link');
+
+      const result = await TopicShareModel.findByShareId(serverDB, created.id);
+
+      expect(result).toBeDefined();
+      expect(result!.workspaceId).toBe(workspaceId);
+    });
+
+    it('should return null workspaceId for a personal topic share', async () => {
+      const created = await topicShareModel.create(topicId, 'link');
+
+      const result = await TopicShareModel.findByShareId(serverDB, created.id);
+
+      expect(result!.workspaceId).toBeNull();
+    });
+  });
+
+  describe('workspace mode ownership', () => {
+    const workspaceId = 'topic-share-ws-ownership';
+    const wsTopicId = 'topic-share-ws-ownership-topic';
+    let wsShareModel: TopicShareModel;
+
+    beforeEach(async () => {
+      await serverDB.insert(workspaces).values({
+        id: workspaceId,
+        name: 'Ownership WS',
+        primaryOwnerId: userId,
+        slug: 'topic-share-ws-ownership',
+      });
+      await serverDB
+        .insert(topics)
+        .values({ id: wsTopicId, title: 'WS Ownership Topic', userId, workspaceId });
+      wsShareModel = new TopicShareModel(serverDB, userId, workspaceId);
+    });
+
+    it('getByTopicId should still find the share after switching visibility to link', async () => {
+      await wsShareModel.create(wsTopicId, 'private');
+
+      const updated = await wsShareModel.updateVisibility(wsTopicId, 'link');
+      expect(updated).not.toBeNull();
+
+      // Regression: topic_shares.visibility is 'private' | 'link' (share semantics),
+      // it must NOT be treated as the workspace 'public' | 'private' row-visibility —
+      // a 'link' share used to be filtered out by its own ownership clause.
+      const info = await wsShareModel.getByTopicId(wsTopicId);
+      expect(info).not.toBeNull();
+      expect(info!.visibility).toBe('link');
+    });
+
+    it('updateVisibility can switch a link share back to private', async () => {
+      await wsShareModel.create(wsTopicId, 'link');
+
+      const updated = await wsShareModel.updateVisibility(wsTopicId, 'private');
+      expect(updated).not.toBeNull();
+      expect(updated!.visibility).toBe('private');
+    });
+
+    it('deleteByTopicId removes a link share in workspace mode', async () => {
+      const created = await wsShareModel.create(wsTopicId, 'link');
+
+      await wsShareModel.deleteByTopicId(wsTopicId);
+
+      const result = await TopicShareModel.findByShareId(serverDB, created.id);
+      expect(result).toBeNull();
+    });
+
+    describe('findByShareIdWithAccessCheck — private is creator-only, even in a workspace', () => {
+      beforeEach(async () => {
+        await seedWorkspaceRoles(serverDB, workspaceId);
+      });
+
+      it('rejects a workspace member (viewer role) for a private share', async () => {
+        await new RbacModel(serverDB, userId2).assignWorkspaceRole({
+          roleName: WORKSPACE_SYSTEM_ROLES.VIEWER,
+          userId: userId2,
+          workspaceId,
+        });
+        const created = await wsShareModel.create(wsTopicId, 'private');
+
+        try {
+          await TopicShareModel.findByShareIdWithAccessCheck(serverDB, created.id, userId2);
+          throw new Error('should not reach');
+        } catch (error) {
+          expect((error as TRPCError).code).toBe('FORBIDDEN');
+        }
+      });
+
+      it('allows the creator to view their own private share', async () => {
+        const created = await wsShareModel.create(wsTopicId, 'private');
+
+        const result = await TopicShareModel.findByShareIdWithAccessCheck(
+          serverDB,
+          created.id,
+          userId,
+        );
+
+        expect(result.topicId).toBe(wsTopicId);
+      });
+
+      it('rejects a non-member user for a private workspace share', async () => {
+        const created = await wsShareModel.create(wsTopicId, 'private');
+
+        try {
+          await TopicShareModel.findByShareIdWithAccessCheck(serverDB, created.id, userId2);
+          throw new Error('should not reach');
+        } catch (error) {
+          expect((error as TRPCError).code).toBe('FORBIDDEN');
+        }
+      });
+
+      it('rejects anonymous access for a private workspace share', async () => {
+        const created = await wsShareModel.create(wsTopicId, 'private');
+
+        try {
+          await TopicShareModel.findByShareIdWithAccessCheck(serverDB, created.id, undefined);
+          throw new Error('should not reach');
+        } catch (error) {
+          expect((error as TRPCError).code).toBe('FORBIDDEN');
+        }
+      });
+
+      it('still allows anonymous access for a link workspace share', async () => {
+        const created = await wsShareModel.create(wsTopicId, 'link');
+
+        const result = await TopicShareModel.findByShareIdWithAccessCheck(
+          serverDB,
+          created.id,
+          undefined,
+        );
+
+        expect(result.topicId).toBe(wsTopicId);
+      });
     });
   });
 

--- a/packages/database/src/models/__tests__/topicShare.test.ts
+++ b/packages/database/src/models/__tests__/topicShare.test.ts
@@ -272,6 +272,17 @@ describe('TopicShareModel', () => {
       expect(info!.visibility).toBe('link');
     });
 
+    it('create keeps the topic creator as share owner when another member creates the share', async () => {
+      // Regression: a workspace admin creating a share for a member's topic used
+      // to insert their own id as topic_shares.user_id, which downstream access
+      // checks treat as ownerId — locking the actual creator out of a private share.
+      const adminShareModel = new TopicShareModel(serverDB, userId2, workspaceId);
+
+      const created = await adminShareModel.create(wsTopicId, 'private');
+
+      expect(created!.userId).toBe(userId);
+    });
+
     it('updateVisibility can switch a link share back to private', async () => {
       await wsShareModel.create(wsTopicId, 'link');
 

--- a/packages/database/src/models/documentShare.ts
+++ b/packages/database/src/models/documentShare.ts
@@ -27,6 +27,15 @@ export class DocumentShareModel {
     this.db = db;
   }
 
+  // document_shares.visibility is share semantics ('private' | 'link'), not the
+  // workspace row-visibility ('public' | 'private') — pass only the scope
+  // columns so buildWorkspaceWhere never filters on it.
+  private ownership = () =>
+    buildWorkspaceWhere(
+      { userId: this.userId, workspaceId: this.workspaceId },
+      { userId: documentShares.userId, workspaceId: documentShares.workspaceId },
+    );
+
   create = async (
     documentId: string,
     params: {
@@ -75,15 +84,7 @@ export class DocumentShareModel {
     const [result] = await this.db
       .update(documentShares)
       .set({ updatedAt: new Date(), visibility })
-      .where(
-        and(
-          eq(documentShares.documentId, documentId),
-          buildWorkspaceWhere(
-            { userId: this.userId, workspaceId: this.workspaceId },
-            documentShares,
-          ),
-        ),
-      )
+      .where(and(eq(documentShares.documentId, documentId), this.ownership()))
       .returning();
 
     return result || null;
@@ -93,15 +94,7 @@ export class DocumentShareModel {
     const [result] = await this.db
       .update(documentShares)
       .set({ permission, updatedAt: new Date() })
-      .where(
-        and(
-          eq(documentShares.documentId, documentId),
-          buildWorkspaceWhere(
-            { userId: this.userId, workspaceId: this.workspaceId },
-            documentShares,
-          ),
-        ),
-      )
+      .where(and(eq(documentShares.documentId, documentId), this.ownership()))
       .returning();
 
     return result || null;
@@ -110,15 +103,7 @@ export class DocumentShareModel {
   deleteByDocumentId = async (documentId: string) => {
     return this.db
       .delete(documentShares)
-      .where(
-        and(
-          eq(documentShares.documentId, documentId),
-          buildWorkspaceWhere(
-            { userId: this.userId, workspaceId: this.workspaceId },
-            documentShares,
-          ),
-        ),
-      );
+      .where(and(eq(documentShares.documentId, documentId), this.ownership()));
   };
 
   getByDocumentId = async (documentId: string) => {
@@ -132,15 +117,7 @@ export class DocumentShareModel {
         visibility: documentShares.visibility,
       })
       .from(documentShares)
-      .where(
-        and(
-          eq(documentShares.documentId, documentId),
-          buildWorkspaceWhere(
-            { userId: this.userId, workspaceId: this.workspaceId },
-            documentShares,
-          ),
-        ),
-      )
+      .where(and(eq(documentShares.documentId, documentId), this.ownership()))
       .limit(1);
 
     return result[0] || null;
@@ -187,6 +164,8 @@ export class DocumentShareModel {
     const isOwner = !!accessUserId && row.document.userId === accessUserId;
 
     if (!isOwner) {
+      // 'private' (or no share record) is creator-only, even inside a
+      // workspace; only 'link' opens the page to other viewers.
       const hasShare = !!row.visibility;
       if (!hasShare || row.visibility === 'private') {
         throw new TRPCError({ code: 'FORBIDDEN', message: 'This page is private' });

--- a/packages/database/src/models/topicShare.ts
+++ b/packages/database/src/models/topicShare.ts
@@ -57,7 +57,10 @@ export class TopicShareModel {
       .insert(topicShares)
       .values({
         topicId,
-        userId: this.userId,
+        // Keep the topic creator as the share owner even when a workspace
+        // admin manages the share — downstream access checks treat this
+        // column as ownerId for private-share visibility.
+        userId: topic.userId,
         visibility,
         workspaceId: this.workspaceId ?? null,
       })

--- a/packages/database/src/models/topicShare.ts
+++ b/packages/database/src/models/topicShare.ts
@@ -26,8 +26,14 @@ export class TopicShareModel {
     this.workspaceId = workspaceId;
   }
 
+  // topic_shares.visibility is share semantics ('private' | 'link'), not the
+  // workspace row-visibility ('public' | 'private') — pass only the scope
+  // columns so buildWorkspaceWhere never filters on it.
   private ownership = () =>
-    buildWorkspaceWhere({ userId: this.userId, workspaceId: this.workspaceId }, topicShares);
+    buildWorkspaceWhere(
+      { userId: this.userId, workspaceId: this.workspaceId },
+      { userId: topicShares.userId, workspaceId: topicShares.workspaceId },
+    );
 
   /**
    * Create or get existing share for a topic.
@@ -131,6 +137,7 @@ export class TopicShareModel {
         title: topics.title,
         topicId: topics.id,
         visibility: topicShares.visibility,
+        workspaceId: topicShares.workspaceId,
       })
       .from(topicShares)
       .innerJoin(topics, eq(topicShares.topicId, topics.id))
@@ -213,7 +220,7 @@ export class TopicShareModel {
     const isOwner = accessUserId && share.ownerId === accessUserId;
 
     // Only check visibility for non-owners
-    // 'private' - only owner can view
+    // 'private' - only the share creator can view, even inside a workspace
     // 'link' - anyone with the link can view
     if (!isOwner && share.visibility === 'private') {
       throw new TRPCError({ code: 'FORBIDDEN', message: 'This share is private' });


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

Fixes workspace topic sharing, which was broken in several ways for workspace-scoped topics:

**1. Share-page message list never loads for workspace topics**

`topic.getShareDetail` consumers construct `MessageModel` / `FileService` with only `share.ownerId`. For a workspace topic the ownership filter then degrades to `workspace_id IS NULL` and returns no messages. The share record now carries `workspaceId`, and `message.getShareMessages` passes it through to `MessageModel` / `FileService`.

**2. `buildWorkspaceWhere` mis-filters on the share table's own `visibility` column**

`topic_shares.visibility` / `document_shares.visibility` hold share semantics (`'private' | 'link'`), not the workspace row-visibility (`'public' | 'private'`). Passing the whole table to `buildWorkspaceWhere` made it filter on that column. Both `TopicShareModel` and `DocumentShareModel` now pass only the scope columns (`userId`, `workspaceId`) via a shared `ownership()` helper.

**3. No permission boundary for managing someone else's workspace topic share**

`topic.createShare` / `updateShareVisibility` / `deleteShare` now enforce creator-or-workspace-owner via `assertCanManageTopicShare` (owner check = `topic:update:all` scope through `RbacModel.hasPermission`). Personal mode is unchanged — the model's ownership filter already scopes mutations to the caller.

**4. Workspace share state changes are now audited**

Transitions in/out of `'link'` visibility write `resource.shared` / `resource.unshared` rows to the workspace audit log, mirroring the existing page-share events. Personal mode is not audited.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- `apps/server/src/routers/lambda/__tests__/integration/topicShare.integration.test.ts` (new): end-to-end share create/update/delete + permission + audit coverage
- `packages/database/src/models/__tests__/topicShare.test.ts` / `documentShare.test.ts`: ownership-filter regression tests for workspace-scoped shares
- `message.integration.test.ts`: workspace share message query coverage

#### 📝 Additional Information

`getByTopicId` now also returns `workspaceId` on the share detail payload; existing consumers are unaffected (additive field).
