### PR TITLE
🐛 fix(hetero): surface the reason Claude Code reports in result errors

### DIFF
--- a/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.test.ts
@@ -141,6 +141,25 @@ describe('ClaudeCodeAdapter', () => {
       expect(errorEvent.data).toMatchObject({ code: 'auth_required', stderr: apiError });
     });
 
+    it('surfaces the reason CC reports in the result `errors` array', () => {
+      const adapter = new ClaudeCodeAdapter();
+      const reason = 'No conversation found with session ID: 4f3a6a4a-2ac2-4a8e-b513-5cff081f3ae6';
+
+      adapter.adapt({ subtype: 'init', type: 'system' });
+      const events = adapter.adapt({
+        duration_ms: 0,
+        errors: [reason],
+        is_error: true,
+        num_turns: 0,
+        subtype: 'error_during_execution',
+        type: 'result',
+      });
+
+      const errorEvent = events.at(-1)!;
+      expect(errorEvent.type).toBe('error');
+      expect(errorEvent.data.message).toBe(reason);
+    });
+
     it('does NOT let a stale streamed API error leak into the next run', () => {
       const adapter = new ClaudeCodeAdapter();
       adapter.adapt({ subtype: 'init', type: 'system' });

--- a/packages/heterogeneous-agents/src/adapters/claudeCode.ts
+++ b/packages/heterogeneous-agents/src/adapters/claudeCode.ts
@@ -296,6 +296,25 @@ const getCliResultMessage = (result: unknown): string | undefined => {
   }
 };
 
+/**
+ * CC reports the reason for a failed run in the result event's `errors` array
+ * — a stale `--resume` id, for instance, yields `subtype:
+ * 'error_during_execution'` with an EMPTY `result` but `errors: ['No
+ * conversation found with session ID: …']`. Reading only `result` therefore
+ * threw away the one line that says what actually happened, leaving the error
+ * card to claim CC "exited without reporting a reason".
+ */
+const getCliResultErrors = (raw: any): string | undefined => {
+  if (!Array.isArray(raw?.errors)) return undefined;
+
+  const text = raw.errors
+    .map((entry: unknown) => getCliResultMessage(entry))
+    .filter((entry?: string): entry is string => !!entry?.trim())
+    .join('\n');
+
+  return text || undefined;
+};
+
 const asRecord = (value: unknown): Record<string, unknown> | undefined =>
   value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -441,10 +460,10 @@ const getAuthRequiredTerminalError = (
  * frequently carry NO `result` text at all — a mid-response network drop
  * yields `{subtype: 'error_during_execution', is_error: true}` and nothing
  * else — which used to surface as an opaque `Agent execution failed`.
- * Prefer, in order: the CLI's own result text, the synthetic `API Error:`
- * line captured off the stream, then a subtype-specific description — and
- * attach the result event's diagnostic fields so the error card's details
- * pane says what actually happened.
+ * Prefer, in order: the CLI's own result text, its `errors` array, the
+ * synthetic `API Error:` line captured off the stream, then a subtype-specific
+ * description — and attach the result event's diagnostic fields so the error
+ * card's details pane says what actually happened.
  */
 const buildFallbackTerminalError = (
   raw: any,
@@ -454,6 +473,7 @@ const buildFallbackTerminalError = (
     typeof raw.subtype === 'string' && raw.subtype !== 'success' ? raw.subtype : undefined;
   const message =
     getCliResultMessage(raw.result) ||
+    getCliResultErrors(raw) ||
     streamedApiError ||
     (subtype && CLI_ERROR_SUBTYPE_MESSAGES[subtype]) ||
     'Agent execution failed';
@@ -1677,10 +1697,12 @@ export class ClaudeCodeAdapter implements AgentEventAdapter {
 
     // Classifiers read the result text; a mid-run API failure often ships an
     // EMPTY result (`subtype: 'error_during_execution'` and nothing else), so
-    // fall back to the synthetic `API Error:` line captured off the stream —
-    // an auth / overload failure that died mid-response still classifies to
-    // its dedicated guide instead of the generic fallback.
-    const classifiableResult = getCliResultMessage(raw.result) || this.lastApiErrorText;
+    // fall back to CC's own `errors` array and then to the synthetic `API
+    // Error:` line captured off the stream — an auth / overload failure that
+    // died mid-response still classifies to its dedicated guide instead of the
+    // generic fallback.
+    const classifiableResult =
+      getCliResultMessage(raw.result) || getCliResultErrors(raw) || this.lastApiErrorText;
     const rateLimitError = getRateLimitTerminalError(classifiableResult, this.pendingRateLimitInfo);
     const finalEvent: HeterogeneousAgentEvent | undefined = raw.is_error
       ? this.makeEvent(


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔗 Related Issue

<!-- none -->

#### 🔀 Description of Change

Claude Code reports why a run failed in the terminal `result` event's `errors` array. A stale `--resume` id, for example, produces:

```json
{
  "type": "result",
  "subtype": "error_during_execution",
  "is_error": true,
  "num_turns": 0,
  "duration_ms": 0,
  "errors": ["No conversation found with session ID: 4f3a6a4a-…"]
}
```

The adapter only looked at `result` (plus the synthetic `API Error:` line captured off the stream), so `errors[]` was thrown away and the terminal error card fell through to the generic subtype copy — "Claude Code hit an error mid-run and exited without reporting a reason." — even though CC had said exactly what happened.

This reads `errors[]` back:

- `buildFallbackTerminalError` now prefers, in order: `result` → **`errors[]`** → streamed `API Error:` line → subtype fallback copy.
- The same text feeds `handleResult`'s `classifiableResult`, so an `errors[]` entry describing a rate limit / overload / auth failure still routes to its dedicated guidance card instead of the generic fallback.

The card now shows `No conversation found with session ID: …`, which is actionable, instead of a dead end.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

Reproduced against a real run: a hetero Claude Code topic whose CC transcript had aged out of `~/.claude/projects/` (CC prunes transcripts per `cleanupPeriodDays`, default 30). `claude --resume <id>` exits 1 with `No conversation found with session ID: …` on stderr and ships the same string in `result.errors[]`.

Unit test added: a `result` event carrying only `errors: [...]` surfaces that text as the terminal error message.

#### 📝 Additional Information

Two related gaps are **not** addressed here and are worth follow-ups:

1. A stale Claude Code resume id is never classified as `ResumeThreadNotFound` — `getCodexResumeError` is hard-gated to `agentType === 'codex'` (`apps/desktop/src/main/controllers/HeterogeneousAgentCtr.ts`). So the renderer's `retryWithoutResume` auto-recovery never fires for CC, while `lh hetero exec` does handle it via `RESUME_RETRY_PATTERNS`.
2. `resolveHeteroResume` guards against a changed cwd but not against a transcript that CC has since deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)