### PR TITLE
♻️ refactor(agent): batch client runtime message writes

### DIFF
--- a/src/services/message/__tests__/metadata-race-condition.test.ts
+++ b/src/services/message/__tests__/metadata-race-condition.test.ts
@@ -7,6 +7,9 @@ import { MessageService } from '../index';
 vi.mock('@/libs/trpc/client', () => ({
   lambdaClient: {
     message: {
+      batchMutate: {
+        mutate: vi.fn(),
+      },
       updateMetadata: {
         mutate: vi.fn(),
       },
@@ -20,6 +23,58 @@ describe('MessageService - Race Condition Control', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     messageService = new MessageService();
+  });
+
+  describe('batch tool message update race condition', () => {
+    it('should cancel a stale batch update for the same tool message', async () => {
+      let firstRequestAborted = false;
+
+      vi.mocked(lambdaClient.message.batchMutate.mutate)
+        .mockImplementationOnce(
+          (_params, options) =>
+            new Promise((resolve, reject) => {
+              options?.signal?.addEventListener('abort', () => {
+                firstRequestAborted = true;
+                reject(new Error('Aborted'));
+              });
+            }),
+        )
+        .mockResolvedValueOnce({
+          results: [{ id: 'tool-1', index: 0, success: true, type: 'updateToolMessage' }],
+          success: true,
+        });
+
+      const firstPromise = messageService.batchMutateOrThrow([
+        {
+          id: 'tool-1',
+          type: 'updateToolMessage',
+          value: { content: 'stale result' },
+        },
+      ]);
+      const secondPromise = messageService.batchMutateOrThrow([
+        {
+          id: 'tool-1',
+          type: 'updateToolMessage',
+          value: { content: 'latest result' },
+        },
+      ]);
+
+      await expect(firstPromise).rejects.toThrow('Aborted');
+      await expect(secondPromise).resolves.toMatchObject({ success: true });
+      expect(firstRequestAborted).toBe(true);
+      expect(lambdaClient.message.batchMutate.mutate).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          operations: [
+            expect.objectContaining({
+              id: 'tool-1',
+              value: { content: 'latest result' },
+            }),
+          ],
+        }),
+        { signal: expect.any(AbortSignal) },
+      );
+    });
   });
 
   describe('updateMessageMetadata race condition', () => {

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -60,6 +60,23 @@ export type MessageBatchOperation =
       };
     };
 
+export interface MessageBatchMutationResult {
+  results?: Array<{
+    id?: string;
+    index: number;
+    success: boolean;
+    type: MessageBatchOperation['type'];
+  }>;
+  success?: boolean;
+}
+
+export class MessageBatchMutationError extends Error {
+  constructor(public readonly result: MessageBatchMutationResult) {
+    const failedCount = result.results?.filter((item) => !item.success).length;
+    super(`Message batch mutation failed for ${failedCount || 'unknown'} operation(s)`);
+  }
+}
+
 export class MessageService {
   batchMutate = async (operations: MessageBatchOperation[]) => {
     return lambdaClient.message.batchMutate.mutate({
@@ -78,6 +95,18 @@ export class MessageService {
         };
       }),
     } as any);
+  };
+
+  batchMutateOrThrow = async (operations: MessageBatchOperation[]) => {
+    const result = (await this.batchMutate(operations)) as MessageBatchMutationResult;
+    const hasFailedOperation = result.results?.some((item) => !item.success) ?? false;
+    const hasCompleteResults = result.results?.length === operations.length;
+
+    if (result.success !== true || !hasCompleteResults || hasFailedOperation) {
+      throw new MessageBatchMutationError(result);
+    }
+
+    return result;
   };
 
   createMessage = async (params: CreateMessageParams): Promise<CreateMessageResult> => {

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -77,9 +77,16 @@ export class MessageBatchMutationError extends Error {
   }
 }
 
+const getBatchMutationAbortKey = (operations: MessageBatchOperation[]) => {
+  if (operations.length !== 1) return;
+
+  const [operation] = operations;
+  if (operation.type === 'updateToolMessage') return `tool-message-${operation.id}`;
+};
+
 export class MessageService {
-  batchMutate = async (operations: MessageBatchOperation[]) => {
-    return lambdaClient.message.batchMutate.mutate({
+  batchMutate = async (operations: MessageBatchOperation[], signal?: AbortSignal) => {
+    const input = {
       operations: operations.map((operation) => {
         if (operation.type === 'createMessage') {
           return {
@@ -94,19 +101,31 @@ export class MessageService {
           value: operation.value,
         };
       }),
-    } as any);
+    } as any;
+
+    return signal
+      ? lambdaClient.message.batchMutate.mutate(input, { signal })
+      : lambdaClient.message.batchMutate.mutate(input);
   };
 
   batchMutateOrThrow = async (operations: MessageBatchOperation[]) => {
-    const result = (await this.batchMutate(operations)) as MessageBatchMutationResult;
-    const hasFailedOperation = result.results?.some((item) => !item.success) ?? false;
-    const hasCompleteResults = result.results?.length === operations.length;
+    const execute = async (signal?: AbortSignal) => {
+      const result = (await (signal
+        ? this.batchMutate(operations, signal)
+        : this.batchMutate(operations))) as MessageBatchMutationResult;
+      const hasFailedOperation = result.results?.some((item) => !item.success) ?? false;
+      const hasCompleteResults = result.results?.length === operations.length;
 
-    if (result.success !== true || !hasCompleteResults || hasFailedOperation) {
-      throw new MessageBatchMutationError(result);
-    }
+      if (result.success !== true || !hasCompleteResults || hasFailedOperation) {
+        throw new MessageBatchMutationError(result);
+      }
 
-    return result;
+      return result;
+    };
+
+    const abortKey = getBatchMutationAbortKey(operations);
+
+    return abortKey ? abortableRequest.execute(abortKey, execute) : execute();
   };
 
   createMessage = async (params: CreateMessageParams): Promise<CreateMessageResult> => {

--- a/src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts
+++ b/src/store/chat/agents/__tests__/createAgentExecutors/call-llm.test.ts
@@ -29,12 +29,6 @@ vi.mock('@/services/chat', () => ({
   },
 }));
 
-vi.mock('@/services/message', () => ({
-  messageService: {
-    updateMessage: vi.fn(),
-  },
-}));
-
 vi.mock('@/store/chat/selectors', () => ({
   topicSelectors: {
     currentActiveTopicSummary: vi.fn().mockReturnValue(undefined),

--- a/src/store/chat/agents/__tests__/createAgentExecutors/fixtures/mockStore.ts
+++ b/src/store/chat/agents/__tests__/createAgentExecutors/fixtures/mockStore.ts
@@ -1,6 +1,7 @@
 import { nanoid } from '@lobechat/utils';
 import { vi } from 'vitest';
 
+import { messageService } from '@/services/message';
 import { type ChatStore } from '@/store/chat/store';
 
 /**
@@ -12,6 +13,7 @@ export const createMockStore = (overrides: Partial<ChatStore> = {}): ChatStore =
   const messageOperationMap: Record<string, string> = {};
   const operationsByMessage: Record<string, string[]> = {};
   const dbMessagesMap: Record<string, any[]> = {};
+  const optimisticCreates = new Map<string, Promise<unknown>>();
 
   const store = {
     // Other store properties (add as needed)
@@ -56,7 +58,12 @@ export const createMockStore = (overrides: Partial<ChatStore> = {}): ChatStore =
     }),
 
     // AI chat methods
-    internal_dispatchMessage: vi.fn(),
+    internal_dispatchMessage: vi.fn().mockImplementation((payload, context) => {
+      if (payload.type !== 'createMessage') return;
+
+      const createPromise = Promise.resolve(store.optimisticCreateMessage(payload.value, context));
+      optimisticCreates.set(payload.id, createPromise);
+    }),
 
     internal_invokeDifferentTypePlugin: vi.fn().mockResolvedValue({ error: null }),
 
@@ -89,7 +96,7 @@ export const createMockStore = (overrides: Partial<ChatStore> = {}): ChatStore =
 
     // Message management methods
     optimisticCreateMessage: vi.fn().mockImplementation(async (params) => {
-      const id = nanoid();
+      const id = params.id ?? nanoid();
       const message = { id, ...params, createdAt: Date.now(), updatedAt: Date.now() };
       return message;
     }),
@@ -147,6 +154,33 @@ export const createMockStore = (overrides: Partial<ChatStore> = {}): ChatStore =
 
     ...overrides,
   } as unknown as ChatStore;
+
+  vi.spyOn(messageService, 'batchMutate').mockImplementation(async (batch) => {
+    const results = [];
+
+    for (const [index, operation] of batch.entries()) {
+      let success = true;
+      if (operation.type === 'createMessage') {
+        const createResult = optimisticCreates.get(operation.message.id!);
+        if (createResult) {
+          try {
+            success = Boolean(await createResult);
+          } catch {
+            success = false;
+          }
+        }
+      }
+
+      results.push({
+        id: operation.type === 'createMessage' ? operation.message.id : operation.id,
+        index,
+        success,
+        type: operation.type,
+      });
+    }
+
+    return { results, success: results.every((item) => item.success) };
+  });
 
   return store;
 };

--- a/src/store/chat/agents/transports/ClientMessageTransport.test.ts
+++ b/src/store/chat/agents/transports/ClientMessageTransport.test.ts
@@ -76,20 +76,26 @@ describe('ClientMessageTransport', () => {
     expect(messageService.batchMutate).toHaveBeenNthCalledWith(1, [
       { id: 'assistant-1', type: 'updateMessage', value: { content: 'Answer' } },
     ]);
-    expect(messageService.batchMutate).toHaveBeenNthCalledWith(2, [
-      { id: 'tool-1', type: 'updateToolMessage', value: { pluginState: { todos: [] } } },
-    ]);
-    expect(messageService.batchMutate).toHaveBeenNthCalledWith(3, [
-      {
-        id: 'tool-1',
-        type: 'updateToolMessage',
-        value: {
-          content: 'Tool result',
-          pluginError: { message: 'Handled failure' },
-          pluginState: { success: false },
+    expect(messageService.batchMutate).toHaveBeenNthCalledWith(
+      2,
+      [{ id: 'tool-1', type: 'updateToolMessage', value: { pluginState: { todos: [] } } }],
+      expect.any(AbortSignal),
+    );
+    expect(messageService.batchMutate).toHaveBeenNthCalledWith(
+      3,
+      [
+        {
+          id: 'tool-1',
+          type: 'updateToolMessage',
+          value: {
+            content: 'Tool result',
+            pluginError: { message: 'Handled failure' },
+            pluginState: { success: false },
+          },
         },
-      },
-    ]);
+      ],
+      expect.any(AbortSignal),
+    );
     expect(store.optimisticUpdatePluginState).not.toHaveBeenCalled();
     expect(store.optimisticUpdateToolMessage).not.toHaveBeenCalled();
     expect(store.replaceMessages).not.toHaveBeenCalled();

--- a/src/store/chat/agents/transports/ClientMessageTransport.test.ts
+++ b/src/store/chat/agents/transports/ClientMessageTransport.test.ts
@@ -1,0 +1,128 @@
+import type { CreateMessageParams } from '@lobechat/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { messageService } from '@/services/message';
+import type { ChatStore } from '@/store/chat/store';
+
+import { ClientMessageTransport } from './ClientMessageTransport';
+
+const createStore = () =>
+  ({
+    dbMessagesMap: { 'message-key': [] },
+    internal_dispatchMessage: vi.fn(),
+    optimisticCreateMessage: vi.fn(),
+    optimisticUpdatePluginState: vi.fn(),
+    optimisticUpdateToolMessage: vi.fn(),
+    replaceMessages: vi.fn(),
+  }) as unknown as ChatStore;
+
+describe('ClientMessageTransport', () => {
+  beforeEach(() => {
+    vi.spyOn(messageService, 'batchMutate').mockImplementation(async (operations) => ({
+      results: operations.map((operation, index) => ({
+        id: operation.type === 'createMessage' ? operation.message.id : operation.id,
+        index,
+        success: true,
+        type: operation.type,
+      })),
+      success: true,
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('creates an optimistic message with a stable id and persists it quietly', async () => {
+    const store = createStore();
+    const transport = new ClientMessageTransport(() => store, 'message-key', 'operation-1');
+    const params: CreateMessageParams = {
+      agentId: 'agent-1',
+      content: '',
+      role: 'assistant',
+      topicId: 'topic-1',
+    };
+
+    const message = await transport.createAssistantMessage(params);
+
+    expect(message.id).toEqual(expect.any(String));
+    expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
+      { id: message.id, type: 'createMessage', value: { ...params, id: message.id } },
+      { operationId: 'operation-1' },
+    );
+    expect(messageService.batchMutate).toHaveBeenCalledWith([
+      { message: { ...params, id: message.id }, type: 'createMessage' },
+    ]);
+    expect(store.optimisticCreateMessage).not.toHaveBeenCalled();
+    expect(store.replaceMessages).not.toHaveBeenCalled();
+  });
+
+  it('applies message and tool updates optimistically before quiet persistence', async () => {
+    const store = createStore();
+    const transport = new ClientMessageTransport(() => store, 'message-key', 'operation-1');
+
+    await transport.update('assistant-1', { content: 'Answer' });
+    await transport.updatePluginState('tool-1', { todos: [] });
+    await transport.updateToolMessage('tool-1', {
+      content: 'Tool result',
+      pluginError: { message: 'Handled failure' },
+      pluginState: { success: false },
+    });
+
+    expect(store.internal_dispatchMessage).toHaveBeenCalledWith(
+      { id: 'assistant-1', type: 'updateMessage', value: { content: 'Answer' } },
+      { operationId: 'operation-1' },
+    );
+    expect(messageService.batchMutate).toHaveBeenNthCalledWith(1, [
+      { id: 'assistant-1', type: 'updateMessage', value: { content: 'Answer' } },
+    ]);
+    expect(messageService.batchMutate).toHaveBeenNthCalledWith(2, [
+      { id: 'tool-1', type: 'updateToolMessage', value: { pluginState: { todos: [] } } },
+    ]);
+    expect(messageService.batchMutate).toHaveBeenNthCalledWith(3, [
+      {
+        id: 'tool-1',
+        type: 'updateToolMessage',
+        value: {
+          content: 'Tool result',
+          pluginError: { message: 'Handled failure' },
+          pluginState: { success: false },
+        },
+      },
+    ]);
+    expect(store.optimisticUpdatePluginState).not.toHaveBeenCalled();
+    expect(store.optimisticUpdateToolMessage).not.toHaveBeenCalled();
+    expect(store.replaceMessages).not.toHaveBeenCalled();
+  });
+
+  it('marks an optimistic create as failed when batch persistence reports a failure', async () => {
+    vi.mocked(messageService.batchMutate).mockResolvedValueOnce({
+      results: [{ id: 'assistant-1', index: 0, success: false, type: 'createMessage' }],
+      success: false,
+    });
+    const store = createStore();
+    const transport = new ClientMessageTransport(() => store, 'message-key', 'operation-1');
+
+    await expect(
+      transport.createAssistantMessage({
+        agentId: 'agent-1',
+        content: '',
+        id: 'assistant-1',
+        role: 'assistant',
+      }),
+    ).rejects.toThrow('Failed to create assistant message');
+
+    expect(store.internal_dispatchMessage).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: 'assistant-1',
+        type: 'updateMessage',
+        value: expect.objectContaining({
+          error: expect.objectContaining({
+            message: 'Failed to create assistant message',
+          }),
+        }),
+      }),
+      { operationId: 'operation-1' },
+    );
+  });
+});

--- a/src/store/chat/agents/transports/ClientMessageTransport.ts
+++ b/src/store/chat/agents/transports/ClientMessageTransport.ts
@@ -11,8 +11,10 @@ import type {
   UIChatMessage,
   UpdateMessageParams,
 } from '@lobechat/types';
+import { ChatErrorType } from '@lobechat/types';
+import { nanoid } from '@lobechat/utils';
 
-import { messageService } from '@/services/message';
+import { type MessageBatchOperation, messageService } from '@/services/message';
 import type { ChatStore } from '@/store/chat/store';
 
 /** Client message adapter backed by the optimistic chat store. */
@@ -29,6 +31,13 @@ export class ClientMessageTransport implements MessageTransport {
 
   createToolMessage(params: CreateMessageParams): Promise<RuntimeMessageRef> {
     return this.createMessage(params);
+  }
+
+  createToolMessageForOperation(
+    params: CreateMessageParams,
+    operationId: string,
+  ): Promise<RuntimeMessageRef> {
+    return this.createMessage(params, operationId);
   }
 
   async deleteMessage(id: string): Promise<void> {
@@ -55,36 +64,92 @@ export class ClientMessageTransport implements MessageTransport {
       optimisticContext,
     );
 
-    const conversationContext = store.internal_getConversationContext(optimisticContext);
-    const result = await messageService.updateMessage(id, params, conversationContext);
-    if (result?.success && result.messages) {
-      store.replaceMessages(result.messages, { context: conversationContext });
-    }
+    await this.persist([{ id, type: 'updateMessage', value: params }]);
   }
 
   async updatePluginState(id: string, state: Record<string, any>): Promise<void> {
-    await this.get().optimisticUpdatePluginState(id, state, { operationId: this.operationId });
+    this.get().internal_dispatchMessage(
+      { id, type: 'updateMessage', value: { pluginState: state } },
+      { operationId: this.operationId },
+    );
+
+    await this.persist([{ id, type: 'updateToolMessage', value: { pluginState: state } }]);
   }
 
   async updateToolMessage(id: string, params: UpdateToolMessageInput): Promise<void> {
-    await this.get().optimisticUpdateToolMessage(
-      id,
+    const store = this.get();
+    const optimisticContext = { operationId: this.operationId };
+    const pluginError = params.pluginError as ChatMessagePluginError | null | undefined;
+
+    store.internal_dispatchMessage(
       {
-        ...params,
-        pluginError: params.pluginError as ChatMessagePluginError | null | undefined,
+        id,
+        type: 'updateMessage',
+        value: {
+          content: params.content,
+          metadata: params.metadata,
+          pluginState: params.pluginState,
+        },
       },
-      { operationId: this.operationId },
+      optimisticContext,
     );
+
+    if (pluginError !== undefined) {
+      store.internal_dispatchMessage(
+        { id, type: 'updateMessagePlugin', value: { error: pluginError } },
+        optimisticContext,
+      );
+    }
+
+    await this.persist([
+      {
+        id,
+        type: 'updateToolMessage',
+        value: { ...params, pluginError },
+      },
+    ]);
   }
 
-  private async createMessage(params: CreateMessageParams): Promise<RuntimeMessageRef> {
-    const result = await this.get().optimisticCreateMessage(params, {
-      operationId: this.operationId,
-    });
+  private async createMessage(
+    params: CreateMessageParams,
+    operationId = this.operationId,
+  ): Promise<RuntimeMessageRef> {
+    const store = this.get();
+    const id = params.id ?? nanoid();
+    const message = { ...params, id };
+    const optimisticContext = { operationId };
 
-    if (!result) throw new Error(`Failed to create ${params.role} message`);
+    store.internal_dispatchMessage(
+      { id, type: 'createMessage', value: message },
+      optimisticContext,
+    );
 
-    return { ...params, id: result.id };
+    try {
+      await this.persist([{ message, type: 'createMessage' }]);
+    } catch (error) {
+      const createError = new Error(`Failed to create ${params.role} message`, { cause: error });
+      store.internal_dispatchMessage(
+        {
+          id,
+          type: 'updateMessage',
+          value: {
+            error: {
+              body: error,
+              message: createError.message,
+              type: ChatErrorType.CreateMessageError,
+            },
+          },
+        },
+        optimisticContext,
+      );
+      throw createError;
+    }
+
+    return message;
+  }
+
+  private async persist(operations: MessageBatchOperation[]): Promise<void> {
+    await messageService.batchMutateOrThrow(operations);
   }
 
   private getMessages(): UIChatMessage[] {

--- a/src/store/chat/agents/transports/ClientToolTransport.test.ts
+++ b/src/store/chat/agents/transports/ClientToolTransport.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { ChatStore } from '@/store/chat/store';
 
+import type { ClientMessageTransport } from './ClientMessageTransport';
 import { ClientToolTransport } from './ClientToolTransport';
 
 describe('ClientToolTransport', () => {
@@ -31,7 +32,14 @@ describe('ClientToolTransport', () => {
       startOperation: vi.fn(() => ({ operationId: `child-operation-${++operationIndex}` })),
       updateOperationMetadata: vi.fn(),
     } as unknown as ChatStore;
-    const transport = new ClientToolTransport(() => store, 'message-key', 'root-operation');
+    const createToolMessageForOperation = vi.fn().mockResolvedValue({ id: 'tool-message' });
+    const messages = { createToolMessageForOperation } as unknown as ClientMessageTransport;
+    const transport = new ClientToolTransport(
+      () => store,
+      'message-key',
+      'root-operation',
+      messages,
+    );
     const call: ChatToolPayload = {
       apiName: 'run',
       arguments: '{}',
@@ -62,5 +70,10 @@ describe('ClientToolTransport', () => {
       type: 'ToolExecutionError',
     });
     expect(completeOperation).not.toHaveBeenCalledWith('child-operation-1');
+    expect(createToolMessageForOperation).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'tool', tool_call_id: 'tool-call' }),
+      'child-operation-2',
+    );
+    expect(store.optimisticCreateMessage).not.toHaveBeenCalled();
   });
 });

--- a/src/store/chat/agents/transports/ClientToolTransport.ts
+++ b/src/store/chat/agents/transports/ClientToolTransport.ts
@@ -8,6 +8,8 @@ import type { ChatToolPayload, CreateMessageParams } from '@lobechat/types';
 
 import type { ChatStore } from '@/store/chat/store';
 
+import type { ClientMessageTransport } from './ClientMessageTransport';
+
 const TOOL_PRICING: Record<string, number> = {
   'lobe-web-browsing/craw': 0.002,
   'lobe-web-browsing/search': 0.001,
@@ -24,6 +26,7 @@ export class ClientToolTransport implements ToolTransport {
     private readonly get: () => ChatStore,
     private readonly messageKey: string,
     private readonly operationId: string,
+    private readonly messages: ClientMessageTransport,
   ) {}
 
   getCost(toolName: string) {
@@ -187,19 +190,19 @@ export class ClientToolTransport implements ToolTransport {
       tool_call_id: input.call.id,
       topicId: rootContext.topicId ?? undefined,
     };
-    const createPromise = store.optimisticCreateMessage(params, {
-      operationId: createOperationId,
-    });
+    const createPromise = this.messages.createToolMessageForOperation(params, createOperationId);
     store.updateOperationMetadata(createOperationId, { createMessagePromise: createPromise });
 
-    const createResult = await createPromise;
-    if (!createResult) {
-      const error = {
-        message: `Failed to create tool message for tool_call_id: ${input.call.id}`,
-        type: 'CreateMessageError',
-      };
-      store.failOperation(createOperationId, error);
-      throw new Error(error.message);
+    let createResult: Awaited<typeof createPromise>;
+    try {
+      createResult = await createPromise;
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : `Failed to create tool message for tool_call_id: ${input.call.id}`;
+      store.failOperation(createOperationId, { message, type: 'CreateMessageError' });
+      throw error;
     }
 
     store.completeOperation(createOperationId);

--- a/src/store/chat/agents/transports/buildClientRuntimeHost.ts
+++ b/src/store/chat/agents/transports/buildClientRuntimeHost.ts
@@ -27,6 +27,7 @@ export const buildClientRuntimeHost = (context: {
 
   const { agentId, groupId, scope, subAgentId, threadId, topicId } = runtimeOperation.context;
   const effectiveAgentId = subAgentId && scope !== 'sub_agent' ? subAgentId : agentId;
+  const messages = new ClientMessageTransport(context.get, context.messageKey, context.operationId);
 
   return {
     operation: {
@@ -38,10 +39,15 @@ export const buildClientRuntimeHost = (context: {
       topicId: topicId ?? undefined,
     },
     transports: {
-      messages: new ClientMessageTransport(context.get, context.messageKey, context.operationId),
+      messages,
       operationStore: localOperationStore,
       stream: localStreamSink,
-      tools: new ClientToolTransport(context.get, context.messageKey, context.operationId),
+      tools: new ClientToolTransport(
+        context.get,
+        context.messageKey,
+        context.operationId,
+        messages,
+      ),
     },
   };
 };

--- a/src/store/chat/slices/agentRun/actions/__tests__/helpers.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/helpers.ts
@@ -65,6 +65,17 @@ export const createMockAbortController = () => {
  * Setup spies for message service methods
  */
 export const spyOnMessageService = () => {
+  const batchMutateSpy = vi
+    .spyOn(messageService, 'batchMutate')
+    .mockImplementation(async (operations) => ({
+      results: operations.map((operation, index) => ({
+        id: operation.type === 'createMessage' ? operation.message.id : operation.id,
+        index,
+        success: true,
+        type: operation.type,
+      })),
+      success: true,
+    }));
   const createMessageSpy = vi
     .spyOn(messageService, 'createMessage')
     .mockResolvedValue({ id: TEST_IDS.NEW_MESSAGE_ID, messages: [] });
@@ -82,6 +93,7 @@ export const spyOnMessageService = () => {
     .mockResolvedValue(undefined as any);
 
   return {
+    batchMutateSpy,
     createMessageSpy,
     removeMessageSpy,
     updateMessageErrorSpy,

--- a/src/store/chat/slices/agentRun/actions/__tests__/streamingExecutor.test.ts
+++ b/src/store/chat/slices/agentRun/actions/__tests__/streamingExecutor.test.ts
@@ -190,6 +190,10 @@ describe('StreamingExecutor actions', () => {
 
       // Verify agent runtime executed successfully
       expect(streamSpy).toHaveBeenCalled();
+      expect(result.current.refreshMessages).toHaveBeenCalledWith({
+        agentId: TEST_IDS.SESSION_ID,
+        topicId: TEST_IDS.TOPIC_ID,
+      });
 
       // Verify operation was completed
       const operations = Object.values(result.current.operations);

--- a/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/client/streamingExecutor.ts
@@ -788,6 +788,10 @@ export class StreamingExecutorActionImpl {
       stepCount,
     );
 
+    // Runtime message transports persist through quiet batch mutations. Reconcile
+    // once at the run boundary instead of replacing the full list after every write.
+    await this.#get().refreshMessages(context);
+
     // Run-completion side effects are assembled once and invoked at
     // this boundary. The bodies are relocated verbatim into `buildRunLifecycle`,
     // so the streamingExecutor characterization net stays green (behavior-preserving).

--- a/src/store/chat/slices/plugin/action.test.ts
+++ b/src/store/chat/slices/plugin/action.test.ts
@@ -34,6 +34,7 @@ vi.mock('zustand/traditional');
 // Mock messageService
 vi.mock('@/services/message', () => ({
   messageService: {
+    batchMutateOrThrow: vi.fn(),
     createMessage: vi.fn(),
     updateMessage: vi.fn(),
     updateMessageError: vi.fn(),
@@ -1333,16 +1334,13 @@ describe('ChatPluginAction', () => {
         );
       });
 
-      it('optimisticUpdateToolMessage should pass groupId via ctx', async () => {
+      it('optimisticUpdateToolMessage should persist through a quiet batch mutation', async () => {
         const { result } = renderHook(() => useChatStore());
         const messageId = 'message-id';
         const content = 'new content';
         const pluginState = { status: 'success' };
 
-        (messageService.updateToolMessage as Mock).mockResolvedValue({
-          success: true,
-          messages: [],
-        });
+        (messageService.batchMutateOrThrow as Mock).mockResolvedValue({ success: true });
 
         let operationId: string;
         await act(async () => {
@@ -1359,16 +1357,14 @@ describe('ChatPluginAction', () => {
           );
         });
 
-        // Now uses single updateToolMessage call instead of multiple parallel calls
-        expect(messageService.updateToolMessage).toHaveBeenCalledWith(
-          messageId,
-          { content, metadata: undefined, pluginError: undefined, pluginState },
-          expect.objectContaining({
-            agentId: groupContext.agentId,
-            groupId: groupContext.groupId,
-            topicId: groupContext.topicId,
-          }),
-        );
+        expect(messageService.batchMutateOrThrow).toHaveBeenCalledWith([
+          {
+            id: messageId,
+            type: 'updateToolMessage',
+            value: { content, metadata: undefined, pluginError: undefined, pluginState },
+          },
+        ]);
+        expect(messageService.updateToolMessage).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/store/chat/slices/plugin/actions/optimisticUpdate.ts
+++ b/src/store/chat/slices/plugin/actions/optimisticUpdate.ts
@@ -226,8 +226,7 @@ export class PluginOptimisticUpdateActionImpl {
     params: UpdateToolMessageParams,
     context?: OptimisticUpdateContext,
   ): Promise<void> => {
-    const { replaceMessages, internal_getConversationContext, internal_dispatchMessage } =
-      this.#get();
+    const { internal_dispatchMessage } = this.#get();
 
     const { content, metadata, pluginState, pluginError } = params;
 
@@ -244,19 +243,13 @@ export class PluginOptimisticUpdateActionImpl {
       );
     }
 
-    const ctx = internal_getConversationContext(context);
-
-    // Use single API call to update all fields in one transaction
-    // This prevents race conditions that occurred with multiple parallel requests
-    const result = await messageService.updateToolMessage(
-      id,
-      { content, metadata, pluginError, pluginState },
-      ctx,
-    );
-
-    if (result?.success && result.messages) {
-      replaceMessages(result.messages, { context: ctx });
-    }
+    await messageService.batchMutateOrThrow([
+      {
+        id,
+        type: 'updateToolMessage',
+        value: { content, metadata, pluginError, pluginState },
+      },
+    ]);
   };
 }
 


### PR DESCRIPTION
## Summary

- persist client AgentRuntime message creates and updates through quiet `batchMutate` operations
- keep optimistic UI updates local with stable preallocated message IDs and fail-closed mutation results
- share the message adapter with local tool execution and reconcile canonical messages once at the run boundary

## Testing

- `bun run check` (79 related tests)
- 98 legacy call-tool / human-approve / aborted-tool regression tests
- `bun run check --type`

Fixes LOBE-11787