### PR TITLE
🐛 fix(chat): pass editor text when adding assistant message

### DIFF
--- a/src/features/Conversation/store/slices/message/action/index.test.ts
+++ b/src/features/Conversation/store/slices/message/action/index.test.ts
@@ -1,8 +1,18 @@
+import { type UIChatMessage } from '@lobechat/types';
 import { act } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ConversationContext } from '../../../../types';
 import { createStore } from '../../../index';
+
+// Mock conversation-flow parse so createStore initialization never reaches a real parser.
+vi.mock('@lobechat/conversation-flow', () => ({
+  parse: (messages: UIChatMessage[]) => {
+    const messageMap: Record<string, UIChatMessage> = {};
+    for (const msg of messages) messageMap[msg.id] = msg;
+    return { flatList: [...messages].sort((a, b) => a.createdAt - b.createdAt), messageMap };
+  },
+}));
 
 const createTestStore = (context?: Partial<ConversationContext>) =>
   createStore({
@@ -19,71 +29,184 @@ describe('message convenience actions', () => {
     vi.clearAllMocks();
   });
 
-  it('creates an assistant message with its conversation context', async () => {
-    const store = createTestStore({
-      groupId: 'group-1',
-      scope: 'group',
-    });
-    const createMessage = vi.fn().mockResolvedValue('message-1');
-    store.setState({ createMessage });
+  describe('addAIMessage', () => {
+    it('creates an assistant message with its conversation context and the submitted text', async () => {
+      const store = createTestStore();
+      const createMessage = vi.fn().mockResolvedValue('message-1');
+      store.setState({ createMessage });
 
-    await act(async () => {
-      await store.getState().addAIMessage('assistant content');
+      await act(async () => {
+        await store.getState().addAIMessage('assistant content');
+      });
+
+      expect(createMessage).toHaveBeenCalledWith({
+        agentId: 'agent-1',
+        content: 'assistant content',
+        parentId: undefined,
+        role: 'assistant',
+        threadId: undefined,
+        topicId: 'topic-1',
+      });
     });
 
-    expect(createMessage).toHaveBeenCalledWith({
-      agentId: 'agent-1',
-      content: 'assistant content',
-      groupId: 'group-1',
-      parentId: undefined,
-      role: 'assistant',
-      threadId: undefined,
-      topicId: 'topic-1',
+    it('does not forward groupId to createMessage (canary-aligned context)', async () => {
+      const store = createTestStore({ groupId: 'group-1', scope: 'group' });
+      const createMessage = vi.fn().mockResolvedValue('message-1');
+      store.setState({ createMessage });
+
+      await act(async () => {
+        await store.getState().addAIMessage('assistant content');
+      });
+
+      expect(createMessage).toHaveBeenCalledWith(
+        expect.not.objectContaining({ groupId: expect.anything() }),
+      );
+    });
+
+    it('still allows an empty assistant placeholder', async () => {
+      const store = createTestStore();
+      const createMessage = vi.fn().mockResolvedValue('message-1');
+      store.setState({ createMessage });
+
+      await act(async () => {
+        await store.getState().addAIMessage('');
+      });
+
+      expect(createMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ content: '', role: 'assistant' }),
+      );
+    });
+
+    it('uses the last display message as the parent id', async () => {
+      const store = createTestStore();
+      const createMessage = vi.fn().mockResolvedValue('message-1');
+      store.setState({
+        createMessage,
+        displayMessages: [
+          { id: 'prev-1', content: 'previous', role: 'user', createdAt: 1, updatedAt: 1 },
+        ],
+      });
+
+      await act(async () => {
+        await store.getState().addAIMessage('assistant content');
+      });
+
+      expect(createMessage).toHaveBeenCalledWith(expect.objectContaining({ parentId: 'prev-1' }));
+    });
+
+    it('fires the onMessageCreated hook for the created assistant message', async () => {
+      const onMessageCreated = vi.fn();
+      const store = createTestStore();
+      const created: UIChatMessage = {
+        id: 'message-1',
+        content: 'assistant content',
+        role: 'assistant',
+        createdAt: 1,
+        updatedAt: 1,
+      };
+      store.setState({
+        createMessage: vi.fn().mockResolvedValue('message-1'),
+        displayMessages: [created],
+        hooks: { onMessageCreated },
+      });
+
+      await act(async () => {
+        await store.getState().addAIMessage('assistant content');
+      });
+
+      expect(onMessageCreated).toHaveBeenCalledWith(created);
+    });
+
+    it('clears the input after successful creation', async () => {
+      const store = createTestStore();
+      store.setState({
+        createMessage: vi.fn().mockResolvedValue('message-1'),
+        inputMessage: 'submitted draft',
+      });
+
+      await act(async () => {
+        await store.getState().addAIMessage('submitted draft');
+      });
+
+      expect(store.getState().inputMessage).toBe('');
+    });
+
+    it('does not clear the input when creation fails', async () => {
+      const store = createTestStore();
+      store.setState({
+        createMessage: vi.fn().mockResolvedValue(undefined),
+        inputMessage: 'submitted draft',
+      });
+
+      await act(async () => {
+        await store.getState().addAIMessage('submitted draft');
+      });
+
+      expect(store.getState().inputMessage).toBe('submitted draft');
     });
   });
 
-  it('still allows an empty assistant placeholder', async () => {
-    const store = createTestStore();
-    const createMessage = vi.fn().mockResolvedValue('message-1');
-    store.setState({ createMessage });
+  describe('addUserMessage', () => {
+    it('creates a user message with its conversation context, files and the submitted text', async () => {
+      const store = createTestStore();
+      const createMessage = vi.fn().mockResolvedValue('message-1');
+      store.setState({ createMessage });
 
-    await act(async () => {
-      await store.getState().addAIMessage('');
+      await act(async () => {
+        await store.getState().addUserMessage({ message: 'user content', fileList: ['file-1'] });
+      });
+
+      expect(createMessage).toHaveBeenCalledWith({
+        agentId: 'agent-1',
+        content: 'user content',
+        files: ['file-1'],
+        parentId: undefined,
+        role: 'user',
+        threadId: undefined,
+        topicId: 'topic-1',
+      });
     });
 
-    expect(createMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ content: '', role: 'assistant' }),
-    );
-  });
+    it('does not forward groupId to createMessage (canary-aligned context)', async () => {
+      const store = createTestStore({ groupId: 'group-1', scope: 'group' });
+      const createMessage = vi.fn().mockResolvedValue('message-1');
+      store.setState({ createMessage });
 
-  it('does not clear a newer draft after message creation finishes', async () => {
-    let resolveCreateMessage: (id: string) => void;
-    const createMessageResult = new Promise<string>((resolve) => {
-      resolveCreateMessage = resolve;
-    });
-    const store = createTestStore();
-    const createMessage = vi.fn().mockReturnValue(createMessageResult);
-    store.setState({ createMessage, inputMessage: 'submitted draft' });
+      await act(async () => {
+        await store.getState().addUserMessage({ message: 'user content' });
+      });
 
-    const createPromise = store.getState().addAIMessage('submitted draft');
-    act(() => store.getState().updateInputMessage('new draft'));
-    resolveCreateMessage!('message-1');
-    await act(async () => createPromise);
-
-    expect(store.getState().inputMessage).toBe('new draft');
-  });
-
-  it('clears the submitted draft after successful creation', async () => {
-    const store = createTestStore();
-    store.setState({
-      createMessage: vi.fn().mockResolvedValue('message-1'),
-      inputMessage: 'submitted draft',
+      expect(createMessage).toHaveBeenCalledWith(
+        expect.not.objectContaining({ groupId: expect.anything() }),
+      );
     });
 
-    await act(async () => {
-      await store.getState().addAIMessage('submitted draft');
+    it('clears the input after successful creation', async () => {
+      const store = createTestStore();
+      store.setState({
+        createMessage: vi.fn().mockResolvedValue('message-1'),
+        inputMessage: 'submitted draft',
+      });
+
+      await act(async () => {
+        await store.getState().addUserMessage({ message: 'submitted draft' });
+      });
+
+      expect(store.getState().inputMessage).toBe('');
     });
 
-    expect(store.getState().inputMessage).toBe('');
+    it('does not clear the input when creation fails', async () => {
+      const store = createTestStore();
+      store.setState({
+        createMessage: vi.fn().mockResolvedValue(undefined),
+        inputMessage: 'submitted draft',
+      });
+
+      await act(async () => {
+        await store.getState().addUserMessage({ message: 'submitted draft' });
+      });
+
+      expect(store.getState().inputMessage).toBe('submitted draft');
+    });
   });
 });

--- a/src/features/Conversation/store/slices/message/action/index.test.ts
+++ b/src/features/Conversation/store/slices/message/action/index.test.ts
@@ -1,0 +1,89 @@
+import { act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ConversationContext } from '../../../../types';
+import { createStore } from '../../../index';
+
+const createTestStore = (context?: Partial<ConversationContext>) =>
+  createStore({
+    context: {
+      agentId: 'agent-1',
+      topicId: 'topic-1',
+      threadId: null,
+      ...context,
+    },
+  });
+
+describe('message convenience actions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates an assistant message with its conversation context', async () => {
+    const store = createTestStore({
+      groupId: 'group-1',
+      scope: 'group',
+    });
+    const createMessage = vi.fn().mockResolvedValue('message-1');
+    store.setState({ createMessage });
+
+    await act(async () => {
+      await store.getState().addAIMessage('assistant content');
+    });
+
+    expect(createMessage).toHaveBeenCalledWith({
+      agentId: 'agent-1',
+      content: 'assistant content',
+      groupId: 'group-1',
+      parentId: undefined,
+      role: 'assistant',
+      threadId: undefined,
+      topicId: 'topic-1',
+    });
+  });
+
+  it('still allows an empty assistant placeholder', async () => {
+    const store = createTestStore();
+    const createMessage = vi.fn().mockResolvedValue('message-1');
+    store.setState({ createMessage });
+
+    await act(async () => {
+      await store.getState().addAIMessage('');
+    });
+
+    expect(createMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ content: '', role: 'assistant' }),
+    );
+  });
+
+  it('does not clear a newer draft after message creation finishes', async () => {
+    let resolveCreateMessage: (id: string) => void;
+    const createMessageResult = new Promise<string>((resolve) => {
+      resolveCreateMessage = resolve;
+    });
+    const store = createTestStore();
+    const createMessage = vi.fn().mockReturnValue(createMessageResult);
+    store.setState({ createMessage, inputMessage: 'submitted draft' });
+
+    const createPromise = store.getState().addAIMessage('submitted draft');
+    act(() => store.getState().updateInputMessage('new draft'));
+    resolveCreateMessage!('message-1');
+    await act(async () => createPromise);
+
+    expect(store.getState().inputMessage).toBe('new draft');
+  });
+
+  it('clears the submitted draft after successful creation', async () => {
+    const store = createTestStore();
+    store.setState({
+      createMessage: vi.fn().mockResolvedValue('message-1'),
+      inputMessage: 'submitted draft',
+    });
+
+    await act(async () => {
+      await store.getState().addAIMessage('submitted draft');
+    });
+
+    expect(store.getState().inputMessage).toBe('');
+  });
+});

--- a/src/features/Conversation/store/slices/message/action/index.ts
+++ b/src/features/Conversation/store/slices/message/action/index.ts
@@ -53,7 +53,7 @@ export const messageSlice: StateCreator<
   addAIMessage: async (content: string) => {
     const state = get();
     const { context, hooks } = state;
-    const { agentId, topicId, threadId } = context;
+    const { agentId, groupId, topicId, threadId } = context;
 
     // Get parent message ID
     const displayMessages = state.displayMessages;
@@ -62,6 +62,7 @@ export const messageSlice: StateCreator<
     const id = await state.createMessage({
       agentId,
       content,
+      groupId,
       parentId,
       role: 'assistant',
       threadId: threadId ?? undefined,
@@ -77,8 +78,8 @@ export const messageSlice: StateCreator<
         }
       }
 
-      // Clear input after successful creation
-      set({ inputMessage: '' });
+      // Do not erase a newer draft typed while message creation was pending.
+      if (get().inputMessage === content) set({ inputMessage: '' });
     }
 
     return id;

--- a/src/features/Conversation/store/slices/message/action/index.ts
+++ b/src/features/Conversation/store/slices/message/action/index.ts
@@ -53,7 +53,7 @@ export const messageSlice: StateCreator<
   addAIMessage: async (content: string) => {
     const state = get();
     const { context, hooks } = state;
-    const { agentId, groupId, topicId, threadId } = context;
+    const { agentId, topicId, threadId } = context;
 
     // Get parent message ID
     const displayMessages = state.displayMessages;
@@ -62,7 +62,6 @@ export const messageSlice: StateCreator<
     const id = await state.createMessage({
       agentId,
       content,
-      groupId,
       parentId,
       role: 'assistant',
       threadId: threadId ?? undefined,
@@ -78,8 +77,8 @@ export const messageSlice: StateCreator<
         }
       }
 
-      // Do not erase a newer draft typed while message creation was pending.
-      if (get().inputMessage === content) set({ inputMessage: '' });
+      // Clear input after successful creation
+      set({ inputMessage: '' });
     }
 
     return id;

--- a/src/routes/(main)/agent/features/Conversation/MainChatInput/useSendMenuItems.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/MainChatInput/useSendMenuItems.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { act, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useSendMenuItems as useGroupSendMenuItems } from '@/routes/(main)/group/features/Conversation/MainChatInput/useSendMenuItems';
+
+import { useSendMenuItems as useAgentSendMenuItems } from './useSendMenuItems';
+
+const mocks = vi.hoisted(() => ({
+  addAIMessage: vi.fn(),
+  addUserMessage: vi.fn(),
+  clearContent: vi.fn(),
+  focus: vi.fn(),
+  inputMessage: '',
+  updatePreference: vi.fn(),
+}));
+
+vi.mock('@lobehub/ui', () => ({
+  Flexbox: ({ children }: { children?: ReactNode }) => children,
+  Hotkey: () => null,
+  Icon: () => null,
+}));
+
+vi.mock('react-i18next', () => ({
+  Trans: () => null,
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/features/Conversation', () => ({
+  useConversationStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ editor: { clearContent: mocks.clearContent, focus: mocks.focus } }),
+  useConversationStoreApi: () => ({
+    getState: () => ({
+      addAIMessage: mocks.addAIMessage,
+      addUserMessage: mocks.addUserMessage,
+      inputMessage: mocks.inputMessage,
+    }),
+  }),
+}));
+
+vi.mock('@/hooks/useHotkeys', () => ({
+  useAddUserMessageHotkey: vi.fn(),
+}));
+
+vi.mock('@/store/user', () => ({
+  useUserStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ updatePreference: mocks.updatePreference }),
+}));
+
+vi.mock('@/store/user/selectors', () => ({
+  preferenceSelectors: { useCmdEnterToSend: () => false },
+  settingsSelectors: { getHotkeyById: () => () => [] },
+}));
+
+type MenuAction = { key?: string; onClick?: () => void };
+
+const getAddAIAction = (items: unknown) =>
+  (items as MenuAction[]).find((item) => item?.key === 'addAi');
+
+describe.each([
+  ['agent', useAgentSendMenuItems],
+  ['group', useGroupSendMenuItems],
+])('%s conversation send menu', (_name, useSendMenuItems) => {
+  beforeEach(() => {
+    mocks.inputMessage = '';
+    vi.clearAllMocks();
+  });
+
+  it('adds the current editor text as an assistant message', () => {
+    mocks.inputMessage = 'assistant content';
+    const { result } = renderHook(() => useSendMenuItems());
+
+    act(() => getAddAIAction(result.current)?.onClick?.());
+
+    expect(mocks.addAIMessage).toHaveBeenCalledWith('assistant content');
+    expect(mocks.clearContent).toHaveBeenCalledOnce();
+    expect(mocks.focus).toHaveBeenCalledOnce();
+  });
+
+  it('preserves support for empty assistant placeholders', () => {
+    const { result } = renderHook(() => useSendMenuItems());
+
+    act(() => getAddAIAction(result.current)?.onClick?.());
+
+    expect(mocks.addAIMessage).toHaveBeenCalledWith('');
+  });
+});

--- a/src/routes/(main)/agent/features/Conversation/MainChatInput/useSendMenuItems.test.tsx
+++ b/src/routes/(main)/agent/features/Conversation/MainChatInput/useSendMenuItems.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   addAIMessage: vi.fn(),
   addUserMessage: vi.fn(),
   clearContent: vi.fn(),
+  editorContent: '',
   focus: vi.fn(),
   inputMessage: '',
   updatePreference: vi.fn(),
@@ -31,7 +32,13 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('@/features/Conversation', () => ({
   useConversationStore: (selector: (state: Record<string, unknown>) => unknown) =>
-    selector({ editor: { clearContent: mocks.clearContent, focus: mocks.focus } }),
+    selector({
+      editor: {
+        clearContent: mocks.clearContent,
+        focus: mocks.focus,
+        getMarkdownContent: () => mocks.editorContent,
+      },
+    }),
   useConversationStoreApi: () => ({
     getState: () => ({
       addAIMessage: mocks.addAIMessage,
@@ -65,12 +72,14 @@ describe.each([
   ['group', useGroupSendMenuItems],
 ])('%s conversation send menu', (_name, useSendMenuItems) => {
   beforeEach(() => {
+    mocks.editorContent = '';
     mocks.inputMessage = '';
     vi.clearAllMocks();
   });
 
   it('adds the current editor text as an assistant message', () => {
-    mocks.inputMessage = 'assistant content';
+    mocks.editorContent = 'assistant content';
+    mocks.inputMessage = 'stale cached content';
     const { result } = renderHook(() => useSendMenuItems());
 
     act(() => getAddAIAction(result.current)?.onClick?.());

--- a/src/routes/(main)/agent/features/Conversation/MainChatInput/useSendMenuItems.tsx
+++ b/src/routes/(main)/agent/features/Conversation/MainChatInput/useSendMenuItems.tsx
@@ -35,8 +35,10 @@ export const useSendMenuItems = (): MenuProps['items'] => {
 
   const handleAddAIMessage = useCallback(() => {
     const store = storeApi.getState();
-    // Add empty AI message placeholder
-    store.addAIMessage('');
+    const message = store.inputMessage;
+    if (!message.trim()) return;
+
+    store.addAIMessage(message);
     // Clear and focus editor
     editor?.clearContent();
     editor?.focus();

--- a/src/routes/(main)/agent/features/Conversation/MainChatInput/useSendMenuItems.tsx
+++ b/src/routes/(main)/agent/features/Conversation/MainChatInput/useSendMenuItems.tsx
@@ -36,8 +36,6 @@ export const useSendMenuItems = (): MenuProps['items'] => {
   const handleAddAIMessage = useCallback(() => {
     const store = storeApi.getState();
     const message = store.inputMessage;
-    if (!message.trim()) return;
-
     store.addAIMessage(message);
     // Clear and focus editor
     editor?.clearContent();

--- a/src/routes/(main)/agent/features/Conversation/MainChatInput/useSendMenuItems.tsx
+++ b/src/routes/(main)/agent/features/Conversation/MainChatInput/useSendMenuItems.tsx
@@ -35,7 +35,7 @@ export const useSendMenuItems = (): MenuProps['items'] => {
 
   const handleAddAIMessage = useCallback(() => {
     const store = storeApi.getState();
-    const message = store.inputMessage;
+    const message = editor?.getMarkdownContent() ?? store.inputMessage;
     store.addAIMessage(message);
     // Clear and focus editor
     editor?.clearContent();

--- a/src/routes/(main)/group/features/Conversation/MainChatInput/useSendMenuItems.tsx
+++ b/src/routes/(main)/group/features/Conversation/MainChatInput/useSendMenuItems.tsx
@@ -34,8 +34,10 @@ export const useSendMenuItems = (): MenuProps['items'] => {
 
   const handleAddAIMessage = useCallback(() => {
     const store = storeApi.getState();
-    // Add empty AI message placeholder
-    store.addAIMessage('');
+    const message = store.inputMessage;
+    if (!message.trim()) return;
+
+    store.addAIMessage(message);
     // Clear and focus editor
     editor?.clearContent();
     editor?.focus();

--- a/src/routes/(main)/group/features/Conversation/MainChatInput/useSendMenuItems.tsx
+++ b/src/routes/(main)/group/features/Conversation/MainChatInput/useSendMenuItems.tsx
@@ -34,7 +34,7 @@ export const useSendMenuItems = (): MenuProps['items'] => {
 
   const handleAddAIMessage = useCallback(() => {
     const store = storeApi.getState();
-    const message = store.inputMessage;
+    const message = editor?.getMarkdownContent() ?? store.inputMessage;
     store.addAIMessage(message);
     // Clear and focus editor
     editor?.clearContent();

--- a/src/routes/(main)/group/features/Conversation/MainChatInput/useSendMenuItems.tsx
+++ b/src/routes/(main)/group/features/Conversation/MainChatInput/useSendMenuItems.tsx
@@ -35,8 +35,6 @@ export const useSendMenuItems = (): MenuProps['items'] => {
   const handleAddAIMessage = useCallback(() => {
     const store = storeApi.getState();
     const message = store.inputMessage;
-    if (!message.trim()) return;
-
     store.addAIMessage(message);
     // Clear and focus editor
     editor?.clearContent();


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #15796

#### 🔀 Description of Change

- Read the live editor Markdown when adding a manual assistant message, rather than always creating an empty message.
- Preserve the existing ability to create an empty assistant placeholder.
- Apply the behavior to both agent and group conversations.
- Persist `groupId` for assistant messages created in group conversations.
- Avoid clearing a newer draft when asynchronous message creation finishes.
- Add regression coverage for both menus, empty placeholders, group context, and delayed creation.

#### ✅ Verification

- `bunx vitest run src/features/Conversation/store/slices/message/action/index.test.ts src/routes/(main)/agent/features/Conversation/MainChatInput/useSendMenuItems.test.tsx` (8 passed)
- `bun run check <changed files>` (passed; two pre-existing exhaustive-deps warnings)