### PR TITLE
✨ feat(chat): open a message link in the side browser from a hover action

### DIFF
--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -512,6 +512,9 @@
   "messageForward.success": "Forwarded to {{title}}",
   "messageForward.successMulti": "Forwarded to {{count}} agents",
   "messageForward.transcript.header": "The following {{count}} messages were forwarded from another conversation. Please use them as context and continue:",
+  "messageLink": {
+    "openInSideBrowser": "Open in side browser"
+  },
   "messageLongCollapse.collapse": "Show less",
   "messageLongCollapse.expand": "Show more",
   "messages.dm.sentTo": "Visible only to {{name}}",

--- a/locales/en-US/chat.json
+++ b/locales/en-US/chat.json
@@ -512,9 +512,7 @@
   "messageForward.success": "Forwarded to {{title}}",
   "messageForward.successMulti": "Forwarded to {{count}} agents",
   "messageForward.transcript.header": "The following {{count}} messages were forwarded from another conversation. Please use them as context and continue:",
-  "messageLink": {
-    "openInSideBrowser": "Open in side browser"
-  },
+  "messageLink.openInSideBrowser": "Open in side browser",
   "messageLongCollapse.collapse": "Show less",
   "messageLongCollapse.expand": "Show more",
   "messages.dm.sentTo": "Visible only to {{name}}",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -512,9 +512,7 @@
   "messageForward.success": "已转发给 {{title}}",
   "messageForward.successMulti": "已转发给 {{count}} 个智能体",
   "messageForward.transcript.header": "以下 {{count}} 条消息转发自另一段对话，请将其作为上下文并继续处理：",
-  "messageLink": {
-    "openInSideBrowser": "在侧边浏览器中打开"
-  },
+  "messageLink.openInSideBrowser": "在侧边浏览器中打开",
   "messageLongCollapse.collapse": "收起",
   "messageLongCollapse.expand": "展开全部",
   "messages.dm.sentTo": "仅对 {{name}} 可见",

--- a/locales/zh-CN/chat.json
+++ b/locales/zh-CN/chat.json
@@ -512,6 +512,9 @@
   "messageForward.success": "已转发给 {{title}}",
   "messageForward.successMulti": "已转发给 {{count}} 个智能体",
   "messageForward.transcript.header": "以下 {{count}} 条消息转发自另一段对话，请将其作为上下文并继续处理：",
+  "messageLink": {
+    "openInSideBrowser": "在侧边浏览器中打开"
+  },
   "messageLongCollapse.collapse": "收起",
   "messageLongCollapse.expand": "展开全部",
   "messages.dm.sentTo": "仅对 {{name}} 可见",

--- a/packages/builtin-tool-web-browsing/package.json
+++ b/packages/builtin-tool-web-browsing/package.json
@@ -9,6 +9,7 @@
   },
   "main": "./src/index.ts",
   "dependencies": {
+    "@lobechat/desktop-bridge": "workspace:*",
     "@lobechat/prompts": "workspace:*"
   },
   "devDependencies": {

--- a/packages/builtin-tool-web-browsing/src/client/Portal/Search/ResultList/SearchItem/index.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Portal/Search/ResultList/SearchItem/index.tsx
@@ -66,20 +66,23 @@ const SearchItem = memo<SearchResultProps>((props) => {
   const openInBrowserTab = useGlobalStore((s) => s.openInBrowserTab);
   const enableInAppBrowser = useUserStore(labPreferSelectors.enableInAppBrowser);
 
+  // Only claim the click when this onClick will actually handle it. Otherwise the
+  // anchor's default behavior — and the desktop preload's external-link branch —
+  // opens the system browser.
+  const handlesClick = isDesktop && enableInAppBrowser && !!url;
+
   const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
-    // Without the in-app browser lab flag the anchor's default behavior
-    // opens the system browser.
-    if (!isDesktop || !enableInAppBrowser || !url) return;
+    if (!handlesClick) return;
 
     event.preventDefault();
-    openInBrowserTab(url);
+    openInBrowserTab(url!);
   };
 
   if (category === 'videos') return <Video {...props} />;
 
   return (
     <a
-      {...{ [RENDERER_HANDLED_LINK_ATTR]: 'true' }}
+      {...(handlesClick ? { [RENDERER_HANDLED_LINK_ATTR]: 'true' } : {})}
       className={styles.container}
       href={url!}
       rel="noreferrer"

--- a/packages/builtin-tool-web-browsing/src/client/Portal/Search/ResultList/SearchItem/index.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Portal/Search/ResultList/SearchItem/index.tsx
@@ -1,4 +1,5 @@
 import { isDesktop } from '@lobechat/const';
+import { RENDERER_HANDLED_LINK_ATTR } from '@lobechat/desktop-bridge';
 import type { UniformSearchResult } from '@lobechat/types';
 import { Flexbox, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
@@ -78,6 +79,7 @@ const SearchItem = memo<SearchResultProps>((props) => {
 
   return (
     <a
+      {...{ [RENDERER_HANDLED_LINK_ATTR]: 'true' }}
       className={styles.container}
       href={url!}
       rel="noreferrer"

--- a/packages/builtin-tool-web-browsing/src/client/Render/Search/SearchResult/SearchResultItem.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Render/Search/SearchResult/SearchResultItem.tsx
@@ -1,4 +1,5 @@
 import { isDesktop } from '@lobechat/const';
+import { RENDERER_HANDLED_LINK_ATTR } from '@lobechat/desktop-bridge';
 import type { UniformSearchResult } from '@lobechat/types';
 import { Block, Flexbox, Text } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
@@ -39,7 +40,12 @@ const SearchResultItem = memo<UniformSearchResult & { style?: CSSProperties }>(
     };
 
     return (
-      <a href={url} target={'_blank'} onClick={handleClick}>
+      <a
+        {...{ [RENDERER_HANDLED_LINK_ATTR]: 'true' }}
+        href={url}
+        target={'_blank'}
+        onClick={handleClick}
+      >
         <Block
           clickable
           className={styles.container}

--- a/packages/builtin-tool-web-browsing/src/client/Render/Search/SearchResult/SearchResultItem.tsx
+++ b/packages/builtin-tool-web-browsing/src/client/Render/Search/SearchResult/SearchResultItem.tsx
@@ -30,10 +30,13 @@ const SearchResultItem = memo<UniformSearchResult & { style?: CSSProperties }>(
     const openInBrowserTab = useGlobalStore((s) => s.openInBrowserTab);
     const enableInAppBrowser = useUserStore(labPreferSelectors.enableInAppBrowser);
 
+    // Only claim the click when this onClick will actually handle it. Otherwise the
+    // anchor's default behavior — and the desktop preload's external-link branch —
+    // opens the system browser.
+    const handlesClick = isDesktop && enableInAppBrowser;
+
     const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
-      // Without the in-app browser lab flag the anchor's default behavior
-      // opens the system browser.
-      if (!isDesktop || !enableInAppBrowser) return;
+      if (!handlesClick) return;
 
       event.preventDefault();
       openInBrowserTab(url);
@@ -41,7 +44,7 @@ const SearchResultItem = memo<UniformSearchResult & { style?: CSSProperties }>(
 
     return (
       <a
-        {...{ [RENDERER_HANDLED_LINK_ATTR]: 'true' }}
+        {...(handlesClick ? { [RENDERER_HANDLED_LINK_ATTR]: 'true' } : {})}
         href={url}
         target={'_blank'}
         onClick={handleClick}

--- a/packages/locales/src/default/chat.ts
+++ b/packages/locales/src/default/chat.ts
@@ -391,6 +391,7 @@ export default {
   'messageAction.reaction': 'Add Reaction',
   'messageAction.regenerate': 'Regenerate',
   'messageAction.select': 'Select',
+  'messageLink.openInSideBrowser': 'Open in side browser',
   'messageForward.bar.cancel': 'Cancel',
   'messageForward.bar.delete': 'Delete',
   'messageForward.bar.forward': 'Forward',

--- a/src/features/Conversation/Markdown/plugins/Link/Render/LinkChip.tsx
+++ b/src/features/Conversation/Markdown/plugins/Link/Render/LinkChip.tsx
@@ -1,7 +1,15 @@
 'use client';
 
+import { isDesktop } from '@lobechat/const';
+import { ActionIcon } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import { memo, type ReactNode } from 'react';
+import { PanelRightIcon } from 'lucide-react';
+import { memo, type MouseEvent, type ReactNode, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { useGlobalStore } from '@/store/global';
+import { useUserStore } from '@/store/user';
+import { labPreferSelectors } from '@/store/user/selectors';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   chip: css`
@@ -18,6 +26,22 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     margin-inline-end: 4px;
     vertical-align: -0.15em;
   `,
+  sideBrowser: css`
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s;
+  `,
+  wrapper: css`
+    display: inline-flex;
+    gap: 2px;
+    align-items: center;
+
+    &:hover [data-side-browser],
+    &:focus-within [data-side-browser] {
+      pointer-events: auto;
+      opacity: 1;
+    }
+  `,
 }));
 
 interface LinkChipProps {
@@ -26,12 +50,47 @@ interface LinkChipProps {
   label: string;
 }
 
-const LinkChip = memo<LinkChipProps>(({ href, icon, label }) => (
-  <a className={styles.chip} href={href} rel="noopener noreferrer" target="_blank">
-    {icon && <span className={styles.icon}>{icon}</span>}
-    {label}
-  </a>
-));
+const isWebUrl = (href?: string) => !!href && /^https?:\/\//i.test(href);
+
+const LinkChip = memo<LinkChipProps>(({ href, icon, label }) => {
+  const { t } = useTranslation('chat');
+  const openInBrowserTab = useGlobalStore((s) => s.openInBrowserTab);
+  const enableInAppBrowser = useUserStore(labPreferSelectors.enableInAppBrowser);
+
+  const openInSideBrowser = useCallback(
+    (event: MouseEvent<HTMLElement>) => {
+      event.preventDefault();
+      openInBrowserTab(href!);
+    },
+    [href, openInBrowserTab],
+  );
+
+  const link = (
+    <a className={styles.chip} href={href} rel="noopener noreferrer" target="_blank">
+      {icon && <span className={styles.icon}>{icon}</span>}
+      {label}
+    </a>
+  );
+
+  if (!isDesktop || !enableInAppBrowser || !isWebUrl(href)) return link;
+
+  return (
+    <span className={styles.wrapper}>
+      {link}
+      {/* Must stay OUTSIDE the anchor: the desktop preload matches clicks with
+          `closest('a')` in the capture phase and stops propagation, so a button
+          nested inside the link would never reach this onClick. */}
+      <ActionIcon
+        data-side-browser
+        className={styles.sideBrowser}
+        icon={PanelRightIcon}
+        size={'small'}
+        title={t('messageLink.openInSideBrowser')}
+        onClick={openInSideBrowser}
+      />
+    </span>
+  );
+});
 
 LinkChip.displayName = 'LinkChip';
 

--- a/src/features/Conversation/Markdown/plugins/Link/Render/index.test.tsx
+++ b/src/features/Conversation/Markdown/plugins/Link/Render/index.test.tsx
@@ -20,6 +20,8 @@ vi.mock('@lobechat/const', async (importOriginal) => ({
 // selector's return value through this module-level flag so each case can flip
 // the "Link Icon" setting on/off without a real store.
 let mockShowIcon = true;
+let mockEnableInAppBrowser = false;
+const mockOpenInBrowserTab = vi.fn();
 const mockNavigate = vi.fn();
 const mockOpenAgentDetail = vi.fn();
 const mockOpenDocument = vi.fn();
@@ -65,9 +67,17 @@ vi.mock('@/store/user', () => ({
 }));
 
 vi.mock('@/store/user/selectors', () => ({
+  labPreferSelectors: {
+    enableInAppBrowser: () => mockEnableInAppBrowser,
+  },
   userGeneralSettingsSelectors: {
     enableMessageLinkIcon: () => mockShowIcon,
   },
+}));
+
+vi.mock('@/store/global', () => ({
+  useGlobalStore: (selector: (s: unknown) => unknown) =>
+    selector({ openInBrowserTab: mockOpenInBrowserTab }),
 }));
 
 const renderLink = (properties: Record<string, unknown>) =>
@@ -80,6 +90,7 @@ const renderLink = (properties: Record<string, unknown>) =>
 afterEach(() => {
   mockShowIcon = true;
   mockIsDesktop = false;
+  mockEnableInAppBrowser = false;
 });
 
 beforeEach(() => {
@@ -260,6 +271,90 @@ describe('Link Render — desktop preload contract', () => {
     });
 
     expect(container.querySelector('a')).not.toHaveAttribute(RENDERER_HANDLED_LINK_ATTR);
+  });
+});
+
+describe('Link Render — open an external link in the side browser', () => {
+  const renderExternal = () =>
+    renderLink({
+      linkDomain: 'localhost',
+      linkHref: 'http://localhost:3022/observability/context',
+      linkKind: 'generic',
+      linkLabel: 'http://localhost:3022/observability/context',
+    });
+
+  it('offers the side-browser action on desktop when the in-app browser is enabled', () => {
+    mockIsDesktop = true;
+    mockEnableInAppBrowser = true;
+
+    const { container } = renderExternal();
+    const action = container.querySelector('[data-side-browser]')!;
+    expect(action).toBeTruthy();
+
+    fireEvent.click(action);
+
+    expect(mockOpenInBrowserTab).toHaveBeenCalledWith(
+      'http://localhost:3022/observability/context',
+    );
+  });
+
+  it('keeps the action OUTSIDE the anchor, or the preload would swallow its click', () => {
+    mockIsDesktop = true;
+    mockEnableInAppBrowser = true;
+
+    const { container } = renderExternal();
+
+    // The preload intercepts clicks via closest('a') in the capture phase, so an
+    // action nested inside the link would never reach React.
+    expect(container.querySelector('a [data-side-browser]')).toBeNull();
+    expect(container.querySelector('[data-side-browser]')!.closest('a')).toBeNull();
+  });
+
+  it('leaves the anchor itself untouched, so a plain click still opens the system browser', () => {
+    mockIsDesktop = true;
+    mockEnableInAppBrowser = true;
+
+    const { container } = renderExternal();
+    const anchor = container.querySelector('a')!;
+
+    expect(anchor).not.toHaveAttribute(RENDERER_HANDLED_LINK_ATTR);
+    expect(anchor).toHaveAttribute('target', '_blank');
+
+    fireEvent.click(anchor);
+    expect(mockOpenInBrowserTab).not.toHaveBeenCalled();
+  });
+
+  it('hides the action on web, and on desktop with the lab flag off', () => {
+    mockIsDesktop = false;
+    mockEnableInAppBrowser = true;
+    const web = renderExternal();
+    expect(web.container.querySelector('[data-side-browser]')).toBeNull();
+    web.unmount();
+
+    mockIsDesktop = true;
+    mockEnableInAppBrowser = false;
+    const flagOff = renderExternal();
+    expect(flagOff.container.querySelector('[data-side-browser]')).toBeNull();
+  });
+
+  it('hides the action for non-web links (mailto) and for portal-bound internal links', () => {
+    mockIsDesktop = true;
+    mockEnableInAppBrowser = true;
+
+    const email = renderLink({
+      linkHref: 'mailto:a@b.com',
+      linkKind: 'email',
+      linkLabel: 'a@b.com',
+    });
+    expect(email.container.querySelector('[data-side-browser]')).toBeNull();
+    email.unmount();
+
+    const internal = renderLink({
+      linkHref: '/verify/run-1',
+      linkKind: 'generic',
+      linkLabel: 'Verify report',
+    });
+    expect(internal.container.querySelector('[data-side-browser]')).toBeNull();
   });
 
   it('navigates non-entity app routes without leaving the SPA', () => {


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [x] 🐛 fix

#### 🔀 Description of Change

A web link in a chat message keeps its default behavior — a plain click still opens the system browser. On desktop with the in-app browser enabled, **hovering the link now reveals an action that opens it in the right-side Browser pane instead**, via `openInBrowserTab(url)` — the same entry point the agent's browser tool already uses.

**The action deliberately sits OUTSIDE the anchor.** The desktop preload matches clicks with `closest('a')` in the capture phase and calls `stopPropagation()`, so a button nested inside the link would never reach React. This isn't hypothetical: it had already silently broken the two web-search result items in `builtin-tool-web-browsing`, which hang `openInBrowserTab` off the anchor's own `onClick` — on desktop that handler has never run, and clicking a search result has always escaped to the system browser instead of the in-app browser. They now declare themselves with `RENDERER_HANDLED_LINK_ATTR` so the preload lets the click through, which makes that feature work for the first time.

Gating: the action only renders when `isDesktop && enableInAppBrowser` (Labs flag, off by default) and the href is http(s). Web has no `<webview>` equivalent, so links there are untouched; `mailto:` and portal-bound internal links (`/verify/<id>`) get no action either.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

End-to-end in an isolated Electron instance on this branch (real login, real chat surface), 6/6 passed: **https://app.lobehub.com/verify/e7902abb-48e3-4dbb-989f-67f9d58833f6**

Real hover reveals the icon (computed `opacity: 1 / pointer-events: auto`); a real click flips the panel to the Browser tab and a `type=webview` CDP target appears pointing at the URL, with the page rendered. A plain click on the anchor still logs `[preload] Intercepted external link click` and goes to the system browser. 20 unit tests cover visibility, the click, the outside-the-anchor DOM constraint, and every fallback.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| A link can only be opened in the system browser | Hover reveals an action that opens it in the right-side browser — screenshots in the verify link above |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
