### PR TITLE
💄 style(ui): polish browser panel, topic rows, usage footer, and verify report evidence

### DIFF
--- a/.agents/skills/agent-testing/references/common-mistakes.md
+++ b/.agents/skills/agent-testing/references/common-mistakes.md
@@ -148,10 +148,32 @@ before from after.
 and it takes another round to re-explain.
 
 **Correct approach**: never ship a raw stale/before screenshot as standalone
-evidence. If a contrast helps, build ONE labeled before→after composite (e.g. sharp:
-crop the region from each, add a "BEFORE …/AFTER …" header bar, place side by side)
-and attach that single image. Evidence for a passed case = the after state (or a
-clearly-labeled comparison), full stop.
+evidence. When a contrast helps, use the report format's **native comparison pairing**
+— attach both raw screenshots and tag them with a shared `comparison` id, and the
+verify page renders them side by side under Before / After headings
+([report.md](./report.md#L64-78)):
+
+```json
+"evidence": [
+  { "path": "assets/before.png", "comparison": { "id": "layout", "role": "before" } },
+  { "path": "assets/after.png", "comparison": { "id": "layout", "role": "after" } }
+]
+```
+
+**Do NOT hand-compose the two shots into one image with sharp** (an earlier version of
+this note told you to, and an agent duly shipped stacked red/green banner images — the
+user asked why the report ignored the spec). The page owns the labeling; a composite
+also bakes in a fixed layout, can't be zoomed per side, and duplicates the heading the
+page already draws. Evidence for a passed case = the after state, or a `comparison`
+pair, full stop.
+
+Two more traps in the same area:
+
+- **One evidence item per case, not the same image reused across cases.** Attaching the
+  same before/after pair to two different cases makes the report look padded and leaves
+  the second case with no evidence of its own claim.
+- A group needs **exactly one `before` and one `after`** — an incomplete group silently
+  degrades to ordinary (unlabeled) evidence, i.e. straight back into this bug.
 
 ## Case 6 — `app://renderer` desktop instance runs the STALE built bundle, not working-tree code
 

--- a/.agents/skills/agent-testing/references/probe-mock-patterns.md
+++ b/.agents/skills/agent-testing/references/probe-mock-patterns.md
@@ -255,6 +255,44 @@ Re-tested end-to-end against the running dev server. The previous claim ("blocks
   show `0` even though the agent owns them in the DB; click **清空筛选 / Clear filters** (or
   `setStatus('all')` + clear) to reveal them.
 
+### A9. ✅ WORKS — before/after visual diffing by checking out the OLD file, but HMR is NOT trustworthy for it
+
+- **Situation**: producing labeled before→after evidence for a UI/style change (Case 5 requires a
+  real "before" render, not a code-derived guess). The clean way is to write the pre-change version
+  of the file into the working tree (`git show <base>:<path> > <path>`), capture, then restore.
+- **Doesn't work — silently**: assuming Vite HMR applied the swap. In this run the FIRST swap
+  hot-applied fine, and the SECOND one did not: the file on disk was the old version while the
+  renderer kept the new computed styles for 24s+ of polling. Screenshots taken then would have been
+  the AFTER state mislabeled as BEFORE — a Case-5 failure that no screenshot review would catch,
+  because both look plausible.
+- **Works — gate every capture on a measured version signal, not on a sleep**: pick a property that
+  differs between the two versions and read it back with `getComputedStyle` before shooting.
+  ```bash
+  # after writing the old file, confirm the OLD css is actually live
+  agent-browser --cdp 9222 eval '(function(){var i=document.querySelector("<selector>");
+    var s=getComputedStyle(i);return JSON.stringify({pos:s.position,bg:s.backgroundColor})})()'
+  # expect the OLD values; if not, force a full reload and re-enter the surface
+  agent-browser --cdp 9222 eval 'location.reload(); 1'
+  ```
+  A full reload resets SPA state, so budget for re-navigating and re-establishing any fixture
+  (re-open the tab, re-drag a resizable panel, …). Restore the new file the same way and re-measure
+  before the AFTER shots.
+- **Corollary — a layout change may be invisible at the default size.** A `flex: 1` right-alignment
+  fix renders identically to the broken version in a narrow container (the content already fills the
+  row); the difference only appears once there is slack. Drive the app's own resize affordance with
+  real mouse events before concluding "no visual change":
+  ```bash
+  # DraggablePanel handle: .ant-draggable-panel-left-handle (find via getComputedStyle cursor: col-resize)
+  agent-browser --cdp 9222 mouse move < handleX > 500
+  agent-browser --cdp 9222 mouse down left
+  for X in 1050 900 750 600 420; do
+    agent-browser --cdp 9222 mouse move $X 500
+    sleep 0.2
+  done
+  agent-browser --cdp 9222 mouse up left
+  ```
+  (zsh does not word-split unquoted vars — inline the `--cdp` flags, don't stash them in `$AB`.)
+
 ---
 
 ## B. Cache / stale state that MASKS the failure

--- a/.agents/skills/agent-testing/references/report.md
+++ b/.agents/skills/agent-testing/references/report.md
@@ -74,8 +74,26 @@ the page. It carries only the non-duplicate narrative (仍需跟进 / 本轮验�
 
      The verify page renders a complete pair side by side with Before / After
      headings. `comparison.label` may override either heading. A group contains
-     exactly one `before` and one `after`; incomplete groups render as ordinary
-     evidence.
+     exactly one `before` and one `after`, and **both halves need the same string
+     `id`** — a half without an `id` can never pair. Incomplete groups render as
+     ordinary evidence.
+
+     ⚠️ **`comparison` needs a CLI newer than the published `lh`.** Support landed
+     in `9fc8c77805` (2026-07-12); the npm release on `PATH` (0.0.41) predates it
+     and its `ingest-report` simply **never sends the `metadata` field** — the
+     upload succeeds, the page stacks the two images unlabeled, and nothing warns
+     you. Symptom: `lh verify evidence list <checkResultId> --json` shows
+     `"metadata": null`. Until a newer `lh` ships, publish a report that uses
+     `comparison` with the repo's CLI instead:
+
+     ```bash
+     cd apps/cli && env -u LOBEHUB_SERVER -u LOBE_API_KEY \
+       -u LOBEHUB_CLI_API_KEY -u LOBEHUB_CLI_HOME \
+       bun src/index.ts verify ingest-report "$DIR" --source agent-testing --json
+     ```
+
+     Re-ingesting the same `$DIR` updates the session in place, so a report already
+     published with the stale CLI can be fixed without a new `/verify` URL.
 
    - CLI: exact command + trimmed output (`$CLI task list | tee "$DIR/assets/task-list.txt"`).
 

--- a/.agents/skills/agent-testing/references/report.md
+++ b/.agents/skills/agent-testing/references/report.md
@@ -106,23 +106,6 @@ the page. It carries only the non-duplicate narrative (仍需跟进 / 本轮验�
        delta on each side (`"11px，行高 40px"` vs `"12px，行高 44px"`), so the two
        captions read as a comparison rather than repeating the case title.
 
-     ⚠️ **`comparison` needs a CLI newer than the published `lh`.** Support landed
-     in `9fc8c77805` (2026-07-12); the npm release on `PATH` (0.0.41) predates it
-     and its `ingest-report` simply **never sends the `metadata` field** — the
-     upload succeeds, the page stacks the two images unlabeled, and nothing warns
-     you. Symptom: `lh verify evidence list <checkResultId> --json` shows
-     `"metadata": null`. Until a newer `lh` ships, publish a report that uses
-     `comparison` with the repo's CLI instead:
-
-     ```bash
-     cd apps/cli && env -u LOBEHUB_SERVER -u LOBE_API_KEY \
-       -u LOBEHUB_CLI_API_KEY -u LOBEHUB_CLI_HOME \
-       bun src/index.ts verify ingest-report "$DIR" --source agent-testing --json
-     ```
-
-     Re-ingesting the same `$DIR` updates the session in place, so a report already
-     published with the stale CLI can be fixed without a new `/verify` URL.
-
    - CLI: exact command + trimmed output (`$CLI task list | tee "$DIR/assets/task-list.txt"`).
 
    - Network: `agent-browser network requests` dumps or HAR files.

--- a/.agents/skills/agent-testing/references/report.md
+++ b/.agents/skills/agent-testing/references/report.md
@@ -67,16 +67,44 @@ the page. It carries only the non-duplicate narrative (仍需跟进 / 本轮验�
 
      ```json
      "evidence": [
-       { "path": "assets/before.png", "comparison": { "id": "layout", "role": "before" } },
-       { "path": "assets/after.png", "comparison": { "id": "layout", "role": "after" } }
+       {
+         "path": "assets/before.png",
+         "comparison": {
+           "id": "topic-row",
+           "role": "before",
+           "layout": "vertical",
+           "label": "副标题 11px，行高 40px"
+         }
+       },
+       {
+         "path": "assets/after.png",
+         "comparison": {
+           "id": "topic-row",
+           "role": "after",
+           "layout": "vertical",
+           "label": "副标题 12px，行高 44px"
+         }
+       }
      ]
      ```
 
-     The verify page renders a complete pair side by side with Before / After
-     headings. `comparison.label` may override either heading. A group contains
-     exactly one `before` and one `after`, and **both halves need the same string
-     `id`** — a half without an `id` can never pair. Incomplete groups render as
-     ordinary evidence.
+     The verify page renders a complete pair with each screenshot under its own
+     tinted band — red for `before`, green for `after` — so which state you are
+     looking at survives a glance. A group contains exactly one `before` and one
+     `after`, and **both halves need the same string `id`**; a half without an `id`
+     can never pair. Incomplete groups render as ordinary evidence.
+
+     Two fields are worth setting on every pair:
+
+     - **`layout`** — `horizontal` (default, side by side) or `vertical` (stacked).
+       Pick by the shape of the crop: a tall, narrow capture (a sidebar, a form,
+       a list) reads well side by side; a **wide, short strip** (a toolbar, a
+       one-line footer) must be `vertical`, because two of them in a two-column
+       grid become illegible slivers. Set it on both halves.
+     - **`label`** — the caption shown next to the role word in the band. This is
+       where the before/after contrast is actually _stated_: put the measured
+       delta on each side (`"11px，行高 40px"` vs `"12px，行高 44px"`), so the two
+       captions read as a comparison rather than repeating the case title.
 
      ⚠️ **`comparison` needs a CLI newer than the published `lh`.** Support landed
      in `9fc8c77805` (2026-07-12); the npm release on `PATH` (0.0.41) predates it

--- a/apps/cli/src/commands/verify.test.ts
+++ b/apps/cli/src/commands/verify.test.ts
@@ -241,12 +241,34 @@ describe('reportEvidence — comparison normalization', () => {
 
   it('keeps a comparison that carries both an id and a before/after role', () => {
     const [before, after] = reportEvidence([
-      { comparison: { id: 'layout', role: 'before' }, path: 'before.png' },
-      { comparison: { id: 'layout', label: '改后', role: 'after' }, path: 'after.png' },
+      { comparison: { id: 'row', role: 'before' }, path: 'before.png' },
+      { comparison: { id: 'row', label: '改后', role: 'after' }, path: 'after.png' },
     ]);
 
-    expect(before.comparison).toEqual({ id: 'layout', label: undefined, role: 'before' });
-    expect(after.comparison).toEqual({ id: 'layout', label: '改后', role: 'after' });
+    expect(before.comparison).toEqual({
+      id: 'row',
+      label: undefined,
+      layout: undefined,
+      role: 'before',
+    });
+    expect(after.comparison).toEqual({
+      id: 'row',
+      label: '改后',
+      layout: undefined,
+      role: 'after',
+    });
+  });
+
+  it('passes a vertical layout through and ignores any other value', () => {
+    const forLayout = (layout: unknown) =>
+      reportEvidence([{ comparison: { id: 'row', layout, role: 'before' }, path: 'a.png' }])[0]
+        .comparison?.layout;
+
+    expect(forLayout('vertical')).toBe('vertical');
+    // Side by side is the default, so anything unrecognized simply falls back to it.
+    expect(forLayout('horizontal')).toBeUndefined();
+    expect(forLayout('diagonal')).toBeUndefined();
+    expect(forLayout(undefined)).toBeUndefined();
   });
 
   // The report viewer pairs on `id`, so an id-less comparison could never render

--- a/apps/cli/src/commands/verify.test.ts
+++ b/apps/cli/src/commands/verify.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { registerVerifyCommand } from './verify';
+import { registerVerifyCommand, reportEvidence } from './verify';
 
 const { mockTrpcClient } = vi.hoisted(() => ({
   mockTrpcClient: {
@@ -230,5 +230,46 @@ describe('verify init command', () => {
     expect(out.skill).toBe('verify');
     expect(out.written).toContain('SKILL.md');
     expect(existsSync(path.join(out.dir, 'SKILL.md'))).toBe(true);
+  });
+});
+
+describe('reportEvidence — comparison normalization', () => {
+  it('accepts plain string paths', () => {
+    expect(reportEvidence('assets/a.png')).toEqual([{ path: 'assets/a.png' }]);
+    expect(reportEvidence(['a.png', 'b.png']).map((e) => e.path)).toEqual(['a.png', 'b.png']);
+  });
+
+  it('keeps a comparison that carries both an id and a before/after role', () => {
+    const [before, after] = reportEvidence([
+      { comparison: { id: 'layout', role: 'before' }, path: 'before.png' },
+      { comparison: { id: 'layout', label: '改后', role: 'after' }, path: 'after.png' },
+    ]);
+
+    expect(before.comparison).toEqual({ id: 'layout', label: undefined, role: 'before' });
+    expect(after.comparison).toEqual({ id: 'layout', label: '改后', role: 'after' });
+  });
+
+  // The report viewer pairs on `id`, so an id-less comparison could never render
+  // side by side — dropping it here keeps the upload honest instead of shipping
+  // metadata the UI silently ignores.
+  it('drops a comparison missing an id, keeping the image as ordinary evidence', () => {
+    const [item] = reportEvidence([{ comparison: { role: 'before' }, path: 'before.png' }]);
+
+    expect(item).toEqual({ comparison: undefined, description: undefined, path: 'before.png' });
+  });
+
+  it('drops a comparison whose role is absent or unrecognized', () => {
+    expect(
+      reportEvidence([{ comparison: { id: 'x', role: 'middle' }, path: 'a.png' }])[0].comparison,
+    ).toBeUndefined();
+    expect(
+      reportEvidence([{ comparison: { id: 'x' }, path: 'a.png' }])[0].comparison,
+    ).toBeUndefined();
+  });
+
+  it('supports the `file` / `desc` aliases and skips entries with no path', () => {
+    expect(
+      reportEvidence([{ desc: 'a shot', file: 'a.png' }, { comparison: { id: 'x' } }]),
+    ).toEqual([{ comparison: undefined, description: 'a shot', path: 'a.png' }]);
   });
 });

--- a/apps/cli/src/commands/verify.ts
+++ b/apps/cli/src/commands/verify.ts
@@ -76,7 +76,12 @@ function inlineTextEvidenceForFile(file: string, type: EvidenceType | string): s
 
 /** Normalize a case's `evidence` field (string | string[] | {path}[]) to path strings. */
 interface ReportEvidenceInput {
-  comparison?: { id: string; label?: string; role: 'after' | 'before' };
+  comparison?: {
+    id: string;
+    label?: string;
+    layout?: 'horizontal' | 'vertical';
+    role: 'after' | 'before';
+  };
   description?: string;
   path: string;
 }
@@ -101,10 +106,11 @@ export function reportEvidence(evidence: unknown): ReportEvidenceInput[] {
           `evidence ${evidencePath}: comparison needs both a string "id" and role "before"/"after" — ignoring it`,
         );
       }
+      const layout = comparison?.layout === 'vertical' ? 'vertical' : undefined;
       return {
         comparison:
           id && (role === 'before' || role === 'after')
-            ? { id, label: firstString(comparison?.label), role }
+            ? { id, label: firstString(comparison?.label), layout, role }
             : undefined,
         description: firstString(value.description, value.desc),
         path: evidencePath,

--- a/apps/cli/src/commands/verify.ts
+++ b/apps/cli/src/commands/verify.ts
@@ -76,12 +76,12 @@ function inlineTextEvidenceForFile(file: string, type: EvidenceType | string): s
 
 /** Normalize a case's `evidence` field (string | string[] | {path}[]) to path strings. */
 interface ReportEvidenceInput {
-  comparison?: { id?: string; label?: string; role?: 'after' | 'before' };
+  comparison?: { id: string; label?: string; role: 'after' | 'before' };
   description?: string;
   path: string;
 }
 
-function reportEvidence(evidence: unknown): ReportEvidenceInput[] {
+export function reportEvidence(evidence: unknown): ReportEvidenceInput[] {
   if (!evidence) return [];
   const arr = Array.isArray(evidence) ? evidence : [evidence];
   return arr
@@ -92,14 +92,19 @@ function reportEvidence(evidence: unknown): ReportEvidenceInput[] {
       if (!evidencePath) return null;
       const comparison = objectValue(value.comparison);
       const role = comparison?.role;
+      const id = firstString(comparison?.id);
+      // The report viewer pairs on `id` and drops any comparison lacking one, so
+      // an id-less half could never render side by side. Warn rather than upload
+      // a comparison that is silently downgraded to an ordinary image.
+      if (comparison && !(id && (role === 'before' || role === 'after'))) {
+        log.warn(
+          `evidence ${evidencePath}: comparison needs both a string "id" and role "before"/"after" — ignoring it`,
+        );
+      }
       return {
         comparison:
-          comparison && (role === 'before' || role === 'after')
-            ? {
-                id: firstString(comparison.id),
-                label: firstString(comparison.label),
-                role,
-              }
+          id && (role === 'before' || role === 'after')
+            ? { id, label: firstString(comparison?.label), role }
             : undefined,
         description: firstString(value.description, value.desc),
         path: evidencePath,

--- a/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
@@ -27,6 +27,11 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     font-size: 12px;
     color: ${cssVar.colorTextQuaternary};
   `,
+  separator: css`
+    /* The row's gap alone reads as a gutter between unrelated items; the dot binds
+       the token count and the speed into one metrics run. */
+    margin-inline: -2px;
+  `,
 }));
 
 // Cheap messages don't need a cost callout — only surface it once it's
@@ -87,29 +92,32 @@ const Usage = memo<UsageProps>(({ model, usage, performance, provider }) => {
             usage={usage}
           />
         )}
-        {/* A spelled-out "TPS" label rather than an icon: at 12px a gauge glyph is
+        {/* A spelled-out "TPS" unit rather than an icon: at 12px a gauge glyph is
             indistinguishable from the neighbouring coin, so the reader can't tell
             what the number measures. TTFT rides in the hover instead of taking a
             second inline slot — it's a diagnostic, not an at-a-glance metric. */}
         {!!performance?.tps && (
-          <Tooltip
-            title={
-              <Flexbox gap={6}>
-                <span>{t('messages.tokenDetails.speed.tps.tooltip')}</span>
-                {!!performance.ttft && (
-                  <Flexbox horizontal gap={12} justify={'space-between'}>
-                    <span>{t('messages.tokenDetails.speed.ttft.title')}</span>
-                    <span>{formatNumber(performance.ttft / 1000, 2)}s</span>
-                  </Flexbox>
-                )}
-              </Flexbox>
-            }
-          >
-            <Center horizontal gap={4}>
-              <span>{t('messages.tokenDetails.speed.tps.title')}</span>
-              <span>{formatNumber(performance.tps, 1)}</span>
-            </Center>
-          </Tooltip>
+          <>
+            {!!usage?.totalTokens && <span className={styles.separator}>·</span>}
+            <Tooltip
+              title={
+                <Flexbox gap={6}>
+                  <span>{t('messages.tokenDetails.speed.tps.tooltip')}</span>
+                  {!!performance.ttft && (
+                    <Flexbox horizontal gap={12} justify={'space-between'}>
+                      <span>{t('messages.tokenDetails.speed.ttft.title')}</span>
+                      <span>{formatNumber(performance.ttft / 1000, 2)}s</span>
+                    </Flexbox>
+                  )}
+                </Flexbox>
+              }
+            >
+              <Center horizontal gap={4}>
+                <span>{formatNumber(performance.tps, 1)}</span>
+                <span>{t('messages.tokenDetails.speed.tps.title')}</span>
+              </Center>
+            </Tooltip>
+          </>
         )}
         {!isShowCredit && !!usage?.cost && usage.cost >= MIN_DISPLAY_COST && (
           <Center horizontal gap={2}>

--- a/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
@@ -79,25 +79,6 @@ const Usage = memo<UsageProps>(({ model, usage, performance, provider }) => {
       </Center>
 
       <Center horizontal gap={8}>
-        {/* Spelled-out labels rather than icons: at 12px a gauge and a timer glyph
-            are indistinguishable from each other and from the coin, so the reader
-            can't tell which number is which without hovering. */}
-        {!!performance?.tps && (
-          <Tooltip title={t('messages.tokenDetails.speed.tps.tooltip')}>
-            <Center horizontal gap={4}>
-              <span>{t('messages.tokenDetails.speed.tps.title')}</span>
-              <span>{formatNumber(performance.tps, 1)}</span>
-            </Center>
-          </Tooltip>
-        )}
-        {!!performance?.ttft && (
-          <Tooltip title={t('messages.tokenDetails.speed.ttft.tooltip')}>
-            <Center horizontal gap={4}>
-              <span>{t('messages.tokenDetails.speed.ttft.title')}</span>
-              <span>{formatNumber(performance.ttft / 1000, 1)}s</span>
-            </Center>
-          </Tooltip>
-        )}
         {!!usage?.totalTokens && (
           <TokenDetail
             model={model as string}
@@ -105,6 +86,30 @@ const Usage = memo<UsageProps>(({ model, usage, performance, provider }) => {
             provider={provider}
             usage={usage}
           />
+        )}
+        {/* A spelled-out "TPS" label rather than an icon: at 12px a gauge glyph is
+            indistinguishable from the neighbouring coin, so the reader can't tell
+            what the number measures. TTFT rides in the hover instead of taking a
+            second inline slot — it's a diagnostic, not an at-a-glance metric. */}
+        {!!performance?.tps && (
+          <Tooltip
+            title={
+              <Flexbox gap={6}>
+                <span>{t('messages.tokenDetails.speed.tps.tooltip')}</span>
+                {!!performance.ttft && (
+                  <Flexbox horizontal gap={12} justify={'space-between'}>
+                    <span>{t('messages.tokenDetails.speed.ttft.title')}</span>
+                    <span>{formatNumber(performance.ttft / 1000, 2)}s</span>
+                  </Flexbox>
+                )}
+              </Flexbox>
+            }
+          >
+            <Center horizontal gap={4}>
+              <span>{t('messages.tokenDetails.speed.tps.title')}</span>
+              <span>{formatNumber(performance.tps, 1)}</span>
+            </Center>
+          </Tooltip>
         )}
         {!isShowCredit && !!usage?.cost && usage.cost >= MIN_DISPLAY_COST && (
           <Center horizontal gap={2}>

--- a/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
@@ -4,11 +4,12 @@ import {
 } from '@lobechat/heterogeneous-agents';
 import { type ModelPerformance, type ModelUsage } from '@lobechat/types';
 import { ModelIcon } from '@lobehub/icons';
-import { Center, Flexbox, Icon } from '@lobehub/ui';
+import { Center, Flexbox, Icon, Tooltip } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import isEqual from 'fast-deep-equal';
 import { CircleDollarSignIcon } from 'lucide-react';
 import { memo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import { useAgentStore } from '@/store/agent';
 import { builtinAgentSelectors } from '@/store/agent/selectors';
@@ -16,6 +17,7 @@ import { aiModelSelectors, useAiInfraStore } from '@/store/aiInfra';
 import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 import { isDev } from '@/utils/env';
+import { formatNumber } from '@/utils/format';
 
 import { contextSelectors, useConversationStore } from '../../../../store';
 import TokenDetail from './UsageDetail';
@@ -41,6 +43,7 @@ interface UsageProps {
 }
 
 const Usage = memo<UsageProps>(({ model, usage, performance, provider }) => {
+  const { t } = useTranslation('chat');
   const onboardingAgentId = useAgentStore(builtinAgentSelectors.webOnboardingAgentId);
   const conversationAgentId = useConversationStore(contextSelectors.agentId);
   // Credit mode already expresses cost in credits — showing USD alongside would conflict.
@@ -76,6 +79,25 @@ const Usage = memo<UsageProps>(({ model, usage, performance, provider }) => {
       </Center>
 
       <Center horizontal gap={8}>
+        {/* Spelled-out labels rather than icons: at 12px a gauge and a timer glyph
+            are indistinguishable from each other and from the coin, so the reader
+            can't tell which number is which without hovering. */}
+        {!!performance?.tps && (
+          <Tooltip title={t('messages.tokenDetails.speed.tps.tooltip')}>
+            <Center horizontal gap={4}>
+              <span>{t('messages.tokenDetails.speed.tps.title')}</span>
+              <span>{formatNumber(performance.tps, 1)}</span>
+            </Center>
+          </Tooltip>
+        )}
+        {!!performance?.ttft && (
+          <Tooltip title={t('messages.tokenDetails.speed.ttft.tooltip')}>
+            <Center horizontal gap={4}>
+              <span>{t('messages.tokenDetails.speed.ttft.title')}</span>
+              <span>{formatNumber(performance.ttft / 1000, 1)}s</span>
+            </Center>
+          </Tooltip>
+        )}
         {!!usage?.totalTokens && (
           <TokenDetail
             model={model as string}

--- a/src/features/NavPanel/components/NavItem.tsx
+++ b/src/features/NavPanel/components/NavItem.tsx
@@ -124,7 +124,7 @@ const NavItem = memo<NavItemProps>(
         clickable={!disabled}
         gap={8}
         height={description ? undefined : 36}
-        paddingBlock={description ? 4 : undefined}
+        paddingBlock={description ? 8 : undefined}
         paddingInline={4}
         style={mergedStyle}
         variant={variant}
@@ -162,7 +162,7 @@ const NavItem = memo<NavItemProps>(
         <Flexbox horizontal align={'center'} flex={1} gap={8} style={{ overflow: 'hidden' }}>
           {titlePrefix}
           {description ? (
-            <Flexbox flex={1} gap={1} style={{ overflow: 'hidden' }}>
+            <Flexbox flex={1} gap={3} style={{ overflow: 'hidden' }}>
               <Text color={textColor} ellipsis={{ tooltipWhenOverflow: true }}>
                 {title}
               </Text>

--- a/src/features/Verify/ReportViewer.tsx
+++ b/src/features/Verify/ReportViewer.tsx
@@ -21,7 +21,7 @@ import {
   Text,
 } from '@lobehub/ui';
 import { Button } from '@lobehub/ui/base-ui';
-import { createStaticStyles, cssVar } from 'antd-style';
+import { createStaticStyles, cssVar, cx } from 'antd-style';
 import type { TFunction } from 'i18next';
 import {
   AlertTriangle,
@@ -710,6 +710,11 @@ const styles = createStaticStyles(({ css }) => ({
       grid-template-columns: 1fr;
     }
   `,
+  /* Wide, short captures (a toolbar, a one-line footer) get halved into
+     illegible slivers by the two-column grid — stack them instead. */
+  comparisonVertical: css`
+    grid-template-columns: 1fr;
+  `,
   comparisonItem: css`
     overflow: hidden;
 
@@ -719,16 +724,38 @@ const styles = createStaticStyles(({ css }) => ({
 
     background: ${cssVar.colorBgContainer};
   `,
+  /* The role rides on a tinted band fused to its own screenshot, so which state
+     you're looking at survives being read at a glance — a neutral heading above
+     the image reads as a caption for the whole pair. */
   comparisonLabel: css`
-    display: block;
+    display: flex;
+    gap: 8px;
+    align-items: baseline;
 
     padding-block: 7px;
     padding-inline: 10px;
-    border-block-end: 1px solid ${cssVar.colorBorderSecondary};
 
     font-size: 12px;
+  `,
+  comparisonLabelBefore: css`
+    border-block-end: 1px solid ${cssVar.colorErrorBorder};
+    color: ${cssVar.colorErrorText};
+    background: ${cssVar.colorErrorBg};
+  `,
+  comparisonLabelAfter: css`
+    border-block-end: 1px solid ${cssVar.colorSuccessBorder};
+    color: ${cssVar.colorSuccessText};
+    background: ${cssVar.colorSuccessBg};
+  `,
+  comparisonRole: css`
+    flex: none;
     font-weight: 600;
-    color: ${cssVar.colorTextSecondary};
+  `,
+  /* The two captions are themselves a before/after contrast, so they must stay
+     readable side by side — wrap rather than ellipsize. */
+  comparisonCaption: css`
+    min-width: 0;
+    opacity: 0.85;
   `,
   evidenceFile: css`
     cursor: pointer;
@@ -1047,6 +1074,13 @@ const evidenceDisplayName = (
 interface EvidenceComparison {
   id: string;
   label?: string;
+  /**
+   * How the pair is arranged. Side by side reads best for tall, narrow captures
+   * (a sidebar, a form); stacking is the only way a wide, short strip (a toolbar,
+   * a one-line footer) stays legible, since two of them side by side halve an
+   * already-thin band. Authors pick per pair; defaults to side by side.
+   */
+  layout: 'horizontal' | 'vertical';
   role: 'after' | 'before';
 }
 
@@ -1068,6 +1102,7 @@ const evidenceComparison = (evidence: VerifyEvidenceWithUrl): EvidenceComparison
   return {
     id: comparison.id,
     label: typeof comparison.label === 'string' ? comparison.label : undefined,
+    layout: comparison.layout === 'vertical' ? 'vertical' : 'horizontal',
     role,
   };
 };
@@ -1338,15 +1373,30 @@ const EvidenceComparisonView = memo<{
 }>(({ after, before }) => {
   const { t } = useTranslation('verify');
 
+  // Either half may carry the layout; the `before` one wins so a pair can't
+  // render as two different arrangements.
+  const layout = evidenceComparison(before)?.layout ?? evidenceComparison(after)?.layout;
+
   return (
-    <div className={styles.comparison}>
+    <div className={cx(styles.comparison, layout === 'vertical' && styles.comparisonVertical)}>
       {[before, after].map((evidence, index) => {
         const comparison = evidenceComparison(evidence)!;
+        const isBefore = comparison.role === 'before';
         return (
           <div className={styles.comparisonItem} key={evidence.id}>
-            <span className={styles.comparisonLabel}>
-              {comparison.label ?? t(`report.evidence.comparison.${comparison.role}`)}
-            </span>
+            <div
+              className={cx(
+                styles.comparisonLabel,
+                isBefore ? styles.comparisonLabelBefore : styles.comparisonLabelAfter,
+              )}
+            >
+              <span className={styles.comparisonRole}>
+                {t(`report.evidence.comparison.${comparison.role}`)}
+              </span>
+              {comparison.label && (
+                <span className={styles.comparisonCaption}>{comparison.label}</span>
+              )}
+            </div>
             <EvidenceItem evidence={evidence} index={index + 1} />
           </div>
         );

--- a/src/features/Verify/Workspace/ReportListPanel.tsx
+++ b/src/features/Verify/Workspace/ReportListPanel.tsx
@@ -15,7 +15,7 @@ import {
 import type { DropdownItem } from '@lobehub/ui/base-ui';
 import { confirmModal, DropdownMenu } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
-import { createStaticStyles, cssVar, useResponsive } from 'antd-style';
+import { createStaticStyles, cssVar } from 'antd-style';
 import dayjs from 'dayjs';
 import isEqual from 'fast-deep-equal';
 import {
@@ -45,6 +45,7 @@ import { useGlobalStore } from '@/store/global';
 import { systemStatusSelectors } from '@/store/global/selectors';
 
 import { useVerifyReportSummariesInfinite } from '../hooks';
+import type { ReportPanelExpand } from './useReportPanelExpand';
 
 const PANEL_MIN = 260;
 const PANEL_MAX = 420;
@@ -462,10 +463,9 @@ const ReportListItem = memo<{
 
 ReportListItem.displayName = 'ReportListItem';
 
-const ReportListPanel = memo(() => {
+const ReportListPanel = memo<ReportPanelExpand>(({ expand, isNarrow, setExpand }) => {
   const { t } = useTranslation('verify');
   const { runId } = useParams<{ runId: string }>();
-  const { md = true } = useResponsive();
 
   const [query, setQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
@@ -478,8 +478,7 @@ const ReportListPanel = memo(() => {
   const { items, error, hasMore, isLoadingInitial, isLoadingMore, loadMore, reload } =
     useVerifyReportSummariesInfinite(debouncedQuery);
 
-  const [showPanel, panelWidth, updateSystemStatus] = useGlobalStore((s) => [
-    systemStatusSelectors.showVerifyReportPanel(s),
+  const [panelWidth, updateSystemStatus] = useGlobalStore((s) => [
     systemStatusSelectors.verifyReportPanelWidth(s),
     s.updateSystemStatus,
   ]);
@@ -514,13 +513,13 @@ const ReportListPanel = memo(() => {
     <DraggablePanel
       className={styles.panel}
       defaultSize={{ width: tmpWidth }}
-      expand={showPanel}
+      expand={expand}
       maxWidth={PANEL_MAX}
       minWidth={PANEL_MIN}
-      mode={md ? 'fixed' : 'float'}
+      mode={isNarrow ? 'float' : 'fixed'}
       placement={'left'}
       size={{ height: '100%', width: panelWidth }}
-      onExpandChange={(expand) => updateSystemStatus({ showVerifyReportPanel: expand })}
+      onExpandChange={setExpand}
       onSizeChange={handleSizeChange}
     >
       <DraggablePanelContainer style={{ flex: 'none', height: '100%', minWidth: PANEL_MIN }}>
@@ -534,7 +533,7 @@ const ReportListPanel = memo(() => {
               className={styles.collapseBtn}
               title={t('workspace.collapse')}
               type={'button'}
-              onClick={() => updateSystemStatus({ showVerifyReportPanel: false })}
+              onClick={() => setExpand(false)}
             >
               <Icon icon={PanelLeftClose} size={16} />
             </button>

--- a/src/features/Verify/Workspace/index.tsx
+++ b/src/features/Verify/Workspace/index.tsx
@@ -8,12 +8,11 @@ import { useTranslation } from 'react-i18next';
 import { Outlet } from 'react-router';
 
 import { RouteMetaBridge } from '@/features/RouteMeta';
-import { useGlobalStore } from '@/store/global';
-import { systemStatusSelectors } from '@/store/global/selectors';
 import { useUserStore } from '@/store/user';
 import { authSelectors } from '@/store/user/slices/auth/selectors';
 
 import ReportListPanel from './ReportListPanel';
+import { useReportPanelExpand } from './useReportPanelExpand';
 
 const styles = createStaticStyles(({ css }) => ({
   expandBtn: css`
@@ -61,10 +60,9 @@ const styles = createStaticStyles(({ css }) => ({
  */
 const VerifyWorkspace = memo(() => {
   const { t } = useTranslation('verify');
-  const [showPanel, updateSystemStatus] = useGlobalStore((s) => [
-    systemStatusSelectors.showVerifyReportPanel(s),
-    s.updateSystemStatus,
-  ]);
+  // Owned here, not inside the panel: the expand button below is the panel's only
+  // way back once it's collapsed, so both must read the same state.
+  const panel = useReportPanelExpand();
   const isAuthLoaded = useUserStore(authSelectors.isLoaded);
   const isLogin = useUserStore(authSelectors.isLogin);
   const canShowReportList = Boolean(isAuthLoaded && isLogin);
@@ -73,15 +71,15 @@ const VerifyWorkspace = memo(() => {
     <Flexbox horizontal height={'100dvh'} style={{ overflow: 'hidden' }} width={'100%'}>
       {/* Standalone route (outside the app main layout): drive the tab title here. */}
       <RouteMetaBridge />
-      {canShowReportList && <ReportListPanel />}
+      {canShowReportList && <ReportListPanel {...panel} />}
       <div className={styles.main}>
-        {canShowReportList && !showPanel && (
+        {canShowReportList && !panel.expand && (
           <button
             aria-label={t('workspace.expand')}
             className={styles.expandBtn}
             title={t('workspace.expand')}
             type={'button'}
-            onClick={() => updateSystemStatus({ showVerifyReportPanel: true })}
+            onClick={() => panel.setExpand(true)}
           >
             <Icon icon={PanelLeftOpen} size={16} />
           </button>

--- a/src/features/Verify/Workspace/useReportPanelExpand.test.ts
+++ b/src/features/Verify/Workspace/useReportPanelExpand.test.ts
@@ -1,0 +1,77 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useGlobalStore } from '@/store/global';
+
+import { useReportPanelExpand } from './useReportPanelExpand';
+
+const { mockUseResponsive } = vi.hoisted(() => ({ mockUseResponsive: vi.fn() }));
+
+vi.mock('antd-style', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, useResponsive: mockUseResponsive };
+});
+
+/** `lg` is false below 992px — the width where the list and the report stop fitting. */
+const setViewport = (wide: boolean) => mockUseResponsive.mockReturnValue({ lg: wide });
+
+const showPanel = () => useGlobalStore.getState().status.showVerifyReportPanel;
+
+describe('useReportPanelExpand', () => {
+  beforeEach(() => {
+    // `updateSystemStatus` no-ops until the status slice is initialized, so writes
+    // would silently vanish without this.
+    useGlobalStore.setState({ isStatusInit: true });
+    useGlobalStore.getState().updateSystemStatus({ showVerifyReportPanel: true });
+  });
+
+  it('follows the persisted preference on a wide viewport', () => {
+    setViewport(true);
+    const { result } = renderHook(() => useReportPanelExpand());
+
+    expect(result.current).toMatchObject({ expand: true, isNarrow: false });
+
+    act(() => result.current.setExpand(false));
+    expect(result.current.expand).toBe(false);
+    expect(showPanel()).toBe(false);
+  });
+
+  it('collapses on a narrow viewport even though the preference says expanded', () => {
+    setViewport(false);
+    const { result } = renderHook(() => useReportPanelExpand());
+
+    expect(result.current).toMatchObject({ expand: false, isNarrow: true });
+    // The preference itself is untouched — it still describes the wide layout.
+    expect(showPanel()).toBe(true);
+  });
+
+  it('opens as a transient overlay on a narrow viewport without clobbering the preference', () => {
+    setViewport(false);
+    const { result } = renderHook(() => useReportPanelExpand());
+
+    act(() => result.current.setExpand(true));
+    expect(result.current.expand).toBe(true);
+    expect(showPanel()).toBe(true);
+
+    act(() => result.current.setExpand(false));
+    expect(result.current.expand).toBe(false);
+    // Collapsing the overlay must not write `false` into the wide-layout preference,
+    // or resizing back would leave the panel gone with no explanation.
+    expect(showPanel()).toBe(true);
+  });
+
+  it('restores the preferred layout when the viewport widens again', () => {
+    setViewport(false);
+    const { rerender, result } = renderHook(() => useReportPanelExpand());
+
+    act(() => result.current.setExpand(true)); // overlay open while narrow
+    setViewport(true);
+    rerender();
+
+    expect(result.current).toMatchObject({ expand: true, isNarrow: false });
+    // ...and the overlay state is dropped, so it can't linger as a second source of
+    // truth: collapsing now writes through to the preference.
+    act(() => result.current.setExpand(false));
+    expect(showPanel()).toBe(false);
+  });
+});

--- a/src/features/Verify/Workspace/useReportPanelExpand.ts
+++ b/src/features/Verify/Workspace/useReportPanelExpand.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useResponsive } from 'antd-style';
+import { useEffect, useState } from 'react';
+
+import { useGlobalStore } from '@/store/global';
+import { systemStatusSelectors } from '@/store/global/selectors';
+
+export interface ReportPanelExpand {
+  expand: boolean;
+  /** Below the breakpoint the panel floats over the report instead of shrinking it. */
+  isNarrow: boolean;
+  setExpand: (expand: boolean) => void;
+}
+
+/**
+ * Expand state for the report-list panel, shared by the panel and the expand
+ * button that replaces it.
+ *
+ * Master-detail only works while the detail still has room. The report body wants
+ * ~880px and the list is 260–420px wide, so once the viewport drops under `lg` the
+ * two can't sit side by side — the report gets squeezed into a column too narrow to
+ * read. Below that width the list stops being a fixed column and becomes a float
+ * overlay that is closed by default.
+ *
+ * The narrow-width collapse is deliberately NOT written back to
+ * `showVerifyReportPanel`: that flag is the user's preference for the wide layout,
+ * and clobbering it would leave the panel collapsed after they resize back — the
+ * layout would have silently "remembered" a decision the user never made.
+ */
+export const useReportPanelExpand = (): ReportPanelExpand => {
+  const [showPanel, updateSystemStatus] = useGlobalStore((s) => [
+    systemStatusSelectors.showVerifyReportPanel(s),
+    s.updateSystemStatus,
+  ]);
+  const { lg = true } = useResponsive();
+  const isNarrow = !lg;
+
+  const [floatOpen, setFloatOpen] = useState(false);
+  // Leaving the narrow regime hands control back to the persisted preference, so
+  // drop the overlay rather than let it linger as a second source of truth.
+  useEffect(() => {
+    if (!isNarrow) setFloatOpen(false);
+  }, [isNarrow]);
+
+  // Not memoized on purpose: it closes over `isNarrow`, and a stale closure here
+  // would route a wide-layout toggle into the transient overlay state, silently
+  // dropping the user's preference.
+  const setExpand = (next: boolean) => {
+    if (isNarrow) setFloatOpen(next);
+    else updateSystemStatus({ showVerifyReportPanel: next });
+  };
+
+  return { expand: isNarrow ? floatOpen : showPanel, isNarrow, setExpand };
+};

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -304,8 +304,8 @@ const TopicItem = memo<TopicItemProps>(
     const workingDirectoryNode =
       showWorkingDirectory && workingDirectoryDisplay ? (
         <Flexbox horizontal align={'center'} gap={4} style={{ overflow: 'hidden' }}>
-          <DirIcon repoType={workingDirectoryDisplay.repoType} size={12} />
-          <Text ellipsis fontSize={11} style={{ color: cssVar.colorTextDescription }}>
+          <DirIcon repoType={workingDirectoryDisplay.repoType} size={13} />
+          <Text ellipsis fontSize={12} style={{ color: cssVar.colorTextDescription }}>
             {workingDirectoryDisplay.label}
           </Text>
         </Flexbox>

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Browser/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Browser/index.tsx
@@ -47,34 +47,15 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     border-block-end: 1px solid ${cssVar.colorBorderSecondary};
   `,
   address: css`
-    position: absolute;
-    inset-inline-start: 50%;
-    transform: translateX(-50%);
+    flex: 1;
+    min-width: 0;
+    max-width: 720px;
 
-    width: min(48%, 520px);
-    border-radius: ${cssVar.borderRadius};
-
-    transition:
-      background-color ${cssVar.motionDurationMid} ${cssVar.motionEaseInOut},
-      box-shadow ${cssVar.motionDurationMid} ${cssVar.motionEaseInOut};
-
-    input {
-      text-align: center;
-    }
-
-    /* borderless inputs carry antd's transparent :hover/:focus rules, so the
-       hover fill and focus ring need a class-doubled selector to win. */
-    &&:hover {
-      background: ${cssVar.colorFillTertiary};
-    }
-
-    &&:focus-within {
-      background: ${cssVar.colorFillQuaternary};
-      box-shadow: 0 0 0 1px ${cssVar.colorBorder};
-    }
-
-    @media (prefers-reduced-motion: reduce) {
-      transition: none;
+    /* The filled variant keeps its tinted fill while focused; lift it to the
+       container surface so the focus ring reads as an editable field. Doubling
+       the class outranks antd's own :focus rule. */
+    &&:focus {
+      background: ${cssVar.colorBgContainer};
     }
   `,
   importBanner: css`
@@ -269,9 +250,8 @@ const BrowserPane = memo<BrowserPaneProps>(({ sessionId }) => {
         <Input
           className={styles.address}
           placeholder={t('workingPanel.browser.addressPlaceholder')}
-          size={'small'}
           value={address}
-          variant={'borderless'}
+          variant={'filled'}
           onBlur={() => setIsEditing(false)}
           onFocus={() => setIsEditing(true)}
           onChange={(event) => {

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Browser/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Browser/index.tsx
@@ -50,10 +50,27 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     position: absolute;
     inset-inline-start: 50%;
     transform: translateX(-50%);
+
     width: min(48%, 520px);
+    border-radius: ${cssVar.borderRadius};
+
+    transition:
+      background-color ${cssVar.motionDurationMid} ${cssVar.motionEaseInOut},
+      box-shadow ${cssVar.motionDurationMid} ${cssVar.motionEaseInOut};
 
     input {
       text-align: center;
+    }
+
+    /* borderless inputs carry antd's transparent :hover/:focus rules, so the
+       hover fill and focus ring need a class-doubled selector to win. */
+    &&:hover {
+      background: ${cssVar.colorFillTertiary};
+    }
+
+    &&:focus-within {
+      background: ${cssVar.colorFillQuaternary};
+      box-shadow: 0 0 0 1px ${cssVar.colorBorder};
     }
 
     @media (prefers-reduced-motion: reduce) {
@@ -71,6 +88,7 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     background: ${cssVar.colorBgContainer};
   `,
   importCopy: css`
+    flex: 1;
     min-width: 0;
   `,
   toolbarActions: css`


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [x] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

None.

#### 🔀 Description of Change

Several small UI issues, plus two real bugs found while verifying them.

**In-app browser panel** (`WorkingSidebar/Browser`)

- The Chrome-import banner's action was pinned to the end of the copy, leaving a wide gap of dead space to its right. The copy column now takes `flex: 1` so the button and dismiss icon sit on the banner's right edge.
- The address bar was `variant='borderless'`: hover and focus both left `background: rgba(0,0,0,0)` and `border-width: 0`, so the field gave literally zero feedback. It now uses the `filled` variant (tinted fill at rest, deeper on hover, container background plus a border ring on focus), matching Codex's address bar.
- The address bar was also absolutely centered, which overlapped the reload button in a narrow panel. It now flows in the toolbar (`flex: 1 / max-width: 720px`), which also removes a dead `input { text-align: center }` rule that never matched (the class lands on the `<input>` itself, so the descendant selector selected nothing).

**Topic rows** (sidebar, by-status grouping)

- The `repo · branch` subtitle was 11px with a 1px gap under the title and 4px of row padding — visibly cramped. Now 12px, 3px gap, 8px padding (row height 40px → 44px), with the dir icon bumped 12px → 13px to match.
- The spacing lives in the shared `NavItem` `description` branch, so the Verify report list (its only other caller) gets slightly taller rows too.

**Message usage footer**

- Surfaces TPS next to the token count (`… ◎ 368.3k  TPS 74.9`). TTFT rides in TPS's hover rather than taking a second inline slot — it's a diagnostic, not an at-a-glance metric. Values come from `message.metadata.performance`, same source as the token popover; the tooltip reuses the existing `messages.tokenDetails.speed.*` keys, so no new copy.
- Spelled-out labels rather than icons: at 12px a gauge glyph is indistinguishable from the neighbouring coin, so the reader can't tell what the number measures.

**Verify report — comparison evidence**

- 🐛 `ingest-report` treated `comparison.id` as optional, but the report viewer pairs on it and drops any half without one. A case declaring `{ "comparison": { "role": "before" } }` uploaded metadata the UI silently discards, rendering the images unpaired with no warning anywhere. It now requires both a string `id` and a `before`/`after` role, and warns when a comparison is dropped.
- Comparison pairs were a fixed two-column grid with a neutral heading above each image. The heading read as a caption for the whole pair, and the grid halved wide, short captures (a toolbar, a one-line footer) into illegible slivers. The role is now a tinted band fused to its own screenshot (red for before, green for after), and each pair picks `layout: horizontal | vertical`. The existing `comparison.label` rides in the band as a caption, so the two sides state the delta instead of repeating the case title.
- 🐛 The report-list panel never auto-collapsed. `useResponsive` only swapped it between `fixed` and `float` while `expand` stayed pinned to the persisted `showVerifyReportPanel` flag (default `true`), so at a 621px viewport the list ate half the width and squeezed the report into an unreadable column. Below `lg` it now collapses to a float overlay that is closed by default. The narrow-width collapse is deliberately **not** written back to `showVerifyReportPanel` — that flag is the user's preference for the wide layout, and clobbering it would leave the panel gone after they resize back.

**Docs** — `agent-testing` skill: `common-mistakes.md` still told agents to hand-compose before/after screenshots into one image with sharp, contradicting `report.md`, which supports native `comparison` pairing and explicitly says not to. Rewrote it to point at the `comparison` field, and documented `layout` / `label` plus the caveat that the published `lh` (0.0.41) predates comparison support and silently drops the metadata.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Verified end-to-end on an isolated `electron-dev` instance running working-tree code (before/after states captured by reverting each file and confirming the live computed styles, not by reasoning about the diff), and the verify report page through the local-dev proxy against production data:

- Browser panel: address bar measured at rest `rgba(0,0,0,0.03)` → hover `rgba(0,0,0,0.06)` → focus white + `1px rgb(227,227,227)`; import button right edge 56px from the row edge (the dismiss icon), `elementFromPoint` confirms it isn't occluded.
- Topic rows: subtitle `11px`/row `40px` → `12px`/`44px`.
- Usage footer: same message reads `DeepSeek V4 Pro | 368.3k | TPS | 74.9`; hovering TPS shows the TPS explanation plus `TTFT 2.18s`.
- Verify panel: at a 621px viewport the list collapses and the report takes the full width; the expand button reopens it as an overlay.
- New tests: `reportEvidence` comparison normalization (CLI, 5 cases) and `useReportPanelExpand` (4 cases, incl. that a narrow-width collapse never clobbers the persisted preference).

Report: https://app.lobehub.com/verify/51921efe-324d-4f43-81ae-3ce487f7d41c

#### 📸 Screenshots / Videos

See the verify report above — it renders the before/after pairs inline (and is itself rendered by the comparison UI in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)