### PR TITLE
💄 style(usage): move TPS next to the model name

### DIFF
--- a/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
+++ b/src/features/Conversation/Messages/components/Extras/Usage/index.tsx
@@ -27,11 +27,6 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     font-size: 12px;
     color: ${cssVar.colorTextQuaternary};
   `,
-  separator: css`
-    /* The row's gap alone reads as a gutter between unrelated items; the dot binds
-       the token count and the speed into one metrics run. */
-    margin-inline: -2px;
-  `,
 }));
 
 // Cheap messages don't need a cost callout — only surface it once it's
@@ -74,31 +69,24 @@ const Usage = memo<UsageProps>(({ model, usage, performance, provider }) => {
       gap={12}
       justify={'space-between'}
     >
-      <Center horizontal gap={4} style={{ fontSize: 12 }}>
-        {heteroName || (
-          <>
-            <ModelIcon model={model as string} type={'mono'} />
-            {modelCard?.displayName || model}
-          </>
-        )}
-      </Center>
-
-      <Center horizontal gap={8}>
-        {!!usage?.totalTokens && (
-          <TokenDetail
-            model={model as string}
-            performance={performance}
-            provider={provider}
-            usage={usage}
-          />
-        )}
-        {/* A spelled-out "TPS" unit rather than an icon: at 12px a gauge glyph is
-            indistinguishable from the neighbouring coin, so the reader can't tell
-            what the number measures. TTFT rides in the hover instead of taking a
-            second inline slot — it's a diagnostic, not an at-a-glance metric. */}
+      {/* The speed describes how this model ran, so it sits with the model name
+          rather than in the token/cost cluster. A spelled-out "TPS" unit rather
+          than an icon: at 12px a gauge glyph is indistinguishable from the
+          neighbouring coin, so the reader can't tell what the number measures.
+          TTFT rides in the hover instead of taking a second inline slot — it's a
+          diagnostic, not an at-a-glance metric. */}
+      <Center horizontal gap={6} style={{ fontSize: 12 }}>
+        <Center horizontal gap={4}>
+          {heteroName || (
+            <>
+              <ModelIcon model={model as string} type={'mono'} />
+              {modelCard?.displayName || model}
+            </>
+          )}
+        </Center>
         {!!performance?.tps && (
           <>
-            {!!usage?.totalTokens && <span className={styles.separator}>·</span>}
+            <span>·</span>
             <Tooltip
               title={
                 <Flexbox gap={6}>
@@ -118,6 +106,17 @@ const Usage = memo<UsageProps>(({ model, usage, performance, provider }) => {
               </Center>
             </Tooltip>
           </>
+        )}
+      </Center>
+
+      <Center horizontal gap={8}>
+        {!!usage?.totalTokens && (
+          <TokenDetail
+            model={model as string}
+            performance={performance}
+            provider={provider}
+            usage={usage}
+          />
         )}
         {!isShowCredit && !!usage?.cost && usage.cost >= MIN_DISPLAY_COST && (
           <Center horizontal gap={2}>


### PR DESCRIPTION
## 💻 变更类型 | Change Type

- [x] 💄 style

## 🔀 变更说明 | Description of Change

Follow-up to #17128. The speed metric now sits with the model label instead of the token/cost cluster.

The throughput describes how *this model* ran, so it reads as part of the model's identity rather than as a third item in the accounting run. The footer now renders:

- **left:** `DeepSeek V4 Pro · 108.7 TPS`
- **right:** `532.8k` (token count) and cost, when present

TTFT still rides in the TPS hover; when `performance.tps` is missing, neither the number nor the separator dot renders.

## 📝 补充信息 | Additional Information

Verified in the running app (dev SPA against the production backend): the assistant footer reads `DeepSeek V4 Pro · 108.7 TPS` on the left with `532.8k` alone on the right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)