### PR TITLE
♻️ refactor: drop redundant type guards on typed data

### DIFF
--- a/apps/server/src/modules/AgentRuntime/adapters/ServerSubAgentTransport.ts
+++ b/apps/server/src/modules/AgentRuntime/adapters/ServerSubAgentTransport.ts
@@ -4,7 +4,6 @@ import type {
   ExecSubAgentResult,
   ExecVirtualSubAgentParams,
 } from '@lobechat/types';
-import { pickString, toRecord } from '@lobechat/utils/object';
 
 import type { RuntimeExecutorContext } from '../context';
 
@@ -16,26 +15,6 @@ const fallbackResult = (error: string): ExecSubAgentResult => ({
   threadId: '',
 });
 
-const normalizeResult = (value: unknown): ExecSubAgentResult => {
-  const result = toRecord(value);
-  if (!result) {
-    return {
-      assistantMessageId: '',
-      operationId: '',
-      success: true,
-      threadId: '',
-    };
-  }
-
-  return {
-    assistantMessageId: pickString(result.assistantMessageId) ?? '',
-    error: pickString(result.error),
-    operationId: pickString(result.operationId) ?? '',
-    success: result.success !== false,
-    threadId: pickString(result.threadId) ?? '',
-  };
-};
-
 /**
  * Server {@link SubAgentTransport} adapter — delegates child-run creation to
  * callbacks injected by AiAgentService while the package owns executor flow.
@@ -46,7 +25,7 @@ export class ServerSubAgentTransport implements SubAgentTransport {
   async execSubAgent(params: ExecSubAgentParams): Promise<ExecSubAgentResult> {
     if (!this.ctx.execSubAgent) return fallbackResult('Sub-agent dispatch is not available.');
 
-    return normalizeResult(await this.ctx.execSubAgent(params));
+    return this.ctx.execSubAgent(params);
   }
 
   async execVirtualSubAgent(params: ExecVirtualSubAgentParams): Promise<ExecSubAgentResult> {
@@ -54,6 +33,6 @@ export class ServerSubAgentTransport implements SubAgentTransport {
       return fallbackResult('Virtual sub-agent dispatch is not available.');
     }
 
-    return normalizeResult(await this.ctx.execVirtualSubAgent(params));
+    return this.ctx.execVirtualSubAgent(params);
   }
 }

--- a/apps/server/src/modules/AgentRuntime/context.ts
+++ b/apps/server/src/modules/AgentRuntime/context.ts
@@ -1,6 +1,10 @@
 import { type AgentState } from '@lobechat/agent-runtime';
 import { type BotPlatformContext } from '@lobechat/context-engine';
-import { type ExecSubAgentParams, type ExecVirtualSubAgentParams } from '@lobechat/types';
+import {
+  type ExecSubAgentParams,
+  type ExecSubAgentResult,
+  type ExecVirtualSubAgentParams,
+} from '@lobechat/types';
 
 import { type MessageModel } from '@/database/models/message';
 import { type LobeChatDatabase } from '@/database/type';
@@ -38,13 +42,13 @@ export interface RuntimeExecutorContext {
    * Injected by AiAgentService so exec_sub_agent / exec_sub_agents executors
    * can dispatch callAgent-triggered runs without a circular import.
    */
-  execSubAgent?: (params: ExecSubAgentParams) => Promise<unknown>;
+  execSubAgent?: (params: ExecSubAgentParams) => Promise<ExecSubAgentResult>;
   /**
    * Callback to fork a `lobe-agent.callSubAgent` virtual child run. Unlike
    * execSubAgent, this path installs the async completion bridge and marks the
    * child operation as a sub-agent.
    */
-  execVirtualSubAgent?: (params: ExecVirtualSubAgentParams) => Promise<unknown>;
+  execVirtualSubAgent?: (params: ExecVirtualSubAgentParams) => Promise<ExecSubAgentResult>;
   hookDispatcher?: HookDispatcher;
   loadAgentState?: (operationId: string) => Promise<AgentState | null>;
   messageModel: MessageModel;

--- a/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
+++ b/apps/server/src/services/agentRuntime/AgentRuntimeService.ts
@@ -32,6 +32,7 @@ import {
 import {
   type ChatToolPayload,
   type ExecSubAgentParams,
+  type ExecSubAgentResult,
   type ExecVirtualSubAgentParams,
   type UIChatMessage,
 } from '@lobechat/types';
@@ -202,13 +203,13 @@ export interface AgentRuntimeDelegate {
    * (AiAgentService.execSubAgent → execAgent: agent-config resolution, tool
    * engine, context engineering, createOperation).
    */
-  execSubAgent?: (params: ExecSubAgentParams) => Promise<unknown>;
+  execSubAgent?: (params: ExecSubAgentParams) => Promise<ExecSubAgentResult>;
   /**
    * Fork a `lobe-agent.callSubAgent` virtual child run. The child is marked as a
    * sub-agent and owns the completion bridge that backfills the parent tool
    * placeholder before resuming the parked parent operation.
    */
-  execVirtualSubAgent?: (params: ExecVirtualSubAgentParams) => Promise<unknown>;
+  execVirtualSubAgent?: (params: ExecVirtualSubAgentParams) => Promise<ExecSubAgentResult>;
 }
 
 export interface AgentRuntimeServiceOptions {

--- a/apps/server/src/services/agentSignal/services/selfIteration/review/proposal.ts
+++ b/apps/server/src/services/agentSignal/services/selfIteration/review/proposal.ts
@@ -1,5 +1,4 @@
 import type { BriefAction } from '@lobechat/types';
-import { isTrimmedNonEmptyString } from '@lobechat/utils';
 import { z } from 'zod';
 
 import type {
@@ -161,8 +160,7 @@ export type NonMergeableSelfReviewProposalActionPlan = ActionPlan & {
  * Snapshot-aware action accepted by proposal metadata projection.
  */
 export type SelfReviewProposalActionPlan =
-  | MergeableSelfReviewProposalActionPlan
-  | NonMergeableSelfReviewProposalActionPlan;
+  MergeableSelfReviewProposalActionPlan | NonMergeableSelfReviewProposalActionPlan;
 
 /**
  * Snapshot-aware self-iteration plan accepted by proposal metadata projection.
@@ -322,16 +320,16 @@ const hasCompleteMergeableSnapshot = (
 
   if (actionType === 'refine_skill') {
     return (
-      isTrimmedNonEmptyString(snapshot.agentDocumentId) &&
-      isTrimmedNonEmptyString(snapshot.documentId) &&
-      isTrimmedNonEmptyString(snapshot.contentHash) &&
+      !!snapshot.agentDocumentId?.trim() &&
+      !!snapshot.documentId?.trim() &&
+      !!snapshot.contentHash?.trim() &&
       snapshot.managed === true &&
       snapshot.writable === true
     );
   }
 
   if (actionType === 'create_skill') {
-    return snapshot.absent === true && isTrimmedNonEmptyString(snapshot.skillName);
+    return snapshot.absent === true && !!snapshot.skillName?.trim();
   }
 
   return false;

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -25,15 +25,16 @@ import {
 import { TaskIdentifier } from '@lobechat/builtin-tool-task';
 import { builtinTools, manualModeExcludeToolIds } from '@lobechat/builtin-tools';
 import { LOADING_FLAT } from '@lobechat/const';
-import type {
-  AgentGroupConfig,
-  AgentManagementContext,
-  BotPlatformContext,
-  LobeToolManifest,
-  ToolExecutor,
-  ToolSource,
+import {
+  type AgentGroupConfig,
+  type AgentManagementContext,
+  type BotPlatformContext,
+  type LobeToolManifest,
+  SkillEngine,
+  type ToolExecutor,
+  type ToolsEngine,
+  type ToolSource,
 } from '@lobechat/context-engine';
-import { SkillEngine, type ToolsEngine } from '@lobechat/context-engine';
 import type { LobeChatDatabase } from '@lobechat/database';
 import { isRemoteHeterogeneousType } from '@lobechat/heterogeneous-agents';
 import { buildTaskManagerDefaultsPrompt } from '@lobechat/prompts';
@@ -68,7 +69,6 @@ import {
   ThreadType,
 } from '@lobechat/types';
 import { nanoid } from '@lobechat/utils';
-import { isRecord } from '@lobechat/utils/object';
 import { TRPCError } from '@trpc/server';
 import debug from 'debug';
 
@@ -172,9 +172,7 @@ const createGraphAwareAgentFactory =
       return upstreamFactory(config);
     }
 
-    const runtimeAgentConfig = isRecord(config.agentConfig)
-      ? (config.agentConfig as LobeAgentConfig)
-      : undefined;
+    const runtimeAgentConfig = config.agentConfig as LobeAgentConfig | undefined;
     const graph = runtimeAgentConfig?.chatConfig?.graph;
     if (runtimeAgentConfig?.chatConfig?.enableGraphMode && graph) {
       const graphResult = ReasoningGraphSchema.safeParse(graph);

--- a/packages/model-runtime/src/core/usageConverters/openai.ts
+++ b/packages/model-runtime/src/core/usageConverters/openai.ts
@@ -1,5 +1,4 @@
 import type { ModelTokensUsage, ModelUsage } from '@lobechat/types';
-import { isRecord } from '@lobechat/utils/object';
 import debug from 'debug';
 import type { Pricing } from 'model-bank';
 import type OpenAI from 'openai';
@@ -23,17 +22,25 @@ const shouldKeepUsageValue = (key: string, value: unknown) => {
 };
 
 /**
- * OpenAI GPT-5.6+ reports cache writes as `cache_write_tokens` under usage details.
- * The field is not yet in all openai SDK type snapshots, so read it defensively.
- *
+ * OpenAI GPT-5.6+ reports cache writes as `cache_write_tokens` under usage details,
+ * a field not yet present in the openai SDK type snapshots — extend the SDK detail
+ * shapes locally until the SDK catches up.
+ */
+type CacheWriteUsageDetails =
+  | (NonNullable<OpenAI.Completions.CompletionUsage['prompt_tokens_details']> & {
+      cache_write_tokens?: number;
+    })
+  | (NonNullable<OpenAI.Responses.ResponseUsage['input_tokens_details']> & {
+      cache_write_tokens?: number;
+    });
+
+/**
  * Billing note: write tokens are a subset of total input tokens and are charged at
  * 1.25× uncached input. They must be excluded from the uncached (1×) miss bucket so
  * computeChatCost does not double-charge textInput + textInput_cacheWrite.
  */
-const readCacheWriteTokens = (details: unknown): number | undefined => {
-  if (!isRecord(details)) return undefined;
-
-  const value = details.cache_write_tokens;
+const readCacheWriteTokens = (details: CacheWriteUsageDetails | undefined): number | undefined => {
+  const value = details?.cache_write_tokens;
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 };
 

--- a/src/features/ChatInput/ControlBar/WorkingDirectoryPicker.tsx
+++ b/src/features/ChatInput/ControlBar/WorkingDirectoryPicker.tsx
@@ -3,7 +3,6 @@
 import { isDesktop } from '@lobechat/const';
 import type { WorkingDirEntry } from '@lobechat/types';
 import { getWorkingDirSourcePath } from '@lobechat/types';
-import { isRecord } from '@lobechat/utils';
 import { ActionIcon, Flexbox, Icon, Input, Popover, Tooltip } from '@lobehub/ui';
 import { toast } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar, cx } from 'antd-style';
@@ -193,8 +192,8 @@ const styles = createStaticStyles(({ css }) => ({
   `,
 }));
 
-const isValidWorkingDirEntry = (entry: unknown): entry is WorkingDirEntry =>
-  isRecord(entry) && !!getWorkingDirectoryPathString(entry.path);
+const isValidWorkingDirEntry = (entry: WorkingDirEntry): boolean =>
+  !!getWorkingDirectoryPathString(entry.path);
 
 type FolderEntry = { path: string; repoType?: 'git' | 'github' };
 

--- a/src/features/ChatInput/ControlBar/WorkingDirectorySection.tsx
+++ b/src/features/ChatInput/ControlBar/WorkingDirectorySection.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { isDesktop } from '@lobechat/const';
+import type { WorkingDirEntry } from '@lobechat/types';
 import { getWorkingDirEffectivePath } from '@lobechat/types';
-import { isRecord } from '@lobechat/utils';
 import { memo } from 'react';
 
 import SafeBoundary from '@/components/ErrorBoundary';
@@ -24,12 +24,9 @@ interface WorkingDirectorySectionProps {
   agentId: string;
 }
 
-const getEntryEffectivePath = (entry: unknown) => {
-  if (!isRecord(entry)) return;
-
+const getEntryEffectivePath = (entry: WorkingDirEntry) => {
   const sourcePath = getWorkingDirectoryPathString(entry.path);
-  const git = isRecord(entry.git) ? entry.git : undefined;
-  return getWorkingDirectoryPathString(git?.activeWorktree) ?? sourcePath;
+  return getWorkingDirectoryPathString(entry.git?.activeWorktree) ?? sourcePath;
 };
 
 /**
@@ -81,7 +78,7 @@ const WorkingDirectorySectionInner = memo<WorkingDirectorySectionProps>(({ agent
   // WorktreeSwitcher commits `sourcePath` as the WorkingDirEntry.path, rewriting
   // the topic's repo source to the linked worktree and breaking later switches.
   const sourceWorkingDirectory =
-    (isRecord(currentEntry) ? getWorkingDirectoryPathString(currentEntry.path) : undefined) ??
+    getWorkingDirectoryPathString(currentEntry?.path) ??
     getWorkingDirectoryPathString(persistedConfig?.path) ??
     effectiveWorkingDirectory;
 

--- a/src/features/Conversation/Error/PlanLimitCard/budget.ts
+++ b/src/features/Conversation/Error/PlanLimitCard/budget.ts
@@ -1,5 +1,4 @@
 import { Plans } from '@lobechat/types';
-import { isRecord } from '@lobechat/utils';
 
 export type PlanLimitPricingBasis = 'approximate' | 'estimated' | 'exact' | 'unknown';
 
@@ -19,12 +18,8 @@ export interface PlanLimitBudgetContext {
 export const getBudgetContextFromErrorBody = (
   body: unknown,
 ): PlanLimitBudgetContext | undefined => {
-  if (!isRecord(body)) return undefined;
-
-  const { budget } = body as { budget?: unknown };
-  if (!isRecord(budget)) return undefined;
-
-  return budget as PlanLimitBudgetContext;
+  const budget = (body as { budget?: PlanLimitBudgetContext } | null | undefined)?.budget;
+  return budget && typeof budget === 'object' ? budget : undefined;
 };
 
 const PLAN_VALUES = new Set<string>(Object.values(Plans));

--- a/src/helpers/workingDirectoryPath.ts
+++ b/src/helpers/workingDirectoryPath.ts
@@ -1,5 +1,4 @@
 import type { WorkingDirConfig, WorkingDirRepoType } from '@lobechat/types';
-import { pickString } from '@lobechat/utils';
 
 import { isDesktop } from '@/const/version';
 
@@ -23,14 +22,14 @@ export const getConfigRepoType = (config?: WorkingDirConfig): WorkingDirRepoType
   return config.repoType ?? (isDesktop ? undefined : 'github');
 };
 
-export const getWorkingDirectoryPathString = (path: unknown) => {
-  const value = pickString(path)?.trim();
+export const getWorkingDirectoryPathString = (path?: string | null) => {
+  const value = path?.trim();
   return value || undefined;
 };
 
 // Last non-empty path segment — the folder name. Also yields the repo name for
 // a web github URL (".../owner/repo" -> "repo").
-export const getWorkingDirectoryName = (path: unknown) => {
+export const getWorkingDirectoryName = (path?: string | null) => {
   const value = getWorkingDirectoryPathString(path);
   if (!value) return;
 

--- a/src/store/chat/slices/topic/selectors.ts
+++ b/src/store/chat/slices/topic/selectors.ts
@@ -91,10 +91,13 @@ const currentTopicWorkingDirectory = (s: ChatStoreState): string | undefined => 
   const activeTopic = currentActiveTopic(s);
   if (!activeTopic) return;
 
+  // Route the raw `workingDirectory` through the extractor too: it is typed as a
+  // string, but a malformed legacy topic may have persisted a `WorkingDirConfig`
+  // object into it (see #17050 and `getTopicMetadataWorkingDirectorySourcePath`),
+  // and this selector's declared `string | undefined` must hold at runtime.
   if (isDesktop) {
-    return (
-      getWorkingDirEffectivePath(activeTopic.metadata?.workingDirectoryConfig) ??
-      activeTopic.metadata?.workingDirectory
+    return getWorkingDirEffectivePath(
+      activeTopic.metadata?.workingDirectoryConfig ?? activeTopic.metadata?.workingDirectory,
     );
   }
 
@@ -102,8 +105,7 @@ const currentTopicWorkingDirectory = (s: ChatStoreState): string | undefined => 
   const meta = activeTopic.metadata;
   return (
     meta?.repos?.[0] ??
-    getWorkingDirEffectivePath(meta?.workingDirectoryConfig) ??
-    meta?.workingDirectory
+    getWorkingDirEffectivePath(meta?.workingDirectoryConfig ?? meta?.workingDirectory)
   );
 };
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [x] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

Remove runtime type guards (`isRecord` / `toRecord` / `pickString` families from `@lobechat/utils`) at call sites where the value is already properly typed — the guards were narrowing types that cannot occur, hiding the real contract instead of enforcing it.

- **`ServerSubAgentTransport`**: type the injected `execSubAgent` / `execVirtualSubAgent` callbacks as `Promise<ExecSubAgentResult>` (their implementations already return exactly that) and delete the `normalizeResult` re-narrowing layer entirely. Contract updated in `RuntimeExecutorContext` and `AgentRuntimeDelegate`.
- **`aiAgent`**: `config.agentConfig` is already an object type on `GeneralAgentConfig` — drop the `isRecord` gate before the cast.
- **selfIteration `proposal.ts`**: snapshot fields are zod-parsed optional strings — replace `isTrimmedNonEmptyString` with plain `!!field?.trim()`.
- **WorkingDirectory picker/section/helpers**: `deviceSelectors.getDeviceWorkingDirs` returns typed `WorkingDirEntry[]` — delete the `isRecord` guards and the `pickString` wrapper on already-`string` paths.
- **openai usage converter**: replace the `isRecord` probe for `cache_write_tokens` with a local `CacheWriteUsageDetails` type anchored to the SDK detail shapes, so the field access is typed until the SDK catches up.
- **`PlanLimitCard/budget.ts`**: collapse the multi-step guard chain on the error body to a cast + one leaf `typeof` check.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

Behavior-preserving refactor. `bun run check` over all changed files: lint clean, related test suites pass (the only failure locally is the pre-existing env-dependent `AgentRuntimeService` default-port assertion, unrelated — the file's diff here is interface-type-only).

#### 📝 Additional Information

Part of a broader cleanup: shared guard helpers stay for genuine `unknown` inspection (error normalizers, recursive traversals); call sites that should parse untyped payloads with zod schemas will be migrated separately.