### PR TITLE
🐛 fix(group): preserve task titles across runtimes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Packages
     env:
-      PACKAGES: '@lobechat/file-loaders @lobechat/prompts @lobechat/model-runtime @lobechat/web-crawler @lobechat/electron-server-ipc @lobechat/utils @lobechat/context-engine @lobechat/agent-runtime @lobechat/conversation-flow @lobechat/ssrf-safe-fetch @lobechat/memory-user-memory @lobechat/types @lobechat/trpc @lobechat/app-config @lobechat/locales @lobechat/env @lobechat/builtin-tool-lobe-agent model-bank @lobechat/agent-gateway-client @lobechat/agent-manager-runtime @lobechat/device-gateway-client @lobechat/device-identity @lobechat/eval-dataset-parser @lobechat/eval-rubric @lobechat/fetch-sse @lobechat/heterogeneous-agents'
+      PACKAGES: '@lobechat/file-loaders @lobechat/prompts @lobechat/model-runtime @lobechat/web-crawler @lobechat/electron-server-ipc @lobechat/utils @lobechat/context-engine @lobechat/agent-runtime @lobechat/conversation-flow @lobechat/ssrf-safe-fetch @lobechat/memory-user-memory @lobechat/types @lobechat/trpc @lobechat/app-config @lobechat/locales @lobechat/env @lobechat/builtin-tool-lobe-agent @lobechat/builtin-tool-group-management model-bank @lobechat/agent-gateway-client @lobechat/agent-manager-runtime @lobechat/device-gateway-client @lobechat/device-identity @lobechat/eval-dataset-parser @lobechat/eval-rubric @lobechat/fetch-sse @lobechat/heterogeneous-agents'
 
     steps:
       - name: Checkout

--- a/apps/server/src/modules/AgentRuntime/executorHelpers.ts
+++ b/apps/server/src/modules/AgentRuntime/executorHelpers.ts
@@ -291,6 +291,7 @@ export const buildServerAgentMemberRunner = (
               // members parent their response here (siblings of the council tool).
               supervisorMessageId: parentMessageId,
               timeout,
+              title: member.title,
               topicId,
             });
             if (result?.started) {

--- a/apps/server/src/services/agentRuntime/types.ts
+++ b/apps/server/src/services/agentRuntime/types.ts
@@ -303,6 +303,8 @@ export interface ExecGroupMemberParams {
   supervisorMessageId?: string;
   /** Per-member timeout (ms), isolated mode. */
   timeout?: number;
+  /** Explicit thread title for an isolated member task. */
+  title?: string;
   /** Group topic id. */
   topicId: string;
 }

--- a/apps/server/src/services/aiAgent/__tests__/execSubAgent.test.ts
+++ b/apps/server/src/services/aiAgent/__tests__/execSubAgent.test.ts
@@ -272,6 +272,36 @@ describe('AiAgentService.execSubAgent', () => {
       );
     });
 
+    it('should use the explicit group task title when creating an isolated thread', async () => {
+      vi.spyOn(service, 'execAgent').mockResolvedValue({
+        operationId: 'member-operation',
+        success: true,
+      } as any);
+
+      await service.execGroupMember({
+        agentId: 'agent-1',
+        anchorMessageId: 'task-anchor',
+        expectedMembers: 1,
+        groupId: 'group-1',
+        groupToolMessageId: 'group-tool-message',
+        instruction: 'A detailed instruction that should not become the title',
+        mode: 'isolated',
+        onComplete: 'resume',
+        parentOperationId: 'parent-operation',
+        title: 'Explicit task title',
+        topicId: 'topic-1',
+      });
+
+      expect(mockThreadModel.create).toHaveBeenCalledWith({
+        agentId: 'agent-1',
+        groupId: 'group-1',
+        sourceMessageId: 'task-anchor',
+        title: 'Explicit task title',
+        topicId: 'topic-1',
+        type: ThreadType.Isolation,
+      });
+    });
+
     it('should store operationId and startedAt in Thread metadata', async () => {
       vi.spyOn(service, 'execAgent').mockResolvedValue({
         agentId: 'agent-1',

--- a/apps/server/src/services/aiAgent/index.ts
+++ b/apps/server/src/services/aiAgent/index.ts
@@ -4059,7 +4059,7 @@ export class AiAgentService {
           parentMessageId: params.anchorMessageId,
           parentOperationId: params.parentOperationId,
           timeout: params.timeout,
-          title: params.instruction?.slice(0, 50),
+          title: params.title ?? params.instruction?.slice(0, 50),
           topicId: params.topicId,
         },
         {

--- a/apps/server/src/services/toolExecution/serverRuntimes/__tests__/groupManagement.test.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/__tests__/groupManagement.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment node
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { buildServerAgentMemberRunner } from '@/server/modules/AgentRuntime/executorHelpers';
+
 import type { ToolExecutionContext } from '../../types';
 import { groupManagementRuntime } from '../groupManagement';
 
@@ -108,7 +110,7 @@ describe('groupManagementRuntime', () => {
         makeCtx(),
       );
       expect(run).toHaveBeenCalledWith({
-        members: [{ agentId: 'agent-a', instruction: 'do work' }],
+        members: [{ agentId: 'agent-a', instruction: 'do work', title: 'work' }],
         mode: 'isolated',
         onComplete: 'resume',
         timeout: 60_000,
@@ -136,8 +138,8 @@ describe('groupManagementRuntime', () => {
       );
       expect(run).toHaveBeenCalledWith({
         members: [
-          { agentId: 'a', instruction: 'ta' },
-          { agentId: 'b', instruction: 'tb' },
+          { agentId: 'a', instruction: 'ta', title: 'A' },
+          { agentId: 'b', instruction: 'tb', title: 'B' },
         ],
         mode: 'isolated',
         onComplete: 'resume',
@@ -149,5 +151,36 @@ describe('groupManagementRuntime', () => {
       const result = await runtime().executeAgentTasks({ tasks: [] } as any, makeCtx());
       expect(result.error?.code).toBe('INVALID_ARGUMENTS');
     });
+  });
+
+  it('forwards an isolated member title to execGroupMember', async () => {
+    const execGroupMember = vi.fn().mockResolvedValue({ started: true });
+    const agentMember = buildServerAgentMemberRunner(
+      {
+        execGroupMember,
+        messageModel: { create: vi.fn().mockResolvedValue({ id: 'group-tool' }) },
+        operationId: 'parent-operation',
+        topicId: 'topic-1',
+      } as any,
+      {
+        metadata: { agentId: 'supervisor', groupId: 'group-1', topicId: 'topic-1' },
+      } as any,
+      { id: 'tool-call' } as any,
+      'supervisor-message',
+    );
+
+    await agentMember!.run({
+      members: [{ agentId: 'worker-1', instruction: 'Detailed instruction', title: 'Task title' }],
+      mode: 'isolated',
+      onComplete: 'resume',
+    });
+
+    expect(execGroupMember).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: 'worker-1',
+        anchorMessageId: 'group-tool',
+        title: 'Task title',
+      }),
+    );
   });
 });

--- a/apps/server/src/services/toolExecution/serverRuntimes/groupManagement.ts
+++ b/apps/server/src/services/toolExecution/serverRuntimes/groupManagement.ts
@@ -138,7 +138,7 @@ class GroupManagementExecutionRuntime {
     }
 
     const { started } = await ctx.agentMember.run({
-      members: [{ agentId: params.agentId, instruction: params.instruction }],
+      members: [{ agentId: params.agentId, instruction: params.instruction, title: params.title }],
       mode: 'isolated',
       onComplete: params.skipCallSupervisor ? 'finish' : 'resume',
       timeout: params.timeout,
@@ -163,7 +163,11 @@ class GroupManagementExecutionRuntime {
     if (tasks.length === 0) return buildError('tasks is required.', 'INVALID_ARGUMENTS');
 
     const { started } = await ctx.agentMember.run({
-      members: tasks.map((task) => ({ agentId: task.agentId, instruction: task.instruction })),
+      members: tasks.map((task) => ({
+        agentId: task.agentId,
+        instruction: task.instruction,
+        title: task.title,
+      })),
       mode: 'isolated',
       onComplete: params.skipCallSupervisor ? 'finish' : 'resume',
       // Per-task timeouts collapse to the longest; the barrier waits for all.

--- a/apps/server/src/services/toolExecution/types.ts
+++ b/apps/server/src/services/toolExecution/types.ts
@@ -74,6 +74,8 @@ export interface ServerAgentMemberRunItem {
   agentId: string;
   /** Optional supervisor instruction to guide the member's response. */
   instruction?: string;
+  /** Optional title for an isolated member task. */
+  title?: string;
 }
 
 export interface ServerAgentMemberRunParams {

--- a/packages/builtin-tool-group-management/package.json
+++ b/packages/builtin-tool-group-management/package.json
@@ -8,6 +8,11 @@
     "./executor": "./src/executor.ts"
   },
   "main": "./src/index.ts",
+  "scripts": {
+    "test": "vitest",
+    "test:coverage": "vitest --coverage --silent='passed-only'",
+    "test:update": "vitest -u"
+  },
   "dependencies": {
     "@lobechat/const": "workspace:*"
   },

--- a/packages/builtin-tool-group-management/src/executor.test.ts
+++ b/packages/builtin-tool-group-management/src/executor.test.ts
@@ -294,7 +294,10 @@ describe('GroupManagementExecutor', () => {
       expect(result.state).toEqual({
         agentId: 'agent-1',
         instruction: 'Do something',
+        runInClient: undefined,
+        skipCallSupervisor: undefined,
         timeout: undefined,
+        title: 'Test Task',
         type: 'executeAgentTask',
       });
     });
@@ -334,8 +337,11 @@ describe('GroupManagementExecutor', () => {
       expect(triggerExecuteTask).toHaveBeenCalledWith({
         agentId: 'agent-1',
         instruction: 'Do something',
+        runInClient: undefined,
+        skipCallSupervisor: undefined,
         supervisorAgentId: 'supervisor-agent',
         timeout: 30000,
+        title: 'Test Task',
         toolMessageId: 'test-message-id',
       });
     });
@@ -364,7 +370,10 @@ describe('GroupManagementExecutor', () => {
       expect(result.state).toEqual({
         agentId: 'agent-1',
         instruction: 'Do something',
+        runInClient: undefined,
+        skipCallSupervisor: undefined,
         timeout: 60000,
+        title: 'Test Task',
         type: 'executeAgentTask',
       });
     });

--- a/packages/builtin-tool-group-management/src/executor.ts
+++ b/packages/builtin-tool-group-management/src/executor.ts
@@ -126,7 +126,7 @@ class GroupManagementExecutor extends BaseExecutor<typeof GroupManagementApiName
     params: ExecuteTaskParams,
     ctx: BuiltinToolContext,
   ): Promise<BuiltinToolResult> => {
-    const { agentId, instruction, timeout, skipCallSupervisor, runInClient } = params;
+    const { agentId, instruction, timeout, title, skipCallSupervisor, runInClient } = params;
 
     // Register afterCompletion callback to trigger async task execution after AgentRuntime completes
     // This follows the same pattern as speak/broadcast - trigger mode, not blocking
@@ -139,6 +139,7 @@ class GroupManagementExecutor extends BaseExecutor<typeof GroupManagementApiName
           skipCallSupervisor,
           supervisorAgentId: ctx.agentId!,
           timeout,
+          title,
           toolMessageId: ctx.messageId,
         }),
       );
@@ -153,6 +154,7 @@ class GroupManagementExecutor extends BaseExecutor<typeof GroupManagementApiName
         runInClient,
         skipCallSupervisor,
         timeout,
+        title,
         type: 'executeAgentTask',
       },
       stop: true,

--- a/packages/builtin-tool-group-management/vitest.config.mts
+++ b/packages/builtin-tool-group-management/vitest.config.mts
@@ -15,7 +15,7 @@ export default defineConfig({
   test: {
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'lcov', 'text-summary'],
+      reporter: ['text', 'json', ['lcov', { projectRoot: repoRoot }], 'text-summary'],
     },
     environment: 'node',
   },

--- a/packages/builtin-tool-group-management/vitest.config.mts
+++ b/packages/builtin-tool-group-management/vitest.config.mts
@@ -1,0 +1,22 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+
+const packageDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(packageDir, '../..');
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(repoRoot, 'src'),
+    },
+  },
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'lcov', 'text-summary'],
+    },
+    environment: 'node',
+  },
+});

--- a/packages/types/src/tool/builtin.ts
+++ b/packages/types/src/tool/builtin.ts
@@ -731,6 +731,10 @@ export interface TriggerExecuteTaskParams extends GroupOrchestrationBaseParams {
    */
   timeout?: number;
   /**
+   * Brief title describing what this task does (shown in UI)
+   */
+  title: string;
+  /**
    * The tool message ID that triggered the task
    */
   toolMessageId: string;

--- a/src/store/chat/slices/aiAgent/actions/__tests__/groupOrchestration.test.ts
+++ b/src/store/chat/slices/aiAgent/actions/__tests__/groupOrchestration.test.ts
@@ -166,6 +166,44 @@ describe('groupOrchestration actions', () => {
     });
   });
 
+  describe('triggerExecuteTask', () => {
+    it('includes the task title in the orchestration payload', async () => {
+      const internalExecGroupOrchestration = vi.fn().mockResolvedValue({ status: 'done' });
+      useChatStore.setState({ internal_execGroupOrchestration: internalExecGroupOrchestration });
+
+      await useChatStore.getState().triggerExecuteTask({
+        agentId: 'target-agent-id',
+        instruction: 'Analyze the data',
+        runInClient: true,
+        supervisorAgentId: TEST_IDS.SUPERVISOR_AGENT_ID,
+        timeout: 30_000,
+        title: 'Data analysis',
+        toolMessageId: 'tool-msg-id',
+      });
+
+      expect(internalExecGroupOrchestration).toHaveBeenCalledWith({
+        groupId: TEST_IDS.GROUP_ID,
+        initialResult: {
+          payload: {
+            decision: 'execute_task',
+            params: {
+              agentId: 'target-agent-id',
+              instruction: 'Analyze the data',
+              runInClient: true,
+              timeout: 30_000,
+              title: 'Data analysis',
+              toolMessageId: 'tool-msg-id',
+            },
+            skipCallSupervisor: false,
+          },
+          type: 'supervisor_decided',
+        },
+        supervisorAgentId: TEST_IDS.SUPERVISOR_AGENT_ID,
+        topicId: TEST_IDS.TOPIC_ID,
+      });
+    });
+  });
+
   describe('triggerSpeak', () => {
     it('should call internal_execGroupOrchestration with speak decision', async () => {
       const { result } = renderHook(() => useChatStore());

--- a/src/store/chat/slices/aiAgent/actions/groupOrchestration.ts
+++ b/src/store/chat/slices/aiAgent/actions/groupOrchestration.ts
@@ -183,6 +183,7 @@ export class GroupOrchestrationActionImpl {
       agentId,
       instruction,
       timeout,
+      title,
       toolMessageId,
       skipCallSupervisor,
       runInClient,
@@ -212,7 +213,7 @@ export class GroupOrchestrationActionImpl {
         type: 'supervisor_decided',
         payload: {
           decision: 'execute_task',
-          params: { agentId, instruction, runInClient, timeout, toolMessageId },
+          params: { agentId, instruction, runInClient, timeout, title, toolMessageId },
           skipCallSupervisor: skipCallSupervisor ?? false,
         },
       },


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Addresses the title-propagation portion of #16918. Thread navigation isolation is intentionally left for a separate change.

#### 🔀 Description of Change

Preserves group task titles across both client and server execution paths. The title now flows through the group-management executor, orchestration callback types, server runtime, executor helper, member execution, and isolated thread creation, including parallel group tasks.

The package now has a local Vitest configuration and CI entry so its executor regression tests run through the normal package-test workflow.

This PR no longer changes message cache keys, thread navigation, query scope, public shares, or SWR cache migration.

#### 🧪 How to Test

- [x] Package executor tests: 17 passed
- [x] Client orchestration tests: 8 passed
- [x] Server runtime/helper/parallel-member tests: 120 passed
- [x] Changed-file ESLint, Stylelint, Prettier, and `git diff --check`
- [ ] Full typecheck requires a fresh dependency install; the existing server `node_modules` is missing the already-declared `@xterm/addon-fit` package

#### 📸 Screenshots / Videos

No visual layout change. This change preserves the title already supplied by the task request.
