### PR TITLE
🐛 fix: align tool debug panel layout

### DIFF
--- a/src/features/Conversation/Messages/AssistantGroup/Tool/Debug/index.tsx
+++ b/src/features/Conversation/Messages/AssistantGroup/Tool/Debug/index.tsx
@@ -151,15 +151,25 @@ const Debug = memo<DebugProps>(
     );
 
     return (
-      <Block variant={'outlined'}>
+      <Block style={{ overflow: 'hidden' }} variant={'outlined'}>
         <Tabs
           items={items}
           orientation={'vertical'}
-          size={'small'}
+          size={'middle'}
           styles={{
+            list: {
+              borderRadius: 0,
+            },
             panel: {
+              flex: 'auto',
               height: 300,
+              minHeight: 0,
+              minWidth: 0,
               padding: 0,
+            },
+            tab: {
+              justifyContent: 'flex-start',
+              textAlign: 'start',
             },
           }}
         />


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes #17130

Linear: [LOBE-11826](https://linear.app/lobehub/issue/LOBE-11826/bug-工具调用详情面板技能状态-json-视图宽度撑爆右侧留白过大且无法滚动复制)

#### 🔀 Description of Change

- Restore the flex constraints required for the debug panel to occupy the remaining width.
- Increase vertical Tab sizing and align labels to the start edge.
- Remove the nested list radius and clip its background with the outer Block radius.
- Preserve horizontal and vertical scrolling plus the anchored copy control for long JSON.

#### 🧪 How to Test

- [x] Tested locally
- [ ] Added/updated tests
- [x] No tests needed

- bun run check src/features/Conversation/Messages/AssistantGroup/Tool/Debug/index.tsx
- git diff --check
- Electron verification with real Skill state data: panel geometry, Tab presentation, two-axis scrolling, and exact clipboard copy.

#### 📸 Screenshots / Videos

| Before | After |
| ------ | ----- |
| [Issue evidence](https://github.com/lobehub/lobehub/issues/17130) | [Verification report](https://app.lobehub.com/verify/ef316d2e-71c0-4109-8a4d-5bad6492f7fa) |

#### 📝 Additional Information

No API, data model, or migration changes.