### PR TITLE
security: pin actions-cool/pr-welcome to a release SHA

### DIFF
--- a/.github/workflows/issue-auto-comments.yml
+++ b/.github/workflows/issue-auto-comments.yml
@@ -41,7 +41,7 @@ jobs:
           fi
 
       - name: Auto Comment on Pull Request Merged
-        uses: actions-cool/pr-welcome@main
+        uses: actions-cool/pr-welcome@db204e23d550b47b449c97f19ddd13367936ffd7 # v1.5.0
         if: github.event.pull_request.merged == true && steps.maintainer-check.outputs.skip != 'true'
         with:
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
`.github/workflows/issue-auto-comments.yml` runs `actions-cool/pr-welcome@main` — a mutable **branch** ref — in a `pull_request_target` job that has `issues: write` + `pull-requests: write` and passes `secrets.GH_TOKEN` (lines 8, 19–20, 44, 47). A branch ref resolves to whatever the tip happens to be when the job runs.

In #14956 this project removed a sibling action from the **same publisher** — `actions-cool/issues-helper` — after all its tags were poisoned in a supply-chain attack that read runner memory to harvest CI/CD secrets (GitHub disabled that repo). `pr-welcome` itself isn't flagged, but it's still on `@main` in a secret-bearing job, so a future tag/branch change there would run in this context.

This pins it to the latest release SHA:

```
actions-cool/pr-welcome@db204e23d550b47b449c97f19ddd13367936ffd7 # v1.5.0
```

One line, no behavior change. And if you'd rather just drop `pr-welcome` entirely — as you did with `issues-helper` — that's completely reasonable; I'm happy to do that version instead. Your call on the remedy.

<sub>AI-assisted; I verified the workflow, the #14956 history, and the tag SHA myself.</sub>
