### PR TITLE
🐛 fix(hetero): drain the message write batcher before subagent writes

### DIFF
--- a/apps/server/src/services/message/__tests__/index.test.ts
+++ b/apps/server/src/services/message/__tests__/index.test.ts
@@ -287,11 +287,44 @@ describe('MessageService', () => {
       });
       expect(result).toEqual({
         results: [
-          { id: 'missing-assistant', index: 0, success: false, type: 'createMessage' },
+          {
+            error: 'create failed',
+            id: 'missing-assistant',
+            index: 0,
+            success: false,
+            type: 'createMessage',
+          },
           { id: 'still-runs', index: 1, success: true, type: 'updateMessage' },
         ],
         success: false,
       });
+    });
+
+    it('surfaces the driver cause of a failed write, not the drizzle query wrapper', async () => {
+      // Drizzle wraps the driver error: its own message is the whole failed
+      // statement + params, while the actionable part (violated constraint,
+      // SQLSTATE) only lives on `cause`. A subagent row written ahead of its
+      // parent lands here, and the caller needs to see *why* to act on it.
+      const driverError = Object.assign(
+        new Error('insert or update on table "messages" violates foreign key constraint'),
+        { code: '23503', constraint: 'messages_parent_id_messages_id_fk' },
+      );
+      const drizzleError = Object.assign(new Error('Failed query: insert into "messages" ...'), {
+        cause: driverError,
+      });
+      vi.mocked(mockMessageModel.create).mockRejectedValueOnce(drizzleError);
+
+      const result = await messageService.batchMutate([
+        {
+          message: { content: '', id: 'orphan', parentId: 'not-yet-written', role: 'user' } as any,
+          type: 'createMessage',
+        },
+      ]);
+
+      expect(result.success).toBe(false);
+      expect(result.results[0].error).toBe(
+        'messages_parent_id_messages_id_fk | 23503 | insert or update on table "messages" violates foreign key constraint',
+      );
     });
   });
 

--- a/apps/server/src/services/message/index.ts
+++ b/apps/server/src/services/message/index.ts
@@ -37,6 +37,25 @@ const logMessageTiming = (
 const createModelTiming = (options: QueryOptions | undefined, prefix: string) =>
   createPrefixedTimingContext(toTimingContext(options), prefix);
 
+/**
+ * Reduce a failed write to something the caller can act on. Drizzle wraps driver
+ * errors in a generic `Failed query: insert into ...` whose message is the whole
+ * statement plus its params — too noisy to return, and it may carry message
+ * content. The driver error underneath (`cause`) holds the actionable part: the
+ * SQLSTATE and the violated constraint.
+ */
+const describeBatchMutateError = (error: unknown): string => {
+  const cause = (error as { cause?: unknown } | undefined)?.cause;
+  const driverError = (cause ?? error) as
+    { code?: string; constraint?: string; message?: string } | undefined;
+
+  const detail = [driverError?.constraint, driverError?.code, driverError?.message]
+    .filter(Boolean)
+    .join(' | ');
+
+  return (detail || String(error)).slice(0, 300);
+};
+
 interface CreateMessageResult {
   id: string;
   messages: any[];
@@ -153,6 +172,7 @@ export class MessageService {
    */
   async batchMutate(operations: MessageBatchOperation[]): Promise<{
     results: {
+      error?: string;
       id?: string;
       index: number;
       success: boolean;
@@ -161,6 +181,7 @@ export class MessageService {
     success: boolean;
   }> {
     const results: {
+      error?: string;
       id?: string;
       index: number;
       success: boolean;
@@ -186,6 +207,7 @@ export class MessageService {
       } catch (error) {
         console.error('[MessageService] batchMutate operation failed:', error);
         results.push({
+          error: describeBatchMutateError(error),
           id: operation.type === 'createMessage' ? operation.message.id : operation.id,
           index,
           success: false,

--- a/src/services/message/index.ts
+++ b/src/services/message/index.ts
@@ -62,6 +62,7 @@ export type MessageBatchOperation =
 
 export interface MessageBatchMutationResult {
   results?: Array<{
+    error?: string;
     id?: string;
     index: number;
     success: boolean;
@@ -72,8 +73,12 @@ export interface MessageBatchMutationResult {
 
 export class MessageBatchMutationError extends Error {
   constructor(public readonly result: MessageBatchMutationResult) {
-    const failedCount = result.results?.filter((item) => !item.success).length;
-    super(`Message batch mutation failed for ${failedCount || 'unknown'} operation(s)`);
+    const failed = result.results?.filter((item) => !item.success) ?? [];
+    const reasons = [...new Set(failed.map((item) => item.error).filter(Boolean))];
+    super(
+      `Message batch mutation failed for ${failed.length || 'unknown'} operation(s)` +
+        (reasons.length > 0 ? `: ${reasons.join('; ')}` : ''),
+    );
   }
 }
 

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -70,6 +70,8 @@ import { labPreferSelectors } from '@/store/user/selectors';
 import { buildRunLifecycle } from '../../lifecycle/buildRunLifecycle';
 import type { RunScope } from '../../lifecycle/types';
 import { createGatewayEventHandler, isCompletedRuntimeEnd } from '../gateway/gatewayEventHandler';
+import { createMessageWriteBatcher, type ToolMessageUpdateOperation } from './messageWriteBatcher';
+import { createPendingCreateLedger } from './pendingCreateLedger';
 
 /** Mirrors `idGenerator('threads', 16)` on the server so sync-allocated ids have the same shape. */
 const generateThreadId = () => `thd_${createNanoId(16)()}`;
@@ -394,46 +396,8 @@ interface SubagentStoreDispatcher {
   update: (id: string, value: Partial<UIChatMessage>) => void;
 }
 
-const HETERO_MESSAGE_WRITE_BATCH_IDLE_MS = 5_000;
-const HETERO_MESSAGE_WRITE_BATCH_MAX_OPS = 50;
 const HETERO_TERMINAL_PERSIST_DRAIN_TIMEOUT_MS = 10_000;
 const HETERO_TERMINAL_EVENT_GRACE_TIMEOUT_MS = 3_000;
-
-type MessageUpdateOperation = Extract<MessageBatchOperation, { type: 'updateMessage' }>;
-type ToolMessageUpdateOperation = Extract<MessageBatchOperation, { type: 'updateToolMessage' }>;
-
-type QueuedMessageWriteOperation =
-  | (Extract<MessageBatchOperation, { type: 'createMessage' }> & {
-      ctx?: never;
-      onFailure?: (error: unknown) => void;
-    })
-  | (MessageUpdateOperation & {
-      ctx?: MessageQueryContext;
-      onFailure?: (error: unknown) => void;
-    })
-  | (ToolMessageUpdateOperation & {
-      ctx?: MessageQueryContext;
-      onFailure?: (error: unknown) => void;
-    });
-
-const mergeMessageUpdateValue = (
-  previous: MessageUpdateOperation['value'],
-  next: MessageUpdateOperation['value'],
-): MessageUpdateOperation['value'] => {
-  const metadata =
-    previous.metadata || next.metadata
-      ? {
-          ...(previous.metadata as Record<string, any> | undefined),
-          ...(next.metadata as Record<string, any> | undefined),
-        }
-      : undefined;
-
-  return {
-    ...previous,
-    ...next,
-    ...(metadata ? { metadata } : {}),
-  };
-};
 
 const waitForPersistQueue = async (
   queue: Promise<void>,
@@ -465,138 +429,6 @@ const waitForPersistQueue = async (
   }
 
   return true;
-};
-
-const createMessageWriteBatcher = (deps: {
-  batchMutate?: (operations: MessageBatchOperation[]) => Promise<any>;
-  createMessage: typeof messageService.createMessage;
-  updateMessage: typeof messageService.updateMessage;
-  updateToolMessage: typeof messageService.updateToolMessage;
-}) => {
-  let operations: QueuedMessageWriteOperation[] = [];
-  let flushChain: Promise<void> = Promise.resolve();
-  let idleTimer: ReturnType<typeof setTimeout> | undefined;
-
-  const clearIdleTimer = () => {
-    if (!idleTimer) return;
-    clearTimeout(idleTimer);
-    idleTimer = undefined;
-  };
-
-  const notifyFailure = (operation: QueuedMessageWriteOperation, error: unknown) => {
-    operation.onFailure?.(error);
-  };
-
-  const runIndividual = async (operation: QueuedMessageWriteOperation) => {
-    if (operation.type === 'createMessage') {
-      await deps.createMessage(operation.message);
-      return;
-    }
-
-    if (operation.type === 'updateToolMessage') {
-      const result = await deps.updateToolMessage(operation.id, operation.value, operation.ctx);
-      if (result?.success === false) notifyFailure(operation, result);
-      return;
-    }
-
-    const result = await deps.updateMessage(operation.id, operation.value, operation.ctx);
-    if (result?.success === false) notifyFailure(operation, result);
-  };
-
-  const runBatch = async (batch: QueuedMessageWriteOperation[]) => {
-    if (deps.batchMutate) {
-      try {
-        const result = await deps.batchMutate(batch as unknown as MessageBatchOperation[]);
-        const failedIndexes = new Set<number>(
-          (result?.results ?? [])
-            .filter((item: { index: number; success: boolean }) => !item.success)
-            .map((item: { index: number }) => item.index),
-        );
-
-        if (result?.success === false && failedIndexes.size === 0) {
-          for (const [index] of batch.entries()) failedIndexes.add(index);
-        }
-
-        for (const index of failedIndexes) {
-          notifyFailure(batch[index], result);
-        }
-        return;
-      } catch (err) {
-        console.error('[HeterogeneousAgent] Failed to flush message write batch:', err);
-        for (const operation of batch) notifyFailure(operation, err);
-        return;
-      }
-    }
-
-    for (const operation of batch) {
-      try {
-        await runIndividual(operation);
-      } catch (err) {
-        console.error('[HeterogeneousAgent] Failed to flush message write operation:', err);
-        notifyFailure(operation, err);
-      }
-    }
-  };
-
-  const flush = async (_reason: string) => {
-    clearIdleTimer();
-    flushChain = flushChain.then(async () => {
-      while (operations.length > 0) {
-        const batch = operations;
-        operations = [];
-        await runBatch(batch);
-      }
-    });
-    await flushChain;
-  };
-
-  const scheduleIdleFlush = () => {
-    clearIdleTimer();
-    idleTimer = setTimeout(() => {
-      void flush('idle');
-    }, HETERO_MESSAGE_WRITE_BATCH_IDLE_MS);
-  };
-
-  const enqueue = (operation: QueuedMessageWriteOperation) => {
-    const last = operations.at(-1);
-    if (
-      last?.type === 'updateMessage' &&
-      operation.type === 'updateMessage' &&
-      last.id === operation.id &&
-      !last.onFailure &&
-      !operation.onFailure
-    ) {
-      last.value = mergeMessageUpdateValue(last.value, operation.value);
-    } else {
-      operations.push(operation);
-    }
-
-    if (operations.length >= HETERO_MESSAGE_WRITE_BATCH_MAX_OPS) {
-      void flush('max-ops');
-    } else {
-      scheduleIdleFlush();
-    }
-  };
-
-  return {
-    enqueueCreateMessage: (
-      message: Extract<MessageBatchOperation, { type: 'createMessage' }>['message'],
-      onFailure?: (error: unknown) => void,
-    ) => enqueue({ message, onFailure, type: 'createMessage' }),
-    enqueueToolMessageUpdate: (
-      id: string,
-      value: ToolMessageUpdateOperation['value'],
-      ctx?: MessageQueryContext,
-      onFailure?: (error: unknown) => void,
-    ) => enqueue({ ctx, id, onFailure, type: 'updateToolMessage', value }),
-    enqueueUpdateMessage: (
-      id: string,
-      value: MessageUpdateOperation['value'],
-      ctx?: MessageQueryContext,
-      onFailure?: (error: unknown) => void,
-    ) => enqueue({ ctx, id, onFailure, type: 'updateMessage', value }),
-    flush,
-  };
 };
 
 interface MessageBatchMutationResult {
@@ -826,21 +658,6 @@ export const executeHeterogeneousAgent = async (
    * be lost once the reducer clears `accContent` on terminal.
    */
   const pendingMainFlush = new Map<string, Record<string, any>>();
-  /**
-   * Retry ledger for every failed row create — assistants AND tool rows, in one
-   * Map on purpose. `messages.parent_id` is a real FK and the parent graph is
-   * not layered: a tool row hangs off its assistant, but a signal/reactive
-   * assistant hangs off the run's last TOOL row (see `computeTurnParentId`).
-   * Splitting the ledger by role would replay a tool-parented assistant before
-   * its parent tool row and lose the turn. Enqueue order IS dependency order —
-   * the reducer can only name a parent it has already emitted a create for —
-   * and `Map` preserves insertion order, so one in-order drain is correct with
-   * no knowledge of which parent kind any given row uses.
-   */
-  const pendingCreates = new Map<
-    string,
-    Extract<MessageBatchOperation, { type: 'createMessage' }>['message']
-  >();
   /** Retry ledger for tool result content / plugin state. */
   const pendingToolFlush = new Map<string, ToolMessageUpdateOperation['value']>();
 
@@ -1047,6 +864,13 @@ export const executeHeterogeneousAgent = async (
     updateMessage: messageService.updateMessage,
     updateToolMessage: messageService.updateToolMessage,
   });
+
+  /** Failed-create retry ledger + the FK-parent barrier for straight-through writes. */
+  const pendingCreateLedger = createPendingCreateLedger({
+    createMessage: messageService.createMessage,
+    flush: messageWriteBatcher.flush,
+  });
+
   const enqueueMainToolResult = (
     toolCallId: string,
     content: string,
@@ -1313,15 +1137,15 @@ export const executeHeterogeneousAgent = async (
     // subagent rows are topic-scoped.
     if (!context.topicId) return;
 
-    // `createThread.sourceMessageId` and `createMessage.parentId` both point at the
-    // main assistant row, which `applyMainIntent` only *enqueues* into the write
-    // batcher. Subagent rows are written straight through, so without this drain
-    // they can reach the DB ahead of their parent — and `messages.parent_id` has an
-    // FK to `messages.id`, so the insert is rejected and the row is lost for good.
-    // No-op when the queue is already empty.
-    if (intent.kind === 'createThread' || intent.kind === 'createMessage') {
-      await messageWriteBatcher.flush('before-subagent-write');
-    }
+    // Both of these hang off the main assistant row, which may still be sitting in
+    // the write batcher (or have failed to write at all). `createThread` is gated
+    // as well: its own `sourceMessageId` has no FK, but letting it through against
+    // a missing parent just buys an orphan thread whose seed `createMessage` fails
+    // a moment later.
+    if (intent.kind === 'createThread')
+      await pendingCreateLedger.ensureParentPersisted(intent.sourceMessageId);
+    if (intent.kind === 'createMessage')
+      await pendingCreateLedger.ensureParentPersisted(intent.parentId);
 
     switch (intent.kind) {
       case 'createThread': {
@@ -1588,7 +1412,7 @@ export const executeHeterogeneousAgent = async (
         } as any;
         messageWriteBatcher.enqueueCreateMessage(messageToCreate, (err) => {
           console.error('[HeterogeneousAgent] Failed to create step assistant:', err);
-          pendingCreates.set(intent.messageId, messageToCreate);
+          pendingCreateLedger.add(intent.messageId, messageToCreate);
         });
         get().internal_dispatchMessage(
           { id: intent.messageId, type: 'createMessage', value: messageToCreate },
@@ -1705,7 +1529,7 @@ export const executeHeterogeneousAgent = async (
           const toolMsg = buildToolMessage(x);
           messageWriteBatcher.enqueueCreateMessage(toolMsg, (err) => {
             console.error('[HeterogeneousAgent] Failed to create tool message:', err);
-            pendingCreates.set(x.toolMessageId, toolMsg);
+            pendingCreateLedger.add(x.toolMessageId, toolMsg);
           });
           toolMsgIdByCallId.set(x.payload.id, x.toolMessageId);
           mainToolCallIds.add(x.payload.id);
@@ -2150,14 +1974,7 @@ export const executeHeterogeneousAgent = async (
             // Order is load-bearing: rows first, in the order they were enqueued
             // (that is their FK dependency order), then the content patches —
             // an update against a row that does not exist yet matches zero rows.
-            for (const [messageId, messageToCreate] of pendingCreates) {
-              try {
-                await messageService.createMessage(messageToCreate);
-                pendingCreates.delete(messageId);
-              } catch (err) {
-                console.error('[HeterogeneousAgent] Failed to replay message create:', err);
-              }
-            }
+            await pendingCreateLedger.drain();
 
             for (const [messageId, update] of pendingMainFlush) {
               try {

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/heterogeneousAgentExecutor.ts
@@ -600,14 +600,18 @@ const createMessageWriteBatcher = (deps: {
 };
 
 interface MessageBatchMutationResult {
-  results?: Array<{ index: number; success: boolean }>;
+  results?: Array<{ error?: string; index: number; success: boolean }>;
   success?: boolean;
 }
 
 class MessageBatchMutationError extends Error {
   constructor(public readonly result: MessageBatchMutationResult) {
-    const failedCount = result.results?.filter((item) => !item.success).length;
-    super(`messageService.batchMutate failed for ${failedCount || 'unknown'} operation(s)`);
+    const failed = result.results?.filter((item) => !item.success) ?? [];
+    const reasons = [...new Set(failed.map((item) => item.error).filter(Boolean))];
+    super(
+      `messageService.batchMutate failed for ${failed.length || 'unknown'} operation(s)` +
+        (reasons.length > 0 ? `: ${reasons.join('; ')}` : ''),
+    );
   }
 }
 
@@ -1308,6 +1312,17 @@ export const executeHeterogeneousAgent = async (
     // caller already guards, but this function is a separate closure). All
     // subagent rows are topic-scoped.
     if (!context.topicId) return;
+
+    // `createThread.sourceMessageId` and `createMessage.parentId` both point at the
+    // main assistant row, which `applyMainIntent` only *enqueues* into the write
+    // batcher. Subagent rows are written straight through, so without this drain
+    // they can reach the DB ahead of their parent — and `messages.parent_id` has an
+    // FK to `messages.id`, so the insert is rejected and the row is lost for good.
+    // No-op when the queue is already empty.
+    if (intent.kind === 'createThread' || intent.kind === 'createMessage') {
+      await messageWriteBatcher.flush('before-subagent-write');
+    }
+
     switch (intent.kind) {
       case 'createThread': {
         try {

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/messageWriteBatcher.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/messageWriteBatcher.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createMessageWriteBatcher } from './messageWriteBatcher';
+
+const createDeps = () => ({
+  batchMutate: vi.fn().mockResolvedValue({ results: [], success: true }),
+  createMessage: vi.fn().mockResolvedValue({ id: 'msg-1' }),
+  updateMessage: vi.fn().mockResolvedValue({ success: true }),
+  updateToolMessage: vi.fn().mockResolvedValue({ success: true }),
+});
+
+const createRow = (id: string, parentId?: string) =>
+  ({ content: '', id, parentId, role: 'assistant' }) as any;
+
+describe('createMessageWriteBatcher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('holds writes until flushed, then sends them as one batch', async () => {
+    const deps = createDeps();
+    const batcher = createMessageWriteBatcher(deps);
+
+    batcher.enqueueCreateMessage(createRow('msg-a'));
+    batcher.enqueueCreateMessage(createRow('msg-b'));
+
+    expect(deps.batchMutate).not.toHaveBeenCalled();
+
+    await batcher.flush('test');
+
+    expect(deps.batchMutate).toHaveBeenCalledTimes(1);
+    expect(deps.batchMutate.mock.calls[0][0]).toHaveLength(2);
+  });
+
+  it('flushing an empty queue is a no-op', async () => {
+    const deps = createDeps();
+    const batcher = createMessageWriteBatcher(deps);
+
+    await batcher.flush('test');
+
+    expect(deps.batchMutate).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The semantic that made subagent rows die against `messages_parent_id_messages_id_fk`:
+   * a failed create is reported ONLY through `onFailure`, and `flush` still resolves.
+   * Awaiting a flush therefore proves nothing about whether the row landed — the
+   * executor has to track failures itself (`pendingCreates`) and re-check before
+   * writing anything that FKs to that row.
+   */
+  it('resolves the flush even when a create fails, reporting it only via onFailure', async () => {
+    const deps = createDeps();
+    deps.batchMutate.mockResolvedValue({
+      results: [{ error: 'messages_parent_id_messages_id_fk', index: 0, success: false }],
+      success: false,
+    });
+    const batcher = createMessageWriteBatcher(deps);
+    const onFailure = vi.fn();
+
+    batcher.enqueueCreateMessage(createRow('msg-parent'), onFailure);
+
+    await expect(batcher.flush('test')).resolves.toBeUndefined();
+    expect(onFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports every queued op when batchMutate throws outright', async () => {
+    const deps = createDeps();
+    const boom = new Error('network down');
+    deps.batchMutate.mockRejectedValue(boom);
+    const batcher = createMessageWriteBatcher(deps);
+    const onFailureA = vi.fn();
+    const onFailureB = vi.fn();
+
+    batcher.enqueueCreateMessage(createRow('msg-a'), onFailureA);
+    batcher.enqueueCreateMessage(createRow('msg-b'), onFailureB);
+
+    await expect(batcher.flush('test')).resolves.toBeUndefined();
+
+    expect(onFailureA).toHaveBeenCalledWith(boom);
+    expect(onFailureB).toHaveBeenCalledWith(boom);
+  });
+
+  it('marks all ops failed when the batch reports failure without per-op indexes', async () => {
+    const deps = createDeps();
+    deps.batchMutate.mockResolvedValue({ success: false });
+    const batcher = createMessageWriteBatcher(deps);
+    const onFailure = vi.fn();
+
+    batcher.enqueueCreateMessage(createRow('msg-a'), onFailure);
+
+    await batcher.flush('test');
+
+    expect(onFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces consecutive updates to the same row, deep-merging metadata', async () => {
+    const deps = createDeps();
+    const batcher = createMessageWriteBatcher(deps);
+
+    batcher.enqueueUpdateMessage('msg-a', { content: 'hel', metadata: { a: 1 } } as any);
+    batcher.enqueueUpdateMessage('msg-a', { content: 'hello', metadata: { b: 2 } } as any);
+
+    await batcher.flush('test');
+
+    const ops = deps.batchMutate.mock.calls[0][0];
+    expect(ops).toHaveLength(1);
+    expect(ops[0].value).toMatchObject({ content: 'hello', metadata: { a: 1, b: 2 } });
+  });
+
+  it('does not coalesce updates that carry an onFailure ledger hook', async () => {
+    const deps = createDeps();
+    const batcher = createMessageWriteBatcher(deps);
+
+    batcher.enqueueUpdateMessage('msg-a', { content: 'one' } as any, undefined, vi.fn());
+    batcher.enqueueUpdateMessage('msg-a', { content: 'two' } as any, undefined, vi.fn());
+
+    await batcher.flush('test');
+
+    expect(deps.batchMutate.mock.calls[0][0]).toHaveLength(2);
+  });
+
+  it('preserves enqueue order — which is FK dependency order', async () => {
+    const deps = createDeps();
+    const batcher = createMessageWriteBatcher(deps);
+
+    batcher.enqueueCreateMessage(createRow('assistant-1'));
+    batcher.enqueueCreateMessage(createRow('tool-1', 'assistant-1'));
+    batcher.enqueueCreateMessage(createRow('assistant-2', 'tool-1'));
+
+    await batcher.flush('test');
+
+    expect(deps.batchMutate.mock.calls[0][0].map((op: any) => op.message.id)).toEqual([
+      'assistant-1',
+      'tool-1',
+      'assistant-2',
+    ]);
+  });
+
+  it('auto-flushes once the queue hits the max-ops ceiling', async () => {
+    const deps = createDeps();
+    const batcher = createMessageWriteBatcher(deps);
+
+    for (let i = 0; i < 50; i += 1) batcher.enqueueCreateMessage(createRow(`msg-${i}`));
+    await batcher.flush('test');
+
+    expect(deps.batchMutate).toHaveBeenCalledTimes(1);
+    expect(deps.batchMutate.mock.calls[0][0]).toHaveLength(50);
+  });
+
+  it('falls back to per-op writes when batchMutate is unavailable', async () => {
+    const deps = { ...createDeps(), batchMutate: undefined };
+    const batcher = createMessageWriteBatcher(deps as any);
+
+    batcher.enqueueCreateMessage(createRow('msg-a'));
+    batcher.enqueueUpdateMessage('msg-b', { content: 'x' } as any);
+
+    await batcher.flush('test');
+
+    expect(deps.createMessage).toHaveBeenCalledTimes(1);
+    expect(deps.updateMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('surfaces a per-op failure through onFailure in the no-batchMutate fallback', async () => {
+    const deps = { ...createDeps(), batchMutate: undefined };
+    const boom = new Error('insert failed');
+    deps.createMessage.mockRejectedValue(boom);
+    const batcher = createMessageWriteBatcher(deps as any);
+    const onFailure = vi.fn();
+
+    batcher.enqueueCreateMessage(createRow('msg-a'), onFailure);
+
+    await expect(batcher.flush('test')).resolves.toBeUndefined();
+    expect(onFailure).toHaveBeenCalledWith(boom);
+  });
+});

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/messageWriteBatcher.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/messageWriteBatcher.ts
@@ -1,0 +1,188 @@
+import type {
+  MessageBatchOperation,
+  MessageQueryContext,
+  messageService,
+} from '@/services/message';
+
+export const HETERO_MESSAGE_WRITE_BATCH_IDLE_MS = 5_000;
+export const HETERO_MESSAGE_WRITE_BATCH_MAX_OPS = 50;
+
+type MessageUpdateOperation = Extract<MessageBatchOperation, { type: 'updateMessage' }>;
+export type ToolMessageUpdateOperation = Extract<
+  MessageBatchOperation,
+  { type: 'updateToolMessage' }
+>;
+
+export type QueuedMessageWriteOperation =
+  | (Extract<MessageBatchOperation, { type: 'createMessage' }> & {
+      ctx?: never;
+      onFailure?: (error: unknown) => void;
+    })
+  | (MessageUpdateOperation & {
+      ctx?: MessageQueryContext;
+      onFailure?: (error: unknown) => void;
+    })
+  | (ToolMessageUpdateOperation & {
+      ctx?: MessageQueryContext;
+      onFailure?: (error: unknown) => void;
+    });
+
+const mergeMessageUpdateValue = (
+  previous: MessageUpdateOperation['value'],
+  next: MessageUpdateOperation['value'],
+): MessageUpdateOperation['value'] => {
+  const metadata =
+    previous.metadata || next.metadata
+      ? {
+          ...(previous.metadata as Record<string, any> | undefined),
+          ...(next.metadata as Record<string, any> | undefined),
+        }
+      : undefined;
+
+  return {
+    ...previous,
+    ...next,
+    ...(metadata ? { metadata } : {}),
+  };
+};
+
+/**
+ * Write-behind queue for the hetero run's message rows: coalesces consecutive
+ * updates to the same row and flushes them as one `batchMutate`.
+ *
+ * Failures are reported ONLY through each operation's `onFailure` — `flush`
+ * resolves either way. Callers that depend on a row actually existing (an FK
+ * parent, say) therefore cannot treat an awaited `flush` as proof it landed;
+ * they must track the failures themselves. See `pendingCreates` in the executor.
+ */
+export const createMessageWriteBatcher = (deps: {
+  batchMutate?: (operations: MessageBatchOperation[]) => Promise<any>;
+  createMessage: typeof messageService.createMessage;
+  updateMessage: typeof messageService.updateMessage;
+  updateToolMessage: typeof messageService.updateToolMessage;
+}) => {
+  let operations: QueuedMessageWriteOperation[] = [];
+  let flushChain: Promise<void> = Promise.resolve();
+  let idleTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const clearIdleTimer = () => {
+    if (!idleTimer) return;
+    clearTimeout(idleTimer);
+    idleTimer = undefined;
+  };
+
+  const notifyFailure = (operation: QueuedMessageWriteOperation, error: unknown) => {
+    operation.onFailure?.(error);
+  };
+
+  const runIndividual = async (operation: QueuedMessageWriteOperation) => {
+    if (operation.type === 'createMessage') {
+      await deps.createMessage(operation.message);
+      return;
+    }
+
+    if (operation.type === 'updateToolMessage') {
+      const result = await deps.updateToolMessage(operation.id, operation.value, operation.ctx);
+      if (result?.success === false) notifyFailure(operation, result);
+      return;
+    }
+
+    const result = await deps.updateMessage(operation.id, operation.value, operation.ctx);
+    if (result?.success === false) notifyFailure(operation, result);
+  };
+
+  const runBatch = async (batch: QueuedMessageWriteOperation[]) => {
+    if (deps.batchMutate) {
+      try {
+        const result = await deps.batchMutate(batch as unknown as MessageBatchOperation[]);
+        const failedIndexes = new Set<number>(
+          (result?.results ?? [])
+            .filter((item: { index: number; success: boolean }) => !item.success)
+            .map((item: { index: number }) => item.index),
+        );
+
+        if (result?.success === false && failedIndexes.size === 0) {
+          for (const [index] of batch.entries()) failedIndexes.add(index);
+        }
+
+        for (const index of failedIndexes) {
+          notifyFailure(batch[index], result);
+        }
+        return;
+      } catch (err) {
+        console.error('[HeterogeneousAgent] Failed to flush message write batch:', err);
+        for (const operation of batch) notifyFailure(operation, err);
+        return;
+      }
+    }
+
+    for (const operation of batch) {
+      try {
+        await runIndividual(operation);
+      } catch (err) {
+        console.error('[HeterogeneousAgent] Failed to flush message write operation:', err);
+        notifyFailure(operation, err);
+      }
+    }
+  };
+
+  const flush = async (_reason: string) => {
+    clearIdleTimer();
+    flushChain = flushChain.then(async () => {
+      while (operations.length > 0) {
+        const batch = operations;
+        operations = [];
+        await runBatch(batch);
+      }
+    });
+    await flushChain;
+  };
+
+  const scheduleIdleFlush = () => {
+    clearIdleTimer();
+    idleTimer = setTimeout(() => {
+      void flush('idle');
+    }, HETERO_MESSAGE_WRITE_BATCH_IDLE_MS);
+  };
+
+  const enqueue = (operation: QueuedMessageWriteOperation) => {
+    const last = operations.at(-1);
+    if (
+      last?.type === 'updateMessage' &&
+      operation.type === 'updateMessage' &&
+      last.id === operation.id &&
+      !last.onFailure &&
+      !operation.onFailure
+    ) {
+      last.value = mergeMessageUpdateValue(last.value, operation.value);
+    } else {
+      operations.push(operation);
+    }
+
+    if (operations.length >= HETERO_MESSAGE_WRITE_BATCH_MAX_OPS) {
+      void flush('max-ops');
+    } else {
+      scheduleIdleFlush();
+    }
+  };
+
+  return {
+    enqueueCreateMessage: (
+      message: Extract<MessageBatchOperation, { type: 'createMessage' }>['message'],
+      onFailure?: (error: unknown) => void,
+    ) => enqueue({ message, onFailure, type: 'createMessage' }),
+    enqueueToolMessageUpdate: (
+      id: string,
+      value: ToolMessageUpdateOperation['value'],
+      ctx?: MessageQueryContext,
+      onFailure?: (error: unknown) => void,
+    ) => enqueue({ ctx, id, onFailure, type: 'updateToolMessage', value }),
+    enqueueUpdateMessage: (
+      id: string,
+      value: MessageUpdateOperation['value'],
+      ctx?: MessageQueryContext,
+      onFailure?: (error: unknown) => void,
+    ) => enqueue({ ctx, id, onFailure, type: 'updateMessage', value }),
+    flush,
+  };
+};

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.test.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createPendingCreateLedger } from './pendingCreateLedger';
+
+const row = (id: string, parentId?: string) =>
+  ({ content: '', id, parentId, role: 'assistant' }) as any;
+
+describe('createPendingCreateLedger', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('ensureParentPersisted', () => {
+    it('flushes the write batcher before letting a straight-through write proceed', async () => {
+      const flush = vi.fn().mockResolvedValue(undefined);
+      const ledger = createPendingCreateLedger({ createMessage: vi.fn(), flush });
+
+      await expect(ledger.ensureParentPersisted('msg-parent')).resolves.toBeUndefined();
+
+      expect(flush).toHaveBeenCalledWith('before-subagent-write');
+    });
+
+    /**
+     * The gap this ledger exists to close. `flush` resolves even when the create
+     * inside it failed — the failure only lands here via `add`. Awaiting the flush
+     * is therefore not proof the parent exists, so the ledger replays it.
+     */
+    it('replays a parent whose batched create failed, then proceeds', async () => {
+      const createMessage = vi.fn().mockResolvedValue({ id: 'msg-parent' });
+      const flush = vi.fn().mockResolvedValue(undefined);
+      const ledger = createPendingCreateLedger({ createMessage, flush });
+
+      // The batcher swallowed this create and reported it through onFailure.
+      ledger.add('msg-parent', row('msg-parent'));
+
+      await expect(ledger.ensureParentPersisted('msg-parent')).resolves.toBeUndefined();
+
+      expect(createMessage).toHaveBeenCalledTimes(1);
+      expect(ledger.has('msg-parent')).toBe(false);
+      expect(ledger.size).toBe(0);
+    });
+
+    it('refuses to proceed when the parent still cannot be written', async () => {
+      const createMessage = vi.fn().mockRejectedValue(new Error('still failing'));
+      const flush = vi.fn().mockResolvedValue(undefined);
+      const ledger = createPendingCreateLedger({ createMessage, flush });
+
+      ledger.add('msg-parent', row('msg-parent'));
+
+      // Better to abort the subagent write than to hit the FK error, skip the
+      // state commit, and strand another Processing thread on the next retry.
+      await expect(ledger.ensureParentPersisted('msg-parent')).rejects.toThrow(
+        /missing FK parent msg-parent/,
+      );
+      expect(ledger.has('msg-parent')).toBe(true);
+    });
+
+    it('replays the whole ledger in dependency order, not just the named parent', async () => {
+      const written: string[] = [];
+      const createMessage = vi.fn().mockImplementation(async (m: any) => void written.push(m.id));
+      const ledger = createPendingCreateLedger({
+        createMessage,
+        flush: vi.fn().mockResolvedValue(undefined),
+      });
+
+      // A signal assistant hangs off the run's last TOOL row, which itself hangs
+      // off an earlier assistant — replaying only `assistant-2` would violate the FK.
+      ledger.add('assistant-1', row('assistant-1'));
+      ledger.add('tool-1', row('tool-1', 'assistant-1'));
+      ledger.add('assistant-2', row('assistant-2', 'tool-1'));
+
+      await ledger.ensureParentPersisted('assistant-2');
+
+      expect(written).toEqual(['assistant-1', 'tool-1', 'assistant-2']);
+    });
+
+    it('does not block on an unrelated row that stays stuck in the ledger', async () => {
+      const createMessage = vi.fn().mockRejectedValue(new Error('unrelated row is broken'));
+      const ledger = createPendingCreateLedger({
+        createMessage,
+        flush: vi.fn().mockResolvedValue(undefined),
+      });
+
+      ledger.add('some-other-row', row('some-other-row'));
+
+      // `msg-parent` was never in the ledger — it wrote fine through the batcher.
+      await expect(ledger.ensureParentPersisted('msg-parent')).resolves.toBeUndefined();
+    });
+
+    it('is a no-op when the ledger is empty', async () => {
+      const createMessage = vi.fn();
+      const ledger = createPendingCreateLedger({
+        createMessage,
+        flush: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await ledger.ensureParentPersisted('msg-parent');
+      await ledger.ensureParentPersisted(undefined);
+
+      expect(createMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('drain', () => {
+    it('keeps rows that fail again so a later pass can retry them', async () => {
+      const createMessage = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('transient'))
+        .mockResolvedValueOnce({ id: 'msg-b' });
+      const ledger = createPendingCreateLedger({
+        createMessage,
+        flush: vi.fn().mockResolvedValue(undefined),
+      });
+
+      ledger.add('msg-a', row('msg-a'));
+      ledger.add('msg-b', row('msg-b'));
+
+      await ledger.drain();
+
+      expect(ledger.has('msg-a')).toBe(true);
+      expect(ledger.has('msg-b')).toBe(false);
+      expect(ledger.size).toBe(1);
+    });
+  });
+});

--- a/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.ts
+++ b/src/store/chat/slices/agentRun/actions/transports/hetero/pendingCreateLedger.ts
@@ -1,0 +1,78 @@
+import type { MessageBatchOperation } from '@/services/message';
+
+type CreateMessageRow = Extract<MessageBatchOperation, { type: 'createMessage' }>['message'];
+
+/**
+ * Retry ledger for every failed row create — assistants AND tool rows, in one
+ * Map on purpose. `messages.parent_id` is a real FK and the parent graph is not
+ * layered: a tool row hangs off its assistant, but a signal/reactive assistant
+ * hangs off the run's last TOOL row (see `computeTurnParentId`). Splitting the
+ * ledger by role would replay a tool-parented assistant before its parent tool
+ * row and lose the turn. Enqueue order IS dependency order — the reducer can
+ * only name a parent it has already emitted a create for — and `Map` preserves
+ * insertion order, so one in-order drain is correct with no knowledge of which
+ * parent kind any given row uses.
+ */
+export const createPendingCreateLedger = (deps: {
+  createMessage: (message: CreateMessageRow) => Promise<unknown>;
+  /** The write batcher's flush. Resolves even when the writes inside it failed. */
+  flush: (reason: string) => Promise<void>;
+}) => {
+  const pending = new Map<string, CreateMessageRow>();
+
+  /**
+   * Replay the ledger in insertion order (= FK dependency order). Best-effort: a
+   * row that fails again stays in the ledger, so callers that need a specific row
+   * to exist must re-check afterwards rather than trust this to have emptied it.
+   */
+  const drain = async () => {
+    for (const [messageId, message] of pending) {
+      try {
+        await deps.createMessage(message);
+        pending.delete(messageId);
+      } catch (err) {
+        console.error('[HeterogeneousAgent] Failed to replay message create:', err);
+      }
+    }
+  };
+
+  return {
+    add: (messageId: string, message: CreateMessageRow) => pending.set(messageId, message),
+
+    drain,
+
+    /**
+     * Gate a straight-through write on its FK parent actually existing in the DB.
+     *
+     * The main row a subagent hangs off is only *enqueued* into the write batcher,
+     * while subagent rows are written straight through — so without a barrier the
+     * child can reach the DB before its parent and Postgres rejects it against
+     * `messages_parent_id_messages_id_fk`.
+     *
+     * Draining the batcher is necessary but NOT sufficient: a create that fails
+     * inside the batcher is reported only through its `onFailure` (which parks it
+     * here) and `flush` resolves regardless, so an awaited flush says nothing about
+     * whether the parent landed. Replay the ledger too, then refuse to proceed while
+     * the parent is still missing — walking into the FK error would skip the run's
+     * state commit and strand another `Processing` thread on every retry
+     * (`threads.source_message_id` has no FK, so the thread create keeps succeeding).
+     */
+    ensureParentPersisted: async (parentId?: string) => {
+      await deps.flush('before-subagent-write');
+
+      if (pending.size > 0) await drain();
+
+      if (parentId && pending.has(parentId)) {
+        throw new Error(
+          `[HeterogeneousAgent] refusing to write a row against missing FK parent ${parentId}`,
+        );
+      }
+    },
+
+    has: (messageId: string) => pending.has(messageId),
+
+    get size() {
+      return pending.size;
+    },
+  };
+};


### PR DESCRIPTION
### 💻 变更类型 | Change Type

- [x] 🐛 fix

### 🔀 变更说明 | Description of Change

异构 agent(CC)spawn subagent 时，subagent 的消息会**永久丢失**，控制台刷屏：

```
[HeterogeneousAgent] Failed to create subagent message: MessageBatchMutationError: messageService.batchMutate failed for 1 operation(s)
[HeterogeneousAgent] Intent failed, run state not advanced: ...
```

#### 根因

主 assistant 行走 write-behind 批处理器（`applyMainIntent` 只是 `enqueueCreateMessage`，idle flush 5s），而 subagent 行是**直连写**。两条路径没有同步点，于是 subagent 的 thread / seed 行可能抢在它的 parent 之前落库 —— 而 `messages.parent_id` 有 FK 指向 `messages.id`，Postgres 直接拒绝：

```
insert or update on table "messages" violates foreign key constraint "messages_parent_id_messages_id_fk"
```

线上日志坐实：失败的 insert 在 `12:04:20.023 UTC` 引用 `parent_id=msg_kgOHLcrFlqkxbLRuME`，而这个 parent 行的 `created_at` 是 `12:04:20.302 UTC` —— 比引用它的子行晚落库 **279ms**。那条 subagent 消息在库里查无此行。

失败后 `reduceAndApplyMain` 跳过 state commit，后果是双重的：subagent 消息永久丢失（终局的 `pendingCreates` replay 只覆盖 main 路径），且因为 `state.runs` 没提交，下个事件会**再建一个新 thread**（`threads.source_message_id` 没有 FK，所以建 thread 总是成功）→ 每来一个事件多一条永不 finalize 的 `Processing` 孤儿 thread。

#### 改动

**1. 把 subagent 写入 gate 在「FK parent 真的落库了」上。**

只 flush 批处理器是不够的：batcher 里失败的 create 只通过 `onFailure` 上报（parked 进 `pendingCreates`），`flush` 照样 resolve —— 所以 await 一个 flush 并不能证明 parent 落库了。如果那次 create 真的失败了（比如一次 transient `batchMutate` 错误），我们会一头撞进同一个 FK 违约，跳过 state commit，并在每次重试时再留下一条孤儿 thread。

所以 barrier 走失败账本：**flush → 按插入顺序重放账本 → parent 仍缺失就拒绝写**。重放必须是全账本按序，而不能只补 parent 那一条 —— 一个 signal assistant 挂在 run 的最后一条 **tool** 行上，只重放 parent 本身会再次违反 FK（这正是 `pendingCreates` 原注释强调的「enqueue order IS dependency order」）。

`createThread` 也一并 gate：它自己的 `sourceMessageId` 虽然没有 FK，但在 parent 缺失时放它过去，只会换来一条孤儿 thread —— 紧接着它的 seed `createMessage` 照样失败。

**2. 可测性：把两个单元从 1800 行的 executor 闭包里剥出来。**

`createMessageWriteBatcher` 本来就是个纯 DI 工厂，只是没导出；新增 `createPendingCreateLedger` 承载账本 + FK barrier。两者现在都能独立测，**18 个测试**钉死了导致这次 bug 的失败语义 —— 尤其是「create 失败时 flush 依然 resolve」和「账本按依赖顺序重放」。

**3. 可观测性：`batchMutate` 不再吞掉失败原因。**

之前 catch 里只 `console.error`，返回体没有 `error` 字段，HTTP 还照样 200，客户端只能看到信息量为零的 `failed for 1 operation(s)`，真因只能翻 Vercel 日志。现在把 driver error 的 constraint + SQLSTATE 透传回调用方（drizzle 外层 message 是整条 SQL + params，噪音大且可能带消息正文，所以只取 `cause` 上可操作的部分并截断）。

### 📝 补充信息 | Additional Information

- 新增 18 个前端测试（`messageWriteBatcher` 11 + `pendingCreateLedger` 7）+ server message service 1 个测试锁定 FK cause 透传，全绿。
- root `tsc --noEmit`：本 PR 相关 0 error（仅剩 2 个 `pinyin-pro` 的 pre-existing 缺依赖报错，与本 PR 无关）。
- 仍建议在 desktop 实跑一次「CC spawn subagent」确认控制台不再刷 `Failed to create subagent message` —— 竞态类修复，单测覆盖的是失败语义而非真实时序窗口。
- 本修复只治新 run；线上已积累的孤儿 `Processing` thread 与丢失的 subagent 消息需要单独 backfill / 清理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)