### PR TITLE
🐛 fix: attribute openapi chat billing/tracing to the API key's workspace

### DIFF
--- a/packages/openapi/src/services/chat.service.ts
+++ b/packages/openapi/src/services/chat.service.ts
@@ -1,4 +1,5 @@
 import type { ChatStreamPayload } from '@lobechat/model-runtime';
+import { mergeModelRuntimeHooks } from '@lobechat/model-runtime';
 import type { LobeAgentChatConfig, LobeAgentConfig, UserSystemAgentConfig } from '@lobechat/types';
 import { RequestTrigger } from '@lobechat/types';
 import { and, eq } from 'drizzle-orm';
@@ -10,6 +11,7 @@ import { agents, agentsToSessions, aiModels, aiProviders } from '@/database/sche
 import type { LobeChatDatabase } from '@/database/type';
 import { KeyVaultsGateKeeper } from '@/server/modules/KeyVaultsEncrypt';
 import { initModelRuntimeWithUserPayload } from '@/server/modules/ModelRuntime';
+import { createLLMGenerationTracingHook } from '@/server/services/llmGenerationTracing/hook';
 import { resolveSystemAgentModelConfig } from '@/server/services/systemAgent/modelConfig';
 
 import { BaseService } from '../common/base.service';
@@ -326,8 +328,12 @@ export class ChatService extends BaseService {
     try {
       const { apiKey } = JSON.parse(await this.getApiKey(provider));
 
-      // Create AgentRuntime instance
-      const hooks = getBusinessModelRuntimeHooks(this.userId!, provider);
+      // Create AgentRuntime instance. Pass workspaceId so workspace-key calls
+      // bill the workspace budget (not the key creator's personal budget) and
+      // trace under the workspace, matching initModelRuntimeFromDB.
+      const businessHooks = getBusinessModelRuntimeHooks(this.userId!, provider, this.workspaceId);
+      const tracingHooks = createLLMGenerationTracingHook(this.userId!, provider, this.workspaceId);
+      const hooks = mergeModelRuntimeHooks(businessHooks, tracingHooks);
       const modelRuntime = await initModelRuntimeWithUserPayload(
         provider,
         { apiKey, userId: this.userId! },


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

The OpenAPI chat path (`packages/openapi/src/services/chat.service.ts`) called `getBusinessModelRuntimeHooks(this.userId!, provider)` without `this.workspaceId`. Consequences when calling `/api/v1` chat with a **workspace** API key:

1. **Billing attribution**: resource scoping was workspace-level, but model spend was charged to the key creator's *personal* budget instead of the workspace budget (the business hooks route by `workspaceId`).
2. **Tracing**: this path never composed `createLLMGenerationTracingHook` at all, so REST chat (and `translate()` / `generateReply()`, which route through `chat()`) produced no `llm_generation_tracing` records.

Both diverged from the canonical server path `initModelRuntimeFromDB` (`apps/server/src/modules/ModelRuntime/index.ts:478-483`), which composes `getBusinessModelRuntimeHooks(userId, provider, workspaceId)` + `createLLMGenerationTracingHook(userId, provider, workspaceId)` via `mergeModelRuntimeHooks`. This PR mirrors that composition in the OpenAPI chat service, passing `this.workspaceId` (already held by `BaseService`; controllers pass it from the request context).

#### 🧪 How to Test

- [x] Tested locally

`bun run check` clean. A full audit of `packages/openapi` for the same class of omission found no other gaps: all controllers pass `getWorkspaceId(c)` into services, all service→model/service constructors propagate `this.workspaceId` where supported, DB queries use `buildWorkspaceWhere`, keyVault resolution is workspace-aware, and `responses.service.ts` delegates to the workspace-aware agent-runtime path — this call site was the only remaining one.

#### 📝 Additional Information

Key decision: kept the fix at the call site (mirroring `initModelRuntimeFromDB`'s hook composition) rather than refactoring `chat.service` onto `initModelRuntimeFromDB` itself, because the OpenAPI path resolves its provider keyVaults through its own workspace-scoped query and a refactor would widen the blast radius of this fix. In OSS the business slot returns `undefined`, so behavior only changes where the slot is overridden (cloud billing) and for tracing (no-op when the tracing service is unconfigured).