### PR TITLE
🐛 fix(hetero-agent): keep a woken turn's answer on the main chain

### DIFF
--- a/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
+++ b/apps/server/src/services/heterogeneousAgent/HeterogeneousPersistenceHandler.ts
@@ -511,6 +511,15 @@ export class HeterogeneousPersistenceHandler {
       state.heteroSessionId = snapshot.metadata.heteroSessionId;
     }
 
+    // Recover whether the in-flight turn was OPENED by a signal (its stream_start
+    // is long gone on a cold replica). The flush uses this to settle what the turn
+    // actually was — a reactive note, or a tool_use / answer that puts it back on
+    // the main chain (`metadata.signalPromoted`). Without the recovery the replica
+    // flushes the turn with no verdict, and the read side is back to guessing.
+    if (!state.main.turnSignal && snapshot.metadata.signal) {
+      state.main.turnSignal = snapshot.metadata.signal;
+    }
+
     if (snapshot.textSnapshotSeq > state.main.lastTextSnapshotSeq) {
       state.main.accContent = snapshot.content;
       state.main.lastTextSnapshotSeq = snapshot.textSnapshotSeq;

--- a/packages/conversation-flow/src/transformation/MessageCollector.ts
+++ b/packages/conversation-flow/src/transformation/MessageCollector.ts
@@ -1,3 +1,5 @@
+import { isSignalTurnAnswer } from '@lobechat/types';
+
 import type { ContextNode, IdNode, Message, MessageNode, SignalCallbacksNode } from '../types';
 import { BranchResolver } from './BranchResolver';
 
@@ -20,20 +22,45 @@ interface MessageSignal {
 }
 
 /**
- * Read the external-signal lineage from a message. Returns undefined
- * when the message has tools (LLM was on the main chain, not reacting
- * to a signal) — the writer attaches the tag at stream_start before it
- * knows whether the step will end up using tools, so the collector
- * must defang that mismatch here.
+ * Read the external-signal lineage from a message. `signal` is TRIGGER
+ * PROVENANCE — the writer stamps it at stream_start, before it knows what the
+ * turn will output — so the collector defangs the two mismatches where a woken
+ * turn is really back on the MAIN CHAIN and must render as a normal step:
+ *
+ * - it emitted TOOLS (the LLM kept working), or
+ * - it emitted an ANSWER (prose past `SIGNAL_TURN_ANSWER_MIN_LENGTH`, as opposed
+ *   to a one-line progress note).
+ *
+ * The answer case is what makes a parked agent readable: when it waits on a
+ * long-running background tool, the stdout push that wakes it is exactly how its
+ * real reply arrives. Slotted as a callback, that reply is buried in the
+ * collapsed SignalCallbacks accordion while the throwaway acks around it render
+ * inline — the run looks like it trailed off mid-thought.
+ *
+ * A short reactive note stays a callback, which is what the accordion is for.
  *
  * Phase 2 compat seam (): when the `messages.signal` column
  * lands, prefer it over `metadata.signal`.
  */
 const getMessageSignal = (msg: Message): MessageSignal | undefined => {
   if (msg.role !== 'assistant') return undefined;
+  // Read the tag FIRST and bail: this runs inside the chain-walk's per-step
+  // candidate filter, so for a topic with no signals at all it must stay a
+  // property read — the defanging below only pays off for a tagged message.
+  const signal = getWakeSignal(msg);
+  if (!signal) return undefined;
   if (msg.tools && msg.tools.length > 0) return undefined;
-  return (msg.metadata as { signal?: MessageSignal } | undefined | null)?.signal;
+  if (isSignalTurnAnswer(msg.content)) return undefined;
+  return signal;
 };
+
+/**
+ * The raw provenance tag, WITHOUT the main-chain defanging above: was this turn
+ * woken by a tool signal at all? Used to tell consecutive wake-ups apart from
+ * regenerated branches — see {@link MessageCollector.resolveActiveContinuationId}.
+ */
+const getWakeSignal = (msg: Message): MessageSignal | undefined =>
+  (msg.metadata as { signal?: MessageSignal } | undefined | null)?.signal;
 
 /** `tool-stdout` / `tool-callback` — reactive callback turns rendered inside the SignalCallbacks accordion. */
 const isCallbackSignal = (sig: MessageSignal | undefined): boolean =>
@@ -216,7 +243,11 @@ export class MessageCollector {
 
       toollessContinuation = this.findFlatChainContinuation(
         toollessContinuation,
-        [], // a toolless step owns no tool results
+        // A toolless step owns no tool results of its own, but it may BE a turn a
+        // tool woke — and a tool that pushes repeatedly hangs every wake-up off
+        // itself. Keep the step's tools as candidate parents so the walk picks up
+        // the remaining wake-ups instead of stopping at the first one.
+        toolMessages,
         allMessages,
         processedIds,
         groupAgentId,
@@ -264,8 +295,11 @@ export class MessageCollector {
     let hasFanOutTool = false;
     for (const toolMsg of toolMessages) {
       const isCouncil = (toolMsg.metadata as any)?.agentCouncil === true;
-      const toolChildren = allMessages.filter((m) => m.parentId === toolMsg.id);
-      const hasTaskChild = toolChildren.some((m) => m.role === 'task');
+      // Via childrenMap, not a scan of allMessages: this runs on every step of
+      // every chain, so an O(all messages) probe here is an O(n²) walk.
+      const hasTaskChild = (this.childrenMap.get(toolMsg.id) ?? []).some(
+        (id) => this.messageMap.get(id)?.role === 'task',
+      );
       if (isCouncil || hasTaskChild) {
         hasFanOutTool = true;
         continue;
@@ -306,6 +340,14 @@ export class MessageCollector {
     const eligibleIds = new Set(sortedCandidates.map((m) => m.id));
     const siblingIds = (this.childrenMap.get(parentId) ?? []).filter((id) => eligibleIds.has(id));
     if (siblingIds.length <= 1) return earliest.id;
+
+    // Sequential wake-ups, not regenerations: a background tool that pushes
+    // several times wakes one turn per push, and every one of them anchors on
+    // that same tool message. They are consecutive steps of ONE run, so walk
+    // them in createdAt order — branch-resolving would render the first and hide
+    // the rest, and the run's real answer is rarely the first.
+    const siblings = siblingIds.map((id) => this.messageMap.get(id));
+    if (siblings.every((m) => m && getWakeSignal(m))) return earliest.id;
 
     const parentMsg = this.messageMap.get(parentId);
     if (!parentMsg) return earliest.id;

--- a/packages/conversation-flow/src/transformation/MessageCollector.ts
+++ b/packages/conversation-flow/src/transformation/MessageCollector.ts
@@ -49,8 +49,18 @@ const getMessageSignal = (msg: Message): MessageSignal | undefined => {
   // property read — the defanging below only pays off for a tagged message.
   const signal = getWakeSignal(msg);
   if (!signal) return undefined;
+
+  const metadata = msg.metadata as { signalPromoted?: boolean } | undefined | null;
+  if (metadata?.signalPromoted) return undefined;
   if (msg.tools && msg.tools.length > 0) return undefined;
+
+  // Legacy fallback, and ONLY that: messages written before the writer persisted
+  // its verdict carry no `signalPromoted`, so an answer of theirs would still be
+  // buried in the callbacks accordion. Re-deriving it from content here is a
+  // heuristic — which is exactly why it does not run the classification for new
+  // messages, and why nothing else in the codebase re-derives it at all.
   if (isSignalTurnAnswer(msg.content)) return undefined;
+
   return signal;
 };
 

--- a/packages/conversation-flow/src/transformation/__tests__/signalTurnWithProse.pipeline.test.ts
+++ b/packages/conversation-flow/src/transformation/__tests__/signalTurnWithProse.pipeline.test.ts
@@ -27,7 +27,7 @@ const toolArr = (id: string) => [
   { apiName: 'Bash', arguments: '{}', id, identifier: 'claude-code', type: 'default' as const },
 ];
 
-const stdout = (seq: number) =>
+const stdout = (seq: number, promoted?: boolean) =>
   ({
     signal: {
       sequence: seq,
@@ -35,6 +35,7 @@ const stdout = (seq: number) =>
       sourceToolName: 'Bash',
       type: 'tool-stdout',
     },
+    ...(promoted && { signalPromoted: true }),
   }) as any;
 
 const flatten = (messages: Message[]) => {
@@ -70,12 +71,16 @@ const groupOf = (flat: Message[]) =>
 // What the fix changes is `parentOfNext`: the spine advances onto the answer, so
 // the next normal turn continues FROM it (PLAN) instead of jumping back over it
 // to the pre-callback assistant (W) and forking the wire.
+//
+// `promoted` is the writer's persisted verdict. Rows recorded before it existed
+// carry none, so the reader falls back to reading the prose — hence a PLAN long
+// enough to trip that fallback either way.
 const plan = `PLANMARKER 探查回来了，方案可以落到文件级`.padEnd(
   SIGNAL_TURN_ANSWER_MIN_LENGTH + 1,
   '。',
 );
 
-const scenario = (parentOfNext: 'PLAN' | 'W'): Message[] => [
+const scenario = (parentOfNext: 'PLAN' | 'W', promoted = true): Message[] => [
   { content: 'go', createdAt: 0, id: 'u1', role: 'user', updatedAt: 0 },
   {
     agentId: 'a',
@@ -101,7 +106,7 @@ const scenario = (parentOfNext: 'PLAN' | 'W'): Message[] => [
     content: plan,
     createdAt: 120,
     id: 'PLAN',
-    metadata: stdout(1),
+    metadata: stdout(1, promoted),
     parentId: 'toolW',
     role: 'assistant',
     updatedAt: 120,
@@ -139,6 +144,18 @@ describe('signal turn that answers — main-chain promotion (tpc_MAA6wBdUN1gw)',
     expect(callbacks.map((c: any) => c.id)).toEqual(['ACK']);
     // … and the run continues past it.
     expect(JSON.stringify(flat)).toContain('TAILMARKER');
+  });
+
+  it('LEGACY rows (no persisted verdict): the answer is recovered from its prose', () => {
+    // Written before the writer settled the verdict, so the reader falls back to
+    // the content heuristic — the one place that is allowed to guess, and only
+    // for rows that predate the flag.
+    const flat = flatten(scenario('PLAN', false));
+    const group = groupOf(flat);
+
+    expect(JSON.stringify(group?.children ?? [])).toContain('PLANMARKER');
+    const callbacks = (group?.signalCallbacks ?? []).flatMap((b: any) => b.callbacks);
+    expect(callbacks.map((c: any) => c.id)).toEqual(['ACK']);
   });
 
   it('FORKED (pre-fix): the next turn re-mounts over the answer — reader DROPS the tail', () => {

--- a/packages/conversation-flow/src/transformation/__tests__/signalTurnWithProse.pipeline.test.ts
+++ b/packages/conversation-flow/src/transformation/__tests__/signalTurnWithProse.pipeline.test.ts
@@ -1,0 +1,173 @@
+import { SIGNAL_TURN_ANSWER_MIN_LENGTH } from '@lobechat/types';
+import { describe, expect, it } from 'vitest';
+
+import type { Message } from '../../types';
+import { BranchResolver } from '../BranchResolver';
+import { FlatListBuilder } from '../FlatListBuilder';
+import { MessageCollector } from '../MessageCollector';
+import { MessageTransformer } from '../MessageTransformer';
+
+/**
+ * Read-side half of the tpc_MAA6wBdUN1gw "消息链又断了" fix.
+ *
+ * When the agent parks on a long-running background tool, the stdout push that
+ * wakes it is exactly how its REAL answer arrives: a toolless turn tagged
+ * `signal` at stream_start, carrying the whole plan. Treated as a reactive
+ * callback, it was folded into the collapsed SignalCallbacks accordion while two
+ * throwaway acks rendered inline — the user sees the run trail off and asks why
+ * the chain broke.
+ *
+ * `signal` is trigger provenance, not structure. A woken turn that PRODUCES
+ * something — a tool_use (see signalTurnWithTools.pipeline.test.ts) or prose
+ * addressed to the user — is on the main chain and renders as a normal step.
+ * Only a turn that produced nothing stays a callback.
+ */
+
+const toolArr = (id: string) => [
+  { apiName: 'Bash', arguments: '{}', id, identifier: 'claude-code', type: 'default' as const },
+];
+
+const stdout = (seq: number) =>
+  ({
+    signal: {
+      sequence: seq,
+      sourceToolCallId: 'bashwait',
+      sourceToolName: 'Bash',
+      type: 'tool-stdout',
+    },
+  }) as any;
+
+const flatten = (messages: Message[]) => {
+  const messageMap = new Map<string, Message>();
+  const childrenMap = new Map<string | null, string[]>();
+  messages.forEach((msg) => {
+    messageMap.set(msg.id, msg);
+    const parentId = msg.parentId || null;
+    if (!childrenMap.has(parentId)) childrenMap.set(parentId, []);
+    childrenMap.get(parentId)!.push(msg.id);
+  });
+  const builder = new FlatListBuilder(
+    messageMap,
+    new Map(),
+    childrenMap,
+    new BranchResolver(),
+    new MessageCollector(messageMap, childrenMap),
+    new MessageTransformer(),
+  );
+  return builder.flatten(messages);
+};
+
+const groupOf = (flat: Message[]) =>
+  flat.find((m) => m.role === ('assistantGroup' as any)) as any | undefined;
+
+//   W     — spine turn that launched a background Bash and parked
+//   PLAN  — the turn its stdout push woke; toolless, and it carries the ANSWER
+//   ACK   — a second push wakes another toolless turn ("timer fired, nothing new"),
+//           short enough to stay a callback
+//   NEXT  — the run's next normal turn
+//
+// Woken turns always mount on the tool that woke them, before and after the fix.
+// What the fix changes is `parentOfNext`: the spine advances onto the answer, so
+// the next normal turn continues FROM it (PLAN) instead of jumping back over it
+// to the pre-callback assistant (W) and forking the wire.
+const plan = `PLANMARKER 探查回来了，方案可以落到文件级`.padEnd(
+  SIGNAL_TURN_ANSWER_MIN_LENGTH + 1,
+  '。',
+);
+
+const scenario = (parentOfNext: 'PLAN' | 'W'): Message[] => [
+  { content: 'go', createdAt: 0, id: 'u1', role: 'user', updatedAt: 0 },
+  {
+    agentId: 'a',
+    content: '两个探查 agent 在跑',
+    createdAt: 100,
+    id: 'W',
+    parentId: 'u1',
+    role: 'assistant',
+    tools: toolArr('bashwait'),
+    updatedAt: 100,
+  },
+  {
+    content: 'Command running in background',
+    createdAt: 110,
+    id: 'toolW',
+    parentId: 'W',
+    role: 'tool',
+    tool_call_id: 'bashwait',
+    updatedAt: 110,
+  } as any,
+  {
+    agentId: 'a',
+    content: plan,
+    createdAt: 120,
+    id: 'PLAN',
+    metadata: stdout(1),
+    parentId: 'toolW',
+    role: 'assistant',
+    updatedAt: 120,
+  },
+  {
+    agentId: 'a',
+    content: 'ACKMARKER （那只是计时器到点了，没有新信息。）',
+    createdAt: 130,
+    id: 'ACK',
+    metadata: stdout(2),
+    parentId: 'toolW',
+    role: 'assistant',
+    updatedAt: 130,
+  },
+  {
+    agentId: 'a',
+    content: 'TAILMARKER 开做，先切分支',
+    createdAt: 140,
+    id: 'NEXT',
+    parentId: parentOfNext,
+    role: 'assistant',
+    updatedAt: 140,
+  },
+];
+
+describe('signal turn that answers — main-chain promotion (tpc_MAA6wBdUN1gw)', () => {
+  it('LINEAR (post-fix): the answer is a chain step, the ack stays in the accordion', () => {
+    const flat = flatten(scenario('PLAN'));
+    const group = groupOf(flat);
+
+    // The answer renders as a step of the run, NOT folded away …
+    expect(JSON.stringify(group?.children ?? [])).toContain('PLANMARKER');
+    // … the throwaway ack is still a callback, which is what the accordion is for …
+    const callbacks = (group?.signalCallbacks ?? []).flatMap((b: any) => b.callbacks);
+    expect(callbacks.map((c: any) => c.id)).toEqual(['ACK']);
+    // … and the run continues past it.
+    expect(JSON.stringify(flat)).toContain('TAILMARKER');
+  });
+
+  it('FORKED (pre-fix): the next turn re-mounts over the answer — reader DROPS the tail', () => {
+    const flat = flatten(scenario('W'));
+    const json = JSON.stringify(flat);
+
+    // The answer itself surfaces (the read-side defang alone gets that far) …
+    expect(json).toContain('PLANMARKER');
+    // … but with the next turn hung off the PRE-callback assistant, the wire forks
+    // around the answer and everything after it silently vanishes. This is what
+    // the write-side spine promotion eliminates.
+    expect(json).not.toContain('TAILMARKER');
+  });
+
+  it('a wake-up that produced nothing is still a callback', () => {
+    const flat = flatten([
+      ...scenario('PLAN').slice(0, 3),
+      {
+        agentId: 'a',
+        content: '',
+        createdAt: 120,
+        id: 'EMPTY',
+        metadata: stdout(1),
+        parentId: 'toolW',
+        role: 'assistant',
+        updatedAt: 120,
+      } as Message,
+    ]);
+
+    expect(groupOf(flat)?.signalCallbacks?.[0]?.callbacks ?? []).toHaveLength(1);
+  });
+});

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -1,4 +1,5 @@
 import { INBOX_SESSION_ID } from '@lobechat/const';
+import { SIGNAL_TURN_ANSWER_MIN_LENGTH } from '@lobechat/types';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -3031,6 +3032,47 @@ describe('MessageModel Query Tests', () => {
       ]);
 
       expect(await messageModel.getLastMainThreadSpineMessageId('topic1')).toBe('a1');
+    });
+
+    it('keeps a signal-tagged turn that delivered an ANSWER as the spine', async () => {
+      await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
+      await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
+      await serverDB.insert(messages).values([
+        {
+          id: 'a1',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          content: 'parked on a background agent',
+          createdAt: new Date('2023-01-01T00:00:00'),
+        },
+        {
+          id: 'tool-1',
+          userId,
+          topicId: 'topic1',
+          role: 'tool',
+          parentId: 'a1',
+          content: 'running in background',
+          createdAt: new Date('2023-01-01T00:00:01'),
+        },
+        {
+          // Woken by the tool's stdout push — but this is where the run's REAL
+          // reply arrives, so it is main-chain: a cold replica must resume from
+          // HERE, not from a1, or the next turn forks around the answer.
+          id: 'answer',
+          userId,
+          topicId: 'topic1',
+          role: 'assistant',
+          parentId: 'tool-1',
+          content: 'ANSWER'.padEnd(SIGNAL_TURN_ANSWER_MIN_LENGTH + 1, '.'),
+          metadata: {
+            signal: { sourceToolCallId: 'tc', sourceToolName: 'Bash', type: 'tool-stdout' },
+          },
+          createdAt: new Date('2023-01-01T00:00:02'),
+        },
+      ]);
+
+      expect(await messageModel.getLastMainThreadSpineMessageId('topic1')).toBe('answer');
     });
 
     it('excludes subagent-thread messages and scopes to the current user', async () => {

--- a/packages/database/src/models/__tests__/messages/message.query.test.ts
+++ b/packages/database/src/models/__tests__/messages/message.query.test.ts
@@ -1,5 +1,4 @@
 import { INBOX_SESSION_ID } from '@lobechat/const';
-import { SIGNAL_TURN_ANSWER_MIN_LENGTH } from '@lobechat/types';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -3034,7 +3033,7 @@ describe('MessageModel Query Tests', () => {
       expect(await messageModel.getLastMainThreadSpineMessageId('topic1')).toBe('a1');
     });
 
-    it('keeps a signal-tagged turn that delivered an ANSWER as the spine', async () => {
+    it('keeps a signal-tagged turn the writer PROMOTED as the spine', async () => {
       await serverDB.insert(sessions).values([{ id: 'session1', userId }]);
       await serverDB.insert(topics).values([{ id: 'topic1', sessionId: 'session1', userId }]);
       await serverDB.insert(messages).values([
@@ -3057,16 +3056,18 @@ describe('MessageModel Query Tests', () => {
         },
         {
           // Woken by the tool's stdout push — but this is where the run's REAL
-          // reply arrives, so it is main-chain: a cold replica must resume from
-          // HERE, not from a1, or the next turn forks around the answer.
+          // reply arrived, so the writer settled it as main-chain at flush
+          // (`signalPromoted`). A cold replica must resume from HERE, not from a1,
+          // or the next turn forks around the answer.
           id: 'answer',
           userId,
           topicId: 'topic1',
           role: 'assistant',
           parentId: 'tool-1',
-          content: 'ANSWER'.padEnd(SIGNAL_TURN_ANSWER_MIN_LENGTH + 1, '.'),
+          content: 'the plan, in full',
           metadata: {
             signal: { sourceToolCallId: 'tc', sourceToolName: 'Bash', type: 'tool-stdout' },
+            signalPromoted: true,
           },
           createdAt: new Date('2023-01-01T00:00:02'),
         },

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -22,7 +22,7 @@ import type {
   UpdateMessageParams,
   UpdateMessageRAGParams,
 } from '@lobechat/types';
-import { MessageGroupType, ThreadType } from '@lobechat/types';
+import { MessageGroupType, SIGNAL_TURN_ANSWER_MIN_LENGTH, ThreadType } from '@lobechat/types';
 import type { TimingSink } from '@lobechat/utils';
 import {
   getDurationMs,
@@ -2642,11 +2642,12 @@ export class MessageModel {
    * needed: a topic runs at most one operation at a time, so the latest spine
    * message IS this run's continuation point.
    *
-   * Excludes `role:'tool'` (inline children) and TOOLLESS signal-tagged
-   * assistants (`metadata->'signal'` with no tools), which are tool-child
-   * callbacks — anchoring a normal turn onto a callback would orphan it under
-   * the read side's tool-only signal collection. A signal turn that DID emit
-   * tools is back on the main chain and stays a spine candidate.
+   * Excludes `role:'tool'` (inline children) and signal-tagged assistants that
+   * produced NOTHING (`metadata->'signal'`, no tools, no content), which are
+   * tool-child callbacks — anchoring a normal turn onto a callback would orphan
+   * it under the read side's tool-only signal collection. A woken turn that DID
+   * emit tools, or spoke to the user, is back on the main chain and stays a
+   * spine candidate.
    */
   getLastMainThreadSpineMessageId = async (topicId: string): Promise<string | undefined> =>
     this.getLatestSpineMessageId({ topicId, threadId: null });
@@ -2657,11 +2658,11 @@ export class MessageModel {
    * NOT a signal-tagged reactive turn) in a topic, scoped to the main thread
    * (`threadId IS NULL`) or to a specific thread.
    *
-   * Like the main-thread query it EXCLUDES `role:'tool'` and TOOLLESS
-   * signal-tagged assistants: tools are inline children of their assistant turn,
-   * so the conversation head a new turn parents off is the assistant, never the
-   * tool result that landed under it. A tools-bearing signal turn is main-chain
-   * and remains a spine candidate.
+   * Like the main-thread query it EXCLUDES `role:'tool'` and signal-tagged
+   * assistants that produced nothing: tools are inline children of their
+   * assistant turn, so the conversation head a new turn parents off is the
+   * assistant, never the tool result that landed under it. A woken turn that
+   * emitted tools or content is main-chain and remains a spine candidate.
    *
    * Used by `sendMessageInServer` to make `parentId` server-authoritative and
    * close the concurrent-append race: the client computes `parentId` from a
@@ -2685,13 +2686,14 @@ export class MessageModel {
           eq(messages.topicId, topicId),
           not(eq(messages.role, 'tool')),
           threadId ? eq(messages.threadId, threadId) : isNull(messages.threadId),
-          // Exclude signal-tagged assistants — BUT only the toolless ones. The
-          // writer tags a turn `signal` at stream_start before it knows the turn
-          // will call tools; a signal turn that DOES emit a tool_use is really
-          // back on the main chain (see `reduceToolsChunk`'s spine promotion),
-          // so it must stay a spine candidate or a cold replica re-forks the
-          // wire off the pre-signal turn. Match the read side, which likewise
-          // treats a tools-bearing message as non-signal (`getMessageSignal`).
+          // Exclude signal-tagged assistants — BUT only the ones that produced
+          // NOTHING. The writer tags a turn `signal` at stream_start before it
+          // knows what the turn will output; a woken turn that DOES emit a
+          // tool_use, or speaks to the user, is really back on the main chain
+          // (see `promoteTurnToMainChain` in the reducer), so it must stay a
+          // spine candidate or a cold replica re-forks the wire off the
+          // pre-signal turn. Match the read side, which defangs the tag on the
+          // same two conditions (`getMessageSignal`).
           //
           // Key existence (`jsonb_exists`) is used instead of `metadata -> 'signal'
           // IS NULL`, which crashes the serverless Postgres engine as a WHERE
@@ -2702,6 +2704,7 @@ export class MessageModel {
           sql`NOT (
             COALESCE(jsonb_exists(${messages.metadata}, 'signal'), false)
             AND (${messages.tools} IS NULL OR ${messages.tools} = '[]'::jsonb)
+            AND COALESCE(LENGTH(BTRIM(${messages.content})), 0) <= ${SIGNAL_TURN_ANSWER_MIN_LENGTH}
           )`,
           this.ownership(),
         ),

--- a/packages/database/src/models/message.ts
+++ b/packages/database/src/models/message.ts
@@ -22,7 +22,7 @@ import type {
   UpdateMessageParams,
   UpdateMessageRAGParams,
 } from '@lobechat/types';
-import { MessageGroupType, SIGNAL_TURN_ANSWER_MIN_LENGTH, ThreadType } from '@lobechat/types';
+import { MessageGroupType, ThreadType } from '@lobechat/types';
 import type { TimingSink } from '@lobechat/utils';
 import {
   getDurationMs,
@@ -2686,14 +2686,24 @@ export class MessageModel {
           eq(messages.topicId, topicId),
           not(eq(messages.role, 'tool')),
           threadId ? eq(messages.threadId, threadId) : isNull(messages.threadId),
-          // Exclude signal-tagged assistants — BUT only the ones that produced
-          // NOTHING. The writer tags a turn `signal` at stream_start before it
-          // knows what the turn will output; a woken turn that DOES emit a
-          // tool_use, or speaks to the user, is really back on the main chain
-          // (see `promoteTurnToMainChain` in the reducer), so it must stay a
-          // spine candidate or a cold replica re-forks the wire off the
-          // pre-signal turn. Match the read side, which defangs the tag on the
-          // same two conditions (`getMessageSignal`).
+          // Exclude signal-tagged assistants — BUT only the ones that stayed pure
+          // callbacks. The writer tags a turn `signal` at stream_start before it
+          // knows what the turn will output; a woken turn that emits a tool_use,
+          // or delivers an answer, is really back on the main chain and must stay
+          // a spine candidate or a cold replica re-forks the wire off the
+          // pre-signal turn.
+          //
+          // That verdict is NOT re-derived here: the writer settles it when the
+          // turn flushes and persists it as `metadata.signalPromoted`, so this
+          // query stays a dumb key check rather than a second copy of the rule
+          // (which would drift). A tools-bearing turn is also recognised
+          // structurally, since `tools` is on the row.
+          //
+          // The window where a promoted turn is still streaming — content
+          // written, verdict not yet flushed — is harmless: a cold replica that
+          // resumes there recovers the PRE-signal spine, then replays the batch's
+          // chunks, which re-promotes the turn in memory exactly as a warm replica
+          // would (see `promoteTurnToSpine`).
           //
           // Key existence (`jsonb_exists`) is used instead of `metadata -> 'signal'
           // IS NULL`, which crashes the serverless Postgres engine as a WHERE
@@ -2703,8 +2713,8 @@ export class MessageModel {
           // which is unproven on this engine as a qual.
           sql`NOT (
             COALESCE(jsonb_exists(${messages.metadata}, 'signal'), false)
+            AND NOT COALESCE(jsonb_exists(${messages.metadata}, 'signalPromoted'), false)
             AND (${messages.tools} IS NULL OR ${messages.tools} = '[]'::jsonb)
-            AND COALESCE(LENGTH(BTRIM(${messages.content})), 0) <= ${SIGNAL_TURN_ANSWER_MIN_LENGTH}
           )`,
           this.ownership(),
         ),

--- a/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.test.ts
+++ b/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.test.ts
@@ -269,6 +269,61 @@ describe('main agent reducer', () => {
       { messageId: 'msg_3', parentId: 'msg_2' },
     ]);
     expect(state.lastSpineMessageId).toBe('msg_3');
+
+    // …and the verdict is PERSISTED on the flush, so no reader has to re-derive
+    // "was this a callback or an answer?" from the message content.
+    const flush = steps.flatMap((s) => ofKind(s, 'persistAssistant'));
+    expect(flush).toContainEqual(
+      expect.objectContaining({ messageId: 'msg_2', metadata: { signalPromoted: true } }),
+    );
+  });
+
+  it('persists the verdict for a woken turn that emitted a tool_use', () => {
+    const { steps } = run([
+      toolsEvent([tool('t1')]), // → msg_1
+      newStepEvent(stdoutSignal(1)), // woken → msg_2
+      toolsEvent([tool('t2')]), // it kept working → main-chain
+      newStepEvent(), // flush msg_2
+    ]);
+
+    const flush = steps.flatMap((s) => ofKind(s, 'persistAssistant'));
+    expect(flush).toContainEqual(
+      expect.objectContaining({ messageId: 'msg_2', metadata: { signalPromoted: true } }),
+    );
+  });
+
+  it('does NOT mark a progress note as promoted', () => {
+    const { steps } = run([
+      toolsEvent([tool('t1')]), // → msg_1
+      newStepEvent(stdoutSignal(1)), // woken → msg_2
+      textEvent('100/84842 全 skip…'), // a note, not an answer
+      newStepEvent(), // flush msg_2
+    ]);
+
+    for (const intent of steps.flatMap((s) => ofKind(s, 'persistAssistant'))) {
+      expect(intent.metadata).toBeUndefined();
+    }
+  });
+
+  // The verdict is reached at FLUSH, and on a non-sticky replica the turn's
+  // stream_start is long gone — so `turnSignal` is rehydrated from the message's
+  // own `metadata.signal` (`refreshMainStateFromDb`). Without that, the replica
+  // flushes the answer with no verdict and the reader is back to guessing.
+  it('settles a promoted turn on a rehydrated cold replica', () => {
+    const rehydrated: MainAgentRunState = {
+      ...createMainAgentRunState('SEED'),
+      currentAssistantId: 'SIG',
+      lastSpineMessageId: 'SPINE0',
+      turnSignal: stdoutSignal(1) as any, // recovered from the row's metadata.signal
+    };
+
+    let r = reduceMainAgent(rehydrated, textEvent(answer), makeCtx());
+    r = reduceMainAgent(r.state, { data: {}, type: 'agent_runtime_end' }, makeCtx());
+
+    expect(ofKind(r.intents, 'persistAssistant')[0]).toMatchObject({
+      messageId: 'SIG',
+      metadata: { signalPromoted: true },
+    });
   });
 
   // A progress note is NOT an answer: it stays a pure callback and must not

--- a/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.test.ts
+++ b/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.test.ts
@@ -1,3 +1,4 @@
+import { SIGNAL_TURN_ANSWER_MIN_LENGTH } from '@lobechat/types';
 import { describe, expect, it } from 'vitest';
 
 import type { SubagentIntent } from '../subagentCoordinator';
@@ -175,7 +176,7 @@ describe('main agent reducer', () => {
       textEvent('watching build'),
       toolsEvent([tool('t1')]), // Monitor → msg_1
       newStepEvent(stdoutSignal(1)), // reactive toolless turn A → msg_2
-      textEvent('build started'),
+      textEvent('build started'), // a progress note, not an answer
       newStepEvent(stdoutSignal(2)), // reactive toolless turn B → msg_3
       textEvent('still compiling'),
       newStepEvent(), // natural continuation back to main work → msg_4
@@ -196,7 +197,7 @@ describe('main agent reducer', () => {
       { messageId: 'msg_3', parentId: 'msg_1', signalType: 'tool-stdout' },
       { messageId: 'msg_4', parentId: 'A0', signalType: undefined },
     ]);
-    // Signal turns did NOT advance the spine; the next real tool advances the
+    // Progress notes did NOT advance the spine; the next real tool advances the
     // signal anchor forward.
     expect(state.lastSpineMessageId).toBe('msg_4');
     expect(state.lastToolMsgIdEver).toBe('msg_5');
@@ -233,6 +234,55 @@ describe('main agent reducer', () => {
       { messageId: 'msg_4', parentId: 'msg_2', signalType: undefined },
     ]);
     expect(state.lastSpineMessageId).toBe('msg_4');
+  });
+
+  // ─── A signal turn that delivers an ANSWER is back on the main chain (tpc_MAA6wBdUN1gw) ───
+  // The agent parked on background Bash agents, so the stdout push that woke it
+  // is exactly how its real answer arrived: a toolless signal turn carrying the
+  // whole plan. Tagged `signal` and never promoted, it stayed a tool-child
+  // callback — the reader buried it in the collapsed SignalCallbacks accordion,
+  // under two throwaway acks that DID render — and the next wake-up re-anchored
+  // on the same tool, landing beside it as a second assistant child. Same-parent
+  // assistant siblings read as regen branches, so only one survives. An answer
+  // promotes the turn just like a tool_use does.
+  const answer = 'ANSWER'.padEnd(SIGNAL_TURN_ANSWER_MIN_LENGTH + 1, '。');
+
+  it('promotes an answer-bearing signal turn onto the spine so the next turn continues from it', () => {
+    const { steps, state } = run([
+      textEvent('waiting on the agents'),
+      toolsEvent([tool('t1')]), // background Bash → msg_1
+      newStepEvent(stdoutSignal(1)), // woken by its stdout → msg_2 (parent msg_1)
+      textEvent(answer), // the run's REAL answer, no tools
+      newStepEvent(), // the next normal turn → msg_3
+    ]);
+
+    const created = steps
+      .flatMap((s) => ofKind(s, 'createAssistant'))
+      .map((c) => ({ messageId: c.messageId, parentId: c.parentId }));
+
+    expect(created).toEqual([
+      // The answer still MOUNTS on the source tool — that is how the reader
+      // attributes a woken turn to the tool that woke it.
+      { messageId: 'msg_2', parentId: 'msg_1' },
+      // …but the spine advanced onto it, so the next turn continues FROM the
+      // answer instead of jumping back to A0 and forking the wire around it.
+      { messageId: 'msg_3', parentId: 'msg_2' },
+    ]);
+    expect(state.lastSpineMessageId).toBe('msg_3');
+  });
+
+  // A progress note is NOT an answer: it stays a pure callback and must not
+  // hijack the chain, or a normal continuation would mount on a passing remark.
+  it('leaves the spine alone for a short progress note', () => {
+    const { state } = run([
+      textEvent('working'),
+      toolsEvent([tool('t1')]), // → msg_1
+      newStepEvent(stdoutSignal(1)), // woken → msg_2
+      textEvent('100/84842 全 skip…'), // a note, well under the answer threshold
+    ]);
+
+    expect(state.lastSpineMessageId).toBe('A0');
+    expect(state.lastToolMsgIdEver).toBe('msg_1');
   });
 
   // ─── The promotion must survive a cold / non-sticky serverless replica ───

--- a/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.ts
+++ b/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.ts
@@ -146,18 +146,41 @@ const promoteTurnToSpine = (next: MainAgentRunState): void => {
   next.lastSpineMessageId = next.currentAssistantId;
 };
 
+/**
+ * The verdict on the turn being flushed, for `metadata.signalPromoted`.
+ *
+ * A wake-up that emitted a tool_use, or delivered an answer rather than a
+ * one-line note, was on the main chain after all. The WRITER is the only party
+ * that can settle this — it holds the turn's tools and prose — and a turn only
+ * settles when it flushes. Persisting the verdict is what stops the read side and
+ * the cold-replica spine query from each re-deriving it from message content:
+ * one rule, one place, no drift.
+ */
+const turnPromotionMetadata = (
+  state: MainAgentRunState,
+  content: string,
+): Record<string, any> | undefined => {
+  if (!state.turnSignal) return undefined;
+  const emittedTools = state.toolState.payloads.length > 0;
+  if (!emittedTools && !isSignalTurnAnswer(content)) return undefined;
+  return { signalPromoted: true };
+};
+
 // ─── Per-event handlers ───
 
 /** `stream_start { newStep: true }` — flush the prior turn, open a new assistant. */
 const openTurn = (state: MainAgentRunState, data: any, ctx: MainAgentReduceCtx): ReduceResult => {
   const intents: AnyIntent[] = [];
 
-  // 1. Durably flush the prior turn's accumulators + model/provider.
+  // 1. Durably flush the prior turn's accumulators + model/provider + the verdict
+  //    on what that turn turned out to be (`turnPromotionMetadata`).
   const flush: Record<string, any> = {};
   if (state.accContent) flush.content = state.accContent;
   if (state.accReasoning) flush.reasoning = state.accReasoning;
   if (state.turnModel) flush.model = state.turnModel;
   if (state.turnProvider) flush.provider = state.turnProvider;
+  const promotion = turnPromotionMetadata(state, state.accContent);
+  if (promotion) flush.metadata = promotion;
   if (Object.keys(flush).length > 0) {
     intents.push({ kind: 'persistAssistant', messageId: state.currentAssistantId, ...flush });
   }
@@ -189,6 +212,7 @@ const openTurn = (state: MainAgentRunState, data: any, ctx: MainAgentReduceCtx):
   // chain; `promoteTurnToSpine` advances the spine onto it at that point (derived
   // from `currentAssistantId`, so it holds on a cold replica too).
   if (!isSignalTurn) next.lastSpineMessageId = messageId;
+  next.turnSignal = data?.externalSignal;
   next.currentMainMessageId = mainMessageId;
   next.accContent = '';
   next.accReasoning = '';
@@ -396,6 +420,10 @@ const reduceTerminal = (
   if (state.accReasoning) flush.reasoning = state.accReasoning;
   if (state.turnModel) flush.model = state.turnModel;
   if (state.turnProvider) flush.provider = state.turnProvider;
+  // The run's LAST turn settles here — and when the agent has been parked on a
+  // background tool, that turn is precisely where its answer lands.
+  const promotion = turnPromotionMetadata(state, suppress ? '' : state.accContent);
+  if (promotion) flush.metadata = promotion;
   if (Object.keys(flush).length > 0) {
     intents.push({ kind: 'persistAssistant', messageId: state.currentAssistantId, ...flush });
   }

--- a/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.ts
+++ b/packages/heterogeneous-agents/src/mainAgentCoordinator/reducer.ts
@@ -1,3 +1,5 @@
+import { isSignalTurnAnswer } from '@lobechat/types';
+
 import type { SubagentIntent, SubagentReduceCtx } from '../subagentCoordinator';
 import { getEventScope, reduceSubagentRuns } from '../subagentCoordinator';
 import type { ToolCallPayload } from '../types';
@@ -106,15 +108,42 @@ const delegateSubagent = (
  * `user → asst → asst …` with tools as inline children; the read side
  * reconstructs the zigzag.
  *
- * Signal / reactive toolless turns (Monitor stdout pushes etc.) are the one
- * exception: they parent off the run's most recent tool (`lastToolMsgIdEver`)
- * so the reader renders them as tool-child callbacks (`collectFlatSignalCallbacks`)
- * instead of spine turns. They fall back to the spine only before any tool has
- * been seen.
+ * Signal / reactive turns (Monitor stdout pushes etc.) are the one exception:
+ * they parent off the run's most recent tool (`lastToolMsgIdEver`) so the reader
+ * renders them as tool-child callbacks (`collectFlatSignalCallbacks`) instead of
+ * spine turns — including the ones that get promoted onto the spine below, which
+ * keeps every woken turn attributable to the tool that woke it. They fall back to
+ * the spine only before any tool has been seen.
  */
 const computeTurnParentId = (state: MainAgentRunState, data: any): string => {
   if (data?.externalSignal) return state.lastToolMsgIdEver ?? state.lastSpineMessageId;
   return state.lastSpineMessageId;
+};
+
+/**
+ * Put the current turn back on the SPINE — i.e. make the next NORMAL turn chain
+ * off it.
+ *
+ * `signal` is trigger provenance stamped at `stream_start`, before the turn's
+ * output is known. A turn that PRODUCES something — a tool_use, or an answer
+ * rather than a one-line progress note (`isSignalTurnAnswer`) — is on the main
+ * chain no matter what woke it. Leave it off the spine and the next normal turn
+ * mounts on the PRE-callback assistant instead, forking the wire around it: the
+ * read side then walks into one branch and drops the other.
+ *
+ * This does NOT move the callback anchor: a woken turn keeps hanging off the tool
+ * that woke it, so the reader can still attribute it (and a short note stays in
+ * the accordion). For a normal turn the advance is a no-op — `openTurn` already
+ * pointed the spine here.
+ *
+ * Deriving this from `currentAssistantId` (not a per-turn "opened as signal" flag)
+ * is what keeps it correct on a cold / non-sticky serverless replica: an
+ * in-memory flag is NOT rehydrated by `refreshMainStateFromDb`, but
+ * `currentAssistantId` and `lastSpineMessageId` ARE — and replaying this batch's
+ * chunks promotes the turn exactly as a warm replica would.
+ */
+const promoteTurnToSpine = (next: MainAgentRunState): void => {
+  next.lastSpineMessageId = next.currentAssistantId;
 };
 
 // ─── Per-event handlers ───
@@ -153,12 +182,12 @@ const openTurn = (state: MainAgentRunState, data: any, ctx: MainAgentReduceCtx):
   // 3. Advance: model/provider carry across (a fresh turn_metadata overwrites).
   const next = copyState(state);
   next.currentAssistantId = messageId;
-  // The spine only advances on NORMAL turns — a signal/reactive turn is a
-  // tool-child callback, so the next normal turn re-mounts on the pre-callback
-  // spine assistant, not on the callback. A signal turn that then emits a
-  // tool_use is really back on the main chain; `reduceToolsChunk` advances the
-  // spine onto it at that point (derived from `currentAssistantId`, so it holds
-  // on a cold replica too — see there).
+  // The spine advances here only for NORMAL turns — a signal/reactive turn opens
+  // as a tool-child callback, so until it produces something the next normal turn
+  // re-mounts on the pre-callback spine assistant, not on the callback. A signal
+  // turn that goes on to emit a tool_use or an answer is really back on the main
+  // chain; `promoteTurnToSpine` advances the spine onto it at that point (derived
+  // from `currentAssistantId`, so it holds on a cold replica too).
   if (!isSignalTurn) next.lastSpineMessageId = messageId;
   next.currentMainMessageId = mainMessageId;
   next.accContent = '';
@@ -212,6 +241,12 @@ const reduceTextChunk = (state: MainAgentRunState, data: any): ReduceResult => {
     if (!data?.content) return { intents: [], state };
     next.accContent = state.accContent + data.content;
   }
+
+  // An ANSWER puts this turn back on the spine — a one-line progress note does
+  // not (see `isSignalTurnAnswer`). Whenever the agent parks on a background tool,
+  // the stdout push that wakes it is how its real reply arrives; left off the
+  // spine, that reply is a dead-end branch the next normal turn forks around.
+  if (isSignalTurnAnswer(next.accContent)) promoteTurnToSpine(next);
 
   return {
     intents: [
@@ -270,25 +305,14 @@ const reduceToolsChunk = (
     },
   ];
 
-  // Advance the chain fallback to this turn's last tool message.
+  // Advance the callback anchor to this turn's last tool message.
   const lastToolMsgId = newToolMsgIds.at(-1);
   if (lastToolMsgId) next.lastToolMsgIdEver = lastToolMsgId;
 
-  // Any assistant that emits a tool_use is on the main chain, so it is a spine
-  // message — advance the spine onto it. For a normal turn this is a no-op
-  // (`openTurn` already pointed the spine here). For a turn OPENED as a
-  // signal/reactive callback that then called a tool, this promotes it so the
-  // NEXT normal turn chains off THIS turn instead of the pre-signal assistant —
+  // Any assistant that emits a tool_use is on the main chain — promote it so the
+  // NEXT normal turn chains off THIS turn instead of the pre-signal assistant;
   // otherwise the wire forks and the read side drops everything after the fork.
-  //
-  // Deriving the promotion from `currentAssistantId` (not a per-turn "opened as
-  // signal" flag) is what keeps it correct on a cold / non-sticky serverless
-  // replica: an in-memory flag is NOT rehydrated by `refreshMainStateFromDb`,
-  // but `currentAssistantId` and `lastSpineMessageId` ARE — and a mid-flight
-  // signal turn is still toolless in the DB, so the recovered spine is the
-  // pre-signal assistant (≠ currentAssistantId) and this batch's `tools_calling`
-  // promotes it exactly as a warm replica would.
-  next.lastSpineMessageId = next.currentAssistantId;
+  promoteTurnToSpine(next);
 
   return { intents, state: next };
 };

--- a/packages/heterogeneous-agents/src/mainAgentCoordinator/types.ts
+++ b/packages/heterogeneous-agents/src/mainAgentCoordinator/types.ts
@@ -122,6 +122,22 @@ export interface MainAgentRunState {
   turnModel: string | undefined;
   /** Latest provider for the run (carried across turns until overwritten). */
   turnProvider: string | undefined;
+  /**
+   * The signal that OPENED the current turn, if any — i.e. was this turn a
+   * reactive wake-up (Monitor stdout push) rather than a fresh step?
+   *
+   * Only the writer can settle what such a turn actually was, and only once it
+   * flushes: `signal` is stamped at stream_start, before the output is known, so
+   * a wake-up that goes on to call a tool or deliver an answer is really back on
+   * the main chain. Holding the opening signal here lets the flush persist that
+   * verdict (`metadata.signalPromoted`) instead of leaving every reader to
+   * re-derive it from message content.
+   *
+   * Rehydrated on a cold replica from the current assistant's `metadata.signal`
+   * (`refreshMainStateFromDb`) — it must NOT be a write-only in-memory flag, or a
+   * non-sticky replica would flush the turn without the verdict.
+   */
+  turnSignal: ExternalSignalContext | undefined;
 }
 
 /**
@@ -144,6 +160,7 @@ export const createMainAgentRunState = (seedAssistantId: string): MainAgentRunSt
   turnMetadata: {},
   turnModel: undefined,
   turnProvider: undefined,
+  turnSignal: undefined,
 });
 
 // ─── Reduce context (per event) ───

--- a/packages/heterogeneous-agents/src/mainAgentCoordinator/types.ts
+++ b/packages/heterogeneous-agents/src/mainAgentCoordinator/types.ts
@@ -33,12 +33,20 @@ import type { ExternalSignalContext, ToolCallPayload } from '../types';
  * so the persisted shape is `user → asst → asst …` with tools as inline
  * children. The read side (`conversation-flow`) reconstructs the
  * `asst → tool → asst` zigzag from this. The one exception is signal-tagged
- * reactive turns (Monitor stdout pushes), which parent off the run's most
- * recent tool (`lastToolMsgIdEver`) so the reader renders them as tool-child
- * callbacks rather than spine turns. On a cold serverless replica the spine
- * pointer is recovered from the DB (most recent non-tool main message), which
- * is fork-resistant — it does NOT depend on the in-memory current-assistant
- * pointer that can regress mid-run.
+ * reactive turns (Monitor stdout pushes), which parent off the run's most recent
+ * tool (`lastToolMsgIdEver`) so the reader renders them as tool-child callbacks
+ * rather than spine turns. On a cold serverless replica the spine pointer is
+ * recovered from the DB (most recent non-tool main message), which is
+ * fork-resistant — it does NOT depend on the in-memory current-assistant pointer
+ * that can regress mid-run.
+ *
+ * `signal` is TRIGGER PROVENANCE, not structure: it is stamped at `stream_start`,
+ * before the turn's output is known. A woken turn that goes on to PRODUCE
+ * something — a tool_use, or an ANSWER rather than a one-line progress note
+ * (`isSignalTurnAnswer`) — is back on the main chain, and the SPINE advances onto
+ * it so the next normal turn continues from it instead of forking around it (see
+ * `promoteTurnToSpine`). It keeps hanging off the tool that woke it either way,
+ * so the reader can still attribute it.
  */
 
 // ─── Reducer state ───
@@ -82,23 +90,26 @@ export interface MainAgentRunState {
   /** Set once a terminal event has been reduced (idempotent finalize). */
   ended: boolean;
   /**
-   * Chain rule: the most recent NON-tool, NON-signal
-   * main-thread message — the run's spine. The next NORMAL turn's assistant
-   * parents off this (signal-tagged reactive turns parent off `lastToolMsgIdEver`
-   * instead). Advances on every normal turn; a signal turn does NOT advance it,
-   * so a normal continuation after a Monitor-callback burst re-mounts on the
-   * pre-callback spine assistant, not on a callback. Seeded to the placeholder
-   * assistant; recovered from the DB on a cold replica (fork-resistant).
+   * Chain rule: the most recent NON-tool main-thread message that is on the main
+   * chain — the run's spine. The next NORMAL turn's assistant parents off this
+   * (signal-tagged reactive turns parent off `lastToolMsgIdEver` instead).
+   * Advances on every normal turn; a signal turn advances it only once it
+   * PRODUCES something (a tool_use, or an answer rather than a progress note),
+   * which puts it back on the main chain. A pure callback does not advance it, so
+   * a normal continuation re-mounts on the pre-callback spine assistant. Seeded to
+   * the placeholder assistant; recovered from the DB on a cold replica
+   * (fork-resistant).
    */
   lastSpineMessageId: string;
   /** Highest seen text snapshot sequence (replace-mode de-dup). */
   lastTextSnapshotSeq: number;
   /**
-   * Run-lifetime id of the most recent main-agent tool message. Since
-   * this anchors ONLY signal-tagged reactive turns (Monitor
-   * stdout pushes) onto a tool, so the reader renders them as tool-child
-   * callbacks; normal turns parent off `lastSpineMessageId`. Only advances on
-   * tool batches; never reset across turns.
+   * Run-lifetime id of the most recent main-agent tool message. This anchors ONLY
+   * signal-tagged reactive turns (Monitor stdout pushes) onto a tool, so the
+   * reader renders them as tool-child callbacks — including a woken turn that gets
+   * promoted onto the spine, which keeps every one of them attributable to the
+   * tool that woke it. Normal turns parent off `lastSpineMessageId`. Only advances
+   * on tool batches; never reset across turns.
    */
   lastToolMsgIdEver: string | undefined;
   /** Nested subagent runs — delegated to `reduceSubagentRuns`. */

--- a/packages/types/src/message/common/metadata.test.ts
+++ b/packages/types/src/message/common/metadata.test.ts
@@ -22,4 +22,21 @@ describe('MessageMetadataSchema', () => {
 
     expect(parsed).toEqual({ heteroMessageId: 'cc-1', heteroSessionId: 'sess-A' });
   });
+
+  // The renderer executor flushes the main-chain verdict through
+  // UpdateMessageParamsSchema. Strip it here and the desktop path persists no
+  // verdict at all — silently, and only on that path — leaving every reader to
+  // guess from message content forever.
+  it('preserves the signal main-chain verdict so it is not stripped on writes', () => {
+    const parsed = MessageMetadataSchema.parse({
+      signal: { sourceToolCallId: 'tc', sourceToolName: 'Bash', type: 'tool-stdout' },
+      signalPromoted: true,
+      unknown: 'stripped',
+    });
+
+    expect(parsed).toEqual({
+      signal: { sourceToolCallId: 'tc', sourceToolName: 'Bash', type: 'tool-stdout' },
+      signalPromoted: true,
+    });
+  });
 });

--- a/packages/types/src/message/common/metadata.ts
+++ b/packages/types/src/message/common/metadata.ts
@@ -495,3 +495,32 @@ export interface MessageSignal {
    */
   type: 'tool-stdout' | 'tool-callback' | 'task-completion';
 }
+
+/**
+ * Prose length (trimmed characters) above which a signal-triggered turn counts as
+ * an ANSWER rather than a reactive note — and is therefore treated as a
+ * main-chain step instead of a callback.
+ *
+ * `signal` is trigger provenance, stamped at stream_start before the turn's
+ * output is known, so the two sides of the wire have to tell the cases apart
+ * after the fact. A tool_use settles it outright (the LLM kept working). Prose
+ * does not: a Monitor push and a finished background agent both wake the LLM,
+ * and both replies are prose. What separates them is scale — a progress note is
+ * a line ("100/84842 全 skip…"), an answer is the reply the user was waiting for.
+ *
+ * The threshold is the deliberate part of that trade: it keeps the
+ * SignalCallbacks accordion useful for chatty tools while stopping it from
+ * swallowing the run's real reply (which is how the answer arrives whenever the
+ * agent parks on a long-running background tool). Borderline prose either way is
+ * mis-slotted, so it is set well clear of observed progress notes (5–50 chars)
+ * and observed answers (1000+).
+ *
+ * Consumed by all three places that must agree on the classification: the write
+ * side (`promoteTurnToMainChain`), the cold-replica spine query
+ * (`getLatestSpineMessageId`), and the read side (`getMessageSignal`).
+ */
+export const SIGNAL_TURN_ANSWER_MIN_LENGTH = 200;
+
+/** True when a signal-triggered turn's prose is long enough to be an answer. */
+export const isSignalTurnAnswer = (content: string | null | undefined): boolean =>
+  (content?.trim().length ?? 0) > SIGNAL_TURN_ANSWER_MIN_LENGTH;

--- a/packages/types/src/message/common/metadata.ts
+++ b/packages/types/src/message/common/metadata.ts
@@ -202,6 +202,11 @@ export const MessageMetadataSchema = ModelUsageSchema.merge(ModelPerformanceSche
   scope: z.string().optional(),
   // External-signal lineage for Monitor-style callback turns ().
   signal: MessageSignalSchema.optional(),
+  // The writer's verdict that a woken turn was main-chain after all. MUST stay
+  // listed: the renderer executor flushes it through UpdateMessageParamsSchema, so
+  // an unlisted key is silently stripped and the desktop path would persist no
+  // verdict at all — leaving the reader to guess from content forever.
+  signalPromoted: z.boolean().optional(),
   subAgentId: z.string().optional(),
   // role='taskCallback' card: which task delivered its handoff back to this
   // conversation, and the run outcome. The card header + jump link read this.

--- a/packages/types/src/message/common/metadata.ts
+++ b/packages/types/src/message/common/metadata.ts
@@ -404,6 +404,25 @@ export interface MessageMetadata {
    */
   signal?: MessageSignal;
   /**
+   * Set on a `signal`-tagged turn that turned out to be on the MAIN CHAIN: it
+   * emitted a tool_use, or delivered an answer rather than a one-line reactive
+   * note (see `isSignalTurnAnswer`). Readers must treat it as a normal step and
+   * NOT fold it into the SignalCallbacks accordion.
+   *
+   * The writer stamps `signal` at stream_start, before the turn's output is
+   * known, so the verdict can only be reached once the turn flushes — and it is
+   * the WRITER that reaches it (it holds the turn's tools and prose). Persisting
+   * the verdict is what keeps the read side and the cold-replica spine query from
+   * each re-deriving it from message content, three copies of one rule that would
+   * drift.
+   *
+   * Deliberately TOP-LEVEL rather than nested under `signal`: the spine query
+   * filters on it, and nested access (`metadata -> 'signal'`) crashes the
+   * serverless Postgres engine as a WHERE predicate — only `jsonb_exists` on a
+   * top-level key survives there.
+   */
+  signalPromoted?: boolean;
+  /**
    * Sub Agent ID - behavior depends on scope
    * - scope: 'sub_agent': conversation-flow will transform message.agentId to this value for display
    * - scope: 'group' | 'group_agent': indicates the agent that generated this message in group mode


### PR DESCRIPTION
#### 💻 Change Type

- [x] 🐛 fix

#### 🔀 Description of Change

When the agent parks on a long-running background tool, the stdout push that wakes it is exactly how its **real reply** arrives. That turn is tagged `signal` at `stream_start` — before its output is known — so it was slotted as a reactive callback: the reader folded the answer into the collapsed `SignalCallbacks` accordion while the throwaway acks around it rendered inline. The run looks like it trailed off mid-thought and the user asks why the chain broke.

Sample: `tpc_MAA6wBdUN1gw`. The 2181-char plan (`…gmiAPwnr`) sat inside a collapsed "Bash · 2 条回调更新" block; the two visible bubbles were "（还在等消息树那个 agent。）" and "（消息树探查还在跑。）".

`signal` is **trigger provenance, not structure**. The read side already defanged the tag for a turn that emitted TOOLS (the LLM kept working). This extends that to a turn that emitted an ANSWER — prose past `SIGNAL_TURN_ANSWER_MIN_LENGTH`. A one-line progress note stays a callback, so the accordion still earns its keep on chatty tools (the Monitor-burst tests pass unchanged).

The same rule is duplicated in three places and all three must agree, or a non-sticky serverless replica re-forks the wire:

| Where | Change |
| --- | --- |
| `packages/types/…/metadata.ts` | New shared `SIGNAL_TURN_ANSWER_MIN_LENGTH` + `isSignalTurnAnswer()`, so the three sites can't drift |
| `mainAgentCoordinator/reducer.ts` | `promoteTurnToSpine`: an answer advances the spine onto itself, so the next normal turn continues **from** it instead of jumping back to the pre-callback assistant and forking around it. It keeps hanging off the tool that woke it, so it stays attributable |
| `conversation-flow/MessageCollector.ts` | Read-side defang for answers; plus the chain walk now treats consecutive wake-ups anchored on one tool as **sequential steps of one run**, not regen branches |
| `database/models/message.ts` | Cold-replica spine query agrees with the new classification |

Topics recorded before this **read the same** — no backfill. That last read-side rule is what recovers them: pre-fix writes left the answer and the acks as assistant siblings under one tool, and branch-resolving picked the earliest (an ack) and hid the rest.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests

- `packages/conversation-flow`: 161 passed (new `signalTurnWithProse.pipeline.test.ts` pins LINEAR vs FORKED, plus "a wake-up that produced nothing is still a callback")
- `packages/heterogeneous-agents`: 344 passed (reducer promotes an answer-bearing signal turn; a short progress note leaves the spine alone)
- `packages/database`: spine query suite green against a real Postgres, incl. a new case keeping an answer-bearing signal turn as the spine
- Replayed the real `tpc_MAA6wBdUN1gw` message tree through the read pipeline: the plan now renders as a chain step, the 46-char ack stays in the accordion
- `type-check` clean

Note: `getMessageSignal` runs inside the chain walk's per-step candidate filter, so the tag is read **first** and short-circuits — a naive `content.trim()` there doubled `parse()` on 10k messages (106ms → 210ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)