### PR TITLE
💄 style: hide 404 status watermark on embedded not-found views

### DIFF
--- a/src/components/404/index.tsx
+++ b/src/components/404/index.tsx
@@ -11,25 +11,28 @@ import { MAX_WIDTH } from '@/const/layoutTokens';
 const NotFound = memo<{
   desc?: string;
   extra?: ReactNode;
+  hideWatermark?: boolean;
   status?: number | string;
   title?: string;
-}>(({ extra, status = 404, title, desc }) => {
+}>(({ extra, hideWatermark, status = 404, title, desc }) => {
   const { t } = useTranslation('error');
   return (
     <Flexbox align={'center'} justify={'center'} style={{ minHeight: '100%', width: '100%' }}>
-      <h1
-        style={{
-          filter: 'blur(8px)',
-          fontSize: `min(${MAX_WIDTH / 3}px, 50vw)`,
-          fontWeight: 'bolder',
-          margin: 0,
-          opacity: 0.12,
-          position: 'absolute',
-          zIndex: 0,
-        }}
-      >
-        {status}
-      </h1>
+      {!hideWatermark && (
+        <h1
+          style={{
+            filter: 'blur(8px)',
+            fontSize: `min(${MAX_WIDTH / 3}px, 50vw)`,
+            fontWeight: 'bolder',
+            margin: 0,
+            opacity: 0.12,
+            position: 'absolute',
+            zIndex: 0,
+          }}
+        >
+          {status}
+        </h1>
+      )}
       <FluentEmoji emoji={'👀'} size={64} />
       <h2 style={{ fontWeight: 'bold', marginTop: '1em', textAlign: 'center' }}>
         {title || t('notFound.title')}

--- a/src/features/AgentNotFound/index.tsx
+++ b/src/features/AgentNotFound/index.tsx
@@ -19,7 +19,7 @@ const BUILTIN_SLUG_SET = new Set<string>(Object.values(BUILTIN_AGENT_SLUGS));
 export const AgentNotFound = memo(() => {
   const { t } = useTranslation('chat');
 
-  return <NotFound desc={t('agentNotFound.desc')} title={t('agentNotFound.title')} />;
+  return <NotFound hideWatermark desc={t('agentNotFound.desc')} title={t('agentNotFound.title')} />;
 });
 
 AgentNotFound.displayName = 'AgentNotFound';

--- a/src/features/FileNotFound/index.tsx
+++ b/src/features/FileNotFound/index.tsx
@@ -13,7 +13,7 @@ import NotFound from '@/components/404';
 const FileNotFound = memo(() => {
   const { t } = useTranslation('file');
 
-  return <NotFound desc={t('notFound.desc')} title={t('notFound.title')} />;
+  return <NotFound hideWatermark desc={t('notFound.desc')} title={t('notFound.title')} />;
 });
 
 FileNotFound.displayName = 'FileNotFound';

--- a/src/features/GroupNotFound/index.tsx
+++ b/src/features/GroupNotFound/index.tsx
@@ -15,7 +15,7 @@ import { agentGroupByIdSelectors, useAgentGroupStore } from '@/store/agentGroup'
 export const GroupNotFound = memo(() => {
   const { t } = useTranslation('chat');
 
-  return <NotFound desc={t('groupNotFound.desc')} title={t('groupNotFound.title')} />;
+  return <NotFound hideWatermark desc={t('groupNotFound.desc')} title={t('groupNotFound.title')} />;
 });
 
 GroupNotFound.displayName = 'GroupNotFound';

--- a/src/routes/(main)/(create)/features/GenerationWorkspace/Content.tsx
+++ b/src/routes/(main)/(create)/features/GenerationWorkspace/Content.tsx
@@ -64,6 +64,7 @@ const Content = ({
     return (
       <Center flex={1} padding={24} width={'100%'}>
         <NotFound
+          hideWatermark
           desc={t('generationTopic.notFound.desc')}
           title={t('generationTopic.notFound.title')}
         />


### PR DESCRIPTION
#### 💻 Change Type

- [x] 💄 style

#### 🔀 Description of Change

Add an optional `hideWatermark` prop to the shared `NotFound` component and enable it for embedded not-found views (`AgentNotFound`, `FileNotFound`, `GroupNotFound`, and the generation workspace's topic not-found state).

These views render inside an existing page layout, where the huge blurred `404` background watermark is visually noisy and misleading (the page itself did load). The full-page 404 route keeps the watermark as before.

#### 🧪 How to Test

- Open a non-existent agent / file / group detail page and check the embedded not-found card no longer shows the blurred `404` background.
- Visit a non-existent route to confirm the full-page 404 still shows the watermark.

- [x] Tested locally
- [x] No tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)