### PR TITLE
🐛 fix(topic): conditionally show attachment deletion

### DIFF
--- a/apps/server/src/routers/lambda/topic.ts
+++ b/apps/server/src/routers/lambda/topic.ts
@@ -53,6 +53,7 @@ const topicProcedure = wsCompatProcedure.use(serverDatabase).use(async (opts) =>
       agentModel: new AgentModel(ctx.serverDB, ctx.userId, wsId),
       agentOperationModel: new AgentOperationModel(ctx.serverDB, ctx.userId, wsId),
       chatGroupModel: new ChatGroupModel(ctx.serverDB, ctx.userId, wsId),
+      fileModel: new FileModel(ctx.serverDB, ctx.userId, wsId),
       heteroSessionImporterRepo: new HeteroSessionImporterRepo(ctx.serverDB, ctx.userId, wsId),
       topicImporterRepo: new TopicImporterRepo(ctx.serverDB, ctx.userId, wsId),
       topicModel: new TopicModel(ctx.serverDB, ctx.userId, wsId),
@@ -478,6 +479,23 @@ export const topicRouter = router({
       return { items: result.items, total: result.total };
     }),
 
+  hasTopicFiles: topicProcedure
+    .use(withScopedPermission('topic:delete'))
+    .input(z.object({ ids: z.array(z.string()).min(1) }))
+    .query(async ({ input, ctx }) => {
+      try {
+        const hasFiles = await ctx.fileModel.hasFilesByTopicIds(input.ids);
+        return { data: { hasFiles }, success: true };
+      } catch (error) {
+        console.error('[topic:hasTopicFiles]', error);
+        throw new TRPCError({
+          cause: error,
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to check topic files',
+        });
+      }
+    }),
+
   hasTopics: topicProcedure.query(async ({ ctx }) => {
     return (await ctx.topicModel.count()) === 0;
   }),
@@ -676,21 +694,22 @@ export const topicRouter = router({
     .mutation(async ({ input, ctx }) => {
       if (!input.removeFiles) return ctx.topicModel.delete(input.id);
 
-      const wsId = ctx.workspaceId ?? undefined;
-      const fileModel = new FileModel(ctx.serverDB, ctx.userId, wsId);
-
       // Collect the topic's deletable attachments BEFORE deleting it — the lookup
       // joins messages, which are cascade-deleted along with the topic. Files
       // still referenced by another topic or the session are intentionally kept.
-      const fileIds = await fileModel.findDeletableFilesByTopicId(input.id);
+      const fileIds = await ctx.fileModel.findDeletableFilesByTopicId(input.id);
 
       const result = await ctx.topicModel.delete(input.id);
 
       if (fileIds.length > 0) {
-        const needToRemove = await fileModel.deleteMany(fileIds, serverDBEnv.REMOVE_GLOBAL_FILE);
+        const needToRemove = await ctx.fileModel.deleteMany(
+          fileIds,
+          serverDBEnv.REMOVE_GLOBAL_FILE,
+        );
         // deleteMany returns only files whose underlying object is no longer
         // referenced by any other file, so the S3 cleanup is reference-safe.
         if (needToRemove && needToRemove.length > 0) {
+          const wsId = ctx.workspaceId ?? undefined;
           const fileService = new FileService(ctx.serverDB, ctx.userId, wsId);
           await fileService.deleteFiles(needToRemove.map((file) => file.url!));
         }

--- a/packages/database/src/models/__tests__/file.test.ts
+++ b/packages/database/src/models/__tests__/file.test.ts
@@ -1692,6 +1692,81 @@ describe('FileModel', () => {
     });
   });
 
+  describe('hasFilesByTopicIds', () => {
+    const sessionId = 'has-topic-files-session';
+    const topicId = 'has-topic-files-topic';
+
+    beforeEach(async () => {
+      await serverDB.insert(sessions).values({ id: sessionId, userId });
+      await serverDB.insert(topics).values({ id: topicId, sessionId, userId });
+      await serverDB
+        .insert(messages)
+        .values({ id: 'has-topic-files-message', role: 'user', topicId, userId });
+    });
+
+    it('returns false when no topic ids are provided', async () => {
+      await expect(fileModel.hasFilesByTopicIds([])).resolves.toBe(false);
+    });
+
+    it('returns false when the topics have no message files', async () => {
+      await expect(fileModel.hasFilesByTopicIds([topicId])).resolves.toBe(false);
+    });
+
+    it('returns true when any selected topic has a message file', async () => {
+      await serverDB.insert(files).values({
+        fileType: 'image/png',
+        id: 'has-topic-files-image',
+        name: 'image.png',
+        size: 1,
+        url: 'has-topic-files-image-key',
+        userId,
+      });
+      await serverDB.insert(messagesFiles).values({
+        fileId: 'has-topic-files-image',
+        messageId: 'has-topic-files-message',
+        userId,
+      });
+
+      await expect(fileModel.hasFilesByTopicIds(['topic-without-files', topicId])).resolves.toBe(
+        true,
+      );
+    });
+
+    it("does not expose another user's topic files", async () => {
+      await serverDB
+        .insert(sessions)
+        .values({ id: 'has-topic-files-other-session', userId: 'user2' });
+      await serverDB.insert(topics).values({
+        id: 'has-topic-files-other-topic',
+        sessionId: 'has-topic-files-other-session',
+        userId: 'user2',
+      });
+      await serverDB.insert(messages).values({
+        id: 'has-topic-files-other-message',
+        role: 'user',
+        topicId: 'has-topic-files-other-topic',
+        userId: 'user2',
+      });
+      await serverDB.insert(files).values({
+        fileType: 'image/png',
+        id: 'has-topic-files-other-image',
+        name: 'other.png',
+        size: 1,
+        url: 'has-topic-files-other-image-key',
+        userId: 'user2',
+      });
+      await serverDB.insert(messagesFiles).values({
+        fileId: 'has-topic-files-other-image',
+        messageId: 'has-topic-files-other-message',
+        userId: 'user2',
+      });
+
+      await expect(fileModel.hasFilesByTopicIds(['has-topic-files-other-topic'])).resolves.toBe(
+        false,
+      );
+    });
+  });
+
   describe('findDeletableFilesByTopicId', () => {
     const sessionId = 'topic-files-session-1';
     const topicId = 'topic-files-topic-1';

--- a/packages/database/src/models/file.ts
+++ b/packages/database/src/models/file.ts
@@ -432,6 +432,33 @@ export class FileModel {
   };
 
   /**
+   * Whether any of the given topics contains a user-owned file attached to a
+   * message. This intentionally checks for attachment presence rather than
+   * deletability: shared files should still be disclosed in the confirmation
+   * UI, while {@link findDeletableFilesByTopicId} remains responsible for
+   * preserving references that survive the topic deletion.
+   */
+  hasFilesByTopicIds = async (topicIds: string[]): Promise<boolean> => {
+    if (topicIds.length === 0) return false;
+
+    const [file] = await this.db
+      .select({ id: messagesFiles.fileId })
+      .from(messagesFiles)
+      .innerJoin(messages, eq(messagesFiles.messageId, messages.id))
+      .innerJoin(files, eq(messagesFiles.fileId, files.id))
+      .where(
+        and(
+          inArray(messages.topicId, topicIds),
+          eq(messagesFiles.userId, this.userId),
+          this.ownership(),
+        ),
+      )
+      .limit(1);
+
+    return Boolean(file);
+  };
+
+  /**
    * Collect the user-uploaded files that should be pre-loaded into a sandbox for
    * the given topic. Combines two associations and de-duplicates by file id:
    * - files attached to messages inside the topic (`messages_files`)

--- a/src/features/AgentTopicManager/BulkActionBar.tsx
+++ b/src/features/AgentTopicManager/BulkActionBar.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { ActionIcon, Flexbox, Text } from '@lobehub/ui';
-import { confirmModal } from '@lobehub/ui/base-ui';
 import { createStaticStyles, cssVar } from 'antd-style';
 import { Archive, Star, Trash2, X } from 'lucide-react';
 import { memo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { confirmRemoveTopic } from '@/features/DeleteTopicConfirm';
 import { useChatStore } from '@/store/chat';
 
 import MoveToAgentButton from './MoveToAgentButton';
@@ -68,19 +68,19 @@ const BulkActionBar = memo(() => {
   }, [selectedIds, updateTopicStatus, exitSelectMode]);
 
   const handleBatchDelete = useCallback(() => {
-    confirmModal({
+    void confirmRemoveTopic({
       content: t('management.bulk.deleteConfirm', { count: selectedIds.length }),
-      okButtonProps: { danger: true },
       okText: t('management.bulk.delete'),
-      onOk: async () => {
+      onConfirm: async (removeFiles) => {
         // Serial removal so each call's optimistic update + refetch resolves
         // cleanly; parallel removeTopic causes cascading refetches.
         for (const id of selectedIds) {
-          await removeTopic(id);
+          await removeTopic(id, removeFiles);
         }
         exitSelectMode();
       },
       title: t('management.bulk.deleteTitle'),
+      topicIds: selectedIds,
     });
   }, [selectedIds, t, removeTopic, exitSelectMode]);
 

--- a/src/features/DeleteTopicConfirm/Content.tsx
+++ b/src/features/DeleteTopicConfirm/Content.tsx
@@ -1,34 +1,38 @@
 'use client';
 
-import { Checkbox, Flexbox } from '@lobehub/ui';
+import { Flexbox } from '@lobehub/ui';
+import { Checkbox } from '@lobehub/ui/base-ui';
+import type { ReactNode } from 'react';
 import { memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface DeleteTopicConfirmContentProps {
   defaultRemoveFiles?: boolean;
+  description?: ReactNode;
   onChange: (removeFiles: boolean) => void;
+  showRemoveFiles: boolean;
 }
 
-const DeleteTopicConfirmContent = memo<DeleteTopicConfirmContentProps>(
-  ({ onChange, defaultRemoveFiles = true }) => {
+export const DeleteTopicConfirmContent = memo<DeleteTopicConfirmContentProps>(
+  ({ description, onChange, showRemoveFiles, defaultRemoveFiles = true }) => {
     const { t } = useTranslation('topic');
     const [checked, setChecked] = useState(defaultRemoveFiles);
 
     return (
       <Flexbox gap={12}>
-        {t('actions.confirmRemoveTopic')}
-        <Checkbox
-          checked={checked}
-          onChange={(value) => {
-            setChecked(value);
-            onChange(value);
-          }}
-        >
-          {t('actions.confirmRemoveTopicFiles')}
-        </Checkbox>
+        {description ?? t('actions.confirmRemoveTopic')}
+        {showRemoveFiles && (
+          <Checkbox
+            checked={checked}
+            onChange={(value) => {
+              setChecked(value);
+              onChange(value);
+            }}
+          >
+            {t('actions.confirmRemoveTopicFiles')}
+          </Checkbox>
+        )}
       </Flexbox>
     );
   },
 );
-
-export default DeleteTopicConfirmContent;

--- a/src/features/DeleteTopicConfirm/index.test.tsx
+++ b/src/features/DeleteTopicConfirm/index.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { topicService } from '@/services/topic';
+
+import { confirmRemoveTopic } from './index';
+
+const confirmModalMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@lobehub/ui/base-ui', () => ({
+  confirmModal: confirmModalMock,
+}));
+
+vi.mock('i18next', () => ({
+  t: (key: string) => key,
+}));
+
+describe('confirmRemoveTopic', () => {
+  beforeEach(() => {
+    confirmModalMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('hides the file option and confirms without file removal when topics have no files', async () => {
+    vi.spyOn(topicService, 'hasTopicFiles').mockResolvedValue(false);
+    const onConfirm = vi.fn();
+
+    await confirmRemoveTopic({ onConfirm, topicIds: ['topic-1'] });
+
+    const config = confirmModalMock.mock.calls[0][0];
+    expect(config.content.props.showRemoveFiles).toBe(false);
+
+    await config.onOk();
+    expect(onConfirm).toHaveBeenCalledWith(false);
+  });
+
+  it('shows the file option and defaults to file removal when a selected topic has files', async () => {
+    vi.spyOn(topicService, 'hasTopicFiles').mockResolvedValue(true);
+    const onConfirm = vi.fn();
+
+    await confirmRemoveTopic({ onConfirm, topicIds: ['topic-1', 'topic-2'] });
+
+    const config = confirmModalMock.mock.calls[0][0];
+    expect(config.content.props.showRemoveFiles).toBe(true);
+
+    await config.onOk();
+    expect(onConfirm).toHaveBeenCalledWith(true);
+  });
+
+  it('shows the file option when attachment presence cannot be determined', async () => {
+    vi.spyOn(topicService, 'hasTopicFiles').mockRejectedValue(new Error('lookup failed'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await confirmRemoveTopic({ onConfirm: vi.fn(), topicIds: ['topic-1'] });
+
+    const config = confirmModalMock.mock.calls[0][0];
+    expect(config.content.props.showRemoveFiles).toBe(true);
+  });
+
+  it('opens the conservative file option when the lookup exceeds 500ms', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(topicService, 'hasTopicFiles').mockReturnValue(new Promise(() => {}));
+
+    const confirmation = confirmRemoveTopic({ onConfirm: vi.fn(), topicIds: ['topic-1'] });
+    expect(confirmModalMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(500);
+    await confirmation;
+
+    const config = confirmModalMock.mock.calls[0][0];
+    expect(config.content.props.showRemoveFiles).toBe(true);
+  });
+});

--- a/src/features/DeleteTopicConfirm/index.test.tsx
+++ b/src/features/DeleteTopicConfirm/index.test.tsx
@@ -27,7 +27,7 @@ describe('confirmRemoveTopic', () => {
     vi.useRealTimers();
   });
 
-  it('hides the file option and confirms without file removal when topics have no files', async () => {
+  it('hides the file option but keeps cleanup enabled when topics have no files', async () => {
     vi.spyOn(topicService, 'hasTopicFiles').mockResolvedValue(false);
     const onConfirm = vi.fn();
 
@@ -36,8 +36,10 @@ describe('confirmRemoveTopic', () => {
     const config = confirmModalMock.mock.calls[0][0];
     expect(config.content.props.showRemoveFiles).toBe(false);
 
+    // Files attached between the precheck snapshot and confirm must still be
+    // cleaned up, so the hidden state confirms with removal enabled.
     await config.onOk();
-    expect(onConfirm).toHaveBeenCalledWith(false);
+    expect(onConfirm).toHaveBeenCalledWith(true);
   });
 
   it('shows the file option and defaults to file removal when a selected topic has files', async () => {

--- a/src/features/DeleteTopicConfirm/index.tsx
+++ b/src/features/DeleteTopicConfirm/index.tsx
@@ -2,34 +2,68 @@
 
 import { confirmModal } from '@lobehub/ui/base-ui';
 import { t } from 'i18next';
+import type { ReactNode } from 'react';
 
-import DeleteTopicConfirmContent from './Content';
+import { topicService } from '@/services/topic';
+
+import { DeleteTopicConfirmContent } from './Content';
+
+const TOPIC_FILE_CHECK_TIMEOUT_MS = 500;
+
+interface ConfirmRemoveTopicOptions {
+  content?: ReactNode;
+  okText?: string;
+  onConfirm: (removeFiles: boolean) => Promise<void> | void;
+  title?: string;
+  topicIds: string[];
+}
 
 /**
- * Open the "delete topic" confirmation dialog. The dialog includes a checkbox —
- * checked by default — to also delete images/files uploaded in the topic, so
- * removing a conversation doesn't leave orphaned attachments in storage.
- *
- * @param onConfirm invoked on confirm with the current checkbox value.
+ * Open the shared topic deletion confirmation. Attachment presence is checked
+ * before the dialog opens; the attachment option is shown only when at least
+ * one selected topic contains an uploaded file. A failed lookup falls back to
+ * showing the option so an unknown state is never mistaken for "no files".
  */
-export const confirmRemoveTopic = (onConfirm: (removeFiles: boolean) => Promise<void> | void) => {
-  // Default to removing attachments to avoid orphaned storage.
-  const state = { removeFiles: true };
+export const confirmRemoveTopic = async ({
+  content,
+  okText,
+  onConfirm,
+  title,
+  topicIds,
+}: ConfirmRemoveTopicOptions): Promise<void> => {
+  let hasFiles = true;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    const timeoutFallback = new Promise<boolean>((resolve) => {
+      timeoutId = setTimeout(() => resolve(true), TOPIC_FILE_CHECK_TIMEOUT_MS);
+    });
+
+    hasFiles = await Promise.race([topicService.hasTopicFiles(topicIds), timeoutFallback]);
+  } catch (error) {
+    console.error('[confirmRemoveTopic]', error);
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+
+  const state = { removeFiles: hasFiles };
 
   confirmModal({
     cancelText: t('cancel', { ns: 'common' }),
     content: (
       <DeleteTopicConfirmContent
+        description={content}
+        showRemoveFiles={hasFiles}
         onChange={(removeFiles) => {
           state.removeFiles = removeFiles;
         }}
       />
     ),
     okButtonProps: { danger: true },
-    okText: t('actions.removeTopic', { ns: 'topic' }),
+    okText: okText ?? t('actions.removeTopic', { ns: 'topic' }),
     onOk: async () => {
       await onConfirm(state.removeFiles);
     },
-    title: t('actions.confirmRemoveTopicTitle', { ns: 'topic' }),
+    title: title ?? t('actions.confirmRemoveTopicTitle', { ns: 'topic' }),
   });
 };

--- a/src/features/DeleteTopicConfirm/index.tsx
+++ b/src/features/DeleteTopicConfirm/index.tsx
@@ -23,6 +23,9 @@ interface ConfirmRemoveTopicOptions {
  * before the dialog opens; the attachment option is shown only when at least
  * one selected topic contains an uploaded file. A failed lookup falls back to
  * showing the option so an unknown state is never mistaken for "no files".
+ *
+ * Cleanup stays enabled when the option is hidden: only an explicit uncheck
+ * opts out of file removal.
  */
 export const confirmRemoveTopic = async ({
   content,
@@ -46,7 +49,11 @@ export const confirmRemoveTopic = async ({
     if (timeoutId !== undefined) clearTimeout(timeoutId);
   }
 
-  const state = { removeFiles: hasFiles };
+  // Cleanup stays enabled even when the option is hidden: the precheck is a
+  // snapshot, and files attached between it and confirm would otherwise be
+  // orphaned. Server-side collection at confirm time is reference-safe and a
+  // no-op when the topic truly has no files.
+  const state = { removeFiles: true };
 
   confirmModal({
     cancelText: t('cancel', { ns: 'common' }),

--- a/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.test.tsx
+++ b/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.test.tsx
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useDropdownMenu } from './useDropdownMenu';
 
-const confirmModalMock = vi.hoisted(() => vi.fn());
+const confirmRemoveTopicMock = vi.hoisted(() => vi.fn());
 const removeTopicMock = vi.hoisted(() => vi.fn());
 const permissionMock = vi.hoisted(() => ({
   create_content: true,
@@ -23,8 +23,8 @@ vi.mock('@lobehub/ui', () => ({
   Icon: () => null,
 }));
 
-vi.mock('@lobehub/ui/base-ui', () => ({
-  confirmModal: confirmModalMock,
+vi.mock('@/features/DeleteTopicConfirm', () => ({
+  confirmRemoveTopic: confirmRemoveTopicMock,
 }));
 
 vi.mock('antd', () => ({
@@ -101,7 +101,7 @@ const getMenuItem = (
 
 describe('PageEditor Copilot TopicSelector useDropdownMenu', () => {
   beforeEach(() => {
-    confirmModalMock.mockReset();
+    confirmRemoveTopicMock.mockReset();
     removeTopicMock.mockReset();
     permissionMock.create_content = true;
     permissionMock.edit_own_content = true;
@@ -180,11 +180,16 @@ describe('PageEditor Copilot TopicSelector useDropdownMenu', () => {
       }),
     );
 
-    getMenuItem(result.current(), 'delete')?.onClick?.();
-    const config = confirmModalMock.mock.calls[0][0];
-    await config.onOk();
+    confirmRemoveTopicMock.mockImplementation(async ({ onConfirm }) => onConfirm(true));
 
-    expect(removeTopicMock).toHaveBeenCalledWith('topic-1');
+    getMenuItem(result.current(), 'delete')?.onClick?.();
+    await vi.waitFor(() => {
+      expect(removeTopicMock).toHaveBeenCalledWith('topic-1', true);
+    });
+
+    expect(confirmRemoveTopicMock).toHaveBeenCalledWith(
+      expect.objectContaining({ topicIds: ['topic-1'] }),
+    );
     expect(onDelete).toHaveBeenCalledWith('topic-1');
     expect(onClose).toHaveBeenCalled();
   });

--- a/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx
+++ b/src/features/PageEditor/Copilot/TopicSelector/useDropdownMenu.tsx
@@ -2,7 +2,6 @@ import { AGENT_CHAT_TOPIC_URL } from '@lobechat/const';
 import type { ChatTopicStatus } from '@lobechat/types';
 import type { MenuProps } from '@lobehub/ui';
 import { Icon } from '@lobehub/ui';
-import { confirmModal } from '@lobehub/ui/base-ui';
 import { App } from 'antd';
 import {
   Archive,
@@ -24,6 +23,7 @@ import { useTranslation } from 'react-i18next';
 import { useActiveWorkspaceSlug } from '@/business/client/hooks/useActiveWorkspaceSlug';
 import { openRenameModal } from '@/components/RenameModal';
 import { isDesktop } from '@/const/version';
+import { confirmRemoveTopic } from '@/features/DeleteTopicConfirm';
 import { openShareModal } from '@/features/ShareModal';
 import { useWorkspaceAwareNavigate } from '@/features/Workspace/useWorkspaceAwareNavigate';
 import { buildWorkspaceAwarePath } from '@/features/Workspace/workspaceAwarePath';
@@ -233,17 +233,13 @@ export const useDropdownMenu = ({
           key: 'delete',
           label: t('delete'),
           onClick: () => {
-            confirmModal({
-              cancelText: t('cancel'),
-              content: t('actions.confirmRemoveTopic', { ns: 'topic' }),
-              okButtonProps: { danger: true },
-              okText: t('delete'),
-              onOk: async () => {
-                await removeTopic(topicId);
+            void confirmRemoveTopic({
+              onConfirm: async (removeFiles) => {
+                await removeTopic(topicId, removeFiles);
                 onDelete?.(topicId);
                 onClose();
               },
-              title: t('delete'),
+              topicIds: [topicId],
             });
           },
         },

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -233,8 +233,11 @@ export const useTopicItemDropdownMenu = ({
         key: 'delete',
         label: t('delete', { ns: 'common' }),
         onClick: () => {
-          confirmRemoveTopic(async (removeFiles) => {
-            await removeTopic(id, removeFiles);
+          void confirmRemoveTopic({
+            onConfirm: async (removeFiles) => {
+              await removeTopic(id, removeFiles);
+            },
+            topicIds: [id],
           });
         },
       },

--- a/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/useMenu.tsx
+++ b/src/routes/(main)/agent/features/Conversation/Header/HeaderActions/useMenu.tsx
@@ -24,6 +24,7 @@ import { useAuthorInfo } from '@/business/client/hooks/useAuthorInfo';
 import { openRenameModal } from '@/components/RenameModal';
 import { DOCUMENT_HISTORY_QUERY_LIST_LIMIT } from '@/const/documentHistory';
 import { isDesktop } from '@/const/version';
+import { confirmRemoveTopic } from '@/features/DeleteTopicConfirm';
 import { openDocumentCompareModal } from '@/features/PageEditor/History/CompareModal';
 import { formatHistoryAbsoluteTime } from '@/features/PageEditor/History/formatHistoryDate';
 import type {
@@ -317,15 +318,11 @@ export const useMenu = (): { menuHeader?: ReactNode; menuItems: DropdownItem[] }
           key: 'delete',
           label: t('delete', { ns: 'common' }),
           onClick: () => {
-            confirmModal({
-              cancelText: t('cancel', { ns: 'common' }),
-              content: t('actions.confirmRemoveTopic', { ns: 'topic' }),
-              okButtonProps: { danger: true },
-              okText: t('delete', { ns: 'common' }),
-              onOk: async () => {
-                await removeTopic(topicId);
+            void confirmRemoveTopic({
+              onConfirm: async (removeFiles) => {
+                await removeTopic(topicId, removeFiles);
               },
-              title: t('delete', { ns: 'common' }),
+              topicIds: [topicId],
             });
           },
         },

--- a/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
+++ b/src/routes/(main)/group/_layout/Sidebar/Topic/List/Item/useDropdownMenu.tsx
@@ -178,8 +178,11 @@ export const useTopicItemDropdownMenu = ({
         key: 'delete',
         label: t('delete', { ns: 'common' }),
         onClick: () => {
-          confirmRemoveTopic(async (removeFiles) => {
-            await removeTopic(id, removeFiles);
+          void confirmRemoveTopic({
+            onConfirm: async (removeFiles) => {
+              await removeTopic(id, removeFiles);
+            },
+            topicIds: [id],
           });
         },
       },

--- a/src/routes/(main)/home/features/Recents/useDropdownMenu.tsx
+++ b/src/routes/(main)/home/features/Recents/useDropdownMenu.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 
 import { useDocumentTransferMenuItem } from '@/business/client/hooks/useDocumentTransferMenuItem';
 import { useTaskTransferMenuItem } from '@/business/client/hooks/useTaskTransferMenuItem';
+import { confirmRemoveTopic } from '@/features/DeleteTopicConfirm';
 import { usePermission } from '@/hooks/usePermission';
 import { type RecentItem } from '@/server/routers/lambda/recent';
 import { documentService } from '@/services/document';
@@ -63,9 +64,20 @@ export const useRecentItemDropdownMenu = (
   );
 
   const handleDelete = useCallback(() => {
+    if (item.type === 'topic') {
+      void confirmRemoveTopic({
+        onConfirm: async (removeFiles) => {
+          // Home has no active agent/group, so chatStore.removeTopic early-returns; call the service directly.
+          await topicService.removeTopic(item.id, removeFiles);
+          await refreshRecents();
+        },
+        topicIds: [item.id],
+      });
+      return;
+    }
+
     const confirmMessages: Record<string, string> = {
       document: t('FileManager.actions.confirmDelete', { ns: 'components' }),
-      topic: t('actions.confirmRemoveTopic', { ns: 'topic' }),
     };
 
     confirmModal({
@@ -75,11 +87,6 @@ export const useRecentItemDropdownMenu = (
       okText: t('delete', { ns: 'common' }),
       onOk: async () => {
         switch (item.type) {
-          case 'topic': {
-            // Home has no active agent/group, so chatStore.removeTopic early-returns; call the service directly
-            await topicService.removeTopic(item.id);
-            break;
-          }
           case 'document': {
             await documentService.deleteDocument(item.id);
             break;

--- a/src/services/topic/index.ts
+++ b/src/services/topic/index.ts
@@ -86,6 +86,11 @@ export class TopicService {
     return lambdaClient.topic.recentTopics.query({ limit });
   };
 
+  hasTopicFiles = async (ids: string[]): Promise<boolean> => {
+    const result = await lambdaClient.topic.hasTopicFiles.query({ ids });
+    return result.data.hasFiles;
+  };
+
   searchTopics = (keywords: string, agentId?: string, groupId?: string): Promise<ChatTopic[]> => {
     return lambdaClient.topic.searchTopics.query({
       agentId,


### PR DESCRIPTION
## Summary

- check whether selected topics contain uploaded attachments before opening the delete confirmation
- hide the attachment deletion option when no attachments are present, with a 500ms conservative fallback
- use the shared confirmation across sidebar, header, recents, bulk management, and Page Copilot deletion entry points
- preserve files that are still referenced by another topic or session

## Why

Topic deletion previously either left uploaded files orphaned or always showed an attachment cleanup option even when the topic had no files. The deletion flow also differed across entry points.

## Validation

- `bun run check <14 changed files>` — 116 tests passed, lint clean
- `bun run check --type` — types clean