### PR TITLE
🐛 fix(desktop): disable macOS vibrancy in fullscreen

### DIFF
--- a/apps/desktop/src/main/core/browser/Browser.ts
+++ b/apps/desktop/src/main/core/browser/Browser.ts
@@ -334,10 +334,12 @@ export default class Browser {
     logger.debug(`[${this.identifier}] Setting up fullscreen event listeners.`);
 
     browserWindow.on('enter-full-screen', () => {
+      this.themeManager.handleFullscreenChange(true);
       this.broadcast('windowFullscreenChanged', { isFullScreen: true });
     });
 
     browserWindow.on('leave-full-screen', () => {
+      this.themeManager.handleFullscreenChange(false);
       this.broadcast('windowFullscreenChanged', { isFullScreen: false });
     });
   }

--- a/apps/desktop/src/main/core/browser/WindowThemeManager.ts
+++ b/apps/desktop/src/main/core/browser/WindowThemeManager.ts
@@ -17,6 +17,8 @@ import {
 
 const logger = createLogger('core:WindowThemeManager');
 
+const MACOS_VIBRANCY: NonNullable<BrowserWindowConstructorOptions['vibrancy']> = 'sidebar';
+
 interface WindowsThemeConfig {
   backgroundColor: string;
   icon?: string;
@@ -102,7 +104,7 @@ export class WindowThemeManager {
 
       return {
         trafficLightPosition: { x: 12, y: trafficLightY },
-        vibrancy: 'sidebar',
+        vibrancy: MACOS_VIBRANCY,
         visualEffectState: 'active',
       };
     }
@@ -156,6 +158,23 @@ export class WindowThemeManager {
     setTimeout(() => {
       this.applyVisualEffects();
     }, THEME_CHANGE_DELAY);
+  }
+
+  /**
+   * Disable macOS vibrancy while fullscreen so the window remains opaque.
+   */
+  handleFullscreenChange(isFullScreen: boolean): void {
+    if (!isMac || !this.browserWindow || this.browserWindow.isDestroyed()) return;
+
+    logger.debug(
+      `[${this.identifier}] Updating macOS vibrancy for fullscreen state: ${isFullScreen}`,
+    );
+
+    try {
+      this.browserWindow.setVibrancy(isFullScreen ? null : MACOS_VIBRANCY);
+    } catch (error) {
+      logger.error(`[${this.identifier}] Failed to update macOS fullscreen vibrancy:`, error);
+    }
   }
 
   // ==================== Visual Effects ====================

--- a/apps/desktop/src/main/core/browser/WindowThemeManager.ts
+++ b/apps/desktop/src/main/core/browser/WindowThemeManager.ts
@@ -17,7 +17,7 @@ import {
 
 const logger = createLogger('core:WindowThemeManager');
 
-const MACOS_VIBRANCY: NonNullable<BrowserWindowConstructorOptions['vibrancy']> = 'sidebar';
+const MACOS_VIBRANCY = 'sidebar';
 
 interface WindowsThemeConfig {
   backgroundColor: string;

--- a/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
+++ b/apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
@@ -37,6 +37,7 @@ const {
     setFullScreen: vi.fn(),
     setPosition: vi.fn(),
     setTitleBarOverlay: vi.fn(),
+    setVibrancy: vi.fn(),
     show: vi.fn(),
     unmaximize: vi.fn(),
     webContents: {
@@ -563,6 +564,27 @@ describe('Browser', () => {
         expect(mockBrowserWindow.webContents.send).toHaveBeenCalledWith('windowFullscreenChanged', {
           isFullScreen: false,
         });
+      });
+
+      it('should disable macOS vibrancy in fullscreen and restore it after leaving', () => {
+        mockEnv.isMac = true;
+        mockEnv.isWindows = false;
+        mockBrowserWindow.on.mockClear();
+
+        new Browser(defaultOptions, mockApp);
+
+        const enterHandler = mockBrowserWindow.on.mock.calls.find(
+          (call) => call[0] === 'enter-full-screen',
+        )?.[1];
+        const leaveHandler = mockBrowserWindow.on.mock.calls.find(
+          (call) => call[0] === 'leave-full-screen',
+        )?.[1];
+
+        enterHandler();
+        expect(mockBrowserWindow.setVibrancy).toHaveBeenLastCalledWith(null);
+
+        leaveHandler();
+        expect(mockBrowserWindow.setVibrancy).toHaveBeenLastCalledWith('sidebar');
       });
     });
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [ ] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

Fixes LOBE-11872

#### 🔀 Description of Change

The macOS desktop window kept its sidebar vibrancy effect when entering native fullscreen, leaving the fullscreen surface translucent and blurred.

This change delegates fullscreen material updates to `WindowThemeManager`:

- disable macOS vibrancy with `setVibrancy(null)` when entering fullscreen;
- restore the configured sidebar vibrancy after leaving fullscreen;
- keep the behavior scoped to macOS and isolate native API failures from the existing fullscreen state broadcast.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

```bash
bun run check apps/desktop/src/main/core/browser/WindowThemeManager.ts apps/desktop/src/main/core/browser/Browser.ts apps/desktop/src/main/core/browser/__tests__/Browser.test.ts
```

Result: lint clean and 65 tests passed.

#### 📸 Screenshots / Videos

N/A — this changes the native macOS window material during the fullscreen transition.

#### 📝 Additional Information

No breaking changes or migration steps are required.
