### PR TITLE
🐛 fix(desktop): persist browser import and prioritize topic status

### DIFF
--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
@@ -20,7 +20,9 @@ vi.mock('@lobehub/ui', () => ({
   Flexbox: ({ children, ...props }: { children?: ReactNode; [key: string]: unknown }) => (
     <div {...props}>{children}</div>
   ),
-  Icon: () => <div data-testid="topic-item-icon" />,
+  Icon: ({ icon }: { icon?: { displayName?: string } }) => (
+    <div data-icon={icon?.displayName} data-testid="topic-item-icon" />
+  ),
   Popover: ({ children }: { children?: ReactNode }) => <>{children}</>,
   Skeleton: {
     Button: (props: Record<string, unknown>) => <div {...props} />,
@@ -333,5 +335,23 @@ describe('TopicItem active state', () => {
 
     expect(screen.queryByTestId('topic-unread-dot')).not.toBeInTheDocument();
     expect(screen.getByTestId('topic-item-icon')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['scheduled', 'Clock'],
+    ['paused', 'CirclePause'],
+    ['completed', 'CircleCheck'],
+  ] as const)('keeps the %s status above linked pull request metadata', (status, icon) => {
+    topicMetaCardMock.value = { pullRequest: { state: 'open' } };
+    useTopicNavigationMock.mockReturnValue({
+      isInAgentSubRoute: false,
+      isInTopicContextRoute: false,
+      navigateToTopic: vi.fn(),
+      routeTopicId: undefined,
+    });
+
+    render(<TopicItem id="tpc_test" status={status} title="Topic" />);
+
+    expect(screen.getByTestId('topic-item-icon')).toHaveAttribute('data-icon', icon);
   });
 });

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
@@ -232,6 +232,22 @@ describe('TopicItem active state', () => {
     expect(screen.getByText('00:33')).toBeInTheDocument();
   });
 
+  it('preserves the masked running-tail icon state for the active topic', () => {
+    agentRuntimeRunningMock.value = true;
+    useTopicNavigationMock.mockReturnValue({
+      isInAgentSubRoute: false,
+      isInTopicContextRoute: true,
+      navigateToTopic: vi.fn(),
+      routeTopicId: 'tpc_test',
+      urlTopicId: 'tpc_test',
+    });
+
+    render(<TopicItem active id="tpc_test" status="running" title="Topic" />);
+
+    expect(screen.queryByTestId('ring-loading')).not.toBeInTheDocument();
+    expect(screen.getByTestId('topic-item-icon')).toHaveAttribute('data-icon', 'Hash');
+  });
+
   it('prefetches messages when a topic is an unread completion', async () => {
     topicUnreadCompletedMock.value = true;
     useTopicNavigationMock.mockReturnValue({

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -427,7 +427,9 @@ const TopicItem = memo<TopicItemProps>(
           // Persisted execution state is the topic's primary status. Keep every
           // non-idle state above git metadata so scheduled / paused / completed
           // topics cannot be mistaken for merely open / merged / closed PRs.
-          if (status && status !== 'active') {
+          // `running` is handled exclusively by shouldShowRunningIcon above so
+          // the masked post-output tail cannot fall back to a static running icon.
+          if (status && status !== 'active' && status !== 'running') {
             const visual = TOPIC_STATUS_VISUALS[status];
             return <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
           }

--- a/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
+++ b/src/routes/(main)/agent/_layout/Sidebar/Topic/List/Item/index.tsx
@@ -286,7 +286,6 @@ const TopicItem = memo<TopicItemProps>(
       title,
     });
 
-    const isCompleted = status === 'completed';
     const isFailed = status === 'failed';
     const isRunning = status === 'running';
     const isWaitingForHuman = status === 'waitingForHuman';
@@ -425,9 +424,16 @@ const TopicItem = memo<TopicItemProps>(
           // in `@lobechat/utils/client/topic`), so it ranks with its two siblings
           // above — and above the PR marker, which shares this single icon slot.
           if (hasUnread) return unreadIcon;
+          // Persisted execution state is the topic's primary status. Keep every
+          // non-idle state above git metadata so scheduled / paused / completed
+          // topics cannot be mistaken for merely open / merged / closed PRs.
+          if (status && status !== 'active') {
+            const visual = TOPIC_STATUS_VISUALS[status];
+            return <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
+          }
           // GitHub PR state marker (open=green, merged=purple, closed=red),
-          // like Codex. Sits below the attention/active states but above the
-          // idle default so an idle topic surfaces its linked PR at a glance.
+          // like Codex. It is secondary metadata, so only an idle topic uses it
+          // as the leading icon.
           if (metaCard?.pullRequest) {
             const prVisual = PR_STATE_VISUAL[getPullRequestState(metaCard.pullRequest)];
             return (
@@ -435,10 +441,6 @@ const TopicItem = memo<TopicItemProps>(
                 <Icon icon={prVisual.icon} size={'small'} style={{ color: prVisual.color }} />
               </Tooltip>
             );
-          }
-          if (isCompleted) {
-            const visual = TOPIC_STATUS_VISUALS.completed;
-            return <Icon icon={visual.icon} size={'small'} style={{ color: visual.color }} />;
           }
           if (metadata?.bot?.platform) {
             const ProviderIcon = getPlatformIcon(metadata.bot!.platform);

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Browser/const.ts
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Browser/const.ts
@@ -1,4 +1,6 @@
 export const BROWSER_WEBVIEW_SESSION_ATTRIBUTE = 'data-lobe-browser-session-id';
+export const BROWSER_IMPORT_BANNER_DISMISSED_STORAGE_KEY =
+  'lobechat:desktop:browser-import-banner:dismissed:v1';
 /**
  * Must stay in sync with BROWSER_PARTITION in the main-process
  * BrowserSidebarCtr — the partition attribute is how `will-attach-webview`

--- a/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Browser/index.tsx
+++ b/src/routes/(main)/agent/features/Conversation/WorkingSidebar/Browser/index.tsx
@@ -18,11 +18,16 @@ import { useTranslation } from 'react-i18next';
 import { message } from '@/components/AntdStaticMethods';
 import { BrowserIcon } from '@/components/BrowserIcon';
 import { DESKTOP_HEADER_ICON_SMALL_SIZE } from '@/const/layoutTokens';
+import { useLocalStorageState } from '@/hooks/useLocalStorageState';
 import { electronBrowserSidebarService } from '@/services/electron/browserSidebar';
 import { useGlobalStore } from '@/store/global';
 
 import AgentOverlay from './AgentOverlay';
-import { BROWSER_WEBVIEW_PARTITION, BROWSER_WEBVIEW_SESSION_ATTRIBUTE } from './const';
+import {
+  BROWSER_IMPORT_BANNER_DISMISSED_STORAGE_KEY,
+  BROWSER_WEBVIEW_PARTITION,
+  BROWSER_WEBVIEW_SESSION_ATTRIBUTE,
+} from './const';
 import { useBrowserSidebarState } from './useBrowserSidebarState';
 import { normalizeBrowserUrl } from './utils';
 
@@ -103,7 +108,10 @@ const BrowserPane = memo<BrowserPaneProps>(({ sessionId }) => {
   const [address, setAddress] = useState('');
   const [isEditing, setIsEditing] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
-  const [showImportBanner, setShowImportBanner] = useState(true);
+  const [isImportBannerDismissed, setIsImportBannerDismissed] = useLocalStorageState(
+    BROWSER_IMPORT_BANNER_DISMISSED_STORAGE_KEY,
+    false,
+  );
   const browserRequest = useGlobalStore((s) => s.status.workingSidebarBrowserRequest);
   const consumedNonce = useRef<number>(undefined);
   const webviewRef = useRef<WebviewElement>(null);
@@ -182,7 +190,7 @@ const BrowserPane = memo<BrowserPaneProps>(({ sessionId }) => {
       }
 
       message.success(t('workingPanel.browser.import.success', { count: result.importedCount }));
-      setShowImportBanner(false);
+      setIsImportBannerDismissed(true);
       if (state.attached) {
         void runAction(() => electronBrowserSidebarService.reload({ sessionId }));
       }
@@ -290,7 +298,7 @@ const BrowserPane = memo<BrowserPaneProps>(({ sessionId }) => {
           />
         </Flexbox>
       </Flexbox>
-      {showImportBanner && (
+      {!isImportBannerDismissed && (
         <Flexbox horizontal align={'center'} className={styles.importBanner} gap={12}>
           <BrowserIcon browser={'Chrome'} size={32} />
           <Flexbox className={styles.importCopy} gap={0}>
@@ -310,7 +318,7 @@ const BrowserPane = memo<BrowserPaneProps>(({ sessionId }) => {
             icon={XCircle}
             size={DESKTOP_HEADER_ICON_SMALL_SIZE}
             title={t('workingPanel.browser.import.dismiss')}
-            onClick={() => setShowImportBanner(false)}
+            onClick={() => setIsImportBannerDismissed(true)}
           />
         </Flexbox>
       )}


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 👷 build
- [ ] ⚡️ perf
- [x] ✅ test
- [ ] 📝 docs
- [ ] 🔨 chore

#### 🔗 Related Issue

N/A

#### 🔀 Description of Change

- Persist dismissal of the Chrome login import banner after either a successful import or an explicit dismiss, so remounting the browser pane, switching topics, or restarting the desktop app does not show it again.
- Treat persisted topic execution status as primary and linked PR/branch metadata as secondary. Scheduled, paused, completed, failed, unread, waiting-for-human, and running states now take precedence; the linked PR icon is used only for idle topics.
- Add regression coverage for scheduled, paused, and completed topics carrying linked PR metadata.

#### 🧪 How to Test

- [x] Tested locally
- [x] Added/updated tests
- [ ] No tests needed

Commands:

```bash
bun run check src/routes/\(main\)/agent/_layout/Sidebar/Topic/List/Item/index.tsx src/routes/\(main\)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx src/routes/\(main\)/agent/features/Conversation/WorkingSidebar/Browser/const.ts src/routes/\(main\)/agent/features/Conversation/WorkingSidebar/Browser/index.tsx
bunx vitest run --silent=passed-only src/routes/\(main\)/agent/_layout/Sidebar/Topic/List/Item/index.test.tsx
```

Result: 12 tests passed.

#### 📸 Screenshots / Videos

Not included. The change corrects icon precedence in the existing topic row and persists the existing import banner dismissal.

#### 📝 Additional Information

The import banner flag is desktop-global rather than topic- or agent-scoped. Import failures do not persist dismissal, so the user can retry.